### PR TITLE
feat: add Hermes Agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Cross-agent messaging for CLI AI agents. No daemon, no network, no complexity.
   </picture>
 </a>
 
-You stop being the copy-paste courier between your agents. Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, and any other CLI agent message each other directly through a shared local SQLite database — no human in the middle.
+You stop being the copy-paste courier between your agents. Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, Hermes Agent, and any other CLI agent message each other directly through a shared local SQLite database — no human in the middle.
 
 **What it isn't:**
 
@@ -40,16 +40,17 @@ bash <(curl -fsSL https://raw.githubusercontent.com/fujibee/agmsg/main/setup.sh)
 # Or clone first if you want to inspect the code
 git clone https://github.com/fujibee/agmsg.git && cd agmsg && ./install.sh
 
-# 2. Restart Claude Code / Codex / Gemini CLI / Antigravity to pick up the new skill
+# 2. Restart Claude Code / Codex / Gemini CLI / Antigravity / Hermes Agent to pick up the new skill
 
 # 3. Run the command — it will prompt for team and agent name on first use
 #    Claude Code:  /agmsg
 #    Codex:        $agmsg
 #    Gemini CLI:   $agmsg
 #    Antigravity:  $agmsg
+#    Hermes Agent: /agmsg
 ```
 
-That's it. The slash command prompts you for a team name and an agent name on first use, then asks you to pick a [delivery mode](#delivery-modes) (default on Claude Code: `monitor` — real-time push; Codex defaults to `turn` because it has no Monitor tool). After that, you talk to your agent naturally — see [First run](#first-run) below.
+That's it. The slash command prompts you for a team name and an agent name on first use. Agents with automatic delivery support then ask you to pick a [delivery mode](#delivery-modes) (default on Claude Code: `monitor` — real-time push; Codex defaults to `turn` because it has no Monitor tool); Hermes Agent uses manual inbox checks only (`mode off`). After that, you talk to your agent naturally — see [First run](#first-run) below.
 
 Prefer a different install method? See [Install](#install) below for `npm` / `npx` and the Claude Code plugin marketplace paths.
 
@@ -104,10 +105,11 @@ The **command name** determines:
 - Skill folder: `~/.agents/skills/<cmd>/`
 - Claude Code / Copilot CLI: `/<cmd>`
 - Codex / Gemini CLI / Antigravity: `$<cmd>`
+- Hermes Agent: `/<cmd>` (installed to `~/.hermes/skills/<cmd>/` when `~/.hermes` exists)
 
 `--cmd` and `--agent-type` are only available via the direct-script path; the `npm` and plugin paths always install as `agmsg` and auto-detect the host agent type.
 
-After install, **restart your agent** (Claude Code / Codex / Gemini CLI / Copilot CLI / Antigravity) so it picks up the new skill.
+After install, **restart your agent** (Claude Code / Codex / Gemini CLI / Copilot CLI / Antigravity / Hermes Agent) so it picks up the new skill.
 
 ### Native Windows / PowerShell shortcut
 
@@ -142,6 +144,7 @@ Open your project in your agent (Claude Code, Codex, Gemini CLI, etc.) and run:
 ```
 /agmsg              # Claude Code, Copilot CLI
 $agmsg              # Codex, Gemini CLI, Antigravity
+/agmsg              # Hermes Agent
 ```
 
 On first use it asks for a **team name** (joins an existing team or creates a new one) and an **agent name** for this project — that's the whole onboarding. After that, talk to your agent naturally:
@@ -270,6 +273,14 @@ Codex supports `mode turn` and `mode off` only — there's no Monitor tool to st
 ```
 
 The Copilot installer drops a `SKILL.md` at `~/.copilot/skills/agmsg/` so `/agmsg` is auto-discovered. Per-project hooks live at `<project>/.github/hooks/agmsg.json`. Copilot CLI has no Monitor-tool equivalent, so only `mode turn` and `mode off` are supported. Asking for `monitor` or `both` is rejected with an error.
+
+### Hermes Agent
+
+```
+/agmsg                          — invokes the agmsg skill
+```
+
+The installer drops a Hermes skill at `~/.hermes/skills/agmsg/SKILL.md` when `~/.hermes` exists. Hermes exposes installed skills as dynamic slash commands, so `/agmsg` invokes the skill. Runtime scripts, teams, and the SQLite store remain in `~/.agents/skills/agmsg/` so Hermes shares the same message floor as the other agents. Hermes currently supports manual inbox checks (`mode off`) only; there is no agmsg automatic delivery hook.
 
 ### Shell (any agent)
 

--- a/bin/agmsg.js
+++ b/bin/agmsg.js
@@ -56,7 +56,7 @@ function printHelp() {
     '  npx agmsg --version    show this bootstrapper\'s version',
     '',
     'After install, restart your agent (Claude Code / Codex / Gemini CLI /',
-    'Copilot CLI / Antigravity / OpenCode) and run the agmsg skill command',
+    'Copilot CLI / Antigravity / OpenCode / Hermes Agent) and run the agmsg skill command',
     'to join a team.',
     '',
     'Homepage: ' + HOMEPAGE,

--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ agmsg_source_version() {
 CMD_NAME=""
 UPDATE_ONLY=false
 INTERACTIVE=true
-AGENT_TYPE=""  # claude-code, codex, gemini, antigravity — passed via --agent-type, or empty for auto/default
+AGENT_TYPE=""  # claude-code, codex, gemini, antigravity, hermes — passed via --agent-type, or empty for auto/default
 
 is_windows_host() {
   if [ "${AGMSG_FORCE_WINDOWS:-}" = "1" ]; then
@@ -98,7 +98,8 @@ while [[ $# -gt 0 ]]; do
       echo "Options:"
       echo "  --cmd <name>      Command & skill folder name (default: agmsg)"
       echo "                    Claude Code: /<cmd>, Codex/Gemini/Antigravity: \$<cmd>"
-      echo "  --agent-type <t>  Agent type: claude-code, codex, gemini, antigravity"
+      echo "                    Hermes Agent: /<cmd>"
+      echo "  --agent-type <t>  Agent type: claude-code, codex, gemini, antigravity, hermes"
       echo "                    Selects which template becomes SKILL.md (matches the"
       echo "                    <type> arg passed to join.sh / whoami.sh)"
       echo "  --update          Update skill scripts only (preserve DB and teams)"
@@ -155,7 +156,9 @@ if [ "$UPDATE_ONLY" = true ]; then
   CMD_NAME="$SKILL_NAME"
   echo "  Updating $SKILL_NAME..."
   if [ -z "$AGENT_TYPE" ]; then
-    if grep -q "whoami.sh.*antigravity" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
+    if grep -q "whoami.sh.*hermes" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
+      AGENT_TYPE="hermes"
+    elif grep -q "whoami.sh.*antigravity" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
       AGENT_TYPE="antigravity"
     elif grep -q "whoami.sh.*gemini" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
       AGENT_TYPE="gemini"
@@ -168,6 +171,8 @@ if [ "$UPDATE_ONLY" = true ]; then
     SKILL_TEMPLATE="cmd.gemini.md"
   elif [ "$AGENT_TYPE" = "antigravity" ]; then
     SKILL_TEMPLATE="cmd.antigravity.md"
+  elif [ "$AGENT_TYPE" = "hermes" ]; then
+    SKILL_TEMPLATE="cmd.hermes.md"
   fi
   sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/$SKILL_TEMPLATE" > "$SKILL_DIR/SKILL.md"
   # Recursive copy so nested helper dirs (scripts/lib/) ship without enumerating files.
@@ -189,6 +194,11 @@ if [ "$UPDATE_ONLY" = true ]; then
   if [ -d "$HOME/.copilot" ]; then
     mkdir -p "$COPILOT_SKILL_DIR"
     sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/cmd.copilot.md" > "$COPILOT_SKILL_DIR/SKILL.md"
+  fi
+  HERMES_SKILL_DIR="$HOME/.hermes/skills/$SKILL_NAME"
+  if [ -d "$HOME/.hermes" ]; then
+    mkdir -p "$HERMES_SKILL_DIR"
+    sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/cmd.hermes.md" > "$HERMES_SKILL_DIR/SKILL.md"
   fi
   cp "$SCRIPT_DIR/openai.yaml" "$SKILL_DIR/agents/openai.yaml" 2>/dev/null || true
   chmod +x "$SKILL_DIR/scripts/"*.sh
@@ -229,6 +239,8 @@ if [ "$AGENT_TYPE" = "gemini" ]; then
   SKILL_TEMPLATE="cmd.gemini.md"
 elif [ "$AGENT_TYPE" = "antigravity" ]; then
   SKILL_TEMPLATE="cmd.antigravity.md"
+elif [ "$AGENT_TYPE" = "hermes" ]; then
+  SKILL_TEMPLATE="cmd.hermes.md"
 fi
 sed "s/__SKILL_NAME__/$CMD_NAME/g" "$SCRIPT_DIR/templates/$SKILL_TEMPLATE" > "$SKILL_DIR/SKILL.md"
 # Recursive copy so nested helper dirs (scripts/lib/) ship without enumerating files.
@@ -278,6 +290,17 @@ if [ -d "$HOME/.copilot" ]; then
   mkdir -p "$COPILOT_SKILL_DIR"
   sed "s/__SKILL_NAME__/$CMD_NAME/g" "$SCRIPT_DIR/templates/cmd.copilot.md" > "$COPILOT_SKILL_DIR/SKILL.md"
   echo "  + installed /$CMD_NAME skill to ~/.copilot/skills/"
+fi
+
+# --- Install Hermes Agent skill ---
+# Hermes reads reusable skills from ~/.hermes/skills/<name>/SKILL.md. Keep the
+# runtime scripts and shared SQLite state in ~/.agents/skills/<name>/ so Hermes
+# talks to the same teams as Claude Code / Codex / Gemini / Copilot sessions.
+HERMES_SKILL_DIR="$HOME/.hermes/skills/$CMD_NAME"
+if [ -d "$HOME/.hermes" ]; then
+  mkdir -p "$HERMES_SKILL_DIR"
+  sed "s/__SKILL_NAME__/$CMD_NAME/g" "$SCRIPT_DIR/templates/cmd.hermes.md" > "$HERMES_SKILL_DIR/SKILL.md"
+  echo "  + installed $CMD_NAME skill to ~/.hermes/skills/"
 fi
 
 # --- Configure Codex sandbox (if Codex is installed) ---
@@ -330,13 +353,14 @@ echo ""
 echo "  ✓ Installed to ~/.agents/skills/$CMD_NAME/ (version $INSTALLED_VERSION)"
 echo ""
 echo "  Next steps:"
-echo "    1. Restart your agent (Claude Code / Codex / Gemini CLI / Antigravity) to pick up the new skill"
+echo "    1. Restart your agent (Claude Code / Codex / Gemini CLI / Antigravity / Hermes Agent) to pick up the new skill"
 echo "    2. Run the command to join a team:"
 echo "       Claude Code:  /$CMD_NAME"
 echo "       Codex:        \$$CMD_NAME"
 echo "       Gemini CLI:   \$$CMD_NAME"
 echo "       Antigravity:  \$$CMD_NAME"
 echo "       Copilot CLI:  /$CMD_NAME"
+echo "       Hermes Agent: /$CMD_NAME"
 echo "       It will prompt for team name and agent name on first run."
 echo ""
 echo "  Docs: https://agmsg.cc/"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agmsg",
   "version": "1.0.4",
-  "description": "Cross-agent messaging via SQLite for CLI AI agents (Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, Antigravity, OpenCode). The npm package is a thin bootstrapper that fetches and runs the canonical bash installer at https://github.com/fujibee/agmsg.",
+  "description": "Cross-agent messaging via SQLite for CLI AI agents (Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, Antigravity, OpenCode, Hermes Agent). The npm package is a thin bootstrapper that fetches and runs the canonical bash installer at https://github.com/fujibee/agmsg.",
   "bin": {
     "agmsg": "bin/agmsg.js"
   },
@@ -25,6 +25,7 @@
     "copilot-cli",
     "antigravity",
     "opencode",
+    "hermes-agent",
     "messaging",
     "multi-agent",
     "agent-to-agent",

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -46,6 +46,7 @@ resolve_hooks_file() {
     codex)       echo "$project/.codex/hooks.json" ;;
     gemini|antigravity) echo "$project/.agent/rules/agmsg.md" ;;
     copilot)     echo "$project/.github/hooks/agmsg.json" ;;
+    hermes)      echo "$project/.hermes/agmsg.json" ;;
     *) echo "Unknown agent type: $type" >&2; return 1 ;;
   esac
 }
@@ -275,6 +276,23 @@ EOF
   esac
 }
 
