### PR TITLE
Make the `monitor` mode and `delivery.sh set` work under Claude Code's sandboxed Bash tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,28 @@ The message store path resolves as **`AGMSG_STORAGE_PATH` (env) > built-in defau
 AGMSG_STORAGE_PATH=/tmp/agmsg-sandbox ./scripts/send.sh myteam alice bob "hi"
 ```
 
+### Sandbox compatibility (Claude Code)
+
+Claude Code's sandbox restricts filesystem writes to the project directory. In `monitor` mode, `watch.sh` runs inside the sandbox and needs to write pidfiles and SQLite WAL files under `~/.agents/skills/agmsg/`. If you have sandboxing enabled, add an allowlist entry to your settings:
+
+**`~/.claude/settings.json`** (user-level — applies to all projects):
+
+```json
+{
+  "sandbox": {
+    "filesystem": {
+      "allowWrite": [
+        "~/.agents/skills/agmsg/"
+      ]
+    }
+  }
+}
+```
+
+This can also go in project-level `.claude/settings.local.json` if you prefer per-project scope. The allowlist merges across all settings scopes and takes effect immediately — no restart needed.
+
+If you installed agmsg under a custom command name (e.g. `m`), adjust the path accordingly (`~/.agents/skills/m/`).
+
 ## Tests
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -101,6 +101,26 @@ Do NOT manually edit config files. Always use join.sh.
 #  TaskStop + relaunch dance described in the cmd template.)
 ```
 
