### PR TITLE
Add SessionEnd hook for symmetric watcher cleanup

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -140,15 +140,18 @@ apply_settings() {
   local settings_esc
   settings_esc=$(read_settings_escaped "$hooks_file")
 
-  # 1) Strip any prior agmsg ownership from SessionStart and Stop.
+  # 1) Strip any prior agmsg ownership from SessionStart, SessionEnd, Stop.
   settings_esc=$(strip_agmsg_event "$settings_esc" "SessionStart" | sed "s/'/''/g")
-  settings_esc=$(strip_agmsg_event "$settings_esc" "Stop" | sed "s/'/''/g")
+  settings_esc=$(strip_agmsg_event "$settings_esc" "SessionEnd"   | sed "s/'/''/g")
+  settings_esc=$(strip_agmsg_event "$settings_esc" "Stop"         | sed "s/'/''/g")
 
   # 2) Re-add what this mode wants.
   case "$mode" in
     monitor)
-      local cmd="'$SKILL_DIR/scripts/session-start.sh' '$type' '$project'"
-      settings_esc=$(add_event_entry "$settings_esc" "SessionStart" "$cmd" | sed "s/'/''/g")
+      local ss="'$SKILL_DIR/scripts/session-start.sh' '$type' '$project'"
+      local se="'$SKILL_DIR/scripts/session-end.sh'   '$type' '$project'"
+      settings_esc=$(add_event_entry "$settings_esc" "SessionStart" "$ss" | sed "s/'/''/g")
+      settings_esc=$(add_event_entry "$settings_esc" "SessionEnd"   "$se" | sed "s/'/''/g")
       ;;
     turn)
       local cmd="'$SKILL_DIR/scripts/check-inbox.sh' '$type' '$project'"
@@ -156,9 +159,11 @@ apply_settings() {
       ;;
     both)
       local ss="'$SKILL_DIR/scripts/session-start.sh' '$type' '$project'"
-      local st="'$SKILL_DIR/scripts/check-inbox.sh' '$type' '$project'"
+      local se="'$SKILL_DIR/scripts/session-end.sh'   '$type' '$project'"
+      local st="'$SKILL_DIR/scripts/check-inbox.sh'   '$type' '$project'"
       settings_esc=$(add_event_entry "$settings_esc" "SessionStart" "$ss" | sed "s/'/''/g")
-      settings_esc=$(add_event_entry "$settings_esc" "Stop" "$st" | sed "s/'/''/g")
+      settings_esc=$(add_event_entry "$settings_esc" "SessionEnd"   "$se" | sed "s/'/''/g")
+      settings_esc=$(add_event_entry "$settings_esc" "Stop"         "$st" | sed "s/'/''/g")
       ;;
     off)
       : # already stripped
@@ -263,6 +268,9 @@ do_status() {
       case "$count" in ''|*[!0-9]*) count=0 ;; esac
       echo "settings hooks file: $hooks_file"
       echo "  SessionStart entries: $count"
+      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract('$(read_settings_escaped "$hooks_file")', '\$.hooks.SessionEnd'));" 2>/dev/null || echo 0)
+      case "$count" in ''|*[!0-9]*) count=0 ;; esac
+      echo "  SessionEnd entries:   $count"
       count=$(sqlite3 :memory: "SELECT json_array_length(json_extract('$(read_settings_escaped "$hooks_file")', '\$.hooks.Stop'));" 2>/dev/null || echo 0)
       case "$count" in ''|*[!0-9]*) count=0 ;; esac
       echo "  Stop entries:         $count"

