### PR TITLE
fix(install): refuse interactive prompt when stdin is not a tty (#98)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,17 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Force non-interactive when stdin is not a terminal. Without this, the
+# command-name prompt below would call `read -r` on whatever stream is wired
+# to fd 0 — which for `curl ... | bash`-style entry paths (e.g. the npm
+# bootstrapper before its own fix) is the wrapper script itself, so the
+# next line of the wrapper gets consumed as the command name. See #98.
+# The `bash <(curl ...)` form in the README is fine because process
+# substitution preserves stdin; this guard only kicks in for pipe entries.
+if [ ! -t 0 ]; then
+  INTERACTIVE=false
+fi
+
 # --- Check dependencies ---
 if ! command -v sqlite3 &>/dev/null; then
   echo "Error: sqlite3 is required but not found." >&2

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -179,3 +179,51 @@ teardown() {
   kill "$second" 2>/dev/null || true
   wait 2>/dev/null || true
 }
+
+# --- Pipe-stdin guard: simulate a curl|bash entry path (#98) ---
+#
+# The npm bootstrapper executes the wrapper as `curl ... | bash`, so install.sh
+# runs with its stdin wired to the wrapper script stream rather than a tty.
+# Before #98 this caused the interactive command-name prompt to consume the
+# next line of the wrapper as CMD_NAME — installing the skill under e.g.
+# "rm -rf $TMP/" instead of "agmsg". The guard added in install.sh forces
+# INTERACTIVE=false whenever stdin is not a tty. These tests pipe a payload
+# that would have been swallowed by `read -r` pre-fix, then verify the
+# install landed under the default name and the payload bytes were left
+# untouched on stdin.
+
+@test "install: non-tty stdin falls back to the 'agmsg' default (#98)" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" </dev/null
+
+  [ -d "$FAKE_HOME/.agents/skills/agmsg" ]
+  [ -f "$SK/.agmsg" ]
+  [ -f "$SK/scripts/whoami.sh" ]
+
+  # No bogus skill directories created from a leaked stdin line.
+  local bogus
+  bogus=$(find "$FAKE_HOME/.agents/skills" -maxdepth 1 -mindepth 1 -type d ! -name agmsg | wc -l | tr -d ' ')
+  [ "$bogus" = "0" ]
+}
+
+@test "install: payload on non-tty stdin is NOT consumed by the prompt (#98)" {
+  # The real failure mode: install.sh's `read -r` would pull the next
+  # line off stdin. Build a stdin that has a sentinel line after what
+  # the install would have prompted for, then assert the sentinel
+  # survived on stdin after install.sh returned.
+  local stdin_capture stdout_capture
+  stdin_capture=$(mktemp)
+  stdout_capture=$(mktemp)
+  {
+    printf 'rm -rf "$TMP"\n'
+    printf 'SENTINEL_SURVIVED\n'
+  } | {
+    HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" > "$stdout_capture" 2>&1
+    cat > "$stdin_capture"
+  }
+
+  [ -d "$FAKE_HOME/.agents/skills/agmsg" ]
+  grep -q '^rm -rf "\$TMP"$' "$stdin_capture"
+  grep -q '^SENTINEL_SURVIVED$' "$stdin_capture"
+  ! grep -q 'rm -rf' "$stdout_capture"
+  rm -f "$stdin_capture" "$stdout_capture"
+}


### PR DESCRIPTION
## Summary

First half of the fix for #98. Adds a one-line stdin-is-tty guard to `install.sh` so the interactive command-name prompt is skipped whenever stdin isn't a real terminal — covering the `curl ... | bash` entry path used by the npm bootstrapper today (and any future pipe-based wrapper).

The README's `bash <(curl ...)` form is unaffected — process substitution preserves stdin as the terminal, so interactive curl users still get the prompt.

The bootstrapper itself (Part B in #98) still needs a follow-up in `fujibee/agmsg-npm` to stop piping; this PR is the defense-in-depth half that lands in the canonical installer first.

## Why this layering

After this PR:
- Anyone running `curl ... | bash` (including current `agmsg@1.0.2` users) gets a working install under `~/.agents/skills/agmsg/` instead of the corrupted `rm -rf "$TMP"` path.
- The bootstrapper republish (1.0.3) is then a follow-up that makes the entry path clean rather than relying on the installer's defense.
- Either change alone would fix today's failure; both together close the door on any future entry path that pipes instead of process-substitutes.

## Verification on a fresh Debian 12 container

Same minimal container we used for #95 (no agmsg state, `~/.agents` doesn't exist yet, no python3, sqlite3 installed).

```bash
$ docker exec agmsg-verify-clean bash -lc '
> SETUP="#!/usr/bin/env bash
> set -euo pipefail
> TMP=\$(mktemp -d)
> git clone --depth 1 --branch fix/install-tty-guard https://github.com/fujibee/agmsg.git \"\$TMP/agmsg\" 2>/dev/null
> \"\$TMP/agmsg/install.sh\" \"\$@\"
> rm -rf \"\$TMP\""
> echo "$SETUP" | bash
> '
  Installing to ~/.agents/skills/agmsg/ ...
  + installed /agmsg command to ~/.claude/commands/
  ✓ Installed to ~/.agents/skills/agmsg/
  ...
       Claude Code:  /agmsg
       Codex:        $agmsg
       Gemini CLI:   $agmsg
       Antigravity:  $agmsg
       Copilot CLI:  /agmsg
```

(Pre-fix the same script printed `~/.agents/skills/rm -rf "$TMP"/` and `/rm -rf "$TMP"`.)

End-to-end the installed scripts run:

```bash
$ ~/.agents/skills/agmsg/scripts/whoami.sh "$(pwd)" claude-code
not_joined=true available_teams=none
```

## Tests

Two new bats cases in `tests/test_install.bats`:

- `install: non-tty stdin falls back to the 'agmsg' default (#98)` — runs install.sh with `</dev/null` and asserts the skill lands under `agmsg`, no bogus sibling directories are created.
- `install: payload on non-tty stdin is NOT consumed by the prompt (#98)` — pipes `'rm -rf "$TMP"\nSENTINEL_SURVIVED\n'` into install.sh and asserts both payload lines survive on stdin after install returns (the property that lets `setup.sh`'s cleanup line execute instead of being swallowed). Also asserts neither bogus string appears in install.sh's stdout.

Full `tests/test_install.bats`: 13/13 pass.

## Follow-up

- `fujibee/agmsg-npm`: rewrite `bin/agmsg.js` to download `setup.sh` to a tempfile and exec it instead of piping curl into bash, then republish as `agmsg@1.0.3`.
- New CI job (or bats case) that runs the npm path inside a minimal container and asserts the skill ends up at `~/.agents/skills/agmsg/` — catches future regressions of this shape.

Closes the install-side half of #98. The bootstrapper-side half remains open until the agmsg-npm republish.

cc @fujibee