### PR TITLE
fix(win): support native Windows (Git Bash + Codex hooks)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.sh text eol=lf

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -84,14 +84,33 @@ strip_agmsg_event() {
   "
 }
 
+# Wrap a POSIX shell command so Codex's Windows runner executes it through Git
+# Bash. On native Windows, Codex runs each hook command via PowerShell, which
+# cannot execute a bare POSIX ".sh" path, so the hook exits non-zero. Codex hook
+# config supports a "commandWindows" key that takes precedence on Windows; the
+# "& '<bash.exe>' -lc \"...\"" form is what Codex itself emits for shell calls.
+windows_wrap() {
+  local posix_cmd="$1"
+  printf "& 'C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe' -lc \"%s\"" "$posix_cmd"
+}
+
 # Append a single entry of the form {"matcher":"","hooks":[{"type":"command","command":"<cmd>"}]}
-# to .hooks.<event>, creating arrays/objects as needed.
+# to .hooks.<event>, creating arrays/objects as needed. For Codex agents (pass
+# "codex" as the 4th arg) the entry also carries a "commandWindows" so the hook
+# runs on native Windows; other agent types are unchanged.
 add_event_entry() {
   local settings_esc="$1"
   local event="$2"
   local cmd="$3"
+  local hook_type="${4:-}"
 
-  local entry="{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"$cmd\"}]}"
+  local hook_inner="\"type\":\"command\",\"command\":\"$cmd\""
+  if [ "$hook_type" = "codex" ]; then
+    local cw; cw=$(windows_wrap "$cmd")
+    cw="${cw//\\/\\\\}"; cw="${cw//\"/\\\"}"
+    hook_inner="$hook_inner,\"commandWindows\":\"$cw\""
+  fi
+  local entry="{\"matcher\":\"\",\"hooks\":[{$hook_inner}]}"
   local entry_esc
   entry_esc=$(printf '%s' "$entry" | sed "s/'/''/g")
 
@@ -243,20 +262,20 @@ apply_settings() {
     monitor)
       local ss="'$SKILL_DIR/scripts/session-start.sh' '$type' '$project'"
       local se="'$SKILL_DIR/scripts/session-end.sh'   '$type' '$project'"
-      settings_esc=$(add_event_entry "$settings_esc" "SessionStart" "$ss" | sed "s/'/''/g")
-      settings_esc=$(add_event_entry "$settings_esc" "SessionEnd"   "$se" | sed "s/'/''/g")
+      settings_esc=$(add_event_entry "$settings_esc" "SessionStart" "$ss" "$type" | sed "s/'/''/g")
+      settings_esc=$(add_event_entry "$settings_esc" "SessionEnd"   "$se" "$type" | sed "s/'/''/g")
       ;;
     turn)
       local cmd="'$SKILL_DIR/scripts/check-inbox.sh' '$type' '$project'"
-      settings_esc=$(add_event_entry "$settings_esc" "Stop" "$cmd" | sed "s/'/''/g")
+      settings_esc=$(add_event_entry "$settings_esc" "Stop" "$cmd" "$type" | sed "s/'/''/g")
       ;;
     both)
       local ss="'$SKILL_DIR/scripts/session-start.sh' '$type' '$project'"
       local se="'$SKILL_DIR/scripts/session-end.sh'   '$type' '$project'"
       local st="'$SKILL_DIR/scripts/check-inbox.sh'   '$type' '$project'"
-      settings_esc=$(add_event_entry "$settings_esc" "SessionStart" "$ss" | sed "s/'/''/g")
-      settings_esc=$(add_event_entry "$settings_esc" "SessionEnd"   "$se" | sed "s/'/''/g")
-      settings_esc=$(add_event_entry "$settings_esc" "Stop"         "$st" | sed "s/'/''/g")
+      settings_esc=$(add_event_entry "$settings_esc" "SessionStart" "$ss" "$type" | sed "s/'/''/g")
+      settings_esc=$(add_event_entry "$settings_esc" "SessionEnd"   "$se" "$type" | sed "s/'/''/g")
+      settings_esc=$(add_event_entry "$settings_esc" "Stop"         "$st" "$type" | sed "s/'/''/g")
       ;;
     off)
       : # already stripped

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -858,3 +858,29 @@ JSON
 
   rm -rf "$proj_b"
 }
