### PR TITLE
fix(storage): open the message DB via a Windows-acceptable path (addresses 1 and 2 of #197)

### DIFF
--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -38,9 +38,21 @@ agmsg_storage_dir() {
   printf '%s\n' "$skill_dir/db"
 }
 
-# Echo the full path to messages.db.
+# Echo the full path to messages.db, in a form the sqlite3 binary can open.
+# On Windows, sqlite3.exe is a native binary that cannot open a Git Bash path
+# like /c/Users/.../db/messages.db: open() fails, so inbox/send/watch all fail
+# to reach the store and the team goes silent (#197, reported by vhsvhafmwf).
+# cygpath -m converts to the mixed C:/Users/.../db/messages.db form that BOTH
+# the shell's `[ -f "$db" ]` test AND sqlite3.exe accept — unlike -w's backslash
+# form (C:\Users\...), which the surrounding shell quoting/tests mishandle.
+# No-op off Windows (cygpath absent). Mirrors agmsg_sql_readfile_path's pattern.
 agmsg_db_path() {
-  printf '%s/messages.db\n' "$(agmsg_storage_dir)"
+  local db
+  db="$(agmsg_storage_dir)/messages.db"
+  if command -v cygpath >/dev/null 2>&1; then
+    db=$(cygpath -m "$db" 2>/dev/null || printf '%s' "$db")
+  fi
+  printf '%s\n' "$db"
 }
 
 # Run sqlite3 against the message store with a busy_timeout, so a writer that

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -247,6 +247,21 @@ if [ -z "$LAST" ]; then
   persist_watermark
 fi
 
+# DB-open healthcheck (#197). The main loop guards every query with
+# `2>/dev/null || true`, so when sqlite3 cannot open the store the watcher keeps
+# spinning and silently delivers nothing — a silent outage. The native
+# sqlite3.exe / Git Bash path mismatch behind #197 is one trigger (now fixed in
+# agmsg_db_path), but permissions, a missing binary, or a corrupt file fail the
+# same way. A *missing* DB file is normal (no messages sent yet), so only flag
+# the case where the file exists but a trivial query cannot run: emit one line
+# on stdout (the Monitor event stream) and exit, turning the silent failure into
+# a visible one. Done before the ready sentinel so we never signal "ready" for a
+# watcher that cannot read the store.
+if [ -f "$DB" ] && ! agmsg_sqlite "$DB" "SELECT 1;" >/dev/null 2>&1; then
+  echo "ERROR: cannot open message DB $DB"
+  exit 1
+fi
+
 # Signal readiness. Once the subscription is resolved and the watermark is set,
 # this watcher will deliver anything that arrives from here on, so it is safe
 # for a leader to start sending. Only exclusive (actas) watchers signal — a

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -30,6 +30,34 @@ teardown() {
   [ "$(agmsg_db_path)" = "$BATS_TEST_TMPDIR/store/messages.db" ]
 }
 
+# --- agmsg_db_path() Windows path conversion (#197) ---
+
+@test "storage: agmsg_db_path applies cygpath -m on Windows so sqlite3.exe can open it (#197)" {
+  # The native sqlite3.exe cannot open a Git Bash /c/... path; cygpath -m maps it
+  # to the mixed C:/... form both the shell and sqlite3.exe accept. cygpath is
+  # absent off Windows, so inject a shim on PATH to exercise the branch.
+  local bindir="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$bindir"
+  cat > "$bindir/cygpath" <<'SH'
+#!/usr/bin/env bash
+# Minimal stand-in: `cygpath -m /c/x` -> C:/x (BSD- and GNU-sed portable).
+shift  # drop the -m flag
+printf '%s\n' "$1" | sed -E 's#^/c/#C:/#'
+SH
+  chmod +x "$bindir/cygpath"
+  run env PATH="$bindir:$PATH" AGMSG_STORAGE_PATH="/c/Users/test/db" \
+    bash -c 'source "'"$SCRIPTS"'/lib/storage.sh"; agmsg_db_path'
+  [ "$status" -eq 0 ]
+  [ "$output" = "C:/Users/test/db/messages.db" ]
+}
+
+@test "storage: agmsg_db_path is a no-op without cygpath (off Windows)" {
+  source "$SCRIPTS/lib/storage.sh"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  # cygpath is absent on the test host, so the path is returned unchanged.
+  [ "$(agmsg_db_path)" = "$BATS_TEST_TMPDIR/store/messages.db" ]
+}
+
 # --- init-db.sh honoring the override ---
 
 @test "storage: init-db creates the db at the overridden path (and makes the dir)" {

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -362,3 +362,22 @@ _wait_pidfile() {
   wait "$w2" 2>/dev/null || true
   wait "$sesspid" 2>/dev/null || true
 }
+
+# DB-open healthcheck (#197): a store that exists but cannot be opened (the
+# native sqlite3.exe / Git Bash /c/ path mismatch, or bad perms) must surface a
+# loud error rather than spin silently delivering nothing.
+@test "watch: surfaces an unopenable DB once instead of spinning silently (#197)" {
+  [ "$(id -u)" -eq 0 ] && skip "chmod 000 is ineffective as root"
+  local DB="$TEST_SKILL_DIR/db/messages.db"
+  [ -f "$DB" ]                # init-db.sh created it in setup_test_env
+  chmod 000 "$DB"
+  local out="$BATS_TEST_TMPDIR/hc.out"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-hc" "$PROJ" claude-code >"$out" 2>/dev/null &
+  local pid=$!
+  sleep 2                     # > one poll interval; a spinning watcher would re-emit
+  kill "$pid" 2>/dev/null || true   # no-op if the healthcheck already exited
+  wait "$pid" 2>/dev/null || true
+  chmod 644 "$DB" 2>/dev/null || true
+  # Exactly one line: 0 would mean a silent spin, >1 a re-emitting loop.
+  [ "$(grep -c 'ERROR: cannot open message DB' "$out")" -eq 1 ]
+}


### PR DESCRIPTION
## Summary

Addresses **(1)** and **(2)** of #197 (Windows / Git Bash). Diagnosis and the fix
proposal are by @vhsvhafmwf — thank you for the detailed report.

This does **not** close #197: findings (3), (4), and (5) from that issue remain
open and are triaged below.

### (1) Open the message DB via a path the native `sqlite3.exe` accepts

`agmsg_db_path()` returned an MSYS/Git Bash path such as
`/c/Users/<you>/.agents/skills/agmsg/db/messages.db`. The native Windows
`sqlite3.exe` cannot open that form (`unable to open database file`), and since
every DB-backed script resolves the store through `DB="$(agmsg_db_path)"`,
`inbox` / `send` / `watch` all fail at once and the team goes silent.

Fix: convert the path through `cygpath -m` inside `agmsg_db_path()`. `-m` yields
the mixed `C:/Users/...` (forward-slash) form that **both** the shell's
`[ -f "$db" ]` test **and** `sqlite3.exe` accept. This mirrors the existing
`cygpath -w` handling in `agmsg_sql_readfile_path()` in the same file. It is a
no-op off Windows (`cygpath` absent).

### (2) Stop hiding a DB-open failure in `watch.sh`

`watch.sh` guards every query with `2>/dev/null || true`, so a store it cannot
open produced a **silent** outage — the watcher kept running and delivered
nothing. It now healthchecks the store at startup (`SELECT 1`) and, when the DB
file exists but cannot be opened, prints a single
`ERROR: cannot open message DB <path>` line to stdout (the monitor event stream)
and exits, rather than spinning. A missing DB file is still normal (no messages
sent yet) and is not flagged. The check runs before the readiness sentinel, so a
watcher that cannot read the store never signals "ready".

## Tests

- `tests/test_storage.bats`: `agmsg_db_path` applies `cygpath -m` when `cygpath`
  is present (PATH-injected shim), and is a no-op without it.
- `tests/test_watch.bats`: a present-but-unopenable DB makes `watch.sh` emit the
  error exactly once and stop, instead of spinning silently.
- Full local `bats tests/` suite green on macOS. Native Windows behavior is
  covered by the `windows-latest` CI jobs (the author develops on macOS and
  cannot reproduce the native `sqlite3.exe` path locally).

## Out of scope — remaining #197 findings (triaged, not implemented here)

- **(3) catch-up drain of unread inbox on attach** — defer to a dedicated,
  flag-gated feature issue. The current "stream from now, do not replay history"
  behavior is deliberate and pinned by the watch-watermark tests; changing it is
  a design decision, not a Windows fix.
- **(4) `despawn` ineffective for non-tmux (OS-terminal) spawns** — a real but
  bounded bug in the spawn/despawn subsystem (not Windows-specific); track and
  fix separately by recording launch metadata for OS-terminal placements.
- **(5) length guard in `send.sh`** — separate feature discussion; a default hard
  refuse would break legitimate multi-KB sends, so prefer a warning or an opt-in
  cap. Decide the policy first.

## Coordination note

`agmsg_db_path()` lives in `scripts/lib/storage.sh`, which is also being reworked
on the `design/storage-axis` branch (#221). This PR is cut from `main`; #221 will
absorb the change on its next rebase.
