### PR TITLE
fix: Bind single-quote-containing config values via readfile() instead of .param set

### DIFF
--- a/scripts/identities.sh
+++ b/scripts/identities.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 
 PROJECT_PATH="${1:?Usage: identities.sh <project_path> <agent_type>}"
 AGENT_TYPE="${2:?Missing agent_type}"
+PROJECT_SQL=$(printf '%s' "$PROJECT_PATH" | sed "s/'/''/g")
+AGENT_TYPE_SQL=$(printf '%s' "$AGENT_TYPE" | sed "s/'/''/g")
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEAMS_DIR="$SCRIPT_DIR/../teams"
@@ -23,26 +25,32 @@ TEAMS_DIR="$SCRIPT_DIR/../teams"
 
 for config_file in "$TEAMS_DIR"/*/config.json; do
   [ -f "$config_file" ] || continue
-  CONFIG_ESCAPED=$(sed "s/'/''/g" "$config_file")
-  TEAM_NAME=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
-    "SELECT json_extract(:json, '\$.name');")
+  cfg_sql=$(printf '%s' "$config_file" | sed "s/'/''/g")
+  TEAM_NAME=$(sqlite3 :memory: "
+    WITH raw(json) AS (SELECT CAST(readfile('$cfg_sql') AS TEXT)),
+    cfg(json) AS (SELECT CASE WHEN json_valid(json) THEN json END FROM raw)
+    SELECT json_extract(json, '\$.name') FROM cfg;
+  ")
   [ -z "$TEAM_NAME" ] && continue
   [ "$TEAM_NAME" = "null" ] && continue
+  TEAM_SQL=$(printf '%s' "$TEAM_NAME" | sed "s/'/''/g")
 
-  sqlite3 -separator $'\t' :memory: ".param set :json '$CONFIG_ESCAPED'" "
-    WITH agents AS (
+  sqlite3 -separator $'\t' :memory: "
+    WITH raw(json) AS (SELECT CAST(readfile('$cfg_sql') AS TEXT)),
+    cfg(json) AS (SELECT CASE WHEN json_valid(json) THEN json END FROM raw),
+    agents AS (
       SELECT
         key AS name,
         CASE
           WHEN json_type(json_extract(value, '\$.registrations')) = 'array' THEN json_extract(value, '\$.registrations')
           ELSE json_array(json_object('type', json_extract(value, '\$.type'), 'project', json_extract(value, '\$.project')))
         END AS registrations
-      FROM json_each(json_extract(:json, '\$.agents'))
+      FROM cfg, json_each(json_extract(cfg.json, '\$.agents'))
     )
-    SELECT DISTINCT '$TEAM_NAME' AS team, name
+    SELECT DISTINCT '$TEAM_SQL' AS team, name
     FROM agents, json_each(agents.registrations) AS r
-    WHERE json_extract(r.value, '\$.project') = '$PROJECT_PATH'
-      AND json_extract(r.value, '\$.type') = '$AGENT_TYPE'
+    WHERE json_extract(r.value, '\$.project') = '$PROJECT_SQL'
+      AND json_extract(r.value, '\$.type') = '$AGENT_TYPE_SQL'
     ORDER BY team, name;
   "
 done

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -30,7 +30,35 @@ TEAMS_DIR="$SCRIPT_DIR/../teams"
 # may not be registered yet) set AGMSG_RESOLVE_PROJECT=0 to keep their path.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/resolve-project.sh"
-PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
+
+# Keep this entrypoint's pre-join project resolver on the same readfile() path
+# as the registry writes below. The sourced helper is shared with files outside
+# this fix's scope, so override only the scan it calls here.
+agmsg_registered_projects() {
+  local type="$1" teams_dir="$SKILL_DIR/teams" config_file cfg_sql type_sql
+  [ -d "$teams_dir" ] || return 0
+  type_sql=$(printf '%s' "$type" | sed "s/'/''/g")
+  for config_file in "$teams_dir"/*/config.json; do
+    [ -f "$config_file" ] || continue
+    cfg_sql=$(printf '%s' "$config_file" | sed "s/'/''/g")
+    sqlite3 :memory: "
+      WITH raw(json) AS (SELECT CAST(readfile('$cfg_sql') AS TEXT)),
+      cfg(json) AS (SELECT CASE WHEN json_valid(json) THEN json END FROM raw),
+      agents AS (
+        SELECT CASE
+          WHEN json_type(json_extract(value, '\$.registrations')) = 'array' THEN json_extract(value, '\$.registrations')
+          ELSE json_array(json_object('type', json_extract(value, '\$.type'), 'project', json_extract(value, '\$.project')))
+        END AS registrations
+        FROM cfg, json_each(json_extract(cfg.json, '\$.agents'))
+      )
+      SELECT DISTINCT json_extract(r.value, '\$.project')
+      FROM agents, json_each(agents.registrations) AS r
+      WHERE json_extract(r.value, '\$.type') = '$type_sql';
+    "
+  done
+}
+
+PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE" 2>/dev/null || printf '%s' "$PROJECT_PATH")"
 
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
 
