### PR TITLE
fix(delivery): scope watcher teardown to (project, type), not project

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -151,9 +151,11 @@ agmsg_delivery_apply_default() {
 # A plug that wants the default apply can delegate to agmsg_delivery_apply_default.
 agmsg_delivery_apply() { agmsg_delivery_apply_default "$@"; }
 agmsg_delivery_on_enable() { :; }
-# Default 'off' teardown: stop this project's watch.sh watchers. A type with its
-# own runtime (e.g. codex's bridge) overrides this. Args: <type> <project>.
-agmsg_delivery_on_disable() { kill_all_watchers "$2" >/dev/null 2>&1 || true; }
+# Default 'off' teardown: stop this (project, type)'s watch.sh watchers. A type
+# with its own runtime (e.g. codex's bridge) overrides this. Args: <type>
+# <project>. Passing the type scopes the kill so disabling one type's delivery
+# never tears down another type's watcher in the same project.
+agmsg_delivery_on_disable() { kill_all_watchers "$2" "$1" >/dev/null 2>&1 || true; }
 
 # Default delivery status (json-hooks types: claude-code, codex). Derives the mode
 # from the settings hooks file's agmsg-owned SessionStart/Stop entries, then prints
@@ -356,8 +358,11 @@ do_set() {
       ;;
     turn)
       echo "Future sessions: Stop hook will check inbox between turns."
-      # Stop only THIS project's watcher; other projects/sessions keep theirs.
-      kill_all_watchers "$PROJECT" >/dev/null 2>&1 || true
+      # Stop only THIS (project, type)'s watcher; other types in this project,
+      # and other projects, keep theirs. (Before scoping, this killed every
+      # watcher in the project — so any type's `set turn` tore down the
+      # project's claude-code monitor, the only type that runs one.)
+      kill_all_watchers "$PROJECT" "$TYPE" >/dev/null 2>&1 || true
       emit_stop_directive
       ;;
     off)
@@ -409,12 +414,22 @@ do_status() {
 }
 
 kill_all_watchers() {
-  # With no argument, kills every running watch.sh (used by stop/restart).
-  # With a <project> argument, kills only watchers launched for that project
-  # path, so switching one project's delivery mode (set turn/off) never tears
-  # down another project's — or another concurrent session's — monitor.
-  local project="${1:-}"
+  # With no argument, kills every running watch.sh (used by stop). With a
+  # <project> argument — and, when given, a <type> — kills only watchers whose
+  # argv matches. watch.sh argv is "watch.sh <session_id> <project> <type>
+  # [name]", so <project> <type> are adjacent space-delimited fields. Scoping to
+  # (project, type) means switching one (project, type)'s delivery mode never
+  # tears down another project's watcher OR another agent type's watcher in the
+  # SAME project — which, because claude-code is the only type with a watcher,
+  # is exactly the collateral kill that a non-claude `set turn` used to cause.
+  local project="${1:-}" type="${2:-}"
   local killed=0
+  # The argv substring to scope to: "<project> <type>" when a type is given
+  # (exact adjacent fields), else just "<project>", else empty (match all).
+  local needle=""
+  if [ -n "$project" ]; then
+    if [ -n "$type" ]; then needle=" $project $type "; else needle=" $project "; fi
+  fi
   if [ -d "$RUN_DIR" ]; then
     for f in "$RUN_DIR"/watch.*.pid; do
       [ -f "$f" ] || continue
@@ -427,12 +442,12 @@ kill_all_watchers() {
         cmd=$(ps -o args= -p "$pid" 2>/dev/null || true)
         case "$cmd" in
           *"$SKILL_DIR/scripts/watch.sh"*)
-            # watch.sh argv is "watch.sh <session_id> <project> <type> [name]",
-            # so the project path is a space-delimited field. When scoped,
-            # skip (and preserve the pidfile of) watchers for other projects.
-            if [ -n "$project" ]; then
+            # When scoped, skip (and preserve the pidfile of) watchers that don't
+            # match this (project, type) — i.e. other projects, and other types
+            # in the same project.
+            if [ -n "$needle" ]; then
               case " $cmd " in
-                *" $project "*) ;;
+                *"$needle"*) ;;
                 *) continue ;;
               esac
             fi
@@ -457,7 +472,11 @@ do_restart() {
   local TYPE="${1:-}"
   local PROJECT="${2:-}"
   local killed
-  killed=$(kill_all_watchers)
+  # Restart only the targeted (project, type)'s watcher when args are given; a
+  # bare `restart` (no args) still tears down every watcher. Same (project,
+  # type) scoping as `set`, so restarting one type's delivery doesn't kill an
+  # unrelated project's or type's watcher.
+  killed=$(kill_all_watchers "$PROJECT" "$TYPE")
   echo "Killed $killed watch process(es)."
   if [ -n "$TYPE" ] && [ -n "$PROJECT" ]; then
     emit_stop_directive

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -293,6 +293,48 @@ JSON
   [[ ! "$output" =~ "invoke the Monitor tool" ]]
 }
 
