### PR TITLE
fix: isolate parallel --continue/--resume sessions sharing a session_id (#93)

### DIFF
--- a/scripts/actas-claim.sh
+++ b/scripts/actas-claim.sh
@@ -40,6 +40,12 @@ source "$SCRIPT_DIR/lib/resolve-project.sh"
 # rather than missing it as not_registered.
 PROJECT="$(agmsg_resolve_project "$PROJECT" "$TYPE")"
 
+# Claim the lock under the per-process instance id (#93), the same token the
+# watcher (re)launched by this actas flow keys its pidfile on. The template
+# passes a bare $CLAUDE_CODE_SESSION_ID; normalize self-derives the composite so
+# a parallel --continue/--resume session can't appear to already own the role.
+SESSION_ID="$(agmsg_normalize_instance_id "$SESSION_ID" "$TYPE")"
+
 # Find the team(s) this name is registered to for the given project/type.
 TEAMS=""
 while IFS=$'\t' read -r team agent; do

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -12,6 +12,8 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"  # agmsg_agent_pid, for instance-id derivation
 
 # Hook runtimes that pass JSON do so on stdin. Interactive invocations such as
 # Gemini's PostToolUse command may inherit a terminal stdin instead; reading
@@ -33,6 +35,11 @@ SESSION_ID=$(printf '%s' "$INPUT" \
   | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
   | head -1)
 if [ -n "$SESSION_ID" ]; then
+  # The monitor watcher keys its pidfile (and its actas owner, below) on the
+  # per-process instance id (#93), not the bare session_id. Normalize to the
+  # same token so this Stop-hook defers to a live watcher in `both` mode instead
+  # of double-delivering.
+  SESSION_ID="$(agmsg_normalize_instance_id "$SESSION_ID" "$TYPE")"
   PIDFILE="$SKILL_DIR/run/watch.$SESSION_ID.pid"
   if [ -f "$PIDFILE" ]; then
     WATCH_PID=$(cat "$PIDFILE" 2>/dev/null || true)

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -32,6 +32,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SKILL_NAME="$(basename "$SKILL_DIR")"
 RUN_DIR="$SKILL_DIR/run"
+# instance-id derivation (#93) for the in-session monitor directive below.
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/resolve-project.sh"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/instance-id.sh"
 
 resolve_hooks_file() {
   local type="$1"
@@ -357,6 +362,12 @@ emit_monitor_directive() {
       session_id="agmsg-$(date +%s)-$$"
     fi
   fi
+
+  # Key the watcher on the per-process instance id (#93) so parallel
+  # --continue/--resume sessions sharing a session_id stay isolated. Baking the
+  # composite into the directive matches SessionStart and makes the pidfile
+  # liveness check below see the real watcher (idempotent in watch.sh).
+  session_id="$(agmsg_normalize_instance_id "$session_id" "$type")"
 
   # Skip the directive when this CC session already has a live watcher —
   # invoking Monitor again would just spawn a duplicate and orphan the

--- a/scripts/lib/actas-lock.sh
+++ b/scripts/lib/actas-lock.sh
@@ -26,6 +26,13 @@
 
 : "${SKILL_DIR:?actas-lock.sh requires SKILL_DIR}"
 
+# Owner tokens are per-process instance ids (see instance-id.sh), not bare
+# session_ids — this is what keeps parallel --continue/--resume sessions that
+# share a session_id from each appearing to own the other's locks (#93). The
+# liveness check (actas_lock_sid_alive) delegates to agmsg_instance_alive.
+# shellcheck disable=SC1091
+. "$SKILL_DIR/scripts/lib/instance-id.sh"
+
 _actas_lock_dir() { printf '%s/run' "$SKILL_DIR"; }
 
 # Encode a team or agent name into a filesystem-safe form. Anything outside
@@ -72,26 +79,14 @@ actas_lock_owner() {
   head -1 "$lock" 2>/dev/null
 }
 
-# Return 0 if the given session_id is alive — that is, some live
-# cc-instance.<pid> currently contains it. Empty sid → not alive.
+# Return 0 if the given owner token is alive. The token is a per-process
+# instance id (composite "<sid>.<pid>" or bare "<sid>" fallback); liveness is
+# delegated to agmsg_instance_alive (composite → kill -0 the embedded pid; bare
+# → live cc-instance.<pid> scan, with upgrade compat). Kept as a thin wrapper
+# so existing callers (gc_stale, watch.sh subscription, session-start GC) need
+# no change. Empty token → not alive.
 actas_lock_sid_alive() {
-  local sid="$1"
-  [ -n "$sid" ] || return 1
-  local run; run="$(_actas_lock_dir)"
-  [ -d "$run" ] || return 1
-  # All loop variables are local — this function gets called from inside other
-  # loops (gc_stale, watch.sh subscription resolution), so leaking $f or $pid
-  # would corrupt the caller's iteration.
-  local f pid s
-  for f in "$run"/cc-instance.*; do
-    [ -f "$f" ] || continue
-    pid=${f##*.}
-    case "$pid" in ''|*[!0-9]*) continue ;; esac
-    kill -0 "$pid" 2>/dev/null || continue
-    s="$(cat "$f" 2>/dev/null || true)"
-    [ "$s" = "$sid" ] && return 0
-  done
-  return 1
+  agmsg_instance_alive "$1"
 }
 
 # Internal: attempt one atomic claim. Echoes "ok" on success, "held:<sid>"

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# instance-id.sh — per-process runtime instance identity.
+#
+# A Claude Code `session_id` is NOT unique across parallel
+# `claude --continue` / `--resume` processes (#93): the second process re-fires
+# SessionStart with the *original* session_id, so two live processes claim to
+# be the same session. Keying watcher/lock state (pidfile, watermark, actas
+# owner) on session_id alone makes those two processes collide — most visibly
+# the watch.sh "kill the previous holder for this session" logic (#66) turns
+# into a mutual kill loop.
+#
+# We disambiguate by composing the session_id with the enclosing agent process
+# pid, which IS unique per live process. The resulting "instance id":
+#   - is stable across /clear within one agent process (sid + pid unchanged),
+#     so the #66 dedup-on-relaunch still works;
+#   - differs between parallel resume processes (different pid), so their
+#     pidfile / watermark / actas owner stop colliding.
+#
+# Token shape:
+#   "<session_id>.<pid>"   composite — pid is the enclosing agent process
+#   "<session_id>"         bare — fallback when the agent pid can't be resolved
+#                          (detached watcher, sandboxed ps, non-agent wrapper)
+#
+# session_ids are UUIDs / "agmsg-<...>" / "unknown-<pid>" — none contain a '.',
+# so "last dot-segment is numeric" unambiguously marks the composite form.
+#
+# Requires: SKILL_DIR set. agmsg_instance_id / agmsg_normalize_instance_id
+# additionally require resolve-project.sh sourced (for agmsg_agent_pid);
+# agmsg_instance_alive and the pure helpers do not.
+
+# Guard against double-source (these are sourced transitively via actas-lock.sh
+# and directly by entry-point scripts).
+[ -n "${_AGMSG_INSTANCE_ID_SH:-}" ] && return 0
+_AGMSG_INSTANCE_ID_SH=1
+
+# Compose from an explicit pid. Bare sid when pid is empty/non-numeric.
+agmsg_instance_id_from_pid() {
+  local sid="$1" pid="$2"
+  case "$pid" in
+    ''|*[!0-9]*) printf '%s' "$sid" ;;
+    *)           printf '%s.%s' "$sid" "$pid" ;;
+  esac
+}
+
+# True iff <token> is composite "<sid>.<pid>": a non-empty prefix, a '.', and
+# an all-digits suffix.
+agmsg_instance_is_composite() {
+  local token="$1"
+  case "$token" in
+    *.*) ;;
+    *) return 1 ;;
+  esac
+  local pid="${token##*.}" prefix="${token%.*}"
+  [ -n "$prefix" ] || return 1
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# Derive an instance id for <session_id> from the enclosing agent <type>.
+# Resolves the agent pid via agmsg_agent_pid; on failure falls back to the bare
+# session_id and emits a one-line stderr warning. The fallback is a known
+# degraded mode: if one entry point (e.g. the Bash tool path) resolves the pid
+# while another (e.g. the Monitor persistent command) cannot, their tokens
+# diverge — the warning makes that split traceable in logs.
+agmsg_instance_id() {
+  local sid="$1" type="$2" pid=""
+  pid="$(agmsg_agent_pid "$type" 2>/dev/null || true)"
+  if [ -z "$pid" ]; then
+    printf 'agmsg: instance-id falling back to bare session_id (agent pid unresolved for type=%s); parallel --continue/--resume isolation is degraded\n' "$type" >&2
+    printf '%s' "$sid"
+    return 0
+  fi
+  agmsg_instance_id_from_pid "$sid" "$pid"
+}
+
+# Idempotent normalize: a token already in composite form is returned as-is; a
+# bare session_id is upgraded via agmsg_instance_id. This is the single entry
+# point every script calls on its raw first/owner argument, so a script handed
+# a pre-computed instance id (hook/monitor path) does not re-derive, while a
+# script handed a bare session_id (template path) self-derives.
+agmsg_normalize_instance_id() {
+  local token="$1" type="$2"
+  if agmsg_instance_is_composite "$token"; then
+    printf '%s' "$token"
+    return 0
+  fi
+  agmsg_instance_id "$token" "$type"
+}
+
+# True iff <token> identifies a still-live instance.
+#   composite "<sid>.<pid>" → the embedded pid is alive (kill -0).
+#   bare "<sid>"            → some live cc-instance.<p> file references it. For
+#                            upgrade compatibility a cc-instance whose content
+#                            is either exactly "<sid>" or the composite
+#                            "<sid>.<numeric>" counts — a pre-upgrade lock holds
+#                            a bare sid while cc-instance may already store the
+#                            composite, and we must not stale it out instantly.
+agmsg_instance_alive() {
+  local token="$1"
+  [ -n "$token" ] || return 1
+  if agmsg_instance_is_composite "$token"; then
+    local pid="${token##*.}"
+    kill -0 "$pid" 2>/dev/null && return 0
+    return 1
+  fi
+  local run f p s
+  run="$SKILL_DIR/run"
+  [ -d "$run" ] || return 1
+  for f in "$run"/cc-instance.*; do
+    [ -f "$f" ] || continue
+    p=${f##*.}
+    case "$p" in ''|*[!0-9]*) continue ;; esac
+    kill -0 "$p" 2>/dev/null || continue
+    s="$(cat "$f" 2>/dev/null || true)"
+    [ "$s" = "$token" ] && return 0
+    # upgrade compat: cc-instance stores "<sid>.<pid>" but the lock holds "<sid>"
+    if agmsg_instance_is_composite "$s" && [ "${s%.*}" = "$token" ]; then
+      return 0
+    fi
+  done
+  return 1
+}

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -75,9 +75,13 @@ agmsg_pid_is_agent() {
 agmsg_agent_pid() {
   local type="$1"
   if [ -n "${AGMSG_AGENT_PID+set}" ]; then
-    [ -n "$AGMSG_AGENT_PID" ] || return 1
-    printf '%s' "$AGMSG_AGENT_PID"
-    return 0
+    case "$AGMSG_AGENT_PID" in
+      '')       return 1 ;;  # explicit empty → force the bare-sid fallback
+      *[!0-9]*)              # non-numeric → ignore, warn, fall back to bare
+        printf 'agmsg: ignoring non-numeric AGMSG_AGENT_PID=%s; using bare session_id\n' "$AGMSG_AGENT_PID" >&2
+        return 1 ;;
+      *) printf '%s' "$AGMSG_AGENT_PID"; return 0 ;;
+    esac
   fi
   local pid="$$" hops=0
   while [ "${pid:-0}" -gt 1 ] && [ "$hops" -lt 20 ]; do

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -65,8 +65,20 @@ agmsg_pid_is_agent() {
 # Walk the process tree from $$ upward, echoing the PID of the nearest ancestor
 # that looks like an agent process of <type>. Empty (return 1) when none is
 # found — e.g. a detached watcher or a plain human shell.
+#
+# Override hook: when AGMSG_AGENT_PID is set, it pins the resolved pid instead
+# of walking the tree — a non-empty value is echoed as-is, an empty value forces
+# the "no agent ancestor" path (so instance-id derivation falls back to the bare
+# session_id). This makes instance-id keying (#93) deterministic for the test
+# suite regardless of the ambient process tree, and is a usable escape hatch
+# when the ps-walk heuristic misfires for an unusual launch topology.
 agmsg_agent_pid() {
   local type="$1"
+  if [ -n "${AGMSG_AGENT_PID+set}" ]; then
+    [ -n "$AGMSG_AGENT_PID" ] || return 1
+    printf '%s' "$AGMSG_AGENT_PID"
+    return 0
+  fi
   local pid="$$" hops=0
   while [ "${pid:-0}" -gt 1 ] && [ "$hops" -lt 20 ]; do
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -27,6 +27,15 @@ source "$SCRIPT_DIR/lib/resolve-project.sh"
 # subdir/worktree clears the registration on the project the session lives in.
 PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
 
+# A drop releases the actas lock keyed under this session's per-process instance
+# id (#93). The template passes a bare $CLAUDE_CODE_SESSION_ID; normalize to the
+# same composite the watcher/claim used so the release matches the real owner
+# token (and doesn't no-op against a bare key). Empty stays empty (lock release
+# is then skipped, as before).
+if [ -n "$SESSION_ID" ]; then
+  SESSION_ID="$(agmsg_normalize_instance_id "$SESSION_ID" "$AGENT_TYPE")"
+fi
+
 if [ -z "$TARGET_AGENT" ]; then
   WHOAMI=$(bash "$SCRIPT_DIR/whoami.sh" "$PROJECT_PATH" "$AGENT_TYPE")
   if echo "$WHOAMI" | grep -q '^agent='; then

--- a/scripts/session-end.sh
+++ b/scripts/session-end.sh
@@ -40,7 +40,17 @@ if [ -n "$INPUT" ]; then
 fi
 [ -z "$SESSION_ID" ] && exit 0
 
-PIDFILE="$RUN_DIR/watch.$SESSION_ID.pid"
+# Re-derive the per-process instance id this session's watcher/locks are keyed
+# under (#93). The enclosing agent process is still alive during the hook, so
+# agmsg_instance_id normally resolves the same "<sid>.<pid>" that session-start
+# computed — cleaning ONLY this process's state, never a sibling --continue/
+# --resume process that shares the bare session_id. If the pid can't be
+# resolved we fall back to the bare session_id (and clean only the bare-keyed
+# artifacts); we deliberately do NOT glob-delete "<sid>.*", which would kill a
+# living sibling — those are left to session-start's liveness GC instead.
+INSTANCE_ID="$(agmsg_instance_id "$SESSION_ID" "$TYPE")"
+
+PIDFILE="$RUN_DIR/watch.$INSTANCE_ID.pid"
 if [ -f "$PIDFILE" ]; then
   pid=$(cat "$PIDFILE" 2>/dev/null || true)
   if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
@@ -58,19 +68,21 @@ fi
 
 # Drop the per-session stream watermark (see #107) — the session is ending, so
 # there is no restart to resume; a future session_id reuse should start fresh.
-rm -f "$RUN_DIR/watch.$SESSION_ID.watermark" 2>/dev/null || true
+rm -f "$RUN_DIR/watch.$INSTANCE_ID.watermark" 2>/dev/null || true
 
-# Clean cc-instance entries that still point at this session_id. The
-# enclosing CC process may itself be exiting (matcher=logout/etc.), in which
-# case its cc-instance.<pid> file would otherwise be left stale.
+# Clean the cc-instance entry that points at this instance id. The enclosing
+# CC process may itself be exiting (matcher=logout/etc.), in which case its
+# cc-instance.<pid> file would otherwise be left stale. A sibling process that
+# shares the bare session_id stores a different instance id, so it is untouched.
 for f in "$RUN_DIR"/cc-instance.*; do
   [ -f "$f" ] || continue
   state=$(cat "$f" 2>/dev/null || true)
-  [ "$state" = "$SESSION_ID" ] && rm -f "$f"
+  [ "$state" = "$INSTANCE_ID" ] && rm -f "$f"
 done
 
-# Release any actas exclusivity locks owned by this session so peers can
-# reclaim those identities on their next watcher cycle. See #62.
-actas_lock_release_all "$SESSION_ID" 2>/dev/null || true
+# Release any actas exclusivity locks owned by this instance so peers can
+# reclaim those identities on their next watcher cycle. Keyed by instance id so
+# a sibling resume process's locks are not released out from under it. See #62.
+actas_lock_release_all "$INSTANCE_ID" 2>/dev/null || true
 
 exit 0

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -53,32 +53,19 @@ fi
 mkdir -p "$RUN_DIR" 2>/dev/null || true
 
 # --- Identify the enclosing Claude Code process. ---
-# Walk the parent chain looking for a process whose argv contains "claude".
-# Stop at PID 1 or after a bounded number of hops. Returns empty when no
-# match — in that case we skip the dedup step entirely.
-find_cc_pid() {
-  local pid="$$"
-  local hops=0
-  while [ "$pid" -gt 1 ] && [ "$hops" -lt 20 ]; do
-    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -z "$pid" ] && return 1
-    [ "$pid" = "0" ] && return 1
-    local cmd
-    cmd=$(ps -o args= -p "$pid" 2>/dev/null || true)
-    # Match the actual claude binary, not e.g. "/bin/zsh -c '...claude...'"
-    # by requiring the basename of the first token to be exactly "claude".
-    local first
-    first=$(printf '%s' "$cmd" | awk '{print $1}')
-    if [ "$(basename -- "${first:-}")" = "claude" ]; then
-      echo "$pid"
-      return 0
-    fi
-    hops=$((hops + 1))
-  done
-  return 1
-}
+# Reuse the shared agent-process resolver (#92) instead of a local ps-walk: it
+# checks both the `comm` name and argv[0] basename against the type's binaries,
+# which is more robust to wrapper/launch shapes than matching only "claude".
+# Empty when no agent ancestor is found (detached / sandboxed) — in that case
+# the instance id degrades to the bare session_id and the dedup step is skipped.
+CC_PID=$(agmsg_agent_pid "$TYPE" 2>/dev/null || true)
 
-CC_PID=$(find_cc_pid 2>/dev/null || true)
+# Per-process instance id (see instance-id.sh): "<session_id>.<cc_pid>", or the
+# bare session_id when cc_pid is unresolved. This — not the bare session_id — is
+# what keys the watcher pidfile / watermark / actas owner, so parallel
+# --continue/--resume processes that share a session_id stay isolated (#93).
+# The cc-instance dedup record and the emitted watch.sh directive both use it.
+INSTANCE_ID="$(agmsg_instance_id_from_pid "$SESSION_ID" "$CC_PID")"
 
 # --- Cleanup of stale cc-instance files and their orphan watchers. ---
 # A cc-instance.<pid> whose CC pid is dead is left over from a previous CC.
@@ -181,8 +168,11 @@ done
 if [ -n "$CC_PID" ]; then
   STATE="$RUN_DIR/cc-instance.$CC_PID"
   if [ -f "$STATE" ]; then
+    # Records the previous instance id this CC attached to. Comparing/killing
+    # by instance id (not bare session_id) keeps the prev_pidfile lookup aligned
+    # with watch.sh's pidfile key.
     prev=$(cat "$STATE" 2>/dev/null || true)
-    if [ -n "$prev" ] && [ "$prev" != "$SESSION_ID" ]; then
+    if [ -n "$prev" ] && [ "$prev" != "$INSTANCE_ID" ]; then
       prev_pidfile="$RUN_DIR/watch.$prev.pid"
       if [ -f "$prev_pidfile" ]; then
         prev_pid=$(cat "$prev_pidfile" 2>/dev/null || true)
@@ -192,7 +182,7 @@ if [ -n "$CC_PID" ]; then
       fi
     fi
   fi
-  printf '%s\n' "$SESSION_ID" > "$STATE"
+  printf '%s\n' "$INSTANCE_ID" > "$STATE"
 fi
 
 WATCH="$SKILL_DIR/scripts/watch.sh"
@@ -201,7 +191,7 @@ cat <<EOF
 AGMSG monitor mode: invoke the Monitor tool now with the following parameters,
 before any other action in this session.
 
-  command: $WATCH $SESSION_ID $PROJECT $TYPE
+  command: $WATCH $INSTANCE_ID $PROJECT $TYPE
   description: agmsg inbox stream
   persistent: true
 

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -50,6 +50,17 @@ source "$SCRIPT_DIR/lib/resolve-project.sh"
 # detached watcher (no agent process to walk to) degrades to the ancestor /
 # git-common-dir signals, which still recover the nested/worktree cases.
 PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
+
+# Disambiguate parallel --continue/--resume sessions that share a session_id
+# (#93). All per-process state below — pidfile, watermark, actas owner, ready
+# sentinel — keys on this per-process instance id rather than the bare
+# session_id, so two processes that share a session_id no longer collide on the
+# same pidfile and kill each other (#66 was a within-session dedup; here it must
+# not fire across sibling processes). Idempotent: the SessionStart directive
+# already passes a composite id (no re-derive); the command template's manual
+# monitor/actas/drop steps pass a bare session_id and we self-derive here.
+SESSION_ID="$(agmsg_normalize_instance_id "$SESSION_ID" "$AGENT_TYPE")"
+
 DB="$(agmsg_db_path)"
 RUN_DIR="$SKILL_DIR/run"
 PIDFILE="$RUN_DIR/watch.$SESSION_ID.pid"

--- a/tests/test_actas_integration.bats
+++ b/tests/test_actas_integration.bats
@@ -12,6 +12,11 @@ load test_helper
 
 setup() {
   setup_test_env
+  # Pin bare instance-id keying (#93): owner tokens / pidfiles stay keyed on the
+  # raw session_id these tests pass, deterministic whether the suite runs under
+  # an agent process (composite) or in CI (bare). The composite path has
+  # dedicated coverage in test_instance_id.bats / test_watch.bats.
+  export AGMSG_AGENT_PID=""
   export SKILL_DIR="$TEST_SKILL_DIR"
   export RUN_DIR="$SKILL_DIR/run"
   mkdir -p "$RUN_DIR"

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -4,6 +4,10 @@ load test_helper
 
 setup() {
   setup_test_env
+  # Pin bare instance-id keying (#93) so watcher pidfiles / cc-instance records
+  # stay keyed on the raw session_id these tests pass — deterministic in CI and
+  # when the suite runs under an agent process. Composite path: test_watch.bats.
+  export AGMSG_AGENT_PID=""
   export TEST_PROJECT="$(mktemp -d)"
 }
 

--- a/tests/test_hook.bats
+++ b/tests/test_hook.bats
@@ -4,6 +4,10 @@ load test_helper
 
 setup() {
   setup_test_env
+  # Pin bare instance-id keying (#93) so check-inbox's watcher-defer and actas
+  # owner checks key on the raw session_id these tests pass — deterministic in
+  # CI and when the suite runs under an agent process.
+  export AGMSG_AGENT_PID=""
   export TEST_PROJECT="$(mktemp -d)"
 }
 

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -11,6 +11,10 @@ setup() {
   export FAKE_HOME="$(mktemp -d)"
   export REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   export SK="$FAKE_HOME/.agents/skills/agmsg"
+  # Pin bare instance-id keying (#93) so the watcher self-clean smoke test keys
+  # its pidfile on the raw session_id it passes — deterministic in CI and when
+  # the suite runs under an agent process.
+  export AGMSG_AGENT_PID=""
 }
 
 teardown() {

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+
+# Tests for the per-process instance id (#93): parallel claude --continue /
+# --resume processes share a session_id, so watcher/lock state keyed on the
+# bare session_id collides. instance-id.sh disambiguates with the enclosing
+# agent pid. These cover the helper functions and the actas-lock distinctness
+# the fix turns on.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  export RUN_DIR="$SKILL_DIR/run"
+  mkdir -p "$RUN_DIR"
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/resolve-project.sh"
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/instance-id.sh"
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+}
+
+teardown() { teardown_test_env; }
+
+# --- agmsg_instance_id_from_pid ---
+
+@test "instance_id_from_pid: numeric pid yields composite" {
+  [ "$(agmsg_instance_id_from_pid sess 1234)" = "sess.1234" ]
+}
+
+@test "instance_id_from_pid: empty pid yields bare sid" {
+  [ "$(agmsg_instance_id_from_pid sess "")" = "sess" ]
+}
+
+@test "instance_id_from_pid: non-numeric pid yields bare sid" {
+  [ "$(agmsg_instance_id_from_pid sess abc)" = "sess" ]
+}
+
+# --- agmsg_instance_is_composite ---
+
+@test "is_composite: true for <sid>.<numeric>" {
+  agmsg_instance_is_composite "sess.1234"
+}
+
+@test "is_composite: true for a UUID-shaped sid with numeric suffix" {
+  agmsg_instance_is_composite "11111111-2222-3333-4444-555555555555.987"
+}
+
+@test "is_composite: false for a bare sid" {
+  ! agmsg_instance_is_composite "sess"
+}
+
+@test "is_composite: false for empty suffix" {
+  ! agmsg_instance_is_composite "sess."
+}
+
+@test "is_composite: false for empty prefix" {
+  ! agmsg_instance_is_composite ".1234"
+}
+
+@test "is_composite: false for non-numeric suffix" {
+  ! agmsg_instance_is_composite "sess.12a"
+}
+
+# --- agmsg_instance_alive ---
+
+@test "instance_alive: composite with a live pid is alive" {
+  agmsg_instance_alive "sess.$$"
+}
+
+@test "instance_alive: composite with a dead pid is not alive" {
+  ! agmsg_instance_alive "sess.2147483647"
+}
+
+@test "instance_alive: bare sid with a live cc-instance is alive" {
+  echo "barex" > "$RUN_DIR/cc-instance.$$"
+  agmsg_instance_alive "barex"
+}
+
+@test "instance_alive: bare sid is alive when cc-instance was upgraded to composite (compat)" {
+  # A pre-upgrade lock holds a bare sid while cc-instance already stores the
+  # composite "<sid>.<pid>" — must not be stale'd out.
+  echo "barey.$$" > "$RUN_DIR/cc-instance.$$"
+  agmsg_instance_alive "barey"
+}
+
+@test "instance_alive: bare sid with no cc-instance is not alive" {
+  ! agmsg_instance_alive "ghost"
+}
+
+@test "instance_alive: empty token is not alive" {
+  ! agmsg_instance_alive ""
+}
+
+# --- agmsg_normalize_instance_id ---
+
+@test "normalize: a composite token passes through unchanged (idempotent)" {
+  [ "$(agmsg_normalize_instance_id "sess.4242" claude-code 2>/dev/null)" = "sess.4242" ]
+}
+
+@test "normalize: a bare sid derives the composite from the agent pid" {
+  # Stub the resolver so the derivation is deterministic without a real agent
+  # ancestor (bats has none).
+  agmsg_agent_pid() { echo 4242; }
+  [ "$(agmsg_normalize_instance_id "sess" claude-code)" = "sess.4242" ]
+}
+
+@test "normalize: falls back to the bare sid when the agent pid is unresolved" {
+  agmsg_agent_pid() { return 1; }
+  # Capture stdout only — the fallback also writes a warning to stderr.
+  local got
+  got="$(agmsg_normalize_instance_id "sess" claude-code 2>/dev/null)"
+  [ "$got" = "sess" ]
+}
+
+@test "normalize: warns on stderr when falling back" {
+  agmsg_agent_pid() { return 1; }
+  run bash -c '
+    source "'"$SKILL_DIR"'/scripts/lib/resolve-project.sh"
+    source "'"$SKILL_DIR"'/scripts/lib/instance-id.sh"
+    agmsg_agent_pid() { return 1; }
+    agmsg_normalize_instance_id sess claude-code 2>&1 1>/dev/null
+  '
+  [[ "$output" == *"falling back to bare session_id"* ]]
+}
+
+# --- actas distinctness: the #93 payoff ---
+
+# Two instance ids that share a session_id prefix but differ in pid must be
+# treated as distinct owners — the collision that broke the actas lock is gone.
+@test "actas: same session_id, different pid → distinct live owners (#93)" {
+  sleep 60 & local pa=$!
+  sleep 60 & local pb=$!
+  local ta="sess.$pa" tb="sess.$pb"
+
+  # pa claims; pb is refused because pa is a live, distinct owner.
+  run actas_lock_claim team alice "$ta"
+  [ "$status" -eq 0 ]
+  run actas_lock_claim team alice "$tb"
+  [ "$status" -eq 1 ]
+  [ "$output" = "held:$ta" ]
+
+  # State classification agrees from both sides.
+  [ "$(actas_lock_state team alice "$ta")" = "mine" ]
+  [ "$(actas_lock_state team alice "$tb")" = "other:$ta" ]
+
+  # When the owner pid dies, the lock is reclaimable (stale → free).
+  kill "$pa" 2>/dev/null || true
+  wait "$pa" 2>/dev/null || true
+  [ "$(actas_lock_state team alice "$tb")" = "free" ]
+
+  kill "$pb" 2>/dev/null || true
+  wait "$pb" 2>/dev/null || true
+}

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -125,6 +125,28 @@ teardown() { teardown_test_env; }
   [[ "$output" == *"falling back to bare session_id"* ]]
 }
 
+# --- AGMSG_AGENT_PID override ---
+
+@test "override: a numeric AGMSG_AGENT_PID pins the resolved pid" {
+  AGMSG_AGENT_PID=4242 run agmsg_agent_pid claude-code
+  [ "$status" -eq 0 ]
+  [ "$output" = "4242" ]
+  [ "$(AGMSG_AGENT_PID=4242 agmsg_instance_id sess claude-code)" = "sess.4242" ]
+}
+
+@test "override: an empty AGMSG_AGENT_PID forces the bare fallback" {
+  AGMSG_AGENT_PID="" run agmsg_agent_pid claude-code
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+  [ "$(AGMSG_AGENT_PID="" agmsg_instance_id sess claude-code 2>/dev/null)" = "sess" ]
+}
+
+@test "override: a non-numeric AGMSG_AGENT_PID is ignored with a warning" {
+  AGMSG_AGENT_PID="abc" run agmsg_agent_pid claude-code
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ignoring non-numeric AGMSG_AGENT_PID"* ]]
+}
+
 # --- actas distinctness: the #93 payoff ---
 
 # Two instance ids that share a session_id prefix but differ in pid must be

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -28,6 +28,20 @@ run_watcher_for() {
   wait "$pid" 2>/dev/null || true
 }
 
+# Compute the per-process instance id (#93) that watch.sh / session-end key on
+# for <sid>, the same way the scripts do. Resolves to a composite "<sid>.<pid>"
+# when an agent ancestor is present (e.g. running the suite under a Claude Code
+# session) and to the bare sid otherwise (e.g. CI) — so filename/owner
+# assertions hold in both environments instead of hardcoding the bare form.
+_iid() {
+  ( export SKILL_DIR="$TEST_SKILL_DIR"
+    # shellcheck disable=SC1090
+    source "$SCRIPTS/lib/resolve-project.sh"
+    # shellcheck disable=SC1090
+    source "$SCRIPTS/lib/instance-id.sh"
+    agmsg_normalize_instance_id "$1" claude-code 2>/dev/null )
+}
+
 @test "watch: restart delivers messages that arrived while the watcher was down" {
   local sid="sess-restart"
 
@@ -74,11 +88,12 @@ run_watcher_for() {
 
 @test "watch: persists a watermark file for the session" {
   run_watcher_for "sess-wm" "$TEST_SKILL_DIR/wm.log" 1.5
-  [ -f "$TEST_SKILL_DIR/run/watch.sess-wm.watermark" ]
+  [ -f "$TEST_SKILL_DIR/run/watch.$(_iid sess-wm).watermark" ]
 }
 
 @test "session-end: removes the session watermark file" {
-  local wm="$TEST_SKILL_DIR/run/watch.sess-end.watermark"
+  # Key the watermark under the same instance id session-end will derive.
+  local wm="$TEST_SKILL_DIR/run/watch.$(_iid sess-end).watermark"
   mkdir -p "$TEST_SKILL_DIR/run"
   echo 5 > "$wm"
   printf '{"session_id":"sess-end"}' | bash "$SCRIPTS/session-end.sh" claude-code "$PROJ" >/dev/null 2>&1 || true
@@ -116,7 +131,8 @@ run_watcher_for() {
     >/dev/null 2>&1 &
   local w=$! i
   for i in 1 2 3 4 5 6 7 8 9 10; do [ -e "$ready" ] && break; sleep 0.5; done
-  [ "$(cat "$ready")" = "sess-own" ]
+  # watch.sh stamps the instance id (composite under an agent ancestor).
+  [ "$(cat "$ready")" = "$(_iid sess-own)" ]
   kill "$w" 2>/dev/null || true
   wait "$w" 2>/dev/null || true
 }
@@ -154,4 +170,59 @@ run_watcher_for() {
   [ ! -f "$TEST_SKILL_DIR/run/ready.team__ghost" ]
   [ -f "$TEST_SKILL_DIR/run/watch.LIVESID.watermark" ]
   [ -f "$TEST_SKILL_DIR/run/ready.team__live" ]
+}
+
+# --- #93: parallel --continue/--resume sessions sharing a session_id ---
+
+# Poll up to ~3s for <pidfile> to record <want_pid>.
+_wait_pidfile() {
+  local pf="$1" want="$2" i
+  for i in $(seq 1 30); do
+    [ -f "$pf" ] && [ "$(cat "$pf" 2>/dev/null)" = "$want" ] && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+@test "watch: two sessions sharing a session_id keep independent watchers (#93)" {
+  # Pre-composite instance ids (same sid prefix, different agent pid) — what
+  # session-start bakes into the directive for two parallel resume processes.
+  local pf1="$TEST_SKILL_DIR/run/watch.shared.1001.pid"
+  local pf2="$TEST_SKILL_DIR/run/watch.shared.1002.pid"
+
+  AGMSG_WATCH_INTERVAL=5 bash "$SCRIPTS/watch.sh" "shared.1001" "$PROJ" claude-code >/dev/null 2>&1 3>&- &
+  local w1=$!
+  AGMSG_WATCH_INTERVAL=5 bash "$SCRIPTS/watch.sh" "shared.1002" "$PROJ" claude-code >/dev/null 2>&1 3>&- &
+  local w2=$!
+
+  _wait_pidfile "$pf1" "$w1"
+  _wait_pidfile "$pf2" "$w2"
+
+  # Distinct pidfiles, and crucially neither watcher killed the other.
+  run kill -0 "$w1"; [ "$status" -eq 0 ]
+  run kill -0 "$w2"; [ "$status" -eq 0 ]
+  [ "$(cat "$pf1")" = "$w1" ]
+  [ "$(cat "$pf2")" = "$w2" ]
+
+  kill "$w1" "$w2" 2>/dev/null || true
+  wait "$w1" 2>/dev/null || true
+  wait "$w2" 2>/dev/null || true
+}
+
+@test "watch: relaunch with the SAME instance id replaces the previous watcher (#66 preserved)" {
+  local pf="$TEST_SKILL_DIR/run/watch.solo.2002.pid"
+
+  AGMSG_WATCH_INTERVAL=5 bash "$SCRIPTS/watch.sh" "solo.2002" "$PROJ" claude-code >/dev/null 2>&1 3>&- &
+  local w1=$!
+  _wait_pidfile "$pf" "$w1"
+
+  AGMSG_WATCH_INTERVAL=5 bash "$SCRIPTS/watch.sh" "solo.2002" "$PROJ" claude-code >/dev/null 2>&1 3>&- &
+  local w2=$!
+  # Successor claims the pidfile slot...
+  _wait_pidfile "$pf" "$w2"
+  # ...and the previous holder was killed.
+  run kill -0 "$w1"; [ "$status" -ne 0 ]
+
+  kill "$w2" 2>/dev/null || true
+  wait "$w2" 2>/dev/null || true
 }


### PR DESCRIPTION
## What

Fixes #93 — parallel `claude --continue` / `--resume` sessions share a `session_id`, so per-process watcher/lock state keyed on the bare session_id collides. Most visibly, `watch.sh`'s #66 "kill the previous holder for this session" became a **mutual kill loop** between two panes (observed live: each pane's watcher killed the other on every relaunch, so inbox push was dead for one of them at all times).

Full design (agreed over two review rounds) is on the issue: #93 (comment).

## Approach

Introduce a per-process **instance id** that all per-process state keys on:

```
instance_id = "<session_id>.<agent_pid>"   when the enclosing agent pid resolves
            = "<session_id>"               bare fallback (degraded mode)
```

- **Stable across `/clear`** within one process (sid + pid unchanged) → #66 dedup-on-relaunch still works.
- **Distinct across parallel resume processes** (different agent pid) → independent pidfile / watermark / actas owner → no mutual kill.
- **Backward compatible** via the bare fallback; the bare-token liveness check keeps a pre-upgrade lock alive when `cc-instance` has already moved to the composite form.

The common SessionStart/monitor path derives the composite **once** and bakes it into the directive (idempotent in `watch.sh`). The command template's manual monitor/actas/drop steps still pass a bare `$CLAUDE_CODE_SESSION_ID`, and each script self-derives at its entry point — so the template needs no threading, but every entry point (`watch.sh`, `actas-claim.sh`, `reset.sh`, `check-inbox.sh`, `delivery.sh`, `session-end.sh`) ends up on the same key.

## Changes

- **`scripts/lib/instance-id.sh`** (new) — `agmsg_instance_id_from_pid` / `agmsg_instance_id` / `agmsg_normalize_instance_id` / `agmsg_instance_is_composite` / `agmsg_instance_alive`.
- **`scripts/lib/actas-lock.sh`** — liveness delegates to `agmsg_instance_alive`; owner tokens are instance ids, so sibling resume processes no longer appear to own each other's locks. The claim/reclaim mutex (#65) is token-opaque and unchanged.
- **`scripts/session-start.sh`** — reuse the shared `agmsg_agent_pid` resolver (#92) instead of a local `find_cc_pid`; key the cc-instance record and the emitted directive on the instance id.
- **`scripts/session-end.sh`** — clean only *this* instance's pidfile/watermark/cc-instance/locks; on an unresolved pid, clean only the bare-keyed artifacts rather than globbing `<sid>.*` (which would kill a living sibling).
- **`scripts/watch.sh` / `actas-claim.sh` / `reset.sh` / `check-inbox.sh` / `delivery.sh`** — normalize the raw session_id at the entry point.
- **`scripts/lib/resolve-project.sh`** — `AGMSG_AGENT_PID` override that pins the resolver (an empty value forces the bare fallback). Deterministic instance-id keying for tests, and an escape hatch when the ps-walk heuristic misfires for an unusual launch topology.

## Tests

- **`tests/test_instance_id.bats`** (new) — helper coverage + the #93 payoff: the same session_id under two different live pids is treated as two distinct owners, exclusivity holds, and a dead owner is reclaimable.
- **`tests/test_watch.bats`** — two sessions sharing a session_id keep independent watchers (no mutual kill); a relaunch with the *same* instance id still self-cleans the previous watcher (#66 preserved).
- Existing integration suites pin bare keying via `AGMSG_AGENT_PID` so they stay deterministic whether run in CI (no agent ancestor → bare) or under a live agent session (ancestor → composite).

### Verification

- `bats tests/` — **265/265 passing**.
- `bash -n` on all modified scripts.

Note: the suite previously assumed `session_id == key`; running it under a Claude Code session surfaced that assumption (the scripts now derive a composite there). The `AGMSG_AGENT_PID` pin makes the suite environment-independent.
