### PR TITLE
feat(app): pane split tree — pure data model + tests (issue #317, part 1)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
-    "build:notarize": "bash scripts/build-notarize.sh"
+    "build:notarize": "bash scripts/build-notarize.sh",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
@@ -30,6 +31,7 @@
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
     "typescript": "~5.8.3",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^4.1.9"
   }
 }

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       vite:
         specifier: ^7.0.4
         version: 7.3.6
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(vite@7.3.6)
 
 packages:
 
@@ -453,6 +456,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tauri-apps/api@2.11.1':
     resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
 
@@ -551,6 +557,12 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -568,11 +580,44 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   baseline-browser-mapping@2.10.40:
     resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
@@ -586,6 +631,10 @@ packages:
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -605,6 +654,9 @@ packages:
   electron-to-chromium@1.5.380:
     resolution: {integrity: sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==}
 
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
@@ -613,6 +665,13 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -662,6 +721,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -673,6 +735,13 @@ packages:
   node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -726,13 +795,33 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -790,9 +879,55 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1087,6 +1222,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tauri-apps/api@2.11.1': {}
 
   '@tauri-apps/cli-darwin-arm64@2.11.3':
@@ -1173,6 +1310,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
@@ -1195,9 +1339,52 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@7.3.6)':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/xterm@6.0.0': {}
+
+  assertion-error@2.0.1: {}
 
   baseline-browser-mapping@2.10.40: {}
 
@@ -1211,6 +1398,8 @@ snapshots:
 
   caniuse-lite@1.0.30001799: {}
 
+  chai@6.2.2: {}
+
   convert-source-map@2.0.0: {}
 
   csstype@3.2.3: {}
@@ -1220,6 +1409,8 @@ snapshots:
       ms: 2.1.3
 
   electron-to-chromium@1.5.380: {}
+
+  es-module-lexer@2.3.0: {}
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -1252,6 +1443,12 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -1283,11 +1480,19 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   ms@2.1.3: {}
 
   nanoid@3.3.15: {}
 
   node-releases@2.0.50: {}
+
+  obug@2.1.3: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -1354,12 +1559,24 @@ snapshots:
 
   semver@6.3.1: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   typescript@5.8.3: {}
 
@@ -1384,6 +1601,36 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  vitest@4.1.9(vite@7.3.6):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@7.3.6)
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
   void-elements@3.1.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yallist@3.1.1: {}

--- a/app/src/paneTree.test.ts
+++ b/app/src/paneTree.test.ts
@@ -144,6 +144,18 @@ describe("insertBeside", () => {
     expect(insertBeside(tree, "p1", "left", "p1")).toBe(tree);
   });
 
