### PR TITLE
fix(install): bound the self-clean race in the watcher re-invocation test

### DIFF
--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -336,7 +336,12 @@ PS1
   bash "$SK/scripts/watch.sh" "$sid" /tmp/install-projA claude-code &
   local second=$!
   wait_for_pidfile_pid "$SK/run/watch.$sid.pid" "$second"
-  # And the previous one was actually killed.
+  # The pidfile can flip to $second a beat before $first's TERM trap has
+  # actually run — poll for its exit rather than checking the instant the
+  # pidfile changes (a single check raced this and flaked, see #124; same
+  # fix already applied to the equivalent check in test_watch.bats).
+  local i
+  for i in $(seq 1 30); do kill -0 "$first" 2>/dev/null || break; sleep 0.1; done
   run kill -0 "$first"
   [ "$status" -ne 0 ]
 


### PR DESCRIPTION
## Summary

Fixes #124. The test re-invokes `watch.sh` for the same `session_id` and
checks that the predecessor actually self-cleaned. After the pidfile is
confirmed to hold the successor's pid (`wait_for_pidfile_pid`, already
bounded-polling), the very next check was a single, unretried `kill -0
"$first"`. Writing the new pidfile and the predecessor actually dying from
its `TERM` are not atomic — under a loaded runner the pidfile can flip a
beat before the predecessor's trap has run, so the single `kill -0` can still
observe it alive.

`tests/test_watch.bats:401-405` already has the identical race on the same
underlying self-clean behavior, with an inline comment explaining exactly
this ("the pidfile can flip to w2 a beat before w1's TERM trap has run —
poll for w1's exit rather than checking the instant the pidfile changes"),
fixed by a bounded poll before the final assertion. This PR applies the same
established pattern to the equivalent check in `tests/test_install.bats` —
the two tests exercise the same `watch.sh` self-clean code path and had
simply diverged (one got the fix, the other didn't).

## Test plan

- `bats tests/test_install.bats` — 46/46 passing.
- Targeted stress: ran just this test 5x concurrently (to add scheduler
  pressure, since the race is load-dependent) — 5/5 passing.
- No `scripts/` changes — this is a test-only fix, matching the issue's own
  assessment ("a race, not a real regression").
- Reviewed by an independent peer before submission (approved, no P1/P2
  findings; P3 note that the existing 30×0.1s poll ceiling matches
  `test_watch.bats` and a genuine regression would still fail the final
  assertion rather than being silently hidden).

- [ ] CI green