### PR TITLE
feat(types): pluggable agent-type registry

### DIFF
--- a/docs/agent-types.md
+++ b/docs/agent-types.md
@@ -23,7 +23,6 @@ cannot execute code. Multi-value keys are whitespace-separated.
 | `cli` | spawnable types | the launch binary |
 | `spawnable` | — | `yes` if `spawn.sh` can launch this type |
 | `spawn` | — | a `.mjs` node-launcher (beside the manifest) `spawn.sh` runs via Node; also marks the type spawnable |
-| `aliases` | — | spawn names this type OWNS (reverse lookup): a bare name listed here resolves to this type as its spawn target |
 | `hooks_file` | yes | project-relative delivery hooks file (e.g. `.codex/hooks.json`) |
 | `monitor` | — | `yes` if the type exposes a Monitor tool; `spawn` skips the readiness wait when `no` |
 
@@ -70,15 +69,6 @@ All type-specific configuration (which binary, which model, which transport, env
 vars) is the launcher's **own default / environment** — agmsg core never names any
 add-on. This is what lets a node-launcher type ship entirely outside the agmsg tree
 (under `${AGMSG_HOME:-$HOME/.config/agmsg}/types`) with no built-in edits.
-
-A type can also **own another type's spawn name** by listing it in its `aliases=`
-key. The lookup is a **reverse** one: `agmsg_type_alias_for <name>` returns the
-registered type that lists `<name>` in its own `aliases=`. This is how an external
-add-on such as `codex-app-server` plugs in as the spawn target for the bare
-`codex` name — it claims `aliases=codex` in *its own* manifest, so spawning `codex`
-dispatches to the add-on's launcher **without editing the built-in `codex`
-manifest**. The alias ships and is removed with the add-on, and a stderr warning is
-emitted if more than one type claims the same name.
 
 ## Adding a type
 

--- a/docs/agent-types.md
+++ b/docs/agent-types.md
@@ -1,0 +1,110 @@
+# Agent types
+
+agmsg supports several agent runtimes — claude-code, codex, gemini, antigravity,
+copilot, opencode — and each is described by a small **manifest** so that the rest
+of agmsg (detection, the join whitelist, spawn, and delivery routing) discovers it
+from data instead of hardcoded `case` arms.
+
+Adding a type is a **manifest + a command template**, not an edit across
+`whoami.sh`, `join.sh`, `spawn.sh`, and `delivery.sh`.
+
+## The manifest
+
+Each type has `types/<name>/type.conf` — read-only `key=value` **data**. agmsg
+reads it with a small per-key reader; it is **never `source`d**, so a manifest
+cannot execute code. Multi-value keys are whitespace-separated.
+
+| key | required | meaning |
+|---|---|---|
+| `name` | yes | the type name (matches the directory) |
+| `template` | yes | the `/agmsg` command template in `templates/` (becomes `SKILL.md`) |
+| `detect` | — | env-var names whose presence selects this type. `explicit` = never auto-detected from the environment |
+| `detect_proc` | — | parent-process-name glob patterns that select this type (e.g. `codex codex-*`) |
+| `cli` | spawnable types | the launch binary |
+| `spawnable` | — | `yes` if `spawn.sh` can launch this type |
+| `spawn` | — | a `.mjs` node-launcher (beside the manifest) `spawn.sh` runs via Node; also marks the type spawnable |
+| `aliases` | — | spawn names this type OWNS (reverse lookup): a bare name listed here resolves to this type as its spawn target |
+| `hooks_file` | yes | project-relative delivery hooks file (e.g. `.codex/hooks.json`) |
+| `monitor` | — | `yes` if the type exposes a Monitor tool; `spawn` skips the readiness wait when `no` |
+
+> The reader does not fail-fast: an omitted key reads as the empty string, so
+> "required" above means "needed for the type to actually work", not "validated at
+> load time".
+
+### Detection
+
+`whoami.sh` auto-detects the running type when none is passed:
+
+1. **Environment** — the manifests' `detect=` env vars, evaluated in sorted type
+   order, which preserves the precedence claude-code < codex < gemini (a runtime's
+   own session vars beat the `GEMINI_*` family that users also set for the SDK).
+   `detect=explicit` types are never selected here.
+2. **Process tree** — walking up from the current process, the first type whose
+   `detect_proc=` glob matches the ancestor's name wins.
+3. Falls back to `claude-code`.
+
+> Precedence note: env detection iterates types in **sorted name order**, so when
+> two types' `detect=` vars are both present the alphabetically-earlier type wins.
+> Keep `detect=` vars runtime-exclusive (a runtime's own session var, not a shared
+> SDK var) so ties don't arise; this is why the `GEMINI_*` family — which users
+> set without the CLI — sits behind the claude-code/codex session vars.
+
+### Delivery
+
+`hooks_file=` is the per-project file delivery hooks are written into. The hook
+*format* (settings JSON vs. rule markdown vs. …) is still per-type code in
+`delivery.sh` (`apply_settings_*`); the manifest drives the file **path** and the
+allowed modes.
+
+### Node-launcher types (external add-ons)
+
+A type whose manifest sets a `spawn=` key to a `.mjs` file is launched by
+`spawn.sh` **via Node** rather than through a `cli=` binary. agmsg core invokes the
+launcher with only four **universal** flags:
+
+```
+node <type-dir>/<spawn>.mjs --name <name> --team <team> --project <path> --initial-input <text>
+```
+
+All type-specific configuration (which binary, which model, which transport, env
+vars) is the launcher's **own default / environment** — agmsg core never names any
+add-on. This is what lets a node-launcher type ship entirely outside the agmsg tree
+(under `${AGMSG_HOME:-$HOME/.config/agmsg}/types`) with no built-in edits.
+
+A type can also **own another type's spawn name** by listing it in its `aliases=`
+key. The lookup is a **reverse** one: `agmsg_type_alias_for <name>` returns the
+registered type that lists `<name>` in its own `aliases=`. This is how an external
+add-on such as `codex-app-server` plugs in as the spawn target for the bare
+`codex` name — it claims `aliases=codex` in *its own* manifest, so spawning `codex`
+dispatches to the add-on's launcher **without editing the built-in `codex`
+manifest**. The alias ships and is removed with the add-on, and a stderr warning is
+emitted if more than one type claims the same name.
+
+## Adding a type
+
+1. Create `types/<name>/type.conf` with at least `name`, `template`, and
+   `hooks_file` (add `detect`/`detect_proc` for auto-detection, and `cli` +
+   `spawnable=yes` if `spawn.sh` should launch it).
+2. Add the command template `templates/cmd.<name>.md`.
+3. If the type needs a delivery hook format that doesn't exist yet, add an
+   `apply_settings_<name>` path in `delivery.sh`. Reusing an existing format needs
+   no code.
+
+That's it — `whoami.sh`, `join.sh`, and `spawn.sh` pick the type up from the
+registry with no further edits.
+
+## Worked example
+
+The six built-in manifests under `types/` are the reference. For instance
+`types/codex/type.conf`:
+
+```
+name=codex
+template=cmd.codex.md
+cli=codex
+spawnable=yes
+detect=CODEX_SANDBOX CODEX_THREAD_ID
+detect_proc=codex codex-*
+hooks_file=.codex/hooks.json
+monitor=no
+```

