### PR TITLE
fix(codex): report bridge liveness in delivery status

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -155,6 +155,7 @@ agmsg_delivery_apply_default() {
 #   agmsg_delivery_on_enable  — side effects when enabling monitor/both (default: none)
 #   agmsg_delivery_on_disable — side effects when turning delivery off  (default: none)
 #   agmsg_delivery_stop_directive — in-session watcher-stop directive (default: Claude TaskStop)
+#   agmsg_delivery_runtime_status — runtime liveness summary (default: watch.sh pidfiles)
 # A plug that wants the default apply can delegate to agmsg_delivery_apply_default.
 agmsg_delivery_apply() { agmsg_delivery_apply_default "$@"; }
 agmsg_delivery_on_enable() { :; }
@@ -217,6 +218,24 @@ agmsg_delivery_status_default() {
   fi
 }
 agmsg_delivery_status() { agmsg_delivery_status_default "$@"; }
+
+agmsg_delivery_runtime_status_default() {
+  if [ -d "$RUN_DIR" ]; then
+    local alive=0 dead=0
+    for f in "$RUN_DIR"/watch.*.pid; do
+      [ -f "$f" ] || continue
+      local pid
+      pid=$(cat "$f" 2>/dev/null || echo "")
+      if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        alive=$((alive + 1))
+      else
+        dead=$((dead + 1))
+      fi
+    done
+    echo "watch processes: $alive alive, $dead stale pidfiles"
+  fi
+}
+agmsg_delivery_runtime_status() { agmsg_delivery_runtime_status_default "$@"; }
 
 # Source the type's delivery plug (if present) so its overrides take effect.
 # One type is handled per invocation, so the global overrides never go stale.
@@ -434,20 +453,7 @@ do_status() {
     agmsg_delivery_status "$TYPE" "$PROJECT"
   fi
 
-  if [ -d "$RUN_DIR" ]; then
-    local alive=0 dead=0
-    for f in "$RUN_DIR"/watch.*.pid; do
-      [ -f "$f" ] || continue
-      local pid
-      pid=$(cat "$f" 2>/dev/null || echo "")
-      if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-        alive=$((alive + 1))
-      else
-        dead=$((dead + 1))
-      fi
-    done
-    echo "watch processes: $alive alive, $dead stale pidfiles"
-  fi
+  agmsg_delivery_runtime_status "$TYPE" "$PROJECT"
 }
 
 kill_all_watchers() {

--- a/scripts/drivers/types/codex/_delivery.sh
+++ b/scripts/drivers/types/codex/_delivery.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # codex delivery plug.
 #
-# codex keeps the default JSON event-hooks apply (agmsg_delivery_apply); it only
-# adds enable/disable side effects: install the monitor shim on enable, stop the
-# bridge on disable. Sourced into delivery.sh's context, so SKILL_DIR,
-# agmsg_resolve_node, CODEX_MONITOR_DOC_URL and stop_codex_bridge are in scope.
+# codex keeps the default JSON event-hooks apply (agmsg_delivery_apply); it adds
+# enable/disable side effects and replaces the runtime status summary with
+# Codex bridge liveness. Sourced into delivery.sh's context, so SKILL_DIR,
+# SCRIPT_DIR, RUN_DIR, agmsg_resolve_node, CODEX_MONITOR_DOC_URL and
+# stop_codex_bridge are in scope.
 # Args (both hooks): on_enable <mode> <type> <project>; on_disable <type> <project>.
 
 agmsg_delivery_on_enable() {
@@ -52,4 +53,65 @@ agmsg_delivery_on_disable() {
   echo "  If no other project uses monitor mode, remove it and restore your PATH:"
   echo "    $SKILL_DIR/scripts/drivers/types/codex/codex-shim-install.sh remove"
   echo "    # then drop ~/.agents/bin from PATH if you added it for monitor"
+}
+
+agmsg_delivery_runtime_status() {
+  local type="$1" project="$2"
+  local pairs found=0
+  pairs=$("$SCRIPT_DIR/identities.sh" "$project" "$type" 2>/dev/null || true)
+
+  if [ -z "$pairs" ]; then
+    echo "Codex bridge: no identities registered for this project"
+    return 0
+  fi
+
+  while IFS=$'\t' read -r team name _rest; do
+    if [ -z "$team" ] || [ -z "$name" ]; then
+      continue
+    fi
+    found=1
+
+    local base pidfile metafile pid meta_pid meta_project meta_type meta_ok
+    base="$RUN_DIR/codex-bridge.$team.$name"
+    pidfile="$base.pid"
+    metafile="$base.meta"
+
+    if [ ! -f "$pidfile" ]; then
+      echo "Codex bridge: $team/$name not running"
+      continue
+    fi
+
+    pid=$(cat "$pidfile" 2>/dev/null || true)
+    if [ -z "$pid" ]; then
+      echo "Codex bridge: $team/$name stale pidfile (empty pid)"
+      continue
+    fi
+
+    if [ ! -f "$metafile" ]; then
+      echo "Codex bridge: $team/$name stale pidfile (missing metadata)"
+      continue
+    fi
+
+    meta_ok=1
+    meta_pid=$(awk -F= '/^pid=/{sub(/^pid=/, ""); print; exit}' "$metafile" 2>/dev/null || true)
+    meta_project=$(awk -F= '/^project=/{sub(/^project=/, ""); print; exit}' "$metafile" 2>/dev/null || true)
+    meta_type=$(awk -F= '/^type=/{sub(/^type=/, ""); print; exit}' "$metafile" 2>/dev/null || true)
+    [ -n "$meta_pid" ] && [ "$meta_pid" != "$pid" ] && meta_ok=0
+    [ -n "$meta_project" ] && [ "$meta_project" != "$project" ] && meta_ok=0
+    [ -n "$meta_type" ] && [ "$meta_type" != "$type" ] && meta_ok=0
+    if [ "$meta_ok" -ne 1 ]; then
+      echo "Codex bridge: $team/$name stale pidfile (metadata mismatch)"
+      continue
+    fi
+
+    if kill -0 "$pid" 2>/dev/null; then
+      echo "Codex bridge: $team/$name alive (pid $pid)"
+    else
+      echo "Codex bridge: $team/$name stale pidfile (pid $pid not running)"
+    fi
+  done <<< "$pairs"
+
+  if [ "$found" -eq 0 ]; then
+    echo "Codex bridge: no identities registered for this project"
+  fi
 }

--- a/tests/test_actas_integration.bats
+++ b/tests/test_actas_integration.bats
@@ -55,6 +55,7 @@ fake_session() {
 }
 
 @test "actas-claim: status=held when role is held by another live session" {
+  skip_on_windows "actas live-session liveness under Git Bash (#182)"
   fake_register T alice
   fake_session "sid-owner" >/dev/null     # this test process is the "live owner"
   echo "sid-owner" > "$(actas_lock_path T alice)"
@@ -135,6 +136,7 @@ fake_session() {
 # Run watch.sh briefly and inspect its stderr for the exclusion message.
 
 @test "watch: excludes pairs held by another live session (stderr message)" {
+  skip_on_windows "actas watcher liveness under Git Bash (#182)"
   fake_register T alice
   fake_register T bob
   fake_session "sid-other" >/dev/null
@@ -156,6 +158,7 @@ fake_session() {
 }
 
 @test "watch: with active_name held by other session, exits with held error" {
+  skip_on_windows "actas watcher liveness under Git Bash (#182)"
   fake_register T alice
   fake_session "sid-other" >/dev/null
   echo "sid-other" > "$(actas_lock_path T alice)"
@@ -169,6 +172,7 @@ fake_session() {
 }
 
 @test "watch: with active_name on a free pair, claims and continues" {
+  skip_on_windows "actas watcher process mgmt under Git Bash (#182)"
   fake_register T alice
 
   AGMSG_WATCH_INTERVAL=1 bash "$SKILL_DIR/scripts/watch.sh" "sid-me" /tmp/p1 claude-code alice \

--- a/tests/test_actas_lock.bats
+++ b/tests/test_actas_lock.bats
@@ -69,6 +69,7 @@ live_pid() { echo "$$"; }
 }
 
 @test "claim: refuses when held by a live other session" {
+  skip_on_windows "actas live-session liveness under Git Bash (#182)"
   fake_cc_instance "$(live_pid)" "sid-other"
   echo "sid-other" > "$(actas_lock_path "T" "alice")"
 
@@ -101,6 +102,7 @@ live_pid() { echo "$$"; }
 # Case 1: serial — once a live owner claims, peer is refused (basic
 # exclusivity sanity check).
 @test "claim: a live owner is never replaced by a serial peer's claim" {
+  skip_on_windows "actas live-session liveness under Git Bash (#182)"
   echo "sid-dead" > "$(actas_lock_path "T" "alice")"
   setup_live_owner "$RUN_DIR" "sid-A"
   actas_lock_claim "T" "alice" "sid-A"
@@ -119,6 +121,7 @@ live_pid() { echo "$$"; }
 # carrying a stale decision: claim must NOT touch the existing live lock
 # even if it tried to enter the stale path.
 @test "claim: a fresh live lock survives a concurrent claimer's stale reclaim attempt" {
+  skip_on_windows "actas live-session liveness under Git Bash (#182)"
   # lock_path already records a live owner (sid-A is alive via cc-instance).
   setup_live_owner "$RUN_DIR" "sid-A"
   echo "sid-A" > "$(actas_lock_path "T" "alice")"
@@ -145,13 +148,14 @@ live_pid() { echo "$$"; }
   [ "$status" -ne 0 ]
 }
 
-@test "sid_alive: pid alive + cc-instance content matches → alive" {
+@test "sid_alive: pid alive + cc-instance content matches -> alive" {
+  skip_on_windows "actas live-session liveness under Git Bash (#182)"
   fake_cc_instance "$(live_pid)" "sid-A"
   run actas_lock_sid_alive "sid-A"
   [ "$status" -eq 0 ]
 }
 
-@test "sid_alive: pid dead → not alive" {
+@test "sid_alive: pid dead -> not alive" {
   fake_cc_instance "99999" "sid-A"  # very unlikely live pid
   run actas_lock_sid_alive "sid-A"
   [ "$status" -ne 0 ]
@@ -188,6 +192,7 @@ live_pid() { echo "$$"; }
 # --- gc_stale ---
 
 @test "gc_stale: removes locks whose owner is dead, returns count" {
+  skip_on_windows "actas live-session liveness under Git Bash (#182)"
   echo "sid-dead-1" > "$(actas_lock_path "T1" "alice")"
   echo "sid-dead-2" > "$(actas_lock_path "T2" "bob")"
   fake_cc_instance "$(live_pid)" "sid-live"
@@ -202,6 +207,7 @@ live_pid() { echo "$$"; }
 }
 
 @test "gc_stale: noop when no stale locks" {
+  skip_on_windows "actas live-session liveness under Git Bash (#182)"
   fake_cc_instance "$(live_pid)" "sid-live"
   echo "sid-live" > "$(actas_lock_path "T" "alice")"
 
@@ -226,6 +232,7 @@ live_pid() { echo "$$"; }
 }
 
 @test "state: other:<sid> when held by a live different session" {
+  skip_on_windows "actas live-session liveness under Git Bash (#182)"
   fake_cc_instance "$(live_pid)" "sid-other"
   echo "sid-other" > "$(actas_lock_path "T" "alice")"
   run actas_lock_state "T" "alice" "sid-me"

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1471,6 +1471,7 @@ EOF
 
   sleep 60 &
   local bpid=$!
+  # shellcheck disable=SC2064  # capture the current child pid for EXIT cleanup
   trap "kill $bpid 2>/dev/null || true" EXIT
   printf '%s\n' "$bpid" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
   cat > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.meta" <<EOF
@@ -1573,6 +1574,7 @@ EOF
 
   sleep 60 &
   local bpid=$!
+  # shellcheck disable=SC2064  # capture the current child pid for EXIT cleanup
   trap "kill $bpid 2>/dev/null || true" EXIT
   printf '%s\n' "$bpid" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
   cat > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.meta" <<EOF

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -161,6 +161,15 @@ settings_file() {
   [[ "$output" =~ "mode: monitor" ]]
 }
 
+@test "delivery status: claude-code still reports the watch process summary" {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"mode: monitor"* ]]
+  [[ "$output" == *"watch processes:"* ]]
+}
+
 @test "delivery status: derives 'turn' from settings with Stop only" {
   bash "$SCRIPTS/delivery.sh" set turn claude-code "$TEST_PROJECT" >/dev/null
   run bash "$SCRIPTS/delivery.sh" status claude-code "$TEST_PROJECT"
@@ -1454,6 +1463,145 @@ EOF
   [[ "$output" == *"not supported for codex"* ]]
 }
 
+@test "delivery status (codex): live bridge reports alive and suppresses watch count" {
+  skip_on_windows "codex bridge status liveness under Git Bash (#182)"
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  sleep 60 &
+  local bpid=$!
+  trap "kill $bpid 2>/dev/null || true" EXIT
+  printf '%s\n' "$bpid" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
+  cat > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.meta" <<EOF
+pid=$bpid
+project=$TEST_PROJECT
+team=team
+name=alice
+type=codex
+EOF
+  printf '%s\n' 99999999 > "$TEST_SKILL_DIR/run/watch.fake.pid"
+
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"mode: monitor"* ]]
+  [[ "$output" == *"Codex bridge: team/alice alive (pid $bpid)"* ]]
+  [[ "$output" != *"watch processes:"* ]]
+
+  kill "$bpid" 2>/dev/null || true
+  trap - EXIT
+}
+
+@test "delivery status (codex): stale bridge pidfile is reported as stale" {
+  skip_on_windows "codex bridge status liveness under Git Bash (#182)"
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  local dead_pid=999999
+  while kill -0 "$dead_pid" 2>/dev/null; do
+    dead_pid=$((dead_pid + 1))
+  done
+  printf '%s\n' "$dead_pid" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
+  cat > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.meta" <<EOF
+pid=$dead_pid
+project=$TEST_PROJECT
+team=team
+name=alice
+type=codex
+EOF
+
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"mode: monitor"* ]]
+  [[ "$output" == *"Codex bridge: team/alice stale pidfile (pid $dead_pid not running)"* ]]
+  [[ "$output" != *"watch processes:"* ]]
+}
+
+@test "delivery status (codex): bridge metadata mismatch is reported as stale" {
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  printf '%s\n' "$$" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
+  cat > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.meta" <<EOF
+pid=$$
+project=$TEST_PROJECT-other
+team=team
+name=alice
+type=codex
+EOF
+
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"mode: monitor"* ]]
+  [[ "$output" == *"Codex bridge: team/alice stale pidfile (metadata mismatch)"* ]]
+  [[ "$output" != *"watch processes:"* ]]
+}
+
+@test "delivery status (codex): missing bridge metadata is reported as stale" {
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  printf '%s\n' "$$" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
+
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"mode: monitor"* ]]
+  [[ "$output" == *"Codex bridge: team/alice stale pidfile (missing metadata)"* ]]
+  [[ "$output" != *"watch processes:"* ]]
+}
+
+@test "delivery status (codex): identity with no bridge reports not running" {
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"mode: monitor"* ]]
+  [[ "$output" == *"Codex bridge: team/alice not running"* ]]
+  [[ "$output" != *"watch processes:"* ]]
+}
+
+@test "delivery status (codex): multiple identities are enumerated independently" {
+  skip_on_windows "codex bridge status liveness under Git Bash (#182)"
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" team bob codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  sleep 60 &
+  local bpid=$!
+  trap "kill $bpid 2>/dev/null || true" EXIT
+  printf '%s\n' "$bpid" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
+  cat > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.meta" <<EOF
+pid=$bpid
+project=$TEST_PROJECT
+team=team
+name=alice
+type=codex
+EOF
+
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Codex bridge: team/alice alive (pid $bpid)"* ]]
+  [[ "$output" == *"Codex bridge: team/bob not running"* ]]
+  [[ "$output" != *"watch processes:"* ]]
+
+  kill "$bpid" 2>/dev/null || true
+  trap - EXIT
+}
+
+@test "delivery status (codex): monitor mode with no identities is explicit" {
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"mode: monitor"* ]]
+  [[ "$output" == *"Codex bridge: no identities registered for this project"* ]]
+  [[ "$output" != *"watch processes:"* ]]
+}
 
 @test "session-start.sh for codex resolves thread id from rollout when CODEX_THREAD_ID is unset" {
   bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -66,6 +66,7 @@ teardown() { teardown_test_env; }
 # --- agmsg_instance_alive ---
 
 @test "instance_alive: composite with a live pid is alive" {
+  skip_on_windows "instance-id live PID liveness under Git Bash (#182)"
   agmsg_instance_alive "sess.$$"
 }
 
@@ -74,11 +75,13 @@ teardown() { teardown_test_env; }
 }
 
 @test "instance_alive: bare sid with a live cc-instance is alive" {
+  skip_on_windows "instance-id live PID liveness under Git Bash (#182)"
   echo "barex" > "$RUN_DIR/cc-instance.$$"
   agmsg_instance_alive "barex"
 }
 
 @test "instance_alive: bare sid is alive when cc-instance was upgraded to composite (compat)" {
+  skip_on_windows "instance-id live PID liveness under Git Bash (#182)"
   # A pre-upgrade lock holds a bare sid while cc-instance already stores the
   # composite "<sid>.<pid>" — must not be stale'd out.
   echo "barey.$$" > "$RUN_DIR/cc-instance.$$"
@@ -151,7 +154,8 @@ teardown() { teardown_test_env; }
 
 # Two instance ids that share a session_id prefix but differ in pid must be
 # treated as distinct owners — the collision that broke the actas lock is gone.
-@test "actas: same session_id, different pid → distinct live owners (#93)" {
+@test "actas: same session_id, different pid -> distinct live owners (#93)" {
+  skip_on_windows "instance-id live PID liveness under Git Bash (#182)"
   sleep 60 & local pa=$!
   sleep 60 & local pb=$!
   local ta="sess.$pa" tb="sess.$pb"

--- a/tests/test_resolve_project.bats
+++ b/tests/test_resolve_project.bats
@@ -191,6 +191,7 @@ setup_git_repo() {
 }
 
 @test "resolve: sibling git worktree resolves to the registered main checkout" {
+  skip_on_windows "git worktree path normalization under Git Bash (#182)"
   command -v git >/dev/null 2>&1 || skip "git not available"
   local base; base="$(setup_git_repo)"
   local repo="$base/repo"

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -81,6 +81,7 @@ _wait_for_file_contains() {
 }
 
 @test "watch: restart delivers messages that arrived while the watcher was down" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
   local sid="sess-restart"
 
   # First watcher: fresh session, takes its mark at MAX(id)=0, then streams M1.
@@ -107,6 +108,7 @@ _wait_for_file_contains() {
 }
 
 @test "watch: a fresh session starts from now and does not replay history" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
   # Pre-existing message before any watcher for this session ever runs.
   bash "$SCRIPTS/send.sh" team bob alice "M0-history" >/dev/null
 
@@ -125,11 +127,13 @@ _wait_for_file_contains() {
 }
 
 @test "watch: persists a watermark file for the session" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
   run_watcher_for "sess-wm" "$TEST_SKILL_DIR/wm.log" 1.5
   [ -f "$TEST_SKILL_DIR/run/watch.$(_iid sess-wm).watermark" ]
 }
 
 @test "watch: exits within one interval when its session dies, without advancing the watermark past an undelivered row (#67)" {
+  skip_on_windows "watcher session liveness under Git Bash (#182)"
   # REWRITTEN from "closed consumer does not advance watermark...". The old test
   # asserted that a closed *downstream* consumer (`watch.sh | head -n 1`) made
   # the watcher stop and not advance the watermark. That contract is unachievable
@@ -181,6 +185,7 @@ _wait_for_file_contains() {
 }
 
 @test "watch: closed stdout exits without advancing the watermark" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
   local sid="sess-stdout-closed"
   local iid="$(_iid "$sid")"
   local wm="$TEST_SKILL_DIR/run/watch.$iid.watermark"
@@ -219,6 +224,7 @@ _wait_for_file_contains() {
 }
 
 @test "watch: actas-mode watcher creates a ready sentinel and removes it on exit" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
   local ready="$TEST_SKILL_DIR/run/ready.team__alice"
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-ready" "$PROJ" claude-code alice \
     >/dev/null 2>&1 &
@@ -244,6 +250,7 @@ _wait_for_file_contains() {
 }
 
 @test "watch: ready sentinel records the owner session_id" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
   local ready="$TEST_SKILL_DIR/run/ready.team__alice"
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-own" "$PROJ" claude-code alice \
     >/dev/null 2>&1 &
@@ -271,6 +278,7 @@ _wait_for_file_contains() {
 }
 
 @test "session-start: GCs stale watermark/ready but keeps live ones" {
+  skip_on_windows "watcher live-owner liveness under Git Bash (#182)"
   bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
   mkdir -p "$TEST_SKILL_DIR/run"
   # Stale (owner has no live cc-instance).
@@ -303,6 +311,7 @@ _wait_pidfile() {
 }
 
 @test "watch: two sessions sharing a session_id keep independent watchers (#93)" {
+  skip_on_windows "watcher process mgmt under Git Bash (#182)"
   # Pre-composite instance ids (same sid prefix, different agent pid) — what
   # session-start bakes into the directive for two parallel resume processes.
   # The embedded pids must be live: the liveness guard (#67) exits a watcher
@@ -335,6 +344,7 @@ _wait_pidfile() {
 }
 
 @test "watch: relaunch with the SAME instance id replaces the previous watcher (#66 preserved)" {
+  skip_on_windows "watcher process mgmt under Git Bash (#182)"
   # The composite instance id's pid must belong to a LIVE process: the watcher's
   # liveness guard (#67) exits any watcher whose embedded session pid is dead, so
   # a fabricated dead pid (the old "solo.2002") would self-exit before the


### PR DESCRIPTION
## Summary
- add a type-overridable delivery runtime status hook while preserving the default `watch.sh` pidfile summary for existing watch-based types
- for Codex, report registered bridge identity state from `codex-bridge.<team>.<name>.pid/.meta` and suppress the generic `watch processes:` line that made healthy bridges look dead
- cover alive, stale/dead pid, missing/mismatched metadata, no bridge, multiple identities, no identities, and the non-Codex default status path
- expand the #182 Windows-only quarantine for tests that depend on live PID/session liveness, watcher background process handling, and Git Bash worktree path normalization, so the experimental Windows full leg reflects the existing quarantine policy

Closes #157.

## Validation
- `bash -n scripts/delivery.sh && bash -n scripts/drivers/types/codex/_delivery.sh`
- `shellcheck scripts/drivers/types/codex/_delivery.sh`
- `git diff --check`
- `bats --print-output-on-failure --filter "delivery status.*(codex|claude-code)" tests/test_delivery.bats` -> 8/8
- `bats --print-output-on-failure -f "codex" tests/test_delivery.bats` -> 17/17
- `bats --print-output-on-failure tests/test_codex_bridge.bats` -> 23/23
- `bats --print-output-on-failure tests/test_actas_integration.bats` -> 10/10
- `bats --print-output-on-failure tests/test_actas_lock.bats` -> 22/22
- `bats --print-output-on-failure tests/test_instance_id.bats` -> 23/23
- `bats --print-output-on-failure tests/test_watch.bats` -> 14/14
- `bats --print-output-on-failure tests/test_resolve_project.bats` -> 16/16
- `bats --print-output-on-failure tests/test_delivery.bats` -> 119/120; the remaining failure is the existing unrelated `delivery set monitor: existing settings with single-quoted hook commands stays valid JSON (#134)` malformed JSON case

CI note: earlier runs failed only in the informational `bats (windows-latest, full (experimental))` leg, first in existing `actas` live-session / watcher process-liveness cases and then in existing `actas-lock` live-owner cases tracked by #182. This patch quarantines those Windows-only cases plus the already documented `instance-id`, `watch`, and sibling worktree path-normalization failures from #182; it does not fix #182.

## Scope notes
This intentionally does not change bridge teardown/orphan handling (#149), launcher/request-file behavior (#153), app-server stall handling (#195/#209), Windows storage/watch DB path handling (#197/#226), or Codex monitor shim setup (#193).

#182 remains open; the added skips apply only on native Windows/Git Bash and the tests still run on Ubuntu/macOS.
