### PR TITLE
feat(storage): phase 1 — append-only read-state events (dual-write)

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -148,8 +148,16 @@ for team in "${TEAM_LIST[@]}"; do
       OUTPUT+="  [$ts] $from: $body"$'\n'
     done <<< "$RESULT"
     OUTPUT+=$'\n'
-    # Mark as read
-    agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
+    # Mark as read — dual-write: append message_read events (append-only
+    # read-state log) for the just-read set, AND keep read_at for back-compat.
+    # The events INSERT runs BEFORE the UPDATE so read_at IS NULL still matches.
+    agmsg_sqlite "$DB" "
+INSERT INTO events (type, team, agent, msg_id)
+  SELECT 'message_read', team, to_agent, id FROM messages
+  WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL;
+UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now')
+  WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL;
+" 2>/dev/null || true
   fi
 done
 

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -44,5 +44,15 @@ while IFS=$'\x1f' read -r from body ts; do
 done <<< "$UNREAD"
 echo ""
 
-# Mark as read (non-fatal — may fail in sandboxed environments)
-agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
+# Mark as read (non-fatal — may fail in sandboxed environments).
+# Dual-write: append message_read events (append-only read-state log) for the
+# messages being read, AND keep updating read_at for backward compatibility.
+# The events INSERT must run BEFORE the UPDATE so `read_at IS NULL` still
+# selects the just-read set.
+agmsg_sqlite "$DB" "
+INSERT INTO events (type, team, agent, msg_id)
+  SELECT 'message_read', team, to_agent, id FROM messages
+  WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL;
+UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now')
+  WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL;
+" 2>/dev/null || true

--- a/scripts/internal/init-db.sh
+++ b/scripts/internal/init-db.sh
@@ -35,4 +35,22 @@ CREATE TABLE IF NOT EXISTS messages (
 
 CREATE INDEX IF NOT EXISTS idx_unread ON messages(team, to_agent, read_at) WHERE read_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_history ON messages(team, created_at DESC);
+
+-- Append-only read-state log. The message CONTENT stays in `messages` (never
+-- moved); this table records ONLY read-state as append-only `message_read`
+-- events (who read which message id, when). During the transition `read_at` is
+-- still dual-written on `messages` for backward compatibility; once consumers
+-- read read-state from here, `read_at` becomes obsolete and `messages` is
+-- append-only. NOTE: content is never written here (that was the storage-axis
+-- mistake that broke message delivery).
+CREATE TABLE IF NOT EXISTS events (
+  seq    INTEGER PRIMARY KEY AUTOINCREMENT,
+  type   TEXT NOT NULL,                 -- 'message_read'
+  team   TEXT NOT NULL,
+  agent  TEXT NOT NULL,                 -- who read it
+  msg_id INTEGER NOT NULL,              -- messages.id that was read
+  at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_read ON events(type, team, agent, msg_id);
 SQL

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -79,6 +79,40 @@ SH
   [[ "$output" =~ "hi via override" ]]
 }
 
+# --- append-only read-state events (transition: dual-write with read_at) ---
+
+@test "storage: reading appends message_read events and dual-writes read_at" {
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  bash "$SCRIPTS/send.sh" testteam alice bob "msg one"
+  bash "$SCRIPTS/send.sh" testteam alice bob "msg two"
+  local db="$AGMSG_STORAGE_PATH/messages.db"
+
+  # read-state log starts empty
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM events;")" -eq 0 ]
+
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [ "$status" -eq 0 ]
+  # dual-write: read_at set AND an append-only message_read event per message
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM messages WHERE read_at IS NOT NULL;")" -eq 2 ]
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM events WHERE type='message_read' AND team='testteam' AND agent='bob';")" -eq 2 ]
+
+  # re-reading is a no-op: no duplicate read-state events
+  bash "$SCRIPTS/inbox.sh" testteam bob
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM events;")" -eq 2 ]
+}
+
+@test "storage: message content is never written to the events table (read-state only)" {
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  bash "$SCRIPTS/send.sh" testteam alice bob "secret body"
+  bash "$SCRIPTS/inbox.sh" testteam bob >/dev/null
+  local db="$AGMSG_STORAGE_PATH/messages.db"
+
+  # events holds ONLY read-state rows — no other event types, no body column.
+  # (Guards against the storage-axis regression of moving content into events.)
+  [ -z "$(sqlite3 "$db" "SELECT type FROM events WHERE type<>'message_read';")" ]
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM messages WHERE body='secret body';")" -eq 1 ]
+}
+
 @test "storage: stop-hook delivery works when the default db dir is absent but the override is populated" {
   local store="$BATS_TEST_TMPDIR/store"
   local project="/tmp/agmsg-storage-test-proj"


### PR DESCRIPTION
## Phase 1 of the storage redesign (read-state → append-only events)

Records read-state as append-only `message_read` events, **dual-written** alongside the existing `messages.read_at` column during the transition. Message **content stays in the `messages` table, untouched**.

### Why
The only mutation on `messages` was `UPDATE read_at` on read. Moving read-state to an append-only event log removes that mutation, so the message log becomes append-only — the prerequisite for append-native backends (jsonl/duckdb) in Phase 2. Content never moves.

### Explicitly NOT doing
Moving message content into events (the earlier storage-axis approach in #221) — that broke every consumer of the `messages` table and caused a delivery outage. Here `events` holds **read-state only**; a test enforces this invariant.

### Changes
- `internal/init-db.sh`: add `events(seq, type, team, agent, msg_id, at)` + index. `messages` schema unchanged.
- `inbox.sh` / `check-inbox.sh`: on read, append `message_read` events **before** the `read_at` UPDATE (so the just-read set is still selectable), keeping `read_at` dual-written for back-compat.
- `tests/test_storage.bats`: dual-write, no-duplicate-on-reread, and content-never-in-events.

### Transition / next
- Now: dual-write; unread judgment still uses `read_at` (behavior unchanged).
- Later: flip unread judgment to events, then retire `read_at` → `messages` fully append-only.
- Phase 2: per-team storage driver selection (sqlite/jsonl), per-team store files, `agmsg storage migrate <driver> [team]`. Supersedes #221's approach.

Existing suites green (test_storage 15/15, test_delivery 122/122).