--- a/install.sh
+++ b/install.sh
@@ -193,6 +193,9 @@ if [ "$UPDATE_ONLY" = true ]; then
   sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$SCRIPT_DIR/templates/$SKILL_TEMPLATE" > "$SKILL_DIR/SKILL.md"
   # Recursive copy so nested helper dirs (scripts/lib/) ship without enumerating files.
   cp -R "$SCRIPT_DIR/scripts/." "$SKILL_DIR/scripts/"
+  # Ship the agent-type manifests so the type registry resolves types post-install.
+  mkdir -p "$SKILL_DIR/types"
+  cp -R "$SCRIPT_DIR/types/." "$SKILL_DIR/types/"
   for tmpl in "$SCRIPT_DIR/templates/"cmd.*.md; do
     sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$tmpl" > "$SKILL_DIR/templates/$(basename "$tmpl")"
   done
@@ -248,7 +251,7 @@ SKILL_DIR="$AGENTS_DIR/skills/$CMD_NAME"
 
 # --- Install skill ---
 echo "  Installing to ~/.agents/skills/$CMD_NAME/ ..."
-mkdir -p "$SKILL_DIR"/{scripts,templates,db,agents}
+mkdir -p "$SKILL_DIR"/{scripts,templates,types,db,agents}
 
 # SKILL.md is generated from the agent-specific command template.
 SKILL_TEMPLATE="cmd.codex.md"
@@ -262,6 +265,8 @@ fi
 sed "s/__SKILL_NAME__/$CMD_NAME/g" "$SCRIPT_DIR/templates/$SKILL_TEMPLATE" > "$SKILL_DIR/SKILL.md"
 # Recursive copy so nested helper dirs (scripts/lib/) ship without enumerating files.
 cp -R "$SCRIPT_DIR/scripts/." "$SKILL_DIR/scripts/"
+# Ship the agent-type manifests so the type registry resolves types post-install.
+cp -R "$SCRIPT_DIR/types/." "$SKILL_DIR/types/"
 
 # Replace placeholder in templates with actual skill name
 for tmpl in "$SCRIPT_DIR/templates/"cmd.*.md; do

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -37,18 +37,27 @@ RUN_DIR="$SKILL_DIR/run"
 . "$SCRIPT_DIR/lib/resolve-project.sh"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/instance-id.sh"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/type-registry.sh"
 
