### PR TITLE
fix(claude-code): gate actas/drop's fresh Monitor on delivery mode

### DIFF
--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -140,10 +140,11 @@ If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
    a. Run TaskList. Find any task whose description begins with "agmsg inbox stream".
    b. **If a matching task is found**: TaskStop it.
    c. **If no matching task is found** (typical when /__SKILL_NAME__ actas runs as the first command of a fresh session — SessionStart hasn't fired the Monitor directive yet, or you're invoking actas before the agent acted on it): skip TaskStop entirely. There is no Monitor to stop. Do NOT attempt TaskStop with a guessed or empty task_id — it will fail with "Invalid tool parameters" and confuse the flow.
-   d. Invoke a fresh Monitor regardless of whether step b or c applied:
+   d. **Only if the project's delivery mode is `monitor` or `both`** (check via `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status claude-code "$(pwd)"`), invoke a fresh Monitor, regardless of whether step b or c applied:
       - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh $CLAUDE_CODE_SESSION_ID "$(pwd)" claude-code <name>`
       - description: `agmsg inbox stream (acting as <name>)`
       - persistent: true
+      Otherwise (mode `turn` or `off`), leave it stopped — `actas` must not start automatic delivery a project wasn't configured for.
    The 4th argument to `watch.sh` restricts the subscription to messages addressed to `<name>` only — other roles' inbound messages stop reaching this session until another `actas` or session end.
 6. Set the session's active FROM to `<name>` — use `<name>` in every `send.sh` call for the rest of this session.
 7. Tell the user: "Now acting as `<name>`. Sends use `<name>` as from; receive restricted to `<name>` only."
@@ -155,10 +156,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
    a. Run TaskList. Find any task whose description begins with "agmsg inbox stream".
    b. **If a matching task is found**: TaskStop it.
    c. **If no matching task is found**: skip TaskStop. Do NOT attempt TaskStop with a guessed or empty task_id.
-   d. Invoke a fresh Monitor with the default subscription (no `actas` name filter — receives every (team, agent) pair currently registered for this project that isn't held by another session):
+   d. **Only if the project's delivery mode is `monitor` or `both`** (check via `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status claude-code "$(pwd)"`), invoke a fresh Monitor with the default subscription (no `actas` name filter — receives every (team, agent) pair currently registered for this project that isn't held by another session):
       - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh $CLAUDE_CODE_SESSION_ID "$(pwd)" claude-code`
       - description: `agmsg inbox stream`
       - persistent: true
+      Otherwise (mode `turn` or `off`), leave it stopped.
 4. Tell the user: "Dropped role `<name>` from this project."
 
 If argument starts with "spawn" (e.g. "spawn codex reviewer", "spawn claude-code alice --window"):

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -61,6 +61,27 @@ teardown() {
   grep -q "backup sentinel" "$backup/SKILL.md"
 }
 
+@test "install: Claude Code command file gates actas/drop's fresh Monitor on delivery mode (#280)" {
+  # actas/drop used to invoke a fresh Monitor unconditionally, ignoring
+  # mode=off/turn (#280) — this is prompt-instruction text, not executable
+  # code, so a content assertion is the regression coverage available: both
+  # sections must carry the same delivery-mode gate the normal entry flow
+  # already has (line ~90 in the template). The Claude Code command file is
+  # only installed when ~/.claude exists (install.sh), separate from the
+  # shared codex-typed $SK/SKILL.md.
+  mkdir -p "$FAKE_HOME/.claude"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  local cmd_file="$FAKE_HOME/.claude/commands/agmsg.md"
+  [ -f "$cmd_file" ]
+  local actas_block drop_block
+  actas_block="$(sed -n '/If argument starts with "actas"/,/If argument starts with "drop"/p' "$cmd_file")"
+  drop_block="$(sed -n '/If argument starts with "drop"/,/If argument starts with "spawn"/p' "$cmd_file")"
+  [[ "$actas_block" == *"delivery mode is"*"monitor"*"both"* ]]
+  [[ "$actas_block" == *"delivery.sh status"* ]]
+  [[ "$drop_block" == *"delivery mode is"*"monitor"*"both"* ]]
+  [[ "$drop_block" == *"delivery.sh status"* ]]
+}
+
 @test "install: --update warns to re-register delivery hooks (#133)" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
   run env HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg --update


### PR DESCRIPTION
Closes #280.

## Problem

`/agmsg actas <name>` and `/agmsg drop <name>` always invoke a fresh Monitor (`watch.sh`), regardless of the project's configured delivery mode. Confirmed live: `delivery.sh status claude-code <project>` reported `mode: off`, yet running `actas <name>` started a `watch.sh` process anyway — 9 stray watchers accumulated in one project this way (found while building the agmsg desktop app).

## Root cause

`scripts/drivers/types/claude-code/template.md`:
- The normal entry flow already gates Monitor invocation on delivery mode: *"...and the project's delivery mode is `monitor` or `both`..., invoke the Monitor tool now."*
- `actas` step 5.d had no such check — "Invoke a fresh Monitor regardless of whether step b or c applied" (that "regardless of" is about the TaskStop-found/not-found branch, but the net effect is no mode gate at all).
- `drop` step 3.d had the identical bug.

Asymmetric implementation: the general entry-point path respects `mode=off`/`turn`, but `actas`/`drop` silently override it.

## Fix

Add the same delivery-mode gate to both steps, mirroring the entry flow's existing wording: only invoke the fresh Monitor when mode is `monitor` or `both`; otherwise leave it stopped.

## Validation

This is prompt-instruction text, not executable code, so full behavioral coverage isn't possible via bats. Added a content-assertion regression test on the compiled Claude Code command file (`~/.claude/commands/<cmd>.md`, separate from the shared codex-typed `SKILL.md`) confirming both the actas and drop sections carry the gate.

- `bats tests/test_install.bats` (42/42, including the new test)
- `bats tests/test_install.bats tests/test_delivery.bats tests/test_type_registry.bats` (181/181, no regressions)