### PR TITLE
Stop ancestor project resolution from over-reaching to $HOME / other teams (#357)

### DIFF
--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -45,23 +45,13 @@ source "$SCRIPT_DIR/lib/storage.sh"
 source "$SCRIPT_DIR/lib/registry-lock.sh"
 # Scope resolution to the join target team (#357): a poison registration in an
 # unrelated team must not steer this join's ancestor/git-common fallback.
+# Registering a project AT $HOME or / is deliberately allowed -- both claude and
+# codex support sessions whose cwd is $HOME, so starting a project there is a
+# legitimate use case. The #357 protection is on the resolution side: the
+# ancestor walk never LANDS on $HOME/`/`, so such a registration only ever
+# matches its exact path and cannot silently vacuum up sessions beneath it.
 PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE" "$TEAM")"
 PROJECT_PATH="$(agmsg_normalize_project_path "$PROJECT_PATH")"
-
-# Refuse to register a project at `/` or $HOME (#357): those are ancestors of
-# nearly every directory, so registering one there poisons the ancestor-walk
-# resolution for every session beneath it. This guards the source; A stray
-# resolution can no longer land here, and neither can a mistaken explicit path.
-_home_norm="$(agmsg_normalize_project_path "${HOME:-}" 2>/dev/null || true)"
-case "$PROJECT_PATH" in
-  "/"|[A-Za-z]:|[A-Za-z]:/)
-    echo "join: refusing to register a project at the filesystem root ('$PROJECT_PATH') — pick a project subdirectory" >&2
-    exit 1 ;;
-esac
-if [ -n "$_home_norm" ] && [ "$PROJECT_PATH" = "$_home_norm" ]; then
-  echo "join: refusing to register a project at \$HOME ('$PROJECT_PATH') — pick a project subdirectory, or a session there would capture unrelated resolutions" >&2
-  exit 1
-fi
 
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
 

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -43,8 +43,25 @@ source "$SCRIPT_DIR/lib/resolve-project.sh"
 source "$SCRIPT_DIR/lib/storage.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/registry-lock.sh"
-PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
+# Scope resolution to the join target team (#357): a poison registration in an
+# unrelated team must not steer this join's ancestor/git-common fallback.
+PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE" "$TEAM")"
 PROJECT_PATH="$(agmsg_normalize_project_path "$PROJECT_PATH")"
+
+# Refuse to register a project at `/` or $HOME (#357): those are ancestors of
+# nearly every directory, so registering one there poisons the ancestor-walk
+# resolution for every session beneath it. This guards the source; A stray
+# resolution can no longer land here, and neither can a mistaken explicit path.
+_home_norm="$(agmsg_normalize_project_path "${HOME:-}" 2>/dev/null || true)"
+case "$PROJECT_PATH" in
+  "/"|[A-Za-z]:|[A-Za-z]:/)
+    echo "join: refusing to register a project at the filesystem root ('$PROJECT_PATH') — pick a project subdirectory" >&2
+    exit 1 ;;
+esac
+if [ -n "$_home_norm" ] && [ "$PROJECT_PATH" = "$_home_norm" ]; then
+  echo "join: refusing to register a project at \$HOME ('$PROJECT_PATH') — pick a project subdirectory, or a session there would capture unrelated resolutions" >&2
+  exit 1
+fi
 
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
 

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -194,19 +194,25 @@ agmsg_project_sql_in_list() {
 }
 
 agmsg_find_registered_project_variant() {
-  local projects="$1" path="$2" candidate match home_norm
+  local projects="$1" path="$2" candidate match match_norm home_norm
   # #357: never resolve to `/` or $HOME. They are ancestors of nearly every
   # directory, so one stray registration there (even in another team, or a
   # leftover) would capture unrelated sessions -- the ancestor walk climbs
   # through them and would otherwise MATCH them, silently rewriting a project to
   # $HOME. The walk may still ASCEND through these dirs; it just must not land on
   # one. (marker resolution, step 1, is unaffected.)
+  #
+  # The exclusion compares NORMALIZED paths, so a registration stored with a
+  # trailing/duplicate slash ("$HOME/", "//") -- which raw string compare would
+  # miss -- is still excluded (agmsg_normalize_project_path collapses/strips
+  # those). Normalization is logical, not symlink-resolving; see the PR notes.
   home_norm="$(agmsg_normalize_project_path "${HOME:-}" 2>/dev/null || true)"
   while IFS= read -r candidate; do
     match=$(printf '%s\n' "$projects" | grep -Fx -- "$candidate" | head -n 1 || true)
     if [ -n "$match" ]; then
-      case "$match" in "/"|""|[A-Za-z]:|[A-Za-z]:/) continue ;; esac
-      { [ -n "$home_norm" ] && [ "$match" = "$home_norm" ]; } && continue
+      match_norm="$(agmsg_normalize_project_path "$match" 2>/dev/null || printf '%s' "$match")"
+      case "$match_norm" in "/"|""|[A-Za-z]:|[A-Za-z]:/) continue ;; esac
+      { [ -n "$home_norm" ] && [ "$match_norm" = "$home_norm" ]; } && continue
       printf '%s' "$match"
       return 0
     fi

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -194,10 +194,19 @@ agmsg_project_sql_in_list() {
 }
 
 agmsg_find_registered_project_variant() {
-  local projects="$1" path="$2" candidate match
+  local projects="$1" path="$2" candidate match home_norm
+  # #357: never resolve to `/` or $HOME. They are ancestors of nearly every
+  # directory, so one stray registration there (even in another team, or a
+  # leftover) would capture unrelated sessions -- the ancestor walk climbs
+  # through them and would otherwise MATCH them, silently rewriting a project to
+  # $HOME. The walk may still ASCEND through these dirs; it just must not land on
+  # one. (marker resolution, step 1, is unaffected.)
+  home_norm="$(agmsg_normalize_project_path "${HOME:-}" 2>/dev/null || true)"
   while IFS= read -r candidate; do
     match=$(printf '%s\n' "$projects" | grep -Fx -- "$candidate" | head -n 1 || true)
     if [ -n "$match" ]; then
+      case "$match" in "/"|""|[A-Za-z]:|[A-Za-z]:/) continue ;; esac
+      { [ -n "$home_norm" ] && [ "$match" = "$home_norm" ]; } && continue
       printf '%s' "$match"
       return 0
     fi
