### PR TITLE
feat(check-inbox): add watermark to prevent stale message re-delivery

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,172 +1,148 @@
 ---
-name: agmsg
-description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
+name: agmsgcrm
+description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
 ---
 
-# Agent Messaging
+Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER directly read or edit config files, DB, or team data. There is NO register.sh — use join.sh to join a team.**
 
-**IMPORTANT: Always use the provided scripts. NEVER directly read or edit config files, DB, or team data. There is NO register.sh — use join.sh to join a team.**
+## Identity
 
-## How to use
+If you already know your AGENT and TEAMS from a previous `$agmsgcrm` call in this session, skip to **Execute** below.
 
-### Step 0: First-run bootstrap
+Otherwise, run: `~/.agents/skills/agmsgcrm/scripts/whoami.sh "$(pwd)" codex`
 
-agmsg keeps its SQLite database, team registry, and runtime state under `~/.agents/skills/agmsg/`. The `./install.sh` install path creates that tree; the Claude Code plugin install path does not (the plugin marketplace flow only drops the skill content into `~/.claude/plugins/cache/`). Before any other command, bootstrap if needed:
+Four possible outputs:
 
-```bash
-if [ ! -d ~/.agents/skills/agmsg ]; then
-  # Locate the plugin install script (any version), run it once.
-  installer=$(ls ~/.claude/plugins/cache/fujibee-agmsg/agmsg/*/install.sh 2>/dev/null | head -1)
-  if [ -n "$installer" ]; then
-    bash "$installer" --cmd agmsg
-  else
-    echo "agmsg not installed. Either:" >&2
-    echo "  - run ./install.sh in the agmsg repo, or" >&2
-    echo "  - install via /plugin marketplace add fujibee/agmsg && /plugin install agmsg@fujibee-agmsg" >&2
-    exit 1
-  fi
-fi
-```
+**A) Single identity:**
+`agent=<name> teams=<t1,t2,...> type=codex project=<path>`
+→ Remember AGENT and TEAMS, then go to **Execute**.
 
-After this runs once, `~/.agents/skills/agmsg/` is populated and you can skip Step 0 on future invocations.
+**B) Multiple identities:**
+`multiple=true agents=<n1,n2,...> teams=<t1,t2,...> type=codex project=<path>`
+→ Ask the user which agent name to use for this session, then go to **Execute**.
 
-### Step 1: Check identity
+**C) Not in a team:**
+`not_joined=true available_teams=<t1,t2,...>` (or `available_teams=none`)
+→ Show the user the available teams from the output, then:
 
-```bash
-~/.agents/skills/agmsg/scripts/whoami.sh "$(pwd)" <type>
-# type: claude-code, codex, gemini, antigravity, copilot
-# Returns: agent=... / multiple=true ... / suggest=true ... / not_joined=true ...
-```
+  > **First-time setup required.**
+  > Joining a team so this agent can send and receive messages.
+  > - **Team name**: a group of agents that can message each other (available: <list from output>)
+  > - **Agent name**: this agent's identity within the team
 
-### Step 2a: If not in a team — join one
+  1. Ask: "Enter a team name (joins existing or creates new)"
+  2. Ask: "Enter a name for this agent"
+  3. **You MUST use join.sh** — run: `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <agent_name> codex "$(pwd)"`
+  4. Show the result and explain:
 
-Ask the user for a team name and agent name, then run:
+  > **Joined!** You can now use `$agmsgcrm` to check and send messages.
+  > - `$agmsgcrm` — check inbox
+  > - `$agmsgcrm send <agent> <message>` — send a message
+  > - `$agmsgcrm team` — list team members
+  > - `$agmsgcrm history` — message history
 
-```bash
-~/.agents/skills/agmsg/scripts/join.sh <team> <agent_name> <type> "$(pwd)"
-```
+  5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
-Do NOT manually edit config files. Always use join.sh.
+     ```
+     Choose delivery mode for incoming messages:
 
-### Step 2b: If already in a team — execute command
+       1) turn — Check inbox at the end of each assistant turn
+                  Stop hook pulls after each response.
 
-**Default (no arguments): IMMEDIATELY check inbox. Do NOT ask what to do.**
+       2) off  — No automatic delivery
+                  Manual $agmsgcrm only.
 
-```bash
-# Check inbox (marks messages as read) — DEFAULT action
-~/.agents/skills/agmsg/scripts/inbox.sh <team> <agent_id>
+     [1]:
+     ```
 
-# Send a message
-~/.agents/skills/agmsg/scripts/send.sh <team> <from_agent> <to_agent> "<message>"
+     - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
+     - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
+       `~/.agents/skills/agmsgcrm/scripts/delivery.sh set <mode> codex "$(pwd)"`
+     - Codex has no Monitor tool, so `monitor` and `both` modes are not offered here.
 
-# Message history
-~/.agents/skills/agmsg/scripts/history.sh <team> [agent_id] [limit]
+  6. Then check inbox for the newly joined team.
 
-# List team members
-~/.agents/skills/agmsg/scripts/team.sh <team>
+**D) Suggestions for reuse:**
+`suggest=true agents=<n1,n2,...> teams=<t1,t2,...> type=codex project=<path> available_teams=<t1,t2,...>`
+→ No exact registration exists for this project, but there are same-type agent names registered elsewhere.
 
-# Leave a team
-~/.agents/skills/agmsg/scripts/leave.sh <team> <agent_id>
+  1. Show the suggested agent names to the user.
+  2. Ask whether to reuse one of those names or choose a new one.
+  3. Ask for the team name to join (existing or new).
+  4. Run: `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <agent_name> codex "$(pwd)"`
+  5. Then continue with the normal post-join flow above.
 
-# Rename a team (moves dir, updates config + messages).
-# After renaming, each existing member should re-run whoami.sh to refresh
-# their cached team name in any running session.
-~/.agents/skills/agmsg/scripts/rename-team.sh <old_team> <new_team>
+## Execute
 
-# Show the installed version — the git-describe provenance string recorded at
-# install time (tag + commits-since + abbreviated commit, plus -dirty when
-# installed from a tree with uncommitted changes). See #117.
-~/.agents/skills/agmsg/scripts/version.sh
+**Only use scripts in `~/.agents/skills/agmsgcrm/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
 
-# Clear registrations for the current project/type.
-# A trailing <session_id> additionally releases any actas exclusivity locks
-# this session held on <agent_id> so peers can pick them up immediately.
-~/.agents/skills/agmsg/scripts/reset.sh "$(pwd)" <type> [agent_id] [session_id]
+**If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
+1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/agmsgcrm/scripts/inbox.sh $TEAM $AGENT`
+2. Do NOT ask the user what to do — just run the inbox check.
+3. If there are messages, read and respond appropriately. To reply:
+   `~/.agents/skills/agmsgcrm/scripts/msg.sh <to_agent> "<message>"`
 
-# Set delivery mode for this project. Replaces the legacy hook.sh on/off,
-# which is kept as a deprecated alias only.
-#   monitor — real-time push via SessionStart + Monitor tool (claude-code only)
-#   turn    — Stop-hook pulls at the end of each assistant turn
-#   both    — monitor primary, turn as fallback
-#   off     — no automatic delivery
-~/.agents/skills/agmsg/scripts/delivery.sh set <mode> <type> "$(pwd)"
-~/.agents/skills/agmsg/scripts/delivery.sh status <type> "$(pwd)"
+If argument is "history":
+1. Run: `~/.agents/skills/agmsgcrm/scripts/history.sh $TEAM $AGENT`
 
-# Multiple roles per project (one CC = one active role).
-# Claude Code: `actas` claims an exclusivity lock for <name> across sessions
-# and restarts the Monitor filtered to <name> only; peer watchers stop
-# subscribing to <name> while this session holds the lock. `drop` releases.
-# Codex: actas is send-side only (no stable session_id during slash commands
-# → no peer-visible lock). See README "Codex caveat" for details.
-~/.agents/skills/agmsg/scripts/actas-claim.sh "$(pwd)" <type> <name> "$session_id"
-~/.agents/skills/agmsg/scripts/reset.sh "$(pwd)" <type> <name> "$session_id"
+If argument is "team":
+1. For each TEAM, run: `~/.agents/skills/agmsgcrm/scripts/team.sh $TEAM`
 
-# (Both of the above are normally driven by `/agmsg actas <name>` and
-#  `/agmsg drop <name>` slash commands, which also handle the Monitor
-#  TaskStop + relaunch dance described in the cmd template.)
+If argument starts with "send" (e.g. "send misaki check the server"):
+1. Parse target agent and message from the arguments
+2. Run: `~/.agents/skills/agmsgcrm/scripts/msg.sh <to_agent> "<message>"`
+   msg.sh auto-resolves team and from-agent. Do NOT use send.sh directly — its 4-positional-arg interface is error-prone.
 
-# Spawn a NEW agent process that takes an actas identity on boot.
-# Pre-joins <name> to a team, then launches the agent CLI in a tmux pane/window
-# (when run inside tmux) or a new OS terminal, with `/agmsg actas <name>` as the
-# initial prompt. By default it BLOCKS until the new agent's watcher attaches
-# (prints `status=ready`), so a leader can send work right after spawn returns
-# without losing it to the agent's cold start. claude-code/codex only; macOS
-# primary, Linux/Windows best-effort. Non-tmux + no usable terminal (headless)
-# errors out.
-#   --project <path>     project to launch in (default: $PWD)
-#   --team <team>        team to join into (default: auto-resolved from project)
-#   --window             new tmux window instead of splitting the current one
-#   --split h|v          tmux split direction (default h)
-#   --terminal <tmpl>    terminal command template ({cmd} = path to the boot
-#                        script) for the non-tmux path; overrides $AGMSG_TERMINAL
-#                        / config spawn.terminal. macOS default uses `open -a`
-#                        (no Automation/TCC permission prompt).
-#   --no-wait            don't block on readiness (fire-and-forget)
-#   --ready-timeout N    seconds to wait for readiness (default 90; on timeout
-#                        prints status=timeout and exits 3). Codex skips the
-#                        wait (it has no Monitor).
-~/.agents/skills/agmsg/scripts/spawn.sh <claude-code|codex> <name> [options]
+If argument is "config":
+1. Run: `~/.agents/skills/agmsgcrm/scripts/config.sh show`
+2. Show the output to the user.
 
-# Tear down a spawned member — the inverse of spawn.
-# Default (graceful): sends a `ctrl:despawn` control message to <name>; the
-# member's watcher drops its own role (releasing the actas lock + registration)
-# and closes its own tmux pane, ending the agent. Blocks until the lock releases
-# (--timeout, default 30s) then prints `status=ok`; on timeout prints
-# status=timeout and exits 3 (retry with --force). Only an exclusive watcher
-# dedicated to <name> acts on it — the despawning session is never torn down.
-# --force: skip the message and tear the member down from the placement recorded
-# at spawn time (kill its tmux pane/window, drop its registration) — for a dead
-# watcher or a codex member (no Monitor). A hand-started member with no placement
-# record can't be --forced.
-#   --force              tear down from the recorded placement, no message
-#   --timeout N          seconds to wait for graceful teardown (default 30)
-~/.agents/skills/agmsg/scripts/despawn.sh <team> <from> <name> [--force] [--timeout N]
-```
+If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
+1. Parse key and value from the arguments.
+2. Run: `~/.agents/skills/agmsgcrm/scripts/config.sh set <key> <value>`
 
