### PR TITLE
fix(codex): replace flaky ls -t rollout lookup with find + portable mtime sort

### DIFF
--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -14,6 +14,24 @@
 # launcher start the bridge — a hook-launched bridge cannot connect to the unix
 # socket from inside the Codex sandbox (#41).
 
+# Newest-N rollout files under $sessions_dir, sorted by mtime descending.
+# `ls -t "$dir"/*/*/*/rollout-*.jsonl` is unreliable on Windows/Git Bash --
+# reported to intermittently return an empty/truncated list with no
+# filesystem changes in between (root cause unconfirmed, possibly an
+# MSYS2 glob/large-arglist interaction), which silently starves
+# agmsg_resolve_codex_thread of any candidate: the SessionStart hook just
+# no-ops and the bridge never launches, with no error output at all. `find`
+# is reported reliable there; do the mtime sort ourselves with the existing
+# portable compat_file_mtime, since `find -printf` is GNU-only (no
+# `-printf` on macOS/BSD find, which this repo also has to support). See #416.
+agmsg_newest_rollout_files() {
+  local dir="$1" limit="$2" f mtime
+  find "$dir" -type f -name 'rollout-*.jsonl' 2>/dev/null | while IFS= read -r f; do
+    mtime=$(compat_file_mtime "$f")
+    printf '%s\t%s\n' "${mtime:-0}" "$f"
+  done | sort -t "$(printf '\t')" -k1,1rn | head -n "$limit" | cut -f2-
+}
+
 # Resolve the current Codex thread id. CODEX_THREAD_ID is only exported on the
 # interactive --remote path; fresh and `codex exec` sessions never export it, so
 # fall back to the newest rollout file whose session_meta cwd matches the
@@ -50,7 +68,7 @@ agmsg_resolve_codex_thread() {
         return 0
       fi
     done <<INNER_EOF
-$(ls -t "$sessions_dir"/*/*/*/rollout-*.jsonl 2>/dev/null | head -20)
+$(agmsg_newest_rollout_files "$sessions_dir" 20)
 INNER_EOF
     [ "$waited" -ge 2 ] && break
     waited=$((waited + 1))

--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -36,8 +36,16 @@ agmsg_newest_rollout_files() {
   # different mechanism. awk reads its input through to EOF regardless of
   # `n` (only *printing* stops early), so `sort` is always fully drained and
   # never SIGPIPEd.
+  # `|| true` on the mtime lookup: under set -e, a plain `var=$(cmd)`
+  # assignment DOES abort on cmd's failure (unlike a substitution used inside
+  # a test/conditional). A rollout that `find` listed but that Codex deletes
+  # or rotates before `stat` runs on it (a real possibility across the ~1-2s
+  # this loop can take with hundreds of files) would otherwise abort this
+  # whole while-loop subshell -- another way to reintroduce the "no
+  # candidate found" failure the ${mtime:-0} fallback below already exists to
+  # avoid.
   find "$dir" -type f -name 'rollout-*.jsonl' 2>/dev/null | while IFS= read -r f; do
-    mtime=$(compat_file_mtime "$f")
+    mtime=$(compat_file_mtime "$f" || true)
     printf '%s\t%s\n' "${mtime:-0}" "$f"
   done | sort -t "$(printf '\t')" -k1,1rn | awk -F'\t' -v n="$limit" 'NR<=n { sub(/^[^\t]*\t/, ""); print }'
 }

--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -26,10 +26,20 @@
 # `-printf` on macOS/BSD find, which this repo also has to support). See #416.
 agmsg_newest_rollout_files() {
   local dir="$1" limit="$2" f mtime
+  # `head -n "$limit"` here would close its read end after $limit lines while
+  # `sort` may still be writing -- under this caller's `set -euo pipefail`,
+  # that SIGPIPEs `sort` (status 141) and pipefail surfaces it as the whole
+  # pipeline's status even though head/cut both still exit 0. With enough
+  # rollout files to exceed the pipe buffer (confirmed at ~20k candidate
+  # lines in review), that silently starves the caller of a result -- the
+  # exact class of bug this function exists to fix, reintroduced by a
+  # different mechanism. awk reads its input through to EOF regardless of
+  # `n` (only *printing* stops early), so `sort` is always fully drained and
+  # never SIGPIPEd.
   find "$dir" -type f -name 'rollout-*.jsonl' 2>/dev/null | while IFS= read -r f; do
     mtime=$(compat_file_mtime "$f")
     printf '%s\t%s\n' "${mtime:-0}" "$f"
-  done | sort -t "$(printf '\t')" -k1,1rn | head -n "$limit" | cut -f2-
+  done | sort -t "$(printf '\t')" -k1,1rn | awk -F'\t' -v n="$limit" 'NR<=n { sub(/^[^\t]*\t/, ""); print }'
 }
 
 # Resolve the current Codex thread id. CODEX_THREAD_ID is only exported on the

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1712,6 +1712,46 @@ EOF
   grep -q -- "--thread rollout-thread-999" "$log"
 }
 
