### PR TITLE
feat(grok-build): add opt-in explicit-launch monitor delivery

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -150,6 +150,7 @@ agmsg_delivery_apply_default() {
 #   agmsg_delivery_apply      — write the hook file for a mode (default: JSON event-hooks)
 #   agmsg_delivery_on_enable  — side effects when enabling monitor/both (default: none)
 #   agmsg_delivery_on_disable — side effects when turning delivery off  (default: none)
+#   agmsg_delivery_stop_directive — in-session watcher-stop directive (default: Claude TaskStop)
 # A plug that wants the default apply can delegate to agmsg_delivery_apply_default.
 agmsg_delivery_apply() { agmsg_delivery_apply_default "$@"; }
 agmsg_delivery_on_enable() { :; }
@@ -158,6 +159,10 @@ agmsg_delivery_on_enable() { :; }
 # <project>. Passing the type scopes the kill so disabling one type's delivery
 # never tears down another type's watcher in the same project.
 agmsg_delivery_on_disable() { kill_all_watchers "$2" "$1" >/dev/null 2>&1 || true; }
+# Default in-session stop directive: tell a running Claude Code session to find
+# and TaskStop its watcher. Types whose runtime launches the watcher a different
+# way (e.g. grok-build's `monitor` tool) override this with their own wording.
+agmsg_delivery_stop_directive() { emit_stop_directive; }
 
 # Default delivery status (json-hooks types: claude-code, codex). Derives the mode
 # from the settings hooks file's agmsg-owned SessionStart/Stop entries, then prints
@@ -361,7 +366,7 @@ do_set() {
       # watcher in the project — so any type's `set turn` tore down the
       # project's claude-code monitor, the only type that runs one.)
       kill_all_watchers "$PROJECT" "$TYPE" >/dev/null 2>&1 || true
-      emit_stop_directive
+      agmsg_delivery_stop_directive
       ;;
     off)
       echo "Future sessions: no automatic delivery."
@@ -374,7 +379,7 @@ do_set() {
       # directive would be noise — and a stray TaskStop could disturb an
       # unrelated agent's watcher. Data-driven, so no per-type branch here.
       case " $SUPPORTED_MODES " in
-        *" monitor "*|*" turn "*|*" both "*) emit_stop_directive ;;
+        *" monitor "*|*" turn "*|*" both "*) agmsg_delivery_stop_directive ;;
       esac
       ;;
   esac

--- a/scripts/drivers/types/grok-build/_delivery.sh
+++ b/scripts/drivers/types/grok-build/_delivery.sh
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
-# grok-build delivery plug — markdown rule file (.grok/rules/agmsg.md).
+# grok-build delivery plug — markdown rule file (.grok/rules/agmsg.md) plus an
+# opt-in, explicitly-launched monitor watcher.
 #
 # Why a rule file (not a hook): Grok Build's passive hooks (SessionStart/Stop)
 # discard their stdout — they cannot inject anything into the conversation. A
 # Stop hook running check-inbox.sh would therefore deliver NOTHING while still
-# marking messages read = silent loss. So grok integrates the same way as
-# gemini / antigravity / opencode: a markdown rule under <project>/.grok/rules/,
-# which Grok always scans into context each turn. The rule tells the agent to
-# poll its own inbox; the agent runs the check as a tool call and reads the
-# output — the one delivery path Grok actually supports.
+# marking messages read = silent loss. So the baseline integration is a markdown
+# rule under <project>/.grok/rules/, which Grok always scans into context each
+# turn. The rule tells the agent to poll its own inbox; the agent runs the check
+# as a tool call and reads the output — the simplest delivery path Grok supports.
+#
+# monitor mode (opt-in): Grok Build DOES expose a `monitor` background-task tool
+# (monitor(command, description, persistent:true)) that accumulates a long-running
+# command's stdout and injects each line back into the conversation as a
+# notification — the same shape as Claude Code's Monitor tool. Running watch.sh
+# under it gives real-time delivery. The ONLY difference from claude-code is that
+# Grok's passive hooks cannot auto-launch it at SessionStart, so the launch is
+# explicit: the rule (and the /agmsg actas flow) instruct the agent to start the
+# watcher via the monitor tool. turn stays the zero-setup default; monitor is
+# additive.
 #
 # The rule points at inbox.sh (not check-inbox.sh): inbox.sh prints the unread
 # messages in plain text AND marks them read in the same call, so the agent sees
