### PR TITLE
feat(app): free shell tab, unattached to any agent

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -177,6 +177,42 @@ fn resolve_login_shell() -> String {
     "/bin/zsh".into()
 }
 
+/// What to spawn for the free-shell tab (App.tsx's "+" tab and a tab's "Open
+/// shell" menu item, unattached to any agent). `args` carries login+
+/// interactive flags on unix so the shell sources the user's profile
+/// (aliases, PATH additions, prompt) the same way a real terminal window
+/// would — plain PTY attachment alone doesn't imply that, since e.g. zsh
+/// only treats stdin-is-a-tty as sufficient for *interactive*, not *login*.
+/// `home` is the frontend's cwd fallback when the current team has no
+/// project dir configured — the frontend's own default-project value always
+/// wins when set (koit: cd'ing from $HOME every time is tedious), this is
+/// only reached when that's empty. A login shell doesn't cd to $HOME on its
+/// own; that's a real terminal app's spawn-time cwd, not shell behavior.
+#[derive(Serialize)]
+pub struct LoginShellInfo {
+    cmd: String,
+    args: Vec<String>,
+    home: String,
+}
+
+#[tauri::command]
+fn login_shell() -> LoginShellInfo {
+    #[cfg(unix)]
+    {
+        LoginShellInfo {
+            cmd: resolve_login_shell(),
+            args: vec!["-il".into()],
+            home: std::env::var("HOME").unwrap_or_default(),
+        }
+    }
+    #[cfg(windows)]
+    {
+        let comspec = std::env::var("ComSpec").unwrap_or_else(|_| "cmd.exe".into());
+        let home = std::env::var("USERPROFILE").unwrap_or_default();
+        LoginShellInfo { cmd: comspec, args: vec![], home }
+    }
+}
+
 /// Appends a timestamped line to ~/Library/Logs/agmsg/path-import.log. The
 /// only real diagnostic available for import_login_shell_path(): it runs
 /// before the webview (and thus DevTools) exists, and its failure mode was
@@ -598,6 +634,7 @@ pub fn run() {
             pty::pty_kill,
             pty::pty_inject,
             pty::agent_state,
+            login_shell,
             agmsg::agmsg_is_installed,
             agmsg::agmsg_install,
             agmsg::agmsg_core_version_status,

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -962,6 +962,27 @@ body.resizing-row {
   opacity: 1;
   color: #f7768e;
 }
+/* The "+" free-shell tab, pinned right after the last real tab (not part
+   of teamWindows.map, so it isn't a .tab itself — no close button, no
+   active/rename state, just an icon button that opens a new one). */
+.tab-new-shell {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-end;
+  width: 26px;
+  height: 26px;
+  margin-bottom: 1px;
+  background: none;
+  border: none;
+  border-radius: 6px 6px 0 0;
+  color: var(--muted);
+  cursor: pointer;
+}
+.tab-new-shell:hover {
+  color: var(--fg);
+  background: var(--panel-2);
+}
 
 /* Stage */
 .stage {

--- a/app/src/App.test.ts
+++ b/app/src/App.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   shellPaneFrom,
+  shellSplitStillValid,
   shellTabStillValid,
-  shellWindowStillOpen,
   shouldShowOutdatedBanner,
   type LoginShellInfo,
 } from "./App";
@@ -66,19 +66,33 @@ describe("shellTabStillValid", () => {
   });
 });
 
