### PR TITLE
Run Codex watch-once through bash

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -803,6 +803,7 @@ class CodexBridge {
     const handle = `agmsg-watch-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     this.watchHandle = handle;
     const command = [
+      BASH_BIN,
       path.join(SCRIPT_DIR, "watch-once.sh"),
       this.opts.project,
       this.opts.type,


### PR DESCRIPTION
## Summary

- run the Codex bridge `watch-once.sh` helper through `BASH_BIN` when asking the app-server to spawn it

## Why

`codex-bridge.js` already uses `BASH_BIN` for direct helper script calls because Git Bash on Windows cannot execute `.sh` files as native Win32 applications. The same constraint applies to the app-server `process/spawn` path: passing `watch-once.sh` directly can fail on Windows with an invalid Win32 application error before the bridge can observe unread messages.

This keeps the change narrow: the watcher command still runs the same script with the same arguments, but the executable is `bash` instead of the `.sh` file itself.

## Validation

- `git diff --check upstream/main..HEAD`
- `node --check scripts/drivers/types/codex/codex-bridge.js`
- local Windows Codex monitor dogfood: message delivered into a live Codex session and replied via agmsg
