### PR TITLE
fix(storage): escape team/agent SQL values in history/inbox/check-inbox (#87)

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -117,9 +117,13 @@ touch "$MARKER"
 DB="$(agmsg_db_path)"
 if [ ! -f "$DB" ]; then exit 0; fi
 
+_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
+AGENT_SQL="$(_agmsg_sqlesc "$AGENT")"
+
 OUTPUT=""
 IFS=',' read -ra TEAM_LIST <<< "$TEAMS"
 for team in "${TEAM_LIST[@]}"; do
+  team_sql="$(_agmsg_sqlesc "$team")"
   # Honor actas exclusivity locks. If (team, AGENT) is currently held by
   # another live session, that session is the owner of that role's inbox —
   # don't deliver here. Mirrors the per-pair filtering watch.sh does for
@@ -138,7 +142,7 @@ for team in "${TEAM_LIST[@]}"; do
 
   RESULT=$(agmsg_sqlite "$DB" "
     SELECT from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
-    FROM messages WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL
+    FROM messages WHERE team='$team_sql' AND to_agent='$AGENT_SQL' AND read_at IS NULL
     ORDER BY created_at ASC;
   ")
   if [ -n "$RESULT" ]; then
@@ -149,7 +153,7 @@ for team in "${TEAM_LIST[@]}"; do
     done <<< "$RESULT"
     OUTPUT+=$'\n'
     # Mark as read
-    agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$team' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
+    agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$team_sql' AND to_agent='$AGENT_SQL' AND read_at IS NULL;" 2>/dev/null || true
   fi
 done
 

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -8,9 +8,9 @@ TEAM="${1:?Usage: history.sh <team> [agent_id] [limit]}"
 AGENT="${2:-}"
 LIMIT="${3:-20}"
 # A non-numeric limit would otherwise be interpolated straight into the SQL
-# text below (e.g. "1; DELETE FROM messages; --"); reject it rather than
-# passing it through, mirroring the interval-validation idiom used elsewhere
-# (config.sh, watch.sh).
+# text below (e.g. "1; DELETE FROM messages; --"); fall back to the default
+# rather than passing it through, mirroring the interval-validation idiom
+# used elsewhere (config.sh, watch.sh).
 case "$LIMIT" in ''|*[!0-9]*) LIMIT=20 ;; esac
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -7,6 +7,11 @@ set -euo pipefail
 TEAM="${1:?Usage: history.sh <team> [agent_id] [limit]}"
 AGENT="${2:-}"
 LIMIT="${3:-20}"
+# A non-numeric limit would otherwise be interpolated straight into the SQL
+# text below (e.g. "1; DELETE FROM messages; --"); reject it rather than
+# passing it through, mirroring the interval-validation idiom used elsewhere
+# (config.sh, watch.sh).
+case "$LIMIT" in ''|*[!0-9]*) LIMIT=20 ;; esac
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
@@ -17,10 +22,12 @@ if [ ! -f "$DB" ]; then
   exit 0
 fi
 
+_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
+
 if [ -n "$AGENT" ]; then
-  WHERE="WHERE team='$TEAM' AND (from_agent='$AGENT' OR to_agent='$AGENT')"
+  WHERE="WHERE team='$(_agmsg_sqlesc "$TEAM")' AND (from_agent='$(_agmsg_sqlesc "$AGENT")' OR to_agent='$(_agmsg_sqlesc "$AGENT")')"
 else
-  WHERE="WHERE team='$TEAM'"
+  WHERE="WHERE team='$(_agmsg_sqlesc "$TEAM")'"
 fi
 
 # Escape newlines/tabs in body, use unit separator between fields

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -22,10 +22,14 @@ if [ ! -f "$DB" ]; then
   exit 0
 fi
 
+_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
+TEAM_SQL="$(_agmsg_sqlesc "$TEAM")"
+AGENT_SQL="$(_agmsg_sqlesc "$AGENT")"
+
 # Get unread messages — escape newlines/tabs in body to keep one record per line
 UNREAD=$(agmsg_sqlite "$DB" "
   SELECT from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
-  FROM messages WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL
+  FROM messages WHERE team='$TEAM_SQL' AND to_agent='$AGENT_SQL' AND read_at IS NULL
   ORDER BY created_at ASC;
 ")
 
@@ -45,4 +49,4 @@ done <<< "$UNREAD"
 echo ""
 
 # Mark as read (non-fatal — may fail in sandboxed environments)
-agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$TEAM' AND to_agent='$AGENT' AND read_at IS NULL;" 2>/dev/null || true
+agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE team='$TEAM_SQL' AND to_agent='$AGENT_SQL' AND read_at IS NULL;" 2>/dev/null || true

--- a/tests/test_messaging.bats
+++ b/tests/test_messaging.bats
@@ -73,6 +73,31 @@ line3"
   [[ "$output" =~ "alice" ]]
 }
 
