### PR TITLE
feat(app): snap pane dividers to terminal cell units, herdr-style gaps

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -3,6 +3,11 @@
   --panel: #11151f;
   --panel-2: #161b27;
   --border: #232a3a;
+  /* One step brighter than --border, specifically for the pane frame
+     (koit: --border alone was too faint to read as a visible box at
+     rest). Its own variable, not a --border change, so the other 27
+     places --border is used elsewhere in the UI stay as-is. */
+  --pane-border: #3a4660;
   --fg: #c5c8c6;
   --muted: #6b7280;
   --accent: #7aa2f7;
@@ -1029,7 +1034,7 @@ body.resizing-row {
   font-size: 11px;
   color: var(--muted);
   background: var(--panel);
-  border: 1px solid var(--border);
+  border: 1px solid var(--pane-border);
   border-bottom: none;
   border-radius: 6px 6px 0 0;
 }
@@ -1123,7 +1128,11 @@ body.resizing-row {
 .pane-divider-h::before {
   content: "";
   position: absolute;
-  background: var(--border);
+  /* Invisible at rest now that the gap itself is a full terminal cell
+     (koit) — a static hairline sitting in the middle of that gap read as
+     a redundant, always-on divider line. Shows only on hover/while
+     actively dragging (below), same as before. */
+  background: transparent;
 }
 .pane-divider-v::before {
   top: 0;
@@ -1139,13 +1148,15 @@ body.resizing-row {
   height: 1px;
   transform: translateY(-50%);
 }
-.pane-divider-v:hover::before {
+.pane-divider-v:hover::before,
+.pane-divider-v.pane-divider-dragging::before {
   left: 0;
   width: 100%;
   transform: none;
   background: var(--accent);
 }
-.pane-divider-h:hover::before {
+.pane-divider-h:hover::before,
+.pane-divider-h.pane-divider-dragging::before {
   top: 0;
   height: 100%;
   transform: none;
@@ -1268,7 +1279,7 @@ body.resizing-row {
   min-height: 0;
   width: 100%;
   height: auto;
-  border: 1px solid var(--border);
+  border: 1px solid var(--pane-border);
   border-top: none;
 }
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -304,6 +304,20 @@ export default function App() {
     setPaneStatus((current) => applyStateChange(current, paneId, state));
   }, []);
 
+  // Cell size in CSS px. The ref is for snapping a divider drag to whole
+  // terminal rows/cols — read once at drag-start, doesn't need a re-render
+  // on every fit. The state twin drives the gap BETWEEN panes below (koit:
+  // should be a full terminal cell per axis, herdr-style, not an arbitrary
+  // fixed px value) — that one has to be real React state since it feeds
+  // rendered CSS. Every pane uses the same fixed font today, so any one of
+  // them reporting is representative of them all.
+  const cellSizeRef = useRef<{ w: number; h: number } | null>(null);
+  const [cellSize, setCellSize] = useState<{ w: number; h: number } | null>(null);
+  const handleCellSize = useCallback((w: number, h: number) => {
+    cellSizeRef.current = { w, h };
+    setCellSize((prev) => (prev && prev.w === w && prev.h === h ? prev : { w, h }));
+  }, []);
+
   // The app user = the member registered with the agmsg-app type (one per team).
   const appUserMember = members.find((m) => m.types.includes(APP_USER_TYPE));
   const appUser = appUserMember?.name ?? "";
@@ -1040,10 +1054,23 @@ export default function App() {
     // own doc).
     const MIN_PANE_PX = 120;
     const cursorClass = axis === "col" ? "resizing-col" : "resizing-row";
+    // Toggled on THIS divider's own element, not document.body — koit: only
+    // the divider actually being dragged should highlight, not every
+    // same-axis divider in the tab (body.resizing-col/row is shared with
+    // the sidebar/chat dividers too, so it can't be reused for this either).
+    const dividerEl = e.currentTarget as HTMLElement;
+    // koit: prefers the divider snapping to whole terminal cells over a
+    // free pixel drag (herdr-inspired, though herdr itself had nothing
+    // reusable here — this is agmsg's own design). Every pane shares the
+    // same fixed font, so one representative cell size (captured by any
+    // TerminalPane's fit) is enough regardless of which panes flank this
+    // specific divider.
+    const cellPx = axis === "col" ? cellSizeRef.current?.w : cellSizeRef.current?.h;
     const onMove = (ev: MouseEvent) => {
       const totalPx = axis === "col" ? parentPx.width : parentPx.height;
       const raw = axis === "col" ? (ev.clientX - parentPx.left) / totalPx : (ev.clientY - parentPx.top) / totalPx;
-      const ratio = clampRatio(raw, MIN_PANE_PX, totalPx);
+      const snapped = cellPx ? (Math.round((raw * totalPx) / cellPx) * cellPx) / totalPx : raw;
+      const ratio = clampRatio(snapped, MIN_PANE_PX, totalPx);
       setWindows((prev) =>
         prev.map((w) => (w.id === windowId ? { ...w, root: updateRatioAtPath(w.root, dragPath, ratio) } : w)),
       );
@@ -1052,9 +1079,11 @@ export default function App() {
       document.removeEventListener("mousemove", onMove);
       document.removeEventListener("mouseup", onUp);
       document.body.classList.remove(cursorClass);
+      dividerEl.classList.remove("pane-divider-dragging");
     };
     document.addEventListener("mousemove", onMove);
     document.addEventListener("mouseup", onUp);
+    dividerEl.classList.add("pane-divider-dragging");
     document.body.classList.add(cursorClass);
   }, []);
 
@@ -1582,6 +1611,17 @@ export default function App() {
                     top: `${rect.top}%`,
                     width: `${rect.width}%`,
                     height: `${rect.height}%`,
+                    // The gap between two adjacent panes is each side's own
+                    // padding added together, so half a cell per side makes
+                    // a full terminal cell of gap at the shared seam
+                    // (koit/herdr: the gap should read as "one cell", not
+                    // an arbitrary fixed px value — falls back to the old
+                    // fixed padding before any pane has fit and reported
+                    // its real cell size).
+                    paddingLeft: cellSize ? cellSize.w / 2 : undefined,
+                    paddingRight: cellSize ? cellSize.w / 2 : undefined,
+                    paddingTop: cellSize ? cellSize.h / 2 : undefined,
+                    paddingBottom: cellSize ? cellSize.h / 2 : undefined,
                   }}
                   onDragOver={(e) => {
                     // Gate on dataTransfer.types, NOT React state: dragover
@@ -1707,29 +1747,32 @@ export default function App() {
                     args={p.args}
                     cwd={p.cwd}
                     onAgentState={applyAgentState}
+                    onCellSize={handleCellSize}
                   />
                 </div>
               );
             })}
 
             {active !== "room" &&
-              activeDividers.map((d) => (
-                <div
-                  key={
-                    d.kind === "single"
-                      ? `single:${d.path.join(".") || "root"}`
-                      : `grid:${d.basePath.join(".") || "root"}:${d.segmentPath.join(".")}`
-                  }
-                  className={d.axis === "col" ? "pane-divider-v" : "pane-divider-h"}
-                  style={{
-                    left: `${d.rect.left}%`,
-                    top: `${d.rect.top}%`,
-                    width: `${d.rect.width}%`,
-                    height: `${d.rect.height}%`,
-                  }}
-                  onMouseDown={(e) => startPaneDividerDrag(e, active, d)}
-                />
-              ))}
+              activeDividers.map((d) => {
+                return (
+                  <div
+                    key={
+                      d.kind === "single"
+                        ? `single:${d.path.join(".") || "root"}`
+                        : `grid:${d.basePath.join(".") || "root"}:${d.segmentPath.join(".")}`
+                    }
+                    className={d.axis === "col" ? "pane-divider-v" : "pane-divider-h"}
+                    style={{
+                      left: `${d.rect.left}%`,
+                      top: `${d.rect.top}%`,
+                      width: `${d.rect.width}%`,
+                      height: `${d.rect.height}%`,
+                    }}
+                    onMouseDown={(e) => startPaneDividerDrag(e, active, d)}
+                  />
+                );
+              })}
           </section>
 
           {showUserChat && chatPaneState === "normal" && (

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -28,6 +28,7 @@ import {
   clampRatio,
   collectDividers,
   computeRects,
+  dividerDragKey,
   insertAsNewLeaf,
   insertBeside,
   leaves,
@@ -317,6 +318,12 @@ export default function App() {
     cellSizeRef.current = { w, h };
     setCellSize((prev) => (prev && prev.w === w && prev.h === h ? prev : { w, h }));
   }, []);
+
+  // Which divider (by dividerDragKey, below) is currently being dragged —
+  // state, not a captured DOM element, so the highlight survives a
+  // grid-segment transpose remounting the divider mid-drag (co1 review,
+  // PR #390).
+  const [draggingDividerKey, setDraggingDividerKey] = useState<string | null>(null);
 
   // The app user = the member registered with the agmsg-app type (one per team).
   const appUserMember = members.find((m) => m.types.includes(APP_USER_TYPE));
@@ -1054,11 +1061,6 @@ export default function App() {
     // own doc).
     const MIN_PANE_PX = 120;
     const cursorClass = axis === "col" ? "resizing-col" : "resizing-row";
-    // Toggled on THIS divider's own element, not document.body — koit: only
-    // the divider actually being dragged should highlight, not every
-    // same-axis divider in the tab (body.resizing-col/row is shared with
-    // the sidebar/chat dividers too, so it can't be reused for this either).
-    const dividerEl = e.currentTarget as HTMLElement;
     // koit: prefers the divider snapping to whole terminal cells over a
     // free pixel drag (herdr-inspired, though herdr itself had nothing
     // reusable here — this is agmsg's own design). Every pane shares the
@@ -1079,11 +1081,15 @@ export default function App() {
       document.removeEventListener("mousemove", onMove);
       document.removeEventListener("mouseup", onUp);
       document.body.classList.remove(cursorClass);
-      dividerEl.classList.remove("pane-divider-dragging");
+      setDraggingDividerKey(null);
     };
     document.addEventListener("mousemove", onMove);
     document.addEventListener("mouseup", onUp);
-    dividerEl.classList.add("pane-divider-dragging");
+    // dragPath.join(".") is this divider's identity on BOTH sides of the
+    // grid-segment transpose queued above (see dividerDragKey's doc) — key
+    // off that, not a captured DOM element, so the highlight survives even
+    // if this transpose swaps in a differently-shaped divider set.
+    setDraggingDividerKey(dragPath.join(".") || "root");
     document.body.classList.add(cursorClass);
   }, []);
 
@@ -1755,6 +1761,7 @@ export default function App() {
 
             {active !== "room" &&
               activeDividers.map((d) => {
+                const isDragging = draggingDividerKey !== null && dividerDragKey(d) === draggingDividerKey;
                 return (
                   <div
                     key={
@@ -1762,7 +1769,12 @@ export default function App() {
                         ? `single:${d.path.join(".") || "root"}`
                         : `grid:${d.basePath.join(".") || "root"}:${d.segmentPath.join(".")}`
                     }
-                    className={d.axis === "col" ? "pane-divider-v" : "pane-divider-h"}
+                    className={[
+                      d.axis === "col" ? "pane-divider-v" : "pane-divider-h",
+                      isDragging && "pane-divider-dragging",
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
                     style={{
                       left: `${d.rect.left}%`,
                       top: `${d.rect.top}%`,

--- a/app/src/TerminalPane.tsx
+++ b/app/src/TerminalPane.tsx
@@ -13,6 +13,9 @@ type Props = {
   args?: string[];
   cwd?: string;
   onAgentState?: (id: string, state: "idle" | "working" | "blocked" | "unknown") => void;
+  /** Reported on every fit — the pane's current cell size in CSS px, so a
+   * divider drag elsewhere can snap to whole terminal rows/cols. */
+  onCellSize?: (widthPx: number, heightPx: number) => void;
 };
 
 function b64ToBytes(b64: string): Uint8Array {
@@ -26,7 +29,7 @@ function b64ToBytes(b64: string): Uint8Array {
  * One embedded agent terminal: an xterm.js view bound to a backend PTY session.
  * Output streams in via `pty-output` events; keystrokes go back via `pty_write`.
  */
-export function TerminalPane({ id, cmd, args = [], cwd, onAgentState }: Props) {
+export function TerminalPane({ id, cmd, args = [], cwd, onAgentState, onCellSize }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
 
@@ -63,6 +66,10 @@ export function TerminalPane({ id, cmd, args = [], cwd, onAgentState }: Props) {
         lastCols = term.cols;
         void invoke("pty_resize", { id, rows: term.rows, cols: term.cols });
       }
+      // Every pane uses the same fixed font today, so any one of them
+      // reporting its cell size is representative of them all — a divider
+      // drag doesn't need to know which specific panes it's between.
+      onCellSize?.(el.offsetWidth / term.cols, el.offsetHeight / term.rows);
     };
 
     const unlisteners: Array<() => void> = [];
@@ -120,7 +127,7 @@ export function TerminalPane({ id, cmd, args = [], cwd, onAgentState }: Props) {
       void invoke("pty_kill", { id });
       term.dispose();
     };
-  }, [id, cmd, cwd, onAgentState]);
+  }, [id, cmd, cwd, onAgentState, onCellSize]);
 
   return <div className="term-pane" ref={ref} />;
 }

--- a/app/src/paneTree.test.ts
+++ b/app/src/paneTree.test.ts
@@ -5,6 +5,7 @@ import {
   clampRatio,
   collectDividers,
   computeRects,
+  dividerDragKey,
   insertAsNewLeaf,
   insertBeside,
   leaves,
@@ -653,5 +654,33 @@ describe("transposeGrid", () => {
     expect(rects.get("3")!.height).toBeCloseTo(20, 6);
     expect(rects.get("2")!.height).toBeCloseTo(50, 6);
     expect(rects.get("4")!.height).toBeCloseTo(50, 6);
+  });
+});
+
+describe("dividerDragKey", () => {
+  it("stays the same across a grid-segment transpose (regression, co1 review PR #390)", () => {
+    // A 3-column aligned grid: transposing a grid-segment divider from one
+    // of these turns the OTHER segments' dividers from "grid-segment" into
+    // "single" (a 2x2 grid stays grid-shaped either way — this needed 3+
+    // columns to reproduce). App.tsx keys its drag-highlight off this
+    // identity precisely because the divider's own DOM node can get
+    // unmounted by that shape change mid-drag.
+    const row = (leftId: string, rest: SplitNode) => split("col", 0.4, leaf(leftId), rest);
+    const tree = split(
+      "row",
+      0.5,
+      row("1", split("col", 0.6, leaf("2"), leaf("3"))),
+      row("4", split("col", 0.6, leaf("5"), leaf("6"))),
+    );
+    const before = collectDividers(tree);
+    const grabbed = before.find((d) => d.kind === "grid-segment")!;
+    expect(grabbed.kind).toBe("grid-segment");
+    const keyBefore = dividerDragKey(grabbed);
+
+    // Mirrors startPaneDividerDrag: transpose at the grabbed divider's own
+    // basePath, exactly as grabbing it does.
+    const transposed = applyAtPath(tree, (grabbed as Extract<DividerInfo, { kind: "grid-segment" }>).basePath, transposeGrid);
+    const after = collectDividers(transposed);
+    expect(after.some((d) => dividerDragKey(d) === keyBefore)).toBe(true);
   });
 });

--- a/app/src/paneTree.ts
+++ b/app/src/paneTree.ts
@@ -207,6 +207,21 @@ export function collectDividers(node: SplitNode, rect: PaneRect = FULL_RECT, pat
   return [...thisSeam, ...collectDividers(node.a, rectA, [...path, "a"]), ...collectDividers(node.b, rectB, [...path, "b"])];
 }
 
+/**
+ * A divider's identity across a grid-segment transpose (co1 review, PR
+ * #390): grabbing a grid-segment divider transposes its aligned grid at
+ * drag-start (see transposeGrid's own doc), and for 3+ segment grids that
+ * changes collectDividers' shape from "grid" divider keys to "single"
+ * ones — a DOM node keyed on the pre-transpose divider gets unmounted
+ * mid-drag. `[...basePath, ...segmentPath]` (or `path` directly for an
+ * already-single divider) stays the correct path to the same split node on
+ * both sides of that transpose, so App.tsx keys its drag-highlight off
+ * this instead of a captured DOM reference.
+ */
+export function dividerDragKey(d: DividerInfo): string {
+  return (d.kind === "single" ? d.path : [...d.basePath, ...d.segmentPath]).join(".") || "root";
+}
+
 function zipPairs(a: SplitNode, b: SplitNode, pairAxis: SplitAxis, pairRatio: number): SplitNode {
   if (a.kind === "leaf" && b.kind === "leaf") {
     return { kind: "split", axis: pairAxis, ratio: pairRatio, a, b };


### PR DESCRIPTION
## Summary
- Divider drags snap to whole terminal columns/rows instead of a free pixel drag (TerminalPane reports its cell size on every fit)
- The gap between panes is now derived from that cell size (herdr-style) instead of a fixed 4px/2px value
- Divider hairline hidden by default, shown only on hover or while that specific divider is being dragged (scoped to the element itself, not the shared `resizing-col`/`resizing-row` body class used by the sidebar/chat dividers)
- Pane frame brightened into its own `--pane-border` variable, separate from the globally-shared `--border`

## Test plan
- [x] `tsc --noEmit` clean
- [x] `pnpm test` (87 tests) green
- [x] Verified live in the running app with koit: divider snap, gap sizing, border brightness, and single-divider drag highlight all confirmed working as intended