-## Sandbox compatibility (Claude Code)
 
-When Claude Code's sandbox is enabled, `watch.sh` (monitor mode) runs inside the sandbox and needs to write pidfiles and SQLite WAL files under `~/.agents/skills/agmsg/`. Add an allowlist entry to `~/.claude/settings.json` (or project-level `.claude/settings.local.json`):
+If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
+1. Parse the new role name.
+2. Run `~/.agents/skills/agmsgcrm/scripts/identities.sh "$(pwd)" codex` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <name> codex "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
+4. Set the session's active FROM to `<name>`. Use `msg.sh --from <name>` for sends until another `actas`.
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Codex has no Monitor tool, so receive still covers all of your registered roles in this project.)"
 
-```json
-{
-  "sandbox": {
-    "filesystem": {
-      "allowWrite": [
-        "~/.agents/skills/agmsg/"
-      ]
-    }
-  }
-}
-```
+If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
+1. Parse the role name.
+2. Run `~/.agents/skills/agmsgcrm/scripts/reset.sh "$(pwd)" codex <name>` to remove that role's registration.
+3. If the session's active FROM was `<name>`, clear that state.
+4. Tell the user: "Dropped role `<name>` from this project."
 
-The allowlist merges across scopes and takes effect immediately — no restart needed. If agmsg was installed under a custom command name (e.g. `m`), adjust the path accordingly.
+If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex reviewer --window"):
+1. Parse `<type>` (must be `claude-code` or `codex`), `<name>`, and any options (`--project`, `--team`, `--window`, `--split h|v`, `--terminal`, `--no-wait`, `--ready-timeout <secs>`).
+2. Run: `~/.agents/skills/agmsgcrm/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
+   - spawn.sh pre-joins `<name>`, then opens a tmux pane/window (when this session is inside tmux) or a new OS terminal, and launches the target CLI with `/agmsgcrm actas <name>` as its initial prompt.
+   - By default it BLOCKS until a spawned claude-code agent's watcher attaches (`status=ready`); `status=timeout` + exit 3 if not ready within `--ready-timeout` (default 90s). `--no-wait` for fire-and-forget. Spawning a codex agent skips the wait (codex has no Monitor).
+   - It refuses early if `<name>` is already held by another live session, if the target CLI is not installed, or if there is no tmux and no usable terminal (headless).
+3. Show the script's output.
 
-**Note on `BASH_SOURCE`**: The sandboxed Bash tool runs commands via pipe/eval, so `BASH_SOURCE[0]` is empty inside sourced functions like `storage.sh`. This is handled internally — `watch.sh` resolves `SKILL_DIR` from `$0` (which works correctly when invoked as a command), and `storage.sh` falls back to that value. No user configuration needed.
+If argument is "mode" (no further args):
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh status codex "$(pwd)"`
+2. Show the output to the user.
 
