### PR TITLE
Add Codex hook support for auto message detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 db/
 teams/
 .DS_Store
+.codex/
+.claude/

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -48,6 +48,7 @@ if [ -f "$MARKER" ]; then
   # Fallback to default if non-numeric
   case "$INTERVAL" in ''|*[!0-9]*) INTERVAL=60 ;; esac
   if [ $(( now - last )) -lt "$INTERVAL" ]; then
+    [ "$TYPE" = "codex" ] && echo "agmsg: check skipped (cooldown)"
     exit 0
   fi
 fi
@@ -78,7 +79,13 @@ for team in "${TEAM_LIST[@]}"; do
   fi
 done
 
-# Exit 0 + JSON block decision = shown to model without "error" label
+# No new messages
+if [ -z "$OUTPUT" ]; then
+  [ "$TYPE" = "codex" ] && echo "agmsg: no new messages"
+  exit 0
+fi
+
+# New messages found
 if [ -n "$OUTPUT" ]; then
   # Escape for JSON: backslash, double-quote, newlines, tabs (macOS/Linux compatible)
   ESCAPED=$(printf '%s' "$OUTPUT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g' | awk '{if(NR>1) printf "\\n"; printf "%s",$0}')

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -48,7 +48,14 @@ if [ -f "$MARKER" ]; then
   # Fallback to default if non-numeric
   case "$INTERVAL" in ''|*[!0-9]*) INTERVAL=60 ;; esac
   if [ $(( now - last )) -lt "$INTERVAL" ]; then
-    [ "$TYPE" = "codex" ] && echo "agmsg: check skipped (cooldown)"
+    if [ "$TYPE" = "codex" ]; then
+      cat <<'ENDJSON'
+{
+  "continue": true,
+  "systemMessage": "agmsg: check skipped (cooldown)"
+}
+ENDJSON
+    fi
     exit 0
   fi
 fi
@@ -81,7 +88,14 @@ done
 
 # No new messages
 if [ -z "$OUTPUT" ]; then
-  [ "$TYPE" = "codex" ] && echo "agmsg: no new messages"
+  if [ "$TYPE" = "codex" ]; then
+    cat <<'ENDJSON'
+{
+  "continue": true,
+  "systemMessage": "agmsg: no new messages"
+}
+ENDJSON
+  fi
   exit 0
 fi
 

--- a/scripts/hook.sh
+++ b/scripts/hook.sh
@@ -28,11 +28,9 @@ resolve_hooks_file() {
 
   case "$type" in
     claude-code)
-      mkdir -p "$project/.claude"
       echo "$project/.claude/settings.local.json"
       ;;
     codex)
-      mkdir -p "$project/.codex"
       echo "$project/.codex/hooks.json"
       ;;
     *)
