### PR TITLE
Fix Gemini stdin blocking and add skill templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ After setup, your agent handles everything — just talk to it naturally. "Send 
 ```bash
 ./install.sh              # Interactive (asks command name, default: agmsg)
 ./install.sh --cmd m      # Non-interactive with custom command name
-./install.sh --target gemini  # Install a Gemini-oriented SKILL.md
+./install.sh --agent-type gemini  # Install a Gemini-oriented SKILL.md
 ```
 
 The **command name** determines:

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ bash <(curl -fsSL https://raw.githubusercontent.com/fujibee/agmsg/main/setup.sh)
 # Or clone first if you want to inspect the code
 git clone https://github.com/fujibee/agmsg.git && cd agmsg && ./install.sh
 
-# 2. Restart Claude Code / Codex to pick up the new skill
+# 2. Restart Claude Code / Codex / Gemini CLI / Antigravity to pick up the new skill
 
 # 3. Run the command — it will prompt for team and agent name on first use
 #    Claude Code:  /agmsg
 #    Codex:        $agmsg
+#    Gemini CLI:   $agmsg
+#    Antigravity:  $agmsg
 ```
 
 That's it. Once two agents have joined the same team, they can message each other. On first join, you'll be asked to pick a **delivery mode** — see [Delivery modes](#delivery-modes) below for the four options. The default on Claude Code is `monitor` (real-time push); Codex defaults to `turn` (between-turns check) because it has no Monitor tool.
@@ -37,14 +39,15 @@ After setup, your agent handles everything — just talk to it naturally. "Send 
 ```bash
 ./install.sh              # Interactive (asks command name, default: agmsg)
 ./install.sh --cmd m      # Non-interactive with custom command name
+./install.sh --target gemini  # Install a Gemini-oriented SKILL.md
 ```
 
 The **command name** determines:
 - Skill folder: `~/.agents/skills/<cmd>/`
 - Claude Code: `/<cmd>`
-- Codex: `$<cmd>`
+- Codex/Gemini/Antigravity: `$<cmd>`
 
-After install, **restart your agent** (Claude Code / Codex) so it picks up the new skill.
+After install, **restart your agent** (Claude Code / Codex / Gemini CLI / Antigravity) so it picks up the new skill.
 
 ## Join a Team
 

--- a/install.sh
+++ b/install.sh
@@ -25,19 +25,23 @@ AGENTS_DIR="$HOME/.agents"
 CMD_NAME=""
 UPDATE_ONLY=false
 INTERACTIVE=true
+TARGET_AGENT=""  # claude-code, codex, gemini, antigravity, or empty for auto/default
 
 # --- Parse args ---
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --cmd)    CMD_NAME="$2"; INTERACTIVE=false; shift 2 ;;
+    --target) TARGET_AGENT="$2"; shift 2 ;;
     --update) UPDATE_ONLY=true; shift ;;
     -h|--help)
       echo "Usage: ./install.sh [options]"
       echo ""
       echo "Options:"
-      echo "  --cmd <name>   Command & skill folder name (default: agmsg)"
-      echo "                 Claude Code: /<cmd>, Codex: \$<cmd>"
-      echo "  --update       Update skill scripts only (preserve DB and teams)"
+      echo "  --cmd <name>      Command & skill folder name (default: agmsg)"
+      echo "                    Claude Code: /<cmd>, Codex/Gemini/Antigravity: \$<cmd>"
+      echo "  --target <agent>  Target agent: claude-code, codex, gemini, antigravity"
+      echo "                    Sets SKILL.md template for a specific agent"
+      echo "  --update          Update skill scripts only (preserve DB and teams)"
       echo ""
       echo "After install, join a team per-project:"
       echo "  ~/.agents/skills/<cmd>/scripts/join.sh <team> <name> <type> <project>"
@@ -78,7 +82,22 @@ if [ "$UPDATE_ONLY" = true ]; then
   fi
   SKILL_NAME="$(basename "$SKILL_DIR")"
   echo "  Updating $SKILL_NAME..."
-  sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/cmd.codex.md" > "$SKILL_DIR/SKILL.md"
+  if [ -z "$TARGET_AGENT" ]; then
+    if grep -q "whoami.sh.*antigravity" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
+      TARGET_AGENT="antigravity"
+    elif grep -q "whoami.sh.*gemini" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
+      TARGET_AGENT="gemini"
+    else
+      TARGET_AGENT="codex"
+    fi
+  fi
+  SKILL_TEMPLATE="cmd.codex.md"
+  if [ "$TARGET_AGENT" = "gemini" ]; then
+    SKILL_TEMPLATE="cmd.gemini.md"
+  elif [ "$TARGET_AGENT" = "antigravity" ]; then
+    SKILL_TEMPLATE="cmd.antigravity.md"
+  fi
+  sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/$SKILL_TEMPLATE" > "$SKILL_DIR/SKILL.md"
   # Recursive copy so nested helper dirs (scripts/lib/) ship without enumerating files.
   cp -R "$SCRIPT_DIR/scripts/." "$SKILL_DIR/scripts/"
   for tmpl in "$SCRIPT_DIR/templates/"cmd.*.md; do
@@ -119,8 +138,14 @@ SKILL_DIR="$AGENTS_DIR/skills/$CMD_NAME"
 echo "  Installing to ~/.agents/skills/$CMD_NAME/ ..."
 mkdir -p "$SKILL_DIR"/{scripts,templates,db,agents}
 
-# SKILL.md is generated from the Codex command template (Codex reads SKILL.md directly)
-sed "s/__SKILL_NAME__/$CMD_NAME/g" "$SCRIPT_DIR/templates/cmd.codex.md" > "$SKILL_DIR/SKILL.md"
+# SKILL.md is generated from the agent-specific command template.
+SKILL_TEMPLATE="cmd.codex.md"
+if [ "$TARGET_AGENT" = "gemini" ]; then
+  SKILL_TEMPLATE="cmd.gemini.md"
+elif [ "$TARGET_AGENT" = "antigravity" ]; then
+  SKILL_TEMPLATE="cmd.antigravity.md"
+fi
+sed "s/__SKILL_NAME__/$CMD_NAME/g" "$SCRIPT_DIR/templates/$SKILL_TEMPLATE" > "$SKILL_DIR/SKILL.md"
 # Recursive copy so nested helper dirs (scripts/lib/) ship without enumerating files.
 cp -R "$SCRIPT_DIR/scripts/." "$SKILL_DIR/scripts/"
 
@@ -204,10 +229,12 @@ echo ""
 echo "  ✓ Installed to ~/.agents/skills/$CMD_NAME/"
 echo ""
 echo "  Next steps:"
-echo "    1. Restart your agent (Claude Code / Codex) to pick up the new skill"
+echo "    1. Restart your agent (Claude Code / Codex / Gemini CLI / Antigravity) to pick up the new skill"
 echo "    2. Run the command to join a team:"
 echo "       Claude Code:  /$CMD_NAME"
 echo "       Codex:        \$$CMD_NAME"
+echo "       Gemini CLI:   \$$CMD_NAME"
+echo "       Antigravity:  \$$CMD_NAME"
 echo "       It will prompt for team name and agent name on first run."
 echo ""
 echo "  Docs: https://agmsg.cc/"

--- a/install.sh
+++ b/install.sh
@@ -25,13 +25,13 @@ AGENTS_DIR="$HOME/.agents"
 CMD_NAME=""
 UPDATE_ONLY=false
 INTERACTIVE=true
-TARGET_AGENT=""  # claude-code, codex, gemini, antigravity, or empty for auto/default
+AGENT_TYPE=""  # claude-code, codex, gemini, antigravity — passed via --agent-type, or empty for auto/default
 
 # --- Parse args ---
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --cmd)    CMD_NAME="$2"; INTERACTIVE=false; shift 2 ;;
-    --target) TARGET_AGENT="$2"; shift 2 ;;
+    --agent-type) AGENT_TYPE="$2"; shift 2 ;;
     --update) UPDATE_ONLY=true; shift ;;
     -h|--help)
       echo "Usage: ./install.sh [options]"
@@ -39,8 +39,9 @@ while [[ $# -gt 0 ]]; do
       echo "Options:"
       echo "  --cmd <name>      Command & skill folder name (default: agmsg)"
       echo "                    Claude Code: /<cmd>, Codex/Gemini/Antigravity: \$<cmd>"
-      echo "  --target <agent>  Target agent: claude-code, codex, gemini, antigravity"
-      echo "                    Sets SKILL.md template for a specific agent"
+      echo "  --agent-type <t>  Agent type: claude-code, codex, gemini, antigravity"
+      echo "                    Selects which template becomes SKILL.md (matches the"
+      echo "                    <type> arg passed to join.sh / whoami.sh)"
       echo "  --update          Update skill scripts only (preserve DB and teams)"
       echo ""
       echo "After install, join a team per-project:"
@@ -82,19 +83,19 @@ if [ "$UPDATE_ONLY" = true ]; then
   fi
   SKILL_NAME="$(basename "$SKILL_DIR")"
   echo "  Updating $SKILL_NAME..."
-  if [ -z "$TARGET_AGENT" ]; then
+  if [ -z "$AGENT_TYPE" ]; then
     if grep -q "whoami.sh.*antigravity" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
-      TARGET_AGENT="antigravity"
+      AGENT_TYPE="antigravity"
     elif grep -q "whoami.sh.*gemini" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
-      TARGET_AGENT="gemini"
+      AGENT_TYPE="gemini"
     else
-      TARGET_AGENT="codex"
+      AGENT_TYPE="codex"
     fi
   fi
   SKILL_TEMPLATE="cmd.codex.md"
-  if [ "$TARGET_AGENT" = "gemini" ]; then
+  if [ "$AGENT_TYPE" = "gemini" ]; then
     SKILL_TEMPLATE="cmd.gemini.md"
-  elif [ "$TARGET_AGENT" = "antigravity" ]; then
+  elif [ "$AGENT_TYPE" = "antigravity" ]; then
     SKILL_TEMPLATE="cmd.antigravity.md"
   fi
   sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/$SKILL_TEMPLATE" > "$SKILL_DIR/SKILL.md"
@@ -140,9 +141,9 @@ mkdir -p "$SKILL_DIR"/{scripts,templates,db,agents}
 
 # SKILL.md is generated from the agent-specific command template.
 SKILL_TEMPLATE="cmd.codex.md"
-if [ "$TARGET_AGENT" = "gemini" ]; then
+if [ "$AGENT_TYPE" = "gemini" ]; then
   SKILL_TEMPLATE="cmd.gemini.md"
-elif [ "$TARGET_AGENT" = "antigravity" ]; then
+elif [ "$AGENT_TYPE" = "antigravity" ]; then
   SKILL_TEMPLATE="cmd.antigravity.md"
 fi
 sed "s/__SKILL_NAME__/$CMD_NAME/g" "$SCRIPT_DIR/templates/$SKILL_TEMPLATE" > "$SKILL_DIR/SKILL.md"

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -11,8 +11,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 
+# Hook runtimes that pass JSON do so on stdin. Interactive invocations such as
+# Gemini's PostToolUse command may inherit a terminal stdin instead; reading
+# unconditionally there blocks waiting for input.
+INPUT=""
+if [ ! -t 0 ]; then
+  INPUT=$(cat 2>/dev/null || true)
+fi
+
 # Prevent infinite loop: if stop hook is already active, exit silently
-INPUT=$(cat 2>/dev/null || true)
 if echo "$INPUT" | grep -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true' 2>/dev/null; then
   exit 0
 fi

--- a/templates/cmd.antigravity.md
+++ b/templates/cmd.antigravity.md
@@ -1,0 +1,136 @@
+---
+name: __SKILL_NAME__
+description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
+---
+
+Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER directly read or edit config files, DB, or team data. There is NO register.sh — use join.sh to join a team.**
+
+## Identity
+
+If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call in this session, skip to **Execute** below.
+
+Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" antigravity`
+
+Four possible outputs:
+
+**A) Single identity:**
+`agent=<name> teams=<t1,t2,...> type=antigravity project=<path>`
+→ Remember AGENT and TEAMS, then go to **Execute**.
+
+**B) Multiple identities:**
+`multiple=true agents=<n1,n2,...> teams=<t1,t2,...> type=antigravity project=<path>`
+→ Ask the user which agent name to use for this session, then go to **Execute**.
+
+**C) Not in a team:**
+`not_joined=true available_teams=<t1,t2,...>` (or `available_teams=none`)
+→ Show the user the available teams from the output, then:
+
+  > **First-time setup required.**
+  > Joining a team so this agent can send and receive messages.
+  > - **Team name**: a group of agents that can message each other (available: <list from output>)
+  > - **Agent name**: this agent's identity within the team
+
+  1. Ask: "Enter a team name (joins existing or creates new)"
+  2. Ask: "Enter a name for this agent"
+  3. **You MUST use join.sh** — run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> antigravity "$(pwd)"`
+  4. Show the result and explain:
+
+  > **Joined!** You can now use `$__SKILL_NAME__` to check and send messages.
+  > - `$__SKILL_NAME__` — check inbox
+  > - `$__SKILL_NAME__ send <agent> <message>` — send a message
+  > - `$__SKILL_NAME__ team` — list team members
+  > - `$__SKILL_NAME__ history` — message history
+
+  5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
+
+     ```
+     Choose delivery mode for incoming messages:
+
+       1) turn — Check inbox at the end of each assistant turn
+                  Stop hook pulls after each response.
+
+       2) off  — No automatic delivery
+                  Manual $__SKILL_NAME__ only.
+
+     [1]:
+     ```
+
+     - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
+     - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
+       `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> antigravity "$(pwd)"`
+     - Codex has no Monitor tool, so `monitor` and `both` modes are not offered here.
+
+  6. Then check inbox for the newly joined team.
+
+**D) Suggestions for reuse:**
+`suggest=true agents=<n1,n2,...> teams=<t1,t2,...> type=antigravity project=<path> available_teams=<t1,t2,...>`
+→ No exact registration exists for this project, but there are same-type agent names registered elsewhere.
+
+  1. Show the suggested agent names to the user.
+  2. Ask whether to reuse one of those names or choose a new one.
+  3. Ask for the team name to join (existing or new).
+  4. Run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> antigravity "$(pwd)"`
+  5. Then continue with the normal post-join flow above.
+
+## Execute
+
+**Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
+
+**If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
+1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
+2. Do NOT ask the user what to do — just run the inbox check.
+3. If there are messages, read and respond appropriately. To reply:
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+
+If argument is "history":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/history.sh $TEAM $AGENT`
+
+If argument is "team":
+1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM`
+
+If argument starts with "send" (e.g. "send misaki check the server"):
+1. Parse target agent and message from the arguments
+2. Determine which team the target agent belongs to, then run:
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+
+If argument is "config":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh show`
+2. Show the output to the user.
+
+If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
+1. Parse key and value from the arguments.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
+
+
+If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
+1. Parse the new role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" antigravity` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> antigravity "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
+4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Codex has no Monitor tool, so receive still covers all of your registered roles in this project.)"
+
+If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
+1. Parse the role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" antigravity <name>` to remove that role's registration.
+3. If the session's active FROM was `<name>`, clear that state.
+4. Tell the user: "Dropped role `<name>` from this project."
+
+If argument is "mode" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status antigravity "$(pwd)"`
+2. Show the output to the user.
+
+If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
+1. Parse the mode. Codex supports only `turn` and `off` — reject `monitor` and `both` with: "Codex has no Monitor tool; only `turn` or `off` modes are supported."
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> antigravity "$(pwd)"`
+
+If argument is "hook on" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn antigravity "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior)."
+
+If argument is "hook off" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off antigravity "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'off'."
+
+If argument is "reset":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" antigravity`
+2. Tell the user the result.

