### PR TITLE
fix(spawn): strip inherited same-type session-identity env vars (#294)

### DIFF
--- a/scripts/drivers/types/claude-code/type.conf
+++ b/scripts/drivers/types/claude-code/type.conf
@@ -6,6 +6,9 @@ spawnable=yes
 model_arg=--model
 detect=CLAUDE_CODE_SESSION_ID
 detect_proc=claude claude-code claude-*
+# Session-identity vars a same-type spawn must NOT inherit, or the child mistakes
+# the parent's session for its own and every turn fails auth (see spawn.sh, #294).
+spawn_unset_env=CLAUDE_CODE_SESSION_ID
 hooks_file=.claude/settings.local.json
 monitor=yes
 delivery_modes=monitor turn both off

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -216,6 +216,24 @@ fi
 # (the default) keeps today's bare-positional behavior.
 PROMPT_ARG="$(agmsg_type_get "$AGENT_TYPE" prompt_arg)"
 
+# Session-identity env vars to strip from a spawned same-type child (issue #294).
+# A terminal launcher (tmux new-window/split-window, a new OS terminal) copies
+# the parent shell's exported environment verbatim. When the spawner is itself a
+# session of the SAME CLI type (e.g. a claude-code session running
+# `agmsg spawn claude-code <name>`), the child inherits the parent's
+# session-identity vars (claude-code's CLAUDE_CODE_SESSION_ID) and mistakes the
+# parent's session for its own — every turn then fails with an Authentication
+# error despite valid credentials. Unset them in the generated boot script so the
+# child starts with a clean identity.
+#
+# This reads a dedicated `spawn_unset_env=` manifest key, NOT `detect=`. `detect=`
+# names the vars whoami uses to recognize a live session of a type, but those are
+# not always session-identity vars: gemini's `detect=GEMINI_API_KEY ...` is a
+# CREDENTIAL, and unsetting it would break the spawned child's auth — the opposite
+# of the fix. `spawn_unset_env=` lists only vars that are safe (and necessary) to
+# drop on spawn; unset (the default) strips nothing.
+SPAWN_UNSET_VARS="$(agmsg_type_get "$AGENT_TYPE" spawn_unset_env)"
+
 # Extra CLI args for this type from the spawn options file (opt-in, see
 # scripts/lib/spawn-options.sh). Read line-by-line — never word-split — so a
 # value containing spaces stays a single token.
@@ -343,6 +361,10 @@ BOOT="$BOOT.command"
 {
   echo '#!/usr/bin/env bash'
   printf 'cd %q || exit 1\n' "$PROJECT"
+  # Drop inherited same-type session-identity vars before exec'ing the CLI (#294).
+  if [ -n "$SPAWN_UNSET_VARS" ]; then
+    printf 'unset %s\n' "$SPAWN_UNSET_VARS"
+  fi
   if [ -n "$SPAWN_AGENT" ]; then
     # Node-launcher path: pass the universal agmsg context + the actas prompt.
     # Type-specific config is the launcher's own default/env, so core stays

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -161,6 +161,42 @@ teardown() {
   [[ "$output" == *"$PROJ"* ]]
 }
 
+@test "spawn: boot script unsets the type's session-identity vars (#294)" {
+  # A same-type spawn (claude-code from a claude-code session) must not leak the
+  # parent's CLAUDE_CODE_SESSION_ID to the child, or the child mistakes the
+  # parent's session for its own and every turn fails with an Authentication
+  # error. The generated boot script unsets the type's detect= vars up front.
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  [ -f "$boot" ]
+  run cat "$boot"
+  [[ "$output" == *"unset CLAUDE_CODE_SESSION_ID"* ]]
+  # The unset must come before the CLI launch line, so the exec'd child never
+  # sees the inherited var.
+  run bash -c "grep -n 'unset CLAUDE_CODE_SESSION_ID' '$boot' | cut -d: -f1"
+  local unset_line="$output"
+  run bash -c "grep -n 'actas' '$boot' | head -1 | cut -d: -f1"
+  [ "$unset_line" -lt "$output" ]
+}
+
+@test "spawn: does NOT unset a type's credential/detect vars (#294)" {
+  # The strip list is a dedicated spawn_unset_env=, NOT detect=. gemini's
+  # detect=GEMINI_API_KEY GOOGLE_GEMINI_CLI are credentials, not a session id —
+  # stripping them would break the spawned child's auth (the opposite of the fix).
+  # gemini has no spawn_unset_env=, so its boot script must emit no `unset` at all
+  # and in particular must never unset GEMINI_API_KEY.
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" gemini alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  [ -f "$boot" ]
+  run cat "$boot"
+  [[ "$output" != *"unset GEMINI_API_KEY"* ]]
+  [[ "$output" != *"unset "* ]]
+}
+
 @test "spawn: grok-build launches the plain grok CLI with the actas prompt" {
   # grok-build is spawnable and monitor=no, so spawn skips the readiness wait.
   # Delivery is a rule file (no hook), so no folder-trust flag is needed —


### PR DESCRIPTION
## Problem

Closes #294.

A terminal launcher (tmux `new-window`/`split-window`, or a new OS terminal) copies the parent shell's exported environment verbatim. When the spawner is itself a session of the **same CLI type** — e.g. a `claude-code` session running `agmsg spawn claude-code <name>` — the child inherits the parent's session-identity var (`CLAUDE_CODE_SESSION_ID`) and mistakes the parent's session for its own. Every turn then fails with a persistent `Authentication error` despite valid credentials.

(Reported with a clean repro by @yktsnd — thank you.)

## Fix

Add a dedicated `spawn_unset_env=` manifest key naming the session-identity vars a same-type spawn must not inherit, and `unset` them at the top of the generated boot script — before the CLI is exec'd, ahead of **both** the node-launcher and direct-CLI launch paths. Only `claude-code` sets it (`CLAUDE_CODE_SESSION_ID`) for now.

**This deliberately does not reuse `detect=`.** `detect=` names the vars whoami uses to recognize a live session of a type, but those are not always session identity: gemini's `detect=GEMINI_API_KEY GOOGLE_GEMINI_CLI` is a **credential**, and unsetting it would break a spawned gemini child's auth — the opposite of the fix. The new key lists only vars safe (and necessary) to drop on spawn; unset (the default) strips nothing.

## Testing

- `claude-code` boot script `unset`s `CLAUDE_CODE_SESSION_ID`, and the `unset` precedes the launch line.
- `gemini` (detect= are credentials, no `spawn_unset_env=`) emits no `unset` and in particular never unsets `GEMINI_API_KEY`.
- Full `tests/test_spawn.bats` green (48 cases).

## Notes / scope

- Only `claude-code` is configured, matching the reporter's empirically-confirmed result. `codex` (`CODEX_THREAD_ID`) is a plausible follow-up candidate for the same treatment but has no report/repro yet, so it's left out.
- #142's `whoami` process-tree fallback is orthogonal: a spawned agent's agmsg identity is set explicitly via `/<cmd> actas <name>`, so auto-detection isn't in play. This PR is purely about the child CLI's own auth env.

Thanks to @yktsnd for the report and the initial approach; the dedicated-key refinement avoids the gemini-credential pitfall.