-## Architecture
+If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
+1. Parse the mode. Codex supports only `turn` and `off` — reject `monitor` and `both` with: "Codex has no Monitor tool; only `turn` or `off` modes are supported."
+2. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set <mode> codex "$(pwd)"`
 
-- **Storage**: SQLite with WAL mode in `~/.agents/skills/agmsg/db/messages.db`
-- **Teams**: `~/.agents/skills/agmsg/teams/<name>/config.json`
-- **Concurrency**: WAL allows multiple readers + 1 writer without conflicts
-- **No daemon**: Direct DB access via `sqlite3` CLI
-- **Dependencies**: bash, sqlite3 (no python3 required)
+If argument is "hook on" (legacy alias):
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set turn codex "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior)."
+
+If argument is "hook off" (legacy alias):
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set off codex "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'off'."
+
+If argument is "version":
+1. Run: `~/.agents/skills/agmsgcrm/scripts/version.sh`
+2. Show the output — the installed version (git-describe provenance recorded at install time).
+
+If argument is "reset":
+1. Run: `~/.agents/skills/agmsgcrm/scripts/reset.sh "$(pwd)" codex`
+2. Tell the user the result.

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -67,6 +67,8 @@ if [ -z "$AGENT" ] || [ -z "$TEAMS" ]; then
   exit 0
 fi
 
+WATERMARK_FILE="$SKILL_DIR/run/check-inbox.$AGENT.watermark"
+
 # Cooldown check. The marker is hook runtime state, not message storage, so it
 # lives in the skill's run dir — independent of AGMSG_STORAGE_PATH. Keeping it
 # out of the store means an overridden/sandboxed store still gets delivery even
@@ -107,6 +109,29 @@ touch "$MARKER"
 DB="$(agmsg_db_path)"
 if [ ! -f "$DB" ]; then exit 0; fi
 
+# Watermark: deliver only messages newer than the last delivered id, preventing
+# old unread messages from being replayed on every check (mirrors watch.sh).
+persist_check_watermark() { printf '%s\n' "$WATERMARK" > "$WATERMARK_FILE" 2>/dev/null || true; }
+
+WATERMARK=""
+if [ -f "$WATERMARK_FILE" ]; then
+  WATERMARK="$(cat "$WATERMARK_FILE" 2>/dev/null || true)"
+  case "$WATERMARK" in ''|*[!0-9]*) WATERMARK="" ;; esac
+fi
+if [ -z "$WATERMARK" ]; then
+  WATERMARK="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages;" 2>/dev/null || echo 0)"
+  case "$WATERMARK" in ''|*[!0-9]*) WATERMARK=0 ;; esac
+  persist_check_watermark
+else
+  DB_MAX="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages;" 2>/dev/null || echo 0)"
+  case "$DB_MAX" in ''|*[!0-9]*) DB_MAX=0 ;; esac
+  if [ "$DB_MAX" -lt "$WATERMARK" ]; then
+    WATERMARK="$DB_MAX"
+    persist_check_watermark
+  fi
+fi
+
+LOOP_WM=$WATERMARK
 OUTPUT=""
 IFS=',' read -ra TEAM_LIST <<< "$TEAMS"
 for team in "${TEAM_LIST[@]}"; do
@@ -128,7 +153,7 @@ for team in "${TEAM_LIST[@]}"; do
 
   RESULT=$(agmsg_sqlite "$DB" "
     SELECT from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
-    FROM messages WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL
+    FROM messages WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL AND id > $LOOP_WM
     ORDER BY created_at ASC;
   ")
   if [ -n "$RESULT" ]; then
@@ -139,9 +164,17 @@ for team in "${TEAM_LIST[@]}"; do
     done <<< "$RESULT"
     OUTPUT+=$'\n'
     # Mark as read
-    agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
+    agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL AND id > $LOOP_WM;" 2>/dev/null || true
   fi
 done
+
+# Advance watermark once across all teams after the loop.
+NEW_WM="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE to_agent='$AGENT' AND id > $LOOP_WM;" 2>/dev/null || echo 0)"
+case "$NEW_WM" in ''|*[!0-9]*) NEW_WM=0 ;; esac
+if [ "$NEW_WM" -gt "$WATERMARK" ]; then
+  WATERMARK="$NEW_WM"
+  persist_check_watermark
+fi
 
 # No new messages
 if [ -z "$OUTPUT" ]; then

--- a/scripts/msg.sh
+++ b/scripts/msg.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# msg.sh — simplified message sender (auto-resolves team and from).
+#
+# Usage:
+#   msg.sh <to> <message>
+#   msg.sh --from <name> <to> <message>
+#   msg.sh --channel <channel> <message>
+#   msg.sh --type <type> <to> <message>
+#   msg.sh --project <path> <to> <message>
+#
+# Eliminates the 4-positional-arg footgun of send.sh by resolving team
+# and from-agent automatically from the project directory, agent type,
+# and actas lock state.
+#
+# For REGISTERED agents only. Service identities (e.g. GM, gm-auto)
+# that are not in teams/*/config.json must use send.sh directly.
+
+MODE="direct"
+PROJECT_PATH=""
+AGENT_TYPE=""
+FROM_OVERRIDE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project)  PROJECT_PATH="$2"; shift 2 ;;
+    --type)     AGENT_TYPE="$2"; shift 2 ;;
+    --from)     FROM_OVERRIDE="$2"; shift 2 ;;
+    --channel)  MODE="channel"; shift ;;
+    --)         shift; break ;;
+    -*)         echo "Error: unknown flag '$1'" >&2
+                echo "Usage: msg.sh [--from <name>] [--type <type>] [--project <path>] [--channel] <to> <message>" >&2
+                exit 1 ;;
+    *)          break ;;
+  esac
+done
+
+TO="${1:?Usage: msg.sh <to> \"<message>\"}"
+MESSAGE="${2:?Missing message body. Usage: msg.sh <to> \"<message>\"}"
+
+if [ $# -gt 2 ]; then
+  echo "Error: too many positional arguments ($# given, expected 2)." >&2
+  echo "The message must be quoted as a single argument." >&2
+  echo "  msg.sh $TO \"your message here\"" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export SKILL_DIR
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"
+
+[ -z "$PROJECT_PATH" ] && PROJECT_PATH="$(pwd)"
+
+# --- Auto-detect agent type ---
+DETECTED_TYPE=""
+if [ -z "$AGENT_TYPE" ]; then
+  if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+    DETECTED_TYPE="claude-code"
+  elif [ -n "${CODEX_SANDBOX:-}" ] || [ -n "${CODEX_THREAD_ID:-}" ]; then
+    DETECTED_TYPE="codex"
+  elif [ -n "${GOOGLE_GEMINI_CLI:-}" ]; then
+    DETECTED_TYPE="gemini"
+  else
+    DETECTED_TYPE="claude-code"
+  fi
+  AGENT_TYPE="$DETECTED_TYPE"
+fi
+
+PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
+
+# --- Resolve identity ---
+PAIRS="$("$SCRIPT_DIR/identities.sh" "$PROJECT_PATH" "$AGENT_TYPE" 2>/dev/null || true)"
+
+# Fallback: if auto-detected type finds nothing, try all known types
+if [ -z "$PAIRS" ] && [ -n "$DETECTED_TYPE" ]; then
+  for try_type in claude-code codex antigravity gemini copilot; do
+    [ "$try_type" = "$DETECTED_TYPE" ] && continue
+    PAIRS="$("$SCRIPT_DIR/identities.sh" "$PROJECT_PATH" "$try_type" 2>/dev/null || true)"
+    if [ -n "$PAIRS" ]; then
+      AGENT_TYPE="$try_type"
+      break
+    fi
+  done
+fi
+
+if [ -z "$PAIRS" ]; then
+  echo "Error: no identity found for this project." >&2
+  echo "Run whoami.sh first, then join.sh to register." >&2
+  exit 1
+fi
+
+TEAM=""
+FROM=""
+TEAMS_DIR="$SCRIPT_DIR/../teams"
+
+# Helper: check if an agent name is a member of a team's config.
+_is_team_member() {
+  local team="$1" name="$2" config
+  config="$TEAMS_DIR/$team/config.json"
+  [ -f "$config" ] || return 1
+  local found
+  found=$(sqlite3 :memory: ".param set :json '$(sed "s/'/''/g" "$config")'" \
+    "SELECT 1 FROM json_each(json_extract(:json, '\$.agents')) WHERE key='$name' LIMIT 1;" 2>/dev/null | tr -d '\r')
+  [ -n "$found" ]
+}
+
+# Helper: list members of a team.
+_team_members() {
+  local team="$1" config
+  config="$TEAMS_DIR/$team/config.json"
+  [ -f "$config" ] || return 0
+  sqlite3 :memory: ".param set :json '$(sed "s/'/''/g" "$config")'" \
+    "SELECT key FROM json_each(json_extract(:json, '\$.agents'));" 2>/dev/null | tr -d '\r'
+}
+
+# --from override: find the team where both FROM and TO coexist
+if [ -n "$FROM_OVERRIDE" ]; then
+  FROM_TEAMS=""
+  while IFS=$'\t' read -r _team _agent; do
+    [ -z "$_team" ] && continue
+    [ "$_agent" = "$FROM_OVERRIDE" ] && FROM_TEAMS="${FROM_TEAMS:+$FROM_TEAMS$'\n'}$_team"
+  done <<< "$PAIRS"
+  if [ -z "$FROM_TEAMS" ]; then
+    echo "Error: --from '$FROM_OVERRIDE' is not registered in any team for this project." >&2
+    echo "Registered agents: $(printf '%s\n' "$PAIRS" | cut -f2 | paste -sd, -)" >&2
+    echo "Service identities (GM, gm-auto, etc.) must use send.sh directly." >&2
+    exit 1
+  fi
+  FROM="$FROM_OVERRIDE"
+  TEAM=$(printf '%s\n' "$FROM_TEAMS" | head -1)
+else
+  AGENT_COUNT=$(printf '%s\n' "$PAIRS" | cut -f2 | sort -u | wc -l | tr -d ' ')
+
+  if [ "$AGENT_COUNT" -eq 1 ]; then
+    TEAM=$(printf '%s\n' "$PAIRS" | head -1 | cut -f1)
+    FROM=$(printf '%s\n' "$PAIRS" | head -1 | cut -f2)
+  else
+    # Multiple identities — find the one locked to this session via actas
+    SESSION_ID="${CLAUDE_CODE_SESSION_ID:-${CODEX_THREAD_ID:-}}"
+    FOUND=""
+    if [ -n "$SESSION_ID" ]; then
+      # shellcheck disable=SC1091
+      source "$SCRIPT_DIR/lib/actas-lock.sh"
+      while IFS=$'\t' read -r _team _agent; do
+        [ -z "$_team" ] && continue
+        state=$(actas_lock_state "$_team" "$_agent" "$SESSION_ID" 2>/dev/null || echo "free")
+        if [ "$state" = "mine" ]; then
+          FOUND="${_team}	${_agent}"
+          break
+        fi
+      done <<< "$PAIRS"
+    fi
+    if [ -n "$FOUND" ]; then
+      TEAM=$(printf '%s' "$FOUND" | cut -f1)
+      FROM=$(printf '%s' "$FOUND" | cut -f2)
+    else
+      echo "Error: multiple identities registered — cannot auto-resolve sender." >&2
+      echo "Registered: $(printf '%s\n' "$PAIRS" | cut -f2 | paste -sd, -)" >&2
+      echo "Use: msg.sh --from <your_name> $TO \"...\"" >&2
+      exit 1
+    fi
+  fi
+fi
+
+# --- Unified TO cross-resolution (direct mode only) ---
+# Collects all teams where FROM is registered, then picks the one where
+# TO is also a member. Handles single-team, multi-team, --from, and
+# actas branches uniformly.
+if [ "$MODE" = "direct" ] && [ -n "$FROM" ]; then
+  ALL_FROM_TEAMS=""
+  while IFS=$'\t' read -r _team _agent; do
+    [ -z "$_team" ] && continue
+    [ "$_agent" = "$FROM" ] && ALL_FROM_TEAMS="${ALL_FROM_TEAMS:+$ALL_FROM_TEAMS$'\n'}$_team"
+  done <<< "$PAIRS"
+
+  MATCHED_TEAM=""
+  MATCHED_COUNT=0
+  while IFS= read -r _try_team; do
+    [ -z "$_try_team" ] && continue
+    if _is_team_member "$_try_team" "$TO"; then
+      MATCHED_TEAM="$_try_team"
+      MATCHED_COUNT=$((MATCHED_COUNT + 1))
+    fi
+  done <<< "$ALL_FROM_TEAMS"
+
+  case "$MATCHED_COUNT" in
+    0)
+      _members=$(_team_members "$TEAM")
+      echo "Error: '$TO' is not a member of any team where '$FROM' is registered." >&2
+      if [ -n "$_members" ]; then
+        echo "Members of $TEAM: $(printf '%s\n' "$_members" | paste -sd, -)" >&2
+      fi
+      exit 1
+      ;;
+    1) TEAM="$MATCHED_TEAM" ;;
+    *)
+      echo "Error: '$FROM' and '$TO' share multiple teams. Ambiguous." >&2
+      exit 1
+      ;;
+  esac
+fi
+
+# --- Delegate to send.sh ---
+if [ "$MODE" = "channel" ]; then
+  exec "$SCRIPT_DIR/send.sh" --channel "$TEAM" "$FROM" "$TO" "$MESSAGE"
+else
+  exec "$SCRIPT_DIR/send.sh" "$TEAM" "$FROM" "$TO" "$MESSAGE"
+fi

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -1,30 +1,187 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: send.sh <team> <from> <to> <message>
+# Usage:
+#   send.sh <team> <from> <to> <message>
+#   send.sh --channel <team> <from> <channel> <message>
 
-TEAM="${1:?Usage: send.sh <team> <from> <to> <message>}"
+MODE="direct"
+if [ "${1:-}" = "--channel" ]; then
+  MODE="channel"
+  shift
+fi
+
+TEAM="${1:?Usage: send.sh [--channel] <team> <from> <to|channel> <message>}"
 FROM="${2:?Missing from agent}"
-TO="${3:?Missing to agent}"
+TO="${3:?Missing to agent or channel}"
 BODY="${4:?Missing message body}"
+
+if [ $# -gt 4 ]; then
+  echo "Error: too many arguments ($# given, expected 4 after flags)." >&2
+  echo "  The message must be a single quoted argument." >&2
+  echo "  send.sh <team> <from> <to> \"your message here\"" >&2
+  echo "  Simpler:  msg.sh <to> \"<message>\"" >&2
+  exit 1
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 DB="$(agmsg_db_path)"
 
-[ -f "$DB" ] || bash "$SCRIPT_DIR/init-db.sh" >/dev/null
+# --- Argument validation (catch common swap/misuse errors) ---
+TEAMS_DIR="$SCRIPT_DIR/../teams"
 
-INSERT="INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$TEAM', '$FROM', '$TO', '$(echo "$BODY" | sed "s/'/''/g")');"
+_smells_like_path() { case "$1" in */*|*\\*) return 0 ;; esac; return 1; }
+_smells_like_session_id() {
+  case "$1" in
+    ????????-????-????-????-????????????) return 0 ;;
+  esac
+  return 1
+}
 
-# Retry once after ensuring the schema. Under a concurrent first-write fan-out
-# (leader → N members against a fresh/override store), one process can see the
-# DB file exist before the winning initializer has finished creating the table,
-# so its INSERT would hit "no such table". init-db.sh is idempotent + uses the
-# busy_timeout, so re-running it waits for the schema, then the INSERT lands.
-# See #114.
-if ! agmsg_sqlite "$DB" "$INSERT" 2>/dev/null; then
-  bash "$SCRIPT_DIR/init-db.sh" >/dev/null
-  agmsg_sqlite "$DB" "$INSERT"
+if [ ! -d "$TEAMS_DIR/$TEAM" ]; then
+  echo "Error: team '$TEAM' does not exist." >&2
+  if _smells_like_session_id "$TEAM" || _smells_like_path "$TEAM"; then
+    echo "  It looks like a session ID or path was passed as the team name." >&2
+    echo "  Arguments may be in the wrong order." >&2
+  fi
+  echo "" >&2
+  echo "  Correct:  send.sh <team> <from> <to> <message>" >&2
+  echo "    arg 1 = team name    (e.g. crm_lab)" >&2
+  echo "    arg 2 = your name    (e.g. kanbei-claude)" >&2
+  echo "    arg 3 = recipient    (e.g. kindaichi)" >&2
+  echo "    arg 4 = message text (quoted)" >&2
+  if [ -d "$TEAMS_DIR" ]; then
+    available=$(ls -1 "$TEAMS_DIR" 2>/dev/null | paste -sd, -)
+    [ -n "$available" ] && echo "  Available teams: $available" >&2
+  fi
+  echo "" >&2
+  echo "  Simpler:  msg.sh <to> <message>  (auto-resolves team and from)" >&2
+  exit 1
 fi
 
-echo "Sent to $TO in team $TEAM"
+_smells_like_agent_type() {
+  case "$1" in
+    claude-code|codex|antigravity|gemini|copilot) return 0 ;;
+  esac
+  return 1
+}
+
+if _smells_like_path "$FROM" || _smells_like_session_id "$FROM"; then
+  echo "Error: from-agent '$FROM' looks like a path or session ID." >&2
+  echo "  Arg 2 must be your agent name, not a path." >&2
+  echo "  Simpler:  msg.sh <to> <message>" >&2
+  exit 1
+fi
+
+if _smells_like_agent_type "$FROM"; then
+  echo "Error: from-agent '$FROM' is an agent type, not an agent name." >&2
+  echo "  Arg 2 must be your identity (e.g. kanbei-claude), not the CLI type." >&2
+  echo "  Simpler:  msg.sh <to> <message>" >&2
+  exit 1
+fi
+
+if _smells_like_path "$TO" || _smells_like_session_id "$TO"; then
+  echo "Error: to-agent '$TO' looks like a path or session ID." >&2
+  echo "  Arg 3 must be the recipient agent name, not a path." >&2
+  echo "  Simpler:  msg.sh <to> <message>" >&2
+  exit 1
+fi
+
+# In direct mode, verify TO is a registered member of the team.
+# Channel mode validates recipients via resolve-channel-members.sh instead.
+if [ "$MODE" = "direct" ]; then
+  CONFIG="$TEAMS_DIR/$TEAM/config.json"
+  if [ -f "$CONFIG" ]; then
+    _to_esc=$(printf '%s' "$TO" | sed "s/'/''/g")
+    _to_registered=$(sqlite3 :memory: \
+      ".param set :json '$(sed "s/'/''/g" "$CONFIG")'" \
+      "SELECT 1 FROM json_each(json_extract(:json, '\$.agents')) WHERE key='$_to_esc' LIMIT 1;" \
+      2>/dev/null | tr -d '\r')
+    if [ -z "$_to_registered" ]; then
+      _members=$(sqlite3 :memory: \
+        ".param set :json '$(sed "s/'/''/g" "$CONFIG")'" \
+        "SELECT key FROM json_each(json_extract(:json, '\$.agents'));" \
+        2>/dev/null | tr -d '\r')
+      echo "Error: to-agent '$TO' is not a member of team '$TEAM'." >&2
+      if [ -n "$_members" ]; then
+        echo "  Members: $(printf '%s\n' "$_members" | paste -sd, -)" >&2
+      fi
+      echo "  Simpler:  msg.sh <to> <message>" >&2
+      exit 1
+    fi
+  fi
+fi
+
+[ -f "$DB" ] || bash "$SCRIPT_DIR/init-db.sh" >/dev/null
+
+sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+if [ "$MODE" = "direct" ]; then
+  INSERT="INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$(sql_escape "$TEAM")', '$(sql_escape "$FROM")', '$(sql_escape "$TO")', '$(sql_escape "$BODY")');"
+
+  # Retry once after ensuring the schema. Under a concurrent first-write fan-out
+  # (leader → N members against a fresh/override store), one process can see the
+  # DB file exist before the winning initializer has finished creating the table,
+  # so its INSERT would hit "no such table". init-db.sh is idempotent + uses the
+  # busy_timeout, so re-running it waits for the schema, then the INSERT lands.
+  # See #114.
+  if ! agmsg_sqlite "$DB" "$INSERT" 2>/dev/null; then
+    bash "$SCRIPT_DIR/init-db.sh" >/dev/null
+    agmsg_sqlite "$DB" "$INSERT"
+  fi
+
+  echo "Sent to $TO in team $TEAM"
+  exit 0
+fi
+
+CHANNEL="$TO"
+bash "$SCRIPT_DIR/init-db.sh" >/dev/null
+CHANNEL_ADDR="@channel"
+TEAM_ESC=$(sql_escape "$TEAM")
+FROM_ESC=$(sql_escape "$FROM")
+CHANNEL_ESC=$(sql_escape "$CHANNEL")
+BODY_ESC=$(sql_escape "$BODY")
+CHANNEL_ADDR_ESC=$(sql_escape "$CHANNEL_ADDR")
+
+members="$("$SCRIPT_DIR/resolve-channel-members.sh" "$TEAM" "$CHANNEL")"
+if [ -z "$members" ]; then
+  echo "No channel recipients resolved for $TEAM/$CHANNEL" >&2
+  exit 1
+fi
+
+delivery_values=""
+while IFS= read -r member; do
+  [ -z "$member" ] && continue
+  member_esc=$(sql_escape "$member")
+  delivery_values="${delivery_values}INSERT OR IGNORE INTO message_deliveries (message_id, team, to_agent) VALUES (_MSG_ID_, '$TEAM_ESC', '$member_esc');"$'\n'
+done <<< "$members"
+
+if [ -z "$delivery_values" ]; then
+  echo "No channel recipients resolved for $TEAM/$CHANNEL" >&2
+  exit 1
+fi
+
+sql=$(cat <<SQL
+BEGIN IMMEDIATE;
+INSERT INTO messages (team, from_agent, to_agent, body, kind, channel)
+VALUES ('$TEAM_ESC', '$FROM_ESC', '$CHANNEL_ADDR_ESC', '$BODY_ESC', 'channel', '$CHANNEL_ESC');
+CREATE TEMP TABLE _agmsg_new_message_id(id INTEGER);
+INSERT INTO _agmsg_new_message_id VALUES (last_insert_rowid());
+SQL
+)
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  sql="${sql}"$'\n'"${line//_MSG_ID_/(SELECT id FROM _agmsg_new_message_id)}"
+done <<< "$delivery_values"
+
+sql="${sql}"$'\n'"DROP TABLE _agmsg_new_message_id;"$'\n'"COMMIT;"
+
+if ! agmsg_sqlite "$DB" "$sql" 2>/dev/null; then
+  bash "$SCRIPT_DIR/init-db.sh" >/dev/null
+  agmsg_sqlite "$DB" "$sql"
+fi
+
+count=$(printf '%s\n' "$members" | sed '/^$/d' | wc -l | tr -d ' ')
+echo "Broadcast to channel $CHANNEL in team $TEAM ($count recipient(s))"

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -88,19 +88,39 @@ if _smells_like_path "$TO" || _smells_like_session_id "$TO"; then
   exit 1
 fi
 
-# In direct mode, verify TO is a registered member of the team.
-# Channel mode validates recipients via resolve-channel-members.sh instead.
-if [ "$MODE" = "direct" ]; then
-  CONFIG="$TEAMS_DIR/$TEAM/config.json"
-  if [ -f "$CONFIG" ]; then
+# Verify FROM is a registered member of the team (all modes).
+# TO validation is direct-mode only; channel mode validates via resolve-channel-members.sh.
+CONFIG="$TEAMS_DIR/$TEAM/config.json"
+if [ -f "$CONFIG" ]; then
+  _config_esc=$(sed "s/'/''/g" "$CONFIG")
+
+  _from_esc=$(printf '%s' "$FROM" | sed "s/'/''/g")
+  _from_registered=$(sqlite3 :memory: \
+    ".param set :json '$_config_esc'" \
+    "SELECT 1 FROM json_each(json_extract(:json, '\$.agents')) WHERE key='$_from_esc' LIMIT 1;" \
+    2>/dev/null | tr -d '\r')
+  if [ -z "$_from_registered" ]; then
+    _members=$(sqlite3 :memory: \
+      ".param set :json '$_config_esc'" \
+      "SELECT key FROM json_each(json_extract(:json, '\$.agents'));" \
+      2>/dev/null | tr -d '\r')
+    echo "Error: from-agent '$FROM' is not a registered member of team '$TEAM'." >&2
+    if [ -n "$_members" ]; then
+      echo "  Members: $(printf '%s\n' "$_members" | paste -sd, -)" >&2
+    fi
+    echo "  Simpler:  msg.sh <to> <message>" >&2
+    exit 1
+  fi
+
+  if [ "$MODE" = "direct" ]; then
     _to_esc=$(printf '%s' "$TO" | sed "s/'/''/g")
     _to_registered=$(sqlite3 :memory: \
-      ".param set :json '$(sed "s/'/''/g" "$CONFIG")'" \
+      ".param set :json '$_config_esc'" \
       "SELECT 1 FROM json_each(json_extract(:json, '\$.agents')) WHERE key='$_to_esc' LIMIT 1;" \
       2>/dev/null | tr -d '\r')
     if [ -z "$_to_registered" ]; then
       _members=$(sqlite3 :memory: \
-        ".param set :json '$(sed "s/'/''/g" "$CONFIG")'" \
+        ".param set :json '$_config_esc'" \
         "SELECT key FROM json_each(json_extract(:json, '\$.agents'));" \
         2>/dev/null | tr -d '\r')
       echo "Error: to-agent '$TO' is not a member of team '$TEAM'." >&2

--- a/templates/cmd.antigravity.md
+++ b/templates/cmd.antigravity.md
@@ -1,5 +1,5 @@
 ---
-name: __SKILL_NAME__
+name: agmsgcrm
 description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
 ---
 
@@ -7,9 +7,9 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 ## Identity
 
-If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call in this session, skip to **Execute** below.
+If you already know your AGENT and TEAMS from a previous `$agmsgcrm` call in this session, skip to **Execute** below.
 
-Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" antigravity`
+Otherwise, run: `~/.agents/skills/agmsgcrm/scripts/whoami.sh "$(pwd)" antigravity`
 
 Four possible outputs:
 