--- a/templates/cmd.gemini.md
+++ b/templates/cmd.gemini.md
@@ -1,0 +1,136 @@
+---
+name: __SKILL_NAME__
+description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
+---
+
+Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER directly read or edit config files, DB, or team data. There is NO register.sh — use join.sh to join a team.**
+
+## Identity
+
+If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call in this session, skip to **Execute** below.
+
+Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" gemini`
+
+Four possible outputs:
+
+**A) Single identity:**
+`agent=<name> teams=<t1,t2,...> type=gemini project=<path>`
+→ Remember AGENT and TEAMS, then go to **Execute**.
+
+**B) Multiple identities:**
+`multiple=true agents=<n1,n2,...> teams=<t1,t2,...> type=gemini project=<path>`
+→ Ask the user which agent name to use for this session, then go to **Execute**.
+
+**C) Not in a team:**
+`not_joined=true available_teams=<t1,t2,...>` (or `available_teams=none`)
+→ Show the user the available teams from the output, then:
+
+  > **First-time setup required.**
+  > Joining a team so this agent can send and receive messages.
+  > - **Team name**: a group of agents that can message each other (available: <list from output>)
+  > - **Agent name**: this agent's identity within the team
+
+  1. Ask: "Enter a team name (joins existing or creates new)"
+  2. Ask: "Enter a name for this agent"
+  3. **You MUST use join.sh** — run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> gemini "$(pwd)"`
+  4. Show the result and explain:
+
+  > **Joined!** You can now use `$__SKILL_NAME__` to check and send messages.
+  > - `$__SKILL_NAME__` — check inbox
+  > - `$__SKILL_NAME__ send <agent> <message>` — send a message
+  > - `$__SKILL_NAME__ team` — list team members
+  > - `$__SKILL_NAME__ history` — message history
+
+  5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
+
+     ```
+     Choose delivery mode for incoming messages:
+
+       1) turn — Check inbox at the end of each assistant turn
+                  Stop hook pulls after each response.
+
+       2) off  — No automatic delivery
+                  Manual $__SKILL_NAME__ only.
+
+     [1]:
+     ```
+
+     - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
+     - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
+       `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> gemini "$(pwd)"`
+     - Codex has no Monitor tool, so `monitor` and `both` modes are not offered here.
+
+  6. Then check inbox for the newly joined team.
+
+**D) Suggestions for reuse:**
+`suggest=true agents=<n1,n2,...> teams=<t1,t2,...> type=gemini project=<path> available_teams=<t1,t2,...>`
+→ No exact registration exists for this project, but there are same-type agent names registered elsewhere.
+
+  1. Show the suggested agent names to the user.
+  2. Ask whether to reuse one of those names or choose a new one.
+  3. Ask for the team name to join (existing or new).
+  4. Run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> gemini "$(pwd)"`
+  5. Then continue with the normal post-join flow above.
+
+## Execute
+
+**Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
+
+**If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
+1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
+2. Do NOT ask the user what to do — just run the inbox check.
+3. If there are messages, read and respond appropriately. To reply:
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+
+If argument is "history":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/history.sh $TEAM $AGENT`
+
+If argument is "team":
+1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM`
+
+If argument starts with "send" (e.g. "send misaki check the server"):
+1. Parse target agent and message from the arguments
+2. Determine which team the target agent belongs to, then run:
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+
+If argument is "config":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh show`
+2. Show the output to the user.
+
+If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
+1. Parse key and value from the arguments.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
+
+
+If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
+1. Parse the new role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" gemini` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> gemini "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
+4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Codex has no Monitor tool, so receive still covers all of your registered roles in this project.)"
+
+If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
+1. Parse the role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" gemini <name>` to remove that role's registration.
+3. If the session's active FROM was `<name>`, clear that state.
+4. Tell the user: "Dropped role `<name>` from this project."
+
+If argument is "mode" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status gemini "$(pwd)"`
+2. Show the output to the user.
+
+If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
+1. Parse the mode. Codex supports only `turn` and `off` — reject `monitor` and `both` with: "Codex has no Monitor tool; only `turn` or `off` modes are supported."
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> gemini "$(pwd)"`
+
+If argument is "hook on" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn gemini "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior)."
+
+If argument is "hook off" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off gemini "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'off'."
+
+If argument is "reset":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" gemini`
+2. Tell the user the result.


### PR DESCRIPTION
## Summary
This PR addresses a blocking issue with stdin in Gemini's `PostToolUse` and adds official skill templates for Gemini CLI and Antigravity agents.

## Details
### Fix: Stdin Blocking in Gemini `PostToolUse`
When using Gemini with CLI tools, `PostToolUse` was causing stdin blocking, which hindered the interactive flow. This fix ensures proper handling of stdin to maintain a smooth conversational experience.

### Feat: Skill Templates
Added necessary template files in `templates/` to support seamless integration and installation for:
- Gemini CLI
- Antigravity (agy)

## Impact
- **Reliability**: Improves stability and responsiveness for Gemini agents during message exchange.
- **Convenience**: Enables easier onboarding and setup for users of Gemini CLI and Antigravity.

Please let me know if any further changes are required. Thank you!