### PR TITLE
fix(spawn): guard '/'-prefixed boot prompt against MSYS path conversion on Git Bash

### DIFF
--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -361,6 +361,20 @@ if [ -n "$PROMPT" ]; then
 ${PROMPT}"
 fi
 
+# Git Bash / MSYS path conversion rewrites exec args that look like absolute
+# POSIX paths when invoking a native Windows binary: a '/<cmd> actas <name>'
+# initial prompt reaches the CLI as 'C:/Program Files/Git/<cmd> actas <name>'
+# and the agent never sees a valid skill invocation. Exclude args starting
+# with the slash command from conversion. The exclusion is prefix-scoped on
+# purpose — MSYS_NO_PATHCONV=1 would also stop converting genuine POSIX-path
+# args (e.g. a node launcher's --project /e/...) that native CLIs rely on.
+# Only the '/' prefix is path-shaped; '$'-prefixed prompts (#283) are never
+# converted, and the variable is inert outside MSYS environments.
+MSYS_GUARD=""
+if [ "$CMD_PREFIX" = "/" ]; then
+  MSYS_GUARD="MSYS2_ARG_CONV_EXCL=/${CMD_NAME} "
+fi
+
 BOOT_DIR="${TMPDIR:-/tmp}/agmsg-spawn"
 mkdir -p "$BOOT_DIR" 2>/dev/null || true
 # Best-effort GC of boot scripts left behind by spawns whose window was closed
@@ -388,7 +402,7 @@ esac
     # Type-specific config is the launcher's own default/env, so core stays
     # generic and names no add-on. Spawn-options tokens (if any) land before
     # --initial-input, same relative position as the direct-CLI path below.
-    printf '%q %q \\\n' "$NODE_BIN" "$SPAWN_AGENT"
+    printf '%s%q %q \\\n' "$MSYS_GUARD" "$NODE_BIN" "$SPAWN_AGENT"
     printf '  --name %q \\\n' "$NAME"
     printf '  --team %q \\\n' "$TEAM"
     printf '  --project %q \\\n' "$PROJECT"
@@ -405,7 +419,7 @@ esac
     # flags like --model or -i); the model id, every spawn-options token, and the
     # actas prompt are quoted. prompt_arg (when set) lands immediately before the
     # prompt so there is no ambiguity about which token is its value.
-    printf '%s' "$CLI_BIN"
+    printf '%s%s' "$MSYS_GUARD" "$CLI_BIN"
     [ -n "$MODEL_ID" ] && printf ' %s %q' "$MODEL_ARG" "$MODEL_ID"
     for _tok in ${SPAWN_OPT_TOKENS[@]+"${SPAWN_OPT_TOKENS[@]}"}; do
       printf ' %q' "$_tok"

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -536,6 +536,35 @@ YAML
   [ "$status" -ne 0 ]
 }
 
