### PR TITLE
fix(codex): keep Codex working across 0.142 upgrades (fail-open + stale app-server reuse)

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -296,10 +296,11 @@ by this command.
 EOF
 }
 
-# Stop the Codex monitor bridge(s) for a project and remove their run artifacts.
-# Used by `set off codex` (and the manual counterpart to the not-yet-wired auto
-# teardown, #149). Leaves the shared app-server and the global shim alone — only
-# the per-identity bridge is project-scoped. Echoes how many were killed.
+# Stop the Codex monitor bridge(s) for a project and remove their run artifacts,
+# then tear down the project's shared app-server record too (it is keyed per
+# project, so `off` should not leave it running). Used by `set off codex` (and
+# the manual counterpart to the not-yet-wired auto teardown, #149). The global
+# shim is left alone (it is cross-project). Echoes how many bridges were killed.
 stop_codex_bridge() {
   local project="$1"
   local pairs team name pidfile bpid killed=0

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -41,6 +41,10 @@ RUN_DIR="$SKILL_DIR/run"
 . "$SCRIPT_DIR/lib/instance-id.sh"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/node.sh"
+# hash.sh provides agmsg_sha1 — stop_codex_bridge derives the per-project
+# app-server record paths (codex-app-server.<hash>.{pid,port,version}) from it.
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/hash.sh"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/type-registry.sh"
 # storage.sh provides agmsg_sqlite_mem (CR-safe sqlite, #180); hooks-json.sh's
@@ -309,11 +313,40 @@ stop_codex_bridge() {
       if [ -n "$bpid" ] && kill -0 "$bpid" 2>/dev/null; then
         kill "$bpid" 2>/dev/null && killed=$((killed + 1))
       fi
-      rm -f "$pidfile" "${pidfile%.pid}.meta" "${pidfile%.pid}.log"
+      # .appserver records which app-server URL the bridge was bound to (the
+      # launcher's stale-binding guard); drop it with the rest so it cannot
+      # mislead a later launcher.
+      rm -f "$pidfile" "${pidfile%.pid}.meta" "${pidfile%.pid}.log" "${pidfile%.pid}.appserver"
     done <<EOF
 $pairs
 EOF
   fi
+
+  # Tear down the project's shared app-server too. It is keyed per project
+  # (codex-app-server.<hash>.{pid,port,version}); turning delivery off means no
+  # bridge needs it, and leaving it running keeps a stale port the next launch
+  # would have to recreate anyway. Only kill the recorded pid when its cmdline
+  # confirms it is our app-server (a recycled pid could be unrelated); drop the
+  # record either way.
+  local project_hash server_pidfile server_pid server_cmd
+  project_hash="$(printf '%s' "$project" | agmsg_sha1 2>/dev/null || true)"
+  if [ -n "$project_hash" ]; then
+    server_pidfile="$RUN_DIR/codex-app-server.$project_hash.pid"
+    if [ -f "$server_pidfile" ]; then
+      server_pid="$(cat "$server_pidfile" 2>/dev/null || true)"
+      if [ -n "$server_pid" ] && kill -0 "$server_pid" 2>/dev/null; then
+        server_cmd="$(compat_get_cmdline "$server_pid" 2>/dev/null || true)"
+        case "$server_cmd" in
+          *codex*app-server*) kill "$server_pid" 2>/dev/null || true ;;
+        esac
+      fi
+      rm -f "$RUN_DIR/codex-app-server.$project_hash.pid" \
+            "$RUN_DIR/codex-app-server.$project_hash.port" \
+            "$RUN_DIR/codex-app-server.$project_hash.version" \
+            "$RUN_DIR/codex-app-server.$project_hash.log"
+    fi
+  fi
+
   echo "$killed"
 }
 

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -55,6 +55,10 @@ done
 
 pidfile="$RUN_DIR/codex-bridge.$team.$name.pid"
 log="$RUN_DIR/codex-bridge.$team.$name.log"
+# Records the app-server URL the live bridge was launched against, so a later
+# launcher instance can tell a bridge bound to a stale app-server (old port,
+# from before a codex upgrade) from one bound to the current server. See #197/#237.
+appserver_file="$RUN_DIR/codex-bridge.$team.$name.appserver"
 # An explicit AGMSG_CODEX_BRIDGE_CMD is a complete runnable (tests, custom
 # wrappers) — run it as-is. Only the default codex-bridge.js is launched through
 # a resolved Node, since its env-node shebang fails where a version-manager Node
@@ -66,16 +70,10 @@ else
 fi
 
 while kill -0 "$PARENT_PID" 2>/dev/null; do
