### PR TITLE
fix(codex): engage the monitor bridge on codex 0.141 (ws transport + loaded-thread discovery)

### DIFF
--- a/scripts/codex-bridge-launcher.sh
+++ b/scripts/codex-bridge-launcher.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Runs outside Codex's tool sandbox, waiting for SessionStart to publish the
-# current thread id. The hook only writes a request file; this launcher owns the
-# app-server socket connection and starts codex-bridge.js from the unsandboxed
-# codex-monitor.sh wrapper process.
+# Runs outside Codex's tool sandbox and owns the app-server connection: it starts
+# codex-bridge.js for this project's single codex identity.
+#
+# On codex 0.141+ the SessionStart hook cannot resolve the thread id
+# (CODEX_THREAD_ID is not exported and no rollout is written for --remote
+# sessions), so the bridge discovers the live TUI thread itself via
+# thread/loaded/list (`--thread loaded`). If an older codex DID write a request
+# file with a real thread id, that id is used instead. See #170, #41.
 
 TYPE="${1:?Usage: codex-bridge-launcher.sh <type> <project_path> <app_server> <parent_pid>}"
 PROJECT="${2:?Missing project_path}"
@@ -16,42 +20,69 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUN_DIR="$SKILL_DIR/run"
 PROJECT_HASH="$(printf '%s' "$PROJECT" | shasum | awk '{print $1}')"
 REQUEST_FILE="$RUN_DIR/codex-bridge-request.$PROJECT_HASH"
+TAB="$(printf '\t')"
 
 mkdir -p "$RUN_DIR"
 
-last_request=""
+resolve_identity() {  # prints "team<TAB>name" lines for the project's codex roles
+  "$SCRIPT_DIR/identities.sh" "$PROJECT" "$TYPE" 2>/dev/null \
+    | awk -v t="$TAB" 'NF >= 2 { print $1 t $2 }' \
+    | sort -u
+}
+
+# actas may register the role a moment after launch, so retry while the parent
+# (codex-monitor.sh) is alive. Proceed only when exactly one identity resolves.
+team="" name=""
 while kill -0 "$PARENT_PID" 2>/dev/null; do
-  if [ -f "$REQUEST_FILE" ]; then
-    request="$(cat "$REQUEST_FILE" 2>/dev/null || true)"
-    if [ -n "$request" ] && [ "$request" != "$last_request" ]; then
-      last_request="$request"
-      IFS="$(printf '\t')" read -r req_type team name thread_id req_app_server <<EOF
-$request
+  ids="$(resolve_identity || true)"
+  count="$(printf '%s\n' "$ids" | grep -c . || true)"
+  if [ "$count" = "1" ]; then
+    IFS="$TAB" read -r team name <<EOF
+$ids
 EOF
-      [ -n "${req_type:-}" ] || req_type="$TYPE"
-      [ -n "${req_app_server:-}" ] || req_app_server="$APP_SERVER"
-      if [ -n "${team:-}" ] && [ -n "${name:-}" ] && [ -n "${thread_id:-}" ]; then
-        pidfile="$RUN_DIR/codex-bridge.$team.$name.pid"
-        if [ -f "$pidfile" ]; then
-          bridge_pid="$(cat "$pidfile" 2>/dev/null || true)"
-          if [ -n "$bridge_pid" ] && kill -0 "$bridge_pid" 2>/dev/null; then
-            sleep 0.2
-            continue
-          fi
-        fi
-        log="$RUN_DIR/codex-bridge.$team.$name.log"
-        bridge_cmd="${AGMSG_CODEX_BRIDGE_CMD:-$SCRIPT_DIR/codex-bridge.js}"
-        nohup "$bridge_cmd" \
-          --project "$PROJECT" \
-          --type "$req_type" \
-          --team "$team" \
-          --name "$name" \
-          --thread "$thread_id" \
-          --app-server "$req_app_server" \
-          --inline-inbox \
-          >>"$log" 2>&1 &
-      fi
+    [ -n "$team" ] && [ -n "$name" ] && break
+    team="" name=""
+  fi
+  sleep 0.3
+done
+[ -n "$team" ] && [ -n "$name" ] || exit 0
+
+pidfile="$RUN_DIR/codex-bridge.$team.$name.pid"
+log="$RUN_DIR/codex-bridge.$team.$name.log"
+bridge_cmd="${AGMSG_CODEX_BRIDGE_CMD:-$SCRIPT_DIR/codex-bridge.js}"
+
+while kill -0 "$PARENT_PID" 2>/dev/null; do
+  if [ -f "$pidfile" ]; then
+    bridge_pid="$(cat "$pidfile" 2>/dev/null || true)"
+    if [ -n "$bridge_pid" ] && kill -0 "$bridge_pid" 2>/dev/null; then
+      sleep 0.3
+      continue
     fi
   fi
-  sleep 0.2
+
+  # Thread source: a request file (older-codex hook) wins; otherwise discover the
+  # live TUI thread via thread/loaded/list.
+  thread_id="loaded"
+  req_app_server="$APP_SERVER"
+  if [ -f "$REQUEST_FILE" ]; then
+    request="$(cat "$REQUEST_FILE" 2>/dev/null || true)"
+    if [ -n "$request" ]; then
+      IFS="$TAB" read -r _rtype _rteam _rname _rthread _rapp <<EOF
+$request
+EOF
+      [ -n "${_rthread:-}" ] && thread_id="$_rthread"
+      [ -n "${_rapp:-}" ] && req_app_server="$_rapp"
+    fi
+  fi
+
+  nohup "$bridge_cmd" \
+    --project "$PROJECT" \
+    --type "$TYPE" \
+    --team "$team" \
+    --name "$name" \
+    --thread "$thread_id" \
+    --app-server "$req_app_server" \
+    --inline-inbox \
+    >>"$log" 2>&1 &
+  sleep 1
 done

