### PR TITLE
feat(check-inbox): add watermark to prevent stale message re-delivery

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -121,11 +121,16 @@ if [ -f "$WATERMARK_FILE" ]; then
   case "$WATERMARK" in ''|*[!0-9]*) WATERMARK="" ;; esac
 fi
 if [ -z "$WATERMARK" ]; then
-  WATERMARK="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages;" 2>/dev/null || echo 0)"
+  # Seed from the latest *read* message for this agent so that current unread
+  # messages are still delivered on the first check (unlike watch.sh which seeds
+  # at MAX(id) since monitor mode only cares about post-attach messages).
+  WATERMARK="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE to_agent='$AGENT' AND read_at IS NOT NULL;" 2>/dev/null || echo 0)"
   case "$WATERMARK" in ''|*[!0-9]*) WATERMARK=0 ;; esac
   persist_check_watermark
 else
-  DB_MAX="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages;" 2>/dev/null || echo 0)"
+  # Safety valve: if the DB was recreated (id space shrank), clamp the
+  # watermark down so we don't skip the entire new store.
+  DB_MAX="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE to_agent='$AGENT';" 2>/dev/null || echo 0)"
   case "$DB_MAX" in ''|*[!0-9]*) DB_MAX=0 ;; esac
   if [ "$DB_MAX" -lt "$WATERMARK" ]; then
     WATERMARK="$DB_MAX"

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -78,6 +78,8 @@ if [ -z "$AGENT" ] || [ -z "$TEAMS" ]; then
   exit 0
 fi
 
+WATERMARK_FILE="$SKILL_DIR/run/check-inbox.$AGENT.watermark"
+
 # Cooldown check. The marker is hook runtime state, not message storage, so it
 # lives in the skill's run dir — independent of AGMSG_STORAGE_PATH. Keeping it
 # out of the store means an overridden/sandboxed store still gets delivery even
@@ -109,6 +111,29 @@ touch "$MARKER"
 DB="$(agmsg_db_path)"
 if [ ! -f "$DB" ]; then exit 0; fi
 
+# Watermark: deliver only messages newer than the last delivered id, preventing
+# old unread messages from being replayed on every check (mirrors watch.sh).
+persist_check_watermark() { printf '%s\n' "$WATERMARK" > "$WATERMARK_FILE" 2>/dev/null || true; }
+
+WATERMARK=""
+if [ -f "$WATERMARK_FILE" ]; then
+  WATERMARK="$(cat "$WATERMARK_FILE" 2>/dev/null || true)"
+  case "$WATERMARK" in ''|*[!0-9]*) WATERMARK="" ;; esac
+fi
+if [ -z "$WATERMARK" ]; then
+  WATERMARK="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages;" 2>/dev/null || echo 0)"
+  case "$WATERMARK" in ''|*[!0-9]*) WATERMARK=0 ;; esac
+  persist_check_watermark
+else
+  DB_MAX="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages;" 2>/dev/null || echo 0)"
+  case "$DB_MAX" in ''|*[!0-9]*) DB_MAX=0 ;; esac
+  if [ "$DB_MAX" -lt "$WATERMARK" ]; then
+    WATERMARK="$DB_MAX"
+    persist_check_watermark
+  fi
+fi
+
+LOOP_WM=$WATERMARK
 OUTPUT=""
 IFS=',' read -ra TEAM_LIST <<< "$TEAMS"
 for team in "${TEAM_LIST[@]}"; do
