### PR TITLE
fix(setup): fall back to a tarball download when git is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,11 +380,16 @@ DB and team configs are preserved. Only scripts and assets are updated.
 
 ## Uninstall
 
+An `uninstall.sh` copy ships inside every install, so this works whether you
+installed via `git clone`, `npx agmsg`, or the curl one-liner:
+
 ```bash
-./uninstall.sh              # Interactive (confirms each step)
-./uninstall.sh --yes        # Remove everything
-./uninstall.sh --keep-data  # Remove skill but keep DB and teams
+~/.agents/skills/agmsg/uninstall.sh              # Interactive (confirms each step)
+~/.agents/skills/agmsg/uninstall.sh --yes        # Remove everything
+~/.agents/skills/agmsg/uninstall.sh --keep-data  # Remove skill but keep DB and teams
 ```
+
+(If you have a `git clone` checkout handy, `./uninstall.sh` from the repo root works the same way.)
 
 Auto-detects installed skill directories and cleans up: skill files, slash commands, hooks, AGENTS.md sections, and team configs.
 

--- a/install.sh
+++ b/install.sh
@@ -255,6 +255,11 @@ if [ "$UPDATE_ONLY" = true ]; then
   # user dropped in and their db/trusted-plugins opt-ins.
   mkdir -p "$SKILL_DIR/plugins"
   cp "$SCRIPT_DIR/plugins/README.md" "$SKILL_DIR/plugins/README.md" 2>/dev/null || true
+  # Ship uninstall.sh alongside the skill itself — npx/curl installs fetch a
+  # temp checkout that gets deleted right after install, so without this copy
+  # those users would have no local uninstaller to run later (only a manual
+  # `git clone` checkout would). See the README's Uninstall section.
+  cp "$SCRIPT_DIR/uninstall.sh" "$SKILL_DIR/uninstall.sh" 2>/dev/null && chmod +x "$SKILL_DIR/uninstall.sh" || true
   # Refresh the Claude Code slash command file (was missed in earlier --update flows).
   CC_COMMANDS_DIR="$HOME/.claude/commands"
   if [ -d "$CC_COMMANDS_DIR" ] && [ -f "$CC_COMMANDS_DIR/$SKILL_NAME.md" ]; then
@@ -357,6 +362,11 @@ cp -R "$SCRIPT_DIR/scripts/." "$SKILL_DIR/scripts/"
 # dropped in and their db/trusted-plugins opt-ins.
 mkdir -p "$SKILL_DIR/plugins"
 cp "$SCRIPT_DIR/plugins/README.md" "$SKILL_DIR/plugins/README.md" 2>/dev/null || true
+# Ship uninstall.sh alongside the skill itself — npx/curl installs fetch a
+# temp checkout that gets deleted right after install, so without this copy
+# those users would have no local uninstaller to run later (only a manual
+# `git clone` checkout would). See the README's Uninstall section.
+cp "$SCRIPT_DIR/uninstall.sh" "$SKILL_DIR/uninstall.sh" 2>/dev/null && chmod +x "$SKILL_DIR/uninstall.sh" || true
 
 cp "$SCRIPT_DIR/openai.yaml" "$SKILL_DIR/agents/openai.yaml" 2>/dev/null || true
 chmod +x "$SKILL_DIR/scripts/"*.sh

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 REF="${AGMSG_REF:-main}"
 
 TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
 if git clone --depth 1 --branch "$REF" https://github.com/fujibee/agmsg.git "$TMP/agmsg" 2>/dev/null; then
   :
 elif command -v curl >/dev/null 2>&1 && command -v tar >/dev/null 2>&1; then
@@ -18,9 +20,13 @@ elif command -v curl >/dev/null 2>&1 && command -v tar >/dev/null 2>&1; then
   # already tolerates running from a non-git tarball checkout (see its
   # provenance-version comment), so no changes needed there.
   echo "agmsg: git clone unavailable/failed — falling back to a tarball download" >&2
