### PR TITLE
feat(app): phase-lock agent-status and monitor pulse dots to wall clock

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -771,6 +771,7 @@ body.resizing-row {
 .agent-status-dot.status-working {
   background: #e0af68;
   animation: agent-status-pulse 1.2s ease-in-out infinite;
+  animation-delay: var(--pulse-delay, 0s);
 }
 .agent-status-dot.status-idle { background: var(--green); }
 
@@ -1224,6 +1225,7 @@ body.resizing-row {
   height: 7px;
   border-radius: 50%;
   animation: monitor-pulse 2.2s ease-in-out infinite;
+  animation-delay: var(--pulse-delay, 0s);
 }
 .monitor-dot.native::before {
   background: var(--green);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -47,6 +47,7 @@ import {
   type PaneRect,
   type SplitNode,
 } from "./paneTree";
+import { PulseDot } from "./pulseSync";
 import "./App.css";
 
 export type Member = { name: string; types: string[]; project: string };
@@ -1495,7 +1496,14 @@ export default function App() {
                         />
                       ) : (
                         <span className="member-check-slot">
-                          {status && <span className={`agent-status-dot status-${status}`} title={status} />}
+                          {status && (
+                            <PulseDot
+                              periodMs={1200}
+                              active={status === "working"}
+                              className={`agent-status-dot status-${status}`}
+                              title={status}
+                            />
+                          )}
                         </span>
                       )}
                       <button
@@ -1832,13 +1840,16 @@ export default function App() {
                     >
                       {p.label}
                     </button>
-                    <span className={p.native ? "monitor-dot native" : "monitor-dot app"}>
+                    <PulseDot
+                      periodMs={2200}
+                      className={p.native ? "monitor-dot native" : "monitor-dot app"}
+                    >
                       <span className="monitor-tip">
                         {p.native
                           ? t("pane.monitorTip.native")
                           : t("pane.monitorTip.app")}
                       </span>
-                    </span>
+                    </PulseDot>
                     <button
                       className="pane-header-close"
                       onClick={() => setModal({ kind: "closePane", paneId: p.id })}

--- a/app/src/pulseSync.tsx
+++ b/app/src/pulseSync.tsx
@@ -1,0 +1,65 @@
+import { useLayoutEffect, useRef, type CSSProperties, type ReactNode } from "react";
+
+/**
+ * Negative animation-delay (a CSS time string, e.g. "-350ms") that phase-
+ * locks a CSS animation of the given period to the wall clock: at any real
+ * moment, every element sampling this at ITS OWN animation-start instant
+ * lands on the same frame, regardless of when each one actually started
+ * animating (koit: unsynced pulsing across panes read as noisy; getting
+ * them to pulse together "looks cool"). The instant of sampling matters —
+ * see PulseDot below for why this can't just be computed once and shared.
+ */
+export function pulseDelay(periodMs: number): string {
+  return `-${Date.now() % periodMs}ms`;
+}
+
+type PulseDotProps = {
+  periodMs: number;
+  active?: boolean;
+  className?: string;
+  title?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+};
+
+/**
+ * A span carrying a `--pulse-delay` custom property (consumed by CSS via
+ * `animation-delay: var(--pulse-delay)`, either directly or through a
+ * ::before pseudo-element that inherits it), resampled from the wall
+ * clock at the exact moment this dot's animation actually starts — on
+ * mount, and again every time `active` flips from false to true.
+ *
+ * A single delay value computed once (e.g. at the app root) only phase-
+ * locks elements whose own animation happens to start at that same
+ * instant. An agent that goes "working" ten minutes after launch, or a
+ * pane opened later, starts its animation timeline at ITS mount/activate
+ * time — offsetting a fixed delay sampled earlier just shifts that
+ * element's phase by however long it waited, which is indistinguishable
+ * from not being synced at all. Resampling per-element, at its own start,
+ * is what actually keeps every element of a period in phase with the wall
+ * clock (and therefore with each other).
+ *
+ * Every agent-status / team-status / monitor pulsing dot should render
+ * through this one component rather than reimplementing the sampling.
+ */
+export function PulseDot({
+  periodMs,
+  active = true,
+  className,
+  title,
+  style,
+  children,
+}: PulseDotProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useLayoutEffect(() => {
+    if (!active) return;
+    ref.current?.style.setProperty("--pulse-delay", pulseDelay(periodMs));
+  }, [active, periodMs]);
+
+  return (
+    <span ref={ref} className={className} title={title} style={style}>
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Agent-status dots (working, 1.2s period) and monitor dots (2.2s period) now phase-lock to the wall clock via a negative `animation-delay`, so multiple pulsing dots visually sync instead of drifting apart.
- Both dot families render through a new shared `PulseDot` component (`app/src/pulseSync.tsx`) instead of each reimplementing the sampling.
- Sampling happens per-element at the exact moment its animation starts (mount, or the transition into `active`) rather than once at a shared ancestor — a single value computed once only phase-locks elements that happen to start animating at that same instant, which doesn't hold once agents go "working" or panes open at different real times.

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm test`
- [x] Verified live in the desktop app: agent-status dots and monitor dots pulse in sync (confirmed by koit)