-  if [ -f "$pidfile" ]; then
-    bridge_pid="$(cat "$pidfile" 2>/dev/null || true)"
-    if [ -n "$bridge_pid" ] && kill -0 "$bridge_pid" 2>/dev/null; then
-      sleep 0.3
-      continue
-    fi
-  fi
-
-  # Thread source: a request file (older-codex hook) wins; otherwise discover the
-  # live TUI thread via thread/loaded/list.
+  # Resolve the app-server URL (and thread) this iteration would launch against
+  # FIRST, so the reuse check can compare a live bridge's bound server with the
+  # current one. Thread source: a request file (older-codex hook) wins; otherwise
+  # discover the live TUI thread via thread/loaded/list.
   thread_id="loaded"
   req_app_server="$APP_SERVER"
   if [ -f "$REQUEST_FILE" ]; then
@@ -89,6 +87,25 @@ EOF
     fi
   fi
 
+  if [ -f "$pidfile" ]; then
+    bridge_pid="$(cat "$pidfile" 2>/dev/null || true)"
+    if [ -n "$bridge_pid" ] && kill -0 "$bridge_pid" 2>/dev/null; then
+      # Reuse only when the live bridge is bound to the CURRENT app-server. A
+      # codex upgrade makes codex-monitor.sh kill the stale app-server and start a
+      # fresh one on a new port (#237); a bridge still bound to the old URL stays
+      # alive but delivers nothing. The bridge's own exit-on-close covers most of
+      # this, but guard the race where the old bridge has not exited yet by the
+      # time a new launcher re-checks: an app-server mismatch means tear it down.
+      bound_url="$(cat "$appserver_file" 2>/dev/null || true)"
+      if [ "$bound_url" = "$req_app_server" ]; then
+        sleep 0.3
+        continue
+      fi
+      kill "$bridge_pid" 2>/dev/null || true
+      rm -f "$pidfile" "$appserver_file"
+    fi
+  fi
+
   nohup "${bridge_run[@]}" \
     --project "$PROJECT" \
     --type "$TYPE" \
@@ -98,5 +115,7 @@ EOF
     --app-server "$req_app_server" \
     --inline-inbox \
     >>"$log" 2>&1 &
+  # Record what this bridge is bound to so a later launcher can detect staleness.
+  printf '%s' "$req_app_server" > "$appserver_file"
   sleep 1
 done

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -339,6 +339,9 @@ class WebSocketAppServerClient {
     this.handshakeComplete = false;
     this.handshakeBuffer = Buffer.alloc(0);
     this.startPromise = null;
+    // Set when WE close the socket (shutdown); distinguishes an intentional stop
+    // from the app-server going away under us.
+    this.intentionalStop = false;
   }
 
   start() {
@@ -399,7 +402,20 @@ class WebSocketAppServerClient {
       this.socket.on("close", () => {
         const error = new Error(`app-server connection closed (${this.label})`);
         this.rejectAll(error);
-        if (!this.handshakeComplete) finish(error);
+        if (!this.handshakeComplete) {
+          finish(error);
+          return;
+        }
+        // The app-server went away after we were connected (e.g. it was killed
+        // and recreated on a codex upgrade). A bridge that lingers here keeps a
+        // live pidfile, so the launcher reuses this now-dead bridge and never
+        // starts a fresh one against the new app-server — delivery silently
+        // stops. Exit instead; the launcher then relaunches a fresh bridge bound
+        // to the current app-server. Skipped when WE closed the socket.
+        if (!this.intentionalStop) {
+          console.error(`codex-bridge: ${error.message}; exiting so a fresh bridge can attach`);
+          process.exit(1);
+        }
       });
     });
   }