@@ -142,11 +140,16 @@ enable_codex_hooks_feature() {
   local codex_config="$HOME/.codex/config.toml"
   [ -f "$codex_config" ] || return 0
 
-  if grep -q 'codex_hooks' "$codex_config" 2>/dev/null; then
+  # Check if already enabled (exact match, not comments)
+  if grep -q '^codex_hooks *= *true' "$codex_config" 2>/dev/null; then
     return 0
   fi
 
-  if grep -q '^\[features\]' "$codex_config" 2>/dev/null; then
+  # Replace existing codex_hooks = false, or add new entry
+  if grep -q '^codex_hooks' "$codex_config" 2>/dev/null; then
+    sed -i.tmp 's/^codex_hooks *= *.*/codex_hooks = true/' "$codex_config"
+    rm -f "$codex_config.tmp"
+  elif grep -q '^\[features\]' "$codex_config" 2>/dev/null; then
     awk '
       { print }
       /^\[features\]/ { print "codex_hooks = true" }
@@ -165,6 +168,8 @@ do_on() {
   local HOOKS_FILE
   HOOKS_FILE=$(resolve_hooks_file "$TYPE" "$PROJECT") || exit 1
   local CHECK_CMD="'$SKILL_DIR/scripts/check-inbox.sh' '$TYPE' '$PROJECT'"
+
+  mkdir -p "$(dirname "$HOOKS_FILE")"
 
   local UPDATED
   UPDATED=$(add_hook "$HOOKS_FILE" "$CHECK_CMD")

--- a/scripts/hook.sh
+++ b/scripts/hook.sh
@@ -21,143 +21,180 @@ read_settings_escaped() {
   fi
 }
 
+# Resolve hooks file path and ensure parent directory exists
+resolve_hooks_file() {
+  local type="$1"
+  local project="$2"
+
+  case "$type" in
+    claude-code)
+      mkdir -p "$project/.claude"
+      echo "$project/.claude/settings.local.json"
+      ;;
+    codex)
+      mkdir -p "$project/.codex"
+      echo "$project/.codex/hooks.json"
+      ;;
+    *)
+      echo "Unknown type: $type" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Add or update agmsg Stop hook in a JSON hooks file
+add_hook() {
+  local settings_file="$1"
+  local check_cmd="$2"
+
+  local SETTINGS_ESC
+  SETTINGS_ESC=$(read_settings_escaped "$settings_file")
+  local HOOK_ENTRY="{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"$check_cmd\"}]}"
+  local HOOK_ESC
+  HOOK_ESC=$(echo "$HOOK_ENTRY" | sed "s/'/''/g")
+
+  sqlite3 :memory: "
+    SELECT CASE
+      WHEN json_extract('$SETTINGS_ESC', '\$.hooks.Stop') IS NULL THEN
+        json_set(
+          CASE WHEN json_extract('$SETTINGS_ESC', '\$.hooks') IS NULL
+            THEN json_set('$SETTINGS_ESC', '\$.hooks', json('{}'))
+            ELSE '$SETTINGS_ESC'
+          END,
+          '\$.hooks.Stop', json_array(json('$HOOK_ESC')))
+      WHEN EXISTS (
+        SELECT 1 FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s,
+          json_each(json_extract(s.value, '\$.hooks')) AS h
+        WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+      ) THEN
+        json_set('$SETTINGS_ESC', '\$.hooks.Stop',
+          (SELECT json_group_array(
+            CASE
+              WHEN EXISTS (
+                SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
+                WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+              ) THEN json('$HOOK_ESC')
+              ELSE json(s.value)
+            END
+          ) FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s)
+        )
+      ELSE
+        json_set('$SETTINGS_ESC', '\$.hooks.Stop',
+          (SELECT json_group_array(json(v.value))
+           FROM (
+             SELECT value FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop'))
+             UNION ALL
+             SELECT '$HOOK_ESC'
+           ) v)
+        )
+    END;
+  "
+}
+
+# Remove agmsg Stop hook from a JSON hooks file
+remove_hook() {
+  local settings_file="$1"
+
+  if [ ! -f "$settings_file" ]; then
+    echo "NO_HOOK"
+    return
+  fi
+
+  local SETTINGS_ESC
+  SETTINGS_ESC=$(sed "s/'/''/g" "$settings_file")
+
+  sqlite3 :memory: "
+    SELECT CASE
+      WHEN json_extract('$SETTINGS_ESC', '\$.hooks.Stop') IS NULL THEN
+        'NO_HOOK'
+      WHEN NOT EXISTS (
+        SELECT 1 FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s,
+          json_each(json_extract(s.value, '\$.hooks')) AS h
+        WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+      ) THEN
+        'NO_HOOK'
+      WHEN (SELECT count(*) FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s
+            WHERE NOT EXISTS (
+              SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
+              WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+            )) = 0 THEN
+        CASE
+          WHEN (SELECT count(*) FROM json_each(json_extract(json_remove('$SETTINGS_ESC', '\$.hooks.Stop'), '\$.hooks'))) = 0 THEN
+            json_remove('$SETTINGS_ESC', '\$.hooks')
+          ELSE
+            json_remove('$SETTINGS_ESC', '\$.hooks.Stop')
+        END
+      ELSE
+        json_set('$SETTINGS_ESC', '\$.hooks.Stop',
+          (SELECT json_group_array(json(s.value))
+           FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s
+           WHERE NOT EXISTS (
+             SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
+             WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+           ))
+        )
+    END;
+  "
+}
+
+# Enable codex_hooks feature flag in config.toml
+enable_codex_hooks_feature() {
+  local codex_config="$HOME/.codex/config.toml"
+  [ -f "$codex_config" ] || return 0
+
+  if grep -q 'codex_hooks' "$codex_config" 2>/dev/null; then
+    return 0
+  fi
+
+  if grep -q '^\[features\]' "$codex_config" 2>/dev/null; then
+    awk '
+      { print }
+      /^\[features\]/ { print "codex_hooks = true" }
+    ' "$codex_config" > "$codex_config.tmp" && mv "$codex_config.tmp" "$codex_config"
+  else
+    printf '\n[features]\ncodex_hooks = true\n' >> "$codex_config"
+  fi
+}
+
 # --- Actions ---
 
 do_on() {
   local TYPE="${1:?Usage: hook.sh on <type> <project_path>}"
   local PROJECT="${2:?Missing project_path}"
 
-  case "$TYPE" in
-    claude-code)
-      local SETTINGS_FILE="$PROJECT/.claude/settings.local.json"
-      local CHECK_CMD="'$SKILL_DIR/scripts/check-inbox.sh' '$TYPE' '$PROJECT'"
-      mkdir -p "$PROJECT/.claude"
+  local HOOKS_FILE
+  HOOKS_FILE=$(resolve_hooks_file "$TYPE" "$PROJECT") || exit 1
+  local CHECK_CMD="'$SKILL_DIR/scripts/check-inbox.sh' '$TYPE' '$PROJECT'"
 
