### PR TITLE
ci(app): gate the frontend vitest suite in app-check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -268,6 +268,10 @@ jobs:
         if: needs.changes.outputs.app_changed != 'false'
         run: pnpm exec tsc --noEmit
 
+      - name: Frontend tests
+        if: needs.changes.outputs.app_changed != 'false'
+        run: pnpm test
+
       - name: Bundle pinned agmsg-core
         if: needs.changes.outputs.app_changed != 'false'
         run: scripts/bundle-core.sh


### PR DESCRIPTION
## Summary
- \`pnpm test\` (vitest, 49 tests from #321's \`paneTree.ts\`) had no CI wiring — not actually a merge gate yet.
- Adds a "Frontend tests" step to \`app-check\`, right alongside the existing TypeScript typecheck / Rust tests steps, same fail-open \`if: needs.changes.outputs.app_changed != 'false'\` convention.
- Rebased on #320 (cc2's Rust test harness/CI) per coordination — no conflict, clean addition.

## Test plan
- [x] \`pnpm test\` locally — 49/49 pass
- [x] CI will exercise this step directly once opened