### PR TITLE
Add Codex Desktop companion waker PoC

### DIFF
--- a/docs/poc-delivery-supervisor-notes.md
+++ b/docs/poc-delivery-supervisor-notes.md
@@ -1,0 +1,543 @@
+# Delivery supervisor PoC notes
+
+Date: 2026-06-28
+Branch: `poc/delivery-supervisor`
+Scope: disposable PoC, Codex-first direction, no upstream posting.
+
+## What was built
+
+Added a standalone Node PoC supervisor at:
+
+- `scripts/poc/delivery-supervisor.js`
+
+It is intentionally not wired into `delivery.sh` or production hooks.
+
+The supervisor owns:
+
+- project-scoped singleton via port/lock files
+- session attach and heartbeat state
+- live/stale liveness without trusting OS pid
+- mailbox cursor
+- mock adapter delivery log
+- optional adapter command boundary for separating core failures from adapter failures
+
+Added smoke tests:
+
+- `tests/poc/test-delivery-supervisor.cjs`
+- `tests/poc/test-delivery-supervisor-adapter-fail.cjs`
+
+## Observations
+
+### AC1 singleton
+
+Status: yes for PoC core.
+
+Second supervisor startup is rejected when an existing supervisor responds on the project port file.
+
+### AC2 heartbeat liveness
+
+Status: yes for PoC core.
+
+Observed both directions:
+
+- live quiet session remains live after heartbeat
+- dead session becomes stale after timeout
+
+### AC3 resume/reattach with cursor
+
+Status: yes for PoC core simulation.
+
+The supervisor process stays alive while a session becomes stale. A held message is delivered after a new session attaches. Cursor prevents duplicate delivery.
+
+This is not yet a real Codex Desktop kill/restart test.
+
+### AC4 real agent idle wake
+
+Status: not yet proven.
+
+The current PoC has a mock adapter and an adapter-command boundary. It has not yet injected into a real Codex Desktop idle thread.
+
+### AC5 single-writer / no duplicate watcher
+
+Status: yes for PoC core.
+
+The singleton port/lock check rejects a second supervisor. The core smoke produced exactly one delivery for the first message and no duplicate delivery while idle.
+
+## Core vs adapter failure split
+
+The adapter-failure smoke starts a supervisor with an adapter command that exits non-zero. Observation:
+
+- `adapter-fail` is recorded in the event log
+- cursor does not advance
+- delivery can be retried later
+
+This gives a clean split between supervisor core health and adapter delivery failure.
+
+## Current risk
+
+The hardest remaining work is Windows daemon supervision and real Codex idle wake:
+
+- how to keep the supervisor alive outside a session lifecycle
+- how to start/stop it safely from hooks or a command
+- how to bind a Codex adapter to a real idle Desktop thread without returning to per-session watcher fragility
+
+## Verification run
+
+Passed:
+
+```text
+node --check scripts/poc/delivery-supervisor.js
+node --check tests/poc/test-delivery-supervisor-adapter-fail.cjs
+node tests/poc/test-delivery-supervisor.cjs
+node tests/poc/test-delivery-supervisor-adapter-fail.cjs
+```
+## AC4 adapter phase update
+
+Added a disposable Codex adapter:
+
+- `scripts/poc/codex-idle-wake-adapter.js`
+
+It reads `AGMSG_SUPERVISOR_MESSAGE_JSON`, connects to a Codex app-server WebSocket endpoint, runs:
+
+1. `initialize`
+2. `initialized`
+3. `thread/loaded/list`
+4. `thread/resume`
+5. `turn/start`
+
+Added tests:
+
+- `tests/poc/test-codex-idle-wake-adapter.cjs`
+- `tests/poc/test-supervisor-codex-adapter.cjs`
+
+Observed:
+
+- Standalone adapter reaches `turn/start` against a fake app-server.
+- Supervisor can invoke the adapter command and advance cursor only after adapter success.
+- The method sequence is verified in both tests.
+
+### Real Codex idle-wake status
+
+Status: partially blocked.
+
+No live installed agmsg Codex app-server endpoint was available at test time:
+
+- recorded ports `59181` and `51843` were closed
+- recorded app-server pids were not alive
+
+Codex CLI exists (`codex-cli 0.138.0`) and supports `codex app-server --listen ws://IP:PORT`, but `codex app-server daemon` lifecycle reports:
+
+```text
+Error: codex app-server daemon lifecycle is only supported on Unix platforms
+```
+
+This is an important Windows observation: the durable daemon manager that would normally keep the app-server alive is not available on Windows in this Codex CLI version. It reinforces that the hard part is not the `turn/start` adapter protocol, but Windows supervision/lifecycle ownership.
+
+Current AC4 result:
+
+- Adapter protocol to `turn/start`: yes, proven against fake app-server.
+- Supervisor -> adapter -> `turn/start`: yes, proven against fake app-server.
+- Real Desktop idle-wake: not yet proven because no live Desktop/app-server endpoint was available.
+- Windows daemon survival: not yet proven; built-in Codex daemon lifecycle is Unix-only here.
+
+## Verification run update
+
+Passed:
+
+```text
+node --check scripts/poc/delivery-supervisor.js
+node --check scripts/poc/codex-idle-wake-adapter.js
+node tests/poc/test-delivery-supervisor.cjs
+node tests/poc/test-delivery-supervisor-adapter-fail.cjs
+node tests/poc/test-codex-idle-wake-adapter.cjs
+node tests/poc/test-supervisor-codex-adapter.cjs
+```
+## Supervisor-owned Codex app-server phase
+
+Added a disposable owner script:
+
+- `scripts/poc/codex-app-server-owner.js`
+
+Important boundary finding:
+
+- Node `child_process.spawn("codex", ...)` fails with `EPERM` in Codex Desktop because `codex` resolves to `C:\Users\orang\AppData\Roaming\npm\codex.ps1`.
+- Node can spawn `node`, `cmd.exe`, and `powershell.exe` from this session.
+- Node can spawn the native Codex executable directly:
+  `C:\Users\orang\AppData\Roaming\npm\node_modules\@openai\codex\node_modules\@openai\codex-win32-x64\vendor\x86_64-pc-windows-msvc\bin\codex.exe`.
+
+Therefore the PoC owner now prefers native `codex.exe` on Windows.
+
+Observed:
+
+- Owner can start `codex.exe app-server --listen ws://127.0.0.1:<port>` and detect the endpoint.
+- Owner can stop the recorded process.
+- A PowerShell-wrapper route was unstable and left child `codex.exe` processes; native exe is the correct Windows route for this PoC.
+
+Attempted real app-server adapter probe:
+
+- Start owned native app-server: success.
+- Run disposable adapter against owned endpoint with `--thread new`: failed with `read ECONNRESET`.
+- App-server log only showed normal startup. No detailed protocol error was emitted.
+
+Interpretation:
+
+- Windows lifecycle ownership is now partially de-risked: the PoC can own a native Codex app-server process.
+- The fake app-server adapter path remains green.
+- Real owned app-server JSON-RPC/WebSocket behavior is not yet compatible with the disposable adapter. This may be a protocol/version/auth/handshake difference in `codex-cli 0.138.0`, rather than a supervisor-core problem.
+- Real Desktop idle-wake remains unproven.
+
+Cleanup:
+
+- Leftover PoC `codex.exe app-server` process was identified by command line and stopped.
+## codex-cli --remote smoke attempt
+
+Added a self-contained smoke script:
+
+- `tests/poc/smoke-codex-remote-wake.cjs`
+
+Goal:
+
+1. start supervisor-owned native `codex.exe app-server --listen ws://127.0.0.1:<port>`
+2. start `codex --remote <endpoint> --cd <project> --no-alt-screen`
+3. use the disposable adapter to inject `turn/start`
+4. observe whether an idle real Codex CLI remote session wakes
+
+Result:
+
+- app-server owner started and exposed `ws://127.0.0.1:57482`
+- remote CLI process failed immediately with:
+
+```text
+Error: stdin is not a terminal
+```
+
+- adapter then saw `connect ECONNREFUSED` because the remote/app-server side was no longer available
+
+Classification:
+
+- supervisor owner: started successfully
+- adapter: not the primary failure in this run
+- real remote session harness: blocked, because `codex --remote` requires a real TTY
+
+Interpretation:
+
+This confirms that the next real wake smoke needs an actual terminal/PTY-backed Codex CLI session, not a background `child_process.spawn` with piped/ignored stdio. On Windows this likely means either a visible terminal launched with `Start-Process` or a PTY-capable harness. The Desktop target is still a later step; this is the CLI-remote stepping stone.
+## visible TTY codex --remote wake probe
+
+A visible PowerShell terminal was launched with:
+
+```text
+codex.exe --remote <owned-endpoint> --cd C:\dev\MathDesk --no-alt-screen
+```
+
+First attempt with the normal adapter path reached a loaded thread but failed at `thread/resume`:
+
+```text
+codex-idle-wake-adapter: no rollout found for thread id <id>
+```
+
+Classification:
+
+- owned app-server: OK
+- visible TTY remote session: OK enough for `thread/loaded/list` to return a loaded thread
+- adapter path: failed at `thread/resume`; this appears specific to remote loaded threads without rollout metadata
+
+Added PoC-only adapter option:
+
+```text
+--skip-resume
+```
+
+Second attempt used `--skip-resume` and called `turn/start` directly on the loaded thread. Result:
+
+```json
+{"ok":true,"threadId":"019f0cfd-c2be-7b93-9501-726c508e8228"}
+```
+
+Interpretation:
+
+- Real Windows `codex-cli --remote` with a real TTY can attach to a supervisor-owned app-server.
+- The disposable adapter can discover the loaded remote thread.
+- `turn/start` is accepted by the real app-server when called directly on that loaded thread.
+- For this remote-session path, `thread/resume` is not the right prerequisite; it fails because no rollout exists for the loaded remote thread.
+
+Current AC4 result:
+
+- Fake app-server turn/start: yes.
+- Supervisor -> adapter -> fake app-server turn/start: yes.
+- Supervisor-owned native app-server lifecycle: yes for start/stop and port persistence after owner returns.
+- Real codex-cli --remote TTY + direct `turn/start`: yes, request accepted.
+- Full user-visible processing/wake observation: partially observed via request acceptance; a longer manual observation can verify the remote TUI rendered/processed the injected turn.
+- Desktop path: still not tested; CLI remote is the stepping stone.
+
+Cleanup:
+
+- owned app-server endpoint was closed after stop
+- visible PowerShell/Codex probe process tree was stopped
+
+## visible TTY remote wake observation update
+
+Added adapter-side notification observation:
+
+- `--wait-after-start-ms <n>` keeps the disposable adapter connected briefly after `turn/start`
+- observed JSON-RPC notifications are returned in the adapter output
+- current PoC records `turn/started`, `turn/completed`, `turn/failed`, and `thread/status/changed`
+
+Fake app-server verification now emits `turn/started` and `thread/status/changed`, and the adapter test asserts both are observed.
+
+Real visible TTY probe:
+
+- supervisor-owned app-server endpoint: `ws://127.0.0.1:59436`
+- launched visible `codex.exe --remote <endpoint> --cd C:\dev\MathDesk --no-alt-screen`
+- adapter args included `--thread loaded --skip-resume --wait-after-start-ms 10000`
+- adapter exited 0 with:
+
+```json
+{"ok":true,"threadId":"019f0d0c-e2ce-7542-ac4c-eeff35b94137","observed":[{"method":"thread/status/changed","threadId":"019f0d0c-e2ce-7542-ac4c-eeff35b94137","status":"active"}]}
+```
+
+Interpretation:
+
+- `turn/start` is not only accepted by the real Windows remote app-server path; the loaded remote thread changes to `active` after injection.
+- This is stronger than the previous request-accepted-only result.
+- The PoC still has not injected into Codex Desktop directly. The validated stepping stone is: supervisor-owned native app-server + visible TTY `codex --remote` + direct `turn/start` on the loaded thread.
+
+Cleanup:
+
+- app-server owner stopped pid `19792`
+- visible terminal process tree was requested to stop; a follow-up process scan found no leftover probe app-server/remote process
+
+## supervisor-to-visible-remote smoke update
+
+Added a Windows-only visible smoke script:
+
+- `tests/poc/smoke-supervisor-codex-remote-visible.ps1`
+
+The script validates the full stepping-stone path:
+
+1. start supervisor-owned native Codex app-server
+2. launch a visible TTY-backed `codex.exe --remote <endpoint> --cd <project> --no-alt-screen`
+3. start `delivery-supervisor.js` with the real Codex adapter command
+4. attach a live `mathdesk-desktop/Eiji` session
+5. send one supervisor message from `Anna` to `Eiji`
+6. verify supervisor cursor advances and adapter stdout reports `thread/status/changed` with `status: active`
+
+Supervisor now records adapter success output as an `adapter-ok` event. This gives the smoke script a durable place to verify the adapter's observed Codex events without coupling the supervisor core to Codex internals.
+
+Clean smoke result:
+
+```json
+{
+  "ok": true,
+  "endpoint": "ws://127.0.0.1:57889",
+  "cursor": 1,
+  "threadId": "019f0d24-8be8-7183-9df6-8f3216e8484d",
+  "observed": [
+    {
+      "method": "thread/status/changed",
+      "threadId": "019f0d24-8be8-7183-9df6-8f3216e8484d",
+      "status": "active"
+    }
+  ]
+}
+```
+
+Interpretation:
+
+- The PoC now proves supervisor -> adapter -> visible Codex remote -> active thread as one integrated path.
+- This is still not Codex Desktop direct injection. It is the strongest CLI-remote stepping stone so far and should be the base for deciding whether/how to bridge into Desktop.
+
+## feasibility verdict and liveness design handoff
+
+Feasibility verdict for this PoC:
+
+- The integrated stepping-stone path is proven on Windows:
+  `delivery-supervisor -> Codex adapter -> visible TTY codex --remote -> thread/status/changed active`.
+- This is enough to stop expanding the heartbeat-based PoC core.
+- The PoC should remain a feasibility artifact, not become production monitor design by accretion.
+
+Liveness handoff:
+
+- Decision owner for the heartbeat prohibition: orange.
+- Design owner for the replacement liveness model: Anna.
+- Implementation owner for the later build slice: Eiji/Codex, after the feasibility verdict is accepted.
+
+Build-stage direction from Anna's design note (`C:\dev\rt-monitor-rnd\design-supervisor-liveness.md`):
+
+- Replace timestamp heartbeat with held-connection liveness.
+- Do not ask the LLM to emit heartbeat/ping messages.
+- Do not add per-session timer processes just to keep liveness fresh.
+- Treat the already-required delivery connection as the liveness primitive:
+  - open connection/register frame = live seat binding
+  - transport drop = dead
+  - reconnect with cursor = resume
+- For Codex, register/bind the target seat to the remote/app-server/thread identity rather than guessing a delivery target.
+
+Implication for PR #3:
+
+- No further investment should go into `lastHeartbeat`, `heartbeat`, or `markStale` beyond their current disposable PoC role.
+- Any next implementation PR should start from held-connection liveness, using this PR only for the adapter and Windows remote feasibility evidence.
+
+## next-target-B closure probes
+
+Anna requested two remaining checks before declaring target 2 closed.
+
+### Check 1: Codex Desktop GUI direct route
+
+Status: FAIL / blocked by missing external Desktop app-server endpoint.
+
+Observed on the real Codex Desktop app (Windows):
+
+- Codex Desktop GUI process is running.
+- It owns a child process:
+  `resources\codex.exe app-server --analytics-default-enabled`.
+- That process does not expose a localhost WebSocket listener for external `turn/start` injection.
+- `Get-NetTCPConnection` for the Desktop app-server pid showed outbound HTTPS connections only, not a local `ws://127.0.0.1:<port>` listener.
+- `codex app-server proxy` attempts to connect to `C:\Users\orang\.codex\app-server-control\app-server-control.sock` and fails on Windows.
+- `codex remote-control start --json` and `codex app-server daemon version` both fail with:
+  `codex app-server daemon lifecycle is only supported on Unix platforms`.
+- Named pipe `\\.\pipe\codex-ipc` exists, but it is not a documented app-server JSON-RPC/WebSocket endpoint and was not used as a workaround.
+
+Conclusion:
+
+- The current PoC cannot honestly claim `supervisor -> adapter -> existing Codex Desktop GUI app-server -> turn/start`.
+- To test or build Desktop GUI direct injection, Codex Desktop needs one of:
+  - a supported WebSocket listener / remote-control endpoint on Windows,
+  - a documented Desktop IPC bridge for app-server JSON-RPC,
+  - or an explicit app-internal tool route accepted as a different integration surface.
+- Fake Desktop substitution is intentionally rejected.
+
+### Check 2: one step past active/render evidence
+
+Status: PASS for the CLI-remote stepping-stone path; strict `turn/completed` notification is not emitted to the adapter, but completion is confirmed through active->idle plus Codex Desktop thread record.
+
+Prompt override was added to the disposable adapter:
+
+- `--prompt-text <text>` bypasses the default `[$agmsg]` prompt wrapper for probe turns.
+- Reason: the default wrapper triggers the agmsg skill in remote Codex and can block on identity/sqlite setup, which is not the render/completion question.
+
+Smoke script was extended:
+
+- `-PromptText <text>`
+- `-RequireIdleAfterActive`
+- `-RequireCompleted` remains available as a strict notification check, but it is not satisfied in this environment.
+
+Clean completion probe:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File tests\poc\smoke-supervisor-codex-remote-visible.ps1 `
+  -Project C:\dev\MathDesk `
+  -WaitAfterStartMs 30000 `
+  -PromptText 'Reply exactly POC_RENDER_OK. Do not run tools.' `
+  -RequireIdleAfterActive
+```
+
+Adapter evidence:
+
+```json
+{
+  "ok": true,
+  "threadId": "019f0d61-af7a-7c52-bce9-f584a2da32d7",
+  "observed": [
+    { "method": "thread/status/changed", "status": "active" },
+    { "method": "thread/status/changed", "status": "idle" }
+  ]
+}
+```
+
+Codex Desktop thread record evidence:
+
+- thread id: `019f0d61-af7a-7c52-bce9-f584a2da32d7`
+- turn status: `completed`
+- final answer: `POC_RENDER_OK`
+
+Conclusion:
+
+- The CLI-remote path renders/processes a turn and reaches completed state, even though the adapter observes status notifications rather than a `turn/completed` notification.
+- This closes the render/completion concern for the remote stepping stone, not for existing Desktop GUI direct injection.
+
+## app-internal conditional wake dogfood
+
+Goal:
+
+- Do not wake the target Codex Desktop thread on empty polling runs.
+- Wake the target thread only when agmsg reports unread mail for that target identity.
+- Keep unread message content in agmsg until the target thread reads it with the official inbox script.
+
+Setup used in MathDesk dogfood:
+
+- collector runner thread: `019f0e3b-c3c1-7ab0-8781-166cdb12c7d4`
+- target thread: `JunoMaCoder中学受験` / `019f0794-1b19-7f80-81be-b823e3035b5e`
+- target identity: `JunoMaCoder`
+- team: `mathdesk-desktop`
+- unread oracle: `scripts/drivers/types/codex/watch-once.sh`
+- target wake route: Codex app-internal `send_message_to_thread`
+- state file: `C:\tmp\agmsg-junoma-conditional-waker-state.json`
+
+Observed flow:
+
+1. With no unread mail, `watch-once.sh` returned `status=timeout`; the target thread received no turn.
+2. Eiji sent one agmsg message to JunoMaCoder.
+3. The collector heartbeat observed `status=pending count=1 max_id=171` via `watch-once.sh`.
+4. The collector wrote `last_notified_max_id=171` and sent one wake prompt to the target thread.
+5. JunoMaCoder woke, ran the official inbox path, read the message, and replied to Eiji.
+6. Later collector runs saw no unread mail and did not send duplicate wake prompts.
+
+Result:
+
+- PASS for "unread-only target wake" in Codex Desktop, using an app-internal thread tool route.
+- PASS for preserving unread ownership: the watcher did not read message content or mark it read.
+- PASS for duplicate suppression in this smoke run.
+
+Boundary:
+
+- This is not direct Desktop GUI app-server injection.
+- This depends on a Codex app-internal `send_message_to_thread` route that is available to Codex agents in this environment, not a standalone shell-only process.
+- Empty polling runs still consume the collector thread, but they do not consume or wake the target work thread.
+
+Interpretation:
+
+This gives a practical companion design for Codex Desktop today: keep polling and no-op noise in a dedicated collector session, and wake the actual work session only when the official agmsg unread oracle reports pending mail. It should be described as a companion/waker path, not as monitor bridge completion.
+
+## PoC verdict: stop standalone exploration
+
+Verdict:
+
+- Stop expanding this standalone PoC.
+- Move back to mainline design work with the findings below.
+- Keep this PR as a Draft PoC record unless/until the integration direction is explicitly accepted.
+
+What is now answered:
+
+- `watch-once.sh` is a usable unread oracle because it detects pending mail without reading message content or advancing the inbox cursor.
+- A collector/waker session can keep empty polling noise out of the target work thread.
+- A target Codex Desktop thread can be woken only when unread mail exists, using the app-internal `send_message_to_thread` route.
+- The same collector heartbeat can multiplex several explicit targets; MathDesk dogfood covered Eiji, JunoMaCoder, and Deneb.
+- Target threads can then read the official inbox themselves and reply over agmsg.
+
+What remains outside this PoC:
+
+- Direct external injection into an existing Codex Desktop GUI app-server endpoint.
+- A standalone shell-only process that wakes Codex Desktop without an app-internal thread route.
+- Registry/management UX for mapping identities to thread ids and state files.
+- Production lifecycle management on Windows.
+
+Recommendation:
+
+Treat the companion/waker route as the current practical Windows Codex Desktop direction, and treat direct monitor bridge work as blocked on a supported Desktop control surface. The next useful work should be mainline design/API shape, not more ad hoc dogfood expansion.
+
+## Final review caveats to carry forward
+
+Anna final review verdict:
+
+- Closure verdict is accurate.
+- Draft/local-only landing is right for this PoC code.
+- The next useful work is mainline design/API shape, not more standalone dogfood expansion.
+
+Caveats that must be visible outside the long notes before this branch is abandoned:
+
+1. The real visible remote path observed `thread/status/changed` active -> idle through the adapter. A completed turn was confirmed out-of-band via the Codex Desktop thread record, not through a `turn/completed` adapter notification.
+2. The validated `codex --remote` path required the PoC-only `--skip-resume` option because `thread/resume` failed on loaded remote threads with `no rollout found`. The normal resume-first protocol sequence is not proven for that path.
+3. The multiplex conditional wake claim is based on MathDesk dogfood across Eiji, JunoMaCoder, and Deneb. Detailed step-by-step notes are strongest for JunoMaCoder, with Eiji/Deneb confirmed by state files and live thread wake/read/reply observations.
+4. The supervisor heartbeat core is feasibility-only. It should not become production liveness by accumulation; the later mainline design should use held-connection liveness.
+5. Desktop GUI direct injection was blocked in this environment: codex-cli `0.138.0` and the current Codex Desktop Windows app exposed no supported localhost WebSocket/Desktop control endpoint for external `turn/start`.

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -803,6 +803,7 @@ class CodexBridge {
     const handle = `agmsg-watch-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     this.watchHandle = handle;
     const command = [
+      BASH_BIN,
       path.join(SCRIPT_DIR, "watch-once.sh"),
       this.opts.project,
       this.opts.type,

--- a/scripts/poc/codex-app-server-owner.js
+++ b/scripts/poc/codex-app-server-owner.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+"use strict";
+
+const childProcess = require("child_process");
+const fs = require("fs");
+const net = require("net");
+const os = require("os");
+const path = require("path");
+
+function usage() {
+  console.log(`Usage: codex-app-server-owner.js start --run-dir <path> [--port <n>] [--codex <path>]\n       codex-app-server-owner.js stop --run-dir <path>`);
+}
+
+function parseArgs(argv) {
+  const opts = { command: argv[0] || "" };
+  for (let i = 1; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") opts.help = true;
+    else if (arg === "--run-dir") opts.runDir = argv[++i];
+    else if (arg === "--port") opts.port = Number(argv[++i]);
+    else if (arg === "--codex") opts.codex = argv[++i];
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return opts;
+}
+
+function defaultCodex() {
+  if (process.platform === "win32") {
+    const nativeExe = path.join(
+      os.homedir(),
+      "AppData",
+      "Roaming",
+      "npm",
+      "node_modules",
+      "@openai",
+      "codex",
+      "node_modules",
+      "@openai",
+      "codex-win32-x64",
+      "vendor",
+      "x86_64-pc-windows-msvc",
+      "bin",
+      "codex.exe",
+    );
+    if (fs.existsSync(nativeExe)) return nativeExe;
+    return path.join(os.homedir(), "AppData", "Roaming", "npm", "codex.ps1");
+  }
+  return "codex";
+}
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+function waitPort(port, timeoutMs = 7000) {
+  return new Promise((resolve) => {
+    const deadline = Date.now() + timeoutMs;
+    const tryOnce = () => {
+      const socket = net.createConnection({ host: "127.0.0.1", port });
+      socket.on("connect", () => { socket.destroy(); resolve(true); });
+      socket.on("error", () => {
+        socket.destroy();
+        if (Date.now() >= deadline) resolve(false);
+        else setTimeout(tryOnce, 100);
+      });
+    };
+    tryOnce();
+  });
+}
+
+function paths(runDir) {
+  const dir = path.resolve(runDir || path.join(process.cwd(), "run", "poc-codex-app-server"));
+  return {
+    dir,
+    pidFile: path.join(dir, "codex-app-server.pid"),
+    portFile: path.join(dir, "codex-app-server.port"),
+    endpointFile: path.join(dir, "codex-app-server.endpoint"),
+    logFile: path.join(dir, "codex-app-server.log"),
+  };
+}
+
+function spawnCodex(codex, args, logFile) {
+  const stdout = fs.openSync(logFile, "a");
+  const stderr = fs.openSync(logFile, "a");
+  if (process.platform === "win32" && codex.toLowerCase().endsWith(".ps1")) {
+    return childProcess.spawn("powershell.exe", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", codex, ...args], {
+      stdio: ["ignore", stdout, stderr],
+      detached: false,
+      windowsHide: true,
+    });
+  }
+  return childProcess.spawn(codex, args, {
+    stdio: ["ignore", stdout, stderr],
+    detached: process.platform === "win32",
+    windowsHide: true,
+  });
+}
+
+function readPid(file) {
+  try { return Number(fs.readFileSync(file, "utf8").trim()); }
+  catch (_) { return 0; }
+}
+
+async function start(opts) {
+  const p = paths(opts.runDir);
+  fs.mkdirSync(p.dir, { recursive: true });
+  const port = opts.port || await freePort();
+  const endpoint = `ws://127.0.0.1:${port}`;
+  const codex = opts.codex || defaultCodex();
+  const child = spawnCodex(codex, ["app-server", "--listen", endpoint], p.logFile);
+  child.unref();
+  fs.writeFileSync(p.pidFile, `${child.pid}\n`);
+  fs.writeFileSync(p.portFile, `${port}\n`);
+  fs.writeFileSync(p.endpointFile, `${endpoint}\n`);
+  const open = await waitPort(port);
+  if (!open) {
+    try { child.kill(); } catch (_) {}
+    throw new Error(`app-server did not open ${endpoint}; see ${p.logFile}`);
+  }
+  console.log(JSON.stringify({ ok: true, pid: child.pid, endpoint, logFile: p.logFile }, null, 2));
+}
+
+function stop(opts) {
+  const p = paths(opts.runDir);
+  const pid = readPid(p.pidFile);
+  let stopped = false;
+  if (pid) {
+    try {
+      if (process.platform === "win32") {
+        childProcess.spawnSync("taskkill.exe", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true });
+      } else {
+        process.kill(-pid);
+      }
+      stopped = true;
+    } catch (_) {
+      try { process.kill(pid); stopped = true; } catch (__) {}
+    }
+  }
+  for (const file of [p.pidFile, p.portFile, p.endpointFile]) {
+    try { fs.unlinkSync(file); } catch (_) {}
+  }
+  console.log(JSON.stringify({ ok: true, stopped, pid }, null, 2));
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help || !opts.command) { usage(); return; }
+  if (opts.command === "start") await start(opts);
+  else if (opts.command === "stop") stop(opts);
+  else throw new Error(`unknown command: ${opts.command}`);
+}
+
+main().catch((error) => {
+  console.error(`codex-app-server-owner: ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/poc/codex-idle-wake-adapter.js
+++ b/scripts/poc/codex-idle-wake-adapter.js
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("crypto");
+const net = require("net");
+const path = require("path");
+
+function usage() {
+  console.log(`Usage: codex-idle-wake-adapter.js --project <path> --app-server ws://host:port [--thread <id|loaded|new>] [--request-timeout-ms <n>] [--wait-after-start-ms <n>] [--prompt-text <text>]
+
+PoC one-shot adapter. Reads AGMSG_SUPERVISOR_MESSAGE_JSON and starts a Codex turn.
+This is intentionally disposable and not wired into production delivery.`);
+}
+
+function parseArgs(argv) {
+  const opts = { thread: "loaded", requestTimeoutMs: 10000, waitAfterStartMs: 0 };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") opts.help = true;
+    else if (arg === "--project") opts.project = argv[++i];
+    else if (arg === "--app-server") opts.appServer = argv[++i];
+    else if (arg === "--thread") opts.thread = argv[++i];
+    else if (arg === "--request-timeout-ms") opts.requestTimeoutMs = Number(argv[++i]);
+    else if (arg === "--wait-after-start-ms") opts.waitAfterStartMs = Number(argv[++i]);
+    else if (arg === "--prompt-text") opts.promptText = argv[++i];
+    else if (arg === "--skip-resume") opts.skipResume = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return opts;
+}
+
+function parseWsTarget(url) {
+  const match = /^ws:\/\/([^/:]+):(\d+)\/?$/.exec(url || "");
+  if (!match) throw new Error(`--app-server must be ws://host:port, got ${url || "<empty>"}`);
+  return { host: match[1], port: Number(match[2]) };
+}
+
+class WsJsonRpcClient {
+  constructor(target, opts = {}) {
+    this.target = target;
+    this.requestTimeoutMs = opts.requestTimeoutMs || 0;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.handlers = new Map();
+    this.buffer = Buffer.alloc(0);
+    this.handshakeBuffer = Buffer.alloc(0);
+    this.handshakeComplete = false;
+    this.connected = false;
+    this.socket = null;
+  }
+
+  start() {
+    return new Promise((resolve, reject) => {
+      const key = crypto.randomBytes(16).toString("base64");
+      this.expectedAccept = crypto.createHash("sha1").update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`).digest("base64");
+      this.socket = net.createConnection(this.target);
+      this.socket.on("connect", () => {
+        this.socket.write([
+          "GET / HTTP/1.1",
+          "Host: localhost",
+          "Upgrade: websocket",
+          "Connection: Upgrade",
+          `Sec-WebSocket-Key: ${key}`,
+          "Sec-WebSocket-Version: 13",
+          "",
+          "",
+        ].join("\r\n"));
+      });
+      this.socket.on("data", (chunk) => this.handleData(chunk, resolve, reject));
+      this.socket.on("error", reject);
+      this.socket.on("close", () => this.rejectAll(new Error("app-server connection closed")));
+    });
+  }
+
+  handleData(chunk, resolveStart, rejectStart) {
+    if (!this.handshakeComplete) {
+      this.handshakeBuffer = Buffer.concat([this.handshakeBuffer, chunk]);
+      const headerEnd = this.handshakeBuffer.indexOf("\r\n\r\n");
+      if (headerEnd === -1) return;
+      const header = this.handshakeBuffer.slice(0, headerEnd).toString("utf8");
+      const rest = this.handshakeBuffer.slice(headerEnd + 4);
+      const lines = header.split(/\r\n/);
+      const headers = new Map();
+      for (const line of lines.slice(1)) {
+        const index = line.indexOf(":");
+        if (index !== -1) headers.set(line.slice(0, index).toLowerCase(), line.slice(index + 1).trim());
+      }
+      if (!/^HTTP\/1\.1 101\b/.test(lines[0] || "") || headers.get("sec-websocket-accept") !== this.expectedAccept) {
+        rejectStart(new Error("websocket upgrade failed"));
+        this.stop();
+        return;
+      }
+      this.handshakeComplete = true;
+      this.connected = true;
+      resolveStart();
+      if (rest.length) this.handleWebSocketBytes(rest);
+      return;
+    }
+    this.handleWebSocketBytes(chunk);
+  }
+
+  handleWebSocketBytes(chunk) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    while (this.buffer.length >= 2) {
+      const first = this.buffer[0];
+      const second = this.buffer[1];
+      const opcode = first & 0x0f;
+      const masked = (second & 0x80) !== 0;
+      let length = second & 0x7f;
+      let offset = 2;
+      if (length === 126) {
+        if (this.buffer.length < offset + 2) return;
+        length = this.buffer.readUInt16BE(offset);
+        offset += 2;
+      } else if (length === 127) {
+        if (this.buffer.length < offset + 8) return;
+        const high = this.buffer.readUInt32BE(offset);
+        const low = this.buffer.readUInt32BE(offset + 4);
+        if (high !== 0) throw new Error("websocket frame too large");
+        length = low;
+        offset += 8;
+      }
+      const maskOffset = offset;
+      if (masked) offset += 4;
+      if (this.buffer.length < offset + length) return;
+      let payload = this.buffer.slice(offset, offset + length);
+      if (masked) {
+        const mask = this.buffer.slice(maskOffset, maskOffset + 4);
+        payload = Buffer.from(payload.map((byte, index) => byte ^ mask[index % 4]));
+      }
+      this.buffer = this.buffer.slice(offset + length);
+      if (opcode === 0x1) this.handleLine(payload.toString("utf8"));
+      if (opcode === 0x8) this.stop();
+    }
+  }
+
+  handleLine(line) {
+    if (!line.trim()) return;
+    const message = JSON.parse(line);
+    if (!Object.prototype.hasOwnProperty.call(message, "id")) {
+      const handlers = this.handlers.get(message.method) || [];
+      for (const handler of handlers) handler(message.params || {});
+      return;
+    }
+    const pending = this.pending.get(message.id);
+    if (!pending) return;
+    this.pending.delete(message.id);
+    if (message.error) pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
+    else pending.resolve(message.result);
+  }
+
+  request(method, params) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      let timer = null;
+      if (this.requestTimeoutMs > 0) {
+        timer = setTimeout(() => {
+          this.pending.delete(id);
+          reject(new Error(`${method} timed out after ${this.requestTimeoutMs}ms`));
+        }, this.requestTimeoutMs);
+      }
+      this.pending.set(id, {
+        resolve: (value) => { if (timer) clearTimeout(timer); resolve(value); },
+        reject: (error) => { if (timer) clearTimeout(timer); reject(error); },
+      });
+      this.sendJson({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  notify(method, params = {}) {
+    this.sendJson({ jsonrpc: "2.0", method, params });
+  }
+
+  on(method, handler) {
+    const handlers = this.handlers.get(method) || [];
+    handlers.push(handler);
+    this.handlers.set(method, handlers);
+  }
+
+  sendJson(value) {
+    if (!this.connected) throw new Error("websocket not connected");
+    this.sendFrame(0x1, Buffer.from(JSON.stringify(value), "utf8"));
+  }
+
+  sendFrame(opcode, payload) {
+    const length = payload.length;
+    let headerLength = 2;
+    if (length >= 126 && length <= 0xffff) headerLength += 2;
+    if (length > 0xffff) headerLength += 8;
+    const mask = crypto.randomBytes(4);
+    const frame = Buffer.alloc(headerLength + 4 + length);
+    frame[0] = 0x80 | opcode;
+    if (length < 126) frame[1] = 0x80 | length;
+    else if (length <= 0xffff) { frame[1] = 0x80 | 126; frame.writeUInt16BE(length, 2); }
+    else { frame[1] = 0x80 | 127; frame.writeUInt32BE(0, 2); frame.writeUInt32BE(length, 6); }
+    mask.copy(frame, headerLength);
+    for (let i = 0; i < length; i += 1) frame[headerLength + 4 + i] = payload[i] ^ mask[i % 4];
+    this.socket.write(frame);
+  }
+
+  rejectAll(error) {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+
+  stop() {
+    this.connected = false;
+    if (this.socket && !this.socket.destroyed) this.socket.destroy();
+  }
+}
+
+function buildPrompt(message) {
+  const body = message.body || "";
+  return [
+    "[$agmsg] Incoming message delivered by delivery-supervisor PoC.",
+    `From: ${message.from || "unknown"}`,
+    `To: ${message.to || "unknown"}`,
+    `Team: ${message.team || "unknown"}`,
+    "",
+    body,
+  ].join("\n");
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function observeEvent(observed, method, params) {
+  observed.push({
+    method,
+    threadId: params && params.threadId,
+    turnId: params && (params.turnId || params.turn_id),
+    status: params && params.status && params.status.type,
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) { usage(); return; }
+  if (!opts.project) throw new Error("missing --project");
+  if (!opts.appServer) throw new Error("missing --app-server");
+  const message = JSON.parse(process.env.AGMSG_SUPERVISOR_MESSAGE_JSON || "{}");
+  if (!message.to) throw new Error("AGMSG_SUPERVISOR_MESSAGE_JSON is missing to");
+
+  const client = new WsJsonRpcClient(parseWsTarget(opts.appServer), { requestTimeoutMs: opts.requestTimeoutMs });
+  const observed = [];
+  for (const method of ["turn/started", "turn/completed", "turn/failed", "thread/status/changed"]) {
+    client.on(method, (params) => observeEvent(observed, method, params));
+  }
+  await client.start();
+  await client.request("initialize", {
+    clientInfo: { name: "agmsg-supervisor-poc", title: "agmsg Supervisor PoC", version: "poc" },
+    capabilities: { experimentalApi: true, requestAttestation: false, optOutNotificationMethods: [] },
+  });
+  client.notify("initialized");
+
+  let threadId = opts.thread;
+  if (threadId === "new") {
+    const started = await client.request("thread/start", {
+      cwd: path.resolve(opts.project),
+      runtimeWorkspaceRoots: [path.resolve(opts.project)],
+      ephemeral: false,
+    });
+    threadId = started.thread && started.thread.id;
+    if (!threadId) throw new Error("thread/start did not return a thread id");
+  } else if (threadId === "loaded") {
+    const loaded = await client.request("thread/loaded/list", {});
+    const ids = loaded && Array.isArray(loaded.data) ? loaded.data : [];
+    if (ids.length !== 1) throw new Error(`expected exactly one loaded thread, got ${ids.length}`);
+    threadId = ids[0];
+  }
+
+  if (!opts.skipResume) {
+    const resumed = await client.request("thread/resume", {
+    threadId,
+    cwd: path.resolve(opts.project),
+    runtimeWorkspaceRoots: [path.resolve(opts.project)],
+    excludeTurns: true,
+  });
+    if (!resumed.thread || resumed.thread.id !== threadId) throw new Error("thread/resume did not return the requested thread");
+    const statusType = resumed.thread.status && resumed.thread.status.type;
+    if (statusType === "active") throw new Error("thread is active; idle-wake test requires an idle thread");
+  }
+
+  await client.request("turn/start", {
+    threadId,
+    input: [{ type: "text", text: opts.promptText || buildPrompt(message), text_elements: [] }],
+    cwd: path.resolve(opts.project),
+    runtimeWorkspaceRoots: [path.resolve(opts.project)],
+  });
+  if (opts.waitAfterStartMs > 0) await sleep(opts.waitAfterStartMs);
+  client.stop();
+  console.log(JSON.stringify({ ok: true, threadId, observed }));
+}
+
+main().catch((error) => {
+  console.error(`codex-idle-wake-adapter: ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/poc/delivery-supervisor.js
+++ b/scripts/poc/delivery-supervisor.js
@@ -1,0 +1,390 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const childProcess = require("child_process");
+const http = require("http");
+const os = require("os");
+const path = require("path");
+
+const DEFAULT_HEARTBEAT_TIMEOUT_MS = 3000;
+const DEFAULT_POLL_MS = 250;
+
+function usage() {
+  console.log(`Usage: delivery-supervisor.js <command> [options]
+
+PoC delivery supervisor. This is intentionally disposable and is not wired into
+production delivery.sh.
+
+Commands:
+  start       Start a project singleton supervisor.
+  attach      Register/refresh a session heartbeat.
+  heartbeat   Refresh a session heartbeat.
+  send        Append a message to the supervisor mailbox.
+  status      Print supervisor status JSON.
+  stop        Stop the supervisor.
+
+Common options:
+  --run-dir <path>     Runtime directory (default: <repo>/run/poc-delivery-supervisor)
+  --project <path>     Project key (default: cwd)
+
+start options:
+  --heartbeat-timeout-ms <n>  Stale timeout (default: ${DEFAULT_HEARTBEAT_TIMEOUT_MS})
+  --poll-ms <n>               Poll interval (default: ${DEFAULT_POLL_MS})
+  --adapter-log <path>        File receiving mock deliveries
+  --adapter-cmd <command>     Optional command run for each delivery
+
+attach/heartbeat options:
+  --team <team> --name <agent> --session <id>
+
+send options:
+  --team <team> --from <agent> --to <agent> --body <text>
+`);
+}
+
+function parseArgs(argv) {
+  const command = argv[0] && !argv[0].startsWith("--") ? argv[0] : "";
+  const opts = { command };
+  const startIndex = command ? 1 : 0;
+  for (let i = startIndex; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") opts.help = true;
+    else if (arg.startsWith("--")) {
+      const key = arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        opts[key] = true;
+      } else {
+        opts[key] = next;
+        i += 1;
+      }
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function repoRoot() {
+  return path.resolve(__dirname, "..", "..");
+}
+
+function projectHash(project) {
+  let h = 2166136261;
+  for (const ch of String(project)) {
+    h ^= ch.charCodeAt(0);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+function paths(opts) {
+  const project = path.resolve(opts.project || process.cwd());
+  const runDir = path.resolve(opts.runDir || path.join(repoRoot(), "run", "poc-delivery-supervisor"));
+  const key = projectHash(project);
+  return {
+    project,
+    runDir,
+    key,
+    portFile: path.join(runDir, `supervisor.${key}.port`),
+    lockFile: path.join(runDir, `supervisor.${key}.lock`),
+    mailboxFile: path.join(runDir, `supervisor.${key}.mailbox.jsonl`),
+    stateFile: path.join(runDir, `supervisor.${key}.state.json`),
+    eventLog: path.join(runDir, `supervisor.${key}.events.log`),
+    adapterLog: path.resolve(opts.adapterLog || path.join(runDir, `supervisor.${key}.adapter.log`)),
+  };
+}
+
+function readJson(file, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (_) {
+    return fallback;
+  }
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(value, null, 2));
+}
+
+function appendLine(file, line) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.appendFileSync(file, `${line}${os.EOL}`);
+}
+
+function appendEvent(p, event, fields = {}) {
+  appendLine(p.eventLog, JSON.stringify({ ts: new Date().toISOString(), event, ...fields }));
+}
+
+function readMailbox(file) {
+  try {
+    return fs.readFileSync(file, "utf8")
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch (_) {
+    return [];
+  }
+}
+
+function request(port, method, pathname, body) {
+  return new Promise((resolve, reject) => {
+    const payload = body ? Buffer.from(JSON.stringify(body)) : Buffer.alloc(0);
+    const req = http.request({ host: "127.0.0.1", port, path: pathname, method, headers: {
+      "content-type": "application/json",
+      "content-length": payload.length,
+    }}, (res) => {
+      const chunks = [];
+      res.on("data", (chunk) => chunks.push(chunk));
+      res.on("end", () => {
+        const text = Buffer.concat(chunks).toString("utf8");
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          reject(new Error(text || `HTTP ${res.statusCode}`));
+          return;
+        }
+        try { resolve(text ? JSON.parse(text) : {}); }
+        catch (_) { resolve({ text }); }
+      });
+    });
+    req.on("error", reject);
+    req.end(payload);
+  });
+}
+
+function readPort(p) {
+  const port = Number(fs.readFileSync(p.portFile, "utf8").trim());
+  if (!Number.isInteger(port) || port <= 0) throw new Error(`invalid port file: ${p.portFile}`);
+  return port;
+}
+
+async function probeExisting(p) {
+  try {
+    const port = readPort(p);
+    await request(port, "GET", "/status");
+    return port;
+  } catch (_) {
+    return 0;
+  }
+}
+
+function requireFields(opts, names) {
+  for (const name of names) {
+    if (!opts[name]) throw new Error(`missing --${name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)}`);
+  }
+}
+
+class Supervisor {
+  constructor(opts, p) {
+    this.opts = opts;
+    this.p = p;
+    this.heartbeatTimeoutMs = Number(opts.heartbeatTimeoutMs || DEFAULT_HEARTBEAT_TIMEOUT_MS);
+    this.pollMs = Number(opts.pollMs || DEFAULT_POLL_MS);
+    this.state = readJson(p.stateFile, { cursor: 0, nextMessageId: 1, sessions: {} });
+    this.delivered = new Set();
+    this.server = null;
+    this.timer = null;
+  }
+
+  save() { writeJson(this.p.stateFile, this.state); }
+
+  attach({ team, name, session }) {
+    const key = `${team}/${name}/${session}`;
+    this.state.sessions[key] = { team, name, session, lastHeartbeat: Date.now(), status: "live" };
+    this.save();
+    appendEvent(this.p, "attach", { team, name, session });
+    return this.state.sessions[key];
+  }
+
+  heartbeat({ team, name, session }) {
+    return this.attach({ team, name, session });
+  }
+
+  liveSessionFor(team, name) {
+    const now = Date.now();
+    const live = Object.values(this.state.sessions)
+      .filter((s) => s.team === team && s.name === name && now - s.lastHeartbeat <= this.heartbeatTimeoutMs)
+      .sort((a, b) => b.lastHeartbeat - a.lastHeartbeat);
+    return live[0] || null;
+  }
+
+  markStale() {
+    const now = Date.now();
+    let changed = false;
+    for (const session of Object.values(this.state.sessions)) {
+      const next = now - session.lastHeartbeat > this.heartbeatTimeoutMs ? "stale" : "live";
+      if (session.status !== next) {
+        session.status = next;
+        appendEvent(this.p, next === "stale" ? "stale" : "live", {
+          team: session.team,
+          name: session.name,
+          session: session.session,
+        });
+        changed = true;
+      }
+    }
+    if (changed) this.save();
+  }
+
+  deliver(message, session) {
+    const delivery = {
+      ts: new Date().toISOString(),
+      id: message.id,
+      team: message.team,
+      from: message.from,
+      to: message.to,
+      session: session.session,
+      body: message.body,
+    };
+    if (this.opts.adapterCmd) {
+      const result = childProcess.spawnSync(this.opts.adapterCmd, {
+        shell: true,
+        encoding: "utf8",
+        env: { ...process.env, AGMSG_SUPERVISOR_MESSAGE_JSON: JSON.stringify(delivery) },
+      });
+      if (result.status !== 0) {
+        appendEvent(this.p, "adapter-fail", { id: message.id, status: result.status, stderr: (result.stderr || "").trim() });
+        return false;
+      }
+      appendEvent(this.p, "adapter-ok", {
+        id: message.id,
+        status: result.status,
+        stdout: (result.stdout || "").trim(),
+        stderr: (result.stderr || "").trim(),
+      });
+    }
+    appendLine(this.p.adapterLog, JSON.stringify(delivery));
+    this.delivered.add(message.id);
+    this.state.cursor = Math.max(this.state.cursor || 0, message.id);
+    this.save();
+    appendEvent(this.p, "deliver", { id: message.id, to: message.to, session: session.session });
+    return true;
+  }
+
+  tick() {
+    this.markStale();
+    const messages = readMailbox(this.p.mailboxFile).filter((m) => m.id > (this.state.cursor || 0));
+    for (const message of messages) {
+      if (this.delivered.has(message.id)) continue;
+      const session = this.liveSessionFor(message.team, message.to);
+      if (!session) {
+        appendEvent(this.p, "hold", { id: message.id, to: message.to, reason: "no-live-session" });
+        break;
+      }
+      if (!this.deliver(message, session)) break;
+    }
+  }
+
+  status() {
+    this.markStale();
+    return {
+      ok: true,
+      pid: process.pid,
+      project: this.p.project,
+      cursor: this.state.cursor || 0,
+      sessions: Object.values(this.state.sessions),
+      files: {
+        portFile: this.p.portFile,
+        lockFile: this.p.lockFile,
+        mailboxFile: this.p.mailboxFile,
+        stateFile: this.p.stateFile,
+        eventLog: this.p.eventLog,
+        adapterLog: this.p.adapterLog,
+      },
+    };
+  }
+
+  async start() {
+    fs.mkdirSync(this.p.runDir, { recursive: true });
+    appendEvent(this.p, "start", { pid: process.pid, project: this.p.project });
+
+    this.server = http.createServer((req, res) => {
+      const chunks = [];
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        let body = {};
+        try { body = chunks.length ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : {}; }
+        catch (_) { body = {}; }
+        const reply = (code, value) => {
+          const text = JSON.stringify(value);
+          res.writeHead(code, { "content-type": "application/json" });
+          res.end(text);
+        };
+        try {
+          if (req.method === "GET" && req.url === "/status") reply(200, this.status());
+          else if (req.method === "POST" && req.url === "/attach") reply(200, this.attach(body));
+          else if (req.method === "POST" && req.url === "/heartbeat") reply(200, this.heartbeat(body));
+          else if (req.method === "POST" && req.url === "/message") {
+            const nextId = this.state.nextMessageId || 1;
+            const msg = { id: nextId, createdAt: new Date().toISOString(), ...body };
+            this.state.nextMessageId = nextId + 1;
+            this.save();
+            appendLine(this.p.mailboxFile, JSON.stringify(msg));
+            appendEvent(this.p, "message", { id: msg.id, to: msg.to });
+            this.tick();
+            reply(200, msg);
+          } else if (req.method === "POST" && req.url === "/stop") {
+            reply(200, { ok: true });
+            setTimeout(() => this.stop(), 20);
+          } else reply(404, { error: "not found" });
+        } catch (error) {
+          reply(500, { error: error.message });
+        }
+      });
+    });
+
+    await new Promise((resolve) => this.server.listen(0, "127.0.0.1", resolve));
+    const port = this.server.address().port;
+    fs.writeFileSync(this.p.portFile, String(port));
+    fs.writeFileSync(this.p.lockFile, JSON.stringify({ pid: process.pid, port, project: this.p.project }));
+    this.timer = setInterval(() => this.tick(), this.pollMs);
+    if (this.timer.unref) this.timer.unref();
+    console.log(`status=started port=${port} pid=${process.pid}`);
+  }
+
+  stop() {
+    appendEvent(this.p, "stop", { pid: process.pid });
+    if (this.timer) clearInterval(this.timer);
+    try { fs.unlinkSync(this.p.portFile); } catch (_) {}
+    try { fs.unlinkSync(this.p.lockFile); } catch (_) {}
+    if (this.server) this.server.close(() => process.exit(0));
+    else process.exit(0);
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (!opts.command || opts.help) { usage(); return; }
+  const p = paths(opts);
+
+  if (opts.command === "start") {
+    const port = await probeExisting(p);
+    if (port) throw new Error(`supervisor already running on port ${port}`);
+    const supervisor = new Supervisor(opts, p);
+    await supervisor.start();
+    return;
+  }
+
+  const port = readPort(p);
+  if (opts.command === "attach") {
+    requireFields(opts, ["team", "name", "session"]);
+    console.log(JSON.stringify(await request(port, "POST", "/attach", opts), null, 2));
+  } else if (opts.command === "heartbeat") {
+    requireFields(opts, ["team", "name", "session"]);
+    console.log(JSON.stringify(await request(port, "POST", "/heartbeat", opts), null, 2));
+  } else if (opts.command === "send") {
+    requireFields(opts, ["team", "from", "to", "body"]);
+    console.log(JSON.stringify(await request(port, "POST", "/message", opts), null, 2));
+  } else if (opts.command === "status") {
+    console.log(JSON.stringify(await request(port, "GET", "/status"), null, 2));
+  } else if (opts.command === "stop") {
+    console.log(JSON.stringify(await request(port, "POST", "/stop"), null, 2));
+  } else {
+    throw new Error(`unknown command: ${opts.command}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(`delivery-supervisor: ${error.message}`);
+  process.exit(1);
+});

--- a/tests/poc/smoke-codex-remote-wake.cjs
+++ b/tests/poc/smoke-codex-remote-wake.cjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+"use strict";
+
+const childProcess = require("child_process");
+const fs = require("fs");
+const net = require("net");
+const os = require("os");
+const path = require("path");
+
+const repo = path.resolve(__dirname, "..", "..");
+const owner = path.join(repo, "scripts", "poc", "codex-app-server-owner.js");
+const adapter = path.join(repo, "scripts", "poc", "codex-idle-wake-adapter.js");
+const project = process.argv[2] || process.cwd();
+const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "agmsg-remote-wake-"));
+
+function nativeCodexExe() {
+  return path.join(os.homedir(), "AppData", "Roaming", "npm", "node_modules", "@openai", "codex", "node_modules", "@openai", "codex-win32-x64", "vendor", "x86_64-pc-windows-msvc", "bin", "codex.exe");
+}
+
+function runNode(args, opts = {}) {
+  return childProcess.spawnSync(process.execPath, args, { cwd: repo, encoding: "utf8", ...opts });
+}
+
+function sleep(ms) { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms); }
+
+function waitForLoaded(endpoint, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const env = { ...process.env, AGMSG_SUPERVISOR_MESSAGE_JSON: JSON.stringify({ id: 1, team: "poc", from: "probe", to: "remote", body: "probe" }) };
+    const r = runNode([adapter, "--project", project, "--app-server", endpoint, "--thread", "loaded", "--request-timeout-ms", "3000"], { env, timeout: 5000 });
+    const output = `${r.stdout || ""}${r.stderr || ""}`;
+    if (r.status === 0) return { ok: true, output };
+    if (!/expected exactly one loaded thread, got 0|no loaded|ECONNRESET|timed out/i.test(output)) {
+      return { ok: false, output, status: r.status };
+    }
+    sleep(500);
+  }
+  return { ok: false, output: "timeout waiting for loaded remote thread" };
+}
+
+function taskkill(pid) {
+  if (!pid) return;
+  if (process.platform === "win32") childProcess.spawnSync("taskkill.exe", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true });
+  else { try { process.kill(pid); } catch (_) {} }
+}
+
+const result = { ok: false, runDir, project };
+let remote;
+try {
+  const start = runNode([owner, "start", "--run-dir", runDir]);
+  result.ownerStart = { status: start.status, stdout: start.stdout, stderr: start.stderr };
+  if (start.status !== 0) throw new Error("owner start failed");
+  const startJson = JSON.parse(start.stdout);
+  result.endpoint = startJson.endpoint;
+  result.ownerPid = startJson.pid;
+
+  const codex = nativeCodexExe();
+  const remoteLog = path.join(runDir, "remote-cli.log");
+  const out = fs.openSync(remoteLog, "a");
+  remote = childProcess.spawn(codex, ["--remote", startJson.endpoint, "--cd", project, "--no-alt-screen"], {
+    cwd: project,
+    stdio: ["ignore", out, out],
+    windowsHide: true,
+  });
+  result.remotePid = remote.pid;
+  result.remoteLog = remoteLog;
+
+  sleep(3000);
+  const wake = waitForLoaded(startJson.endpoint, 20000);
+  result.wake = wake;
+  result.remoteLogTail = fs.existsSync(remoteLog) ? fs.readFileSync(remoteLog, "utf8").slice(-4000) : "";
+  result.ok = Boolean(wake.ok);
+} catch (error) {
+  result.error = error.message;
+} finally {
+  if (remote && remote.pid) taskkill(remote.pid);
+  runNode([owner, "stop", "--run-dir", runDir]);
+}
+
+console.log(JSON.stringify(result, null, 2));
+process.exit(result.ok ? 0 : 1);

--- a/tests/poc/smoke-supervisor-codex-remote-visible.ps1
+++ b/tests/poc/smoke-supervisor-codex-remote-visible.ps1
@@ -1,0 +1,142 @@
+param(
+  [string]$Project = (Get-Location).Path,
+  [int]$WaitAfterStartMs = 10000,
+  [string]$PromptText = "",
+  [switch]$RequireCompleted,
+  [switch]$RequireIdleAfterActive
+)
+
+$ErrorActionPreference = 'Stop'
+
+$Repo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$Node = (Get-Command node).Source
+$Owner = Join-Path $Repo 'scripts\poc\codex-app-server-owner.js'
+$Supervisor = Join-Path $Repo 'scripts\poc\delivery-supervisor.js'
+$Adapter = Join-Path $Repo 'scripts\poc\codex-idle-wake-adapter.js'
+$RunDir = Join-Path $env:TEMP ('agmsg-supervisor-remote-' + [guid]::NewGuid().ToString('N'))
+$CodexExe = Join-Path $env:APPDATA 'npm\node_modules\@openai\codex\node_modules\@openai\codex-win32-x64\vendor\x86_64-pc-windows-msvc\bin\codex.exe'
+
+if (-not (Test-Path -LiteralPath $CodexExe)) {
+  throw "native codex.exe not found: $CodexExe"
+}
+
+function Quote-CommandArg([string]$Value) {
+  '"' + ($Value -replace '"', '\"') + '"'
+}
+
+function Invoke-NodeJson {
+  param([Parameter(ValueFromRemainingArguments = $true)][string[]]$NodeArgs)
+  $previousErrorActionPreference = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    $raw = & $Node @NodeArgs 2>&1
+    $exitCode = $LASTEXITCODE
+  } finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+  }
+  if ($exitCode -ne 0) {
+    throw "node command failed ($exitCode): $($NodeArgs -join ' ')`n$($raw -join "`n")"
+  }
+  ($raw -join "`n") | ConvertFrom-Json
+}
+
+function Wait-SupervisorReady([string]$Dir) {
+  $deadline = (Get-Date).AddSeconds(10)
+  while ((Get-Date) -lt $deadline) {
+    $portFile = Get-ChildItem -LiteralPath $Dir -Filter 'supervisor.*.port' -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($portFile) { return }
+    Start-Sleep -Milliseconds 100
+  }
+  throw "supervisor port file was not created under $Dir"
+}
+
+function Stop-Tree([int]$ProcessId) {
+  if ($ProcessId -gt 0) {
+    try { taskkill.exe /PID $ProcessId /T /F 2>$null | Out-Null } catch {}
+  }
+}
+
+$summary = [ordered]@{
+  ok = $false
+  runDir = $RunDir
+  project = (Resolve-Path $Project).Path
+}
+$remoteProcess = $null
+$supervisorProcess = $null
+
+try {
+  New-Item -ItemType Directory -Force -Path $RunDir | Out-Null
+
+  $ownerStart = Invoke-NodeJson $Owner 'start' '--run-dir' $RunDir
+  $summary.endpoint = $ownerStart.endpoint
+  $summary.ownerPid = $ownerStart.pid
+
+  $remoteCommand = "& '$CodexExe' --remote '$($ownerStart.endpoint)' --cd '$Project' --no-alt-screen"
+  $remoteProcess = Start-Process powershell.exe -ArgumentList @('-NoExit', '-Command', $remoteCommand) -PassThru
+  $summary.remotePid = $remoteProcess.Id
+  Start-Sleep -Seconds 8
+
+  $adapterArgs = @(
+    (Quote-CommandArg $Node),
+    (Quote-CommandArg $Adapter),
+    '--project', (Quote-CommandArg $Project),
+    '--app-server', $ownerStart.endpoint,
+    '--thread', 'loaded',
+    '--skip-resume',
+    '--request-timeout-ms', '30000',
+    '--wait-after-start-ms', [string]$WaitAfterStartMs
+  )
+  if ($PromptText) {
+    $adapterArgs += @('--prompt-text', (Quote-CommandArg $PromptText))
+  }
+  $adapterCmd = $adapterArgs -join ' '
+  $summary.adapterCmd = $adapterCmd
+
+  $supervisorOut = Join-Path $RunDir 'supervisor.stdout.log'
+  $supervisorErr = Join-Path $RunDir 'supervisor.stderr.log'
+  $supervisorArgs = @(
+    $Supervisor, 'start', '--run-dir', $RunDir, '--project', $Project,
+    '--heartbeat-timeout-ms', '30000', '--poll-ms', '100', '--adapter-cmd', $adapterCmd
+  )
+  $supervisorArgLine = ($supervisorArgs | ForEach-Object { Quote-CommandArg $_ }) -join ' '
+  $supervisorProcess = Start-Process -FilePath $Node -ArgumentList $supervisorArgLine -RedirectStandardOutput $supervisorOut -RedirectStandardError $supervisorErr -PassThru
+  $summary.supervisorPid = $supervisorProcess.Id
+  Wait-SupervisorReady $RunDir
+
+  Invoke-NodeJson $Supervisor 'attach' '--run-dir' $RunDir '--project' $Project '--team' 'mathdesk-desktop' '--name' 'Eiji' '--session' 'visible-remote-smoke' | Out-Null
+  Invoke-NodeJson $Supervisor 'send' '--run-dir' $RunDir '--project' $Project '--team' 'mathdesk-desktop' '--from' 'Anna' '--to' 'Eiji' '--body' 'supervisor to visible codex remote smoke' | Out-Null
+
+  $status = Invoke-NodeJson $Supervisor 'status' '--run-dir' $RunDir '--project' $Project
+  $summary.cursor = $status.cursor
+  $eventLogFile = Get-ChildItem -LiteralPath $RunDir -Filter 'supervisor.*.events.log' | Select-Object -First 1
+  if (-not $eventLogFile) { throw "supervisor event log was not created under $RunDir" }
+  $summary.eventLog = $eventLogFile.FullName
+  $events = Get-Content -LiteralPath $eventLogFile.FullName | Where-Object { $_ } | ForEach-Object { $_ | ConvertFrom-Json }
+  $adapterOk = @($events | Where-Object { $_.event -eq 'adapter-ok' } | Select-Object -Last 1)[0]
+  if (-not $adapterOk) { throw 'adapter-ok event was not recorded' }
+  $summary.adapterStdout = $adapterOk.stdout
+  $adapterOutput = $adapterOk.stdout | ConvertFrom-Json
+  $active = @($adapterOutput.observed | Where-Object { $_.method -eq 'thread/status/changed' -and $_.status -eq 'active' })
+  if ($active.Count -lt 1) { throw "no active status observed in adapter stdout: $($adapterOk.stdout)" }
+  if ($RequireCompleted) {
+    $completed = @($adapterOutput.observed | Where-Object { $_.method -eq 'turn/completed' })
+    if ($completed.Count -lt 1) { throw "no turn/completed observed in adapter stdout: $($adapterOk.stdout)" }
+  }
+  if ($RequireIdleAfterActive) {
+    $idle = @($adapterOutput.observed | Where-Object { $_.method -eq 'thread/status/changed' -and $_.status -eq 'idle' })
+    if ($idle.Count -lt 1) { throw "no idle status observed after active in adapter stdout: $($adapterOk.stdout)" }
+  }
+  $summary.threadId = $adapterOutput.threadId
+  $summary.observed = $adapterOutput.observed
+  $summary.requireCompleted = [bool]$RequireCompleted
+  $summary.requireIdleAfterActive = [bool]$RequireIdleAfterActive
+  $summary.ok = $true
+} finally {
+  try { Invoke-NodeJson $Supervisor 'stop' '--run-dir' $RunDir '--project' $Project | Out-Null } catch {}
+  try { Invoke-NodeJson $Owner 'stop' '--run-dir' $RunDir | Out-Null } catch {}
+  if ($remoteProcess) { Stop-Tree $remoteProcess.Id }
+  if ($supervisorProcess) { Stop-Tree $supervisorProcess.Id }
+}
+
+$summary | ConvertTo-Json -Depth 8
+if (-not $summary.ok) { exit 1 }

--- a/tests/poc/test-codex-idle-wake-adapter.cjs
+++ b/tests/poc/test-codex-idle-wake-adapter.cjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert");
+const childProcess = require("child_process");
+const crypto = require("crypto");
+const fs = require("fs");
+const net = require("net");
+const os = require("os");
+const path = require("path");
+
+const repo = path.resolve(__dirname, "..", "..");
+const adapter = path.join(repo, "scripts", "poc", "codex-idle-wake-adapter.js");
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "agmsg-codex-adapter-poc-"));
+const project = path.join(tmp, "project");
+fs.mkdirSync(project, { recursive: true });
+
+function encodeFrame(payload) {
+  const body = Buffer.from(JSON.stringify(payload), "utf8");
+  let header;
+  if (body.length < 126) {
+    header = Buffer.alloc(2);
+    header[0] = 0x81;
+    header[1] = body.length;
+  } else if (body.length <= 0xffff) {
+    header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 126;
+    header.writeUInt16BE(body.length, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x81;
+    header[1] = 127;
+    header.writeUInt32BE(0, 2);
+    header.writeUInt32BE(body.length, 6);
+  }
+  return Buffer.concat([header, body]);
+}
+
+function decodeFrames(buffer) {
+  const frames = [];
+  let offset = 0;
+  while (buffer.length - offset >= 2) {
+    const first = buffer[offset];
+    const second = buffer[offset + 1];
+    const opcode = first & 0x0f;
+    const masked = (second & 0x80) !== 0;
+    let length = second & 0x7f;
+    let cursor = offset + 2;
+    if (length === 126) {
+      if (buffer.length - cursor < 2) break;
+      length = buffer.readUInt16BE(cursor);
+      cursor += 2;
+    } else if (length === 127) {
+      if (buffer.length - cursor < 8) break;
+      const high = buffer.readUInt32BE(cursor);
+      const low = buffer.readUInt32BE(cursor + 4);
+      assert.strictEqual(high, 0);
+      length = low;
+      cursor += 8;
+    }
+    let mask;
+    if (masked) {
+      if (buffer.length - cursor < 4) break;
+      mask = buffer.slice(cursor, cursor + 4);
+      cursor += 4;
+    }
+    if (buffer.length - cursor < length) break;
+    let payload = buffer.slice(cursor, cursor + length);
+    if (masked) payload = Buffer.from(payload.map((byte, index) => byte ^ mask[index % 4]));
+    frames.push({ opcode, text: payload.toString("utf8"), end: cursor + length });
+    offset = cursor + length;
+  }
+  return { frames, rest: buffer.slice(offset) };
+}
+
+const seen = [];
+let server;
+
+function runAdapter(args, env) {
+  return new Promise((resolve) => {
+    const child = childProcess.spawn(process.execPath, args, { cwd: repo, env });
+    const stdout = [];
+    const stderr = [];
+    const timer = setTimeout(() => {
+      child.kill();
+      resolve({ status: null, stdout: Buffer.concat(stdout).toString("utf8"), stderr: Buffer.concat(stderr).toString("utf8"), error: new Error("timeout") });
+    }, 5000);
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      resolve({ status: code, stdout: Buffer.concat(stdout).toString("utf8"), stderr: Buffer.concat(stderr).toString("utf8") });
+    });
+  });
+}
+function startServer() {
+  return new Promise((resolve) => {
+    server = net.createServer((socket) => {
+      let handshaken = false;
+      let buffer = Buffer.alloc(0);
+      socket.on("data", (chunk) => {
+        buffer = Buffer.concat([buffer, chunk]);
+        if (!handshaken) {
+          const headerEnd = buffer.indexOf("\r\n\r\n");
+          if (headerEnd === -1) return;
+          const header = buffer.slice(0, headerEnd).toString("utf8");
+          const keyLine = header.split(/\r\n/).find((line) => /^Sec-WebSocket-Key:/i.test(line));
+          const key = keyLine.split(":")[1].trim();
+          const accept = crypto.createHash("sha1").update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`).digest("base64");
+          socket.write([
+            "HTTP/1.1 101 Switching Protocols",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            `Sec-WebSocket-Accept: ${accept}`,
+            "",
+            "",
+          ].join("\r\n"));
+          buffer = buffer.slice(headerEnd + 4);
+          handshaken = true;
+        }
+        const decoded = decodeFrames(buffer);
+        buffer = decoded.rest;
+        for (const frame of decoded.frames) {
+          if (frame.opcode !== 1) continue;
+          const msg = JSON.parse(frame.text);
+          seen.push(msg);
+          if (!Object.prototype.hasOwnProperty.call(msg, "id")) continue;
+          let result = {};
+          if (msg.method === "initialize") result = {};
+          else if (msg.method === "thread/loaded/list") result = { data: ["thread-fake-1"] };
+          else if (msg.method === "thread/resume") result = { thread: { id: msg.params.threadId, status: { type: "idle" } } };
+          else if (msg.method === "turn/start") result = { turn: { id: "turn-fake-1" } };
+          socket.write(encodeFrame({ jsonrpc: "2.0", id: msg.id, result }));
+          if (msg.method === "turn/start") {
+            socket.write(encodeFrame({ jsonrpc: "2.0", method: "turn/started", params: { threadId: msg.params.threadId, turnId: "turn-fake-1" } }));
+            socket.write(encodeFrame({ jsonrpc: "2.0", method: "thread/status/changed", params: { threadId: msg.params.threadId, status: { type: "active" } } }));
+          }
+        }
+      });
+    });
+    server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+  });
+}
+
+(async () => {
+  const port = await startServer();
+  const env = {
+    ...process.env,
+    AGMSG_SUPERVISOR_MESSAGE_JSON: JSON.stringify({ id: 7, team: "mathdesk-desktop", from: "Anna", to: "Eiji", body: "wake please" }),
+  };
+  const result = await runAdapter([adapter, "--project", project, "--app-server", `ws://127.0.0.1:${port}`, "--thread", "loaded", "--wait-after-start-ms", "50"], env);
+  server.close();
+  assert.strictEqual(result.status, 0, `adapter failed\nseen=${JSON.stringify(seen)}\nstdout=${result.stdout}\nstderr=${result.stderr}\nerror=${result.error && result.error.message}`);
+  const methods = seen.map((msg) => msg.method).filter(Boolean);
+  assert.deepStrictEqual(methods, ["initialize", "initialized", "thread/loaded/list", "thread/resume", "turn/start"]);
+  const turnStart = seen.find((msg) => msg.method === "turn/start");
+  assert.strictEqual(turnStart.params.threadId, "thread-fake-1");
+  assert.match(turnStart.params.input[0].text, /wake please/);
+  assert.match(turnStart.params.input[0].text, /From: Anna/);
+  const output = JSON.parse(result.stdout);
+  assert.deepStrictEqual(output.observed.map((event) => event.method), ["turn/started", "thread/status/changed"]);
+  assert.strictEqual(output.observed[0].threadId, "thread-fake-1");
+  console.log(JSON.stringify({ ok: true, methods, observed: output.observed }, null, 2));
+})().catch((error) => {
+  if (server) server.close();
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/tests/poc/test-delivery-supervisor-adapter-fail.cjs
+++ b/tests/poc/test-delivery-supervisor-adapter-fail.cjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert");
+const childProcess = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const repo = path.resolve(__dirname, "..", "..");
+const script = path.join(repo, "scripts", "poc", "delivery-supervisor.js");
+const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "agmsg-supervisor-adapter-poc-"));
+const project = path.join(runDir, "project");
+fs.mkdirSync(project, { recursive: true });
+
+function run(args) {
+  return childProcess.spawnSync(process.execPath, [script, ...args, "--run-dir", runDir, "--project", project], {
+    cwd: repo,
+    encoding: "utf8",
+  });
+}
+
+function start() {
+  return childProcess.spawn(process.execPath, [
+    script, "start",
+    "--run-dir", runDir,
+    "--project", project,
+    "--heartbeat-timeout-ms", "700",
+    "--poll-ms", "100",
+    "--adapter-cmd", `${JSON.stringify(process.execPath)} -e "process.exit(3)"`,
+  ], { cwd: repo, stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function sleep(ms) { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms); }
+
+function waitForPort() {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const found = fs.readdirSync(runDir).find((name) => name.endsWith(".port"));
+    if (found) return;
+    sleep(50);
+  }
+  throw new Error("port file not created");
+}
+
+function jsonRun(args) {
+  const result = run(args);
+  assert.strictEqual(result.status, 0, `${args.join(" ")} failed\nstdout=${result.stdout}\nstderr=${result.stderr}`);
+  return JSON.parse(result.stdout);
+}
+
+function eventLines() {
+  const file = fs.readdirSync(runDir).find((name) => name.endsWith(".events.log"));
+  if (!file) return [];
+  return fs.readFileSync(path.join(runDir, file), "utf8").split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line));
+}
+
+let proc;
+try {
+  proc = start();
+  waitForPort();
+  jsonRun(["attach", "--team", "mathdesk-desktop", "--name", "Eiji", "--session", "s1"]);
+  jsonRun(["send", "--team", "mathdesk-desktop", "--from", "Anna", "--to", "Eiji", "--body", "adapter-fails"]);
+  sleep(250);
+  const status = jsonRun(["status"]);
+  assert.strictEqual(status.cursor, 0, "adapter failure must not advance cursor");
+  assert(eventLines().some((entry) => entry.event === "adapter-fail"), "adapter failure should be attributed separately");
+  jsonRun(["stop"]);
+  proc = null;
+  console.log(JSON.stringify({ ok: true, runDir }, null, 2));
+} finally {
+  if (proc && !proc.killed) proc.kill();
+}

--- a/tests/poc/test-delivery-supervisor.cjs
+++ b/tests/poc/test-delivery-supervisor.cjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert");
+const childProcess = require("child_process");
+const fs = require("fs");
+const http = require("http");
+const os = require("os");
+const path = require("path");
+
+const repo = path.resolve(__dirname, "..", "..");
+const script = path.join(repo, "scripts", "poc", "delivery-supervisor.js");
+const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "agmsg-supervisor-poc-"));
+const project = path.join(runDir, "project");
+fs.mkdirSync(project, { recursive: true });
+
+function run(args, opts = {}) {
+  return childProcess.spawnSync(process.execPath, [script, ...args, "--run-dir", runDir, "--project", project], {
+    cwd: repo,
+    encoding: "utf8",
+    ...opts,
+  });
+}
+
+function start() {
+  const proc = childProcess.spawn(process.execPath, [script, "start", "--run-dir", runDir, "--project", project, "--heartbeat-timeout-ms", "700", "--poll-ms", "100"], {
+    cwd: repo,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return proc;
+}
+
+function waitForPort() {
+  const deadline = Date.now() + 5000;
+  const file = fs.readdirSync(runDir).find((name) => name.endsWith(".port"));
+  if (file) return Number(fs.readFileSync(path.join(runDir, file), "utf8"));
+  while (Date.now() < deadline) {
+    const found = fs.readdirSync(runDir).find((name) => name.endsWith(".port"));
+    if (found) return Number(fs.readFileSync(path.join(runDir, found), "utf8"));
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+  }
+  throw new Error("port file not created");
+}
+
+function jsonRun(args) {
+  const result = run(args);
+  assert.strictEqual(result.status, 0, `${args.join(" ")} failed\nstdout=${result.stdout}\nstderr=${result.stderr}`);
+  return JSON.parse(result.stdout);
+}
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function adapterLines() {
+  const file = fs.readdirSync(runDir).find((name) => name.endsWith(".adapter.log"));
+  if (!file) return [];
+  return fs.readFileSync(path.join(runDir, file), "utf8").split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line));
+}
+
+let proc;
+try {
+  proc = start();
+  waitForPort();
+
+  const second = run(["start", "--heartbeat-timeout-ms", "700", "--poll-ms", "100"]);
+  assert.notStrictEqual(second.status, 0, "second supervisor start should be rejected");
+  assert.match(second.stderr, /already running/, "second start should report singleton lock/port");
+
+  jsonRun(["attach", "--team", "mathdesk-desktop", "--name", "Eiji", "--session", "s1"]);
+  jsonRun(["send", "--team", "mathdesk-desktop", "--from", "Anna", "--to", "Eiji", "--body", "first"]);
+  sleep(250);
+  let lines = adapterLines();
+  assert.strictEqual(lines.length, 1, "first message should deliver once");
+  assert.strictEqual(lines[0].session, "s1");
+
+  sleep(250);
+  lines = adapterLines();
+  assert.strictEqual(lines.length, 1, "cursor should prevent duplicate delivery");
+
+  jsonRun(["heartbeat", "--team", "mathdesk-desktop", "--name", "Eiji", "--session", "s1"]);
+  let status = jsonRun(["status"]);
+  assert.strictEqual(status.sessions[0].status, "live", "quiet live session should remain live after heartbeat");
+
+  sleep(900);
+  status = jsonRun(["status"]);
+  assert.strictEqual(status.sessions[0].status, "stale", "dead session should become stale after timeout");
+
+  jsonRun(["send", "--team", "mathdesk-desktop", "--from", "Anna", "--to", "Eiji", "--body", "held"]);
+  sleep(250);
+  lines = adapterLines();
+  assert.strictEqual(lines.length, 1, "message to stale session should be held");
+
+  jsonRun(["attach", "--team", "mathdesk-desktop", "--name", "Eiji", "--session", "s2"]);
+  sleep(250);
+  lines = adapterLines();
+  assert.strictEqual(lines.length, 2, "held message should deliver after reattach");
+  assert.strictEqual(lines[1].session, "s2", "reattached session should receive held message");
+
+  const pid = proc.pid;
+  status = jsonRun(["status"]);
+  assert.strictEqual(status.pid, pid, "supervisor process should survive session stale/reattach sequence");
+
+  jsonRun(["stop"]);
+  proc = null;
+  console.log(JSON.stringify({ ok: true, runDir }, null, 2));
+} finally {
+  if (proc && !proc.killed) proc.kill();
+}

--- a/tests/poc/test-supervisor-codex-adapter.cjs
+++ b/tests/poc/test-supervisor-codex-adapter.cjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert");
+const childProcess = require("child_process");
+const crypto = require("crypto");
+const fs = require("fs");
+const net = require("net");
+const os = require("os");
+const path = require("path");
+
+const repo = path.resolve(__dirname, "..", "..");
+const supervisor = path.join(repo, "scripts", "poc", "delivery-supervisor.js");
+const adapter = path.join(repo, "scripts", "poc", "codex-idle-wake-adapter.js");
+const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "agmsg-supervisor-codex-adapter-"));
+const project = path.join(runDir, "project");
+fs.mkdirSync(project, { recursive: true });
+
+function sleep(ms) { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms); }
+
+function encodeFrame(payload) {
+  const body = Buffer.from(JSON.stringify(payload), "utf8");
+  if (body.length < 126) return Buffer.concat([Buffer.from([0x81, body.length]), body]);
+  const header = Buffer.alloc(4);
+  header[0] = 0x81;
+  header[1] = 126;
+  header.writeUInt16BE(body.length, 2);
+  return Buffer.concat([header, body]);
+}
+
+function decodeFrames(buffer) {
+  const frames = [];
+  let offset = 0;
+  while (buffer.length - offset >= 2) {
+    const first = buffer[offset];
+    const second = buffer[offset + 1];
+    const opcode = first & 0x0f;
+    const masked = (second & 0x80) !== 0;
+    let length = second & 0x7f;
+    let cursor = offset + 2;
+    if (length === 126) { if (buffer.length - cursor < 2) break; length = buffer.readUInt16BE(cursor); cursor += 2; }
+    if (length === 127) { if (buffer.length - cursor < 8) break; length = buffer.readUInt32BE(cursor + 4); cursor += 8; }
+    let mask;
+    if (masked) { if (buffer.length - cursor < 4) break; mask = buffer.slice(cursor, cursor + 4); cursor += 4; }
+    if (buffer.length - cursor < length) break;
+    let payload = buffer.slice(cursor, cursor + length);
+    if (masked) payload = Buffer.from(payload.map((byte, index) => byte ^ mask[index % 4]));
+    frames.push({ opcode, text: payload.toString("utf8") });
+    offset = cursor + length;
+  }
+  return { frames, rest: buffer.slice(offset) };
+}
+
+const seen = [];
+let fakeServer;
+
+function startFakeServer() {
+  return new Promise((resolve) => {
+    fakeServer = net.createServer((socket) => {
+      let handshaken = false;
+      let buffer = Buffer.alloc(0);
+      socket.on("data", (chunk) => {
+        buffer = Buffer.concat([buffer, chunk]);
+        if (!handshaken) {
+          const headerEnd = buffer.indexOf("\r\n\r\n");
+          if (headerEnd === -1) return;
+          const header = buffer.slice(0, headerEnd).toString("utf8");
+          const key = header.split(/\r\n/).find((line) => /^Sec-WebSocket-Key:/i.test(line)).split(":")[1].trim();
+          const accept = crypto.createHash("sha1").update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`).digest("base64");
+          socket.write(["HTTP/1.1 101 Switching Protocols", "Upgrade: websocket", "Connection: Upgrade", `Sec-WebSocket-Accept: ${accept}`, "", ""].join("\r\n"));
+          buffer = buffer.slice(headerEnd + 4);
+          handshaken = true;
+        }
+        const decoded = decodeFrames(buffer);
+        buffer = decoded.rest;
+        for (const frame of decoded.frames) {
+          const msg = JSON.parse(frame.text);
+          seen.push(msg);
+          if (!Object.prototype.hasOwnProperty.call(msg, "id")) continue;
+          let result = {};
+          if (msg.method === "thread/loaded/list") result = { data: ["thread-fake-1"] };
+          else if (msg.method === "thread/resume") result = { thread: { id: msg.params.threadId, status: { type: "idle" } } };
+          else if (msg.method === "turn/start") result = { turn: { id: "turn-fake-1" } };
+          socket.write(encodeFrame({ jsonrpc: "2.0", id: msg.id, result }));
+        }
+      });
+    });
+    fakeServer.listen(0, "127.0.0.1", () => resolve(fakeServer.address().port));
+  });
+}
+
+function runCli(args) {
+  return new Promise((resolve) => {
+    const child = childProcess.spawn(process.execPath, [supervisor, ...args, "--run-dir", runDir, "--project", project], { cwd: repo });
+    const stdout = [];
+    const stderr = [];
+    const timer = setTimeout(() => {
+      child.kill();
+      resolve({ status: null, stdout: Buffer.concat(stdout).toString("utf8"), stderr: Buffer.concat(stderr).toString("utf8"), error: new Error("timeout") });
+    }, 5000);
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      resolve({ status: code, stdout: Buffer.concat(stdout).toString("utf8"), stderr: Buffer.concat(stderr).toString("utf8") });
+    });
+  });
+}
+
+async function jsonRunAsync(args) {
+  const result = await runCli(args);
+  assert.strictEqual(result.status, 0, `${args.join(" ")} failed\nstdout=${result.stdout}\nstderr=${result.stderr}\nerror=${result.error && result.error.message}`);
+  return JSON.parse(result.stdout);
+}
+function run(args) {
+  return childProcess.spawnSync(process.execPath, [supervisor, ...args, "--run-dir", runDir, "--project", project], { cwd: repo, encoding: "utf8" });
+}
+
+function jsonRun(args) {
+  const result = run(args);
+  assert.strictEqual(result.status, 0, `${args.join(" ")} failed\nstdout=${result.stdout}\nstderr=${result.stderr}`);
+  return JSON.parse(result.stdout);
+}
+
+function waitForPort() {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const found = fs.readdirSync(runDir).find((name) => name.endsWith(".port"));
+    if (found) return;
+    sleep(50);
+  }
+  throw new Error("supervisor port not ready");
+}
+
+(async () => {
+  const fakePort = await startFakeServer();
+  const adapterCmd = `${JSON.stringify(process.execPath)} ${JSON.stringify(adapter)} --project ${JSON.stringify(project)} --app-server ws://127.0.0.1:${fakePort} --thread loaded`;
+  const proc = childProcess.spawn(process.execPath, [supervisor, "start", "--run-dir", runDir, "--project", project, "--heartbeat-timeout-ms", "1000", "--poll-ms", "100", "--adapter-cmd", adapterCmd], { cwd: repo, stdio: ["ignore", "pipe", "pipe"] });
+  try {
+    waitForPort();
+    await jsonRunAsync(["attach", "--team", "mathdesk-desktop", "--name", "Eiji", "--session", "s1"]);
+    await jsonRunAsync(["send", "--team", "mathdesk-desktop", "--from", "Anna", "--to", "Eiji", "--body", "supervisor to codex adapter"]);
+    sleep(500);
+    const methods = seen.map((msg) => msg.method).filter(Boolean);
+    assert.deepStrictEqual(methods, ["initialize", "initialized", "thread/loaded/list", "thread/resume", "turn/start"]);
+    const status = await jsonRunAsync(["status"]);
+    assert.strictEqual(status.cursor, 1);
+    const events = fs.readFileSync(status.files.eventLog, "utf8").trim().split(/\r?\n/).map((line) => JSON.parse(line));
+    const adapterOk = events.find((event) => event.event === "adapter-ok");
+    assert(adapterOk, "adapter-ok event was not recorded");
+    assert.match(adapterOk.stdout, /"ok":true/);
+    await jsonRunAsync(["stop"]);
+    console.log(JSON.stringify({ ok: true, methods, adapterOk: true }, null, 2));
+  } finally {
+    if (!proc.killed) proc.kill();
+    fakeServer.close();
+  }
+})().catch((error) => {
+  if (fakeServer) fakeServer.close();
+  console.error(error.stack || error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## What this enables

Codex Desktop agents can receive agmsg mail without manually checking their inbox.

A companion waker keeps polling work in a collector process/thread. If there is no unread mail, the target Codex thread is left alone. If mail arrives, the companion wakes the correct Codex Desktop thread, and that target thread reads the official agmsg inbox itself.

In practice:

- a Claude/agent can send mail to a Codex Desktop agent
- the Codex Desktop work thread wakes only when it has unread mail
- the work thread does not receive periodic no-op polling turns
- the collector does not read or mark the message body
- multiple Codex Desktop agents can be watched from one collector

Dogfooded targets:

- Eiji
- JunoMaCoder
- Deneb

Observed behavior:

- no unread mail -> no target wake
- unread mail -> target thread wakes, reads inbox, and replies over agmsg

## Implementation

This adds a companion waker PoC around the existing agmsg scripts:

- `watch-once.sh` is used as the unread oracle
- per-target state suppresses duplicate wakes
- wake delivery uses the Codex app thread route
- the target thread remains responsible for reading official agmsg inbox

## Verification

```text
git diff --check upstream/main...HEAD
node --check scripts/poc/delivery-supervisor.js
node --check scripts/poc/codex-idle-wake-adapter.js
node --check scripts/poc/codex-app-server-owner.js
node tests/poc/test-delivery-supervisor.cjs
node tests/poc/test-delivery-supervisor-adapter-fail.cjs
node tests/poc/test-codex-idle-wake-adapter.cjs
node tests/poc/test-supervisor-codex-adapter.cjs
npm test
```

Additional dogfood notes are in `docs/poc-delivery-supervisor-notes.md`.