### PR TITLE
Add claim/ack API + PID sentinel helper for atomic delivery

### DIFF
--- a/scripts/internal/init-db.sh
+++ b/scripts/internal/init-db.sh
@@ -35,4 +35,11 @@ CREATE TABLE IF NOT EXISTS messages (
 
 CREATE INDEX IF NOT EXISTS idx_unread ON messages(team, to_agent, read_at) WHERE read_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_history ON messages(team, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS claims (
+  message_id INTEGER PRIMARY KEY,
+  owner TEXT NOT NULL,
+  expires_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_claims_expiry ON claims(expires_at);
 SQL

--- a/scripts/lib/claims.sh
+++ b/scripts/lib/claims.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# delivery daemon 向け unread message claim API。
+
+if ! type agmsg_db_path >/dev/null 2>&1; then
+  _agmsg_claims_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  source "$_agmsg_claims_dir/storage.sh"
+fi
+
+_agmsg_claim_quote() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/''/g")"; }
+
+_agmsg_claim_init() {
+  local scripts_dir
+  scripts_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  bash "$scripts_dir/internal/init-db.sh" >/dev/null
+}
+
+# stdout: id US from US body US created_at。空 output は claim 対象なし。
+agmsg_claim_next() {
+  local team="$1" agent="$2" owner="$3" ttl="${4:-30}" db
+  db="$(agmsg_db_path)"; _agmsg_claim_init
+  agmsg_sqlite "$db" <<SQL
+BEGIN IMMEDIATE;
+DELETE FROM claims WHERE expires_at <= strftime('%Y-%m-%dT%H:%M:%SZ', 'now');
+INSERT OR IGNORE INTO claims(message_id, owner, expires_at)
+SELECT id, $(_agmsg_claim_quote "$owner"), strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '+${ttl} seconds')
+FROM messages WHERE team=$(_agmsg_claim_quote "$team") AND to_agent=$(_agmsg_claim_quote "$agent") AND read_at IS NULL
+AND NOT EXISTS (SELECT 1 FROM claims WHERE claims.message_id=messages.id)
+ORDER BY created_at, id LIMIT 1;
+SELECT m.id || char(31) || m.from_agent || char(31) || replace(replace(m.body, char(10), '\\n'), char(9), '\\t') || char(31) || m.created_at
+FROM messages m JOIN claims c ON c.message_id=m.id WHERE c.owner=$(_agmsg_claim_quote "$owner") AND m.read_at IS NULL
+ORDER BY m.id LIMIT 1;
+COMMIT;
+SQL
+}
+
+agmsg_release_claim() {
+  local id="$1" owner="$2" db
+  db="$(agmsg_db_path)"; _agmsg_claim_init
+  agmsg_sqlite "$db" "DELETE FROM claims WHERE message_id=$(printf '%d' "$id") AND owner=$(_agmsg_claim_quote "$owner");"
+}
+
+agmsg_ack_claim() {
+  local id="$1" owner="$2" db
+  db="$(agmsg_db_path)"; _agmsg_claim_init
+  agmsg_sqlite "$db" <<SQL
+BEGIN IMMEDIATE;
+UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id=$(printf '%d' "$id")
+AND EXISTS (SELECT 1 FROM claims WHERE message_id=$(printf '%d' "$id") AND owner=$(_agmsg_claim_quote "$owner"));
+DELETE FROM claims WHERE message_id=$(printf '%d' "$id") AND owner=$(_agmsg_claim_quote "$owner");
+COMMIT;
+SQL
+}

--- a/scripts/receiver-live.sh
+++ b/scripts/receiver-live.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEAM="${1:?team required}"
+AGENT="${2:?agent required}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/actas-lock.sh"
+ready="$(SKILL_DIR="$SKILL_DIR" agmsg_ready_path "$TEAM" "$AGENT")"
+[[ -f "$ready" ]] || exit 1
+pid="$(sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' "$ready")"
+[[ "$pid" =~ ^[0-9]+$ && "$pid" != 0 ]] && kill -0 "$pid" 2>/dev/null

--- a/tests/test_claims.bats
+++ b/tests/test_claims.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  source "$SCRIPTS/lib/claims.sh"
+  export TEST_TEAM=claims-team TEST_AGENT=grok-pane TEST_OWNER=daemon-a
+  "$SCRIPTS/send.sh" "$TEST_TEAM" sender "$TEST_AGENT" "claim payload" >/dev/null
+}
+
+teardown() { teardown_test_env; }
+
+@test "claim is exclusive until release" {
+  run agmsg_claim_next "$TEST_TEAM" "$TEST_AGENT" "$TEST_OWNER" 60
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+
+  run agmsg_claim_next "$TEST_TEAM" "$TEST_AGENT" daemon-b 60
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "released claim can be claimed and acknowledged exactly once" {
+  first="$(agmsg_claim_next "$TEST_TEAM" "$TEST_AGENT" "$TEST_OWNER" 60)"
+  id="${first%%$'\x1f'*}"
+  agmsg_release_claim "$id" "$TEST_OWNER"
+
+  second="$(agmsg_claim_next "$TEST_TEAM" "$TEST_AGENT" daemon-b 60)"
+  [ -n "$second" ]
+  id="${second%%$'\x1f'*}"
+  agmsg_ack_claim "$id" daemon-b
+
+  run agmsg_claim_next "$TEST_TEAM" "$TEST_AGENT" daemon-c 60
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "wrong owner cannot acknowledge a claim" {
+  first="$(agmsg_claim_next "$TEST_TEAM" "$TEST_AGENT" "$TEST_OWNER" 60)"
+  id="${first%%$'\x1f'*}"
+  agmsg_ack_claim "$id" wrong-owner
+  run agmsg_claim_next "$TEST_TEAM" "$TEST_AGENT" daemon-b 60
+  [ -z "$output" ]
+}
+
+@test "expired claim is reclaimed by another daemon" {
+  first="$(agmsg_claim_next "$TEST_TEAM" "$TEST_AGENT" "$TEST_OWNER" 0)"
+  [ -n "$first" ]
+  run agmsg_claim_next "$TEST_TEAM" "$TEST_AGENT" daemon-b 60
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+@test "claim preserves escaped body text" {
+  "$SCRIPTS/send.sh" "$TEST_TEAM" sender "$TEST_AGENT" $'line one\nline two\tend' >/dev/null
+  first="$(agmsg_claim_next "$TEST_TEAM" "$TEST_AGENT" "$TEST_OWNER" 60)"
+  [[ "$first" == *'line one\\nline two\\tend'* ]]
+}


### PR DESCRIPTION
Fixes #373 · related to #338

## Motivation

External delivery daemons (e.g. downstream projects that build their own delivery pipe on top of agmsg) plug in as a receiver for grok-build's rule-file self-poll fallback or a future explicit-daemon mode. Today's \`inbox.sh --quiet\` reads unread rows and marks them read in two separate SQL statements. When such a daemon consumes messages, an inject failure between those two statements causes silent message loss, and a race between two receivers can cause duplicate delivery. See #373 for the full failure model.

This PR adds a small **claim / lease / ack API** that lets any receiver atomically hold a message before consuming it:

- inject failure → \`release\`, next poll retries (no loss)
- concurrent receivers → only one wins the claim (no duplicate)
- process crash → lease expires, another receiver reclaims

The API is orthogonal to the existing monitor watcher in grok-build. Upstream's monitor watcher could adopt these helpers to atomicize its own delivery loop as a follow-up, and downstream external daemons can start using them immediately.

The \`receiver-live.sh\` helper also composes with #338 Gap 2 (spawn readiness) as a shared liveness primitive — flagged in the comment thread there.

## Changes

- **\`scripts/internal/init-db.sh\`** — add \`claims\` table (\`message_id\` PK, \`owner\`, \`expires_at\`) + expiry index. \`CREATE TABLE IF NOT EXISTS\` so existing DBs upgrade in place.
- **\`scripts/lib/claims.sh\`** (new, 52 lines) — \`agmsg_claim_next\` / \`agmsg_ack_claim\` / \`agmsg_release_claim\` built around a single \`BEGIN IMMEDIATE\` transaction with \`INSERT OR IGNORE\` + expiry GC.
- **\`scripts/receiver-live.sh\`** (new, 12 lines) — small helper: read \`pid=N\` from an agent's ready sentinel and \`kill -0\` it. Exits 0 if live, non-zero if stale or missing. Rule files or watchers can use it to gate a fallback path.
- **\`tests/test_claims.bats\`** (new, 5 cases) — excludes already-claimed / release + reclaim + ack / wrong-owner ack rejection / expired claim reclaim / newline+tab body round-trip.

## Notes

- No existing behavior is changed; nothing in-tree calls the new API yet.
- Driver-side integration (e.g. a grok-build \`both\` mode that pairs an external daemon with the rule-file fallback) is planned as a follow-up so it can be discussed against the current monitor design (#245).

🤖 Prepared with [Claude Code](https://claude.com/claude-code)