@@ -32,14 +32,14 @@ Four possible outputs:
 
   1. Ask: "Enter a team name (joins existing or creates new)"
   2. Ask: "Enter a name for this agent"
-  3. **You MUST use join.sh** — run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> antigravity "$(pwd)"`
+  3. **You MUST use join.sh** — run: `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <agent_name> antigravity "$(pwd)"`
   4. Show the result and explain:
 
-  > **Joined!** You can now use `$__SKILL_NAME__` to check and send messages.
-  > - `$__SKILL_NAME__` — check inbox
-  > - `$__SKILL_NAME__ send <agent> <message>` — send a message
-  > - `$__SKILL_NAME__ team` — list team members
-  > - `$__SKILL_NAME__ history` — message history
+  > **Joined!** You can now use `$agmsgcrm` to check and send messages.
+  > - `$agmsgcrm` — check inbox
+  > - `$agmsgcrm send <agent> <message>` — send a message
+  > - `$agmsgcrm team` — list team members
+  > - `$agmsgcrm history` — message history
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -50,14 +50,14 @@ Four possible outputs:
                   Stop hook pulls after each response.
 
        2) off  — No automatic delivery
-                  Manual $__SKILL_NAME__ only.
+                  Manual $agmsgcrm only.
 
      [1]:
      ```
 
      - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
      - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
