### PR TITLE
fix(sqlite): harden message query literals

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -111,6 +111,7 @@ if [ ! -f "$DB" ]; then exit 0; fi
 
 OUTPUT=""
 IFS=',' read -ra TEAM_LIST <<< "$TEAMS"
+AGENT_SQL=$(agmsg_sql_literal "$AGENT")
 for team in "${TEAM_LIST[@]}"; do
   # Honor actas exclusivity locks. If (team, AGENT) is currently held by
   # another live session, that session is the owner of that role's inbox —
@@ -128,9 +129,10 @@ for team in "${TEAM_LIST[@]}"; do
     other:*) continue ;;
   esac
 
+  TEAM_SQL=$(agmsg_sql_literal "$team")
   RESULT=$(agmsg_sqlite "$DB" "
     SELECT from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
-    FROM messages WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL
+    FROM messages WHERE team=$TEAM_SQL AND to_agent=$AGENT_SQL AND read_at IS NULL
     ORDER BY created_at ASC;
   ")
   if [ -n "$RESULT" ]; then
@@ -141,7 +143,7 @@ for team in "${TEAM_LIST[@]}"; do
     done <<< "$RESULT"
     OUTPUT+=$'\n'
     # Mark as read
-    agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
+    agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team=$TEAM_SQL AND to_agent=$AGENT_SQL AND read_at IS NULL;" 2>/dev/null || true
   fi
 done
 

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -12,15 +12,24 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 DB="$(agmsg_db_path)"
 
+case "$LIMIT" in
+  ''|*[!0-9]*)
+    echo "Invalid limit: $LIMIT (must be a non-negative integer)" >&2
+    exit 1
+    ;;
+esac
+
 if [ ! -f "$DB" ]; then
   echo "No messages (DB not initialized)"
   exit 0
 fi
 
+TEAM_SQL=$(agmsg_sql_literal "$TEAM")
 if [ -n "$AGENT" ]; then
-  WHERE="WHERE team='$TEAM' AND (from_agent='$AGENT' OR to_agent='$AGENT')"
+  AGENT_SQL=$(agmsg_sql_literal "$AGENT")
+  WHERE="WHERE team=$TEAM_SQL AND (from_agent=$AGENT_SQL OR to_agent=$AGENT_SQL)"
 else
-  WHERE="WHERE team='$TEAM'"
+  WHERE="WHERE team=$TEAM_SQL"
 fi
 
 # Escape newlines/tabs in body, use unit separator between fields

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -22,10 +22,13 @@ if [ ! -f "$DB" ]; then
   exit 0
 fi
 
