### PR TITLE
fix(send): reject unregistered from/to agents

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -315,7 +315,7 @@ $agmsg
 ### シェル（任意のエージェント）
 
 ```bash
-~/.agents/skills/<cmd>/scripts/send.sh <team> <from> <to> "<message>"
+~/.agents/skills/<cmd>/scripts/send.sh <team> <from> <to> "<message>" [--force]
 ~/.agents/skills/<cmd>/scripts/inbox.sh <team> <agent_id>
 ~/.agents/skills/<cmd>/scripts/history.sh <team> [agent_id] [limit]
 ~/.agents/skills/<cmd>/scripts/team.sh <team>
@@ -325,7 +325,7 @@ $agmsg
 ~/.agents/skills/<cmd>/scripts/reset.sh <project_path> <type> [agent_id]
 ```
 
-`send.sh` はちょうど4つの位置引数を取る: `<team> <from> <to> "<message>"`。シェルが1つの引数として認識するようメッセージはクォートすること — クォートされていないスペース入りメッセージは誤って分割される。
+`send.sh` は4つの位置引数 `<team> <from> <to> "<message>"` に加えて、末尾に任意で `--force` を取る。シェルが1つの引数として認識するようメッセージはクォートすること — クォートされていないスペース入りメッセージは誤って分割される。`from`・`to` はどちらも `<team>` に事前登録済みである必要があり、未登録の名前は(登録済み一覧を添えて)エラーになる — 意図的な事前登録前送信をしたい場合のみ `--force` でこのチェックを迂回できる。
 
 ## FAQ / 設計メモ
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ See [docs/opencode.md](docs/opencode.md) for full setup instructions.
 ### Shell (any agent)
 
 ```bash
-~/.agents/skills/<cmd>/scripts/send.sh <team> <from> <to> "<message>"
+~/.agents/skills/<cmd>/scripts/send.sh <team> <from> <to> "<message>" [--force]
 ~/.agents/skills/<cmd>/scripts/inbox.sh <team> <agent_id>
 ~/.agents/skills/<cmd>/scripts/history.sh <team> [agent_id] [limit]
 ~/.agents/skills/<cmd>/scripts/team.sh <team>
@@ -339,7 +339,7 @@ See [docs/opencode.md](docs/opencode.md) for full setup instructions.
 ~/.agents/skills/<cmd>/scripts/reset.sh <project_path> <type> [agent_id]
 ```
 
-`send.sh` takes exactly four positional arguments: `<team> <from> <to> "<message>"`. Quote the message so the shell sees it as one argument; an unquoted message with spaces will be misparsed.
+`send.sh` takes four positional arguments — `<team> <from> <to> "<message>"` — plus an optional trailing `--force`. Quote the message so the shell sees it as one argument; an unquoted message with spaces will be misparsed. Both `from` and `to` must already be registered in `<team>`; an unregistered name errors out (listing the currently registered names) instead of silently storing an undeliverable message. Pass `--force` to bypass this check for an intentional pre-registration send.
 
 ## FAQ / Design notes
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -58,8 +58,8 @@ Do NOT manually edit config files. Always use join.sh.
 # Check inbox (marks messages as read) — DEFAULT action
 ~/.agents/skills/agmsg/scripts/inbox.sh <team> <agent_id>
 
-# Send a message
-~/.agents/skills/agmsg/scripts/send.sh <team> <from_agent> <to_agent> "<message>"
+# Send a message (from/to must already be registered in <team>; add --force to bypass)
+~/.agents/skills/agmsg/scripts/send.sh <team> <from_agent> <to_agent> "<message>" [--force]
 
 # Message history
 ~/.agents/skills/agmsg/scripts/history.sh <team> [agent_id] [limit]

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -1,18 +1,64 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: send.sh <team> <from> <to> <message>
+# Usage: send.sh <team> <from> <to> <message> [--force]
 
-TEAM="${1:?Usage: send.sh <team> <from> <to> <message>}"
+TEAM="${1:?Usage: send.sh <team> <from> <to> <message> [--force]}"
 FROM="${2:?Missing from agent}"
 TO="${3:?Missing to agent}"
 BODY="${4:?Missing message body}"
+FORCE=0
+if [ "${5:-}" = "--force" ]; then
+  FORCE=1
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 DB="$(agmsg_db_path)"
 
 [ -f "$DB" ] || bash "$SCRIPT_DIR/internal/init-db.sh" >/dev/null
