### PR TITLE
fix(codex-shim): forward args on a flags-only monitored launch

### DIFF
--- a/scripts/drivers/types/codex/codex-shim.sh
+++ b/scripts/drivers/types/codex/codex-shim.sh
@@ -133,7 +133,7 @@ monitor_cmd="${AGMSG_CODEX_MONITOR_CMD:-$SCRIPT_DIR/codex-monitor.sh}"
 
 case "$command_name" in
   "")
-    AGMSG_REAL_CODEX="$real_codex" exec "$monitor_cmd" --project "$project" --codex-command codex --
+    AGMSG_REAL_CODEX="$real_codex" exec "$monitor_cmd" --project "$project" --codex-command codex -- "$@"
     ;;
   resume)
     monitor_args=()

--- a/tests/test_codex_shim.bats
+++ b/tests/test_codex_shim.bats
@@ -53,6 +53,15 @@ teardown() {
   grep -q "monitor real=$FAKE_CODEX <--project> <$TEST_PROJECT> <--codex-command> <codex> <--> <fix this>" "$CALL_LOG"
 }
 
+@test "codex shim: monitor project forwards a flags-only launch to codex-monitor (#386)" {
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+
+  run bash -c 'cd "$TEST_PROJECT" && AGMSG_REAL_CODEX="$FAKE_CODEX" AGMSG_CODEX_MONITOR_CMD="$FAKE_MONITOR" bash "$TYPES/codex/codex-shim.sh" --yolo'
+
+  [ "$status" -eq 0 ]
+  grep -q "monitor real=$FAKE_CODEX <--project> <$TEST_PROJECT> <--codex-command> <codex> <--> <--yolo>" "$CALL_LOG"
+}
+
 @test "codex shim: non-monitor project passes through to real codex" {
   bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT" >/dev/null
 


### PR DESCRIPTION
Root-caused, fixed, and verified by @kimyuujin in #386 — carried forward here with credit (Co-authored-by).

Closes #386.

## What

`scripts/drivers/types/codex/codex-shim.sh`'s `first_non_option()` skips every `-`/`--`-prefixed argument, so a flags-only launch (e.g. `codex --yolo`, no subcommand) lands in the `""` case of the `command_name` dispatch. That branch was the only one that didn't forward `"$@"` to `codex-monitor.sh` — so the flags were silently dropped and the monitored session ran with default approval behavior instead of the one requested, easy to miss until Codex unexpectedly asks for approval mid-task.

The `resume` and `*` branches already forward the remaining arguments; this applies the same `"$@"` forwarding to the `""` branch — a one-line change.

## Tests

Added a regression case to `tests/test_codex_shim.bats`: a flags-only monitored launch (`codex --yolo`) now asserts the monitor receives `-- --yolo`, matching the existing style of the neighboring resume/prompt-launch tests. Full file run: 10/10 green locally.

## Verification

Reporter verified end-to-end (monitor receiving `-- --yolo`, TUI execing as `codex --remote ws://... --yolo`) per #386's repro. The no-argument case stays safe on macOS bash 3.2 since `codex-monitor.sh` already guards the empty-array expansion (`${CODEX_ARGS[@]+"${CODEX_ARGS[@]}"}`, #235/#237).