+@test "spawn: '/'-prefixed boot prompt is guarded against MSYS path conversion" {
+  # On Git Bash / MSYS, an argv token starting with '/' is rewritten to a
+  # Windows path when handed to a native binary: '/agmsg actas alice' arrives
+  # as 'C:/Program Files/Git/agmsg actas alice'. The boot script must scope it
+  # out via MSYS2_ARG_CONV_EXCL on the CLI launch line (prefix-scoped, NOT
+  # MSYS_NO_PATHCONV=1, so genuine path args keep converting).
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  [ -f "$boot" ]
+  local cmd; cmd="$(basename "$TEST_SKILL_DIR")"
+  # The guard must sit on the same line as the CLI invocation, ahead of it.
+  run grep -E "^MSYS2_ARG_CONV_EXCL=/$cmd claude" "$boot"
+  [ "$status" -eq 0 ]
+}
+
+@test "spawn: \$-prefixed boot prompt gets no MSYS guard (codex)" {
+  # '$'-prefixed prompts are not path-shaped, so no exclusion is emitted —
+  # keeps the boot script byte-identical for agentskills CLIs.
+  bash "$SCRIPTS/join.sh" myteam existing codex "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" codex reviewer --project "$PROJ"
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  [ -f "$boot" ]
+  run grep -F "MSYS2_ARG_CONV_EXCL" "$boot"
+  [ "$status" -ne 0 ]
+}
+
 @test "spawn: boot script keeps the .command suffix only on macOS (#282)" {
   # macOS `open -a Terminal` needs .command to execute the file; every other
   # launcher runs it via bash or its shebang, and on Windows .command makes


### PR DESCRIPTION
Fixes #336.

## What

On Windows Git Bash, MSYS path conversion rewrites the `/`-prefixed initial prompt before it reaches the native CLI — `claude '/agmsg actas alice'` arrives as `C:/Program Files/Git/agmsg actas alice`, so the spawned agent never receives a valid skill invocation (details + repro in #336).

The boot script now prefixes the CLI launch line with `MSYS2_ARG_CONV_EXCL=/<cmd>` when the type's `cmd_prefix` is `/`:

```bash
MSYS2_ARG_CONV_EXCL=/agmsg claude /agmsg\ actas\ alice
```

## Why prefix-scoped (and not `MSYS_NO_PATHCONV=1`)

The exclusion list matches only args starting with `/<cmd>`, so genuine POSIX-path args — e.g. the node launcher's `--project /e/...` — keep being converted, which native CLIs rely on. The blanket switch would break those. The variable is inert outside MSYS, and `$`-prefixed types (#283) emit no guard at all — their boot scripts stay byte-identical (asserted by test).

## Tests

Two bats tests following the #283 boot-content pattern:

- `spawn: '/'-prefixed boot prompt is guarded against MSYS path conversion` — asserts the guard sits on the CLI launch line ahead of the binary
- `spawn: $-prefixed boot prompt gets no MSYS guard (codex)` — asserts the boot script stays byte-identical for agentskills CLIs

Honest note on local runs: on native Windows Git Bash the spawn bats harness itself doesn't run for me — 38/49 tests fail on a clean `main` checkout, including the existing #283 boot-content tests, all at the same `[ "$status" -eq 0 ]` spawn call. The new tests are built for CI (where the #283 pattern passes); local functional verification was done by direct boot-script capture instead (below).

## Field verification (Windows 11 + Git Bash + Windows Terminal)

Boot script captured via an `AGMSG_TERMINAL="{cmd}"` template (nothing launched):

```bash
# claude-code (cmd_prefix "/") — guard emitted on the CLI line:
MSYS2_ARG_CONV_EXCL=/agmsg claude /agmsg\ actas\ alice

# codex (cmd_prefix "$") — no guard, byte-identical:
codex \$agmsg\ actas\ reviewer
```

argv observed at the native-binary boundary:

```console
$ python -c "import sys; print(sys.argv[1])" "/agmsg actas alice"
C:/Program Files/Git/agmsg actas alice          # without guard — the bug
$ MSYS2_ARG_CONV_EXCL=/agmsg python -c "import sys; print(sys.argv[1])" "/agmsg actas alice"
/agmsg actas alice                              # with guard — verbatim
```

An end-to-end spawn with the same change applied to a live install (pre-queued task → spawn → agent claims identity → replies) succeeded, with the spawned agent's session log showing the **unmangled** prompt.

---
（日本語要約）Git Bash の MSYS パス変換が `/` 始まりの初期プロンプトを Windows パスに書き換え、spawn されたエージェントにスキル呼び出しが届かない問題（#336）の修正です。`cmd_prefix=/` の型に限り、boot スクリプトの CLI 起動行へ `MSYS2_ARG_CONV_EXCL=/<cmd>` を付与します。全体無効化（`MSYS_NO_PATHCONV=1`）にしない理由は本文のとおりです。
