### PR TITLE
feat(app): show agent and team status

### DIFF
--- a/app/src-tauri/src/agent_state.rs
+++ b/app/src-tauri/src/agent_state.rs
@@ -117,6 +117,23 @@ pub fn classify(agent_type: &str, tail: &str) -> PaneState {
         "(y/n)",
         "[y/N]",
         "[Y/n]",
+        // Generic numbered-choice menus (e.g. the plan-mode-exit conflict
+        // dialog) don't say "Do you want to proceed?" at all — confirmed
+        // from a live capture, #385 — but they all share this footer
+        // regardless of which menu is showing, so it covers the class
+        // instead of enumerating every prompt's own wording.
+        "Enter to select",
+        // Structural fallback for the SAME class of menu, for when even
+        // that footer isn't there (confirmed from a live capture, #385: the
+        // plan-review "Ready to code?" screen has neither "Do you want to
+        // proceed?" nor "Enter to select" — just "Would you like to
+        // proceed?" and a numbered list). Every one of these interactive
+        // menus opens with its first option pre-selected behind "❯", so
+        // matching that marker generalizes across prompt wording we
+        // haven't seen yet instead of enumerating each one — the same idea
+        // herdr uses for codex's "›" cursor glyph (src/detect/manifest.rs),
+        // just applied to claude's own selector character.
+        "❯ 1.",
     ];
     const BRAILLE_SPINNERS: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
     // Claude Code's "thinking" spinner cycles through these sparkle glyphs,
@@ -213,13 +230,115 @@ impl TailBuffer {
         // bytes were still sitting near the front of that one giant "line"
         // long after the real terminal had moved past them.
         let lines: Vec<&str> = text.split(['\r', '\n']).collect();
+        let recent = &lines[lines.len().saturating_sub(20)..];
+
+        // Structural narrowing, ported from herdr's src/detect/manifest.rs
+        // (prompt_box_body / after_last_horizontal_rule): scope down to the
+        // live bordered box's body when the window holds a complete one,
+        // else to whatever came after the most recent box's closing rule.
+        // Pure box-drawing-character geometry, no words involved, so it
+        // generalizes across every dialog's own wording and sheds stale
+        // scrollback the recency window alone can't (a resolved dialog's
+        // closing rule marks everything above it as no-longer-current).
+        let scoped = prompt_box_body(recent).unwrap_or_else(|| after_last_horizontal_rule(recent));
+        let menu_option_selected = scoped.iter().any(|line| is_chevron_menu_line(line));
+
         // Joined with a space, not '\n'/'\r': a narrow pane wraps a prompt
         // like "Do you want to proceed?" across two frames, and either
         // separator would split that phrase apart, permanently defeating
         // classify()'s substring match for as long as the pane stays that
         // width.
-        lines[lines.len().saturating_sub(20)..].join(" ")
+        let mut flattened = scoped.join(" ");
+        if menu_option_selected {
+            // A line starting with claude's selector glyph followed by real
+            // content (not the bare, nothing-highlighted composer prompt)
+            // means SOME option is currently highlighted in an interactive
+            // menu — herdr: claude.toml's `^\s*❯` gate, the same idea as
+            // codex's `›` cursor glyph. Guaranteed present in the flattened
+            // text this way regardless of which option number is shown or
+            // whether an adjacent color code broke the natural adjacency.
+            flattened.push_str(" ❯ 1.");
+        }
+        flattened
     }