+# The per-project delivery hooks file is the type's manifest `hooks_file=`
+# (project-relative), not a hardcoded per-type case. The hook FORMAT written into
+# it is still type-specific (apply_settings_* below).
 resolve_hooks_file() {
   local type="$1"
   local project="$2"
-  case "$type" in
-    claude-code) echo "$project/.claude/settings.local.json" ;;
-    codex)       echo "$project/.codex/hooks.json" ;;
-    gemini|antigravity) echo "$project/.agent/rules/agmsg.md" ;;
-    copilot)     echo "$project/.github/hooks/agmsg.json" ;;
-    opencode)    echo "$project/.opencode/rules/agmsg.md" ;;
-    *) echo "Unknown agent type: $type" >&2; return 1 ;;
+  local rel
+  rel="$(agmsg_type_get "$type" hooks_file)"
+  if [ -z "$rel" ]; then
+    echo "Unknown agent type: $type" >&2
+    return 1
+  fi
+  # hooks_file is project-relative; reject absolute paths or traversal so a
+  # manifest can't redirect writes outside the project.
+  case "$rel" in
+    /*|*..*) echo "Invalid hooks_file for $type: $rel" >&2; return 1 ;;
   esac
+  echo "$project/$rel"
 }
 
 sql_readfile_path() {

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -7,19 +7,22 @@ set -euo pipefail
 
 TEAM="${1:?Usage: join.sh <team> <agent_id> <type> <project_path>}"
 AGENT_ID="${2:?Missing agent_id}"
-AGENT_TYPE="${3:?Missing type (claude-code | codex)}"
+AGENT_TYPE="${3:?Missing type (a registered type under types/<name>/)}"
 PROJECT_PATH="${4:?Missing project_path}"
 
-# Reject unknown agent types — the rest of agmsg (delivery.sh,
-# session-start.sh, identities.sh lookups) only supports the values listed
-# here. Allowing arbitrary strings silently mis-registers an agent and
-# makes monitor mode fail with a confusing "no joined teams" message.
-case "$AGENT_TYPE" in
-  claude-code|codex|gemini|antigravity|copilot|opencode) ;;
-  *) echo "Unknown agent type: '$AGENT_TYPE' (supported: claude-code, codex, gemini, antigravity, copilot, opencode)" >&2; exit 1 ;;
-esac
-
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/type-registry.sh"
+
+# Reject unknown agent types — the rest of agmsg (delivery.sh,
+# session-start.sh, identities.sh lookups) only supports registered types
+# (types/<name>/type.conf). Allowing arbitrary strings silently mis-registers an
+# agent and makes monitor mode fail with a confusing "no joined teams" message.
+if ! agmsg_is_known_type "$AGENT_TYPE"; then
+  echo "Unknown agent type: '$AGENT_TYPE' (supported: $(agmsg_known_types | sort -u | paste -sd, - | sed 's/,/, /g'))" >&2
+  exit 1
+fi
+
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 

--- a/scripts/lib/type-registry.sh
+++ b/scripts/lib/type-registry.sh
@@ -108,27 +108,3 @@ agmsg_type_has() {
   done
   return 1
 }
-
-# Reverse spawn-alias lookup: echo the registered type that CLAIMS <name> as a
-# spawn alias — i.e. lists <name> in its OWN manifest's `aliases=` key — or
-# nothing. This lets a type (e.g. an external add-on) own the alias in its own
-# manifest instead of editing another type's manifest, so the alias ships and is
-# removed with that type. Deterministic: first match in sorted type order wins; a
-# stderr warning is emitted if more than one type claims <name>.
-agmsg_type_alias_for() {
-  local want="$1" t found="" extra=""
-  while IFS= read -r t; do
-    [ -n "$t" ] || continue
-    if agmsg_type_has "$t" aliases "$want"; then
-      if [ -z "$found" ]; then found="$t"; else extra="$extra $t"; fi
-    fi
-  done <<EOF
-$(agmsg_known_types | sort -u)
-EOF
-  if [ -n "$extra" ]; then
-    printf 'agmsg: multiple types claim spawn alias %s (%s%s); using %s\n' \
-      "$want" "$found" "$extra" "$found" >&2
-  fi
-  [ -n "$found" ] && printf '%s\n' "$found"
-  return 0
-}

--- a/scripts/lib/type-registry.sh
+++ b/scripts/lib/type-registry.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Agent-type registry.
+#
+# Agent types are discovered from `types/<name>/type.conf` manifests instead of
+# hardcoded whitelists, so a type (and its template / delivery / session-start /
+# spawn behavior) can be added by dropping a directory — including by an external
+# add-on outside the agmsg tree.
+#
+# IMPORTANT — manifests are read-only `key=value` DATA and are NEVER `source`d.
+# A small per-key reader is used, so a third-party add-on's manifest cannot
+# execute code. Multi-value keys are space-separated.
+#
+# Search order:
+#   1. in-tree built-ins:  <skill-root>/types
+#   2. external add-ons:   ${AGMSG_HOME:-$HOME/.config/agmsg}/types
+# Built-in names are reserved; if the same name appears in both, the in-tree one
+# wins (listed first).
+#
+# Safe under `set -u`: every env read is guarded.
+
+# Resolve THIS lib's directory at SOURCE time. BASH_SOURCE inside a later
+# function call — especially within a command-substitution subshell, or when the
+# lib was sourced via a relative path from a different cwd — can resolve against
+# the wrong directory; capturing it once here is robust however the registry is
+# queried later.
+_AGMSG_REGISTRY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+
+# Echo the type search directories, one per line (in-tree first).
+_agmsg_type_search_dirs() {
+  local root="${AGMSG_TYPES_ROOT:-}"
+  if [ -z "$root" ]; then
+    # this lib lives at <root>/scripts/lib/type-registry.sh -> up two = <root>
+    root="$(cd "$_AGMSG_REGISTRY_LIB_DIR/../.." 2>/dev/null && pwd)"
+  fi
+  [ -n "$root" ] && printf '%s\n' "$root/types"
+  # ${HOME:-} keeps this safe under `set -u` with an empty environment.
+  local ext="${AGMSG_HOME:-${HOME:-}/.config/agmsg}/types"
+  [ -n "$root" ] && [ "$ext" = "$root/types" ] || printf '%s\n' "$ext"
+}
+
+# Echo the directory holding <name>/type.conf, or return 1.
+agmsg_type_dir() {
+  local want="$1" d
+  while IFS= read -r d; do
+    [ -n "$d" ] || continue
+    [ -f "$d/$want/type.conf" ] && { printf '%s\n' "$d/$want"; return 0; }
+  done <<EOF
+$(_agmsg_type_search_dirs)
+EOF
+  return 1
+}
+
+# List all known type names (deduped, sorted).
+agmsg_known_types() {
+  local d sub name
+  while IFS= read -r d; do
+    [ -n "$d" ] && [ -d "$d" ] || continue
+    for sub in "$d"/*/; do
+      [ -f "${sub}type.conf" ] || continue
+      name="$(basename "$sub")"
+      printf '%s\n' "$name"
+    done
+  done <<EOF
+$(_agmsg_type_search_dirs)
+EOF
+}
+
+# 0 if <name> is a known type.
+agmsg_is_known_type() {
+  local want="$1" t
+  while IFS= read -r t; do
+    [ "$t" = "$want" ] && return 0
+  done <<EOF
+$(agmsg_known_types | sort -u)
+EOF
+  return 1
+}
+
+# Read a single key from <name>/type.conf. Usage:
+#   agmsg_type_get <name> <key> [default]
+# Reads (never sources) the manifest; strips surrounding quotes/space.
+agmsg_type_get() {
+  local name="$1" key="$2" def="${3:-}" dir line val
+  dir="$(agmsg_type_dir "$name")" || { printf '%s\n' "$def"; return 0; }
+  # `|| true` so a no-match grep (exit 1) does not, under set -e + pipefail,
+  # abort the assignment before the default-return branch below is reached.
+  line="$( { grep -E "^[[:space:]]*${key}[[:space:]]*=" "$dir/type.conf" 2>/dev/null || true; } | head -1)"
+  if [ -z "$line" ]; then
+    printf '%s\n' "$def"
+    return 0
+  fi
+  val="${line#*=}"
+  # trim leading/trailing whitespace
+  val="${val#"${val%%[![:space:]]*}"}"
+  val="${val%"${val##*[![:space:]]}"}"
+  # strip one pair of surrounding double quotes if present
+  case "$val" in
+    \"*\") val="${val#\"}"; val="${val%\"}" ;;
+  esac
+  printf '%s\n' "$val"
+}
+
+# Comma-or-space list helper: 0 if <value> is in the space-separated <name>'s <key>.
+agmsg_type_has() {
+  local name="$1" key="$2" want="$3" tok
+  for tok in $(agmsg_type_get "$name" "$key"); do
+    [ "$tok" = "$want" ] && return 0
+  done
+  return 1
+}
+
+# Reverse spawn-alias lookup: echo the registered type that CLAIMS <name> as a
+# spawn alias — i.e. lists <name> in its OWN manifest's `aliases=` key — or
+# nothing. This lets a type (e.g. an external add-on) own the alias in its own
+# manifest instead of editing another type's manifest, so the alias ships and is
+# removed with that type. Deterministic: first match in sorted type order wins; a
+# stderr warning is emitted if more than one type claims <name>.
+agmsg_type_alias_for() {
+  local want="$1" t found="" extra=""
+  while IFS= read -r t; do
+    [ -n "$t" ] || continue
+    if agmsg_type_has "$t" aliases "$want"; then
+      if [ -z "$found" ]; then found="$t"; else extra="$extra $t"; fi
+    fi
+  done <<EOF
+$(agmsg_known_types | sort -u)
+EOF
+  if [ -n "$extra" ]; then
+    printf 'agmsg: multiple types claim spawn alias %s (%s%s); using %s\n' \
+      "$want" "$found" "$extra" "$found" >&2
+  fi
+  [ -n "$found" ] && printf '%s\n' "$found"
+  return 0
+}

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -66,13 +66,6 @@ NAME="${2:-}"
 [ -n "$NAME" ] || die "Usage: spawn.sh <agent-type> <name> [options]"
 shift 2 || true
 
-# A type may be a spawn ALIAS owned by another type (which lists this name in its
-# own `aliases=` key); redirect via the registry's reverse lookup. Lets an
-# external add-on own e.g. the `codex` spawn name without editing a built-in.
-if alias="$(agmsg_type_alias_for "$AGENT_TYPE")" && [ -n "$alias" ]; then
-  AGENT_TYPE="$alias"
-fi
-
 # A type is spawnable iff its manifest declares `spawnable=yes` (direct-CLI) OR a
 # `spawn=` node launcher. The error lists the computed spawnable set from the
 # registry — no type name is hardcoded here.

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -15,7 +15,8 @@ set -euo pipefail
 # Usage:
 #   spawn.sh <agent-type> <name> [options]
 #
-#   <agent-type>   claude-code | codex   (only these two are supported today)
+#   <agent-type>   any registered type whose manifest is spawnable: a `cli=`
+#                  binary (direct-CLI launch) or a `spawn=` node launcher
 #   <name>         actas identity for the spawned agent
 #
 # Options:
@@ -42,7 +43,8 @@ set -euo pipefail
 # right after spawn returns without racing the agent's cold start. Codex has no
 # Monitor, so the wait is skipped for codex.
 #
-# Scope note: claude-code/codex only; macOS is the primary target, Linux and
+# Scope note: spawnable types are those whose manifest declares `spawnable=yes`;
+# macOS is the primary target, Linux and
 # Windows are best-effort (no guarantee — please open an issue/PR if a given
 # terminal does not work). Headless environments (no tmux and no usable
 # terminal) error out, because the agent CLIs need an interactive terminal.
@@ -52,6 +54,8 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"  # actas-lock.sh requires SKILL_DIR
 TEAMS_DIR="$SKILL_DIR/teams"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/type-registry.sh"
 
 die() { echo "spawn: $*" >&2; exit 1; }
 
@@ -62,13 +66,40 @@ NAME="${2:-}"
 [ -n "$NAME" ] || die "Usage: spawn.sh <agent-type> <name> [options]"
 shift 2 || true
 
-case "$AGENT_TYPE" in
-  claude-code|codex) ;;
-  gemini|antigravity|copilot|opencode)
-    die "agent type '$AGENT_TYPE' is not supported by spawn yet (supported: claude-code, codex)" ;;
-  *)
-    die "unknown agent type '$AGENT_TYPE' (supported: claude-code, codex)" ;;
-esac
+# A type may be a spawn ALIAS owned by another type (which lists this name in its
+# own `aliases=` key); redirect via the registry's reverse lookup. Lets an
+# external add-on own e.g. the `codex` spawn name without editing a built-in.
+if alias="$(agmsg_type_alias_for "$AGENT_TYPE")" && [ -n "$alias" ]; then
+  AGENT_TYPE="$alias"
+fi
+
+# A type is spawnable iff its manifest declares `spawnable=yes` (direct-CLI) OR a
+# `spawn=` node launcher. The error lists the computed spawnable set from the
+# registry — no type name is hardcoded here.
+spawnable_types() {
+  local t
+  while IFS= read -r t; do
+    [ -n "$t" ] || continue
+    # `if` (not `&& printf`) so a non-spawnable last type does not leave the loop
+    # — and thus the function — with a non-zero status, which `set -e`+pipefail
+    # would turn into a silent exit at the `SUPPORTED_LIST=$(...)` assignment.
+    if [ "$(agmsg_type_get "$t" spawnable)" = "yes" ] || [ -n "$(agmsg_type_get "$t" spawn)" ]; then
+      printf '%s\n' "$t"
+    fi
+  done <<EOF
+$(agmsg_known_types | sort -u)
+EOF
+  return 0
+}
+SUPPORTED_LIST="$(spawnable_types | paste -sd, - | sed 's/,/, /g')"
+if ! agmsg_is_known_type "$AGENT_TYPE"; then
+  die "unknown agent type '$AGENT_TYPE' (supported: ${SUPPORTED_LIST})"
+elif [ "$(agmsg_type_get "$AGENT_TYPE" spawnable)" != "yes" ] && [ -z "$(agmsg_type_get "$AGENT_TYPE" spawn)" ]; then
+  # Gate must match spawnable_types(): spawnable iff `spawnable=yes` OR a `spawn=`
+  # node launcher. (Honouring only spawnable=yes here would reject a node-launcher
+  # add-on while still listing it in SUPPORTED_LIST.)
+  die "agent type '$AGENT_TYPE' is not supported by spawn yet (supported: ${SUPPORTED_LIST})"
+fi
 
 # --- Parse options ---
 PROJECT="$PWD"