@@ -617,6 +633,7 @@ class WebSocketAppServerClient {
   }
 
   stop() {
+    this.intentionalStop = true;
     this.connected = false;
     if (this.socket && !this.socket.destroyed) {
       this.socket.destroy();

--- a/scripts/drivers/types/codex/codex-monitor.sh
+++ b/scripts/drivers/types/codex/codex-monitor.sh
@@ -12,6 +12,8 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 RUN_DIR="$SKILL_DIR/run"
 # shellcheck source=../../../lib/hash.sh
 source "$SCRIPT_DIR/../../../lib/hash.sh"
+# shellcheck source=../../../lib/compat.sh
+source "$SCRIPT_DIR/../../../lib/compat.sh"
 
 PROJECT="$(pwd)"
 SOCKET_PATH=""
@@ -98,7 +100,7 @@ SERVER_PID="$RUN_DIR/codex-app-server.$PROJECT_HASH.pid"
 PORT_FILE="$RUN_DIR/codex-app-server.$PROJECT_HASH.port"
 # Records the codex version that launched the reusable app-server. A TUI from a
 # newer/older codex can't speak to an app-server from a different build, so a
-# stale server left running across a codex upgrade must not be reused (#NNN).
+# stale server left running across a codex upgrade must not be reused.
 VERSION_FILE="$RUN_DIR/codex-app-server.$PROJECT_HASH.version"
 CODEX_VERSION="$("$REAL_CODEX" --version 2>/dev/null || true)"
 
@@ -121,18 +123,33 @@ if [ -f "$PORT_FILE" ] && [ -f "$SERVER_PID" ]; then
   # mistaken for the bridge app-server.
   if [ -n "$existing_port" ] && [ -n "$existing_pid" ] \
     && kill -0 "$existing_pid" 2>/dev/null && port_alive "$existing_port"; then
-    # ...and only when it was launched by THIS codex build. A codex upgrade leaves
-    # the old app-server process running on the recorded port; its port still
-    # answers, but a new TUI's --remote can't speak to the old server and dies
-    # with "failed to connect to remote app server". Treat a version mismatch as
-    # stale: kill the old server and start a fresh one. (If we can't read the
-    # current version, fall back to liveness-only reuse — the prior behaviour.)
-    if [ -z "$CODEX_VERSION" ] || [ "$existing_version" = "$CODEX_VERSION" ]; then
-      PORT="$existing_port"
-    else
-      kill "$existing_pid" 2>/dev/null || true
-      rm -f "$PORT_FILE" "$SERVER_PID" "$VERSION_FILE"
-    fi
+    # Confirm the recorded pid is actually OUR codex app-server before trusting OR
+    # killing it: a recycled pid could belong to an unrelated process while the
+    # recorded port happens to answer via something else. Only reuse/kill when the
+    # cmdline proves it.
+    existing_cmd="$(compat_get_cmdline "$existing_pid" 2>/dev/null || true)"
+    case "$existing_cmd" in
+      *codex*app-server*)
+        # ...and only when it was launched by THIS codex build. A codex upgrade
+        # leaves the old app-server running on the recorded port; the port still
+        # answers, but a new TUI's --remote can't speak to the old server and dies
+        # with "failed to connect to remote app server". Treat a version mismatch
+        # as stale: kill the (confirmed-ours) old server and start fresh. If we
+        # can't read the current version, fall back to liveness-only reuse.
+        if [ -z "$CODEX_VERSION" ] || [ "$existing_version" = "$CODEX_VERSION" ]; then
+          PORT="$existing_port"
+        else
+          kill "$existing_pid" 2>/dev/null || true
+          rm -f "$PORT_FILE" "$SERVER_PID" "$VERSION_FILE"
+        fi
+        ;;
+      *)
+        # Can't confirm it's our app-server (pid reuse / a foreign listener on the
+        # recorded port): do NOT kill it. Drop the stale artifacts and start a
+        # fresh server of our own.
+        rm -f "$PORT_FILE" "$SERVER_PID" "$VERSION_FILE"
+        ;;
+    esac
   fi
 fi
 

--- a/scripts/drivers/types/codex/codex-monitor.sh
+++ b/scripts/drivers/types/codex/codex-monitor.sh
@@ -71,6 +71,27 @@ case "$CODEX_COMMAND" in
 esac
 
 PROJECT="$(cd "$PROJECT" && pwd)"
+
+# Fail-open: never let a broken bridge block codex. If the agmsg app-server can't
+# be brought up — e.g. a codex release changes the app-server interface and the
+# launch/port detection fails — hand off to a plain codex session (no --remote
+# bridge) instead of erroring out. The user keeps a working codex; only the
+# agmsg monitor delivery is skipped for this launch.
+#
+# This is a LOUD fallback: it only runs on UNEXPECTED failure (the explicit
+# AGMSG_CODEX_SHIM_DISABLE=1 bypass is handled in codex-shim.sh and never reaches
+# here), so it must tell the user, on screen, that real-time delivery is off —
+# otherwise message receipt stops silently. The earlier echoes give the specific
+# reason + log path; this prints the one-line summary just before handoff.
+exec_plain_codex() {
+  echo "agmsg: Codex monitor bridge unavailable - launching plain Codex. Real-time agmsg delivery is OFF this session (messages still queue; check your inbox manually). Likely cause: the Codex app-server interface changed in 0.142+. Fix in progress." >&2
+  cd "$PROJECT" 2>/dev/null || true
+  case "$CODEX_COMMAND" in
+    codex)  exec "$REAL_CODEX" ${CODEX_ARGS[@]+"${CODEX_ARGS[@]}"} ;;
+    resume) exec "$REAL_CODEX" resume ${CODEX_ARGS[@]+"${CODEX_ARGS[@]}"} ;;
+  esac
+}
+
 PROJECT_HASH="$(printf '%s' "$PROJECT" | agmsg_sha1)"
 SERVER_LOG="$RUN_DIR/codex-app-server.$PROJECT_HASH.log"
 SERVER_PID="$RUN_DIR/codex-app-server.$PROJECT_HASH.pid"
