### PR TITLE
feat(windows): add MSYS2 compat shim (#88)

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "$0")" && pwd)/lib/compat.sh"
 
 # Check inbox across all teams with cooldown. Skips if last check was < 60 seconds ago.
 # Usage: check-inbox.sh <type> <project_path>
@@ -91,11 +93,7 @@ fi
 MARKER="$SKILL_DIR/run/.lastcheck-$AGENT"
 
 if [ -f "$MARKER" ]; then
-  if [ "$(uname)" = "Darwin" ]; then
-    last=$(stat -f %m "$MARKER")
-  else
-    last=$(stat -c %Y "$MARKER")
-  fi
+  last=$(compat_file_mtime "$MARKER")
   now=$(date +%s)
   # Prefer the new delivery.turn.check_interval; fall back to legacy
   # hook.check_interval for users who haven't migrated.

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -34,6 +34,8 @@ SKILL_NAME="$(basename "$SKILL_DIR")"
 RUN_DIR="$SKILL_DIR/run"
 # instance-id derivation (#93) for the in-session monitor directive below.
 # shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/compat.sh"
+# shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/resolve-project.sh"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/instance-id.sh"
@@ -238,11 +240,7 @@ emit_monitor_directive() {
   # present (older CC, non-CC runtimes).
   local session_id="${CLAUDE_CODE_SESSION_ID:-}"
   if [ -z "$session_id" ]; then
-    if command -v uuidgen >/dev/null 2>&1; then
-      session_id="agmsg-$(uuidgen | tr 'A-Z' 'a-z')"
-    else
-      session_id="agmsg-$(date +%s)-$$"
-    fi
+    session_id="agmsg-$(compat_uuidgen | tr 'A-Z' 'a-z')"
   fi
 
   # Key the watcher on the per-process instance id (#93) so parallel
@@ -439,7 +437,7 @@ kill_all_watchers() {
         # Defensive: only kill if the pid's command line still looks like
         # our watch.sh. Defends against pid recycling — a stale pidfile
         # could point at an unrelated process that reused the pid.
-        cmd=$(ps -o args= -p "$pid" 2>/dev/null || true)
+        cmd=$(compat_get_cmdline "$pid" 2>/dev/null || true)
         case "$cmd" in
           *"$SKILL_DIR/scripts/watch.sh"*)
             # When scoped, skip (and preserve the pidfile of) watchers that don't

--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -66,7 +66,7 @@ agmsg_session_start() {
   if [ -z "$app_server" ]; then
     agent_pid=$(agmsg_agent_pid "$TYPE" 2>/dev/null || true)
     if [ -n "$agent_pid" ]; then
-      agent_cmd=$(ps -o args= -p "$agent_pid" 2>/dev/null || true)
+      agent_cmd=$(compat_get_cmdline "$agent_pid" 2>/dev/null || true)
       app_server=$(printf '%s\n' "$agent_cmd" \
         | sed -n 's/.*\(unix:\/\/[^[:space:]]*\).*/\1/p' \
         | head -1)

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# compat.sh — Platform compatibility shim for agmsg on MSYS2/Windows.
+#
+# MSYS2's ps does not support POSIX -o flags (ppid=, args=, comm=), uuidgen
+# may be absent, and stat flags differ across platforms. This shim provides
+# portable wrappers so the rest of the scripts need not branch per-platform.
+#
+# Usage: source this file early; call _agmsg_detect_platform (or let the
+#        wrappers lazy-init it), then use compat_* functions.
+
+_agmsg_platform=""
+
+_agmsg_detect_platform() {
+  [ -n "$_agmsg_platform" ] && return
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) _agmsg_platform="msys"  ;;
+    Darwin*)               _agmsg_platform="macos" ;;
+    *)                     _agmsg_platform="linux" ;;
+  esac
+}
+
+# Get parent PID of a process.  Replaces: ps -o ppid= -p <pid>
+compat_get_ppid() {
+  local pid="$1"
+  [ -z "$pid" ] && return 1
+  _agmsg_detect_platform
+  case "$_agmsg_platform" in
+    msys)
+      ps -l -p "$pid" 2>/dev/null | awk '
+        NR==1 { for (i = 1; i <= NF; i++) if ($i == "PPID") col = i; next }
+        NR==2 && col { print $col }
+      '
+      ;;
+    *)
+      ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '
+      ;;
+  esac
+}
+
+# Get full command line of a process.  Replaces: ps -o args= -p <pid>
+compat_get_cmdline() {
+  local pid="$1"
+  [ -z "$pid" ] && return 1
+  _agmsg_detect_platform
+  case "$_agmsg_platform" in
+    msys)
+      if [ -r "/proc/$pid/cmdline" ]; then
+        tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null
+      else
+        ps -l -p "$pid" 2>/dev/null | awk 'NR==2{print $NF}'
+      fi
+      ;;
+    *)
+      ps -o args= -p "$pid" 2>/dev/null
+      ;;
+  esac
+}
+
+# Get the bare command name of a process.  Replaces: ps -o comm= -p <pid>
+compat_get_comm() {
+  local pid="$1"
+  [ -z "$pid" ] && return 1
+  _agmsg_detect_platform
+  case "$_agmsg_platform" in
+    msys)
+      if [ -r "/proc/$pid/cmdline" ]; then
+        tr '\0' '\n' < "/proc/$pid/cmdline" 2>/dev/null | head -1 | xargs basename 2>/dev/null
+      else
+        ps -l -p "$pid" 2>/dev/null | awk 'NR==2{print $NF}' | xargs basename 2>/dev/null
+      fi
+      ;;
+    *)
+      ps -o comm= -p "$pid" 2>/dev/null | xargs basename 2>/dev/null
+      ;;
+  esac
+}
+
+# Generate a UUID.  Replaces: uuidgen
+compat_uuidgen() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen
+  elif [ -r /proc/sys/kernel/random/uuid ]; then
+    cat /proc/sys/kernel/random/uuid
+  else
+    sqlite3 :memory: "SELECT lower(
+      hex(randomblob(4)) || '-' ||
+      hex(randomblob(2)) || '-4' ||
+      substr(hex(randomblob(2)),2) || '-' ||
+      substr('89ab', abs(random()) % 4 + 1, 1) ||
+      substr(hex(randomblob(2)),2) || '-' ||
+      hex(randomblob(6)));"
+  fi | tr -d '\r'
+}
+
+# Get file modification time as epoch seconds.
+# Replaces: stat -f %m (macOS) / stat -c %Y (Linux/MSYS2)
+compat_file_mtime() {
+  local file="$1"
+  [ -z "$file" ] && return 1
+  _agmsg_detect_platform
+  case "$_agmsg_platform" in
+    macos)  stat -f %m "$file" 2>/dev/null ;;
+    *)      stat -c %Y "$file" 2>/dev/null ;;
+  esac
+}

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -29,6 +29,9 @@
 
 : "${SKILL_DIR:?resolve-project.sh requires SKILL_DIR}"
 
