### PR TITLE
fix(app): v0.1.2 — Windows bash path bug, banner overlap, update feedback

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -193,7 +193,7 @@ jobs:
           name: agmsg-app-windows
           path: |
             app/src-tauri/target/release/bundle/msi/*.msi
+            app/src-tauri/target/release/bundle/msi/*.msi.sig
             app/src-tauri/target/release/bundle/nsis/*.exe
-            app/src-tauri/target/release/bundle/nsis/*.zip
-            app/src-tauri/target/release/bundle/nsis/*.zip.sig
+            app/src-tauri/target/release/bundle/nsis/*.exe.sig
           if-no-files-found: warn

--- a/app/README.md
+++ b/app/README.md
@@ -106,6 +106,12 @@ Auto-update is wired up via `tauri-plugin-updater`, checked silently on launch a
 on-demand via **agmsg → Check for Updates…**. The private signing key lives in
 the worktree-root `.secrets/` locally (never committed) and as the
 `TAURI_SIGNING_PRIVATE_KEY`/`TAURI_SIGNING_PRIVATE_KEY_PASSWORD` secrets in CI.
+`TAURI_SIGNING_PRIVATE_KEY` must be the **decoded** minisign key text itself
+(two lines, starting with `untrusted comment:`) — not the base64-encoded form
+`.secrets/agmsg-app-updater.key` is stored as on disk. Feeding the encoded file
+straight into the secret fails with "failed to decode secret key: Missing
+comment in secret key" the moment something (e.g. `createUpdaterArtifacts`)
+actually exercises it, which can go unnoticed for a while if nothing does.
 
 The updater endpoint points at a **fixed tag**, `app-latest`
 (`releases/download/app-latest/latest.json`) — deliberately NOT

--- a/app/src-tauri/src/agmsg.rs
+++ b/app/src-tauri/src/agmsg.rs
@@ -18,6 +18,38 @@ fn agmsg_base() -> PathBuf {
     PathBuf::from(home).join(".agents/skills/agmsg")
 }
 
+/// Matches agmsg-core's own scripts/lib/storage.sh convention (`cygpath -m`:
+/// drive-letter form with forward slashes, e.g. "C:/Users/name/..."). A
+/// standalone string transform (rather than inline in bash_path below) so
+/// it's testable on any host platform, not just Windows — its only
+/// non-test caller is behind a Windows-only cfg, hence the dead_code
+/// allowance on other platforms.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn to_bash_slashes(s: &str) -> String {
+    let s = s.strip_prefix(r"\\?\").unwrap_or(s);
+    s.replace('\\', "/")
+}
+
+/// Converts a native path into a form Git Bash on Windows accepts as an
+/// argument. Without this, a raw Windows path handed to bash.exe has its
+/// backslashes silently eaten by MSYS's argv parsing (backslash is an
+/// escape character there) — "C:\Users\x\y.sh" arrives as "C:Usersxy.sh" and
+/// bash reports "No such file or directory". Also strips the `\\?\`
+/// extended-length prefix Path::canonicalize / Tauri's resource_dir() can
+/// return, which bash doesn't understand either. Every path this app hands
+/// to bash (install.sh, agmsg-core scripts, ...) must go through this —
+/// found in review after first-run install and every agmsg-core script call
+/// (join.sh, send.sh, ...) failed identically on real Windows hardware.
+#[cfg(target_os = "windows")]
+fn bash_path(p: &std::path::Path) -> String {
+    to_bash_slashes(&p.to_string_lossy())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn bash_path(p: &std::path::Path) -> String {
+    p.to_string_lossy().into_owned()
+}
+
 fn db_path() -> PathBuf {
     agmsg_base().join("db/messages.db")
 }
@@ -242,7 +274,7 @@ pub fn agmsg_install(app: AppHandle) -> Result<(), String> {
         .join("agmsg-core")
         .join("install.sh");
     let output = std::process::Command::new("bash")
-        .arg(&install_sh)
+        .arg(bash_path(&install_sh))
         .output()
         .map_err(|e| e.to_string())?;
     if output.status.success() {
@@ -325,7 +357,7 @@ pub fn agmsg_update_core(app: AppHandle) -> Result<(), String> {
         .join("agmsg-core")
         .join("install.sh");
     let output = std::process::Command::new("bash")
-        .arg(&install_sh)
+        .arg(bash_path(&install_sh))
         .args(["--cmd", "agmsg", "--update"])
         .output()
         .map_err(|e| e.to_string())?;
@@ -407,7 +439,7 @@ pub fn agmsg_messages(
 fn run_script(name: &str, args: &[&str]) -> Result<String, String> {
     let script = agmsg_base().join("scripts").join(name);
     let output = std::process::Command::new("bash")
-        .arg(script)
+        .arg(bash_path(&script))
         .args(args)
         .output()
         .map_err(|e| e.to_string())?;
@@ -540,7 +572,34 @@ pub fn start_watcher(app: AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_semver;
+    use super::{parse_semver, to_bash_slashes};
+
+    #[test]
+    fn strips_verbatim_prefix_and_flips_slashes() {
+        // The exact shape resource_dir()/canonicalize() produced on the
+        // Windows hardware where this was found.
+        assert_eq!(
+            to_bash_slashes(r"\\?\C:\Users\koichi\AppData\Local\agmsg\agmsg-core\install.sh"),
+            "C:/Users/koichi/AppData/Local/agmsg/agmsg-core/install.sh",
+        );
+    }
+
+    #[test]
+    fn flips_slashes_in_mixed_paths() {
+        // agmsg_base() joins a literal ".agents/skills/agmsg" (forward
+        // slashes) onto a platform-joined home dir (backslashes on
+        // Windows) — the real path run_script() builds is a mix of both.
+        assert_eq!(
+            to_bash_slashes(r"C:\Users\koichi\.agents/skills/agmsg\scripts\join.sh"),
+            "C:/Users/koichi/.agents/skills/agmsg/scripts/join.sh",
+        );
+    }
+
+    #[test]
+    fn is_a_no_op_on_an_already_posix_style_path() {
+        assert_eq!(to_bash_slashes("/Users/koichi/.agents/skills/agmsg/scripts/join.sh"),
+            "/Users/koichi/.agents/skills/agmsg/scripts/join.sh");
+    }
 
     #[test]
     fn parses_clean_semver() {

--- a/app/src-tauri/src/agmsg.rs
+++ b/app/src-tauri/src/agmsg.rs
@@ -486,7 +486,10 @@ pub fn agmsg_join(
     agent_type: String,
     project: String,
 ) -> Result<(), String> {
+    // create_dir_all takes the native form; bash_path is only for the value
+    // that crosses into a bash argument below (join.sh's $4).
     std::fs::create_dir_all(&project).map_err(|e| e.to_string())?;
+    let project = bash_path(std::path::Path::new(&project));
     run_script("join.sh", &[&team, &name, &agent_type, &project]).map(|_| ())
 }
 
@@ -511,6 +514,7 @@ pub fn agmsg_leave(team: String, name: String) -> Result<(), String> {
 /// which a static type.conf flag can't see).
 #[tauri::command]
 pub fn agmsg_delivery_mode(agent_type: String, project: String) -> Result<String, String> {
+    let project = bash_path(std::path::Path::new(&project));
     let output = run_script("delivery.sh", &["status", &agent_type, &project])?;
     for line in output.lines() {
         if let Some(mode) = line.strip_prefix("mode:") {
@@ -599,6 +603,16 @@ mod tests {
     fn is_a_no_op_on_an_already_posix_style_path() {
         assert_eq!(to_bash_slashes("/Users/koichi/.agents/skills/agmsg/scripts/join.sh"),
             "/Users/koichi/.agents/skills/agmsg/scripts/join.sh");
+    }
+
+    #[test]
+    fn flips_slashes_in_a_project_dir_argument() {
+        // Not just the script path — join.sh's $4 and delivery.sh's $3 are
+        // project directories that cross the same bash argv boundary.
+        assert_eq!(
+            to_bash_slashes(r"C:\Users\koichi\agmsg-agents\alice"),
+            "C:/Users/koichi/agmsg-agents/alice",
+        );
     }
 
     #[test]

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -29,12 +29,15 @@ body,
   font: 13px/1.5 -apple-system, "SF Pro Text", Helvetica, Arial, sans-serif;
 }
 
+/* These sit at the very top of the window, same row as the overlaid macOS
+   traffic lights (titleBarStyle: Overlay) — left padding clears them
+   horizontally, same idea as .sidebar-head's top padding does vertically. */
 .startup-error-banner {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 8px 14px;
+  padding: 8px 14px 8px 80px;
   background: #4a1f1f;
   color: #ffd7d7;
   font-size: 12px;
@@ -53,7 +56,7 @@ body,
 .startup-installing-banner {
   display: flex;
   align-items: center;
-  padding: 8px 14px;
+  padding: 8px 14px 8px 80px;
   background: var(--panel-2);
   color: var(--muted);
   font-size: 12px;
@@ -65,7 +68,7 @@ body,
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 8px 14px;
+  padding: 8px 14px 8px 80px;
   background: #4a3a1f;
   color: #ffe7b3;
   font-size: 12px;
@@ -75,6 +78,27 @@ body,
   background: transparent;
   border: 1px solid #ffe7b3;
   color: #ffe7b3;
+  border-radius: 4px;
+  padding: 2px 8px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.startup-success-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 14px 8px 80px;
+  background: #1f4a2c;
+  color: #c8f7d4;
+  font-size: 12px;
+  border-bottom: 1px solid #2b6b41;
+}
+.startup-success-banner button {
+  background: transparent;
+  border: 1px solid #c8f7d4;
+  color: #c8f7d4;
   border-radius: 4px;
   padding: 2px 8px;
   cursor: pointer;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -141,6 +141,10 @@ export default function App() {
   // Never updated automatically: only ever from the user clicking Update.
   const [coreOutdated, setCoreOutdated] = useState<{ installed: string | null; pinned: string } | null>(null);
   const [updatingCore, setUpdatingCore] = useState(false);
+  // The version just updated to, shown as a confirmation banner — Update now
+  // otherwise completes silently (the outdated banner just disappears),
+  // which read as "did that actually work?" in testing.
+  const [coreUpdateSucceeded, setCoreUpdateSucceeded] = useState<string | null>(null);
   const [teams, setTeams] = useState<string[]>([]);
   const [team, setTeam] = useState<string>("");
   const [members, setMembers] = useState<Member[]>([]);
@@ -818,10 +822,12 @@ export default function App() {
           </span>
           <button
             onClick={async () => {
+              const targetVersion = coreOutdated.pinned;
               setUpdatingCore(true);
               try {
                 await invoke("agmsg_update_core");
                 setCoreOutdated(null);
+                setCoreUpdateSucceeded(targetVersion);
                 await loadTeams();
               } catch (err) {
                 console.error(err);
@@ -838,6 +844,12 @@ export default function App() {
       {updatingCore && (
         <div className="startup-installing-banner">
           <span>{t("startupError.updating")}</span>
+        </div>
+      )}
+      {coreUpdateSucceeded && (
+        <div className="startup-success-banner">
+          <span>{t("startupError.updateSucceeded", { version: coreUpdateSucceeded })}</span>
+          <button onClick={() => setCoreUpdateSucceeded(null)}>{t("startupError.dismiss")}</button>
         </div>
       )}
       {startupError && (

--- a/app/src/i18n/locales/de.json
+++ b/app/src/i18n/locales/de.json
@@ -15,6 +15,7 @@
     "updateNow": "Jetzt aktualisieren",
     "updating": "agmsg wird aktualisiert…",
     "updateFailed": "agmsg konnte nicht aktualisiert werden: {{error}}",
+    "updateSucceeded": "agmsg-CLI wurde auf {{version}} aktualisiert.",
     "dismiss": "Verwerfen"
   },
   "sidebar": {

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -18,6 +18,7 @@
     "updateNow": "Update now",
     "updating": "Updating agmsg…",
     "updateFailed": "Couldn't update agmsg: {{error}}",
+    "updateSucceeded": "Updated agmsg CLI to {{version}}.",
     "dismiss": "Dismiss"
   },
   "sidebar": {

--- a/app/src/i18n/locales/es.json
+++ b/app/src/i18n/locales/es.json
@@ -15,6 +15,7 @@
     "updateNow": "Actualizar ahora",
     "updating": "Actualizando agmsg…",
     "updateFailed": "No se pudo actualizar agmsg: {{error}}",
+    "updateSucceeded": "Se actualizó el CLI de agmsg a {{version}}.",
     "dismiss": "Descartar"
   },
   "sidebar": {

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -15,6 +15,7 @@
     "updateNow": "Mettre à jour",
     "updating": "Mise à jour d'agmsg…",
     "updateFailed": "Impossible de mettre à jour agmsg : {{error}}",
+    "updateSucceeded": "CLI agmsg mis à jour vers {{version}}.",
     "dismiss": "Ignorer"
   },
   "sidebar": {

--- a/app/src/i18n/locales/ja.json
+++ b/app/src/i18n/locales/ja.json
@@ -15,6 +15,7 @@
     "updateNow": "今すぐアップデート",
     "updating": "agmsgをアップデート中…",
     "updateFailed": "agmsgのアップデートに失敗しました: {{error}}",
+    "updateSucceeded": "agmsg CLIを{{version}}にアップデートしました。",
     "dismiss": "閉じる"
   },
   "sidebar": {

--- a/app/src/i18n/locales/ko.json
+++ b/app/src/i18n/locales/ko.json
@@ -15,6 +15,7 @@
     "updateNow": "지금 업데이트",
     "updating": "agmsg 업데이트 중…",
     "updateFailed": "agmsg 업데이트에 실패했습니다: {{error}}",
+    "updateSucceeded": "agmsg CLI를 {{version}}(으)로 업데이트했습니다.",
     "dismiss": "닫기"
   },
   "sidebar": {

--- a/app/src/i18n/locales/pt-BR.json
+++ b/app/src/i18n/locales/pt-BR.json
@@ -15,6 +15,7 @@
     "updateNow": "Atualizar agora",
     "updating": "Atualizando o agmsg…",
     "updateFailed": "Não foi possível atualizar o agmsg: {{error}}",
+    "updateSucceeded": "O CLI do agmsg foi atualizado para {{version}}.",
     "dismiss": "Dispensar"
   },
   "sidebar": {

--- a/app/src/i18n/locales/zh-CN.json
+++ b/app/src/i18n/locales/zh-CN.json
@@ -15,6 +15,7 @@
     "updateNow": "立即更新",
     "updating": "正在更新 agmsg…",
     "updateFailed": "无法更新 agmsg：{{error}}",
+    "updateSucceeded": "已将 agmsg CLI 更新到 {{version}}。",
     "dismiss": "关闭"
   },
   "sidebar": {

--- a/app/src/i18n/locales/zh-TW.json
+++ b/app/src/i18n/locales/zh-TW.json
@@ -15,6 +15,7 @@
     "updateNow": "立即更新",
     "updating": "正在更新 agmsg…",
     "updateFailed": "無法更新 agmsg：{{error}}",
+    "updateSucceeded": "已將 agmsg CLI 更新至 {{version}}。",
     "dismiss": "關閉"
   },
   "sidebar": {


### PR DESCRIPTION
## Summary

Real-hardware testing of v0.1.1 (macOS auto-update path + first Windows run) surfaced five issues, all fixed here:

1. **Windows: every Rust→bash invocation failed** (top priority — this broke fresh installs, team creation, and every agmsg-core script call on Windows). MSYS bash's argv parsing treats backslash as an escape character, so an unconverted native Windows path like `C:\Users\x\y.sh` arrives at bash as `C:Usersxy.sh` — "No such file or directory". Tauri's `resource_dir()` also returns a `\\?\` extended-length-prefixed path bash doesn't understand either. Adds `bash_path()`, applied at all three bash invocation sites (`install.sh`, and every `run_script()` call — `join.sh`, `send.sh`, `api.sh` reads, ...), producing the same `C:/Users/...` form agmsg-core's own `scripts/lib/storage.sh` already produces via `cygpath -m` for the identical reason. No-op on non-Windows. 3 new unit tests cover the exact path shapes seen on the hardware where this was found.
2. **Windows CI never uploaded updater artifacts**: the artifact-upload glob looked for `nsis/*.zip(.sig)`, which never matched anything — `createUpdaterArtifacts` actually produces `*.exe.sig`/`*.msi.sig` (confirmed from the app-v0.1.1 CI run's own log).
3. **Startup banners rendered under macOS's overlaid traffic-light window controls** (`titleBarStyle: Overlay`) — add left padding, same idea as `.sidebar-head`'s existing top padding for the same overlay.
4. **"Update now" completed silently** — the outdated-CLI banner just vanished with no confirmation, read as "did that even work?" in testing. Adds a dismissible success banner naming the version just updated to. i18n'd across all 9 languages.
5. **README**: documents the actual root cause of v0.1.1's first CI failure — `TAURI_SIGNING_PRIVATE_KEY` must be the decoded minisign key text, not the base64-encoded form the key file is stored as on disk.

## Verification

- `cargo test` — 7 unit tests (4 existing + 3 new for `bash_path`/`to_bash_slashes`), all pass
- `cargo check`, `pnpm exec tsc --noEmit`, `git diff --check` — all clean
- Verified the Windows-only code path compiles by temporarily forcing its `cfg` on (no cross-compile toolchain available locally)

## Test plan — real-hardware gate before tagging `app-v0.1.2`

Per the process agreed after v0.1.0/v0.1.1: this merges to `main` freely (the app isn't released until a tag is cut), then `app-release.yml` runs via `workflow_dispatch` from `main` for a signed test build, which gets verified on real Windows hardware before any tag:

- [ ] CI required checks pass, static review
- [ ] Uninstall CLI (`uninstall.sh --yes`), launch app → first-run auto-install succeeds
- [ ] Create a team (`join.sh` path)
- [ ] Send as app-user → team room reflects it
- [ ] Check for Updates completes without error