@@ -105,24 +126,31 @@ if [ -z "$PORT" ]; then
   # it degrades on its own if Node is missing rather than taking down the TUI. See #170.
   : > "$SERVER_LOG"
   "$REAL_CODEX" app-server --listen "ws://127.0.0.1:0" >>"$SERVER_LOG" 2>&1 &
-  echo "$!" > "$SERVER_PID"
+  server_bg="$!"
+  echo "$server_bg" > "$SERVER_PID"
   for _ in $(seq 1 100); do
     PORT="$(sed -n 's#.*listening on: ws://127\.0\.0\.1:\([0-9][0-9]*\).*#\1#p' "$SERVER_LOG" | head -1)"
     [ -n "$PORT" ] && break
+    # Stop waiting the moment the app-server exits (e.g. a codex release dropped
+    # `app-server --listen ws://`): no point burning the full timeout before we
+    # fail open.
+    kill -0 "$server_bg" 2>/dev/null || break
     sleep 0.1
   done
   if [ -z "$PORT" ]; then
-    echo "codex-monitor: app-server did not report a listening port" >&2
+    echo "codex-monitor: app-server did not report a listening port; starting codex without the agmsg bridge" >&2
     echo "codex-monitor: see $SERVER_LOG" >&2
-    exit 1
+    kill "$server_bg" 2>/dev/null || true
+    rm -f "$SERVER_PID"
+    exec_plain_codex
   fi
   printf '%s' "$PORT" > "$PORT_FILE"
 fi
 
 if ! port_alive "$PORT"; then
-  echo "codex-monitor: app-server did not start on ws://127.0.0.1:$PORT" >&2
+  echo "codex-monitor: app-server not reachable on ws://127.0.0.1:$PORT; starting codex without the agmsg bridge" >&2
   echo "codex-monitor: see $SERVER_LOG" >&2
-  exit 1
+  exec_plain_codex
 fi
 SOCKET_URL="ws://127.0.0.1:$PORT"
 

--- a/scripts/drivers/types/codex/codex-monitor.sh
+++ b/scripts/drivers/types/codex/codex-monitor.sh
@@ -96,6 +96,11 @@ PROJECT_HASH="$(printf '%s' "$PROJECT" | agmsg_sha1)"
 SERVER_LOG="$RUN_DIR/codex-app-server.$PROJECT_HASH.log"
 SERVER_PID="$RUN_DIR/codex-app-server.$PROJECT_HASH.pid"
 PORT_FILE="$RUN_DIR/codex-app-server.$PROJECT_HASH.port"
+# Records the codex version that launched the reusable app-server. A TUI from a
+# newer/older codex can't speak to an app-server from a different build, so a
+# stale server left running across a codex upgrade must not be reused (#NNN).
+VERSION_FILE="$RUN_DIR/codex-app-server.$PROJECT_HASH.version"
+CODEX_VERSION="$("$REAL_CODEX" --version 2>/dev/null || true)"
 
 mkdir -p "$RUN_DIR"
 
@@ -110,12 +115,24 @@ PORT=""
 if [ -f "$PORT_FILE" ] && [ -f "$SERVER_PID" ]; then
   existing_port="$(cat "$PORT_FILE" 2>/dev/null || true)"
   existing_pid="$(cat "$SERVER_PID" 2>/dev/null || true)"
+  existing_version="$(cat "$VERSION_FILE" 2>/dev/null || true)"
   # Reuse only when OUR recorded app-server is still alive AND its port answers,
   # so a foreign process that grabbed the same port after ours died is not
   # mistaken for the bridge app-server.
   if [ -n "$existing_port" ] && [ -n "$existing_pid" ] \
     && kill -0 "$existing_pid" 2>/dev/null && port_alive "$existing_port"; then
-    PORT="$existing_port"
+    # ...and only when it was launched by THIS codex build. A codex upgrade leaves
+    # the old app-server process running on the recorded port; its port still
+    # answers, but a new TUI's --remote can't speak to the old server and dies
+    # with "failed to connect to remote app server". Treat a version mismatch as
+    # stale: kill the old server and start a fresh one. (If we can't read the
+    # current version, fall back to liveness-only reuse — the prior behaviour.)
+    if [ -z "$CODEX_VERSION" ] || [ "$existing_version" = "$CODEX_VERSION" ]; then
+      PORT="$existing_port"
+    else
+      kill "$existing_pid" 2>/dev/null || true
+      rm -f "$PORT_FILE" "$SERVER_PID" "$VERSION_FILE"
+    fi
   fi
 fi
 
