### PR TITLE
fix(app): v0.1.3 — import login shell PATH so agent spawn works from Finder

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agmsg-app",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agmsg-app"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agmsg-app"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -85,13 +85,15 @@ fn import_login_shell_path() {
         }
     };
     let stdout = String::from_utf8_lossy(&output.stdout);
-    match stdout.find(START).zip(stdout.find(END)) {
-        Some((s, e)) if s + START.len() <= e => {
-            let path = &stdout[s + START.len()..e];
-            if !path.is_empty() {
-                std::env::set_var("PATH", path);
-            }
-        }
+    // Look for END strictly after START, not just anywhere in stdout — shell
+    // startup noise printing the literal END text before our own marker
+    // output would otherwise false-match against it.
+    let parsed = stdout.find(START).and_then(|s| {
+        let after_start = s + START.len();
+        stdout[after_start..].find(END).map(|e| &stdout[after_start..after_start + e])
+    });
+    match parsed {
+        Some(path) if !path.is_empty() => std::env::set_var("PATH", path),
         _ => eprintln!("warning: couldn't parse login shell PATH output from {shell}"),
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -56,6 +56,46 @@ fn save_zoom(app: &AppHandle, zoom: f64) {
     let _ = std::fs::write(path, serde_json::json!({ "zoom": zoom }).to_string());
 }
 
+/// Replaces this process's own PATH with the one the user's login shell
+/// resolves — a Finder/LaunchServices-launched GUI app gets the OS's
+/// minimal default PATH, missing anything the shell profile adds (Homebrew,
+/// ~/.claude/local, nvm, etc.), so every agent spawn (pty::pty_spawn) fails
+/// with "not found in PATH" despite working fine from a terminal-launched
+/// `tauri dev`, which inherits the terminal's own full PATH. Must run
+/// before anything could spawn a pane. Windows doesn't have this problem
+/// (PATH comes from the registry regardless of launch method), so this is
+/// only ever called under cfg(unix).
+///
+/// Runs the shell with -i (interactive) as well as -l (login): some PATH
+/// setups (e.g. nvm) only run in .zshrc/.bashrc, which plain -l wouldn't
+/// source. An interactive shell can print other things to stdout first
+/// (MOTD, prompts) — wrapping the $PATH readout in unique markers and
+/// extracting just what's between them keeps that noise from corrupting it.
+#[cfg(unix)]
+fn import_login_shell_path() {
+    const START: &str = "__AGMSG_PATH_START__";
+    const END: &str = "__AGMSG_PATH_END__";
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".into());
+    let script = format!("printf '{START}%s{END}' \"$PATH\"");
+    let output = match std::process::Command::new(&shell).args(["-ilc", &script]).output() {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("warning: couldn't run login shell ({shell}) to import PATH: {e}");
+            return;
+        }
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    match stdout.find(START).zip(stdout.find(END)) {
+        Some((s, e)) if s + START.len() <= e => {
+            let path = &stdout[s + START.len()..e];
+            if !path.is_empty() {
+                std::env::set_var("PATH", path);
+            }
+        }
+        _ => eprintln!("warning: couldn't parse login shell PATH output from {shell}"),
+    }
+}
+
 /// Build the application menu in `lang`. macOS derives the default menu's
 /// About/Hide/Quit labels from the crate name (which can't contain a space),
 /// so we define them explicitly to read "agmsg" (matching productName) and
@@ -286,6 +326,17 @@ pub fn run() {
         })
         .manage(PtyManager::default())
         .setup(|app| {
+            // A Finder/LaunchServices-launched GUI app gets the OS's minimal
+            // default PATH, missing anything a login shell adds (Homebrew,
+            // ~/.claude/local, etc.) — every agent spawn (pty::pty_spawn)
+            // fails with "not found in PATH" despite working fine from a
+            // terminal-launched `tauri dev`, which inherits the terminal's
+            // full PATH. Must run before anything could spawn a pane.
+            // Windows doesn't have this problem (PATH comes from the
+            // registry regardless of launch method), hence unix-only.
+            #[cfg(unix)]
+            import_login_shell_path();
+
             // Restore the zoom level saved on the last quit/change — .manage()
             // above only had 1.0 to work with (no AppHandle yet to read the
             // config file at that point).

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "agmsg",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "cc.agmsg.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

koit's real-hardware dogfooding of the packaged, Finder-launched v0.1.2 build hit `Failed to start "claude": Unable to spawn claude because it doesn't exist on the filesystem and was not found in PATH` — same for codex.

Root cause: a Finder/LaunchServices-launched GUI app (not a terminal) gets the OS's minimal default PATH, missing anything the login shell adds (Homebrew, `~/.claude/local`, nvm, etc.). Every agent spawn (`pty::pty_spawn`) fails as a result, despite working fine from a terminal-launched `tauri dev`, which inherits the terminal's own full PATH. Windows doesn't have this problem (PATH comes from the registry regardless of launch method), so the fix only runs under `cfg(unix)`.

Ruled out a regression first: confirmed via `app-v0.1.1..app-v0.1.2`'s diff that `pty.rs` itself was untouched across those releases (`git diff app-v0.1.1 app-v0.1.2 -- app/src-tauri/src/pty.rs` is empty) — this was always latent, just never exercised before since prior testing was dev-mode only.

Tried the `fix-path-env` crate first per the initial suggestion, but it doesn't exist on crates.io under that name (or any close variant I could find) — replaced with a small self-contained `import_login_shell_path()`:
- Resolves `$SHELL`, runs it with `-il` (interactive + login — some PATH setups like nvm only run in `.zshrc`/`.bashrc` rather than a login shell's profile)
- Extracts `$PATH` from between unique markers wrapped around the readout, so other stdout noise a real interactive shell can print (MOTD, etc.) doesn't corrupt the result

Also bumps the version to 0.1.3.

## Verification

- `cargo check`, `pnpm exec tsc --noEmit`, `cargo test` (9 unchanged unit tests) — all clean
- Manually verified the shell-PATH-extraction logic against a near-empty simulated environment (`env -i`) and confirmed it correctly recovers the full PATH (Homebrew, nvm, etc.)
- **Real end-to-end verification**: built the actual `.app` locally, launched it via `open` (not `tauri dev` — this starts the process with the OS's own minimal PATH, same as a Finder double-click would) and confirmed via `ps eww <pid>` that the running process's PATH includes Homebrew and other login-shell-only entries after this fix — it wouldn't have without it

## Test plan — macOS-only gate this round (Windows untouched)

Per the plan: this round's gate is local macOS testing with a fresh test account (`agmsg-test`, clean `HOME`, Finder-launched), not a Windows re-test.

- [ ] CI required checks pass (app-only fast-path), static review
- [ ] `workflow_dispatch` build from `main` → koit verifies on the `agmsg-test` macOS account: DMG → Finder launch → auto-install → install a CLI → spawn → send
- [ ] If this passes: cut `app-v0.1.3`