### PR TITLE
WIP/skeleton: per-type delivery driver dispatch (#48)

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -32,6 +32,24 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SKILL_NAME="$(basename "$SKILL_DIR")"
 RUN_DIR="$SKILL_DIR/run"
+
+# Per-agent-type delivery drivers (#48). delivery.sh dispatches apply/status to
+# scripts/drivers/<type>.sh when one exists; otherwise it falls back to the
+# legacy in-file paths below. Shared class libs (e.g. _rulefile.sh) load once
+# here. WIP skeleton: only the rule-file class (gemini, antigravity) is wired
+# through the dispatcher so far — see scripts/drivers/README.md.
+DRIVERS_DIR="$SCRIPT_DIR/drivers"
+# shellcheck source=scripts/drivers/_rulefile.sh
+[ -f "$DRIVERS_DIR/_rulefile.sh" ] && . "$DRIVERS_DIR/_rulefile.sh"
+
+# True when a per-type driver exists. The type is guarded to a safe charset so
+# the sourced path can never escape DRIVERS_DIR.
+has_driver() {
+  case "$1" in
+    *[!a-z-]*|'') return 1 ;;
+    *) [ -f "$DRIVERS_DIR/$1.sh" ] ;;
+  esac
+}
 # instance-id derivation (#93) for the in-session monitor directive below.
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/resolve-project.sh"
@@ -245,43 +263,21 @@ EOF
   fi
 }
 