@@ -18,9 +28,11 @@
 #
 # Rule files need no folder-trust (Grok's trust gate is for execution —
 # hooks/MCP/LSP — not rules), and a project-level .grok/rules is read even
-# outside a git repo, so this also works for spawned sessions. delivery_modes is
-# "turn off": turn => rule present (self-poll active), off => rule removed.
-# Uses resolve_hooks_file + SKILL_DIR from delivery.sh's sourced context.
+# outside a git repo, so this also works for spawned sessions.
+# delivery_modes is "turn monitor off". A marker comment at the top of the rule
+# records which mode wrote it so status can tell turn from monitor.
+# Uses resolve_hooks_file + SKILL_DIR + RUN_DIR from delivery.sh's sourced context.
+
 agmsg_delivery_apply() {
   local type="$1"
   local project="$2"
@@ -28,12 +40,14 @@ agmsg_delivery_apply() {
   local rule_file
   rule_file=$(resolve_hooks_file "$type" "$project")
 
-  # Always start clean; turn rewrites the rule, off leaves it absent.
+  # Always start clean; turn/monitor rewrite the rule, off leaves it absent.
   rm -f "$rule_file"
 
-  if [ "$mode" = "turn" ]; then
-    mkdir -p "$(dirname "$rule_file")"
-    cat <<EOF > "$rule_file"
+  case "$mode" in
+    turn)
+      mkdir -p "$(dirname "$rule_file")"
+      cat <<EOF > "$rule_file"
+<!-- agmsg-delivery-mode: turn -->
 # agmsg — check your inbox each turn
 
 You belong to one or more agmsg teams. Before you respond to the user on each
@@ -49,12 +63,123 @@ turn, check your agmsg inbox so you never miss a teammate's message.
 3. If any messages were shown, relay them to the user before continuing with
    their request.
 
-There is no background watcher for Grok Build — this self-check is how delivery
+There is no background watcher in turn mode — this self-check is how delivery
 works. Removing this file turns automatic delivery off.
 EOF
+      ;;
+    monitor)
+      mkdir -p "$(dirname "$rule_file")"
+      cat <<EOF > "$rule_file"
+<!-- agmsg-delivery-mode: monitor -->
+# agmsg — keep a real-time inbox watcher running
+
+You belong to one or more agmsg teams. Incoming messages are delivered in real
+time by a background watcher you launch with the \`monitor\` tool.
+
+At the start of each session (and any time no agmsg watcher is running), launch
+it once:
+
+1. Identify yourself if you have not already:
+   \`$SKILL_DIR/scripts/whoami.sh '$project' $type\`
+   It prints your \`agent=\` name and \`teams=\` list.
+2. Start the watcher with the \`monitor\` tool, persistent, so each new message
+   streams into the conversation as a notification:
+   - command: \`$SKILL_DIR/scripts/watch.sh "\$GROK_SESSION_ID" '$project' $type\`
+   - description: \`agmsg inbox stream\`
+   - persistent: true
+3. Each notification line is one message:
+   \`<ts> | <team> | <from> -> <to> | <body>\`. React as they arrive; reply with
+   \`$SKILL_DIR/scripts/send.sh <team> <your-agent-name> <to_agent> "<message>"\`.
+
+Launch it only once per session — if a watcher is already streaming, do not
+start a second one. Stopping is via the \`kill_command_or_subagent\` tool on the
+watcher's task id. Removing this file turns automatic delivery off.
+EOF
+      ;;
+    off)
+      : # rule file already removed
+      ;;
+  esac
+}
+
+# Enabling monitor: nudge the CURRENT session to launch the watcher now (the
+# rule above re-declares it for future turns/sessions). Mirrors claude-code's
+# in-session directive, but worded for Grok's `monitor` tool since there is no
+# SessionStart hook to auto-launch it.
+agmsg_delivery_on_enable() {
+  local mode="$1" type="$2" project="$3"
+  [ "$mode" = "monitor" ] || return 0
+  echo "Future sessions: the .grok/rules/agmsg.md rule will prompt the watcher launch (Grok has no SessionStart auto-start)."
+  _agmsg_grok_emit_monitor_directive "$type" "$project"
+}
+
+# Grok-flavored stop directive (overrides the default Claude TaskStop wording).
+agmsg_delivery_stop_directive() {
+  cat <<'EOF'
+
+AGMSG-DIRECTIVE: If an agmsg inbox watcher is streaming into this session via
+the monitor tool, stop it with kill_command_or_subagent on its task id. Any
+watch.sh processes have already been killed by this command.
+EOF
+}
+
+# Status: the rule file's marker is the state. Absent => off; a monitor marker
+# => monitor; anything else (a present rule) => turn.
+agmsg_delivery_status() {
+  local type="$1" project="$2"
+  local rule_file
+  rule_file="$(resolve_hooks_file "$type" "$project")"
+  if [ ! -f "$rule_file" ]; then
+    echo "mode: off"
+  elif grep -q "agmsg-delivery-mode: monitor" "$rule_file" 2>/dev/null; then
+    echo "mode: monitor"
+  else
+    echo "mode: turn"
   fi
 }
 
-# Status is the rule file's presence: present => turn, absent => off (no monitor
-# for a self-poll type). Same shared helper the other rule-file types use.
-agmsg_delivery_status() { rulefile_status "$@"; }
+# Emit the in-session "launch the watcher now" directive for Grok. Mirrors
+# delivery.sh's emit_monitor_directive (claude-code) but bakes GROK_SESSION_ID
+# and points at Grok's monitor tool. Reuses the shared instance-id normalization
+# and the dup-watcher guard so a second `set monitor` does not orphan a live
+# watcher.
+_agmsg_grok_emit_monitor_directive() {
+  local type="$1" project="$2"
+  local watch="$SKILL_DIR/scripts/watch.sh"
+
+  # Grok exports GROK_SESSION_ID for every subprocess; bake it in so the agent
+  # never invents a value and SessionEnd-style cleanup can find the pidfile.
+  local session_id="${GROK_SESSION_ID:-}"
+  if [ -z "$session_id" ]; then
+    session_id="agmsg-$(compat_uuidgen | tr 'A-Z' 'a-z')"
+  fi
+  session_id="$(agmsg_normalize_instance_id "$session_id" "$type")"
+
+  local pidfile="$RUN_DIR/watch.$session_id.pid"
+  if [ -f "$pidfile" ]; then
+    local existing
+    existing=$(cat "$pidfile" 2>/dev/null || true)
+    if [ -n "$existing" ] && kill -0 "$existing" 2>/dev/null; then
+      cat <<EOF
+
+A watch.sh is already streaming into this session (pid $existing). No
+action needed — the existing watcher is the active one.
+EOF
+      return 0
+    fi
+  fi
+
+  local watch_command
+  watch_command="$(printf '%q %q %q %q' "$watch" "$session_id" "$project" "$type")"
+  cat <<EOF
+
+AGMSG-DIRECTIVE: For this running session, invoke the monitor tool now with:
+  command: $watch_command
+  description: agmsg inbox stream
+  persistent: true
+
+Pass the command above verbatim — the session id is already filled in. Each
+output line is one message; stop the watcher with kill_command_or_subagent on
+its task id when you switch roles or turn delivery off.
+EOF
+}

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -46,20 +46,25 @@ Four possible outputs:
      ```
      Choose delivery mode for incoming messages:
 