-       `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> antigravity "$(pwd)"`
+       `~/.agents/skills/agmsgcrm/scripts/delivery.sh set <mode> antigravity "$(pwd)"`
      - Codex has no Monitor tool, so `monitor` and `both` modes are not offered here.
 
   6. Then check inbox for the newly joined team.
@@ -69,68 +69,68 @@ Four possible outputs:
   1. Show the suggested agent names to the user.
   2. Ask whether to reuse one of those names or choose a new one.
   3. Ask for the team name to join (existing or new).
-  4. Run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> antigravity "$(pwd)"`
+  4. Run: `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <agent_name> antigravity "$(pwd)"`
   5. Then continue with the normal post-join flow above.
 
 ## Execute
 
-**Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
+**Only use scripts in `~/.agents/skills/agmsgcrm/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
 
 **If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
-1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
+1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/agmsgcrm/scripts/inbox.sh $TEAM $AGENT`
 2. Do NOT ask the user what to do — just run the inbox check.
 3. If there are messages, read and respond appropriately. To reply:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+   `~/.agents/skills/agmsgcrm/scripts/msg.sh <to_agent> "<message>"`
 
 If argument is "history":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/history.sh $TEAM $AGENT`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/history.sh $TEAM $AGENT`
 
 If argument is "team":
-1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM`
+1. For each TEAM, run: `~/.agents/skills/agmsgcrm/scripts/team.sh $TEAM`
 
 If argument starts with "send" (e.g. "send misaki check the server"):
 1. Parse target agent and message from the arguments
-2. Determine which team the target agent belongs to, then run:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/msg.sh <to_agent> "<message>"`
+   msg.sh auto-resolves team and from-agent. Do NOT use send.sh directly — its 4-positional-arg interface is error-prone.
 
 If argument is "config":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh show`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/config.sh show`
 2. Show the output to the user.
 
 If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
 1. Parse key and value from the arguments.
-2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/config.sh set <key> <value>`
 
 
 If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 1. Parse the new role name.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" antigravity` to see whether the role is already registered for this (project, type).
-3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> antigravity "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
-4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
-5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Codex has no Monitor tool, so receive still covers all of your registered roles in this project.)"
+2. Run `~/.agents/skills/agmsgcrm/scripts/identities.sh "$(pwd)" antigravity` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <name> antigravity "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
+4. Set the session's active FROM to `<name>`. Use `msg.sh --from <name>` for sends until another `actas`.
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Antigravity has no Monitor tool, so receive still covers all of your registered roles in this project.)"
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" antigravity <name>` to remove that role's registration.
+2. Run `~/.agents/skills/agmsgcrm/scripts/reset.sh "$(pwd)" antigravity <name>` to remove that role's registration.
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
 If argument is "mode" (no further args):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status antigravity "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh status antigravity "$(pwd)"`
 2. Show the output to the user.
 
 If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
 1. Parse the mode. Codex supports only `turn` and `off` — reject `monitor` and `both` with: "Codex has no Monitor tool; only `turn` or `off` modes are supported."
-2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> antigravity "$(pwd)"`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set <mode> antigravity "$(pwd)"`
 
 If argument is "hook on" (legacy alias):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn antigravity "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set turn antigravity "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior)."
 
 If argument is "hook off" (legacy alias):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off antigravity "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set off antigravity "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'off'."
 
 If argument is "reset":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" antigravity`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/reset.sh "$(pwd)" antigravity`
 2. Tell the user the result.

--- a/templates/cmd.claude-code.md
+++ b/templates/cmd.claude-code.md
@@ -6,9 +6,9 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 ## Identity
 
-If you already know your AGENT and TEAMS from a previous `/__SKILL_NAME__` call in this session, skip to **Execute** below.
+If you already know your AGENT and TEAMS from a previous `/agmsgcrm` call in this session, skip to **Execute** below.
 
-Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" claude-code`
+Otherwise, run: `~/.agents/skills/agmsgcrm/scripts/whoami.sh "$(pwd)" claude-code`
 
 Four possible outputs:
 
@@ -31,19 +31,18 @@ Four possible outputs:
 
   1. Ask: "Enter a team name (joins existing or creates new)"
   2. Ask: "Enter a name for this agent"
-  3. **You MUST use join.sh** — run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> claude-code "$(pwd)"`
+  3. **You MUST use join.sh** — run: `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <agent_name> claude-code "$(pwd)"`
   4. Show the result and explain:
 
-  > **Joined!** You can now use `/__SKILL_NAME__` to check and send messages.
-  > - `/__SKILL_NAME__` — check inbox
-  > - `/__SKILL_NAME__ send <agent> <message>` — send a message
-  > - `/__SKILL_NAME__ team` — list team members
-  > - `/__SKILL_NAME__ history` — message history
-  > - `/__SKILL_NAME__ mode <monitor|turn|both|off>` — switch delivery mode
-  > - `/__SKILL_NAME__ actas <name>` — switch to another role in this project (creates if needed)
-  > - `/__SKILL_NAME__ drop <name>` — remove a role from this project
-  > - `/__SKILL_NAME__ spawn <type> <name>` — launch a new agent in a tmux pane / terminal and have it actas <name>
-  > - `/__SKILL_NAME__ despawn <name>` — tear down a member you spawned (graceful, or `--force`)
+  > **Joined!** You can now use `/agmsgcrm` to check and send messages.
+  > - `/agmsgcrm` — check inbox
+  > - `/agmsgcrm send <agent> <message>` — send a message
+  > - `/agmsgcrm team` — list team members
+  > - `/agmsgcrm history` — message history
+  > - `/agmsgcrm mode <monitor|turn|both|off>` — switch delivery mode
+  > - `/agmsgcrm actas <name>` — switch to another role in this project (creates if needed)
+  > - `/agmsgcrm drop <name>` — remove a role from this project
+  > - `/agmsgcrm spawn <type> <name>` — launch a new agent in a tmux pane / terminal and have it actas <name>
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -61,14 +60,14 @@ Four possible outputs:
                      Redundant safety net.
 
        4) off     — No automatic delivery
-                     Manual /__SKILL_NAME__ only.
+                     Manual /agmsgcrm only.
 
      [1]:
      ```
 
      - **Wait for the user's answer before proceeding.** Empty input means `1` (monitor).
      - Map the chosen number to a mode and run:
-       `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> claude-code "$(pwd)"`
+       `~/.agents/skills/agmsgcrm/scripts/delivery.sh set <mode> claude-code "$(pwd)"`
      - Read the `AGMSG-DIRECTIVE` block printed by `delivery.sh` and follow it (invoke Monitor or TaskStop as instructed).
 
   6. Then check inbox for the newly joined team.
@@ -80,29 +79,29 @@ Four possible outputs:
   1. Show the suggested agent names to the user.
   2. Ask whether to reuse one of those names or choose a new one.
   3. Ask for the team name to join (existing or new).
-  4. Run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> claude-code "$(pwd)"`
+  4. Run: `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <agent_name> claude-code "$(pwd)"`
   5. Then continue with the normal post-join flow above.
 
 ## Execute
 
-**Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
+**Only use scripts in `~/.agents/skills/agmsgcrm/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
 
-**Ensure monitor is running first.** Before processing any subcommand below, check whether this session already has an `agmsg inbox stream` Monitor task in its TaskList. If not, and the project's delivery mode is `monitor` or `both` (check via `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status claude-code "$(pwd)"`), invoke the Monitor tool now:
+**Ensure monitor is running first.** Before processing any subcommand below, check whether this session already has an `agmsg inbox stream` Monitor task in its TaskList. If not, and the project's delivery mode is `monitor` or `both` (check via `~/.agents/skills/agmsgcrm/scripts/delivery.sh status claude-code "$(pwd)"`), invoke the Monitor tool now:
 