-apply_settings_gemini() {
-  local type="$1"
-  local project="$2"
-  local mode="$3"
-  local rule_file
-  rule_file=$(resolve_hooks_file "$type" "$project")
-
-  # Remove existing rule file
-  rm -f "$rule_file"
-
-  case "$mode" in
-    turn|both)
-      mkdir -p "$(dirname "$rule_file")"
-      cat <<EOF > "$rule_file"
-# agmsg Integration Rule
-
-## PostToolUse
-After each tool call, automatically check the agmsg inbox for unread messages.
-- Command: '$SKILL_DIR/scripts/check-inbox.sh' '$type' '$project'
-EOF
-      ;;
-    monitor)
-      echo "Warning: 'monitor' mode is not fully supported for $type yet. Using turn-based hook." >&2
-      apply_settings_gemini "$type" "$project" "turn"
-      ;;
-    off)
-      ;;
-  esac
-}
+# NOTE(#48): the rule-file apply/status logic that used to live here as
+# apply_settings_gemini now lives in scripts/drivers/_rulefile.sh, reached via
+# the driver dispatch in apply_settings()/do_status() below.
 
 apply_settings() {
   local type="$1"
   local project="$2"
   local mode="$3"
 
-  if [ "$type" = "gemini" ] || [ "$type" = "antigravity" ]; then
-    apply_settings_gemini "$type" "$project" "$mode"
+  # Per-type driver (#48). Rule-file runtimes (gemini, antigravity) resolve here;
+  # copilot and the JSON settings path below are not yet extracted — TODO(#48).
+  if has_driver "$type"; then
+    # shellcheck source=/dev/null
+    . "$DRIVERS_DIR/$type.sh"
+    agmsg_driver_apply "$type" "$project" "$mode"
     return
   fi
 
@@ -450,7 +446,11 @@ do_status() {
   if [ -n "$TYPE" ] && [ -n "$PROJECT" ]; then
     local hf
     hf=$(resolve_hooks_file "$TYPE" "$PROJECT")
-    if [ "$TYPE" = "gemini" ] || [ "$TYPE" = "antigravity" ] || [ "$TYPE" = "copilot" ]; then
+    if has_driver "$TYPE"; then
+      # shellcheck source=/dev/null
+      . "$DRIVERS_DIR/$TYPE.sh"
+      echo "mode: $(agmsg_driver_status "$TYPE" "$PROJECT")"
+    elif [ "$TYPE" = "copilot" ]; then
       local mode="off"
       if [ -f "$hf" ]; then
         mode="turn"
@@ -483,7 +483,7 @@ do_status() {
     fi
   fi
 
-  if [ -n "$TYPE" ] && [ -n "$PROJECT" ] && [ "$TYPE" != "gemini" ] && [ "$TYPE" != "antigravity" ] && [ "$TYPE" != "copilot" ]; then
+  if [ -n "$TYPE" ] && [ -n "$PROJECT" ] && ! has_driver "$TYPE" && [ "$TYPE" != "copilot" ]; then
     local hooks_file
     hooks_file=$(resolve_hooks_file "$TYPE" "$PROJECT")
     if [ -f "$hooks_file" ]; then

--- a/scripts/drivers/README.md
+++ b/scripts/drivers/README.md
@@ -1,0 +1,48 @@
+# delivery drivers (skeleton — #48)
+
+Per-agent-type delivery drivers, dispatched by `delivery.sh`. This is a **WIP
+skeleton** to make the #48 refactor concrete — only the **rule-file class**
+(`gemini`, `antigravity`) is wired through the dispatcher so far; `claude-code` /
+`codex` / `copilot` still run on the legacy in-`delivery.sh` paths (see the
+`TODO(#48)` markers there). Behavior is unchanged and the bats suite stays green.
+
+## Contract
+
+`delivery.sh` looks up `scripts/drivers/<type>.sh`; if it exists, it sources it
+and calls the verbs below. A driver runs in `delivery.sh`'s environment, so it
+may use `resolve_hooks_file()`, `SKILL_DIR`, `SKILL_NAME`, etc.
+
+| verb | signature | returns |
+|---|---|---|
+| `agmsg_driver_apply` | `<type> <project> <mode>` | writes/removes this runtime's hook/rule config for `mode` |
+| `agmsg_driver_status` | `<type> <project>` | echoes the current mode (e.g. `turn` / `off`) |
+
+A type with no `drivers/<type>.sh` falls through to the legacy path — so the
+extraction can land class by class without a flag day.
+
+## Classes
+
+Most runtimes collapse onto a shared class lib (`_<class>.sh`); the per-type
+file just supplies its identity:
+
+- **rule-file** (`_rulefile.sh`): single Markdown rule file, presence = `turn`.
+  `gemini`, `antigravity` today; the natural home for **OpenCode (#136)** and
+  **Cursor (#131)** — each becomes a 3-line `drivers/<type>.sh` + a path in
+  `resolve_hooks_file`, no dispatcher edits.
+- **json-hooks** (planned `_jsonhooks.sh`): JSON hook file. `claude-code`
+  (settings.json, supports `monitor`/`both`), `codex`, `copilot`.
+- **manual** (planned): no hook file, `off` only. **Hermes (#118/#119)** —
+  already implemented as `apply_settings_manual_only` in that PR; would move
+  here as `drivers/hermes.sh`.
+
+## Adding a rule-file runtime (worked example: opencode)
+
+```sh
+# 1) resolve_hooks_file(): opencode) echo "$project/.opencode/rules/agmsg.md" ;;
+# 2) scripts/drivers/opencode.sh:
+agmsg_driver_apply()  { rulefile_apply "$@"; }
+agmsg_driver_status() { rulefile_status "$@"; }
+# 3) join.sh allowlist: add `opencode`
+```
+
+No edits to `apply_settings` / `do_status`.

--- a/scripts/drivers/_rulefile.sh
+++ b/scripts/drivers/_rulefile.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Shared driver for the "rule-file" class of agent runtimes.
+#
+# These runtimes read a single Markdown instruction/rule file whose *presence*
+# means turn-mode delivery and whose absence means off. There is no Monitor
+# equivalent, so monitor/both degrade to turn. The only per-runtime difference
+# is *where* that file lives, which `resolve_hooks_file <type>` already knows —
+# so a per-type driver in this class is a 3-line file that sources this lib
+# (see drivers/gemini.sh). Adding a new rule-file runtime (opencode, cursor, …)
+# becomes one such file plus its path entry in resolve_hooks_file.
+#
+# Sourced by delivery.sh, so it relies on delivery.sh's globals/functions:
+#   resolve_hooks_file(), SKILL_DIR
+#
+# Verbs (the driver contract delivery.sh dispatches to):
+#   rulefile_apply  <type> <project> <mode>   — write/remove the rule file
+#   rulefile_status <type> <project>          — echo the current mode (turn|off)
+
+rulefile_apply() {
+  local type="$1"
+  local project="$2"
+  local mode="$3"
+  local rule_file
+  rule_file=$(resolve_hooks_file "$type" "$project")
+
+  # Remove existing rule file first so re-applying turn is an idempotent
+  # rewrite and turn->off cleanly removes it.
+  rm -f "$rule_file"
+
+  case "$mode" in
+    turn|both)
+      mkdir -p "$(dirname "$rule_file")"
+      cat <<EOF > "$rule_file"
+# agmsg Integration Rule
+
+## PostToolUse
+After each tool call, automatically check the agmsg inbox for unread messages.
+- Command: '$SKILL_DIR/scripts/check-inbox.sh' '$type' '$project'
+EOF
+      ;;
+    monitor)
+      echo "Warning: 'monitor' mode is not fully supported for $type yet. Using turn-based hook." >&2
+      rulefile_apply "$type" "$project" "turn"
+      ;;
+    off)
+      ;;
+  esac
+}
+
+# Mode is inferred from the rule file's presence: present → turn, absent → off.
+rulefile_status() {
+  local type="$1"
+  local project="$2"
+  local rule_file
+  rule_file=$(resolve_hooks_file "$type" "$project")
+  if [ -f "$rule_file" ]; then
+    echo "turn"
+  else
+    echo "off"
+  fi
+}

--- a/scripts/drivers/antigravity.sh
+++ b/scripts/drivers/antigravity.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# antigravity driver — rule-file class. Shares .agent/rules/agmsg.md with gemini
+# (path owned by resolve_hooks_file). Thin: behavior lives in _rulefile.sh.
+
+agmsg_driver_apply() { rulefile_apply "$@"; }
+agmsg_driver_status() { rulefile_status "$@"; }

--- a/scripts/drivers/gemini.sh
+++ b/scripts/drivers/gemini.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# gemini driver — rule-file class. Rule file: <project>/.agent/rules/agmsg.md
+# (path owned by resolve_hooks_file). Thin: the behavior lives in _rulefile.sh.
+
+agmsg_driver_apply() { rulefile_apply "$@"; }
+agmsg_driver_status() { rulefile_status "$@"; }


### PR DESCRIPTION
**WIP / discussion skeleton for #48 — not for merge as-is.** Posting a concrete starting point so the per-type-driver shape is something we can react to in code; please reshape or take it over freely, @fujibee.

## What this is

A thin, behavior-preserving slice of #48 ("Refactor `delivery.sh` into per-agent-type drivers"). It introduces the dispatcher + extracts **one class** (rule-file: `gemini`, `antigravity`) so the shape is real without a flag-day rewrite. Types with no driver fall through to today's in-`delivery.sh` paths, so the rest can be extracted class by class later.

## What changed

- `scripts/drivers/_rulefile.sh` — shared rule-file class lib (`rulefile_apply` / `rulefile_status`), lifted verbatim from `apply_settings_gemini`.
- `scripts/drivers/{gemini,antigravity}.sh` — 3-line per-type drivers exposing the `agmsg_driver_apply` / `agmsg_driver_status` verbs.
- `scripts/delivery.sh` — `apply_settings` / `do_status` dispatch to `scripts/drivers/<type>.sh` when it exists (`has_driver`); `claude-code` / `codex` / `copilot` still use the legacy paths, marked `TODO(#48)`.
- `scripts/drivers/README.md` — the driver contract and the class map.

CLI (`delivery.sh set|status …`) and mode semantics are unchanged. **No behavior change; full bats suite green.**

## Why the class angle (the part worth debating)

Since #48 was filed, three more agent types arrived/were requested, and they cluster by *capability*, which is why most of them want to be **thin**:

| class | agents | per-type file is… |
|---|---|---|
| rule-file | gemini, antigravity, **OpenCode #136**, **Cursor #131** | 3 lines + a path |
| json-hooks | claude-code, codex, copilot | (not yet extracted) |
| manual | **Hermes #118/#119** (`apply_settings_manual_only`) | off-only |

Adding a rule-file runtime then becomes:

```sh
# 1) resolve_hooks_file(): opencode) echo "$project/.opencode/rules/agmsg.md" ;;
# 2) scripts/drivers/opencode.sh:
agmsg_driver_apply()  { rulefile_apply "$@"; }
agmsg_driver_status() { rulefile_status "$@"; }
# 3) join.sh allowlist: + opencode
```

— no edits to `apply_settings` / `do_status`. That directly de-conflicts #136 and #131, which currently each add a parallel `apply_settings_*` and another `|| <type>` arm.

## Open questions for @fujibee

- Per-type files (#48's shape) sourcing a shared `_<class>.sh`, vs. dispatching straight to a class — I went with the former to match #48; happy to flip.
- Whether to extract `json-hooks` (claude-code/codex/copilot) in the same PR or keep this rule-file-only.
- Naming: `_rulefile.sh` / `agmsg_driver_apply` are placeholders.

Not claiming #48 — this is a strawman to make the discussion concrete. cc @sperkbird (#136), @kurochan001 (#131). Related: #46, #47, #118, #119.
