### PR TITLE
fix(watch): mark read_at on live delivery so a later inbox.sh does not replay it

### DIFF
--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -319,12 +319,32 @@ persist_watermark() { printf '%s\n' "$LAST" > "$WATERMARK_FILE" 2>/dev/null || t
 # path so the two do not drift (#review finding, 2026-07-19). $1 is trusted
 # to be a DB-sourced id everywhere this is called, but it is guarded anyway
 # (matches inbox.sh's own defensive stance) since it is interpolated into SQL.
+#
+# $2/$3 (team, to) scope this to the DEFINITIVE receiver for that role:
+#   - an exclusive watcher (ACTIVE_NAME set) only marks its own role's rows.
+#   - a broad watcher (ACTIVE_NAME empty) subscribes to every registered role
+#     in the project (see PAIRS above), so without this guard it would also
+#     mark read_at for a role that has its OWN exclusive watcher — e.g. a
+#     leader's default SessionStart watcher racing/clobbering the read state
+#     an actas'd member's exclusive watcher is responsible for. Skip when an
+#     exclusive ready sentinel for (team, to) exists; that role's own watcher
+#     owns the read state (review finding, 2026-07-19).
+#
+# Note: this is a best-effort mark on local write success, not a delivery ack
+# — there is no protocol to confirm the downstream Monitor reader actually
+# consumed the line (a pipe write can succeed into a kernel buffer even if the
+# reader is about to exit). A stronger guarantee needs the claim/ack redesign
+# tracked in #373; out of scope for this fix (review finding, 2026-07-19).
 mark_read() {
-  local mid="$1"
+  local mid="$1" team="$2" to="$3"
   case "$mid" in
     ''|*[!0-9]*) return 0 ;;
   esac
-  agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id=$mid AND read_at IS NULL;" 2>/dev/null || true
+  if [ -z "$ACTIVE_NAME" ] && [ -n "$team" ] && [ -n "$to" ]; then
+    [ -e "$(agmsg_ready_path "$team" "$to")" ] && return 0
+  fi
+  agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id=$mid AND read_at IS NULL;" 2>/dev/null \
+    || echo "agmsg watch: could not mark message $mid read (db busy/unavailable); a later inbox.sh call will re-surface it" >&2
 }
 
 LAST=""
@@ -405,7 +425,7 @@ while true; do
         # which also ends the agent CLI sharing it. Deterministic teardown, no
         # dependence on the agent LLM noticing the message. See #109.
         if [ "$body" = "ctrl:despawn" ]; then
-          mark_read "$id"
+          mark_read "$id" "$team" "$to"
           LAST="$id"; persist_watermark
           # Only an EXCLUSIVE watcher dedicated to exactly this role tears
           # itself down. A broad-subscription watcher (e.g. a leader whose
@@ -434,7 +454,7 @@ while true; do
         # unread. Without this, every message ever streamed live stays
         # read_at IS NULL forever, and a single inbox.sh call replays the
         # entire history as "new".
-        mark_read "$id"
+        mark_read "$id" "$team" "$to"
         LAST="$id"
         persist_watermark
       done <<< "$ROWS"

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -312,6 +312,21 @@ done <<< "$PAIRS"
 WATERMARK_FILE="$RUN_DIR/watch.$SESSION_ID.watermark"
 persist_watermark() { printf '%s\n' "$LAST" > "$WATERMARK_FILE" 2>/dev/null || true; }
 
+# Mark a row's read_at so a later inbox.sh call does not re-surface it as
+# unread — the watermark only stops THIS watcher from re-streaming a row, it
+# never touches read_at (see the call sites below for the full rationale).
+# Shared by both the normal delivery path and the ctrl:despawn control-row
+# path so the two do not drift (#review finding, 2026-07-19). $1 is trusted
+# to be a DB-sourced id everywhere this is called, but it is guarded anyway
+# (matches inbox.sh's own defensive stance) since it is interpolated into SQL.
+mark_read() {
+  local mid="$1"
+  case "$mid" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id=$mid AND read_at IS NULL;" 2>/dev/null || true
+}
+
 LAST=""
 if [ -f "$WATERMARK_FILE" ]; then
   LAST="$(cat "$WATERMARK_FILE" 2>/dev/null || true)"
@@ -390,6 +405,7 @@ while true; do
         # which also ends the agent CLI sharing it. Deterministic teardown, no
         # dependence on the agent LLM noticing the message. See #109.
         if [ "$body" = "ctrl:despawn" ]; then
+          mark_read "$id"
           LAST="$id"; persist_watermark
           # Only an EXCLUSIVE watcher dedicated to exactly this role tears
           # itself down. A broad-subscription watcher (e.g. a leader whose
@@ -413,6 +429,12 @@ while true; do
           cleanup
           exit 0
         fi
