### PR TITLE
feat(plugin): add .claude-plugin/ manifests for Claude Code marketplace (#76)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "fujibee-agmsg",
+  "description": "Hosts the agmsg plugin — cross-agent messaging for CLI AI agents over a shared local SQLite store.",
+  "owner": {
+    "name": "fujibee",
+    "email": "fujibee@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "agmsg",
+      "source": "./",
+      "description": "Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, Antigravity, and any other CLI AI agent. No daemon, no network, no dependencies beyond bash and sqlite3."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "agmsg",
+  "description": "Cross-agent messaging via SQLite. Send messages between CLI AI agents. No daemon, no network.",
+  "version": "1.0.0",
+  "author": {
+    "name": "fujibee"
+  },
+  "homepage": "https://agmsg.cc",
+  "repository": "https://github.com/fujibee/agmsg",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "codex",
+    "gemini-cli",
+    "copilot-cli",
+    "messaging",
+    "multi-agent",
+    "sqlite",
+    "cli"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` so `fujibee/agmsg` can be added as a Claude Code plugin marketplace and the `agmsg` plugin name is claimed in the marketplace namespace.

Part of epic #75 (preemptive name registration). Lands the marketplace + plugin manifests; functional plugin install (the `skills/`/`agents/` content) is a follow-up — the canonical install path is still `bash install.sh`.

## What's in the PR

- `.claude-plugin/marketplace.json` — marketplace named `fujibee-agmsg`, lists one plugin (`agmsg`) sourced at `./`.
- `.claude-plugin/plugin.json` — plugin manifest with name, description, version, author, homepage, repository, license, keywords.

## Validation

```
$ claude plugin validate .
Validating marketplace manifest: .../.claude-plugin/marketplace.json
✔ Validation passed
```

## End-user effect

After this merges, anyone can do:

```
/plugin marketplace add fujibee/agmsg
/plugin install agmsg@fujibee-agmsg
```

The plugin will install (the manifests are valid), but won't yet ship a working skill — that's a follow-up. The install.sh-based install path is the canonical install for now.

## Why now (not after functional plugin content is ready)

- Claims the `agmsg` name in the marketplace namespace before anyone else can submit a competing plugin under the same name.
- Unblocks #77 (Anthropic community marketplace submission), which requires a validating plugin manifest.
- Cheap to land, near-zero risk: just two manifest files in a hidden directory; nothing else changes.

## Test plan

- [ ] `claude plugin validate .` passes ✓ (already confirmed locally).
- [ ] Existing `install.sh` regression: no change to existing flow.

## Cross-links

- Closes #76 partially (manifests only — functional plugin content tracked as follow-up).
- Epic #75.