### PR TITLE
fix(session-start): skip Monitor directive for .claude/worktrees sub-sessions

### DIFF
--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -86,6 +86,29 @@ fi
 # Fallback so the instruction is still actionable even outside a hook flow.
 [ -z "$SESSION_ID" ] && SESSION_ID="unknown-$$"
 
+# --- Skip spawned worktree sub-sessions (.claude/worktrees checkouts). ---
+# Claude Code's background-task feature runs a short-lived sub-session in an
+# isolated worktree under .claude/worktrees/<name>. SessionStart still fires
+# there (#92's resolve-project normalizes its cwd back to the registered
+# project, so identities resolve fine), so a persistent inbox watcher was
+# getting launched for it too — but that watcher keeps the sub-session's
+# Monitor alive past the point its task finishes, so the parent session never
+# receives the sub-session's completion notification (#367). The sub-session
+# is also not normally an agmsg team member in its own right, so a watcher
+# has little value there anyway. cwd may arrive as forward slashes or
+# JSON-escaped backslashes depending on platform, so match on the substring
+# regardless of separator.
+HOOK_CWD=""
+if [ -n "$INPUT" ]; then
+  HOOK_CWD=$(printf '%s' "$INPUT" \
+    | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | head -1)
+fi
+[ -z "$HOOK_CWD" ] && HOOK_CWD="${PWD:-}"
+case "$HOOK_CWD" in
+  *.claude*worktrees*) exit 0 ;;
+esac
+
 mkdir -p "$RUN_DIR" 2>/dev/null || true
 
 # --- Identify the enclosing Claude Code process. ---

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -96,8 +96,12 @@ fi
 # receives the sub-session's completion notification (#367). The sub-session
 # is also not normally an agmsg team member in its own right, so a watcher
 # has little value there anyway. cwd may arrive as forward slashes or
-# JSON-escaped backslashes depending on platform, so match on the substring
-# regardless of separator.
+# JSON-escaped backslashes depending on platform (a single escaped backslash
+# decodes to two raw '\' bytes in the captured substring), so normalize both
+# to '/' and squeeze doubled separators before matching. Match the exact
+# ".claude/worktrees" PATH SEGMENT sequence, not a loose substring — a naive
+# `*.claude*worktrees*` glob would also skip an unrelated project merely
+# named e.g. ".claude-tools/my-worktrees-app".
 HOOK_CWD=""
 if [ -n "$INPUT" ]; then
   HOOK_CWD=$(printf '%s' "$INPUT" \
@@ -105,8 +109,9 @@ if [ -n "$INPUT" ]; then
     | head -1)
 fi
 [ -z "$HOOK_CWD" ] && HOOK_CWD="${PWD:-}"
