### PR TITLE
fix(directive): quote Monitor command args so space-in-path survives (#188)

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -266,10 +266,15 @@ EOF
     fi
   fi
 
+  # Shell-quote each argv (printf %q) so a paste-and-run host shell keeps paths
+  # with spaces or apostrophes intact; a plain '...' wrap breaks on /o'brien/...
+  # (#188).
+  local watch_command
+  watch_command="$(printf '%q %q %q %q' "$watch" "$session_id" "$project" "$type")"
   cat <<EOF
 
 AGMSG-DIRECTIVE: For this running session, invoke the Monitor tool now with:
-  command: '$watch' '$session_id' '$project' '$type'
+  command: $watch_command
   description: agmsg inbox stream
   persistent: true
 

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -269,7 +269,7 @@ EOF
   cat <<EOF
 
 AGMSG-DIRECTIVE: For this running session, invoke the Monitor tool now with:
-  command: $watch $session_id $project $type
+  command: '$watch' '$session_id' '$project' '$type'
   description: agmsg inbox stream
   persistent: true
 

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -216,7 +216,7 @@ cat <<EOF
 AGMSG monitor mode: invoke the Monitor tool now with the following parameters,
 before any other action in this session.
 
-  command: $WATCH $INSTANCE_ID $PROJECT $TYPE
+  command: '$WATCH' '$INSTANCE_ID' '$PROJECT' '$TYPE'
   description: agmsg inbox stream
   persistent: true
 

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -211,12 +211,17 @@ if [ -n "$CC_PID" ]; then
 fi
 
 WATCH="$SKILL_DIR/scripts/watch.sh"
+# Shell-quote each argv so the host can paste the command into Monitor and run
+# it verbatim. A plain '...' wrap breaks on paths with an apostrophe
+# (/Users/o'brien/...); printf %q escapes spaces, quotes and other metacharacters
+# safely for shell re-execution (#188).
+WATCH_COMMAND="$(printf '%q %q %q %q' "$WATCH" "$INSTANCE_ID" "$PROJECT" "$TYPE")"
 
 cat <<EOF
 AGMSG monitor mode: invoke the Monitor tool now with the following parameters,
 before any other action in this session.
 
-  command: '$WATCH' '$INSTANCE_ID' '$PROJECT' '$TYPE'
+  command: $WATCH_COMMAND
   description: agmsg inbox stream
   persistent: true
 

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -196,6 +196,28 @@ settings_file() {
   [[ "$output" =~ "watch.sh" ]]
 }
 
+@test "delivery set monitor: directive quotes args so a space-in-path survives (#188)" {
+  # The host pastes the emitted command into Monitor and runs it as a shell
+  # command; without quoting, a project path with whitespace (iCloud Drive)
+  # word-splits and watch.sh resolves the wrong project. AGMSG_RESOLVE_PROJECT=0
+  # keeps the raw path so the assertion is deterministic.
+  local sp="$TEST_PROJECT/Mobile Documents/proj with space"
+  mkdir -p "$sp"
+  run env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/delivery.sh" set monitor claude-code "$sp"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"'$sp'"* ]]
+}
+
+@test "session-start: Monitor directive quotes args so a space-in-path survives (#188)" {
+  local sp="$TEST_PROJECT/Mobile Documents/proj with space"
+  mkdir -p "$sp"
+  env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/join.sh" team alice claude-code "$sp" >/dev/null
+  run env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/session-start.sh" claude-code "$sp" </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "invoke the Monitor tool" ]]
+  [[ "$output" == *"'$sp'"* ]]
+}
+
 @test "delivery set turn: emits AGMSG-DIRECTIVE to stop any running watcher" {
   run bash "$SCRIPTS/delivery.sh" set turn claude-code "$TEST_PROJECT"
   [[ "$output" =~ "AGMSG-DIRECTIVE" ]]

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -196,26 +196,39 @@ settings_file() {
   [[ "$output" =~ "watch.sh" ]]
 }
 
-@test "delivery set monitor: directive quotes args so a space-in-path survives (#188)" {
-  # The host pastes the emitted command into Monitor and runs it as a shell
-  # command; without quoting, a project path with whitespace (iCloud Drive)
-  # word-splits and watch.sh resolves the wrong project. AGMSG_RESOLVE_PROJECT=0
-  # keeps the raw path so the assertion is deterministic.
-  local sp="$TEST_PROJECT/Mobile Documents/proj with space"
+# The host pastes the emitted command into Monitor and runs it as a shell
+# command; if the argv isn't shell-quoted, a project path with whitespace
+# (iCloud Drive) or an apostrophe (/Users/o'brien/...) is mis-parsed and watch.sh
+# resolves the wrong project. These re-parse the emitted line the way the host
+# shell would and assert the project survives as one argv element. The path
+# carries BOTH a space and an apostrophe (the case a plain '...' wrap breaks on).
+# AGMSG_RESOLVE_PROJECT=0 keeps the raw path so the round-trip is deterministic.
+
+@test "delivery set monitor: directive argv round-trips through a shell (#188)" {
+  local sp="$TEST_PROJECT/Mobile Documents/o'brien proj"
   mkdir -p "$sp"
   run env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/delivery.sh" set monitor claude-code "$sp"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"'$sp'"* ]]
+  local cmdline
+  cmdline=$(printf '%s\n' "$output" | sed -n 's/^[[:space:]]*command: //p')
+  [ -n "$cmdline" ]
+  eval "set -- $cmdline"
+  [ "$3" = "$sp" ]
+  [ "$4" = "claude-code" ]
 }
 
-@test "session-start: Monitor directive quotes args so a space-in-path survives (#188)" {
-  local sp="$TEST_PROJECT/Mobile Documents/proj with space"
+@test "session-start: Monitor directive argv round-trips through a shell (#188)" {
+  local sp="$TEST_PROJECT/Mobile Documents/o'brien proj"
   mkdir -p "$sp"
   env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/join.sh" team alice claude-code "$sp" >/dev/null
   run env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/session-start.sh" claude-code "$sp" </dev/null
   [ "$status" -eq 0 ]
   [[ "$output" =~ "invoke the Monitor tool" ]]
-  [[ "$output" == *"'$sp'"* ]]
+  local cmdline
+  cmdline=$(printf '%s\n' "$output" | sed -n 's/^[[:space:]]*command: //p')
+  [ -n "$cmdline" ]
+  eval "set -- $cmdline"
+  [ "$3" = "$sp" ]
 }
 
 @test "delivery set turn: emits AGMSG-DIRECTIVE to stop any running watcher" {


### PR DESCRIPTION
## Summary

Fixes #188 (reported by @HidakaKoyo). Both Monitor-invocation directives interpolated the `watch.sh` argv unquoted:

```
command: $WATCH $INSTANCE_ID $PROJECT $TYPE
```

The host agent pastes the rendered string into Monitor and runs it as a shell command, so a project path containing whitespace — notably macOS iCloud Drive paths under `~/Library/Mobile Documents/...` — word-splits. `watch.sh` then receives a truncated path, `agmsg_resolve_project` finds no registration, and it exits immediately: the session silently has **no live watcher** for its entire lifetime, even though the agent's registration is intact.

## Fix

Single-quote each argument in both emit paths:
- `scripts/session-start.sh` — the SessionStart hook directive (the path in the report).
- `scripts/delivery.sh` `emit_monitor_directive` — the in-session directive printed after `delivery.sh set monitor`/`both`, which had the identical defect.

```
command: '$WATCH' '$INSTANCE_ID' '$PROJECT' '$TYPE'
```

## Tests

Two regression tests (one per emit path): register a claude-code agent at a project path with a space and assert the emitted `command:` line wraps the path in quotes so it stays a single argv element. Full suite green except the two pre-existing `test_watch.bats` timing flakes (unrelated — no watcher code touched).

Fixes #188.