+# shellcheck disable=SC1091
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat.sh"
+
 # agmsg_registered_projects() below reads team configs via readfile() and needs
 # agmsg_sql_readfile_path(). Not every caller that sources resolve-project.sh
 # also sources storage.sh (e.g. actas-claim.sh), so pull it in here. Re-sourcing
@@ -76,8 +79,8 @@ agmsg_pid_is_agent() {
   kill -0 "$pid" 2>/dev/null || return 1
   local binaries comm first base bin
   binaries=$(_agmsg_agent_binaries "$type")
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null | xargs basename 2>/dev/null || true)
-  first=$(ps -o args= -p "$pid" 2>/dev/null | awk '{print $1}')
+  comm=$(compat_get_comm "$pid" 2>/dev/null || true)
+  first=$(compat_get_cmdline "$pid" 2>/dev/null | awk '{print $1}' || true)
   base=$(basename -- "${first:-}" 2>/dev/null || true)
   for bin in $binaries; do
     case "$comm" in "$bin"|"$bin"-*) return 0 ;; esac
@@ -109,7 +112,7 @@ agmsg_agent_pid() {
   fi
   local pid="$$" hops=0
   while [ "${pid:-0}" -gt 1 ] && [ "$hops" -lt 20 ]; do
-    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    pid=$(compat_get_ppid "$pid" 2>/dev/null || true)
     [ -z "$pid" ] && return 1
     [ "$pid" = "0" ] && return 1
     if agmsg_pid_is_agent "$pid" "$type"; then

--- a/scripts/session-end.sh
+++ b/scripts/session-end.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "$0")" && pwd)/lib/compat.sh"
 
 # SessionEnd hook — symmetric counterpart of session-start.sh.
 #
