### PR TITLE
fix(delivery): "malformed JSON" on Windows Git Bash + sqlite3 3.53

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -59,6 +59,15 @@ sql_readfile_path() {
   printf '%s' "$path" | sed "s/'/''/g"
 }
 
+# `sqlite3 ... > "$tmp"` cannot be used to round-trip the settings JSON on
+# Windows: the CLI emits stdout in text mode, so embedded LFs become CR LF
+# and any bare CR in the value is rendered as the literal two-character
+# sequence "^M". After three strip+mv cycles the on-disk file is no longer
+# valid JSON and the 4th sqlite3 call fails with
+# "Error in 2nd command line argument: malformed JSON" (#161). Each
+# rewrite below therefore uses writefile() — it emits the raw blob exactly
+# as the SQL produced it, with no text translation, on every platform.
+
 # Strip any agmsg-owned hook entries from <event> in the JSON at <path>. An
 # entry is "agmsg-owned" when one of its inner hooks references a path under
 # our skill directory. Result is written back to <path> atomically.
@@ -76,9 +85,16 @@ strip_agmsg_event_file() {
   sql_path=$(sql_readfile_path "$path")
   local tmp
   tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
-  if ! sqlite3 :memory: "
+  local sql_tmp
+  sql_tmp=$(sql_readfile_path "$tmp")
+  # writefile() returns the byte count actually written. We treat a NULL or
+  # non-positive return as failure so a sqlite3 error doesn't leave a
+  # half-written file in place of the original. See the rationale comment
+  # above sql_readfile_path() for why stdout redirect is unusable on Windows.
+  local n
+  n=$(sqlite3 :memory: "
     WITH src AS (SELECT readfile('$sql_path') AS j)
-    SELECT CASE
+    SELECT writefile('$sql_tmp', CASE
       WHEN json_extract(src.j, '\$.hooks.$event') IS NULL THEN
         src.j
       WHEN (SELECT count(*) FROM json_each(json_extract(src.j, '\$.hooks.$event')) AS s
@@ -96,12 +112,10 @@ strip_agmsg_event_file() {
              WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
            ))
         )
-    END
+    END)
     FROM src;
-  " > "$tmp"; then
-    rm -f "$tmp"
-    return 1
-  fi
+  ") || { rm -f "$tmp"; return 1; }
+  case "$n" in ''|0|-*|*[!0-9-]*) rm -f "$tmp"; return 1 ;; esac
   mv "$tmp" "$path"
 }
 
@@ -142,13 +156,16 @@ add_event_entry_file() {
 
   local tmp
   tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
-  if ! sqlite3 :memory: "
+  local sql_tmp
+  sql_tmp=$(sql_readfile_path "$tmp")
+  local n
+  n=$(sqlite3 :memory: "
     WITH base AS (
       SELECT CASE WHEN json_extract(readfile('$sql_path'), '\$.hooks') IS NULL
                   THEN json_set(readfile('$sql_path'), '\$.hooks', json('{}'))
                   ELSE readfile('$sql_path') END AS s
     )
-    SELECT CASE
+    SELECT writefile('$sql_tmp', CASE
       WHEN json_extract(s, '\$.hooks.$event') IS NULL THEN
         json_set(s, '\$.hooks.$event', json_array(json('$entry_esc')))
       ELSE
@@ -159,12 +176,10 @@ add_event_entry_file() {
              SELECT '$entry_esc'
            ) v)
         )
-    END
+    END)
     FROM base;
-  " > "$tmp"; then
-    rm -f "$tmp"
-    return 1
-  fi
+  ") || { rm -f "$tmp"; return 1; }
+  case "$n" in ''|0|-*|*[!0-9-]*) rm -f "$tmp"; return 1 ;; esac
   mv "$tmp" "$path"
 }
 
@@ -177,19 +192,20 @@ prune_empty_hooks_file() {
   sql_path=$(sql_readfile_path "$path")
   local tmp
   tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
-  if ! sqlite3 :memory: "
+  local sql_tmp
+  sql_tmp=$(sql_readfile_path "$tmp")
+  local n
+  n=$(sqlite3 :memory: "
     WITH src AS (SELECT readfile('$sql_path') AS j)
-    SELECT CASE
+    SELECT writefile('$sql_tmp', CASE
       WHEN json_extract(src.j, '\$.hooks') IS NULL THEN src.j
       WHEN (SELECT count(*) FROM json_each(json_extract(src.j, '\$.hooks'))) = 0 THEN
         json_remove(src.j, '\$.hooks')
       ELSE src.j
-    END
+    END)
     FROM src;
-  " > "$tmp"; then
-    rm -f "$tmp"
-    return 1
-  fi
+  ") || { rm -f "$tmp"; return 1; }
+  case "$n" in ''|0|-*|*[!0-9-]*) rm -f "$tmp"; return 1 ;; esac
   mv "$tmp" "$path"
 }
 


### PR DESCRIPTION
## fix(delivery): "malformed JSON" on Windows Git Bash + sqlite3 3.53

### Summary

`delivery.sh set monitor|turn|both` fails on Windows + Git Bash with `Error in 2nd command line argument: malformed JSON` on the 4th sqlite3 call, leaving the user's `settings.local.json` empty (or with only a partial strip applied). The same delivery path works on Linux.

### Reproduction

```bash
# Git Bash on Windows, sqlite3.exe 3.53.2 (winget SQLite.SQLite)
mkdir -p /tmp/repro/.claude && echo '{}' > /tmp/repro/.claude/settings.local.json
./scripts/delivery.sh set monitor claude-code /tmp/repro
# → Error in 2nd command line argument: malformed JSON
```