+apply_settings_manual_only() {
+  local type="$1"
+  local mode="$2"
+
+  case "$mode" in
+    off) ;;
+    monitor|both|turn)
+      echo "Error: '$mode' mode is not supported for $type (no automatic delivery hook). Use 'off'." >&2
+      return 1
+      ;;
+    *)
+      echo "Unknown mode: $mode (use off)" >&2
+      return 1
+      ;;
+  esac
+}
+
 apply_settings() {
   local type="$1"
   local project="$2"
@@ -287,6 +305,11 @@ apply_settings() {
 
   if [ "$type" = "copilot" ]; then
     apply_settings_copilot "$type" "$project" "$mode"
+    return
+  fi
+
+  if [ "$type" = "hermes" ]; then
+    apply_settings_manual_only "$type" "$mode"
     return
   fi
 
@@ -433,6 +456,10 @@ do_set() {
       ;;
     off)
       echo "Future sessions: no automatic delivery."
+      if [ "$TYPE" = "hermes" ]; then
+        echo "Hermes has no agmsg automatic delivery hook; manual inbox checks only."
+        return
+      fi
       kill_all_watchers "$PROJECT" >/dev/null 2>&1 || true
       emit_stop_directive
       ;;
@@ -448,16 +475,19 @@ do_status() {
   # a project-scoped mode, so we just skip the mode line and report the
   # global watcher state below.
   if [ -n "$TYPE" ] && [ -n "$PROJECT" ]; then
-    local hf
-    hf=$(resolve_hooks_file "$TYPE" "$PROJECT")
-    if [ "$TYPE" = "gemini" ] || [ "$TYPE" = "antigravity" ] || [ "$TYPE" = "copilot" ]; then
+    if [ "$TYPE" = "hermes" ]; then
+      echo "mode: off"
+    elif [ "$TYPE" = "gemini" ] || [ "$TYPE" = "antigravity" ] || [ "$TYPE" = "copilot" ]; then
+      local hf
+      hf=$(resolve_hooks_file "$TYPE" "$PROJECT")
       local mode="off"
       if [ -f "$hf" ]; then
         mode="turn"
       fi
       echo "mode: $mode"
     else
-      local has_ss=0 has_st=0
+      local hf has_ss=0 has_st=0
+      hf=$(resolve_hooks_file "$TYPE" "$PROJECT")
       if [ -f "$hf" ]; then
         local sql_hf
         sql_hf=$(sql_readfile_path "$hf")
@@ -483,7 +513,7 @@ do_status() {
     fi
   fi
 
-  if [ -n "$TYPE" ] && [ -n "$PROJECT" ] && [ "$TYPE" != "gemini" ] && [ "$TYPE" != "antigravity" ] && [ "$TYPE" != "copilot" ]; then
+  if [ -n "$TYPE" ] && [ -n "$PROJECT" ] && [ "$TYPE" != "gemini" ] && [ "$TYPE" != "antigravity" ] && [ "$TYPE" != "copilot" ] && [ "$TYPE" != "hermes" ]; then
     local hooks_file
     hooks_file=$(resolve_hooks_file "$TYPE" "$PROJECT")
     if [ -f "$hooks_file" ]; then

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -46,7 +46,8 @@ resolve_hooks_file() {
     codex)       echo "$project/.codex/hooks.json" ;;
     gemini|antigravity) echo "$project/.agent/rules/agmsg.md" ;;
     copilot)     echo "$project/.github/hooks/agmsg.json" ;;
-    hermes)      echo "$project/.hermes/agmsg.json" ;;
+    # hermes is manual-only (mode off): apply_settings and do_status short-circuit
+    # it before ever calling resolve_hooks_file, so it intentionally has no entry.
     *) echo "Unknown agent type: $type" >&2; return 1 ;;
   esac
 }

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 TEAM="${1:?Usage: join.sh <team> <agent_id> <type> <project_path>}"
 AGENT_ID="${2:?Missing agent_id}"
