### PR TITLE
Redesign identity model: decouple agent from project path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ After install, **restart your agent** (Claude Code / Codex) so it picks up the n
 
 ## Join a Team
 
-Agents join teams **per-project**. The easiest way:
+Agents join teams by **identity**: `(agent name, team)`. Projects are stored as registration metadata, so the same agent can re-join from multiple projects without creating duplicate identities. The easiest way:
 
 1. Open Claude Code in your project
 2. Run `/<cmd>` (e.g. `/agmsg`)
@@ -69,6 +69,21 @@ You can join the same project with multiple agent names (e.g. `cc` and `reviewer
 ~/.agents/skills/agmsg/scripts/join.sh myteam reviewer claude-code /path/to/project
 ```
 
+### Reusing the same identity across projects
+
+If you join the same team with the same agent name from another project, agmsg keeps the same identity and adds a registration record for the new project.
+
+```bash
+~/.agents/skills/agmsg/scripts/join.sh myteam alice claude-code /path/to/project-a
+~/.agents/skills/agmsg/scripts/join.sh myteam alice claude-code /path/to/project-b
+```
+
+If you want to clear the current project's registrations without leaving the team identity entirely:
+
+```bash
+~/.agents/skills/agmsg/scripts/reset.sh /path/to/project-b claude-code
+```
+
 ## Usage
 
 ### Claude Code
@@ -80,6 +95,7 @@ You can join the same project with multiple agent names (e.g. `cc` and `reviewer
 /agmsg send <agent> <message>   — send message
 /agmsg hook on                  — enable auto message detection
 /agmsg hook off                 — disable auto message detection
+/agmsg reset                    — clear current project registration
 ```
 
 ### Codex
@@ -97,6 +113,7 @@ $agmsg                          — or /skills → agmsg
 ~/.agents/skills/<cmd>/scripts/team.sh <team>
 ~/.agents/skills/<cmd>/scripts/whoami.sh <project_path> <type>
 ~/.agents/skills/<cmd>/scripts/hook.sh on|off <type> <project_path>
+~/.agents/skills/<cmd>/scripts/reset.sh <project_path> <type> [agent_id]
 ```
 
 ## Update
@@ -132,7 +149,7 @@ bats tests/    # requires bats-core: brew install bats-core
 ├── SKILL.md                      # Skill definition (read by CC & Codex)
 ├── agents/
 │   └── openai.yaml               # Codex metadata
-├── scripts/                      # 11 bash scripts
+├── scripts/                      # Bash scripts
 ├── templates/                    # Command templates per tool
 ├── db/messages.db                # SQLite WAL-mode message store
 └── teams/                        # Team configs (self-contained)

--- a/SKILL.md
+++ b/SKILL.md
@@ -14,8 +14,7 @@ description: Cross-agent messaging via SQLite. Send messages between Claude Code
 ```bash
 ~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" <type>
 # type: claude-code, codex, gemini
-# Returns: agent=<name> teams=<t1,t2,...> type=<type> project=<path>
-# Empty output means not in any team yet.
+# Returns: agent=... / multiple=true ... / suggest=true ... / not_joined=true ...
 ```
 
 ### Step 2a: If not in a team — join one
@@ -47,6 +46,9 @@ Do NOT manually edit config files. Always use join.sh.
 
 # Leave a team
 ~/.agents/skills/__SKILL_NAME__/scripts/leave.sh <team> <agent_id>
+
+# Clear registrations for the current project/type
+~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" <type> [agent_id]
 
 # Enable/disable auto message checking (hook)
 ~/.agents/skills/__SKILL_NAME__/scripts/hook.sh on <type> "$(pwd)"

--- a/docs/index.html
+++ b/docs/index.html
@@ -138,7 +138,7 @@
       </div>
       <div class="feature">
         <h3>Team-based</h3>
-        <p>Agents join teams per-project. Multiple identities supported.</p>
+        <p>Agents join teams by identity and can register multiple projects under the same name.</p>
       </div>
     </div>
 

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -27,11 +27,59 @@ EOF
   echo "Created team: $TEAM"
 fi
 
-# --- Add agent ---
-AGENT_OBJ="{\"type\":\"$AGENT_TYPE\",\"project\":\"$PROJECT_PATH\"}"
+# --- Add or extend agent registrations ---
+CONFIG_ESCAPED=$(sed "s/'/''/g" "$TEAM_CONFIG")
+REGISTRATION="{\"type\":\"$AGENT_TYPE\",\"project\":\"$PROJECT_PATH\"}"
+REGISTRATION_ESCAPED=$(printf '%s' "$REGISTRATION" | sed "s/'/''/g")
+
+EXISTING=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+  "SELECT json_extract(:json, '$.agents.$AGENT_ID');")
+
+if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
+  AGENT_OBJ="{\"registrations\":[${REGISTRATION}]}"
+else
+  EXISTING_ESCAPED=$(printf '%s' "$EXISTING" | sed "s/'/''/g")
+  NORMALIZED=$(sqlite3 :memory: "
+    WITH agent(a) AS (SELECT '$EXISTING_ESCAPED')
+    SELECT CASE
+      WHEN json_type(json_extract(a, '\$.registrations')) = 'array' THEN a
+      ELSE json_object(
+        'registrations',
+        json_array(json_object(
+          'type', json_extract(a, '\$.type'),
+          'project', json_extract(a, '\$.project')
+        ))
+      )
+    END
+    FROM agent;
+  ")
+  NORMALIZED_ESCAPED=$(printf '%s' "$NORMALIZED" | sed "s/'/''/g")
+
+  HAS_REGISTRATION=$(sqlite3 :memory: "
+    SELECT EXISTS(
+      SELECT 1
+      FROM json_each(json_extract('$NORMALIZED_ESCAPED', '\$.registrations'))
+      WHERE json_extract(value, '\$.type') = '$AGENT_TYPE'
+        AND json_extract(value, '\$.project') = '$PROJECT_PATH'
+    );
+  ")
+
+  if [ "$HAS_REGISTRATION" = "1" ]; then
+    AGENT_OBJ="$NORMALIZED"
+  else
+    AGENT_OBJ=$(sqlite3 :memory: "
+      SELECT json_set(
+        '$NORMALIZED_ESCAPED',
+        '\$.registrations[' || json_array_length(json_extract('$NORMALIZED_ESCAPED', '\$.registrations')) || ']',
+        json('$REGISTRATION_ESCAPED')
+      );
+    ")
+  fi
+fi
+
 UPDATED=$(sqlite3 :memory: \
-  ".param set :json '$(sed "s/'/''/g" "$TEAM_CONFIG")'" \
-  "SELECT json_set(:json, '$.agents.$AGENT_ID', json('$AGENT_OBJ'));")
+  ".param set :json '$CONFIG_ESCAPED'" \
+  "SELECT json_set(:json, '$.agents.$AGENT_ID', json('$(printf '%s' "$AGENT_OBJ" | sed "s/'/''/g")'));")
 echo "$UPDATED" > "$TEAM_CONFIG"
 
 echo "Joined team $TEAM as $AGENT_ID"

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: reset.sh <project_path> <type> [agent_id]
+#
+# Removes registrations for the given project/type across all teams.
+# If agent_id is omitted, it is resolved from whoami.sh for the current project/type.
+
+PROJECT_PATH="${1:?Usage: reset.sh <project_path> <type> [agent_id]}"
+AGENT_TYPE="${2:?Usage: reset.sh <project_path> <type> [agent_id]}"
+TARGET_AGENT="${3:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEAMS_DIR="$SCRIPT_DIR/../teams"
+
+if [ -z "$TARGET_AGENT" ]; then
+  WHOAMI=$(bash "$SCRIPT_DIR/whoami.sh" "$PROJECT_PATH" "$AGENT_TYPE")
+  if echo "$WHOAMI" | grep -q '^agent='; then
+    TARGET_AGENT=$(echo "$WHOAMI" | sed -n 's/.*agent=\([^ ]*\).*/\1/p')
+  elif echo "$WHOAMI" | grep -q '^multiple=true'; then
+    echo "Multiple identities match this project/type. Pass an agent_id explicitly." >&2
+    exit 1
+  else
+    echo "No registered identity found for this project/type." >&2
+    exit 1
+  fi
+fi
+
+if [ ! -d "$TEAMS_DIR" ]; then
+  echo "No team registrations found."
+  exit 0
+fi
+
+REMOVED=0
+TOUCHED_TEAMS=0
+
+for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
+  [ -f "$TEAM_CONFIG" ] || continue
+  TEAM_DIR="$(dirname "$TEAM_CONFIG")"
+  TEAM_NAME="$(basename "$TEAM_DIR")"
+  CONFIG_ESCAPED=$(sed "s/'/''/g" "$TEAM_CONFIG")
+
+  AGENT_JSON=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+    "SELECT json_extract(:json, '$.agents.$TARGET_AGENT');")
+  if [ -z "$AGENT_JSON" ] || [ "$AGENT_JSON" = "null" ]; then
+    continue
+  fi
+
+  AGENT_ESCAPED=$(printf '%s' "$AGENT_JSON" | sed "s/'/''/g")
+  NORMALIZED=$(sqlite3 :memory: "
+    WITH agent(a) AS (SELECT '$AGENT_ESCAPED')
+    SELECT CASE
+      WHEN json_type(json_extract(a, '\$.registrations')) = 'array' THEN a
+      ELSE json_object(
+        'registrations',
+        json_array(json_object(
+          'type', json_extract(a, '\$.type'),
+          'project', json_extract(a, '\$.project')
+        ))
+      )
+    END
+    FROM agent;
+  ")
+  NORMALIZED_ESCAPED=$(printf '%s' "$NORMALIZED" | sed "s/'/''/g")
+
+  MATCH_COUNT=$(sqlite3 :memory: "
+    SELECT count(*)
+    FROM json_each(json_extract('$NORMALIZED_ESCAPED', '\$.registrations'))
+    WHERE json_extract(value, '\$.type') = '$AGENT_TYPE'
+      AND json_extract(value, '\$.project') = '$PROJECT_PATH';
+  ")
+  if [ "$MATCH_COUNT" -eq 0 ]; then
+    continue
+  fi
+
+  FILTERED=$(sqlite3 :memory: "
+    SELECT json_object(
+      'registrations',
+      COALESCE((
+        SELECT json_group_array(json(value))
+        FROM json_each(json_extract('$NORMALIZED_ESCAPED', '\$.registrations'))
+        WHERE NOT (
+          json_extract(value, '\$.type') = '$AGENT_TYPE'
+          AND json_extract(value, '\$.project') = '$PROJECT_PATH'
+        )
+      ), json('[]'))
+    );
+  ")
+  FILTERED_ESCAPED=$(printf '%s' "$FILTERED" | sed "s/'/''/g")
+  REMAINING=$(sqlite3 :memory: "
+    SELECT json_array_length(json_extract('$FILTERED_ESCAPED', '\$.registrations'));
+  ")
+
+  if [ "$REMAINING" -eq 0 ]; then
+    UPDATED=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+      "SELECT json_remove(:json, '$.agents.$TARGET_AGENT');")
+  else
+    UPDATED=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+      "SELECT json_set(:json, '$.agents.$TARGET_AGENT', json('$FILTERED_ESCAPED'));")
+  fi
+
+  AGENT_COUNT=$(sqlite3 :memory: "
+    SELECT count(*)
+    FROM json_each(json_extract('$(printf '%s' "$UPDATED" | sed "s/'/''/g")', '\$.agents'));
+  ")
+
+  if [ "$AGENT_COUNT" -eq 0 ]; then
+    rm -f "$TEAM_CONFIG"
+    rmdir "$TEAM_DIR" 2>/dev/null || true
+  else
+    echo "$UPDATED" > "$TEAM_CONFIG"
+  fi
+
+  REMOVED=$((REMOVED + MATCH_COUNT))
+  TOUCHED_TEAMS=$((TOUCHED_TEAMS + 1))
+  echo "Cleared $MATCH_COUNT registration(s) for $TARGET_AGENT from $TEAM_NAME"
+done
+
+if [ "$REMOVED" -eq 0 ]; then
+  echo "No registrations removed."
+else
+  echo "Reset complete: removed $REMOVED registration(s) across $TOUCHED_TEAMS team(s)"
+fi

--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -18,12 +18,36 @@ echo "Team: $TEAM"
 echo ""
 
 COUNT=0
-while IFS='	' read -r name type project; do
-  echo "  $name ($type) — $project"
+while IFS='	' read -r name types project registrations; do
+  if [ "${registrations:-0}" -gt 1 ]; then
+    echo "  $name ($types) — $project (+$((registrations - 1)) more)"
+  else
+    echo "  $name ($types) — $project"
+  fi
   COUNT=$((COUNT + 1))
 done < <(sqlite3 -separator '	' :memory: \
   ".param set :json '$(sed "s/'/''/g" "$CONFIG")'" \
-  "SELECT key, json_extract(value, '$.type'), json_extract(value, '$.project') FROM json_each(json_extract(:json, '$.agents'));")
+  "WITH agents AS (
+     SELECT
+       key AS name,
+       CASE
+         WHEN json_type(json_extract(value, '$.registrations')) = 'array' THEN json_extract(value, '$.registrations')
+         ELSE json_array(json_object('type', json_extract(value, '$.type'), 'project', json_extract(value, '$.project')))
+       END AS registrations
+     FROM json_each(json_extract(:json, '$.agents'))
+   )
+   SELECT
+     name,
+     group_concat(DISTINCT json_extract(r.value, '$.type')),
+     COALESCE((
+       SELECT json_extract(r2.value, '$.project')
+       FROM json_each(agents.registrations) AS r2
+       ORDER BY CAST(r2.key AS INTEGER) DESC
+       LIMIT 1
+     ), '?'),
+     json_array_length(registrations)
+   FROM agents, json_each(agents.registrations) AS r
+   GROUP BY name, registrations;")
 
 echo ""
 echo "$COUNT member(s)"

--- a/scripts/whoami.sh
+++ b/scripts/whoami.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # Show agent identity in id(1) style.
 # Single match:    agent=<name> teams=<t1,t2,...> type=<type> project=<path>
 # Multiple match:  multiple=true agents=<n1,n2,...> teams=<t1,t2,...> type=<type> project=<path>
+# Suggestions:     suggest=true agents=<n1,n2,...> teams=<t1,t2,...> type=<type> project=<path> available_teams=<...>
 # Not joined:      not_joined=true available_teams=<t1,t2,...> (or "none")
 #
 # Usage: whoami.sh <project_path> <type>
@@ -21,7 +22,8 @@ if [ ! -d "$TEAMS_DIR" ]; then
 fi
 
 # Scan all team configs
-MATCHES=""
+EXACT_MATCHES=""
+SUGGESTED_MATCHES=""
 ALL_TEAMS=""
 
 for config_file in "$TEAMS_DIR"/*/config.json; do
@@ -34,25 +36,63 @@ for config_file in "$TEAMS_DIR"/*/config.json; do
   # Find agents matching project and type
   while IFS='	' read -r agent_name; do
     [ -n "$agent_name" ] || continue
-    MATCHES="${MATCHES:+$MATCHES
+    EXACT_MATCHES="${EXACT_MATCHES:+$EXACT_MATCHES
 }$agent_name	$TEAM_NAME"
-  done < <(sqlite3 -separator '	' :memory: ".param set :json '$CONFIG_ESCAPED'" \
-    "SELECT key FROM json_each(json_extract(:json, '$.agents'))
-     WHERE json_extract(value, '$.project') = '$PROJECT_PATH'
-       AND json_extract(value, '$.type') = '$AGENT_TYPE';")
+  done < <(sqlite3 -separator '	' :memory: ".param set :json '$CONFIG_ESCAPED'" "
+    WITH agents AS (
+      SELECT
+        key AS name,
+        CASE
+          WHEN json_type(json_extract(value, '\$.registrations')) = 'array' THEN json_extract(value, '\$.registrations')
+          ELSE json_array(json_object('type', json_extract(value, '\$.type'), 'project', json_extract(value, '\$.project')))
+        END AS registrations
+      FROM json_each(json_extract(:json, '\$.agents'))
+    )
+    SELECT DISTINCT name
+    FROM agents, json_each(agents.registrations) AS r
+    WHERE json_extract(r.value, '\$.project') = '$PROJECT_PATH'
+      AND json_extract(r.value, '\$.type') = '$AGENT_TYPE';
+  ")
+
+  # Find agents with same type registered elsewhere for suggestion purposes
+  while IFS='	' read -r agent_name; do
+    [ -n "$agent_name" ] || continue
+    SUGGESTED_MATCHES="${SUGGESTED_MATCHES:+$SUGGESTED_MATCHES
+}$agent_name	$TEAM_NAME"
+  done < <(sqlite3 -separator '	' :memory: ".param set :json '$CONFIG_ESCAPED'" "
+    WITH agents AS (
+      SELECT
+        key AS name,
+        CASE
+          WHEN json_type(json_extract(value, '\$.registrations')) = 'array' THEN json_extract(value, '\$.registrations')
+          ELSE json_array(json_object('type', json_extract(value, '\$.type'), 'project', json_extract(value, '\$.project')))
+        END AS registrations
+      FROM json_each(json_extract(:json, '\$.agents'))
+    )
+    SELECT DISTINCT name
+    FROM agents, json_each(agents.registrations) AS r
+    WHERE json_extract(r.value, '\$.type') = '$AGENT_TYPE';
+  ")
 done
 
-if [ -z "$MATCHES" ]; then
+if [ -z "$EXACT_MATCHES" ] && [ -z "$SUGGESTED_MATCHES" ]; then
   echo "not_joined=true available_teams=${ALL_TEAMS:-none}"
   exit 0
 fi
 
+if [ -z "$EXACT_MATCHES" ]; then
+  AGENT_NAMES=$(echo "$SUGGESTED_MATCHES" | cut -f1 | awk '!seen[$0]++' | paste -sd, -)
+  TEAM_NAMES=$(echo "$SUGGESTED_MATCHES" | cut -f2 | awk '!seen[$0]++' | paste -sd, -)
+  echo "suggest=true agents=$AGENT_NAMES teams=$TEAM_NAMES type=$AGENT_TYPE project=$PROJECT_PATH available_teams=${ALL_TEAMS:-none}"
+  exit 0
+fi
+
 # Deduplicate agent names and team names
-AGENT_NAMES=$(echo "$MATCHES" | cut -f1 | awk '!seen[$0]++' | paste -sd, -)
-TEAM_NAMES=$(echo "$MATCHES" | cut -f2 | awk '!seen[$0]++' | paste -sd, -)
+AGENT_NAMES=$(echo "$EXACT_MATCHES" | cut -f1 | awk '!seen[$0]++' | paste -sd, -)
+TEAM_NAMES=$(echo "$EXACT_MATCHES" | cut -f2 | awk '!seen[$0]++' | paste -sd, -)
 
 # Count unique agent names
-AGENT_COUNT=$(echo "$MATCHES" | cut -f1 | sort -u | wc -l | tr -d ' ')
+AGENT_COUNT=$(echo "$EXACT_MATCHES" | cut -f1 | sort -u | wc -l | tr -d ' ')
 
 if [ "$AGENT_COUNT" -eq 1 ]; then
   echo "agent=$AGENT_NAMES teams=$TEAM_NAMES type=$AGENT_TYPE project=$PROJECT_PATH"

--- a/templates/cmd.claude-code.md
+++ b/templates/cmd.claude-code.md
@@ -10,7 +10,7 @@ If you already know your AGENT and TEAMS from a previous `/__SKILL_NAME__` call 
 
 Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" claude-code`
 
-Three possible outputs:
+Four possible outputs:
 
 **A) Single identity:**
 `agent=<name> teams=<t1,t2,...> type=claude-code project=<path>`
@@ -46,6 +46,16 @@ Three possible outputs:
      - If no: skip
 
   6. Then check inbox for the newly joined team.
+
+**D) Suggestions for reuse:**
+`suggest=true agents=<n1,n2,...> teams=<t1,t2,...> type=claude-code project=<path> available_teams=<t1,t2,...>`
+→ No exact registration exists for this project, but there are same-type agent names registered elsewhere.
+
+  1. Show the suggested agent names to the user.
+  2. Ask whether to reuse one of those names or choose a new one.
+  3. Ask for the team name to join (existing or new).
+  4. Run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> claude-code "$(pwd)"`
+  5. Then continue with the normal post-join flow above.
 
 ## Execute
 
@@ -83,3 +93,7 @@ If argument is "config":
 If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
 1. Parse key and value from the arguments.
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
+
+If argument is "reset":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" claude-code`
+2. Tell the user the result.