+@test "session-start.sh for codex resolves the rollout by real mtime, not filename order (#416)" {
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  local fake="$TEST_SKILL_DIR/fake-codex-bridge"
+  local log="$TEST_SKILL_DIR/fake-codex-bridge.log"
+  cat >"$fake" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$AGMSG_TEST_LOG"
+EOF
+  chmod +x "$fake"
+
+  # `ls -t "$dir"/*/*/*/rollout-*.jsonl` was flaky on Windows/Git Bash --
+  # intermittently returned an empty/truncated list with no filesystem
+  # changes in between, so agmsg_resolve_codex_thread got starved of any
+  # candidate and the SessionStart hook silently no-opped (#416). The fix
+  # replaced it with find + a portable per-file mtime sort. Prove it is a
+  # real mtime sort and not an accidental filename-lexical sort: one rollout
+  # has an OLDER-looking filename timestamp but its actual mtime is touched
+  # to be the newest of the two, matching this project's cwd. A find+sort-
+  # by-name "fix" would pick the wrong (stale) rollout here.
+  local rollout_dir="$TEST_SKILL_DIR/home/.codex/sessions/2026/06/17"
+  mkdir -p "$rollout_dir"
+  printf '%s\n' "{\"type\":\"session_meta\",\"payload\":{\"id\":\"stale-by-name-uuid\",\"cwd\":\"$TEST_PROJECT\"}}" \
+    > "$rollout_dir/rollout-2020-01-01T00-00-00-stale-by-name-uuid.jsonl"
+  printf '%s\n' "{\"type\":\"session_meta\",\"payload\":{\"id\":\"newer-by-name-uuid\",\"cwd\":\"$TEST_PROJECT\"}}" \
+    > "$rollout_dir/rollout-2026-06-17T00-00-00-newer-by-name-uuid.jsonl"
+  sleep 1
+  touch "$rollout_dir/rollout-2020-01-01T00-00-00-stale-by-name-uuid.jsonl"
+
+  HOME="$TEST_SKILL_DIR/home" \
+  AGMSG_CODEX_BRIDGE=1 \
+  AGMSG_CODEX_BRIDGE_APP_SERVER="unix://$TEST_SKILL_DIR/run/codex-app-server.test.sock" \
+  AGMSG_CODEX_BRIDGE_CMD="$fake" \
+  AGMSG_TEST_LOG="$log" \
+    env -u CODEX_THREAD_ID bash "$SCRIPTS/session-start.sh" codex "$TEST_PROJECT" >/dev/null
+
+  for _ in {1..20}; do [ -f "$log" ] && break; sleep 0.1; done
+  [ -f "$log" ]
+  grep -q -- "--thread stale-by-name-uuid" "$log"
+}
+
 @test "delivery set monitor (codex): warns loudly when Node is missing" {
   # Node preflight: the bridge is a Node program; enabling monitor without Node
   # must flag it rather than silently never starting. AGMSG_CODEX_NODE points the


### PR DESCRIPTION
## What

Fixes #416: `agmsg_resolve_codex_thread()` in `scripts/drivers/types/codex/_session-start.sh` used

```sh
ls -t "$sessions_dir"/*/*/*/rollout-*.jsonl 2>/dev/null | head -20
```

to find the current Codex session's rollout file (the fallback path used whenever `CODEX_THREAD_ID` isn't exported — fresh sessions and `codex exec`). Reported flaky on Windows/Git Bash (MSYS2): the exact same command, with no filesystem changes in between, sometimes listed the full ~220 matching files and sometimes returned almost nothing. A plain `find` over the same tree consistently returned the correct, complete list every time.

Because `agmsg_resolve_codex_thread` silently returns empty when the lookup comes up short, this makes `agmsg_session_start` exit before ever reaching the bridge launch logic — from the outside it just looks like "Codex monitor mode never starts the bridge", with no error output at all.

## Fix

Replace the `ls -t` glob with `find "$sessions_dir" -type f -name 'rollout-*.jsonl'` (reported reliable) and sort the results by mtime ourselves, using the repo's existing portable `compat_file_mtime` helper (already used elsewhere for the same macOS/Linux `stat` flag difference) rather than `find -printf`, which is GNU-only and has no equivalent on macOS/BSD find.

The reporter didn't pin down *why* `ls -t`'s glob+sort was unreliable there (possibly an MSYS2 large-arglist or timestamp interaction) — this fix sidesteps the question entirely by not depending on that code path being reliable.

## Tests

Added to `tests/test_delivery.bats`, alongside the existing single-rollout resolution test: a case with two rollouts matching the project's cwd where the filename embeds an *older*-looking timestamp but the file's actual mtime is the newer of the two (`touch`ed after both are written). This proves the lookup sorts by real filesystem mtime and not by an accidental filename-lexical order — a naive `find | sort` "fix" would pick the wrong (stale) rollout here, and does fail this test (verified locally by swapping in that exact implementation before restoring the real fix).

Full `test_delivery.bats` (129 tests) and `test_codex_resume.bats` pass locally.

Closes #416.