-AGENT_TYPE="${3:?Missing type (claude-code | codex)}"
+AGENT_TYPE="${3:?Missing type (claude-code | codex | gemini | antigravity | copilot | hermes)}"
 PROJECT_PATH="${4:?Missing project_path}"
 
 # Reject unknown agent types — the rest of agmsg (delivery.sh,
@@ -15,8 +15,8 @@ PROJECT_PATH="${4:?Missing project_path}"
 # here. Allowing arbitrary strings silently mis-registers an agent and
 # makes monitor mode fail with a confusing "no joined teams" message.
 case "$AGENT_TYPE" in
-  claude-code|codex|gemini|antigravity|copilot) ;;
-  *) echo "Unknown agent type: '$AGENT_TYPE' (supported: claude-code, codex, gemini, antigravity, copilot)" >&2; exit 1 ;;
+  claude-code|codex|gemini|antigravity|copilot|hermes) ;;
+  *) echo "Unknown agent type: '$AGENT_TYPE' (supported: claude-code, codex, gemini, antigravity, copilot, hermes)" >&2; exit 1 ;;
 esac
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/templates/cmd.hermes.md
+++ b/templates/cmd.hermes.md
@@ -1,0 +1,124 @@
+---
+name: __SKILL_NAME__
+description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, Hermes Agent, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
+---
+
+Hermes Agent skill for agmsg cross-agent messaging. **IMPORTANT: Always use the provided scripts. NEVER directly read or edit config files, DB, or team data. There is NO register.sh — use join.sh to join a team.**
+
+## Identity
+
+If you already know your AGENT and TEAMS from a previous `/__SKILL_NAME__` use in this session, skip to **Execute** below.
+
+Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" hermes`
+
+Four possible outputs:
+
+**A) Single identity:**
+`agent=<name> teams=<t1,t2,...> type=hermes project=<path>`
+→ Remember AGENT and TEAMS, then go to **Execute**.
+
+**B) Multiple identities:**
+`multiple=true agents=<n1,n2,...> teams=<t1,t2,...> type=hermes project=<path>`
+→ Ask the user which agent name to use for this session, then go to **Execute**.
+
+**C) Not in a team:**
+`not_joined=true available_teams=<t1,t2,...>` (or `available_teams=none`)
+→ Show the user the available teams from the output, then:
+
+  > **First-time setup required.**
+  > Joining a team so this agent can send and receive messages.
+  > - **Team name**: a group of agents that can message each other (available: <list from output>)
+  > - **Agent name**: this agent's identity within the team
+
+  1. Ask: "Enter a team name (joins existing or creates new)"
+  2. Ask: "Enter a name for this agent"
+  3. **You MUST use join.sh** — run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> hermes "$(pwd)"`
+  4. Show the result and explain:
+
+  > **Joined!** You can now use `/__SKILL_NAME__` to check and send messages.
+  > - ask to check inbox — check unread messages
+  > - ask `send <agent> <message>` — send a message
+  > - ask `team` — list team members
+  > - ask `history` — message history
+
+  5. Hermes has no agmsg automatic delivery hook. Set manual delivery explicitly:
+     `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off hermes "$(pwd)"`
+
+  6. Then check inbox for the newly joined team.
+
+**D) Suggestions for reuse:**
+`suggest=true agents=<n1,n2,...> teams=<t1,t2,...> type=hermes project=<path> available_teams=<t1,t2,...>`
+→ No exact registration exists for this project, but there are same-type agent names registered elsewhere.
+
+  1. Show the suggested agent names to the user.
+  2. Ask whether to reuse one of those names or choose a new one.
+  3. Ask for the team name to join (existing or new).
+  4. Run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> hermes "$(pwd)"`
+  5. Then continue with the normal post-join flow above.
+
+## Execute
+
+**Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db` directly.**
+
+**If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
+1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
+2. Do NOT ask the user what to do — just run the inbox check.
+3. If there are messages, read and respond appropriately. To reply:
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+
+If argument is "history":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/history.sh $TEAM $AGENT`
+
+If argument is "team":
+1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM`
+
+If argument starts with "send" (e.g. "send misaki check the server"):
+1. Parse target agent and message from the arguments
+2. Determine which team the target agent belongs to, then run:
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+
+If argument is "config":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh show`
+2. Show the output to the user.
+
+If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
+1. Parse key and value from the arguments.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
+
+If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
+1. Parse the new role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" hermes` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> hermes "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
+4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent."
+
+If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
+1. Parse the role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" hermes <name>` to remove that role's registration.
+3. If the session's active FROM was `<name>`, clear that state.
+4. Tell the user: "Dropped role `<name>` from this project."
+
+If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex reviewer --window"):
+1. Parse `<type>` (must be `claude-code` or `codex`), `<name>`, and any options (`--project`, `--team`, `--window`, `--split h|v`, `--terminal`, `--no-wait`, `--ready-timeout <secs>`).
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
+3. Show the script's output.
+
+If argument is "mode" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status hermes "$(pwd)"`
+2. Show the output to the user.
+
+If argument starts with "mode" followed by a mode name (e.g. "mode off"):
+1. Parse the mode. Hermes supports only `off`.
+2. If the requested mode is `off`, run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off hermes "$(pwd)"`
+3. If the requested mode is `monitor`, `both`, or `turn`, do not run a command; tell the user: "Hermes has no agmsg automatic delivery hook; only `off` mode is supported."
+
+If argument is "hook on" (legacy alias):
+1. Tell the user: "Hermes has no agmsg automatic delivery hook; use manual inbox checks."
+
+If argument is "hook off" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off hermes "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'off'."
+
+If argument is "reset":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" hermes`
+2. Tell the user the result.

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -989,3 +989,54 @@ JSON
   allow_len=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$(settings_file)'), '\$.permissions.allow'));")
   [ "$allow_len" = "600" ]
 }