+
+# --- Windows support: codex hooks emit commandWindows; other types do not ---
+
+@test "delivery set turn (codex): Stop entry carries commandWindows wrapping Git Bash" {
+  run bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  local hook_file="$TEST_PROJECT/.codex/hooks.json"
+  [ -f "$hook_file" ]
+  local cw
+  cw=$(sqlite3 :memory: "SELECT json_extract(readfile('$hook_file'), '\$.hooks.Stop[0].hooks[0].commandWindows');")
+  [ -n "$cw" ]
+  [[ "$cw" == *"Program Files\\Git\\bin\\bash.exe"* ]]
+  [[ "$cw" == *"-lc"* ]]
+  [[ "$cw" == *"check-inbox.sh"* ]]
+}
+
+@test "delivery set turn (claude-code): Stop entry has NO commandWindows (regression guard)" {
+  run bash "$SCRIPTS/delivery.sh" set turn claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  local hook_file="$TEST_PROJECT/.claude/settings.local.json"
+  [ -f "$hook_file" ]
+  local cw
+  cw=$(sqlite3 :memory: "SELECT json_extract(readfile('$hook_file'), '\$.hooks.Stop[0].hooks[0].commandWindows');")
+  [ -z "$cw" ]
+}
+


### PR DESCRIPTION
## Summary

agmsg assumes a POSIX shell environment. It runs fine on macOS/Linux, but on
**native Windows** (Git Bash as the shell, Codex CLI as an agent) two things break:

1. **Codex hook commands never run.** On Windows, Codex executes its hook
   `command` strings through **PowerShell**, which cannot execute a bare POSIX
   `.sh` path. The Codex hooks agmsg generates (e.g. `Stop`, `SessionStart`)
   therefore exit non-zero, and between-turn inbox delivery silently stops.
2. **CRLF corruption.** Without an `eol` policy, a Windows checkout can rewrite
   the shell scripts to CRLF, which breaks `#!/usr/bin/env bash` shebang parsing
   and here-doc/`read` handling.

This PR fixes both, with no behavior change on macOS/Linux.

## Changes

### 1. `scripts/delivery.sh` — emit a Windows hook command for Codex

Codex hook config supports a `commandWindows` key that takes precedence over
`command` on Windows. This PR adds a `windows_wrap()` helper and an optional 4th
argument to `add_event_entry()` so that, **for Codex agents only**, each hook
entry also carries a `commandWindows` that runs the same script through Git Bash:

```sh
windows_wrap() {
  local posix_cmd="$1"
  printf "& 'C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe' -lc \"%s\"" "$posix_cmd"
}
```

A generated Codex hook entry then looks like:

```json
{"type":"command",
 "command":"'<skill>/scripts/check-inbox.sh' 'codex' '<project>'",
 "commandWindows":"& 'C:\\Program Files\\Git\\bin\\bash.exe' -lc \"'<skill>/scripts/check-inbox.sh' 'codex' '<project>'\""}
```

`claude-code` and the `gemini`/`antigravity` rule-file path are untouched —
they never receive a `commandWindows`, so macOS/Linux behavior is identical.

> **Open question for maintainers:** the Git Bash path is hardcoded to
> `C:\Program Files\Git\bin\bash.exe`. It would be cleaner to derive it (e.g.
> from `$BASH`, `command -v bash`, or `where.exe bash`). Happy to change this to
> whatever you prefer.

### 2. `.gitattributes` (new) — force LF on checkout

```gitattributes
* text=auto eol=lf
*.sh text eol=lf
```

Keeps the shell scripts LF on a Windows checkout.

## Test plan

- **macOS/Linux:** no change — only `command` is emitted; hooks behave exactly as before.
- **Windows (Git Bash + Codex):** `delivery.sh set turn codex <project>` now
  produces a `.codex/hooks.json` whose `Stop` entry has both `command` and
  `commandWindows` (verified valid JSON); `delivery.sh set turn claude-code
  <project>` produces an entry with `command` only (no `commandWindows`).

## Out of scope

This is the first Windows support for agmsg, kept intentionally minimal. While
porting we also dealt with waking an idle Codex worker (external terminal poke)
and a synchronous request/reply bridge, but those live in additional scripts not
included here. Happy to discuss them separately if there's interest.
