### PR TITLE
Add rename-team script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ To rename a team (moves the team dir, updates `config.json`, migrates messages):
 ~/.agents/skills/agmsg/scripts/rename-team.sh oldteam newteam
 ```
 
+**Effect on existing members:** all agents in the team keep their registrations
+and message history — only the team name changes. However, any session that has
+already cached the team name (e.g. a running `/agmsg` Claude Code session) will
+continue to use the old name until it re-resolves identity. After a rename,
+each member should re-run `whoami` from their project to pick up the new name:
+
+```bash
+~/.agents/skills/agmsg/scripts/whoami.sh "$(pwd)" claude-code
+```
+
 ### Multiple identities
 
 You can join the same project with multiple agent names (e.g. `cc` and `reviewer`). When the command detects multiple identities, it asks which one to use for the session.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ To leave a team:
 ~/.agents/skills/agmsg/scripts/leave.sh myteam alice
 ```
 
+To rename a team (moves the team dir, updates `config.json`, migrates messages):
+
+```bash
+~/.agents/skills/agmsg/scripts/rename-team.sh oldteam newteam
+```
+
 ### Multiple identities
 
 You can join the same project with multiple agent names (e.g. `cc` and `reviewer`). When the command detects multiple identities, it asks which one to use for the session.

--- a/SKILL.md
+++ b/SKILL.md
@@ -47,7 +47,9 @@ Do NOT manually edit config files. Always use join.sh.
 # Leave a team
 ~/.agents/skills/__SKILL_NAME__/scripts/leave.sh <team> <agent_id>
 
-# Rename a team (moves dir, updates config + messages)
+# Rename a team (moves dir, updates config + messages).
+# After renaming, each existing member should re-run whoami.sh to refresh
+# their cached team name in any running session.
 ~/.agents/skills/__SKILL_NAME__/scripts/rename-team.sh <old_team> <new_team>
 
 # Clear registrations for the current project/type

--- a/SKILL.md
+++ b/SKILL.md
@@ -47,6 +47,9 @@ Do NOT manually edit config files. Always use join.sh.
 # Leave a team
 ~/.agents/skills/__SKILL_NAME__/scripts/leave.sh <team> <agent_id>
 
+# Rename a team (moves dir, updates config + messages)
+~/.agents/skills/__SKILL_NAME__/scripts/rename-team.sh <old_team> <new_team>
+
 # Clear registrations for the current project/type
 ~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" <type> [agent_id]
 

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -50,3 +50,9 @@ if [ -f "$DB" ]; then
 fi
 
 echo "Renamed team $OLD_TEAM → $NEW_TEAM"
+echo
+echo "Note: existing members in other projects/sessions still see the old"
+echo "team name cached. Each member should re-run whoami in their project"
+echo "to pick up the new name:"
+echo
+echo "  ~/.agents/skills/<skill>/scripts/whoami.sh \"\$(pwd)\" <type>"

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: rename-team.sh <old_team> <new_team>
+#
+# Renames a team:
+#   1. moves teams/<old>/ to teams/<new>/
+#   2. updates "name" field in the moved config.json
+#   3. updates messages.db: UPDATE messages SET team=<new> WHERE team=<old>
+
+OLD_TEAM="${1:?Usage: rename-team.sh <old_team> <new_team>}"
+NEW_TEAM="${2:?Missing new team name}"
+
+if [ "$OLD_TEAM" = "$NEW_TEAM" ]; then
+  echo "Old and new team names are the same: $OLD_TEAM"
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEAMS_DIR="$SCRIPT_DIR/../teams"
+DB="$SCRIPT_DIR/../db/messages.db"
+OLD_DIR="$TEAMS_DIR/$OLD_TEAM"
+NEW_DIR="$TEAMS_DIR/$NEW_TEAM"
+
+if [ ! -d "$OLD_DIR" ]; then
+  echo "Team not found: $OLD_TEAM"
+  exit 1
+fi
+
+if [ -e "$NEW_DIR" ]; then
+  echo "Team already exists: $NEW_TEAM"
+  exit 1
+fi
+
+# --- Move directory ---
+mv "$OLD_DIR" "$NEW_DIR"
+
+# --- Update name in config.json ---
+NEW_CONFIG="$NEW_DIR/config.json"
+if [ -f "$NEW_CONFIG" ]; then
+  CONFIG_ESCAPED=$(sed "s/'/''/g" "$NEW_CONFIG")
+  UPDATED=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+    "SELECT json_set(:json, '\$.name', '$NEW_TEAM');")
+  echo "$UPDATED" > "$NEW_CONFIG"
+fi
+
+# --- Update messages in DB ---
+if [ -f "$DB" ]; then
+  sqlite3 "$DB" "UPDATE messages SET team='$NEW_TEAM' WHERE team='$OLD_TEAM';"
+fi
+
+echo "Renamed team $OLD_TEAM → $NEW_TEAM"

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -145,3 +145,58 @@ teardown() {
   [[ "$output" =~ "removed 1 registration" ]]
   [ ! -d "$TEST_SKILL_DIR/teams/myteam" ]
 }