-      local SETTINGS_ESC
-      SETTINGS_ESC=$(read_settings_escaped "$SETTINGS_FILE")
-      local HOOK_ENTRY="{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"$CHECK_CMD\"}]}"
-      local HOOK_ESC
-      HOOK_ESC=$(echo "$HOOK_ENTRY" | sed "s/'/''/g")
+  local UPDATED
+  UPDATED=$(add_hook "$HOOKS_FILE" "$CHECK_CMD")
+  echo "$UPDATED" > "$HOOKS_FILE"
 
-      local UPDATED
-      UPDATED=$(sqlite3 :memory: "
-        SELECT CASE
-          WHEN json_extract('$SETTINGS_ESC', '\$.hooks.Stop') IS NULL THEN
-            json_set(
-              CASE WHEN json_extract('$SETTINGS_ESC', '\$.hooks') IS NULL
-                THEN json_set('$SETTINGS_ESC', '\$.hooks', json('{}'))
-                ELSE '$SETTINGS_ESC'
-              END,
-              '\$.hooks.Stop', json_array(json('$HOOK_ESC')))
-          WHEN EXISTS (
-            SELECT 1 FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s,
-              json_each(json_extract(s.value, '\$.hooks')) AS h
-            WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
-          ) THEN
-            json_set('$SETTINGS_ESC', '\$.hooks.Stop',
-              (SELECT json_group_array(
-                CASE
-                  WHEN EXISTS (
-                    SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
-                    WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
-                  ) THEN json('$HOOK_ESC')
-                  ELSE json(s.value)
-                END
-              ) FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s)
-            )
-          ELSE
-            json_set('$SETTINGS_ESC', '\$.hooks.Stop',
-              (SELECT json_group_array(json(v.value))
-               FROM (
-                 SELECT value FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop'))
-                 UNION ALL
-                 SELECT '$HOOK_ESC'
-               ) v)
-            )
-        END;
-      ")
-      echo "$UPDATED" > "$SETTINGS_FILE"
-      echo "Hook enabled for $PROJECT (claude-code)"
-      echo "Restart your agent to activate the hook."
-      ;;
-    codex)
-      echo "Codex hook support not yet implemented"
-      exit 1
-      ;;
-    *)
-      echo "Unknown type: $TYPE" >&2
-      exit 1
-      ;;
-  esac
+  if [ "$TYPE" = "codex" ]; then
+    enable_codex_hooks_feature
+  fi
+
+  echo "Hook enabled for $PROJECT ($TYPE)"
+  echo "Restart your agent to activate the hook."
 }
 
 do_off() {
   local TYPE="${1:?Usage: hook.sh off <type> <project_path>}"
   local PROJECT="${2:?Missing project_path}"
 
-  case "$TYPE" in
-    claude-code)
-      local SETTINGS_FILE="$PROJECT/.claude/settings.local.json"
+  local HOOKS_FILE
+  HOOKS_FILE=$(resolve_hooks_file "$TYPE" "$PROJECT") || exit 1
 
-      if [ ! -f "$SETTINGS_FILE" ]; then
-        echo "No hook configured"
-        exit 0
-      fi
+  local UPDATED
+  UPDATED=$(remove_hook "$HOOKS_FILE")
 
