### PR TITLE
feat(api): add scripts/api.sh — read-only JSON entry point for non-bash consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,16 @@ Full discovery order, the trust model, and authoring guidance:
 [docs/plugins.md](docs/plugins.md) (design rationale in
 [ADR 0002](docs/adr/0002-driver-discovery-and-plugin-opt-in.md)).
 
+## Building on agmsg
+
+Writing something *outside* agmsg's own scripts that reads or drives agmsg —
+a GUI app, a bot, a derivative project (`agmsg-shogi`, `agmsg-go`,
+`agmsg-mcp`, …)? Read data via `scripts/api.sh` (JSON out, no need to touch
+`messages.db` or `teams/*/config.json` directly — those are internal and free
+to change), and write through the existing scripts (`send.sh`, `join.sh`,
+…) rather than the database. Full guidance:
+[docs/building-on-agmsg.md](docs/building-on-agmsg.md).
+
 ## Community
 
 - **Product Hunt**: #5 Product of the Day, [2026-06-09 launch](https://www.producthunt.com/products/agmsg) — 219 upvotes, 39 comments

--- a/docs/building-on-agmsg.md
+++ b/docs/building-on-agmsg.md
@@ -1,0 +1,97 @@
+# Building on agmsg
+
+This is for anyone writing a program *outside* agmsg's own bash scripts that
+wants to read or act on agmsg data — a GUI app, a web dashboard, a bot in
+another language, a derivative project (`agmsg-shogi`, `agmsg-go`,
+`agmsg-mcp`, …). If you're extending agmsg's own behavior (a new agent type,
+a new storage backend), see [Plugins](plugins.md) instead — this doc is about
+consuming agmsg from the outside, not swapping a piece of it from the inside.
+
+## The rule: go through scripts, not files
+
+agmsg's actual storage (a SQLite file today, `teams/<team>/config.json` for
+rosters) is an implementation detail, not a contract. Design work is underway
+for a pluggable storage axis — swappable backends behind a common contract,
+so a message store doesn't have to be this SQLite file. Code outside
+`scripts/` that opens `messages.db` directly, or hand-parses a team's
+`config.json`, will break with no warning if that lands. Go through the
+scripts in `scripts/` instead — they're the stable surface; what's behind
+them is free to change.
+
+## Reading data: `scripts/api.sh`
+
+```sh
+~/.agents/skills/<cmd>/scripts/api.sh get teams
+~/.agents/skills/<cmd>/scripts/api.sh get teams <team> members
+~/.agents/skills/<cmd>/scripts/api.sh get teams <team> messages [--agent <name>] [--limit N] [--before-id <id>]
+```
+
+JSON out — plain lines for `teams`, JSONL (one record per line) for
+`members`/`messages`. `messages` returns oldest-first, capped by `--limit`
+(default 30, meaning the most recent 30 — not the first 30), each record
+shaped like:
+
+```json
+{"type":"message_sent","id":1234,"team":"agsuite","from":"alice","to":"bob","body":"...","at":"2026-07-02T10:00:00Z"}
+```
+
+That shape isn't incidental — it matches the `message_sent` event shape the
+in-progress storage-axis design defines for a future `storage_history`
+primitive. `api.sh` queries sqlite directly today; once that axis lands, this
+command is meant to become a thin call into the driver-agnostic function
+instead, with **no change to this output**. Code that consumes `api.sh`'s
+JSON today keeps working unmodified after that migration — which is the
+whole point of going through it instead of the database file.
+
+`api.sh` is intentionally read-only in v1 and shaped like a small REST API —
+verb (`get`) + resource nouns (`teams`, `members`, `messages`) — kubectl-style
+positional args rather than a `/teams/<team>/messages`-style path string
+(there's a fixed, small set of routes; a path string would just add parsing
+overhead on both ends for no real flexibility). A write verb (`post` for
+send, say) is a plausible future addition — the shape is deliberately left
+room to grow into that without a redesign.
+
+## Writing data: the existing write scripts
+
+There's no write API yet — call the same scripts agmsg's own CLI-driven
+flows use:
+
+| Action | Script |
+|---|---|
+| Send a message | `scripts/send.sh <team> <from> <to> <body>` |
+| Join a team / register an agent | `scripts/join.sh <team> <name> <type> <project>` |
+| Rename an agent | `scripts/rename.sh <team> <old> <new>` |
+| Remove an agent from a team | `scripts/leave.sh <team> <name>` |
+| Check delivery mode | `scripts/delivery.sh status [<type> <project>]` |
+| Set delivery mode | `scripts/delivery.sh set <mode> <type> <project>` |
+
+These are the same scripts `/agmsg` (or your configured command) itself
+shells out to — there is no more-privileged internal path. Treat them as the
+only sanctioned way to mutate agmsg state; nothing outside `scripts/` should
+write to `db/` or `teams/` directly, for the same forward-compatibility
+reason reads go through `api.sh`.
+
+## Spawning and driving an agent
+
+Reading/writing agmsg data is one half of "building on agmsg" — the other is
+actually running an agent under it, e.g. a GUI that opens a real terminal and
+boots a CLI agent into a team. That's not a script call: give the agent's CLI
+`/<cmd> actas <name>` as its initial prompt (mirroring what `spawn.sh` does
+for a CLI-driven spawn) against a PTY or terminal you own, and — for a type
+whose CLI doesn't self-deliver — write inbound messages straight into that
+PTY's stdin yourself as they arrive, rather than waiting for the CLI to look
+idle (idle-detection heuristics are fragile — some CLIs keep redrawing a
+spinner well after they're actually ready for input). A short pause between
+the message text and the Enter keystroke is worth building in too: some CLIs
+misread text+Enter written back-to-back as a paste and swallow the Enter.
+
+## Versioning and stability
+
+`api.sh`'s interface (verbs, resource nouns, the JSONL record shape) is meant
+to stay stable across releases the way the write scripts' argument order
+already does. A breaking change to it would be called out in
+[CHANGELOG.md](../CHANGELOG.md) same as any other breaking change. There is
+no version negotiation yet (no `api.sh version`, no content-type header) —
+if your project needs to pin against a specific agmsg version, pin the
+install (see [Update](../README.md#update)) rather than assuming forward
+compatibility of anything not documented here.

--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -28,8 +28,12 @@ set -euo pipefail
 #   api.sh get teams <team> members
 #   api.sh get teams <team> messages [--agent <name>] [--limit N] [--before-id <id>]
 #
-# Output is always either plain lines (teams) or JSONL, one record per line,
-# UTF-8, no pretty-printing. Nothing is written; this is read-only.
+# Output is always JSONL — one JSON object per line, UTF-8, no
+# pretty-printing — for every resource, including `teams` (a uniform
+# contract beats a special case a non-bash consumer has to remember).
+# Nothing is written; this is read-only. Every id (message ids included) is
+# a JSON string, never a bare number — ids are opaque per the driver
+# interface spec, and today's sqlite integer ids are no exception.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
@@ -42,10 +46,22 @@ shift
 get_teams() {
   local teams_dir="$SCRIPT_DIR/../teams"
   [ -d "$teams_dir" ] || return 0
+  local names=()
   for dir in "$teams_dir"/*/; do
     [ -f "${dir}config.json" ] || continue
-    basename "$dir"
-  done | sort
+    names+=("$(basename "$dir")")
+  done
+  [ ${#names[@]} -eq 0 ] && return 0
+  # One sqlite call for all names (not one per team) — json_object() still
+  # handles the JSON-escaping per name (a quote in a team name, say), it's
+  # just batched into a single UNION ALL rather than N process spawns.
+  local query="" name
+  for name in "${names[@]}"; do
+    local name_sql; name_sql="$(_agmsg_sqlesc "$name")"
+    [ -n "$query" ] && query="$query UNION ALL "
+    query="${query}SELECT '$name_sql' AS n"
+  done
+  agmsg_sqlite_mem "SELECT json_object('name', n) FROM ($query) ORDER BY n;"
 }
 
 get_members() {
@@ -112,10 +128,15 @@ get_messages() {
   # ASC — oldest-first output, same ordering contract §2.1 of the driver
   # spec requires of storage_history, so a future swap to that function
   # doesn't change what this command prints.
+  # id is CAST to TEXT: the driver-interface spec treats every message id as
+  # opaque, and a legacy sqlite integer id is specifically passed through as
+  # a decimal STRING (not a JSON number) so a future UUIDv7/Redis-stream-id
+  # driver doesn't change this field's JSON type — a consumer parsing id as
+  # a string today needs no change once that lands.
   agmsg_sqlite "$db" "
     SELECT json_object(
       'type', 'message_sent',
-      'id', id,
+      'id', CAST(id AS TEXT),
       'team', team,
       'from', from_agent,
       'to', to_agent,

--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# api.sh — a read-only, JSON-emitting entry point for non-bash consumers
+# (a GUI client, a bot in another language — anything that wants agmsg data
+# without shelling out to sqlite3 directly). An ordinary core script, same
+# standing as send.sh/history.sh/inbox.sh — NOT part of the storage-driver
+# ABI (design/storage-axis, in progress as of this writing): that axis stays
+# a sourced-function contract external drivers implement, and this stays a
+# consumer of it. Queries the sqlite
+# store directly for now; once the storage axis lands, the `messages`
+# resource's query below is meant to become `storage_history`
+# (driver-agnostic), unchanged on the outside — see the JSONL shape note there.
+#
+# Shaped like a REST contract on purpose — verb + resource words — so
+# growing past read-only later (a `post teams <team> messages` == send,
+# say) is a new verb branch, not a redesign. v1 only implements `get`.
+#
+# kubectl-style rather than gh-api-style: fixed resource nouns as separate
+# positional args, not a "/teams/<team>/messages" path string. gh api's raw
+# path makes sense for a generic HTTP passthrough (any path the real API
+# supports just works); this has a small, fully-hardcoded set of routes, so
+# a path string would only add parsing/construction overhead on both ends
+# for no real flexibility gained.
+#
+# Usage:
+#   api.sh get teams
+#   api.sh get teams <team> members
+#   api.sh get teams <team> messages [--agent <name>] [--limit N] [--before-id <id>]
+#
+# Output is always either plain lines (teams) or JSONL, one record per line,
+# UTF-8, no pretty-printing. Nothing is written; this is read-only.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/storage.sh"
+
+_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
+
+VERB="${1:?Usage: api.sh <verb> <resource> ... — e.g. api.sh get teams}"
+shift
+
+get_teams() {
+  local teams_dir="$SCRIPT_DIR/../teams"
+  [ -d "$teams_dir" ] || return 0
+  for dir in "$teams_dir"/*/; do
+    [ -f "${dir}config.json" ] || continue
+    basename "$dir"
+  done | sort
+}
+
+get_members() {
+  local team="$1"
+  local config="$SCRIPT_DIR/../teams/$team/config.json"
+  [ -f "$config" ] || return 0
+  local path_sql; path_sql="$(agmsg_sql_readfile_path "$config")"
+  # Table-alias the outer and inner json_each explicitly (a.key/a.value vs
+  # r.value) — both produce a column literally named "value", and an
+  # unqualified reference inside the correlated subquery silently resolves
+  # to the wrong scope (returns empty, not an error) without the aliases.
+  agmsg_sqlite_mem "
+    WITH cfg AS (SELECT CAST(readfile('$path_sql') AS TEXT) AS json)
+    SELECT json_object(
+      'name', a.key,
+      'types', (
+        SELECT json_group_array(DISTINCT json_extract(r.value, '\$.type'))
+        FROM json_each(json_extract(a.value, '\$.registrations')) AS r
+      ),
+      'project', (
+        SELECT json_extract(r.value, '\$.project')
+        FROM json_each(json_extract(a.value, '\$.registrations')) AS r
+        LIMIT 1
+      )
+    )
+    FROM cfg, json_each(json_extract(cfg.json, '\$.agents')) AS a
+    ORDER BY a.key;
+  "
+}
+
+get_messages() {
+  local team="$1"
+  shift
+  local agent="" limit=30 before_id=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --agent) agent="${2:?--agent needs a value}"; shift 2 ;;
+      --limit) limit="${2:?--limit needs a value}"; shift 2 ;;
+      --before-id) before_id="${2:?--before-id needs a value}"; shift 2 ;;
+      *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+  done
+  # Non-numeric values would otherwise land straight in the SQL text below —
+  # same guard history.sh uses for LIMIT.
+  case "$limit" in ''|*[!0-9]*) limit=30 ;; esac
+  case "$before_id" in ''|*[!0-9]*) before_id="" ;; esac
+
+  local db; db="$(agmsg_db_path)"
+  if [ ! -f "$db" ]; then
+    return 0 # no store yet — empty result, not an error
+  fi
+
+  local team_sql; team_sql="$(_agmsg_sqlesc "$team")"
+  local where="team='$team_sql'"
+  if [ -n "$agent" ]; then
+    local agent_sql; agent_sql="$(_agmsg_sqlesc "$agent")"
+    where="$where AND (from_agent='$agent_sql' OR to_agent='$agent_sql')"
+  fi
+  if [ -n "$before_id" ]; then
+    where="$where AND id<$before_id"
+  fi
+
+  # Inner query takes the most recent `limit` by id DESC, outer re-sorts
+  # ASC — oldest-first output, same ordering contract §2.1 of the driver
+  # spec requires of storage_history, so a future swap to that function
+  # doesn't change what this command prints.
+  agmsg_sqlite "$db" "
+    SELECT json_object(
+      'type', 'message_sent',
+      'id', id,
+      'team', team,
+      'from', from_agent,
+      'to', to_agent,
+      'body', body,
+      'at', created_at
+    ) FROM (
+      SELECT * FROM messages WHERE $where ORDER BY id DESC LIMIT $limit
+    ) ORDER BY id ASC;
+  "
+}
+
+route_get() {
+  local resource="${1:?Usage: api.sh get teams [<team> members|messages ...]}"
+  shift
+  case "$resource" in
+    teams)
+      if [ $# -eq 0 ]; then
+        get_teams
+        return
+      fi
+      local team="$1"
+      shift
+      local sub="${1:?Usage: api.sh get teams <team> members|messages ...}"
+      shift
+      case "$sub" in
+        members) get_members "$team" ;;
+        messages) get_messages "$team" "$@" ;;
+        *) echo "Unknown resource: teams $team $sub" >&2; exit 1 ;;
+      esac
+      ;;
+    *) echo "Unknown resource: $resource" >&2; exit 1 ;;
+  esac
+}
+
+case "$VERB" in
+  get) route_get "$@" ;;
+  *)
+    echo "Unknown verb: $VERB (only 'get' is implemented — read-only for now)" >&2
+    exit 1
+    ;;
+esac

