### PR TITLE
Fix Codex monitor multi-identity delivery

### DIFF
--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -62,6 +62,25 @@ INNER_EOF
 agmsg_session_start() {
   thread_id="$(agmsg_resolve_codex_thread "$PROJECT")"
   [ -n "$thread_id" ] || exit 0
+  # A recorded role belongs to its recorded Codex thread. The in-sandbox
+  # fallback has no launcher to arbitrate this, so exclude a mismatched role
+  # rather than ever injecting it into this session's thread (#150/#350).
+  # shellcheck source=../../../lib/role-session.sh
+  source "$SKILL_DIR/scripts/lib/role-session.sh"
+  project_phys="$(agmsg_canonical_path "$PROJECT" 2>/dev/null || printf '%s' "$PROJECT")"
+  safe_pairs=""
+  while IFS=$'\t' read -r candidate_team candidate_name; do
+    [ -n "$candidate_team" ] || continue
+    candidate_thread="$(agmsg_role_session_uuid "$candidate_team" "$candidate_name" 2>/dev/null || true)"
+    if [ -n "$candidate_thread" ]; then
+      candidate_project="$(agmsg_role_session_get "$candidate_team" "$candidate_name" project 2>/dev/null || true)"
+      candidate_project_phys="$(agmsg_canonical_path "$candidate_project" 2>/dev/null || printf '%s' "$candidate_project")"
+      { [ "$candidate_project_phys" = "$project_phys" ] && [ "$candidate_thread" = "$thread_id" ]; } || continue
+    fi
+    safe_pairs="${safe_pairs:+$safe_pairs$'\n'}${candidate_team}"$'\t'"${candidate_name}"
+  done <<< "$PAIRS"
+  PAIRS="$safe_pairs"
+  [ -n "$PAIRS" ] || exit 0
   app_server="${AGMSG_CODEX_BRIDGE_APP_SERVER:-}"
   if [ -z "$app_server" ]; then
     agent_pid=$(agmsg_agent_pid "$TYPE" 2>/dev/null || true)
@@ -81,25 +100,23 @@ agmsg_session_start() {
   fi
   [ -n "$app_server" ] || exit 0
 
-  pair_count=$(printf '%s\n' "$PAIRS" | awk 'NF >= 2 { c++ } END { print c + 0 }')
-  [ "$pair_count" = "1" ] || exit 0
-  team=$(printf '%s\n' "$PAIRS" | awk 'NF >= 2 { print $1; exit }')
-  name=$(printf '%s\n' "$PAIRS" | awk 'NF >= 2 { print $2; exit }')
-  [ -n "$team" ] && [ -n "$name" ] || exit 0
-
   if [ "${AGMSG_CODEX_BRIDGE_LAUNCHER:-}" = "1" ]; then
     project_hash=$(printf '%s' "$PROJECT" | agmsg_sha1)
     request_file="$RUN_DIR/codex-bridge-request.$project_hash"
     tmp_request="$request_file.$$"
     mkdir -p "$RUN_DIR" 2>/dev/null || true
-    printf '%s\t%s\t%s\t%s\t%s\n' \
-      "$TYPE" "$team" "$name" "$thread_id" "$app_server" > "$tmp_request"
+    printf '%s\t%s\t%s\n' "$TYPE" "$thread_id" "$app_server" > "$tmp_request"
     mv "$tmp_request" "$request_file"
     exit 0
   fi
 
   mkdir -p "$RUN_DIR" 2>/dev/null || true
-  pidfile="$RUN_DIR/codex-bridge.$team.$name.pid"
+  bridge_key=$(printf '%s' "$PAIRS" | agmsg_sha1)
+  bridge_pairs=()
+  while IFS=$'\t' read -r candidate_team candidate_name; do
+    bridge_pairs+=(--pair "$candidate_team"$'\t'"$candidate_name")
+  done <<< "$PAIRS"
+  pidfile="$RUN_DIR/codex-bridge.$bridge_key.pid"
   if [ -f "$pidfile" ]; then
     bridge_pid=$(cat "$pidfile" 2>/dev/null || true)
     if [ -n "$bridge_pid" ] && kill -0 "$bridge_pid" 2>/dev/null; then
@@ -107,7 +124,7 @@ agmsg_session_start() {
     fi
   fi
 
-  log="$RUN_DIR/codex-bridge.$team.$name.log"
+  log="$RUN_DIR/codex-bridge.$bridge_key.log"
   # An explicit AGMSG_CODEX_BRIDGE_CMD is a complete runnable (tests, custom
   # wrappers) — run it as-is. Only the default codex-bridge.js is launched
   # through a resolved Node, since its env-node shebang fails in shells where a
@@ -120,8 +137,7 @@ agmsg_session_start() {
   nohup "${bridge_run[@]}" \
     --project "$PROJECT" \
     --type "$TYPE" \
-    --team "$team" \
-    --name "$name" \
+    "${bridge_pairs[@]}" \
     --thread "$thread_id" \
     --app-server "$app_server" \
     --inline-inbox \

--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -111,7 +111,15 @@ agmsg_session_start() {
   fi
 
   mkdir -p "$RUN_DIR" 2>/dev/null || true
-  bridge_key=$(printf '%s' "$PAIRS" | agmsg_sha1)
+  pair_count=$(printf '%s\n' "$PAIRS" | grep -c . || true)
+  if [ "$pair_count" = "1" ]; then
+    IFS=$'\t' read -r key_team key_name <<EOF
+$PAIRS
+EOF
+    bridge_key="$key_team.$key_name"
+  else
+    bridge_key=$(printf '%s' "$PAIRS" | agmsg_sha1)
+  fi
   bridge_pairs=()
   while IFS=$'\t' read -r candidate_team candidate_name; do
     bridge_pairs+=(--pair "$candidate_team"$'\t'"$candidate_name")

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -95,12 +95,12 @@ while IFS="$TAB" read -r candidate_team candidate_name; do
   if [ -n "$candidate_thread" ]; then
     candidate_project="$(agmsg_role_session_get "$candidate_team" "$candidate_name" project 2>/dev/null || true)"
     candidate_project_phys="$(agmsg_canonical_path "$candidate_project" 2>/dev/null || printf '%s' "$candidate_project")"
-    # A foreign-project record is irrelevant here and falls back to the live
-    # thread. A lone role keeps #350's legacy recorded-thread affinity even
+    # A record for another project proves this role's current seat is elsewhere:
+    # never consume its unread rows from this project. A lone same-project role keeps #350's legacy recorded-thread affinity even
     # before a concrete request thread is available; multiplexed roles require
     # proof and are excluded while the hint is only `loaded`.
-    if [ "$candidate_project_phys" = "$PROJECT_PHYS" ] \
-       && { { [ "$thread_hint" = "loaded" ] && [ "$raw_identity_count" != "1" ]; } \
+    if [ "$candidate_project_phys" != "$PROJECT_PHYS" ] \
+       || { { [ "$thread_hint" = "loaded" ] && [ "$raw_identity_count" != "1" ]; } \
             || { [ "$thread_hint" != "loaded" ] && [ "$candidate_thread" != "$thread_hint" ]; }; }; then
       continue
     fi

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -55,6 +55,7 @@ while kill -0 "$PARENT_PID" 2>/dev/null; do
   sleep 0.3
 done
 [ -n "$ids" ] || exit 0
+registered_ids="$ids"
 
 # Safety over delivery (#150): a role-session record identifies the thread that
 # owns a role. Never inject that role's inbox into a different live TUI. Roles
@@ -115,6 +116,17 @@ else
 fi
 
 while kill -0 "$PARENT_PID" 2>/dev/null; do
+  # actas can join a second role after SessionStart. Re-exec through the same
+  # safety filter when the registration set changes, replacing the old bridge
+  # so the new role is actually subscribed instead of being stranded.
+  latest_ids="$(resolve_identity || true)"
+  if [ "$latest_ids" != "$registered_ids" ]; then
+    if [ -f "$pidfile" ]; then
+      old_pid="$(cat "$pidfile" 2>/dev/null || true)"
+      [ -n "$old_pid" ] && kill "$old_pid" 2>/dev/null || true
+    fi
+    exec "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID"
+  fi
   # Resolve the app-server URL (and thread) this iteration would launch against
   # FIRST, so the reuse check can compare a live bridge's bound server with the
   # current one. Thread source: a request file (older-codex hook) wins; otherwise

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -187,9 +187,9 @@ EOF
   # cwd has run more than one codex thread, so a co-resident thread can capture
   # this role's messages. The role-session record (#339) stores this role's own
   # thread deterministically; use it when present AND recorded for THIS project.
-  # A request-file thread (above) still wins; no record -- or a record for a
-  # different project -- falls back to "loaded" (fail-open for roles predating the
-  # record). Freshness holds because a role re-runs actas on resume (#339), which
+  # A request-file thread (above) still wins; roles with no record fall back to
+  # "loaded". A foreign-project record was filtered out before launch (#150).
+  # Freshness holds because a role re-runs actas on resume (#339), which
   # rewrites the record with its current thread.
   if [ "$thread_id" = "loaded" ] && [ "$(printf '%s\n' "$ids" | grep -c . || true)" = "1" ]; then
     IFS="$TAB" read -r team name <<EOF

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -46,6 +46,20 @@ resolve_identity() {  # prints "team<TAB>name" lines for the project's codex rol
     | sort -u
 }
 
+# Any change here can change the safe subscription set. Include the request
+# thread plus each role's recorded session/project, not merely registrations:
+# actas/resume rewrites a role record without changing identities.sh output.
+safety_fingerprint() {
+  local request="" team name rec rec_project
+  [ -f "$REQUEST_FILE" ] && request="$(cat "$REQUEST_FILE" 2>/dev/null || true)"
+  printf 'request=%s\n' "$request"
+  resolve_identity | while IFS="$TAB" read -r team name; do
+    rec="$(agmsg_role_session_uuid "$team" "$name" 2>/dev/null || true)"
+    rec_project="$(agmsg_role_session_get "$team" "$name" project 2>/dev/null || true)"
+    printf '%s\t%s\t%s\t%s\n' "$team" "$name" "$rec" "$rec_project"
+  done
+}
+
 # actas may register the role a moment after launch, so retry while the parent
 # (codex-monitor.sh) is alive. Multiple identities are intentional (#150).
 ids=""
@@ -55,7 +69,7 @@ while kill -0 "$PARENT_PID" 2>/dev/null; do
   sleep 0.3
 done
 [ -n "$ids" ] || exit 0
-registered_ids="$ids"
+safety_state="$(safety_fingerprint)"
 
 # Safety over delivery (#150): a role-session record identifies the thread that
 # owns a role. Never inject that role's inbox into a different live TUI. Roles
@@ -119,8 +133,8 @@ while kill -0 "$PARENT_PID" 2>/dev/null; do
   # actas can join a second role after SessionStart. Re-exec through the same
   # safety filter when the registration set changes, replacing the old bridge
   # so the new role is actually subscribed instead of being stranded.
-  latest_ids="$(resolve_identity || true)"
-  if [ "$latest_ids" != "$registered_ids" ]; then
+  latest_state="$(safety_fingerprint)"
+  if [ "$latest_state" != "$safety_state" ]; then
     if [ -f "$pidfile" ]; then
       old_pid="$(cat "$pidfile" 2>/dev/null || true)"
       [ -n "$old_pid" ] && kill "$old_pid" 2>/dev/null || true

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -88,13 +88,20 @@ EOF
   fi
 fi
 safe_ids=""
+raw_identity_count="$(printf '%s\n' "$ids" | grep -c . || true)"
 while IFS="$TAB" read -r candidate_team candidate_name; do
   [ -n "$candidate_team" ] || continue
   candidate_thread="$(agmsg_role_session_uuid "$candidate_team" "$candidate_name" 2>/dev/null || true)"
   if [ -n "$candidate_thread" ]; then
     candidate_project="$(agmsg_role_session_get "$candidate_team" "$candidate_name" project 2>/dev/null || true)"
     candidate_project_phys="$(agmsg_canonical_path "$candidate_project" 2>/dev/null || printf '%s' "$candidate_project")"
-    if [ "$candidate_project_phys" != "$PROJECT_PHYS" ] || [ "$thread_hint" = "loaded" ] || [ "$candidate_thread" != "$thread_hint" ]; then
+    # A foreign-project record is irrelevant here and falls back to the live
+    # thread. A lone role keeps #350's legacy recorded-thread affinity even
+    # before a concrete request thread is available; multiplexed roles require
+    # proof and are excluded while the hint is only `loaded`.
+    if [ "$candidate_project_phys" = "$PROJECT_PHYS" ] \
+       && { { [ "$thread_hint" = "loaded" ] && [ "$raw_identity_count" != "1" ]; } \
+            || { [ "$thread_hint" != "loaded" ] && [ "$candidate_thread" != "$thread_hint" ]; }; }; then
       continue
     fi
   fi
@@ -109,7 +116,15 @@ if [ -z "$ids" ]; then
   exec "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID"
 fi
 
-bridge_key="$(printf '%s' "$ids" | agmsg_sha1)"
+identity_count="$(printf '%s\n' "$ids" | grep -c . || true)"
+if [ "$identity_count" = "1" ]; then
+  IFS="$TAB" read -r key_team key_name <<EOF
+$ids
+EOF
+  bridge_key="$key_team.$key_name"
+else
+  bridge_key="$(printf '%s' "$ids" | agmsg_sha1)"
+fi
 bridge_pairs=()
 while IFS="$TAB" read -r candidate_team candidate_name; do
   bridge_pairs+=(--pair "$candidate_team"$'\t'"$candidate_name")

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Runs outside Codex's tool sandbox and owns the app-server connection: it starts
-# codex-bridge.js for this project's single codex identity.
+# Runs outside Codex's tool sandbox and owns the app-server connection. One
+# bridge subscribes to every unpinned codex identity in this project.
 #
 # On codex 0.141+ the SessionStart hook cannot resolve the thread id
 # (CODEX_THREAD_ID is not exported and no rollout is written for --remote
@@ -47,33 +47,63 @@ resolve_identity() {  # prints "team<TAB>name" lines for the project's codex rol
 }
 
 # actas may register the role a moment after launch, so retry while the parent
-# (codex-monitor.sh) is alive. Proceed only when exactly one identity resolves.
-team="" name=""
+# (codex-monitor.sh) is alive. Multiple identities are intentional (#150).
+ids=""
 while kill -0 "$PARENT_PID" 2>/dev/null; do
   ids="$(resolve_identity || true)"
-  count="$(printf '%s\n' "$ids" | grep -c . || true)"
-  if [ "$count" = "1" ]; then
-    IFS="$TAB" read -r team name <<EOF
-$ids
-EOF
-    [ -n "$team" ] && [ -n "$name" ] && break
-    team="" name=""
-  fi
+  [ -n "$ids" ] && break
   sleep 0.3
 done
-[ -n "$team" ] && [ -n "$name" ] || exit 0
+[ -n "$ids" ] || exit 0
 
-pidfile="$RUN_DIR/codex-bridge.$team.$name.pid"
-log="$RUN_DIR/codex-bridge.$team.$name.log"
+# Safety over delivery (#150): a role-session record identifies the thread that
+# owns a role. Never inject that role's inbox into a different live TUI. Roles
+# without a record may share the current project TUI. If the hook could not
+# provide a concrete live thread (`loaded`), recorded roles are conservatively
+# left unsubscribed rather than guessed. They remain unread for their proper
+# next SessionStart.
+thread_hint="loaded"
+if [ -f "$REQUEST_FILE" ]; then
+  request="$(cat "$REQUEST_FILE" 2>/dev/null || true)"
+  if [ -n "$request" ]; then
+    IFS="$TAB" read -r _hint_type _hint_thread _hint_app <<EOF
+$request
+EOF
+    [ -n "${_hint_thread:-}" ] && thread_hint="$_hint_thread"
+  fi
+fi
+safe_ids=""
+while IFS="$TAB" read -r candidate_team candidate_name; do
+  [ -n "$candidate_team" ] || continue
+  candidate_thread="$(agmsg_role_session_uuid "$candidate_team" "$candidate_name" 2>/dev/null || true)"
+  if [ -n "$candidate_thread" ]; then
+    candidate_project="$(agmsg_role_session_get "$candidate_team" "$candidate_name" project 2>/dev/null || true)"
+    candidate_project_phys="$(agmsg_canonical_path "$candidate_project" 2>/dev/null || printf '%s' "$candidate_project")"
+    if [ "$candidate_project_phys" != "$PROJECT_PHYS" ] || [ "$thread_hint" = "loaded" ] || [ "$candidate_thread" != "$thread_hint" ]; then
+      continue
+    fi
+  fi
+  safe_ids="${safe_ids:+$safe_ids$'\n'}${candidate_team}"$'\t'"${candidate_name}"
+done <<< "$ids"
+ids="$safe_ids"
+[ -n "$ids" ] || exit 0
+
+bridge_key="$(printf '%s' "$ids" | agmsg_sha1)"
+bridge_pairs=()
+while IFS="$TAB" read -r candidate_team candidate_name; do
+  bridge_pairs+=(--pair "$candidate_team"$'\t'"$candidate_name")
+done <<< "$ids"
+pidfile="$RUN_DIR/codex-bridge.$bridge_key.pid"
+log="$RUN_DIR/codex-bridge.$bridge_key.log"
 # Records the app-server URL the live bridge was launched against, so a later
 # launcher instance can tell a bridge bound to a stale app-server (old port,
 # from before a codex upgrade) from one bound to the current server. See #197/#237.
-appserver_file="$RUN_DIR/codex-bridge.$team.$name.appserver"
+appserver_file="$RUN_DIR/codex-bridge.$bridge_key.appserver"
 # Records the thread a live bridge was bound to (#350), so a later launcher can
 # rebind when the resolved thread changes -- e.g. once a role-session record
 # appears for a bridge first launched on "loaded", it is torn down and relaunched
 # on the recorded thread instead of clinging to the ambiguous "loaded" one.
-thread_file="$RUN_DIR/codex-bridge.$team.$name.thread"
+thread_file="$RUN_DIR/codex-bridge.$bridge_key.thread"
 # An explicit AGMSG_CODEX_BRIDGE_CMD is a complete runnable (tests, custom
 # wrappers) — run it as-is. Only the default codex-bridge.js is launched through
 # a resolved Node, since its env-node shebang fails where a version-manager Node
@@ -94,7 +124,7 @@ while kill -0 "$PARENT_PID" 2>/dev/null; do
   if [ -f "$REQUEST_FILE" ]; then
     request="$(cat "$REQUEST_FILE" 2>/dev/null || true)"
     if [ -n "$request" ]; then
-      IFS="$TAB" read -r _rtype _rteam _rname _rthread _rapp <<EOF
+      IFS="$TAB" read -r _rtype _rthread _rapp <<EOF
 $request
 EOF
       [ -n "${_rthread:-}" ] && thread_id="$_rthread"
@@ -102,7 +132,10 @@ EOF
     fi
   fi
 
-  # Prefer this role's RECORDED codex thread (#350). The app-server's "loaded"
+  # With exactly one identity, preserve #350's role-session thread affinity.
+  # Multiple identities are multiplexed into the active project thread; a role
+  # that has a recorded thread is handled by its own future launcher pass rather
+  # than being silently mapped to another role's recorded thread.
   # thread is whichever conversation the server last touched -- ambiguous when a
   # cwd has run more than one codex thread, so a co-resident thread can capture
   # this role's messages. The role-session record (#339) stores this role's own
@@ -111,7 +144,10 @@ EOF
   # different project -- falls back to "loaded" (fail-open for roles predating the
   # record). Freshness holds because a role re-runs actas on resume (#339), which
   # rewrites the record with its current thread.
-  if [ "$thread_id" = "loaded" ]; then
+  if [ "$thread_id" = "loaded" ] && [ "$(printf '%s\n' "$ids" | grep -c . || true)" = "1" ]; then
+    IFS="$TAB" read -r team name <<EOF
+$ids
+EOF
     rec_thread="$(agmsg_role_session_uuid "$team" "$name" 2>/dev/null || true)"
     if [ -n "$rec_thread" ]; then
       rec_project="$(agmsg_role_session_get "$team" "$name" project 2>/dev/null || true)"
@@ -148,8 +184,7 @@ EOF
   nohup "${bridge_run[@]}" \
     --project "$PROJECT" \
     --type "$TYPE" \
-    --team "$team" \
-    --name "$name" \
+    "${bridge_pairs[@]}" \
     --thread "$thread_id" \
     --app-server "$req_app_server" \
     --inline-inbox \

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -101,7 +101,13 @@ while IFS="$TAB" read -r candidate_team candidate_name; do
   safe_ids="${safe_ids:+$safe_ids$'\n'}${candidate_team}"$'\t'"${candidate_name}"
 done <<< "$ids"
 ids="$safe_ids"
-[ -n "$ids" ] || exit 0
+# A role record may be written by actas later in this same first turn. An empty
+# safe set is therefore transient, not terminal: retry while the parent lives.
+if [ -z "$ids" ]; then
+  kill -0 "$PARENT_PID" 2>/dev/null || exit 0
+  sleep 0.3
+  exec "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID"
+fi
 
 bridge_key="$(printf '%s' "$ids" | agmsg_sha1)"
 bridge_pairs=()

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -85,6 +85,7 @@ function parseArgs(argv) {
     requestTimeoutMs: Number(process.env.AGMSG_CODEX_BRIDGE_REQUEST_TIMEOUT_MS || 30000),
     watchFailureLimit: Number(process.env.AGMSG_CODEX_BRIDGE_WATCH_FAILURE_LIMIT || 3),
     inlineInbox: false,
+    pairs: [],
     turnTimeout: Number(process.env.AGMSG_CODEX_BRIDGE_TURN_TIMEOUT || 60),
   };
 
@@ -102,6 +103,10 @@ function parseArgs(argv) {
       opts.team = argv[++i];
     } else if (arg === "--name") {
       opts.name = argv[++i];
+    } else if (arg === "--pair") {
+      const [team, name] = (argv[++i] || "").split("\t");
+      if (!team || !name) die("--pair must be team<TAB>agent");
+      opts.pairs.push({ team, name });
     } else if (arg === "--timeout") {
       opts.timeout = Number(argv[++i]);
     } else if (arg === "--interval") {
@@ -171,7 +176,7 @@ function runScript(script, args) {
   return result;
 }
 
-function resolveIdentity(opts) {
+function resolveIdentities(opts) {
   const result = runScript("identities.sh", [toPosixPath(opts.project), opts.type]);
   if (result.status !== 0) {
     die(`identity resolution failed: ${(result.stderr || result.stdout).trim()}`);
@@ -187,7 +192,8 @@ function resolveIdentity(opts) {
     })
     .filter((pair) => pair.team && pair.name)
     .filter((pair) => !opts.team || pair.team === opts.team)
-    .filter((pair) => !opts.name || pair.name === opts.name);
+    .filter((pair) => !opts.name || pair.name === opts.name)
+    .filter((pair) => opts.pairs.length === 0 || opts.pairs.some((wanted) => wanted.team === pair.team && wanted.name === pair.name));
 
   const deduped = [];
   const seen = new Set();
@@ -200,8 +206,7 @@ function resolveIdentity(opts) {
   }
 
   if (deduped.length === 0) die("no matching codex identity; run actas or pass --team/--name");
-  if (deduped.length > 1) die("multiple identities match; pass --team and --name");
-  return deduped[0];
+  return deduped;
 }
 
 class AppServerClient {
@@ -658,9 +663,10 @@ class WebSocketAppServerClient {
 }
 
 class CodexBridge {
-  constructor(opts, identity) {
+  constructor(opts, identities) {
     this.opts = opts;
-    this.identity = identity;
+    this.identities = identities;
+    this.identity = identities[0];
     this.client = createAppServerClient(opts);
     this.threadId = opts.threadId || null;
     this.threadIdle = true;
@@ -675,8 +681,9 @@ class CodexBridge {
     this.watchRearmTimer = null;
     this.inlineInboxText = "";
     this.stopping = false;
-    this.pidfile = path.join(RUN_DIR, `codex-bridge.${identity.team}.${identity.name}.pid`);
-    this.metafile = path.join(RUN_DIR, `codex-bridge.${identity.team}.${identity.name}.meta`);
+    const key = crypto.createHash("sha1").update(identities.map((p) => `${p.team}\t${p.name}`).join("\n")).digest("hex");
+    this.pidfile = path.join(RUN_DIR, `codex-bridge.${key}.pid`);
+    this.metafile = path.join(RUN_DIR, `codex-bridge.${key}.meta`);
   }
 
   async run() {
@@ -724,8 +731,7 @@ class CodexBridge {
       [
         `pid=${process.pid}`,
         `project=${this.opts.project}`,
-        `team=${this.identity.team}`,
-        `name=${this.identity.name}`,
+        `identities=${this.identities.map((p) => `${p.team}/${p.name}`).join(",")}`,
         `type=${this.opts.type}`,
       ].join("\n") + "\n",
     );
@@ -826,15 +832,12 @@ class CodexBridge {
       // project path. The spawn cwd below stays native for the app-server.
       toPosixPath(this.opts.project),
       this.opts.type,
-      "--team",
-      this.identity.team,
-      "--name",
-      this.identity.name,
       "--timeout",
       String(this.opts.timeout),
       "--interval",
       String(this.opts.interval),
     ];
+    for (const pair of this.identities) command.push("--pair", `${pair.team}\t${pair.name}`);
     try {
       await this.client.request("process/spawn", {
         command,
@@ -1029,36 +1032,29 @@ class CodexBridge {
     const send = path.join(SCRIPTS_DIR, "send.sh");
     if (this.opts.inlineInbox) {
       return [
-        `agmsg delivered the following unread messages for ${this.identity.team}/${this.identity.name}:`,
+        "agmsg delivered the following unread messages. Each section names the identity to use when replying:",
         "",
         this.inlineInboxText.trim(),
         "",
         "Continue the conversation in this Codex thread. If a reply to an agmsg sender is needed, send it with:",
-        `${send} ${this.identity.team} ${this.identity.name} <to> <message>`,
+        this.identities.map((p) => `${send} ${p.team} ${p.name} <to> <message>  # reply as ${p.team}/${p.name}`).join("\n"),
       ].join("\n");
     }
     return [
-      `agmsg has unread messages for ${this.identity.team}/${this.identity.name}.`,
-      `Run: ${inbox} ${this.identity.team} ${this.identity.name}`,
+      `agmsg has unread messages for ${this.identities.map((p) => `${p.team}/${p.name}`).join(", ")}.`,
       "Read the messages and continue the conversation. If a reply is needed, send it with:",
-      `${send} ${this.identity.team} ${this.identity.name} <to> <message>`,
+      this.identities.map((p) => `${send} ${p.team} ${p.name} <to> <message>`).join("\n"),
     ].join("\n");
   }
 
   readInboxForPrompt() {
-    const result = spawnSync(BASH_BIN, [path.join(SCRIPTS_DIR, "inbox.sh"), this.identity.team, this.identity.name], {
-      cwd: this.opts.project,
-      encoding: "utf8",
-    });
-    if (result.error) {
-      console.error(`codex-bridge: inbox.sh failed: ${result.error.message}`);
-      return "";
+    const sections = [];
+    for (const pair of this.identities) {
+      const result = spawnSync(BASH_BIN, [path.join(SCRIPTS_DIR, "inbox.sh"), pair.team, pair.name], { cwd: this.opts.project, encoding: "utf8" });
+      if (result.error || result.status !== 0) { console.error(`codex-bridge: inbox.sh failed for ${pair.team}/${pair.name}`); continue; }
+      if ((result.stdout || "").trim()) sections.push(`Messages addressed to ${pair.team}/${pair.name}:\n${result.stdout.trim()}`);
     }
-    if (result.status !== 0) {
-      console.error(`codex-bridge: inbox.sh exited ${result.status}: ${(result.stderr || "").trim()}`);
-      return "";
-    }
-    return result.stdout || "";
+    return sections.join("\n\n");
   }
 
   async shutdown() {
@@ -1218,13 +1214,13 @@ async function main() {
     return;
   }
 
-  const identity = resolveIdentity(opts);
+  const identities = resolveIdentities(opts);
   if (opts.resolveOnly) {
-    console.log(`${identity.team}\t${identity.name}`);
+    console.log(identities.map((pair) => `${pair.team}\t${pair.name}`).join("\n"));
     return;
   }
 
-  const bridge = new CodexBridge(opts, identity);
+  const bridge = new CodexBridge(opts, identities);
   await bridge.run();
 }
 

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -1048,8 +1048,20 @@ class CodexBridge {
   }
 
   readInboxForPrompt() {
+    // Re-resolve locks immediately before reading. watch-once only tells us
+    // that *some* eligible identity woke; ownership can change before this
+    // turn starts, so never let a stale bridge membership mark another
+    // session's messages read.
+    const eligible = spawnSync(BASH_BIN, [path.join(SCRIPT_DIR, "eligible-pairs.sh"), toPosixPath(this.opts.project), this.opts.type,
+      ...this.identities.flatMap((pair) => ["--pair", `${pair.team}\t${pair.name}`])], { cwd: this.opts.project, encoding: "utf8" });
+    if (eligible.error || eligible.status !== 0) {
+      console.error("codex-bridge: could not resolve eligible identities before reading inbox");
+      return "";
+    }
+    const allowed = new Set((eligible.stdout || "").split(/\r?\n/).filter(Boolean));
     const sections = [];
     for (const pair of this.identities) {
+      if (!allowed.has(`${pair.team}\t${pair.name}`)) continue;
       const result = spawnSync(BASH_BIN, [path.join(SCRIPTS_DIR, "inbox.sh"), pair.team, pair.name], { cwd: this.opts.project, encoding: "utf8" });
       if (result.error || result.status !== 0) { console.error(`codex-bridge: inbox.sh failed for ${pair.team}/${pair.name}`); continue; }
       if ((result.stdout || "").trim()) sections.push(`Messages addressed to ${pair.team}/${pair.name}:\n${result.stdout.trim()}`);

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -681,7 +681,9 @@ class CodexBridge {
     this.watchRearmTimer = null;
     this.inlineInboxText = "";
     this.stopping = false;
-    const key = crypto.createHash("sha1").update(identities.map((p) => `${p.team}\t${p.name}`).join("\n")).digest("hex");
+    const key = identities.length === 1
+      ? `${identities[0].team}.${identities[0].name}`
+      : crypto.createHash("sha1").update(identities.map((p) => `${p.team}\t${p.name}`).join("\n")).digest("hex");
     this.pidfile = path.join(RUN_DIR, `codex-bridge.${key}.pid`);
     this.metafile = path.join(RUN_DIR, `codex-bridge.${key}.meta`);
   }

--- a/scripts/drivers/types/codex/eligible-pairs.sh
+++ b/scripts/drivers/types/codex/eligible-pairs.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Print identities this bridge may read right now. This deliberately resolves
+# locks at read time: a role may be claimed by another session after the bridge
+# armed its watcher, and inbox.sh would otherwise mark that role's rows read.
+PROJECT="${1:?project required}"
+TYPE="${2:?type required}"
+shift 2
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+source "$SCRIPT_DIR/../../../lib/actas-lock.sh"
+source "$SCRIPT_DIR/../../../lib/subscription.sh"
+
+requested=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --pair) requested="${requested:+$requested$'\n'}${2:?pair required}"; shift 2 ;;
+    *) echo "eligible-pairs: unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+pairs="$(agmsg_subscription_pairs "$PROJECT" "$TYPE" "")"
+if [ -n "$requested" ]; then
+  pairs="$(printf '%s\n' "$pairs" | while IFS=$'\t' read -r team name; do
+    printf '%s\n' "$requested" | grep -Fxq "${team}"$'\t'"${name}" && printf '%s\t%s\n' "$team" "$name"
+  done || true)"
+fi
+printf '%s\n' "$pairs"

--- a/scripts/drivers/types/codex/watch-once.sh
+++ b/scripts/drivers/types/codex/watch-once.sh
@@ -21,6 +21,7 @@ shift 2
 
 ACTIVE_NAME=""
 TEAM_FILTER=""
+PAIR_FILTERS=""
 TIMEOUT="${AGMSG_WATCH_ONCE_TIMEOUT:-300}"
 INTERVAL="${AGMSG_WATCH_ONCE_INTERVAL:-}"
 
@@ -28,6 +29,7 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --name) ACTIVE_NAME="${2:?--name needs an agent name}"; shift 2 ;;
     --team) TEAM_FILTER="${2:?--team needs a team name}"; shift 2 ;;
+    --pair) PAIR_FILTERS="${PAIR_FILTERS:+$PAIR_FILTERS$'\n'}${2:?--pair needs team<TAB>agent}"; shift 2 ;;
     --timeout) TIMEOUT="${2:?--timeout needs seconds}"; shift 2 ;;
     --interval) INTERVAL="${2:?--interval needs seconds}"; shift 2 ;;
     -h|--help)
@@ -61,6 +63,14 @@ DB="$(agmsg_db_path)"
 PAIRS="$(agmsg_subscription_pairs "$PROJECT_PATH" "$AGENT_TYPE" "" "$ACTIVE_NAME")" || exit 1
 if [ -n "$TEAM_FILTER" ]; then
   PAIRS=$(printf '%s\n' "$PAIRS" | awk -v t="$TEAM_FILTER" -F'\t' 'NF >= 2 && $1 == t')
+fi
+if [ -n "$PAIR_FILTERS" ]; then
+  selected=""
+  while IFS=$'\t' read -r team agent; do
+    printf '%s\n' "$PAIR_FILTERS" | grep -Fxq "${team}"$'\t'"${agent}" || continue
+    selected="${selected:+$selected$'\n'}${team}"$'\t'"${agent}"
+  done <<< "$PAIRS"
+  PAIRS="$selected"
 fi
 
 if [ -z "$PAIRS" ]; then

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -90,11 +90,19 @@ EOF
   [ "$output" = $'team\talice' ]
 }
 
-@test "codex-bridge: resolve-only rejects ambiguous identities" {
+@test "codex-bridge: resolve-only lists all identities when unfiltered" {
   skip_on_windows "codex bridge identity resolution on Windows (#182)"
   run node "$TYPES/codex/codex-bridge.js" --project "$PROJ" --resolve-only
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "multiple identities match" ]]
+  [ "$status" -eq 0 ]
+  [[ "$output" == *$'team\talice'* ]]
+  [[ "$output" == *$'team\tbob'* ]]
+}
+
+@test "codex-bridge: explicit --pair keeps a single identity" {
+  skip_on_windows "codex bridge identity resolution on Windows (#182)"
+  run node "$TYPES/codex/codex-bridge.js" --project "$PROJ" --pair $'team\tbob' --resolve-only
+  [ "$status" -eq 0 ]
+  [ "$output" = $'team\tbob' ]
 }
 
 @test "codex-bridge: rejects unsupported app-server endpoints" {

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -59,12 +59,10 @@ run_launcher() {
   grep -q -- "--thread loaded" "$CAPTURE"
 }
 
-@test "launcher: falls back to 'loaded' when the record is for a different project (#350)" {
+@test "launcher: leaves a role with a foreign-project record unsubscribed (#150)" {
   put_record team alice other-thread "/some/other/project" codex
   run_launcher
-  [ -f "$CAPTURE" ]
-  grep -q -- "--thread loaded" "$CAPTURE"
-  ! grep -q -- "--thread other-thread" "$CAPTURE"
+  [ ! -f "$CAPTURE" ]
 }
 
 @test "launcher: writes the bound-thread file so a later launcher can rebind (#350)" {


### PR DESCRIPTION
Fixes #150.\n\nCodex monitor now multiplexes eligible identities into one bridge and labels inline inbox sections with the identity to use for replies. Explicit --team/--name filtering remains supported.\n\nFor role-session safety, identities recorded against a different (or unprovable) live Codex thread are left unread rather than injected into the wrong thread. Multiple concurrent live TUIs are intentionally not multiplexed.\n\nTests: bats -f 'resolve-only|explicit --pair' tests/test_codex_bridge.bats; shell and Node syntax checks; git diff --check.