@@ -130,7 +155,7 @@ for team in "${TEAM_LIST[@]}"; do
 
   RESULT=$(agmsg_sqlite "$DB" "
     SELECT from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
-    FROM messages WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL
+    FROM messages WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL AND id > $LOOP_WM
     ORDER BY created_at ASC;
   ")
   if [ -n "$RESULT" ]; then
@@ -141,9 +166,17 @@ for team in "${TEAM_LIST[@]}"; do
     done <<< "$RESULT"
     OUTPUT+=$'\n'
     # Mark as read
-    agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
+    agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL AND id > $LOOP_WM;" 2>/dev/null || true
   fi
 done
+
+# Advance watermark once across all teams after the loop.
+NEW_WM="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE to_agent='$AGENT' AND id > $LOOP_WM;" 2>/dev/null || echo 0)"
+case "$NEW_WM" in ''|*[!0-9]*) NEW_WM=0 ;; esac
+if [ "$NEW_WM" -gt "$WATERMARK" ]; then
+  WATERMARK="$NEW_WM"
+  persist_check_watermark
+fi
 
 # No new messages
 if [ -z "$OUTPUT" ]; then

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -78,7 +78,7 @@ _agmsg_escape_flag() {
 
 agmsg_sqlite() {
   # shellcheck disable=SC2046  # intentional split: "-escape off" → two args, or none
-  sqlite3 $(_agmsg_escape_flag) -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@"
+  sqlite3 $(_agmsg_escape_flag) -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@" | tr -d '\r'
 }
 
 # In-memory sqlite for JSON parsing / scalar lookups whose stdout is captured in


### PR DESCRIPTION
## Summary

- Introduces a per-agent watermark file to track the highest delivered message id in check-inbox.sh
- Prevents unread messages that accumulated during agent downtime from being replayed on reconnect
- Aligns turn-mode delivery (check-inbox.sh) with monitor-mode delivery (watch.sh), which already uses a watermark

## Problem

check-inbox.sh filters unread messages with WHERE read_at IS NULL and no lower-bound on id. For agents using turn delivery mode (Antigravity / Gemini PostToolUse, Codex Stop hook), the hook fires only when the agent is active. Any messages sent while the agent was offline accumulate in the database with read_at IS NULL. When the agent next becomes active and the hook fires, **all accumulated messages are delivered at once**, no matter how old they are.

This means an agent can receive and act on instructions that were relevant to a session that ended hours or days ago, leading to unintended behaviour.

watch.sh (used in monitor mode) already avoids this by setting a watermark to MAX(id) at startup and only streaming messages with id > watermark. check-inbox.sh had no equivalent protection.

## Solution

Add a per-agent watermark persisted at SKILL_DIR/run/check-inbox.agent.watermark:

- **Initialisation**: on first invocation (no watermark file), seed the watermark from `MAX(id) WHERE to_agent='$AGENT' AND read_at IS NOT NULL` — the latest *already-read* message for this agent. This ensures that **current unread messages are delivered on the first check**, unlike watch.sh which seeds at `MAX(id)` (monitor mode only cares about post-attach messages). This is an intentional divergence: turn-mode's first check legitimately needs to drain pending unread.
- **Query filter**: append AND id > LOOP_WM to both the SELECT and UPDATE statements, where LOOP_WM is the watermark snapshotted before the team loop begins.
- **Watermark advance**: after all teams are processed, query MAX(id) WHERE to_agent = AGENT AND id > LOOP_WM across all teams and persist the result. Advancing once after the loop (rather than per-team) ensures agents belonging to multiple teams never skip messages whose ids fall between two teams maxima.
- **Safety valve**: if the stored watermark exceeds the DB's current `MAX(id) WHERE to_agent='$AGENT'` (DB wiped and recreated), reset to that agent-scoped max to prevent permanent message silence. Both the seed and the safety valve are scoped to `to_agent` to avoid being influenced by other agents' message ids.
- **Windows CR strip**: `agmsg_sqlite()` (the on-disk DB wrapper) now pipes through `tr -d '\r'`, mirroring `agmsg_sqlite_mem()`. On Windows, `sqlite3.exe` emits `\r\n`; without stripping, the watermark integer validation rejects the value and silently resets to 0, making the watermark inert.

No other files are modified. Existing cooldown, actas-lock, and monitor-deferral logic is unchanged.

## Behaviour change

The first turn-mode check now **delivers current unread messages** (seeded from the latest read id, not the global max). This differs from the original implementation which seeded at `MAX(id)` and delivered nothing on the first check. The new behaviour matches what users and the existing CI tests expect: send a message, start the agent, first check delivers it.

## Testing

**Basic replay prevention**

1. Join an agent to a team with turn delivery mode.
2. While the agent is not running, send several messages to it via send.sh.
3. Start the agent and trigger check-inbox.sh manually.
4. Verify: the watermark file is created and current unread messages are delivered on the first check.
5. Send a new message while the agent is active.
6. Trigger check-inbox.sh again; verify the new message is delivered and the watermark advances.

**Multi-team correctness**

1. Register the same agent in two teams.
2. Send messages to both teams (both above the current watermark).
3. Invoke check-inbox.sh; verify both messages are delivered in the same run.

**Safety valve (DB recreation)**

1. Write a watermark value larger than the current DB MAX(id).
2. Invoke check-inbox.sh; verify the watermark is reset and delivery resumes normally.

**Per-agent isolation**

1. Register two agents (A and B) in the same team.
2. Send a message to A only.
3. Verify B's watermark is not influenced by A's message id.