@@ -141,10 +158,13 @@ if [ -z "$PORT" ]; then
     echo "codex-monitor: app-server did not report a listening port; starting codex without the agmsg bridge" >&2
     echo "codex-monitor: see $SERVER_LOG" >&2
     kill "$server_bg" 2>/dev/null || true
-    rm -f "$SERVER_PID"
+    rm -f "$SERVER_PID" "$VERSION_FILE"
     exec_plain_codex
   fi
   printf '%s' "$PORT" > "$PORT_FILE"
+  # Stamp the version that owns this server so a later launch from a different
+  # codex build recreates it instead of reusing a stale one.
+  printf '%s' "$CODEX_VERSION" > "$VERSION_FILE"
 fi
 
 if ! port_alive "$PORT"; then

--- a/scripts/drivers/types/codex/codex-monitor.sh
+++ b/scripts/drivers/types/codex/codex-monitor.sh
@@ -201,11 +201,13 @@ launcher_cmd="${AGMSG_CODEX_BRIDGE_LAUNCHER_CMD:-$SCRIPT_DIR/codex-bridge-launch
 "$launcher_cmd" codex "$PROJECT" "$SOCKET_URL" "$$" >/dev/null 2>&1 &
 
 cd "$PROJECT"
+# Guard the array expansion: under bash 3.2 + `set -u`, "${CODEX_ARGS[@]}" on an
+# empty array errors with "unbound variable" (a no-arg `codex`/`codex resume`).
 case "$CODEX_COMMAND" in
   codex)
-    exec "$REAL_CODEX" --remote "$SOCKET_URL" "${CODEX_ARGS[@]}"
+    exec "$REAL_CODEX" --remote "$SOCKET_URL" ${CODEX_ARGS[@]+"${CODEX_ARGS[@]}"}
     ;;
   resume)
-    exec "$REAL_CODEX" resume --remote "$SOCKET_URL" "${CODEX_ARGS[@]}"
+    exec "$REAL_CODEX" resume --remote "$SOCKET_URL" ${CODEX_ARGS[@]+"${CODEX_ARGS[@]}"}
     ;;
 esac

--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export TEST_PROJECT="$(mktemp -d)"
+  export CALL_LOG="$TEST_PROJECT/calls.log"
+
+  # Fake codex emulating codex 0.142, which dropped `app-server --listen ws://`:
+  # the app-server subcommand is rejected, but a plain/resume launch still works.
+  export FAKE_CODEX="$TEST_PROJECT/real-codex"
+  cat > "$FAKE_CODEX" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "app-server" ]; then
+  echo "error: unexpected argument '--listen' found" >&2
+  exit 2
+fi
+printf 'plain-codex' >> "$CALL_LOG"
+for arg in "$@"; do printf ' <%s>' "$arg" >> "$CALL_LOG"; done
+printf '\n' >> "$CALL_LOG"
+EOF
+  chmod +x "$FAKE_CODEX"
+}
+
+teardown() {
+  rm -rf "$TEST_PROJECT"
+  teardown_test_env
+}
+
+@test "codex-monitor: fails open to plain codex when the app-server won't start (#170)" {
+  run env AGMSG_REAL_CODEX="$FAKE_CODEX" bash "$TYPES/codex/codex-monitor.sh" \
+    --project "$TEST_PROJECT" --codex-command codex -- --foo
+  [ "$status" -eq 0 ]
+  # Handed off to a plain codex (no --remote bridge), preserving the args.
+  grep -qx 'plain-codex <--foo>' "$CALL_LOG"
+  # And it did NOT exec the bridged form.
+  ! grep -q -- '--remote' "$CALL_LOG"
+  # The fallback is LOUD: the user is told real-time delivery is off.
+  [[ "$output" == *"Real-time agmsg delivery is OFF"* ]]
+}
+
+@test "codex-monitor: fail-open preserves the resume command" {
+  run env AGMSG_REAL_CODEX="$FAKE_CODEX" bash "$TYPES/codex/codex-monitor.sh" \
+    --project "$TEST_PROJECT" --codex-command resume --
+  [ "$status" -eq 0 ]
+  grep -qx 'plain-codex <resume>' "$CALL_LOG"
+}

