### PR TITLE
fix(identity): match project registrations across Windows path forms (#268)

### DIFF
--- a/scripts/identities.sh
+++ b/scripts/identities.sh
@@ -15,13 +15,16 @@ set -euo pipefail
 
 PROJECT_PATH="${1:?Usage: identities.sh <project_path> <agent_type>}"
 AGENT_TYPE="${2:?Missing agent_type}"
-PROJECT_SQL=$(printf '%s' "$PROJECT_PATH" | sed "s/'/''/g")
 AGENT_TYPE_SQL=$(printf '%s' "$AGENT_TYPE" | sed "s/'/''/g")
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"  # resolve-project.sh requires SKILL_DIR
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 # shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/storage.sh"
+PROJECT_SQL_IN=$(agmsg_project_sql_in_list "$PROJECT_PATH")
 
 [ -d "$TEAMS_DIR" ] || exit 0
 
@@ -51,7 +54,7 @@ for config_file in "$TEAMS_DIR"/*/config.json; do
     )
     SELECT DISTINCT '$TEAM_SQL' AS team, name
     FROM agents, json_each(agents.registrations) AS r
-    WHERE json_extract(r.value, '\$.project') = '$PROJECT_SQL'
+    WHERE json_extract(r.value, '\$.project') IN ($PROJECT_SQL_IN)
       AND json_extract(r.value, '\$.type') = '$AGENT_TYPE_SQL'
     ORDER BY team, name;
   " | tr -d '\r'

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -44,6 +44,7 @@ source "$SCRIPT_DIR/lib/storage.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/registry-lock.sh"
 PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
+PROJECT_PATH="$(agmsg_normalize_project_path "$PROJECT_PATH")"
 
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
 
@@ -66,6 +67,7 @@ CONFIG_SQL=$(agmsg_sql_readfile_path "$TEAM_CONFIG")
 AGENT_ID_SQL=$(printf '%s' "$AGENT_ID" | sed "s/'/''/g")
 AGENT_TYPE_SQL=$(printf '%s' "$AGENT_TYPE" | sed "s/'/''/g")
 PROJECT_SQL=$(printf '%s' "$PROJECT_PATH" | sed "s/'/''/g")
+PROJECT_SQL_IN=$(agmsg_project_sql_in_list "$PROJECT_PATH")
 REGISTRATION=$(sqlite3 :memory: "SELECT json_object('type', '$AGENT_TYPE_SQL', 'project', '$PROJECT_SQL');")
 REGISTRATION_ESCAPED=$(printf '%s' "$REGISTRATION" | sed "s/'/''/g")
 
@@ -101,7 +103,7 @@ else
       SELECT 1
       FROM json_each(json_extract('$NORMALIZED_ESCAPED', '\$.registrations'))
       WHERE json_extract(value, '\$.type') = '$AGENT_TYPE_SQL'
-        AND json_extract(value, '\$.project') = '$PROJECT_SQL'
+        AND json_extract(value, '\$.project') IN ($PROJECT_SQL_IN)
     );
   ")
 

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -57,6 +57,154 @@ agmsg_canonical_path() {
   fi
 }
 
+# Normalize only path spelling, not filesystem identity. Windows paths use the
+# mixed form used by Git for Windows (`C:/path`); POSIX paths keep their form
+# except for redundant trailing slashes.
+#
+# Trade-off: the reinterpretation is form-based, not platform-gated, so a POSIX
+# path whose first component is a single letter (`/c/foo`) is treated as an
+# MSYS drive form. Lookups stay correct either way — the variant set generated
+# below always includes the original spelling — but such paths are rare enough
+# on POSIX hosts that we prefer the simpler, platform-independent rule.
+agmsg_normalize_project_path() {
+  local p="$1" drive rest squeezed
+  [ -n "$p" ] || { printf '%s' "$p"; return 0; }
+  p="${p//\\//}"
+
+  # Collapse repeated slashes (C://x, /c//x) while preserving a UNC-style
+  # leading double slash.
+  squeezed=$(printf '%s' "$p" | tr -s '/')
+  case "$p" in
+    //*) p="/$squeezed" ;;
+    *)   p="$squeezed" ;;
+  esac
+
+  case "$p" in
+    /[A-Za-z])
+      drive=$(printf '%s' "${p#/}" | tr '[:lower:]' '[:upper:]')
+      printf '%s:/' "$drive"
+      return 0
+      ;;
+    /[A-Za-z]/*)
+      drive=$(printf '%s' "${p:1:1}" | tr '[:lower:]' '[:upper:]')
+      rest="${p:2}"
+      p="$drive:$rest"
+      ;;
+    [A-Za-z]:)
+      drive=$(printf '%s' "${p:0:1}" | tr '[:lower:]' '[:upper:]')
+      printf '%s:/' "$drive"
+      return 0
+      ;;
+    [A-Za-z]:/*)
+      drive=$(printf '%s' "${p:0:1}" | tr '[:lower:]' '[:upper:]')
+      p="$drive:${p:2}"
+      ;;
+  esac
+
+  case "$p" in
+    [A-Za-z]:/)
+      printf '%s' "$p"
+      return 0
+      ;;
+    */)
+      while [ "$p" != "/" ] && [ "${p%/}" != "$p" ]; do
+        p="${p%/}"
+      done
+      case "$p" in [A-Za-z]:) p="$p/" ;; esac
+      ;;
+  esac
+  printf '%s' "$p"
+}
+
+# Print equivalent project path spellings for lookup compatibility with legacy
+# registrations. The first line is the canonical comparison form.
+agmsg_project_path_variants() {
+  local raw="$1"
+  local norm="$1" drive lower rest mixed_lower msys_lower msys_upper native_upper native_lower
+  local variants=() existing
+  norm="$(agmsg_normalize_project_path "$norm")"
+
+  _agmsg_add_project_variant() {
+    local candidate="$1" seen
+    [ -n "$candidate" ] || return 0
+    # ${arr[@]+...} guards the empty-array expansion: under `set -u` bash 3.2
+    # (macOS default) treats "${variants[@]}" on an empty array as unbound.
+    for seen in ${variants[@]+"${variants[@]}"}; do
+      [ "$seen" = "$candidate" ] && return 0
+    done
+    variants[${#variants[@]}]="$candidate"
+  }
+
+  _agmsg_add_project_variant "$norm"
+  # The caller's exact spelling always participates — covers exotic forms the
+  # normalizer does not model (e.g. native UNC \\server\share).
+  _agmsg_add_project_variant "$raw"
+  case "$norm" in
+    [A-Z]:/*)
+      drive="${norm:0:1}"
+      lower="$(printf '%s' "$drive" | tr '[:upper:]' '[:lower:]')"
+      rest="${norm:2}"
+      mixed_lower="$lower:$rest"
+      msys_lower="/$lower$rest"
+      msys_upper="/$drive$rest"
+      native_upper="$drive:${rest//\//\\}"
+      native_lower="$lower:${rest//\//\\}"
+
+      _agmsg_add_project_variant "$mixed_lower"
+      _agmsg_add_project_variant "$msys_lower"
+      _agmsg_add_project_variant "$msys_upper"
+      _agmsg_add_project_variant "$native_upper"
+      _agmsg_add_project_variant "$native_lower"
+      if [ "$norm" != "$drive:/" ]; then
+        _agmsg_add_project_variant "$norm/"
+        _agmsg_add_project_variant "$mixed_lower/"
+        _agmsg_add_project_variant "$msys_lower/"
+        _agmsg_add_project_variant "$msys_upper/"
+        _agmsg_add_project_variant "$native_upper\\"
+        _agmsg_add_project_variant "$native_lower\\"
+      fi
+      ;;
+    //*)
+      # UNC: registrations may be stored with backslashes and/or a trailing
+      # separator.
+      _agmsg_add_project_variant "${norm//\//\\}"
+      _agmsg_add_project_variant "$norm/"
+      _agmsg_add_project_variant "${norm//\//\\}\\"
+      ;;
+    /|[A-Z]:/) : ;;
+    /*)
+      # Legacy POSIX registrations may carry a trailing slash.
+      _agmsg_add_project_variant "$norm/"
+      ;;
+  esac
+
+  for existing in ${variants[@]+"${variants[@]}"}; do
+    printf '%s\n' "$existing"
+  done
+  unset -f _agmsg_add_project_variant
+}
+
+agmsg_project_sql_in_list() {
+  local path="$1" candidate escaped out=""
+  while IFS= read -r candidate; do
+    escaped=$(printf '%s' "$candidate" | sed "s/'/''/g")
+    out="${out:+$out,}'$escaped'"
+  done < <(agmsg_project_path_variants "$path")
+  printf '%s' "$out"
+}
+
+agmsg_find_registered_project_variant() {
+  local projects="$1" path="$2" candidate match
+  while IFS= read -r candidate; do
+    match=$(printf '%s\n' "$projects" | grep -Fx -- "$candidate" | head -n 1 || true)
+    if [ -n "$match" ]; then
+      printf '%s' "$match"
+      return 0
+    fi
+  done < <(agmsg_project_path_variants "$path")
+  return 1
+}
+
 # Map an agent type to the binary basename(s) its process may carry.
 _agmsg_agent_binaries() {
   case "$1" in
@@ -197,7 +345,7 @@ agmsg_registered_projects() {
 # dir (the git checkout itself is then unregistered, so we decline and let the
 # ancestor walk handle it). return 1 when git is absent or nothing matches.
 agmsg_gitcommon_project() {
-  local start="$1" type="$2" common main projects
+  local start="$1" type="$2" common main projects match
   command -v git >/dev/null 2>&1 || return 1
   [ -d "$start" ] || return 1
   common=$(cd "$start" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null) || return 1
@@ -207,23 +355,27 @@ agmsg_gitcommon_project() {
   main=$(cd "$(dirname "$common")" 2>/dev/null && pwd) || return 1
   projects="$(agmsg_registered_projects "$type")"
   [ -n "$projects" ] || return 1
-  printf '%s\n' "$projects" | grep -Fxq "$main" || return 1
-  printf '%s' "$main"
+  match="$(agmsg_find_registered_project_variant "$projects" "$main")" || return 1
+  printf '%s' "$match"
 }
 
 # Echo the nearest ancestor of <start> (inclusive) that is a registered project
 # for <type>. return 1 when none matches.
 agmsg_ancestor_project() {
-  local start="$1" type="$2" projects d
+  local start="$1" type="$2" projects d next match
   projects="$(agmsg_registered_projects "$type")"
   [ -n "$projects" ] || return 1
-  d="$start"
-  while [ -n "$d" ] && [ "$d" != "/" ] && [ "$d" != "." ]; do
-    if printf '%s\n' "$projects" | grep -Fxq "$d"; then
-      printf '%s' "$d"
+  d="$(agmsg_normalize_project_path "$start")"
+  while [ -n "$d" ] && [ "$d" != "." ]; do
+    if match="$(agmsg_find_registered_project_variant "$projects" "$d")"; then
+      printf '%s' "$match"
       return 0
     fi
-    d=$(dirname "$d")
+    case "$d" in "/"|[A-Za-z]:|[A-Za-z]:/) break ;; esac
+    next=$(dirname "$d")
+    [ -z "$next" ] && break
+    [ "$next" = "$d" ] && break
+    d="$next"
   done
   return 1
 }

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -30,6 +30,9 @@ source "$SCRIPT_DIR/lib/registry-lock.sh"
 # Resolve the session's real project root (see #92) so a drop issued from a
 # subdir/worktree clears the registration on the project the session lives in.
 PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
+# Equivalent path spellings (#268) — a drop must remove a registration stored
+# in any Windows/MSYS form, not just the exact resolved string.
+PROJECT_SQL_IN=$(agmsg_project_sql_in_list "$PROJECT_PATH")
 
 # A drop releases the actas lock keyed under this session's per-process instance
 # id (#93). The template passes a bare $CLAUDE_CODE_SESSION_ID; normalize to the
@@ -106,7 +109,7 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
     SELECT count(*)
     FROM json_each(json_extract('$NORMALIZED_ESCAPED', '\$.registrations'))
     WHERE json_extract(value, '\$.type') = '$AGENT_TYPE'
-      AND json_extract(value, '\$.project') = '$PROJECT_PATH';
+      AND json_extract(value, '\$.project') IN ($PROJECT_SQL_IN);
   ")
   if [ "$MATCH_COUNT" -eq 0 ]; then
     agmsg_lock_release
@@ -121,7 +124,7 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
         FROM json_each(json_extract('$NORMALIZED_ESCAPED', '\$.registrations'))
         WHERE NOT (
           json_extract(value, '\$.type') = '$AGENT_TYPE'
-          AND json_extract(value, '\$.project') = '$PROJECT_PATH'
+          AND json_extract(value, '\$.project') IN ($PROJECT_SQL_IN)
         )
       ), json('[]'))
     );

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -79,6 +79,8 @@ source "$SCRIPT_DIR/lib/type-registry.sh"
 source "$SCRIPT_DIR/lib/storage.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/spawn-options.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"
 
 die() { echo "spawn: $*" >&2; exit 1; }
 
@@ -173,6 +175,7 @@ if [ ! -d "$PROJECT" ]; then
   die "project path does not exist: $PROJECT"
 fi
 PROJECT="$(cd "$PROJECT" && pwd)"
+PROJECT="$(agmsg_normalize_project_path "$PROJECT")"
 
 # --- Resolve the launch method from the manifest ---
 # A non-empty `spawn=` launcher means this type runs via a Node launcher (e.g. an
@@ -240,13 +243,13 @@ fi
 # registered for this project (any type). Zero or many → require --team.
 resolve_team() {
   [ -d "$TEAMS_DIR" ] || return 0
-  local config_file team_name cfg_sql proj_sql count_for_project
+  local config_file team_name cfg_sql project_sql_in count_for_project
   local found=""
   # Read each config via readfile() and compare with SQL string literals rather
   # than `.param set` bindings: the sqlite3 shell's dot-command tokenizer does
   # NOT honour SQL '' escaping, so a value containing a single quote (a project
   # path like /tmp/pro'j) breaks `.param set`. SQL string literals do honour ''.
-  proj_sql=$(printf '%s' "$PROJECT" | sed "s/'/''/g")
+  project_sql_in=$(agmsg_project_sql_in_list "$PROJECT")
   for config_file in "$TEAMS_DIR"/*/config.json; do
     [ -f "$config_file" ] || continue
     cfg_sql=$(printf '%s' "$config_file" | sed "s/'/''/g")
@@ -265,7 +268,7 @@ resolve_team() {
       )
       SELECT COUNT(*)
       FROM agents, json_each(agents.registrations) AS r
-      WHERE json_extract(r.value, '\$.project') = '$proj_sql';
+      WHERE json_extract(r.value, '\$.project') IN ($project_sql_in);
     ")
     if [ "${count_for_project:-0}" -gt 0 ]; then
       found="${found:+$found

--- a/tests/test_identity_path_forms.bats
+++ b/tests/test_identity_path_forms.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+
+# Windows path-form compatibility for project identity resolution (#268).
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/resolve-project.sh"
+}
+
+teardown() {
+  teardown_test_env
+}
+
+write_team_config() {
+  local project="$1" type="${2:-codex}" agent="${3:-alice}"
+  local project_sql type_sql agent_sql
+  project_sql=$(printf '%s' "$project" | sed "s/'/''/g")
+  type_sql=$(printf '%s' "$type" | sed "s/'/''/g")
+  agent_sql=$(printf '%s' "$agent" | sed "s/'/''/g")
+  mkdir -p "$TEST_SKILL_DIR/teams/team"
+  sqlite3 :memory: "
+    SELECT json_object(
+      'name', 'team',
+      'agents', json_object(
+        '$agent_sql',
+        json_object(
+          'registrations',
+          json_array(json_object('type', '$type_sql', 'project', '$project_sql'))
+        )
+      )
+    );
+  " > "$TEST_SKILL_DIR/teams/team/config.json"
+}
+
+assert_identity_for() {
+  local input="$1"
+  run bash "$SCRIPTS/identities.sh" "$input" codex
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ $'team\talice' ]]
+}
+
+@test "normalize: Windows path forms become uppercase-drive mixed form" {
+  [ "$(agmsg_normalize_project_path '/c/Users/regis/Proj/')" = "C:/Users/regis/Proj" ]
+  [ "$(agmsg_normalize_project_path 'c:/Users/regis/Proj/')" = "C:/Users/regis/Proj" ]
+  [ "$(agmsg_normalize_project_path 'C:\Users\regis\Proj\')" = "C:/Users/regis/Proj" ]
+}
+
+@test "normalize: root paths are preserved" {
+  [ "$(agmsg_normalize_project_path 'C:/')" = "C:/" ]
+  [ "$(agmsg_normalize_project_path 'C:////')" = "C:/" ]
+  [ "$(agmsg_normalize_project_path '/c/')" = "C:/" ]
+  [ "$(agmsg_normalize_project_path '/')" = "/" ]
+}
+
+@test "identities: stored mixed path matches common Windows input forms" {
+  write_team_config 'C:/x'
+
+  assert_identity_for '/c/x'
+  assert_identity_for 'C:\x'
+  assert_identity_for 'C:/x/'
+  assert_identity_for 'c:/x'
+}
+
+@test "identities: legacy stored MSYS path matches mixed input form" {
+  write_team_config '/c/x'
+
+  assert_identity_for 'C:/x'
+}
+
+@test "identities: Windows variant SQL remains safe for single quotes" {
+  write_team_config "C:/x's"
+
+  assert_identity_for "/c/x's"
+}
+
+@test "identities: non-Windows path strips trailing slash and still matches" {
+  write_team_config '/tmp/agmsg-proj'
+
+  assert_identity_for '/tmp/agmsg-proj/'
+}
+
+@test "normalize: repeated slashes collapse, UNC leading slashes survive" {
+  [ "$(agmsg_normalize_project_path 'C://x//y')" = "C:/x/y" ]
+  [ "$(agmsg_normalize_project_path '/c//x')" = "C:/x" ]
+  [ "$(agmsg_normalize_project_path '//server/share/repo')" = "//server/share/repo" ]
+}
+
+@test "identities: UNC registration matches across slash and backslash forms" {
+  write_team_config '\\server\share\repo'
+
+  assert_identity_for '//server/share/repo'
+  assert_identity_for '\\server\share\repo'
+}
+
+@test "identities: legacy POSIX registration with trailing slash still matches" {
+  write_team_config '/tmp/agmsg-proj/'
+
+  assert_identity_for '/tmp/agmsg-proj'
+}
+
+@test "join: stores canonical mixed Windows path going forward" {
+  AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/join.sh" team alice codex '/c/x/' >/dev/null
+
+  cfg="$TEST_SKILL_DIR/teams/team/config.json"
+  project="$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.agents.alice.registrations[0].project');")"
+  [ "$project" = "C:/x" ]
+}