-      local SETTINGS_ESC
-      SETTINGS_ESC=$(sed "s/'/''/g" "$SETTINGS_FILE")
-
-      local UPDATED
-      UPDATED=$(sqlite3 :memory: "
-        SELECT CASE
-          WHEN json_extract('$SETTINGS_ESC', '\$.hooks.Stop') IS NULL THEN
-            'NO_HOOK'
-          WHEN NOT EXISTS (
-            SELECT 1 FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s,
-              json_each(json_extract(s.value, '\$.hooks')) AS h
-            WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
-          ) THEN
-            'NO_HOOK'
-          WHEN (SELECT count(*) FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s
-                WHERE NOT EXISTS (
-                  SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
-                  WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
-                )) = 0 THEN
-            CASE
-              WHEN (SELECT count(*) FROM json_each(json_extract(json_remove('$SETTINGS_ESC', '\$.hooks.Stop'), '\$.hooks'))) = 0 THEN
-                json_remove('$SETTINGS_ESC', '\$.hooks')
-              ELSE
-                json_remove('$SETTINGS_ESC', '\$.hooks.Stop')
-            END
-          ELSE
-            json_set('$SETTINGS_ESC', '\$.hooks.Stop',
-              (SELECT json_group_array(json(s.value))
-               FROM json_each(json_extract('$SETTINGS_ESC', '\$.hooks.Stop')) AS s
-               WHERE NOT EXISTS (
-                 SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
-                 WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
-               ))
-            )
-        END;
-      ")
-
-      if [ "$UPDATED" = "NO_HOOK" ]; then
-        echo "No hook configured"
-      else
-        echo "$UPDATED" > "$SETTINGS_FILE"
-        echo "Hook disabled for $PROJECT (claude-code)"
-        echo "Restart your agent to deactivate the hook."
-      fi
-      ;;
-    codex)
-      echo "Codex hook support not yet implemented"
-      exit 1
-      ;;
-    *)
-      echo "Unknown type: $TYPE" >&2
-      exit 1
-      ;;
-  esac
+  if [ "$UPDATED" = "NO_HOOK" ]; then
+    echo "No hook configured"
+  else
+    echo "$UPDATED" > "$HOOKS_FILE"
+    echo "Hook disabled for $PROJECT ($TYPE)"
+    echo "Restart your agent to deactivate the hook."
+  fi
 }
 
 # --- Dispatch ---

--- a/templates/cmd.codex.md
+++ b/templates/cmd.codex.md
@@ -41,7 +41,12 @@ Three possible outputs:
   > - `$__SKILL_NAME__ team` — list team members
   > - `$__SKILL_NAME__ history` — message history
 
-  5. Then check inbox for the newly joined team.
+  5. **REQUIRED — Do NOT skip this step.** Ask the user: "Enable auto message checking? When enabled, incoming messages are automatically detected after each response. You can turn it on/off anytime with `$__SKILL_NAME__ hook on/off`."
+     - **Wait for the user's answer before proceeding.**
+     - If yes: run `~/.agents/skills/__SKILL_NAME__/scripts/hook.sh on codex "$(pwd)"`
+     - If no: skip
+
+  6. Then check inbox for the newly joined team.
 
 ## Execute
 
@@ -72,3 +77,11 @@ If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
 1. Parse key and value from the arguments.
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
 
+
+If argument is "hook on":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/hook.sh on codex "$(pwd)"`
+2. Tell the user: "Auto message checking enabled."
+
+If argument is "hook off":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/hook.sh off codex "$(pwd)"`
+2. Tell the user: "Auto message checking disabled."

--- a/tests/test_hook.bats
+++ b/tests/test_hook.bats
@@ -57,10 +57,18 @@ print(len(d['hooks']['Stop']))
   rm -rf "$spaced"
 }
 
-@test "hook on: codex exits with error" {
+@test "hook on: codex creates hooks.json" {
   run bash "$SCRIPTS/hook.sh" on codex "$TEST_PROJECT"
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "not yet implemented" ]]
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_PROJECT/.codex/hooks.json" ]
+  [[ "$output" =~ "Hook enabled" ]]
+}
+
+@test "hook off: codex removes hook" {
+  bash "$SCRIPTS/hook.sh" on codex "$TEST_PROJECT"
+  run bash "$SCRIPTS/hook.sh" off codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Hook disabled" ]]
 }
 
 # --- hook.sh off ---


### PR DESCRIPTION
## Summary
- Add Codex Stop hook support in `hook.sh` (writes to `.codex/hooks.json`)
- Auto-enables `codex_hooks = true` feature flag in `config.toml`
- Codex-specific hook output: JSON `systemMessage` for cooldown/no-messages, `decision: "block"` for new messages
- Shared `add_hook`/`remove_hook` functions for Claude Code and Codex
- Codex template restored with hook on/off commands and first-join setup prompt

## Test plan
- [x] 43 BATS tests passing (including Codex hook on/off tests)
- [x] Reviewed by dev-co (Codex) — three rounds, all issues resolved
- [x] Tested end-to-end on Codex: cooldown, no-messages, and new-message scenarios

Closes #1