### PR TITLE
fix(npm): pin install to the bootstrapper's version, not main

### DIFF
--- a/bin/agmsg.js
+++ b/bin/agmsg.js
@@ -29,9 +29,23 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const SETUP_URL = 'https://raw.githubusercontent.com/fujibee/agmsg/main/setup.sh';
+const RAW_BASE = 'https://raw.githubusercontent.com/fujibee/agmsg';
 const REPO_URL = 'https://github.com/fujibee/agmsg';
 const HOMEPAGE = 'https://agmsg.cc';
+
+// Install the repo ref that matches THIS bootstrapper's version, so
+// `npx agmsg@X` installs X — not whatever happens to be on main. We fetch
+// setup.sh from the matching tag AND pass AGMSG_REF so setup.sh clones the
+// same tag. Falls back to main only when the version can't be read (e.g. a
+// dev checkout with no published tag). See #172.
+//
+// Bootstrappers published before this fix (<= 1.0.5) hardcoded main and
+// cannot be retrofitted — `npx agmsg@1.0.5` will still pull main. Pinning
+// holds from the first release that ships this file (1.0.6) onward.
+function installRef() {
+  const v = readVersion();
+  return v && v !== '?' ? 'v' + v : 'main';
+}
 
 function readVersion() {
   try {
@@ -75,21 +89,27 @@ function runInstaller(passthroughArgs) {
   // bootstrapper plus a still-vulnerable install.sh would also work; doing it
   // correctly here is defense-in-depth and lets future interactive prompts
   // in setup.sh keep working for real-tty users.
+  const ref = installRef();
+  const setupUrl = RAW_BASE + '/' + ref + '/setup.sh';
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agmsg-bootstrap-'));
   const setupPath = path.join(tmpDir, 'setup.sh');
 
   try {
-    const fetch = spawnSync('curl', ['-fsSL', '-o', setupPath, SETUP_URL], { stdio: 'inherit' });
+    const fetch = spawnSync('curl', ['-fsSL', '-o', setupPath, setupUrl], { stdio: 'inherit' });
     if (fetch.error) {
       console.error('agmsg: failed to launch curl:', fetch.error.message);
       process.exit(1);
     }
     if (fetch.status !== 0) {
-      console.error('agmsg: curl exited ' + fetch.status + ' fetching ' + SETUP_URL);
+      console.error('agmsg: curl exited ' + fetch.status + ' fetching ' + setupUrl);
       process.exit(fetch.status || 1);
     }
 
-    const result = spawnSync('bash', [setupPath, ...passthroughArgs], { stdio: 'inherit' });
+    // Pin the clone inside setup.sh to the same ref we fetched it from.
+    const result = spawnSync('bash', [setupPath, ...passthroughArgs], {
+      stdio: 'inherit',
+      env: Object.assign({}, process.env, { AGMSG_REF: ref })
+    });
     if (result.error) {
       console.error('agmsg: failed to launch bash:', result.error.message);
       process.exit(1);

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+# Which ref of the canonical repo to install. The npm bootstrapper
+# (bin/agmsg.js) sets AGMSG_REF to the tag matching its own version
+# (e.g. v1.0.6) so `npx agmsg@X` installs X — not whatever is on main.
+# The README's `curl .../main/setup.sh` form leaves it unset and gets
+# main (the latest). See #172.
+REF="${AGMSG_REF:-main}"
+
 TMP=$(mktemp -d)
-git clone --depth 1 https://github.com/fujibee/agmsg.git "$TMP/agmsg" 2>/dev/null
+if ! git clone --depth 1 --branch "$REF" https://github.com/fujibee/agmsg.git "$TMP/agmsg" 2>/dev/null; then
+  echo "agmsg: failed to clone ref '$REF' from https://github.com/fujibee/agmsg.git" >&2
+  rm -rf "$TMP"
+  exit 1
+fi
 "$TMP/agmsg/install.sh" "$@"
 rm -rf "$TMP"


### PR DESCRIPTION
## Summary
`npx agmsg@X` (and an installed `agmsg@X`) currently installs whatever is on `main`, ignoring the pinned version. Both layers of the bootstrapper were hardcoded to `main`:

1. `bin/agmsg.js` fetched setup.sh from `.../fujibee/agmsg/main/setup.sh`.
2. `setup.sh` ran `git clone --depth 1 …` with no ref (default branch = `main`).

## Fix
- `bin/agmsg.js`: derive the ref from the bootstrapper's own version (`v${version}`), fetch setup.sh from that tag, and pass `AGMSG_REF` to setup.sh. Falls back to `main` when the version can't be read.
- `setup.sh`: read `AGMSG_REF` (default `main`) and `git clone --depth 1 --branch "$AGMSG_REF"`, with a clean error if the ref can't be cloned.

## Verification
- `node --check bin/agmsg.js`; `--version` / `--help` / unknown-arg exit code all correct.
- `installRef()` resolves `1.0.5` → `v1.0.5` → correct setup URL + `AGMSG_REF`.
- Tag-pinned clone proven against a real tag (`--branch v1.0.4` yields VERSION 1.0.4, not main); a bogus ref fails cleanly.
- Full bats suite: 345/346 pass. The single failure (`watch: closed consumer does not advance watermark past an undelivered row`) is pre-existing on `main` and environment-specific (SIGPIPE/`head` timing), unrelated to this change.

## Known limitation
Bootstrappers published at or before 1.0.5 hardcode `main` and cannot be retrofitted; `npx agmsg@1.0.5` will still pull `main`. Pinning holds from the first release that ships this fix (1.0.6) onward.

Closes #172