### PR TITLE
Add /agmsg actas and drop for multiple roles per project

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,19 @@ Same project, same agent type, different role — for example a `tech-lead` iden
 Mechanics:
 
 - `actas <name>` is **exclusive**: switches both sending and receiving to `<name>`. The skill joins the role under your current team if needed, then TaskStops the running `agmsg inbox stream` Monitor and relaunches one filtered to `<name>` only (via `watch.sh`'s optional 4th argument). Messages addressed to other roles stop reaching the session until you `actas` again or end the session.
-- `drop <name>` removes only that role's registration for this project (via `reset.sh`). If the role is no longer registered anywhere, it's also dropped from the team config. If `<name>` was the currently-active role, the watcher is restarted in default mode (all your registered roles).
+- `drop <name>` removes only that role's registration for this project (via `reset.sh`). If the role is no longer registered anywhere, it's also dropped from the team config. If `<name>` was the currently-active role, the watcher is restarted in default mode (all roles registered for this project at relaunch time).
 - Switching is session-scoped state held by the agent. `/clear` or a new session resets back to the multiple-identities picker.
+
+#### Subscription model
+
+agmsg follows a **one CC session = one active role** model. Each watcher subscribes to a *static* set of identities decided at launch:
+
+- **Without `actas`**: the watcher subscribes to whichever `(team, agent)` pairs were registered for this `(project, agent_type)` at the moment `watch.sh` started. The set is *not* re-resolved later. A role joined mid-session via `actas` from another CC does *not* start arriving in CCs that were launched before it.
+- **After `actas <name>`**: the watcher is relaunched filtered to `<name>` only. Other registered roles stop arriving in this CC even if they pre-existed.
+
+This is intentional: it keeps each CC bound to one role's inbox, so a `tech-lead` window stays clear of `biz-analyst` traffic and vice versa — even when both roles are registered under the same project. To pick up a role added after a CC launched (without switching to it exclusively), restart the CC or `/clear` so SessionStart re-launches `watch.sh` with the fresh identity list.
+
+The send side mirrors this: every `send.sh` call from this CC uses the active role as the `from` agent, whether that's the implicit one (default) or the one set by the most recent `actas`.
 
 ### Reusing the same identity across projects
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ You can join the same project with multiple agent names (e.g. `cc` and `reviewer
 ~/.agents/skills/agmsg/scripts/join.sh myteam reviewer claude-code /path/to/project
 ```
 
+### Multiple roles per project (`actas` / `drop`)
+
+Same project, same agent type, different role — for example a `tech-lead` identity for architecture reviews and a `biz-analyst` identity for requirements work, both living on top of the same workspace. Toolset and assets are shared; only the role differs.
+
+```
+/agmsg actas tech-lead     # switch to tech-lead (creates it if not yet registered)
+/agmsg actas biz-analyst   # switch to biz-analyst
+/agmsg drop biz-analyst    # remove the role from this project
+```
+
+Mechanics:
+
+- `actas <name>` checks whether `<name>` is already registered for this `(project, type)`. If not, it joins under your current team automatically (or asks you to pick the team if you're in several). After that, sends from this session use `<name>` as the from agent — `watch.sh` already subscribes to **all** roles you've registered for the project, so incoming messages to any of your roles still reach you.
+- `drop <name>` removes only that role's registration for this project (via `reset.sh`). If the role is no longer registered anywhere, it's also dropped from the team config — like `leave.sh` for that one role.
+- Switching is session-scoped state held by the agent. `/clear` or a new session resets back to the multiple-identities picker.
+
 ### Reusing the same identity across projects
 
 If you join the same team with the same agent name from another project, agmsg keeps the same identity and adds a registration record for the new project.
@@ -144,6 +160,8 @@ The command updates `db/config.yaml`, rewrites the project's hook entries, and p
 /agmsg send <agent> <message>           — send message
 /agmsg mode <monitor|turn|both|off>     — switch delivery mode
 /agmsg mode                             — show current mode
+/agmsg actas <name>                     — switch to another role in this project (create if needed)
+/agmsg drop <name>                      — remove a role from this project
 /agmsg hook on | off                    — legacy aliases (mode turn | off)
 /agmsg reset                            — clear current project registration
 ```

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Same project, same agent type, different role — for example a `tech-lead` iden
 
 Mechanics:
 
-- `actas <name>` checks whether `<name>` is already registered for this `(project, type)`. If not, it joins under your current team automatically (or asks you to pick the team if you're in several). After that, sends from this session use `<name>` as the from agent — `watch.sh` already subscribes to **all** roles you've registered for the project, so incoming messages to any of your roles still reach you.
-- `drop <name>` removes only that role's registration for this project (via `reset.sh`). If the role is no longer registered anywhere, it's also dropped from the team config — like `leave.sh` for that one role.
+- `actas <name>` is **exclusive**: switches both sending and receiving to `<name>`. The skill joins the role under your current team if needed, then TaskStops the running `agmsg inbox stream` Monitor and relaunches one filtered to `<name>` only (via `watch.sh`'s optional 4th argument). Messages addressed to other roles stop reaching the session until you `actas` again or end the session.
+- `drop <name>` removes only that role's registration for this project (via `reset.sh`). If the role is no longer registered anywhere, it's also dropped from the team config. If `<name>` was the currently-active role, the watcher is restarted in default mode (all your registered roles).
 - Switching is session-scoped state held by the agent. `/clear` or a new session resets back to the multiple-identities picker.
 
 ### Reusing the same identity across projects

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -342,10 +342,18 @@ kill_all_watchers() {
   if [ -d "$RUN_DIR" ]; then
     for f in "$RUN_DIR"/watch.*.pid; do
       [ -f "$f" ] || continue
-      local pid
+      local pid cmd
       pid=$(cat "$f" 2>/dev/null || echo "")
       if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-        kill "$pid" 2>/dev/null && killed=$((killed + 1))
+        # Defensive: only kill if the pid's command line still looks like
+        # our watch.sh. Defends against pid recycling — a stale pidfile
+        # could point at an unrelated process that reused the pid.
+        cmd=$(ps -o args= -p "$pid" 2>/dev/null || true)
+        case "$cmd" in
+          *"$SKILL_DIR/scripts/watch.sh"*)
+            kill "$pid" 2>/dev/null && killed=$((killed + 1)) ;;
+          *) ;;  # not our watcher; leave it
+        esac
       fi
       rm -f "$f"
     done

--- a/scripts/session-end.sh
+++ b/scripts/session-end.sh
@@ -36,7 +36,14 @@ PIDFILE="$RUN_DIR/watch.$SESSION_ID.pid"
 if [ -f "$PIDFILE" ]; then
   pid=$(cat "$PIDFILE" 2>/dev/null || true)
   if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-    kill "$pid" 2>/dev/null || true
+    # Defensive: only kill if the pid's command line still looks like our
+    # watch.sh. Pids can be recycled — a stale pidfile could point at an
+    # unrelated process that took the same pid.
+    cmd=$(ps -o args= -p "$pid" 2>/dev/null || true)
+    case "$cmd" in
+      *"$SKILL_DIR/scripts/watch.sh"*) kill "$pid" 2>/dev/null || true ;;
+      *) ;;
+    esac
   fi
   rm -f "$PIDFILE"
 fi

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -78,23 +78,46 @@ CC_PID=$(find_cc_pid 2>/dev/null || true)
 
 # --- Cleanup of stale cc-instance files and their orphan watchers. ---
 # A cc-instance.<pid> whose CC pid is dead is left over from a previous CC.
-# Before removing it, kill the watcher bound to its last session_id — that
-# watcher would otherwise linger if the CC crashed without propagating
-# signals (force-quit, OOM, etc.). Only kills watchers we have explicit
-# evidence for (dead CC → known last session_id), so a manually-invoked
-# Monitor whose CC is alive but never wrote a cc-instance is left alone.
+# Before removing it, optionally kill the watcher bound to its last
+# session_id — but only if that session_id isn't still referenced by a
+# LIVE cc-instance file. The same session_id can move from one CC pid to
+# another (e.g. on `claude --continue` / `--resume`), so a dead-pid record
+# alone is not evidence the session is gone.
+
+# First pass: collect session_ids that are still referenced by a LIVE CC.
+live_sids=""
+for f in "$RUN_DIR"/cc-instance.*; do
+  [ -f "$f" ] || continue
+  pid=${f##*.}
+  case "$pid" in ''|*[!0-9]*) continue ;; esac
+  if kill -0 "$pid" 2>/dev/null; then
+    s=$(cat "$f" 2>/dev/null || true)
+    [ -n "$s" ] && live_sids="$live_sids|$s"
+  fi
+done
+
+# Second pass: clean each dead cc-instance, killing its bound watcher only
+# when no live CC still references that session_id.
 for f in "$RUN_DIR"/cc-instance.*; do
   [ -f "$f" ] || continue
   pid=${f##*.}
   case "$pid" in ''|*[!0-9]*) continue ;; esac
   kill -0 "$pid" 2>/dev/null && continue
   dead_sid=$(cat "$f" 2>/dev/null || true)
-  if [ -n "$dead_sid" ]; then
+  if [ -n "$dead_sid" ] \
+      && ! printf '%s\n' "$live_sids" | tr '|' '\n' | grep -Fxq "$dead_sid"; then
     orphan_pidfile="$RUN_DIR/watch.$dead_sid.pid"
     if [ -f "$orphan_pidfile" ]; then
       orphan_pid=$(cat "$orphan_pidfile" 2>/dev/null || true)
       if [ -n "$orphan_pid" ] && kill -0 "$orphan_pid" 2>/dev/null; then
-        kill "$orphan_pid" 2>/dev/null || true
+        # Defensive: only kill if the pid's command line actually matches
+        # our watch.sh. Defends against pid recycling — a stale pidfile
+        # could point at an unrelated process that took the same pid.
+        cmd=$(ps -o args= -p "$orphan_pid" 2>/dev/null || true)
+        case "$cmd" in
+          *"$SKILL_DIR/scripts/watch.sh"*) kill "$orphan_pid" 2>/dev/null || true ;;
+          *) ;;  # not our watcher anymore; leave it alone
+        esac
       fi
       rm -f "$orphan_pidfile"
     fi

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -76,14 +76,30 @@ find_cc_pid() {
 
 CC_PID=$(find_cc_pid 2>/dev/null || true)
 
-# --- Best-effort cleanup of stale cc-instance files. ---
-# Any cc-instance.<pid> whose pid is dead is left over from a previous CC
-# run and can be removed safely.
+# --- Cleanup of stale cc-instance files and their orphan watchers. ---
+# A cc-instance.<pid> whose CC pid is dead is left over from a previous CC.
+# Before removing it, kill the watcher bound to its last session_id — that
+# watcher would otherwise linger if the CC crashed without propagating
+# signals (force-quit, OOM, etc.). Only kills watchers we have explicit
+# evidence for (dead CC → known last session_id), so a manually-invoked
+# Monitor whose CC is alive but never wrote a cc-instance is left alone.
 for f in "$RUN_DIR"/cc-instance.*; do
   [ -f "$f" ] || continue
   pid=${f##*.}
   case "$pid" in ''|*[!0-9]*) continue ;; esac
-  kill -0 "$pid" 2>/dev/null || rm -f "$f"
+  kill -0 "$pid" 2>/dev/null && continue
+  dead_sid=$(cat "$f" 2>/dev/null || true)
+  if [ -n "$dead_sid" ]; then
+    orphan_pidfile="$RUN_DIR/watch.$dead_sid.pid"
+    if [ -f "$orphan_pidfile" ]; then
+      orphan_pid=$(cat "$orphan_pidfile" 2>/dev/null || true)
+      if [ -n "$orphan_pid" ] && kill -0 "$orphan_pid" 2>/dev/null; then
+        kill "$orphan_pid" 2>/dev/null || true
+      fi
+      rm -f "$orphan_pidfile"
+    fi
+  fi
+  rm -f "$f"
 done
 
 # Same defensive pass for stale watcher pidfiles. A pidfile whose recorded
@@ -99,6 +115,7 @@ for f in "$RUN_DIR"/watch.*.pid; do
   fi
   kill -0 "$pid" 2>/dev/null || rm -f "$f"
 done
+
 
 # --- Dedup against the previous watcher in this CC instance. ---
 if [ -n "$CC_PID" ]; then

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -7,11 +7,14 @@ set -u
 # hook (`session-start.sh`), but also works standalone as `tail -f` for
 # inbox: any agent runtime that can read stdout can consume it.
 #
-# Usage: watch.sh <session_id> <project_path> <agent_type>
+# Usage: watch.sh <session_id> <project_path> <agent_type> [active_name]
 #
 # Behavior:
-#   - Resolves all (team, agent) pairs for (project_path, agent_type) via
-#     identities.sh. Subscribes to messages addressed to any of those pairs.
+#   - Resolves (team, agent) pairs for (project_path, agent_type) via
+#     identities.sh. By default, subscribes to messages addressed to any
+#     of those pairs.
+#   - When [active_name] is given, narrows the subscription to only pairs
+#     whose agent name matches — useful for `actas` exclusive role mode.
 #   - Sets the high-water mark to the current MAX(id) at startup so the
 #     stream begins with whatever arrives after launch — no replay of
 #     historical messages.
@@ -24,9 +27,10 @@ set -u
 #   - Writes a pidfile at ~/.agents/agmsg/run/watch.<session_id>.pid and
 #     removes it on EXIT / SIGTERM / SIGINT.
 
-SESSION_ID="${1:?Usage: watch.sh <session_id> <project_path> <agent_type>}"
+SESSION_ID="${1:?Usage: watch.sh <session_id> <project_path> <agent_type> [active_name]}"
 PROJECT_PATH="${2:?Missing project_path}"
 AGENT_TYPE="${3:?Missing agent_type}"
+ACTIVE_NAME="${4:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -48,8 +52,15 @@ trap 'exit 0' INT TERM HUP
 
 # Resolve subscription set.
 PAIRS="$("$SCRIPT_DIR/identities.sh" "$PROJECT_PATH" "$AGENT_TYPE")"
+if [ -n "$ACTIVE_NAME" ]; then
+  PAIRS=$(printf '%s\n' "$PAIRS" | awk -v n="$ACTIVE_NAME" -F'\t' 'NF >= 2 && $2 == n')
+fi
 if [ -z "$PAIRS" ]; then
-  echo "agmsg watch: no joined teams for $PROJECT_PATH ($AGENT_TYPE); nothing to do"
+  if [ -n "$ACTIVE_NAME" ]; then
+    echo "agmsg watch: no registration for agent '$ACTIVE_NAME' in $PROJECT_PATH ($AGENT_TYPE); nothing to do"
+  else
+    echo "agmsg watch: no joined teams for $PROJECT_PATH ($AGENT_TYPE); nothing to do"
+  fi
   exit 0
 fi
 

--- a/templates/cmd.claude-code.md
+++ b/templates/cmd.claude-code.md
@@ -85,6 +85,14 @@ Four possible outputs:
 
 **Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
 
+**Ensure monitor is running first.** Before processing any subcommand below, check whether this session already has an `agmsg inbox stream` Monitor task in its TaskList. If not, and the project's delivery mode is `monitor` or `both` (check via `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status claude-code "$(pwd)"`), invoke the Monitor tool now:
+
+- command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh $CLAUDE_CODE_SESSION_ID "$(pwd)" claude-code`
+- description: `agmsg inbox stream`
+- persistent: true
+
+Then continue with the user's subcommand. This catches the case where the user invokes `/__SKILL_NAME__` as the first prompt before the SessionStart-hook directive has been acted on.
+
 **If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
 1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
 2. Do NOT ask the user what to do — just run the inbox check.

--- a/templates/cmd.claude-code.md
+++ b/templates/cmd.claude-code.md
@@ -40,6 +40,8 @@ Four possible outputs:
   > - `/__SKILL_NAME__ team` — list team members
   > - `/__SKILL_NAME__ history` — message history
   > - `/__SKILL_NAME__ mode <monitor|turn|both|off>` — switch delivery mode
+  > - `/__SKILL_NAME__ actas <name>` — switch to another role in this project (creates if needed)
+  > - `/__SKILL_NAME__ drop <name>` — remove a role from this project
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -99,6 +101,20 @@ If argument starts with "send" (e.g. "send misaki check the server"):
 1. Parse target agent and message from the arguments
 2. Determine which team the target agent belongs to, then run:
    `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+
+If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
+1. Parse the new role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" claude-code` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, you need to join under the existing team. Read TEAMS from the in-session whoami state (it may be a single team or comma-separated). For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> claude-code "$(pwd)"`. For multiple teams, ask the user which team to join the new role into, then run join.sh for that team.
+4. Set the session's active FROM to `<name>` — use `<name>` as the `from_agent` in every `send.sh` call for the rest of this session (or until another `actas`). Keep this in memory; no state file is written.
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent."
+6. Then run inbox check.
+
+If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
+1. Parse the role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" claude-code <name>` to remove only that role's registration for this project. If the role has no other registrations left, reset.sh also drops it from the team config.
+3. If the session's active FROM was `<name>`, clear that state and fall back to whichever identity whoami now reports (re-run whoami if uncertain).
+4. Tell the user: "Dropped role `<name>` from this project."
 
 If argument is "mode" (no further args):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status claude-code "$(pwd)"`

--- a/templates/cmd.claude-code.md
+++ b/templates/cmd.claude-code.md
@@ -105,15 +105,22 @@ If argument starts with "send" (e.g. "send misaki check the server"):
 If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 1. Parse the new role name.
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" claude-code` to see whether the role is already registered for this (project, type).
-3. If the name does not appear in the output, you need to join under the existing team. Read TEAMS from the in-session whoami state (it may be a single team or comma-separated). For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> claude-code "$(pwd)"`. For multiple teams, ask the user which team to join the new role into, then run join.sh for that team.
-4. Set the session's active FROM to `<name>` — use `<name>` as the `from_agent` in every `send.sh` call for the rest of this session (or until another `actas`). Keep this in memory; no state file is written.
-5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent."
-6. Then run inbox check.
+3. If the name does not appear in the output, join under the existing team. Read TEAMS from the in-session whoami state (it may be a single team or comma-separated). For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> claude-code "$(pwd)"`. For multiple teams, ask the user which team to join the new role into, then run join.sh for that team.
+4. **Switch receive too — exclusive role mode.** Find the running agmsg Monitor task with TaskList (description begins with "agmsg inbox stream") and TaskStop it. Then invoke a fresh Monitor:
+    - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh $CLAUDE_CODE_SESSION_ID "$(pwd)" claude-code <name>`
+    - description: `agmsg inbox stream (acting as <name>)`
+    - persistent: true
+   The 4th argument to `watch.sh` restricts the subscription to messages addressed to `<name>` only — other roles' inbound messages stop reaching this session until another `actas` or session end.
+5. Set the session's active FROM to `<name>` — use `<name>` in every `send.sh` call for the rest of this session.
+6. Tell the user: "Now acting as `<name>`. Sends use `<name>` as from; receive restricted to `<name>` only."
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" claude-code <name>` to remove only that role's registration for this project. If the role has no other registrations left, reset.sh also drops it from the team config.
-3. If the session's active FROM was `<name>`, clear that state and fall back to whichever identity whoami now reports (re-run whoami if uncertain).
+3. If the session's active FROM was `<name>`, clear that state. Then TaskStop the existing agmsg Monitor task and invoke a fresh Monitor with the default (all-roles) subscription:
+    - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh $CLAUDE_CODE_SESSION_ID "$(pwd)" claude-code`
+    - description: `agmsg inbox stream`
+    - persistent: true
 4. Tell the user: "Dropped role `<name>` from this project."
 
 If argument is "mode" (no further args):

--- a/templates/cmd.codex.md
+++ b/templates/cmd.codex.md
@@ -107,7 +107,7 @@ If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" codex` to see whether the role is already registered for this (project, type).
 3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> codex "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
 4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
-5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent."
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Codex has no Monitor tool, so receive still covers all of your registered roles in this project.)"
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.

--- a/templates/cmd.codex.md
+++ b/templates/cmd.codex.md
@@ -102,6 +102,19 @@ If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
 
 
+If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
+1. Parse the new role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" codex` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> codex "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
+4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent."
+
+If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
+1. Parse the role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" codex <name>` to remove that role's registration.
+3. If the session's active FROM was `<name>`, clear that state.
+4. Tell the user: "Dropped role `<name>` from this project."
+
 If argument is "mode" (no further args):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status codex "$(pwd)"`
 2. Show the output to the user.

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -203,17 +203,35 @@ settings_file() {
 # --- stop subcommand ---
 
 @test "delivery stop: kills watchers and emits stop directive" {
-  # Spawn a real subprocess to act as the watcher; record its pid.
-  mkdir -p "$TEST_SKILL_DIR/run"
-  sleep 30 &
-  local sleep_pid=$!
-  echo "$sleep_pid" > "$TEST_SKILL_DIR/run/watch.fake-sess.pid"
+  # Spawn an actual watch.sh process so the safety check (argv contains
+  # watch.sh) passes.
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" stop-test "$TEST_PROJECT" claude-code &
+  local watch_pid=$!
+  sleep 1
+  [ -f "$TEST_SKILL_DIR/run/watch.stop-test.pid" ]
   run bash "$SCRIPTS/delivery.sh" stop
   [[ "$output" =~ "Killed 1 watch" ]]
   [[ "$output" =~ "AGMSG-DIRECTIVE" ]]
-  [ ! -f "$TEST_SKILL_DIR/run/watch.fake-sess.pid" ]
-  # And the sleep process should be dead.
-  ! kill -0 "$sleep_pid" 2>/dev/null
+  [ ! -f "$TEST_SKILL_DIR/run/watch.stop-test.pid" ]
+  sleep 1
+  ! kill -0 "$watch_pid" 2>/dev/null
+}
+
+@test "delivery stop: skips pid whose command line is not watch.sh (pid recycling safety)" {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  sleep 30 &
+  local unrelated_pid=$!
+  echo "$unrelated_pid" > "$TEST_SKILL_DIR/run/watch.stale-sess.pid"
+  run bash "$SCRIPTS/delivery.sh" stop
+  [[ "$output" =~ "Killed 0 watch" ]]
+  [ ! -f "$TEST_SKILL_DIR/run/watch.stale-sess.pid" ]
+  # The unrelated sleep process must still be alive.
+  kill -0 "$unrelated_pid" 2>/dev/null
+  kill "$unrelated_pid" 2>/dev/null || true
 }
 
 # --- restart subcommand ---
@@ -550,4 +568,31 @@ JSON
   kill -0 "$untracked_pid" 2>/dev/null
   [ -f "$TEST_SKILL_DIR/run/watch.untracked-sid.pid" ]
   kill "$untracked_pid" 2>/dev/null || true
+}
+
+@test "session-start.sh does NOT kill a watcher when its session_id is still live under a different CC pid" {
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  # The session moved from one CC pid to another (claude --continue / resume).
+  # cc-instance.<dead> still references the same session_id as
+  # cc-instance.<live>. The watcher must NOT be killed.
+  sleep 30 &
+  local watcher_pid=$!
+  echo "$watcher_pid" > "$TEST_SKILL_DIR/run/watch.shared-sid.pid"
+  local dead_cc=999999
+  echo "shared-sid" > "$TEST_SKILL_DIR/run/cc-instance.$dead_cc"
+  echo "shared-sid" > "$TEST_SKILL_DIR/run/cc-instance.$$"
+
+  echo "{\"session_id\":\"x\"}" \
+    | bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" >/dev/null
+
+  kill -0 "$watcher_pid" 2>/dev/null
+  [ -f "$TEST_SKILL_DIR/run/watch.shared-sid.pid" ]
+  [ ! -f "$TEST_SKILL_DIR/run/cc-instance.$dead_cc" ]
+  kill "$watcher_pid" 2>/dev/null || true
 }

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -408,7 +408,7 @@ JSON
   [ ! -f "$TEST_SKILL_DIR/run/watch.empty-pid.pid" ]
 }
 
-@test "session-start.sh leaves alive watcher pidfiles alone" {
+@test "session-start.sh leaves alive watcher pidfiles alone (when bound to a live CC instance)" {
   mkdir -p "$TEST_SKILL_DIR/teams/myteam"
   cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
 {"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
@@ -418,6 +418,8 @@ JSON
   sleep 30 &
   local alive_pid=$!
   echo "$alive_pid" > "$TEST_SKILL_DIR/run/watch.live-session.pid"
+  # Bind this watcher to a live CC instance (use $$ as a stand-in).
+  echo "live-session" > "$TEST_SKILL_DIR/run/cc-instance.$$"
   echo '{"session_id":"x"}' | bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" >/dev/null
   [ -f "$TEST_SKILL_DIR/run/watch.live-session.pid" ]
   kill "$alive_pid" 2>/dev/null || true
@@ -512,4 +514,40 @@ JSON
 JSON
   run bash "$SCRIPTS/watch.sh" t-sid "$TEST_PROJECT" claude-code nobody
   [[ "$output" =~ "no registration for agent 'nobody'" ]]
+}
+
+# --- session-start.sh orphan watcher cleanup ---
+
+@test "session-start.sh kills orphan watchers whose owning CC instance is gone" {
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  # Orphan: watcher referenced by a cc-instance.<dead-pid> file.
+  sleep 30 &
+  local orphan_pid=$!
+  echo "$orphan_pid" > "$TEST_SKILL_DIR/run/watch.orphan-sid.pid"
+  # Use a PID that's almost certainly not in use as the dead CC ancestor.
+  local dead_cc_pid=999999
+  echo "orphan-sid" > "$TEST_SKILL_DIR/run/cc-instance.$dead_cc_pid"
+
+  # Untracked watcher: no cc-instance points to it. Conservative semantics
+  # leave it alone (we have no evidence the CC is dead).
+  sleep 30 &
+  local untracked_pid=$!
+  echo "$untracked_pid" > "$TEST_SKILL_DIR/run/watch.untracked-sid.pid"
+
+  echo "{\"session_id\":\"current-sid\"}" \
+    | bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" >/dev/null
+
+  ! kill -0 "$orphan_pid" 2>/dev/null
+  [ ! -f "$TEST_SKILL_DIR/run/watch.orphan-sid.pid" ]
+  [ ! -f "$TEST_SKILL_DIR/run/cc-instance.$dead_cc_pid" ]
+  # Untracked watcher untouched
+  kill -0 "$untracked_pid" 2>/dev/null
+  [ -f "$TEST_SKILL_DIR/run/watch.untracked-sid.pid" ]
+  kill "$untracked_pid" 2>/dev/null || true
 }

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -596,3 +596,33 @@ JSON
   [ ! -f "$TEST_SKILL_DIR/run/cc-instance.$dead_cc" ]
   kill "$watcher_pid" 2>/dev/null || true
 }
+
+@test "watch.sh subscription is static — newly joined identities don't appear in a running watcher" {
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  DB="$TEST_SKILL_DIR/db/messages.db"
+
+  # Watcher starts with only `alice` registered. Default subscription set
+  # is resolved at launch and not re-evaluated each poll.
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" t-static "$TEST_PROJECT" claude-code > /tmp/agmsg-static 2>&1 &
+  local pid=$!
+  sleep 1
+
+  # Join `bob` to the same (project, type) after the watcher is running.
+  bash "$SCRIPTS/join.sh" myteam bob claude-code "$TEST_PROJECT"
+
+  # Insert messages for both. alice should arrive (alice was in the original
+  # subscription set); bob should NOT arrive (joined after launch).
+  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'sys', 'alice', 'for-alice-static');"
+  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'sys', 'bob',   'for-bob-static');"
+
+  sleep 3
+  kill -TERM "$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null || true
+
+  grep -q "for-alice-static" /tmp/agmsg-static
+  ! grep -q "for-bob-static" /tmp/agmsg-static
+  rm -f /tmp/agmsg-static
+}

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -470,3 +470,46 @@ JSON
 
   unset CLAUDE_CODE_SESSION_ID
 }
+
+# --- watch.sh exclusive role filter ---
+
+@test "watch.sh restricts subscription to active_name when 4th arg is given" {
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{
+  "name":"myteam",
+  "agents":{
+    "alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]},
+    "bob":  {"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}
+  }
+}
+JSON
+  # Insert two messages, one for each agent.
+  DB="$TEST_SKILL_DIR/db/messages.db"
+  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'system', 'alice', 'for-alice');"
+  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'system', 'bob', 'for-bob');"
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" t-sid "$TEST_PROJECT" claude-code bob > /tmp/agmsg-as-bob 2>&1 &
+  local pid=$!
+  # High-water-mark = MAX(id) at startup, so prior messages aren't replayed.
+  # Insert NEW messages and wait for several poll iterations.
+  sleep 1
+  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'system', 'alice', 'new-for-alice');"
+  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'system', 'bob', 'new-for-bob');"
+  sleep 3
+  kill -TERM "$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null || true
+
+  grep -q "new-for-bob"   /tmp/agmsg-as-bob
+  ! grep -q "new-for-alice" /tmp/agmsg-as-bob
+  rm -f /tmp/agmsg-as-bob
+}
+
+@test "watch.sh exits when active_name is not registered" {
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  run bash "$SCRIPTS/watch.sh" t-sid "$TEST_PROJECT" claude-code nobody
+  [[ "$output" =~ "no registration for agent 'nobody'" ]]
+}


### PR DESCRIPTION
## Summary

Closes #42.

Adds two new `/agmsg` subcommands so a single workspace can carry multiple roles for the same agent without leaving the session:

- `/agmsg actas <name>` — switch the session's active from-agent to `<name>`. If `<name>` isn't registered for this `(project, type)`, join under the current team first (ask if several teams are joined). Sends from this session now use `<name>`.
- `/agmsg drop <name>` — remove that role's registration for this project (via `reset.sh`). If `<name>` has no other registrations, also dropped from the team config.

Use case: same Claude Code project running `tech-lead` (architecture reviews) and `biz-analyst` (requirements) identities side by side, sharing the same files and toolset.

## What's in this PR

- **`templates/cmd.claude-code.md`** — adds `actas` / `drop` handler blocks and lists them in the post-join welcome message.
- **`templates/cmd.codex.md`** — same pair of handlers, with `codex` as the agent type passed to `join.sh` / `reset.sh`.
- **`README.md`** — new `### Multiple roles per project (actas / drop)` section right under the existing "Multiple identities" subsection, plus two lines in the Usage > Claude Code command reference.

No new shell scripts. `actas` routes to `join.sh` for the create-if-missing case; `drop` routes to `reset.sh`. Session-active state lives only in the agent's memory — `/clear` resets back to the multiple-identities picker, which is the desired behavior.

## Test plan

- [x] `bats tests/` clean — 101 passing (no test changes needed; mechanics route through already-tested join.sh / reset.sh)
- [x] Templates rendered into `~/.claude/commands/agmsg.md` and `~/.agents/skills/agmsg/SKILL.md` via `./install.sh --update`