### PR TITLE
fix(codex): arm watch-once.sh via bash on Windows

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -803,6 +803,7 @@ class CodexBridge {
     const handle = `agmsg-watch-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     this.watchHandle = handle;
     const command = [
+      BASH_BIN,
       path.join(SCRIPT_DIR, "watch-once.sh"),
       this.opts.project,
       this.opts.type,


### PR DESCRIPTION
Extracts the one-line Windows fix from #260 by @orangewk so it lands independently of the PoC. Full credit to @orangewk.

## Problem

On Windows, `armWatch` in the codex bridge spawned `watch-once.sh` directly. A `.sh` file has no executable shell association on Windows, so the inbox watcher never armed and codex agents stopped receiving messages.

## Fix

Prepend `BASH_BIN` to the watch command so `watch-once.sh` runs under bash — exactly as the same driver already does for every other script invocation (e.g. `inbox.sh`). `BASH_BIN` (`process.env.GIT_BASH || process.env.AGMSG_BASH || "bash"`) is already defined at the top of the file, so this is a single-line change with no new surface.

```diff
     const command = [
+      BASH_BIN,
       path.join(SCRIPT_DIR, "watch-once.sh"),
```

## Notes

- POSIX behavior is unchanged (`BASH_BIN` defaults to `bash`).
- This is just the watcher-arming fix carved out of the larger delivery PoC in #260 so it can be reviewed and merged on its own.