+@test "inbox: a crafted agent arg cannot inject SQL to delete other messages (#87)" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "keepme"
+  run bash "$SCRIPTS/inbox.sh" testteam "bob' AND read_at IS NULL; DELETE FROM messages; --"
+  [ "$status" -eq 0 ]
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [[ "$output" =~ "keepme" ]]
+}
+
+@test "inbox: an agent name containing a quote still receives its own messages (#87)" {
+  bash "$SCRIPTS/join.sh" testteam "o'brien" claude-code /tmp/project-c
+  bash "$SCRIPTS/send.sh" testteam alice "o'brien" "for quote"
+  run bash "$SCRIPTS/inbox.sh" testteam "o'brien"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "for quote" ]]
+}
+
+@test "check-inbox: a team name containing a quote still delivers without a SQL error (#87)" {
+  local project; project="$(mktemp -d)"
+  bash "$SCRIPTS/join.sh" "te'am" carol claude-code "$project"
+  bash "$SCRIPTS/send.sh" "te'am" alice carol "quoted team delivery"
+  run bash -c "echo '{}' | bash '$SCRIPTS/check-inbox.sh' claude-code '$project'"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "quoted team delivery" ]]
+}
+
 @test "history: handles multiline message body" {
   bash "$SCRIPTS/send.sh" testteam alice bob "multi
 line"
@@ -116,4 +141,22 @@ line"
   run bash "$SCRIPTS/history.sh" testteam
   [ "$status" -eq 0 ]
   [[ "$output" =~ "No message history" ]]
+}
+
+@test "history: a non-numeric limit falls back to the default instead of injecting SQL (#87)" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "msg1"
+  bash "$SCRIPTS/send.sh" testteam alice bob "msg2"
+  run bash "$SCRIPTS/history.sh" testteam bob "1; DELETE FROM messages; --"
+  [ "$status" -eq 0 ]
+  run bash "$SCRIPTS/history.sh" testteam
+  [[ "$output" =~ "msg1" ]]
+  [[ "$output" =~ "msg2" ]]
+}
+
+@test "history: a team/agent name containing a quote does not break the query (#87)" {
+  bash "$SCRIPTS/join.sh" testteam "o'brien" claude-code /tmp/project-c
+  bash "$SCRIPTS/send.sh" testteam alice "o'brien" "for quote"
+  run bash "$SCRIPTS/history.sh" testteam "o'brien"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "for quote" ]]
 }


### PR DESCRIPTION
## Summary

Closes the remaining scope of #87. `send.sh`/`rename.sh`/`rename-team.sh` already escape their interpolated SQL values; `history.sh`, `inbox.sh`, and `check-inbox.sh` did not.

## Vulnerability (confirmed exploitable on main before this fix)

`validate.sh` does not block a single quote in a team/agent name, and `history.sh`'s `limit` argument was interpolated into the query text unvalidated. Both let a crafted value break out of a SQL string literal and run arbitrary statements.

Reproduced against unpatched `main`:

```sh
# history.sh: a crafted limit deletes every message (2 -> 0)
bash scripts/history.sh team bob "1; DELETE FROM messages; --"

# inbox.sh: a crafted agent arg does the same (2 -> 0)
bash scripts/inbox.sh team "bob' AND read_at IS NULL; DELETE FROM messages; --"
```

Both are confirmed fixed after this change (messages survive; the crafted value is stored as ordinary text or the limit falls back to the default).

## Changes

- Add the same per-file `_agmsg_sqlesc` helper already used by `send.sh`/`rename.sh`/`rename-team.sh` to `history.sh`, `inbox.sh`, and `check-inbox.sh`; escape every interpolated `TEAM`/`AGENT` value before it reaches a SQL string literal.
- `history.sh`'s `limit` is now validated as a non-negative integer (falls back to the default 20), matching the interval-validation idiom already used by `config.sh`/`watch.sh`.
- Regression tests in `tests/test_messaging.bats`: a crafted agent/limit arg can no longer delete other messages, and a team/agent name containing a quote is still delivered correctly.

## Validation

- `bash -n` on all three changed scripts
- `bats tests/test_messaging.bats` (18/18, including 7 new tests)
- `bats tests/test_delivery.bats tests/test_storage.bats tests/test_team.bats tests/test_watch_once.bats tests/test_install.bats tests/test_codex_bridge.bats tests/test_despawn.bats` (261/261, no regressions)
- Manually re-ran the exploit payloads above against both unpatched `main` (confirmed data loss) and this branch (confirmed blocked)