### PR TITLE
test(app): fake-script harness for the Rust command layer + CI (#318)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -275,3 +275,45 @@ jobs:
       - name: Rust check
         if: needs.changes.outputs.app_changed != 'false'
         run: cargo check --manifest-path src-tauri/Cargo.toml
+
+      - name: Rust tests
+        if: needs.changes.outputs.app_changed != 'false'
+        run: cargo test --manifest-path src-tauri/Cargo.toml
+
+  # Windows leg for the app: the command layer's bash resolution and path
+  # conversion are all behind cfg(windows) and had never run in CI — the very
+  # 0.1.1→0.1.3 regressions (WSL bash.exe, backslash argv). This runs cargo test
+  # on windows-latest so those paths are actually exercised. Same fail-open
+  # convention as app-check: run unless the diff provably doesn't touch app/.
+  app-test-windows:
+    name: app test (windows-latest)
+    needs: changes
+    if: ${{ !cancelled() }}
+    runs-on: windows-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: No app changes — skipping app tests
+        if: needs.changes.outputs.app_changed == 'false'
+        run: echo "Diff does not touch app/ — reporting green without running the app tests."
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: needs.changes.outputs.app_changed != 'false'
+
+      - uses: Swatinem/rust-cache@v2
+        if: needs.changes.outputs.app_changed != 'false'
+        with:
+          workspaces: app/src-tauri
+
+      - name: Bundle pinned agmsg-core
+        if: needs.changes.outputs.app_changed != 'false'
+        run: scripts/bundle-core.sh
+        shell: bash
+
+      - name: Rust tests
+        if: needs.changes.outputs.app_changed != 'false'
+        run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serial_test",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -25,6 +26,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tempfile",
 ]
 
 [[package]]
