### PR TITLE
fix(grok-build): bind fresh grok watchers + reap dead-grok orphans (#245)

### DIFF
--- a/scripts/drivers/types/grok-build/_delivery.sh
+++ b/scripts/drivers/types/grok-build/_delivery.sh
@@ -74,7 +74,16 @@ EOF
 # agmsg — keep a real-time inbox watcher running
 
 You belong to one or more agmsg teams. Incoming messages are delivered in real
-time by a background watcher you launch with the \`monitor\` tool.
+time by the \`monitor\` tool, which streams each new message into THIS
+conversation as a notification.
+
+> Launch with the \`monitor\` tool ONLY. The \`monitor\` tool is the only thing
+> that surfaces watcher output to you. Do NOT start the watcher with
+> \`run_terminal_command\` (with or without \`background: true\`), and do NOT roll
+> your own \`tail -f\` of a log file. A terminal/background command writes the
+> stream to a log you never see, so messages keep arriving but you silently miss
+> every one of them — and stray watcher tasks pile up. If unsure which tool you
+> used, you used the wrong one unless it was literally \`monitor\`.
 
 At the start of each session (and any time no agmsg watcher is running), launch
 it once:
@@ -82,8 +91,9 @@ it once:
 1. Identify yourself if you have not already:
    \`$SKILL_DIR/scripts/whoami.sh '$project' $type\`
    It prints your \`agent=\` name and \`teams=\` list.
-2. Start the watcher with the \`monitor\` tool, persistent, so each new message
-   streams into the conversation as a notification:
+2. Start the watcher with the \`monitor\` tool (that exact tool — not
+   \`run_terminal_command\`), persistent, so each new message streams into the
+   conversation as a notification. Pass these three fields verbatim:
    - command: \`$SKILL_DIR/scripts/watch.sh "\$GROK_SESSION_ID" '$project' $type\`
    - description: \`agmsg inbox stream\`
    - persistent: true
@@ -91,7 +101,12 @@ it once:
    other pipe, or a redirection: each watcher line is one message, and a closed
    pipe (e.g. \`head\` exiting after N lines) makes the watcher's writes fail so
    messages after the Nth are dropped silently.
-3. Each notification line is one message:
+3. Verify it attached: a \`monitor\` task named \`agmsg inbox stream\` should now
+   be listed and streaming. If you do not see a live \`monitor\` task (e.g. you
+   ran the command as a terminal/background command by mistake), stop whatever
+   you started and relaunch via the \`monitor\` tool — otherwise no message will
+   ever reach you.
+4. Each notification line is one message:
    \`<ts> | <team> | <from> -> <to> | <body>\`. React as they arrive; reply with
    \`$SKILL_DIR/scripts/send.sh <team> <your-agent-name> <to_agent> "<message>"\`.
 

--- a/scripts/drivers/types/grok-build/_delivery.sh
+++ b/scripts/drivers/types/grok-build/_delivery.sh
@@ -87,6 +87,10 @@ it once:
    - command: \`$SKILL_DIR/scripts/watch.sh "\$GROK_SESSION_ID" '$project' $type\`
    - description: \`agmsg inbox stream\`
    - persistent: true
+   Use the command EXACTLY as written. Do NOT append \`| head\`, \`| tail\`, any
+   other pipe, or a redirection: each watcher line is one message, and a closed
+   pipe (e.g. \`head\` exiting after N lines) makes the watcher's writes fail so
+   messages after the Nth are dropped silently.
 3. Each notification line is one message:
    \`<ts> | <team> | <from> -> <to> | <body>\`. React as they arrive; reply with
    \`$SKILL_DIR/scripts/send.sh <team> <your-agent-name> <to_agent> "<message>"\`.

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -50,11 +50,12 @@ Four possible outputs:
                      A .grok/rules/agmsg.md rule has you self-check inbox.sh
                      each turn. Zero setup; no background watcher.
 
-       2) monitor — Real-time push via the `monitor` tool
+       2) monitor — Real-time push via the `monitor` tool (BETA)
                      Launches watch.sh through the `monitor` tool (NOT
                      run_terminal_command); each new message streams in as a
                      notification. You launch it explicitly (Grok hooks can't
-                     auto-start it at SessionStart).
+                     auto-start it at SessionStart). BETA: still stabilizing —
+                     turn mode is the stable default.
 
        3) off     — No automatic delivery
                      Manual /__SKILL_NAME__ only.
@@ -65,7 +66,7 @@ Four possible outputs:
      - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
      - Map the chosen number to a mode (`1`→`turn`, `2`→`monitor`, `3`→`off`) and run:
        `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> grok-build "$(pwd)"`
-     - If you chose `monitor`, read the `AGMSG-DIRECTIVE` block that `delivery.sh` prints and follow it now: invoke the `monitor` tool with the given `command` / `description` / `persistent: true` so the watcher starts streaming into this session. `both` is not supported.
+     - If you chose `monitor`, tell the user it is a **BETA** that is still stabilizing (turn mode is the stable default). Then read the `AGMSG-DIRECTIVE` block that `delivery.sh` prints and follow it now: invoke the `monitor` tool with the given `command` / `description` / `persistent: true` so the watcher starts streaming into this session. `both` is not supported.
 
   6. Then check inbox for the newly joined team.
 

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -50,10 +50,11 @@ Four possible outputs:
                      A .grok/rules/agmsg.md rule has you self-check inbox.sh
                      each turn. Zero setup; no background watcher.
 
-       2) monitor — Real-time push via a background watcher
-                     Launches watch.sh through the `monitor` tool; each new
-                     message streams in as a notification. You launch the watcher
-                     explicitly (Grok hooks can't auto-start it at SessionStart).
+       2) monitor — Real-time push via the `monitor` tool
+                     Launches watch.sh through the `monitor` tool (NOT
+                     run_terminal_command); each new message streams in as a
+                     notification. You launch it explicitly (Grok hooks can't
+                     auto-start it at SessionStart).
 
        3) off     — No automatic delivery
                      Manual /__SKILL_NAME__ only.
@@ -89,6 +90,8 @@ Four possible outputs:
 - persistent: true
 
 Pass the `command` to the `monitor` tool **exactly as written** — do **not** append `| head`, `| tail`, any other pipe, or a redirection. Each watcher line is one message; a closed downstream pipe (e.g. `head` exiting after N lines) makes the watcher's writes fail and messages after the Nth are dropped silently.
+
+Launch it with the **`monitor` tool only** — **never** `run_terminal_command` (with or without `background: true`) and **never** a hand-rolled `tail -f` of a log. Only the `monitor` tool surfaces the stream into this conversation; a terminal/background launch writes to a log you never see, so messages keep arriving but you silently miss them (and stray watcher tasks pile up). After launching, confirm a live `monitor` task named `agmsg inbox stream` exists; if you don't see one (e.g. you launched it as a terminal/background command by mistake), stop that and relaunch via the `monitor` tool.
 
 Each output line is one message: `<ts> | <team> | <from> -> <to> | <body>`. React to messages as they arrive; reply with `send.sh`. Launch it only once — if a watcher is already streaming, do not start a second one. In `turn`/`off` mode there is no watcher; skip this.
 

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -88,6 +88,8 @@ Four possible outputs:
 - description: `agmsg inbox stream`
 - persistent: true
 
+Pass the `command` to the `monitor` tool **exactly as written** — do **not** append `| head`, `| tail`, any other pipe, or a redirection. Each watcher line is one message; a closed downstream pipe (e.g. `head` exiting after N lines) makes the watcher's writes fail and messages after the Nth are dropped silently.
+
 Each output line is one message: `<ts> | <team> | <from> -> <to> | <body>`. React to messages as they arrive; reply with `send.sh`. Launch it only once — if a watcher is already streaming, do not start a second one. In `turn`/`off` mode there is no watcher; skip this.
 
 **If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -104,6 +104,39 @@ agmsg_normalize_instance_id() {
   agmsg_instance_id "$token" "$type"
 }
 
+# Resolve a stable, session-bound instance id for a grok-build watcher.
+#
+# Grok Build's `monitor` tool launches the watcher in a shell where
+# GROK_SESSION_ID is unset and detached from grok's process tree, so neither the
+# env var nor the agmsg_agent_pid ppid walk yields grok's session. The watcher
+# would otherwise key on a throwaway id (a fresh one per relaunch → a fresh
+# watermark → replayed/“start from now” gaps, and no liveness gating). Instead,
+# find the live `grok --resume <id>` whose <id> belongs to THIS project's grok
+# session dir and key on "<id>.<pid>": a composite that is STABLE across watcher
+# relaunches (same session → same watermark/pidfile) and liveness-gated on the
+# grok pid. Prints "<id>.<pid>" and returns 0 on success; 1 if none is found
+# (caller then falls back to a throwaway id so the watcher still starts).
+agmsg_grok_resume_instance_id() {
+  local project="$1" enc sess_dir gp gargs gid
+  [ -n "$project" ] || return 1
+  # grok url-encodes the project path (only '/' → '%2F') for its session dir.
+  enc=$(printf '%s' "$project" | sed 's#/#%2F#g')
+  sess_dir="$HOME/.grok/sessions/$enc"
+  [ -d "$sess_dir" ] || return 1
+  for gp in $(pgrep -x grok 2>/dev/null || true); do
+    gargs=$(ps -o args= -p "$gp" 2>/dev/null || true)
+    case "$gargs" in *--resume*) ;; *) continue ;; esac
+    gid=$(printf '%s' "$gargs" | sed -n 's/.*--resume[ =]*\([0-9A-Za-z][0-9A-Za-z-]*\).*/\1/p')
+    [ -n "$gid" ] || continue
+    # Confirm this session belongs to the project we're watching.
+    if [ -e "$sess_dir/$gid" ]; then
+      printf '%s.%s' "$gid" "$gp"
+      return 0
+    fi
+  done
+  return 1
+}
+
 # True iff <token> identifies a still-live instance.
 #   composite "<sid>.<pid>" → the embedded pid is alive (kill -0).
 #   bare "<sid>"            → some live cc-instance.<p> file references it. For

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -104,25 +104,70 @@ agmsg_normalize_instance_id() {
   agmsg_instance_id "$token" "$type"
 }
 
+# Walk up the ppid chain from <pid> (default: this shell) looking for an ancestor
+# whose command basename is exactly "grok". Prints that pid and returns 0; returns
+# 1 if none is found within a small depth bound. Grok Build's `monitor` tool runs
+# the watcher as a descendant of the grok process, so the grok session that owns a
+# watcher is reliably one of its ancestors — when that grok exits, the watcher is
+# orphaned (reparented to init) and the walk no longer finds it.
+agmsg_grok_ancestor_pid() {
+  local pid="${1:-$$}" depth=0 ppid comm
+  while [ -n "$pid" ] && [ "$pid" != 0 ] && [ "$pid" != 1 ] && [ "$depth" -lt 12 ]; do
+    ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    [ -n "$ppid" ] || return 1
+    comm=$(ps -o comm= -p "$ppid" 2>/dev/null || true)
+    if [ "${comm##*/}" = grok ]; then
+      printf '%s' "$ppid"
+      return 0
+    fi
+    pid="$ppid"
+    depth=$((depth + 1))
+  done
+  return 1
+}
+
+# Newest UUID-form session id under a grok project session dir. Grok names each
+# session dir with a UUID; the most-recently-modified one is the active session
+# for the live grok process. Prints the id and returns 0; 1 if the dir has none.
+agmsg_grok_newest_session_id() {
+  local sess_dir="$1" d name
+  [ -d "$sess_dir" ] || return 1
+  for d in $(ls -1dt "$sess_dir"/*/ 2>/dev/null); do
+    name=${d%/}; name=${name##*/}
+    case "$name" in
+      [0-9a-fA-F]*-[0-9a-fA-F]*-*) printf '%s' "$name"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
 # Resolve a stable, session-bound instance id for a grok-build watcher.
 #
 # Grok Build's `monitor` tool launches the watcher in a shell where
-# GROK_SESSION_ID is unset and detached from grok's process tree, so neither the
-# env var nor the agmsg_agent_pid ppid walk yields grok's session. The watcher
-# would otherwise key on a throwaway id (a fresh one per relaunch → a fresh
-# watermark → replayed/“start from now” gaps, and no liveness gating). Instead,
-# find the live `grok --resume <id>` whose <id> belongs to THIS project's grok
-# session dir and key on "<id>.<pid>": a composite that is STABLE across watcher
+# GROK_SESSION_ID is unset, so neither the env var nor the agmsg_agent_pid ppid
+# walk (which keys on the claude/codex agent binaries) yields grok's session. The
+# watcher would otherwise key on a throwaway id (a fresh one per relaunch → a
+# fresh watermark → replayed/"start from now" gaps, and — being bare, not
+# composite — NO liveness gating, so it lingers forever after grok exits, #245).
+# Bind to a composite "<session_id>.<grok_pid>" instead: STABLE across watcher
 # relaunches (same session → same watermark/pidfile) and liveness-gated on the
-# grok pid. Prints "<id>.<pid>" and returns 0 on success; 1 if none is found
-# (caller then falls back to a throwaway id so the watcher still starts).
-agmsg_grok_resume_instance_id() {
-  local project="$1" enc sess_dir gp gargs gid
+# grok pid (the watcher self-exits once grok dies). Two cases:
+#   1. `grok --resume <id>` — the id is in argv; pair it with that grok pid.
+#   2. fresh `grok` (no --resume, no id in argv) — the watcher is a descendant of
+#      the grok that launched it; pair that ancestor grok pid with the project's
+#      newest session id.
+# Prints "<id>.<pid>" and returns 0 on success; 1 if no live grok is found for
+# this project (caller then falls back to a throwaway id so the watcher still
+# starts).
+agmsg_grok_instance_id() {
+  local project="$1" enc sess_dir gp gargs gid grok_pid
   [ -n "$project" ] || return 1
   # grok url-encodes the project path (only '/' → '%2F') for its session dir.
   enc=$(printf '%s' "$project" | sed 's#/#%2F#g')
   sess_dir="$HOME/.grok/sessions/$enc"
   [ -d "$sess_dir" ] || return 1
+
+  # 1) Precise: a live `grok --resume <id>` whose <id> is in this project's dir.
   for gp in $(pgrep -x grok 2>/dev/null || true); do
     gargs=$(ps -o args= -p "$gp" 2>/dev/null || true)
     case "$gargs" in *--resume*) ;; *) continue ;; esac
@@ -134,7 +179,66 @@ agmsg_grok_resume_instance_id() {
       return 0
     fi
   done
+
+  # 2) Fresh grok (no --resume): bind to the ancestor grok that launched this
+  #    watcher, paired with the project's newest session id.
+  grok_pid=$(agmsg_grok_ancestor_pid 2>/dev/null || true)
+  if [ -n "$grok_pid" ]; then
+    gid=$(agmsg_grok_newest_session_id "$sess_dir" 2>/dev/null || true)
+    if [ -n "$gid" ]; then
+      printf '%s.%s' "$gid" "$grok_pid"
+      return 0
+    fi
+  fi
+
   return 1
+}
+
+# Reap orphaned grok-build watchers for <project>: live watch.sh processes whose
+# launching grok has exited (no live grok ancestor — see agmsg_grok_ancestor_pid).
+# A bare-id watcher from before the composite-binding fix never self-exits when
+# its grok dies (#245), so a fresh grok watcher sweeps those leftovers on startup.
+# Specific-PID kill ONLY — never a pattern kill (`pkill -f watch.sh` once wiped
+# every live watcher across all sessions). Skips <self_pid> and any watcher that
+# still has a live grok ancestor (its grok is alive → not an orphan).
+# True iff <args> is an actual `<shell> <path>/watch.sh ... grok-build ...`
+# invocation for <project> — NOT merely a process whose command line mentions
+# those strings (e.g. a shell running `grep watch.sh ... grok-build`, which a
+# loose substring match would wrongly flag and kill). Confirms watch.sh is the
+# executed script (argv[0] or argv[1] basename) and grok-build / the project are
+# positional args, not text inside a `-c` wrapper.
+agmsg_args_is_grok_watcher() {
+  local args="$1" project="$2" a1 a2 saw_type=0 saw_proj=0 w
+  set -f
+  # shellcheck disable=SC2086
+  set -- $args
+  set +f
+  a1="${1##*/}"; a2="${2##*/}"
+  # watch.sh must be the program: `watch.sh ...` or `<shell> watch.sh ...`.
+  [ "$a1" = "watch.sh" ] || [ "$a2" = "watch.sh" ] || return 1
+  for w in "$@"; do
+    [ "$w" = "grok-build" ] && saw_type=1
+    [ "$w" = "$project" ] && saw_proj=1
+  done
+  [ "$saw_type" = 1 ] && [ "$saw_proj" = 1 ]
+}
+
+agmsg_reap_orphan_grok_watchers() {
+  local project="$1" self="${2:-$$}" pid args
+  [ -n "$project" ] || return 0
+  command -v ps >/dev/null 2>&1 || return 0
+  # Default IFS so `read` splits the leading pid column off the rest as args; an
+  # empty IFS would put the whole line in $pid and match nothing.
+  while read -r pid args; do
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    [ "$pid" = "$self" ] && continue
+    agmsg_args_is_grok_watcher "$args" "$project" || continue
+    # A live grok ancestor means the watcher is still owned by a running grok.
+    agmsg_grok_ancestor_pid "$pid" >/dev/null 2>&1 && continue
+    kill "$pid" 2>/dev/null || true
+  done <<EOF
+$(ps -eo pid=,args= 2>/dev/null)
+EOF
 }
 
 # True iff <token> identifies a still-live instance.

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -225,12 +225,17 @@ agmsg_grok_instance_id() {
 # not match and its orphan watcher would simply be left alone (fail-closed — the
 # bias is toward never killing the wrong process, never toward a stray kill).
 agmsg_args_is_grok_watcher() {
-  local args="$1" project="$2" a1 a2 saw_type=0 saw_proj=0 w
+  local args="$1" project="${2:-}" a1 a2 saw_type=0 saw_proj=0 w
+  [ -n "$args" ] || return 1
   set -f
   # shellcheck disable=SC2086
   set -- $args
   set +f
-  a1="${1##*/}"; a2="${2##*/}"
+  # Guard every positional access: callers run under `set -u`, and ps lists
+  # kernel/system processes with empty args, so $1/$2 may be unset here.
+  [ "$#" -ge 1 ] || return 1
+  a1="${1##*/}"
+  a2=""; [ "$#" -ge 2 ] && a2="${2##*/}"
   # watch.sh must be the program: `watch.sh ...` or `<shell> watch.sh ...`.
   [ "$a1" = "watch.sh" ] || [ "$a2" = "watch.sh" ] || return 1
   for w in "$@"; do
@@ -248,6 +253,7 @@ agmsg_reap_orphan_grok_watchers() {
   # empty IFS would put the whole line in $pid and match nothing.
   while read -r pid args; do
     case "$pid" in ''|*[!0-9]*) continue ;; esac
+    [ -n "${args:-}" ] || continue
     [ "$pid" = "$self" ] && continue
     agmsg_args_is_grok_watcher "$args" "$project" || continue
     # A live grok ancestor means the watcher is still owned by a running grok.

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -167,29 +167,42 @@ agmsg_grok_instance_id() {
   sess_dir="$HOME/.grok/sessions/$enc"
   [ -d "$sess_dir" ] || return 1
 
-  # 1) Precise: a live `grok --resume <id>` whose <id> is in this project's dir.
-  for gp in $(pgrep -x grok 2>/dev/null || true); do
-    gargs=$(ps -o args= -p "$gp" 2>/dev/null || true)
-    case "$gargs" in *--resume*) ;; *) continue ;; esac
-    gid=$(printf '%s' "$gargs" | sed -n 's/.*--resume[ =]*\([0-9A-Za-z][0-9A-Za-z-]*\).*/\1/p')
-    [ -n "$gid" ] || continue
-    # Confirm this session belongs to the project we're watching.
-    if [ -e "$sess_dir/$gid" ]; then
-      printf '%s.%s' "$gid" "$gp"
-      return 0
-    fi
-  done
-
-  # 2) Fresh grok (no --resume): bind to the ancestor grok that launched this
-  #    watcher, paired with the project's newest session id.
+  # 1) Primary: bind to the grok process that actually launched THIS watcher (its
+  #    ancestor). This is correct even when several grok sessions share the same
+  #    project — a plain `pgrep -x grok` scan could otherwise bind watcher B to
+  #    watcher A's grok, colliding their pidfile/watermark and liveness. If the
+  #    ancestor grok was started with `--resume <id>`, key on that id; otherwise
+  #    (a fresh grok) key on the project's newest session id.
   grok_pid=$(agmsg_grok_ancestor_pid 2>/dev/null || true)
   if [ -n "$grok_pid" ]; then
-    gid=$(agmsg_grok_newest_session_id "$sess_dir" 2>/dev/null || true)
+    gargs=$(ps -o args= -p "$grok_pid" 2>/dev/null || true)
+    gid=""
+    case "$gargs" in
+      *--resume*) gid=$(printf '%s' "$gargs" | sed -n 's/.*--resume[ =]*\([0-9A-Za-z][0-9A-Za-z-]*\).*/\1/p') ;;
+    esac
+    # A resume id must belong to this project's session dir; else fall back to
+    # the newest session id under it.
+    [ -n "$gid" ] && [ ! -e "$sess_dir/$gid" ] && gid=""
+    [ -n "$gid" ] || gid=$(agmsg_grok_newest_session_id "$sess_dir" 2>/dev/null || true)
     if [ -n "$gid" ]; then
       printf '%s.%s' "$gid" "$grok_pid"
       return 0
     fi
   fi
+
+  # 2) Fallback: the ancestor grok could not be resolved (a detached watcher with
+  #    no grok in its process tree). Best-effort — find any live `grok --resume
+  #    <id>` whose <id> is in this project's dir.
+  for gp in $(pgrep -x grok 2>/dev/null || true); do
+    gargs=$(ps -o args= -p "$gp" 2>/dev/null || true)
+    case "$gargs" in *--resume*) ;; *) continue ;; esac
+    gid=$(printf '%s' "$gargs" | sed -n 's/.*--resume[ =]*\([0-9A-Za-z][0-9A-Za-z-]*\).*/\1/p')
+    [ -n "$gid" ] || continue
+    if [ -e "$sess_dir/$gid" ]; then
+      printf '%s.%s' "$gid" "$gp"
+      return 0
+    fi
+  done
 
   return 1
 }
