### PR TITLE
feat(app): persist UI settings across restarts

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tempfile",
 ]
 
@@ -4097,6 +4098,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.13.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-window-state = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Terminal-embedded core: own agent PTYs (spawn + read + write + inject) and

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -498,6 +498,11 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        // Restores the main window's size/position/maximized state on
+        // launch and saves it on move/resize/close — fully automatic, no
+        // frontend involvement needed (unlike zoom/view-visibility, which
+        // are app-specific state the frontend also reads/writes).
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         // Built in English first — the frontend doesn't get a chance to
         // report its actual language until after the webview loads and
         // i18next resolves it, so set_menu_language rebuilds this shortly

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -97,7 +97,7 @@ type DropPreview = { paneId: string; zone: ReturnType<typeof classifyDrop> };
 type Modal =
   | { kind: "team"; firstRun: boolean }
   | { kind: "agent" }
-  | { kind: "appuser" }
+  | { kind: "appuser"; auto: boolean }
   | { kind: "rename"; current: string }
   | { kind: "leave"; name: string }
   | { kind: "settings" }
@@ -114,6 +114,22 @@ const ROOM_PAGE_SIZE = 30;
 // enough for now; panes always start fresh each launch anyway (they're
 // live PTYs, not something a restart could restore even if we tried).
 const LAST_TEAM_KEY = "agmsg-app-last-team";
+// Persists the two View menu toggles below. See the seeding useEffect for
+// why restoring these pushes INTO Rust (set_team_room_visible/
+// set_user_chat_visible) rather than reading view_visibility unconditionally.
+const SHOW_TEAM_ROOM_KEY = "agmsg-app-show-team-room";
+const SHOW_USER_CHAT_KEY = "agmsg-app-show-user-chat";
+// Persists the sidebar's icon-only-rail collapse toggle.
+const SIDEBAR_COLLAPSED_KEY = "agmsg-app-sidebar-collapsed";
+// Persists the terminal font size (Settings modal). xterm.js default is 15;
+// this app has always hardcoded 12 (a bit denser), so that's the fallback.
+const TERMINAL_FONT_SIZE_KEY = "agmsg-app-terminal-font-size";
+const DEFAULT_TERMINAL_FONT_SIZE = 12;
+// "Don't show this again" for the auto-triggered app-user prompt (see the
+// team-change effect below) — adding an app-user is always reachable from
+// the chat's "Add one" link, so a user who dismisses the auto-prompt once
+// shouldn't be re-asked on every future team switch.
+const SUPPRESS_APPUSER_PROMPT_KEY = "agmsg-app-suppress-appuser-prompt";
 // Custom drag-and-drop MIME type for pane-swap drags (see PANE_DRAG_MIME
 // usages below) — a made-up type, not text/plain, so a stray OS file drag
 // or an unrelated drag elsewhere on the page never accidentally matches a
@@ -159,10 +175,19 @@ export default function App() {
   const [spawnTypes, setSpawnTypes] = useState<AgentType[]>([]);
   const [sidebarWidth, setSidebarWidth] = useState(200);
   const [chatHeight, setChatHeight] = useState(160);
+  // Terminal font size, adjustable from the Settings modal and persisted
+  // across restarts (see TERMINAL_FONT_SIZE_KEY).
+  const [terminalFontSize, setTerminalFontSize] = useState(() => {
+    const stored = Number(localStorage.getItem(TERMINAL_FONT_SIZE_KEY));
+    return stored > 0 ? stored : DEFAULT_TERMINAL_FONT_SIZE;
+  });
   // Collapses the team sidebar to an icon-only rail so panes get more width.
-  // Session-only (no persistence needed) — spawning/messaging a member isn't
-  // offered from the collapsed rail; expand to get back to the full list.
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  // Persisted across restarts (see SIDEBAR_COLLAPSED_KEY) — spawning/
+  // messaging a member isn't offered from the collapsed rail; expand to get
+  // back to the full list.
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(
+    () => localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "true",
+  );
   // Popup the collapsed rail's team-icon button opens — team switching, the
   // one thing the full sidebar's team <select> offers that needs a menu
   // instead of a direct icon action at rail width. Settings is a direct
@@ -381,19 +406,37 @@ export default function App() {
     invoke<string>("agmsg_command_name").then(setCmdName).catch(() => {});
   }, []);
 