+TEAM_SQL=$(agmsg_sql_literal "$TEAM")
+AGENT_SQL=$(agmsg_sql_literal "$AGENT")
+
 # Get unread messages — escape newlines/tabs in body to keep one record per line
 UNREAD=$(agmsg_sqlite "$DB" "
   SELECT from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
-  FROM messages WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL
+  FROM messages WHERE team=$TEAM_SQL AND to_agent=$AGENT_SQL AND read_at IS NULL
   ORDER BY created_at ASC;
 ")
 
@@ -45,4 +48,4 @@ done <<< "$UNREAD"
 echo ""
 
 # Mark as read (non-fatal — may fail in sandboxed environments)
-agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
+agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team=$TEAM_SQL AND to_agent=$AGENT_SQL AND read_at IS NULL;" 2>/dev/null || true

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -93,6 +93,18 @@ agmsg_sqlite_mem() {
   sqlite3 :memory: "$@" | tr -d '\r'
 }
 
+# Escape a shell value for use inside a SQLite single-quoted string literal.
+# Bash cannot carry NUL bytes, so single-quote doubling is the full literal
+# escaping needed for the text values agmsg passes through the sqlite3 CLI.
+agmsg_sql_escape() {
+  printf '%s' "$1" | sed "s/'/''/g"
+}
+
+# Echo a complete SQLite string literal, including the surrounding quotes.
+agmsg_sql_literal() {
+  printf "'%s'" "$(agmsg_sql_escape "$1")"
+}
+
 # Turn a filesystem path into a form sqlite3's readfile() can open, then escape
 # it as a SQL string literal. On Windows, sqlite3.exe is a native binary that
 # can't open a Git Bash path like /d/a/agmsg/x.json — readfile() returns NULL

--- a/scripts/lib/subscription.sh
+++ b/scripts/lib/subscription.sh
@@ -3,10 +3,10 @@
 #
 # Required caller-set variables:
 #   SKILL_DIR  agmsg skill root
+# Required sourced helpers:
+#   lib/storage.sh  for agmsg_sql_literal
 
 : "${SKILL_DIR:?subscription.sh requires SKILL_DIR}"
-
-agmsg_sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
 
 # Resolve the (team, agent) rows this process should receive for.
 #
@@ -75,12 +75,12 @@ agmsg_subscription_pairs() {
 # Build a SQL predicate for a tab-separated pair list.
 agmsg_subscription_where() {
   local pairs="$1"
-  local where="" team agent t_esc a_esc pair
+  local where="" team agent t_sql a_sql pair
   while IFS=$'\t' read -r team agent; do
     [ -z "$team" ] && continue
-    t_esc=$(agmsg_sql_escape "$team")
-    a_esc=$(agmsg_sql_escape "$agent")
-    pair="(team='$t_esc' AND to_agent='$a_esc')"
+    t_sql=$(agmsg_sql_literal "$team")
+    a_sql=$(agmsg_sql_literal "$agent")
+    pair="(team=$t_sql AND to_agent=$a_sql)"
     where="${where:+$where OR }$pair"
   done <<< "$pairs"
   printf '%s' "$where"

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -53,7 +53,9 @@ fi
 
 # --- Update messages in DB ---
 if [ -f "$DB" ]; then
-  agmsg_sqlite "$DB" "UPDATE messages SET team='$NEW_TEAM' WHERE team='$OLD_TEAM';"
+  OLD_TEAM_SQL=$(agmsg_sql_literal "$OLD_TEAM")
+  NEW_TEAM_SQL=$(agmsg_sql_literal "$NEW_TEAM")
+  agmsg_sqlite "$DB" "UPDATE messages SET team=$NEW_TEAM_SQL WHERE team=$OLD_TEAM_SQL;"
 fi
 
 echo "Renamed team $OLD_TEAM → $NEW_TEAM"

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -50,8 +50,11 @@ echo "$UPDATED" > "$TEAM_CONFIG"
 
 # --- Update messages in DB ---
 if [ -f "$DB" ]; then
-  agmsg_sqlite "$DB" "UPDATE messages SET from_agent='$NEW_NAME' WHERE team='$TEAM' AND from_agent='$OLD_NAME';"
-  agmsg_sqlite "$DB" "UPDATE messages SET to_agent='$NEW_NAME' WHERE team='$TEAM' AND to_agent='$OLD_NAME';"
+  TEAM_SQL=$(agmsg_sql_literal "$TEAM")
+  OLD_NAME_SQL=$(agmsg_sql_literal "$OLD_NAME")
+  NEW_NAME_SQL=$(agmsg_sql_literal "$NEW_NAME")
+  agmsg_sqlite "$DB" "UPDATE messages SET from_agent=$NEW_NAME_SQL WHERE team=$TEAM_SQL AND from_agent=$OLD_NAME_SQL;"
+  agmsg_sqlite "$DB" "UPDATE messages SET to_agent=$NEW_NAME_SQL WHERE team=$TEAM_SQL AND to_agent=$OLD_NAME_SQL;"
 fi
 
 echo "Renamed $OLD_NAME → $NEW_NAME in team $TEAM"

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -14,7 +14,11 @@ DB="$(agmsg_db_path)"
 
 [ -f "$DB" ] || bash "$SCRIPT_DIR/internal/init-db.sh" >/dev/null
 
-INSERT="INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$TEAM', '$FROM', '$TO', '$(echo "$BODY" | sed "s/'/''/g")');"
+TEAM_SQL=$(agmsg_sql_literal "$TEAM")
+FROM_SQL=$(agmsg_sql_literal "$FROM")
+TO_SQL=$(agmsg_sql_literal "$TO")
+BODY_SQL=$(agmsg_sql_literal "$BODY")
+INSERT="INSERT INTO messages (team, from_agent, to_agent, body) VALUES ($TEAM_SQL, $FROM_SQL, $TO_SQL, $BODY_SQL);"
 
 # Retry once after ensuring the schema. Under a concurrent first-write fan-out
 # (leader → N members against a fresh/override store), one process can see the

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -200,16 +200,14 @@ if [ -z "$PAIRS" ]; then
 fi
 
 # Build the SQL WHERE clause. Each pair contributes:
-#   (team='<team>' AND to_agent='<agent>')
-# joined by OR. Single quotes inside team/agent names are doubled for SQL.
-sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
-
+#   (team=<literal> AND to_agent=<literal>)
+# joined by OR.
 WHERE_PAIRS=""
 while IFS=$'\t' read -r team agent; do
   [ -z "$team" ] && continue
-  t_esc=$(sql_escape "$team")
-  a_esc=$(sql_escape "$agent")
-  pair="(team='$t_esc' AND to_agent='$a_esc')"
+  t_sql=$(agmsg_sql_literal "$team")
+  a_sql=$(agmsg_sql_literal "$agent")
+  pair="(team=$t_sql AND to_agent=$a_sql)"
   WHERE_PAIRS="${WHERE_PAIRS:+$WHERE_PAIRS OR }$pair"
 done <<< "$PAIRS"
 

--- a/tests/test_messaging.bats
+++ b/tests/test_messaging.bats
@@ -21,6 +21,34 @@ teardown() {
   [[ "$output" =~ "Sent to bob" ]]
 }
 
+@test "send: stores quoted team, agents, and body as values" {
+  run bash "$SCRIPTS/send.sh" "team'one" "ali'ce" "bo'b" "it's fine"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Sent to bo'b in team team'one" ]]
+
+  local count
+  count=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "
+    SELECT COUNT(*)
+    FROM messages
+    WHERE team='team''one'
+      AND from_agent='ali''ce'
+      AND to_agent='bo''b'
+      AND body='it''s fine';
+  " | tr -d '\r')
+  [ "$count" = "1" ]
+}
+
+@test "send: treats injected to_agent SQL as data" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "safe" >/dev/null
+
+  run bash "$SCRIPTS/send.sh" testteam alice "bob','payload'); DELETE FROM messages; --" "ignored"
+  [ "$status" -eq 0 ]
+
+  local count
+  count=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COUNT(*) FROM messages;" | tr -d '\r')
+  [ "$count" = "2" ]
+}
+
 @test "send: fails without required args" {
   run bash "$SCRIPTS/send.sh"
   [ "$status" -ne 0 ]
@@ -40,6 +68,14 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" =~ "hello bob" ]]
   [[ "$output" =~ "alice" ]]
+}
+
+@test "inbox: shows quoted team and agent messages" {
+  bash "$SCRIPTS/send.sh" "team'one" "ali'ce" "bo'b" "quoted hello"
+  run bash "$SCRIPTS/inbox.sh" "team'one" "bo'b"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "quoted hello" ]]
+  [[ "$output" =~ "ali'ce" ]]
 }
 
 @test "inbox: marks messages as read" {
@@ -73,6 +109,35 @@ line3"
   [[ "$output" =~ "alice" ]]
 }
 