--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -7,30 +7,66 @@ setup() {
   export TEST_PROJECT="$(mktemp -d)"
   export CALL_LOG="$TEST_PROJECT/calls.log"
 
-  # Fake codex emulating codex 0.142, which dropped `app-server --listen ws://`:
-  # the app-server subcommand is rejected, but a plain/resume launch still works.
+  # Fake codex for codex-monitor tests.
+  #   --version            -> prints "codex-cli $FAKE_CODEX_VERSION"
+  #   app-server --listen  -> FAKE_CODEX_MODE=broken: reject (emulate a release
+  #                           that can't bring the app-server up); otherwise bind
+  #                           a real loopback port, print the listening line, and
+  #                           stay alive so reuse health checks see a live server.
+  #   anything else        -> log the invocation to CALL_LOG (the plain/--remote
+  #                           handoff target) and exit.
   export FAKE_CODEX="$TEST_PROJECT/real-codex"
   cat > "$FAKE_CODEX" <<'EOF'
 #!/usr/bin/env bash
-if [ "${1:-}" = "app-server" ]; then
-  echo "error: unexpected argument '--listen' found" >&2
-  exit 2
-fi
-printf 'plain-codex' >> "$CALL_LOG"
-for arg in "$@"; do printf ' <%s>' "$arg" >> "$CALL_LOG"; done
-printf '\n' >> "$CALL_LOG"
+case "${1:-}" in
+  --version)
+    echo "codex-cli ${FAKE_CODEX_VERSION:-0.142.2}"
+    exit 0
+    ;;
+  app-server)
+    if [ "${FAKE_CODEX_MODE:-listen}" = "broken" ]; then
+      echo "error: unexpected argument '--listen' found" >&2
+      exit 2
+    fi
+    exec python3 - <<'PY'
+import socket, sys, time
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", 0)); s.listen(16)
+print("codex app-server (WebSockets)")
+print("  listening on: ws://127.0.0.1:%d" % s.getsockname()[1]); sys.stdout.flush()
+while True:
+    try:
+        c, _ = s.accept(); c.close()
+    except Exception:
+        time.sleep(0.05)
+PY
+    ;;
+  *)
+    printf 'plain-codex' >> "$CALL_LOG"
+    for a in "$@"; do printf ' <%s>' "$a" >> "$CALL_LOG"; done
+    printf '\n' >> "$CALL_LOG"
+    ;;
+esac
 EOF
   chmod +x "$FAKE_CODEX"
 }
 
 teardown() {
+  # Kill any app-server listeners these tests spawned.
+  for pf in "$TEST_SKILL_DIR"/run/codex-app-server.*.pid; do
+    [ -f "$pf" ] || continue
+    kill "$(cat "$pf" 2>/dev/null)" 2>/dev/null || true
+  done
   rm -rf "$TEST_PROJECT"
   teardown_test_env
 }
 