--- a/scripts/session-end.sh
+++ b/scripts/session-end.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SessionEnd hook — symmetric counterpart of session-start.sh.
+#
+# Usage: session-end.sh <type> <project_path>
+#
+# When Claude Code terminates a session (matchers: clear / resume / logout /
+# prompt_input_exit / bypass_permissions_disabled / other), this script:
+#   1. Reads session_id from the hook input JSON on stdin.
+#   2. Kills the watch.sh process for that session via its pidfile.
+#   3. Removes the matching cc-instance.<cc_pid> file if it still points at
+#      this session_id, so the next SessionStart starts cleanly.
+#
+# Cleanup is best-effort: any missing pieces just result in nothing to do.
+# The script always exits 0 — SessionEnd cannot block session termination
+# anyway, and a non-zero exit would only generate noise in logs.
+
+TYPE="${1:?Usage: session-end.sh <type> <project_path>}"
+PROJECT="${2:?Missing project_path}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUN_DIR="$SKILL_DIR/run"
+
+INPUT=$(cat 2>/dev/null || true)
+SESSION_ID=""
+if [ -n "$INPUT" ]; then
+  SESSION_ID=$(printf '%s' "$INPUT" \
+    | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | head -1)
+fi
+[ -z "$SESSION_ID" ] && exit 0
+
+PIDFILE="$RUN_DIR/watch.$SESSION_ID.pid"
+if [ -f "$PIDFILE" ]; then
+  pid=$(cat "$PIDFILE" 2>/dev/null || true)
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+  fi
+  rm -f "$PIDFILE"
+fi
+
+# Clean cc-instance entries that still point at this session_id. The
+# enclosing CC process may itself be exiting (matcher=logout/etc.), in which
+# case its cc-instance.<pid> file would otherwise be left stale.
+for f in "$RUN_DIR"/cc-instance.*; do
+  [ -f "$f" ] || continue
+  state=$(cat "$f" 2>/dev/null || true)
+  [ "$state" = "$SESSION_ID" ] && rm -f "$f"
+done
+
+exit 0

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -281,3 +281,80 @@ JSON
   echo '{"session_id":"x"}' | bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" >/dev/null
   [ ! -f "$TEST_SKILL_DIR/run/cc-instance.$dead_pid" ]
 }
+
+# --- SessionEnd hook integration ---
+
+has_session_end() {
+  [ -f "$1" ] && grep -q "session-end.sh" "$1"
+}
+
+@test "delivery set monitor: installs SessionEnd alongside SessionStart" {
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  has_session_start "$(settings_file)"
+  has_session_end   "$(settings_file)"
+  ! has_check_inbox "$(settings_file)"
+}
+
+@test "delivery set both: installs SessionStart, SessionEnd, Stop" {
+  bash "$SCRIPTS/delivery.sh" set both claude-code "$TEST_PROJECT"
+  has_session_start "$(settings_file)"
+  has_session_end   "$(settings_file)"
+  has_check_inbox   "$(settings_file)"
+}
+
+@test "delivery set turn: no SessionEnd installed" {
+  bash "$SCRIPTS/delivery.sh" set turn claude-code "$TEST_PROJECT"
+  ! has_session_end "$(settings_file)"
+}
+
+@test "delivery set off: removes SessionEnd along with other entries" {
+  bash "$SCRIPTS/delivery.sh" set both claude-code "$TEST_PROJECT"
+  bash "$SCRIPTS/delivery.sh" set off  claude-code "$TEST_PROJECT"
+  ! has_session_end "$(settings_file)"
+}
+
+@test "delivery: monitor is idempotent for SessionEnd entry" {
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  local n
+  n=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$(settings_file)'), '\$.hooks.SessionEnd'));")
+  [ "$n" = "1" ]
+}
+
+# --- session-end.sh behavior ---
+
+@test "session-end.sh kills the watcher matching session_id and removes pidfile" {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  sleep 30 &
+  local target_pid=$!
+  echo "$target_pid" > "$TEST_SKILL_DIR/run/watch.sess-A.pid"
+  echo '{"session_id":"sess-A"}' | bash "$SCRIPTS/session-end.sh" claude-code "$TEST_PROJECT"
+  sleep 1
+  ! kill -0 "$target_pid" 2>/dev/null
+  [ ! -f "$TEST_SKILL_DIR/run/watch.sess-A.pid" ]
+}
+
+@test "session-end.sh leaves other sessions' watchers alone" {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  sleep 30 &
+  local other_pid=$!
+  echo "$other_pid" > "$TEST_SKILL_DIR/run/watch.sess-B.pid"
+  echo '{"session_id":"sess-A"}' | bash "$SCRIPTS/session-end.sh" claude-code "$TEST_PROJECT"
+  kill -0 "$other_pid" 2>/dev/null
+  [ -f "$TEST_SKILL_DIR/run/watch.sess-B.pid" ]
+  kill "$other_pid" 2>/dev/null || true
+}
+
+@test "session-end.sh removes cc-instance file that points to this session" {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  echo "sess-A" > "$TEST_SKILL_DIR/run/cc-instance.12345"
+  echo "sess-B" > "$TEST_SKILL_DIR/run/cc-instance.67890"
+  echo '{"session_id":"sess-A"}' | bash "$SCRIPTS/session-end.sh" claude-code "$TEST_PROJECT"
+  [ ! -f "$TEST_SKILL_DIR/run/cc-instance.12345" ]
+  [ -f "$TEST_SKILL_DIR/run/cc-instance.67890" ]
+}
+
+@test "session-end.sh exits 0 when input has no session_id" {
+  echo '{}' | bash "$SCRIPTS/session-end.sh" claude-code "$TEST_PROJECT"
+}


