### PR TITLE
fix(delivery): scope set turn/off watcher kill to the target project

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -350,13 +350,13 @@ do_set() {
       ;;
     turn)
       echo "Future sessions: Stop hook will check inbox between turns."
-      # If a watcher is alive in this session, ask Claude to stop it.
-      kill_all_watchers >/dev/null 2>&1 || true
+      # Stop only THIS project's watcher; other projects/sessions keep theirs.
+      kill_all_watchers "$PROJECT" >/dev/null 2>&1 || true
       emit_stop_directive
       ;;
     off)
       echo "Future sessions: no automatic delivery."
-      kill_all_watchers >/dev/null 2>&1 || true
+      kill_all_watchers "$PROJECT" >/dev/null 2>&1 || true
       emit_stop_directive
       ;;
   esac
@@ -439,6 +439,11 @@ do_status() {
 }
 
 kill_all_watchers() {
+  # With no argument, kills every running watch.sh (used by stop/restart).
+  # With a <project> argument, kills only watchers launched for that project
+  # path, so switching one project's delivery mode (set turn/off) never tears
+  # down another project's — or another concurrent session's — monitor.
+  local project="${1:-}"
   local killed=0
   if [ -d "$RUN_DIR" ]; then
     for f in "$RUN_DIR"/watch.*.pid; do
@@ -452,6 +457,15 @@ kill_all_watchers() {
         cmd=$(ps -o args= -p "$pid" 2>/dev/null || true)
         case "$cmd" in
           *"$SKILL_DIR/scripts/watch.sh"*)
+            # watch.sh argv is "watch.sh <session_id> <project> <type> [name]",
+            # so the project path is a space-delimited field. When scoped,
+            # skip (and preserve the pidfile of) watchers for other projects.
+            if [ -n "$project" ]; then
+              case " $cmd " in
+                *" $project "*) ;;
+                *) continue ;;
+              esac
+            fi
             kill "$pid" 2>/dev/null && killed=$((killed + 1)) ;;
           *) ;;  # not our watcher; leave it
         esac

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -759,3 +759,102 @@ JSON
   ! grep -q "for-bob-static" /tmp/agmsg-static
   rm -f /tmp/agmsg-static
 }
