### PR TITLE
fix(app): v0.1.2 round 6 — suppress Windows console window + bash profile delay

### DIFF
--- a/app/src-tauri/src/agmsg.rs
+++ b/app/src-tauri/src/agmsg.rs
@@ -93,7 +93,14 @@ fn resolve_bash() -> Result<PathBuf, String> {
         }
     }
 
-    if let Ok(output) = std::process::Command::new("where").arg("git").output() {
+    let mut where_cmd = std::process::Command::new("where");
+    where_cmd.arg("git");
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        where_cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    if let Ok(output) = where_cmd.output() {
         if output.status.success() {
             if let Some(first_line) = String::from_utf8_lossy(&output.stdout).lines().next() {
                 // git.exe sits at <root>\cmd\git.exe or <root>\bin\git.exe;
@@ -121,6 +128,25 @@ fn resolve_bash() -> Result<PathBuf, String> {
 #[cfg(not(target_os = "windows"))]
 fn resolve_bash() -> Result<PathBuf, String> {
     Ok(PathBuf::from("bash"))
+}
+
+/// A bash Command pre-configured for running agmsg-core scripts: resolved
+/// via resolve_bash() (not a bare "bash" — see there), --noprofile --norc
+/// so it doesn't spend a few seconds sourcing the user's shell profile on
+/// every single call (these scripts don't depend on it, on any platform),
+/// and on Windows CREATE_NO_WINDOW so spawning it doesn't flash a console
+/// window on screen for every command — GUI processes get one by default.
+/// Callers add the script path and its args on top of what this returns.
+fn bash_command() -> Result<std::process::Command, String> {
+    let mut cmd = std::process::Command::new(resolve_bash()?);
+    cmd.args(["--noprofile", "--norc"]);
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    Ok(cmd)
 }
 
 fn db_path() -> PathBuf {
@@ -346,7 +372,7 @@ pub fn agmsg_install(app: AppHandle) -> Result<(), String> {
         .map_err(|e| e.to_string())?
         .join("agmsg-core")
         .join("install.sh");
-    let output = std::process::Command::new(resolve_bash()?)
+    let output = bash_command()?
         .arg(bash_path(&install_sh))
         .output()
         .map_err(|e| e.to_string())?;
@@ -429,7 +455,7 @@ pub fn agmsg_update_core(app: AppHandle) -> Result<(), String> {
         .map_err(|e| e.to_string())?
         .join("agmsg-core")
         .join("install.sh");
-    let output = std::process::Command::new(resolve_bash()?)
+    let output = bash_command()?
         .arg(bash_path(&install_sh))
         .args(["--cmd", "agmsg", "--update"])
         .output()
@@ -511,7 +537,7 @@ pub fn agmsg_messages(
 /// itself. Returns stdout on success, stderr on failure.
 fn run_script(name: &str, args: &[&str]) -> Result<String, String> {
     let script = agmsg_base().join("scripts").join(name);
-    let output = std::process::Command::new(resolve_bash()?)
+    let output = bash_command()?
         .arg(bash_path(&script))
         .args(args)
         .output()


### PR DESCRIPTION
## Summary

Round 6, Windows UX polish after round 5's real-hardware test confirmed everything works functionally (auto-install, team creation, send, the HOME fix — all good). Two issues remained:

- Every command visibly **flashed a console window** — a GUI process spawning a console program (bash.exe) gets one by default on Windows.
- Every command **took 5+ seconds** — bash was sourcing the user's shell profile on every single invocation.

New `bash_command()` applies both fixes at all three bash invocation sites (`agmsg_install`, `agmsg_update_core`, `run_script`) plus `resolve_bash()`'s own internal `where git` lookup:

- `--noprofile --norc` — skips profile/rc sourcing agmsg-core's scripts don't depend on. Verified real script output is unaffected on macOS (a real `api.sh get teams` call via the new `bash_command()` ran correctly in ~0.04s locally, consistent with profile-loading being the actual multi-second cost on Windows).
- `CREATE_NO_WINDOW` (`0x08000000`) via `CommandExt::creation_flags`, cfg'd to Windows only — the flag and trait don't exist on other targets.

## Verification

- `cargo test` — 9 unit tests (unchanged from #309, this fix doesn't touch path-conversion logic), all pass
- `cargo check`, `pnpm exec tsc --noEmit` — clean
- Ran a real `api.sh get teams` call through `bash_command()` locally on macOS to confirm `--noprofile --norc` doesn't break real script output
- The Windows-only `CommandExt`/`creation_flags` code can only be verified by an actual Windows compile (no cross-compile toolchain available locally, and `std::os::windows` genuinely doesn't exist when compiling for a non-Windows target regardless of local `cfg` tricks) — relying on Windows CI + the real-hardware gate for this one

## Test plan — same real-hardware gate, expected final round before tagging

- [ ] CI required checks pass (including the Windows job compiling `CommandExt::creation_flags` for real), static review
- [ ] `workflow_dispatch` build from `main` → koit verifies on real Windows hardware: no console flash, commands feel instant, same functional checklist as round 5
- [ ] If this passes: cut `app-v0.1.2`