### PR TITLE
fix(antigravity): resolve Codex leftovers and delivery_modes mismatch

### DIFF
--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -58,7 +58,7 @@ Four possible outputs:
      - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
      - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
        `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> antigravity "$(pwd)"`
-     - Codex has no Monitor tool, so `monitor` and `both` modes are not offered here.
+     - Antigravity has no Monitor tool, so `monitor` and `both` modes are not offered here.
 
   6. Then check inbox for the newly joined team.
 
@@ -107,7 +107,7 @@ If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" antigravity` to see whether the role is already registered for this (project, type).
 3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> antigravity "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
 4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
-5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Codex has no Monitor tool, so receive still covers all of your registered roles in this project.)"
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Antigravity has no Monitor tool, so receive still covers all of your registered roles in this project.)"
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.
@@ -120,7 +120,7 @@ If argument is "mode" (no further args):
 2. Show the output to the user.
 
 If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
-1. Parse the mode. Codex supports only `turn` and `off` — reject `monitor` and `both` with: "Codex has no Monitor tool; only `turn` or `off` modes are supported."
+1. Parse the mode. Antigravity supports only `turn` and `off` — reject `monitor` and `both` with: "Antigravity has no Monitor tool; only `turn` or `off` modes are supported."
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> antigravity "$(pwd)"`
 
 If argument is "hook on" (legacy alias):

--- a/scripts/drivers/types/antigravity/type.conf
+++ b/scripts/drivers/types/antigravity/type.conf
@@ -10,4 +10,4 @@ prompt_arg=--prompt-interactive
 detect=explicit
 hooks_file=.agent/rules/agmsg.md
 monitor=no
-delivery_modes=monitor turn both off
+delivery_modes=turn off

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1446,6 +1446,31 @@ JSON
   [ "$count" -eq 1 ]
 }
 
+@test "antigravity supports off mode: removes rule file" {
+  bash "$SCRIPTS/delivery.sh" set turn antigravity "$TEST_PROJECT"
+  [ -f "$TEST_PROJECT/.agent/rules/agmsg.md" ]
+  run bash "$SCRIPTS/delivery.sh" set off antigravity "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_PROJECT/.agent/rules/agmsg.md" ]
+}
+
+# #399: type.conf previously advertised delivery_modes=monitor turn both off,
+# but antigravity has no Monitor tool or bridge equivalent — the manifest must
+# match what the template actually offers (turn/off only, like cursor/gemini).
+@test "antigravity rejects monitor mode" {
+  run bash "$SCRIPTS/delivery.sh" set monitor antigravity "$TEST_PROJECT"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "not supported" ]]
+  [ ! -f "$TEST_PROJECT/.agent/rules/agmsg.md" ]
+}
+
+@test "antigravity rejects both mode" {
+  run bash "$SCRIPTS/delivery.sh" set both antigravity "$TEST_PROJECT"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "not supported" ]]
+  [ ! -f "$TEST_PROJECT/.agent/rules/agmsg.md" ]
+}
+
 # --- Codex monitor bridge (#41) ---
 @test "session-start.sh for codex starts bridge when monitor launcher env is present" {
   bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null


### PR DESCRIPTION
Closes #399.

## Problem

`scripts/drivers/types/antigravity/template.md` had three copy-paste leftovers referring to `Codex` where they should refer to Antigravity (delivery-mode picker note, actas confirmation message, mode-set rejection message).

Separately, `type.conf` declared `delivery_modes=monitor turn both off`, but antigravity has no Monitor tool or bridge equivalent (unlike codex/grok-build, which do have one) — the template only ever offered `turn`/`off` and hard-rejected `monitor`/`both`. Confirmed by checking the antigravity driver directory: no `codex-bridge*`/`*-monitor.sh` equivalent exists, unlike codex's directory.

## Fix

- Renamed the three `Codex` → `Antigravity` strings in `template.md`.
- Narrowed `type.conf`'s `delivery_modes` to `turn off`, matching what the template actually implements (same shape as cursor/gemini/opencode).

## Tests

Added `test_delivery.bats` cases mirroring the existing cursor coverage: antigravity supports `off` (removes the rule file), and rejects both `monitor` and `both` with a clear error via the `delivery_modes` gate in `delivery.sh`.

All 128 tests in `test_delivery.bats` pass, plus `test_type_registry.bats`/`test_team.bats`/`test_spawn.bats` (130 tests, unaffected).