-- command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh $CLAUDE_CODE_SESSION_ID "$(pwd)" claude-code`
+- command: `~/.agents/skills/agmsgcrm/scripts/watch.sh $CLAUDE_CODE_SESSION_ID "$(pwd)" claude-code`
 - description: `agmsg inbox stream`
 - persistent: true
 
-Then continue with the user's subcommand. This catches the case where the user invokes `/__SKILL_NAME__` as the first prompt before the SessionStart-hook directive has been acted on.
+Then continue with the user's subcommand. This catches the case where the user invokes `/agmsgcrm` as the first prompt before the SessionStart-hook directive has been acted on.
 
-**Sandbox compatibility.** When Claude Code's sandbox is enabled, `watch.sh` (monitor mode) runs inside the sandbox and needs to write pidfiles and SQLite WAL files under `~/.agents/skills/__SKILL_NAME__/`. If monitor mode fails with write/permission errors there, add an allowlist entry to `~/.claude/settings.json` (or project-level `.claude/settings.local.json`):
+**Sandbox compatibility.** When Claude Code's sandbox is enabled, `watch.sh` (monitor mode) runs inside the sandbox and needs to write pidfiles and SQLite WAL files under `~/.agents/skills/agmsgcrm/`. If monitor mode fails with write/permission errors there, add an allowlist entry to `~/.claude/settings.json` (or project-level `.claude/settings.local.json`):
 
 ```json
 {
   "sandbox": {
     "filesystem": {
       "allowWrite": [
-        "~/.agents/skills/__SKILL_NAME__/"
+        "~/.agents/skills/agmsgcrm/"
       ]
     }
   }
@@ -112,100 +111,92 @@ Then continue with the user's subcommand. This catches the case where the user i
 The allowlist merges across scopes and takes effect immediately — no restart needed. (The `BASH_SOURCE`-empty case under the sandbox — the Bash tool runs commands via pipe/eval, so `BASH_SOURCE[0]` is empty inside sourced functions — is handled internally: `watch.sh` resolves `SKILL_DIR` from `$0` and `storage.sh` falls back to it. No user configuration needed.)
 
 **If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
-1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
+1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/agmsgcrm/scripts/inbox.sh $TEAM $AGENT`
 2. Do NOT ask the user what to do — just run the inbox check.
 3. If there are messages, read and respond appropriately. To reply:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+   `~/.agents/skills/agmsgcrm/scripts/msg.sh <to_agent> "<message>"`
 
 If argument is "history":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/history.sh $TEAM $AGENT`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/history.sh $TEAM $AGENT`
 
 If argument is "team":
-1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM`
+1. For each TEAM, run: `~/.agents/skills/agmsgcrm/scripts/team.sh $TEAM`
 
 If argument starts with "send" (e.g. "send misaki check the server"):
 1. Parse target agent and message from the arguments
-2. Determine which team the target agent belongs to, then run:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/msg.sh <to_agent> "<message>"`
+   msg.sh auto-resolves team and from-agent. Do NOT use send.sh directly — its 4-positional-arg interface is error-prone.
 
 If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 1. Parse the new role name.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" claude-code` to see whether the role is already registered for this (project, type).
-3. If the name does not appear in the output, join under the existing team. Read TEAMS from the in-session whoami state (it may be a single team or comma-separated). For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> claude-code "$(pwd)"`. For multiple teams, ask the user which team to join the new role into, then run join.sh for that team.
-4. **Pre-flight claim** the actas exclusivity lock so this role isn't already owned by another live session: `~/.agents/skills/__SKILL_NAME__/scripts/actas-claim.sh "$(pwd)" claude-code <name> "$CLAUDE_CODE_SESSION_ID"`. Read the `status=` line of the output:
+2. Run `~/.agents/skills/agmsgcrm/scripts/identities.sh "$(pwd)" claude-code` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, join under the existing team. Read TEAMS from the in-session whoami state (it may be a single team or comma-separated). For a single team, run `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <name> claude-code "$(pwd)"`. For multiple teams, ask the user which team to join the new role into, then run join.sh for that team.
+4. **Pre-flight claim** the actas exclusivity lock so this role isn't already owned by another live session: `~/.agents/skills/agmsgcrm/scripts/actas-claim.sh "$(pwd)" claude-code <name> "$CLAUDE_CODE_SESSION_ID"`. Read the `status=` line of the output:
     - `status=ok ...`: proceed to step 5.
-    - `status=held team=<team> owner=<sid>`: another live session currently owns `<name>` in `<team>`. Tell the user: "Cannot actas as `<name>` — it is held by session `<sid>` in team `<team>`. Run `/__SKILL_NAME__ drop <name>` in that session first, then retry." Then abort — do NOT touch the running Monitor.
+    - `status=held team=<team> owner=<sid>`: another live session currently owns `<name>` in `<team>`. Tell the user: "Cannot actas as `<name>` — it is held by session `<sid>` in team `<team>`. Run `/agmsgcrm drop <name>` in that session first, then retry." Then abort — do NOT touch the running Monitor.
     - `status=not_registered`: shouldn't happen if step 3 ran; treat as an error.
 5. **Switch receive too — exclusive role mode.**
    a. Run TaskList. Find any task whose description begins with "agmsg inbox stream".
    b. **If a matching task is found**: TaskStop it.
-   c. **If no matching task is found** (typical when /__SKILL_NAME__ actas runs as the first command of a fresh session — SessionStart hasn't fired the Monitor directive yet, or you're invoking actas before the agent acted on it): skip TaskStop entirely. There is no Monitor to stop. Do NOT attempt TaskStop with a guessed or empty task_id — it will fail with "Invalid tool parameters" and confuse the flow.
+   c. **If no matching task is found** (typical when /agmsgcrm actas runs as the first command of a fresh session — SessionStart hasn't fired the Monitor directive yet, or you're invoking actas before the agent acted on it): skip TaskStop entirely. There is no Monitor to stop. Do NOT attempt TaskStop with a guessed or empty task_id — it will fail with "Invalid tool parameters" and confuse the flow.
    d. Invoke a fresh Monitor regardless of whether step b or c applied:
-      - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh $CLAUDE_CODE_SESSION_ID "$(pwd)" claude-code <name>`
+      - command: `~/.agents/skills/agmsgcrm/scripts/watch.sh $CLAUDE_CODE_SESSION_ID "$(pwd)" claude-code <name>`
       - description: `agmsg inbox stream (acting as <name>)`
       - persistent: true
    The 4th argument to `watch.sh` restricts the subscription to messages addressed to `<name>` only — other roles' inbound messages stop reaching this session until another `actas` or session end.
-6. Set the session's active FROM to `<name>` — use `<name>` in every `send.sh` call for the rest of this session.
+6. After actas, `msg.sh` auto-resolves the active FROM from the actas lock — no manual FROM tracking needed.
 7. Tell the user: "Now acting as `<name>`. Sends use `<name>` as from; receive restricted to `<name>` only."
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" claude-code <name> "$CLAUDE_CODE_SESSION_ID"` to remove only that role's registration for this project. If the role has no other registrations left, reset.sh also drops it from the team config. The 4th argument releases any actas exclusivity locks this session held on the role so peers can pick it up immediately (see #62).
+2. Run `~/.agents/skills/agmsgcrm/scripts/reset.sh "$(pwd)" claude-code <name> "$CLAUDE_CODE_SESSION_ID"` to remove only that role's registration for this project. If the role has no other registrations left, reset.sh also drops it from the team config. The 4th argument releases any actas exclusivity locks this session held on the role so peers can pick it up immediately (see #62).
 3. If the session's active FROM was `<name>`, clear that state. Then:
    a. Run TaskList. Find any task whose description begins with "agmsg inbox stream".
    b. **If a matching task is found**: TaskStop it.
    c. **If no matching task is found**: skip TaskStop. Do NOT attempt TaskStop with a guessed or empty task_id.
    d. Invoke a fresh Monitor with the default subscription (no `actas` name filter — receives every (team, agent) pair currently registered for this project that isn't held by another session):
-      - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh $CLAUDE_CODE_SESSION_ID "$(pwd)" claude-code`
+      - command: `~/.agents/skills/agmsgcrm/scripts/watch.sh $CLAUDE_CODE_SESSION_ID "$(pwd)" claude-code`
       - description: `agmsg inbox stream`
       - persistent: true
 4. Tell the user: "Dropped role `<name>` from this project."
 
 If argument starts with "spawn" (e.g. "spawn codex reviewer", "spawn claude-code alice --window"):
 1. Parse `<type>` (must be `claude-code` or `codex`), `<name>`, and any options (`--project`, `--team`, `--window`, `--split h|v`, `--terminal`, `--no-wait`, `--ready-timeout <secs>`).
-2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
-   - spawn.sh pre-joins `<name>`, then opens a tmux pane/window (when this session is inside tmux) or a new OS terminal, and launches the target CLI with `/__SKILL_NAME__ actas <name>` as its initial prompt.
+2. Run: `~/.agents/skills/agmsgcrm/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
+   - spawn.sh pre-joins `<name>`, then opens a tmux pane/window (when this session is inside tmux) or a new OS terminal, and launches the target CLI with `/agmsgcrm actas <name>` as its initial prompt.
    - By default it BLOCKS until the new agent's watcher attaches and prints `status=ready` — so you can message `<name>` right away. It prints `status=timeout` and exits 3 if not ready within `--ready-timeout` (default 90s); pass `--no-wait` for fire-and-forget. Codex skips the wait (no Monitor).
    - It refuses early if `<name>` is already held by another live session, if the target CLI is not installed, or if there is no tmux and no usable terminal (headless).
 3. Show the script's output. Do NOT TaskStop or relaunch this session's own Monitor — spawn affects a separate, newly launched agent, not this session's subscription.
 
-If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --force"):
-1. Parse `<name>` and any options (`--force`, `--timeout <secs>`). `despawn` is the inverse of `spawn` — it tears down a member you previously spawned.
-2. Determine which team `<name>` belongs to (as with `send`), then run:
-   `~/.agents/skills/__SKILL_NAME__/scripts/despawn.sh <team> $AGENT <name> [--force] [--timeout <secs>]`
-   - Default (graceful): sends a `ctrl:despawn` control message to `<name>`. The member's watcher drops its own role (releasing the actas lock + registration) and closes its own tmux pane, which ends the agent CLI. Blocks until the lock releases, up to `--timeout` (default 30s), then prints `status=ok`. On timeout it prints `status=timeout` and exits 3 — the member's watcher didn't respond (dead watcher, or a codex member with no Monitor); retry with `--force`.
-   - `--force`: skips the message and tears the member down from the placement recorded at spawn time — kills its tmux pane/window and drops its registration. Use when the member's watcher can't respond.
-3. Show the script's output. Do NOT TaskStop or relaunch this session's own Monitor — despawn affects the spawned member, not this session's subscription.
-
 If argument is "mode" (no further args):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status claude-code "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh status claude-code "$(pwd)"`
 2. Show the output to the user.
 
 If argument starts with "mode" followed by a mode name (e.g. "mode monitor"):
 1. Parse the mode (one of `monitor`, `turn`, `both`, `off`).
-2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> claude-code "$(pwd)"`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set <mode> claude-code "$(pwd)"`
 3. Read the `AGMSG-DIRECTIVE` block in the command output and follow it (invoke Monitor or TaskStop as instructed).
 
 If argument is "hook on" (legacy alias):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn claude-code "$(pwd)"`
-2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior). Consider using /__SKILL_NAME__ mode monitor for real-time push."
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set turn claude-code "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior). Consider using /agmsgcrm mode monitor for real-time push."
 
 If argument is "hook off" (legacy alias):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off claude-code "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set off claude-code "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'off'."
 
 If argument is "config":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh show`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/config.sh show`
 2. Show the output to the user.
 
 If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
 1. Parse key and value from the arguments.
-2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/config.sh set <key> <value>`
 
 If argument is "version":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/version.sh`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/version.sh`
 2. Show the output — the installed version (git-describe provenance recorded at install time).
 
 If argument is "reset":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" claude-code`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/reset.sh "$(pwd)" claude-code`
 2. Tell the user the result.

--- a/templates/cmd.codex.md
+++ b/templates/cmd.codex.md
@@ -1,5 +1,5 @@
 ---
-name: __SKILL_NAME__
+name: agmsgcrm
 description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
 ---
 
@@ -7,9 +7,9 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 ## Identity
 
-If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call in this session, skip to **Execute** below.
+If you already know your AGENT and TEAMS from a previous `$agmsgcrm` call in this session, skip to **Execute** below.
 
-Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" codex`
+Otherwise, run: `~/.agents/skills/agmsgcrm/scripts/whoami.sh "$(pwd)" codex`
 
 Four possible outputs:
 
@@ -32,14 +32,14 @@ Four possible outputs:
 
   1. Ask: "Enter a team name (joins existing or creates new)"
   2. Ask: "Enter a name for this agent"
-  3. **You MUST use join.sh** — run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> codex "$(pwd)"`
+  3. **You MUST use join.sh** — run: `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <agent_name> codex "$(pwd)"`
   4. Show the result and explain:
 
-  > **Joined!** You can now use `$__SKILL_NAME__` to check and send messages.
-  > - `$__SKILL_NAME__` — check inbox
-  > - `$__SKILL_NAME__ send <agent> <message>` — send a message
-  > - `$__SKILL_NAME__ team` — list team members
-  > - `$__SKILL_NAME__ history` — message history
+  > **Joined!** You can now use `$agmsgcrm` to check and send messages.
+  > - `$agmsgcrm` — check inbox
+  > - `$agmsgcrm send <agent> <message>` — send a message
+  > - `$agmsgcrm team` — list team members
+  > - `$agmsgcrm history` — message history
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -50,14 +50,14 @@ Four possible outputs:
                   Stop hook pulls after each response.
 
        2) off  — No automatic delivery
-                  Manual $__SKILL_NAME__ only.
+                  Manual $agmsgcrm only.
 
      [1]:
      ```
 
      - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
      - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
-       `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> codex "$(pwd)"`
+       `~/.agents/skills/agmsgcrm/scripts/delivery.sh set <mode> codex "$(pwd)"`
      - Codex has no Monitor tool, so `monitor` and `both` modes are not offered here.
 
   6. Then check inbox for the newly joined team.
@@ -69,88 +69,80 @@ Four possible outputs:
   1. Show the suggested agent names to the user.
   2. Ask whether to reuse one of those names or choose a new one.
   3. Ask for the team name to join (existing or new).
-  4. Run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> codex "$(pwd)"`
+  4. Run: `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <agent_name> codex "$(pwd)"`
   5. Then continue with the normal post-join flow above.
 
 ## Execute
 
-**Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
+**Only use scripts in `~/.agents/skills/agmsgcrm/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
 
 **If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
-1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
+1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/agmsgcrm/scripts/inbox.sh $TEAM $AGENT`
 2. Do NOT ask the user what to do — just run the inbox check.
 3. If there are messages, read and respond appropriately. To reply:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+   `~/.agents/skills/agmsgcrm/scripts/msg.sh <to_agent> "<message>"`
 
 If argument is "history":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/history.sh $TEAM $AGENT`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/history.sh $TEAM $AGENT`
 
 If argument is "team":
-1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM`
+1. For each TEAM, run: `~/.agents/skills/agmsgcrm/scripts/team.sh $TEAM`
 
 If argument starts with "send" (e.g. "send misaki check the server"):
 1. Parse target agent and message from the arguments
-2. Determine which team the target agent belongs to, then run:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/msg.sh <to_agent> "<message>"`
+   msg.sh auto-resolves team and from-agent. Do NOT use send.sh directly — its 4-positional-arg interface is error-prone.
 
 If argument is "config":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh show`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/config.sh show`
 2. Show the output to the user.
 
 If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
 1. Parse key and value from the arguments.
-2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/config.sh set <key> <value>`
 
 
 If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 1. Parse the new role name.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" codex` to see whether the role is already registered for this (project, type).
-3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> codex "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
-4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
+2. Run `~/.agents/skills/agmsgcrm/scripts/identities.sh "$(pwd)" codex` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <name> codex "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
+4. Set the session's active FROM to `<name>`. Use `msg.sh --from <name>` for sends until another `actas`.
 5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Codex has no Monitor tool, so receive still covers all of your registered roles in this project.)"
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" codex <name>` to remove that role's registration.
+2. Run `~/.agents/skills/agmsgcrm/scripts/reset.sh "$(pwd)" codex <name>` to remove that role's registration.
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
 If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex reviewer --window"):
 1. Parse `<type>` (must be `claude-code` or `codex`), `<name>`, and any options (`--project`, `--team`, `--window`, `--split h|v`, `--terminal`, `--no-wait`, `--ready-timeout <secs>`).
-2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
-   - spawn.sh pre-joins `<name>`, then opens a tmux pane/window (when this session is inside tmux) or a new OS terminal, and launches the target CLI with `/__SKILL_NAME__ actas <name>` as its initial prompt.
+2. Run: `~/.agents/skills/agmsgcrm/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
+   - spawn.sh pre-joins `<name>`, then opens a tmux pane/window (when this session is inside tmux) or a new OS terminal, and launches the target CLI with `/agmsgcrm actas <name>` as its initial prompt.
    - By default it BLOCKS until a spawned claude-code agent's watcher attaches (`status=ready`); `status=timeout` + exit 3 if not ready within `--ready-timeout` (default 90s). `--no-wait` for fire-and-forget. Spawning a codex agent skips the wait (codex has no Monitor).
    - It refuses early if `<name>` is already held by another live session, if the target CLI is not installed, or if there is no tmux and no usable terminal (headless).
 3. Show the script's output.
 
-If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --force"):
-1. Parse `<name>` and any options (`--force`, `--timeout <secs>`). `despawn` is the inverse of `spawn` — it tears down a member you previously spawned.
-2. Determine which team `<name>` belongs to (as with `send`), then run:
-   `~/.agents/skills/__SKILL_NAME__/scripts/despawn.sh <team> $AGENT <name> [--force] [--timeout <secs>]`
-   - Default (graceful): sends a `ctrl:despawn` control message to `<name>`. A claude-code member's watcher drops its own role and closes its own tmux pane, ending the agent. Blocks until the lock releases, up to `--timeout` (default 30s), then prints `status=ok`. On timeout it prints `status=timeout` and exits 3 — retry with `--force`. A codex member has no watcher to respond, so use `--force` for it.
-   - `--force`: skips the message and tears the member down from the placement recorded at spawn time — kills its tmux pane/window and drops its registration.
-3. Show the script's output.
-
 If argument is "mode" (no further args):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status codex "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh status codex "$(pwd)"`
 2. Show the output to the user.
 
 If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
 1. Parse the mode. Codex supports only `turn` and `off` — reject `monitor` and `both` with: "Codex has no Monitor tool; only `turn` or `off` modes are supported."
-2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> codex "$(pwd)"`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set <mode> codex "$(pwd)"`
 
 If argument is "hook on" (legacy alias):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn codex "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set turn codex "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior)."
 
 If argument is "hook off" (legacy alias):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off codex "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set off codex "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'off'."
 
 If argument is "version":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/version.sh`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/version.sh`
 2. Show the output — the installed version (git-describe provenance recorded at install time).
 
 If argument is "reset":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" codex`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/reset.sh "$(pwd)" codex`
 2. Tell the user the result.

