### PR TITLE
ci(app-release): tag<->version guard + bump-app-version.sh to prevent bump slips

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -48,8 +48,33 @@ permissions:
   contents: read
 
 jobs:
+  # Guard: on a tag build (app-vX.Y.Z), the tag's version must match the app's
+  # own tauri.conf.json version before either platform builds. Without this a
+  # forgotten bump ships an installer whose in-app version disagrees with the
+  # release tag (the v0.1.4 pin-bump-only slip). Same idea as the CLI's
+  # release.yml tag<->VERSION guard. Skipped on workflow_dispatch (no tag).
+  verify-version:
+    name: verify version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Assert tag matches tauri.conf.json version
+        run: |
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "Not a tag build (${GITHUB_REF_NAME}) — skipping version assertion."
+            exit 0
+          fi
+          tag_version="${GITHUB_REF_NAME#app-v}"
+          conf_version="$(jq -r '.version' app/src-tauri/tauri.conf.json)"
+          if [ "$tag_version" != "$conf_version" ]; then
+            echo "::error::Tag version ($tag_version) != app/src-tauri/tauri.conf.json version ($conf_version). Run scripts/release/bump-app-version.sh $tag_version and commit the bump before tagging." >&2
+            exit 1
+          fi
+          echo "OK: tag app-v$tag_version matches tauri.conf.json version $conf_version"
+
   build-macos:
     name: build (macos)
+    needs: verify-version
     runs-on: macos-latest
     env:
       # Step-level `if:` can't reference `secrets` directly (GitHub rejects
@@ -124,6 +149,7 @@ jobs:
 
   build-windows:
     name: build (windows)
+    needs: verify-version
     runs-on: windows-latest
     permissions:
       contents: read

