### PR TITLE
Remove python3 dependency

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -59,4 +59,4 @@ Do NOT manually edit config files. Always use join.sh.
 - **Teams**: `~/.agents/skills/__SKILL_NAME__/teams/<name>/config.json`
 - **Concurrency**: WAL allows multiple readers + 1 writer without conflicts
 - **No daemon**: Direct DB access via `sqlite3` CLI
-- **Dependencies**: bash, sqlite3, python3 (for JSON formatting only)
+- **Dependencies**: bash, sqlite3 (no python3 required)

--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# --- Check dependencies ---
+if ! command -v sqlite3 &>/dev/null; then
+  echo "Error: sqlite3 is required but not found." >&2
+  echo "  macOS: included by default" >&2
+  echo "  Linux: sudo apt install sqlite3  (or equivalent)" >&2
+  exit 1
+fi
+
 # --- Banner ---
 echo ""
 echo "  agmsg — Agent Messaging"
@@ -146,42 +154,32 @@ if [ -f "$CODEX_CONFIG" ]; then
   else
     cp "$CODEX_CONFIG" "$CODEX_CONFIG.bak"
     echo "  ~ backed up $CODEX_CONFIG → $CODEX_CONFIG.bak"
-    python3 -c "
-import re
 
-config_path = '$CODEX_CONFIG'
-new_paths = $(python3 -c "import json; print(json.dumps([$(printf '"%s",' "${missing[@]}" | sed 's/,$//')]))")
+    # Build entries string: "path1", "path2"
+    entries=$(printf ', "%s"' "${missing[@]}")
+    entries="${entries:2}"  # remove leading ", "
 
-with open(config_path) as f:
-    content = f.read()
-
-entries = ', '.join('\"' + p + '\"' for p in new_paths)
-
-match = re.search(r'writable_roots\s*=\s*\[([^\]]*)\]', content)
-if match:
-    # Append to existing writable_roots
-    existing = match.group(1).rstrip()
-    if existing:
-        new_entry = existing + ', ' + entries
-    else:
-        new_entry = entries
-    content = content[:match.start(1)] + new_entry + content[match.end(1):]
-elif re.search(r'^\[sandbox_workspace_write\]\s*$', content, re.MULTILINE):
-    # [sandbox_workspace_write] section exists but no writable_roots — add under it
-    content = re.sub(
-        r'(\[sandbox_workspace_write\]\s*\n)',
-        r'\1writable_roots = [' + entries + ']\n',
-        content,
-        count=1
-    )
-else:
-    # No [sandbox_workspace_write] section at all
-    content += '\n[sandbox_workspace_write]\nwritable_roots = [' + entries + ']\n'
-
-with open(config_path, 'w') as f:
-    f.write(content)
-" 2>/dev/null && echo "  + added Codex writable_roots for db/ and teams/" \
-             || echo "  ! failed to configure Codex sandbox (update ~/.codex/config.toml manually)"
+    if grep -q 'writable_roots' "$CODEX_CONFIG" 2>/dev/null; then
+      # Append to existing writable_roots (handles multiline arrays)
+      awk -v new_entries="$entries" '
+        /writable_roots/ { in_roots=1 }
+        in_roots && /\]/ {
+          sub(/\]/, ", " new_entries "]")
+          in_roots=0
+        }
+        { print }
+      ' "$CODEX_CONFIG" > "$CODEX_CONFIG.tmp" && mv "$CODEX_CONFIG.tmp" "$CODEX_CONFIG"
+    elif grep -q '^\[sandbox_workspace_write\]' "$CODEX_CONFIG" 2>/dev/null; then
+      # Section exists but no writable_roots
+      awk -v entries="$entries" '
+        { print }
+        /^\[sandbox_workspace_write\]/ { print "writable_roots = [" entries "]" }
+      ' "$CODEX_CONFIG" > "$CODEX_CONFIG.tmp" && mv "$CODEX_CONFIG.tmp" "$CODEX_CONFIG"
+    else
+      # No section at all
+      printf '\n[sandbox_workspace_write]\nwritable_roots = [%s]\n' "$entries" >> "$CODEX_CONFIG"
+    fi
+    echo "  + added Codex writable_roots for db/ and teams/"
   fi
 fi
 

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -12,7 +12,7 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Prevent infinite loop: if stop hook is already active, exit silently
 INPUT=$(cat 2>/dev/null || true)
