### PR TITLE
feat(app): add session-only dismiss to outdated-CLI banner

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -88,6 +88,26 @@ body,
   cursor: pointer;
   flex-shrink: 0;
 }
+.startup-outdated-banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+/* Deliberately unobtrusive — a way out for someone who really wants the
+   warning gone, not a peer action to "Update now". Two-class selector
+   (0,2,0) beats .startup-outdated-banner button's (0,1,1) without
+   !important. */
+.startup-outdated-banner .startup-outdated-banner-dismiss {
+  border: none;
+  padding: 0 4px;
+  font-size: 14px;
+  line-height: 1;
+  opacity: 0.6;
+}
+.startup-outdated-banner .startup-outdated-banner-dismiss:hover {
+  opacity: 1;
+}
 
 .startup-success-banner {
   display: flex;

--- a/app/src/App.test.ts
+++ b/app/src/App.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowOutdatedBanner } from "./App";
+
+describe("shouldShowOutdatedBanner", () => {
+  it("shows when outdated, not updating, and not dismissed", () => {
+    expect(shouldShowOutdatedBanner({ installed: "1.1.0", pinned: "1.1.8" }, false, false)).toBe(true);
+  });
+
+  it("hides when not outdated (null)", () => {
+    expect(shouldShowOutdatedBanner(null, false, false)).toBe(false);
+  });
+
+  it("hides while an update is in flight", () => {
+    expect(shouldShowOutdatedBanner({ installed: "1.1.0", pinned: "1.1.8" }, true, false)).toBe(false);
+  });
+
+  it("hides once dismissed, independent of updatingCore", () => {
+    expect(shouldShowOutdatedBanner({ installed: "1.1.0", pinned: "1.1.8" }, false, true)).toBe(false);
+  });
+});

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -147,6 +147,19 @@ const PANE_DRAG_MIME = "application/x-agmsg-pane";
 // A spawnable agent type discovered from agmsg's type registry.
 export type AgentType = { name: string; cli: string; options: string[] };
 
+// Whether the outdated-CLI banner should render. A pure function (rather
+// than an inline JSX condition) purely so it's unit-testable — pinning down
+// that "Update now" already in flight (updatingCore) and a session-only ×
+// dismiss both independently suppress the banner, on top of the base
+// coreOutdated !== null check.
+export function shouldShowOutdatedBanner<T>(
+  coreOutdated: T,
+  updatingCore: boolean,
+  dismissed: boolean,
+): coreOutdated is NonNullable<T> {
+  return coreOutdated != null && !updatingCore && !dismissed;
+}
+
 export default function App() {
   const { t } = useTranslation();
   // Set when a startup call that the whole app depends on (loading teams)
@@ -163,6 +176,11 @@ export default function App() {
   // install still passes agmsg_is_installed(), so this is a separate check.
   // Never updated automatically: only ever from the user clicking Update.
   const [coreOutdated, setCoreOutdated] = useState<{ installed: string | null; pinned: string } | null>(null);
+  // The outdated banner's own × dismiss — deliberately session-only, not
+  // persisted (no localStorage key): a user who dismisses it once still
+  // hasn't actually updated the CLI, so the warning should come back on the
+  // next launch rather than staying silenced forever.
+  const [coreOutdatedDismissed, setCoreOutdatedDismissed] = useState(false);
   const [updatingCore, setUpdatingCore] = useState(false);
   // The version just updated to, shown as a confirmation banner — Update now
   // otherwise completes silently (the outdated banner just disappears),
@@ -1245,7 +1263,7 @@ export default function App() {
           <span>{t("startupError.installing")}</span>
         </div>
       )}
-      {coreOutdated && !updatingCore && (
+      {shouldShowOutdatedBanner(coreOutdated, updatingCore, coreOutdatedDismissed) && (
         <div className="startup-outdated-banner">
           <span>
             {t("startupError.coreOutdated", {
@@ -1253,25 +1271,34 @@ export default function App() {
               pinned: coreOutdated.pinned,
             })}
           </span>
-          <button
-            onClick={async () => {
-              const targetVersion = coreOutdated.pinned;
-              setUpdatingCore(true);
-              try {
-                await invoke("agmsg_update_core");
-                setCoreOutdated(null);
-                setCoreUpdateSucceeded(targetVersion);
-                await loadTeams();
-              } catch (err) {
-                console.error(err);
-                setStartupError(t("startupError.updateFailed", { error: String(err) }));
-              } finally {
-                setUpdatingCore(false);
-              }
-            }}
-          >
-            {t("startupError.updateNow")}
-          </button>
+          <div className="startup-outdated-banner-actions">
+            <button
+              onClick={async () => {
+                const targetVersion = coreOutdated.pinned;
+                setUpdatingCore(true);
+                try {
+                  await invoke("agmsg_update_core");
+                  setCoreOutdated(null);
+                  setCoreUpdateSucceeded(targetVersion);
+                  await loadTeams();
+                } catch (err) {
+                  console.error(err);
+                  setStartupError(t("startupError.updateFailed", { error: String(err) }));
+                } finally {
+                  setUpdatingCore(false);
+                }
+              }}
+            >
+              {t("startupError.updateNow")}
+            </button>
+            <button
+              className="startup-outdated-banner-dismiss"
+              onClick={() => setCoreOutdatedDismissed(true)}
+              title={t("startupError.dismiss")}
+            >
+              ×
+            </button>
+          </div>
         </div>
       )}
       {updatingCore && (

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1295,6 +1295,7 @@ export default function App() {
               className="startup-outdated-banner-dismiss"
               onClick={() => setCoreOutdatedDismissed(true)}
               title={t("startupError.dismiss")}
+              aria-label={t("startupError.dismiss")}
             >
               ×
             </button>


### PR DESCRIPTION
## Summary
- The "your agmsg CLI is out of date" banner had no way to dismiss it short of clicking Update now — koit wanted a low-key way to get rid of it if you don't want to update yet.
- Adds a small × button on the far right of the banner. Clicking it hides the banner for the rest of the session only — no persistence, no localStorage key. It reappears on the next launch if the CLI is still outdated.
- Extracted the render condition into a pure `shouldShowOutdatedBanner(coreOutdated, updatingCore, dismissed)` type-guard function for unit testability, per this repo's convention.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `pnpm test` — 143 passed (4 new: shows/hides across outdated, updating-in-flight, and dismissed states)