+  # A failed git clone can still leave a partial $TMP/agmsg behind (git
+  # creates the destination dir before it can fail) — clear it so the
+  # tarball's extracted dir moves cleanly into place instead of nesting
+  # inside the leftover directory.
+  rm -rf "$TMP/agmsg"
   if ! curl -fsSL "https://github.com/fujibee/agmsg/archive/$REF.tar.gz" | tar -xz -C "$TMP" 2>/dev/null; then
     echo "agmsg: failed to download tarball for ref '$REF' from https://github.com/fujibee/agmsg" >&2
-    rm -rf "$TMP"
     exit 1
   fi
   # GitHub extracts to a single top-level "agmsg-<ref>" directory (slashes in
@@ -28,14 +34,11 @@ elif command -v curl >/dev/null 2>&1 && command -v tar >/dev/null 2>&1; then
   extracted="$(find "$TMP" -mindepth 1 -maxdepth 1 -type d -name 'agmsg-*' | head -1)"
   if [ -z "$extracted" ]; then
     echo "agmsg: tarball downloaded but no agmsg-* directory was found inside it" >&2
-    rm -rf "$TMP"
     exit 1
   fi
   mv "$extracted" "$TMP/agmsg"
 else
   echo "agmsg: failed to clone ref '$REF' from https://github.com/fujibee/agmsg.git (git unavailable, and no curl+tar to fall back to)" >&2
-  rm -rf "$TMP"
   exit 1
 fi
 "$TMP/agmsg/install.sh" "$@"
-rm -rf "$TMP"

--- a/setup.sh
+++ b/setup.sh
@@ -9,8 +9,31 @@ set -euo pipefail
 REF="${AGMSG_REF:-main}"
 
 TMP=$(mktemp -d)
-if ! git clone --depth 1 --branch "$REF" https://github.com/fujibee/agmsg.git "$TMP/agmsg" 2>/dev/null; then
-  echo "agmsg: failed to clone ref '$REF' from https://github.com/fujibee/agmsg.git" >&2
+if git clone --depth 1 --branch "$REF" https://github.com/fujibee/agmsg.git "$TMP/agmsg" 2>/dev/null; then
+  :
+elif command -v curl >/dev/null 2>&1 && command -v tar >/dev/null 2>&1; then
+  # No git (or the clone failed for some other reason, e.g. no network path to
+  # git's protocol) — fall back to a plain tarball download so a machine with
+  # no git at all (a fresh, non-developer Mac) can still install. install.sh
+  # already tolerates running from a non-git tarball checkout (see its
+  # provenance-version comment), so no changes needed there.
+  echo "agmsg: git clone unavailable/failed — falling back to a tarball download" >&2
+  if ! curl -fsSL "https://github.com/fujibee/agmsg/archive/$REF.tar.gz" | tar -xz -C "$TMP" 2>/dev/null; then
+    echo "agmsg: failed to download tarball for ref '$REF' from https://github.com/fujibee/agmsg" >&2
+    rm -rf "$TMP"
+    exit 1
+  fi
+  # GitHub extracts to a single top-level "agmsg-<ref>" directory (slashes in
+  # <ref> become dashes) — find it rather than hardcoding the exact name.
+  extracted="$(find "$TMP" -mindepth 1 -maxdepth 1 -type d -name 'agmsg-*' | head -1)"
+  if [ -z "$extracted" ]; then
+    echo "agmsg: tarball downloaded but no agmsg-* directory was found inside it" >&2
+    rm -rf "$TMP"
+    exit 1
+  fi
+  mv "$extracted" "$TMP/agmsg"
+else
+  echo "agmsg: failed to clone ref '$REF' from https://github.com/fujibee/agmsg.git (git unavailable, and no curl+tar to fall back to)" >&2
   rm -rf "$TMP"
   exit 1
 fi

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -45,6 +45,21 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "install: ships an executable uninstall.sh so npx/curl installs have one to run later" {
+  # setup.sh's temp checkout is deleted right after install, so a copy inside
+  # the skill dir is the only uninstaller npx/curl-installed users ever have.
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  [ -x "$SK/uninstall.sh" ]
+  diff "$REPO_ROOT/uninstall.sh" "$SK/uninstall.sh"
+}
+
+@test "install: --update refreshes uninstall.sh even if it went missing" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  rm -f "$SK/uninstall.sh"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  [ -x "$SK/uninstall.sh" ]
+}
+
 @test "install: --update --cmd updates the named skill even when a backup skill exists" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
   local backup="$FAKE_HOME/.agents/skills/agmsg.backup-keep"

