### PR TITLE
fix(app): resolve MSYS project paths to native on Windows spawn (#315)

### DIFF
--- a/app/src-tauri/src/agmsg.rs
+++ b/app/src-tauri/src/agmsg.rs
@@ -55,7 +55,7 @@ fn agmsg_base() -> PathBuf {
 /// non-test caller is behind a Windows-only cfg, hence the dead_code
 /// allowance on other platforms.
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
-fn to_bash_slashes(s: &str) -> String {
+pub(crate) fn to_bash_slashes(s: &str) -> String {
     let s = s.strip_prefix(r"\\?\").unwrap_or(s);
     let s = s.replace('\\', "/");
     let bytes = s.as_bytes();
@@ -63,6 +63,37 @@ fn to_bash_slashes(s: &str) -> String {
         format!("/{}{}", (bytes[0] as char).to_ascii_lowercase(), &s[2..])
     } else {
         s
+    }
+}
+
+/// Converts an MSYS/Git-Bash path ("/c/Users/name") back to native Windows
+/// form ("C:\\Users\\name") — the inverse of to_bash_slashes. Team
+/// registrations on Windows store `project` in MSYS form (every skill script
+/// keys identity on Git Bash's $(pwd)), but that string is worthless to a
+/// native Win32 API: handed to create_dir_all or a PTY's cwd, Windows resolves
+/// the rootless "/c/Users/..." against the current drive and yields the phantom
+/// "C:\\c\\Users\\..." — a genuinely different directory, silently created and
+/// spawned into, which splits the app-user and its agents into separate teams
+/// whose messages never meet (see issue #315). Only the leading "/<drive>"
+/// segment is rewritten; anything already native ("C:\\..." / "C:/...") or
+/// relative passes through untouched. A standalone string transform so it's
+/// testable on any host — its non-test callers (agmsg_join, pty::pty_spawn) are
+/// behind Windows-only cfgs, hence the dead_code allowance elsewhere.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(crate) fn msys_to_native(s: &str) -> String {
+    let bytes = s.as_bytes();
+    // "/c" or "/c/rest" -> drive letter, but not "/cygdrive/..." or "/home/..."
+    // (a multi-char first segment is a real POSIX root, not a drive).
+    if bytes.len() >= 2
+        && bytes[0] == b'/'
+        && bytes[1].is_ascii_alphabetic()
+        && (bytes.len() == 2 || bytes[2] == b'/')
+    {
+        let drive = (bytes[1] as char).to_ascii_uppercase();
+        let rest = s[2..].replace('/', "\\");
+        format!("{drive}:{rest}")
+    } else {
+        s.to_string()
     }
 }
 
@@ -603,8 +634,15 @@ pub fn agmsg_join(
     agent_type: String,
     project: String,
 ) -> Result<(), String> {
-    // create_dir_all takes the native form; bash_path is only for the value
-    // that crosses into a bash argument below (join.sh's $4).
+    // The caller can hand us an MSYS-form path (/c/Users/...) read back from an
+    // existing registration (e.g. adding an agent into the app-user's team). On
+    // Windows create_dir_all needs the native form, or it silently builds the
+    // phantom C:\c\Users\... tree the spawned agent then splits into (#315).
+    // No-op for a path that's already native. create_dir_all takes the native
+    // form; bash_path is only for the value that crosses into a bash argument
+    // below (join.sh's $4).
+    #[cfg(target_os = "windows")]
+    let project = msys_to_native(&project);
     std::fs::create_dir_all(&project).map_err(|e| e.to_string())?;
     let project = bash_path(std::path::Path::new(&project));
     run_script("join.sh", &[&team, &name, &agent_type, &project]).map(|_| ())
@@ -693,7 +731,7 @@ pub fn start_watcher(app: AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::{agmsg_base, parse_semver, run_script, to_bash_slashes};
+    use super::{agmsg_base, msys_to_native, parse_semver, run_script, to_bash_slashes};
     use serial_test::serial;
     use std::io::Write;
 
@@ -737,6 +775,42 @@ mod tests {
     #[test]
     fn lowercases_the_drive_letter() {
         assert_eq!(to_bash_slashes(r"D:\work\x.sh"), "/d/work/x.sh");
+    }
+
+    #[test]
+    fn msys_to_native_rewrites_the_drive_segment() {
+        // The exact registration shape from issue #315: an MSYS project path
+        // must become a native Windows path before it reaches create_dir_all or
+        // a PTY cwd, or Windows builds/spawns the phantom C:\c\Users\... dir.
+        assert_eq!(
+            msys_to_native("/c/Users/kei40/agmsg-agents/Chikamichi"),
+            r"C:\Users\kei40\agmsg-agents\Chikamichi",
+        );
+    }
+
+    #[test]
+    fn msys_to_native_uppercases_and_handles_other_drives() {
+        assert_eq!(msys_to_native("/d/work/x"), r"D:\work\x");
+        assert_eq!(msys_to_native("/c"), "C:");
+    }
+
+    #[test]
+    fn msys_to_native_is_a_no_op_on_native_and_posix_root_paths() {
+        // Already-native paths (either slash style) and genuine multi-segment
+        // POSIX roots must pass through untouched — only "/<drive>" is a drive.
+        assert_eq!(msys_to_native(r"C:\Users\kei40\x"), r"C:\Users\kei40\x");
+        assert_eq!(msys_to_native("C:/Users/kei40/x"), "C:/Users/kei40/x");
+        assert_eq!(msys_to_native("/Users/koichi/x"), "/Users/koichi/x");
+        assert_eq!(msys_to_native("/home/koichi/x"), "/home/koichi/x");
+        assert_eq!(msys_to_native("/cygdrive/c/x"), "/cygdrive/c/x");
+    }
+
+    #[test]
+    fn msys_to_native_round_trips_with_to_bash_slashes() {
+        // The two are inverses across the drive boundary; storage (MSYS) and
+        // native (create_dir_all/cwd) must agree so the agent's $(pwd) matches.
+        let native = r"C:\Users\kei40\agmsg-agents\Chikamichi";
+        assert_eq!(msys_to_native(&to_bash_slashes(native)), native);
     }
 
     #[test]
@@ -868,5 +942,58 @@ mod tests {
     fn run_script_errors_when_the_script_is_missing() {
         let _base = fake_base(&[]);
         assert!(run_script("nope.sh", &[]).is_err());
+    }
+
+    // --- #315 Windows spawn-path regression (runs on the windows-latest job) ---
+
+    /// The core #315 guarantee, independent of bash: create_dir_all runs before
+    /// run_script and must build the NATIVE dir, not the phantom C:\c\Users\...
+    /// Windows would derive from an unconverted MSYS project path. The join.sh
+    /// result is ignored so a bash hiccup can't mask the create_dir_all check.
+    #[test]
+    #[serial]
+    #[cfg(target_os = "windows")]
+    fn agmsg_join_creates_the_native_dir_not_the_phantom() {
+        let _base = fake_base(&[("join.sh", "exit 0")]);
+        let tmp = tempfile::tempdir().unwrap();
+        let native_proj = tmp.path().join("agmsg-agents").join("alice");
+        // MSYS form, as a Windows registration stores it.
+        let msys_proj = to_bash_slashes(&native_proj.to_string_lossy());
+        let _ = super::agmsg_join("t".into(), "alice".into(), "claude-code".into(), msys_proj);
+        assert!(
+            native_proj.is_dir(),
+            "agmsg_join must create the native dir, not a phantom C:\\c\\Users\\... tree",
+        );
+    }
+
+    /// End to end through the fake join.sh: the native dir is created AND join.sh
+    /// receives the project ($4) in MSYS form, so storage/identity keys stay MSYS
+    /// while the filesystem side is native.
+    #[test]
+    #[serial]
+    #[cfg(target_os = "windows")]
+    fn agmsg_join_passes_msys_form_to_join_sh() {
+        let dir = tempfile::tempdir().unwrap();
+        // Forward-slash base so both Rust (agmsg_base) and Git Bash ($AGMSG_APP_BASE
+        // expansion / redirect) accept it — a native backslash path gets mangled by
+        // MSYS argv/redirect handling.
+        let base = dir.path().to_string_lossy().replace('\\', "/");
+        let sdir = dir.path().join("scripts");
+        std::fs::create_dir_all(&sdir).unwrap();
+        std::fs::write(
+            sdir.join("join.sh"),
+            "#!/usr/bin/env bash\nprintf '%s' \"$4\" > \"$AGMSG_APP_BASE/arg4.txt\"\n",
+        )
+        .unwrap();
+        let _env = EnvGuard::set("AGMSG_APP_BASE", &base);
+
+        let native_proj = dir.path().join("agmsg-agents").join("bob");
+        let msys_proj = to_bash_slashes(&native_proj.to_string_lossy());
+        super::agmsg_join("t".into(), "bob".into(), "claude-code".into(), msys_proj.clone())
+            .expect("join should succeed");
+
+        assert!(native_proj.is_dir(), "native project dir should be created");
+        let got = std::fs::read_to_string(dir.path().join("arg4.txt")).unwrap();
+        assert_eq!(got, msys_proj, "join.sh $4 should be the MSYS form");
     }
 }

--- a/app/src-tauri/src/pty.rs
+++ b/app/src-tauri/src/pty.rs
@@ -57,6 +57,26 @@ struct ExitEvent {
     id: String,
 }
 
+/// Windows-only: turn a spawn cwd from a team registration (MSYS form,
+/// /c/Users/...) into a native path, and refuse it if it isn't a real directory.
+/// CreateProcessW resolves a rootless /c/Users/... against the current drive ->
+/// the phantom C:\c\Users\... dir; the agent then boots there, its own $(pwd)
+/// matches no registration, and it splits into a phantom team whose messages
+/// never reach the app (#315). Erroring (instead of booting into a mangled dir)
+/// surfaces in the terminal pane via the frontend's failed-spawn handler. Split
+/// out from pty_spawn so it's unit-testable without a Tauri AppHandle.
+#[cfg(target_os = "windows")]
+fn resolve_windows_cwd(dir: &str) -> Result<String, String> {
+    let native = crate::agmsg::msys_to_native(dir);
+    if !std::path::Path::new(&native).is_dir() {
+        return Err(format!(
+            "agent working directory doesn't exist: {native} (from registration \
+             path {dir}). Re-add the agent so its project points at a real folder."
+        ));
+    }
+    Ok(native)
+}
+
 /// Spawn `cmd args` in a fresh PTY and stream its output to the webview as
 /// `pty-output` events. Stores the session under `id`.
 #[tauri::command]
@@ -84,6 +104,9 @@ pub fn pty_spawn(
         builder.arg(a);
     }
     if let Some(dir) = &cwd {
+        #[cfg(target_os = "windows")]
+        builder.cwd(resolve_windows_cwd(dir)?);
+        #[cfg(not(target_os = "windows"))]
         builder.cwd(dir);
     }
     builder.env("TERM", "xterm-256color");
@@ -207,4 +230,24 @@ pub fn pty_inject(manager: State<'_, PtyManager>, id: String, text: String) -> R
         }
     });
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    // resolve_windows_cwd is behind cfg(windows); this test runs on the
+    // windows-latest app-test CI job (a compile-pass elsewhere isn't validation
+    // — the 0.1.2 lesson). Exercises the #315 phantom-cwd guard end to end.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn resolve_windows_cwd_rejects_phantom_and_accepts_a_real_dir() {
+        use super::resolve_windows_cwd;
+        // A nonexistent MSYS-form cwd (the phantom-splitting registration) is
+        // rejected rather than booted into.
+        assert!(resolve_windows_cwd("/c/no/such/agmsg/project/dir").is_err());
+        // A real dir addressed in MSYS form resolves to native and is accepted.
+        let tmp = tempfile::tempdir().unwrap();
+        let msys = crate::agmsg::to_bash_slashes(&tmp.path().to_string_lossy());
+        let native = resolve_windows_cwd(&msys).expect("a real dir should be accepted");
+        assert!(std::path::Path::new(&native).is_dir());
+    }
 }


### PR DESCRIPTION
## Problem

Closes #315.

On Windows, team registrations store `project` in MSYS form (`/c/Users/...`) because every skill script keys identity on Git Bash's `$(pwd)`. The app used that string verbatim in two native Win32 spots:

1. `agmsg_join` -> `create_dir_all(project)`
2. `pty_spawn` -> the PTY spawn cwd (CreateProcessW)

Windows resolves a rootless `/c/Users/...` against the *current drive*, producing the phantom directory `C:\c\Users\...`. The app silently created that tree and booted the agent there. Inside the pane, Git Bash `$(pwd)` then reported `/c/c/Users/...` (doubled `/c/c/`), which matched no registration, so the agent auto-created a *phantom team* and registered itself there. Result: the app-user lives in the real team, the spawned agents live in the phantom team, and their messages never meet — agent<->app messaging breaks with no error.

## Fix

- Add `msys_to_native()`, the inverse of the existing `to_bash_slashes()`: `/c/Users/x` -> `C:\Users\x`. Only the leading `/<drive>` segment is rewritten; already-native and genuine POSIX-root paths pass through untouched.
- `agmsg_join`: normalize to native form before `create_dir_all`, so the app stops silently building the phantom `C:\c\Users\...` tree. Storage is unchanged (still MSYS form via `bash_path`).
- `pty_spawn`: convert the cwd to native, and refuse to spawn with a clear error if it does not resolve to a real directory — instead of booting the agent into a phantom/relative dir. Extracted as `resolve_windows_cwd()` so it is unit-testable without a Tauri `AppHandle`. The frontend already surfaces a failed spawn into the terminal pane.

All native-path changes are behind `#[cfg(target_os = "windows")]`; non-Windows behavior is unchanged.

## Testing

Built on the #320 fake-script harness + windows-latest `cargo test` job.

- `msys_to_native` unit tests (all OSes), including a round-trip with `to_bash_slashes`.
- cfg(windows) tests, executed by the windows-latest app-test job:
  - `agmsg_join` creates the *native* project dir (not the phantom `C:\c\Users\...`), and passes the project to `join.sh`'s `$4` in MSYS form.
  - `resolve_windows_cwd` rejects a nonexistent (phantom) MSYS cwd and accepts a real dir, resolving it to native.
- Verified locally on macOS by force-enabling the cfg(windows) blocks/tests (all pass), then reverting.

Note: full end-to-end agent<->app messaging on Windows can't be exercised on a non-Windows host or in CI; that remains a real-Windows-machine check before the fix ships in a tagged app release.