-       1) turn — Check inbox at the end of each assistant turn
-                  A .grok/rules/agmsg.md rule has you self-check inbox.sh
-                  each turn (Grok hooks can't push, so delivery is self-poll).
+       1) turn    — Check inbox at the end of each assistant turn
+                     A .grok/rules/agmsg.md rule has you self-check inbox.sh
+                     each turn. Zero setup; no background watcher.
 
-       2) off  — No automatic delivery
-                  Manual /__SKILL_NAME__ only.
+       2) monitor — Real-time push via a background watcher
+                     Launches watch.sh through the `monitor` tool; each new
+                     message streams in as a notification. You launch the watcher
+                     explicitly (Grok hooks can't auto-start it at SessionStart).
+
+       3) off     — No automatic delivery
+                     Manual /__SKILL_NAME__ only.
 
      [1]:
      ```
 
      - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
-     - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
+     - Map the chosen number to a mode (`1`→`turn`, `2`→`monitor`, `3`→`off`) and run:
        `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> grok-build "$(pwd)"`
-     - Grok Build has no Monitor-tool equivalent, so `monitor` and `both` modes are not offered here.
+     - If you chose `monitor`, read the `AGMSG-DIRECTIVE` block that `delivery.sh` prints and follow it now: invoke the `monitor` tool with the given `command` / `description` / `persistent: true` so the watcher starts streaming into this session. `both` is not supported.
 
   6. Then check inbox for the newly joined team.
 
@@ -76,6 +81,14 @@ Four possible outputs:
 ## Execute
 
 **Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
+
+**Ensure the monitor is running first (monitor mode only).** If the project's delivery mode is `monitor` (check via `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status grok-build "$(pwd)"`) and no `agmsg inbox stream` watcher is running in this session yet, invoke the `monitor` tool now (before the subcommand below):
+
+- command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "$GROK_SESSION_ID" "$(pwd)" grok-build`
+- description: `agmsg inbox stream`
+- persistent: true
+
+Each output line is one message: `<ts> | <team> | <from> -> <to> | <body>`. React to messages as they arrive; reply with `send.sh`. Launch it only once — if a watcher is already streaming, do not start a second one. In `turn`/`off` mode there is no watcher; skip this.
 
 **If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
 1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
