### PR TITLE
feat: add GitHub Copilot CLI support (turn mode)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,7 +15,7 @@ agmsg is built around three orthogonal axes, each of which has exactly one **dri
 | Axis | What it abstracts | Bundled drivers |
 |---|---|---|
 | **storage** | Where messages and team state live, and how they are queried | `sqlite` (default), `jsonl-duckdb` |
-| **agent** | Per-runtime differences (hook formats, settings file locations, monitor tool availability) | `claude-code`, `codex`, `gemini`, `antigravity` |
+| **agent** | Per-runtime differences (hook formats, settings file locations, monitor tool availability) | `claude-code`, `codex`, `gemini`, `antigravity`, `copilot` |
 | **delivery** | How a recipient is notified that a message arrived | `monitor`, `turn`, `both`, `off` |
 
 The three axes are independent: any storage driver can be paired with any agent driver and any delivery mode. They share a common discovery/config/dependency-check protocol (see the spec) but expose axis-specific operations.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Cross-agent messaging for CLI AI agents. No daemon, no network, no complexity.
 
-Claude Code, Codex, Gemini CLI, and any CLI agent can message each other via a shared SQLite database.
+Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, and any CLI agent can message each other via a shared SQLite database.
 
 Two `monitor`-mode Claude Code instances, left alone in the same team, play tic-tac-toe against each other with no human in the loop — each picks up the other's move in real time:
 
@@ -143,7 +143,7 @@ How incoming messages reach your agent. Pick one at first join via the prompt, o
 | mode | mechanism | latency | who it's for |
 |---|---|---|---|
 | **`monitor`** (default on Claude Code) | SessionStart hook → Monitor tool → blocking SQLite stream | ~5s | Claude Code users wanting real-time push |
-| **`turn`** (default on Codex) | Stop hook fires `check-inbox.sh` between assistant turns | until your next interaction | Codex (no Monitor tool); Claude Code users on a quieter loop |
+| **`turn`** (default on Codex / Copilot CLI) | Stop hook fires `check-inbox.sh` between assistant turns | until your next interaction | Codex / Copilot CLI (no Monitor tool); Claude Code users on a quieter loop |
 | **`both`** | monitor primary, turn as per-session safety net | ~5s; falls back to turn-end on watcher failure | belt-and-suspenders |
 | **`off`** | no automatic delivery | manual `/agmsg` only | minimalists |
 
@@ -193,6 +193,18 @@ $agmsg                          — or /skills → agmsg
 ```
 
 Codex supports `mode turn` and `mode off` only — there's no Monitor tool to stream into.
+
+### GitHub Copilot CLI
+
+```
+/agmsg                          — invokes the agmsg skill
+```
+
+The Copilot installer drops a `SKILL.md` at `~/.copilot/skills/agmsg/` so
+`/agmsg` is auto-discovered. Per-project hooks live at
+`<project>/.github/hooks/agmsg.json`. Copilot CLI has no Monitor-tool
+equivalent, so only `mode turn` and `mode off` are supported. Asking for
+`monitor` or `both` is rejected with an error.
 
 ### Shell (any agent)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agmsg
-description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
+description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
 ---
 
 # Agent Messaging
@@ -13,7 +13,7 @@ description: Cross-agent messaging via SQLite. Send messages between Claude Code
 
 ```bash
 ~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" <type>
-# type: claude-code, codex, gemini
+# type: claude-code, codex, gemini, antigravity, copilot
 # Returns: agent=... / multiple=true ... / suggest=true ... / not_joined=true ...
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -89,11 +89,14 @@ if [ "$UPDATE_ONLY" = true ]; then
   if [ -d "$CC_COMMANDS_DIR" ] && [ -f "$CC_COMMANDS_DIR/$SKILL_NAME.md" ]; then
     sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/cmd.claude-code.md" > "$CC_COMMANDS_DIR/$SKILL_NAME.md"
   fi
-  # Refresh the Copilot CLI skill (Copilot reads SKILL.md from its own skills
-  # dir; the shared ~/.agents/skills/<name>/SKILL.md is Codex-typed and would
-  # mis-identify the agent as codex when invoked from Copilot).
+  # Refresh / install the Copilot CLI skill (Copilot reads SKILL.md from its
+  # own skills dir; the shared ~/.agents/skills/<name>/SKILL.md is
+  # Codex-typed and would mis-identify the agent as codex when invoked from
+  # Copilot). Same condition as the fresh-install path so users upgrading
+  # from a pre-Copilot release via --update also gain the skill.
   COPILOT_SKILL_DIR="$HOME/.copilot/skills/$SKILL_NAME"
