### PR TITLE
feat(app): sidebar per-section + buttons, replacing the New dropdown

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -160,21 +160,10 @@ select:focus {
   border-color: var(--accent);
 }
 
-/* + New menu */
+/* + New menu (collapsed-rail only — the expanded sidebar has its own
+   direct + buttons per section instead, see .section-add-btn) */
 .new-wrap {
   position: relative;
-}
-.new-btn {
-  background: var(--panel-2);
-  color: var(--fg);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 4px 10px;
-  white-space: nowrap;
-  cursor: pointer;
-}
-.new-btn:hover {
-  border-color: var(--accent);
 }
 .new-menu {
   position: absolute;
@@ -634,9 +623,6 @@ body.resizing-row {
   width: auto;
   display: block;
 }
-.brand-row .new-wrap {
-  margin-left: auto;
-}
 .sidebar-head .brand {
   font-size: 15px;
 }
@@ -708,6 +694,34 @@ body.resizing-row {
   letter-spacing: 0.6px;
   color: var(--muted);
   white-space: nowrap;
+}
+.sidebar-title-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.section-add-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: var(--panel-2);
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+}
+.section-add-btn:hover {
+  background: var(--accent);
+  color: #fff;
+}
+.section-add-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 .filter-actions {
   display: flex;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1404,38 +1404,19 @@ export default function App() {
               <div className="sidebar-head" data-tauri-drag-region>
                 <div className="brand-row">
                   <img className="logo" src="/agmsg-logo.png" alt={t("sidebar.logoAlt")} />
-                  <div className="new-wrap" onClick={(e) => e.stopPropagation()}>
-                  <button className="new-btn" onClick={toggleNewMenu}>
-                    {t("sidebar.newMenu.trigger")}
-                  </button>
-                  {newMenu && (
-                    <div className="new-menu">
-                      <button
-                        onClick={() => {
-                          setNewMenu(false);
-                          setModal({ kind: "team", firstRun: false });
-                        }}
-                      >
-                        {t("sidebar.newMenu.team")}
-                      </button>
-                      <button
-                        disabled={!team}
-                        onClick={() => {
-                          setNewMenu(false);
-                          setModal({ kind: "agent" });
-                          // Refresh in case spawn-options.yaml or a new type
-                          // manifest showed up since app start.
-                          invoke<AgentType[]>("agmsg_spawnable_types")
-                            .then(setSpawnTypes)
-                            .catch(() => {});
-                        }}
-                      >
-                        {t("sidebar.newMenu.agent")}
-                      </button>
-                    </div>
-                  )}
-                  </div>
                 </div>
+              </div>
+              <div className="sidebar-title">
+                <span className="sidebar-title-label">
+                  {t("sidebar.team.title")}
+                  <button
+                    className="section-add-btn"
+                    title={t("sidebar.team.new")}
+                    onClick={() => setModal({ kind: "team", firstRun: false })}
+                  >
+                    +
+                  </button>
+                </span>
               </div>
               <div className="team-status-rail" aria-label="Open pane status">
                 {teams.map((teamName) => {
@@ -1454,7 +1435,24 @@ export default function App() {
                 })}
               </div>
               <div className="sidebar-title">
-                <span>{t("sidebar.title")}</span>
+                <span className="sidebar-title-label">
+                  {t("sidebar.title")}
+                  <button
+                    className="section-add-btn"
+                    title={t("sidebar.newAgent")}
+                    disabled={!team}
+                    onClick={() => {
+                      setModal({ kind: "agent" });
+                      // Refresh in case spawn-options.yaml or a new type
+                      // manifest showed up since app start.
+                      invoke<AgentType[]>("agmsg_spawnable_types")
+                        .then(setSpawnTypes)
+                        .catch(() => {});
+                    }}
+                  >
+                    +
+                  </button>
+                </span>
                 {active === "room" && others.length > 0 && (
                   <span className="filter-actions">
                     <button onClick={selectAllMembers}>{t("sidebar.filter.all")}</button>

--- a/app/src/i18n/locales/de.json
+++ b/app/src/i18n/locales/de.json
@@ -27,7 +27,12 @@
       "team": "Team…",
       "agent": "Agent…"
     },
+    "team": {
+      "title": "Team",
+      "new": "Neues Team"
+    },
     "title": "Agenten",
+    "newAgent": "Neuer Agent",
     "filter": {
       "all": "alle",
       "none": "keine"
@@ -37,7 +42,7 @@
       "titleRunning": "läuft bereits — klicken zum Fokussieren",
       "titleSpawn": "in einem PTY-Bereich starten",
       "noTypes": "—",
-      "emptyState": "Noch keine Agenten. ＋ Neu → Agent verwenden."
+      "emptyState": "Noch keine Agenten. Mit der ＋-Schaltfläche oben einen hinzufügen."
     },
     "user": {
       "title": "app-user in {{team}}"

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -37,7 +37,12 @@
       "team": "Team…",
       "agent": "Agent…"
     },
+    "team": {
+      "title": "Team",
+      "new": "New team"
+    },
     "title": "Agents",
+    "newAgent": "New agent",
     "filter": {
       "all": "all",
       "none": "none"
@@ -47,7 +52,7 @@
       "titleRunning": "already running — click to focus",
       "titleSpawn": "spawn in a PTY pane",
       "noTypes": "—",
-      "emptyState": "No agents yet. Use ＋ New → Agent."
+      "emptyState": "No agents yet. Use the + button above to add one."
     },
     "user": {
       "title": "app-user in {{team}}"

--- a/app/src/i18n/locales/es.json
+++ b/app/src/i18n/locales/es.json
@@ -27,7 +27,12 @@
       "team": "Equipo…",
       "agent": "Agente…"
     },
+    "team": {
+      "title": "Equipo",
+      "new": "Nuevo equipo"
+    },
     "title": "Agentes",
+    "newAgent": "Nuevo agente",
     "filter": {
       "all": "todos",
       "none": "ninguno"
@@ -37,7 +42,7 @@
       "titleRunning": "ya está en ejecución — haga clic para enfocar",
       "titleSpawn": "iniciar en un panel PTY",
       "noTypes": "—",
-      "emptyState": "Aún no hay agentes. Use ＋ Nuevo → Agente."
+      "emptyState": "Aún no hay agentes. Use el botón ＋ de arriba para añadir uno."
     },
     "user": {
       "title": "app-user en {{team}}"

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -27,7 +27,12 @@
       "team": "Équipe…",
       "agent": "Agent…"
     },
+    "team": {
+      "title": "Équipe",
+      "new": "Nouvelle équipe"
+    },
     "title": "Agents",
+    "newAgent": "Nouvel agent",
     "filter": {
       "all": "tous",
       "none": "aucun"
@@ -37,7 +42,7 @@
       "titleRunning": "déjà en cours — cliquer pour afficher",
       "titleSpawn": "démarrer dans un panneau PTY",
       "noTypes": "—",
-      "emptyState": "Aucun agent pour l'instant. Utilisez ＋ Nouveau → Agent."
+      "emptyState": "Aucun agent pour l'instant. Utilisez le bouton ＋ ci-dessus pour en ajouter un."
     },
     "user": {
       "title": "app-user dans {{team}}"

--- a/app/src/i18n/locales/ja.json
+++ b/app/src/i18n/locales/ja.json
@@ -27,7 +27,12 @@
       "team": "チーム…",
       "agent": "エージェント…"
     },
+    "team": {
+      "title": "チーム",
+      "new": "新規チーム"
+    },
     "title": "エージェント",
+    "newAgent": "新規エージェント",
     "filter": {
       "all": "すべて",
       "none": "なし"
@@ -37,7 +42,7 @@
       "titleRunning": "実行中 — クリックしてフォーカス",
       "titleSpawn": "PTYペインで起動",
       "noTypes": "—",
-      "emptyState": "エージェントはまだありません。＋ 新規 → エージェント から追加してください。"
+      "emptyState": "エージェントはまだありません。上の＋ボタンから追加してください。"
     },
     "user": {
       "title": "{{team}} のapp-user"

--- a/app/src/i18n/locales/ko.json
+++ b/app/src/i18n/locales/ko.json
@@ -27,7 +27,12 @@
       "team": "팀…",
       "agent": "에이전트…"
     },
+    "team": {
+      "title": "팀",
+      "new": "새 팀"
+    },
     "title": "에이전트",
+    "newAgent": "새 에이전트",
     "filter": {
       "all": "전체",
       "none": "없음"
@@ -37,7 +42,7 @@
       "titleRunning": "실행 중 — 클릭하면 포커스",
       "titleSpawn": "PTY 창에서 실행",
       "noTypes": "—",
-      "emptyState": "아직 에이전트가 없습니다. ＋ 새로 만들기 → 에이전트를 사용하세요."
+      "emptyState": "아직 에이전트가 없습니다. 위의 ＋ 버튼을 사용해 추가하세요."
     },
     "user": {
       "title": "{{team}}의 app-user"

--- a/app/src/i18n/locales/pt-BR.json
+++ b/app/src/i18n/locales/pt-BR.json
@@ -27,7 +27,12 @@
       "team": "Equipe…",
       "agent": "Agente…"
     },
+    "team": {
+      "title": "Equipe",
+      "new": "Nova equipe"
+    },
     "title": "Agentes",
+    "newAgent": "Novo agente",
     "filter": {
       "all": "todos",
       "none": "nenhum"
@@ -37,7 +42,7 @@
       "titleRunning": "já em execução — clique para focar",
       "titleSpawn": "iniciar em um painel PTY",
       "noTypes": "—",
-      "emptyState": "Nenhum agente ainda. Use ＋ Novo → Agente."
+      "emptyState": "Nenhum agente ainda. Use o botão ＋ acima para adicionar um."
     },
     "user": {
       "title": "app-user em {{team}}"

--- a/app/src/i18n/locales/zh-CN.json
+++ b/app/src/i18n/locales/zh-CN.json
@@ -27,7 +27,12 @@
       "team": "团队…",
       "agent": "智能体…"
     },
+    "team": {
+      "title": "团队",
+      "new": "新建团队"
+    },
     "title": "智能体",
+    "newAgent": "新建智能体",
     "filter": {
       "all": "全部",
       "none": "无"
@@ -37,7 +42,7 @@
       "titleRunning": "已在运行 — 点击以聚焦",
       "titleSpawn": "在 PTY 面板中启动",
       "noTypes": "—",
-      "emptyState": "暂无智能体。使用 ＋ 新建 → 智能体。"
+      "emptyState": "暂无智能体。使用上方的 ＋ 按钮添加。"
     },
     "user": {
       "title": "{{team}} 中的 app-user"

--- a/app/src/i18n/locales/zh-TW.json
+++ b/app/src/i18n/locales/zh-TW.json
@@ -27,7 +27,12 @@
       "team": "團隊…",
       "agent": "代理…"
     },
+    "team": {
+      "title": "團隊",
+      "new": "新增團隊"
+    },
     "title": "代理",
+    "newAgent": "新增代理",
     "filter": {
       "all": "全部",
       "none": "無"
@@ -37,7 +42,7 @@
       "titleRunning": "已在執行中 — 點選以切換至該面板",
       "titleSpawn": "在 PTY 面板中啟動",
       "noTypes": "—",
-      "emptyState": "尚無代理。請使用「＋ 新增 → 代理」新增。"
+      "emptyState": "尚無代理。請使用上方的「＋」按鈕新增。"
     },
     "user": {
       "title": "{{team}} 的 app-user"

--- a/app/src/modals.test.ts
+++ b/app/src/modals.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { shouldCloseOnEscape } from "./modals";
+
+function esc(overrides: Partial<{ isComposing: boolean; keyCode: number; defaultPrevented: boolean }> = {}) {
+  return {
+    key: "Escape",
+    isComposing: false,
+    keyCode: 27,
+    defaultPrevented: false,
+    ...overrides,
+  };
+}
+
+describe("shouldCloseOnEscape", () => {
+  it("closes on a plain Escape", () => {
+    expect(shouldCloseOnEscape(esc())).toBe(true);
+  });
+
+  it("ignores non-Escape keys", () => {
+    expect(shouldCloseOnEscape({ ...esc(), key: "Enter" })).toBe(false);
+  });
+
+  it("does not close while an IME composition is in progress", () => {
+    expect(shouldCloseOnEscape(esc({ isComposing: true }))).toBe(false);
+  });
+
+  it("does not close on the WKWebView IME keyCode 229 fallback", () => {
+    expect(shouldCloseOnEscape(esc({ keyCode: 229 }))).toBe(false);
+  });
+
+  it("does not close when a child already consumed the event", () => {
+    expect(shouldCloseOnEscape(esc({ defaultPrevented: true }))).toBe(false);
+  });
+});

--- a/app/src/modals.tsx
+++ b/app/src/modals.tsx
@@ -6,6 +6,24 @@ import { AUTO_TIMEZONE, detectTimeZone, isValidTimeZone, listTimeZones } from ".
 
 type BrowseDir = (current: string) => Promise<string | null>;
 
+/**
+ * Whether an Escape keydown should close a modal. Excludes IME composition:
+ * while composing (e.g. converting kana to kanji), Escape cancels the
+ * pending conversion rather than acting on the page, and WKWebView doesn't
+ * always set `isComposing` for that event — keyCode 229 is the traditional
+ * cross-browser signal for "this keydown belongs to an IME," so it's
+ * checked too. Also respects `defaultPrevented`, so a child (a native
+ * select, a datalist) that already consumed the Escape keeps the modal
+ * open. Exported as a pure function so this logic is unit-testable without
+ * mounting a component.
+ */
+export function shouldCloseOnEscape(e: Pick<KeyboardEvent, "key" | "isComposing" | "keyCode" | "defaultPrevented">): boolean {
+  if (e.key !== "Escape") return false;
+  if (e.defaultPrevented) return false;
+  if (e.isComposing || e.keyCode === 229) return false;
+  return true;
+}
+
 /** Modal chrome: dimmed backdrop + centered card. */
 function Modal(props: {
   title: string;
@@ -16,7 +34,7 @@ function Modal(props: {
   useEffect(() => {
     if (!onClose) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (shouldCloseOnEscape(e)) onClose();
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);

--- a/app/src/modals.tsx
+++ b/app/src/modals.tsx
@@ -12,6 +12,16 @@ function Modal(props: {
   children: React.ReactNode;
   onClose?: () => void;
 }) {
+  const { onClose } = props;
+  useEffect(() => {
+    if (!onClose) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
   return (
     <div className="modal-backdrop" onClick={props.onClose}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>


### PR DESCRIPTION
## Summary
- The expanded sidebar now has its own "Team" heading (mirrors the existing "Agents" one) with a + button that opens the new-team modal directly, and the "Agents" heading gets the same treatment for spawning an agent — no more picking Team vs Agent from a dropdown first. The collapsed rail keeps its dropdown as-is (no room for two separate headers at 44px wide). All 9 locales translated.
- Escape now closes any modal (added to the shared `Modal` wrapper in `modals.tsx`, so it applies to every modal that passes `onClose`, not just the new ones here) — found while live-testing the new + buttons.

Note: this branch carries over commit b3cbcc5 from `feat/app-divider-focus-ux`, which was done but never turned into its own PR before that branch's divider work (#390) merged.

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm test`
- [x] Verified live in the desktop app: sidebar + buttons open the right modal directly, Escape closes modals (confirmed by koit)