### PR TITLE
fix(delivery): escape hook command values via json_object (cross-platform JSON escaping)

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -143,15 +143,23 @@ add_event_entry_file() {
   local sql_path
   sql_path=$(sql_readfile_path "$path")
 
-  local hook_inner="\"type\":\"command\",\"command\":\"$cmd\""
+  # Build the entry with SQLite's own json_object()/json_array() so SQLite does
+  # every JSON-level escape. Raw values go in as ordinary SQL string literals
+  # (single quotes doubled) — the only escaping this layer needs. Hand-building
+  # the JSON string instead (and only escaping the codex commandWindows) left
+  # the "command" value's embedded " and ' unescaped, producing "malformed
+  # JSON" on tricky project paths and on native Windows sqlite builds (#134).
+  local cmd_lit
+  cmd_lit=$(printf '%s' "$cmd" | sed "s/'/''/g")
+  local hook_obj="json_object('type','command','command','$cmd_lit'"
   if [ "$hook_type" = "codex" ]; then
-    local cw; cw=$(windows_wrap "$cmd")
-    cw="${cw//\\/\\\\}"; cw="${cw//\"/\\\"}"
-    hook_inner="$hook_inner,\"commandWindows\":\"$cw\""
+    local cw cw_lit
+    cw=$(windows_wrap "$cmd")
+    cw_lit=$(printf '%s' "$cw" | sed "s/'/''/g")
+    hook_obj="$hook_obj,'commandWindows','$cw_lit'"
   fi
-  local entry="{\"matcher\":\"\",\"hooks\":[{$hook_inner}]}"
-  local entry_esc
-  entry_esc=$(printf '%s' "$entry" | sed "s/'/''/g")
+  hook_obj="$hook_obj)"
+  local entry_sql="json_object('matcher','','hooks',json_array($hook_obj))"
 
   local tmp tmp_sql
   tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
@@ -169,13 +177,13 @@ add_event_entry_file() {
     ),
     out AS (SELECT CASE
       WHEN json_extract(s, '\$.hooks.$event') IS NULL THEN
-        json_set(s, '\$.hooks.$event', json_array(json('$entry_esc')))
+        json_set(s, '\$.hooks.$event', json_array($entry_sql))
       ELSE
         json_set(s, '\$.hooks.$event',
           (SELECT json_group_array(json(v.value)) FROM (
              SELECT value FROM json_each(json_extract(s, '\$.hooks.$event'))
              UNION ALL
-             SELECT '$entry_esc'
+             SELECT $entry_sql
            ) v)
         )
     END AS blob FROM base)

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -961,12 +961,27 @@ JSON
 # commandWindows. The "command" value's own embedded " and ' went in raw, so any
 # project path containing them produced "Error: stepping, malformed JSON" and no
 # hook file — for BOTH claude-code and codex (#134 Bug 1, reporter #138). These
-# are build-agnostic: they reproduce on macOS/Linux, not just native Windows.
+# reproduce on macOS/Linux independent of the sqlite build.
+#
+# Note: these cover the cross-platform JSON-escaping defect only. Native-Windows
+# delivery has a separate, still-open failure (empty commandWindows / invalid
+# JSON even for plain paths — sqlite3.exe / CRLF, #130); see the windows-latest
+# experimental leg. Not addressed here.
 
 # SQL string-literal escape so a tricky path is safe inside our own probe query.
 sql_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
 
+# The quote/backslash path cases below use " and \ in directory names, which are
+# not legal filename characters on NTFS — they can't even be created under Git
+# Bash on Windows. Skip there; the required ubuntu/macos legs cover them.
+skip_if_no_special_fs() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) skip "\" and \\ are not legal filename chars on NTFS" ;;
+  esac
+}
+
 @test "delivery set turn: project path with quotes yields valid JSON (claude-code) (#134)" {
+  skip_if_no_special_fs
   local proj="$TEST_PROJECT/o'brien \"x\""
   mkdir -p "$proj"
   run bash "$SCRIPTS/delivery.sh" set turn claude-code "$proj"
@@ -982,6 +997,7 @@ sql_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
 }
 
 @test "delivery set turn: project path with quotes yields valid JSON + commandWindows (codex) (#134)" {
+  skip_if_no_special_fs
   local proj="$TEST_PROJECT/o'brien \"x\""
   mkdir -p "$proj"
   run bash "$SCRIPTS/delivery.sh" set turn codex "$proj"
@@ -1001,6 +1017,7 @@ sql_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
   # json_object must JSON-escape a literal backslash in the raw command value
   # (a hand-built "command":"..." left it raw). Backslashes are the norm in
   # Windows-shaped inputs, so verify the byte survives the round-trip.
+  skip_if_no_special_fs
   local proj="$TEST_PROJECT/a\\b"
   mkdir -p "$proj"
   run bash "$SCRIPTS/delivery.sh" set turn claude-code "$proj"

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -955,6 +955,78 @@ JSON
   [ -z "$cw" ]
 }
 
