### PR TITLE
feat(install): record git-describe provenance version (/agmsg version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The command updates `db/config.yaml`, rewrites the project's hook entries, and p
 /agmsg drop <name>                      — remove a role from this project
 /agmsg spawn <type> <name>              — launch a new agent (claude-code/codex) that takes <name>
 /agmsg hook on | off                    — legacy aliases (mode turn | off)
+/agmsg version                          — show the installed version (git-describe provenance)
 /agmsg reset                            — clear current project registration
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -73,6 +73,11 @@ Do NOT manually edit config files. Always use join.sh.
 # their cached team name in any running session.
 ~/.agents/skills/agmsg/scripts/rename-team.sh <old_team> <new_team>
 
+# Show the installed version — the git-describe provenance string recorded at
+# install time (tag + commits-since + abbreviated commit, plus -dirty when
+# installed from a tree with uncommitted changes). See #117.
+~/.agents/skills/agmsg/scripts/version.sh
+
 # Clear registrations for the current project/type.
 # A trailing <session_id> additionally releases any actas exclusivity locks
 # this session held on <agent_id> so peers can pick them up immediately.

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,24 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 AGENTS_DIR="$HOME/.agents"
 
+# Resolve a provenance version for the source being installed, so an installed
+# copy is uniquely identifiable even between tagged releases (the canonical
+# VERSION only bumps at release). From a git checkout: `git describe` — tag +
+# commits-since + abbreviated commit, plus `-dirty` when the source tree had
+# uncommitted changes. Non-git (tarball via setup.sh/npx, no .git): fall back to
+# the canonical VERSION file. See #117.
+agmsg_source_version() {
+  local v
+  if v="$(git -C "$SCRIPT_DIR" describe --tags --always --dirty --abbrev=7 2>/dev/null)" \
+      && [ -n "$v" ]; then
+    printf '%s' "$v"
+  elif [ -f "$SCRIPT_DIR/VERSION" ]; then
+    tr -d '[:space:]' < "$SCRIPT_DIR/VERSION"
+  else
+    printf 'unknown'
+  fi
+}
+
 # --- Defaults ---
 CMD_NAME=""
 UPDATE_ONLY=false
@@ -168,7 +186,9 @@ if [ "$UPDATE_ONLY" = true ]; then
   cp "$SCRIPT_DIR/openai.yaml" "$SKILL_DIR/agents/openai.yaml" 2>/dev/null || true
   chmod +x "$SKILL_DIR/scripts/"*.sh
   install_windows_helpers
-  echo "  + updated scripts, templates, and SKILL.md"
+  INSTALLED_VERSION="$(agmsg_source_version)"
+  printf '%s\n' "$INSTALLED_VERSION" > "$SKILL_DIR/VERSION"
+  echo "  + updated scripts, templates, and SKILL.md (version $INSTALLED_VERSION)"
   echo "  ~ DB and team configs preserved"
   echo ""
   echo "  ! Restart any running agent sessions to pick up the updated scripts."
@@ -218,6 +238,10 @@ install_windows_helpers
 
 # Marker file for uninstall detection
 touch "$SKILL_DIR/.agmsg"
+
+# Record the provenance version of the source we installed from (see #117).
+INSTALLED_VERSION="$(agmsg_source_version)"
+printf '%s\n' "$INSTALLED_VERSION" > "$SKILL_DIR/VERSION"
 
 # Initialize DB
 if [ ! -f "$SKILL_DIR/db/messages.db" ]; then
@@ -296,7 +320,7 @@ fi
 
 # --- Done ---
 echo ""
-echo "  ✓ Installed to ~/.agents/skills/$CMD_NAME/"
+echo "  ✓ Installed to ~/.agents/skills/$CMD_NAME/ (version $INSTALLED_VERSION)"
 echo ""
 echo "  Next steps:"
 echo "    1. Restart your agent (Claude Code / Codex / Gemini CLI / Antigravity) to pick up the new skill"

--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,15 @@ AGENTS_DIR="$HOME/.agents"
 # uncommitted changes. Non-git (tarball via setup.sh/npx, no .git): fall back to
 # the canonical VERSION file. See #117.
 agmsg_source_version() {
-  local v
-  if v="$(git -C "$SCRIPT_DIR" describe --tags --always --dirty --abbrev=7 2>/dev/null)" \
+  local v top
+  # Only describe when SCRIPT_DIR is ITS OWN git checkout. `git describe`
+  # searches ancestors for a .git, so a non-git copy unpacked under some other
+  # git repo would otherwise record that PARENT repo's describe instead of
+  # agmsg's canonical VERSION. Requiring the toplevel to equal SCRIPT_DIR also
+  # works for agmsg's own worktrees (install.sh sits at the worktree root).
+  top="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [ -n "$top" ] && [ "$top" = "$SCRIPT_DIR" ] \
+      && v="$(git -C "$SCRIPT_DIR" describe --tags --always --dirty --abbrev=7 2>/dev/null)" \
       && [ -n "$v" ]; then
     printf '%s' "$v"
   elif [ -f "$SCRIPT_DIR/VERSION" ]; then

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Print the installed agmsg version — the git-describe provenance string that
+# install.sh recorded at install time (see #117). This identifies the exact
+# source an install came from, including commits past the last tagged release
+# and a `-dirty` marker when it was installed from a tree with uncommitted
+# changes. Falls back gracefully if no version was recorded (older install).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -f "$SKILL_DIR/VERSION" ]; then
+  cat "$SKILL_DIR/VERSION"
+else
+  echo "unknown (no VERSION recorded — reinstall/--update to record provenance)"
+fi

--- a/templates/cmd.claude-code.md
+++ b/templates/cmd.claude-code.md
@@ -193,6 +193,10 @@ If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
 1. Parse key and value from the arguments.
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
 
+If argument is "version":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/version.sh`
+2. Show the output — the installed version (git-describe provenance recorded at install time).
+
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" claude-code`
 2. Tell the user the result.

--- a/templates/cmd.codex.md
+++ b/templates/cmd.codex.md
@@ -139,6 +139,10 @@ If argument is "hook off" (legacy alias):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off codex "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'off'."
 
+If argument is "version":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/version.sh`
+2. Show the output — the installed version (git-describe provenance recorded at install time).
+
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" codex`
 2. Tell the user the result.

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -274,11 +274,14 @@ teardown() {
 @test "install: records a git-describe provenance VERSION and /version prints it" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
   # install.sh runs from a git checkout here, so the recorded version is a
-  # `git describe` string (starts with the tag).
+  # `git describe` string: a tag (v1.2.3-N-gSHA) when tags are present, or — in
+  # a tag-less checkout like CI's shallow clone — the bare abbreviated commit
+  # from `--always` (any hex, e.g. a828563). Accept both; just not "unknown".
   [ -f "$SK/VERSION" ]
   run cat "$SK/VERSION"
   [ -n "$output" ]
-  [[ "$output" == v* || "$output" =~ ^[0-9] ]]
+  [[ "$output" =~ ^(v[0-9]|[0-9]+\.[0-9]+|[0-9a-f]{7}) ]]
+  [[ "$output" != unknown* ]]
   # /version (version.sh) prints the same recorded value.
   run bash "$SK/scripts/version.sh"
   [ "$status" -eq 0 ]

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -300,3 +300,23 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" =~ "unknown" ]]
 }
+
+@test "install: a non-git copy nested in a foreign git repo records canonical VERSION, not the parent's describe" {
+  # `git describe` searches ancestors for a .git. A non-git agmsg copy unpacked
+  # under some OTHER git repo must still record agmsg's canonical VERSION, not
+  # the parent repo's describe. See #117 review.
+  local parent="$BATS_TEST_TMPDIR/foreign"
+  mkdir -p "$parent"
+  git -C "$parent" init -q
+  git -C "$parent" -c user.email=t@e -c user.name=t commit -q --allow-empty -m init
+  git -C "$parent" tag v9.9.9
+  mkdir -p "$parent/agmsg-src"
+  cp -R "$REPO_ROOT/." "$parent/agmsg-src/"
+  rm -rf "$parent/agmsg-src/.git"   # non-git copy, nested under the foreign repo
+  local canonical; canonical="$(tr -d '[:space:]' < "$parent/agmsg-src/VERSION")"
+
+  HOME="$FAKE_HOME" bash "$parent/agmsg-src/install.sh" --cmd agmsg
+  run cat "$SK/VERSION"
+  [ "$output" = "$canonical" ]
+  [[ "$output" != v9.9.9* ]]
+}

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -270,3 +270,33 @@ teardown() {
   ! grep -q 'rm -rf' "$stdout_capture"
   rm -f "$stdin_capture" "$stdout_capture"
 }
+
+@test "install: records a git-describe provenance VERSION and /version prints it" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  # install.sh runs from a git checkout here, so the recorded version is a
+  # `git describe` string (starts with the tag).
+  [ -f "$SK/VERSION" ]
+  run cat "$SK/VERSION"
+  [ -n "$output" ]
+  [[ "$output" == v* || "$output" =~ ^[0-9] ]]
+  # /version (version.sh) prints the same recorded value.
+  run bash "$SK/scripts/version.sh"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(cat "$SK/VERSION")" ]
+}
+
+@test "install: --update refreshes the recorded VERSION" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  echo "stale-marker" > "$SK/VERSION"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  run cat "$SK/VERSION"
+  [ "$output" != "stale-marker" ]
+}
+
+@test "version.sh falls back gracefully when no VERSION was recorded" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  rm -f "$SK/VERSION"
+  run bash "$SK/scripts/version.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "unknown" ]]
+}