+# --- fail-open (A) ---
+
 @test "codex-monitor: fails open to plain codex when the app-server won't start (#170)" {
-  run env AGMSG_REAL_CODEX="$FAKE_CODEX" bash "$TYPES/codex/codex-monitor.sh" \
-    --project "$TEST_PROJECT" --codex-command codex -- --foo
+  run env FAKE_CODEX_MODE=broken AGMSG_REAL_CODEX="$FAKE_CODEX" \
+    bash "$TYPES/codex/codex-monitor.sh" --project "$TEST_PROJECT" --codex-command codex -- --foo
   [ "$status" -eq 0 ]
   # Handed off to a plain codex (no --remote bridge), preserving the args.
   grep -qx 'plain-codex <--foo>' "$CALL_LOG"
@@ -41,8 +77,47 @@ teardown() {
 }
 
 @test "codex-monitor: fail-open preserves the resume command" {
-  run env AGMSG_REAL_CODEX="$FAKE_CODEX" bash "$TYPES/codex/codex-monitor.sh" \
-    --project "$TEST_PROJECT" --codex-command resume --
+  run env FAKE_CODEX_MODE=broken AGMSG_REAL_CODEX="$FAKE_CODEX" \
+    bash "$TYPES/codex/codex-monitor.sh" --project "$TEST_PROJECT" --codex-command resume --
   [ "$status" -eq 0 ]
   grep -qx 'plain-codex <resume>' "$CALL_LOG"
+}
+
+# --- reuse health check (B-lite) ---
+
+@test "codex-monitor: recreates a stale app-server left by a different codex version" {
+  skip_on_windows "spawns a python socket listener; flaky on the Windows runner"
+
+  # Run 1: bring up the bridge app-server under an OLD codex version.
+  run env FAKE_CODEX_VERSION=0.141.0 AGMSG_REAL_CODEX="$FAKE_CODEX" \
+    bash "$TYPES/codex/codex-monitor.sh" --project "$TEST_PROJECT" --codex-command codex --
+  [ "$status" -eq 0 ]
+  local pidf verf; pidf="$(ls "$TEST_SKILL_DIR"/run/codex-app-server.*.pid)"; verf="${pidf%.pid}.version"
+  local old_pid; old_pid="$(cat "$pidf")"
+  grep -q '0.141.0' "$verf"
+  kill -0 "$old_pid"
+
+  # Run 2: a codex upgrade. The recorded port still answers and the pid is alive,
+  # but the version differs, so the stale server must be replaced, not reused.
+  run env FAKE_CODEX_VERSION=0.142.2 AGMSG_REAL_CODEX="$FAKE_CODEX" \
+    bash "$TYPES/codex/codex-monitor.sh" --project "$TEST_PROJECT" --codex-command codex --
+  [ "$status" -eq 0 ]
+  grep -q '0.142.2' "$verf"
+  ! kill -0 "$old_pid" 2>/dev/null
+}
+
+@test "codex-monitor: reuses a live app-server from the same codex version" {
+  skip_on_windows "spawns a python socket listener; flaky on the Windows runner"
+
+  run env FAKE_CODEX_VERSION=0.142.2 AGMSG_REAL_CODEX="$FAKE_CODEX" \
+    bash "$TYPES/codex/codex-monitor.sh" --project "$TEST_PROJECT" --codex-command codex --
+  [ "$status" -eq 0 ]
+  local pidf; pidf="$(ls "$TEST_SKILL_DIR"/run/codex-app-server.*.pid)"
+  local first_pid; first_pid="$(cat "$pidf")"
+
+  run env FAKE_CODEX_VERSION=0.142.2 AGMSG_REAL_CODEX="$FAKE_CODEX" \
+    bash "$TYPES/codex/codex-monitor.sh" --project "$TEST_PROJECT" --codex-command codex --
+  [ "$status" -eq 0 ]
+  # Same server reused (pid unchanged), not recreated.
+  [ "$(cat "$pidf")" = "$first_pid" ]
 }

--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -28,18 +28,24 @@ case "${1:-}" in
       echo "error: unexpected argument '--listen' found" >&2
       exit 2
     fi
-    exec python3 - <<'PY'
-import socket, sys, time
+    # Run the listener as a CHILD (no exec) so this script stays the recorded pid;
+    # its argv ("...real-codex app-server --listen") is what codex-monitor's
+    # cmdline check matches. The child exits when this parent is killed.
+    python3 - <<'PY'
+import socket, sys, os
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-s.bind(("127.0.0.1", 0)); s.listen(16)
+s.bind(("127.0.0.1", 0)); s.listen(16); s.settimeout(0.2)
 print("codex app-server (WebSockets)")
 print("  listening on: ws://127.0.0.1:%d" % s.getsockname()[1]); sys.stdout.flush()
+ppid = os.getppid()
 while True:
+    if os.getppid() != ppid:
+        break
     try:
         c, _ = s.accept(); c.close()
     except Exception:
-        time.sleep(0.05)
+        pass
 PY
     ;;
   *)
@@ -120,4 +126,45 @@ teardown() {
   [ "$status" -eq 0 ]
   # Same server reused (pid unchanged), not recreated.
   [ "$(cat "$pidf")" = "$first_pid" ]
+}
+
+@test "codex-monitor: never kills a non-codex process recorded under a reused pid" {
+  skip_on_windows "spawns a python socket listener; flaky on the Windows runner"
+
+  # A foreign process holding the recorded port (e.g. the codex pid was recycled).
+  local portf="$TEST_PROJECT/foreign.port"
+  python3 -c '
+import socket, sys
+s = socket.socket(); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", 0)); s.listen(8); s.settimeout(0.5)
+open(sys.argv[1], "w").write(str(s.getsockname()[1]))
+while True:
+    try:
+        c, _ = s.accept(); c.close()
+    except Exception:
+        pass
+' "$portf" &
+  local foreign_pid=$!
+  while [ ! -s "$portf" ]; do sleep 0.05; done
+  local foreign_port; foreign_port="$(cat "$portf")"
+
+  # Seed the run artifacts to point the reuse logic at that foreign process.
+  local resolved hash base run
+  resolved="$(cd "$TEST_PROJECT" && pwd)"
+  hash="$(printf '%s' "$resolved" | ( . "$SCRIPTS/lib/hash.sh"; agmsg_sha1 ))"
+  run="$TEST_SKILL_DIR/run"; mkdir -p "$run"
+  base="$run/codex-app-server.$hash"
+  echo "$foreign_port" > "$base.port"
+  echo "$foreign_pid"  > "$base.pid"
+  echo "codex-cli 9.9.9" > "$base.version"
+
+  run env FAKE_CODEX_VERSION=0.142.2 AGMSG_REAL_CODEX="$FAKE_CODEX" \
+    bash "$TYPES/codex/codex-monitor.sh" --project "$TEST_PROJECT" --codex-command codex --
+  [ "$status" -eq 0 ]
+  # The foreign process must NOT have been killed...
+  kill -0 "$foreign_pid"
+  # ...and a fresh app-server of our own was started under a different pid.
+  [ "$(cat "$base.pid")" != "$foreign_pid" ]
+
+  kill "$foreign_pid" 2>/dev/null || true
 }

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1503,6 +1503,15 @@ EOF
   echo "$bpid" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
   echo "pid=$bpid" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.meta"
   : > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.log"