--- a/templates/cmd.codex.md
+++ b/templates/cmd.codex.md
@@ -11,7 +11,7 @@ If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call 
 
 Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" codex`
 
-Three possible outputs:
+Four possible outputs:
 
 **A) Single identity:**
 `agent=<name> teams=<t1,t2,...> type=codex project=<path>`
@@ -47,6 +47,16 @@ Three possible outputs:
      - If no: skip
 
   6. Then check inbox for the newly joined team.
+
+**D) Suggestions for reuse:**
+`suggest=true agents=<n1,n2,...> teams=<t1,t2,...> type=codex project=<path> available_teams=<t1,t2,...>`
+→ No exact registration exists for this project, but there are same-type agent names registered elsewhere.
+
+  1. Show the suggested agent names to the user.
+  2. Ask whether to reuse one of those names or choose a new one.
+  3. Ask for the team name to join (existing or new).
+  4. Run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> codex "$(pwd)"`
+  5. Then continue with the normal post-join flow above.
 
 ## Execute
 
@@ -85,3 +95,7 @@ If argument is "hook on":
 If argument is "hook off":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/hook.sh off codex "$(pwd)"`
 2. Tell the user: "Auto message checking disabled."
+
+If argument is "reset":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" codex`
+2. Tell the user the result.

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -32,6 +32,16 @@ teardown() {
   [[ "$output" =~ "2 member" ]]
 }
 