--- a/scripts/codex-bridge-launcher.sh
+++ b/scripts/codex-bridge-launcher.sh
@@ -20,6 +20,10 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUN_DIR="$SKILL_DIR/run"
 PROJECT_HASH="$(printf '%s' "$PROJECT" | shasum | awk '{print $1}')"
 REQUEST_FILE="$RUN_DIR/codex-bridge-request.$PROJECT_HASH"
+
+# shellcheck source=lib/node.sh
+source "$SCRIPT_DIR/lib/node.sh"
+NODE_BIN="$(agmsg_resolve_node)"
 TAB="$(printf '\t')"
 
 mkdir -p "$RUN_DIR"
@@ -75,7 +79,7 @@ EOF
     fi
   fi
 
-  nohup "$bridge_cmd" \
+  nohup "$NODE_BIN" "$bridge_cmd" \
     --project "$PROJECT" \
     --type "$TYPE" \
     --team "$team" \

--- a/scripts/codex-bridge-launcher.sh
+++ b/scripts/codex-bridge-launcher.sh
@@ -53,7 +53,15 @@ done
 
 pidfile="$RUN_DIR/codex-bridge.$team.$name.pid"
 log="$RUN_DIR/codex-bridge.$team.$name.log"
-bridge_cmd="${AGMSG_CODEX_BRIDGE_CMD:-$SCRIPT_DIR/codex-bridge.js}"
+# An explicit AGMSG_CODEX_BRIDGE_CMD is a complete runnable (tests, custom
+# wrappers) — run it as-is. Only the default codex-bridge.js is launched through
+# a resolved Node, since its env-node shebang fails where a version-manager Node
+# is not on PATH (#170).
+if [ -n "${AGMSG_CODEX_BRIDGE_CMD:-}" ]; then
+  bridge_run=("$AGMSG_CODEX_BRIDGE_CMD")
+else
+  bridge_run=("$NODE_BIN" "$SCRIPT_DIR/codex-bridge.js")
+fi
 
 while kill -0 "$PARENT_PID" 2>/dev/null; do
   if [ -f "$pidfile" ]; then
@@ -79,7 +87,7 @@ EOF
     fi
   fi
 
-  nohup "$NODE_BIN" "$bridge_cmd" \
+  nohup "${bridge_run[@]}" \
     --project "$PROJECT" \
     --type "$TYPE" \
     --team "$team" \

--- a/scripts/codex-bridge.js
+++ b/scripts/codex-bridge.js
@@ -27,8 +27,12 @@ Options:
   --max-wakes <n>         Stop after n wakeups, useful for tests.
   --stale-wake-limit <n>  Stop after n repeated unchanged wakeups (default: 1).
   --app-server <url>      Connect through an existing app-server endpoint.
