### PR TITLE
fix(rename): tombstone renamed-away names so join/actas can't silently revive them

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -45,10 +45,10 @@ After this runs once, `~/.agents/skills/agmsg/` is populated and you can skip St
 Ask the user for a team name. If it's an existing team, run `team.sh <team>` first to see the current roster and note the names already in use. Look for a naming convention already in play (e.g. a shared base name with role/number suffixes like `aggie-cc1`/`aggie-cc2`, or names derived from the team name) and, when one exists, propose 2-3 unused names that extend it; otherwise propose 2-3 short, distinctive identity names (not a bare tool-type label like `codex`/`cc`). Either way, names must not collide with the roster. For a brand-new team, skip the roster check and just ask. Then run:
 
 ```bash
-~/.agents/skills/agmsg/scripts/join.sh <team> <agent_name> <type> "$(pwd)"
+~/.agents/skills/agmsg/scripts/join.sh <team> <agent_name> <type> "$(pwd)" [--force]
 ```
 
-Do NOT manually edit config files. Always use join.sh.
+Do NOT manually edit config files. Always use join.sh. If the name was recently renamed away with `rename.sh`, join.sh refuses to revive it (printing the new name it maps to) instead of silently re-registering it — this guards against a CLI slash-command history resubmitting `actas <old_name>` after a rename. Pass `--force` only for a deliberate, unrelated reuse of that exact name.
 
 ### Step 2b: If already in a team — execute command
 

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -102,37 +102,6 @@ if [ "$FORCE" -ne 1 ] && [ -f "$TEAM_CONFIG" ]; then
   fi
 fi
 