--- a/tests/test_setup.bats
+++ b/tests/test_setup.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+
+# setup.sh is the bootstrapper both `npx agmsg` and the README's
+# `curl .../main/setup.sh | bash` path run: it fetches the repo (git clone,
+# with a curl+tar tarball fallback for machines with no git — see #172-adjacent
+# git-less-install gap) into a temp dir and hands off to install.sh. These
+# tests stub git/curl/tar so no real network call happens and the fetch
+# outcome is deterministic; install.sh's own behavior is already covered by
+# test_install.bats, so the fake install.sh here just records that it ran.
+
+load test_helper
+
+setup() {
+  export REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  export FAKE_HOME="$(mktemp -d)"
+  export STUB_BIN="$(mktemp -d)"
+
+  # A fake install.sh that proves setup.sh handed off to *some* checkout
+  # rather than asserting on install.sh's real behavior (covered elsewhere).
+  read -r -d '' FAKE_INSTALL <<'EOF' || true
+#!/usr/bin/env bash
+echo "FAKE_INSTALL_RAN $*"
+EOF
+  export FAKE_INSTALL
+}
+
+teardown() {
+  rm -rf "$FAKE_HOME" "$STUB_BIN"
+}
+
+stub_git_success() {
+  cat > "$STUB_BIN/git" <<EOF
+#!/usr/bin/env bash
+dest="\${@: -1}"
+mkdir -p "\$dest"
+printf '%s\n' "\$FAKE_INSTALL" > "\$dest/install.sh"
+chmod +x "\$dest/install.sh"
+exit 0
+EOF
+  chmod +x "$STUB_BIN/git"
+}
+
+stub_git_fail() {
+  cat > "$STUB_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$STUB_BIN/git"
+}
+
+stub_curl_marker() {
+  # Records that it was invoked (used to prove it's skipped on the git-success path)
+  cat > "$STUB_BIN/curl" <<EOF
+#!/usr/bin/env bash
+touch "$STUB_BIN/.curl-was-called"
+exit 1
+EOF
+  chmod +x "$STUB_BIN/curl"
+}
+
+# Builds a real gzipped tarball fixture (top-level "agmsg-<ref>/install.sh")
+# and stubs curl to just cat it to stdout instead of hitting the network.
+stub_curl_tarball_success() {
+  local ref="${1:-main}"
+  local fixture_dir="$STUB_BIN/fixture"
+  mkdir -p "$fixture_dir/agmsg-$ref"
+  printf '%s\n' "$FAKE_INSTALL" > "$fixture_dir/agmsg-$ref/install.sh"
+  chmod +x "$fixture_dir/agmsg-$ref/install.sh"
+  tar -C "$fixture_dir" -czf "$STUB_BIN/fixture.tar.gz" "agmsg-$ref"
+
+  cat > "$STUB_BIN/curl" <<EOF
+#!/usr/bin/env bash
+cat "$STUB_BIN/fixture.tar.gz"
+EOF
+  chmod +x "$STUB_BIN/curl"
+}
+
+stub_curl_tarball_malformed() {
+  # A tarball with no top-level agmsg-* dir at all.
+  local fixture_dir="$STUB_BIN/fixture"
+  mkdir -p "$fixture_dir/not-agmsg"
+  touch "$fixture_dir/not-agmsg/file"
+  tar -C "$fixture_dir" -czf "$STUB_BIN/fixture.tar.gz" "not-agmsg"
+
+  cat > "$STUB_BIN/curl" <<EOF
+#!/usr/bin/env bash
+cat "$STUB_BIN/fixture.tar.gz"
+exit 0
+EOF
+  chmod +x "$STUB_BIN/curl"
+}
+
+stub_curl_fail() {
+  cat > "$STUB_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 22
+EOF
+  chmod +x "$STUB_BIN/curl"
+}
+
+@test "setup: uses git clone when git succeeds, never touches curl" {
+  stub_git_success
+  stub_curl_marker
+
+  run env PATH="$STUB_BIN:/usr/bin:/bin" HOME="$FAKE_HOME" \
+    bash "$REPO_ROOT/setup.sh" --cmd agmsg-test
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"FAKE_INSTALL_RAN --cmd agmsg-test"* ]]
+  [ ! -f "$STUB_BIN/.curl-was-called" ]
+}
+
+@test "setup: falls back to tarball download when git clone fails" {
+  stub_git_fail
+  stub_curl_tarball_success main
+
+  run env PATH="$STUB_BIN:/usr/bin:/bin" HOME="$FAKE_HOME" AGMSG_REF=main \
+    bash "$REPO_ROOT/setup.sh" --cmd agmsg-test
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"falling back to a tarball download"* ]]
+  [[ "$output" == *"FAKE_INSTALL_RAN --cmd agmsg-test"* ]]
+}
+
+@test "setup: tarball fallback respects AGMSG_REF" {
+  stub_git_fail
+  stub_curl_tarball_success v1.1.3
+
+  run env PATH="$STUB_BIN:/usr/bin:/bin" HOME="$FAKE_HOME" AGMSG_REF=v1.1.3 \
+    bash "$REPO_ROOT/setup.sh" --cmd agmsg-test
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"FAKE_INSTALL_RAN --cmd agmsg-test"* ]]
+}
+
+@test "setup: fails cleanly when git is unavailable and there is no curl/tar" {
+  # A PATH with only the bare minimum (mktemp, rm) — no git, curl, or tar —
+  # so the real system binaries can't leak in via a fallback PATH entry.
+  local bare_bin="$(mktemp -d)"
+  ln -s "$(command -v bash)" "$bare_bin/bash"
+  ln -s "$(command -v mktemp)" "$bare_bin/mktemp"
+  ln -s "$(command -v rm)" "$bare_bin/rm"
+
+  run env -i PATH="$bare_bin" HOME="$FAKE_HOME" \
+    bash "$REPO_ROOT/setup.sh" --cmd agmsg-test
+  rm -rf "$bare_bin"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"git unavailable, and no curl+tar to fall back to"* ]]
+}
+
+@test "setup: fails cleanly when the tarball download itself fails" {
+  stub_git_fail
+  stub_curl_fail
+
+  run env PATH="$STUB_BIN:/usr/bin:/bin" HOME="$FAKE_HOME" \
+    bash "$REPO_ROOT/setup.sh" --cmd agmsg-test
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to download tarball"* ]]
+}
+
+@test "setup: fails cleanly when the tarball has no agmsg-* top-level dir" {
+  stub_git_fail
+  stub_curl_tarball_malformed
+
+  run env PATH="$STUB_BIN:/usr/bin:/bin" HOME="$FAKE_HOME" \
+    bash "$REPO_ROOT/setup.sh" --cmd agmsg-test
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no agmsg-* directory was found"* ]]
+}

