### PR TITLE
[codex] Add native Windows agmsg helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,32 @@ The **command name** determines:
 
 After install, **restart your agent** (Claude Code / Codex / Gemini CLI / Antigravity) so it picks up the new skill.
 
+### Native Windows / PowerShell shortcut
+
+When `install.sh` runs under Git Bash on Windows, it also installs optional native helpers:
+
+- `~/.agents/agmsg.ps1` — a PowerShell function wrapper
+- `~/.agents/agmsg-run.sh` — the Git Bash runner used by that wrapper
+- `~/.agents/bin/sqlite3` — a compatibility shim for Windows `sqlite3.exe` output
+
+To enable the PowerShell command, dot-source the generated file from your PowerShell profile:
+
+```powershell
+. "$HOME\.agents\agmsg.ps1"
+```
+
+Then a PowerShell session can run:
+
+```powershell
+agmsg
+agmsg history
+agmsg team
+agmsg send alice "hello from PowerShell"
+agmsg mode turn
+```
+
+The installer prints the same profile line but does not modify your profile automatically.
+
 ## First run
 
 Open your project in your agent (Claude Code, Codex, Gemini CLI, etc.) and run:

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,40 @@ UPDATE_ONLY=false
 INTERACTIVE=true
 AGENT_TYPE=""  # claude-code, codex, gemini, antigravity — passed via --agent-type, or empty for auto/default
 
