### PR TITLE
fix(app-release): Authenticode-sign Windows binaries during tauri build

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -23,10 +23,13 @@ name: app release
 #   (the signing identity itself is hardcoded in tauri.conf.json, not a
 #   secret — don't set APPLE_SIGNING_IDENTITY as a step env var unless it's
 #   actually populated, an empty override breaks codesign)
-#   Windows codesign (azure/artifact-signing-action, OIDC federated via
-#   azure/login — no client secret. Account: agmsg-artifact-signing, East US,
-#   endpoint https://eus.codesigning.azure.net/, certificate profile
-#   agmsg-app-signing (Public Trust, CN=Koichi Fujikawa). App registration:
+#   Windows codesign (Azure Trusted Signing via the TrustedSigning PowerShell
+#   module, wired into `tauri build` through bundle.windows.signCommand ->
+#   app/scripts/sign-windows.ps1 so signing happens BEFORE cab packing and
+#   updater .sig generation (#333). OIDC federated via azure/login — no
+#   client secret. Account: agmsg-artifact-signing, East US, endpoint
+#   https://eus.codesigning.azure.net/, certificate profile agmsg-app-signing
+#   (Public Trust, CN=Koichi Fujikawa). App registration:
 #   agmsg-github-actions, federated for the main branch):
 #     AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID
 #   Auto-updater artifact signing (keypair already generated locally, see
@@ -186,12 +189,13 @@ jobs:
         working-directory: .
         shell: bash
 
-      - name: Build
-        env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: pnpm tauri build
-
+      # Login BEFORE the build: Authenticode signing now happens inside
+      # `tauri build` (bundle > windows > signCommand -> sign-windows.ps1), so
+      # the Azure CLI credential must already exist when the bundler runs.
+      # Signing binaries after the build (the old artifact-signing-action
+      # step) mutated bytes the updater's minisign .sig had already been
+      # computed over — every 0.1.4 update failed signature verification, and
+      # the in-place pass also corrupted the MSI's embedded cabinet (#333).
       - name: Azure login (OIDC)
         if: ${{ env.HAS_AZURE_CREDS == 'true' }}
         uses: azure/login@v3
@@ -200,19 +204,44 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Sign Windows binaries (Azure Trusted Signing)
+      - name: Install TrustedSigning PowerShell module
         if: ${{ env.HAS_AZURE_CREDS == 'true' }}
