### PR TITLE
fix(codex): resolve shim through symlinks, warn when monitor mode isn't actually reached

### DIFF
--- a/scripts/drivers/types/codex/_delivery.sh
+++ b/scripts/drivers/types/codex/_delivery.sh
@@ -48,10 +48,50 @@ agmsg_delivery_on_disable() {
   echo "    # then drop any agmsg Codex function or ~/.agents/bin PATH entry you added for monitor"
 }
 
+agmsg_codex_shim_path_warning() {
+  # "mode: monitor" only means a project is CONFIGURED for monitor delivery;
+  # it says nothing about whether `codex` on PATH actually reaches the shim
+  # right now. A PATH-based install (codex-shim-install.sh install, or a raw
+  # symlink) that loses to the real Codex binary in PATH order launches
+  # completely unmonitored sessions with no other signal at all -- delivery
+  # status kept reporting "monitor" throughout. See #387/#397.
+  #
+  # Scoped to the case we can actually verify from here: a PATH-based shim
+  # install exists at all. The shell-function install method is invisible to
+  # this script (functions from an interactive profile aren't inherited by a
+  # fresh, non-interactive `bash delivery.sh status` invocation), so silently
+  # skip when no PATH-based install is present rather than false-alarming on
+  # every function-only setup.
+  local marker="Optional Codex entrypoint shim for agmsg monitor mode"
+  local shim_bin="$HOME/.agents/bin/codex"
+  [ -f "$shim_bin" ] && grep -q "$marker" "$shim_bin" 2>/dev/null || return 0
+
+  local resolved
+  resolved="$(command -v codex 2>/dev/null || true)"
+  if [ -z "$resolved" ]; then
+    echo "WARNING: delivery mode is monitor and the agmsg codex shim is installed at $shim_bin, but 'codex' does not resolve on PATH here -- check that \$HOME/.agents/bin is on PATH."
+  elif [ "$resolved" != "$shim_bin" ] && ! (grep -q "$marker" "$resolved" 2>/dev/null); then
+    echo "WARNING: delivery mode is monitor and the agmsg codex shim is installed at $shim_bin, but 'codex' on PATH resolves to $resolved instead -- Codex launches may bypass the bridge entirely. Put \$HOME/.agents/bin earlier in PATH."
+  fi
+}
+
 agmsg_delivery_runtime_status() {
   local type="$1" project="$2"
   local pairs found=0
   pairs=$("$SCRIPT_DIR/identities.sh" "$project" "$type" 2>/dev/null || true)
+
+  # Capture the FULL output rather than piping into `head -1`: head closing
+  # its read end after one line while agmsg_delivery_status_default is still
+  # writing more would SIGPIPE it, and under this script's set -euo
+  # pipefail that aborts the whole `delivery.sh status` call outright --
+  # the same class of bug fixed in #423 (sort | head under pipefail), now
+  # avoided here by never piping into an early-closing reader at all.
+  local full_status mode_line
+  full_status="$(agmsg_delivery_status_default "$type" "$project" 2>/dev/null || true)"
+  mode_line="${full_status%%$'\n'*}"
+  case "$mode_line" in
+    "mode: monitor"|"mode: both") agmsg_codex_shim_path_warning ;;
+  esac
 
   if [ -z "$pairs" ]; then
     echo "Codex bridge: no identities registered for this project"

--- a/scripts/drivers/types/codex/_delivery.sh
+++ b/scripts/drivers/types/codex/_delivery.sh
@@ -48,50 +48,49 @@ agmsg_delivery_on_disable() {
   echo "    # then drop any agmsg Codex function or ~/.agents/bin PATH entry you added for monitor"
 }
 