### PR DESCRIPTION
## Summary

Adds a `SessionEnd` hook (`session-end.sh`) as the symmetric counterpart of `session-start.sh`. Closes #33.

`delivery.sh set monitor` and `set both` now install **both** SessionStart and SessionEnd entries into the project's `.claude/settings.local.json`. `set turn` and `set off` leave SessionEnd absent (and strip it on transition). All injections remain idempotent — repeated `set` calls produce exactly one entry per relevant event.

## Why

Before: the watcher exited only because Claude Code propagated `SIGHUP`/`SIGTERM` to its child processes when the session terminated, and the recently-added trap in `watch.sh` happened to clean up the pidfile. Works for `/exit` and `/clear`, but fragile against force-quit, network/terminal disconnects, or anything that bypasses normal signal flow.

After: SessionEnd fires on every documented exit reason (`clear` / `resume` / `logout` / `prompt_input_exit` / `bypass_permissions_disabled` / `other`). `session-end.sh` reads `session_id` from the hook input, kills the watcher via `~/.agents/agmsg/run/watch.<session_id>.pid`, removes the pidfile, and clears the matching `cc-instance.<cc_pid>` state file if it still points at this session. Best-effort, always exits 0.

## What's in this PR

- **`scripts/session-end.sh`** (new). Reads `session_id` from stdin, kills the watcher for that session, removes the pidfile and any cc-instance state pointing at it.
- **`scripts/delivery.sh`** — `apply_settings` now strips and re-adds SessionEnd alongside SessionStart and Stop. `do_status` reports SessionEnd entry count.
- **`tests/test_delivery.bats`** — adds coverage for SessionEnd injection across all four modes, idempotency, `session-end.sh` killing the right watcher (and only that one), cc-instance state cleanup, and the no-session_id no-op path.

## Test plan

- [x] `bats tests/` clean — 87 passing, 0 failing (was 78 before this PR)
- [x] `delivery.sh set monitor` on the live install produces both `SessionStart` and `SessionEnd` entries; `delivery.sh status` reports both
- [x] `delivery.sh set off` removes both
- [x] Idempotent: 3× `set monitor` results in exactly one SessionEnd entry

## What this does *not* fix

It does **not** suppress Claude Code's interactive "Background work is running, the following will stop when you exit" dialog. That fires *before* SessionEnd, so SessionEnd-side cleanup can't replace user confirmation. Tracked separately — outside agmsg's scope.

## Out of scope

- Install UI mode-selection prompt — #29.
- `hook.sh` deprecation message, `/agmsg mode` skill subcommand, README mode-decision tree — #30.