### PR TITLE
feat(storage): pluggable storage axis — driver contract, sqlite + jsonl backends (#203–#207)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,6 +124,56 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         run: bats --print-output-on-failure tests/
 
+  # Continuously verify that the storage contract is backend-portable: run the
+  # SAME driver-agnostic contract suite against the jsonl driver (the sqlite run
+  # is covered by the `bats` job above). This catches silent rot in jsonl as the
+  # contract evolves. Not a required check yet (promote once stable). duckdb is an
+  # opt-in accelerator, absent on the runner, so the jq path is exercised here.
+  storage-jsonl:
+    name: storage contract (jsonl, ${{ matrix.os }})
+    needs: changes
+    if: ${{ !cancelled() }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      # Both userlands — the jsonl driver shells out to jq/sed/sort/cksum/paste,
+      # whose behaviour differs between GNU (Linux) and BSD (macOS).
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docs-only change — skipping
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Diff is documentation-only; skipping the jsonl storage contract."
+
+      - name: Ensure jq + sqlite3 (Linux)
+        if: runner.os == 'Linux' && needs.changes.outputs.docs_only != 'true'
+        run: |
+          jq --version >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y jq; }
+          sqlite3 --version >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y sqlite3; }
+
+      - name: Install bats
+        if: needs.changes.outputs.docs_only != 'true'
+        run: |
+          npm config set prefix "$HOME/.npm-global"
+          npm install -g bats
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+
+      - name: Show tool versions
+        if: needs.changes.outputs.docs_only != 'true'
+        run: |
+          jq --version
+          sqlite3 --version
+          bats --version
+
+      - name: Run the storage contract against the jsonl driver
+        if: needs.changes.outputs.docs_only != 'true'
+        env:
+          AGMSG_STORAGE_DRIVER: jsonl
+        run: bats --print-output-on-failure tests/test_storage_contract.bats
+
   # Windows coverage for the native helpers shipped in #103 (Git Bash runner,
   # sqlite3 compatibility shim, cygpath normalization). The POSIX-assuming suite
   # is not fully green on Windows yet, so this is staged (#125): a single focused

--- a/docs/adr/0003-storage-axis-driver-abi-and-scope.md
+++ b/docs/adr/0003-storage-axis-driver-abi-and-scope.md
@@ -1,0 +1,83 @@
+# ADR 0003: Storage axis — driver ABI, contract shape, and scope boundary
+
+**Status:** proposed (draft — subject to change)
+**Date:** 2026-06-24
+**Deciders:** @fujibee
+
+## Context
+
+1.1.0 shipped the axis-generic driver registry and external-plugin opt-in
+([ADR 0002](0002-driver-discovery-and-plugin-opt-in.md)). 1.1.1 implements the
+**storage axis** — the message store, made pluggable — with drivers `sqlite`
+(default), `jsonl`+`duckdb`, and `redis`. Before writing code, three
+architectural questions needed locking. An independent design pass (codex, this
+session) converged with the earlier Fugu-demo design (codex + gemini) and
+corrected an initial lean toward a subcommand ABI; this ADR records the
+converged decisions. ADRs are revisable, so it reaffirms or tightens
+[ADR 0001](0001-storage-driver-pluginization.md) where that is the better choice.
+
+## Decision
+
+1. **Drivers stay sourced bash, behind a *locked* ABI.** Keep ADR 0001's
+   sourced-function model, but tighten it: a driver exposes only the `storage_*`
+   domain operations and must not leak SQL fragments, file paths, or backend
+   cursors to core. Non-bash backends are reached by a thin bash facade that
+   shells out (duckdb, redis-cli, a helper). A subcommand + JSONL-pipe protocol
+   is reserved as an *internal* form a facade may exec later if a driver truly
+   can't be bash — it is **not** promoted to the core ABI now.
+
+2. **The contract abstracts use-cases, not queries.** Core calls domain
+   operations (send / list-unread / mark-read / watch-after / history), never a
+   query language. Two consequences: (a) the watch/check-inbox replay checkpoint
+   is an **opaque, driver-issued delivery cursor**, kept separate from read
+   state — core never compares it, so it absorbs sqlite int ids, UUIDv7, Redis
+   stream ids, and JSONL offsets; (b) read-marking is recipient-scoped and
+   idempotent. This removes the `id > watermark` (integer-id) assumption that
+   currently lives in core and would break on UUIDv7 / Redis streams. The
+   canonical export/import format is a JSONL event log.
+
+3. **Redis (1.1.2) is a message store only.** The team registry and run-state
+   (pidfiles, watch watermarks, actas locks, ready sentinels) are *not* moved
+   onto the network with it — those carry distributed-lease / TTL / clock /
+   orphan-reclaim concerns beyond the storage axis. Multi-host coordination, if
+   wanted, becomes a separate **coordination axis** under its own ADR. Redis
+   enters as a remote message bus, not as shared everything.
+
+**Phasing:** 1.1.1 = storage facade + `sqlite` driver + `jsonl`(+`duckdb`)
+driver (duckdb an opt-in query accelerator; default install stays bash +
+sqlite). 1.1.2 = `redis` (message store).
+
+## Alternatives considered
+
+- **Subcommand + JSONL pipe as the core driver ABI.** Cleaner process boundary
+  and language-agnostic, but the inner sqlite3/duckdb/redis-cli process runs
+  inside the driver regardless, so piping the core↔driver boundary adds
+  call-path complexity (and an extra fork on the unread/insert hot path) before
+  any real benefit. Independent codex and the Fugu design both landed on sourced;
+  kept as a deferred internal-impl option.
+- **Structured query params with a single core-comparable watermark.** Rejected
+  the comparable watermark — any cursor core can compare leaks the backend's id
+  scheme. The opaque-cursor decision generalizes it.
+- **Redis as full shared state (messages + registry + coordination).** Rejected
+  for 1.1.2: balloons into distributed coordination; split to a future axis.
+
+## Consequences
+
+- Positive: one ABI serves sqlite / jsonl-duckdb / redis with no core changes;
+  opaque cursor + use-case contract make a new backend a self-contained driver;
+  default install unchanged; aligns with ADR 0002's registry + opt-in.
+- Negative: core code that assumes the integer `messages.id` / `read_at` column
+  must move behind the contract before any non-sqlite driver works (the bulk of
+  1.1.1 — #203/#204/#206). Sourced drivers keep ADR 0002's trust concern,
+  mitigated by opt-in + the `storage_*` prefix discipline.
+- Neutral: the subcommand+pipe protocol and multi-host coordination are
+  explicitly *deferred, not rejected* — each can land under a later ADR.
+
+## References
+
+- Builds on [ADR 0001](0001-storage-driver-pluginization.md) and
+  [ADR 0002](0002-driver-discovery-and-plugin-opt-in.md).
+- Spec (where the `storage_*` signatures live, not this ADR):
+  [`docs/spec/driver-interface.md`](../spec/driver-interface.md).
+- Implementation: #51 (epic), #203 (contract), #204 (facade + sqlite),
+  #205 (event-log), #206 (call-site migration), #207 (jsonl+duckdb), #208 (redis).

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -87,7 +87,7 @@ storage_list_unread <team> <agent> [--limit N]
 storage_mark_read_batch <team> <agent> <id> [<id> ...]
 storage_watch_tip <team:agent> [<team:agent> ...]
 storage_watch_after <cursor> <team:agent> [<team:agent> ...]
-storage_history <team> <agent> [--limit N]
+storage_history <team> [agent] [--limit N]
 storage_export <file>
 storage_import <file>
 storage_compact                # internal; see §2.7
@@ -96,6 +96,14 @@ storage_compact                # internal; see §2.7
 Every record carries `id` (UUIDv7 for new writes, an opaque string for legacy
 ids) and `at` (ISO-8601 UTC). `storage_send` prints the new message's `id` on a
 single line. The `watch_*` pair is defined in §2.2.
+
+`storage_history`'s `<agent>` is optional: given, it returns only messages where
+that agent is the sender or the recipient; omitted (or empty), it returns the
+whole team's messages. Both forms are JSONL `message_sent` records in time order.
+Read-state is deliberately **not** carried on a history record — it is
+recipient-scoped (§2.3), so a consumer that wants a read/unread marker derives it
+by cross-referencing `storage_list_unread` for the relevant recipient rather than
+from the history record itself.
 
 **stdout framing.** The **control ops** — `storage_check`, `storage_init`,
 `storage_mark_read_batch`, `storage_compact` — **must** use the §1.4 convention:

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -170,6 +170,17 @@ to `<agent>` in `<team>` that have no matching `message_read` for that same
 affects another's, and re-marking an already-read id is **idempotent** (a no-op,
 or a duplicate event the projection collapses).
 
+**Schema version.** This is **event-log schema v1**. The two event types above
+and their fields are the v1 contract. Forward compatibility is a hard rule, not a
+courtesy: a projection **must ignore event `type`s it does not recognize and
+object fields it does not recognize**. That is the only "version marker" v1 needs
+— a later revision may add new optional fields or new event types without a
+breaking bump, and a v1 reader stays correct (it skips what it cannot interpret
+rather than failing). `export` emits the raw event stream in `seq` order; a v1
+`import` accepts the record types it knows and is free to drop ones it does not.
+A change that removes or repurposes an existing field is the only thing that
+requires a new major schema version.
+
 ### 2.4 Legacy compatibility (sqlite only)
 
 The bundled sqlite driver reads two sources for `storage_list_unread` and
@@ -204,10 +215,42 @@ Drivers own the concurrency model of their backing store:
 
 ### 2.7 Compaction
 
-The event log grows unbounded. Drivers implement an internal `storage_compact`
-that collapses redundant events (coalescing repeated `message_read` markers for
-the same `(msg_id, team, agent)`). v1 exposes this only internally; a user-facing
-CLI may follow.
+The event log grows unbounded (append-only), so every record-replaying driver —
+and especially a `jsonl` driver that re-reads the whole file per query — needs a
+way to bound it. Drivers implement an internal `storage_compact` that collapses
+redundant events. v1 exposes this only internally; a user-facing CLI may follow.
+
+`storage_compact` is the load-bearing primitive that keeps a log-based backend in
+its fast band, so its behaviour is **contractual**, not best-effort. A conforming
+`storage_compact` must satisfy all of:
+
+1. **Idempotent** — `compact` then `compact` again leaves the store identical to a
+   single `compact`. Running it repeatedly is always safe.
+2. **State-preserving (observable equivalence)** — every contract read
+   (`storage_list_unread`, `storage_history`, and the projected state an `export`
+   re-imports to) returns the **same result** before and after a `compact`. Only
+   the physical footprint (event count / bytes) shrinks; no visible message,
+   read-state, or ordering changes.
+3. **Read-coalescing** — redundant `message_read` markers for the same
+   `(team, agent, msg_id)` collapse to one. This is the primary size win and the
+   minimum a driver must do. (`storage_mark_read_batch` is itself write-idempotent,
+   so such duplicates do not arise in single-writer use; they come from a racing
+   writer or a merged `import`, and compaction is the backstop that cleans them up.)
+4. **Monotonic** — `compact` never increases the stored event count.
+5. **Cursor-safe (never skip)** — `compact` must **not invalidate a delivery
+   cursor (§2.2) already handed out**. A cursor issued before a `compact` must,
+   when replayed after it, still deliver every `message_sent` that falls after it
+   — none may be skipped. A driver whose physical cursor would be broken by
+   compaction (e.g. a `jsonl` byte offset invalidated by a log rewrite) must use a
+   **logical, compaction-stable cursor** so that, in the worst case, a stale
+   cursor **degrades to at-least-once re-delivery and never to a dropped
+   message**. The bundled sqlite driver gets this for free: it never deletes or
+   renumbers `message_sent` rows, and it issues cursors from a monotonic
+   high-water (`sqlite_sequence`) that a `DELETE`-based compaction cannot move
+   backwards.
+
+Compaction must never touch `message_sent` records; it operates only on the
+redundant read-state markers layered over them.
 
 ## 3. CLI mapping
 

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -82,6 +82,7 @@ the swap-ability the axis exists for.
 storage_check
 storage_describe
 storage_init
+storage_store_exists
 storage_send <team> <from> <to> <body>
 storage_list_unread <team> <agent> [--limit N]
 storage_mark_read_batch <team> <agent> <id> [<id> ...]
@@ -96,6 +97,13 @@ storage_compact                # internal; see §2.7
 Every record carries `id` (UUIDv7 for new writes, an opaque string for legacy
 ids) and `at` (ISO-8601 UTC). `storage_send` prints the new message's `id` on a
 single line. The `watch_*` pair is defined in §2.2.
+
+`storage_store_exists` answers — by exit code, 0 if a store is already present and
+non-trivially initialized, non-zero otherwise — **without creating one**. A read
+call-site (inbox / history) uses it to say "no messages yet" in a project that has
+never used agmsg, rather than lazily materializing an empty store on a mere read.
+It is the driver, not a fixed `messages.db` file check, that knows where its store
+lives (sqlite's db file, jsonl's `events.jsonl`, a Redis key, …).
 
 `storage_history`'s `<agent>` is optional: given, it returns only messages where
 that agent is the sender or the recipient; omitted (or empty), it returns the

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -67,63 +67,120 @@ Directives are advisory: the host agent decides whether to surface them to the u
 
 ## 2. Storage driver
 
+The storage axis is **messages only**: the durable message log and its read /
+replay state. The team registry (`teams/<team>/config.json`) and run-state
+(pidfiles, the per-session delivery cursor, actas locks, ready sentinels) are
+**not** part of this contract — they stay file-based and form a separate axis
+(see [ADR 0003](../adr/0003-storage-axis-driver-abi-and-scope.md)). A storage driver
+must implement the *entire* contract below: "this driver does only messages,
+that one also does teams" is disallowed, because a partial implementation breaks
+the swap-ability the axis exists for.
+
 ### 2.1 Required functions
 
 ```
 storage_check
 storage_describe
 storage_init
-storage_insert_message <team> <from> <to> <body>
-storage_unread <team> <agent> [--limit N]
-storage_mark_read <id>
-storage_mark_read_batch <id> [<id> ...]
+storage_send <team> <from> <to> <body>
+storage_list_unread <team> <agent> [--limit N]
+storage_mark_read_batch <team> <agent> <id> [<id> ...]
+storage_watch_tip <team:agent> [<team:agent> ...]
+storage_watch_after <cursor> <team:agent> [<team:agent> ...]
 storage_history <team> <agent> [--limit N]
-storage_teams
-storage_team_members <team>
 storage_export <file>
 storage_import <file>
+storage_compact                # internal; see §2.7
 ```
 
-All functions write structured output (JSONL) to stdout when returning records and follow §1.4 for status. Records always include `id` (UUIDv7 for new writes, opaque string for legacy IDs) and `at` (ISO-8601 UTC).
+Record-returning functions write one JSON object per line (JSONL) to stdout and
+follow §1.4 for status. Every record carries `id` (UUIDv7 for new writes, an
+opaque string for legacy ids) and `at` (ISO-8601 UTC). `storage_send` prints the
+new message's `id` on a single line. The `watch_*` pair is defined in §2.2.
 
-### 2.2 Event log schema
+### 2.2 Delivery cursor (watch / replay)
 
-Bundled drivers represent state as an append-only event log. Each event is one record with a `type` discriminator:
+Live delivery (`watch.sh`, `check-inbox.sh`) resumes from a checkpoint instead of
+re-reading the whole log. That checkpoint is an **opaque, driver-issued cursor**
+— a position in the driver's global message order. Core treats it as an opaque
+string: it persists the latest cursor (per session — the successor to the old
+`watch.<sid>.watermark` file) and passes it back unchanged. **Core never parses,
+compares, or orders cursors.** This is what lets one contract serve sqlite
+integer ids, UUIDv7, Redis stream ids, and JSONL byte offsets — the
+`id > watermark` integer assumption is removed from core entirely.
+
+- `storage_watch_tip <pairs...>` — print the cursor for "now" (the current tip of
+  the global order) as a single bare line. A fresh watcher starts here, so it
+  delivers only messages that arrive *after* it attached (no history replay; the
+  no-arg inbox check covers the backlog).
+- `storage_watch_after <cursor> <pairs...>` — print, as JSONL and in delivery
+  order, every `message_sent` after `<cursor>` addressed to one of the
+  subscription pairs; then print a final cursor record
+  `{"type":"cursor","cursor":"<opaque>"}` as the last line (always emitted, even
+  when there are zero new messages, so core can advance). Poll-once: it returns
+  what is currently available and exits — core loops on its own interval; a
+  streaming backend may implement it as one non-blocking drain.
+
+Each `<pair>` is `<team>:<agent>`. Team and agent names cannot contain `:` (the
+name rules enforce this); a driver may additionally reject a pair it cannot split
+unambiguously.
+
+### 2.3 Event log schema
+
+The bundled drivers represent state as an append-only event log. Each event is
+one record with a `type` discriminator — and only these two types live in the
+storage axis (team membership does not; see the §2 intro):
 
 ```jsonl
 {"type":"message_sent","id":"0192...","team":"agsuite","from":"aggie-cc","to":"aggie-co","body":"...","at":"2026-05-30T19:00:00Z"}
-{"type":"message_read","id":"0192...","msg_id":"0192...","agent":"aggie-co","at":"2026-05-30T19:05:00Z"}
-{"type":"team_joined","id":"0192...","team":"agsuite","agent":"alice","agent_type":"claude-code","project":"/path","at":"..."}
-{"type":"team_left","id":"0192...","team":"agsuite","agent":"alice","at":"..."}
+{"type":"message_read","id":"0192...","msg_id":"0192...","team":"agsuite","agent":"aggie-co","at":"2026-05-30T19:05:00Z"}
 ```
 
-Drivers project these events to answer queries. `storage_unread` returns `message_sent` events whose `id` has no corresponding `message_read` for the requesting agent.
+`storage_list_unread <team> <agent>` returns the `message_sent` events addressed
+to `<agent>` in `<team>` that have no matching `message_read` for that same
+`(team, agent)`. Read-marking is **recipient-scoped**: a `message_read` names the
+`(team, agent)` that read the message, so marking one recipient's copy never
+affects another's, and re-marking an already-read id is **idempotent** (a no-op,
+or a duplicate event the projection collapses).
 
-### 2.3 Legacy compatibility (sqlite only)
+### 2.4 Legacy compatibility (sqlite only)
 
-The bundled sqlite driver reads two sources for `storage_unread` and `storage_history`:
+The bundled sqlite driver reads two sources for `storage_list_unread` and
+`storage_history`:
 
-1. The legacy `messages` table (rows where `read=0`) for installations that predate the event log refactor
-2. The new event log tables for everything written after the refactor
+1. the legacy `messages` table (rows where `read_at IS NULL`) for installs that
+   predate the event log, and
+2. the event-log tables for everything written after.
 
-Writes only target the event log. There is no automated migration; legacy rows stay where they are and remain queryable indefinitely.
+Writes target the event log. There is no automated migration; legacy rows stay
+queryable indefinitely. Legacy integer ids are passed through as decimal strings
+(opaque, per §2.5).
 
-### 2.4 Identifiers
+### 2.5 Identifiers
 
-All IDs generated by drivers must be **UUIDv7** strings. The interface treats IDs as opaque, so drivers reading legacy data (integer autoincrement IDs in sqlite) may pass them through as decimal strings.
+IDs that drivers generate for new writes are **UUIDv7** strings. The interface
+treats every id as opaque, so a driver reading legacy data (sqlite autoincrement
+ints) passes them through as decimal strings. UUIDv7 is generated inside the
+driver (`python -c "..."`, a `uuidgen` that supports v7, or a shell
+implementation); drivers must not depend on a counter file. The delivery cursor
+(§2.2) is a **separate** opaque token from message ids — a driver may build it
+from ids, byte offsets, or stream positions.
 
-UUIDv7 is generated within the driver (e.g. via `python -c "..."`, `uuidgen` on platforms that support v7, or a shell implementation). Drivers must not depend on a counter file.
+### 2.6 Concurrency
 
-### 2.5 Concurrency
+Drivers own the concurrency model of their backing store:
 
-Drivers are responsible for the concurrency model of their backing store:
+- the sqlite driver relies on SQLite's WAL mode;
+- a `jsonl` / `duckdb` driver uses a lockfile around mark-read sequences and
+  around `compact` / `export` / `import`; single appends may rely on POSIX append
+  atomicity for writes ≤ `PIPE_BUF` bytes.
 
-- The sqlite driver relies on SQLite's WAL mode.
-- The `jsonl-duckdb` driver must use a lockfile around mark-read sequences and around `convert`/`export`/`import`. Single-message appends may rely on POSIX append atomicity for writes ≤ `PIPE_BUF` bytes.
+### 2.7 Compaction
 
