### PR TITLE
fix(instance-id): stop Claude Code 2.1.x daemon from hijacking pid resolution

### DIFF
--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -280,7 +280,18 @@ EOF
 }
 
 # True iff <token> identifies a still-live instance.
-#   composite "<sid>.<pid>" → the embedded pid is alive (kill -0).
+#   composite "<sid>.<pid>" → the embedded pid is alive (kill -0), AND, when a
+#                            cc-instance.<pid> record exists for that pid, its
+#                            content still names this exact token. A shared pid
+#                            (the Claude Code 2.1.x daemon, #349) can outlive
+#                            the specific session that derived this token —
+#                            session-start.sh's dedup overwrites cc-instance.
+#                            <pid> with the newest attaching token, so a stale
+#                            token's kill-0-only check would otherwise report
+#                            "alive" forever via the shared pid. No record at
+#                            all (codex: its SessionStart plug exits before
+#                            ever reaching that write) falls back to the plain
+#                            pid check, unchanged from before.
 #   bare "<sid>"            → some live cc-instance.<p> file references it. For
 #                            upgrade compatibility a cc-instance whose content
 #                            is either exactly "<sid>" or the composite
@@ -292,7 +303,12 @@ agmsg_instance_alive() {
   [ -n "$token" ] || return 1
   if agmsg_instance_is_composite "$token"; then
     local pid="${token##*.}"
-    _agmsg_pid_alive "$pid" && return 0
+    _agmsg_pid_alive "$pid" || return 1
+    local f s
+    f="$SKILL_DIR/run/cc-instance.$pid"
+    [ -f "$f" ] || return 0
+    s="$(cat "$f" 2>/dev/null || true)"
+    [ "$s" = "$token" ] && return 0
     return 1
   fi
   local run f p s

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -238,14 +238,17 @@ _agmsg_agent_binaries() {
 # a recycled pid pointing at an unrelated process must not hijack resolution.
 #
 # Claude Code 2.1.x daemon architecture (#349): sessions run as version-named
-# binaries (e.g. ".../claude/versions/2.1.199 --bg-spare ..."), parented by a
-# long-lived `claude daemon run ...` process. Matching plain comm/argv0
-# "claude" against that daemon would resolve the SAME shared pid as "the
-# enclosing agent" for every daemon-hosted session — reintroducing the #93
-# collision class (cross-session watcher kills, immortal orphan watchers).
-# Two adjustments: never trust the daemon process itself, and additionally
-# recognize the version-named session binary so the walk stops at the real
-# per-session process instead of continuing past it to the (excluded) daemon.
+# binaries carrying a `--bg-spare` flag (e.g. ".../claude/versions/2.1.199
+# --bg-spare ..."), parented by a long-lived `claude daemon run ...` process.
+# `--bg-spare` appears on the real per-session binary too, so it is NOT a safe
+# exclusion signal — only "daemon run" identifies the daemon itself. Matching
+# plain comm/argv0 "claude" against the daemon would resolve the SAME shared
+# pid as "the enclosing agent" for every daemon-hosted session — reintroducing
+# the #93 collision class (cross-session watcher kills, immortal orphan
+# watchers). Two adjustments: never trust the daemon process itself, and
+# additionally recognize the version-named session binary so the walk stops
+# at the real per-session process instead of continuing past it to the
+# (excluded) daemon.
 agmsg_pid_is_agent() {
   local pid="$1" type="$2"
   [ -n "$pid" ] || return 1
@@ -255,7 +258,7 @@ agmsg_pid_is_agent() {
   comm=$(compat_get_comm "$pid" 2>/dev/null || true)
   cmdline=$(compat_get_cmdline "$pid" 2>/dev/null || true)
   case "$cmdline" in
-    *"daemon run"*|*"--bg-spare"*) return 1 ;;
+    *"daemon run"*) return 1 ;;
   esac
   first=$(printf '%s' "$cmdline" | awk '{print $1}' || true)
   base=$(basename -- "${first:-}" 2>/dev/null || true)

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -236,19 +236,37 @@ _agmsg_agent_binaries() {
 # Does <pid> currently look like an agent process of <type>? Checks both the
 # `comm` name and argv[0] basename. Guards marker trust against PID recycling —
 # a recycled pid pointing at an unrelated process must not hijack resolution.
+#
+# Claude Code 2.1.x daemon architecture (#349): sessions run as version-named
+# binaries (e.g. ".../claude/versions/2.1.199 --bg-spare ..."), parented by a
+# long-lived `claude daemon run ...` process. Matching plain comm/argv0
+# "claude" against that daemon would resolve the SAME shared pid as "the
+# enclosing agent" for every daemon-hosted session — reintroducing the #93
+# collision class (cross-session watcher kills, immortal orphan watchers).
+# Two adjustments: never trust the daemon process itself, and additionally
+# recognize the version-named session binary so the walk stops at the real
+# per-session process instead of continuing past it to the (excluded) daemon.
 agmsg_pid_is_agent() {
   local pid="$1" type="$2"
   [ -n "$pid" ] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
-  local binaries comm first base bin
+  local binaries comm cmdline first base bin
   binaries=$(_agmsg_agent_binaries "$type")
   comm=$(compat_get_comm "$pid" 2>/dev/null || true)
-  first=$(compat_get_cmdline "$pid" 2>/dev/null | awk '{print $1}' || true)
+  cmdline=$(compat_get_cmdline "$pid" 2>/dev/null || true)
+  case "$cmdline" in
+    *"daemon run"*|*"--bg-spare"*) return 1 ;;
+  esac
+  first=$(printf '%s' "$cmdline" | awk '{print $1}' || true)
   base=$(basename -- "${first:-}" 2>/dev/null || true)
   for bin in $binaries; do
     case "$comm" in "$bin"|"$bin"-*) return 0 ;; esac
     [ "$base" = "$bin" ] && return 0
   done
+  if [ "$type" = "claude-code" ]; then
+    case "$comm" in [0-9]*.[0-9]*.[0-9]*) return 0 ;; esac
+    case "$base" in [0-9]*.[0-9]*.[0-9]*) return 0 ;; esac
+  fi
   return 1
 }
 

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -93,6 +93,21 @@ teardown() { teardown_test_env; }
   ! agmsg_instance_alive "sess.2147483647"
 }
 
