### PR TITLE
Mode selection prompt on first /agmsg join

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,6 +83,11 @@ if [ "$UPDATE_ONLY" = true ]; then
   for tmpl in "$SCRIPT_DIR/templates/"cmd.*.md; do
     sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$tmpl" > "$SKILL_DIR/templates/$(basename "$tmpl")"
   done
+  # Refresh the Claude Code slash command file (was missed in earlier --update flows).
+  CC_COMMANDS_DIR="$HOME/.claude/commands"
+  if [ -d "$CC_COMMANDS_DIR" ] && [ -f "$CC_COMMANDS_DIR/$SKILL_NAME.md" ]; then
+    sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/cmd.claude-code.md" > "$CC_COMMANDS_DIR/$SKILL_NAME.md"
+  fi
   cp "$SCRIPT_DIR/openai.yaml" "$SKILL_DIR/agents/openai.yaml" 2>/dev/null || true
   chmod +x "$SKILL_DIR/scripts/"*.sh
   echo "  + updated scripts, templates, and SKILL.md"

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -184,16 +184,29 @@ emit_monitor_directive() {
   local type="$1"
   local project="$2"
   local watch="$SKILL_DIR/scripts/watch.sh"
+
+  # Claude Code exports CLAUDE_CODE_SESSION_ID for every subprocess of the
+  # session. Bake it directly into the command so the agent never has to
+  # invent a value — that lets SessionEnd find and clean the matching
+  # pidfile reliably. Fall back to a generated id when the env var isn't
+  # present (older CC, non-CC runtimes).
+  local session_id="${CLAUDE_CODE_SESSION_ID:-}"
+  if [ -z "$session_id" ]; then
+    if command -v uuidgen >/dev/null 2>&1; then
+      session_id="agmsg-$(uuidgen | tr 'A-Z' 'a-z')"
+    else
+      session_id="agmsg-$(date +%s)-$$"
+    fi
+  fi
+
   cat <<EOF
 
 AGMSG-DIRECTIVE: For this running session, invoke the Monitor tool now with:
-  command: $watch \$AGMSG_SESSION_ID $project $type
+  command: $watch $session_id $project $type
   description: agmsg inbox stream
   persistent: true
 
-Substitute \$AGMSG_SESSION_ID with the current session_id when known
-(passed by the SessionStart hook in production; in interactive use, any
-unique string per session works — the pidfile uses it as a key).
+Pass the command above verbatim — the session_id is already filled in.
 EOF
 }
 

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -86,6 +86,20 @@ for f in "$RUN_DIR"/cc-instance.*; do
   kill -0 "$pid" 2>/dev/null || rm -f "$f"
 done
 
+# Same defensive pass for stale watcher pidfiles. A pidfile whose recorded
+# pid is dead (or empty) means a watcher exited without running its EXIT
+# trap — usually an edge case like SIGKILL or a synthesized session_id
+# that SessionEnd's lookup couldn't match.
+for f in "$RUN_DIR"/watch.*.pid; do
+  [ -f "$f" ] || continue
+  pid=$(cat "$f" 2>/dev/null || true)
+  if [ -z "$pid" ]; then
+    rm -f "$f"
+    continue
+  fi
+  kill -0 "$pid" 2>/dev/null || rm -f "$f"
+done
+
 # --- Dedup against the previous watcher in this CC instance. ---
 if [ -n "$CC_PID" ]; then
   STATE="$RUN_DIR/cc-instance.$CC_PID"

--- a/templates/cmd.claude-code.md
+++ b/templates/cmd.claude-code.md
@@ -40,10 +40,31 @@ Four possible outputs:
   > - `/__SKILL_NAME__ team` — list team members
   > - `/__SKILL_NAME__ history` — message history
 
-  5. **REQUIRED — Do NOT skip this step.** Ask the user: "Enable auto message checking? When enabled, incoming messages are automatically detected after each response. You can turn it on/off anytime with `/__SKILL_NAME__ hook on/off`."
-     - **Wait for the user's answer before proceeding.**
-     - If yes: run `~/.agents/skills/__SKILL_NAME__/scripts/hook.sh on claude-code "$(pwd)"`
-     - If no: skip
+  5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
+
+     ```
+     Choose delivery mode for incoming messages:
+
+       1) monitor — Real-time push (~5s latency)
+                     SessionStart hook + Monitor tool streams events.
+                     Recommended.
+
+       2) turn    — Check inbox at the end of each assistant turn
+                     Stop hook pulls after each response.
+
+       3) both    — monitor primary, turn as fallback
+                     Redundant safety net.
+
+       4) off     — No automatic delivery
+                     Manual /__SKILL_NAME__ only.
+
+     [1]:
+     ```
+
+     - **Wait for the user's answer before proceeding.** Empty input means `1` (monitor).
+     - Map the chosen number to a mode and run:
+       `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> claude-code "$(pwd)"`
+     - Read the `AGMSG-DIRECTIVE` block printed by `delivery.sh` and follow it (invoke Monitor or TaskStop as instructed).
 
   6. Then check inbox for the newly joined team.
 

--- a/templates/cmd.codex.md
+++ b/templates/cmd.codex.md
@@ -41,10 +41,24 @@ Four possible outputs:
   > - `$__SKILL_NAME__ team` — list team members
   > - `$__SKILL_NAME__ history` — message history
 