+is_windows_host() {
+  if [ "${AGMSG_FORCE_WINDOWS:-}" = "1" ]; then
+    return 0
+  fi
+
+  case "$(uname -s 2>/dev/null || echo unknown)" in
+    MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+install_windows_helpers() {
+  if ! is_windows_host; then
+    return 0
+  fi
+
+  mkdir -p "$AGENTS_DIR/bin"
+  sed "s/__SKILL_NAME__/$CMD_NAME/g" "$SCRIPT_DIR/scripts/windows/agmsg.ps1" > "$AGENTS_DIR/$CMD_NAME.ps1"
+  sed "s/__SKILL_NAME__/$CMD_NAME/g" "$SCRIPT_DIR/scripts/windows/agmsg-run.sh" > "$AGENTS_DIR/$CMD_NAME-run.sh"
+  cp "$SCRIPT_DIR/scripts/windows/sqlite3-shim.sh" "$AGENTS_DIR/bin/sqlite3"
+  chmod +x "$AGENTS_DIR/$CMD_NAME-run.sh" "$AGENTS_DIR/bin/sqlite3"
+
+  # Make the shim available to the rest of this installer run. The generated
+  # PowerShell runner also prepends this path for future manual invocations.
+  export PATH="$AGENTS_DIR/bin:$PATH"
+
+  echo "  + installed Windows helpers to ~/.agents/"
+  echo "    PowerShell shortcut: ~/.agents/$CMD_NAME.ps1"
+  echo "    Git Bash runner:     ~/.agents/$CMD_NAME-run.sh"
+  echo "    sqlite3 shim:        ~/.agents/bin/sqlite3"
+  echo "  ~ To enable the PowerShell shortcut, dot-source it from your profile:"
+  echo "    . \"\$HOME\\.agents\\$CMD_NAME.ps1\""
+}
+
 # --- Parse args ---
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -93,6 +127,7 @@ if [ "$UPDATE_ONLY" = true ]; then
     exit 1
   fi
   SKILL_NAME="$(basename "$SKILL_DIR")"
+  CMD_NAME="$SKILL_NAME"
   echo "  Updating $SKILL_NAME..."
   if [ -z "$AGENT_TYPE" ]; then
     if grep -q "whoami.sh.*antigravity" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
@@ -132,6 +167,7 @@ if [ "$UPDATE_ONLY" = true ]; then
   fi
   cp "$SCRIPT_DIR/openai.yaml" "$SKILL_DIR/agents/openai.yaml" 2>/dev/null || true
   chmod +x "$SKILL_DIR/scripts/"*.sh
+  install_windows_helpers
   echo "  + updated scripts, templates, and SKILL.md"
   echo "  ~ DB and team configs preserved"
   echo ""
@@ -178,6 +214,7 @@ done
 
 cp "$SCRIPT_DIR/openai.yaml" "$SKILL_DIR/agents/openai.yaml" 2>/dev/null || true
 chmod +x "$SKILL_DIR/scripts/"*.sh
+install_windows_helpers
 
 # Marker file for uninstall detection
 touch "$SKILL_DIR/.agmsg"

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -45,6 +45,14 @@ resolve_hooks_file() {
   esac
 }
 
+sql_readfile_path() {
+  local path="$1"
+  if command -v cygpath >/dev/null 2>&1; then
+    path=$(cygpath -w "$path" 2>/dev/null || printf '%s' "$path")
+  fi
+  printf '%s' "$path" | sed "s/'/''/g"
+}
+
 # Strip any agmsg-owned hook entries from <event> in the JSON at <path>. An
 # entry is "agmsg-owned" when one of its inner hooks references a path under
 # our skill directory. Result is written back to <path> atomically.
@@ -58,10 +66,12 @@ resolve_hooks_file() {
 strip_agmsg_event_file() {
   local path="$1"
   local event="$2"
+  local sql_path
+  sql_path=$(sql_readfile_path "$path")
   local tmp
   tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
   if ! sqlite3 :memory: "
-    WITH src AS (SELECT readfile('$path') AS j)
+    WITH src AS (SELECT readfile('$sql_path') AS j)
     SELECT CASE
       WHEN json_extract(src.j, '\$.hooks.$event') IS NULL THEN
         src.j
@@ -92,11 +102,14 @@ strip_agmsg_event_file() {
 # Wrap a POSIX shell command so Codex's Windows runner executes it through Git
 # Bash. On native Windows, Codex runs each hook command via PowerShell, which
 # cannot execute a bare POSIX ".sh" path, so the hook exits non-zero. Codex hook
-# config supports a "commandWindows" key that takes precedence on Windows; the
-# "& '<bash.exe>' -lc \"...\"" form is what Codex itself emits for shell calls.
+# config supports a "commandWindows" key that takes precedence on Windows.
 windows_wrap() {
   local posix_cmd="$1"
-  printf "& 'C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe' -lc \"%s\"" "$posix_cmd"
+  local agents_bin="$HOME/.agents/bin"
+  local bash_cmd="PATH='$agents_bin':\$PATH; $posix_cmd"
+  local bash_cmd_ps
+  bash_cmd_ps=$(printf '%s' "$bash_cmd" | sed "s/'/''/g")
+  printf "& 'C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe' -lc '%s'" "$bash_cmd_ps"
 }
 
 # Append a single entry of the form {"matcher":"","hooks":[{"type":"command","command":"<cmd>"}]}
@@ -110,6 +123,8 @@ add_event_entry_file() {
   local event="$2"
   local cmd="$3"
   local hook_type="${4:-}"
+  local sql_path
+  sql_path=$(sql_readfile_path "$path")
 
   local hook_inner="\"type\":\"command\",\"command\":\"$cmd\""
   if [ "$hook_type" = "codex" ]; then
@@ -125,9 +140,9 @@ add_event_entry_file() {
   tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
   if ! sqlite3 :memory: "
     WITH base AS (
-      SELECT CASE WHEN json_extract(readfile('$path'), '\$.hooks') IS NULL
-                  THEN json_set(readfile('$path'), '\$.hooks', json('{}'))
-                  ELSE readfile('$path') END AS s
+      SELECT CASE WHEN json_extract(readfile('$sql_path'), '\$.hooks') IS NULL
+                  THEN json_set(readfile('$sql_path'), '\$.hooks', json('{}'))
+                  ELSE readfile('$sql_path') END AS s
     )
     SELECT CASE
       WHEN json_extract(s, '\$.hooks.$event') IS NULL THEN
@@ -154,10 +169,12 @@ add_event_entry_file() {
 # rationale (#95).
 prune_empty_hooks_file() {
   local path="$1"
+  local sql_path
+  sql_path=$(sql_readfile_path "$path")
   local tmp
   tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
   if ! sqlite3 :memory: "
-    WITH src AS (SELECT readfile('$path') AS j)
+    WITH src AS (SELECT readfile('$sql_path') AS j)
     SELECT CASE
       WHEN json_extract(src.j, '\$.hooks') IS NULL THEN src.j
       WHEN (SELECT count(*) FROM json_each(json_extract(src.j, '\$.hooks'))) = 0 THEN
@@ -431,15 +448,17 @@ do_status() {
     else
       local has_ss=0 has_st=0
       if [ -f "$hf" ]; then
+        local sql_hf
+        sql_hf=$(sql_readfile_path "$hf")
         has_ss=$(sqlite3 :memory: "
           SELECT EXISTS(
-            SELECT 1 FROM json_each(json_extract(readfile('$hf'), '\$.hooks.SessionStart')) AS s,
+            SELECT 1 FROM json_each(json_extract(readfile('$sql_hf'), '\$.hooks.SessionStart')) AS s,
               json_each(json_extract(s.value, '\$.hooks')) AS h
             WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
           );" 2>/dev/null || echo 0)
         has_st=$(sqlite3 :memory: "
           SELECT EXISTS(
-            SELECT 1 FROM json_each(json_extract(readfile('$hf'), '\$.hooks.Stop')) AS s,
+            SELECT 1 FROM json_each(json_extract(readfile('$sql_hf'), '\$.hooks.Stop')) AS s,
               json_each(json_extract(s.value, '\$.hooks')) AS h
             WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
           );" 2>/dev/null || echo 0)
@@ -458,16 +477,18 @@ do_status() {
     hooks_file=$(resolve_hooks_file "$TYPE" "$PROJECT")
     if [ -f "$hooks_file" ]; then
       local count
+      local sql_hooks_file
+      sql_hooks_file=$(sql_readfile_path "$hooks_file")
       # readfile() rather than interpolating the file contents into argv —
       # for large settings (#95) the latter hits MAX_ARG_STRLEN on Linux.
-      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$hooks_file'), '\$.hooks.SessionStart'));" 2>/dev/null || echo 0)
+      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$sql_hooks_file'), '\$.hooks.SessionStart'));" 2>/dev/null || echo 0)
       case "$count" in ''|*[!0-9]*) count=0 ;; esac
       echo "settings hooks file: $hooks_file"
       echo "  SessionStart entries: $count"
-      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$hooks_file'), '\$.hooks.SessionEnd'));" 2>/dev/null || echo 0)
+      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$sql_hooks_file'), '\$.hooks.SessionEnd'));" 2>/dev/null || echo 0)
       case "$count" in ''|*[!0-9]*) count=0 ;; esac
       echo "  SessionEnd entries:   $count"
-      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$hooks_file'), '\$.hooks.Stop'));" 2>/dev/null || echo 0)
+      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$sql_hooks_file'), '\$.hooks.Stop'));" 2>/dev/null || echo 0)
       case "$count" in ''|*[!0-9]*) count=0 ;; esac
       echo "  Stop entries:         $count"
     fi

--- a/scripts/windows/agmsg-run.sh
+++ b/scripts/windows/agmsg-run.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runner used by the native Windows PowerShell shortcut.
+#
+# PowerShell passes subcommand data through AGMSG_* environment variables so
+# message bodies do not need to survive another layer of shell quoting.
+
+export PATH="$HOME/.agents/bin:$HOME/bin:$PATH"
+
+SKILL_NAME="${AGMSG_SKILL_NAME:-__SKILL_NAME__}"
+SD="$HOME/.agents/skills/$SKILL_NAME/scripts"
+TYPE="${AGMSG_AGENT_TYPE:-codex}"
+PROJECT="${AGMSG_PROJECT:-$(pwd)}"
+SUB="${AGMSG_SUB:-inbox}"
+AGENT="${AGMSG_AGENT:-}"
+TEAMS="${AGMSG_TEAM:-}"
+
+field_value() {
+  local line="$1" key="$2"
+  printf '%s\n' "$line" | sed -n "s/.*$key=\([^[:space:]]*\).*/\1/p"
+}
+
+resolve_identity() {
+  if [[ -n "$AGENT" && -n "$TEAMS" ]]; then
+    return 0
+  fi
+
+  local who
+  if ! who="$("$SD/whoami.sh" "$PROJECT" "$TYPE")"; then
+    printf '%s\n' "$who" >&2
+    return 1
+  fi
+
+  case "$who" in
+    agent=*)
+      AGENT="${AGENT:-$(field_value "$who" agent)}"
+      TEAMS="${TEAMS:-$(field_value "$who" teams)}"
+      ;;
+    multiple=true*)
+      printf '%s\n' "$who" >&2
+      echo "agmsg: multiple identities found; set AGMSG_AGENT and AGMSG_TEAM, or use the agent skill command." >&2
+      return 2
+      ;;
+    not_joined=true*|suggest=true*)
+      printf '%s\n' "$who" >&2
+      echo "agmsg: this project is not joined yet. Run the agmsg skill once in your agent, then retry." >&2
+      return 2
+      ;;
+    *)
+      printf '%s\n' "$who" >&2
+      echo "agmsg: could not resolve project identity." >&2
+      return 2
+      ;;
+  esac
+
+  if [[ -z "$AGENT" || -z "$TEAMS" ]]; then
+    echo "agmsg: missing AGMSG_AGENT or AGMSG_TEAM after identity lookup." >&2
+    return 2
+  fi
+}
+
+first_team() {
+  printf '%s' "${TEAMS%%,*}"
+}
+
+for_each_team() {
+  local script="$1"
+  resolve_identity
+  local team
+  IFS=',' read -ra team_list <<< "$TEAMS"
+  for team in "${team_list[@]}"; do
+    "$script" "$team" "$AGENT"
+  done
+}
+
+case "$SUB" in
+  inbox)
+    for_each_team "$SD/inbox.sh"
+    ;;
+  history)
+    for_each_team "$SD/history.sh"
+    ;;
+  team)
+    resolve_identity
+    IFS=',' read -ra team_list <<< "$TEAMS"
+    for team in "${team_list[@]}"; do
+      "$SD/team.sh" "$team"
+    done
+    ;;
+  send)
+    resolve_identity
+    exec "$SD/send.sh" "$(first_team)" "$AGENT" "${AGMSG_TO:?missing recipient}" "${AGMSG_MSG:?missing message}"
+    ;;
+  mode)
+    MODE="${AGMSG_MODE:-}"
+    if [[ -z "$MODE" ]]; then
+      exec "$SD/delivery.sh" status "$TYPE" "$PROJECT"
+    fi
+    case "$MODE" in
+      turn|off) exec "$SD/delivery.sh" set "$MODE" "$TYPE" "$PROJECT" ;;
+      monitor|both)
+        echo "Codex has no Monitor tool; only 'turn' or 'off' modes are supported." >&2
+        exit 2
+        ;;
+      *)
+        echo "usage: $SKILL_NAME mode [turn|off]" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  reset)
+    if [[ -n "$AGENT" ]]; then
+      exec "$SD/reset.sh" "$PROJECT" "$TYPE" "$AGENT"
+    fi
+    exec "$SD/reset.sh" "$PROJECT" "$TYPE"
+    ;;
+  *)
+    echo "usage: $SKILL_NAME [inbox|history|team|mode [turn|off]|send <to> <message>|reset]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/windows/agmsg.ps1
+++ b/scripts/windows/agmsg.ps1
@@ -1,0 +1,71 @@
+# PowerShell shortcut for agmsg on native Windows.
+#
+# Dot-source this file from your PowerShell profile:
+#   . "$HOME\.agents\__SKILL_NAME__.ps1"
+#
+# The function passes user text through environment variables before handing
+# off to Git Bash, so spaces, quotes, and non-ASCII message bodies survive the
+# PowerShell -> bash boundary.
+function __SKILL_NAME__ {
+    [CmdletBinding()]
+    param([Parameter(ValueFromRemainingArguments = $true)] [object[]] $rest)
+
+    $bash = $env:AGMSG_BASH
+    if (-not $bash) {
+        $candidates = @(
+            "$env:ProgramFiles\Git\bin\bash.exe",
+            "${env:ProgramFiles(x86)}\Git\bin\bash.exe"
+        ) | Where-Object { $_ -and (Test-Path $_) }
+
+        if ($candidates.Count -gt 0) {
+            $bash = $candidates[0]
+        } else {
+            $cmd = Get-Command bash.exe -All -ErrorAction SilentlyContinue |
+                Where-Object { ($_.Source -like '*\Git\*') -or ($_.Path -like '*\Git\*') } |
+                Select-Object -First 1
+            if ($cmd) { $bash = if ($cmd.Source) { $cmd.Source } else { $cmd.Path } }
+        }
+    }
+
+    if (-not $bash -or -not (Test-Path $bash)) {
+        Write-Error "Git Bash not found. Install Git for Windows or set AGMSG_BASH to bash.exe."
+        return
+    }
+
+    $saved = @{}
+    foreach ($name in @('AGMSG_SUB', 'AGMSG_TO', 'AGMSG_MSG', 'AGMSG_MODE')) {
+        $saved[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+    }
+
+    try {
+        $sub = if ($rest -and $rest.Count -ge 1) { [string]$rest[0] } else { 'inbox' }
+        $env:AGMSG_SUB = $sub
+
+        if ($sub -eq 'send') {
+            if (-not $rest -or $rest.Count -lt 3) {
+                Write-Host 'usage: __SKILL_NAME__ send <to> <message>'
+                return
+            }
+            $env:AGMSG_TO = [string]$rest[1]
+            $env:AGMSG_MSG = ($rest[2..($rest.Count - 1)] -join ' ')
+        }
+
+        if ($sub -eq 'mode') {
+            if ($rest.Count -gt 2) {
+                Write-Host 'usage: __SKILL_NAME__ mode [turn|off]'
+                return
+            }
+            if ($rest.Count -eq 2) { $env:AGMSG_MODE = [string]$rest[1] }
+        }
+
+        & $bash -lc '"$HOME/.agents/__SKILL_NAME__-run.sh"'
+    } finally {
+        foreach ($name in $saved.Keys) {
+            if ($null -eq $saved[$name]) {
+                Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+            } else {
+                [Environment]::SetEnvironmentVariable($name, $saved[$name], 'Process')
+            }
+        }
+    }
+}

--- a/scripts/windows/sqlite3-shim.sh
+++ b/scripts/windows/sqlite3-shim.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# sqlite3 compatibility shim for agmsg on native Windows / Git Bash.
+#
+# The winget SQLite CLI can print control characters such as char(31) using
+# caret notation and can emit CRLF line endings. agmsg parses char(31) as a
+# field separator and expects LF records. This wrapper restores the behavior
+# the POSIX scripts expect:
+#   - pass -escape off when the sqlite3 build supports it
+#   - strip CR bytes from CLI output
+
+CACHE_FILE="${AGMSG_SQLITE3_CACHE_FILE:-${HOME:-}/.agents/run/sqlite3-shim.cache}"
+SUPPORTS_ESCAPE_OFF="${AGMSG_SQLITE3_ESCAPE_OFF:-}"
+
+find_real_sqlite3() {
+  local self
+  self="$(cd "$(dirname "$0")" && pwd -P)/$(basename "$0")"
+
+  local name candidate
+  for name in sqlite3.exe sqlite3; do
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      [ "$candidate" = "$self" ] && continue
+      [ -x "$candidate" ] || continue
+      if grep -q "sqlite3 compatibility shim for agmsg" "$candidate" 2>/dev/null; then
+        continue
+      fi
+      printf '%s\n' "$candidate"
+      return 0
+    done < <(type -ap "$name" 2>/dev/null || true)
+  done
+}
+
+load_cache() {
+  [ -n "$CACHE_FILE" ] || return 1
+  [ -f "$CACHE_FILE" ] || return 1
+
+  local cached_real cached_escape
+  {
+    IFS= read -r cached_real || return 1
+    IFS= read -r cached_escape || cached_escape=""
+  } < "$CACHE_FILE"
+
+  [ -n "$cached_real" ] || return 1
+  [ -x "$cached_real" ] || return 1
+  REAL_SQLITE3="$cached_real"
+  if [ -z "$SUPPORTS_ESCAPE_OFF" ]; then
+    SUPPORTS_ESCAPE_OFF="$cached_escape"
+  fi
+  return 0
+}
+
+write_cache() {
+  [ -n "$CACHE_FILE" ] || return 0
+  [ -n "${REAL_SQLITE3:-}" ] || return 0
+
+  local cache_dir tmp
+  cache_dir="$(dirname "$CACHE_FILE")"
+  mkdir -p "$cache_dir" 2>/dev/null || return 0
+  tmp=$(mktemp "${cache_dir}/sqlite3-shim.XXXXXX" 2>/dev/null) || return 0
+  {
+    printf '%s\n' "$REAL_SQLITE3"
+    printf '%s\n' "$SUPPORTS_ESCAPE_OFF"
+  } > "$tmp"
+  mv "$tmp" "$CACHE_FILE" 2>/dev/null || rm -f "$tmp"
+}
+
+REAL_SQLITE3="${AGMSG_REAL_SQLITE3:-}"
+if [ -z "$REAL_SQLITE3" ]; then
+  load_cache || true
+fi
+if [ -z "$REAL_SQLITE3" ]; then
+  REAL_SQLITE3="$(find_real_sqlite3 || true)"
+fi
+if [ -z "$REAL_SQLITE3" ]; then
+  echo "sqlite3 shim: real sqlite3 executable not found" >&2
+  exit 127
+fi
+
+if [ -z "$SUPPORTS_ESCAPE_OFF" ]; then
+  if "$REAL_SQLITE3" -escape off :memory: "SELECT 1;" >/dev/null 2>&1; then
+    SUPPORTS_ESCAPE_OFF=1
+  else
+    SUPPORTS_ESCAPE_OFF=0
+  fi
+  write_cache
+fi
+
+if [ "$SUPPORTS_ESCAPE_OFF" = "1" ]; then
+  "$REAL_SQLITE3" -escape off "$@" | tr -d '\r'
+else
+  "$REAL_SQLITE3" "$@" | tr -d '\r'
+fi
+exit "${PIPESTATUS[0]}"

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -871,6 +871,7 @@ JSON
   [ -n "$cw" ]
   [[ "$cw" == *"Program Files\\Git\\bin\\bash.exe"* ]]
   [[ "$cw" == *"-lc"* ]]
+  [[ "$cw" == *".agents/bin"* ]]
   [[ "$cw" == *"check-inbox.sh"* ]]
 }
 