-### 2.6 Compaction
-
-The event log grows unbounded. Drivers must implement an internal `storage_compact` function that collapses redundant events (e.g. coalescing `message_read` markers, dropping events for deleted teams). v1 exposes this only as an internal command; a user-facing CLI may follow.
+The event log grows unbounded. Drivers implement an internal `storage_compact`
+that collapses redundant events (coalescing repeated `message_read` markers for
+the same `(msg_id, team, agent)`). v1 exposes this only internally; a user-facing
+CLI may follow.
 
 ## 3. CLI mapping
 

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -99,7 +99,11 @@ single line. The `watch_*` pair is defined in §2.2.
 
 `storage_history`'s `<agent>` is optional: given, it returns only messages where
 that agent is the sender or the recipient; omitted (or empty), it returns the
-whole team's messages. Both forms are JSONL `message_sent` records in time order.
+whole team's messages. Both forms are JSONL `message_sent` records. `--limit N`
+selects the **most recent N** of the matching set; the output is always in
+**time order, oldest→newest** (so a limited query returns the tail of the history,
+still chronological — never newest-first). A driver must honour both this
+selection (recency) and this ordering so the result is identical across backends.
 Read-state is deliberately **not** carried on a history record — it is
 recipient-scoped (§2.3), so a consumer that wants a read/unread marker derives it
 by cross-referencing `storage_list_unread` for the relevant recipient rather than

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -98,17 +98,20 @@ ids) and `at` (ISO-8601 UTC). `storage_send` prints the new message's `id` on a
 single line. The `watch_*` pair is defined in §2.2.
 
 **stdout framing.** The **control ops** — `storage_check`, `storage_init`,
-`storage_mark_read_batch`, `storage_describe`, `storage_compact` — **must** use
-the §1.4 convention: a status name (`ok` / `missing_deps` / `runtime_error` / …)
-on the last stdout line, with the matching exit code. The **record-returning
-ops** — `storage_send`, `storage_list_unread`, `storage_history`,
-`storage_watch_tip`, `storage_watch_after` — write **data only** to stdout (JSONL
-records, or a bare id / cursor token; one record per line) and signal outcome
-with the **exit code** alone: `0` on success, non-zero with a message on
-**stderr** on failure. They never emit a §1.4 status name to stdout, so a status
-word can never be misread as a record. The trailing `cursor` record of
-`storage_watch_after` is part of that data stream (a designated final line), not
-a status.
+`storage_mark_read_batch`, `storage_compact` — **must** use the §1.4 convention:
+a status name (`ok` / `missing_deps` / `runtime_error` / …) on the last stdout
+line, with the matching exit code. The **record-returning ops** —
+`storage_send`, `storage_list_unread`, `storage_history`, `storage_watch_tip`,
+`storage_watch_after` — write **data only** to stdout (JSONL records, or a bare
+id / cursor token; one record per line) and signal outcome with the **exit code**
+alone: `0` on success, non-zero with a message on **stderr** on failure. They
+never emit a §1.4 status name to stdout, so a status word can never be misread as
+a record. The trailing `cursor` record of `storage_watch_after` is part of that
+data stream (a designated final line), not a status.
+
+`storage_describe` is a **metadata op**, not a control op: it always exits 0 and
+writes only its `key=value` registry metadata to stdout — never a §1.4 status
+name, which a metadata consumer would otherwise misread.
 
 ### 2.2 Delivery cursor (watch / replay)
 

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -97,17 +97,18 @@ Every record carries `id` (UUIDv7 for new writes, an opaque string for legacy
 ids) and `at` (ISO-8601 UTC). `storage_send` prints the new message's `id` on a
 single line. The `watch_*` pair is defined in §2.2.
 
