### PR TITLE
fix(install): warn to re-register delivery hooks after upgrade (#133)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -313,6 +313,12 @@ if [ "$UPDATE_ONLY" = true ]; then
   echo "  ! Restart any running agent sessions to pick up the updated scripts."
   echo "    In-flight watch.sh processes keep the old code until they restart."
   echo ""
+  echo "  ! If a project uses 'monitor'/'both'/'turn' delivery, re-run"
+  echo "    'delivery.sh set <mode> <type> <project>' there. An upgrade (or a skill"
+  echo "    manager that rewrites settings) can drop the SessionStart/Stop hook from"
+  echo "    a project's settings, silently stopping delivery until it is re-registered."
+  echo "    Check with 'delivery.sh status <type> <project>'. (#133)"
+  echo ""
   echo "  ✓ Update complete"
   echo ""
   exit 0

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -61,6 +61,16 @@ teardown() {
   grep -q "backup sentinel" "$backup/SKILL.md"
 }
 
+@test "install: --update warns to re-register delivery hooks (#133)" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  run env HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg --update
+  [ "$status" -eq 0 ]
+  # Surface the silent-delivery-loss footgun: an upgrade can drop a project's
+  # SessionStart/Stop hook, so the user is told to re-run delivery.sh set.
+  [[ "$output" =~ "delivery.sh set" ]]
+  [[ "$output" =~ "#133" ]]
+}
+
 @test "install: AGMSG_STORAGE_PATH override works against the installed skill" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
   local store="$FAKE_HOME/override-store"


### PR DESCRIPTION
## Summary

Addresses the silent-failure half of #133. After a skill upgrade — or when a skill manager rewrites a project's settings — the `SessionStart`/`Stop` hook agmsg installed can be dropped, and `delivery.sh set` is not re-run automatically. Delivery then stops silently with no signal to the user.

`install.sh --update` now prints a visible post-upgrade notice to re-run `delivery.sh set <mode> <type> <project>` (and verify with `delivery.sh status`) in projects that use monitor/both/turn delivery.

## Scope

This is the **warning**, not full auto re-registration. Auto re-register would need per-project *mode* persistence (which mode each project was configured with) — there is no project/mode registry today, only the hook file's presence. That infra is a follow-up (candidate for 1.1.1); this PR removes the *silent* part of the failure now.

Note: the 1.1.0 restructure itself does **not** break existing hooks — top-level script paths (`scripts/session-start.sh` etc.) didn't move — so this is a general upgrade-safety improvement, not a 1.1.0 regression fix.

## Tests

Adds an install test asserting `--update` output mentions `delivery.sh set` and `#133`. Full install suite green (36/0).

Refs #133.