### PR TITLE
docs(cursor): fix leftover OpenCode references in cursor template

### DIFF
--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -58,7 +58,7 @@ Four possible outputs:
      - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
      - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
        `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> cursor "$(pwd)"`
-     - OpenCode has no Monitor tool, so `monitor` and `both` modes are not offered here.
+     - Cursor CLI has no Monitor tool, so `monitor` and `both` modes are not offered here.
 
   6. Then check inbox for the newly joined team.
 
@@ -106,7 +106,7 @@ If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" cursor` to see whether the role is already registered for this (project, type).
 3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> cursor "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
 4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
-5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (OpenCode has no Monitor tool, so receive still covers all of your registered roles in this project.)"
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Cursor CLI has no Monitor tool, so receive still covers all of your registered roles in this project.)"
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.
@@ -119,7 +119,7 @@ If argument is "mode" (no further args):
 2. Show the output to the user.
 
 If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
-1. Parse the mode. OpenCode supports only `turn` and `off` — reject `monitor` and `both` with: "OpenCode has no Monitor tool; only `turn` or `off` modes are supported."
+1. Parse the mode. Cursor CLI supports only `turn` and `off` — reject `monitor` and `both` with: "Cursor CLI has no Monitor tool; only `turn` or `off` modes are supported."
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> cursor "$(pwd)"`
 
 If argument is "hook on" (legacy alias):


### PR DESCRIPTION
## Summary

The cursor agent-type template still refers to "OpenCode" in three user-facing strings — these are leftovers from the initial copy of `opencode/template.md` when cursor support landed in #189 (`feat/cursor-type`). The delivery-mode constraint they describe (no Monitor tool, only `turn`/`off`) is correct for cursor as declared in `scripts/drivers/types/cursor/type.conf` (`monitor=no`, `delivery_modes=turn off`), but the agent name was never renamed.

This PR renames `OpenCode` → `Cursor CLI` in those three strings, matching the naming convention used by other CLI-only types (e.g. `Copilot CLI` in copilot's template).

## What changes

Three string substitutions in `scripts/drivers/types/cursor/template.md`:

| line | context |
|---|---|
| 61  | delivery-mode picker footnote |
| 109 | `actas` confirmation message |
| 122 | `mode` set rejection message |

No behavior change — pure user-facing string fix.

## Verification

Confirmed against `v1.1.7` tag and `main`:

```console
$ curl -s https://raw.githubusercontent.com/fujibee/agmsg/v1.1.7/scripts/drivers/types/cursor/template.md | grep -n OpenCode
61:     - OpenCode has no Monitor tool, so `monitor` and `both` modes are not offered here.
109:5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (OpenCode has no Monitor tool, so receive still covers all of your registered roles in this project.)"
122:1. Parse the mode. OpenCode supports only `turn` and `off` — reject `monitor` and `both` with: "OpenCode has no Monitor tool; only `turn` or `off` modes are supported."
```

## Follow-up (out of scope for this PR)

While investigating I noticed `scripts/drivers/types/antigravity/template.md` has an analogous copy-paste issue (three strings referring to `Codex` where they should refer to Antigravity). It also appears to conflict with antigravity's `type.conf` which declares `delivery_modes=monitor turn both off`, so the correct fix isn't just a rename — the whole "no Monitor tool" section may not belong there. Happy to file a separate issue if useful.

## Test plan

- [x] `grep -c OpenCode scripts/drivers/types/cursor/template.md` → 0
- [x] `grep -c "Cursor CLI" scripts/drivers/types/cursor/template.md` → 3
- [x] Full-file diff reviewed: only the three intended lines changed