### PR TITLE
fix(spawn): correct boot script for Windows-tmux launch and per-type prefix (#282, #283)

### DIFF
--- a/scripts/drivers/types/antigravity/type.conf
+++ b/scripts/drivers/types/antigravity/type.conf
@@ -3,6 +3,8 @@ name=antigravity
 template=template.md
 cli=agy
 spawnable=yes
+# antigravity invokes a skill with "$", not Claude Code's "/" (see spawn.sh, #283).
+cmd_prefix=$
 model_arg=--model
 prompt_arg=--prompt-interactive
 detect=explicit

--- a/scripts/drivers/types/codex/type.conf
+++ b/scripts/drivers/types/codex/type.conf
@@ -3,6 +3,8 @@ name=codex
 template=template.md
 cli=codex
 spawnable=yes
+# codex invokes a skill with "$", not Claude Code's "/" (see spawn.sh, #283).
+cmd_prefix=$
 model_arg=-m
 detect=CODEX_SANDBOX CODEX_THREAD_ID
 detect_proc=codex codex-*

--- a/scripts/drivers/types/gemini/type.conf
+++ b/scripts/drivers/types/gemini/type.conf
@@ -3,6 +3,8 @@ name=gemini
 template=template.md
 cli=gemini
 spawnable=yes
+# gemini invokes a skill with "$", not Claude Code's "/" (see spawn.sh, #283).
+cmd_prefix=$
 model_arg=--model
 detect=GEMINI_API_KEY GOOGLE_GEMINI_CLI
 detect_proc=gemini gemini-*

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -347,7 +347,15 @@ AGMSG_RESOLVE_PROJECT=0 "$SCRIPT_DIR/join.sh" "$TEAM" "$NAME" "$AGENT_TYPE" "$PR
 # to hand a one-shot goal to a codex peer, which has no Monitor and so never
 # notices a message sent after it goes idle (see docs/codex-monitor-beta.md).
 CMD_NAME="$(basename "$SKILL_DIR")"
-ACTAS_PROMPT="/${CMD_NAME} actas ${NAME}"
+# The skill-invocation prefix differs by CLI: Claude Code dispatches a "/" slash
+# command, while agentskills-based CLIs (codex, gemini, antigravity) invoke a
+# skill with "$" — a `codex '/agmsg actas ...'` boot prompt is not a reliable
+# skill invocation (#283). type.conf's cmd_prefix= names it per type; unset
+# defaults to "/" (Claude Code, the historical hardcoded value) so any type not
+# explicitly configured keeps today's behavior.
+CMD_PREFIX="$(agmsg_type_get "$AGENT_TYPE" cmd_prefix)"
+[ -n "$CMD_PREFIX" ] || CMD_PREFIX="/"
+ACTAS_PROMPT="${CMD_PREFIX}${CMD_NAME} actas ${NAME}"
 if [ -n "$PROMPT" ]; then
   ACTAS_PROMPT="${ACTAS_PROMPT}
 ${PROMPT}"
@@ -357,10 +365,17 @@ BOOT_DIR="${TMPDIR:-/tmp}/agmsg-spawn"
 mkdir -p "$BOOT_DIR" 2>/dev/null || true
 # Best-effort GC of boot scripts left behind by spawns whose window was closed
 # before the script could remove itself (see the trailing rm below).
-find "$BOOT_DIR" -name 'boot-*.command' -type f -mtime +1 -delete 2>/dev/null || true
+# GC matches both the bare and the .command-suffixed form (see the rename below).
+find "$BOOT_DIR" -name 'boot-*' -type f -mtime +1 -delete 2>/dev/null || true
 BOOT="$(mktemp "$BOOT_DIR/boot-XXXXXX")"
-mv "$BOOT" "$BOOT.command"   # .command so macOS `open` runs it in Terminal
-BOOT="$BOOT.command"
+# macOS `open -a Terminal` (launch_macos_terminal) only runs a file as a shell
+# script if it ends in .command, so rename there. Every other launcher invokes
+# the script through bash (Linux/Windows Terminal) or runs it via its shebang
+# (tmux) — and on Windows the .command extension makes Explorer/psmux open it in
+# Notepad instead of executing it (#282), so keep the bare executable path.
+case "$(uname -s)" in
+  Darwin) mv "$BOOT" "$BOOT.command"; BOOT="$BOOT.command" ;;
+esac
 {
   echo '#!/usr/bin/env bash'
   printf 'cd %q || exit 1\n' "$PROJECT"

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -506,6 +506,52 @@ YAML
   [[ "$output" == *"reviewer"* ]]
 }
 