+}
+
+// Structural detectors ported from herdr's src/detect/manifest.rs — pure
+// box-drawing-character and glyph geometry, no literal English words. herdr
+// uses these to pick WHICH region of the screen to run its phrase rules
+// against, not to classify state by shape alone; we do the same, applying
+// them ahead of classify()'s (still literal) pattern matching.
+
+/// A line made (almost) entirely of the box-drawing rule character, with
+/// nothing but whitespace after it — the top/bottom border of a bordered
+/// box (the permission-prompt/plan-review dialogs all draw one).
+fn is_horizontal_rule(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let rule_chars = trimmed.chars().take_while(|&ch| ch == '─').count();
+    if rule_chars == 0 {
+        return false;
+    }
+    let rest: String = trimmed.chars().skip(rule_chars).collect();
+    rest.trim().is_empty() || rule_chars >= 3
+}
+
+/// Index of the top border of the most recently opened box: the
+/// second-to-last horizontal-rule line, scanning bottom-up.
+fn prompt_box_top_border_index(lines: &[&str]) -> Option<usize> {
+    let mut rules_seen = 0;
+    for index in (0..lines.len()).rev() {
+        if is_horizontal_rule(lines[index]) {
+            rules_seen += 1;
+            if rules_seen == 2 {
+                return Some(index);
+            }
+        }
+    }
+    None
+}
+
+/// The lines strictly between a currently-open box's top and bottom
+/// border, if the window holds a complete one.
+fn prompt_box_body<'a>(lines: &'a [&'a str]) -> Option<&'a [&'a str]> {
+    let top = prompt_box_top_border_index(lines)?;
+    let body_start = top + 1;
+    let body_end = lines[body_start..]
+        .iter()
+        .position(|line| is_horizontal_rule(line))
+        .map(|relative| body_start + relative)
+        .unwrap_or(lines.len());
+    lines.get(body_start..body_end)
+}
+
+/// Everything after the last horizontal-rule line in the window (the
+/// fallback when there's no complete box, only a box that just closed).
+fn after_last_horizontal_rule<'a>(lines: &'a [&'a str]) -> &'a [&'a str] {
+    match lines.iter().rposition(|line| is_horizontal_rule(line)) {
+        Some(index) => &lines[index + 1..],
+        None => lines,
+    }
+}
+
+/// claude's menu-selector glyph followed by a NUMBERED option ("❯ 1. ...")
+/// means an option is currently highlighted in an interactive menu (herdr:
+/// claude.toml's `^\s*❯` gate). The bare composer prompt ("❯" alone) is
+/// already excluded by requiring real content — but the composer ALSO
+/// shows "❯ " immediately followed by whatever the user is typing (e.g.
+/// "❯ fix the bug"), which looks just as "non-empty" and caused a false
+/// Blocked the moment anyone typed a message (#385, live repro). Requiring
+/// the content to start with digits + '.' (the option-numbering every one
+/// of these menus actually uses) rules that out without misclassifying a
+/// real menu.
+fn is_chevron_menu_line(line: &str) -> bool {
+    let Some(rest) = line.trim_start().strip_prefix('❯') else {
+        return false;
+    };
+    let rest = rest.trim_start();
+    let digits = rest.chars().take_while(|c| c.is_ascii_digit()).count();
+    digits > 0 && rest.as_bytes().get(digits) == Some(&b'.')
 }
 
 // Cursor Forward (CSI n C) and Cursor Horizontal Absolute (CSI n G) both move
@@ -297,7 +416,10 @@ fn strip_ansi(input: &str) -> String {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use super::{classify, DetectionTracker, PaneState, TailBuffer, TAIL_CAPACITY};
+    use super::{
+        after_last_horizontal_rule, classify, is_chevron_menu_line, is_horizontal_rule,
+        prompt_box_body, DetectionTracker, PaneState, TailBuffer, TAIL_CAPACITY,
+    };
 
     #[test]
     fn tail_is_bounded_to_capacity() {
@@ -340,6 +462,100 @@ mod tests {
             "got: {snapshot:?}"
         );
         assert_eq!(classify("claude", &snapshot), PaneState::Idle);
+    }
+
+    #[test]
+    fn is_horizontal_rule_requires_only_whitespace_after_a_short_run() {
+        assert!(is_horizontal_rule("────────────"));
+        assert!(is_horizontal_rule("  ───  "));
+        // A pure rule of any length (nothing after it) still counts.
+        assert!(is_horizontal_rule("──"));
+        // With trailing content, at least 3 rule chars are required — a
+        // labeled divider like "── Section ──" is still a rule, but a
+        // stray "--" in normal prose isn't.
+        assert!(is_horizontal_rule("─── Section"));
+        assert!(!is_horizontal_rule("── not a rule"));
+        assert!(!is_horizontal_rule(""));
+        assert!(!is_horizontal_rule("plain text"));
+    }
+
+    #[test]
+    fn is_chevron_menu_line_excludes_the_bare_composer_prompt() {
+        assert!(is_chevron_menu_line("❯ 1. Yes"));
+        assert!(is_chevron_menu_line("  ❯ 1. Exit plan mode"));
+        assert!(is_chevron_menu_line("❯ 10. tenth option"));
+        assert!(!is_chevron_menu_line("❯"));
+        assert!(!is_chevron_menu_line("❯ "));
+        assert!(!is_chevron_menu_line("no chevron here"));
+    }
+
+    #[test]
+    fn is_chevron_menu_line_ignores_the_user_typing_a_message() {
+        // Live repro (#385): the composer shows "❯ <whatever you're
+        // typing>" the same way it shows "❯ 1. <option>" for a real menu —
+        // "content after the glyph" alone isn't enough to tell them apart.
+        // Typing any message briefly flipped the pane to Blocked until this
+        // was tightened to require the option-numbering real menus use.
+        assert!(!is_chevron_menu_line("❯ あああ"));
+        assert!(!is_chevron_menu_line("❯ /agmsg actas Alice"));
+        assert!(!is_chevron_menu_line("❯ fix the lint errors"));
+    }
+
+    #[test]
+    fn prompt_box_body_extracts_the_lines_between_the_two_most_recent_rules() {
+        let lines = [
+            "stale text",
+            "────",
+            "Do you want to proceed?",
+            "❯ 1. Yes",
+            "────",
+        ];
+        assert_eq!(
+            prompt_box_body(&lines),
+            Some(&["Do you want to proceed?", "❯ 1. Yes"][..])
+        );
+    }
+
+    #[test]
+    fn after_last_horizontal_rule_falls_back_when_only_one_rule_is_in_view() {
+        let lines = [
+            "Do you want to proceed?",
+            "❯ 1. Yes",
+            "────",
+            "next turn's output",
+        ];
+        assert_eq!(prompt_box_body(&lines), None);
+        assert_eq!(after_last_horizontal_rule(&lines), &["next turn's output"]);
+    }
+
+    #[test]
+    fn detection_tail_scopes_to_the_open_box_and_drops_a_stale_closed_one() {
+        // Two dialogs back to back: an earlier, already-resolved box (whose
+        // "Do you want to proceed?" is stale scrollback now) followed by a
+        // brand new one that's actually open. Only the open box's content
+        // should survive — this is what makes a resolved dialog's text stop
+        // poisoning classify() even within the same 20-line window, on top
+        // of (not instead of) the recency window itself (#385).
+        let mut tail = TailBuffer::default();
+        tail.push(
+            "────\n\
+Do you want to proceed?\n\
+❯ 1. Yes\n\
+────\n\
+some output after answering\n\
+────\n\
+Would you like to proceed?\n\
+❯ 1. Yes, and use auto mode\n\
+────\n"
+                .as_bytes(),
+        );
+        let snapshot = tail.detection_tail();
+        assert!(
+            !snapshot.contains("Do you want to proceed?"),
+            "got: {snapshot:?}"
+        );
+        assert!(snapshot.contains("Would you like to proceed?"));
+        assert_eq!(classify("claude", &snapshot), PaneState::Blocked);
     }
 
     #[test]
@@ -437,6 +653,35 @@ mod tests {
         assert_eq!(
             classify("claude", "Working\nCompleted\n3 awaiting input"),
             PaneState::Idle
+        );
+    }
+
+    #[test]
+    fn detects_generic_numbered_choice_menus() {
+        // Captured live (#385): the plan-mode-exit conflict dialog never
+        // says "Do you want to proceed?" — only a numbered list and this
+        // footer.
+        assert_eq!(
+            classify(
+                "claude",
+                "1. Exit plan mode and continue actas 2. Stay in plan mode Enter to select · ↑/↓ to navigate · Esc to cancel"
+            ),
+            PaneState::Blocked
+        );
+    }
+
+    #[test]
+    fn detects_menus_with_neither_known_phrase_via_the_selector_marker() {
+        // Captured live (#385): the plan-review "Ready to code?" screen has
+        // neither "Do you want to proceed?" nor "Enter to select" — just
+        // "Would you like to proceed?", which isn't in any pattern list —
+        // so only the "❯ 1." selector marker catches it.
+        assert_eq!(
+            classify(
+                "claude",
+                "Would you like to proceed? ❯ 1. Yes, and use auto mode   2. Yes, manually approve edits"
+            ),
+            PaneState::Blocked
         );
     }
 

--- a/app/src-tauri/src/agent_state.rs
+++ b/app/src-tauri/src/agent_state.rs
@@ -1,0 +1,99 @@
+use std::collections::VecDeque;
+
+pub const TAIL_CAPACITY: usize = 8 * 1024;
+pub const DETECTION_INTERVAL: std::time::Duration = std::time::Duration::from_millis(400);
+
+pub struct TailBuffer {
+    bytes: VecDeque<u8>,
+}
+
+impl Default for TailBuffer {
+    fn default() -> Self {
+        Self {
+            bytes: VecDeque::with_capacity(TAIL_CAPACITY),
+        }
+    }
+}
+
+impl TailBuffer {
+    pub fn push(&mut self, input: &[u8]) {
+        let overflow = self
+            .bytes
+            .len()
+            .saturating_add(input.len())
+            .saturating_sub(TAIL_CAPACITY);
+        self.bytes.drain(..overflow.min(self.bytes.len()));
+        if input.len() > TAIL_CAPACITY {
+            self.bytes.extend(&input[input.len() - TAIL_CAPACITY..]);
+        } else {
+            self.bytes.extend(input);
+        }
+    }
+
+    pub fn detection_tail(&self) -> String {
+        let raw: Vec<u8> = self.bytes.iter().copied().collect();
+        let text = strip_ansi(&String::from_utf8_lossy(&raw));
+        let lines: Vec<&str> = text.lines().collect();
+        lines[lines.len().saturating_sub(20)..].join("\n")
+    }
+}
+
+fn strip_ansi(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '\u{1b}' {
+            output.push(ch);
+            continue;
+        }
+
+        match chars.peek().copied() {
+            Some('[') => {
+                chars.next();
+                for c in chars.by_ref() {
+                    if ('@'..='~').contains(&c) {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                chars.next();
+                let mut escaped = false;
+                for c in chars.by_ref() {
+                    if c == '\u{7}' || (escaped && c == '\\') {
+                        break;
+                    }
+                    escaped = c == '\u{1b}';
+                }
+            }
+            _ => {}
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TailBuffer, TAIL_CAPACITY};
+
+    #[test]
+    fn tail_is_bounded_to_capacity() {
+        let mut tail = TailBuffer::default();
+        tail.push(&vec![b'a'; TAIL_CAPACITY + 10]);
+        assert_eq!(tail.bytes.len(), TAIL_CAPACITY);
+    }
+
+    #[test]
+    fn detection_tail_strips_ansi_and_keeps_last_twenty_lines() {
+        let mut tail = TailBuffer::default();
+        let content = (0..25)
+            .map(|line| format!("\u{1b}[31mline-{line}\u{1b}[0m"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        tail.push(content.as_bytes());
+        let snapshot = tail.detection_tail();
+        assert!(!snapshot.contains('\u{1b}'));
+        assert!(snapshot.starts_with("line-5"));
+        assert!(snapshot.ends_with("line-24"));
+    }
+}

--- a/app/src-tauri/src/agent_state.rs
+++ b/app/src-tauri/src/agent_state.rs
@@ -178,7 +178,12 @@ impl TailBuffer {
         let raw: Vec<u8> = self.bytes.iter().copied().collect();
         let text = strip_ansi(&String::from_utf8_lossy(&raw));
         let lines: Vec<&str> = text.lines().collect();
-        lines[lines.len().saturating_sub(20)..].join("\n")
+        // Joined with a space, not "\n": a narrow pane wraps a prompt like "Do
+        // you want to proceed?" across two lines, and a literal "\n" would
+        // split that phrase apart, permanently defeating classify()'s
+        // substring match for as long as the pane stays that width (#385
+        // "blocking doesn't react" diagnosis).
+        lines[lines.len().saturating_sub(20)..].join(" ")
     }
 
     pub fn snapshot(&self) -> (String, u64) {
@@ -252,6 +257,17 @@ mod tests {
         let mut tail = TailBuffer::default();
         tail.push(b"before\x1b]0;title\x07middle\x1b]9;progress\x1b\\after");
         assert_eq!(tail.detection_tail(), "beforemiddleafter");
+    }
+
+    #[test]
+    fn detection_tail_survives_narrow_pane_word_wrap() {
+        let mut tail = TailBuffer::default();
+        // A narrow pane wraps the approval prompt mid-phrase.
+        tail.push(b"Do you want to\nproceed?\n");
+        assert_eq!(
+            classify("claude", &tail.detection_tail()),
+            PaneState::Blocked
+        );
     }
 
     #[test]

--- a/app/src-tauri/src/agent_state.rs
+++ b/app/src-tauri/src/agent_state.rs
@@ -145,11 +145,23 @@ pub fn classify(agent_type: &str, tail: &str) -> PaneState {
     // for claude was relying on neither signal actually firing — any tick
     // without a Blocked match fell straight through to Idle mid-generation.
     const CLAUDE_SPINNERS: &[&str] = &["✢", "✳", "✶", "✻", "✽"];
+    // Verified against herdr's codex.toml (src/detect/manifests/codex.toml)
+    // rather than guessed: "Press enter to continue" and "Do you trust the
+    // contents of this directory?" were never real Codex CLI strings (the
+    // latter reads like VS Code's workspace-trust dialog, not Codex) and
+    // never matched anything.
     const CODEX_BLOCKED: &[&str] = &[
         "Allow command?",
-        "Do you trust the contents of this directory?",
-        "Press enter to continue",
         "enter to submit answer",
+        "enter to submit all",
+        "press enter to confirm or esc to cancel",
+        "[y/n]",
+        "yes (y)",
+        // Set in the window title, not the screen — TailBuffer::detection_tail
+        // appends the last-seen title to the flattened text, so this still
+        // matches via the same plain substring check. herdr's cheapest/
+        // highest-priority Codex blocked signal.
+        "Action Required",
     ];
     const GEMINI_BLOCKED: &[&str] = &[
         "Do you trust the files in this folder?",
@@ -163,6 +175,11 @@ pub fn classify(agent_type: &str, tail: &str) -> PaneState {
     };
     let working_patterns: &[&str] = match agent_type {
         "gemini" => &["Thinking", "esc to cancel"],
+        // Codex's working signal is purely the title-bar spinner glyph
+        // (below) — herdr's codex.toml has no phrase-based working rule at
+        // all, and "esc to interrupt" is confirmed absent from it (it only
+        // appears in devin.toml/opencode.toml).
+        "codex" => &[],
         _ => &["esc to interrupt", "Esc to interrupt"],
     };
     let spinners: &[&str] = match agent_type {
@@ -170,16 +187,22 @@ pub fn classify(agent_type: &str, tail: &str) -> PaneState {
         _ => BRAILLE_SPINNERS,
     };
 
+    // Case-insensitive, matching herdr's own gates (they normalize both
+    // sides via `.to_lowercase()`) — we don't actually know the exact
+    // casing every one of these strings renders with on screen, so
+    // matching loosely here beats silently missing a real match over a
+    // capitalization difference.
+    let tail_lower = tail.to_lowercase();
     if COMMON_BLOCKED
         .iter()
         .chain(blocked_patterns.iter())
-        .any(|pattern| tail.contains(pattern))
+        .any(|pattern| tail_lower.contains(&pattern.to_lowercase()))
     {
         PaneState::Blocked
     } else if working_patterns
         .iter()
         .chain(spinners.iter())
-        .any(|pattern| tail.contains(pattern))
+        .any(|pattern| tail_lower.contains(&pattern.to_lowercase()))
     {
         PaneState::Working
     } else {
@@ -219,7 +242,7 @@ impl TailBuffer {
 
     pub fn detection_tail(&self) -> String {
         let raw: Vec<u8> = self.bytes.iter().copied().collect();
-        let text = strip_ansi(&String::from_utf8_lossy(&raw));
+        let (text, title) = strip_ansi(&String::from_utf8_lossy(&raw));
         // Split on '\r' as well as '\n': ink redraws the spinner/status line
         // in place with a bare carriage return, not a newline (confirmed
         // from a real capture, #385 — dozens of "Cerebrating…" spinner
@@ -258,6 +281,15 @@ impl TailBuffer {
             // text this way regardless of which option number is shown or
             // whether an adjacent color code broke the natural adjacency.
             flattened.push_str(" ❯ 1.");
+        }
+        // Codex reports its own state through the window title, not the
+        // screen (herdr: codex.toml's `osc_title` region — a Braille
+        // spinner glyph means Working, "Action Required" means Blocked).
+        // Appending it here lets classify()'s existing substring patterns
+        // pick it up without needing their own code path.
+        if let Some(title) = title {
+            flattened.push(' ');
+            flattened.push_str(&title);
         }
         flattened
     }
@@ -351,8 +383,16 @@ fn is_chevron_menu_line(line: &str) -> bool {
 // Blocked/Working). `col` tracks the 0-indexed column the next printed
 // character would land on, reset on '\r'/'\n', so both forms can be
 // rendered back as the gap of spaces they visually are.
-fn strip_ansi(input: &str) -> String {
+//
+// Returns the stripped body text plus the LAST OSC 0/2 window-title string
+// seen, if any. Codex sets its live/blocked state in the window title, not
+// the visible screen (herdr: codex.toml's `osc_title` region) — e.g. a
+// Braille spinner glyph in the title means Working, "Action Required" means
+// Blocked — so that title text has to survive somewhere for classify() to
+// see it, instead of being silently discarded like every other OSC.
+fn strip_ansi(input: &str) -> (String, Option<String>) {
     let mut output = String::with_capacity(input.len());
+    let mut title: Option<String> = None;
     let mut col: usize = 0;
     let mut chars = input.chars().peekable();
     while let Some(ch) = chars.next() {
@@ -398,18 +438,26 @@ fn strip_ansi(input: &str) -> String {
             }
             Some(']') => {
                 chars.next();
+                let mut body = String::new();
                 let mut escaped = false;
                 for c in chars.by_ref() {
                     if c == '\u{7}' || (escaped && c == '\\') {
                         break;
                     }
                     escaped = c == '\u{1b}';
+                    body.push(c);
+                }
+                // "0;<title>" or "2;<title>" (OSC 0 sets icon+title, OSC 2
+                // sets title only — both are the window title as far as a
+                // reader is concerned).
+                if let Some(rest) = body.strip_prefix("0;").or_else(|| body.strip_prefix("2;")) {
+                    title = Some(rest.trim_end_matches('\u{1b}').to_string());
                 }
             }
             _ => {}
         }
     }
-    output
+    (output, title)
 }
 
 #[cfg(test)]
@@ -559,10 +607,45 @@ Would you like to proceed?\n\
     }
 
     #[test]
-    fn detection_tail_strips_bel_and_st_terminated_osc_sequences() {
+    fn detection_tail_strips_non_title_bel_and_st_terminated_osc_sequences() {
         let mut tail = TailBuffer::default();
-        tail.push(b"before\x1b]0;title\x07middle\x1b]9;progress\x1b\\after");
+        tail.push(b"before\x1b]9;progress\x07middle\x1b]8;;url\x1b\\after");
         assert_eq!(tail.detection_tail(), "beforemiddleafter");
+    }
+
+    #[test]
+    fn detection_tail_appends_the_osc_0_and_2_window_title() {
+        // Codex reports Working/Blocked through the window title, not the
+        // screen (herdr: codex.toml's `osc_title` region) — the title has
+        // to survive into the flattened text for classify() to see it.
+        let mut tail = TailBuffer::default();
+        tail.push(b"before\x1b]0;Action Required\x07after");
+        assert_eq!(tail.detection_tail(), "beforeafter Action Required");
+
+        // OSC 2 (title-only, no icon) counts the same way.
+        let mut tail2 = TailBuffer::default();
+        tail2.push(b"before\x1b]2;codex\x07after");
+        assert_eq!(tail2.detection_tail(), "beforeafter codex");
+    }
+
+    #[test]
+    fn codex_blocked_and_working_signals_come_from_the_title_not_the_screen() {
+        // End-to-end (TailBuffer -> classify()): a codex pane whose visible
+        // screen has nothing recognizable, but whose title carries the
+        // real signal (herdr: codex.toml's osc_title region).
+        let mut blocked = TailBuffer::default();
+        blocked.push(b"ordinary transcript output\x1b]0;Action Required\x07");
+        assert_eq!(
+            classify("codex", &blocked.detection_tail()),
+            PaneState::Blocked
+        );
+
+        let mut working = TailBuffer::default();
+        working.push("ordinary transcript output\x1b]2;⠙ codex\u{7}".as_bytes());
+        assert_eq!(
+            classify("codex", &working.detection_tail()),
+            PaneState::Working
+        );
     }
 
     #[test]
@@ -619,12 +702,15 @@ Would you like to proceed?\n\
             classify("gemini", "Do you trust the files in this folder?"),
             PaneState::Blocked
         );
+        // "enter to submit ANSWER", not COMMON_BLOCKED's "Enter to confirm"
+        // — picked to not accidentally overlap with the shared list, so
+        // this only passes if it's really CODEX_BLOCKED doing the work.
         assert_eq!(
-            classify("codex", "Press enter to continue"),
+            classify("codex", "please press Enter to submit Answer now"),
             PaneState::Blocked
         );
         assert_eq!(
-            classify("claude", "Press enter to continue"),
+            classify("claude", "please press Enter to submit Answer now"),
             PaneState::Idle
         );
     }
@@ -693,7 +779,7 @@ Would you like to proceed?\n\
     #[test]
     fn working_to_idle_requires_three_confirmations() {
         let started = Instant::now();
-        let mut tracker = DetectionTracker::new("codex".to_string());
+        let mut tracker = DetectionTracker::new("claude".to_string());
         let ready = started + Duration::from_secs(3);
         assert_eq!(
             tracker.observe("esc to interrupt", ready),
@@ -739,7 +825,7 @@ Would you like to proceed?\n\
         // zero-width escape (e.g. cursor blink) starts firing every tick
         // regardless of real activity (#385).
         let started = Instant::now();
-        let mut tracker = DetectionTracker::new("codex".to_string());
+        let mut tracker = DetectionTracker::new("claude".to_string());
         let ready = started + Duration::from_secs(3);
         assert_eq!(
             tracker.observe("esc to interrupt (1s)", ready),

--- a/app/src-tauri/src/agent_state.rs
+++ b/app/src-tauri/src/agent_state.rs
@@ -22,7 +22,7 @@ pub struct DetectionTracker {
     state: PaneState,
     created_at: Instant,
     idle_confirmations: u8,
-    last_output_seq: Option<u64>,
+    last_tail: Option<String>,
 }
 
 impl DetectionTracker {
@@ -32,7 +32,7 @@ impl DetectionTracker {
             state: PaneState::Unknown,
             created_at: Instant::now(),
             idle_confirmations: 0,
-            last_output_seq: None,
+            last_tail: None,
         }
     }
 
@@ -40,19 +40,35 @@ impl DetectionTracker {
         self.state
     }
 
-    pub fn observe(&mut self, tail: &str, output_seq: u64, now: Instant) -> Option<PaneState> {
+    pub fn observe(&mut self, tail: &str, now: Instant) -> Option<PaneState> {
         if now.saturating_duration_since(self.created_at) < STARTUP_GRACE {
             return None;
         }
 
-        let output_changed = self.last_output_seq != Some(output_seq);
-        self.last_output_seq = Some(output_seq);
-        let candidate = if !output_changed && self.state == PaneState::Working {
-            PaneState::Idle
-        } else if !output_changed && self.state == PaneState::Blocked {
-            PaneState::Blocked
-        } else {
+        // Compares the DERIVED text, not a raw byte/push counter: a blinking
+        // cursor or other zero-width escape noise still arrives as PTY bytes
+        // every tick even while the pane is genuinely idle, so a push-based
+        // "did anything arrive" signal never goes quiet and the 3-tick
+        // debounce below never got to fire (#385 — panes stuck showing
+        // Working forever after the agent actually finished).
+        let tail_changed = self.last_tail.as_deref() != Some(tail);
+        self.last_tail = Some(tail.to_string());
+        let candidate = if tail_changed {
             classify(&self.agent_type, tail)
+        } else {
+            // A static tail means nothing new happened since last tick:
+            // Working debounces down toward Idle below (no more output ==
+            // probably done), and every other state — crucially including
+            // Idle itself — just holds. Re-running classify() here on an
+            // Idle pane's unchanged snapshot was the actual bug: if that
+            // frozen frame still had a stale spinner glyph in it (a
+            // synchronized-output redraw that stalled mid-animation), it
+            // matched Working again immediately, bounced right back to
+            // Idle after another 3-tick debounce, and repeated forever.
+            match self.state {
+                PaneState::Working => PaneState::Idle,
+                other => other,
+            }
         };
         let next = match (self.state, candidate) {
             (_, PaneState::Blocked) => {
@@ -102,7 +118,16 @@ pub fn classify(agent_type: &str, tail: &str) -> PaneState {
         "[y/N]",
         "[Y/n]",
     ];
-    const SPINNERS: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+    const BRAILLE_SPINNERS: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+    // Claude Code's "thinking" spinner cycles through these sparkle glyphs,
+    // not the braille dots above — confirmed from a real capture (#385):
+    // "✻i…", "✳…", "✶5", "✢di", "✽n30" all rendering behind a whimsical
+    // verb ("Considering…" etc). The braille set never matched claude panes,
+    // and "esc to interrupt" doesn't appear in the current CLI build either
+    // (checked via `strings` on the installed binary), so Working detection
+    // for claude was relying on neither signal actually firing — any tick
+    // without a Blocked match fell straight through to Idle mid-generation.
+    const CLAUDE_SPINNERS: &[&str] = &["✢", "✳", "✶", "✻", "✽"];
     const CODEX_BLOCKED: &[&str] = &[
         "Allow command?",
         "Do you trust the contents of this directory?",
@@ -123,6 +148,10 @@ pub fn classify(agent_type: &str, tail: &str) -> PaneState {
         "gemini" => &["Thinking", "esc to cancel"],
         _ => &["esc to interrupt", "Esc to interrupt"],
     };
+    let spinners: &[&str] = match agent_type {
+        "claude" | "claude-code" => CLAUDE_SPINNERS,
+        _ => BRAILLE_SPINNERS,
+    };
 
     if COMMON_BLOCKED
         .iter()
@@ -132,7 +161,7 @@ pub fn classify(agent_type: &str, tail: &str) -> PaneState {
         PaneState::Blocked
     } else if working_patterns
         .iter()
-        .chain(SPINNERS.iter())
+        .chain(spinners.iter())
         .any(|pattern| tail.contains(pattern))
     {
         PaneState::Working
@@ -143,14 +172,12 @@ pub fn classify(agent_type: &str, tail: &str) -> PaneState {
 
 pub struct TailBuffer {
     bytes: VecDeque<u8>,
-    output_seq: u64,
 }
 
 impl Default for TailBuffer {
     fn default() -> Self {
         Self {
             bytes: VecDeque::with_capacity(TAIL_CAPACITY),
-            output_seq: 0,
         }
     }
 }
@@ -160,7 +187,6 @@ impl TailBuffer {
         if input.is_empty() {
             return;
         }
-        self.output_seq = self.output_seq.wrapping_add(1);
         let overflow = self
             .bytes
             .len()
@@ -177,25 +203,46 @@ impl TailBuffer {
     pub fn detection_tail(&self) -> String {
         let raw: Vec<u8> = self.bytes.iter().copied().collect();
         let text = strip_ansi(&String::from_utf8_lossy(&raw));
-        let lines: Vec<&str> = text.lines().collect();
-        // Joined with a space, not "\n": a narrow pane wraps a prompt like "Do
-        // you want to proceed?" across two lines, and a literal "\n" would
-        // split that phrase apart, permanently defeating classify()'s
-        // substring match for as long as the pane stays that width (#385
-        // "blocking doesn't react" diagnosis).
+        // Split on '\r' as well as '\n': ink redraws the spinner/status line
+        // in place with a bare carriage return, not a newline (confirmed
+        // from a real capture, #385 — dozens of "Cerebrating…" spinner
+        // frames arrive '\r'-separated with no '\n' at all). `.lines()`
+        // alone treated that whole run as ONE line, so it never aged out of
+        // the last-20 window — a resolved permission prompt, or a finished
+        // "Working" spinner, could keep matching indefinitely because its
+        // bytes were still sitting near the front of that one giant "line"
+        // long after the real terminal had moved past them.
+        let lines: Vec<&str> = text.split(['\r', '\n']).collect();
+        // Joined with a space, not '\n'/'\r': a narrow pane wraps a prompt
+        // like "Do you want to proceed?" across two frames, and either
+        // separator would split that phrase apart, permanently defeating
+        // classify()'s substring match for as long as the pane stays that
+        // width.
         lines[lines.len().saturating_sub(20)..].join(" ")
-    }
-
-    pub fn snapshot(&self) -> (String, u64) {
-        (self.detection_tail(), self.output_seq)
     }
 }
 
+// Cursor Forward (CSI n C) and Cursor Horizontal Absolute (CSI n G) both move
+// the cursor without printing — ink pads/aligns text with them instead of
+// writing literal spaces (confirmed from a real permission-prompt capture,
+// #385: "Do\x1b[5Gyou\x1b[9Gwant\x1b[14Gto\x1b[17Gproceed?" renders as "Do you
+// want to proceed?", but naively dropping the escapes glued it into
+// "Doyouwanttoproceed?", which no longer matched classify()'s substring
+// patterns — the actual cause of panes getting stuck instead of turning
+// Blocked/Working). `col` tracks the 0-indexed column the next printed
+// character would land on, reset on '\r'/'\n', so both forms can be
+// rendered back as the gap of spaces they visually are.
 fn strip_ansi(input: &str) -> String {
     let mut output = String::with_capacity(input.len());
+    let mut col: usize = 0;
     let mut chars = input.chars().peekable();
     while let Some(ch) = chars.next() {
         if ch != '\u{1b}' {
+            if ch == '\r' || ch == '\n' {
+                col = 0;
+            } else {
+                col += 1;
+            }
             output.push(ch);
             continue;
         }
@@ -203,10 +250,31 @@ fn strip_ansi(input: &str) -> String {
         match chars.peek().copied() {
             Some('[') => {
                 chars.next();
+                let mut params = String::new();
                 for c in chars.by_ref() {
                     if ('@'..='~').contains(&c) {
+                        match c {
+                            'C' => {
+                                let n = params.parse().unwrap_or(1).clamp(1, 512);
+                                output.extend(std::iter::repeat_n(' ', n));
+                                col += n;
+                            }
+                            // Only a forward jump can be represented as
+                            // spaces; a same-or-backward jump is left alone
+                            // since already-emitted text can't be un-printed.
+                            'G' => {
+                                let target: usize = params.parse().unwrap_or(1).max(1);
+                                if target > col + 1 {
+                                    let gap = (target - 1 - col).min(512);
+                                    output.extend(std::iter::repeat_n(' ', gap));
+                                    col = target - 1;
+                                }
+                            }
+                            _ => {}
+                        }
                         break;
                     }
+                    params.push(c);
                 }
             }
             Some(']') => {
@@ -253,10 +321,61 @@ mod tests {
     }
 
     #[test]
+    fn carriage_return_redraws_age_out_old_frames_like_newlines_do() {
+        // ink rewrites the spinner in place with a bare '\r', never '\n'
+        // (#385). A resolved permission prompt followed by enough spinner
+        // redraws must age out of the last-20-frame window exactly like a
+        // resolved prompt followed by enough real newlines would — a stale
+        // "Do you want to proceed?" sitting near the front of one giant
+        // '\r'-joined "line" was why panes stayed stuck as Blocked (or
+        // Working, from stale spinner text) long after they'd moved on.
+        let mut tail = TailBuffer::default();
+        tail.push(b"Do you want to proceed?\r");
+        for i in 0..25 {
+            tail.push(format!("frame-{i}\r").as_bytes());
+        }
+        let snapshot = tail.detection_tail();
+        assert!(
+            !snapshot.contains("Do you want to proceed?"),
+            "got: {snapshot:?}"
+        );
+        assert_eq!(classify("claude", &snapshot), PaneState::Idle);
+    }
+
+    #[test]
     fn detection_tail_strips_bel_and_st_terminated_osc_sequences() {
         let mut tail = TailBuffer::default();
         tail.push(b"before\x1b]0;title\x07middle\x1b]9;progress\x1b\\after");
         assert_eq!(tail.detection_tail(), "beforemiddleafter");
+    }
+
+    #[test]
+    fn cursor_forward_sequences_become_the_spaces_they_visually_are() {
+        // CSI n C (Cursor Forward) moves the cursor without printing — used
+        // here for the box's 1-column left indent before "Do".
+        let mut tail = TailBuffer::default();
+        tail.push(b"\x1b[1CDo you want to proceed?");
+        assert_eq!(tail.detection_tail(), " Do you want to proceed?");
+    }
+
+    #[test]
+    fn cursor_horizontal_absolute_sequences_become_the_spaces_they_visually_are() {
+        // Captured verbatim (mid-word color codes trimmed) from a real
+        // Claude Code permission dialog (#385): ink right-pads each word to
+        // a precomputed column with CSI n G (Cursor Horizontal Absolute)
+        // instead of writing literal spaces. Dropping those escapes (the
+        // old behavior, which only handled the unrelated Cursor Forward
+        // form) glued the phrase into "Doyouwanttoproceed?", which no
+        // longer matched classify()'s "Do you want to proceed?" pattern —
+        // the actual cause of panes getting stuck instead of turning
+        // Blocked.
+        let mut tail = TailBuffer::default();
+        tail.push(b"\x1b[1CDo\x1b[5Gyou\x1b[9Gwant\x1b[14Gto\x1b[17Gproceed?");
+        assert_eq!(tail.detection_tail(), " Do you want to proceed?");
+        assert_eq!(
+            classify("claude", &tail.detection_tail()),
+            PaneState::Blocked
+        );
     }
 
     #[test]
@@ -295,6 +414,25 @@ mod tests {
     }
 
     #[test]
+    fn uses_claude_sparkle_spinner_not_braille() {
+        // Real captured spinner frames (#385) — claude never emits the
+        // braille dots, so this only passes once classify() checks the
+        // sparkle glyphs for claude specifically.
+        assert_eq!(
+            classify("claude", "✻ Considering… (10s)"),
+            PaneState::Working
+        );
+        assert_eq!(
+            classify("claude-code", "✳ Percolating…"),
+            PaneState::Working
+        );
+        assert_eq!(
+            classify("claude", "⠋ some other cli's spinner"),
+            PaneState::Idle
+        );
+    }
+
+    #[test]
     fn ignores_claude_dashboard_history_headings() {
         assert_eq!(
             classify("claude", "Working\nCompleted\n3 awaiting input"),
@@ -313,13 +451,13 @@ mod tests {
         let mut tracker = DetectionTracker::new("codex".to_string());
         let ready = started + Duration::from_secs(3);
         assert_eq!(
-            tracker.observe("esc to interrupt", 1, ready),
+            tracker.observe("esc to interrupt", ready),
             Some(PaneState::Working)
         );
-        assert_eq!(tracker.observe("esc to interrupt", 1, ready), None);
-        assert_eq!(tracker.observe("esc to interrupt", 1, ready), None);
+        assert_eq!(tracker.observe("esc to interrupt", ready), None);
+        assert_eq!(tracker.observe("esc to interrupt", ready), None);
         assert_eq!(
-            tracker.observe("esc to interrupt", 1, ready),
+            tracker.observe("esc to interrupt", ready),
             Some(PaneState::Idle)
         );
     }
@@ -330,10 +468,10 @@ mod tests {
         let mut tracker = DetectionTracker::new("codex".to_string());
         let ready = started + Duration::from_secs(3);
         assert_eq!(
-            tracker.observe("Allow command?", 1, ready),
+            tracker.observe("Allow command?", ready),
             Some(PaneState::Blocked)
         );
-        assert_eq!(tracker.observe("Allow command?", 1, ready), None);
+        assert_eq!(tracker.observe("Allow command?", ready), None);
         assert_eq!(tracker.state(), PaneState::Blocked);
     }
 
@@ -341,7 +479,66 @@ mod tests {
     fn startup_grace_keeps_new_panes_unknown() {
         let started = Instant::now();
         let mut tracker = DetectionTracker::new("gemini".to_string());
-        assert_eq!(tracker.observe("Thinking", 1, started), None);
+        assert_eq!(tracker.observe("Thinking", started), None);
         assert_eq!(tracker.state(), PaneState::Unknown);
+    }
+
+    #[test]
+    fn changing_text_keeps_resetting_the_idle_debounce() {
+        // A live token/elapsed-time counter changes the tail every tick
+        // while genuinely still working (e.g. "esc to interrupt (12s)" ->
+        // "... (13s)"). Each such change must keep resetting the 3-tick
+        // debounce, the same way a truly static byte stream would — the
+        // debounce keys off the derived text, not a raw "did any PTY byte
+        // arrive" counter, which could never go quiet on its own once a
+        // zero-width escape (e.g. cursor blink) starts firing every tick
+        // regardless of real activity (#385).
+        let started = Instant::now();
+        let mut tracker = DetectionTracker::new("codex".to_string());
+        let ready = started + Duration::from_secs(3);
+        assert_eq!(
+            tracker.observe("esc to interrupt (1s)", ready),
+            Some(PaneState::Working)
+        );
+        assert_eq!(tracker.observe("esc to interrupt (2s)", ready), None);
+        assert_eq!(tracker.observe("esc to interrupt (3s)", ready), None);
+        // Still changing on what would have been the 3rd quiet tick — stays
+        // Working, doesn't debounce yet.
+        assert_eq!(tracker.observe("esc to interrupt (4s)", ready), None);
+        assert_eq!(tracker.state(), PaneState::Working);
+        // Now it goes genuinely quiet — 3 fresh identical ticks required.
+        assert_eq!(tracker.observe("esc to interrupt (4s)", ready), None);
+        assert_eq!(tracker.observe("esc to interrupt (4s)", ready), None);
+        assert_eq!(
+            tracker.observe("esc to interrupt (4s)", ready),
+            Some(PaneState::Idle)
+        );
+    }
+
+    #[test]
+    fn idle_does_not_bounce_back_to_working_on_a_stale_frozen_spinner() {
+        // Captured live from a real pane (#385): a synchronized-output
+        // redraw stalled mid-animation, so the tail stayed byte-for-byte
+        // identical for many ticks in a row while still containing a
+        // spinner glyph from the moment it froze. Once Working correctly
+        // debounces down to Idle, re-running classify() on that same
+        // still-spinner-containing static tail flipped it right back to
+        // Working — which then re-debounced to Idle after another 3 ticks,
+        // forever. A static tail must hold whatever state it's already in
+        // (other than Working, which debounces toward Idle) rather than
+        // being reclassified from scratch.
+        let started = Instant::now();
+        let mut tracker = DetectionTracker::new("claude".to_string());
+        let ready = started + Duration::from_secs(3);
+        let frozen = "✻ Baked for 50s · 1 monitor still running";
+        assert_eq!(tracker.observe(frozen, ready), Some(PaneState::Working));
+        assert_eq!(tracker.observe(frozen, ready), None);
+        assert_eq!(tracker.observe(frozen, ready), None);
+        assert_eq!(tracker.observe(frozen, ready), Some(PaneState::Idle));
+        // The bug: this next call used to flip straight back to Working.
+        for _ in 0..10 {
+            assert_eq!(tracker.observe(frozen, ready), None);
+            assert_eq!(tracker.state(), PaneState::Idle);
+        }
     }
 }

--- a/app/src-tauri/src/agent_state.rs
+++ b/app/src-tauri/src/agent_state.rs
@@ -1,22 +1,166 @@
 use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
 
 pub const TAIL_CAPACITY: usize = 8 * 1024;
 pub const DETECTION_INTERVAL: std::time::Duration = std::time::Duration::from_millis(400);
+const STARTUP_GRACE: Duration = Duration::from_secs(2);
+const IDLE_CONFIRMATIONS: u8 = 3;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PaneState {
+    Idle,
+    Working,
+    Blocked,
+    Unknown,
+}
+
+pub struct DetectionTracker {
+    agent_type: String,
+    state: PaneState,
+    created_at: Instant,
+    idle_confirmations: u8,
+    last_output_seq: Option<u64>,
+}
+
+impl DetectionTracker {
+    pub fn new(agent_type: String) -> Self {
+        Self {
+            agent_type,
+            state: PaneState::Unknown,
+            created_at: Instant::now(),
+            idle_confirmations: 0,
+            last_output_seq: None,
+        }
+    }
+
+    pub fn state(&self) -> PaneState {
+        self.state
+    }
+
+    pub fn observe(&mut self, tail: &str, output_seq: u64, now: Instant) -> Option<PaneState> {
+        if now.saturating_duration_since(self.created_at) < STARTUP_GRACE {
+            return None;
+        }
+
+        let output_changed = self.last_output_seq != Some(output_seq);
+        self.last_output_seq = Some(output_seq);
+        let candidate = if !output_changed && self.state == PaneState::Working {
+            PaneState::Idle
+        } else if !output_changed && self.state == PaneState::Blocked {
+            PaneState::Blocked
+        } else {
+            classify(&self.agent_type, tail)
+        };
+        let next = match (self.state, candidate) {
+            (_, PaneState::Blocked) => {
+                self.idle_confirmations = 0;
+                PaneState::Blocked
+            }
+            (_, PaneState::Working) => {
+                self.idle_confirmations = 0;
+                PaneState::Working
+            }
+            (PaneState::Working, PaneState::Idle) => {
+                self.idle_confirmations = self.idle_confirmations.saturating_add(1);
+                if self.idle_confirmations < IDLE_CONFIRMATIONS {
+                    PaneState::Working
+                } else {
+                    self.idle_confirmations = 0;
+                    PaneState::Idle
+                }
+            }
+            (_, next) => {
+                self.idle_confirmations = 0;
+                next
+            }
+        };
+
+        if next == self.state {
+            None
+        } else {
+            self.state = next;
+            Some(next)
+        }
+    }
+}
+
+pub fn classify(agent_type: &str, tail: &str) -> PaneState {
+    if !matches!(agent_type, "claude-code" | "claude" | "codex" | "gemini") {
+        return PaneState::Unknown;
+    }
+
+    const COMMON_BLOCKED: &[&str] = &[
+        "Do you want to proceed?",
+        "Allow this action?",
+        "waiting for approval",
+        "Waiting for approval",
+        "Enter to confirm",
+        "(y/n)",
+        "[y/N]",
+        "[Y/n]",
+    ];
+    const SPINNERS: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+    const CODEX_BLOCKED: &[&str] = &[
+        "Allow command?",
+        "Do you trust the contents of this directory?",
+        "Press enter to continue",
+        "enter to submit answer",
+    ];
+    const GEMINI_BLOCKED: &[&str] = &[
+        "Do you trust the files in this folder?",
+        "(Use Enter to select)",
+    ];
+
+    let blocked_patterns = match agent_type {
+        "codex" => CODEX_BLOCKED,
+        "gemini" => GEMINI_BLOCKED,
+        _ => &[],
+    };
+    let working_patterns: &[&str] = match agent_type {
+        "gemini" => &["Thinking", "esc to cancel"],
+        _ => &["esc to interrupt", "Esc to interrupt"],
+    };
+
+    if COMMON_BLOCKED
+        .iter()
+        .chain(blocked_patterns.iter())
+        .any(|pattern| tail.contains(pattern))
+    {
+        PaneState::Blocked
+    } else if working_patterns
+        .iter()
+        .chain(SPINNERS.iter())
+        .any(|pattern| tail.contains(pattern))
+    {
+        PaneState::Working
+    } else {
+        PaneState::Idle
+    }
+}
 
 pub struct TailBuffer {
     bytes: VecDeque<u8>,
+    output_seq: u64,
 }
 
 impl Default for TailBuffer {
     fn default() -> Self {
         Self {
             bytes: VecDeque::with_capacity(TAIL_CAPACITY),
+            output_seq: 0,
         }
     }
 }
 
 impl TailBuffer {
     pub fn push(&mut self, input: &[u8]) {
+        if input.is_empty() {
+            return;
+        }
+        self.output_seq = self.output_seq.wrapping_add(1);
         let overflow = self
             .bytes
             .len()
@@ -35,6 +179,10 @@ impl TailBuffer {
         let text = strip_ansi(&String::from_utf8_lossy(&raw));
         let lines: Vec<&str> = text.lines().collect();
         lines[lines.len().saturating_sub(20)..].join("\n")
+    }
+
+    pub fn snapshot(&self) -> (String, u64) {
+        (self.detection_tail(), self.output_seq)
     }
 }
 
@@ -74,7 +222,9 @@ fn strip_ansi(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{TailBuffer, TAIL_CAPACITY};
+    use std::time::{Duration, Instant};
+
+    use super::{classify, DetectionTracker, PaneState, TailBuffer, TAIL_CAPACITY};
 
     #[test]
     fn tail_is_bounded_to_capacity() {
@@ -95,5 +245,87 @@ mod tests {
         assert!(!snapshot.contains('\u{1b}'));
         assert!(snapshot.starts_with("line-5"));
         assert!(snapshot.ends_with("line-24"));
+    }
+
+    #[test]
+    fn detection_tail_strips_bel_and_st_terminated_osc_sequences() {
+        let mut tail = TailBuffer::default();
+        tail.push(b"before\x1b]0;title\x07middle\x1b]9;progress\x1b\\after");
+        assert_eq!(tail.detection_tail(), "beforemiddleafter");
+    }
+
+    #[test]
+    fn blocked_patterns_take_priority_over_working_noise() {
+        assert_eq!(
+            classify("codex", "Thinking\nAllow command?"),
+            PaneState::Blocked
+        );
+    }
+
+    #[test]
+    fn uses_agent_specific_blocked_patterns() {
+        assert_eq!(
+            classify("gemini", "Do you trust the files in this folder?"),
+            PaneState::Blocked
+        );
+        assert_eq!(
+            classify("codex", "Press enter to continue"),
+            PaneState::Blocked
+        );
+        assert_eq!(
+            classify("claude", "Press enter to continue"),
+            PaneState::Idle
+        );
+    }
+
+    #[test]
+    fn ignores_claude_dashboard_history_headings() {
+        assert_eq!(
+            classify("claude", "Working\nCompleted\n3 awaiting input"),
+            PaneState::Idle
+        );
+    }
+
+    #[test]
+    fn unsupported_agents_remain_unknown() {
+        assert_eq!(classify("grok", "Thinking"), PaneState::Unknown);
+    }
+
+    #[test]
+    fn working_to_idle_requires_three_confirmations() {
+        let started = Instant::now();
+        let mut tracker = DetectionTracker::new("codex".to_string());
+        let ready = started + Duration::from_secs(3);
+        assert_eq!(
+            tracker.observe("esc to interrupt", 1, ready),
+            Some(PaneState::Working)
+        );
+        assert_eq!(tracker.observe("esc to interrupt", 1, ready), None);
+        assert_eq!(tracker.observe("esc to interrupt", 1, ready), None);
+        assert_eq!(
+            tracker.observe("esc to interrupt", 1, ready),
+            Some(PaneState::Idle)
+        );
+    }
+
+    #[test]
+    fn blocked_state_stays_sticky_while_output_is_quiet() {
+        let started = Instant::now();
+        let mut tracker = DetectionTracker::new("codex".to_string());
+        let ready = started + Duration::from_secs(3);
+        assert_eq!(
+            tracker.observe("Allow command?", 1, ready),
+            Some(PaneState::Blocked)
+        );
+        assert_eq!(tracker.observe("Allow command?", 1, ready), None);
+        assert_eq!(tracker.state(), PaneState::Blocked);
+    }
+
+    #[test]
+    fn startup_grace_keeps_new_panes_unknown() {
+        let started = Instant::now();
+        let mut tracker = DetectionTracker::new("gemini".to_string());
+        assert_eq!(tracker.observe("Thinking", 1, started), None);
+        assert_eq!(tracker.state(), PaneState::Unknown);
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod agmsg;
+mod agent_state;
 mod menu_i18n;
 mod pty;
 
@@ -576,6 +577,7 @@ pub fn run() {
             }
             // Start the agmsg DB watcher so the team room updates live.
             agmsg::start_watcher(app.handle().clone());
+            app.state::<PtyManager>().start_detection_tick();
             // Quiet startup check — only surfaces a dialog when an update is
             // actually available (see check_for_updates's user_initiated flag).
             let app_handle = app.handle().clone();

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -577,7 +577,7 @@ pub fn run() {
             }
             // Start the agmsg DB watcher so the team room updates live.
             agmsg::start_watcher(app.handle().clone());
-            app.state::<PtyManager>().start_detection_tick();
+            app.state::<PtyManager>().start_detection_tick(app.handle().clone());
             // Quiet startup check — only surfaces a dialog when an update is
             // actually available (see check_for_updates's user_initiated flag).
             let app_handle = app.handle().clone();
@@ -592,6 +592,7 @@ pub fn run() {
             pty::pty_resize,
             pty::pty_kill,
             pty::pty_inject,
+            pty::agent_state,
             agmsg::agmsg_is_installed,
             agmsg::agmsg_install,
             agmsg::agmsg_core_version_status,

--- a/app/src-tauri/src/pty.rs
+++ b/app/src-tauri/src/pty.rs
@@ -29,7 +29,7 @@ use portable_pty::{CommandBuilder, MasterPty, PtySize};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 
-use crate::agent_state::{TailBuffer, DETECTION_INTERVAL};
+use crate::agent_state::{DetectionTracker, PaneState, TailBuffer, DETECTION_INTERVAL};
 
 /// One live PTY-backed agent terminal.
 struct PtySession {
@@ -39,6 +39,7 @@ struct PtySession {
     /// (and let its SessionEnd hook release the agmsg actas lock).
     pid: Option<u32>,
     tail: Arc<Mutex<TailBuffer>>,
+    detection: Arc<Mutex<DetectionTracker>>,
 }
 
 /// All live sessions, keyed by a frontend-chosen id (e.g. "claude-1").
@@ -49,21 +50,33 @@ pub struct PtyManager {
 }
 
 impl PtyManager {
-    pub fn start_detection_tick(&self) {
+    pub fn start_detection_tick(&self, app: AppHandle) {
         let sessions = Arc::clone(&self.sessions);
         thread::spawn(move || loop {
             thread::sleep(DETECTION_INTERVAL);
-            let tails: Vec<Arc<Mutex<TailBuffer>>> = sessions
+            let snapshots: Vec<(String, Arc<Mutex<TailBuffer>>, Arc<Mutex<DetectionTracker>>)> = sessions
                 .lock()
                 .unwrap()
-                .values()
-                .map(|session| Arc::clone(&session.tail))
+                .iter()
+                .map(|(id, session)| {
+                    (id.clone(), Arc::clone(&session.tail), Arc::clone(&session.detection))
+                })
                 .collect();
-            for tail in tails {
-                let _ = tail.lock().unwrap().detection_tail();
+            let now = std::time::Instant::now();
+            for (id, tail, detection) in snapshots {
+                let (tail, output_seq) = tail.lock().unwrap().snapshot();
+                if let Some(state) = detection.lock().unwrap().observe(&tail, output_seq, now) {
+                    let _ = app.emit("agent-state", AgentStateEvent { id, state });
+                }
             }
         });
     }
+}
+
+#[derive(Clone, Serialize)]
+struct AgentStateEvent {
+    id: String,
+    state: PaneState,
 }
 
 #[derive(Clone, Serialize)]
@@ -192,6 +205,12 @@ pub fn pty_spawn(
     let mut reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
     let tail = Arc::new(Mutex::new(TailBuffer::default()));
+    let agent_type = std::path::Path::new(&cmd)
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or(&cmd)
+        .to_ascii_lowercase();
+    let detection = Arc::new(Mutex::new(DetectionTracker::new(agent_type)));
 
     // Reader thread: stream output to the webview.
     {
@@ -219,9 +238,17 @@ pub fn pty_spawn(
 
     manager.sessions.lock().unwrap().insert(
         id,
-        PtySession { master: pair.master, writer, pid, tail },
+        PtySession { master: pair.master, writer, pid, tail, detection },
     );
     Ok(())
+}
+
+#[tauri::command]
+pub fn agent_state(manager: State<'_, PtyManager>, id: String) -> Result<PaneState, String> {
+    let sessions = manager.sessions.lock().unwrap();
+    let session = sessions.get(&id).ok_or("no such pty session")?;
+    let state = session.detection.lock().unwrap().state();
+    Ok(state)
 }
 
 /// Forward keystrokes/data from xterm.js into the PTY.

--- a/app/src-tauri/src/pty.rs
+++ b/app/src-tauri/src/pty.rs
@@ -64,8 +64,8 @@ impl PtyManager {
                 .collect();
             let now = std::time::Instant::now();
             for (id, tail, detection) in snapshots {
-                let (tail, output_seq) = tail.lock().unwrap().snapshot();
-                if let Some(state) = detection.lock().unwrap().observe(&tail, output_seq, now) {
+                let tail = tail.lock().unwrap().detection_tail();
+                if let Some(state) = detection.lock().unwrap().observe(&tail, now) {
                     let _ = app.emit("agent-state", AgentStateEvent { id, state });
                 }
             }

--- a/app/src-tauri/src/pty.rs
+++ b/app/src-tauri/src/pty.rs
@@ -29,6 +29,8 @@ use portable_pty::{CommandBuilder, MasterPty, PtySize};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 
+use crate::agent_state::{TailBuffer, DETECTION_INTERVAL};
+
 /// One live PTY-backed agent terminal.
 struct PtySession {
     master: Box<dyn MasterPty + Send>,
@@ -36,6 +38,7 @@ struct PtySession {
     /// Child process id, so closing a pane can actually terminate the agent
     /// (and let its SessionEnd hook release the agmsg actas lock).
     pid: Option<u32>,
+    tail: Arc<Mutex<TailBuffer>>,
 }
 
 /// All live sessions, keyed by a frontend-chosen id (e.g. "claude-1").
@@ -43,6 +46,24 @@ struct PtySession {
 #[derive(Default)]
 pub struct PtyManager {
     sessions: Arc<Mutex<HashMap<String, PtySession>>>,
+}
+
+impl PtyManager {
+    pub fn start_detection_tick(&self) {
+        let sessions = Arc::clone(&self.sessions);
+        thread::spawn(move || loop {
+            thread::sleep(DETECTION_INTERVAL);
+            let tails: Vec<Arc<Mutex<TailBuffer>>> = sessions
+                .lock()
+                .unwrap()
+                .values()
+                .map(|session| Arc::clone(&session.tail))
+                .collect();
+            for tail in tails {
+                let _ = tail.lock().unwrap().detection_tail();
+            }
+        });
+    }
 }
 
 #[derive(Clone, Serialize)]
@@ -170,17 +191,20 @@ pub fn pty_spawn(
 
     let mut reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
+    let tail = Arc::new(Mutex::new(TailBuffer::default()));
 
     // Reader thread: stream output to the webview.
     {
         let app = app.clone();
         let id = id.clone();
+        let reader_tail = Arc::clone(&tail);
         thread::spawn(move || {
             let mut buf = [0u8; 8192];
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) => break,
                     Ok(n) => {
+                        reader_tail.lock().unwrap().push(&buf[..n]);
                         let b64 = base64::engine::general_purpose::STANDARD.encode(&buf[..n]);
                         let _ = app.emit("pty-output", OutputEvent { id: id.clone(), b64 });
                     }
@@ -193,7 +217,10 @@ pub fn pty_spawn(
         });
     }
 
-    manager.sessions.lock().unwrap().insert(id, PtySession { master: pair.master, writer, pid });
+    manager.sessions.lock().unwrap().insert(
+        id,
+        PtySession { master: pair.master, writer, pid, tail },
+    );
     Ok(())
 }
 

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -631,20 +631,32 @@ body.resizing-row {
   padding: 3px 6px;
 }
 .team-status-row {
-  height: 16px;
+  height: 20px;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
+  gap: 6px;
+  width: 100%;
+  padding: 0 4px;
   background: none;
   border: none;
   border-radius: 3px;
   cursor: pointer;
+  color: inherit;
+  font-size: 11px;
+  text-align: left;
 }
 .team-status-row:hover,
 .team-status-row.active {
   background: var(--panel-2);
 }
+.team-status-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .team-status-dot {
+  flex: 0 0 auto;
   width: 7px;
   height: 7px;
   border-radius: 50%;
@@ -662,6 +674,11 @@ body.resizing-row {
   padding: 2px;
   border: 1px solid var(--border);
   border-radius: 4px;
+}
+.collapsed-team-status .team-status-row {
+  justify-content: center;
+  gap: 0;
+  padding: 0;
 }
 .language-switcher {
   font-size: 11px;

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -624,6 +624,45 @@ body.resizing-row {
 .sidebar-head select {
   width: 100%;
 }
+.team-status-rail {
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid var(--border);
+  padding: 3px 6px;
+}
+.team-status-row {
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+}
+.team-status-row:hover,
+.team-status-row.active {
+  background: var(--panel-2);
+}
+.team-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+.team-status-dot.status-blocked { background: #f7768e; }
+.team-status-dot.status-working {
+  background: #e0af68;
+  animation: agent-status-pulse 1.2s ease-in-out infinite;
+}
+.team-status-dot.status-done { background: #2ac3de; }
+.team-status-dot.status-idle { background: var(--green); }
+.collapsed-team-status {
+  width: 28px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
 .language-switcher {
   font-size: 11px;
 }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -667,7 +667,6 @@ body.resizing-row {
   background: #e0af68;
   animation: agent-status-pulse 1.2s ease-in-out infinite;
 }
-.team-status-dot.status-done { background: #2ac3de; }
 .team-status-dot.status-idle { background: var(--green); }
 .collapsed-team-status {
   width: 28px;
@@ -764,8 +763,7 @@ body.resizing-row {
   background: #e0af68;
   animation: agent-status-pulse 1.2s ease-in-out infinite;
 }
-.agent-status-dot.status-done { background: #2ac3de; }
-.agent-status-dot.status-idle { display: none; }
+.agent-status-dot.status-idle { background: var(--green); }
 
 @keyframes agent-status-pulse {
   50% { opacity: 0.35; transform: scale(0.8); }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -663,10 +663,7 @@ body.resizing-row {
   background: var(--muted);
 }
 .team-status-dot.status-blocked { background: #f7768e; }
-.team-status-dot.status-working {
-  background: #e0af68;
-  animation: agent-status-pulse 1.2s ease-in-out infinite;
-}
+.team-status-dot.status-working { background: #e0af68; }
 .team-status-dot.status-idle { background: var(--green); }
 .collapsed-team-status {
   width: 28px;
@@ -728,6 +725,14 @@ body.resizing-row {
   cursor: pointer;
   margin-left: 4px;
 }
+.member-check-slot {
+  flex-shrink: 0;
+  width: 13px;
+  margin-left: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 .member {
   flex: 1;
   min-width: 0;
@@ -753,7 +758,6 @@ body.resizing-row {
   display: inline-block;
   width: 7px;
   height: 7px;
-  margin-left: 6px;
   border-radius: 50%;
   background: var(--muted);
   vertical-align: middle;

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -694,15 +694,25 @@ body.resizing-row {
 .member-name {
   font-weight: 600;
 }
-/* Green dot marks a member that already has a live pane. */
-.running-dot {
+.agent-status-dot {
   display: inline-block;
   width: 7px;
   height: 7px;
   margin-left: 6px;
   border-radius: 50%;
-  background: var(--green);
+  background: var(--muted);
   vertical-align: middle;
+}
+.agent-status-dot.status-blocked { background: #f7768e; }
+.agent-status-dot.status-working {
+  background: #e0af68;
+  animation: agent-status-pulse 1.2s ease-in-out infinite;
+}
+.agent-status-dot.status-done { background: #2ac3de; }
+.agent-status-dot.status-idle { display: none; }
+
+@keyframes agent-status-pulse {
+  50% { opacity: 0.35; transform: scale(0.8); }
 }
 .member-types {
   font-size: 11px;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,6 +14,12 @@ import {
 } from "lucide-react";
 import { TerminalPane } from "./TerminalPane";
 import {
+  applyStateChange,
+  displayPaneStatus,
+  type PaneStatusMap,
+  type RawState,
+} from "./agentStatus";
+import {
   AgentModal,
   AppUserModal,
   ConfirmModal,
@@ -146,6 +152,7 @@ export default function App() {
   const [members, setMembers] = useState<Member[]>([]);
   const [messages, setMessages] = useState<Message[]>([]);
   const [panes, setPanes] = useState<Pane[]>([]);
+  const [paneStatus, setPaneStatus] = useState<PaneStatusMap>({});
   const [windows, setWindows] = useState<Window[]>([]);
   const [active, setActive] = useState<string>("room");
   const [target, setTarget] = useState<string>("");
@@ -298,6 +305,33 @@ export default function App() {
   panesRef.current = panes;
   const windowsRef = useRef<Window[]>([]);
   windowsRef.current = windows;
+  const activeRef = useRef(active);
+  activeRef.current = active;
+  const focusedPaneRef = useRef<string | null>(null);
+
+  const paneIsFocused = useCallback((paneId: string) => {
+    const owner = windowsRef.current.find((window) => leaves(window.root).includes(paneId));
+    return focusedPaneRef.current === paneId && owner?.id === activeRef.current;
+  }, []);
+
+  const applyAgentState = useCallback(
+    (paneId: string, state: RawState) => {
+      setPaneStatus((current) =>
+        applyStateChange(current, paneId, state, paneIsFocused(paneId), Date.now()),
+      );
+    },
+    [paneIsFocused],
+  );
+
+  const focusPane = useCallback((paneId: string) => {
+    focusedPaneRef.current = paneId;
+    setPaneStatus((current) => {
+      const status = current[paneId];
+      return status
+        ? applyStateChange(current, paneId, status.state, true, Date.now())
+        : current;
+    });
+  }, []);
 
   // The app user = the member registered with the agmsg-app type (one per team).
   const appUserMember = members.find((m) => m.types.includes(APP_USER_TYPE));
@@ -501,6 +535,24 @@ export default function App() {
     });
     return () => void p.then((u) => u());
   }, [team, cmdName]);
+
+  useEffect(() => {
+    const stateListener = listen<{ id: string; state: RawState }>("agent-state", (event) => {
+      applyAgentState(event.payload.id, event.payload.state);
+    });
+    const exitListener = listen<{ id: string }>("pty-exit", (event) => {
+      setPaneStatus((current) => {
+        if (!(event.payload.id in current)) return current;
+        const next = { ...current };
+        delete next[event.payload.id];
+        return next;
+      });
+    });
+    return () => {
+      void stateListener.then((unlisten) => unlisten());
+      void exitListener.then((unlisten) => unlisten());
+    };
+  }, [applyAgentState]);
 
   // Load-more-on-scroll-up: fetch the page older than the currently-oldest
   // loaded message and prepend it, restoring the scroll position afterward
@@ -1269,46 +1321,62 @@ export default function App() {
                 )}
               </div>
               <ul className="members">
-                {others.map((m) => (
-                  <li
-                    key={m.name}
-                    className="member-row"
-                    onContextMenu={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      closeAllMenus();
-                      setMemberMenu({ member: m, x: e.clientX, y: e.clientY });
-                    }}
-                  >
-                    {active === "room" && (
-                      <input
-                        type="checkbox"
-                        className="member-check"
-                        title={t("sidebar.member.checkboxTitle")}
-                        checked={!deselected.has(m.name)}
-                        onChange={() => toggleMember(m.name)}
-                        onClick={(e) => e.stopPropagation()}
-                      />
-                    )}
-                    <button
-                      className="member"
-                      onClick={() => spawnMember(m)}
-                      title={
-                        panes.some((p) => p.label === m.name)
-                          ? t("sidebar.member.titleRunning")
-                          : t("sidebar.member.titleSpawn")
-                      }
+                {others.map((m) => {
+                  const pane = panes.find(
+                    (candidate) =>
+                      candidate.label === m.name &&
+                      windows.some(
+                        (window) =>
+                          window.team === team && leaves(window.root).includes(candidate.id),
+                      ),
+                  );
+                  const status = pane ? displayPaneStatus(paneStatus[pane.id]) : null;
+                  return (
+                    <li
+                      key={m.name}
+                      className="member-row"
+                      onContextMenu={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        closeAllMenus();
+                        setMemberMenu({ member: m, x: e.clientX, y: e.clientY });
+                      }}
                     >
-                      <span className="member-name">
-                        {m.name}
-                        {panes.some((p) => p.label === m.name) && <span className="running-dot" />}
-                      </span>
-                      <span className="member-types">
-                        {m.types.join(", ") || t("sidebar.member.noTypes")}
-                      </span>
-                    </button>
-                  </li>
-                ))}
+                      {active === "room" && (
+                        <input
+                          type="checkbox"
+                          className="member-check"
+                          title={t("sidebar.member.checkboxTitle")}
+                          checked={!deselected.has(m.name)}
+                          onChange={() => toggleMember(m.name)}
+                          onClick={(e) => e.stopPropagation()}
+                        />
+                      )}
+                      <button
+                        className="member"
+                        onClick={() => spawnMember(m)}
+                        title={
+                          pane
+                            ? t("sidebar.member.titleRunning")
+                            : t("sidebar.member.titleSpawn")
+                        }
+                      >
+                        <span className="member-name">
+                          {m.name}
+                          {status && (
+                            <span
+                              className={`agent-status-dot status-${status}`}
+                              title={status}
+                            />
+                          )}
+                        </span>
+                        <span className="member-types">
+                          {m.types.join(", ") || t("sidebar.member.noTypes")}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
                 {others.length === 0 && (
                   <li className="empty">{t("sidebar.member.emptyState")}</li>
                 )}
@@ -1512,6 +1580,7 @@ export default function App() {
                     width: `${rect.width}%`,
                     height: `${rect.height}%`,
                   }}
+                  onFocusCapture={() => focusPane(p.id)}
                   onDragOver={(e) => {
                     // Gate on dataTransfer.types, NOT React state: dragover
                     // fires on whatever element is under the cursor, whose
@@ -1630,7 +1699,13 @@ export default function App() {
                       ×
                     </button>
                   </div>
-                  <TerminalPane id={p.id} cmd={p.cmd} args={p.args} cwd={p.cwd} />
+                  <TerminalPane
+                    id={p.id}
+                    cmd={p.cmd}
+                    args={p.args}
+                    cwd={p.cwd}
+                    onAgentState={applyAgentState}
+                  />
                 </div>
               );
             })}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1349,7 +1349,7 @@ export default function App() {
                         setMemberMenu({ member: m, x: e.clientX, y: e.clientY });
                       }}
                     >
-                      {active === "room" && (
+                      {active === "room" ? (
                         <input
                           type="checkbox"
                           className="member-check"
@@ -1358,6 +1358,10 @@ export default function App() {
                           onChange={() => toggleMember(m.name)}
                           onClick={(e) => e.stopPropagation()}
                         />
+                      ) : (
+                        <span className="member-check-slot">
+                          {status && <span className={`agent-status-dot status-${status}`} title={status} />}
+                        </span>
                       )}
                       <button
                         className="member"
@@ -1368,15 +1372,7 @@ export default function App() {
                             : t("sidebar.member.titleSpawn")
                         }
                       >
-                        <span className="member-name">
-                          {m.name}
-                          {status && (
-                            <span
-                              className={`agent-status-dot status-${status}`}
-                              title={status}
-                            />
-                          )}
-                        </span>
+                        <span className="member-name">{m.name}</span>
                         <span className="member-types">
                           {m.types.join(", ") || t("sidebar.member.noTypes")}
                         </span>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -13,13 +13,7 @@ import {
   Users,
 } from "lucide-react";
 import { TerminalPane } from "./TerminalPane";
-import {
-  aggregateTeamStatus,
-  applyStateChange,
-  displayPaneStatus,
-  type PaneStatusMap,
-  type RawState,
-} from "./agentStatus";
+import { aggregateTeamStatus, applyStateChange, type PaneStatusMap, type RawState } from "./agentStatus";
 import {
   AgentModal,
   AppUserModal,
@@ -306,32 +300,8 @@ export default function App() {
   panesRef.current = panes;
   const windowsRef = useRef<Window[]>([]);
   windowsRef.current = windows;
-  const activeRef = useRef(active);
-  activeRef.current = active;
-  const focusedPaneRef = useRef<string | null>(null);
-
-  const paneIsFocused = useCallback((paneId: string) => {
-    const owner = windowsRef.current.find((window) => leaves(window.root).includes(paneId));
-    return focusedPaneRef.current === paneId && owner?.id === activeRef.current;
-  }, []);
-
-  const applyAgentState = useCallback(
-    (paneId: string, state: RawState) => {
-      setPaneStatus((current) =>
-        applyStateChange(current, paneId, state, paneIsFocused(paneId), Date.now()),
-      );
-    },
-    [paneIsFocused],
-  );
-
-  const focusPane = useCallback((paneId: string) => {
-    focusedPaneRef.current = paneId;
-    setPaneStatus((current) => {
-      const status = current[paneId];
-      return status
-        ? applyStateChange(current, paneId, status.state, true, Date.now())
-        : current;
-    });
+  const applyAgentState = useCallback((paneId: string, state: RawState) => {
+    setPaneStatus((current) => applyStateChange(current, paneId, state));
   }, []);
 
   // The app user = the member registered with the agmsg-app type (one per team).
@@ -839,14 +809,7 @@ export default function App() {
         const paneIds = windows
           .filter((window) => window.team === teamName)
           .flatMap((window) => leaves(window.root));
-        const statuses = paneIds.map(
-          (paneId) =>
-            paneStatus[paneId] ?? {
-              state: "unknown" as const,
-              seen: true,
-              changedAt: 0,
-            },
-        );
+        const statuses = paneIds.map((paneId) => paneStatus[paneId] ?? { state: "unknown" as const });
         return [teamName, aggregateTeamStatus(statuses)];
       }),
     );
@@ -1374,7 +1337,7 @@ export default function App() {
                           window.team === team && leaves(window.root).includes(candidate.id),
                       ),
                   );
-                  const status = pane ? displayPaneStatus(paneStatus[pane.id]) : null;
+                  const status = pane ? (paneStatus[pane.id]?.state ?? "unknown") : null;
                   return (
                     <li
                       key={m.name}
@@ -1624,7 +1587,6 @@ export default function App() {
                     width: `${rect.width}%`,
                     height: `${rect.height}%`,
                   }}
-                  onFocusCapture={() => focusPane(p.id)}
                   onDragOver={(e) => {
                     // Gate on dataTransfer.types, NOT React state: dragover
                     // fires on whatever element is under the cursor, whose

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { TerminalPane } from "./TerminalPane";
 import {
+  aggregateTeamStatus,
   applyStateChange,
   displayPaneStatus,
   type PaneStatusMap,
@@ -832,6 +833,24 @@ export default function App() {
   // teams' windows stay mounted with their PTYs alive, just not listed
   // here or offered as spawn/move targets.
   const teamWindows = useMemo(() => windows.filter((w) => w.team === team), [windows, team]);
+  const teamStatusByName = useMemo(() => {
+    return Object.fromEntries(
+      teams.map((teamName) => {
+        const paneIds = windows
+          .filter((window) => window.team === teamName)
+          .flatMap((window) => leaves(window.root));
+        const statuses = paneIds.map(
+          (paneId) =>
+            paneStatus[paneId] ?? {
+              state: "unknown" as const,
+              seen: true,
+              changedAt: 0,
+            },
+        );
+        return [teamName, aggregateTeamStatus(statuses)];
+      }),
+    );
+  }, [teams, windows, paneStatus]);
 
   // If Show Team Room gets switched off while it's the active tab, land on
   // whichever pane tab exists instead — the room tab itself is about to
@@ -1243,6 +1262,22 @@ export default function App() {
                 </div>
               )}
 
+              <div className="team-status-rail collapsed-team-status" aria-label="Open pane status">
+                {teams.map((teamName) => {
+                  const status = teamStatusByName[teamName] ?? "unknown";
+                  return (
+                    <button
+                      key={teamName}
+                      className={teamName === team ? "team-status-row active" : "team-status-row"}
+                      title={`${teamName}: ${status} (open panes)`}
+                      onClick={() => setTeam(teamName)}
+                    >
+                      <span className={`team-status-dot status-${status}`} />
+                    </button>
+                  );
+                })}
+              </div>
+
               <div className="rail-spacer" />
 
               {appUser && (
@@ -1309,6 +1344,21 @@ export default function App() {
                     </option>
                   ))}
                 </select>
+              </div>
+              <div className="team-status-rail" aria-label="Open pane status">
+                {teams.map((teamName) => {
+                  const status = teamStatusByName[teamName] ?? "unknown";
+                  return (
+                    <button
+                      key={teamName}
+                      className={teamName === team ? "team-status-row active" : "team-status-row"}
+                      title={`${teamName}: ${status} (open panes)`}
+                      onClick={() => setTeam(teamName)}
+                    >
+                      <span className={`team-status-dot status-${status}`} />
+                    </button>
+                  );
+                })}
               </div>
               <div className="sidebar-title">
                 <span>{t("sidebar.title")}</span>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1337,13 +1337,6 @@ export default function App() {
                   )}
                   </div>
                 </div>
-                <select value={team} onChange={(e) => setTeam(e.target.value)}>
-                  {teams.map((teamName) => (
-                    <option key={teamName} value={teamName}>
-                      {teamName}
-                    </option>
-                  ))}
-                </select>
               </div>
               <div className="team-status-rail" aria-label="Open pane status">
                 {teams.map((teamName) => {
@@ -1356,6 +1349,7 @@ export default function App() {
                       onClick={() => setTeam(teamName)}
                     >
                       <span className={`team-status-dot status-${status}`} />
+                      <span className="team-status-name">{teamName}</span>
                     </button>
                   );
                 })}

--- a/app/src/TerminalPane.tsx
+++ b/app/src/TerminalPane.tsx
@@ -12,6 +12,7 @@ type Props = {
   cmd: string;
   args?: string[];
   cwd?: string;
+  onAgentState?: (id: string, state: "idle" | "working" | "blocked" | "unknown") => void;
 };
 
 function b64ToBytes(b64: string): Uint8Array {
@@ -25,7 +26,7 @@ function b64ToBytes(b64: string): Uint8Array {
  * One embedded agent terminal: an xterm.js view bound to a backend PTY session.
  * Output streams in via `pty-output` events; keystrokes go back via `pty_write`.
  */
-export function TerminalPane({ id, cmd, args = [], cwd }: Props) {
+export function TerminalPane({ id, cmd, args = [], cwd, onAgentState }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
 
@@ -88,7 +89,11 @@ export function TerminalPane({ id, cmd, args = [], cwd }: Props) {
         // wrong. Write the failure straight into the terminal — it's already
         // the visible surface for this pane, no extra UI needed.
         term.write(`\r\n\x1b[91m${t("terminal.failedToStart", { cmd, error: String(err) })}\x1b[0m\r\n`);
+        return;
       }
+      void invoke<"idle" | "working" | "blocked" | "unknown">("agent_state", { id })
+        .then((state) => onAgentState?.(id, state))
+        .catch(() => {});
     })();
 
     // Re-fit whenever the pane's box changes — covers initial layout, switching
@@ -115,7 +120,7 @@ export function TerminalPane({ id, cmd, args = [], cwd }: Props) {
       void invoke("pty_kill", { id });
       term.dispose();
     };
-  }, [id, cmd, cwd]);
+  }, [id, cmd, cwd, onAgentState]);
 
   return <div className="term-pane" ref={ref} />;
 }

--- a/app/src/agentStatus.test.ts
+++ b/app/src/agentStatus.test.ts
@@ -1,42 +1,25 @@
 import { describe, expect, it } from "vitest";
-import {
-  aggregateTeamStatus,
-  applyStateChange,
-  displayPaneStatus,
-  type PaneStatus,
-  type PaneStatusMap,
-} from "./agentStatus";
+import { aggregateTeamStatus, applyStateChange, type PaneStatus, type PaneStatusMap } from "./agentStatus";
 
-const status = (state: PaneStatus["state"], seen = true): PaneStatus => ({
-  state,
-  seen,
-  changedAt: 1,
-});
+const status = (state: PaneStatus["state"]): PaneStatus => ({ state });
 
 describe("applyStateChange", () => {
-  it("marks a background completion unseen", () => {
+  it("sets the new state for a pane", () => {
+    const result = applyStateChange({}, "pane", "working");
+    expect(result.pane).toEqual({ state: "working" });
+  });
+
+  it("returns the same map reference when the state didn't change", () => {
     const initial: PaneStatusMap = { pane: status("working") };
-    const result = applyStateChange(initial, "pane", "idle", false, 2);
-    expect(result.pane).toEqual({ state: "idle", seen: false, changedAt: 2 });
-    expect(displayPaneStatus(result.pane)).toBe("done");
+    const result = applyStateChange(initial, "pane", "working");
+    expect(result).toBe(initial);
   });
 
-  it("marks a focused completion seen", () => {
-    const initial: PaneStatusMap = { pane: status("blocked") };
-    const result = applyStateChange(initial, "pane", "idle", true, 2);
-    expect(result.pane).toEqual({ state: "idle", seen: true, changedAt: 2 });
-  });
-
-  it("marks an existing unseen completion seen when focused", () => {
-    const initial: PaneStatusMap = { pane: status("idle", false) };
-    const result = applyStateChange(initial, "pane", "idle", true, 2);
-    expect(result.pane.seen).toBe(true);
-    expect(result.pane.changedAt).toBe(1);
-  });
-
-  it("does not treat an initial idle state as a completion", () => {
-    const result = applyStateChange({}, "pane", "idle", false, 2);
-    expect(result.pane.seen).toBe(true);
+  it("updates only the given pane", () => {
+    const initial: PaneStatusMap = { a: status("working"), b: status("idle") };
+    const result = applyStateChange(initial, "a", "blocked");
+    expect(result.a).toEqual({ state: "blocked" });
+    expect(result.b).toEqual({ state: "idle" });
   });
 });
 
@@ -46,22 +29,10 @@ describe("aggregateTeamStatus", () => {
   });
 
   it("lets one blocked pane beat every other state", () => {
-    expect(
-      aggregateTeamStatus([
-        status("working"),
-        status("idle", false),
-        status("blocked"),
-      ]),
-    ).toBe("blocked");
+    expect(aggregateTeamStatus([status("working"), status("idle"), status("blocked")])).toBe("blocked");
   });
 
-  it("prioritizes unseen completion over working", () => {
-    expect(aggregateTeamStatus([status("working"), status("idle", false)])).toBe("done");
-  });
-
-  it("prioritizes working over seen idle and unknown", () => {
-    expect(aggregateTeamStatus([status("idle"), status("unknown"), status("working")])).toBe(
-      "working",
-    );
+  it("prioritizes working over idle and unknown", () => {
+    expect(aggregateTeamStatus([status("idle"), status("unknown"), status("working")])).toBe("working");
   });
 });

--- a/app/src/agentStatus.test.ts
+++ b/app/src/agentStatus.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateTeamStatus,
+  applyStateChange,
+  displayPaneStatus,
+  type PaneStatus,
+  type PaneStatusMap,
+} from "./agentStatus";
+
+const status = (state: PaneStatus["state"], seen = true): PaneStatus => ({
+  state,
+  seen,
+  changedAt: 1,
+});
+
+describe("applyStateChange", () => {
+  it("marks a background completion unseen", () => {
+    const initial: PaneStatusMap = { pane: status("working") };
+    const result = applyStateChange(initial, "pane", "idle", false, 2);
+    expect(result.pane).toEqual({ state: "idle", seen: false, changedAt: 2 });
+    expect(displayPaneStatus(result.pane)).toBe("done");
+  });
+
+  it("marks a focused completion seen", () => {
+    const initial: PaneStatusMap = { pane: status("blocked") };
+    const result = applyStateChange(initial, "pane", "idle", true, 2);
+    expect(result.pane).toEqual({ state: "idle", seen: true, changedAt: 2 });
+  });
+
+  it("marks an existing unseen completion seen when focused", () => {
+    const initial: PaneStatusMap = { pane: status("idle", false) };
+    const result = applyStateChange(initial, "pane", "idle", true, 2);
+    expect(result.pane.seen).toBe(true);
+    expect(result.pane.changedAt).toBe(1);
+  });
+
+  it("does not treat an initial idle state as a completion", () => {
+    const result = applyStateChange({}, "pane", "idle", false, 2);
+    expect(result.pane.seen).toBe(true);
+  });
+});
+
+describe("aggregateTeamStatus", () => {
+  it("returns unknown for an empty set", () => {
+    expect(aggregateTeamStatus([])).toBe("unknown");
+  });
+
+  it("lets one blocked pane beat every other state", () => {
+    expect(
+      aggregateTeamStatus([
+        status("working"),
+        status("idle", false),
+        status("blocked"),
+      ]),
+    ).toBe("blocked");
+  });
+
+  it("prioritizes unseen completion over working", () => {
+    expect(aggregateTeamStatus([status("working"), status("idle", false)])).toBe("done");
+  });
+
+  it("prioritizes working over seen idle and unknown", () => {
+    expect(aggregateTeamStatus([status("idle"), status("unknown"), status("working")])).toBe(
+      "working",
+    );
+  });
+});

--- a/app/src/agentStatus.ts
+++ b/app/src/agentStatus.ts
@@ -1,0 +1,48 @@
+export type RawState = "idle" | "working" | "blocked" | "unknown";
+export type DisplayState = RawState | "done";
+export type PaneStatus = { state: RawState; seen: boolean; changedAt: number };
+export type PaneStatusMap = Record<string, PaneStatus>;
+
+export function applyStateChange(
+  map: PaneStatusMap,
+  paneId: string,
+  newState: RawState,
+  isPaneFocused: boolean,
+  now: number,
+): PaneStatusMap {
+  const previous = map[paneId];
+  const completed =
+    (previous?.state === "working" || previous?.state === "blocked") && newState === "idle";
+  const seen = isPaneFocused ? true : completed ? false : (previous?.seen ?? true);
+  const changedAt = previous?.state === newState ? (previous?.changedAt ?? now) : now;
+
+  if (
+    previous &&
+    previous.state === newState &&
+    previous.seen === seen &&
+    previous.changedAt === changedAt
+  ) {
+    return map;
+  }
+
+  return { ...map, [paneId]: { state: newState, seen, changedAt } };
+}
+
+export function displayPaneStatus(status: PaneStatus | undefined): DisplayState {
+  if (!status) return "unknown";
+  return status.state === "idle" && !status.seen ? "done" : status.state;
+}
+
+export function aggregateTeamStatus(statuses: PaneStatus[]): DisplayState {
+  const priority: Record<DisplayState, number> = {
+    blocked: 4,
+    done: 3,
+    working: 2,
+    idle: 1,
+    unknown: 0,
+  };
+  return statuses.reduce<DisplayState>((aggregate, status) => {
+    const candidate = displayPaneStatus(status);
+    return priority[candidate] > priority[aggregate] ? candidate : aggregate;
+  }, "unknown");
+}

--- a/app/src/agentStatus.ts
+++ b/app/src/agentStatus.ts
@@ -1,48 +1,21 @@
 export type RawState = "idle" | "working" | "blocked" | "unknown";
-export type DisplayState = RawState | "done";
-export type PaneStatus = { state: RawState; seen: boolean; changedAt: number };
+export type PaneStatus = { state: RawState };
 export type PaneStatusMap = Record<string, PaneStatus>;
 
-export function applyStateChange(
-  map: PaneStatusMap,
-  paneId: string,
-  newState: RawState,
-  isPaneFocused: boolean,
-  now: number,
-): PaneStatusMap {
-  const previous = map[paneId];
-  const completed =
-    (previous?.state === "working" || previous?.state === "blocked") && newState === "idle";
-  const seen = isPaneFocused ? true : completed ? false : (previous?.seen ?? true);
-  const changedAt = previous?.state === newState ? (previous?.changedAt ?? now) : now;
-
-  if (
-    previous &&
-    previous.state === newState &&
-    previous.seen === seen &&
-    previous.changedAt === changedAt
-  ) {
-    return map;
-  }
-
-  return { ...map, [paneId]: { state: newState, seen, changedAt } };
+export function applyStateChange(map: PaneStatusMap, paneId: string, newState: RawState): PaneStatusMap {
+  if (map[paneId]?.state === newState) return map;
+  return { ...map, [paneId]: { state: newState } };
 }
 
-export function displayPaneStatus(status: PaneStatus | undefined): DisplayState {
-  if (!status) return "unknown";
-  return status.state === "idle" && !status.seen ? "done" : status.state;
-}
-
-export function aggregateTeamStatus(statuses: PaneStatus[]): DisplayState {
-  const priority: Record<DisplayState, number> = {
-    blocked: 4,
-    done: 3,
+export function aggregateTeamStatus(statuses: PaneStatus[]): RawState {
+  const priority: Record<RawState, number> = {
+    blocked: 3,
     working: 2,
     idle: 1,
     unknown: 0,
   };
-  return statuses.reduce<DisplayState>((aggregate, status) => {
-    const candidate = displayPaneStatus(status);
-    return priority[candidate] > priority[aggregate] ? candidate : aggregate;
-  }, "unknown");
+  return statuses.reduce<RawState>(
+    (aggregate, status) => (priority[status.state] > priority[aggregate] ? status.state : aggregate),
+    "unknown",
+  );
 }


### PR DESCRIPTION
Closes #384.

## Summary

(1) Add an 8 KB ANSI-stripped PTY tail side-tap without changing the existing `pty-output` stream.
(2) Detect idle, working, blocked, and unknown states on one shared 400 ms backend tick.
(3) Derive persistent unseen completion ("done") in a pure frontend reducer.
(4) Show per-member status dots and aggregate open-pane status for every team.
(5) Keep team switching and all message/member data scoped to the active team.

## Detection behavior

- New panes remain unknown for two seconds.
- Working becomes idle after three consecutive quiet ticks.
- Blocked remains sticky while output is quiet and clears only when new output classifies as working or idle.
- Events are emitted only when the effective state changes.
- The on-demand `agent_state` command restores frontend state after a mount or reload.
- Unsupported agent types remain unknown.

The quiet-tick check uses a monotonically increasing PTY output sequence. This is necessary because raw terminal tails retain erased spinner text; matching the tail alone could otherwise leave a completed pane working indefinitely.

## Observed patterns

The three supported CLIs were launched in local PTYs.

### Claude Code 2.1.207

Observed:
- workspace trust prompt: `Enter to confirm`
- active turn: `esc to interrupt` plus spinner glyphs
- the no-argument agents dashboard retains historical `Working` and `Completed` headings while idle

The generic word `Working` is intentionally not a matcher because the dashboard heading would produce a permanent false positive.

### Codex 0.144.1

Observed:
- directory trust prompt: `Do you trust the contents of this directory?`
- update/trust confirmation: `Press enter to continue`
- startup/active work: `esc to interrupt` plus braille spinner glyphs

The existing permission chrome `Allow command?` and answer prompt `enter to submit answer` are also included.

### Gemini CLI 0.49.0

Observed:
- folder trust prompt: `Do you trust the files in this folder?`
- authentication choice: `(Use Enter to select)`

The local account was rejected by Gemini Code Assist before an authenticated working turn could run, so Gemini working matching remains limited to `Thinking`, `esc to cancel`, and the shared spinner glyphs. This limitation is explicit rather than claiming an unobserved working path.

## Scope and deviations

- The requested 400 ms tick and 8 KB tail capacity were retained; they were responsive under the local PTY observations.
- The shared timer uses one standard Rust thread instead of adding a Tokio dependency.
- No Cargo dependencies were added.
- PTY spawn, write, inject, and message-delivery behavior is unchanged. Detection only reads a side-tap of the existing output bytes.
- Other teams expose aggregate state for currently open panes only. Their member lists and messages remain inaccessible until that team is selected.

Deferred by design: foreground process-group detection, OSC capture, configurable TOML manifests, closed-pane inference, and sound/toast notifications.

## Tests

- `cargo test` (31 passed)
- `pnpm test` (89 passed)
- `pnpm build`
- `git diff --check origin/main...HEAD`

The Vite build reports the existing large-chunk warning.