### PR TITLE
feat(spawn): enable spawn for antigravity, copilot, cursor, gemini, opencode

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ codex:
   --dangerously-skip-permissions: false  # a `false` value suppresses the flag entirely
 ```
 
-All nine agent types (`claude-code`, `codex`, `grok-build`, `hermes`, `cursor`, `gemini`, `antigravity`, `copilot`, `opencode`) are spawnable. macOS is the primary target; Linux and Windows are best-effort (please open an issue/PR if your terminal isn't handled). Headless environments — no tmux **and** no usable terminal — error out, since the agent CLIs need an interactive terminal.
+Eight of the nine agent types are spawnable — `claude-code`, `codex`, `grok-build`, `cursor`, `gemini`, `antigravity`, `copilot`, `opencode`. `hermes` is not: its CLI has no mode that starts an interactive session pre-seeded with an initial prompt (#279). macOS is the primary target; Linux and Windows are best-effort (please open an issue/PR if your terminal isn't handled). Headless environments — no tmux **and** no usable terminal — error out, since the agent CLIs need an interactive terminal.
 
 ### Tear down a spawned agent (`despawn`)
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ codex:
   --dangerously-skip-permissions: false  # a `false` value suppresses the flag entirely
 ```
 
-Only `claude-code` and `codex` are supported today. macOS is the primary target; Linux and Windows are best-effort (please open an issue/PR if your terminal isn't handled). Headless environments — no tmux **and** no usable terminal — error out, since the agent CLIs need an interactive terminal.
+All nine agent types (`claude-code`, `codex`, `grok-build`, `hermes`, `cursor`, `gemini`, `antigravity`, `copilot`, `opencode`) are spawnable. macOS is the primary target; Linux and Windows are best-effort (please open an issue/PR if your terminal isn't handled). Headless environments — no tmux **and** no usable terminal — error out, since the agent CLIs need an interactive terminal.
 
 ### Tear down a spawned agent (`despawn`)
 

--- a/docs/agent-types.md
+++ b/docs/agent-types.md
@@ -21,9 +21,11 @@ a manifest cannot execute code. Multi-value keys are whitespace-separated.
 | `template` | yes | the `/agmsg` command template filename, relative to the type dir (e.g. `template.md`); becomes `SKILL.md` |
 | `detect` | — | env-var names whose presence selects this type. `explicit` = never auto-detected from the environment |
 | `detect_proc` | — | parent-process-name glob patterns that select this type (e.g. `codex codex-*`) |
-| `cli` | spawnable types | the launch binary |
+| `cli` | spawnable types | the launch command. Usually a single binary name, but may be a fixed multi-word prefix (subcommand and/or flags a CLI needs ahead of its own options, e.g. `opencode run --interactive`) — only the first word is resolved/checked as the executable; the rest are passed through as-is. Safe because this is manifest data agmsg ships, not runtime user input |
 | `spawnable` | — | `yes` if `spawn.sh` can launch this type |
 | `spawn` | — | a `.mjs` node-launcher (beside the manifest) `spawn.sh` runs via Node; also marks the type spawnable |
+| `model_arg` | — | the `--model`/`-m`-style flag `spawn --model <id>` passes through to the CLI; a type with no `model_arg` refuses `--model` |
+| `prompt_arg` | — | for a CLI that does not accept the actas prompt as a bare positional argument, the named flag whose value IS the prompt (e.g. antigravity's `--prompt-interactive`, copilot's `--interactive`) — `spawn.sh` inserts it immediately before the (already-quoted) prompt. Unset = bare positional, the default |
 | `hooks_file` | yes | project-relative delivery hooks file (e.g. `.codex/hooks.json`) |
 | `monitor` | — | `yes` if the type exposes a native Monitor tool; `spawn` skips the readiness wait when `no` |
 | `delivery_modes` | — | space-separated delivery modes the type's CLI accepts (e.g. `monitor turn off`); `delivery.sh`'s gate rejects anything else. Defaults to `monitor turn both off` when omitted |

--- a/scripts/drivers/types/antigravity/type.conf
+++ b/scripts/drivers/types/antigravity/type.conf
@@ -1,6 +1,10 @@
 # agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
 name=antigravity
 template=template.md
+cli=agy
+spawnable=yes
+model_arg=--model
+prompt_arg=--prompt-interactive
 detect=explicit
 hooks_file=.agent/rules/agmsg.md
 monitor=no

--- a/scripts/drivers/types/copilot/type.conf
+++ b/scripts/drivers/types/copilot/type.conf
@@ -1,6 +1,10 @@
 # agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
 name=copilot
 template=template.md
+cli=copilot
+spawnable=yes
+model_arg=--model
+prompt_arg=--interactive
 detect=explicit
 hooks_file=.github/hooks/agmsg.json
 monitor=no

--- a/scripts/drivers/types/cursor/type.conf
+++ b/scripts/drivers/types/cursor/type.conf
@@ -2,6 +2,8 @@
 name=cursor
 template=template.md
 cli=cursor-agent
+spawnable=yes
+model_arg=--model
 detect_proc=cursor-agent cursor-agent-*
 hooks_file=.cursor/rules/agmsg.mdc
 monitor=no

--- a/scripts/drivers/types/gemini/type.conf
+++ b/scripts/drivers/types/gemini/type.conf
@@ -1,6 +1,9 @@
 # agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
 name=gemini
 template=template.md
+cli=gemini
+spawnable=yes
+model_arg=--model
 detect=GEMINI_API_KEY GOOGLE_GEMINI_CLI
 detect_proc=gemini gemini-*
 hooks_file=.agent/rules/agmsg.md

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -98,10 +98,10 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
-If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex reviewer --window", "spawn hermes reviewer"):
-1. Parse `<type>` (must be `claude-code`, `codex`, or `hermes`), `<name>`, and any options (`--project`, `--team`, `--window`, `--split h|v`, `--terminal`, `--no-wait`, `--ready-timeout <secs>`).
+If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex reviewer --window"):
+1. Parse `<type>` (must be `claude-code` or `codex` — `hermes` itself is not spawnable via this command; its CLI has no mode that starts an interactive session pre-seeded with an initial prompt, #279), `<name>`, and any options (`--project`, `--team`, `--window`, `--split h|v`, `--terminal`, `--no-wait`, `--ready-timeout <secs>`).
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
-3. Show the script's output. A spawned hermes session takes the actas role `<name>` via the boot prompt and uses Hermes's own default profile.
+3. Show the script's output.
 
 If argument is "mode" (no further args):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status hermes "$(pwd)"`

--- a/scripts/drivers/types/hermes/type.conf
+++ b/scripts/drivers/types/hermes/type.conf
@@ -2,7 +2,13 @@
 name=hermes
 template=template.md
 cli=hermes
-spawnable=yes
+# spawnable=yes deliberately omitted (#279): the hermes CLI has no known mode
+# that starts an interactive session pre-seeded with an initial prompt — its
+# only prompt-taking flags (-z/--oneshot, chat -q/--query) are non-interactive
+# and exit after one turn, and `chat` takes no positional message. Until a
+# real invocation is found (a two-step `-q` then `--continue` boot is an
+# unverified idea, not confirmed to work), spawn.sh should refuse this type
+# with a clear message rather than fail deep inside with an argparse error.
 detect=explicit
 monitor=no
 delivery_modes=off

--- a/scripts/drivers/types/opencode/type.conf
+++ b/scripts/drivers/types/opencode/type.conf
@@ -1,6 +1,9 @@
 # agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
 name=opencode
 template=template.md
+cli=opencode run --interactive
+spawnable=yes
+model_arg=--model
 detect_proc=opencode opencode-*
 hooks_file=.opencode/rules/agmsg.md
 monitor=no

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -179,13 +179,21 @@ PROJECT="$(cd "$PROJECT" && pwd)"
 # external add-on); otherwise it is a direct-CLI launch. The `cli=` binary is
 # REQUIRED for direct-CLI types and OPTIONAL for node launchers (which resolve
 # their own runtime). No per-type case — all data-driven from the manifest.
+#
+# `cli=` is trusted manifest data (agmsg ships it, not runtime user input), so
+# it may be a single binary name OR a fixed command-line prefix of several
+# space-separated tokens — a subcommand and/or fixed flags a CLI needs before
+# its own options (e.g. `opencode run --interactive`, whose message is not a
+# top-level argument). Only the first word names the actual executable to
+# resolve/check; the rest are passed through as-is in the boot script below.
 SPAWN_LAUNCHER="$(agmsg_type_get "$AGENT_TYPE" spawn)"
 CLI_BIN="$(agmsg_type_get "$AGENT_TYPE" cli)"
+CLI_BIN_EXE="${CLI_BIN%% *}"
 CLI_PATH=""
 if [ -n "$CLI_BIN" ]; then
-  command -v "$CLI_BIN" >/dev/null 2>&1 \
-    || die "'$CLI_BIN' not found on PATH — install the ${AGENT_TYPE} CLI first"
-  CLI_PATH="$(command -v "$CLI_BIN")"
+  command -v "$CLI_BIN_EXE" >/dev/null 2>&1 \
+    || die "'$CLI_BIN_EXE' not found on PATH — install the ${AGENT_TYPE} CLI first"
+  CLI_PATH="$(command -v "$CLI_BIN_EXE")"
 elif [ -z "$SPAWN_LAUNCHER" ]; then
   die "agent type '$AGENT_TYPE' manifest declares neither a 'cli' binary nor a 'spawn' launcher"
 fi
@@ -199,6 +207,14 @@ MODEL_ARG="$(agmsg_type_get "$AGENT_TYPE" model_arg)"
 if [ -n "$MODEL_ID" ] && [ -z "$MODEL_ARG" ]; then
   die "agent type '$AGENT_TYPE' does not support --model (no model_arg in its manifest)"
 fi
+
+# Some CLIs don't accept the actas prompt as a bare positional argument — they
+# require it as the value of a named flag instead (e.g. antigravity's
+# `--prompt-interactive <text>`, copilot's `-i/--interactive <text>`; their
+# `-p/--prompt` equivalents are a DIFFERENT one-shot, non-interactive mode and
+# would not work here). `prompt_arg=` in the manifest names that flag; unset
+# (the default) keeps today's bare-positional behavior.
+PROMPT_ARG="$(agmsg_type_get "$AGENT_TYPE" prompt_arg)"
 
 # Extra CLI args for this type from the spawn options file (opt-in, see
 # scripts/lib/spawn-options.sh). Read line-by-line — never word-split — so a
@@ -342,14 +358,19 @@ BOOT="$BOOT.command"
     printf '  --initial-input %q\n' "$ACTAS_PROMPT"
   else
     # Direct-CLI launch:
-    # `<cli> [<model_arg> <model_id>] [spawn-options...] "/<cmd> actas <name>"`.
-    # model_arg is the manifest flag spelling (not %q-quoted — a bare flag like
-    # --model or -m); the model id and every spawn-options token are quoted.
-    printf '%q' "$CLI_BIN"
+    # `<cli> [<model_arg> <model_id>] [spawn-options...] [<prompt_arg>] "/<cmd> actas <name>"`.
+    # cli is emitted unquoted — it is trusted fixed-prefix manifest data (see
+    # above) that may itself be several tokens (e.g. `opencode run --interactive`).
+    # model_arg/prompt_arg are the manifest flag spellings (not %q-quoted — bare
+    # flags like --model or -i); the model id, every spawn-options token, and the
+    # actas prompt are quoted. prompt_arg (when set) lands immediately before the
+    # prompt so there is no ambiguity about which token is its value.
+    printf '%s' "$CLI_BIN"
     [ -n "$MODEL_ID" ] && printf ' %s %q' "$MODEL_ARG" "$MODEL_ID"
     for _tok in ${SPAWN_OPT_TOKENS[@]+"${SPAWN_OPT_TOKENS[@]}"}; do
       printf ' %q' "$_tok"
     done
+    [ -n "$PROMPT_ARG" ] && printf ' %s' "$PROMPT_ARG"
     printf ' %q\n' "$ACTAS_PROMPT"
   fi
   echo 'rm -f "$0" 2>/dev/null'   # self-clean once the agent exits

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -481,6 +481,16 @@ PY
   grep -q "~/.agents/skills/agmsg/scripts" "$hermes_skill"
 }
 
+@test "install: Hermes skill no longer advertises 'spawn hermes' as a valid example (#279)" {
+  mkdir -p "$FAKE_HOME/.hermes"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  local hermes_skill="$FAKE_HOME/.hermes/skills/agmsg/SKILL.md"
+  [ -f "$hermes_skill" ]
+  ! grep -q "spawn hermes reviewer" "$hermes_skill"
+  ! grep -q 'must be `claude-code`, `codex`, or `hermes`' "$hermes_skill"
+  grep -q "hermes.*is not spawnable\|hermes.*not spawnable" "$hermes_skill"
+}
+
 @test "install: custom command name is substituted in Hermes skill" {
   mkdir -p "$FAKE_HOME/.hermes"
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd msg

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -208,7 +208,13 @@ teardown() {
 }
 
 @test "spawn --model: refused for a type with no model_arg in its manifest" {
-  run bash "$SCRIPTS/spawn.sh" hermes foo --project "$PROJ" --model whatever --no-wait
+  # No real built-in is spawnable without a model_arg (#279 dropped hermes'
+  # spawnable=yes, its only remaining example) — fixture a minimal one,
+  # reusing the already-stubbed `claude` binary as its cli=.
+  local nd="$TEST_SKILL_DIR/scripts/drivers/types/nomodeltype"
+  mkdir -p "$nd"
+  printf 'name=nomodeltype\ntemplate=template.md\ncli=claude\nspawnable=yes\n' > "$nd/type.conf"
+  run bash "$SCRIPTS/spawn.sh" nomodeltype foo --project "$PROJ" --model whatever --no-wait
   [ "$status" -ne 0 ]
   [[ "$output" =~ "does not support --model" ]]
 }

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -10,7 +10,7 @@ setup() {
   # a terminal. PATH is prepended so the stubs win.
   export STUB_BIN="$TEST_SKILL_DIR/stub-bin"
   mkdir -p "$STUB_BIN"
-  for bin in claude codex grok hermes; do
+  for bin in claude codex grok hermes cursor-agent gemini agy copilot opencode; do
     printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB_BIN/$bin"
     chmod +x "$STUB_BIN/$bin"
   done
@@ -37,14 +37,14 @@ teardown() {
 
 # --- argument validation ---
 
-@test "spawn: rejects unsupported agent type (gemini)" {
-  run bash "$SCRIPTS/spawn.sh" gemini foo --project "$PROJ"
-  [ "$status" -ne 0 ]
-  [[ "$output" =~ "not supported by spawn yet" ]]
-}
-
-@test "spawn: rejects unsupported agent type (opencode)" {
-  run bash "$SCRIPTS/spawn.sh" opencode foo --project "$PROJ"
+@test "spawn: rejects a known type with neither cli= nor spawn= (#277)" {
+  # All nine built-ins are spawnable now, so the 'not supported by spawn yet'
+  # gate (a known type missing both cli= and spawn=) needs a fixture — no
+  # real built-in demonstrates it any more.
+  local nd="$TEST_SKILL_DIR/scripts/drivers/types/noclitype"
+  mkdir -p "$nd"
+  printf 'name=noclitype\ntemplate=template.md\n' > "$nd/type.conf"
+  run bash "$SCRIPTS/spawn.sh" noclitype foo --project "$PROJ"
   [ "$status" -ne 0 ]
   [[ "$output" =~ "not supported by spawn yet" ]]
 }
@@ -81,6 +81,16 @@ teardown() {
   run env PATH="$STUB_BIN:/usr/bin:/bin" bash "$SCRIPTS/spawn.sh" codex foo --project "$PROJ"
   [ "$status" -ne 0 ]
   [[ "$output" =~ "not found on PATH" ]]
+}
+
+@test "spawn: a multi-word cli= (opencode) checks only its first word's existence (#277)" {
+  rm -f "$STUB_BIN/opencode"
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run env PATH="$STUB_BIN:/usr/bin:/bin" bash "$SCRIPTS/spawn.sh" opencode foo --project "$PROJ"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "'opencode' not found on PATH" ]]
+  # never searches for the literal multi-word string as one executable name
+  [[ "$output" != *"'opencode run --interactive' not found"* ]]
 }
 
 # --- team resolution ---
@@ -210,6 +220,75 @@ teardown() {
   boot="$(cat "$CAPTURE")"
   run cat "$boot"
   [[ "$output" != *"--model"* ]]
+}
+
+# --- newly spawnable types (#277): cursor, gemini, antigravity, copilot, opencode ---
+
+@test "spawn: cursor launches cursor-agent with a bare positional prompt" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" cursor alice --project "$PROJ" --model sonnet-4-thinking --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" == *"cursor-agent --model sonnet-4-thinking"* ]]
+  [[ "$output" == *"actas"* ]]
+}
+
+@test "spawn: gemini launches gemini with a bare positional prompt" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" gemini alice --project "$PROJ" --model gemini-3-pro --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" == *"gemini --model gemini-3-pro"* ]]
+  [[ "$output" == *"actas"* ]]
+}
+
+@test "spawn: antigravity launches agy with --prompt-interactive (not a bare positional)" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" antigravity alice --project "$PROJ" --model gemini-3-pro --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" == *"agy --model gemini-3-pro --prompt-interactive"* ]]
+  [[ "$output" == *"actas"* ]]
+}
+
+@test "spawn: copilot launches copilot with --interactive (not a bare positional)" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" copilot alice --project "$PROJ" --model gpt-5.4 --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" == *"copilot --model gpt-5.4 --interactive"* ]]
+  [[ "$output" == *"actas"* ]]
+}
+
+@test "spawn: opencode launches its 'run --interactive' fixed subcommand prefix" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" opencode alice --project "$PROJ" --model anthropic/claude-opus-4-8 --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" == *"opencode run --interactive --model anthropic/claude-opus-4-8"* ]]
+  [[ "$output" == *"actas"* ]]
+  # no bare 'opencode' invocation without the fixed prefix
+  [[ "$output" != *$'\n''opencode --model'* ]]
+}
+
+@test "spawn: prompt_arg lands after spawn-options, immediately before the prompt" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  local opts="$TEST_SKILL_DIR/spawn_options.yaml"
+  cat > "$opts" <<'YAML'
+antigravity:
+  --sandbox: true
+YAML
+  run env AGMSG_SPAWN_OPTIONS_FILE="$opts" \
+    bash "$SCRIPTS/spawn.sh" antigravity alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" == *"agy --sandbox --prompt-interactive"* ]]
 }
 
 # --- spawn options (#273): per-type extra CLI args from a YAML file ---

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -64,7 +64,9 @@ write_node_launcher_fixtures() {
   [ "$status" -ne 0 ]
 }
 
-@test "type-registry: spawnable set is exactly all nine built-ins (#277)" {
+@test "type-registry: spawnable set is exactly eight of the nine built-ins (#277, #279)" {
+  # hermes deliberately stays out (#279): no known CLI mode starts it
+  # interactive with a seeded initial prompt.
   run env -i PATH="$PATH" bash -c \
     "source '$SCRIPTS/lib/type-registry.sh'
      while IFS= read -r t; do
@@ -72,7 +74,7 @@ write_node_launcher_fixtures() {
        [ \"\$(agmsg_type_get \"\$t\" spawnable)\" = yes ] && echo \"\$t\"
      done <<< \"\$(agmsg_known_types | sort -u)\" | paste -sd, -"
   [ "$status" -eq 0 ]
-  [ "$output" = "antigravity,claude-code,codex,copilot,cursor,gemini,grok-build,hermes,opencode" ]
+  [ "$output" = "antigravity,claude-code,codex,copilot,cursor,gemini,grok-build,opencode" ]
 }
 
 @test "type-registry: detection manifests carry the expected env / proc keys" {

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -64,7 +64,7 @@ write_node_launcher_fixtures() {
   [ "$status" -ne 0 ]
 }
 
-@test "type-registry: spawnable set is exactly claude-code, codex, grok-build and hermes" {
+@test "type-registry: spawnable set is exactly all nine built-ins (#277)" {
   run env -i PATH="$PATH" bash -c \
     "source '$SCRIPTS/lib/type-registry.sh'
      while IFS= read -r t; do
@@ -72,7 +72,7 @@ write_node_launcher_fixtures() {
        [ \"\$(agmsg_type_get \"\$t\" spawnable)\" = yes ] && echo \"\$t\"
      done <<< \"\$(agmsg_known_types | sort -u)\" | paste -sd, -"
   [ "$status" -eq 0 ]
-  [ "$output" = "claude-code,codex,grok-build,hermes" ]
+  [ "$output" = "antigravity,claude-code,codex,copilot,cursor,gemini,grok-build,hermes,opencode" ]
 }
 
 @test "type-registry: detection manifests carry the expected env / proc keys" {


### PR DESCRIPTION
Closes #277.

## Summary

Only 4 of 9 registered types were spawnable. The other 5 (`antigravity`, `copilot`, `cursor`, `gemini`, `opencode`) all have real CLI binaries capable of an interactive session seeded with an initial prompt — verified empirically against each installed CLI's `--help` output — they were simply never wired up, for two different reasons.

## What was blocking each type

- **cursor**, **gemini**: nothing structural. `cursor` already had `cli=cursor-agent` but was missing `spawnable=yes`; `gemini` was missing a manifest entirely. Both accept a bare positional prompt plus `--model`, matching the existing claude-code/codex contract exactly.
- **antigravity** (`agy`), **copilot**: neither accepts a bare positional prompt. They require it as the value of a named flag instead — `agy --prompt-interactive "<text>"`, `copilot -i/--interactive "<text>"` (their `-p/--prompt` equivalents are a *different*, non-interactive one-shot mode — not what spawn needs). `spawn.sh` had no manifest field for this.
- **opencode**: structurally different again — the message isn't a top-level argument at all. It needs the `run` subcommand plus a separate boolean flag to stay interactive: `opencode run --interactive [message..]`. The top-level `opencode [project]` positional is a project *path*, not a prompt.

## Design

Two `spawn.sh` changes cover all five:

1. **Relax `cli=`** from "a single binary name" to "a trusted fixed command-line prefix" (still manifest data agmsg ships, not runtime user input — safe). The CLI-exists check resolves only the first word; the boot script no longer collapses the whole value into one `%q` token (which would search for a literally space-containing binary name) — it's emitted as-is so it word-splits into the right argv tokens. This lets `opencode` set `cli=opencode run --interactive` with **no other new mechanism** — `--interactive` is a plain boolean per opencode's own `--help`, so baking it into the fixed prefix ahead of `--model`/the prompt is unambiguous. The 6 existing single-word `cli=` values are unaffected.
2. **Add `prompt_arg=<flag>`.** When set, `spawn.sh` inserts `<flag>` immediately before the final actas prompt (which already carries `--boot-prompt`'s text when given) instead of passing it bare — placed as the last two tokens so there's no adjacency ambiguity with `--model`/spawn-options. Unset = today's bare-positional behavior, unchanged for the 4 previously-spawnable types.

## Per-type manifest changes

| type | `cli=` | new keys |
|---|---|---|
| `cursor` | `cursor-agent` (unchanged) | `+ spawnable=yes`, `+ model_arg=--model` |
| `gemini` | `gemini` (new) | `+ spawnable=yes`, `+ model_arg=--model` |
| `antigravity` | `agy` (new) | `+ spawnable=yes`, `+ model_arg=--model`, `+ prompt_arg=--prompt-interactive` |
| `copilot` | `copilot` (new) | `+ spawnable=yes`, `+ model_arg=--model`, `+ prompt_arg=--interactive` |
| `opencode` | `opencode run --interactive` (new) | `+ spawnable=yes`, `+ model_arg=--model` |

Resulting invocations:
```
cursor-agent --model <id> "<actas prompt>"
gemini --model <id> "<actas prompt>"
agy --model <id> --prompt-interactive "<actas prompt>"
copilot --model <id> --interactive "<actas prompt>"
opencode run --interactive --model <id> "<actas prompt>"
```

## Docs

- `docs/agent-types.md`: documents the relaxed `cli=` semantics and the new `prompt_arg=` field in the manifest key table.
- `README.md`: the stale "only claude-code and codex" spawn line (grok-build/hermes were already spawnable too) is corrected to all nine.

## Validation

- `bash -n` on `spawn.sh`
- `bats tests/test_spawn.bats` (44/44 — per-type boot-script assertions for all 5 new types, a `prompt_arg` + spawn-options ordering regression, a multi-word `cli=` existence-check regression for opencode, and the two obsolete tests whose old expectations — gemini/opencode rejected, spawnable set = 4 types — updated to the new state)
- `bats tests/test_type_registry.bats tests/test_spawn_options.bats tests/test_despawn.bats tests/test_install.bats` (75/75, no regressions)