### PR TITLE
Add /agmsg mode command, deprecate hook.sh, document delivery modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ git clone https://github.com/fujibee/agmsg.git && cd agmsg && ./install.sh
 #    Codex:        $agmsg
 ```
 
-That's it. Once two agents have joined the same team, they can message each other. On first join, you'll be asked to enable **auto message detection** — incoming messages are automatically detected after each response (via Stop hook, with 60-second cooldown).
+That's it. Once two agents have joined the same team, they can message each other. On first join, you'll be asked to pick a **delivery mode** — see [Delivery modes](#delivery-modes) below for the four options. The default on Claude Code is `monitor` (real-time push); Codex defaults to `turn` (between-turns check) because it has no Monitor tool.
 
 After setup, your agent handles everything — just talk to it naturally. "Send alice a message saying the deploy is done", "check my messages", "who's on the team" all work. The shell scripts below are for reference and advanced use.
 
@@ -100,18 +100,52 @@ If you want to clear the current project's registrations without leaving the tea
 ~/.agents/skills/agmsg/scripts/reset.sh /path/to/project-b claude-code
 ```
 
+## Delivery modes
+
+How incoming messages reach your agent. Pick one at first join via the prompt, or change it later with `/agmsg mode <name>`.
+
+| mode | mechanism | latency | who it's for |
+|---|---|---|---|
+| **`monitor`** (default on Claude Code) | SessionStart hook → Monitor tool → blocking SQLite stream | ~5s | Claude Code users wanting real-time push |
+| **`turn`** (default on Codex) | Stop hook fires `check-inbox.sh` between assistant turns | until your next interaction | Codex (no Monitor tool); Claude Code users on a quieter loop |
+| **`both`** | monitor primary, turn as per-session safety net | ~5s; falls back to turn-end on watcher failure | belt-and-suspenders |
+| **`off`** | no automatic delivery | manual `/agmsg` only | minimalists |
+
+### Picking a mode
+
+```
+/agmsg mode monitor    — switch this project to real-time push (Claude Code)
+/agmsg mode turn       — switch to between-turns checking
+/agmsg mode both       — monitor with turn as a safety net
+/agmsg mode off        — manual /agmsg only
+/agmsg mode            — show current mode
+```
+
+Settings are per-project. Each `<project>/.claude/settings.local.json` gets exactly the hooks the chosen mode needs — repeated `set` calls are idempotent.
+
+### Migrating from legacy `hook on/off`
+
+`hook on` is now a thin alias for `mode turn` (with a one-line deprecation hint). To switch to real-time push:
+
+```
+/agmsg mode monitor
+```
+
+The command updates `db/config.yaml`, rewrites the project's hook entries, and prints an `AGMSG-DIRECTIVE` that activates `monitor` in the current session — no agent restart needed.
+
 ## Usage
 
 ### Claude Code
 
 ```
-/agmsg                          — check inbox (all teams)
-/agmsg history                  — message history
-/agmsg team                     — list team members
-/agmsg send <agent> <message>   — send message
-/agmsg hook on                  — enable auto message detection
-/agmsg hook off                 — disable auto message detection
-/agmsg reset                    — clear current project registration
+/agmsg                                  — check inbox (all teams)
+/agmsg history                          — message history
+/agmsg team                             — list team members
+/agmsg send <agent> <message>           — send message
+/agmsg mode <monitor|turn|both|off>     — switch delivery mode
+/agmsg mode                             — show current mode
+/agmsg hook on | off                    — legacy aliases (mode turn | off)
+/agmsg reset                            — clear current project registration
 ```
 
 ### Codex
@@ -119,6 +153,8 @@ If you want to clear the current project's registrations without leaving the tea
 ```
 $agmsg                          — or /skills → agmsg
 ```
+
+Codex supports `mode turn` and `mode off` only — there's no Monitor tool to stream into.
 
 ### Shell (any agent)
 
@@ -128,9 +164,12 @@ $agmsg                          — or /skills → agmsg
 ~/.agents/skills/<cmd>/scripts/history.sh <team> [agent_id] [limit]
 ~/.agents/skills/<cmd>/scripts/team.sh <team>
 ~/.agents/skills/<cmd>/scripts/whoami.sh <project_path> <type>