@@ -57,7 +59,7 @@ if [ -f "$PIDFILE" ]; then
     # Defensive: only kill if the pid's command line still looks like our
     # watch.sh. Pids can be recycled — a stale pidfile could point at an
     # unrelated process that took the same pid.
-    cmd=$(ps -o args= -p "$pid" 2>/dev/null || true)
+    cmd=$(compat_get_cmdline "$pid" 2>/dev/null || true)
     case "$cmd" in
       *"$SKILL_DIR/scripts/watch.sh"*) kill "$pid" 2>/dev/null || true ;;
       *) ;;

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "$0")" && pwd)/lib/compat.sh"
 
 # SessionStart hook for delivery modes `monitor` and `both`.
 #
@@ -136,7 +138,7 @@ for f in "$RUN_DIR"/cc-instance.*; do
         # Defensive: only kill if the pid's command line actually matches
         # our watch.sh. Defends against pid recycling — a stale pidfile
         # could point at an unrelated process that took the same pid.
-        cmd=$(ps -o args= -p "$orphan_pid" 2>/dev/null || true)
+        cmd=$(compat_get_cmdline "$orphan_pid" 2>/dev/null || true)
         case "$cmd" in
           *"$SKILL_DIR/scripts/watch.sh"*) kill "$orphan_pid" 2>/dev/null || true ;;
           *) ;;  # not our watcher anymore; leave it alone

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -u
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "$0")" && pwd)/lib/compat.sh"
 
 # Stream new agmsg messages for the current session as they arrive.
 #
@@ -85,7 +87,7 @@ mkdir -p "$RUN_DIR" 2>/dev/null || true
 if [ -f "$PIDFILE" ]; then
   prev_pid=$(cat "$PIDFILE" 2>/dev/null || true)
   if [ -n "$prev_pid" ] && [ "$prev_pid" != "$$" ] && kill -0 "$prev_pid" 2>/dev/null; then
-    prev_cmd=$(ps -o args= -p "$prev_pid" 2>/dev/null || true)
+    prev_cmd=$(compat_get_cmdline "$prev_pid" 2>/dev/null || true)
     if [ -n "$prev_cmd" ]; then
       case "$prev_cmd" in
         *"$SKILL_DIR/scripts/watch.sh"*) kill "$prev_pid" 2>/dev/null || true ;;

--- a/scripts/whoami.sh
+++ b/scripts/whoami.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/type-registry.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/compat.sh"
 
 # Auto-detect CLI type from environment variables and the process tree, driven by
 # the per-type manifests' `detect=` (env-var names) and `detect_proc=` (process
@@ -52,7 +54,7 @@ EOF
   # (the globs are disjoint, so order within a level is irrelevant).
   local pid=$$ max_depth=10 depth=0 proc_name _pats _pat
   while [ $depth -lt $max_depth ] && [ "$pid" != "1" ] && [ -n "$pid" ]; do
-    proc_name=$(ps -p "$pid" -o comm= 2>/dev/null | xargs basename 2>/dev/null || true)
+    proc_name=$(compat_get_comm "$pid" 2>/dev/null || true)
     if [ -n "$proc_name" ]; then
       while IFS= read -r _t; do
         [ -n "$_t" ] || continue
@@ -73,7 +75,7 @@ EOF
     fi
 
     # Move to parent process
