### PR TITLE
fix(spawn): wrap boot script with bash -l for psmux on Windows (#335)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -7,6 +7,8 @@ description: Cross-agent messaging via SQLite. Send messages between Claude Code
 
 **IMPORTANT: Always use the provided scripts. NEVER directly read or edit config files, DB, or team data. There is NO register.sh — use join.sh to join a team.**
 
+**Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/agmsg/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
+
 ## How to use
 
 ### Step 0: First-run bootstrap

--- a/install.sh
+++ b/install.sh
@@ -69,6 +69,16 @@ configure_codex_sandbox() {
   fi
 
   local writable_paths=("$SKILL_DIR/db" "$SKILL_DIR/teams" "$SKILL_DIR/run")
+  # On Windows (MSYS2/Git Bash), $SKILL_DIR is in MSYS form (/c/Users/...).
+  # Codex is a native Windows binary whose Rust path resolution cannot parse
+  # MSYS paths — /c/Users/... is resolved to C:\c\Users\... (a phantom path).
+  # Convert to the mixed C:/Users/... form that both the shell and Codex accept.
+  if command -v cygpath >/dev/null 2>&1; then
+    local i
+    for i in "${!writable_paths[@]}"; do
+      writable_paths[$i]="$(cygpath -m "${writable_paths[$i]}" 2>/dev/null || printf '%s' "${writable_paths[$i]}")"
+    done
+  fi
   local missing=()
   local p
   for p in "${writable_paths[@]}"; do

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -474,17 +474,25 @@ launch_in_tmux() {
   command -v tmux >/dev/null 2>&1 \
     || die "\$TMUX is set but the tmux binary is not on PATH; add it to PATH, or run outside tmux to use the OS-terminal path"
 
+  # On Windows (psmux), tmux launches processes via Windows APIs that do not
+  # process shebang lines; an extensionless boot script is accepted but never
+  # executed (#335). Wrap with `bash -l` — same pattern as launch_windows_terminal.
+  local -a tmux_boot=("$BOOT")
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) tmux_boot=(bash -l "$BOOT") ;;
+  esac
+
   # Name the window/pane after the agent rather than letting tmux fall back to
   # the boot script's filename (boot-XXXXXX). `automatic-rename off` keeps the
   # name from being clobbered once the boot script runs the CLI / drops to a
   # shell.
   local target_id
   if [ "$TMUX_TARGET" = "window" ]; then
-    target_id="$(tmux new-window -P -F '#{window_id}' -n "$NAME" -c "$PROJECT" "$BOOT")"
+    target_id="$(tmux new-window -P -F '#{window_id}' -n "$NAME" -c "$PROJECT" "${tmux_boot[@]}")"
     tmux set-window-option -t "$target_id" automatic-rename off 2>/dev/null || true
   else
     local dir="-h"; [ "$SPLIT" = "v" ] && dir="-v"
-    target_id="$(tmux split-window "$dir" -P -F '#{pane_id}' -c "$PROJECT" "$BOOT")"
+    target_id="$(tmux split-window "$dir" -P -F '#{pane_id}' -c "$PROJECT" "${tmux_boot[@]}")"
     tmux select-pane -t "$target_id" -T "$NAME" 2>/dev/null || true
   fi
   # Record placement so `despawn --force` can tear this member down even if its

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -437,13 +437,23 @@ launch_in_tmux() {
   # the boot script's filename (boot-XXXXXX). `automatic-rename off` keeps the
   # name from being clobbered once the boot script runs the CLI / drops to a
   # shell.
+  # On Windows (MSYS2/Git Bash + psmux), tmux hands the command token to
+  # CreateProcess/ShellExecute. An extensionless boot script has no file
+  # association, so Windows shows an "Open with" dialog instead of executing
+  # it (#282 follow-up). Prefix `bash -l` so the interpreter is an .exe
+  # Windows can resolve — matches launch_windows_terminal's pattern.
+  local boot_argv=("$BOOT")
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) boot_argv=(bash -l "$BOOT") ;;
+  esac
+
   local target_id
   if [ "$TMUX_TARGET" = "window" ]; then
-    target_id="$(tmux new-window -P -F '#{window_id}' -n "$NAME" -c "$PROJECT" "$BOOT")"
+    target_id="$(tmux new-window -P -F '#{window_id}' -n "$NAME" -c "$PROJECT" "${boot_argv[@]}")"
     tmux set-window-option -t "$target_id" automatic-rename off 2>/dev/null || true
   else
     local dir="-h"; [ "$SPLIT" = "v" ] && dir="-v"
-    target_id="$(tmux split-window "$dir" -P -F '#{pane_id}' -c "$PROJECT" "$BOOT")"
+    target_id="$(tmux split-window "$dir" -P -F '#{pane_id}' -c "$PROJECT" "${boot_argv[@]}")"
     tmux select-pane -t "$target_id" -T "$NAME" 2>/dev/null || true
   fi
   # Record placement so `despawn --force` can tear this member down even if its

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -437,23 +437,13 @@ launch_in_tmux() {
   # the boot script's filename (boot-XXXXXX). `automatic-rename off` keeps the
   # name from being clobbered once the boot script runs the CLI / drops to a
   # shell.
-  # On Windows (MSYS2/Git Bash + psmux), tmux hands the command token to
-  # CreateProcess/ShellExecute. An extensionless boot script has no file
-  # association, so Windows shows an "Open with" dialog instead of executing
-  # it (#282 follow-up). Prefix `bash -l` so the interpreter is an .exe
-  # Windows can resolve — matches launch_windows_terminal's pattern.
-  local boot_argv=("$BOOT")
-  case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*) boot_argv=(bash -l "$BOOT") ;;
-  esac
-
   local target_id
   if [ "$TMUX_TARGET" = "window" ]; then
-    target_id="$(tmux new-window -P -F '#{window_id}' -n "$NAME" -c "$PROJECT" "${boot_argv[@]}")"
+    target_id="$(tmux new-window -P -F '#{window_id}' -n "$NAME" -c "$PROJECT" "$BOOT")"
     tmux set-window-option -t "$target_id" automatic-rename off 2>/dev/null || true
   else
     local dir="-h"; [ "$SPLIT" = "v" ] && dir="-v"
-    target_id="$(tmux split-window "$dir" -P -F '#{pane_id}' -c "$PROJECT" "${boot_argv[@]}")"
+    target_id="$(tmux split-window "$dir" -P -F '#{pane_id}' -c "$PROJECT" "$BOOT")"
     tmux select-pane -t "$target_id" -T "$NAME" 2>/dev/null || true
   fi
   # Record placement so `despawn --force` can tear this member down even if its

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -800,3 +800,74 @@ YAML
   [[ "$output" == *"reviewer"* ]]
   [[ "$output" == *"REVIEW_THE_DIFF"* ]]
 }
+
+# --- #335: psmux on Windows cannot exec an extensionless boot script ---
+#
+# These fake `uname -s` (via a stub honoring $FAKE_UNAME_S) and stub `tmux` to
+# capture its argv, so the Windows launch path is exercised on a Linux/macOS
+# runner. On Windows the boot script must run through `bash -l`; elsewhere the
+# bare path (shebang-honored by Unix tmux) is kept.
+
+@test "spawn: launch_in_tmux runs the boot script via bash -l on Windows (#335)" {
+  local cap="$TEST_SKILL_DIR/tmux-argv.txt"
+  : > "$cap"
+  cat > "$STUB_BIN/uname" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_UNAME_S:-Linux}"
+EOF
+  chmod +x "$STUB_BIN/uname"
+  cat > "$STUB_BIN/tmux" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$cap"
+case "\$1" in
+  new-window)   echo '@1' ;;
+  split-window) echo '%1' ;;
+esac
+exit 0
+EOF
+  chmod +x "$STUB_BIN/tmux"
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  # Default target is a split pane.
+  run env TMUX="/tmp/fake,1,0" FAKE_UNAME_S="MINGW64_NT-10.0-19045" \
+    bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  # A new window is the other branch.
+  run env TMUX="/tmp/fake,1,0" FAKE_UNAME_S="MINGW64_NT-10.0-19045" \
+    bash "$SCRIPTS/spawn.sh" claude-code bob --project "$PROJ" --no-wait --window
+  [ "$status" -eq 0 ]
+  # Both branches must launch through `bash -l <boot>`, not the bare path.
+  run grep -E 'split-window .* bash -l /' "$cap"
+  [ "$status" -eq 0 ]
+  run grep -E 'new-window .* bash -l /' "$cap"
+  [ "$status" -eq 0 ]
+}
+
+@test "spawn: launch_in_tmux keeps the bare boot path off Windows (#335)" {
+  local cap="$TEST_SKILL_DIR/tmux-argv.txt"
+  : > "$cap"
+  cat > "$STUB_BIN/uname" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_UNAME_S:-Linux}"
+EOF
+  chmod +x "$STUB_BIN/uname"
+  cat > "$STUB_BIN/tmux" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$cap"
+case "\$1" in
+  new-window)   echo '@1' ;;
+  split-window) echo '%1' ;;
+esac
+exit 0
+EOF
+  chmod +x "$STUB_BIN/tmux"
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run env TMUX="/tmp/fake,1,0" FAKE_UNAME_S="Linux" \
+    bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  # Unix tmux honors the shebang, so no `bash -l` wrapper is emitted.
+  run grep -F 'bash -l' "$cap"
+  [ "$status" -ne 0 ]
+  # ...and the bare boot path is still the launched command.
+  run grep -E 'split-window .* /.*boot-' "$cap"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

