### PR TITLE
fix(watch): persist per-session watermark so Monitor restarts don't silently drop messages

### DIFF
--- a/scripts/session-end.sh
+++ b/scripts/session-end.sh
@@ -50,6 +50,10 @@ if [ -f "$PIDFILE" ]; then
   rm -f "$PIDFILE"
 fi
 
+# Drop the per-session stream watermark (see #107) — the session is ending, so
+# there is no restart to resume; a future session_id reuse should start fresh.
+rm -f "$RUN_DIR/watch.$SESSION_ID.watermark" 2>/dev/null || true
+
 # Clean cc-instance entries that still point at this session_id. The
 # enclosing CC process may itself be exiting (matcher=logout/etc.), in which
 # case its cc-instance.<pid> file would otherwise be left stale.

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -15,9 +15,12 @@ set -u
 #     of those pairs.
 #   - When [active_name] is given, narrows the subscription to only pairs
 #     whose agent name matches — useful for `actas` exclusive role mode.
-#   - Sets the high-water mark to the current MAX(id) at startup so the
-#     stream begins with whatever arrives after launch — no replay of
-#     historical messages.
+#   - A fresh session sets the high-water mark to the current MAX(id) at
+#     startup, so the stream begins with whatever arrives after launch — no
+#     replay of historical messages. The mark is persisted per session_id, so
+#     a restart of this session's watcher (actas/drop/clear/self-restart)
+#     resumes from the last delivered id and does not drop messages that
+#     arrived during the restart gap. See #107.
 #   - Polls the SQLite DB at AGMSG_WATCH_INTERVAL seconds (default 5, also
 #     overridable via the delivery.monitor.poll_interval config key).
 #   - Emits one line per new message:
@@ -160,12 +163,37 @@ while IFS=$'\t' read -r team agent; do
   WHERE_PAIRS="${WHERE_PAIRS:+$WHERE_PAIRS OR }$pair"
 done <<< "$PAIRS"
 
-# Get the starting watermark. Missing DB is OK — we'll just block until it appears.
-LAST=0
-if [ -f "$DB" ]; then
-  LAST="$(sqlite3 "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE $WHERE_PAIRS;" 2>/dev/null || echo 0)"
+# Determine the starting watermark.
+#
+# The watermark is persisted per session_id so that a *restart* of this
+# session's watcher resumes from the last delivered id instead of jumping to
+# the current MAX(id). Monitor restarts are routine — `actas`/`drop` do
+# TaskStop + relaunch, `/clear`/resume re-fires the SessionStart directive, and
+# a killed watcher self-restarts — and the old "start from MAX(id)" behavior
+# silently dropped every message that landed in the gap between the previous
+# watcher stopping and the new one taking its mark. Resuming from the persisted
+# watermark closes that gap; staying strictly after the last delivered id
+# avoids re-streaming anything already seen. See #107.
+#
+# A *fresh* session (no persisted watermark) still starts from the current
+# MAX(id) — live push, no replay of history (the no-arg inbox check covers
+# historical unread, not this stream).
+WATERMARK_FILE="$RUN_DIR/watch.$SESSION_ID.watermark"
+persist_watermark() { printf '%s\n' "$LAST" > "$WATERMARK_FILE" 2>/dev/null || true; }
+
+LAST=""
+if [ -f "$WATERMARK_FILE" ]; then
+  LAST="$(cat "$WATERMARK_FILE" 2>/dev/null || true)"
+  case "$LAST" in ''|*[!0-9]*) LAST="" ;; esac
 fi
-case "$LAST" in ''|*[!0-9]*) LAST=0 ;; esac
+if [ -z "$LAST" ]; then
+  LAST=0
+  if [ -f "$DB" ]; then
+    LAST="$(sqlite3 "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE $WHERE_PAIRS;" 2>/dev/null || echo 0)"
+  fi
+  case "$LAST" in ''|*[!0-9]*) LAST=0 ;; esac
+  persist_watermark
+fi
 
 while true; do
   if [ -f "$DB" ]; then
@@ -183,6 +211,8 @@ while true; do
         printf '%s | %s | %s → %s | %s\n' "$ts" "$team" "$from" "$to" "$body"
         LAST="$id"
       done <<< "$ROWS"