+@test "inbox: predicate-widening team input does not expose or mark unrelated messages" {
+  bash "$SCRIPTS/send.sh" team1 alice bob "bob-only" >/dev/null
+  bash "$SCRIPTS/send.sh" team2 alice carol "carol-only" >/dev/null
+
+  run bash "$SCRIPTS/inbox.sh" "x' OR 1=1 --" bob
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "No new messages" ]]
+
+  local read_count
+  read_count=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COUNT(*) FROM messages WHERE read_at IS NOT NULL;" | tr -d '\r')
+  [ "$read_count" = "0" ]
+}
+
+@test "check-inbox: predicate-widening team input does not mark unrelated messages" {
+  local project
+  project="$BATS_TEST_TMPDIR/project-evil"
+  mkdir -p "$project"
+  bash "$SCRIPTS/join.sh" "x' OR 1=1 --" bob claude-code "$project"
+  bash "$SCRIPTS/send.sh" testteam alice bob "normal-bob" >/dev/null
+
+  run bash "$SCRIPTS/check-inbox.sh" claude-code "$project"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  local read_count
+  read_count=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COUNT(*) FROM messages WHERE read_at IS NOT NULL;" | tr -d '\r')
+  [ "$read_count" = "0" ]
+}
+
 @test "history: handles multiline message body" {
   bash "$SCRIPTS/send.sh" testteam alice bob "multi
 line"
@@ -93,6 +158,15 @@ line"
   [[ "$output" =~ "msg2" ]]
 }
 