+
+# #355: reject a from/to that isn't registered in <team> — an unnoticed typo
+# (e.g. a stray send to "dummy") used to insert successfully with exit 0,
+# landing an undeliverable message and polluting history. Validation lives
+# here (the front door), not in storage.sh, so other entry points (api.sh)
+# can keep their own policy. --force bypasses this for intentional
+# pre-registration sends (e.g. notifying a role before its own join.sh runs).
+if [ "$FORCE" -ne 1 ]; then
+  TEAM_CONFIG="$SCRIPT_DIR/../teams/$TEAM/config.json"
+
+  _agmsg_roster_check() {
+    local role="$1" name="$2"
+    if [ ! -f "$TEAM_CONFIG" ]; then
+      echo "Error: team '$TEAM' has no registered agents — cannot send as $role '$name' (use --force to bypass)." >&2
+      return 1
+    fi
+    local cfg_sql name_sql found roster
+    cfg_sql=$(agmsg_sql_readfile_path "$TEAM_CONFIG")
+    name_sql=$(printf '%s' "$name" | sed "s/'/''/g")
+    found=$(agmsg_sqlite_mem "
+      WITH raw(json) AS (SELECT CAST(readfile('$cfg_sql') AS TEXT)),
+      cfg(json) AS (SELECT CASE WHEN json_valid(json) THEN json END FROM raw)
+      SELECT value
+      FROM cfg, json_each(json_extract(cfg.json, '\$.agents'))
+      WHERE key = '$name_sql';
+    ")
+    if [ -z "$found" ]; then
+      roster=$(agmsg_sqlite_mem "
+        WITH raw(json) AS (SELECT CAST(readfile('$cfg_sql') AS TEXT)),
+        cfg(json) AS (SELECT CASE WHEN json_valid(json) THEN json END FROM raw)
+        SELECT group_concat(key, ', ')
+        FROM cfg, json_each(json_extract(cfg.json, '\$.agents'));
+      ")
+      echo "Error: $role agent '$name' is not registered in team '$TEAM' (registered: ${roster:-none}). Use --force to bypass." >&2
+      return 1
+    fi
+    return 0
+  }
+
+  _agmsg_roster_check "from" "$FROM" || exit 1
+  _agmsg_roster_check "to" "$TO" || exit 1
+fi
 
 # Escape EVERY interpolated value as a SQL string literal, not just body: a
 # team/agent name containing a single quote would otherwise break the INSERT

--- a/tests/test_despawn.bats
+++ b/tests/test_despawn.bats
@@ -19,6 +19,7 @@ teardown() {
 
 @test "despawn: graceful — ctrl:despawn makes the member drop its role" {
   bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/join.sh" team leader claude-code "$PROJ" >/dev/null
   # Make the member session look alive so the leader sees a live lock to wait on.
   setup_live_owner "$RUN" sess-m
 
@@ -71,6 +72,7 @@ teardown() {
 
 @test "despawn: times out (exit 3) when the member never drops" {
   bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/join.sh" team leader claude-code "$PROJ" >/dev/null
   setup_live_owner "$RUN" sess-m
   printf 'sess-m\n' > "$RUN/actas.team__alice.session"   # held live, no watcher to act
 
@@ -86,6 +88,7 @@ teardown() {
   # take down the leader session. A broad watcher must skip the control message.
   bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
   bash "$SCRIPTS/join.sh" team leader claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/join.sh" team boss claude-code "$PROJ" >/dev/null
 
   # Broad watcher (no actas arg) — subscribes to both alice and leader.
   AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE bash "$SCRIPTS/watch.sh" sess-broad "$PROJ" claude-code \

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -38,6 +38,8 @@ teardown() {
 
 @test "install: --update restores scripts/lib even if it went missing" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  bash "$SK/scripts/join.sh" demo alice claude-code /tmp/install-update-projA
+  bash "$SK/scripts/join.sh" demo bob   claude-code /tmp/install-update-projB
   rm -rf "$SK/scripts/lib"
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
   [ -f "$SK/scripts/lib/storage.sh" ]
@@ -109,6 +111,8 @@ teardown() {
 
 @test "install: AGMSG_STORAGE_PATH override works against the installed skill" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  bash "$SK/scripts/join.sh" demo alice claude-code /tmp/install-override-projA
+  bash "$SK/scripts/join.sh" demo bob   claude-code /tmp/install-override-projB
   local store="$FAKE_HOME/override-store"
   AGMSG_STORAGE_PATH="$store" bash "$SK/scripts/send.sh" demo alice bob "via override"
   [ -f "$store/messages.db" ]

--- a/tests/test_messaging.bats
+++ b/tests/test_messaging.bats
@@ -26,6 +26,41 @@ teardown() {
   [ "$status" -ne 0 ]
 }
 
+# --- send.sh: roster validation (#355) ---
+
+@test "send: rejects an unregistered from agent and does not insert" {
+  run bash "$SCRIPTS/send.sh" testteam dummy bob "hi"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "from agent 'dummy' is not registered" ]]
+  local n
+  n=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COUNT(*) FROM messages;")
+  [ "$n" -eq 0 ]
+}
+
+@test "send: rejects an unregistered to agent and does not insert" {
+  run bash "$SCRIPTS/send.sh" testteam alice dummy "hi"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "to agent 'dummy' is not registered" ]]
+  local n
+  n=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COUNT(*) FROM messages;")
+  [ "$n" -eq 0 ]
+}
+
+@test "send: rejection lists the currently registered roster" {
+  run bash "$SCRIPTS/send.sh" testteam alice dummy "hi"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "registered: alice, bob" ]]
+}
+
+@test "send: --force bypasses the roster check even with no team config at all" {
+  run bash "$SCRIPTS/send.sh" brandnewteam ghost nobody "hi" --force
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Sent to nobody" ]]
+  local n
+  n=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COUNT(*) FROM messages WHERE team='brandnewteam';")
+  [ "$n" -eq 1 ]
+}
+
 # --- inbox.sh ---
 
 @test "inbox: shows no messages when empty" {

--- a/tests/test_messaging.bats
+++ b/tests/test_messaging.bats
@@ -91,6 +91,7 @@ line3"
 
 @test "check-inbox: a team name containing a quote still delivers without a SQL error (#87)" {
   local project; project="$(mktemp -d)"
+  bash "$SCRIPTS/join.sh" "te'am" alice claude-code /tmp/project-a
   bash "$SCRIPTS/join.sh" "te'am" carol claude-code "$project"
   bash "$SCRIPTS/send.sh" "te'am" alice carol "quoted team delivery"
   run bash -c "echo '{}' | bash '$SCRIPTS/check-inbox.sh' claude-code '$project'"

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -70,6 +70,8 @@ SH
 # --- end-to-end roundtrip through the override ---
 
 @test "storage: send and inbox share the overridden db" {
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a
+  bash "$SCRIPTS/join.sh" testteam bob claude-code /tmp/project-b
   export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
   bash "$SCRIPTS/send.sh" testteam alice bob "hi via override"
   [ -f "$AGMSG_STORAGE_PATH/messages.db" ]
@@ -85,6 +87,7 @@ SH
 
   # Register an agent so check-inbox can resolve identity via whoami.
   bash "$SCRIPTS/join.sh" testteam alice claude-code "$project"
+  bash "$SCRIPTS/join.sh" testteam bob claude-code /tmp/agmsg-storage-test-bob
 
   # A message addressed to alice lives only in the overridden store.
   AGMSG_STORAGE_PATH="$store" bash "$SCRIPTS/send.sh" testteam bob alice "via override store"
@@ -102,6 +105,8 @@ SH
 @test "storage: default db is untouched when the override is set" {
   # The default store was initialized in setup; writing through an override
   # must not add rows to it.
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a
+  bash "$SCRIPTS/join.sh" testteam bob claude-code /tmp/project-b
   export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
   bash "$SCRIPTS/send.sh" testteam alice bob "isolated"
 
@@ -136,7 +141,7 @@ SH
   # sends silently drop. With the wrapper they wait and all land. See #114.
   local x
   for x in 1 2 3 4 5 6 7 8 9 10; do
-    ( bash "$SCRIPTS/send.sh" team leader "tgt$x" "job $x" >/dev/null 2>&1 ) &
+    ( bash "$SCRIPTS/send.sh" team leader "tgt$x" "job $x" --force >/dev/null 2>&1 ) &
   done
   wait
   local n
@@ -152,7 +157,7 @@ SH
   export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/freshstore"
   local x
   for x in 1 2 3 4 5 6 7 8 9 10; do
-    ( bash "$SCRIPTS/send.sh" team leader "tgt$x" "job $x" >/dev/null 2>&1 ) &
+    ( bash "$SCRIPTS/send.sh" team leader "tgt$x" "job $x" --force >/dev/null 2>&1 ) &
   done
   wait
   local n

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -16,6 +16,7 @@ setup() {
   case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) export AGMSG_AGENT_PID="" ;; esac
   export PROJ="/tmp/agmsg-watch-proj"
   bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/join.sh" team bob claude-code "$PROJ" >/dev/null
 }
 
 teardown() {


### PR DESCRIPTION
Closes #355.

## Problem

`send.sh <team> <from> <to> <message>` performed no existence check on either `from` or `to`. A typo'd recipient (e.g. an accidental send to `dummy`) was accepted and stored: the message landed addressed to nobody, was never deliverable, and silently polluted team history with exit 0 — observed live on a real team DB.

## Fix

Both `from` and `to` are now checked against the team's roster (`teams/<team>/config.json`) before the INSERT. An unregistered name errors out and lists the currently registered names, so a typo is obvious immediately:

```
Error: to agent 'dummy' is not registered in team 'myteam' (registered: alice, bob, carol). Use --force to bypass.
```

- Validation lives in `send.sh` (the front door), not `storage.sh`, so other entry points (`api.sh`) can keep their own independent policy.
- `--force` bypasses the check for intentional pre-registration sends (e.g. notifying a role before its own `join.sh` runs).

## Tests

Several existing tests sent through team/agent pairs that were never `join.sh`'d — this only ever worked because there was no validation. Updated those:
- Added missing `join.sh` calls where the test's actual intent was to exercise messaging/delivery behavior (`test_messaging`, `test_storage`, `test_install`, `test_despawn`, `test_watch`).
- Used `--force` where the test is genuinely about concurrency/storage semantics unrelated to registration (the two SQLITE_BUSY fan-out tests in `test_storage.bats`).

All directly affected suites pass: `test_messaging.bats`, `test_storage.bats`, `test_install.bats` (one unrelated pre-existing failure — a git-describe provenance format test that also fails on an unmodified worktree off the same `origin/main`, unrelated to this change), `test_despawn.bats`, `test_watch.bats`, plus `test_api.bats`/`test_codex_bridge.bats`/`test_delivery.bats`/`test_team.bats` (unaffected).