### PR TITLE
fix(codex): grace fallback for thread/resume failure on Codex 0.142+

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -772,19 +772,28 @@ class CodexBridge {
       console.error(`codex-bridge: discovered loaded thread ${this.threadId}`);
     }
     if (this.threadId) {
-      const response = await this.client.request("thread/resume", {
-        threadId: this.threadId,
-        cwd: this.opts.project,
-        runtimeWorkspaceRoots: [this.opts.project],
-        excludeTurns: true,
-      });
-      if (!response.thread || response.thread.id !== this.threadId) {
-        die("thread/resume did not return the requested thread id");
+      try {
+        const response = await this.client.request("thread/resume", {
+          threadId: this.threadId,
+          cwd: this.opts.project,
+          runtimeWorkspaceRoots: [this.opts.project],
+          excludeTurns: true,
+        });
+        if (!response.thread || response.thread.id !== this.threadId) {
+          die("thread/resume did not return the requested thread id");
+        }
+        const type = response.thread.status && response.thread.status.type;
+        this.threadIdle = type !== "active";
+        this.turnActive = type === "active";
+        console.error(`codex-bridge: resumed thread ${this.threadId}`);
+      } catch (err) {
+        // Codex 0.142+ の --remote セッションでは rollout が作成されないため
+        // thread/resume が失敗する。turn/start は threadId だけで動作するので
+        // デフォルト状態 (idle) で続行する。
+        console.error(`codex-bridge: thread/resume failed (${err.message}); proceeding without resume`);
+        this.threadIdle = true;
+        this.turnActive = false;
       }
-      const type = response.thread.status && response.thread.status.type;
-      this.threadIdle = type !== "active";
-      this.turnActive = type === "active";
-      console.error(`codex-bridge: resumed thread ${this.threadId}`);
       return;
     }
     const response = await this.client.request("thread/start", {


### PR DESCRIPTION
## Summary

Codex CLI 0.142+ introduced `--remote` sessions where the rollout is not created,
causing `thread/resume` requests to fail. Without this fix, `codex-bridge.js`
calls `die()` on such failure and exits.

This PR wraps the `thread/resume` call in a try/catch and falls back to
`threadIdle=true, turnActive=false` when the resume fails, allowing `turn/start`
which only needs `threadId` to proceed. The bridge continues to operate in idle
state instead of exiting.

## Related

Follow-up to #237 (`fix(codex): keep Codex working across 0.142 upgrades`).

## Test plan

- [x] `node --check scripts/drivers/types/codex/codex-bridge.js`
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