@@ -984,4 +985,3 @@ JSON
   allow_len=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$(settings_file)'), '\$.permissions.allow'));")
   [ "$allow_len" = "600" ]
 }
-

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -120,6 +120,49 @@ teardown() {
   grep -q "whoami.sh \"\$(pwd)\" copilot" "$FAKE_HOME/.copilot/skills/agmsg/SKILL.md"
 }
 
+@test "install: Windows helpers are generated with the selected command name" {
+  AGMSG_FORCE_WINDOWS=1 HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd msg
+
+  [ -f "$FAKE_HOME/.agents/msg.ps1" ]
+  [ -f "$FAKE_HOME/.agents/msg-run.sh" ]
+  [ -f "$FAKE_HOME/.agents/bin/sqlite3" ]
+  [ -x "$FAKE_HOME/.agents/msg-run.sh" ]
+  [ -x "$FAKE_HOME/.agents/bin/sqlite3" ]
+
+  grep -q "function msg" "$FAKE_HOME/.agents/msg.ps1"
+  grep -q '\$HOME/.agents/msg-run.sh' "$FAKE_HOME/.agents/msg.ps1"
+  grep -q 'SKILL_NAME="${AGMSG_SKILL_NAME:-msg}"' "$FAKE_HOME/.agents/msg-run.sh"
+  ! grep -q "__SKILL_NAME__" "$FAKE_HOME/.agents/msg.ps1"
+  ! grep -q "__SKILL_NAME__" "$FAKE_HOME/.agents/msg-run.sh"
+}
+
+@test "install --update: restores Windows helpers" {
+  AGMSG_FORCE_WINDOWS=1 HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  echo "tampered" > "$FAKE_HOME/.agents/agmsg-run.sh"
+
+  AGMSG_FORCE_WINDOWS=1 HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+
+  ! grep -q "^tampered$" "$FAKE_HOME/.agents/agmsg-run.sh"
+  grep -q 'SKILL_NAME="${AGMSG_SKILL_NAME:-agmsg}"' "$FAKE_HOME/.agents/agmsg-run.sh"
+}
+
+@test "windows runner: sends and receives messages through AGMSG environment values" {
+  AGMSG_FORCE_WINDOWS=1 HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  bash "$SK/scripts/join.sh" demo alice codex /tmp/agmsg-win-a
+  bash "$SK/scripts/join.sh" demo bob codex /tmp/agmsg-win-b
+
+  local msg="hello with spaces and 'quotes'"
+  HOME="$FAKE_HOME" AGMSG_TEAM=demo AGMSG_AGENT=alice AGMSG_SUB=send AGMSG_TO=bob AGMSG_MSG="$msg" \
+    bash "$FAKE_HOME/.agents/agmsg-run.sh"
+
+  run env HOME="$FAKE_HOME" AGMSG_TEAM=demo AGMSG_AGENT=bob AGMSG_SUB=inbox \
+    bash "$FAKE_HOME/.agents/agmsg-run.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "$msg" ]]
+  [[ "$output" != *"^_"* ]]
+  [ -f "$FAKE_HOME/.agents/run/sqlite3-shim.cache" ]
+}
+
 @test "plugin SKILL.md bootstrap: a fresh plugin install path can bootstrap ~/.agents/skills/agmsg" {
   # Simulate the post-plugin-install state: no ~/.agents/skills/agmsg yet, but
   # the plugin marketplace flow has populated the cache dir with a copy of the

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -185,6 +185,25 @@ for SKILL_DIR in "${SKILL_DIRS[@]}"; do
   fi
 done
 
+# --- 2c. Remove native Windows helpers ---
+for SKILL_DIR in "${SKILL_DIRS[@]}"; do
+  SKILL_NAME="$(basename "$SKILL_DIR")"
+  for helper in "$AGENTS_DIR/$SKILL_NAME.ps1" "$AGENTS_DIR/$SKILL_NAME-run.sh"; do
+    if [ -f "$helper" ]; then
+      rm "$helper"
+      echo "  - removed $helper"
+      REMOVED=true
+    fi
+  done
+done
+
+SQLITE_SHIM="$AGENTS_DIR/bin/sqlite3"
+if [ -f "$SQLITE_SHIM" ] && grep -q "sqlite3 compatibility shim for agmsg" "$SQLITE_SHIM" 2>/dev/null; then
+  rm "$SQLITE_SHIM"
+  echo "  - removed $SQLITE_SHIM"
+  REMOVED=true
+fi
+
 # --- 3. Remove skill directories ---
 for SKILL_DIR in "${SKILL_DIRS[@]}"; do
   SKILL_NAME="$(basename "$SKILL_DIR")"
@@ -264,6 +283,7 @@ fi
 
 # --- 5. Clean up empty ~/.agents/ ---
 if [ -d "$AGENTS_DIR" ]; then
+  rmdir "$AGENTS_DIR/bin" 2>/dev/null || true
   rmdir "$AGENTS_DIR/skills" 2>/dev/null || true
   rmdir "$AGENTS_DIR" 2>/dev/null || true
 fi


### PR DESCRIPTION
## Summary

- Add optional native Windows helpers: a PowerShell function wrapper, a Git Bash runner, and a sqlite3 compatibility shim.
- Normalize `sqlite3 readfile()` paths in `delivery.sh` so native Windows sqlite can read Git Bash paths.
- Install/update/uninstall the helpers and document the PowerShell profile opt-in step.
- Add install tests for helper generation, update restoration, and runner-based send/inbox flow.

## Why

Native Windows Codex sessions run from PowerShell, while agmsg's core scripts are POSIX shell. The wrapper keeps user message text in environment variables across the PowerShell to Git Bash boundary, and the sqlite3 shim restores LF/raw separator output expected by inbox/history parsing.

## Validation

- `npm test`
- `bash -n install.sh uninstall.sh scripts/delivery.sh scripts/windows/agmsg-run.sh scripts/windows/sqlite3-shim.sh`
- Fake-HOME Windows helper generation smoke with `AGMSG_FORCE_WINDOWS=1`
- Fake-HOME runner send/inbox smoke preserving spaces and quotes
- Fake-HOME `delivery.sh set turn` / `status` smoke through Git Bash with `commandWindows`
- PowerShell dot-source smoke for generated `agmsg.ps1`

Full Bats suite was not run locally because `bats` is not installed in this environment.