@@ -117,13 +148,31 @@ if [ ! -d "$PROJECT" ]; then
 fi
 PROJECT="$(cd "$PROJECT" && pwd)"
 
-# --- Resolve the target CLI and make sure it is installed ---
-case "$AGENT_TYPE" in
-  claude-code) CLI_BIN="claude" ;;
-  codex)       CLI_BIN="codex" ;;
-esac
-command -v "$CLI_BIN" >/dev/null 2>&1 \
-  || die "'$CLI_BIN' not found on PATH — install the ${AGENT_TYPE} CLI first"
+# --- Resolve the launch method from the manifest ---
+# A non-empty `spawn=` launcher means this type runs via a Node launcher (e.g. an
+# external add-on); otherwise it is a direct-CLI launch. The `cli=` binary is
+# REQUIRED for direct-CLI types and OPTIONAL for node launchers (which resolve
+# their own runtime). No per-type case — all data-driven from the manifest.
+SPAWN_LAUNCHER="$(agmsg_type_get "$AGENT_TYPE" spawn)"
+CLI_BIN="$(agmsg_type_get "$AGENT_TYPE" cli)"
+CLI_PATH=""
+if [ -n "$CLI_BIN" ]; then
+  command -v "$CLI_BIN" >/dev/null 2>&1 \
+    || die "'$CLI_BIN' not found on PATH — install the ${AGENT_TYPE} CLI first"
+  CLI_PATH="$(command -v "$CLI_BIN")"
+elif [ -z "$SPAWN_LAUNCHER" ]; then
+  die "agent type '$AGENT_TYPE' manifest declares neither a 'cli' binary nor a 'spawn' launcher"
+fi
+# Resolve the node launcher path from the manifest (not hardcoded), if any.
+SPAWN_AGENT=""
+if [ -n "$SPAWN_LAUNCHER" ]; then
+  NODE_BIN="${AGMSG_NODE_BIN:-$(command -v node 2>/dev/null || true)}"
+  [ -n "$NODE_BIN" ] || die "'node' not found on PATH — spawning '$AGENT_TYPE' requires Node.js"
+  type_dir="$(agmsg_type_dir "$AGENT_TYPE")" \
+    || die "agent type '$AGENT_TYPE' is not registered (no types/$AGENT_TYPE/type.conf)"
+  SPAWN_AGENT="$type_dir/$SPAWN_LAUNCHER"
+  [ -f "$SPAWN_AGENT" ] || die "spawn launcher not found for '$AGENT_TYPE': $SPAWN_AGENT"
+fi
 
 # --- Resolve the team to join <name> into ---
 # When --team is omitted, derive it from any team that already has an agent