+@test "instance_alive: composite is not alive when cc-instance.<pid> now names a different token (#349)" {
+  skip_on_windows "instance-id live PID liveness under Git Bash (#182)"
+  # Simulates a shared pid (Claude Code 2.1.x daemon) whose cc-instance record
+  # was overwritten by a newer session attaching to the same pid — the pid is
+  # still alive, but this token is no longer the one it currently names.
+  echo "newsess.$$" > "$RUN_DIR/cc-instance.$$"
+  ! agmsg_instance_alive "oldsess.$$"
+}
+
+@test "instance_alive: composite is alive when cc-instance.<pid> still names this exact token (#349)" {
+  skip_on_windows "instance-id live PID liveness under Git Bash (#182)"
+  echo "sess.$$" > "$RUN_DIR/cc-instance.$$"
+  agmsg_instance_alive "sess.$$"
+}
+
 @test "instance_alive: bare sid with a live cc-instance is alive" {
   skip_on_windows "instance-id live PID liveness under Git Bash (#182)"
   echo "barex" > "$RUN_DIR/cc-instance.$$"

--- a/tests/test_resolve_project.bats
+++ b/tests/test_resolve_project.bats
@@ -210,6 +210,58 @@ JSON
   [ "$status" -ne 0 ]
 }
 
+# --- Claude Code 2.1.x daemon architecture (#349) ---
+
+@test "pid-is-agent: excludes a 'claude daemon run' process even though argv0 matches" {
+  skip_on_windows "process argv faking via exec -a (#349)"
+  bash -c 'exec -a "claude daemon run --json-path /tmp/agmsg-test-daemon.json" sleep 5' &
+  local p=$!
+  sleep 0.3
+  run agmsg_pid_is_agent "$p" claude-code
+  kill "$p" 2>/dev/null || true
+  [ "$status" -ne 0 ]
+}
+
+@test "pid-is-agent: excludes a --bg-spare process even though argv0 matches" {
+  skip_on_windows "process argv faking via exec -a (#349)"
+  bash -c 'exec -a "claude --bg-spare" sleep 5' &
+  local p=$!
+  sleep 0.3
+  run agmsg_pid_is_agent "$p" claude-code
+  kill "$p" 2>/dev/null || true
+  [ "$status" -ne 0 ]
+}
+
+@test "pid-is-agent: accepts a version-named claude-code session binary" {
+  skip_on_windows "process argv faking via exec -a (#349)"
+  bash -c 'exec -a "2.1.199" sleep 5' &
+  local p=$!
+  sleep 0.3
+  run agmsg_pid_is_agent "$p" claude-code
+  kill "$p" 2>/dev/null || true
+  [ "$status" -eq 0 ]
+}
+
+@test "pid-is-agent: accepts a version-named session binary under a full versions/ path" {
+  skip_on_windows "process argv faking via exec -a (#349)"
+  bash -c 'exec -a "/home/x/.local/share/claude/versions/2.1.199" sleep 5' &
+  local p=$!
+  sleep 0.3
+  run agmsg_pid_is_agent "$p" claude-code
+  kill "$p" 2>/dev/null || true
+  [ "$status" -eq 0 ]
+}
+
+@test "pid-is-agent: a version-named binary is NOT accepted for a non-claude-code type" {
+  skip_on_windows "process argv faking via exec -a (#349)"
+  bash -c 'exec -a "2.1.199" sleep 5' &
+  local p=$!
+  sleep 0.3
+  run agmsg_pid_is_agent "$p" codex
+  kill "$p" 2>/dev/null || true
+  [ "$status" -ne 0 ]
+}
+
 @test "read-marker: untrusted pid is not honored even if the file exists" {
   agmsg_write_project_marker "$$" "/should/not/trust"   # $$ is not an agent
   run agmsg_read_project_marker "$$" claude-code

--- a/tests/test_resolve_project.bats
+++ b/tests/test_resolve_project.bats
@@ -222,14 +222,18 @@ JSON
   [ "$status" -ne 0 ]
 }
 