+      # Persist after each delivered batch so a restart resumes from here.
+      persist_watermark
     fi
   fi
 

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+
+# Regression tests for the watch.sh per-session watermark (#107): a Monitor
+# restart must deliver messages that arrived during the restart gap, without
+# re-delivering anything already streamed, while a fresh session still starts
+# from "now" rather than replaying history.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export PROJ="/tmp/agmsg-watch-proj"
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+}
+
+teardown() {
+  teardown_test_env
+}
+
+# Run watch.sh in the background for <secs> seconds, capturing stdout to <out>.
+# Returns once the watcher has been stopped.
+run_watcher_for() {
+  local sid="$1" out="$2" secs="$3"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null &
+  local pid=$!
+  sleep "$secs"
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+@test "watch: restart delivers messages that arrived while the watcher was down" {
+  local sid="sess-restart"
+
+  # First watcher: fresh session, takes its mark at MAX(id)=0, then streams M1.
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
+    >"$TEST_SKILL_DIR/out1.log" 2>/dev/null &
+  local w1=$!
+  sleep 1.5
+  bash "$SCRIPTS/send.sh" team bob alice "M1-before-stop" >/dev/null
+  sleep 2
+  kill "$w1" 2>/dev/null || true
+  wait "$w1" 2>/dev/null || true
+  grep -q "M1-before-stop" "$TEST_SKILL_DIR/out1.log"
+
+  # A message arrives while NO watcher is running for this session.
+  bash "$SCRIPTS/send.sh" team bob alice "M2-in-gap" >/dev/null
+
+  # Restart the SAME session_id — should resume from the persisted watermark.
+  run_watcher_for "$sid" "$TEST_SKILL_DIR/out2.log" 2
+
+  # In-gap message is delivered on restart...
+  grep -q "M2-in-gap" "$TEST_SKILL_DIR/out2.log"
+  # ...and the already-streamed message is NOT re-delivered.
+  ! grep -q "M1-before-stop" "$TEST_SKILL_DIR/out2.log"
+}
+
+@test "watch: a fresh session starts from now and does not replay history" {
+  # Pre-existing message before any watcher for this session ever runs.
+  bash "$SCRIPTS/send.sh" team bob alice "M0-history" >/dev/null
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-fresh" "$PROJ" claude-code \
+    >"$TEST_SKILL_DIR/fresh.log" 2>/dev/null &
+  local w=$!
+  sleep 1.5
+  bash "$SCRIPTS/send.sh" team bob alice "M-live" >/dev/null
+  sleep 2
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  # Live message after attach is delivered; pre-existing history is not replayed.
+  grep -q "M-live" "$TEST_SKILL_DIR/fresh.log"
+  ! grep -q "M0-history" "$TEST_SKILL_DIR/fresh.log"
+}
+
+@test "watch: persists a watermark file for the session" {
+  run_watcher_for "sess-wm" "$TEST_SKILL_DIR/wm.log" 1.5
+  [ -f "$TEST_SKILL_DIR/run/watch.sess-wm.watermark" ]
+}
+
+@test "session-end: removes the session watermark file" {
+  local wm="$TEST_SKILL_DIR/run/watch.sess-end.watermark"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  echo 5 > "$wm"
+  printf '{"session_id":"sess-end"}' | bash "$SCRIPTS/session-end.sh" claude-code "$PROJ" >/dev/null 2>&1 || true
+  [ ! -f "$wm" ]
+}


### PR DESCRIPTION
Closes #107.

## Problem

`watch.sh` set its high-water mark to the current `MAX(id)` at **every** startup and streamed only `id > mark`. Monitor restarts are routine — `actas`/`drop` do TaskStop + relaunch, `/clear` and resume re-fire the SessionStart directive, and a killed watcher self-restarts — so any message that landed in the gap between the old watcher stopping and the new one taking its mark was **never pushed**. It sat unread in the DB (still visible via the no-arg inbox check) but real-time delivery skipped it. This is the mechanism behind dropped jobs in spawned-worker crews (reported: 6 of 9 lost).

## Fix

Persist the watermark **per `session_id`** (`run/watch.<sid>.watermark`):

- **Fresh session** (no watermark file) → start from `MAX(id)` as before: live push, no replay of history.
- **Restart of the same session** (actas/drop/clear/self-restart all reuse the session_id) → resume from the **last delivered id**, so in-gap messages are delivered. Staying strictly after the last delivered id means nothing already streamed is re-sent.

`session-end.sh` removes the watermark on real session end, so a future session_id reuse starts fresh.

This is complementary to the spawn handshake (#108): #107 stops in-gap loss for every Monitor restart generally; the handshake makes spawn readiness a positive signal.

## Tests

`tests/test_watch.bats`:
- restart delivers a message that arrived while the watcher was down — exactly once (no duplicate)
- a fresh session starts from "now" and does not replay history
- watermark file is persisted
- `session-end` removes it

Full suite green (208).