-**stdout framing.** The §1.4 convention (a status name on the last stdout line)
-applies only to the **control ops** — `storage_check`, `storage_init`,
-`storage_mark_read_batch`, `storage_describe`, `storage_compact`. The
-**record-returning ops** — `storage_send`, `storage_list_unread`,
-`storage_history`, `storage_watch_tip`, `storage_watch_after` — write **data
-only** to stdout (JSONL records, or a bare id / cursor token; one record per
-line) and signal outcome with the **exit code** alone: `0` on success, non-zero
-with a message on **stderr** on failure. They never emit a §1.4 status name to
-stdout, so a status word can never be misread as a record. The trailing `cursor`
-record of `storage_watch_after` is part of that data stream (a designated final
-line), not a status.
+**stdout framing.** The **control ops** — `storage_check`, `storage_init`,
+`storage_mark_read_batch`, `storage_describe`, `storage_compact` — **must** use
+the §1.4 convention: a status name (`ok` / `missing_deps` / `runtime_error` / …)
+on the last stdout line, with the matching exit code. The **record-returning
+ops** — `storage_send`, `storage_list_unread`, `storage_history`,
+`storage_watch_tip`, `storage_watch_after` — write **data only** to stdout (JSONL
+records, or a bare id / cursor token; one record per line) and signal outcome
+with the **exit code** alone: `0` on success, non-zero with a message on
+**stderr** on failure. They never emit a §1.4 status name to stdout, so a status
+word can never be misread as a record. The trailing `cursor` record of
+`storage_watch_after` is part of that data stream (a designated final line), not
+a status.
 
 ### 2.2 Delivery cursor (watch / replay)
 

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -93,10 +93,21 @@ storage_import <file>
 storage_compact                # internal; see §2.7
 ```
 
-Record-returning functions write one JSON object per line (JSONL) to stdout and
-follow §1.4 for status. Every record carries `id` (UUIDv7 for new writes, an
-opaque string for legacy ids) and `at` (ISO-8601 UTC). `storage_send` prints the
-new message's `id` on a single line. The `watch_*` pair is defined in §2.2.
+Every record carries `id` (UUIDv7 for new writes, an opaque string for legacy
+ids) and `at` (ISO-8601 UTC). `storage_send` prints the new message's `id` on a
+single line. The `watch_*` pair is defined in §2.2.
+
+**stdout framing.** The §1.4 convention (a status name on the last stdout line)
+applies only to the **control ops** — `storage_check`, `storage_init`,
+`storage_mark_read_batch`, `storage_describe`, `storage_compact`. The
+**record-returning ops** — `storage_send`, `storage_list_unread`,
+`storage_history`, `storage_watch_tip`, `storage_watch_after` — write **data
+only** to stdout (JSONL records, or a bare id / cursor token; one record per
+line) and signal outcome with the **exit code** alone: `0` on success, non-zero
+with a message on **stderr** on failure. They never emit a §1.4 status name to
+stdout, so a status word can never be misread as a record. The trailing `cursor`
+record of `storage_watch_after` is part of that data stream (a designated final
+line), not a status.
 
 ### 2.2 Delivery cursor (watch / replay)
 
@@ -109,6 +120,14 @@ compares, or orders cursors.** This is what lets one contract serve sqlite
 integer ids, UUIDv7, Redis stream ids, and JSONL byte offsets — the
 `id > watermark` integer assumption is removed from core entirely.
 
+The cursor is opaque to core but constrained for transport: it must be a
+**single-line, whitespace-free, printable token** that survives being written to
+a run-dir file and passed back as one `argv` argument to the sourced driver.
+Native positions that already satisfy this (a sqlite integer `seq`, a Redis
+stream id) are used as-is; a driver whose native position carries unsafe
+characters (e.g. a JSONL byte offset bundled with metadata) must encode it
+(base64url or similar) into a single safe token.
+
 - `storage_watch_tip <pairs...>` — print the cursor for "now" (the current tip of
   the global order) as a single bare line. A fresh watcher starts here, so it
   delivers only messages that arrive *after* it attached (no history replay; the
@@ -116,10 +135,14 @@ integer ids, UUIDv7, Redis stream ids, and JSONL byte offsets — the
 - `storage_watch_after <cursor> <pairs...>` — print, as JSONL and in delivery
   order, every `message_sent` after `<cursor>` addressed to one of the
   subscription pairs; then print a final cursor record
-  `{"type":"cursor","cursor":"<opaque>"}` as the last line (always emitted, even
-  when there are zero new messages, so core can advance). Poll-once: it returns
-  what is currently available and exits — core loops on its own interval; a
-  streaming backend may implement it as one non-blocking drain.
+  `{"type":"cursor","cursor":"<opaque>"}` as the last line. That trailing cursor
+  is the **global tip the driver can safely resume from at call time** (the same
+  notion as `storage_watch_tip`) — *not* the cursor of the last matching message.
+  It is always emitted, and advances even when zero subscription messages fell in
+  the range, so a watcher behind heavy off-subscription traffic does not re-scan
+  the same span on every poll. Poll-once: it returns what is currently available
+  and exits — core loops on its own interval; a streaming backend may implement
+  it as one non-blocking drain.
 
 Each `<pair>` is `<team>:<agent>`. Team and agent names cannot contain `:` (the
 name rules enforce this); a driver may additionally reject a pair it cannot split

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -145,20 +145,25 @@ for team in "${TEAM_LIST[@]}"; do
     RESULT=$(agmsg_sqlite ':memory:' "
       SELECT json_extract(value,'\$.from') || char(31) ||
              replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
-             json_extract(value,'\$.at')
+             json_extract(value,'\$.at') || char(31) ||
+             json_extract(value,'\$.id')
       FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
     ")
     COUNT=$(printf '%s\n' "$RESULT" | wc -l | tr -d ' ')
     OUTPUT+="$COUNT new message(s) in $team:"$'\n'
-    while IFS=$'\x1f' read -r from body ts; do
-      [ -n "$ts$from$body" ] || continue
+    IDS=()
+    while IFS=$'\x1f' read -r from body ts id; do
+      [ -n "$id" ] || continue
       OUTPUT+="  [$ts] $from: $body"$'\n'
+      IDS+=("$id")
     done <<< "$RESULT"
     OUTPUT+=$'\n'
-    # Mark read — transitional legacy UPDATE (not storage_mark_read_batch yet);
-    # flips to events at step 3 alongside watch-once, which still reads legacy
-    # read_at. See the matching note in inbox.sh.
-    agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
+    # Mark read via the facade (§2.1 storage_mark_read_batch): recipient-scoped,
+    # idempotent; a legacy id records a message_read event without mutating the
+    # legacy row (§2.4).
+    if [ "${#IDS[@]}" -gt 0 ]; then
+      storage_mark_read_batch "$team" "$AGENT" "${IDS[@]}" >/dev/null 2>&1 || true
+    fi
   fi
 done
 

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -114,6 +114,7 @@ mkdir -p "$SKILL_DIR/run"
 touch "$MARKER"
 
 # Check for unread messages and mark as read
+agmsg_storage_load
 DB="$(agmsg_db_path)"
 if [ ! -f "$DB" ]; then exit 0; fi
 
@@ -136,19 +137,27 @@ for team in "${TEAM_LIST[@]}"; do
     other:*) continue ;;
   esac
 
-  RESULT=$(agmsg_sqlite "$DB" "
-    SELECT from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
-    FROM messages WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL
-    ORDER BY created_at ASC;
-  ")
-  if [ -n "$RESULT" ]; then
-    COUNT=$(echo "$RESULT" | wc -l | tr -d ' ')
+  # Unread via the storage facade (§2.1 storage_list_unread = events ∪ legacy),
+  # JSONL parsed in one pass with sqlite's JSON funcs (no jq; cf. lib/hooks-json.sh).
+  UNREAD_JSONL=$(storage_list_unread "$team" "$AGENT")
+  if [ -n "$UNREAD_JSONL" ]; then
+    _arr="[$(printf '%s' "$UNREAD_JSONL" | paste -sd, -)]"
+    RESULT=$(agmsg_sqlite ':memory:' "
+      SELECT json_extract(value,'\$.from') || char(31) ||
+             replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
+             json_extract(value,'\$.at')
+      FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+    ")
+    COUNT=$(printf '%s\n' "$RESULT" | wc -l | tr -d ' ')
     OUTPUT+="$COUNT new message(s) in $team:"$'\n'
     while IFS=$'\x1f' read -r from body ts; do
+      [ -n "$ts$from$body" ] || continue
       OUTPUT+="  [$ts] $from: $body"$'\n'
     done <<< "$RESULT"
     OUTPUT+=$'\n'
-    # Mark as read
+    # Mark read — transitional legacy UPDATE (not storage_mark_read_batch yet);
+    # flips to events at step 3 alongside watch-once, which still reads legacy
+    # read_at. See the matching note in inbox.sh.
     agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
   fi
 done

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -113,10 +113,10 @@ fi
 mkdir -p "$SKILL_DIR/run"
 touch "$MARKER"
 
-# Check for unread messages and mark as read
+# Check for unread messages and mark as read. Ask the active driver whether a
+# store exists (driver-level, works for jsonl too) — don't create one on a poll.
 agmsg_storage_load
-DB="$(agmsg_db_path)"
-if [ ! -f "$DB" ]; then exit 0; fi
+if ! storage_store_exists; then exit 0; fi
 
 OUTPUT=""
 IFS=',' read -ra TEAM_LIST <<< "$TEAMS"

--- a/scripts/drivers/storage/jsonl-unread.duckdb.sql
+++ b/scripts/drivers/storage/jsonl-unread.duckdb.sql
@@ -1,0 +1,20 @@
+-- duckdb "unread for a recipient" anti-join, file-direct (no daemon).
+-- Read as DATA by the jsonl driver (scripts/drivers/storage/jsonl.sh) and never
+-- parsed by bash, so its apostrophes and "double-quoted" identifiers can't trip
+-- the macOS system bash 3.2 parser. The driver fills the placeholders by literal
+-- bash substitution: __LG__ = events.jsonl path, __TL__ = team, __AL__ = agent
+-- (all already SQL-escaped — apostrophes doubled — before substitution).
+-- Columns are read as explicit VARCHAR, never read_json_auto, whose type
+-- inference would parse `at` as a TIMESTAMP and drop the canonical ISO-8601 T/Z.
+SELECT to_json(struct_pack(type := 'message_sent', id := s.id, team := s.team,
+         "from" := s."from", "to" := s."to", body := s.body, at := s.at))
+FROM (SELECT * FROM read_json('__LG__', columns={type:'VARCHAR', id:'VARCHAR',
+        team:'VARCHAR', "from":'VARCHAR', "to":'VARCHAR', body:'VARCHAR',
+        at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited')
+      WHERE type='message_sent' AND team='__TL__' AND "to"='__AL__') s
+WHERE s.id NOT IN (
+  SELECT msg_id FROM read_json('__LG__', columns={type:'VARCHAR', id:'VARCHAR',
+        team:'VARCHAR', "from":'VARCHAR', "to":'VARCHAR', body:'VARCHAR',
+        at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited')
+  WHERE type='message_read' AND team='__TL__' AND agent='__AL__')
+ORDER BY s.at, s.id;

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -187,9 +187,12 @@ storage_mark_read_batch() {
 _jsonl_mark() {
   local team="$1" agent="$2"; shift 2
   local log id at line existing; log="$(_jsonl_log)"
+  # A failed scan of existing reads (e.g. a corrupt log) must abort the mark, not
+  # silently treat every id as new and append — that would be the same swallowed
+  # failure. The caller turns this non-zero into runtime_error.
   existing="$(jq -r --arg team "$team" --arg agent "$agent" \
     'select(.type=="message_read" and .team==$team and .agent==$agent) | .msg_id' \
-    "$log" 2>/dev/null)"
+    "$log")" || return 1
   for id in "$@"; do
     printf '%s\n' "$existing" | grep -Fxq "$id" && continue
     at="$(_jsonl_now)"

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -287,6 +287,6 @@ _jsonl_compact_do() {
   # single-quoted jq string in this position desyncs the macOS system bash 3.2
   # parser and breaks the rest of the file (a no-error `bash -n`, but a real
   # source failure). Keep new jq one-liners here.
-  jq -c -s 'reduce .[] as $e ({out:[], seen:{}}; if $e.type=="message_sent" then .out += [$e] elif $e.type=="message_read" then ([$e.team,$e.agent,$e.msg_id]|join(" ")) as $k | if .seen[$k] then . else .seen[$k]=true | .out += [$e] end else . end) | .out[]' "$log" > "$tmp" || { rm -f "$tmp"; return 1; }
+  jq -c -s 'reduce .[] as $e ({out:[], seen:{}}; if $e.type=="message_sent" then .out += [$e] elif $e.type=="message_read" then ([$e.team,$e.agent,$e.msg_id]|tojson) as $k | if .seen[$k] then . else .seen[$k]=true | .out += [$e] end else . end) | .out[]' "$log" > "$tmp" || { rm -f "$tmp"; return 1; }
   mv "$tmp" "$log"
 }

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# jsonl storage driver (opt-in).
+#
+# Implements the storage contract (docs/spec/driver-interface.md §2, ADR 0003)
+# over an append-only JSONL event log — the same canonical model as the sqlite
+# driver (message_sent / message_read), but the file IS the store. Sourced by the
+# storage facade (lib/storage.sh), so agmsg_db_path is in scope; the log lives at
+# <db-dir>/events.jsonl.
+#
+# Engine: jq is the zero-extra-dep default (declared by storage_check). duckdb is
+# an OPT-IN accelerator for the one hot anti-join (list_unread) on large logs —
+# the PoC crossover is ~10-20k events (#207 / FINDINGS.md); below it jq's lack of
+# startup cost wins, so the driver picks jq unless the log is big AND duckdb is on
+# PATH. No daemon: duckdb runs file-direct, one process per query.
+#
+# Framing (§1.4): record-returning ops write JSONL to stdout and fail non-zero;
+# control ops (check/init/mark_read_batch/compact) print a §1.4 status name.
+#
+# Delivery cursor (§2.2): a LOGICAL position — the ordinal count of message_sent
+# events, NOT a byte offset. Compaction only coalesces message_read (never removes
+# or reorders message_sent), so an ordinal stays valid across a log rewrite; a
+# byte offset would not. The cursor is an opaque decimal string to core.
+
+# --- helpers ---------------------------------------------------------------
+
+_jsonl_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+_jsonl_log() { printf '%s\n' "$(dirname "$(agmsg_db_path)")/events.jsonl"; }
+
+_jsonl_init_file() {
+  local log; log="$(_jsonl_log)"
+  mkdir -p "$(dirname "$log")" 2>/dev/null || true
+  [ -f "$log" ] || : > "$log" 2>/dev/null || true
+}
+
+# UUIDv7 (§2.5) — python3 preferred, /dev/urandom shell fallback. No counter file.
+_jsonl_uuid7() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import os, time
+ms = int(time.time() * 1000) & ((1 << 48) - 1)
+b = bytearray(os.urandom(16))
+b[0] = (ms >> 40) & 0xFF; b[1] = (ms >> 32) & 0xFF
+b[2] = (ms >> 24) & 0xFF; b[3] = (ms >> 16) & 0xFF
+b[4] = (ms >> 8) & 0xFF;  b[5] = ms & 0xFF
+b[6] = 0x70 | (b[6] & 0x0F)
+b[8] = 0x80 | (b[8] & 0x3F)
+h = b.hex()
+print(f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}")
+PY
+    return
+  fi
+  local ms hex rnd
+  ms=$(( $(date -u +%s) * 1000 ))
+  hex=$(printf '%012x' "$ms")
+  rnd=$(head -c 10 /dev/urandom | od -An -tx1 | tr -d ' \n')
+  printf '%s-%s-7%s-8%s-%s\n' \
+    "${hex:0:8}" "${hex:8:4}" "${rnd:0:3}" "${rnd:3:3}" "${rnd:6:12}"
+}
+
+# Serialize all log mutations (append / mark / compact / import) behind a portable
+# mkdir lock; record-returning reads take a single file read as their snapshot.
+_jsonl_with_lock() {
+  local lock i=0 rc=0
+  lock="$(_jsonl_log).lock"
+  until mkdir "$lock" 2>/dev/null; do
+    i=$((i + 1)); [ "$i" -ge 1000 ] && return 1
+    sleep 0.01
+  done
+  "$@" || rc=$?
+  rmdir "$lock" 2>/dev/null || true
+  return $rc
+}
+
+# duckdb is used only when present AND the log is past the jq crossover. The check
+# is byte-size based (file-direct I/O is size-bound, FINDINGS.md): ~5 MB ≈ tens of
+# thousands of events. AGMSG_JSONL_ENGINE=jq|duckdb forces a choice (tests/bench).
+_jsonl_use_duckdb() {
+  case "${AGMSG_JSONL_ENGINE:-}" in
+    jq) return 1 ;;
+    duckdb) command -v duckdb >/dev/null 2>&1 && return 0 || return 1 ;;
+  esac
+  command -v duckdb >/dev/null 2>&1 || return 1
+  local log sz; log="$(_jsonl_log)"
+  sz=$(wc -c < "$log" 2>/dev/null | tr -d ' ') || return 1
+  [ "${sz:-0}" -ge "${AGMSG_JSONL_DUCKDB_BYTES:-5242880}" ]
+}
+
+# --- contract: lifecycle ----------------------------------------------------
+
+storage_check() {
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'AGMSG-DIRECTIVE: {"type":"install_deps","driver":"jsonl","commands":["brew install jq"],"reason":"jq not found on PATH"}\n'
+    echo missing_deps
+    return 10
+  fi
+  echo ok
+}
+
+storage_describe() {
+  printf 'name=jsonl\n'
+  printf 'backend=append-only JSONL event log (jq; duckdb opt-in accelerator)\n'
+  printf 'log=%s\n' "$(_jsonl_log)"
+}
+
+storage_init() {
+  _jsonl_init_file
+  echo ok
+}
+
+# --- contract: messages -----------------------------------------------------
+
+storage_send() {
+  local team="$1" from="$2" to="$3" body="$4"
+  local id at line; id="$(_jsonl_uuid7)"; at="$(_jsonl_now)"
+  _jsonl_init_file
+  line="$(jq -nc --arg id "$id" --arg team "$team" --arg from "$from" \
+    --arg to "$to" --arg body "$body" --arg at "$at" \
+    '{type:"message_sent",id:$id,team:$team,from:$from,to:$to,body:$body,at:$at}')" \
+    || return 1
+  _jsonl_with_lock _jsonl_append "$line" || return 1
+  printf '%s\n' "$id"
+}
+_jsonl_append() { printf '%s\n' "$1" >> "$(_jsonl_log)"; }
+
+storage_list_unread() {
+  local team="$1" agent="$2" limit=""
+  shift 2
+  while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
+  case "$limit" in ''|*[!0-9]*) limit="" ;; esac
+  _jsonl_init_file
+  local log out; log="$(_jsonl_log)"
+  if _jsonl_use_duckdb; then
+    out="$(_jsonl_unread_duckdb "$team" "$agent" "$log")" || return 1
+  else
+    out="$(jq -c --arg team "$team" --arg agent "$agent" -s '
+      (reduce .[] as $e ({};
+        if $e.type=="message_read" and $e.team==$team and $e.agent==$agent
+        then .[$e.msg_id]=true else . end)) as $read
+      | .[]
+      | select(.type=="message_sent" and .team==$team and .to==$agent and ($read[.id] | not))
+      | {type:"message_sent",id:.id,team:.team,from:.from,to:.to,body:.body,at:.at}
+    ' "$log")" || return 1
+  fi
+  [ -n "$out" ] || return 0
+  if [ -n "$limit" ]; then printf '%s\n' "$out" | head -n "$limit"; else printf '%s\n' "$out"; fi
+}
+
+# duckdb file-direct anti-join (opt-in, large logs). Same unread set AND identical
+# record shape as the jq path. Fields are read as explicit VARCHAR columns — never
+# read_json_auto, whose type inference would parse `at` as a TIMESTAMP and re-emit
+# it as "Y-M-D H:M:S", losing the canonical ISO-8601 "...T...Z" the jq path keeps.
+_jsonl_unread_duckdb() {
+  local team="$1" agent="$2" log="$3"
+  local cols="columns={type:'VARCHAR', id:'VARCHAR', team:'VARCHAR', \"from\":'VARCHAR', \"to\":'VARCHAR', body:'VARCHAR', at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited'"
+  duckdb -noheader -list -newline $'\n' <<SQL 2>/dev/null
+SELECT to_json(struct_pack(type := 'message_sent', id := s.id, team := s.team,
+         "from" := s."from", "to" := s."to", body := s.body, at := s.at))
+FROM (SELECT * FROM read_json('$log', $cols) WHERE type='message_sent'
+        AND team='$team' AND "to"='$agent') s
+WHERE s.id NOT IN (
+  SELECT msg_id FROM read_json('$log', $cols)
+  WHERE type='message_read' AND team='$team' AND agent='$agent')
+ORDER BY s.at, s.id;
+SQL
+}
+
+storage_mark_read_batch() {
+  local team="$1" agent="$2"; shift 2
+  _jsonl_init_file
+  _jsonl_with_lock _jsonl_mark "$team" "$agent" "$@"
+  echo ok
+}
+_jsonl_mark() {
+  local team="$1" agent="$2"; shift 2
+  local log id at line existing; log="$(_jsonl_log)"
+  existing="$(jq -r --arg team "$team" --arg agent "$agent" \
+    'select(.type=="message_read" and .team==$team and .agent==$agent) | .msg_id' \
+    "$log" 2>/dev/null)"
+  for id in "$@"; do
+    printf '%s\n' "$existing" | grep -Fxq "$id" && continue
+    at="$(_jsonl_now)"
+    line="$(jq -nc --arg id "$(_jsonl_uuid7)" --arg msg_id "$id" --arg team "$team" \
+      --arg agent "$agent" --arg at "$at" \
+      '{type:"message_read",id:$id,msg_id:$msg_id,team:$team,agent:$agent,at:$at}')"
+    printf '%s\n' "$line" >> "$log"
+    existing="$existing"$'\n'"$id"
+  done
+}
+
+# --- contract: watch (delivery cursor §2.2) ---------------------------------
+
+storage_watch_tip() {
+  _jsonl_init_file
+  jq -s '[.[] | select(.type=="message_sent")] | length' "$(_jsonl_log)" 2>/dev/null || echo 0
+}
+
+storage_watch_after() {
+  local cursor="$1"; shift
+  case "$cursor" in ''|*[!0-9]*) cursor=0 ;; esac
+  _jsonl_init_file
+  local pairs_json; pairs_json="$(printf '%s\n' "$@" | jq -Rsc 'split("\n") | map(select(length>0))')"
+  # One file read = one snapshot: the trailing cursor (total message_sent count)
+  # is computed from the same scan, so it never runs ahead of the rows returned.
+  jq -c --argjson cursor "$cursor" --argjson pairs "$pairs_json" -s '
+    [.[] | select(.type=="message_sent")] as $sent
+    | ($sent
+        | to_entries
+        | map(select((.key >= $cursor)
+              and ((.value.team + ":" + .value.to) as $p | ($pairs | index($p)) != null)))
+        | .[].value
+        | {type:"message_sent",id:.id,team:.team,from:.from,to:.to,body:.body,at:.at}),
+      {type:"cursor",cursor:(($sent | length) | tostring)}
+  ' "$(_jsonl_log)" 2>/dev/null
+}
+
+# --- contract: history ------------------------------------------------------
+
+storage_history() {
+  local team="$1"; shift
+  local agent="" limit=""
+  if [ $# -gt 0 ] && [ "${1#-}" = "$1" ]; then agent="$1"; shift; fi
+  while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
+  case "$limit" in ''|*[!0-9]*) limit="-1" ;; esac
+  _jsonl_init_file
+  jq -c --arg team "$team" --arg agent "$agent" --argjson limit "$limit" -s '
+    [.[] | select(.type=="message_sent" and .team==$team
+            and ($agent=="" or .to==$agent or .from==$agent))
+     | {type:"message_sent",id:.id,team:.team,from:.from,to:.to,body:.body,at:.at}]
+    | (if $limit >= 0 and (length > $limit) then .[length-$limit:] else . end)
+    | .[]
+  ' "$(_jsonl_log)" 2>/dev/null
+}
+
+# --- contract: export / import / compact ------------------------------------
+
+storage_export() {
+  _jsonl_init_file
+  # Forward-compat (§2.3): only the v1 event types are projected; unknown types
+  # are dropped rather than leaked.
+  jq -c 'select(.type=="message_sent" or .type=="message_read")' "$(_jsonl_log)" > "$1"
+}
+
+storage_import() {
+  local file="$1"; [ -f "$file" ] || return 1
+  _jsonl_init_file
+  _jsonl_with_lock _jsonl_import_do "$file"
+}
+_jsonl_import_do() {
+  jq -c 'select(.type=="message_sent" or .type=="message_read")' "$1" >> "$(_jsonl_log)"
+}
+
+storage_compact() {
+  _jsonl_init_file
+  _jsonl_with_lock _jsonl_compact_do || { echo runtime_error; return 13; }
+  echo ok
+}
+_jsonl_compact_do() {
+  local log tmp; log="$(_jsonl_log)"; tmp="$log.compact.$$"
+  # Keep every message_sent in order; collapse duplicate message_read for the same
+  # (team, agent, msg_id) to the first seen. message_sent order is preserved, so
+  # the ordinal delivery cursor stays valid (§2.7 cursor-safe).
+  jq -c -s '
+    reduce .[] as $e ({out:[], seen:{}};
+      if $e.type=="message_sent" then .out += [$e]
+      elif $e.type=="message_read" then
+        ($e.team + " " + $e.agent + " " + $e.msg_id) as $k
+        | if .seen[$k] then . else .seen[$k]=true | .out += [$e] end
+      else . end)
+    | .out[]
+  ' "$log" > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$log"
+}

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -60,10 +60,10 @@ PY
 # Serialize all log mutations (append / mark / compact / import) behind a portable
 # mkdir lock; record-returning reads take a single file read as their snapshot.
 _jsonl_with_lock() {
-  local lock i=0 rc=0
+  local lock i=0 rc=0 max="${AGMSG_JSONL_LOCK_TRIES:-1000}"
   lock="$(_jsonl_log).lock"
   until mkdir "$lock" 2>/dev/null; do
-    i=$((i + 1)); [ "$i" -ge 1000 ] && return 1
+    i=$((i + 1)); [ "$i" -ge "$max" ] && return 1
     sleep 0.01
   done
   "$@" || rc=$?
@@ -155,15 +155,22 @@ storage_list_unread() {
 # it as "Y-M-D H:M:S", losing the canonical ISO-8601 "...T...Z" the jq path keeps.
 _jsonl_unread_duckdb() {
   local team="$1" agent="$2" log="$3"
+  # SQL-escape every value spliced into the query (team/agent are not apostrophe-
+  # free per validate.sh, and the path may contain one) so a legal team/agent that
+  # the jq path handles can't break — or silently misbehave on — the duckdb path.
+  local tl al lg
+  tl="$(printf '%s' "$team"  | sed "s/'/''/g")"
+  al="$(printf '%s' "$agent" | sed "s/'/''/g")"
+  lg="$(printf '%s' "$log"   | sed "s/'/''/g")"
   local cols="columns={type:'VARCHAR', id:'VARCHAR', team:'VARCHAR', \"from\":'VARCHAR', \"to\":'VARCHAR', body:'VARCHAR', at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited'"
   duckdb -noheader -list -newline $'\n' <<SQL 2>/dev/null
 SELECT to_json(struct_pack(type := 'message_sent', id := s.id, team := s.team,
          "from" := s."from", "to" := s."to", body := s.body, at := s.at))
-FROM (SELECT * FROM read_json('$log', $cols) WHERE type='message_sent'
-        AND team='$team' AND "to"='$agent') s
+FROM (SELECT * FROM read_json('$lg', $cols) WHERE type='message_sent'
+        AND team='$tl' AND "to"='$al') s
 WHERE s.id NOT IN (
-  SELECT msg_id FROM read_json('$log', $cols)
-  WHERE type='message_read' AND team='$team' AND agent='$agent')
+  SELECT msg_id FROM read_json('$lg', $cols)
+  WHERE type='message_read' AND team='$tl' AND agent='$al')
 ORDER BY s.at, s.id;
 SQL
 }
@@ -171,7 +178,10 @@ SQL
 storage_mark_read_batch() {
   local team="$1" agent="$2"; shift 2
   _jsonl_init_file
-  _jsonl_with_lock _jsonl_mark "$team" "$agent" "$@"
+  # Propagate a lock-acquire / write failure as a §1.4 control-op error — never
+  # swallow it as ok, or inbox/check-inbox would treat unread as read with no
+  # message_read written (re-delivery loop / stale wake on the read hot path).
+  _jsonl_with_lock _jsonl_mark "$team" "$agent" "$@" || { echo runtime_error; return 13; }
   echo ok
 }
 _jsonl_mark() {
@@ -195,7 +205,10 @@ _jsonl_mark() {
 
 storage_watch_tip() {
   _jsonl_init_file
-  jq -s '[.[] | select(.type=="message_sent")] | length' "$(_jsonl_log)" 2>/dev/null || echo 0
+  # An empty log makes jq return 0 with exit 0; a CORRUPT log makes jq fail, and
+  # that must surface as a non-zero exit (data-op framing §2.1) — no `|| echo 0`
+  # fallback that would mask a broken store as a fresh tip of 0.
+  jq -s '[.[] | select(.type=="message_sent")] | length' "$(_jsonl_log)"
 }
 
 storage_watch_after() {

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -23,6 +23,11 @@
 
 # --- helpers ---------------------------------------------------------------
 
+# Where this driver (and its companion duckdb .sql) lives — captured at source
+# time so the optional duckdb path can read the query from a data file rather than
+# carry apostrophe-laden SQL inline (which the macOS bash 3.2 parser mis-handles).
+_JSONL_DRIVER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+
 _jsonl_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 _jsonl_log() { printf '%s\n' "$(dirname "$(agmsg_db_path)")/events.jsonl"; }
 
@@ -154,25 +159,24 @@ storage_list_unread() {
 # read_json_auto, whose type inference would parse `at` as a TIMESTAMP and re-emit
 # it as "Y-M-D H:M:S", losing the canonical ISO-8601 "...T...Z" the jq path keeps.
 _jsonl_unread_duckdb() {
-  local team="$1" agent="$2" log="$3"
+  local team="$1" agent="$2" log="$3" tl al lg sql tpl
   # SQL-escape every value spliced into the query (team/agent are not apostrophe-
   # free per validate.sh, and the path may contain one) so a legal team/agent that
   # the jq path handles can't break — or silently misbehave on — the duckdb path.
-  local tl al lg
   tl="$(printf '%s' "$team"  | sed "s/'/''/g")"
   al="$(printf '%s' "$agent" | sed "s/'/''/g")"
   lg="$(printf '%s' "$log"   | sed "s/'/''/g")"
-  local cols="columns={type:'VARCHAR', id:'VARCHAR', team:'VARCHAR', \"from\":'VARCHAR', \"to\":'VARCHAR', body:'VARCHAR', at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited'"
-  duckdb -noheader -list -newline $'\n' <<SQL 2>/dev/null
-SELECT to_json(struct_pack(type := 'message_sent', id := s.id, team := s.team,
-         "from" := s."from", "to" := s."to", body := s.body, at := s.at))
-FROM (SELECT * FROM read_json('$lg', $cols) WHERE type='message_sent'
-        AND team='$tl' AND "to"='$al') s
-WHERE s.id NOT IN (
-  SELECT msg_id FROM read_json('$lg', $cols)
-  WHERE type='message_read' AND team='$tl' AND agent='$al')
-ORDER BY s.at, s.id;
-SQL
+  # Read the query from the companion .sql DATA file and fill placeholders with
+  # plain bash substitution (literal, so a value with sed-special / regex chars is
+  # safe). Keeping the SQL out of this shell file is what makes the driver parse
+  # under macOS bash 3.2 (an inline apostrophe-laden SQL string desyncs its parser).
+  tpl="$_JSONL_DRIVER_DIR/jsonl-unread.duckdb.sql"
+  [ -f "$tpl" ] || return 1
+  sql="$(cat "$tpl")"
+  sql="${sql//__LG__/$lg}"
+  sql="${sql//__TL__/$tl}"
+  sql="${sql//__AL__/$al}"
+  printf '%s\n' "$sql" | duckdb -noheader -list 2>/dev/null
 }
 
 storage_mark_read_batch() {
@@ -278,15 +282,11 @@ _jsonl_compact_do() {
   local log tmp; log="$(_jsonl_log)"; tmp="$log.compact.$$"
   # Keep every message_sent in order; collapse duplicate message_read for the same
   # (team, agent, msg_id) to the first seen. message_sent order is preserved, so
-  # the ordinal delivery cursor stays valid (§2.7 cursor-safe).
-  jq -c -s '
-    reduce .[] as $e ({out:[], seen:{}};
-      if $e.type=="message_sent" then .out += [$e]
-      elif $e.type=="message_read" then
-        ($e.team + " " + $e.agent + " " + $e.msg_id) as $k
-        | if .seen[$k] then . else .seen[$k]=true | .out += [$e] end
-      else . end)
-    | .out[]
-  ' "$log" > "$tmp" || { rm -f "$tmp"; return 1; }
+  # the ordinal delivery cursor stays valid (compaction cursor-safety, spec 2.7).
+  # NOTE: this jq program is deliberately a SINGLE line — a multi-line
+  # single-quoted jq string in this position desyncs the macOS system bash 3.2
+  # parser and breaks the rest of the file (a no-error `bash -n`, but a real
+  # source failure). Keep new jq one-liners here.
+  jq -c -s 'reduce .[] as $e ({out:[], seen:{}}; if $e.type=="message_sent" then .out += [$e] elif $e.type=="message_read" then ([$e.team,$e.agent,$e.msg_id]|join(" ")) as $k | if .seen[$k] then . else .seen[$k]=true | .out += [$e] end else . end) | .out[]' "$log" > "$tmp" || { rm -f "$tmp"; return 1; }
   mv "$tmp" "$log"
 }

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -107,6 +107,10 @@ storage_init() {
   echo ok
 }
 
+# Does a store already exist? (does NOT create one.) The log is the store, so a
+# read call-site can answer "no messages yet" without lazily creating events.jsonl.
+storage_store_exists() { [ -f "$(_jsonl_log)" ]; }
+
 # --- contract: messages -----------------------------------------------------
 
 storage_send() {

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -24,9 +24,11 @@ _sqlite_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
 
 # Run a record-returning query: strip CR but PRESERVE the sqlite exit status
 # (pipefail), so a backend failure surfaces as a non-zero return instead of
-# being swallowed by tr's exit 0 (§2.1 stdout framing / co1 review).
+# being swallowed by tr's exit 0. The backend's error text goes to stderr (a
+# separate fd — it never pollutes the JSONL on stdout) so failures are
+# debuggable, per §2.1 framing (#203 (1) / co1 review).
 _sqlite_data() {
-  ( set -o pipefail; agmsg_sqlite "$(_sqlite_db)" "$1" 2>/dev/null | tr -d '\r' )
+  ( set -o pipefail; agmsg_sqlite "$(_sqlite_db)" "$1" | tr -d '\r' )
 }
 
 # UUIDv7: 48-bit ms timestamp + version/variant + random. python3 preferred;
@@ -137,12 +139,13 @@ storage_list_unread() {
   shift 2
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
+  storage_init >/dev/null
   local tl al; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
   _sqlite_data "
     SELECT j FROM (
       SELECT json_object('type','message_sent','id',e.id,'team',e.team,
                'from',e.from_agent,'to',e.to_agent,'body',e.body,'at',e.at) AS j,
-             1 AS src, e.seq AS ord
+             e.at AS ts, 1 AS src, e.seq AS ord
       FROM events e
       WHERE e.type='message_sent' AND e.team='$tl' AND e.to_agent='$al'
         AND NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
@@ -150,13 +153,13 @@ storage_list_unread() {
       UNION ALL
       SELECT json_object('type','message_sent','id',CAST(m.id AS TEXT),'team',m.team,
                'from',m.from_agent,'to',m.to_agent,'body',m.body,'at',m.created_at) AS j,
-             0 AS src, m.id AS ord
+             m.created_at AS ts, 0 AS src, m.id AS ord
       FROM messages m
       WHERE m.team='$tl' AND m.to_agent='$al' AND m.read_at IS NULL
         AND NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
                         AND r.team=m.team AND r.agent='$al' AND r.msg_id=CAST(m.id AS TEXT))
     )
-    ORDER BY src, ord ${limit:+LIMIT $limit};
+    ORDER BY ts, src, ord ${limit:+LIMIT $limit};
   "
 }
 
@@ -212,21 +215,22 @@ storage_history() {
   shift 2
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
+  storage_init >/dev/null
   local tl al; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
   _sqlite_data "
     SELECT j FROM (
       SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
-               'to',to_agent,'body',body,'at',at) AS j, 1 AS src, seq AS ord
+               'to',to_agent,'body',body,'at',at) AS j, at AS ts, 1 AS src, seq AS ord
       FROM events
       WHERE type='message_sent' AND team='$tl' AND (to_agent='$al' OR from_agent='$al')
       UNION ALL
       SELECT json_object('type','message_sent','id',CAST(id AS TEXT),'team',team,
                'from',from_agent,'to',to_agent,'body',body,'at',created_at) AS j,
-             0 AS src, id AS ord
+             created_at AS ts, 0 AS src, id AS ord
       FROM messages
       WHERE team='$tl' AND (to_agent='$al' OR from_agent='$al')
     )
-    ORDER BY src, ord ${limit:+LIMIT $limit};
+    ORDER BY ts, src, ord ${limit:+LIMIT $limit};
   "
 }
 

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -122,13 +122,21 @@ storage_init() {
 storage_send() {
   local team="$1" from="$2" to="$3" body="$4"
   local id at db; id="$(_sqlite_uuid7)"; at="$(_sqlite_now)"; db="$(_sqlite_db)"
-  storage_init >/dev/null
-  agmsg_sqlite "$db" "
+  local insert="
     INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
     VALUES ('message_sent','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
             '$(_sqlite_lit "$from")','$(_sqlite_lit "$to")','$(_sqlite_lit "$body")',
             '$(_sqlite_lit "$at")');
-  " >/dev/null 2>&1 || return 1
+  "
+  # Try the INSERT first and only fall back to storage_init on failure (the #114
+  # pattern). Running storage_init — which issues PRAGMA journal_mode=WAL and the
+  # CREATE TABLE/INDEX statements — on EVERY send serializes badly under a
+  # concurrent first-write fan-out and lost rows past the busy_timeout. The common
+  # path is now a single INSERT; only a missing table pays the init + retry.
+  if ! agmsg_sqlite "$db" "$insert" >/dev/null 2>&1; then
+    storage_init >/dev/null
+    agmsg_sqlite "$db" "$insert" >/dev/null 2>&1 || return 1
+  fi
   printf '%s\n' "$id"
 }
 
@@ -203,7 +211,13 @@ storage_watch_after() {
   local cursor="$1"; shift
   case "$cursor" in ''|*[!0-9]*) cursor=0 ;; esac
   local pairs; pairs="$(_sqlite_pair_in "$@")"
+  # The message scan and the trailing-cursor (high-water) read MUST observe the
+  # same snapshot, or a row inserted between the two statements would advance the
+  # cursor past a message the scan never returned — a silent skip. A deferred read
+  # transaction pins one WAL snapshot across both SELECTs, so the emitted cursor
+  # never runs ahead of what the scan saw (§2.2 "never skip").
   _sqlite_data "
+    BEGIN;
     SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
                        'to',to_agent,'body',body,'at',at)
     FROM events
@@ -212,6 +226,7 @@ storage_watch_after() {
     ORDER BY seq ASC;
     SELECT json_object('type','cursor','cursor',
                        CAST(MAX($cursor, $(_sqlite_highwater)) AS TEXT));
+    COMMIT;
   "
 }
 

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -217,28 +217,41 @@ storage_watch_after() {
 
 # --- contract: history -----------------------------------------------------
 
-# storage_history <team> <agent> [--limit N]  — events ∪ legacy, agent involved.
+# storage_history <team> [agent] [--limit N]  — events ∪ legacy in time order.
+# With <agent>, only rows where that agent is sender or recipient; omit it (empty)
+# for the whole team (§2.1 G3 — an additive widening, existing callers unchanged).
 storage_history() {
   local team="$1" agent="$2" limit=""
   shift 2
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
   storage_init >/dev/null
-  local tl al; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  local tl al afilter; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  if [ -n "$agent" ]; then
+    afilter="AND (to_agent='$al' OR from_agent='$al')"
+  else
+    afilter=""
+  fi
+  # --limit returns the most RECENT N (inner DESC + LIMIT), re-sorted to
+  # chronological order for output — the intuitive "recent history" semantics,
+  # not the oldest N.
   _sqlite_data "
     SELECT j FROM (
-      SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
-               'to',to_agent,'body',body,'at',at) AS j, at AS ts, 1 AS src, seq AS ord
-      FROM events
-      WHERE type='message_sent' AND team='$tl' AND (to_agent='$al' OR from_agent='$al')
-      UNION ALL
-      SELECT json_object('type','message_sent','id',CAST(id AS TEXT),'team',team,
-               'from',from_agent,'to',to_agent,'body',body,'at',created_at) AS j,
-             created_at AS ts, 0 AS src, id AS ord
-      FROM messages
-      WHERE team='$tl' AND (to_agent='$al' OR from_agent='$al')
+      SELECT j, ts, src, ord FROM (
+        SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
+                 'to',to_agent,'body',body,'at',at) AS j, at AS ts, 1 AS src, seq AS ord
+        FROM events
+        WHERE type='message_sent' AND team='$tl' $afilter
+        UNION ALL
+        SELECT json_object('type','message_sent','id',CAST(id AS TEXT),'team',team,
+                 'from',from_agent,'to',to_agent,'body',body,'at',created_at) AS j,
+               created_at AS ts, 0 AS src, id AS ord
+        FROM messages
+        WHERE team='$tl' $afilter
+      )
+      ORDER BY ts DESC, src DESC, ord DESC ${limit:+LIMIT $limit}
     )
-    ORDER BY ts, src, ord ${limit:+LIMIT $limit};
+    ORDER BY ts ASC, src ASC, ord ASC;
   "
 }
 

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -185,9 +185,18 @@ storage_mark_read_batch() {
 
 # --- contract: delivery cursor ---------------------------------------------
 
+# The delivery tip is the monotonic AUTOINCREMENT high-water (largest rowid ever
+# assigned to `events`), read from sqlite_sequence — NOT MAX(seq) over live rows.
+# A DELETE-based storage_compact can lower MAX(seq) (e.g. by coalescing the
+# tail message_read) but never the high-water, so a cursor issued before a
+# compaction stays valid and a fresh tip never moves backwards (§2.7 cursor-safe).
+_sqlite_highwater() {
+  printf "COALESCE((SELECT seq FROM sqlite_sequence WHERE name='events'),0)"
+}
+
 storage_watch_tip() {
   storage_init >/dev/null
-  _sqlite_data "SELECT COALESCE(MAX(seq),0) FROM events;"
+  _sqlite_data "SELECT $(_sqlite_highwater);"
 }
 
 storage_watch_after() {
@@ -202,8 +211,7 @@ storage_watch_after() {
       AND (team || ':' || to_agent) IN ($pairs)
     ORDER BY seq ASC;
     SELECT json_object('type','cursor','cursor',
-                       CAST(COALESCE(MAX(seq), $cursor) AS TEXT))
-    FROM events;
+                       CAST(MAX($cursor, $(_sqlite_highwater)) AS TEXT));
   "
 }
 

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -83,6 +83,10 @@ storage_describe() {
   printf 'db=%s\n' "$(_sqlite_db)"
 }
 
+# Does a store already exist? (does NOT create one — lets a read call-site answer
+# "no messages yet" without lazily initializing a store in a storeless project.)
+storage_store_exists() { [ -f "$(_sqlite_db)" ]; }
+
 storage_init() {
   local db; db="$(_sqlite_db)"
   mkdir -p "$(dirname "$db")" 2>/dev/null || true

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -5,15 +5,29 @@
 # over SQLite. Sourced by the storage facade (lib/storage.sh, agmsg_storage_load),
 # so agmsg_db_path / agmsg_sqlite / agmsg_sql_readfile_path from storage.sh are in
 # scope. State is an append-only `events` log (canonical JSONL: message_sent /
-# message_read); the legacy `messages` table is read for back-compat (§2.4).
+# message_read). The legacy `messages` table is read **read-only** and UNIONed
+# into list_unread / history so an existing store keeps its inbox and history
+# after #206 switches call sites onto the contract (§2.4); legacy rows are never
+# migrated or mutated here.
 #
-# The delivery cursor (§2.2) is the events.seq autoincrement, returned to core as
-# an opaque decimal string — core never parses it. Read-marking is recipient-
-# scoped ((team, agent)) and idempotent.
+# Framing (§1.4 / ADR 0003): record-returning ops write data only to stdout and
+# fail with a non-zero exit; control ops (check/init/mark_read_batch/compact)
+# print a §1.4 status name on stdout. The delivery cursor (§2.2) is the events.seq
+# autoincrement, returned as an opaque decimal string. Read-marking is
+# recipient-scoped ((team, agent)) and idempotent.
 
 # --- helpers ---------------------------------------------------------------
 
 _sqlite_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+_sqlite_db() { agmsg_db_path; }
+_sqlite_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+# Run a record-returning query: strip CR but PRESERVE the sqlite exit status
+# (pipefail), so a backend failure surfaces as a non-zero return instead of
+# being swallowed by tr's exit 0 (§2.1 stdout framing / co1 review).
+_sqlite_data() {
+  ( set -o pipefail; agmsg_sqlite "$(_sqlite_db)" "$1" 2>/dev/null | tr -d '\r' )
+}
 
 # UUIDv7: 48-bit ms timestamp + version/variant + random. python3 preferred;
 # fall back to a /dev/urandom shell build. No counter file (§2.5).
@@ -33,22 +47,15 @@ print(f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}")
 PY
     return
   fi
-  # Shell fallback: 48-bit ms hex from epoch + 80 random bits from urandom.
   local ms hex rnd
   ms=$(( $(date -u +%s) * 1000 ))
   hex=$(printf '%012x' "$ms")
   rnd=$(head -c 10 /dev/urandom | od -An -tx1 | tr -d ' \n')
-  printf '%s-%s-7%s-%s%s-%s\n' \
-    "${hex:0:8}" "${hex:8:4}" "${rnd:0:3}" \
-    "8" "${rnd:3:3}" "${rnd:6:12}"
+  printf '%s-%s-7%s-8%s-%s\n' \
+    "${hex:0:8}" "${hex:8:4}" "${rnd:0:3}" "${rnd:3:3}" "${rnd:6:12}"
 }
 
-_sqlite_db() { agmsg_db_path; }
-
-# Build a SQL string literal (single-quote escaped) from $1.
-_sqlite_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
-
-# Build an "IN (...)" list of team||':'||agent pairs from "<team>:<agent>" args.
+# IN (...) list of "team:agent" pairs.
 _sqlite_pair_in() {
   local out="" p t a
   for p in "$@"; do
@@ -58,11 +65,14 @@ _sqlite_pair_in() {
   printf '%s' "${out:-''}"
 }
 
-# --- contract: lifecycle ---------------------------------------------------
+# --- contract: lifecycle (control ops, §1.4 status on stdout) ---------------
 
 storage_check() {
-  command -v sqlite3 >/dev/null 2>&1 || { echo "missing_deps: sqlite3 not found" >&2; return 3; }
-  echo "ok"
+  if ! command -v sqlite3 >/dev/null 2>&1; then
+    echo missing_deps
+    return 10
+  fi
+  echo ok
 }
 
 storage_describe() {
@@ -90,7 +100,19 @@ storage_init() {
     );
     CREATE INDEX IF NOT EXISTS events_sent ON events(type, team, to_agent, seq);
     CREATE INDEX IF NOT EXISTS events_read ON events(type, team, agent, msg_id);
-  " >/dev/null 2>&1
+    -- Legacy store (read-only here). Created so the UNION queries always parse
+    -- even on a brand-new install with no pre-event-log data.
+    CREATE TABLE IF NOT EXISTS messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      team TEXT NOT NULL,
+      from_agent TEXT NOT NULL,
+      to_agent TEXT NOT NULL,
+      body TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+      read_at TEXT
+    );
+  " >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  echo ok
 }
 
 # --- contract: messages ----------------------------------------------------
@@ -98,7 +120,7 @@ storage_init() {
 storage_send() {
   local team="$1" from="$2" to="$3" body="$4"
   local id at db; id="$(_sqlite_uuid7)"; at="$(_sqlite_now)"; db="$(_sqlite_db)"
-  storage_init
+  storage_init >/dev/null
   agmsg_sqlite "$db" "
     INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
     VALUES ('message_sent','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
@@ -109,61 +131,67 @@ storage_send() {
 }
 
 # storage_list_unread <team> <agent> [--limit N]
+# events-unread ∪ legacy-unread (read_at IS NULL, not superseded by a read event).
 storage_list_unread() {
   local team="$1" agent="$2" limit=""
   shift 2
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
-  local db; db="$(_sqlite_db)"
   local tl al; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
-  agmsg_sqlite "$db" "
-    SELECT json_object('id',e.id,'team',e.team,'from',e.from_agent,
-                       'to',e.to_agent,'body',e.body,'at',e.at)
-    FROM events e
-    WHERE e.type='message_sent' AND e.team='$tl' AND e.to_agent='$al'
-      AND NOT EXISTS (
-        SELECT 1 FROM events r
-        WHERE r.type='message_read' AND r.team=e.team
-          AND r.agent='$al' AND r.msg_id=e.id)
-    ORDER BY e.seq ASC ${limit:+LIMIT $limit};
-  " 2>/dev/null | tr -d '\r'
+  _sqlite_data "
+    SELECT j FROM (
+      SELECT json_object('type','message_sent','id',e.id,'team',e.team,
+               'from',e.from_agent,'to',e.to_agent,'body',e.body,'at',e.at) AS j,
+             1 AS src, e.seq AS ord
+      FROM events e
+      WHERE e.type='message_sent' AND e.team='$tl' AND e.to_agent='$al'
+        AND NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
+                        AND r.team=e.team AND r.agent='$al' AND r.msg_id=e.id)
+      UNION ALL
+      SELECT json_object('type','message_sent','id',CAST(m.id AS TEXT),'team',m.team,
+               'from',m.from_agent,'to',m.to_agent,'body',m.body,'at',m.created_at) AS j,
+             0 AS src, m.id AS ord
+      FROM messages m
+      WHERE m.team='$tl' AND m.to_agent='$al' AND m.read_at IS NULL
+        AND NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
+                        AND r.team=m.team AND r.agent='$al' AND r.msg_id=CAST(m.id AS TEXT))
+    )
+    ORDER BY src, ord ${limit:+LIMIT $limit};
+  "
 }
 
-# storage_mark_read_batch <team> <agent> <id> [<id> ...]
+# storage_mark_read_batch <team> <agent> <id> [<id> ...]  (control op)
 storage_mark_read_batch() {
   local team="$1" agent="$2"; shift 2
-  [ $# -gt 0 ] || return 0
+  [ $# -gt 0 ] || { echo ok; return 0; }
   local db at tl al; db="$(_sqlite_db)"; at="$(_sqlite_now)"
   tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
-  storage_init
+  storage_init >/dev/null
   local id sql=""
   for id in "$@"; do
     local idl rid; idl="$(_sqlite_lit "$id")"; rid="$(_sqlite_uuid7)"
-    # Idempotent: only insert a message_read if this recipient hasn't read it.
     sql="$sql
     INSERT INTO events (type,id,team,agent,msg_id,at)
     SELECT 'message_read','$(_sqlite_lit "$rid")','$tl','$al','$idl','$(_sqlite_lit "$at")'
     WHERE NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
                       AND r.team='$tl' AND r.agent='$al' AND r.msg_id='$idl');"
   done
-  agmsg_sqlite "$db" "$sql" >/dev/null 2>&1
+  agmsg_sqlite "$db" "$sql" >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  echo ok
 }
 
 # --- contract: delivery cursor ---------------------------------------------
 
-# storage_watch_tip <team:agent> ... -> opaque cursor for "now"
 storage_watch_tip() {
-  local db; db="$(_sqlite_db)"
-  storage_init
-  agmsg_sqlite "$db" "SELECT COALESCE(MAX(seq),0) FROM events;" 2>/dev/null | tr -d '\r'
+  storage_init >/dev/null
+  _sqlite_data "SELECT COALESCE(MAX(seq),0) FROM events;"
 }
 
-# storage_watch_after <cursor> <team:agent> ... -> JSONL message_sent + cursor record
 storage_watch_after() {
   local cursor="$1"; shift
   case "$cursor" in ''|*[!0-9]*) cursor=0 ;; esac
-  local db pairs; db="$(_sqlite_db)"; pairs="$(_sqlite_pair_in "$@")"
-  agmsg_sqlite "$db" "
+  local pairs; pairs="$(_sqlite_pair_in "$@")"
+  _sqlite_data "
     SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
                        'to',to_agent,'body',body,'at',at)
     FROM events
@@ -173,34 +201,41 @@ storage_watch_after() {
     SELECT json_object('type','cursor','cursor',
                        CAST(COALESCE(MAX(seq), $cursor) AS TEXT))
     FROM events;
-  " 2>/dev/null | tr -d '\r'
+  "
 }
 
 # --- contract: history -----------------------------------------------------
 
-# storage_history <team> <agent> [--limit N]
+# storage_history <team> <agent> [--limit N]  — events ∪ legacy, agent involved.
 storage_history() {
   local team="$1" agent="$2" limit=""
   shift 2
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
-  local db tl al; db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
-  agmsg_sqlite "$db" "
-    SELECT json_object('id',id,'team',team,'from',from_agent,'to',to_agent,
-                       'body',body,'at',at)
-    FROM events
-    WHERE type='message_sent' AND team='$tl'
-      AND (to_agent='$al' OR from_agent='$al')
-    ORDER BY seq ASC ${limit:+LIMIT $limit};
-  " 2>/dev/null | tr -d '\r'
+  local tl al; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  _sqlite_data "
+    SELECT j FROM (
+      SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
+               'to',to_agent,'body',body,'at',at) AS j, 1 AS src, seq AS ord
+      FROM events
+      WHERE type='message_sent' AND team='$tl' AND (to_agent='$al' OR from_agent='$al')
+      UNION ALL
+      SELECT json_object('type','message_sent','id',CAST(id AS TEXT),'team',team,
+               'from',from_agent,'to',to_agent,'body',body,'at',created_at) AS j,
+             0 AS src, id AS ord
+      FROM messages
+      WHERE team='$tl' AND (to_agent='$al' OR from_agent='$al')
+    )
+    ORDER BY src, ord ${limit:+LIMIT $limit};
+  "
 }
 
 # --- contract: export / import / compact -----------------------------------
 
 storage_export() {
-  local file="$1" db; db="$(_sqlite_db)"
-  storage_init
-  agmsg_sqlite "$db" "
+  local file="$1"
+  storage_init >/dev/null
+  _sqlite_data "
     SELECT CASE type
       WHEN 'message_sent' THEN json_object('type','message_sent','id',id,'team',team,
              'from',from_agent,'to',to_agent,'body',body,'at',at)
@@ -208,19 +243,18 @@ storage_export() {
              'agent',agent,'msg_id',msg_id,'at',at)
     END
     FROM events ORDER BY seq ASC;
-  " 2>/dev/null | tr -d '\r' > "$file"
+  " > "$file"
 }
 
 storage_import() {
   local file="$1" db; db="$(_sqlite_db)"
   [ -f "$file" ] || return 1
-  storage_init
+  storage_init >/dev/null
   local line t id team frm to body msg_id agent at
+  j() { sqlite3 :memory: "SELECT COALESCE(json_extract('$(_sqlite_lit "$line")','\$.$1'),'')" 2>/dev/null | tr -d '\r'; }
   while IFS= read -r line; do
     [ -n "$line" ] || continue
-    t=$(printf '%s' "$line" | sed -n 's/.*"type":"\([^"]*\)".*/\1/p')
-    j() { printf '%s' "$line" | sqlite3 :memory: "SELECT COALESCE(json_extract('$(_sqlite_lit "$line")','\$.$1'),'')" 2>/dev/null | tr -d '\r'; }
-    id=$(j id); team=$(j team); at=$(j at)
+    t=$(j type); id=$(j id); team=$(j team); at=$(j at)
     if [ "$t" = message_sent ]; then
       frm=$(j from); to=$(j to); body=$(j body)
       agmsg_sqlite "$db" "INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
@@ -237,12 +271,13 @@ storage_import() {
   done < "$file"
 }
 
-# Internal (§2.7): coalesce duplicate message_read markers, keeping the earliest.
+# Internal (§2.7): coalesce duplicate message_read markers, keeping the earliest. (control op)
 storage_compact() {
   local db; db="$(_sqlite_db)"
   agmsg_sqlite "$db" "
     DELETE FROM events WHERE type='message_read' AND seq NOT IN (
       SELECT MIN(seq) FROM events WHERE type='message_read'
       GROUP BY team, agent, msg_id);
-  " >/dev/null 2>&1
+  " >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  echo ok
 }

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -221,8 +221,13 @@ storage_watch_after() {
 # With <agent>, only rows where that agent is sender or recipient; omit it (empty)
 # for the whole team (§2.1 G3 — an additive widening, existing callers unchanged).
 storage_history() {
-  local team="$1" agent="$2" limit=""
-  shift 2
+  local team="$1"; shift
+  local agent="" limit=""
+  # <agent> is optional: consume a leading NON-flag argument as the agent (an
+  # empty string is allowed and also means team-wide). A leading --flag means no
+  # agent was given. This is what makes `storage_history <team> --limit N` and
+  # `storage_history <team>` parse correctly per the §2.1 contract (co1 review).
+  if [ $# -gt 0 ] && [ "${1#-}" = "$1" ]; then agent="$1"; shift; fi
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
   storage_init >/dev/null

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# sqlite storage driver (built-in, default).
+#
+# Implements the storage contract (docs/spec/driver-interface.md §2, ADR 0003)
+# over SQLite. Sourced by the storage facade (lib/storage.sh, agmsg_storage_load),
+# so agmsg_db_path / agmsg_sqlite / agmsg_sql_readfile_path from storage.sh are in
+# scope. State is an append-only `events` log (canonical JSONL: message_sent /
+# message_read); the legacy `messages` table is read for back-compat (§2.4).
+#
+# The delivery cursor (§2.2) is the events.seq autoincrement, returned to core as
+# an opaque decimal string — core never parses it. Read-marking is recipient-
+# scoped ((team, agent)) and idempotent.
+
+# --- helpers ---------------------------------------------------------------
+
+_sqlite_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# UUIDv7: 48-bit ms timestamp + version/variant + random. python3 preferred;
+# fall back to a /dev/urandom shell build. No counter file (§2.5).
+_sqlite_uuid7() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import os, time
+ms = int(time.time() * 1000) & ((1 << 48) - 1)
+b = bytearray(os.urandom(16))
+b[0] = (ms >> 40) & 0xFF; b[1] = (ms >> 32) & 0xFF
+b[2] = (ms >> 24) & 0xFF; b[3] = (ms >> 16) & 0xFF
+b[4] = (ms >> 8) & 0xFF;  b[5] = ms & 0xFF
+b[6] = 0x70 | (b[6] & 0x0F)            # version 7
+b[8] = 0x80 | (b[8] & 0x3F)            # variant 10
+h = b.hex()
+print(f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}")
+PY
+    return
+  fi
+  # Shell fallback: 48-bit ms hex from epoch + 80 random bits from urandom.
+  local ms hex rnd
+  ms=$(( $(date -u +%s) * 1000 ))
+  hex=$(printf '%012x' "$ms")
+  rnd=$(head -c 10 /dev/urandom | od -An -tx1 | tr -d ' \n')
+  printf '%s-%s-7%s-%s%s-%s\n' \
+    "${hex:0:8}" "${hex:8:4}" "${rnd:0:3}" \
+    "8" "${rnd:3:3}" "${rnd:6:12}"
+}
+
+_sqlite_db() { agmsg_db_path; }
+
+# Build a SQL string literal (single-quote escaped) from $1.
+_sqlite_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+# Build an "IN (...)" list of team||':'||agent pairs from "<team>:<agent>" args.
+_sqlite_pair_in() {
+  local out="" p t a
+  for p in "$@"; do
+    t="${p%%:*}"; a="${p#*:}"
+    out="${out:+$out,}'$(_sqlite_lit "$t:$a")'"
+  done
+  printf '%s' "${out:-''}"
+}
+
+# --- contract: lifecycle ---------------------------------------------------
+
+storage_check() {
+  command -v sqlite3 >/dev/null 2>&1 || { echo "missing_deps: sqlite3 not found" >&2; return 3; }
+  echo "ok"
+}
+
+storage_describe() {
+  printf 'name=sqlite\n'
+  printf 'backend=SQLite (WAL) event log + legacy messages table\n'
+  printf 'db=%s\n' "$(_sqlite_db)"
+}
+
+storage_init() {
+  local db; db="$(_sqlite_db)"
+  mkdir -p "$(dirname "$db")" 2>/dev/null || true
+  agmsg_sqlite "$db" "
+    PRAGMA journal_mode=WAL;
+    CREATE TABLE IF NOT EXISTS events (
+      seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+      type       TEXT NOT NULL,
+      id         TEXT NOT NULL,
+      team       TEXT,
+      from_agent TEXT,
+      to_agent   TEXT,
+      body       TEXT,
+      msg_id     TEXT,
+      agent      TEXT,
+      at         TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS events_sent ON events(type, team, to_agent, seq);
+    CREATE INDEX IF NOT EXISTS events_read ON events(type, team, agent, msg_id);
+  " >/dev/null 2>&1
+}
+
+# --- contract: messages ----------------------------------------------------
+
+storage_send() {
+  local team="$1" from="$2" to="$3" body="$4"
+  local id at db; id="$(_sqlite_uuid7)"; at="$(_sqlite_now)"; db="$(_sqlite_db)"
+  storage_init
+  agmsg_sqlite "$db" "
+    INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
+    VALUES ('message_sent','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
+            '$(_sqlite_lit "$from")','$(_sqlite_lit "$to")','$(_sqlite_lit "$body")',
+            '$(_sqlite_lit "$at")');
+  " >/dev/null 2>&1 || return 1
+  printf '%s\n' "$id"
+}
+
+# storage_list_unread <team> <agent> [--limit N]
+storage_list_unread() {
+  local team="$1" agent="$2" limit=""
+  shift 2
+  while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
+  case "$limit" in ''|*[!0-9]*) limit="" ;; esac
+  local db; db="$(_sqlite_db)"
+  local tl al; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  agmsg_sqlite "$db" "
+    SELECT json_object('id',e.id,'team',e.team,'from',e.from_agent,
+                       'to',e.to_agent,'body',e.body,'at',e.at)
+    FROM events e
+    WHERE e.type='message_sent' AND e.team='$tl' AND e.to_agent='$al'
+      AND NOT EXISTS (
+        SELECT 1 FROM events r
+        WHERE r.type='message_read' AND r.team=e.team
+          AND r.agent='$al' AND r.msg_id=e.id)
+    ORDER BY e.seq ASC ${limit:+LIMIT $limit};
+  " 2>/dev/null | tr -d '\r'
+}
+
+# storage_mark_read_batch <team> <agent> <id> [<id> ...]
+storage_mark_read_batch() {
+  local team="$1" agent="$2"; shift 2
+  [ $# -gt 0 ] || return 0
+  local db at tl al; db="$(_sqlite_db)"; at="$(_sqlite_now)"
+  tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  storage_init
+  local id sql=""
+  for id in "$@"; do
+    local idl rid; idl="$(_sqlite_lit "$id")"; rid="$(_sqlite_uuid7)"
+    # Idempotent: only insert a message_read if this recipient hasn't read it.
+    sql="$sql
+    INSERT INTO events (type,id,team,agent,msg_id,at)
+    SELECT 'message_read','$(_sqlite_lit "$rid")','$tl','$al','$idl','$(_sqlite_lit "$at")'
+    WHERE NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
+                      AND r.team='$tl' AND r.agent='$al' AND r.msg_id='$idl');"
+  done
+  agmsg_sqlite "$db" "$sql" >/dev/null 2>&1
+}
+
+# --- contract: delivery cursor ---------------------------------------------
+
+# storage_watch_tip <team:agent> ... -> opaque cursor for "now"
+storage_watch_tip() {
+  local db; db="$(_sqlite_db)"
+  storage_init
+  agmsg_sqlite "$db" "SELECT COALESCE(MAX(seq),0) FROM events;" 2>/dev/null | tr -d '\r'
+}
+
+# storage_watch_after <cursor> <team:agent> ... -> JSONL message_sent + cursor record
+storage_watch_after() {
+  local cursor="$1"; shift
+  case "$cursor" in ''|*[!0-9]*) cursor=0 ;; esac
+  local db pairs; db="$(_sqlite_db)"; pairs="$(_sqlite_pair_in "$@")"
+  agmsg_sqlite "$db" "
+    SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
+                       'to',to_agent,'body',body,'at',at)
+    FROM events
+    WHERE type='message_sent' AND seq > $cursor
+      AND (team || ':' || to_agent) IN ($pairs)
+    ORDER BY seq ASC;
+    SELECT json_object('type','cursor','cursor',
+                       CAST(COALESCE(MAX(seq), $cursor) AS TEXT))
+    FROM events;
+  " 2>/dev/null | tr -d '\r'
+}
+
+# --- contract: history -----------------------------------------------------
+
+# storage_history <team> <agent> [--limit N]
+storage_history() {
+  local team="$1" agent="$2" limit=""
+  shift 2
+  while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
+  case "$limit" in ''|*[!0-9]*) limit="" ;; esac
+  local db tl al; db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  agmsg_sqlite "$db" "
+    SELECT json_object('id',id,'team',team,'from',from_agent,'to',to_agent,
+                       'body',body,'at',at)
+    FROM events
+    WHERE type='message_sent' AND team='$tl'
+      AND (to_agent='$al' OR from_agent='$al')
+    ORDER BY seq ASC ${limit:+LIMIT $limit};
+  " 2>/dev/null | tr -d '\r'
+}
+
+# --- contract: export / import / compact -----------------------------------
+
+storage_export() {
+  local file="$1" db; db="$(_sqlite_db)"
+  storage_init
+  agmsg_sqlite "$db" "
+    SELECT CASE type
+      WHEN 'message_sent' THEN json_object('type','message_sent','id',id,'team',team,
+             'from',from_agent,'to',to_agent,'body',body,'at',at)
+      WHEN 'message_read' THEN json_object('type','message_read','id',id,'team',team,
+             'agent',agent,'msg_id',msg_id,'at',at)
+    END
+    FROM events ORDER BY seq ASC;
+  " 2>/dev/null | tr -d '\r' > "$file"
+}
+
+storage_import() {
+  local file="$1" db; db="$(_sqlite_db)"
+  [ -f "$file" ] || return 1
+  storage_init
+  local line t id team frm to body msg_id agent at
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    t=$(printf '%s' "$line" | sed -n 's/.*"type":"\([^"]*\)".*/\1/p')
+    j() { printf '%s' "$line" | sqlite3 :memory: "SELECT COALESCE(json_extract('$(_sqlite_lit "$line")','\$.$1'),'')" 2>/dev/null | tr -d '\r'; }
+    id=$(j id); team=$(j team); at=$(j at)
+    if [ "$t" = message_sent ]; then
+      frm=$(j from); to=$(j to); body=$(j body)
+      agmsg_sqlite "$db" "INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
+        VALUES ('message_sent','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
+                '$(_sqlite_lit "$frm")','$(_sqlite_lit "$to")','$(_sqlite_lit "$body")',
+                '$(_sqlite_lit "$at")');" >/dev/null 2>&1
+    elif [ "$t" = message_read ]; then
+      agent=$(j agent); msg_id=$(j msg_id)
+      agmsg_sqlite "$db" "INSERT INTO events (type,id,team,agent,msg_id,at)
+        VALUES ('message_read','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
+                '$(_sqlite_lit "$agent")','$(_sqlite_lit "$msg_id")','$(_sqlite_lit "$at")');" \
+        >/dev/null 2>&1
+    fi
+  done < "$file"
+}
+
+# Internal (§2.7): coalesce duplicate message_read markers, keeping the earliest.
+storage_compact() {
+  local db; db="$(_sqlite_db)"
+  agmsg_sqlite "$db" "
+    DELETE FROM events WHERE type='message_read' AND seq NOT IN (
+      SELECT MIN(seq) FROM events WHERE type='message_read'
+      GROUP BY team, agent, msg_id);
+  " >/dev/null 2>&1
+}

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -247,6 +247,9 @@ storage_history() {
 storage_export() {
   local file="$1"
   storage_init >/dev/null
+  # Forward-compat (§2.3): only the v1 event types are projected. A WHERE filter
+  # (not just a CASE) keeps unknown-type rows out entirely, so they never surface
+  # as a NULL → blank line on stdout, matching list_unread/history/watch_after.
   _sqlite_data "
     SELECT CASE type
       WHEN 'message_sent' THEN json_object('type','message_sent','id',id,'team',team,
@@ -254,7 +257,9 @@ storage_export() {
       WHEN 'message_read' THEN json_object('type','message_read','id',id,'team',team,
              'agent',agent,'msg_id',msg_id,'at',at)
     END
-    FROM events ORDER BY seq ASC;
+    FROM events
+    WHERE type IN ('message_sent','message_read')
+    ORDER BY seq ASC;
   " > "$file"
 }
 

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -653,7 +653,7 @@ class CodexBridge {
     this.pendingWake = false;
     this.watchHandle = null;
     this.wakeCount = 0;
-    this.lastWakeMaxId = 0;
+    this.lastWakeMaxId = "";
     this.staleWakeCount = 0;
     this.watchFailureCount = 0;
     this.watchRearmTimer = null;
@@ -1108,7 +1108,9 @@ class CodexBridge {
   }
 
   isStaleWake(maxId) {
-    if (maxId <= 0 || this.lastWakeMaxId !== maxId) {
+    // maxId is an OPAQUE token (the unread frontier id from watch-once), compared
+    // only for equality — never ordered. An empty token means "no unread".
+    if (!maxId || this.lastWakeMaxId !== maxId) {
       this.lastWakeMaxId = maxId;
       this.staleWakeCount = 0;
       return false;
@@ -1187,8 +1189,10 @@ function readPid(file) {
 }
 
 function parseMaxId(stdout) {
-  const match = String(stdout || "").match(/\bmax_id=([0-9]+)/);
-  return match ? Number(match[1]) : 0;
+  // max_id is now an opaque token (UUIDv7 / legacy decimal / any whitespace-free
+  // string), not an integer — return it verbatim for equality-only comparison.
+  const match = String(stdout || "").match(/\bmax_id=(\S+)/);
+  return match ? match[1] : "";
 }
 
 async function main() {

--- a/scripts/drivers/types/codex/watch-once.sh
+++ b/scripts/drivers/types/codex/watch-once.sh
@@ -57,7 +57,6 @@ source "$SCRIPT_DIR/../../../lib/resolve-project.sh"
 source "$SCRIPT_DIR/../../../lib/subscription.sh"
 
 PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
-DB="$(agmsg_db_path)"
 
 PAIRS="$(agmsg_subscription_pairs "$PROJECT_PATH" "$AGENT_TYPE" "" "$ACTIVE_NAME")" || exit 1
 if [ -n "$TEAM_FILTER" ]; then
@@ -72,13 +71,15 @@ fi
 deadline=$(( $(date +%s) + TIMEOUT ))
 
 while true; do
-  if [ -f "$DB" ]; then
+  if storage_store_exists; then
     # Unread across the subscription via the storage facade (§2.1, events ∪ legacy)
-    # — one storage_list_unread per pair, summed. max_id is an OPAQUE token: the
-    # greatest unread id across pairs, used by codex-bridge only for equality
-    # (stale-wake detection), never ordered. It is no longer an integer.
+    # — one storage_list_unread per pair, summed. max_id is an OPAQUE equality-only
+    # token for codex-bridge stale-wake detection (never ordered): a cksum DIGEST of
+    # the whole unread SET, so it changes whenever the set changes. A "greatest id"
+    # frontier could miss a set change under a backend whose ids aren't
+    # recency-ordered (jsonl); a set digest is robust on every backend.
     count=0
-    max_id=""
+    all_ids=""
     while IFS=$'\t' read -r _team _agent; do
       [ -n "$_team" ] && [ -n "$_agent" ] || continue
       u="$(storage_list_unread "$_team" "$_agent" 2>/dev/null || true)"
@@ -89,10 +90,13 @@ while true; do
       " 2>/dev/null || true)"
       [ -n "$ids" ] || continue
       count=$(( count + $(printf '%s\n' "$ids" | grep -c .) ))
-      pairmax="$(printf '%s\n' "$ids" | LC_ALL=C sort | tail -1)"
-      if [ -z "$max_id" ] || [ "$pairmax" \> "$max_id" ]; then max_id="$pairmax"; fi
+      all_ids="$all_ids$ids"$'\n'
     done <<< "$PAIRS"
     if [ "$count" -gt 0 ]; then
+      # cksum = POSIX (no shasum dep). Field 1 is whitespace-free for the bridge's
+      # `max_id=(\S+)` parse. The bridge only compares it within one session, so the
+      # checksum needn't be stable across platforms — only deterministic per run.
+      max_id="$(printf '%s' "$all_ids" | sed '/^$/d' | LC_ALL=C sort | cksum | cut -d' ' -f1)"
       printf 'status=pending count=%s max_id=%s\n' "$count" "$max_id"
       exit 0
     fi

--- a/scripts/drivers/types/codex/watch-once.sh
+++ b/scripts/drivers/types/codex/watch-once.sh
@@ -48,6 +48,7 @@ case "$INTERVAL" in ''|*[!0-9]*) echo "watch-once: --interval must be a whole nu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 source "$SCRIPT_DIR/../../../lib/storage.sh"
+agmsg_storage_load
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/../../../lib/actas-lock.sh"
 # shellcheck disable=SC1091
@@ -68,20 +69,29 @@ if [ -z "$PAIRS" ]; then
   exit 1
 fi
 
-WHERE_PAIRS="$(agmsg_subscription_where "$PAIRS")"
 deadline=$(( $(date +%s) + TIMEOUT ))
 
 while true; do
   if [ -f "$DB" ]; then
-    row="$(agmsg_sqlite -separator $'\t' "$DB" "
-      SELECT COUNT(*), COALESCE(MAX(id), 0)
-      FROM messages
-      WHERE read_at IS NULL AND ($WHERE_PAIRS);
-    " 2>/dev/null || true)"
-    count="${row%%$'\t'*}"
-    max_id="${row#*$'\t'}"
-    case "$count" in ''|*[!0-9]*) count=0 ;; esac
-    case "$max_id" in ''|*[!0-9]*) max_id=0 ;; esac
+    # Unread across the subscription via the storage facade (§2.1, events ∪ legacy)
+    # — one storage_list_unread per pair, summed. max_id is an OPAQUE token: the
+    # greatest unread id across pairs, used by codex-bridge only for equality
+    # (stale-wake detection), never ordered. It is no longer an integer.
+    count=0
+    max_id=""
+    while IFS=$'\t' read -r _team _agent; do
+      [ -n "$_team" ] && [ -n "$_agent" ] || continue
+      u="$(storage_list_unread "$_team" "$_agent" 2>/dev/null || true)"
+      [ -n "$u" ] || continue
+      uarr="[$(printf '%s' "$u" | paste -sd, -)]"
+      ids="$(agmsg_sqlite ':memory:' "
+        SELECT json_extract(value,'\$.id') FROM json_each('$(printf '%s' "$uarr" | sed "s/'/''/g")');
+      " 2>/dev/null || true)"
+      [ -n "$ids" ] || continue
+      count=$(( count + $(printf '%s\n' "$ids" | grep -c .) ))
+      pairmax="$(printf '%s\n' "$ids" | LC_ALL=C sort | tail -1)"
+      if [ -z "$max_id" ] || [ "$pairmax" \> "$max_id" ]; then max_id="$pairmax"; fi
+    done <<< "$PAIRS"
     if [ "$count" -gt 0 ]; then
       printf 'status=pending count=%s max_id=%s\n' "$count" "$max_id"
       exit 0

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -11,9 +11,10 @@ LIMIT="${3:-20}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 agmsg_storage_load
-DB="$(agmsg_db_path)"
 
-if [ ! -f "$DB" ]; then
+# Ask the active driver whether a store exists (driver-level, works for jsonl) —
+# a history read must not create one in a storeless project.
+if ! storage_store_exists; then
   echo "No messages (DB not initialized)"
   exit 0
 fi

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -10,6 +10,7 @@ LIMIT="${3:-20}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
+agmsg_storage_load
 DB="$(agmsg_db_path)"
 
 if [ ! -f "$DB" ]; then
@@ -17,25 +18,49 @@ if [ ! -f "$DB" ]; then
   exit 0
 fi
 
-if [ -n "$AGENT" ]; then
-  WHERE="WHERE team='$TEAM' AND (from_agent='$AGENT' OR to_agent='$AGENT')"
-else
-  WHERE="WHERE team='$TEAM'"
-fi
+# History (events ∪ legacy) via the facade; <agent> optional — omitted = whole
+# team (§2.1). The driver returns the most recent --limit records already in
+# chronological order, so no reversal here.
+HIST_JSONL=$(storage_history "$TEAM" "$AGENT" --limit "$LIMIT")
 
-# Escape newlines/tabs in body, use unit separator between fields
-RESULT=$(agmsg_sqlite "$DB" "
-  SELECT from_agent || char(31) || to_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at || char(31) || CASE WHEN read_at IS NULL THEN '●' ELSE '○' END
-  FROM messages $WHERE ORDER BY created_at DESC LIMIT $LIMIT;
-")
-
-if [ -z "$RESULT" ]; then
+if [ -z "$HIST_JSONL" ]; then
   echo "No message history."
   exit 0
 fi
 
-# Reverse order (oldest first) and display
-REVERSED=$(echo "$RESULT" | tail -r 2>/dev/null || echo "$RESULT" | tac 2>/dev/null || echo "$RESULT" | awk '{a[NR]=$0} END{for(i=NR;i>=1;i--)print a[i]}')
-while IFS=$'\x1f' read -r from to body ts status; do
+# Parse to "from \x1f to \x1f body \x1f at \x1f id" rows (no jq; cf. lib/hooks-json.sh).
+_arr="[$(printf '%s' "$HIST_JSONL" | paste -sd, -)]"
+ROWS=$(agmsg_sqlite ':memory:' "
+  SELECT json_extract(value,'\$.from') || char(31) ||
+         json_extract(value,'\$.to') || char(31) ||
+         replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
+         json_extract(value,'\$.at') || char(31) ||
+         json_extract(value,'\$.id')
+  FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+")
+
+# Read-state for the ●(unread)/○(read) marker (G2(c)): read-state is
+# recipient-scoped and not carried on a history record, so derive it by unioning
+# storage_list_unread over the distinct recipients in this slice. (Phase 1:
+# mark-read still lands in legacy read_at, which the facade UNION reflects.)
+RECIPIENTS=$(while IFS=$'\x1f' read -r _f to _rest; do
+  [ -n "$to" ] && printf '%s\n' "$to"
+done <<< "$ROWS" | sort -u)
+
+UNREAD_IDS=""
+while IFS= read -r r; do
+  [ -n "$r" ] || continue
+  u=$(storage_list_unread "$TEAM" "$r") || continue
+  [ -n "$u" ] || continue
+  uarr="[$(printf '%s' "$u" | paste -sd, -)]"
+  ids=$(agmsg_sqlite ':memory:' "
+    SELECT json_extract(value,'\$.id') FROM json_each('$(printf '%s' "$uarr" | sed "s/'/''/g")');
+  ")
+  UNREAD_IDS+="$ids"$'\n'
+done <<< "$RECIPIENTS"
+
+while IFS=$'\x1f' read -r from to body ts id; do
+  [ -n "$ts$from$to$body" ] || continue
+  if printf '%s\n' "$UNREAD_IDS" | grep -Fxq "$id"; then status='●'; else status='○'; fi
   echo "  $status [$ts] $from → $to: $body"
-done <<< "$REVERSED"
+done <<< "$ROWS"

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -15,11 +15,11 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 agmsg_storage_load
-DB="$(agmsg_db_path)"
 
 # Preserve the read-only "not initialized yet" behaviour: an inbox check must not
-# create the store, so guard on the file before touching the facade.
-if [ ! -f "$DB" ]; then
+# create the store. Ask the active driver whether one exists (driver-level, so it
+# works for jsonl's events.jsonl as well as sqlite's messages.db).
+if ! storage_store_exists; then
   if [ "$QUIET" = true ]; then exit 0; fi
   echo "No messages (DB not initialized)"
   exit 0

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -14,35 +14,51 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
+agmsg_storage_load
 DB="$(agmsg_db_path)"
 
+# Preserve the read-only "not initialized yet" behaviour: an inbox check must not
+# create the store, so guard on the file before touching the facade.
 if [ ! -f "$DB" ]; then
   if [ "$QUIET" = true ]; then exit 0; fi
   echo "No messages (DB not initialized)"
   exit 0
 fi
 
-# Get unread messages — escape newlines/tabs in body to keep one record per line
-UNREAD=$(agmsg_sqlite "$DB" "
-  SELECT from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
-  FROM messages WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL
-  ORDER BY created_at ASC;
-")
+# Unread comes from the storage facade (§2.1 storage_list_unread = the event log
+# UNION the legacy messages table), as one JSONL record per line in delivery
+# order. Parse it with sqlite's JSON funcs in a single pass — the repo idiom, no
+# jq dependency (cf. lib/hooks-json.sh).
+UNREAD_JSONL=$(storage_list_unread "$TEAM" "$AGENT")
 
-if [ -z "$UNREAD" ]; then
+if [ -z "$UNREAD_JSONL" ]; then
   if [ "$QUIET" = true ]; then exit 0; fi
   echo "No new messages."
   exit 0
 fi
 
-# Display
-COUNT=$(echo "$UNREAD" | wc -l | tr -d ' ')
+# JSONL -> JSON array -> "from \x1f body \x1f at" rows (newlines/tabs in the body
+# escaped so each message stays one display line).
+_arr="[$(printf '%s' "$UNREAD_JSONL" | paste -sd, -)]"
+ROWS=$(agmsg_sqlite ':memory:' "
+  SELECT json_extract(value,'\$.from') || char(31) ||
+         replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
+         json_extract(value,'\$.at')
+  FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+")
+
+COUNT=$(printf '%s\n' "$ROWS" | wc -l | tr -d ' ')
 echo "$COUNT new message(s):"
 echo ""
 while IFS=$'\x1f' read -r from body ts; do
+  [ -n "$ts$from$body" ] || continue
   echo "  [$ts] $from: $body"
-done <<< "$UNREAD"
+done <<< "$ROWS"
 echo ""
 
-# Mark as read (non-fatal — may fail in sandboxed environments)
+# Mark read — transitional legacy UPDATE, NOT storage_mark_read_batch yet. The
+# read-state writers (inbox/check-inbox) and the legacy-read_at readers that have
+# not migrated (watch-once, whose codex-bridge consumes an integer max_id cursor)
+# must flip together at step 3 (send → events + watch → facade). Marking via
+# events now would be invisible to those readers and split read-state. Non-fatal.
 agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -37,28 +37,31 @@ if [ -z "$UNREAD_JSONL" ]; then
   exit 0
 fi
 
-# JSONL -> JSON array -> "from \x1f body \x1f at" rows (newlines/tabs in the body
-# escaped so each message stays one display line).
+# JSONL -> JSON array -> "from \x1f body \x1f at \x1f id" rows (newlines/tabs in
+# the body escaped so each message stays one display line).
 _arr="[$(printf '%s' "$UNREAD_JSONL" | paste -sd, -)]"
 ROWS=$(agmsg_sqlite ':memory:' "
   SELECT json_extract(value,'\$.from') || char(31) ||
          replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
-         json_extract(value,'\$.at')
+         json_extract(value,'\$.at') || char(31) ||
+         json_extract(value,'\$.id')
   FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
 ")
 
 COUNT=$(printf '%s\n' "$ROWS" | wc -l | tr -d ' ')
 echo "$COUNT new message(s):"
 echo ""
-while IFS=$'\x1f' read -r from body ts; do
-  [ -n "$ts$from$body" ] || continue
+IDS=()
+while IFS=$'\x1f' read -r from body ts id; do
+  [ -n "$id" ] || continue
   echo "  [$ts] $from: $body"
+  IDS+=("$id")
 done <<< "$ROWS"
 echo ""
 
-# Mark read — transitional legacy UPDATE, NOT storage_mark_read_batch yet. The
-# read-state writers (inbox/check-inbox) and the legacy-read_at readers that have
-# not migrated (watch-once, whose codex-bridge consumes an integer max_id cursor)
-# must flip together at step 3 (send → events + watch → facade). Marking via
-# events now would be invisible to those readers and split read-state. Non-fatal.
-agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
+# Mark read via the storage facade (§2.1 storage_mark_read_batch): recipient-scoped
+# and idempotent. For a legacy id it records a message_read event without mutating
+# the legacy row (§2.4). Non-fatal — may fail in sandboxed environments.
+if [ "${#IDS[@]}" -gt 0 ]; then
+  storage_mark_read_batch "$TEAM" "$AGENT" "${IDS[@]}" >/dev/null 2>&1 || true
+fi

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -118,3 +118,66 @@ agmsg_sql_readfile_path() {
   fi
   printf '%s' "$path" | sed "s/'/''/g"
 }
+
+# ── Storage driver facade (storage axis) ─────────────────────────────────────
+# The helpers above resolve the legacy sqlite path and run raw SQL; call sites
+# keep using them until #206 migrates them onto the contract below. The facade
+# resolves the *active* storage driver, sources it, and makes the storage_*
+# contract (docs/spec/driver-interface.md §2 / ADR 0003) available. Driver
+# discovery + trust reuse the axis-generic registry (ADR 0002, driver-registry.sh).
+
+# Path to the machine-wide driver config (spec §4). Overridable for tests.
+_agmsg_storage_config_path() {
+  printf '%s\n' "${AGMSG_CONFIG:-$HOME/.agents/agmsg/config.json}"
+}
+
+# Active storage driver name: env override > config "storage" key > built-in.
+agmsg_storage_driver() {
+  if [ -n "${AGMSG_STORAGE_DRIVER:-}" ]; then
+    printf '%s\n' "$AGMSG_STORAGE_DRIVER"
+    return 0
+  fi
+  local cfg name
+  cfg="$(_agmsg_storage_config_path)"
+  if [ -n "$cfg" ] && [ -f "$cfg" ]; then
+    name="$(sqlite3 :memory: \
+      "SELECT COALESCE(json_extract(readfile('$(agmsg_sql_readfile_path "$cfg")'), '\$.storage'), '')" \
+      2>/dev/null | tr -d '\r')"
+    if [ -n "$name" ] && [ "$name" != "null" ]; then
+      printf '%s\n' "$name"
+      return 0
+    fi
+  fi
+  printf 'sqlite\n'
+}
+
+# Locate and source the active storage driver's storage_* functions. Idempotent.
+# Resolution reuses the registry search bases (in-tree builtins always trusted;
+# external plugin dirs gated by the opt-in trustfile, ADR 0002).
+_AGMSG_STORAGE_LOADED=""
+agmsg_storage_load() {
+  [ -n "$_AGMSG_STORAGE_LOADED" ] && return 0
+  # Pull in the axis-generic registry once (its functions may not be sourced yet).
+  if ! command -v agmsg_driver_bases >/dev/null 2>&1; then
+    local _lib
+    _lib="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+    # shellcheck disable=SC1091
+    [ -n "$_lib" ] && . "$_lib/driver-registry.sh"
+  fi
+  local name file kind base
+  name="$(agmsg_storage_driver)"
+  while IFS="$(printf '\t')" read -r kind base; do
+    [ -n "$base" ] || continue
+    file="$base/storage/$name.sh"
+    [ -f "$file" ] || continue
+    if [ "$kind" = external ] && ! agmsg_driver_is_trusted storage "$name" "$file"; then
+      continue
+    fi
+    # shellcheck disable=SC1090
+    . "$file"
+    _AGMSG_STORAGE_LOADED="$name"
+    return 0
+  done < <(agmsg_driver_bases)
+  printf 'agmsg: no trusted storage driver "%s" found\n' "$name" >&2
+  return 1
+}

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -119,6 +119,17 @@ agmsg_sql_readfile_path() {
   printf '%s' "$path" | sed "s/'/''/g"
 }
 
+# Escape an arbitrary scalar for safe interpolation into a SQL string literal
+# (double every single quote). Same semantics as the sqlite driver's internal
+# _sqlite_lit / storage_send escaping, but driver-agnostic and available to the
+# registry scripts that still write the legacy messages table directly
+# (rename.sh / rename-team.sh). A team or agent name may legitimately contain a
+# single quote (validate.sh only blocks path traversal), which would otherwise
+# break the INSERT/UPDATE and is an injection surface (#223, #87).
+agmsg_sqlesc() {
+  printf '%s' "$1" | sed "s/'/''/g"
+}
+
 # ── Storage driver facade (storage axis) ─────────────────────────────────────
 # The helpers above resolve the legacy sqlite path and run raw SQL; call sites
 # keep using them until #206 migrates them onto the contract below. The facade

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -71,23 +71,34 @@ fi
 mv "$OLD_DIR/config.json" "$NEW_DIR/config.json"
 
 # --- Update name in config.json ---
+# Read the config with readfile() (not `.param set`, whose dot-command tokenizer
+# does NOT honour SQL '' escaping, so an apostrophe in the config content breaks
+# the binding) and escape the new team name as a SQL string literal (#223, #87):
+# a team name may contain a single quote (validate.sh only blocks path traversal).
+# Mirrors join.sh's readfile-based, apostrophe-safe registry read.
 NEW_CONFIG="$NEW_DIR/config.json"
 if [ -f "$NEW_CONFIG" ]; then
-  CONFIG_ESCAPED=$(sed "s/'/''/g" "$NEW_CONFIG")
-  UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
-    "SELECT json_set(:json, '\$.name', '$NEW_TEAM');")
-  agmsg_write_atomic "$NEW_CONFIG" "$UPDATED"
+  CONFIG_SQL=$(agmsg_sql_readfile_path "$NEW_CONFIG")
+  NEW_TEAM_LIT=$(agmsg_sqlesc "$NEW_TEAM")
+  UPDATED=$(agmsg_sqlite_mem \
+    "SELECT json_set(CAST(readfile('$CONFIG_SQL') AS TEXT), '\$.name', '$NEW_TEAM_LIT');")
+  echo "$UPDATED" > "$NEW_CONFIG"
 fi
 
 # --- Update messages in DB ---
 # Rewrite the team name in BOTH stores: the event log (where storage_send now
 # writes) and the legacy messages table (pre-event-log installs). Without the
 # events update a rename would orphan every message sent after the storage flip.
+# Escape both team names as SQL string literals (#223, #87): a team name may
+# contain a single quote (validate.sh only blocks path traversal), which would
+# otherwise break the UPDATE and is an injection surface.
 if [ -f "$DB" ]; then
-  agmsg_sqlite "$DB" "UPDATE messages SET team='$(_agmsg_sqlesc "$NEW_TEAM")' WHERE team='$(_agmsg_sqlesc "$OLD_TEAM")';"
+  OLD_LIT=$(agmsg_sqlesc "$OLD_TEAM")
+  NEW_LIT=$(agmsg_sqlesc "$NEW_TEAM")
+  agmsg_sqlite "$DB" "UPDATE messages SET team='$NEW_LIT' WHERE team='$OLD_LIT';"
   # events may not exist yet on an install that has not sent since the storage
   # flip — best-effort, never abort the rename over a missing optional table.
-  agmsg_sqlite "$DB" "UPDATE events SET team='$(_agmsg_sqlesc "$NEW_TEAM")' WHERE team='$(_agmsg_sqlesc "$OLD_TEAM")';" 2>/dev/null || true
+  agmsg_sqlite "$DB" "UPDATE events SET team='$NEW_LIT' WHERE team='$OLD_LIT';" 2>/dev/null || true
 fi
 
 agmsg_lock_release

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -80,8 +80,14 @@ if [ -f "$NEW_CONFIG" ]; then
 fi
 
 # --- Update messages in DB ---
+# Rewrite the team name in BOTH stores: the event log (where storage_send now
+# writes) and the legacy messages table (pre-event-log installs). Without the
+# events update a rename would orphan every message sent after the storage flip.
 if [ -f "$DB" ]; then
   agmsg_sqlite "$DB" "UPDATE messages SET team='$(_agmsg_sqlesc "$NEW_TEAM")' WHERE team='$(_agmsg_sqlesc "$OLD_TEAM")';"
+  # events may not exist yet on an install that has not sent since the storage
+  # flip — best-effort, never abort the rename over a missing optional table.
+  agmsg_sqlite "$DB" "UPDATE events SET team='$(_agmsg_sqlesc "$NEW_TEAM")' WHERE team='$(_agmsg_sqlesc "$OLD_TEAM")';" 2>/dev/null || true
 fi
 
 agmsg_lock_release

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -58,9 +58,15 @@ UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
 agmsg_write_atomic "$TEAM_CONFIG" "$UPDATED"
 
 # --- Update messages in DB ---
+# Escape every interpolated value as a SQL string literal (#223, #87): an agent
+# or team name may contain a single quote, which would otherwise break the UPDATE
+# and is an injection surface (e.g. a name widening the WHERE predicate).
 if [ -f "$DB" ]; then
-  agmsg_sqlite "$DB" "UPDATE messages SET from_agent='$(_agmsg_sqlesc "$NEW_NAME")' WHERE team='$(_agmsg_sqlesc "$TEAM")' AND from_agent='$(_agmsg_sqlesc "$OLD_NAME")';"
-  agmsg_sqlite "$DB" "UPDATE messages SET to_agent='$(_agmsg_sqlesc "$NEW_NAME")' WHERE team='$(_agmsg_sqlesc "$TEAM")' AND to_agent='$(_agmsg_sqlesc "$OLD_NAME")';"
+  TEAM_LIT=$(agmsg_sqlesc "$TEAM")
+  OLD_LIT=$(agmsg_sqlesc "$OLD_NAME")
+  NEW_LIT=$(agmsg_sqlesc "$NEW_NAME")
+  agmsg_sqlite "$DB" "UPDATE messages SET from_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND from_agent='$OLD_LIT';"
+  agmsg_sqlite "$DB" "UPDATE messages SET to_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND to_agent='$OLD_LIT';"
 fi
 
 agmsg_lock_release

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -10,29 +10,18 @@ BODY="${4:?Missing message body}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
+agmsg_storage_load
 DB="$(agmsg_db_path)"
 
+# Keep the full-schema bootstrap (registry + storage tables) for a first-ever
+# command; the message write itself goes through the storage facade below.
 [ -f "$DB" ] || bash "$SCRIPT_DIR/internal/init-db.sh" >/dev/null
 
-# Escape EVERY interpolated value as a SQL string literal, not just body: a
-# team/agent name containing a single quote would otherwise break the INSERT
-# (correctness) or change its meaning (injection surface).
-_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
-INSERT="INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$(_agmsg_sqlesc "$TEAM")', '$(_agmsg_sqlesc "$FROM")', '$(_agmsg_sqlesc "$TO")', '$(_agmsg_sqlesc "$BODY")');"
-
-# Retry once after ensuring the schema. Under a concurrent first-write fan-out
-# (leader → N members against a fresh/override store), one process can see the
-# DB file exist before the winning initializer has finished creating the table,
-# so its INSERT would hit "no such table". init-db.sh is idempotent + uses the
-# busy_timeout, so re-running it waits for the schema, then the INSERT lands.
-# See #114.
-# Pipe the SQL via stdin (not as an argv) so a large body cannot overflow the
-# OS command-line limit (the "Argument list too long" crash).
-if ! printf '%s
-' "$INSERT" | agmsg_sqlite "$DB" 2>/dev/null; then
-  bash "$SCRIPT_DIR/internal/init-db.sh" >/dev/null
-  printf '%s
-' "$INSERT" | agmsg_sqlite "$DB"
-fi
+# Write through the storage axis (§2.1 storage_send) — the active driver now owns
+# the message log (an append-only message_sent event), not a direct INSERT.
+# storage_send re-inits its schema idempotently before writing, which subsumes the
+# #114 concurrent first-write race the old path retried around (a process seeing
+# the DB file before the table exists just creates it). The new id is not surfaced.
+storage_send "$TEAM" "$FROM" "$TO" "$BODY" >/dev/null
 
 echo "Sent to $TO in team $TEAM"

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -364,8 +364,12 @@ while true; do
           # despawn target) must NOT act on it — its $TMUX_PANE is the leader's
           # own pane, so killing it would take down the leader's session. The
           # spawned member's watcher runs in actas mode (ACTIVE_NAME=$to) in its
-          # own pane; that's the one meant to respond. The trailing cursor still
-          # advances the watermark past this control message at the batch end. See #109.
+          # own pane; that's the one meant to respond. A broad watcher `continue`s
+          # and reaches the trailing cursor at batch end, so its watermark advances
+          # past this control message. The target watcher below exits BEFORE the
+          # cursor record, so it does not persist a cursor — harmless, since it
+          # drops the role and won't resume as it; a same-session resume would
+          # re-read the despawn (at-least-once) and re-tear-down idempotently. See #109.
           if [ -z "$ACTIVE_NAME" ] || [ "$to" != "$ACTIVE_NAME" ]; then
             continue
           fi

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -45,6 +45,7 @@ ACTIVE_NAME="${4:-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
+agmsg_storage_load
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/actas-lock.sh"
 # shellcheck disable=SC1091
@@ -230,18 +231,13 @@ if [ -z "$PAIRS" ]; then
   exit 0
 fi
 
-# Build the SQL WHERE clause. Each pair contributes:
-#   (team='<team>' AND to_agent='<agent>')
-# joined by OR. Single quotes inside team/agent names are doubled for SQL.
-sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
-
-WHERE_PAIRS=""
+# SUB_PAIRS holds the subscription as <team>:<agent> tokens — the argument form
+# the storage facade's watch ops take (§2.2). Live delivery goes entirely through
+# storage_watch_tip / storage_watch_after now, so no SQL WHERE clause is built here.
+SUB_PAIRS=()
 while IFS=$'\t' read -r team agent; do
   [ -z "$team" ] && continue
-  t_esc=$(sql_escape "$team")
-  a_esc=$(sql_escape "$agent")
-  pair="(team='$t_esc' AND to_agent='$a_esc')"
-  WHERE_PAIRS="${WHERE_PAIRS:+$WHERE_PAIRS OR }$pair"
+  SUB_PAIRS+=("$team:$agent")
 done <<< "$PAIRS"
 
 # Determine the starting watermark.
@@ -259,20 +255,22 @@ done <<< "$PAIRS"
 # A *fresh* session (no persisted watermark) still starts from the current
 # MAX(id) — live push, no replay of history (the no-arg inbox check covers
 # historical unread, not this stream).
+# The watermark is now an OPAQUE delivery cursor (§2.2), not an integer id — the
+# active storage driver issues and interprets it; this script only persists the
+# latest token and passes it back unchanged.
 WATERMARK_FILE="$RUN_DIR/watch.$SESSION_ID.watermark"
 persist_watermark() { printf '%s\n' "$LAST" > "$WATERMARK_FILE" 2>/dev/null || true; }
 
 LAST=""
 if [ -f "$WATERMARK_FILE" ]; then
-  LAST="$(cat "$WATERMARK_FILE" 2>/dev/null || true)"
-  case "$LAST" in ''|*[!0-9]*) LAST="" ;; esac
+  # Opaque token: a single whitespace-free line. No integer validation — just
+  # strip stray surrounding whitespace.
+  LAST="$(tr -d '[:space:]' < "$WATERMARK_FILE" 2>/dev/null || true)"
 fi
 if [ -z "$LAST" ]; then
-  LAST=0
-  if [ -f "$DB" ]; then
-    LAST="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE $WHERE_PAIRS;" 2>/dev/null || echo 0)"
-  fi
-  case "$LAST" in ''|*[!0-9]*) LAST=0 ;; esac
+  # A fresh watcher starts from the current tip (live push, no history replay).
+  LAST="$(storage_watch_tip "${SUB_PAIRS[@]}" 2>/dev/null || true)"
+  case "$LAST" in '') LAST=0 ;; esac
   persist_watermark
 fi
 
@@ -323,16 +321,36 @@ while true; do
     exit 0
   fi
   if [ -f "$DB" ]; then
-    ROWS="$(agmsg_sqlite -separator $'\x1f' "$DB" "
-      SELECT id, created_at, team, from_agent, to_agent,
-             replace(replace(body, char(13), ''), char(10), '\\n')
-      FROM messages
-      WHERE id > $LAST AND ($WHERE_PAIRS)
-      ORDER BY id;
-    " 2>/dev/null || true)"
+    # Pull messages after the cursor via the storage facade (§2.2). The output is
+    # JSONL: zero or more message_sent records in delivery order, then a trailing
+    # {"type":"cursor","cursor":"<token>"} as the LAST line — the position to
+    # resume from. Parse every record in one pass with sqlite's JSON funcs (the
+    # repo idiom; no jq). Newlines/tabs in the body are escaped to keep one line.
+    OUT="$(storage_watch_after "$LAST" "${SUB_PAIRS[@]}" 2>/dev/null || true)"
+    if [ -n "$OUT" ]; then
+      _arr="[$(printf '%s' "$OUT" | paste -sd, -)]"
+      ROWS="$(agmsg_sqlite ':memory:' "
+        SELECT COALESCE(json_extract(value,'\$.type'),'') || char(31) ||
+               COALESCE(json_extract(value,'\$.id'),'') || char(31) ||
+               COALESCE(json_extract(value,'\$.at'),'') || char(31) ||
+               COALESCE(json_extract(value,'\$.team'),'') || char(31) ||
+               COALESCE(json_extract(value,'\$.from'),'') || char(31) ||
+               COALESCE(json_extract(value,'\$.to'),'') || char(31) ||
+               replace(replace(replace(COALESCE(json_extract(value,'\$.body'),''), char(13), ''), char(10), '\\n'), char(9), '\t') || char(31) ||
+               COALESCE(json_extract(value,'\$.cursor'),'')
+        FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+      " 2>/dev/null || true)"
 
-    if [ -n "$ROWS" ]; then
-      while IFS=$'\x1f' read -r id ts team from to body; do
+      while IFS=$'\x1f' read -r kind id ts team from to body cursor; do
+        [ -z "$kind" ] && continue
+        if [ "$kind" = "cursor" ]; then
+          # Trailing cursor = the resume point. Advance + persist only after the
+          # batch's messages were delivered above; a crash mid-batch re-delivers
+          # from the old cursor (at-least-once, never skip — §2.2).
+          LAST="$cursor"; persist_watermark
+          continue
+        fi
+        [ "$kind" = "message_sent" ] || continue
         [ -z "$id" ] && continue
         # Control message: a leader's `despawn` sends `ctrl:despawn` to this
         # role. Tear ourselves down rather than printing it — drop the role
@@ -340,14 +358,14 @@ while true; do
         # which also ends the agent CLI sharing it. Deterministic teardown, no
         # dependence on the agent LLM noticing the message. See #109.
         if [ "$body" = "ctrl:despawn" ]; then
-          LAST="$id"; persist_watermark
           # Only an EXCLUSIVE watcher dedicated to exactly this role tears
           # itself down. A broad-subscription watcher (e.g. a leader whose
           # default watcher subscribes to every project role, including the
           # despawn target) must NOT act on it — its $TMUX_PANE is the leader's
           # own pane, so killing it would take down the leader's session. The
           # spawned member's watcher runs in actas mode (ACTIVE_NAME=$to) in its
-          # own pane; that's the one meant to respond. See #109.
+          # own pane; that's the one meant to respond. The trailing cursor still
+          # advances the watermark past this control message at the batch end. See #109.
           if [ -z "$ACTIVE_NAME" ] || [ "$to" != "$ACTIVE_NAME" ]; then
             continue
           fi
@@ -363,8 +381,6 @@ while true; do
           cleanup
           exit 0
         fi
-        LAST="$id"
-        persist_watermark
       done <<< "$ROWS"
     fi
   fi

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -840,11 +840,12 @@ JSON
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" t-sid "$TEST_PROJECT" claude-code bob > /tmp/agmsg-as-bob 2>&1 &
   local pid=$!
-  # High-water-mark = MAX(id) at startup, so prior messages aren't replayed.
-  # Insert NEW messages and wait for several poll iterations.
+  # The watcher seeds its cursor from the storage tip at startup, so prior
+  # messages aren't replayed. Send NEW messages through the facade (storage_send
+  # writes the event log the watcher now streams) and wait for several polls.
   sleep 1
-  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'system', 'alice', 'new-for-alice');"
-  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'system', 'bob', 'new-for-bob');"
+  bash "$SCRIPTS/send.sh" myteam system alice "new-for-alice" >/dev/null
+  bash "$SCRIPTS/send.sh" myteam system bob "new-for-bob" >/dev/null
   sleep 3
   kill -TERM "$pid" 2>/dev/null
   wait "$pid" 2>/dev/null || true
@@ -942,10 +943,10 @@ JSON
   # Join `bob` to the same (project, type) after the watcher is running.
   bash "$SCRIPTS/join.sh" myteam bob claude-code "$TEST_PROJECT"
 
-  # Insert messages for both. alice should arrive (alice was in the original
-  # subscription set); bob should NOT arrive (joined after launch).
-  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'sys', 'alice', 'for-alice-static');"
-  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'sys', 'bob',   'for-bob-static');"
+  # Send messages for both via the facade. alice should arrive (alice was in the
+  # original subscription set); bob should NOT arrive (joined after launch).
+  bash "$SCRIPTS/send.sh" myteam sys alice "for-alice-static" >/dev/null
+  bash "$SCRIPTS/send.sh" myteam sys bob   "for-bob-static" >/dev/null
 
   sleep 3
   kill -TERM "$pid" 2>/dev/null

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -141,7 +141,7 @@ SH
   wait
   local n
   n=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" \
-    "SELECT COUNT(*) FROM messages WHERE from_agent='leader';")
+    "SELECT COUNT(*) FROM events WHERE type='message_sent' AND from_agent='leader';")
   [ "$n" -eq 10 ]
 }
 
@@ -156,6 +156,6 @@ SH
   done
   wait
   local n
-  n=$(sqlite3 "$AGMSG_STORAGE_PATH/messages.db" "SELECT COUNT(*) FROM messages;")
+  n=$(sqlite3 "$AGMSG_STORAGE_PATH/messages.db" "SELECT COUNT(*) FROM events WHERE type='message_sent';")
   [ "$n" -eq 10 ]
 }

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -95,6 +95,34 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [[ "$output" == *h2* ]]
 }
 
+@test "contract: history without an agent returns the whole team (§2.1 G3)" {
+  storage_send agsuite alice bob "tw1"
+  storage_send agsuite carol dave "tw2"   # involves neither alice nor bob
+  run storage_history agsuite              # omitted agent = whole team
+  [ "$status" -eq 0 ]
+  [[ "$output" == *tw1* ]]
+  [[ "$output" == *tw2* ]]
+  # the agent-scoped form still filters (additive, existing behaviour intact)
+  run storage_history agsuite carol
+  [[ "$output" == *tw2* ]]
+  [[ "$output" != *tw1* ]]
+}
+
+@test "contract: history --limit returns the most recent N in chronological order" {
+  storage_send agsuite alice bob "old1"
+  storage_send agsuite alice bob "old2"
+  storage_send agsuite alice bob "new3"
+  run storage_history agsuite bob --limit 2
+  [ "$status" -eq 0 ]
+  [[ "$output" == *old2* ]]      # the two most recent
+  [[ "$output" == *new3* ]]
+  [[ "$output" != *old1* ]]      # the oldest dropped
+  local l2 l3
+  l2=$(printf '%s\n' "$output" | grep -n old2 | head -1 | cut -d: -f1)
+  l3=$(printf '%s\n' "$output" | grep -n new3 | head -1 | cut -d: -f1)
+  [ "$l2" -lt "$l3" ]            # chronological order, not reverse
+}
+
 @test "contract: export then import round-trips the event log" {
   local id; id=$(storage_send agsuite alice bob "keep")
   storage_mark_read_batch agsuite bob "$id"

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -198,6 +198,19 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   fi
   run storage_list_unread agsuite bob
   [ "$status" -ne 0 ]
+  run storage_watch_tip agsuite:bob   # the tip read must also fail, not report 0
+  [ "$status" -ne 0 ]
+}
+
+@test "contract(jsonl): mark_read_batch fails non-zero when the lock is unavailable" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = jsonl ] || skip "jsonl-specific (mkdir write lock)"
+  local id; id=$(storage_send agsuite alice bob "x")
+  # Hold the write lock so the mark can't acquire it; cap retries so it fails fast.
+  mkdir "$(dirname "$(agmsg_db_path)")/events.jsonl.lock"
+  AGMSG_JSONL_LOCK_TRIES=2 run storage_mark_read_batch agsuite bob "$id"
+  rmdir "$(dirname "$(agmsg_db_path)")/events.jsonl.lock" 2>/dev/null || true
+  [ "$status" -ne 0 ]                  # control op surfaces the failure
+  [[ "$output" != *ok* ]]             # never a false "ok"
 }
 
 # --- compaction contract (§2.7) --------------------------------------------

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -213,26 +213,68 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
 
 # --- sqlite-specific: compaction physically shrinks the log -----------------
 
-@test "contract(sqlite): compact coalesces duplicate read markers and shrinks the log" {
+@test "contract(sqlite): compact coalesces tail duplicates AND high-water keeps the tip/cursor safe" {
+  # This is the test that actually EXERCISES cursor-safety: mark_read_batch is
+  # write-idempotent, so the driver-agnostic cursor tests above never create the
+  # tail-duplicate rows whose deletion would regress a naive MAX(seq) tip. Here we
+  # inject those duplicates directly (the highest seqs in the log), then compact —
+  # the case that distinguishes the AUTOINCREMENT high-water from MAX(seq).
   local db; db="$(agmsg_db_path)"
-  local id; id=$(storage_send agsuite alice bob "s1")
-  # mark_read_batch is write-idempotent (a NOT EXISTS guard), so duplicate
-  # message_read rows only arise from a racing writer or a merged import. Inject
-  # them directly — that race/import residue is exactly what compact cleans up.
+  storage_send agsuite alice bob "s1"
+  # cursor taken before a later send — must still deliver that later message.
+  local cur0; cur0=$(storage_watch_tip agsuite:bob)
+  storage_send agsuite alice bob "s2-late"
+  local id; id=$(storage_send agsuite alice bob "s3")
+  # duplicate read markers as the TAIL rows (highest seq): compact deletes these,
+  # dropping MAX(seq) but NOT the high-water.
   agmsg_sqlite "$db" "INSERT INTO events (type,id,team,agent,msg_id,at) VALUES
     ('message_read','r1','agsuite','bob','$id','2026-01-01T00:00:01Z'),
     ('message_read','r2','agsuite','bob','$id','2026-01-01T00:00:02Z'),
     ('message_read','r3','agsuite','bob','$id','2026-01-01T00:00:03Z');"
-  local reads_before total_before
+  local reads_before total_before tip_before
   reads_before=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events WHERE type='message_read';" | tr -d '\r')
   total_before=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events;" | tr -d '\r')
+  tip_before=$(storage_watch_tip agsuite:bob)
   [ "$reads_before" -eq 3 ]
+
   storage_compact
-  local reads_after total_after
+
+  local reads_after total_after tip_after
   reads_after=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events WHERE type='message_read';" | tr -d '\r')
   total_after=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events;" | tr -d '\r')
+  tip_after=$(storage_watch_tip agsuite:bob)
   [ "$reads_after" -eq 1 ]                 # coalesced to one
-  [ "$total_after" -lt "$total_before" ]   # strictly shrank (2 dupes removed)
+  [ "$total_after" -lt "$total_before" ]   # strictly shrank (2 tail dupes removed)
+  # high-water: the tip did NOT regress even though the tail rows (= old MAX seq)
+  # were deleted. A MAX(seq) implementation would fail here.
+  [ "$tip_after" -ge "$tip_before" ]
+  # and the cursor issued before s2-late still delivers it — no message_sent lost.
+  run storage_watch_after "$cur0" agsuite:bob
+  [[ "$output" == *"s2-late"* ]]
+}
+
+@test "contract(sqlite): forward-compat — export/list/history ignore an unknown event type" {
+  local db; db="$(agmsg_db_path)"
+  storage_send agsuite alice bob "known"
+  # a v2-style event a v1 reader has never seen — must be skipped, not leaked.
+  agmsg_sqlite "$db" "INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
+    VALUES ('message_reaction','x1','agsuite','bob','alice','👍','2026-02-02T00:00:00Z');"
+  # export stays clean JSONL: no blank line, no unknown type, every line valid JSON.
+  local f="$TEST_SKILL_DIR/fc.jsonl"
+  storage_export "$f"
+  [ "$(grep -c '^$' "$f")" -eq 0 ]          # no blank line leaked by the unknown type
+  ! grep -q 'message_reaction' "$f"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    [ "$(sqlite3 :memory: "SELECT json_valid('$(printf '%s' "$line" | sed "s/'/''/g")')")" = "1" ]
+  done < "$f"
+  # the known message is still visible; the unknown event perturbs nothing.
+  run storage_list_unread agsuite bob
+  [[ "$output" == *known* ]]
+  [[ "$output" != *message_reaction* ]]
+  run storage_history agsuite bob
+  [[ "$output" == *known* ]]
+  [[ "$output" != *message_reaction* ]]
 }
 
 # --- sqlite-specific: legacy messages-table compatibility (§2.4) ------------

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -118,3 +118,65 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
     [ "$(sqlite3 :memory: "SELECT json_valid('$(printf '%s' "$line" | sed "s/'/''/g")')")" = "1" ]
   done <<< "$output"
 }
+
+@test "contract: list_unread / history records carry a type field" {
+  storage_send agsuite alice bob "t1"
+  run storage_list_unread agsuite bob
+  [[ "$output" == *'"type":"message_sent"'* ]]
+  run storage_history agsuite bob
+  [[ "$output" == *'"type":"message_sent"'* ]]
+}
+
+@test "contract: the delivery cursor is a single whitespace-free token" {
+  local tip; tip=$(storage_watch_tip agsuite:bob)
+  [ -n "$tip" ]
+  [ "$(printf '%s' "$tip" | wc -l | tr -d ' ')" = "0" ]   # one line, no trailing newline
+  [[ "$tip" != *" "* ]]
+  [[ "$tip" != *$'\t'* ]]
+}
+
+@test "contract: watch_after's trailing cursor record is the final line" {
+  local tip; tip=$(storage_watch_tip agsuite:bob)
+  storage_send agsuite alice bob "w1"
+  local out; out=$(storage_watch_after "$tip" agsuite:bob)
+  [[ "$(printf '%s\n' "$out" | tail -1)" == *'"type":"cursor"'* ]]
+}
+
+@test "contract: a data op fails non-zero on a broken store (no silent success)" {
+  # pipefail must surface the backend error instead of tr swallowing it.
+  local db; db="$(agmsg_db_path)"
+  rm -f "$db"-wal "$db"-shm
+  printf 'not a sqlite database' > "$db"
+  run storage_list_unread agsuite bob
+  [ "$status" -ne 0 ]
+}
+
+# --- sqlite-specific: legacy messages-table compatibility (§2.4) ------------
+# These assert the sqlite driver's read-only UNION of the pre-event-log store;
+# they are intentionally NOT driver-agnostic (a fresh jsonl/redis store has no
+# legacy table). Existing installs must keep their inbox + history at cutover.
+
+@test "contract(sqlite): legacy messages rows surface in unread and history" {
+  local db; db="$(agmsg_db_path)"
+  agmsg_sqlite "$db" "INSERT INTO messages (team,from_agent,to_agent,body,read_at)
+    VALUES ('agsuite','alice','bob','legacy-unread',NULL),
+           ('agsuite','alice','bob','legacy-read','2026-01-01T00:00:00Z');"
+  run storage_list_unread agsuite bob
+  [[ "$output" == *legacy-unread* ]]
+  [[ "$output" != *legacy-read* ]]
+  run storage_history agsuite bob
+  [[ "$output" == *legacy-unread* ]]
+  [[ "$output" == *legacy-read* ]]
+}
+
+@test "contract(sqlite): marking a legacy id read hides it without mutating the row" {
+  local db; db="$(agmsg_db_path)"
+  agmsg_sqlite "$db" "INSERT INTO messages (team,from_agent,to_agent,body)
+    VALUES ('agsuite','alice','bob','legacy-x');"
+  local lid; lid=$(agmsg_sqlite "$db" "SELECT id FROM messages WHERE body='legacy-x';" | tr -d '\r')
+  storage_mark_read_batch agsuite bob "$lid"
+  run storage_list_unread agsuite bob
+  [[ "$output" != *legacy-x* ]]
+  # the legacy row is never mutated (read_at stays NULL) — no destructive migration.
+  [ -z "$(agmsg_sqlite "$db" "SELECT read_at FROM messages WHERE body='legacy-x';" | tr -d '\r')" ]
+}

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -151,6 +151,90 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [ "$status" -ne 0 ]
 }
 
+# --- compaction contract (§2.7) --------------------------------------------
+# These pin storage_compact's behavioural guarantees through the facade, so they
+# hold for every driver: idempotent, state-preserving, cursor-safe, monotonic tip.
+
+@test "contract: compact is state-preserving (unread + history unchanged)" {
+  local a b c
+  a=$(storage_send agsuite alice bob "p1")
+  b=$(storage_send agsuite alice bob "p2")
+  c=$(storage_send agsuite bob alice "p3")
+  storage_mark_read_batch agsuite bob "$a"
+  # redundant markers — fodder compaction should coalesce away invisibly
+  storage_mark_read_batch agsuite bob "$a"
+  storage_mark_read_batch agsuite bob "$a"
+  local unread_before history_before
+  unread_before=$(storage_list_unread agsuite bob)
+  history_before=$(storage_history agsuite bob)
+  storage_compact
+  [ "$(storage_list_unread agsuite bob)" = "$unread_before" ]
+  [ "$(storage_history agsuite bob)" = "$history_before" ]
+}
+
+@test "contract: compact is idempotent (second compact is a no-op for visible state)" {
+  local id; id=$(storage_send agsuite alice bob "i1")
+  storage_mark_read_batch agsuite bob "$id"
+  storage_mark_read_batch agsuite bob "$id"
+  storage_compact
+  local after_one; after_one=$(storage_export "$TEST_SKILL_DIR/c1.jsonl"; cat "$TEST_SKILL_DIR/c1.jsonl")
+  storage_compact
+  storage_export "$TEST_SKILL_DIR/c2.jsonl"
+  [ "$(cat "$TEST_SKILL_DIR/c2.jsonl")" = "$after_one" ]
+}
+
+@test "contract: compact is cursor-safe (a pre-compact cursor skips nothing)" {
+  local tip; tip=$(storage_watch_tip agsuite:bob)
+  storage_send agsuite alice bob "c1"
+  storage_send agsuite alice bob "c2"
+  # pile up redundant read markers AFTER the sends, so compaction deletes the
+  # highest-seq rows — the case that would regress a naive MAX(seq) cursor.
+  local x; x=$(storage_send agsuite alice carol "noise")
+  storage_mark_read_batch agsuite carol "$x"
+  storage_mark_read_batch agsuite carol "$x"
+  storage_mark_read_batch agsuite carol "$x"
+  storage_compact
+  run storage_watch_after "$tip" agsuite:bob
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"c1"* ]]
+  [[ "$output" == *"c2"* ]]
+}
+
+@test "contract: the delivery tip never regresses across a compact (monotonic)" {
+  storage_send agsuite alice bob "m1"
+  local id; id=$(storage_send agsuite alice bob "m2")
+  storage_mark_read_batch agsuite bob "$id"
+  storage_mark_read_batch agsuite bob "$id"   # redundant tail markers
+  local tip_before; tip_before=$(storage_watch_tip agsuite:bob)
+  storage_compact
+  local tip_after; tip_after=$(storage_watch_tip agsuite:bob)
+  [ "$tip_after" -ge "$tip_before" ]
+}
+
+# --- sqlite-specific: compaction physically shrinks the log -----------------
+
+@test "contract(sqlite): compact coalesces duplicate read markers and shrinks the log" {
+  local db; db="$(agmsg_db_path)"
+  local id; id=$(storage_send agsuite alice bob "s1")
+  # mark_read_batch is write-idempotent (a NOT EXISTS guard), so duplicate
+  # message_read rows only arise from a racing writer or a merged import. Inject
+  # them directly — that race/import residue is exactly what compact cleans up.
+  agmsg_sqlite "$db" "INSERT INTO events (type,id,team,agent,msg_id,at) VALUES
+    ('message_read','r1','agsuite','bob','$id','2026-01-01T00:00:01Z'),
+    ('message_read','r2','agsuite','bob','$id','2026-01-01T00:00:02Z'),
+    ('message_read','r3','agsuite','bob','$id','2026-01-01T00:00:03Z');"
+  local reads_before total_before
+  reads_before=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events WHERE type='message_read';" | tr -d '\r')
+  total_before=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events;" | tr -d '\r')
+  [ "$reads_before" -eq 3 ]
+  storage_compact
+  local reads_after total_after
+  reads_after=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events WHERE type='message_read';" | tr -d '\r')
+  total_after=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events;" | tr -d '\r')
+  [ "$reads_after" -eq 1 ]                 # coalesced to one
+  [ "$total_after" -lt "$total_before" ]   # strictly shrank (2 dupes removed)
+}
+
 # --- sqlite-specific: legacy messages-table compatibility (§2.4) ------------
 # These assert the sqlite driver's read-only UNION of the pre-event-log store;
 # they are intentionally NOT driver-agnostic (a fresh jsonl/redis store has no

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -181,10 +181,15 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
 }
 
 @test "contract: a data op fails non-zero on a broken store (no silent success)" {
-  # pipefail must surface the backend error instead of tr swallowing it.
-  local db; db="$(agmsg_db_path)"
-  rm -f "$db"-wal "$db"-shm
-  printf 'not a sqlite database' > "$db"
+  # A backend error must surface as a non-zero exit, never a silent empty result.
+  # Corruption is store-specific, so break whichever store the active driver reads.
+  if [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = jsonl ]; then
+    printf 'not json at all {{{\n' > "$(dirname "$(agmsg_db_path)")/events.jsonl"
+  else
+    local db; db="$(agmsg_db_path)"
+    rm -f "$db"-wal "$db"-shm
+    printf 'not a sqlite database' > "$db"
+  fi
   run storage_list_unread agsuite bob
   [ "$status" -ne 0 ]
 }
@@ -252,6 +257,7 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
 # --- sqlite-specific: compaction physically shrinks the log -----------------
 
 @test "contract(sqlite): compact coalesces tail duplicates AND high-water keeps the tip/cursor safe" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = sqlite ] || skip "sqlite-specific (direct events-table injection / high-water)"
   # This is the test that actually EXERCISES cursor-safety: mark_read_batch is
   # write-idempotent, so the driver-agnostic cursor tests above never create the
   # tail-duplicate rows whose deletion would regress a naive MAX(seq) tip. Here we
@@ -292,6 +298,7 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
 }
 
 @test "contract(sqlite): forward-compat — export/list/history ignore an unknown event type" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = sqlite ] || skip "sqlite-specific (direct events-table injection)"
   local db; db="$(agmsg_db_path)"
   storage_send agsuite alice bob "known"
   # a v2-style event a v1 reader has never seen — must be skipped, not leaked.
@@ -321,6 +328,7 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
 # legacy table). Existing installs must keep their inbox + history at cutover.
 
 @test "contract(sqlite): legacy messages rows surface in unread and history" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = sqlite ] || skip "sqlite-specific (legacy messages table)"
   local db; db="$(agmsg_db_path)"
   agmsg_sqlite "$db" "INSERT INTO messages (team,from_agent,to_agent,body,read_at)
     VALUES ('agsuite','alice','bob','legacy-unread',NULL),
@@ -334,6 +342,7 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
 }
 
 @test "contract(sqlite): marking a legacy id read hides it without mutating the row" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = sqlite ] || skip "sqlite-specific (legacy messages table)"
   local db; db="$(agmsg_db_path)"
   agmsg_sqlite "$db" "INSERT INTO messages (team,from_agent,to_agent,body)
     VALUES ('agsuite','alice','bob','legacy-x');"

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -27,6 +27,12 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [[ "$output" == *ok* ]]
 }
 
+@test "contract: storage_store_exists is true once the store is initialized" {
+  # setup() ran storage_init, so the active driver's store is present.
+  run storage_store_exists
+  [ "$status" -eq 0 ]
+}
+
 @test "contract: send returns an id and list_unread shows the message" {
   local id; id=$(storage_send agsuite alice bob "hi")
   [ -n "$id" ]

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# Driver-agnostic storage-contract tests (docs/spec/driver-interface.md §2,
+# ADR 0003). They exercise the storage_* contract through the facade, so the
+# SAME tests pin every driver: they run against the built-in sqlite driver here,
+# and `AGMSG_STORAGE_DRIVER=<name> bats tests/test_storage_contract.bats` runs the
+# identical contract against jsonl / redis once those land.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  storage_init
+}
+
+teardown() { teardown_test_env; }
+
+# pull the cursor token out of a watch_after stream's trailing cursor record
+_cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]*\)".*/\1/p'; }
+
+@test "contract: storage_check reports ok" {
+  run storage_check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "contract: send returns an id and list_unread shows the message" {
+  local id; id=$(storage_send agsuite alice bob "hi")
+  [ -n "$id" ]
+  run storage_list_unread agsuite bob
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"body":"hi"'* ]]
+  [[ "$output" == *"$id"* ]]
+}
+
+@test "contract: mark_read_batch is idempotent (double mark is a no-op)" {
+  local id; id=$(storage_send agsuite alice bob "x")
+  storage_mark_read_batch agsuite bob "$id"
+  run storage_list_unread agsuite bob
+  [ -z "$output" ]
+  # Re-marking the same id changes nothing — still read, no error.
+  storage_mark_read_batch agsuite bob "$id"
+  run storage_list_unread agsuite bob
+  [ -z "$output" ]
+}
+
+@test "contract: mark_read is recipient-scoped (one agent's read doesn't hide another's)" {
+  local m; m=$(storage_send agsuite alice carol "for carol")
+  # bob records a read of carol's message id — scoped to bob, so carol is unaffected.
+  storage_mark_read_batch agsuite bob "$m"
+  run storage_list_unread agsuite carol
+  [[ "$output" == *"for carol"* ]]
+}
+
+@test "contract: watch_tip + watch_after deliver only post-tip messages, with a cursor" {
+  storage_send agsuite alice bob "before"
+  local tip; tip=$(storage_watch_tip agsuite:bob)
+  storage_send agsuite alice bob "after"
+  run storage_watch_after "$tip" agsuite:bob
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"body":"after"'* ]]
+  [[ "$output" != *'"body":"before"'* ]]
+  [[ "$output" == *'"type":"cursor"'* ]]
+}
+
+@test "contract: watch_after advances the cursor even with zero matching messages" {
+  local tip; tip=$(storage_watch_tip agsuite:bob)
+  storage_send agsuite alice carol "off-subscription"
+  run storage_watch_after "$tip" agsuite:bob
+  [ "$status" -eq 0 ]
+  [[ "$output" != *message_sent* ]]
+  local newcur; newcur=$(_cursor_of "$output")
+  [ -n "$newcur" ]
+  [ "$newcur" != "$tip" ]
+}
+
+@test "contract: cursor round-trips — re-watching from it does not re-scan" {
+  local tip; tip=$(storage_watch_tip agsuite:bob)
+  storage_send agsuite alice bob "m1"
+  local out1; out1=$(storage_watch_after "$tip" agsuite:bob)
+  [[ "$out1" == *m1* ]]
+  local cur1; cur1=$(_cursor_of "$out1")
+  run storage_watch_after "$cur1" agsuite:bob
+  [[ "$output" != *m1* ]]
+}
+
+@test "contract: history returns messages involving the agent" {
+  storage_send agsuite alice bob "h1"
+  storage_send agsuite bob alice "h2"
+  run storage_history agsuite bob
+  [[ "$output" == *h1* ]]
+  [[ "$output" == *h2* ]]
+}
+
+@test "contract: export then import round-trips the event log" {
+  local id; id=$(storage_send agsuite alice bob "keep")
+  storage_mark_read_batch agsuite bob "$id"
+  local f="$TEST_SKILL_DIR/export.jsonl"
+  storage_export "$f"
+  [ -s "$f" ]
+  rm -f "$TEST_SKILL_DIR"/db/messages.db*
+  storage_init
+  storage_import "$f"
+  run storage_history agsuite bob
+  [[ "$output" == *keep* ]]
+}
+
+@test "contract: record-returning ops emit pure JSONL (no status word on stdout)" {
+  storage_send agsuite alice bob "j1"
+  run storage_list_unread agsuite bob
+  [ "$status" -eq 0 ]
+  local line
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    [ "$(sqlite3 :memory: "SELECT json_valid('$(printf '%s' "$line" | sed "s/'/''/g")')")" = "1" ]
+  done <<< "$output"
+}

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -213,6 +213,15 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [[ "$output" != *ok* ]]             # never a false "ok"
 }
 
+@test "contract(jsonl): mark_read_batch fails non-zero on a corrupt log" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = jsonl ] || skip "jsonl-specific (corrupt JSONL)"
+  storage_send agsuite alice bob "x" >/dev/null
+  printf 'not json {{{\n' > "$(dirname "$(agmsg_db_path)")/events.jsonl"
+  run storage_mark_read_batch agsuite bob someid
+  [ "$status" -ne 0 ]                  # the existing-reads scan failure aborts the mark
+  [[ "$output" != *ok* ]]
+}
+
 # --- compaction contract (§2.7) --------------------------------------------
 # These pin storage_compact's behavioural guarantees through the facade, so they
 # hold for every driver: idempotent, state-preserving, cursor-safe, monotonic tip.

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -123,6 +123,16 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [ "$l2" -lt "$l3" ]            # chronological order, not reverse
 }
 
+@test "contract: history <team> --limit (no agent) treats --limit as a flag, not the agent" {
+  storage_send agsuite alice bob "p1"
+  storage_send agsuite carol dave "p2"
+  run storage_history agsuite --limit 1     # --limit must NOT be consumed as <agent>
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c .)" -eq 1 ]   # exactly one record (team-wide)
+  [[ "$output" == *'"type":"message_sent"'* ]]         # pure JSONL, not a parse error
+  [ "$(sqlite3 :memory: "SELECT json_valid('$(printf '%s' "$output" | sed "s/'/''/g")')")" = "1" ]
+}
+
 @test "contract: export then import round-trips the event log" {
   local id; id=$(storage_send agsuite alice bob "keep")
   storage_mark_read_batch agsuite bob "$id"

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -213,6 +213,20 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [[ "$output" != *ok* ]]             # never a false "ok"
 }
 
+@test "contract(jsonl): compact keys reads by tuple, not a space-join (no collision)" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = jsonl ] || skip "jsonl-specific (compaction key)"
+  storage_init
+  local log; log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  # Two DISTINCT (team, agent, msg_id) tuples that a space-joined key would merge:
+  #   ("a b","c","1")  and  ("a","b c","1")  both flatten to "a b c 1".
+  printf '%s\n%s\n' \
+    '{"type":"message_read","id":"r1","msg_id":"1","team":"a b","agent":"c","at":"x"}' \
+    '{"type":"message_read","id":"r2","msg_id":"1","team":"a","agent":"b c","at":"y"}' >> "$log"
+  storage_compact
+  run grep -c '"type":"message_read"' "$log"   # both are distinct read-state; keep both
+  [ "$output" -eq 2 ]
+}
+
 @test "contract(jsonl): mark_read_batch fails non-zero on a corrupt log" {
   [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = jsonl ] || skip "jsonl-specific (corrupt JSONL)"
   storage_send agsuite alice bob "x" >/dev/null

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -323,6 +323,61 @@ teardown() {
   [[ "$output" =~ "same" ]]
 }
 
+# --- SQL string-literal escaping for interpolated names (#223, #87) ---
+# Team and agent names may contain a single quote (validate.sh only blocks path
+# traversal). Before escaping, such a name broke the INSERT/UPDATE and was an
+# injection surface (a name could widen the WHERE predicate). These pin the
+# escaping so a quoted name round-trips and a crafted name cannot touch other
+# rows.
+
+@test "rename-team: escapes quoted team names and migrates only the matching team" {
+  bash "$SCRIPTS/join.sh" "a'team"    alice claude-code /tmp/proj-a
+  bash "$SCRIPTS/join.sh" "a'team"    bob   claude-code /tmp/proj-b
+  bash "$SCRIPTS/join.sh" "keep'team" carol claude-code /tmp/proj-c
+  bash "$SCRIPTS/join.sh" "keep'team" dave  claude-code /tmp/proj-d
+  bash "$SCRIPTS/send.sh" "a'team"    alice bob  "moved"
+  bash "$SCRIPTS/send.sh" "keep'team" carol dave "stay"
+
+  run bash "$SCRIPTS/rename-team.sh" "a'team" "n'team"
+  [ "$status" -eq 0 ]
+  [ ! -d "$TEST_SKILL_DIR/teams/a'team" ]
+  [ -f "$TEST_SKILL_DIR/teams/n'team/config.json" ]
+
+  # config "name" field updated to the quoted new name (json_set value escaped)
+  run sqlite_mem "SELECT json_extract(readfile('$(rf "$TEST_SKILL_DIR/teams/n'team/config.json")'), '\$.name');"
+  [ "$output" = "n'team" ]
+
+  # the message moved to the new quoted team name (messages + events UPDATE escaped)
+  run bash "$SCRIPTS/inbox.sh" "n'team" bob
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "moved" ]]
+
+  # the other quoted team is untouched — the WHERE predicate was not widened
+  run bash "$SCRIPTS/inbox.sh" "keep'team" dave
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "stay" ]]
+}
+
+@test "rename: escapes the agent name in the messages UPDATE without widening it" {
+  # rename.sh rewrites the legacy messages table directly. Seed it with the
+  # renamed agent's row plus an unrelated victim row that an unscoped/injection
+  # predicate would wrongly rewrite.
+  local db="$TEST_SKILL_DIR/db/messages.db"
+  sqlite3 "$db" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('t', 'alice', 'x', 'a-msg');"
+  sqlite3 "$db" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('t', 'keepme', 'x', 'k-msg');"
+  bash "$SCRIPTS/join.sh" t alice claude-code /tmp/proj
+
+  run bash "$SCRIPTS/rename.sh" t alice carol
+  [ "$status" -eq 0 ]
+
+  # the renamed agent's row moved to the new name ...
+  run sqlite3 "$db" "SELECT from_agent FROM messages WHERE body='a-msg';"
+  [ "$output" = "carol" ]
+  # ... and the unrelated row was NOT rewritten (predicate stayed scoped)
+  run sqlite3 "$db" "SELECT from_agent FROM messages WHERE body='k-msg';"
+  [ "$output" = "keepme" ]
+}
+
 @test "join: rejects unknown agent type" {
   run bash "$SCRIPTS/join.sh" myteam alice claude /tmp/proj
   [ "$status" -ne 0 ]

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -53,6 +53,16 @@ _max_message_id() {
     agmsg_sqlite "$(agmsg_db_path)" "SELECT COALESCE(MAX(id), 0) FROM messages;" )
 }
 
+# The delivery watermark is now an opaque storage cursor (the event-log
+# high-water), not a legacy messages id. This mirrors what storage_watch_tip
+# issues, so tests can assert the watcher's persisted watermark against it.
+_storage_tip() {
+  ( # shellcheck disable=SC1090
+    source "$SCRIPTS/lib/storage.sh"
+    agmsg_sqlite "$(agmsg_db_path)" \
+      "SELECT COALESCE((SELECT seq FROM sqlite_sequence WHERE name='events'),0);" )
+}
+
 _wait_for_file() {
   local file="$1" i
   for i in $(seq 1 100); do
@@ -167,7 +177,7 @@ _wait_for_file_contains() {
 
   bash "$SCRIPTS/send.sh" team bob alice "M1-delivered" >/dev/null
   _wait_for_file_contains "$out" "M1-delivered"
-  local first_id="$(_max_message_id)"
+  local first_id="$(_storage_tip)"
 
   # Owning session dies (reap it so kill -0 reports gone, not a zombie), then a
   # newer row arrives. The liveness guard runs before the DB poll, so the watcher
@@ -175,7 +185,7 @@ _wait_for_file_contains() {
   kill "$sesspid" 2>/dev/null || true
   wait "$sesspid" 2>/dev/null || true
   bash "$SCRIPTS/send.sh" team bob alice "M2-undelivered" >/dev/null
-  local second_id="$(_max_message_id)"
+  local second_id="$(_storage_tip)"
 
   _wait_for_missing "$pf" || { kill "$w" 2>/dev/null || true; false; }
   run kill -0 "$w"; [ "$status" -ne 0 ]


### PR DESCRIPTION
## Summary

Implements the storage axis from **ADR 0003**: agmsg's message log moves behind a
small use-case contract so the backend is swappable, with no change to user-facing
behaviour. Two backends ship — the default **sqlite** driver and an opt-in
**jsonl** driver (jq, with an optional duckdb accelerator). The *same*
driver-agnostic contract suite passes against both, proving the contract is
backend-portable.

Single PR covering the axis checklist #203–#207. Redis is a later, separate change.

## What's in it

- **#203 — contract spec** (`docs/spec/driver-interface.md §2`): the `storage_*`
  use-case contract (send / list_unread / mark_read_batch / watch_tip /
  watch_after / history / store_exists, plus check / init / describe / compact /
  export / import). The delivery cursor is **opaque to core** (never parsed or
  compared); read-state is recipient-scoped; the team registry stays out of the
  contract.
- **#204 — facade + sqlite driver + driver-agnostic contract tests.** The active
  driver is chosen by config / `AGMSG_STORAGE_DRIVER`. The sqlite driver reads the
  legacy `messages` table **read-only** (UNION) so existing installs keep their
  inbox and history across the cutover — legacy rows are never mutated or migrated.
- **#205 — canonical event-log model + compaction.** Schema v1 with a
  forward-compat rule (projections ignore unknown event types / fields).
  Compaction is a five-property contract: idempotent, state-preserving,
  read-coalescing, monotonic, and **cursor-safe** (an issued cursor never skips a
  message). The sqlite cursor is the AUTOINCREMENT high-water, which survives
  DELETE / VACUUM.
- **#206 — call-site migration.** send / inbox / check-inbox / history / watch /
  watch-once now go through the facade. Landed as a read-first phase (additive —
  all reads via the events ∪ legacy UNION) followed by one **atomic flip** of the
  writers and the live delivery cursor, because read-state and the old integer-id
  cursor were coupled across several readers (including the codex bridge).
- **#207 — jsonl (+duckdb) driver.** Append-only JSONL log; jq is the
  zero-extra-dep engine, duckdb an opt-in file-direct accelerator for large logs
  (crossover ~10–20k events). The delivery cursor is a **logical ordinal**
  (compaction-stable, not a byte offset). `storage_store_exists` lets read
  call-sites answer "no messages yet" without a fixed `messages.db` assumption.

## Testing

Full bats suite green. The contract suite also runs against the jsonl driver via a
new non-required CI leg (ubuntu + macos, to cover GNU/BSD userland differences).
The duckdb path is verified byte-identical to the jq path.