+
+@test "delivery hermes: status is manual/off" {
+  run bash "$SCRIPTS/delivery.sh" status hermes "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "mode: off" ]]
+}
+
+@test "delivery hermes: rejects automatic modes" {
+  local mode
+  for mode in turn monitor both; do
+    run bash "$SCRIPTS/delivery.sh" set "$mode" hermes "$TEST_PROJECT"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "not supported for hermes" ]]
+    [ ! -e "$TEST_PROJECT/.hermes/agmsg.json" ]
+  done
+}
+
+@test "delivery hermes: rejects unknown mode" {
+  run bash "$SCRIPTS/delivery.sh" set bogus hermes "$TEST_PROJECT"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Unknown mode" ]]
+  [ ! -e "$TEST_PROJECT/.hermes/agmsg.json" ]
+}
+
+@test "delivery hermes: accepts off without writing hook config" {
+  run bash "$SCRIPTS/delivery.sh" set off hermes "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Delivery mode set to 'off'" ]]
+  [[ "$output" =~ "manual inbox checks only" ]]
+  [[ "$output" != *"AGMSG-DIRECTIVE"* ]]
+  [ ! -e "$TEST_PROJECT/.hermes/agmsg.json" ]
+}
+
+@test "delivery hermes: set off does not stop Claude Code watchers for the same project" {
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" hermes-preserve-test "$TEST_PROJECT" claude-code &
+  local watch_pid=$!
+  sleep 1
+  [ -f "$TEST_SKILL_DIR/run/watch.hermes-preserve-test.pid" ]
+
+  run bash "$SCRIPTS/delivery.sh" set off hermes "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  run kill -0 "$watch_pid"
+  [ "$status" -eq 0 ]
+
+  kill "$watch_pid" 2>/dev/null || true
+  wait 2>/dev/null || true
+}

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -96,6 +96,35 @@ teardown() {
   [ ! -d "$FAKE_HOME/.copilot" ]
 }
 
