### PR TITLE
test(whoami): isolate auto-detect tests from the runner's own process tree

### DIFF
--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -10,6 +10,36 @@ teardown() {
   teardown_test_env
 }
 
+# Auto-detect tests must not depend on the actual runtime this suite itself
+# happens to run under (#142): when bats runs from inside a real Codex/
+# Gemini/etc session, ambient env vars and the real process tree can make
+# detect_cli_type see a signal the test never set, masking the fallback (or
+# a different env var's) path under test.
+clear_autodetect_env() {
+  unset CLAUDE_CODE_SESSION_ID CODEX_SANDBOX CODEX_THREAD_ID \
+    GEMINI_CLI GEMINI_API_KEY GROK_SESSION_ID 2>/dev/null || true
+}
+
+# Prepend a fake `ps` to PATH so detect_cli_type's process-tree walk
+# (compat_get_comm -> `ps -o comm= -p <pid>`, compat_get_ppid -> `ps -o
+# ppid= -p <pid>`) can never match a real ancestor process name (e.g.
+# `codex` when this suite itself runs under a live Codex session) --
+# reports no process name and an immediate top-of-tree, so the walk always
+# falls through to the default.
+mock_no_agent_ps() {
+  local bindir="$TEST_SKILL_DIR/mock-ps-bin"
+  mkdir -p "$bindir"
+  cat > "$bindir/ps" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"-o ppid="*) echo 1 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$bindir/ps"
+  export PATH="$bindir:$PATH"
+}
+
 # --- join.sh ---
 
 @test "join: creates team and adds agent" {
@@ -189,6 +219,7 @@ teardown() {
 
 @test "whoami: auto-detects claude-code from CLAUDE_CODE_SESSION_ID env" {
   bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj
+  clear_autodetect_env
   CLAUDE_CODE_SESSION_ID=test-session run bash "$SCRIPTS/whoami.sh" /tmp/proj
   [ "$status" -eq 0 ]
   [[ "$output" =~ "agent=alice" ]]
@@ -197,10 +228,12 @@ teardown() {
 
 @test "whoami: auto-detects codex from CODEX_SANDBOX env" {
   bash "$SCRIPTS/join.sh" myteam bob codex /tmp/proj
-  # Unset CLAUDE_CODE_SESSION_ID: bats can run under a CC session that
-  # already exports it, which would shadow the codex signal under the
-  # CLAUDE_CODE_SESSION_ID-first detection order.
-  unset CLAUDE_CODE_SESSION_ID
+  # Clear ALL ambient auto-detect vars, not just CLAUDE_CODE_SESSION_ID --
+  # bats can run under a real Codex session that already exports
+  # CODEX_THREAD_ID too, which would still land on codex here (so this
+  # particular assertion happens to survive it) but masks whether
+  # CODEX_SANDBOX specifically is what's being exercised.
+  clear_autodetect_env
   CODEX_SANDBOX=seatbelt run bash "$SCRIPTS/whoami.sh" /tmp/proj
   [ "$status" -eq 0 ]
   [[ "$output" =~ "agent=bob" ]]
@@ -209,7 +242,7 @@ teardown() {
 
 @test "whoami: auto-detects codex from CODEX_THREAD_ID env" {
   bash "$SCRIPTS/join.sh" myteam bob codex /tmp/proj
-  unset CLAUDE_CODE_SESSION_ID
+  clear_autodetect_env
   CODEX_THREAD_ID=some-thread run bash "$SCRIPTS/whoami.sh" /tmp/proj
   [ "$status" -eq 0 ]
   [[ "$output" =~ "agent=bob" ]]
@@ -218,6 +251,8 @@ teardown() {
 
 @test "whoami: defaults to claude-code when no env vars set" {
   bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj
+  clear_autodetect_env
+  mock_no_agent_ps
   run bash "$SCRIPTS/whoami.sh" /tmp/proj
   [ "$status" -eq 0 ]
   [[ "$output" =~ "agent=alice" ]]
@@ -227,6 +262,7 @@ teardown() {
 @test "whoami: explicit type overrides auto-detection" {
   bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj
   bash "$SCRIPTS/join.sh" myteam bob codex /tmp/proj
+  clear_autodetect_env
   CODEX_SANDBOX=test run bash "$SCRIPTS/whoami.sh" /tmp/proj claude-code
   [ "$status" -eq 0 ]
   [[ "$output" =~ "agent=alice" ]]

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -15,29 +15,65 @@ teardown() {
 # Gemini/etc session, ambient env vars and the real process tree can make
 # detect_cli_type see a signal the test never set, masking the fallback (or
 # a different env var's) path under test.
+#
+# Derived from the type registry (agmsg_type_get ... detect), not a
+# hardcoded list -- detect_cli_type itself is registry-driven with "no
+# hardcoded type list" by design (see its own comment in whoami.sh), so a
+# hardcoded var list here would silently stop covering a future type's new
+# detect= var. Found in review of the first cut of this fix.
 clear_autodetect_env() {
-  unset CLAUDE_CODE_SESSION_ID CODEX_SANDBOX CODEX_THREAD_ID \
-    GEMINI_CLI GEMINI_API_KEY GROK_SESSION_ID 2>/dev/null || true
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/type-registry.sh"
+  local t detect v
+  while IFS= read -r t; do
+    [ -n "$t" ] || continue
+    detect="$(agmsg_type_get "$t" detect)"
+    [ -n "$detect" ] && [ "$detect" != "explicit" ] || continue
+    for v in $detect; do
+      unset "$v" 2>/dev/null || true
+    done
+  done <<EOF
+$(agmsg_known_types | sort -u)
+EOF
 }
 
-# Prepend a fake `ps` to PATH so detect_cli_type's process-tree walk
-# (compat_get_comm -> `ps -o comm= -p <pid>`, compat_get_ppid -> `ps -o
-# ppid= -p <pid>`) can never match a real ancestor process name (e.g.
-# `codex` when this suite itself runs under a live Codex session) --
-# reports no process name and an immediate top-of-tree, so the walk always
-# falls through to the default.
+# Prepend a fake `ps` to PATH so detect_cli_type's process-tree walk can
+# never match a real ancestor process name (e.g. `codex` when this suite
+# itself runs under a live Codex session) -- reports no process name and an
+# immediate top-of-tree, so the walk always falls through to the default.
+#
+# Covers all THREE of compat.sh's process-lookup shapes, not just the
+# POSIX one (P1 from review of the first cut): compat_get_comm/
+# compat_get_ppid's POSIX branch (`ps -o comm=`/`ps -o ppid=`), AND their
+# MSYS branch, which on a real MSYS host tries /proc/<pid>/cmdline and a
+# WinPID/CIM lookup BEFORE ever falling back to `ps -l -p` -- so this also
+# forces those two branches to skip straight to the ps fallback that this
+# mock actually answers.
 mock_no_agent_ps() {
   local bindir="$TEST_SKILL_DIR/mock-ps-bin"
   mkdir -p "$bindir"
   cat > "$bindir/ps" <<'EOF'
 #!/usr/bin/env bash
 case "$*" in
+  *"-l"*)
+    # MSYS `ps -l -p <pid>` shape (compat_get_comm's final fallback,
+    # compat_get_ppid, and _compat_get_winpid all parse this format by
+    # HEADER COLUMN NAME, not position). Deliberately name no column
+    # WINPID or PPID, so every one of those awk extractors finds nothing
+    # and reports empty -- same "nothing found" outcome as the POSIX
+    # branch below, not a specific pid value that could be misread as a
+    # real ancestor.
+    printf 'S UID PID TIME CMD\n'
+    printf '0 0 1 0:00 mock-no-agent\n'
+    ;;
   *"-o ppid="*) echo 1 ;;
   *) exit 0 ;;
 esac
 EOF
   chmod +x "$bindir/ps"
   export PATH="$bindir:$PATH"
+  export _AGMSG_COMPAT_NO_PROC=1
+  export _AGMSG_COMPAT_NO_CIM=1
 }
 
 # --- join.sh ---


### PR DESCRIPTION
## What

Fixes #142: `whoami: defaults to claude-code when no env vars set` (and the other auto-detect tests) were not hermetic — they only omitted explicit env var setup, but never isolated the two other inputs `detect_cli_type` actually reads:

- **Ambient env vars.** Running the suite from inside a real Codex session, `CODEX_THREAD_ID` is already exported.
- **The process tree.** `detect_cli_type` walks parent processes looking for a known agent binary name; under a real Codex session there's a genuine `codex` ancestor.

So the "defaults to claude-code" test's result depended on which runtime happened to run the suite, not on the fallback path it was meant to exercise. This is not a `whoami.sh` bug — detecting Codex under a real Codex process is correct behavior — it's a test hermeticity gap, as the issue's own classification says.

Reproduced locally: clearing only `CLAUDE_CODE_SESSION_ID` (as the codex-specific tests already did) while injecting an ambient `CODEX_THREAD_ID` makes the pre-fix "defaults to claude-code" test fail exactly as reported.

## Fix (test-only, no production behavior change)

Two helpers in `tests/test_team.bats`:

- `clear_autodetect_env` — unsets every env var any type's `detect=` manifest key checks (`CLAUDE_CODE_SESSION_ID`, `CODEX_SANDBOX`, `CODEX_THREAD_ID`, `GEMINI_CLI`, `GEMINI_API_KEY`, `GROK_SESSION_ID`), so a test only sees the signal it explicitly sets.
- `mock_no_agent_ps` — prepends a fake `ps` to PATH that reports no process name and an immediate top-of-tree, so `detect_cli_type`'s process-tree walk (`compat_get_comm`/`compat_get_ppid`, both backed by `ps -o comm=`/`ps -o ppid=` on POSIX) can never match a real ancestor process.

Applied `clear_autodetect_env` to all five auto-detect tests (the codex-specific ones previously unset only `CLAUDE_CODE_SESSION_ID`, not the full set) and `mock_no_agent_ps` to the fallback-default test specifically, since that's the one that also needs the process-tree path neutralized.

## Tests

This PR *is* the test fix. Verified the repro/fix pair directly:

```
$ env -u CLAUDE_CODE_SESSION_ID CODEX_THREAD_ID=simulated-ambient-codex bats --filter "whoami: defaults to claude-code" tests/test_team.bats   # pre-fix
not ok 1 whoami: defaults to claude-code when no env vars set

$ env -u CLAUDE_CODE_SESSION_ID CODEX_THREAD_ID=simulated-ambient-codex bats --filter "whoami: defaults to claude-code" tests/test_team.bats   # post-fix
ok 1 whoami: defaults to claude-code when no env vars set
```

Full `tests/test_team.bats` passes locally.

Closes #142.
