### PR TITLE
fix(gemini): drop monitor/both — Gemini has no Monitor tool

### DIFF
--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -58,7 +58,7 @@ Four possible outputs:
      - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
      - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
        `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> gemini "$(pwd)"`
-     - Codex has no Monitor tool, so `monitor` and `both` modes are not offered here.
+     - Gemini has no Monitor tool, so `monitor` and `both` modes are not offered here.
 
   6. Then check inbox for the newly joined team.
 
@@ -107,7 +107,7 @@ If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" gemini` to see whether the role is already registered for this (project, type).
 3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> gemini "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
 4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
-5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Codex has no Monitor tool, so receive still covers all of your registered roles in this project.)"
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Gemini has no Monitor tool, so receive still covers all of your registered roles in this project.)"
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.
@@ -120,7 +120,7 @@ If argument is "mode" (no further args):
 2. Show the output to the user.
 
 If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
-1. Parse the mode. Codex supports only `turn` and `off` — reject `monitor` and `both` with: "Codex has no Monitor tool; only `turn` or `off` modes are supported."
+1. Parse the mode. Gemini supports only `turn` and `off` — reject `monitor` and `both` with: "Gemini has no Monitor tool; only `turn` or `off` modes are supported."
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> gemini "$(pwd)"`
 
 If argument is "hook on" (legacy alias):

--- a/scripts/drivers/types/gemini/type.conf
+++ b/scripts/drivers/types/gemini/type.conf
@@ -5,4 +5,4 @@ detect=GEMINI_API_KEY GOOGLE_GEMINI_CLI
 detect_proc=gemini gemini-*
 hooks_file=.agent/rules/agmsg.md
 monitor=no
-delivery_modes=monitor turn both off
+delivery_modes=turn off


### PR DESCRIPTION
## Problem
Gemini's driver advertises `delivery_modes=monitor turn both off`, so it shows a `monitor` capability where it has none. Evidence Gemini does not support monitor:

- `type.conf` has `monitor=no` and there are no monitor scripts under `scripts/drivers/types/gemini/` (cf. codex has `codex-monitor.sh` / `codex-bridge.js` / `watch-once.sh`).
- The driver was seeded from the Codex template: `template.md` literally says "no Monitor tool, so `monitor` and `both` modes are not offered" and "reject `monitor` and `both`" — but mislabels the agent as "Codex".

The site (agmsg.cc Agent types) faithfully renders `type.conf`, so it surfaced the wrong `monitor` chip for Gemini.

## Fix
- `type.conf`: `delivery_modes=monitor turn both off` -> `delivery_modes=turn off`.
- `template.md`: correct the three leftover "Codex" references to "Gemini".

No behavior change for other types. After this lands, the site drops Gemini's monitor chip on the next build.