### PR TITLE
fix(delivery): write tmp file via writefile() to avoid Windows CRLF accumulation

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -69,6 +69,18 @@ sql_readfile_path() {
 # the per-arg MAX_ARG_STRLEN cap (131072 bytes) once the settings file
 # crosses ~21 KB, so `delivery.sh set` failed with E2BIG (see #95). Using
 # readfile() keeps the file off the argv entirely.
+#
+# Writes the result via writefile() rather than shell stdout redirection
+# (`> "$tmp"`). On native Windows the sqlite3 CLI opens stdout in text
+# mode, so every `\n` is translated to `\r\n` on the way out. When the
+# value being written is the file's own readfile() bytes — which already
+# contain `\r\n` after the first write — each round-trip doubles the
+# `\r` count. `delivery.sh set monitor` invokes this chain four times
+# (strip SessionStart, SessionEnd, Stop; then add), so by the fourth
+# call the file holds enough trailing `\r` and literal `^M` bytes that
+# json_extract() rejects it as malformed JSON. writefile() writes bytes
+# directly to disk and is unaffected by the CLI's text-mode stdout (see
+# cause B in #101).
 strip_agmsg_event_file() {
   local path="$1"
   local event="$2"
@@ -76,9 +88,11 @@ strip_agmsg_event_file() {
   sql_path=$(sql_readfile_path "$path")
   local tmp
   tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
+  local tmp_path
+  tmp_path=$(sql_readfile_path "$tmp")
   if ! sqlite3 :memory: "
     WITH src AS (SELECT readfile('$sql_path') AS j)
-    SELECT CASE
+    SELECT writefile('$tmp_path', CASE
       WHEN json_extract(src.j, '\$.hooks.$event') IS NULL THEN
         src.j
       WHEN (SELECT count(*) FROM json_each(json_extract(src.j, '\$.hooks.$event')) AS s
@@ -96,9 +110,9 @@ strip_agmsg_event_file() {
              WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
            ))
         )
-    END
+    END)
     FROM src;
-  " > "$tmp"; then
+  " >/dev/null; then
     rm -f "$tmp"
     return 1
   fi
@@ -142,13 +156,15 @@ add_event_entry_file() {
 
   local tmp
   tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
+  local tmp_path
+  tmp_path=$(sql_readfile_path "$tmp")
   if ! sqlite3 :memory: "
     WITH base AS (
       SELECT CASE WHEN json_extract(readfile('$sql_path'), '\$.hooks') IS NULL
                   THEN json_set(readfile('$sql_path'), '\$.hooks', json('{}'))
                   ELSE readfile('$sql_path') END AS s
     )
-    SELECT CASE
+    SELECT writefile('$tmp_path', CASE
       WHEN json_extract(s, '\$.hooks.$event') IS NULL THEN
         json_set(s, '\$.hooks.$event', json_array(json('$entry_esc')))
       ELSE
@@ -159,9 +175,9 @@ add_event_entry_file() {
              SELECT '$entry_esc'
            ) v)
         )
-    END
+    END)
     FROM base;
-  " > "$tmp"; then
+  " >/dev/null; then
     rm -f "$tmp"
     return 1
   fi
@@ -177,16 +193,18 @@ prune_empty_hooks_file() {
   sql_path=$(sql_readfile_path "$path")
   local tmp
   tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
+  local tmp_path
+  tmp_path=$(sql_readfile_path "$tmp")
   if ! sqlite3 :memory: "
     WITH src AS (SELECT readfile('$sql_path') AS j)
-    SELECT CASE
+    SELECT writefile('$tmp_path', CASE
       WHEN json_extract(src.j, '\$.hooks') IS NULL THEN src.j
       WHEN (SELECT count(*) FROM json_each(json_extract(src.j, '\$.hooks'))) = 0 THEN
         json_remove(src.j, '\$.hooks')
       ELSE src.j
-    END
+    END)
     FROM src;
-  " > "$tmp"; then
+  " >/dev/null; then
     rm -f "$tmp"
     return 1
   fi

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -84,6 +84,25 @@ settings_file() {
   [ "$n" = "1" ]
 }
 
+@test "delivery set monitor: settings file contains no CR bytes" {
+  # Regression for the Windows CRLF-accumulation bug: `delivery.sh set
+  # monitor` runs strip×3 + add through the read-modify-write loop. On
+  # native Windows the sqlite3 CLI's text-mode stdout turned each `\n`
+  # into `\r\n`, so each round doubled the `\r` count of the readfile()
+  # output and the fourth call rejected the result as malformed JSON
+  # (cause B in #101). Switching the write side to writefile() bypasses
+  # the CLI's stdout, so the output now contains no CR bytes on any
+  # platform. This passes on Linux/macOS too (they never produced CRs),
+  # which is the point — the assertion holds wherever the test runs.
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  local cr_count
+  cr_count=$(tr -cd '\r' < "$(settings_file)" | wc -c | tr -d ' ')
+  [ "$cr_count" = "0" ]
+  local valid
+  valid=$(sqlite3 :memory: "SELECT json_valid(readfile('$(settings_file)'));")
+  [ "$valid" = "1" ]
+}
+
 @test "delivery set both: idempotent across repeats" {
   bash "$SCRIPTS/delivery.sh" set both claude-code "$TEST_PROJECT"
   bash "$SCRIPTS/delivery.sh" set both claude-code "$TEST_PROJECT"


### PR DESCRIPTION
## Summary

`delivery.sh set monitor` (and `set off` / `set turn`) fails on native Windows + Git Bash with:

```
Error in 2nd command line argument: malformed JSON
```

The failure surfaces from the fourth `sqlite3` invocation of a `set monitor` run (strip SessionStart, SessionEnd, Stop; then add), because by then the JSON file on disk has accumulated enough stray `\r` bytes that `json_extract()` rejects it.

This is **cause B in #101** (closed without a fix). I can still reproduce it on v1.0.5 / `main` (`13815c1`).

## Root cause

`strip_agmsg_event_file`, `add_event_entry_file` and `prune_empty_hooks_file` all round-trip the settings file through:

```bash
sqlite3 :memory: "SELECT ... FROM (... readfile('$sql_path') ...)" > "$tmp"
mv "$tmp" "$path"
```

On native Windows the `sqlite3` CLI opens stdout in **text mode**, so every `\n` it writes is translated to `\r\n`. The value being written is the file's own `readfile()` output — which already contains `\r\n` after the first write — so every round doubles the `\r` count:

```
round 0: 7b7d 0a                       {}\n
round 1: 7b7d 0d0a 0d0a                {}\r\n\r\n
round 2: 7b7d 0d0d 0a 0d0d 0a 0d0a     {}\r\r\n\r\r\n\r\n
round 3: 7b 7d 5e4d 0d0d 0a 5e4d ...   {}^M\r\r\n^M...   ← literal "^M" bytes
```

By round 4 the file is no longer valid JSON, and `json_extract()` raises *malformed JSON* on the next read.

## Fix

Switch the write side from shell stdout redirection to SQLite's own `writefile()`. `writefile()` writes bytes directly to disk and is unaffected by the CLI's text-mode stdout, so the round-trip no longer accumulates CR bytes.

```diff
-  if ! sqlite3 :memory: "
-    SELECT CASE ... END
-    FROM src;
-  " > "$tmp"; then
+  local tmp_path
+  tmp_path=$(sql_readfile_path "$tmp")
+  if ! sqlite3 :memory: "
+    SELECT writefile('$tmp_path', CASE ... END)
+    FROM src;
+  " >/dev/null; then
```

Applied identically in all three functions. `sql_readfile_path` already handles the MSYS→Windows path conversion the native sqlite3 CLI requires (this is the same fix-up #95 made for the read side, so the input path is reused).

No-op on Linux/macOS: their sqlite3 builds never produced the CRs in the first place. The path stays the same `mktemp → sqlite3 → mv` shape.

## Verification

Local repro on Git Bash + sqlite3 3.53.2 (winget):

- Before the patch: `delivery.sh set monitor claude-code <project>` fails at the fourth sqlite call with *malformed JSON*; the on-disk settings file contains the `^M\r\r\n` pattern from the dump above.
- After the patch: `set monitor` succeeds, the file is valid JSON, and `od -c` shows no `\r` bytes anywhere. Re-running `set monitor` three times in a row is still idempotent (1 SessionStart entry); `set off` cleanly empties the hooks. Existing `tests/test_delivery.bats` cases all still describe the right behavior.

Added one new regression test:

```
@test "delivery set monitor: settings file contains no CR bytes" {
  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
  cr_count=$(tr -cd '\r' < "$(settings_file)" | wc -c | tr -d ' ')
  [ "$cr_count" = "0" ]
  valid=$(sqlite3 :memory: "SELECT json_valid(readfile('$(settings_file)'));")
  [ "$valid" = "1" ]
}
```

The assertion holds on Linux/macOS too (they never wrote CRs), which is the point — it expresses what should be true everywhere, and is the check that would have caught this in the `windows-latest` CI leg added in #152.

## Scope and relation to other PRs

- **#101** (closed, COMPLETED, no linked fix) — same root cause B, never landed. This PR is the fix.
- **#158** (open) — addresses how the hook entry JSON is built (`json_object()` + `readfile()` to avoid hand-escaping). Touches different lines in the same functions; the two fixes are orthogonal and compose cleanly. If #158 merges first, this PR rebases trivially; the writefile() change only rewrites the outer `SELECT ... > "$tmp"` shell, not the JSON-building expression inside.
- **#143 / #138 / #134** — open Windows reports whose user-visible symptom (*"malformed JSON"* / *"stepping, malformed JSON"*) overlaps with this one. Once both PRs land the failure mode should be gone end-to-end.

## Test plan

- [ ] Existing `tests/test_delivery.bats` stays green on Linux CI
- [ ] `windows-latest` CI leg passes (this is the real signal for the fix)
- [ ] New `no CR bytes` test passes on both legs