+# --- watcher teardown is (project, type)-scoped (#218) ---
+# claude-code is the only type that runs a watch.sh watcher. Before scoping,
+# `set turn <any other type>` ran `kill_all_watchers "$PROJECT"` (project only)
+# and tore down the project's claude-code monitor — collateral that killed
+# unrelated agents' monitors on a shared machine.
+
+@test "delivery set turn (other type): does NOT kill the project's claude-code watcher (#218)" {
+  skip_on_windows "watcher process mgmt under Git Bash (#182)"
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  # A live claude-code watcher for this project.
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" cc-sess "$TEST_PROJECT" claude-code &
+  local watch_pid=$!
+  sleep 1
+  [ -f "$TEST_SKILL_DIR/run/watch.cc-sess.pid" ]
+  # Switching a DIFFERENT type's delivery in the SAME project must not touch it.
+  run bash "$SCRIPTS/delivery.sh" set turn copilot "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_SKILL_DIR/run/watch.cc-sess.pid" ]
+  kill -0 "$watch_pid" 2>/dev/null
+  kill "$watch_pid" 2>/dev/null || true
+}
+
+@test "delivery set off (claude-code): DOES kill the project's claude-code watcher (type matches)" {
+  skip_on_windows "watcher process mgmt under Git Bash (#182)"
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" cc-sess2 "$TEST_PROJECT" claude-code &
+  local watch_pid=$!
+  sleep 1
+  [ -f "$TEST_SKILL_DIR/run/watch.cc-sess2.pid" ]
+  run bash "$SCRIPTS/delivery.sh" set off claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_SKILL_DIR/run/watch.cc-sess2.pid" ]
+  sleep 1
+  ! kill -0 "$watch_pid" 2>/dev/null
+}
+
 # --- watch.sh signal handling ---
 
 @test "watch.sh exits promptly on SIGTERM and cleans its pidfile" {

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -335,6 +335,34 @@ JSON
   ! kill -0 "$watch_pid" 2>/dev/null
 }
 
+@test "delivery (project, type) scoping holds for a project path with spaces (#218)" {
+  skip_on_windows "watcher process mgmt under Git Bash (#182)"
+  # The argv match is the literal "<project> <type>" string, so a space in the
+  # project path is matched verbatim — no false negatives (target preserved/
+  # killed correctly) and no false positives across the space boundary.
+  local sp="$TEST_PROJECT/with space proj"
+  mkdir -p "$sp"
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$sp"}]}}}
+JSON
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sp-sess "$sp" claude-code &
+  local watch_pid=$!
+  sleep 1
+  [ -f "$TEST_SKILL_DIR/run/watch.sp-sess.pid" ]
+  # Another type's set turn in the SAME space-containing project: must NOT kill it.
+  run bash "$SCRIPTS/delivery.sh" set turn copilot "$sp"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_SKILL_DIR/run/watch.sp-sess.pid" ]
+  kill -0 "$watch_pid" 2>/dev/null
+  # claude-code off for the SAME space-containing project: must kill it (right target).
+  run bash "$SCRIPTS/delivery.sh" set off claude-code "$sp"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_SKILL_DIR/run/watch.sp-sess.pid" ]
+  sleep 1
+  ! kill -0 "$watch_pid" 2>/dev/null
+}
+
 # --- watch.sh signal handling ---
 
 @test "watch.sh exits promptly on SIGTERM and cleans its pidfile" {


### PR DESCRIPTION
## Problem

`delivery.sh set turn` / `set off` / `restart` tore down **every** `watch.sh` watcher in the project, ignoring the agent type. The teardown ran `kill_all_watchers "$PROJECT"` — project-scoped only — from:

- `do_set`'s `turn` branch (runs on every `set turn <any type>`),
- the default `agmsg_delivery_on_disable` (runs on `set off`),
- `do_restart`.

Since **claude-code is the only type that runs a `watch.sh` watcher**, a `set turn <other type> <project>` — e.g. a gemini / opencode / cursor / grok-build agent enabling its rule-file delivery — killed the project's claude-code monitor. On a shared, multi-agent machine this repeatedly killed unrelated agents' monitors (observed live during grok-build dogfooding). The existing "other projects/sessions keep theirs" comments were inaccurate: a sibling **type** in the same project was not protected.

## Fix

Scope watcher teardown to **(project, type)**, not project alone:

- `kill_all_watchers` takes an optional `<type>`. `watch.sh` argv is `watch.sh <session_id> <project> <type> [name]`, so it now matches the adjacent `" <project> <type> "` fields — killing only that (project, type)'s watcher.
- Pass `$TYPE` from the call sites that auto-fire on a delivery change: `do_set`'s `turn` branch and the default `on_disable`; and from `do_restart`.
- A bare `delivery.sh stop` (no args) still kills **every** watcher (global stop is intentional).

This also means a `monitor=no` type's `set` finds no watcher of its own type and kills nothing — the collateral is eliminated without a special case.

## Tests

- `set turn <other type>` does **not** kill the project's claude-code watcher (the regression).
- `set off claude-code` **does** kill the project's claude-code watcher (type matches).
- Existing `stop` (global), `restart`, and pid-recycling-safety tests still pass.
- Full bats suite: green.

Closes #218.
