### PR TITLE
feat(send): --all broadcast and comma-separated recipients

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -268,7 +268,8 @@ despawnは指定されたメンバーにのみ作用する — `despawn` を実�
 /agmsg                                  — 受信箱を確認（全チーム）
 /agmsg history                          — メッセージ履歴
 /agmsg team                             — チームメンバー一覧
-/agmsg send <agent> <message>           — メッセージ送信
+/agmsg send <agent|--all|@all|a,b> <message>
+                                        — メッセージ送信
 /agmsg mode <monitor|turn|both|off>     — 配信モード切り替え
 /agmsg mode                             — 現在のモードを表示
 /agmsg actas <name>                     — このプロジェクトで別のロールに切り替え（必要なら作成）
@@ -315,7 +316,7 @@ $agmsg
 ### シェル（任意のエージェント）
 
 ```bash
-~/.agents/skills/<cmd>/scripts/send.sh <team> <from> <to> "<message>"
+~/.agents/skills/<cmd>/scripts/send.sh <team> <from> <to|--all|@all|a,b> "<message>"
 ~/.agents/skills/<cmd>/scripts/inbox.sh <team> <agent_id>
 ~/.agents/skills/<cmd>/scripts/history.sh <team> [agent_id] [limit]
 ~/.agents/skills/<cmd>/scripts/team.sh <team>
@@ -325,7 +326,7 @@ $agmsg
 ~/.agents/skills/<cmd>/scripts/reset.sh <project_path> <type> [agent_id]
 ```
 
-`send.sh` はちょうど4つの位置引数を取る: `<team> <from> <to> "<message>"`。シェルが1つの引数として認識するようメッセージはクォートすること — クォートされていないスペース入りメッセージは誤って分割される。
+`send.sh` はちょうど4つの位置引数を取る: `<team> <from> <to|--all|@all|a,b> "<message>"`。`<to>` には単一エージェント、`--all`、`@all`、または `alice,bob` のようなカンマ区切りリストを指定できる。カンマ後の空白は取り除かれ、空の宛先はスキップされる。シェルが1つの引数として認識するようメッセージはクォートすること。ラッパーやシェル連携でも本文を1引数として渡す必要があり、そうしないとスペース入りメッセージは切り詰めまたは誤分割される。
 
 ## FAQ / 設計メモ
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ The command updates `db/config.yaml`, rewrites the project's hook entries, and p
 /agmsg                                  — check inbox (all teams)
 /agmsg history                          — message history
 /agmsg team                             — list team members
-/agmsg send <agent> <message>           — send message
+/agmsg send <agent|--all|@all|a,b> <message>
+                                        — send message
 /agmsg mode <monitor|turn|both|off>     — switch delivery mode
 /agmsg mode                             — show current mode
 /agmsg actas <name>                     — switch to another role in this project (create if needed)
@@ -316,7 +317,7 @@ See [docs/opencode.md](docs/opencode.md) for full setup instructions.
 ### Shell (any agent)
 
 ```bash
-~/.agents/skills/<cmd>/scripts/send.sh <team> <from> <to> "<message>"
+~/.agents/skills/<cmd>/scripts/send.sh <team> <from> <to|--all|@all|a,b> "<message>"
 ~/.agents/skills/<cmd>/scripts/inbox.sh <team> <agent_id>
 ~/.agents/skills/<cmd>/scripts/history.sh <team> [agent_id] [limit]
 ~/.agents/skills/<cmd>/scripts/team.sh <team>
@@ -326,7 +327,7 @@ See [docs/opencode.md](docs/opencode.md) for full setup instructions.
 ~/.agents/skills/<cmd>/scripts/reset.sh <project_path> <type> [agent_id]
 ```
 