@@ -207,6 +220,10 @@ agmsg_grok_instance_id() {
 # loose substring match would wrongly flag and kill). Confirms watch.sh is the
 # executed script (argv[0] or argv[1] basename) and grok-build / the project are
 # positional args, not text inside a `-c` wrapper.
+#
+# Word-splits the ps args string, so a project path containing whitespace will
+# not match and its orphan watcher would simply be left alone (fail-closed — the
+# bias is toward never killing the wrong process, never toward a stray kill).
 agmsg_args_is_grok_watcher() {
   local args="$1" project="$2" a1 a2 saw_type=0 saw_proj=0 w
   set -f

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -33,18 +33,11 @@ source "$(cd "$(dirname "$0")" && pwd)/lib/compat.sh"
 #     removes it on EXIT / SIGTERM / SIGINT.
 
 # session_id is normally baked into the launch command (CLAUDE_CODE_SESSION_ID /
-# GROK_SESSION_ID). But some runtimes do not export a session id into the
-# watcher's shell — notably Grok Build's `monitor` tool, where the rule's literal
-# "$GROK_SESSION_ID" expands to empty — so failing hard here would stop the
-# watcher from ever starting (it fails fast with a "Usage" error on the first
-# launch). Generate a fallback id instead, mirroring the bridge's
-# CLAUDE_CODE_SESSION_ID fallback: the watcher only needs SOME unique id to key
-# its pidfile/watermark; parallel --continue/--resume isolation (#93) is then
-# best-effort. project_path and agent_type are still required.
+# GROK_SESSION_ID). An empty first arg is tolerated and resolved below (after the
+# libs are sourced) rather than failing hard, so a runtime that cannot bake one
+# in — notably Grok Build's `monitor` tool, where "$GROK_SESSION_ID" expands to
+# empty — still starts the watcher. project_path and agent_type are required.
 SESSION_ID="${1:-}"
-if [ -z "$SESSION_ID" ]; then
-  SESSION_ID="agmsg-$(compat_uuidgen | tr 'A-Z' 'a-z')"
-fi
 PROJECT_PATH="${2:?Missing project_path}"
 AGENT_TYPE="${3:?Missing agent_type}"
 ACTIVE_NAME="${4:-}"
@@ -56,6 +49,22 @@ source "$SCRIPT_DIR/lib/storage.sh"
 source "$SCRIPT_DIR/lib/actas-lock.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/resolve-project.sh"
+
+# Resolve a session id when the launcher could not bake one in (empty first arg).
+# Grok Build's `monitor` tool runs the watcher with $GROK_SESSION_ID unset and
+# detached from grok's process tree, so neither the env var nor the instance-id
+# ppid walk yields grok's session. Bind to the live `grok --resume <id>` for this
+# project instead — keyed as <id>.<pid>, the watermark/pidfile are stable across
+# watcher relaunches (no replay gap) and liveness-gated on the grok pid. Fall
+# back to a throwaway id only if that can't be found, so the watcher still starts
+# (#238). Uses the raw project path the watcher was launched with, before
+# agmsg_resolve_project rewrites it, to match grok's session dir.
+if [ -z "$SESSION_ID" ]; then
+  case "$AGENT_TYPE" in
+    grok-build) SESSION_ID="$(agmsg_grok_resume_instance_id "$PROJECT_PATH" 2>/dev/null || true)" ;;
+  esac
+  [ -z "$SESSION_ID" ] && SESSION_ID="agmsg-$(compat_uuidgen | tr 'A-Z' 'a-z')"
+fi
 
 # Resolve the session's real project root (see #92). The actas/drop/ensure-
 # monitor flows relaunch this watcher with a raw "$(pwd)"; without resolution a

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -51,17 +51,25 @@ source "$SCRIPT_DIR/lib/actas-lock.sh"
 source "$SCRIPT_DIR/lib/resolve-project.sh"
 
 # Resolve a session id when the launcher could not bake one in (empty first arg).
-# Grok Build's `monitor` tool runs the watcher with $GROK_SESSION_ID unset and
-# detached from grok's process tree, so neither the env var nor the instance-id
-# ppid walk yields grok's session. Bind to the live `grok --resume <id>` for this
-# project instead — keyed as <id>.<pid>, the watermark/pidfile are stable across
-# watcher relaunches (no replay gap) and liveness-gated on the grok pid. Fall
-# back to a throwaway id only if that can't be found, so the watcher still starts
-# (#238). Uses the raw project path the watcher was launched with, before
-# agmsg_resolve_project rewrites it, to match grok's session dir.
+# Grok Build's `monitor` tool runs the watcher with $GROK_SESSION_ID unset, so
+# neither the env var nor the instance-id ppid walk (it keys on the claude/codex
+# agent binaries) yields grok's session. Bind to a composite "<session_id>.<grok
+# _pid>" instead — keyed this way the watermark/pidfile are stable across watcher
+# relaunches (no replay gap) and liveness-gated on the grok pid, so the watcher
+# self-exits once grok dies rather than lingering as a bare-id orphan (#245).
+# agmsg_grok_instance_id handles both `grok --resume <id>` and a fresh `grok`
+# (no --resume). Fall back to a throwaway id only if no live grok is found, so the
+# watcher still starts (#238). Uses the raw project path the watcher was launched
+# with, before agmsg_resolve_project rewrites it, to match grok's session dir.
 if [ -z "$SESSION_ID" ]; then
   case "$AGENT_TYPE" in
-    grok-build) SESSION_ID="$(agmsg_grok_resume_instance_id "$PROJECT_PATH" 2>/dev/null || true)" ;;
+    grok-build)
+      SESSION_ID="$(agmsg_grok_instance_id "$PROJECT_PATH" 2>/dev/null || true)"
+      # A fresh grok watcher reaps bare-id grok watchers left behind by older
+      # (pre-composite) versions whose grok has since exited (#245). Specific-PID
+      # kill only — never a pattern kill.
+      agmsg_reap_orphan_grok_watchers "$PROJECT_PATH" "$$" 2>/dev/null || true
+      ;;
   esac
   [ -z "$SESSION_ID" ] && SESSION_ID="agmsg-$(compat_uuidgen | tr 'A-Z' 'a-z')"
 fi

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -207,14 +207,31 @@ teardown() { teardown_test_env; }
   [ "$status" -ne 0 ]
 }
 
