### PR TITLE
feat(spawn): per-type spawn options via a configurable YAML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,18 @@ By default `spawn` **blocks until the new agent is actually listening** — its 
 
 Options: `--boot-prompt <text>` (initial task; see above), `--project <path>` (default: current project), `--team <team>` (auto-resolved when the project has a single team), and `--terminal <tmpl>` / `$AGMSG_TERMINAL` / config `spawn.terminal` to override the terminal command on the non-tmux path (a `{cmd}` placeholder is replaced with the path to the generated boot script). On macOS the default opens whichever terminal you're currently in (iTerm or Terminal, via `$TERM_PROGRAM`) using `open -a` — a plain app launch, so it does **not** trigger the Automation/AppleScript permission prompts that scripting the terminal directly would.
 
+To always pass a given agent type extra CLI flags on spawn (e.g. a default permission mode or sandbox policy), set them in a YAML **spawn options** file — one section per type, a flat `--flag: value` map underneath. Path: `$AGMSG_SPAWN_OPTIONS_FILE`, else `~/.agmsg/config/spawn_options.yaml`; a missing file or section is a no-op.
+
+```yaml
+claude-code:
+  --permission-mode: acceptEdits
+  --dangerously-skip-permissions: true   # a `true` value emits the flag with no argument
+
+codex:
+  --sandbox: workspace-write
+  --dangerously-skip-permissions: false  # a `false` value suppresses the flag entirely
+```
+
 Only `claude-code` and `codex` are supported today. macOS is the primary target; Linux and Windows are best-effort (please open an issue/PR if your terminal isn't handled). Headless environments — no tmux **and** no usable terminal — error out, since the agent CLIs need an interactive terminal.
 
 ### Tear down a spawned agent (`despawn`)

--- a/scripts/lib/spawn-options.sh
+++ b/scripts/lib/spawn-options.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# spawn-options.sh — per-agent-type extra CLI args injected by spawn.sh.
+#
+# Reads a small YAML file mapping agent type -> a flat map of CLI flag ->
+# value, using the same simple dialect db/config.yaml already uses (flat
+# "section:" header + 2-space-indented "key: value", no nesting, no
+# quoting — see config.sh's yaml_get). Turns one type's section into a list
+# of ready-to-use shell tokens spawn.sh splices into its launch command.
+#
+# File resolution: $AGMSG_SPAWN_OPTIONS_FILE if set, else
+# ~/.agmsg/config/spawn_options.yaml — agmsg's planned install-path-
+# independent config home (#201), distinct from the current skill-dir-rooted
+# db/config.yaml so it survives a custom --cmd install or multiple installs.
+# A missing file, missing type section, or empty file all mean "no extra
+# args" — this feature is fully opt-in and backward compatible.
+#
+# Value semantics (per key under a type's section):
+#   <key>: <value>   -> two tokens: <key> <value>
+#   <key>: true      -> one token:  <key>            (boolean flag on)
+#   <key>: false     -> no tokens                     (explicitly suppressed)
+
+# Guard against double-source.
+[ -n "${_AGMSG_SPAWN_OPTIONS_SH:-}" ] && return 0
+_AGMSG_SPAWN_OPTIONS_SH=1
+
+agmsg_spawn_options_file() {
+  printf '%s' "${AGMSG_SPAWN_OPTIONS_FILE:-$HOME/.agmsg/config/spawn_options.yaml}"
+}
+
+# Emit one shell token per output line for <type>'s section. Each line is a
+# complete argv token — the caller must read line-by-line (never word-split
+# the output), so a value containing spaces stays a single token.
+agmsg_spawn_options_tokens() {
+  local type="$1" file
+  file="$(agmsg_spawn_options_file)"
+  [ -f "$file" ] || return 0
+
+  awk -v section="$type" '
+    /^[^ #]/ { in_section = ($0 ~ "^" section ":") }
+    in_section && /^  [^ ]/ {
+      line = $0
+      sub(/^  /, "", line)
+      idx = index(line, ":")
+      if (idx == 0) next
+      key = substr(line, 1, idx - 1)
+      val = substr(line, idx + 1)
+      sub(/[ \t]+#.*$/, "", val)
+      sub(/^[ \t]+/, "", val)
+      sub(/[ \t]+$/, "", val)
+      if (val == "false") next
+      print key
+      if (val != "" && val != "true") print val
+    }
+  ' "$file"
+}

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -50,6 +50,13 @@ set -euo pipefail
 #                      ids); the flag spelling comes from the type's manifest
 #                      `model_arg=`. Refused for a type with no model_arg.
 #
+# Spawn options: extra CLI args to always pass a given type's launched
+# binary (e.g. a default permission mode or sandbox policy), configured
+# per-type in a YAML file rather than hardcoded — see
+# scripts/lib/spawn-options.sh. File: $AGMSG_SPAWN_OPTIONS_FILE, else
+# ~/.agmsg/config/spawn_options.yaml. Optional; a missing file/section is a
+# no-op.
+#
 # Readiness: by default spawn blocks until the new agent's watcher attaches and
 # is receiving (it prints `status=ready ...`), so a leader can safely send work
 # right after spawn returns without racing the agent's cold start. Codex has no
@@ -70,6 +77,8 @@ source "$SCRIPT_DIR/lib/actas-lock.sh"
 source "$SCRIPT_DIR/lib/type-registry.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/storage.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/spawn-options.sh"
 
 die() { echo "spawn: $*" >&2; exit 1; }
 
@@ -190,6 +199,15 @@ MODEL_ARG="$(agmsg_type_get "$AGENT_TYPE" model_arg)"
 if [ -n "$MODEL_ID" ] && [ -z "$MODEL_ARG" ]; then
   die "agent type '$AGENT_TYPE' does not support --model (no model_arg in its manifest)"
 fi
+
+# Extra CLI args for this type from the spawn options file (opt-in, see
+# scripts/lib/spawn-options.sh). Read line-by-line — never word-split — so a
+# value containing spaces stays a single token.
+SPAWN_OPT_TOKENS=()
+while IFS= read -r _spawn_opt_tok; do
+  SPAWN_OPT_TOKENS+=("$_spawn_opt_tok")
+done < <(agmsg_spawn_options_tokens "$AGENT_TYPE")
+
 # Resolve the node launcher path from the manifest (not hardcoded), if any.
 SPAWN_AGENT=""
 if [ -n "$SPAWN_LAUNCHER" ]; then
@@ -312,18 +330,26 @@ BOOT="$BOOT.command"
   if [ -n "$SPAWN_AGENT" ]; then
     # Node-launcher path: pass the universal agmsg context + the actas prompt.
     # Type-specific config is the launcher's own default/env, so core stays
-    # generic and names no add-on.
+    # generic and names no add-on. Spawn-options tokens (if any) land before
+    # --initial-input, same relative position as the direct-CLI path below.
     printf '%q %q \\\n' "$NODE_BIN" "$SPAWN_AGENT"
     printf '  --name %q \\\n' "$NAME"
     printf '  --team %q \\\n' "$TEAM"
     printf '  --project %q \\\n' "$PROJECT"
+    for _tok in ${SPAWN_OPT_TOKENS[@]+"${SPAWN_OPT_TOKENS[@]}"}; do
+      printf '  %q \\\n' "$_tok"
+    done
     printf '  --initial-input %q\n' "$ACTAS_PROMPT"
   else
-    # Direct-CLI launch: `<cli> [<model_arg> <model_id>] "/<cmd> actas <name>"`.
+    # Direct-CLI launch:
+    # `<cli> [<model_arg> <model_id>] [spawn-options...] "/<cmd> actas <name>"`.
     # model_arg is the manifest flag spelling (not %q-quoted — a bare flag like
-    # --model or -m); the model id is quoted.
+    # --model or -m); the model id and every spawn-options token are quoted.
     printf '%q' "$CLI_BIN"
     [ -n "$MODEL_ID" ] && printf ' %s %q' "$MODEL_ARG" "$MODEL_ID"
+    for _tok in ${SPAWN_OPT_TOKENS[@]+"${SPAWN_OPT_TOKENS[@]}"}; do
+      printf ' %q' "$_tok"
+    done
     printf ' %q\n' "$ACTAS_PROMPT"
   fi
   echo 'rm -f "$0" 2>/dev/null'   # self-clean once the agent exits

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -212,6 +212,95 @@ teardown() {
   [[ "$output" != *"--model"* ]]
 }
 
+# --- spawn options (#273): per-type extra CLI args from a YAML file ---
+
+@test "spawn: injects spawn-options flags from AGMSG_SPAWN_OPTIONS_FILE" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  local opts="$TEST_SKILL_DIR/spawn_options.yaml"
+  cat > "$opts" <<'YAML'
+claude-code:
+  --permission-mode: acceptEdits
+  --dangerously-skip-permissions: true
+YAML
+  run env AGMSG_SPAWN_OPTIONS_FILE="$opts" \
+    bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" == *"claude --permission-mode acceptEdits --dangerously-skip-permissions"* ]]
+  [[ "$output" == *"actas"* ]]
+}
+
+@test "spawn: spawn-options flags land after --model, before the actas prompt" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  local opts="$TEST_SKILL_DIR/spawn_options.yaml"
+  cat > "$opts" <<'YAML'
+claude-code:
+  --permission-mode: acceptEdits
+YAML
+  run env AGMSG_SPAWN_OPTIONS_FILE="$opts" \
+    bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --model claude-opus-4-8 --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" == *"claude --model claude-opus-4-8 --permission-mode acceptEdits"* ]]
+}
+
+@test "spawn: a false spawn-options value suppresses that flag" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  local opts="$TEST_SKILL_DIR/spawn_options.yaml"
+  cat > "$opts" <<'YAML'
+claude-code:
+  --dangerously-skip-permissions: false
+YAML
+  run env AGMSG_SPAWN_OPTIONS_FILE="$opts" \
+    bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" != *"--dangerously-skip-permissions"* ]]
+}
+
+@test "spawn: only the spawned type's section applies, not another type's" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  local opts="$TEST_SKILL_DIR/spawn_options.yaml"
+  cat > "$opts" <<'YAML'
+codex:
+  --sandbox: workspace-write
+YAML
+  run env AGMSG_SPAWN_OPTIONS_FILE="$opts" \
+    bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" != *"--sandbox"* ]]
+}
+
+@test "spawn: no spawn-options file leaves the launch unchanged" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run env AGMSG_SPAWN_OPTIONS_FILE="$TEST_SKILL_DIR/no-such-file.yaml" \
+    bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" == *"claude"*"actas"* ]]
+}
+
+@test "spawn: falls back to ~/.agmsg/config/spawn_options.yaml when the env var is unset" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  mkdir -p "$HOME/.agmsg/config"
+  cat > "$HOME/.agmsg/config/spawn_options.yaml" <<'YAML'
+claude-code:
+  --permission-mode: acceptEdits
+YAML
+  unset AGMSG_SPAWN_OPTIONS_FILE
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" == *"--permission-mode acceptEdits"* ]]
+}
+
 @test "spawn: actas prompt uses the install command name (not hardcoded agmsg)" {
   # Rename the skill dir to a custom command name and re-point SCRIPTS so the
   # script resolves SKILL_DIR basename = the custom name.

--- a/tests/test_spawn_options.bats
+++ b/tests/test_spawn_options.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/lib/spawn-options.sh (#273): per-agent-type extra CLI
+# args spawn.sh injects, configured via a YAML file (AGMSG_SPAWN_OPTIONS_FILE
+# or the default ~/.agmsg/config/spawn_options.yaml).
+
+load test_helper
+
+setup() {
+  setup_test_env
+  # shellcheck disable=SC1090
+  source "$TEST_SKILL_DIR/scripts/lib/spawn-options.sh"
+}
+
+teardown() { teardown_test_env; }
+
+# --- agmsg_spawn_options_file ---
+
+@test "spawn_options_file: defaults to ~/.agmsg/config/spawn_options.yaml under HOME" {
+  unset AGMSG_SPAWN_OPTIONS_FILE
+  [ "$(agmsg_spawn_options_file)" = "$HOME/.agmsg/config/spawn_options.yaml" ]
+}
+
+@test "spawn_options_file: AGMSG_SPAWN_OPTIONS_FILE overrides the default" {
+  export AGMSG_SPAWN_OPTIONS_FILE="/tmp/custom-spawn-options.yaml"
+  [ "$(agmsg_spawn_options_file)" = "/tmp/custom-spawn-options.yaml" ]
+}
+
+# --- agmsg_spawn_options_tokens ---
+
+@test "spawn_options_tokens: missing file yields no tokens" {
+  export AGMSG_SPAWN_OPTIONS_FILE="$TEST_SKILL_DIR/does-not-exist.yaml"
+  run agmsg_spawn_options_tokens claude-code
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "spawn_options_tokens: missing type section yields no tokens" {
+  local file="$TEST_SKILL_DIR/spawn_options.yaml"
+  cat > "$file" <<'YAML'
+codex:
+  --sandbox: workspace-write
+YAML
+  export AGMSG_SPAWN_OPTIONS_FILE="$file"
+  run agmsg_spawn_options_tokens claude-code
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "spawn_options_tokens: a string value expands to a two-token flag+value" {
+  local file="$TEST_SKILL_DIR/spawn_options.yaml"
+  cat > "$file" <<'YAML'
+claude-code:
+  --permission-mode: acceptEdits
+YAML
+  export AGMSG_SPAWN_OPTIONS_FILE="$file"
+  run agmsg_spawn_options_tokens claude-code
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "--permission-mode" ]
+  [ "${lines[1]}" = "acceptEdits" ]
+  [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "spawn_options_tokens: a true value expands to a single flag-only token" {
+  local file="$TEST_SKILL_DIR/spawn_options.yaml"
+  cat > "$file" <<'YAML'
+claude-code:
+  --dangerously-skip-permissions: true
+YAML
+  export AGMSG_SPAWN_OPTIONS_FILE="$file"
+  run agmsg_spawn_options_tokens claude-code
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "--dangerously-skip-permissions" ]
+  [ "${#lines[@]}" -eq 1 ]
+}
+
+@test "spawn_options_tokens: a false value is suppressed entirely" {
+  local file="$TEST_SKILL_DIR/spawn_options.yaml"
+  cat > "$file" <<'YAML'
+claude-code:
+  --dangerously-skip-permissions: false
+  --permission-mode: acceptEdits
+YAML
+  export AGMSG_SPAWN_OPTIONS_FILE="$file"
+  run agmsg_spawn_options_tokens claude-code
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"--dangerously-skip-permissions"* ]]
+  [[ "$output" == *"--permission-mode"* ]]
+}
+
+@test "spawn_options_tokens: multiple keys under a section all emit, in order" {
+  local file="$TEST_SKILL_DIR/spawn_options.yaml"
+  cat > "$file" <<'YAML'
+codex:
+  --sandbox: workspace-write
+  --ask-for-approval: never
+YAML
+  export AGMSG_SPAWN_OPTIONS_FILE="$file"
+  run agmsg_spawn_options_tokens codex
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "--sandbox" ]
+  [ "${lines[1]}" = "workspace-write" ]
+  [ "${lines[2]}" = "--ask-for-approval" ]
+  [ "${lines[3]}" = "never" ]
+}
+
+@test "spawn_options_tokens: only the requested type's section is read" {
+  local file="$TEST_SKILL_DIR/spawn_options.yaml"
+  cat > "$file" <<'YAML'
+claude-code:
+  --permission-mode: acceptEdits
+codex:
+  --sandbox: workspace-write
+YAML
+  export AGMSG_SPAWN_OPTIONS_FILE="$file"
+  run agmsg_spawn_options_tokens codex
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"permission-mode"* ]]
+  [[ "$output" == *"--sandbox"* ]]
+  [[ "$output" == *"workspace-write"* ]]
+}
+
+@test "spawn_options_tokens: a value containing spaces stays a single token" {
+  local file="$TEST_SKILL_DIR/spawn_options.yaml"
+  cat > "$file" <<'YAML'
+claude-code:
+  --append-system-prompt: be extra careful with destructive commands
+YAML
+  export AGMSG_SPAWN_OPTIONS_FILE="$file"
+  run agmsg_spawn_options_tokens claude-code
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "--append-system-prompt" ]
+  [ "${lines[1]}" = "be extra careful with destructive commands" ]
+  [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "spawn_options_tokens: empty file yields no tokens" {
+  local file="$TEST_SKILL_DIR/spawn_options.yaml"
+  : > "$file"
+  export AGMSG_SPAWN_OPTIONS_FILE="$file"
+  run agmsg_spawn_options_tokens claude-code
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -206,3 +206,42 @@ write_node_launcher_fixtures() {
   ! echo "$output" | grep -q "is not supported by spawn yet"
   ! echo "$output" | grep -q "unknown agent type"
 }
+
+@test "spawn: the node-launcher path also splices spawn-options tokens (before --initial-input) (#273)" {
+  write_node_launcher_fixtures
+  local proj="$BATS_TEST_TMPDIR/nodeproj"
+  mkdir -p "$proj"
+  bash "$SCRIPTS/join.sh" nodeteam existing claude-code "$proj"
+
+  local stub_bin="$BATS_TEST_TMPDIR/stub-bin"
+  mkdir -p "$stub_bin"
+  local capture="$BATS_TEST_TMPDIR/launch-capture.txt"
+  cat > "$stub_bin/record.sh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$capture"
+EOF
+  chmod +x "$stub_bin/record.sh"
+
+  local opts="$BATS_TEST_TMPDIR/spawn_options.yaml"
+  cat > "$opts" <<'YAML'
+nodetype:
+  --extra-flag: extra-value
+YAML
+
+  run env -u TMUX AGMSG_TERMINAL="$stub_bin/record.sh {cmd}" \
+    AGMSG_SPAWN_OPTIONS_FILE="$opts" \
+    bash "$SCRIPTS/spawn.sh" nodetype nodeagent --project "$proj" --no-wait
+  [ "$status" -eq 0 ]
+  local boot; boot="$(cat "$capture")"
+  [ -f "$boot" ]
+  run cat "$boot"
+  [[ "$output" == *"nodetype-launcher.mjs"* ]]
+  [[ "$output" == *"--extra-flag"* ]]
+  [[ "$output" == *"extra-value"* ]]
+  # spawn-options tokens land before --initial-input, matching the direct-CLI
+  # path's "before the actas prompt" placement.
+  local before_flag after_flag before_input
+  before_flag=$(grep -n -- "--extra-flag" "$boot" | head -1 | cut -d: -f1)
+  before_input=$(grep -n -- "--initial-input" "$boot" | head -1 | cut -d: -f1)
+  [ "$before_flag" -lt "$before_input" ]
+}


### PR DESCRIPTION
Closes #273.

## Summary

`spawn.sh` only knew about `--model` and the actas boot prompt as per-invocation extras. This adds a **spawn options** file: a small YAML config, one section per agent type, letting every spawn of that type consistently pass extra CLI flags to the underlying binary (e.g. a default permission mode or sandbox policy) without hardcoding them into `spawn.sh`.

## Design

- Path: `$AGMSG_SPAWN_OPTIONS_FILE` if set, else `~/.agmsg/config/spawn_options.yaml` (agmsg's planned install-path-independent config home, #201).
- File is optional; a missing file or missing type section is a no-op.
- Format matches the simple YAML dialect `db/config.yaml`/`config.sh` already use (flat `section:` + 2-space-indented `key: value`, no nesting, no quoting).

```yaml
claude-code:
  --permission-mode: acceptEdits
  --dangerously-skip-permissions: true

codex:
  --sandbox: workspace-write
  --ask-for-approval: never
```

Value semantics:
| value | expands to |
|---|---|
| string/number | `<key> <value>` (two tokens) |
| `true` | `<key>` alone (boolean flag on) |
| `false` | nothing (flag suppressed) |

v1 is a flat map only — a flag cannot be repeated with multiple values (e.g. codex's `-c foo=1 -c bar=2`). Out of scope until a real need shows up.

## Changes

- `scripts/lib/spawn-options.sh`: resolves the file path and emits one type's section as shell-safe tokens (one per line — never word-split by the caller, so a value containing spaces stays intact).
- `spawn.sh` sources it and splices the tokens into the boot script for both the direct-CLI path (after `--model`, before the actas prompt) and the node-launcher path (before `--initial-input`).
- README documents the new option.

## Validation

- `bash -n` on both changed scripts
- `bats tests/test_spawn_options.bats` (11/11, new unit tests for token-emission semantics)
- `bats tests/test_spawn.bats` (38/38, including 6 new end-to-end tests: flag injection, ordering vs `--model`, `false` suppression, type-section isolation, missing-file no-op, and the default-path fallback)
- `bats tests/test_despawn.bats tests/test_team.bats` (no regressions)