-  // Rust holds the only durable copy of these two flags (see view_visibility
-  // in lib.rs) — seed our state from there on mount rather than guessing
-  // `true`. Without this, a webview remount that doesn't restart the Rust
-  // process (Vite HMR during `tauri dev`, or any future webview reload)
-  // would reset these back to `true` while the native menu checkbox and
-  // Rust's own state kept whatever was last set, silently disagreeing.
+  // Rust holds the only durable-within-process copy of these two flags (see
+  // view_visibility in lib.rs) — it exists so a webview remount that doesn't
+  // restart the Rust process (Vite HMR during `tauri dev`, or any future
+  // webview reload) doesn't reset the frontend back to `true` while Rust
+  // (and the native menu checkbox) still hold whatever was last set.
+  // Across a real restart Rust itself always inits to `true`, so on mount we
+  // restore from localStorage first and PUSH that into Rust via
+  // set_team_room_visible/set_user_chat_visible (also resyncs the native
+  // menu checkbox) — falling back to view_visibility only the first time
+  // there's nothing stored yet.
   useEffect(() => {
-    invoke<{ team_room: boolean; user_chat: boolean }>("view_visibility")
-      .then((v) => {
-        setShowTeamRoom(v.team_room);
-        setShowUserChat(v.user_chat);
-      })
-      .catch(() => {});
+    const storedTeamRoom = localStorage.getItem(SHOW_TEAM_ROOM_KEY);
+    const storedUserChat = localStorage.getItem(SHOW_USER_CHAT_KEY);
+    if (storedTeamRoom !== null) {
+      const v = storedTeamRoom === "true";
+      setShowTeamRoom(v);
+      void invoke("set_team_room_visible", { visible: v });
+    }
+    if (storedUserChat !== null) {
+      const v = storedUserChat === "true";
+      setShowUserChat(v);
+      void invoke("set_user_chat_visible", { visible: v });
+    }
+    if (storedTeamRoom === null || storedUserChat === null) {
+      invoke<{ team_room: boolean; user_chat: boolean }>("view_visibility")
+        .then((v) => {
+          if (storedTeamRoom === null) setShowTeamRoom(v.team_room);
+          if (storedUserChat === null) setShowUserChat(v.user_chat);
+        })
+        .catch(() => {});
+    }
   }, []);
 
   // Native "View > Show Team Room" menu checkbox toggles the room tab itself.
@@ -407,6 +450,21 @@ export default function App() {
     const p = listen<boolean>("toggle-user-chat", (e) => setShowUserChat(e.payload));
     return () => void p.then((u) => u());
   }, []);
+
+  // Persist the two View toggles and the sidebar collapse state across
+  // restarts (see their _KEY constants above).
+  useEffect(() => {
+    localStorage.setItem(SHOW_TEAM_ROOM_KEY, String(showTeamRoom));
+  }, [showTeamRoom]);
+  useEffect(() => {
+    localStorage.setItem(SHOW_USER_CHAT_KEY, String(showUserChat));
+  }, [showUserChat]);
+  useEffect(() => {
+    localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(sidebarCollapsed));
+  }, [sidebarCollapsed]);
+  useEffect(() => {
+    localStorage.setItem(TERMINAL_FONT_SIZE_KEY, String(terminalFontSize));
+  }, [terminalFontSize]);
 
   // Spawnable agent types (for the Add-agent type picker). spawnMember
   // re-fetches this itself right before spawning — see there for why.