--- a/tests/test_api.bats
+++ b/tests/test_api.bats
@@ -1,0 +1,187 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a
+  bash "$SCRIPTS/join.sh" testteam bob codex /tmp/project-b
+}
+
+teardown() {
+  teardown_test_env
+}
+
+# Extract one JSON field's string value from a line via sqlite's own JSON
+# parser rather than grep/sed — avoids false matches on substrings and
+# validates the line is actually parseable JSON as a side effect. Escapes
+# the line's own single quotes before embedding it as a SQL string literal
+# (mirrors _agmsg_sqlesc in the scripts under test) — this is about safely
+# handing arbitrary JSON *into* the test's own SQL, unrelated to whether
+# api.sh itself escapes correctly.
+json_field() {
+  local escaped; escaped="$(printf %s "$1" | sed "s/'/''/g")"
+  sqlite_mem "SELECT json_extract('$escaped', '\$.$2');"
+}
+
+# Same escaping as json_field, for a plain json_valid() check.
+json_valid_line() {
+  local escaped; escaped="$(printf %s "$1" | sed "s/'/''/g")"
+  sqlite_mem "SELECT json_valid('$escaped');"
+}
+
+# --- get teams ---
+
+@test "api: get teams lists joined teams as JSONL" {
+  run bash "$SCRIPTS/api.sh" get teams
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 1 ]
+  [ "$(json_field "$output" name)" = "testteam" ]
+}
+
+@test "api: get teams is empty (not an error) when no teams exist" {
+  teardown_test_env
+  setup_test_env
+  run bash "$SCRIPTS/api.sh" get teams
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "api: get teams emits valid JSON even for a team name containing a quote" {
+  bash "$SCRIPTS/join.sh" "o'brien" carol claude-code /tmp/project-c
+  run bash "$SCRIPTS/api.sh" get teams
+  [ "$status" -eq 0 ]
+  local line
+  line="$(echo "$output" | grep "o'brien" || true)"
+  [ -n "$line" ]
+  [ "$(json_valid_line "$line")" = "1" ]
+  [ "$(json_field "$line" name)" = "o'brien" ]
+}
+
+# --- get teams <team> members ---
+
+@test "api: get teams <team> members lists members with type and project" {
+  run bash "$SCRIPTS/api.sh" get teams testteam members
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 2 ]
+  local alice_line
+  alice_line="$(echo "$output" | grep '"alice"')"
+  [ "$(json_field "$alice_line" project)" = "/tmp/project-a" ]
+}
+
+@test "api: get teams <team> members is empty for a nonexistent team" {
+  run bash "$SCRIPTS/api.sh" get teams ghost-team members
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- get teams <team> messages ---
+
+@test "api: get teams <team> messages returns sent messages oldest-first" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "first"
+  bash "$SCRIPTS/send.sh" testteam bob alice "second"
+  run bash "$SCRIPTS/api.sh" get teams testteam messages
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 2 ]
+  local first_line second_line
+  first_line="$(echo "$output" | sed -n 1p)"
+  second_line="$(echo "$output" | sed -n 2p)"
+  [ "$(json_field "$first_line" body)" = "first" ]
+  [ "$(json_field "$second_line" body)" = "second" ]
+}
+
+@test "api: get teams <team> messages id is a JSON string, not a number" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "hi"
+  run bash "$SCRIPTS/api.sh" get teams testteam messages
+  [ "$status" -eq 0 ]
+  # json_type() reports "text" for a JSON string field, "integer" for a bare
+  # number — this is the regression aggie-co1's review caught (#289): ids
+  # must stay opaque strings, not JSON numbers, to match the driver
+  # interface's legacy-id contract.
+  [ "$(sqlite_mem "SELECT json_type('$output', '\$.id');")" = "text" ]
+}
+
+@test "api: get teams <team> messages is empty for a nonexistent team" {
+  run bash "$SCRIPTS/api.sh" get teams ghost-team messages
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "api: get teams <team> messages --agent filters to that agent's thread" {
+  bash "$SCRIPTS/join.sh" testteam carol claude-code /tmp/project-c
+  bash "$SCRIPTS/send.sh" testteam alice bob "to bob"
+  bash "$SCRIPTS/send.sh" testteam alice carol "to carol"
+  run bash "$SCRIPTS/api.sh" get teams testteam messages --agent bob
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 1 ]
+  [ "$(json_field "$output" body)" = "to bob" ]
+}
+
+@test "api: get teams <team> messages --limit caps to the most recent N" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "one"
+  bash "$SCRIPTS/send.sh" testteam alice bob "two"
+  bash "$SCRIPTS/send.sh" testteam alice bob "three"
+  run bash "$SCRIPTS/api.sh" get teams testteam messages --limit 2
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 2 ]
+  # oldest-first ordering still holds within the capped set — the 2 MOST
+  # RECENT, not the first 2.
+  [ "$(json_field "$(echo "$output" | sed -n 1p)" body)" = "two" ]
+  [ "$(json_field "$(echo "$output" | sed -n 2p)" body)" = "three" ]
+}
+
+@test "api: get teams <team> messages --before-id pages further back" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "one"
+  bash "$SCRIPTS/send.sh" testteam alice bob "two"
+  bash "$SCRIPTS/send.sh" testteam alice bob "three"
+  local first_page oldest_id
+  first_page="$(bash "$SCRIPTS/api.sh" get teams testteam messages --limit 2)"
+  oldest_id="$(json_field "$(echo "$first_page" | sed -n 1p)" id)"
+  run bash "$SCRIPTS/api.sh" get teams testteam messages --before-id "$oldest_id"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 1 ]
+  [ "$(json_field "$output" body)" = "one" ]
+}
+
+@test "api: get teams <team> messages emits valid JSON for a body containing a quote" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "she said \"hi\""
+  run bash "$SCRIPTS/api.sh" get teams testteam messages
+  [ "$status" -eq 0 ]
+  [ "$(json_valid_line "$output")" = "1" ]
+  [ "$(json_field "$output" body)" = 'she said "hi"' ]
+}
+
+@test "api: get teams <team> messages --agent with a quote in the name doesn't break the query" {
+  bash "$SCRIPTS/join.sh" testteam "o'brien" claude-code /tmp/project-o
+  bash "$SCRIPTS/send.sh" testteam alice "o'brien" "hello"
+  run bash "$SCRIPTS/api.sh" get teams testteam messages --agent "o'brien"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 1 ]
+  [ "$(json_field "$output" body)" = "hello" ]
+}
+
+# --- routing / error paths ---
+
+@test "api: unknown verb fails" {
+  run bash "$SCRIPTS/api.sh" post teams
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Unknown verb" ]]
+}
+
+@test "api: unknown top-level resource fails" {
+  run bash "$SCRIPTS/api.sh" get bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Unknown resource" ]]
+}
+
+@test "api: unknown team sub-resource fails" {
+  run bash "$SCRIPTS/api.sh" get teams testteam bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Unknown resource" ]]
+}
+
+@test "api: no arguments fails with a usage message" {
+  run bash "$SCRIPTS/api.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Usage" ]]
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/api.sh`, a read-only, JSON-emitting core script for non-bash consumers (a GUI client, a bot in another language) to read agmsg data without shelling out to sqlite3 directly or parsing team config JSON themselves.
- Verb + resource-noun interface (`get teams`, `get teams <team> members`, `get teams <team> messages`), kubectl-style rather than a `gh api`-style path string — this has a small, fully-hardcoded route set, so a path string would only add parsing/construction overhead for no real flexibility gained.
- `messages` output matches the `message_sent` JSONL event shape (and oldest-first ordering) the in-progress `design/storage-axis` work defines for a future `storage_history` primitive — bare-sqlite now, meant to become a thin call into that function once the storage axis lands, with no change to this script's own outward interface.
- Deliberately **not** folded into the storage-driver ABI itself — that axis stays a clean sourced-function contract for external driver authors; this is just a consumer of it, same standing as `send.sh`/`history.sh`/`inbox.sh`.
- `teams` / `teams <team> members` read team config directly — the team registry is expected to stay outside the storage axis (not something this PR changes).
- Adds `docs/building-on-agmsg.md` (+ a README pointer): guidance for anyone consuming agmsg data from outside its own scripts — read via `api.sh`, write via the existing scripts, never touch `messages.db`/`teams/*/config.json` directly.

## Test plan
- [x] Verified against a throwaway fixture (fake `db/messages.db` + `teams/<team>/config.json`): `get teams`, `get teams <team> members`, `get teams <team> messages` (with `--agent`/`--limit`/`--before-id`), unknown verb/resource error paths, nonexistent-team empty-not-error behavior.
- [x] Verified against a real local install (`install.sh --cmd agmsg --update`) with live team/message data.
- [x] Consumed from an external (non-bash) client in a separate, unpublished project: `teams`/`members`/`messages` reads now go through this instead of touching sqlite/team-config directly.