-  if [ -d "$HOME/.copilot" ] && [ -f "$COPILOT_SKILL_DIR/SKILL.md" ]; then
+  if [ -d "$HOME/.copilot" ]; then
+    mkdir -p "$COPILOT_SKILL_DIR"
     sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/cmd.copilot.md" > "$COPILOT_SKILL_DIR/SKILL.md"
   fi
   cp "$SCRIPT_DIR/openai.yaml" "$SKILL_DIR/agents/openai.yaml" 2>/dev/null || true

--- a/install.sh
+++ b/install.sh
@@ -89,6 +89,13 @@ if [ "$UPDATE_ONLY" = true ]; then
   if [ -d "$CC_COMMANDS_DIR" ] && [ -f "$CC_COMMANDS_DIR/$SKILL_NAME.md" ]; then
     sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/cmd.claude-code.md" > "$CC_COMMANDS_DIR/$SKILL_NAME.md"
   fi
+  # Refresh the Copilot CLI skill (Copilot reads SKILL.md from its own skills
+  # dir; the shared ~/.agents/skills/<name>/SKILL.md is Codex-typed and would
+  # mis-identify the agent as codex when invoked from Copilot).
+  COPILOT_SKILL_DIR="$HOME/.copilot/skills/$SKILL_NAME"
+  if [ -d "$HOME/.copilot" ] && [ -f "$COPILOT_SKILL_DIR/SKILL.md" ]; then
+    sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/cmd.copilot.md" > "$COPILOT_SKILL_DIR/SKILL.md"
+  fi
   cp "$SCRIPT_DIR/openai.yaml" "$SKILL_DIR/agents/openai.yaml" 2>/dev/null || true
   chmod +x "$SKILL_DIR/scripts/"*.sh
   echo "  + updated scripts, templates, and SKILL.md"
@@ -154,6 +161,17 @@ if [ -d "$HOME/.claude" ]; then
   echo "  + installed /$CMD_NAME command to ~/.claude/commands/"
 fi
 
+# --- Install Copilot CLI skill ---
+# Copilot loads SKILL.md from ~/.copilot/skills/<name>/. The shared
+# ~/.agents/skills/<name>/SKILL.md is Codex-typed (whoami ... codex) and
+# would mis-identify a Copilot session — keep the Copilot copy separate.
+COPILOT_SKILL_DIR="$HOME/.copilot/skills/$CMD_NAME"
+if [ -d "$HOME/.copilot" ]; then
+  mkdir -p "$COPILOT_SKILL_DIR"
+  sed "s/__SKILL_NAME__/$CMD_NAME/g" "$SCRIPT_DIR/templates/cmd.copilot.md" > "$COPILOT_SKILL_DIR/SKILL.md"
+  echo "  + installed /$CMD_NAME skill to ~/.copilot/skills/"
+fi
+
 # --- Configure Codex sandbox (if Codex is installed) ---
 CODEX_CONFIG="$HOME/.codex/config.toml"
 if [ -f "$CODEX_CONFIG" ]; then
@@ -208,6 +226,7 @@ echo "    1. Restart your agent (Claude Code / Codex) to pick up the new skill"
 echo "    2. Run the command to join a team:"
 echo "       Claude Code:  /$CMD_NAME"
 echo "       Codex:        \$$CMD_NAME"
+echo "       Copilot CLI:  /$CMD_NAME"
 echo "       It will prompt for team name and agent name on first run."
 echo ""
 echo "  Docs: https://agmsg.cc/"

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -72,14 +72,16 @@ if [ -f "$MARKER" ]; then
   [ -z "$INTERVAL" ] && INTERVAL=$("$SCRIPT_DIR/config.sh" get hook.check_interval 60)
   case "$INTERVAL" in ''|*[!0-9]*) INTERVAL=60 ;; esac
   if [ $(( now - last )) -lt "$INTERVAL" ]; then
-    if [ "$TYPE" = "codex" ]; then
-      cat <<'ENDJSON'
+    case "$TYPE" in
+      codex|copilot)
+        cat <<'ENDJSON'
 {
   "continue": true,
   "systemMessage": "agmsg: check skipped (cooldown)"
 }
 ENDJSON
-    fi
+        ;;
+    esac
     exit 0
   fi
 fi
@@ -129,14 +131,16 @@ done
 
 # No new messages
 if [ -z "$OUTPUT" ]; then
