### PR TITLE
fix(grok-build): start the watcher when GROK_SESSION_ID is empty (#236 follow-up)

### DIFF
--- a/scripts/drivers/types/grok-build/_delivery.sh
+++ b/scripts/drivers/types/grok-build/_delivery.sh
@@ -147,8 +147,12 @@ _agmsg_grok_emit_monitor_directive() {
   local type="$1" project="$2"
   local watch="$SKILL_DIR/scripts/watch.sh"
 
-  # Grok exports GROK_SESSION_ID for every subprocess; bake it in so the agent
-  # never invents a value and SessionEnd-style cleanup can find the pidfile.
+  # Bake GROK_SESSION_ID in when it is set here, so the agent does not invent a
+  # value and cleanup can find the pidfile. NOTE: Grok does NOT reliably export
+  # GROK_SESSION_ID into the `monitor` tool's own shell — the rule's literal
+  # "$GROK_SESSION_ID" can expand to empty there — so watch.sh self-generates a
+  # fallback id when its first arg is empty rather than failing. This directive
+  # path still bakes the real id when delivery.sh runs with it in the env.
   local session_id="${GROK_SESSION_ID:-}"
   if [ -z "$session_id" ]; then
     session_id="agmsg-$(compat_uuidgen | tr 'A-Z' 'a-z')"

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -32,7 +32,19 @@ source "$(cd "$(dirname "$0")" && pwd)/lib/compat.sh"
 #   - Writes a pidfile at ~/.agents/agmsg/run/watch.<session_id>.pid and
 #     removes it on EXIT / SIGTERM / SIGINT.
 
-SESSION_ID="${1:?Usage: watch.sh <session_id> <project_path> <agent_type> [active_name]}"
+# session_id is normally baked into the launch command (CLAUDE_CODE_SESSION_ID /
+# GROK_SESSION_ID). But some runtimes do not export a session id into the
+# watcher's shell — notably Grok Build's `monitor` tool, where the rule's literal
+# "$GROK_SESSION_ID" expands to empty — so failing hard here would stop the
+# watcher from ever starting (it fails fast with a "Usage" error on the first
+# launch). Generate a fallback id instead, mirroring the bridge's
+# CLAUDE_CODE_SESSION_ID fallback: the watcher only needs SOME unique id to key
+# its pidfile/watermark; parallel --continue/--resume isolation (#93) is then
+# best-effort. project_path and agent_type are still required.
+SESSION_ID="${1:-}"
+if [ -z "$SESSION_ID" ]; then
+  SESSION_ID="agmsg-$(compat_uuidgen | tr 'A-Z' 'a-z')"
+fi
 PROJECT_PATH="${2:?Missing project_path}"
 AGENT_TYPE="${3:?Missing agent_type}"
 ACTIVE_NAME="${4:-}"

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -381,3 +381,21 @@ _wait_pidfile() {
   # Exactly one line: 0 would mean a silent spin, >1 a re-emitting loop.
   [ "$(grep -c 'ERROR: cannot open message DB' "$out")" -eq 1 ]
 }
+
+# Empty session_id fallback (#236 grok monitor): Grok's `monitor` tool may run
+# the launch command with an empty $GROK_SESSION_ID, so watch.sh must self-assign
+# an id and start, not die with a "Usage" error (which left the monitor down).
+@test "watch: empty session_id gets a generated fallback instead of a Usage error (#236)" {
+  local out="$BATS_TEST_TMPDIR/empty-sid.out"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "" "$PROJ" claude-code alice >"$out" 2>&1 &
+  local pid=$!
+  # A fallback id means a watch.agmsg-*.pid appears under run/ as the watcher arms.
+  local i started=0
+  for i in $(seq 1 25); do
+    if ls "$TEST_SKILL_DIR/run"/watch.agmsg-*.pid >/dev/null 2>&1; then started=1; break; fi
+    sleep 0.2
+  done
+  kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
+  [ "$started" -eq 1 ]
+  ! grep -q "Usage: watch.sh" "$out"
+}


### PR DESCRIPTION
## Summary

Follow-up to #236. A real-grok end-to-end test of the new grok-build `monitor`
delivery surfaced a first-launch failure: Grok's `monitor` tool does not reliably
export `GROK_SESSION_ID` into the launched command's shell, so the rule's literal
`"$GROK_SESSION_ID"` expands to empty and `watch.sh "" ...` died on `${1:?Usage}`
("Task failed in 0.1s"). The grok agent recovered on a retry, but a less capable
agent (or a different grok build) would leave the monitor down — so the watcher
must not depend on a session id being present in its shell.

## Change

- `scripts/watch.sh`: when the first arg (session_id) is empty, self-assign a
  fallback `agmsg-<uuid>` (mirroring the bridge's `CLAUDE_CODE_SESSION_ID`
  fallback) instead of failing. `project_path` and `agent_type` stay required.
  Claude Code is unaffected (it always bakes a real `CLAUDE_CODE_SESSION_ID`).
- `scripts/drivers/types/grok-build/_delivery.sh`: correct the now-false comment
  that claimed "Grok exports GROK_SESSION_ID for every subprocess".
- `tests/test_watch.bats`: assert an empty session id starts the watcher (a
  fallback `watch.agmsg-*.pid` appears, no `Usage` error) instead of exiting.

## Verification

- Local `bats tests/test_watch.bats` green (incl. the new case).
- Found by spawning a real grok-build agent (grok 0.2.67) with monitor delivery:
  before, the first watcher launch failed with the Usage error; the fallback makes
  it start on the first try. Real-time delivery (send -> `<monitor-event>`) works.

Trade-off: a generated id means parallel `--continue/--resume` isolation (#93) is
best-effort for that watcher, the same as the existing bare-session-id fallback.
