### PR TITLE
Bind the codex bridge to the role's recorded thread, not "loaded" (#350)

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -28,6 +28,16 @@ source "$SCRIPT_DIR/../../../lib/node.sh"
 NODE_BIN="$(agmsg_resolve_node)"
 TAB="$(printf '\t')"
 
+# role-session record (#350): the bridge prefers this role's RECORDED codex thread
+# over the app-server's "loaded" thread (see the thread-resolution block below).
+# shellcheck source=../../../lib/role-session.sh
+source "$SCRIPT_DIR/../../../lib/role-session.sh"
+# shellcheck source=../../../lib/resolve-project.sh
+source "$SCRIPT_DIR/../../../lib/resolve-project.sh"
+# Canonicalize once so the record's project (stored from the codex actas flow's
+# cwd) compares equal to this launcher's project even across a symlinked path.
+PROJECT_PHYS="$(agmsg_canonical_path "$PROJECT" 2>/dev/null || printf '%s' "$PROJECT")"
+
 mkdir -p "$RUN_DIR"
 
 resolve_identity() {  # prints "team<TAB>name" lines for the project's codex roles
@@ -59,6 +69,11 @@ log="$RUN_DIR/codex-bridge.$team.$name.log"
 # launcher instance can tell a bridge bound to a stale app-server (old port,
 # from before a codex upgrade) from one bound to the current server. See #197/#237.
 appserver_file="$RUN_DIR/codex-bridge.$team.$name.appserver"
+# Records the thread a live bridge was bound to (#350), so a later launcher can
+# rebind when the resolved thread changes -- e.g. once a role-session record
+# appears for a bridge first launched on "loaded", it is torn down and relaunched
+# on the recorded thread instead of clinging to the ambiguous "loaded" one.
+thread_file="$RUN_DIR/codex-bridge.$team.$name.thread"
 # An explicit AGMSG_CODEX_BRIDGE_CMD is a complete runnable (tests, custom
 # wrappers) — run it as-is. Only the default codex-bridge.js is launched through
 # a resolved Node, since its env-node shebang fails where a version-manager Node
@@ -87,6 +102,24 @@ EOF
     fi
   fi
 
+  # Prefer this role's RECORDED codex thread (#350). The app-server's "loaded"
+  # thread is whichever conversation the server last touched -- ambiguous when a
+  # cwd has run more than one codex thread, so a co-resident thread can capture
+  # this role's messages. The role-session record (#339) stores this role's own
+  # thread deterministically; use it when present AND recorded for THIS project.
+  # A request-file thread (above) still wins; no record -- or a record for a
+  # different project -- falls back to "loaded" (fail-open for roles predating the
+  # record). Freshness holds because a role re-runs actas on resume (#339), which
+  # rewrites the record with its current thread.
+  if [ "$thread_id" = "loaded" ]; then
+    rec_thread="$(agmsg_role_session_uuid "$team" "$name" 2>/dev/null || true)"
+    if [ -n "$rec_thread" ]; then
+      rec_project="$(agmsg_role_session_get "$team" "$name" project 2>/dev/null || true)"
+      rec_project_phys="$(agmsg_canonical_path "$rec_project" 2>/dev/null || printf '%s' "$rec_project")"
+      [ "$rec_project_phys" = "$PROJECT_PHYS" ] && thread_id="$rec_thread"
+    fi
+  fi
+
   if [ -f "$pidfile" ]; then
     bridge_pid="$(cat "$pidfile" 2>/dev/null || true)"
     if [ -n "$bridge_pid" ] && kill -0 "$bridge_pid" 2>/dev/null; then
@@ -96,13 +129,19 @@ EOF
       # alive but delivers nothing. The bridge's own exit-on-close covers most of
       # this, but guard the race where the old bridge has not exited yet by the
       # time a new launcher re-checks: an app-server mismatch means tear it down.
+      # Reuse only when the live bridge is bound to BOTH the current app-server
+      # AND the current thread. The thread guard (#350) is what lets a bridge
+      # first launched on the ambiguous "loaded" thread rebind once this role's
+      # recorded thread becomes known -- otherwise the app-server match alone
+      # would keep the wrong-thread bridge alive indefinitely.
       bound_url="$(cat "$appserver_file" 2>/dev/null || true)"
-      if [ "$bound_url" = "$req_app_server" ]; then
+      bound_thread="$(cat "$thread_file" 2>/dev/null || true)"
+      if [ "$bound_url" = "$req_app_server" ] && [ "$bound_thread" = "$thread_id" ]; then
         sleep 0.3
         continue
       fi
       kill "$bridge_pid" 2>/dev/null || true
-      rm -f "$pidfile" "$appserver_file"
+      rm -f "$pidfile" "$appserver_file" "$thread_file"
     fi
   fi
 
@@ -117,5 +156,6 @@ EOF
     >>"$log" 2>&1 &
   # Record what this bridge is bound to so a later launcher can detect staleness.
   printf '%s' "$req_app_server" > "$appserver_file"
+  printf '%s' "$thread_id" > "$thread_file"
   sleep 1
 done

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+# Unit tests for codex-bridge-launcher.sh thread resolution (#350).
+# The launcher must bind the bridge to the role's RECORDED codex thread instead
+# of the app-server's ambiguous "loaded" thread (which a co-resident codex thread
+# in the same cwd could otherwise capture). A mock bridge (AGMSG_CODEX_BRIDGE_CMD)
+# records the --thread the launcher passes.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  export RUN_DIR="$SKILL_DIR/run"; mkdir -p "$RUN_DIR"
+  export PROJ="$TEST_SKILL_DIR/proj"; mkdir -p "$PROJ"
+  bash "$SCRIPTS/join.sh" team alice codex "$PROJ" >/dev/null
+
+  export CAPTURE="$TEST_SKILL_DIR/thread-capture.txt"
+  export MOCK="$TEST_SKILL_DIR/mock-bridge.sh"
+  cat > "$MOCK" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$CAPTURE"
+exit 0
+EOF
+  chmod +x "$MOCK"
+  export AGMSG_CODEX_BRIDGE_CMD="$MOCK"
+  export LAUNCHER="$SCRIPTS/drivers/types/codex/codex-bridge-launcher.sh"
+}
+
+teardown() { teardown_test_env; }
+
+# Write a role-session record (team, agent) -> thread for a project.
+put_record() {
+  SKILL_DIR="$TEST_SKILL_DIR" bash -c \
+    'source "$1/lib/role-session.sh"; agmsg_role_session_record "$2" "$3" "$4" "$5" "$6"' \
+    _ "$SCRIPTS" "$@"
+}
+
+# Drive the launcher against a short-lived parent, blocking until it exits. fd 3
+# is closed on the backgrounded parent and the launcher so a stray descriptor
+# can't keep bats from exiting on macOS (#bats-fd3).
+run_launcher() {
+  sleep 2 3>&- & local p=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$p" >/dev/null 2>&1 3>&- || true
+  wait "$p" 2>/dev/null || true
+}
+
+@test "launcher: binds the recorded thread when the record's project matches (#350)" {
+  put_record team alice rec-thread-1 "$PROJ" codex
+  run_launcher
+  [ -f "$CAPTURE" ]
+  grep -q -- "--thread rec-thread-1" "$CAPTURE"
+  ! grep -q -- "--thread loaded" "$CAPTURE"
+}
+
+@test "launcher: falls back to 'loaded' when no record exists (#350)" {
+  run_launcher
+  [ -f "$CAPTURE" ]
+  grep -q -- "--thread loaded" "$CAPTURE"
+}
+
+@test "launcher: falls back to 'loaded' when the record is for a different project (#350)" {
+  put_record team alice other-thread "/some/other/project" codex
+  run_launcher
+  [ -f "$CAPTURE" ]
+  grep -q -- "--thread loaded" "$CAPTURE"
+  ! grep -q -- "--thread other-thread" "$CAPTURE"
+}
+
+@test "launcher: writes the bound-thread file so a later launcher can rebind (#350)" {
+  put_record team alice rec-thread-1 "$PROJ" codex
+  run_launcher
+  [ "$(cat "$RUN_DIR/codex-bridge.team.alice.thread" 2>/dev/null)" = "rec-thread-1" ]
+}


