### PR TITLE
Isolate Codex monitor bridges by role

### DIFF
--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -181,8 +181,13 @@ EOF
   else
     bridge_run=("$(agmsg_resolve_node)" "$SKILL_DIR/scripts/drivers/types/codex/codex-bridge.js")
   fi
+  local storage_dir
+  storage_dir="$(agmsg_storage_dir)"
   nohup "${bridge_run[@]}" \
     --project "$PROJECT" \
+    --workspace-root "$storage_dir" \
+    --workspace-root "$SKILL_DIR/teams" \
+    --workspace-root "$SKILL_DIR/run" \
     --type "$TYPE" \
     "${bridge_pairs[@]}" \
     --thread "$thread_id" \

--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -112,6 +112,9 @@ agmsg_session_start() {
       candidate_project="$(agmsg_role_session_get "$candidate_team" "$candidate_name" project 2>/dev/null || true)"
       candidate_project_phys="$(agmsg_canonical_path "$candidate_project" 2>/dev/null || printf '%s' "$candidate_project")"
       { [ "$candidate_project_phys" = "$project_phys" ] && [ "$candidate_thread" = "$thread_id" ]; } || continue
+    else
+      # No recorded seat means no live TUI for this role; leave its inbox unread.
+      continue
     fi
     safe_pairs="${safe_pairs:+$safe_pairs$'\n'}${candidate_team}"$'\t'"${candidate_name}"
   done <<< "$PAIRS"

--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -188,6 +188,6 @@ EOF
     --thread "$thread_id" \
     --app-server "$app_server" \
     --inline-inbox \
-    >>"$log" 2>&1 &
+    >>"$log" 2>&1 3>&- &
   exit 0
 }

--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -193,6 +193,6 @@ EOF
     --thread "$thread_id" \
     --app-server "$app_server" \
     --inline-inbox \
-    >>"$log" 2>&1 3>&- &
+    >>"$log" 2>&1 3>&- 4>&- &
   exit 0
 }

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -14,6 +14,7 @@ TYPE="${1:?Usage: codex-bridge-launcher.sh <type> <project_path> <app_server> <p
 PROJECT="${2:?Missing project_path}"
 APP_SERVER="${3:?Missing app_server}"
 PARENT_PID="${4:?Missing parent_pid}"
+ROLE_PAIR="${5:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
@@ -43,6 +44,7 @@ mkdir -p "$RUN_DIR"
 resolve_identity() {  # prints "team<TAB>name" lines for the project's codex roles
   "$SCRIPT_DIR/../../../identities.sh" "$PROJECT" "$TYPE" 2>/dev/null \
     | awk -v t="$TAB" 'NF >= 2 { print $1 t $2 }' \
+    | { if [ -n "$ROLE_PAIR" ]; then grep -Fx "$ROLE_PAIR" || true; else cat; fi; } \
     | sort -u
 }
 
