### PR TITLE
feat(app): wire pane split tree into rendering + drag-drop (issue #317, part 2)

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -881,6 +881,99 @@ body.resizing-row {
   outline: 2px dashed var(--accent);
   outline-offset: -2px;
 }
+
+/* Draggable dividers BETWEEN panes within one tab (issue #317) — absolutely
+   positioned within .stage (left/top/width/height % set inline from
+   collectDividers, see App.tsx), unlike .divider-v/.divider-h above (which
+   are flex-layout siblings for the sidebar/chat). Same generous-grab-area,
+   hairline-until-hover language as those. z-index above .pane-cell so the
+   grab area isn't occluded by a neighboring pane's own box. */
+.pane-divider-v,
+.pane-divider-h {
+  position: absolute;
+  z-index: 5;
+  background: transparent;
+}
+.pane-divider-v {
+  min-width: 7px;
+  margin-left: -3px;
+  cursor: col-resize;
+}
+.pane-divider-h {
+  min-height: 7px;
+  margin-top: -3px;
+  cursor: row-resize;
+}
+.pane-divider-v::before,
+.pane-divider-h::before {
+  content: "";
+  position: absolute;
+  background: var(--border);
+}
+.pane-divider-v::before {
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  transform: translateX(-50%);
+}
+.pane-divider-h::before {
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1px;
+  transform: translateY(-50%);
+}
+.pane-divider-v:hover::before {
+  left: 0;
+  width: 100%;
+  transform: none;
+  background: var(--accent);
+}
+.pane-divider-h:hover::before {
+  top: 0;
+  height: 100%;
+  transform: none;
+  background: var(--accent);
+}
+
+/* Directional split-drop preview (issue #317, classifyDrop's split zones):
+   the highlighted half is the one the dragged pane will occupy once
+   dropped — the target's existing pane keeps the other half. Without this,
+   the 16-zone rule (swap in the center, directional split near an edge)
+   would be undiscoverable — there'd be no visible difference between a
+   drop that swaps and one that splits until after the drop landed. */
+.pane-split-preview {
+  position: absolute;
+  z-index: 4;
+  background: var(--accent);
+  opacity: 0.25;
+  pointer-events: none;
+}
+.pane-split-preview.preview-top {
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 50%;
+}
+.pane-split-preview.preview-bottom {
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 50%;
+}
+.pane-split-preview.preview-left {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 50%;
+}
+.pane-split-preview.preview-right {
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 50%;
+}
 /* Slow pulse shows which delivery path is watching this pane — see
    Pane.native. Green = the type self-delivers (its own agmsg Monitor);
    accent (blue) = the app's universal stdin-inject monitor is doing it.

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -885,9 +885,11 @@ body.resizing-row {
 /* Draggable dividers BETWEEN panes within one tab (issue #317) — absolutely
    positioned within .stage (left/top/width/height % set inline from
    collectDividers, see App.tsx), unlike .divider-v/.divider-h above (which
-   are flex-layout siblings for the sidebar/chat). Same generous-grab-area,
-   hairline-until-hover language as those. z-index above .pane-cell so the
-   grab area isn't occluded by a neighboring pane's own box. */
+   are flex-layout siblings for the sidebar/chat). Same grab-width (3px,
+   matching .divider-v/.divider-h's own `flex: 0 0 3px`) and
+   hairline-until-hover language as those (aggie review — this one was
+   originally wider and stood out as inconsistent). z-index above .pane-cell
+   so the grab area isn't occluded by a neighboring pane's own box. */
 .pane-divider-v,
 .pane-divider-h {
   position: absolute;
@@ -895,13 +897,13 @@ body.resizing-row {
   background: transparent;
 }
 .pane-divider-v {
-  min-width: 7px;
-  margin-left: -3px;
+  min-width: 3px;
+  margin-left: -1.5px;
   cursor: col-resize;
 }
 .pane-divider-h {
-  min-height: 7px;
-  margin-top: -3px;
+  min-height: 3px;
+  margin-top: -1.5px;
   cursor: row-resize;
 }
 .pane-divider-v::before,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -457,6 +457,11 @@ export default function App() {
 
   // Remove a pane from whichever window holds it. If that empties the window,
   // drop the window too and fall back to the team room if it was active.
+  // Splice-only — it never re-homes the pane into some other window (that's
+  // moveToNewWindow/movePaneToWindow's job) — which is exactly what
+  // splitPaneBeside's cross-window path relies on: detach here, then insert
+  // into the target tree in a SEPARATE setWindows call, with no risk of the
+  // paneId briefly (or permanently) existing as a leaf in two windows at once.
   const detachPane = useCallback((paneId: string) => {
     const owner = windowsRef.current.find((w) => leaves(w.root).includes(paneId));
     if (!owner) return;
@@ -849,6 +854,10 @@ export default function App() {
     e.preventDefault();
     const stage = (e.currentTarget as HTMLElement).closest(".stage") as HTMLElement | null;
     if (!stage) return;
+    // Captured once at drag-start, not re-measured per mousemove — if the OS
+    // window itself is resized mid-drag (rare, and only for the duration of
+    // this one gesture), the math below would be against a stale box. Not
+    // worth guarding: the next drag on the same divider recaptures it fresh.
     const stageBox = stage.getBoundingClientRect();
     const parentPx = {
       left: stageBox.left + (divider.bounds.left / 100) * stageBox.width,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -12,6 +12,25 @@ import {
   RenameModal,
   SettingsModal,
 } from "./modals";
+import {
+  classifyDrop,
+  clampRatio,
+  collectDividers,
+  computeRects,
+  insertAsNewLeaf,
+  insertBeside,
+  leaves,
+  presetTree,
+  renameLeaf,
+  sameZone,
+  spliceOutLeaf,
+  swapLeaves,
+  updateRatioAtPath,
+  type DividerInfo,
+  type DropSide,
+  type PaneRect,
+  type SplitNode,
+} from "./paneTree";
 import "./App.css";
 
 export type Member = { name: string; types: string[]; project: string };
@@ -35,11 +54,13 @@ type Pane = {
    *  grok-build, hermes, ...): the app's stdin-inject IS their only delivery. */
   native: boolean;
 };
-// A tab. Holds one or more panes, arranged per its `layout` (see paneRect) —
-// a flat split for now, ahead of tmux-style nested layouts later.
+// A tab. Holds one or more panes, arranged as a binary split tree (see
+// paneTree.ts) — draggable dividers and directional split/swap drag-drop
+// (issue #317) both need real nested structure, which a flat list + layout
+// enum couldn't represent (see the design doc on that issue for why).
 type Window = {
   id: string;
-  paneIds: string[];
+  root: SplitNode;
   /** User-set tab name (Rename); falls back to the joined pane labels. */
   customLabel?: string;
   /** The team this tab was spawned under. Agents can't message across
@@ -48,13 +69,18 @@ type Window = {
    *  it doesn't. Windows for other teams stay mounted (PTYs alive) but
    *  hidden until that team is selected again. */
   team: string;
-  /** How this tab's panes are arranged. "vertical" (default, what plain
-   *  spawn produces): side-by-side full-height columns. "horizontal":
-   *  stacked full-width rows. "tile": a grid, row count/sizes from
-   *  tileRowSizes — see its comment for the rule. */
-  layout: PaneLayout;
 };
+// The three canonical arrangements offered from the right-click Layout
+// submenu and the native View > Pane Layout menu. Picking one is a one-shot
+// RESET (presetTree in paneTree.ts) — it discards whatever manual divider
+// drags or split-drops produced and rebuilds a fresh tree matching the
+// preset; it is NOT a persisted mode the window stays locked into.
 type PaneLayout = "vertical" | "horizontal" | "tile";
+// A pane being dragged, and where within the target pane it's hovering —
+// drives both the drop classification (paneTree's classifyDrop) and the
+// half-occupied preview highlight (see dropPreview below). null while
+// nothing is being dragged over a pane.
+type DropPreview = { paneId: string; zone: ReturnType<typeof classifyDrop> };
 type Modal =
   | { kind: "team"; firstRun: boolean }
   | { kind: "agent" }
@@ -82,47 +108,6 @@ const LAST_TEAM_KEY = "agmsg-app-last-team";
 const PANE_DRAG_MIME = "application/x-agmsg-pane";
 // A spawnable agent type discovered from agmsg's type registry.
 export type AgentType = { name: string; cli: string; options: string[] };
-
-// Row sizes for the "tile" layout, front-loading the extra pane(s) onto the
-// earlier (top) rows: n=1→[1], 2→[2], 3→[2,1], 4→[2,2], 5→[3,2], 6→[3,3],
-// 7→[4,3], 8→[4,4], 9→[3,3,3]. Row count caps at 4 columns/row (using 2 rows
-// once that's exceeded) and never drops below 2 rows once n≥3 — a single
-// row of 3+ reads as "vertical" layout, not a tile grid.
-function tileRowSizes(n: number): number[] {
-  const rows = n <= 2 ? 1 : Math.max(2, Math.ceil(n / 4));
-  const base = Math.floor(n / rows);
-  const extra = n % rows;
-  return Array.from({ length: rows }, (_, i) => base + (i < extra ? 1 : 0));
-}
-
-type PaneRect = { left: number; top: number; width: number; height: number };
-
-// A pane's position/size (all percentages of the tab's stage area) for
-// `layout`, given its index among `count` panes in the same window.
-function paneRect(layout: PaneLayout, idx: number, count: number): PaneRect {
-  if (layout === "horizontal") {
-    return { left: 0, width: 100, top: (idx * 100) / count, height: 100 / count };
-  }
-  if (layout === "tile") {
-    const rowSizes = tileRowSizes(count);
-    let seen = 0;
-    for (let row = 0; row < rowSizes.length; row++) {
-      const rowSize = rowSizes[row];
-      if (idx < seen + rowSize) {
-        const col = idx - seen;
-        return {
-          left: (col * 100) / rowSize,
-          width: 100 / rowSize,
-          top: (row * 100) / rowSizes.length,
-          height: 100 / rowSizes.length,
-        };
-      }
-      seen += rowSize;
-    }
-  }
-  // "vertical" (default): side-by-side full-height columns.
-  return { left: (idx * 100) / count, width: 100 / count, top: 0, height: 100 };
-}
 
 export default function App() {
   const { t } = useTranslation();
@@ -191,10 +176,12 @@ export default function App() {
   // same "armed" highlight, since they're just two ways to pick the same
   // pane up.
   const [swapSource, setSwapSource] = useState<string | null>(null);
-  // The pane currently under the cursor during a drag — highlighted as the
-  // drop target. Separate from swapSource: that's "picked up", this is
-  // "hovering over".
-  const [dragOverPaneId, setDragOverPaneId] = useState<string | null>(null);
+  // The pane currently under the cursor during a drag, and which of
+  // paneTree's 16 drop zones it's over — drives both the drop's outcome
+  // (swap vs. directional split-replace, see classifyDrop) and the preview
+  // highlight showing which half will be occupied. Separate from
+  // swapSource: that's "picked up", this is "hovering over".
+  const [dropPreview, setDropPreview] = useState<DropPreview | null>(null);
   // Same idea, but for tabs — dropping a pane header on a tab moves it into
   // that tab instead of swapping within the current one.
   const [dragOverWindowId, setDragOverWindowId] = useState<string | null>(null);
@@ -471,16 +458,14 @@ export default function App() {
   // Remove a pane from whichever window holds it. If that empties the window,
   // drop the window too and fall back to the team room if it was active.
   const detachPane = useCallback((paneId: string) => {
-    const owner = windowsRef.current.find((w) => w.paneIds.includes(paneId));
+    const owner = windowsRef.current.find((w) => leaves(w.root).includes(paneId));
     if (!owner) return;
-    const remaining = owner.paneIds.filter((id) => id !== paneId);
-    setWindows((prev) =>
-      prev
-        .map((w) => (w.id === owner.id ? { ...w, paneIds: remaining } : w))
-        .filter((w) => w.paneIds.length > 0),
-    );
-    if (remaining.length === 0) {
+    const nextRoot = spliceOutLeaf(owner.root, paneId);
+    if (nextRoot === null) {
+      setWindows((prev) => prev.filter((w) => w.id !== owner.id));
       setActive((a) => (a === owner.id ? "room" : a));
+    } else {
+      setWindows((prev) => prev.map((w) => (w.id === owner.id ? { ...w, root: nextRoot } : w)));
     }
   }, []);
 
@@ -492,7 +477,7 @@ export default function App() {
       // focus its window (one live agent per identity).
       const existing = panesRef.current.find((p) => p.label === m.name);
       if (existing) {
-        const w = windowsRef.current.find((win) => win.paneIds.includes(existing.id));
+        const w = windowsRef.current.find((win) => leaves(win.root).includes(existing.id));
         if (w) setActive(w.id);
         return;
       }
@@ -543,12 +528,12 @@ export default function App() {
       setPanes((prev) => [...prev, pane]);
       if (targetWindowId) {
         setWindows((prev) =>
-          prev.map((w) => (w.id === targetWindowId ? { ...w, paneIds: [...w.paneIds, id] } : w)),
+          prev.map((w) => (w.id === targetWindowId ? { ...w, root: insertAsNewLeaf(w.root, id) } : w)),
         );
         setActive(targetWindowId);
       } else {
         const winId = `w-${seq.current++}`;
-        setWindows((prev) => [...prev, { id: winId, paneIds: [id], team, layout: "vertical" }]);
+        setWindows((prev) => [...prev, { id: winId, root: { kind: "leaf", paneId: id }, team }]);
         setActive(winId);
       }
     },
@@ -570,24 +555,25 @@ export default function App() {
   const closeWindow = useCallback((windowId: string) => {
     const w = windowsRef.current.find((x) => x.id === windowId);
     if (!w) return;
-    for (const pid of w.paneIds) void invoke("pty_kill", { id: pid });
-    setPanes((prev) => prev.filter((p) => !w.paneIds.includes(p.id)));
+    const paneIds = leaves(w.root);
+    for (const pid of paneIds) void invoke("pty_kill", { id: pid });
+    setPanes((prev) => prev.filter((p) => !paneIds.includes(p.id)));
     setWindows((prev) => prev.filter((x) => x.id !== windowId));
     setActive((a) => (a === windowId ? "room" : a));
   }, []);
 
   // Move a pane into another tab, adding it to that tab's side-by-side split
-  // (uncapped — N panes in a tab render as N equal columns). The pane's own
-  // DOM node never unmounts (see the stage render below), so this is a pure
-  // reassignment — the running process and its scrollback are untouched, same
-  // as a tmux pane move.
+  // (uncapped — N panes in a tab render as N equal columns, see
+  // insertAsNewLeaf). The pane's own DOM node never unmounts (see the stage
+  // render below), so this is a pure reassignment — the running process and
+  // its scrollback are untouched, same as a tmux pane move.
   const movePaneToWindow = useCallback(
     (paneId: string, targetWindowId: string) => {
       const target = windowsRef.current.find((w) => w.id === targetWindowId);
-      if (!target || target.paneIds.includes(paneId)) return;
+      if (!target || leaves(target.root).includes(paneId)) return;
       detachPane(paneId);
       setWindows((prev) =>
-        prev.map((w) => (w.id === targetWindowId ? { ...w, paneIds: [...w.paneIds, paneId] } : w)),
+        prev.map((w) => (w.id === targetWindowId ? { ...w, root: insertAsNewLeaf(w.root, paneId) } : w)),
       );
       setActive(targetWindowId);
     },
@@ -600,31 +586,73 @@ export default function App() {
     (paneId: string) => {
       detachPane(paneId);
       const winId = `w-${seq.current++}`;
-      setWindows((prev) => [...prev, { id: winId, paneIds: [paneId], team, layout: "vertical" }]);
+      setWindows((prev) => [...prev, { id: winId, root: { kind: "leaf", paneId }, team }]);
       setActive(winId);
     },
     [detachPane, team],
   );
 
-  // Swap two panes' positions within the same window (paneRect derives
-  // position purely from index in paneIds, so this is all a layout swap
-  // needs — no DOM remount, same as every other pane move in this file).
+  // Swap two panes' positions within the same window (tree shape unchanged
+  // — no DOM remount, same as every other pane move in this file).
   const swapPanesInWindow = useCallback((windowId: string, paneA: string, paneB: string) => {
     setWindows((prev) =>
-      prev.map((w) => {
-        if (w.id !== windowId) return w;
-        const ids = [...w.paneIds];
-        const i = ids.indexOf(paneA);
-        const j = ids.indexOf(paneB);
-        if (i === -1 || j === -1) return w;
-        [ids[i], ids[j]] = [ids[j], ids[i]];
-        return { ...w, paneIds: ids };
-      }),
+      prev.map((w) => (w.id === windowId ? { ...w, root: swapLeaves(w.root, paneA, paneB) } : w)),
     );
   }, []);
 
+  // Swap two panes across DIFFERENT windows — the "drop near the center of
+  // another window's pane" case from the directional drag-drop rule
+  // (classifyDrop's swap zones). Two independent renameLeaf calls, one per
+  // tree (see paneTree.ts's renameLeaf doc): each tree keeps its shape, just
+  // the paneId at that leaf changes. Delegates to swapPanesInWindow when
+  // both panes turn out to already be in the same window.
+  const swapPanesAcrossWindows = useCallback(
+    (paneA: string, windowIdB: string, paneB: string) => {
+      const windowA = windowsRef.current.find((w) => leaves(w.root).includes(paneA));
+      if (!windowA) return;
+      if (windowA.id === windowIdB) {
+        swapPanesInWindow(windowIdB, paneA, paneB);
+        return;
+      }
+      setWindows((prev) =>
+        prev.map((w) => {
+          if (w.id === windowA.id) return { ...w, root: renameLeaf(w.root, paneA, paneB) };
+          if (w.id === windowIdB) return { ...w, root: renameLeaf(w.root, paneB, paneA) };
+          return w;
+        }),
+      );
+    },
+    [swapPanesInWindow],
+  );
+
+  // Directional split-drop (classifyDrop's split zones): `sourcePaneId`
+  // becomes a new sibling of `targetPaneId` on `side`, splitting that leaf.
+  // Same-window: insertBeside handles splicing sourcePaneId out of its
+  // current spot in that same tree itself (see its own doc — this is
+  // exactly the "newPaneId already present" path). Cross-window: detach it
+  // from its own window's tree first (same detach the right-click Move-to
+  // path already uses), then insertBeside finds it absent and inserts
+  // directly.
+  const splitPaneBeside = useCallback(
+    (sourcePaneId: string, targetWindowId: string, targetPaneId: string, side: DropSide) => {
+      const sourceWindow = windowsRef.current.find((w) => leaves(w.root).includes(sourcePaneId));
+      if (sourceWindow && sourceWindow.id !== targetWindowId) {
+        detachPane(sourcePaneId);
+      }
+      setWindows((prev) =>
+        prev.map((w) =>
+          w.id === targetWindowId ? { ...w, root: insertBeside(w.root, targetPaneId, side, sourcePaneId) } : w,
+        ),
+      );
+      setActive(targetWindowId);
+    },
+    [detachPane],
+  );
+
   const setWindowLayout = useCallback((windowId: string, layout: PaneLayout) => {
-    setWindows((prev) => prev.map((w) => (w.id === windowId ? { ...w, layout } : w)));
+    setWindows((prev) =>
+      prev.map((w) => (w.id === windowId ? { ...w, root: presetTree(layout, leaves(w.root)) } : w)),
+    );
   }, []);
 
   // Native "View > Pane Layout" menu items duplicate the right-click-tab
@@ -642,7 +670,7 @@ export default function App() {
   const windowLabel = useCallback(
     (w: Window) =>
       w.customLabel ??
-      w.paneIds
+      leaves(w.root)
         .map((pid) => panes.find((p) => p.id === pid)?.label)
         .filter(Boolean)
         .join(" · "),
@@ -653,6 +681,24 @@ export default function App() {
   // teams' windows stay mounted with their PTYs alive, just not listed
   // here or offered as spawn/move targets.
   const teamWindows = useMemo(() => windows.filter((w) => w.team === team), [windows, team]);
+
+  // Every window's leaf rects, computed once per render rather than per-pane
+  // (computeRects walks the whole tree) — looked up by window id, then pane
+  // id, in the panes.map below and again for each window's dividers.
+  const rectsByWindow = useMemo(() => {
+    const m = new Map<string, Map<string, PaneRect>>();
+    for (const w of windows) m.set(w.id, computeRects(w.root));
+    return m;
+  }, [windows]);
+
+  // Dividers only for the currently active window — they're pure UI chrome
+  // with no state of their own beyond the tree's ratios, unlike panes (which
+  // stay mounted while inactive to keep their PTY alive), so there's no
+  // reason to render an invisible window's dividers too.
+  const activeDividers = useMemo(() => {
+    const w = windows.find((win) => win.id === active);
+    return w ? collectDividers(w.root) : [];
+  }, [windows, active]);
 
   const startRenameWindow = useCallback(
     (windowId: string) => {
@@ -790,6 +836,50 @@ export default function App() {
     },
     [chatHeight],
   );
+
+  // Draggable pane dividers (issue #317). Same document-level drag-tracking
+  // pattern as startSidebarDrag/startChatDrag above, but the ratio being
+  // dragged belongs to one specific split node (divider.path) rather than a
+  // single flat width/height — updateRatioAtPath's own doc explains why
+  // reusing this path across the whole gesture is safe (a ratio edit never
+  // changes the tree's shape). divider.bounds is that node's OWN un-split
+  // rect (not the whole stage) — converting a pixel delta into a ratio has
+  // to be relative to the parent being split, not the stage as a whole.
+  const startPaneDividerDrag = useCallback((e: React.MouseEvent, windowId: string, divider: DividerInfo) => {
+    e.preventDefault();
+    const stage = (e.currentTarget as HTMLElement).closest(".stage") as HTMLElement | null;
+    if (!stage) return;
+    const stageBox = stage.getBoundingClientRect();
+    const parentPx = {
+      left: stageBox.left + (divider.bounds.left / 100) * stageBox.width,
+      top: stageBox.top + (divider.bounds.top / 100) * stageBox.height,
+      width: (divider.bounds.width / 100) * stageBox.width,
+      height: (divider.bounds.height / 100) * stageBox.height,
+    };
+    const axis = divider.axis;
+    // Minimum pane size in px, converted to a ratio bound against THIS
+    // divider's own parent size (paneTree's clampRatio) rather than a flat
+    // percent — a flat percent clamp still compounds under nesting (see its
+    // own doc).
+    const MIN_PANE_PX = 120;
+    const cursorClass = axis === "col" ? "resizing-col" : "resizing-row";
+    const onMove = (ev: MouseEvent) => {
+      const totalPx = axis === "col" ? parentPx.width : parentPx.height;
+      const raw = axis === "col" ? (ev.clientX - parentPx.left) / totalPx : (ev.clientY - parentPx.top) / totalPx;
+      const ratio = clampRatio(raw, MIN_PANE_PX, totalPx);
+      setWindows((prev) =>
+        prev.map((w) => (w.id === windowId ? { ...w, root: updateRatioAtPath(w.root, divider.path, ratio) } : w)),
+      );
+    };
+    const onUp = () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.body.classList.remove(cursorClass);
+    };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    document.body.classList.add(cursorClass);
+  }, []);
 
   return (
     <div
@@ -1117,28 +1207,27 @@ export default function App() {
             </div>
 
             {/* Every pane is a permanent, flat child of .stage — its window only
-                decides WHERE it's positioned (paneRect, from its layout),
-                never whether it's mounted. That keeps each pane's DOM node
-                (and TerminalPane's xterm + PTY listeners) alive across a
+                decides WHERE it's positioned (computeRects, from its split
+                tree), never whether it's mounted. That keeps each pane's DOM
+                node (and TerminalPane's xterm + PTY listeners) alive across a
                 Move-to or a layout change, so the running process and its
                 scrollback survive — the same pane split tmux gives you, not
                 a respawn. Inactive-window panes go visibility:hidden but
                 stay laid out, so a resize doesn't leave them stale for next
                 time. */}
             {panes.map((p) => {
-              const win = windows.find((w) => w.paneIds.includes(p.id));
+              const win = windows.find((w) => leaves(w.root).includes(p.id));
               if (!win) return null;
-              const idx = win.paneIds.indexOf(p.id);
-              const count = win.paneIds.length;
-              const rect = paneRect(win.layout, idx, count);
+              const rect = rectsByWindow.get(win.id)?.get(p.id);
+              if (!rect) return null;
               const isActiveWindow = active === win.id;
-              const isDropTarget = dragOverPaneId === p.id && swapSource !== p.id;
+              const preview = dropPreview?.paneId === p.id && swapSource !== p.id ? dropPreview.zone : null;
               return (
                 <div
                   key={p.id}
                   className={[
                     isActiveWindow ? "pane-cell" : "pane-cell inactive",
-                    isDropTarget && "drop-target",
+                    preview?.kind === "swap" && "drop-target",
                   ]
                     .filter(Boolean)
                     .join(" ")}
@@ -1160,7 +1249,15 @@ export default function App() {
                     if (!e.dataTransfer.types.includes(PANE_DRAG_MIME)) return;
                     e.preventDefault(); // required to allow dropping
                     e.dataTransfer.dropEffect = "move";
-                    setDragOverPaneId((cur) => (cur === p.id ? cur : p.id));
+                    // Classify by WHERE within this pane's own box the
+                    // cursor is (paneTree's 16-zone rule) — corner/center
+                    // bands mean swap (today's behavior), an edge band
+                    // means a directional split-replace on that side.
+                    const box = e.currentTarget.getBoundingClientRect();
+                    const xFrac = (e.clientX - box.left) / box.width;
+                    const yFrac = (e.clientY - box.top) / box.height;
+                    const zone = classifyDrop(xFrac, yFrac);
+                    setDropPreview((cur) => (cur?.paneId === p.id && sameZone(cur.zone, zone) ? cur : { paneId: p.id, zone }));
                   }}
                   onDragLeave={(e) => {
                     // Only clear if we're leaving this cell for something
@@ -1168,19 +1265,26 @@ export default function App() {
                     // from the header onto the terminal below) shouldn't
                     // flicker the highlight off.
                     if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                      setDragOverPaneId((cur) => (cur === p.id ? null : cur));
+                      setDropPreview((cur) => (cur?.paneId === p.id ? null : cur));
                     }
                   }}
                   onDrop={(e) => {
                     e.preventDefault();
-                    setDragOverPaneId(null);
+                    const zone = dropPreview?.paneId === p.id ? dropPreview.zone : null;
+                    setDropPreview(null);
                     setSwapSource(null);
                     const sourceId = e.dataTransfer.getData(PANE_DRAG_MIME);
-                    if (sourceId && win.paneIds.includes(sourceId) && sourceId !== p.id) {
-                      swapPanesInWindow(win.id, sourceId, p.id);
+                    if (!sourceId || sourceId === p.id || !zone) return;
+                    if (zone.kind === "swap") {
+                      swapPanesAcrossWindows(sourceId, win.id, p.id);
+                    } else {
+                      splitPaneBeside(sourceId, win.id, p.id, zone.side);
                     }
                   }}
                 >
+                  {preview?.kind === "split" && (
+                    <div className={`pane-split-preview preview-${preview.side}`} />
+                  )}
                   <div
                     className="pane-header"
                     onContextMenu={(e) => {
@@ -1217,7 +1321,7 @@ export default function App() {
                       }}
                       onDragEnd={() => {
                         setSwapSource(null);
-                        setDragOverPaneId(null);
+                        setDropPreview(null);
                         setDragOverWindowId(null);
                         setDragOverNewTab(false);
                       }}
@@ -1225,7 +1329,7 @@ export default function App() {
                         e.stopPropagation();
                         if (swapSource === p.id) {
                           setSwapSource(null);
-                        } else if (swapSource && win.paneIds.includes(swapSource)) {
+                        } else if (swapSource && leaves(win.root).includes(swapSource)) {
                           swapPanesInWindow(win.id, swapSource, p.id);
                           setSwapSource(null);
                         } else {
@@ -1254,6 +1358,21 @@ export default function App() {
                 </div>
               );
             })}
+
+            {active !== "room" &&
+              activeDividers.map((d) => (
+                <div
+                  key={d.path.join(".") || "root"}
+                  className={d.axis === "col" ? "pane-divider-v" : "pane-divider-h"}
+                  style={{
+                    left: `${d.rect.left}%`,
+                    top: `${d.rect.top}%`,
+                    width: `${d.rect.width}%`,
+                    height: `${d.rect.height}%`,
+                  }}
+                  onMouseDown={(e) => startPaneDividerDrag(e, active, d)}
+                />
+              ))}
           </section>
 
           {showUserChat && <div className="divider-h" onMouseDown={startChatDrag} />}
@@ -1366,7 +1485,7 @@ export default function App() {
         (() => {
           const win = windows.find((w) => w.id === modal.windowId);
           if (!win) return null;
-          const names = win.paneIds
+          const names = leaves(win.root)
             .map((pid) => panes.find((p) => p.id === pid)?.label)
             .filter((n): n is string => Boolean(n));
           return (
@@ -1468,13 +1587,14 @@ export default function App() {
           const otherWindows = windows.filter(
             (w) => w.id !== paneMenu.windowId && w.team === sourceWindow?.team,
           );
+          const sourceLeaves = sourceWindow ? leaves(sourceWindow.root) : [];
           // Only offer "split off into a new tab" when this pane is currently
           // sharing its window — if it's already alone, a new tab would be a no-op.
-          const canSplitOff = (sourceWindow?.paneIds.length ?? 1) > 1;
+          const canSplitOff = sourceLeaves.length > 1;
           // Sibling panes in the same tab — the same swap the header's
           // click/drag already does, exposed here too for symmetry with
           // "Move to ▸".
-          const siblingPanes = (sourceWindow?.paneIds ?? [])
+          const siblingPanes = sourceLeaves
             .filter((pid) => pid !== paneMenu.paneId)
             .map((pid) => panes.find((p) => p.id === pid))
             .filter((p): p is Pane => p != null);
@@ -1549,7 +1669,6 @@ export default function App() {
 
       {windowMenu &&
         (() => {
-          const win = windows.find((w) => w.id === windowMenu.windowId);
           const layouts: PaneLayout[] = ["vertical", "horizontal", "tile"];
           return (
             <div
@@ -1568,10 +1687,14 @@ export default function App() {
               <div className="submenu-trigger">
                 <span className="submenu-label">{t("ctxMenu.window.layout")}</span>
                 <div className="submenu">
+                  {/* No "active" highlight here (unlike before): a preset is a
+                      one-shot reset, not a persisted mode (issue #317) — the
+                      tab's actual arrangement can be any shape after manual
+                      divider drags or split-drops, so no single preset button
+                      is "the current one" to mark. */}
                   {layouts.map((l) => (
                     <button
                       key={l}
-                      className={win?.layout === l ? "active" : undefined}
                       onClick={() => {
                         setWindowLayout(windowMenu.windowId, l);
                         setWindowMenu(null);

--- a/app/src/TerminalPane.tsx
+++ b/app/src/TerminalPane.tsx
@@ -92,12 +92,24 @@ export function TerminalPane({ id, cmd, args = [], cwd }: Props) {
     })();
 
     // Re-fit whenever the pane's box changes — covers initial layout, switching
-    // back to this tab (display:none -> block), and window resizes.
-    const ro = new ResizeObserver(() => fitNow());
+    // back to this tab (display:none -> block), and window resizes. Also
+    // fires continuously while a divider is being dragged (issue #317):
+    // debounced here rather than reacting to every single event, since
+    // fitNow's fit.fit() + pty_resize is expensive and can spam some CLIs
+    // with rapid SIGWINCH in a way that garbles their redraw — the dragged
+    // pane's own CSS size still tracks the cursor live (that's just the
+    // browser reflowing .pane-cell's inline style), only the actual PTY
+    // resize + xterm reflow is throttled.
+    let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+    const ro = new ResizeObserver(() => {
+      if (resizeTimer) clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(fitNow, 75);
+    });
     if (ref.current) ro.observe(ref.current);
 
     return () => {
       disposed = true;
+      if (resizeTimer) clearTimeout(resizeTimer);
       ro.disconnect();
       unlisteners.forEach((u) => u());
       void invoke("pty_kill", { id });

--- a/app/src/paneTree.test.ts
+++ b/app/src/paneTree.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   classifyDrop,
   clampRatio,
+  collectDividers,
   computeRects,
   insertAsNewLeaf,
   insertBeside,
@@ -9,8 +10,10 @@ import {
   minRatioForPx,
   presetTree,
   renameLeaf,
+  sameZone,
   spliceOutLeaf,
   swapLeaves,
+  updateRatioAtPath,
   type SplitNode,
 } from "./paneTree";
 
@@ -84,6 +87,73 @@ describe("computeRects", () => {
       for (const r of rects.values()) area += (r.width / 100) * (r.height / 100);
       expect(area).toBeCloseTo(1, 9);
     }
+  });
+});
+
+describe("updateRatioAtPath", () => {
+  it("updates the root node's ratio at an empty path", () => {
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    expect(updateRatioAtPath(tree, [], 0.3)).toEqual(split("col", 0.3, leaf("p1"), leaf("p2")));
+  });
+
+  it("updates a nested node's ratio, leaving the rest of the tree untouched", () => {
+    const tree = split("col", 0.5, leaf("p1"), split("row", 0.5, leaf("p2"), leaf("p3")));
+    const result = updateRatioAtPath(tree, ["b"], 0.75);
+    expect(result).toEqual(split("col", 0.5, leaf("p1"), split("row", 0.75, leaf("p2"), leaf("p3"))));
+  });
+
+  it("is a no-op when the path runs into a leaf (stale path safety)", () => {
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    expect(updateRatioAtPath(tree, ["a", "b"], 0.9)).toBe(tree);
+  });
+});
+
+describe("collectDividers", () => {
+  it("returns one divider per internal split node, at the seam between its children", () => {
+    const tree = split("col", 0.25, leaf("p1"), leaf("p2"));
+    const dividers = collectDividers(tree);
+    expect(dividers).toEqual([
+      {
+        path: [],
+        axis: "col",
+        ratio: 0.25,
+        rect: { left: 25, top: 0, width: 0, height: 100 },
+        bounds: { left: 0, top: 0, width: 100, height: 100 },
+      },
+    ]);
+  });
+
+  it("returns no dividers for a bare leaf", () => {
+    expect(collectDividers(leaf("solo"))).toEqual([]);
+  });
+
+  it("returns one divider per split node in a nested tree, each with its own seam and PARENT bounds (not the whole stage)", () => {
+    const tree = split("col", 0.5, leaf("p1"), split("row", 0.5, leaf("p2"), leaf("p3")));
+    const dividers = collectDividers(tree);
+    expect(dividers).toHaveLength(2);
+    expect(dividers.find((d) => d.path.length === 0)).toEqual({
+      path: [],
+      axis: "col",
+      ratio: 0.5,
+      rect: { left: 50, top: 0, width: 0, height: 100 },
+      bounds: { left: 0, top: 0, width: 100, height: 100 },
+    });
+    expect(dividers.find((d) => d.path.length === 1)).toEqual({
+      path: ["b"],
+      axis: "row",
+      ratio: 0.5,
+      rect: { left: 50, top: 50, width: 50, height: 0 },
+      // The nested divider's bounds are its OWN parent's rect (the "b" child
+      // of the root split — half the stage), not the full stage.
+      bounds: { left: 50, top: 0, width: 50, height: 100 },
+    });
+  });
+
+  it("a path from collectDividers round-trips through updateRatioAtPath", () => {
+    const tree = split("col", 0.5, leaf("p1"), split("row", 0.5, leaf("p2"), leaf("p3")));
+    const nested = collectDividers(tree).find((d) => d.path.length === 1)!;
+    const result = updateRatioAtPath(tree, nested.path, 0.8);
+    expect(result).toEqual(split("col", 0.5, leaf("p1"), split("row", 0.8, leaf("p2"), leaf("p3"))));
   });
 });
 
@@ -270,6 +340,24 @@ describe("classifyDrop (16-zone rule)", () => {
   ] as const)("cell %i classifies as %o", (cell, expected) => {
     const [x, y] = cellCenter(cell);
     expect(classifyDrop(x, y)).toEqual(expected);
+  });
+});
+
+describe("sameZone", () => {
+  it("treats any two swap zones as equal", () => {
+    expect(sameZone({ kind: "swap" }, { kind: "swap" })).toBe(true);
+  });
+
+  it("treats split zones with the same side as equal", () => {
+    expect(sameZone({ kind: "split", side: "top" }, { kind: "split", side: "top" })).toBe(true);
+  });
+
+  it("treats split zones with different sides as unequal", () => {
+    expect(sameZone({ kind: "split", side: "top" }, { kind: "split", side: "bottom" })).toBe(false);
+  });
+
+  it("treats swap and split as unequal regardless of side", () => {
+    expect(sameZone({ kind: "swap" }, { kind: "split", side: "left" })).toBe(false);
   });
 });
 

--- a/app/src/paneTree.ts
+++ b/app/src/paneTree.ts
@@ -35,24 +35,78 @@ export function leaves(node: SplitNode): string[] {
 
 const FULL_RECT: PaneRect = { left: 0, top: 0, width: 100, height: 100 };
 
+/** Splits `rect` into its two children's rects for a `split` node's axis/ratio. */
+function splitRect(rect: PaneRect, axis: SplitAxis, ratio: number): [PaneRect, PaneRect] {
+  if (axis === "col") {
+    const aWidth = rect.width * ratio;
+    return [{ ...rect, width: aWidth }, { ...rect, left: rect.left + aWidth, width: rect.width - aWidth }];
+  }
+  const aHeight = rect.height * ratio;
+  return [{ ...rect, height: aHeight }, { ...rect, top: rect.top + aHeight, height: rect.height - aHeight }];
+}
+
 /** Walks the tree, splitting `rect` at each node's axis/ratio, returning every leaf's rect. */
 export function computeRects(node: SplitNode, rect: PaneRect = FULL_RECT): Map<string, PaneRect> {
   if (node.kind === "leaf") return new Map([[node.paneId, rect]]);
-  const { axis, ratio, a, b } = node;
-  let rectA: PaneRect;
-  let rectB: PaneRect;
-  if (axis === "col") {
-    const aWidth = rect.width * ratio;
-    rectA = { ...rect, width: aWidth };
-    rectB = { ...rect, left: rect.left + aWidth, width: rect.width - aWidth };
-  } else {
-    const aHeight = rect.height * ratio;
-    rectA = { ...rect, height: aHeight };
-    rectB = { ...rect, top: rect.top + aHeight, height: rect.height - aHeight };
-  }
-  const rectsA = computeRects(a, rectA);
-  const rectsB = computeRects(b, rectB);
+  const [rectA, rectB] = splitRect(rect, node.axis, node.ratio);
+  const rectsA = computeRects(node.a, rectA);
+  const rectsB = computeRects(node.b, rectB);
   return new Map([...rectsA, ...rectsB]);
+}
+
+/** A path of child-selectors from the root down to one specific `split` node. */
+export type SplitPath = ("a" | "b")[];
+
+/**
+ * Immutably updates the ratio of the `split` node at `path`. Safe to reuse a
+ * `path` across an uninterrupted sequence of calls (e.g. every `mousemove`
+ * during one divider drag) — a ratio update never changes the tree's shape,
+ * so a path captured at drag-start stays valid for the whole gesture. It is
+ * NOT safe to reuse a path across a splice/insert (see `insertBeside`'s own
+ * doc for why paths go stale there).
+ */
+export function updateRatioAtPath(node: SplitNode, path: SplitPath, ratio: number): SplitNode {
+  if (path.length === 0) {
+    return node.kind === "split" ? { ...node, ratio } : node;
+  }
+  if (node.kind === "leaf") return node;
+  const [head, ...rest] = path;
+  if (head === "a") {
+    const a = updateRatioAtPath(node.a, rest, ratio);
+    return a === node.a ? node : { ...node, a };
+  }
+  const b = updateRatioAtPath(node.b, rest, ratio);
+  return b === node.b ? node : { ...node, b };
+}
+
+export type DividerInfo = {
+  path: SplitPath;
+  axis: SplitAxis;
+  /** The seam itself — a degenerate 0-width (col) or 0-height (row) slice, for positioning the divider line in the UI. */
+  rect: PaneRect;
+  /** The full UN-split parent rect (what `rect` here was before this node's own split) — drag math needs this to convert a pixel delta back into a ratio, since ratio is relative to the PARENT's size, not the whole stage. */
+  bounds: PaneRect;
+  ratio: number;
+};
+
+/**
+ * Walks the tree, returning one `DividerInfo` per internal `split` node —
+ * the axis to drag it along, its current ratio, the `path` to feed back
+ * into `updateRatioAtPath` while dragging, and both the seam's own rect
+ * (positioning) and its parent's full bounds (drag math).
+ */
+export function collectDividers(node: SplitNode, rect: PaneRect = FULL_RECT, path: SplitPath = []): DividerInfo[] {
+  if (node.kind === "leaf") return [];
+  const [rectA, rectB] = splitRect(rect, node.axis, node.ratio);
+  const seam: PaneRect =
+    node.axis === "col"
+      ? { left: rectA.left + rectA.width, top: rect.top, width: 0, height: rect.height }
+      : { left: rect.left, top: rectA.top + rectA.height, width: rect.width, height: 0 };
+  return [
+    { path, axis: node.axis, rect: seam, bounds: rect, ratio: node.ratio },
+    ...collectDividers(node.a, rectA, [...path, "a"]),
+    ...collectDividers(node.b, rectB, [...path, "b"]),
+  ];
 }
 
 /**
@@ -245,6 +299,11 @@ export function classifyDrop(xFrac: number, yFrac: number): DropZone {
   if (rowOuter === colOuter) return { kind: "swap" }; // corner or center
   if (rowOuter) return { kind: "split", side: row === 0 ? "top" : "bottom" };
   return { kind: "split", side: col === 0 ? "left" : "right" };
+}
+
+/** Value-equality for two DropZones — used to skip a state update (and thus a re-render) on every dragover tick that lands in the same zone as before. */
+export function sameZone(a: DropZone, b: DropZone): boolean {
+  return a.kind === "swap" ? b.kind === "swap" : b.kind === "split" && a.side === b.side;
 }
 
 /**


### PR DESCRIPTION
Part 2 of #317 (part 1: #321). Wires the pure `SplitNode` tree from part 1 into `App.tsx`'s actual rendering and drag-drop.

## Summary
- `Window.paneIds: string[]` + `layout` enum → `Window.root: SplitNode`. Every pane-move operation (`detachPane`, `movePaneToWindow`, `moveToNewWindow`, `spawnMember`, `swapPanesInWindow`) now walks the tree via `paneTree.ts`'s pure functions instead of splicing a flat array.
- The right-click Layout submenu / View > Pane Layout menu (#316) are now a one-shot **reset** via `presetTree`, not a persisted mode — the "active" preset highlight is gone, since the tree can be any shape after manual edits (confirmed with koit — see #317's design doc).
- **Draggable dividers** between panes: `collectDividers` + `updateRatioAtPath` + `clampRatio` (pixel-based clamp), new `.pane-divider-v`/`.pane-divider-h` elements. The original ask's "lock to one axis" concern turned out to be structural once the arrangement is a real split tree — each divider belongs to exactly one node's own axis by construction, so there's no separate lock/reset state to track.
- **Directional split/swap drag-drop** (`classifyDrop`'s 16-zone rule): dropping near a pane's center still swaps (unchanged); dropping near an edge splits that pane and inserts the dragged one on that side (`splitPaneBeside`). Cross-window drops of both kinds are handled (`swapPanesAcrossWindows` via two `renameLeaf` calls; `splitPaneBeside` detaches from the source tree first). A translucent highlight over the half that will be occupied previews the outcome before drop.
- `TerminalPane.tsx`: debounces the actual `pty_resize` + xterm reflow (75ms) independently of the divider's own live CSS resize — the `ResizeObserver` fires on every `mousemove` during a drag, and calling `pty_resize` that often is expensive and can garble some CLIs with rapid SIGWINCH.
- `paneTree.ts` additions: `updateRatioAtPath`, `collectDividers`, `sameZone` — all test-first, same pattern as part 1.

## Test coverage note (per the new "PRs default to tests" standard)
- `paneTree.ts`: 60 tests total (up from 49), covering every new pure function including the divider-path round-trip and the reference-equality convention (a real bug — see below).
- `App.tsx`/`TerminalPane.tsx`: **no automated coverage.** There's no component-testing harness in this repo yet, and the interactive parts (real mouse drag sequences, PTY resize timing under load) aren't practical to unit test without one. All tree-shape logic is pushed into the already-tested `paneTree.ts`; the React layer is thin glue on top.
- **Manual verification is incomplete**: this session has no GUI access (SSH-only environment — confirmed via `screencapture` only ever capturing the desktop, never the app window, even with the process confirmed running). `cargo check`, `tsc --noEmit`, `pnpm test`, and a full `pnpm tauri build` all pass, but real divider-drag / drag-drop interaction needs koit's hardware pass before merge, same as every other UI change in this app's history.

## Bug caught during review-cycle test-writing
While adding `updateRatioAtPath`'s tests, a real deviation from `paneTree.ts`'s own stated reference-equality convention surfaced: it unconditionally spread a new object on the path even when the recursive call returned an unchanged child, breaking the "same reference when nothing changed" contract the rest of the file relies on. Fixed before this PR (caught by the new test, never reached App.tsx).

## Test plan
- [x] `cargo check` — clean (no Rust changes in this PR)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` — 60/60 pass
- [x] `pnpm tauri build` — full release build succeeds
- [ ] Manual: draggable dividers resize correctly and stay within bounds
- [ ] Manual: drag a pane near another pane's center → swaps (unchanged behavior)
- [ ] Manual: drag a pane near another pane's edge → splits with the correct side, preview highlight matches the actual outcome
- [ ] Manual: same for cross-window drops (swap and split)
- [ ] Manual: Vertical/Horizontal/Tile preset menus still reset correctly