### PR TITLE
feat(app): show app and bundled core versions in the About dialog

### DIFF
--- a/app/src-tauri/src/agmsg.rs
+++ b/app/src-tauri/src/agmsg.rs
@@ -437,6 +437,12 @@ pub fn agmsg_install(app: AppHandle) -> Result<(), String> {
 /// running app can compare against it without shelling out to git.
 const PINNED_CORE_REF: &str = include_str!("../../AGMSG_CORE_REF");
 
+/// The pinned core ref for display (e.g. "v1.1.6") — the About dialog shows
+/// which agmsg core this build bundles next to the app's own version.
+pub(crate) fn pinned_core_ref() -> &'static str {
+    PINNED_CORE_REF.trim()
+}
+
 /// Parses a leading "X.Y.Z" out of a version string, ignoring anything after
 /// (git-describe suffixes like "-3-gabc1234", "-dirty", or a leading "v").
 /// None for anything that doesn't start with a clean X.Y.Z — including the

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -192,10 +192,23 @@ fn make_menu(app: &AppHandle, lang: &str) -> tauri::Result<Menu<Wry>> {
     let m = |key: &str| menu_i18n::t(lang, "nativeMenu", key, &[]);
     let m_name = |key: &str| menu_i18n::t(lang, "nativeMenu", key, &[("name", name)]);
     let icon = tauri::image::Image::from_bytes(include_bytes!("../icons/icon.png")).ok();
+    // version → macOS ApplicationVersion / the Windows "Version:" line;
+    // short_version → the parenthesized build suffix on both (muda's
+    // full_version() renders "version (short_version)" on Windows, and the
+    // macOS About panel does the same with its ApplicationVersion/Version
+    // pair). Both OSes thus show "0.1.4 (core v1.1.6)" — the app version and
+    // which agmsg core this build bundles.
     let about = PredefinedMenuItem::about(
         app,
         Some(&m_name("about")),
-        Some(AboutMetadataBuilder::new().name(Some(name.to_string())).icon(icon).build()),
+        Some(
+            AboutMetadataBuilder::new()
+                .name(Some(name.to_string()))
+                .version(Some(app.package_info().version.to_string()))
+                .short_version(Some(format!("core {}", agmsg::pinned_core_ref())))
+                .icon(icon)
+                .build(),
+        ),
     )?;
     let check_updates =
         MenuItem::with_id(app, CHECK_UPDATES_ID, m("checkForUpdates"), true, None::<&str>)?;


### PR DESCRIPTION
## Summary
- The About dialog showed only the app name — the Windows 0.1.4 gate round surfaced it as `Name: agmsg` with no version line at all; macOS likewise showed no version.
- Sets `AboutMetadata.version` to the app version (from `package_info()`) and `short_version` to the bundled core ref (`AGMSG_CORE_REF` via the existing `PINNED_CORE_REF` embed), exposed through a new `agmsg::pinned_core_ref()` accessor.
- Cross-platform rendering is intentionally symmetric: muda's Windows `full_version()` renders `version (short_version)`, and the macOS About panel composes its `ApplicationVersion`/`Version` pair the same way — so both OSes show **`0.1.4 (core v1.1.6)`**.

Out of scope (upstream limitation, already reported): the Windows About icon — muda's Windows implementation ignores the supplied icon (MB_ICONINFORMATION / TD_INFORMATION_ICON fixed), and tauri-plugin-dialog has no icon API. Text-only change here.

## Testing
- `cargo check` / `cargo test` 21/21 pass
- `tsc --noEmit` / `pnpm test` 81/81 pass (frontend untouched; regression run only)
- UI verification: native About panel — macOS/Windows visual check happens on the 0.1.5 gate round (the version string composition is asserted against muda 0.19.3 source, `show_about_dialog` / `full_version()` / `NSAboutPanelOption*` mapping).