-@test "grok_instance_id: a live grok --resume yields composite <id>.<pid> (#245)" {
+@test "grok_instance_id: prefers the watcher's ancestor grok over other live groks (#245)" {
+  # Two live `grok --resume` sessions share this project; the watcher must bind
+  # to ITS ancestor grok (2222 / gidB), not whichever pgrep lists first.
+  local proj="/tmp/agmsg-grok-multi"
+  local enc; enc=$(printf '%s' "$proj" | sed 's#/#%2F#g')
+  local gidA="019faaaa-1111-1111-1111-111111111111"
+  local gidB="019fbbbb-2222-2222-2222-222222222222"
+  mkdir -p "$HOME/.grok/sessions/$enc/$gidA" "$HOME/.grok/sessions/$enc/$gidB"
+  pgrep() { printf '1111\n2222\n'; }
+  ps() { case "$*" in *1111*) echo "grok --resume $gidA" ;; *2222*) echo "grok --resume $gidB" ;; esac; }
+  agmsg_grok_ancestor_pid() { echo 2222; }
+  run agmsg_grok_instance_id "$proj"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$gidB.2222" ]
+}
+
+@test "grok_instance_id: a live grok --resume yields composite <id>.<pid> via fallback (#245)" {
+  # Ancestor unresolvable (detached watcher) -> the pgrep fallback finds the live
+  # `grok --resume` for this project. Distinct var name from the function's own
+  # local `gid`, which would otherwise shadow it (dynamic scope) in the ps stub.
   local proj="/tmp/agmsg-grok-resume"
   local enc; enc=$(printf '%s' "$proj" | sed 's#/#%2F#g')
-  # Distinct from the function's own local `gid`, which would otherwise shadow
-  # this value (dynamic scope) when the ps stub is called mid-resolution.
   local gidval="019f0a8a-e25f-7f52-ac5c-543643b1755a"
   mkdir -p "$HOME/.grok/sessions/$enc/$gidval"
-  # Fake a single live `grok --resume <gidval>` at pid 4242.
+  agmsg_grok_ancestor_pid() { return 1; }
   pgrep() { echo 4242; }
   ps() { case "$*" in *4242*) echo "grok --resume $gidval" ;; esac; }
   run agmsg_grok_instance_id "$proj"

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -179,3 +179,110 @@ teardown() { teardown_test_env; }
   kill "$pb" 2>/dev/null || true
   wait "$pb" 2>/dev/null || true
 }