--- a/scripts/release/bump-app-version.sh
+++ b/scripts/release/bump-app-version.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Bump the desktop app version across every file that carries it, in one shot.
+#
+# The app version (currently 0.1.x) is separate from the CLI's VERSION file
+# (sync-version.sh handles that one). Four files carry the app version and must
+# move together, or a release ships an installer whose in-app version disagrees
+# with the tag — the app-release.yml tag guard now fails such a mismatch, and
+# this script is the paired "do it right in one command" so the human never
+# hand-edits three of four and forgets the last.
+#
+# Usage:
+#   scripts/release/bump-app-version.sh <X.Y.Z>   # bare semver, no leading v/app-v
+#
+# Release flow:
+#   1. scripts/release/bump-app-version.sh 0.1.4
+#   2. review the diff, confirm the agmsg-core pin it prints
+#   3. git commit -am "chore(app): bump version to 0.1.4"
+#   4. git tag app-v0.1.4 && git push --follow-tags
+set -euo pipefail
+
+die() { echo "bump-app-version: $*" >&2; exit 1; }
+
+VERSION="${1:-}"
+[ -n "$VERSION" ] || die "usage: bump-app-version.sh <X.Y.Z>  (bare semver, no leading v/app-v)"
+# Reject a tag-shaped or v-prefixed argument up front (same guard style as
+# update-cask.sh) so `app-v0.1.4` or `v0.1.4` can't slip in as the version.
+case "$VERSION" in
+  v*|app-*) die "version must be bare semver, no leading v/app-v (got '$VERSION')" ;;
+esac
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] \
+  || die "version must be semver MAJOR.MINOR.PATCH (got '$VERSION')"
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+APP="$ROOT/app"
+
+# Replace only the FIRST `"version": "..."` in a JSON file — the top-level one
+# (both tauri.conf.json and package.json carry it there). awk keeps the edit to
+# a single line so the diff is a one-liner and file formatting is untouched
+# (portable across GNU/BSD, unlike sed's `0,/re/` address).
+bump_json() {
+  local f="$1"
+  [ -f "$f" ] || die "not found: $f"
+  awk -v v="$VERSION" '
+    !done && /"version":[[:space:]]*"[^"]*"/ {
+      sub(/"version":[[:space:]]*"[^"]*"/, "\"version\": \"" v "\""); done=1
+    } { print }
+  ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+  grep -q "\"version\": \"$VERSION\"" "$f" || die "failed to bump version in $f"
+}
+
+bump_json "$APP/src-tauri/tauri.conf.json"
+bump_json "$APP/package.json"
+
+# Cargo.toml: the [package] version is the first `version = ` line in the file.
+awk -v v="$VERSION" '
+  !done && /^version[[:space:]]*=/ { sub(/^version[[:space:]]*=.*/, "version = \"" v "\""); done=1 }
+  { print }
+' "$APP/src-tauri/Cargo.toml" > "$APP/src-tauri/Cargo.toml.tmp" \
+  && mv "$APP/src-tauri/Cargo.toml.tmp" "$APP/src-tauri/Cargo.toml"
+
+# Cargo.lock: bump only the version line inside the agmsg-app package block.
+awk -v v="$VERSION" '
+  /^name = "agmsg-app"$/ { inpkg=1 }
+  inpkg && /^version[[:space:]]*=/ { sub(/^version[[:space:]]*=.*/, "version = \"" v "\""); inpkg=0 }
+  { print }
+' "$APP/src-tauri/Cargo.lock" > "$APP/src-tauri/Cargo.lock.tmp" \
+  && mv "$APP/src-tauri/Cargo.lock.tmp" "$APP/src-tauri/Cargo.lock"
+
+echo "Bumped app version -> $VERSION:"
+echo "  app/src-tauri/tauri.conf.json"
+echo "  app/package.json"
+echo "  app/src-tauri/Cargo.toml"
+echo "  app/src-tauri/Cargo.lock (agmsg-app)"
+
+# The bundled agmsg-core is pinned separately (app/AGMSG_CORE_REF); a version
+# bump is the moment to confirm it, since the app ships whatever it points at.
+CORE_REF="$(tr -d '[:space:]' < "$APP/AGMSG_CORE_REF" 2>/dev/null || true)"
+echo
+echo "NOTE: bundled agmsg-core pin is AGMSG_CORE_REF=${CORE_REF:-<unset>}"
+echo "      Is that the core version to ship with app v$VERSION? Edit app/AGMSG_CORE_REF if not."

