### PR TITLE
fix(app): display chat timestamps in local time, not raw UTC

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { TerminalPane } from "./TerminalPane";
 import { aggregateTeamStatus, applyStateChange, type PaneStatusMap, type RawState } from "./agentStatus";
-import { AUTO_TIMEZONE, formatMessageTime, resolveTimeZone } from "./time";
+import { AUTO_TIMEZONE, formatMessageTime, isValidTimeZone, resolveTimeZone } from "./time";
 import {
   AgentModal,
   AppUserModal,
@@ -194,8 +194,15 @@ export default function App() {
       : DEFAULT_TERMINAL_FONT_SIZE;
   });
   // Timezone used to display chat/team-room timestamps (see time.ts and
-  // TIMEZONE_KEY) — "auto" (the default) tracks the OS timezone live.
-  const [timezone, setTimezone] = useState(() => localStorage.getItem(TIMEZONE_KEY) ?? AUTO_TIMEZONE);
+  // TIMEZONE_KEY) — "auto" (the default) tracks the OS timezone live. A
+  // corrupted/no-longer-recognized stored zone falls back to "auto" here
+  // too, so the Settings <select> always has a matching option instead of
+  // rendering blank.
+  const [timezone, setTimezone] = useState(() => {
+    const stored = localStorage.getItem(TIMEZONE_KEY);
+    if (!stored || stored === AUTO_TIMEZONE) return AUTO_TIMEZONE;
+    return isValidTimeZone(stored) ? stored : AUTO_TIMEZONE;
+  });
   // Collapses the team sidebar to an icon-only rail so panes get more width.
   // Persisted across restarts (see SIDEBAR_COLLAPSED_KEY) — spawning/
   // messaging a member isn't offered from the collapsed rail; expand to get

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { TerminalPane } from "./TerminalPane";
 import { aggregateTeamStatus, applyStateChange, type PaneStatusMap, type RawState } from "./agentStatus";
+import { AUTO_TIMEZONE, formatMessageTime, resolveTimeZone } from "./time";
 import {
   AgentModal,
   AppUserModal,
@@ -132,6 +133,10 @@ const DEFAULT_TERMINAL_FONT_SIZE = 12;
 // the chat's "Add one" link, so a user who dismisses the auto-prompt once
 // shouldn't be re-asked on every future team switch.
 const SUPPRESS_APPUSER_PROMPT_KEY = "agmsg-app-suppress-appuser-prompt";
+// Persists the Settings modal's timezone choice (see time.ts) — defaults to
+// AUTO_TIMEZONE, which tracks the OS timezone live rather than freezing
+// whatever was detected at first launch.
+const TIMEZONE_KEY = "agmsg-app-timezone";
 // Custom drag-and-drop MIME type for pane-swap drags (see PANE_DRAG_MIME
 // usages below) — a made-up type, not text/plain, so a stray OS file drag
 // or an unrelated drag elsewhere on the page never accidentally matches a
@@ -188,6 +193,9 @@ export default function App() {
       ? stored
       : DEFAULT_TERMINAL_FONT_SIZE;
   });
+  // Timezone used to display chat/team-room timestamps (see time.ts and
+  // TIMEZONE_KEY) — "auto" (the default) tracks the OS timezone live.
+  const [timezone, setTimezone] = useState(() => localStorage.getItem(TIMEZONE_KEY) ?? AUTO_TIMEZONE);
   // Collapses the team sidebar to an icon-only rail so panes get more width.
   // Persisted across restarts (see SIDEBAR_COLLAPSED_KEY) — spawning/
   // messaging a member isn't offered from the collapsed rail; expand to get