+## Sandbox compatibility (Claude Code)
+
+When Claude Code's sandbox is enabled, `watch.sh` (monitor mode) runs inside the sandbox and needs to write pidfiles and SQLite WAL files under `~/.agents/skills/agmsg/`. Add an allowlist entry to `~/.claude/settings.json` (or project-level `.claude/settings.local.json`):
+
+```json
+{
+  "sandbox": {
+    "filesystem": {
+      "allowWrite": [
+        "~/.agents/skills/agmsg/"
+      ]
+    }
+  }
+}
+```
+
+The allowlist merges across scopes and takes effect immediately — no restart needed. If agmsg was installed under a custom command name (e.g. `m`), adjust the path accordingly.
+
+**Note on `BASH_SOURCE`**: The sandboxed Bash tool runs commands via pipe/eval, so `BASH_SOURCE[0]` is empty inside sourced functions like `storage.sh`. This is handled internally — `watch.sh` resolves `SKILL_DIR` from `$0` (which works correctly when invoked as a command), and `storage.sh` falls back to that value. No user configuration needed.
+
 ## Architecture
 
 - **Storage**: SQLite with WAL mode in `~/.agents/skills/agmsg/db/messages.db`

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -59,7 +59,7 @@ strip_agmsg_event_file() {
   local path="$1"
   local event="$2"
   local tmp
-  tmp=$(mktemp)
+  tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
   if ! sqlite3 :memory: "
     WITH src AS (SELECT readfile('$path') AS j)
     SELECT CASE
@@ -122,7 +122,7 @@ add_event_entry_file() {
   entry_esc=$(printf '%s' "$entry" | sed "s/'/''/g")
 
   local tmp
-  tmp=$(mktemp)
+  tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
   if ! sqlite3 :memory: "
     WITH base AS (
       SELECT CASE WHEN json_extract(readfile('$path'), '\$.hooks') IS NULL
@@ -155,7 +155,7 @@ add_event_entry_file() {
 prune_empty_hooks_file() {
   local path="$1"
   local tmp
-  tmp=$(mktemp)
+  tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
   if ! sqlite3 :memory: "
     WITH src AS (SELECT readfile('$path') AS j)
     SELECT CASE
@@ -275,7 +275,7 @@ apply_settings() {
   # Work on a temp copy so a partially-modified file never replaces the
   # original until the whole chain succeeds.
   local tmp_state
-  tmp_state=$(mktemp)
+  tmp_state=$(mktemp "${TMPDIR:-/tmp}/agmsg-state.XXXXXX")
   if [ -f "$hooks_file" ]; then
     cp "$hooks_file" "$tmp_state"
   else

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -7,7 +7,8 @@
 #
 # Resolution order:
 #   1. AGMSG_STORAGE_PATH — directory that holds messages.db (env override)
-#   2. built-in default   — <skill>/db
+#   2. SKILL_DIR env var  — set by callers before sourcing (sandbox fallback)
+#   3. BASH_SOURCE[0]     — derive from this file's own path (standard case)
 #
 # [seam] A config-file layer is expected to slot in between the env override
 # and the built-in default once the storage-driver work lands; the intended
@@ -22,8 +23,18 @@ agmsg_storage_dir() {
     return
   fi
   local lib_dir skill_dir
-  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  skill_dir="$(cd "$lib_dir/../.." && pwd)"
+  if [ -n "${BASH_SOURCE[0]:-}" ]; then
+    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    skill_dir="$(cd "$lib_dir/../.." && pwd)"
+  elif [ -n "${SKILL_DIR:-}" ]; then
+    # BASH_SOURCE empty — e.g. Claude Code sandbox runs Bash via pipe/eval
+    # so BASH_SOURCE is not populated. Fall back to SKILL_DIR which the
+    # calling script resolves from $0 (which IS populated correctly).
+    skill_dir="$SKILL_DIR"
+  else
+    echo "Error: cannot resolve storage dir (BASH_SOURCE and SKILL_DIR both empty)" >&2
+    return 1
+  fi
   printf '%s\n' "$skill_dir/db"
 }
 

--- a/scripts/release/sync-version.sh
+++ b/scripts/release/sync-version.sh
@@ -64,7 +64,7 @@ for rel in "${DERIVED[@]}"; do
     rc=1
     continue
   fi
-  tmp=$(mktemp)
+  tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg-ver.XXXXXX")
   jq --arg v "$VERSION" '.version = $v' "$path" > "$tmp"
   mv "$tmp" "$path"
   echo "  $rel: $current -> $VERSION"

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -55,13 +55,21 @@ mkdir -p "$RUN_DIR" 2>/dev/null || true
 # Stop the prior holder before claiming the slot. ps args check defends
 # against pid recycling — only touch processes whose cmdline still matches
 # our watch.sh. See #66.
+#
+# When ps is unavailable (e.g. Claude Code sandbox), fall back to kill -0
+# which confirms the pid is alive but cannot validate the cmdline.
 if [ -f "$PIDFILE" ]; then
   prev_pid=$(cat "$PIDFILE" 2>/dev/null || true)
   if [ -n "$prev_pid" ] && [ "$prev_pid" != "$$" ] && kill -0 "$prev_pid" 2>/dev/null; then
     prev_cmd=$(ps -o args= -p "$prev_pid" 2>/dev/null || true)
-    case "$prev_cmd" in
-      *"$SKILL_DIR/scripts/watch.sh"*) kill "$prev_pid" 2>/dev/null || true ;;
-    esac
+    if [ -n "$prev_cmd" ]; then
+      case "$prev_cmd" in
+        *"$SKILL_DIR/scripts/watch.sh"*) kill "$prev_pid" 2>/dev/null || true ;;
+      esac
+    else
+      # ps unavailable (sandboxed) — skip cmdline validation, rely on kill -0
+      kill "$prev_pid" 2>/dev/null || true
+    fi
   fi
 fi
 

--- a/templates/cmd.claude-code.md
+++ b/templates/cmd.claude-code.md
@@ -93,6 +93,22 @@ Four possible outputs:
 
 Then continue with the user's subcommand. This catches the case where the user invokes `/__SKILL_NAME__` as the first prompt before the SessionStart-hook directive has been acted on.
 
+**Sandbox compatibility.** When Claude Code's sandbox is enabled, `watch.sh` (monitor mode) runs inside the sandbox and needs to write pidfiles and SQLite WAL files under `~/.agents/skills/__SKILL_NAME__/`. If monitor mode fails with write/permission errors there, add an allowlist entry to `~/.claude/settings.json` (or project-level `.claude/settings.local.json`):
+
+```json
+{
+  "sandbox": {
+    "filesystem": {
+      "allowWrite": [
+        "~/.agents/skills/__SKILL_NAME__/"
+      ]
+    }
+  }
+}
+```
+
+The allowlist merges across scopes and takes effect immediately — no restart needed. (The `BASH_SOURCE`-empty case under the sandbox — the Bash tool runs commands via pipe/eval, so `BASH_SOURCE[0]` is empty inside sourced functions — is handled internally: `watch.sh` resolves `SKILL_DIR` from `$0` and `storage.sh` falls back to it. No user configuration needed.)
+
 **If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
 1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
 2. Do NOT ask the user what to do — just run the inbox check.


### PR DESCRIPTION
Thank you for creating `agmsg`! This PR fixes two issues that arise when using it with [Claude Code's sandbox](https://code.claude.com/docs/en/sandbox-environments#sandboxed-bash-tool) enabled.

Note that I used LLMs to investigate and fix these issues, as well as writing this PR description. The models I used were the followings:

- GLM-5.1 and GLM-5.2 from Z.ai (for investigation and fixing)
- Claude Opus 4.8 from Anthropic (for testing on a Linux VM)

I used Claude Code as the harness.

All code changes were reviewed and tested by me.

## Summary

When Claude Code (CC) runs its Bash tool with the sandbox enabled (macOS `sandbox-exec` / Seatbelt; Linux seccomp-bpf), two categories of `agmsg` operations break:

- **`monitor` delivery** — `watch.sh` (launched via the Monitor tool) runs *inside* the sandbox and can't resolve its DB path, validate a prior watcher, or (without a one-line user config) write its pidfile.
- **`delivery.sh set <mode>`** — invoked from a sandboxed Bash tool (e.g. via `/agmsg`), it aborts before writing `settings.local.json`.

This PR fixes both, and documents the single required user-side setting.

### Why it breaks

| Context | Sandboxed? | Scripts that run here |
|---|---|---|
| Hooks (SessionStart / Stop / SessionEnd) | **No** (outside) | `session-start.sh`, `session-end.sh`, `check-inbox.sh` |
| Monitor tool (persistent bash) | **Yes** (inside) | `watch.sh` |
| Bash tool (ad-hoc, incl. `/agmsg`) | **Yes** (inside) | `delivery.sh set …`, `agmsg send …` |

The sandbox allows **reads anywhere**, **writes only inside an allowlist**, and **blocks `ps`**. (It also blocks `kill -0` for arbitrary PIDs — see *Known limitations*.) Only the "inside sandbox" rows are affected.

## Changes

### 1. `scripts/lib/storage.sh` — DB path when `BASH_SOURCE[0]` is empty

CC's Bash tool runs commands via pipe/eval, so `BASH_SOURCE[0]` is empty inside `source`d functions. `agmsg_storage_dir()` used it to derive the DB path and fell back to CWD, resolving `messages.db` under the project dir instead of under the skill.

**Fix**: add a `SKILL_DIR` env-var fallback. Every script that sources `storage.sh` already resolves `SKILL_DIR` from `$0` (which *is* populated when the script is invoked as a command), so this needs no caller changes. Resolution order is now `AGMSG_STORAGE_PATH` → `BASH_SOURCE[0]` → `SKILL_DIR` → error.

### 2. `scripts/watch.sh` — graceful `ps` fallback

`watch.sh` validates a prior watcher's cmdline via `ps -o args=` before killing it (pid-recycling defense, #66). Under the sandbox `ps` is blocked, which crashed the branch. Now it treats empty `ps` output as "ps unavailable" and proceeds without the cmdline check.

> ⚠️ Caveat (see *Known limitations*): the gate guarding this block is `kill -0 "$prev_pid"`, which is *also* blocked under the sandbox — so in practice the whole dedup is skipped and a superseded watcher can be orphaned (minor). Documented, not fixed here.

### 3. `scripts/delivery.sh` + `scripts/release/sync-version.sh` — anchor `mktemp` to `$TMPDIR`

`delivery.sh set …` runs under `set -euo pipefail`. Its settings-injection helpers (`strip_agmsg_event_file`, `add_event_entry_file`, `prune_empty_hooks_file`, `apply_settings`) each call **bare `mktemp`**. On macOS, BSD `mktemp` with no template resolves the temp dir via `confstr(_CS_DARWIN_USER_TEMP_DIR)` to `/var/folders/.../T/` and **ignores the `$TMPDIR` env var**. CC's sandbox blocks that path, so:

```
$ mktemp
mktemp: mkstemp failed on /var/folders/1j/…/T/tmp.IoANuLvaKm: Operation not permitted
```

That aborts the entire `set` before it ever reaches the `settings.local.json` write. (The hooks file itself is innocent — it lives inside the project and is writable.)

**Fix**: anchor every `mktemp` to the sandbox temp dir. GNU `mktemp` (Linux) already honors `$TMPDIR`, so the explicit form is portable and strictly safer there too.

```bash
tmp=$(mktemp)                                    # before
tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")     # after
```

### 4. `README.md` + `SKILL.md` — document the required `allowWrite` setting

Monitor mode needs to write pidfiles and SQLite WAL/SHM under `~/.agents/skills/agmsg/`, which is outside the project dir. Users with the sandbox enabled must allowlist it. Both docs now describe this and the `BASH_SOURCE` handling.

## User-facing requirement

Users with Claude Code's sandbox enabled need to add (any settings scope):

```json
{
  "sandbox": {
    "filesystem": {
      "allowWrite": ["~/.agents/skills/agmsg/"]
    }
  }
}
```

Future improvement (not in this PR): `delivery.sh set monitor` could auto-inject this into `.claude/settings.local.json` so no manual config is needed.

## Testing

| Platform | Sandbox | Result |
|---|---|---|
| macOS (Apple Silicon) | `sandbox-exec` (Seatbelt) | ✅ `monitor` delivery end-to-end; `delivery.sh set monitor\|turn\|off` all write `settings.local.json` |
| Linux VM | seccomp-bpf | ✅ `monitor` delivery verified end-to-end |

## Known limitations

There are two minor issues remaining under the sandbox.

- **`delivery.sh status` misreports live watchers as dead.** `do_status` classifies pidfiles with `kill -0 "$pid"`, which the sandbox blocks for any pid ≠ `$$`. A genuinely-running watcher is reported `0 alive, 1 stale`. Same mechanism as the `ps` block; reproduces on macOS **and** Linux.
- **`watch.sh` prior-watcher dedup is skipped under the sandbox** (the `kill -0` gate in change #2), so a superseded `watch.sh` can be orphaned until it exits on its own. Minor; the new watcher still takes over via the pidfile.

Both stem from `kill -0`/`ps` being unavailable in-sandbox. The right fix is a design choice — a **heartbeat file** (`watch.sh` touches `run/watch.<sid>.heartbeat` each poll cycle; liveness checks read its mtime) is the leading candidate, vs. degrading gracefully ("N pidfiles present, liveness unverifiable"). Left for a follow-up PR because it's a behavior decision best made by the maintainer. Happy to open a separate PR for it.
