### PR TITLE
ci: add staged Windows (windows-latest) coverage (#125)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,3 +55,60 @@ jobs:
 
       - name: Run bats suite
         run: bats --print-output-on-failure tests/
+
+  # Windows coverage for the native helpers shipped in #103 (PowerShell wrapper,
+  # Git Bash runner, sqlite3 compatibility shim, cygpath normalization). The
+  # POSIX-assuming suite is not fully green on Windows yet, so this is staged
+  # (#125): a focused leg targeting the Windows-relevant tests, plus a full leg
+  # that is informational only (continue-on-error) to track how far the rest
+  # gets. Neither is a required check yet — promote the focused leg to required
+  # once it is reliably green. The required checks stay bats (ubuntu/macos).
+  bats-windows:
+    name: bats (windows-latest, ${{ matrix.leg }})
+    runs-on: windows-latest
+    # The full leg is best-effort: a failure there must not fail the workflow.
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - leg: Windows helpers
+            filter: "[Ww]indows"
+            experimental: false
+          - leg: full (experimental)
+            filter: ""
+            experimental: true
+    defaults:
+      run:
+        # bats is bash; on Windows runners `shell: bash` is Git Bash, the same
+        # environment native Windows users run agmsg under.
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install sqlite3
+        shell: pwsh
+        run: choco install sqlite -y --no-progress
+
+      - name: Put chocolatey shims on PATH (Git Bash form)
+        run: echo "/c/ProgramData/chocolatey/bin" >> "$GITHUB_PATH"
+
+      - name: Install bats
+        run: |
+          npm config set prefix "$HOME/.npm-global"
+          npm install -g bats
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+
+      - name: Show tool versions
+        run: |
+          bash --version | head -1
+          sqlite3 --version || sqlite3.exe --version || echo "sqlite3 not found on PATH"
+          bats --version
+
+      - name: Run tests
+        run: |
+          if [ -n "${{ matrix.filter }}" ]; then
+            bats --print-output-on-failure --filter "${{ matrix.filter }}" tests/
+          else
+            bats --print-output-on-failure tests/
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,8 +70,10 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     # The full leg exercises POSIX-assuming tests that can hang on Windows
     # (no native equivalent for some sleeps/process checks); bound the job so a
-    # hang can't pin a runner for hours.
-    timeout-minutes: 20
+    # hang can't pin a runner. The malformed-JSON failures this surfaces appear
+    # early, so 12 min is enough to capture the useful map of what's broken
+    # while keeping the per-PR cost down (the leg is continue-on-error anyway).
+    timeout-minutes: 12
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,15 +68,27 @@ jobs:
     runs-on: windows-latest
     # The full leg is best-effort: a failure there must not fail the workflow.
     continue-on-error: ${{ matrix.experimental }}
+    # The full leg exercises POSIX-assuming tests that can hang on Windows
+    # (no native equivalent for some sleeps/process checks); bound the job so a
+    # hang can't pin a runner for hours.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         include:
-          - leg: Windows helpers
+          # Focused leg: the install-side native Windows helpers (#103). These
+          # are green on windows-latest today and are the candidate to promote
+          # to a required check. Other Windows-relevant tests (delivery hook
+          # JSON, the PowerShell runner smoke) currently fail on the #143/#138
+          # "malformed JSON" bug and are tracked by the full leg below until
+          # that is fixed in a separate PR.
+          - leg: install helpers
             filter: "[Ww]indows"
+            target: tests/test_install.bats
             experimental: false
           - leg: full (experimental)
             filter: ""
+            target: tests/
             experimental: true
     defaults:
       run:
@@ -108,7 +120,7 @@ jobs:
       - name: Run tests
         run: |
           if [ -n "${{ matrix.filter }}" ]; then
-            bats --print-output-on-failure --filter "${{ matrix.filter }}" tests/
+            bats --print-output-on-failure --filter "${{ matrix.filter }}" "${{ matrix.target }}"
           else
-            bats --print-output-on-failure tests/
+            bats --print-output-on-failure "${{ matrix.target }}"
           fi


### PR DESCRIPTION
Refs #125.

## What

Adds a `windows-latest` job to the test workflow so the native Windows helpers from #103 (PowerShell wrapper, Git Bash runner, sqlite3 compatibility shim, `cygpath` normalization) get automated coverage instead of only `AGMSG_FORCE_WINDOWS` on the POSIX runners + manual smoke tests.

## How (approach C from the issue — staged, non-blocking)

A `bats-windows` job on `windows-latest`, running under Git Bash (`shell: bash`) with a choco-installed `sqlite3`, in two legs:

- **`Windows helpers`** (focused) — runs the Windows-relevant tests via `bats --filter '[Ww]indows'` (helper generation/restore + the runner send/inbox + shim cache smoke). This is the leg meant to become required once stable.
- **`full (experimental)`** — runs the entire suite with `continue-on-error: true`, informational only, to track how far the POSIX-assuming tests get on Windows.

The required checks stay **`bats (ubuntu-latest)` / `bats (macos-latest)`** — neither Windows leg is required yet (per the issue: promote once reliably green).

## Note

Windows CI can't be validated locally, so this is expected to iterate: the first `windows-latest` run will surface PATH/sqlite/CRLF quirks to fix before the focused leg is green. This PR is the starting point; doubles as live coverage for the #101/#102/#130 Windows issues.