--- a/tests/test_bump_app_version.bats
+++ b/tests/test_bump_app_version.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+# bump-app-version.sh derives its ROOT from the script's own location
+# ($(dirname)/../..), so we exercise it against a temp tree: a copy of the real
+# script under <tmp>/scripts/release/ plus fixture version files under <tmp>/app.
+# This keeps the test from mutating the real repo's version files.
+
+setup() {
+  BUMP_ROOT="$(mktemp -d)"
+  mkdir -p "$BUMP_ROOT/scripts/release" "$BUMP_ROOT/app/src-tauri"
+  cp "${BATS_TEST_DIRNAME}/../scripts/release/bump-app-version.sh" "$BUMP_ROOT/scripts/release/"
+  BUMP="$BUMP_ROOT/scripts/release/bump-app-version.sh"
+
+  printf '{\n  "productName": "agmsg",\n  "version": "0.1.3"\n}\n' \
+    > "$BUMP_ROOT/app/src-tauri/tauri.conf.json"
+  printf '{\n  "name": "agmsg-app",\n  "version": "0.1.3"\n}\n' \
+    > "$BUMP_ROOT/app/package.json"
+  printf '[package]\nname = "agmsg-app"\nversion = "0.1.3"\nedition = "2021"\n\n[dependencies]\nserde = "1"\n' \
+    > "$BUMP_ROOT/app/src-tauri/Cargo.toml"
+  # An unrelated package precedes agmsg-app so we can prove only the app entry moves.
+  printf '[[package]]\nname = "other"\nversion = "9.9.9"\n\n[[package]]\nname = "agmsg-app"\nversion = "0.1.3"\ndependencies = []\n' \
+    > "$BUMP_ROOT/app/src-tauri/Cargo.lock"
+  printf 'v1.1.6\n' > "$BUMP_ROOT/app/AGMSG_CORE_REF"
+}
+
+teardown() { rm -rf "$BUMP_ROOT"; }
+
+@test "bump-app-version: rejects a v/app-v prefixed version" {
+  run bash "$BUMP" app-v0.1.4
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"bare semver"* ]]
+  run bash "$BUMP" v0.1.4
+  [ "$status" -ne 0 ]
+}
+
+@test "bump-app-version: rejects a non-semver version" {
+  run bash "$BUMP" 1.2
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"semver"* ]]
+}
+
+@test "bump-app-version: requires a version argument" {
+  run bash "$BUMP"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"usage"* ]]
+}
+
+@test "bump-app-version: bumps all four version files to the new version" {
+  run bash "$BUMP" 0.1.4
+  [ "$status" -eq 0 ]
+  grep -q '"version": "0.1.4"' "$BUMP_ROOT/app/src-tauri/tauri.conf.json"
+  grep -q '"version": "0.1.4"' "$BUMP_ROOT/app/package.json"
+  grep -q '^version = "0.1.4"' "$BUMP_ROOT/app/src-tauri/Cargo.toml"
+  # the agmsg-app lock entry moves; an unrelated package's version must not.
+  run grep -A1 'name = "agmsg-app"' "$BUMP_ROOT/app/src-tauri/Cargo.lock"
+  [[ "$output" == *'version = "0.1.4"'* ]]
+  run grep -A1 'name = "other"' "$BUMP_ROOT/app/src-tauri/Cargo.lock"
+  [[ "$output" == *'version = "9.9.9"'* ]]
+}
+
+@test "bump-app-version: surfaces the agmsg-core pin for confirmation" {
+  run bash "$BUMP" 0.1.4
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"AGMSG_CORE_REF=v1.1.6"* ]]
+}


### PR DESCRIPTION
## Problem

The v0.1.4 app release shipped an installer whose **in-app version still read 0.1.3** — only the `AGMSG_CORE_REF` pin was bumped and the four files that carry the app version were not. Nothing caught the mismatch before the tagged build ran.

## Fix — two mechanized guards

**1. `verify-version` job in app-release.yml (belt).** A fast ubuntu job that both platform builds now `needs:`. On a tag build (`app-vX.Y.Z`) it asserts the tag's version equals `app/src-tauri/tauri.conf.json`'s version and fails fast with a clear `::error::` pointing at the bump script; on `workflow_dispatch` (no tag) it's a no-op. Same philosophy as the CLI `release.yml` tag↔VERSION guard. If it fails, neither build runs.

**2. `scripts/release/bump-app-version.sh <X.Y.Z>` (suspenders).** Bumps every file that carries the app version in one command:
- `app/src-tauri/tauri.conf.json`
- `app/package.json`
- `app/src-tauri/Cargo.toml`
- the `agmsg-app` entry in `app/src-tauri/Cargo.lock`

It validates the argument is bare semver (rejects `v`/`app-v` prefixes, same style as `update-cask.sh`), makes one-line diffs via portable `awk`, and echoes the current `AGMSG_CORE_REF` so the human confirms the core pin the app will ship with.

## Testing

- `tests/test_bump_app_version.bats` (5 cases): rejects `v`/`app-v`-prefixed and non-semver args, requires an arg, bumps all four files, and proves an unrelated `Cargo.lock` entry is left untouched. Runs against a temp copy so it never mutates the repo's real version files.
- Manually ran `bump-app-version.sh 0.1.4` in a worktree: all four files → one-line diffs, core-pin note printed; reverted (this PR is tooling only, no version change).
- The `verify-version` workflow guard is validated at tag time (can't run in PR CI); YAML parses clean and the assertion logic mirrors the CLI guard.

Together: a forgotten bump can no longer reach a tagged build, and the one-command bump makes forgetting unlikely in the first place.