-  if [ "$TYPE" = "codex" ]; then
-    cat <<'ENDJSON'
+  case "$TYPE" in
+    codex|copilot)
+      cat <<'ENDJSON'
 {
   "continue": true,
   "systemMessage": "agmsg: no new messages"
 }
 ENDJSON
-  fi
+      ;;
+  esac
   exit 0
 fi
 

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -40,6 +40,7 @@ resolve_hooks_file() {
     claude-code) echo "$project/.claude/settings.local.json" ;;
     codex)       echo "$project/.codex/hooks.json" ;;
     gemini|antigravity) echo "$project/.agent/rules/agmsg.md" ;;
+    copilot)     echo "$project/.github/hooks/agmsg.json" ;;
     *) echo "Unknown agent type: $type" >&2; return 1 ;;
   esac
 }
@@ -129,6 +130,51 @@ prune_empty_hooks() {
   "
 }
 
+apply_settings_copilot() {
+  local type="$1"
+  local project="$2"
+  local mode="$3"
+  local hooks_file
+  hooks_file=$(resolve_hooks_file "$type" "$project")
+
+  # Always strip first so re-applying the same mode is a no-op rewrite, and
+  # turn -> off cleanly removes the file.
+  rm -f "$hooks_file"
+
+  case "$mode" in
+    turn)
+      mkdir -p "$(dirname "$hooks_file")"
+      local cmd="'$SKILL_DIR/scripts/check-inbox.sh' '$type' '$project'"
+      # json_quote handles quoting + escaping for arbitrary command strings
+      # (project paths may contain shell-special chars).
+      local cmd_json
+      cmd_json=$(sqlite3 :memory: "SELECT json_quote('$(printf '%s' "$cmd" | sed "s/'/''/g")');")
+      # Use PascalCase 'Stop' trigger so the input payload field names match
+      # the snake_case form (session_id) that check-inbox.sh already parses.
+      cat <<EOF > "$hooks_file"
+{
+  "version": 1,
+  "hooks": {
+    "Stop": [
+      {
+        "type": "command",
+        "bash": $cmd_json,
+        "timeoutSec": 30
+      }
+    ]
+  }
+}
+EOF
+      ;;
+    monitor|both)
+      echo "Error: '$mode' mode is not supported for $type (no Monitor-tool equivalent). Use 'turn' or 'off'." >&2
+      return 1
+      ;;
+    off)
+      ;;
+  esac
+}
+
 apply_settings_gemini() {
   local type="$1"
   local project="$2"
@@ -166,6 +212,11 @@ apply_settings() {
 
   if [ "$type" = "gemini" ] || [ "$type" = "antigravity" ]; then
     apply_settings_gemini "$type" "$project" "$mode"
+    return
+  fi
+
+  if [ "$type" = "copilot" ]; then
+    apply_settings_copilot "$type" "$project" "$mode"
     return
   fi
 
@@ -316,7 +367,7 @@ do_status() {
   if [ -n "$TYPE" ] && [ -n "$PROJECT" ]; then
     local hf
     hf=$(resolve_hooks_file "$TYPE" "$PROJECT")
-    if [ "$TYPE" = "gemini" ] || [ "$TYPE" = "antigravity" ]; then
+    if [ "$TYPE" = "gemini" ] || [ "$TYPE" = "antigravity" ] || [ "$TYPE" = "copilot" ]; then
       local mode="off"
       if [ -f "$hf" ]; then
         mode="turn"
@@ -347,7 +398,7 @@ do_status() {
     fi
   fi
 
-  if [ -n "$TYPE" ] && [ -n "$PROJECT" ] && [ "$TYPE" != "gemini" ] && [ "$TYPE" != "antigravity" ]; then
+  if [ -n "$TYPE" ] && [ -n "$PROJECT" ] && [ "$TYPE" != "gemini" ] && [ "$TYPE" != "antigravity" ] && [ "$TYPE" != "copilot" ]; then
     local hooks_file
     hooks_file=$(resolve_hooks_file "$TYPE" "$PROJECT")
     if [ -f "$hooks_file" ]; then

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -137,21 +137,34 @@ apply_settings_copilot() {
   local hooks_file
   hooks_file=$(resolve_hooks_file "$type" "$project")
 
-  # Always strip first so re-applying the same mode is a no-op rewrite, and
-  # turn -> off cleanly removes the file.
+  # Validate the mode BEFORE touching any existing file. Rejecting
+  # monitor/both must not destroy a working turn hook.
+  case "$mode" in
+    turn|off) ;;
+    monitor|both)
+      echo "Error: '$mode' mode is not supported for $type (no Monitor-tool equivalent). Use 'turn' or 'off'." >&2
+      return 1
+      ;;
+    *)
+      echo "Unknown mode: $mode (use turn|off)" >&2
+      return 1
+      ;;
+  esac
+
+  # Strip first so re-applying turn is an idempotent rewrite and turn->off
+  # cleanly removes the file.
   rm -f "$hooks_file"
 
-  case "$mode" in
-    turn)
-      mkdir -p "$(dirname "$hooks_file")"
-      local cmd="'$SKILL_DIR/scripts/check-inbox.sh' '$type' '$project'"
-      # json_quote handles quoting + escaping for arbitrary command strings
-      # (project paths may contain shell-special chars).
-      local cmd_json
-      cmd_json=$(sqlite3 :memory: "SELECT json_quote('$(printf '%s' "$cmd" | sed "s/'/''/g")');")
-      # Use PascalCase 'Stop' trigger so the input payload field names match
-      # the snake_case form (session_id) that check-inbox.sh already parses.
-      cat <<EOF > "$hooks_file"
+  if [ "$mode" = "turn" ]; then
+    mkdir -p "$(dirname "$hooks_file")"
+    local cmd="'$SKILL_DIR/scripts/check-inbox.sh' '$type' '$project'"
+    # json_quote handles JSON-string escaping for arbitrary command strings
+    # (project paths may contain JSON-special chars).
+    local cmd_json
+    cmd_json=$(sqlite3 :memory: "SELECT json_quote('$(printf '%s' "$cmd" | sed "s/'/''/g")');")
+    # Use PascalCase 'Stop' trigger so the input payload field names match
+    # the snake_case form (session_id) that check-inbox.sh already parses.
+    cat <<EOF > "$hooks_file"
 {
   "version": 1,
   "hooks": {
@@ -165,14 +178,7 @@ apply_settings_copilot() {
   }
 }
 EOF
-      ;;
-    monitor|both)
-      echo "Error: '$mode' mode is not supported for $type (no Monitor-tool equivalent). Use 'turn' or 'off'." >&2
-      return 1
-      ;;
-    off)
-      ;;
-  esac
+  fi
 }
 
 apply_settings_gemini() {

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -15,8 +15,8 @@ PROJECT_PATH="${4:?Missing project_path}"
 # here. Allowing arbitrary strings silently mis-registers an agent and
 # makes monitor mode fail with a confusing "no joined teams" message.
 case "$AGENT_TYPE" in
-  claude-code|codex|gemini|antigravity) ;;
-  *) echo "Unknown agent type: '$AGENT_TYPE' (supported: claude-code, codex, gemini, antigravity)" >&2; exit 1 ;;
+  claude-code|codex|gemini|antigravity|copilot) ;;
+  *) echo "Unknown agent type: '$AGENT_TYPE' (supported: claude-code, codex, gemini, antigravity, copilot)" >&2; exit 1 ;;
 esac
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/whoami.sh
+++ b/scripts/whoami.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Not joined:      not_joined=true available_teams=<t1,t2,...> (or "none")
 #
 # Usage: whoami.sh <project_path> <type>
