### PR TITLE
fix(spawn): convert team config paths for readfile() via agmsg_sql_readfile_path

### DIFF
--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -292,7 +292,8 @@ resolve_team() {
   project_sql_in=$(agmsg_project_sql_in_list "$PROJECT")
   for config_file in "$TEAMS_DIR"/*/config.json; do
     [ -f "$config_file" ] || continue
-    cfg_sql=$(printf '%s' "$config_file" | sed "s/'/''/g")
+    # readfile() needs a native-Windows path — agmsg_sql_readfile_path converts and SQL-escapes it.
+    cfg_sql=$(agmsg_sql_readfile_path "$config_file")
     team_name=$(agmsg_sqlite_mem \
       "SELECT json_extract(CAST(readfile('$cfg_sql') AS TEXT), '\$.name');")
     # Does any agent in this team have a registration for PROJECT (any type)?

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -650,6 +650,17 @@ YAML
   [[ "$output" == *"reviewer"* ]]
 }
 
+@test "spawn: resolve_team reads team configs via agmsg_sql_readfile_path (Windows-native sqlite3 regression)" {
+  # sqlite3.exe (native Windows) cannot readfile() a POSIX-form path: it returns
+  # NULL, the JSON probe yields no rows, and spawn dies with 'no team is
+  # registered' even though join succeeded. The helper cygpath-converts and
+  # SQL-escapes; a bare sed-escape here reintroduces the bug. No portable
+  # runtime probe exists (it needs a native sqlite3 plus a POSIX-form tmpdir),
+  # so assert the source directly.
+  run grep -F 'cfg_sql=$(agmsg_sql_readfile_path "$config_file")' "$SCRIPTS/spawn.sh"
+  [ "$status" -eq 0 ]
+}
+
 @test "spawn: codex boot prompt uses the \$ skill prefix, not / (#283)" {
   # codex invokes a skill with \$<cmd>, not Claude Code's /<cmd>. The boot script
   # must carry \$<cmd> actas, never /<cmd> actas. (%q escapes the space as "\ ",


### PR DESCRIPTION
## Summary

`resolve_team` in `spawn.sh` is the only `readfile()` caller that passes a raw sed-escaped path into SQL. Every other caller (`join.sh`, `whoami.sh`, `identities.sh`, `api.sh`, `resolve-project.sh`) already goes through `agmsg_sql_readfile_path`, which cygpath-converts the path on Windows and SQL-escapes it. This PR aligns `spawn.sh` with them (1 line) and adds a regression test.

## Symptom / minimal reproduction

Environment: Windows, Git Bash, a **native Windows sqlite3.exe first on PATH** (e.g. the WinGet build — `sqlite3 3.53.3`).

A native sqlite3.exe cannot `readfile()` a POSIX-form path (`/tmp/...`, `/c/...`): it returns NULL, the JSON probe yields no rows, and spawn dies with `no team is registered` even though `join.sh` just succeeded:

```bash
$ ./scripts/join.sh myteam alice claude-code "$PWD"
Joined team myteam as alice
$ ./scripts/spawn.sh claude-code bob --project "$PWD"
spawn: no team is registered ...
```

In normal use the bug is masked because registrations usually hold `C:/`-form project paths — but the bats suite runs under a POSIX-form `$TMPDIR`, so on such a machine **every join→spawn test fails** (38 failures for us). With this fix the suite is green again (remaining failures on our machine are unrelated, pre-existing environment issues).

- agmsg version: v1.1.7 (also reproduced on v1.1.6)
- host agent: Claude Code (found while running the test suite; diagnosis cross-checked by a Codex reviewer)

## Change

- `scripts/spawn.sh`: `cfg_sql=$(printf '%s' "$config_file" | sed "s/'/''/g")` → `cfg_sql=$(agmsg_sql_readfile_path "$config_file")` (the variable feeds both queries in the loop, so one line covers both)
- `tests/test_spawn.bats`: source-level regression assert. No portable runtime probe exists — it would need a native sqlite3 plus a POSIX-form tmpdir — so the test pins the helper usage directly, with a comment explaining why.

The single-quote behaviour is preserved: the helper SQL-escapes exactly like the old sed, and `spawn: team resolution survives a single quote in the project path` still passes.

## Tests

```
$ bats tests/test_spawn.bats -f "team"
1..6
ok 1-6 (including the new regression test)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hh8w1h5CJJH77a6N4gwN2