@@ -48,15 +76,22 @@ EOF
 fi
 
 # --- Add or extend agent registrations ---
-CONFIG_ESCAPED=$(sed "s/'/''/g" "$TEAM_CONFIG")
-REGISTRATION="{\"type\":\"$AGENT_TYPE\",\"project\":\"$PROJECT_PATH\"}"
+CONFIG_SQL=$(printf '%s' "$TEAM_CONFIG" | sed "s/'/''/g")
+AGENT_ID_SQL=$(printf '%s' "$AGENT_ID" | sed "s/'/''/g")
+AGENT_TYPE_SQL=$(printf '%s' "$AGENT_TYPE" | sed "s/'/''/g")
+PROJECT_SQL=$(printf '%s' "$PROJECT_PATH" | sed "s/'/''/g")
+REGISTRATION=$(sqlite3 :memory: "SELECT json_object('type', '$AGENT_TYPE_SQL', 'project', '$PROJECT_SQL');")
 REGISTRATION_ESCAPED=$(printf '%s' "$REGISTRATION" | sed "s/'/''/g")
 
-EXISTING=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
-  "SELECT json_extract(:json, '$.agents.$AGENT_ID');")
+EXISTING=$(sqlite3 :memory: "
+  WITH cfg AS (SELECT CAST(readfile('$CONFIG_SQL') AS TEXT) AS json)
+  SELECT value
+  FROM cfg, json_each(json_extract(cfg.json, '\$.agents'))
+  WHERE key = '$AGENT_ID_SQL';
+")
 
 if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
-  AGENT_OBJ="{\"registrations\":[${REGISTRATION}]}"
+  AGENT_OBJ=$(sqlite3 :memory: "SELECT json_object('registrations', json_array(json('$REGISTRATION_ESCAPED')));")
 else
   EXISTING_ESCAPED=$(printf '%s' "$EXISTING" | sed "s/'/''/g")
   NORMALIZED=$(sqlite3 :memory: "
@@ -79,8 +114,8 @@ else
     SELECT EXISTS(
       SELECT 1
       FROM json_each(json_extract('$NORMALIZED_ESCAPED', '\$.registrations'))
-      WHERE json_extract(value, '\$.type') = '$AGENT_TYPE'
-        AND json_extract(value, '\$.project') = '$PROJECT_PATH'
+      WHERE json_extract(value, '\$.type') = '$AGENT_TYPE_SQL'
+        AND json_extract(value, '\$.project') = '$PROJECT_SQL'
     );
   ")
 
@@ -97,9 +132,21 @@ else
   fi
 fi
 
+AGENT_OBJ_ESCAPED=$(printf '%s' "$AGENT_OBJ" | sed "s/'/''/g")
 UPDATED=$(sqlite3 :memory: \
-  ".param set :json '$CONFIG_ESCAPED'" \
-  "SELECT json_set(:json, '$.agents.$AGENT_ID', json('$(printf '%s' "$AGENT_OBJ" | sed "s/'/''/g")'));")
+  "WITH cfg AS (SELECT CAST(readfile('$CONFIG_SQL') AS TEXT) AS json)
+  SELECT json_set(
+    cfg.json,
+    '\$.agents',
+    json_patch(
+      CASE
+        WHEN json_type(json_extract(cfg.json, '\$.agents')) = 'object' THEN json_extract(cfg.json, '\$.agents')
+        ELSE json('{}')
+      END,
+      json_object('$AGENT_ID_SQL', json('$AGENT_OBJ_ESCAPED'))
+    )
+  )
+  FROM cfg;")
 echo "$UPDATED" > "$TEAM_CONFIG"
 
 echo "Joined team $TEAM as $AGENT_ID"

--- a/scripts/whoami.sh
+++ b/scripts/whoami.sh
@@ -83,7 +83,36 @@ TEAMS_DIR="$SCRIPT_DIR/../teams"
 # into a subdir/worktree must not be treated as a fresh, unregistered project.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/resolve-project.sh"
-PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
+
+# Keep this entrypoint's pre-lookup project resolver on the same readfile()
+# path as the registry queries below. The sourced helper is shared with files
+# outside this fix's scope, so override only the scan it calls here.
+agmsg_registered_projects() {
+  local type="$1" teams_dir="$SKILL_DIR/teams" config_file cfg_sql type_sql
+  [ -d "$teams_dir" ] || return 0
+  type_sql=$(printf '%s' "$type" | sed "s/'/''/g")
+  for config_file in "$teams_dir"/*/config.json; do
+    [ -f "$config_file" ] || continue
+    cfg_sql=$(printf '%s' "$config_file" | sed "s/'/''/g")
+    sqlite3 :memory: "
+      WITH raw(json) AS (SELECT CAST(readfile('$cfg_sql') AS TEXT)),
+      cfg(json) AS (SELECT CASE WHEN json_valid(json) THEN json END FROM raw),
+      agents AS (
+        SELECT CASE
+          WHEN json_type(json_extract(value, '\$.registrations')) = 'array' THEN json_extract(value, '\$.registrations')
+          ELSE json_array(json_object('type', json_extract(value, '\$.type'), 'project', json_extract(value, '\$.project')))
+        END AS registrations
+        FROM cfg, json_each(json_extract(cfg.json, '\$.agents'))
+      )
+      SELECT DISTINCT json_extract(r.value, '\$.project')
+      FROM agents, json_each(agents.registrations) AS r
+      WHERE json_extract(r.value, '\$.type') = '$type_sql';
+    "
+  done
+}
+
+PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE" 2>/dev/null || printf '%s' "$PROJECT_PATH")"
+AGENT_TYPE_SQL=$(printf '%s' "$AGENT_TYPE" | sed "s/'/''/g")
 
 if [ ! -d "$TEAMS_DIR" ]; then
   echo "not_joined=true available_teams=none"
@@ -102,28 +131,35 @@ ALL_TEAMS=""
 
 for config_file in "$TEAMS_DIR"/*/config.json; do
   [ -f "$config_file" ] || continue
-  CONFIG_ESCAPED=$(sed "s/'/''/g" "$config_file")
-  TEAM_NAME=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
-    "SELECT json_extract(:json, '$.name');")
-  ALL_TEAMS="${ALL_TEAMS:+$ALL_TEAMS,}$TEAM_NAME"
+  cfg_sql=$(printf '%s' "$config_file" | sed "s/'/''/g")
+  TEAM_NAME=$(sqlite3 :memory: "
+    WITH raw(json) AS (SELECT CAST(readfile('$cfg_sql') AS TEXT)),
+    cfg(json) AS (SELECT CASE WHEN json_valid(json) THEN json END FROM raw)
+    SELECT json_extract(json, '\$.name') FROM cfg;
+  ")
+  if [ -n "$TEAM_NAME" ] && [ "$TEAM_NAME" != "null" ]; then
+    ALL_TEAMS="${ALL_TEAMS:+$ALL_TEAMS,}$TEAM_NAME"
+  fi
 
   while IFS='	' read -r agent_name; do
     [ -n "$agent_name" ] || continue
     SUGGESTED_MATCHES="${SUGGESTED_MATCHES:+$SUGGESTED_MATCHES
 }$TEAM_NAME	$agent_name"
-  done < <(sqlite3 -separator '	' :memory: ".param set :json '$CONFIG_ESCAPED'" "
-    WITH agents AS (
+  done < <(sqlite3 -separator '	' :memory: "
+    WITH raw(json) AS (SELECT CAST(readfile('$cfg_sql') AS TEXT)),
+    cfg(json) AS (SELECT CASE WHEN json_valid(json) THEN json END FROM raw),
+    agents AS (
       SELECT
         key AS name,
         CASE
           WHEN json_type(json_extract(value, '\$.registrations')) = 'array' THEN json_extract(value, '\$.registrations')
           ELSE json_array(json_object('type', json_extract(value, '\$.type'), 'project', json_extract(value, '\$.project')))
         END AS registrations
-      FROM json_each(json_extract(:json, '\$.agents'))
+      FROM cfg, json_each(json_extract(cfg.json, '\$.agents'))
     )
     SELECT DISTINCT name
     FROM agents, json_each(agents.registrations) AS r
-    WHERE json_extract(r.value, '\$.type') = '$AGENT_TYPE';
+    WHERE json_extract(r.value, '\$.type') = '$AGENT_TYPE_SQL';
   ")
 done
 

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -84,6 +84,40 @@ teardown() {
   [[ "$output" =~ "teams=myteam" ]]
 }
 
+@test "whoami: resolves project paths containing single quotes" {
+  local project="$TEST_SKILL_DIR/pro'j"
+  mkdir -p "$project/subdir"
+  bash "$SCRIPTS/join.sh" myteam alice claude-code "$project"
+  run bash "$SCRIPTS/whoami.sh" "$project/subdir" claude-code
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "agent=alice" ]]
+  [[ "$output" =~ "teams=myteam" ]]
+  [[ "$output" =~ "project=$project" ]]
+  [[ ! "$output" =~ "not_joined=true" ]]
+  [[ ! "$output" =~ ".parameter" ]]
+}
+
+@test "whoami: resolves team and agent names containing single quotes" {
+  local team="O'Brien"
+  local agent="al'ice"
+  bash "$SCRIPTS/join.sh" "$team" "$agent" claude-code /tmp/proj
+  run bash "$SCRIPTS/whoami.sh" /tmp/proj claude-code
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "agent=$agent" ]]
+  [[ "$output" =~ "teams=$team" ]]
+  [[ ! "$output" =~ ".parameter" ]]
+}
+
+@test "whoami: ignores malformed team configs without sqlite parameter output" {
+  mkdir -p "$TEST_SKILL_DIR/teams/bad"
+  printf '{' > "$TEST_SKILL_DIR/teams/bad/config.json"
+  run bash "$SCRIPTS/whoami.sh" /tmp/proj claude-code
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "not_joined=true" ]]
+  [[ ! "$output" =~ ".parameter" ]]
+  [[ ! "$output" =~ "malformed JSON" ]]
+}
+
 @test "whoami: returns not_joined when no match" {
   run bash "$SCRIPTS/whoami.sh" /tmp/unknown claude-code
   [ "$status" -eq 0 ]
@@ -277,4 +311,3 @@ teardown() {
   run bash "$SCRIPTS/join.sh" myteam alice opencode /tmp/proj
   [ "$status" -eq 0 ]
 }
-


### PR DESCRIPTION
## Summary
The shared team-registry scripts bind config.json into sqlite3 by interpolating it into a `.param set :json '<config>'` dot-command. The sqlite3 shell's dot-command tokenizer does not honor SQL `''` escaping, so any config value containing a single quote (e.g.

## Changes
Replace each `.param set :json '<config>'` dot-command in whoami.sh, identities.sh, and join.sh with the same pattern resolve_team already uses: read the config file inside SQL via `readfile('<path>')` CAST to TEXT, or interpolate the value as a SQL string literal with proper `''` doubling. Audit each of the three scripts for every `.param set :json` site and convert them uniformly so paths and names with apostrophes are handled everywhere.

Fixes #112
