### PR TITLE
fix(check-inbox): bound the stdin read so a never-closed pipe cannot freeze the agent pane

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -30,10 +30,23 @@ emit_status_json() {
 
 # Hook runtimes that pass JSON do so on stdin. Interactive invocations such as
 # Gemini's PostToolUse command may inherit a terminal stdin instead; reading
-# unconditionally there blocks waiting for input.
+# unconditionally there blocks waiting for input. The `[ ! -t 0 ]` guard above
+# only rules out that TTY case -- a non-TTY stdin whose write end is left
+# open (a hook runtime that writes the payload and then simply never closes
+# the pipe) still leaves this `cat` waiting for an EOF that never arrives.
+# Stop/turn hooks run synchronously, so a `cat` stuck here freezes the whole
+# agent pane until the user kills it. Bound the read; a runtime that forgets
+# to close its pipe still gets its payload delivered (it's already sitting in
+# the command substitution buffer by the time the deadline fires), just a few
+# seconds late instead of never. Fails open when `timeout` isn't on PATH
+# (stock macOS) -- same unbounded read as before, no regression there. #381
 INPUT=""
 if [ ! -t 0 ]; then
-  INPUT=$(cat 2>/dev/null || true)
+  if command -v timeout >/dev/null 2>&1; then
+    INPUT=$(timeout "${AGMSG_STDIN_TIMEOUT:-2}" cat 2>/dev/null || true)
+  else
+    INPUT=$(cat 2>/dev/null || true)
+  fi
 fi
 
 # Prevent infinite loop: if stop hook is already active, exit silently

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -43,7 +43,7 @@ emit_status_json() {
 INPUT=""
 if [ ! -t 0 ]; then
   if command -v timeout >/dev/null 2>&1; then
-    INPUT=$(timeout "${AGMSG_STDIN_TIMEOUT:-2}" cat 2>/dev/null || true)
+    INPUT=$(timeout "${AGMSG_HOOK_STDIN_TIMEOUT:-2}" cat 2>/dev/null || true)
   else
     INPUT=$(cat 2>/dev/null || true)
   fi

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -30,7 +30,7 @@ emit_status_json() {
 
 # Hook runtimes that pass JSON do so on stdin. Interactive invocations such as
 # Gemini's PostToolUse command may inherit a terminal stdin instead; reading
-# unconditionally there blocks waiting for input. The `[ ! -t 0 ]` guard above
+# unconditionally there blocks waiting for input. The `[ ! -t 0 ]` guard just below
 # only rules out that TTY case -- a non-TTY stdin whose write end is left
 # open (a hook runtime that writes the payload and then simply never closes
 # the pipe) still leaves this `cat` waiting for an EOF that never arrives.

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -869,6 +869,49 @@ EOF
   [[ "$output" =~ "ping copilot" ]]
 }
 
+@test "check-inbox: does not hang when stdin is a non-TTY pipe that never reaches EOF (#381)" {
+  # A minimal `timeout` shim so this test exercises check-inbox.sh's own
+  # `command -v timeout` code path deterministically, regardless of whether
+  # the host actually ships GNU timeout (stock macOS does not) -- what's
+  # under test is check-inbox.sh's wiring to `timeout`, not the host
+  # environment. Prepended first on PATH so it wins even where a real one
+  # also exists.
+  local bindir="$TEST_SKILL_DIR/shimbin"
+  mkdir -p "$bindir"
+  cat > "$bindir/timeout" <<'EOF'
+#!/usr/bin/env bash
+secs="$1"; shift
+("$@") & cmd_pid=$!
+( sleep "$secs"; kill "$cmd_pid" 2>/dev/null ) & watchdog_pid=$!
+if wait "$cmd_pid" 2>/dev/null; then
+  kill "$watchdog_pid" 2>/dev/null
+  exit 0
+else
+  exit 124
+fi
+EOF
+  chmod +x "$bindir/timeout"
+
+  bash "$SCRIPTS/join.sh" testteam alice claude-code "$TEST_PROJECT"
+
+  local fifo="$TEST_PROJECT/repro.fifo"
+  mkfifo "$fifo"
+  # Write the payload, then hold the write end open without closing it --
+  # exactly the "hook runtime forgets to close the pipe" shape from the
+  # issue's own FIFO repro. A plain `sleep N | check-inbox.sh` does NOT
+  # reproduce this: bash waits for every pipeline member, so it looks like a
+  # hang even when the hook itself exits immediately.
+  { printf '%s' '{"stop_hook_active":false,"session_id":"repro-381"}'; sleep 300; } > "$fifo" &
+  local writer_pid="$!"
+
+  local newpath="$bindir:$PATH"
+  run bash -c "PATH='$newpath' AGMSG_STDIN_TIMEOUT=1 bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT' < '$fifo'"
+
+  kill "$writer_pid" 2>/dev/null || true
+  rm -f "$fifo"
+
+  [ "$status" -eq 0 ]
+}
 
 
 

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -905,7 +905,7 @@ EOF
   local writer_pid="$!"
 
   local newpath="$bindir:$PATH"
-  run bash -c "PATH='$newpath' AGMSG_STDIN_TIMEOUT=1 bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT' < '$fifo'"
+  run bash -c "PATH='$newpath' AGMSG_HOOK_STDIN_TIMEOUT=1 bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT' < '$fifo'"
 
   kill "$writer_pid" 2>/dev/null || true
   rm -f "$fifo"


### PR DESCRIPTION
## What

Fixes #381: `check-inbox.sh` read its hook payload with an unbounded `cat`. When the host hands it a non-TTY stdin whose write end is left open (a hook runtime that writes the payload and then simply never closes the pipe), that `cat` waits for an EOF that never comes.

Stop/turn hooks are synchronous — the agent cannot finish its turn until the hook process exits. A hook that never returns doesn't just miss a message: it freezes the agent's pane (spinner stuck, keyboard dead) until the user kills it. The existing `[ ! -t 0 ]` guard (from #64) only covers the TTY case; this is a distinct non-TTY-no-EOF shape.

## Fix

Bound the read: when `timeout` is on PATH, wrap `cat` in it (`${AGMSG_HOOK_STDIN_TIMEOUT:-2}` seconds, overridable). The payload is already sitting in the command substitution buffer by the time the deadline fires, so a runtime that forgets to close its pipe still gets its message delivered — just a few seconds late instead of never. Falls back to the prior unbounded read when `timeout` isn't available (stock macOS ships no `timeout`/`gtimeout` by default) — no behavior change there, matching what the issue's own suggested fix already accounted for.

## Scope note

The issue also suggested a second, broader layer: re-exec the whole hook script under a `timeout` deadline as a backstop against any other kind of internal hang (a wedged `sqlite3` call, a stuck lock). Confirmed with koit as explicitly out of scope for this PR: guarding against a failure mode that hasn't actually been observed is its own regression risk (it changes the hook's process tree shape and exit-code handling for every invocation, not just the reported one). Noting it here rather than opening a new tracking issue.

## Tests

Added to `tests/test_delivery.bats`: a FIFO-based repro (matching the issue's own repro shape — a plain `sleep | check-inbox.sh` pipeline does NOT reproduce this, since bash waits for every pipeline member) with a self-contained `timeout` shim so the test exercises `check-inbox.sh`'s wiring deterministically regardless of whether the host itself ships a real `timeout` binary.

Full `test_delivery.bats` (129 tests) passes locally.

Closes #381.