+
+# --- grok-build session binding (#245) ---
+#
+# A grok-build watcher launched by Grok's `monitor` tool gets an empty session id.
+# Keying on a bare throwaway id means no liveness gating, so the watcher lingers
+# forever after grok exits (the pid-91475-alive-3h orphan). These cover the
+# resolution that binds the watcher to a composite "<grok-session>.<grok-pid>"
+# (liveness-gated) for both the `--resume` and the fresh (no-resume) launch.
+
+@test "grok_newest_session_id: returns the newest UUID-form session dir (#245)" {
+  local sd="$HOME/.grok/sessions/proj"
+  mkdir -p "$sd/aaaa1111-1111-1111-1111-111111111111"
+  mkdir -p "$sd/bbbb2222-2222-2222-2222-222222222222"
+  mkdir -p "$sd/not-a-session"        # non-UUID dir must be ignored
+  touch -t 202601010000 "$sd/aaaa1111-1111-1111-1111-111111111111"
+  touch -t 202612310000 "$sd/bbbb2222-2222-2222-2222-222222222222"
+  run agmsg_grok_newest_session_id "$sd"
+  [ "$status" -eq 0 ]
+  [ "$output" = "bbbb2222-2222-2222-2222-222222222222" ]
+}
+
+@test "grok_newest_session_id: fails on a dir with no UUID session (#245)" {
+  local sd="$HOME/.grok/sessions/empty"
+  mkdir -p "$sd/scratch"
+  run agmsg_grok_newest_session_id "$sd"
+  [ "$status" -ne 0 ]
+}
+
+@test "grok_instance_id: a live grok --resume yields composite <id>.<pid> (#245)" {
+  local proj="/tmp/agmsg-grok-resume"
+  local enc; enc=$(printf '%s' "$proj" | sed 's#/#%2F#g')
+  # Distinct from the function's own local `gid`, which would otherwise shadow
+  # this value (dynamic scope) when the ps stub is called mid-resolution.
+  local gidval="019f0a8a-e25f-7f52-ac5c-543643b1755a"
+  mkdir -p "$HOME/.grok/sessions/$enc/$gidval"
+  # Fake a single live `grok --resume <gidval>` at pid 4242.
+  pgrep() { echo 4242; }
+  ps() { case "$*" in *4242*) echo "grok --resume $gidval" ;; esac; }
+  run agmsg_grok_instance_id "$proj"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$gidval.4242" ]
+  agmsg_instance_is_composite "$output"
+}
+
+@test "grok_instance_id: a fresh grok (no --resume) binds via ancestor + newest session (#245)" {
+  local proj="/tmp/agmsg-grok-fresh"
+  local enc; enc=$(printf '%s' "$proj" | sed 's#/#%2F#g')
+  local gid="019fabcd-1111-2222-3333-444455556666"
+  mkdir -p "$HOME/.grok/sessions/$enc/$gid"
+  # No `grok --resume` process; the fresh grok is found as the watcher's ancestor.
+  pgrep() { return 0; }
+  ps() { return 0; }
+  agmsg_grok_ancestor_pid() { echo 7777; }
+  run agmsg_grok_instance_id "$proj"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$gid.7777" ]
+  agmsg_instance_is_composite "$output"
+}
+
+@test "grok_instance_id: fails (caller falls back) when no live grok exists (#245)" {
+  local proj="/tmp/agmsg-grok-none"
+  local enc; enc=$(printf '%s' "$proj" | sed 's#/#%2F#g')
+  mkdir -p "$HOME/.grok/sessions/$enc/019f0049-95e5-7e70-af04-450a9c487da1"
+  pgrep() { return 0; }
+  ps() { return 0; }
+  agmsg_grok_ancestor_pid() { return 1; }   # watcher not under any grok
+  run agmsg_grok_instance_id "$proj"
+  [ "$status" -ne 0 ]
+}
+
+@test "grok_ancestor_pid: fails when no grok is in the ancestry (#245)" {
+  # The bats process tree has no grok ancestor (except if the suite itself is run
+  # under a grok session, which CI never is).
+  run agmsg_grok_ancestor_pid $$
+  [ "$status" -ne 0 ]
+}
+
+@test "args_is_grok_watcher: matches a real watcher invocation (#245)" {
+  local proj="/Users/x/projects/comms-agent"
+  agmsg_args_is_grok_watcher "bash /skills/agmsg/scripts/watch.sh sess.1 $proj grok-build" "$proj"
+}
+
+@test "args_is_grok_watcher: matches an empty-sid watcher (double space) (#245)" {
+  local proj="/Users/x/projects/comms-agent"
+  agmsg_args_is_grok_watcher "bash /skills/agmsg/scripts/watch.sh  $proj grok-build" "$proj"
+}
+
+@test "args_is_grok_watcher: excludes a shell that merely mentions the strings (#245)" {
+  # A process running `grep watch.sh ... grok-build` would be wrongly killed by a
+  # loose substring match. watch.sh is not the executed program here.
+  local proj="/Users/x/projects/comms-agent"
+  run agmsg_args_is_grok_watcher "/bin/zsh -c grep watch.sh foo grok-build $proj" "$proj"
+  [ "$status" -ne 0 ]
+}
+
+@test "args_is_grok_watcher: excludes a watcher for a different project (#245)" {
+  run agmsg_args_is_grok_watcher "bash /s/watch.sh sess.1 /other/proj grok-build" "/Users/x/comms-agent"
+  [ "$status" -ne 0 ]
+}
+
+@test "reap_orphan_grok_watchers: no-op and self-safe when nothing matches (#245)" {
+  # No grok-build watcher for this throwaway project exists; the reaper must not
+  # error and must never touch the caller (a pattern kill once wiped live ones).
+  run agmsg_reap_orphan_grok_watchers "/tmp/agmsg-no-such-project-xyz" $$
+  [ "$status" -eq 0 ]
+  kill -0 $$
+}

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -296,6 +296,29 @@ teardown() { teardown_test_env; }
   [ "$status" -ne 0 ]
 }
 