-#   type: claude-code, codex, gemini, etc.
+#   type: claude-code, codex, gemini, antigravity, copilot
 
 PROJECT_PATH="${1:?Usage: whoami.sh <project_path> <type>}"
 AGENT_TYPE="${2:?Usage: whoami.sh <project_path> <type>}"

--- a/templates/cmd.copilot.md
+++ b/templates/cmd.copilot.md
@@ -1,0 +1,136 @@
+---
+name: __SKILL_NAME__
+description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
+---
+
+Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER directly read or edit config files, DB, or team data. There is NO register.sh — use join.sh to join a team.**
+
+## Identity
+
+If you already know your AGENT and TEAMS from a previous `/__SKILL_NAME__` call in this session, skip to **Execute** below.
+
+Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" copilot`
+
+Four possible outputs:
+
+**A) Single identity:**
+`agent=<name> teams=<t1,t2,...> type=copilot project=<path>`
+→ Remember AGENT and TEAMS, then go to **Execute**.
+
+**B) Multiple identities:**
+`multiple=true agents=<n1,n2,...> teams=<t1,t2,...> type=copilot project=<path>`
+→ Ask the user which agent name to use for this session, then go to **Execute**.
+
+**C) Not in a team:**
+`not_joined=true available_teams=<t1,t2,...>` (or `available_teams=none`)
+→ Show the user the available teams from the output, then:
+
+  > **First-time setup required.**
+  > Joining a team so this agent can send and receive messages.
+  > - **Team name**: a group of agents that can message each other (available: <list from output>)
+  > - **Agent name**: this agent's identity within the team
+
+  1. Ask: "Enter a team name (joins existing or creates new)"
+  2. Ask: "Enter a name for this agent"
+  3. **You MUST use join.sh** — run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> copilot "$(pwd)"`
+  4. Show the result and explain:
+
+  > **Joined!** You can now use `/__SKILL_NAME__` to check and send messages.
+  > - `/__SKILL_NAME__` — check inbox
+  > - `/__SKILL_NAME__ send <agent> <message>` — send a message
+  > - `/__SKILL_NAME__ team` — list team members
+  > - `/__SKILL_NAME__ history` — message history
+
+  5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
+
+     ```
+     Choose delivery mode for incoming messages:
+
+       1) turn — Check inbox at the end of each assistant turn
+                  Stop hook pulls after each response.
+
+       2) off  — No automatic delivery
+                  Manual /__SKILL_NAME__ only.
+
+     [1]:
+     ```
+
+     - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
+     - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
+       `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> copilot "$(pwd)"`
+     - Copilot CLI has no Monitor-tool equivalent, so `monitor` and `both` modes are not offered here.
+
+  6. Then check inbox for the newly joined team.
+
+**D) Suggestions for reuse:**
+`suggest=true agents=<n1,n2,...> teams=<t1,t2,...> type=copilot project=<path> available_teams=<t1,t2,...>`
+→ No exact registration exists for this project, but there are same-type agent names registered elsewhere.
+
+  1. Show the suggested agent names to the user.
+  2. Ask whether to reuse one of those names or choose a new one.
+  3. Ask for the team name to join (existing or new).
+  4. Run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> copilot "$(pwd)"`
+  5. Then continue with the normal post-join flow above.
+
+## Execute
+
+**Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
+
+**If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
+1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
+2. Do NOT ask the user what to do — just run the inbox check.
+3. If there are messages, read and respond appropriately. To reply:
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+
+If argument is "history":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/history.sh $TEAM $AGENT`
+
+If argument is "team":
+1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM`
+
+If argument starts with "send" (e.g. "send misaki check the server"):
+1. Parse target agent and message from the arguments
+2. Determine which team the target agent belongs to, then run:
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+
+If argument is "config":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh show`
+2. Show the output to the user.
+
+If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
+1. Parse key and value from the arguments.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
+
+
+If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
+1. Parse the new role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" copilot` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> copilot "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
+4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Copilot CLI has no Monitor tool, so receive still covers all of your registered roles in this project.)"
+
+If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
+1. Parse the role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" copilot <name>` to remove that role's registration.
+3. If the session's active FROM was `<name>`, clear that state.
+4. Tell the user: "Dropped role `<name>` from this project."
+
+If argument is "mode" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status copilot "$(pwd)"`
+2. Show the output to the user.
+
+If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
+1. Parse the mode. Copilot supports only `turn` and `off` — reject `monitor` and `both` with: "Copilot CLI has no Monitor tool; only `turn` or `off` modes are supported."
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> copilot "$(pwd)"`
+
+If argument is "hook on" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn copilot "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior)."
+
+If argument is "hook off" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off copilot "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'off'."
+
+If argument is "reset":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" copilot`
+2. Tell the user the result.

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -518,6 +518,86 @@ JSON
   [[ "$output" =~ "mode: turn" ]]
 }
 
