### PR TITLE
fix(session-start): skip Monitor directive when watcher already alive

### DIFF
--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -219,6 +219,24 @@ if [ -n "$CC_PID" ]; then
   printf '%s\n' "$INSTANCE_ID" > "$STATE"
 fi
 
+# --- Skip directive when a watcher is already alive for this instance. ---
+# /compact re-fires SessionStart within the same CC process and session_id, so
+# INSTANCE_ID is identical to the already-running watcher's.  Without this
+# guard the agent spawns a second Monitor whose watch.sh kills the incumbent,
+# the old Monitor task emits "stream ended", and the agent loops trying to
+# restart.  Mirrors emit_monitor_directive in delivery.sh.
+WATCHER_PIDFILE="$RUN_DIR/watch.$INSTANCE_ID.pid"
+if [ -f "$WATCHER_PIDFILE" ]; then
+  existing=$(cat "$WATCHER_PIDFILE" 2>/dev/null || true)
+  if [ -n "$existing" ] && kill -0 "$existing" 2>/dev/null; then
+    cat <<EOF
+AGMSG monitor mode: a watch.sh is already streaming for this session (pid $existing).
+No action needed — the existing watcher is the active one.
+EOF
+    exit 0
+  fi
+fi
+
 WATCH="$SKILL_DIR/scripts/watch.sh"
 # Shell-quote each argv so the host can paste the command into Monitor and run
 # it verbatim. A plain '...' wrap breaks on paths with an apostrophe

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -270,6 +270,41 @@ _wait_for_file_contains() {
   [ "$(cat "$ready")" = "sess-new" ]
 }
 
+@test "session-start: skips directive when watcher already alive (compact dedup)" {
+  skip_on_windows "#134"
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  # Start a watcher so a pidfile exists with a live pid.
+  AGMSG_WATCH_INTERVAL=60 bash "$SCRIPTS/watch.sh" "sess1" "$PROJ" claude-code \
+    >/dev/null 2>&1 &
+  local wpid=$!
+
+  # Resolve the instance id session-start.sh will compute for "sess1".
+  local iid
+  iid=$(_iid "sess1")
+  local pf="$TEST_SKILL_DIR/run/watch.$iid.pid"
+  _wait_for_file "$pf"
+
+  # Record cc-instance so the dedup path sees "same instance".
+  echo "$iid" > "$TEST_SKILL_DIR/run/cc-instance.$$"
+
+  # Fire session-start with the same session_id (simulates /compact re-fire).
+  local out
+  out=$(printf '{"session_id":"sess1"}' \
+    | bash "$SCRIPTS/session-start.sh" claude-code "$PROJ" 2>/dev/null || true)
+
+  # The directive must NOT tell the agent to invoke Monitor.
+  [[ "$out" == *"already streaming"* ]]
+  [[ "$out" != *"invoke the Monitor tool"* ]]
+
+  # The original watcher must still be alive.
+  kill -0 "$wpid" 2>/dev/null
+
+  kill "$wpid" 2>/dev/null || true
+  wait "$wpid" 2>/dev/null || true
+}
+
 @test "session-start: GCs stale watermark/ready but keeps live ones" {
   bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
   mkdir -p "$TEST_SKILL_DIR/run"


### PR DESCRIPTION
## Summary

`/compact` re-fires the `SessionStart` hook within the same CC process and session. Because `session-start.sh` emitted the Monitor directive unconditionally, this spawned a second `watch.sh` that killed the incumbent watcher. The old Monitor task then received "stream ended" and the agent looped trying to restart.

Fix: before emitting the directive, check the pidfile for a live watcher — the same guard `delivery.sh`'s `emit_monitor_directive` already has. When a watcher is alive for the current instance, print a status line and exit 0.

Includes a bats test that simulates the compact re-fire scenario.

## Test plan

- [x] `bats tests/test_watch.bats` — 16/16 pass (including the new compact dedup test)
- [x] `bats tests/test_delivery.bats` — 114/114 pass
- [x] Manual: installed locally, ran `/compact` in a live session, confirmed the watcher survived without a double Monitor invocation
