### PR TITLE
fix(spawn): guard '/'-prefixed boot prompt against MSYS path conversion on Git Bash

### DIFF
--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -390,6 +390,26 @@ if [ -n "$PROMPT" ]; then
 ${PROMPT}"
 fi
 
+# Git Bash / MSYS path conversion rewrites exec args that look like absolute
+# POSIX paths when invoking a native Windows binary: a '/<cmd> actas <name>'
+# initial prompt reaches the CLI as 'C:/Program Files/Git/<cmd> actas <name>'
+# and the agent never sees a valid skill invocation. Exclude args starting
+# with the slash command from conversion. The exclusion is prefix-scoped on
+# purpose — MSYS_NO_PATHCONV=1 would also stop converting genuine POSIX-path
+# args (e.g. a node launcher's --project /e/...) that native CLIs rely on.
+# Only the '/' prefix is path-shaped; '$'-prefixed prompts (#283) are never
+# converted, and the variable is inert outside MSYS environments.
+# cmd_prefix/cmd_name are resolved exactly as agmsg_actas_prompt does
+# (lib/boot-command.sh) -- #344 moved that resolution into the helper, so the two
+# inputs the guard needs are recomputed here rather than read from now-absent vars.
+_msys_cmd_name="$(basename "$SKILL_DIR")"
+_msys_cmd_prefix="$(agmsg_type_get "$AGENT_TYPE" cmd_prefix)"
+[ -n "$_msys_cmd_prefix" ] || _msys_cmd_prefix="/"
+MSYS_GUARD=""
+if [ "$_msys_cmd_prefix" = "/" ]; then
+  MSYS_GUARD="MSYS2_ARG_CONV_EXCL=/${_msys_cmd_name} "
+fi
+
 BOOT_DIR="${TMPDIR:-/tmp}/agmsg-spawn"
 mkdir -p "$BOOT_DIR" 2>/dev/null || true
 # Best-effort GC of boot scripts left behind by spawns whose window was closed
@@ -421,7 +441,7 @@ esac
     # Type-specific config is the launcher's own default/env, so core stays
     # generic and names no add-on. Spawn-options tokens (if any) land before
     # --initial-input, same relative position as the direct-CLI path below.
-    printf '%q %q \\\n' "$NODE_BIN" "$SPAWN_AGENT"
+    printf '%s%q %q \\\n' "$MSYS_GUARD" "$NODE_BIN" "$SPAWN_AGENT"
     printf '  --name %q \\\n' "$NAME"
     printf '  --team %q \\\n' "$TEAM"
     printf '  --project %q \\\n' "$PROJECT"
@@ -441,7 +461,9 @@ esac
     # %q-quoted); the model id and every spawn-options token are quoted. The
     # role-identity tail (name/prompt_arg + the actas prompt) is emitted by
     # agmsg_role_cli_args so its flag order matches resurrect-panes.sh.
-    printf '%s' "$CLI_BIN"
+    # MSYS_GUARD (#336) prefixes the CLI line as a command-local env assignment;
+    # emitted with %s (not %q) so it stays an assignment, not a single token.
+    printf '%s%s' "$MSYS_GUARD" "$CLI_BIN"
     agmsg_role_resume_head "$AGENT_TYPE" "$RESUME_UUID"
     [ -n "$MODEL_ID" ] && printf ' %s %q' "$MODEL_ARG" "$MODEL_ID"
     for _tok in ${SPAWN_OPT_TOKENS[@]+"${SPAWN_OPT_TOKENS[@]}"}; do

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -680,6 +680,35 @@ YAML
   [ "$status" -ne 0 ]
 }
 
+@test "spawn: '/'-prefixed boot prompt is guarded against MSYS path conversion" {
+  # On Git Bash / MSYS, an argv token starting with '/' is rewritten to a
+  # Windows path when handed to a native binary: '/agmsg actas alice' arrives
+  # as 'C:/Program Files/Git/agmsg actas alice'. The boot script must scope it
+  # out via MSYS2_ARG_CONV_EXCL on the CLI launch line (prefix-scoped, NOT
+  # MSYS_NO_PATHCONV=1, so genuine path args keep converting).
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  [ -f "$boot" ]
+  local cmd; cmd="$(basename "$TEST_SKILL_DIR")"
+  # The guard must sit on the same line as the CLI invocation, ahead of it.
+  run grep -E "^MSYS2_ARG_CONV_EXCL=/$cmd claude" "$boot"
+  [ "$status" -eq 0 ]
+}
+
+@test "spawn: \$-prefixed boot prompt gets no MSYS guard (codex)" {
+  # '$'-prefixed prompts are not path-shaped, so no exclusion is emitted —
+  # keeps the boot script byte-identical for agentskills CLIs.
+  bash "$SCRIPTS/join.sh" myteam existing codex "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" codex reviewer --project "$PROJ"
+  [ "$status" -eq 0 ]
+  boot="$(cat "$CAPTURE")"
+  [ -f "$boot" ]
+  run grep -F "MSYS2_ARG_CONV_EXCL" "$boot"
+  [ "$status" -ne 0 ]
+}
+
 @test "spawn: boot script keeps the .command suffix only on macOS (#282)" {
   # macOS `open -a Terminal` needs .command to execute the file; every other
   # launcher runs it via bash or its shebang, and on Windows .command makes


### PR DESCRIPTION
Based on #337 by @Salmonellasarduri, carried forward onto current `main`. The
original branch began to conflict after #344 (the spawn.sh boot-command refactor)
landed, so the change is rebased here with the credit preserved.

Closes #336.

## What

On Windows Git Bash, MSYS path conversion rewrites the `/`-prefixed initial
prompt before it reaches the native CLI — `claude '/agmsg actas alice'` arrives
as `C:/Program Files/Git/agmsg actas alice`, so the spawned agent never receives
a valid skill invocation (repro in #336).

The boot script now prefixes the CLI launch line with `MSYS2_ARG_CONV_EXCL=/<cmd>`
when the type's `cmd_prefix` is `/`:

```bash
MSYS2_ARG_CONV_EXCL=/agmsg claude /agmsg\ actas\ alice
```

The exclusion is prefix-scoped on purpose: it matches only args starting with
`/<cmd>`, so genuine POSIX-path args (e.g. a node launcher's `--project /e/...`)
keep being converted, which native CLIs rely on. A blanket `MSYS_NO_PATHCONV=1`
would break those. The variable is inert outside MSYS, and `$`-prefixed types
(#283) emit no guard — their boot scripts stay byte-identical (asserted by test).

## Delta vs #337 (rebase note)

#344 moved `cmd_prefix` / `cmd_name` resolution into `agmsg_actas_prompt`
(`lib/boot-command.sh`), so those variables no longer exist in `spawn.sh`. The
guard now recomputes the two inputs it needs the same way `agmsg_actas_prompt`
does. A plain textual merge would have left the guard reading now-undefined
variables and silently emitting nothing, so this small adjustment keeps the fix
functional. The guard is applied at both current launch points (the node-launcher
path and the direct-CLI path). No change to the original behavior.

## Tests

Two bats tests (from #337): a `/`-prefixed prompt carries the guard on the CLI
launch line; a `$`-prefixed prompt (codex) does not. Full `test_spawn.bats`
passes locally, and the CI bats matrix (including the windows leg) covers it.

## Verification

This is Windows-specific behavior. Functional verification — boot-script capture
plus an end-to-end spawn on Windows 11 + Git Bash — was done by the original
author in #337; CI here covers the automated matrix.
