### PR TITLE
fix: escape interpolated values as SQL string literals

### DIFF
--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -26,6 +26,9 @@ agmsg_validate_team_name "$OLD_TEAM" || exit 1
 agmsg_validate_team_name "$NEW_TEAM" || exit 1
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 DB="$(agmsg_db_path)"
+# Escape interpolated identifiers as SQL string literals (parity with
+# send.sh): a team/agent name with a single quote would break the UPDATE.
+_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
 OLD_DIR="$TEAMS_DIR/$OLD_TEAM"
 NEW_DIR="$TEAMS_DIR/$NEW_TEAM"
 
@@ -53,7 +56,7 @@ fi
 
 # --- Update messages in DB ---
 if [ -f "$DB" ]; then
-  agmsg_sqlite "$DB" "UPDATE messages SET team='$NEW_TEAM' WHERE team='$OLD_TEAM';"
+  agmsg_sqlite "$DB" "UPDATE messages SET team='$(_agmsg_sqlesc "$NEW_TEAM")' WHERE team='$(_agmsg_sqlesc "$OLD_TEAM")';"
 fi
 
 echo "Renamed team $OLD_TEAM → $NEW_TEAM"

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -17,6 +17,9 @@ source "$SCRIPT_DIR/lib/validate.sh"
 agmsg_validate_team_name "$TEAM" || exit 1
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 DB="$(agmsg_db_path)"
+# Escape interpolated identifiers as SQL string literals (parity with
+# send.sh): a team/agent name with a single quote would break the UPDATE.
+_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
 
 if [ ! -f "$TEAM_CONFIG" ]; then
@@ -50,8 +53,8 @@ echo "$UPDATED" > "$TEAM_CONFIG"
 
 # --- Update messages in DB ---
 if [ -f "$DB" ]; then
-  agmsg_sqlite "$DB" "UPDATE messages SET from_agent='$NEW_NAME' WHERE team='$TEAM' AND from_agent='$OLD_NAME';"
-  agmsg_sqlite "$DB" "UPDATE messages SET to_agent='$NEW_NAME' WHERE team='$TEAM' AND to_agent='$OLD_NAME';"
+  agmsg_sqlite "$DB" "UPDATE messages SET from_agent='$(_agmsg_sqlesc "$NEW_NAME")' WHERE team='$(_agmsg_sqlesc "$TEAM")' AND from_agent='$(_agmsg_sqlesc "$OLD_NAME")';"
+  agmsg_sqlite "$DB" "UPDATE messages SET to_agent='$(_agmsg_sqlesc "$NEW_NAME")' WHERE team='$(_agmsg_sqlesc "$TEAM")' AND to_agent='$(_agmsg_sqlesc "$OLD_NAME")';"
 fi
 
 echo "Renamed $OLD_NAME → $NEW_NAME in team $TEAM"

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -14,7 +14,11 @@ DB="$(agmsg_db_path)"
 
 [ -f "$DB" ] || bash "$SCRIPT_DIR/internal/init-db.sh" >/dev/null
 
-INSERT="INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$TEAM', '$FROM', '$TO', '$(echo "$BODY" | sed "s/'/''/g")');"
+# Escape EVERY interpolated value as a SQL string literal, not just body: a
+# team/agent name containing a single quote would otherwise break the INSERT
+# (correctness) or change its meaning (injection surface).
+_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
+INSERT="INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$(_agmsg_sqlesc "$TEAM")', '$(_agmsg_sqlesc "$FROM")', '$(_agmsg_sqlesc "$TO")', '$(_agmsg_sqlesc "$BODY")');"
 
 # Retry once after ensuring the schema. Under a concurrent first-write fan-out
 # (leader → N members against a fresh/override store), one process can see the


### PR DESCRIPTION
send.sh, rename.sh and rename-team.sh interpolate team/from/to (and old/new names) directly into SQL string literals, escaping only body. A team or agent name containing a single quote breaks the INSERT/UPDATE (correctness) and is an injection surface. Escape every interpolated value with the same sed idiom already used for body, via a small _agmsg_sqlesc helper.