### PR TITLE
docs: storage driver pluginization design (epic #51)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,79 @@
+# Architecture
+
+This document describes the internal shape of agmsg — the mental model a contributor needs before reading the code or the interface spec. For *what* to implement, see [`docs/spec/`](docs/spec/). For *why* a decision was made, see [`docs/adr/`](docs/adr/).
+
+## Goal
+
+A cross-agent messaging primitive that works between any combination of Claude Code, Codex, Gemini CLI, Antigravity, and future agent runtimes — with no daemon, no network, no shared cloud. Messages move through local files on a single machine; receivers are notified through whatever hook or streaming mechanism their host runtime provides.
+
+The default install must work with **bash + sqlite3 only**. Any feature beyond that is opt-in and may require additional dependencies that the user agrees to install.
+
+## The 3-axis driver model
+
+agmsg is built around three orthogonal axes, each of which has exactly one **driver** active at a time. A driver is a swappable implementation behind a fixed protocol.
+
+| Axis | What it abstracts | Bundled drivers |
+|---|---|---|
+| **storage** | Where messages and team state live, and how they are queried | `sqlite` (default), `jsonl-duckdb` |
+| **agent** | Per-runtime differences (hook formats, settings file locations, monitor tool availability) | `claude-code`, `codex`, `gemini`, `antigravity` |
+| **delivery** | How a recipient is notified that a message arrived | `monitor`, `turn`, `both`, `off` |
+
+The three axes are independent: any storage driver can be paired with any agent driver and any delivery mode. They share a common discovery/config/dependency-check protocol (see the spec) but expose axis-specific operations.
+
+## Driver vs plugin
+
+- **driver** is the architectural unit. Both bundled implementations and user-installed ones are drivers.
+- **plugin** is a distribution distinction: a driver that ships outside agmsg core, dropped into a user-controlled directory.
+
+Bundled drivers live under `scripts/drivers/<axis>/`. Inside `scripts/`, the top-level `.sh` files are directly-invokable commands; subdirectories group implementation code by category (`drivers/` for axis drivers, `lib/` for shared helpers).
+
+The plugin path (`~/.agents/agmsg/plugins/<axis>/<name>/`) is reserved for a future enhancement and is not implemented in v1. Until a concrete external driver is wanted, all drivers ship bundled. Both are discovered and loaded through the same protocol.
+
+agmsg does not use the terms *backend*, *extension*, *provider*, or *adapter*. `storage`, when written in user-facing documentation and CLI, is a synonym for "storage driver".
+
+## Dependency management
+
+Drivers may require external tools (e.g. the `jsonl-duckdb` storage driver needs `duckdb` on `$PATH`). agmsg never installs those tools itself. Instead:
+
+1. When a driver is activated or its `check` subcommand is invoked, it inspects its environment.
+2. If a dependency is missing, the driver emits a **machine-readable `AGMSG-DIRECTIVE`** line on stdout describing what to install and how.
+3. The host agent (Claude Code, Codex, etc.) reads the directive and runs the install command, with the user's consent, using its own tools.
+4. On the next agmsg invocation, the dependency check passes and the driver activates.
+
+This keeps agmsg itself minimal and platform-agnostic. The host agent is already trusted with file and shell access, so dependency installation is naturally its responsibility.
+
+The same `AGMSG-DIRECTIVE` mechanism is used for other host-agent-coordinated actions (e.g. telling Claude Code to invoke its Monitor tool when delivery mode is set to `monitor`).
+
+## Failure semantics
+
+Switching a storage driver is the most consequential action agmsg takes. The protocol prioritizes leaving the system in a recoverable state:
+
+- A dep-check failure during `agmsg storage switch` does **not** change the active driver. The user is prompted with the directive and given a fallback.
+- A `convert` always writes to a staging store first, verifies it, then performs the atomic config flip. The previous driver remains active and intact until the final step.
+- Status codes are structured (`ok`, `missing_deps`, `incompatible_core`, `corrupt_state`, `runtime_error`) so the host agent can react appropriately rather than treating every non-zero exit identically.
+
+## Storage shape
+
+Storage drivers expose CRUD-like operations to the rest of agmsg (insert a message, list unread for an agent, mark read, query history). Internally, the bundled drivers represent state as an **append-only event log** (`message_sent`, `message_read`, etc.). Mutable status — most importantly the read flag — is derived by projection over the event stream rather than by in-place updates.
+
+The sqlite driver retains a backward-compatible read path for the legacy `messages` table with an inline `read` column, so existing installs continue to work without migration. New writes go to the event log; reads union both sources.
+
+Message identifiers are **UUIDv7** strings. The interface treats them as opaque so existing sqlite databases with integer autoincrement IDs remain readable.
+
+## Vocabulary
+
+| Term | Meaning |
+|---|---|
+| **driver** | Swappable implementation of a fixed protocol on one axis |
+| **plugin** | A driver distributed outside agmsg core |
+| **bundled driver** | A driver shipped inside agmsg core |
+| **storage** | The storage axis, or its active driver, in user-facing contexts |
+| **AGMSG-DIRECTIVE** | A JSON line emitted on stdout instructing the host agent to take a specific action |
+| **host agent** | The runtime invoking agmsg scripts (Claude Code, Codex, Gemini CLI, Antigravity, …) |
+| **event log** | The append-only record of message lifecycle events that bundled storage drivers project queries over |
+
+## See also
+
+- [`docs/spec/driver-interface.md`](docs/spec/driver-interface.md) — the formal contract a driver must satisfy
+- [`docs/adr/`](docs/adr/) — historical record of design decisions
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — how to propose changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to agmsg
+
+Thanks for considering a contribution! agmsg is a small project; this guide is intentionally short.
+
+## Where to start
+
+- Read [`README.md`](README.md) for what agmsg does and how to install it.
+- Read [`ARCHITECTURE.md`](ARCHITECTURE.md) for the mental model (3-axis driver, vocabulary, dependency-management philosophy).
+- Browse [`docs/adr/`](docs/adr/) for the history of design decisions — they explain *why* things are the way they are.
+- The [`docs/spec/`](docs/spec/) directory contains the formal contracts; consult these when implementing or extending a driver.
+
+## Reporting bugs and requesting features
+
+Open an issue on [`fujibee/agmsg`](https://github.com/fujibee/agmsg/issues). Include the agmsg version, the host agent (Claude Code / Codex / Gemini CLI / Antigravity), and a minimal reproduction if possible.
+
+## Pull requests
+
+1. Discuss substantial changes in an issue first.
+2. Branch from `main`. Keep PRs focused — one logical change per PR.
+3. Run the test suite: `bats tests/`.
+4. Match the surrounding code style. Bash is the primary language; use `set -euo pipefail` at the top of every script.
+5. Update docs if the change is user-visible.
+
+## Architecture Decision Records
+
+agmsg uses ADRs ([Architecture Decision Records](https://adr.github.io/)) to capture significant design judgments. An ADR records the context, the decision, the alternatives considered, and the consequences.
+
+### When to file an ADR
+
+File a new ADR when proposing or accepting a change that:
+
+- adds, removes, or replaces a driver axis,
+- changes the driver interface or `AGMSG-DIRECTIVE` schema,
+- changes how data is laid out on disk in a non-backward-compatible way,
+- introduces a new external dependency (even an optional one),
+- changes the project's vocabulary or naming conventions,
+- or is otherwise a judgment call that future contributors will want to understand.
+
+Small bug fixes, doc updates, dependency bumps, and new tests do not need ADRs.
+
+### How to file an ADR
+
+1. Copy [`docs/adr/template.md`](docs/adr/template.md) to `docs/adr/NNNN-short-title.md` where `NNNN` is the next free number.
+2. Fill in the sections. Be honest in *Alternatives considered* — the value of an ADR is largely in capturing what you rejected and why.
+3. Open a PR. Discussion happens on the PR. Status starts as `proposed`; mark it `accepted` when merged.
+4. When a later ADR supersedes an earlier one, leave the original in place and link forward (`Status: superseded by ADR-XXXX`). ADRs are immutable history, not a wiki.
+
+### When you find an undocumented decision
+
+If you spot a design choice in the code whose rationale is unclear, an ADR retroactively capturing it is a welcome contribution. Mark it `accepted` and reference the commit or PR that originally introduced the behavior.
+
+## Adding a driver
+
+Bundled drivers live under `scripts/drivers/<axis>/<name>.sh`. (Top-level `.sh` files in `scripts/` are directly-invokable commands; subdirectories group implementation code.) Third-party plugin drivers live under `~/.agents/agmsg/plugins/<axis>/<name>/`. Both must implement the contract in [`docs/spec/driver-interface.md`](docs/spec/driver-interface.md).
+
+A new bundled driver should arrive with:
+
+- the driver script,
+- bats tests under `tests/`,
+- a README section or doc page describing the trade-offs of using it,
+- and, if it changes the driver protocol itself, an ADR.
+
+## Code of conduct
+
+Be kind. Assume good faith. Disagreement on technical questions is welcome; disagreement on people is not.

--- a/docs/adr/0001-storage-driver-pluginization.md
+++ b/docs/adr/0001-storage-driver-pluginization.md
@@ -1,0 +1,117 @@
+# ADR 0001: Storage driver pluginization with dependency-managed plugins
+
+**Status:** accepted
+**Date:** 2026-05-30
+**Deciders:** @fujibee
+
+## Context
+
+agmsg was scaffolded with a single hard-coded storage layer (SQLite) accessed inline from helper scripts. As contributors and use cases grow, the project needs:
+
+1. A way to swap the storage layer (the immediate motivating example is a JSONL file queried by DuckDB, which is friendlier for `grep`/`tail` inspection and for cross-machine sync via `git`/`rsync`).
+2. A pattern for opt-in features that require external binaries the default install does not have (e.g. `duckdb`).
+
+The constraint is that **the default install must remain bash + sqlite3 only** — no new users should be asked to install anything. Anything more capable must be opt-in, with the dependency story handled cleanly.
+
+The same general "swappable driver behind a fixed protocol" shape will eventually apply to per-agent-type runtime adapters (issue [#48](https://github.com/fujibee/agmsg/issues/48)) and to delivery mechanisms (current `monitor`/`turn`/`both`/`off` mode dispatch). This ADR establishes the convention; subsequent ADRs may apply the same convention to the other axes.
+
+## Decision
+
+agmsg adopts a **3-axis driver model**: storage, agent, delivery. Each axis has exactly one active driver at a time, swapped through a common discovery/config/dependency-check protocol but exposing axis-specific operations. This ADR implements axis A (storage); the other axes follow under their own ADRs.
+
+The locked design points are:
+
+1. **Storage uses an append-only event log** (`message_sent`, `message_read`, …) projected by the driver to answer queries. The bundled sqlite driver also retains a **backward-compatible read path** for the legacy `messages` table with a mutable `read` flag, so existing installs do not need to migrate. New writes only target the event log.
+2. **Drivers are bash scripts sourced by agmsg core**, exposing axis-prefixed functions (`storage_*`, `agent_*`, `delivery_*`). Subcommand-and-JSONL-pipe drivers (which would allow Python/Go implementations) are deferred until there is concrete demand.
+3. **Common protocol is shared across axes; axis-specific functions are not forced into a single interface.** Every driver implements `<axis>_check` and `<axis>_describe`; everything else is per-axis.
+4. **Message IDs are UUIDv7.** Existing SQLite integer autoincrement IDs are read as opaque decimal strings. A counter file is rejected.
+5. **`AGMSG-DIRECTIVE` is a structured JSON line** (`AGMSG-DIRECTIVE: {...}`) emitted on stdout, parsed by the host agent. Free-text directives are dropped.
+6. **`agmsg storage convert` uses staging + atomic flip**: write to a staging store, verify, then atomically update config. The previous driver remains active and intact until the final step.
+7. **`storage_check` and `agmsg storage switch` return structured status codes** (`ok`, `missing_deps`, `incompatible_core`, `corrupt_state`, `runtime_error`) so the host agent can react appropriately rather than seeing only "non-zero exit".
+
+agmsg itself never installs dependencies. Drivers emit `AGMSG-DIRECTIVE` lines on stdout when a dependency is missing; the host agent (Claude Code, Codex, Gemini CLI, Antigravity) parses the directive and runs the install command using its own tools, with the user's consent.
+
+The v1 scope is **bundled drivers only**. Third-party plugin drivers (drivers shipped outside agmsg core, dropped into `~/.agents/agmsg/plugins/`) and the loader machinery they require (`plugin.json` parsing, `min_core_version` gating) are deferred until a concrete external driver is wanted. The vocabulary distinction between *bundled driver* and *plugin* is preserved in documentation so the protocol can be extended later without renaming.
+
+The active storage driver is **machine-wide** (recorded in `~/.agents/agmsg/config.json`). Per-project override is deferred.
+
+Vocabulary is **driver** (architectural unit), **plugin** (driver shipped outside core), **storage** (user-facing CLI noun for the storage axis). `backend`, `extension`, `provider`, and `adapter` are not used.
+
+## Alternatives considered
+
+### On mutable records vs event log (decision 1)
+
+- **A. Mutable records (status quo, extended to JSONL).** Keep one row per message with an in-place `read` flag. Rejected: JSONL would need to rewrite the entire file on every `mark_read`, destroying the append-only property that motivated the JSONL+DuckDB option in the first place.
+- **B. Event log everywhere, with full migration of existing sqlite installs.** Adopted *almost*. Rejected because the migration burden on existing users (single-machine, but still real) is avoidable: the sqlite driver can keep reading the legacy table while writing new events.
+- **C. Event log everywhere, with backward-compatible read path on sqlite.** **Chosen.** The new format is uniform across drivers; existing sqlite data stays readable without explicit user action.
+
+### On driver invocation style (decision 2)
+
+- **A. Sourced bash functions.** **Chosen.** Matches existing agmsg style, lowest overhead, simplest to author.
+- **B. Subcommand + JSONL pipe over stdin/stdout.** Cleaner contract, allows non-bash drivers. Rejected as YAGNI: no contributor has asked for a non-bash driver, and the protocol can be added later without breaking the bash one (drivers can wrap a subprocess).
+
+### On interface unification across axes (decision 3)
+
+- **A. One interface for all three axes.** Considered briefly. Rejected after review: storage is CRUD-shaped, agent is runtime-glue-shaped, delivery is lifecycle-shaped. Forcing them through one interface either over-abstracts or leaks axis-specific semantics into the abstract one. Reviewer (aggie-co) made the strongest case for this rejection.
+- **B. Common protocol (discovery, config, dep-check, status codes) + axis-specific functions.** **Chosen.**
+
+### On IDs (decision 4)
+
+- **A. Counter file (`~/.agents/agmsg/next_id`).** Rejected: reintroduces the locking complexity the event-log design tried to remove, and worsens future multi-machine stories.
+- **B. ULID.** Considered. Functionally equivalent to UUIDv7 for our needs; UUIDv7 chosen because it is an IETF standard and has more cross-language tooling.
+- **C. UUIDv7.** **Chosen.**
+
+### On directive format (decision 5)
+
+- **A. Free-text directive parsed by the host agent.** Rejected: brittle, model-dependent, hard to test.
+- **B. Structured JSON line with `type` discriminator.** **Chosen.** Trivial to parse, easy to extend with new directive types, and humans can still read it directly.
+
+### On convert safety (decision 6)
+
+- **A. In-place convert.** Rejected: a partial failure leaves the user with half-migrated data and no obvious recovery path.
+- **B. Staging + atomic flip.** **Chosen.** Failure leaves the old driver active and intact; rollback is implicit.
+
+### On status codes (decision 7)
+
+- **A. Single non-zero exit on any failure.** Rejected: the host agent cannot distinguish "deps missing, please install" from "data corrupt, do not touch" — both require different reactions.
+- **B. Structured status (`ok`, `missing_deps`, `incompatible_core`, `corrupt_state`, `runtime_error`).** **Chosen.** Enables the agentic install flow to succeed only on the right error class.
+
+### On machine-wide vs per-project active driver
+
+- **A. Per-project.** Rejected: increases configuration surface for marginal benefit; users would have to coordinate driver choice across projects with shared teams.
+- **B. Machine-wide single active driver.** **Chosen.** Per-project override deferred to a future ADR if demand emerges.
+
+### On vocabulary
+
+- **A. `backend`.** Considered for storage. Rejected as ambiguous (could imply server-side service) and inconsistent with the other axes.
+- **B. `extension` / `provider` / `adapter`.** Rejected as imported terminology with mismatched connotations (additive vs swap, cloud-domain bias, GoF-pattern reference).
+- **C. `driver` (architectural) + `plugin` (distribution).** **Chosen.** `storage` as a user-facing noun for the axis.
+
+## Consequences
+
+### Positive
+
+- Existing sqlite users see no change: zero migration, zero new dependencies.
+- A JSONL+DuckDB driver becomes a small, well-scoped addition rather than a fork of the storage layer.
+- The same protocol can be reused for axis B (agent — issue [#48](https://github.com/fujibee/agmsg/issues/48)) and axis C (delivery — future refactor).
+- Failure modes are recoverable by construction: dep-check failures do not switch drivers, conversions only flip at the end, status codes give the host agent enough information to react correctly.
+- Contributors can ship third-party drivers as plugins under `~/.agents/agmsg/plugins/storage/<name>/` without forking the repo.
+
+### Negative
+
+- Compaction of the event log becomes a long-term obligation; the v1 implementation includes only an internal command, and a user-facing one will be needed eventually.
+- Drivers carry their own concurrency story (sqlite via WAL, jsonl-duckdb via lockfile). Inconsistent bugs are possible if a driver author misjudges atomicity.
+- Bash sourced functions create namespace coupling; the axis-prefix convention mitigates but does not eliminate the risk. A future migration to subcommand-style drivers would be a non-trivial refactor.
+- Plugin loader is deferred. When it lands, the trust model (shell plugins run with user privileges) becomes a real concern that needs an ADR of its own.
+
+### Neutral
+
+- The legacy `messages` table in existing sqlite databases is preserved indefinitely. Disk usage grows slowly until a future compaction tool removes it.
+- Message IDs are heterogeneous across the legacy/new boundary (integer strings vs UUIDv7), but the interface treats them as opaque so user-visible queries remain straightforward.
+
+## References
+
+- Epic: [#51](https://github.com/fujibee/agmsg/issues/51)
+- Related: [#48](https://github.com/fujibee/agmsg/issues/48) (agent-type driver refactor), [#49](https://github.com/fujibee/agmsg/issues/49) (`AGMSG_STORAGE_PATH` env var)
+- Specification: [`docs/spec/driver-interface.md`](../spec/driver-interface.md)
+- Concept overview: [`ARCHITECTURE.md`](../../ARCHITECTURE.md)

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,33 @@
+# ADR NNNN: Title
+
+**Status:** proposed | accepted | superseded by [ADR-XXXX](XXXX-other.md)
+**Date:** YYYY-MM-DD
+**Deciders:** @fujibee
+
+## Context
+
+The situation that prompted the decision. What constraints exist? What problem are we solving? Why is a decision needed now?
+
+## Decision
+
+What we chose, stated as plainly as possible. One paragraph if possible.
+
+## Alternatives considered
+
+For each alternative we rejected, name it and say why. Include the option of "do nothing" if relevant.
+
+- **Alternative A.** Description. Rejected because …
+- **Alternative B.** Description. Rejected because …
+
+## Consequences
+
+What changes as a result of this decision. Include both benefits and costs.
+
+- Positive: …
+- Negative: …
+- Neutral: …
+
+## References
+
+- Issue, PR, or discussion links
+- Related ADRs

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -1,0 +1,156 @@
+# Driver Interface Specification
+
+**Status:** draft (epic [#51](https://github.com/fujibee/agmsg/issues/51))
+**Scope:** axis A — storage. The common protocol sections also apply to axes B (agent) and C (delivery) but their axis-specific functions are out of scope here.
+
+This document defines the contract between agmsg core and a storage driver. It is the authoritative source for what any new driver must implement.
+
+**v1 scope:** bundled drivers only. The plugin path (`~/.agents/agmsg/plugins/`), `plugin.json` metadata, and `min_core_version` gating are deferred to a future revision; see §6.
+
+## 1. Common driver protocol
+
+These conventions apply to every driver on every axis.
+
+### 1.1 Driver location
+
+Bundled drivers live at `scripts/drivers/<axis>/<name>.sh`. Their metadata is implicit and tied to the agmsg core version.
+
+### 1.2 Calling convention
+
+Drivers are bash scripts that agmsg core `source`s and then calls by function name. Function names are prefixed by axis to avoid collisions: storage drivers expose `storage_*` functions, agent drivers expose `agent_*`, delivery drivers expose `delivery_*`.
+
+Drivers must not pollute the global namespace beyond their prefix and must not define `set -e`/`set -u` semantics; those are the caller's responsibility.
+
+### 1.3 Required common functions
+
+Every driver, on every axis, implements:
+
+| Function | Purpose | Returns |
+|---|---|---|
+| `<axis>_check` | Verify that all runtime dependencies are present and the driver can activate. May emit an `AGMSG-DIRECTIVE` on stdout when a dependency is missing. | status code (see §1.4) |
+| `<axis>_describe` | Print a one-line human-readable description on stdout. | always 0 |
+
+### 1.4 Status codes
+
+Driver functions that can fail report a structured status by exit code **and** by printing the status name on stdout as the last line. The status names are:
+
+| Code | Name | Meaning |
+|---|---|---|
+| 0 | `ok` | Operation succeeded |
+| 10 | `missing_deps` | A required external dependency is not installed. An `AGMSG-DIRECTIVE` describing the install was emitted on stdout. |
+| 12 | `corrupt_state` | Driver detected unrecoverable inconsistency in its data store. Manual intervention required. |
+| 13 | `runtime_error` | Any other failure. stderr contains the message. |
+
+(Code `11 incompatible_core` is reserved for the future plugin loader; not used in v1.)
+
+Callers may treat any non-zero exit as failure, but the status name is the source of truth for the host agent's reaction.
+
+### 1.6 `AGMSG-DIRECTIVE`
+
+A single line written to stdout, prefixed with `AGMSG-DIRECTIVE: ` followed by a JSON object. The host agent reads, parses, and acts on the directive.
+
+```
+AGMSG-DIRECTIVE: {"type":"install_deps","driver":"jsonl-duckdb","commands":["brew install duckdb"],"reason":"duckdb binary not found on PATH"}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | string | One of `install_deps`, `invoke_monitor`, `stop_task`. Extensible. |
+| `driver` | string | The driver name emitting the directive (when applicable) |
+| `commands` | string[] | Shell commands the host agent may run, in order. Optional. |
+| `reason` | string | Human-readable explanation for the user. |
+| `*` | any | Type-specific fields; consult the per-type schema in this document. |
+
+Directives are advisory: the host agent decides whether to surface them to the user, run them automatically, or ignore them.
+
+## 2. Storage driver
+
+### 2.1 Required functions
+
+```
+storage_check
+storage_describe
+storage_init
+storage_insert_message <team> <from> <to> <body>
+storage_unread <team> <agent> [--limit N]
+storage_mark_read <id>
+storage_mark_read_batch <id> [<id> ...]
+storage_history <team> <agent> [--limit N]
+storage_teams
+storage_team_members <team>
+storage_export <file>
+storage_import <file>
+```
+
+All functions write structured output (JSONL) to stdout when returning records and follow §1.4 for status. Records always include `id` (UUIDv7 for new writes, opaque string for legacy IDs) and `at` (ISO-8601 UTC).
+
+### 2.2 Event log schema
+
+Bundled drivers represent state as an append-only event log. Each event is one record with a `type` discriminator:
+
+```jsonl
+{"type":"message_sent","id":"0192...","team":"agsuite","from":"aggie-cc","to":"aggie-co","body":"...","at":"2026-05-30T19:00:00Z"}
+{"type":"message_read","id":"0192...","msg_id":"0192...","agent":"aggie-co","at":"2026-05-30T19:05:00Z"}
+{"type":"team_joined","id":"0192...","team":"agsuite","agent":"alice","agent_type":"claude-code","project":"/path","at":"..."}
+{"type":"team_left","id":"0192...","team":"agsuite","agent":"alice","at":"..."}
+```
+
+Drivers project these events to answer queries. `storage_unread` returns `message_sent` events whose `id` has no corresponding `message_read` for the requesting agent.
+
+### 2.3 Legacy compatibility (sqlite only)
+
+The bundled sqlite driver reads two sources for `storage_unread` and `storage_history`:
+
+1. The legacy `messages` table (rows where `read=0`) for installations that predate the event log refactor
+2. The new event log tables for everything written after the refactor
+
+Writes only target the event log. There is no automated migration; legacy rows stay where they are and remain queryable indefinitely.
+
+### 2.4 Identifiers
+
+All IDs generated by drivers must be **UUIDv7** strings. The interface treats IDs as opaque, so drivers reading legacy data (integer autoincrement IDs in sqlite) may pass them through as decimal strings.
+
+UUIDv7 is generated within the driver (e.g. via `python -c "..."`, `uuidgen` on platforms that support v7, or a shell implementation). Drivers must not depend on a counter file.
+
+### 2.5 Concurrency
+
+Drivers are responsible for the concurrency model of their backing store:
+
+- The sqlite driver relies on SQLite's WAL mode.
+- The `jsonl-duckdb` driver must use a lockfile around mark-read sequences and around `convert`/`export`/`import`. Single-message appends may rely on POSIX append atomicity for writes ≤ `PIPE_BUF` bytes.
+
+### 2.6 Compaction
+
+The event log grows unbounded. Drivers must implement an internal `storage_compact` function that collapses redundant events (e.g. coalescing `message_read` markers, dropping events for deleted teams). v1 exposes this only as an internal command; a user-facing CLI may follow.
+
+## 3. CLI mapping
+
+| User command | Driver function(s) |
+|---|---|
+| `agmsg storage` | `storage_describe` of active driver |
+| `agmsg storage list` | iterate available drivers, call `<axis>_describe` per driver |
+| `agmsg storage switch <name>` | new driver's `storage_check`; on `ok`, update config; on `missing_deps`, propagate directive without switching |
+| `agmsg storage convert <to>` | new driver's `storage_check`; if `ok`, current `storage_export` → temp → new `storage_import` → verify → atomic config update |
+| `agmsg storage export <file>` | active driver's `storage_export` |
+| `agmsg storage import <file>` | active driver's `storage_import` |
+
+## 4. Config
+
+Active driver per axis is recorded in `~/.agents/agmsg/config.json`:
+
+```json
+{
+  "storage": "sqlite",
+  "delivery": { "claude-code": "monitor", "codex": "turn" }
+}
+```
+
+`storage` is a single string (machine-wide). `delivery` is per agent type because runtimes differ in available delivery mechanisms. `agent` is implicit from the per-invocation `<type>` argument.
+
+## 5. Out of scope (deferred)
+
+- **Plugin loader** — `~/.agents/agmsg/plugins/<axis>/<name>/` discovery, `plugin.json` parsing, `min_core_version` gating, and the `incompatible_core` status code. Deferred until a concrete third-party driver is wanted; in the meantime, all drivers ship bundled.
+- **Plugin signing or sandboxing** — orthogonal to the loader; would be addressed when the loader lands.
+- **Per-project active driver override** — v1 is machine-wide; future enhancement.
+- **Subcommand + JSONL-pipe driver protocol** (language-independent drivers) — deferred until a non-bash driver is actually wanted.
+- **Cross-machine storage drivers** (postgres, s3-jsonl) — not blocked by this spec; can be added under the same protocol when needed.


### PR DESCRIPTION
## Summary

Lands the design docs for the storage driver pluginization work tracked in #51. **No implementation in this PR** — this PR exists so subsequent implementation PRs can reference a stable design.

Five files:

| File | Purpose |
|---|---|
| `ARCHITECTURE.md` | Mental model — 3-axis driver, vocabulary, dependency-management philosophy. Read this first. |
| `docs/spec/driver-interface.md` | Formal contract: function set, status codes, event log schema, AGMSG-DIRECTIVE JSON schema, CLI mapping, config layout. |
| `docs/adr/0001-storage-driver-pluginization.md` | The 7 locked design judgments with alternatives considered. |
| `docs/adr/template.md` | Starting point for future ADRs. |
| `CONTRIBUTING.md` | When and how to file an ADR; driver authoring entry point. |

## Locked decisions (captured in ADR 0001)

1. **Event log** for storage, with backward-compatible reads of the legacy sqlite `messages` table → no user migration needed.
2. **Bash sourced functions** for drivers; subcommand+JSONL-pipe deferred (YAGNI).
3. **Common protocol across axes, axis-specific functions** — discovery/config/dep-check shared, operations per-axis.
4. **UUIDv7** for new message IDs; legacy integer IDs read as opaque strings.
5. **Structured `AGMSG-DIRECTIVE`** as a JSON line on stdout.
6. **`convert` = staging + atomic flip** — old driver remains active until the final config update.
7. **Structured status codes** (`ok` / `missing_deps` / `corrupt_state` / `runtime_error`) so the host agent can react correctly.

## v1 scope

Bundled drivers only — `sqlite` (rewritten to event log with backcompat reads) and `jsonl-duckdb` (new). The plugin loader (`~/.agents/agmsg/plugins/`, `plugin.json`, `min_core_version` gating, `incompatible_core` status code) is **deferred** until a concrete third-party driver is wanted; vocabulary distinction is preserved in docs for forward compatibility.

## Layout convention

- `scripts/*.sh` — directly-invokable commands
- `scripts/drivers/<axis>/<name>.sh` — axis drivers
- `scripts/lib/*.sh` — shared helpers (introduced by #49)

## Cross-links

- Closes part of #51 (design only — implementation work remains)
- Aligns with #48 (agent-type driver refactor — same protocol)
- Aligns with #49 (`AGMSG_STORAGE_PATH` env var — variable naming `AGMSG_STORAGE_*` already forward-compatible)

## Test plan

- [ ] Read `ARCHITECTURE.md` end-to-end — does the mental model hold up?
- [ ] Skim `docs/spec/driver-interface.md` — is the function set complete? Anything obviously missing?
- [ ] Skim `docs/adr/0001` — are the alternatives written honestly? Anything that should be reconsidered?
- [ ] Confirm `CONTRIBUTING.md` ADR rules read as you'd want them to.

No code changes; no automated tests apply.