-`send.sh` takes exactly four positional arguments: `<team> <from> <to> "<message>"`. Quote the message so the shell sees it as one argument; an unquoted message with spaces will be misparsed.
+`send.sh` takes exactly four positional arguments: `<team> <from> <to|--all|@all|a,b> "<message>"`. `<to>` may be one agent, `--all`, `@all`, or a comma-separated list such as `alice,bob`; spaces after commas are trimmed and empty entries are skipped. Quote the message so the shell sees it as one argument. Wrappers and shell integrations must pass the body as one argument too; otherwise a message with spaces will be truncated or misparsed.
 
 ## FAQ / Design notes
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -57,7 +57,9 @@ Do NOT manually edit config files. Always use join.sh.
 ~/.agents/skills/agmsg/scripts/inbox.sh <team> <agent_id>
 
 # Send a message
-~/.agents/skills/agmsg/scripts/send.sh <team> <from_agent> <to_agent> "<message>"
+~/.agents/skills/agmsg/scripts/send.sh <team> <from_agent> <to_agent|--all|@all|a,b> "<message>"
+# Recipient may be one agent, --all, @all, or comma-separated agents.
+# Pass the message body as one quoted shell argument.
 
 # Message history
 ~/.agents/skills/agmsg/scripts/history.sh <team> [agent_id] [limit]

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -36,7 +36,7 @@ Four possible outputs:
 
   > **Joined!** You can now use `/__SKILL_NAME__` to check and send messages.
   > - `/__SKILL_NAME__` — check inbox
-  > - `/__SKILL_NAME__ send <agent> <message>` — send a message
+  > - `/__SKILL_NAME__ send <agent|--all|@all|a,b> <message>` — send a message
   > - `/__SKILL_NAME__ team` — list team members
   > - `/__SKILL_NAME__ history` — message history
   > - `/__SKILL_NAME__ mode <monitor|turn|both|off>` — switch delivery mode
@@ -115,7 +115,7 @@ The allowlist merges across scopes and takes effect immediately — no restart n
 1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
 2. Do NOT ask the user what to do — just run the inbox check.
 3. If there are messages, read and respond appropriately. To reply:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent|--all|@all|a,b> "<message>"`
 
 If argument is "history":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/history.sh $TEAM $AGENT`
@@ -124,9 +124,10 @@ If argument is "team":
 1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM`
 
 If argument starts with "send" (e.g. "send misaki check the server"):
-1. Parse target agent and message from the arguments
-2. Determine which team the target agent belongs to, then run:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+1. Parse target spec (`agent`, `--all`, `@all`, or comma-separated agents) and message from the arguments.
+2. Keep the message body as one shell argument when invoking the script.
+3. Determine which team the target spec belongs to, then run:
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent|--all|@all|a,b> "<message>"`
 
 If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 1. Parse the new role name.

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -37,7 +37,7 @@ Four possible outputs:
 
   > **Joined!** You can now use `$__SKILL_NAME__` to check and send messages.
   > - `$__SKILL_NAME__` — check inbox
-  > - `$__SKILL_NAME__ send <agent> <message>` — send a message
+  > - `$__SKILL_NAME__ send <agent|--all|@all|a,b> <message>` — send a message
   > - `$__SKILL_NAME__ team` — list team members
   > - `$__SKILL_NAME__ history` — message history
 
@@ -85,7 +85,7 @@ Four possible outputs:
 1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
 2. Do NOT ask the user what to do — just run the inbox check.
 3. If there are messages, read and respond appropriately. To reply:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent|--all|@all|a,b> "<message>"`
 
 If argument is "history":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/history.sh $TEAM $AGENT`