-~/.agents/skills/<cmd>/scripts/hook.sh on|off <type> <project_path>
+~/.agents/skills/<cmd>/scripts/delivery.sh set <mode> <type> <project_path>
+~/.agents/skills/<cmd>/scripts/delivery.sh status [<type> <project_path>]
 ~/.agents/skills/<cmd>/scripts/reset.sh <project_path> <type> [agent_id]
 ```
+
+`hook.sh on|off` still works as a legacy alias for `delivery.sh set turn|off` but prints a deprecation notice.
 
 ## Update
 

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -130,10 +130,12 @@ create_default_config() {
   cat > "$CONFIG_FILE" <<'YAML'
 # agmsg configuration
 # https://agmsg.cc/
+#
+# Mode (monitor | turn | both | off) is per-project — derived from each
+# project's .claude/settings.local.json by `delivery.sh status`. There is
+# no global "mode" key. Only machine-wide tuning lives here.
 
 delivery:
-  # How incoming messages reach this agent: monitor | turn | both | off
-  mode: monitor
   monitor:
     # watch.sh SQLite poll interval, seconds
     poll_interval: 5

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -230,7 +230,6 @@ do_set() {
   esac
 
   apply_settings "$TYPE" "$PROJECT" "$MODE"
-  "$SCRIPT_DIR/config.sh" set delivery.mode "$MODE" >/dev/null
 
   echo "Delivery mode set to '$MODE' for $PROJECT ($TYPE)"
 
@@ -257,20 +256,35 @@ do_status() {
   local TYPE="${1:-}"
   local PROJECT="${2:-}"
 
-  local mode
-  mode=$("$SCRIPT_DIR/config.sh" get delivery.mode "" 2>/dev/null || true)
-  if [ -z "$mode" ]; then
-    # Legacy: if hook.check_interval exists from a prior hook.sh install,
-    # treat that as effective mode=turn for reporting.
-    local legacy
-    legacy=$("$SCRIPT_DIR/config.sh" get hook.check_interval "" 2>/dev/null || true)
-    if [ -n "$legacy" ]; then
-      mode="turn (legacy hook.check_interval=$legacy)"
-    else
-      mode="off (default)"
+  # Mode is derived from the project's settings.local.json — there's no
+  # global mode value. When called without <type> <project>, we can't infer
+  # a project-scoped mode, so we just skip the mode line and report the
+  # global watcher state below.
+  if [ -n "$TYPE" ] && [ -n "$PROJECT" ]; then
+    local hf
+    hf=$(resolve_hooks_file "$TYPE" "$PROJECT")
+    local has_ss=0 has_st=0
+    if [ -f "$hf" ]; then
+      has_ss=$(sqlite3 :memory: "
+        SELECT EXISTS(
+          SELECT 1 FROM json_each(json_extract(readfile('$hf'), '\$.hooks.SessionStart')) AS s,
+            json_each(json_extract(s.value, '\$.hooks')) AS h
+          WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+        );" 2>/dev/null || echo 0)
+      has_st=$(sqlite3 :memory: "
+        SELECT EXISTS(
+          SELECT 1 FROM json_each(json_extract(readfile('$hf'), '\$.hooks.Stop')) AS s,
+            json_each(json_extract(s.value, '\$.hooks')) AS h
+          WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+        );" 2>/dev/null || echo 0)
     fi
+    local mode="off"
+    if [ "$has_ss" = "1" ] && [ "$has_st" = "1" ]; then mode="both"
+    elif [ "$has_ss" = "1" ]; then mode="monitor"
+    elif [ "$has_st" = "1" ]; then mode="turn"
+    fi
+    echo "mode: $mode"
   fi
-  echo "mode: $mode"
 
   if [ -n "$TYPE" ] && [ -n "$PROJECT" ]; then
     local hooks_file

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -199,6 +199,23 @@ emit_monitor_directive() {
     fi
   fi
 
+  # Skip the directive when this CC session already has a live watcher —
+  # invoking Monitor again would just spawn a duplicate and orphan the
+  # previous watcher process.
+  local pidfile="$RUN_DIR/watch.$session_id.pid"
+  if [ -f "$pidfile" ]; then
+    local existing
+    existing=$(cat "$pidfile" 2>/dev/null || true)
+    if [ -n "$existing" ] && kill -0 "$existing" 2>/dev/null; then
+      cat <<EOF
+
+A watch.sh is already streaming into this session (pid $existing). No
+action needed — the existing watcher is the active one.
+EOF
+      return 0
+    fi
+  fi
+
   cat <<EOF
 
 AGMSG-DIRECTIVE: For this running session, invoke the Monitor tool now with:

--- a/scripts/hook.sh
+++ b/scripts/hook.sh
@@ -14,6 +14,8 @@ shift
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+echo "agmsg: hook.sh is deprecated; use 'delivery.sh set <mode>' or '/agmsg mode <mode>' instead." >&2
+
 case "$ACTION" in
   on)  exec "$SCRIPT_DIR/delivery.sh" set turn "$@" ;;
   off) exec "$SCRIPT_DIR/delivery.sh" set off  "$@" ;;

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -18,8 +18,11 @@ set -euo pipefail
 # instances of the same project get their own cc_pid, so they never step
 # on each other.
 #
-# Quietly exits 0 when delivery.mode is not monitor/both, when whoami says
-# the agent isn't joined to anything yet, etc.
+# Quietly exits 0 when whoami says the agent isn't joined to anything yet.
+# Mode is implicit: if this script is being invoked at all, it's because
+# `delivery.sh set monitor` (or `both`) installed it in the project's
+# settings.local.json — that fact alone is the source of truth for "should
+# we emit the directive?". No separate global mode value to consult.
 
 TYPE="${1:?Usage: session-start.sh <type> <project_path>}"
 PROJECT="${2:?Missing project_path}"
@@ -27,9 +30,6 @@ PROJECT="${2:?Missing project_path}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUN_DIR="$SKILL_DIR/run"
-
-MODE=$("$SCRIPT_DIR/config.sh" get delivery.mode "off" 2>/dev/null || echo off)
-case "$MODE" in monitor|both) ;; *) exit 0 ;; esac
 
 # Identity sanity check — no point launching a watcher with an empty pair set.
 PAIRS=$("$SCRIPT_DIR/identities.sh" "$PROJECT" "$TYPE" 2>/dev/null || true)

--- a/templates/cmd.claude-code.md
+++ b/templates/cmd.claude-code.md
@@ -39,6 +39,7 @@ Four possible outputs:
   > - `/__SKILL_NAME__ send <agent> <message>` — send a message
   > - `/__SKILL_NAME__ team` — list team members
   > - `/__SKILL_NAME__ history` — message history
+  > - `/__SKILL_NAME__ mode <monitor|turn|both|off>` — switch delivery mode
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -99,13 +100,22 @@ If argument starts with "send" (e.g. "send misaki check the server"):
 2. Determine which team the target agent belongs to, then run:
    `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
 