@@ -107,22 +120,33 @@ If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 1. Parse the new role name.
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" grok-build` to see whether the role is already registered for this (project, type).
 3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> grok-build "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
-4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
-5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Grok Build has no Monitor tool, so receive still covers all of your registered roles in this project.)"
+4. **If delivery mode is `monitor`**, switch the watcher to the new role so receive is restricted to it:
+   a. If an `agmsg inbox stream` watcher is already running in this session, stop it with `kill_command_or_subagent` on its task id.
+   b. Launch a fresh watcher with the `monitor` tool (persistent):
+      - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "$GROK_SESSION_ID" "$(pwd)" grok-build <name>`
+      - description: `agmsg inbox stream`
+   The 4th argument restricts the subscription to messages addressed to `<name>` only. In `turn`/`off` mode there is no watcher to switch — skip this step.
+5. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
+6. Tell the user: "Now acting as `<name>`. Sends use `<name>` as from. In monitor mode, receive is restricted to `<name>`; in turn/off mode receive still covers all your registered roles."
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" grok-build <name>` to remove that role's registration.
 3. If the session's active FROM was `<name>`, clear that state.
-4. Tell the user: "Dropped role `<name>` from this project."
+4. **If delivery mode is `monitor`** and an `agmsg inbox stream` watcher is running in this session, stop it with `kill_command_or_subagent`, then relaunch it with the `monitor` tool using the default (no 4th arg) subscription so receive covers the project's remaining roles:
+   - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "$GROK_SESSION_ID" "$(pwd)" grok-build`
+   - description: `agmsg inbox stream`
+   - persistent: true
+5. Tell the user: "Dropped role `<name>` from this project."
 
 If argument is "mode" (no further args):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status grok-build "$(pwd)"`
 2. Show the output to the user.
 
 If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