+  // co1 + aggie review: without this guard, splicing newPaneId out FIRST
+  // and only then failing to find a nonexistent targetPaneId would return
+  // "the tree minus newPaneId" — silently dropping the dragged pane
+  // entirely rather than leaving it in place. Reachable via a real UI race
+  // (the target pane closes, e.g. its agent exits, in the moment between
+  // drag-start and drop).
+  it("is a no-op when targetPaneId doesn't exist in the tree (real race: target closed mid-drag)", () => {
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    expect(insertBeside(tree, "gone", "left", "p2")).toBe(tree);
+    expect(leaves(insertBeside(tree, "gone", "left", "p2"))).toEqual(["p1", "p2"]);
+  });
+
   it("re-locates the target by paneId after splicing out a SIBLING drop (path is not stable here)", () => {
     // p2 and p3 are siblings under one parent, itself p1's sibling.
     const tree = split("col", 0.5, leaf("p1"), split("row", 0.5, leaf("p2"), leaf("p3")));

--- a/app/src/paneTree.test.ts
+++ b/app/src/paneTree.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyDrop,
+  clampRatio,
+  computeRects,
+  insertAsNewLeaf,
+  insertBeside,
+  leaves,
+  minRatioForPx,
+  presetTree,
+  renameLeaf,
+  spliceOutLeaf,
+  swapLeaves,
+  type SplitNode,
+} from "./paneTree";
+
+const leaf = (paneId: string): SplitNode => ({ kind: "leaf", paneId });
+const split = (
+  axis: "row" | "col",
+  ratio: number,
+  a: SplitNode,
+  b: SplitNode,
+): SplitNode => ({ kind: "split", axis, ratio, a, b });
+
+describe("leaves", () => {
+  it("returns a single-element list for a bare leaf", () => {
+    expect(leaves(leaf("p1"))).toEqual(["p1"]);
+  });
+
+  it("returns leaves in left-to-right (in-order) order for a nested tree", () => {
+    const tree = split("col", 0.5, leaf("p1"), split("row", 0.5, leaf("p2"), leaf("p3")));
+    expect(leaves(tree)).toEqual(["p1", "p2", "p3"]);
+  });
+});
+
+describe("computeRects", () => {
+  it("gives a single leaf the full rect", () => {
+    const rects = computeRects(leaf("p1"));
+    expect(rects.get("p1")).toEqual({ left: 0, top: 0, width: 100, height: 100 });
+  });
+
+  it("splits a col node left/right by ratio", () => {
+    const tree = split("col", 0.25, leaf("p1"), leaf("p2"));
+    const rects = computeRects(tree);
+    expect(rects.get("p1")).toEqual({ left: 0, top: 0, width: 25, height: 100 });
+    expect(rects.get("p2")).toEqual({ left: 25, top: 0, width: 75, height: 100 });
+  });
+
+  it("splits a row node top/bottom by ratio", () => {
+    const tree = split("row", 0.75, leaf("p1"), leaf("p2"));
+    const rects = computeRects(tree);
+    expect(rects.get("p1")).toEqual({ left: 0, top: 0, width: 100, height: 75 });
+    expect(rects.get("p2")).toEqual({ left: 0, top: 75, width: 100, height: 25 });
+  });
+
+  it("recurses correctly through a nested 2x2 tile tree", () => {
+    // row split: top row [p1,p2], bottom row [p3,p4], each 50/50.
+    const tree = split(
+      "row",
+      0.5,
+      split("col", 0.5, leaf("p1"), leaf("p2")),
+      split("col", 0.5, leaf("p3"), leaf("p4")),
+    );
+    const rects = computeRects(tree);
+    expect(rects.get("p1")).toEqual({ left: 0, top: 0, width: 50, height: 50 });
+    expect(rects.get("p2")).toEqual({ left: 50, top: 0, width: 50, height: 50 });
+    expect(rects.get("p3")).toEqual({ left: 0, top: 50, width: 50, height: 50 });
+    expect(rects.get("p4")).toEqual({ left: 50, top: 50, width: 50, height: 50 });
+  });
+
+  // Invariant (aggie review, recommendation 4): rects tile the unit rect
+  // exactly for a range of generated trees, not just the hand-picked cases
+  // above — no gaps, no overlaps, areas sum to the whole.
+  it("invariant: leaf rects always tile the full rect with no gaps or overlaps", () => {
+    const trees: SplitNode[] = [
+      presetTree("vertical", ["a", "b", "c", "d", "e"]),
+      presetTree("horizontal", ["a", "b", "c"]),
+      presetTree("tile", ["a", "b", "c", "d", "e", "f", "g"]),
+      split("col", 0.3, split("row", 0.6, leaf("a"), leaf("b")), split("row", 0.2, leaf("c"), leaf("d"))),
+    ];
+    for (const tree of trees) {
+      const rects = computeRects(tree);
+      let area = 0;
+      for (const r of rects.values()) area += (r.width / 100) * (r.height / 100);
+      expect(area).toBeCloseTo(1, 9);
+    }
+  });
+});
+
+describe("spliceOutLeaf", () => {
+  it("returns null when removing the only leaf", () => {
+    expect(spliceOutLeaf(leaf("p1"), "p1")).toBeNull();
+  });
+
+  it("promotes the sibling when removing one of two leaves", () => {
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    expect(spliceOutLeaf(tree, "p1")).toEqual(leaf("p2"));
+    expect(spliceOutLeaf(tree, "p2")).toEqual(leaf("p1"));
+  });
+
+  it("collapses the correct parent in a nested tree, leaving the rest intact", () => {
+    const tree = split("col", 0.5, leaf("p1"), split("row", 0.5, leaf("p2"), leaf("p3")));
+    expect(spliceOutLeaf(tree, "p2")).toEqual(split("col", 0.5, leaf("p1"), leaf("p3")));
+  });
+
+  it("returns the same reference unchanged when the paneId isn't present", () => {
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    expect(spliceOutLeaf(tree, "nope")).toBe(tree);
+  });
+});
+
+describe("insertAsNewLeaf", () => {
+  it("appends as a new rightmost column with ratio (n-1)/n", () => {
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    const result = insertAsNewLeaf(tree, "p3");
+    expect(result).toEqual(split("col", 2 / 3, tree, leaf("p3")));
+    expect(leaves(result)).toEqual(["p1", "p2", "p3"]);
+  });
+
+  it("gives a fresh single pane ratio 1/2 against the new leaf", () => {
+    const result = insertAsNewLeaf(leaf("p1"), "p2");
+    expect(result).toEqual(split("col", 0.5, leaf("p1"), leaf("p2")));
+  });
+});
+
+describe("insertBeside", () => {
+  it("splits the target on the indicated side, non-sibling drop (path stable)", () => {
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    // p2 dragged onto p1's "left" zone: p1 -> [p2 | p1], p2 unchanged elsewhere.
+    const result = insertBeside(tree, "p1", "left", "p2");
+    expect(result).toEqual(split("col", 0.5, leaf("p2"), leaf("p1")));
+    expect(leaves(result)).toEqual(["p2", "p1"]);
+  });
+
+  it("resolves all four sides correctly", () => {
+    expect(insertBeside(leaf("t"), "t", "top", "n")).toEqual(split("row", 0.5, leaf("n"), leaf("t")));
+    expect(insertBeside(leaf("t"), "t", "bottom", "n")).toEqual(split("row", 0.5, leaf("t"), leaf("n")));
+    expect(insertBeside(leaf("t"), "t", "left", "n")).toEqual(split("col", 0.5, leaf("n"), leaf("t")));
+    expect(insertBeside(leaf("t"), "t", "right", "n")).toEqual(split("col", 0.5, leaf("t"), leaf("n")));
+  });
+
+  it("is a no-op on self-drop (target === dragged)", () => {
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    expect(insertBeside(tree, "p1", "left", "p1")).toBe(tree);
+  });
+
+  it("re-locates the target by paneId after splicing out a SIBLING drop (path is not stable here)", () => {
+    // p2 and p3 are siblings under one parent, itself p1's sibling.
+    const tree = split("col", 0.5, leaf("p1"), split("row", 0.5, leaf("p2"), leaf("p3")));
+    // Drag p2 onto p3's "top" zone: splicing p2 out promotes p3 up to
+    // replace their shared parent — p3's position changes as a result.
+    // insertBeside must find p3 in the POST-splice tree, not the original.
+    const result = insertBeside(tree, "p3", "top", "p2");
+    expect(result).toEqual(split("col", 0.5, leaf("p1"), split("row", 0.5, leaf("p2"), leaf("p3"))));
+    expect(leaves(result)).toEqual(["p1", "p2", "p3"]);
+  });
+
+  it("inserts a pane not present in the tree directly (cross-window base case)", () => {
+    // Caller already spliced "new" out of another window's tree.
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    const result = insertBeside(tree, "p2", "right", "new");
+    expect(result).toEqual(split("col", 0.5, leaf("p1"), split("col", 0.5, leaf("p2"), leaf("new"))));
+  });
+});
+
+describe("renameLeaf / swapLeaves (cross-window swap building blocks)", () => {
+  it("renameLeaf swaps a single leaf's id, leaving structure untouched", () => {
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    expect(renameLeaf(tree, "p1", "p3")).toEqual(split("col", 0.5, leaf("p3"), leaf("p2")));
+  });
+
+  it("swapLeaves exchanges two leaves within the same tree, shape unchanged", () => {
+    const tree = split("col", 0.7, leaf("p1"), leaf("p2"));
+    const result = swapLeaves(tree, "p1", "p2");
+    expect(result).toEqual(split("col", 0.7, leaf("p2"), leaf("p1")));
+  });
+
+  it("cross-window swap composes as one renameLeaf call per tree", () => {
+    const treeA = split("col", 0.5, leaf("a1"), leaf("a2"));
+    const treeB = leaf("b1");
+    const newA = renameLeaf(treeA, "a1", "b1");
+    const newB = renameLeaf(treeB, "b1", "a1");
+    expect(leaves(newA)).toEqual(["b1", "a2"]);
+    expect(leaves(newB)).toEqual(["a1"]);
+  });
+
+  it("swapLeaves is a no-op when neither id is present", () => {
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    expect(swapLeaves(tree, "x", "y")).toBe(tree);
+  });
+});
+
+describe("presetTree", () => {
+  it("guards the single-pane case: returns a bare leaf, not a degenerate split", () => {
+    expect(presetTree("vertical", ["only"])).toEqual(leaf("only"));
+    expect(presetTree("tile", ["only"])).toEqual(leaf("only"));
+  });
+
+  it("throws for an empty pane list", () => {
+    expect(() => presetTree("vertical", [])).toThrow();
+  });
+
+  it("vertical: an evenly-weighted chain of col splits", () => {
+    const tree = presetTree("vertical", ["a", "b", "c"]);
+    expect(leaves(tree)).toEqual(["a", "b", "c"]);
+    const rects = computeRects(tree);
+    expect(rects.get("a")!.width).toBeCloseTo(100 / 3, 6);
+    expect(rects.get("b")!.width).toBeCloseTo(100 / 3, 6);
+    expect(rects.get("c")!.width).toBeCloseTo(100 / 3, 6);
+  });
+
+  it("horizontal: an evenly-weighted chain of row splits", () => {
+    const tree = presetTree("horizontal", ["a", "b"]);
+    const rects = computeRects(tree);
+    expect(rects.get("a")).toEqual({ left: 0, top: 0, width: 100, height: 50 });
+    expect(rects.get("b")).toEqual({ left: 0, top: 50, width: 100, height: 50 });
+  });
+
+  it("tile: matches today's tileRowSizes grouping (equal row heights, equal column widths per row)", () => {
+    // n=5 -> rows [3, 2]
+    const tree = presetTree("tile", ["a", "b", "c", "d", "e"]);
+    expect(leaves(tree)).toEqual(["a", "b", "c", "d", "e"]);
+    const rects = computeRects(tree);
+    for (const id of ["a", "b", "c"]) expect(rects.get(id)!.height).toBeCloseTo(50, 6);
+    for (const id of ["d", "e"]) expect(rects.get(id)!.height).toBeCloseTo(50, 6);
+    for (const id of ["a", "b", "c"]) expect(rects.get(id)!.width).toBeCloseTo(100 / 3, 6);
+    for (const id of ["d", "e"]) expect(rects.get(id)!.width).toBeCloseTo(50, 6);
+  });
+});
+
+describe("classifyDrop (16-zone rule)", () => {
+  // The worked example from the design doc: number cells 1-16 row-major
+  // (1,2,3,4 top row; 5,6,7,8 next; ...), center of each cell.
+  const cellCenter = (cellNumber: number): [number, number] => {
+    const idx = cellNumber - 1;
+    const row = Math.floor(idx / 4);
+    const col = idx % 4;
+    return [(col + 0.5) / 4, (row + 0.5) / 4];
+  };
+
+  it.each([
+    [1, { kind: "swap" }],
+    [2, { kind: "split", side: "top" }],
+    [3, { kind: "split", side: "top" }],
+    [4, { kind: "swap" }],
+    [5, { kind: "split", side: "left" }],
+    [6, { kind: "swap" }],
+    [7, { kind: "swap" }],
+    [8, { kind: "split", side: "right" }],
+    [9, { kind: "split", side: "left" }],
+    [10, { kind: "swap" }],
+    [11, { kind: "swap" }],
+    [12, { kind: "split", side: "right" }],
+    [13, { kind: "swap" }],
+    [14, { kind: "split", side: "bottom" }],
+    [15, { kind: "split", side: "bottom" }],
+    [16, { kind: "swap" }],
+  ] as const)("cell %i classifies as %o", (cell, expected) => {
+    const [x, y] = cellCenter(cell);
+    expect(classifyDrop(x, y)).toEqual(expected);
+  });
+});
+
+describe("clampRatio / minRatioForPx", () => {
+  it("does not clamp a ratio comfortably inside the pixel-derived bound", () => {
+    expect(clampRatio(0.5, 100, 1000)).toBeCloseTo(0.5, 9);
+  });
+
+  it("clamps to the pixel-derived minimum, not a flat percent", () => {
+    // 120px minimum against a 400px total => 30% floor.
+    expect(minRatioForPx(120, 400)).toBeCloseTo(0.3, 9);
+    expect(clampRatio(0.05, 120, 400)).toBeCloseTo(0.3, 9);
+    expect(clampRatio(0.95, 120, 400)).toBeCloseTo(0.7, 9);
+  });
+
+  it("never returns a bound at or beyond 0.5 in either direction", () => {
+    expect(minRatioForPx(500, 400)).toBeLessThanOrEqual(0.5);
+  });
+});
+
+describe("invariants (aggie review, recommendation 4)", () => {
+  it("round-trip: leaves(spliceOutLeaf(insertAsNewLeaf(t, id), id)) === leaves(t)", () => {
+    const trees: SplitNode[] = [
+      leaf("solo"),
+      presetTree("vertical", ["a", "b", "c"]),
+      presetTree("tile", ["a", "b", "c", "d", "e"]),
+    ];
+    for (const tree of trees) {
+      const inserted = insertAsNewLeaf(tree, "NEW");
+      const spliced = spliceOutLeaf(inserted, "NEW");
+      expect(spliced && leaves(spliced)).toEqual(leaves(tree));
+    }
+  });
+
+  it("every ratio stays within the open interval (0, 1) after a sequence of operations", () => {
+    let tree = presetTree("tile", ["a", "b", "c", "d"]);
+    tree = insertAsNewLeaf(tree, "e");
+    tree = insertBeside(tree, "a", "top", "e");
+    tree = swapLeaves(tree, "b", "c");
+
+    const walk = (node: SplitNode): void => {
+      if (node.kind === "leaf") return;
+      expect(node.ratio).toBeGreaterThan(0);
+      expect(node.ratio).toBeLessThan(1);
+      walk(node.a);
+      walk(node.b);
+    };
+    walk(tree);
+  });
+});

--- a/app/src/paneTree.ts
+++ b/app/src/paneTree.ts
@@ -109,6 +109,16 @@ function contains(node: SplitNode, paneId: string): boolean {
  *
  * Self-drop (`targetPaneId === newPaneId`) is a no-op: the target IS the
  * dragged pane, so there is nothing to move.
+ *
+ * A missing `targetPaneId` (not found anywhere in `node`) is also a no-op,
+ * returning `node` unchanged (co1 review — was missing): without this
+ * guard, splicing `newPaneId` out first and then failing to find
+ * `targetPaneId` to replace would silently drop the dragged pane from the
+ * tree entirely, since `replaceLeaf` is itself a no-op when the target
+ * isn't found, but by then `newPaneId` has already been removed. Checked
+ * against the ORIGINAL tree, before any splicing — splicing `newPaneId`
+ * out never removes or moves an unrelated `targetPaneId` leaf, so its
+ * presence there is equivalent to its presence in the post-splice tree.
  */
 export function insertBeside(
   node: SplitNode,
@@ -117,6 +127,7 @@ export function insertBeside(
   newPaneId: string,
 ): SplitNode {
   if (targetPaneId === newPaneId) return node;
+  if (!contains(node, targetPaneId)) return node;
 
   const base = contains(node, newPaneId) ? (spliceOutLeaf(node, newPaneId) ?? node) : node;
   const axis: SplitAxis = side === "top" || side === "bottom" ? "row" : "col";
@@ -143,7 +154,18 @@ export function insertAsNewLeaf(node: SplitNode, newPaneId: string): SplitNode {
   return { kind: "split", axis: "col", ratio: (n - 1) / n, a: node, b: leaf(newPaneId) };
 }
 
-/** Renames a single leaf's paneId in place — the cross-window swap building block. */
+/**
+ * Renames a single leaf's paneId in place — the cross-window swap building
+ * block (see the design doc: cross-window swap is two independent
+ * `renameLeaf` calls, one per tree, each renaming the OTHER tree's pane in).
+ *
+ * Only safe when `newId` isn't already present in `node` — callers must
+ * apply at most one `renameLeaf` per tree (which is exactly what
+ * cross-window swap does: `oldId`/`newId` each live in a different tree, so
+ * neither call's `newId` can already be present in the tree it's applied
+ * to). Calling this with a `newId` that already exists in `node` would
+ * silently create two leaves sharing one paneId.
+ */
 export function renameLeaf(node: SplitNode, oldId: string, newId: string): SplitNode {
   if (node.kind === "leaf") {
     return node.paneId === oldId ? { ...node, paneId: newId } : node;

--- a/app/src/paneTree.ts
+++ b/app/src/paneTree.ts
@@ -1,0 +1,242 @@
+// A tab's pane arrangement as a binary split tree, replacing the old flat
+// `paneIds: string[]` + `layout: "vertical"|"horizontal"|"tile"` enum (see
+// design doc, issue #317). Every function here is pure — no React state, no
+// DOM, no Tauri APIs — so App.tsx only calls these and stores the resulting
+// tree; it doesn't contain any tree-shape logic of its own. That separation
+// is what makes this testable without a rendered component or a webview.
+//
+// Immutability convention used throughout: a function returns the SAME node
+// reference when nothing changed in that subtree, and only allocates a new
+// object on the path from the root to an actual change. Several functions
+// below (spliceOutLeaf, swapLeaves, renameLeaf) rely on that reference
+// equality to detect "was this the subtree that changed" without threading
+// an extra found-flag through the recursion.
+
+export type SplitAxis = "row" | "col";
+
+export type SplitNode =
+  | { kind: "leaf"; paneId: string }
+  | { kind: "split"; axis: SplitAxis; ratio: number; a: SplitNode; b: SplitNode };
+
+export type PaneRect = { left: number; top: number; width: number; height: number };
+
+export type DropSide = "top" | "bottom" | "left" | "right";
+export type DropZone = { kind: "swap" } | { kind: "split"; side: DropSide };
+
+function leaf(paneId: string): SplitNode {
+  return { kind: "leaf", paneId };
+}
+
+/** In-order leaf traversal — "which panes are in this tab", ignoring arrangement. */
+export function leaves(node: SplitNode): string[] {
+  if (node.kind === "leaf") return [node.paneId];
+  return [...leaves(node.a), ...leaves(node.b)];
+}
+
+const FULL_RECT: PaneRect = { left: 0, top: 0, width: 100, height: 100 };
+
+/** Walks the tree, splitting `rect` at each node's axis/ratio, returning every leaf's rect. */
+export function computeRects(node: SplitNode, rect: PaneRect = FULL_RECT): Map<string, PaneRect> {
+  if (node.kind === "leaf") return new Map([[node.paneId, rect]]);
+  const { axis, ratio, a, b } = node;
+  let rectA: PaneRect;
+  let rectB: PaneRect;
+  if (axis === "col") {
+    const aWidth = rect.width * ratio;
+    rectA = { ...rect, width: aWidth };
+    rectB = { ...rect, left: rect.left + aWidth, width: rect.width - aWidth };
+  } else {
+    const aHeight = rect.height * ratio;
+    rectA = { ...rect, height: aHeight };
+    rectB = { ...rect, top: rect.top + aHeight, height: rect.height - aHeight };
+  }
+  const rectsA = computeRects(a, rectA);
+  const rectsB = computeRects(b, rectB);
+  return new Map([...rectsA, ...rectsB]);
+}
+
+/**
+ * Removes a leaf, collapsing its parent (the sibling is promoted up to take
+ * the parent's own place). Returns `null` if `node` itself was just that one
+ * leaf (caller should close the window/tab, same as today when `paneIds`
+ * empties). Returns `node` unchanged (same reference) if `paneId` isn't
+ * found anywhere in this tree.
+ */
+export function spliceOutLeaf(node: SplitNode, paneId: string): SplitNode | null {
+  if (node.kind === "leaf") {
+    return node.paneId === paneId ? null : node;
+  }
+  const resultA = spliceOutLeaf(node.a, paneId);
+  if (resultA === null) return node.b;
+  if (resultA !== node.a) return { ...node, a: resultA };
+  const resultB = spliceOutLeaf(node.b, paneId);
+  if (resultB === null) return node.a;
+  if (resultB !== node.b) return { ...node, b: resultB };
+  return node;
+}
+
+function replaceLeaf(node: SplitNode, paneId: string, replacement: SplitNode): SplitNode {
+  if (node.kind === "leaf") {
+    return node.paneId === paneId ? replacement : node;
+  }
+  const a = replaceLeaf(node.a, paneId, replacement);
+  if (a !== node.a) return { ...node, a };
+  const b = replaceLeaf(node.b, paneId, replacement);
+  if (b !== node.b) return { ...node, b };
+  return node;
+}
+
+function contains(node: SplitNode, paneId: string): boolean {
+  if (node.kind === "leaf") return node.paneId === paneId;
+  return contains(node.a, paneId) || contains(node.b, paneId);
+}
+
+/**
+ * Directional split-drop: replaces the `targetPaneId` leaf with a new split
+ * node — `newPaneId` on the side the drop indicated, the target's existing
+ * pane on the other side.
+ *
+ * If `newPaneId` is already present in `node` (the common same-window drag
+ * case), it's spliced out FIRST, and `targetPaneId` is then re-located BY
+ * PANE ID in the resulting (post-splice) tree — not by any path captured
+ * before the splice. This matters when the target is the dragged pane's
+ * sibling: splicing collapses their shared parent and promotes the sibling
+ * to a new position, so a path captured beforehand would point at the wrong
+ * node afterward. Searching fresh, post-splice, sidesteps that entirely.
+ *
+ * If `newPaneId` is NOT present (e.g. the caller already spliced it out of
+ * another window's tree for a cross-window drop), it's inserted directly.
+ *
+ * Self-drop (`targetPaneId === newPaneId`) is a no-op: the target IS the
+ * dragged pane, so there is nothing to move.
+ */
+export function insertBeside(
+  node: SplitNode,
+  targetPaneId: string,
+  side: DropSide,
+  newPaneId: string,
+): SplitNode {
+  if (targetPaneId === newPaneId) return node;
+
+  const base = contains(node, newPaneId) ? (spliceOutLeaf(node, newPaneId) ?? node) : node;
+  const axis: SplitAxis = side === "top" || side === "bottom" ? "row" : "col";
+  const newIsFirst = side === "top" || side === "left";
+  const replacement: SplitNode = {
+    kind: "split",
+    axis,
+    ratio: 0.5,
+    a: newIsFirst ? leaf(newPaneId) : leaf(targetPaneId),
+    b: newIsFirst ? leaf(targetPaneId) : leaf(newPaneId),
+  };
+  return replaceLeaf(base, targetPaneId, replacement);
+}
+
+/**
+ * Appends `newPaneId` as a new rightmost column, giving it 1/n of the total
+ * width (n = leaf count after insertion) and uniformly compressing the
+ * existing tree's share to (n-1)/n — matching today's "adding a pane evenly
+ * redistributes all columns" behavior, rather than handing the new pane
+ * half the screen.
+ */
+export function insertAsNewLeaf(node: SplitNode, newPaneId: string): SplitNode {
+  const n = leaves(node).length + 1;
+  return { kind: "split", axis: "col", ratio: (n - 1) / n, a: node, b: leaf(newPaneId) };
+}
+
+/** Renames a single leaf's paneId in place — the cross-window swap building block. */
+export function renameLeaf(node: SplitNode, oldId: string, newId: string): SplitNode {
+  if (node.kind === "leaf") {
+    return node.paneId === oldId ? { ...node, paneId: newId } : node;
+  }
+  const a = renameLeaf(node.a, oldId, newId);
+  const b = renameLeaf(node.b, oldId, newId);
+  if (a === node.a && b === node.b) return node;
+  return { ...node, a, b };
+}
+
+/** Exchanges two leaves' paneIds within the SAME tree (tree shape unchanged). */
+export function swapLeaves(node: SplitNode, idA: string, idB: string): SplitNode {
+  if (node.kind === "leaf") {
+    if (node.paneId === idA) return { ...node, paneId: idB };
+    if (node.paneId === idB) return { ...node, paneId: idA };
+    return node;
+  }
+  const a = swapLeaves(node.a, idA, idB);
+  const b = swapLeaves(node.b, idA, idB);
+  if (a === node.a && b === node.b) return node;
+  return { ...node, a, b };
+}
+
+function chainNodes(axis: SplitAxis, nodes: SplitNode[]): SplitNode {
+  if (nodes.length === 1) return nodes[0];
+  return { kind: "split", axis, ratio: 1 / nodes.length, a: nodes[0], b: chainNodes(axis, nodes.slice(1)) };
+}
+
+// Row sizes for the "tile" preset — same grouping as the pre-tree
+// tileRowSizes in App.tsx: n=1→[1], 2→[2], 3→[2,1], 4→[2,2], 5→[3,2], ...
+function tileRowSizes(n: number): number[] {
+  const rows = n <= 2 ? 1 : Math.max(2, Math.ceil(n / 4));
+  const base = Math.floor(n / rows);
+  const extra = n % rows;
+  return Array.from({ length: rows }, (_, i) => base + (i < extra ? 1 : 0));
+}
+
+/**
+ * Discards whatever tree currently exists and rebuilds a fresh canonical
+ * tree for `preset` from `paneIds` — a one-shot RESET, not a persisted mode
+ * (confirmed with koit: picking Vertical/Horizontal/Tile from the menu just
+ * re-arranges the tab back to that pattern; it doesn't lock out further
+ * manual divider drags or split-drops afterward).
+ */
+export function presetTree(preset: "vertical" | "horizontal" | "tile", paneIds: string[]): SplitNode {
+  if (paneIds.length === 0) throw new Error("presetTree requires at least one pane");
+  if (paneIds.length === 1) return leaf(paneIds[0]);
+  if (preset === "vertical") return chainNodes("col", paneIds.map(leaf));
+  if (preset === "horizontal") return chainNodes("row", paneIds.map(leaf));
+  // tile: equal-height rows, each row an equal-width chain of its own panes.
+  const rows = tileRowSizes(paneIds.length);
+  let idx = 0;
+  const rowNodes = rows.map((size) => {
+    const rowIds = paneIds.slice(idx, idx + size);
+    idx += size;
+    return chainNodes("col", rowIds.map(leaf));
+  });
+  return chainNodes("row", rowNodes);
+}
+
+function band(frac: number): 0 | 1 | 2 | 3 {
+  return Math.min(3, Math.max(0, Math.floor(frac * 4))) as 0 | 1 | 2 | 3;
+}
+
+/**
+ * Classifies a drop position (fraction of the target pane's own rendered
+ * rect, 0–1 on each axis) into the 16-zone rule: divide each axis into 4
+ * bands and call band 0/3 "outer", 1/2 "inner". Corner (outer×outer) and
+ * center (inner×inner) both mean swap; an edge (exactly one axis outer)
+ * means directional split-replace on that edge.
+ */
+export function classifyDrop(xFrac: number, yFrac: number): DropZone {
+  const col = band(xFrac);
+  const row = band(yFrac);
+  const rowOuter = row === 0 || row === 3;
+  const colOuter = col === 0 || col === 3;
+  if (rowOuter === colOuter) return { kind: "swap" }; // corner or center
+  if (rowOuter) return { kind: "split", side: row === 0 ? "top" : "bottom" };
+  return { kind: "split", side: col === 0 ? "left" : "right" };
+}
+
+/**
+ * Converts a minimum-pixel divider constraint into a ratio bound against a
+ * node's own CURRENT rendered size in px (not a flat percent — a flat
+ * percent clamp still compounds under nesting: two nested 10%-clamped
+ * splits can produce a pane as small as 1% of the screen).
+ */
+export function minRatioForPx(minPx: number, totalPx: number): number {
+  if (totalPx <= 0) return 0.5;
+  return Math.min(0.5, minPx / totalPx);
+}
+
+export function clampRatio(ratio: number, minPx: number, totalPx: number): number {
+  const min = minRatioForPx(minPx, totalPx);
+  return Math.min(1 - min, Math.max(min, ratio));
+}

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Separate from vite.config.ts (which is tuned for Tauri dev/build — fixed
+// port, ignored src-tauri watch, TAURI_DEV_HOST). Tests here are plain TS
+// logic (paneTree.ts) with no DOM/React dependency, so no jsdom environment
+// or react plugin is needed.
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Part 1 of #317. Lands the pure data model and its full test coverage on its own before touching `App.tsx`'s rendering/drag-drop — a follow-up PR wires this in.

## Summary
- `app/src/paneTree.ts`: a binary split tree (`SplitNode`) that will replace the current flat `paneIds: string[]` + `layout` enum. Pure functions only — no React state, no DOM, no Tauri APIs: `leaves`, `computeRects`, `spliceOutLeaf`, `insertBeside`, `insertAsNewLeaf`, `renameLeaf`/`swapLeaves`, `presetTree`, `classifyDrop` (the 16-zone rule), `clampRatio`/`minRatioForPx`.
- Implements every decision from the #317 design doc's review round: self-drop/sibling-drop guards in `insertBeside` (re-searches the target by paneId in the post-splice tree, not by path), cross-window swap as two independent `renameLeaf` calls, `insertAsNewLeaf`'s `(n-1)/n` ratio, pixel-based ratio clamping.
- `app/src/paneTree.test.ts`: 48 tests — per-function cases, the full 16-cell drop-zone table from the design doc, and the 3 invariants from review (rect tiling completeness, insert/splice round-trip identity, ratio bounds).
- Introduces **vitest** as the frontend test runner (own `vitest.config.ts`, separate from the Tauri-tuned `vite.config.ts` since these tests have no DOM/React dependency) and a `pnpm test` script.
- `App.tsx` is untouched — `paneTree.ts` isn't wired in yet, so this is a pure addition with zero behavior change to the running app.

## Test plan
- [x] `pnpm test` — 48/48 pass
- [x] `pnpm build` (tsc + vite) — clean
- [x] `pnpm --dir app exec tsc --noEmit` — clean
- Coordinated with cc2 (#318, Rust test harness/CI) — no file overlap; CI wiring for `pnpm test` will land as a follow-up once #318 merges, rebased on top of it.