@@ -224,7 +273,18 @@ BOOT="$BOOT.command"
 {
   echo '#!/usr/bin/env bash'
   printf 'cd %q || exit 1\n' "$PROJECT"
-  printf '%q %q\n' "$CLI_BIN" "$ACTAS_PROMPT"
+  if [ -n "$SPAWN_AGENT" ]; then
+    # Node-launcher path: pass the universal agmsg context + the actas prompt.
+    # Type-specific config is the launcher's own default/env, so core stays
+    # generic and names no add-on.
+    printf '%q %q \\\n' "$NODE_BIN" "$SPAWN_AGENT"
+    printf '  --name %q \\\n' "$NAME"
+    printf '  --team %q \\\n' "$TEAM"
+    printf '  --project %q \\\n' "$PROJECT"
+    printf '  --initial-input %q\n' "$ACTAS_PROMPT"
+  else
+    printf '%q %q\n' "$CLI_BIN" "$ACTAS_PROMPT"
+  fi
   echo 'rm -f "$0" 2>/dev/null'   # self-clean once the agent exits
   echo 'exec "${SHELL:-/bin/bash}" -i'
 } > "$BOOT"
@@ -368,12 +428,12 @@ place_and_launch() {
 # receiving. Block until that appears so the leader doesn't send a job into the
 # cold-start window (before the watcher attaches) and lose it.
 #
-# Codex has no Monitor/watcher, so nothing would ever touch the sentinel —
-# skip the wait for codex (its receive is poll-based anyway).
+# Types without a Monitor (manifest `monitor=no`) never touch the readiness
+# sentinel, so skip the wait for them (their receive is poll-based anyway).
 READY_PATH="$(agmsg_ready_path "$TEAM" "$NAME")"
-if [ "$AGENT_TYPE" = "codex" ] && [ "$WAIT_READY" = "1" ]; then
+if [ "$(agmsg_type_get "$AGENT_TYPE" monitor)" = "no" ] && [ "$WAIT_READY" = "1" ]; then
   WAIT_READY=0
-  echo "spawn: codex has no Monitor — skipping readiness wait (--no-wait implied)" >&2
+  echo "spawn: '$AGENT_TYPE' has no Monitor — skipping readiness wait (--no-wait implied)" >&2
 fi
 
 # Clear any stale sentinel before launching so we only observe THIS spawn's

--- a/scripts/whoami.sh
+++ b/scripts/whoami.sh
@@ -11,57 +11,66 @@ set -euo pipefail
 #   type: claude-code, codex, gemini, antigravity, copilot, opencode
 #   If type is omitted, auto-detect from env vars and process tree.
 
-# Auto-detect CLI type from environment variables and process tree
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/type-registry.sh"
+
+# Auto-detect CLI type from environment variables and the process tree, driven by
+# the per-type manifests' `detect=` (env-var names) and `detect_proc=` (process
+# name globs) keys — no hardcoded type list lives here.
 detect_cli_type() {
-  # 1. Check environment variables. Order matters: prefer the env vars that
-  # the runtime *itself* exports for its own session over the env vars users
-  # commonly set globally for unrelated reasons. CLAUDE_CODE_SESSION_ID and
-  # CODEX_SANDBOX / CODEX_THREAD_ID are set by their runtimes only. The
-  # GEMINI_API_KEY family is also routinely set by users of the Gemini API
-  # SDK without the Gemini CLI being involved, so it goes last.
-  if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
-    echo "claude-code"
-    return 0
-  fi
+  # `detect=` / `detect_proc=` tokens are split with `read -ra` (IFS word-split,
+  # NO pathname expansion) rather than an unquoted `for x in $list` — a file in
+  # the caller's cwd matching a pattern like `claude-*` must not glob-eat the
+  # pattern. (Plain `set -f` can't be used here: agmsg_known_types discovers types
+  # via a `*/` glob that must keep working.)
 
-  if [ -n "${CODEX_SANDBOX:-}" ] || [ -n "${CODEX_THREAD_ID:-}" ]; then
-    echo "codex"
-    return 0
-  fi
+  # 1. Environment variables. Sorted registry order preserves the historical
+  # precedence: a runtime's own session vars (CLAUDE_CODE_SESSION_ID, CODEX_*) are
+  # checked before the GEMINI_* family, which users also set for the SDK without
+  # the CLI. `detect=explicit` (and types with no detect=) are never auto-detected.
+  local _t _v _detect _toks
+  while IFS= read -r _t; do
+    [ -n "$_t" ] || continue
+    _detect="$(agmsg_type_get "$_t" detect)"
+    if [ -z "$_detect" ] || [ "$_detect" = "explicit" ]; then
+      continue
+    fi
+    read -ra _toks <<<"$_detect"
+    for _v in "${_toks[@]}"; do
+      if [ -n "${!_v:-}" ]; then
+        echo "$_t"
+        return 0
+      fi
+    done
+  done <<EOF
+$(agmsg_known_types | sort -u)
+EOF
 
-  if [ -n "${GEMINI_API_KEY:-}" ] || [ -n "${GOOGLE_GEMINI_CLI:-}" ]; then
-    echo "gemini"
-    return 0
-  fi
-
-  # 2. Fall back to process tree detection
-  local pid=$$
-  local max_depth=10
-  local depth=0
-
+  # 2. Process-tree detection via each type's `detect_proc=` name globs. Walk up
+  # from this process; at each ancestor the first type whose glob matches wins
+  # (the globs are disjoint, so order within a level is irrelevant).
+  local pid=$$ max_depth=10 depth=0 proc_name _pats _pat
   while [ $depth -lt $max_depth ] && [ "$pid" != "1" ] && [ -n "$pid" ]; do
-    # Get process name
-    local proc_name
     proc_name=$(ps -p "$pid" -o comm= 2>/dev/null | xargs basename 2>/dev/null || true)
-
-    case "$proc_name" in
-      codex|codex-*)
-        echo "codex"
-        return 0
-        ;;
-      gemini|gemini-*)
-        echo "gemini"
-        return 0
-        ;;
-      claude|claude-code|claude-*)
-        echo "claude-code"
-        return 0
-        ;;
-      opencode|opencode-*)
-        echo "opencode"
-        return 0
-        ;;
-    esac
+    if [ -n "$proc_name" ]; then
+      while IFS= read -r _t; do
+        [ -n "$_t" ] || continue
+        _pats="$(agmsg_type_get "$_t" detect_proc)"
+        [ -n "$_pats" ] || continue
+        read -ra _toks <<<"$_pats"
+        for _pat in "${_toks[@]}"; do
+          # $_pat is intentionally an UNQUOTED glob pattern matched against the
+          # process name; read -ra already kept it out of pathname expansion.
+          # shellcheck disable=SC2254
+          case "$proc_name" in
+            $_pat) echo "$_t"; return 0 ;;
+          esac
+        done
+      done <<EOF
+$(agmsg_known_types | sort -u)
+EOF
+    fi
 
     # Move to parent process
     pid=$(ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' ' || true)
