### PR TITLE
fix(gemini): detect the real GEMINI_CLI env var, not GOOGLE_GEMINI_CLI

### DIFF
--- a/scripts/drivers/types/gemini/type.conf
+++ b/scripts/drivers/types/gemini/type.conf
@@ -6,7 +6,7 @@ spawnable=yes
 # gemini invokes a skill with "$", not Claude Code's "/" (see spawn.sh, #283).
 cmd_prefix=$
 model_arg=--model
-detect=GEMINI_API_KEY GOOGLE_GEMINI_CLI
+detect=GEMINI_CLI GEMINI_API_KEY
 detect_proc=gemini gemini-*
 hooks_file=.agent/rules/agmsg.md
 monitor=no

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -183,7 +183,7 @@ teardown() {
 
 @test "spawn: does NOT unset a type's credential/detect vars (#294)" {
   # The strip list is a dedicated spawn_unset_env=, NOT detect=. gemini's
-  # detect=GEMINI_API_KEY GOOGLE_GEMINI_CLI are credentials, not a session id —
+  # detect=GEMINI_CLI GEMINI_API_KEY: the session marker + a credential, not a session id —
   # stripping them would break the spawned child's auth (the opposite of the fix).
   # gemini has no spawn_unset_env=, so its boot script must emit no `unset` at all
   # and in particular must never unset GEMINI_API_KEY.

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -82,7 +82,7 @@ write_node_launcher_fixtures() {
   g() { env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_get $1 $2"; }
   [ "$(g claude-code detect)" = "CLAUDE_CODE_SESSION_ID" ]
   [ "$(g codex detect)" = "CODEX_SANDBOX CODEX_THREAD_ID" ]
-  [ "$(g gemini detect)" = "GEMINI_API_KEY GOOGLE_GEMINI_CLI" ]
+  [ "$(g gemini detect)" = "GEMINI_CLI GEMINI_API_KEY" ]
   [ "$(g antigravity detect)" = "explicit" ]
   [ "$(g copilot detect)" = "explicit" ]
   [ "$(g opencode detect_proc)" = "opencode opencode-*" ]


### PR DESCRIPTION
## Summary

Gemini CLI exports `GEMINI_CLI=1` in its shell tool environment. The manifest's `GOOGLE_GEMINI_CLI` name does not exist upstream, so Gemini sessions fell through env detection (misdetected as codex in the report). This switches the gemini manifest to detect the real variable, keeping `GEMINI_API_KEY` as the secondary signal:

```
detect=GEMINI_CLI GEMINI_API_KEY
```

Root cause was identified by @apstndb in #347 with upstream source references ([gemini-cli shell docs](https://github.com/google-gemini/gemini-cli/blob/15a9429b69bd4c72514678ac17c88087f7ab9d48/docs/tools/shell.md?plain=1#L132-L136), [shellExecutionService.ts](https://github.com/google-gemini/gemini-cli/blob/15a9429b69bd4c72514678ac17c88087f7ab9d48/packages/core/src/services/shellExecutionService.ts#L51-L61)) — thank you!

## Testing

- `bats tests/test_type_registry.bats` 17/17 pass (detect assertion updated)
- `bats tests/test_spawn.bats` 49/49 pass (comment reference updated)

Closes #347