### PR TITLE
fix(install): don't let co-located app-v* tags pollute the recorded core VERSION

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,9 +40,17 @@ agmsg_source_version() {
   # git repo would otherwise record that PARENT repo's describe instead of
   # agmsg's canonical VERSION. Requiring the toplevel to equal SCRIPT_DIR also
   # works for agmsg's own worktrees (install.sh sits at the worktree root).
+  #
+  # --match "v[0-9]*" restricts `describe` to core release tags (v1.1.8, ...);
+  # unrestricted --tags also matches the co-located app-v* tag lineage
+  # (app-v0.2.0, ...), and whichever lineage is closer in history wins. When
+  # an app-v* tag was the most recent, installs recorded provenance like
+  # "app-v0.2.0-26-g95d01ca" instead of "v1.1.8-27-g95d01ca" -- a string the
+  # app's own version comparison (agmsg_core_version_status in agmsg.rs)
+  # can't parse as semver, which it then treats as "outdated" unconditionally.
   top="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
   if [ -n "$top" ] && [ "$top" = "$SCRIPT_DIR" ] \
-      && v="$(git -C "$SCRIPT_DIR" describe --tags --always --dirty --abbrev=7 2>/dev/null)" \
+      && v="$(git -C "$SCRIPT_DIR" describe --tags --always --dirty --abbrev=7 --match 'v[0-9]*' 2>/dev/null)" \
       && [ -n "$v" ]; then
     printf '%s' "$v"
   elif [ -f "$SCRIPT_DIR/VERSION" ]; then

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -409,6 +409,41 @@ PS1
   [ "$output" = "$(cat "$SK/VERSION")" ]
 }
 
+@test "install: recorded VERSION uses the core tag lineage, not a co-located app-v* tag" {
+  # agmsg-core and the desktop app share one repo/tag namespace (v1.2.3 core
+  # releases alongside app-v0.2.0 app releases). Unrestricted `git describe
+  # --tags` matches whichever lineage is closer in history -- when an app-v*
+  # tag landed after the last core v* tag, installs recorded provenance like
+  # "app-v0.2.0-26-gHASH" instead of "v1.1.8-27-gHASH", which the desktop
+  # app's own version comparison can't parse as semver and treats as
+  # unconditionally outdated. See aggie/koit bug report.
+  # Resolve to the PHYSICAL path: on macOS $BATS_TEST_TMPDIR lands under
+  # /var/folders/... which is itself a symlink to /private/var/folders/....
+  # install.sh's SCRIPT_DIR uses plain `pwd` (logical, follows the symlink
+  # form actually cd'd into), while `git rev-parse --show-toplevel` always
+  # returns the physical path -- agmsg_source_version()'s toplevel-equality
+  # check would then never match on a logical-path synth dir, skipping
+  # `git describe` entirely regardless of tags. Unrelated pre-existing
+  # quirk, not something this fix touches -- work around it in the fixture.
+  local synth
+  mkdir -p "$BATS_TEST_TMPDIR/synth-agmsg"
+  synth="$(cd "$BATS_TEST_TMPDIR/synth-agmsg" && pwd -P)"
+  cp -R "$REPO_ROOT/." "$synth/"
+  rm -rf "$synth/.git"
+  git -C "$synth" init -q
+  git -C "$synth" -c user.email=t@e -c user.name=t add -A
+  git -C "$synth" -c user.email=t@e -c user.name=t commit -q -m "core release"
+  git -C "$synth" tag v1.0.0
+  git -C "$synth" -c user.email=t@e -c user.name=t commit -q --allow-empty -m "app release"
+  git -C "$synth" tag app-v9.9.9
+  git -C "$synth" -c user.email=t@e -c user.name=t commit -q --allow-empty -m "one more commit"
+
+  HOME="$FAKE_HOME" bash "$synth/install.sh" --cmd agmsg
+  run cat "$SK/VERSION"
+  [[ "$output" =~ ^v1\.0\.0- ]]
+  [[ "$output" != app-v9.9.9* ]]
+}
+
 @test "install: --update refreshes the recorded VERSION" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
   echo "stale-marker" > "$SK/VERSION"


### PR DESCRIPTION
## What

`install.sh`'s `agmsg_source_version()` records a `git describe` provenance string into the installed `VERSION` file (see #117). It used `git describe --tags` unrestricted, which matches both core release tags (`v1.1.8`) and the desktop app's own `app-v*` tags sharing the same repo/tag namespace — whichever lineage is closer in history wins.

When an `app-v*` tag (e.g. `app-v0.2.0`) landed after the last core `v*` tag, a fresh `HEAD` install recorded provenance like `app-v0.2.0-26-g95d01ca` instead of `v1.1.8-27-g95d01ca`. Confirmed on this machine:

```
$ git describe --tags --always --dirty --abbrev=7
app-v0.2.0-26-g95d01ca
$ git describe --tags --always --dirty --abbrev=7 --match 'v[0-9]*'
v1.1.8-27-g95d01ca
```

The app's own version comparison (`agmsg_core_version_status` in `app/src-tauri/src/agmsg.rs`) can't parse an `app-v*`-prefixed string as semver and treats an unparseable `installed` version as unconditionally outdated (`None => true`) — this misfires the app's "CLI might be outdated" banner on an install that's actually current.

## Fix

Restrict `git describe` to core release tags with `--match 'v[0-9]*'`.

Grepped the repo for other consumers of the recorded `VERSION` to check for downstream impact: `scripts/version.sh` only prints it verbatim (unaffected), and this is the only place a raw `git describe --tags` occurs anywhere in the repo — no other parsing logic needs updating.

## Tests

Added to `tests/test_install.bats`: a synthetic repo with a `v1.0.0` tag followed by a later `app-v9.9.9` tag confirms the recorded `VERSION` uses the core tag lineage, not the app one.

Full `test_install.bats` passes locally.
