### PR TITLE
fix(spawn): launch the boot script via bash -l inside tmux on Windows (#335)

### DIFF
--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -474,17 +474,28 @@ launch_in_tmux() {
   command -v tmux >/dev/null 2>&1 \
     || die "\$TMUX is set but the tmux binary is not on PATH; add it to PATH, or run outside tmux to use the OS-terminal path"
 
+  # How tmux should launch the boot script. Unix tmux honors the shebang and runs
+  # an extensionless file through its interpreter, so the bare path works. On
+  # Windows the tmux-compatible multiplexer (psmux) hands the command token to
+  # CreateProcess/ShellExecute instead: an extensionless boot-XXXXXX has no file
+  # association, so Windows pops an "Open with" dialog and the agent never starts
+  # (#335). Launch it through `bash -l` there, matching launch_windows_terminal.
+  local boot_argv=("$BOOT")
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) boot_argv=(bash -l "$BOOT") ;;
+  esac
+
   # Name the window/pane after the agent rather than letting tmux fall back to
   # the boot script's filename (boot-XXXXXX). `automatic-rename off` keeps the
   # name from being clobbered once the boot script runs the CLI / drops to a
   # shell.
   local target_id
   if [ "$TMUX_TARGET" = "window" ]; then
-    target_id="$(tmux new-window -P -F '#{window_id}' -n "$NAME" -c "$PROJECT" "$BOOT")"
+    target_id="$(tmux new-window -P -F '#{window_id}' -n "$NAME" -c "$PROJECT" "${boot_argv[@]}")"
     tmux set-window-option -t "$target_id" automatic-rename off 2>/dev/null || true
   else
     local dir="-h"; [ "$SPLIT" = "v" ] && dir="-v"
-    target_id="$(tmux split-window "$dir" -P -F '#{pane_id}' -c "$PROJECT" "$BOOT")"
+    target_id="$(tmux split-window "$dir" -P -F '#{pane_id}' -c "$PROJECT" "${boot_argv[@]}")"
     tmux select-pane -t "$target_id" -T "$NAME" 2>/dev/null || true
   fi
   # Record placement so `despawn --force` can tear this member down even if its

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -800,3 +800,74 @@ YAML
   [[ "$output" == *"reviewer"* ]]
   [[ "$output" == *"REVIEW_THE_DIFF"* ]]
 }
+
+# --- #335: psmux on Windows cannot exec an extensionless boot script ---
+#
+# These fake `uname -s` (via a stub honoring $FAKE_UNAME_S) and stub `tmux` to
+# capture its argv, so the Windows launch path is exercised on a Linux/macOS
+# runner. On Windows the boot script must run through `bash -l`; elsewhere the
+# bare path (shebang-honored by Unix tmux) is kept.
+
+@test "spawn: launch_in_tmux runs the boot script via bash -l on Windows (#335)" {
+  local cap="$TEST_SKILL_DIR/tmux-argv.txt"
+  : > "$cap"
+  cat > "$STUB_BIN/uname" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_UNAME_S:-Linux}"
+EOF
+  chmod +x "$STUB_BIN/uname"
+  cat > "$STUB_BIN/tmux" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$cap"
+case "\$1" in
+  new-window)   echo '@1' ;;
+  split-window) echo '%1' ;;
+esac
+exit 0
+EOF
+  chmod +x "$STUB_BIN/tmux"
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  # Default target is a split pane.
+  run env TMUX="/tmp/fake,1,0" FAKE_UNAME_S="MINGW64_NT-10.0-19045" \
+    bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  # A new window is the other branch.
+  run env TMUX="/tmp/fake,1,0" FAKE_UNAME_S="MINGW64_NT-10.0-19045" \
+    bash "$SCRIPTS/spawn.sh" claude-code bob --project "$PROJ" --no-wait --window
+  [ "$status" -eq 0 ]
+  # Both branches must launch through `bash -l <boot>`, not the bare path.
+  run grep -E 'split-window .* bash -l /' "$cap"
+  [ "$status" -eq 0 ]
+  run grep -E 'new-window .* bash -l /' "$cap"
+  [ "$status" -eq 0 ]
+}
+
+@test "spawn: launch_in_tmux keeps the bare boot path off Windows (#335)" {
+  local cap="$TEST_SKILL_DIR/tmux-argv.txt"
+  : > "$cap"
+  cat > "$STUB_BIN/uname" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_UNAME_S:-Linux}"
+EOF
+  chmod +x "$STUB_BIN/uname"
+  cat > "$STUB_BIN/tmux" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$cap"
+case "\$1" in
+  new-window)   echo '@1' ;;
+  split-window) echo '%1' ;;
+esac
+exit 0
+EOF
+  chmod +x "$STUB_BIN/tmux"
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run env TMUX="/tmp/fake,1,0" FAKE_UNAME_S="Linux" \
+    bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  # Unix tmux honors the shebang, so no `bash -l` wrapper is emitted.
+  run grep -F 'bash -l' "$cap"
+  [ "$status" -ne 0 ]
+  # ...and the bare boot path is still the launched command.
+  run grep -E 'split-window .* /.*boot-' "$cap"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Reported, diagnosed, and fixed by @masa6161 in #335 — carried forward here with
credit (Co-authored-by trailer on the commit).

Closes #335.

## What

`launch_in_tmux()` fails to execute the boot script on Windows when the
tmux-compatible multiplexer is psmux. Unix tmux honors the boot script's shebang
and runs the extensionless file through bash; psmux hands the command token to
Windows CreateProcess/ShellExecute, which has no association for an extensionless
file, so Windows shows an "Open with" dialog and the spawned agent never starts.

The fix launches the boot script through `bash -l` on Windows, matching the
existing pattern in `launch_windows_terminal` (`wt.exe new-tab bash -l "$BOOT"`).
It is applied to both the `new-window` and `split-window` branches. macOS/Linux
are unchanged — Unix tmux honors the shebang, so the bare path is kept.

This closes a residual hole from #329, which gated the Darwin-only `.command`
rename (#282) but left extensionless scripts unexecutable under psmux.

## Tests

Two bats tests stub `uname` (to fake a MINGW platform) and `tmux` (to capture its
argv):

- Windows: both `new-window` and `split-window` launch `bash -l <boot>`.
- Non-Windows: no `bash -l` wrapper is emitted; the bare boot path is launched.

Full `test_spawn.bats` passes locally.

## Verification

Windows/psmux-specific behavior. The reporter verified before/after on psmux
v3.3.4 + agmsg v1.1.6 + Windows 11 across codex and claude-code spawns (see the
table in #335). CI covers the bats matrix (including the windows leg); a
real-Windows functional reconfirm is advisable before shipping in a release.
