### PR TITLE
perf(app): batch pty-output writes to one term.write() per animation frame

### DIFF
--- a/app/src/TerminalPane.tsx
+++ b/app/src/TerminalPane.tsx
@@ -5,6 +5,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { createWriteBatcher } from "./writeBatcher";
 
 type Props = {
   /** Stable session id; also the key the backend stores the PTY under. */
@@ -92,44 +93,26 @@ export function TerminalPane({ id, cmd, args = [], cwd, fontSize = 12, onAgentSt
     // term.write() resets xterm's cursor blink phase, so writing many
     // times within a single frame is a plausible source of the reported
     // visible flicker/jitter — batching bounds that to once per frame
-    // regardless of how bursty the backend is.
-    let pendingOutput: Uint8Array[] = [];
-    let flushHandle: number | null = null;
-    const flushPendingOutput = () => {
-      flushHandle = null;
-      if (pendingOutput.length === 0) return;
-      const total = pendingOutput.reduce((sum, chunk) => sum + chunk.length, 0);
-      const merged = new Uint8Array(total);
-      let offset = 0;
-      for (const chunk of pendingOutput) {
-        merged.set(chunk, offset);
-        offset += chunk.length;
-      }
-      pendingOutput = [];
-      term.write(merged);
-    };
+    // regardless of how bursty the backend is. See writeBatcher.ts for why
+    // this isn't just a bare requestAnimationFrame (it stalls in a
+    // backgrounded/occluded webview, and agmsg mounts panes while hidden).
+    const writeBatcher = createWriteBatcher({ onFlush: (data) => term.write(data) });
 
     const unlisteners: Array<() => void> = [];
     (async () => {
       // Register listeners BEFORE spawning so no early output is missed.
       unlisteners.push(
         await listen<{ id: string; b64: string }>("pty-output", (e) => {
-          if (e.payload.id !== id) return;
-          pendingOutput.push(b64ToBytes(e.payload.b64));
-          if (flushHandle === null) flushHandle = requestAnimationFrame(flushPendingOutput);
+          if (e.payload.id === id) writeBatcher.push(b64ToBytes(e.payload.b64));
         }),
       );
       unlisteners.push(
         await listen<{ id: string }>("pty-exit", (e) => {
           if (e.payload.id !== id) return;
           // Flush synchronously first — any output still waiting for its
-          // batched animation-frame write must land before the exit
-          // banner, or the banner could render above the process's own
-          // final lines.
-          if (flushHandle !== null) {
-            cancelAnimationFrame(flushHandle);
-            flushPendingOutput();
-          }
+          // batched write must land before the exit banner, or the banner
+          // could render above the process's own final lines.
+          writeBatcher.flushNow();
           term.write(`\r\n\x1b[90m${t("terminal.processExited")}\x1b[0m\r\n`);
         }),
       );
@@ -170,8 +153,7 @@ export function TerminalPane({ id, cmd, args = [], cwd, fontSize = 12, onAgentSt
     return () => {
       disposed = true;
       if (resizeTimer) clearTimeout(resizeTimer);
-      if (flushHandle !== null) cancelAnimationFrame(flushHandle);
-      pendingOutput = [];
+      writeBatcher.dispose();
       ro.disconnect();
       unlisteners.forEach((u) => u());
       void invoke("pty_kill", { id });

--- a/app/src/TerminalPane.tsx
+++ b/app/src/TerminalPane.tsx
@@ -101,22 +101,42 @@ export function TerminalPane({ id, cmd, args = [], cwd, fontSize = 12, onAgentSt
     const unlisteners: Array<() => void> = [];
     (async () => {
       // Register listeners BEFORE spawning so no early output is missed.
-      unlisteners.push(
-        await listen<{ id: string; b64: string }>("pty-output", (e) => {
-          if (e.payload.id === id) writeBatcher.push(b64ToBytes(e.payload.b64));
-        }),
-      );
-      unlisteners.push(
-        await listen<{ id: string }>("pty-exit", (e) => {
-          if (e.payload.id !== id) return;
-          // Flush synchronously first — any output still waiting for its
-          // batched write must land before the exit banner, or the banner
-          // could render above the process's own final lines.
-          writeBatcher.flushNow();
-          term.write(`\r\n\x1b[90m${t("terminal.processExited")}\x1b[0m\r\n`);
-        }),
-      );
-      if (disposed) return;
+      // `listen()` is async — if this effect's cleanup runs while one of
+      // these awaits is still in flight (a fast unmount/remount, or React
+      // re-running the effect), the listener resolves into a component
+      // that's already torn down. Each registration below checks `disposed`
+      // right after its own await and, if already torn down, unregisters
+      // itself immediately instead of joining `unlisteners` — otherwise the
+      // Tauri listener would keep firing this closure's stale term/
+      // writeBatcher forever (a real listener leak), and — before
+      // writeBatcher.dispose() became permanent (see writeBatcher.ts) —
+      // could even resurrect its scheduling after teardown. The `disposed`
+      // check inside each callback body is defense in depth for an event
+      // already queued at the moment unlisten() runs.
+      const unlistenOutput = await listen<{ id: string; b64: string }>("pty-output", (e) => {
+        if (disposed) return;
+        if (e.payload.id === id) writeBatcher.push(b64ToBytes(e.payload.b64));
+      });
+      if (disposed) {
+        unlistenOutput();
+        return;
+      }
+      unlisteners.push(unlistenOutput);
+
+      const unlistenExit = await listen<{ id: string }>("pty-exit", (e) => {
+        if (disposed) return;
+        if (e.payload.id !== id) return;
+        // Flush synchronously first — any output still waiting for its
+        // batched write must land before the exit banner, or the banner
+        // could render above the process's own final lines.
+        writeBatcher.flushNow();
+        term.write(`\r\n\x1b[90m${t("terminal.processExited")}\x1b[0m\r\n`);
+      });
+      if (disposed) {
+        unlistenExit();
+        return;
+      }
+      unlisteners.push(unlistenExit);
       term.onData((data) => void invoke("pty_write", { id, data }));
       fitNow(); // size the PTY to the pane if it's already laid out
       try {

--- a/app/src/TerminalPane.tsx
+++ b/app/src/TerminalPane.tsx
@@ -83,17 +83,54 @@ export function TerminalPane({ id, cmd, args = [], cwd, fontSize = 12, onAgentSt
       onCellSize?.(el.offsetWidth / term.cols, el.offsetHeight / term.rows);
     };
 
+    // Coalesce PTY output into at most one term.write() per animation frame
+    // instead of one per backend event. The Rust reader thread emits an
+    // event per raw PTY read (unbatched, no debounce) — a chatty CLI (issue
+    // #383: Codex's title-escape-driven spinner churns very frequently)
+    // can fire far more of these than the browser can usefully paint
+    // between frames. Unverified hypothesis behind this change: each
+    // term.write() resets xterm's cursor blink phase, so writing many
+    // times within a single frame is a plausible source of the reported
+    // visible flicker/jitter — batching bounds that to once per frame
+    // regardless of how bursty the backend is.
+    let pendingOutput: Uint8Array[] = [];
+    let flushHandle: number | null = null;
+    const flushPendingOutput = () => {
+      flushHandle = null;
+      if (pendingOutput.length === 0) return;
+      const total = pendingOutput.reduce((sum, chunk) => sum + chunk.length, 0);
+      const merged = new Uint8Array(total);
+      let offset = 0;
+      for (const chunk of pendingOutput) {
+        merged.set(chunk, offset);
+        offset += chunk.length;
+      }
+      pendingOutput = [];
+      term.write(merged);
+    };
+
     const unlisteners: Array<() => void> = [];
     (async () => {
       // Register listeners BEFORE spawning so no early output is missed.
       unlisteners.push(
         await listen<{ id: string; b64: string }>("pty-output", (e) => {
-          if (e.payload.id === id) term.write(b64ToBytes(e.payload.b64));
+          if (e.payload.id !== id) return;
+          pendingOutput.push(b64ToBytes(e.payload.b64));
+          if (flushHandle === null) flushHandle = requestAnimationFrame(flushPendingOutput);
         }),
       );
       unlisteners.push(
         await listen<{ id: string }>("pty-exit", (e) => {
-          if (e.payload.id === id) term.write(`\r\n\x1b[90m${t("terminal.processExited")}\x1b[0m\r\n`);
+          if (e.payload.id !== id) return;
+          // Flush synchronously first — any output still waiting for its
+          // batched animation-frame write must land before the exit
+          // banner, or the banner could render above the process's own
+          // final lines.
+          if (flushHandle !== null) {
+            cancelAnimationFrame(flushHandle);
+            flushPendingOutput();
+          }
+          term.write(`\r\n\x1b[90m${t("terminal.processExited")}\x1b[0m\r\n`);
         }),
       );
       if (disposed) return;
@@ -133,6 +170,8 @@ export function TerminalPane({ id, cmd, args = [], cwd, fontSize = 12, onAgentSt
     return () => {
       disposed = true;
       if (resizeTimer) clearTimeout(resizeTimer);
+      if (flushHandle !== null) cancelAnimationFrame(flushHandle);
+      pendingOutput = [];
       ro.disconnect();
       unlisteners.forEach((u) => u());
       void invoke("pty_kill", { id });

--- a/app/src/writeBatcher.test.ts
+++ b/app/src/writeBatcher.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWriteBatcher } from "./writeBatcher";
+
+const bytes = (s: string) => new TextEncoder().encode(s);
+const text = (b: Uint8Array) => new TextDecoder().decode(b);
+
+// Fully manual/injected scheduling — no real timers or requestAnimationFrame
+// — so every test controls exactly which of (frame, timer, byte threshold)
+// fires first, deterministically.
+function fakeSchedulers() {
+  let nextHandle = 1;
+  const frameCallbacks = new Map<number, () => void>();
+  const timerCallbacks = new Map<number, () => void>();
+  return {
+    requestFrame: vi.fn((cb: () => void) => {
+      const h = nextHandle++;
+      frameCallbacks.set(h, cb);
+      return h;
+    }),
+    cancelFrame: vi.fn((h: number) => frameCallbacks.delete(h)),
+    setTimer: vi.fn((cb: () => void, _ms: number) => {
+      const h = nextHandle++;
+      timerCallbacks.set(h, cb);
+      return h as unknown as ReturnType<typeof setTimeout>;
+    }),
+    clearTimer: vi.fn((h: ReturnType<typeof setTimeout>) => timerCallbacks.delete(h as unknown as number)),
+    fireFrame: () => {
+      const [h, cb] = [...frameCallbacks.entries()][0];
+      frameCallbacks.delete(h);
+      cb();
+    },
+    fireTimer: () => {
+      const [h, cb] = [...timerCallbacks.entries()][0];
+      timerCallbacks.delete(h);
+      cb();
+    },
+  };
+}
+
+describe("createWriteBatcher", () => {
+  it("does not flush until the frame callback fires", () => {
+    const s = fakeSchedulers();
+    const onFlush = vi.fn();
+    const batcher = createWriteBatcher({ onFlush, ...s });
+    batcher.push(bytes("hi"));
+    expect(onFlush).not.toHaveBeenCalled();
+    s.fireFrame();
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(text(onFlush.mock.calls[0][0])).toBe("hi");
+  });
+
+  it("flushes via the latency timer if the frame never fires (backgrounded webview)", () => {
+    const s = fakeSchedulers();
+    const onFlush = vi.fn();
+    const batcher = createWriteBatcher({ onFlush, ...s });
+    batcher.push(bytes("bg"));
+    // Simulate a suspended requestAnimationFrame: only the timer fires.
+    s.fireTimer();
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(text(onFlush.mock.calls[0][0])).toBe("bg");
+  });
+
+  it("cancels the timer once the frame fires first", () => {
+    const s = fakeSchedulers();
+    const batcher = createWriteBatcher({ onFlush: vi.fn(), ...s });
+    batcher.push(bytes("x"));
+    s.fireFrame();
+    expect(s.clearTimer).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the frame once the timer fires first", () => {
+    const s = fakeSchedulers();
+    const batcher = createWriteBatcher({ onFlush: vi.fn(), ...s });
+    batcher.push(bytes("x"));
+    s.fireTimer();
+    expect(s.cancelFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes immediately once pending bytes reach the threshold, without waiting for scheduling", () => {
+    const s = fakeSchedulers();
+    const onFlush = vi.fn();
+    const batcher = createWriteBatcher({ onFlush, maxPendingBytes: 5, ...s });
+    batcher.push(bytes("abc")); // 3 bytes, schedules
+    expect(onFlush).not.toHaveBeenCalled();
+    batcher.push(bytes("def")); // total 6 >= 5 -> flush now, cancels the schedule
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(text(onFlush.mock.calls[0][0])).toBe("abcdef");
+    expect(s.cancelFrame).toHaveBeenCalledTimes(1);
+    expect(s.clearTimer).toHaveBeenCalledTimes(1);
+  });
+
+  it("merges multiple pushed chunks in arrival order", () => {
+    const s = fakeSchedulers();
+    const onFlush = vi.fn();
+    const batcher = createWriteBatcher({ onFlush, ...s });
+    batcher.push(bytes("one-"));
+    batcher.push(bytes("two-"));
+    batcher.push(bytes("three"));
+    s.fireFrame();
+    expect(text(onFlush.mock.calls[0][0])).toBe("one-two-three");
+  });
+
+  it("only schedules once across multiple pushes before a flush", () => {
+    const s = fakeSchedulers();
+    const batcher = createWriteBatcher({ onFlush: vi.fn(), ...s });
+    batcher.push(bytes("a"));
+    batcher.push(bytes("b"));
+    batcher.push(bytes("c"));
+    expect(s.requestFrame).toHaveBeenCalledTimes(1);
+    expect(s.setTimer).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose cancels any pending schedule and drops buffered data without flushing", () => {
+    const s = fakeSchedulers();
+    const onFlush = vi.fn();
+    const batcher = createWriteBatcher({ onFlush, ...s });
+    batcher.push(bytes("never written"));
+    batcher.dispose();
+    expect(s.cancelFrame).toHaveBeenCalledTimes(1);
+    expect(s.clearTimer).toHaveBeenCalledTimes(1);
+    expect(onFlush).not.toHaveBeenCalled();
+    // A push after dispose should behave like a fresh batcher, not resurrect
+    // dropped data.
+    batcher.push(bytes("new"));
+    s.fireFrame();
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(text(onFlush.mock.calls[0][0])).toBe("new");
+  });
+
+  it("flushNow flushes and cancels scheduling on demand (e.g. before writing an exit banner)", () => {
+    const s = fakeSchedulers();
+    const onFlush = vi.fn();
+    const batcher = createWriteBatcher({ onFlush, ...s });
+    batcher.push(bytes("last output"));
+    batcher.flushNow();
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(s.cancelFrame).toHaveBeenCalledTimes(1);
+    expect(s.clearTimer).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushNow is a no-op when nothing is pending", () => {
+    const s = fakeSchedulers();
+    const onFlush = vi.fn();
+    const batcher = createWriteBatcher({ onFlush, ...s });
+    batcher.flushNow();
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/writeBatcher.test.ts
+++ b/app/src/writeBatcher.test.ts
@@ -119,12 +119,22 @@ describe("createWriteBatcher", () => {
     expect(s.cancelFrame).toHaveBeenCalledTimes(1);
     expect(s.clearTimer).toHaveBeenCalledTimes(1);
     expect(onFlush).not.toHaveBeenCalled();
-    // A push after dispose should behave like a fresh batcher, not resurrect
-    // dropped data.
-    batcher.push(bytes("new"));
-    s.fireFrame();
-    expect(onFlush).toHaveBeenCalledTimes(1);
-    expect(text(onFlush.mock.calls[0][0])).toBe("new");
+  });
+
+  it("dispose is permanent — a push() arriving after dispose (e.g. a Tauri listener that resolved late, after its owning component already tore down) must not resurrect scheduling or flush", () => {
+    const s = fakeSchedulers();
+    const onFlush = vi.fn();
+    const batcher = createWriteBatcher({ onFlush, ...s });
+    batcher.dispose();
+    s.requestFrame.mockClear();
+    s.setTimer.mockClear();
+    batcher.push(bytes("late arrival"));
+    expect(s.requestFrame).not.toHaveBeenCalled();
+    expect(s.setTimer).not.toHaveBeenCalled();
+    expect(onFlush).not.toHaveBeenCalled();
+    // Even an explicit flushNow() call must stay inert post-dispose.
+    batcher.flushNow();
+    expect(onFlush).not.toHaveBeenCalled();
   });
 
   it("flushNow flushes and cancels scheduling on demand (e.g. before writing an exit banner)", () => {

--- a/app/src/writeBatcher.ts
+++ b/app/src/writeBatcher.ts
@@ -49,6 +49,13 @@ export function createWriteBatcher(options: WriteBatcherOptions): WriteBatcher {
   let pendingBytes = 0;
   let frameHandle: number | null = null;
   let timerHandle: ReturnType<typeof setTimeout> | null = null;
+  // Permanent, not a "reset": once disposed, push/flushNow must stay no-ops
+  // forever. Without this, a push() arriving after teardown (a real race —
+  // see TerminalPane.tsx, where Tauri listener registration is async and
+  // can resolve after the owning effect's cleanup already ran) would
+  // resurrect scheduling and eventually call onFlush again, writing into
+  // whatever the caller tore down (e.g. a disposed xterm instance).
+  let disposed = false;
 
   function cancelScheduled() {
     if (frameHandle !== null) {
@@ -62,6 +69,7 @@ export function createWriteBatcher(options: WriteBatcherOptions): WriteBatcher {
   }
 
   function flushNow() {
+    if (disposed) return;
     cancelScheduled();
     if (pending.length === 0) return;
     const merged = new Uint8Array(pendingBytes);
@@ -76,6 +84,7 @@ export function createWriteBatcher(options: WriteBatcherOptions): WriteBatcher {
   }
 
   function schedule() {
+    if (disposed) return;
     if (frameHandle !== null || timerHandle !== null) return;
     frameHandle = requestFrame(() => {
       frameHandle = null;
@@ -88,6 +97,7 @@ export function createWriteBatcher(options: WriteBatcherOptions): WriteBatcher {
   }
 
   function push(chunk: Uint8Array) {
+    if (disposed) return;
     pending.push(chunk);
     pendingBytes += chunk.length;
     if (pendingBytes >= maxPendingBytes) {
@@ -98,6 +108,7 @@ export function createWriteBatcher(options: WriteBatcherOptions): WriteBatcher {
   }
 
   function dispose() {
+    disposed = true;
     cancelScheduled();
     pending = [];
     pendingBytes = 0;

--- a/app/src/writeBatcher.ts
+++ b/app/src/writeBatcher.ts
@@ -1,0 +1,107 @@
+// Coalesces frequently-arriving byte chunks into a single flush, bounded
+// two ways so it can never stall or grow unbounded (see issue #383's PR for
+// the motivating case — batching term.write() calls per animation frame):
+//
+// - requestAnimationFrame alone is not enough: it throttles to ~1fps or
+//   stops entirely in a backgrounded/occluded webview, and agmsg mounts
+//   panes while hidden (display:none) and can run agents in the background
+//   for long stretches — output would accumulate unbounded until the pane
+//   became visible again (memory spike, then one giant write).
+// - maxLatencyMs is a timer fallback that guarantees a flush within that
+//   window regardless of whether the animation frame ever fires. Whichever
+//   of the two fires first flushes and cancels the other.
+// - maxPendingBytes is a hard cap: crossing it flushes immediately,
+//   synchronously, inside push() — bounds worst-case memory even if the
+//   frame/timer scheduling itself is somehow delayed further.
+
+export type WriteBatcherOptions = {
+  onFlush: (data: Uint8Array) => void;
+  maxPendingBytes?: number;
+  maxLatencyMs?: number;
+  // Injectable for testing; default to the real browser globals.
+  requestFrame?: (cb: () => void) => number;
+  cancelFrame?: (handle: number) => void;
+  setTimer?: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (handle: ReturnType<typeof setTimeout>) => void;
+};
+
+export type WriteBatcher = {
+  push: (chunk: Uint8Array) => void;
+  /** Flush whatever is pending right now, bypassing any scheduled wait. */
+  flushNow: () => void;
+  /** Cancel any pending schedule and drop buffered data without flushing —
+   * for teardown, where writing to an about-to-be-disposed target is wrong. */
+  dispose: () => void;
+};
+
+const DEFAULT_MAX_PENDING_BYTES = 256 * 1024;
+const DEFAULT_MAX_LATENCY_MS = 100;
+
+export function createWriteBatcher(options: WriteBatcherOptions): WriteBatcher {
+  const maxPendingBytes = options.maxPendingBytes ?? DEFAULT_MAX_PENDING_BYTES;
+  const maxLatencyMs = options.maxLatencyMs ?? DEFAULT_MAX_LATENCY_MS;
+  const requestFrame = options.requestFrame ?? requestAnimationFrame;
+  const cancelFrame = options.cancelFrame ?? cancelAnimationFrame;
+  const setTimer = options.setTimer ?? setTimeout;
+  const clearTimer = options.clearTimer ?? clearTimeout;
+
+  let pending: Uint8Array[] = [];
+  let pendingBytes = 0;
+  let frameHandle: number | null = null;
+  let timerHandle: ReturnType<typeof setTimeout> | null = null;
+
+  function cancelScheduled() {
+    if (frameHandle !== null) {
+      cancelFrame(frameHandle);
+      frameHandle = null;
+    }
+    if (timerHandle !== null) {
+      clearTimer(timerHandle);
+      timerHandle = null;
+    }
+  }
+
+  function flushNow() {
+    cancelScheduled();
+    if (pending.length === 0) return;
+    const merged = new Uint8Array(pendingBytes);
+    let offset = 0;
+    for (const chunk of pending) {
+      merged.set(chunk, offset);
+      offset += chunk.length;
+    }
+    pending = [];
+    pendingBytes = 0;
+    options.onFlush(merged);
+  }
+
+  function schedule() {
+    if (frameHandle !== null || timerHandle !== null) return;
+    frameHandle = requestFrame(() => {
+      frameHandle = null;
+      flushNow();
+    });
+    timerHandle = setTimer(() => {
+      timerHandle = null;
+      flushNow();
+    }, maxLatencyMs);
+  }
+
+  function push(chunk: Uint8Array) {
+    pending.push(chunk);
+    pendingBytes += chunk.length;
+    if (pendingBytes >= maxPendingBytes) {
+      flushNow();
+      return;
+    }
+    schedule();
+  }
+
+  function dispose() {
+    cancelScheduled();
+    pending = [];
+    pendingBytes = 0;
+  }
+
+  return { push, flushNow, dispose };
+}


### PR DESCRIPTION
## Summary

**Unverified mitigation** for issue #383 (referenced only — not closing it; see below), based on the cursorBlink phase-reset hypothesis.

The Rust PTY reader thread (`app/src-tauri/src/pty.rs`) emits one `pty-output` event per raw read from a fixed 8KB buffer — unbatched, no debounce. The frontend (`app/src/TerminalPane.tsx`) previously called `term.write()` synchronously for every single one of those events. Codex CLI's "thinking" spinner drives frequent OSC 0/2 window-title escape updates (`app/src-tauri/src/agent_state.rs`), producing much choppier PTY output churn than other agent types.

**Hypothesis** (not yet confirmed): xterm.js resets its cursor blink phase on every `term.write()` call. If writes arrive faster than the browser can usefully paint between them, the cursor's blink state gets reset far more often than the human eye's blink-cycle expectation, which could read as visible flicker/jitter — this matches issue #383's Windows report of a jittering cursor specifically during Codex CLI output.

This PR batches PTY output into at most one `term.write()` call per animation frame (~16ms at 60fps) regardless of how many backend events arrive within that frame, concatenating their bytes before writing. The `pty-exit` handler now flushes any pending batched output synchronously first, so the "process exited" banner can't render out of order ahead of the process's own last lines.

## Why merge without reproduction

Per team discussion: this batching is a reasonable improvement independent of whether it actually fixes #383 (unthrottled per-chunk writes are wasteful regardless), and is low-risk (order-preserving, only defers/coalesces writes within a single frame, flushes are still immediate relative to human perception). Issue #383 itself stays open — it'll be closed once someone can confirm on real Windows hardware with a Codex CLI session that the flicker is gone.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 99 passed (no logic extracted here worth a unit test; this is DOM/timing behavior, and this repo has no component-test infra — see the same rationale in #391/#394)
- [ ] **Not reproduced or visually verified** — no Windows machine or Codex CLI available in this environment. Please test with an actual Codex CLI session on Windows before treating #383 as resolved.