-    pid=$(ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' ' || true)
+    pid=$(compat_get_ppid "$pid" 2>/dev/null || true)
     depth=$((depth + 1))
   done
 

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -9,6 +9,11 @@ load test_helper
 
 setup() {
   setup_test_env
+  # On MSYS2, the compat shim makes the ppid walk succeed; _iid() (bats
+  # subshell) and watch.sh (standalone bash) have different process trees, so
+  # the walk can produce different instance IDs. Pin to bare-sid on MSYS2 so
+  # both contexts agree deterministically.
+  case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) export AGMSG_AGENT_PID="" ;; esac
   export PROJ="/tmp/agmsg-watch-proj"
   bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
 }


### PR DESCRIPTION
## Summary

Add `scripts/lib/compat.sh` — a platform compatibility shim that wraps MSYS2-incompatible POSIX commands (`ps -o ppid=/args=/comm=`, `uuidgen`, `stat -c/-f`) with portable alternatives. Replace 12 call sites across 8 scripts with the `compat_*` wrappers.

On Linux/macOS the wrappers fall through to the original commands, so behavior is unchanged on those platforms.

**Scope (per maintainer guidance):** this is the _core_ compat-shim PR. The `delivery.sh` `"shell":"bash"` hook-routing and the PowerShell bootstrap installers are intentionally excluded and will follow as separate PRs.

## What changed

- **New file:** `scripts/lib/compat.sh` — 5 wrapper functions:
  - `compat_get_ppid` — replaces `ps -o ppid= -p <pid>`
  - `compat_get_cmdline` — replaces `ps -o args= -p <pid>`
  - `compat_get_comm` — replaces `ps -o comm= -p <pid>`
  - `compat_uuidgen` — replaces `uuidgen` (falls back to `/proc/sys/kernel/random/uuid`, then `sqlite3`)
  - `compat_file_mtime` — replaces `stat -f %m` (macOS) / `stat -c %Y` (Linux)

- **Call-site swaps (12 sites, 8 files):**
  - `resolve-project.sh` (3): `agmsg_pid_is_agent` comm+cmdline, `agmsg_agent_pid` ppid walk
  - `whoami.sh` (2): `detect_cli_type` process-tree walk
  - `delivery.sh` (2): `emit_monitor_directive` uuidgen, `kill_all_watchers` cmdline check
  - `session-start.sh` (1): orphan watcher cmdline check
  - `session-end.sh` (1): watcher cmdline check
  - `watch.sh` (1): previous-watcher cmdline check
  - `check-inbox.sh` (1): cooldown `stat` mtime
  - `codex/_session-start.sh` (1): app-server argv extraction

- **Test fix:** `test_watch.bats` pins `AGMSG_AGENT_PID=""` on MSYS2 so the ppid walk (now functional) doesn't cause instance-id mismatches between bats subshell and standalone bash contexts.

## Coordination

- Built on `8d662ba` (current `main`, includes #198 and #200)
- #198 (`_agmsg_pid_alive` via `tasklist`) operates at a different layer (pid _liveness_ vs process _interrogation_) — no conflict
- #200 (`printf %q` quoting) is preserved in both `delivery.sh` and `session-start.sh`

## Test plan

Verified on Windows 11 / Git Bash (MINGW64) against the full test suite, comparing baseline (`main`) vs this branch:

| Suite | main | + compat shim | Delta |
|-------|------|--------------|-------|
| `test_delivery` (101) | 101 pass | 101 pass | 0 |
| `test_resolve_project` (16) | 15 pass / 1 fail | 15 pass / 1 fail | 0 |
| `test_instance_id` (23) | 19 pass / 4 fail | 19 pass / 4 fail | 0 |
| `test_codex_bridge` (16) | 16 pass | 16 pass | 0 |
| `test_watch` (13) | 6-7 pass / 6-7 fail | 6-7 pass / 6-7 fail | 0 |

No regressions. Pre-existing failures are `kill -0` / git-worktree issues tracked separately in #182 and #198.

Closes #88 (core shim).