@@ -75,7 +84,7 @@ detect_cli_type() {
 PROJECT_PATH="${1:?Usage: whoami.sh <project_path> [type]}"
 AGENT_TYPE="${2:-$(detect_cli_type)}"
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# SCRIPT_DIR is already resolved above (before sourcing the type registry).
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -10,6 +10,11 @@ setup_test_env() {
   cp -R "$BATS_TEST_DIRNAME"/../scripts/. "$TEST_SKILL_DIR/scripts/"
   chmod +x "$TEST_SKILL_DIR/scripts/"*.sh
 
+  # Copy the agent-type manifests so the type registry resolves types inside the
+  # sandbox (scripts/lib/type-registry.sh reads <skill-root>/types/<name>/type.conf).
+  mkdir -p "$TEST_SKILL_DIR/types"
+  cp -R "$BATS_TEST_DIRNAME"/../types/. "$TEST_SKILL_DIR/types/"
+
   # Initialize DB
   bash "$TEST_SKILL_DIR/scripts/init-db.sh"
 

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -16,23 +16,17 @@ load test_helper
 setup() { setup_test_env; }
 teardown() { teardown_test_env; }
 
-# Write two fixture types into TEST_SKILL_DIR/types so the suite exercises the
-# node-launcher (spawn=) + alias mechanism generically, with no dependency on any
-# real external add-on:
-#   - "nodetype": a node-launcher type. Its manifest sets spawn= to a .mjs and
-#     OWNS the spawn name "aliassrc" via aliases=. A stub launcher file sits
-#     beside the manifest.
-#   - "aliassrc": a bare type whose spawn name is reverse-claimed by nodetype.
+# Write a node-launcher fixture type into TEST_SKILL_DIR/types so the suite
+# exercises the spawn= (Node launcher) mechanism generically, with no dependency
+# on any real external add-on:
+#   - "nodetype": a node-launcher type whose manifest sets spawn= to a .mjs, with
+#     a stub launcher file beside the manifest.
 write_node_launcher_fixtures() {
   local nd="$TEST_SKILL_DIR/types/nodetype"
   mkdir -p "$nd"
-  printf 'name=nodetype\ntemplate=cmd.nodetype.md\nspawn=nodetype-launcher.mjs\naliases=aliassrc\n' \
+  printf 'name=nodetype\ntemplate=cmd.nodetype.md\nspawn=nodetype-launcher.mjs\n' \
     > "$nd/type.conf"
   printf '// stub node launcher fixture\n' > "$nd/nodetype-launcher.mjs"
-
-  local as="$TEST_SKILL_DIR/types/aliassrc"
-  mkdir -p "$as"
-  printf 'name=aliassrc\n' > "$as/type.conf"
 }
 
 @test "type-registry: known_types lists the six built-ins" {
@@ -189,13 +183,6 @@ write_node_launcher_fixtures() {
   echo "$output" | tr ',' '\n' | grep -qx nodetype
   echo "$output" | tr ',' '\n' | grep -qx claude-code
   echo "$output" | tr ',' '\n' | grep -qx codex
-}
-
-@test "type-registry: alias reverse-resolves aliassrc to its owning type nodetype" {
-  write_node_launcher_fixtures
-  run env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_alias_for aliassrc"
-  [ "$status" -eq 0 ]
-  [ "$output" = "nodetype" ]
 }
 
 @test "spawn: a spawn= node-launcher type clears the spawnable gate" {

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -1,0 +1,211 @@
+#!/usr/bin/env bats
+
+# Direct unit tests for the pluggable agent-type registry: discovery + the
+# per-key manifest reader. The behavioral wiring (whoami detection, join
+# whitelist, spawn dispatch, delivery routing) is covered by the existing
+# whoami/join/spawn/delivery suites; these lock the registry primitives and the
+# six built-in manifests themselves.
+#
+# setup_test_env copies both scripts/ and types/ into TEST_SKILL_DIR, so the lib
+# resolves <skill-root>/types there. Each case sources the lib in a wiped env so
+# host vars (this is a Claude Code session — CLAUDE_CODE_SESSION_ID is set) cannot
+# leak into detection.
+
+load test_helper
+
+setup() { setup_test_env; }
+teardown() { teardown_test_env; }
+
+# Write two fixture types into TEST_SKILL_DIR/types so the suite exercises the
+# node-launcher (spawn=) + alias mechanism generically, with no dependency on any
+# real external add-on:
+#   - "nodetype": a node-launcher type. Its manifest sets spawn= to a .mjs and
+#     OWNS the spawn name "aliassrc" via aliases=. A stub launcher file sits
+#     beside the manifest.
+#   - "aliassrc": a bare type whose spawn name is reverse-claimed by nodetype.
+write_node_launcher_fixtures() {
+  local nd="$TEST_SKILL_DIR/types/nodetype"
+  mkdir -p "$nd"
+  printf 'name=nodetype\ntemplate=cmd.nodetype.md\nspawn=nodetype-launcher.mjs\naliases=aliassrc\n' \
+    > "$nd/type.conf"
+  printf '// stub node launcher fixture\n' > "$nd/nodetype-launcher.mjs"
+
+  local as="$TEST_SKILL_DIR/types/aliassrc"
+  mkdir -p "$as"
+  printf 'name=aliassrc\n' > "$as/type.conf"
+}
+
+@test "type-registry: known_types lists the six built-ins" {
+  run env -i PATH="$PATH" bash -c \
+    "source '$SCRIPTS/lib/type-registry.sh'; agmsg_known_types | sort -u | paste -sd, -"
+  [ "$status" -eq 0 ]
+  [ "$output" = "antigravity,claude-code,codex,copilot,gemini,opencode" ]
+}
+
+@test "type-registry: is_known_type accepts a built-in and rejects a bogus type" {
+  run env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_is_known_type opencode"
+  [ "$status" -eq 0 ]
+  run env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_is_known_type bogus-type"
+  [ "$status" -ne 0 ]
+}
+
+@test "type-registry: type_get reads keys and returns a default for a missing one" {
+  run env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_get codex template"
+  [ "$status" -eq 0 ]; [ "$output" = "cmd.codex.md" ]
+  run env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_get codex hooks_file"
+  [ "$output" = ".codex/hooks.json" ]
+  run env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_get codex cli"
+  [ "$output" = "codex" ]
+  run env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_get gemini missingkey FALLBACK"
+  [ "$output" = "FALLBACK" ]
+}
+
+@test "type-registry: spawnable set is exactly claude-code and codex" {
+  run env -i PATH="$PATH" bash -c \
+    "source '$SCRIPTS/lib/type-registry.sh'
+     while IFS= read -r t; do
+       [ -n \"\$t\" ] || continue
+       [ \"\$(agmsg_type_get \"\$t\" spawnable)\" = yes ] && echo \"\$t\"
+     done <<< \"\$(agmsg_known_types | sort -u)\" | paste -sd, -"
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude-code,codex" ]
+}
+
+@test "type-registry: detection manifests carry the expected env / proc keys" {
+  g() { env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_get $1 $2"; }
+  [ "$(g claude-code detect)" = "CLAUDE_CODE_SESSION_ID" ]
+  [ "$(g codex detect)" = "CODEX_SANDBOX CODEX_THREAD_ID" ]
+  [ "$(g gemini detect)" = "GEMINI_API_KEY GOOGLE_GEMINI_CLI" ]
+  [ "$(g antigravity detect)" = "explicit" ]
+  [ "$(g copilot detect)" = "explicit" ]
+  [ "$(g opencode detect_proc)" = "opencode opencode-*" ]
+}
+
+@test "type-registry: whoami detects codex end-to-end from CODEX_THREAD_ID" {
+  # Join a codex agent so whoami has a registration to report, then call it with
+  # no explicit type: detection must pick codex from the manifest's detect= key.
+  bash "$SCRIPTS/join.sh" myteam bob codex "$BATS_TEST_TMPDIR" >/dev/null
+  run env -i PATH="$PATH" CODEX_THREAD_ID=x bash "$SCRIPTS/whoami.sh" "$BATS_TEST_TMPDIR"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "type=codex"
+}
+
+@test "type-registry: env-detection precedence is claude-code < codex < gemini" {
+  # Reproduce whoami's manifest-driven env sweep (sorted order) and assert the
+  # historical precedence: a runtime's own session var beats the GEMINI_* family,
+  # and detect=explicit types never win.
+  sweep() {
+    env -i PATH="$PATH" "$@" bash -c "
+      source '$SCRIPTS/lib/type-registry.sh'
+      while IFS= read -r t; do
+        [ -n \"\$t\" ] || continue
+        d=\$(agmsg_type_get \"\$t\" detect)
+        if [ -z \"\$d\" ] || [ \"\$d\" = explicit ]; then continue; fi
+        for v in \$d; do [ -n \"\${!v:-}\" ] && { echo \"\$t\"; exit 0; }; done
+      done <<< \"\$(agmsg_known_types | sort -u)\"
+      echo claude-code"
+  }
+  [ "$(sweep CODEX_THREAD_ID=x)" = codex ]
+  [ "$(sweep GEMINI_API_KEY=x)" = gemini ]
+  [ "$(sweep CLAUDE_CODE_SESSION_ID=x CODEX_THREAD_ID=y)" = claude-code ]
+  [ "$(sweep CODEX_SANDBOX=x GEMINI_API_KEY=y)" = codex ]
+  [ "$(sweep)" = claude-code ]
+}
+
+@test "type-registry: manifests are DATA — never executed" {
+  # An adversarial value must be read as a literal string, not run.
+  local dir="$TEST_SKILL_DIR/types/evil"
+  mkdir -p "$dir"
+  printf 'name=evil\ncli=$(touch %s/PWNED)\n' "$BATS_TEST_TMPDIR" > "$dir/type.conf"
+  run env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_get evil cli"
+  [ "$status" -eq 0 ]
+  [ ! -e "$BATS_TEST_TMPDIR/PWNED" ]
+}
+
+@test "type-registry: type_get returns its default under set -e + pipefail" {
+  # A missing key must reach the default branch even when grep exits 1 under
+  # pipefail (regression: the assignment used to abort silently).
+  run bash -c "set -euo pipefail; source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_get gemini missingkey DEF; echo REACHED"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qx "DEF"
+  echo "$output" | grep -qx "REACHED"
+}
+
+@test "type-registry: detect_proc matching is independent of the caller's cwd" {
+  # Regression: `for p in \$pats` glob-expanded the patterns against cwd, so a
+  # project file like codex-helper made codex-* stop matching real codex procs.
+  # detect_cli_type runs the split under `set -f`; prove that makes it cwd-proof.
+  local proj="$BATS_TEST_TMPDIR/proj"; mkdir -p "$proj"; touch "$proj/codex-helper" "$proj/claude-x"
+  run env -i PATH="$PATH" bash -c "cd '$proj'
+    source '$SCRIPTS/lib/type-registry.sh'; set -f
+    pats=\$(agmsg_type_get codex detect_proc); m=no
+    for p in \$pats; do case codex-nightly in \$p) m=yes ;; esac; done
+    echo \$m"
+  [ "$output" = "yes" ]
+}
+
+@test "type-registry: whoami precedence — claude-code beats codex end-to-end" {
+  bash "$SCRIPTS/join.sh" t alice claude-code "$BATS_TEST_TMPDIR" >/dev/null
+  run env -i PATH="$PATH" CLAUDE_CODE_SESSION_ID=x CODEX_THREAD_ID=y bash "$SCRIPTS/whoami.sh" "$BATS_TEST_TMPDIR"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "type=claude-code"
+}
+
+@test "type-registry: refactored scripts hardcode no per-type branch" {
+  # join.sh and spawn.sh must be fully data-driven; whoami.sh is allowed only its
+  # default fallback (echo "claude-code"). Any other type literal on a non-comment
+  # line is a re-introduced per-type branch.
+  local types='claude-code|codex|gemini|antigravity|copilot|opencode'
+  for f in join.sh spawn.sh; do
+    run bash -c "sed 's/#.*//' '$SCRIPTS/$f' | grep -nE '$types' || true"
+    [ -z "$output" ] || { echo "hardcoded type literal in $f:"; echo "$output"; false; }
+  done
+  run bash -c "sed 's/#.*//' '$SCRIPTS/whoami.sh' | grep -nE '$types' | grep -vE 'echo \"claude-code\"' || true"
+  [ -z "$output" ] || { echo "unexpected type literal in whoami.sh:"; echo "$output"; false; }
+}
+
+@test "type-registry: node-launcher type resolves its spawn launcher file" {
+  write_node_launcher_fixtures
+  run env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_get nodetype spawn"
+  [ "$status" -eq 0 ]
+  [ "$output" = "nodetype-launcher.mjs" ]
+  run env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_dir nodetype"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  [ -f "$output/nodetype-launcher.mjs" ]
+}
+
+@test "type-registry: spawnable set (spawnable=yes OR non-empty spawn=) includes nodetype" {
+  write_node_launcher_fixtures
+  run env -i PATH="$PATH" bash -c \
+    "source '$SCRIPTS/lib/type-registry.sh'
+     while IFS= read -r t; do
+       [ -n \"\$t\" ] || continue
+       if [ \"\$(agmsg_type_get \"\$t\" spawnable)\" = yes ] || [ -n \"\$(agmsg_type_get \"\$t\" spawn)\" ]; then
+         echo \"\$t\"
+       fi
+     done <<< \"\$(agmsg_known_types | sort -u)\" | paste -sd, -"
+  [ "$status" -eq 0 ]
+  echo "$output" | tr ',' '\n' | grep -qx nodetype
+  echo "$output" | tr ',' '\n' | grep -qx claude-code
+  echo "$output" | tr ',' '\n' | grep -qx codex
+}
+
+@test "type-registry: alias reverse-resolves aliassrc to its owning type nodetype" {
+  write_node_launcher_fixtures
+  run env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_alias_for aliassrc"
+  [ "$status" -eq 0 ]
+  [ "$output" = "nodetype" ]
+}
+
+@test "spawn: a spawn= node-launcher type clears the spawnable gate" {
+  # Regression: the gate honoured only spawnable=yes while spawnable_types() also
+  # counts spawn=, so a node-launcher type (nodetype: spawn=, no spawnable=yes)
+  # was rejected as 'not supported' yet listed as supported. It must clear the
+  # gate (it then fails later for lack of a team/terminal — that's expected).
+  write_node_launcher_fixtures
+  run "$SCRIPTS/spawn.sh" nodetype someagent --project "$BATS_TEST_TMPDIR"
+  [ "$status" -ne 0 ]
+  ! echo "$output" | grep -q "is not supported by spawn yet"
+  ! echo "$output" | grep -q "unknown agent type"
+}

--- a/types/antigravity/type.conf
+++ b/types/antigravity/type.conf
@@ -1,0 +1,6 @@
+# agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
+name=antigravity
+template=cmd.antigravity.md
+detect=explicit
+hooks_file=.agent/rules/agmsg.md
+monitor=no

--- a/types/claude-code/type.conf
+++ b/types/claude-code/type.conf
@@ -1,0 +1,9 @@
+# agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
+name=claude-code
+template=cmd.claude-code.md
+cli=claude
+spawnable=yes
+detect=CLAUDE_CODE_SESSION_ID
+detect_proc=claude claude-code claude-*
+hooks_file=.claude/settings.local.json
+monitor=yes

--- a/types/codex/type.conf
+++ b/types/codex/type.conf
@@ -1,0 +1,9 @@
+# agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
+name=codex
+template=cmd.codex.md
+cli=codex
+spawnable=yes
+detect=CODEX_SANDBOX CODEX_THREAD_ID
+detect_proc=codex codex-*
+hooks_file=.codex/hooks.json
+monitor=no

--- a/types/copilot/type.conf
+++ b/types/copilot/type.conf
@@ -1,0 +1,6 @@
+# agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
+name=copilot
+template=cmd.copilot.md
+detect=explicit
+hooks_file=.github/hooks/agmsg.json
+monitor=no

--- a/types/gemini/type.conf
+++ b/types/gemini/type.conf
@@ -1,0 +1,7 @@
+# agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
+name=gemini
+template=cmd.gemini.md
+detect=GEMINI_API_KEY GOOGLE_GEMINI_CLI
+detect_proc=gemini gemini-*
+hooks_file=.agent/rules/agmsg.md
+monitor=no

--- a/types/opencode/type.conf
+++ b/types/opencode/type.conf
@@ -1,0 +1,6 @@
+# agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
+name=opencode
+template=cmd.opencode.md
+detect_proc=opencode opencode-*
+hooks_file=.opencode/rules/agmsg.md
+monitor=no


### PR DESCRIPTION
## Summary

Adding an agent type to agmsg is currently a hardcoded, multi-file edit. The most
recent addition — **OpenCode (#136)** — touched 8 files, adding per-type `case`
arms in `whoami.sh`, `join.sh`, `spawn.sh`, and `delivery.sh` plus a template and
docs. Every new type repeats that scatter, and the type list drifts between files.

This PR makes a type **data**: a small read-only manifest at
`types/<name>/type.conf` describes detection, the whitelist, spawn, and delivery
routing, and the scripts read it instead of hardcoded `case` arms. The six
existing types are converted with **zero behavior change** — the full suite stays
green (296 → 311 with the new registry tests).

## What changes

- **New** `scripts/lib/type-registry.sh` — discovery + a per-key reader.
  Manifests are read-only `key=value` **data**, **never `source`d** (a third-party
  type cannot execute code; an adversarial `cli=$(touch X)` is read as a literal).
- `types/{claude-code,codex,gemini,antigravity,copilot,opencode}/type.conf` — the
  six built-ins as manifests (`detect` / `detect_proc`, `cli` / `spawnable`,
  `hooks_file`, `monitor`, `template`).
- `whoami.sh` — detection reads `detect=` (env vars) and `detect_proc=` (process
  globs); sorted order preserves the claude-code < codex < gemini precedence.
- `join.sh` — the whitelist validates against the registry.
- `spawn.sh` — the spawnable set and launch binary come from the manifest; the
  error lists the computed spawnable set.
- `delivery.sh` — `resolve_hooks_file` reads `hooks_file=` (the per-type hook
  *format* in `apply_settings_*` is unchanged).
- `install.sh` / `tests/test_helper.bash` — ship/copy `types/`.
- `docs/agent-types.md` — the manifest schema + "adding a type = manifest +
  template".

## Adding a type, after this PR

Drop `types/<name>/type.conf` + `templates/cmd.<name>.md`. `whoami`, `join`, and
`spawn` pick it up with no further edits. (A genuinely new delivery hook *format*
still needs an `apply_settings_<name>`; reusing a format needs no code.)

## Extensible to external add-on types

Beyond built-in CLI types, a type can declare a **node launcher** so an agent
runtime ships **entirely outside the agmsg tree** and plugs in with no core edits:

- `spawn=<launcher>.mjs` — `spawn.sh` launches it via Node with four **universal**
  flags (`--name --team --project --initial-input`); all type-specific config is
  the launcher's own default/env, so core names no add-on.

Types are always selected **explicitly** (`spawn <type>`), so an add-on never
hijacks a built-in's spawn name.

### Real-world example

The node-launcher plug point is demonstrated by a real, separately-released add-on:

- **Add-on:** [`lucianlamp/agmsg-codex-app-server`](https://github.com/lucianlamp/agmsg-codex-app-server)
  — a Codex runtime (app-server + host-managed turn-trigger watcher + a
  scroll-region TUI) that installs **on top of** a stock agmsg purely via the
  registry (a `types/codex-app-server/` manifest with `spawn=`), touching no
  built-in; spawned explicitly as `spawn codex-app-server <name>`.
- **Reference fork (this branch):** [`lucianlamp/agmsg`](https://github.com/lucianlamp/agmsg)
  — a stock install of this PR with the add-on dropped on top.

The add-on lives in its own repo and is **not** part of this PR — it is only the
proof that the mechanism hosts external types cleanly.

## Testing

- Full existing suite green and behavior-unchanged for the built-ins (296/296).
- New `tests/test_type_registry.bats`: discovery, the key reader + default,
  detection-manifest values + precedence + end-to-end via `whoami.sh`, the
  spawnable set, the node-launcher (`spawn=`) plug point (an in-tree fixture, so
  the mechanism is not dead code), a no-hardcoded-type-name guard, and a guard
  that manifests are data (the adversarial `$(touch …)` runs nothing). 311/311.
- End-to-end: the linked add-on installs onto a stock build of this branch and
  `spawn codex-app-server` produces a boot command that runs its Node launcher
  with the universal flags.

## Scope / non-goals

- No new built-in types, runtimes, or delivery semantics — only the routing
  *source* changes (case → manifest).
- The per-type delivery hook *format* code (`apply_settings_*`) is unchanged.
- The codex-app-server add-on is external and out of scope here.
