### PR TITLE
fix(storage): busy_timeout on all DB connections — concurrent writes no longer drop (SQLITE_BUSY)

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -119,7 +119,7 @@ for team in "${TEAM_LIST[@]}"; do
     other:*) continue ;;
   esac
 
-  RESULT=$(sqlite3 "$DB" "
+  RESULT=$(agmsg_sqlite "$DB" "
     SELECT from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
     FROM messages WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL
     ORDER BY created_at ASC;
@@ -132,7 +132,7 @@ for team in "${TEAM_LIST[@]}"; do
     done <<< "$RESULT"
     OUTPUT+=$'\n'
     # Mark as read
-    sqlite3 "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
+    agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
   fi
 done
 

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -24,7 +24,7 @@ else
 fi
 
 # Escape newlines/tabs in body, use unit separator between fields
-RESULT=$(sqlite3 "$DB" "
+RESULT=$(agmsg_sqlite "$DB" "
   SELECT from_agent || char(31) || to_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at || char(31) || CASE WHEN read_at IS NULL THEN '●' ELSE '○' END
   FROM messages $WHERE ORDER BY created_at DESC LIMIT $LIMIT;
 ")

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -23,7 +23,7 @@ if [ ! -f "$DB" ]; then
 fi
 
 # Get unread messages — escape newlines/tabs in body to keep one record per line
-UNREAD=$(sqlite3 "$DB" "
+UNREAD=$(agmsg_sqlite "$DB" "
   SELECT from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
   FROM messages WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL
   ORDER BY created_at ASC;
@@ -45,4 +45,4 @@ done <<< "$UNREAD"
 echo ""
 
 # Mark as read (non-fatal — may fail in sandboxed environments)
-sqlite3 "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
+agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -8,7 +8,7 @@ DB_DIR="$(dirname "$DB")"
 mkdir -p "$DB_DIR"
 
 if [ ! -f "$DB" ]; then
-  sqlite3 "$DB" <<'SQL'
+  agmsg_sqlite "$DB" <<'SQL'
 PRAGMA journal_mode=WAL;
 
 CREATE TABLE messages (

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -7,11 +7,23 @@ DB="$(agmsg_db_path)"
 DB_DIR="$(dirname "$DB")"
 mkdir -p "$DB_DIR"
 
-if [ ! -f "$DB" ]; then
-  agmsg_sqlite "$DB" <<'SQL'
-PRAGMA journal_mode=WAL;
+# Idempotent and safe to run concurrently. When a leader fans a job out to N
+# members against a fresh/override store (see #106), every send.sh races to
+# initialize. Running unconditionally with IF NOT EXISTS (rather than guarding
+# on the file's existence) means a process that sees the DB file but not yet
+# its schema still ends up with a usable table. See #114.
 
-CREATE TABLE messages (
+# WAL is a persistent, one-time DB property and only an optimization. Changing
+# the journal mode wants exclusive access, so a concurrent set on a brand-new
+# DB can return "database is locked" even with a busy_timeout — set it
+# best-effort; whichever initializer wins makes it stick for everyone.
+agmsg_sqlite "$DB" "PRAGMA journal_mode=WAL;" >/dev/null 2>&1 || true
+
+# Schema. IF NOT EXISTS + the busy_timeout from agmsg_sqlite make a concurrent
+# first-time creation a no-op for the losers rather than an "already exists"
+# abort.
+agmsg_sqlite "$DB" <<'SQL'
+CREATE TABLE IF NOT EXISTS messages (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   team TEXT NOT NULL,
   from_agent TEXT NOT NULL,
@@ -21,8 +33,6 @@ CREATE TABLE messages (
   read_at TEXT
 );
 
-CREATE INDEX idx_unread ON messages(team, to_agent, read_at) WHERE read_at IS NULL;
-CREATE INDEX idx_history ON messages(team, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_unread ON messages(team, to_agent, read_at) WHERE read_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_history ON messages(team, created_at DESC);
 SQL
-  echo "DB initialized: $DB"
-fi

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -42,3 +42,21 @@ agmsg_storage_dir() {
 agmsg_db_path() {
   printf '%s/messages.db\n' "$(agmsg_storage_dir)"
 }
+
+# Run sqlite3 against the message store with a busy_timeout, so a writer that
+# finds the DB locked WAITS for it instead of failing immediately with
+# SQLITE_BUSY. WAL (set at init) lets readers and a single writer coexist, but
+# concurrent writers still serialize; with the default busy_timeout=0 a leader
+# fanning a job out to N members would lose all but one write — and silently,
+# since the failed sends just exit non-zero. All DB-backed call sites go through
+# this wrapper. In-memory JSON parsing (`sqlite3 :memory:`) does not need it —
+# it has no file lock to contend for. Override the timeout via
+# $AGMSG_BUSY_TIMEOUT (milliseconds). See #114.
+#
+# Uses the `.timeout` dot-command rather than `PRAGMA busy_timeout=N`: the
+# PRAGMA returns its value as a row, which sqlite3 would print to stdout and
+# corrupt every SELECT's output (and the watch stream). `.timeout` sets the
+# same busy timeout silently.
+agmsg_sqlite() {
+  sqlite3 -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@"
+}

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -47,7 +47,7 @@ fi
 
 # --- Update messages in DB ---
 if [ -f "$DB" ]; then
-  sqlite3 "$DB" "UPDATE messages SET team='$NEW_TEAM' WHERE team='$OLD_TEAM';"
+  agmsg_sqlite "$DB" "UPDATE messages SET team='$NEW_TEAM' WHERE team='$OLD_TEAM';"
 fi
 
 echo "Renamed team $OLD_TEAM → $NEW_TEAM"

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -46,8 +46,8 @@ echo "$UPDATED" > "$TEAM_CONFIG"
 
 # --- Update messages in DB ---
 if [ -f "$DB" ]; then
-  sqlite3 "$DB" "UPDATE messages SET from_agent='$NEW_NAME' WHERE team='$TEAM' AND from_agent='$OLD_NAME';"
-  sqlite3 "$DB" "UPDATE messages SET to_agent='$NEW_NAME' WHERE team='$TEAM' AND to_agent='$OLD_NAME';"
+  agmsg_sqlite "$DB" "UPDATE messages SET from_agent='$NEW_NAME' WHERE team='$TEAM' AND from_agent='$OLD_NAME';"
+  agmsg_sqlite "$DB" "UPDATE messages SET to_agent='$NEW_NAME' WHERE team='$TEAM' AND to_agent='$OLD_NAME';"
 fi
 
 echo "Renamed $OLD_NAME → $NEW_NAME in team $TEAM"

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -12,10 +12,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 DB="$(agmsg_db_path)"
 
-if [ ! -f "$DB" ]; then
-  bash "$SCRIPT_DIR/init-db.sh"
-fi
+[ -f "$DB" ] || bash "$SCRIPT_DIR/init-db.sh" >/dev/null
 
-agmsg_sqlite "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$TEAM', '$FROM', '$TO', '$(echo "$BODY" | sed "s/'/''/g")');"
+INSERT="INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$TEAM', '$FROM', '$TO', '$(echo "$BODY" | sed "s/'/''/g")');"
+
+# Retry once after ensuring the schema. Under a concurrent first-write fan-out
+# (leader → N members against a fresh/override store), one process can see the
+# DB file exist before the winning initializer has finished creating the table,
+# so its INSERT would hit "no such table". init-db.sh is idempotent + uses the
+# busy_timeout, so re-running it waits for the schema, then the INSERT lands.
+# See #114.
+if ! agmsg_sqlite "$DB" "$INSERT" 2>/dev/null; then
+  bash "$SCRIPT_DIR/init-db.sh" >/dev/null
+  agmsg_sqlite "$DB" "$INSERT"
+fi
 
 echo "Sent to $TO in team $TEAM"

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -16,6 +16,6 @@ if [ ! -f "$DB" ]; then
   bash "$SCRIPT_DIR/init-db.sh"
 fi
 
-sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$TEAM', '$FROM', '$TO', '$(echo "$BODY" | sed "s/'/''/g")');"
+agmsg_sqlite "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$TEAM', '$FROM', '$TO', '$(echo "$BODY" | sed "s/'/''/g")');"
 
 echo "Sent to $TO in team $TEAM"

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -224,7 +224,7 @@ fi
 if [ -z "$LAST" ]; then
   LAST=0
   if [ -f "$DB" ]; then
-    LAST="$(sqlite3 "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE $WHERE_PAIRS;" 2>/dev/null || echo 0)"
+    LAST="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE $WHERE_PAIRS;" 2>/dev/null || echo 0)"
   fi
   case "$LAST" in ''|*[!0-9]*) LAST=0 ;; esac
   persist_watermark
@@ -250,7 +250,7 @@ fi
 
 while true; do
   if [ -f "$DB" ]; then
-    ROWS="$(sqlite3 -separator $'\x1f' "$DB" "
+    ROWS="$(agmsg_sqlite -separator $'\x1f' "$DB" "
       SELECT id, created_at, team, from_agent, to_agent,
              replace(replace(body, char(13), ''), char(10), '\\n')
       FROM messages

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -81,3 +81,25 @@ teardown() {
   default_count=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COUNT(*) FROM messages;")
   [ "$default_count" -eq 0 ]
 }
+
+@test "storage: agmsg_sqlite sets a busy timeout without polluting output" {
+  # .timeout (not PRAGMA) so the timeout value is never echoed into results.
+  source "$SCRIPTS/lib/storage.sh"
+  run agmsg_sqlite ":memory:" "SELECT 'only-this';"
+  [ "$status" -eq 0 ]
+  [ "$output" = "only-this" ]
+}
+
+@test "send: concurrent fan-out to N recipients all land (no SQLITE_BUSY)" {
+  # Without a busy_timeout, concurrent writers fail with SQLITE_BUSY(5) and the
+  # sends silently drop. With the wrapper they wait and all land. See #114.
+  local x
+  for x in 1 2 3 4 5 6 7 8 9 10; do
+    ( bash "$SCRIPTS/send.sh" team leader "tgt$x" "job $x" >/dev/null 2>&1 ) &
+  done
+  wait
+  local n
+  n=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" \
+    "SELECT COUNT(*) FROM messages WHERE from_agent='leader';")
+  [ "$n" -eq 10 ]
+}

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -103,3 +103,18 @@ teardown() {
     "SELECT COUNT(*) FROM messages WHERE from_agent='leader';")
   [ "$n" -eq 10 ]
 }
+
+@test "send: concurrent fan-out to a FRESH (uninitialized) store all lands" {
+  # No init-db first — every send races to initialize an override store that
+  # doesn't exist yet. Without idempotent init + INSERT retry, the losers abort
+  # on "already exists" / "no such table" and drop. See #114.
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/freshstore"
+  local x
+  for x in 1 2 3 4 5 6 7 8 9 10; do
+    ( bash "$SCRIPTS/send.sh" team leader "tgt$x" "job $x" >/dev/null 2>&1 ) &
+  done
+  wait
+  local n
+  n=$(sqlite3 "$AGMSG_STORAGE_PATH/messages.db" "SELECT COUNT(*) FROM messages;")
+  [ "$n" -eq 10 ]
+}


### PR DESCRIPTION
Closes #114.

## Problem

`send.sh` (and every other `sqlite3` caller) opened the DB with the default `busy_timeout=0`, so **concurrent writers fail immediately with `SQLITE_BUSY`** instead of waiting. A leader fanning a job out to N members hit this every time — only one write landed, the rest errored, and because `send.sh` just exits non-zero the dropped messages were **silently lost** (never reached the DB). WAL allows readers + one writer, but does not let writers run concurrently.

Repro (4 parallel sends → 3 fail with `database is locked (5)`):
```sh
for x in A B C D; do ( send.sh team t tgt-$x "x" ) & done; wait
```

## Fix

Add `agmsg_sqlite()` to `lib/storage.sh` — `sqlite3` with a `.timeout`, so a writer **waits** for the lock instead of failing — and route every DB-backed call site through it: `send`, `inbox`, `check-inbox`, `history`, `rename`, `rename-team`, `watch`, `init-db`. In-memory JSON parsing (`sqlite3 :memory:`) is untouched (no file lock to contend for). Override via `$AGMSG_BUSY_TIMEOUT` (ms, default 5000).

Uses the **`.timeout` dot-command, not `PRAGMA busy_timeout=N`**: the PRAGMA returns its value as a row that `sqlite3` prints to stdout, which would corrupt every SELECT's output and the watch stream. `.timeout` sets the same busy timeout silently. (Caught in testing — the first cut leaked `5000` into results.)

## Tests

- a 10-way concurrent `send.sh` fan-out all lands (no `SQLITE_BUSY`)
- `agmsg_sqlite` output is not polluted by the timeout setting

Full suite green (235). Packaging smoke: installed into an isolated `HOME`, concurrent fan-out lands 8/8 through the installed scripts.

## Context

Surfaced in a crew fan-out experiment alongside `agmsg spawn` (#104/#105). Independent of the spawn handshake (#108, merged) and despawn (#109). High priority — a hard blocker for any leader→N delivery.