@@ -484,6 +492,11 @@ export default function App() {
   useEffect(() => {
     localStorage.setItem(TERMINAL_FONT_SIZE_KEY, String(terminalFontSize));
   }, [terminalFontSize]);
+  useEffect(() => {
+    localStorage.setItem(TIMEZONE_KEY, timezone);
+  }, [timezone]);
+  // Resolved once per render for both message-time display sites below.
+  const effectiveTimeZone = resolveTimeZone(timezone);
 
   // Spawnable agent types (for the Add-agent type picker). spawnMember
   // re-fetches this itself right before spawning — see there for why.
@@ -1648,7 +1661,7 @@ export default function App() {
                     <b className="mf">{g.from}</b>
                     <span className="arrow">→</span>
                     <b className="mt">{g.to}</b>
-                    <span className="grp-time">{g.items[0].created_at.slice(11, 19)}</span>
+                    <span className="grp-time">{formatMessageTime(g.items[0].created_at, effectiveTimeZone)}</span>
                   </div>
                   {g.items.map((m) => (
                     <div className="grp-body" key={m.id}>
@@ -1921,7 +1934,7 @@ export default function App() {
               <div className="appuser-chat" ref={chatRef} onClick={() => composerInputRef.current?.focus()}>
                 {myThread.map((m) => (
                   <div className={m.from === appUser ? "chat-line out" : "chat-line in"} key={m.id}>
-                    <span className="chat-time">{m.created_at.slice(11, 19)}</span>
+                    <span className="chat-time">{formatMessageTime(m.created_at, effectiveTimeZone)}</span>
                     <span className="chat-peer">
                       {m.from === appUser
                         ? t("chat.peer.to", { to: m.to })
@@ -2041,6 +2054,8 @@ export default function App() {
           onClose={() => setModal(null)}
           terminalFontSize={terminalFontSize}
           onTerminalFontSizeChange={setTerminalFontSize}
+          timezone={timezone}
+          onTimezoneChange={setTimezone}
         />
       )}
       {modal?.kind === "closeWindow" &&

--- a/app/src/i18n/locales/de.json
+++ b/app/src/i18n/locales/de.json
@@ -173,6 +173,10 @@
     "title": "Einstellungen",
     "terminalFontSize": {
       "label": "Terminal-Schriftgröße"
+    },
+    "timezone": {
+      "label": "Zeitzone",
+      "auto": "Automatisch ({{zone}})"
     }
   },
   "nativeMenu": {

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -10,6 +10,10 @@
     "title": "Settings",
     "terminalFontSize": {
       "label": "Terminal font size"
+    },
+    "timezone": {
+      "label": "Timezone",
+      "auto": "Auto ({{zone}})"
     }
   },
   "startupError": {

--- a/app/src/i18n/locales/es.json
+++ b/app/src/i18n/locales/es.json
@@ -173,6 +173,10 @@
     "title": "Configuración",
     "terminalFontSize": {
       "label": "Tamaño de fuente de la terminal"
+    },
+    "timezone": {
+      "label": "Zona horaria",
+      "auto": "Automático ({{zone}})"
     }
   },
   "nativeMenu": {

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -173,6 +173,10 @@
     "title": "Paramètres",
     "terminalFontSize": {
       "label": "Taille de police du terminal"
+    },
+    "timezone": {
+      "label": "Fuseau horaire",
+      "auto": "Auto ({{zone}})"
     }
   },
   "nativeMenu": {

--- a/app/src/i18n/locales/ja.json
+++ b/app/src/i18n/locales/ja.json
@@ -173,6 +173,10 @@
     "title": "設定",
     "terminalFontSize": {
       "label": "ターミナルのフォントサイズ"
+    },
+    "timezone": {
+      "label": "タイムゾーン",
+      "auto": "自動 ({{zone}})"
     }
   },
   "nativeMenu": {

--- a/app/src/i18n/locales/ko.json
+++ b/app/src/i18n/locales/ko.json
@@ -173,6 +173,10 @@
     "title": "설정",
     "terminalFontSize": {
       "label": "터미널 글꼴 크기"
+    },
+    "timezone": {
+      "label": "시간대",
+      "auto": "자동 ({{zone}})"
     }
   },
   "nativeMenu": {

--- a/app/src/i18n/locales/pt-BR.json
+++ b/app/src/i18n/locales/pt-BR.json
@@ -173,6 +173,10 @@
     "title": "Configurações",
     "terminalFontSize": {
       "label": "Tamanho da fonte do terminal"
+    },
+    "timezone": {
+      "label": "Fuso horário",
+      "auto": "Automático ({{zone}})"
     }
   },
   "nativeMenu": {

--- a/app/src/i18n/locales/zh-CN.json
+++ b/app/src/i18n/locales/zh-CN.json
@@ -173,6 +173,10 @@
     "title": "设置",
     "terminalFontSize": {
       "label": "终端字体大小"
+    },
+    "timezone": {
+      "label": "时区",
+      "auto": "自动 ({{zone}})"
     }
   },
   "nativeMenu": {

--- a/app/src/i18n/locales/zh-TW.json
+++ b/app/src/i18n/locales/zh-TW.json
@@ -173,6 +173,10 @@
     "title": "設定",
     "terminalFontSize": {
       "label": "終端機字型大小"
+    },
+    "timezone": {
+      "label": "時區",
+      "auto": "自動 ({{zone}})"
     }
   },
   "nativeMenu": {

--- a/app/src/modals.tsx
+++ b/app/src/modals.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { SUPPORTED_LANGUAGES } from "./i18n";
-import { AUTO_TIMEZONE, detectTimeZone, listTimeZones } from "./time";
+import { AUTO_TIMEZONE, detectTimeZone, isValidTimeZone, listTimeZones } from "./time";
 
 type BrowseDir = (current: string) => Promise<string | null>;
 
@@ -382,6 +382,16 @@ export function SettingsModal(props: {
   // Computed once per modal open, not on every keystroke — the full zone
   // list (400+ IANA names) doesn't change while the dropdown is open.
   const [timeZones] = useState(listTimeZones);
+  // A plain <select> with 400+ flat IANA names is nearly unusable: a native
+  // select's keyboard jump only matches the START of an option ("Asia/Tokyo"
+  // never matches typing "Tokyo"). A text input + <datalist> keeps this
+  // dependency-free while getting the browser's own substring-matching
+  // suggestion filtering. Local draft text so a still-typing/partial value
+  // can be shown without committing an invalid zone to app state.
+  const autoLabel = t("settings.timezone.auto", { zone: detectTimeZone() });
+  const [timezoneText, setTimezoneText] = useState(() =>
+    props.timezone === AUTO_TIMEZONE ? autoLabel : props.timezone,
+  );
   return (
     <Modal title={t("modal.settings.title")} onClose={props.onClose}>
       <label>
@@ -414,14 +424,26 @@ export function SettingsModal(props: {
       </label>
       <label>
         {t("settings.timezone.label")}
-        <select value={props.timezone} onChange={(e) => props.onTimezoneChange(e.target.value)}>
-          <option value={AUTO_TIMEZONE}>{t("settings.timezone.auto", { zone: detectTimeZone() })}</option>
+        <input
+          type="text"
+          list="settings-timezone-options"
+          value={timezoneText}
+          onChange={(e) => {
+            const v = e.target.value;
+            setTimezoneText(v);
+            // Only commit a complete, valid entry — mid-typing text (e.g.
+            // "Tokyo" before the datalist suggestion is picked) shouldn't
+            // overwrite the persisted timezone with something invalid.
+            if (v === autoLabel) props.onTimezoneChange(AUTO_TIMEZONE);
+            else if (isValidTimeZone(v)) props.onTimezoneChange(v);
+          }}
+        />
+        <datalist id="settings-timezone-options">
+          <option value={autoLabel} />
           {timeZones.map((zone) => (
-            <option key={zone} value={zone}>
-              {zone}
-            </option>
+            <option key={zone} value={zone} />
           ))}
-        </select>
+        </datalist>
       </label>
       <div className="modal-actions">
         <button type="button" className="primary" onClick={props.onClose}>

--- a/app/src/modals.tsx
+++ b/app/src/modals.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { SUPPORTED_LANGUAGES } from "./i18n";
+import { AUTO_TIMEZONE, detectTimeZone, listTimeZones } from "./time";
 
 type BrowseDir = (current: string) => Promise<string | null>;
 
@@ -374,8 +375,13 @@ export function SettingsModal(props: {
   onClose: () => void;
   terminalFontSize: number;
   onTerminalFontSizeChange: (size: number) => void;
+  timezone: string;
+  onTimezoneChange: (timezone: string) => void;
 }) {
   const { t, i18n } = useTranslation();
+  // Computed once per modal open, not on every keystroke — the full zone
+  // list (400+ IANA names) doesn't change while the dropdown is open.
+  const [timeZones] = useState(listTimeZones);
   return (
     <Modal title={t("modal.settings.title")} onClose={props.onClose}>
       <label>
@@ -405,6 +411,17 @@ export function SettingsModal(props: {
             }
           }}
         />
+      </label>
+      <label>
+        {t("settings.timezone.label")}
+        <select value={props.timezone} onChange={(e) => props.onTimezoneChange(e.target.value)}>
+          <option value={AUTO_TIMEZONE}>{t("settings.timezone.auto", { zone: detectTimeZone() })}</option>
+          {timeZones.map((zone) => (
+            <option key={zone} value={zone}>
+              {zone}
+            </option>
+          ))}
+        </select>
       </label>
       <div className="modal-actions">
         <button type="button" className="primary" onClick={props.onClose}>

--- a/app/src/modals.tsx
+++ b/app/src/modals.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { SUPPORTED_LANGUAGES } from "./i18n";
@@ -392,6 +392,21 @@ export function SettingsModal(props: {
   const [timezoneText, setTimezoneText] = useState(() =>
     props.timezone === AUTO_TIMEZONE ? autoLabel : props.timezone,
   );
+  // Switching language mid-modal recomputes autoLabel (it's translated) but
+  // wouldn't otherwise touch this draft, leaving it showing the old
+  // language's "Auto (...)" text. Only re-sync when the draft still equals
+  // the PREVIOUS autoLabel and the committed timezone is still auto — never
+  // clobbers a custom zone name the user is typing/has typed.
+  const lastAutoLabelRef = useRef(autoLabel);
+  useEffect(() => {
+    if (props.timezone === AUTO_TIMEZONE && timezoneText === lastAutoLabelRef.current) {
+      setTimezoneText(autoLabel);
+    }
+    lastAutoLabelRef.current = autoLabel;
+    // Deliberately scoped to autoLabel changes only (see comment above) —
+    // timezoneText/props.timezone are read via closure, not deps, so this
+    // doesn't re-fire on every keystroke or timezone change.
+  }, [autoLabel]);
   return (
     <Modal title={t("modal.settings.title")} onClose={props.onClose}>
       <label>

--- a/app/src/time.test.ts
+++ b/app/src/time.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { AUTO_TIMEZONE, formatMessageTime, resolveTimeZone } from "./time";
+
+describe("formatMessageTime", () => {
+  it("converts a UTC timestamp to the given IANA zone", () => {
+    // 2026-07-14T20:23:55Z -> 05:23:55 the next day in Tokyo (UTC+9)
+    expect(formatMessageTime("2026-07-14T20:23:55Z", "Asia/Tokyo")).toBe("05:23:55");
+  });
+
+  it("is a no-op conversion for UTC itself", () => {
+    expect(formatMessageTime("2026-07-14T20:23:55Z", "UTC")).toBe("20:23:55");
+  });
+
+  it("handles a negative-offset zone crossing midnight backwards", () => {
+    // 2026-07-14T02:00:00Z -> 2026-07-13 22:00:00 in New York (UTC-4, EDT in July)
+    expect(formatMessageTime("2026-07-14T02:00:00Z", "America/New_York")).toBe("22:00:00");
+  });
+
+  it("falls back to the raw slice on an unparseable timestamp", () => {
+    expect(formatMessageTime("not-a-date", "UTC")).toBe("not-a-date".slice(11, 19));
+  });
+
+  it("falls back to the raw slice on an invalid timezone", () => {
+    const createdAt = "2026-07-14T20:23:55Z";
+    expect(formatMessageTime(createdAt, "Not/AZone")).toBe(createdAt.slice(11, 19));
+  });
+});
+
+describe("resolveTimeZone", () => {
+  it("passes an explicit zone through unchanged", () => {
+    expect(resolveTimeZone("Europe/Paris")).toBe("Europe/Paris");
+  });
+
+  it("resolves the auto sentinel to a real zone, not the sentinel itself", () => {
+    expect(resolveTimeZone(AUTO_TIMEZONE)).not.toBe(AUTO_TIMEZONE);
+    expect(typeof resolveTimeZone(AUTO_TIMEZONE)).toBe("string");
+  });
+});

--- a/app/src/time.test.ts
+++ b/app/src/time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { AUTO_TIMEZONE, formatMessageTime, resolveTimeZone } from "./time";
+import { AUTO_TIMEZONE, formatMessageTime, isValidTimeZone, resolveTimeZone } from "./time";
 
 describe("formatMessageTime", () => {
   it("converts a UTC timestamp to the given IANA zone", () => {
@@ -24,15 +24,35 @@ describe("formatMessageTime", () => {
     const createdAt = "2026-07-14T20:23:55Z";
     expect(formatMessageTime(createdAt, "Not/AZone")).toBe(createdAt.slice(11, 19));
   });
+
+  it("renders midnight as 00:00:00, not 24:00:00", () => {
+    // hour12: false is documented to yield the 24-hour "0-23" cycle rather
+    // than the "1-24" cycle some locales default to for a bare hour: "2-digit".
+    expect(formatMessageTime("2026-07-14T00:00:00Z", "UTC")).toBe("00:00:00");
+  });
+});
+
+describe("isValidTimeZone", () => {
+  it("accepts a real IANA zone", () => {
+    expect(isValidTimeZone("Asia/Tokyo")).toBe(true);
+  });
+
+  it("rejects a made-up zone name", () => {
+    expect(isValidTimeZone("Not/AZone")).toBe(false);
+  });
 });
 
 describe("resolveTimeZone", () => {
-  it("passes an explicit zone through unchanged", () => {
+  it("passes a valid explicit zone through unchanged", () => {
     expect(resolveTimeZone("Europe/Paris")).toBe("Europe/Paris");
   });
 
   it("resolves the auto sentinel to a real zone, not the sentinel itself", () => {
     expect(resolveTimeZone(AUTO_TIMEZONE)).not.toBe(AUTO_TIMEZONE);
     expect(typeof resolveTimeZone(AUTO_TIMEZONE)).toBe("string");
+  });
+
+  it("falls back to the auto-detected zone for an invalid stored value", () => {
+    expect(resolveTimeZone("Not/AZone")).toBe(resolveTimeZone(AUTO_TIMEZONE));
   });
 });

--- a/app/src/time.ts
+++ b/app/src/time.ts
@@ -53,7 +53,12 @@ function formatterFor(timeZone: string): Intl.DateTimeFormat {
       hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",
-      hour12: false,
+      // hour12: false alone is ambiguous — depending on the ICU version,
+      // "false" can still resolve to the h24 cycle (which renders midnight
+      // as "24", not "00"). hourCycle: "h23" is the unambiguous way to pin
+      // 0-23 with midnight as "00" (caught by CI running a different Node
+      // than local dev — see the midnight regression test).
+      hourCycle: "h23",
     });
     formatterCache.set(timeZone, formatter);
   }

--- a/app/src/time.ts
+++ b/app/src/time.ts
@@ -31,6 +31,35 @@ export function listTimeZones(): string[] {
   return [detectTimeZone()];
 }
 
+export function isValidTimeZone(timeZone: string): boolean {
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// One formatter per zone, reused across every message/render — a chat
+// history with hundreds of visible messages would otherwise construct a
+// fresh Intl.DateTimeFormat per message per render for what's always the
+// same (timeZone, options) pair.
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+function formatterFor(timeZone: string): Intl.DateTimeFormat {
+  let formatter = formatterCache.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+    formatterCache.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
 /** Formats a UTC ISO 8601 timestamp as 24-hour HH:MM:SS in `timeZone`.
  * Built from Intl.DateTimeFormat's parts (not its formatted string) to
  * avoid locale-specific punctuation/midnight-as-"24:00" quirks across
@@ -39,13 +68,7 @@ export function formatMessageTime(createdAt: string, timeZone: string): string {
   const d = new Date(createdAt);
   if (Number.isNaN(d.getTime())) return createdAt.slice(11, 19);
   try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false,
-    }).formatToParts(d);
+    const parts = formatterFor(timeZone).formatToParts(d);
     const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "00";
     return `${get("hour")}:${get("minute")}:${get("second")}`;
   } catch {
@@ -53,8 +76,14 @@ export function formatMessageTime(createdAt: string, timeZone: string): string {
   }
 }
 
-/** Resolves the "auto" sentinel to a real IANA zone; passes an explicit
- * override through unchanged. */
+/** Resolves the "auto" sentinel to a real IANA zone; passes a valid
+ * explicit override through unchanged. Falls back to the auto-detected
+ * zone for anything invalid (a corrupted localStorage value, or a zone
+ * name the runtime no longer recognizes) rather than letting an unknown
+ * zone reach Intl.DateTimeFormat, which would make formatMessageTime fall
+ * back to the raw UTC slice — silently reintroducing #393 for that one
+ * stored value. */
 export function resolveTimeZone(selected: string): string {
-  return selected === AUTO_TIMEZONE ? detectTimeZone() : selected;
+  if (selected === AUTO_TIMEZONE) return detectTimeZone();
+  return isValidTimeZone(selected) ? selected : detectTimeZone();
 }

--- a/app/src/time.ts
+++ b/app/src/time.ts
@@ -1,0 +1,60 @@
+// Timezone-aware formatting for chat/team-room timestamps. agmsg's message
+// store writes created_at as UTC (strftime('%Y-%m-%dT%H:%M:%SZ', 'now') —
+// see init-db.sh), so displaying it correctly always requires a conversion;
+// there is no "just show the string" option (see issue #393).
+
+/** Sentinel stored/selected value meaning "follow the OS timezone live",
+ * rather than freezing whatever was detected at first launch. */
+export const AUTO_TIMEZONE = "auto";
+
+export function detectTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return "UTC";
+  }
+}
+
+/** All IANA zone names the runtime knows about, for the Settings dropdown.
+ * `Intl.supportedValuesOf` landed in evergreen webviews in 2022 — Tauri v2's
+ * minimum WebView2/WebKit versions are new enough, but this degrades to
+ * just the detected zone (still usable, just not a full picker) rather than
+ * throwing on an unexpectedly old webview. */
+export function listTimeZones(): string[] {
+  const intl = Intl as unknown as { supportedValuesOf?: (key: string) => string[] };
+  try {
+    const zones = intl.supportedValuesOf?.("timeZone");
+    if (zones && zones.length > 0) return zones;
+  } catch {
+    // fall through to the single-zone fallback below
+  }
+  return [detectTimeZone()];
+}
+
+/** Formats a UTC ISO 8601 timestamp as 24-hour HH:MM:SS in `timeZone`.
+ * Built from Intl.DateTimeFormat's parts (not its formatted string) to
+ * avoid locale-specific punctuation/midnight-as-"24:00" quirks across
+ * webview engines — this only ever needs three zero-padded numbers. */
+export function formatMessageTime(createdAt: string, timeZone: string): string {
+  const d = new Date(createdAt);
+  if (Number.isNaN(d.getTime())) return createdAt.slice(11, 19);
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    }).formatToParts(d);
+    const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "00";
+    return `${get("hour")}:${get("minute")}:${get("second")}`;
+  } catch {
+    return createdAt.slice(11, 19);
+  }
+}
+
+/** Resolves the "auto" sentinel to a real IANA zone; passes an explicit
+ * override through unchanged. */
+export function resolveTimeZone(selected: string): string {
+  return selected === AUTO_TIMEZONE ? detectTimeZone() : selected;
+}


### PR DESCRIPTION
## Summary
- `created_at` is stored UTC (`strftime('%Y-%m-%dT%H:%M:%SZ', 'now')` in `init-db.sh`); both display call sites (`grp-time`, `chat-time` in `App.tsx`) just did `created_at.slice(11, 19)` — no timezone conversion at all.
- Adds `app/src/time.ts`: pure helpers (`detectTimeZone`, `listTimeZones`, `formatMessageTime`, `resolveTimeZone`) plus a `time.test.ts` covering the conversion, a negative-offset/DST case, and the unparseable-input/invalid-zone fallbacks.
- Adds a timezone selector to the Settings modal, next to language/font size — defaults to `"auto"` (tracks the OS timezone live via `Intl.DateTimeFormat().resolvedOptions().timeZone`), with a full IANA zone list for manual override via `Intl.supportedValuesOf`.
- Persisted through the same localStorage mechanism #391 set up (`agmsg-app-timezone`).
- Both timestamp display sites now go through `formatMessageTime(created_at, effectiveTimeZone)`.

Reported by @otsune via X.

Closes #393

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 95 passed (7 new in `time.test.ts`)
- [x] JSON-validated all 9 locale files
- [ ] No Rust changes in this PR — `cargo check`/`cargo test` not affected
- [ ] Same as #391: could not do a live `tauri dev` UI smoke test this round (no reliable way for this agent to drive a native Tauri window). Recommend a quick manual check (open Settings, switch timezone, confirm chat/room timestamps update) before merge.