--- a/tests/test_setup.bats
+++ b/tests/test_setup.bats
@@ -48,6 +48,19 @@ EOF
   chmod +x "$STUB_BIN/git"
 }
 
+# Real git creates the clone destination dir before it can fail partway
+# through (e.g. a bad ref after the initial mkdir). Reproduces that leftover.
+stub_git_fail_partial_dest() {
+  cat > "$STUB_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+dest="${@: -1}"
+mkdir -p "$dest"
+touch "$dest/.git-partial-leftover"
+exit 1
+EOF
+  chmod +x "$STUB_BIN/git"
+}
+
 stub_curl_marker() {
   # Records that it was invoked (used to prove it's skipped on the git-success path)
   cat > "$STUB_BIN/curl" <<EOF
@@ -96,6 +109,24 @@ stub_curl_fail() {
 exit 22
 EOF
   chmod +x "$STUB_BIN/curl"
+}
+
+# install.sh that reports its own resolved directory then fails, so a test
+# can find $TMP (its parent) and assert the EXIT trap cleaned it up.
+stub_git_success_failing_install() {
+  cat > "$STUB_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+dest="${@: -1}"
+mkdir -p "$dest"
+cat > "$dest/install.sh" <<'INNER'
+#!/usr/bin/env bash
+echo "INSTALL_DIR=$(cd "$(dirname "$0")" && pwd)"
+exit 3
+INNER
+chmod +x "$dest/install.sh"
+exit 0
+EOF
+  chmod +x "$STUB_BIN/git"
 }
 
 @test "setup: uses git clone when git succeeds, never touches curl" {
@@ -163,4 +194,39 @@ EOF
     bash "$REPO_ROOT/setup.sh" --cmd agmsg-test
   [ "$status" -ne 0 ]
   [[ "$output" == *"no agmsg-* directory was found"* ]]
+}
+
+@test "setup: tarball fallback works even if a failed git clone left a partial dest dir (#296 co1 finding)" {
+  stub_git_fail_partial_dest
+  stub_curl_tarball_success main
+
+  run env PATH="$STUB_BIN:/usr/bin:/bin" HOME="$FAKE_HOME" AGMSG_REF=main \
+    bash "$REPO_ROOT/setup.sh" --cmd agmsg-test
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"FAKE_INSTALL_RAN --cmd agmsg-test"* ]]
+}
+
+@test "setup: tarball fallback resolves GitHub's dash-converted dir name for a slash-containing AGMSG_REF" {
+  stub_git_fail
+  # GitHub's archive endpoint converts slashes in the ref to dashes for the
+  # top-level extracted directory name (e.g. feature/foo -> agmsg-feature-foo).
+  stub_curl_tarball_success "feature-foo"
+
+  run env PATH="$STUB_BIN:/usr/bin:/bin" HOME="$FAKE_HOME" AGMSG_REF="feature/foo" \
+    bash "$REPO_ROOT/setup.sh" --cmd agmsg-test
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"FAKE_INSTALL_RAN --cmd agmsg-test"* ]]
+}
+
+@test "setup: cleans up the temp dir (EXIT trap) even when install.sh fails" {
+  stub_git_success_failing_install
+
+  run env PATH="$STUB_BIN:/usr/bin:/bin" HOME="$FAKE_HOME" \
+    bash "$REPO_ROOT/setup.sh" --cmd agmsg-test
+  [ "$status" -eq 3 ]
+  local install_dir tmp_dir
+  install_dir="$(echo "$output" | sed -n 's/^INSTALL_DIR=//p')"
+  [ -n "$install_dir" ]
+  tmp_dir="$(dirname "$install_dir")"
+  [ ! -d "$tmp_dir" ]
 }


