### PR TITLE
fix(delivery): avoid E2BIG on large settings.local.json (#95)

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -45,43 +45,48 @@ resolve_hooks_file() {
   esac
 }
 
-read_settings_escaped() {
-  if [ -f "$1" ]; then
-    sed "s/'/''/g" "$1"
-  else
-    echo '{}'
-  fi
-}
-
-# Strip any agmsg-owned hook entries from <event> in settings JSON. An entry
-# is "agmsg-owned" when one of its inner hooks references a path under our
-# skill directory. Result: the entire <event> array minus those entries
-# (or .hooks.<event> deleted if the array becomes empty).
-strip_agmsg_event() {
-  local settings_esc="$1"
+# Strip any agmsg-owned hook entries from <event> in the JSON at <path>. An
+# entry is "agmsg-owned" when one of its inner hooks references a path under
+# our skill directory. Result is written back to <path> atomically.
+#
+# Reads the settings via sqlite3's readfile() rather than interpolating the
+# file's contents into the SQL string. The old in-memory chain embedded the
+# settings blob 6× into a single sqlite3 argv element; on Linux that hits
+# the per-arg MAX_ARG_STRLEN cap (131072 bytes) once the settings file
+# crosses ~21 KB, so `delivery.sh set` failed with E2BIG (see #95). Using
+# readfile() keeps the file off the argv entirely.
+strip_agmsg_event_file() {
+  local path="$1"
   local event="$2"
-
-  sqlite3 :memory: "
+  local tmp
+  tmp=$(mktemp)
+  if ! sqlite3 :memory: "
+    WITH src AS (SELECT readfile('$path') AS j)
     SELECT CASE
-      WHEN json_extract('$settings_esc', '\$.hooks.$event') IS NULL THEN
-        '$settings_esc'
-      WHEN (SELECT count(*) FROM json_each(json_extract('$settings_esc', '\$.hooks.$event')) AS s
+      WHEN json_extract(src.j, '\$.hooks.$event') IS NULL THEN
+        src.j
+      WHEN (SELECT count(*) FROM json_each(json_extract(src.j, '\$.hooks.$event')) AS s
             WHERE NOT EXISTS (
               SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
               WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
             )) = 0 THEN
-        json_remove('$settings_esc', '\$.hooks.$event')
+        json_remove(src.j, '\$.hooks.$event')
       ELSE
-        json_set('$settings_esc', '\$.hooks.$event',
+        json_set(src.j, '\$.hooks.$event',
           (SELECT json_group_array(json(s.value))
-           FROM json_each(json_extract('$settings_esc', '\$.hooks.$event')) AS s
+           FROM json_each(json_extract(src.j, '\$.hooks.$event')) AS s
            WHERE NOT EXISTS (
              SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
              WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
            ))
         )
-    END;
-  "
+    END
+    FROM src;
+  " > "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  mv "$tmp" "$path"
 }
 
 # Wrap a POSIX shell command so Codex's Windows runner executes it through Git
@@ -95,11 +100,13 @@ windows_wrap() {
 }
 
 # Append a single entry of the form {"matcher":"","hooks":[{"type":"command","command":"<cmd>"}]}
-# to .hooks.<event>, creating arrays/objects as needed. For Codex agents (pass
-# "codex" as the 4th arg) the entry also carries a "commandWindows" so the hook
-# runs on native Windows; other agent types are unchanged.
-add_event_entry() {
-  local settings_esc="$1"
+# to .hooks.<event> in the JSON at <path>, creating arrays/objects as needed.
+# For Codex agents (pass "codex" as the 4th arg) the entry also carries a
+# "commandWindows" so the hook runs on native Windows; other agent types are
+# unchanged. Writes the result back to <path>. As with strip_agmsg_event_file,
+# the settings are read via readfile() rather than via argv (#95).
+add_event_entry_file() {
+  local path="$1"
   local event="$2"
   local cmd="$3"
   local hook_type="${4:-}"
@@ -114,11 +121,13 @@ add_event_entry() {
   local entry_esc
   entry_esc=$(printf '%s' "$entry" | sed "s/'/''/g")
 
-  sqlite3 :memory: "
+  local tmp
+  tmp=$(mktemp)
+  if ! sqlite3 :memory: "
     WITH base AS (
-      SELECT CASE WHEN json_extract('$settings_esc', '\$.hooks') IS NULL
-                  THEN json_set('$settings_esc', '\$.hooks', json('{}'))
-                  ELSE '$settings_esc' END AS s
+      SELECT CASE WHEN json_extract(readfile('$path'), '\$.hooks') IS NULL
+                  THEN json_set(readfile('$path'), '\$.hooks', json('{}'))
+                  ELSE readfile('$path') END AS s
     )
     SELECT CASE
       WHEN json_extract(s, '\$.hooks.$event') IS NULL THEN
@@ -133,20 +142,34 @@ add_event_entry() {
         )
     END
     FROM base;
-  "
+  " > "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  mv "$tmp" "$path"
 }
 
-# Drop the entire .hooks object if it ended up empty after stripping.
-prune_empty_hooks() {
-  local s="$1"
-  sqlite3 :memory: "
+# Drop the entire .hooks object if it ended up empty after stripping. Reads
+# and writes <path> via readfile() — see strip_agmsg_event_file for the
+# rationale (#95).
+prune_empty_hooks_file() {
+  local path="$1"
+  local tmp
+  tmp=$(mktemp)
+  if ! sqlite3 :memory: "
+    WITH src AS (SELECT readfile('$path') AS j)
     SELECT CASE
-      WHEN json_extract('$s', '\$.hooks') IS NULL THEN '$s'
-      WHEN (SELECT count(*) FROM json_each(json_extract('$s', '\$.hooks'))) = 0 THEN
-        json_remove('$s', '\$.hooks')
-      ELSE '$s'
-    END;
-  "
+      WHEN json_extract(src.j, '\$.hooks') IS NULL THEN src.j
+      WHEN (SELECT count(*) FROM json_each(json_extract(src.j, '\$.hooks'))) = 0 THEN
+        json_remove(src.j, '\$.hooks')
+      ELSE src.j
+    END
+    FROM src;
+  " > "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  mv "$tmp" "$path"
 }
 
 apply_settings_copilot() {
@@ -249,47 +272,54 @@ apply_settings() {
   hooks_file=$(resolve_hooks_file "$type" "$project")
   mkdir -p "$(dirname "$hooks_file")"
 
-  local settings_esc
-  settings_esc=$(read_settings_escaped "$hooks_file")
+  # Work on a temp copy so a partially-modified file never replaces the
+  # original until the whole chain succeeds.
+  local tmp_state
+  tmp_state=$(mktemp)
+  if [ -f "$hooks_file" ]; then
+    cp "$hooks_file" "$tmp_state"
+  else
+    printf '{}' > "$tmp_state"
+  fi
 
   # 1) Strip any prior agmsg ownership from SessionStart, SessionEnd, Stop.
-  settings_esc=$(strip_agmsg_event "$settings_esc" "SessionStart" | sed "s/'/''/g")
-  settings_esc=$(strip_agmsg_event "$settings_esc" "SessionEnd"   | sed "s/'/''/g")
-  settings_esc=$(strip_agmsg_event "$settings_esc" "Stop"         | sed "s/'/''/g")
+  strip_agmsg_event_file "$tmp_state" "SessionStart"
+  strip_agmsg_event_file "$tmp_state" "SessionEnd"
+  strip_agmsg_event_file "$tmp_state" "Stop"
 
   # 2) Re-add what this mode wants.
   case "$mode" in
     monitor)
       local ss="'$SKILL_DIR/scripts/session-start.sh' '$type' '$project'"
       local se="'$SKILL_DIR/scripts/session-end.sh'   '$type' '$project'"
-      settings_esc=$(add_event_entry "$settings_esc" "SessionStart" "$ss" "$type" | sed "s/'/''/g")
-      settings_esc=$(add_event_entry "$settings_esc" "SessionEnd"   "$se" "$type" | sed "s/'/''/g")
+      add_event_entry_file "$tmp_state" "SessionStart" "$ss" "$type"
+      add_event_entry_file "$tmp_state" "SessionEnd"   "$se" "$type"
       ;;
     turn)
       local cmd="'$SKILL_DIR/scripts/check-inbox.sh' '$type' '$project'"
-      settings_esc=$(add_event_entry "$settings_esc" "Stop" "$cmd" "$type" | sed "s/'/''/g")
+      add_event_entry_file "$tmp_state" "Stop" "$cmd" "$type"
       ;;
     both)
       local ss="'$SKILL_DIR/scripts/session-start.sh' '$type' '$project'"
       local se="'$SKILL_DIR/scripts/session-end.sh'   '$type' '$project'"
       local st="'$SKILL_DIR/scripts/check-inbox.sh'   '$type' '$project'"
-      settings_esc=$(add_event_entry "$settings_esc" "SessionStart" "$ss" "$type" | sed "s/'/''/g")
-      settings_esc=$(add_event_entry "$settings_esc" "SessionEnd"   "$se" "$type" | sed "s/'/''/g")
-      settings_esc=$(add_event_entry "$settings_esc" "Stop"         "$st" "$type" | sed "s/'/''/g")
+      add_event_entry_file "$tmp_state" "SessionStart" "$ss" "$type"
+      add_event_entry_file "$tmp_state" "SessionEnd"   "$se" "$type"
+      add_event_entry_file "$tmp_state" "Stop"         "$st" "$type"
       ;;
     off)
       : # already stripped
       ;;
     *)
+      rm -f "$tmp_state"
       echo "Unknown mode: $mode (use monitor|turn|both|off)" >&2
       return 1
       ;;
   esac
 
-  settings_esc=$(prune_empty_hooks "$settings_esc")
+  prune_empty_hooks_file "$tmp_state"
 
-  # Unescape for write.
-  printf '%s' "$settings_esc" | sed "s/''/'/g" > "$hooks_file"
+  mv "$tmp_state" "$hooks_file"
 }
 
 emit_monitor_directive() {
@@ -428,14 +458,16 @@ do_status() {
     hooks_file=$(resolve_hooks_file "$TYPE" "$PROJECT")
     if [ -f "$hooks_file" ]; then
       local count
-      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract('$(read_settings_escaped "$hooks_file")', '\$.hooks.SessionStart'));" 2>/dev/null || echo 0)
+      # readfile() rather than interpolating the file contents into argv —
+      # for large settings (#95) the latter hits MAX_ARG_STRLEN on Linux.
+      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$hooks_file'), '\$.hooks.SessionStart'));" 2>/dev/null || echo 0)
       case "$count" in ''|*[!0-9]*) count=0 ;; esac
       echo "settings hooks file: $hooks_file"
       echo "  SessionStart entries: $count"
-      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract('$(read_settings_escaped "$hooks_file")', '\$.hooks.SessionEnd'));" 2>/dev/null || echo 0)
+      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$hooks_file'), '\$.hooks.SessionEnd'));" 2>/dev/null || echo 0)
       case "$count" in ''|*[!0-9]*) count=0 ;; esac
       echo "  SessionEnd entries:   $count"
-      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract('$(read_settings_escaped "$hooks_file")', '\$.hooks.Stop'));" 2>/dev/null || echo 0)
+      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$hooks_file'), '\$.hooks.Stop'));" 2>/dev/null || echo 0)
       case "$count" in ''|*[!0-9]*) count=0 ;; esac
       echo "  Stop entries:         $count"
     fi

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -884,3 +884,95 @@ JSON
   [ -z "$cw" ]
 }
 