+        # Mark delivered so a later inbox.sh call (e.g. a respawned/resumed
+        # session's actas re-registration) does not re-surface this message as
+        # unread. Without this, every message ever streamed live stays
+        # read_at IS NULL forever, and a single inbox.sh call replays the
+        # entire history as "new".
+        mark_read "$id"
         LAST="$id"
         persist_watermark
       done <<< "$ROWS"

--- a/tests/test_despawn.bats
+++ b/tests/test_despawn.bats
@@ -47,6 +47,36 @@ teardown() {
   kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true
 }
 
+# read_at for the most recent message with the given body, empty if unread.
+_read_at_for_body() {
+  ( # shellcheck disable=SC1090
+    source "$SCRIPTS/lib/storage.sh"
+    agmsg_sqlite "$(agmsg_db_path)" \
+      "SELECT read_at FROM messages WHERE body='$1' ORDER BY id DESC LIMIT 1;" )
+}
+
+@test "despawn: graceful — ctrl:despawn control row is marked read (does not linger as unread)" {
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/join.sh" team leader claude-code "$PROJ" >/dev/null
+  setup_live_owner "$RUN" sess-m
+
+  AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE bash "$SCRIPTS/watch.sh" sess-m "$PROJ" claude-code alice \
+    >/dev/null 2>&1 &
+  local wpid=$! i
+  for i in 1 2 3 4 5 6 7 8 9 10; do [ -e "$RUN/ready.team__alice" ] && break; sleep 0.5; done
+  [ -e "$RUN/ready.team__alice" ]
+
+  run bash "$SCRIPTS/despawn.sh" team leader alice --timeout 10
+  [ "$status" -eq 0 ]
+
+  # The ctrl:despawn row itself must not be left permanently unread — a
+  # broad (non-actas) watcher that later scans this project's inbox must not
+  # see it resurface as a "new" message (2026-07-19 review finding).
+  [ -n "$(_read_at_for_body "ctrl:despawn")" ]
+
+  kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true
+}
+
 @test "despawn --force: kills recorded placement and drops registration without the member" {
   bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
   # Placement as spawn would have recorded it (pane %99 doesn't exist; kill is

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -532,3 +532,85 @@ _wait_pidfile() {
   ! grep -q "Usage: watch.sh" "$out"
   ! grep -q "ERROR: unknown agent type" "$out"
 }
+
+# read_at for the most recent message with the given body, empty if unread.
+_read_at_for_body() {
+  ( # shellcheck disable=SC1090
+    source "$SCRIPTS/lib/storage.sh"
+    agmsg_sqlite "$(agmsg_db_path)" \
+      "SELECT read_at FROM messages WHERE body='$1' ORDER BY id DESC LIMIT 1;" )
+}
+
+
+@test "watch: marks a delivered message's read_at so a later inbox.sh does not re-surface it" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-readat"
+  local out="$TEST_SKILL_DIR/readat.log"
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
+    >"$out" 2>/dev/null 3>&- &
+  local w=$!
+  # Wait for the watcher to actually attach (watermark file appears) before
+  # sending, instead of a fixed sleep — avoids flakiness on a slow/loaded CI
+  # runner (2026-07-19 review finding).
+  _wait_for_file "$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark" \
+    || { kill "$w" 2>/dev/null || true; false; }
+  bash "$SCRIPTS/send.sh" team bob alice "M-readat-check" >/dev/null
+
+  # Delivered live...
+  _wait_for_file_contains "$out" "M-readat-check" \
+    || { kill "$w" 2>/dev/null || true; false; }
+  # ...and read_at follows shortly after delivery — poll instead of a fixed
+  # sleep for the same flakiness reason.
+  local i got=""
+  for i in $(seq 1 50); do
+    got="$(_read_at_for_body "M-readat-check")"
+    [ -n "$got" ] && break
+    sleep 0.1
+  done
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  [ -n "$got" ]
+  # A subsequent inbox.sh call must not report it as a new/unread message.
+  ! bash "$SCRIPTS/inbox.sh" team alice | grep -q "M-readat-check"
+}
+
+@test "watch: a broad watcher does not mark read_at for a role with its own exclusive ready sentinel" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  # Simulate alice already having a live exclusive watcher elsewhere: the
+  # sentinel's mere presence is the protocol (#108) — no live process needed
+  # for this guard, which only checks the file (review finding, 2026-07-19).
+  mkdir -p "$TEST_SKILL_DIR/run"
+  touch "$TEST_SKILL_DIR/run/ready.team__alice"
+
+  local sid="sess-broad-guard"
+  local out="$TEST_SKILL_DIR/broad-guard.log"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
+    >"$out" 2>/dev/null 3>&- &
+  local w=$!
+  _wait_for_file "$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark" \
+    || { kill "$w" 2>/dev/null || true; false; }
+
+  bash "$SCRIPTS/send.sh" team bob alice "M-broad-guard-alice" >/dev/null
+  bash "$SCRIPTS/send.sh" team bob bob "M-broad-guard-bob" >/dev/null
+
+  # Both stream through this broad watcher (PAIRS covers every project role)...
+  _wait_for_file_contains "$out" "M-broad-guard-bob" \
+    || { kill "$w" 2>/dev/null || true; false; }
+
+  # ...but only bob's (no exclusive owner) gets marked read by this watcher.
+  local i got_bob=""
+  for i in $(seq 1 50); do
+    got_bob="$(_read_at_for_body "M-broad-guard-bob")"
+    [ -n "$got_bob" ] && break
+    sleep 0.1
+  done
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  [ -n "$got_bob" ]
+  # Alice's exclusive ready sentinel means this broad watcher must defer —
+  # it must NOT have consumed the read state that alice's own watcher owns.
+  [ -z "$(_read_at_for_body "M-broad-guard-alice")" ]
+}