--- a/templates/cmd.copilot.md
+++ b/templates/cmd.copilot.md
@@ -1,5 +1,5 @@
 ---
-name: __SKILL_NAME__
+name: agmsgcrm
 description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
 ---
 
@@ -7,9 +7,9 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 ## Identity
 
-If you already know your AGENT and TEAMS from a previous `/__SKILL_NAME__` call in this session, skip to **Execute** below.
+If you already know your AGENT and TEAMS from a previous `/agmsgcrm` call in this session, skip to **Execute** below.
 
-Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" copilot`
+Otherwise, run: `~/.agents/skills/agmsgcrm/scripts/whoami.sh "$(pwd)" copilot`
 
 Four possible outputs:
 
@@ -32,14 +32,14 @@ Four possible outputs:
 
   1. Ask: "Enter a team name (joins existing or creates new)"
   2. Ask: "Enter a name for this agent"
-  3. **You MUST use join.sh** — run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> copilot "$(pwd)"`
+  3. **You MUST use join.sh** — run: `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <agent_name> copilot "$(pwd)"`
   4. Show the result and explain:
 
-  > **Joined!** You can now use `/__SKILL_NAME__` to check and send messages.
-  > - `/__SKILL_NAME__` — check inbox
-  > - `/__SKILL_NAME__ send <agent> <message>` — send a message
-  > - `/__SKILL_NAME__ team` — list team members
-  > - `/__SKILL_NAME__ history` — message history
+  > **Joined!** You can now use `/agmsgcrm` to check and send messages.
+  > - `/agmsgcrm` — check inbox
+  > - `/agmsgcrm send <agent> <message>` — send a message
+  > - `/agmsgcrm team` — list team members
+  > - `/agmsgcrm history` — message history
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -50,14 +50,14 @@ Four possible outputs:
                   Stop hook pulls after each response.
 
        2) off  — No automatic delivery
-                  Manual /__SKILL_NAME__ only.
+                  Manual /agmsgcrm only.
 
      [1]:
      ```
 
      - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
      - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
-       `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> copilot "$(pwd)"`
+       `~/.agents/skills/agmsgcrm/scripts/delivery.sh set <mode> copilot "$(pwd)"`
      - Copilot CLI has no Monitor-tool equivalent, so `monitor` and `both` modes are not offered here.
 
   6. Then check inbox for the newly joined team.
@@ -69,68 +69,68 @@ Four possible outputs:
   1. Show the suggested agent names to the user.
   2. Ask whether to reuse one of those names or choose a new one.
   3. Ask for the team name to join (existing or new).
-  4. Run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> copilot "$(pwd)"`
+  4. Run: `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <agent_name> copilot "$(pwd)"`
   5. Then continue with the normal post-join flow above.
 
 ## Execute
 
-**Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
+**Only use scripts in `~/.agents/skills/agmsgcrm/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
 
 **If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