+# --- copilot agent tests ---
+
+@test "delivery set turn (copilot): writes .github/hooks/agmsg.json with version + Stop entry" {
+  run bash "$SCRIPTS/delivery.sh" set turn copilot "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Delivery mode set to 'turn'" ]]
+  local hook_file="$TEST_PROJECT/.github/hooks/agmsg.json"
+  [ -f "$hook_file" ]
+  # JSON sanity: version=1, Stop entry references check-inbox.sh
+  local v
+  v=$(sqlite3 :memory: "SELECT json_extract(readfile('$hook_file'), '\$.version');")
+  [ "$v" = "1" ]
+  local cmd
+  cmd=$(sqlite3 :memory: "SELECT json_extract(readfile('$hook_file'), '\$.hooks.Stop[0].bash');")
+  [[ "$cmd" =~ "check-inbox.sh" ]]
+  [[ "$cmd" =~ "copilot" ]]
+}
+
+@test "delivery set off (copilot): removes the hook file" {
+  bash "$SCRIPTS/delivery.sh" set turn copilot "$TEST_PROJECT"
+  [ -f "$TEST_PROJECT/.github/hooks/agmsg.json" ]
+  run bash "$SCRIPTS/delivery.sh" set off copilot "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_PROJECT/.github/hooks/agmsg.json" ]
+}
+
+@test "delivery set monitor (copilot): rejected; no hook file written" {
+  run bash "$SCRIPTS/delivery.sh" set monitor copilot "$TEST_PROJECT"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "not supported" ]]
+  [ ! -f "$TEST_PROJECT/.github/hooks/agmsg.json" ]
+}
+
+@test "delivery set both (copilot): rejected" {
+  run bash "$SCRIPTS/delivery.sh" set both copilot "$TEST_PROJECT"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "not supported" ]]
+}
+
+@test "delivery status (copilot): derives mode from hook file existence" {
+  run bash "$SCRIPTS/delivery.sh" status copilot "$TEST_PROJECT"
+  [[ "$output" =~ "mode: off" ]]
+
+  bash "$SCRIPTS/delivery.sh" set turn copilot "$TEST_PROJECT"
+  run bash "$SCRIPTS/delivery.sh" status copilot "$TEST_PROJECT"
+  [[ "$output" =~ "mode: turn" ]]
+}
+
+@test "delivery set turn (copilot): idempotent across repeats" {
+  bash "$SCRIPTS/delivery.sh" set turn copilot "$TEST_PROJECT"
+  bash "$SCRIPTS/delivery.sh" set turn copilot "$TEST_PROJECT"
+  bash "$SCRIPTS/delivery.sh" set turn copilot "$TEST_PROJECT"
+  local n
+  n=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$TEST_PROJECT/.github/hooks/agmsg.json'), '\$.hooks.Stop'));")
+  [ "$n" = "1" ]
+}
+
+@test "check-inbox (copilot): emits JSON cooldown message inside cooldown window" {
+  bash "$SCRIPTS/join.sh" testteam alice copilot "$TEST_PROJECT"
+  # Prime the cooldown marker
+  echo '{}' | bash "$SCRIPTS/check-inbox.sh" copilot "$TEST_PROJECT" >/dev/null
+  # Second call within cooldown: copilot should get JSON, not silence
+  run bash -c "echo '{}' | bash '$SCRIPTS/check-inbox.sh' copilot '$TEST_PROJECT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "agmsg: check skipped (cooldown)" ]]
+  [[ "$output" =~ "\"continue\"" ]]
+}
+
+@test "check-inbox (copilot): emits decision=block JSON when new messages arrive" {
+  bash "$SCRIPTS/join.sh" testteam alice copilot "$TEST_PROJECT"
+  bash "$SCRIPTS/join.sh" testteam bob   copilot "$TEST_PROJECT"
+  # Push cooldown window into the past so the first invocation is not skipped.
+  bash "$SCRIPTS/config.sh" set delivery.turn.check_interval 0 >/dev/null
+  bash "$SCRIPTS/send.sh" testteam bob alice "ping copilot"
+  run bash -c "echo '{}' | bash '$SCRIPTS/check-inbox.sh' copilot '$TEST_PROJECT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "\"decision\": \"block\"" ]]
+  [[ "$output" =~ "ping copilot" ]]
+}
+
 
 
 

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -551,6 +551,28 @@ JSON
   [ ! -f "$TEST_PROJECT/.github/hooks/agmsg.json" ]
 }
 