+@test "install: drops a Hermes skill when ~/.hermes exists" {
+  mkdir -p "$FAKE_HOME/.hermes"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  local hermes_skill="$FAKE_HOME/.hermes/skills/agmsg/SKILL.md"
+  [ -f "$hermes_skill" ]
+  grep -q "whoami.sh \"\$(pwd)\" hermes" "$hermes_skill"
+  grep -q "^name: agmsg" "$hermes_skill"
+  grep -q "~/.agents/skills/agmsg/scripts" "$hermes_skill"
+}
+
+@test "install: custom command name is substituted in Hermes skill" {
+  mkdir -p "$FAKE_HOME/.hermes"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd msg
+  local hermes_skill="$FAKE_HOME/.hermes/skills/msg/SKILL.md"
+  [ -f "$hermes_skill" ]
+  grep -q "^name: msg" "$hermes_skill"
+  grep -q "~/.agents/skills/msg/scripts" "$hermes_skill"
+  grep -q "You can now use \`/msg\`" "$hermes_skill"
+  ! grep -q "__SKILL_NAME__" "$hermes_skill"
+}
+
+@test "install: --agent-type hermes makes shared SKILL.md Hermes-typed" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg --agent-type hermes
+  grep -q "whoami.sh \"\$(pwd)\" hermes" "$SK/SKILL.md"
+  ! grep -q "whoami.sh \"\$(pwd)\" codex" "$SK/SKILL.md"
+  ! grep -q "whoami.sh \"\$(pwd)\" gemini" "$SK/SKILL.md"
+  ! grep -q "whoami.sh \"\$(pwd)\" antigravity" "$SK/SKILL.md"
+}
+
 @test "install --update: refreshes the Copilot skill if it was previously installed" {
   mkdir -p "$FAKE_HOME/.copilot"
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
@@ -106,6 +135,17 @@ teardown() {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
   ! grep -q "^tampered$" "$copilot_skill"
   grep -q "whoami.sh \"\$(pwd)\" copilot" "$copilot_skill"
+}
+
+@test "install --update: refreshes the Hermes skill if it was previously installed" {
+  mkdir -p "$FAKE_HOME/.hermes"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  local hermes_skill="$FAKE_HOME/.hermes/skills/agmsg/SKILL.md"
+  [ -f "$hermes_skill" ]
+  echo "tampered" > "$hermes_skill"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  ! grep -q "^tampered$" "$hermes_skill"
+  grep -q "whoami.sh \"\$(pwd)\" hermes" "$hermes_skill"
 }
 
 # Regression for a Copilot review finding: --update used to gate the Copilot
@@ -167,6 +207,15 @@ teardown() {
   [ -f "$FAKE_HOME/.agents/run/sqlite3-shim.cache" ]
 }
 
+@test "install --update: installs Hermes skill for upgraders without prior skill" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  [ ! -d "$FAKE_HOME/.hermes/skills/agmsg" ]
+  mkdir -p "$FAKE_HOME/.hermes"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  [ -f "$FAKE_HOME/.hermes/skills/agmsg/SKILL.md" ]
+  grep -q "whoami.sh \"\$(pwd)\" hermes" "$FAKE_HOME/.hermes/skills/agmsg/SKILL.md"
+}
+
 @test "plugin SKILL.md bootstrap: a fresh plugin install path can bootstrap ~/.agents/skills/agmsg" {
   # Simulate the post-plugin-install state: no ~/.agents/skills/agmsg yet, but
   # the plugin marketplace flow has populated the cache dir with a copy of the
@@ -209,14 +258,22 @@ teardown() {
   bash "$SK/scripts/watch.sh" "$sid" /tmp/install-projA claude-code &
   local first=$!
   # Give the first watcher long enough to write the pidfile and enter its
-  # poll loop. The sleep is short — if it's flaky, raise to 0.5s.
-  sleep 0.3
+  # poll loop. Poll instead of sleeping a fixed interval so this stays stable
+  # under full-suite load.
+  local i
+  for i in {1..20}; do
+    [ -f "$SK/run/watch.$sid.pid" ] && [ "$(cat "$SK/run/watch.$sid.pid")" -eq "$first" ] && break
+    sleep 0.1
+  done
   [ -f "$SK/run/watch.$sid.pid" ]
   [ "$(cat "$SK/run/watch.$sid.pid")" -eq "$first" ]
 
   bash "$SK/scripts/watch.sh" "$sid" /tmp/install-projA claude-code &
   local second=$!
-  sleep 0.3
+  for i in {1..20}; do
+    [ "$(cat "$SK/run/watch.$sid.pid" 2>/dev/null || echo 0)" -eq "$second" ] && break
+    sleep 0.1
+  done
   # New pid wrote the pidfile.
   [ "$(cat "$SK/run/watch.$sid.pid")" -eq "$second" ]
   # And the previous one was actually killed.

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -273,3 +273,8 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "join: accepts hermes" {
+  run bash "$SCRIPTS/join.sh" myteam alice hermes /tmp/proj
+  [ "$status" -eq 0 ]
+}
+


### PR DESCRIPTION
## Summary

- add a Hermes Agent skill template and install it under `~/.hermes/skills/<cmd>/`
- keep agmsg runtime scripts/state shared under `~/.agents/skills/<cmd>/`
- support `hermes` identities in `join.sh` and manual-only delivery in `delivery.sh`
- document Hermes `/agmsg` usage and manual inbox checks (`mode off`)

## Notes

Hermes Agent exposes installed skills as dynamic slash commands, so installing `~/.hermes/skills/agmsg/SKILL.md` makes `/agmsg` available in Hermes sessions. Hermes does not have an agmsg automatic delivery hook here, so `delivery.sh set off hermes` is a no-op for hooks/watchers and does not emit Claude-specific directives or stop existing Claude Code watchers for the same project.

## Verification

- `npm run test`
- `bash -n install.sh scripts/delivery.sh scripts/join.sh setup.sh`
- `node -c bin/agmsg.js`
- `git diff --check`
- `bats tests` (244/244)
- Hermes Agent smoke/E2E in an isolated HOME:
  - `/agmsg team: test-team agent: hermes-test`
  - `/agmsg send hermes-test hello from hermes e2e`
  - `/agmsg` inbox/read
