### PR TITLE
chore(app): bump version to 0.1.4

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agmsg-app",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agmsg-app"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agmsg-app"
-version = "0.1.3"
+version = "0.1.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "agmsg",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "cc.agmsg.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
Missed alongside #331's `AGMSG_CORE_REF` bump — caught by aggie's preflight before dispatch (same class of miss as the 0.1.2 release cycle). Bumps `package.json`, `Cargo.toml`, `tauri.conf.json`, `Cargo.lock` from 0.1.3 to 0.1.4.

## Test plan
- [x] `bundle-core.sh` — still resolves v1.1.6 correctly
- [x] `cargo check` / `cargo test` (21/21) — clean, confirms `agmsg-app v0.1.4` compiles
- [x] `pnpm exec tsc --noEmit` / `pnpm test` (81/81) — clean