### PR TITLE
ci(tests): bound the bats job with timeout-minutes: 15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,11 @@ jobs:
     # block the PR). When changes failed, docs_only is empty → heavy steps run.
     if: ${{ !cancelled() }}
     runs-on: ${{ matrix.os }}
+    # Bound a hung runner/test: the suite normally finishes in ~5 min, so a job
+    # still running at 15 fails fast (and is re-runnable) instead of pinning this
+    # REQUIRED check for the GitHub default of 6h — seen with a stalled macOS
+    # runner. bats-windows already sets its own timeout; this covers ubuntu/macos.
+    timeout-minutes: 15
     strategy:
       # Cover both GNU (Linux) and BSD (macOS) userlands — the scripts shell out
       # to sed/stat/mktemp/ps etc. whose flags differ between them.


### PR DESCRIPTION
Adds a 15-minute `timeout-minutes` to the required `bats` job (ubuntu/macos).

The suite normally finishes in ~5 minutes, but a stalled macOS runner left a required check hung for ~33 minutes (the default GitHub job timeout is 6h), pinning the PR. Bounding the job makes a stall fail fast and re-runnable instead of blocking. `bats-windows` already sets its own timeout; this covers ubuntu/macos.