-1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
+1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/agmsgcrm/scripts/inbox.sh $TEAM $AGENT`
 2. Do NOT ask the user what to do — just run the inbox check.
 3. If there are messages, read and respond appropriately. To reply:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+   `~/.agents/skills/agmsgcrm/scripts/msg.sh <to_agent> "<message>"`
 
 If argument is "history":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/history.sh $TEAM $AGENT`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/history.sh $TEAM $AGENT`
 
 If argument is "team":
-1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM`
+1. For each TEAM, run: `~/.agents/skills/agmsgcrm/scripts/team.sh $TEAM`
 
 If argument starts with "send" (e.g. "send misaki check the server"):
 1. Parse target agent and message from the arguments
-2. Determine which team the target agent belongs to, then run:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/msg.sh <to_agent> "<message>"`
+   msg.sh auto-resolves team and from-agent. Do NOT use send.sh directly — its 4-positional-arg interface is error-prone.
 
 If argument is "config":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh show`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/config.sh show`
 2. Show the output to the user.
 
 If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
 1. Parse key and value from the arguments.
-2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/config.sh set <key> <value>`
 
 
 If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 1. Parse the new role name.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" copilot` to see whether the role is already registered for this (project, type).
-3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> copilot "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
-4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
+2. Run `~/.agents/skills/agmsgcrm/scripts/identities.sh "$(pwd)" copilot` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <name> copilot "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
+4. Set the session's active FROM to `<name>`. Use `msg.sh --from <name>` for sends until another `actas`.
 5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Copilot CLI has no Monitor tool, so receive still covers all of your registered roles in this project.)"
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" copilot <name>` to remove that role's registration.
+2. Run `~/.agents/skills/agmsgcrm/scripts/reset.sh "$(pwd)" copilot <name>` to remove that role's registration.
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
 If argument is "mode" (no further args):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status copilot "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh status copilot "$(pwd)"`
 2. Show the output to the user.
 
 If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
 1. Parse the mode. Copilot supports only `turn` and `off` — reject `monitor` and `both` with: "Copilot CLI has no Monitor tool; only `turn` or `off` modes are supported."
-2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> copilot "$(pwd)"`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set <mode> copilot "$(pwd)"`
 
 If argument is "hook on" (legacy alias):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn copilot "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set turn copilot "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior)."
 
 If argument is "hook off" (legacy alias):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off copilot "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set off copilot "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'off'."
 
 If argument is "reset":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" copilot`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/reset.sh "$(pwd)" copilot`
 2. Tell the user the result.

--- a/templates/cmd.gemini.md
+++ b/templates/cmd.gemini.md
@@ -1,5 +1,5 @@
 ---
-name: __SKILL_NAME__
+name: agmsgcrm
 description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
 ---
 
@@ -7,9 +7,9 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 ## Identity
 
-If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call in this session, skip to **Execute** below.
+If you already know your AGENT and TEAMS from a previous `$agmsgcrm` call in this session, skip to **Execute** below.
 
-Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" gemini`
+Otherwise, run: `~/.agents/skills/agmsgcrm/scripts/whoami.sh "$(pwd)" gemini`
 
 Four possible outputs:
 
@@ -32,14 +32,14 @@ Four possible outputs:
 
   1. Ask: "Enter a team name (joins existing or creates new)"
   2. Ask: "Enter a name for this agent"
-  3. **You MUST use join.sh** — run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> gemini "$(pwd)"`
+  3. **You MUST use join.sh** — run: `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <agent_name> gemini "$(pwd)"`
   4. Show the result and explain:
 
-  > **Joined!** You can now use `$__SKILL_NAME__` to check and send messages.
-  > - `$__SKILL_NAME__` — check inbox
-  > - `$__SKILL_NAME__ send <agent> <message>` — send a message
-  > - `$__SKILL_NAME__ team` — list team members
-  > - `$__SKILL_NAME__ history` — message history
+  > **Joined!** You can now use `$agmsgcrm` to check and send messages.
+  > - `$agmsgcrm` — check inbox
+  > - `$agmsgcrm send <agent> <message>` — send a message
+  > - `$agmsgcrm team` — list team members
+  > - `$agmsgcrm history` — message history
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -50,14 +50,14 @@ Four possible outputs:
                   Stop hook pulls after each response.
 
        2) off  — No automatic delivery
-                  Manual $__SKILL_NAME__ only.
+                  Manual $agmsgcrm only.
 
      [1]:
      ```
 
      - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
      - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
-       `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> gemini "$(pwd)"`
+       `~/.agents/skills/agmsgcrm/scripts/delivery.sh set <mode> gemini "$(pwd)"`
      - Codex has no Monitor tool, so `monitor` and `both` modes are not offered here.
 
   6. Then check inbox for the newly joined team.
@@ -69,68 +69,68 @@ Four possible outputs:
   1. Show the suggested agent names to the user.
   2. Ask whether to reuse one of those names or choose a new one.
   3. Ask for the team name to join (existing or new).
-  4. Run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> gemini "$(pwd)"`
+  4. Run: `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <agent_name> gemini "$(pwd)"`
   5. Then continue with the normal post-join flow above.
 
 ## Execute
 
-**Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
+**Only use scripts in `~/.agents/skills/agmsgcrm/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
 
 **If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
-1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
+1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/agmsgcrm/scripts/inbox.sh $TEAM $AGENT`
 2. Do NOT ask the user what to do — just run the inbox check.
 3. If there are messages, read and respond appropriately. To reply:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+   `~/.agents/skills/agmsgcrm/scripts/msg.sh <to_agent> "<message>"`
 
 If argument is "history":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/history.sh $TEAM $AGENT`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/history.sh $TEAM $AGENT`
 
 If argument is "team":
-1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM`
+1. For each TEAM, run: `~/.agents/skills/agmsgcrm/scripts/team.sh $TEAM`
 
 If argument starts with "send" (e.g. "send misaki check the server"):
 1. Parse target agent and message from the arguments
-2. Determine which team the target agent belongs to, then run:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/msg.sh <to_agent> "<message>"`
+   msg.sh auto-resolves team and from-agent. Do NOT use send.sh directly — its 4-positional-arg interface is error-prone.
 
 If argument is "config":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh show`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/config.sh show`
 2. Show the output to the user.
 
 If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
 1. Parse key and value from the arguments.
-2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/config.sh set <key> <value>`
 
 
 If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 1. Parse the new role name.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" gemini` to see whether the role is already registered for this (project, type).
-3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> gemini "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
-4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
-5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Codex has no Monitor tool, so receive still covers all of your registered roles in this project.)"
+2. Run `~/.agents/skills/agmsgcrm/scripts/identities.sh "$(pwd)" gemini` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/agmsgcrm/scripts/join.sh <team> <name> gemini "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
+4. Set the session's active FROM to `<name>`. Use `msg.sh --from <name>` for sends until another `actas`.
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Gemini has no Monitor tool, so receive still covers all of your registered roles in this project.)"
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" gemini <name>` to remove that role's registration.
+2. Run `~/.agents/skills/agmsgcrm/scripts/reset.sh "$(pwd)" gemini <name>` to remove that role's registration.
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
 If argument is "mode" (no further args):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status gemini "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh status gemini "$(pwd)"`
 2. Show the output to the user.
 
 If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
 1. Parse the mode. Codex supports only `turn` and `off` — reject `monitor` and `both` with: "Codex has no Monitor tool; only `turn` or `off` modes are supported."
-2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> gemini "$(pwd)"`
+2. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set <mode> gemini "$(pwd)"`
 
 If argument is "hook on" (legacy alias):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn gemini "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set turn gemini "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior)."
 
 If argument is "hook off" (legacy alias):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off gemini "$(pwd)"`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/delivery.sh set off gemini "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'off'."
 
 If argument is "reset":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" gemini`
+1. Run: `~/.agents/skills/agmsgcrm/scripts/reset.sh "$(pwd)" gemini`
 2. Tell the user the result.


### PR DESCRIPTION
## Summary

- Introduces a per-agent watermark file to track the highest delivered message id in check-inbox.sh
- Prevents unread messages that accumulated during agent downtime from being replayed on reconnect
- Aligns turn-mode delivery (check-inbox.sh) with monitor-mode delivery (watch.sh), which already uses a watermark

## Problem

check-inbox.sh filters unread messages with WHERE read_at IS NULL and no lower-bound on id. For agents using turn delivery mode (Antigravity / Gemini PostToolUse, Codex Stop hook), the hook fires only when the agent is active. Any messages sent while the agent was offline accumulate in the database with read_at IS NULL. When the agent next becomes active and the hook fires, **all accumulated messages are delivered at once**, no matter how old they are.

This means an agent can receive and act on instructions that were relevant to a session that ended hours or days ago, leading to unintended behaviour.

watch.sh (used in monitor mode) already avoids this by setting a watermark to MAX(id) at startup and only streaming messages with id > watermark. check-inbox.sh had no equivalent protection.

## Solution

Add a per-agent watermark persisted at SKILL_DIR/run/check-inbox.agent.watermark:

- **Initialisation**: on first invocation (no watermark file), set watermark to COALESCE(MAX(id), 0). Only messages arriving after this point will ever be delivered.
- **Query filter**: append AND id > LOOP_WM to both the SELECT and UPDATE statements, where LOOP_WM is the watermark snapshotted before the team loop begins.
- **Watermark advance**: after all teams are processed, query MAX(id) WHERE to_agent = AGENT AND id > LOOP_WM across all teams and persist the result. Advancing once after the loop (rather than per-team) ensures agents belonging to multiple teams never skip messages whose ids fall between two teams maxima.
- **Safety valve**: if the stored watermark exceeds the DBs current MAX(id) (DB wiped and recreated), reset to MAX(id) to prevent permanent message silence.

No other files are modified. Existing cooldown, actas-lock, and monitor-deferral logic is unchanged.

## Testing

**Basic replay prevention**

1. Join an agent to a team with turn delivery mode.
2. While the agent is not running, send several messages to it via send.sh.
3. Start the agent and trigger check-inbox.sh manually.
4. Verify: the watermark file is created and no stale messages are delivered.
5. Send a new message while the agent is active.
6. Trigger check-inbox.sh again; verify the new message is delivered and the watermark advances.

**Multi-team correctness**

1. Register the same agent in two teams.
2. Send messages to both teams (both above the current watermark).
3. Invoke check-inbox.sh; verify both messages are delivered in the same run.

**Safety valve (DB recreation)**

1. Write a watermark value larger than the current DB MAX(id).
2. Invoke check-inbox.sh; verify the watermark is reset and delivery resumes normally.
