### PR TITLE
fix(codex-bridge): make the turn watchdog an idle timeout, not a fixed ceiling

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -48,6 +48,11 @@ Options:
                           CODEX_THREAD_ID; "loaded" discovers the live TUI thread
                           via thread/loaded/list (codex 0.141+, see #170).
   --loaded-timeout <ms>   Max wait for a loaded thread to appear (default: 30000).
+  --turn-timeout <sec>    Idle watchdog: assume a turn ended after this many
+                          seconds with no new agent-message output (default:
+                          60; 0 disables). Re-armed on every output chunk, so
+                          an actively-working turn is never cut off regardless
+                          of total duration — only true silence trips it.
   --inline-inbox          Read inbox in the bridge and include message text in the turn input.
   --resolve-only          Print resolved team/name and exit.
   --help                  Show this help.
@@ -1143,13 +1148,21 @@ class CodexBridge {
     }
   }
 
+  // Idle watchdog, not a fixed ceiling on the turn's total duration: every
+  // agent-message delta (onAgentMessageDelta) re-arms it, so a turn that is
+  // actively producing output never trips it no matter how long it runs —
+  // only turnTimeout seconds of silence does. This matters because the app
+  // -server does not reliably send turn/completed (#41), so something has to
+  // detect a turn that will never report completion; a turn that is visibly
+  // still working is not that case, and cutting it off before it reaches its
+  // own send.sh call silently drops whatever it was about to report.
   startTurnWatchdog() {
     this.clearTurnWatchdog();
     if (!this.opts.turnTimeout) return;
     this.turnTimer = setTimeout(() => {
       this.turnTimer = null;
       console.error(
-        `codex-bridge: no turn completion within ${this.opts.turnTimeout}s; assuming the turn ended and resuming`,
+        `codex-bridge: no turn activity within ${this.opts.turnTimeout}s; assuming the turn ended and resuming`,
       );
       this.onTurnEnded().catch((error) =>
         console.error(`codex-bridge: resume after turn timeout failed: ${error.message}`),
@@ -1196,6 +1209,15 @@ class CodexBridge {
   onAgentMessageDelta(params) {
     if (params.threadId !== this.threadId) return;
     process.stderr.write(params.delta);
+    // The turn is demonstrably still producing output, so push the watchdog
+    // deadline forward instead of leaving it counting down from turn start.
+    // Without this, a turn that is actively reasoning/tool-calling for longer
+    // than turnTimeout (default 60s) — e.g. diagnosing a multi-step failure
+    // before replying — gets cut off by startTurnWatchdog()'s fixed timer
+    // before it ever reaches its own send.sh call, and the bridge silently
+    // re-arms as if the turn had ended with nothing to report. Only a turn
+    // that goes truly silent for turnTimeout seconds should trip this.
+    if (this.turnActive) this.startTurnWatchdog();
   }
 
   buildPrompt() {

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -49,9 +49,10 @@ Options:
                           via thread/loaded/list (codex 0.141+, see #170).
   --loaded-timeout <ms>   Max wait for a loaded thread to appear (default: 30000).
   --turn-timeout <sec>    Idle watchdog: assume a turn ended after this many
-                          seconds with no new agent-message output (default:
-                          60; 0 disables). Re-armed on every output chunk, so
-                          an actively-working turn is never cut off regardless
+                          seconds with no app-server activity for it at all
+                          (default: 60; 0 disables). Re-armed on any
+                          reasoning/tool-call/message notification, so an
+                          actively-working turn is never cut off regardless
                           of total duration — only true silence trips it.
   --inline-inbox          Read inbox in the bridge and include message text in the turn input.
   --resolve-only          Print resolved team/name and exit.
@@ -232,6 +233,11 @@ class AppServerClient {
     this.handlers = new Map();
     this.requestHandlers = new Map();
     this.child = null;
+    // Set by CodexBridge to learn about ANY thread-scoped activity, even for
+    // methods with no registered handler below -- e.g. reasoning/tool-call
+    // progress notifications the bridge doesn't otherwise care about, but
+    // which still prove a turn is alive. See onThreadActivity() call site.
+    this.onThreadActivity = null;
   }
 
   start() {
@@ -297,6 +303,17 @@ class AppServerClient {
     // exact #299 deadlock this fix exists to close. `method` presence is
     // what a JSON-RPC response never has, so it is the correct discriminator.
     if (message.method) {
+      // Fires for every thread-scoped notification/request, including the
+      // many the bridge has no specific handler for (reasoning deltas, tool
+      // -call/command-output progress, etc.) -- unlike the handlers Map
+      // below, which silently drops anything it has no registered method
+      // for. This is the ONLY generic signal that a turn is still doing
+      // something; without it, a turn that spends most of its time in
+      // exactly those unhandled notification types looks idle to the turn
+      // watchdog even while it is actively working. See onThreadActivity().
+      if (this.onThreadActivity && message.params && message.params.threadId) {
+        this.onThreadActivity(message.params.threadId);
+      }
       if (Object.prototype.hasOwnProperty.call(message, "id")) {
         this.dispatchRequest(message.id, message.method, message.params || {});
       } else if (this.handlers.has(message.method)) {
@@ -415,6 +432,10 @@ class WebSocketAppServerClient {
     this.pending = new Map();
     this.handlers = new Map();
     this.requestHandlers = new Map();
+    // Set by CodexBridge to learn about ANY thread-scoped activity, even for
+    // methods with no registered handler below. See the identical property
+    // and its call site in AppServerClient.handleLine().
+    this.onThreadActivity = null;
     this.socket = null;
     this.buffer = Buffer.alloc(0);
     this.connected = false;
@@ -624,6 +645,17 @@ class WebSocketAppServerClient {
     // this fix exists to close. `method` presence is what a JSON-RPC response
     // never has, so it is the correct discriminator.
     if (message.method) {
+      // Fires for every thread-scoped notification/request, including the
+      // many the bridge has no specific handler for (reasoning deltas, tool
+      // -call/command-output progress, etc.) -- unlike the handlers Map
+      // below, which silently drops anything it has no registered method
+      // for. This is the ONLY generic signal that a turn is still doing
+      // something; without it, a turn that spends most of its time in
+      // exactly those unhandled notification types looks idle to the turn
+      // watchdog even while it is actively working. See onThreadActivity().
+      if (this.onThreadActivity && message.params && message.params.threadId) {
+        this.onThreadActivity(message.params.threadId);
+      }
       if (Object.prototype.hasOwnProperty.call(message, "id")) {
         this.dispatchRequest(message.id, message.method, message.params || {});
       } else if (this.handlers.has(message.method)) {
@@ -800,6 +832,14 @@ class CodexBridge {
     this.ensureSingleInstance();
     this.writeMeta();
     this.installSignals();
+    // Any thread-scoped app-server activity for OUR active turn re-arms the
+    // idle watchdog -- reasoning, tool-call/command progress, agent-message
+    // deltas, all of it, not just one specific notification type. See
+    // startTurnWatchdog()'s comment for why a fixed-from-start ceiling was
+    // wrong here.
+    this.client.onThreadActivity = (threadId) => {
+      if (threadId === this.threadId && this.turnActive) this.startTurnWatchdog();
+    };
     this.client.on("process/exited", this.clientHandler("process/exited", (params) => this.onProcessExited(params)));
     this.client.on("error", this.clientHandler("error", (params) => this.onServerError(params)));
     this.client.on("item/agentMessage/delta", this.clientHandler("item/agentMessage/delta", (params) => this.onAgentMessageDelta(params)));
@@ -1148,14 +1188,16 @@ class CodexBridge {
     }
   }
 
-  // Idle watchdog, not a fixed ceiling on the turn's total duration: every
-  // agent-message delta (onAgentMessageDelta) re-arms it, so a turn that is
-  // actively producing output never trips it no matter how long it runs —
-  // only turnTimeout seconds of silence does. This matters because the app
-  // -server does not reliably send turn/completed (#41), so something has to
-  // detect a turn that will never report completion; a turn that is visibly
-  // still working is not that case, and cutting it off before it reaches its
-  // own send.sh call silently drops whatever it was about to report.
+  // Idle watchdog, not a fixed ceiling on the turn's total duration: ANY
+  // thread-scoped app-server activity re-arms it (client.onThreadActivity,
+  // set in run() -- reasoning deltas, tool-call/command progress, agent
+  // -message deltas, all of it), so a turn that is actively doing something
+  // never trips it no matter how long it runs — only turnTimeout seconds of
+  // true silence does. This matters because the app-server does not reliably
+  // send turn/completed (#41), so something has to detect a turn that will
+  // never report completion; a turn that is visibly still working is not
+  // that case, and cutting it off before it reaches its own send.sh call
+  // silently drops whatever it was about to report.
   startTurnWatchdog() {
     this.clearTurnWatchdog();
     if (!this.opts.turnTimeout) return;
@@ -1209,15 +1251,9 @@ class CodexBridge {
   onAgentMessageDelta(params) {
     if (params.threadId !== this.threadId) return;
     process.stderr.write(params.delta);
-    // The turn is demonstrably still producing output, so push the watchdog
-    // deadline forward instead of leaving it counting down from turn start.
-    // Without this, a turn that is actively reasoning/tool-calling for longer
-    // than turnTimeout (default 60s) — e.g. diagnosing a multi-step failure
-    // before replying — gets cut off by startTurnWatchdog()'s fixed timer
-    // before it ever reaches its own send.sh call, and the bridge silently
-    // re-arms as if the turn had ended with nothing to report. Only a turn
-    // that goes truly silent for turnTimeout seconds should trip this.
-    if (this.turnActive) this.startTurnWatchdog();
+    // Watchdog re-arm on this activity is handled generically by
+    // client.onThreadActivity (see run()), covering every notification type,
+    // not just this one.
   }
 
   buildPrompt() {

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -1305,6 +1305,65 @@ EOF
   [[ "$output" =~ "wakeup 2" ]]
 }
 
+@test "codex-bridge: an actively-streaming turn is not cut off by the idle watchdog past turn-timeout" {
+  run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
+  if [ "$status" -ne 0 ]; then
+    skip "node child_process.spawn is not available in this sandbox"
+  fi
+
+  # turn-timeout is 1s, but this fake keeps the turn "active" by sending
+  # item/agentMessage/delta every 300ms for 1.5s (5x the nominal timeout)
+  # before finally completing. If the watchdog were a fixed ceiling from turn
+  # start (the pre-fix behavior), it would fire well before turn/completed
+  # and the bridge would report the turn as ended via the timeout message
+  # instead of a real completion — the regression this test guards against.
+  local fake="$TEST_SKILL_DIR/fake-app-server-streaming.js"
+  cat >"$fake" <<'EOF'
+const readline = require("readline");
+const rl = readline.createInterface({ input: process.stdin });
+let maxId = 0;
+function send(value) { process.stdout.write(`${JSON.stringify(value)}\n`); }
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  } else if (message.method === "thread/start") {
+    send({ jsonrpc: "2.0", id: message.id, result: { thread: { id: "thread-1", status: { type: "idle" } } } });
+  } else if (message.method === "process/spawn") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    maxId += 1;
+    const id = maxId;
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "process/exited", params: { processHandle: message.params.processHandle, exitCode: 0, stdout: `status=pending count=1 max_id=${id}\n`, stderr: "" } });
+    }, 10);
+  } else if (message.method === "turn/start") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    const threadId = message.params.threadId;
+    for (let i = 1; i <= 5; i += 1) {
+      setTimeout(() => {
+        send({ jsonrpc: "2.0", method: "item/agentMessage/delta", params: { threadId, delta: `chunk-${i} ` } });
+      }, i * 300);
+    }
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "turn/completed", params: { threadId, turn: {} } });
+    }, 1600);
+  } else if (message.method === "process/kill") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  }
+});
+EOF
+
+  AGMSG_CODEX_APP_SERVER_CMD="node $fake" run node "$TYPES/codex/codex-bridge.js" \
+    --project "$PROJ" --team team --name alice --timeout 1 --interval 1 --turn-timeout 1 --max-wakes 2
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "wakeup 1" ]]
+  [[ "$output" =~ "chunk-5" ]]                       # the full stream was delivered, not cut short
+  [[ "$output" =~ "turn completed on thread" ]]      # ended via real completion...
+  [[ "$output" != *"no turn activity within"* ]]     # ...never via the idle watchdog
+  [[ "$output" =~ "wakeup 2" ]]
+}
+
 @test "codex-bridge: delivers a wake observed while the resumed thread was still active (no stale-stop)" {
   run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
   if [ "$status" -ne 0 ]; then

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -1364,6 +1364,59 @@ EOF
   [[ "$output" =~ "wakeup 2" ]]
 }
 
+@test "codex-bridge: non-message turn activity (reasoning/tool-call progress) also re-arms the idle watchdog" {
+  run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
+  if [ "$status" -ne 0 ]; then
+    skip "node child_process.spawn is not available in this sandbox"
+  fi
+
+  # Same shape as the streaming test above, but sends ONLY notification types
+  # the bridge has no dedicated handler for (a plausible reasoning-delta and
+  # a tool-call-progress notification) -- never item/agentMessage/delta. If
+  # re-arming only covered that one specific method (an earlier, incomplete
+  # version of this fix), this turn would still get cut off by the watchdog
+  # despite being visibly active the whole time.
+  local fake="$TEST_SKILL_DIR/fake-app-server-nonmessage-activity.js"
+  cat >"$fake" <<'EOF'
+const readline = require("readline");
+const rl = readline.createInterface({ input: process.stdin });
+let maxId = 0;
+function send(value) { process.stdout.write(`${JSON.stringify(value)}\n`); }
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  } else if (message.method === "thread/start") {
+    send({ jsonrpc: "2.0", id: message.id, result: { thread: { id: "thread-1", status: { type: "idle" } } } });
+  } else if (message.method === "process/spawn") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    maxId += 1;
+    const id = maxId;
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "process/exited", params: { processHandle: message.params.processHandle, exitCode: 0, stdout: `status=pending count=1 max_id=${id}\n`, stderr: "" } });
+    }, 10);
+  } else if (message.method === "turn/start") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    const threadId = message.params.threadId;
+    setTimeout(() => send({ jsonrpc: "2.0", method: "item/reasoning/textDelta", params: { threadId, delta: "thinking..." } }), 300);
+    setTimeout(() => send({ jsonrpc: "2.0", method: "item/commandExecution/outputDelta", params: { threadId, delta: "$ ls\n" } }), 900);
+    setTimeout(() => send({ jsonrpc: "2.0", method: "turn/completed", params: { threadId, turn: {} } }), 1600);
+  } else if (message.method === "process/kill") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  }
+});
+EOF
+
+  AGMSG_CODEX_APP_SERVER_CMD="node $fake" run node "$TYPES/codex/codex-bridge.js" \
+    --project "$PROJ" --team team --name alice --timeout 1 --interval 1 --turn-timeout 1 --max-wakes 2
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "wakeup 1" ]]
+  [[ "$output" =~ "turn completed on thread" ]]      # ended via real completion...
+  [[ "$output" != *"no turn activity within"* ]]     # ...never via the idle watchdog
+  [[ "$output" =~ "wakeup 2" ]]
+}
+
 @test "codex-bridge: delivers a wake observed while the resumed thread was still active (no stale-stop)" {
   run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
   if [ "$status" -ne 0 ]; then


### PR DESCRIPTION
## Summary

`startTurnWatchdog()` arms a single fixed-duration timer from turn start
(`--turn-timeout`, default 60s) and never touches it again until the turn
ends. A turn that is genuinely still working — reasoning, running tools,
composing a multi-step reply — for longer than that gets cut off by this
timer before it ever reaches its own `send.sh` call. `onTurnEnded()` then
runs exactly as it does on a real completion, so the bridge silently re-arms
as if the turn had ended with nothing to report; whatever it was about to
send never goes out, and the requesting peer sees only silence.

This turns the watchdog into a true **idle** timeout: any thread-scoped
app-server activity for the active turn re-arms it, so a turn is only ever
cut off after `turnTimeout` seconds of true silence, regardless of how long
it has been running in total. This preserves the watchdog's actual purpose
(rescue a turn that will never send `turn/completed` — the app-server does
not reliably send it, see #41) — a turn that is visibly still working is not
that case.

## Implementation

- `AppServerClient`/`WebSocketAppServerClient` (both transports) gain an
  `onThreadActivity` callback, invoked from `handleLine()` for **every**
  thread-scoped notification/request — including the many the bridge has no
  specific handler for (reasoning deltas, tool-call/command-output progress,
  etc.), which the existing `handlers` Map otherwise drops silently before
  dispatch. This is deliberately generic rather than enumerating specific
  event names: the exact set of "the turn is doing something" notifications
  isn't fully known/stable to this bridge, and a generic hook can't miss one.
- `CodexBridge` wires `onThreadActivity` to re-arm `startTurnWatchdog()` for
  its own active thread/turn.
- `onAgentMessageDelta`'s own re-arm (an earlier, narrower iteration of this
  fix) is now redundant and removed — the generic hook already covers it.

## Observed in production

A Codex bridge turn spent well over 60s diagnosing a GitHub auth/DNS
failure (correctly identifying an invalid `gh` CLI token and a
network-restricted sandbox, and proposing next steps) but the watchdog fired
before it reached `send.sh`, so the diagnosis was silently lost and the
requesting peer received nothing.

## Test plan

- `tests/test_codex_bridge.bats`:
  - "an actively-streaming turn is not cut off by the idle watchdog past
    turn-timeout" (agent-message deltas keep it alive well past the nominal
    timeout, then a real `turn/completed` ends it — never the watchdog).
  - "non-message turn activity (reasoning/tool-call progress) also re-arms
    the idle watchdog" (same shape, but only `item/reasoning/textDelta` and
    `item/commandExecution/outputDelta` — never `agentMessage/delta` — to
    prove the fix isn't scoped to one specific notification type).
- `bats tests/test_codex_bridge.bats tests/test_codex_bridge_launcher.bats` —
  47/47 passing (30 pre-existing + 2 new here, plus the launcher suite),
  including the existing watchdog regression tests (#41, #299) unmodified
  and still green.
- Reviewed via `/review:self-multi-model` (Codex + Fugu) before submission:
  Codex's first pass correctly flagged that an earlier iteration of this fix
  only re-armed on `agentMessage/delta` and missed the multi-step
  reasoning/tool-call case above — addressed by the generic
  `onThreadActivity` hook in the commit history here, with a dedicated
  regression test.

- [ ] CI green