-if echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); exit(0 if d.get('stop_hook_active') else 1)" 2>/dev/null; then
+if echo "$INPUT" | grep -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true' 2>/dev/null; then
   exit 0
 fi
 
@@ -63,11 +63,12 @@ done
 
 # Exit 0 + JSON block decision = shown to model without "error" label
 if [ -n "$OUTPUT" ]; then
-  ESCAPED=$(echo "$OUTPUT" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))")
+  # Escape for JSON: backslash, double-quote, newlines, tabs
+  ESCAPED=$(printf '%s' "$OUTPUT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g' | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/\\n$//')
   cat <<ENDJSON
 {
   "decision": "block",
-  "reason": $ESCAPED
+  "reason": "$ESCAPED"
 }
 ENDJSON
   exit 0

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -16,22 +16,24 @@ if [ ! -f "$DB" ]; then
 fi
 
 if [ -n "$AGENT" ]; then
-  QUERY="SELECT id, from_agent, to_agent, body, created_at, CASE WHEN read_at IS NULL THEN 'unread' ELSE 'read' END as status FROM messages WHERE team='$TEAM' AND (from_agent='$AGENT' OR to_agent='$AGENT') ORDER BY created_at DESC LIMIT $LIMIT;"
+  WHERE="WHERE team='$TEAM' AND (from_agent='$AGENT' OR to_agent='$AGENT')"
 else
-  QUERY="SELECT id, from_agent, to_agent, body, created_at, CASE WHEN read_at IS NULL THEN 'unread' ELSE 'read' END as status FROM messages WHERE team='$TEAM' ORDER BY created_at DESC LIMIT $LIMIT;"
+  WHERE="WHERE team='$TEAM'"
 fi
 
-RESULT=$(sqlite3 -json "$DB" "$QUERY")
+# Escape newlines/tabs in body, use unit separator between fields
+RESULT=$(sqlite3 "$DB" "
+  SELECT from_agent || char(31) || to_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at || char(31) || CASE WHEN read_at IS NULL THEN '●' ELSE '○' END
+  FROM messages $WHERE ORDER BY created_at DESC LIMIT $LIMIT;
+")
 
-if [ "$RESULT" = "[]" ] || [ -z "$RESULT" ]; then
+if [ -z "$RESULT" ]; then
   echo "No message history."
   exit 0
 fi
 
-echo "$RESULT" | python3 -c '
-import json, sys
-msgs = json.load(sys.stdin)
-for m in reversed(msgs):
-    status = "●" if m["status"] == "unread" else "○"
-    print(f"  {status} [{m["created_at"]}] {m["from_agent"]} → {m["to_agent"]}: {m["body"]}")
-'
+# Reverse order (oldest first) and display
+REVERSED=$(echo "$RESULT" | tail -r 2>/dev/null || echo "$RESULT" | tac 2>/dev/null || echo "$RESULT" | awk '{a[NR]=$0} END{for(i=NR;i>=1;i--)print a[i]}')
+while IFS=$'\x1f' read -r from to body ts status; do
+  echo "  $status [$ts] $from → $to: $body"
+done <<< "$REVERSED"

--- a/scripts/hook.sh
+++ b/scripts/hook.sh
@@ -12,6 +12,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SKILL_NAME="$(basename "$SKILL_DIR")"
 
+# Read settings file or return empty object, escaped for SQL
+read_settings_escaped() {
+  if [ -f "$1" ]; then
+    sed "s/'/''/g" "$1"
+  else
+    echo '{}'
+  fi
+}
+
 # --- Actions ---
 
 do_on() {
@@ -24,33 +33,50 @@ do_on() {
       local CHECK_CMD="'$SKILL_DIR/scripts/check-inbox.sh' '$TYPE' '$PROJECT'"
       mkdir -p "$PROJECT/.claude"
 
-      python3 - "$SETTINGS_FILE" "$CHECK_CMD" "$SKILL_NAME" <<'PYEOF'
-import json, os, sys
+      local SETTINGS_ESC
+      SETTINGS_ESC=$(read_settings_escaped "$SETTINGS_FILE")
+      local HOOK_ENTRY="{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"$CHECK_CMD\"}]}"
+      local HOOK_ESC
+      HOOK_ESC=$(echo "$HOOK_ENTRY" | sed "s/'/''/g")
 
-settings_file, check_cmd, marker = sys.argv[1], sys.argv[2], sys.argv[3]
-
-settings = json.load(open(settings_file)) if os.path.exists(settings_file) else {}
-
-hook_entry = {
-    "matcher": "",
-    "hooks": [{"type": "command", "command": check_cmd}]
-}
-
-hooks = settings.setdefault("hooks", {})
-stop_hooks = hooks.setdefault("Stop", [])
-
-idx = next((i for i, h in enumerate(stop_hooks)
-            if any(marker in hh.get("command", "") for hh in h.get("hooks", []))), None)
-
-if idx is not None:
-    stop_hooks[idx] = hook_entry
-else:
-    stop_hooks.append(hook_entry)
-
-with open(settings_file, "w") as f:
-    json.dump(settings, f, indent=2)
-    f.write("\n")
-PYEOF
+      local UPDATED
+      UPDATED=$(sqlite3 :memory: "
+        SELECT CASE
+          WHEN json_extract('$SETTINGS_ESC', '\$.hooks.Stop') IS NULL THEN
+            json_set(
+              CASE WHEN json_extract('$SETTINGS_ESC', '\$.hooks') IS NULL
+                THEN json_set('$SETTINGS_ESC', '\$.hooks', json('{}'))
+                ELSE '$SETTINGS_ESC'
+              END,
+              '\$.hooks.Stop', json_array(json('$HOOK_ESC')))
+          WHEN EXISTS (
+            SELECT 1 FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s,
+              json_each(json_extract(s.value, '\$.hooks')) AS h
+            WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+          ) THEN
+            json_set('$SETTINGS_ESC', '\$.hooks.Stop',
+              (SELECT json_group_array(
+                CASE
+                  WHEN EXISTS (
+                    SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
+                    WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+                  ) THEN json('$HOOK_ESC')
+                  ELSE json(s.value)
+                END
+              ) FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s)
+            )
+          ELSE
+            json_set('$SETTINGS_ESC', '\$.hooks.Stop',
+              (SELECT json_group_array(json(v.value))
+               FROM (
+                 SELECT value FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop'))
+                 UNION ALL
+                 SELECT '$HOOK_ESC'
+               ) v)
+            )
+        END;
+      ")
+      echo "$UPDATED" > "$SETTINGS_FILE"
       echo "Hook enabled for $PROJECT (claude-code)"
       ;;
     codex)
@@ -77,33 +103,49 @@ do_off() {
         exit 0
       fi
 
-      python3 - "$SETTINGS_FILE" "$SKILL_NAME" "$PROJECT" <<'PYEOF'
-import json, sys
+      local SETTINGS_ESC
+      SETTINGS_ESC=$(sed "s/'/''/g" "$SETTINGS_FILE")
 
-settings_file, marker, project = sys.argv[1], sys.argv[2], sys.argv[3]
+      local UPDATED
+      UPDATED=$(sqlite3 :memory: "
+        SELECT CASE
+          WHEN json_extract('$SETTINGS_ESC', '\$.hooks.Stop') IS NULL THEN
+            'NO_HOOK'
+          WHEN NOT EXISTS (
+            SELECT 1 FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s,
+              json_each(json_extract(s.value, '\$.hooks')) AS h
+            WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+          ) THEN
+            'NO_HOOK'
+          WHEN (SELECT count(*) FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s
+                WHERE NOT EXISTS (
+                  SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
+                  WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+                )) = 0 THEN
+            CASE
+              WHEN (SELECT count(*) FROM json_each(json_extract(json_remove('$SETTINGS_ESC', '\$.hooks.Stop'), '\$.hooks'))) = 0 THEN
+                json_remove('$SETTINGS_ESC', '\$.hooks')
+              ELSE
+                json_remove('$SETTINGS_ESC', '\$.hooks.Stop')
+            END
+          ELSE
+            json_set('$SETTINGS_ESC', '\$.hooks.Stop',
+              (SELECT json_group_array(json(s.value))
+               FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s
+               WHERE NOT EXISTS (
+                 SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
+                 WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+               ))
+            )
+        END;
+      ")
 
-settings = json.load(open(settings_file))
-hooks = settings.get("hooks", {})
-stop_hooks = hooks.get("Stop", [])
-
-filtered = [h for h in stop_hooks
-            if not any(marker in hh.get("command", "") for hh in h.get("hooks", []))]
-
-if len(filtered) == len(stop_hooks):
-    print("No hook configured")
-else:
-    if filtered:
-        hooks["Stop"] = filtered
-    else:
-        hooks.pop("Stop", None)
-    if not hooks:
-        settings.pop("hooks", None)
-
-    with open(settings_file, "w") as f:
-        json.dump(settings, f, indent=2)
-        f.write("\n")
-    print(f"Hook disabled for {project} (claude-code)")
-PYEOF
+      if [ "$UPDATED" = "NO_HOOK" ]; then
+        echo "No hook configured"
+      else
+        echo "$UPDATED" > "$SETTINGS_FILE"
+        echo "Hook disabled for $PROJECT (claude-code)"
+      fi
       ;;
     codex)
       echo "Codex hook support not yet implemented"

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -20,25 +20,27 @@ if [ ! -f "$DB" ]; then
   exit 0
 fi
 
-# Get unread messages
-UNREAD=$(sqlite3 -json "$DB" "SELECT id, from_agent, body, created_at FROM messages WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL ORDER BY created_at ASC;")
+# Get unread messages — escape newlines/tabs in body to keep one record per line
+UNREAD=$(sqlite3 "$DB" "
+  SELECT from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
+  FROM messages WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL
+  ORDER BY created_at ASC;
+")
 
-if [ "$UNREAD" = "[]" ] || [ -z "$UNREAD" ]; then
+if [ -z "$UNREAD" ]; then
   if [ "$QUIET" = true ]; then exit 0; fi
   echo "No new messages."
   exit 0
 fi
 
 # Display
-echo "$UNREAD" | python3 -c '
-import json, sys
-msgs = json.load(sys.stdin)
-print(f"{len(msgs)} new message(s):")
-print()
-for m in msgs:
-    print(f"  [{m["created_at"]}] {m["from_agent"]}: {m["body"]}")
-print()
-'
+COUNT=$(echo "$UNREAD" | wc -l | tr -d ' ')
+echo "$COUNT new message(s):"
+echo ""
+while IFS=$'\x1f' read -r from body ts; do
+  echo "  [$ts] $from: $body"
+done <<< "$UNREAD"
+echo ""
 
 # Mark as read (non-fatal — may fail in sandboxed environments)
 sqlite3 "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -28,21 +28,10 @@ EOF
 fi
 
 # --- Add agent ---
-python3 -c "
-import json
-
-config_path = '$TEAM_CONFIG'
-with open(config_path) as f:
-    config = json.load(f)
-
-config['agents']['$AGENT_ID'] = {
-    'type': '$AGENT_TYPE',
-    'project': '$PROJECT_PATH'
-}
-
-with open(config_path, 'w') as f:
-    json.dump(config, f, indent=2, ensure_ascii=False)
-    f.write('\n')
-"
+AGENT_OBJ="{\"type\":\"$AGENT_TYPE\",\"project\":\"$PROJECT_PATH\"}"
+UPDATED=$(sqlite3 :memory: \
+  ".param set :json '$(sed "s/'/''/g" "$TEAM_CONFIG")'" \
+  "SELECT json_set(:json, '$.agents.$AGENT_ID', json('$AGENT_OBJ'));")
+echo "$UPDATED" > "$TEAM_CONFIG"
 
 echo "Joined team $TEAM as $AGENT_ID"

--- a/scripts/leave.sh
+++ b/scripts/leave.sh
@@ -17,29 +17,29 @@ if [ ! -f "$TEAM_CONFIG" ]; then
   exit 1
 fi
 
-python3 -c "
-import json, sys, os
+CONFIG_ESCAPED=$(sed "s/'/''/g" "$TEAM_CONFIG")
 
-config_path = '$TEAM_CONFIG'
-with open(config_path) as f:
-    config = json.load(f)
+# Check if agent exists
+EXISTS=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+  "SELECT json_extract(:json, '$.agents.$AGENT_ID');")
+if [ -z "$EXISTS" ] || [ "$EXISTS" = "null" ]; then
+  echo "Agent $AGENT_ID not in team $TEAM"
+  exit 1
+fi
 
-agents = config.get('agents', {})
-if '$AGENT_ID' not in agents:
-    print('Agent $AGENT_ID not in team $TEAM')
-    sys.exit(1)
+# Remove agent
+UPDATED=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+  "SELECT json_remove(:json, '$.agents.$AGENT_ID');")
 
-del agents['$AGENT_ID']
+# Check if agents is now empty
+AGENT_COUNT=$(sqlite3 :memory: \
+  "SELECT count(*) FROM json_each(json_extract('$(echo "$UPDATED" | sed "s/'/''/g")', '$.agents'));")
 
-if not agents:
-    # Team is empty, remove it
-    os.remove(config_path)
-    os.rmdir(os.path.dirname(config_path))
-    print('Left team $TEAM (team removed — no members left)')
-else:
-    config['agents'] = agents
-    with open(config_path, 'w') as f:
-        json.dump(config, f, indent=2, ensure_ascii=False)
-        f.write('\n')
-    print('Left team $TEAM')
-"
+if [ "$AGENT_COUNT" -eq 0 ]; then
+  rm -f "$TEAM_CONFIG"
+  rmdir "$TEAMS_DIR/$TEAM" 2>/dev/null || true
+  echo "Left team $TEAM (team removed — no members left)"
+else
+  echo "$UPDATED" > "$TEAM_CONFIG"
+  echo "Left team $TEAM"
+fi

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -20,27 +20,28 @@ if [ ! -f "$TEAM_CONFIG" ]; then
 fi
 
 # --- Update team config ---
-python3 -c "
-import json, sys
+CONFIG_ESCAPED=$(sed "s/'/''/g" "$TEAM_CONFIG")
 
-config_path = '$TEAM_CONFIG'
-with open(config_path) as f:
-    config = json.load(f)
+# Check old exists
+OLD_VAL=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+  "SELECT json_extract(:json, '$.agents.$OLD_NAME');")
+if [ -z "$OLD_VAL" ] || [ "$OLD_VAL" = "null" ]; then
+  echo "Agent $OLD_NAME not in team $TEAM"
+  exit 1
+fi
 
-agents = config.get('agents', {})
-if '$OLD_NAME' not in agents:
-    print('Agent $OLD_NAME not in team $TEAM')
-    sys.exit(1)
-if '$NEW_NAME' in agents:
-    print('Agent $NEW_NAME already exists in team $TEAM')
-    sys.exit(1)
+# Check new doesn't exist
+NEW_VAL=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+  "SELECT json_extract(:json, '$.agents.$NEW_NAME');")
+if [ -n "$NEW_VAL" ] && [ "$NEW_VAL" != "null" ]; then
+  echo "Agent $NEW_NAME already exists in team $TEAM"
+  exit 1
+fi
 
-agents['$NEW_NAME'] = agents.pop('$OLD_NAME')
-
-with open(config_path, 'w') as f:
-    json.dump(config, f, indent=2, ensure_ascii=False)
-    f.write('\n')
-"
+# Rename: set new key with old value, remove old key
+UPDATED=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+  "SELECT json_remove(json_set(:json, '$.agents.$NEW_NAME', json_extract(:json, '$.agents.$OLD_NAME')), '$.agents.$OLD_NAME');")
+echo "$UPDATED" > "$TEAM_CONFIG"
 
 # --- Update messages in DB ---
 if [ -f "$DB" ]; then

--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -14,17 +14,16 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
-python3 -c "
-import json
-with open('$CONFIG') as f:
-    config = json.load(f)
-print(f\"Team: {config['name']}\")
-print()
-agents = config.get('agents', {})
-for name, info in agents.items():
-    t = info.get('type', '?')
-    desc = info.get('description', info.get('project', ''))
-    print(f'  {name} ({t}) — {desc}')
-print()
-print(f'{len(agents)} member(s)')
-"
+echo "Team: $TEAM"
+echo ""
+
+COUNT=0
+while IFS='	' read -r name type project; do
+  echo "  $name ($type) — $project"
+  COUNT=$((COUNT + 1))
+done < <(sqlite3 -separator '	' :memory: \
+  ".param set :json '$(sed "s/'/''/g" "$CONFIG")'" \
+  "SELECT key, json_extract(value, '$.type'), json_extract(value, '$.project') FROM json_each(json_extract(:json, '$.agents'));")
+
+echo ""
+echo "$COUNT member(s)"

--- a/scripts/whoami.sh
+++ b/scripts/whoami.sh
@@ -20,36 +20,42 @@ if [ ! -d "$TEAMS_DIR" ]; then
   exit 0
 fi
 
-python3 -c "
-import json, os, glob
+# Scan all team configs
+MATCHES=""
+ALL_TEAMS=""
 
-teams_dir = '$TEAMS_DIR'
-project = '$PROJECT_PATH'
-agent_type = '$AGENT_TYPE'
+for config_file in "$TEAMS_DIR"/*/config.json; do
+  [ -f "$config_file" ] || continue
+  CONFIG_ESCAPED=$(sed "s/'/''/g" "$config_file")
+  TEAM_NAME=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+    "SELECT json_extract(:json, '$.name');")
+  ALL_TEAMS="${ALL_TEAMS:+$ALL_TEAMS,}$TEAM_NAME"
 
-# Collect all matches: (agent_name, team)
-matches = []
-all_teams = []
+  # Find agents matching project and type
+  while IFS='	' read -r agent_name; do
+    [ -n "$agent_name" ] || continue
+    MATCHES="${MATCHES:+$MATCHES
+}$agent_name	$TEAM_NAME"
+  done < <(sqlite3 -separator '	' :memory: ".param set :json '$CONFIG_ESCAPED'" \
+    "SELECT key FROM json_each(json_extract(:json, '$.agents'))
+     WHERE json_extract(value, '$.project') = '$PROJECT_PATH'
+       AND json_extract(value, '$.type') = '$AGENT_TYPE';")
+done
 
-for config_path in sorted(glob.glob(os.path.join(teams_dir, '*/config.json'))):
-    with open(config_path) as f:
-        config = json.load(f)
-    team = config.get('name', '')
-    all_teams.append(team)
-    for name, info in config.get('agents', {}).items():
-        if info.get('project', '') == project and info.get('type', '') == agent_type:
-            matches.append((name, team))
+if [ -z "$MATCHES" ]; then
+  echo "not_joined=true available_teams=${ALL_TEAMS:-none}"
+  exit 0
+fi
 
-if not matches:
-    available = ','.join(all_teams) if all_teams else 'none'
-    print(f'not_joined=true available_teams={available}')
-else:
-    # Group by unique agent names
-    agent_names = list(dict.fromkeys(m[0] for m in matches))
-    team_names = list(dict.fromkeys(m[1] for m in matches))
+# Deduplicate agent names and team names
+AGENT_NAMES=$(echo "$MATCHES" | cut -f1 | awk '!seen[$0]++' | paste -sd, -)
+TEAM_NAMES=$(echo "$MATCHES" | cut -f2 | awk '!seen[$0]++' | paste -sd, -)
 
-    if len(agent_names) == 1:
-        print(f'agent={agent_names[0]} teams={','.join(team_names)} type={agent_type} project={project}')
-    else:
-        print(f'multiple=true agents={','.join(agent_names)} teams={','.join(team_names)} type={agent_type} project={project}')
-"
+# Count unique agent names
+AGENT_COUNT=$(echo "$MATCHES" | cut -f1 | sort -u | wc -l | tr -d ' ')
+
+if [ "$AGENT_COUNT" -eq 1 ]; then
+  echo "agent=$AGENT_NAMES teams=$TEAM_NAMES type=$AGENT_TYPE project=$PROJECT_PATH"
+else
+  echo "multiple=true agents=$AGENT_NAMES teams=$TEAM_NAMES type=$AGENT_TYPE project=$PROJECT_PATH"
+fi

--- a/tests/test_messaging.bats
+++ b/tests/test_messaging.bats
@@ -63,6 +63,25 @@ teardown() {
   [[ "$output" =~ "ping" ]]
 }
 
+@test "inbox: handles multiline message body" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "line1
+line2
+line3"
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "1 new message" ]]
+  [[ "$output" =~ "alice" ]]
+}
+
+@test "history: handles multiline message body" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "multi
+line"
+  run bash "$SCRIPTS/history.sh" testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "alice" ]]
+  [[ "$output" =~ "bob" ]]
+}
+
 # --- history.sh ---
 
 @test "history: shows message history" {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -73,14 +73,11 @@ for SKILL_DIR in "${SKILL_DIRS[@]}"; do
   for config in "$TEAMS_DIR"/*/config.json; do
     [ -f "$config" ] || continue
 
-    projects=$(python3 -c "
-import json
-with open('$config') as f:
-    cfg = json.load(f)
-for name, info in cfg.get('agents', {}).items():
-    if info.get('type') == 'claude-code' and 'project' in info:
-        print(info['project'])
-" 2>/dev/null || true)
+    projects=$(sqlite3 -separator '	' :memory: \
+      ".param set :json '$(sed "s/'/''/g" "$config")'" \
+      "SELECT json_extract(value, '$.project') FROM json_each(json_extract(:json, '$.agents'))
+       WHERE json_extract(value, '$.type') = 'claude-code'
+         AND json_extract(value, '$.project') IS NOT NULL;" 2>/dev/null || true)
 
     while IFS= read -r project; do
       [ -n "$project" ] || continue
@@ -98,39 +95,53 @@ for name, info in cfg.get('agents', {}).items():
         done
       fi
 
-      # Remove PostToolUse hook from settings.json
-      settings_file="$project/.claude/settings.json"
-      if [ -f "$settings_file" ] && grep -q "scripts/inbox.sh" "$settings_file" 2>/dev/null; then
-        python3 -c "
-import json
-
-with open('$settings_file') as f:
-    settings = json.load(f)
-
-hooks = settings.get('hooks', {})
-post_hooks = hooks.get('PostToolUse', [])
-
-filtered = [
-    h for h in post_hooks
-    if not any(
-        'scripts/inbox.sh' in hook.get('command', '')
-        for hook in h.get('hooks', [])
-    )
-]
-
-if len(filtered) != len(post_hooks):
-    hooks['PostToolUse'] = filtered
-    if not filtered:
-        del hooks['PostToolUse']
-    if not hooks:
-        del settings['hooks']
-    with open('$settings_file', 'w') as f:
-        json.dump(settings, f, indent=2, ensure_ascii=False)
-        f.write('\n')
-    print('  - removed PostToolUse hook from $settings_file')
-" 2>/dev/null || true
-        REMOVED=true
-      fi
+      # Remove only agmsg hook entries from settings files (preserve other hooks)
+      SKILL_NAME="$(basename "$SKILL_DIR")"
+      for settings_file in "$project/.claude/settings.json" "$project/.claude/settings.local.json"; do
+        if [ -f "$settings_file" ] && grep -q "$SKILL_NAME" "$settings_file" 2>/dev/null; then
+          SETTINGS_ESC=$(sed "s/'/''/g" "$settings_file")
+          UPDATED=$(sqlite3 :memory: "
+            WITH hook_types(ht) AS (VALUES ('Stop'), ('PostToolUse'))
+            SELECT COALESCE(
+              (SELECT result FROM (
+                SELECT '$SETTINGS_ESC' AS result
+              ) WHERE NOT EXISTS (
+                SELECT 1 FROM hook_types, json_each(json_extract('$SETTINGS_ESC', '\$.hooks.' || ht)) AS e,
+                  json_each(json_extract(e.value, '\$.hooks')) AS h
+                WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+              )),
+              (SELECT CASE
+                WHEN (SELECT count(*) FROM json_each(json_extract(filtered, '\$.hooks'))
+                      WHERE json_array_length(value) > 0 OR json_type(value) != 'array') = 0
+                THEN json_remove(filtered, '\$.hooks')
+                ELSE filtered
+              END
+              FROM (
+                SELECT json_set(json_set('$SETTINGS_ESC',
+                  '\$.hooks.Stop',
+                  COALESCE((SELECT json_group_array(json(e.value))
+                    FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS e
+                    WHERE NOT EXISTS (
+                      SELECT 1 FROM json_each(json_extract(e.value, '\$.hooks')) AS h
+                      WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+                    )), json('[]'))),
+                  '\$.hooks.PostToolUse',
+                  COALESCE((SELECT json_group_array(json(e.value))
+                    FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.PostToolUse')) AS e
+                    WHERE NOT EXISTS (
+                      SELECT 1 FROM json_each(json_extract(e.value, '\$.hooks')) AS h
+                      WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+                    )), json('[]'))) AS filtered
+              ))
+            );
+          " 2>/dev/null) || true
+          if [ -n "$UPDATED" ] && [ "$UPDATED" != "$SETTINGS_ESC" ]; then
+            echo "$UPDATED" > "$settings_file"
+            echo "  - removed agmsg hook from $settings_file"
+            REMOVED=true
+          fi
+        fi
+      done
     done <<< "$projects"
   done
 done
@@ -180,34 +191,46 @@ if [ -f "$CODEX_CONFIG" ]; then
 
   if [ "$needs_cleanup" = true ]; then
     cp "$CODEX_CONFIG" "$CODEX_CONFIG.bak"
-    python3 -c "
-import re
+    # Build pattern of skill dirs to remove
+    skill_pattern=$(printf '|%s' "${SKILL_DIRS[@]}")
+    skill_pattern="${skill_pattern:1}"  # remove leading |
 
-config_path = '$CODEX_CONFIG'
-skill_dirs = [$(printf '"%s",' "${SKILL_DIRS[@]}" | sed 's/,$//')]
-
-with open(config_path) as f:
-    content = f.read()
-
-match = re.search(r'writable_roots\s*=\s*\[([^\]]*)\]', content)
-if match:
-    entries = match.group(1)
-    # Parse existing entries
-    paths = re.findall(r'\"([^\"]+)\"', entries)
-    # Filter out paths belonging to removed skill dirs
-    filtered = [p for p in paths if not any(p.startswith(sd) for sd in skill_dirs)]
-    if filtered:
-        new_val = ', '.join('\"' + p + '\"' for p in filtered)
-        content = content[:match.start(1)] + new_val + content[match.end(1):]
-    else:
-        # Remove entire writable_roots line and empty [sandbox_workspace_write] section
-        content = re.sub(r'\n?writable_roots\s*=\s*\[[^\]]*\]\n?', '\n', content)
-        content = re.sub(r'\n\[sandbox_workspace_write\]\s*\n(?=\n|\[|$)', '\n', content)
-
-    with open(config_path, 'w') as f:
-        f.write(content)
-    print('  - cleaned Codex writable_roots (backup: config.toml.bak)')
-" 2>/dev/null || true
+    # Remove matching entries from writable_roots (handles multiline arrays)
+    awk -v pattern="$skill_pattern" '
+      /writable_roots/ { in_roots=1; buf="" }
+      in_roots { buf = buf $0 "\n" }
+      in_roots && /\]/ {
+        # Remove entries matching skill dirs
+        n = split(pattern, pats, "|")
+        for (i = 1; i <= n; i++) {
+          gsub("\"" pats[i] "[^\"]*\"[, ]*", "", buf)
+        }
+        # Clean up trailing/leading commas
+        gsub(/,[ \t]*\]/, "]", buf)
+        gsub(/\[[ \t]*,/, "[", buf)
+        gsub(/,[ \t]*,/, ",", buf)
+        # Check if empty
+        if (buf ~ /writable_roots[^[]*\[\s*\]/) {
+          in_roots=0; next
+        }
+        printf "%s", buf
+        in_roots=0; next
+      }
+      !in_roots { print }
+    ' "$CODEX_CONFIG" > "$CODEX_CONFIG.tmp" && mv "$CODEX_CONFIG.tmp" "$CODEX_CONFIG"
+    # Remove empty [sandbox_workspace_write] section
+    awk '
+      /^\[sandbox_workspace_write\]/ {
+        header=$0
+        if (getline nextline <= 0) next
+        if (nextline ~ /^\[/ || nextline == "") { print nextline; next }
+        print header
+        print nextline
+        next
+      }
+      { print }
+    ' "$CODEX_CONFIG" > "$CODEX_CONFIG.tmp" && mv "$CODEX_CONFIG.tmp" "$CODEX_CONFIG"
+    echo "  - cleaned Codex writable_roots (backup: config.toml.bak)"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Remove all python3 usage from scripts, install.sh, and uninstall.sh
- Use sqlite3 JSON1 functions, sed, and awk as replacements
- Add sqlite3 dependency check at install time

## Changes
- **Scripts (9 files)**: JSON config ops → sqlite3 `json_set`/`json_extract`/`json_each`, message display → `char(31)` separator with newline escaping, hook management → sqlite3 JSON array manipulation
- **install.sh**: TOML writable_roots editing → awk (multiline array support), added sqlite3 check
- **uninstall.sh**: config.json reading → sqlite3, hook cleanup → sqlite3 (only removes agmsg entries), TOML cleanup → awk
- **Tests**: Added multiline message body tests (35 total, all passing)

## Review
Reviewed by dev-co (Codex) via agmsg. Three issues found and fixed:
1. Multiline message body regression (separator mode) → fixed with `char(31)` + newline escaping
2. Uninstall hook removal too aggressive → now filters only agmsg entries
3. TOML sed not handling multiline arrays → replaced with awk

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)