-                          Currently supports unix://PATH over WebSocket.
-  --thread <id|current>   Resume an existing app-server thread. "current" uses CODEX_THREAD_ID.
+                          Supports unix://PATH or ws://host:port over WebSocket.
+  --thread <id|current|loaded>
+                          Resume an existing app-server thread. "current" uses
+                          CODEX_THREAD_ID; "loaded" discovers the live TUI thread
+                          via thread/loaded/list (codex 0.141+, see #170).
+  --loaded-timeout <ms>   Max wait for a loaded thread to appear (default: 30000).
   --inline-inbox          Read inbox in the bridge and include message text in the turn input.
   --resolve-only          Print resolved team/name and exit.
   --help                  Show this help.
@@ -80,6 +84,8 @@ function parseArgs(argv) {
       opts.appServer = argv[++i];
     } else if (arg === "--thread") {
       opts.threadId = argv[++i];
+    } else if (arg === "--loaded-timeout") {
+      opts.loadedTimeout = Number(argv[++i]);
     } else if (arg === "--inline-inbox") {
       opts.inlineInbox = true;
     } else {
@@ -247,9 +253,15 @@ class AppServerClient {
   }
 }
 
-class UnixWebSocketAppServerClient {
-  constructor(socketPath) {
-    this.socketPath = socketPath;
+// WebSocket app-server client. The handshake and framing are transport-agnostic;
+// only the connection target differs: a unix socket path ({ path }) for
+// `--app-server unix://…`, or a TCP host/port ({ host, port }) for
+// `--app-server ws://host:port` (codex 0.141+ accepts only ws:// for `--remote`,
+// see #170).
+class WebSocketAppServerClient {
+  constructor(connectOptions, label) {
+    this.connectOptions = connectOptions;
+    this.label = label || "app-server";
     this.nextId = 1;
     this.pending = new Map();
     this.handlers = new Map();
@@ -269,7 +281,7 @@ class UnixWebSocketAppServerClient {
         .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
         .digest("base64");
 
-      this.socket = net.createConnection(this.socketPath);
+      this.socket = net.createConnection(this.connectOptions);
       this.socket.on("connect", () => {
         this.socket.write(
           [
@@ -290,7 +302,7 @@ class UnixWebSocketAppServerClient {
         reject(error);
       });
       this.socket.on("close", () => {
-        this.rejectAll(new Error("app-server socket closed"));
+        this.rejectAll(new Error(`app-server connection closed (${this.label})`));
       });
     });
   }
@@ -566,7 +578,34 @@ class CodexBridge {
     this.client.notify("initialized");
   }
 
+  async resolveLoadedThread() {
+    // codex 0.141+ does not export CODEX_THREAD_ID to hooks and writes no rollout
+    // for --remote sessions, so the thread id cannot be resolved out-of-band.
+    // Ask the app-server which thread the live TUI has loaded instead. See #170.
+    const deadline = Date.now() + (this.opts.loadedTimeout || 30000);
+    for (;;) {
+      const response = await this.client.request("thread/loaded/list", {});
+      const ids = response && Array.isArray(response.data) ? response.data : [];
+      if (ids.length > 0) {
+        if (ids.length > 1) {
+          console.error(
+            `codex-bridge: ${ids.length} threads loaded; attaching to the first (${ids[0]})`,
+          );
+        }
+        return ids[0];
+      }
+      if (Date.now() >= deadline) {
+        die("no loaded codex thread found via thread/loaded/list");
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+
   async ensureThread() {
+    if (this.threadId === "loaded") {
+      this.threadId = await this.resolveLoadedThread();
+      console.error(`codex-bridge: discovered loaded thread ${this.threadId}`);
+    }
     if (this.threadId) {
       const response = await this.client.request("thread/resume", {
         threadId: this.threadId,
@@ -896,10 +935,10 @@ function appServerCommand(opts = {}) {
     if (opts.appServer === "stdio://" || opts.appServer === "stdio") {
       return ["codex", "app-server", "--listen", "stdio://"];
     }
-    if (opts.appServer.startsWith("unix://")) {
-      die("--app-server unix:// is handled by the direct WebSocket client");
+    if (opts.appServer.startsWith("unix://") || opts.appServer.startsWith("ws://")) {
+      die("--app-server unix://PATH or ws://host:port is handled by the direct WebSocket client");
     }
-    die("--app-server currently supports only unix://PATH");
+    die("--app-server supports only unix://PATH or ws://host:port");
   }
   if (process.env.AGMSG_CODEX_APP_SERVER_CMD) {
     return ["/bin/sh", "-lc", process.env.AGMSG_CODEX_APP_SERVER_CMD];
@@ -907,12 +946,28 @@ function appServerCommand(opts = {}) {
   return ["codex", "app-server", "--listen", "stdio://"];
 }
 
+function parseWsTarget(url) {
+  // ws://host:port → { host, port }. wss:// would need TLS, which the plain
+  // net socket below does not do; the agmsg app-server is loopback ws only.
+  const match = /^ws:\/\/([^/:]+):(\d+)\/?$/.exec(url);
+  if (!match) die(`--app-server ${url} must be ws://host:port`);
+  const port = Number(match[2]);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    die(`--app-server ${url} has an invalid port`);
+  }
+  return { host: match[1], port };
+}
+
 function createAppServerClient(opts) {
   if (opts.appServer && opts.appServer.startsWith("unix://")) {
     const rawSocketPath = opts.appServer.slice("unix://".length);
     if (!rawSocketPath) die("--app-server unix:// requires a socket path");
     const socketPath = path.isAbsolute(rawSocketPath) ? rawSocketPath : path.resolve(process.cwd(), rawSocketPath);
-    return new UnixWebSocketAppServerClient(socketPath);
+    return new WebSocketAppServerClient({ path: socketPath }, `unix://${socketPath}`);
+  }
+  if (opts.appServer && opts.appServer.startsWith("ws://")) {
+    const target = parseWsTarget(opts.appServer);
+    return new WebSocketAppServerClient(target, opts.appServer);
   }
   return new AppServerClient(appServerCommand(opts), opts.project);
 }

--- a/scripts/codex-monitor.sh
+++ b/scripts/codex-monitor.sh
@@ -19,11 +19,14 @@ REAL_CODEX="${AGMSG_REAL_CODEX:-codex}"
 
 usage() {
   cat <<EOF
-Usage: codex-monitor.sh [--project <path>] [--socket-path <path>] [--codex-command <codex|resume>] [-- <args...>]
+Usage: codex-monitor.sh [--project <path>] [--codex-command <codex|resume>] [-- <args...>]
 
-Starts/reuses an agmsg-managed Codex app-server socket, enables agmsg Codex
-bridge hooks for this project, then execs:
-  codex resume --remote <socket>
+Starts/reuses an agmsg-managed Codex app-server on a loopback ws:// port,
+enables agmsg Codex bridge delivery for this project, then execs:
+  codex resume --remote ws://127.0.0.1:<port>
+
+(--socket-path is accepted for compatibility but ignored: codex 0.141+ requires
+a ws:// transport for --remote. See #170.)
 EOF
 }
 
@@ -67,31 +70,48 @@ esac
 
 PROJECT="$(cd "$PROJECT" && pwd)"
 PROJECT_HASH="$(printf '%s' "$PROJECT" | shasum | awk '{print $1}')"
-[ -n "$SOCKET_PATH" ] || SOCKET_PATH="$RUN_DIR/codex-app-server.$PROJECT_HASH.sock"
-case "$SOCKET_PATH" in
-  /*) ;;
-  *) SOCKET_PATH="$PROJECT/$SOCKET_PATH" ;;
-esac
-SOCKET_URL="unix://$SOCKET_PATH"
 SERVER_LOG="$RUN_DIR/codex-app-server.$PROJECT_HASH.log"
 SERVER_PID="$RUN_DIR/codex-app-server.$PROJECT_HASH.pid"
+PORT_FILE="$RUN_DIR/codex-app-server.$PROJECT_HASH.port"
 
-mkdir -p "$RUN_DIR" "$(dirname "$SOCKET_PATH")"
+mkdir -p "$RUN_DIR"
 
-if [ ! -S "$SOCKET_PATH" ]; then
-  "$REAL_CODEX" app-server --listen "$SOCKET_URL" >>"$SERVER_LOG" 2>&1 &
+# codex 0.141+ accepts only ws:// (not unix://) for the TUI's --remote, so the
+# shared app-server listens on a loopback ws port instead of a unix socket. The
+# port is recorded per project so a second monitor reuses a live server. See #170.
+port_alive() {  # $1 = port; succeeds if something is accepting on 127.0.0.1:$1
+  (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+}
+
+PORT=""
+if [ -f "$PORT_FILE" ]; then
+  existing_port="$(cat "$PORT_FILE" 2>/dev/null || true)"
+  if [ -n "$existing_port" ] && port_alive "$existing_port"; then
+    PORT="$existing_port"
+  fi
+fi
+
+if [ -z "$PORT" ]; then
+  PORT="$(node -e 'const s=require("net").createServer();s.listen(0,"127.0.0.1",()=>{process.stdout.write(String(s.address().port));s.close();});' 2>/dev/null || true)"
+  if [ -z "$PORT" ]; then
+    echo "codex-monitor: could not allocate a loopback port (is node available?)" >&2
+    exit 1
+  fi
+  "$REAL_CODEX" app-server --listen "ws://127.0.0.1:$PORT" >>"$SERVER_LOG" 2>&1 &
   echo "$!" > "$SERVER_PID"
+  printf '%s' "$PORT" > "$PORT_FILE"
   for _ in $(seq 1 50); do
-    [ -S "$SOCKET_PATH" ] && break
+    port_alive "$PORT" && break
     sleep 0.1
   done
 fi
 
-if [ ! -S "$SOCKET_PATH" ]; then
-  echo "codex-monitor: app-server socket did not appear: $SOCKET_PATH" >&2
+if ! port_alive "$PORT"; then
+  echo "codex-monitor: app-server did not start on ws://127.0.0.1:$PORT" >&2
   echo "codex-monitor: see $SERVER_LOG" >&2
   exit 1
 fi
+SOCKET_URL="ws://127.0.0.1:$PORT"
 
 "$SCRIPT_DIR/delivery.sh" set monitor codex "$PROJECT" >/dev/null
 

--- a/scripts/codex-monitor.sh
+++ b/scripts/codex-monitor.sh
@@ -84,9 +84,14 @@ port_alive() {  # $1 = port; succeeds if something is accepting on 127.0.0.1:$1
 }
 
 PORT=""
-if [ -f "$PORT_FILE" ]; then
+if [ -f "$PORT_FILE" ] && [ -f "$SERVER_PID" ]; then
   existing_port="$(cat "$PORT_FILE" 2>/dev/null || true)"
-  if [ -n "$existing_port" ] && port_alive "$existing_port"; then
+  existing_pid="$(cat "$SERVER_PID" 2>/dev/null || true)"
+  # Reuse only when OUR recorded app-server is still alive AND its port answers,
+  # so a foreign process that grabbed the same port after ours died is not
+  # mistaken for the bridge app-server.
+  if [ -n "$existing_port" ] && [ -n "$existing_pid" ] \
+    && kill -0 "$existing_pid" 2>/dev/null && port_alive "$existing_port"; then
     PORT="$existing_port"
   fi
 fi

--- a/scripts/codex-monitor.sh
+++ b/scripts/codex-monitor.sh
@@ -92,18 +92,24 @@ if [ -f "$PORT_FILE" ]; then
 fi
 
 if [ -z "$PORT" ]; then
-  PORT="$(node -e 'const s=require("net").createServer();s.listen(0,"127.0.0.1",()=>{process.stdout.write(String(s.address().port));s.close();});' 2>/dev/null || true)"
-  if [ -z "$PORT" ]; then
-    echo "codex-monitor: could not allocate a loopback port (is node available?)" >&2
-    exit 1
-  fi
-  "$REAL_CODEX" app-server --listen "ws://127.0.0.1:$PORT" >>"$SERVER_LOG" 2>&1 &
+  # Let the app-server pick a free loopback port (--listen ws://127.0.0.1:0) and
+  # report it ("listening on: ws://127.0.0.1:<port>"). This keeps codex-monitor.sh
+  # free of any Node dependency — only the bridge (codex-bridge.js) needs Node, and
+  # it degrades on its own if Node is missing rather than taking down the TUI. See #170.
+  : > "$SERVER_LOG"
+  "$REAL_CODEX" app-server --listen "ws://127.0.0.1:0" >>"$SERVER_LOG" 2>&1 &
   echo "$!" > "$SERVER_PID"
-  printf '%s' "$PORT" > "$PORT_FILE"
-  for _ in $(seq 1 50); do
-    port_alive "$PORT" && break
+  for _ in $(seq 1 100); do
+    PORT="$(sed -n 's#.*listening on: ws://127\.0\.0\.1:\([0-9][0-9]*\).*#\1#p' "$SERVER_LOG" | head -1)"
+    [ -n "$PORT" ] && break
     sleep 0.1
   done
+  if [ -z "$PORT" ]; then
+    echo "codex-monitor: app-server did not report a listening port" >&2
+    echo "codex-monitor: see $SERVER_LOG" >&2
+    exit 1
+  fi
+  printf '%s' "$PORT" > "$PORT_FILE"
 fi
 
 if ! port_alive "$PORT"; then

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -37,6 +37,8 @@ RUN_DIR="$SKILL_DIR/run"
 . "$SCRIPT_DIR/lib/resolve-project.sh"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/instance-id.sh"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/node.sh"
 
 resolve_hooks_file() {
   local type="$1"
@@ -534,11 +536,13 @@ do_set() {
         # Presence only: the bridge uses old/stable APIs (the sole modern feature
         # is one optional-chaining call, Node 14+), and any Node new enough to run
         # Codex itself runs the bridge — so a version gate would be noise.
-        # AGMSG_CODEX_NODE overrides the binary the check looks for (also testable).
-        codex_node="${AGMSG_CODEX_NODE:-node}"
-        if ! command -v "$codex_node" >/dev/null 2>&1; then
-          echo "WARNING: Node.js ('$codex_node') was not found on PATH. The Codex bridge needs Node —"
-          echo "  monitor delivery will NOT start until Node is installed."
+        # Resolve via the same path the runtime uses (lib/node.sh) so this warning
+        # matches what the launcher will actually do — including a version-manager
+        # Node off PATH. AGMSG_NODE / AGMSG_CODEX_NODE override the binary.
+        codex_node="$(agmsg_resolve_node)"
+        if ! command -v "$codex_node" >/dev/null 2>&1 && [ ! -x "$codex_node" ]; then
+          echo "WARNING: Node.js ('$codex_node') was not found. The Codex bridge needs Node —"
+          echo "  monitor delivery will NOT start until Node is installed (or set AGMSG_NODE)."
         fi
         # The bridge launches from the Codex SessionStart hook, which fires on the
         # FIRST turn of a new session (not the moment Codex opens) — and an

--- a/scripts/lib/node.sh
+++ b/scripts/lib/node.sh
@@ -12,12 +12,20 @@
 # relying on PATH today (the caller still fails the same way, with the existing
 # delivery.sh preflight warning). See #170.
 agmsg_resolve_node() {
-  if command -v node >/dev/null 2>&1; then
-    command -v node
+  # An explicit override is authoritative — return it verbatim, even if it does
+  # not exist, so the caller's preflight surfaces a misconfigured value rather
+  # than silently falling back. AGMSG_NODE is the canonical name; AGMSG_CODEX_NODE
+  # is kept for back-compat with the delivery.sh preflight.
+  if [ -n "${AGMSG_NODE:-}" ]; then
+    printf '%s\n' "$AGMSG_NODE"
     return 0
   fi
-  if [ -n "${AGMSG_NODE:-}" ] && [ -x "${AGMSG_NODE}" ]; then
-    printf '%s\n' "$AGMSG_NODE"
+  if [ -n "${AGMSG_CODEX_NODE:-}" ]; then
+    printf '%s\n' "$AGMSG_CODEX_NODE"
+    return 0
+  fi
+  if command -v node >/dev/null 2>&1; then
+    command -v node
     return 0
   fi
 

--- a/scripts/lib/node.sh
+++ b/scripts/lib/node.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Resolve a Node binary to run codex-bridge.js.
+#
+# The bridge is a Node program, but a version-manager Node (nvm / fnm / volta) is
+# only placed on PATH by an interactive shell's init. A bridge launched from a
+# non-interactive context — e.g. a spawn boot script — therefore cannot find it
+# via the `#!/usr/bin/env node` shebang, and Codex monitor silently never starts.
+#
+# Search order: active PATH (honours a loaded version manager) → an explicit
+# AGMSG_NODE override → common version-manager / system locations (newest nvm/fnm
+# version first). Falls back to bare "node" so the behaviour is never worse than
+# relying on PATH today (the caller still fails the same way, with the existing
+# delivery.sh preflight warning). See #170.
+agmsg_resolve_node() {
+  if command -v node >/dev/null 2>&1; then
+    command -v node
+    return 0
+  fi
+  if [ -n "${AGMSG_NODE:-}" ] && [ -x "${AGMSG_NODE}" ]; then
+    printf '%s\n' "$AGMSG_NODE"
+    return 0
+  fi
+
+  # Glob the version-manager dirs directly in the for-list (expands in both bash
+  # and zsh, unlike an unquoted glob held in a variable). Keep the newest match
+  # by version sort. Unmatched globs iterate once as the literal pattern, which
+  # the -x test rejects.
+  local n best=""
+  for n in \
+    "$HOME"/.nvm/versions/node/*/bin/node \
+    "$HOME"/.fnm/node-versions/*/installation/bin/node \
+    "$HOME"/.local/share/fnm/node-versions/*/installation/bin/node; do
+    [ -x "$n" ] || continue
+    if [ -z "$best" ] || [ "$(printf '%s\n%s\n' "$best" "$n" | sort -V | tail -1)" = "$n" ]; then
+      best="$n"
+    fi
+  done
+  if [ -n "$best" ]; then
+    printf '%s\n' "$best"
+    return 0
+  fi
+
+  for n in "$HOME/.volta/bin/node" /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+    if [ -x "$n" ]; then
+      printf '%s\n' "$n"
+      return 0
+    fi
+  done
+
+  printf '%s\n' "node"
+  return 0
+}

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -142,9 +142,16 @@ if [ "$TYPE" = "codex" ]; then
   fi
 
   log="$RUN_DIR/codex-bridge.$team.$name.log"
-  bridge_cmd="${AGMSG_CODEX_BRIDGE_CMD:-$SCRIPT_DIR/codex-bridge.js}"
-  node_bin="$(agmsg_resolve_node)"
-  nohup "$node_bin" "$bridge_cmd" \
+  # An explicit AGMSG_CODEX_BRIDGE_CMD is a complete runnable (tests, custom
+  # wrappers) — run it as-is. Only the default codex-bridge.js is launched
+  # through a resolved Node, since its env-node shebang fails in shells where a
+  # version-manager Node is not on PATH (#170).
+  if [ -n "${AGMSG_CODEX_BRIDGE_CMD:-}" ]; then
+    bridge_run=("$AGMSG_CODEX_BRIDGE_CMD")
+  else
+    bridge_run=("$(agmsg_resolve_node)" "$SCRIPT_DIR/codex-bridge.js")
+  fi
+  nohup "${bridge_run[@]}" \
     --project "$PROJECT" \
     --type "$TYPE" \
     --team "$team" \

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -34,6 +34,8 @@ RUN_DIR="$SKILL_DIR/run"
 source "$SCRIPT_DIR/lib/actas-lock.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/resolve-project.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/node.sh"
 
 # Identity sanity check — no point launching a watcher with an empty pair set.
 PAIRS=$("$SCRIPT_DIR/identities.sh" "$PROJECT" "$TYPE" 2>/dev/null || true)
@@ -141,7 +143,8 @@ if [ "$TYPE" = "codex" ]; then
 
   log="$RUN_DIR/codex-bridge.$team.$name.log"
   bridge_cmd="${AGMSG_CODEX_BRIDGE_CMD:-$SCRIPT_DIR/codex-bridge.js}"
-  nohup "$bridge_cmd" \
+  node_bin="$(agmsg_resolve_node)"
+  nohup "$node_bin" "$bridge_cmd" \
     --project "$PROJECT" \
     --type "$TYPE" \
     --team "$team" \

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -34,9 +34,9 @@ teardown() {
 }
 
 @test "codex-bridge: rejects unsupported app-server endpoints" {
-  run node "$SCRIPTS/codex-bridge.js" --project "$PROJ" --team team --name alice --app-server ws://127.0.0.1:9999
+  run node "$SCRIPTS/codex-bridge.js" --project "$PROJ" --team team --name alice --app-server http://127.0.0.1:9999
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "supports only unix" ]]
+  [[ "$output" =~ "supports only unix://PATH or ws://host:port" ]]
 }
 
 @test "codex-bridge: connects to unix app-server sockets over websocket" {
@@ -193,6 +193,137 @@ EOF
   grep -q "turn/start" "$log"
 }
 
+@test "codex-bridge: connects to ws://host:port app-server endpoints" {
+  run node -e 'const net = require("net"); const crypto = require("crypto"); if (!net || !crypto) process.exit(1);'
+  if [ "$status" -ne 0 ]; then
+    skip "node net/crypto modules are not available in this sandbox"
+  fi
+
+  local fake="$TEST_SKILL_DIR/fake-ws-tcp-app-server.js"
+  local portfile="$TEST_SKILL_DIR/fake-ws-tcp.port"
+  local log="$TEST_SKILL_DIR/fake-ws-tcp-app-server.log"
+  rm -f "$portfile"
+  cat >"$fake" <<'EOF'
+const crypto = require("crypto");
+const fs = require("fs");
+const net = require("net");
+
+const portfile = process.argv[2];
+const log = process.argv[3];
+
+function sendFrame(socket, value) {
+  const payload = Buffer.from(JSON.stringify(value), "utf8");
+  let header;
+  if (payload.length < 126) {
+    header = Buffer.from([0x81, payload.length]);
+  } else {
+    header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 126;
+    header.writeUInt16BE(payload.length, 2);
+  }
+  socket.write(Buffer.concat([header, payload]));
+}
+
+function handleMessage(socket, message) {
+  fs.appendFileSync(log, `${message.method}\n`);
+  if (message.method === "initialize") {
+    sendFrame(socket, { jsonrpc: "2.0", id: message.id, result: {} });
+  } else if (message.method === "thread/resume") {
+    sendFrame(socket, {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { thread: { id: message.params.threadId, status: { type: "idle" } } },
+    });
+  } else if (message.method === "process/spawn") {
+    sendFrame(socket, { jsonrpc: "2.0", id: message.id, result: {} });
+    setTimeout(() => {
+      sendFrame(socket, {
+        jsonrpc: "2.0",
+        method: "process/exited",
+        params: { processHandle: message.params.processHandle, exitCode: 0, stdout: "status=pending count=1 max_id=1\n", stderr: "" },
+      });
+    }, 10);
+  } else if (message.method === "turn/start") {
+    sendFrame(socket, { jsonrpc: "2.0", id: message.id, result: {} });
+    setTimeout(() => {
+      sendFrame(socket, { jsonrpc: "2.0", method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: "turn-1" } } });
+    }, 10);
+  }
+}
+
+function parseFrames(socket, state, chunk) {
+  state.buffer = Buffer.concat([state.buffer, chunk]);
+  while (state.buffer.length >= 2) {
+    const opcode = state.buffer[0] & 0x0f;
+    let length = state.buffer[1] & 0x7f;
+    let offset = 2;
+    if (length === 126) {
+      if (state.buffer.length < offset + 2) return;
+      length = state.buffer.readUInt16BE(offset);
+      offset += 2;
+    }
+    const masked = (state.buffer[1] & 0x80) !== 0;
+    const maskOffset = offset;
+    if (masked) offset += 4;
+    if (state.buffer.length < offset + length) return;
+    let payload = state.buffer.slice(offset, offset + length);
+    if (masked) {
+      const mask = state.buffer.slice(maskOffset, maskOffset + 4);
+      payload = Buffer.from(payload.map((byte, index) => byte ^ mask[index % 4]));
+    }
+    state.buffer = state.buffer.slice(offset + length);
+    if (opcode === 0x1) handleMessage(socket, JSON.parse(payload.toString("utf8")));
+  }
+}
+
+const server = net.createServer((socket) => {
+  const state = { buffer: Buffer.alloc(0), upgraded: false, header: Buffer.alloc(0) };
+  socket.on("data", (chunk) => {
+    if (!state.upgraded) {
+      state.header = Buffer.concat([state.header, chunk]);
+      const end = state.header.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      const header = state.header.slice(0, end).toString("utf8");
+      const rest = state.header.slice(end + 4);
+      const key = (header.match(/Sec-WebSocket-Key: (.*)\r\n/i) || [])[1].trim();
+      const accept = crypto.createHash("sha1").update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`).digest("base64");
+      socket.write(["HTTP/1.1 101 Switching Protocols", "Upgrade: websocket", "Connection: Upgrade", `Sec-WebSocket-Accept: ${accept}`, "", ""].join("\r\n"));
+      state.upgraded = true;
+      if (rest.length > 0) parseFrames(socket, state, rest);
+      return;
+    }
+    parseFrames(socket, state, chunk);
+  });
+  socket.on("close", () => server.close(() => process.exit(0)));
+});
+
+server.listen(0, "127.0.0.1", () => {
+  fs.writeFileSync(portfile, String(server.address().port));
+});
+EOF
+
+  node "$fake" "$portfile" "$log" &
+  local server_pid="$!"
+  for _ in {1..50}; do
+    [ -s "$portfile" ] && break
+    sleep 0.1
+  done
+  local port
+  port="$(cat "$portfile")"
+
+  run node "$SCRIPTS/codex-bridge.js" \
+    --project "$PROJ" --team team --name alice --thread thread-existing \
+    --app-server "ws://127.0.0.1:$port" --timeout 1 --interval 1 --max-wakes 1
+
+  kill "$server_pid" 2>/dev/null || true
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "resumed thread thread-existing" ]]
+  grep -q "initialize" "$log"
+  grep -q "thread/resume" "$log"
+}
+
 @test "codex-bridge: refuses when the same identity already has a live bridge" {
   mkdir -p "$TEST_SKILL_DIR/run"
   echo "$$" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
@@ -311,6 +442,87 @@ EOF
   [ "$status" -eq 0 ]
   grep -q "thread/resume" "$log"
   ! grep -q "thread/start" "$log"
+}
+
+@test "codex-bridge: --thread loaded discovers the live thread via thread/loaded/list" {
+  run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
+  if [ "$status" -ne 0 ]; then
+    skip "node child_process.spawn is not available in this sandbox"
+  fi
+
+  local fake="$TEST_SKILL_DIR/fake-app-server-loaded.js"
+  local log="$TEST_SKILL_DIR/fake-app-server-loaded.log"
+  cat >"$fake" <<'EOF'
+const fs = require("fs");
+const readline = require("readline");
+const log = process.argv[2];
+const rl = readline.createInterface({ input: process.stdin });
+
+function send(value) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  fs.appendFileSync(log, `${message.method}\n`);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  } else if (message.method === "thread/loaded/list") {
+    send({ jsonrpc: "2.0", id: message.id, result: { data: ["thread-live-42"] } });
+  } else if (message.method === "thread/resume") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { thread: { id: message.params.threadId, status: { type: "idle" } } },
+    });
+  } else if (message.method === "process/spawn") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    setTimeout(() => process.exit(0), 10);
+  } else if (message.method === "process/kill") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  }
+});
+EOF
+
+  AGMSG_CODEX_APP_SERVER_CMD="node $fake $log" run node "$SCRIPTS/codex-bridge.js" \
+    --project "$PROJ" --team team --name alice --thread loaded --loaded-timeout 5000 --timeout 20
+
+  [ "$status" -eq 0 ]
+  grep -q "thread/loaded/list" "$log"
+  grep -q "thread/resume" "$log"
+  ! grep -q "thread/start" "$log"
+}
+
+@test "codex-bridge: --thread loaded errors when no thread is loaded in time" {
+  run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
+  if [ "$status" -ne 0 ]; then
+    skip "node child_process.spawn is not available in this sandbox"
+  fi
+
+  local fake="$TEST_SKILL_DIR/fake-app-server-empty-loaded.js"
+  cat >"$fake" <<'EOF'
+const readline = require("readline");
+const rl = readline.createInterface({ input: process.stdin });
+
+function send(value) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  } else if (message.method === "thread/loaded/list") {
+    send({ jsonrpc: "2.0", id: message.id, result: { data: [] } });
+  }
+});
+EOF
+
+  AGMSG_CODEX_APP_SERVER_CMD="node $fake" run node "$SCRIPTS/codex-bridge.js" \
+    --project "$PROJ" --team team --name alice --thread loaded --loaded-timeout 1500 --timeout 20
+
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "no loaded codex thread" ]]
 }
 
 @test "codex-bridge: inline-inbox includes unread message text in turn input" {

--- a/tests/test_node_resolve.bats
+++ b/tests/test_node_resolve.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+setup() {
+  SCRIPTS="$BATS_TEST_DIRNAME/../scripts"
+  FAKE_HOME="$(mktemp -d)"
+}
+
+teardown() {
+  [ -n "${FAKE_HOME:-}" ] && rm -rf "$FAKE_HOME"
+}
+
+make_fake_node() {  # $1 = path to create as an executable stub
+  mkdir -p "$(dirname "$1")"
+  printf '#!/bin/sh\necho fake-node\n' > "$1"
+  chmod +x "$1"
+}
+
+@test "resolve_node: prefers node on PATH over a version-manager node" {
+  make_fake_node "$FAKE_HOME/.nvm/versions/node/v18.0.0/bin/node"
+  # A real node is on the test runner's PATH; it must win.
+  run bash -c 'source "'"$SCRIPTS"'/lib/node.sh"; HOME="'"$FAKE_HOME"'" agmsg_resolve_node'
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(command -v node)" ]
+}
+
+@test "resolve_node: finds the newest version-manager node when PATH lacks node" {
+  make_fake_node "$FAKE_HOME/.nvm/versions/node/v18.4.0/bin/node"
+  make_fake_node "$FAKE_HOME/.nvm/versions/node/v20.11.0/bin/node"
+  make_fake_node "$FAKE_HOME/.nvm/versions/node/v9.9.0/bin/node"
+  run env -i HOME="$FAKE_HOME" PATH=/usr/bin:/bin bash -c 'source "'"$SCRIPTS"'/lib/node.sh"; agmsg_resolve_node'
+  [ "$status" -eq 0 ]
+  # Version sort, not lexical: v20.11.0 beats v9.9.0 and v18.4.0.
+  [ "$output" = "$FAKE_HOME/.nvm/versions/node/v20.11.0/bin/node" ]
+}
+
+@test "resolve_node: honours an explicit AGMSG_NODE override" {
+  make_fake_node "$FAKE_HOME/custom/node"
+  run env -i HOME="$FAKE_HOME" PATH=/usr/bin:/bin AGMSG_NODE="$FAKE_HOME/custom/node" \
+    bash -c 'source "'"$SCRIPTS"'/lib/node.sh"; agmsg_resolve_node'
+  [ "$status" -eq 0 ]
+  [ "$output" = "$FAKE_HOME/custom/node" ]
+}


### PR DESCRIPTION
## Summary
On codex 0.141 the Codex **monitor** bridge never engaged, so a registered `codex` agent received no pushed messages while idle (#170). Two breakages:

1. `codex --remote <addr>` now accepts only `ws://host:port` (rejects `unix://`), but the bridge used a `unix://` socket — the TUI exited before the bridge could attach.
2. With `--remote`, codex no longer exposes the thread id to hooks (`CODEX_THREAD_ID` unset, no rollout under `~/.codex/sessions/`), so the launcher never learned which thread to attach to.

## Changes
- **`codex-bridge.js`** — the WebSocket app-server client now connects over either a unix socket (`{ path }`) or a TCP host/port (`{ host, port }`), so `--app-server` accepts `ws://host:port` as well as `unix://PATH` (handshake/framing unchanged). New `--thread loaded` discovers the live TUI thread via `thread/loaded/list` instead of a hook-resolved id.
- **`codex-monitor.sh`** — runs the shared app-server on `ws://127.0.0.1:<port>` (port recorded per project for reuse) and connects the TUI with `--remote ws://127.0.0.1:<port>`.
- **`codex-bridge-launcher.sh`** — resolves the project's single codex identity itself and starts the bridge with `--thread loaded`. A request file carrying a real thread id (older codex, hook path) still takes precedence, preserving backward compatibility.

## Verification
- `tests/test_codex_bridge.bats` (16 cases, all green locally): added `ws://host:port` connect, `thread/loaded/list` discovery, and the no-loaded-thread timeout. The prior "rejects unsupported endpoints" case now uses `http://` since `ws://` is supported.
- Protocol confirmed against the real codex 0.141 binary: `codex app-server --listen` documents `ws://IP:PORT`, and `generate-json-schema` exposes `thread/loaded/list` → `{ data: string[] }`.
- Full cross-platform validation deferred to CI; a live end-to-end run on codex 0.141 is recommended before release as the final gate.

Closes #170