### PR TITLE
fix(resolve): resolve session's real project from subdir/worktree (#92)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -91,6 +91,29 @@ A marker file (`run/.lastcheck-<agent>`) tracks the last check time. Configurabl
 | New messages | `decision: "block"` | `decision: "block"` |
 | UI label | "Stop hook error:" ([#2](https://github.com/fujibee/agmsg/issues/2)) | "warning:" ([#2](https://github.com/fujibee/agmsg/issues/2)) |
 
+### Project resolution ([#92](https://github.com/fujibee/agmsg/issues/92))
+
+Slash commands pass `"$(pwd)"` as the project key. When the user `cd`s into a
+subdirectory or git worktree of the project the session actually lives in, that
+pwd no longer matches the registered project — lookups miss and a phantom record
+gets minted for the subdir. `lib/resolve-project.sh` recovers the real root with
+two signals, neither needing a stable `session_id` (Codex doesn't expose one):
+
+1. **Per-process marker.** At SessionStart, `proj.<agent_pid>.project` records
+   the authoritative project (the hook's baked-in `$2`), keyed by the enclosing
+   agent process PID. A slash command runs as a child of that same process, so
+   it walks the ppid chain to the agent PID and reads the marker back. Trust is
+   gated on the PID still being a live agent process (recycling guard); stale
+   markers are GC'd at SessionStart/SessionEnd.
+2. **Ancestor walk.** Failing a marker, the nearest ancestor of pwd that is a
+   registered project for the type wins. Git-independent, so it also covers
+   worktrees, non-git trees, and Codex.
+
+Order: marker → ancestor → pwd (unchanged fallback). Resolution is applied by
+the agent-driven entry scripts (`whoami.sh`, `actas-claim.sh`, `join.sh`,
+`reset.sh`); direct shell invocations and `spawn.sh`'s explicit `--project` opt
+out via `AGMSG_RESOLVE_PROJECT=0`.
+
 ## Scripts
 
 | Script | Purpose |
@@ -124,6 +147,7 @@ All scripts use only `bash` and `sqlite3`. No python3 dependency.
 │   └── config.yaml       # User configuration
 ├── run/                  # Hook/watcher runtime state
 │   ├── watch.<sid>.pid   # Monitor watcher pidfiles
+│   ├── proj.<pid>.project # Session's real project root, keyed by agent PID (#92)
 │   └── .lastcheck-*      # Cooldown markers
 └── teams/
     └── <team>/

--- a/docs/design.md
+++ b/docs/design.md
@@ -97,22 +97,31 @@ Slash commands pass `"$(pwd)"` as the project key. When the user `cd`s into a
 subdirectory or git worktree of the project the session actually lives in, that
 pwd no longer matches the registered project — lookups miss and a phantom record
 gets minted for the subdir. `lib/resolve-project.sh` recovers the real root with
-two signals, neither needing a stable `session_id` (Codex doesn't expose one):
+three signals, none needing a stable `session_id` (Codex doesn't expose one):
 
 1. **Per-process marker.** At SessionStart, `proj.<agent_pid>.project` records
    the authoritative project (the hook's baked-in `$2`), keyed by the enclosing
    agent process PID. A slash command runs as a child of that same process, so
    it walks the ppid chain to the agent PID and reads the marker back. Trust is
    gated on the PID still being a live agent process (recycling guard); stale
-   markers are GC'd at SessionStart/SessionEnd.
+   markers are GC'd at SessionStart/SessionEnd. **Claude Code monitor/both
+   only** — Codex rejects monitor mode (no Monitor tool), so it never installs
+   `session-start.sh` and writes no marker; Codex relies on signals 2–3.
 2. **Ancestor walk.** Failing a marker, the nearest ancestor of pwd that is a
-   registered project for the type wins. Git-independent, so it also covers
-   worktrees, non-git trees, and Codex.
+   registered project for the type wins. Git-independent — covers nested
+   subdirs and worktrees that live *under* the registered project, on cc and
+   Codex alike.
+3. **Git common-dir.** Failing that, the registered main checkout of pwd's git
+   repo (via `git rev-parse --git-common-dir`), recovering a *sibling* worktree
+   the ancestor walk cannot reach. Validated against the registry, so it
+   declines when registration sits on an umbrella parent dir.
 
-Order: marker → ancestor → pwd (unchanged fallback). Resolution is applied by
-the agent-driven entry scripts (`whoami.sh`, `actas-claim.sh`, `join.sh`,
-`reset.sh`); direct shell invocations and `spawn.sh`'s explicit `--project` opt
-out via `AGMSG_RESOLVE_PROJECT=0`.
+Order: marker → ancestor → git-common-dir → pwd (unchanged fallback).
+Resolution is applied by the agent-driven entry points (`whoami.sh`,
+`actas-claim.sh`, `join.sh`, `reset.sh`, and `watch.sh` — whose subscription
+must track the same resolved project); direct shell invocations and
+`spawn.sh`'s explicit `--project` opt out via `AGMSG_RESOLVE_PROJECT=0`.
+`identities.sh` stays a pure lookup — its callers pass an already-resolved path.
 
 ## Scripts
 

--- a/scripts/actas-claim.sh
+++ b/scripts/actas-claim.sh
@@ -32,6 +32,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"  # actas-lock.sh requires SKILL_DIR
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"
+
+# Resolve the session's real project root (see #92) before any lookup, so an
+# actas issued from a subdir/worktree claims against the registered project
+# rather than missing it as not_registered.
+PROJECT="$(agmsg_resolve_project "$PROJECT" "$TYPE")"
 
 # Find the team(s) this name is registered to for the given project/type.
 TEAMS=""

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -20,7 +20,18 @@ case "$AGENT_TYPE" in
 esac
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEAMS_DIR="$SCRIPT_DIR/../teams"
+
+# Resolve the session's real project root from the passed pwd (see #92), so an
+# agent-driven join from a subdir/worktree registers under the project the
+# session lives in instead of minting a phantom record for the subdir.
+# Callers passing an explicit, deliberate path (e.g. spawn.sh's --project, which
+# may not be registered yet) set AGMSG_RESOLVE_PROJECT=0 to keep their path.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"
+PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
+
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
 
 # --- Ensure team config exists ---

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# resolve-project.sh — resolve an agent SESSION's real project root from a
+# possibly-misleading invocation pwd. See #92.
+#
+# Background: agmsg slash commands pass "$(pwd)" as the project key. When the
+# user cd's into a subdirectory (or a git worktree) of the project the agent
+# session actually lives in, that pwd no longer matches the registered project,
+# so lookups silently miss and phantom registrations get created under a fresh
+# alias tied to the subdir.
+#
+# Two complementary signals recover the real root, NEITHER needing a stable
+# session_id (Codex slash commands don't expose one — docs/actas.md):
+#
+#   1. A per-process marker written at SessionStart, keyed by the enclosing
+#      agent process PID:  run/proj.<agent_pid>.project = <real root>
+#      Works for claude-code and codex alike — both have a process we can walk
+#      to via the ppid chain, and a slash command runs as a child of it.
+#   2. Ancestor walk: the nearest ancestor of pwd that is a registered project
+#      for this type. Git-independent (handles worktrees, non-git trees), and
+#      covers Codex / non-hook invocations where no marker was written.
+#
+# Resolution order: marker -> ancestor -> pwd. The pwd fallback is unchanged
+# behavior, so direct shell invocations and genuinely-unrelated directories
+# keep working as before. Set AGMSG_RESOLVE_PROJECT=0 to force the raw pwd:
+# used by spawn.sh, which passes an explicit, not-yet-registered --project that
+# must never be rewritten to the spawning session's own project.
+#
+# Required caller-set variable: SKILL_DIR — agmsg skill root.
+
+: "${SKILL_DIR:?resolve-project.sh requires SKILL_DIR}"
+
+_agmsg_run_dir() { printf '%s/run' "$SKILL_DIR"; }
+
+# Map an agent type to the binary basename(s) its process may carry.
+_agmsg_agent_binaries() {
+  case "$1" in
+    claude-code) echo "claude" ;;
+    codex)       echo "codex" ;;
+    gemini)      echo "gemini" ;;
+    antigravity) echo "antigravity" ;;
+    copilot)     echo "copilot" ;;
+    *)           echo "claude codex gemini" ;;
+  esac
+}
+
+# Does <pid> currently look like an agent process of <type>? Checks both the
+# `comm` name and argv[0] basename. Guards marker trust against PID recycling —
+# a recycled pid pointing at an unrelated process must not hijack resolution.
+agmsg_pid_is_agent() {
+  local pid="$1" type="$2"
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  local binaries comm first base bin
+  binaries=$(_agmsg_agent_binaries "$type")
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null | xargs basename 2>/dev/null || true)
+  first=$(ps -o args= -p "$pid" 2>/dev/null | awk '{print $1}')
+  base=$(basename -- "${first:-}" 2>/dev/null || true)
+  for bin in $binaries; do
+    case "$comm" in "$bin"|"$bin"-*) return 0 ;; esac
+    [ "$base" = "$bin" ] && return 0
+  done
+  return 1
+}
+
+# Walk the process tree from $$ upward, echoing the PID of the nearest ancestor
+# that looks like an agent process of <type>. Empty (return 1) when none is
+# found — e.g. a detached watcher or a plain human shell.
+agmsg_agent_pid() {
+  local type="$1"
+  local pid="$$" hops=0
+  while [ "${pid:-0}" -gt 1 ] && [ "$hops" -lt 20 ]; do
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    [ -z "$pid" ] && return 1
+    [ "$pid" = "0" ] && return 1
+    if agmsg_pid_is_agent "$pid" "$type"; then
+      printf '%s' "$pid"
+      return 0
+    fi
+    hops=$((hops + 1))
+  done
+  return 1
+}
+
+agmsg_project_marker_path() { printf '%s/proj.%s.project' "$(_agmsg_run_dir)" "$1"; }
+
+# Persist <project> as the real root for agent <pid>. Best-effort.
+agmsg_write_project_marker() {
+  local pid="$1" project="$2" dir
+  [ -n "$pid" ] && [ -n "$project" ] || return 1
+  dir="$(_agmsg_run_dir)"
+  mkdir -p "$dir" 2>/dev/null || true
+  printf '%s\n' "$project" > "$(agmsg_project_marker_path "$pid")" 2>/dev/null || return 1
+}
+
+# Read the marker for <pid>, but only trust it when <pid> is still a live agent
+# process of <type>. Empty (return 1) otherwise.
+agmsg_read_project_marker() {
+  local pid="$1" type="$2" f
+  f="$(agmsg_project_marker_path "$pid")"
+  [ -f "$f" ] || return 1
+  agmsg_pid_is_agent "$pid" "$type" || return 1
+  head -1 "$f" 2>/dev/null
+}
+
+# Remove markers whose pid is no longer alive. Liveness-only (not argv) so a
+# transient ps hiccup can't delete a live agent's marker; a recycled-but-live
+# pid is handled by the read-side argv check instead.
+agmsg_marker_gc_stale() {
+  local dir; dir="$(_agmsg_run_dir)"
+  [ -d "$dir" ] || return 0
+  local f pid
+  for f in "$dir"/proj.*.project; do
+    [ -f "$f" ] || continue
+    pid=${f##*/proj.}; pid=${pid%.project}
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    kill -0 "$pid" 2>/dev/null || rm -f "$f"
+  done
+}
+
+# List distinct registered project paths for <type>, one per line.
+agmsg_registered_projects() {
+  local type="$1" teams_dir="$SKILL_DIR/teams" config_file cfg_sql
+  [ -d "$teams_dir" ] || return 0
+  for config_file in "$teams_dir"/*/config.json; do
+    [ -f "$config_file" ] || continue
+    cfg_sql=$(sed "s/'/''/g" "$config_file")
+    sqlite3 :memory: ".param set :json '$cfg_sql'" "
+      WITH agents AS (
+        SELECT CASE
+          WHEN json_type(json_extract(value, '\$.registrations')) = 'array' THEN json_extract(value, '\$.registrations')
+          ELSE json_array(json_object('type', json_extract(value, '\$.type'), 'project', json_extract(value, '\$.project')))
+        END AS registrations
+        FROM json_each(json_extract(:json, '\$.agents'))
+      )
+      SELECT DISTINCT json_extract(r.value, '\$.project')
+      FROM agents, json_each(agents.registrations) AS r
+      WHERE json_extract(r.value, '\$.type') = '$type';
+    "
+  done
+}
+
+# Echo the nearest ancestor of <start> (inclusive) that is a registered project
+# for <type>. return 1 when none matches.
+agmsg_ancestor_project() {
+  local start="$1" type="$2" projects d
+  projects="$(agmsg_registered_projects "$type")"
+  [ -n "$projects" ] || return 1
+  d="$start"
+  while [ -n "$d" ] && [ "$d" != "/" ] && [ "$d" != "." ]; do
+    if printf '%s\n' "$projects" | grep -Fxq "$d"; then
+      printf '%s' "$d"
+      return 0
+    fi
+    d=$(dirname "$d")
+  done
+  return 1
+}
+
+# Resolve the real project root for a slash-command invocation.
+# Usage: agmsg_resolve_project <pwd_path> <type>
+agmsg_resolve_project() {
+  local pwd_path="$1" type="$2" pid marker anc
+  # Explicit opt-out: caller passed a deliberate, possibly-unregistered path.
+  if [ "${AGMSG_RESOLVE_PROJECT:-1}" = "0" ]; then
+    printf '%s' "$pwd_path"; return 0
+  fi
+  # 1) Per-process SessionStart marker (precise; cc + codex).
+  if pid="$(agmsg_agent_pid "$type")" && [ -n "$pid" ]; then
+    if marker="$(agmsg_read_project_marker "$pid" "$type")" && [ -n "$marker" ]; then
+      printf '%s' "$marker"; return 0
+    fi
+  fi
+  # 2) Nearest registered ancestor of pwd (git-independent; covers codex).
+  if anc="$(agmsg_ancestor_project "$pwd_path" "$type")" && [ -n "$anc" ]; then
+    printf '%s' "$anc"; return 0
+  fi
+  # 3) Unchanged fallback.
+  printf '%s' "$pwd_path"
+}

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -139,6 +139,28 @@ agmsg_registered_projects() {
   done
 }
 
+# Echo the main-checkout root of <start>'s git repo, but only when it is a
+# registered project for <type>. This recovers a SIBLING git worktree back to
+# the registered main checkout — a case the ancestor walk cannot reach because
+# the worktree is not nested under the registered path. Validation against the
+# registry keeps it from misfiring when registration sits on an umbrella parent
+# dir (the git checkout itself is then unregistered, so we decline and let the
+# ancestor walk handle it). return 1 when git is absent or nothing matches.
+agmsg_gitcommon_project() {
+  local start="$1" type="$2" common main projects
+  command -v git >/dev/null 2>&1 || return 1
+  [ -d "$start" ] || return 1
+  common=$(cd "$start" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null) || return 1
+  [ -n "$common" ] || return 1
+  # --git-common-dir may be relative to <start>; make it absolute.
+  case "$common" in /*) ;; *) common="$start/$common" ;; esac
+  main=$(cd "$(dirname "$common")" 2>/dev/null && pwd) || return 1
+  projects="$(agmsg_registered_projects "$type")"
+  [ -n "$projects" ] || return 1
+  printf '%s\n' "$projects" | grep -Fxq "$main" || return 1
+  printf '%s' "$main"
+}
+
 # Echo the nearest ancestor of <start> (inclusive) that is a registered project
 # for <type>. return 1 when none matches.
 agmsg_ancestor_project() {
@@ -159,21 +181,28 @@ agmsg_ancestor_project() {
 # Resolve the real project root for a slash-command invocation.
 # Usage: agmsg_resolve_project <pwd_path> <type>
 agmsg_resolve_project() {
-  local pwd_path="$1" type="$2" pid marker anc
+  local pwd_path="$1" type="$2" pid marker anc gitc
   # Explicit opt-out: caller passed a deliberate, possibly-unregistered path.
   if [ "${AGMSG_RESOLVE_PROJECT:-1}" = "0" ]; then
     printf '%s' "$pwd_path"; return 0
   fi
-  # 1) Per-process SessionStart marker (precise; cc + codex).
+  # 1) Per-process SessionStart marker (precise). Written only by session-start
+  #    (cc monitor/both); codex never installs it, so codex relies on 2)/3).
   if pid="$(agmsg_agent_pid "$type")" && [ -n "$pid" ]; then
     if marker="$(agmsg_read_project_marker "$pid" "$type")" && [ -n "$marker" ]; then
       printf '%s' "$marker"; return 0
     fi
   fi
-  # 2) Nearest registered ancestor of pwd (git-independent; covers codex).
+  # 2) Nearest registered ancestor of pwd (git-independent; covers nested
+  #    subdirs and worktrees that live under the registered project).
   if anc="$(agmsg_ancestor_project "$pwd_path" "$type")" && [ -n "$anc" ]; then
     printf '%s' "$anc"; return 0
   fi
-  # 3) Unchanged fallback.
+  # 3) Registered main checkout of pwd's git repo (recovers a SIBLING worktree
+  #    the ancestor walk cannot reach). Validated against the registry.
+  if gitc="$(agmsg_gitcommon_project "$pwd_path" "$type")" && [ -n "$gitc" ]; then
+    printf '%s' "$gitc"; return 0
+  fi
+  # 4) Unchanged fallback.
   printf '%s' "$pwd_path"
 }

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -20,6 +20,12 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEAMS_DIR="$SKILL_DIR/teams"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"
+
+# Resolve the session's real project root (see #92) so a drop issued from a
+# subdir/worktree clears the registration on the project the session lives in.
+PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
 
 if [ -z "$TARGET_AGENT" ]; then
   WHOAMI=$(bash "$SCRIPT_DIR/whoami.sh" "$PROJECT_PATH" "$AGENT_TYPE")

--- a/scripts/session-end.sh
+++ b/scripts/session-end.sh
@@ -24,6 +24,12 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUN_DIR="$SKILL_DIR/run"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"
+
+# Drop project markers (#92) whose agent process has exited. Liveness-based, so
+# a session that persists across /clear keeps its marker until the process dies.
+agmsg_marker_gc_stale 2>/dev/null || true
 
 INPUT=$(cat 2>/dev/null || true)
 SESSION_ID=""

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -32,6 +32,8 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUN_DIR="$SKILL_DIR/run"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"
 
 # Identity sanity check — no point launching a watcher with an empty pair set.
 PAIRS=$("$SCRIPT_DIR/identities.sh" "$PROJECT" "$TYPE" 2>/dev/null || true)
@@ -146,6 +148,16 @@ done
 # above, since the liveness check enumerates the remaining cc-instance.*
 # files. See #62.
 actas_lock_gc_stale >/dev/null 2>&1 || true
+
+# --- Record this session's real project root, keyed by the agent process. ---
+# Slash commands resolve the project from $(pwd), which breaks when the user
+# cd's into a subdir/worktree (see #92). Persist the authoritative project (our
+# $2, baked into the hook at delivery time) keyed by the enclosing agent PID so
+# actas/join/whoami can recover it without a stable session_id — the key that
+# makes this work for Codex too. Drop markers whose agent process has died.
+agmsg_marker_gc_stale 2>/dev/null || true
+AGENT_PID=$(agmsg_agent_pid "$TYPE" 2>/dev/null || true)
+[ -n "$AGENT_PID" ] && agmsg_write_project_marker "$AGENT_PID" "$PROJECT" 2>/dev/null || true
 
 
 # --- Dedup against the previous watcher in this CC instance. ---

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -173,7 +173,10 @@ case "$STATE" in
 esac
 
 # --- Pre-join so the child's actas just claims (no interactive team prompt) ---
-"$SCRIPT_DIR/join.sh" "$TEAM" "$NAME" "$AGENT_TYPE" "$PROJECT" >/dev/null
+# PROJECT here is the explicit spawn target (--project / $PWD), which may not be
+# registered yet. Opt out of #92 pwd-resolution so join.sh registers exactly
+# this path rather than rewriting it to the spawning session's own project.
+AGMSG_RESOLVE_PROJECT=0 "$SCRIPT_DIR/join.sh" "$TEAM" "$NAME" "$AGENT_TYPE" "$PROJECT" >/dev/null
 
 # --- Build the boot script the new agent will run ---
 # Rather than embed a multiply-escaped command string into each platform's

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -37,6 +37,16 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"
+
+# Resolve the session's real project root (see #92). The actas/drop/ensure-
+# monitor flows relaunch this watcher with a raw "$(pwd)"; without resolution a
+# watcher started from a subdir/worktree finds no registration and exits, so
+# actas would switch the from-line yet silently kill the receive side. A
+# detached watcher (no agent process to walk to) degrades to the ancestor /
+# git-common-dir signals, which still recover the nested/worktree cases.
+PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
 DB="$(agmsg_db_path)"
 RUN_DIR="$SKILL_DIR/run"
 PIDFILE="$RUN_DIR/watch.$SESSION_ID.pid"

--- a/scripts/whoami.sh
+++ b/scripts/whoami.sh
@@ -72,7 +72,14 @@ PROJECT_PATH="${1:?Usage: whoami.sh <project_path> [type]}"
 AGENT_TYPE="${2:-$(detect_cli_type)}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEAMS_DIR="$SCRIPT_DIR/../teams"
+
+# Resolve the session's real project root from the passed pwd (see #92): a cd
+# into a subdir/worktree must not be treated as a fresh, unregistered project.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"
+PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
 
 if [ ! -d "$TEAMS_DIR" ]; then
   echo "not_joined=true available_teams=none"

--- a/tests/test_resolve_project.bats
+++ b/tests/test_resolve_project.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+
+# Tests for #92 project resolution: a slash command issued from a subdir or
+# git worktree must resolve to the registered project the session lives in,
+# not mint a phantom record for the subdir.
+#
+# Coverage:
+#   - lib/resolve-project.sh: ancestor walk, marker precedence, opt-out,
+#     pwd fallback, type isolation, marker GC, pid-recycling guard
+#   - entry scripts (whoami/actas-claim/join) resolving end-to-end from a subdir
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  export RUN_DIR="$SKILL_DIR/run"
+  mkdir -p "$RUN_DIR"
+
+  # A real project tree so dirname-based ancestor walking operates on real
+  # paths: ROOT/sub/deep.
+  export ROOT="$(mktemp -d)"
+  mkdir -p "$ROOT/sub/deep"
+
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/resolve-project.sh"
+}
+
+teardown() {
+  rm -rf "$ROOT"
+  teardown_test_env
+}
+
+# Register (team, agent, project) without resolution, so test fixtures land at
+# the exact path we ask for regardless of cwd.
+reg() {
+  AGMSG_RESOLVE_PROJECT=0 bash "$SKILL_DIR/scripts/join.sh" "$1" "$2" "${4:-claude-code}" "$3"
+}
+
+# --- ancestor walk ---
+
+@test "resolve: subdir resolves to the registered ancestor project" {
+  reg T alice "$ROOT"
+  result="$(agmsg_resolve_project "$ROOT/sub/deep" claude-code)"
+  [ "$result" = "$ROOT" ]
+}
+
+@test "resolve: registered path itself is returned unchanged" {
+  reg T alice "$ROOT"
+  result="$(agmsg_resolve_project "$ROOT" claude-code)"
+  [ "$result" = "$ROOT" ]
+}
+
+# --- pwd fallback ---
+
+@test "resolve: unrelated dir with no registered ancestor falls back to pwd" {
+  reg T alice "$ROOT"
+  other="$(mktemp -d)"
+  result="$(agmsg_resolve_project "$other/x" claude-code)"
+  [ "$result" = "$other/x" ]
+  rm -rf "$other"
+}
+
+# --- type isolation ---
+
+@test "resolve: ancestor of a different type does not match" {
+  reg T alice "$ROOT" claude-code
+  result="$(agmsg_resolve_project "$ROOT/sub" codex)"
+  [ "$result" = "$ROOT/sub" ]   # no codex registration → unchanged
+}
+
+# --- opt-out ---
+
+@test "resolve: AGMSG_RESOLVE_PROJECT=0 forces the raw pwd" {
+  reg T alice "$ROOT"
+  result="$(AGMSG_RESOLVE_PROJECT=0 agmsg_resolve_project "$ROOT/sub/deep" claude-code)"
+  [ "$result" = "$ROOT/sub/deep" ]
+}
+
+# --- marker precedence (forced via function overrides) ---
+
+@test "resolve: a valid marker wins over the ancestor walk" {
+  reg T alice "$ROOT"
+  local markroot="$(mktemp -d)"
+  # Force a marker lookup that succeeds for a synthetic pid.
+  agmsg_agent_pid() { printf '%s' 4242; }
+  agmsg_pid_is_agent() { return 0; }
+  agmsg_write_project_marker 4242 "$markroot"
+
+  result="$(agmsg_resolve_project "$ROOT/sub/deep" claude-code)"
+  [ "$result" = "$markroot" ]
+  rm -rf "$markroot"
+}
+
+# --- marker GC ---
+
+@test "marker-gc: removes markers for dead pids, keeps live ones" {
+  agmsg_write_project_marker 999999 "/some/dead"   # pid 999999 ~ never alive
+  agmsg_write_project_marker "$$" "/some/live"     # this bats process is alive
+  [ -f "$(agmsg_project_marker_path 999999)" ]
+  [ -f "$(agmsg_project_marker_path "$$")" ]
+
+  agmsg_marker_gc_stale
+
+  [ ! -f "$(agmsg_project_marker_path 999999)" ]
+  [ -f "$(agmsg_project_marker_path "$$")" ]
+}
+
+# --- pid-recycling guard ---
+
+@test "pid-is-agent: a live non-agent process is not trusted" {
+  # $$ is bats/bash, not claude/codex — must not be accepted as an agent.
+  run agmsg_pid_is_agent "$$" claude-code
+  [ "$status" -ne 0 ]
+}
+
+@test "read-marker: untrusted pid is not honored even if the file exists" {
+  agmsg_write_project_marker "$$" "/should/not/trust"   # $$ is not an agent
+  run agmsg_read_project_marker "$$" claude-code
+  [ "$status" -ne 0 ]
+}
+
+# --- end-to-end through entry scripts ---
+
+@test "whoami: subdir invocation resolves to the registered identity" {
+  reg T alice "$ROOT"
+  run bash "$SKILL_DIR/scripts/whoami.sh" "$ROOT/sub/deep" claude-code
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "agent=alice" ]]
+  [[ "$output" =~ "project=$ROOT" ]]
+}
+
+@test "actas-claim: subdir invocation claims against the registered project" {
+  reg T alice "$ROOT"
+  echo "sid-me" > "$RUN_DIR/cc-instance.$$"   # make sid-me look alive
+
+  run bash "$SKILL_DIR/scripts/actas-claim.sh" "$ROOT/sub/deep" claude-code alice "sid-me"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "status=ok" ]]
+  [[ "$output" =~ "team=T" ]]
+}
+
+@test "join: agent-driven subdir join registers under the resolved project" {
+  reg T alice "$ROOT"
+  bash "$SKILL_DIR/scripts/join.sh" T bob claude-code "$ROOT/sub"   # resolution ON
+
+  # bob lands on ROOT, not ROOT/sub.
+  run bash "$SKILL_DIR/scripts/identities.sh" "$ROOT" claude-code
+  [[ "$output" =~ "bob" ]]
+  run bash "$SKILL_DIR/scripts/identities.sh" "$ROOT/sub" claude-code
+  [[ ! "$output" =~ "bob" ]]
+}
+
+@test "join: explicit opt-out registers the exact path (spawn path)" {
+  reg T alice "$ROOT"
+  AGMSG_RESOLVE_PROJECT=0 bash "$SKILL_DIR/scripts/join.sh" T carol claude-code "$ROOT/sub"
+
+  run bash "$SKILL_DIR/scripts/identities.sh" "$ROOT/sub" claude-code
+  [[ "$output" =~ "carol" ]]
+}

--- a/tests/test_resolve_project.bats
+++ b/tests/test_resolve_project.bats
@@ -158,3 +158,69 @@ reg() {
   run bash "$SKILL_DIR/scripts/identities.sh" "$ROOT/sub" claude-code
   [[ "$output" =~ "carol" ]]
 }
+
+# --- watch.sh: actas/drop watcher must not die from a subdir (the High bug) ---
+
+@test "watch: actas watcher from a subdir does not exit with no-registration" {
+  reg T alice "$ROOT"
+  # Launch the actas watcher (ACTIVE_NAME=alice) from a subdir; without
+  # resolution it would see no registration and exit immediately.
+  bash "$SKILL_DIR/scripts/watch.sh" sid-w "$ROOT/sub/deep" claude-code alice \
+    >"$BATS_TEST_TMPDIR/w.out" 2>&1 &
+  local wpid=$!
+  sleep 1
+  # A resolving watcher is still alive in its poll loop; an unresolved one has
+  # already exited.
+  local alive=0
+  kill -0 "$wpid" 2>/dev/null && alive=1
+  kill "$wpid" 2>/dev/null || true
+  wait "$wpid" 2>/dev/null || true
+
+  [ "$alive" -eq 1 ]
+  run cat "$BATS_TEST_TMPDIR/w.out"
+  [[ ! "$output" =~ "no registration" ]]
+}
+
+# --- git common-dir: sibling worktree recovery, and no-misfire guard ---
+
+setup_git_repo() {
+  # Echo a realpath'd base dir so git's symlink-resolved paths match what we
+  # register (mktemp on macOS lives under a /var -> /private symlink).
+  local base; base="$(cd "$(mktemp -d)" && pwd -P)"
+  printf '%s' "$base"
+}
+
+@test "resolve: sibling git worktree resolves to the registered main checkout" {
+  command -v git >/dev/null 2>&1 || skip "git not available"
+  local base; base="$(setup_git_repo)"
+  local repo="$base/repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  git -C "$repo" worktree add -q "$base/repo-wt" >/dev/null 2>&1
+
+  reg T alice "$repo"   # registration on the main checkout
+
+  # repo-wt is a sibling of repo (not nested), so the ancestor walk misses and
+  # git-common-dir must recover the main checkout.
+  result="$(agmsg_resolve_project "$base/repo-wt" claude-code)"
+  [ "$result" = "$repo" ]
+  rm -rf "$base"
+}
+
+@test "resolve: nested worktree under a registered parent uses ancestor, not git-common-dir" {
+  command -v git >/dev/null 2>&1 || skip "git not available"
+  local base; base="$(setup_git_repo)"
+  mkdir -p "$base/parent/repo"
+  git -C "$base/parent/repo" init -q
+  git -C "$base/parent/repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  git -C "$base/parent/repo" worktree add -q "$base/parent/repo-wt" >/dev/null 2>&1
+
+  reg T alice "$base/parent"   # registration on the umbrella parent dir
+
+  # The git checkout ($base/parent/repo) is NOT registered, so git-common-dir
+  # must decline and the ancestor walk must win with the parent.
+  result="$(agmsg_resolve_project "$base/parent/repo-wt" claude-code)"
+  [ "$result" = "$base/parent" ]
+  rm -rf "$base"
+}


### PR DESCRIPTION
## Problem

Closes #92.

agmsg slash commands key the project off `"$(pwd)"`. When the user `cd`s into a subdirectory or git worktree of the project the session actually lives in, that pwd no longer matches the registered project:

- `whoami.sh` → `suggest=true` (treated as a different project)
- `actas-claim.sh` → `status=not_registered`
- `join.sh` → mints a **phantom** registration under a fresh alias tied to the subdir
- the `actas`/`drop` Monitor relaunch → `watch.sh` finds no registration and exits, so `actas` switches the from-line but **silently kills the receive side**

A live repro was hit while working in a git worktree (`.../ag-dev-agent/agmsg-spawn`) of an agent registered at the parent (`.../ag-dev-agent`).

## Approach

`lib/resolve-project.sh` recovers the real project root from a misleading pwd using three signals — **none require a stable `session_id`** (Codex slash commands don't expose one):

1. **Per-process marker.** At SessionStart, `run/proj.<agent_pid>.project` records the authoritative project (the hook's baked-in `$2`), keyed by the enclosing agent process PID. A slash command runs as a child of that process, so it walks the ppid chain to the agent PID and reads the marker back. Trust is gated on the PID still being a live agent process (PID-recycling guard); stale markers are GC'd at SessionStart/SessionEnd. **Claude Code monitor/both only** — Codex rejects monitor mode (no Monitor tool) so it never installs `session-start.sh` and writes no marker.
2. **Ancestor walk.** Failing a marker, the nearest ancestor of pwd registered for the type wins. Git-independent — covers nested subdirs and worktrees that live *under* the registered project, on cc and Codex alike.
3. **Git common-dir.** Failing that, the registered main checkout of pwd's git repo (`git rev-parse --git-common-dir`), recovering a *sibling* worktree the ancestor walk cannot reach. Validated against the registry, so it declines when registration sits on an umbrella parent dir (no misfire).

Resolution order: **marker → ancestor → git-common-dir → pwd** (unchanged fallback). Phantoms are impossible: a candidate is only adopted from the marker (authoritative) or when it matches an existing registration.

## Scope

- Applied by the agent-driven entry points: `whoami.sh`, `actas-claim.sh`, `join.sh`, `reset.sh`, and `watch.sh` (its subscription must track the same resolved project).
- Direct shell invocations and `spawn.sh`'s explicit `--project` (which may be a not-yet-registered path) opt out via `AGMSG_RESOLVE_PROJECT=0`.
- `identities.sh` stays a pure lookup — its internal callers pass an already-resolved path.

## Coverage by runtime

| Case | Claude Code | Codex |
|---|---|---|
| `cd` into a subdir of the registered project | marker / ancestor | ancestor |
| worktree nested under the registered project | marker / ancestor | ancestor |
| sibling git worktree of the registered checkout | git-common-dir | git-common-dir |
| unrelated dir | pwd (unchanged) | pwd (unchanged) |

## Tests

16 cases in `tests/test_resolve_project.bats` — ancestor walk, marker precedence, opt-out, type isolation, marker GC, PID-recycling guard, sibling-worktree via git-common-dir, no-misfire under an umbrella-parent registration, watcher-survives-subdir, and end-to-end through `whoami`/`actas-claim`/`join`.

**Full suite green: 220 passed, 0 failed.**

## Notes

- Template `actas` step 2 still checks role existence via `identities.sh "$(pwd)"` (which stays pure). This is benign: `join.sh` resolves before registering, so no phantom is created — at worst a redundant (idempotent) join call. Left as-is to avoid churning the slash-command templates.

## Out of scope (per #92)

- `watch.sh` honoring an existing actas lock at startup (Layer 1 safety net).
- A `clean.sh` to prune phantom registrations created before this fix.

---

Thanks to @fujibee's Codex reviewer for catching the `watch.sh` receive-side gap and the overstated Codex/worktree claims in the first pass.