### PR DESCRIPTION
## Summary
- `setup.sh` (the bootstrapper both `npx agmsg` and the README's `curl | bash` install path use) hard-required `git clone` with no fallback — a machine with no git couldn't install at all.
- Adds a curl+tar tarball-download fallback that kicks in automatically when git is missing or the clone fails, downloading `https://github.com/fujibee/agmsg/archive/$REF.tar.gz` instead.
- If neither git nor curl+tar is available, fails with a clear error instead of a confusing one.
- Fixed two issues co1 found in review: a partial git-clone destination could break the tarball fallback's `mv` (nested instead of replaced), and `$TMP` wasn't cleaned up on early-exit paths — added an `EXIT` trap.
- Also ships `uninstall.sh` inside every install (skill dir copy), since npx/curl installs delete their temp checkout right after `install.sh` runs and previously left no local uninstaller behind.

## Test plan
- [x] `bats tests/test_setup.bats` — 9 tests (git-success path skips curl, tarball fallback on git failure, AGMSG_REF respected incl. slash-containing refs, clean failure with no git/curl/tar, clean failure on download error, clean failure on malformed tarball, partial-clone-leftover repro, EXIT-trap cleanup)
- [x] `bats tests/test_install.bats` — full regression pass (45 tests) plus 2 new tests for the uninstall.sh copy
- [x] Manual end-to-end verification against the real GitHub repo: forced git out of PATH, confirmed the fallback downloads+extracts+installs successfully; confirmed the normal git-clone path still installs successfully; confirmed install → uninstall.sh --yes round-trips cleanly