### PR DESCRIPTION
Closes #350.

## Problem

The codex bridge is launched with `--thread loaded`, resolving to whichever conversation the app-server last touched. When a project cwd has run more than one codex thread, `loaded` is ambiguous — a co-resident codex thread can capture a role's messages. They are replayed as turns on the wrong conversation, landing nowhere the operator's live session can see, while still being marked read.

Confirmed from a live bridge log (see the [forensics comment](https://github.com/fujibee/agmsg/issues/350)): the bridge injected inbound messages into a stale thread for many turns while the role's own recorded thread sat idle.

## Fix

`codex-bridge-launcher.sh` now prefers this role's **recorded** codex thread (the role→session record added in #339) over `loaded`:

- Use the recorded thread when it exists **and** its recorded project matches this launcher's project (canonicalized, so a symlinked path still compares equal).
- Fall back to `loaded` when there is no record, or the record is for a different project — **fail-open** for roles predating the record.
- A request-file thread (older-codex hook) still wins.
- Freshness holds because a role re-runs `actas` on resume (#339), which rewrites the record with its current thread.

The reuse check also compares the **bound thread** now (a new `.thread` state file next to `.appserver`), so a bridge first launched on `loaded` **rebinds** the moment this role's record appears — the app-server match alone no longer keeps a wrong-thread bridge alive.

Builds on the role-session record API from #339 / #344.

## Tests

New `tests/test_codex_bridge_launcher.bats`: the launcher binds the recorded thread on a project match, falls back to `loaded` with no record or a cross-project record, and writes the bound-thread state file. Existing codex bridge/monitor/resume suites stay green.