### PR TITLE
ci: always run tests so the required check never stalls

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,21 +6,16 @@ name: tests
 # "only the changed tests", which would miss regressions in shared libs
 # (lib/*.sh) that fan out across many scripts.
 #
-# Docs-only changes are skipped via paths-ignore.
+# No paths-ignore: this workflow is a required status check on main, and a
+# required check that never reports (because a docs-only PR was filtered out)
+# leaves the PR stuck "pending" forever. Always running keeps every PR
+# mergeable — the cost is one cheap, free run on docs-only changes.
 
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
 
 permissions:
   contents: read


### PR DESCRIPTION
Follow-up to #116, now that `tests` is a **required status check** on `main`.

With `paths-ignore` (docs / `*.md` / `LICENSE`), a docs-only PR never triggers the workflow — so the required `bats (ubuntu-latest)` / `bats (macos-latest)` contexts never report, and the PR is stuck "pending" and unmergeable.

Drop `paths-ignore` from both triggers. The suite is ~2 min and runners are free on this public repo, so always running is the safe trade for keeping every PR mergeable. (This PR is itself the first run under the required-check rule.)