@@ -308,16 +317,26 @@ agmsg_marker_gc_stale() {
   done
 }
 
-# List distinct registered project paths for <type>, one per line.
+# List distinct registered project paths for <type>, one per line. An optional
+# <team> scopes the scan to that team's config only (#357): a poison registration
+# in an unrelated team must not leak into this team's resolution. Omitting <team>
+# keeps the legacy all-teams scan for callers that don't know the target team
+# (whoami/actas/watch) — a deliberate phased migration.
 agmsg_registered_projects() {
-  local type="$1" teams_dir="$SKILL_DIR/teams" config_file cfg_sql type_sql
+  local type="$1" team="${2:-}" teams_dir="$SKILL_DIR/teams" config_file cfg_sql type_sql
   [ -d "$teams_dir" ] || return 0
   # Read config.json inside SQL via readfile() rather than binding it through a
   # `.param set` dot-command — the sqlite3 shell tokenizer doesn't honour SQL ''
   # escaping, so a config value with a single quote breaks the bind (#112). The
   # path and type are interpolated as SQL string literals with '' doubling.
   type_sql=$(printf '%s' "$type" | sed "s/'/''/g")
-  for config_file in "$teams_dir"/*/config.json; do
+  local -a configs
+  if [ -n "$team" ]; then
+    configs=("$teams_dir/$team/config.json")
+  else
+    configs=("$teams_dir"/*/config.json)
+  fi
+  for config_file in ${configs[@]+"${configs[@]}"}; do
     [ -f "$config_file" ] || continue
     cfg_sql=$(agmsg_sql_readfile_path "$config_file")
     sqlite3 :memory: "