On Windows, psmux (the tmux implementation) launches processes via Windows APIs
that do not process shebang lines. The extensionless boot script generated by
`spawn.sh` is accepted by `tmux new-window`/`split-window` but silently never
executed — the spawned pane opens and immediately closes with no agent running.

This PR wraps the boot script with `bash -l` on MINGW/MSYS/CYGWIN inside
`launch_in_tmux`, using the same pattern that `launch_windows_terminal` already
uses for `wt.exe`. Non-Windows platforms are unaffected — the `tmux_boot` array
defaults to the bare script path.

Closes #335.

## What changed

- `scripts/spawn.sh`: Added a `tmux_boot` array in `launch_in_tmux()` that
  prepends `bash -l` on Windows. Both `new-window` and `split-window` use the
  array expansion `"${tmux_boot[@]}"` instead of the bare `"$BOOT"`.

## Test results

Tested on psmux 3.3.4 / MINGW64 / Windows 11 (post-#344 merge):

| Method | Result |
|--------|--------|
| `tmux split-window "$BOOT"` (current upstream) | ❌ Script not executed |
| `tmux split-window bash -l "$BOOT"` (this fix) | ✅ Script runs correctly |

## Test plan

- [x] Verify on Windows with psmux: `agmsg spawn` creates a working pane
- [ ] Verify on macOS/Linux: no behavioral change (`tmux_boot` is just `("$BOOT")`)
- [ ] Existing `test_spawn.bats` tests pass (they use the OS-terminal path, not tmux)

---

If you spot any issues or need additional verification, please let me know.