### PR TITLE
fix(plugin): SKILL.md self-bootstrap and substitute name placeholder (closes #83)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -9,10 +9,31 @@ description: Cross-agent messaging via SQLite. Send messages between Claude Code
 
 ## How to use
 
+### Step 0: First-run bootstrap
+
+agmsg keeps its SQLite database, team registry, and runtime state under `~/.agents/skills/agmsg/`. The `./install.sh` install path creates that tree; the Claude Code plugin install path does not (the plugin marketplace flow only drops the skill content into `~/.claude/plugins/cache/`). Before any other command, bootstrap if needed:
+
+```bash
+if [ ! -d ~/.agents/skills/agmsg ]; then
+  # Locate the plugin install script (any version), run it once.
+  installer=$(ls ~/.claude/plugins/cache/fujibee-agmsg/agmsg/*/install.sh 2>/dev/null | head -1)
+  if [ -n "$installer" ]; then
+    bash "$installer" --cmd agmsg
+  else
+    echo "agmsg not installed. Either:" >&2
+    echo "  - run ./install.sh in the agmsg repo, or" >&2
+    echo "  - install via /plugin marketplace add fujibee/agmsg && /plugin install agmsg@fujibee-agmsg" >&2
+    exit 1
+  fi
+fi
+```
+
+After this runs once, `~/.agents/skills/agmsg/` is populated and you can skip Step 0 on future invocations.
+
 ### Step 1: Check identity
 
 ```bash
-~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" <type>
+~/.agents/skills/agmsg/scripts/whoami.sh "$(pwd)" <type>
 # type: claude-code, codex, gemini, antigravity, copilot
 # Returns: agent=... / multiple=true ... / suggest=true ... / not_joined=true ...
 ```
@@ -22,7 +43,7 @@ description: Cross-agent messaging via SQLite. Send messages between Claude Code
 Ask the user for a team name and agent name, then run:
 
 ```bash
-~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> <type> "$(pwd)"
+~/.agents/skills/agmsg/scripts/join.sh <team> <agent_name> <type> "$(pwd)"
 ```
 
 Do NOT manually edit config files. Always use join.sh.
@@ -33,29 +54,29 @@ Do NOT manually edit config files. Always use join.sh.
 
 ```bash
 # Check inbox (marks messages as read) — DEFAULT action
-~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh <team> <agent_id>
+~/.agents/skills/agmsg/scripts/inbox.sh <team> <agent_id>
 
 # Send a message
-~/.agents/skills/__SKILL_NAME__/scripts/send.sh <team> <from_agent> <to_agent> "<message>"
+~/.agents/skills/agmsg/scripts/send.sh <team> <from_agent> <to_agent> "<message>"
 
 # Message history
-~/.agents/skills/__SKILL_NAME__/scripts/history.sh <team> [agent_id] [limit]
+~/.agents/skills/agmsg/scripts/history.sh <team> [agent_id] [limit]
 
 # List team members
-~/.agents/skills/__SKILL_NAME__/scripts/team.sh <team>
+~/.agents/skills/agmsg/scripts/team.sh <team>
 
 # Leave a team
-~/.agents/skills/__SKILL_NAME__/scripts/leave.sh <team> <agent_id>
+~/.agents/skills/agmsg/scripts/leave.sh <team> <agent_id>
 
 # Rename a team (moves dir, updates config + messages).
 # After renaming, each existing member should re-run whoami.sh to refresh
 # their cached team name in any running session.
-~/.agents/skills/__SKILL_NAME__/scripts/rename-team.sh <old_team> <new_team>
+~/.agents/skills/agmsg/scripts/rename-team.sh <old_team> <new_team>
 
 # Clear registrations for the current project/type.
 # A trailing <session_id> additionally releases any actas exclusivity locks
 # this session held on <agent_id> so peers can pick them up immediately.
-~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" <type> [agent_id] [session_id]
+~/.agents/skills/agmsg/scripts/reset.sh "$(pwd)" <type> [agent_id] [session_id]
 
 # Set delivery mode for this project. Replaces the legacy hook.sh on/off,
 # which is kept as a deprecated alias only.
@@ -63,8 +84,8 @@ Do NOT manually edit config files. Always use join.sh.
 #   turn    — Stop-hook pulls at the end of each assistant turn
 #   both    — monitor primary, turn as fallback
 #   off     — no automatic delivery
-~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> <type> "$(pwd)"
-~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status <type> "$(pwd)"
+~/.agents/skills/agmsg/scripts/delivery.sh set <mode> <type> "$(pwd)"
+~/.agents/skills/agmsg/scripts/delivery.sh status <type> "$(pwd)"
 
 # Multiple roles per project (one CC = one active role).
 # Claude Code: `actas` claims an exclusivity lock for <name> across sessions
@@ -72,8 +93,8 @@ Do NOT manually edit config files. Always use join.sh.
 # subscribing to <name> while this session holds the lock. `drop` releases.
 # Codex: actas is send-side only (no stable session_id during slash commands
 # → no peer-visible lock). See README "Codex caveat" for details.
-~/.agents/skills/__SKILL_NAME__/scripts/actas-claim.sh "$(pwd)" <type> <name> "$session_id"
-~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" <type> <name> "$session_id"
+~/.agents/skills/agmsg/scripts/actas-claim.sh "$(pwd)" <type> <name> "$session_id"
+~/.agents/skills/agmsg/scripts/reset.sh "$(pwd)" <type> <name> "$session_id"
 
 # (Both of the above are normally driven by `/agmsg actas <name>` and
 #  `/agmsg drop <name>` slash commands, which also handle the Monitor
@@ -82,8 +103,8 @@ Do NOT manually edit config files. Always use join.sh.
 
 ## Architecture
 
-- **Storage**: SQLite with WAL mode in `~/.agents/skills/__SKILL_NAME__/db/messages.db`
-- **Teams**: `~/.agents/skills/__SKILL_NAME__/teams/<name>/config.json`
+- **Storage**: SQLite with WAL mode in `~/.agents/skills/agmsg/db/messages.db`
+- **Teams**: `~/.agents/skills/agmsg/teams/<name>/config.json`
 - **Concurrency**: WAL allows multiple readers + 1 writer without conflicts
 - **No daemon**: Direct DB access via `sqlite3` CLI
 - **Dependencies**: bash, sqlite3 (no python3 required)

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -120,6 +120,40 @@ teardown() {
   grep -q "whoami.sh \"\$(pwd)\" copilot" "$FAKE_HOME/.copilot/skills/agmsg/SKILL.md"
 }
 
+@test "plugin SKILL.md bootstrap: a fresh plugin install path can bootstrap ~/.agents/skills/agmsg" {
+  # Simulate the post-plugin-install state: no ~/.agents/skills/agmsg yet, but
+  # the plugin marketplace flow has populated the cache dir with a copy of the
+  # repo. Then run the Step 0 bootstrap snippet from SKILL.md and assert the
+  # canonical install location exists.
+  local plugin_dir="$FAKE_HOME/.claude/plugins/cache/fujibee-agmsg/agmsg/1.0.0"
+  mkdir -p "$plugin_dir"
+  cp -R "$REPO_ROOT/." "$plugin_dir/"
+  [ ! -d "$SK" ]  # canonical agmsg location absent
+
+  # Run the same shell snippet our SKILL.md prescribes as Step 0.
+  HOME="$FAKE_HOME" bash -c '
+    if [ ! -d ~/.agents/skills/agmsg ]; then
+      installer=$(ls ~/.claude/plugins/cache/fujibee-agmsg/agmsg/*/install.sh 2>/dev/null | head -1)
+      [ -n "$installer" ] && bash "$installer" --cmd agmsg
+    fi
+  '
+
+  [ -d "$SK" ]
+  [ -f "$SK/db/messages.db" ]
+  [ -f "$SK/scripts/whoami.sh" ]
+  # The substituted SKILL.md the installer drops should not still carry the
+  # __SKILL_NAME__ placeholder (Codex / Gemini / Antigravity all read it).
+  ! grep -q "__SKILL_NAME__" "$SK/SKILL.md"
+}
+
+# Regression guard for #83: the plugin's SKILL.md is consumed verbatim by the
+# Claude Code plugin install path, so it must not carry the install-time
+# __SKILL_NAME__ placeholder (which install.sh substitutes for the
+# generated-per-agent-type SKILL.md, but the plugin install does not).
+@test "plugin SKILL.md: repo SKILL.md has no unsubstituted __SKILL_NAME__ placeholder" {
+  ! grep -q "__SKILL_NAME__" "$REPO_ROOT/SKILL.md"
+}
+
 @test "install: watch.sh self-cleans a prior watcher on re-invocation for the same sid" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
   bash "$SK/scripts/join.sh" demo alice claude-code /tmp/install-projA


### PR DESCRIPTION
## Summary

The plugin marketplace install path (`/plugin install agmsg@fujibee-agmsg`) has two coupled problems that the `./install.sh` path hides:

1. **No state bootstrap.** Plugin install drops the repo into `~/.claude/plugins/cache/` but never creates `~/.agents/skills/agmsg/`, where the scripts expect the SQLite DB, team registry, and runtime state. The first `scripts/send.sh` (or anything reading from that tree) would fail on a clean machine.
2. **Unsubstituted `__SKILL_NAME__`.** `install.sh` runs `sed s/__SKILL_NAME__/<cmd>/` when generating the installed SKILL.md from `templates/cmd.codex.md`. The plugin install path bypasses that substitution and ships the repo's `SKILL.md` verbatim, so every script path inside it was literally `~/.agents/skills/__SKILL_NAME__/scripts/...`.

This PR addresses both — minimal, no script changes, ready to ship before the EN buzz week.

## Changes

- **`SKILL.md`**:
  - Replace every `__SKILL_NAME__` with the literal `agmsg` (the plugin name is fixed by `plugin.json`; no per-user customisation on the plugin path).
  - New **Step 0: First-run bootstrap** at the top of "How to use" — a single shell snippet the agent runs once. It detects the canonical install dir, locates the plugin-shipped `install.sh` via a glob over the cache path, and runs it with `--cmd agmsg`. Idempotent: skipped on subsequent invocations.

## Tests

- `tests/test_install.bats`:
  - **New**: a bats case that materialises a fake plugin cache (`$FAKE_HOME/.claude/plugins/cache/fujibee-agmsg/agmsg/1.0.0/`), runs the Step 0 snippet from SKILL.md, and asserts the canonical install dir is populated end-to-end (DB present, scripts present, no leftover `__SKILL_NAME__`).
  - **New regression guard**: fails if `__SKILL_NAME__` ever reappears in the repo `SKILL.md` itself.

All 11 install tests pass locally.

## Out of scope

- The version single-source-of-truth concern (#84) is independent and handled separately.
- More structural plugin-install changes (B/C in #83) — not needed for the buzz week; option A is enough.

## Cross-links

- Closes #83.
- Related to epic #75 (name registration) — this unblocks the realistic functional path for users who install via the Anthropic community marketplace (#77).