### PR TITLE
fix(bin): normalise Windows backslash paths before handing to bash/curl

### DIFF
--- a/bin/agmsg.js
+++ b/bin/agmsg.js
@@ -79,6 +79,19 @@ function printHelp() {
   ].join('\n'));
 }
 
+// Normalise a native path to the forward-slash form that bash.exe and
+// curl.exe accept on Windows. bash is an MSYS2 program: Windows gives it a
+// raw command-line string rather than a real argv[], and MSYS's own argv
+// reconstruction treats backslash as an escape character, so a native
+// `C:\Users\...\setup.sh` argument gets corrupted (e.g. `\U`, `\T` are read
+// as escapes) into a path that doesn't exist — "No such file or directory"
+// for a file that's actually there. Forward slashes have no such ambiguity,
+// and both bash and curl accept them on Windows. No-op on POSIX (no
+// backslashes to replace). See #262.
+function toBashPath(p) {
+  return p.replace(/\\/g, '/');
+}
+
 function runInstaller(passthroughArgs) {
   // Fetch the canonical setup.sh to a private tempdir, then exec it directly
   // with bash. This keeps the installer's stdin wired to the parent process's
@@ -92,7 +105,10 @@ function runInstaller(passthroughArgs) {
   const ref = installRef();
   const setupUrl = RAW_BASE + '/' + ref + '/setup.sh';
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agmsg-bootstrap-'));
-  const setupPath = path.join(tmpDir, 'setup.sh');
+  // os.tmpdir()/path.join() return backslash-separated paths on Windows.
+  // fs.rmSync (below) handles that form fine since it's a native Node call;
+  // curl and bash are external processes, so they get the bash-safe form.
+  const setupPath = toBashPath(path.join(tmpDir, 'setup.sh'));
 
   try {
     const fetch = spawnSync('curl', ['-fsSL', '-o', setupPath, setupUrl], { stdio: 'inherit' });
@@ -120,22 +136,30 @@ function runInstaller(passthroughArgs) {
   }
 }
 
-const args = process.argv.slice(2);
+function main() {
+  const args = process.argv.slice(2);
 
-if (args.length === 0 || args[0] === 'install') {
-  // Forward anything after `install` (e.g. `agmsg install --cmd m`) to
-  // setup.sh, which passes "$@" through to install.sh.
-  const passthrough = args[0] === 'install' ? args.slice(1) : args;
-  runInstaller(passthrough);
-} else if (args[0] === '--help' || args[0] === '-h' || args[0] === 'help') {
-  printHelp();
-  process.exit(0);
-} else if (args[0] === '--version' || args[0] === '-v') {
-  process.stdout.write('agmsg bootstrapper ' + readVersion() + '\n');
-  process.stdout.write('canonical project: ' + REPO_URL + '\n');
-  process.exit(0);
-} else {
-  console.error('agmsg: unknown argument: ' + args[0]);
-  console.error('Run `npx agmsg --help` for usage.');
-  process.exit(2);
+  if (args.length === 0 || args[0] === 'install') {
+    // Forward anything after `install` (e.g. `agmsg install --cmd m`) to
+    // setup.sh, which passes "$@" through to install.sh.
+    const passthrough = args[0] === 'install' ? args.slice(1) : args;
+    runInstaller(passthrough);
+  } else if (args[0] === '--help' || args[0] === '-h' || args[0] === 'help') {
+    printHelp();
+    process.exit(0);
+  } else if (args[0] === '--version' || args[0] === '-v') {
+    process.stdout.write('agmsg bootstrapper ' + readVersion() + '\n');
+    process.stdout.write('canonical project: ' + REPO_URL + '\n');
+    process.exit(0);
+  } else {
+    console.error('agmsg: unknown argument: ' + args[0]);
+    console.error('Run `npx agmsg --help` for usage.');
+    process.exit(2);
+  }
 }
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { toBashPath };

--- a/tests/test_bin_agmsg.bats
+++ b/tests/test_bin_agmsg.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+BIN="$BATS_TEST_DIRNAME/../bin/agmsg.js"
+
+@test "bin/agmsg.js: --version exits successfully" {
+  run node "$BIN" --version
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "agmsg bootstrapper" ]]
+}
+
+@test "bin/agmsg.js: --help exits successfully" {
+  run node "$BIN" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "npm bootstrapper for cross-agent messaging" ]]
+}
+
+@test "bin/agmsg.js: toBashPath converts backslashes to forward slashes (#262)" {
+  run node -e 'const { toBashPath } = require(process.argv[1]); const input = String.raw`C:\Users\me\AppData\Local\Temp\agmsg-bootstrap-abc123\setup.sh`; const expected = "C:/Users/me/AppData/Local/Temp/agmsg-bootstrap-abc123/setup.sh"; if (toBashPath(input) !== expected) process.exit(1);' "$BIN"
+  [ "$status" -eq 0 ]
+}
+
+@test "bin/agmsg.js: toBashPath is a no-op on POSIX paths" {
+  run node -e 'const { toBashPath } = require(process.argv[1]); const p = "/tmp/agmsg-bootstrap-abc123/setup.sh"; if (toBashPath(p) !== p) process.exit(1);' "$BIN"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Root-caused and originally proposed by @masa6161 in #262 — carried forward here (fresh implementation from main, credit via Co-authored-by) per the team's convention for stale-but-sound external reports.

Closes #262.

## What

`npx agmsg` fails on Windows: `runInstaller()` in `bin/agmsg.js` builds the setup.sh tempfile path with `os.tmpdir()` + `path.join()`, which returns backslash-separated paths on Windows (e.g. `C:\Users\...\Temp\agmsg-bootstrap-XXXXXX\setup.sh`). That path is passed directly to `spawnSync('bash', [setupPath])`. bash.exe (Git Bash/MSYS2) reconstructs its argv from the raw Windows command-line string using its own backslash-escaping convention, which mangles the path — bash reports `setup.sh: No such file or directory` for a file that's actually there.

The fix adds `toBashPath()`, which normalises backslashes to forward slashes before the path is handed to `curl -o` and `bash` (both external processes on Windows that accept forward-slash paths fine). `fs.rmSync` keeps using the native-separator path since it's an in-process Node call, not affected by this bug. No-op on POSIX (no backslashes to replace).

`bin/agmsg.js` also gained a `require.main === module` guard + `module.exports` so `toBashPath` is unit-testable in isolation, matching the existing pattern in `scripts/drivers/types/codex/codex-bridge.js`'s `toPosixPath`.

## Tests

New `tests/test_bin_agmsg.bats`:
- `--version` / `--help` still exit 0 after the module-guard refactor
- `toBashPath` converts a Windows backslash path to forward slashes
- `toBashPath` is a no-op on an already-POSIX path

Full local run of the new file passes (4/4). Per the changed-files-only convention, the rest of the suite is left to CI.

## Verification

Windows-specific bug; no real-Windows machine in this loop. The reporter (@masa6161) verified the equivalent fix (identical `.replace(/\\/g, '/')` approach) end-to-end on Windows 11 + PowerShell + Git Bash, including a full `node bin/agmsg.js` install run — see the "Verification" section of #262. CI covers the bats matrix on ubuntu/macos; the Windows bats leg is a separate focused job (`tests/test_install.bats`) and doesn't currently include this file, consistent with other JS-logic tests in this repo (e.g. codex-bridge's `toPosixPath` tests).