+@test "args_is_grok_watcher: set -u safe on empty / short args (#245)" {
+  # watch.sh runs under set -u; ps lists kernel procs with empty args, so the
+  # matcher must not trip nounset on unset positional params.
+  run bash -u -c "source '$SCRIPTS/lib/instance-id.sh'
+    agmsg_args_is_grok_watcher '' '/p' && echo unexpected1
+    agmsg_args_is_grok_watcher 'bash' '/p' && echo unexpected2
+    echo OK"
+  [ "$status" -eq 0 ]
+  [ "$output" = "OK" ]
+}
+
+@test "reap_orphan_grok_watchers: survives set -u scanning the real ps table (#245)" {
+  # Regression for a startup crash: under set -u the reaper scanned ps output
+  # that includes empty-args processes and tripped nounset, killing the watcher
+  # before it armed. It must complete and leave the caller alive.
+  run bash -u -c "SKILL_DIR='$SKILL_DIR'
+    source '$SCRIPTS/lib/instance-id.sh'
+    agmsg_reap_orphan_grok_watchers '/tmp/agmsg-no-such-project-xyz' \$\$
+    echo OK"
+  [ "$status" -eq 0 ]
+  [ "$output" = "OK" ]
+}
+
 @test "reap_orphan_grok_watchers: no-op and self-safe when nothing matches (#245)" {
   # No grok-build watcher for this throwaway project exists; the reaper must not
   # error and must never touch the caller (a pattern kill once wiped live ones).

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -395,6 +395,36 @@ _wait_pidfile() {
 # Empty session_id fallback (#236 grok monitor): Grok's `monitor` tool may run
 # the launch command with an empty $GROK_SESSION_ID, so watch.sh must self-assign
 # an id and start, not die with a "Usage" error (which left the monitor down).
+# No silent message loss across a burst (#245): the head-5 truncation bug had a
+# grok agent append `| head -5` to the monitor command, so after the 5th line the
+# consumer closed and later messages were dropped while the watermark advanced
+# past them. With the watcher streaming normally (no downstream truncation), a
+# burst of N>5 consecutive messages must ALL be delivered.
+@test "watch: delivers a burst of 8 consecutive messages without loss (#245)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-burst"
+  local out="$TEST_SKILL_DIR/burst.log"
+  local wm="$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark"
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null &
+  local w=$!
+  _wait_for_file "$wm"          # ready to receive (watermark seeded)
+
+  local n
+  for n in 1 2 3 4 5 6 7 8; do
+    bash "$SCRIPTS/send.sh" team bob alice "BURST-$n" >/dev/null
+  done
+
+  # Wait for the last one to arrive, then assert EVERY message is present.
+  _wait_for_file_contains "$out" "BURST-8" || { kill "$w" 2>/dev/null || true; false; }
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  for n in 1 2 3 4 5 6 7 8; do
+    grep -q "BURST-$n" "$out"
+  done
+}
+
 @test "watch: empty session_id gets a generated fallback instead of a Usage error (#236)" {
   local out="$BATS_TEST_TMPDIR/empty-sid.out"
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "" "$PROJ" claude-code alice >"$out" 2>&1 &


### PR DESCRIPTION
## Problem

Grok Build's `monitor` tool launches the agmsg watcher with an empty
`$GROK_SESSION_ID`. Two failure modes followed:

1. **Lingering orphan watchers.** An empty session id fell back to a bare
   throwaway instance id. The #67 liveness guard only applies to *composite*
   ids (`<sid>.<pid>`), so a bare-id watcher never self-exits when its grok
   session dies — it lingers indefinitely (observed: a watcher still alive
   3h+ after its grok had exited). A prior fix bound a composite id only for
   `grok --resume <id>` sessions (id present in argv); a fresh `grok` (no
   `--resume`) still fell back to bare.

2. **Silent message loss.** If the watcher's stdout consumer truncates the
   stream (e.g. a `| head -5` appended to the monitor command), writes past
   the consumer's close are dropped while the watermark advances past them,
   so later messages are lost silently.

## Fix

- `agmsg_grok_instance_id` (generalizes the former resume-only helper):
  resolves a composite `<session_id>.<grok_pid>` for both `grok --resume` and
  a fresh `grok`. For a fresh grok it binds to the grok process that is the
  watcher's ancestor, paired with the project's newest session id. Composite
  ids are stable across watcher relaunches (no watermark/replay gap) and
  liveness-gated, so the watcher self-exits when grok dies.
- `agmsg_reap_orphan_grok_watchers`: on startup a fresh grok watcher reaps
  leftover bare-id grok-build watchers whose grok has already exited.
  Specific-PID kill only; a strict invocation match (watch.sh must be the
  executed program, with grok-build and the project as positional args)
  ensures a process that merely *mentions* those strings is never killed.
- grok-build monitor rule + onboarding template: instruct agents to pass the
  monitor command exactly, with no `| head` / `| tail` / pipe / redirection
  appended (a closed downstream pipe drops messages silently).

## Tests

New regression tests (bats):
- composite resolution for resume and fresh grok; newest-session-dir; grok
  ancestor resolution
- watcher-arg matching incl. false-positive exclusion (a shell that merely
  mentions the strings is not matched)
- reaper safety (no-op / self-safe when nothing matches)
- an 8-message burst delivered with no loss

All changed suites green locally (`test_instance_id.bats`, `test_watch.bats`).

## Verification (local machine)

- Composite resolution against a live grok session yields `<id>.<pid>`
  (liveness-gated on the grok pid).
- Reaper dry-run: keeps a watcher whose grok is alive, flags only watchers
  whose grok has exited.
- Before/after for the loss path: with `| head -5`, only 5 of 8 messages were
  delivered; without it, all 8 were delivered.

Closes #245.

## Update: monitor-mode launch hardening

Live dogfooding surfaced that the silent "messages never arrive" reports (and
accumulating watcher tasks) were caused by the launch *method*, not the watcher:
the grok-build rule described delivery as "a background watcher you launch with
the `monitor` tool", and the word "background" led agents to start `watch.sh`
via `run_terminal_command` with `background: true`. That logs the stream to a
file and never injects it into the conversation — a silent failure. (The
emit/watermark print logic is unchanged; the session-binding work in this PR did
not cause it.)

This adds launch-method hardening to the grok-build delivery rule and onboarding
template:
- delivery is described as coming from the `monitor` tool (drops the
  "background watcher" framing)
- explicit prohibition: launch with the `monitor` tool only — never
  `run_terminal_command` (with or without `background: true`), and never a
  hand-rolled `tail -f` of a log
- a verify step: confirm a live `monitor` task named `agmsg inbox stream` exists
  after launch, and relaunch via the tool if it is missing
