### PR TITLE
fix(codex): resolve Codex thread by physical path so symlinked project paths match (#160)

### DIFF
--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -31,6 +31,22 @@
 
 _agmsg_run_dir() { printf '%s/run' "$SKILL_DIR"; }
 
+# Canonicalize a directory path by resolving symlinks to its physical location.
+# Portable on purpose: `cd && pwd -P` works on macOS bash 3.2 (no GNU realpath)
+# and Linux alike. Falls back to the input unchanged when the path doesn't
+# exist or isn't a directory, so non-existent inputs still compare as their
+# literal value. The `cd` runs in a command-substitution subshell, so the
+# caller's working directory is never affected. See #160.
+agmsg_canonical_path() {
+  local p="$1" phys
+  [ -n "$p" ] || { printf '%s' "$p"; return 0; }
+  if phys=$(cd "$p" 2>/dev/null && pwd -P); then
+    printf '%s' "$phys"
+  else
+    printf '%s' "$p"
+  fi
+}
+
 # Map an agent type to the binary basename(s) its process may carry.
 _agmsg_agent_binaries() {
   case "$1" in

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -40,7 +40,7 @@ _agmsg_run_dir() { printf '%s/run' "$SKILL_DIR"; }
 agmsg_canonical_path() {
   local p="$1" phys
   [ -n "$p" ] || { printf '%s' "$p"; return 0; }
-  if phys=$(cd "$p" 2>/dev/null && pwd -P); then
+  if phys=$(cd -- "$p" 2>/dev/null && pwd -P); then
     printf '%s' "$phys"
   else
     printf '%s' "$p"

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -52,7 +52,14 @@ agmsg_resolve_codex_thread() {
   fi
   local sessions_dir="$HOME/.codex/sessions"
   [ -d "$sessions_dir" ] || return 0
-  local waited=0 f first esc cwd tid
+  # Compare PHYSICAL paths. agmsg may open the project via a symlinked/logical
+  # path (e.g. a workspace under a symlinked home) while Codex records the
+  # canonical cwd in session_meta. A raw string compare then misses every
+  # rollout, so the thread is never resolved and the bridge never starts. See
+  # #160. Canonicalize the project once; canonicalize each rollout cwd per row.
+  local project_phys
+  project_phys=$(agmsg_canonical_path "$project")
+  local waited=0 f first esc cwd cwd_phys tid
   while :; do
     while IFS= read -r f; do
       [ -f "$f" ] || continue
@@ -60,7 +67,8 @@ agmsg_resolve_codex_thread() {
       case "$first" in *'"session_meta"'*) ;; *) continue ;; esac
       esc=$(printf '%s' "$first" | sed "s/'/''/g")
       cwd=$(sqlite3 ":memory:" "SELECT COALESCE(json_extract('$esc','\$.payload.cwd'),'')" 2>/dev/null)
-      [ "$cwd" = "$project" ] || continue
+      cwd_phys=$(agmsg_canonical_path "$cwd")
+      [ "$cwd_phys" = "$project_phys" ] || continue
       tid=$(sqlite3 ":memory:" "SELECT COALESCE(json_extract('$esc','\$.payload.id'),'')" 2>/dev/null)
       if [ -n "$tid" ]; then
         printf '%s' "$tid"

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -495,6 +495,49 @@ JSON
   unset CLAUDE_CODE_SESSION_ID
 }
 
+@test "session-start.sh for codex matches rollout cwd via a symlinked project path (#160)" {
+  # agmsg opens the project through a symlink (linkproj), but Codex records the
+  # canonical/physical cwd (realproj) in session_meta. A raw string compare
+  # misses the rollout, so the thread never resolves and the bridge never
+  # starts. With physical-path canonicalization the two reconcile.
+  local realproj="$TEST_PROJECT/realproj"
+  local linkproj="$TEST_PROJECT/linkproj"
+  mkdir -p "$realproj"
+  ln -s "$realproj" "$linkproj"
+  local phys
+  phys=$(cd "$realproj" && pwd -P)
+
+  bash "$SCRIPTS/join.sh" team alice codex "$linkproj" >/dev/null
+
+  # Stage a Codex rollout whose session_meta records the PHYSICAL cwd.
+  local sdir="$HOME/.codex/sessions/2026/06/19"
+  mkdir -p "$sdir"
+  printf '{"type":"session_meta","payload":{"id":"thread-sym","cwd":"%s"}}\n' "$phys" \
+    > "$sdir/rollout-test.jsonl"
+
+  local fake="$TEST_SKILL_DIR/fake-codex-bridge"
+  local log="$TEST_SKILL_DIR/fake-codex-bridge.log"
+  cat >"$fake" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$AGMSG_TEST_LOG"
+EOF
+  chmod +x "$fake"
+
+  # No CODEX_THREAD_ID -> forces the rollout-scan fallback that does the compare.
+  AGMSG_CODEX_BRIDGE_APP_SERVER="unix://$TEST_SKILL_DIR/run/codex-app-server.test.sock" \
+  AGMSG_CODEX_BRIDGE_CMD="$fake" \
+  AGMSG_TEST_LOG="$log" \
+    bash "$SCRIPTS/session-start.sh" codex "$linkproj" >/dev/null
+
+  for _ in {1..20}; do
+    [ -f "$log" ] && break
+    sleep 0.1
+  done
+
+  [ -f "$log" ]
+  grep -q -- "--thread thread-sym" "$log"
+}
+
 # --- gemini agent tests ---
 
 @test "delivery set turn (gemini): installs rule file" {

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -523,11 +523,14 @@ printf '%s\n' "$*" >> "$AGMSG_TEST_LOG"
 EOF
   chmod +x "$fake"
 
-  # No CODEX_THREAD_ID -> forces the rollout-scan fallback that does the compare.
+  # env -u CODEX_THREAD_ID forces the rollout-scan fallback that does the
+  # compare — without it, a CODEX_THREAD_ID inherited from the parent env (e.g.
+  # running the suite inside a Codex session) short-circuits the resolver and
+  # this test never exercises the path it's meant to cover.
   AGMSG_CODEX_BRIDGE_APP_SERVER="unix://$TEST_SKILL_DIR/run/codex-app-server.test.sock" \
   AGMSG_CODEX_BRIDGE_CMD="$fake" \
   AGMSG_TEST_LOG="$log" \
-    bash "$SCRIPTS/session-start.sh" codex "$linkproj" >/dev/null
+    env -u CODEX_THREAD_ID bash "$SCRIPTS/session-start.sh" codex "$linkproj" >/dev/null
 
   for _ in {1..20}; do
     [ -f "$log" ] && break


### PR DESCRIPTION
## Problem

`agmsg_resolve_codex_thread` in `scripts/session-start.sh` matched the agmsg project path against each Codex rollout's `session_meta` cwd using a **raw string compare**. When the project is opened through a symlinked/logical path while Codex records the canonical/physical cwd, the compare misses every rollout, the thread is never resolved, and the Codex bridge never starts.

Reported in #160 (thanks @naoak), who also pinpointed the fix: normalize both paths before comparing.

## Fix

- Add a portable `agmsg_canonical_path` helper in `scripts/lib/resolve-project.sh`. It canonicalizes a directory to its physical location via `cd -- "$p" && pwd -P` — deliberately avoiding GNU `realpath` (absent on macOS). Non-existent / non-directory inputs fall back to the literal value, so behavior is unchanged for those. The `cd` runs in a command-substitution subshell, so the caller's working directory is untouched.
- In `agmsg_resolve_codex_thread`, canonicalize the project once and each rollout cwd per row, then compare the physical paths.

## Test

- New regression test in `tests/test_delivery.bats`: opens the project via a symlink while staging a Codex rollout whose `session_meta` records the physical cwd, then asserts the bridge launches with the resolved `--thread`. The call is wrapped in `env -u CODEX_THREAD_ID` so an inherited thread id can't short-circuit the resolver and skip the path under test.
- Verified the test **fails without** the fix and **passes with** it.
- Full suites green (incl. with `CODEX_THREAD_ID` set in the parent env): `test_delivery` (86), `test_resolve_project`, `test_codex_bridge`, `test_hook`, `test_watch`, `test_actas_integration`.

Fixes #160