### PR DESCRIPTION
## Problem

Identity resolution compares the caller's project path with the stored registration using raw SQL string equality. On Windows (Git Bash / MSYS) the same directory can be spelled `C:/x`, `/c/x`, `C:\x`, with either drive-letter case or a trailing separator. When the spelling differs — e.g. a registration stored as `C:/Users/me/Proj` queried with `$(pwd)` = `/c/Users/me/Proj` — the exact match fails and `whoami.sh` falls into the ancestor walk, which in practice showed up as multi-second stalls/timeouts. Related: #268 (PR #275 addresses the codex-bridge side; this PR fixes the general resolution layer).

## Approach

- `lib/resolve-project.sh`: new pure-bash helpers — `agmsg_normalize_project_path` (canonical mixed form `C:/x`, uppercase drive, collapsed slashes, no trailing separator; UNC `//server/share` preserved), `agmsg_project_path_variants` (equivalent-spelling candidate set, always including the caller's exact spelling), `agmsg_project_sql_in_list`, and `agmsg_find_registered_project_variant`.
- `identities.sh`, `join.sh` (duplicate check), `spawn.sh` (team resolution), `reset.sh` (drop): compare with the candidate set (`IN (...)`, quotes escaped) instead of raw equality, so legacy registrations in any spelling keep matching without rewriting config files.
- `join.sh` / `spawn.sh`: store the canonical mixed form going forward.
- `agmsg_ancestor_project`: terminate reliably at `/`, `C:`, `C:/` (previously `dirname` could loop at a drive root), and match each ancestor across spellings.

Drive-letter reinterpretation is form-based, not platform-gated: a POSIX path like `/c/foo` is treated as an MSYS drive form. Lookups stay correct either way (the variant set always includes the original spelling); the trade-off is documented in the code.

Known related gaps left out of scope: codex-bridge project hashing / bridge status metadata compare raw forms (see #275 discussion).

## Tests

`tests/test_identity_path_forms.bats` (10 cases): normalization incl. roots, repeated slashes, UNC; stored-mixed × input-MSYS/native/lowercase/trailing; legacy stored MSYS and trailing-slash POSIX registrations; single-quote SQL safety; join storing canonical form. Existing suites pass (`test_resolve_project`, `test_compat`, `test_spawn_options`, `test_actas_lock`). New constructs are bash-3.2 compatible (empty-array expansions guarded for `set -u`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)