### PR TITLE
feat(despawn): tear down spawned crew members (#109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,21 @@ Options: `--project <path>` (default: current project), `--team <team>` (auto-re
 
 Only `claude-code` and `codex` are supported today. macOS is the primary target; Linux and Windows are best-effort (please open an issue/PR if your terminal isn't handled). Headless environments — no tmux **and** no usable terminal — error out, since the agent CLIs need an interactive terminal.
 
+### Tear down a spawned agent (`despawn`)
+
+`despawn` is the inverse of `spawn` — it cleanly tears down a member you brought up.
+
+```
+/agmsg despawn reviewer          # graceful: the member drops its role and closes its own pane
+/agmsg despawn alice --force     # force: tear it down from here when its watcher can't respond
+```
+
+By default `despawn <name>` is **graceful**: it sends a `ctrl:despawn` control message to `<name>`, whose watcher drops its own role (releasing the actas lock and registration) and closes its own tmux pane — ending the agent. It blocks until the role is released, up to `--timeout <secs>` (default 30), then prints `status=ok`. If the member's watcher never responds it prints `status=timeout` and exits 3 — retry with `--force`.
+
+`--force` skips the message and tears the member down from the placement recorded at spawn time: it kills the member's tmux pane/window and drops its registration. Use it when the member's watcher can't respond — a dead watcher, or a **codex** member (no Monitor, so graceful has nothing to act on). A member started by hand (no spawn placement record) can't be `--force`d; despawn says so and leaves it for you to close.
+
+Despawn only acts on the named member — the session running `despawn` is never torn down, and a broad-subscription watcher ignores a `ctrl:despawn` aimed at another role.
+
 ## Delivery modes
 
 How incoming messages reach your agent. Pick one at first join via the prompt, or change it later with `/agmsg mode <name>`.
@@ -234,6 +249,7 @@ The command updates `db/config.yaml`, rewrites the project's hook entries, and p
 /agmsg actas <name>                     — switch to another role in this project (create if needed)
 /agmsg drop <name>                      — remove a role from this project
 /agmsg spawn <type> <name>              — launch a new agent (claude-code/codex) that takes <name>
+/agmsg despawn <name> [--force]         — tear down a member you spawned (graceful, or --force)
 /agmsg hook on | off                    — legacy aliases (mode turn | off)
 /agmsg version                          — show the installed version (git-describe provenance)
 /agmsg reset                            — clear current project registration

--- a/SKILL.md
+++ b/SKILL.md
@@ -126,6 +126,21 @@ Do NOT manually edit config files. Always use join.sh.
 #                        prints status=timeout and exits 3). Codex skips the
 #                        wait (it has no Monitor).
 ~/.agents/skills/agmsg/scripts/spawn.sh <claude-code|codex> <name> [options]
+
+# Tear down a spawned member — the inverse of spawn.
+# Default (graceful): sends a `ctrl:despawn` control message to <name>; the
+# member's watcher drops its own role (releasing the actas lock + registration)
+# and closes its own tmux pane, ending the agent. Blocks until the lock releases
+# (--timeout, default 30s) then prints `status=ok`; on timeout prints
+# status=timeout and exits 3 (retry with --force). Only an exclusive watcher
+# dedicated to <name> acts on it — the despawning session is never torn down.
+# --force: skip the message and tear the member down from the placement recorded
+# at spawn time (kill its tmux pane/window, drop its registration) — for a dead
+# watcher or a codex member (no Monitor). A hand-started member with no placement
+# record can't be --forced.
+#   --force              tear down from the recorded placement, no message
+#   --timeout N          seconds to wait for graceful teardown (default 30)
+~/.agents/skills/agmsg/scripts/despawn.sh <team> <from> <name> [--force] [--timeout N]
 ```
 
 ## Sandbox compatibility (Claude Code)

--- a/scripts/despawn.sh
+++ b/scripts/despawn.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# despawn.sh — tear down a spawned crew member, the inverse of spawn.sh.
+#
+# Usage:
+#   despawn.sh <team> <from> <name> [--force] [--timeout <secs>]
+#
+#   <team>   team the member is in
+#   <from>   the leader's own agent name (sender of the control message)
+#   <name>   the member to tear down
+#
+# Default (graceful): send a `ctrl:despawn` control message to <name>. The
+# member's watcher (watch.sh) sees it, drops its own role (releasing the actas
+# lock) and closes its own tmux pane — ending its CLI. We block until the lock
+# is released, up to --timeout (default 30s); on timeout the member didn't
+# respond (dead watcher, or a codex member with no Monitor) — re-run with
+# --force.
+#
+# --force: skip the message and tear the member down from here using the
+# placement recorded at spawn time — kill its tmux pane/window and drop its
+# registration. For when the member's watcher can't respond.
+#
+# See #109. Graceful teardown's full pane-close is tmux-only (the member needs a
+# tmux pane to close); an OS-terminal member drops its role but its window must
+# be closed by hand.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"  # actas-lock.sh requires SKILL_DIR
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/actas-lock.sh"
+
+die() { echo "despawn: $*" >&2; exit 1; }
+
+TEAM="${1:-}"; FROM="${2:-}"; NAME="${3:-}"
+[ -n "$TEAM" ] && [ -n "$FROM" ] && [ -n "$NAME" ] \
+  || die "Usage: despawn.sh <team> <from> <name> [--force] [--timeout <secs>]"
+shift 3 || true
+
+FORCE=0
+TIMEOUT=30
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --force) FORCE=1; shift ;;
+    --timeout) TIMEOUT="${2:?--timeout needs seconds}"; shift 2 ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+case "$TIMEOUT" in ''|*[!0-9]*) die "--timeout must be a whole number of seconds" ;; esac
+
+SPAWN_REC="$(agmsg_spawn_path "$TEAM" "$NAME")"
+
+# Kill the recorded tmux target. ids are self-describing: %N pane, @N window.
+kill_recorded_placement() {
+  [ -f "$SPAWN_REC" ] || return 1
+  local id _proj _type
+  IFS=$'\t' read -r id _proj _type < "$SPAWN_REC"
+  [ -n "$id" ] || return 1
+  if command -v tmux >/dev/null 2>&1; then
+    case "$id" in
+      %*) tmux kill-pane   -t "$id" 2>/dev/null || true ;;
+      @*) tmux kill-window -t "$id" 2>/dev/null || true ;;
+    esac
+  fi
+  printf '%s\t%s\t%s' "$id" "$_proj" "$_type"   # echo back for the caller
+}
+
+if [ "$FORCE" = "1" ]; then
+  [ -f "$SPAWN_REC" ] || die "no placement record for '$TEAM/$NAME' — nothing to force (was it launched via 'spawn'? graceful despawn does not need this)"
+  IFS=$'\t' read -r _id _proj _type < "$SPAWN_REC"
+  kill_recorded_placement >/dev/null
+  # Drop the member's registration, and release its (now-stale) lock.
+  if [ -n "${_proj:-}" ] && [ -n "${_type:-}" ]; then
+    "$SCRIPT_DIR/reset.sh" "$_proj" "$_type" "$NAME" >/dev/null 2>&1 || true
+  fi
+  owner="$(actas_lock_owner "$TEAM" "$NAME")"
+  [ -n "$owner" ] && actas_lock_release "$TEAM" "$NAME" "$owner" 2>/dev/null || true
+  rm -f "$SPAWN_REC" 2>/dev/null || true
+  echo "status=forced name=$NAME team=$TEAM"
+  exit 0
+fi
+
+# --- Graceful ---
+state="$(actas_lock_state "$TEAM" "$NAME" "" 2>/dev/null || echo free)"
+case "$state" in
+  free)
+    echo "despawn: '$NAME' holds no live actas lock — nothing to confirm a teardown against (a codex member has no watcher; a tmux member may already be gone). If a window remains, use --force." >&2
+    rm -f "$SPAWN_REC" 2>/dev/null || true
+    echo "status=ok name=$NAME team=$TEAM note=no-live-lock"
+    exit 0
+    ;;
+esac
+
+"$SCRIPT_DIR/send.sh" "$TEAM" "$FROM" "$NAME" "ctrl:despawn" >/dev/null
+
+waited=0
+while true; do
+  state="$(actas_lock_state "$TEAM" "$NAME" "" 2>/dev/null || echo free)"
+  [ "$state" = "free" ] && break
+  if [ "$waited" -ge "$TIMEOUT" ]; then
+    echo "status=timeout name=$NAME team=$TEAM after=${TIMEOUT}s"
+    echo "despawn: '$NAME' did not tear down within ${TIMEOUT}s — its watcher may be dead. Retry with --force." >&2
+    exit 3
+  fi
+  sleep 1
+  waited=$((waited + 1))
+done
+
+rm -f "$SPAWN_REC" 2>/dev/null || true
+echo "status=ok name=$NAME team=$TEAM after=${waited}s"

--- a/scripts/lib/actas-lock.sh
+++ b/scripts/lib/actas-lock.sh
@@ -65,6 +65,17 @@ agmsg_ready_path() {
   printf '%s/ready.%s__%s' "$(_actas_lock_dir)" "$t" "$a"
 }
 
+# Placement record path for a spawned (team, agent). `spawn` writes the
+# member's tmux target id + project + type here at launch time so that
+# `despawn --force` can tear the member down (kill its pane/window, drop its
+# registration) even when the member's own watcher is dead and can't respond
+# to a ctrl:despawn. Same encoding as the lock path. See #109.
+agmsg_spawn_path() {
+  local team="$1" agent="$2"
+  local t a; t="$(_actas_lock_encode "$team")"; a="$(_actas_lock_encode "$agent")"
+  printf '%s/spawn.%s__%s' "$(_actas_lock_dir)" "$t" "$a"
+}
+
 # Read the owner session_id of a lock file. Empty if no lock or unreadable.
 actas_lock_owner() {
   local lock; lock="$(actas_lock_path "$1" "$2")"

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -249,16 +249,20 @@ launch_in_tmux() {
   # the boot script's filename (boot-XXXXXX). `automatic-rename off` keeps the
   # name from being clobbered once the boot script runs the CLI / drops to a
   # shell.
+  local target_id
   if [ "$TMUX_TARGET" = "window" ]; then
-    local win_id
-    win_id="$(tmux new-window -P -F '#{window_id}' -n "$NAME" -c "$PROJECT" "$BOOT")"
-    tmux set-window-option -t "$win_id" automatic-rename off 2>/dev/null || true
+    target_id="$(tmux new-window -P -F '#{window_id}' -n "$NAME" -c "$PROJECT" "$BOOT")"
+    tmux set-window-option -t "$target_id" automatic-rename off 2>/dev/null || true
   else
     local dir="-h"; [ "$SPLIT" = "v" ] && dir="-v"
-    local pane_id
-    pane_id="$(tmux split-window "$dir" -P -F '#{pane_id}' -c "$PROJECT" "$BOOT")"
-    tmux select-pane -t "$pane_id" -T "$NAME" 2>/dev/null || true
+    target_id="$(tmux split-window "$dir" -P -F '#{pane_id}' -c "$PROJECT" "$BOOT")"
+    tmux select-pane -t "$target_id" -T "$NAME" 2>/dev/null || true
   fi
+  # Record placement so `despawn --force` can tear this member down even if its
+  # watcher later can't respond to ctrl:despawn. tmux ids are self-describing:
+  # %N = pane (kill-pane), @N = window (kill-window). See #109.
+  printf '%s\t%s\t%s\n' "$target_id" "$PROJECT" "$AGENT_TYPE" \
+    > "$(agmsg_spawn_path "$TEAM" "$NAME")" 2>/dev/null || true
 }
 
 launch_macos_terminal() {

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -261,6 +261,31 @@ while true; do
     if [ -n "$ROWS" ]; then
       while IFS=$'\x1f' read -r id ts team from to body; do
         [ -z "$id" ] && continue
+        # Control message: a leader's `despawn` sends `ctrl:despawn` to this
+        # role. Tear ourselves down rather than printing it — drop the role
+        # (releases the lock + registration) then close our own tmux pane,
+        # which also ends the agent CLI sharing it. Deterministic teardown, no
+        # dependence on the agent LLM noticing the message. See #109.
+        if [ "$body" = "ctrl:despawn" ]; then
+          LAST="$id"; persist_watermark
+          # Only an EXCLUSIVE watcher dedicated to exactly this role tears
+          # itself down. A broad-subscription watcher (e.g. a leader whose
+          # default watcher subscribes to every project role, including the
+          # despawn target) must NOT act on it — its $TMUX_PANE is the leader's
+          # own pane, so killing it would take down the leader's session. The
+          # spawned member's watcher runs in actas mode (ACTIVE_NAME=$to) in its
+          # own pane; that's the one meant to respond. See #109.
+          if [ -z "$ACTIVE_NAME" ] || [ "$to" != "$ACTIVE_NAME" ]; then
+            continue
+          fi
+          "$SCRIPT_DIR/reset.sh" "$PROJECT_PATH" "$AGENT_TYPE" "$to" "$SESSION_ID" >/dev/null 2>&1 || true
+          if [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then
+            tmux kill-pane -t "$TMUX_PANE" 2>/dev/null || true
+          else
+            echo "agmsg watch: despawned '$to' (role dropped); close this window manually" >&2
+          fi
+          exit 0
+        fi
         printf '%s | %s | %s → %s | %s\n' "$ts" "$team" "$from" "$to" "$body"
         LAST="$id"
       done <<< "$ROWS"

--- a/templates/cmd.claude-code.md
+++ b/templates/cmd.claude-code.md
@@ -43,6 +43,7 @@ Four possible outputs:
   > - `/__SKILL_NAME__ actas <name>` — switch to another role in this project (creates if needed)
   > - `/__SKILL_NAME__ drop <name>` — remove a role from this project
   > - `/__SKILL_NAME__ spawn <type> <name>` — launch a new agent in a tmux pane / terminal and have it actas <name>
+  > - `/__SKILL_NAME__ despawn <name>` — tear down a member you spawned (graceful, or `--force`)
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -167,6 +168,14 @@ If argument starts with "spawn" (e.g. "spawn codex reviewer", "spawn claude-code
    - By default it BLOCKS until the new agent's watcher attaches and prints `status=ready` — so you can message `<name>` right away. It prints `status=timeout` and exits 3 if not ready within `--ready-timeout` (default 90s); pass `--no-wait` for fire-and-forget. Codex skips the wait (no Monitor).
    - It refuses early if `<name>` is already held by another live session, if the target CLI is not installed, or if there is no tmux and no usable terminal (headless).
 3. Show the script's output. Do NOT TaskStop or relaunch this session's own Monitor — spawn affects a separate, newly launched agent, not this session's subscription.
+
+If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --force"):
+1. Parse `<name>` and any options (`--force`, `--timeout <secs>`). `despawn` is the inverse of `spawn` — it tears down a member you previously spawned.
+2. Determine which team `<name>` belongs to (as with `send`), then run:
+   `~/.agents/skills/__SKILL_NAME__/scripts/despawn.sh <team> $AGENT <name> [--force] [--timeout <secs>]`
+   - Default (graceful): sends a `ctrl:despawn` control message to `<name>`. The member's watcher drops its own role (releasing the actas lock + registration) and closes its own tmux pane, which ends the agent CLI. Blocks until the lock releases, up to `--timeout` (default 30s), then prints `status=ok`. On timeout it prints `status=timeout` and exits 3 — the member's watcher didn't respond (dead watcher, or a codex member with no Monitor); retry with `--force`.
+   - `--force`: skips the message and tears the member down from the placement recorded at spawn time — kills its tmux pane/window and drops its registration. Use when the member's watcher can't respond.
+3. Show the script's output. Do NOT TaskStop or relaunch this session's own Monitor — despawn affects the spawned member, not this session's subscription.
 
 If argument is "mode" (no further args):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status claude-code "$(pwd)"`

--- a/templates/cmd.codex.md
+++ b/templates/cmd.codex.md
@@ -123,6 +123,14 @@ If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex re
    - It refuses early if `<name>` is already held by another live session, if the target CLI is not installed, or if there is no tmux and no usable terminal (headless).
 3. Show the script's output.
 
+If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --force"):
+1. Parse `<name>` and any options (`--force`, `--timeout <secs>`). `despawn` is the inverse of `spawn` — it tears down a member you previously spawned.
+2. Determine which team `<name>` belongs to (as with `send`), then run:
+   `~/.agents/skills/__SKILL_NAME__/scripts/despawn.sh <team> $AGENT <name> [--force] [--timeout <secs>]`
+   - Default (graceful): sends a `ctrl:despawn` control message to `<name>`. A claude-code member's watcher drops its own role and closes its own tmux pane, ending the agent. Blocks until the lock releases, up to `--timeout` (default 30s), then prints `status=ok`. On timeout it prints `status=timeout` and exits 3 — retry with `--force`. A codex member has no watcher to respond, so use `--force` for it.
+   - `--force`: skips the message and tears the member down from the placement recorded at spawn time — kills its tmux pane/window and drops its registration.
+3. Show the script's output.
+
 If argument is "mode" (no further args):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status codex "$(pwd)"`
 2. Show the output to the user.

--- a/tests/test_despawn.bats
+++ b/tests/test_despawn.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+
+# Tests for despawn (#109): a leader tears down a spawned member. Graceful path
+# is watcher-driven (watch.sh sees ctrl:despawn, drops its own role); --force is
+# leader-driven from the recorded placement.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export PROJ="/tmp/agmsg-despawn-proj"
+  export RUN="$TEST_SKILL_DIR/run"
+  mkdir -p "$RUN"
+}
+
+teardown() {
+  teardown_test_env
+}
+
+@test "despawn: graceful — ctrl:despawn makes the member drop its role" {
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  # Make the member session look alive so the leader sees a live lock to wait on.
+  setup_live_owner "$RUN" sess-m
+
+  # Unset TMUX_PANE: the ctrl:despawn handler runs `tmux kill-pane -t $TMUX_PANE`,
+  # and a watcher launched from inside the developer's tmux would inherit the
+  # REAL pane id and close the session running the tests. With TMUX_PANE empty,
+  # the handler takes the "close manually" branch — role-drop is still asserted.
+  AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE bash "$SCRIPTS/watch.sh" sess-m "$PROJ" claude-code alice \
+    >/dev/null 2>&1 &
+  local wpid=$! i
+  # Wait for the watcher to attach (it claims the lock + writes the ready sentinel).
+  for i in 1 2 3 4 5 6 7 8 9 10; do [ -e "$RUN/ready.team__alice" ] && break; sleep 0.5; done
+  [ -e "$RUN/ready.team__alice" ]
+  [ -f "$RUN/actas.team__alice.session" ]
+
+  run bash "$SCRIPTS/despawn.sh" team leader alice --timeout 10
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status=ok"* ]]
+
+  # Member dropped its role: lock released and registration gone.
+  [ ! -f "$RUN/actas.team__alice.session" ]
+  run bash "$SCRIPTS/identities.sh" "$PROJ" claude-code
+  [[ "$output" != *alice* ]]
+
+  kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true
+}
+
+@test "despawn --force: kills recorded placement and drops registration without the member" {
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  # Placement as spawn would have recorded it (pane %99 doesn't exist; kill is
+  # best-effort/no-op here — we assert the registration + lock + record effects).
+  printf '%s\t%s\t%s\n' '%99' "$PROJ" claude-code > "$RUN/spawn.team__alice"
+  printf 'somesid\n' > "$RUN/actas.team__alice.session"
+
+  run bash "$SCRIPTS/despawn.sh" team leader alice --force
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status=forced"* ]]
+  [ ! -f "$RUN/spawn.team__alice" ]                 # placement record cleaned
+  [ ! -f "$RUN/actas.team__alice.session" ]         # lock released
+  run bash "$SCRIPTS/identities.sh" "$PROJ" claude-code
+  [[ "$output" != *alice* ]]                        # registration dropped
+}
+
+@test "despawn --force: errors when there is no placement record" {
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  run bash "$SCRIPTS/despawn.sh" team leader alice --force
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "no placement record" ]]
+}
+
+@test "despawn: times out (exit 3) when the member never drops" {
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  setup_live_owner "$RUN" sess-m
+  printf 'sess-m\n' > "$RUN/actas.team__alice.session"   # held live, no watcher to act
+
+  run bash "$SCRIPTS/despawn.sh" team leader alice --timeout 2
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"status=timeout"* ]]
+}
+
+@test "despawn: a broad (non-actas) watcher ignores ctrl:despawn and does not self-destruct" {
+  # Regression for the self-kill bug: a leader's default watcher subscribes to
+  # EVERY project role. If it acted on a ctrl:despawn addressed to one of them,
+  # it would run `tmux kill-pane -t $TMUX_PANE` against the leader's OWN pane and
+  # take down the leader session. A broad watcher must skip the control message.
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/join.sh" team leader claude-code "$PROJ" >/dev/null
+
+  # Broad watcher (no actas arg) — subscribes to both alice and leader.
+  AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE bash "$SCRIPTS/watch.sh" sess-broad "$PROJ" claude-code \
+    >/dev/null 2>&1 &
+  local wpid=$! i
+  for i in 1 2 3 4 5 6 7 8 9 10; do kill -0 "$wpid" 2>/dev/null && break; sleep 0.5; done
+
+  # Deliver a despawn aimed at alice straight into the stream.
+  bash "$SCRIPTS/send.sh" team boss alice "ctrl:despawn" >/dev/null
+  sleep 2
+
+  kill -0 "$wpid" 2>/dev/null            # watcher still alive — did NOT self-destruct
+  run bash "$SCRIPTS/identities.sh" "$PROJ" claude-code
+  [[ "$output" == *alice* ]]             # broad watcher did not drop alice's role
+
+  kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true
+}
+
+@test "despawn: graceful no-op when the member holds no live lock (e.g. codex)" {
+  bash "$SCRIPTS/join.sh" team alice codex "$PROJ" >/dev/null
+  run bash "$SCRIPTS/despawn.sh" team leader alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no-live-lock"* ]]
+}


### PR DESCRIPTION
## What

Add `despawn` — the inverse of `spawn` — to tear down a spawned crew member.

- **graceful** (default): send a `ctrl:despawn` control message to the member. Its watcher (`watch.sh`) sees it, drops its own role (releasing the actas lock + registration) and closes its own tmux pane, which ends the member CLI. The leader blocks until the lock is released, up to `--timeout` (default 30s).
- **`--force`**: tear the member down from the placement recorded at spawn time — kill its tmux pane/window and drop its registration — for when the member's own watcher can't respond (dead watcher, or a codex member with no Monitor).

## How

- `scripts/despawn.sh`: `despawn.sh <team> <from> <name> [--force] [--timeout <secs>]`.
- `scripts/spawn.sh`: records the member's tmux target id + project + type via a new `agmsg_spawn_path` helper at launch, so `--force` has a placement to act on.
- `scripts/lib/actas-lock.sh`: `agmsg_spawn_path` placement-record path helper.
- `scripts/watch.sh`: handle `ctrl:despawn`. **Only an exclusive (actas) watcher dedicated to exactly the despawned role tears itself down.** A broad-subscription watcher must skip the control message — its `$TMUX_PANE` is the leader's own pane, so acting on a despawn for any subscribed role would kill the leader's session. This is the core safety fix.

## Command surface

`despawn` is wired as a first-class command, not just a script:

- `templates/cmd.claude-code.md` + `cmd.codex.md`: a `despawn` handler mapping `/<cmd> despawn <name> [--force] [--timeout N]` to `despawn.sh`, plus the help line shown at join.
- `README.md`: a "Tear down a spawned agent (`despawn`)" section next to `spawn`, and a cheatsheet line.
- `SKILL.md`: the despawn invocation documented alongside spawn.

## Tests

- `tests/test_despawn.bats`: graceful teardown, `--force` placement teardown, `--force` error with no record, graceful timeout (exit 3), graceful no-op when no live lock, and a regression test asserting a broad watcher ignores `ctrl:despawn` and does not self-destruct.
- The test harness unsets `TMUX_PANE` when launching the watcher under test, so the `ctrl:despawn` handler never targets a real pane.

## Validation

- Full suite: **249/249 green**.
- Packaging smoke (isolated `HOME`, clean install): `despawn.sh` is packaged and runs end-to-end (graceful no-op + `--force` no-record error paths).
- Local end-to-end run confirmed both paths on real tmux members: graceful self-teardown (~1s, window closes, role/registration dropped) and `--force` (pane kill + registration drop) — **the leader session survives in both cases** (the bug this fixes).
- A nested run (leader → spawn A → A spawns B → A despawns B → leader despawns A) confirmed self-teardown at every level with no orphaned panes/watchers/records and the despawning session always surviving.
- Packaging smoke also asserts the installed command template carries the `despawn` handler and `despawn.sh` is shipped.

Closes #109.