@@ -62,6 +64,24 @@ safety_fingerprint() {
 
 # actas may register the role a moment after launch, so retry while the parent
 # (codex-monitor.sh) is alive. Multiple identities are intentional (#150).
+# The parent only dispatches. Every role receives an independent child launcher
+# and therefore an independent bridge bound to its own recorded thread.
+if [ -z "$ROLE_PAIR" ]; then
+  known_pairs=""
+  while kill -0 "$PARENT_PID" 2>/dev/null; do
+    current_pairs="$(resolve_identity || true)"
+    while IFS="$TAB" read -r child_team child_name; do
+      [ -n "$child_team" ] || continue
+      child_pair="$child_team"$'\t'"$child_name"
+      printf '%s\n' "$known_pairs" | grep -Fxq "$child_pair" && continue
+      nohup "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID" "$child_pair" >/dev/null 2>&1 &
+      known_pairs="${known_pairs:+$known_pairs$'\n'}$child_pair"
+    done <<< "$current_pairs"
+    sleep 0.3
+  done
+  exit 0
+fi
+
 ids=""
 while kill -0 "$PARENT_PID" 2>/dev/null; do
   ids="$(resolve_identity || true)"
@@ -99,11 +119,12 @@ while IFS="$TAB" read -r candidate_team candidate_name; do
     # never consume its unread rows from this project. A lone same-project role keeps #350's legacy recorded-thread affinity even
     # before a concrete request thread is available; multiplexed roles require
     # proof and are excluded while the hint is only `loaded`.
-    if [ "$candidate_project_phys" != "$PROJECT_PHYS" ] \
-       || { { [ "$thread_hint" = "loaded" ] && [ "$raw_identity_count" != "1" ]; } \
-            || { [ "$thread_hint" != "loaded" ] && [ "$candidate_thread" != "$thread_hint" ]; }; }; then
+    if [ "$candidate_project_phys" != "$PROJECT_PHYS" ]; then
       continue
     fi
+  else
+    # A role without a recorded seat has no live TUI to receive its turn.
+    continue
   fi
   safe_ids="${safe_ids:+$safe_ids$'\n'}${candidate_team}"$'\t'"${candidate_name}"
 done <<< "$ids"
@@ -236,6 +257,10 @@ EOF
     --app-server "$req_app_server" \
     --inline-inbox \
     >>"$log" 2>&1 &
+  launched_pid=$!
+  if [ -n "${AGMSG_CODEX_BRIDGE_CMD:-}" ]; then
+    wait "$launched_pid" 2>/dev/null || true
+  fi
   # Record what this bridge is bound to so a later launcher can detect staleness.
   printf '%s' "$req_app_server" > "$appserver_file"
   printf '%s' "$thread_id" > "$thread_file"

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -140,7 +140,7 @@ if [ -z "$ROLE_PAIR" ]; then
       printf '%s\n' "$known_pairs" | grep -Fxq "$child_pair" && continue
       # Close bats' result fd when present; a detached child must not keep the
       # test harness pipe open after its test has completed.
-      nohup "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$LIFETIME_PID" "$child_pair" >/dev/null 2>&1 3>&- &
+      nohup "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$LIFETIME_PID" "$child_pair" >/dev/null 2>&1 3>&- 4>&- &
       known_pairs="${known_pairs:+$known_pairs$'\n'}$child_pair"
     done <<< "$current_pairs"
     sleep 0.3
@@ -320,7 +320,7 @@ EOF
     --thread "$thread_id" \
     --app-server "$req_app_server" \
     --inline-inbox \
-    >>"$log" 2>&1 3>&- &
+    >>"$log" 2>&1 3>&- 4>&- &
   launched_pid=$!
   printf '%s\n' "$launched_pid" > "$pidfile"
   if [ -n "${AGMSG_CODEX_BRIDGE_CMD:-}" ]; then

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -74,7 +74,9 @@ if [ -z "$ROLE_PAIR" ]; then
       [ -n "$child_team" ] || continue
       child_pair="$child_team"$'\t'"$child_name"
       printf '%s\n' "$known_pairs" | grep -Fxq "$child_pair" && continue
-      nohup "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID" "$child_pair" >/dev/null 2>&1 &
+      # Close bats' result fd when present; a detached child must not keep the
+      # test harness pipe open after its test has completed.
+      nohup "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID" "$child_pair" >/dev/null 2>&1 3>&- &
       known_pairs="${known_pairs:+$known_pairs$'\n'}$child_pair"
     done <<< "$current_pairs"
     sleep 0.3
@@ -249,7 +251,7 @@ EOF
     --thread "$thread_id" \
     --app-server "$req_app_server" \
     --inline-inbox \
-    >>"$log" 2>&1 &
+    >>"$log" 2>&1 3>&- &
   launched_pid=$!
   if [ -n "${AGMSG_CODEX_BRIDGE_CMD:-}" ]; then
     wait "$launched_pid" 2>/dev/null || true

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -134,7 +134,7 @@ ids="$safe_ids"
 if [ -z "$ids" ]; then
   kill -0 "$PARENT_PID" 2>/dev/null || exit 0
   sleep 0.3
-  exec "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID"
+  exec "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID" "$ROLE_PAIR"
 fi
 
 identity_count="$(printf '%s\n' "$ids" | grep -c . || true)"
@@ -181,7 +181,7 @@ while kill -0 "$PARENT_PID" 2>/dev/null; do
       old_pid="$(cat "$pidfile" 2>/dev/null || true)"
       [ -n "$old_pid" ] && kill "$old_pid" 2>/dev/null || true
     fi
-    exec "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID"
+    exec "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID" "$ROLE_PAIR"
   fi
   # Resolve the app-server URL (and thread) this iteration would launch against
   # FIRST, so the reuse check can compare a live bridge's bound server with the
@@ -200,29 +200,22 @@ EOF
     fi
   fi
 
-  # With exactly one identity, preserve #350's role-session thread affinity.
-  # Multiple identities are multiplexed into the active project thread; a role
-  # that has a recorded thread is handled by its own future launcher pass rather
-  # than being silently mapped to another role's recorded thread.
-  # thread is whichever conversation the server last touched -- ambiguous when a
-  # cwd has run more than one codex thread, so a co-resident thread can capture
-  # this role's messages. The role-session record (#339) stores this role's own
-  # thread deterministically; use it when present AND recorded for THIS project.
-  # A request-file thread (above) still wins; roles with no record fall back to
-  # "loaded". A foreign-project record was filtered out before launch (#150).
-  # Freshness holds because a role re-runs actas on resume (#339), which
-  # rewrites the record with its current thread.
-  if [ "$thread_id" = "loaded" ] && [ "$(printf '%s\n' "$ids" | grep -c . || true)" = "1" ]; then
-    IFS="$TAB" read -r team name <<EOF
+  # A child launcher is role-scoped. The project request file only supplies a
+  # current app-server endpoint; its thread belongs to whichever role most
+  # recently fired SessionStart and must never override this role's seat.
+  IFS="$TAB" read -r team name <<EOF
 $ids
 EOF
-    rec_thread="$(agmsg_role_session_uuid "$team" "$name" 2>/dev/null || true)"
-    if [ -n "$rec_thread" ]; then
-      rec_project="$(agmsg_role_session_get "$team" "$name" project 2>/dev/null || true)"
-      rec_project_phys="$(agmsg_canonical_path "$rec_project" 2>/dev/null || printf '%s' "$rec_project")"
-      [ "$rec_project_phys" = "$PROJECT_PHYS" ] && thread_id="$rec_thread"
-    fi
+  rec_thread="$(agmsg_role_session_uuid "$team" "$name" 2>/dev/null || true)"
+  rec_project="$(agmsg_role_session_get "$team" "$name" project 2>/dev/null || true)"
+  rec_project_phys="$(agmsg_canonical_path "$rec_project" 2>/dev/null || printf '%s' "$rec_project")"
+  if [ -z "$rec_thread" ] || [ "$rec_project_phys" != "$PROJECT_PHYS" ]; then
+    sleep 0.3
+    continue
   fi
+  thread_id="$rec_thread"
+
+  # The role-session record is the sole thread authority (#150 phase 2/#350).
 
   if [ -f "$pidfile" ]; then
     bridge_pid="$(cat "$pidfile" 2>/dev/null || true)"

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -27,6 +27,9 @@ REQUEST_FILE="$RUN_DIR/codex-bridge-request.$PROJECT_HASH"
 # shellcheck source=../../../lib/node.sh
 source "$SCRIPT_DIR/../../../lib/node.sh"
 NODE_BIN="$(agmsg_resolve_node)"
+# shellcheck source=../../../lib/storage.sh
+source "$SCRIPT_DIR/../../../lib/storage.sh"
+STORAGE_DIR="$(agmsg_storage_dir)"
 TAB="$(printf '\t')"
 
 # role-session record (#350): the bridge prefers this role's RECORDED codex thread
@@ -246,6 +249,9 @@ EOF
 
   nohup "${bridge_run[@]}" \
     --project "$PROJECT" \
+    --workspace-root "$STORAGE_DIR" \
+    --workspace-root "$SKILL_DIR/teams" \
+    --workspace-root "$SKILL_DIR/run" \
     --type "$TYPE" \
     "${bridge_pairs[@]}" \
     --thread "$thread_id" \

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -28,7 +28,7 @@ RUN_DIR="$SKILL_DIR/run"
 source "$SCRIPT_DIR/../../../lib/hash.sh"
 PROJECT_HASH="$(printf '%s' "$PROJECT" | agmsg_sha1)"
 REQUEST_FILE="$RUN_DIR/codex-bridge-request.$PROJECT_HASH"
-DISPATCHER_LOCK="$RUN_DIR/codex-bridge-dispatcher.$PROJECT_HASH.lock"
+DISPATCHER_LOCK_RESOURCE="codex-dispatcher:$PROJECT_HASH"
 SERVER_PID_FILE="$RUN_DIR/codex-app-server.$PROJECT_HASH.pid"
 
 # shellcheck source=../../../lib/node.sh
@@ -61,30 +61,35 @@ if [ -z "$LIFETIME_PID" ] || ! kill -0 "$LIFETIME_PID" 2>/dev/null; then
 fi
 
 release_dispatcher_lock() {
-  local owner=""
-  owner="$(readlink "$DISPATCHER_LOCK" 2>/dev/null || true)"
-  [ "$owner" = "$$" ] || return 0
-  rm -f "$DISPATCHER_LOCK"
+  agmsg_runtime_lock_release "$DISPATCHER_LOCK_RESOURCE" "$$"
 }
 
 acquire_dispatcher_lock() {
-  local owner="" attempt
+  local owner="" attempt _barrier_attempt _barrier_count
   for attempt in {1..20}; do
-    # The symlink target publishes the owner in the same atomic operation that
-    # creates the lock, so contenders can never mistake a live lock for an
-    # ownerless stale directory. A forced stale replacement is followed by an
-    # ownership check: only the process whose target remains installed wins.
-    if ln -s "$$" "$DISPATCHER_LOCK" 2>/dev/null; then
+    owner="$(agmsg_runtime_lock_acquire "$DISPATCHER_LOCK_RESOURCE" "$$" 2>/dev/null || true)"
+    if [ "$owner" = "$$" ]; then
       trap release_dispatcher_lock EXIT
       trap 'exit 0' INT TERM
       return 0
     fi
-    owner="$(readlink "$DISPATCHER_LOCK" 2>/dev/null || true)"
     if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
       return 1
     fi
-    ln -sfn "$$" "$DISPATCHER_LOCK" 2>/dev/null || true
-    owner="$(readlink "$DISPATCHER_LOCK" 2>/dev/null || true)"
+    if [ -n "${AGMSG_TEST_DISPATCHER_STALE_BARRIER:-}" ]; then
+      : > "$AGMSG_TEST_DISPATCHER_STALE_BARRIER.$$"
+      for _barrier_attempt in {1..100}; do
+        _barrier_count="$(find "$(dirname "$AGMSG_TEST_DISPATCHER_STALE_BARRIER")" \
+          -maxdepth 1 -name "$(basename "$AGMSG_TEST_DISPATCHER_STALE_BARRIER").*" \
+          -type f 2>/dev/null | wc -l | tr -d ' ')"
+        [ "$_barrier_count" -ge 2 ] && break
+        sleep 0.05
+      done
+    fi
+    # Replace only the exact stale generation observed above. SQLite serializes
+    # both statements with competing reclaimers, so once A replaces stale S
+    # with live A, B's `owner = S` delete cannot remove A (true CAS semantics).
+    owner="$(agmsg_runtime_lock_acquire "$DISPATCHER_LOCK_RESOURCE" "$$" "${owner:-0}" 2>/dev/null || true)"
     if [ "$owner" = "$$" ]; then
       trap release_dispatcher_lock EXIT
       trap 'exit 0' INT TERM
@@ -126,7 +131,7 @@ safety_fingerprint() {
 if [ -z "$ROLE_PAIR" ]; then
   acquire_dispatcher_lock || exit 0
   known_pairs=""
-  while [ "$(readlink "$DISPATCHER_LOCK" 2>/dev/null || true)" = "$$" ] \
+  while agmsg_runtime_lock_verify "$DISPATCHER_LOCK_RESOURCE" "$$" \
     && kill -0 "$LIFETIME_PID" 2>/dev/null; do
     current_pairs="$(resolve_identity || true)"
     while IFS="$TAB" read -r child_team child_name; do

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 # dispatcher -> role child -> bridge process chain.
 exec 3>&- 4>&-
 
-# Runs outside Codex's tool sandbox and owns the app-server connection. One
-# bridge subscribes to every unpinned codex identity in this project.
+# Runs outside Codex's tool sandbox and owns the app-server connections. The
+# dispatcher starts one bridge per recorded Codex role in this project.
 #
 # On codex 0.141+ the SessionStart hook cannot resolve the thread id
 # (CODEX_THREAD_ID is not exported and no rollout is written for --remote

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -28,6 +28,8 @@ RUN_DIR="$SKILL_DIR/run"
 source "$SCRIPT_DIR/../../../lib/hash.sh"
 PROJECT_HASH="$(printf '%s' "$PROJECT" | agmsg_sha1)"
 REQUEST_FILE="$RUN_DIR/codex-bridge-request.$PROJECT_HASH"
+DISPATCHER_LOCK="$RUN_DIR/codex-bridge-dispatcher.$PROJECT_HASH.lock"
+SERVER_PID_FILE="$RUN_DIR/codex-app-server.$PROJECT_HASH.pid"
 
 # shellcheck source=../../../lib/node.sh
 source "$SCRIPT_DIR/../../../lib/node.sh"
@@ -48,6 +50,42 @@ source "$SCRIPT_DIR/../../../lib/resolve-project.sh"
 PROJECT_PHYS="$(agmsg_canonical_path "$PROJECT" 2>/dev/null || printf '%s' "$PROJECT")"
 
 mkdir -p "$RUN_DIR"
+
+# The app-server is shared by every Codex TUI in a project. Bind dispatcher and
+# role-child lifetime to that shared process rather than whichever TUI happened
+# to start first. Tests/older launchers without the sidecar retain parent-PID
+# fallback behavior.
+LIFETIME_PID="$(cat "$SERVER_PID_FILE" 2>/dev/null || true)"
+if [ -z "$LIFETIME_PID" ] || ! kill -0 "$LIFETIME_PID" 2>/dev/null; then
+  LIFETIME_PID="$PARENT_PID"
+fi
+
+release_dispatcher_lock() {
+  local owner=""
+  owner="$(cat "$DISPATCHER_LOCK/pid" 2>/dev/null || true)"
+  [ "$owner" = "$$" ] || return 0
+  rm -f "$DISPATCHER_LOCK/pid"
+  rmdir "$DISPATCHER_LOCK" 2>/dev/null || true
+}
+
+acquire_dispatcher_lock() {
+  local owner="" attempt
+  for attempt in 1 2; do
+    if mkdir "$DISPATCHER_LOCK" 2>/dev/null; then
+      printf '%s\n' "$$" > "$DISPATCHER_LOCK/pid"
+      trap release_dispatcher_lock EXIT
+      trap 'exit 0' INT TERM
+      return 0
+    fi
+    owner="$(cat "$DISPATCHER_LOCK/pid" 2>/dev/null || true)"
+    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
+      return 1
+    fi
+    rm -f "$DISPATCHER_LOCK/pid"
+    rmdir "$DISPATCHER_LOCK" 2>/dev/null || true
+  done
+  return 1
+}
 
 resolve_identity() {  # prints "team<TAB>name" lines for the project's codex roles
   "$SCRIPT_DIR/../../../identities.sh" "$PROJECT" "$TYPE" 2>/dev/null \
@@ -75,8 +113,9 @@ safety_fingerprint() {
 # The parent only dispatches. Every role receives an independent child launcher
 # and therefore an independent bridge bound to its own recorded thread.
 if [ -z "$ROLE_PAIR" ]; then
+  acquire_dispatcher_lock || exit 0
   known_pairs=""
-  while kill -0 "$PARENT_PID" 2>/dev/null; do
+  while kill -0 "$LIFETIME_PID" 2>/dev/null; do
     current_pairs="$(resolve_identity || true)"
     while IFS="$TAB" read -r child_team child_name; do
       [ -n "$child_team" ] || continue
@@ -84,7 +123,7 @@ if [ -z "$ROLE_PAIR" ]; then
       printf '%s\n' "$known_pairs" | grep -Fxq "$child_pair" && continue
       # Close bats' result fd when present; a detached child must not keep the
       # test harness pipe open after its test has completed.
-      nohup "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID" "$child_pair" >/dev/null 2>&1 3>&- &
+      nohup "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$LIFETIME_PID" "$child_pair" >/dev/null 2>&1 3>&- &
       known_pairs="${known_pairs:+$known_pairs$'\n'}$child_pair"
     done <<< "$current_pairs"
     sleep 0.3
@@ -249,6 +288,8 @@ EOF
       fi
       kill "$bridge_pid" 2>/dev/null || true
       rm -f "$pidfile" "$appserver_file" "$thread_file"
+    else
+      rm -f "$pidfile" "$appserver_file" "$thread_file"
     fi
   fi
 
@@ -264,8 +305,11 @@ EOF
     --inline-inbox \
     >>"$log" 2>&1 3>&- &
   launched_pid=$!
+  printf '%s\n' "$launched_pid" > "$pidfile"
   if [ -n "${AGMSG_CODEX_BRIDGE_CMD:-}" ]; then
     wait "$launched_pid" 2>/dev/null || true
+    recorded_pid="$(cat "$pidfile" 2>/dev/null || true)"
+    [ "$recorded_pid" != "$launched_pid" ] || rm -f "$pidfile"
   fi
   # Record what this bridge is bound to so a later launcher can detect staleness.
   printf '%s' "$req_app_server" > "$appserver_file"

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -29,6 +29,7 @@ source "$SCRIPT_DIR/../../../lib/hash.sh"
 PROJECT_HASH="$(printf '%s' "$PROJECT" | agmsg_sha1)"
 REQUEST_FILE="$RUN_DIR/codex-bridge-request.$PROJECT_HASH"
 DISPATCHER_LOCK="$RUN_DIR/codex-bridge-dispatcher.$PROJECT_HASH.lock"
+DISPATCHER_REAPER="$RUN_DIR/codex-bridge-dispatcher.$PROJECT_HASH.reap"
 SERVER_PID_FILE="$RUN_DIR/codex-app-server.$PROJECT_HASH.pid"
 
 # shellcheck source=../../../lib/node.sh
@@ -70,7 +71,13 @@ release_dispatcher_lock() {
 
 acquire_dispatcher_lock() {
   local owner="" attempt
-  for attempt in 1 2; do
+  for attempt in {1..20}; do
+    # A stale-owner reaper has exclusive authority over the main lock. Never
+    # race it by creating or deleting the main directory while it is active.
+    if [ -d "$DISPATCHER_REAPER" ]; then
+      sleep 0.05
+      continue
+    fi
     if mkdir "$DISPATCHER_LOCK" 2>/dev/null; then
       printf '%s\n' "$$" > "$DISPATCHER_LOCK/pid"
       trap release_dispatcher_lock EXIT
@@ -81,8 +88,27 @@ acquire_dispatcher_lock() {
     if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
       return 1
     fi
+    if ! mkdir "$DISPATCHER_REAPER" 2>/dev/null; then
+      sleep 0.05
+      continue
+    fi
+    # Re-read under the reaper lock: another process may have replaced the
+    # stale owner before we acquired exclusive cleanup authority.
+    owner="$(cat "$DISPATCHER_LOCK/pid" 2>/dev/null || true)"
+    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
+      rmdir "$DISPATCHER_REAPER" 2>/dev/null || true
+      return 1
+    fi
     rm -f "$DISPATCHER_LOCK/pid"
     rmdir "$DISPATCHER_LOCK" 2>/dev/null || true
+    if mkdir "$DISPATCHER_LOCK" 2>/dev/null; then
+      printf '%s\n' "$$" > "$DISPATCHER_LOCK/pid"
+      rmdir "$DISPATCHER_REAPER" 2>/dev/null || true
+      trap release_dispatcher_lock EXIT
+      trap 'exit 0' INT TERM
+      return 0
+    fi
+    rmdir "$DISPATCHER_REAPER" 2>/dev/null || true
   done
   return 1
 }

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# The launcher is detached from codex-monitor.sh and may outlive the shell that
+# invoked it. Never retain test-harness result/trace descriptors through the
+# dispatcher -> role child -> bridge process chain.
+exec 3>&- 4>&-
+
 # Runs outside Codex's tool sandbox and owns the app-server connection. One
 # bridge subscribes to every unpinned codex identity in this project.
 #

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -29,7 +29,6 @@ source "$SCRIPT_DIR/../../../lib/hash.sh"
 PROJECT_HASH="$(printf '%s' "$PROJECT" | agmsg_sha1)"
 REQUEST_FILE="$RUN_DIR/codex-bridge-request.$PROJECT_HASH"
 DISPATCHER_LOCK="$RUN_DIR/codex-bridge-dispatcher.$PROJECT_HASH.lock"
-DISPATCHER_REAPER="$RUN_DIR/codex-bridge-dispatcher.$PROJECT_HASH.reap"
 SERVER_PID_FILE="$RUN_DIR/codex-app-server.$PROJECT_HASH.pid"
 
 # shellcheck source=../../../lib/node.sh
@@ -63,52 +62,38 @@ fi
 
 release_dispatcher_lock() {
   local owner=""
-  owner="$(cat "$DISPATCHER_LOCK/pid" 2>/dev/null || true)"
+  owner="$(readlink "$DISPATCHER_LOCK" 2>/dev/null || true)"
   [ "$owner" = "$$" ] || return 0
-  rm -f "$DISPATCHER_LOCK/pid"
-  rmdir "$DISPATCHER_LOCK" 2>/dev/null || true
+  rm -f "$DISPATCHER_LOCK"
 }
 
 acquire_dispatcher_lock() {
   local owner="" attempt
   for attempt in {1..20}; do
-    # A stale-owner reaper has exclusive authority over the main lock. Never
-    # race it by creating or deleting the main directory while it is active.
-    if [ -d "$DISPATCHER_REAPER" ]; then
-      sleep 0.05
-      continue
-    fi
-    if mkdir "$DISPATCHER_LOCK" 2>/dev/null; then
-      printf '%s\n' "$$" > "$DISPATCHER_LOCK/pid"
+    # The symlink target publishes the owner in the same atomic operation that
+    # creates the lock, so contenders can never mistake a live lock for an
+    # ownerless stale directory. A forced stale replacement is followed by an
+    # ownership check: only the process whose target remains installed wins.
+    if ln -s "$$" "$DISPATCHER_LOCK" 2>/dev/null; then
       trap release_dispatcher_lock EXIT
       trap 'exit 0' INT TERM
       return 0
     fi
-    owner="$(cat "$DISPATCHER_LOCK/pid" 2>/dev/null || true)"
+    owner="$(readlink "$DISPATCHER_LOCK" 2>/dev/null || true)"
     if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
       return 1
     fi
-    if ! mkdir "$DISPATCHER_REAPER" 2>/dev/null; then
-      sleep 0.05
-      continue
-    fi
-    # Re-read under the reaper lock: another process may have replaced the
-    # stale owner before we acquired exclusive cleanup authority.
-    owner="$(cat "$DISPATCHER_LOCK/pid" 2>/dev/null || true)"
-    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
-      rmdir "$DISPATCHER_REAPER" 2>/dev/null || true
-      return 1
-    fi
-    rm -f "$DISPATCHER_LOCK/pid"
-    rmdir "$DISPATCHER_LOCK" 2>/dev/null || true
-    if mkdir "$DISPATCHER_LOCK" 2>/dev/null; then
-      printf '%s\n' "$$" > "$DISPATCHER_LOCK/pid"
-      rmdir "$DISPATCHER_REAPER" 2>/dev/null || true
+    ln -sfn "$$" "$DISPATCHER_LOCK" 2>/dev/null || true
+    owner="$(readlink "$DISPATCHER_LOCK" 2>/dev/null || true)"
+    if [ "$owner" = "$$" ]; then
       trap release_dispatcher_lock EXIT
       trap 'exit 0' INT TERM
       return 0
     fi
-    rmdir "$DISPATCHER_REAPER" 2>/dev/null || true
+    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
+      return 1
+    fi
+    sleep 0.05
   done
   return 1
 }
@@ -141,7 +126,8 @@ safety_fingerprint() {
 if [ -z "$ROLE_PAIR" ]; then
   acquire_dispatcher_lock || exit 0
   known_pairs=""
-  while kill -0 "$LIFETIME_PID" 2>/dev/null; do
+  while [ "$(readlink "$DISPATCHER_LOCK" 2>/dev/null || true)" = "$$" ] \
+    && kill -0 "$LIFETIME_PID" 2>/dev/null; do
     current_pairs="$(resolve_identity || true)"
     while IFS="$TAB" read -r child_team child_name; do
       [ -n "$child_team" ] || continue

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -26,6 +26,8 @@ Beta Codex app-server bridge for agmsg pseudo-monitoring.
 
 Options:
   --project <path>        Project path to monitor.
+  --workspace-root <path> Additional writable root to retain on bridge turns.
+                          Repeat for multiple roots.
   --type <agent_type>     Agent type for identity resolution (default: codex).
   --team <team>           Limit wakeups to one team.
   --name <agent>          Limit wakeups to one agent name.
@@ -86,6 +88,7 @@ function parseArgs(argv) {
     watchFailureLimit: Number(process.env.AGMSG_CODEX_BRIDGE_WATCH_FAILURE_LIMIT || 3),
     inlineInbox: false,
     pairs: [],
+    workspaceRoots: [],
     turnTimeout: Number(process.env.AGMSG_CODEX_BRIDGE_TURN_TIMEOUT || 60),
   };
 
@@ -97,6 +100,8 @@ function parseArgs(argv) {
       opts.resolveOnly = true;
     } else if (arg === "--project") {
       opts.project = argv[++i];
+    } else if (arg === "--workspace-root") {
+      opts.workspaceRoots.push(argv[++i]);
     } else if (arg === "--type") {
       opts.type = argv[++i];
     } else if (arg === "--team") {
@@ -138,6 +143,8 @@ function parseArgs(argv) {
 
   if (opts.help) return opts;
   if (!opts.project) die("--project is required");
+  if (opts.workspaceRoots.some((root) => !root)) die("--workspace-root requires a path");
+  opts.workspaceRoots = [...new Set([opts.project, ...opts.workspaceRoots])];
   if (!Number.isFinite(opts.timeout) || opts.timeout <= 0) die("--timeout must be a positive number");
   if (!Number.isFinite(opts.interval) || opts.interval <= 0) die("--interval must be a positive number");
   if (!Number.isFinite(opts.maxWakes) || opts.maxWakes < 0) die("--max-wakes must be a non-negative number");
@@ -915,7 +922,7 @@ class CodexBridge {
         response = await this.client.request("thread/resume", {
           threadId: this.threadId,
           cwd: this.opts.project,
-          runtimeWorkspaceRoots: [this.opts.project],
+          runtimeWorkspaceRoots: this.opts.workspaceRoots,
           excludeTurns: true,
         });
       } catch (err) {
@@ -948,7 +955,7 @@ class CodexBridge {
     }
     const response = await this.client.request("thread/start", {
       cwd: this.opts.project,
-      runtimeWorkspaceRoots: [this.opts.project],
+      runtimeWorkspaceRoots: this.opts.workspaceRoots,
       ephemeral: false,
     });
     this.threadId = response.thread && response.thread.id;
@@ -1120,7 +1127,7 @@ class CodexBridge {
         threadId: this.threadId,
         input: [{ type: "text", text: prompt, text_elements: [] }],
         cwd: this.opts.project,
-        runtimeWorkspaceRoots: [this.opts.project],
+        runtimeWorkspaceRoots: this.opts.workspaceRoots,
       });
       console.error(`codex-bridge: started turn on thread ${this.threadId}`);
       this.pendingWake = false;

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -206,6 +206,7 @@ function resolveIdentities(opts) {
   }
 
   if (deduped.length === 0) die("no matching codex identity; run actas or pass --team/--name");
+  if (deduped.length > 1) die("multiple identities match; launch one bridge per --pair");
   return deduped;
 }
 
@@ -1195,18 +1196,19 @@ class CodexBridge {
     const send = path.join(SCRIPTS_DIR, "send.sh");
     if (this.opts.inlineInbox) {
       return [
-        "agmsg delivered the following unread messages. Each section names the identity to use when replying:",
+        `agmsg delivered the following unread messages for ${this.identity.team}/${this.identity.name}:`,
         "",
         this.inlineInboxText.trim(),
         "",
         "Continue the conversation in this Codex thread. If a reply to an agmsg sender is needed, send it with:",
-        this.identities.map((p) => `${send} ${p.team} ${p.name} <to> <message>  # reply as ${p.team}/${p.name}`).join("\n"),
+        `${send} ${this.identity.team} ${this.identity.name} <to> <message>`,
       ].join("\n");
     }
     return [
-      `agmsg has unread messages for ${this.identities.map((p) => `${p.team}/${p.name}`).join(", ")}.`,
+      `agmsg has unread messages for ${this.identity.team}/${this.identity.name}.`,
+      `Run: ${inbox} ${this.identity.team} ${this.identity.name}`,
       "Read the messages and continue the conversation. If a reply is needed, send it with:",
-      this.identities.map((p) => `${send} ${p.team} ${p.name} <to> <message>`).join("\n"),
+      `${send} ${this.identity.team} ${this.identity.name} <to> <message>`,
     ].join("\n");
   }
 
@@ -1227,7 +1229,7 @@ class CodexBridge {
       if (!allowed.has(`${pair.team}\t${pair.name}`)) continue;
       const result = spawnSync(BASH_BIN, [path.join(SCRIPTS_DIR, "inbox.sh"), pair.team, pair.name], { cwd: this.opts.project, encoding: "utf8" });
       if (result.error || result.status !== 0) { console.error(`codex-bridge: inbox.sh failed for ${pair.team}/${pair.name}`); continue; }
-      if ((result.stdout || "").trim()) sections.push(`Messages addressed to ${pair.team}/${pair.name}:\n${result.stdout.trim()}`);
+      if ((result.stdout || "").trim()) sections.push(result.stdout.trim());
     }
     return sections.join("\n\n");
   }

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -115,7 +115,7 @@ If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> codex "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
 4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
 5. Record this session as the role's seat so it can be resumed later (best-effort): determine which team `<name>` belongs to (from the identities output / the join above), then run `~/.agents/skills/__SKILL_NAME__/scripts/drivers/types/codex/codex-record-session.sh <team> <name> "$(pwd)"`. It writes the record only when this session's codex thread id is unambiguous; otherwise it records nothing and the role simply boots fresh next time (no harm). This is what lets a later `spawn <role>` bring the role back into this conversation.
-6. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (Codex has no Monitor tool, so receive still covers all of your registered roles in this project.)"
+6. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. In monitor mode, receive is isolated to `<name>` on its recorded Codex thread; roles without a live recorded thread remain unread."
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -115,7 +115,7 @@ If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> codex "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
 4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
 5. Record this session as the role's seat so it can be resumed later (best-effort): determine which team `<name>` belongs to (from the identities output / the join above), then run `~/.agents/skills/__SKILL_NAME__/scripts/drivers/types/codex/codex-record-session.sh <team> <name> "$(pwd)"`. It writes the record only when this session's codex thread id is unambiguous; otherwise it records nothing and the role simply boots fresh next time (no harm). This is what lets a later `spawn <role>` bring the role back into this conversation.
-6. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. In monitor mode, receive is isolated to `<name>` on its recorded Codex thread; roles without a live recorded thread remain unread."
+6. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. In monitor mode, each role's incoming messages are routed only to that role's recorded Codex thread; roles without a recorded thread remain unread."
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -93,6 +93,58 @@ agmsg_sqlite() {
   sqlite3 $(_agmsg_escape_flag) -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@"
 }
 
+# Runtime ownership seam. This is the first run/-state-in-storage primitive for
+# the storage 1.2 direction: a future remote driver can preserve these acquire /
+# verify / release semantics with SETNX, WATCH, or its native equivalent.
+# `locks` is intentionally resource-generic; Codex dispatchers are merely the
+# first caller. Acquire prints the current owner. With expected_owner supplied,
+# replacement is a transactionally serialized compare-and-swap.
+_agmsg_runtime_lock_resource_sql() {
+  printf '%s' "$1" | sed "s/'/''/g"
+}
+
+agmsg_runtime_lock_acquire() {
+  local resource owner_pid expected_owner db resource_sql
+  resource="$1"; owner_pid="$2"; expected_owner="${3:-}"
+  case "$owner_pid:$expected_owner" in *[!0-9:]*) return 1 ;; esac
+  mkdir -p "$(agmsg_storage_dir)" || return 1
+  db="$(agmsg_db_path)"
+  resource_sql="$(_agmsg_runtime_lock_resource_sql "$resource")"
+  agmsg_sqlite "$db" <<SQL | tr -d '\r'
+CREATE TABLE IF NOT EXISTS locks (
+  resource TEXT PRIMARY KEY,
+  owner_pid INTEGER NOT NULL,
+  acquired_at TEXT NOT NULL
+);
+BEGIN IMMEDIATE;
+$(if [ -n "$expected_owner" ]; then printf "DELETE FROM locks WHERE resource = '%s' AND owner_pid = %s;" "$resource_sql" "$expected_owner"; fi)
+INSERT OR IGNORE INTO locks(resource, owner_pid, acquired_at)
+VALUES('$resource_sql', $owner_pid, strftime('%Y-%m-%dT%H:%M:%SZ','now'));
+SELECT owner_pid FROM locks WHERE resource = '$resource_sql';
+COMMIT;
+SQL
+}
+
+agmsg_runtime_lock_owner() {
+  local resource_sql
+  resource_sql="$(_agmsg_runtime_lock_resource_sql "$1")"
+  agmsg_sqlite "$(agmsg_db_path)" \
+    "SELECT owner_pid FROM locks WHERE resource = '$resource_sql';" 2>/dev/null \
+    | tr -d '\r'
+}
+
+agmsg_runtime_lock_verify() {
+  [ "$(agmsg_runtime_lock_owner "$1" 2>/dev/null || true)" = "$2" ]
+}
+
+agmsg_runtime_lock_release() {
+  local resource_sql
+  resource_sql="$(_agmsg_runtime_lock_resource_sql "$1")"
+  agmsg_sqlite "$(agmsg_db_path)" \
+    "DELETE FROM locks WHERE resource = '$resource_sql' AND owner_pid = $2;" \
+    >/dev/null 2>&1 || true
+}
+
 # In-memory sqlite for JSON parsing / scalar lookups whose stdout is captured in
 # a command substitution ($(...)). On Windows, sqlite3.exe writes stdout in text
 # mode and turns every \n into \r\n; command substitution strips the trailing \n

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -103,11 +103,18 @@ _agmsg_runtime_lock_resource_sql() {
   printf '%s' "$1" | sed "s/'/''/g"
 }
 
+agmsg_storage_ensure_initialized() {
+  local lib_dir init_script
+  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  init_script="$lib_dir/../internal/init-db.sh"
+  AGMSG_STORAGE_PATH="$(agmsg_storage_dir)" bash "$init_script" >/dev/null
+}
+
 agmsg_runtime_lock_acquire() {
   local resource owner_pid expected_owner db resource_sql
   resource="$1"; owner_pid="$2"; expected_owner="${3:-}"
   case "$owner_pid:$expected_owner" in *[!0-9:]*) return 1 ;; esac
-  mkdir -p "$(agmsg_storage_dir)" || return 1
+  agmsg_storage_ensure_initialized || return 1
   db="$(agmsg_db_path)"
   resource_sql="$(_agmsg_runtime_lock_resource_sql "$resource")"
   agmsg_sqlite "$db" <<SQL | tr -d '\r'
@@ -134,11 +141,13 @@ agmsg_runtime_lock_owner() {
 }
 
 agmsg_runtime_lock_verify() {
+  case "$2" in *[!0-9]*|'') return 1 ;; esac
   [ "$(agmsg_runtime_lock_owner "$1" 2>/dev/null || true)" = "$2" ]
 }
 
 agmsg_runtime_lock_release() {
   local resource_sql
+  case "$2" in *[!0-9]*|'') return 1 ;; esac
   resource_sql="$(_agmsg_runtime_lock_resource_sql "$1")"
   agmsg_sqlite "$(agmsg_db_path)" \
     "DELETE FROM locks WHERE resource = '$resource_sql' AND owner_pid = $2;" \

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -886,6 +886,16 @@ rl.on("line", (line) => {
       send({ jsonrpc: "2.0", id: message.id, error: { message: "missing inline inbox body" } });
       return;
     }
+    const expectedRoots = [
+      process.env.PROJ,
+      `${process.env.TEST_SKILL_DIR}/custom-store`,
+      `${process.env.TEST_SKILL_DIR}/teams`,
+      `${process.env.TEST_SKILL_DIR}/run`,
+    ];
+    if (JSON.stringify(message.params.runtimeWorkspaceRoots) !== JSON.stringify(expectedRoots)) {
+      send({ jsonrpc: "2.0", id: message.id, error: { message: "wrong runtime workspace roots" } });
+      return;
+    }
     send({ jsonrpc: "2.0", id: message.id, result: {} });
     setTimeout(() => {
       send({
@@ -901,7 +911,12 @@ rl.on("line", (line) => {
 EOF
 
   AGMSG_CODEX_APP_SERVER_CMD="node $fake" run node "$TYPES/codex/codex-bridge.js" \
-    --project "$PROJ" --team team --name alice --timeout 1 --interval 1 --max-wakes 1 --inline-inbox
+    --project "$PROJ" \
+    --workspace-root "$TEST_SKILL_DIR/custom-store" \
+    --workspace-root "$TEST_SKILL_DIR/teams" \
+    --workspace-root "$TEST_SKILL_DIR/run" \
+    --workspace-root "$PROJ" \
+    --team team --name alice --timeout 1 --interval 1 --max-wakes 1 --inline-inbox
 
   [ "$status" -eq 0 ]
   [[ "$output" =~ "started turn" ]]

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -90,12 +90,11 @@ EOF
   [ "$output" = $'team\talice' ]
 }
 
-@test "codex-bridge: resolve-only lists all identities when unfiltered" {
+@test "codex-bridge: resolve-only rejects multiple identities without a role pair" {
   skip_on_windows "codex bridge identity resolution on Windows (#182)"
   run node "$TYPES/codex/codex-bridge.js" --project "$PROJ" --resolve-only
-  [ "$status" -eq 0 ]
-  [[ "$output" == *$'team\talice'* ]]
-  [[ "$output" == *$'team\tbob'* ]]
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "launch one bridge per --pair" ]]
 }
 
 @test "codex-bridge: explicit --pair keeps a single identity" {

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -40,9 +40,17 @@ put_record() {
 # is closed on the backgrounded parent and the launcher so a stray descriptor
 # can't keep bats from exiting on macOS (#bats-fd3).
 run_launcher() {
-  sleep 2 3>&- & local p=$!
+  sleep 4 3>&- & local p=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$p" >/dev/null 2>&1 3>&- || true
   wait "$p" 2>/dev/null || true
+  # The launcher starts the mock through nohup. Its bound-thread metadata is
+  # written synchronously, but the mock's capture can land just after the
+  # parent exits, especially now that a per-role child launcher is involved.
+  local i
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    [ -f "$CAPTURE" ] && break
+    sleep 0.1
+  done
 }
 
 @test "launcher: binds the recorded thread when the record's project matches (#350)" {
@@ -53,10 +61,9 @@ run_launcher() {
   ! grep -q -- "--thread loaded" "$CAPTURE"
 }
 
-@test "launcher: falls back to 'loaded' when no record exists (#350)" {
+@test "launcher: leaves a role without a recorded live thread unsubscribed (#150)" {
   run_launcher
-  [ -f "$CAPTURE" ]
-  grep -q -- "--thread loaded" "$CAPTURE"
+  [ ! -f "$CAPTURE" ]
 }
 
 @test "launcher: leaves a role with a foreign-project record unsubscribed (#150)" {
@@ -69,4 +76,21 @@ run_launcher() {
   put_record team alice rec-thread-1 "$PROJ" codex
   run_launcher
   [ "$(cat "$RUN_DIR/codex-bridge.team.alice.thread" 2>/dev/null)" = "rec-thread-1" ]
+}
+
+@test "launcher: starts one bridge per recorded role and thread (#150 phase 2)" {
+  bash "$SCRIPTS/join.sh" team bob codex "$PROJ" >/dev/null
+  put_record team alice thread-alice "$PROJ" codex
+  put_record team bob thread-bob "$PROJ" codex
+  run_launcher
+
+  local i lines=0
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    lines=$(wc -l < "$CAPTURE" 2>/dev/null | tr -d ' ' || true)
+    [ "$lines" -ge 2 ] && break
+    sleep 0.1
+  done
+  [ "$lines" -ge 2 ]
+  grep -q -- $'--pair team\talice --thread thread-alice' "$CAPTURE"
+  grep -q -- $'--pair team\tbob --thread thread-bob' "$CAPTURE"
 }

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -102,7 +102,7 @@ run_launcher() {
   run_launcher & local driver_pid=$!
 
   local i recorded=""
-  for i in {1..30}; do
+  for i in {1..50}; do
     recorded="$(cat "$RUN_DIR/codex-bridge.team.alice.pid" 2>/dev/null || true)"
     [ -n "$recorded" ] && [ "$recorded" != 99999999 ] && break
     sleep 0.1
@@ -161,13 +161,14 @@ run_launcher() {
 @test "launcher: stale dispatcher reclamation remains singleton under contention" {
   put_record team alice thread-alice "$PROJ" codex
   export MOCK_BRIDGE_SLEEP=8
-  local hash lock
+  local hash lock_db
   hash=$(printf '%s' "$PROJ" | bash -c 'source "$1"; agmsg_sha1' _ "$SCRIPTS/lib/hash.sh")
-  lock="$RUN_DIR/codex-bridge-dispatcher.$hash.lock"
-  ln -s 99999999 "$lock"
-  # A crash from the former two-directory implementation could leave this
-  # behind forever. The owner-in-link protocol must not depend on that reaper.
+  lock_db="$TEST_SKILL_DIR/db/messages.db"
+  sqlite3 "$lock_db" "CREATE TABLE locks(resource TEXT PRIMARY KEY, owner_pid INTEGER NOT NULL, acquired_at TEXT NOT NULL); INSERT INTO locks VALUES('codex-dispatcher:$hash', 99999999, datetime('now'));"
+  # A crash from the former two-directory implementation can leave this behind.
+  # The transactional lock protocol must not depend on that legacy reaper.
   mkdir "$RUN_DIR/codex-bridge-dispatcher.$hash.reap"
+  export AGMSG_TEST_DISPATCHER_STALE_BARRIER="$TEST_SKILL_DIR/stale-observed"
   sleep 10 3>&- & local parent_a=$!
   sleep 10 3>&- & local parent_b=$!
 

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -36,6 +36,13 @@ put_record() {
     _ "$SCRIPTS" "$@"
 }
 
+write_request() {
+  local thread="$1" hash
+  hash=$(SKILL_DIR="$TEST_SKILL_DIR" bash -c \
+    'source "$1/lib/hash.sh"; printf "%s" "$2" | agmsg_sha1' _ "$SCRIPTS" "$PROJ")
+  printf 'codex\t%s\tws://127.0.0.1:1\n' "$thread" > "$RUN_DIR/codex-bridge-request.$hash"
+}
+
 # Drive the launcher against a short-lived parent, blocking until it exits. fd 3
 # is closed on the backgrounded parent and the launcher so a stray descriptor
 # can't keep bats from exiting on macOS (#bats-fd3).
@@ -93,4 +100,31 @@ run_launcher() {
   [ "$lines" -ge 2 ]
   grep -q -- $'--pair team\talice --thread thread-alice' "$CAPTURE"
   grep -q -- $'--pair team\tbob --thread thread-bob' "$CAPTURE"
+}
+
+@test "launcher: project request thread never overrides per-role recorded threads (#150 phase 2)" {
+  bash "$SCRIPTS/join.sh" team bob codex "$PROJ" >/dev/null
+  put_record team alice thread-alice "$PROJ" codex
+  put_record team bob thread-bob "$PROJ" codex
+  write_request thread-bob
+  run_launcher
+
+  grep -q -- $'--pair team\talice --thread thread-alice' "$CAPTURE"
+  grep -q -- $'--pair team\tbob --thread thread-bob' "$CAPTURE"
+  ! grep -q -- $'--pair team\talice --thread thread-bob' "$CAPTURE"
+}
+
+@test "launcher: role record update keeps child scoped to the same pair" {
+  put_record team alice thread-before "$PROJ" codex
+  sleep 4 3>&- & local p=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$p" $'team\talice' >/dev/null 2>&1 3>&- &
+  local launcher_pid=$!
+  sleep 1
+  put_record team alice thread-after "$PROJ" codex
+  wait "$launcher_pid" 2>/dev/null || true
+  wait "$p" 2>/dev/null || true
+
+  grep -q -- $'--pair team\talice --thread thread-before' "$CAPTURE"
+  grep -q -- $'--pair team\talice --thread thread-after' "$CAPTURE"
+  ! grep -q -- '--pair team bob' "$CAPTURE"
 }

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -20,6 +20,7 @@ setup() {
   cat > "$MOCK" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$CAPTURE"
+[ -z "\${MOCK_BRIDGE_SLEEP:-}" ] || sleep "\$MOCK_BRIDGE_SLEEP"
 exit 0
 EOF
   chmod +x "$MOCK"
@@ -94,6 +95,25 @@ run_launcher() {
   [ "$(cat "$RUN_DIR/codex-bridge.team.alice.thread" 2>/dev/null)" = "rec-thread-1" ]
 }
 
+@test "launcher: replaces a stale role pidfile with the spawned bridge pid" {
+  put_record team alice rec-thread-1 "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=3
+  printf '%s\n' 99999999 > "$RUN_DIR/codex-bridge.team.alice.pid"
+  run_launcher & local driver_pid=$!
+
+  local i recorded=""
+  for i in {1..30}; do
+    recorded="$(cat "$RUN_DIR/codex-bridge.team.alice.pid" 2>/dev/null || true)"
+    [ -n "$recorded" ] && [ "$recorded" != 99999999 ] && break
+    sleep 0.1
+  done
+  [ -n "$recorded" ]
+  [ "$recorded" != 99999999 ]
+  kill -0 "$recorded"
+
+  wait "$driver_pid" 2>/dev/null || true
+}
+
 @test "launcher: starts one bridge per recorded role and thread (#150 phase 2)" {
   bash "$SCRIPTS/join.sh" team bob codex "$PROJ" >/dev/null
   put_record team alice thread-alice "$PROJ" codex
@@ -111,6 +131,31 @@ run_launcher() {
   [ "$lines" -ge 2 ]
   grep -q -- $'--pair team\talice --thread thread-alice' "$CAPTURE"
   grep -q -- $'--pair team\tbob --thread thread-bob' "$CAPTURE"
+}
+
+@test "launcher: only one dispatcher runs per project" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=8
+  sleep 10 3>&- & local parent_a=$!
+  sleep 10 3>&- & local parent_b=$!
+
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent_a" >/dev/null 2>&1 3>&- &
+  local launcher_a=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent_b" >/dev/null 2>&1 3>&- &
+  local launcher_b=$!
+
+  local i
+  for i in {1..50}; do
+    [ -f "$CAPTURE" ] && break
+    sleep 0.1
+  done
+  [ -f "$CAPTURE" ]
+  [ "$(wc -l < "$CAPTURE" | tr -d ' ')" -eq 1 ]
+
+  wait "$launcher_a" 2>/dev/null || true
+  wait "$launcher_b" 2>/dev/null || true
+  wait "$parent_a" 2>/dev/null || true
+  wait "$parent_b" 2>/dev/null || true
 }
 
 @test "launcher: project request thread never overrides per-role recorded threads (#150 phase 2)" {

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -48,7 +48,7 @@ write_request() {
 # is closed on the backgrounded parent and the launcher so a stray descriptor
 # can't keep bats from exiting on macOS (#bats-fd3).
 run_launcher() {
-  sleep 4 3>&- & local p=$!
+  sleep 6 3>&- & local p=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$p" >/dev/null 2>&1 3>&- || true
   wait "$p" 2>/dev/null || true
   # The launcher starts the mock through nohup. Its bound-thread metadata is
@@ -164,8 +164,10 @@ run_launcher() {
   local hash lock
   hash=$(printf '%s' "$PROJ" | bash -c 'source "$1"; agmsg_sha1' _ "$SCRIPTS/lib/hash.sh")
   lock="$RUN_DIR/codex-bridge-dispatcher.$hash.lock"
-  mkdir "$lock"
-  printf '%s\n' 99999999 > "$lock/pid"
+  ln -s 99999999 "$lock"
+  # A crash from the former two-directory implementation could leave this
+  # behind forever. The owner-in-link protocol must not depend on that reaper.
+  mkdir "$RUN_DIR/codex-bridge-dispatcher.$hash.reap"
   sleep 10 3>&- & local parent_a=$!
   sleep 10 3>&- & local parent_b=$!
 

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -116,10 +116,15 @@ run_launcher() {
 
 @test "launcher: role record update keeps child scoped to the same pair" {
   put_record team alice thread-before "$PROJ" codex
-  sleep 4 3>&- & local p=$!
+  sleep 6 3>&- & local p=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$p" $'team\talice' >/dev/null 2>&1 3>&- &
   local launcher_pid=$!
-  sleep 1
+  local i
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+    grep -q -- $'--pair team\talice --thread thread-before' "$CAPTURE" 2>/dev/null && break
+    sleep 0.1
+  done
+  grep -q -- $'--pair team\talice --thread thread-before' "$CAPTURE"
   put_record team alice thread-after "$PROJ" codex
   wait "$launcher_pid" 2>/dev/null || true
   wait "$p" 2>/dev/null || true

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -54,7 +54,7 @@ run_launcher() {
   # written synchronously, but the mock's capture can land just after the
   # parent exits, especially now that a per-role child launcher is involved.
   local i
-  for i in 1 2 3 4 5 6 7 8 9 10; do
+  for i in {1..30}; do
     [ -f "$CAPTURE" ] && break
     sleep 0.1
   done
@@ -101,8 +101,10 @@ run_launcher() {
   run_launcher
 
   local i lines=0
-  for i in 1 2 3 4 5 6 7 8 9 10; do
-    lines=$(wc -l < "$CAPTURE" 2>/dev/null | tr -d ' ' || true)
+  for i in {1..30}; do
+    if [ -f "$CAPTURE" ]; then
+      lines=$(wc -l < "$CAPTURE" | tr -d ' ')
+    fi
     [ "$lines" -ge 2 ] && break
     sleep 0.1
   done
@@ -129,7 +131,7 @@ run_launcher() {
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$p" $'team\talice' >/dev/null 2>&1 3>&- &
   local launcher_pid=$!
   local i
-  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+  for i in {1..50}; do
     grep -q -- $'--pair team\talice --thread thread-before' "$CAPTURE" 2>/dev/null && break
     sleep 0.1
   done

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -158,6 +158,36 @@ run_launcher() {
   wait "$parent_b" 2>/dev/null || true
 }
 
+@test "launcher: stale dispatcher reclamation remains singleton under contention" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=8
+  local hash lock
+  hash=$(printf '%s' "$PROJ" | bash -c 'source "$1"; agmsg_sha1' _ "$SCRIPTS/lib/hash.sh")
+  lock="$RUN_DIR/codex-bridge-dispatcher.$hash.lock"
+  mkdir "$lock"
+  printf '%s\n' 99999999 > "$lock/pid"
+  sleep 10 3>&- & local parent_a=$!
+  sleep 10 3>&- & local parent_b=$!
+
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent_a" >/dev/null 2>&1 3>&- &
+  local launcher_a=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent_b" >/dev/null 2>&1 3>&- &
+  local launcher_b=$!
+
+  local i
+  for i in {1..50}; do
+    [ -f "$CAPTURE" ] && break
+    sleep 0.1
+  done
+  [ -f "$CAPTURE" ]
+  [ "$(wc -l < "$CAPTURE" | tr -d ' ')" -eq 1 ]
+
+  wait "$launcher_a" 2>/dev/null || true
+  wait "$launcher_b" 2>/dev/null || true
+  wait "$parent_a" 2>/dev/null || true
+  wait "$parent_b" 2>/dev/null || true
+}
+
 @test "launcher: project request thread never overrides per-role recorded threads (#150 phase 2)" {
   bash "$SCRIPTS/join.sh" team bob codex "$PROJ" >/dev/null
   put_record team alice thread-alice "$PROJ" codex

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -68,6 +68,15 @@ run_launcher() {
   ! grep -q -- "--thread loaded" "$CAPTURE"
 }
 
+@test "launcher: passes the active storage override as a workspace root" {
+  export AGMSG_STORAGE_PATH="$TEST_SKILL_DIR/custom-store"
+  put_record team alice rec-thread-1 "$PROJ" codex
+  run_launcher
+
+  grep -q -- "--workspace-root $AGMSG_STORAGE_PATH" "$CAPTURE"
+  ! grep -q -- "--workspace-root $TEST_SKILL_DIR/db" "$CAPTURE"
+}
+
 @test "launcher: leaves a role without a recorded live thread unsubscribed (#150)" {
   run_launcher
   [ ! -f "$CAPTURE" ]

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1898,6 +1898,7 @@ EOF
 
 @test "session-start.sh for codex resolves the rollout by real mtime, not filename order (#416)" {
   bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  _seed_role_record team alice stale-by-name-uuid "$TEST_PROJECT" codex
   local fake="$TEST_SKILL_DIR/fake-codex-bridge"
   local log="$TEST_SKILL_DIR/fake-codex-bridge.log"
   cat >"$fake" <<'EOF'

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1573,6 +1573,7 @@ EOF
   chmod +x "$fake"
 
   AGMSG_CODEX_BRIDGE=1 \
+  AGMSG_STORAGE_PATH="$TEST_SKILL_DIR/custom-store" \
   AGMSG_CODEX_BRIDGE_APP_SERVER="unix://$TEST_SKILL_DIR/run/codex-app-server.test.sock" \
   AGMSG_CODEX_BRIDGE_CMD="$fake" \
   AGMSG_TEST_LOG="$log" \
@@ -1586,6 +1587,7 @@ EOF
 
   [ -f "$log" ]
   grep -q -- "--project $TEST_PROJECT" "$log"
+  grep -q -- "--workspace-root $TEST_SKILL_DIR/custom-store" "$log"
   grep -q -- "--thread thread-123" "$log"
   grep -q -- "--app-server unix://$TEST_SKILL_DIR/run/codex-app-server.test.sock" "$log"
   grep -q -- "--inline-inbox" "$log"

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -947,7 +947,8 @@ EOF
   # issue's own FIFO repro. A plain `sleep N | check-inbox.sh` does NOT
   # reproduce this: bash waits for every pipeline member, so it looks like a
   # hang even when the hook itself exits immediately.
-  { printf '%s' '{"stop_hook_active":false,"session_id":"repro-381"}'; sleep 300; } > "$fifo" &
+  { printf '%s' '{"stop_hook_active":false,"session_id":"repro-381"}'; sleep 300; } \
+    3>&- 4>&- > "$fifo" &
   local writer_pid="$!"
 
   local newpath="$bindir:$PATH"

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -752,6 +752,7 @@ JSON
   phys=$(cd "$realproj" && pwd -P)
 
   bash "$SCRIPTS/join.sh" team alice codex "$linkproj" >/dev/null
+  _seed_role_record team alice thread-sym "$linkproj" codex
 
   # Stage a Codex rollout whose session_meta records the PHYSICAL cwd.
   local sdir="$HOME/.codex/sessions/2026/06/19"
@@ -1562,6 +1563,7 @@ JSON
 # --- Codex monitor bridge (#41) ---
 @test "session-start.sh for codex starts bridge when monitor launcher env is present" {
   bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  _seed_role_record team alice thread-123 "$TEST_PROJECT" codex
   local fake="$TEST_SKILL_DIR/fake-codex-bridge"
   local log="$TEST_SKILL_DIR/fake-codex-bridge.log"
   cat >"$fake" <<'EOF'
@@ -1863,6 +1865,7 @@ EOF
 
 @test "session-start.sh for codex resolves thread id from rollout when CODEX_THREAD_ID is unset" {
   bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  _seed_role_record team alice rollout-thread-999 "$TEST_PROJECT" codex
   local fake="$TEST_SKILL_DIR/fake-codex-bridge"
   local log="$TEST_SKILL_DIR/fake-codex-bridge.log"
   cat >"$fake" <<'EOF'

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -136,6 +136,25 @@ SH
   ! printf '%s' "$output" | grep -q '\^_'
 }
 
+@test "storage: runtime lock replacement is compare-and-swap" {
+  source "$SCRIPTS/lib/storage.sh"
+  local resource="codex-dispatcher:test" owner
+
+  owner="$(agmsg_runtime_lock_acquire "$resource" 111)"
+  [ "$owner" = 111 ]
+  owner="$(agmsg_runtime_lock_acquire "$resource" 222 111)"
+  [ "$owner" = 222 ]
+  # A contender that observed the old generation cannot delete its successor.
+  owner="$(agmsg_runtime_lock_acquire "$resource" 333 111)"
+  [ "$owner" = 222 ]
+  agmsg_runtime_lock_verify "$resource" 222
+  ! agmsg_runtime_lock_verify "$resource" 333
+  agmsg_runtime_lock_release "$resource" 333
+  agmsg_runtime_lock_verify "$resource" 222
+  agmsg_runtime_lock_release "$resource" 222
+  [ -z "$(agmsg_runtime_lock_owner "$resource")" ]
+}
+
 @test "send: concurrent fan-out to N recipients all land (no SQLITE_BUSY)" {
   # Without a busy_timeout, concurrent writers fail with SQLITE_BUSY(5) and the
   # sends silently drop. With the wrapper they wait and all land. See #114.

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -155,6 +155,15 @@ SH
   [ -z "$(agmsg_runtime_lock_owner "$resource")" ]
 }
 
+@test "storage: runtime lock initializes a fresh store before send" {
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/lock-first-store"
+  source "$SCRIPTS/lib/storage.sh"
+
+  [ "$(agmsg_runtime_lock_acquire codex-dispatcher:test 111)" = 111 ]
+  bash "$SCRIPTS/send.sh" team alice bob "after lock init" --force
+  [ "$(agmsg_sqlite "$(agmsg_db_path)" "SELECT COUNT(*) FROM messages WHERE body = 'after lock init';")" = 1 ]
+}
+
 @test "send: concurrent fan-out to N recipients all land (no SQLITE_BUSY)" {
   # Without a busy_timeout, concurrent writers fail with SQLITE_BUSY(5) and the
   # sends silently drop. With the wrapper they wait and all land. See #114.


### PR DESCRIPTION
Follow-up to #419 for issue #150.\n\nEach recorded Codex role now gets its own bridge bound only to that role's recorded thread. Roles without a recorded live TUI, or with a record for another project, remain unsubscribed so their messages stay unread. The phase-one path that multiplexed multiple identities into one TUI is removed: codex-bridge rejects ambiguous multi-identity resolution unless a single --pair is supplied.\n\nTests:\n- bats -f 'resolve-only|explicit --pair|inline-inbox' tests/test_codex_bridge.bats\n- bats tests/test_codex_bridge_launcher.bats\n- bash/node syntax checks\n- git diff --check