### PR TITLE
fix: Stop orphaned watch.sh from advancing the shared watermark past undelivered messages

### DIFF
--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -107,7 +107,9 @@ cleanup() {
   # watcher (Monitor re-invoked for the same session_id) overwrites $PIDFILE
   # with its own pid before killing us; without this guard our EXIT trap
   # would erase the successor's record. See #66.
-  [ "$(cat "$PIDFILE" 2>/dev/null)" = "$$" ] && rm -f "$PIDFILE"
+  local pidfile_pid=""
+  [ -f "$PIDFILE" ] && IFS= read -r pidfile_pid < "$PIDFILE" || true
+  [ "$pidfile_pid" = "$$" ] && rm -f "$PIDFILE"
   if [ -n "$READY_FILES" ]; then
     while IFS= read -r _rf; do
       [ -z "$_rf" ] && continue
@@ -115,7 +117,9 @@ cleanup() {
       # same (team, name) overwrites it with its own session_id before this one
       # exits; without this guard our EXIT could delete the live successor's
       # sentinel. Mirrors the pidfile guard above. See #108 review.
-      [ "$(cat "$_rf" 2>/dev/null)" = "$SESSION_ID" ] && rm -f "$_rf" 2>/dev/null || true
+      local _owner=""
+      [ -f "$_rf" ] && IFS= read -r _owner < "$_rf" || true
+      [ "$_owner" = "$SESSION_ID" ] && rm -f "$_rf" 2>/dev/null || true
     done <<< "$READY_FILES"
   fi
 }
@@ -297,11 +301,13 @@ while true; do
           fi
           exit 0
         fi
-        printf '%s | %s | %s → %s | %s\n' "$ts" "$team" "$from" "$to" "$body"
+        if ! printf '%s | %s | %s → %s | %s\n' "$ts" "$team" "$from" "$to" "$body"; then
+          cleanup
+          exit 0
+        fi
         LAST="$id"
+        persist_watermark
       done <<< "$ROWS"
-      # Persist after each delivered batch so a restart resumes from here.
-      persist_watermark
     fi
   fi
 

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -42,6 +42,39 @@ _iid() {
     agmsg_normalize_instance_id "$1" claude-code 2>/dev/null )
 }
 
+_max_message_id() {
+  ( # shellcheck disable=SC1090
+    source "$SCRIPTS/lib/storage.sh"
+    agmsg_sqlite "$(agmsg_db_path)" "SELECT COALESCE(MAX(id), 0) FROM messages;" )
+}
+
+_wait_for_file() {
+  local file="$1" i
+  for i in $(seq 1 100); do
+    [ -f "$file" ] && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+_wait_for_missing() {
+  local file="$1" i
+  for i in $(seq 1 100); do
+    [ ! -e "$file" ] && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+_wait_for_file_contains() {
+  local file="$1" needle="$2" i
+  for i in $(seq 1 100); do
+    [ -f "$file" ] && grep -q "$needle" "$file" && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
 @test "watch: restart delivers messages that arrived while the watcher was down" {
   local sid="sess-restart"
 
@@ -89,6 +122,71 @@ _iid() {
 @test "watch: persists a watermark file for the session" {
   run_watcher_for "sess-wm" "$TEST_SKILL_DIR/wm.log" 1.5
   [ -f "$TEST_SKILL_DIR/run/watch.$(_iid sess-wm).watermark" ]
+}
+
+@test "watch: closed consumer does not advance watermark past an undelivered row" {
+  local sid="sess-consumer-close"
+  local iid="$(_iid "$sid")"
+  local wm="$TEST_SKILL_DIR/run/watch.$iid.watermark"
+  local pf="$TEST_SKILL_DIR/run/watch.$iid.pid"
+  local first_out="$TEST_SKILL_DIR/first-delivery.log"
+
+  ( AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
+      | head -n 1 > "$first_out" ) 2>/dev/null &
+  local pipeline=$!
+
+  _wait_for_file "$wm"
+  [ -f "$pf" ]
+  local w="$(cat "$pf")"
+
+  bash "$SCRIPTS/send.sh" team bob alice "M1-before-consumer-close" >/dev/null
+  local first_id="$(_max_message_id)"
+  _wait_for_file_contains "$first_out" "M1-before-consumer-close"
+
+  bash "$SCRIPTS/send.sh" team bob alice "M2-after-consumer-close" >/dev/null
+  local second_id="$(_max_message_id)"
+  _wait_for_missing "$pf" || {
+    kill "$w" "$pipeline" 2>/dev/null || true
+    wait "$pipeline" 2>/dev/null || true
+    false
+  }
+  wait "$pipeline" 2>/dev/null || true
+
+  [ "$first_id" != "$second_id" ]
+  [ "$(cat "$wm")" = "$first_id" ]
+
+  run_watcher_for "$sid" "$TEST_SKILL_DIR/redelivery.log" 2
+  grep -q "M2-after-consumer-close" "$TEST_SKILL_DIR/redelivery.log"
+  ! grep -q "M1-before-consumer-close" "$TEST_SKILL_DIR/redelivery.log"
+}
+
+@test "watch: closed stdout exits without advancing the watermark" {
+  local sid="sess-stdout-closed"
+  local iid="$(_iid "$sid")"
+  local wm="$TEST_SKILL_DIR/run/watch.$iid.watermark"
+  local pf="$TEST_SKILL_DIR/run/watch.$iid.pid"
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
+    1>&- 2>/dev/null &
+  local w=$!
+
+  _wait_for_file "$wm"
+  [ -f "$pf" ]
+  local initial="$(cat "$wm")"
+
+  bash "$SCRIPTS/send.sh" team bob alice "M-after-closed-stdout" >/dev/null
+
+  _wait_for_missing "$pf" || {
+    kill "$w" 2>/dev/null || true
+    wait "$w" 2>/dev/null || true
+    false
+  }
+  wait "$w" 2>/dev/null || true
+
+  [ "$(cat "$wm")" = "$initial" ]
+
+  run_watcher_for "$sid" "$TEST_SKILL_DIR/closed-redelivery.log" 2
+  grep -q "M-after-closed-stdout" "$TEST_SKILL_DIR/closed-redelivery.log"
 }
 
 @test "session-end: removes the session watermark file" {


### PR DESCRIPTION
## Summary
A message addressed to a subscribed role can be silently dropped from the live monitor stream (never surfaced, never re-delivered) even though it is correctly persisted in the DB. Root cause: an orphaned watch.sh whose Monitor/consumer has already exited keeps advancing the per-session watermark.

## Changes
In watch.sh, make persist_watermark conditional on the row actually reaching a live consumer: detect a closed stdout (write failure / EPIPE on the printf that emits the row) and, on failure, exit without persisting the watermark so a successor watcher re-streams the un-consumed batch. Concretely, check the exit status of the stdout write in the streaming loop and break/exit before calling persist_watermark when the write fails.

Fixes #127