+# Regression for a Copilot review finding: the unsupported-mode arms used to
+# `rm -f` the hook file before validating the mode, so fat-fingering
+# `mode monitor` on a project with a working `turn` config silently wiped
+# delivery. Validation must come first.
+@test "delivery set monitor (copilot): does NOT delete an existing turn hook" {
+  bash "$SCRIPTS/delivery.sh" set turn copilot "$TEST_PROJECT" >/dev/null
+  [ -f "$TEST_PROJECT/.github/hooks/agmsg.json" ]
+  run bash "$SCRIPTS/delivery.sh" set monitor copilot "$TEST_PROJECT"
+  [ "$status" -ne 0 ]
+  [ -f "$TEST_PROJECT/.github/hooks/agmsg.json" ]
+  local n
+  n=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$TEST_PROJECT/.github/hooks/agmsg.json'), '\$.hooks.Stop'));")
+  [ "$n" = "1" ]
+}
+
+@test "delivery set both (copilot): does NOT delete an existing turn hook" {
+  bash "$SCRIPTS/delivery.sh" set turn copilot "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" set both copilot "$TEST_PROJECT"
+  [ "$status" -ne 0 ]
+  [ -f "$TEST_PROJECT/.github/hooks/agmsg.json" ]
+}
+
 @test "delivery set both (copilot): rejected" {
   run bash "$SCRIPTS/delivery.sh" set both copilot "$TEST_PROJECT"
   [ "$status" -ne 0 ]

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -72,6 +72,38 @@ teardown() {
 # previous watch.sh running but invisible to every cleanup pathway (pidfile
 # got overwritten). watch.sh now self-cleans the previous holder of its
 # pidfile at startup. See #66.
+@test "install: drops a Copilot SKILL.md when ~/.copilot exists" {
+  mkdir -p "$FAKE_HOME/.copilot"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  local copilot_skill="$FAKE_HOME/.copilot/skills/agmsg/SKILL.md"
+  [ -f "$copilot_skill" ]
+  # The Copilot SKILL.md must drive whoami with type=copilot, not codex,
+  # otherwise Copilot sessions get mis-identified.
+  grep -q "whoami.sh \"\$(pwd)\" copilot" "$copilot_skill"
+  ! grep -q "whoami.sh \"\$(pwd)\" codex" "$copilot_skill"
+  # Frontmatter has the substituted skill name.
+  grep -q "^name: agmsg" "$copilot_skill"
+}
+
+@test "install: skips Copilot skill when ~/.copilot is absent" {
+  # Make sure ~/.copilot isn't there
+  rm -rf "$FAKE_HOME/.copilot"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  [ ! -d "$FAKE_HOME/.copilot" ]
+}
+
+@test "install --update: refreshes the Copilot skill if it was previously installed" {
+  mkdir -p "$FAKE_HOME/.copilot"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  local copilot_skill="$FAKE_HOME/.copilot/skills/agmsg/SKILL.md"
+  [ -f "$copilot_skill" ]
+  # Mutate the file so we can verify --update overwrites.
+  echo "tampered" > "$copilot_skill"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  ! grep -q "^tampered$" "$copilot_skill"
+  grep -q "whoami.sh \"\$(pwd)\" copilot" "$copilot_skill"
+}
+
 @test "install: watch.sh self-cleans a prior watcher on re-invocation for the same sid" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
   bash "$SK/scripts/join.sh" demo alice claude-code /tmp/install-projA

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -104,6 +104,22 @@ teardown() {
   grep -q "whoami.sh \"\$(pwd)\" copilot" "$copilot_skill"
 }
 
+# Regression for a Copilot review finding: --update used to gate the Copilot
+# skill refresh on the SKILL.md already existing, which meant users who had
+# installed agmsg before the Copilot integration landed could never gain the
+# skill via the documented upgrade path. --update must install it for them.
+@test "install --update: installs Copilot skill for upgraders without prior skill" {
+  # First install without ~/.copilot, simulating a Copilot-less environment
+  # at the time the user originally installed agmsg.
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  [ ! -d "$FAKE_HOME/.copilot/skills/agmsg" ]
+  # User then installs Copilot CLI and runs --update.
+  mkdir -p "$FAKE_HOME/.copilot"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  [ -f "$FAKE_HOME/.copilot/skills/agmsg/SKILL.md" ]
+  grep -q "whoami.sh \"\$(pwd)\" copilot" "$FAKE_HOME/.copilot/skills/agmsg/SKILL.md"
+}
+
 @test "install: watch.sh self-cleans a prior watcher on re-invocation for the same sid" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
   bash "$SK/scripts/join.sh" demo alice claude-code /tmp/install-projA

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -143,6 +143,23 @@ for SKILL_DIR in "${SKILL_DIRS[@]}"; do
         fi
       done
     done <<< "$projects"
+
+    # --- Copilot CLI project-scoped hook file cleanup ---
+    copilot_projects=$(sqlite3 -separator '	' :memory: \
+      ".param set :json '$(sed "s/'/''/g" "$config")'" \
+      "SELECT json_extract(value, '$.project') FROM json_each(json_extract(:json, '$.agents'))
+       WHERE json_extract(value, '$.type') = 'copilot'
+         AND json_extract(value, '$.project') IS NOT NULL;" 2>/dev/null || true)
+
+    while IFS= read -r project; do
+      [ -n "$project" ] || continue
+      copilot_hook="$project/.github/hooks/agmsg.json"
+      if [ -f "$copilot_hook" ] && grep -q "$(basename "$SKILL_DIR")" "$copilot_hook" 2>/dev/null; then
+        rm "$copilot_hook"
+        echo "  - removed agmsg Copilot hook from $project"
+        REMOVED=true
+      fi
+    done <<< "$copilot_projects"
   done
 done
 
@@ -153,6 +170,17 @@ for SKILL_DIR in "${SKILL_DIRS[@]}"; do
   if [ -f "$CC_CMD" ]; then
     rm "$CC_CMD"
     echo "  - removed /$SKILL_NAME from ~/.claude/commands/"
+    REMOVED=true
+  fi
+done
+
+# --- 2b. Remove Copilot CLI skill ---
+for SKILL_DIR in "${SKILL_DIRS[@]}"; do
+  SKILL_NAME="$(basename "$SKILL_DIR")"
+  COPILOT_SKILL="$HOME/.copilot/skills/$SKILL_NAME"
+  if [ -d "$COPILOT_SKILL" ]; then
+    rm -rf "$COPILOT_SKILL"
+    echo "  - removed /$SKILL_NAME skill from ~/.copilot/skills/"
     REMOVED=true
   fi
 done


### PR DESCRIPTION
## Summary

Adds GitHub Copilot CLI (the standalone `copilot` command) as a new `agent` axis driver. The integration follows the same shape as the existing Codex driver: `turn` / `off` only, with a project-scoped Stop hook that calls `check-inbox.sh` at the end of each assistant turn. `monitor` / `both` are rejected with a clear error (no Monitor-tool equivalent on Copilot CLI, same situation as Codex). Verified end-to-end against a live Copilot CLI session.

## Changes

- **New agent type `copilot`** in `scripts/join.sh` allowlist and `scripts/whoami.sh`.
- **delivery driver** (`apply_settings_copilot`) writes `<project>/.github/hooks/agmsg.json` as `{"version":1,"hooks":{"Stop":[...]}}`. PascalCase `Stop` is used so the payload field names are snake_case (`session_id`) — the same shape `check-inbox.sh` already parses for Codex. `do_status` derives mode from file existence; turn↔off transitions are idempotent.
- **install / uninstall**: drops `~/.copilot/skills/<cmd>/SKILL.md` (generated from new `templates/cmd.copilot.md`) when `~/.copilot` exists. Kept separate from the Codex-typed `~/.agents/skills/<cmd>/SKILL.md` so Copilot sessions don't run `whoami.sh ... codex` by mistake. `uninstall.sh` removes the Copilot skill dir and each project's `.github/hooks/agmsg.json`.
- **`check-inbox.sh`** extends the existing Codex JSON output path (`{"continue":true,...}` / `{"decision":"block","reason":"..."}`) to `copilot`. The block shape is what Copilot's `Stop` hook accepts.

## UX caveat — hook activation requires session restart

After `/agmsg` joins a team and runs `delivery.sh set turn copilot`, the newly written `.github/hooks/agmsg.json` is **not picked up in the same session** — Copilot CLI scans hook files at session start, so the user has to `/exit` and re-launch `copilot` once for the Stop hook to begin firing. Verifying this surfaced the same behavior on the existing Codex `.codex/hooks.json` path, so it's a shared turn-mode property rather than something to paper over Copilot-only.

## Test plan

- [x] `bats tests/` → 172/172. 13 new cases covering delivery wiring, JSON shape, install/update, monitor/both rejection, and two regressions caught during self-review (below).
- [x] End-to-end against a live Copilot CLI session: `/agmsg` join → `mode turn` → peer (Claude Code on `monitor`) sends a message → Copilot next turn surfaces the injected `decision:block` payload. Bidirectional.

## Commits

- `91c264e` `feat: add GitHub Copilot CLI support (turn mode)` — Copilot driver, install/uninstall, docs, 10 new bats cases.
- `d19ec64` `fix(copilot): repair two regressions surfaced in self-review` — a self review of the first commit caught two defects, fixed here with regression tests:
  - `apply_settings_copilot` used to `rm -f` the hook file before validating the requested mode, so `set monitor copilot` on a working turn config silently wiped the file en route to the error. Validation now runs before any filesystem mutation.
  - `install.sh --update` gated the Copilot SKILL.md refresh on the skill file already existing, making the documented upgrade path a no-op for anyone who had agmsg installed before this PR landed. Now matches the fresh-install path.