### PR TITLE
fix(delivery): validate writefile() byte count, not just sqlite3 exit code

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -83,9 +83,17 @@ strip_agmsg_event_file() {
   # using caret notation ("^M"), corrupting the JSON so the next read fails
   # with "malformed JSON" (#143/#138, same root cause as #102). writefile()
   # emits the bytes verbatim. See also strip's readfile() (#95).
-  if ! sqlite3 :memory: "
-    WITH src AS (SELECT readfile('$sql_path') AS j)
-    SELECT writefile('$tmp_sql', coalesce(CASE
+  # Validate writefile()'s result, not just sqlite3's exit code. writefile()
+  # returns the byte count written and yields NULL on a failed write (e.g. an
+  # unwritable tmp dir) — but sqlite3 still exits 0, so an exit-code-only check
+  # would mv an empty/partial tmp over the original. Compare the bytes written
+  # to the content's byte length (CAST AS BLOB so multibyte content isn't
+  # miscounted by character-based length()); anything but an exact match fails.
+  # Guard contributed in #162 (kevinsj15).
+  local wrote
+  wrote=$(sqlite3 :memory: "
+    WITH src AS (SELECT readfile('$sql_path') AS j),
+    out AS (SELECT coalesce(CASE
       WHEN json_extract(src.j, '\$.hooks.$event') IS NULL THEN
         src.j
       WHEN (SELECT count(*) FROM json_each(json_extract(src.j, '\$.hooks.$event')) AS s
@@ -103,12 +111,10 @@ strip_agmsg_event_file() {
              WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
            ))
         )
-    END, ''))
-    FROM src;
-  " >/dev/null; then
-    rm -f "$tmp"
-    return 1
-  fi
+    END, '') AS blob FROM src)
+    SELECT writefile('$tmp_sql', blob) = length(CAST(blob AS BLOB)) FROM out;
+  ") || { rm -f "$tmp"; return 1; }
+  [ "$wrote" = "1" ] || { rm -f "$tmp"; return 1; }
   mv "$tmp" "$path"
 }
 
@@ -152,13 +158,16 @@ add_event_entry_file() {
   tmp_sql=$(sql_readfile_path "$tmp")
   # writefile() instead of CLI redirect — see strip_agmsg_event_file for why
   # (strict sqlite3 caret-escapes control bytes in CLI output, #143/#102).
-  if ! sqlite3 :memory: "
+  # Validate writefile()'s byte count vs the content length — see
+  # strip_agmsg_event_file for why the exit code alone is insufficient (#162).
+  local wrote
+  wrote=$(sqlite3 :memory: "
     WITH base AS (
       SELECT CASE WHEN json_extract(readfile('$sql_path'), '\$.hooks') IS NULL
                   THEN json_set(readfile('$sql_path'), '\$.hooks', json('{}'))
                   ELSE readfile('$sql_path') END AS s
-    )
-    SELECT writefile('$tmp_sql', CASE
+    ),
+    out AS (SELECT CASE
       WHEN json_extract(s, '\$.hooks.$event') IS NULL THEN
         json_set(s, '\$.hooks.$event', json_array(json('$entry_esc')))
       ELSE
@@ -169,12 +178,10 @@ add_event_entry_file() {
              SELECT '$entry_esc'
            ) v)
         )
-    END)
-    FROM base;
-  " >/dev/null; then
-    rm -f "$tmp"
-    return 1
-  fi
+    END AS blob FROM base)
+    SELECT writefile('$tmp_sql', blob) = length(CAST(blob AS BLOB)) FROM out;
+  ") || { rm -f "$tmp"; return 1; }
+  [ "$wrote" = "1" ] || { rm -f "$tmp"; return 1; }
   mv "$tmp" "$path"
 }
 