+# --- Hook JSON escaping: build entries via json_object, not by hand (#134) ---
+#
+# The pre-fix code hand-assembled the entry JSON and only escaped the codex
+# commandWindows. The "command" value's own embedded " and ' went in raw, so any
+# project path containing them produced "Error: stepping, malformed JSON" and no
+# hook file — for BOTH claude-code and codex (#134 Bug 1, reporter #138). These
+# are build-agnostic: they reproduce on macOS/Linux, not just native Windows.
+
+# SQL string-literal escape so a tricky path is safe inside our own probe query.
+sql_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+@test "delivery set turn: project path with quotes yields valid JSON (claude-code) (#134)" {
+  local proj="$TEST_PROJECT/o'brien \"x\""
+  mkdir -p "$proj"
+  run bash "$SCRIPTS/delivery.sh" set turn claude-code "$proj"
+  [ "$status" -eq 0 ]
+  local hf="$proj/.claude/settings.local.json"
+  [ -f "$hf" ]
+  local hfq; hfq=$(sql_lit "$hf")
+  [ "$(sqlite3 :memory: "SELECT json_valid(readfile('$hfq'));")" = "1" ]
+  local cmd
+  cmd=$(sqlite3 :memory: "SELECT json_extract(readfile('$hfq'), '\$.hooks.Stop[0].hooks[0].command');")
+  [[ "$cmd" == *"check-inbox.sh"* ]]
+  [[ "$cmd" == *"o'brien \"x\""* ]]
+}
+
+@test "delivery set turn: project path with quotes yields valid JSON + commandWindows (codex) (#134)" {
+  local proj="$TEST_PROJECT/o'brien \"x\""
+  mkdir -p "$proj"
+  run bash "$SCRIPTS/delivery.sh" set turn codex "$proj"
+  [ "$status" -eq 0 ]
+  local hf="$proj/.codex/hooks.json"
+  [ -f "$hf" ]
+  local hfq; hfq=$(sql_lit "$hf")
+  [ "$(sqlite3 :memory: "SELECT json_valid(readfile('$hfq'));")" = "1" ]
+  local cw
+  cw=$(sqlite3 :memory: "SELECT json_extract(readfile('$hfq'), '\$.hooks.Stop[0].hooks[0].commandWindows');")
+  [ -n "$cw" ]
+  [[ "$cw" == *"Program Files\\Git\\bin\\bash.exe"* ]]
+  [[ "$cw" == *"check-inbox.sh"* ]]
+}
+
+@test "delivery set turn: project path with a backslash round-trips intact (#134)" {
+  # json_object must JSON-escape a literal backslash in the raw command value
+  # (a hand-built "command":"..." left it raw). Backslashes are the norm in
+  # Windows-shaped inputs, so verify the byte survives the round-trip.
+  local proj="$TEST_PROJECT/a\\b"
+  mkdir -p "$proj"
+  run bash "$SCRIPTS/delivery.sh" set turn claude-code "$proj"
+  [ "$status" -eq 0 ]
+  local hf="$proj/.claude/settings.local.json"
+  local hfq; hfq=$(sql_lit "$hf")
+  [ "$(sqlite3 :memory: "SELECT json_valid(readfile('$hfq'));")" = "1" ]
+  local cmd
+  cmd=$(sqlite3 :memory: "SELECT json_extract(readfile('$hfq'), '\$.hooks.Stop[0].hooks[0].command');")
+  [[ "$cmd" == *'a\b'* ]]
+}
+
+@test "delivery set monitor: existing settings with single-quoted hook commands stays valid JSON (#134)" {
+  # The reporter's trigger: settings.local.json already holds hook commands
+  # containing single quotes. Pre-fix, re-adding our entries produced malformed
+  # JSON. Post-fix the round-trip stays valid and preserves the prior hook.
+  mkdir -p "$TEST_PROJECT/.claude"
+  cat > "$(settings_file)" <<'JSON'
+{"hooks":{"Stop":[{"matcher":"","hooks":[{"type":"command","command":"bash -lc 'echo it'\''s mine'"}]}]}}
+JSON
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [ "$(sqlite3 :memory: "SELECT json_valid(readfile('$(settings_file)'));")" = "1" ]
+  has_session_start "$(settings_file)"
+}
+
 # --- Large settings.local.json: must not trip Linux MAX_ARG_STRLEN (#95) ---
 #
 # Reporter's actual settings was 32,357 bytes. The pre-fix code embedded the


### PR DESCRIPTION
## Summary

`add_event_entry_file` hand-assembled the hook entry JSON as a string and only escaped the codex `commandWindows` value, leaving the `"command"` value's own embedded `"` and `'` unescaped. When a project path (or a pre-existing hook command) contained those characters, `sqlite3` aborted with `Error: stepping, malformed JSON` and wrote no hook file — for **both** `claude-code` and `codex`. Reproduces on Linux/macOS, independent of the sqlite build.

## Fix

Build the entry with SQLite's own `json_object()` / `json_array()` so SQLite performs all JSON-level escaping. Raw values are passed only as ordinary SQL string literals (single quotes doubled) — the one escape this layer needs. The `windows_wrap` PowerShell `''` escaping is unchanged (PowerShell-level, not SQL).

No new dependency: still `sqlite3` + `bash` only (a JSON parser like Python would break the project's sqlite3-only core).

## Tests

Adds regression tests in `test_delivery.bats`, green on the required `ubuntu-latest` / `macos-latest` legs:

- project path containing `'` and `"` → valid JSON, command round-trips (claude-code)
- same, plus `commandWindows` present and Git Bash path intact (codex)
- project path containing a backslash → byte survives the round-trip
- pre-existing settings carrying single-quoted hook commands → stays valid JSON

The path-based cases are guarded to `skip` on Git Bash / Windows, where `"` and `\` are not legal filename characters.

## Scope and known limitation

This fixes the **cross-platform JSON-escaping** defect only. It does **not** fix native-Windows delivery: on the `windows-latest` *experimental* (non-required) leg, `delivery set` still produces an empty `commandWindows` (test #127) and invalid JSON (#132) **even for plain project paths**. That is a separate Windows-specific cause (`sqlite3.exe` / CRLF, see #130), not the escaping addressed here, and is left for a follow-up.

Refs #134 (Bug 1, escaping portion), #138, #130.