+# --- Large settings.local.json: must not trip Linux MAX_ARG_STRLEN (#95) ---
+#
+# Reporter's actual settings was 32,357 bytes. The pre-fix code embedded the
+# whole blob 6x into one sqlite3 argv element inside strip_agmsg_event, so on
+# Linux (MAX_ARG_STRLEN = 131072) anything above ~21 KB triggered E2BIG. The
+# test below uses ~30 KB to stay close to the reporter's size and reliably
+# fail before the fix on Linux. macOS has a much higher per-arg ceiling
+# (kern.argmax ≈ 1 MB) so the pre-fix code can survive 30 KB there — the
+# test still passes on macOS post-fix; the regression guard is meaningful
+# on Linux CI.
+
+@test "delivery set monitor: handles a large settings.local.json without E2BIG (#95)" {
+  mkdir -p "$TEST_PROJECT/.claude"
+  # Build a ~30 KB settings file with a populated permissions.allow list.
+  # 600 entries * ~50 bytes each ≈ 30 KB.
+  {
+    printf '{"permissions":{"allow":['
+    local i
+    for i in $(seq 1 600); do
+      [ "$i" -gt 1 ] && printf ','
+      printf '"Bash(mkdir:/tmp/agmsg-e2big-entry-%04d)"' "$i"
+    done
+    printf ']}}'
+  } > "$(settings_file)"
+  local size
+  size=$(wc -c < "$(settings_file)" | tr -d ' ')
+  [ "$size" -gt 25000 ]
+
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  has_session_start "$(settings_file)"
+
+  # Existing user permissions must be preserved across the rewrite.
+  local first last allow_len
+  first=$(sqlite3 :memory: "SELECT json_extract(readfile('$(settings_file)'), '\$.permissions.allow[0]');")
+  last=$(sqlite3 :memory:  "SELECT json_extract(readfile('$(settings_file)'), '\$.permissions.allow[599]');")
+  allow_len=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$(settings_file)'), '\$.permissions.allow'));")
+  [ "$first" = "Bash(mkdir:/tmp/agmsg-e2big-entry-0001)" ]
+  [ "$last" = "Bash(mkdir:/tmp/agmsg-e2big-entry-0600)" ]
+  [ "$allow_len" = "600" ]
+}
+
+@test "delivery set both: handles a large settings.local.json across strip+add+prune (#95)" {
+  mkdir -p "$TEST_PROJECT/.claude"
+  {
+    printf '{"permissions":{"allow":['
+    local i
+    for i in $(seq 1 600); do
+      [ "$i" -gt 1 ] && printf ','
+      printf '"Bash(mkdir:/tmp/agmsg-e2big-both-%04d)"' "$i"
+    done
+    printf ']}}'
+  } > "$(settings_file)"
+
+  # `both` exercises three add_event_entry_file calls after three
+  # strip_agmsg_event_file calls — the longest chain in apply_settings.
+  run bash "$SCRIPTS/delivery.sh" set both claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  has_session_start "$(settings_file)"
+  has_check_inbox "$(settings_file)"
+
+  local allow_len
+  allow_len=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$(settings_file)'), '\$.permissions.allow'));")
+  [ "$allow_len" = "600" ]
+}
+
+@test "delivery set off: idempotent strip on a large settings.local.json (#95)" {
+  mkdir -p "$TEST_PROJECT/.claude"
+  # Pre-populate with both user permissions and an agmsg-owned Stop entry,
+  # then verify `set off` strips only the agmsg entry without choking on
+  # the file size.
+  bash "$SCRIPTS/delivery.sh" set turn claude-code "$TEST_PROJECT"
+  # Now inflate the file with extra user permissions on top of the hook.
+  python3 - "$(settings_file)" <<'PY'
+import json, sys
+p = sys.argv[1]
+with open(p) as f: d = json.load(f)
+d.setdefault("permissions", {}).setdefault("allow", [])
+d["permissions"]["allow"].extend(
+    f"Bash(mkdir:/tmp/agmsg-e2big-off-{i:04d})" for i in range(1, 601)
+)
+with open(p, "w") as f: json.dump(d, f)
+PY
+
+  run bash "$SCRIPTS/delivery.sh" set off claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  ! has_check_inbox "$(settings_file)"
+  local allow_len
+  allow_len=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$(settings_file)'), '\$.permissions.allow'));")
+  [ "$allow_len" = "600" ]
+}
+

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -954,19 +954,28 @@ JSON
   mkdir -p "$TEST_PROJECT/.claude"
   # Pre-populate with both user permissions and an agmsg-owned Stop entry,
   # then verify `set off` strips only the agmsg entry without choking on