-If argument is "hook on":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/hook.sh on claude-code "$(pwd)"`
-2. Tell the user: "Auto message checking enabled."
+If argument is "mode" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status claude-code "$(pwd)"`
+2. Show the output to the user.
 
-If argument is "hook off":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/hook.sh off claude-code "$(pwd)"`
-2. Tell the user: "Auto message checking disabled."
+If argument starts with "mode" followed by a mode name (e.g. "mode monitor"):
+1. Parse the mode (one of `monitor`, `turn`, `both`, `off`).
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> claude-code "$(pwd)"`
+3. Read the `AGMSG-DIRECTIVE` block in the command output and follow it (invoke Monitor or TaskStop as instructed).
+
+If argument is "hook on" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn claude-code "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior). Consider using /__SKILL_NAME__ mode monitor for real-time push."
+
+If argument is "hook off" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off claude-code "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'off'."
 
 If argument is "config":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh show`

--- a/templates/cmd.codex.md
+++ b/templates/cmd.codex.md
@@ -102,13 +102,21 @@ If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
 
 
-If argument is "hook on":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/hook.sh on codex "$(pwd)"`
-2. Tell the user: "Auto message checking enabled."
+If argument is "mode" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status codex "$(pwd)"`
+2. Show the output to the user.
 
-If argument is "hook off":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/hook.sh off codex "$(pwd)"`
-2. Tell the user: "Auto message checking disabled."
+If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
+1. Parse the mode. Codex supports only `turn` and `off` — reject `monitor` and `both` with: "Codex has no Monitor tool; only `turn` or `off` modes are supported."
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> codex "$(pwd)"`
+
+If argument is "hook on" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn codex "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior)."
+
+If argument is "hook off" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off codex "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'off'."
 
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" codex`

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -124,29 +124,44 @@ settings_file() {
   [ "$p" = "Bash" ]
 }
 