Linux: works. Git Bash: fails at `add_event_entry_file SessionStart` (the 4th sqlite3 call after three `strip_agmsg_event_file` passes).

### Root cause

`strip_agmsg_event_file`, `add_event_entry_file`, and `prune_empty_hooks_file` all rewrite the temp state file with:

```bash
sqlite3 :memory: "<SELECT …>" > "$tmp"
```

On Windows, `sqlite3.exe`'s stdout is in text mode. Two compounding effects corrupt the temp file across the three strip passes:

1. Every embedded `\n` in the SELECT result is translated to `\r\n` on the way out.
2. Any bare CR byte present in the value (i.e. one that's not part of a CRLF pair) is rendered as the literal two-character ASCII sequence `^M` (`0x5E 0x4D`) — this is sqlite3 CLI's quoted-string rendering for unprintable control chars.

Watching the file evolve through the three strip passes (`xxd`):

```
initial               : {}                            7b7d
after strip #1        : {}\r\n                        7b7d 0d0a
after strip #2        : {}\r\r\n\r\n                  7b7d 0d0d 0a0d 0a
after strip #3        : {}^M\r\r\n\r\r\n\r\n          7b7d 5e4d 0d0d 0a0d 0d0a 0d0a
```

By the time `add_event_entry_file` runs, the file begins with the literal characters `{}^M…`, which is no longer valid JSON. `json_extract(readfile(…), '$.hooks')` throws "malformed JSON", the `SELECT` aborts, the second positional argument (the bash-built SQL string) is the one blamed, and the user gets the misleading error message.

(The `^M` only appears starting on the third pass because the first pass writes a value with no embedded CR — the CR-rendering only kicks in once the BLOB itself contains a CR.)

This explains every observed symptom:
- Re-running the exact failing SQL in another shell **succeeds** — the bug is the temp file's contents, not the SQL.
- Linux is unaffected — stdout text-mode translation is a Windows-only behaviour.
- It only manifests in `set monitor|turn|both` because those modes chain ≥4 sqlite3 rewrites of the same temp file; `status`/`stop` do not.
- A single trivial settings.local.json (`{}`) reproduces it deterministically.

### Fix

Replace each `sqlite3 :memory: "<select>" > "$tmp"` with `writefile()` in the SQL:

```sql
SELECT writefile('<tmp_win_path>', CASE … END) FROM …;
```

`writefile()` writes the raw bytes of its value argument with no text-mode translation on any platform. The output file ends up byte-identical to what the SQL produced — no trailing newline, no CR doubling, no `^M` rendering. Linux behaviour is unchanged (the redirect path already produced byte-identical output there, with the exception of one extra trailing `\n` that `readfile()` was tolerant of).

The patch also adds a return-code check on `writefile()` (`NULL`/`0` ⇒ treat as failure, drop the half-written tmp file, return 1) so a sqlite3 error doesn't silently replace the user's settings with an empty file.

### Files touched

- `scripts/delivery.sh`: 3 functions rewritten to use `writefile()` (`strip_agmsg_event_file`, `add_event_entry_file`, `prune_empty_hooks_file`). ~30 LOC of net additions, mostly a shared rationale comment.

### Before / after

Before (Windows Git Bash):
```
$ ./scripts/delivery.sh set monitor claude-code /tmp/repro
Error in 2nd command line argument: malformed JSON
```

After:
```
$ ./scripts/delivery.sh set monitor claude-code /tmp/repro
Delivery mode set to 'monitor' for /tmp/repro (claude-code)
Future sessions: SessionStart hook will auto-launch the watcher.
…
$ cat /tmp/repro/.claude/settings.local.json
{"hooks":{"SessionStart":[…],"SessionEnd":[…]}}
```

All four modes (`monitor`/`turn`/`both`/`off`) verified:
- Clean byte-perfect output (no CR, no trailing newline).
- Idempotent (`set monitor` twice → identical file hash).
- Preserves pre-existing non-agmsg hook entries.
- `set off` correctly prunes the `hooks` object when nothing remains.

### Test plan

- [ ] `bats tests/test_delivery.bats` passes on Linux (unchanged behaviour).
- [ ] On Windows Git Bash, `set monitor`/`set turn`/`set both`/`set off` round-trip without error.
- [ ] Pre-existing non-agmsg hooks in `settings.local.json` survive a full `monitor → off` cycle.
- [ ] `windows-latest` CI job in `.github/workflows` exercises `set monitor` end-to-end.

### Related issues

Should close (or substantially address) the following open Windows-compat reports:

- Fixes #143 — `set turn` still fails with malformed JSON on Windows after v1.0.5
- Fixes #138 — `set turn` fails with malformed JSON on Windows (v1.0.4)
- Fixes #134 — Windows compatibility: malformed JSON in delivery.sh
- Re-opens / supersedes #101 — `set` silently corrupts hooks file on native Windows (same root cause)
- Related #125 — CI: add `windows-latest` coverage for native Windows helpers (this PR's behaviour would be caught by that job)

### Notes

- The bug was masked by the preceding fix in #95 (which moved the settings blob off argv via `readfile()`). #95 fixed the `E2BIG` failure on Linux but introduced the temp-file round-trip pattern that this PR exposes as broken on Windows.
- A simpler "trim trailing CR/LF before next readfile" workaround was considered and rejected: it would mask the underlying `^M`-rendering issue, which would resurface the moment any string value happened to contain an embedded CR (e.g. a Windows-style path that some future contributor stores back in the file).