+
+# --- set turn/off is project-scoped: must not kill other projects' watchers ---
+
+@test "delivery set turn: kills only the target project's watcher, leaves other projects'" {
+  local proj_a="$TEST_PROJECT"
+  local proj_b
+  proj_b="$(mktemp -d)"
+
+  mkdir -p "$TEST_SKILL_DIR/teams/team-a" "$TEST_SKILL_DIR/teams/team-b"
+  cat > "$TEST_SKILL_DIR/teams/team-a/config.json" <<JSON
+{"name":"team-a","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$proj_a"}]}}}
+JSON
+  cat > "$TEST_SKILL_DIR/teams/team-b/config.json" <<JSON
+{"name":"team-b","agents":{"bob":{"registrations":[{"type":"claude-code","project":"$proj_b"}]}}}
+JSON
+
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sid-a "$proj_a" claude-code &
+  local pid_a=$!
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sid-b "$proj_b" claude-code &
+  local pid_b=$!
+  sleep 1
+  [ -f "$TEST_SKILL_DIR/run/watch.sid-a.pid" ]
+  [ -f "$TEST_SKILL_DIR/run/watch.sid-b.pid" ]
+
+  run bash "$SCRIPTS/delivery.sh" set turn claude-code "$proj_a"
+  [ "$status" -eq 0 ]
+  sleep 1
+
+  # Target project A: watcher killed, pidfile removed.
+  ! kill -0 "$pid_a" 2>/dev/null
+  [ ! -f "$TEST_SKILL_DIR/run/watch.sid-a.pid" ]
+
+  # Other project B: watcher and its pidfile must survive.
+  kill -0 "$pid_b" 2>/dev/null
+  [ -f "$TEST_SKILL_DIR/run/watch.sid-b.pid" ]
+
+  kill "$pid_b" 2>/dev/null || true
+  rm -rf "$proj_b"
+}
+
+@test "delivery set off: kills only the target project's watcher, leaves other projects'" {
+  local proj_a="$TEST_PROJECT"
+  local proj_b
+  proj_b="$(mktemp -d)"
+
+  mkdir -p "$TEST_SKILL_DIR/teams/team-a" "$TEST_SKILL_DIR/teams/team-b"
+  cat > "$TEST_SKILL_DIR/teams/team-a/config.json" <<JSON
+{"name":"team-a","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$proj_a"}]}}}
+JSON
+  cat > "$TEST_SKILL_DIR/teams/team-b/config.json" <<JSON
+{"name":"team-b","agents":{"bob":{"registrations":[{"type":"claude-code","project":"$proj_b"}]}}}
+JSON
+
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" off-a "$proj_a" claude-code &
+  local pid_a=$!
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" off-b "$proj_b" claude-code &
+  local pid_b=$!
+  sleep 1
+
+  run bash "$SCRIPTS/delivery.sh" set off claude-code "$proj_a"
+  [ "$status" -eq 0 ]
+  sleep 1
+
+  ! kill -0 "$pid_a" 2>/dev/null
+  [ ! -f "$TEST_SKILL_DIR/run/watch.off-a.pid" ]
+  kill -0 "$pid_b" 2>/dev/null
+  [ -f "$TEST_SKILL_DIR/run/watch.off-b.pid" ]
+
+  kill "$pid_b" 2>/dev/null || true
+  rm -rf "$proj_b"
+}
+
+@test "delivery stop: remains global — kills watchers across all projects" {
+  local proj_a="$TEST_PROJECT"
+  local proj_b
+  proj_b="$(mktemp -d)"
+
+  mkdir -p "$TEST_SKILL_DIR/teams/team-a" "$TEST_SKILL_DIR/teams/team-b"
+  cat > "$TEST_SKILL_DIR/teams/team-a/config.json" <<JSON
+{"name":"team-a","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$proj_a"}]}}}
+JSON
+  cat > "$TEST_SKILL_DIR/teams/team-b/config.json" <<JSON
+{"name":"team-b","agents":{"bob":{"registrations":[{"type":"claude-code","project":"$proj_b"}]}}}
+JSON
+
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" stop-a "$proj_a" claude-code &
+  local pid_a=$!
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" stop-b "$proj_b" claude-code &
+  local pid_b=$!
+  sleep 1
+
+  run bash "$SCRIPTS/delivery.sh" stop
+  [[ "$output" =~ "Killed 2 watch" ]]
+  sleep 1
+  ! kill -0 "$pid_a" 2>/dev/null
+  ! kill -0 "$pid_b" 2>/dev/null
+
+  rm -rf "$proj_b"
+}


### PR DESCRIPTION
## Scope
`delivery.sh set turn|off <project>` called `kill_all_watchers` with no
argument, which killed every running `watch.sh` across all projects and
sessions. Switching one project's delivery mode (e.g. `/agmsg mode turn`, or a
setup script arming codex `turn` mode for a new worktree) therefore tore down
unrelated sessions' real-time monitors.

This gives `kill_all_watchers` an optional `<project>` argument: when set, it
kills only watchers whose argv carries that project path (the project is a
space-delimited field in `watch.sh <session_id> <project> <type> [name]`) and
leaves other projects' watchers and pidfiles intact. `do_set` for `turn`/`off`
now pass `"$PROJECT"`; `stop`/`restart` keep the global kill (intended).

## Validation
- `bats tests/test_delivery.bats` → 66/66 passed, including the new
  project-scoped cases:
  - `set turn` / `set off` kill only the target project's watcher
  - `stop` remains global across all projects

## Post-Merge Checklist
None