-1. Parse the mode. Grok Build supports only `turn` and `off` — reject `monitor` and `both` with: "Grok Build has no Monitor tool; only `turn` or `off` modes are supported."
+1. Parse the mode. Grok Build supports `turn`, `monitor`, and `off` — reject `both` with: "Grok Build does not support `both`; use `turn`, `monitor`, or `off`."
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> grok-build "$(pwd)"`
+3. If the mode is `monitor`, read the `AGMSG-DIRECTIVE` block `delivery.sh` prints and follow it: invoke the `monitor` tool with the given command so the watcher starts in this session. If the mode is `turn` or `off` and a watcher is streaming, stop it with `kill_command_or_subagent`.
 
 If argument is "hook on" (legacy alias):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn grok-build "$(pwd)"`

--- a/scripts/drivers/types/grok-build/type.conf
+++ b/scripts/drivers/types/grok-build/type.conf
@@ -7,5 +7,12 @@ model_arg=--model
 detect=GROK_SESSION_ID
 detect_proc=grok grok-*
 hooks_file=.grok/rules/agmsg.md
-monitor=yes
+# monitor=no: spawn skips the readiness handshake for grok-build. Its monitor
+# watcher attaches when the agent runs the actas/rule launch (no SessionStart
+# hook), so there is no sentinel for `spawn` to await reliably; awaiting it would
+# hang a default turn/off-mode spawn (no watcher) until timeout. monitor is still
+# offered as a delivery mode below — the delivery_modes gate, not this key, is
+# what enables it. A readiness handshake for monitor-mode grok spawns is a
+# follow-up tied to the unread catch-up drain (#229).
+monitor=no
 delivery_modes=turn monitor off

--- a/scripts/drivers/types/grok-build/type.conf
+++ b/scripts/drivers/types/grok-build/type.conf
@@ -7,5 +7,5 @@ model_arg=--model
 detect=GROK_SESSION_ID
 detect_proc=grok grok-*
 hooks_file=.grok/rules/agmsg.md
-monitor=no
-delivery_modes=turn off
+monitor=yes
+delivery_modes=turn monitor off

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -444,12 +444,15 @@ place_and_launch() {
 # receiving. Block until that appears so the leader doesn't send a job into the
 # cold-start window (before the watcher attaches) and lose it.
 #
-# Types without a Monitor (manifest `monitor=no`) never touch the readiness
-# sentinel, so skip the wait for them (their receive is poll-based anyway).
+# Types with `monitor=no` do not produce a spawn-awaitable readiness sentinel, so
+# skip the wait. That covers types with no Monitor at all (codex) AND types whose
+# watcher attaches via the agent's own launch rather than a spawn-time sentinel
+# (grok-build, whose monitor mode is real but not awaitable here) — receive there
+# is poll-based or agent-launched anyway.
 READY_PATH="$(agmsg_ready_path "$TEAM" "$NAME")"
 if [ "$(agmsg_type_get "$AGENT_TYPE" monitor)" = "no" ] && [ "$WAIT_READY" = "1" ]; then
   WAIT_READY=0
-  echo "spawn: '$AGENT_TYPE' has no Monitor — skipping readiness wait (--no-wait implied)" >&2
+  echo "spawn: '$AGENT_TYPE' has no spawn readiness handshake — skipping readiness wait (--no-wait implied)" >&2
 fi
 
 # Clear any stale sentinel before launching so we only observe THIS spawn's

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1595,11 +1595,38 @@ JSON
   [ ! -f "$TEST_PROJECT/.grok/rules/agmsg.md" ]
 }
 
