### PR TITLE
fix(codex-bridge): normalize Windows drive-letter project path to POSIX before identity resolution

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -58,6 +58,14 @@ function die(message) {
   process.exit(1);
 }
 
+function toPosixPath(p) {
+  if (typeof p !== "string" || p.length === 0) return p;
+  const normalized = p.replace(/\\/g, "/");
+  const match = /^([A-Za-z]):\//.exec(normalized);
+  if (!match) return normalized;
+  return `/${match[1].toLowerCase()}${normalized.slice(2)}`;
+}
+
 function parseArgs(argv) {
   const opts = {
     type: "codex",
@@ -156,7 +164,7 @@ function runScript(script, args) {
 }
 
 function resolveIdentity(opts) {
-  const result = runScript("identities.sh", [opts.project, opts.type]);
+  const result = runScript("identities.sh", [toPosixPath(opts.project), opts.type]);
   if (result.status !== 0) {
     die(`identity resolution failed: ${(result.stderr || result.stdout).trim()}`);
   }
@@ -1209,4 +1217,8 @@ async function main() {
   await bridge.run();
 }
 
-main().catch((error) => die(error.message));
+if (require.main === module) {
+  main().catch((error) => die(error.message));
+}
+
+module.exports = { toPosixPath };

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -58,12 +58,20 @@ function die(message) {
   process.exit(1);
 }
 
+// Convert a native Windows path into the MSYS/Git-Bash POSIX form that agmsg
+// registration data is keyed by (Git Bash stores e.g. `/c/Users/me/proj`).
+// A drive-letter path `C:\...`/`C:/...` becomes `/c/...` and its backslashes
+// become forward slashes; a UNC path `\\host\share` becomes `//host/share`.
+// Only inputs carrying a Windows drive-letter or UNC prefix are rewritten, so
+// an already-POSIX path is returned byte-for-byte unchanged - including a POSIX
+// path that legitimately contains a backslash in a filename, which must not be
+// mangled on macOS/Linux.
 function toPosixPath(p) {
   if (typeof p !== "string" || p.length === 0) return p;
-  const normalized = p.replace(/\\/g, "/");
-  const match = /^([A-Za-z]):\//.exec(normalized);
-  if (!match) return normalized;
-  return `/${match[1].toLowerCase()}${normalized.slice(2)}`;
+  if (/^\\\\/.test(p)) return p.replace(/\\/g, "/"); // UNC: \\host\share -> //host/share
+  const match = /^([A-Za-z]):[\\/]/.exec(p);
+  if (!match) return p; // already POSIX (no drive letter): leave exactly as-is
+  return `/${match[1].toLowerCase()}${p.slice(2).replace(/\\/g, "/")}`;
 }
 
 function parseArgs(argv) {
@@ -813,7 +821,10 @@ class CodexBridge {
     const command = [
       BASH_BIN,
       path.join(SCRIPT_DIR, "watch-once.sh"),
-      this.opts.project,
+      // watch-once.sh resolves the subscription set through the same exact
+      // project-key lookup as identities.sh, so it needs the POSIX form of the
+      // project path. The spawn cwd below stays native for the app-server.
+      toPosixPath(this.opts.project),
       this.opts.type,
       "--team",
       this.identity.team,

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -71,8 +71,15 @@ EOF
   [ "$status" -eq 0 ]
 }
 
-@test "codex-bridge: toPosixPath normalizes backslashes without a drive letter" {
-  run node -e 'const { toPosixPath } = require(process.argv[1]); if (toPosixPath(String.raw`relative\path\without\drive`) !== "relative/path/without/drive") process.exit(1);' "$TYPES/codex/codex-bridge.js"
+@test "codex-bridge: toPosixPath maps UNC paths to POSIX paths" {
+  run node -e 'const { toPosixPath } = require(process.argv[1]); if (toPosixPath(String.raw`\\host\share\proj`) !== "//host/share/proj") process.exit(1);' "$TYPES/codex/codex-bridge.js"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-bridge: toPosixPath preserves a literal backslash in a POSIX path" {
+  # On POSIX hosts a backslash is a valid filename character; a driveless path
+  # must be returned byte-for-byte so a genuine registration is not mangled.
+  run node -e 'const { toPosixPath } = require(process.argv[1]); const p = String.raw`/tmp/proj\withslash`; if (toPosixPath(p) !== p) process.exit(1);' "$TYPES/codex/codex-bridge.js"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -61,6 +61,21 @@ EOF
   [[ "$output" =~ "Beta Codex app-server bridge" ]]
 }
 
+@test "codex-bridge: toPosixPath maps Windows drive paths to POSIX paths" {
+  run node -e 'const { toPosixPath } = require(process.argv[1]); const expected = "/c/Users/me/OneDrive/codex-work"; if (toPosixPath(String.raw`C:\Users\me\OneDrive\codex-work`) !== expected) process.exit(1); if (toPosixPath("C:/Users/me/OneDrive/codex-work") !== expected) process.exit(1);' "$TYPES/codex/codex-bridge.js"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-bridge: toPosixPath leaves POSIX paths unchanged" {
+  run node -e 'const { toPosixPath } = require(process.argv[1]); if (toPosixPath("/c/Users/me/OneDrive/codex-work") !== "/c/Users/me/OneDrive/codex-work") process.exit(1); if (toPosixPath("/home/me/x") !== "/home/me/x") process.exit(1);' "$TYPES/codex/codex-bridge.js"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-bridge: toPosixPath normalizes backslashes without a drive letter" {
+  run node -e 'const { toPosixPath } = require(process.argv[1]); if (toPosixPath(String.raw`relative\path\without\drive`) !== "relative/path/without/drive") process.exit(1);' "$TYPES/codex/codex-bridge.js"
+  [ "$status" -eq 0 ]
+}
+
 @test "codex-bridge: resolve-only prints the selected identity" {
   skip_on_windows "codex bridge identity resolution on Windows (#182)"
   run node "$TYPES/codex/codex-bridge.js" --project "$PROJ" --team team --name alice --resolve-only


### PR DESCRIPTION
## Summary

On Windows the Codex monitor-mode bridge fails to start with `no matching codex identity; run actas or pass --team/--name` even when the identity is correctly registered.

## Background

`resolveIdentity()` forwards `opts.project` to `identities.sh`, but `parseArgs` sets `opts.project = path.resolve(opts.project)`, which on Windows yields a native drive-letter path (`C:\Users\me\OneDrive\codex-work`). `identities.sh` matches the registered project with plain SQL string equality against the POSIX/MSYS form stored at registration time (`/c/Users/me/OneDrive/codex-work`, produced by Git Bash), so a native Windows path never matches. This is distinct from the backslash-escaping issue: even the forward-slash drive-letter form (`C:/Users/...`) fails, because it is a path-format mismatch, not an escaping one.

## Change

- Add a `toPosixPath()` helper that converts a Windows drive-letter path (`C:\...` / `C:/...` -> `/c/...`, lowercased drive, backslashes to forward slashes) or a UNC path (`\\host\share` -> `//host/share`) to the MSYS/Git-Bash POSIX form. It only rewrites inputs carrying a drive-letter or UNC prefix, so an already-POSIX path - including one that legitimately contains a backslash in a filename on macOS/Linux - is returned byte-for-byte unchanged.
- Apply the conversion only where the path is compared against registration data: the `identities.sh` call in `resolveIdentity()` and the `watch-once.sh` invocation in `armWatch()`. `watch-once.sh` resolves the subscription set through the same exact project-key lookup, so without this the identity would resolve but message delivery would still fail on Windows.
- `opts.project` itself is left as the native `path.resolve()` result, since it is also used as the app-server spawn `cwd` where a POSIX path would break process spawning. Only the strings forwarded to the shell lookups are normalized.

POSIX/macOS/Linux behavior is unchanged, since those paths have no drive-letter prefix.

## Testing

- `bats tests/test_codex_bridge.bats` (adds coverage for `toPosixPath`: drive-letter and UNC mapping, no-op on already-POSIX paths, and literal-backslash preservation on POSIX paths).

Fixes #268
