### PR TITLE
chore(app): bump version to 0.1.5

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agmsg-app",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agmsg-app"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agmsg-app"
-version = "0.1.4"
+version = "0.1.5"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "agmsg",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "cc.agmsg.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- Bumps the app version 0.1.4 -> 0.1.5 across all four files `bump-app-version.sh` touches (package.json, Cargo.toml, Cargo.lock, tauri.conf.json), via that script.
- Discovered as a bump slip: #377/#354/#379 landed on main but tauri.conf.json's version was still 0.1.4 (same failure mode #334's tag<->version guard exists to catch — the guard would have caught it at tag time, this closes the gap earlier).
- AGMSG_CORE_REF is already v1.1.7 (#379) — confirmed correct for this version, no change needed here.
- This is the last code change for 0.1.5.

## Testing
- `bundle-core.sh` sanity check pass (v1.1.7)
- `tsc --noEmit` / `pnpm test` 81/81 pass, `cargo check` / `cargo test` 21/21 pass