### PR TITLE
fix: strip CR from sqlite3 output so Windows Git Bash works (#130)

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -39,6 +39,8 @@ RUN_DIR="$SKILL_DIR/run"
 . "$SCRIPT_DIR/lib/instance-id.sh"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/node.sh"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/storage.sh"
 
 resolve_hooks_file() {
   local type="$1"
@@ -93,7 +95,7 @@ strip_agmsg_event_file() {
   # miscounted by character-based length()); anything but an exact match fails.
   # Guard contributed in #162 (kevinsj15).
   local wrote
-  wrote=$(sqlite3 :memory: "
+  wrote=$(agmsg_sqlite_mem "
     WITH src AS (SELECT readfile('$sql_path') AS j),
     out AS (SELECT coalesce(CASE
       WHEN json_extract(src.j, '\$.hooks.$event') IS NULL THEN
@@ -171,7 +173,7 @@ add_event_entry_file() {
   # Validate writefile()'s byte count vs the content length — see
   # strip_agmsg_event_file for why the exit code alone is insufficient (#162).
   local wrote
-  wrote=$(sqlite3 :memory: "
+  wrote=$(agmsg_sqlite_mem "
     WITH base AS (
       SELECT CASE WHEN json_extract(readfile('$sql_path'), '\$.hooks') IS NULL
                   THEN json_set(readfile('$sql_path'), '\$.hooks', json('{}'))
@@ -209,7 +211,7 @@ prune_empty_hooks_file() {
   # Validate writefile()'s byte count vs the content length — see
   # strip_agmsg_event_file for why the exit code alone is insufficient (#162).
   local wrote
-  wrote=$(sqlite3 :memory: "
+  wrote=$(agmsg_sqlite_mem "
     WITH src AS (SELECT readfile('$sql_path') AS j),
     out AS (SELECT coalesce(CASE
       WHEN json_extract(src.j, '\$.hooks') IS NULL THEN src.j
@@ -287,7 +289,7 @@ apply_settings_copilot() {
     # json_quote handles JSON-string escaping for arbitrary command strings
     # (project paths may contain JSON-special chars).
     local cmd_json
-    cmd_json=$(sqlite3 :memory: "SELECT json_quote('$(printf '%s' "$cmd" | sed "s/'/''/g")');")
+    cmd_json=$(agmsg_sqlite_mem "SELECT json_quote('$(printf '%s' "$cmd" | sed "s/'/''/g")');")
     # Use PascalCase 'Stop' trigger so the input payload field names match
     # the snake_case form (session_id) that check-inbox.sh already parses.
     cat <<EOF > "$hooks_file"
@@ -612,13 +614,13 @@ do_status() {
       if [ -f "$hf" ]; then
         local sql_hf
         sql_hf=$(sql_readfile_path "$hf")
-        has_ss=$(sqlite3 :memory: "
+        has_ss=$(agmsg_sqlite_mem "
           SELECT EXISTS(
             SELECT 1 FROM json_each(json_extract(readfile('$sql_hf'), '\$.hooks.SessionStart')) AS s,
               json_each(json_extract(s.value, '\$.hooks')) AS h
             WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
           );" 2>/dev/null || echo 0)
-        has_st=$(sqlite3 :memory: "
+        has_st=$(agmsg_sqlite_mem "
           SELECT EXISTS(
             SELECT 1 FROM json_each(json_extract(readfile('$sql_hf'), '\$.hooks.Stop')) AS s,
               json_each(json_extract(s.value, '\$.hooks')) AS h
@@ -643,14 +645,14 @@ do_status() {
       sql_hooks_file=$(sql_readfile_path "$hooks_file")
       # readfile() rather than interpolating the file contents into argv —
       # for large settings (#95) the latter hits MAX_ARG_STRLEN on Linux.
-      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$sql_hooks_file'), '\$.hooks.SessionStart'));" 2>/dev/null || echo 0)
+      count=$(agmsg_sqlite_mem "SELECT json_array_length(json_extract(readfile('$sql_hooks_file'), '\$.hooks.SessionStart'));" 2>/dev/null || echo 0)
       case "$count" in ''|*[!0-9]*) count=0 ;; esac
       echo "settings hooks file: $hooks_file"
       echo "  SessionStart entries: $count"
-      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$sql_hooks_file'), '\$.hooks.SessionEnd'));" 2>/dev/null || echo 0)
+      count=$(agmsg_sqlite_mem "SELECT json_array_length(json_extract(readfile('$sql_hooks_file'), '\$.hooks.SessionEnd'));" 2>/dev/null || echo 0)
       case "$count" in ''|*[!0-9]*) count=0 ;; esac
       echo "  SessionEnd entries:   $count"
-      count=$(sqlite3 :memory: "SELECT json_array_length(json_extract(readfile('$sql_hooks_file'), '\$.hooks.Stop'));" 2>/dev/null || echo 0)
+      count=$(agmsg_sqlite_mem "SELECT json_array_length(json_extract(readfile('$sql_hooks_file'), '\$.hooks.Stop'));" 2>/dev/null || echo 0)
       case "$count" in ''|*[!0-9]*) count=0 ;; esac
       echo "  Stop entries:         $count"
     fi

--- a/scripts/identities.sh
+++ b/scripts/identities.sh
@@ -18,13 +18,15 @@ AGENT_TYPE="${2:?Missing agent_type}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEAMS_DIR="$SCRIPT_DIR/../teams"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/storage.sh"
 
 [ -d "$TEAMS_DIR" ] || exit 0
 
 for config_file in "$TEAMS_DIR"/*/config.json; do
   [ -f "$config_file" ] || continue
   CONFIG_ESCAPED=$(sed "s/'/''/g" "$config_file")
-  TEAM_NAME=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+  TEAM_NAME=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
     "SELECT json_extract(:json, '\$.name');")
   [ -z "$TEAM_NAME" ] && continue
   [ "$TEAM_NAME" = "null" ] && continue
@@ -44,5 +46,5 @@ for config_file in "$TEAMS_DIR"/*/config.json; do
     WHERE json_extract(r.value, '\$.project') = '$PROJECT_PATH'
       AND json_extract(r.value, '\$.type') = '$AGENT_TYPE'
     ORDER BY team, name;
-  "
+  " | tr -d '\r'
 done

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -35,6 +35,8 @@ agmsg_validate_team_name "$TEAM" || exit 1
 # may not be registered yet) set AGMSG_RESOLVE_PROJECT=0 to keep their path.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/resolve-project.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/storage.sh"
 PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
 
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
@@ -57,14 +59,14 @@ CONFIG_ESCAPED=$(sed "s/'/''/g" "$TEAM_CONFIG")
 REGISTRATION="{\"type\":\"$AGENT_TYPE\",\"project\":\"$PROJECT_PATH\"}"
 REGISTRATION_ESCAPED=$(printf '%s' "$REGISTRATION" | sed "s/'/''/g")
 
-EXISTING=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+EXISTING=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
   "SELECT json_extract(:json, '$.agents.$AGENT_ID');")
 
 if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
   AGENT_OBJ="{\"registrations\":[${REGISTRATION}]}"
 else
   EXISTING_ESCAPED=$(printf '%s' "$EXISTING" | sed "s/'/''/g")
-  NORMALIZED=$(sqlite3 :memory: "
+  NORMALIZED=$(agmsg_sqlite_mem "
     WITH agent(a) AS (SELECT '$EXISTING_ESCAPED')
     SELECT CASE
       WHEN json_type(json_extract(a, '\$.registrations')) = 'array' THEN a
@@ -80,7 +82,7 @@ else
   ")
   NORMALIZED_ESCAPED=$(printf '%s' "$NORMALIZED" | sed "s/'/''/g")
 
-  HAS_REGISTRATION=$(sqlite3 :memory: "
+  HAS_REGISTRATION=$(agmsg_sqlite_mem "
     SELECT EXISTS(
       SELECT 1
       FROM json_each(json_extract('$NORMALIZED_ESCAPED', '\$.registrations'))
@@ -92,7 +94,7 @@ else
   if [ "$HAS_REGISTRATION" = "1" ]; then
     AGENT_OBJ="$NORMALIZED"
   else
-    AGENT_OBJ=$(sqlite3 :memory: "
+    AGENT_OBJ=$(agmsg_sqlite_mem "
       SELECT json_set(
         '$NORMALIZED_ESCAPED',
         '\$.registrations[' || json_array_length(json_extract('$NORMALIZED_ESCAPED', '\$.registrations')) || ']',
@@ -102,7 +104,7 @@ else
   fi
 fi
 
-UPDATED=$(sqlite3 :memory: \
+UPDATED=$(agmsg_sqlite_mem \
   ".param set :json '$CONFIG_ESCAPED'" \
   "SELECT json_set(:json, '$.agents.$AGENT_ID', json('$(printf '%s' "$AGENT_OBJ" | sed "s/'/''/g")'));")
 echo "$UPDATED" > "$TEAM_CONFIG"

--- a/scripts/leave.sh
+++ b/scripts/leave.sh
@@ -14,6 +14,8 @@ TEAMS_DIR="$SCRIPT_DIR/../teams"
 # Reject team names that would escape teams/ as a path segment (#140).
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/validate.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/storage.sh"
 agmsg_validate_team_name "$TEAM" || exit 1
 
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
@@ -26,7 +28,7 @@ fi
 CONFIG_ESCAPED=$(sed "s/'/''/g" "$TEAM_CONFIG")
 
 # Check if agent exists
-EXISTS=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+EXISTS=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
   "SELECT json_extract(:json, '$.agents.$AGENT_ID');")
 if [ -z "$EXISTS" ] || [ "$EXISTS" = "null" ]; then
   echo "Agent $AGENT_ID not in team $TEAM"
@@ -34,11 +36,11 @@ if [ -z "$EXISTS" ] || [ "$EXISTS" = "null" ]; then
 fi
 
 # Remove agent
-UPDATED=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
   "SELECT json_remove(:json, '$.agents.$AGENT_ID');")
 
 # Check if agents is now empty
-AGENT_COUNT=$(sqlite3 :memory: \
+AGENT_COUNT=$(agmsg_sqlite_mem \
   "SELECT count(*) FROM json_each(json_extract('$(echo "$UPDATED" | sed "s/'/''/g")', '$.agents'));")
 
 if [ "$AGENT_COUNT" -eq 0 ]; then

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -168,7 +168,7 @@ agmsg_registered_projects() {
       SELECT DISTINCT json_extract(r.value, '\$.project')
       FROM agents, json_each(agents.registrations) AS r
       WHERE json_extract(r.value, '\$.type') = '$type';
-    "
+    " | tr -d '\r'
   done
 }
 

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -80,3 +80,15 @@ agmsg_sqlite() {
   # shellcheck disable=SC2046  # intentional split: "-escape off" → two args, or none
   sqlite3 $(_agmsg_escape_flag) -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@"
 }
+
+# In-memory sqlite for JSON parsing / scalar lookups whose stdout is captured in
+# a command substitution ($(...)). On Windows, sqlite3.exe writes stdout in text
+# mode and turns every \n into \r\n; command substitution strips the trailing \n
+# but keeps the \r, so a captured "1" becomes "1\r" and string / integer
+# comparisons silently fail — hooks don't get written, counts misparse, etc.
+# (#130). Strip the CR; it is never a meaningful byte in a JSON or scalar result.
+# No busy_timeout (a :memory: db has no file lock) and no escape flag (these
+# call sites parse JSON/scalars, not the control-byte message stream).
+agmsg_sqlite_mem() {
+  sqlite3 :memory: "$@" | tr -d '\r'
+}

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -46,7 +46,7 @@ mv "$OLD_DIR" "$NEW_DIR"
 NEW_CONFIG="$NEW_DIR/config.json"
 if [ -f "$NEW_CONFIG" ]; then
   CONFIG_ESCAPED=$(sed "s/'/''/g" "$NEW_CONFIG")
-  UPDATED=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+  UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
     "SELECT json_set(:json, '\$.name', '$NEW_TEAM');")
   echo "$UPDATED" > "$NEW_CONFIG"
 fi

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -28,7 +28,7 @@ fi
 CONFIG_ESCAPED=$(sed "s/'/''/g" "$TEAM_CONFIG")
 
 # Check old exists
-OLD_VAL=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+OLD_VAL=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
   "SELECT json_extract(:json, '$.agents.$OLD_NAME');")
 if [ -z "$OLD_VAL" ] || [ "$OLD_VAL" = "null" ]; then
   echo "Agent $OLD_NAME not in team $TEAM"
@@ -36,7 +36,7 @@ if [ -z "$OLD_VAL" ] || [ "$OLD_VAL" = "null" ]; then
 fi
 
 # Check new doesn't exist
-NEW_VAL=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+NEW_VAL=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
   "SELECT json_extract(:json, '$.agents.$NEW_NAME');")
 if [ -n "$NEW_VAL" ] && [ "$NEW_VAL" != "null" ]; then
   echo "Agent $NEW_NAME already exists in team $TEAM"
@@ -44,7 +44,7 @@ if [ -n "$NEW_VAL" ] && [ "$NEW_VAL" != "null" ]; then
 fi
 
 # Rename: set new key with old value, remove old key
-UPDATED=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
   "SELECT json_remove(json_set(:json, '$.agents.$NEW_NAME', json_extract(:json, '$.agents.$OLD_NAME')), '$.agents.$OLD_NAME');")
 echo "$UPDATED" > "$TEAM_CONFIG"
 

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -22,6 +22,8 @@ TEAMS_DIR="$SKILL_DIR/teams"
 source "$SCRIPT_DIR/lib/actas-lock.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/resolve-project.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/storage.sh"
 
 # Resolve the session's real project root (see #92) so a drop issued from a
 # subdir/worktree clears the registration on the project the session lives in.
@@ -63,14 +65,14 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
   TEAM_NAME="$(basename "$TEAM_DIR")"
   CONFIG_ESCAPED=$(sed "s/'/''/g" "$TEAM_CONFIG")
 
-  AGENT_JSON=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+  AGENT_JSON=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
     "SELECT json_extract(:json, '$.agents.$TARGET_AGENT');")
   if [ -z "$AGENT_JSON" ] || [ "$AGENT_JSON" = "null" ]; then
     continue
   fi
 
   AGENT_ESCAPED=$(printf '%s' "$AGENT_JSON" | sed "s/'/''/g")
-  NORMALIZED=$(sqlite3 :memory: "
+  NORMALIZED=$(agmsg_sqlite_mem "
     WITH agent(a) AS (SELECT '$AGENT_ESCAPED')
     SELECT CASE
       WHEN json_type(json_extract(a, '\$.registrations')) = 'array' THEN a
@@ -86,7 +88,7 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
   ")
   NORMALIZED_ESCAPED=$(printf '%s' "$NORMALIZED" | sed "s/'/''/g")
 
-  MATCH_COUNT=$(sqlite3 :memory: "
+  MATCH_COUNT=$(agmsg_sqlite_mem "
     SELECT count(*)
     FROM json_each(json_extract('$NORMALIZED_ESCAPED', '\$.registrations'))
     WHERE json_extract(value, '\$.type') = '$AGENT_TYPE'
@@ -96,7 +98,7 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
     continue
   fi
 
-  FILTERED=$(sqlite3 :memory: "
+  FILTERED=$(agmsg_sqlite_mem "
     SELECT json_object(
       'registrations',
       COALESCE((
@@ -110,19 +112,19 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
     );
   ")
   FILTERED_ESCAPED=$(printf '%s' "$FILTERED" | sed "s/'/''/g")
-  REMAINING=$(sqlite3 :memory: "
+  REMAINING=$(agmsg_sqlite_mem "
     SELECT json_array_length(json_extract('$FILTERED_ESCAPED', '\$.registrations'));
   ")
 
   if [ "$REMAINING" -eq 0 ]; then
-    UPDATED=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+    UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
       "SELECT json_remove(:json, '$.agents.$TARGET_AGENT');")
   else
-    UPDATED=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+    UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
       "SELECT json_set(:json, '$.agents.$TARGET_AGENT', json('$FILTERED_ESCAPED'));")
   fi
 
-  AGENT_COUNT=$(sqlite3 :memory: "
+  AGENT_COUNT=$(agmsg_sqlite_mem "
     SELECT count(*)
     FROM json_each(json_extract('$(printf '%s' "$UPDATED" | sed "s/'/''/g")', '\$.agents'));
   ")

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -38,6 +38,8 @@ source "$SCRIPT_DIR/lib/resolve-project.sh"
 source "$SCRIPT_DIR/lib/node.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/hash.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/storage.sh"
 
 # Identity sanity check — no point launching a watcher with an empty pair set.
 PAIRS=$("$SCRIPT_DIR/identities.sh" "$PROJECT" "$TYPE" 2>/dev/null || true)
@@ -70,10 +72,10 @@ agmsg_resolve_codex_thread() {
       first=$(head -1 "$f" 2>/dev/null)
       case "$first" in *'"session_meta"'*) ;; *) continue ;; esac
       esc=$(printf '%s' "$first" | sed "s/'/''/g")
-      cwd=$(sqlite3 ":memory:" "SELECT COALESCE(json_extract('$esc','\$.payload.cwd'),'')" 2>/dev/null)
+      cwd=$(agmsg_sqlite_mem "SELECT COALESCE(json_extract('$esc','\$.payload.cwd'),'')" 2>/dev/null)
       cwd_phys=$(agmsg_canonical_path "$cwd")
       [ "$cwd_phys" = "$project_phys" ] || continue
-      tid=$(sqlite3 ":memory:" "SELECT COALESCE(json_extract('$esc','\$.payload.id'),'')" 2>/dev/null)
+      tid=$(agmsg_sqlite_mem "SELECT COALESCE(json_extract('$esc','\$.payload.id'),'')" 2>/dev/null)
       if [ -n "$tid" ]; then
         printf '%s' "$tid"
         return 0

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -52,6 +52,8 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"  # actas-lock.sh requires SKILL_DIR
 TEAMS_DIR="$SKILL_DIR/teams"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/storage.sh"
 
 die() { echo "spawn: $*" >&2; exit 1; }
 
@@ -140,10 +142,10 @@ resolve_team() {
   for config_file in "$TEAMS_DIR"/*/config.json; do
     [ -f "$config_file" ] || continue
     cfg_sql=$(printf '%s' "$config_file" | sed "s/'/''/g")
-    team_name=$(sqlite3 :memory: \
+    team_name=$(agmsg_sqlite_mem \
       "SELECT json_extract(CAST(readfile('$cfg_sql') AS TEXT), '\$.name');")
     # Does any agent in this team have a registration for PROJECT (any type)?
-    count_for_project=$(sqlite3 :memory: "
+    count_for_project=$(agmsg_sqlite_mem "
       WITH cfg AS (SELECT CAST(readfile('$cfg_sql') AS TEXT) AS json),
       agents AS (
         SELECT

--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -31,6 +31,8 @@ while IFS='	' read -r name types project registrations; do
     echo "  $name ($types) — $project"
   fi
   COUNT=$((COUNT + 1))
+# tr -d '\r': sqlite3.exe on Windows emits CRLF rows; the trailing CR would make
+# the `registrations` field "N\r" and trip the integer test in the loop (#130).
 done < <(sqlite3 -separator '	' :memory: \
   ".param set :json '$(sed "s/'/''/g" "$CONFIG")'" \
   "WITH agents AS (
@@ -53,7 +55,7 @@ done < <(sqlite3 -separator '	' :memory: \
      ), '?'),
      json_array_length(registrations)
    FROM agents, json_each(agents.registrations) AS r
-   GROUP BY name, registrations;")
+   GROUP BY name, registrations;" | tr -d '\r')
 
 echo ""
 echo "$COUNT member(s)"

--- a/scripts/whoami.sh
+++ b/scripts/whoami.sh
@@ -83,6 +83,8 @@ TEAMS_DIR="$SCRIPT_DIR/../teams"
 # into a subdir/worktree must not be treated as a fresh, unregistered project.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/resolve-project.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/storage.sh"
 PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
 
 if [ ! -d "$TEAMS_DIR" ]; then
@@ -103,7 +105,7 @@ ALL_TEAMS=""
 for config_file in "$TEAMS_DIR"/*/config.json; do
   [ -f "$config_file" ] || continue
   CONFIG_ESCAPED=$(sed "s/'/''/g" "$config_file")
-  TEAM_NAME=$(sqlite3 :memory: ".param set :json '$CONFIG_ESCAPED'" \
+  TEAM_NAME=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
     "SELECT json_extract(:json, '$.name');")
   ALL_TEAMS="${ALL_TEAMS:+$ALL_TEAMS,}$TEAM_NAME"
 
@@ -124,7 +126,7 @@ for config_file in "$TEAMS_DIR"/*/config.json; do
     SELECT DISTINCT name
     FROM agents, json_each(agents.registrations) AS r
     WHERE json_extract(r.value, '\$.type') = '$AGENT_TYPE';
-  ")
+  " | tr -d '\r')
 done
 
 if [ -z "$EXACT_MATCHES" ] && [ -z "$SUGGESTED_MATCHES" ]; then


### PR DESCRIPTION
## Summary

Part of stopping the `windows-latest` CI leg from always failing. `sqlite3.exe` writes stdout in text mode on Windows and turns every `\n` into `\r\n`. Command substitution (`$(...)`) strips the trailing `\n` but keeps the `\r`, so every captured value gained a trailing carriage return. That silently broke a wide range of script logic on native Windows / Git Bash:

- **delivery.sh** — `wrote=$(… writefile()=length() …)` compared `"1\r" != "1"`, so hooks were never written.
- **identities.sh / join.sh / whoami.sh** — team/agent names came back as `"name\r"`, so identity resolution returned "no matching identity" (breaks the Codex bridge resolve path and actas-claim).
- **team.sh** — the registrations count parsed as `"N\r"` and tripped the integer test. This is the original report, #130.
- **reset / leave / rename / spawn / session-start** — assorted scalar/JSON captures.

## Fix

Add `agmsg_sqlite_mem()` to `lib/storage.sh` — `sqlite3 :memory: "$@" | tr -d '\r'` — and route the in-memory JSON/scalar call sites through it. CR is never a meaningful byte in those results. The `-separator` / process-substitution forms (`team.sh`, `identities.sh`, `whoami.sh`, `resolve-project.sh`) strip CR inline.

Exit-status note: the scalar-capture call sites (delivery / join / reset, etc.) run under `set -o pipefail`, so `sqlite3`'s exit status is preserved across the added pipe. The process-substitution forms do not propagate the pipe's status to the enclosing `while`/`for` either before or after this change, so the added `tr` introduces no new error-handling regression there.

No new dependency: still `sqlite3` + `bash` only.

## Tests

Full bats suite green on macOS/Linux (355 pass; the only failures are a pre-existing `test_watch.bats` timing flake and unrelated watcher/defaults tests). The real validation is the `windows-latest` experimental leg.

Note: this fixes production-script CRLF bugs (notably the #130 team-count report). It does not on its own turn the windows-latest experimental leg green — several .bats assertions capture `sqlite3` output directly and are themselves CRLF-fragile, and some failures are process/liveness gaps; those are tracked separately.

Refs #130, #87, #61, #134.