@@ -345,7 +364,7 @@ agmsg_registered_projects() {
 # dir (the git checkout itself is then unregistered, so we decline and let the
 # ancestor walk handle it). return 1 when git is absent or nothing matches.
 agmsg_gitcommon_project() {
-  local start="$1" type="$2" common main projects match
+  local start="$1" type="$2" team="${3:-}" common main projects match
   command -v git >/dev/null 2>&1 || return 1
   [ -d "$start" ] || return 1
   common=$(cd "$start" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null) || return 1
@@ -353,7 +372,7 @@ agmsg_gitcommon_project() {
   # --git-common-dir may be relative to <start>; make it absolute.
   case "$common" in /*) ;; *) common="$start/$common" ;; esac
   main=$(cd "$(dirname "$common")" 2>/dev/null && pwd) || return 1
-  projects="$(agmsg_registered_projects "$type")"
+  projects="$(agmsg_registered_projects "$type" "$team")"
   [ -n "$projects" ] || return 1
   match="$(agmsg_find_registered_project_variant "$projects" "$main")" || return 1
   printf '%s' "$match"
@@ -362,8 +381,8 @@ agmsg_gitcommon_project() {
 # Echo the nearest ancestor of <start> (inclusive) that is a registered project
 # for <type>. return 1 when none matches.
 agmsg_ancestor_project() {
-  local start="$1" type="$2" projects d next match
-  projects="$(agmsg_registered_projects "$type")"
+  local start="$1" type="$2" team="${3:-}" projects d next match
+  projects="$(agmsg_registered_projects "$type" "$team")"
   [ -n "$projects" ] || return 1
   d="$(agmsg_normalize_project_path "$start")"
   while [ -n "$d" ] && [ "$d" != "." ]; do
@@ -381,9 +400,14 @@ agmsg_ancestor_project() {
 }
 
 # Resolve the real project root for a slash-command invocation.
-# Usage: agmsg_resolve_project <pwd_path> <type>
+# Usage: agmsg_resolve_project <pwd_path> <type> [team]
+# An optional <team> scopes the registry-based fallbacks (ancestor / git-common)
+# to that team, so a poison registration in another team can't capture this
+# resolution (#357). join.sh passes it (the join target team is known);
+# team-agnostic callers (whoami/actas/watch/reset) omit it and keep the legacy
+# all-teams behavior.
 agmsg_resolve_project() {
-  local pwd_path="$1" type="$2" pid marker anc gitc
+  local pwd_path="$1" type="$2" team="${3:-}" pid marker anc gitc
   # Explicit opt-out: caller passed a deliberate, possibly-unregistered path.
   if [ "${AGMSG_RESOLVE_PROJECT:-1}" = "0" ]; then
     printf '%s' "$pwd_path"; return 0
@@ -397,12 +421,12 @@ agmsg_resolve_project() {
   fi
   # 2) Nearest registered ancestor of pwd (git-independent; covers nested
   #    subdirs and worktrees that live under the registered project).
-  if anc="$(agmsg_ancestor_project "$pwd_path" "$type")" && [ -n "$anc" ]; then
+  if anc="$(agmsg_ancestor_project "$pwd_path" "$type" "$team")" && [ -n "$anc" ]; then
     printf '%s' "$anc"; return 0
   fi
   # 3) Registered main checkout of pwd's git repo (recovers a SIBLING worktree
   #    the ancestor walk cannot reach). Validated against the registry.
-  if gitc="$(agmsg_gitcommon_project "$pwd_path" "$type")" && [ -n "$gitc" ]; then
+  if gitc="$(agmsg_gitcommon_project "$pwd_path" "$type" "$team")" && [ -n "$gitc" ]; then
     printf '%s' "$gitc"; return 0
   fi
   # 4) Unchanged fallback.

--- a/tests/test_resolve_project.bats
+++ b/tests/test_resolve_project.bats
@@ -123,12 +123,6 @@ JSON
   rm -rf "$other"
 }
 
-@test "join: refuses a trailing-slash \$HOME registration (#357)" {
-  # $HOME/ normalizes to $HOME before the guard, so it must still be refused.
-  run bash "$SKILL_DIR/scripts/join.sh" T alice claude-code "$HOME/"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"refusing to register a project at \$HOME"* ]]
-}
 
 @test "resolve: team scoping ignores another team's registration (#357)" {
   local home_norm; home_norm="$(agmsg_normalize_project_path "$HOME")"
@@ -154,16 +148,21 @@ JSON
   [[ "$output" == *"/some/other/proj"* ]]
 }
 
-@test "join: refuses to register a project at \$HOME (#357)" {
-  run bash "$SKILL_DIR/scripts/join.sh" T alice claude-code "$HOME"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"refusing to register a project at \$HOME"* ]]
+@test "join: ALLOWS registering a project at \$HOME (deliberate use case) (#357)" {
+  # Starting a project at $HOME is legitimate (both claude and codex run there);
+  # #357 protects on the resolution side, not by refusing the registration.
+  run env AGMSG_RESOLVE_PROJECT=0 bash "$SKILL_DIR/scripts/join.sh" T alice claude-code "$HOME"
+  [ "$status" -eq 0 ]
 }
 
-@test "join: refuses to register a project at the filesystem root (#357)" {
-  run env AGMSG_RESOLVE_PROJECT=0 bash "$SKILL_DIR/scripts/join.sh" T alice claude-code "/"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"filesystem root"* ]]
+@test "resolve: an exact \$HOME registration still resolves \$HOME for a session AT \$HOME (#357)" {
+  # The exclusion stops the ancestor walk from LANDING on $HOME for sessions
+  # beneath it, but a session whose pwd IS $HOME still resolves to $HOME -- via
+  # the pwd fallback, so "someone who started there works".
+  local home_norm; home_norm="$(agmsg_normalize_project_path "$HOME")"
+  poison_reg test cc "$home_norm" claude-code
+  result="$(agmsg_resolve_project "$HOME" claude-code)"
+  [ "$result" = "$home_norm" ]
 }
 
 # --- opt-out ---

--- a/tests/test_resolve_project.bats
+++ b/tests/test_resolve_project.bats
@@ -104,6 +104,32 @@ JSON
   rm -rf "$other"
 }
 
+@test "resolve: a \$HOME/ (trailing slash) registration is still excluded (#357 normalized compare)" {
+  local home_norm; home_norm="$(agmsg_normalize_project_path "$HOME")"
+  mkdir -p "$HOME/agmsg-agents/aglive"
+  poison_reg test cc "$home_norm/" claude-code       # stored WITH a trailing slash
+
+  # The walk generates a trailing-slash candidate too, so this really matches the
+  # poison -- the exclusion must still fire because it compares normalized paths.
+  result="$(agmsg_resolve_project "$HOME/agmsg-agents/aglive" claude-code)"
+  [ "$result" = "$(agmsg_normalize_project_path "$HOME/agmsg-agents/aglive")" ]
+}
+
+@test "resolve: a // (doubled-slash root) registration is still excluded (#357)" {
+  poison_reg test cc "//" claude-code
+  other="$(mktemp -d)"
+  result="$(agmsg_resolve_project "$other/x" claude-code)"
+  [ "$result" = "$other/x" ]            # // normalizes to / -> excluded
+  rm -rf "$other"
+}
+
+@test "join: refuses a trailing-slash \$HOME registration (#357)" {
+  # $HOME/ normalizes to $HOME before the guard, so it must still be refused.
+  run bash "$SKILL_DIR/scripts/join.sh" T alice claude-code "$HOME/"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refusing to register a project at \$HOME"* ]]
+}
+
 @test "resolve: team scoping ignores another team's registration (#357)" {
   local home_norm; home_norm="$(agmsg_normalize_project_path "$HOME")"
   mkdir -p "$HOME/agmsg-agents/aglive"

--- a/tests/test_resolve_project.bats
+++ b/tests/test_resolve_project.bats
@@ -69,6 +69,77 @@ reg() {
   [ "$result" = "$ROOT/sub" ]   # no codex registration → unchanged
 }
 
+# --- #357: over-reach of the ancestor walk (poison registrations) ---
+
+# Inject a registration directly into a team's config, bypassing join.sh's guard
+# -- this simulates a poison registration left by an older version (join now
+# refuses $HOME / root, but old data persists).
+poison_reg() {  # <team> <agent> <project> [type]
+  local team="$1" agent="$2" proj="$3" type="${4:-claude-code}"
+  mkdir -p "$SKILL_DIR/teams/$team"
+  cat > "$SKILL_DIR/teams/$team/config.json" <<JSON
+{"name":"$team","agents":{"$agent":{"registrations":[{"type":"$type","project":"$proj"}]}}}
+JSON
+}
+
+@test "resolve: a \$HOME registration never captures resolution (#357 shallow-exclusion)" {
+  local home_norm; home_norm="$(agmsg_normalize_project_path "$HOME")"
+  mkdir -p "$HOME/agmsg-agents/aglive"
+  poison_reg test cc "$home_norm" claude-code       # poison: $HOME registered
+
+  # Sanity: the poison IS in the (all-teams) registry, so this really exercises
+  # the exclusion rather than a missing registration.
+  agmsg_registered_projects claude-code | grep -Fxq -- "$home_norm"
+
+  # A session deep under $HOME must NOT resolve up to $HOME.
+  result="$(agmsg_resolve_project "$HOME/agmsg-agents/aglive" claude-code)"
+  [ "$result" = "$(agmsg_normalize_project_path "$HOME/agmsg-agents/aglive")" ]
+}
+
+@test "resolve: a / registration never captures resolution (#357)" {
+  poison_reg test cc "/" claude-code
+  other="$(mktemp -d)"
+  result="$(agmsg_resolve_project "$other/x" claude-code)"
+  [ "$result" = "$other/x" ]            # falls back to pwd, not "/"
+  rm -rf "$other"
+}
+
+@test "resolve: team scoping ignores another team's registration (#357)" {
+  local home_norm; home_norm="$(agmsg_normalize_project_path "$HOME")"
+  mkdir -p "$HOME/agmsg-agents/aglive"
+  poison_reg test cc "$home_norm" claude-code       # poison lives in team 'test'
+
+  # Scoped to 'aglive' (no registration there) → the 'test' poison is invisible.
+  result="$(agmsg_resolve_project "$HOME/agmsg-agents/aglive" claude-code aglive)"
+  [ "$result" = "$(agmsg_normalize_project_path "$HOME/agmsg-agents/aglive")" ]
+}
+
+@test "registered_projects: a team scope returns only that team's projects (#357)" {
+  reg aglive lead "$ROOT" claude-code
+  poison_reg other cc "/some/other/proj" claude-code
+
+  run agmsg_registered_projects claude-code aglive
+  [[ "$output" == *"$ROOT"* ]]
+  [[ "$output" != *"/some/other/proj"* ]]
+
+  # No team → legacy all-teams scan still sees both (back-compat).
+  run agmsg_registered_projects claude-code
+  [[ "$output" == *"$ROOT"* ]]
+  [[ "$output" == *"/some/other/proj"* ]]
+}
+
+@test "join: refuses to register a project at \$HOME (#357)" {
+  run bash "$SKILL_DIR/scripts/join.sh" T alice claude-code "$HOME"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refusing to register a project at \$HOME"* ]]
+}
+
+@test "join: refuses to register a project at the filesystem root (#357)" {
+  run env AGMSG_RESOLVE_PROJECT=0 bash "$SKILL_DIR/scripts/join.sh" T alice claude-code "/"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"filesystem root"* ]]
+}
+
 # --- opt-out ---
 
 @test "resolve: AGMSG_RESOLVE_PROJECT=0 forces the raw pwd" {


### PR DESCRIPTION
Closes #357.

## Problem

The #92 ancestor walk resolves a session's project by climbing pwd's ancestors to the nearest **registered** project. A user-side report hit a case where a newly-registered claude-code agent's project silently became **$HOME** instead of its real project dir (a codex member in the same team registered correctly — the asymmetry is explained below).

Two flaws let a stray registration capture unrelated sessions:

1. **All-teams scan.** `agmsg_registered_projects` scanned *every* team's config, so a poison registration in an unrelated team (`test/cc → $HOME`) leaked into another team's resolution.
2. **$HOME / `/` as match targets.** The walk would match `$HOME` or `/`, which are ancestors of nearly every directory — one registration there poisons every session beneath it.

**Why codex was fine:** the registry scan is per-type, and the poison was a *claude-code* registration; codex's walk found no $HOME match and fell back to pwd correctly.

## Fix

Both fixes are on the **resolution side**; the per-process SessionStart **marker (step 1) is untouched**.

- **Team-scoping (phased).** `agmsg_resolve_project` / `_registered_projects` / `_ancestor_project` / `_gitcommon_project` take an optional `<team>`. `join.sh` passes the join target team, so a registration in another team can't steer it. Omitting the team keeps the legacy all-teams behavior — team-agnostic callers (whoami / actas / watch / reset) migrate later.
- **Ancestor-landing exclusion.** `agmsg_find_registered_project_variant` never *lands on* `/` or `$HOME`. The walk may still ascend through them; it just won't resolve to one. So a `$HOME` registration only ever matches its **exact** path: a session started **at** `$HOME` still resolves to `$HOME` (via the pwd fallback), while sessions in subdirectories beneath `$HOME` are **not** vacuumed up to it.

**Registering a project at `$HOME` or `/` is deliberately allowed** — both claude and codex support sessions whose cwd is `$HOME`, so starting a project there is legitimate. `join` neither refuses nor warns; the protection is purely that the resolution never *lands* on those dirs for a session that didn't start there.

## Notes

- **Normalized compare.** The `/` / `$HOME` exclusion compares **normalized** paths (`agmsg_normalize_project_path` collapses duplicate slashes and strips a trailing one). A poison stored as `$HOME/` or `//` — which the walk's trailing-slash candidate variant *does* match — is still excluded. join's own path is normalized upstream.
- **Symlink boundary.** Normalization is **logical**, not symlink-resolving (that's `agmsg_canonical_path`). A `$HOME` expressed via a divergent symlink path (e.g. macOS `/private/var/...` vs `/var/...`) is not caught by the shallow exclusion. In practice registrations store the logical path (from `$(pwd)` / `$HOME`), so the logical compare covers the real case; the team-scoping fix still contains any such registration to its own team. Canonical comparison would be a follow-up if a symlinked-$HOME poison is ever observed.

## Tests

New `#357` cases in `test_resolve_project.bats`: poison `$HOME` / `/` / `$HOME/` / `//` / other-team registrations no longer capture resolution; a team scope returns only that team's projects (all-teams still works with no team); an exact-`$HOME` session still resolves `$HOME`; join allows a `$HOME` registration. The existing resolve suite stays green.