+@test "join: re-join with same name adds registration instead of duplicate agent" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj-a
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj-b
+  run bash "$SCRIPTS/team.sh" myteam
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "alice" ]]
+  [[ "$output" =~ "1 member" ]]
+  [[ "$output" =~ "+1 more" ]]
+}
+
 # --- leave.sh ---
 
 @test "leave: removes agent from team" {
@@ -94,4 +104,44 @@ teardown() {
   bash "$SCRIPTS/join.sh" team1 alice claude-code /tmp/other
   run bash "$SCRIPTS/whoami.sh" /tmp/nothere claude-code
   [[ "$output" =~ "available_teams=team1" ]]
+}
+
+@test "whoami: finds re-joined agent in another project registration" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj-a
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj-b
+  run bash "$SCRIPTS/whoami.sh" /tmp/proj-b claude-code
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "agent=alice" ]]
+  [[ "$output" =~ "teams=myteam" ]]
+}
+
+@test "whoami: suggests same-type agents registered elsewhere when no exact match" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj-a
+  run bash "$SCRIPTS/whoami.sh" /tmp/proj-b claude-code
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "suggest=true" ]]
+  [[ "$output" =~ "agents=alice" ]]
+  [[ "$output" =~ "available_teams=myteam" ]]
+}
+
+# --- reset.sh ---
+
+@test "reset: removes only current project registration" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj-a
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj-b
+  run bash "$SCRIPTS/reset.sh" /tmp/proj-a claude-code alice
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "removed 1 registration" ]]
+  run bash "$SCRIPTS/whoami.sh" /tmp/proj-a claude-code
+  [[ "$output" =~ "suggest=true" ]]
+  run bash "$SCRIPTS/whoami.sh" /tmp/proj-b claude-code
+  [[ "$output" =~ "agent=alice" ]]
+}
+
+@test "reset: removes agent when last registration is cleared" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj-a
+  run bash "$SCRIPTS/reset.sh" /tmp/proj-a claude-code alice
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "removed 1 registration" ]]
+  [ ! -d "$TEST_SKILL_DIR/teams/myteam" ]
 }


### PR DESCRIPTION
## Summary
- Agent identity is now `(name, team)` only — project path and type are metadata
- Re-joining with the same name from a different project adds a registration instead of creating a duplicate agent
- New `reset.sh` command to clear registrations by project/type
- `whoami.sh` now suggests same-type agents registered elsewhere when no exact match
- Backward compatible with old config format (auto-normalize)

## Changes
- `join.sh`: registrations array, re-join adds metadata
- `whoami.sh`: 4 output modes (exact/multiple/suggest/not_joined)
- `team.sh`: registration-aware display with (+N more)
- `reset.sh`: new script for clearing registrations
- Templates, README, SKILL.md updated

## Test plan
- [x] 48 BATS tests passing (6 new tests for identity model)
- [x] Implemented by dev-co (Codex), reviewed and verified by dev-cc (Claude Code)
- [x] Manual testing: whoami, re-join, reset, team display

Closes #15