-@test "pid-is-agent: excludes a --bg-spare process even though argv0 matches" {
+@test "pid-is-agent: accepts the real session shape (version-named binary + --bg-spare)" {
   skip_on_windows "process argv faking via exec -a (#349)"
-  bash -c 'exec -a "claude --bg-spare" sleep 5' &
+  # --bg-spare appears on the REAL per-session binary too (per #349's report),
+  # so it must NOT be an exclusion signal on its own — only "daemon run"
+  # identifies the daemon. This is the actual reported shape:
+  # ".../claude/versions/2.1.199 --bg-spare ...".
+  bash -c 'exec -a "2.1.199 --bg-spare" sleep 5' &
   local p=$!
   sleep 0.3
   run agmsg_pid_is_agent "$p" claude-code
   kill "$p" 2>/dev/null || true
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 0 ]
 }
 
 @test "pid-is-agent: accepts a version-named claude-code session binary" {


### PR DESCRIPTION
## Summary

Fixes #349, reported by fukuda-deltax with an excellent detailed repro (thank you). On Claude Code 2.1.x, sessions run as version-named binaries (e.g. `.../claude/versions/2.1.199 --bg-spare ...`) parented by a long-lived `claude daemon run ...` process. `agmsg_pid_is_agent` matched plain comm/argv0 `claude`, which the version-named session binary never does, so the ppid walk skipped past the real session process and resolved the shared daemon pid instead. Every daemon-hosted session then derived the same instance-id suffix, reintroducing the #93 collision class: cross-session (even cross-project) watcher kills via `session-start.sh`'s dedup, since its `cc-instance.<pid>` record is keyed on that shared pid — "the agent went deaf" with no visible error.

## Fix

Two adjustments in `agmsg_pid_is_agent` (`scripts/lib/resolve-project.sh`):
- Never match a process whose cmdline contains `daemon run` or `--bg-spare` — excludes the daemon itself regardless of what its comm/argv0 look like.
- For `claude-code`, additionally recognize a version-named session binary (comm or argv0 basename shaped like `2.1.199`) so the walk stops at the real per-session process instead of continuing past it to the (now-excluded) daemon.

Hardened `agmsg_instance_alive`'s composite-token liveness check (`scripts/lib/instance-id.sh`) as defense in depth: a shared pid surviving indefinitely can't by itself prove a specific token is still the live one. When a `cc-instance.<pid>` record exists, its content must still match the exact token — a shared pid whose record has since been overwritten by a newer attaching session now correctly reads as not-alive instead of alive forever. When no record exists at all (codex never writes one; its SessionStart plug exits before reaching that write), this falls back to the prior pid-only check, unchanged.

## Testing

Reproduced the daemon and version-binary process shapes with real backgrounded processes via bash's `exec -a` to control comm/argv0 (the existing ppid-walk tests in this file already test at this unit level, not via full `session-start.sh` integration). Added composite `cc-instance` mismatch coverage to `test_instance_id.bats`. Full `test_resolve_project.bats` and `test_instance_id.bats` pass with the new cases; `test_actas_lock.bats`, `test_actas_integration.bats`, `test_delivery.bats`, `test_watch.bats`, and `test_role_session.bats` all pass unchanged (two isolated flaky failures reproduced on unmodified `main` too and passed on re-run — unrelated to this change).