### PR TITLE
fix(codex): grace fallback for thread/resume failure on Codex 0.142+ (rebase of #276)

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -909,12 +909,28 @@ class CodexBridge {
       console.error(`codex-bridge: discovered loaded thread ${this.threadId}`);
     }
     if (this.threadId) {
-      const response = await this.client.request("thread/resume", {
-        threadId: this.threadId,
-        cwd: this.opts.project,
-        runtimeWorkspaceRoots: [this.opts.project],
-        excludeTurns: true,
-      });
+      let response;
+      try {
+        response = await this.client.request("thread/resume", {
+          threadId: this.threadId,
+          cwd: this.opts.project,
+          runtimeWorkspaceRoots: [this.opts.project],
+          excludeTurns: true,
+        });
+      } catch (err) {
+        // Codex 0.142+'s --remote sessions may not create a rollout, which
+        // makes the thread/resume request itself fail outright. turn/start
+        // only needs threadId, so keep the bridge alive by falling back to
+        // the idle state instead of dying. This catch covers only the
+        // request -- the "did not return the requested thread id" check
+        // below is a distinct failure (a resume that succeeded but returned
+        // the wrong thread) and should still die() as before, not be
+        // silently swallowed by this fallback.
+        console.error(`codex-bridge: thread/resume failed (${err.message}); proceeding without resume`);
+        this.threadIdle = true;
+        this.turnActive = false;
+        return;
+      }
       if (!response.thread || response.thread.id !== this.threadId) {
         die("thread/resume did not return the requested thread id");
       }

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -676,6 +676,90 @@ EOF
   ! grep -q "thread/start" "$log"
 }
 
+@test "codex-bridge: falls back to idle instead of dying when thread/resume itself fails (#276)" {
+  run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
+  if [ "$status" -ne 0 ]; then
+    skip "node child_process.spawn is not available in this sandbox"
+  fi
+
+  # Codex 0.142+'s --remote sessions may not create a rollout, so the
+  # thread/resume request itself can fail outright (not merely return a
+  # mismatched thread). turn/start only needs threadId, so the bridge should
+  # keep running in idle state instead of die()ing.
+  local fake="$TEST_SKILL_DIR/fake-app-server-resume-fails.js"
+  cat >"$fake" <<'EOF'
+const readline = require("readline");
+const rl = readline.createInterface({ input: process.stdin });
+function send(value) { process.stdout.write(`${JSON.stringify(value)}\n`); }
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  } else if (message.method === "thread/resume") {
+    send({ jsonrpc: "2.0", id: message.id, error: { message: "no rollout for this thread" } });
+  } else if (message.method === "process/spawn") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    setTimeout(() => {
+      send({
+        jsonrpc: "2.0",
+        method: "process/exited",
+        params: { processHandle: message.params.processHandle, exitCode: 0, stdout: "status=pending count=1 max_id=1\n", stderr: "" },
+      });
+    }, 10);
+  } else if (message.method === "turn/start") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: "turn-1" } } });
+    }, 10);
+  } else if (message.method === "process/kill") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  }
+});
+EOF
+
+  AGMSG_CODEX_APP_SERVER_CMD="node $fake" run node "$TYPES/codex/codex-bridge.js" \
+    --project "$PROJ" --team team --name alice --thread thread-no-rollout \
+    --timeout 1 --interval 1 --max-wakes 1
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "thread/resume failed" ]]
+  [[ "$output" =~ "proceeding without resume" ]]
+  [[ "$output" =~ "started turn" ]]
+}
+
+@test "codex-bridge: still dies when thread/resume succeeds but returns the wrong thread id (#276)" {
+  run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
+  if [ "$status" -ne 0 ]; then
+    skip "node child_process.spawn is not available in this sandbox"
+  fi
+
+  # This is a DISTINCT failure mode from the request itself erroring -- the
+  # request succeeded but the app-server handed back a different thread. The
+  # #276 fallback must not swallow it: the try/catch added there wraps only
+  # the request, not this validation.
+  local fake="$TEST_SKILL_DIR/fake-app-server-resume-wrong-id.js"
+  cat >"$fake" <<'EOF'
+const readline = require("readline");
+const rl = readline.createInterface({ input: process.stdin });
+function send(value) { process.stdout.write(`${JSON.stringify(value)}\n`); }
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  } else if (message.method === "thread/resume") {
+    send({ jsonrpc: "2.0", id: message.id, result: { thread: { id: "some-other-thread", status: { type: "idle" } } } });
+  }
+});
+EOF
+
+  AGMSG_CODEX_APP_SERVER_CMD="node $fake" run node "$TYPES/codex/codex-bridge.js" \
+    --project "$PROJ" --team team --name alice --thread thread-expected --timeout 20
+
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "did not return the requested thread id" ]]
+  [[ "$output" != *"proceeding without resume"* ]]
+}
+
 @test "codex-bridge: --thread loaded discovers the live thread via thread/loaded/list" {
   run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
   if [ "$status" -ne 0 ]; then


### PR DESCRIPTION
## What

In-house rebase and finish of #276 (external PR by u-ichi, open since 2026-07-01): Codex CLI 0.142+'s `--remote` sessions don't create a rollout, so `thread/resume` fails outright and the pre-existing code's `die()` took the whole bridge down with it. This wraps the resume in a try/catch and falls back to `threadIdle=true, turnActive=false` — `turn/start` only needs `threadId`, so the bridge keeps running instead of exiting.

Original fix and diagnosis by u-ichi (commit authorship preserved via `git rebase`, not squashed).

## Why a separate PR instead of pushing to #276

I don't have push access to u-ichi's fork (only the PR ref itself, via `gh pr checkout`), so this rebases the same commit onto current `main` in a fresh branch here rather than force-pushing to their branch. Please close #276 in favor of this one once merged — same fix, same author credit, just rebased past the `codex-bridge.js` changes that landed today (#299, #419).

## Changes from the original PR

- Rebased onto current `main` (the original diff no longer applied cleanly after today's `ensureThread()` changes).
- Narrowed the `try`/`catch` to wrap only the `thread/resume` request itself, not the subsequent `!response.thread || response.thread.id !== this.threadId` check. That check is a distinct failure (a resume that succeeded but returned the wrong thread) and should still `die()` as before — the original diff's catch block accidentally covered both, so a wrong-thread response would have been silently treated as "no rollout, fall back to idle" instead of the hard failure it actually is.
- Translated the added Japanese comment to English.
- Added regression tests for both paths (see below) — the original PR's test plan was `node --check` + `npm test` only, with no new test coverage.

## Tests

Added to `tests/test_codex_bridge.bats`:
- `thread/resume` itself failing (app-server responds with an error) → bridge logs the fallback and proceeds to a normal turn instead of exiting.
- `thread/resume` succeeding but returning a different thread id → still `die()`s, proving the narrowed catch doesn't swallow this separate case.

Full `test_codex_bridge.bats` and `test_codex_bridge_launcher.bats` pass locally (one launcher test intermittently fails under this shared host's load regardless of branch — reproduced identically on a clean `main` checkout, unrelated to this change).
