### PR TITLE
fix(send): validate team name before resolving roster config path

### DIFF
--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -14,6 +14,15 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/validate.sh"
+
+# #414: TEAM becomes a path segment (teams/$TEAM/config.json) below whether or
+# not --force is given, so validate it unconditionally, before any config-path
+# resolution or DB init. --force bypasses roster *membership* only — it must
+# never bypass team-name path safety.
+agmsg_validate_team_name "$TEAM" || exit 1
+
 DB="$(agmsg_db_path)"
 
 [ -f "$DB" ] || bash "$SCRIPT_DIR/internal/init-db.sh" >/dev/null

--- a/tests/test_messaging.bats
+++ b/tests/test_messaging.bats
@@ -61,6 +61,53 @@ teardown() {
   [ "$n" -eq 1 ]
 }
 
+# --- send.sh: team-name validation (#414) ---
+
+@test "send: rejects a team name with path traversal (../) and never consults a config outside teams/" {
+  local escape_dir
+  escape_dir="$(dirname "$TEST_SKILL_DIR")/escape-send"
+  mkdir -p "$escape_dir"
+  echo '{"agents":{"alice":{},"bob":{}}}' >"$escape_dir/config.json"
+  run bash "$SCRIPTS/send.sh" "../../escape-send" alice bob "hi"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "path traversal" ]]
+  local n
+  n=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COUNT(*) FROM messages;")
+  [ "$n" -eq 0 ]
+  rm -rf "$escape_dir"
+}
+
+@test "send: rejects '..' and '.' as team names" {
+  run bash "$SCRIPTS/send.sh" ".." alice bob "hi"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "not allowed" ]]
+  run bash "$SCRIPTS/send.sh" "." alice bob "hi"
+  [ "$status" -eq 1 ]
+}
+
+@test "send: rejects a team name starting with '-'" {
+  run bash "$SCRIPTS/send.sh" "-rf" alice bob "hi"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "must not start with" ]]
+}
+
+@test "send: rejects an invalid team name even when --force is supplied" {
+  run bash "$SCRIPTS/send.sh" "../../escape-force" alice bob "hi" --force
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "path traversal" ]]
+  local n
+  n=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COUNT(*) FROM messages;")
+  [ "$n" -eq 0 ]
+}
+
+@test "send: still accepts a UTF-8 (Japanese) team name" {
+  bash "$SCRIPTS/join.sh" "テストチーム" alice claude-code /tmp/project-jp
+  bash "$SCRIPTS/join.sh" "テストチーム" bob claude-code /tmp/project-jp2
+  run bash "$SCRIPTS/send.sh" "テストチーム" alice bob "hello"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Sent to bob" ]]
+}
+
 # --- inbox.sh ---
 
 @test "inbox: shows no messages when empty" {


### PR DESCRIPTION
## Summary

Fixes #414. `send.sh`'s roster validation (added in #409) resolved
`teams/<team>/config.json` from the raw `TEAM` argument without
calling `agmsg_validate_team_name` — the centralized validator every
other team-name-to-path entry point uses (`join.sh`, `team.sh`,
`leave.sh`, `rename.sh`, `rename-team.sh`, added for #140/#147).

A caller supplying a path-dangerous team name (`../..`, a leading
`-`, control characters) could steer the roster config read outside
`teams/`. This is a read-only containment issue (the constructed path
always appends `/config.json`, and the insert itself still just
stores the caller-supplied team string as data) — it does not permit
writes outside `teams/` — but it should not have been possible at all.

## Fix

`agmsg_validate_team_name "$TEAM"` now runs unconditionally, before
any config-path resolution or DB init — including when `--force` is
given. `--force` bypasses roster *membership* only; it must never
bypass team-name path safety.

## Tests

Added to `tests/test_messaging.bats`:
- rejects a traversal team name and confirms an external sentinel
  `config.json` outside `teams/` is never consulted (no insert)
- rejects `.` / `..` team names
- rejects a team name starting with `-`
- rejects a traversal team name even with `--force`
- still accepts a UTF-8 (Japanese) team name

All of `test_messaging.bats`, `test_delivery.bats`, `test_team.bats`,
`test_storage.bats`, `test_install.bats`, `test_watch.bats`,
`test_watch_once.bats`, `test_api.bats`, `test_codex_bridge.bats`,
`test_despawn.bats` pass locally, except one pre-existing, unrelated
failure in `test_install.bats` ("records a git-describe provenance
VERSION...") that also fails on an untouched `origin/main` checkout —
an environmental issue, not a regression from this change.