+@test "history: filters quoted team and agent as values" {
+  bash "$SCRIPTS/send.sh" "team'one" "ali'ce" "bo'b" "quoted history"
+  run bash "$SCRIPTS/history.sh" "team'one" "bo'b"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "quoted history" ]]
+  [[ "$output" =~ "ali'ce" ]]
+  [[ "$output" =~ "bo'b" ]]
+}
+
 @test "history: filters by agent" {
   bash "$SCRIPTS/send.sh" testteam alice bob "for bob"
   bash "$SCRIPTS/send.sh" testteam bob alice "for alice"
@@ -110,6 +184,17 @@ line"
   [ "$status" -eq 0 ]
   local count=$(echo "$output" | grep -c "→")
   [ "$count" -eq 1 ]
+}
+
+@test "history: rejects injected limit without executing it" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "limit target" >/dev/null
+
+  run bash "$SCRIPTS/history.sh" testteam "" "1; UPDATE messages SET read_at='pwned' WHERE 1=1; --"
+  [ "$status" -ne 0 ]
+
+  local read_at
+  read_at=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COALESCE(read_at, '') FROM messages WHERE body='limit target';" | tr -d '\r')
+  [ -z "$read_at" ]
 }
 
 @test "history: shows no history message when empty" {


### PR DESCRIPTION
## 変更内容

メッセージDBまわりの SQLite クエリ組み立てを安全にします。

このPRでは、SQLite文字列リテラルの生成を共通化し、以下に適用しました。

- `send.sh`
- `inbox.sh`
- `history.sh`
- `check-inbox.sh`
- `watch.sh`
- `scripts/lib/subscription.sh`
- `rename.sh` / `rename-team.sh` のメッセージDB更新部分

あわせて、`history.sh` の `LIMIT` 引数は非負整数のみ受け付けるように検証を追加しました。

## 背景

一部のメッセージDBクエリでは、CLIから渡された値をSQL文字列に直接埋め込んでいました。

そのため、次の問題が起きる可能性がありました。

- `'` を含む正当な team / agent 名でSQL構文が壊れる
- `OR 1=1 --` のような入力でWHERE条件が広がり、関係ないメッセージを読めたり既読化できたりする

特に `send.sh` は `BODY` だけをエスケープしていて、`TEAM` / `FROM` / `TO` は直接SQLに埋め込まれていました。

## 実装方針

- `scripts/lib/storage.sh` に `agmsg_sql_escape` / `agmsg_sql_literal` を追加
- メッセージDBに渡す値の直接埋め込みを、共通 helper 経由に変更
- `LIMIT` は文字列として扱わず、数値として検証してからSQLに渡す
- quote を含む値と、predicate widening を狙う入力の回帰テストを追加

このPRのスコープは #87 に書かれているメッセージDB経路に限定しています。team registry / identity config のJSON pathまわりは、別PRで扱う想定です。

## テスト

最新 `main` にrebaseした後、以下を実行しました。

- `git diff --check`
- `bash -n scripts/lib/storage.sh scripts/send.sh scripts/inbox.sh scripts/history.sh scripts/check-inbox.sh scripts/watch.sh scripts/lib/subscription.sh scripts/rename.sh scripts/rename-team.sh`
- `bash -n scripts/drivers/types/codex/watch-once.sh`
- `bats tests/test_messaging.bats tests/test_watch_once.bats tests/test_watch.bats tests/test_storage.bats tests/test_delivery.bats` (`149/149` pass)
- `bats tests/` (`391/392` pass)

全体実行では、Codex実行環境に依存する既存テストが1件だけ失敗しています。

- `whoami: defaults to claude-code when no env vars set`

この失敗は、Codex環境では agent type の自動検出が `codex` 側に寄るためで、今回のSQLite query hardeningの変更とは無関係です。

Refs #87