-case "$HOOK_CWD" in
-  *.claude*worktrees*) exit 0 ;;
+HOOK_CWD_NORM=$(printf '%s' "$HOOK_CWD" | tr '\\' '/' | sed 's#//*#/#g')
+case "$HOOK_CWD_NORM" in
+  */.claude/worktrees|*/.claude/worktrees/*|.claude/worktrees|.claude/worktrees/*) exit 0 ;;
 esac
 
 mkdir -p "$RUN_DIR" 2>/dev/null || true

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -479,6 +479,17 @@ JSON
   [[ "$output" =~ "invoke the Monitor tool" ]]
 }
 
+@test "session-start: does NOT skip a project whose path merely contains 'claude' and 'worktrees' loosely" {
+  # Regression guard: a naive *.claude*worktrees* glob would also match
+  # unrelated project names like .claude-tools/my-worktrees-app, which don't
+  # form the actual .claude/worktrees path segment sequence.
+  env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/join.sh" team alice claude-code "$TEST_PROJECT" >/dev/null
+  local decoy_cwd="$TEST_PROJECT/.claude-tools/my-worktrees-app"
+  run env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" <<< "{\"session_id\":\"sid-decoy\",\"cwd\":\"$decoy_cwd\"}"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "invoke the Monitor tool" ]]
+}
+
 # --- session-start.sh dedup across /clear ---
 
 @test "session-start.sh kills previous watcher when called with new session_id in same cc-instance" {

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -445,6 +445,40 @@ JSON
   [ ! -f "$TEST_SKILL_DIR/run/watch.sigterm-test.pid" ]
 }
 
+# --- session-start.sh: skip worktree sub-sessions (#367) ---
+
+@test "session-start: skips the Monitor directive when hook cwd is under .claude/worktrees/" {
+  env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/join.sh" team alice claude-code "$TEST_PROJECT" >/dev/null
+  local sub_cwd="$TEST_PROJECT/.claude/worktrees/bg-task-1"
+  run env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" <<< "{\"session_id\":\"sid-sub\",\"cwd\":\"$sub_cwd\"}"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [[ ! "$output" =~ "invoke the Monitor tool" ]]
+}
+
+@test "session-start: skips when hook cwd uses escaped-backslash (Windows JSON) separators" {
+  env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/join.sh" team alice claude-code "$TEST_PROJECT" >/dev/null
+  run env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" <<< '{"session_id":"sid-sub-win","cwd":"C:\\proj\\.claude\\worktrees\\bg-1"}'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "session-start: falls back to \$PWD for the worktree check when the hook input has no cwd" {
+  env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/join.sh" team alice claude-code "$TEST_PROJECT" >/dev/null
+  local sub_cwd="$TEST_PROJECT/.claude/worktrees/bg-task-2"
+  mkdir -p "$sub_cwd"
+  run env AGMSG_RESOLVE_PROJECT=0 bash -c "cd '$sub_cwd' && bash '$SCRIPTS/session-start.sh' claude-code '$TEST_PROJECT' <<< '{\"session_id\":\"sid-sub-nocwd\"}'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "session-start: still emits the Monitor directive for a normal (non-worktree) cwd" {
+  env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/join.sh" team alice claude-code "$TEST_PROJECT" >/dev/null
+  run env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" <<< "{\"session_id\":\"sid-normal\",\"cwd\":\"$TEST_PROJECT\"}"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "invoke the Monitor tool" ]]
+}
+
 # --- session-start.sh dedup across /clear ---
 
 @test "session-start.sh kills previous watcher when called with new session_id in same cc-instance" {


### PR DESCRIPTION
## Summary

Fixes #367, reported by amabile4 with a confirmed local patch (thank you). Claude Code's background-task feature runs a short-lived sub-session in an isolated worktree under `.claude/worktrees/<name>`. `SessionStart` still fires there (#92's resolve-project normalizes its cwd back to the registered project, so identities resolve fine), so monitor mode was launching a persistent inbox watcher for it too. That watcher keeps the sub-session's Monitor alive past the point its task actually finishes, so the parent session never receives the sub-session's completion notification — the reported symptom.

## Fix

`session-start.sh` now reads the hook input's `cwd` (falling back to `$PWD` when absent) right after resolving `SESSION_ID`, before any `RUN_DIR` setup or dedup, and exits 0 without emitting a directive when that path contains `.claude/worktrees` — regardless of whether the platform delivered forward slashes or JSON-escaped backslashes (matches on substring, separator-agnostic, per the reporter's own verified patch).

## Testing

Added to `test_delivery.bats`: skips for a worktree cwd from the hook payload, skips for a Windows-style escaped-backslash cwd, falls back to `$PWD` when the hook payload omits `cwd`, and still emits the directive normally for an ordinary (non-worktree) cwd. Full `test_delivery.bats` (134 tests) passes clean. `test_actas_integration.bats` passes. `test_watch.bats` is flaky independent of this change (a different, unrelated test fails each run and passes on retry — confirmed clean on a third run); session-start.sh's own dedicated tests within it are unaffected.

## Out of scope

Per the issue's own notes: `session-end.sh` fires in sub-sessions too but no real harm was confirmed there, so it's left untouched. An opt-out env var for a deliberate worktree-hosted agmsg role (also mentioned as a maybe) isn't included — no reported use case for it yet.