### PR TITLE
fix(codex): Git Bash compatibility for the Codex bridge (portable hash + bash-exec)

### DIFF
--- a/scripts/codex-bridge-launcher.sh
+++ b/scripts/codex-bridge-launcher.sh
@@ -18,7 +18,9 @@ PARENT_PID="${4:?Missing parent_pid}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUN_DIR="$SKILL_DIR/run"
-PROJECT_HASH="$(printf '%s' "$PROJECT" | shasum | awk '{print $1}')"
+# shellcheck source=lib/hash.sh
+source "$SCRIPT_DIR/lib/hash.sh"
+PROJECT_HASH="$(printf '%s' "$PROJECT" | agmsg_sha1)"
 REQUEST_FILE="$RUN_DIR/codex-bridge-request.$PROJECT_HASH"
 
 # shellcheck source=lib/node.sh

--- a/scripts/codex-bridge.js
+++ b/scripts/codex-bridge.js
@@ -12,6 +12,12 @@ const SCRIPT_DIR = __dirname;
 const SKILL_DIR = path.resolve(SCRIPT_DIR, "..");
 const RUN_DIR = path.join(SKILL_DIR, "run");
 
+// Git Bash on Windows cannot exec a .sh path directly — spawnSync of the script
+// fails with EFTYPE. Invoke the helper scripts through bash on every platform.
+// bash is always present in agmsg's runtime (the bridge is launched from a bash
+// context); honour the same overrides delivery.sh's windows_wrap uses.
+const BASH_BIN = process.env.GIT_BASH || process.env.AGMSG_BASH || "bash";
+
 function usage() {
   console.log(`Usage: codex-bridge.js --project <path> [--type codex] [--team <team>] [--name <agent>]
 
@@ -116,7 +122,7 @@ function parseArgs(argv) {
 }
 
 function runScript(script, args) {
-  const result = spawnSync(path.join(SCRIPT_DIR, script), args, {
+  const result = spawnSync(BASH_BIN, [path.join(SCRIPT_DIR, script), ...args], {
     cwd: SKILL_DIR,
     encoding: "utf8",
   });
@@ -831,7 +837,7 @@ class CodexBridge {
   }
 
   readInboxForPrompt() {
-    const result = spawnSync(path.join(SCRIPT_DIR, "inbox.sh"), [this.identity.team, this.identity.name], {
+    const result = spawnSync(BASH_BIN, [path.join(SCRIPT_DIR, "inbox.sh"), this.identity.team, this.identity.name], {
       cwd: this.opts.project,
       encoding: "utf8",
     });

--- a/scripts/codex-monitor.sh
+++ b/scripts/codex-monitor.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUN_DIR="$SKILL_DIR/run"
+# shellcheck source=lib/hash.sh
+source "$SCRIPT_DIR/lib/hash.sh"
 
 PROJECT="$(pwd)"
 SOCKET_PATH=""
@@ -69,7 +71,7 @@ case "$CODEX_COMMAND" in
 esac
 
 PROJECT="$(cd "$PROJECT" && pwd)"
-PROJECT_HASH="$(printf '%s' "$PROJECT" | shasum | awk '{print $1}')"
+PROJECT_HASH="$(printf '%s' "$PROJECT" | agmsg_sha1)"
 SERVER_LOG="$RUN_DIR/codex-app-server.$PROJECT_HASH.log"
 SERVER_PID="$RUN_DIR/codex-app-server.$PROJECT_HASH.pid"
 PORT_FILE="$RUN_DIR/codex-app-server.$PROJECT_HASH.port"

--- a/scripts/lib/hash.sh
+++ b/scripts/lib/hash.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Portable SHA-1 of stdin, emitting the bare hex digest.
+#
+# The codex monitor names a per-project socket and request file after a hash of
+# the project path. The original `shasum` is a Perl script that ships on macOS
+# and most Linux, but NOT in Git for Windows' Git Bash, where it fails with
+# "shasum: command not found" — leaving the hash empty so the socket/request
+# files never match and the bridge never engages (#130 area, surfaced on the
+# windows-latest CI leg).
+#
+# Fall back through the tools each platform actually has, in a FIXED order so
+# every script computes the same digest on a given machine (session-start.sh,
+# codex-monitor.sh and codex-bridge-launcher.sh must agree on the name):
+#   shasum (macOS/Linux) -> sha1sum (Git Bash/Linux) -> openssl (near-universal).
+# On macOS/Linux this returns the exact same value as before (shasum wins), so
+# existing socket/request paths are unchanged; only Windows behaviour improves.
+agmsg_sha1() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum | awk '{print $1}'
+  elif command -v sha1sum >/dev/null 2>&1; then
+    sha1sum | awk '{print $1}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha1 | awk '{print $NF}'
+  else
+    # cksum is in POSIX and always present; not SHA-1, but a stable per-machine
+    # digest is all the socket/request naming needs.
+    cksum | awk '{print $1}'
+  fi
+}

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -36,6 +36,8 @@ source "$SCRIPT_DIR/lib/actas-lock.sh"
 source "$SCRIPT_DIR/lib/resolve-project.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/node.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/hash.sh"
 
 # Identity sanity check — no point launching a watcher with an empty pair set.
 PAIRS=$("$SCRIPT_DIR/identities.sh" "$PROJECT" "$TYPE" 2>/dev/null || true)
@@ -107,7 +109,7 @@ if [ "$TYPE" = "codex" ]; then
     fi
   fi
   if [ -z "$app_server" ]; then
-    project_hash=$(printf '%s' "$PROJECT" | shasum | awk '{print $1}')
+    project_hash=$(printf '%s' "$PROJECT" | agmsg_sha1)
     socket_path="$RUN_DIR/codex-app-server.$project_hash.sock"
     if [ -S "$socket_path" ] || [ "${AGMSG_TEST_ASSUME_CODEX_SOCKET:-}" = "$socket_path" ]; then
       app_server="unix://$socket_path"
@@ -122,7 +124,7 @@ if [ "$TYPE" = "codex" ]; then
   [ -n "$team" ] && [ -n "$name" ] || exit 0
 
   if [ "${AGMSG_CODEX_BRIDGE_LAUNCHER:-}" = "1" ]; then
-    project_hash=$(printf '%s' "$PROJECT" | shasum | awk '{print $1}')
+    project_hash=$(printf '%s' "$PROJECT" | agmsg_sha1)
     request_file="$RUN_DIR/codex-bridge-request.$project_hash"
     tmp_request="$request_file.$$"
     mkdir -p "$RUN_DIR" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Part of the effort to stop the `windows-latest` CI leg from always failing. Two Git Bash incompatibilities that broke the Codex bridge on native Windows:

1. **`shasum` is absent in Git for Windows' Git Bash.** `session-start.sh`, `codex-monitor.sh` and `codex-bridge-launcher.sh` hashed the project path with `shasum` to name the per-project app-server socket and bridge request file. It failed with "command not found", leaving the hash empty so the files never matched and the bridge could not engage.

2. **Node cannot exec a `.sh` path directly on Windows (EFTYPE).** `codex-bridge.js` `spawnSync`'d `identities.sh` / `inbox.sh` by path, which dies with EFTYPE under Git Bash.

## Fix

1. Add `lib/hash.sh` with `agmsg_sha1()`: `shasum → sha1sum → openssl → cksum`, a fixed fallback order so every script agrees on the digest for a given machine. On macOS/Linux `shasum` still wins, so existing socket/request paths are byte-for-byte unchanged.
2. Spawn the helper scripts through `bash` in `codex-bridge.js` (honouring the `GIT_BASH`/`AGMSG_BASH` overrides `delivery.sh`'s `windows_wrap` already uses).

## Tests

Full bats suite green on macOS/Linux (`test_codex_bridge`, `test_codex_shim`, `test_delivery` all pass; the only failures are pre-existing `test_watch.bats` timing flakes unrelated to this change). The real validation is the `windows-latest` experimental leg — this should clear the codex-bridge EFTYPE failures (#34–38) and the `shasum`-dependent session-start cases.

## Scope

Git Bash compatibility for the Codex bridge only. The larger `windows-latest` failures — CRLF / sqlite3.exe JSON round-trips (#130, #87), watcher process management, and actas liveness (#134 Bug 2) — are separate clusters handled in follow-ups.

Refs #130, #125.