### PR TITLE
join.sh: reject unknown agent type

### DIFF
--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -7,8 +7,17 @@ set -euo pipefail
 
 TEAM="${1:?Usage: join.sh <team> <agent_id> <type> <project_path>}"
 AGENT_ID="${2:?Missing agent_id}"
-AGENT_TYPE="${3:?Missing type (claude-code, codex, etc.)}"
+AGENT_TYPE="${3:?Missing type (claude-code | codex)}"
 PROJECT_PATH="${4:?Missing project_path}"
+
+# Reject unknown agent types — the rest of agmsg (delivery.sh,
+# session-start.sh, identities.sh lookups) only supports the values listed
+# here. Allowing arbitrary strings silently mis-registers an agent and
+# makes monitor mode fail with a confusing "no joined teams" message.
+case "$AGENT_TYPE" in
+  claude-code|codex) ;;
+  *) echo "Unknown agent type: '$AGENT_TYPE' (supported: claude-code, codex)" >&2; exit 1 ;;
+esac
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEAMS_DIR="$SCRIPT_DIR/../teams"

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -200,3 +200,19 @@ teardown() {
   [ "$status" -ne 0 ]
   [[ "$output" =~ "same" ]]
 }
+
+@test "join: rejects unknown agent type" {
+  run bash "$SCRIPTS/join.sh" myteam alice claude /tmp/proj
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Unknown agent type" ]]
+}
+
+@test "join: accepts claude-code" {
+  run bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj
+  [ "$status" -eq 0 ]
+}
+
+@test "join: accepts codex" {
+  run bash "$SCRIPTS/join.sh" myteam alice codex /tmp/proj
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes a recurring UX papercut: `join.sh` silently accepted any string for the agent type, so agents typing `claude` instead of `claude-code` would register correctly under the wrong key. `identities.sh` then couldn't match them, and `watch.sh` exited with "no joined teams for …" — a confusing failure mode.

Validates against the allowlist the rest of agmsg already supports (`claude-code`, `codex`). 101 bats tests pass (was 98).