### PR TITLE
fix(windows): use tasklist for native pid liveness in agmsg_instance_alive (#134)

### DIFF
--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -33,6 +33,21 @@
 [ -n "${_AGMSG_INSTANCE_ID_SH:-}" ] && return 0
 _AGMSG_INSTANCE_ID_SH=1
 
+# Cross-platform pid liveness check. Git Bash's kill(1) only sees MSYS2/Cygwin
+# PIDs; native Windows processes (Claude Code, etc.) are invisible to it, so
+# kill -0 always returns false for them (#134). On Windows we fall back to
+# tasklist.exe which queries the native process table.
+_agmsg_pid_alive() {
+  local pid="$1"
+  case "${MSYSTEM:-}" in
+    MINGW*|MSYS*|CLANGARM*)
+      MSYS_NO_PATHCONV=1 tasklist /FI "PID eq $pid" 2>/dev/null | grep -q "$pid"
+      return $?
+      ;;
+  esac
+  kill -0 "$pid" 2>/dev/null
+}
+
 # Compose from an explicit pid. Bare sid when pid is empty/non-numeric.
 agmsg_instance_id_from_pid() {
   local sid="$1" pid="$2"
@@ -102,7 +117,7 @@ agmsg_instance_alive() {
   [ -n "$token" ] || return 1
   if agmsg_instance_is_composite "$token"; then
     local pid="${token##*.}"
-    kill -0 "$pid" 2>/dev/null && return 0
+    _agmsg_pid_alive "$pid" && return 0
     return 1
   fi
   local run f p s
@@ -112,7 +127,7 @@ agmsg_instance_alive() {
     [ -f "$f" ] || continue
     p=${f##*.}
     case "$p" in ''|*[!0-9]*) continue ;; esac
-    kill -0 "$p" 2>/dev/null || continue
+    _agmsg_pid_alive "$p" || continue
     s="$(cat "$f" 2>/dev/null || true)"
     [ "$s" = "$token" ] && return 0
     # upgrade compat: cc-instance stores "<sid>.<pid>" but the lock holds "<sid>"


### PR DESCRIPTION
## Summary

Fixes the `actas_lock_sid_alive()` always-false bug on native Windows (#134, Bug 2).

## Problem

`agmsg_instance_alive()` uses `kill -0 $pid` to check whether a process holding an actas lock is still running. On Windows, Git Bash's `kill` builtin only sees MSYS2/Cygwin-internal PIDs. Native Windows processes (Claude Code, Antigravity, etc.) have native PIDs that are invisible to `kill -0`, so the liveness check always returns false — every lock is treated as stale, breaking session exclusivity.

The existing bats tests pass on `windows-latest` CI because they exercise bash-spawned PIDs (which `kill -0` *can* see under Git Bash), so the native-PID failure path is not reproduced in CI.

## Solution

Add a `_agmsg_pid_alive()` helper in `scripts/lib/instance-id.sh` that detects Windows via the `$MSYSTEM` environment variable (set by Git Bash / MSYS2) and uses `tasklist /FI "PID eq $pid"` to query the native Windows process table:

- `MSYSTEM` matches `MINGW*`, `MSYS*`, or `CLANGARM*` → Windows path (tasklist)
- `MSYSTEM` unset or other value → Unix path (kill -0)
- `MSYS_NO_PATHCONV=1` prevents Git Bash from mangling the `/FI` flag into a filesystem path

Replace the two `kill -0` calls inside `agmsg_instance_alive()` with `_agmsg_pid_alive`. All other `kill -0` sites in the codebase (watch.sh, delivery.sh, session-start.sh, etc.) are intentionally left unchanged — they are tracked in #182.

## Verified on native Windows

- `MSYSTEM=MINGW64` → `MINGW*` pattern matches
- Native Windows PID → `tasklist` correctly reports ALIVE
- Non-existent PID → `tasklist` output has no match → correctly reports DEAD
- Linux/macOS → `MSYSTEM` unset → falls through to `kill -0` (no behaviour change)

## Related issues

- #134 — this PR addresses Bug 2 (actas_lock_sid_alive always false)
- #182 — quarantined watcher process-management tests (separate, broader kill -0 migration)
- #184 — native Windows delivery JSON round-trip bugs (separate root cause)