-  5. **REQUIRED — Do NOT skip this step.** Ask the user: "Enable auto message checking? When enabled, incoming messages are automatically detected after each response. You can turn it on/off anytime with `$__SKILL_NAME__ hook on/off`."
-     - **Wait for the user's answer before proceeding.**
-     - If yes: run `~/.agents/skills/__SKILL_NAME__/scripts/hook.sh on codex "$(pwd)"`
-     - If no: skip
+  5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
+
+     ```
+     Choose delivery mode for incoming messages:
+
+       1) turn — Check inbox at the end of each assistant turn
+                  Stop hook pulls after each response.
+
+       2) off  — No automatic delivery
+                  Manual $__SKILL_NAME__ only.
+
+     [1]:
+     ```
+
+     - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
+     - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
+       `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> codex "$(pwd)"`
+     - Codex has no Monitor tool, so `monitor` and `both` modes are not offered here.
 
   6. Then check inbox for the newly joined team.
 

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -358,3 +358,52 @@ has_session_end() {
 @test "session-end.sh exits 0 when input has no session_id" {
   echo '{}' | bash "$SCRIPTS/session-end.sh" claude-code "$TEST_PROJECT"
 }
+
+# --- CLAUDE_CODE_SESSION_ID baking ---
+
+@test "delivery set monitor: bakes CLAUDE_CODE_SESSION_ID into the directive" {
+  CLAUDE_CODE_SESSION_ID="real-uuid-1234" run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  [[ "$output" =~ "real-uuid-1234" ]]
+  ! [[ "$output" =~ "\\\$AGMSG_SESSION_ID" ]]
+  ! [[ "$output" =~ "\\\$CLAUDE_CODE_SESSION_ID" ]]
+}
+
+@test "delivery set monitor: falls back to a generated id when env is unset" {
+  # Ensure env var is unset
+  unset CLAUDE_CODE_SESSION_ID
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  [[ "$output" =~ "AGMSG-DIRECTIVE" ]]
+  # No placeholder leaked
+  ! [[ "$output" =~ "\\\$AGMSG_SESSION_ID" ]]
+}
+
+# --- session-start.sh: stale watcher pidfile cleanup ---
+
+@test "session-start.sh removes watch.<sid>.pid files whose pid is dead" {
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+  echo "999999" > "$TEST_SKILL_DIR/run/watch.dead-session.pid"  # bogus pid
+  : > "$TEST_SKILL_DIR/run/watch.empty-pid.pid"                  # empty pid
+  echo '{"session_id":"x"}' | bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" >/dev/null
+  [ ! -f "$TEST_SKILL_DIR/run/watch.dead-session.pid" ]
+  [ ! -f "$TEST_SKILL_DIR/run/watch.empty-pid.pid" ]
+}
+
+@test "session-start.sh leaves alive watcher pidfiles alone" {
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+  sleep 30 &
+  local alive_pid=$!
+  echo "$alive_pid" > "$TEST_SKILL_DIR/run/watch.live-session.pid"
+  echo '{"session_id":"x"}' | bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" >/dev/null
+  [ -f "$TEST_SKILL_DIR/run/watch.live-session.pid" ]
+  kill "$alive_pid" 2>/dev/null || true
+}


### PR DESCRIPTION
## Summary

Implements [#29](https://github.com/fujibee/agmsg/issues/29). Replaces the legacy "Enable auto message checking? y/n" prompt in the `/agmsg` skill with a delivery-mode picker that runs the first time a user joins a team in a project.

| Template | Modes offered |
|---|---|
| `cmd.claude-code.md` | `monitor` (default), `turn`, `both`, `off` |
| `cmd.codex.md`       | `turn` (default), `off` — Monitor tool isn't available on Codex |

The chosen mode is applied via `delivery.sh set <mode> <type> <project>`, which prints an `AGMSG-DIRECTIVE` that activates monitor (or stops it for `turn`/`off`) in the current session — no restart needed.

## What's in this PR

- **`templates/cmd.claude-code.md`** — fresh-join flow now shows the four-mode picker with one-line descriptions per mode (English only, per project rules) and pipes the answer into `delivery.sh set`. The skill follows the directive afterwards.
- **`templates/cmd.codex.md`** — same shape with the modes Codex can actually use; explicit note that `monitor`/`both` are hidden because Codex has no Monitor tool.
- **`install.sh --update`** — now also refreshes `~/.claude/commands/<cmd>.md` (the Claude Code slash-command file), which earlier `--update` runs missed.

## Out of scope

- **Legacy migration.** Existing users with `hook.check_interval` set but no `delivery.mode` keep working in turn mode via the fallback read in `check-inbox.sh`. They can upgrade with `delivery.sh set monitor …` today, or wait for the dedicated `/agmsg mode` command in #30.
- **install.sh interactive mode prompt.** install is global; the mode is per-project, so it's only asked in the per-project `/agmsg` flow.
- **`/agmsg mode` command + `hook.sh` deprecation message + README mode decision tree.** All #30.

## Test plan

- [x] `bats tests/` clean — 87 passing
- [x] Deployed via `./install.sh --update`, slash-command file now shows the new picker
- [x] Codex template numbers stay 1/2 (no skipped numbers from hiding monitor/both)

Closes #29

---

## Update: also closes #36

Scope expanded during review when a stale `watch.<random>.pid` surfaced from a mid-session `delivery.sh set monitor` call. Two fixes folded in:

1. **`delivery.sh` `emit_monitor_directive`** now reads `CLAUDE_CODE_SESSION_ID` from the env (exported by Claude Code to every subprocess) and bakes the real session_id into the directive's `command:` line. The agent no longer has to invent a session_id, and the pidfile name matches what `session-end.sh` looks for at session exit. Falls back to a generated id when the env var isn't present (older CC, non-CC runtimes).
2. **`session-start.sh` cleanup pass** now also removes `watch.<sid>.pid` files whose recorded pid is dead — defensive cleanup of any leftover from edge cases.

Tests bumped from 87 → 91.
