### PR TITLE
docs(codex): safe Git Bash quoting from Windows PowerShell

### DIFF
--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -13,6 +13,12 @@ If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call 
 
 Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" codex`
 
+**Windows PowerShell:** The Shell requirement above still applies, but a bare `bash` in PowerShell often resolves to the WSL shim. Invoke **Git Bash** explicitly and keep the entire `-lc` payload inside one PowerShell single-quoted string:
+
+`& 'C:\Program Files\Git\bin\bash.exe' -lc '~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" codex'`
+
+Do not use POSIX `'"'"'` quote splicing in PowerShell; it can leave the `-lc` payload unterminated. Windows PowerShell 5.1 strips the embedded double quotes when passing the payload, so `"$(pwd)"` arrives unquoted — fine unless the current directory contains spaces; prefer PowerShell 7.3+ if it does. If Git Bash is installed elsewhere, replace the executable path above with its actual path.
+
 Four possible outputs:
 
 **A) Single identity:**

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -36,6 +36,13 @@ teardown() {
   [[ "$output" =~ "hello from install" ]]
 }
 
+@test "install: Codex skill documents safe Git Bash quoting for Windows PowerShell" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg --agent-type codex
+
+  grep -Fq "& 'C:\\Program Files\\Git\\bin\\bash.exe' -lc '~/.agents/skills/agmsg/scripts/whoami.sh \"\$(pwd)\" codex'" "$SK/SKILL.md"
+  grep -Fq "Do not use POSIX \`'\"'\"'\` quote splicing in PowerShell" "$SK/SKILL.md"
+}
+
 @test "install: --update restores scripts/lib even if it went missing" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
   bash "$SK/scripts/join.sh" demo alice claude-code /tmp/install-update-projA


### PR DESCRIPTION
## Summary

On native Windows, Codex often starts agent-typed shell commands from **PowerShell**. agmsg scripts must run under **Git Bash**, but:

1. A bare `bash` in PowerShell frequently resolves to the **WSL** shim (`WindowsApps\bash.exe`), which uses a different `$HOME`/DB than Claude Code + Git Bash.
2. POSIX `'"'"'` quote splicing inside a PowerShell `-lc` string can leave the payload **unterminated**.
3. Windows PowerShell **5.1** strips embedded double quotes when forwarding the payload (paths with spaces then break).

This PR adds a short **Windows PowerShell** note to the Codex skill template (right after the first `whoami` example) showing a safe full-path Git Bash invocation, and adds an install smoke test so the guidance survives `install.sh --agent-type codex` substitution.

## Why the template (not only root SKILL.md)

`install.sh` generates the deployed skill from `scripts/drivers/types/<type>/template.md`. The root `SKILL.md` is not what users get after install/update (see #345 / Shell requirement rollout). The regression test asserts the **installed** `~/.agents/skills/agmsg/SKILL.md` contents.

## Scope

- **In:** `scripts/drivers/types/codex/template.md`, `tests/test_install.bats`
- **Out:** other agent type templates, delivery `commandWindows` / `windows_wrap()`, README (already documents Git Bash alias + WSL trap)

## Test plan

- [x] `bats tests/test_install.bats --filter 'Codex skill documents safe Git Bash'` (1 passed)
- [x] Full `tests/test_install.bats` run locally — new test green; unrelated local failures (node_modules symlink copy / path form) noted as environment noise
- [ ] CI ubuntu/macos full suite
- [ ] CI windows-latest `bats-windows` filtered leg (test name includes `Windows`)
- [ ] Manual (optional): after `install.sh --agent-type codex`, confirm installed `SKILL.md` uses skill name `agmsg` (not `__SKILL_NAME__`)

## Notes for reviewers

- Intentionally **Codex-only**: README already calls out Codex + PowerShell as the sharp edge; happy to mirror the block to other templates if desired.
- Overlaps the existing Shell requirement paragraph on purpose: principle (`bash -lc`) vs PS-safe **Git Bash path + quoting**.
- `@test` name includes `Windows` so the CI `bats-windows` filter (`[Ww]indows`) picks it up.