-# --- config is updated alongside ---
+# --- status derives mode from settings.local.json ---
 
-@test "delivery set: writes delivery.mode into config.yaml" {
-  bash "$SCRIPTS/delivery.sh" set both claude-code "$TEST_PROJECT"
-  run bash "$SCRIPTS/config.sh" get delivery.mode
-  [ "$output" = "both" ]
+@test "delivery status: derives 'both' from settings with SessionStart + Stop" {
+  bash "$SCRIPTS/delivery.sh" set both claude-code "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status claude-code "$TEST_PROJECT"
+  [[ "$output" =~ "mode: both" ]]
+}
+
+@test "delivery status: derives 'monitor' from settings with SessionStart only" {
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status claude-code "$TEST_PROJECT"
+  [[ "$output" =~ "mode: monitor" ]]
+}
+
+@test "delivery status: derives 'turn' from settings with Stop only" {
+  bash "$SCRIPTS/delivery.sh" set turn claude-code "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status claude-code "$TEST_PROJECT"
+  [[ "$output" =~ "mode: turn" ]]
+}
+
+@test "delivery status: derives 'off' from settings with no agmsg hooks" {
+  run bash "$SCRIPTS/delivery.sh" status claude-code "$TEST_PROJECT"
+  [[ "$output" =~ "mode: off" ]]
 }
 
 # --- hook.sh backward compat ---
 
 @test "hook.sh on delegates to delivery set turn" {
-  bash "$SCRIPTS/hook.sh" on claude-code "$TEST_PROJECT"
+  bash "$SCRIPTS/hook.sh" on claude-code "$TEST_PROJECT" 2>&1
   has_check_inbox "$(settings_file)"
-  run bash "$SCRIPTS/config.sh" get delivery.mode
-  [ "$output" = "turn" ]
+  ! has_session_start "$(settings_file)"
 }
 
 @test "hook.sh off delegates to delivery set off" {
-  bash "$SCRIPTS/hook.sh" on  claude-code "$TEST_PROJECT"
-  bash "$SCRIPTS/hook.sh" off claude-code "$TEST_PROJECT"
+  bash "$SCRIPTS/hook.sh" on  claude-code "$TEST_PROJECT" 2>&1
+  bash "$SCRIPTS/hook.sh" off claude-code "$TEST_PROJECT" 2>&1
   ! has_check_inbox "$(settings_file)"
-  run bash "$SCRIPTS/config.sh" get delivery.mode
-  [ "$output" = "off" ]
+  ! has_session_start "$(settings_file)"
 }
 
 # --- rejects unknown mode ---

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -407,3 +407,19 @@ JSON
   [ -f "$TEST_SKILL_DIR/run/watch.live-session.pid" ]
   kill "$alive_pid" 2>/dev/null || true
 }
+
+# --- hook.sh deprecation notice ---
+
+@test "hook.sh on prints a deprecation notice on stderr" {
+  run bash "$SCRIPTS/hook.sh" on claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  # Combined stderr+stdout is captured by `run` — assert the notice appears.
+  [[ "$output" =~ "deprecated" ]]
+}
+
+@test "hook.sh off prints a deprecation notice on stderr" {
+  bash "$SCRIPTS/hook.sh" on claude-code "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/hook.sh" off claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "deprecated" ]]
+}

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -438,3 +438,35 @@ JSON
   [ "$status" -eq 0 ]
   [[ "$output" =~ "deprecated" ]]
 }
+
+# --- emit_monitor_directive idempotency ---
+
+@test "emit monitor directive: skips when a live watcher already exists for this session" {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  # Spawn a live process and pretend it's our watcher for this session_id.
+  sleep 30 &
+  local live_pid=$!
+  CLAUDE_CODE_SESSION_ID="live-test-sid"
+  export CLAUDE_CODE_SESSION_ID
+  echo "$live_pid" > "$TEST_SKILL_DIR/run/watch.$CLAUDE_CODE_SESSION_ID.pid"
+
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "already streaming" ]]
+  ! [[ "$output" =~ "AGMSG-DIRECTIVE" ]]
+
+  kill "$live_pid" 2>/dev/null || true
+  unset CLAUDE_CODE_SESSION_ID
+}
+
+@test "emit monitor directive: emits when no live watcher exists for this session" {
+  CLAUDE_CODE_SESSION_ID="fresh-sid-no-watcher"
+  export CLAUDE_CODE_SESSION_ID
+
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "AGMSG-DIRECTIVE" ]]
+  [[ "$output" =~ "fresh-sid-no-watcher" ]]
+
+  unset CLAUDE_CODE_SESSION_ID
+}