@@ -94,9 +94,10 @@ If argument is "team":
 1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM`
 
 If argument starts with "send" (e.g. "send misaki check the server"):
-1. Parse target agent and message from the arguments
-2. Determine which team the target agent belongs to, then run:
-   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+1. Parse target spec (`agent`, `--all`, `@all`, or comma-separated agents) and message from the arguments.
+2. Keep the message body as one shell argument when invoking the script.
+3. Determine which team the target spec belongs to, then run:
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent|--all|@all|a,b> "<message>"`
 
 If argument is "config":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh show`

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 # Usage: send.sh <team> <from> <to> <message>
+#   <to> may be a single agent, a comma-separated list (alice,bob), or --all
+#   (alias: @all) to broadcast to every team member except the sender.
 
 TEAM="${1:?Usage: send.sh <team> <from> <to> <message>}"
 FROM="${2:?Missing from agent}"
@@ -12,13 +14,44 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 DB="$(agmsg_db_path)"
 
+# Resolve broadcast / multi-recipient forms into RECIPIENTS.
+if [ "$TO" = "--all" ] || [ "$TO" = "@all" ]; then
+  # Reject team names that would escape teams/ as a path segment (#140).
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/lib/validate.sh"
+  agmsg_validate_team_name "$TEAM" || exit 1
+  CONFIG="$SCRIPT_DIR/../teams/$TEAM/config.json"
+  [ -f "$CONFIG" ] || { echo "Team not found: $TEAM" >&2; exit 1; }
+  # tr -d '\r': sqlite3.exe on Windows emits CRLF rows (#130).
+  mapfile -t RECIPIENTS < <(sqlite3 :memory: \
+    ".param set :json '$(sed "s/'/''/g" "$CONFIG")'" \
+    "SELECT key FROM json_each(json_extract(:json, '\$.agents')) ORDER BY key;" \
+    | tr -d '\r' | grep -Fxv -- "$FROM" || true)
+  if [ "${#RECIPIENTS[@]}" -eq 0 ]; then
+    echo "No recipients in team $TEAM besides $FROM" >&2
+    exit 1
+  fi
+else
+  IFS=',' read -r -a RECIPIENTS <<< "$TO"
+fi
+
 [ -f "$DB" ] || bash "$SCRIPT_DIR/internal/init-db.sh" >/dev/null
 
 # Escape EVERY interpolated value as a SQL string literal, not just body: a
 # team/agent name containing a single quote would otherwise break the INSERT
 # (correctness) or change its meaning (injection surface).
 _agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
-INSERT="INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$(_agmsg_sqlesc "$TEAM")', '$(_agmsg_sqlesc "$FROM")', '$(_agmsg_sqlesc "$TO")', '$(_agmsg_sqlesc "$BODY")');"
+
+# One multi-row INSERT so a broadcast is atomic: either every recipient gets
+# the message or none does (no partial fan-out if a later row fails).
+VALUES=""
+for _to in "${RECIPIENTS[@]}"; do
+  [ -n "$_to" ] || continue
+  [ -n "$VALUES" ] && VALUES="$VALUES, "
+  VALUES="$VALUES('$(_agmsg_sqlesc "$TEAM")', '$(_agmsg_sqlesc "$FROM")', '$(_agmsg_sqlesc "$_to")', '$(_agmsg_sqlesc "$BODY")')"
+done
+[ -n "$VALUES" ] || { echo "Missing to agent" >&2; exit 1; }
+INSERT="INSERT INTO messages (team, from_agent, to_agent, body) VALUES $VALUES;"
 
 # Retry once after ensuring the schema. Under a concurrent first-write fan-out
 # (leader → N members against a fresh/override store), one process can see the
@@ -35,4 +68,7 @@ if ! printf '%s
 ' "$INSERT" | agmsg_sqlite "$DB"
 fi
 
-echo "Sent to $TO in team $TEAM"
+for _to in "${RECIPIENTS[@]}"; do
+  [ -n "$_to" ] || continue
+  echo "Sent to $_to in team $TEAM"
+done

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -35,6 +35,13 @@ else
   IFS=',' read -r -a RECIPIENTS <<< "$TO"
 fi
 
+trim_recipient() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
 [ -f "$DB" ] || bash "$SCRIPT_DIR/internal/init-db.sh" >/dev/null
 
 # Escape EVERY interpolated value as a SQL string literal, not just body: a
@@ -46,6 +53,7 @@ _agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
 # the message or none does (no partial fan-out if a later row fails).
 VALUES=""
 for _to in "${RECIPIENTS[@]}"; do
+  _to="$(trim_recipient "$_to")"
   [ -n "$_to" ] || continue
   [ -n "$VALUES" ] && VALUES="$VALUES, "
   VALUES="$VALUES('$(_agmsg_sqlesc "$TEAM")', '$(_agmsg_sqlesc "$FROM")', '$(_agmsg_sqlesc "$_to")', '$(_agmsg_sqlesc "$BODY")')"
@@ -69,6 +77,7 @@ if ! printf '%s
 fi
 
 for _to in "${RECIPIENTS[@]}"; do
+  _to="$(trim_recipient "$_to")"
   [ -n "$_to" ] || continue
   echo "Sent to $_to in team $TEAM"
 done

--- a/tests/test_messaging.bats
+++ b/tests/test_messaging.bats
@@ -179,9 +179,15 @@ line"
 }
 
 @test "send @all: alias works" {
+  bash "$SCRIPTS/join.sh" testteam carol claude-code /tmp/project-c
   run bash "$SCRIPTS/send.sh" testteam alice @all "alias ping"
   [ "$status" -eq 0 ]
   [[ "$output" =~ "Sent to bob" ]]
+  [[ "$output" =~ "Sent to carol" ]]
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [[ "$output" =~ "alias ping" ]]
+  run bash "$SCRIPTS/inbox.sh" testteam carol
+  [[ "$output" =~ "alias ping" ]]
 }
 
 @test "send --all: fails when team does not exist" {
@@ -205,6 +211,39 @@ line"
   [[ "$output" =~ "pair ping" ]]
   run bash "$SCRIPTS/inbox.sh" testteam carol
   [[ "$output" =~ "pair ping" ]]
+}
+
+@test "send: comma-separated recipients tolerate spaces after commas" {
+  bash "$SCRIPTS/join.sh" testteam carol claude-code /tmp/project-c
+  run bash "$SCRIPTS/send.sh" testteam alice "bob, carol" "spaced pair ping"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Sent to bob" ]]
+  [[ "$output" =~ "Sent to carol" ]]
+  [[ ! "$output" =~ "Sent to  carol" ]]
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [[ "$output" =~ "spaced pair ping" ]]
+  run bash "$SCRIPTS/inbox.sh" testteam carol
+  [[ "$output" =~ "spaced pair ping" ]]
+}
+
+@test "send: comma-separated recipients skip empty middle entries" {
+  bash "$SCRIPTS/join.sh" testteam carol claude-code /tmp/project-c
+  run bash "$SCRIPTS/send.sh" testteam alice bob,,carol "empty middle ping"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Sent to bob" ]]
+  [[ "$output" =~ "Sent to carol" ]]
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [[ "$output" =~ "empty middle ping" ]]
+  run bash "$SCRIPTS/inbox.sh" testteam carol
+  [[ "$output" =~ "empty middle ping" ]]
+}
+
+@test "send: comma-separated recipients skip trailing empty entries" {
+  run bash "$SCRIPTS/send.sh" testteam alice bob, "trailing empty ping"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Sent to bob in team testteam" ]
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [[ "$output" =~ "trailing empty ping" ]]
 }
 
 @test "send: single recipient still works unchanged" {

--- a/tests/test_messaging.bats
+++ b/tests/test_messaging.bats
@@ -160,3 +160,55 @@ line"
   [ "$status" -eq 0 ]
   [[ "$output" =~ "for quote" ]]
 }
+
+# --- send.sh --all / multi-recipient (#25/#26) ---
+
+@test "send --all: broadcasts to every member except the sender" {
+  bash "$SCRIPTS/join.sh" testteam carol claude-code /tmp/project-c
+  run bash "$SCRIPTS/send.sh" testteam alice --all "team ping"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Sent to bob" ]]
+  [[ "$output" =~ "Sent to carol" ]]
+  [[ ! "$output" =~ "Sent to alice" ]]
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [[ "$output" =~ "team ping" ]]
+  run bash "$SCRIPTS/inbox.sh" testteam carol
+  [[ "$output" =~ "team ping" ]]
+  run bash "$SCRIPTS/inbox.sh" testteam alice
+  [[ "$output" =~ "No new messages" ]]
+}
+
+@test "send @all: alias works" {
+  run bash "$SCRIPTS/send.sh" testteam alice @all "alias ping"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Sent to bob" ]]
+}
+
+@test "send --all: fails when team does not exist" {
+  run bash "$SCRIPTS/send.sh" ghostteam alice --all "nobody home"
+  [ "$status" -ne 0 ]
+}
+
+@test "send --all: fails when sender is the only member" {
+  bash "$SCRIPTS/join.sh" soloteam alice claude-code /tmp/project-a
+  run bash "$SCRIPTS/send.sh" soloteam alice --all "echo chamber"
+  [ "$status" -ne 0 ]
+}
+
+@test "send: comma-separated recipients each get the message" {
+  bash "$SCRIPTS/join.sh" testteam carol claude-code /tmp/project-c
+  run bash "$SCRIPTS/send.sh" testteam alice bob,carol "pair ping"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Sent to bob" ]]
+  [[ "$output" =~ "Sent to carol" ]]
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [[ "$output" =~ "pair ping" ]]
+  run bash "$SCRIPTS/inbox.sh" testteam carol
+  [[ "$output" =~ "pair ping" ]]
+}
+
+@test "send: single recipient still works unchanged" {
+  run bash "$SCRIPTS/send.sh" testteam alice bob "solo hello"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Sent to bob in team testteam" ]
+}


### PR DESCRIPTION
## What

Extends `<to>` in `send.sh <team> <from> <to> <message>` to support multiple
recipients and broadcast:

- `--all` (alias `@all`) — deliver to every team member except the sender
- `alice,bob` — comma-separated multiple recipients (spaces after commas are
  tolerated, empty entries are skipped)
- Single-recipient calls are **byte-for-byte unchanged** (no regression)

## Why

Broadcasting to a whole team (leader → all members) is a common need, but
previously required calling `send.sh` once per recipient. This addresses the
long-standing requests in #25 / #26.

## How

- `--all`/`@all`: enumerates `agents` from the team config
  (`teams/<team>/config.json`) via sqlite3's `json_each`, excluding the
  sender, to build the recipient set.
  - The team name is validated with `agmsg_validate_team_name`
    (`lib/validate.sh`), rejecting path fragments that would escape
    `teams/` (#140).
  - `tr -d '\r'`: works around Windows `sqlite3.exe` emitting CRLF-terminated
    rows (same class of issue as #130).
- Comma-separated recipients: split with `IFS=',' read -r -a`, then each
  recipient is trimmed of surrounding whitespace and empty entries are
  dropped, so `alice, bob`, `alice,,bob`, and `alice,` all resolve cleanly.
  If every entry is empty the call fails with `Missing to agent`.
- Delivery is a **single multi-row INSERT** — atomic, so a partial fan-out
  (some recipients get the message, others don't) can't happen if one row
  fails mid-way.
- Every interpolated value (team/from/to/body) is escaped via
  `_agmsg_sqlesc` (no new SQL-injection surface introduced).

## Breaking changes

None. Single-recipient invocations produce byte-identical stdout and DB
writes to before this change; no new required flags, no changed defaults.

## Tests

Added 9 cases to `tests/test_messaging.bats` covering broadcast (`--all` and
`@all`), team-not-found and sole-member failure modes, comma-separated
recipients, space tolerance after commas, skipping empty middle/trailing
entries, and single-recipient backward compatibility.

Behaviour was also verified functionally end-to-end against an isolated store
(`AGMSG_STORAGE_PATH`): `alice, bob` / `alice,,bob` / `alice,` all deliver to
the intended recipients, `, ,` fails with `Missing to agent`, and `@all` /
`--all` broadcast to every member except the sender (a sole-member team fails
with `No recipients`).

## Compatibility

- Existing single-recipient call output and DB writes are unchanged.
- Verified on Windows (Git Bash), including the CRLF workaround (#130-class
  issue).