+
+# --- rename-team.sh ---
+
+@test "rename-team: renames the team dir and updates config.json name" {
+  bash "$SCRIPTS/join.sh" oldteam alice claude-code /tmp/proj
+  run bash "$SCRIPTS/rename-team.sh" oldteam newteam
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Renamed team oldteam → newteam" ]]
+  [ ! -d "$TEST_SKILL_DIR/teams/oldteam" ]
+  [ -f "$TEST_SKILL_DIR/teams/newteam/config.json" ]
+  run sqlite3 :memory: "SELECT json_extract(readfile('$TEST_SKILL_DIR/teams/newteam/config.json'), '\$.name');"
+  [ "$output" = "newteam" ]
+}
+
+@test "rename-team: preserves agents in the team" {
+  bash "$SCRIPTS/join.sh" oldteam alice claude-code /tmp/proj-a
+  bash "$SCRIPTS/join.sh" oldteam bob   codex       /tmp/proj-b
+  bash "$SCRIPTS/rename-team.sh" oldteam newteam
+  run bash "$SCRIPTS/team.sh" newteam
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "alice" ]]
+  [[ "$output" =~ "bob" ]]
+  [[ "$output" =~ "2 member" ]]
+}
+
+@test "rename-team: migrates messages to the new team name" {
+  bash "$SCRIPTS/join.sh" oldteam alice claude-code /tmp/proj-a
+  bash "$SCRIPTS/join.sh" oldteam bob   claude-code /tmp/proj-b
+  bash "$SCRIPTS/send.sh" oldteam alice bob "hello"
+  bash "$SCRIPTS/rename-team.sh" oldteam newteam
+  run bash "$SCRIPTS/inbox.sh" newteam bob
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "hello" ]]
+}
+
+@test "rename-team: fails when old team is missing" {
+  run bash "$SCRIPTS/rename-team.sh" nope newname
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Team not found: nope" ]]
+}
+
+@test "rename-team: fails when new team already exists" {
+  bash "$SCRIPTS/join.sh" team-a alice claude-code /tmp/proj-a
+  bash "$SCRIPTS/join.sh" team-b bob   claude-code /tmp/proj-b
+  run bash "$SCRIPTS/rename-team.sh" team-a team-b
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Team already exists: team-b" ]]
+}
+
+@test "rename-team: fails when old and new are identical" {
+  bash "$SCRIPTS/join.sh" sameteam alice claude-code /tmp/proj
+  run bash "$SCRIPTS/rename-team.sh" sameteam sameteam
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "same" ]]
+}


### PR DESCRIPTION
## Summary

Adds `scripts/rename-team.sh` to atomically rename a team. Until now, a team name picked at first `join.sh` was effectively permanent.

What it does:
1. Moves `teams/<old>/` → `teams/<new>/`
2. Updates `name` field inside the moved `config.json`
3. `UPDATE messages SET team='<new>' WHERE team='<old>'` in `db/messages.db`
4. Prints a hint telling existing members to re-run `whoami.sh` in their projects so cached team names refresh

Agents and their per-project registrations live inside `config.json`, so they move with the team dir — no data loss, no manual re-join.

Hook settings (`.claude/settings.local.json` etc.) are not affected because they don't store team names.

## Test plan

- [x] `bats tests/test_team.bats` — all 21 tests pass, including 6 new `rename-team` cases:
  - renames dir + updates config.json name
  - preserves agents in the team
  - migrates messages
  - fails when old team missing
  - fails when new team already exists
  - fails when old == new

Closes #21