@@ -488,8 +546,11 @@ export default function App() {
       .catch(console.error);
     loadMembers(team)
       .then((m) => {
-        if (!m.some((x) => x.types.includes(APP_USER_TYPE))) {
-          setModal((cur) => cur ?? { kind: "appuser" });
+        if (
+          !m.some((x) => x.types.includes(APP_USER_TYPE)) &&
+          localStorage.getItem(SUPPRESS_APPUSER_PROMPT_KEY) !== "true"
+        ) {
+          setModal((cur) => cur ?? { kind: "appuser", auto: true });
         }
       })
       .catch(console.error);
@@ -1752,6 +1813,7 @@ export default function App() {
                     cmd={p.cmd}
                     args={p.args}
                     cwd={p.cwd}
+                    fontSize={terminalFontSize}
                     onAgentState={applyAgentState}
                     onCellSize={handleCellSize}
                   />
@@ -1855,7 +1917,7 @@ export default function App() {
                 {!appUser && team && (
                   <div className="empty">
                     {t("chat.emptyState.noUser")}
-                    <button className="link" onClick={() => setModal({ kind: "appuser" })}>
+                    <button className="link" onClick={() => setModal({ kind: "appuser", auto: false })}>
                       {t("chat.emptyState.addOne")}
                     </button>
                   </div>
@@ -1920,7 +1982,18 @@ export default function App() {
         />
       )}
       {modal?.kind === "appuser" && (
-        <AppUserModal onAdd={onAddAppUser} onClose={() => setModal(null)} browseDir={browseDir} />
+        <AppUserModal
+          onAdd={onAddAppUser}
+          onClose={() => {
+            // Dismissing the auto-prompt (vs. the "Add one" link's manual
+            // open) means the user doesn't want to add one right now — an
+            // app-user is always reachable from the chat link, so don't
+            // re-ask on every future team switch (see SUPPRESS_APPUSER_PROMPT_KEY).
+            if (modal.auto) localStorage.setItem(SUPPRESS_APPUSER_PROMPT_KEY, "true");
+            setModal(null);
+          }}
+          browseDir={browseDir}
+        />
       )}
       {modal?.kind === "agent" && (
         <AgentModal
@@ -1944,7 +2017,13 @@ export default function App() {
           onClose={() => setModal(null)}
         />
       )}
-      {modal?.kind === "settings" && <SettingsModal onClose={() => setModal(null)} />}
+      {modal?.kind === "settings" && (
+        <SettingsModal
+          onClose={() => setModal(null)}
+          terminalFontSize={terminalFontSize}
+          onTerminalFontSizeChange={setTerminalFontSize}
+        />
+      )}
       {modal?.kind === "closeWindow" &&
         (() => {
           const win = windows.find((w) => w.id === modal.windowId);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -18,6 +18,8 @@ import {
   AgentModal,
   AppUserModal,
   ConfirmModal,
+  MAX_TERMINAL_FONT_SIZE,
+  MIN_TERMINAL_FONT_SIZE,
   NewTeamModal,
   RenameModal,
   SettingsModal,
@@ -176,10 +178,15 @@ export default function App() {
   const [sidebarWidth, setSidebarWidth] = useState(200);
   const [chatHeight, setChatHeight] = useState(160);
   // Terminal font size, adjustable from the Settings modal and persisted
-  // across restarts (see TERMINAL_FONT_SIZE_KEY).
+  // across restarts (see TERMINAL_FONT_SIZE_KEY). Validated against the same
+  // range the Settings <input> enforces — a stray/corrupted localStorage
+  // value (NaN, Infinity, out of range) would otherwise reach xterm as-is
+  // and persist itself right back on the next write.
   const [terminalFontSize, setTerminalFontSize] = useState(() => {
     const stored = Number(localStorage.getItem(TERMINAL_FONT_SIZE_KEY));
-    return stored > 0 ? stored : DEFAULT_TERMINAL_FONT_SIZE;
+    return Number.isFinite(stored) && stored >= MIN_TERMINAL_FONT_SIZE && stored <= MAX_TERMINAL_FONT_SIZE
+      ? stored
+      : DEFAULT_TERMINAL_FONT_SIZE;
   });
   // Collapses the team sidebar to an icon-only rail so panes get more width.
   // Persisted across restarts (see SIDEBAR_COLLAPSED_KEY) — spawning/
@@ -196,9 +203,23 @@ export default function App() {
   // Toggled from the native "View > Show Team Room" menu item — when off,
   // the room tab itself disappears from the tab bar (not just its
   // content), matching Show User Chat's own toggle just below it.
-  const [showTeamRoom, setShowTeamRoom] = useState(true);
-  // Toggled from the native "View > Show User Chat" menu item.
-  const [showUserChat, setShowUserChat] = useState(true);
+  // Lazily restored from localStorage (see SHOW_TEAM_ROOM_KEY) rather than
+  // always starting `true` and correcting via an effect — the mount-time
+  // seeding effect below still exists, but only to push this already-
+  // correct initial value INTO Rust, not to setState a second time (that
+  // would race the persist effect just below it: a persist effect keyed on
+  // [showTeamRoom] captures the value AS OF THE RENDER IT WAS DECLARED IN,
+  // so if this state started `true` and got corrected by a later setState,
+  // the initial-render persist effect would already have fired and written
+  // the stale `true` back to localStorage before the correction landed).
+  const [showTeamRoom, setShowTeamRoom] = useState(
+    () => localStorage.getItem(SHOW_TEAM_ROOM_KEY) !== "false",
+  );
+  // Toggled from the native "View > Show User Chat" menu item. See
+  // showTeamRoom just above for why this is lazily restored.
+  const [showUserChat, setShowUserChat] = useState(
+    () => localStorage.getItem(SHOW_USER_CHAT_KEY) !== "false",
+  );
   // The app-user chat pane's 3 states (session-only, like sidebarCollapsed):
   // "normal" (today's layout), "minimized" (collapses the history away,
   // leaving just the composer row — the team room becomes the only log,
@@ -406,29 +427,27 @@ export default function App() {
     invoke<string>("agmsg_command_name").then(setCmdName).catch(() => {});
   }, []);
 
-  // Rust holds the only durable-within-process copy of these two flags (see
-  // view_visibility in lib.rs) — it exists so a webview remount that doesn't
-  // restart the Rust process (Vite HMR during `tauri dev`, or any future
-  // webview reload) doesn't reset the frontend back to `true` while Rust
-  // (and the native menu checkbox) still hold whatever was last set.
-  // Across a real restart Rust itself always inits to `true`, so on mount we
-  // restore from localStorage first and PUSH that into Rust via
-  // set_team_room_visible/set_user_chat_visible (also resyncs the native
-  // menu checkbox) — falling back to view_visibility only the first time
-  // there's nothing stored yet.
+  // showTeamRoom/showUserChat are already correctly seeded from localStorage
+  // by their useState initializers above — this effect's only job is to
+  // PUSH that initial value into Rust (set_team_room_visible/
+  // set_user_chat_visible, which also resyncs the native menu checkbox), so
+  // Rust doesn't sit at its own process-default `true` while the frontend
+  // shows something else. No setState here: doing so would re-introduce the
+  // write-then-correct race this replaced (a persist effect below, keyed on
+  // showTeamRoom/showUserChat, would capture the stale initial-render value
+  // and write it back to localStorage before a corrective setState's
+  // re-render could fix it).
+  //
+  // Falls back to Rust's own view_visibility only when localStorage has
+  // nothing stored yet (true first run) — this also covers a webview
+  // remount that doesn't restart the Rust process (Vite HMR during
+  // `tauri dev`), where Rust may hold a value localStorage hasn't caught
+  // up to yet.
   useEffect(() => {
     const storedTeamRoom = localStorage.getItem(SHOW_TEAM_ROOM_KEY);
     const storedUserChat = localStorage.getItem(SHOW_USER_CHAT_KEY);
-    if (storedTeamRoom !== null) {
-      const v = storedTeamRoom === "true";
-      setShowTeamRoom(v);
-      void invoke("set_team_room_visible", { visible: v });
-    }
-    if (storedUserChat !== null) {
-      const v = storedUserChat === "true";
-      setShowUserChat(v);
-      void invoke("set_user_chat_visible", { visible: v });
-    }
+    if (storedTeamRoom !== null) void invoke("set_team_room_visible", { visible: storedTeamRoom === "true" });
+    if (storedUserChat !== null) void invoke("set_user_chat_visible", { visible: storedUserChat === "true" });
     if (storedTeamRoom === null || storedUserChat === null) {
       invoke<{ team_room: boolean; user_chat: boolean }>("view_visibility")
         .then((v) => {

--- a/app/src/TerminalPane.tsx
+++ b/app/src/TerminalPane.tsx
@@ -12,6 +12,7 @@ type Props = {
   cmd: string;
   args?: string[];
   cwd?: string;
+  fontSize?: number;
   onAgentState?: (id: string, state: "idle" | "working" | "blocked" | "unknown") => void;
   /** Reported on every fit — the pane's current cell size in CSS px, so a
    * divider drag elsewhere can snap to whole terminal rows/cols. */
@@ -29,19 +30,29 @@ function b64ToBytes(b64: string): Uint8Array {
  * One embedded agent terminal: an xterm.js view bound to a backend PTY session.
  * Output streams in via `pty-output` events; keystrokes go back via `pty_write`.
  */
-export function TerminalPane({ id, cmd, args = [], cwd, onAgentState, onCellSize }: Props) {
+export function TerminalPane({ id, cmd, args = [], cwd, fontSize = 12, onAgentState, onCellSize }: Props) {
   const ref = useRef<HTMLDivElement>(null);
+  // Live handles to the current terminal/fit addon, for the font-size effect
+  // below to reach — that effect must NOT be a dependency of the main effect
+  // (a fontSize change would otherwise kill and respawn the PTY, losing the
+  // running process).
+  const termRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const idRef = useRef(id);
+  idRef.current = id;
   const { t } = useTranslation();
 
   useEffect(() => {
     let disposed = false;
     const term = new Terminal({
-      fontSize: 12,
+      fontSize,
       fontFamily: "Menlo, Monaco, 'Courier New', monospace",
       cursorBlink: true,
       theme: { background: "#0b0e14", foreground: "#c5c8c6" },
     });
+    termRef.current = term;
     const fit = new FitAddon();
+    fitRef.current = fit;
     term.loadAddon(fit);
     term.open(ref.current!);
 
@@ -126,8 +137,34 @@ export function TerminalPane({ id, cmd, args = [], cwd, onAgentState, onCellSize
       unlisteners.forEach((u) => u());
       void invoke("pty_kill", { id });
       term.dispose();
+      termRef.current = null;
+      fitRef.current = null;
     };
   }, [id, cmd, cwd, onAgentState, onCellSize]);
+
+  // Apply a fontSize change live, without recreating the terminal (which
+  // would kill and respawn the PTY). Skips its very first run — at that
+  // point termRef was *just* created above with this same fontSize value
+  // (passed to the Terminal constructor), so re-fitting would be a no-op
+  // re-resize racing the pty_spawn call still in flight in the effect above.
+  const skipInitialFontSizeEffect = useRef(true);
+  useEffect(() => {
+    if (skipInitialFontSizeEffect.current) {
+      skipInitialFontSizeEffect.current = false;
+      return;
+    }
+    const term = termRef.current;
+    const fit = fitRef.current;
+    const el = ref.current;
+    if (!term || !fit || !el || el.offsetWidth === 0 || el.offsetHeight === 0) return;
+    term.options.fontSize = fontSize;
+    try {
+      fit.fit();
+    } catch {
+      return;
+    }
+    void invoke("pty_resize", { id: idRef.current, rows: term.rows, cols: term.cols });
+  }, [fontSize]);
 
   return <div className="term-pane" ref={ref} />;
 }

--- a/app/src/TerminalPane.tsx
+++ b/app/src/TerminalPane.tsx
@@ -164,7 +164,13 @@ export function TerminalPane({ id, cmd, args = [], cwd, fontSize = 12, onAgentSt
       return;
     }
     void invoke("pty_resize", { id: idRef.current, rows: term.rows, cols: term.cols });
-  }, [fontSize]);
+    // A font size change resizes xterm's internal cell geometry without
+    // resizing the .term-pane container itself, so the ResizeObserver in
+    // the main effect above never fires for it — re-report cell size here,
+    // or divider snap/gap sizing (see onCellSize's doc comment) silently
+    // stays pinned to whatever font was active on last container resize.
+    onCellSize?.(el.offsetWidth / term.cols, el.offsetHeight / term.rows);
+  }, [fontSize, onCellSize]);
 
   return <div className="term-pane" ref={ref} />;
 }

--- a/app/src/i18n/locales/de.json
+++ b/app/src/i18n/locales/de.json
@@ -170,7 +170,10 @@
     "label": "Sprache"
   },
   "settings": {
-    "title": "Einstellungen"
+    "title": "Einstellungen",
+    "terminalFontSize": {
+      "label": "Terminal-Schriftgröße"
+    }
   },
   "nativeMenu": {
     "about": "Über {{name}}",

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -7,7 +7,10 @@
     "projectDirLabel": "Project dir"
   },
   "settings": {
-    "title": "Settings"
+    "title": "Settings",
+    "terminalFontSize": {
+      "label": "Terminal font size"
+    }
   },
   "startupError": {
     "installing": "Installing agmsg…",

--- a/app/src/i18n/locales/es.json
+++ b/app/src/i18n/locales/es.json
@@ -170,7 +170,10 @@
     "label": "Idioma"
   },
   "settings": {
-    "title": "Configuración"
+    "title": "Configuración",
+    "terminalFontSize": {
+      "label": "Tamaño de fuente de la terminal"
+    }
   },
   "nativeMenu": {
     "about": "Acerca de {{name}}",

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -170,7 +170,10 @@
     "label": "Langue"
   },
   "settings": {
-    "title": "Paramètres"
+    "title": "Paramètres",
+    "terminalFontSize": {
+      "label": "Taille de police du terminal"
+    }
   },
   "nativeMenu": {
     "about": "À propos de {{name}}",

--- a/app/src/i18n/locales/ja.json
+++ b/app/src/i18n/locales/ja.json
@@ -170,7 +170,10 @@
     "label": "言語"
   },
   "settings": {
-    "title": "設定"
+    "title": "設定",
+    "terminalFontSize": {
+      "label": "ターミナルのフォントサイズ"
+    }
   },
   "nativeMenu": {
     "about": "{{name}} について",

--- a/app/src/i18n/locales/ko.json
+++ b/app/src/i18n/locales/ko.json
@@ -170,7 +170,10 @@
     "label": "언어"
   },
   "settings": {
-    "title": "설정"
+    "title": "설정",
+    "terminalFontSize": {
+      "label": "터미널 글꼴 크기"
+    }
   },
   "nativeMenu": {
     "about": "{{name}} 정보",

--- a/app/src/i18n/locales/pt-BR.json
+++ b/app/src/i18n/locales/pt-BR.json
@@ -170,7 +170,10 @@
     "label": "Idioma"
   },
   "settings": {
-    "title": "Configurações"
+    "title": "Configurações",
+    "terminalFontSize": {
+      "label": "Tamanho da fonte do terminal"
+    }
   },
   "nativeMenu": {
     "about": "Sobre o {{name}}",

--- a/app/src/i18n/locales/zh-CN.json
+++ b/app/src/i18n/locales/zh-CN.json
@@ -170,7 +170,10 @@
     "label": "语言"
   },
   "settings": {
-    "title": "设置"
+    "title": "设置",
+    "terminalFontSize": {
+      "label": "终端字体大小"
+    }
   },
   "nativeMenu": {
     "about": "关于 {{name}}",

--- a/app/src/i18n/locales/zh-TW.json
+++ b/app/src/i18n/locales/zh-TW.json
@@ -170,7 +170,10 @@
     "label": "語言"
   },
   "settings": {
-    "title": "設定"
+    "title": "設定",
+    "terminalFontSize": {
+      "label": "終端機字型大小"
+    }
   },
   "nativeMenu": {
     "about": "關於 {{name}}",

--- a/app/src/modals.tsx
+++ b/app/src/modals.tsx
@@ -364,8 +364,11 @@ export function ConfirmModal(props: {
   );
 }
 
-const MIN_TERMINAL_FONT_SIZE = 8;
-const MAX_TERMINAL_FONT_SIZE = 24;
+// Exported so App.tsx can validate a localStorage-restored value against the
+// same range this modal's <input> enforces (see terminalFontSize's lazy
+// useState initializer).
+export const MIN_TERMINAL_FONT_SIZE = 8;
+export const MAX_TERMINAL_FONT_SIZE = 24;
 
 export function SettingsModal(props: {
   onClose: () => void;

--- a/app/src/modals.tsx
+++ b/app/src/modals.tsx
@@ -364,10 +364,14 @@ export function ConfirmModal(props: {
   );
 }
 
-// The only setting today is language, so this is a single dropdown rather
-// than a full preferences panel — expand into sections here as more
-// settings show up instead of adding separate modals per setting.
-export function SettingsModal(props: { onClose: () => void }) {
+const MIN_TERMINAL_FONT_SIZE = 8;
+const MAX_TERMINAL_FONT_SIZE = 24;
+
+export function SettingsModal(props: {
+  onClose: () => void;
+  terminalFontSize: number;
+  onTerminalFontSizeChange: (size: number) => void;
+}) {
   const { t, i18n } = useTranslation();
   return (
     <Modal title={t("modal.settings.title")} onClose={props.onClose}>
@@ -383,6 +387,21 @@ export function SettingsModal(props: { onClose: () => void }) {
             </option>
           ))}
         </select>
+      </label>
+      <label>
+        {t("settings.terminalFontSize.label")}
+        <input
+          type="number"
+          min={MIN_TERMINAL_FONT_SIZE}
+          max={MAX_TERMINAL_FONT_SIZE}
+          value={props.terminalFontSize}
+          onChange={(e) => {
+            const n = Number(e.target.value);
+            if (n >= MIN_TERMINAL_FONT_SIZE && n <= MAX_TERMINAL_FONT_SIZE) {
+              props.onTerminalFontSizeChange(n);
+            }
+          }}
+        />
       </label>
       <div className="modal-actions">
         <button type="button" className="primary" onClick={props.onClose}>


### PR DESCRIPTION
## Summary
- Persist Show Team Room / Show User Chat toggles to localStorage; restored values are pushed into Rust on boot (`set_team_room_visible`/`set_user_chat_visible`), which also resyncs the native View menu checkboxes.
- Terminal font size is now adjustable from the Settings modal (was hardcoded to 12) and persisted; applied live to running terminals without killing the PTY.
- Sidebar collapsed state is now persisted (was session-only).
- Window size/position/maximized state is now persisted via `tauri-plugin-window-state` (official Tauri plugin, no prior partial implementation existed).
- Added a "don't show again" suppression for the auto-triggered app-user prompt on team switch — dismissing the auto-prompt sets a flag; the "Add one" chat link is unaffected and always available.
- Currently selected team was already persisted (`LAST_TEAM_KEY`) — no change needed.
- Pane split ratios (paneTree) are deliberately left out of scope for a follow-up, per the task's own note that it's OK to defer if it adds complexity.

## Test plan
- [x] `cargo test` (48 passed) and `pnpm test` (87 passed) — no regressions
- [x] `pnpm exec tsc --noEmit` clean
- [x] `cargo check` clean with the new `tauri-plugin-window-state` dependency
- [ ] Could not do a live `tauri dev` UI smoke test this round — port 1420 was held by another concurrent worktree's dev server (left untouched), and a native Tauri window isn't something this agent can drive/screenshot. Recommend a quick manual check (toggle each setting, restart the app, confirm it stuck) before merge.

Related to koit's request in the same task: this PR also adds the app-user prompt suppression flag.