-agmsg_codex_shim_path_warning() {
+agmsg_codex_shim_path_note() {
   # "mode: monitor" only means a project is CONFIGURED for monitor delivery;
   # it says nothing about whether `codex` on PATH actually reaches the shim
   # right now. A PATH-based install (codex-shim-install.sh install, or a raw
   # symlink) that loses to the real Codex binary in PATH order launches
-  # completely unmonitored sessions with no other signal at all -- delivery
-  # status kept reporting "monitor" throughout. See #387/#397.
+  # completely unmonitored sessions with no other signal at all. See #387/#397.
   #
-  # Scoped to the case we can actually verify from here: a PATH-based shim
-  # install exists at all. The shell-function install method is invisible to
-  # this script (functions from an interactive profile aren't inherited by a
-  # fresh, non-interactive `bash delivery.sh status` invocation), so silently
-  # skip when no PATH-based install is present rather than false-alarming on
-  # every function-only setup.
+  # This is inherently a best-effort hint, not a diagnosis: the shim FILE
+  # existing at $HOME/.agents/bin/codex does NOT mean this install relies on
+  # PATH resolution for it. The shell-function method (on_enable's primary
+  # recommendation) is the common case, and having the PATH shim file ALSO
+  # present alongside it is normal, not contradictory -- a function takes
+  # priority over PATH in an interactive shell regardless of what's on PATH,
+  # and a fresh non-interactive `command -v codex` here never sees that
+  # function at all, so it can look like a "mismatch" on a perfectly healthy,
+  # function-routed setup. Found in real-machine testing after the first cut
+  # of this check warned unconditionally on exactly that combination.
+  #
+  # So: only surface this note when the PATH shim file exists AND resolves
+  # to something else AND no bridge for this project has ever come alive
+  # (weak but non-alarmist corroboration -- a live/previously-live bridge
+  # means SOMETHING is routing correctly already, by whichever method).
+  # Phrased as a conditional hint, not an assertion of brokenness.
+  local project="$1" any_alive="$2"
+  [ "$any_alive" = "0" ] || return 0
+
   local marker="Optional Codex entrypoint shim for agmsg monitor mode"
   local shim_bin="$HOME/.agents/bin/codex"
   [ -f "$shim_bin" ] && grep -q "$marker" "$shim_bin" 2>/dev/null || return 0
 
   local resolved
   resolved="$(command -v codex 2>/dev/null || true)"
-  if [ -z "$resolved" ]; then
-    echo "WARNING: delivery mode is monitor and the agmsg codex shim is installed at $shim_bin, but 'codex' does not resolve on PATH here -- check that \$HOME/.agents/bin is on PATH."
-  elif [ "$resolved" != "$shim_bin" ] && ! (grep -q "$marker" "$resolved" 2>/dev/null); then
-    echo "WARNING: delivery mode is monitor and the agmsg codex shim is installed at $shim_bin, but 'codex' on PATH resolves to $resolved instead -- Codex launches may bypass the bridge entirely. Put \$HOME/.agents/bin earlier in PATH."
+  if [ -n "$resolved" ] && [ "$resolved" != "$shim_bin" ] && ! (grep -q "$marker" "$resolved" 2>/dev/null); then
+    echo "Note: an agmsg codex shim is installed at $shim_bin, but 'codex' resolves to $resolved in this non-interactive check, and no bridge for this project has come alive yet."
+    echo "  If you launch Codex via the agmsg shell function (codex() in your shell profile), this is expected and fine -- a function isn't visible to this check."
+    echo "  If you rely on the PATH-based shim instead, put \$HOME/.agents/bin earlier in PATH."
   fi
 }
 
 agmsg_delivery_runtime_status() {
   local type="$1" project="$2"
-  local pairs found=0
+  local pairs found=0 any_alive=0
   pairs=$("$SCRIPT_DIR/identities.sh" "$project" "$type" 2>/dev/null || true)
-
-  # Capture the FULL output rather than piping into `head -1`: head closing
-  # its read end after one line while agmsg_delivery_status_default is still
-  # writing more would SIGPIPE it, and under this script's set -euo
-  # pipefail that aborts the whole `delivery.sh status` call outright --
-  # the same class of bug fixed in #423 (sort | head under pipefail), now
-  # avoided here by never piping into an early-closing reader at all.
-  local full_status mode_line
-  full_status="$(agmsg_delivery_status_default "$type" "$project" 2>/dev/null || true)"
-  mode_line="${full_status%%$'\n'*}"
-  case "$mode_line" in
-    "mode: monitor"|"mode: both") agmsg_codex_shim_path_warning ;;
-  esac
 
   if [ -z "$pairs" ]; then
     echo "Codex bridge: no identities registered for this project"
@@ -139,6 +138,7 @@ agmsg_delivery_runtime_status() {
 
     if kill -0 "$pid" 2>/dev/null; then
       echo "Codex bridge: $team/$name alive (pid $pid)"
+      any_alive=1
     else
       echo "Codex bridge: $team/$name stale pidfile (pid $pid not running)"
     fi
@@ -147,4 +147,17 @@ agmsg_delivery_runtime_status() {
   if [ "$found" -eq 0 ]; then
     echo "Codex bridge: no identities registered for this project"
   fi
+
+  # Capture the FULL output rather than piping into `head -1`: head closing
+  # its read end after one line while agmsg_delivery_status_default is still
+  # writing more would SIGPIPE it, and under this script's set -euo
+  # pipefail that aborts the whole `delivery.sh status` call outright --
+  # the same class of bug fixed in #423 (sort | head under pipefail), now
+  # avoided here by never piping into an early-closing reader at all.
+  local full_status mode_line
+  full_status="$(agmsg_delivery_status_default "$type" "$project" 2>/dev/null || true)"
+  mode_line="${full_status%%$'\n'*}"
+  case "$mode_line" in
+    "mode: monitor"|"mode: both") agmsg_codex_shim_path_note "$project" "$any_alive" ;;
+  esac
 }

--- a/scripts/drivers/types/codex/codex-shim.sh
+++ b/scripts/drivers/types/codex/codex-shim.sh
@@ -8,10 +8,35 @@ set -euo pipefail
 # launches are routed through codex-monitor.sh. Everything else is passed
 # through to the real Codex command unchanged.
 
+# Resolve $0 through symlinks to its real location, POSIX-portably (no
+# `readlink -f`: BSD/macOS readlink doesn't support it, only GNU's does).
+# Installing this shim as a symlink -- consistent with the header comment
+# below -- is a documented install method, but `dirname "$0"` alone resolves
+# to the SYMLINK's directory, not the real script's. That pointed
+# `$SCRIPT_DIR/../../../delivery.sh` at a nonexistent path, which
+# is_monitor_project() then silently treated as "not a monitor project"
+# instead of a broken install -- every Codex launch quietly bypassed the
+# bridge with no signal at all. See #387.
+_agmsg_resolve_self() {
+  local src="$1" dir link
+  while [ -L "$src" ]; do
+    dir="$(cd "$(dirname "$src")" && pwd)"
+    link="$(readlink "$src")"
+    case "$link" in
+      /*) src="$link" ;;
+      *) src="$dir/$link" ;;
+    esac
+  done
+  dir="$(cd "$(dirname "$src")" && pwd)"
+  printf '%s/%s\n' "$dir" "$(basename "$src")"
+}
+
 if [ "${AGMSG_CODEX_SHIM_WRAPPER:-}" = "1" ] && [ -n "${AGMSG_CODEX_SHIM_SCRIPT_DIR:-}" ]; then
   SCRIPT_DIR="$AGMSG_CODEX_SHIM_SCRIPT_DIR"
+  SELF_PATH="$AGMSG_CODEX_SHIM_SCRIPT_DIR/codex-shim.sh"
 else
-  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  SELF_PATH="$(_agmsg_resolve_self "$0")"
+  SCRIPT_DIR="$(dirname "$SELF_PATH")"
 fi
 
 is_agmsg_wrapper() {
@@ -24,9 +49,8 @@ resolve_real_codex() {
     return 0
   fi
 
-  local self_dir self_path shim_target path_dir candidate candidate_dir candidate_path
-  self_dir="$(cd "$(dirname "$0")" && pwd)"
-  self_path="$self_dir/$(basename "$0")"
+  local self_path shim_target path_dir candidate candidate_dir candidate_path
+  self_path="$SELF_PATH"
   shim_target="${AGMSG_CODEX_SHIM_TARGET:-}"
 
   local old_ifs="$IFS"
@@ -111,8 +135,18 @@ first_non_option() {
 
 is_monitor_project() {
   local project="$1"
+  local delivery_script="$SCRIPT_DIR/../../../delivery.sh"
+  if [ ! -f "$delivery_script" ]; then
+    # A broken install (e.g. SCRIPT_DIR resolved wrong, or the skill was
+    # relocated/removed underneath an existing shim) previously looked
+    # identical to "this project just isn't in monitor mode" -- the shim
+    # failed open with zero signal. Warn loudly instead before doing so.
+    # See #387.
+    echo "agmsg codex shim: cannot find delivery.sh at $delivery_script (broken install?); falling through to plain codex" >&2
+    return 1
+  fi
   local status
-  status="$("$SCRIPT_DIR/../../../delivery.sh" status codex "$project" 2>/dev/null || true)"
+  status="$("$delivery_script" status codex "$project" 2>/dev/null || true)"
   printf '%s\n' "$status" | grep -qx "mode: monitor"
 }
 

--- a/tests/test_codex_shim.bats
+++ b/tests/test_codex_shim.bats
@@ -172,6 +172,66 @@ teardown() {
   grep -q "monitor real=$FAKE_CODEX <--project> <$TEST_PROJECT> <--codex-command> <resume> <-->" "$CALL_LOG"
 }
 
+@test "codex shim: _agmsg_resolve_self follows a relative-target symlink (#387)" {
+  # A direct unit test of the resolution helper (extracted verbatim from the
+  # shipped script via awk, so this exercises the real implementation) rather
+  # than a full shim invocation -- avoids needing to fabricate a whole
+  # relative skill-tree layout just to get a relative `ln -s` target that
+  # still resolves to a real delivery.sh. Covers the non-absolute branch of
+  # its target-reconstruction (`ln -s ../real/target.sh link`, as opposed to
+  # an absolute target).
+  local helper="$TEST_PROJECT/resolve-self.sh"
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'set -euo pipefail'
+    awk '/^_agmsg_resolve_self\(\)/,/^}/' "$TYPES/codex/codex-shim.sh"
+    echo '_agmsg_resolve_self "$1"'
+  } > "$helper"
+
+  mkdir -p "$TEST_PROJECT/real/deep" "$TEST_PROJECT/bin"
+  : > "$TEST_PROJECT/real/deep/target.sh"
+  ln -s "../real/deep/target.sh" "$TEST_PROJECT/bin/link"
+
+  run bash "$helper" "$TEST_PROJECT/bin/link"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TEST_PROJECT/real/deep/target.sh" ]
+}
+
+@test "codex shim: _agmsg_resolve_self follows a multi-hop symlink chain (#387)" {
+  local helper="$TEST_PROJECT/resolve-self.sh"
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'set -euo pipefail'
+    awk '/^_agmsg_resolve_self\(\)/,/^}/' "$TYPES/codex/codex-shim.sh"
+    echo '_agmsg_resolve_self "$1"'
+  } > "$helper"
+
+  mkdir -p "$TEST_PROJECT/real" "$TEST_PROJECT/hop" "$TEST_PROJECT/bin"
+  : > "$TEST_PROJECT/real/target.sh"
+  ln -s "$TEST_PROJECT/real/target.sh" "$TEST_PROJECT/hop/hop1"
+  ln -s "$TEST_PROJECT/hop/hop1" "$TEST_PROJECT/bin/link"
+
+  run bash "$helper" "$TEST_PROJECT/bin/link"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TEST_PROJECT/real/target.sh" ]
+}
+
+@test "codex shim: a multi-hop symlink chain still resolves its own script location (#387)" {
+  # symlink -> symlink -> real script. _agmsg_resolve_self's while loop must
+  # keep following until it reaches a non-symlink.
+  export HOME="$TEST_PROJECT/home"
+  mkdir -p "$HOME/.agents/bin" "$HOME/intermediate"
+  ln -s "$TYPES/codex/codex-shim.sh" "$HOME/intermediate/codex-hop1"
+  ln -s "$HOME/intermediate/codex-hop1" "$HOME/.agents/bin/codex"
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+
+  PATH="$HOME/.agents/bin:$PATH" run bash -c 'cd "$TEST_PROJECT" && AGMSG_REAL_CODEX="$FAKE_CODEX" AGMSG_CODEX_MONITOR_CMD="$FAKE_MONITOR" codex resume'
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"cannot find delivery.sh"* ]]
+  grep -q "monitor real=$FAKE_CODEX <--project> <$TEST_PROJECT> <--codex-command> <resume> <-->" "$CALL_LOG"
+}
+
 @test "codex shim: a broken install (missing delivery.sh) warns loudly instead of silently passing through (#387)" {
   export HOME="$TEST_PROJECT/home"
   mkdir -p "$HOME/.agents/bin"

--- a/tests/test_codex_shim.bats
+++ b/tests/test_codex_shim.bats
@@ -152,3 +152,39 @@ teardown() {
   [ "$status" -eq 0 ]
   grep -q "monitor real=$FAKE_CODEX <--project> <$TEST_PROJECT> <--codex-command> <resume> <-->" "$CALL_LOG"
 }
+
+@test "codex shim: a raw symlink install still resolves its own script location (#387)" {
+  # Installing codex-shim.sh directly as a symlink (ln -s .../codex-shim.sh
+  # ~/.agents/bin/codex) is a documented install method -- the header comment
+  # says exactly this. Before #387, dirname "$0" resolved to the symlink's
+  # OWN directory rather than the real script's, so the relative delivery.sh
+  # lookup pointed nowhere and the shim silently fell through to plain codex
+  # with zero signal, in every monitor-mode project, unconditionally.
+  export HOME="$TEST_PROJECT/home"
+  mkdir -p "$HOME/.agents/bin"
+  ln -s "$TYPES/codex/codex-shim.sh" "$HOME/.agents/bin/codex"
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+
+  PATH="$HOME/.agents/bin:$PATH" run bash -c 'cd "$TEST_PROJECT" && AGMSG_REAL_CODEX="$FAKE_CODEX" AGMSG_CODEX_MONITOR_CMD="$FAKE_MONITOR" codex resume'
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"cannot find delivery.sh"* ]]
+  grep -q "monitor real=$FAKE_CODEX <--project> <$TEST_PROJECT> <--codex-command> <resume> <-->" "$CALL_LOG"
+}
+
+@test "codex shim: a broken install (missing delivery.sh) warns loudly instead of silently passing through (#387)" {
+  export HOME="$TEST_PROJECT/home"
+  mkdir -p "$HOME/.agents/bin"
+  # A shim copied somewhere with no skill tree above it at all -- SCRIPT_DIR
+  # resolves fine, but the relative delivery.sh three levels up genuinely
+  # does not exist. This must be reported, not treated as "not a monitor
+  # project".
+  cp "$TYPES/codex/codex-shim.sh" "$HOME/.agents/bin/codex"
+  chmod +x "$HOME/.agents/bin/codex"
+
+  PATH="$HOME/.agents/bin:$PATH" run bash -c 'cd "$TEST_PROJECT" && AGMSG_REAL_CODEX="$FAKE_CODEX" codex'
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "cannot find delivery.sh" ]]
+  grep -q "real-codex" "$CALL_LOG"
+}

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1686,6 +1686,53 @@ EOF
   [[ "$output" != *"watch processes:"* ]]
 }
 
+@test "delivery status (codex): warns when the installed shim loses to a different codex on PATH (#387)" {
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+
+  mkdir -p "$HOME/.agents/bin"
+  cp "$TYPES/codex/codex-shim.sh" "$HOME/.agents/bin/codex"
+  chmod +x "$HOME/.agents/bin/codex"
+
+  # A different, non-agmsg codex earlier on PATH -- exactly the "PATH order
+  # loses" shape from #387/#397: mode stays "monitor" but launches never
+  # actually reach the shim.
+  local other_bin="$TEST_SKILL_DIR/other-bin"
+  mkdir -p "$other_bin"
+  printf '#!/usr/bin/env bash\necho real\n' > "$other_bin/codex"
+  chmod +x "$other_bin/codex"
+
+  PATH="$other_bin:$HOME/.agents/bin:$PATH" run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARNING: delivery mode is monitor"* ]]
+  [[ "$output" == *"$other_bin/codex"* ]]
+}
+
+@test "delivery status (codex): no PATH-mismatch warning when the shim correctly wins PATH order (#387)" {
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+
+  mkdir -p "$HOME/.agents/bin"
+  cp "$TYPES/codex/codex-shim.sh" "$HOME/.agents/bin/codex"
+  chmod +x "$HOME/.agents/bin/codex"
+
+  PATH="$HOME/.agents/bin:$PATH" run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"WARNING:"* ]]
+}
+
+@test "delivery status (codex): no PATH-mismatch warning when no PATH-based shim is installed (#387)" {
+  # The shell-function-only install method is invisible to this script (a
+  # function from an interactive profile isn't inherited by a fresh
+  # `bash delivery.sh status` invocation) -- must not false-alarm here.
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"WARNING:"* ]]
+}
+
 @test "delivery status (codex): multiple identities are enumerated independently" {
   skip_on_windows "codex bridge status liveness under Git Bash (#182)"
   bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1686,7 +1686,7 @@ EOF
   [[ "$output" != *"watch processes:"* ]]
 }
 
-@test "delivery status (codex): warns when the installed shim loses to a different codex on PATH (#387)" {
+@test "delivery status (codex): notes when the installed shim loses to a different codex on PATH and no bridge has ever been alive (#387)" {
   bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
   bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
 
@@ -1696,7 +1696,8 @@ EOF
 
   # A different, non-agmsg codex earlier on PATH -- exactly the "PATH order
   # loses" shape from #387/#397: mode stays "monitor" but launches never
-  # actually reach the shim.
+  # actually reach the shim. No bridge has ever come alive here either, so
+  # this is the one case with enough corroboration to say something.
   local other_bin="$TEST_SKILL_DIR/other-bin"
   mkdir -p "$other_bin"
   printf '#!/usr/bin/env bash\necho real\n' > "$other_bin/codex"
@@ -1704,11 +1705,11 @@ EOF
 
   PATH="$other_bin:$HOME/.agents/bin:$PATH" run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"WARNING: delivery mode is monitor"* ]]
+  [[ "$output" == *"Note: an agmsg codex shim is installed"* ]]
   [[ "$output" == *"$other_bin/codex"* ]]
 }
 
-@test "delivery status (codex): no PATH-mismatch warning when the shim correctly wins PATH order (#387)" {
+@test "delivery status (codex): no PATH-mismatch note when the shim correctly wins PATH order (#387)" {
   bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
   bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
 
@@ -1718,10 +1719,10 @@ EOF
 
   PATH="$HOME/.agents/bin:$PATH" run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
-  [[ "$output" != *"WARNING:"* ]]
+  [[ "$output" != *"Note: an agmsg codex shim"* ]]
 }
 
-@test "delivery status (codex): no PATH-mismatch warning when no PATH-based shim is installed (#387)" {
+@test "delivery status (codex): no PATH-mismatch note when no PATH-based shim is installed (#387)" {
   # The shell-function-only install method is invisible to this script (a
   # function from an interactive profile isn't inherited by a fresh
   # `bash delivery.sh status` invocation) -- must not false-alarm here.
@@ -1730,7 +1731,49 @@ EOF
 
   run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
-  [[ "$output" != *"WARNING:"* ]]
+  [[ "$output" != *"Note: an agmsg codex shim"* ]]
+}
+
+@test "delivery status (codex): no PATH-mismatch note when a bridge is alive even if the shim file loses on PATH (#387 regression)" {
+  # Real-machine regression: the shim FILE existing at ~/.agents/bin/codex
+  # does not mean this install relies on PATH resolution for it -- the
+  # shell-function method (recommended first, in on_enable) is common, and
+  # having the PATH shim file ALSO present is a normal side effect of
+  # following the setup instructions, not evidence of a broken PATH-based
+  # setup. A live bridge is corroborating evidence that delivery is
+  # actually working (by whichever method), so the note must remain silent.
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+
+  mkdir -p "$HOME/.agents/bin" "$TEST_SKILL_DIR/run"
+  cp "$TYPES/codex/codex-shim.sh" "$HOME/.agents/bin/codex"
+  chmod +x "$HOME/.agents/bin/codex"
+
+  local other_bin="$TEST_SKILL_DIR/other-bin"
+  mkdir -p "$other_bin"
+  printf '#!/usr/bin/env bash\necho real\n' > "$other_bin/codex"
+  chmod +x "$other_bin/codex"
+
+  sleep 60 &
+  local bpid=$!
+  # shellcheck disable=SC2064  # capture the current child pid for EXIT cleanup
+  trap "kill $bpid 2>/dev/null || true" EXIT
+  printf '%s\n' "$bpid" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
+  cat > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.meta" <<EOF
+pid=$bpid
+project=$TEST_PROJECT
+team=team
+name=alice
+type=codex
+EOF
+
+  PATH="$other_bin:$HOME/.agents/bin:$PATH" run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Codex bridge: team/alice alive"* ]]
+  [[ "$output" != *"Note: an agmsg codex shim"* ]]
+
+  kill "$bpid" 2>/dev/null || true
+  trap - EXIT
 }
 
 @test "delivery status (codex): multiple identities are enumerated independently" {


### PR DESCRIPTION
## What

Fixes #387: two ways Codex monitor setup can silently launch unmonitored sessions while `delivery.sh status` keeps reporting `mode: monitor`, with no other signal at all.

### Trap 1 — symlink install breaks the shim's self-location

`codex-shim.sh` locates `delivery.sh` relative to `dirname "$0"`. Installing the shim as a symlink — the header comment's own documented method (`ln -s .../codex-shim.sh ~/.agents/bin/codex`) — pointed `dirname "$0"` at the symlink's own directory rather than the real script's, so the relative `delivery.sh` lookup went nowhere. `is_monitor_project()` then read the missing file as "not a monitor project" instead of a broken install, and every Codex launch quietly fell through to plain codex.

### Trap 2 — PATH order loses, complete passthrough with no signal

When a PATH-based shim install (`codex-shim-install.sh install`, or the symlink method above) loses to the real Codex binary in PATH order, launches bypass the shim entirely. `delivery.sh status` only checks the project's hooks config, so it has no way to notice — it just keeps saying `mode: monitor`.

## Fix

1. `codex-shim.sh` resolves `$0` through symlinks first — a portable loop-based equivalent of `readlink -f` (BSD/macOS `readlink` has no `-f`, only GNU's does). Also warns loudly on stderr instead of silently falling through when the resolved `delivery.sh` path genuinely doesn't exist (a broken install, distinct from "this project isn't in monitor mode").
2. `delivery.sh status` (codex plug) now checks, when a PATH-based shim install is present, whether `codex` on PATH actually resolves to it — and notes a possible mismatch. Scoped specifically to the PATH-install case: the shell-function install method is invisible to a fresh, non-interactive `bash delivery.sh status` invocation (functions from an interactive shell profile aren't inherited), so this intentionally does not attempt to verify that method and stays silent for function-only setups rather than false-alarming.

   **Update after real-machine testing:** the first cut of this check fired unconditionally on any PATH mismatch, which false-positived on a common, healthy combination — the shim FILE existing at `~/.agents/bin/codex` does not mean an install relies on PATH resolution for it; many installs use the shell-function method (recommended first in `on_enable`) while the PATH shim file is *also* present as a leftover of following setup instructions. A shell function wins over PATH in an interactive shell regardless of what's on PATH there, so this was flagging perfectly working setups. The check now only surfaces its note when, in addition to the PATH mismatch, no bridge has *ever* come alive for the project — weak but non-alarmist corroboration that something might actually be wrong — and the wording was downgraded from an assertive "WARNING: ... bypass the bridge entirely" to a conditional "Note: ... if you use the function, this is expected."

## Scope note

The issue's suggestion 2 also floats a broader `agmsg doctor` diagnostic (tracked separately as #267) that would additionally verify how `codex` resolves in interactive vs. non-interactive shells — i.e. covering the shell-function case too. That's a bigger, separate feature and out of scope here; this PR only adds the narrower `delivery.sh status` check described above. Related #397 (`cli_wrapper=` config proposal) is also out of scope — that's a new config-interface addition that needs its own review, not a fix riding along with this one.

## Tests

Added to `tests/test_codex_shim.bats`:
- a raw symlink install still resolves its own script location and routes through the bridge (repro'd the original bug first — confirmed it silently falls through to plain codex on `origin/main`, then confirmed the fix routes correctly)
- a broken install (missing `delivery.sh`) warns loudly instead of silently passing through

Added to `tests/test_delivery.bats`:
- notes when the installed shim loses to a different `codex` on PATH and no bridge has ever been alive
- no note when the shim correctly wins PATH order
- no note when no PATH-based shim is installed at all (the function-only case)
- no note when a bridge is alive even though the shim file loses on PATH (the exact real-machine false-positive this PR now avoids)

Full `test_codex_shim.bats` and `test_delivery.bats` pass locally.

Closes #387.
