### PR TITLE
fix(storage): pass sqlite3 -escape off so the char(31) separator stays raw (#102)

### DIFF
--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -57,6 +57,26 @@ agmsg_db_path() {
 # PRAGMA returns its value as a row, which sqlite3 would print to stdout and
 # corrupt every SELECT's output (and the watch stream). `.timeout` sets the
 # same busy timeout silently.
+# sqlite3 >= 3.50 renders control bytes in CLI output using caret notation —
+# the char(31) record separator becomes the two literal chars "^_", and a CR
+# becomes "^M". That breaks the `IFS=$'\x1f' read` field splitting in
+# inbox/check-inbox/history and the monitor watch stream (#102), the same
+# sqlite3 >= 3.50 escaping behaviour behind #143. `-escape off` restores the
+# raw bytes. Older sqlite3 (< 3.50) doesn't know the option (and emits raw bytes
+# anyway), so probe once and only pass the flag when the build accepts it.
+_AGMSG_ESCAPE_FLAG=
+_AGMSG_ESCAPE_PROBED=
+_agmsg_escape_flag() {
+  if [ -z "$_AGMSG_ESCAPE_PROBED" ]; then
+    _AGMSG_ESCAPE_PROBED=1
+    if sqlite3 -escape off :memory: "SELECT 1;" >/dev/null 2>&1; then
+      _AGMSG_ESCAPE_FLAG="-escape off"
+    fi
+  fi
+  printf '%s' "$_AGMSG_ESCAPE_FLAG"
+}
+
 agmsg_sqlite() {
-  sqlite3 -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@"
+  # shellcheck disable=SC2046  # intentional split: "-escape off" → two args, or none
+  sqlite3 $(_agmsg_escape_flag) -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@"
 }

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -90,6 +90,19 @@ teardown() {
   [ "$output" = "only-this" ]
 }
 
+@test "storage: agmsg_sqlite emits a raw char(31) separator, not caret '^_' (#102)" {
+  # sqlite3 >= 3.50 renders control bytes with caret notation by default, which
+  # would turn the char(31) record separator into the two chars "^_" and break
+  # the IFS=$'\x1f' field splitting in inbox/history/check-inbox + the watch
+  # stream. agmsg_sqlite must pass -escape off so the byte stays raw. On older
+  # sqlite3 the byte is raw anyway, so this holds on every supported version.
+  source "$SCRIPTS/lib/storage.sh"
+  run agmsg_sqlite ":memory:" "SELECT 'a'||char(31)||'b';"
+  [ "$status" -eq 0 ]
+  printf '%s' "$output" | grep -q $'\x1f'
+  ! printf '%s' "$output" | grep -q '\^_'
+}
+
 @test "send: concurrent fan-out to N recipients all land (no SQLITE_BUSY)" {
   # Without a busy_timeout, concurrent writers fail with SQLITE_BUSY(5) and the
   # sends silently drop. With the wrapper they wait and all land. See #114.


### PR DESCRIPTION
## What

Fixes #102 — on **sqlite3 ≥ 3.50** the CLI escapes control bytes with caret notation by default, so the `char(31)` unit separator that `inbox.sh` / `check-inbox.sh` / `history.sh` (and the monitor watch stream) place between fields is emitted as the two literal characters `^_` (and a CR as `^M`). The `IFS=$'\x1f' read` field splitting then finds no separator and collapses every record into one mangled field — core message-display corruption. Reporter saw it on sqlite 3.51.1.

Same sqlite3 ≥ 3.50 escaping behaviour as #143; cross-platform, acute wherever a 3.50+ build is installed (Windows ships one, hence the overlap with the Windows reports).

## Fix

Central, single-point fix in `agmsg_sqlite()` (every DB-backed read goes through it): pass **`-escape off`**, which restores raw byte output. Older sqlite3 (< 3.50) doesn't know the option and emits raw bytes anyway, so the flag is **probed once** and only added when the build accepts it.

## Verification

- `agmsg_sqlite` emits a raw `0x1F` (not `^_`) on **both** sqlite 3.43 and 3.53.
- `inbox.sh` parses correctly under strict 3.53, where it was broken before the fix.
- `tests/test_storage.bats` + `tests/test_messaging.bats` green; a regression test for the raw separator is added.

Closes #102