### PR TITLE
fix: validate team names to prevent teams/ path traversal (#140)

### DIFF
--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -23,6 +23,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 
+# Reject team names that would escape teams/ as a path segment (#140).
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/validate.sh"
+agmsg_validate_team_name "$TEAM" || exit 1
+
 # Resolve the session's real project root from the passed pwd (see #92), so an
 # agent-driven join from a subdir/worktree registers under the project the
 # session lives in instead of minting a phantom record for the subdir.

--- a/scripts/leave.sh
+++ b/scripts/leave.sh
@@ -10,6 +10,12 @@ AGENT_ID="${2:?Missing agent_id}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEAMS_DIR="$SCRIPT_DIR/../teams"
+
+# Reject team names that would escape teams/ as a path segment (#140).
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/validate.sh"
+agmsg_validate_team_name "$TEAM" || exit 1
+
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
 
 if [ ! -f "$TEAM_CONFIG" ]; then

--- a/scripts/lib/validate.sh
+++ b/scripts/lib/validate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# validate.sh — input validation for values that become filesystem paths.
+#
+# Team names are used directly as path segments in the team registry
+# (teams/<name>/config.json). A name containing "/", "\", or equal to "." / ".."
+# can escape teams/ and create/read/move/delete files outside the agmsg state
+# tree (#140). Validate at every entry point that turns a team name into a path:
+# join.sh, leave.sh, team.sh, rename.sh, rename-team.sh.
+#
+# Team names are intentionally allowed to be arbitrary UTF-8 (e.g. Japanese team
+# names like "testチーム" exist in the wild), so this is a deny-list of
+# path-dangerous constructs, NOT an ASCII allow-list. Multibyte UTF-8 bytes are
+# all >= 0x80, so they never match the control-character range below.
+
+# Guard against double-source.
+[ -n "${_AGMSG_VALIDATE_SH:-}" ] && return 0
+_AGMSG_VALIDATE_SH=1
+
+# Return 0 if <name> is safe to use as a single path segment, else print a
+# specific error to stderr and return 1.
+agmsg_validate_team_name() {
+  local name="$1"
+  if [ -z "$name" ]; then
+    echo "agmsg: invalid team name: must not be empty" >&2
+    return 1
+  fi
+  case "$name" in
+    .|..)
+      echo "agmsg: invalid team name '$name': '.' and '..' are not allowed" >&2
+      return 1 ;;
+    */*|*\\*)
+      echo "agmsg: invalid team name '$name': must not contain '/' or '\\' (path traversal)" >&2
+      return 1 ;;
+    -*)
+      # Leading '-' would be parsed as an option by downstream tools.
+      echo "agmsg: invalid team name '$name': must not start with '-'" >&2
+      return 1 ;;
+  esac
+  # Reject control characters (NUL can't reach a shell var, but newline / tab /
+  # other C0 + DEL can corrupt paths, configs, and row-counting output).
+  case "$name" in
+    *[[:cntrl:]]*)
+      echo "agmsg: invalid team name: must not contain control characters" >&2
+      return 1 ;;
+  esac
+  return 0
+}

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -18,6 +18,12 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
+# Reject team names that would escape teams/ as a path segment, on either side
+# of the rename (#140).
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/validate.sh"
+agmsg_validate_team_name "$OLD_TEAM" || exit 1
+agmsg_validate_team_name "$NEW_TEAM" || exit 1
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 DB="$(agmsg_db_path)"
 OLD_DIR="$TEAMS_DIR/$OLD_TEAM"

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -11,6 +11,10 @@ NEW_NAME="${3:?Missing new agent name}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
+# Reject team names that would escape teams/ as a path segment (#140).
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/validate.sh"
+agmsg_validate_team_name "$TEAM" || exit 1
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 DB="$(agmsg_db_path)"
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"

--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -7,6 +7,12 @@ set -euo pipefail
 TEAM="${1:?Usage: team.sh <team>}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Reject team names that would escape teams/ as a path segment (#140).
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/validate.sh"
+agmsg_validate_team_name "$TEAM" || exit 1
+
 CONFIG="$SCRIPT_DIR/../teams/$TEAM/config.json"
 
 if [ ! -f "$CONFIG" ]; then

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -278,3 +278,72 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+
+# --- #140: team-name path traversal ---
+
+@test "join: rejects a team name with path traversal (../)" {
+  run bash "$SCRIPTS/join.sh" "../../escape-join" alice claude-code /tmp/proj
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "path traversal" ]]
+  # Nothing was created outside teams/.
+  [ ! -f "$(dirname "$TEST_SKILL_DIR")/escape-join/config.json" ]
+}
+
+@test "join: rejects '..' and '.' as team names" {
+  run bash "$SCRIPTS/join.sh" ".." alice claude-code /tmp/proj
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "not allowed" ]]
+  run bash "$SCRIPTS/join.sh" "." alice claude-code /tmp/proj
+  [ "$status" -eq 1 ]
+}
+
+@test "join: rejects a team name starting with '-'" {
+  run bash "$SCRIPTS/join.sh" "-rf" alice claude-code /tmp/proj
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "must not start with" ]]
+}
+
+@test "join: rejects an empty team name" {
+  run bash "$SCRIPTS/join.sh" "" alice claude-code /tmp/proj
+  [ "$status" -ne 0 ]
+}
+
+@test "team: rejects a traversal team name" {
+  run bash "$SCRIPTS/team.sh" "../../escape-team"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "path traversal" ]]
+}
+
+@test "leave: rejects a traversal team name" {
+  run bash "$SCRIPTS/leave.sh" "../../escape-leave" alice
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "path traversal" ]]
+}
+
+@test "rename: rejects a traversal team name" {
+  run bash "$SCRIPTS/rename.sh" "../../escape-rename" old new
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "path traversal" ]]
+}
+
+@test "rename-team: rejects traversal on the new name and does not move outside teams/" {
+  bash "$SCRIPTS/join.sh" srcteam bob claude-code /tmp/proj
+  run bash "$SCRIPTS/rename-team.sh" srcteam "../../escape-renamed"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "path traversal" ]]
+  [ ! -f "$(dirname "$TEST_SKILL_DIR")/escape-renamed/config.json" ]
+  # Source team is untouched.
+  [ -f "$TEST_SKILL_DIR/teams/srcteam/config.json" ]
+}
+
+@test "rename-team: rejects traversal on the old name" {
+  run bash "$SCRIPTS/rename-team.sh" "../../escape-old" newteam
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "path traversal" ]]
+}
+
+@test "join: still accepts a UTF-8 (Japanese) team name" {
+  run bash "$SCRIPTS/join.sh" "テストチーム" alice claude-code /tmp/proj
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_SKILL_DIR/teams/テストチーム/config.json" ]
+}


### PR DESCRIPTION
## What

Fixes #140 — team names were used directly as filesystem path segments in the team registry (`teams/<name>/config.json`), so a name containing `/`, `\`, or equal to `.` / `..` could escape `teams/` and create/read/move/delete config files and team directories outside the agmsg state tree.

Affected entry points: `join.sh`, `leave.sh`, `team.sh`, `rename.sh`, `rename-team.sh`.

## How

- New `scripts/lib/validate.sh` → `agmsg_validate_team_name`, called at every entry point that turns a team name into a path.
- It is a **deny-list** of path-dangerous constructs (empty, `.`, `..`, `/`, `\`, leading `-`, control characters), **not** an ASCII allow-list. Team names are intentionally arbitrary UTF-8 (Japanese team names are already in use); multibyte UTF-8 bytes are all `>= 0x80` and never match the control-character class, so legitimate names stay valid.
- `scripts/lib/` ships via the installer's recursive copy — no install change needed.

## Verification

The issue's repro is now rejected (exit 1, no escaped files), and legitimate ASCII + UTF-8 names still join:

```
join.sh "../../outside-team" ...   → agmsg: invalid team name '../../outside-team': must not contain '/' or '\' (path traversal)  (exit 1)
team.sh "../../outside-team"        → rejected
rename-team.sh oldteam "../../x"    → rejected, source team untouched
join.sh "testチーム" ...            → joined (UTF-8 preserved)
```

Tests added to `tests/test_team.bats`: traversal / `.`+`..` / leading-dash / empty rejection across all five scripts, no-escape assertions for join and rename-team, and a UTF-8 acceptance regression. `bats tests/test_team.bats` → 42/42.

Closes #140