@@ -189,19 +196,20 @@ prune_empty_hooks_file() {
   tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
   tmp_sql=$(sql_readfile_path "$tmp")
   # writefile() instead of CLI redirect — see strip_agmsg_event_file (#143/#102).
-  if ! sqlite3 :memory: "
-    WITH src AS (SELECT readfile('$sql_path') AS j)
-    SELECT writefile('$tmp_sql', coalesce(CASE
+  # Validate writefile()'s byte count vs the content length — see
+  # strip_agmsg_event_file for why the exit code alone is insufficient (#162).
+  local wrote
+  wrote=$(sqlite3 :memory: "
+    WITH src AS (SELECT readfile('$sql_path') AS j),
+    out AS (SELECT coalesce(CASE
       WHEN json_extract(src.j, '\$.hooks') IS NULL THEN src.j
       WHEN (SELECT count(*) FROM json_each(json_extract(src.j, '\$.hooks'))) = 0 THEN
         json_remove(src.j, '\$.hooks')
       ELSE src.j
-    END, ''))
-    FROM src;
-  " >/dev/null; then
-    rm -f "$tmp"
-    return 1
-  fi
+    END, '') AS blob FROM src)
+    SELECT writefile('$tmp_sql', blob) = length(CAST(blob AS BLOB)) FROM out;
+  ") || { rm -f "$tmp"; return 1; }
+  [ "$wrote" = "1" ] || { rm -f "$tmp"; return 1; }
   mv "$tmp" "$path"
 }
 

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -128,6 +128,25 @@ settings_file() {
   [ "$p" = "Bash" ]
 }
 
+@test "delivery set monitor: round-trips multibyte (UTF-8) settings without a short-write reject" {
+  # The writefile() guard compares bytes written to the content's BYTE length
+  # (CAST AS BLOB). A character-length comparison would mismatch on multibyte
+  # content and wrongly reject the write, so set monitor would fail. Seed an
+  # unrelated multibyte value and confirm the write succeeds and survives.
+  mkdir -p "$TEST_PROJECT/.claude"
+  printf '%s\n' '{"note":"日本語のメモ — ünïcödé ✓","permissions":{"allow":["Bash"]}}' > "$(settings_file)"
+
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+
+  # Still valid JSON, the multibyte value survived byte-for-byte, hook landed.
+  local valid
+  valid=$(sqlite3 :memory: "SELECT json_valid(readfile('$(settings_file)'));")
+  [ "$valid" = "1" ]
+  grep -q "日本語のメモ" "$(settings_file)"
+  grep -q "session-start.sh" "$(settings_file)"
+}
+
 # --- status derives mode from settings.local.json ---
 
 @test "delivery status: derives 'both' from settings with SessionStart + Stop" {


### PR DESCRIPTION
## Problem

#158 routed the hook-file rewrites in `delivery.sh` through `writefile()` to stop the Windows sqlite3 CLI from caret-escaping control bytes and corrupting the JSON. But it still gated success only on **sqlite3's exit code**.

`writefile()` returns the byte count written and yields **NULL on a failed write** (e.g. an unwritable tmp dir) — while sqlite3 still **exits 0**. So a failed or short write slipped past the exit-code check and the function would `mv` an empty/partial tmp over the user's settings file.

Reproduction (confirmed): `sqlite3 :memory: "SELECT writefile('/no/such/dir/x','abc');"` prints empty/NULL yet exits 0.

## Fix

`strip_agmsg_event_file`, `add_event_entry_file`, and `prune_empty_hooks_file` now compare `writefile()`'s returned byte count against the content's **byte length** and fail (without replacing the original) on anything but an exact match:

```sql
... out AS (SELECT <content> AS blob FROM ...)
SELECT writefile('$tmp_sql', blob) = length(CAST(blob AS BLOB)) FROM out;
```

- The content is hoisted into an `out` CTE so it isn't evaluated twice.
- `CAST(blob AS BLOB)` gives the **byte** length — a character-based `length()` would mismatch on multibyte (UTF-8) content (e.g. a project path or hook command containing non-ASCII) and wrongly reject a perfectly good write.

## Tests

- New regression: `delivery set monitor` round-trips multibyte (UTF-8) settings without a short-write reject. **Verified non-vacuous** — it fails if the comparison uses character-length instead of `CAST AS BLOB`.
- Full Bats suite green (342).

## Credit

The return-value guard was contributed by @kevinsj15 in #162; this takes the byte-length-comparison form suggested in review. Follows up #158 (which closed #143/#138).