@@ -3471,6 +3473,31 @@ checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
 dependencies = [
  "libc",
  "serial-core",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -34,3 +34,10 @@ anyhow = "1"
 # PTY output is raw bytes (TUI box-drawing etc.); ship it to the webview as
 # base64 so multibyte sequences split across reads render correctly in xterm.
 base64 = "0.22"
+
+[dev-dependencies]
+# Fake-script harness: a temp install base of stub scripts the command layer runs.
+tempfile = "3"
+# The command layer reads process env (AGMSG_APP_BASE / HOME / PATH); serialize
+# the tests that mutate it so they don't race under the default parallel runner.
+serial_test = "3"

--- a/app/src-tauri/src/agmsg.rs
+++ b/app/src-tauri/src/agmsg.rs
@@ -772,13 +772,42 @@ mod tests {
     // run_script() resolves <base>/scripts/<name>, runs it through bash, and maps
     // stdout→Ok / stderr→Err. Pointing AGMSG_APP_BASE at a temp dir of fake
     // scripts lets us exercise that whole path (the 0.1.1→0.1.3 regressions all
-    // lived here) without a real agmsg install. Env is process-global, so these
-    // are #[serial]. Skipped on Windows: the CI runner's `bash` resolution
-    // (resolve_bash) is Git-Bash-specific and covered by the windows app-test job.
+    // lived here) without a real agmsg install. AGMSG_APP_BASE is process-global,
+    // so any test that reads it is #[serial]; add #[serial] to future ones too.
+    // The run_script cases are skipped on Windows: resolve_bash there is Git-Bash
+    // -specific and is covered by the windows-latest app-test CI job instead.
 
-    /// Write the given `(name, body)` fakes under a temp `scripts/` dir and point
-    /// AGMSG_APP_BASE at it. Returns the TempDir — keep it alive for the test.
-    fn fake_base(scripts: &[(&str, &str)]) -> tempfile::TempDir {
+    /// Restores an env var to its prior value (or unsets it) on drop, so a
+    /// panicking test can't leak an override into the next one — the manual
+    /// remove_var-at-end approach loses that on unwind.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+    impl EnvGuard {
+        fn set(key: &'static str, val: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            std::env::set_var(key, val);
+            EnvGuard { key, prev }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    /// A temp install base whose `scripts/` holds the given `(name, body)` fakes,
+    /// with AGMSG_APP_BASE pointed at it. Bind it for the test's duration; on drop
+    /// the temp dir is removed and AGMSG_APP_BASE is restored.
+    struct FakeBase {
+        _dir: tempfile::TempDir,
+        _env: EnvGuard,
+    }
+    fn fake_base(scripts: &[(&str, &str)]) -> FakeBase {
         let dir = tempfile::tempdir().expect("tempdir");
         let sdir = dir.path().join("scripts");
         std::fs::create_dir_all(&sdir).unwrap();
@@ -787,25 +816,23 @@ mod tests {
             writeln!(f, "#!/usr/bin/env bash").unwrap();
             f.write_all(body.as_bytes()).unwrap();
         }
-        std::env::set_var("AGMSG_APP_BASE", dir.path());
-        dir
+        let env = EnvGuard::set("AGMSG_APP_BASE", &dir.path().to_string_lossy());
+        FakeBase { _dir: dir, _env: env }
     }
 
     #[test]
     #[serial]
     fn agmsg_base_honors_the_env_override() {
         let dir = tempfile::tempdir().unwrap();
-        std::env::set_var("AGMSG_APP_BASE", dir.path());
+        let _env = EnvGuard::set("AGMSG_APP_BASE", &dir.path().to_string_lossy());
         assert_eq!(agmsg_base(), dir.path());
-        std::env::remove_var("AGMSG_APP_BASE");
     }
 
     #[test]
     #[serial]
     fn agmsg_base_falls_back_when_override_is_empty() {
-        std::env::set_var("AGMSG_APP_BASE", "");
+        let _env = EnvGuard::set("AGMSG_APP_BASE", "");
         assert!(agmsg_base().ends_with(".agents/skills/agmsg"));
-        std::env::remove_var("AGMSG_APP_BASE");
     }
 
     #[test]
@@ -815,7 +842,6 @@ mod tests {
         let _base = fake_base(&[("ok.sh", "echo hello-from-fake")]);
         let out = run_script("ok.sh", &[]).expect("should succeed");
         assert_eq!(out.trim(), "hello-from-fake");
-        std::env::remove_var("AGMSG_APP_BASE");
     }
 
     #[test]
@@ -825,7 +851,6 @@ mod tests {
         let _base = fake_base(&[("boom.sh", "echo the-error >&2; exit 1")]);
         let err = run_script("boom.sh", &[]).unwrap_err();
         assert!(err.contains("the-error"), "stderr not surfaced: {err:?}");
-        std::env::remove_var("AGMSG_APP_BASE");
     }
 
     #[test]
@@ -835,7 +860,6 @@ mod tests {
         let _base = fake_base(&[("args.sh", "printf '%s\\n' \"$@\"")]);
         let out = run_script("args.sh", &["a", "b c", "d"]).unwrap();
         assert_eq!(out.lines().collect::<Vec<_>>(), ["a", "b c", "d"]);
-        std::env::remove_var("AGMSG_APP_BASE");
     }
 
     #[test]
@@ -844,6 +868,5 @@ mod tests {
     fn run_script_errors_when_the_script_is_missing() {
         let _base = fake_base(&[]);
         assert!(run_script("nope.sh", &[]).is_err());
-        std::env::remove_var("AGMSG_APP_BASE");
     }
 }

--- a/app/src-tauri/src/agmsg.rs
+++ b/app/src-tauri/src/agmsg.rs
@@ -27,7 +27,18 @@ fn home_dir_string() -> Option<String> {
 }
 
 /// Base dir of the agmsg install (skill layout: db/, teams/, scripts/, ...).
+///
+/// `AGMSG_APP_BASE`, when set to a non-empty path, overrides the derived
+/// location. This is the command layer's injection point — the test harness
+/// points it at a temp dir of fake `scripts/*.sh` (mirrors resolve_bash's
+/// `AGMSG_APP_BASH` override). In normal operation it is unset and the base is
+/// `<home>/.agents/skills/agmsg`.
 fn agmsg_base() -> PathBuf {
+    if let Ok(over) = std::env::var("AGMSG_APP_BASE") {
+        if !over.is_empty() {
+            return PathBuf::from(over);
+        }
+    }
     let home = home_dir_string().unwrap_or_else(|| ".".into());
     PathBuf::from(home).join(".agents/skills/agmsg")
 }
@@ -682,7 +693,9 @@ pub fn start_watcher(app: AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_semver, to_bash_slashes};
+    use super::{agmsg_base, parse_semver, run_script, to_bash_slashes};
+    use serial_test::serial;
+    use std::io::Write;
 
     #[test]
     fn strips_verbatim_prefix_and_converts_to_posix() {
@@ -752,5 +765,85 @@ mod tests {
         assert!(parse_semver("1.1.10") > parse_semver("1.1.9"));
         assert!(parse_semver("1.1.4") < parse_semver("1.2.0"));
         assert!(parse_semver("1.1.4") < parse_semver("2.0.0"));
+    }
+
+    // --- command-layer harness (fake agmsg-core scripts) ---
+    //
+    // run_script() resolves <base>/scripts/<name>, runs it through bash, and maps
+    // stdout→Ok / stderr→Err. Pointing AGMSG_APP_BASE at a temp dir of fake
+    // scripts lets us exercise that whole path (the 0.1.1→0.1.3 regressions all
+    // lived here) without a real agmsg install. Env is process-global, so these
+    // are #[serial]. Skipped on Windows: the CI runner's `bash` resolution
+    // (resolve_bash) is Git-Bash-specific and covered by the windows app-test job.
+
+    /// Write the given `(name, body)` fakes under a temp `scripts/` dir and point
+    /// AGMSG_APP_BASE at it. Returns the TempDir — keep it alive for the test.
+    fn fake_base(scripts: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sdir = dir.path().join("scripts");
+        std::fs::create_dir_all(&sdir).unwrap();
+        for (name, body) in scripts {
+            let mut f = std::fs::File::create(sdir.join(name)).unwrap();
+            writeln!(f, "#!/usr/bin/env bash").unwrap();
+            f.write_all(body.as_bytes()).unwrap();
+        }
+        std::env::set_var("AGMSG_APP_BASE", dir.path());
+        dir
+    }
+
+    #[test]
+    #[serial]
+    fn agmsg_base_honors_the_env_override() {
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("AGMSG_APP_BASE", dir.path());
+        assert_eq!(agmsg_base(), dir.path());
+        std::env::remove_var("AGMSG_APP_BASE");
+    }
+
+    #[test]
+    #[serial]
+    fn agmsg_base_falls_back_when_override_is_empty() {
+        std::env::set_var("AGMSG_APP_BASE", "");
+        assert!(agmsg_base().ends_with(".agents/skills/agmsg"));
+        std::env::remove_var("AGMSG_APP_BASE");
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(not(target_os = "windows"))]
+    fn run_script_returns_stdout_on_success() {
+        let _base = fake_base(&[("ok.sh", "echo hello-from-fake")]);
+        let out = run_script("ok.sh", &[]).expect("should succeed");
+        assert_eq!(out.trim(), "hello-from-fake");
+        std::env::remove_var("AGMSG_APP_BASE");
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(not(target_os = "windows"))]
+    fn run_script_returns_stderr_as_err_on_failure() {
+        let _base = fake_base(&[("boom.sh", "echo the-error >&2; exit 1")]);
+        let err = run_script("boom.sh", &[]).unwrap_err();
+        assert!(err.contains("the-error"), "stderr not surfaced: {err:?}");
+        std::env::remove_var("AGMSG_APP_BASE");
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(not(target_os = "windows"))]
+    fn run_script_passes_arguments_through_in_order() {
+        let _base = fake_base(&[("args.sh", "printf '%s\\n' \"$@\"")]);
+        let out = run_script("args.sh", &["a", "b c", "d"]).unwrap();
+        assert_eq!(out.lines().collect::<Vec<_>>(), ["a", "b c", "d"]);
+        std::env::remove_var("AGMSG_APP_BASE");
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(not(target_os = "windows"))]
+    fn run_script_errors_when_the_script_is_missing() {
+        let _base = fake_base(&[]);
+        assert!(run_script("nope.sh", &[]).is_err());
+        std::env::remove_var("AGMSG_APP_BASE");
     }
 }


### PR DESCRIPTION
Closes #318.

The app's command layer (`app/src-tauri/src/agmsg.rs`: resolve bash → run an
agmsg-core script → parse stdout/stderr) had no coverage, yet every 0.1.1→0.1.3
regression lived there (WSL `bash.exe`, missing `HOME`, PATH propagation).

## Changes

- `agmsg_base()`: add an `AGMSG_APP_BASE` override (mirrors `resolve_bash`'s
  `AGMSG_APP_BASH`) — the command layer's injection point.
- **Fake-script harness** (tests): a temp `<base>/scripts/*.sh` pointed at via
  `AGMSG_APP_BASE`, serialized with `serial_test`. Covers `run_script`
  success→stdout, failure→stderr `Err`, argument passthrough, and a missing
  script. The existing `to_bash_slashes` / `parse_semver` pure-fn tests are
  kept as-is.
- dev-deps: `tempfile`, `serial_test`.
- CI (`tests.yml`): run `cargo test` in the app job, and add a **windows-latest**
  app-test job so the `cfg(windows)` bash-resolution / path-conversion code is
  actually exercised (it had never run in CI). Same change-detection / fail-open
  convention as the existing app job (`app_changed != 'false'`).

## Verification

`cargo test` green locally: 15 passed (9 existing pure-fn + 6 new command-layer).

## Out of scope

Frontend tests (vitest, pane tree) — tracked separately.