### PR DESCRIPTION
## Summary

Closes #30. Final polish on the monitor-delivery epic (#31):

- **`/agmsg mode <monitor|turn|both|off>`** — new skill subcommand for switching delivery mode mid-session. `/agmsg mode` with no args shows current state via `delivery.sh status`.
- **`hook.sh` is now a thin alias with a deprecation notice** — prints "hook.sh is deprecated; use 'delivery.sh set <mode>' or '/agmsg mode <mode>' instead." on stderr, then delegates to `delivery.sh set turn|off`. Existing users keep working.
- **README** gets a Delivery modes section with the mode comparison table, picker examples, and a one-liner migration recipe from legacy `hook on/off`.

## What's in this PR

- **`scripts/hook.sh`** — emits the deprecation notice before delegating. Behavior is otherwise unchanged.
- **`templates/cmd.claude-code.md`** — adds `mode` and `mode <name>` subcommand handling; `hook on/off` handlers now route through `delivery.sh` with a one-line "consider /agmsg mode monitor" hint on `hook on`. Welcome message lists `mode` alongside the other commands.
- **`templates/cmd.codex.md`** — same `mode` / `mode <name>` handling. Codex variant rejects `monitor` / `both` and explains why.
- **`README.md`** — new `## Delivery modes` section with the mode table, picker examples, and migration guidance. Usage section's command reference is updated to include `/agmsg mode …`, demote `hook on/off` as legacy, and replace bare `hook.sh` references with `delivery.sh set/status`.
- **`tests/test_delivery.bats`** — two new tests asserting the deprecation notice is emitted by `hook.sh on` and `hook.sh off`.

## Test plan

- [x] `bats tests/` — 93 passing, 0 failing (was 91 before this PR)
- [x] `./install.sh --update` deploys the new templates; live `~/.claude/commands/agmsg.md` reflects them
- [x] `~/.agents/skills/agmsg/scripts/hook.sh on …` prints the deprecation notice and still flips mode to `turn`
- [x] `~/.agents/skills/agmsg/scripts/delivery.sh status …` reports current mode; this is what `/agmsg mode` (no args) surfaces

## Epic status after this PR

`#31` (monitor delivery mode) — all four child issues closed:
- `#28` end-to-end implementation (already merged)
- `#29` mode-selection prompt (already merged)
- `#30` cleanup + `/agmsg mode` + README — **this PR**
- `#36` `CLAUDE_CODE_SESSION_ID` + stale pidfile cleanup (already merged)

---

## Follow-up commit: drop global `delivery.mode`

Discovered while smoke-testing `/agmsg mode` that the global config's `delivery.mode` was a buggy concept — setting a mode on one project would clobber what `delivery.sh status` reported for *all other* projects, since hooks are per-project but the config key was global.

Fix: stop writing `delivery.mode` to global config. Derive mode per-project from the project's `settings.local.json` by inspecting which agmsg-owned hook entries exist.

- `delivery.sh apply_settings` no longer touches `config.sh set delivery.mode`.
- `delivery.sh status` reads the project's settings, counts agmsg entries in `SessionStart` / `Stop`, and reports `monitor` / `turn` / `both` / `off` accordingly.
- `session-start.sh` drops its global-mode gate; being installed in `settings.local.json` is the source of truth.
- `db/config.yaml` default drops the `mode` key; only `monitor.poll_interval` and `turn.check_interval` remain (legitimate machine-wide tuning).
- Existing installs still have `delivery.mode: monitor` written; it is now ignored, no migration needed.
- Tests updated: assertions that checked `config.sh get delivery.mode` now check `delivery.sh status` output instead. Total tests bumped from 93 → 96.

This is part of #30's "cleanup" remit — keeping the polish in one PR rather than fragmenting.