+@test "spawn: codex boot prompt uses the \$ skill prefix, not / (#283)" {
+  # codex invokes a skill with \$<cmd>, not Claude Code's /<cmd>. The boot script
+  # must carry \$<cmd> actas, never /<cmd> actas. (%q escapes the space as "\ ",
+  # so match the "<prefix><cmd>\ actas" token — the cd path's /<cmd>/proj has no
+  # "\ actas" and so can't false-match the slash form.)
+  bash "$SCRIPTS/join.sh" myteam existing codex "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" codex reviewer --project "$PROJ"
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  [ -f "$boot" ]
+  local cmd; cmd="$(basename "$TEST_SKILL_DIR")"
+  run grep -F "\$$cmd"'\ actas' "$boot"
+  [ "$status" -eq 0 ]
+  run grep -F "/$cmd"'\ actas' "$boot"
+  [ "$status" -ne 0 ]
+}
+
+@test "spawn: claude-code boot prompt keeps the / slash prefix (#283)" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  [ -f "$boot" ]
+  local cmd; cmd="$(basename "$TEST_SKILL_DIR")"
+  run grep -F "/$cmd"'\ actas' "$boot"
+  [ "$status" -eq 0 ]
+  run grep -F "\$$cmd"'\ actas' "$boot"
+  [ "$status" -ne 0 ]
+}
+
+@test "spawn: boot script keeps the .command suffix only on macOS (#282)" {
+  # macOS `open -a Terminal` needs .command to execute the file; every other
+  # launcher runs it via bash or its shebang, and on Windows .command makes
+  # Explorer/psmux open it in Notepad instead of running it.
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  [ -f "$boot" ]
+  if [ "$(uname -s)" = "Darwin" ]; then
+    [[ "$boot" == *.command ]]
+  else
+    [[ "$boot" != *.command ]]
+  fi
+}
+
 # --- pre-flight exclusivity check ---
 
 @test "spawn: refuses when the name is held by another live session" {


### PR DESCRIPTION
## Problem

Two boot-script defects surfaced while spawning agents on Windows inside tmux (both reported by @masa6161, with diagnosis and suggested fixes — thank you).

**#282 — `.command` suffix breaks execution on Windows/tmux.** `spawn.sh` renames the boot script to `*.command`, a macOS convention (`open -a Terminal` only runs a file as a script if it ends in `.command`). On Windows that extension has no shell association, so tmux/psmux (and Explorer) open the file in Notepad instead of executing it — the spawned agent never starts. This only affects the tmux path; the non-tmux Windows path invokes `bash` explicitly.

**#283 — hardcoded `/` command prefix is wrong for `$`-prefix CLIs.** The actas boot prompt hardcoded `/<cmd> actas <name>` (Claude Code's slash-command form). agentskills-based CLIs invoke a skill with `$` instead, so `codex '/agmsg actas ...'` is not a reliable invocation and the identity claim can silently fail. `install.sh` documents the split: `Claude Code: /<cmd>, Codex/Gemini/Antigravity: $<cmd>`.

## Fix

**#282:**
- Gate the `.command` rename to `Darwin` (only `launch_macos_terminal` needs it; every other launcher runs the script through bash or its shebang).
- Broaden the leftover-GC glob from `boot-*.command` to `boot-*` so it still cleans the bare files other platforms now leave.

**#283:**
- Add a `cmd_prefix=` manifest key. Default (unset) stays `/`, so any type not explicitly configured is unchanged.
- Set `cmd_prefix=$` for the CLIs `install.sh` documents as `$<cmd>`: **codex, gemini, antigravity**. Other types are left at the `/` default pending confirmation of their convention (no behavior change, no speculative regressions).

## Testing

- codex boot prompt uses `$<cmd> actas` and never `/<cmd> actas`; claude-code keeps `/<cmd> actas`.
- The boot path carries `.command` only on macOS (uname-conditional assertion, so it validates the gate on whichever OS the suite runs — incl. the windows-latest and ubuntu bats legs).
- Full `tests/test_spawn.bats` green (47 cases).

## Notes / scope

- The `.command` fix cannot be exercised end-to-end on non-Windows (the Notepad-vs-exec behavior is Windows-specific); the assertion covers the extension gate, and the launch itself remains a real-Windows check.
- Only codex/gemini/antigravity get `$` — matching the documented conventions. cursor/opencode/grok-build/hermes/copilot stay `/` for now; correcting those needs per-CLI confirmation and can follow.