### PR DESCRIPTION
## Summary

`inbox.sh` and `check-inbox.sh` both mark delivered rows' `read_at` before
displaying them, but `watch.sh` — the live Monitor-mode delivery path — never
touched `read_at` at all. A message delivered live through a watcher stayed
`read_at IS NULL` forever, so a later `inbox.sh`/`check-inbox.sh` call (or the
`history.sh` unread marker `●`) would surface it again as if it were still
unread, even though the recipient already saw it via the watcher.

This adds a small `mark_read()` helper in `watch.sh` and calls it from both the
normal delivery branch (replacing the ambient assumption that display alone
was enough) and the `ctrl:despawn` control-row branch, so control messages
handled by the watcher also stop lingering as unread.

## Why this is a distinct fix from #338 / #373

- Issue #338 is about messages queued **before** a no-Monitor type's watcher
  ever attaches (never drained at all).
- Issue #373 is about atomic claim/ack semantics for consumption in general
  (a broader redesign).
- This fix is orthogonal to both: it's specifically about messages that
  **are** delivered live via an already-attached watcher, which is the most
  common path, simply never persisting that fact to storage. Confirmed via
  direct DB inspection and reading `watch.sh` (no `read_at` reference existed
  anywhere in the file before this change).

## Test plan

- New tests: `tests/test_watch.bats` ("watch: marks a delivered message's
  read_at so a later inbox.sh does not re-surface it") and
  `tests/test_despawn.bats` ("despawn: graceful — ctrl:despawn control row is
  marked read (does not linger as unread)").
- `bats tests/*.bats` — 728/729 passing; the sole failure
  (`install: watch.sh self-cleans a prior watcher on re-invocation for the
  same sid`) is a pre-existing order-dependent flake unrelated to this diff,
  confirmed by running `tests/test_install.bats` alone (46/46 pass).
- Cross-reviewed by two independent peers before submission (both found real
  issues, since fixed): a not-yet-integer-validated `$id` interpolated into
  SQL, the despawn control-row gap, and flaky fixed-`sleep` test timing
  (replaced with bounded polling helpers).

- [ ] CI green

## Update (2026-07-19): additional review pass, two more fixes

A follow-up `/review:self-multi-model` pass (Codex + Fugu, run independently
of the peer review above) found two more real issues before this had any
maintainer eyes on it, now fixed in the latest commit:

- **Scoping gap (Fugu, confirmed by direct code reading):** a broad
  (non-actas) watcher subscribes to every registered role in the project.
  Without scoping, it would also mark `read_at` for a role that has its OWN
  exclusive watcher — e.g. a leader's default SessionStart watcher racing the
  read state an actas'd member's exclusive watcher is responsible for.
  `mark_read` now skips when an exclusive ready sentinel exists for
  `(team, to)` and this watcher isn't it. New test:
  `tests/test_watch.bats` ("a broad watcher does not mark read_at for a role
  with its own exclusive ready sentinel").
- **Pipe-delivery limitation (Codex, P2):** a pipe write to the Monitor stream
  can succeed (accepted into a kernel buffer) even if the downstream reader
  is about to exit — there's no ack protocol here. Marking `read_at`
  immediately after a "successful" `printf` therefore isn't a delivery
  guarantee. This is now documented as a known best-effort limitation in the
  code rather than silently assumed away; a real fix needs the claim/ack
  redesign already tracked in #373 — out of scope for this small bugfix.

Also: a genuine SQLite update failure is now logged to stderr instead of
silently swallowed.

Full suite re-verified: 730/730 (this worktree's copy of the pre-existing
`install: watch.sh self-cleans...` flake did not reproduce on this run).
