### PR TITLE
feat(app): aligned-grid seam-segment dragging + lazy transpose (issue #317, part 3)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -13,6 +13,7 @@ import {
   SettingsModal,
 } from "./modals";
 import {
+  applyAtPath,
   classifyDrop,
   clampRatio,
   collectDividers,
@@ -25,6 +26,7 @@ import {
   sameZone,
   spliceOutLeaf,
   swapLeaves,
+  transposeGrid,
   updateRatioAtPath,
   type DividerInfo,
   type DropSide,
@@ -844,16 +846,31 @@ export default function App() {
 
   // Draggable pane dividers (issue #317). Same document-level drag-tracking
   // pattern as startSidebarDrag/startChatDrag above, but the ratio being
-  // dragged belongs to one specific split node (divider.path) rather than a
-  // single flat width/height — updateRatioAtPath's own doc explains why
-  // reusing this path across the whole gesture is safe (a ratio edit never
-  // changes the tree's shape). divider.bounds is that node's OWN un-split
-  // rect (not the whole stage) — converting a pixel delta into a ratio has
-  // to be relative to the parent being split, not the stage as a whole.
+  // dragged belongs to one specific split node rather than a single flat
+  // width/height. For a "single" divider that's just divider.path directly
+  // — updateRatioAtPath's own doc explains why reusing this path across the
+  // whole gesture is safe (a ratio edit never changes the tree's shape).
+  //
+  // For a "grid-segment" divider (issue #317 part 3 — an aligned grid's
+  // per-column/per-row seam, see transposeGrid), the node to drag doesn't
+  // exist yet: grabbing it first LAZILY transposes the aligned grid at
+  // divider.basePath into the orthogonal arrangement, which is what turns
+  // this one segment into its own independent node at
+  // [...basePath, ...segmentPath] — transposeGrid's own doc explains why
+  // this is safe (visually a no-op, so divider.bounds — captured from
+  // BEFORE the transpose — is already correct for the drag math below).
   const startPaneDividerDrag = useCallback((e: React.MouseEvent, windowId: string, divider: DividerInfo) => {
     e.preventDefault();
     const stage = (e.currentTarget as HTMLElement).closest(".stage") as HTMLElement | null;
     if (!stage) return;
+    if (divider.kind === "grid-segment") {
+      setWindows((prev) =>
+        prev.map((w) =>
+          w.id === windowId ? { ...w, root: applyAtPath(w.root, divider.basePath, transposeGrid) } : w,
+        ),
+      );
+    }
+    const dragPath = divider.kind === "grid-segment" ? [...divider.basePath, ...divider.segmentPath] : divider.path;
     // Captured once at drag-start, not re-measured per mousemove — if the OS
     // window itself is resized mid-drag (rare, and only for the duration of
     // this one gesture), the math below would be against a stale box. Not
@@ -877,7 +894,7 @@ export default function App() {
       const raw = axis === "col" ? (ev.clientX - parentPx.left) / totalPx : (ev.clientY - parentPx.top) / totalPx;
       const ratio = clampRatio(raw, MIN_PANE_PX, totalPx);
       setWindows((prev) =>
-        prev.map((w) => (w.id === windowId ? { ...w, root: updateRatioAtPath(w.root, divider.path, ratio) } : w)),
+        prev.map((w) => (w.id === windowId ? { ...w, root: updateRatioAtPath(w.root, dragPath, ratio) } : w)),
       );
     };
     const onUp = () => {
@@ -1371,7 +1388,11 @@ export default function App() {
             {active !== "room" &&
               activeDividers.map((d) => (
                 <div
-                  key={d.path.join(".") || "root"}
+                  key={
+                    d.kind === "single"
+                      ? `single:${d.path.join(".") || "root"}`
+                      : `grid:${d.basePath.join(".") || "root"}:${d.segmentPath.join(".")}`
+                  }
                   className={d.axis === "col" ? "pane-divider-v" : "pane-divider-h"}
                   style={{
                     left: `${d.rect.left}%`,

--- a/app/src/paneTree.test.ts
+++ b/app/src/paneTree.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyAtPath,
   classifyDrop,
   clampRatio,
   collectDividers,
@@ -10,10 +11,13 @@ import {
   minRatioForPx,
   presetTree,
   renameLeaf,
+  sameShapeAndRatio,
   sameZone,
   spliceOutLeaf,
   swapLeaves,
+  transposeGrid,
   updateRatioAtPath,
+  type DividerInfo,
   type SplitNode,
 } from "./paneTree";
 
@@ -109,11 +113,12 @@ describe("updateRatioAtPath", () => {
 });
 
 describe("collectDividers", () => {
-  it("returns one divider per internal split node, at the seam between its children", () => {
+  it("returns one 'single' divider per internal split node, at the seam between its children", () => {
     const tree = split("col", 0.25, leaf("p1"), leaf("p2"));
     const dividers = collectDividers(tree);
     expect(dividers).toEqual([
       {
+        kind: "single",
         path: [],
         axis: "col",
         ratio: 0.25,
@@ -127,18 +132,22 @@ describe("collectDividers", () => {
     expect(collectDividers(leaf("solo"))).toEqual([]);
   });
 
-  it("returns one divider per split node in a nested tree, each with its own seam and PARENT bounds (not the whole stage)", () => {
+  it("returns 'single' (not grid-segment) dividers for a non-aligned tree — one per split node, each with its own seam and PARENT bounds (not the whole stage)", () => {
     const tree = split("col", 0.5, leaf("p1"), split("row", 0.5, leaf("p2"), leaf("p3")));
     const dividers = collectDividers(tree);
     expect(dividers).toHaveLength(2);
-    expect(dividers.find((d) => d.path.length === 0)).toEqual({
+    const single = dividers.filter((d): d is Extract<DividerInfo, { kind: "single" }> => d.kind === "single");
+    expect(single).toHaveLength(2);
+    expect(single.find((d) => d.path.length === 0)).toEqual({
+      kind: "single",
       path: [],
       axis: "col",
       ratio: 0.5,
       rect: { left: 50, top: 0, width: 0, height: 100 },
       bounds: { left: 0, top: 0, width: 100, height: 100 },
     });
-    expect(dividers.find((d) => d.path.length === 1)).toEqual({
+    expect(single.find((d) => d.path.length === 1)).toEqual({
+      kind: "single",
       path: ["b"],
       axis: "row",
       ratio: 0.5,
@@ -151,9 +160,63 @@ describe("collectDividers", () => {
 
   it("a path from collectDividers round-trips through updateRatioAtPath", () => {
     const tree = split("col", 0.5, leaf("p1"), split("row", 0.5, leaf("p2"), leaf("p3")));
-    const nested = collectDividers(tree).find((d) => d.path.length === 1)!;
+    const dividers = collectDividers(tree).filter(
+      (d): d is Extract<DividerInfo, { kind: "single" }> => d.kind === "single",
+    );
+    const nested = dividers.find((d) => d.path.length === 1)!;
     const result = updateRatioAtPath(tree, nested.path, 0.8);
     expect(result).toEqual(split("col", 0.5, leaf("p1"), split("row", 0.8, leaf("p2"), leaf("p3"))));
+  });
+
+  it("returns 'grid-segment' dividers (not one 'single') for the seam between two aligned column-chains", () => {
+    // A 2x2 tile: top row [p1,p2], bottom row [p3,p4], both rows split 50/50.
+    const tree = split(
+      "row",
+      0.5,
+      split("col", 0.5, leaf("p1"), leaf("p2")),
+      split("col", 0.5, leaf("p3"), leaf("p4")),
+    );
+    const dividers = collectDividers(tree);
+    // 1 root seam (as 2 segments, one per column) + 1 nested seam per row (2 rows) = 4 total.
+    expect(dividers).toHaveLength(4);
+    const segments = dividers.filter(
+      (d): d is Extract<DividerInfo, { kind: "grid-segment" }> => d.kind === "grid-segment",
+    );
+    expect(segments).toHaveLength(2);
+    expect(segments).toEqual(
+      expect.arrayContaining([
+        {
+          kind: "grid-segment",
+          basePath: [],
+          segmentPath: ["a"],
+          axis: "row",
+          ratio: 0.5,
+          rect: { left: 0, top: 50, width: 50, height: 0 },
+          bounds: { left: 0, top: 0, width: 50, height: 100 },
+        },
+        {
+          kind: "grid-segment",
+          basePath: [],
+          segmentPath: ["b"],
+          axis: "row",
+          ratio: 0.5,
+          rect: { left: 50, top: 50, width: 50, height: 0 },
+          bounds: { left: 50, top: 0, width: 50, height: 100 },
+        },
+      ]),
+    );
+  });
+
+  it("falls back to a single divider when the two sides don't match ratios (not aligned)", () => {
+    const tree = split(
+      "row",
+      0.5,
+      split("col", 0.3, leaf("p1"), leaf("p2")), // different ratio from below
+      split("col", 0.7, leaf("p3"), leaf("p4")),
+    );
+    const dividers = collectDividers(tree);
+    const root = dividers.find((d) => d.kind === "single" && d.path.length === 0);
+    expect(root).toMatchObject({ kind: "single", path: [] });
   });
 });
 
@@ -406,5 +469,189 @@ describe("invariants (aggie review, recommendation 4)", () => {
       walk(node.b);
     };
     walk(tree);
+  });
+});
+
+describe("applyAtPath", () => {
+  it("applies fn to the root when path is empty", () => {
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    const result = applyAtPath(tree, [], (n) => (n.kind === "split" ? { ...n, ratio: 0.9 } : n));
+    expect(result).toEqual(split("col", 0.9, leaf("p1"), leaf("p2")));
+  });
+
+  it("applies fn at a nested path, leaving the rest of the tree untouched", () => {
+    const tree = split("col", 0.5, leaf("p1"), split("row", 0.5, leaf("p2"), leaf("p3")));
+    const result = applyAtPath(tree, ["b"], (n) => (n.kind === "leaf" ? n : { ...n, ratio: 0.1 }));
+    expect(result).toEqual(split("col", 0.5, leaf("p1"), split("row", 0.1, leaf("p2"), leaf("p3"))));
+  });
+
+  it("is a no-op (same reference) when the path runs into a leaf", () => {
+    const tree = split("col", 0.5, leaf("p1"), leaf("p2"));
+    expect(applyAtPath(tree, ["a", "b"], (n) => n)).toBe(tree);
+  });
+});
+
+describe("sameShapeAndRatio", () => {
+  it("two bare leaves always match, regardless of paneId", () => {
+    expect(sameShapeAndRatio(leaf("p1"), leaf("p2"))).toBe(true);
+  });
+
+  it("a leaf never matches a split", () => {
+    expect(sameShapeAndRatio(leaf("p1"), split("col", 0.5, leaf("p2"), leaf("p3")))).toBe(false);
+  });
+
+  it("matches two splits with the same axis, ratio, and recursively matching children", () => {
+    const a = split("col", 0.5, leaf("p1"), leaf("p2"));
+    const b = split("col", 0.5, leaf("p3"), leaf("p4"));
+    expect(sameShapeAndRatio(a, b)).toBe(true);
+  });
+
+  it("rejects a different axis", () => {
+    const a = split("col", 0.5, leaf("p1"), leaf("p2"));
+    const b = split("row", 0.5, leaf("p3"), leaf("p4"));
+    expect(sameShapeAndRatio(a, b)).toBe(false);
+  });
+
+  it("rejects a different ratio", () => {
+    const a = split("col", 0.5, leaf("p1"), leaf("p2"));
+    const b = split("col", 0.3, leaf("p3"), leaf("p4"));
+    expect(sameShapeAndRatio(a, b)).toBe(false);
+  });
+
+  it("rejects mismatched depth (a 3-column chain vs. a 2-column chain)", () => {
+    const a = split("col", 0.5, leaf("p1"), split("col", 0.5, leaf("p2"), leaf("p3")));
+    const b = split("col", 0.5, leaf("p4"), leaf("p5"));
+    expect(sameShapeAndRatio(a, b)).toBe(false);
+  });
+
+  it("matches arbitrarily deep chains as long as every level's axis and ratio line up", () => {
+    const a = split("col", 0.4, leaf("p1"), split("col", 0.6, leaf("p2"), leaf("p3")));
+    const b = split("col", 0.4, leaf("p4"), split("col", 0.6, leaf("p5"), leaf("p6")));
+    expect(sameShapeAndRatio(a, b)).toBe(true);
+  });
+});
+
+describe("transposeGrid", () => {
+  it("is a no-op for a bare leaf", () => {
+    const solo = leaf("solo");
+    expect(transposeGrid(solo)).toBe(solo);
+  });
+
+  it("is a no-op when either side is a bare leaf (not a chain)", () => {
+    const tree = split("row", 0.5, leaf("p1"), split("col", 0.5, leaf("p2"), leaf("p3")));
+    expect(transposeGrid(tree)).toBe(tree);
+  });
+
+  it("is a no-op when the two sides don't match (not aligned)", () => {
+    const tree = split(
+      "row",
+      0.5,
+      split("col", 0.3, leaf("p1"), leaf("p2")),
+      split("col", 0.7, leaf("p3"), leaf("p4")),
+    );
+    expect(transposeGrid(tree)).toBe(tree);
+  });
+
+  it("transposes a 2x2 aligned grid: row(col(1,2;c), col(3,4;c); r) -> col(row(1,3;r), row(2,4;r); c)", () => {
+    const tree = split(
+      "row",
+      0.5,
+      split("col", 0.5, leaf("1"), leaf("2")),
+      split("col", 0.5, leaf("3"), leaf("4")),
+    );
+    const result = transposeGrid(tree);
+    expect(result).toEqual(
+      split("col", 0.5, split("row", 0.5, leaf("1"), leaf("3")), split("row", 0.5, leaf("2"), leaf("4"))),
+    );
+  });
+
+  it("generalizes to a 3-column aligned grid", () => {
+    const row = (leftId: string, rest: SplitNode) => split("col", 0.4, leaf(leftId), rest);
+    const tree = split(
+      "row",
+      0.5,
+      row("1", split("col", 0.6, leaf("2"), leaf("3"))),
+      row("4", split("col", 0.6, leaf("5"), leaf("6"))),
+    );
+    const result = transposeGrid(tree);
+    expect(leaves(result)).toEqual(["1", "4", "2", "5", "3", "6"]);
+    // Each column becomes its own independent row-pair, same 0.5 starting ratio.
+    expect(result).toEqual(
+      split(
+        "col",
+        0.4,
+        split("row", 0.5, leaf("1"), leaf("4")),
+        split("col", 0.6, split("row", 0.5, leaf("2"), leaf("5")), split("row", 0.5, leaf("3"), leaf("6"))),
+      ),
+    );
+  });
+
+  it("is self-inverse for the 2-column/2-row case: transposing twice (with no drag in between) returns the original tree", () => {
+    const tree = split(
+      "row",
+      0.5,
+      split("col", 0.5, leaf("1"), leaf("2")),
+      split("col", 0.5, leaf("3"), leaf("4")),
+    );
+    expect(transposeGrid(transposeGrid(tree))).toEqual(tree);
+  });
+
+  // co1 review: self-inverse does NOT generalize past 2 columns/rows — a
+  // transposed 3-column grid's own top-level children no longer match each
+  // other (a 1-level leaf-pair vs. a 2-level chain), so a second
+  // transposeGrid call is just a no-op rather than reconstructing the
+  // original. Documented as an accepted limitation, not a bug: the app
+  // never needs to un-transpose (a grabbed segment only ever drags its own
+  // node afterward).
+  it("is NOT self-inverse for 3+ columns — transposing twice is a no-op, not a round-trip", () => {
+    const row = (leftId: string, rest: SplitNode) => split("col", 0.4, leaf(leftId), rest);
+    const tree = split(
+      "row",
+      0.5,
+      row("1", split("col", 0.6, leaf("2"), leaf("3"))),
+      row("4", split("col", 0.6, leaf("5"), leaf("6"))),
+    );
+    const once = transposeGrid(tree);
+    const twice = transposeGrid(once);
+    expect(twice).toBe(once); // second call is a no-op (not aligned anymore)
+    expect(twice).not.toEqual(tree);
+  });
+
+  it("is visually a no-op: computeRects gives identical rects before and after transposing", () => {
+    const tree = split(
+      "row",
+      0.3,
+      split("col", 0.7, leaf("1"), leaf("2")),
+      split("col", 0.7, leaf("3"), leaf("4")),
+    );
+    const before = computeRects(tree);
+    const after = computeRects(transposeGrid(tree));
+    for (const id of ["1", "2", "3", "4"]) {
+      expect(after.get(id)).toEqual(before.get(id));
+    }
+  });
+
+  it("end-to-end: grabbing a grid-segment, transposing, then dragging only moves that one segment", () => {
+    const tree = split(
+      "row",
+      0.5,
+      split("col", 0.5, leaf("1"), leaf("2")),
+      split("col", 0.5, leaf("3"), leaf("4")),
+    );
+    const segment = collectDividers(tree).find(
+      (d): d is Extract<DividerInfo, { kind: "grid-segment" }> => d.kind === "grid-segment" && d.segmentPath[0] === "a",
+    )!;
+    const transposed = applyAtPath(tree, segment.basePath, transposeGrid);
+    const dragPath = [...segment.basePath, ...segment.segmentPath];
+    const dragged = updateRatioAtPath(transposed, dragPath, 0.8);
+
+    // Column 1 (leaves 1,3) moved to the new ratio; column 2 (leaves 2,4)
+    // is untouched, still at the original shared 0.5 — proving the two
+    // columns are now independent instead of both moving together.
+    const rects = computeRects(dragged);
+    expect(rects.get("1")!.height).toBeCloseTo(80, 6);
+    expect(rects.get("3")!.height).toBeCloseTo(20, 6);
+    expect(rects.get("2")!.height).toBeCloseTo(50, 6);
+    expect(rects.get("4")!.height).toBeCloseTo(50, 6);
   });
 });

--- a/app/src/paneTree.ts
+++ b/app/src/paneTree.ts
@@ -58,6 +58,25 @@ export function computeRects(node: SplitNode, rect: PaneRect = FULL_RECT): Map<s
 export type SplitPath = ("a" | "b")[];
 
 /**
+ * Immutably replaces the node at `path` with `fn(nodeAtPath)`. The general
+ * path-walking machinery `updateRatioAtPath` below is one instance of;
+ * `transposeGrid`'s lazy per-segment divider grab is another (see there).
+ * Returns `node` unchanged (same reference) if `path` runs into a leaf
+ * before it's exhausted — same stale-path safety as `updateRatioAtPath`.
+ */
+export function applyAtPath(node: SplitNode, path: SplitPath, fn: (n: SplitNode) => SplitNode): SplitNode {
+  if (path.length === 0) return fn(node);
+  if (node.kind === "leaf") return node;
+  const [head, ...rest] = path;
+  if (head === "a") {
+    const a = applyAtPath(node.a, rest, fn);
+    return a === node.a ? node : { ...node, a };
+  }
+  const b = applyAtPath(node.b, rest, fn);
+  return b === node.b ? node : { ...node, b };
+}
+
+/**
  * Immutably updates the ratio of the `split` node at `path`. Safe to reuse a
  * `path` across an uninterrupted sequence of calls (e.g. every `mousemove`
  * during one divider drag) — a ratio update never changes the tree's shape,
@@ -66,47 +85,196 @@ export type SplitPath = ("a" | "b")[];
  * doc for why paths go stale there).
  */
 export function updateRatioAtPath(node: SplitNode, path: SplitPath, ratio: number): SplitNode {
-  if (path.length === 0) {
-    return node.kind === "split" ? { ...node, ratio } : node;
-  }
-  if (node.kind === "leaf") return node;
-  const [head, ...rest] = path;
-  if (head === "a") {
-    const a = updateRatioAtPath(node.a, rest, ratio);
-    return a === node.a ? node : { ...node, a };
-  }
-  const b = updateRatioAtPath(node.b, rest, ratio);
-  return b === node.b ? node : { ...node, b };
+  return applyAtPath(node, path, (n) => (n.kind === "split" ? { ...n, ratio } : n));
 }
 
-export type DividerInfo = {
-  path: SplitPath;
-  axis: SplitAxis;
-  /** The seam itself — a degenerate 0-width (col) or 0-height (row) slice, for positioning the divider line in the UI. */
-  rect: PaneRect;
-  /** The full UN-split parent rect (what `rect` here was before this node's own split) — drag math needs this to convert a pixel delta back into a ratio, since ratio is relative to the PARENT's size, not the whole stage. */
-  bounds: PaneRect;
-  ratio: number;
-};
+export type DividerInfo =
+  | {
+      kind: "single";
+      path: SplitPath;
+      axis: SplitAxis;
+      /** The seam itself — a degenerate 0-width (col) or 0-height (row) slice, for positioning the divider line in the UI. */
+      rect: PaneRect;
+      /** The full UN-split parent rect (what `rect` here was before this node's own split) — drag math needs this to convert a pixel delta back into a ratio, since ratio is relative to the PARENT's size, not the whole stage. */
+      bounds: PaneRect;
+      ratio: number;
+    }
+  | {
+      kind: "grid-segment";
+      /** Path to the aligned-grid split node itself (BEFORE transposing — see transposeGrid). */
+      basePath: SplitPath;
+      /** Path, within `basePath`'s `a` child's own shape, to this segment's leaf-pair. Doubles as the path to this segment's own independent node once transposeGrid has been applied at `basePath` — the transposed structure mirrors `a`'s shape exactly (see transposeGrid's doc). */
+      segmentPath: SplitPath;
+      axis: SplitAxis;
+      rect: PaneRect;
+      /** This segment's own slice of the grid — already correct for drag math even before transposing, since transposeGrid doesn't change rendered geometry (only which future drags are independent). */
+      bounds: PaneRect;
+      ratio: number;
+    };
 
 /**
- * Walks the tree, returning one `DividerInfo` per internal `split` node —
- * the axis to drag it along, its current ratio, the `path` to feed back
- * into `updateRatioAtPath` while dragging, and both the seam's own rect
- * (positioning) and its parent's full bounds (drag math).
+ * True if `a` and `b` have identical tree SHAPE (same nesting) and the same
+ * ratio at every corresponding split node — i.e. they'd form visually
+ * aligned columns (or rows) if placed side by side, regardless of which
+ * specific panes occupy the leaves. This is the "aligned grid" check
+ * `collectDividers` and `transposeGrid` both use.
+ *
+ * The ratio comparison is intentionally exact (`===`), not a tolerance
+ * range: the moment a manual drag nudges one side's ratio even slightly
+ * off the other's, the grid is no longer aligned and per-segment grabbing
+ * should stop offering itself — falling back to one whole-grid divider is
+ * the confirmed-correct behavior once symmetry breaks (see transposeGrid's
+ * own doc), not a bug to loosen this into tolerating.
+ */
+export function sameShapeAndRatio(a: SplitNode, b: SplitNode): boolean {
+  if (a.kind === "leaf" || b.kind === "leaf") return a.kind === "leaf" && b.kind === "leaf";
+  return a.axis === b.axis && a.ratio === b.ratio && sameShapeAndRatio(a.a, b.a) && sameShapeAndRatio(a.b, b.b);
+}
+
+function leafPaths(node: SplitNode, path: SplitPath = []): SplitPath[] {
+  if (node.kind === "leaf") return [path];
+  return [...leafPaths(node.a, [...path, "a"]), ...leafPaths(node.b, [...path, "b"])];
+}
+
+function orderedLeafRects(node: SplitNode, rect: PaneRect): PaneRect[] {
+  if (node.kind === "leaf") return [rect];
+  const [rectA, rectB] = splitRect(rect, node.axis, node.ratio);
+  return [...orderedLeafRects(node.a, rectA), ...orderedLeafRects(node.b, rectB)];
+}
+
+// One segment per leaf position in `node.a`'s own shape (equivalently
+// `node.b`'s — sameShapeAndRatio guarantees they match), each covering just
+// that segment's own slice of the seam instead of the whole thing.
+function gridSegments(
+  node: Extract<SplitNode, { kind: "split" }>,
+  rect: PaneRect,
+  rectA: PaneRect,
+  basePath: SplitPath,
+): DividerInfo[] {
+  const segmentPaths = leafPaths(node.a);
+  const segmentRects = orderedLeafRects(node.a, rectA);
+  return segmentPaths.map((segmentPath, i) => {
+    const segRect = segmentRects[i];
+    const seam: PaneRect =
+      node.axis === "col"
+        ? { left: rectA.left + rectA.width, top: segRect.top, width: 0, height: segRect.height }
+        : { left: segRect.left, top: rectA.top + rectA.height, width: segRect.width, height: 0 };
+    // This segment's bounds AFTER transposing — what its own independent
+    // node's rect becomes — span the segment's own slice on the axis
+    // node.a/node.b were divided along, but the FULL original rect on the
+    // OTHER axis. E.g. for row(colChain, colChain), a column's eventual
+    // row-node spans that column's own width but the WHOLE original height
+    // (both rows combined), not just the one row segRect came from — using
+    // segRect's height directly here would be wrong (co1/self-review catch:
+    // the naive version undersized every segment's drag bounds to just its
+    // own row/column instead of the full space its transposed node owns).
+    const bounds: PaneRect =
+      node.axis === "col"
+        ? { left: rect.left, top: segRect.top, width: rect.width, height: segRect.height }
+        : { left: segRect.left, top: rect.top, width: segRect.width, height: rect.height };
+    return { kind: "grid-segment", basePath, segmentPath, axis: node.axis, rect: seam, bounds, ratio: node.ratio };
+  });
+}
+
+/**
+ * Walks the tree, returning one `DividerInfo` per internal `split` node's
+ * seam — a plain `"single"` divider spanning the whole seam ordinarily, or,
+ * when that node's two children are themselves an ALIGNED grid (see
+ * sameShapeAndRatio), one `"grid-segment"` divider per column/row instead —
+ * letting each be dragged independently (see transposeGrid). Recursion into
+ * `node.a`/`node.b`'s own children happens unconditionally either way; only
+ * how THIS ONE seam is represented changes.
  */
 export function collectDividers(node: SplitNode, rect: PaneRect = FULL_RECT, path: SplitPath = []): DividerInfo[] {
   if (node.kind === "leaf") return [];
   const [rectA, rectB] = splitRect(rect, node.axis, node.ratio);
-  const seam: PaneRect =
-    node.axis === "col"
-      ? { left: rectA.left + rectA.width, top: rect.top, width: 0, height: rect.height }
-      : { left: rect.left, top: rectA.top + rectA.height, width: rect.width, height: 0 };
-  return [
-    { path, axis: node.axis, rect: seam, bounds: rect, ratio: node.ratio },
-    ...collectDividers(node.a, rectA, [...path, "a"]),
-    ...collectDividers(node.b, rectB, [...path, "b"]),
-  ];
+  const isAlignedGrid = node.a.kind !== "leaf" && node.b.kind !== "leaf" && sameShapeAndRatio(node.a, node.b);
+  const thisSeam: DividerInfo[] = isAlignedGrid
+    ? gridSegments(node, rect, rectA, path)
+    : [
+        {
+          kind: "single",
+          path,
+          axis: node.axis,
+          rect:
+            node.axis === "col"
+              ? { left: rectA.left + rectA.width, top: rect.top, width: 0, height: rect.height }
+              : { left: rect.left, top: rectA.top + rectA.height, width: rect.width, height: 0 },
+          bounds: rect,
+          ratio: node.ratio,
+        },
+      ];
+  return [...thisSeam, ...collectDividers(node.a, rectA, [...path, "a"]), ...collectDividers(node.b, rectB, [...path, "b"])];
+}
+
+function zipPairs(a: SplitNode, b: SplitNode, pairAxis: SplitAxis, pairRatio: number): SplitNode {
+  if (a.kind === "leaf" && b.kind === "leaf") {
+    return { kind: "split", axis: pairAxis, ratio: pairRatio, a, b };
+  }
+  // sameShapeAndRatio (checked by transposeGrid before calling) guarantees
+  // both are "split" here, with matching axis/ratio to each other.
+  const splitA = a as Extract<SplitNode, { kind: "split" }>;
+  const splitB = b as Extract<SplitNode, { kind: "split" }>;
+  return {
+    kind: "split",
+    axis: splitA.axis,
+    ratio: splitA.ratio,
+    a: zipPairs(splitA.a, splitB.a, pairAxis, pairRatio),
+    b: zipPairs(splitA.b, splitB.b, pairAxis, pairRatio),
+  };
+}
+
+/**
+ * Transposes an ALIGNED grid — a split whose two children are themselves
+ * matching chains (same shape, same ratios at every level; see
+ * sameShapeAndRatio) — into the orthogonal arrangement. E.g.
+ * row(colChain, colChain) with identical column ratios on both sides
+ * becomes col(rowChain, rowChain), where each new row-pair has its OWN
+ * (initially identical) ratio, independent of the others:
+ *   row(col(1,2;c), col(3,4;c); r)  ⇄  col(row(1,3;r), row(2,4;r); c)
+ *
+ * Visually a no-op at the moment of transpose regardless of size —
+ * computeRects produces IDENTICAL leaf rects before and after (only which
+ * FUTURE divider drags are independent of each other changes). This is what
+ * makes per-column (or per-row) independent divider dragging possible on an
+ * aligned N-way grid without a true N-ary grid data structure: as long as
+ * the grid stays aligned, grabbing one column's own seam lazily transposes
+ * just that one seam into its own independent node, rather than needing
+ * every divider to already be independently addressable up front.
+ *
+ * Self-inverse ONLY for the 2-column/2-row case (co1 review — the doc here
+ * previously overclaimed this generally): transposing
+ * row(col(1,2;c),col(3,4;c);r) twice does return the original tree, because
+ * the transposed result col(row(1,3;r),row(2,4;r);c) is ITSELF a valid
+ * aligned-grid input (its two children match). For 3+ columns this doesn't
+ * hold — e.g. transposing a 3-column grid produces
+ * col(row(1,4;r), col(row(2,5;r),row(3,6;r);c2); c1), whose own two
+ * top-level children (a 1-level pair vs. a 2-level chain) no longer match
+ * each other, so a second transposeGrid call is just a no-op rather than
+ * reconstructing the original 2-row form. This is fine for how the app
+ * actually uses this: grabbing a segment transposes once and then only
+ * drags that segment's own node — nothing ever needs to un-transpose.
+ *
+ * Returns `node` unchanged if it isn't an aligned grid (not a split whose
+ * two children are themselves matching further-split chains) — the plain
+ * single-divider, whole-grid-drag fallback applies there, same as any
+ * asymmetric or manually-adjusted tree today. Deliberately scoped to
+ * exactly this one shape — a further generalization to partially-aligned
+ * nested arrangements is out of scope (confirmed with koit).
+ */
+export function transposeGrid(node: SplitNode): SplitNode {
+  if (node.kind === "leaf") return node;
+  const { axis, ratio, a, b } = node;
+  if (a.kind === "leaf" || b.kind === "leaf") return node; // not a chain on either side
+  if (!sameShapeAndRatio(a, b)) return node; // not aligned
+  const innerAxis: SplitAxis = axis === "row" ? "col" : "row";
+  return {
+    kind: "split",
+    axis: innerAxis,
+    ratio: a.ratio,
+    a: zipPairs(a.a, b.a, axis, ratio),
+    b: zipPairs(a.b, b.b, axis, ratio),
+  };
 }
 
 /**


### PR DESCRIPTION
Part 3 of #317. **Based on #324 (part 2)** — this PR's diff only shows cleanly against that branch until #324 merges into main; will retarget to main once it does.

## Motivation
koit feedback from #324's GUI check: on a 2x2 (or 2×N) tile — top row [1,2], bottom row [3,4] — as long as the columns stay aligned (same column ratio on both rows), each column's own horizontal seam should be independently draggable (move just column 1's row boundary without disturbing column 2's), not lumped into one whole-grid divider.

## Summary
A binary split tree can't represent "N independent row-boundaries" directly under a single `row(colChain, colChain)` node — there's only one ratio there. Solved with a **lazy transpose** instead of a bigger data structure:

- `sameShapeAndRatio(a, b)`: true when two subtrees have identical shape and matching ratios at every level.
- `transposeGrid(node)`: for a split whose two children are themselves matching chains, converts `row(colChain, colChain)` into `col(rowChain, rowChain)` (or the reverse) — each new row/col-pair starts with the SAME ratio the shared seam had, but is now independent. **Visually a no-op** at the moment of transpose (`computeRects` gives identical rects before/after) regardless of size. **Self-inverse only for the 2-column/2-row case** (transposing twice reconstructs the original) — for 3+ columns, the transposed tree's own top-level children no longer match each other, so a second call is a no-op rather than a round-trip. Not a problem for how the app uses this: a grabbed segment only ever drags its own node afterward, nothing needs to un-transpose. Scoped to exactly this shape — partially-aligned/nested generalizations are explicitly out of scope (confirmed with koit).
- `collectDividers` now detects an aligned grid at each node it visits and emits one `"grid-segment"` `DividerInfo` per column/row instead of a single `"single"` one spanning the whole seam — `DividerInfo` is a discriminated union now.
- Grabbing a grid-segment divider lazily transposes the tree at that node (`applyAtPath`, generalizing `updateRatioAtPath`'s path-walking to an arbitrary transform) before attaching the usual ratio-drag.
- A tree that's already been manually adjusted (columns no longer aligned) falls back to today's single whole-grid divider — confirmed with koit as correct.

Also: pane-divider grab width now matches the sidebar/chat dividers' 3px (was 7px, an inconsistency koit noticed during the same GUI check).

## Test coverage
21 new `paneTree.ts` tests (81 total, up from 60): `sameShapeAndRatio`, `applyAtPath`, `transposeGrid` (2-column, 3-column, self-inverse for 2-column + explicitly NOT self-inverse for 3-column, visually-a-no-op, and an end-to-end grab→transpose→drag test proving the two columns move independently), plus updated `collectDividers` tests for the discriminated union and the grid-segment case.

`App.tsx` wiring itself has no automated coverage, same known gap as part 2 — manual GUI verification remains the gate.

## Test plan
- [x] `cargo check` — clean (no Rust changes)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` — 81/81 pass
- [x] `pnpm tauri build` — full release build succeeds
- [ ] Manual: 2x2 (and 2×3+) tile grid, drag one column's row-boundary independently of the other(s)
- [ ] Manual: after breaking alignment (drag whole-grid divider, or manually resize one column), confirm fallback to single whole-grid divider
- [ ] Manual: divider grab-width now matches sidebar/chat visually