-# Once a name is actually (re)joined past this point — whether because no
-# tombstone existed, or --force explicitly overrode one — it is no longer
-# "renamed away". Clear any matching tombstone so a later normal (non-forced)
-# join for this same identity (e.g. adding a second project/type
-# registration) doesn't keep hitting it (#360 review).
-if [ -f "$TEAM_CONFIG" ]; then
-  STRIP_SQL=$(agmsg_sql_readfile_path "$TEAM_CONFIG")
-  HAS_TOMBSTONE=$(agmsg_sqlite_mem "
-    WITH cfg AS (SELECT CAST(readfile('$STRIP_SQL') AS TEXT) AS json)
-    SELECT EXISTS(
-      SELECT 1 FROM cfg, json_each(json_extract(cfg.json, '\$.renamed'))
-      WHERE json_extract(value, '\$.from') = '$AGENT_ID_SQL'
-    ) FROM cfg;
-  ")
-  if [ "$HAS_TOMBSTONE" = "1" ]; then
-    STRIPPED=$(agmsg_sqlite_mem "
-      WITH cfg AS (SELECT CAST(readfile('$STRIP_SQL') AS TEXT) AS json)
-      SELECT json_set(cfg.json, '\$.renamed',
-        COALESCE(
-          (SELECT json_group_array(value)
-           FROM cfg, json_each(json_extract(cfg.json, '\$.renamed'))
-           WHERE json_extract(value, '\$.from') != '$AGENT_ID_SQL'),
-          json('[]')
-        )
-      )
-      FROM cfg;
-    ")
-    agmsg_write_atomic "$TEAM_CONFIG" "$STRIPPED"
-  fi
-fi
-
 # --- Add or extend agent registrations ---
 CONFIG_SQL=$(agmsg_sql_readfile_path "$TEAM_CONFIG")
 AGENT_TYPE_SQL=$(printf '%s' "$AGENT_TYPE" | sed "s/'/''/g")
@@ -191,17 +160,31 @@ else
 fi
 
 AGENT_OBJ_ESCAPED=$(printf '%s' "$AGENT_OBJ" | sed "s/'/''/g")
+# Clearing a matching tombstone (#360 review) is folded into this SAME
+# read-modify-write, not a separate one: a name is only ever "actually
+# (re)joined" once this single write lands, so if anything fails before it,
+# the tombstone (and thus the guard above) stays intact instead of being
+# dropped without a completed join.
 UPDATED=$(agmsg_sqlite_mem \
   "WITH cfg AS (SELECT CAST(readfile('$CONFIG_SQL') AS TEXT) AS json)
   SELECT json_set(
-    cfg.json,
-    '\$.agents',
-    json_patch(
-      CASE
-        WHEN json_type(json_extract(cfg.json, '\$.agents')) = 'object' THEN json_extract(cfg.json, '\$.agents')
-        ELSE json('{}')
-      END,
-      json_object('$AGENT_ID_SQL', json('$AGENT_OBJ_ESCAPED'))
+    json_set(
+      cfg.json,
+      '\$.agents',
+      json_patch(
+        CASE
+          WHEN json_type(json_extract(cfg.json, '\$.agents')) = 'object' THEN json_extract(cfg.json, '\$.agents')
+          ELSE json('{}')
+        END,
+        json_object('$AGENT_ID_SQL', json('$AGENT_OBJ_ESCAPED'))
+      )
+    ),
+    '\$.renamed',
+    COALESCE(
+      (SELECT json_group_array(value)
+       FROM json_each(json_extract(cfg.json, '\$.renamed'))
+       WHERE json_extract(value, '\$.from') != '$AGENT_ID_SQL'),
+      json('[]')
     )
   )
   FROM cfg;")

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -102,6 +102,37 @@ if [ "$FORCE" -ne 1 ] && [ -f "$TEAM_CONFIG" ]; then
   fi
 fi
 
+# Once a name is actually (re)joined past this point — whether because no
+# tombstone existed, or --force explicitly overrode one — it is no longer
+# "renamed away". Clear any matching tombstone so a later normal (non-forced)
+# join for this same identity (e.g. adding a second project/type
+# registration) doesn't keep hitting it (#360 review).
+if [ -f "$TEAM_CONFIG" ]; then
+  STRIP_SQL=$(agmsg_sql_readfile_path "$TEAM_CONFIG")
+  HAS_TOMBSTONE=$(agmsg_sqlite_mem "
+    WITH cfg AS (SELECT CAST(readfile('$STRIP_SQL') AS TEXT) AS json)
+    SELECT EXISTS(
+      SELECT 1 FROM cfg, json_each(json_extract(cfg.json, '\$.renamed'))
+      WHERE json_extract(value, '\$.from') = '$AGENT_ID_SQL'
+    ) FROM cfg;
+  ")
+  if [ "$HAS_TOMBSTONE" = "1" ]; then
+    STRIPPED=$(agmsg_sqlite_mem "
+      WITH cfg AS (SELECT CAST(readfile('$STRIP_SQL') AS TEXT) AS json)
+      SELECT json_set(cfg.json, '\$.renamed',
+        COALESCE(
+          (SELECT json_group_array(value)
+           FROM cfg, json_each(json_extract(cfg.json, '\$.renamed'))
+           WHERE json_extract(value, '\$.from') != '$AGENT_ID_SQL'),
+          json('[]')
+        )
+      )
+      FROM cfg;
+    ")
+    agmsg_write_atomic "$TEAM_CONFIG" "$STRIPPED"
+  fi
+fi
+
 # --- Add or extend agent registrations ---
 CONFIG_SQL=$(agmsg_sql_readfile_path "$TEAM_CONFIG")
 AGENT_TYPE_SQL=$(printf '%s' "$AGENT_TYPE" | sed "s/'/''/g")

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: join.sh <team> <agent_id> <type> <project_path>
+# Usage: join.sh <team> <agent_id> <type> <project_path> [--force]
 #
 # Adds an agent to a team. Creates the team if it doesn't exist.
 
-TEAM="${1:?Usage: join.sh <team> <agent_id> <type> <project_path>}"
+TEAM="${1:?Usage: join.sh <team> <agent_id> <type> <project_path> [--force]}"
 AGENT_ID="${2:?Missing agent_id}"
 AGENT_TYPE="${3:?Missing type (a registered type under scripts/drivers/types/<name>/)}"
 PROJECT_PATH="${4:?Missing project_path}"
+FORCE=0
+if [ "${5:-}" = "--force" ]; then
+  FORCE=1
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck disable=SC1091
@@ -69,9 +73,37 @@ if [ ! -f "$TEAM_CONFIG" ]; then
   echo "Created team: $TEAM"
 fi
 
+# --- Refuse silently reviving a name that rename.sh just renamed away (#360) ---
+# A CLI's slash-command history can resubmit `/agmsg actas <old_name>` well
+# after a rename — actas falls through to this join.sh, which used to
+# materialize <old_name> again with no warning, silently rolling the rename
+# back. rename.sh appends a {from,to,at} tombstone to the $.renamed array;
+# --force bypasses this for a deliberate, unrelated reuse of the name. The
+# agent id is compared as an ordinary SQL value (json_each + WHERE), not
+# spliced into a JSON path, so a name containing a single quote can't break
+# the query.
+AGENT_ID_SQL=$(printf '%s' "$AGENT_ID" | sed "s/'/''/g")
+if [ "$FORCE" -ne 1 ] && [ -f "$TEAM_CONFIG" ]; then
+  TOMBSTONE_SQL=$(agmsg_sql_readfile_path "$TEAM_CONFIG")
+  TOMBSTONE=$(agmsg_sqlite_mem "
+    WITH cfg AS (SELECT CAST(readfile('$TOMBSTONE_SQL') AS TEXT) AS json)
+    SELECT value
+    FROM cfg, json_each(json_extract(cfg.json, '\$.renamed'))
+    WHERE json_extract(value, '\$.from') = '$AGENT_ID_SQL'
+    ORDER BY key DESC
+    LIMIT 1;
+  ")
+  if [ -n "$TOMBSTONE" ] && [ "$TOMBSTONE" != "null" ]; then
+    TOMBSTONE_ESCAPED=$(printf '%s' "$TOMBSTONE" | sed "s/'/''/g")
+    RENAMED_TO=$(agmsg_sqlite_mem "SELECT json_extract('$TOMBSTONE_ESCAPED', '\$.to');")
+    RENAMED_AT=$(agmsg_sqlite_mem "SELECT json_extract('$TOMBSTONE_ESCAPED', '\$.at');")
+    echo "Error: '$AGENT_ID' was renamed to '$RENAMED_TO' in team '$TEAM' at $RENAMED_AT. Did you mean to join/actas as '$RENAMED_TO'? Use --force to create '$AGENT_ID' as a new, separate identity anyway." >&2
+    exit 1
+  fi
+fi
+
 # --- Add or extend agent registrations ---
 CONFIG_SQL=$(agmsg_sql_readfile_path "$TEAM_CONFIG")
-AGENT_ID_SQL=$(printf '%s' "$AGENT_ID" | sed "s/'/''/g")
 AGENT_TYPE_SQL=$(printf '%s' "$AGENT_TYPE" | sed "s/'/''/g")
 PROJECT_SQL=$(printf '%s' "$PROJECT_PATH" | sed "s/'/''/g")
 PROJECT_SQL_IN=$(agmsg_project_sql_in_list "$PROJECT_PATH")

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -55,6 +55,28 @@ fi
 # Rename: set new key with old value, remove old key
 UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
   "SELECT json_remove(json_set(:json, '$.agents.$NEW_NAME', json_extract(:json, '$.agents.$OLD_NAME')), '$.agents.$OLD_NAME');")
+
+# Tombstone the old name so a later join/actas can't silently revive it (#360):
+# a CLI's slash-command history can resubmit `/agmsg actas <old_name>` well
+# after this rename, and without this record join.sh would happily
+# re-materialize <old_name>, rolling the rename back with no warning.
+# Stored as an array of {from,to,at} entries (rather than keying an object by
+# the old name) so a name containing a single quote can't break the JSON path
+# expression the way `$.agents.$OLD_NAME` above requires it not to — from/to
+# are bound as ordinary SQL string values, never spliced into a path.
+OLD_NAME_SQL=$(_agmsg_sqlesc "$OLD_NAME")
+NEW_NAME_SQL=$(_agmsg_sqlesc "$NEW_NAME")
+RENAMED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+UPDATED_ESCAPED=$(printf '%s' "$UPDATED" | sed "s/'/''/g")
+UPDATED=$(agmsg_sqlite_mem ".param set :json '$UPDATED_ESCAPED'" \
+  "SELECT json_set(:json, '\$.renamed',
+     json_insert(
+       CASE WHEN json_type(json_extract(:json, '\$.renamed')) = 'array'
+            THEN json_extract(:json, '\$.renamed') ELSE json('[]') END,
+       '\$[#]', json_object('from', '$OLD_NAME_SQL', 'to', '$NEW_NAME_SQL', 'at', '$RENAMED_AT')
+     )
+   );")
+
 agmsg_write_atomic "$TEAM_CONFIG" "$UPDATED"
 
 # --- Update messages in DB ---

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -391,6 +391,18 @@ teardown() {
   [[ "$output" =~ "claude " ]]
 }
 
+@test "join: after --force revives a name, a later normal join for it no longer needs --force" {
+  # Once --force deliberately reuses a renamed-away name, that identity's
+  # tombstone must be cleared — otherwise every subsequent registration
+  # (e.g. adding a second project) would keep hitting the same guard forever.
+  bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj
+  bash "$SCRIPTS/rename.sh" myteam claude claude-orchestrator
+  bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj --force
+  run bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj-2
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Joined team myteam as claude" ]]
+}
+
 @test "join: joining the new name after a rename succeeds normally" {
   bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj
   bash "$SCRIPTS/rename.sh" myteam claude claude-orchestrator

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -323,6 +323,106 @@ teardown() {
   [[ "$output" =~ "same" ]]
 }
 
+# --- rename.sh (agent rename) ---
+
+@test "rename: renames an agent, preserving its registration" {
+  bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj
+  run bash "$SCRIPTS/rename.sh" myteam claude claude-orchestrator
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Renamed claude → claude-orchestrator" ]]
+  run bash "$SCRIPTS/team.sh" myteam
+  [[ "$output" =~ "claude-orchestrator" ]]
+  [[ ! "$output" =~ "claude " ]]
+}
+
+@test "rename: migrates messages to the new agent name" {
+  bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj-a
+  bash "$SCRIPTS/join.sh" myteam bob    claude-code /tmp/proj-b
+  bash "$SCRIPTS/send.sh" myteam claude bob "hello"
+  bash "$SCRIPTS/rename.sh" myteam claude claude-orchestrator
+  run bash "$SCRIPTS/inbox.sh" myteam bob
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "hello" ]]
+  [[ "$output" =~ "claude-orchestrator" ]]
+}
+
+@test "rename: fails when old agent is missing" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj
+  run bash "$SCRIPTS/rename.sh" myteam nope newname
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Agent nope not in team" ]]
+}
+
+@test "rename: fails when new agent already exists" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj-a
+  bash "$SCRIPTS/join.sh" myteam bob   claude-code /tmp/proj-b
+  run bash "$SCRIPTS/rename.sh" myteam alice bob
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Agent bob already exists" ]]
+}
+
+# --- rename.sh tombstone / actas revive guard (#360) ---
+
+@test "rename: leaves a tombstone recording old -> new" {
+  bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj
+  bash "$SCRIPTS/rename.sh" myteam claude claude-orchestrator
+  run sqlite_mem "SELECT json_extract(readfile('$(rf "$TEST_SKILL_DIR/teams/myteam/config.json")'), '\$.renamed[0].from') || ' -> ' || json_extract(readfile('$(rf "$TEST_SKILL_DIR/teams/myteam/config.json")'), '\$.renamed[0].to');"
+  [ "$output" = "claude -> claude-orchestrator" ]
+}
+
+@test "join: refuses to silently revive a name that was just renamed away" {
+  bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj
+  bash "$SCRIPTS/rename.sh" myteam claude claude-orchestrator
+  run bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "was renamed to 'claude-orchestrator'" ]]
+  run bash "$SCRIPTS/team.sh" myteam
+  [[ ! "$output" =~ "claude " ]]
+}
+
+@test "join: --force still revives a renamed-away name when explicitly requested" {
+  bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj
+  bash "$SCRIPTS/rename.sh" myteam claude claude-orchestrator
+  run bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj --force
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Joined team myteam as claude" ]]
+  run bash "$SCRIPTS/team.sh" myteam
+  [[ "$output" =~ "claude-orchestrator" ]]
+  [[ "$output" =~ "claude " ]]
+}
+
+@test "join: joining the new name after a rename succeeds normally" {
+  bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj
+  bash "$SCRIPTS/rename.sh" myteam claude claude-orchestrator
+  run bash "$SCRIPTS/join.sh" myteam claude-orchestrator claude-code /tmp/proj2
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Joined team myteam as claude-orchestrator" ]]
+}
+
+@test "join: the tombstone guard does not break on an agent name containing a quote (#87-class)" {
+  # Exercises join.sh's new lookup directly against a hand-authored tombstone
+  # (rather than going through rename.sh, which has its own pre-existing,
+  # unrelated quote-handling gap in its old/new-exists checks — #360 doesn't
+  # touch those) to isolate that THIS guard's json_each+WHERE value compare
+  # is quote-safe, unlike a raw '$.renamed.<name>' path segment would be.
+  local agent="al'ice"
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<EOF
+{
+  "name": "myteam",
+  "agents": {},
+  "renamed": [
+    {"from": "$agent", "to": "bob", "at": "2026-01-01T00:00:00Z"}
+  ]
+}
+EOF
+  run bash "$SCRIPTS/join.sh" myteam "$agent" claude-code /tmp/proj
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "was renamed to 'bob'" ]]
+  [[ ! "$output" =~ "syntax error" ]]
+  [[ ! "$output" =~ ".parameter" ]]
+}
+
 @test "join: rejects unknown agent type" {
   run bash "$SCRIPTS/join.sh" myteam alice claude /tmp/proj
   [ "$status" -ne 0 ]


### PR DESCRIPTION
## Summary

Fixes #360, reported by VariousBuilder with a thorough repro (thank you). A CLI's slash-command history can resubmit `/agmsg actas <old_name>` well after `rename.sh <team> <old> <new>` succeeds — the actas flow falls through to `join.sh`, which used to happily re-materialize `<old_name>` with no warning, silently rolling the rename back for that project.

## Fix

`rename.sh` now appends a `{from,to,at}` tombstone entry to the team config's `$.renamed` array on every successful rename. `join.sh` checks it before registering: if the requested `agent_id` matches a tombstone's `from`, it errors out naming the current name instead of joining, unless `--force` is passed for a deliberate, unrelated reuse of that exact name.

The tombstone lookup compares the agent id as an ordinary SQL value via `json_each` + `WHERE`, not by splicing it into a JSON path segment — unlike `rename.sh`'s own pre-existing `$.agents.$OLD_NAME` path lookups, this is safe for a name containing a single quote (caught during development by an existing `whoami` quote test that started failing against an earlier, path-segment-based version of this change).

Also updated `SKILL.md`'s join usage line to document `[--force]` and the new refusal behavior.

## Testing

Added to `tests/test_team.bats`: `rename.sh` happy-path coverage (no prior test existed beyond a traversal-rejection check), the tombstone write, the join guard firing and being bypassed by `--force`, joining the new name succeeding normally after a rename, and the guard staying quote-safe via a hand-authored tombstone (since `rename.sh`'s own pre-existing old/new-exists checks have an unrelated quote-handling gap this issue doesn't touch). Full `test_team.bats`, `test_spawn.bats`, `test_actas_integration.bats`, `test_actas_lock.bats`, and `test_messaging.bats` all pass.

## Out of scope

The issue's proposals (b) (rewriting `run/actas.*`/`run/ready.*` state on rename) and (c) (a history-prefill caveat note in `rename.sh`'s output) are left for a follow-up — this PR ships proposal (a), the highest-value piece per the issue itself.