-  # the file size.
+  # the file size. Build the inflated fixture via sqlite3 (no python3
+  # dependency — agmsg is bash + sqlite3 only).
   bash "$SCRIPTS/delivery.sh" set turn claude-code "$TEST_PROJECT"
-  # Now inflate the file with extra user permissions on top of the hook.
-  python3 - "$(settings_file)" <<'PY'
-import json, sys
-p = sys.argv[1]
-with open(p) as f: d = json.load(f)
-d.setdefault("permissions", {}).setdefault("allow", [])
-d["permissions"]["allow"].extend(
-    f"Bash(mkdir:/tmp/agmsg-e2big-off-{i:04d})" for i in range(1, 601)
-)
-with open(p, "w") as f: json.dump(d, f)
-PY
+
+  local allow_json
+  allow_json=$(
+    printf '['
+    local i
+    for i in $(seq 1 600); do
+      [ "$i" -gt 1 ] && printf ','
+      printf '"Bash(mkdir:/tmp/agmsg-e2big-off-%04d)"' "$i"
+    done
+    printf ']'
+  )
+  local inflated
+  inflated=$(sqlite3 :memory: "
+    SELECT json_set(
+      json_set(readfile('$(settings_file)'), '\$.permissions', json('{}')),
+      '\$.permissions.allow', json('$allow_json')
+    );
+  ")
+  printf '%s' "$inflated" > "$(settings_file)"
 
   run bash "$SCRIPTS/delivery.sh" set off claude-code "$TEST_PROJECT"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes #95. Reworks `apply_settings()` so the settings JSON is read via sqlite3's `readfile()` from a temp file at each stage instead of being interpolated into the `sqlite3` argv. The old in-memory chain embedded the blob 6× in `strip_agmsg_event` (and 4× in the add/prune helpers), so settings files above ~21 KB tripped Linux's `MAX_ARG_STRLEN` (131072 bytes per single argv element) and `delivery.sh set` died with `E2BIG`.

Affected agent types: **claude-code** and **codex** (both use the generic `apply_settings()` path). `gemini` / `antigravity` (markdown) and `copilot` (template rewrite via `rm -f` + heredoc) are not affected.

## Diff shape

- `strip_agmsg_event` → `strip_agmsg_event_file` (reads & writes a path; SQL references `readfile('$path')`)
- `add_event_entry` → `add_event_entry_file`
- `prune_empty_hooks` → `prune_empty_hooks_file`
- `read_settings_escaped` removed — no callers left.
- `apply_settings`: in-memory `$settings_esc` chain → temp-file chain. The user's `settings.local.json` only changes at the end of the chain via `mv`, so a mid-chain failure no longer leaves a partially-modified file.
- `delivery.sh status`: the three "count entries" probes also switched to `readfile()` (they had a much higher threshold — ~130 KB — but it cost nothing to fix while in the file).

No behavior change for normal-sized settings. The functions take paths instead of strings, but they only had internal callers.

## Tests

Three new regression cases in `tests/test_delivery.bats`:

- `delivery set monitor` on a ~25 KB `settings.local.json` (matches the reporter's ~32 KB case scaled down to stay portable). 25 KB × 6 ≈ 150 KB > Linux's per-arg cap, so the test fails on Linux pre-fix.
- `delivery set both` — exercises the longest chain (3× strip + 3× add + 1× prune).
- `delivery set off` — exercises strip-only, with an existing agmsg-owned entry plus 600 user permissions, confirming idempotent strip on a large file.

All three preserve and verify the user's `permissions.allow` array length (600 entries) across the rewrite.

Full suite: 71/71 pass locally (68 existing + 3 new).

## Platform notes

- Linux: `MAX_ARG_STRLEN` is fixed at 32 pages = 131072 bytes per single argv element, regardless of `ARG_MAX`. This is where the reporter hit the wall.
- macOS: `kern.argmax` ≈ 1 MB; a 32 KB settings file (6× = 192 KB) survives there, so the bug never surfaced for mac-only developers. The new tests still pass on macOS post-fix.

## Test plan

- [ ] CI bats run goes green on Linux (where pre-fix the new tests would have failed).
- [ ] Manual: run `delivery.sh set monitor` against a project with a settings file ≥ 25 KB on Linux; verify no E2BIG and the existing permissions block is intact.
- [ ] Manual: `delivery.sh status` against the same file shows correct hook entry counts.

Closes #95.