### PR TITLE
feat: override message store path via AGMSG_STORAGE_PATH (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,21 @@ DB and team configs are preserved. Only scripts and assets are updated.
 
 Auto-detects installed skill directories and cleans up: skill files, slash commands, hooks, AGENTS.md sections, and team configs.
 
+## Configuration
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AGMSG_STORAGE_PATH` | `<skill>/db` | Directory holding the SQLite message store (`messages.db`). Override to relocate the store — handy for tests, sandboxes, or running isolated instances. |
+
+The message store path resolves as **`AGMSG_STORAGE_PATH` (env) > built-in default**. (A config-file layer is planned to slot in between the two as part of the storage-driver work; the intended order is env > config > default.) The override is scoped to the SQLite store only — team configs under `teams/` are unaffected.
+
+```bash
+# Run against an isolated store
+AGMSG_STORAGE_PATH=/tmp/agmsg-sandbox ./scripts/send.sh myteam alice bob "hi"
+```
+
 ## Tests
 
 ```bash

--- a/docs/design.md
+++ b/docs/design.md
@@ -16,6 +16,7 @@ An agent is identified by `(name, team)`. Project path and agent type (claude-co
 
 `~/.agents/skills/<cmd>/db/messages.db`
 
+- Path resolved by `scripts/lib/storage.sh` (`agmsg_db_path`); override the storage directory with `AGMSG_STORAGE_PATH` (env > built-in default). Scoped to the SQLite store only.
 - WAL journal mode for concurrent access (multiple readers + 1 writer)
 - Schema:
   ```sql
@@ -78,7 +79,7 @@ Agent responds → Stop hook fires → check-inbox.sh runs
 
 ### Cooldown
 
-A marker file (`db/.lastcheck-<agent>`) tracks the last check time. Configurable via `hook.check_interval` (default 60 seconds).
+A marker file (`run/.lastcheck-<agent>`) tracks the last check time. Configurable via `hook.check_interval` (default 60 seconds). It lives in the run dir (hook runtime state), not the message store, so it is unaffected by `AGMSG_STORAGE_PATH`.
 
 ### Claude Code vs Codex
 
@@ -119,8 +120,10 @@ All scripts use only `bash` and `sqlite3`. No python3 dependency.
 ├── scripts/              # All shell scripts
 ├── templates/            # Command templates (cmd.claude-code.md, cmd.codex.md)
 ├── db/
-│   ├── messages.db       # SQLite message store
-│   ├── config.yaml       # User configuration
+│   ├── messages.db       # SQLite message store (relocatable via AGMSG_STORAGE_PATH)
+│   └── config.yaml       # User configuration
+├── run/                  # Hook/watcher runtime state
+│   ├── watch.<sid>.pid   # Monitor watcher pidfiles
 │   └── .lastcheck-*      # Cooldown markers
 └── teams/
     └── <team>/

--- a/install.sh
+++ b/install.sh
@@ -80,6 +80,8 @@ if [ "$UPDATE_ONLY" = true ]; then
   echo "  Updating $SKILL_NAME..."
   sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/cmd.codex.md" > "$SKILL_DIR/SKILL.md"
   cp "$SCRIPT_DIR/scripts/"*.sh "$SKILL_DIR/scripts/"
+  mkdir -p "$SKILL_DIR/scripts/lib"
+  cp "$SCRIPT_DIR/scripts/lib/"*.sh "$SKILL_DIR/scripts/lib/"
   for tmpl in "$SCRIPT_DIR/templates/"cmd.*.md; do
     sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$tmpl" > "$SKILL_DIR/templates/$(basename "$tmpl")"
   done
@@ -118,6 +120,8 @@ mkdir -p "$SKILL_DIR"/{scripts,templates,db,agents}
 # SKILL.md is generated from the Codex command template (Codex reads SKILL.md directly)
 sed "s/__SKILL_NAME__/$CMD_NAME/g" "$SCRIPT_DIR/templates/cmd.codex.md" > "$SKILL_DIR/SKILL.md"
 cp "$SCRIPT_DIR/scripts/"*.sh "$SKILL_DIR/scripts/"
+mkdir -p "$SKILL_DIR/scripts/lib"
+cp "$SCRIPT_DIR/scripts/lib/"*.sh "$SKILL_DIR/scripts/lib/"
 
 # Replace placeholder in templates with actual skill name
 for tmpl in "$SCRIPT_DIR/templates/"cmd.*.md; do

--- a/install.sh
+++ b/install.sh
@@ -79,9 +79,8 @@ if [ "$UPDATE_ONLY" = true ]; then
   SKILL_NAME="$(basename "$SKILL_DIR")"
   echo "  Updating $SKILL_NAME..."
   sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/cmd.codex.md" > "$SKILL_DIR/SKILL.md"
-  cp "$SCRIPT_DIR/scripts/"*.sh "$SKILL_DIR/scripts/"
-  mkdir -p "$SKILL_DIR/scripts/lib"
-  cp "$SCRIPT_DIR/scripts/lib/"*.sh "$SKILL_DIR/scripts/lib/"
+  # Recursive copy so nested helper dirs (scripts/lib/) ship without enumerating files.
+  cp -R "$SCRIPT_DIR/scripts/." "$SKILL_DIR/scripts/"
   for tmpl in "$SCRIPT_DIR/templates/"cmd.*.md; do
     sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$tmpl" > "$SKILL_DIR/templates/$(basename "$tmpl")"
   done
@@ -119,9 +118,8 @@ mkdir -p "$SKILL_DIR"/{scripts,templates,db,agents}
 
 # SKILL.md is generated from the Codex command template (Codex reads SKILL.md directly)
 sed "s/__SKILL_NAME__/$CMD_NAME/g" "$SCRIPT_DIR/templates/cmd.codex.md" > "$SKILL_DIR/SKILL.md"
-cp "$SCRIPT_DIR/scripts/"*.sh "$SKILL_DIR/scripts/"
-mkdir -p "$SKILL_DIR/scripts/lib"
-cp "$SCRIPT_DIR/scripts/lib/"*.sh "$SKILL_DIR/scripts/lib/"
+# Recursive copy so nested helper dirs (scripts/lib/) ship without enumerating files.
+cp -R "$SCRIPT_DIR/scripts/." "$SKILL_DIR/scripts/"
 
 # Replace placeholder in templates with actual skill name
 for tmpl in "$SCRIPT_DIR/templates/"cmd.*.md; do

--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,9 @@ if [ "$UPDATE_ONLY" = true ]; then
   echo "  + updated scripts, templates, and SKILL.md"
   echo "  ~ DB and team configs preserved"
   echo ""
+  echo "  ! Restart any running agent sessions to pick up the updated scripts."
+  echo "    In-flight watch.sh processes keep the old code until they restart."
+  echo ""
   echo "  ✓ Update complete"
   echo ""
   exit 0

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -9,6 +9,7 @@ PROJECT="${2:?Missing project_path}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/storage.sh"
 
 # Prevent infinite loop: if stop hook is already active, exit silently
 INPUT=$(cat 2>/dev/null || true)
@@ -50,8 +51,11 @@ if [ -z "$AGENT" ] || [ -z "$TEAMS" ]; then
   exit 0
 fi
 
-# Cooldown check
-MARKER="$SKILL_DIR/db/.lastcheck-$AGENT"
+# Cooldown check. The marker is hook runtime state, not message storage, so it
+# lives in the skill's run dir — independent of AGMSG_STORAGE_PATH. Keeping it
+# out of the store means an overridden/sandboxed store still gets delivery even
+# when the default db dir doesn't exist.
+MARKER="$SKILL_DIR/run/.lastcheck-$AGENT"
 
 if [ -f "$MARKER" ]; then
   if [ "$(uname)" = "Darwin" ]; then
@@ -78,10 +82,11 @@ ENDJSON
   fi
 fi
 
+mkdir -p "$SKILL_DIR/run"
 touch "$MARKER"
 
 # Check for unread messages and mark as read
-DB="$SKILL_DIR/db/messages.db"
+DB="$(agmsg_db_path)"
 if [ ! -f "$DB" ]; then exit 0; fi
 
 OUTPUT=""

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -8,7 +8,9 @@ TEAM="${1:?Usage: history.sh <team> [agent_id] [limit]}"
 AGENT="${2:-}"
 LIMIT="${3:-20}"
 
-DB="$(cd "$(dirname "$0")/../db" && pwd)/messages.db"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/storage.sh"
+DB="$(agmsg_db_path)"
 
 if [ ! -f "$DB" ]; then
   echo "No messages (DB not initialized)"

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -12,7 +12,9 @@ if [ "${3:-}" = "--quiet" ]; then
   QUIET=true
 fi
 
-DB="$(cd "$(dirname "$0")/../db" && pwd)/messages.db"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/storage.sh"
+DB="$(agmsg_db_path)"
 
 if [ ! -f "$DB" ]; then
   if [ "$QUIET" = true ]; then exit 0; fi

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DB_DIR="$(cd "$(dirname "$0")/../db" && pwd)"
-DB="$DB_DIR/messages.db"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/storage.sh"
+DB="$(agmsg_db_path)"
+DB_DIR="$(dirname "$DB")"
+mkdir -p "$DB_DIR"
 
 if [ ! -f "$DB" ]; then
   sqlite3 "$DB" <<'SQL'

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# storage.sh — resolve the path to the sqlite message store (messages.db).
+#
+# Scope: the storage axis only — where messages are persisted. This is NOT a
+# storage-driver interface; it just centralizes the path resolution that was
+# previously duplicated across the script set.
+#
+# Resolution order:
+#   1. AGMSG_STORAGE_PATH — directory that holds messages.db (env override)
+#   2. built-in default   — <skill>/db
+#
+# [seam] A config-file layer is expected to slot in between the env override
+# and the built-in default once the storage-driver work lands; the intended
+# full order is env > config > default. Keep that logic here so call sites
+# stay unchanged.
+
+# Echo the directory that holds (or will hold) the message store.
+agmsg_storage_dir() {
+  if [ -n "${AGMSG_STORAGE_PATH:-}" ]; then
+    # Strip a single trailing slash for a stable join with the filename.
+    printf '%s\n' "${AGMSG_STORAGE_PATH%/}"
+    return
+  fi
+  local lib_dir skill_dir
+  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  skill_dir="$(cd "$lib_dir/../.." && pwd)"
+  printf '%s\n' "$skill_dir/db"
+}
+
+# Echo the full path to messages.db.
+agmsg_db_path() {
+  printf '%s/messages.db\n' "$(agmsg_storage_dir)"
+}

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -17,8 +17,9 @@ if [ "$OLD_TEAM" = "$NEW_TEAM" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/storage.sh"
 TEAMS_DIR="$SCRIPT_DIR/../teams"
-DB="$SCRIPT_DIR/../db/messages.db"
+DB="$(agmsg_db_path)"
 OLD_DIR="$TEAMS_DIR/$OLD_TEAM"
 NEW_DIR="$TEAMS_DIR/$NEW_TEAM"
 

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -10,8 +10,9 @@ OLD_NAME="${2:?Missing old agent name}"
 NEW_NAME="${3:?Missing new agent name}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/storage.sh"
 TEAMS_DIR="$SCRIPT_DIR/../teams"
-DB="$SCRIPT_DIR/../db/messages.db"
+DB="$(agmsg_db_path)"
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
 
 if [ ! -f "$TEAM_CONFIG" ]; then

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -8,10 +8,12 @@ FROM="${2:?Missing from agent}"
 TO="${3:?Missing to agent}"
 BODY="${4:?Missing message body}"
 
-DB="$(cd "$(dirname "$0")/../db" && pwd)/messages.db"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/storage.sh"
+DB="$(agmsg_db_path)"
 
 if [ ! -f "$DB" ]; then
-  bash "$(dirname "$0")/init-db.sh"
+  bash "$SCRIPT_DIR/init-db.sh"
 fi
 
 sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$TEAM', '$FROM', '$TO', '$(echo "$BODY" | sed "s/'/''/g")');"

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -34,7 +34,8 @@ ACTIVE_NAME="${4:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-DB="$SKILL_DIR/db/messages.db"
+source "$SCRIPT_DIR/lib/storage.sh"
+DB="$(agmsg_db_path)"
 RUN_DIR="$SKILL_DIR/run"
 PIDFILE="$RUN_DIR/watch.$SESSION_ID.pid"
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -5,8 +5,9 @@ setup_test_env() {
   export TEST_SKILL_DIR="$(mktemp -d)"
   mkdir -p "$TEST_SKILL_DIR"/{scripts,db,teams}
 
-  # Copy all scripts to isolated skill dir
+  # Copy all scripts to isolated skill dir (including the lib/ helpers they source)
   cp "$BATS_TEST_DIRNAME"/../scripts/*.sh "$TEST_SKILL_DIR/scripts/"
+  cp -R "$BATS_TEST_DIRNAME"/../scripts/lib "$TEST_SKILL_DIR/scripts/lib"
   chmod +x "$TEST_SKILL_DIR/scripts/"*.sh
 
   # Initialize DB

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -5,9 +5,9 @@ setup_test_env() {
   export TEST_SKILL_DIR="$(mktemp -d)"
   mkdir -p "$TEST_SKILL_DIR"/{scripts,db,teams}
 
-  # Copy all scripts to isolated skill dir (including the lib/ helpers they source)
-  cp "$BATS_TEST_DIRNAME"/../scripts/*.sh "$TEST_SKILL_DIR/scripts/"
-  cp -R "$BATS_TEST_DIRNAME"/../scripts/lib "$TEST_SKILL_DIR/scripts/lib"
+  # Copy all scripts to isolated skill dir. Recursive so nested helper dirs
+  # (scripts/lib/) come along without enumerating files.
+  cp -R "$BATS_TEST_DIRNAME"/../scripts/. "$TEST_SKILL_DIR/scripts/"
   chmod +x "$TEST_SKILL_DIR/scripts/"*.sh
 
   # Initialize DB

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+# Install smoke tests. These run the real install.sh against a throwaway HOME so
+# the packaged artifact (not a hand-built tree like test_helper builds) is what
+# gets validated. Catches packaging drift — e.g. a new scripts/lib/ helper that
+# the installer forgets to copy, which would make every command die at `source`.
+
+setup() {
+  export FAKE_HOME="$(mktemp -d)"
+  export REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  export SK="$FAKE_HOME/.agents/skills/agmsg"
+}
+
+teardown() {
+  rm -rf "$FAKE_HOME"
+}
+
+@test "install: fresh install ships scripts/lib and the commands actually run" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  [ -f "$SK/scripts/lib/storage.sh" ]
+
+  # End-to-end through the installed scripts — a missing sourced helper would
+  # surface here, not just as a stat on a file.
+  bash "$SK/scripts/join.sh" demo alice claude-code /tmp/install-projA
+  bash "$SK/scripts/join.sh" demo bob   claude-code /tmp/install-projB
+  run bash "$SK/scripts/send.sh" demo alice bob "hello from install"
+  [ "$status" -eq 0 ]
+  run bash "$SK/scripts/inbox.sh" demo bob
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "hello from install" ]]
+}
+
+@test "install: --update restores scripts/lib even if it went missing" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  rm -rf "$SK/scripts/lib"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  [ -f "$SK/scripts/lib/storage.sh" ]
+  run bash "$SK/scripts/send.sh" demo alice bob "after update"
+  [ "$status" -eq 0 ]
+}
+
+@test "install: AGMSG_STORAGE_PATH override works against the installed skill" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  local store="$FAKE_HOME/override-store"
+  AGMSG_STORAGE_PATH="$store" bash "$SK/scripts/send.sh" demo alice bob "via override"
+  [ -f "$store/messages.db" ]
+  run bash -c "AGMSG_STORAGE_PATH='$store' bash '$SK/scripts/inbox.sh' demo bob"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "via override" ]]
+}

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+}
+
+teardown() {
+  teardown_test_env
+}
+
+# --- agmsg_db_path() resolution ---
+
+@test "storage: default path resolves under the skill dir" {
+  source "$SCRIPTS/lib/storage.sh"
+  unset AGMSG_STORAGE_PATH
+  [ "$(agmsg_db_path)" = "$TEST_SKILL_DIR/db/messages.db" ]
+}
+
+@test "storage: AGMSG_STORAGE_PATH overrides the storage dir" {
+  source "$SCRIPTS/lib/storage.sh"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  [ "$(agmsg_db_path)" = "$BATS_TEST_TMPDIR/store/messages.db" ]
+}
+
+@test "storage: trailing slash on the override is normalized" {
+  source "$SCRIPTS/lib/storage.sh"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store/"
+  [ "$(agmsg_db_path)" = "$BATS_TEST_TMPDIR/store/messages.db" ]
+}
+
+# --- init-db.sh honoring the override ---
+
+@test "storage: init-db creates the db at the overridden path (and makes the dir)" {
+  local custom="$BATS_TEST_TMPDIR/nested/store"
+  [ ! -d "$custom" ]
+  AGMSG_STORAGE_PATH="$custom" bash "$SCRIPTS/init-db.sh"
+  [ -f "$custom/messages.db" ]
+}
+
+# --- end-to-end roundtrip through the override ---
+
+@test "storage: send and inbox share the overridden db" {
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  bash "$SCRIPTS/send.sh" testteam alice bob "hi via override"
+  [ -f "$AGMSG_STORAGE_PATH/messages.db" ]
+
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "hi via override" ]]
+}
+
+@test "storage: stop-hook delivery works when the default db dir is absent but the override is populated" {
+  local store="$BATS_TEST_TMPDIR/store"
+  local project="/tmp/agmsg-storage-test-proj"
+
+  # Register an agent so check-inbox can resolve identity via whoami.
+  bash "$SCRIPTS/join.sh" testteam alice claude-code "$project"
+
+  # A message addressed to alice lives only in the overridden store.
+  AGMSG_STORAGE_PATH="$store" bash "$SCRIPTS/send.sh" testteam bob alice "via override store"
+
+  # Simulate a clean install whose default skill db dir never existed.
+  rm -rf "$TEST_SKILL_DIR/db"
+
+  # Stop-hook delivery must still succeed (exit 0) and surface the message —
+  # the cooldown marker now lives in run/, not the (absent) db dir.
+  run bash -c "echo '{}' | AGMSG_STORAGE_PATH='$store' bash '$SCRIPTS/check-inbox.sh' claude-code '$project'"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "via override store" ]]
+}
+
+@test "storage: default db is untouched when the override is set" {
+  # The default store was initialized in setup; writing through an override
+  # must not add rows to it.
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  bash "$SCRIPTS/send.sh" testteam alice bob "isolated"
+
+  local default_count
+  default_count=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COUNT(*) FROM messages;")
+  [ "$default_count" -eq 0 ]
+}


### PR DESCRIPTION
Closes #49.

## What
Allow relocating the SQLite message store (`messages.db`) via an env var, so tests / sandboxes / isolated instances can point at their own store without copying the skill dir.

## How
- New helper `scripts/lib/storage.sh` centralizes path resolution. The store **directory** resolves as:
  `AGMSG_STORAGE_PATH` (env) **>** built-in default (`<skill>/db`).
  A documented seam is left for the config-file layer (`~/.agents/agmsg/config.json`) from the storage-driver work (epic #51) — intended full order `env > config > default`.
- All 8 scripts that touch `messages.db` now source the helper instead of recomputing the path (`send`, `inbox`, `history`, `init-db`, `rename`, `rename-team`, `check-inbox`, `watch`).
- `init-db.sh` now `mkdir -p`'s the resolved dir, so an override can point anywhere.
- Moved the Stop-hook cooldown marker out of the store: `db/.lastcheck-*` → `run/.lastcheck-*`. It's hook runtime state, not message storage, so an overridden/sandboxed store still receives delivery even when the default db dir doesn't exist.

## Scope (intentional)
- SQLite store path only. `teams/` and `config.yaml` are unchanged.
- No storage-*interface* abstraction — that lands with the driver work (#51). This PR composes cleanly with ADR-0001 (which already references `AGMSG_STORAGE_PATH` for #49).

## Tests
- New `tests/test_storage.bats` (7 cases): default resolution, override, trailing-slash normalization, `init-db` dir creation, send↔inbox roundtrip through the override, default-store isolation, and a regression test (override populated + default db dir absent → `check-inbox` exits 0 and surfaces the message).
- Full suite: **119 tests, 0 failures**.

## Docs
- `README.md` — new Configuration section documenting the variable + resolution order.
- `docs/design.md` — storage path resolution note and updated install layout (`run/` holds pidfiles + cooldown markers).

Reviewed via agmsg by `aggie-co`; the flagged cooldown-marker isolation issue is addressed here. Naming kept 2-layer (`AGMSG_STORAGE_PATH`/`agmsg_storage_dir` vs the sqlite-specific `agmsg_db_path`) per review.