-describe("shellWindowStillOpen", () => {
-  it("stays true when the target window is still open", () => {
-    expect(shellWindowStillOpen([{ id: "w-1" }, { id: "w-2" }], "w-1")).toBe(true);
+describe("shellSplitStillValid", () => {
+  const windows = [
+    { id: "w-1", team: "teamA" },
+    { id: "w-2", team: "teamA" },
+  ];
+
+  it("stays valid when the target window is open and the team hasn't changed", () => {
+    expect(shellSplitStillValid(windows, "w-1", "teamA", "teamA")).toBe(true);
   });
 
   it("goes false when the target window was closed during the await", () => {
     // Regression: openShellInWindow used to commit anyway, leaving an
     // orphaned pane and `active` pointing at a nonexistent window id (co1,
     // PR #431).
-    expect(shellWindowStillOpen([{ id: "w-2" }], "w-1")).toBe(false);
+    expect(shellSplitStillValid([{ id: "w-2", team: "teamA" }], "w-1", "teamA", "teamA")).toBe(false);
   });
 
   it("goes false against an empty window list", () => {
-    expect(shellWindowStillOpen([], "w-1")).toBe(false);
+    expect(shellSplitStillValid([], "w-1", "teamA", "teamA")).toBe(false);
+  });
+
+  it("goes false when the team switched even though the window is still open", () => {
+    // Regression (2nd co1 round): the target window can survive the await
+    // untouched but now belong to the team the user navigated away from —
+    // it's a hidden tab at that point, so splitting into it and activating
+    // it reproduces the same hidden-active bug shellTabStillValid guards
+    // against on the new-tab path (co1, PR #431).
+    expect(shellSplitStillValid(windows, "w-1", "teamB", "teamA")).toBe(false);
   });
 });

--- a/app/src/App.test.ts
+++ b/app/src/App.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { shellPaneFrom, shouldShowOutdatedBanner, type LoginShellInfo } from "./App";
+import {
+  shellPaneFrom,
+  shellTabStillValid,
+  shellWindowStillOpen,
+  shouldShowOutdatedBanner,
+  type LoginShellInfo,
+} from "./App";
 
 describe("shouldShowOutdatedBanner", () => {
   it("shows when outdated, not updating, and not dismissed", () => {
@@ -44,5 +50,35 @@ describe("shellPaneFrom", () => {
   it("passes cwd through as-is, including undefined", () => {
     const info: LoginShellInfo = { cmd: "/bin/bash", args: ["-il"], home: "/home/koit" };
     expect(shellPaneFrom(info, "shell-2", "Shell", undefined)?.cwd).toBeUndefined();
+  });
+});
+
+describe("shellTabStillValid", () => {
+  it("stays valid when the team hasn't changed while getLoginShell was in flight", () => {
+    expect(shellTabStillValid("teamA", "teamA")).toBe(true);
+  });
+
+  it("goes invalid when the user switched teams during the await", () => {
+    // Regression: openShellTab used to commit the new window under the
+    // stale (closed-over) team regardless, silently hiding it since only
+    // the current team's windows render (co1, PR #431).
+    expect(shellTabStillValid("teamB", "teamA")).toBe(false);
+  });
+});
+
+describe("shellWindowStillOpen", () => {
+  it("stays true when the target window is still open", () => {
+    expect(shellWindowStillOpen([{ id: "w-1" }, { id: "w-2" }], "w-1")).toBe(true);
+  });
+
+  it("goes false when the target window was closed during the await", () => {
+    // Regression: openShellInWindow used to commit anyway, leaving an
+    // orphaned pane and `active` pointing at a nonexistent window id (co1,
+    // PR #431).
+    expect(shellWindowStillOpen([{ id: "w-2" }], "w-1")).toBe(false);
+  });
+
+  it("goes false against an empty window list", () => {
+    expect(shellWindowStillOpen([], "w-1")).toBe(false);
   });
 });

--- a/app/src/App.test.ts
+++ b/app/src/App.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { shouldShowOutdatedBanner } from "./App";
+import { shellPaneFrom, shouldShowOutdatedBanner, type LoginShellInfo } from "./App";
 
 describe("shouldShowOutdatedBanner", () => {
   it("shows when outdated, not updating, and not dismissed", () => {
@@ -16,5 +16,33 @@ describe("shouldShowOutdatedBanner", () => {
 
   it("hides once dismissed, independent of updatingCore", () => {
     expect(shouldShowOutdatedBanner({ installed: "1.1.0", pinned: "1.1.8" }, false, true)).toBe(false);
+  });
+});
+
+describe("shellPaneFrom", () => {
+  it("returns null when login_shell hasn't resolved — no guessed-shell fallback", () => {
+    // Regression: an earlier version defaulted to "bash" here when the
+    // async login_shell fetch hadn't landed yet, which broke on Windows
+    // (no bash) and wasn't the user's actual login shell even on unix
+    // (co1 review, PR #431).
+    expect(shellPaneFrom(null, "shell-1", "Shell", undefined)).toBeNull();
+  });
+
+  it("builds a shell pane from resolved login shell info", () => {
+    const info: LoginShellInfo = { cmd: "/bin/zsh", args: ["-il"], home: "/Users/koit" };
+    expect(shellPaneFrom(info, "shell-1", "Shell", "/Users/koit/project")).toEqual({
+      id: "shell-1",
+      label: "Shell",
+      cmd: "/bin/zsh",
+      args: ["-il"],
+      cwd: "/Users/koit/project",
+      native: false,
+      shell: true,
+    });
+  });
+
+  it("passes cwd through as-is, including undefined", () => {
+    const info: LoginShellInfo = { cmd: "/bin/bash", args: ["-il"], home: "/home/koit" };
+    expect(shellPaneFrom(info, "shell-2", "Shell", undefined)?.cwd).toBeUndefined();
   });
 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,6 +8,7 @@ import {
   Minimize2,
   Minus,
   PanelLeftClose,
+  Plus,
   RectangleHorizontal,
   Settings,
   Users,
@@ -71,6 +72,12 @@ type Pane = {
    *  False for actas-booted types with no monitor of their own (codex,
    *  grok-build, hermes, ...): the app's stdin-inject IS their only delivery. */
   native: boolean;
+  /** A free login shell (the "+" tab, or a tab's "Open shell" context menu
+   *  item) — unattached to any agent. Drives the sidebar-click "spawn beside
+   *  the shell instead of a new tab" behavior below: it has to be an
+   *  explicit flag rather than inferred from `cmd`, since `cmd` is
+   *  whatever login_shell resolved (zsh/bash/fish/...), not a fixed string. */
+  shell?: boolean;
 };
 // A tab. Holds one or more panes, arranged as a binary split tree (see
 // paneTree.ts) — draggable dividers and directional split/swap drag-drop
@@ -94,6 +101,11 @@ type Window = {
 // drags or split-drops produced and rebuilds a fresh tree matching the
 // preset; it is NOT a persisted mode the window stays locked into.
 type PaneLayout = "vertical" | "horizontal" | "tile";
+// What Rust's login_shell resolved (see lib.rs) — the user's actual login
+// shell binary plus the flags to make it behave like one (source profile,
+// interactive prompt), for the free-shell "+" tab. `home` is the $HOME
+// fallback used when the current team has no project dir configured.
+type LoginShellInfo = { cmd: string; args: string[]; home: string };
 // A pane being dragged, and where within the target pane it's hovering —
 // drives both the drop classification (paneTree's classifyDrop) and the
 // half-occupied preview highlight (see dropPreview below). null while
@@ -193,6 +205,7 @@ export default function App() {
   const [panes, setPanes] = useState<Pane[]>([]);
   const [paneStatus, setPaneStatus] = useState<PaneStatusMap>({});
   const [windows, setWindows] = useState<Window[]>([]);
+  const [loginShell, setLoginShell] = useState<LoginShellInfo | null>(null);
   const [active, setActive] = useState<string>("room");
   // Remembers which tab was active on each team, so switching back to a
   // team you were already on lands where you left it instead of always
@@ -469,6 +482,15 @@ export default function App() {
     invoke<string>("agmsg_command_name").then(setCmdName).catch(() => {});
   }, []);
 
+  // What to spawn for the free-shell "+" tab — the user's actual login
+  // shell (respecting $SHELL), not a hardcoded one. Resolved once in Rust
+  // (lib.rs's login_shell) since the webview has no reliable way to read
+  // $SHELL itself (unset for a Finder-launched process — see
+  // import_login_shell_path's doc comment).
+  useEffect(() => {
+    invoke<LoginShellInfo>("login_shell").then(setLoginShell).catch(() => {});
+  }, []);
+
   // showTeamRoom/showUserChat are already correctly seeded from localStorage
   // by their useState initializers above — this effect's only job is to
   // PUSH that initial value into Rust (set_team_room_visible/
@@ -675,18 +697,7 @@ export default function App() {
     const stateListener = listen<{ id: string; state: RawState }>("agent-state", (event) => {
       applyAgentState(event.payload.id, event.payload.state);
     });
-    const exitListener = listen<{ id: string }>("pty-exit", (event) => {
-      setPaneStatus((current) => {
-        if (!(event.payload.id in current)) return current;
-        const next = { ...current };
-        delete next[event.payload.id];
-        return next;
-      });
-    });
-    return () => {
-      void stateListener.then((unlisten) => unlisten());
-      void exitListener.then((unlisten) => unlisten());
-    };
+    return () => void stateListener.then((unlisten) => unlisten());
   }, [applyAgentState]);
 
   // Load-more-on-scroll-up: fetch the page older than the currently-oldest
@@ -837,6 +848,28 @@ export default function App() {
     [detachPane],
   );
 
+  useEffect(() => {
+    const p = listen<{ id: string }>("pty-exit", (e) => {
+      setPaneStatus((current) => {
+        if (!(e.payload.id in current)) return current;
+        const next = { ...current };
+        delete next[e.payload.id];
+        return next;
+      });
+      // A free-shell pane has no "still running, look at the error" state
+      // worth preserving the way an agent's crash banner does
+      // (TerminalPane's own pty-exit listener writes that inline) — its own
+      // exit/Ctrl-D is a deliberate "done here" (koit), so the pane (and its
+      // tab, if it was the last one) just goes away instead of sitting on a
+      // dead prompt. Agent panes are untouched — this only fires for panes
+      // flagged `shell`.
+      if (panesRef.current.find((pane) => pane.id === e.payload.id)?.shell) {
+        closeWindowPane(e.payload.id);
+      }
+    });
+    return () => void p.then((unlisten) => unlisten());
+  }, [closeWindowPane]);
+
   // Close a whole tab: kill every pane it holds.
   const closeWindow = useCallback((windowId: string) => {
     const w = windowsRef.current.find((x) => x.id === windowId);
@@ -877,6 +910,67 @@ export default function App() {
     },
     [detachPane, team],
   );
+
+  // A plain login shell pane, unattached to any agent (vim'ing a file,
+  // poking around — not agmsg's business). Falls back to "bash" with no
+  // args if login_shell hasn't resolved yet (invoke failed, or this fires
+  // before the mount effect's response lands). cwd defaults to the current
+  // team's project dir (teamProject) rather than wherever the shell would
+  // otherwise start — koit: re-cd'ing from $HOME every time is tedious —
+  // falling back to $HOME only when no project dir is configured. Shared by
+  // openShellTab (new tab) and openShellInWindow (split into an existing
+  // tab) below; both only ever act on the current team's tabs (windowMenu
+  // can only target a teamWindows entry), so teamProject is always the
+  // right project for either call site.
+  const buildShellPane = useCallback(
+    (): Pane => ({
+      id: `shell-${seq.current++}`,
+      label: t("tabs.shellLabel"),
+      cmd: loginShell?.cmd ?? "bash",
+      args: loginShell?.args ?? [],
+      cwd: teamProject || loginShell?.home || undefined,
+      native: false,
+      shell: true,
+    }),
+    [loginShell, t, teamProject],
+  );
+
+  // The "+" tab at the end of the tab bar. Same new-Pane-plus-new-Window
+  // shape as spawnMember's no-targetWindowId branch and moveToNewWindow above.
+  const openShellTab = useCallback(() => {
+    const pane = buildShellPane();
+    setPanes((prev) => [...prev, pane]);
+    const winId = `w-${seq.current++}`;
+    setWindows((prev) => [...prev, { id: winId, root: { kind: "leaf", paneId: pane.id }, team }]);
+    setActive(winId);
+  }, [buildShellPane, team]);
+
+  // A tab's "Open shell" context-menu item — splits a shell pane in beside
+  // whatever's already in that tab. The symmetric counterpart of spawning an
+  // agent beside an open shell pane (see windowHasShellPane/spawnMember
+  // below): either direction, shell and agent end up split in the same tab.
+  const openShellInWindow = useCallback(
+    (windowId: string) => {
+      const pane = buildShellPane();
+      setPanes((prev) => [...prev, pane]);
+      setWindows((prev) =>
+        prev.map((w) => (w.id === windowId ? { ...w, root: insertAsNewLeaf(w.root, pane.id) } : w)),
+      );
+      setActive(windowId);
+    },
+    [buildShellPane],
+  );
+
+  // True when `windowId`'s tab currently has a free-shell pane in it — the
+  // signal spawnMember's sidebar-click site uses to decide "spawn this agent
+  // beside the shell in the same tab" (koit's design B) instead of the
+  // default "open a new tab".
+  const windowHasShellPane = useCallback((windowId: string) => {
+    const w = windowsRef.current.find((w) => w.id === windowId);
+    if (!w) return false;
+    const ids = leaves(w.root);
+    return panesRef.current.some((p) => ids.includes(p.id) && p.shell);
+  }, []);
 
   // Swap two panes' positions within the same window (tree shape unchanged
   // — no DOM remount, same as every other pane move in this file).
@@ -1560,7 +1654,7 @@ export default function App() {
                       )}
                       <button
                         className="member"
-                        onClick={() => spawnMember(m)}
+                        onClick={() => spawnMember(m, windowHasShellPane(active) ? active : undefined)}
                         title={
                           pane
                             ? t("sidebar.member.titleRunning")
@@ -1685,6 +1779,9 @@ export default function App() {
                 </button>
               </span>
             ))}
+            <button className="tab-new-shell" title={t("tabs.newShell")} onClick={openShellTab}>
+              <Plus size={13} />
+            </button>
             {/* Tabs are all clickable buttons, so they eat the drag region
                 the <nav> itself claims — this dedicated strip is always
                 empty and always draggable, regardless of tab count. */}
@@ -2364,6 +2461,14 @@ export default function App() {
                 }}
               >
                 {t("ctxMenu.window.rename")}
+              </button>
+              <button
+                onClick={() => {
+                  openShellInWindow(windowMenu.windowId);
+                  setWindowMenu(null);
+                }}
+              >
+                {t("ctxMenu.window.openShell")}
               </button>
               <div className="submenu-trigger">
                 <span className="submenu-label">{t("ctxMenu.window.layout")}</span>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -83,7 +83,7 @@ export type Pane = {
 // paneTree.ts) — draggable dividers and directional split/swap drag-drop
 // (issue #317) both need real nested structure, which a flat list + layout
 // enum couldn't represent (see the design doc on that issue for why).
-type Window = {
+export type Window = {
   id: string;
   root: SplitNode;
   /** User-set tab name (Rename); falls back to the joined pane labels. */
@@ -117,6 +117,23 @@ export type LoginShellInfo = { cmd: string; args: string[]; home: string };
 export function shellPaneFrom(info: LoginShellInfo | null, id: string, label: string, cwd: string | undefined): Pane | null {
   if (!info) return null;
   return { id, label, cmd: info.cmd, args: info.args, cwd, native: false, shell: true };
+}
+
+// Whether openShellTab's new window should still be committed after its
+// getLoginShell await — false if the user switched teams while it was in
+// flight. Committing anyway would silently add a window under the stale
+// team (hidden — only the current team's windows render) while `active`
+// pointed at it (co1, PR #431).
+export function shellTabStillValid(currentTeam: string, requestedTeam: string): boolean {
+  return currentTeam === requestedTeam;
+}
+
+// Whether openShellInWindow's target tab is still open after its
+// getLoginShell await — false if the user closed it while in flight.
+// Committing anyway would leave an orphaned pane (no window references it)
+// and `active` pointing at a window id that no longer exists (co1, PR #431).
+export function shellWindowStillOpen(windows: ReadonlyArray<Pick<Window, "id">>, windowId: string): boolean {
+  return windows.some((w) => w.id === windowId);
 }
 // A pane being dragged, and where within the target pane it's hovering —
 // drives both the drop classification (paneTree's classifyDrop) and the
@@ -414,6 +431,12 @@ export default function App() {
   panesRef.current = panes;
   const windowsRef = useRef<Window[]>([]);
   windowsRef.current = windows;
+  // The stale-context guard openShellTab/openShellInWindow re-check after
+  // their getLoginShell await (see below) — a real gap now that login_shell
+  // resolution can take real time, during which the user can switch teams
+  // or close the target tab (co1, PR #431).
+  const teamRef = useRef<string>("");
+  teamRef.current = team;
   const applyAgentState = useCallback((paneId: string, state: RawState) => {
     setPaneStatus((current) => applyStateChange(current, paneId, state));
   }, []);
@@ -968,13 +991,20 @@ export default function App() {
   }, [getLoginShell, t, teamProject]);
 
   // The "+" tab at the end of the tab bar. Same new-Pane-plus-new-Window
-  // shape as spawnMember's no-targetWindowId branch and moveToNewWindow above.
+  // shape as spawnMember's no-targetWindowId branch and moveToNewWindow
+  // above. buildShellPane's getLoginShell await is a real gap now (not just
+  // a microtask) — the user can switch teams while it's in flight, which
+  // would otherwise add the new window under the STALE `team` closed over
+  // at click time (hidden, since only the current team's windows render)
+  // while `active` still points at it (co1, PR #431). Bail out rather than
+  // create an orphaned, invisible tab if the team moved on.
   const openShellTab = useCallback(async () => {
+    const requestedTeam = team;
     const pane = await buildShellPane();
-    if (!pane) return;
+    if (!pane || !shellTabStillValid(teamRef.current, requestedTeam)) return;
     setPanes((prev) => [...prev, pane]);
     const winId = `w-${seq.current++}`;
-    setWindows((prev) => [...prev, { id: winId, root: { kind: "leaf", paneId: pane.id }, team }]);
+    setWindows((prev) => [...prev, { id: winId, root: { kind: "leaf", paneId: pane.id }, team: requestedTeam }]);
     setActive(winId);
   }, [buildShellPane, team]);
 
@@ -982,10 +1012,14 @@ export default function App() {
   // whatever's already in that tab. The symmetric counterpart of spawning an
   // agent beside an open shell pane (see windowHasShellPane/spawnMember
   // below): either direction, shell and agent end up split in the same tab.
+  // Same stale-context concern as openShellTab: the target tab can be
+  // closed while getLoginShell's await is in flight, which would otherwise
+  // leave an orphaned pane (windows never referencing it) and `active`
+  // pointing at a window id that no longer exists (co1, PR #431).
   const openShellInWindow = useCallback(
     async (windowId: string) => {
       const pane = await buildShellPane();
-      if (!pane) return;
+      if (!pane || !shellWindowStillOpen(windowsRef.current, windowId)) return;
       setPanes((prev) => [...prev, pane]);
       setWindows((prev) =>
         prev.map((w) => (w.id === windowId ? { ...w, root: insertAsNewLeaf(w.root, pane.id) } : w)),

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -128,12 +128,24 @@ export function shellTabStillValid(currentTeam: string, requestedTeam: string): 
   return currentTeam === requestedTeam;
 }
 
-// Whether openShellInWindow's target tab is still open after its
-// getLoginShell await — false if the user closed it while in flight.
-// Committing anyway would leave an orphaned pane (no window references it)
-// and `active` pointing at a window id that no longer exists (co1, PR #431).
-export function shellWindowStillOpen(windows: ReadonlyArray<Pick<Window, "id">>, windowId: string): boolean {
-  return windows.some((w) => w.id === windowId);
+// Whether openShellInWindow's target tab is still a valid split target
+// after its getLoginShell await — false if the user closed it (no window
+// references it, and `active` would point at a nonexistent id), OR just
+// switched teams while it was in flight: the target window can still exist
+// but now belong to the team the user navigated away from, in which case
+// splitting into it and setting `active` there produces the same
+// hidden-active bug openShellTab's shellTabStillValid guards against — a
+// window's `team` never changes after creation, so if the current team no
+// longer matches `requestedTeam` the window can't be a live tab regardless
+// of whether it's still present in `windows` (co1, PR #431).
+export function shellSplitStillValid(
+  windows: ReadonlyArray<Pick<Window, "id" | "team">>,
+  windowId: string,
+  currentTeam: string,
+  requestedTeam: string,
+): boolean {
+  if (currentTeam !== requestedTeam) return false;
+  return windows.some((w) => w.id === windowId && w.team === requestedTeam);
 }
 // A pane being dragged, and where within the target pane it's hovering —
 // drives both the drop classification (paneTree's classifyDrop) and the
@@ -1012,21 +1024,24 @@ export default function App() {
   // whatever's already in that tab. The symmetric counterpart of spawning an
   // agent beside an open shell pane (see windowHasShellPane/spawnMember
   // below): either direction, shell and agent end up split in the same tab.
-  // Same stale-context concern as openShellTab: the target tab can be
-  // closed while getLoginShell's await is in flight, which would otherwise
-  // leave an orphaned pane (windows never referencing it) and `active`
-  // pointing at a window id that no longer exists (co1, PR #431).
+  // Same stale-context concern as openShellTab, in two shapes: the target
+  // tab can be closed while getLoginShell's await is in flight (orphaned
+  // pane, `active` pointing at a dead id), or the team can just switch
+  // while the window itself stays open — it's now a hidden tab under the
+  // team the user navigated away from, so splitting into it and activating
+  // it reproduces the same hidden-active bug (co1, PR #431).
   const openShellInWindow = useCallback(
     async (windowId: string) => {
+      const requestedTeam = team;
       const pane = await buildShellPane();
-      if (!pane || !shellWindowStillOpen(windowsRef.current, windowId)) return;
+      if (!pane || !shellSplitStillValid(windowsRef.current, windowId, teamRef.current, requestedTeam)) return;
       setPanes((prev) => [...prev, pane]);
       setWindows((prev) =>
         prev.map((w) => (w.id === windowId ? { ...w, root: insertAsNewLeaf(w.root, pane.id) } : w)),
       );
       setActive(windowId);
     },
-    [buildShellPane],
+    [buildShellPane, team],
   );
 
   // True when `windowId`'s tab currently has a free-shell pane in it — the

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -61,7 +61,7 @@ type Message = {
   body: string;
   created_at: string;
 };
-type Pane = {
+export type Pane = {
   id: string;
   label: string;
   cmd: string;
@@ -105,7 +105,19 @@ type PaneLayout = "vertical" | "horizontal" | "tile";
 // shell binary plus the flags to make it behave like one (source profile,
 // interactive prompt), for the free-shell "+" tab. `home` is the $HOME
 // fallback used when the current team has no project dir configured.
-type LoginShellInfo = { cmd: string; args: string[]; home: string };
+export type LoginShellInfo = { cmd: string; args: string[]; home: string };
+
+// Builds a free-shell Pane from Rust's resolved login shell — or null if
+// it hasn't resolved (yet, or ever). Deliberately has NO "bash" guess-
+// fallback: an earlier version defaulted to bash when `info` was still
+// unresolved, which raced the mount-effect fetch (app just launched, user
+// immediately hits "+") — broken on Windows (no bash), and not the user's
+// actual login shell even on unix (co1 review, PR #431). Pure so the
+// no-fallback contract is unit-testable without mounting the app.
+export function shellPaneFrom(info: LoginShellInfo | null, id: string, label: string, cwd: string | undefined): Pane | null {
+  if (!info) return null;
+  return { id, label, cmd: info.cmd, args: info.args, cwd, native: false, shell: true };
+}
 // A pane being dragged, and where within the target pane it's hovering —
 // drives both the drop classification (paneTree's classifyDrop) and the
 // half-occupied preview highlight (see dropPreview below). null while
@@ -486,10 +498,35 @@ export default function App() {
   // shell (respecting $SHELL), not a hardcoded one. Resolved once in Rust
   // (lib.rs's login_shell) since the webview has no reliable way to read
   // $SHELL itself (unset for a Finder-launched process — see
-  // import_login_shell_path's doc comment).
+  // import_login_shell_path's doc comment). Just a warm-cache prefetch —
+  // getLoginShell (below) is what open-shell call sites actually await, so
+  // a click landing before this resolves still gets the real shell instead
+  // of racing to a fallback.
   useEffect(() => {
-    invoke<LoginShellInfo>("login_shell").then(setLoginShell).catch(() => {});
+    invoke<LoginShellInfo>("login_shell")
+      .then(setLoginShell)
+      .catch((err) => {
+        console.error(err);
+      });
   }, []);
+
+  // Resolves login_shell, awaiting Rust if the mount-effect prefetch above
+  // hasn't landed yet (real race: app just launched, user immediately hits
+  // "+" or "Open shell"). Returns null on failure — callers must NOT
+  // fall back to a guessed shell (e.g. "bash"): broken on Windows, and not
+  // the user's actual login shell even on unix (co1 review, PR #431).
+  const getLoginShell = useCallback(async (): Promise<LoginShellInfo | null> => {
+    if (loginShell) return loginShell;
+    try {
+      const info = await invoke<LoginShellInfo>("login_shell");
+      setLoginShell(info);
+      return info;
+    } catch (err) {
+      console.error(err);
+      setStartupError(t("startupError.loginShellFailed", { error: String(err) }));
+      return null;
+    }
+  }, [loginShell, t]);
 
   // showTeamRoom/showUserChat are already correctly seeded from localStorage
   // by their useState initializers above — this effect's only job is to
@@ -912,33 +949,29 @@ export default function App() {
   );
 
   // A plain login shell pane, unattached to any agent (vim'ing a file,
-  // poking around — not agmsg's business). Falls back to "bash" with no
-  // args if login_shell hasn't resolved yet (invoke failed, or this fires
-  // before the mount effect's response lands). cwd defaults to the current
-  // team's project dir (teamProject) rather than wherever the shell would
+  // poking around — not agmsg's business). Awaits getLoginShell (see the
+  // mount-effect section above) rather than reading `loginShell` state
+  // directly — null means it's genuinely unresolved/unresolvable, at which
+  // point shellPaneFrom itself refuses to guess a fallback shell (co1, PR
+  // #431); getLoginShell has already surfaced startupError in that case, so
+  // callers just bail out with no pane. cwd defaults to the current team's
+  // project dir (teamProject) rather than wherever the shell would
   // otherwise start — koit: re-cd'ing from $HOME every time is tedious —
   // falling back to $HOME only when no project dir is configured. Shared by
   // openShellTab (new tab) and openShellInWindow (split into an existing
   // tab) below; both only ever act on the current team's tabs (windowMenu
   // can only target a teamWindows entry), so teamProject is always the
   // right project for either call site.
-  const buildShellPane = useCallback(
-    (): Pane => ({
-      id: `shell-${seq.current++}`,
-      label: t("tabs.shellLabel"),
-      cmd: loginShell?.cmd ?? "bash",
-      args: loginShell?.args ?? [],
-      cwd: teamProject || loginShell?.home || undefined,
-      native: false,
-      shell: true,
-    }),
-    [loginShell, t, teamProject],
-  );
+  const buildShellPane = useCallback(async (): Promise<Pane | null> => {
+    const info = await getLoginShell();
+    return shellPaneFrom(info, `shell-${seq.current++}`, t("tabs.shellLabel"), teamProject || info?.home || undefined);
+  }, [getLoginShell, t, teamProject]);
 
   // The "+" tab at the end of the tab bar. Same new-Pane-plus-new-Window
   // shape as spawnMember's no-targetWindowId branch and moveToNewWindow above.
-  const openShellTab = useCallback(() => {
-    const pane = buildShellPane();
+  const openShellTab = useCallback(async () => {
+    const pane = await buildShellPane();
+    if (!pane) return;
     setPanes((prev) => [...prev, pane]);
     const winId = `w-${seq.current++}`;
     setWindows((prev) => [...prev, { id: winId, root: { kind: "leaf", paneId: pane.id }, team }]);
@@ -950,8 +983,9 @@ export default function App() {
   // agent beside an open shell pane (see windowHasShellPane/spawnMember
   // below): either direction, shell and agent end up split in the same tab.
   const openShellInWindow = useCallback(
-    (windowId: string) => {
-      const pane = buildShellPane();
+    async (windowId: string) => {
+      const pane = await buildShellPane();
+      if (!pane) return;
       setPanes((prev) => [...prev, pane]);
       setWindows((prev) =>
         prev.map((w) => (w.id === windowId ? { ...w, root: insertAsNewLeaf(w.root, pane.id) } : w)),
@@ -1779,7 +1813,12 @@ export default function App() {
                 </button>
               </span>
             ))}
-            <button className="tab-new-shell" title={t("tabs.newShell")} onClick={openShellTab}>
+            <button
+              className="tab-new-shell"
+              title={t("tabs.newShell")}
+              aria-label={t("tabs.newShell")}
+              onClick={openShellTab}
+            >
               <Plus size={13} />
             </button>
             {/* Tabs are all clickable buttons, so they eat the drag region

--- a/app/src/i18n/locales/de.json
+++ b/app/src/i18n/locales/de.json
@@ -50,7 +50,9 @@
   },
   "tabs": {
     "roomLabel": "# Team-Room",
-    "close": "×"
+    "close": "×",
+    "newShell": "Neuer Shell-Tab",
+    "shellLabel": "Shell"
   },
   "room": {
     "loadingMore": "Weitere werden geladen…",
@@ -155,6 +157,7 @@
     },
     "window": {
       "rename": "Umbenennen…",
+      "openShell": "Shell öffnen",
       "layout": "Layout ▸",
       "layoutVertical": "Vertikal",
       "layoutHorizontal": "Horizontal",

--- a/app/src/i18n/locales/de.json
+++ b/app/src/i18n/locales/de.json
@@ -9,6 +9,7 @@
   "startupError": {
     "installing": "agmsg wird installiert…",
     "installFailed": "agmsg konnte nicht installiert werden: {{error}}",
+    "loginShellFailed": "Die Login-Shell konnte nicht ermittelt werden: {{error}}",
     "loadTeamsFailed": "agmsg-Teams konnten nicht geladen werden: {{error}}. Ist agmsg unter ~/.agents/skills/agmsg installiert?",
     "coreOutdated": "Deine agmsg-CLI ist veraltet ({{installed}} < {{pinned}}) und funktioniert möglicherweise nicht richtig mit dieser App.",
     "versionUnknown": "unbekannt",

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -60,7 +60,9 @@
   },
   "tabs": {
     "roomLabel": "# team room",
-    "close": "×"
+    "close": "×",
+    "newShell": "New shell tab",
+    "shellLabel": "Shell"
   },
   "room": {
     "loadingMore": "Loading more…",
@@ -165,6 +167,7 @@
     },
     "window": {
       "rename": "Rename…",
+      "openShell": "Open shell",
       "layout": "Layout ▸",
       "layoutVertical": "Vertical",
       "layoutHorizontal": "Horizontal",

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -19,6 +19,7 @@
   "startupError": {
     "installing": "Installing agmsg…",
     "installFailed": "Couldn't install agmsg: {{error}}",
+    "loginShellFailed": "Couldn't determine your login shell: {{error}}",
     "loadTeamsFailed": "Couldn't load agmsg teams: {{error}}. Is agmsg installed at ~/.agents/skills/agmsg?",
     "coreOutdated": "Your agmsg CLI is out of date ({{installed}} < {{pinned}}) and may not work correctly with this app.",
     "versionUnknown": "unknown",

--- a/app/src/i18n/locales/es.json
+++ b/app/src/i18n/locales/es.json
@@ -9,6 +9,7 @@
   "startupError": {
     "installing": "Instalando agmsg…",
     "installFailed": "No se pudo instalar agmsg: {{error}}",
+    "loginShellFailed": "No se pudo determinar tu shell de inicio de sesión: {{error}}",
     "loadTeamsFailed": "No se pudieron cargar los equipos de agmsg: {{error}}. ¿Está agmsg instalado en ~/.agents/skills/agmsg?",
     "coreOutdated": "Tu CLI de agmsg está desactualizada ({{installed}} < {{pinned}}) y puede no funcionar bien con esta app.",
     "versionUnknown": "desconocida",

--- a/app/src/i18n/locales/es.json
+++ b/app/src/i18n/locales/es.json
@@ -50,7 +50,9 @@
   },
   "tabs": {
     "roomLabel": "# sala del equipo",
-    "close": "×"
+    "close": "×",
+    "newShell": "Nueva pestaña de shell",
+    "shellLabel": "Shell"
   },
   "room": {
     "loadingMore": "Cargando más…",
@@ -155,6 +157,7 @@
     },
     "window": {
       "rename": "Renombrar…",
+      "openShell": "Abrir shell",
       "layout": "Diseño ▸",
       "layoutVertical": "Vertical",
       "layoutHorizontal": "Horizontal",

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -9,6 +9,7 @@
   "startupError": {
     "installing": "Installation d'agmsg…",
     "installFailed": "Impossible d'installer agmsg : {{error}}",
+    "loginShellFailed": "Impossible de déterminer votre shell de connexion : {{error}}",
     "loadTeamsFailed": "Impossible de charger les équipes agmsg : {{error}}. agmsg est-il installé dans ~/.agents/skills/agmsg ?",
     "coreOutdated": "Ton CLI agmsg est obsolète ({{installed}} < {{pinned}}) et pourrait ne pas fonctionner correctement avec cette app.",
     "versionUnknown": "inconnue",

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -50,7 +50,9 @@
   },
   "tabs": {
     "roomLabel": "# salle d'équipe",
-    "close": "×"
+    "close": "×",
+    "newShell": "Nouvel onglet shell",
+    "shellLabel": "Shell"
   },
   "room": {
     "loadingMore": "Chargement…",
@@ -155,6 +157,7 @@
     },
     "window": {
       "rename": "Renommer…",
+      "openShell": "Ouvrir un shell",
       "layout": "Disposition ▸",
       "layoutVertical": "Vertical",
       "layoutHorizontal": "Horizontal",

--- a/app/src/i18n/locales/ja.json
+++ b/app/src/i18n/locales/ja.json
@@ -50,7 +50,9 @@
   },
   "tabs": {
     "roomLabel": "# チームルーム",
-    "close": "×"
+    "close": "×",
+    "newShell": "新規シェルタブ",
+    "shellLabel": "シェル"
   },
   "room": {
     "loadingMore": "さらに読み込み中…",
@@ -155,6 +157,7 @@
     },
     "window": {
       "rename": "名前を変更…",
+      "openShell": "シェルを開く",
       "layout": "レイアウト ▸",
       "layoutVertical": "縦",
       "layoutHorizontal": "横",

--- a/app/src/i18n/locales/ja.json
+++ b/app/src/i18n/locales/ja.json
@@ -9,6 +9,7 @@
   "startupError": {
     "installing": "agmsgをインストール中…",
     "installFailed": "agmsgのインストールに失敗しました: {{error}}",
+    "loginShellFailed": "ログインシェルを取得できませんでした: {{error}}",
     "loadTeamsFailed": "agmsgのチームを読み込めませんでした: {{error}}。agmsgは ~/.agents/skills/agmsg にインストールされていますか?",
     "coreOutdated": "インストール済みのagmsg CLIが古い可能性があります({{installed}} < {{pinned}})。このアプリと正しく動作しない場合があります。",
     "versionUnknown": "不明",

--- a/app/src/i18n/locales/ko.json
+++ b/app/src/i18n/locales/ko.json
@@ -50,7 +50,9 @@
   },
   "tabs": {
     "roomLabel": "# 팀 채팅방",
-    "close": "×"
+    "close": "×",
+    "newShell": "새 셸 탭",
+    "shellLabel": "셸"
   },
   "room": {
     "loadingMore": "더 불러오는 중…",
@@ -155,6 +157,7 @@
     },
     "window": {
       "rename": "이름 변경…",
+      "openShell": "셸 열기",
       "layout": "레이아웃 ▸",
       "layoutVertical": "세로",
       "layoutHorizontal": "가로",

--- a/app/src/i18n/locales/ko.json
+++ b/app/src/i18n/locales/ko.json
@@ -9,6 +9,7 @@
   "startupError": {
     "installing": "agmsg 설치 중…",
     "installFailed": "agmsg 설치에 실패했습니다: {{error}}",
+    "loginShellFailed": "로그인 셸을 확인할 수 없습니다: {{error}}",
     "loadTeamsFailed": "agmsg 팀을 불러올 수 없습니다: {{error}}. ~/.agents/skills/agmsg 경로에 agmsg가 설치되어 있나요?",
     "coreOutdated": "설치된 agmsg CLI가 오래되었습니다({{installed}} < {{pinned}}). 이 앱과 제대로 작동하지 않을 수 있습니다.",
     "versionUnknown": "알 수 없음",

--- a/app/src/i18n/locales/pt-BR.json
+++ b/app/src/i18n/locales/pt-BR.json
@@ -50,7 +50,9 @@
   },
   "tabs": {
     "roomLabel": "# sala da equipe",
-    "close": "×"
+    "close": "×",
+    "newShell": "Nova aba de shell",
+    "shellLabel": "Shell"
   },
   "room": {
     "loadingMore": "Carregando mais…",
@@ -155,6 +157,7 @@
     },
     "window": {
       "rename": "Renomear…",
+      "openShell": "Abrir shell",
       "layout": "Layout ▸",
       "layoutVertical": "Vertical",
       "layoutHorizontal": "Horizontal",

--- a/app/src/i18n/locales/pt-BR.json
+++ b/app/src/i18n/locales/pt-BR.json
@@ -9,6 +9,7 @@
   "startupError": {
     "installing": "Instalando o agmsg…",
     "installFailed": "Não foi possível instalar o agmsg: {{error}}",
+    "loginShellFailed": "Não foi possível determinar seu shell de login: {{error}}",
     "loadTeamsFailed": "Não foi possível carregar as equipes do agmsg: {{error}}. O agmsg está instalado em ~/.agents/skills/agmsg?",
     "coreOutdated": "Seu CLI do agmsg está desatualizado ({{installed}} < {{pinned}}) e pode não funcionar corretamente com este app.",
     "versionUnknown": "desconhecida",

--- a/app/src/i18n/locales/zh-CN.json
+++ b/app/src/i18n/locales/zh-CN.json
@@ -50,7 +50,9 @@
   },
   "tabs": {
     "roomLabel": "# 团队聊天室",
-    "close": "×"
+    "close": "×",
+    "newShell": "新建 Shell 标签",
+    "shellLabel": "Shell"
   },
   "room": {
     "loadingMore": "正在加载更多…",
@@ -155,6 +157,7 @@
     },
     "window": {
       "rename": "重命名…",
+      "openShell": "打开 Shell",
       "layout": "布局 ▸",
       "layoutVertical": "纵向",
       "layoutHorizontal": "横向",

--- a/app/src/i18n/locales/zh-CN.json
+++ b/app/src/i18n/locales/zh-CN.json
@@ -9,6 +9,7 @@
   "startupError": {
     "installing": "正在安装 agmsg…",
     "installFailed": "无法安装 agmsg：{{error}}",
+    "loginShellFailed": "无法确定您的登录 Shell：{{error}}",
     "loadTeamsFailed": "无法加载 agmsg 团队：{{error}}。是否已在 ~/.agents/skills/agmsg 安装 agmsg？",
     "coreOutdated": "已安装的 agmsg CLI 版本过旧（{{installed}} < {{pinned}}），可能无法与此应用正常配合。",
     "versionUnknown": "未知",

--- a/app/src/i18n/locales/zh-TW.json
+++ b/app/src/i18n/locales/zh-TW.json
@@ -50,7 +50,9 @@
   },
   "tabs": {
     "roomLabel": "# 團隊聊天室",
-    "close": "×"
+    "close": "×",
+    "newShell": "新增 Shell 分頁",
+    "shellLabel": "Shell"
   },
   "room": {
     "loadingMore": "載入更多…",
@@ -155,6 +157,7 @@
     },
     "window": {
       "rename": "重新命名…",
+      "openShell": "開啟 Shell",
       "layout": "版面配置 ▸",
       "layoutVertical": "縱向",
       "layoutHorizontal": "橫向",

--- a/app/src/i18n/locales/zh-TW.json
+++ b/app/src/i18n/locales/zh-TW.json
@@ -9,6 +9,7 @@
   "startupError": {
     "installing": "正在安裝 agmsg…",
     "installFailed": "無法安裝 agmsg：{{error}}",
+    "loginShellFailed": "無法判斷您的登入 Shell：{{error}}",
     "loadTeamsFailed": "無法載入 agmsg 團隊：{{error}}。agmsg 是否已安裝於 ~/.agents/skills/agmsg？",
     "coreOutdated": "已安裝的 agmsg CLI 版本過舊（{{installed}} < {{pinned}}），可能無法與此應用程式正常搭配。",
     "versionUnknown": "未知",


### PR DESCRIPTION
## Summary
- "+" tab pinned at the tab bar's right end opens the user's login shell (respects `$SHELL`, dscl fallback on macOS, `-il` flags), via a new `login_shell` Tauri command
- Clicking a sidebar agent while a shell tab is active spawns the agent beside it in the same tab (reuses the existing `spawnMember(m, windowId)` split-spawn path) instead of opening a new tab
- Tab context menu gains "Open shell" — the symmetric counterpart, splits a shell pane into an existing agent tab
- Shell cwd defaults to the current team's project dir, falling back to `$HOME`/`%USERPROFILE%` only when that's unset
- A shell pane auto-closes (and its tab, if it was the last pane in it) when the shell process exits; agent panes are unaffected and keep their existing exit banner

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 139/139 passing
- [x] `cargo check --no-default-features` clean
- [x] Live-verified in `pnpm tauri dev`: "+" tab opens a login shell, sidebar agent click while a shell tab is active spawns beside it, tab context menu "Open shell" works, shell cwd follows team project dir, shell exit auto-closes its pane