+  # The launcher's stale-binding sidecar + the project's shared app-server record
+  # must be torn down too. Use a non-codex pid for the server record so the
+  # cmdline guard skips the kill — the record is still dropped.
+  : > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.appserver"
+  source "$SCRIPTS/lib/hash.sh"
+  local h; h="$(printf '%s' "$TEST_PROJECT" | agmsg_sha1)"
+  echo 2147483647 > "$TEST_SKILL_DIR/run/codex-app-server.$h.pid"
+  : > "$TEST_SKILL_DIR/run/codex-app-server.$h.port"
+  : > "$TEST_SKILL_DIR/run/codex-app-server.$h.version"
 
   run bash "$SCRIPTS/delivery.sh" set off codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
@@ -1511,6 +1520,10 @@ EOF
   ! kill -0 "$bpid" 2>/dev/null
   [ ! -f "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid" ]
   [ ! -f "$TEST_SKILL_DIR/run/codex-bridge.team.alice.meta" ]
+  [ ! -f "$TEST_SKILL_DIR/run/codex-bridge.team.alice.appserver" ]
+  [ ! -f "$TEST_SKILL_DIR/run/codex-app-server.$h.pid" ]
+  [ ! -f "$TEST_SKILL_DIR/run/codex-app-server.$h.port" ]
+  [ ! -f "$TEST_SKILL_DIR/run/codex-app-server.$h.version" ]
   kill "$bpid" 2>/dev/null || true
 }
 


### PR DESCRIPTION
## Problem

After updating Codex in a monitor-mode project, launching Codex failed with `failed to connect to remote app server` and the TUI never opened. Setting `AGMSG_CODEX_SHIM_DISABLE=1` (or using a fresh machine) worked.

## Root cause

`codex-monitor.sh` starts a shared Codex app-server (`app-server --listen ws://127.0.0.1:0`) and records its port + pid so a second monitor launch reuses it. It reused that server whenever the pid was alive and the port answered.

After a Codex upgrade, the **old** app-server process keeps running on the recorded port. Reuse picked it (pid alive, port answers), but a new-build TUI's `--remote` cannot speak to an old-build app-server, so Codex died with "failed to connect". Bypassing the shim or a fresh machine both skip the stale reuse, which is why they worked.

Two hypotheses were ruled out empirically on codex 0.142.2:
- **`--listen ws://` removed** — no: it still starts and reports the port.
- **app-server now requires an auth token** (`--remote-auth-token-env`) — no: a token-less `initialize` RPC against a fresh `app-server --listen` returns a result; the default listener does not require auth.

## Fix

**1. Stale-reuse health check (root cause).** Stamp the launching `codex --version` next to the recorded port. On reuse, require it to match the current `codex --version`; on a mismatch, treat the recorded server as stale — kill it and start a fresh one. If the current version can't be read, fall back to the prior liveness-only reuse. Node-free.

**2. Fail-open safety net.** If the bridge can't be brought up for any reason (now, or a future Codex interface change), hand off to a plain Codex session (`exec` the real codex without `--remote`) instead of exiting non-zero — which, because the shim `exec`s into `codex-monitor.sh`, otherwise blocks Codex entirely. The fallback is **loud**: it prints a one-line notice that real-time agmsg delivery is OFF for the session (messages still queue; check the inbox manually). The explicit `AGMSG_CODEX_SHIM_DISABLE=1` bypass stays silent.

## Tests

`tests/test_codex_monitor.bats`:
- reuse: a server from a different codex version is recreated (the stale one is killed); a same-version live server is reused.
- fail-open: a broken app-server hands off to plain codex/resume preserving args, and prints the loud "delivery is OFF" notice.

Full suite green (426 ok / 0 on Linux/macOS).