### PR DESCRIPTION
Closes #117.

## Problem

The installed skill recorded **no version**, and the canonical `VERSION` (`1.0.3`) only changes at a tagged release — so every commit on `main` between releases installs as the same `1.0.3`, with no way to tell which commit is actually running (or whether it was installed from a dirty/in-dev tree, as the current `--update`-from-a-worktree dev loop does).

## Change

`install.sh` records a provenance string to `<skill>/VERSION` at install time (both fresh and `--update`):

- **git checkout** → `git describe --tags --always --dirty --abbrev=7`, e.g. `v1.0.3-6-g5aad45e` (6 commits past `v1.0.3` at `5aad45e`), with a `-dirty` suffix when the source tree had uncommitted changes. This is the standard OSS convention for "exactly which source produced this build" — the `g` prefix is git's own abbreviated-commit marker, `-dirty` flags local edits to tracked files.
- **non-git** (tarball via `setup.sh`/`npx`, no `.git`) → falls back to the canonical `VERSION` value (`1.0.3`).

Adds `scripts/version.sh` and a `/<cmd> version` subcommand to print it. `install.sh` also reports the version it just installed.

The canonical `VERSION` / `package.json` / `.claude-plugin/plugin.json` stay **strict semver** (release tooling depends on them) — only the installed copy carries the git provenance.

## Tests

- install records a `git describe` VERSION; `version.sh` prints the same value
- `--update` refreshes the recorded VERSION
- `version.sh` falls back to "unknown" when no VERSION is present
- verified live: git install → `v1.0.3-6-g5aad45e-dirty`; non-git copy → `1.0.3`

Full suite green (239).
