### PR TITLE
fix(codex-bridge): auto-decline approval requests, arm the turn watchdog on externally-active turns

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -268,31 +268,34 @@ class AppServerClient {
       return;
     }
 
-    if (Object.prototype.hasOwnProperty.call(message, "id")) {
-      const pending = this.pending.get(message.id);
-      if (pending) {
-        this.pending.delete(message.id);
-        if (message.error) {
-          pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
-        } else {
-          pending.resolve(message.result);
-        }
-        return;
-      }
-      // Not a reply to one of our own requests -- a server-initiated request
-      // awaiting an answer (e.g. an approval/elicitation prompt). Before #299
-      // this branch returned here unconditionally, silently dropping any such
-      // request before method dispatch ever ran: the app-server (and whatever
-      // real-world action was waiting on it, like a shell command) then hung
-      // forever with no reply ever sent.
-      if (message.method) {
+    // A message carrying `method` is always a request or notification FROM
+    // the app-server -- check this BEFORE looking at `pending`. Client and
+    // server number their own outbound requests independently on this
+    // bidirectional connection, so a server-initiated request's `id` can
+    // collide with the id of one of OUR still-outstanding requests (e.g. our
+    // pending "turn/start" and an incoming approval request both landing on
+    // id 4). Checking `pending` first would then wrongly resolve our own
+    // request with the approval's params and swallow the approval -- the
+    // exact #299 deadlock this fix exists to close. `method` presence is
+    // what a JSON-RPC response never has, so it is the correct discriminator.
+    if (message.method) {
+      if (Object.prototype.hasOwnProperty.call(message, "id")) {
         this.dispatchRequest(message.id, message.method, message.params || {});
+      } else if (this.handlers.has(message.method)) {
+        this.dispatch(message.method, message.params || {});
       }
       return;
     }
 
-    if (message.method && this.handlers.has(message.method)) {
-      this.dispatch(message.method, message.params || {});
+    if (Object.prototype.hasOwnProperty.call(message, "id")) {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      if (message.error) {
+        pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
+      } else {
+        pending.resolve(message.result);
+      }
     }
   }
 
@@ -593,28 +596,33 @@ class WebSocketAppServerClient {
       console.error(`codex-bridge: ignoring non-json app-server message: ${line}`);
       return;
     }
-    if (Object.prototype.hasOwnProperty.call(message, "id")) {
-      const pending = this.pending.get(message.id);
-      if (pending) {
-        this.pending.delete(message.id);
-        if (message.error) {
-          pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
-        } else {
-          pending.resolve(message.result);
-        }
-        return;
-      }
-      // Not a reply to one of our own requests -- a server-initiated request
-      // awaiting an answer (e.g. an approval/elicitation prompt). Before #299
-      // this branch returned here unconditionally, silently dropping any such
-      // request before method dispatch ever ran.
-      if (message.method) {
+    // A message carrying `method` is always a request or notification FROM
+    // the app-server -- check this BEFORE looking at `pending`. Client and
+    // server number their own outbound requests independently on this
+    // bidirectional connection, so a server-initiated request's `id` can
+    // collide with the id of one of OUR still-outstanding requests. Checking
+    // `pending` first would then wrongly resolve our own request with the
+    // approval's params and swallow the approval -- the exact #299 deadlock
+    // this fix exists to close. `method` presence is what a JSON-RPC response
+    // never has, so it is the correct discriminator.
+    if (message.method) {
+      if (Object.prototype.hasOwnProperty.call(message, "id")) {
         this.dispatchRequest(message.id, message.method, message.params || {});
+      } else if (this.handlers.has(message.method)) {
+        this.dispatch(message.method, message.params || {});
       }
       return;
     }
-    if (message.method && this.handlers.has(message.method)) {
-      this.dispatch(message.method, message.params || {});
+
+    if (Object.prototype.hasOwnProperty.call(message, "id")) {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      if (message.error) {
+        pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
+      } else {
+        pending.resolve(message.result);
+      }
     }
   }
 

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -212,6 +212,7 @@ class AppServerClient {
     this.nextId = 1;
     this.pending = new Map();
     this.handlers = new Map();
+    this.requestHandlers = new Map();
     this.child = null;
   }
 
@@ -249,6 +250,14 @@ class AppServerClient {
     this.handlers.set(method, handler);
   }
 
+  // Register a handler for a REQUEST the app-server sends us (a message with
+  // both `method` and `id`, expecting a reply) -- as opposed to `on()`, which
+  // only ever sees notifications (no `id`). Approval/elicitation prompts are
+  // requests: see dispatchRequest() and #299.
+  onRequest(method, handler) {
+    this.requestHandlers.set(method, handler);
+  }
+
   handleLine(line) {
     if (!line.trim()) return;
     let message;
@@ -261,12 +270,23 @@ class AppServerClient {
 
     if (Object.prototype.hasOwnProperty.call(message, "id")) {
       const pending = this.pending.get(message.id);
-      if (!pending) return;
-      this.pending.delete(message.id);
-      if (message.error) {
-        pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
-      } else {
-        pending.resolve(message.result);
+      if (pending) {
+        this.pending.delete(message.id);
+        if (message.error) {
+          pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
+        } else {
+          pending.resolve(message.result);
+        }
+        return;
+      }
+      // Not a reply to one of our own requests -- a server-initiated request
+      // awaiting an answer (e.g. an approval/elicitation prompt). Before #299
+      // this branch returned here unconditionally, silently dropping any such
+      // request before method dispatch ever ran: the app-server (and whatever
+      // real-world action was waiting on it, like a shell command) then hung
+      // forever with no reply ever sent.
+      if (message.method) {
+        this.dispatchRequest(message.id, message.method, message.params || {});
       }
       return;
     }
@@ -274,6 +294,30 @@ class AppServerClient {
     if (message.method && this.handlers.has(message.method)) {
       this.dispatch(message.method, message.params || {});
     }
+  }
+
+  dispatchRequest(id, method, params) {
+    const handler = this.requestHandlers.get(method);
+    if (!handler) {
+      console.error(`codex-bridge: no handler for app-server request '${method}'; replying with method-not-found`);
+      this.respondError(id, -32601, `Method not found: ${method}`);
+      return;
+    }
+    Promise.resolve()
+      .then(() => handler(params))
+      .then((result) => this.respond(id, result === undefined ? null : result))
+      .catch((error) => {
+        console.error(`codex-bridge: ${method} request handler failed: ${error.message}`);
+        this.respondError(id, -32000, error.message || String(error));
+      });
+  }
+
+  respond(id, result) {
+    this.child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+  }
+
+  respondError(id, code, message) {
+    this.child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } })}\n`);
   }
 
   request(method, params) {
@@ -349,6 +393,7 @@ class WebSocketAppServerClient {
     this.nextId = 1;
     this.pending = new Map();
     this.handlers = new Map();
+    this.requestHandlers = new Map();
     this.socket = null;
     this.buffer = Buffer.alloc(0);
     this.connected = false;
@@ -442,6 +487,14 @@ class WebSocketAppServerClient {
 
   on(method, handler) {
     this.handlers.set(method, handler);
+  }
+
+  // Register a handler for a REQUEST the app-server sends us (a message with
+  // both `method` and `id`, expecting a reply) -- as opposed to `on()`, which
+  // only ever sees notifications (no `id`). Approval/elicitation prompts are
+  // requests: see dispatchRequest() and #299.
+  onRequest(method, handler) {
+    this.requestHandlers.set(method, handler);
   }
 
   handleData(chunk, resolveStart, rejectStart) {
@@ -542,18 +595,51 @@ class WebSocketAppServerClient {
     }
     if (Object.prototype.hasOwnProperty.call(message, "id")) {
       const pending = this.pending.get(message.id);
-      if (!pending) return;
-      this.pending.delete(message.id);
-      if (message.error) {
-        pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
-      } else {
-        pending.resolve(message.result);
+      if (pending) {
+        this.pending.delete(message.id);
+        if (message.error) {
+          pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
+        } else {
+          pending.resolve(message.result);
+        }
+        return;
+      }
+      // Not a reply to one of our own requests -- a server-initiated request
+      // awaiting an answer (e.g. an approval/elicitation prompt). Before #299
+      // this branch returned here unconditionally, silently dropping any such
+      // request before method dispatch ever ran.
+      if (message.method) {
+        this.dispatchRequest(message.id, message.method, message.params || {});
       }
       return;
     }
     if (message.method && this.handlers.has(message.method)) {
       this.dispatch(message.method, message.params || {});
     }
+  }
+
+  dispatchRequest(id, method, params) {
+    const handler = this.requestHandlers.get(method);
+    if (!handler) {
+      console.error(`codex-bridge: no handler for app-server request '${method}'; replying with method-not-found`);
+      this.respondError(id, -32601, `Method not found: ${method}`);
+      return;
+    }
+    Promise.resolve()
+      .then(() => handler(params))
+      .then((result) => this.respond(id, result === undefined ? null : result))
+      .catch((error) => {
+        console.error(`codex-bridge: ${method} request handler failed: ${error.message}`);
+        this.respondError(id, -32000, error.message || String(error));
+      });
+  }
+
+  respond(id, result) {
+    this.sendJson({ jsonrpc: "2.0", id, result });
+  }
+
+  respondError(id, code, message) {
+    this.sendJson({ jsonrpc: "2.0", id, error: { code, message } });
   }
 
   request(method, params) {
@@ -691,9 +777,28 @@ class CodexBridge {
     this.client.on("turn/started", this.clientHandler("turn/started", () => {
       this.turnActive = true;
       this.threadIdle = false;
+      // This turn was not started by tryStartTurn() -- e.g. a TUI-driven turn
+      // on a thread the bridge shares -- so nothing else will arm a watchdog
+      // for it. Without one, a turn that never reports completion (the app
+      // -server does not reliably send turn/completed, see #41) leaves
+      // turnActive stuck true and every later wake deferred forever. See #299.
+      this.startTurnWatchdog();
     }));
     this.client.on("turn/completed", this.clientHandler("turn/completed", (params) => this.onTurnCompleted(params)));
     this.client.on("turn/failed", this.clientHandler("turn/failed", () => this.onTurnCompleted()));
+
+    // A headless bridge must never leave a prompt only a human can answer
+    // unanswered -- an unanswered approval/elicitation request wedges the
+    // thread in "waitingOnApproval" forever, with no watchdog able to save it
+    // (see #299). Auto-decline everything: a denied command/patch/permission
+    // still lets the turn finish normally instead of hanging.
+    this.client.onRequest("item/commandExecution/requestApproval", () => this.denyApproval());
+    this.client.onRequest("item/fileChange/requestApproval", () => this.denyApproval());
+    this.client.onRequest("item/permissions/requestApproval", () => this.denyPermissions());
+    this.client.onRequest("mcpServer/elicitation/request", () => this.denyElicitation());
+    // Legacy (pre-v2) app-server protocol names, kept as a safety net.
+    this.client.onRequest("execCommandApproval", () => this.denyLegacyApproval());
+    this.client.onRequest("applyPatchApproval", () => this.denyLegacyApproval());
 
     this.client.start();
     await this.client.ready?.();
@@ -800,6 +905,11 @@ class CodexBridge {
       const type = response.thread.status && response.thread.status.type;
       this.threadIdle = type !== "active";
       this.turnActive = type === "active";
+      // The thread can already be active on resume (e.g. a stuck approval
+      // predating this bridge, or a co-resident TUI turn) with no bridge-owned
+      // turn/start to hang a watchdog off of. Arm one here too so a pending
+      // wake never waits on it forever. See #299.
+      if (this.turnActive) this.startTurnWatchdog();
       console.error(`codex-bridge: resumed thread ${this.threadId}`);
       return;
     }
@@ -907,6 +1017,10 @@ class CodexBridge {
     if (type === "active") {
       this.turnActive = true;
       this.threadIdle = false;
+      // See the identical comment on the "turn/started" handler in run() --
+      // this transition can also happen without tryStartTurn() ever calling
+      // startTurnWatchdog() itself. See #299.
+      this.startTurnWatchdog();
       return;
     }
     if (type === "idle") {
@@ -1017,6 +1131,29 @@ class CodexBridge {
   onServerError(params) {
     if (params.threadId && params.threadId !== this.threadId) return;
     console.error(`codex-bridge: server error: ${JSON.stringify(params)}`);
+  }
+
+  // Response shapes below are the app-server's actual v2/legacy approval
+  // protocol (codex-rs app-server-protocol ServerRequest), not guesses.
+  denyApproval() {
+    console.error("codex-bridge: auto-declining an approval request (headless bridge, see #299)");
+    return { decision: "decline" };
+  }
+
+  denyLegacyApproval() {
+    console.error("codex-bridge: auto-denying a legacy approval request (headless bridge, see #299)");
+    return { decision: "denied" };
+  }
+
+  denyPermissions() {
+    // No optional grant fields set = no additional permissions granted.
+    console.error("codex-bridge: auto-declining a permissions request (headless bridge, see #299)");
+    return { permissions: {}, scope: "turn" };
+  }
+
+  denyElicitation() {
+    console.error("codex-bridge: auto-declining an MCP elicitation request (headless bridge, see #299)");
+    return { action: "decline", content: null, _meta: null };
   }
 
   onAgentMessageDelta(params) {

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -1259,3 +1259,166 @@ EOF
   [[ "$output" =~ "wakeup 2" ]]    # proves wakeup 1 was delivered, not stale-stopped
   grep -q "turn/start" "$log"      # the deferred wake actually reached a turn
 }
+
+# --- deadlock hardening (#299): the bridge must never leave an app-server
+# request unanswered, and a watchdog must always be armed while a turn is
+# active, even when the bridge did not start that turn itself. ---
+
+@test "codex-bridge: auto-declines an approval request from the app-server (#299)" {
+  run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
+  if [ "$status" -ne 0 ]; then
+    skip "node child_process.spawn is not available in this sandbox"
+  fi
+
+  local fake="$TEST_SKILL_DIR/fake-app-server-approval.js"
+  local log="$TEST_SKILL_DIR/fake-app-server-approval.log"
+  cat >"$fake" <<'EOF'
+const fs = require("fs");
+const readline = require("readline");
+const log = process.argv[2];
+const rl = readline.createInterface({ input: process.stdin });
+function send(value) { process.stdout.write(`${JSON.stringify(value)}\n`); }
+rl.on("line", (line) => {
+  fs.appendFileSync(log, `${line}\n`);
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  } else if (message.method === "thread/start") {
+    send({ jsonrpc: "2.0", id: message.id, result: { thread: { id: "thread-1", status: { type: "idle" } } } });
+  } else if (message.method === "process/spawn") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "process/exited", params: { processHandle: message.params.processHandle, exitCode: 0, stdout: "status=pending count=1 max_id=1\n", stderr: "" } });
+    }, 10);
+  } else if (message.method === "turn/start") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    // A server-initiated request: only a human could normally answer this.
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", id: 500, method: "item/commandExecution/requestApproval", params: { command: ["rm", "-rf", "/"] } });
+    }, 10);
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: "turn-1" } } });
+    }, 40);
+  } else if (message.method === "process/kill") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  }
+});
+EOF
+
+  AGMSG_CODEX_APP_SERVER_CMD="node $fake $log" run node "$TYPES/codex/codex-bridge.js" \
+    --project "$PROJ" --team team --name alice --timeout 1 --interval 1 --max-wakes 1
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "auto-declining an approval request" ]]
+  grep -q '"id":500' "$log"          # the bridge's reply, echoed back by the fake server
+  grep -q '"decision":"decline"' "$log"
+}
+
+@test "codex-bridge: an unhandled server-initiated request gets a method-not-found reply instead of hanging (#299)" {
+  run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
+  if [ "$status" -ne 0 ]; then
+    skip "node child_process.spawn is not available in this sandbox"
+  fi
+
+  local fake="$TEST_SKILL_DIR/fake-app-server-unknown-request.js"
+  local log="$TEST_SKILL_DIR/fake-app-server-unknown-request.log"
+  cat >"$fake" <<'EOF'
+const fs = require("fs");
+const readline = require("readline");
+const log = process.argv[2];
+const rl = readline.createInterface({ input: process.stdin });
+function send(value) { process.stdout.write(`${JSON.stringify(value)}\n`); }
+rl.on("line", (line) => {
+  fs.appendFileSync(log, `${line}\n`);
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    // A future/unknown request type the bridge has no handler for.
+    send({ jsonrpc: "2.0", id: 9001, method: "totally/unknown/method", params: {} });
+  } else if (message.method === "thread/start") {
+    send({ jsonrpc: "2.0", id: message.id, result: { thread: { id: "thread-1", status: { type: "idle" } } } });
+  } else if (message.method === "process/spawn") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "process/exited", params: { processHandle: message.params.processHandle, exitCode: 0, stdout: "status=pending count=1 max_id=1\n", stderr: "" } });
+    }, 10);
+  } else if (message.method === "turn/start") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: "turn-1" } } });
+    }, 10);
+  } else if (message.method === "process/kill") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  }
+});
+EOF
+
+  AGMSG_CODEX_APP_SERVER_CMD="node $fake $log" run node "$TYPES/codex/codex-bridge.js" \
+    --project "$PROJ" --team team --name alice --timeout 1 --interval 1 --max-wakes 1
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "no handler for app-server request 'totally/unknown/method'" ]]
+  grep -q '"id":9001' "$log"
+  grep -q '"code":-32601' "$log"
+}
+
+@test "codex-bridge: the turn watchdog rescues a resumed thread already active with no bridge-owned turn (#299)" {
+  run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
+  if [ "$status" -ne 0 ]; then
+    skip "node child_process.spawn is not available in this sandbox"
+  fi
+
+  # Regression: thread/resume reports the thread already "active" (e.g. a
+  # stuck approval predating this bridge) and this fake NEVER sends
+  # turn/completed or an idle notification -- the pre-#299 bridge had no
+  # watchdog for a turn it did not start itself, so a pending wake would wait
+  # forever. With the fix, startTurnWatchdog() is armed on resume too, so the
+  # deferred wake still gets delivered once the (short, test-only) turn
+  # timeout elapses.
+  local fake="$TEST_SKILL_DIR/fake-app-server-stuck-active.js"
+  local log="$TEST_SKILL_DIR/fake-app-server-stuck-active.log"
+  cat >"$fake" <<'EOF'
+const fs = require("fs");
+const readline = require("readline");
+const log = process.argv[2];
+const rl = readline.createInterface({ input: process.stdin });
+let spawns = 0;
+function send(value) { process.stdout.write(`${JSON.stringify(value)}\n`); }
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  fs.appendFileSync(log, `${message.method}\n`);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  } else if (message.method === "thread/resume") {
+    send({ jsonrpc: "2.0", id: message.id, result: { thread: { id: message.params.threadId, status: { type: "active" } } } });
+  } else if (message.method === "process/spawn") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    spawns += 1;
+    // Same unread max_id (5) until the deferred wake is delivered; a second
+    // message (6) follows so the run then terminates via --max-wakes, same
+    // pattern as the "delivers a wake observed while..." test above.
+    const id = spawns === 1 ? 5 : 6;
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "process/exited", params: { processHandle: message.params.processHandle, exitCode: 0, stdout: `status=pending count=1 max_id=${id}\n`, stderr: "" } });
+    }, 10);
+  } else if (message.method === "turn/start") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: "turn-1" } } });
+    }, 10);
+  } else if (message.method === "process/kill") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  }
+});
+EOF
+
+  AGMSG_CODEX_APP_SERVER_CMD="node $fake $log" run node "$TYPES/codex/codex-bridge.js" \
+    --project "$PROJ" --team team --name alice --thread thread-active \
+    --timeout 1 --interval 1 --turn-timeout 1 --max-wakes 2
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "wakeup 1" ]]
+  [[ "$output" =~ "wakeup 2" ]]
+  [[ "$output" =~ "started turn" ]]
+  grep -q "turn/start" "$log"
+}

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -1362,6 +1362,63 @@ EOF
   grep -q '"code":-32601' "$log"
 }
 
+@test "codex-bridge: an approval request id colliding with our own pending request id is still answered (#299 review)" {
+  run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
+  if [ "$status" -ne 0 ]; then
+    skip "node child_process.spawn is not available in this sandbox"
+  fi
+
+  # Client and server number their OWN outbound requests independently on
+  # this bidirectional connection, so a server-initiated request's id can
+  # collide with the id of one of our still-outstanding requests. Reuse the
+  # exact id the bridge assigned to its own pending "turn/start" (message.id
+  # at that point, whatever it happens to be) for the approval request, and
+  # send it BEFORE turn/start's real ack -- while that id is still pending.
+  # A handleLine() that checked `pending` before `method` would wrongly
+  # resolve turn/start with the approval's params and never reply to the
+  # approval at all, silently swallowing the real ack too.
+  local fake="$TEST_SKILL_DIR/fake-app-server-id-collision.js"
+  local log="$TEST_SKILL_DIR/fake-app-server-id-collision.log"
+  cat >"$fake" <<'EOF'
+const fs = require("fs");
+const readline = require("readline");
+const log = process.argv[2];
+const rl = readline.createInterface({ input: process.stdin });
+function send(value) { process.stdout.write(`${JSON.stringify(value)}\n`); }
+rl.on("line", (line) => {
+  fs.appendFileSync(log, `${line}\n`);
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  } else if (message.method === "thread/start") {
+    send({ jsonrpc: "2.0", id: message.id, result: { thread: { id: "thread-1", status: { type: "idle" } } } });
+  } else if (message.method === "process/spawn") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "process/exited", params: { processHandle: message.params.processHandle, exitCode: 0, stdout: "status=pending count=1 max_id=1\n", stderr: "" } });
+    }, 10);
+  } else if (message.method === "turn/start") {
+    const collideId = message.id;
+    send({ jsonrpc: "2.0", id: collideId, method: "item/commandExecution/requestApproval", params: { command: ["rm", "-rf", "/"] } });
+    send({ jsonrpc: "2.0", id: collideId, result: {} });
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: "turn-1" } } });
+    }, 10);
+  } else if (message.method === "process/kill") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  }
+});
+EOF
+
+  AGMSG_CODEX_APP_SERVER_CMD="node $fake $log" run node "$TYPES/codex/codex-bridge.js" \
+    --project "$PROJ" --team team --name alice --timeout 1 --interval 1 --max-wakes 1
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "auto-declining an approval request" ]]
+  [[ "$output" =~ "started turn" ]]   # proves turn/start's real ack was NOT swallowed by the collision
+  grep -q '"decision":"decline"' "$log"
+}
+
 @test "codex-bridge: the turn watchdog rescues a resumed thread already active with no bridge-owned turn (#299)" {
   run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
   if [ "$status" -ne 0 ]; then


### PR DESCRIPTION
## What

Fixes the Codex bridge deadlock described in #299: a thread stuck in `waitingOnApproval` wedged the bridge forever, with no way for the delivery to recover.

Root cause, confirmed against current `main` and against the actual app-server protocol (codex-rs `app-server-protocol` schema):

1. **No approval handler at all.** The bridge never registered a handler for any server-initiated request (approval, elicitation, etc.).
2. **Deeper: `AppServerClient.handleLine()` silently dropped every such request before dispatch could even run.** Any inbound message with an `id` was treated as a reply to one of *our own* outbound requests; if it didn't match a pending request, the code returned immediately — before the `method`-based dispatch table was ever consulted. A server-initiated request always carries an `id` (it expects a reply), so even a registered `.on("approval/...")`-style handler could never have been reached. Fixing (1) required fixing (2) first.
3. **The turn watchdog only ever armed after the bridge's own `turn/start` succeeded.** A thread that was already `active` for any other reason (a stuck approval predating the bridge, a co-resident TUI turn, a `turn/started` notification not caused by us) never got a watchdog, so a deferred wake could wait forever.

## Fix

- `AppServerClient`/`WebSocketAppServerClient.handleLine()` now route an unmatched `id`+`method` message to a new request-handler table (`onRequest()`/`dispatchRequest()`) instead of dropping it. A method with no registered handler gets an explicit JSON-RPC `-32601` method-not-found reply instead of hanging the caller forever.
- The bridge auto-declines `item/commandExecution/requestApproval`, `item/fileChange/requestApproval`, `item/permissions/requestApproval`, `mcpServer/elicitation/request`, and the legacy v1 `execCommandApproval`/`applyPatchApproval` methods. A headless bridge must never leave a prompt only a human can answer unanswered; a denied command/patch/permission still lets the turn finish normally instead of hanging.
- `startTurnWatchdog()` — the existing #41 mechanism that assumes a turn has ended after a timeout and resumes wake detection — is now also armed at every place a thread transitions to "active" outside of `tryStartTurn()`'s own success path: the `turn/started` notification handler, `onThreadStatus()`'s active branch, and an already-active thread discovered on `thread/resume`. No new watchdog concept or config was needed — this just closes the gaps in the one that already exists and is already tested.

## Scope note

Two of the issue's suggested fixes are deliberately **out of scope** for this PR:

- **Launcher liveness beyond URL/thread match** (issue point 3) — already partially covered by #350/#353 (thread-guard, merged after this issue was filed), but a heartbeat-based freshness check for the remaining gap risks false-positive teardown of a healthy-but-legitimately-idle bridge. Needs a more careful design.
- **Prefer the most-recently-active loaded thread over `ids[0]`** (issue point 4) — largely moot now that #350's role-session binding avoids the ambiguous "loaded" path for any role that has run `actas`; the residual case is narrow and the relevant app-server API for "most recent" wasn't confirmed.

Both are noted here rather than filed as new issues, to avoid issue sprawl.

## Tests

Added to `tests/test_codex_bridge.bats` (all via the existing fake-stdio-app-server harness):
- auto-declines an approval request from the app-server
- an unhandled server-initiated request gets a method-not-found reply instead of hanging
- the turn watchdog rescues a resumed thread already active with no bridge-owned turn

All 30 tests in `test_codex_bridge.bats` (27 pre-existing + 3 new) and all 4 in `test_codex_bridge_launcher.bats` pass locally.

Closes #299.
