### PR TITLE
Fix Codex bridge self-PID restart loop

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -1289,6 +1289,10 @@ class CodexBridge {
   ensureSingleInstance() {
     const existing = readPid(this.pidfile);
     if (!existing) return;
+    // The launcher records the spawned PID immediately so status never points
+    // at a stale predecessor. When that write wins the startup race, this
+    // process sees its own PID here; it owns the reservation, not a peer bridge.
+    if (existing === process.pid) return;
     try {
       process.kill(existing, 0);
       die(`bridge already running for ${this.identity.team}/${this.identity.name} (pid ${existing})`);

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -564,6 +564,27 @@ EOF
   [[ "$output" =~ "bridge already running" ]]
 }
 
+@test "codex-bridge: accepts its PID when the launcher records it before startup (#442)" {
+  skip_on_windows "codex bridge identity resolution on Windows (#182)"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  local wrapper="$TEST_SKILL_DIR/run-with-preseeded-pid.sh"
+  cat > "$wrapper" <<'EOF'
+#!/usr/bin/env bash
+pidfile="$1"
+shift
+printf '%s\n' "$$" > "$pidfile"
+exec "$@"
+EOF
+  chmod +x "$wrapper"
+
+  AGMSG_CODEX_APP_SERVER_CMD="exit 1" run "$wrapper" \
+    "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid" \
+    node "$TYPES/codex/codex-bridge.js" --project "$PROJ" --team team --name alice
+
+  [ "$status" -ne 0 ]
+  [[ ! "$output" =~ "bridge already running" ]]
+}
+
 @test "codex-bridge: starts a turn when app-server reports watch-once pending" {
   run node -e 'const r = require("child_process").spawnSync("/bin/sh", ["-c", "true"]); if (r.error) { console.error(r.error.message); process.exit(1); }'
   if [ "$status" -ne 0 ]; then


### PR DESCRIPTION
Fixes #442.

The per-role launcher records the spawned bridge PID immediately. If that write wins the startup race, the bridge single-instance check sees its own PID and previously treated it as a competing live bridge. Accept the self-PID as the launcher reservation while retaining rejection of every other live PID.

Regression coverage deterministically pre-seeds the bridge process' own PID before startup.

Tested: `bats tests/test_codex_bridge.bats` (35/35).