-@test "delivery set monitor (grok-build): rejected; no rule file written" {
-  run bash "$SCRIPTS/delivery.sh" set monitor grok-build "$TEST_PROJECT"
-  [ "$status" -ne 0 ]
-  [[ "$output" =~ "not supported" ]]
-  [ ! -f "$TEST_PROJECT/.grok/rules/agmsg.md" ]
+@test "delivery set monitor (grok-build): writes a monitor rule and emits the launch directive" {
+  GROK_SESSION_ID="grok-sess-1" run bash "$SCRIPTS/delivery.sh" set monitor grok-build "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Delivery mode set to 'monitor'" ]]
+  # Emits an in-session directive to launch watch.sh via the monitor tool, with
+  # GROK_SESSION_ID baked into the command (not CLAUDE_CODE_SESSION_ID).
+  [[ "$output" == *"AGMSG-DIRECTIVE"* ]]
+  [[ "$output" == *"watch.sh"* ]]
+  [[ "$output" == *"grok-sess-1"* ]]
+  [[ "$output" == *"grok-build"* ]]
+  # The rule carries the monitor marker and points at the monitor tool.
+  local rule_file="$TEST_PROJECT/.grok/rules/agmsg.md"
+  [ -f "$rule_file" ]
+  run cat "$rule_file"
+  [[ "$output" == *"agmsg-delivery-mode: monitor"* ]]
+  [[ "$output" == *"monitor"* ]]
+  [[ "$output" == *"watch.sh"* ]]
+}
+
+@test "delivery status (grok-build): reports monitor when the monitor rule is present" {
+  GROK_SESSION_ID="grok-sess-2" bash "$SCRIPTS/delivery.sh" set monitor grok-build "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status grok-build "$TEST_PROJECT"
+  [[ "$output" =~ "mode: monitor" ]]
+}
+
+@test "delivery set turn then monitor (grok-build): rewrites the rule from turn to monitor" {
+  bash "$SCRIPTS/delivery.sh" set turn grok-build "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status grok-build "$TEST_PROJECT"
+  [[ "$output" =~ "mode: turn" ]]
+  GROK_SESSION_ID="grok-sess-3" bash "$SCRIPTS/delivery.sh" set monitor grok-build "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status grok-build "$TEST_PROJECT"
+  [[ "$output" =~ "mode: monitor" ]]
 }
 
 @test "delivery set both (grok-build): rejected; does NOT delete an existing turn rule" {

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -152,10 +152,9 @@ teardown() {
 }
 
 @test "spawn: grok-build launches the plain grok CLI with the actas prompt" {
-  # grok-build is spawnable; --no-wait skips the readiness handshake here so the
-  # test asserts only the launch command. Delivery is a rule file (no hook), so
-  # no folder-trust flag is needed — the launch is the bare
-  # `grok "/<cmd> actas <name>"`, like claude-code.
+  # grok-build is spawnable and monitor=no, so spawn skips the readiness wait.
+  # Delivery is a rule file (no hook), so no folder-trust flag is needed —
+  # the launch is the bare `grok "/<cmd> actas <name>"`, like claude-code.
   bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
   run bash "$SCRIPTS/spawn.sh" grok-build alice --project "$PROJ" --no-wait
   [ "$status" -eq 0 ]
@@ -312,4 +311,19 @@ teardown() {
   run bash "$SCRIPTS/spawn.sh" codex reviewer --project "$PROJ"
   [ "$status" -eq 0 ]
   [[ "$output" == *"skipping readiness wait"* ]]
+}
+
+@test "spawn: grok-build skips the readiness wait even without --no-wait (monitor=no)" {
+  # Regression guard: grok-build's monitor watcher attaches via the agent's
+  # actas/rule launch (no SessionStart hook) and only in monitor mode, so there
+  # is no ready sentinel for spawn to await. With monitor=no, spawn must skip the
+  # wait and return immediately instead of hanging a default turn/off-mode spawn
+  # until --ready-timeout. (Without this, monitor=yes made the wait fire.)
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run env -u TMUX bash "$SCRIPTS/spawn.sh" grok-build alice --project "$PROJ" \
+    --terminal "true # {cmd}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipping readiness wait"* ]]
+  [[ "$output" != *"status=timeout"* ]]
+  [[ "$output" != *"status=ready"* ]]
 }

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -152,9 +152,10 @@ teardown() {
 }
 
 @test "spawn: grok-build launches the plain grok CLI with the actas prompt" {
-  # grok-build is spawnable and monitor=no, so spawn skips the readiness wait.
-  # Delivery is a rule file (no hook), so no folder-trust flag is needed —
-  # the launch is the bare `grok "/<cmd> actas <name>"`, like claude-code.
+  # grok-build is spawnable; --no-wait skips the readiness handshake here so the
+  # test asserts only the launch command. Delivery is a rule file (no hook), so
+  # no folder-trust flag is needed — the launch is the bare
+  # `grok "/<cmd> actas <name>"`, like claude-code.
   bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
   run bash "$SCRIPTS/spawn.sh" grok-build alice --project "$PROJ" --no-wait
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Add an opt-in, explicitly-launched `monitor` delivery mode for **grok-build**, giving
it real-time inbox push (not just per-turn self-poll).

Grok Build exposes a `monitor` background-task tool — `monitor(command, description,
persistent: true)` accumulates a long-running command's stdout and injects each line
back into the conversation as a notification — the same shape as Claude Code's
`Monitor` tool. Running agmsg's `watch.sh` under it yields real-time delivery.

The **only** difference from claude-code: Grok's passive hooks discard stdout and
inject no context, so the watcher cannot be auto-started from SessionStart. The
launch is therefore explicit — the `.grok/rules/agmsg.md` rule and the `/agmsg`
actas flow instruct the agent to start the watcher via the `monitor` tool. `turn`
stays the zero-setup default; `monitor` is additive and opt-in.

## Changes

- `scripts/drivers/types/grok-build/type.conf`: `delivery_modes=turn monitor off` (the gate that enables `monitor`). `monitor` stays `no` so `spawn` keeps skipping the readiness handshake for grok-build (its watcher attaches via the agent's actas/rule launch, only in monitor mode — there is no sentinel to await, and waiting would hang a default turn/off-mode spawn until timeout).
- `scripts/drivers/types/grok-build/_delivery.sh`:
  - `apply` writes a turn rule or a monitor rule (each tagged with an
    `agmsg-delivery-mode:` marker comment).
  - `on_enable` (monitor) emits an in-session `AGMSG-DIRECTIVE` to launch `watch.sh`
    via the `monitor` tool, baking `GROK_SESSION_ID` into the command and reusing the
    shared instance-id normalization + dup-watcher guard.
  - `stop_directive` override: grok-flavored stop (`kill_command_or_subagent`).
  - `status` reports `monitor` / `turn` / `off` from the rule marker.
- `scripts/delivery.sh`: extract the in-session stop directive into a Template-Method
  hook (`agmsg_delivery_stop_directive`, default = the existing Claude `TaskStop`
  wording) so a type can override the wording. No behavior change for other types.
- `scripts/drivers/types/grok-build/template.md`: offer `monitor` in the delivery
  prompt; ensure-monitor-running preamble; launch/teardown the watcher in the actas
  and drop flows (`kill_command_or_subagent` + relaunch); accept `monitor` in `mode`;
  drop the stale "Grok has no Monitor tool" claims.

## Tests

- `tests/test_delivery.bats`: monitor now writes a monitor rule + emits the launch
  directive (with `GROK_SESSION_ID` baked, not `CLAUDE_CODE_SESSION_ID`); status
  reports `monitor`; turn->monitor rewrites the rule. (`both` is still rejected.)
- `tests/test_spawn.bats`: comment corrected (grok-build is now `monitor=yes`;
  `--no-wait` is why the launch test does not block on readiness).

## Notes

- `spawn` keeps skipping the readiness handshake for grok-build (`monitor=no`). A
  handshake for monitor-mode grok spawns needs the unread catch-up drain (#229) to
  cover the cold-start window first, so it is left as a follow-up. `--no-wait` and
  `--ready-timeout` are unaffected.
- watch.sh liveness (#67/#215) keys on the agent pid resolved from the process tree;
  grok-build resolves via `detect_proc=grok grok-*`, the same mechanism as other types.
- Cut from `main`; independent of the storage branch.