-        uses: azure/artifact-signing-action@v2
-        with:
-          endpoint: https://eus.codesigning.azure.net/
-          signing-account-name: agmsg-artifact-signing
-          certificate-profile-name: agmsg-app-signing
-          files-folder: ${{ github.workspace }}/app/src-tauri/target/release/bundle
-          files-folder-filter: exe,msi
-          files-folder-recurse: true
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
+        shell: pwsh
+        run: Install-Module -Name TrustedSigning -Force -Scope CurrentUser -Repository PSGallery
+
+      - name: Build
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        shell: bash
+        run: |
+          # With Azure creds, sign each artifact during bundling: the app exe
+          # is signed before it is packed into the MSI cab / NSIS installer,
+          # and the updater .sig is generated over the final signed bytes.
+          # Feature branches build unsigned (federated identity trusts main
+          # only, so there is no credential to sign with).
+          if [ "$HAS_AZURE_CREDS" = "true" ]; then
+            sign_script="${GITHUB_WORKSPACE//\\//}/app/scripts/sign-windows.ps1"
+            config="$(jq -cn --arg cmd "pwsh -NoProfile -ExecutionPolicy Bypass -File $sign_script %1" '{bundle: {windows: {signCommand: $cmd}}}')"
+            pnpm tauri build --config "$config"
+          else
+            pnpm tauri build
+          fi
+
+      - name: Verify Authenticode signatures
+        if: ${{ env.HAS_AZURE_CREDS == 'true' }}
+        shell: pwsh
+        run: |
+          $shipped = Get-ChildItem -Path src-tauri/target/release/bundle/msi/*.msi, src-tauri/target/release/bundle/nsis/*.exe
+          if ($shipped.Count -eq 0) { Write-Error "no shipped artifacts found to verify"; exit 1 }
+          foreach ($f in $shipped) {
+            $sig = Get-AuthenticodeSignature -FilePath $f.FullName
+            if ($sig.Status -ne 'Valid') {
+              Write-Error "$($f.Name): Authenticode status $($sig.Status) — signCommand did not run or failed silently"
+              exit 1
+            }
+            Write-Output "OK: $($f.Name) signed by $($sig.SignerCertificate.Subject)"
+          }
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -192,8 +192,8 @@ jobs:
       # Login BEFORE the build: Authenticode signing now happens inside
       # `tauri build` (bundle > windows > signCommand -> sign-windows.ps1), so
       # the Azure CLI credential must already exist when the bundler runs.
-      # Signing binaries after the build (the old artifact-signing-action
-      # step) mutated bytes the updater's minisign .sig had already been
+      # Signing binaries after the build (the old post-build signing step,
+      # since removed) mutated bytes the updater's minisign .sig had already been
       # computed over — every 0.1.4 update failed signature verification, and
       # the in-place pass also corrupted the MSI's embedded cabinet (#333).
       - name: Azure login (OIDC)

--- a/app/scripts/sign-windows.ps1
+++ b/app/scripts/sign-windows.ps1
@@ -1,0 +1,30 @@
+# Authenticode-signs one file with Azure Trusted Signing. Invoked by the Tauri
+# bundler (bundle > windows > signCommand) once per artifact DURING the build:
+# the bare app exe before it is packed into the MSI cab / NSIS installer, then
+# the installers themselves. That ordering is the point — the updater's
+# minisign .sig is generated after signing, over the bytes that actually ship
+# (issue #333: post-build in-place signing invalidated the .sig and corrupted
+# the MSI cabinet).
+#
+# Auth: DefaultAzureCredential. In CI, azure/login provides the Azure CLI
+# credential via OIDC (federated for the main branch only — no client secret
+# exists, which is why trusted-signing-cli is not usable here).
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$File
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Module -ListAvailable -Name TrustedSigning)) {
+  Install-Module -Name TrustedSigning -Force -Scope CurrentUser -Repository PSGallery
+}
+
+Invoke-TrustedSigning `
+  -Endpoint "https://eus.codesigning.azure.net/" `
+  -CodeSigningAccountName "agmsg-artifact-signing" `
+  -CertificateProfileName "agmsg-app-signing" `
+  -FileDigest SHA256 `
+  -TimestampRfc3161 "http://timestamp.acs.microsoft.com" `
+  -TimestampDigest SHA256 `
+  -Files $File

--- a/tests/test_app_release_signing.bats
+++ b/tests/test_app_release_signing.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+# Regression guards for issue #333: on Windows, Authenticode signing must
+# happen DURING `tauri build` (bundle > windows > signCommand), never as a
+# post-build in-place pass — signing after the build mutates bytes the
+# updater's minisign .sig was already computed over (every 0.1.4 in-app
+# update failed verification) and corrupted the MSI's embedded cabinet.
+# Real signing is only exercisable on main (OIDC federated identity), so
+# these tests pin the workflow's structure instead.
+
+WORKFLOW="${BATS_TEST_DIRNAME}/../.github/workflows/app-release.yml"
+SIGN_SCRIPT="${BATS_TEST_DIRNAME}/../app/scripts/sign-windows.ps1"
+
+@test "app-release: no post-build in-place signing action remains" {
+  ! grep -q "artifact-signing-action" "$WORKFLOW"
+  ! grep -q "trusted-signing-action" "$WORKFLOW"
+}
+
+@test "app-release: azure login runs before the windows build" {
+  login_line="$(grep -n "azure/login" "$WORKFLOW" | head -1 | cut -d: -f1)"
+  build_line="$(grep -n "pnpm tauri build --config" "$WORKFLOW" | head -1 | cut -d: -f1)"
+  [ -n "$login_line" ]
+  [ -n "$build_line" ]
+  [ "$login_line" -lt "$build_line" ]
+}
+
+@test "app-release: windows build wires signCommand to sign-windows.ps1 per artifact" {
+  grep -q "signCommand" "$WORKFLOW"
+  grep -q "sign-windows.ps1" "$WORKFLOW"
+  grep -q '$sign_script %1' "$WORKFLOW"
+}
+
+@test "app-release: shipped artifacts are verified as Authenticode-signed" {
+  grep -q "Get-AuthenticodeSignature" "$WORKFLOW"
+}
+
+@test "sign-windows.ps1: same trusted-signing account/profile the action used" {
+  grep -q "Invoke-TrustedSigning" "$SIGN_SCRIPT"
+  grep -q "https://eus.codesigning.azure.net/" "$SIGN_SCRIPT"
+  grep -q "agmsg-artifact-signing" "$SIGN_SCRIPT"
+  grep -q "agmsg-app-signing" "$SIGN_SCRIPT"
+}

--- a/tests/test_app_release_signing.bats
+++ b/tests/test_app_release_signing.bats
@@ -12,8 +12,15 @@ WORKFLOW="${BATS_TEST_DIRNAME}/../.github/workflows/app-release.yml"
 SIGN_SCRIPT="${BATS_TEST_DIRNAME}/../app/scripts/sign-windows.ps1"
 
 @test "app-release: no post-build in-place signing action remains" {
-  ! grep -q "artifact-signing-action" "$WORKFLOW"
-  ! grep -q "trusted-signing-action" "$WORKFLOW"
+  # `run` + explicit status check, not bare `! grep ...`: bash's `set -e`
+  # (which bats enables for the test body) exempts `!`-negated commands from
+  # aborting the function on failure, so two bare `! grep` statements in a
+  # row would silently swallow the first one's failure — only the LAST
+  # statement's exit code would determine the test's outcome.
+  run grep -q -- "uses: azure/artifact-signing-action" "$WORKFLOW"
+  [ "$status" -ne 0 ]
+  run grep -q -- "uses: azure/trusted-signing-action" "$WORKFLOW"
+  [ "$status" -ne 0 ]
 }
 
 @test "app-release: azure login runs before the windows build" {


### PR DESCRIPTION
Closes #333

## Problem

Windows app-v0.1.4 shipped with two release-blocking defects:

1. The in-app updater rejects the update with "signature verification failed".
2. The standalone MSI fails to install: "cabinet file 'app.cab' ... is corrupt".

## Root cause

In `.github/workflows/app-release.yml`, the Windows job ran `pnpm tauri build` first (which generates the updater's minisign `.sig` files over the just-built bytes) and only then ran `azure/artifact-signing-action@v2`, which Authenticode-signs the `.exe`/`.msi` **in place**. Signing mutates the binaries, so the shipped bytes no longer match the already-generated `.sig` (bug 1), and the same in-place pass corrupted the MSI's embedded cabinet stream (bug 2). The signing keys themselves were never wrong (pubkey ID matches in `latest.json` and `tauri.conf.json`).

## Change

Sign **during** bundling instead of after it:

- (1) `bundle > windows > signCommand` is injected at build time (CI-only, via `tauri build --config`), pointing at the new `app/scripts/sign-windows.ps1`. The bundler invokes it per artifact, so the app exe is signed **before** it is packed into the MSI cab / NSIS installer, and the updater `.sig` is generated over the final signed bytes.
- (2) `sign-windows.ps1` uses the Microsoft `TrustedSigning` PowerShell module (`Invoke-TrustedSigning`) with the same endpoint/account/certificate profile the removed action used. Auth is `DefaultAzureCredential`, which picks up the `azure/login` OIDC session — `trusted-signing-cli` (the approach suggested in Tauri docs) was evaluated and rejected because it strictly requires a client secret, and this repo's federated app registration has none.
- (3) `azure/login` moves before the build step; the post-build `azure/artifact-signing-action` step is removed.
- (4) A new "Verify Authenticode signatures" step fails the job if any shipped `.msi`/`.exe` is not validly signed, so a silently skipped or broken `signCommand` cannot ship.
- (5) `tests/test_app_release_signing.bats` pins the structure (no post-build signing action, login before build, signCommand wiring, verification step present) since real signing is only exercisable on `main`.

Feature-branch/dispatch behavior is unchanged: without usable Azure credentials the build produces unsigned artifacts exactly as before (the federated identity trusts `main` only).

## Verification

- Local: new + adjacent bats suites green (10/10); workflow YAML parses; the `jq`-built `--config` payload produces the expected `signCommand` string with a forward-slash absolute path.
- Full end-to-end (real signing + updater verification + MSI install) is only possible from `main` due to the OIDC branch restriction: after merge, a `workflow_dispatch` run on `main` plus the real-Windows-machine checklist gates the `app-v*` tag as usual.