### PR TITLE
draft: Stage-1 remote sync dogfood client

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,6 +133,56 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         run: bats --print-output-on-failure tests/
 
+  # Continuously verify that the storage contract is backend-portable: run the
+  # SAME driver-agnostic contract suite against the jsonl driver (the sqlite run
+  # is covered by the `bats` job above). This catches silent rot in jsonl as the
+  # contract evolves. Not a required check yet (promote once stable). duckdb is an
+  # opt-in accelerator, absent on the runner, so the jq path is exercised here.
+  storage-jsonl:
+    name: storage contract (jsonl, ${{ matrix.os }})
+    needs: changes
+    if: ${{ !cancelled() }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      # Both userlands — the jsonl driver shells out to jq/sed/sort/cksum/paste,
+      # whose behaviour differs between GNU (Linux) and BSD (macOS).
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docs-only change — skipping
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Diff is documentation-only; skipping the jsonl storage contract."
+
+      - name: Ensure jq + sqlite3 (Linux)
+        if: runner.os == 'Linux' && needs.changes.outputs.docs_only != 'true'
+        run: |
+          jq --version >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y jq; }
+          sqlite3 --version >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y sqlite3; }
+
+      - name: Install bats
+        if: needs.changes.outputs.docs_only != 'true'
+        run: |
+          npm config set prefix "$HOME/.npm-global"
+          npm install -g bats
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+
+      - name: Show tool versions
+        if: needs.changes.outputs.docs_only != 'true'
+        run: |
+          jq --version
+          sqlite3 --version
+          bats --version
+
+      - name: Run the storage contract against the jsonl driver
+        if: needs.changes.outputs.docs_only != 'true'
+        env:
+          AGMSG_STORAGE_DRIVER: jsonl
+        run: bats --print-output-on-failure tests/test_storage_contract.bats
+
   # Windows coverage for the native helpers shipped in #103 (Git Bash runner,
   # sqlite3 compatibility shim, cygpath normalization). The POSIX-assuming suite
   # is not fully green on Windows yet, so this is staged (#125): a single focused

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -347,6 +347,54 @@ jobs:
         if: needs.changes.outputs.server_changed != 'false'
         run: npm run build
 
+      - name: Compiled start smoke test
+        if: needs.changes.outputs.server_changed != 'false'
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/agmsg_test
+          AGMSG_SERVER_TOKEN: ci-compiled-start-token
+          LOG_LEVEL: silent
+        run: |
+          npm start > "$RUNNER_TEMP/agmsg-server.log" 2>&1 &
+          server_pid=$!
+          cleanup() {
+            kill "$server_pid" 2>/dev/null || true
+            wait "$server_pid" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+          for _attempt in $(seq 1 20); do
+            if curl --fail --silent http://127.0.0.1:8787/v1/health >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat "$RUNNER_TEMP/agmsg-server.log"
+          exit 1
+
+      - name: Docker image and health smoke test
+        if: needs.changes.outputs.server_changed != 'false'
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/agmsg_test
+          AGMSG_SERVER_TOKEN: ci-docker-start-token
+          CONTAINER_NAME: agmsg-reference-ci-${{ github.run_id }}
+        run: |
+          docker build -t agmsg-reference-server:ci .
+          docker run --detach --name "$CONTAINER_NAME" --network host \
+            --env DATABASE_URL --env AGMSG_SERVER_TOKEN \
+            --env HOST=127.0.0.1 --env PORT=8788 --env LOG_LEVEL=silent \
+            agmsg-reference-server:ci
+          cleanup() {
+            docker rm --force "$CONTAINER_NAME" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          for _attempt in $(seq 1 20); do
+            if curl --fail --silent http://127.0.0.1:8788/v1/health >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs "$CONTAINER_NAME"
+          exit 1
+
   # Windows leg for the app: the command layer's bash resolution and path
   # conversion are all behind cfg(windows) and had never run in CI — the very
   # 0.1.1→0.1.3 regressions (WSL bash.exe, backslash argv). This runs cargo test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
       app_changed: ${{ steps.detect.outputs.app_changed }}
+      server_changed: ${{ steps.detect.outputs.server_changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,6 +59,7 @@ jobs:
             echo "Event is '$EVENT' (not pull_request) — running the full suite."
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             echo "app_changed=true" >> "$GITHUB_OUTPUT"
+            echo "server_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
@@ -65,21 +67,24 @@ jobs:
           echo "$changed"
           docs_only=true
           app_changed=false
+          server_changed=false
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
               docs/*) ;;
               site/*) ;;
               app/*) app_changed=true ;;
+              server/*) docs_only=false; server_changed=true ;;
               llms.txt|llms-full.txt) ;;
               README.md|CHANGELOG.md|CONTRIBUTING.md|PRIVACY.md|ARCHITECTURE.md|RELEASING.md|LICENSE) ;;
               # NOTE: SKILL.md is intentionally not here — the suite tests it.
               *) docs_only=false ;;
             esac
           done <<< "$changed"
-          echo "Result: docs_only=$docs_only app_changed=$app_changed"
+          echo "Result: docs_only=$docs_only app_changed=$app_changed server_changed=$server_changed"
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
           echo "app_changed=$app_changed" >> "$GITHUB_OUTPUT"
+          echo "server_changed=$server_changed" >> "$GITHUB_OUTPUT"
 
   bats:
     name: bats (${{ matrix.os }})
@@ -283,6 +288,64 @@ jobs:
       - name: Rust tests
         if: needs.changes.outputs.app_changed != 'false'
         run: cargo test --manifest-path src-tauri/Cargo.toml
+
+  # PostgreSQL-backed contract tests for the independent reference server.
+  # Like app-check, this always reports and skips heavy work only when the diff
+  # provably does not touch server/.
+  server-check:
+    name: remote server
+    needs: changes
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_DB: agmsg_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d agmsg_test"
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 20
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: No server changes — skipping checks
+        if: needs.changes.outputs.server_changed == 'false'
+        run: echo "Diff does not touch server/ — reporting green without running server checks."
+
+      - uses: actions/setup-node@v4
+        if: needs.changes.outputs.server_changed != 'false'
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+
+      - name: Install dependencies
+        if: needs.changes.outputs.server_changed != 'false'
+        run: npm ci
+
+      - name: Typecheck
+        if: needs.changes.outputs.server_changed != 'false'
+        run: npm run typecheck
+
+      - name: PostgreSQL integration tests
+        if: needs.changes.outputs.server_changed != 'false'
+        env:
+          TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/agmsg_test
+        run: npm test
+
+      - name: Build
+        if: needs.changes.outputs.server_changed != 'false'
+        run: npm run build
 
   # Windows leg for the app: the command layer's bash resolution and path
   # conversion are all behind cfg(windows) and had never run in CI — the very

--- a/docs/adr/0003-storage-axis-driver-abi-and-scope.md
+++ b/docs/adr/0003-storage-axis-driver-abi-and-scope.md
@@ -1,0 +1,83 @@
+# ADR 0003: Storage axis — driver ABI, contract shape, and scope boundary
+
+**Status:** proposed (draft — subject to change)
+**Date:** 2026-06-24
+**Deciders:** @fujibee
+
+## Context
+
+1.1.0 shipped the axis-generic driver registry and external-plugin opt-in
+([ADR 0002](0002-driver-discovery-and-plugin-opt-in.md)). 1.1.1 implements the
+**storage axis** — the message store, made pluggable — with drivers `sqlite`
+(default), `jsonl`+`duckdb`, and `redis`. Before writing code, three
+architectural questions needed locking. An independent design pass (codex, this
+session) converged with the earlier Fugu-demo design (codex + gemini) and
+corrected an initial lean toward a subcommand ABI; this ADR records the
+converged decisions. ADRs are revisable, so it reaffirms or tightens
+[ADR 0001](0001-storage-driver-pluginization.md) where that is the better choice.
+
+## Decision
+
+1. **Drivers stay sourced bash, behind a *locked* ABI.** Keep ADR 0001's
+   sourced-function model, but tighten it: a driver exposes only the `storage_*`
+   domain operations and must not leak SQL fragments, file paths, or backend
+   cursors to core. Non-bash backends are reached by a thin bash facade that
+   shells out (duckdb, redis-cli, a helper). A subcommand + JSONL-pipe protocol
+   is reserved as an *internal* form a facade may exec later if a driver truly
+   can't be bash — it is **not** promoted to the core ABI now.
+
+2. **The contract abstracts use-cases, not queries.** Core calls domain
+   operations (send / list-unread / mark-read / watch-after / history), never a
+   query language. Two consequences: (a) the watch/check-inbox replay checkpoint
+   is an **opaque, driver-issued delivery cursor**, kept separate from read
+   state — core never compares it, so it absorbs sqlite int ids, UUIDv7, Redis
+   stream ids, and JSONL offsets; (b) read-marking is recipient-scoped and
+   idempotent. This removes the `id > watermark` (integer-id) assumption that
+   currently lives in core and would break on UUIDv7 / Redis streams. The
+   canonical export/import format is a JSONL event log.
+
+3. **Redis (1.1.2) is a message store only.** The team registry and run-state
+   (pidfiles, watch watermarks, actas locks, ready sentinels) are *not* moved
+   onto the network with it — those carry distributed-lease / TTL / clock /
+   orphan-reclaim concerns beyond the storage axis. Multi-host coordination, if
+   wanted, becomes a separate **coordination axis** under its own ADR. Redis
+   enters as a remote message bus, not as shared everything.
+
+**Phasing:** 1.1.1 = storage facade + `sqlite` driver + `jsonl`(+`duckdb`)
+driver (duckdb an opt-in query accelerator; default install stays bash +
+sqlite). 1.1.2 = `redis` (message store).
+
+## Alternatives considered
+
+- **Subcommand + JSONL pipe as the core driver ABI.** Cleaner process boundary
+  and language-agnostic, but the inner sqlite3/duckdb/redis-cli process runs
+  inside the driver regardless, so piping the core↔driver boundary adds
+  call-path complexity (and an extra fork on the unread/insert hot path) before
+  any real benefit. Independent codex and the Fugu design both landed on sourced;
+  kept as a deferred internal-impl option.
+- **Structured query params with a single core-comparable watermark.** Rejected
+  the comparable watermark — any cursor core can compare leaks the backend's id
+  scheme. The opaque-cursor decision generalizes it.
+- **Redis as full shared state (messages + registry + coordination).** Rejected
+  for 1.1.2: balloons into distributed coordination; split to a future axis.
+
+## Consequences
+
+- Positive: one ABI serves sqlite / jsonl-duckdb / redis with no core changes;
+  opaque cursor + use-case contract make a new backend a self-contained driver;
+  default install unchanged; aligns with ADR 0002's registry + opt-in.
+- Negative: core code that assumes the integer `messages.id` / `read_at` column
+  must move behind the contract before any non-sqlite driver works (the bulk of
+  1.1.1 — #203/#204/#206). Sourced drivers keep ADR 0002's trust concern,
+  mitigated by opt-in + the `storage_*` prefix discipline.
+- Neutral: the subcommand+pipe protocol and multi-host coordination are
+  explicitly *deferred, not rejected* — each can land under a later ADR.
+
+## References
+
+- Builds on [ADR 0001](0001-storage-driver-pluginization.md) and
+  [ADR 0002](0002-driver-discovery-and-plugin-opt-in.md).
+- Spec (where the `storage_*` signatures live, not this ADR):
+  [`docs/spec/driver-interface.md`](../spec/driver-interface.md).
+- Implementation: #51 (epic), #203 (contract), #204 (facade + sqlite),
+  #205 (event-log), #206 (call-site migration), #207 (jsonl+duckdb), #208 (redis).

--- a/docs/adr/0003-storage-axis-driver-abi-and-scope.md
+++ b/docs/adr/0003-storage-axis-driver-abi-and-scope.md
@@ -70,6 +70,21 @@ sqlite). 1.1.2 = `redis` (message store).
   must move behind the contract before any non-sqlite driver works (the bulk of
   1.1.1 — #203/#204/#206). Sourced drivers keep ADR 0002's trust concern,
   mitigated by opt-in + the `storage_*` prefix discipline.
+- Known gap (not yet migrated, tracked for a follow-up): `rename.sh` /
+  `rename-team.sh` rewrite historical `from_agent`/`to_agent`/`team` values by
+  running `UPDATE` directly against the sqlite driver's own `messages` and
+  `events` tables — bypassing the contract entirely, guarded only by "does the
+  sqlite db file exist". A team/agent renamed while a non-sqlite driver is
+  active gets its live registry entry renamed correctly, but the driver's
+  historical message log is not — no contract function exists yet for
+  "rewrite a name across history" (`storage_send`/`storage_history`/etc. all
+  operate on messages, not identities). `api.sh`'s `get teams <team> messages`
+  read path has the same coupling for a different reason: it needs
+  `--before-id` cursor pagination `storage_history` does not expose, so it
+  runs its own event-log ∪ legacy-table query rather than the facade function
+  — correct today (it still reads driver-shaped tables, not different ones),
+  but it too would need a driver-contract addition (a paginated history op) to
+  stop assuming sqlite's schema shape under a non-sqlite driver.
 - Neutral: the subcommand+pipe protocol and multi-host coordination are
   explicitly *deferred, not rejected* — each can land under a later ADR.
 

--- a/docs/adr/0005-stage-1-remote-sync.md
+++ b/docs/adr/0005-stage-1-remote-sync.md
@@ -61,6 +61,12 @@ envelope selected by the binding configuration. Stage 1 supports only envelope
 version 1 with `cipher: "none"`; a future encrypted driver performs its
 encrypt-once operation at this same boundary.
 
+The record also contains `allow_new`. When current policy or sequence exhaustion
+blocks new writes, the engine sets it to false: prepare must still emit
+`sync_state` so pull can continue, but must not reserve a new envelope. Write
+eligibility is not pull eligibility; unsupported or policy-violating remote
+envelopes still need durable quarantine and transport progress.
+
 The driver emits one `sync_state` record followed by zero or more ordered
 `sync_push_candidate` records. `sync_state` includes the driver generation and
 durable pull transport cursor, allowing a cycle to begin without adding a

--- a/docs/adr/0005-stage-1-remote-sync.md
+++ b/docs/adr/0005-stage-1-remote-sync.md
@@ -1,0 +1,156 @@
+# ADR 0005: Stage-1 local-first remote synchronization
+
+**Status:** proposed (dogfood contract)
+**Date:** 2026-07-20
+**Deciders:** @fujibee
+
+## Context
+
+The storage-axis ABI in ADR 0003 covers local message storage and delivery. It
+does not define the crash boundaries needed to replicate a local-first store to
+the versioned HTTP API in `server/spec/v1.md`. Stage 1 adds polling push/pull for
+dogfood while keeping `storage_send` local and independent of network health.
+
+The HTTP engine and the storage driver have different responsibilities. The
+engine owns transport, authentication, capability and binding validation,
+policy evaluation, retry classification, and polling. The driver owns every
+local durability transition. In particular, the engine must never receive a
+new wire ID or envelope that was not already committed locally, and it must
+never advance a cursor ahead of durable local state.
+
+## Decision
+
+### Optional synchronization extension
+
+A storage driver may advertise the Stage-1 extension and implement these three
+operations in addition to the ADR 0003 ABI:
+
+```text
+storage_sync_prepare_push <local-team> <server-instance-id> <remote-team-id> <protocol-version> <limit>
+storage_sync_reconcile_push <local-team> <server-instance-id> <remote-team-id> <protocol-version>
+storage_sync_apply_pull <local-team> <server-instance-id> <remote-team-id> <protocol-version>
+```
+
+The SQLite driver is the Stage-1 implementation. Drivers that do not advertise
+the extension remain valid local-only drivers. Core must fail clearly rather
+than emulate these durability operations outside an unsupported driver.
+
+The binding is keyed by immutable `server_instance_id`, the server's stable
+team/stream ID, and protocol version. Endpoint URL is deliberately absent: the
+same server database may move without invalidating its cursors. A different
+instance at the same URL is a different binding. The local team name selects
+local messages but is not the remote stream identity.
+
+Binding arguments contain no credentials or other secrets. Authentication
+material remains inside the HTTP engine. Bulk records never use argv: all input
+and output use UTF-8 JSONL, one complete JSON object per line, so message data is
+not exposed through `ps(1)` and is not bounded by `ARG_MAX`.
+
+Each binding also records the storage driver's persistent generation. Every
+local position is interpreted only together with that generation. Compaction
+that preserves the driver's cursor space preserves the generation; replacement
+or reinitialization of that position space creates a new generation. This
+prevents a reused local position from inheriting stale remote state.
+
+### Prepare push
+
+`storage_sync_prepare_push` reads one `sync_prepare` JSONL record from stdin.
+It contains the engine's validated envelope selection and capability limits,
+but no credentials. The ABI is cipher-neutral: the driver creates the canonical
+envelope selected by the binding configuration. Stage 1 supports only envelope
+version 1 with `cipher: "none"`; a future encrypted driver performs its
+encrypt-once operation at this same boundary.
+
+The driver emits one `sync_state` record followed by zero or more ordered
+`sync_push_candidate` records. `sync_state` includes the driver generation and
+durable pull transport cursor, allowing a cycle to begin without adding a
+fourth state-read operation. Each candidate includes its opaque local position,
+local ID, durable random wire ID, and exact envelope.
+
+Reservation is atomic and re-entrant by `(binding, driver generation, local
+position)`. Calling prepare again before reconciliation must emit the identical
+wire ID and byte-identical envelope; it must not reserialize, re-encode,
+re-encrypt, or reserve a second wire ID. Existing unacknowledged reservations
+are emitted before new local positions.
+
+### Reconcile push
+
+`storage_sync_reconcile_push` reads `sync_push_ack` records from stdin. The
+engine supplies only a complete, order-validated server acknowledgement set.
+The driver verifies that every wire ID and local position matches a durable
+reservation, records the canonical server sequence, and advances the durable
+push cursor in one transaction.
+
+The push cursor advances only through the contiguous prefix of local message
+positions whose reservations are acknowledged. A later acknowledgement cannot
+skip an earlier unacknowledged message. Replaying the same acknowledgements is
+idempotent; a conflicting server sequence is `corrupt_state`.
+
+### Apply pull
+
+`storage_sync_apply_pull` reads validated `sync_pull_message` records and one
+final `sync_pull_cursor` record from stdin. The engine has already verified the
+response binding, ordering, server policy, local security history, envelope
+syntax, and (where supported) plaintext or ciphertext authenticity. Each
+message still contains the unchanged wire envelope plus its evaluated import
+state and an optional local projection.
+
+The driver commits a page atomically:
+
+1. Persist every unchanged wire envelope in quarantine, keyed uniquely by wire
+   ID within the immutable binding.
+2. If that wire ID already maps to the same immutable envelope, reconcile the
+   server sequence onto the existing local record and do not create another
+   local event. This is the push-echo path and is idempotent.
+3. If no mapping exists and the evaluated state is importable, allocate one
+   local ID, import one local message event, and persist the mapping in the same
+   transaction.
+4. If the mapping or quarantine contains a different immutable envelope, record
+   `corrupt_state`; never import or expose it.
+5. Keep blocking states such as `unsupported_cipher`, `pending_key`,
+   `authentication_failed`, `malformed`, and `policy_violation` durable without
+   importing them.
+6. Advance the pull transport cursor only after every earlier sequence in the
+   page has reached one of those durable outcomes.
+
+The wire-ID unique index is independent of the local message-ID index. A pulled
+echo therefore reconciles to its mapped local ID, while an unmapped remote
+message receives a new local driver ID exactly once.
+
+### Three independent progress layers
+
+Remote transport progress, decrypt/import state, and user/agent read state are
+separate. Pull may advance after durable quarantine even when a key is missing;
+adding a key may reprocess quarantine without rewinding transport; importing a
+message does not mark it read. Existing local `message_read` events remain the
+read layer.
+
+The following future operation names are reserved but are not implemented in
+Stage 1:
+
+```text
+storage_sync_resync       # operator-approved recovery after HTTP 410
+storage_sync_reprocess    # retry pending decrypt/import states
+```
+
+HTTP 410 remains terminal in Stage 1. The engine must not reset a transport
+cursor automatically.
+
+## Consequences
+
+- A send stays a local transaction; network failure cannot block the agent hot
+  path.
+- Crash recovery repeats durable reservations and acknowledgements instead of
+  synthesizing new wire identities.
+- The transport engine is backend-neutral, while each participating driver can
+  make remote reconciliation atomic with its own local message store.
+- SQLite is the initial dogfood backend. JSONL remains local-only until it can
+  provide the same atomic import and cursor guarantees.
+- The client downloads the whole team stream and projects recipients locally;
+  the opaque envelope prevents server-side recipient routing.
+
+## References
+
+- [HTTP API v1](../../server/spec/v1.md)
+- [ADR 0003: storage-axis ABI and scope](0003-storage-axis-driver-abi-and-scope.md)
+- Issue #441 (local-first cross-machine replication proposal)

--- a/docs/remote-sync-dogfood.md
+++ b/docs/remote-sync-dogfood.md
@@ -1,0 +1,54 @@
+# Stage-1 remote sync dogfood
+
+Stage 1 polls the draft reference server while every `send` still commits to the
+local SQLite store first. It is intentionally branch-only and is not installed
+by the released core yet.
+
+Requirements: Node.js 22+, SQLite, jq, base64, and a provisioned team on the
+reference server. The bearer token is accepted only through
+`AGMSG_SYNC_TOKEN`; it is never stored in sync config or passed as an argument.
+
+Configure each machine (or each isolated dogfood store) with an explicit local
+plaintext policy:
+
+```sh
+export AGMSG_STORAGE_PATH=/path/to/machine-a-store
+export AGMSG_SYNC_TOKEN='deployment bearer token'
+
+scripts/remote-sync.sh configure \
+  --team example-team \
+  --server http://127.0.0.1:8787 \
+  --team-id 018f3f7e-0000-7000-8000-000000000001 \
+  --minimum-security plaintext-allowed
+```
+
+Run one push/pull cycle:
+
+```sh
+scripts/remote-sync.sh once --team example-team
+```
+
+Or poll continuously (five seconds by default):
+
+```sh
+scripts/remote-sync.sh run --team example-team --interval 5
+```
+
+The command emits timestamped JSONL lifecycle events. Set a log file to retain
+the exact push/ack/pull/import trace; the file is append-only from the client's
+perspective and includes imported plaintext bodies:
+
+```sh
+export AGMSG_SYNC_LOG_FILE=/path/to/stage1-dogfood.jsonl
+scripts/remote-sync.sh once --team example-team
+```
+
+For a single-host two-machine simulation, repeat configuration with two
+different `AGMSG_STORAGE_PATH` directories and the same immutable remote team
+ID. A message sent into store A is pushed by A and imported by B; the pull echo
+on A only confirms its existing local-to-wire mapping and does not create a
+second local message.
+
+HTTP 410 (`resync-required`) is terminal. Stage 1 never rewinds or resets the
+transport cursor automatically. JSONL and other drivers that do not advertise
+`capabilities=stage1-sync` remain valid local-only drivers.

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -100,17 +100,20 @@ ids) and `at` (ISO-8601 UTC). `storage_send` prints the new message's `id` on a
 single line. The `watch_*` pair is defined in §2.2.
 
 **stdout framing.** The **control ops** — `storage_check`, `storage_init`,
-`storage_mark_read_batch`, `storage_describe`, `storage_compact` — **must** use
-the §1.4 convention: a status name (`ok` / `missing_deps` / `runtime_error` / …)
-on the last stdout line, with the matching exit code. The **record-returning
-ops** — `storage_send`, `storage_list_unread`, `storage_history`,
-`storage_watch_tip`, `storage_watch_after` — write **data only** to stdout (JSONL
-records, or a bare id / cursor token; one record per line) and signal outcome
-with the **exit code** alone: `0` on success, non-zero with a message on
-**stderr** on failure. They never emit a §1.4 status name to stdout, so a status
-word can never be misread as a record. The trailing `cursor` record of
-`storage_watch_after` is part of that data stream (a designated final line), not
-a status.
+`storage_mark_read_batch`, `storage_compact` — **must** use the §1.4 convention:
+a status name (`ok` / `missing_deps` / `runtime_error` / …) on the last stdout
+line, with the matching exit code. The **record-returning ops** —
+`storage_send`, `storage_list_unread`, `storage_history`, `storage_watch_tip`,
+`storage_watch_after` — write **data only** to stdout (JSONL records, or a bare
+id / cursor token; one record per line) and signal outcome with the **exit code**
+alone: `0` on success, non-zero with a message on **stderr** on failure. They
+never emit a §1.4 status name to stdout, so a status word can never be misread as
+a record. The trailing `cursor` record of `storage_watch_after` is part of that
+data stream (a designated final line), not a status.
+
+`storage_describe` is a **metadata op**, not a control op: it always exits 0 and
+writes only its `key=value` registry metadata to stdout — never a §1.4 status
+name, which a metadata consumer would otherwise misread.
 
 ### 2.2 Delivery cursor (watch / replay)
 

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -284,6 +284,32 @@ its fast band, so its behaviour is **contractual**, not best-effort. A conformin
 Compaction must never touch `message_sent` records; it operates only on the
 redundant read-state markers layered over them.
 
+### 2.8 Optional Stage-1 remote synchronization extension
+
+A driver that can make remote reconciliation atomic with its local message log
+may advertise `capabilities=stage1-sync` from `storage_describe` and implement:
+
+```text
+storage_sync_prepare_push <local-team> <server-instance-id> <remote-team-id> <protocol-version> <limit>
+storage_sync_reconcile_push <local-team> <server-instance-id> <remote-team-id> <protocol-version>
+storage_sync_apply_pull <local-team> <server-instance-id> <remote-team-id> <protocol-version>
+```
+
+The extension is optional: a driver without it remains a conforming local-only
+storage driver. Bulk input and output are UTF-8 JSONL on stdin/stdout; only the
+non-secret binding identifiers and limits above may use argv. The binding key
+is `(server_instance_id, remote_team_id, protocol_version)`, and every local
+position is additionally paired with the driver's persistent generation.
+
+Prepare durably reserves a wire ID and exact canonical envelope before emitting
+it and is re-entrant by local position. Reconcile atomically records complete
+server acknowledgements and advances only an acknowledged contiguous local
+prefix. Apply-pull atomically quarantines unchanged envelopes, reconciles mapped
+echoes or imports unmapped wire IDs once, and advances the transport cursor only
+after durable local outcomes. Transport, decrypt/import, and read progress are
+independent. The complete framing, record schemas, crash boundaries, and future
+reserved operation names are defined by [ADR 0005](../adr/0005-stage-1-remote-sync.md).
+
 ## 3. CLI mapping
 
 | User command | Driver function(s) |

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -84,6 +84,7 @@ the swap-ability the axis exists for.
 storage_check
 storage_describe
 storage_init
+storage_store_exists
 storage_send <team> <from> <to> <body>
 storage_list_unread <team> <agent> [--limit N]
 storage_mark_read_batch <team> <agent> <id> [<id> ...]
@@ -98,6 +99,13 @@ storage_compact                # internal; see §2.7
 Every record carries `id` (UUIDv7 for new writes, an opaque string for legacy
 ids) and `at` (ISO-8601 UTC). `storage_send` prints the new message's `id` on a
 single line. The `watch_*` pair is defined in §2.2.
+
+`storage_store_exists` answers — by exit code, 0 if a store is already present and
+non-trivially initialized, non-zero otherwise — **without creating one**. A read
+call-site (inbox / history) uses it to say "no messages yet" in a project that has
+never used agmsg, rather than lazily materializing an empty store on a mere read.
+It is the driver, not a fixed `messages.db` file check, that knows where its store
+lives (sqlite's db file, jsonl's `events.jsonl`, a Redis key, …).
 
 `storage_history`'s `<agent>` is optional: given, it returns only messages where
 that agent is the sender or the recipient; omitted (or empty), it returns the

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -99,17 +99,18 @@ Every record carries `id` (UUIDv7 for new writes, an opaque string for legacy
 ids) and `at` (ISO-8601 UTC). `storage_send` prints the new message's `id` on a
 single line. The `watch_*` pair is defined in §2.2.
 
-**stdout framing.** The §1.4 convention (a status name on the last stdout line)
-applies only to the **control ops** — `storage_check`, `storage_init`,
-`storage_mark_read_batch`, `storage_describe`, `storage_compact`. The
-**record-returning ops** — `storage_send`, `storage_list_unread`,
-`storage_history`, `storage_watch_tip`, `storage_watch_after` — write **data
-only** to stdout (JSONL records, or a bare id / cursor token; one record per
-line) and signal outcome with the **exit code** alone: `0` on success, non-zero
-with a message on **stderr** on failure. They never emit a §1.4 status name to
-stdout, so a status word can never be misread as a record. The trailing `cursor`
-record of `storage_watch_after` is part of that data stream (a designated final
-line), not a status.
+**stdout framing.** The **control ops** — `storage_check`, `storage_init`,
+`storage_mark_read_batch`, `storage_describe`, `storage_compact` — **must** use
+the §1.4 convention: a status name (`ok` / `missing_deps` / `runtime_error` / …)
+on the last stdout line, with the matching exit code. The **record-returning
+ops** — `storage_send`, `storage_list_unread`, `storage_history`,
+`storage_watch_tip`, `storage_watch_after` — write **data only** to stdout (JSONL
+records, or a bare id / cursor token; one record per line) and signal outcome
+with the **exit code** alone: `0` on success, non-zero with a message on
+**stderr** on failure. They never emit a §1.4 status name to stdout, so a status
+word can never be misread as a record. The trailing `cursor` record of
+`storage_watch_after` is part of that data stream (a designated final line), not
+a status.
 
 ### 2.2 Delivery cursor (watch / replay)
 

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -89,7 +89,7 @@ storage_list_unread <team> <agent> [--limit N]
 storage_mark_read_batch <team> <agent> <id> [<id> ...]
 storage_watch_tip <team:agent> [<team:agent> ...]
 storage_watch_after <cursor> <team:agent> [<team:agent> ...]
-storage_history <team> <agent> [--limit N]
+storage_history <team> [agent] [--limit N]
 storage_export <file>
 storage_import <file>
 storage_compact                # internal; see §2.7
@@ -98,6 +98,14 @@ storage_compact                # internal; see §2.7
 Every record carries `id` (UUIDv7 for new writes, an opaque string for legacy
 ids) and `at` (ISO-8601 UTC). `storage_send` prints the new message's `id` on a
 single line. The `watch_*` pair is defined in §2.2.
+
+`storage_history`'s `<agent>` is optional: given, it returns only messages where
+that agent is the sender or the recipient; omitted (or empty), it returns the
+whole team's messages. Both forms are JSONL `message_sent` records in time order.
+Read-state is deliberately **not** carried on a history record — it is
+recipient-scoped (§2.3), so a consumer that wants a read/unread marker derives it
+by cross-referencing `storage_list_unread` for the relevant recipient rather than
+from the history record itself.
 
 **stdout framing.** The **control ops** — `storage_check`, `storage_init`,
 `storage_mark_read_batch`, `storage_compact` — **must** use the §1.4 convention:

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -172,6 +172,17 @@ to `<agent>` in `<team>` that have no matching `message_read` for that same
 affects another's, and re-marking an already-read id is **idempotent** (a no-op,
 or a duplicate event the projection collapses).
 
+**Schema version.** This is **event-log schema v1**. The two event types above
+and their fields are the v1 contract. Forward compatibility is a hard rule, not a
+courtesy: a projection **must ignore event `type`s it does not recognize and
+object fields it does not recognize**. That is the only "version marker" v1 needs
+— a later revision may add new optional fields or new event types without a
+breaking bump, and a v1 reader stays correct (it skips what it cannot interpret
+rather than failing). `export` emits the raw event stream in `seq` order; a v1
+`import` accepts the record types it knows and is free to drop ones it does not.
+A change that removes or repurposes an existing field is the only thing that
+requires a new major schema version.
+
 ### 2.4 Legacy compatibility (sqlite only)
 
 The bundled sqlite driver reads two sources for `storage_list_unread` and
@@ -206,10 +217,42 @@ Drivers own the concurrency model of their backing store:
 
 ### 2.7 Compaction
 
-The event log grows unbounded. Drivers implement an internal `storage_compact`
-that collapses redundant events (coalescing repeated `message_read` markers for
-the same `(msg_id, team, agent)`). v1 exposes this only internally; a user-facing
-CLI may follow.
+The event log grows unbounded (append-only), so every record-replaying driver —
+and especially a `jsonl` driver that re-reads the whole file per query — needs a
+way to bound it. Drivers implement an internal `storage_compact` that collapses
+redundant events. v1 exposes this only internally; a user-facing CLI may follow.
+
+`storage_compact` is the load-bearing primitive that keeps a log-based backend in
+its fast band, so its behaviour is **contractual**, not best-effort. A conforming
+`storage_compact` must satisfy all of:
+
+1. **Idempotent** — `compact` then `compact` again leaves the store identical to a
+   single `compact`. Running it repeatedly is always safe.
+2. **State-preserving (observable equivalence)** — every contract read
+   (`storage_list_unread`, `storage_history`, and the projected state an `export`
+   re-imports to) returns the **same result** before and after a `compact`. Only
+   the physical footprint (event count / bytes) shrinks; no visible message,
+   read-state, or ordering changes.
+3. **Read-coalescing** — redundant `message_read` markers for the same
+   `(team, agent, msg_id)` collapse to one. This is the primary size win and the
+   minimum a driver must do. (`storage_mark_read_batch` is itself write-idempotent,
+   so such duplicates do not arise in single-writer use; they come from a racing
+   writer or a merged `import`, and compaction is the backstop that cleans them up.)
+4. **Monotonic** — `compact` never increases the stored event count.
+5. **Cursor-safe (never skip)** — `compact` must **not invalidate a delivery
+   cursor (§2.2) already handed out**. A cursor issued before a `compact` must,
+   when replayed after it, still deliver every `message_sent` that falls after it
+   — none may be skipped. A driver whose physical cursor would be broken by
+   compaction (e.g. a `jsonl` byte offset invalidated by a log rewrite) must use a
+   **logical, compaction-stable cursor** so that, in the worst case, a stale
+   cursor **degrades to at-least-once re-delivery and never to a dropped
+   message**. The bundled sqlite driver gets this for free: it never deletes or
+   renumbers `message_sent` rows, and it issues cursors from a monotonic
+   high-water (`sqlite_sequence`) that a `DELETE`-based compaction cannot move
+   backwards.
+
+Compaction must never touch `message_sent` records; it operates only on the
+redundant read-state markers layered over them.
 
 ## 3. CLI mapping
 

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -216,6 +216,16 @@ Writes target the event log. There is no automated migration; legacy rows stay
 queryable indefinitely. Legacy integer ids are passed through as decimal strings
 (opaque, per §2.5).
 
+**Known gap — consumers still coupled to the sqlite driver's own schema.**
+`rename.sh`/`rename-team.sh` (rewriting a renamed identity across historical
+messages) and `api.sh`'s `get teams <team> messages` (which needs
+`--before-id` pagination the contract does not expose) currently read/write
+the sqlite driver's `messages`/`events` tables directly rather than through a
+`storage_*` function, so they only work correctly when sqlite is the active
+driver. See [ADR 0003](../adr/0003-storage-axis-driver-abi-and-scope.md)'s
+consequences for the tracked follow-up (a rename-across-history op, and a
+paginated history op).
+
 ### 2.5 Identifiers
 
 IDs that drivers generate for new writes are **UUIDv7** strings. The interface

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -69,63 +69,120 @@ Directives are advisory: the host agent decides whether to surface them to the u
 
 ## 2. Storage driver
 
+The storage axis is **messages only**: the durable message log and its read /
+replay state. The team registry (`teams/<team>/config.json`) and run-state
+(pidfiles, the per-session delivery cursor, actas locks, ready sentinels) are
+**not** part of this contract — they stay file-based and form a separate axis
+(see [ADR 0003](../adr/0003-storage-axis-driver-abi-and-scope.md)). A storage driver
+must implement the *entire* contract below: "this driver does only messages,
+that one also does teams" is disallowed, because a partial implementation breaks
+the swap-ability the axis exists for.
+
 ### 2.1 Required functions
 
 ```
 storage_check
 storage_describe
 storage_init
-storage_insert_message <team> <from> <to> <body>
-storage_unread <team> <agent> [--limit N]
-storage_mark_read <id>
-storage_mark_read_batch <id> [<id> ...]
+storage_send <team> <from> <to> <body>
+storage_list_unread <team> <agent> [--limit N]
+storage_mark_read_batch <team> <agent> <id> [<id> ...]
+storage_watch_tip <team:agent> [<team:agent> ...]
+storage_watch_after <cursor> <team:agent> [<team:agent> ...]
 storage_history <team> <agent> [--limit N]
-storage_teams
-storage_team_members <team>
 storage_export <file>
 storage_import <file>
+storage_compact                # internal; see §2.7
 ```
 
-All functions write structured output (JSONL) to stdout when returning records and follow §1.4 for status. Records always include `id` (UUIDv7 for new writes, opaque string for legacy IDs) and `at` (ISO-8601 UTC).
+Record-returning functions write one JSON object per line (JSONL) to stdout and
+follow §1.4 for status. Every record carries `id` (UUIDv7 for new writes, an
+opaque string for legacy ids) and `at` (ISO-8601 UTC). `storage_send` prints the
+new message's `id` on a single line. The `watch_*` pair is defined in §2.2.
 
-### 2.2 Event log schema
+### 2.2 Delivery cursor (watch / replay)
 
-Bundled drivers represent state as an append-only event log. Each event is one record with a `type` discriminator:
+Live delivery (`watch.sh`, `check-inbox.sh`) resumes from a checkpoint instead of
+re-reading the whole log. That checkpoint is an **opaque, driver-issued cursor**
+— a position in the driver's global message order. Core treats it as an opaque
+string: it persists the latest cursor (per session — the successor to the old
+`watch.<sid>.watermark` file) and passes it back unchanged. **Core never parses,
+compares, or orders cursors.** This is what lets one contract serve sqlite
+integer ids, UUIDv7, Redis stream ids, and JSONL byte offsets — the
+`id > watermark` integer assumption is removed from core entirely.
+
+- `storage_watch_tip <pairs...>` — print the cursor for "now" (the current tip of
+  the global order) as a single bare line. A fresh watcher starts here, so it
+  delivers only messages that arrive *after* it attached (no history replay; the
+  no-arg inbox check covers the backlog).
+- `storage_watch_after <cursor> <pairs...>` — print, as JSONL and in delivery
+  order, every `message_sent` after `<cursor>` addressed to one of the
+  subscription pairs; then print a final cursor record
+  `{"type":"cursor","cursor":"<opaque>"}` as the last line (always emitted, even
+  when there are zero new messages, so core can advance). Poll-once: it returns
+  what is currently available and exits — core loops on its own interval; a
+  streaming backend may implement it as one non-blocking drain.
+
+Each `<pair>` is `<team>:<agent>`. Team and agent names cannot contain `:` (the
+name rules enforce this); a driver may additionally reject a pair it cannot split
+unambiguously.
+
+### 2.3 Event log schema
+
+The bundled drivers represent state as an append-only event log. Each event is
+one record with a `type` discriminator — and only these two types live in the
+storage axis (team membership does not; see the §2 intro):
 
 ```jsonl
 {"type":"message_sent","id":"0192...","team":"agsuite","from":"aggie-cc","to":"aggie-co","body":"...","at":"2026-05-30T19:00:00Z"}
-{"type":"message_read","id":"0192...","msg_id":"0192...","agent":"aggie-co","at":"2026-05-30T19:05:00Z"}
-{"type":"team_joined","id":"0192...","team":"agsuite","agent":"alice","agent_type":"claude-code","project":"/path","at":"..."}
-{"type":"team_left","id":"0192...","team":"agsuite","agent":"alice","at":"..."}
+{"type":"message_read","id":"0192...","msg_id":"0192...","team":"agsuite","agent":"aggie-co","at":"2026-05-30T19:05:00Z"}
 ```
 
-Drivers project these events to answer queries. `storage_unread` returns `message_sent` events whose `id` has no corresponding `message_read` for the requesting agent.
+`storage_list_unread <team> <agent>` returns the `message_sent` events addressed
+to `<agent>` in `<team>` that have no matching `message_read` for that same
+`(team, agent)`. Read-marking is **recipient-scoped**: a `message_read` names the
+`(team, agent)` that read the message, so marking one recipient's copy never
+affects another's, and re-marking an already-read id is **idempotent** (a no-op,
+or a duplicate event the projection collapses).
 
-### 2.3 Legacy compatibility (sqlite only)
+### 2.4 Legacy compatibility (sqlite only)
 
-The bundled sqlite driver reads two sources for `storage_unread` and `storage_history`:
+The bundled sqlite driver reads two sources for `storage_list_unread` and
+`storage_history`:
 
-1. The legacy `messages` table (rows where `read=0`) for installations that predate the event log refactor
-2. The new event log tables for everything written after the refactor
+1. the legacy `messages` table (rows where `read_at IS NULL`) for installs that
+   predate the event log, and
+2. the event-log tables for everything written after.
 
-Writes only target the event log. There is no automated migration; legacy rows stay where they are and remain queryable indefinitely.
+Writes target the event log. There is no automated migration; legacy rows stay
+queryable indefinitely. Legacy integer ids are passed through as decimal strings
+(opaque, per §2.5).
 
-### 2.4 Identifiers
+### 2.5 Identifiers
 
-All IDs generated by drivers must be **UUIDv7** strings. The interface treats IDs as opaque, so drivers reading legacy data (integer autoincrement IDs in sqlite) may pass them through as decimal strings.
+IDs that drivers generate for new writes are **UUIDv7** strings. The interface
+treats every id as opaque, so a driver reading legacy data (sqlite autoincrement
+ints) passes them through as decimal strings. UUIDv7 is generated inside the
+driver (`python -c "..."`, a `uuidgen` that supports v7, or a shell
+implementation); drivers must not depend on a counter file. The delivery cursor
+(§2.2) is a **separate** opaque token from message ids — a driver may build it
+from ids, byte offsets, or stream positions.
 
-UUIDv7 is generated within the driver (e.g. via `python -c "..."`, `uuidgen` on platforms that support v7, or a shell implementation). Drivers must not depend on a counter file.
+### 2.6 Concurrency
 
-### 2.5 Concurrency
+Drivers own the concurrency model of their backing store:
 
-Drivers are responsible for the concurrency model of their backing store:
+- the sqlite driver relies on SQLite's WAL mode;
+- a `jsonl` / `duckdb` driver uses a lockfile around mark-read sequences and
+  around `compact` / `export` / `import`; single appends may rely on POSIX append
+  atomicity for writes ≤ `PIPE_BUF` bytes.
 
-- The sqlite driver relies on SQLite's WAL mode.
-- The `jsonl-duckdb` driver must use a lockfile around mark-read sequences and around `convert`/`export`/`import`. Single-message appends may rely on POSIX append atomicity for writes ≤ `PIPE_BUF` bytes.
+### 2.7 Compaction
 
-### 2.6 Compaction
-
-The event log grows unbounded. Drivers must implement an internal `storage_compact` function that collapses redundant events (e.g. coalescing `message_read` markers, dropping events for deleted teams). v1 exposes this only as an internal command; a user-facing CLI may follow.
+The event log grows unbounded. Drivers implement an internal `storage_compact`
+that collapses redundant events (coalescing repeated `message_read` markers for
+the same `(msg_id, team, agent)`). v1 exposes this only internally; a user-facing
+CLI may follow.
 
 ## 3. CLI mapping
 

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -101,7 +101,11 @@ single line. The `watch_*` pair is defined in §2.2.
 
 `storage_history`'s `<agent>` is optional: given, it returns only messages where
 that agent is the sender or the recipient; omitted (or empty), it returns the
-whole team's messages. Both forms are JSONL `message_sent` records in time order.
+whole team's messages. Both forms are JSONL `message_sent` records. `--limit N`
+selects the **most recent N** of the matching set; the output is always in
+**time order, oldest→newest** (so a limited query returns the tail of the history,
+still chronological — never newest-first). A driver must honour both this
+selection (recency) and this ordering so the result is identical across backends.
 Read-state is deliberately **not** carried on a history record — it is
 recipient-scoped (§2.3), so a consumer that wants a read/unread marker derives it
 by cross-referencing `storage_list_unread` for the relevant recipient rather than

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -95,10 +95,21 @@ storage_import <file>
 storage_compact                # internal; see §2.7
 ```
 
-Record-returning functions write one JSON object per line (JSONL) to stdout and
-follow §1.4 for status. Every record carries `id` (UUIDv7 for new writes, an
-opaque string for legacy ids) and `at` (ISO-8601 UTC). `storage_send` prints the
-new message's `id` on a single line. The `watch_*` pair is defined in §2.2.
+Every record carries `id` (UUIDv7 for new writes, an opaque string for legacy
+ids) and `at` (ISO-8601 UTC). `storage_send` prints the new message's `id` on a
+single line. The `watch_*` pair is defined in §2.2.
+
+**stdout framing.** The §1.4 convention (a status name on the last stdout line)
+applies only to the **control ops** — `storage_check`, `storage_init`,
+`storage_mark_read_batch`, `storage_describe`, `storage_compact`. The
+**record-returning ops** — `storage_send`, `storage_list_unread`,
+`storage_history`, `storage_watch_tip`, `storage_watch_after` — write **data
+only** to stdout (JSONL records, or a bare id / cursor token; one record per
+line) and signal outcome with the **exit code** alone: `0` on success, non-zero
+with a message on **stderr** on failure. They never emit a §1.4 status name to
+stdout, so a status word can never be misread as a record. The trailing `cursor`
+record of `storage_watch_after` is part of that data stream (a designated final
+line), not a status.
 
 ### 2.2 Delivery cursor (watch / replay)
 
@@ -111,6 +122,14 @@ compares, or orders cursors.** This is what lets one contract serve sqlite
 integer ids, UUIDv7, Redis stream ids, and JSONL byte offsets — the
 `id > watermark` integer assumption is removed from core entirely.
 
+The cursor is opaque to core but constrained for transport: it must be a
+**single-line, whitespace-free, printable token** that survives being written to
+a run-dir file and passed back as one `argv` argument to the sourced driver.
+Native positions that already satisfy this (a sqlite integer `seq`, a Redis
+stream id) are used as-is; a driver whose native position carries unsafe
+characters (e.g. a JSONL byte offset bundled with metadata) must encode it
+(base64url or similar) into a single safe token.
+
 - `storage_watch_tip <pairs...>` — print the cursor for "now" (the current tip of
   the global order) as a single bare line. A fresh watcher starts here, so it
   delivers only messages that arrive *after* it attached (no history replay; the
@@ -118,10 +137,14 @@ integer ids, UUIDv7, Redis stream ids, and JSONL byte offsets — the
 - `storage_watch_after <cursor> <pairs...>` — print, as JSONL and in delivery
   order, every `message_sent` after `<cursor>` addressed to one of the
   subscription pairs; then print a final cursor record
-  `{"type":"cursor","cursor":"<opaque>"}` as the last line (always emitted, even
-  when there are zero new messages, so core can advance). Poll-once: it returns
-  what is currently available and exits — core loops on its own interval; a
-  streaming backend may implement it as one non-blocking drain.
+  `{"type":"cursor","cursor":"<opaque>"}` as the last line. That trailing cursor
+  is the **global tip the driver can safely resume from at call time** (the same
+  notion as `storage_watch_tip`) — *not* the cursor of the last matching message.
+  It is always emitted, and advances even when zero subscription messages fell in
+  the range, so a watcher behind heavy off-subscription traffic does not re-scan
+  the same span on every poll. Poll-once: it returns what is currently available
+  and exits — core loops on its own interval; a streaming backend may implement
+  it as one non-blocking drain.
 
 Each `<pair>` is `<team>:<agent>`. Team and agent names cannot contain `:` (the
 name rules enforce this); a driver may additionally reject a pair it cannot split

--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -37,6 +37,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
+agmsg_storage_load
 
 _agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
 
@@ -104,15 +105,21 @@ get_messages() {
       *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
   done
-  # Non-numeric values would otherwise land straight in the SQL text below —
-  # same guard history.sh uses for LIMIT.
+  # Non-numeric --limit would otherwise land straight in the SQL text below —
+  # same guard history.sh uses for LIMIT. --before-id is an opaque message id
+  # (event-log ids are UUIDs, not numeric — see below), so it is NOT
+  # numeric-filtered; it is bound as an escaped SQL string literal instead.
   case "$limit" in ''|*[!0-9]*) limit=30 ;; esac
-  case "$before_id" in ''|*[!0-9]*) before_id="" ;; esac
 
   local db; db="$(agmsg_db_path)"
   if [ ! -f "$db" ]; then
     return 0 # no store yet — empty result, not an error
   fi
+  # The events table is created lazily by the facade on first write, so a
+  # pure-legacy store (init-db.sh ran, storage_send never called) may have
+  # messages but no events table yet — the UNION below would fail to parse
+  # without it. storage_init is idempotent (CREATE TABLE IF NOT EXISTS).
+  storage_init >/dev/null
 
   local team_sql; team_sql="$(_agmsg_sqlesc "$team")"
   local where="team='$team_sql'"
@@ -120,31 +127,50 @@ get_messages() {
     local agent_sql; agent_sql="$(_agmsg_sqlesc "$agent")"
     where="$where AND (from_agent='$agent_sql' OR to_agent='$agent_sql')"
   fi
+  local before_clause=""
   if [ -n "$before_id" ]; then
-    where="$where AND id<$before_id"
+    local before_id_sql; before_id_sql="$(_agmsg_sqlesc "$before_id")"
+    # Anchor pagination on the target row's own position (ord, see below),
+    # not on comparing id values directly: a legacy row's id and an
+    # event-log row's id are not from the same counter, so "id < before_id"
+    # only makes sense within a single source. A before_id that matches no
+    # row (bad cursor, or a compacted-away message) makes the subquery NULL,
+    # so the whole clause is false — an empty page, not an error.
+    before_clause="AND ord < (SELECT ord FROM combined WHERE id='$before_id_sql')"
   fi
 
-  # Inner query takes the most recent `limit` by id DESC, outer re-sorts
+  # Inner query takes the most recent `limit` by ord DESC, outer re-sorts
   # ASC — oldest-first output, same ordering contract §2.1 of the driver
-  # spec requires of storage_history, so a future swap to that function
-  # doesn't change what this command prints.
-  # id is CAST to TEXT: the driver-interface spec treats every message id as
-  # opaque, and a legacy sqlite integer id is specifically passed through as
-  # a decimal STRING (not a JSON number) so a future UUIDv7/Redis-stream-id
-  # driver doesn't change this field's JSON type — a consumer parsing id as
-  # a string today needs no change once that lands.
+  # spec requires of storage_history.
+  # Reads BOTH the event log (where storage_send now writes) and the legacy
+  # messages table (pre-flip installs), mirroring storage_history's UNION —
+  # without it, any message sent after the storage flip would be invisible
+  # here. `ord` is each source's own native monotonic counter (events.seq /
+  # messages.id), used only to order rows and anchor before-id pagination;
+  # it is never compared across sources.
+  # id is exposed as TEXT: the driver-interface spec treats every message id
+  # as opaque — a legacy sqlite integer id is a decimal STRING (not a JSON
+  # number), same as an event-log UUID, so a consumer parsing id as a string
+  # today needs no change as drivers evolve.
   agmsg_sqlite "$db" "
+    WITH combined AS (
+      SELECT id, team, from_agent, to_agent, body, at AS created_at, seq AS ord
+      FROM events WHERE type='message_sent'
+      UNION ALL
+      SELECT CAST(id AS TEXT) AS id, team, from_agent, to_agent, body, created_at, id AS ord
+      FROM messages
+    )
     SELECT json_object(
       'type', 'message_sent',
-      'id', CAST(id AS TEXT),
+      'id', id,
       'team', team,
       'from', from_agent,
       'to', to_agent,
       'body', body,
       'at', created_at
     ) FROM (
-      SELECT * FROM messages WHERE $where ORDER BY id DESC LIMIT $limit
-    ) ORDER BY id ASC;
+      SELECT * FROM combined WHERE $where $before_clause ORDER BY ord DESC LIMIT $limit
+    ) ORDER BY ord ASC;
   "
 }
 

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -127,16 +127,13 @@ mkdir -p "$SKILL_DIR/run"
 touch "$MARKER"
 
 # Check for unread messages and mark as read
+agmsg_storage_load
 DB="$(agmsg_db_path)"
 if [ ! -f "$DB" ]; then exit 0; fi
-
-_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
-AGENT_SQL="$(_agmsg_sqlesc "$AGENT")"
 
 OUTPUT=""
 IFS=',' read -ra TEAM_LIST <<< "$TEAMS"
 for team in "${TEAM_LIST[@]}"; do
-  team_sql="$(_agmsg_sqlesc "$team")"
   # Honor actas exclusivity locks. If (team, AGENT) is currently held by
   # another live session, that session is the owner of that role's inbox —
   # don't deliver here. Mirrors the per-pair filtering watch.sh does for
@@ -153,19 +150,27 @@ for team in "${TEAM_LIST[@]}"; do
     other:*) continue ;;
   esac
 
-  RESULT=$(agmsg_sqlite "$DB" "
-    SELECT id || char(31) || from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
-    FROM messages WHERE team='$team_sql' AND to_agent='$AGENT_SQL' AND read_at IS NULL
-    ORDER BY created_at ASC;
-  ")
-  if [ -n "$RESULT" ]; then
-    COUNT=$(echo "$RESULT" | wc -l | tr -d ' ')
+  # Unread via the storage facade (§2.1 storage_list_unread = events ∪ legacy),
+  # JSONL parsed in one pass with sqlite's JSON funcs (no jq; cf. lib/hooks-json.sh).
+  # id is kept so the mark step below targets exactly the rows shown.
+  UNREAD_JSONL=$(storage_list_unread "$team" "$AGENT")
+  if [ -n "$UNREAD_JSONL" ]; then
+    _arr="[$(printf '%s' "$UNREAD_JSONL" | paste -sd, -)]"
+    RESULT=$(agmsg_sqlite ':memory:' "
+      SELECT json_extract(value,'\$.id') || char(31) ||
+             json_extract(value,'\$.from') || char(31) ||
+             replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
+             json_extract(value,'\$.at')
+      FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+    ")
+    COUNT=$(printf '%s\n' "$RESULT" | wc -l | tr -d ' ')
     OUTPUT+="$COUNT new message(s) in $team:"$'\n'
     IDS=""
     while IFS=$'\x1f' read -r id from body ts; do
+      [ -n "$ts$from$body" ] || continue
       OUTPUT+="  [$ts] $from: $body"$'\n'
       case "$id" in
-        ''|*[!0-9]*) ;; # defensive: never splice a non-numeric value into SQL
+        ''|*[!0-9]*) ;; # event-log id (UUID) or unset -> not a legacy row; skip
         *) IDS="${IDS:+$IDS,}$id" ;;
       esac
     done <<< "$RESULT"
@@ -181,8 +186,11 @@ for team in "${TEAM_LIST[@]}"; do
         [ "$_agmsg_barrier_waited" -ge 200 ] && break # 10s safety cap
       done
     fi
-    # Mark as read — only the ids captured above, so a message that arrives
-    # between the SELECT and this UPDATE is not marked read unseen.
+    # Mark read — transitional legacy UPDATE (not storage_mark_read_batch yet);
+    # flips to events at step 3 alongside watch-once, which still reads legacy
+    # read_at. See the matching note in inbox.sh. Only the numeric (legacy-
+    # table) ids captured above, so a message that arrives between the SELECT
+    # and this UPDATE is not marked read unseen.
     if [ -n "$IDS" ]; then
       agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id IN ($IDS);" 2>/dev/null || true
     fi

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -157,22 +157,19 @@ for team in "${TEAM_LIST[@]}"; do
   if [ -n "$UNREAD_JSONL" ]; then
     _arr="[$(printf '%s' "$UNREAD_JSONL" | paste -sd, -)]"
     RESULT=$(agmsg_sqlite ':memory:' "
-      SELECT json_extract(value,'\$.id') || char(31) ||
-             json_extract(value,'\$.from') || char(31) ||
+      SELECT json_extract(value,'\$.from') || char(31) ||
              replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
-             json_extract(value,'\$.at')
+             json_extract(value,'\$.at') || char(31) ||
+             json_extract(value,'\$.id')
       FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
     ")
     COUNT=$(printf '%s\n' "$RESULT" | wc -l | tr -d ' ')
     OUTPUT+="$COUNT new message(s) in $team:"$'\n'
-    IDS=""
-    while IFS=$'\x1f' read -r id from body ts; do
-      [ -n "$ts$from$body" ] || continue
+    IDS=()
+    while IFS=$'\x1f' read -r from body ts id; do
+      [ -n "$id" ] || continue
       OUTPUT+="  [$ts] $from: $body"$'\n'
-      case "$id" in
-        ''|*[!0-9]*) ;; # event-log id (UUID) or unset -> not a legacy row; skip
-        *) IDS="${IDS:+$IDS,}$id" ;;
-      esac
+      IDS+=("$id")
     done <<< "$RESULT"
     OUTPUT+=$'\n'
     # Test seam: a two-file barrier that lets the race regression test land a
@@ -186,13 +183,13 @@ for team in "${TEAM_LIST[@]}"; do
         [ "$_agmsg_barrier_waited" -ge 200 ] && break # 10s safety cap
       done
     fi
-    # Mark read — transitional legacy UPDATE (not storage_mark_read_batch yet);
-    # flips to events at step 3 alongside watch-once, which still reads legacy
-    # read_at. See the matching note in inbox.sh. Only the numeric (legacy-
-    # table) ids captured above, so a message that arrives between the SELECT
-    # and this UPDATE is not marked read unseen.
-    if [ -n "$IDS" ]; then
-      agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id IN ($IDS);" 2>/dev/null || true
+    # Mark read via the facade (§2.1 storage_mark_read_batch): recipient-scoped,
+    # idempotent; a legacy id records a message_read event without mutating the
+    # legacy row (§2.4). Only the ids collected from the rows actually
+    # displayed above — never a blanket match — so a message that arrives
+    # after the SELECT above can never be marked read unseen.
+    if [ "${#IDS[@]}" -gt 0 ]; then
+      storage_mark_read_batch "$team" "$AGENT" "${IDS[@]}" >/dev/null 2>&1 || true
     fi
   fi
 done

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -126,10 +126,10 @@ fi
 mkdir -p "$SKILL_DIR/run"
 touch "$MARKER"
 
-# Check for unread messages and mark as read
+# Check for unread messages and mark as read. Ask the active driver whether a
+# store exists (driver-level, works for jsonl too) — don't create one on a poll.
 agmsg_storage_load
-DB="$(agmsg_db_path)"
-if [ ! -f "$DB" ]; then exit 0; fi
+if ! storage_store_exists; then exit 0; fi
 
 OUTPUT=""
 IFS=',' read -ra TEAM_LIST <<< "$TEAMS"

--- a/scripts/drivers/storage/jsonl-unread.duckdb.sql
+++ b/scripts/drivers/storage/jsonl-unread.duckdb.sql
@@ -1,0 +1,20 @@
+-- duckdb "unread for a recipient" anti-join, file-direct (no daemon).
+-- Read as DATA by the jsonl driver (scripts/drivers/storage/jsonl.sh) and never
+-- parsed by bash, so its apostrophes and "double-quoted" identifiers can't trip
+-- the macOS system bash 3.2 parser. The driver fills the placeholders by literal
+-- bash substitution: __LG__ = events.jsonl path, __TL__ = team, __AL__ = agent
+-- (all already SQL-escaped — apostrophes doubled — before substitution).
+-- Columns are read as explicit VARCHAR, never read_json_auto, whose type
+-- inference would parse `at` as a TIMESTAMP and drop the canonical ISO-8601 T/Z.
+SELECT to_json(struct_pack(type := 'message_sent', id := s.id, team := s.team,
+         "from" := s."from", "to" := s."to", body := s.body, at := s.at))
+FROM (SELECT * FROM read_json('__LG__', columns={type:'VARCHAR', id:'VARCHAR',
+        team:'VARCHAR', "from":'VARCHAR', "to":'VARCHAR', body:'VARCHAR',
+        at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited')
+      WHERE type='message_sent' AND team='__TL__' AND "to"='__AL__') s
+WHERE s.id NOT IN (
+  SELECT msg_id FROM read_json('__LG__', columns={type:'VARCHAR', id:'VARCHAR',
+        team:'VARCHAR', "from":'VARCHAR', "to":'VARCHAR', body:'VARCHAR',
+        at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited')
+  WHERE type='message_read' AND team='__TL__' AND agent='__AL__')
+ORDER BY s.at, s.id;

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -187,9 +187,12 @@ storage_mark_read_batch() {
 _jsonl_mark() {
   local team="$1" agent="$2"; shift 2
   local log id at line existing; log="$(_jsonl_log)"
+  # A failed scan of existing reads (e.g. a corrupt log) must abort the mark, not
+  # silently treat every id as new and append — that would be the same swallowed
+  # failure. The caller turns this non-zero into runtime_error.
   existing="$(jq -r --arg team "$team" --arg agent "$agent" \
     'select(.type=="message_read" and .team==$team and .agent==$agent) | .msg_id' \
-    "$log" 2>/dev/null)"
+    "$log")" || return 1
   for id in "$@"; do
     printf '%s\n' "$existing" | grep -Fxq "$id" && continue
     at="$(_jsonl_now)"

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -287,6 +287,6 @@ _jsonl_compact_do() {
   # single-quoted jq string in this position desyncs the macOS system bash 3.2
   # parser and breaks the rest of the file (a no-error `bash -n`, but a real
   # source failure). Keep new jq one-liners here.
-  jq -c -s 'reduce .[] as $e ({out:[], seen:{}}; if $e.type=="message_sent" then .out += [$e] elif $e.type=="message_read" then ([$e.team,$e.agent,$e.msg_id]|join(" ")) as $k | if .seen[$k] then . else .seen[$k]=true | .out += [$e] end else . end) | .out[]' "$log" > "$tmp" || { rm -f "$tmp"; return 1; }
+  jq -c -s 'reduce .[] as $e ({out:[], seen:{}}; if $e.type=="message_sent" then .out += [$e] elif $e.type=="message_read" then ([$e.team,$e.agent,$e.msg_id]|tojson) as $k | if .seen[$k] then . else .seen[$k]=true | .out += [$e] end else . end) | .out[]' "$log" > "$tmp" || { rm -f "$tmp"; return 1; }
   mv "$tmp" "$log"
 }

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# jsonl storage driver (opt-in).
+#
+# Implements the storage contract (docs/spec/driver-interface.md §2, ADR 0003)
+# over an append-only JSONL event log — the same canonical model as the sqlite
+# driver (message_sent / message_read), but the file IS the store. Sourced by the
+# storage facade (lib/storage.sh), so agmsg_db_path is in scope; the log lives at
+# <db-dir>/events.jsonl.
+#
+# Engine: jq is the zero-extra-dep default (declared by storage_check). duckdb is
+# an OPT-IN accelerator for the one hot anti-join (list_unread) on large logs —
+# the PoC crossover is ~10-20k events (#207 / FINDINGS.md); below it jq's lack of
+# startup cost wins, so the driver picks jq unless the log is big AND duckdb is on
+# PATH. No daemon: duckdb runs file-direct, one process per query.
+#
+# Framing (§1.4): record-returning ops write JSONL to stdout and fail non-zero;
+# control ops (check/init/mark_read_batch/compact) print a §1.4 status name.
+#
+# Delivery cursor (§2.2): a LOGICAL position — the ordinal count of message_sent
+# events, NOT a byte offset. Compaction only coalesces message_read (never removes
+# or reorders message_sent), so an ordinal stays valid across a log rewrite; a
+# byte offset would not. The cursor is an opaque decimal string to core.
+
+# --- helpers ---------------------------------------------------------------
+
+_jsonl_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+_jsonl_log() { printf '%s\n' "$(dirname "$(agmsg_db_path)")/events.jsonl"; }
+
+_jsonl_init_file() {
+  local log; log="$(_jsonl_log)"
+  mkdir -p "$(dirname "$log")" 2>/dev/null || true
+  [ -f "$log" ] || : > "$log" 2>/dev/null || true
+}
+
+# UUIDv7 (§2.5) — python3 preferred, /dev/urandom shell fallback. No counter file.
+_jsonl_uuid7() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import os, time
+ms = int(time.time() * 1000) & ((1 << 48) - 1)
+b = bytearray(os.urandom(16))
+b[0] = (ms >> 40) & 0xFF; b[1] = (ms >> 32) & 0xFF
+b[2] = (ms >> 24) & 0xFF; b[3] = (ms >> 16) & 0xFF
+b[4] = (ms >> 8) & 0xFF;  b[5] = ms & 0xFF
+b[6] = 0x70 | (b[6] & 0x0F)
+b[8] = 0x80 | (b[8] & 0x3F)
+h = b.hex()
+print(f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}")
+PY
+    return
+  fi
+  local ms hex rnd
+  ms=$(( $(date -u +%s) * 1000 ))
+  hex=$(printf '%012x' "$ms")
+  rnd=$(head -c 10 /dev/urandom | od -An -tx1 | tr -d ' \n')
+  printf '%s-%s-7%s-8%s-%s\n' \
+    "${hex:0:8}" "${hex:8:4}" "${rnd:0:3}" "${rnd:3:3}" "${rnd:6:12}"
+}
+
+# Serialize all log mutations (append / mark / compact / import) behind a portable
+# mkdir lock; record-returning reads take a single file read as their snapshot.
+_jsonl_with_lock() {
+  local lock i=0 rc=0
+  lock="$(_jsonl_log).lock"
+  until mkdir "$lock" 2>/dev/null; do
+    i=$((i + 1)); [ "$i" -ge 1000 ] && return 1
+    sleep 0.01
+  done
+  "$@" || rc=$?
+  rmdir "$lock" 2>/dev/null || true
+  return $rc
+}
+
+# duckdb is used only when present AND the log is past the jq crossover. The check
+# is byte-size based (file-direct I/O is size-bound, FINDINGS.md): ~5 MB ≈ tens of
+# thousands of events. AGMSG_JSONL_ENGINE=jq|duckdb forces a choice (tests/bench).
+_jsonl_use_duckdb() {
+  case "${AGMSG_JSONL_ENGINE:-}" in
+    jq) return 1 ;;
+    duckdb) command -v duckdb >/dev/null 2>&1 && return 0 || return 1 ;;
+  esac
+  command -v duckdb >/dev/null 2>&1 || return 1
+  local log sz; log="$(_jsonl_log)"
+  sz=$(wc -c < "$log" 2>/dev/null | tr -d ' ') || return 1
+  [ "${sz:-0}" -ge "${AGMSG_JSONL_DUCKDB_BYTES:-5242880}" ]
+}
+
+# --- contract: lifecycle ----------------------------------------------------
+
+storage_check() {
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'AGMSG-DIRECTIVE: {"type":"install_deps","driver":"jsonl","commands":["brew install jq"],"reason":"jq not found on PATH"}\n'
+    echo missing_deps
+    return 10
+  fi
+  echo ok
+}
+
+storage_describe() {
+  printf 'name=jsonl\n'
+  printf 'backend=append-only JSONL event log (jq; duckdb opt-in accelerator)\n'
+  printf 'log=%s\n' "$(_jsonl_log)"
+}
+
+storage_init() {
+  _jsonl_init_file
+  echo ok
+}
+
+# --- contract: messages -----------------------------------------------------
+
+storage_send() {
+  local team="$1" from="$2" to="$3" body="$4"
+  local id at line; id="$(_jsonl_uuid7)"; at="$(_jsonl_now)"
+  _jsonl_init_file
+  line="$(jq -nc --arg id "$id" --arg team "$team" --arg from "$from" \
+    --arg to "$to" --arg body "$body" --arg at "$at" \
+    '{type:"message_sent",id:$id,team:$team,from:$from,to:$to,body:$body,at:$at}')" \
+    || return 1
+  _jsonl_with_lock _jsonl_append "$line" || return 1
+  printf '%s\n' "$id"
+}
+_jsonl_append() { printf '%s\n' "$1" >> "$(_jsonl_log)"; }
+
+storage_list_unread() {
+  local team="$1" agent="$2" limit=""
+  shift 2
+  while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
+  case "$limit" in ''|*[!0-9]*) limit="" ;; esac
+  _jsonl_init_file
+  local log out; log="$(_jsonl_log)"
+  if _jsonl_use_duckdb; then
+    out="$(_jsonl_unread_duckdb "$team" "$agent" "$log")" || return 1
+  else
+    out="$(jq -c --arg team "$team" --arg agent "$agent" -s '
+      (reduce .[] as $e ({};
+        if $e.type=="message_read" and $e.team==$team and $e.agent==$agent
+        then .[$e.msg_id]=true else . end)) as $read
+      | .[]
+      | select(.type=="message_sent" and .team==$team and .to==$agent and ($read[.id] | not))
+      | {type:"message_sent",id:.id,team:.team,from:.from,to:.to,body:.body,at:.at}
+    ' "$log")" || return 1
+  fi
+  [ -n "$out" ] || return 0
+  if [ -n "$limit" ]; then printf '%s\n' "$out" | head -n "$limit"; else printf '%s\n' "$out"; fi
+}
+
+# duckdb file-direct anti-join (opt-in, large logs). Same unread set AND identical
+# record shape as the jq path. Fields are read as explicit VARCHAR columns — never
+# read_json_auto, whose type inference would parse `at` as a TIMESTAMP and re-emit
+# it as "Y-M-D H:M:S", losing the canonical ISO-8601 "...T...Z" the jq path keeps.
+_jsonl_unread_duckdb() {
+  local team="$1" agent="$2" log="$3"
+  local cols="columns={type:'VARCHAR', id:'VARCHAR', team:'VARCHAR', \"from\":'VARCHAR', \"to\":'VARCHAR', body:'VARCHAR', at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited'"
+  duckdb -noheader -list -newline $'\n' <<SQL 2>/dev/null
+SELECT to_json(struct_pack(type := 'message_sent', id := s.id, team := s.team,
+         "from" := s."from", "to" := s."to", body := s.body, at := s.at))
+FROM (SELECT * FROM read_json('$log', $cols) WHERE type='message_sent'
+        AND team='$team' AND "to"='$agent') s
+WHERE s.id NOT IN (
+  SELECT msg_id FROM read_json('$log', $cols)
+  WHERE type='message_read' AND team='$team' AND agent='$agent')
+ORDER BY s.at, s.id;
+SQL
+}
+
+storage_mark_read_batch() {
+  local team="$1" agent="$2"; shift 2
+  _jsonl_init_file
+  _jsonl_with_lock _jsonl_mark "$team" "$agent" "$@"
+  echo ok
+}
+_jsonl_mark() {
+  local team="$1" agent="$2"; shift 2
+  local log id at line existing; log="$(_jsonl_log)"
+  existing="$(jq -r --arg team "$team" --arg agent "$agent" \
+    'select(.type=="message_read" and .team==$team and .agent==$agent) | .msg_id' \
+    "$log" 2>/dev/null)"
+  for id in "$@"; do
+    printf '%s\n' "$existing" | grep -Fxq "$id" && continue
+    at="$(_jsonl_now)"
+    line="$(jq -nc --arg id "$(_jsonl_uuid7)" --arg msg_id "$id" --arg team "$team" \
+      --arg agent "$agent" --arg at "$at" \
+      '{type:"message_read",id:$id,msg_id:$msg_id,team:$team,agent:$agent,at:$at}')"
+    printf '%s\n' "$line" >> "$log"
+    existing="$existing"$'\n'"$id"
+  done
+}
+
+# --- contract: watch (delivery cursor §2.2) ---------------------------------
+
+storage_watch_tip() {
+  _jsonl_init_file
+  jq -s '[.[] | select(.type=="message_sent")] | length' "$(_jsonl_log)" 2>/dev/null || echo 0
+}
+
+storage_watch_after() {
+  local cursor="$1"; shift
+  case "$cursor" in ''|*[!0-9]*) cursor=0 ;; esac
+  _jsonl_init_file
+  local pairs_json; pairs_json="$(printf '%s\n' "$@" | jq -Rsc 'split("\n") | map(select(length>0))')"
+  # One file read = one snapshot: the trailing cursor (total message_sent count)
+  # is computed from the same scan, so it never runs ahead of the rows returned.
+  jq -c --argjson cursor "$cursor" --argjson pairs "$pairs_json" -s '
+    [.[] | select(.type=="message_sent")] as $sent
+    | ($sent
+        | to_entries
+        | map(select((.key >= $cursor)
+              and ((.value.team + ":" + .value.to) as $p | ($pairs | index($p)) != null)))
+        | .[].value
+        | {type:"message_sent",id:.id,team:.team,from:.from,to:.to,body:.body,at:.at}),
+      {type:"cursor",cursor:(($sent | length) | tostring)}
+  ' "$(_jsonl_log)" 2>/dev/null
+}
+
+# --- contract: history ------------------------------------------------------
+
+storage_history() {
+  local team="$1"; shift
+  local agent="" limit=""
+  if [ $# -gt 0 ] && [ "${1#-}" = "$1" ]; then agent="$1"; shift; fi
+  while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
+  case "$limit" in ''|*[!0-9]*) limit="-1" ;; esac
+  _jsonl_init_file
+  jq -c --arg team "$team" --arg agent "$agent" --argjson limit "$limit" -s '
+    [.[] | select(.type=="message_sent" and .team==$team
+            and ($agent=="" or .to==$agent or .from==$agent))
+     | {type:"message_sent",id:.id,team:.team,from:.from,to:.to,body:.body,at:.at}]
+    | (if $limit >= 0 and (length > $limit) then .[length-$limit:] else . end)
+    | .[]
+  ' "$(_jsonl_log)" 2>/dev/null
+}
+
+# --- contract: export / import / compact ------------------------------------
+
+storage_export() {
+  _jsonl_init_file
+  # Forward-compat (§2.3): only the v1 event types are projected; unknown types
+  # are dropped rather than leaked.
+  jq -c 'select(.type=="message_sent" or .type=="message_read")' "$(_jsonl_log)" > "$1"
+}
+
+storage_import() {
+  local file="$1"; [ -f "$file" ] || return 1
+  _jsonl_init_file
+  _jsonl_with_lock _jsonl_import_do "$file"
+}
+_jsonl_import_do() {
+  jq -c 'select(.type=="message_sent" or .type=="message_read")' "$1" >> "$(_jsonl_log)"
+}
+
+storage_compact() {
+  _jsonl_init_file
+  _jsonl_with_lock _jsonl_compact_do || { echo runtime_error; return 13; }
+  echo ok
+}
+_jsonl_compact_do() {
+  local log tmp; log="$(_jsonl_log)"; tmp="$log.compact.$$"
+  # Keep every message_sent in order; collapse duplicate message_read for the same
+  # (team, agent, msg_id) to the first seen. message_sent order is preserved, so
+  # the ordinal delivery cursor stays valid (§2.7 cursor-safe).
+  jq -c -s '
+    reduce .[] as $e ({out:[], seen:{}};
+      if $e.type=="message_sent" then .out += [$e]
+      elif $e.type=="message_read" then
+        ($e.team + " " + $e.agent + " " + $e.msg_id) as $k
+        | if .seen[$k] then . else .seen[$k]=true | .out += [$e] end
+      else . end)
+    | .out[]
+  ' "$log" > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$log"
+}

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -60,10 +60,10 @@ PY
 # Serialize all log mutations (append / mark / compact / import) behind a portable
 # mkdir lock; record-returning reads take a single file read as their snapshot.
 _jsonl_with_lock() {
-  local lock i=0 rc=0
+  local lock i=0 rc=0 max="${AGMSG_JSONL_LOCK_TRIES:-1000}"
   lock="$(_jsonl_log).lock"
   until mkdir "$lock" 2>/dev/null; do
-    i=$((i + 1)); [ "$i" -ge 1000 ] && return 1
+    i=$((i + 1)); [ "$i" -ge "$max" ] && return 1
     sleep 0.01
   done
   "$@" || rc=$?
@@ -155,15 +155,22 @@ storage_list_unread() {
 # it as "Y-M-D H:M:S", losing the canonical ISO-8601 "...T...Z" the jq path keeps.
 _jsonl_unread_duckdb() {
   local team="$1" agent="$2" log="$3"
+  # SQL-escape every value spliced into the query (team/agent are not apostrophe-
+  # free per validate.sh, and the path may contain one) so a legal team/agent that
+  # the jq path handles can't break — or silently misbehave on — the duckdb path.
+  local tl al lg
+  tl="$(printf '%s' "$team"  | sed "s/'/''/g")"
+  al="$(printf '%s' "$agent" | sed "s/'/''/g")"
+  lg="$(printf '%s' "$log"   | sed "s/'/''/g")"
   local cols="columns={type:'VARCHAR', id:'VARCHAR', team:'VARCHAR', \"from\":'VARCHAR', \"to\":'VARCHAR', body:'VARCHAR', at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited'"
   duckdb -noheader -list -newline $'\n' <<SQL 2>/dev/null
 SELECT to_json(struct_pack(type := 'message_sent', id := s.id, team := s.team,
          "from" := s."from", "to" := s."to", body := s.body, at := s.at))
-FROM (SELECT * FROM read_json('$log', $cols) WHERE type='message_sent'
-        AND team='$team' AND "to"='$agent') s
+FROM (SELECT * FROM read_json('$lg', $cols) WHERE type='message_sent'
+        AND team='$tl' AND "to"='$al') s
 WHERE s.id NOT IN (
-  SELECT msg_id FROM read_json('$log', $cols)
-  WHERE type='message_read' AND team='$team' AND agent='$agent')
+  SELECT msg_id FROM read_json('$lg', $cols)
+  WHERE type='message_read' AND team='$tl' AND agent='$al')
 ORDER BY s.at, s.id;
 SQL
 }
@@ -171,7 +178,10 @@ SQL
 storage_mark_read_batch() {
   local team="$1" agent="$2"; shift 2
   _jsonl_init_file
-  _jsonl_with_lock _jsonl_mark "$team" "$agent" "$@"
+  # Propagate a lock-acquire / write failure as a §1.4 control-op error — never
+  # swallow it as ok, or inbox/check-inbox would treat unread as read with no
+  # message_read written (re-delivery loop / stale wake on the read hot path).
+  _jsonl_with_lock _jsonl_mark "$team" "$agent" "$@" || { echo runtime_error; return 13; }
   echo ok
 }
 _jsonl_mark() {
@@ -195,7 +205,10 @@ _jsonl_mark() {
 
 storage_watch_tip() {
   _jsonl_init_file
-  jq -s '[.[] | select(.type=="message_sent")] | length' "$(_jsonl_log)" 2>/dev/null || echo 0
+  # An empty log makes jq return 0 with exit 0; a CORRUPT log makes jq fail, and
+  # that must surface as a non-zero exit (data-op framing §2.1) — no `|| echo 0`
+  # fallback that would mask a broken store as a fresh tip of 0.
+  jq -s '[.[] | select(.type=="message_sent")] | length' "$(_jsonl_log)"
 }
 
 storage_watch_after() {

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -23,6 +23,11 @@
 
 # --- helpers ---------------------------------------------------------------
 
+# Where this driver (and its companion duckdb .sql) lives — captured at source
+# time so the optional duckdb path can read the query from a data file rather than
+# carry apostrophe-laden SQL inline (which the macOS bash 3.2 parser mis-handles).
+_JSONL_DRIVER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+
 _jsonl_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 _jsonl_log() { printf '%s\n' "$(dirname "$(agmsg_db_path)")/events.jsonl"; }
 
@@ -154,25 +159,24 @@ storage_list_unread() {
 # read_json_auto, whose type inference would parse `at` as a TIMESTAMP and re-emit
 # it as "Y-M-D H:M:S", losing the canonical ISO-8601 "...T...Z" the jq path keeps.
 _jsonl_unread_duckdb() {
-  local team="$1" agent="$2" log="$3"
+  local team="$1" agent="$2" log="$3" tl al lg sql tpl
   # SQL-escape every value spliced into the query (team/agent are not apostrophe-
   # free per validate.sh, and the path may contain one) so a legal team/agent that
   # the jq path handles can't break — or silently misbehave on — the duckdb path.
-  local tl al lg
   tl="$(printf '%s' "$team"  | sed "s/'/''/g")"
   al="$(printf '%s' "$agent" | sed "s/'/''/g")"
   lg="$(printf '%s' "$log"   | sed "s/'/''/g")"
-  local cols="columns={type:'VARCHAR', id:'VARCHAR', team:'VARCHAR', \"from\":'VARCHAR', \"to\":'VARCHAR', body:'VARCHAR', at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited'"
-  duckdb -noheader -list -newline $'\n' <<SQL 2>/dev/null
-SELECT to_json(struct_pack(type := 'message_sent', id := s.id, team := s.team,
-         "from" := s."from", "to" := s."to", body := s.body, at := s.at))
-FROM (SELECT * FROM read_json('$lg', $cols) WHERE type='message_sent'
-        AND team='$tl' AND "to"='$al') s
-WHERE s.id NOT IN (
-  SELECT msg_id FROM read_json('$lg', $cols)
-  WHERE type='message_read' AND team='$tl' AND agent='$al')
-ORDER BY s.at, s.id;
-SQL
+  # Read the query from the companion .sql DATA file and fill placeholders with
+  # plain bash substitution (literal, so a value with sed-special / regex chars is
+  # safe). Keeping the SQL out of this shell file is what makes the driver parse
+  # under macOS bash 3.2 (an inline apostrophe-laden SQL string desyncs its parser).
+  tpl="$_JSONL_DRIVER_DIR/jsonl-unread.duckdb.sql"
+  [ -f "$tpl" ] || return 1
+  sql="$(cat "$tpl")"
+  sql="${sql//__LG__/$lg}"
+  sql="${sql//__TL__/$tl}"
+  sql="${sql//__AL__/$al}"
+  printf '%s\n' "$sql" | duckdb -noheader -list 2>/dev/null
 }
 
 storage_mark_read_batch() {
@@ -278,15 +282,11 @@ _jsonl_compact_do() {
   local log tmp; log="$(_jsonl_log)"; tmp="$log.compact.$$"
   # Keep every message_sent in order; collapse duplicate message_read for the same
   # (team, agent, msg_id) to the first seen. message_sent order is preserved, so
-  # the ordinal delivery cursor stays valid (§2.7 cursor-safe).
-  jq -c -s '
-    reduce .[] as $e ({out:[], seen:{}};
-      if $e.type=="message_sent" then .out += [$e]
-      elif $e.type=="message_read" then
-        ($e.team + " " + $e.agent + " " + $e.msg_id) as $k
-        | if .seen[$k] then . else .seen[$k]=true | .out += [$e] end
-      else . end)
-    | .out[]
-  ' "$log" > "$tmp" || { rm -f "$tmp"; return 1; }
+  # the ordinal delivery cursor stays valid (compaction cursor-safety, spec 2.7).
+  # NOTE: this jq program is deliberately a SINGLE line — a multi-line
+  # single-quoted jq string in this position desyncs the macOS system bash 3.2
+  # parser and breaks the rest of the file (a no-error `bash -n`, but a real
+  # source failure). Keep new jq one-liners here.
+  jq -c -s 'reduce .[] as $e ({out:[], seen:{}}; if $e.type=="message_sent" then .out += [$e] elif $e.type=="message_read" then ([$e.team,$e.agent,$e.msg_id]|join(" ")) as $k | if .seen[$k] then . else .seen[$k]=true | .out += [$e] end else . end) | .out[]' "$log" > "$tmp" || { rm -f "$tmp"; return 1; }
   mv "$tmp" "$log"
 }

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -107,6 +107,10 @@ storage_init() {
   echo ok
 }
 
+# Does a store already exist? (does NOT create one.) The log is the store, so a
+# read call-site can answer "no messages yet" without lazily creating events.jsonl.
+storage_store_exists() { [ -f "$(_jsonl_log)" ]; }
+
 # --- contract: messages -----------------------------------------------------
 
 storage_send() {

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -83,6 +83,24 @@ _sqlite_sync_schema() {
       PRIMARY KEY(server_instance_id,remote_team_id,protocol_version,wire_id),
       UNIQUE(server_instance_id,remote_team_id,protocol_version,server_seq)
     );
+    CREATE TABLE IF NOT EXISTS sync_conflicts (
+      conflict_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      local_team TEXT NOT NULL,
+      server_instance_id TEXT NOT NULL,
+      remote_team_id TEXT NOT NULL,
+      protocol_version INTEGER NOT NULL,
+      driver_generation TEXT NOT NULL,
+      server_seq TEXT NOT NULL,
+      wire_id TEXT NOT NULL,
+      envelope_v INTEGER NOT NULL,
+      cipher TEXT NOT NULL,
+      key_id TEXT,
+      blob TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      observed_at TEXT NOT NULL,
+      UNIQUE(server_instance_id,remote_team_id,protocol_version,
+             server_seq,wire_id,reason)
+    );
   " >/dev/null 2>&1 || return 13
   generation=$(agmsg_sqlite "$db" \
     "SELECT generation FROM sync_store_metadata WHERE singleton=1;" 2>/dev/null | tr -d '\r')
@@ -114,17 +132,18 @@ storage_sync_prepare_push() {
   [ "$limit" -ge 1 ] && [ "$limit" -le 1000 ] || return 13
   _sqlite_sync_schema || return $?
 
-  local prepare generation db tl input_ok version cipher key_id max_blob
+  local prepare generation db tl input_ok version cipher key_id max_blob allow_new
   prepare=$(cat)
   input_ok=$(printf '%s\n' "$prepare" | jq -r \
     'select(.type=="sync_prepare" and (.envelope_v|type)=="number" and
             (.cipher|type)=="string" and has("key_id") and
-            (.max_blob_bytes|type)=="number") | "ok"' 2>/dev/null)
+            (.max_blob_bytes|type)=="number" and (.allow_new|type)=="boolean") | "ok"' 2>/dev/null)
   [ "$input_ok" = ok ] || return 13
   version=$(printf '%s\n' "$prepare" | jq -r '.envelope_v')
   cipher=$(printf '%s\n' "$prepare" | jq -r '.cipher')
   key_id=$(printf '%s\n' "$prepare" | jq -r '.key_id // empty')
   max_blob=$(printf '%s\n' "$prepare" | jq -r '.max_blob_bytes')
+  allow_new=$(printf '%s\n' "$prepare" | jq -r 'if .allow_new then 1 else 0 end')
   # Stage 1 implements the cipher-neutral ABI with the plaintext profile only.
   [ "$version" = 1 ] && [ "$cipher" = none ] && [ -z "$key_id" ] || return 13
   case "$max_blob" in ''|*[!0-9]*) return 13 ;; esac
@@ -149,6 +168,7 @@ storage_sync_prepare_push() {
        AND m.driver_generation=b.driver_generation AND m.local_position=e.seq
      WHERE e.type='message_sent' AND e.team='$tl' AND e.seq>b.push_cursor
        AND m.server_seq IS NULL
+       AND ($allow_new=1 OR m.wire_id IS NOT NULL)
      ORDER BY e.seq LIMIT $limit;
   ") || return 13
 
@@ -229,7 +249,8 @@ storage_sync_reconcile_push() {
   [ "$count" -gt 0 ] || return 13
 
   agmsg_sqlite "$db" "BEGIN IMMEDIATE;
-    CREATE TEMP TABLE incoming_sync_acks(local_position INTEGER,wire_id TEXT,server_seq TEXT);
+    CREATE TEMP TABLE incoming_sync_acks(
+      local_position INTEGER UNIQUE,wire_id TEXT UNIQUE,server_seq TEXT UNIQUE);
     INSERT INTO incoming_sync_acks VALUES $values;
     CREATE TEMP TABLE sync_assert(ok INTEGER CHECK(ok=1));
     INSERT INTO sync_assert SELECT CASE WHEN COUNT(*)=$count THEN 1 ELSE 0 END
@@ -273,12 +294,14 @@ storage_sync_apply_pull() {
   local team="$1" server="$2" remote="$3" protocol="$4"
   _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
   _sqlite_sync_schema || return $?
-  local generation db tl sql_file line type final_cursor="" corrupt=0
+  local generation db tl sql_file line type final_cursor="" corrupt=0 outcome_ids=""
   local seq wire received v cipher key_id blob status policy local_rev reason
   local from to body at local_id q
   generation=$(_sqlite_sync_generation); db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"
   _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || return 13
   sql_file=$(mktemp "${TMPDIR:-/tmp}/agmsg-sync-sql.XXXXXX") || return 13
+  _AGMSG_SYNC_SQL_FILE="$sql_file"
+  trap 'case "${_AGMSG_SYNC_SQL_FILE:-}" in "${TMPDIR:-/tmp}"/agmsg-sync-sql.*) rm -f "$_AGMSG_SYNC_SQL_FILE" ;; esac' EXIT INT TERM HUP
   printf '%s\n' 'BEGIN IMMEDIATE;' > "$sql_file"
 
   while IFS= read -r line; do
@@ -292,6 +315,10 @@ storage_sync_apply_pull() {
     [ "$type" = sync_pull_message ] || { rm -f "$sql_file"; return 13; }
     seq=$(printf '%s\n' "$line" | jq -r '.server_seq // empty')
     wire=$(printf '%s\n' "$line" | jq -r '.id // empty')
+    printf '%s\n' "$wire" | grep -Eq \
+      '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' \
+      || { rm -f "$sql_file"; trap - EXIT INT TERM HUP; return 13; }
+    outcome_ids="${outcome_ids}${outcome_ids:+,}'$wire'"
     received=$(printf '%s\n' "$line" | jq -r '.server_received_at // empty')
     v=$(printf '%s\n' "$line" | jq -r '.envelope.v')
     cipher=$(printf '%s\n' "$line" | jq -r '.envelope.cipher')
@@ -305,6 +332,33 @@ storage_sync_apply_pull() {
     case "$status" in importable|unsupported_cipher|pending_key|authentication_failed|malformed|policy_violation) ;; *) rm -f "$sql_file"; return 13 ;; esac
     q="'$(_sqlite_lit "$key_id")'"; [ -n "$key_id" ] || q=NULL
     printf "%s\n" "
+      INSERT OR IGNORE INTO sync_conflicts
+        (local_team,server_instance_id,remote_team_id,protocol_version,
+         driver_generation,server_seq,wire_id,envelope_v,cipher,key_id,blob,
+         reason,observed_at)
+      SELECT '$tl','$server','$remote',$protocol,'$generation','$seq','$wire',$v,
+             '$(_sqlite_lit "$cipher")',$q,'$(_sqlite_lit "$blob")',
+             'server sequence maps to another wire id',
+             strftime('%Y-%m-%dT%H:%M:%fZ','now')
+      WHERE EXISTS(SELECT 1 FROM sync_quarantine qx
+        WHERE qx.server_instance_id='$server' AND qx.remote_team_id='$remote'
+          AND qx.protocol_version=$protocol AND qx.server_seq='$seq'
+          AND qx.wire_id<>'$wire');
+      INSERT OR IGNORE INTO sync_conflicts
+        (local_team,server_instance_id,remote_team_id,protocol_version,
+         driver_generation,server_seq,wire_id,envelope_v,cipher,key_id,blob,
+         reason,observed_at)
+      SELECT '$tl','$server','$remote',$protocol,'$generation','$seq','$wire',$v,
+             '$(_sqlite_lit "$cipher")',$q,'$(_sqlite_lit "$blob")',
+             'wire id maps to another sequence or envelope',
+             strftime('%Y-%m-%dT%H:%M:%fZ','now')
+      WHERE EXISTS(SELECT 1 FROM sync_quarantine qx
+        WHERE qx.server_instance_id='$server' AND qx.remote_team_id='$remote'
+          AND qx.protocol_version=$protocol AND qx.wire_id='$wire'
+          AND (qx.server_seq<>'$seq' OR qx.envelope_v<>$v
+            OR qx.cipher<>'$(_sqlite_lit "$cipher")'
+            OR COALESCE(qx.key_id,'')<>'$(_sqlite_lit "$key_id")'
+            OR qx.blob<>'$(_sqlite_lit "$blob")'));
       INSERT OR IGNORE INTO sync_quarantine
         (local_team,server_instance_id,remote_team_id,protocol_version,
          driver_generation,server_seq,wire_id,server_received_at,envelope_v,
@@ -332,10 +386,14 @@ storage_sync_apply_pull() {
         AND remote_team_id='$remote' AND protocol_version=$protocol AND wire_id='$wire'
         AND envelope_v=$v AND cipher='$(_sqlite_lit "$cipher")'
         AND COALESCE(key_id,'')='$(_sqlite_lit "$key_id")'
-        AND blob='$(_sqlite_lit "$blob")' AND (server_seq IS NULL OR server_seq='$seq');
+        AND blob='$(_sqlite_lit "$blob")' AND (server_seq IS NULL OR server_seq='$seq')
+        AND EXISTS(SELECT 1 FROM sync_quarantine qx
+          WHERE qx.server_instance_id='$server' AND qx.remote_team_id='$remote'
+            AND qx.protocol_version=$protocol AND qx.wire_id='$wire'
+            AND qx.status='importable');
       UPDATE sync_quarantine SET status='reconciled' WHERE server_instance_id='$server'
         AND remote_team_id='$remote' AND protocol_version=$protocol AND wire_id='$wire'
-        AND status<>'corrupt_state' AND EXISTS(SELECT 1 FROM sync_messages m
+        AND status='importable' AND EXISTS(SELECT 1 FROM sync_messages m
           WHERE m.server_instance_id='$server' AND m.remote_team_id='$remote'
             AND m.protocol_version=$protocol AND m.wire_id='$wire' AND m.server_seq='$seq');" >> "$sql_file"
 
@@ -356,7 +414,10 @@ storage_sync_apply_pull() {
           AND NOT EXISTS(SELECT 1 FROM sync_quarantine qx
           WHERE qx.server_instance_id='$server' AND qx.remote_team_id='$remote'
             AND qx.protocol_version=$protocol AND qx.wire_id='$wire'
-            AND qx.status='corrupt_state');
+            AND qx.status='corrupt_state')
+          AND NOT EXISTS(SELECT 1 FROM sync_conflicts cx
+          WHERE cx.server_instance_id='$server' AND cx.remote_team_id='$remote'
+            AND cx.protocol_version=$protocol AND cx.wire_id='$wire');
         INSERT OR IGNORE INTO sync_messages
           (local_team,server_instance_id,remote_team_id,protocol_version,
            driver_generation,local_position,local_id,wire_id,envelope_v,cipher,
@@ -378,14 +439,34 @@ storage_sync_apply_pull() {
       AND protocol_version=$protocol AND driver_generation='$generation';
     COMMIT;" >> "$sql_file"
   if ! agmsg_sqlite "$db" < "$sql_file" >/dev/null 2>&1; then
-    rm -f "$sql_file"; return 13
+    rm -f "$sql_file"; trap - EXIT INT TERM HUP; return 13
   fi
   rm -f "$sql_file"
-  corrupt=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_quarantine WHERE
+  trap - EXIT INT TERM HUP
+  _AGMSG_SYNC_SQL_FILE=""
+  corrupt=$(agmsg_sqlite "$db" "SELECT
+    (SELECT COUNT(*) FROM sync_quarantine WHERE
     server_instance_id='$server' AND remote_team_id='$remote' AND protocol_version=$protocol
-    AND status='corrupt_state';" | tr -d '\r')
+    AND status='corrupt_state') +
+    (SELECT COUNT(*) FROM sync_conflicts WHERE server_instance_id='$server'
+     AND remote_team_id='$remote' AND protocol_version=$protocol);" | tr -d '\r')
   _sqlite_data "SELECT json_object('type','sync_apply_result','transport_cursor',
     transport_cursor,'corrupt_count',$corrupt) FROM sync_bindings
     WHERE local_team='$tl' AND server_instance_id='$server' AND remote_team_id='$remote'
-      AND protocol_version=$protocol AND driver_generation='$generation';"
+      AND protocol_version=$protocol AND driver_generation='$generation';
+    SELECT json_object('type','sync_apply_outcome','id',wire_id,
+                       'server_seq',server_seq,'status',status)
+      FROM sync_quarantine WHERE server_instance_id='$server'
+       AND remote_team_id='$remote' AND protocol_version=$protocol
+       AND wire_id IN (${outcome_ids:-''})
+    UNION ALL
+    SELECT json_object('type','sync_apply_outcome','id',c.wire_id,
+                       'server_seq',c.server_seq,'status','corrupt_state')
+      FROM sync_conflicts c WHERE c.server_instance_id='$server'
+       AND c.remote_team_id='$remote' AND c.protocol_version=$protocol
+       AND c.wire_id IN (${outcome_ids:-''})
+       AND NOT EXISTS(SELECT 1 FROM sync_quarantine qx
+         WHERE qx.server_instance_id=c.server_instance_id
+           AND qx.remote_team_id=c.remote_team_id
+           AND qx.protocol_version=c.protocol_version AND qx.wire_id=c.wire_id);"
 }

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+# Optional Stage-1 remote synchronization extension for the SQLite driver.
+# See docs/adr/0005-stage-1-remote-sync.md. All bulk input/output is JSONL.
+
+_sqlite_sync_uuid4() {
+  local h n variant
+  h=$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n') || return 1
+  [ "${#h}" -eq 32 ] || return 1
+  n=$((16#${h:16:1}))
+  variant=$(printf '%x' $(((n & 3) | 8)))
+  printf '%s-%s-4%s-%s%s-%s\n' \
+    "${h:0:8}" "${h:8:4}" "${h:13:3}" "$variant" "${h:17:3}" "${h:20:12}"
+}
+
+_sqlite_sync_valid_binding() {
+  printf '%s\n' "$1" | grep -Eq \
+    '^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' || return 1
+  printf '%s\n' "$2" | grep -Eq \
+    '^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' || return 1
+  case "$3" in ''|*[!0-9]*) return 1 ;; esac
+}
+
+_sqlite_sync_schema() {
+  command -v jq >/dev/null 2>&1 || {
+    echo "agmsg: Stage-1 sync requires jq" >&2
+    return 10
+  }
+  storage_init >/dev/null || return 13
+  local db generation
+  db="$(_sqlite_db)"
+  agmsg_sqlite "$db" "
+    CREATE TABLE IF NOT EXISTS sync_store_metadata (
+      singleton INTEGER PRIMARY KEY CHECK(singleton=1),
+      generation TEXT NOT NULL UNIQUE
+    );
+    CREATE TABLE IF NOT EXISTS sync_bindings (
+      local_team TEXT NOT NULL,
+      server_instance_id TEXT NOT NULL,
+      remote_team_id TEXT NOT NULL,
+      protocol_version INTEGER NOT NULL,
+      driver_generation TEXT NOT NULL,
+      push_cursor INTEGER NOT NULL DEFAULT 0,
+      transport_cursor TEXT NOT NULL DEFAULT '0',
+      PRIMARY KEY(local_team,server_instance_id,remote_team_id,
+                  protocol_version,driver_generation)
+    );
+    CREATE TABLE IF NOT EXISTS sync_messages (
+      local_team TEXT NOT NULL,
+      server_instance_id TEXT NOT NULL,
+      remote_team_id TEXT NOT NULL,
+      protocol_version INTEGER NOT NULL,
+      driver_generation TEXT NOT NULL,
+      local_position INTEGER NOT NULL,
+      local_id TEXT NOT NULL,
+      wire_id TEXT NOT NULL,
+      envelope_v INTEGER NOT NULL,
+      cipher TEXT NOT NULL,
+      key_id TEXT,
+      blob TEXT NOT NULL,
+      server_seq TEXT,
+      direction TEXT NOT NULL CHECK(direction IN ('push','pull')),
+      PRIMARY KEY(local_team,server_instance_id,remote_team_id,
+                  protocol_version,driver_generation,local_position),
+      UNIQUE(server_instance_id,remote_team_id,protocol_version,wire_id)
+    );
+    CREATE TABLE IF NOT EXISTS sync_quarantine (
+      local_team TEXT NOT NULL,
+      server_instance_id TEXT NOT NULL,
+      remote_team_id TEXT NOT NULL,
+      protocol_version INTEGER NOT NULL,
+      driver_generation TEXT NOT NULL,
+      server_seq TEXT NOT NULL,
+      wire_id TEXT NOT NULL,
+      server_received_at TEXT NOT NULL,
+      envelope_v INTEGER NOT NULL,
+      cipher TEXT NOT NULL,
+      key_id TEXT,
+      blob TEXT NOT NULL,
+      status TEXT NOT NULL,
+      policy_revision TEXT,
+      local_security_revision TEXT,
+      reason TEXT,
+      PRIMARY KEY(server_instance_id,remote_team_id,protocol_version,wire_id),
+      UNIQUE(server_instance_id,remote_team_id,protocol_version,server_seq)
+    );
+  " >/dev/null 2>&1 || return 13
+  generation=$(agmsg_sqlite "$db" \
+    "SELECT generation FROM sync_store_metadata WHERE singleton=1;" 2>/dev/null | tr -d '\r')
+  if [ -z "$generation" ]; then
+    generation=$(_sqlite_sync_uuid4) || return 13
+    agmsg_sqlite "$db" "INSERT OR IGNORE INTO sync_store_metadata(singleton,generation)
+      VALUES(1,'$(_sqlite_lit "$generation")');" >/dev/null 2>&1 || return 13
+  fi
+}
+
+_sqlite_sync_generation() {
+  agmsg_sqlite "$(_sqlite_db)" \
+    "SELECT generation FROM sync_store_metadata WHERE singleton=1;" | tr -d '\r'
+}
+
+_sqlite_sync_ensure_binding() {
+  local team="$1" server="$2" remote="$3" protocol="$4" generation="$5"
+  agmsg_sqlite "$(_sqlite_db)" "INSERT OR IGNORE INTO sync_bindings
+    (local_team,server_instance_id,remote_team_id,protocol_version,driver_generation)
+    VALUES('$(_sqlite_lit "$team")','$server','$remote',$protocol,'$generation');" \
+    >/dev/null 2>&1
+}
+
+# Emits sync_state followed by ordered, durable push reservations.
+storage_sync_prepare_push() {
+  local team="$1" server="$2" remote="$3" protocol="$4" limit="$5"
+  _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
+  case "$limit" in ''|*[!0-9]*) return 13 ;; esac
+  [ "$limit" -ge 1 ] && [ "$limit" -le 1000 ] || return 13
+  _sqlite_sync_schema || return $?
+
+  local prepare generation db tl input_ok version cipher key_id max_blob
+  prepare=$(cat)
+  input_ok=$(printf '%s\n' "$prepare" | jq -r \
+    'select(.type=="sync_prepare" and (.envelope_v|type)=="number" and
+            (.cipher|type)=="string" and has("key_id") and
+            (.max_blob_bytes|type)=="number") | "ok"' 2>/dev/null)
+  [ "$input_ok" = ok ] || return 13
+  version=$(printf '%s\n' "$prepare" | jq -r '.envelope_v')
+  cipher=$(printf '%s\n' "$prepare" | jq -r '.cipher')
+  key_id=$(printf '%s\n' "$prepare" | jq -r '.key_id // empty')
+  max_blob=$(printf '%s\n' "$prepare" | jq -r '.max_blob_bytes')
+  # Stage 1 implements the cipher-neutral ABI with the plaintext profile only.
+  [ "$version" = 1 ] && [ "$cipher" = none ] && [ -z "$key_id" ] || return 13
+  case "$max_blob" in ''|*[!0-9]*) return 13 ;; esac
+
+  generation=$(_sqlite_sync_generation) || return 13
+  _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || return 13
+  db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"
+
+  local rows line pos local_id body at created plaintext blob bytes wire
+  rows=$(_sqlite_data "
+    SELECT json_object('local_position',CAST(e.seq AS TEXT),'local_id',e.id,
+                       'body',e.body,'at',e.at,'from_agent',e.from_agent,
+                       'to_agent',e.to_agent)
+      FROM events e
+      JOIN sync_bindings b ON b.local_team='$tl'
+       AND b.server_instance_id='$server' AND b.remote_team_id='$remote'
+       AND b.protocol_version=$protocol AND b.driver_generation='$generation'
+      LEFT JOIN sync_messages m ON m.local_team=b.local_team
+       AND m.server_instance_id=b.server_instance_id
+       AND m.remote_team_id=b.remote_team_id
+       AND m.protocol_version=b.protocol_version
+       AND m.driver_generation=b.driver_generation AND m.local_position=e.seq
+     WHERE e.type='message_sent' AND e.team='$tl' AND e.seq>b.push_cursor
+       AND m.server_seq IS NULL
+     ORDER BY e.seq LIMIT $limit;
+  ") || return 13
+
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    pos=$(printf '%s\n' "$line" | jq -r '.local_position')
+    local_id=$(printf '%s\n' "$line" | jq -r '.local_id')
+    # A reservation already produced by an earlier call is immutable.
+    if [ -n "$(agmsg_sqlite "$db" "SELECT wire_id FROM sync_messages WHERE
+        local_team='$tl' AND server_instance_id='$server' AND remote_team_id='$remote'
+        AND protocol_version=$protocol AND driver_generation='$generation'
+        AND local_position=$pos;" 2>/dev/null)" ]; then
+      continue
+    fi
+    body=$(printf '%s\n' "$line" | jq -r '.body')
+    [ -n "$body" ] || return 13
+    at=$(printf '%s\n' "$line" | jq -r '.at')
+    case "$at" in ????-??-??T??:??:??Z) created="${at%Z}.000000Z" ;; *) created="$at" ;; esac
+    plaintext=$(printf '%s\n' "$line" | jq -c --arg created "$created" \
+      '{body:.body,created_at:$created,from_agent:.from_agent,to_agent:.to_agent}') || return 13
+    bytes=$(LC_ALL=C printf '%s' "$plaintext" | wc -c | tr -d ' ')
+    [ "$bytes" -ge 1 ] && [ "$bytes" -le 1048576 ] && [ "$bytes" -le "$max_blob" ] || return 13
+    blob=$(printf '%s' "$plaintext" | base64 | tr -d '\r\n') || return 13
+    wire=$(_sqlite_sync_uuid4) || return 13
+    # INSERT OR IGNORE makes concurrent prepare calls converge on one winner;
+    # the final SELECT below always emits the committed winner's bytes.
+    agmsg_sqlite "$db" "BEGIN IMMEDIATE;
+      INSERT OR IGNORE INTO sync_messages
+        (local_team,server_instance_id,remote_team_id,protocol_version,
+         driver_generation,local_position,local_id,wire_id,envelope_v,cipher,
+         key_id,blob,direction)
+      VALUES('$tl','$server','$remote',$protocol,'$generation',$pos,
+             '$(_sqlite_lit "$local_id")','$wire',1,'none',NULL,
+             '$(_sqlite_lit "$blob")','push');
+      COMMIT;" >/dev/null 2>&1 || return 13
+  done <<EOF
+$rows
+EOF
+
+  _sqlite_data "SELECT json_object('type','sync_state','driver_generation',
+      '$generation','transport_cursor',transport_cursor)
+    FROM sync_bindings WHERE local_team='$tl' AND server_instance_id='$server'
+      AND remote_team_id='$remote' AND protocol_version=$protocol
+      AND driver_generation='$generation';
+    SELECT json_object('type','sync_push_candidate','local_position',
+      CAST(m.local_position AS TEXT),'local_id',m.local_id,'id',m.wire_id,
+      'envelope',json_object('v',m.envelope_v,'cipher',m.cipher,
+                             'key_id',m.key_id,'blob',m.blob))
+    FROM sync_messages m JOIN sync_bindings b
+      ON b.local_team=m.local_team AND b.server_instance_id=m.server_instance_id
+     AND b.remote_team_id=m.remote_team_id AND b.protocol_version=m.protocol_version
+     AND b.driver_generation=m.driver_generation
+    WHERE m.local_team='$tl' AND m.server_instance_id='$server'
+      AND m.remote_team_id='$remote' AND m.protocol_version=$protocol
+      AND m.driver_generation='$generation' AND m.local_position>b.push_cursor
+      AND m.server_seq IS NULL ORDER BY m.local_position LIMIT $limit;"
+}
+
+# Reads complete server acknowledgements and advances only the contiguous prefix.
+storage_sync_reconcile_push() {
+  local team="$1" server="$2" remote="$3" protocol="$4"
+  _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
+  _sqlite_sync_schema || return $?
+  local generation db tl line values="" pos wire seq disposition count=0
+  generation=$(_sqlite_sync_generation); db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    [ "$(printf '%s\n' "$line" | jq -r '.type // empty')" = sync_push_ack ] || return 13
+    pos=$(printf '%s\n' "$line" | jq -r '.local_position // empty')
+    wire=$(printf '%s\n' "$line" | jq -r '.id // empty')
+    seq=$(printf '%s\n' "$line" | jq -r '.server_seq // empty')
+    disposition=$(printf '%s\n' "$line" | jq -r '.disposition // empty')
+    case "$pos:$seq" in *[!0-9:]*) return 13 ;; esac
+    case "$disposition" in stored|duplicate) ;; *) return 13 ;; esac
+    printf '%s' "$wire" | grep -Eq '^[0-9a-f-]{36}$' || return 13
+    values="${values}${values:+,}($pos,'$wire','$seq')"; count=$((count + 1))
+  done
+  [ "$count" -gt 0 ] || return 13
+
+  agmsg_sqlite "$db" "BEGIN IMMEDIATE;
+    CREATE TEMP TABLE incoming_sync_acks(local_position INTEGER,wire_id TEXT,server_seq TEXT);
+    INSERT INTO incoming_sync_acks VALUES $values;
+    CREATE TEMP TABLE sync_assert(ok INTEGER CHECK(ok=1));
+    INSERT INTO sync_assert SELECT CASE WHEN COUNT(*)=$count THEN 1 ELSE 0 END
+      FROM incoming_sync_acks a JOIN sync_messages m
+        ON m.local_team='$tl' AND m.server_instance_id='$server'
+       AND m.remote_team_id='$remote' AND m.protocol_version=$protocol
+       AND m.driver_generation='$generation' AND m.local_position=a.local_position
+       AND m.wire_id=a.wire_id
+       AND (m.server_seq IS NULL OR m.server_seq=a.server_seq);
+    UPDATE sync_messages SET server_seq=(SELECT a.server_seq FROM incoming_sync_acks a
+      WHERE a.local_position=sync_messages.local_position AND a.wire_id=sync_messages.wire_id)
+      WHERE local_team='$tl' AND server_instance_id='$server' AND remote_team_id='$remote'
+        AND protocol_version=$protocol AND driver_generation='$generation'
+        AND EXISTS(SELECT 1 FROM incoming_sync_acks a
+          WHERE a.local_position=sync_messages.local_position AND a.wire_id=sync_messages.wire_id);
+    UPDATE sync_bindings AS b SET push_cursor=COALESCE((
+      SELECT MAX(e.seq) FROM events e
+      WHERE e.type='message_sent' AND e.team='$tl' AND e.seq>b.push_cursor
+        AND NOT EXISTS (
+          SELECT 1 FROM events gap LEFT JOIN sync_messages gm
+            ON gm.local_team='$tl' AND gm.server_instance_id='$server'
+           AND gm.remote_team_id='$remote' AND gm.protocol_version=$protocol
+           AND gm.driver_generation='$generation' AND gm.local_position=gap.seq
+          WHERE gap.type='message_sent' AND gap.team='$tl'
+            AND gap.seq>b.push_cursor AND gap.seq<=e.seq AND gm.server_seq IS NULL
+        )),b.push_cursor)
+    WHERE b.local_team='$tl' AND b.server_instance_id='$server'
+      AND b.remote_team_id='$remote' AND b.protocol_version=$protocol
+      AND b.driver_generation='$generation';
+    COMMIT;" >/dev/null 2>&1 || return 12
+
+  _sqlite_data "SELECT json_object('type','sync_reconcile_result','push_cursor',
+    CAST(push_cursor AS TEXT)) FROM sync_bindings WHERE local_team='$tl'
+    AND server_instance_id='$server' AND remote_team_id='$remote'
+    AND protocol_version=$protocol AND driver_generation='$generation';"
+}
+
+# Reads a validated pull page, durably quarantines/reconciles/imports it, then
+# advances the transport cursor in the same transaction.
+storage_sync_apply_pull() {
+  local team="$1" server="$2" remote="$3" protocol="$4"
+  _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
+  _sqlite_sync_schema || return $?
+  local generation db tl sql_file line type final_cursor="" corrupt=0
+  local seq wire received v cipher key_id blob status policy local_rev reason
+  local from to body at local_id q
+  generation=$(_sqlite_sync_generation); db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"
+  _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || return 13
+  sql_file=$(mktemp "${TMPDIR:-/tmp}/agmsg-sync-sql.XXXXXX") || return 13
+  printf '%s\n' 'BEGIN IMMEDIATE;' > "$sql_file"
+
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    type=$(printf '%s\n' "$line" | jq -r '.type // empty')
+    if [ "$type" = sync_pull_cursor ]; then
+      final_cursor=$(printf '%s\n' "$line" | jq -r '.next_after // empty')
+      case "$final_cursor" in ''|*[!0-9]*) rm -f "$sql_file"; return 13 ;; esac
+      continue
+    fi
+    [ "$type" = sync_pull_message ] || { rm -f "$sql_file"; return 13; }
+    seq=$(printf '%s\n' "$line" | jq -r '.server_seq // empty')
+    wire=$(printf '%s\n' "$line" | jq -r '.id // empty')
+    received=$(printf '%s\n' "$line" | jq -r '.server_received_at // empty')
+    v=$(printf '%s\n' "$line" | jq -r '.envelope.v')
+    cipher=$(printf '%s\n' "$line" | jq -r '.envelope.cipher')
+    key_id=$(printf '%s\n' "$line" | jq -r '.envelope.key_id // empty')
+    blob=$(printf '%s\n' "$line" | jq -r '.envelope.blob')
+    status=$(printf '%s\n' "$line" | jq -r '.status')
+    policy=$(printf '%s\n' "$line" | jq -r '.policy_revision // empty')
+    local_rev=$(printf '%s\n' "$line" | jq -r '.local_security_revision // empty')
+    reason=$(printf '%s\n' "$line" | jq -r '.reason // empty')
+    case "$seq:$v" in *[!0-9:]*) rm -f "$sql_file"; return 13 ;; esac
+    case "$status" in importable|unsupported_cipher|pending_key|authentication_failed|malformed|policy_violation) ;; *) rm -f "$sql_file"; return 13 ;; esac
+    q="'$(_sqlite_lit "$key_id")'"; [ -n "$key_id" ] || q=NULL
+    printf "%s\n" "
+      INSERT OR IGNORE INTO sync_quarantine
+        (local_team,server_instance_id,remote_team_id,protocol_version,
+         driver_generation,server_seq,wire_id,server_received_at,envelope_v,
+         cipher,key_id,blob,status,policy_revision,local_security_revision,reason)
+      VALUES('$tl','$server','$remote',$protocol,'$generation','$seq','$wire',
+        '$(_sqlite_lit "$received")',$v,'$(_sqlite_lit "$cipher")',$q,
+        '$(_sqlite_lit "$blob")','$status','$(_sqlite_lit "$policy")',
+        '$(_sqlite_lit "$local_rev")','$(_sqlite_lit "$reason")');
+      UPDATE sync_quarantine SET status='corrupt_state',reason='wire envelope mismatch'
+       WHERE server_instance_id='$server' AND remote_team_id='$remote'
+         AND protocol_version=$protocol AND wire_id='$wire'
+         AND (server_seq<>'$seq' OR envelope_v<>$v OR cipher<>'$(_sqlite_lit "$cipher")'
+              OR COALESCE(key_id,'')<>'$(_sqlite_lit "$key_id")'
+              OR blob<>'$(_sqlite_lit "$blob")');
+      UPDATE sync_quarantine SET status='corrupt_state',reason='mapped envelope mismatch'
+       WHERE server_instance_id='$server' AND remote_team_id='$remote'
+         AND protocol_version=$protocol AND wire_id='$wire' AND EXISTS(
+           SELECT 1 FROM sync_messages m WHERE m.server_instance_id='$server'
+             AND m.remote_team_id='$remote' AND m.protocol_version=$protocol
+             AND m.wire_id='$wire' AND (m.envelope_v<>$v OR m.cipher<>'$(_sqlite_lit "$cipher")'
+               OR COALESCE(m.key_id,'')<>'$(_sqlite_lit "$key_id")'
+               OR m.blob<>'$(_sqlite_lit "$blob")'
+               OR (m.server_seq IS NOT NULL AND m.server_seq<>'$seq')));
+      UPDATE sync_messages SET server_seq='$seq' WHERE server_instance_id='$server'
+        AND remote_team_id='$remote' AND protocol_version=$protocol AND wire_id='$wire'
+        AND envelope_v=$v AND cipher='$(_sqlite_lit "$cipher")'
+        AND COALESCE(key_id,'')='$(_sqlite_lit "$key_id")'
+        AND blob='$(_sqlite_lit "$blob")' AND (server_seq IS NULL OR server_seq='$seq');
+      UPDATE sync_quarantine SET status='reconciled' WHERE server_instance_id='$server'
+        AND remote_team_id='$remote' AND protocol_version=$protocol AND wire_id='$wire'
+        AND status<>'corrupt_state' AND EXISTS(SELECT 1 FROM sync_messages m
+          WHERE m.server_instance_id='$server' AND m.remote_team_id='$remote'
+            AND m.protocol_version=$protocol AND m.wire_id='$wire' AND m.server_seq='$seq');" >> "$sql_file"
+
+    if [ "$status" = importable ]; then
+      from=$(printf '%s\n' "$line" | jq -r '.projection.from_agent // empty')
+      to=$(printf '%s\n' "$line" | jq -r '.projection.to_agent // empty')
+      body=$(printf '%s\n' "$line" | jq -r '.projection.body // empty')
+      at=$(printf '%s\n' "$line" | jq -r '.projection.created_at // empty')
+      [ -n "$from" ] && [ -n "$to" ] && [ -n "$body" ] && [ -n "$at" ] || { rm -f "$sql_file"; return 13; }
+      local_id=$(_sqlite_uuid7) || { rm -f "$sql_file"; return 13; }
+      printf "%s\n" "
+        INSERT INTO events(type,id,team,from_agent,to_agent,body,at)
+        SELECT 'message_sent','$local_id','$tl','$(_sqlite_lit "$from")',
+               '$(_sqlite_lit "$to")','$(_sqlite_lit "$body")','$(_sqlite_lit "$at")'
+        WHERE NOT EXISTS(SELECT 1 FROM sync_messages m
+          WHERE m.server_instance_id='$server' AND m.remote_team_id='$remote'
+            AND m.protocol_version=$protocol AND m.wire_id='$wire')
+          AND NOT EXISTS(SELECT 1 FROM sync_quarantine qx
+          WHERE qx.server_instance_id='$server' AND qx.remote_team_id='$remote'
+            AND qx.protocol_version=$protocol AND qx.wire_id='$wire'
+            AND qx.status='corrupt_state');
+        INSERT OR IGNORE INTO sync_messages
+          (local_team,server_instance_id,remote_team_id,protocol_version,
+           driver_generation,local_position,local_id,wire_id,envelope_v,cipher,
+           key_id,blob,server_seq,direction)
+        SELECT '$tl','$server','$remote',$protocol,'$generation',seq,id,'$wire',$v,
+               '$(_sqlite_lit "$cipher")',$q,'$(_sqlite_lit "$blob")','$seq','pull'
+          FROM events WHERE id='$local_id';
+        UPDATE sync_quarantine SET status='imported' WHERE server_instance_id='$server'
+          AND remote_team_id='$remote' AND protocol_version=$protocol AND wire_id='$wire'
+          AND status<>'corrupt_state' AND EXISTS(SELECT 1 FROM sync_messages m
+            WHERE m.server_instance_id='$server' AND m.remote_team_id='$remote'
+              AND m.protocol_version=$protocol AND m.wire_id='$wire'
+              AND m.direction='pull');" >> "$sql_file"
+    fi
+  done
+  [ -n "$final_cursor" ] || { rm -f "$sql_file"; return 13; }
+  printf "%s\n" "UPDATE sync_bindings SET transport_cursor='$final_cursor'
+    WHERE local_team='$tl' AND server_instance_id='$server' AND remote_team_id='$remote'
+      AND protocol_version=$protocol AND driver_generation='$generation';
+    COMMIT;" >> "$sql_file"
+  if ! agmsg_sqlite "$db" < "$sql_file" >/dev/null 2>&1; then
+    rm -f "$sql_file"; return 13
+  fi
+  rm -f "$sql_file"
+  corrupt=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_quarantine WHERE
+    server_instance_id='$server' AND remote_team_id='$remote' AND protocol_version=$protocol
+    AND status='corrupt_state';" | tr -d '\r')
+  _sqlite_data "SELECT json_object('type','sync_apply_result','transport_cursor',
+    transport_cursor,'corrupt_count',$corrupt) FROM sync_bindings
+    WHERE local_team='$tl' AND server_instance_id='$server' AND remote_team_id='$remote'
+      AND protocol_version=$protocol AND driver_generation='$generation';"
+}

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -343,7 +343,11 @@ storage_sync_apply_pull() {
       WHERE EXISTS(SELECT 1 FROM sync_quarantine qx
         WHERE qx.server_instance_id='$server' AND qx.remote_team_id='$remote'
           AND qx.protocol_version=$protocol AND qx.server_seq='$seq'
-          AND qx.wire_id<>'$wire');
+          AND qx.wire_id<>'$wire')
+         OR EXISTS(SELECT 1 FROM sync_messages mx
+        WHERE mx.server_instance_id='$server' AND mx.remote_team_id='$remote'
+          AND mx.protocol_version=$protocol AND mx.server_seq='$seq'
+          AND mx.wire_id<>'$wire');
       INSERT OR IGNORE INTO sync_conflicts
         (local_team,server_instance_id,remote_team_id,protocol_version,
          driver_generation,server_seq,wire_id,envelope_v,cipher,key_id,blob,
@@ -358,7 +362,14 @@ storage_sync_apply_pull() {
           AND (qx.server_seq<>'$seq' OR qx.envelope_v<>$v
             OR qx.cipher<>'$(_sqlite_lit "$cipher")'
             OR COALESCE(qx.key_id,'')<>'$(_sqlite_lit "$key_id")'
-            OR qx.blob<>'$(_sqlite_lit "$blob")'));
+            OR qx.blob<>'$(_sqlite_lit "$blob")'))
+         OR EXISTS(SELECT 1 FROM sync_messages mx
+        WHERE mx.server_instance_id='$server' AND mx.remote_team_id='$remote'
+          AND mx.protocol_version=$protocol AND mx.wire_id='$wire'
+          AND (mx.server_seq IS NOT NULL AND mx.server_seq<>'$seq'
+            OR mx.envelope_v<>$v OR mx.cipher<>'$(_sqlite_lit "$cipher")'
+            OR COALESCE(mx.key_id,'')<>'$(_sqlite_lit "$key_id")'
+            OR mx.blob<>'$(_sqlite_lit "$blob")'));
       INSERT OR IGNORE INTO sync_quarantine
         (local_team,server_instance_id,remote_team_id,protocol_version,
          driver_generation,server_seq,wire_id,server_received_at,envelope_v,
@@ -373,6 +384,12 @@ storage_sync_apply_pull() {
          AND (server_seq<>'$seq' OR envelope_v<>$v OR cipher<>'$(_sqlite_lit "$cipher")'
               OR COALESCE(key_id,'')<>'$(_sqlite_lit "$key_id")'
               OR blob<>'$(_sqlite_lit "$blob")');
+      UPDATE sync_quarantine SET status='corrupt_state',reason='binding sequence conflict'
+       WHERE server_instance_id='$server' AND remote_team_id='$remote'
+         AND protocol_version=$protocol AND wire_id='$wire'
+         AND EXISTS(SELECT 1 FROM sync_conflicts cx
+           WHERE cx.server_instance_id='$server' AND cx.remote_team_id='$remote'
+             AND cx.protocol_version=$protocol AND cx.wire_id='$wire');
       UPDATE sync_quarantine SET status='corrupt_state',reason='mapped envelope mismatch'
        WHERE server_instance_id='$server' AND remote_team_id='$remote'
          AND protocol_version=$protocol AND wire_id='$wire' AND EXISTS(

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -24,9 +24,11 @@ _sqlite_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
 
 # Run a record-returning query: strip CR but PRESERVE the sqlite exit status
 # (pipefail), so a backend failure surfaces as a non-zero return instead of
-# being swallowed by tr's exit 0 (§2.1 stdout framing / co1 review).
+# being swallowed by tr's exit 0. The backend's error text goes to stderr (a
+# separate fd — it never pollutes the JSONL on stdout) so failures are
+# debuggable, per §2.1 framing (#203 (1) / co1 review).
 _sqlite_data() {
-  ( set -o pipefail; agmsg_sqlite "$(_sqlite_db)" "$1" 2>/dev/null | tr -d '\r' )
+  ( set -o pipefail; agmsg_sqlite "$(_sqlite_db)" "$1" | tr -d '\r' )
 }
 
 # UUIDv7: 48-bit ms timestamp + version/variant + random. python3 preferred;
@@ -137,12 +139,13 @@ storage_list_unread() {
   shift 2
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
+  storage_init >/dev/null
   local tl al; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
   _sqlite_data "
     SELECT j FROM (
       SELECT json_object('type','message_sent','id',e.id,'team',e.team,
                'from',e.from_agent,'to',e.to_agent,'body',e.body,'at',e.at) AS j,
-             1 AS src, e.seq AS ord
+             e.at AS ts, 1 AS src, e.seq AS ord
       FROM events e
       WHERE e.type='message_sent' AND e.team='$tl' AND e.to_agent='$al'
         AND NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
@@ -150,13 +153,13 @@ storage_list_unread() {
       UNION ALL
       SELECT json_object('type','message_sent','id',CAST(m.id AS TEXT),'team',m.team,
                'from',m.from_agent,'to',m.to_agent,'body',m.body,'at',m.created_at) AS j,
-             0 AS src, m.id AS ord
+             m.created_at AS ts, 0 AS src, m.id AS ord
       FROM messages m
       WHERE m.team='$tl' AND m.to_agent='$al' AND m.read_at IS NULL
         AND NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
                         AND r.team=m.team AND r.agent='$al' AND r.msg_id=CAST(m.id AS TEXT))
     )
-    ORDER BY src, ord ${limit:+LIMIT $limit};
+    ORDER BY ts, src, ord ${limit:+LIMIT $limit};
   "
 }
 
@@ -212,21 +215,22 @@ storage_history() {
   shift 2
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
+  storage_init >/dev/null
   local tl al; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
   _sqlite_data "
     SELECT j FROM (
       SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
-               'to',to_agent,'body',body,'at',at) AS j, 1 AS src, seq AS ord
+               'to',to_agent,'body',body,'at',at) AS j, at AS ts, 1 AS src, seq AS ord
       FROM events
       WHERE type='message_sent' AND team='$tl' AND (to_agent='$al' OR from_agent='$al')
       UNION ALL
       SELECT json_object('type','message_sent','id',CAST(id AS TEXT),'team',team,
                'from',from_agent,'to',to_agent,'body',body,'at',created_at) AS j,
-             0 AS src, id AS ord
+             created_at AS ts, 0 AS src, id AS ord
       FROM messages
       WHERE team='$tl' AND (to_agent='$al' OR from_agent='$al')
     )
-    ORDER BY src, ord ${limit:+LIMIT $limit};
+    ORDER BY ts, src, ord ${limit:+LIMIT $limit};
   "
 }
 

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -122,13 +122,21 @@ storage_init() {
 storage_send() {
   local team="$1" from="$2" to="$3" body="$4"
   local id at db; id="$(_sqlite_uuid7)"; at="$(_sqlite_now)"; db="$(_sqlite_db)"
-  storage_init >/dev/null
-  agmsg_sqlite "$db" "
+  local insert="
     INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
     VALUES ('message_sent','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
             '$(_sqlite_lit "$from")','$(_sqlite_lit "$to")','$(_sqlite_lit "$body")',
             '$(_sqlite_lit "$at")');
-  " >/dev/null 2>&1 || return 1
+  "
+  # Try the INSERT first and only fall back to storage_init on failure (the #114
+  # pattern). Running storage_init — which issues PRAGMA journal_mode=WAL and the
+  # CREATE TABLE/INDEX statements — on EVERY send serializes badly under a
+  # concurrent first-write fan-out and lost rows past the busy_timeout. The common
+  # path is now a single INSERT; only a missing table pays the init + retry.
+  if ! agmsg_sqlite "$db" "$insert" >/dev/null 2>&1; then
+    storage_init >/dev/null
+    agmsg_sqlite "$db" "$insert" >/dev/null 2>&1 || return 1
+  fi
   printf '%s\n' "$id"
 }
 
@@ -203,7 +211,13 @@ storage_watch_after() {
   local cursor="$1"; shift
   case "$cursor" in ''|*[!0-9]*) cursor=0 ;; esac
   local pairs; pairs="$(_sqlite_pair_in "$@")"
+  # The message scan and the trailing-cursor (high-water) read MUST observe the
+  # same snapshot, or a row inserted between the two statements would advance the
+  # cursor past a message the scan never returned — a silent skip. A deferred read
+  # transaction pins one WAL snapshot across both SELECTs, so the emitted cursor
+  # never runs ahead of what the scan saw (§2.2 "never skip").
   _sqlite_data "
+    BEGIN;
     SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
                        'to',to_agent,'body',body,'at',at)
     FROM events
@@ -212,6 +226,7 @@ storage_watch_after() {
     ORDER BY seq ASC;
     SELECT json_object('type','cursor','cursor',
                        CAST(MAX($cursor, $(_sqlite_highwater)) AS TEXT));
+    COMMIT;
   "
 }
 

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -217,28 +217,41 @@ storage_watch_after() {
 
 # --- contract: history -----------------------------------------------------
 
-# storage_history <team> <agent> [--limit N]  — events ∪ legacy, agent involved.
+# storage_history <team> [agent] [--limit N]  — events ∪ legacy in time order.
+# With <agent>, only rows where that agent is sender or recipient; omit it (empty)
+# for the whole team (§2.1 G3 — an additive widening, existing callers unchanged).
 storage_history() {
   local team="$1" agent="$2" limit=""
   shift 2
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
   storage_init >/dev/null
-  local tl al; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  local tl al afilter; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  if [ -n "$agent" ]; then
+    afilter="AND (to_agent='$al' OR from_agent='$al')"
+  else
+    afilter=""
+  fi
+  # --limit returns the most RECENT N (inner DESC + LIMIT), re-sorted to
+  # chronological order for output — the intuitive "recent history" semantics,
+  # not the oldest N.
   _sqlite_data "
     SELECT j FROM (
-      SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
-               'to',to_agent,'body',body,'at',at) AS j, at AS ts, 1 AS src, seq AS ord
-      FROM events
-      WHERE type='message_sent' AND team='$tl' AND (to_agent='$al' OR from_agent='$al')
-      UNION ALL
-      SELECT json_object('type','message_sent','id',CAST(id AS TEXT),'team',team,
-               'from',from_agent,'to',to_agent,'body',body,'at',created_at) AS j,
-             created_at AS ts, 0 AS src, id AS ord
-      FROM messages
-      WHERE team='$tl' AND (to_agent='$al' OR from_agent='$al')
+      SELECT j, ts, src, ord FROM (
+        SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
+                 'to',to_agent,'body',body,'at',at) AS j, at AS ts, 1 AS src, seq AS ord
+        FROM events
+        WHERE type='message_sent' AND team='$tl' $afilter
+        UNION ALL
+        SELECT json_object('type','message_sent','id',CAST(id AS TEXT),'team',team,
+                 'from',from_agent,'to',to_agent,'body',body,'at',created_at) AS j,
+               created_at AS ts, 0 AS src, id AS ord
+        FROM messages
+        WHERE team='$tl' $afilter
+      )
+      ORDER BY ts DESC, src DESC, ord DESC ${limit:+LIMIT $limit}
     )
-    ORDER BY ts, src, ord ${limit:+LIMIT $limit};
+    ORDER BY ts ASC, src ASC, ord ASC;
   "
 }
 

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -185,9 +185,18 @@ storage_mark_read_batch() {
 
 # --- contract: delivery cursor ---------------------------------------------
 
+# The delivery tip is the monotonic AUTOINCREMENT high-water (largest rowid ever
+# assigned to `events`), read from sqlite_sequence — NOT MAX(seq) over live rows.
+# A DELETE-based storage_compact can lower MAX(seq) (e.g. by coalescing the
+# tail message_read) but never the high-water, so a cursor issued before a
+# compaction stays valid and a fresh tip never moves backwards (§2.7 cursor-safe).
+_sqlite_highwater() {
+  printf "COALESCE((SELECT seq FROM sqlite_sequence WHERE name='events'),0)"
+}
+
 storage_watch_tip() {
   storage_init >/dev/null
-  _sqlite_data "SELECT COALESCE(MAX(seq),0) FROM events;"
+  _sqlite_data "SELECT $(_sqlite_highwater);"
 }
 
 storage_watch_after() {
@@ -202,8 +211,7 @@ storage_watch_after() {
       AND (team || ':' || to_agent) IN ($pairs)
     ORDER BY seq ASC;
     SELECT json_object('type','cursor','cursor',
-                       CAST(COALESCE(MAX(seq), $cursor) AS TEXT))
-    FROM events;
+                       CAST(MAX($cursor, $(_sqlite_highwater)) AS TEXT));
   "
 }
 

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -83,6 +83,10 @@ storage_describe() {
   printf 'db=%s\n' "$(_sqlite_db)"
 }
 
+# Does a store already exist? (does NOT create one — lets a read call-site answer
+# "no messages yet" without lazily initializing a store in a storeless project.)
+storage_store_exists() { [ -f "$(_sqlite_db)" ]; }
+
 storage_init() {
   local db; db="$(_sqlite_db)"
   mkdir -p "$(dirname "$db")" 2>/dev/null || true

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -5,15 +5,29 @@
 # over SQLite. Sourced by the storage facade (lib/storage.sh, agmsg_storage_load),
 # so agmsg_db_path / agmsg_sqlite / agmsg_sql_readfile_path from storage.sh are in
 # scope. State is an append-only `events` log (canonical JSONL: message_sent /
-# message_read); the legacy `messages` table is read for back-compat (§2.4).
+# message_read). The legacy `messages` table is read **read-only** and UNIONed
+# into list_unread / history so an existing store keeps its inbox and history
+# after #206 switches call sites onto the contract (§2.4); legacy rows are never
+# migrated or mutated here.
 #
-# The delivery cursor (§2.2) is the events.seq autoincrement, returned to core as
-# an opaque decimal string — core never parses it. Read-marking is recipient-
-# scoped ((team, agent)) and idempotent.
+# Framing (§1.4 / ADR 0003): record-returning ops write data only to stdout and
+# fail with a non-zero exit; control ops (check/init/mark_read_batch/compact)
+# print a §1.4 status name on stdout. The delivery cursor (§2.2) is the events.seq
+# autoincrement, returned as an opaque decimal string. Read-marking is
+# recipient-scoped ((team, agent)) and idempotent.
 
 # --- helpers ---------------------------------------------------------------
 
 _sqlite_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+_sqlite_db() { agmsg_db_path; }
+_sqlite_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+# Run a record-returning query: strip CR but PRESERVE the sqlite exit status
+# (pipefail), so a backend failure surfaces as a non-zero return instead of
+# being swallowed by tr's exit 0 (§2.1 stdout framing / co1 review).
+_sqlite_data() {
+  ( set -o pipefail; agmsg_sqlite "$(_sqlite_db)" "$1" 2>/dev/null | tr -d '\r' )
+}
 
 # UUIDv7: 48-bit ms timestamp + version/variant + random. python3 preferred;
 # fall back to a /dev/urandom shell build. No counter file (§2.5).
@@ -33,22 +47,15 @@ print(f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}")
 PY
     return
   fi
-  # Shell fallback: 48-bit ms hex from epoch + 80 random bits from urandom.
   local ms hex rnd
   ms=$(( $(date -u +%s) * 1000 ))
   hex=$(printf '%012x' "$ms")
   rnd=$(head -c 10 /dev/urandom | od -An -tx1 | tr -d ' \n')
-  printf '%s-%s-7%s-%s%s-%s\n' \
-    "${hex:0:8}" "${hex:8:4}" "${rnd:0:3}" \
-    "8" "${rnd:3:3}" "${rnd:6:12}"
+  printf '%s-%s-7%s-8%s-%s\n' \
+    "${hex:0:8}" "${hex:8:4}" "${rnd:0:3}" "${rnd:3:3}" "${rnd:6:12}"
 }
 
-_sqlite_db() { agmsg_db_path; }
-
-# Build a SQL string literal (single-quote escaped) from $1.
-_sqlite_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
-
-# Build an "IN (...)" list of team||':'||agent pairs from "<team>:<agent>" args.
+# IN (...) list of "team:agent" pairs.
 _sqlite_pair_in() {
   local out="" p t a
   for p in "$@"; do
@@ -58,11 +65,14 @@ _sqlite_pair_in() {
   printf '%s' "${out:-''}"
 }
 
-# --- contract: lifecycle ---------------------------------------------------
+# --- contract: lifecycle (control ops, §1.4 status on stdout) ---------------
 
 storage_check() {
-  command -v sqlite3 >/dev/null 2>&1 || { echo "missing_deps: sqlite3 not found" >&2; return 3; }
-  echo "ok"
+  if ! command -v sqlite3 >/dev/null 2>&1; then
+    echo missing_deps
+    return 10
+  fi
+  echo ok
 }
 
 storage_describe() {
@@ -90,7 +100,19 @@ storage_init() {
     );
     CREATE INDEX IF NOT EXISTS events_sent ON events(type, team, to_agent, seq);
     CREATE INDEX IF NOT EXISTS events_read ON events(type, team, agent, msg_id);
-  " >/dev/null 2>&1
+    -- Legacy store (read-only here). Created so the UNION queries always parse
+    -- even on a brand-new install with no pre-event-log data.
+    CREATE TABLE IF NOT EXISTS messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      team TEXT NOT NULL,
+      from_agent TEXT NOT NULL,
+      to_agent TEXT NOT NULL,
+      body TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+      read_at TEXT
+    );
+  " >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  echo ok
 }
 
 # --- contract: messages ----------------------------------------------------
@@ -98,7 +120,7 @@ storage_init() {
 storage_send() {
   local team="$1" from="$2" to="$3" body="$4"
   local id at db; id="$(_sqlite_uuid7)"; at="$(_sqlite_now)"; db="$(_sqlite_db)"
-  storage_init
+  storage_init >/dev/null
   agmsg_sqlite "$db" "
     INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
     VALUES ('message_sent','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
@@ -109,61 +131,67 @@ storage_send() {
 }
 
 # storage_list_unread <team> <agent> [--limit N]
+# events-unread ∪ legacy-unread (read_at IS NULL, not superseded by a read event).
 storage_list_unread() {
   local team="$1" agent="$2" limit=""
   shift 2
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
-  local db; db="$(_sqlite_db)"
   local tl al; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
-  agmsg_sqlite "$db" "
-    SELECT json_object('id',e.id,'team',e.team,'from',e.from_agent,
-                       'to',e.to_agent,'body',e.body,'at',e.at)
-    FROM events e
-    WHERE e.type='message_sent' AND e.team='$tl' AND e.to_agent='$al'
-      AND NOT EXISTS (
-        SELECT 1 FROM events r
-        WHERE r.type='message_read' AND r.team=e.team
-          AND r.agent='$al' AND r.msg_id=e.id)
-    ORDER BY e.seq ASC ${limit:+LIMIT $limit};
-  " 2>/dev/null | tr -d '\r'
+  _sqlite_data "
+    SELECT j FROM (
+      SELECT json_object('type','message_sent','id',e.id,'team',e.team,
+               'from',e.from_agent,'to',e.to_agent,'body',e.body,'at',e.at) AS j,
+             1 AS src, e.seq AS ord
+      FROM events e
+      WHERE e.type='message_sent' AND e.team='$tl' AND e.to_agent='$al'
+        AND NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
+                        AND r.team=e.team AND r.agent='$al' AND r.msg_id=e.id)
+      UNION ALL
+      SELECT json_object('type','message_sent','id',CAST(m.id AS TEXT),'team',m.team,
+               'from',m.from_agent,'to',m.to_agent,'body',m.body,'at',m.created_at) AS j,
+             0 AS src, m.id AS ord
+      FROM messages m
+      WHERE m.team='$tl' AND m.to_agent='$al' AND m.read_at IS NULL
+        AND NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
+                        AND r.team=m.team AND r.agent='$al' AND r.msg_id=CAST(m.id AS TEXT))
+    )
+    ORDER BY src, ord ${limit:+LIMIT $limit};
+  "
 }
 
-# storage_mark_read_batch <team> <agent> <id> [<id> ...]
+# storage_mark_read_batch <team> <agent> <id> [<id> ...]  (control op)
 storage_mark_read_batch() {
   local team="$1" agent="$2"; shift 2
-  [ $# -gt 0 ] || return 0
+  [ $# -gt 0 ] || { echo ok; return 0; }
   local db at tl al; db="$(_sqlite_db)"; at="$(_sqlite_now)"
   tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
-  storage_init
+  storage_init >/dev/null
   local id sql=""
   for id in "$@"; do
     local idl rid; idl="$(_sqlite_lit "$id")"; rid="$(_sqlite_uuid7)"
-    # Idempotent: only insert a message_read if this recipient hasn't read it.
     sql="$sql
     INSERT INTO events (type,id,team,agent,msg_id,at)
     SELECT 'message_read','$(_sqlite_lit "$rid")','$tl','$al','$idl','$(_sqlite_lit "$at")'
     WHERE NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
                       AND r.team='$tl' AND r.agent='$al' AND r.msg_id='$idl');"
   done
-  agmsg_sqlite "$db" "$sql" >/dev/null 2>&1
+  agmsg_sqlite "$db" "$sql" >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  echo ok
 }
 
 # --- contract: delivery cursor ---------------------------------------------
 
-# storage_watch_tip <team:agent> ... -> opaque cursor for "now"
 storage_watch_tip() {
-  local db; db="$(_sqlite_db)"
-  storage_init
-  agmsg_sqlite "$db" "SELECT COALESCE(MAX(seq),0) FROM events;" 2>/dev/null | tr -d '\r'
+  storage_init >/dev/null
+  _sqlite_data "SELECT COALESCE(MAX(seq),0) FROM events;"
 }
 
-# storage_watch_after <cursor> <team:agent> ... -> JSONL message_sent + cursor record
 storage_watch_after() {
   local cursor="$1"; shift
   case "$cursor" in ''|*[!0-9]*) cursor=0 ;; esac
-  local db pairs; db="$(_sqlite_db)"; pairs="$(_sqlite_pair_in "$@")"
-  agmsg_sqlite "$db" "
+  local pairs; pairs="$(_sqlite_pair_in "$@")"
+  _sqlite_data "
     SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
                        'to',to_agent,'body',body,'at',at)
     FROM events
@@ -173,34 +201,41 @@ storage_watch_after() {
     SELECT json_object('type','cursor','cursor',
                        CAST(COALESCE(MAX(seq), $cursor) AS TEXT))
     FROM events;
-  " 2>/dev/null | tr -d '\r'
+  "
 }
 
 # --- contract: history -----------------------------------------------------
 
-# storage_history <team> <agent> [--limit N]
+# storage_history <team> <agent> [--limit N]  — events ∪ legacy, agent involved.
 storage_history() {
   local team="$1" agent="$2" limit=""
   shift 2
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
-  local db tl al; db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
-  agmsg_sqlite "$db" "
-    SELECT json_object('id',id,'team',team,'from',from_agent,'to',to_agent,
-                       'body',body,'at',at)
-    FROM events
-    WHERE type='message_sent' AND team='$tl'
-      AND (to_agent='$al' OR from_agent='$al')
-    ORDER BY seq ASC ${limit:+LIMIT $limit};
-  " 2>/dev/null | tr -d '\r'
+  local tl al; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  _sqlite_data "
+    SELECT j FROM (
+      SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
+               'to',to_agent,'body',body,'at',at) AS j, 1 AS src, seq AS ord
+      FROM events
+      WHERE type='message_sent' AND team='$tl' AND (to_agent='$al' OR from_agent='$al')
+      UNION ALL
+      SELECT json_object('type','message_sent','id',CAST(id AS TEXT),'team',team,
+               'from',from_agent,'to',to_agent,'body',body,'at',created_at) AS j,
+             0 AS src, id AS ord
+      FROM messages
+      WHERE team='$tl' AND (to_agent='$al' OR from_agent='$al')
+    )
+    ORDER BY src, ord ${limit:+LIMIT $limit};
+  "
 }
 
 # --- contract: export / import / compact -----------------------------------
 
 storage_export() {
-  local file="$1" db; db="$(_sqlite_db)"
-  storage_init
-  agmsg_sqlite "$db" "
+  local file="$1"
+  storage_init >/dev/null
+  _sqlite_data "
     SELECT CASE type
       WHEN 'message_sent' THEN json_object('type','message_sent','id',id,'team',team,
              'from',from_agent,'to',to_agent,'body',body,'at',at)
@@ -208,19 +243,18 @@ storage_export() {
              'agent',agent,'msg_id',msg_id,'at',at)
     END
     FROM events ORDER BY seq ASC;
-  " 2>/dev/null | tr -d '\r' > "$file"
+  " > "$file"
 }
 
 storage_import() {
   local file="$1" db; db="$(_sqlite_db)"
   [ -f "$file" ] || return 1
-  storage_init
+  storage_init >/dev/null
   local line t id team frm to body msg_id agent at
+  j() { sqlite3 :memory: "SELECT COALESCE(json_extract('$(_sqlite_lit "$line")','\$.$1'),'')" 2>/dev/null | tr -d '\r'; }
   while IFS= read -r line; do
     [ -n "$line" ] || continue
-    t=$(printf '%s' "$line" | sed -n 's/.*"type":"\([^"]*\)".*/\1/p')
-    j() { printf '%s' "$line" | sqlite3 :memory: "SELECT COALESCE(json_extract('$(_sqlite_lit "$line")','\$.$1'),'')" 2>/dev/null | tr -d '\r'; }
-    id=$(j id); team=$(j team); at=$(j at)
+    t=$(j type); id=$(j id); team=$(j team); at=$(j at)
     if [ "$t" = message_sent ]; then
       frm=$(j from); to=$(j to); body=$(j body)
       agmsg_sqlite "$db" "INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
@@ -237,12 +271,13 @@ storage_import() {
   done < "$file"
 }
 
-# Internal (§2.7): coalesce duplicate message_read markers, keeping the earliest.
+# Internal (§2.7): coalesce duplicate message_read markers, keeping the earliest. (control op)
 storage_compact() {
   local db; db="$(_sqlite_db)"
   agmsg_sqlite "$db" "
     DELETE FROM events WHERE type='message_read' AND seq NOT IN (
       SELECT MIN(seq) FROM events WHERE type='message_read'
       GROUP BY team, agent, msg_id);
-  " >/dev/null 2>&1
+  " >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  echo ok
 }

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -221,8 +221,13 @@ storage_watch_after() {
 # With <agent>, only rows where that agent is sender or recipient; omit it (empty)
 # for the whole team (§2.1 G3 — an additive widening, existing callers unchanged).
 storage_history() {
-  local team="$1" agent="$2" limit=""
-  shift 2
+  local team="$1"; shift
+  local agent="" limit=""
+  # <agent> is optional: consume a leading NON-flag argument as the agent (an
+  # empty string is allowed and also means team-wide). A leading --flag means no
+  # agent was given. This is what makes `storage_history <team> --limit N` and
+  # `storage_history <team>` parse correctly per the §2.1 contract (co1 review).
+  if [ $# -gt 0 ] && [ "${1#-}" = "$1" ]; then agent="$1"; shift; fi
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
   storage_init >/dev/null

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# sqlite storage driver (built-in, default).
+#
+# Implements the storage contract (docs/spec/driver-interface.md §2, ADR 0003)
+# over SQLite. Sourced by the storage facade (lib/storage.sh, agmsg_storage_load),
+# so agmsg_db_path / agmsg_sqlite / agmsg_sql_readfile_path from storage.sh are in
+# scope. State is an append-only `events` log (canonical JSONL: message_sent /
+# message_read); the legacy `messages` table is read for back-compat (§2.4).
+#
+# The delivery cursor (§2.2) is the events.seq autoincrement, returned to core as
+# an opaque decimal string — core never parses it. Read-marking is recipient-
+# scoped ((team, agent)) and idempotent.
+
+# --- helpers ---------------------------------------------------------------
+
+_sqlite_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# UUIDv7: 48-bit ms timestamp + version/variant + random. python3 preferred;
+# fall back to a /dev/urandom shell build. No counter file (§2.5).
+_sqlite_uuid7() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import os, time
+ms = int(time.time() * 1000) & ((1 << 48) - 1)
+b = bytearray(os.urandom(16))
+b[0] = (ms >> 40) & 0xFF; b[1] = (ms >> 32) & 0xFF
+b[2] = (ms >> 24) & 0xFF; b[3] = (ms >> 16) & 0xFF
+b[4] = (ms >> 8) & 0xFF;  b[5] = ms & 0xFF
+b[6] = 0x70 | (b[6] & 0x0F)            # version 7
+b[8] = 0x80 | (b[8] & 0x3F)            # variant 10
+h = b.hex()
+print(f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}")
+PY
+    return
+  fi
+  # Shell fallback: 48-bit ms hex from epoch + 80 random bits from urandom.
+  local ms hex rnd
+  ms=$(( $(date -u +%s) * 1000 ))
+  hex=$(printf '%012x' "$ms")
+  rnd=$(head -c 10 /dev/urandom | od -An -tx1 | tr -d ' \n')
+  printf '%s-%s-7%s-%s%s-%s\n' \
+    "${hex:0:8}" "${hex:8:4}" "${rnd:0:3}" \
+    "8" "${rnd:3:3}" "${rnd:6:12}"
+}
+
+_sqlite_db() { agmsg_db_path; }
+
+# Build a SQL string literal (single-quote escaped) from $1.
+_sqlite_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+# Build an "IN (...)" list of team||':'||agent pairs from "<team>:<agent>" args.
+_sqlite_pair_in() {
+  local out="" p t a
+  for p in "$@"; do
+    t="${p%%:*}"; a="${p#*:}"
+    out="${out:+$out,}'$(_sqlite_lit "$t:$a")'"
+  done
+  printf '%s' "${out:-''}"
+}
+
+# --- contract: lifecycle ---------------------------------------------------
+
+storage_check() {
+  command -v sqlite3 >/dev/null 2>&1 || { echo "missing_deps: sqlite3 not found" >&2; return 3; }
+  echo "ok"
+}
+
+storage_describe() {
+  printf 'name=sqlite\n'
+  printf 'backend=SQLite (WAL) event log + legacy messages table\n'
+  printf 'db=%s\n' "$(_sqlite_db)"
+}
+
+storage_init() {
+  local db; db="$(_sqlite_db)"
+  mkdir -p "$(dirname "$db")" 2>/dev/null || true
+  agmsg_sqlite "$db" "
+    PRAGMA journal_mode=WAL;
+    CREATE TABLE IF NOT EXISTS events (
+      seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+      type       TEXT NOT NULL,
+      id         TEXT NOT NULL,
+      team       TEXT,
+      from_agent TEXT,
+      to_agent   TEXT,
+      body       TEXT,
+      msg_id     TEXT,
+      agent      TEXT,
+      at         TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS events_sent ON events(type, team, to_agent, seq);
+    CREATE INDEX IF NOT EXISTS events_read ON events(type, team, agent, msg_id);
+  " >/dev/null 2>&1
+}
+
+# --- contract: messages ----------------------------------------------------
+
+storage_send() {
+  local team="$1" from="$2" to="$3" body="$4"
+  local id at db; id="$(_sqlite_uuid7)"; at="$(_sqlite_now)"; db="$(_sqlite_db)"
+  storage_init
+  agmsg_sqlite "$db" "
+    INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
+    VALUES ('message_sent','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
+            '$(_sqlite_lit "$from")','$(_sqlite_lit "$to")','$(_sqlite_lit "$body")',
+            '$(_sqlite_lit "$at")');
+  " >/dev/null 2>&1 || return 1
+  printf '%s\n' "$id"
+}
+
+# storage_list_unread <team> <agent> [--limit N]
+storage_list_unread() {
+  local team="$1" agent="$2" limit=""
+  shift 2
+  while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
+  case "$limit" in ''|*[!0-9]*) limit="" ;; esac
+  local db; db="$(_sqlite_db)"
+  local tl al; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  agmsg_sqlite "$db" "
+    SELECT json_object('id',e.id,'team',e.team,'from',e.from_agent,
+                       'to',e.to_agent,'body',e.body,'at',e.at)
+    FROM events e
+    WHERE e.type='message_sent' AND e.team='$tl' AND e.to_agent='$al'
+      AND NOT EXISTS (
+        SELECT 1 FROM events r
+        WHERE r.type='message_read' AND r.team=e.team
+          AND r.agent='$al' AND r.msg_id=e.id)
+    ORDER BY e.seq ASC ${limit:+LIMIT $limit};
+  " 2>/dev/null | tr -d '\r'
+}
+
+# storage_mark_read_batch <team> <agent> <id> [<id> ...]
+storage_mark_read_batch() {
+  local team="$1" agent="$2"; shift 2
+  [ $# -gt 0 ] || return 0
+  local db at tl al; db="$(_sqlite_db)"; at="$(_sqlite_now)"
+  tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  storage_init
+  local id sql=""
+  for id in "$@"; do
+    local idl rid; idl="$(_sqlite_lit "$id")"; rid="$(_sqlite_uuid7)"
+    # Idempotent: only insert a message_read if this recipient hasn't read it.
+    sql="$sql
+    INSERT INTO events (type,id,team,agent,msg_id,at)
+    SELECT 'message_read','$(_sqlite_lit "$rid")','$tl','$al','$idl','$(_sqlite_lit "$at")'
+    WHERE NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
+                      AND r.team='$tl' AND r.agent='$al' AND r.msg_id='$idl');"
+  done
+  agmsg_sqlite "$db" "$sql" >/dev/null 2>&1
+}
+
+# --- contract: delivery cursor ---------------------------------------------
+
+# storage_watch_tip <team:agent> ... -> opaque cursor for "now"
+storage_watch_tip() {
+  local db; db="$(_sqlite_db)"
+  storage_init
+  agmsg_sqlite "$db" "SELECT COALESCE(MAX(seq),0) FROM events;" 2>/dev/null | tr -d '\r'
+}
+
+# storage_watch_after <cursor> <team:agent> ... -> JSONL message_sent + cursor record
+storage_watch_after() {
+  local cursor="$1"; shift
+  case "$cursor" in ''|*[!0-9]*) cursor=0 ;; esac
+  local db pairs; db="$(_sqlite_db)"; pairs="$(_sqlite_pair_in "$@")"
+  agmsg_sqlite "$db" "
+    SELECT json_object('type','message_sent','id',id,'team',team,'from',from_agent,
+                       'to',to_agent,'body',body,'at',at)
+    FROM events
+    WHERE type='message_sent' AND seq > $cursor
+      AND (team || ':' || to_agent) IN ($pairs)
+    ORDER BY seq ASC;
+    SELECT json_object('type','cursor','cursor',
+                       CAST(COALESCE(MAX(seq), $cursor) AS TEXT))
+    FROM events;
+  " 2>/dev/null | tr -d '\r'
+}
+
+# --- contract: history -----------------------------------------------------
+
+# storage_history <team> <agent> [--limit N]
+storage_history() {
+  local team="$1" agent="$2" limit=""
+  shift 2
+  while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
+  case "$limit" in ''|*[!0-9]*) limit="" ;; esac
+  local db tl al; db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  agmsg_sqlite "$db" "
+    SELECT json_object('id',id,'team',team,'from',from_agent,'to',to_agent,
+                       'body',body,'at',at)
+    FROM events
+    WHERE type='message_sent' AND team='$tl'
+      AND (to_agent='$al' OR from_agent='$al')
+    ORDER BY seq ASC ${limit:+LIMIT $limit};
+  " 2>/dev/null | tr -d '\r'
+}
+
+# --- contract: export / import / compact -----------------------------------
+
+storage_export() {
+  local file="$1" db; db="$(_sqlite_db)"
+  storage_init
+  agmsg_sqlite "$db" "
+    SELECT CASE type
+      WHEN 'message_sent' THEN json_object('type','message_sent','id',id,'team',team,
+             'from',from_agent,'to',to_agent,'body',body,'at',at)
+      WHEN 'message_read' THEN json_object('type','message_read','id',id,'team',team,
+             'agent',agent,'msg_id',msg_id,'at',at)
+    END
+    FROM events ORDER BY seq ASC;
+  " 2>/dev/null | tr -d '\r' > "$file"
+}
+
+storage_import() {
+  local file="$1" db; db="$(_sqlite_db)"
+  [ -f "$file" ] || return 1
+  storage_init
+  local line t id team frm to body msg_id agent at
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    t=$(printf '%s' "$line" | sed -n 's/.*"type":"\([^"]*\)".*/\1/p')
+    j() { printf '%s' "$line" | sqlite3 :memory: "SELECT COALESCE(json_extract('$(_sqlite_lit "$line")','\$.$1'),'')" 2>/dev/null | tr -d '\r'; }
+    id=$(j id); team=$(j team); at=$(j at)
+    if [ "$t" = message_sent ]; then
+      frm=$(j from); to=$(j to); body=$(j body)
+      agmsg_sqlite "$db" "INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
+        VALUES ('message_sent','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
+                '$(_sqlite_lit "$frm")','$(_sqlite_lit "$to")','$(_sqlite_lit "$body")',
+                '$(_sqlite_lit "$at")');" >/dev/null 2>&1
+    elif [ "$t" = message_read ]; then
+      agent=$(j agent); msg_id=$(j msg_id)
+      agmsg_sqlite "$db" "INSERT INTO events (type,id,team,agent,msg_id,at)
+        VALUES ('message_read','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
+                '$(_sqlite_lit "$agent")','$(_sqlite_lit "$msg_id")','$(_sqlite_lit "$at")');" \
+        >/dev/null 2>&1
+    fi
+  done < "$file"
+}
+
+# Internal (§2.7): coalesce duplicate message_read markers, keeping the earliest.
+storage_compact() {
+  local db; db="$(_sqlite_db)"
+  agmsg_sqlite "$db" "
+    DELETE FROM events WHERE type='message_read' AND seq NOT IN (
+      SELECT MIN(seq) FROM events WHERE type='message_read'
+      GROUP BY team, agent, msg_id);
+  " >/dev/null 2>&1
+}

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -247,6 +247,9 @@ storage_history() {
 storage_export() {
   local file="$1"
   storage_init >/dev/null
+  # Forward-compat (§2.3): only the v1 event types are projected. A WHERE filter
+  # (not just a CASE) keeps unknown-type rows out entirely, so they never surface
+  # as a NULL → blank line on stdout, matching list_unread/history/watch_after.
   _sqlite_data "
     SELECT CASE type
       WHEN 'message_sent' THEN json_object('type','message_sent','id',id,'team',team,
@@ -254,7 +257,9 @@ storage_export() {
       WHEN 'message_read' THEN json_object('type','message_read','id',id,'team',team,
              'agent',agent,'msg_id',msg_id,'at',at)
     END
-    FROM events ORDER BY seq ASC;
+    FROM events
+    WHERE type IN ('message_sent','message_read')
+    ORDER BY seq ASC;
   " > "$file"
 }
 

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -80,6 +80,7 @@ storage_check() {
 storage_describe() {
   printf 'name=sqlite\n'
   printf 'backend=SQLite (WAL) event log + legacy messages table\n'
+  printf 'capabilities=stage1-sync\n'
   printf 'db=%s\n' "$(_sqlite_db)"
 }
 
@@ -335,3 +336,9 @@ storage_compact() {
   " >/dev/null 2>&1 || { echo runtime_error; return 13; }
   echo ok
 }
+
+# Optional Stage-1 remote synchronization extension (ADR 0005). Keep the
+# implementation separate from the local storage ABI so local-only callers do
+# not pay its jq/base64 dependency cost.
+# shellcheck disable=SC1090
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sqlite-sync.sh"

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -777,7 +777,7 @@ class CodexBridge {
     this.pendingWake = false;
     this.watchHandle = null;
     this.wakeCount = 0;
-    this.lastWakeMaxId = 0;
+    this.lastWakeMaxId = "";
     this.staleWakeCount = 0;
     this.watchFailureCount = 0;
     this.watchRearmTimer = null;
@@ -1312,7 +1312,9 @@ class CodexBridge {
   }
 
   isStaleWake(maxId) {
-    if (maxId <= 0 || this.lastWakeMaxId !== maxId) {
+    // maxId is an OPAQUE token (the unread frontier id from watch-once), compared
+    // only for equality — never ordered. An empty token means "no unread".
+    if (!maxId || this.lastWakeMaxId !== maxId) {
       this.lastWakeMaxId = maxId;
       this.staleWakeCount = 0;
       return false;
@@ -1391,8 +1393,10 @@ function readPid(file) {
 }
 
 function parseMaxId(stdout) {
-  const match = String(stdout || "").match(/\bmax_id=([0-9]+)/);
-  return match ? Number(match[1]) : 0;
+  // max_id is now an opaque token (UUIDv7 / legacy decimal / any whitespace-free
+  // string), not an integer — return it verbatim for equality-only comparison.
+  const match = String(stdout || "").match(/\bmax_id=(\S+)/);
+  return match ? match[1] : "";
 }
 
 async function main() {

--- a/scripts/drivers/types/codex/watch-once.sh
+++ b/scripts/drivers/types/codex/watch-once.sh
@@ -50,6 +50,7 @@ case "$INTERVAL" in ''|*[!0-9]*) echo "watch-once: --interval must be a whole nu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 source "$SCRIPT_DIR/../../../lib/storage.sh"
+agmsg_storage_load
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/../../../lib/actas-lock.sh"
 # shellcheck disable=SC1091
@@ -78,20 +79,29 @@ if [ -z "$PAIRS" ]; then
   exit 1
 fi
 
-WHERE_PAIRS="$(agmsg_subscription_where "$PAIRS")"
 deadline=$(( $(date +%s) + TIMEOUT ))
 
 while true; do
   if [ -f "$DB" ]; then
-    row="$(agmsg_sqlite -separator $'\t' "$DB" "
-      SELECT COUNT(*), COALESCE(MAX(id), 0)
-      FROM messages
-      WHERE read_at IS NULL AND ($WHERE_PAIRS);
-    " 2>/dev/null || true)"
-    count="${row%%$'\t'*}"
-    max_id="${row#*$'\t'}"
-    case "$count" in ''|*[!0-9]*) count=0 ;; esac
-    case "$max_id" in ''|*[!0-9]*) max_id=0 ;; esac
+    # Unread across the subscription via the storage facade (§2.1, events ∪ legacy)
+    # — one storage_list_unread per pair, summed. max_id is an OPAQUE token: the
+    # greatest unread id across pairs, used by codex-bridge only for equality
+    # (stale-wake detection), never ordered. It is no longer an integer.
+    count=0
+    max_id=""
+    while IFS=$'\t' read -r _team _agent; do
+      [ -n "$_team" ] && [ -n "$_agent" ] || continue
+      u="$(storage_list_unread "$_team" "$_agent" 2>/dev/null || true)"
+      [ -n "$u" ] || continue
+      uarr="[$(printf '%s' "$u" | paste -sd, -)]"
+      ids="$(agmsg_sqlite ':memory:' "
+        SELECT json_extract(value,'\$.id') FROM json_each('$(printf '%s' "$uarr" | sed "s/'/''/g")');
+      " 2>/dev/null || true)"
+      [ -n "$ids" ] || continue
+      count=$(( count + $(printf '%s\n' "$ids" | grep -c .) ))
+      pairmax="$(printf '%s\n' "$ids" | LC_ALL=C sort | tail -1)"
+      if [ -z "$max_id" ] || [ "$pairmax" \> "$max_id" ]; then max_id="$pairmax"; fi
+    done <<< "$PAIRS"
     if [ "$count" -gt 0 ]; then
       printf 'status=pending count=%s max_id=%s\n' "$count" "$max_id"
       exit 0

--- a/scripts/drivers/types/codex/watch-once.sh
+++ b/scripts/drivers/types/codex/watch-once.sh
@@ -59,7 +59,6 @@ source "$SCRIPT_DIR/../../../lib/resolve-project.sh"
 source "$SCRIPT_DIR/../../../lib/subscription.sh"
 
 PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
-DB="$(agmsg_db_path)"
 
 PAIRS="$(agmsg_subscription_pairs "$PROJECT_PATH" "$AGENT_TYPE" "" "$ACTIVE_NAME")" || exit 1
 if [ -n "$TEAM_FILTER" ]; then
@@ -82,13 +81,15 @@ fi
 deadline=$(( $(date +%s) + TIMEOUT ))
 
 while true; do
-  if [ -f "$DB" ]; then
+  if storage_store_exists; then
     # Unread across the subscription via the storage facade (§2.1, events ∪ legacy)
-    # — one storage_list_unread per pair, summed. max_id is an OPAQUE token: the
-    # greatest unread id across pairs, used by codex-bridge only for equality
-    # (stale-wake detection), never ordered. It is no longer an integer.
+    # — one storage_list_unread per pair, summed. max_id is an OPAQUE equality-only
+    # token for codex-bridge stale-wake detection (never ordered): a cksum DIGEST of
+    # the whole unread SET, so it changes whenever the set changes. A "greatest id"
+    # frontier could miss a set change under a backend whose ids aren't
+    # recency-ordered (jsonl); a set digest is robust on every backend.
     count=0
-    max_id=""
+    all_ids=""
     while IFS=$'\t' read -r _team _agent; do
       [ -n "$_team" ] && [ -n "$_agent" ] || continue
       u="$(storage_list_unread "$_team" "$_agent" 2>/dev/null || true)"
@@ -99,10 +100,13 @@ while true; do
       " 2>/dev/null || true)"
       [ -n "$ids" ] || continue
       count=$(( count + $(printf '%s\n' "$ids" | grep -c .) ))
-      pairmax="$(printf '%s\n' "$ids" | LC_ALL=C sort | tail -1)"
-      if [ -z "$max_id" ] || [ "$pairmax" \> "$max_id" ]; then max_id="$pairmax"; fi
+      all_ids="$all_ids$ids"$'\n'
     done <<< "$PAIRS"
     if [ "$count" -gt 0 ]; then
+      # cksum = POSIX (no shasum dep). Field 1 is whitespace-free for the bridge's
+      # `max_id=(\S+)` parse. The bridge only compares it within one session, so the
+      # checksum needn't be stable across platforms — only deterministic per run.
+      max_id="$(printf '%s' "$all_ids" | sed '/^$/d' | LC_ALL=C sort | cksum | cut -d' ' -f1)"
       printf 'status=pending count=%s max_id=%s\n' "$count" "$max_id"
       exit 0
     fi

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -16,9 +16,10 @@ case "$LIMIT" in ''|*[!0-9]*) LIMIT=20 ;; esac
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 agmsg_storage_load
-DB="$(agmsg_db_path)"
 
-if [ ! -f "$DB" ]; then
+# Ask the active driver whether a store exists (driver-level, works for jsonl) —
+# a history read must not create one in a storeless project.
+if ! storage_store_exists; then
   echo "No messages (DB not initialized)"
   exit 0
 fi

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -15,6 +15,7 @@ case "$LIMIT" in ''|*[!0-9]*) LIMIT=20 ;; esac
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
+agmsg_storage_load
 DB="$(agmsg_db_path)"
 
 if [ ! -f "$DB" ]; then
@@ -22,27 +23,49 @@ if [ ! -f "$DB" ]; then
   exit 0
 fi
 
-_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
+# History (events ∪ legacy) via the facade; <agent> optional — omitted = whole
+# team (§2.1). The driver returns the most recent --limit records already in
+# chronological order, so no reversal here.
+HIST_JSONL=$(storage_history "$TEAM" "$AGENT" --limit "$LIMIT")
 
-if [ -n "$AGENT" ]; then
-  WHERE="WHERE team='$(_agmsg_sqlesc "$TEAM")' AND (from_agent='$(_agmsg_sqlesc "$AGENT")' OR to_agent='$(_agmsg_sqlesc "$AGENT")')"
-else
-  WHERE="WHERE team='$(_agmsg_sqlesc "$TEAM")'"
-fi
-
-# Escape newlines/tabs in body, use unit separator between fields
-RESULT=$(agmsg_sqlite "$DB" "
-  SELECT from_agent || char(31) || to_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at || char(31) || CASE WHEN read_at IS NULL THEN '●' ELSE '○' END
-  FROM messages $WHERE ORDER BY created_at DESC LIMIT $LIMIT;
-")
-
-if [ -z "$RESULT" ]; then
+if [ -z "$HIST_JSONL" ]; then
   echo "No message history."
   exit 0
 fi
 
-# Reverse order (oldest first) and display
-REVERSED=$(echo "$RESULT" | tail -r 2>/dev/null || echo "$RESULT" | tac 2>/dev/null || echo "$RESULT" | awk '{a[NR]=$0} END{for(i=NR;i>=1;i--)print a[i]}')
-while IFS=$'\x1f' read -r from to body ts status; do
+# Parse to "from \x1f to \x1f body \x1f at \x1f id" rows (no jq; cf. lib/hooks-json.sh).
+_arr="[$(printf '%s' "$HIST_JSONL" | paste -sd, -)]"
+ROWS=$(agmsg_sqlite ':memory:' "
+  SELECT json_extract(value,'\$.from') || char(31) ||
+         json_extract(value,'\$.to') || char(31) ||
+         replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
+         json_extract(value,'\$.at') || char(31) ||
+         json_extract(value,'\$.id')
+  FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+")
+
+# Read-state for the ●(unread)/○(read) marker (G2(c)): read-state is
+# recipient-scoped and not carried on a history record, so derive it by unioning
+# storage_list_unread over the distinct recipients in this slice. (Phase 1:
+# mark-read still lands in legacy read_at, which the facade UNION reflects.)
+RECIPIENTS=$(while IFS=$'\x1f' read -r _f to _rest; do
+  [ -n "$to" ] && printf '%s\n' "$to"
+done <<< "$ROWS" | sort -u)
+
+UNREAD_IDS=""
+while IFS= read -r r; do
+  [ -n "$r" ] || continue
+  u=$(storage_list_unread "$TEAM" "$r") || continue
+  [ -n "$u" ] || continue
+  uarr="[$(printf '%s' "$u" | paste -sd, -)]"
+  ids=$(agmsg_sqlite ':memory:' "
+    SELECT json_extract(value,'\$.id') FROM json_each('$(printf '%s' "$uarr" | sed "s/'/''/g")');
+  ")
+  UNREAD_IDS+="$ids"$'\n'
+done <<< "$RECIPIENTS"
+
+while IFS=$'\x1f' read -r from to body ts id; do
+  [ -n "$ts$from$to$body" ] || continue
+  if printf '%s\n' "$UNREAD_IDS" | grep -Fxq "$id"; then status='●'; else status='○'; fi
   echo "  $status [$ts] $from → $to: $body"
-done <<< "$REVERSED"
+done <<< "$ROWS"

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -15,11 +15,11 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 agmsg_storage_load
-DB="$(agmsg_db_path)"
 
 # Preserve the read-only "not initialized yet" behaviour: an inbox check must not
-# create the store, so guard on the file before touching the facade.
-if [ ! -f "$DB" ]; then
+# create the store. Ask the active driver whether one exists (driver-level, so it
+# works for jsonl's events.jsonl as well as sqlite's messages.db).
+if ! storage_store_exists; then
   if [ "$QUIET" = true ]; then exit 0; fi
   echo "No messages (DB not initialized)"
   exit 0

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -14,44 +14,53 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
+agmsg_storage_load
 DB="$(agmsg_db_path)"
 
+# Preserve the read-only "not initialized yet" behaviour: an inbox check must not
+# create the store, so guard on the file before touching the facade.
 if [ ! -f "$DB" ]; then
   if [ "$QUIET" = true ]; then exit 0; fi
   echo "No messages (DB not initialized)"
   exit 0
 fi
 
-_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
-TEAM_SQL="$(_agmsg_sqlesc "$TEAM")"
-AGENT_SQL="$(_agmsg_sqlesc "$AGENT")"
+# Unread comes from the storage facade (§2.1 storage_list_unread = the event log
+# UNION the legacy messages table), as one JSONL record per line in delivery
+# order. Parse it with sqlite's JSON funcs in a single pass — the repo idiom, no
+# jq dependency (cf. lib/hooks-json.sh).
+UNREAD_JSONL=$(storage_list_unread "$TEAM" "$AGENT")
 
-# Get unread messages — id first so the mark step below targets exactly these
-# rows; escape newlines/tabs in body to keep one record per line
-UNREAD=$(agmsg_sqlite "$DB" "
-  SELECT id || char(31) || from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
-  FROM messages WHERE team='$TEAM_SQL' AND to_agent='$AGENT_SQL' AND read_at IS NULL
-  ORDER BY created_at ASC;
-")
-
-if [ -z "$UNREAD" ]; then
+if [ -z "$UNREAD_JSONL" ]; then
   if [ "$QUIET" = true ]; then exit 0; fi
   echo "No new messages."
   exit 0
 fi
 
-# Display, collecting the ids actually shown
-COUNT=$(echo "$UNREAD" | wc -l | tr -d ' ')
+# JSONL -> JSON array -> "id \x1f from \x1f body \x1f at" rows (newlines/tabs in
+# the body escaped so each message stays one display line). id is kept so the
+# mark step below can target exactly the rows shown, not a blanket match.
+_arr="[$(printf '%s' "$UNREAD_JSONL" | paste -sd, -)]"
+ROWS=$(agmsg_sqlite ':memory:' "
+  SELECT json_extract(value,'\$.id') || char(31) ||
+         json_extract(value,'\$.from') || char(31) ||
+         replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
+         json_extract(value,'\$.at')
+  FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+")
+
+COUNT=$(printf '%s\n' "$ROWS" | wc -l | tr -d ' ')
 echo "$COUNT new message(s):"
 echo ""
 IDS=""
 while IFS=$'\x1f' read -r id from body ts; do
+  [ -n "$ts$from$body" ] || continue
   echo "  [$ts] $from: $body"
   case "$id" in
-    ''|*[!0-9]*) ;; # defensive: never splice a non-numeric value into SQL
+    ''|*[!0-9]*) ;; # event-log id (UUID) or unset -> not a legacy row; skip
     *) IDS="${IDS:+$IDS,}$id" ;;
   esac
-done <<< "$UNREAD"
+done <<< "$ROWS"
 echo ""
 
 # Test seam: a two-file barrier that lets the race regression test land a
@@ -66,10 +75,17 @@ if [ -n "${AGMSG_TEST_MARK_BARRIER:-}" ]; then
   done
 fi
 
-# Mark as read (non-fatal — may fail in sandboxed environments).
-# Only the ids displayed above: a blanket "WHERE read_at IS NULL" would also
-# swallow messages that arrived between the SELECT and this UPDATE — they
-# would be marked read without ever having been shown.
+# Mark as read — transitional legacy UPDATE, NOT storage_mark_read_batch yet.
+# The read-state writers (inbox/check-inbox) and the legacy-read_at readers
+# that have not migrated (watch-once, whose codex-bridge consumes an integer
+# max_id cursor) must flip together at step 3 (send -> events + watch ->
+# facade); marking event-log rows here would be invisible to those readers
+# and split read-state, so only the numeric (legacy-table) ids collected
+# above are targeted — event-log entries get their own mark-read flip later.
+# Only the ids actually displayed: a blanket "WHERE read_at IS NULL" would
+# also swallow messages that arrived between the SELECT and this UPDATE —
+# they would be marked read without ever having been shown. Non-fatal (may
+# fail in sandboxed environments).
 if [ -n "$IDS" ]; then
   agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id IN ($IDS);" 2>/dev/null || true
 fi

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -37,29 +37,25 @@ if [ -z "$UNREAD_JSONL" ]; then
   exit 0
 fi
 
-# JSONL -> JSON array -> "id \x1f from \x1f body \x1f at" rows (newlines/tabs in
-# the body escaped so each message stays one display line). id is kept so the
-# mark step below can target exactly the rows shown, not a blanket match.
+# JSONL -> JSON array -> "from \x1f body \x1f at \x1f id" rows (newlines/tabs in
+# the body escaped so each message stays one display line).
 _arr="[$(printf '%s' "$UNREAD_JSONL" | paste -sd, -)]"
 ROWS=$(agmsg_sqlite ':memory:' "
-  SELECT json_extract(value,'\$.id') || char(31) ||
-         json_extract(value,'\$.from') || char(31) ||
+  SELECT json_extract(value,'\$.from') || char(31) ||
          replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
-         json_extract(value,'\$.at')
+         json_extract(value,'\$.at') || char(31) ||
+         json_extract(value,'\$.id')
   FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
 ")
 
 COUNT=$(printf '%s\n' "$ROWS" | wc -l | tr -d ' ')
 echo "$COUNT new message(s):"
 echo ""
-IDS=""
-while IFS=$'\x1f' read -r id from body ts; do
-  [ -n "$ts$from$body" ] || continue
+IDS=()
+while IFS=$'\x1f' read -r from body ts id; do
+  [ -n "$id" ] || continue
   echo "  [$ts] $from: $body"
-  case "$id" in
-    ''|*[!0-9]*) ;; # event-log id (UUID) or unset -> not a legacy row; skip
-    *) IDS="${IDS:+$IDS,}$id" ;;
-  esac
+  IDS+=("$id")
 done <<< "$ROWS"
 echo ""
 
@@ -75,17 +71,12 @@ if [ -n "${AGMSG_TEST_MARK_BARRIER:-}" ]; then
   done
 fi
 
-# Mark as read — transitional legacy UPDATE, NOT storage_mark_read_batch yet.
-# The read-state writers (inbox/check-inbox) and the legacy-read_at readers
-# that have not migrated (watch-once, whose codex-bridge consumes an integer
-# max_id cursor) must flip together at step 3 (send -> events + watch ->
-# facade); marking event-log rows here would be invisible to those readers
-# and split read-state, so only the numeric (legacy-table) ids collected
-# above are targeted — event-log entries get their own mark-read flip later.
-# Only the ids actually displayed: a blanket "WHERE read_at IS NULL" would
-# also swallow messages that arrived between the SELECT and this UPDATE —
-# they would be marked read without ever having been shown. Non-fatal (may
-# fail in sandboxed environments).
-if [ -n "$IDS" ]; then
-  agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id IN ($IDS);" 2>/dev/null || true
+# Mark read via the storage facade (§2.1 storage_mark_read_batch): recipient-
+# scoped and idempotent. For a legacy id it records a message_read event
+# without mutating the legacy row (§2.4). Only the ids collected from the
+# rows actually displayed above — never a blanket match — so a message that
+# arrives after the SELECT above can never be marked read unseen. Non-fatal —
+# may fail in sandboxed environments.
+if [ "${#IDS[@]}" -gt 0 ]; then
+  storage_mark_read_batch "$TEAM" "$AGENT" "${IDS[@]}" >/dev/null 2>&1 || true
 fi

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import process from "node:process";
+
+const UUID_V7 = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const SEQUENCE = /^(0|[1-9][0-9]*)$/;
+const TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/;
+const PROTOCOL = "1";
+const MAX_SEQUENCE = 9_223_372_036_854_775_807n;
+
+function usage() {
+  return `usage:
+  remote-sync.sh configure --team NAME --server URL --team-id UUID --minimum-security plaintext-allowed
+  remote-sync.sh once --team NAME [--limit N]
+  remote-sync.sh run --team NAME [--limit N] [--interval SECONDS]
+
+AGMSG_SYNC_TOKEN is required and is never written to config or argv.`;
+}
+
+function options(args) {
+  const result = { _: [] };
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (!value.startsWith("--")) { result._.push(value); continue; }
+    const next = args[index + 1];
+    if (next === undefined || next.startsWith("--")) throw new Error(`missing value for ${value}`);
+    result[value.slice(2)] = next;
+    index += 1;
+  }
+  return result;
+}
+
+function requireName(value, label) {
+  if (typeof value !== "string" || value.length < 1 || value.length > 128 ||
+      value.startsWith("-") || value === "." || value === ".." ||
+      /[./\\"\[\]\u0000-\u001f\u007f]/u.test(value) || value !== value.normalize("NFC")) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function sequence(value, label) {
+  if (typeof value !== "string" || !SEQUENCE.test(value) || BigInt(value) > MAX_SEQUENCE) {
+    throw new Error(`${label} is not a canonical sequence`);
+  }
+  return value;
+}
+
+function configPath(team) {
+  const root = process.env.AGMSG_SYNC_STORAGE_DIR;
+  if (!root) throw new Error("AGMSG_SYNC_STORAGE_DIR is not set");
+  return join(root, "remote-sync", `${encodeURIComponent(team)}.json`);
+}
+
+async function writeConfig(path, value) {
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const temporary = join(directory, `.${basename(path)}.${process.pid}.tmp`);
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600, flag: "wx" });
+  await rename(temporary, path);
+}
+
+async function loadConfig(team) {
+  const value = JSON.parse(await readFile(configPath(team), "utf8"));
+  if (value.local_team !== team || value.protocol_version !== 1 ||
+      !UUID_V7.test(value.server_instance_id) || !UUID_V7.test(value.remote_team_id)) {
+    throw new Error("sync config binding is invalid");
+  }
+  return value;
+}
+
+function endpoint(base, path) {
+  const root = new URL(base);
+  if (root.username || root.password || root.search || root.hash) {
+    throw new Error("server URL must not contain credentials, query, or fragment");
+  }
+  const prefix = root.pathname.replace(/\/$/, "");
+  const separator = path.indexOf("?");
+  const pathname = separator === -1 ? path : path.slice(0, separator);
+  const query = separator === -1 ? "" : path.slice(separator + 1);
+  root.pathname = `${prefix}${pathname}`;
+  root.search = query;
+  return root;
+}
+
+async function request(config, path, init = {}) {
+  const token = process.env.AGMSG_SYNC_TOKEN;
+  if (!token) throw new Error("AGMSG_SYNC_TOKEN is required");
+  const headers = {
+    "Agmsg-Protocol-Version": PROTOCOL,
+    "Agmsg-Team-ID": config.remote_team_id,
+    Authorization: `Bearer ${token}`,
+    ...init.headers,
+  };
+  const response = await fetch(endpoint(config.server_url, path), {
+    ...init, headers, redirect: "error", signal: AbortSignal.timeout(15_000),
+  });
+  const protocol = response.headers.get("agmsg-protocol-version");
+  if (protocol !== PROTOCOL) throw new Error("response protocol version mismatch");
+  const text = await response.text();
+  let body;
+  try { body = JSON.parse(text); } catch { throw new Error(`HTTP ${response.status} returned invalid JSON`); }
+  if (!response.ok) {
+    const code = body?.error?.code ?? "unknown-error";
+    const error = new Error(`HTTP ${response.status} ${code}`);
+    error.status = response.status; error.code = code; error.body = body;
+    throw error;
+  }
+  validateBinding(config, body);
+  return body;
+}
+
+async function health(serverUrl) {
+  const response = await fetch(endpoint(serverUrl, "/v1/health"), {
+    redirect: "error", signal: AbortSignal.timeout(15_000),
+  });
+  if (response.headers.get("agmsg-protocol-version") !== PROTOCOL) {
+    throw new Error("health protocol version mismatch");
+  }
+  const body = await response.json();
+  if (!response.ok || body.status !== "ok" || body.database !== "ok" || !UUID_V7.test(body.server_instance_id)) {
+    throw new Error("server health is unavailable or unbound");
+  }
+  return body;
+}
+
+function validateBinding(config, body) {
+  if (body?.protocol_version !== 1 || body?.server_instance_id !== config.server_instance_id ||
+      body?.team_id !== config.remote_team_id) {
+    throw new Error("server/team binding mismatch");
+  }
+}
+
+async function driver(operation, config, input, extra = []) {
+  const script = process.env.AGMSG_SYNC_DRIVER;
+  if (!script) throw new Error("AGMSG_SYNC_DRIVER is not set");
+  const args = [script, operation, config.local_team, config.server_instance_id,
+    config.remote_team_id, String(config.protocol_version), ...extra];
+  return new Promise((resolve, reject) => {
+    const child = spawn("bash", args, { stdio: ["pipe", "pipe", "pipe"], env: process.env });
+    let stdout = ""; let stderr = "";
+    child.stdout.setEncoding("utf8"); child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve(parseJsonl(stdout));
+      else reject(new Error(`storage sync ${operation} failed (${code}): ${stderr.trim()}`));
+    });
+    child.stdin.end(input.map((record) => `${JSON.stringify(record)}\n`).join(""));
+  });
+}
+
+function parseJsonl(value) {
+  return value.split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+}
+
+async function event(name, fields = {}) {
+  const record = { at: new Date().toISOString(), event: name, ...fields };
+  const line = `${JSON.stringify(record)}\n`;
+  process.stdout.write(line);
+  if (process.env.AGMSG_SYNC_LOG_FILE) {
+    await appendFile(process.env.AGMSG_SYNC_LOG_FILE, line, { encoding: "utf8", mode: 0o600 });
+  }
+}
+
+function currentPolicy(capabilities, serverSeq) {
+  const target = BigInt(serverSeq);
+  const candidates = capabilities.policy_history.filter((entry) =>
+    BigInt(sequence(entry.effective_from_seq, "policy effective_from_seq")) <= target);
+  if (candidates.length === 0) throw new Error("policy history has no effective entry");
+  return candidates.reduce((best, entry) => BigInt(entry.policy_revision) > BigInt(best.policy_revision) ? entry : best);
+}
+
+function currentLocalPolicy(config, serverSeq) {
+  const target = BigInt(serverSeq);
+  const candidates = config.local_security_history.filter((entry) => BigInt(entry.effective_from_seq) <= target);
+  if (candidates.length === 0) throw new Error("local security history has no effective entry");
+  return candidates.reduce((best, entry) => BigInt(entry.local_security_revision) > BigInt(best.local_security_revision) ? entry : best);
+}
+
+function canonicalPlaintext(envelope) {
+  if (envelope.v !== 1 || envelope.cipher !== "none" || envelope.key_id !== null ||
+      typeof envelope.blob !== "string" || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(envelope.blob)) {
+    throw new Error("malformed envelope");
+  }
+  const bytes = Buffer.from(envelope.blob, "base64");
+  if (bytes.length < 1 || bytes.length > 1024 * 1024 || bytes.toString("base64") !== envelope.blob) {
+    throw new Error("malformed base64 blob");
+  }
+  const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  const value = JSON.parse(text);
+  const keys = Object.keys(value);
+  if (JSON.stringify(keys) !== JSON.stringify(["body", "created_at", "from_agent", "to_agent"]) ||
+      typeof value.body !== "string" || Buffer.byteLength(value.body) < 1 || Buffer.byteLength(value.body) > 1_000_000 ||
+      typeof value.created_at !== "string" || !TIMESTAMP.test(value.created_at)) {
+    throw new Error("malformed plaintext projection");
+  }
+  requireName(value.from_agent, "from_agent"); requireName(value.to_agent, "to_agent");
+  const canonical = JSON.stringify({ body: value.body, created_at: value.created_at,
+    from_agent: value.from_agent, to_agent: value.to_agent });
+  if (canonical !== text) throw new Error("plaintext is not canonical JCS");
+  return value;
+}
+
+function evaluatePull(config, capabilities, message) {
+  sequence(message.server_seq, "message server_seq");
+  if (!UUID_V4.test(message.id) || !TIMESTAMP.test(message.server_received_at) || typeof message.envelope !== "object") {
+    return { status: "malformed", reason: "invalid message metadata" };
+  }
+  const serverPolicy = currentPolicy(capabilities, message.server_seq);
+  const localPolicy = currentLocalPolicy(config, message.server_seq);
+  if (!serverPolicy.accepted_envelope_versions.includes(message.envelope.v) ||
+      !serverPolicy.write_allowed_ciphers.includes(message.envelope.cipher) ||
+      (localPolicy.minimum_security_mode === "e2ee-required" && message.envelope.cipher === "none")) {
+    return { status: "policy_violation", reason: "envelope violates effective policy",
+      policy_revision: serverPolicy.policy_revision,
+      local_security_revision: localPolicy.local_security_revision };
+  }
+  if (message.envelope.v !== 1 || message.envelope.cipher !== "none") {
+    return { status: "unsupported_cipher", reason: "Stage-1 supports cipher none only",
+      policy_revision: serverPolicy.policy_revision,
+      local_security_revision: localPolicy.local_security_revision };
+  }
+  try {
+    return { status: "importable", projection: canonicalPlaintext(message.envelope),
+      policy_revision: serverPolicy.policy_revision,
+      local_security_revision: localPolicy.local_security_revision };
+  } catch (error) {
+    return { status: "malformed", reason: error.message,
+      policy_revision: serverPolicy.policy_revision,
+      local_security_revision: localPolicy.local_security_revision };
+  }
+}
+
+function validateCapabilities(config, value) {
+  validateBinding(config, value);
+  sequence(value.current_seq, "current_seq"); sequence(value.min_available_seq, "min_available_seq");
+  if (!Array.isArray(value.policy_history) || value.policy_history.length < 1 || value.policy_history.length > 4096 ||
+      !Array.isArray(value.accepted_envelope_versions) || !Array.isArray(value.write_allowed_ciphers)) {
+    throw new Error("capabilities response is invalid");
+  }
+  if (!value.accepted_envelope_versions.includes(1) || !value.write_allowed_ciphers.includes("none")) {
+    throw new Error("server does not currently allow Stage-1 plaintext writes");
+  }
+  const boundary = value.next_sequence_boundary;
+  if (boundary === null) throw new Error("remote sequence is exhausted");
+  sequence(boundary, "next_sequence_boundary");
+  if (currentLocalPolicy(config, boundary).minimum_security_mode !== "plaintext-allowed") {
+    throw new Error("local security policy disallows Stage-1 plaintext writes");
+  }
+}
+
+async function configure(args) {
+  const team = requireName(args.team, "team");
+  if (!UUID_V7.test(args["team-id"] ?? "")) throw new Error("team-id must be a canonical UUIDv7");
+  if (args["minimum-security"] !== "plaintext-allowed") {
+    throw new Error("Stage-1 requires explicit --minimum-security plaintext-allowed");
+  }
+  if (!process.env.AGMSG_SYNC_TOKEN) throw new Error("AGMSG_SYNC_TOKEN is required");
+  const serverUrl = new URL(args.server).toString().replace(/\/$/, "");
+  const ready = await health(serverUrl);
+  const config = {
+    format_version: 1, local_team: team, server_url: serverUrl,
+    server_instance_id: ready.server_instance_id, remote_team_id: args["team-id"],
+    protocol_version: 1,
+    local_security_history: [{ local_security_revision: "0", effective_from_seq: "1",
+      minimum_security_mode: "plaintext-allowed" }],
+  };
+  const capabilities = await request(config, "/v1/capabilities");
+  validateCapabilities(config, capabilities);
+  await writeConfig(configPath(team), config);
+  await event("configured", { team, server_instance_id: config.server_instance_id,
+    remote_team_id: config.remote_team_id });
+}
+
+async function cycle(config, limit) {
+  const ready = await health(config.server_url);
+  if (ready.server_instance_id !== config.server_instance_id) throw new Error("health server instance changed");
+  const capabilities = await request(config, "/v1/capabilities");
+  validateCapabilities(config, capabilities);
+  await event("capabilities", { team: config.local_team, current_seq: capabilities.current_seq,
+    policy_revision: capabilities.policy_revision });
+
+  const prepared = await driver("prepare", config, [{ type: "sync_prepare", envelope_v: 1,
+    cipher: "none", key_id: null, max_blob_bytes: Number(capabilities.max_blob_bytes) }], [String(limit)]);
+  const state = prepared.find((record) => record.type === "sync_state");
+  const candidates = prepared.filter((record) => record.type === "sync_push_candidate");
+  if (!state) throw new Error("driver omitted sync_state");
+  sequence(state.transport_cursor, "transport_cursor");
+  await event("push.prepared", { count: candidates.length, local_positions: candidates.map((item) => item.local_position),
+    wire_ids: candidates.map((item) => item.id) });
+
+  if (candidates.length > 0) {
+    const posted = await request(config, "/v1/messages", { method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: candidates.map(({ id, envelope }) => ({ id, envelope })) }) });
+    if (!Array.isArray(posted.acks) || posted.acks.length !== candidates.length) throw new Error("incomplete ack mapping");
+    const ackRecords = posted.acks.map((ack, index) => {
+      const candidate = candidates[index];
+      if (ack.id !== candidate.id || !["stored", "duplicate"].includes(ack.disposition)) throw new Error("ack order/id mismatch");
+      sequence(ack.server_seq, "ack server_seq");
+      return { type: "sync_push_ack", local_position: candidate.local_position, id: ack.id,
+        server_seq: ack.server_seq, disposition: ack.disposition };
+    });
+    await event("push.ack", { acks: ackRecords.map(({ id, server_seq, disposition }) => ({ id, server_seq, disposition })) });
+    const reconciled = await driver("reconcile", config, ackRecords);
+    await event("push.reconciled", { result: reconciled[0] ?? null });
+  }
+
+  let cursor = state.transport_cursor;
+  let pullCapabilities = capabilities;
+  for (;;) {
+    const page = await request(config, `/v1/messages?after=${encodeURIComponent(cursor)}&limit=${limit}`);
+    sequence(page.next_after, "next_after");
+    if (!Array.isArray(page.messages) || page.messages.length > limit || typeof page.has_more !== "boolean") {
+      throw new Error("pull page is invalid");
+    }
+    let expected = BigInt(cursor) + 1n;
+    for (const message of page.messages) {
+      sequence(message.server_seq, "message server_seq");
+      if (BigInt(message.server_seq) !== expected) throw new Error("pull page sequence is not contiguous");
+      expected += 1n;
+    }
+    const expectedNext = page.messages.at(-1)?.server_seq ?? cursor;
+    if (page.next_after !== expectedNext || (page.has_more && page.messages.length === 0)) {
+      throw new Error("pull page cursor/has_more is inconsistent");
+    }
+    if (BigInt(page.next_after) > BigInt(pullCapabilities.current_seq)) {
+      pullCapabilities = await request(config, "/v1/capabilities");
+      validateCapabilities(config, pullCapabilities);
+      if (BigInt(page.next_after) > BigInt(pullCapabilities.current_seq)) {
+        throw new Error("capability history does not cover the pull page");
+      }
+    }
+    const records = page.messages.map((message) => {
+      const evaluated = evaluatePull(config, pullCapabilities, message);
+      return { type: "sync_pull_message", ...message, ...evaluated };
+    });
+    records.push({ type: "sync_pull_cursor", next_after: page.next_after });
+    await event("pull.received", { after: cursor, next_after: page.next_after,
+      messages: page.messages.map((message) => ({ id: message.id, server_seq: message.server_seq })) });
+    const applied = await driver("apply", config, records);
+    for (const record of records) {
+      if (record.type === "sync_pull_message" && record.projection) {
+        await event("pull.import", { id: record.id, server_seq: record.server_seq,
+          from_agent: record.projection.from_agent, to_agent: record.projection.to_agent,
+          body: record.projection.body });
+      }
+    }
+    await event("pull.applied", { result: applied[0] ?? null });
+    cursor = page.next_after;
+    if (!page.has_more) break;
+  }
+}
+
+async function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  const args = options(rest);
+  if (!["configure", "once", "run"].includes(command)) throw new Error(usage());
+  if (command === "configure") { await configure(args); return; }
+  const team = requireName(args.team, "team");
+  const limit = Number(args.limit ?? 100);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 1000) throw new Error("limit must be 1..1000");
+  const config = await loadConfig(team);
+  if (command === "once") { await cycle(config, limit); return; }
+  const interval = Number(args.interval ?? 5);
+  if (!Number.isFinite(interval) || interval < 0.2) throw new Error("interval must be at least 0.2 seconds");
+  for (;;) {
+    try { await cycle(config, limit); }
+    catch (error) {
+      await event("cycle.error", { message: error.message, code: error.code ?? null });
+      if (error.status === 410 || error.code === "resync-required") throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval * 1000));
+  }
+}
+
+main().catch(async (error) => {
+  await event("fatal", { message: error.message, code: error.code ?? null });
+  process.stderr.write(`${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -87,7 +87,7 @@ function endpoint(base, path) {
   return root;
 }
 
-async function request(config, path, init = {}) {
+export async function request(config, path, init = {}) {
   const token = process.env.AGMSG_SYNC_TOKEN;
   if (!token) throw new Error("AGMSG_SYNC_TOKEN is required");
   const headers = {
@@ -96,9 +96,10 @@ async function request(config, path, init = {}) {
     Authorization: `Bearer ${token}`,
     ...init.headers,
   };
+  const url = endpoint(config.server_url, path);
   let response;
   try {
-    response = await fetch(endpoint(config.server_url, path), {
+    response = await fetch(url, {
       ...init, headers, redirect: "error", signal: AbortSignal.timeout(15_000),
     });
   } catch (error) {
@@ -106,10 +107,28 @@ async function request(config, path, init = {}) {
     throw error;
   }
   const protocol = response.headers.get("agmsg-protocol-version");
-  if (protocol !== PROTOCOL) throw new Error("response protocol version mismatch");
-  const text = await response.text();
+  let text;
+  try { text = await response.text(); } catch (error) {
+    error.retryable = true;
+    throw error;
+  }
   let body;
-  try { body = JSON.parse(text); } catch { throw new Error(`HTTP ${response.status} returned invalid JSON`); }
+  try { body = JSON.parse(text); } catch {
+    if (!response.ok && [502, 503, 504].includes(response.status)) {
+      const error = new Error(`HTTP ${response.status} intermediary failure`);
+      error.status = response.status; error.retryable = true;
+      throw error;
+    }
+    throw new Error(`HTTP ${response.status} returned invalid JSON`);
+  }
+  if (protocol !== PROTOCOL) {
+    if (!response.ok && [502, 503, 504].includes(response.status)) {
+      const error = new Error(`HTTP ${response.status} intermediary failure`);
+      error.status = response.status; error.retryable = true;
+      throw error;
+    }
+    throw new Error("response protocol version mismatch");
+  }
   if (!response.ok) {
     validateErrorBinding(config, response.status, body);
     const code = body?.error?.code ?? "unknown-error";
@@ -268,20 +287,60 @@ export function validateCapabilities(config, value) {
       !Array.isArray(value.accepted_envelope_versions) || !Array.isArray(value.write_allowed_ciphers)) {
     throw new Error("capabilities response is invalid");
   }
-  sequence(value.policy_revision, "policy_revision");
-  sequence(value.effective_from_seq, "effective_from_seq");
+  const current = BigInt(value.current_seq);
+  const floor = BigInt(value.min_available_seq);
+  if (floor > current) throw new Error("min_available_seq exceeds current_seq");
+  const currentRevision = BigInt(sequence(value.policy_revision, "policy_revision"));
+  const currentBoundary = BigInt(sequence(value.effective_from_seq, "effective_from_seq"));
   sequence(value.max_blob_bytes, "max_blob_bytes");
   if (BigInt(value.max_blob_bytes) < 1n || BigInt(value.max_blob_bytes) > 1_048_576n) {
     throw new Error("max_blob_bytes is outside the protocol limit");
   }
+  validatePolicySet(value.accepted_envelope_versions, value.write_allowed_ciphers, "current policy");
+  let previousRevision = -1n;
+  let previousBoundary = 0n;
   for (const entry of value.policy_history) {
-    sequence(entry.policy_revision, "policy history revision");
-    sequence(entry.effective_from_seq, "policy history boundary");
-    if (!Array.isArray(entry.accepted_envelope_versions) || !Array.isArray(entry.write_allowed_ciphers)) {
-      throw new Error("policy history entry is invalid");
+    const revision = BigInt(sequence(entry.policy_revision, "policy history revision"));
+    const boundary = BigInt(sequence(entry.effective_from_seq, "policy history boundary"));
+    validatePolicySet(entry.accepted_envelope_versions, entry.write_allowed_ciphers, "policy history");
+    if (revision <= previousRevision || boundary <= previousBoundary) {
+      throw new Error("policy history is not canonical ascending history");
     }
+    previousRevision = revision; previousBoundary = boundary;
   }
-  if (value.next_sequence_boundary !== null) sequence(value.next_sequence_boundary, "next_sequence_boundary");
+  if (BigInt(value.policy_history[0].effective_from_seq) !== 1n) {
+    throw new Error("policy history must begin at sequence 1");
+  }
+  const final = value.policy_history.at(-1);
+  if (BigInt(final.policy_revision) !== currentRevision ||
+      BigInt(final.effective_from_seq) !== currentBoundary ||
+      !sameArray(final.accepted_envelope_versions, value.accepted_envelope_versions) ||
+      !sameArray(final.write_allowed_ciphers, value.write_allowed_ciphers)) {
+    throw new Error("current policy does not match final policy history entry");
+  }
+  if (value.next_sequence_boundary === null) {
+    if (current !== MAX_SEQUENCE) throw new Error("next_sequence_boundary is unexpectedly null");
+  } else {
+    const next = BigInt(sequence(value.next_sequence_boundary, "next_sequence_boundary"));
+    if (current === MAX_SEQUENCE || next !== current + 1n) {
+      throw new Error("next_sequence_boundary does not follow current_seq");
+    }
+    if (previousBoundary > next) throw new Error("policy history starts beyond the next sequence boundary");
+  }
+}
+
+function validatePolicySet(versions, ciphers, label) {
+  if (!Array.isArray(versions) || versions.length < 1 ||
+      versions.some((version) => !Number.isInteger(version) || version < 0 || version > 0xffff_ffff) ||
+      new Set(versions).size !== versions.length || !Array.isArray(ciphers) ||
+      ciphers.some((cipher) => typeof cipher !== "string" || !/^[a-z0-9][a-z0-9._-]{0,63}$/u.test(cipher)) ||
+      new Set(ciphers).size !== ciphers.length) {
+    throw new Error(`${label} capability set is invalid`);
+  }
+}
+
+function sameArray(left, right) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 export function plaintextWriteEligible(config, value) {

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
 const UUID_V7 = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -95,15 +96,22 @@ async function request(config, path, init = {}) {
     Authorization: `Bearer ${token}`,
     ...init.headers,
   };
-  const response = await fetch(endpoint(config.server_url, path), {
-    ...init, headers, redirect: "error", signal: AbortSignal.timeout(15_000),
-  });
+  let response;
+  try {
+    response = await fetch(endpoint(config.server_url, path), {
+      ...init, headers, redirect: "error", signal: AbortSignal.timeout(15_000),
+    });
+  } catch (error) {
+    error.retryable = true;
+    throw error;
+  }
   const protocol = response.headers.get("agmsg-protocol-version");
   if (protocol !== PROTOCOL) throw new Error("response protocol version mismatch");
   const text = await response.text();
   let body;
   try { body = JSON.parse(text); } catch { throw new Error(`HTTP ${response.status} returned invalid JSON`); }
   if (!response.ok) {
+    validateErrorBinding(config, response.status, body);
     const code = body?.error?.code ?? "unknown-error";
     const error = new Error(`HTTP ${response.status} ${code}`);
     error.status = response.status; error.code = code; error.body = body;
@@ -113,16 +121,31 @@ async function request(config, path, init = {}) {
   return body;
 }
 
+export function validateErrorBinding(config, status, body) {
+  const preResolution = status === 400 || status === 401 || status === 426;
+  const carriesBinding = body?.server_instance_id !== undefined || body?.team_id !== undefined;
+  if (!preResolution || carriesBinding) validateBinding(config, body);
+}
+
 async function health(serverUrl) {
-  const response = await fetch(endpoint(serverUrl, "/v1/health"), {
-    redirect: "error", signal: AbortSignal.timeout(15_000),
-  });
+  let response;
+  try {
+    response = await fetch(endpoint(serverUrl, "/v1/health"), {
+      redirect: "error", signal: AbortSignal.timeout(15_000),
+    });
+  } catch (error) {
+    error.retryable = true;
+    throw error;
+  }
   if (response.headers.get("agmsg-protocol-version") !== PROTOCOL) {
     throw new Error("health protocol version mismatch");
   }
   const body = await response.json();
   if (!response.ok || body.status !== "ok" || body.database !== "ok" || !UUID_V7.test(body.server_instance_id)) {
-    throw new Error("server health is unavailable or unbound");
+    const error = new Error("server health is unavailable or unbound");
+    error.status = response.status;
+    error.retryable = response.status === 503;
+    throw error;
   }
   return body;
 }
@@ -134,13 +157,15 @@ function validateBinding(config, body) {
   }
 }
 
-async function driver(operation, config, input, extra = []) {
+export async function driver(operation, config, input, extra = []) {
   const script = process.env.AGMSG_SYNC_DRIVER;
   if (!script) throw new Error("AGMSG_SYNC_DRIVER is not set");
   const args = [script, operation, config.local_team, config.server_instance_id,
     config.remote_team_id, String(config.protocol_version), ...extra];
   return new Promise((resolve, reject) => {
-    const child = spawn("bash", args, { stdio: ["pipe", "pipe", "pipe"], env: process.env });
+    const childEnvironment = { ...process.env };
+    delete childEnvironment.AGMSG_SYNC_TOKEN;
+    const child = spawn("bash", args, { stdio: ["pipe", "pipe", "pipe"], env: childEnvironment });
     let stdout = ""; let stderr = "";
     child.stdout.setEncoding("utf8"); child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk) => { stdout += chunk; });
@@ -236,22 +261,65 @@ function evaluatePull(config, capabilities, message) {
   }
 }
 
-function validateCapabilities(config, value) {
+export function validateCapabilities(config, value) {
   validateBinding(config, value);
   sequence(value.current_seq, "current_seq"); sequence(value.min_available_seq, "min_available_seq");
   if (!Array.isArray(value.policy_history) || value.policy_history.length < 1 || value.policy_history.length > 4096 ||
       !Array.isArray(value.accepted_envelope_versions) || !Array.isArray(value.write_allowed_ciphers)) {
     throw new Error("capabilities response is invalid");
   }
-  if (!value.accepted_envelope_versions.includes(1) || !value.write_allowed_ciphers.includes("none")) {
-    throw new Error("server does not currently allow Stage-1 plaintext writes");
+  sequence(value.policy_revision, "policy_revision");
+  sequence(value.effective_from_seq, "effective_from_seq");
+  sequence(value.max_blob_bytes, "max_blob_bytes");
+  if (BigInt(value.max_blob_bytes) < 1n || BigInt(value.max_blob_bytes) > 1_048_576n) {
+    throw new Error("max_blob_bytes is outside the protocol limit");
   }
+  for (const entry of value.policy_history) {
+    sequence(entry.policy_revision, "policy history revision");
+    sequence(entry.effective_from_seq, "policy history boundary");
+    if (!Array.isArray(entry.accepted_envelope_versions) || !Array.isArray(entry.write_allowed_ciphers)) {
+      throw new Error("policy history entry is invalid");
+    }
+  }
+  if (value.next_sequence_boundary !== null) sequence(value.next_sequence_boundary, "next_sequence_boundary");
+}
+
+export function plaintextWriteEligible(config, value) {
+  validateCapabilities(config, value);
   const boundary = value.next_sequence_boundary;
-  if (boundary === null) throw new Error("remote sequence is exhausted");
-  sequence(boundary, "next_sequence_boundary");
-  if (currentLocalPolicy(config, boundary).minimum_security_mode !== "plaintext-allowed") {
-    throw new Error("local security policy disallows Stage-1 plaintext writes");
+  return boundary !== null && value.accepted_envelope_versions.includes(1) &&
+    value.write_allowed_ciphers.includes("none") &&
+    currentLocalPolicy(config, boundary).minimum_security_mode === "plaintext-allowed";
+}
+
+export function isRetryable(error) {
+  if (error?.retryable === true) return true;
+  return [408, 429, 500, 502, 503, 504].includes(error?.status);
+}
+
+export function validateAckMapping(candidates, acks) {
+  if (!Array.isArray(acks) || acks.length !== candidates.length) {
+    throw new Error("incomplete ack mapping");
   }
+  const seenIds = new Set();
+  const seenSequences = new Set();
+  let previous = -1n;
+  return acks.map((ack, index) => {
+    const candidate = candidates[index];
+    const fields = Object.keys(ack).sort().join(",");
+    if (fields !== "disposition,id,server_seq" || ack.id !== candidate.id ||
+        !["stored", "duplicate"].includes(ack.disposition)) {
+      throw new Error("ack shape/order/id mismatch");
+    }
+    sequence(ack.server_seq, "ack server_seq");
+    const current = BigInt(ack.server_seq);
+    if (seenIds.has(ack.id) || seenSequences.has(ack.server_seq) || current <= previous) {
+      throw new Error("ack sequence mapping is not strictly increasing and unique");
+    }
+    seenIds.add(ack.id); seenSequences.add(ack.server_seq); previous = current;
+    return { type: "sync_push_ack", local_position: candidate.local_position, id: ack.id,
+      server_seq: ack.server_seq, disposition: ack.disposition };
+  });
 }
 
 async function configure(args) {
@@ -285,8 +353,10 @@ async function cycle(config, limit) {
   await event("capabilities", { team: config.local_team, current_seq: capabilities.current_seq,
     policy_revision: capabilities.policy_revision });
 
+  const writeEligible = plaintextWriteEligible(config, capabilities);
   const prepared = await driver("prepare", config, [{ type: "sync_prepare", envelope_v: 1,
-    cipher: "none", key_id: null, max_blob_bytes: Number(capabilities.max_blob_bytes) }], [String(limit)]);
+    cipher: "none", key_id: null, max_blob_bytes: Number(capabilities.max_blob_bytes),
+    allow_new: writeEligible }], [String(limit)]);
   const state = prepared.find((record) => record.type === "sync_state");
   const candidates = prepared.filter((record) => record.type === "sync_push_candidate");
   if (!state) throw new Error("driver omitted sync_state");
@@ -294,18 +364,14 @@ async function cycle(config, limit) {
   await event("push.prepared", { count: candidates.length, local_positions: candidates.map((item) => item.local_position),
     wire_ids: candidates.map((item) => item.id) });
 
-  if (candidates.length > 0) {
+  if (!writeEligible) {
+    await event("push.blocked", { reason: capabilities.next_sequence_boundary === null ?
+      "sequence-exhausted" : "plaintext-write-not-allowed" });
+  } else if (candidates.length > 0) {
     const posted = await request(config, "/v1/messages", { method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ messages: candidates.map(({ id, envelope }) => ({ id, envelope })) }) });
-    if (!Array.isArray(posted.acks) || posted.acks.length !== candidates.length) throw new Error("incomplete ack mapping");
-    const ackRecords = posted.acks.map((ack, index) => {
-      const candidate = candidates[index];
-      if (ack.id !== candidate.id || !["stored", "duplicate"].includes(ack.disposition)) throw new Error("ack order/id mismatch");
-      sequence(ack.server_seq, "ack server_seq");
-      return { type: "sync_push_ack", local_position: candidate.local_position, id: ack.id,
-        server_seq: ack.server_seq, disposition: ack.disposition };
-    });
+    const ackRecords = validateAckMapping(candidates, posted.acks);
     await event("push.ack", { acks: ackRecords.map(({ id, server_seq, disposition }) => ({ id, server_seq, disposition })) });
     const reconciled = await driver("reconcile", config, ackRecords);
     await event("push.reconciled", { result: reconciled[0] ?? null });
@@ -344,12 +410,16 @@ async function cycle(config, limit) {
     await event("pull.received", { after: cursor, next_after: page.next_after,
       messages: page.messages.map((message) => ({ id: message.id, server_seq: message.server_seq })) });
     const applied = await driver("apply", config, records);
-    for (const record of records) {
-      if (record.type === "sync_pull_message" && record.projection) {
-        await event("pull.import", { id: record.id, server_seq: record.server_seq,
-          from_agent: record.projection.from_agent, to_agent: record.projection.to_agent,
-          body: record.projection.body });
-      }
+    for (const outcome of applied.filter((record) => record.type === "sync_apply_outcome")) {
+      const source = records.find((record) => record.type === "sync_pull_message" && record.id === outcome.id);
+      await event(outcome.status === "imported" ? "pull.import" :
+        outcome.status === "reconciled" ? "pull.reconciled" : "pull.quarantined", {
+        id: outcome.id, server_seq: outcome.server_seq, status: outcome.status,
+        ...(outcome.status === "imported" && source?.projection ? {
+          from_agent: source.projection.from_agent, to_agent: source.projection.to_agent,
+          body: source.projection.body,
+        } : {}),
+      });
     }
     await event("pull.applied", { result: applied[0] ?? null });
     cursor = page.next_after;
@@ -373,14 +443,16 @@ async function main() {
     try { await cycle(config, limit); }
     catch (error) {
       await event("cycle.error", { message: error.message, code: error.code ?? null });
-      if (error.status === 410 || error.code === "resync-required") throw error;
+      if (!isRetryable(error)) throw error;
     }
     await new Promise((resolve) => setTimeout(resolve, interval * 1000));
   }
 }
 
-main().catch(async (error) => {
-  await event("fatal", { message: error.message, code: error.code ?? null });
-  process.stderr.write(`${error.message}\n`);
-  process.exitCode = 1;
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(async (error) => {
+    await event("fatal", { message: error.message, code: error.code ?? null });
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/internal/storage-sync-driver.sh
+++ b/scripts/internal/storage-sync-driver.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Private adapter between the Node polling engine and sourced storage drivers.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+export SKILL_DIR
+# shellcheck disable=SC1091
+. "$SKILL_DIR/scripts/lib/storage.sh"
+agmsg_storage_load
+
+op="${1:-}"; shift || true
+case "$op" in
+  prepare)   command -v storage_sync_prepare_push >/dev/null 2>&1 || exit 14
+             storage_sync_prepare_push "$@" ;;
+  reconcile) command -v storage_sync_reconcile_push >/dev/null 2>&1 || exit 14
+             storage_sync_reconcile_push "$@" ;;
+  apply)     command -v storage_sync_apply_pull >/dev/null 2>&1 || exit 14
+             storage_sync_apply_pull "$@" ;;
+  *) echo "usage: storage-sync-driver.sh prepare|reconcile|apply ..." >&2; exit 2 ;;
+esac

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -179,3 +179,66 @@ agmsg_sql_readfile_path() {
   fi
   printf '%s' "$path" | sed "s/'/''/g"
 }
+
+# ── Storage driver facade (storage axis) ─────────────────────────────────────
+# The helpers above resolve the legacy sqlite path and run raw SQL; call sites
+# keep using them until #206 migrates them onto the contract below. The facade
+# resolves the *active* storage driver, sources it, and makes the storage_*
+# contract (docs/spec/driver-interface.md §2 / ADR 0003) available. Driver
+# discovery + trust reuse the axis-generic registry (ADR 0002, driver-registry.sh).
+
+# Path to the machine-wide driver config (spec §4). Overridable for tests.
+_agmsg_storage_config_path() {
+  printf '%s\n' "${AGMSG_CONFIG:-$HOME/.agents/agmsg/config.json}"
+}
+
+# Active storage driver name: env override > config "storage" key > built-in.
+agmsg_storage_driver() {
+  if [ -n "${AGMSG_STORAGE_DRIVER:-}" ]; then
+    printf '%s\n' "$AGMSG_STORAGE_DRIVER"
+    return 0
+  fi
+  local cfg name
+  cfg="$(_agmsg_storage_config_path)"
+  if [ -n "$cfg" ] && [ -f "$cfg" ]; then
+    name="$(sqlite3 :memory: \
+      "SELECT COALESCE(json_extract(readfile('$(agmsg_sql_readfile_path "$cfg")'), '\$.storage'), '')" \
+      2>/dev/null | tr -d '\r')"
+    if [ -n "$name" ] && [ "$name" != "null" ]; then
+      printf '%s\n' "$name"
+      return 0
+    fi
+  fi
+  printf 'sqlite\n'
+}
+
+# Locate and source the active storage driver's storage_* functions. Idempotent.
+# Resolution reuses the registry search bases (in-tree builtins always trusted;
+# external plugin dirs gated by the opt-in trustfile, ADR 0002).
+_AGMSG_STORAGE_LOADED=""
+agmsg_storage_load() {
+  [ -n "$_AGMSG_STORAGE_LOADED" ] && return 0
+  # Pull in the axis-generic registry once (its functions may not be sourced yet).
+  if ! command -v agmsg_driver_bases >/dev/null 2>&1; then
+    local _lib
+    _lib="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+    # shellcheck disable=SC1091
+    [ -n "$_lib" ] && . "$_lib/driver-registry.sh"
+  fi
+  local name file kind base
+  name="$(agmsg_storage_driver)"
+  while IFS="$(printf '\t')" read -r kind base; do
+    [ -n "$base" ] || continue
+    file="$base/storage/$name.sh"
+    [ -f "$file" ] || continue
+    if [ "$kind" = external ] && ! agmsg_driver_is_trusted storage "$name" "$file"; then
+      continue
+    fi
+    # shellcheck disable=SC1090
+    . "$file"
+    _AGMSG_STORAGE_LOADED="$name"
+    return 0
+  done < <(agmsg_driver_bases)
+  printf 'agmsg: no trusted storage driver "%s" found\n' "$name" >&2
+  return 1
+}

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -180,6 +180,17 @@ agmsg_sql_readfile_path() {
   printf '%s' "$path" | sed "s/'/''/g"
 }
 
+# Escape an arbitrary scalar for safe interpolation into a SQL string literal
+# (double every single quote). Same semantics as the sqlite driver's internal
+# _sqlite_lit / storage_send escaping, but driver-agnostic and available to the
+# registry scripts that still write the legacy messages table directly
+# (rename.sh / rename-team.sh). A team or agent name may legitimately contain a
+# single quote (validate.sh only blocks path traversal), which would otherwise
+# break the INSERT/UPDATE and is an injection surface (#223, #87).
+agmsg_sqlesc() {
+  printf '%s' "$1" | sed "s/'/''/g"
+}
+
 # ── Storage driver facade (storage axis) ─────────────────────────────────────
 # The helpers above resolve the legacy sqlite path and run raw SQL; call sites
 # keep using them until #206 migrates them onto the contract below. The facade

--- a/scripts/remote-sync.sh
+++ b/scripts/remote-sync.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Stage-1 polling synchronization client (dogfood; ADR 0005).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export SKILL_DIR
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/storage.sh"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/node.sh"
+export AGMSG_SYNC_STORAGE_DIR="$(agmsg_storage_dir)"
+export AGMSG_SYNC_DRIVER="$SCRIPT_DIR/internal/storage-sync-driver.sh"
+NODE_BIN="$(agmsg_resolve_node)"
+exec "$NODE_BIN" "$SCRIPT_DIR/internal/remote-sync.mjs" "$@"

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -80,8 +80,14 @@ if [ -f "$NEW_CONFIG" ]; then
 fi
 
 # --- Update messages in DB ---
+# Rewrite the team name in BOTH stores: the event log (where storage_send now
+# writes) and the legacy messages table (pre-event-log installs). Without the
+# events update a rename would orphan every message sent after the storage flip.
 if [ -f "$DB" ]; then
   agmsg_sqlite "$DB" "UPDATE messages SET team='$(_agmsg_sqlesc "$NEW_TEAM")' WHERE team='$(_agmsg_sqlesc "$OLD_TEAM")';"
+  # events may not exist yet on an install that has not sent since the storage
+  # flip — best-effort, never abort the rename over a missing optional table.
+  agmsg_sqlite "$DB" "UPDATE events SET team='$(_agmsg_sqlesc "$NEW_TEAM")' WHERE team='$(_agmsg_sqlesc "$OLD_TEAM")';" 2>/dev/null || true
 fi
 
 agmsg_lock_release

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -28,9 +28,6 @@ agmsg_validate_team_name "$OLD_TEAM" || exit 1
 agmsg_validate_team_name "$NEW_TEAM" || exit 1
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 DB="$(agmsg_db_path)"
-# Escape interpolated identifiers as SQL string literals (parity with
-# send.sh): a team/agent name with a single quote would break the UPDATE.
-_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
 OLD_DIR="$TEAMS_DIR/$OLD_TEAM"
 NEW_DIR="$TEAMS_DIR/$NEW_TEAM"
 
@@ -71,23 +68,34 @@ fi
 mv "$OLD_DIR/config.json" "$NEW_DIR/config.json"
 
 # --- Update name in config.json ---
+# Read the config with readfile() (not `.param set`, whose dot-command tokenizer
+# does NOT honour SQL '' escaping, so an apostrophe in the config content breaks
+# the binding) and escape the new team name as a SQL string literal (#223, #87):
+# a team name may contain a single quote (validate.sh only blocks path traversal).
+# Mirrors join.sh's readfile-based, apostrophe-safe registry read.
 NEW_CONFIG="$NEW_DIR/config.json"
 if [ -f "$NEW_CONFIG" ]; then
-  CONFIG_ESCAPED=$(sed "s/'/''/g" "$NEW_CONFIG")
-  UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
-    "SELECT json_set(:json, '\$.name', '$NEW_TEAM');")
-  agmsg_write_atomic "$NEW_CONFIG" "$UPDATED"
+  CONFIG_SQL=$(agmsg_sql_readfile_path "$NEW_CONFIG")
+  NEW_TEAM_LIT=$(agmsg_sqlesc "$NEW_TEAM")
+  UPDATED=$(agmsg_sqlite_mem \
+    "SELECT json_set(CAST(readfile('$CONFIG_SQL') AS TEXT), '\$.name', '$NEW_TEAM_LIT');")
+  echo "$UPDATED" > "$NEW_CONFIG"
 fi
 
 # --- Update messages in DB ---
 # Rewrite the team name in BOTH stores: the event log (where storage_send now
 # writes) and the legacy messages table (pre-event-log installs). Without the
 # events update a rename would orphan every message sent after the storage flip.
+# Escape both team names as SQL string literals (#223, #87): a team name may
+# contain a single quote (validate.sh only blocks path traversal), which would
+# otherwise break the UPDATE and is an injection surface.
 if [ -f "$DB" ]; then
-  agmsg_sqlite "$DB" "UPDATE messages SET team='$(_agmsg_sqlesc "$NEW_TEAM")' WHERE team='$(_agmsg_sqlesc "$OLD_TEAM")';"
+  OLD_LIT=$(agmsg_sqlesc "$OLD_TEAM")
+  NEW_LIT=$(agmsg_sqlesc "$NEW_TEAM")
+  agmsg_sqlite "$DB" "UPDATE messages SET team='$NEW_LIT' WHERE team='$OLD_LIT';"
   # events may not exist yet on an install that has not sent since the storage
   # flip — best-effort, never abort the rename over a missing optional table.
-  agmsg_sqlite "$DB" "UPDATE events SET team='$(_agmsg_sqlesc "$NEW_TEAM")' WHERE team='$(_agmsg_sqlesc "$OLD_TEAM")';" 2>/dev/null || true
+  agmsg_sqlite "$DB" "UPDATE events SET team='$NEW_LIT' WHERE team='$OLD_LIT';" 2>/dev/null || true
 fi
 
 agmsg_lock_release

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -19,9 +19,6 @@ source "$SCRIPT_DIR/lib/validate.sh"
 agmsg_validate_team_name "$TEAM" || exit 1
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 DB="$(agmsg_db_path)"
-# Escape interpolated identifiers as SQL string literals (parity with
-# send.sh): a team/agent name with a single quote would break the UPDATE.
-_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
 
 if [ ! -f "$TEAM_CONFIG" ]; then
@@ -64,8 +61,8 @@ UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
 # the old name) so a name containing a single quote can't break the JSON path
 # expression the way `$.agents.$OLD_NAME` above requires it not to — from/to
 # are bound as ordinary SQL string values, never spliced into a path.
-OLD_NAME_SQL=$(_agmsg_sqlesc "$OLD_NAME")
-NEW_NAME_SQL=$(_agmsg_sqlesc "$NEW_NAME")
+OLD_NAME_SQL=$(agmsg_sqlesc "$OLD_NAME")
+NEW_NAME_SQL=$(agmsg_sqlesc "$NEW_NAME")
 RENAMED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 UPDATED_ESCAPED=$(printf '%s' "$UPDATED" | sed "s/'/''/g")
 UPDATED=$(agmsg_sqlite_mem ".param set :json '$UPDATED_ESCAPED'" \
@@ -80,9 +77,23 @@ UPDATED=$(agmsg_sqlite_mem ".param set :json '$UPDATED_ESCAPED'" \
 agmsg_write_atomic "$TEAM_CONFIG" "$UPDATED"
 
 # --- Update messages in DB ---
+# Rewrite the agent name in BOTH stores: the event log (where storage_send now
+# writes) and the legacy messages table (pre-event-log installs). Without the
+# events update a rename would orphan every message sent after the storage flip
+# (mirrors rename-team.sh's team-name rewrite for the same reason).
+# Escape every interpolated value as a SQL string literal (#223, #87): an agent
+# or team name may contain a single quote, which would otherwise break the UPDATE
+# and is an injection surface (e.g. a name widening the WHERE predicate).
 if [ -f "$DB" ]; then
-  agmsg_sqlite "$DB" "UPDATE messages SET from_agent='$(_agmsg_sqlesc "$NEW_NAME")' WHERE team='$(_agmsg_sqlesc "$TEAM")' AND from_agent='$(_agmsg_sqlesc "$OLD_NAME")';"
-  agmsg_sqlite "$DB" "UPDATE messages SET to_agent='$(_agmsg_sqlesc "$NEW_NAME")' WHERE team='$(_agmsg_sqlesc "$TEAM")' AND to_agent='$(_agmsg_sqlesc "$OLD_NAME")';"
+  TEAM_LIT=$(agmsg_sqlesc "$TEAM")
+  OLD_LIT=$(agmsg_sqlesc "$OLD_NAME")
+  NEW_LIT=$(agmsg_sqlesc "$NEW_NAME")
+  agmsg_sqlite "$DB" "UPDATE messages SET from_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND from_agent='$OLD_LIT';"
+  agmsg_sqlite "$DB" "UPDATE messages SET to_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND to_agent='$OLD_LIT';"
+  # events may not exist yet on an install that has not sent since the storage
+  # flip — best-effort, never abort the rename over a missing optional table.
+  agmsg_sqlite "$DB" "UPDATE events SET from_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND from_agent='$OLD_LIT';" 2>/dev/null || true
+  agmsg_sqlite "$DB" "UPDATE events SET to_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND to_agent='$OLD_LIT';" 2>/dev/null || true
 fi
 
 agmsg_lock_release

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -23,8 +23,11 @@ source "$SCRIPT_DIR/lib/validate.sh"
 # never bypass team-name path safety.
 agmsg_validate_team_name "$TEAM" || exit 1
 
+agmsg_storage_load
 DB="$(agmsg_db_path)"
 
+# Keep the full-schema bootstrap (registry + storage tables) for a first-ever
+# command; the message write itself goes through the storage facade below.
 [ -f "$DB" ] || bash "$SCRIPT_DIR/internal/init-db.sh" >/dev/null
 
 # #355: reject a from/to that isn't registered in <team> — an unnoticed typo
@@ -69,25 +72,11 @@ if [ "$FORCE" -ne 1 ]; then
   _agmsg_roster_check "to" "$TO" || exit 1
 fi
 
-# Escape EVERY interpolated value as a SQL string literal, not just body: a
-# team/agent name containing a single quote would otherwise break the INSERT
-# (correctness) or change its meaning (injection surface).
-_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
-INSERT="INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('$(_agmsg_sqlesc "$TEAM")', '$(_agmsg_sqlesc "$FROM")', '$(_agmsg_sqlesc "$TO")', '$(_agmsg_sqlesc "$BODY")');"
-
-# Retry once after ensuring the schema. Under a concurrent first-write fan-out
-# (leader → N members against a fresh/override store), one process can see the
-# DB file exist before the winning initializer has finished creating the table,
-# so its INSERT would hit "no such table". init-db.sh is idempotent + uses the
-# busy_timeout, so re-running it waits for the schema, then the INSERT lands.
-# See #114.
-# Pipe the SQL via stdin (not as an argv) so a large body cannot overflow the
-# OS command-line limit (the "Argument list too long" crash).
-if ! printf '%s
-' "$INSERT" | agmsg_sqlite "$DB" 2>/dev/null; then
-  bash "$SCRIPT_DIR/internal/init-db.sh" >/dev/null
-  printf '%s
-' "$INSERT" | agmsg_sqlite "$DB"
-fi
+# Write through the storage axis (§2.1 storage_send) — the active driver now owns
+# the message log (an append-only message_sent event), not a direct INSERT.
+# storage_send re-inits its schema idempotently before writing, which subsumes the
+# #114 concurrent first-write race the old path retried around (a process seeing
+# the DB file before the table exists just creates it). The new id is not surfaced.
+storage_send "$TEAM" "$FROM" "$TO" "$BODY" >/dev/null
 
 echo "Sent to $TO in team $TEAM"

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -364,8 +364,12 @@ while true; do
           # despawn target) must NOT act on it — its $TMUX_PANE is the leader's
           # own pane, so killing it would take down the leader's session. The
           # spawned member's watcher runs in actas mode (ACTIVE_NAME=$to) in its
-          # own pane; that's the one meant to respond. The trailing cursor still
-          # advances the watermark past this control message at the batch end. See #109.
+          # own pane; that's the one meant to respond. A broad watcher `continue`s
+          # and reaches the trailing cursor at batch end, so its watermark advances
+          # past this control message. The target watcher below exits BEFORE the
+          # cursor record, so it does not persist a cursor — harmless, since it
+          # drops the role and won't resume as it; a same-session resume would
+          # re-read the despawn (at-least-once) and re-tear-down idempotently. See #109.
           if [ -z "$ACTIVE_NAME" ] || [ "$to" != "$ACTIVE_NAME" ]; then
             continue
           fi

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -45,6 +45,7 @@ ACTIVE_NAME="${4:-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
+agmsg_storage_load
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/actas-lock.sh"
 # shellcheck disable=SC1091
@@ -230,18 +231,13 @@ if [ -z "$PAIRS" ]; then
   exit 0
 fi
 
-# Build the SQL WHERE clause. Each pair contributes:
-#   (team='<team>' AND to_agent='<agent>')
-# joined by OR. Single quotes inside team/agent names are doubled for SQL.
-sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
-
-WHERE_PAIRS=""
+# SUB_PAIRS holds the subscription as <team>:<agent> tokens — the argument form
+# the storage facade's watch ops take (§2.2). Live delivery goes entirely through
+# storage_watch_tip / storage_watch_after now, so no SQL WHERE clause is built here.
+SUB_PAIRS=()
 while IFS=$'\t' read -r team agent; do
   [ -z "$team" ] && continue
-  t_esc=$(sql_escape "$team")
-  a_esc=$(sql_escape "$agent")
-  pair="(team='$t_esc' AND to_agent='$a_esc')"
-  WHERE_PAIRS="${WHERE_PAIRS:+$WHERE_PAIRS OR }$pair"
+  SUB_PAIRS+=("$team:$agent")
 done <<< "$PAIRS"
 
 # Determine the starting watermark.
@@ -259,20 +255,22 @@ done <<< "$PAIRS"
 # A *fresh* session (no persisted watermark) still starts from the current
 # MAX(id) — live push, no replay of history (the no-arg inbox check covers
 # historical unread, not this stream).
+# The watermark is now an OPAQUE delivery cursor (§2.2), not an integer id — the
+# active storage driver issues and interprets it; this script only persists the
+# latest token and passes it back unchanged.
 WATERMARK_FILE="$RUN_DIR/watch.$SESSION_ID.watermark"
 persist_watermark() { printf '%s\n' "$LAST" > "$WATERMARK_FILE" 2>/dev/null || true; }
 
 LAST=""
 if [ -f "$WATERMARK_FILE" ]; then
-  LAST="$(cat "$WATERMARK_FILE" 2>/dev/null || true)"
-  case "$LAST" in ''|*[!0-9]*) LAST="" ;; esac
+  # Opaque token: a single whitespace-free line. No integer validation — just
+  # strip stray surrounding whitespace.
+  LAST="$(tr -d '[:space:]' < "$WATERMARK_FILE" 2>/dev/null || true)"
 fi
 if [ -z "$LAST" ]; then
-  LAST=0
-  if [ -f "$DB" ]; then
-    LAST="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE $WHERE_PAIRS;" 2>/dev/null || echo 0)"
-  fi
-  case "$LAST" in ''|*[!0-9]*) LAST=0 ;; esac
+  # A fresh watcher starts from the current tip (live push, no history replay).
+  LAST="$(storage_watch_tip "${SUB_PAIRS[@]}" 2>/dev/null || true)"
+  case "$LAST" in '') LAST=0 ;; esac
   persist_watermark
 fi
 
@@ -323,16 +321,36 @@ while true; do
     exit 0
   fi
   if [ -f "$DB" ]; then
-    ROWS="$(agmsg_sqlite -separator $'\x1f' "$DB" "
-      SELECT id, created_at, team, from_agent, to_agent,
-             replace(replace(body, char(13), ''), char(10), '\\n')
-      FROM messages
-      WHERE id > $LAST AND ($WHERE_PAIRS)
-      ORDER BY id;
-    " 2>/dev/null || true)"
+    # Pull messages after the cursor via the storage facade (§2.2). The output is
+    # JSONL: zero or more message_sent records in delivery order, then a trailing
+    # {"type":"cursor","cursor":"<token>"} as the LAST line — the position to
+    # resume from. Parse every record in one pass with sqlite's JSON funcs (the
+    # repo idiom; no jq). Newlines/tabs in the body are escaped to keep one line.
+    OUT="$(storage_watch_after "$LAST" "${SUB_PAIRS[@]}" 2>/dev/null || true)"
+    if [ -n "$OUT" ]; then
+      _arr="[$(printf '%s' "$OUT" | paste -sd, -)]"
+      ROWS="$(agmsg_sqlite ':memory:' "
+        SELECT COALESCE(json_extract(value,'\$.type'),'') || char(31) ||
+               COALESCE(json_extract(value,'\$.id'),'') || char(31) ||
+               COALESCE(json_extract(value,'\$.at'),'') || char(31) ||
+               COALESCE(json_extract(value,'\$.team'),'') || char(31) ||
+               COALESCE(json_extract(value,'\$.from'),'') || char(31) ||
+               COALESCE(json_extract(value,'\$.to'),'') || char(31) ||
+               replace(replace(replace(COALESCE(json_extract(value,'\$.body'),''), char(13), ''), char(10), '\\n'), char(9), '\t') || char(31) ||
+               COALESCE(json_extract(value,'\$.cursor'),'')
+        FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+      " 2>/dev/null || true)"
 
-    if [ -n "$ROWS" ]; then
-      while IFS=$'\x1f' read -r id ts team from to body; do
+      while IFS=$'\x1f' read -r kind id ts team from to body cursor; do
+        [ -z "$kind" ] && continue
+        if [ "$kind" = "cursor" ]; then
+          # Trailing cursor = the resume point. Advance + persist only after the
+          # batch's messages were delivered above; a crash mid-batch re-delivers
+          # from the old cursor (at-least-once, never skip — §2.2).
+          LAST="$cursor"; persist_watermark
+          continue
+        fi
+        [ "$kind" = "message_sent" ] || continue
         [ -z "$id" ] && continue
         # Control message: a leader's `despawn` sends `ctrl:despawn` to this
         # role. Tear ourselves down rather than printing it — drop the role
@@ -340,14 +358,14 @@ while true; do
         # which also ends the agent CLI sharing it. Deterministic teardown, no
         # dependence on the agent LLM noticing the message. See #109.
         if [ "$body" = "ctrl:despawn" ]; then
-          LAST="$id"; persist_watermark
           # Only an EXCLUSIVE watcher dedicated to exactly this role tears
           # itself down. A broad-subscription watcher (e.g. a leader whose
           # default watcher subscribes to every project role, including the
           # despawn target) must NOT act on it — its $TMUX_PANE is the leader's
           # own pane, so killing it would take down the leader's session. The
           # spawned member's watcher runs in actas mode (ACTIVE_NAME=$to) in its
-          # own pane; that's the one meant to respond. See #109.
+          # own pane; that's the one meant to respond. The trailing cursor still
+          # advances the watermark past this control message at the batch end. See #109.
           if [ -z "$ACTIVE_NAME" ] || [ "$to" != "$ACTIVE_NAME" ]; then
             continue
           fi
@@ -363,8 +381,6 @@ while true; do
           cleanup
           exit 0
         fi
-        LAST="$id"
-        persist_watermark
       done <<< "$ROWS"
     fi
   fi

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+test
+.env

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY migrations ./migrations
+COPY src ./src
+RUN npm run build
+
+FROM node:22-alpine
+ENV NODE_ENV=production
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY --from=build /app/dist ./dist
+USER node
+EXPOSE 8787
+CMD ["node", "dist/src/index.js"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
-COPY tsconfig.json ./
+COPY tsconfig.json tsconfig.build.json ./
 COPY migrations ./migrations
 COPY src ./src
 RUN npm run build

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,64 @@
+# agmsg remote storage reference server
+
+This directory contains the thin, self-hosted PostgreSQL reference
+implementation of the [HTTP API v1 contract](spec/v1.md). It is independent of
+the root installer package and desktop app.
+
+The server currently implements the v1 plaintext envelope (`cipher: "none"`).
+It stores envelope blobs opaquely and does not inspect sender, recipient, body,
+or client creation time. Authentication is a deployment concern in the protocol;
+this reference uses one required bearer token and still authorizes every
+team-scoped operation against an immutable `Agmsg-Team-ID`.
+
+## Run with Compose
+
+Change the token and database password in `compose.yaml` before exposing the
+service outside a local development machine, then run:
+
+```sh
+docker compose up --build
+```
+
+`GET /v1/health` is available without credentials. The message, member, and
+capability endpoints require these headers:
+
+```http
+Authorization: Bearer <AGMSG_SERVER_TOKEN>
+Agmsg-Protocol-Version: 1
+Agmsg-Team-ID: <immutable UUIDv7 team ID>
+```
+
+## Run from source
+
+Node.js 22 and PostgreSQL 17 are the reference versions.
+
+```sh
+npm install
+export DATABASE_URL=postgresql://localhost/agmsg
+export AGMSG_SERVER_TOKEN='replace-with-at-least-16-bytes'
+npm run migrate
+npm run provision -- example/team.json
+npm run dev
+```
+
+The server also runs the idempotent migration at startup. Team creation and
+roster mutation remain outside HTTP v1: the provisioning command atomically
+applies the complete operator-owned roster manifest. IDs and retired names are
+checked against permanent identity history before replacement.
+
+## Verify
+
+Integration tests use an isolated, randomly named PostgreSQL schema. The test
+only removes the schema it created and validates its generated name first.
+
+```sh
+export TEST_DATABASE_URL=postgresql://localhost/agmsg_test
+npm run typecheck
+npm test
+npm run build
+```
+
+The integration suite covers atomic batch rollback, complete input-order ack
+mapping, transactional team sequence allocation, UUID conflict handling,
+retention tombstones, cursor floors, capability snapshots, roster reads, and
+strict JSON framing.

--- a/server/README.md
+++ b/server/README.md
@@ -46,6 +46,14 @@ roster mutation remain outside HTTP v1: the provisioning command atomically
 applies the complete operator-owned roster manifest. IDs and retired names are
 checked against permanent identity history before replacement.
 
+Retention is also an operator operation. It atomically creates permanent
+idempotency tombstones, removes the covered delivery prefix, and advances the
+team cursor floor while holding the same team-row lock as writers:
+
+```sh
+npm run retain -- <team-uuid> <through-sequence>
+```
+
 ## Verify
 
 Integration tests use an isolated, randomly named PostgreSQL schema. The test

--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -1,0 +1,30 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: agmsg
+      POSTGRES_USER: agmsg
+      POSTGRES_PASSWORD: agmsg-local-only
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U agmsg -d agmsg"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+    volumes:
+      - agmsg-postgres:/var/lib/postgresql/data
+
+  server:
+    build: .
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://agmsg:agmsg-local-only@postgres:5432/agmsg
+      AGMSG_SERVER_TOKEN: change-this-development-token
+      HOST: 0.0.0.0
+      PORT: 8787
+    ports:
+      - "8787:8787"
+
+volumes:
+  agmsg-postgres:

--- a/server/example/team.json
+++ b/server/example/team.json
@@ -1,0 +1,17 @@
+{
+  "team_id": "018f3f7e-0000-7000-8000-000000000001",
+  "team_name": "example-team",
+  "members": [
+    {
+      "member_id": "018f3f7e-0000-7000-8000-000000000010",
+      "name": "worker-1",
+      "registrations": [
+        {
+          "registration_id": "018f3f7e-0000-7000-8000-000000000011",
+          "installation_id": "018f3f7e-0000-7000-8000-000000000012",
+          "type": "codex"
+        }
+      ]
+    }
+  ]
+}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -1,0 +1,89 @@
+CREATE TABLE IF NOT EXISTS server_metadata (
+  singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+  server_instance_id UUID NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+);
+
+CREATE TABLE IF NOT EXISTS teams (
+  team_id UUID PRIMARY KEY,
+  team_name TEXT NOT NULL,
+  current_seq BIGINT NOT NULL DEFAULT 0 CHECK (current_seq >= 0),
+  min_available_seq BIGINT NOT NULL DEFAULT 0,
+  policy_revision BIGINT NOT NULL DEFAULT 0 CHECK (policy_revision >= 0),
+  accepted_envelope_versions INTEGER[] NOT NULL DEFAULT ARRAY[1],
+  write_allowed_ciphers TEXT[] NOT NULL DEFAULT ARRAY['none']::TEXT[],
+  max_blob_bytes INTEGER NOT NULL DEFAULT 1048576
+    CHECK (max_blob_bytes BETWEEN 1 AND 1048576),
+  members_revision BIGINT NOT NULL DEFAULT 0 CHECK (members_revision >= 0),
+  CHECK (min_available_seq >= 0 AND min_available_seq <= current_seq)
+);
+
+CREATE TABLE IF NOT EXISTS team_policy_history (
+  team_id UUID NOT NULL REFERENCES teams(team_id) ON DELETE RESTRICT,
+  policy_revision BIGINT NOT NULL CHECK (policy_revision >= 0),
+  effective_from_seq BIGINT NOT NULL CHECK (effective_from_seq >= 1),
+  accepted_envelope_versions INTEGER[] NOT NULL,
+  write_allowed_ciphers TEXT[] NOT NULL,
+  PRIMARY KEY (team_id, policy_revision)
+);
+
+CREATE INDEX IF NOT EXISTS team_policy_history_effective_idx
+  ON team_policy_history(team_id, effective_from_seq, policy_revision DESC);
+
+CREATE TABLE IF NOT EXISTS messages (
+  team_id UUID NOT NULL REFERENCES teams(team_id) ON DELETE RESTRICT,
+  id UUID NOT NULL,
+  team_seq BIGINT NOT NULL CHECK (team_seq >= 1),
+  server_received_at TIMESTAMPTZ(6) NOT NULL DEFAULT clock_timestamp(),
+  envelope_v INTEGER NOT NULL,
+  cipher TEXT NOT NULL,
+  key_id TEXT,
+  blob TEXT NOT NULL,
+  envelope_digest BYTEA NOT NULL,
+  PRIMARY KEY (team_id, id),
+  UNIQUE (team_id, team_seq)
+);
+
+CREATE TABLE IF NOT EXISTS message_tombstones (
+  team_id UUID NOT NULL REFERENCES teams(team_id) ON DELETE RESTRICT,
+  id UUID NOT NULL,
+  original_team_seq BIGINT NOT NULL CHECK (original_team_seq >= 1),
+  envelope_digest BYTEA NOT NULL,
+  PRIMARY KEY (team_id, id)
+);
+
+CREATE TABLE IF NOT EXISTS members (
+  team_id UUID NOT NULL REFERENCES teams(team_id) ON DELETE RESTRICT,
+  member_id UUID NOT NULL,
+  name TEXT NOT NULL,
+  PRIMARY KEY (team_id, member_id),
+  UNIQUE (team_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS member_identity_history (
+  team_id UUID NOT NULL REFERENCES teams(team_id) ON DELETE RESTRICT,
+  member_id UUID NOT NULL,
+  name TEXT NOT NULL,
+  PRIMARY KEY (team_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS member_identity_history_member_idx
+  ON member_identity_history(team_id, member_id);
+
+CREATE TABLE IF NOT EXISTS registrations (
+  team_id UUID NOT NULL,
+  registration_id UUID NOT NULL,
+  member_id UUID NOT NULL,
+  installation_id UUID NOT NULL,
+  type TEXT NOT NULL,
+  PRIMARY KEY (team_id, registration_id),
+  FOREIGN KEY (team_id, member_id)
+    REFERENCES members(team_id, member_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS registration_identity_history (
+  team_id UUID NOT NULL REFERENCES teams(team_id) ON DELETE RESTRICT,
+  registration_id UUID NOT NULL,
+  member_id UUID NOT NULL,
+  PRIMARY KEY (team_id, registration_id)
+);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,2990 @@
+{
+  "name": "@agmsg/reference-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@agmsg/reference-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "fastify": "5.10.0",
+        "json-dup-key-validator": "1.0.3",
+        "pg": "8.22.0",
+        "uuid": "14.0.1",
+        "zod": "4.4.3"
+      },
+      "devDependencies": {
+        "@types/node": "^22.20.1",
+        "@types/pg": "8.20.0",
+        "tsx": "4.23.1",
+        "typescript": "7.0.2",
+        "vitest": "4.1.10"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+      "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.1.0.tgz",
+      "integrity": "sha512-PxcYtKLbQ8Z+yApiqjK8FwxIwvEj38k2OiLc17u8dkJSlmfi2wHHPaSnaoqBPQqtvF8YVsDgDpP2snDCfFrpfw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^7.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+      "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.3.0.tgz",
+      "integrity": "sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/backslash": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/backslash/-/backslash-0.2.2.tgz",
+      "integrity": "sha512-PKRYPE2LLTtNUYz1dszquxKSBs6XyLyJRHgFpY5rlq7y3DscDx239k5Gm+zenoY47OU4CApan1o0k2R8ptZC1Q=="
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/fast-uri": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.10.0.tgz",
+      "integrity": "sha512-A9L0ziuWGQHgEEVgF3davQ9vbD93IuX+lo2IsxapQmu5b/Y/ynn9m9K5JHt9dvyJXOFc5iN0Zk5GHEOqnzhWjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/json-dup-key-validator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/json-dup-key-validator/-/json-dup-key-validator-1.0.3.tgz",
+      "integrity": "sha512-JvJcV01JSiO7LRz7DY1Fpzn4wX2rJ3dfNTiAfnlvLNdhhnm0Pgdvhi2SGpENrZn7eSg26Ps3TPhOcuD/a4STXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "backslash": "^0.2.0"
+      }
+    },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
+      "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@agmsg/reference-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && cp -R migrations dist/migrations",
+    "dev": "tsx watch src/index.ts",
+    "migrate": "tsx src/migrate.ts",
+    "provision": "tsx src/provision.ts",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "fastify": "5.10.0",
+    "json-dup-key-validator": "1.0.3",
+    "pg": "8.22.0",
+    "uuid": "14.0.1",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.20.1",
+    "@types/pg": "8.20.0",
+    "tsx": "4.23.1",
+    "typescript": "7.0.2",
+    "vitest": "4.1.10"
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,8 @@
     "dev": "tsx watch src/index.ts",
     "migrate": "tsx src/migrate.ts",
     "provision": "tsx src/provision.ts",
-    "start": "node dist/index.js",
+    "retain": "tsx src/retain.ts",
+    "start": "node dist/src/index.js",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/server/spec/v1.md
+++ b/server/spec/v1.md
@@ -244,15 +244,30 @@ It is deliberately separate from unauthenticated health and says nothing about
 which ciphers a particular client can read.
 
 Independently of server policy, every client sync configuration MUST durably
-pin a local `minimum_security_mode` to its `(server_instance_id, team_id)`
-binding. V1 defines `plaintext-allowed` and `e2ee-required`; the latter excludes
-`none`. Initial binding requires an explicit local/operator choice, and a server
-response MUST NOT silently create, lower, or replace it. An approved server
-rebind retains the pin unless the operator explicitly changes it. For new
-messages, the effective write set is the intersection of the server's
-`write_allowed_ciphers`, locally supported ciphers, and ciphers satisfying the
-local minimum. An empty intersection is a terminal configuration state, not a
-reason to downgrade.
+pin an append-only local security history to its `(server_instance_id, team_id)`
+binding. Each entry contains canonical decimal `local_security_revision` and
+`effective_from_seq` plus `minimum_security_mode`. V1 defines
+`plaintext-allowed` and `e2ee-required`; the latter excludes `none`. The initial
+entry has revision `0`, is effective from sequence `1`, and requires an explicit
+local/operator mode choice. A server response MUST NOT silently create, lower,
+or replace this history. An operator-approved replacement binding MUST
+explicitly establish a new history and MUST NOT silently lower the prior
+security posture.
+
+The history is part of durable sync configuration, not ephemeral device state.
+A new device for an existing binding MUST import the established history from
+trusted configuration or require explicit operator provisioning; it MUST NOT
+reconstruct history from only the server's current policy or silently apply the
+current local mode back to sequence `1`.
+
+For a message at sequence `S`, the effective local minimum is the entry with the
+greatest local revision whose `effective_from_seq <= S`. Same-boundary changes
+collapse to the greatest revision. Clients MUST bound effective local history
+to 4096 entries just like server policy history and MUST reject a further
+distinct-boundary change atomically. For new messages, the effective write set
+is the intersection of the server's `write_allowed_ciphers`, locally supported
+ciphers, and ciphers satisfying the effective local minimum. An empty
+intersection is a terminal configuration state, not a reason to downgrade.
 
 ```json
 {
@@ -261,6 +276,8 @@ reason to downgrade.
   "team_id": "018f3f7e-0000-7000-8000-000000000001",
   "team_name": "example-team",
   "min_available_seq": "0",
+  "current_seq": "0",
+  "next_sequence_boundary": "1",
   "accepted_envelope_versions": [1],
   "write_allowed_ciphers": ["none"],
   "policy_revision": "0",
@@ -300,11 +317,24 @@ Multiple policy changes before the next message may therefore share one
 `max_blob_bytes` is decoded opaque-byte size and MUST NOT exceed the protocol
 maximum.
 
+`current_seq` is the team's current committed sequence at this snapshot.
+`next_sequence_boundary` is `current_seq + 1`, or null when `current_seq` is the
+signed BIGINT maximum. Both non-null values use the canonical sequence-string
+format. A normal local security-mode change MUST fetch a fresh authenticated
+capability snapshot, verify its binding, and durably append the next local
+revision with `effective_from_seq = next_sequence_boundary`. It MUST fail if
+that boundary is null. This makes plaintext-to-E2EE transitions prospective:
+valid earlier plaintext keeps its earlier local policy. A request to hide or
+reclassify earlier plaintext is a separate explicit retroactive local action;
+it MUST NOT rewrite the normal effective history.
+
 Capability reads and POST policy enforcement MUST use the same authoritative
 team policy state. Servers only advertise write admission. Client read/decrypt
 capability is local state and MUST NOT be inferred from this response.
-The current fields and complete `policy_history` MUST be read from one database
-transaction and snapshot.
+The sequence boundary, current fields, and complete `policy_history` MUST be
+read from one database transaction and snapshot. Capability responses MUST send
+`Cache-Control: no-store`; clients MUST NOT use a cached response to choose a
+local effective boundary.
 Policy mutation locks the team row, increments `policy_revision`, and records
 `effective_from_seq = current_seq + 1` atomically. A policy change whose next
 revision or `effective_from_seq` would exceed signed BIGINT maximum MUST fail
@@ -312,10 +342,11 @@ atomically rather than wrap.
 
 Before creating or POSTing a new envelope, a client MUST fetch this
 authenticated response, verify its server/team binding, and preflight the
-effective write set. A v1 client supports only `none`; if the server disallows
-`none` or the local mode is `e2ee-required`, it MUST stop without generating or
-POSTing a plaintext envelope. A later POST policy race may still return `403`,
-which the client handles as specified below.
+effective write set for `next_sequence_boundary`. A v1 client supports only
+`none`; if the server disallows `none` or the effective local mode is
+`e2ee-required`, it MUST stop without generating or POSTing a plaintext
+envelope. A later POST policy race may still return `403`, which the client
+handles as specified below.
 
 ## `POST /v1/messages`
 
@@ -496,10 +527,11 @@ Clients MUST keep three independent progress layers:
 Readers use capability policy history (`policy_revision` and
 `effective_from_seq`) to distinguish allowed legacy `none` envelopes from a
 post-policy downgrade attempt. They MUST also apply the durable local
-`minimum_security_mode`. An envelope that violates the effective server policy
-at its `server_seq` or the local minimum enters durable `policy_violation` with
-the reason recorded. It MUST NOT be imported or exposed as readable, although
-the transport cursor may advance after that quarantine record is durable.
+security-history entry effective at the message's `server_seq`. An envelope
+that violates the effective server policy or effective local minimum at its
+sequence enters durable `policy_violation` with the reason recorded. It MUST
+NOT be imported or exposed as readable, although the transport cursor may
+advance after that quarantine record is durable.
 
 Pull echo reconciliation is normative. After durable quarantine, the client
 looks up the wire ID in reconciliation state:

--- a/server/spec/v1.md
+++ b/server/spec/v1.md
@@ -1,0 +1,347 @@
+# agmsg Remote Storage HTTP API v1
+
+Status: draft for protocol review
+
+This document is the normative contract between agmsg storage drivers and the
+self-hosted reference server. The words MUST, MUST NOT, SHOULD, and MAY are to
+be interpreted as described by RFC 2119.
+
+## Scope and conventions
+
+V1 defines four endpoints:
+
+- `POST /v1/messages`
+- `GET /v1/messages?after=<team_seq>`
+- `GET /v1/members`
+- `GET /v1/health`
+
+JSON is used for every request and response except requests without a body.
+JSON field names are case-sensitive. Unknown request fields MUST be rejected
+with `400 invalid-request`, so clients do not silently believe an unsupported
+field was stored.
+
+Every team-scoped request MUST include:
+
+```http
+Agmsg-Protocol-Version: 1
+Agmsg-Team: <team-name>
+```
+
+Every response, including errors, MUST include:
+
+```http
+Agmsg-Protocol-Version: 1
+```
+
+`GET /v1/health` does not require either request header because it is also the
+version-discovery and orchestration probe. A missing, malformed, or unsupported
+version on another endpoint returns `426 unsupported-protocol-version` and the
+server's supported versions. Selecting credentials and authenticating access to
+the named team are deployment concerns outside this protocol version; a server
+MUST NOT treat the `Agmsg-Team` header alone as authorization.
+
+Timestamps are RFC 3339 strings in UTC. Sequence values in JSON and query
+parameters are canonical decimal strings matching `0|[1-9][0-9]*` and MUST fit
+in a signed 64-bit integer. They are strings so JavaScript clients never lose
+PostgreSQL `BIGINT` precision. A message UUID is a canonical lowercase RFC 4122
+UUID string.
+
+## Common response fields
+
+Successful team-scoped responses include:
+
+```json
+{
+  "protocol_version": 1,
+  "team": "example-team",
+  "min_available_seq": "0"
+}
+```
+
+`min_available_seq` is the smallest valid cursor for the team. It is normally
+zero. If retention removes all messages through sequence `N`, it becomes `N`.
+A client cursor smaller than this floor cannot be incrementally repaired.
+
+Errors have one shape:
+
+```json
+{
+  "protocol_version": 1,
+  "error": {
+    "code": "invalid-request",
+    "message": "human-readable summary",
+    "details": {}
+  }
+}
+```
+
+Clients MUST branch on `error.code`, not on `message`.
+
+## Message representation
+
+The client-supplied, immutable message payload is:
+
+```json
+{
+  "message_uuid": "018f3f7e-89ab-7def-8123-456789abcdef",
+  "from_agent": "leader",
+  "to_agent": "worker-1",
+  "body": "Run the test suite",
+  "created_at": "2026-07-20T06:30:00Z"
+}
+```
+
+All five fields are required and MUST be strings. Agent names and `body` MUST
+be non-empty. `created_at` identifies client creation time; server receipt time
+is separate metadata. The immutable payload for UUID conflict checks is exactly
+the four fields other than `message_uuid`. Equality is equality of decoded JSON
+string values after timestamp validation and normalization to its RFC 3339 UTC
+form; JSON whitespace and object key order are not payload differences.
+
+A server-returned message adds its canonical team sequence:
+
+```json
+{
+  "server_seq": "42",
+  "message_uuid": "018f3f7e-89ab-7def-8123-456789abcdef",
+  "from_agent": "leader",
+  "to_agent": "worker-1",
+  "body": "Run the test suite",
+  "created_at": "2026-07-20T06:30:00Z"
+}
+```
+
+`server_seq` and `team_seq` refer to the same value. HTTP schemas use
+`server_seq`; the database and ordering rules call it `team_seq`.
+
+## `POST /v1/messages`
+
+Stores one atomic batch. The request body is:
+
+```json
+{
+  "messages": [
+    {
+      "message_uuid": "018f3f7e-89ab-7def-8123-456789abcdef",
+      "from_agent": "leader",
+      "to_agent": "worker-1",
+      "body": "Run the test suite",
+      "created_at": "2026-07-20T06:30:00Z"
+    }
+  ]
+}
+```
+
+`messages` MUST contain between 1 and 1000 elements. The server validates the
+whole request before committing any element.
+
+Success returns `200` for both new and replayed batches:
+
+```json
+{
+  "protocol_version": 1,
+  "team": "example-team",
+  "min_available_seq": "0",
+  "acks": [
+    {
+      "message_uuid": "018f3f7e-89ab-7def-8123-456789abcdef",
+      "server_seq": "42",
+      "disposition": "stored"
+    }
+  ]
+}
+```
+
+The `acks` array MUST have the same length and order as the input array. Every
+input element maps to its canonical `server_seq`; no element may be omitted.
+`disposition` is `stored` if this transaction first inserted the UUID and
+`duplicate` if an identical UUID/payload already existed. Repeated identical
+UUIDs within one request receive the same sequence; only the first occurrence
+can be `stored`.
+
+The entire batch is one database transaction. If any UUID already exists for
+the team with a different immutable payload, the server MUST return
+`409 message-uuid-conflict` and roll back every insertion and sequence update:
+
+```json
+{
+  "protocol_version": 1,
+  "error": {
+    "code": "message-uuid-conflict",
+    "message": "message_uuid already exists with a different payload",
+    "details": {
+      "message_uuid": "018f3f7e-89ab-7def-8123-456789abcdef"
+    }
+  }
+}
+```
+
+An implementation using `ON CONFLICT DO NOTHING RETURNING` MUST query the
+conflicting UUIDs again inside the same transaction and fill the missing ack
+mappings. Returning only rows produced by `RETURNING` violates this contract.
+
+## `GET /v1/messages?after=<team_seq>`
+
+Returns messages for the team in ascending `server_seq` order, strictly after
+the supplied cursor. `after` is required and MUST be a canonical decimal
+sequence string as defined above.
+The optional `limit` is an integer from 1 through 1000 and defaults to 100.
+
+```http
+GET /v1/messages?after=40&limit=100
+```
+
+Success returns `200`:
+
+```json
+{
+  "protocol_version": 1,
+  "team": "example-team",
+  "min_available_seq": "0",
+  "messages": [
+    {
+      "server_seq": "41",
+      "message_uuid": "018f3f7e-89ab-7def-8123-456789abcdef",
+      "from_agent": "leader",
+      "to_agent": "worker-1",
+      "body": "Run the test suite",
+      "created_at": "2026-07-20T06:30:00Z"
+    }
+  ],
+  "next_after": "41",
+  "has_more": false
+}
+```
+
+`next_after` is the last returned sequence, or the supplied `after` when the
+page is empty. `has_more` states whether a later sequence was visible to the
+same database snapshot but excluded by `limit`.
+
+If `after < min_available_seq`, the server returns `410 resync-required` and no
+messages:
+
+```json
+{
+  "protocol_version": 1,
+  "team": "example-team",
+  "min_available_seq": "100",
+  "error": {
+    "code": "resync-required",
+    "message": "cursor predates retained history",
+    "details": {
+      "after": "42",
+      "min_available_seq": "100"
+    }
+  }
+}
+```
+
+The client MUST discard incremental cursor assumptions and perform the
+out-of-band full-resync procedure negotiated by its storage driver. V1 does not
+define that procedure.
+
+## `GET /v1/members`
+
+Returns the current team roster:
+
+```json
+{
+  "protocol_version": 1,
+  "team": "example-team",
+  "min_available_seq": "0",
+  "members": [
+    {
+      "name": "worker-1",
+      "registrations": [
+        {
+          "type": "codex",
+          "project": "/srv/projects/example"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Members are sorted by `name`; registrations are sorted by `type`, then
+`project`. `name`, `type`, and `project` are non-empty strings. An agent with no
+registrations has an empty `registrations` array. V1 is read-only for members;
+roster mutation remains outside this API.
+
+## `GET /v1/health`
+
+A healthy server returns `200` after a successful database probe:
+
+```json
+{
+  "status": "ok",
+  "protocol": {
+    "supported_versions": [1]
+  },
+  "database": "ok"
+}
+```
+
+If the process is serving HTTP but its database probe fails, it returns `503`
+with `status: "unavailable"`, the same protocol advertisement, and
+`database: "unavailable"`. Health responses MUST NOT expose credentials,
+connection strings, or raw database errors.
+
+## Protocol negotiation errors
+
+Unsupported or absent versions on team-scoped endpoints return `426`:
+
+```json
+{
+  "protocol_version": 1,
+  "error": {
+    "code": "unsupported-protocol-version",
+    "message": "a supported Agmsg-Protocol-Version header is required",
+    "details": {
+      "requested_version": 2,
+      "supported_versions": [1]
+    }
+  }
+}
+```
+
+The response header uses the server's highest supported version. Clients MUST
+NOT silently downgrade a write unless their configuration explicitly allows
+that version.
+
+## Team sequence allocation and visibility
+
+V1 MUST NOT use a global sequence or a PostgreSQL `BIGSERIAL`/sequence object.
+PostgreSQL sequences are non-transactional and can expose gaps or ordering that
+does not match commit visibility.
+
+Each team has one row containing `current_seq` and `min_available_seq`. A write
+transaction performs the following steps:
+
+1. Create the team row if absent, using an idempotent insert.
+2. Lock that row with `SELECT ... FOR UPDATE`.
+3. Load every UUID in the batch and reject any payload conflict.
+4. In input first-occurrence order, increment the locked row's `current_seq`
+   once for each new UUID and insert that message with the resulting value.
+5. Select all UUIDs again inside the transaction and build the complete,
+   input-ordered ack mapping.
+6. Commit the messages, mappings, and updated `current_seq` atomically.
+
+Transactions for one team serialize on its team row. A later writer cannot
+allocate a sequence until the prior holder commits or rolls back, so committed
+`team_seq` order is the visibility order for that team. Transactions for
+different teams do not share this lock and MAY proceed concurrently. A rollback
+MUST leave neither messages nor consumed team sequence values.
+
+Retention changes to `min_available_seq` MUST lock the same team row and commit
+the new floor atomically with deletion/archival of the covered messages.
+
+## Reference server technology (non-normative)
+
+The reference implementation lives in the repository's independent `server/`
+package rather than the root installer package or Tauri app. The proposed stack
+is TypeScript on Node.js 22 LTS with Fastify, `pg`, Zod, and Vitest. PostgreSQL
+integration tests run against a real PostgreSQL service. A Dockerfile and
+Compose example support self-hosting. These choices are implementation details;
+clients are pinned to this protocol document, not to the reference server's
+language or framework.

--- a/server/spec/v1.md
+++ b/server/spec/v1.md
@@ -16,15 +16,17 @@ V1 defines four endpoints:
 - `GET /v1/health`
 
 JSON is used for every request and response except requests without a body.
-JSON field names are case-sensitive. Unknown request fields MUST be rejected
-with `400 invalid-request`, so clients do not silently believe an unsupported
-field was stored.
+Request bodies MUST use `Content-Type: application/json` and UTF-8, MUST NOT
+exceed 2 MiB, and MUST NOT contain duplicate object keys. JSON field names are
+case-sensitive. Unknown request fields MUST be rejected with
+`400 invalid-request`, so clients do not silently believe an unsupported field
+was stored. Clients MUST ignore unknown response fields.
 
 Every team-scoped request MUST include:
 
 ```http
 Agmsg-Protocol-Version: 1
-Agmsg-Team: <team-name>
+Agmsg-Team-ID: <immutable-team-uuid>
 ```
 
 Every response, including errors, MUST include:
@@ -36,15 +38,25 @@ Agmsg-Protocol-Version: 1
 `GET /v1/health` does not require either request header because it is also the
 version-discovery and orchestration probe. A missing, malformed, or unsupported
 version on another endpoint returns `426 unsupported-protocol-version` and the
-server's supported versions. Selecting credentials and authenticating access to
-the named team are deployment concerns outside this protocol version; a server
-MUST NOT treat the `Agmsg-Team` header alone as authorization.
+server's supported versions. The header version MUST equal the URL path version.
+Selecting credentials and authenticating access to the team are deployment
+concerns outside this protocol version; a server MUST NOT treat the
+`Agmsg-Team-ID` header alone as authorization. Credentials MUST NOT be embedded
+in that header or in URLs; deployments supply credentials separately (for
+example, an `Authorization` header).
 
-Timestamps are RFC 3339 strings in UTC. Sequence values in JSON and query
+Timestamps MUST use the exact UTC form `YYYY-MM-DDTHH:MM:SS.ffffffZ`, with six
+fractional digits and no leap seconds. Sequence values in JSON and query
 parameters are canonical decimal strings matching `0|[1-9][0-9]*` and MUST fit
 in a signed 64-bit integer. They are strings so JavaScript clients never lose
-PostgreSQL `BIGINT` precision. A message UUID is a canonical lowercase RFC 4122
-UUID string.
+PostgreSQL `BIGINT` precision. Team IDs and message UUIDs MUST be canonical
+lowercase UUIDv7 values as specified by RFC 9562. A team ID is never reused,
+including after deletion and recreation of a team with the same display name.
+
+Clients MUST key cursors by `(server origin, team_id, protocol version)` and
+MUST stop if a response `team_id` differs from the configured ID. Clients MUST
+NOT automatically follow redirects or forward authorization/team headers to
+another origin.
 
 ## Common response fields
 
@@ -53,10 +65,15 @@ Successful team-scoped responses include:
 ```json
 {
   "protocol_version": 1,
-  "team": "example-team",
+  "team_id": "018f3f7e-0000-7000-8000-000000000001",
+  "team_name": "example-team",
   "min_available_seq": "0"
 }
 ```
+
+`team_id` is the immutable stream identity. `team_name` is a mutable display
+label only: 1–128 Unicode scalar values normalized to NFC and compared
+case-sensitively. It MUST NOT identify cursor state.
 
 `min_available_seq` is the smallest valid cursor for the team. It is normally
 zero. If retention removes all messages through sequence `N`, it becomes `N`.
@@ -77,37 +94,58 @@ Errors have one shape:
 
 Clients MUST branch on `error.code`, not on `message`.
 
-## Message representation
+## Message representation and encryption envelope
 
-The client-supplied, immutable message payload is:
+The client-supplied immutable message is:
 
 ```json
 {
-  "message_uuid": "018f3f7e-89ab-7def-8123-456789abcdef",
-  "from_agent": "leader",
-  "to_agent": "worker-1",
-  "body": "Run the test suite",
-  "created_at": "2026-07-20T06:30:00Z"
+  "id": "018f3f7e-89ab-7def-8123-456789abcdef",
+  "created_at": "2026-07-20T06:30:00.000000Z",
+  "envelope": {
+    "v": 1,
+    "cipher": "none",
+    "blob": "eyJmcm9tX2FnZW50IjoibGVhZGVyIiwidG9fYWdlbnQiOiJ3b3JrZXItMSIsImJvZHkiOiJSdW4gdGhlIHRlc3Qgc3VpdGUifQ=="
+  }
 }
 ```
 
-All five fields are required and MUST be strings. Agent names and `body` MUST
-be non-empty. `created_at` identifies client creation time; server receipt time
-is separate metadata. The immutable payload for UUID conflict checks is exactly
-the four fields other than `message_uuid`. Equality is equality of decoded JSON
-string values after timestamp validation and normalization to its RFC 3339 UTC
-form; JSON whitespace and object key order are not payload differences.
+`id`, `created_at`, and all three envelope fields are required. `v` is the
+envelope format version and is the integer `1`. `cipher` is `none` for the v1
+driver; future drivers may use additional lowercase scheme identifiers matching
+`[a-z0-9][a-z0-9._-]{0,63}` without changing this HTTP or database contract.
+`blob` is 1–1,398,104 ASCII characters of canonical padded RFC 4648 base64
+(representing at most 1 MiB). The server validates only this outer syntax and
+length; it does not decode the bytes.
+
+The server MUST treat `cipher` and `blob` as opaque values. It MUST NOT decode,
+parse, index, filter, log, or validate plaintext inside `blob`. The server-visible
+message fields are only team authorization context, `id`, `server_seq`, and
+`created_at`. In particular, sender, recipient, and body live inside the blob;
+recipient filtering occurs locally after team-stream synchronization.
+
+For `cipher: "none"`, the decoded blob is UTF-8 JSON containing the current
+plaintext driver payload (`from_agent`, `to_agent`, and `body`). Clients produce
+and consume that format, but the server remains unaware of it. Future E2EE
+changes only `cipher` and blob bytes; it does not change endpoints, message
+columns, ordering, or ack semantics.
+
+UUID conflict equality compares the canonical `created_at`, envelope `v`,
+`cipher`, and exact canonical `blob` string. JSON whitespace outside the base64
+string is irrelevant.
 
 A server-returned message adds its canonical team sequence:
 
 ```json
 {
   "server_seq": "42",
-  "message_uuid": "018f3f7e-89ab-7def-8123-456789abcdef",
-  "from_agent": "leader",
-  "to_agent": "worker-1",
-  "body": "Run the test suite",
-  "created_at": "2026-07-20T06:30:00Z"
+  "id": "018f3f7e-89ab-7def-8123-456789abcdef",
+  "created_at": "2026-07-20T06:30:00.000000Z",
+  "envelope": {
+    "v": 1,
+    "cipher": "none",
+    "blob": "eyJmcm9tX2FnZW50IjoibGVhZGVyIiwidG9fYWdlbnQiOiJ3b3JrZXItMSIsImJvZHkiOiJSdW4gdGhlIHRlc3Qgc3VpdGUifQ=="
+  }
 }
 ```
 
@@ -122,11 +160,13 @@ Stores one atomic batch. The request body is:
 {
   "messages": [
     {
-      "message_uuid": "018f3f7e-89ab-7def-8123-456789abcdef",
-      "from_agent": "leader",
-      "to_agent": "worker-1",
-      "body": "Run the test suite",
-      "created_at": "2026-07-20T06:30:00Z"
+      "id": "018f3f7e-89ab-7def-8123-456789abcdef",
+      "created_at": "2026-07-20T06:30:00.000000Z",
+      "envelope": {
+        "v": 1,
+        "cipher": "none",
+        "blob": "eyJmcm9tX2FnZW50IjoibGVhZGVyIiwidG9fYWdlbnQiOiJ3b3JrZXItMSIsImJvZHkiOiJSdW4gdGhlIHRlc3Qgc3VpdGUifQ=="
+      }
     }
   ]
 }
@@ -140,11 +180,12 @@ Success returns `200` for both new and replayed batches:
 ```json
 {
   "protocol_version": 1,
-  "team": "example-team",
+  "team_id": "018f3f7e-0000-7000-8000-000000000001",
+  "team_name": "example-team",
   "min_available_seq": "0",
   "acks": [
     {
-      "message_uuid": "018f3f7e-89ab-7def-8123-456789abcdef",
+      "id": "018f3f7e-89ab-7def-8123-456789abcdef",
       "server_seq": "42",
       "disposition": "stored"
     }
@@ -160,7 +201,8 @@ UUIDs within one request receive the same sequence; only the first occurrence
 can be `stored`.
 
 The entire batch is one database transaction. If any UUID already exists for
-the team with a different immutable payload, the server MUST return
+the team with a different immutable payload, or the same batch repeats a UUID
+with differing payloads, the server MUST return
 `409 message-uuid-conflict` and roll back every insertion and sequence update:
 
 ```json
@@ -168,9 +210,9 @@ the team with a different immutable payload, the server MUST return
   "protocol_version": 1,
   "error": {
     "code": "message-uuid-conflict",
-    "message": "message_uuid already exists with a different payload",
+    "message": "message id already exists with a different payload",
     "details": {
-      "message_uuid": "018f3f7e-89ab-7def-8123-456789abcdef"
+      "id": "018f3f7e-89ab-7def-8123-456789abcdef"
     }
   }
 }
@@ -196,16 +238,19 @@ Success returns `200`:
 ```json
 {
   "protocol_version": 1,
-  "team": "example-team",
+  "team_id": "018f3f7e-0000-7000-8000-000000000001",
+  "team_name": "example-team",
   "min_available_seq": "0",
   "messages": [
     {
       "server_seq": "41",
-      "message_uuid": "018f3f7e-89ab-7def-8123-456789abcdef",
-      "from_agent": "leader",
-      "to_agent": "worker-1",
-      "body": "Run the test suite",
-      "created_at": "2026-07-20T06:30:00Z"
+      "id": "018f3f7e-89ab-7def-8123-456789abcdef",
+      "created_at": "2026-07-20T06:30:00.000000Z",
+      "envelope": {
+        "v": 1,
+        "cipher": "none",
+        "blob": "eyJmcm9tX2FnZW50IjoibGVhZGVyIiwidG9fYWdlbnQiOiJ3b3JrZXItMSIsImJvZHkiOiJSdW4gdGhlIHRlc3Qgc3VpdGUifQ=="
+      }
     }
   ],
   "next_after": "41",
@@ -215,7 +260,8 @@ Success returns `200`:
 
 `next_after` is the last returned sequence, or the supplied `after` when the
 page is empty. `has_more` states whether a later sequence was visible to the
-same database snapshot but excluded by `limit`.
+same database snapshot but excluded by `limit`. The floor check, message page,
+and `has_more` probe MUST use one database transaction and snapshot.
 
 If `after < min_available_seq`, the server returns `410 resync-required` and no
 messages:
@@ -223,7 +269,8 @@ messages:
 ```json
 {
   "protocol_version": 1,
-  "team": "example-team",
+  "team_id": "018f3f7e-0000-7000-8000-000000000001",
+  "team_name": "example-team",
   "min_available_seq": "100",
   "error": {
     "code": "resync-required",
@@ -236,9 +283,10 @@ messages:
 }
 ```
 
-The client MUST discard incremental cursor assumptions and perform the
-out-of-band full-resync procedure negotiated by its storage driver. V1 does not
-define that procedure.
+The client MUST enter a terminal `resync-required` state, stop incremental
+sync, and surface operator action. It MUST NOT reset the cursor or discard local
+state automatically. V1 provides no full-snapshot operation; recovery is a
+manual or driver-specific operation outside this protocol.
 
 ## `GET /v1/members`
 
@@ -247,15 +295,19 @@ Returns the current team roster:
 ```json
 {
   "protocol_version": 1,
-  "team": "example-team",
+  "team_id": "018f3f7e-0000-7000-8000-000000000001",
+  "team_name": "example-team",
   "min_available_seq": "0",
+  "members_revision": "7",
   "members": [
     {
+      "member_id": "018f3f7e-0000-7000-8000-000000000010",
       "name": "worker-1",
       "registrations": [
         {
-          "type": "codex",
-          "project": "/srv/projects/example"
+          "registration_id": "018f3f7e-0000-7000-8000-000000000011",
+          "installation_id": "018f3f7e-0000-7000-8000-000000000012",
+          "type": "codex"
         }
       ]
     }
@@ -263,14 +315,35 @@ Returns the current team roster:
 }
 ```
 
-Members are sorted by `name`; registrations are sorted by `type`, then
-`project`. `name`, `type`, and `project` are non-empty strings. An agent with no
-registrations has an empty `registrations` array. V1 is read-only for members;
-roster mutation remains outside this API.
+Members are sorted by `member_id`; registrations are sorted by
+`registration_id`. All IDs are immutable UUIDv7 values. `name` follows the
+agent-name rules above, `type` is a non-empty driver type string, and an agent
+with no registrations has an empty array. `installation_id` identifies the
+installation that owns a registration. Machine-local project paths MUST NOT be
+uploaded or returned.
+
+V1 HTTP is read-only for members. The authoritative source is an operator
+provisioning document applied by the reference server's local admin CLI. That
+document contains `team_id`, `team_name`, and the complete `members` array in
+the response schema above. Applying it is an atomic replace for that team:
+unchanged IDs update mutable fields, new IDs are created, omitted IDs are
+removed, and `members_revision` increments transactionally. The server MUST NOT
+infer members from message senders or recipients, and MUST NOT require direct
+database edits. Other implementations MAY use another administrative control
+plane, but MUST provide the same ID/lifecycle semantics and GET representation.
 
 ## `GET /v1/health`
 
-A healthy server returns `200` after a successful database probe:
+This endpoint is a readiness and version-discovery probe, not a process
+liveness signal. Orchestrators MUST NOT use its `503` response alone as a
+reason to restart the process during a database outage.
+
+A ready server returns `200` after a successful database probe and includes
+the v1 response header:
+
+```http
+Agmsg-Protocol-Version: 1
+```
 
 ```json
 {
@@ -305,9 +378,33 @@ Unsupported or absent versions on team-scoped endpoints return `426`:
 }
 ```
 
-The response header uses the server's highest supported version. Clients MUST
-NOT silently downgrade a write unless their configuration explicitly allows
-that version.
+The response header identifies the version that encoded the response envelope,
+so `/v1` responses always use `Agmsg-Protocol-Version: 1`, even when the server
+also supports newer versions. Supported alternatives are advertised only in
+`details.supported_versions`. Clients MUST NOT silently downgrade a write.
+
+## Error and retry semantics
+
+All application-generated non-2xx responses use the common error envelope.
+
+| HTTP | Error code | Meaning | Client action |
+| --- | --- | --- | --- |
+| 400 | `invalid-request` | Malformed JSON, header, team ID, cursor, or schema | Do not retry unchanged |
+| 401 | `unauthenticated` | Credentials absent or invalid | Stop and refresh credentials |
+| 403 | `forbidden` | Credentials cannot access this team | Stop |
+| 404 | `team-not-found` | Immutable team ID is not provisioned | Stop; never create implicitly |
+| 409 | `message-uuid-conflict` | UUID payload differs | Stop and surface corruption/conflict |
+| 410 | `resync-required` | Cursor is below retention floor | Enter terminal resync state |
+| 413 | `request-too-large` | Body exceeds 2 MiB | Split/reduce without changing UUIDs |
+| 426 | `unsupported-protocol-version` | Header absent or differs from path/supported versions | Stop or explicitly reconfigure |
+| 429 | `rate-limited` | Temporary admission limit | Retry with backoff and `Retry-After` |
+| 503 | `unavailable` | Temporary server/database failure | Retry with backoff |
+| 507 | `sequence-exhausted` | Team sequence reached signed BIGINT maximum | Stop writes; reads remain available |
+
+A POST timeout, transport loss, or `5xx` has unknown outcome. The client MUST
+retry the same UUID/payload batch and rely on complete ack mapping; it MUST NOT
+mint replacement UUIDs. `409` is not retryable. Servers SHOULD include
+`Retry-After` on `429` and MAY include it on `503`.
 
 ## Team sequence allocation and visibility
 
@@ -318,7 +415,8 @@ does not match commit visibility.
 Each team has one row containing `current_seq` and `min_available_seq`. A write
 transaction performs the following steps:
 
-1. Create the team row if absent, using an idempotent insert.
+1. Verify that operator provisioning created the immutable team row; otherwise
+   return `404 team-not-found` without creating it from an untrusted header.
 2. Lock that row with `SELECT ... FOR UPDATE`.
 3. Load every UUID in the batch and reject any payload conflict.
 4. In input first-occurrence order, increment the locked row's `current_seq`
@@ -333,8 +431,19 @@ allocate a sequence until the prior holder commits or rolls back, so committed
 different teams do not share this lock and MAY proceed concurrently. A rollback
 MUST leave neither messages nor consumed team sequence values.
 
+If `current_seq` is `9223372036854775807`, the server MUST reject new UUIDs with
+`507 sequence-exhausted` and MUST NOT wrap, become negative, or partially store
+the batch. Duplicate UUID lookups and existing reads remain available.
+
 Retention changes to `min_available_seq` MUST lock the same team row and commit
-the new floor atomically with deletion/archival of the covered messages.
+the new floor atomically with deletion/archival of the covered delivery rows.
+The server MUST retain, for the lifetime of the immutable team ID, a dedupe
+tombstone containing `(team_id, id, created_at, envelope, original team_seq)`.
+Retention MUST NOT permit a replayed UUID to acquire a new
+sequence. An identical replay returns `duplicate` with its original sequence;
+a differing replay remains `409`, even when its delivery row is below the pull
+floor. V1 intentionally specifies permanent idempotency metadata and advertises
+no finite replay window.
 
 ## Reference server technology (non-normative)
 

--- a/server/spec/v1.md
+++ b/server/spec/v1.md
@@ -66,11 +66,13 @@ Message `id` is a client-generated opaque 128-bit UUID value represented as a
 canonical lowercase UUIDv4 (122 random payload bits plus the required UUID
 version and variant bits). It MUST be generated with a cryptographically secure
 random number generator, be unique within the team stream, be generated once
-with the envelope, and be durably stored before POST. Local driver IDs remain
-local; clients persist the local-ID/wire-ID mapping in reconciliation state and
-MUST NOT regenerate a wire ID during retry. When importing a remote message, a
-client assigns a local ID according to its local driver contract and durably
-maps it to the unchanged wire ID.
+with the envelope, and be durably stored before POST. A timestamp-bearing UUID,
+including UUIDv7, MUST NOT be used as the wire ID. Local driver IDs remain local
+and continue to follow the local driver's UUIDv7 contract; clients persist the
+local-ID/wire-ID mapping in reconciliation state and MUST NOT regenerate a wire
+ID during retry. When importing a remote message, a client assigns a local ID
+according to its local driver contract and durably maps it to the unchanged
+wire ID.
 
 Each database deployment has an immutable, canonical lowercase UUIDv7
 `server_instance_id`, created once and persisted with the database. Restoring or
@@ -268,6 +270,10 @@ quarantine can evaluate the policy effective at any sequence. Its final entry
 MUST exactly match the response's current `policy_revision`,
 `effective_from_seq`, `accepted_envelope_versions`, and
 `write_allowed_ciphers` fields.
+For a message at sequence `S`, the effective policy is the history entry with
+the greatest `policy_revision` among entries whose `effective_from_seq <= S`.
+Multiple policy changes before the next message may therefore share one
+`effective_from_seq` boundary.
 `max_blob_bytes` is decoded opaque-byte size and MUST NOT exceed the protocol
 maximum.
 
@@ -552,7 +558,9 @@ Agmsg-Protocol-Version: 1
 
 If the process is serving HTTP but its database probe fails, it returns `503`
 with `status: "unavailable"`, the same protocol advertisement, and
-`database: "unavailable"`. Health responses MUST NOT expose credentials,
+`database: "unavailable"`. It omits `server_instance_id` if that persisted value
+could not be read, and clients MUST NOT create or change a cursor binding from
+an unavailable response. Health responses MUST NOT expose credentials,
 connection strings, or raw database errors.
 
 ## Protocol negotiation errors

--- a/server/spec/v1.md
+++ b/server/spec/v1.md
@@ -69,10 +69,12 @@ random number generator, be unique within the team stream, be generated once
 with the envelope, and be durably stored before POST. A timestamp-bearing UUID,
 including UUIDv7, MUST NOT be used as the wire ID. Local driver IDs remain local
 and continue to follow the local driver's UUIDv7 contract; clients persist the
-local-ID/wire-ID mapping in reconciliation state and MUST NOT regenerate a wire
-ID during retry. When importing a remote message, a client assigns a local ID
-according to its local driver contract and durably maps it to the unchanged
-wire ID.
+local-ID/wire-ID mapping together with the immutable canonical envelope in
+reconciliation state and MUST NOT regenerate a wire ID during retry. A pulled
+wire ID with no mapping receives a new local ID under the local driver contract,
+and that mapping is made durable as part of import. A pulled wire ID that
+already has a mapping follows the echo-reconciliation rules under Pull state
+layers and MUST NOT receive another local ID.
 
 Each database deployment has an immutable, canonical lowercase UUIDv7
 `server_instance_id`, created once and persisted with the database. Restoring or
@@ -151,8 +153,11 @@ The client-supplied immutable message is:
 version and is the integer `1`. `cipher` is `none` for the v1
 driver; future drivers may use additional lowercase scheme identifiers matching
 `[a-z0-9][a-z0-9._-]{0,63}` without changing this HTTP or database contract.
-`key_id` is null for `none`; encrypted schemes use a non-empty, scheme-defined
-key/epoch identifier so readers never trial-decrypt against unbounded keys.
+`key_id` MUST be either JSON null or a JSON string already normalized to NFC.
+A non-null value is 1–256 UTF-8 bytes, contains no U+0000–U+001F or U+007F, and
+is compared by exact UTF-8 bytes without case folding. It MUST be null for
+`none`; encrypted schemes use a non-null scheme-defined key/epoch identifier so
+readers never trial-decrypt against unbounded keys.
 `blob` is 1–1,398,104 ASCII characters of canonical padded RFC 4648 base64
 (representing at most 1 MiB). The server MAY base64-decode solely to verify
 canonical padding/size and compute the idempotency digest. It MUST treat the
@@ -179,7 +184,10 @@ All fields are required strings. `created_at` follows the canonical timestamp
 rule. `from_agent` and `to_agent` follow the agent-name rules above. `body` is
 non-empty and at most 1,000,000 UTF-8 bytes before JSON encoding. Clients
 produce and validate this plaintext format, but the server remains unaware of
-it.
+it. The complete JCS-encoded plaintext, after JSON escaping, MUST fit within
+the smaller of the protocol's 1 MiB decoded-blob limit and the authenticated
+capability response's `max_blob_bytes`. The body limit alone is not sufficient
+admission validation.
 
 Before the first POST, a client MUST durably store the exact `id`, `v`,
 `cipher`, `key_id`, and `blob`. Every retry, crash recovery, and compaction replay
@@ -235,6 +243,17 @@ This authenticated, team-scoped endpoint advertises the current write policy.
 It is deliberately separate from unauthenticated health and says nothing about
 which ciphers a particular client can read.
 
+Independently of server policy, every client sync configuration MUST durably
+pin a local `minimum_security_mode` to its `(server_instance_id, team_id)`
+binding. V1 defines `plaintext-allowed` and `e2ee-required`; the latter excludes
+`none`. Initial binding requires an explicit local/operator choice, and a server
+response MUST NOT silently create, lower, or replace it. An approved server
+rebind retains the pin unless the operator explicitly changes it. For new
+messages, the effective write set is the intersection of the server's
+`write_allowed_ciphers`, locally supported ciphers, and ciphers satisfying the
+local minimum. An empty intersection is a terminal configuration state, not a
+reason to downgrade.
+
 ```json
 {
   "protocol_version": 1,
@@ -263,11 +282,15 @@ incremented atomically whenever policy changes. `effective_from_seq` is the
 first team sequence governed by this policy revision. Sequences begin at `1`,
 so a newly provisioned team's revision `0` is effective from `1`. These values
 let readers distinguish permitted legacy plaintext from a post-policy
-downgrade. `policy_history` is the complete, ascending list of revisions for
-the immutable team ID, including the current revision. The server MUST retain
-and return this history for the team's lifetime so clients with durable older
-quarantine can evaluate the policy effective at any sequence. Its final entry
-MUST exactly match the response's current `policy_revision`,
+downgrade. `policy_history` is the complete, ascending effective history for the
+immutable team ID, including the current revision. If multiple revisions share
+one `effective_from_seq`, only the greatest revision is effective and the server
+MUST collapse superseded entries in this response. At most 4096 effective
+history entries may exist for a team; an administrative policy mutation that
+would create another distinct boundary MUST fail atomically. The server MUST
+retain and return this bounded history for the team's lifetime so clients with
+durable older quarantine can evaluate the policy effective at any sequence.
+Its final entry MUST exactly match the response's current `policy_revision`,
 `effective_from_seq`, `accepted_envelope_versions`, and
 `write_allowed_ciphers` fields.
 For a message at sequence `S`, the effective policy is the history entry with
@@ -286,6 +309,13 @@ Policy mutation locks the team row, increments `policy_revision`, and records
 `effective_from_seq = current_seq + 1` atomically. A policy change whose next
 revision or `effective_from_seq` would exceed signed BIGINT maximum MUST fail
 atomically rather than wrap.
+
+Before creating or POSTing a new envelope, a client MUST fetch this
+authenticated response, verify its server/team binding, and preflight the
+effective write set. A v1 client supports only `none`; if the server disallows
+`none` or the local mode is `e2ee-required`, it MUST stop without generating or
+POSTing a plaintext envelope. A later POST policy race may still return `403`,
+which the client handles as specified below.
 
 ## `POST /v1/messages`
 
@@ -453,9 +483,10 @@ manual or driver-specific operation outside this protocol.
 
 Clients MUST keep three independent progress layers:
 
-1. **Transport:** durably quarantine every envelope together with wire ID and
-   `server_seq`, then advance the transport cursor. A crash must not lose an
-   envelope whose sequence was acknowledged locally.
+1. **Transport:** durably quarantine every envelope together with wire ID,
+   `server_seq`, server policy evaluation, and local security evaluation before
+   advancing the transport cursor. A crash must not lose an envelope whose
+   sequence was acknowledged locally.
 2. **Decrypt/import:** process quarantined envelopes into states such as
    `pending_key`, `unsupported_cipher`, `authentication_failed`, or `malformed`.
    Key/capability changes may reprocess this layer without rewinding transport.
@@ -464,7 +495,28 @@ Clients MUST keep three independent progress layers:
 
 Readers use capability policy history (`policy_revision` and
 `effective_from_seq`) to distinguish allowed legacy `none` envelopes from a
-post-policy downgrade attempt.
+post-policy downgrade attempt. They MUST also apply the durable local
+`minimum_security_mode`. An envelope that violates the effective server policy
+at its `server_seq` or the local minimum enters durable `policy_violation` with
+the reason recorded. It MUST NOT be imported or exposed as readable, although
+the transport cursor may advance after that quarantine record is durable.
+
+Pull echo reconciliation is normative. After durable quarantine, the client
+looks up the wire ID in reconciliation state:
+
+- If a mapping exists and its canonical immutable envelope matches, the client
+  MUST NOT create a local ID or event. It durably records `server_seq` and remote
+  observation/confirmation on the already-mapped local record.
+- If a mapping exists but points to a different immutable envelope, the client
+  enters durable `corrupt_state`, MUST NOT import or read the message, and MUST
+  surface operator action.
+- Only if no mapping exists may the client allocate one local ID, durably store
+  the local-ID/wire-ID/envelope mapping, and import the message once.
+
+The transport cursor may advance only after the applicable reconciliation or
+import is durable, or after a durable blocking quarantine state such as
+`pending_key`, `unsupported_cipher`, `authentication_failed`, `malformed`,
+`policy_violation`, or `corrupt_state` has been recorded.
 
 Because routing fields are opaque, the server cannot provide recipient routing,
 search, or per-recipient delivery. Clients download the team stream and project
@@ -658,10 +710,10 @@ tombstone containing `(team_id, id, envelope_digest, original team_seq)`.
 `envelope_digest` is SHA-256 over: ASCII `agmsg-envelope-v1` followed by a zero
 byte; envelope `v` as unsigned 32-bit big-endian; unsigned 32-bit big-endian
 length plus UTF-8 bytes of `cipher`; one byte `0` for null `key_id`, otherwise
-byte `1` then its length+UTF-8 bytes; and unsigned 32-bit big-endian length plus
-the base64-decoded opaque blob bytes. This exact length-prefixed preimage is the
-canonical immutable payload digest. Decoded bytes used for hashing are not
-persisted or logged.
+byte `1` then its unsigned 32-bit big-endian byte length plus exact UTF-8 bytes;
+and unsigned 32-bit big-endian length plus the base64-decoded opaque blob bytes.
+This exact length-prefixed preimage is the canonical immutable payload digest.
+Decoded bytes used for hashing are not persisted or logged.
 
 Retention MUST NOT permit a replayed UUID to acquire a new
 sequence. An identical replay returns `duplicate` with its original sequence;

--- a/server/spec/v1.md
+++ b/server/spec/v1.md
@@ -8,16 +8,19 @@ be interpreted as described by RFC 2119.
 
 ## Scope and conventions
 
-V1 defines four endpoints:
+V1 defines five endpoints:
 
 - `POST /v1/messages`
 - `GET /v1/messages?after=<team_seq>`
 - `GET /v1/members`
+- `GET /v1/capabilities`
 - `GET /v1/health`
 
 JSON is used for every request and response except requests without a body.
 Request bodies MUST use `Content-Type: application/json` and UTF-8, MUST NOT
-exceed 2 MiB, and MUST NOT contain duplicate object keys. JSON field names are
+exceed 2 MiB as counted from streamed request bytes, and MUST NOT contain
+duplicate object keys. V1 rejects any `Content-Encoding` other than `identity`.
+JSON field names are
 case-sensitive. Unknown request fields MUST be rejected with
 `400 invalid-request`, so clients do not silently believe an unsupported field
 was stored. Clients MUST ignore unknown response fields.
@@ -49,12 +52,35 @@ Timestamps MUST use the exact UTC form `YYYY-MM-DDTHH:MM:SS.ffffffZ`, with six
 fractional digits and no leap seconds. Sequence values in JSON and query
 parameters are canonical decimal strings matching `0|[1-9][0-9]*` and MUST fit
 in a signed 64-bit integer. They are strings so JavaScript clients never lose
-PostgreSQL `BIGINT` precision. Team IDs and message UUIDs MUST be canonical
-lowercase UUIDv7 values as specified by RFC 9562. A team ID is never reused,
-including after deletion and recreation of a team with the same display name.
+PostgreSQL `BIGINT` precision. Team IDs and server instance IDs MUST be
+canonical lowercase UUIDv7 values as specified by RFC 9562. A team ID is never
+reused, including after deletion and recreation with the same display name.
 
-Clients MUST key cursors by `(server origin, team_id, protocol version)` and
-MUST stop if a response `team_id` differs from the configured ID. Clients MUST
+Agent-name strings are first normalized to NFC and then MUST contain 1–128
+Unicode scalar values. They MUST NOT start with `-`, equal `.` or `..`, contain
+any of `.`, `/`, `\`, `"`, `[`, or `]`, or contain U+0000–U+001F or U+007F.
+These rules pin remote member projection to the local agmsg agent-name safety
+contract while retaining non-ASCII names.
+
+Message `id` is a client-generated opaque 128-bit UUID value represented as a
+canonical lowercase UUIDv4 (122 random payload bits plus the required UUID
+version and variant bits). It MUST be generated with a cryptographically secure
+random number generator, be unique within the team stream, be generated once
+with the envelope, and be durably stored before POST. Local driver IDs remain
+local; clients persist the local-ID/wire-ID mapping in reconciliation state and
+MUST NOT regenerate a wire ID during retry. When importing a remote message, a
+client assigns a local ID according to its local driver contract and durably
+maps it to the unchanged wire ID.
+
+Each database deployment has an immutable, canonical lowercase UUIDv7
+`server_instance_id`, created once and persisted with the database. Restoring or
+moving the same database retains it; initializing a new database creates a new
+one. Reverse-proxy aliases for one deployment therefore share the ID, while a
+replacement database at the same URL does not.
+
+Clients MUST key cursors by `(server_instance_id, team_id, protocol version)`
+and MUST stop if a response ID differs from its stored binding. Before the first
+team request, a client discovers `server_instance_id` from health. Clients MUST
 NOT automatically follow redirects or forward authorization/team headers to
 another origin.
 
@@ -65,6 +91,7 @@ Successful team-scoped responses include:
 ```json
 {
   "protocol_version": 1,
+  "server_instance_id": "018f3f7e-0000-7000-8000-000000000000",
   "team_id": "018f3f7e-0000-7000-8000-000000000001",
   "team_name": "example-team",
   "min_available_seq": "0"
@@ -72,8 +99,8 @@ Successful team-scoped responses include:
 ```
 
 `team_id` is the immutable stream identity. `team_name` is a mutable display
-label only: 1–128 Unicode scalar values normalized to NFC and compared
-case-sensitively. It MUST NOT identify cursor state.
+label only. It is first normalized to NFC and then MUST contain 1–128 Unicode
+scalar values; comparison is case-sensitive. It MUST NOT identify cursor state.
 
 `min_available_seq` is the smallest valid cursor for the team. It is normally
 zero. If retention removes all messages through sequence `N`, it becomes `N`.
@@ -94,63 +121,165 @@ Errors have one shape:
 
 Clients MUST branch on `error.code`, not on `message`.
 
+Errors produced before database/team resolution (`400`, `401`, malformed
+version `426`) omit `server_instance_id` and `team_id`. Once the database is
+resolved, every application error includes `server_instance_id`; once the team
+is resolved, it also includes `team_id`. Thus `403`, `409`, `410`, `429`, and
+team-scoped `503` include both IDs. `404 team-not-found` includes
+`server_instance_id` and the requested `team_id`. Clients apply the same ID
+mismatch stop rule to success and error responses.
+
 ## Message representation and encryption envelope
 
 The client-supplied immutable message is:
 
 ```json
 {
-  "id": "018f3f7e-89ab-7def-8123-456789abcdef",
-  "created_at": "2026-07-20T06:30:00.000000Z",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
   "envelope": {
     "v": 1,
     "cipher": "none",
-    "blob": "eyJmcm9tX2FnZW50IjoibGVhZGVyIiwidG9fYWdlbnQiOiJ3b3JrZXItMSIsImJvZHkiOiJSdW4gdGhlIHRlc3Qgc3VpdGUifQ=="
+    "key_id": null,
+    "blob": "eyJib2R5IjoiUnVuIHRoZSB0ZXN0IHN1aXRlIiwiY3JlYXRlZF9hdCI6IjIwMjYtMDctMjBUMDY6MzA6MDAuMDAwMDAwWiIsImZyb21fYWdlbnQiOiJsZWFkZXIiLCJ0b19hZ2VudCI6Indvcmtlci0xIn0="
   }
 }
 ```
 
-`id`, `created_at`, and all three envelope fields are required. `v` is the
-envelope format version and is the integer `1`. `cipher` is `none` for the v1
+`id` and all four envelope fields are required. `v` is the envelope format
+version and is the integer `1`. `cipher` is `none` for the v1
 driver; future drivers may use additional lowercase scheme identifiers matching
 `[a-z0-9][a-z0-9._-]{0,63}` without changing this HTTP or database contract.
+`key_id` is null for `none`; encrypted schemes use a non-empty, scheme-defined
+key/epoch identifier so readers never trial-decrypt against unbounded keys.
 `blob` is 1–1,398,104 ASCII characters of canonical padded RFC 4648 base64
-(representing at most 1 MiB). The server validates only this outer syntax and
-length; it does not decode the bytes.
+(representing at most 1 MiB). The server MAY base64-decode solely to verify
+canonical padding/size and compute the idempotency digest. It MUST treat the
+resulting bytes as opaque and MUST NOT persist or log the decoded form.
 
-The server MUST treat `cipher` and `blob` as opaque values. It MUST NOT decode,
-parse, index, filter, log, or validate plaintext inside `blob`. The server-visible
-message fields are only team authorization context, `id`, `server_seq`, and
-`created_at`. In particular, sender, recipient, and body live inside the blob;
-recipient filtering occurs locally after team-stream synchronization.
+The server MUST treat `blob` contents as opaque. It MUST NOT decode, parse,
+index, filter, log, or validate plaintext inside `blob`. The only
+application-message fields visible to the server are team authorization
+context, `id`, `server_seq`, and server-assigned `server_received_at`. Envelope
+admission metadata (`v`, `cipher`, `key_id`, and blob byte length) is also
+necessarily visible for capability and policy enforcement, but is not a
+routing or search surface. Client creation time, sender, recipient, and body
+live inside the blob; recipient filtering occurs locally after team-stream
+synchronization.
 
-For `cipher: "none"`, the decoded blob is UTF-8 JSON containing the current
-plaintext driver payload (`from_agent`, `to_agent`, and `body`). Clients produce
-and consume that format, but the server remains unaware of it. Future E2EE
-changes only `cipher` and blob bytes; it does not change endpoints, message
-columns, ordering, or ack semantics.
+For `cipher: "none"`, decoded bytes MUST be RFC 8785 JSON Canonicalization
+Scheme (JCS) encoding of exactly this object (no unknown or duplicate keys):
 
-UUID conflict equality compares the canonical `created_at`, envelope `v`,
-`cipher`, and exact canonical `blob` string. JSON whitespace outside the base64
-string is irrelevant.
+```json
+{"body":"Run the test suite","created_at":"2026-07-20T06:30:00.000000Z","from_agent":"leader","to_agent":"worker-1"}
+```
+
+All fields are required strings. `created_at` follows the canonical timestamp
+rule. `from_agent` and `to_agent` follow the agent-name rules above. `body` is
+non-empty and at most 1,000,000 UTF-8 bytes before JSON encoding. Clients
+produce and validate this plaintext format, but the server remains unaware of
+it.
+
+Before the first POST, a client MUST durably store the exact `id`, `v`,
+`cipher`, `key_id`, and `blob`. Every retry, crash recovery, and compaction replay
+MUST reuse those exact values; it MUST NOT reserialize, re-encode, or re-encrypt
+the same ID. This remains required for randomized future encryption.
+
+V1 clients MUST emit `cipher: "none"`; a server may recognize additional cipher
+profiles while continuing to store their blobs opaquely. A v1 client receiving
+an unknown cipher MUST
+durably quarantine the unchanged envelope, surface an unsupported-cipher state,
+and may advance the team cursor only after quarantine is durable. It MUST NOT
+discard or interpret the blob. Future ciphers require separately pinned scheme
+profiles, capability handling, key lifecycle, AEAD associated-data rules, and
+padding policy. Those contracts are reserved, not defined by v1. The envelope
+boundary keeps HTTP message columns/endpoints stable; client crypto contracts
+are not claimed to remain unchanged.
+
+Any future authenticated-encryption profile MUST bind this wire `id` as the
+message-UUID component of its AEAD associated data. A local driver ID MUST NOT
+be used for that purpose because it differs across replicas.
+
+UUID conflict equality is keyed by the wire `id` and compares exact canonical
+envelope bytes: RFC 8785 JCS encoding of the object containing `v`, `cipher`,
+`key_id`, and `blob`. JSON whitespace and input key order are irrelevant, but
+all envelope values are byte-stable. Server-assigned `server_received_at` is not
+part of conflict equality.
 
 A server-returned message adds its canonical team sequence:
 
 ```json
 {
   "server_seq": "42",
-  "id": "018f3f7e-89ab-7def-8123-456789abcdef",
-  "created_at": "2026-07-20T06:30:00.000000Z",
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "server_received_at": "2026-07-20T06:30:01.000000Z",
   "envelope": {
     "v": 1,
     "cipher": "none",
-    "blob": "eyJmcm9tX2FnZW50IjoibGVhZGVyIiwidG9fYWdlbnQiOiJ3b3JrZXItMSIsImJvZHkiOiJSdW4gdGhlIHRlc3Qgc3VpdGUifQ=="
+    "key_id": null,
+    "blob": "eyJib2R5IjoiUnVuIHRoZSB0ZXN0IHN1aXRlIiwiY3JlYXRlZF9hdCI6IjIwMjYtMDctMjBUMDY6MzA6MDAuMDAwMDAwWiIsImZyb21fYWdlbnQiOiJsZWFkZXIiLCJ0b19hZ2VudCI6Indvcmtlci0xIn0="
   }
 }
 ```
 
 `server_seq` and `team_seq` refer to the same value. HTTP schemas use
 `server_seq`; the database and ordering rules call it `team_seq`.
+`server_received_at` is assigned once by the server when a new ID is inserted,
+uses the canonical timestamp format, and never changes on duplicate replay. It
+is ordering/diagnostic metadata only; sequence remains authoritative.
+
+## `GET /v1/capabilities`
+
+This authenticated, team-scoped endpoint advertises the current write policy.
+It is deliberately separate from unauthenticated health and says nothing about
+which ciphers a particular client can read.
+
+```json
+{
+  "protocol_version": 1,
+  "server_instance_id": "018f3f7e-0000-7000-8000-000000000000",
+  "team_id": "018f3f7e-0000-7000-8000-000000000001",
+  "team_name": "example-team",
+  "min_available_seq": "0",
+  "accepted_envelope_versions": [1],
+  "write_allowed_ciphers": ["none"],
+  "policy_revision": "0",
+  "effective_from_seq": "1",
+  "max_blob_bytes": "1048576",
+  "policy_history": [
+    {
+      "policy_revision": "0",
+      "effective_from_seq": "1",
+      "accepted_envelope_versions": [1],
+      "write_allowed_ciphers": ["none"]
+    }
+  ]
+}
+```
+
+`policy_revision` is a server-assigned canonical decimal string, initially `0`,
+incremented atomically whenever policy changes. `effective_from_seq` is the
+first team sequence governed by this policy revision. Sequences begin at `1`,
+so a newly provisioned team's revision `0` is effective from `1`. These values
+let readers distinguish permitted legacy plaintext from a post-policy
+downgrade. `policy_history` is the complete, ascending list of revisions for
+the immutable team ID, including the current revision. The server MUST retain
+and return this history for the team's lifetime so clients with durable older
+quarantine can evaluate the policy effective at any sequence. Its final entry
+MUST exactly match the response's current `policy_revision`,
+`effective_from_seq`, `accepted_envelope_versions`, and
+`write_allowed_ciphers` fields.
+`max_blob_bytes` is decoded opaque-byte size and MUST NOT exceed the protocol
+maximum.
+
+Capability reads and POST policy enforcement MUST use the same authoritative
+team policy state. Servers only advertise write admission. Client read/decrypt
+capability is local state and MUST NOT be inferred from this response.
+The current fields and complete `policy_history` MUST be read from one database
+transaction and snapshot.
+Policy mutation locks the team row, increments `policy_revision`, and records
+`effective_from_seq = current_seq + 1` atomically. A policy change whose next
+revision or `effective_from_seq` would exceed signed BIGINT maximum MUST fail
+atomically rather than wrap.
 
 ## `POST /v1/messages`
 
@@ -160,12 +289,12 @@ Stores one atomic batch. The request body is:
 {
   "messages": [
     {
-      "id": "018f3f7e-89ab-7def-8123-456789abcdef",
-      "created_at": "2026-07-20T06:30:00.000000Z",
+      "id": "550e8400-e29b-41d4-a716-446655440000",
       "envelope": {
         "v": 1,
         "cipher": "none",
-        "blob": "eyJmcm9tX2FnZW50IjoibGVhZGVyIiwidG9fYWdlbnQiOiJ3b3JrZXItMSIsImJvZHkiOiJSdW4gdGhlIHRlc3Qgc3VpdGUifQ=="
+        "key_id": null,
+        "blob": "eyJib2R5IjoiUnVuIHRoZSB0ZXN0IHN1aXRlIiwiY3JlYXRlZF9hdCI6IjIwMjYtMDctMjBUMDY6MzA6MDAuMDAwMDAwWiIsImZyb21fYWdlbnQiOiJsZWFkZXIiLCJ0b19hZ2VudCI6Indvcmtlci0xIn0="
       }
     }
   ]
@@ -175,17 +304,38 @@ Stores one atomic batch. The request body is:
 `messages` MUST contain between 1 and 1000 elements. The server validates the
 whole request before committing any element.
 
+Inside the single transaction, processing order is normative:
+
+1. Authenticate/authorize `team_id`, lock the team row, and look up every input
+   ID (including permanent tombstones).
+2. For an existing ID, compare exact canonical envelope bytes. An equal replay
+   receives its original duplicate ack regardless of current cipher policy; an
+   unequal replay makes the whole batch `409`.
+3. For new IDs only, reject an envelope version/cipher the server cannot store
+   with `422 unsupported-cipher`. If the cipher is recognized but disallowed by
+   current team policy, reject with `403 cipher-policy-violation`.
+4. Only after every element passes those steps may the server allocate sequences
+   and insert new IDs.
+
+Both cipher errors include `write_allowed_ciphers`, `policy_revision`, and the
+offending `id`, `v`, and `cipher` in `error.details`. An
+`unsupported-cipher` error also includes `accepted_envelope_versions`. This
+ordering preserves idempotent replay of legacy ciphertext after policy changes
+without allowing new downgrade writes.
+
 Success returns `200` for both new and replayed batches:
 
 ```json
 {
   "protocol_version": 1,
+  "server_instance_id": "018f3f7e-0000-7000-8000-000000000000",
   "team_id": "018f3f7e-0000-7000-8000-000000000001",
   "team_name": "example-team",
   "min_available_seq": "0",
+  "policy_revision": "0",
   "acks": [
     {
-      "id": "018f3f7e-89ab-7def-8123-456789abcdef",
+      "id": "550e8400-e29b-41d4-a716-446655440000",
       "server_seq": "42",
       "disposition": "stored"
     }
@@ -208,11 +358,13 @@ with differing payloads, the server MUST return
 ```json
 {
   "protocol_version": 1,
+  "server_instance_id": "018f3f7e-0000-7000-8000-000000000000",
+  "team_id": "018f3f7e-0000-7000-8000-000000000001",
   "error": {
     "code": "message-uuid-conflict",
     "message": "message id already exists with a different payload",
     "details": {
-      "id": "018f3f7e-89ab-7def-8123-456789abcdef"
+      "id": "550e8400-e29b-41d4-a716-446655440000"
     }
   }
 }
@@ -238,18 +390,20 @@ Success returns `200`:
 ```json
 {
   "protocol_version": 1,
+  "server_instance_id": "018f3f7e-0000-7000-8000-000000000000",
   "team_id": "018f3f7e-0000-7000-8000-000000000001",
   "team_name": "example-team",
   "min_available_seq": "0",
   "messages": [
     {
       "server_seq": "41",
-      "id": "018f3f7e-89ab-7def-8123-456789abcdef",
-      "created_at": "2026-07-20T06:30:00.000000Z",
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "server_received_at": "2026-07-20T06:30:01.000000Z",
       "envelope": {
         "v": 1,
         "cipher": "none",
-        "blob": "eyJmcm9tX2FnZW50IjoibGVhZGVyIiwidG9fYWdlbnQiOiJ3b3JrZXItMSIsImJvZHkiOiJSdW4gdGhlIHRlc3Qgc3VpdGUifQ=="
+        "key_id": null,
+        "blob": "eyJib2R5IjoiUnVuIHRoZSB0ZXN0IHN1aXRlIiwiY3JlYXRlZF9hdCI6IjIwMjYtMDctMjBUMDY6MzA6MDAuMDAwMDAwWiIsImZyb21fYWdlbnQiOiJsZWFkZXIiLCJ0b19hZ2VudCI6Indvcmtlci0xIn0="
       }
     }
   ],
@@ -269,6 +423,7 @@ messages:
 ```json
 {
   "protocol_version": 1,
+  "server_instance_id": "018f3f7e-0000-7000-8000-000000000000",
   "team_id": "018f3f7e-0000-7000-8000-000000000001",
   "team_name": "example-team",
   "min_available_seq": "100",
@@ -288,6 +443,31 @@ sync, and surface operator action. It MUST NOT reset the cursor or discard local
 state automatically. V1 provides no full-snapshot operation; recovery is a
 manual or driver-specific operation outside this protocol.
 
+### Pull state layers
+
+Clients MUST keep three independent progress layers:
+
+1. **Transport:** durably quarantine every envelope together with wire ID and
+   `server_seq`, then advance the transport cursor. A crash must not lose an
+   envelope whose sequence was acknowledged locally.
+2. **Decrypt/import:** process quarantined envelopes into states such as
+   `pending_key`, `unsupported_cipher`, `authentication_failed`, or `malformed`.
+   Key/capability changes may reprocess this layer without rewinding transport.
+3. **Read:** user/agent read state advances independently of both transport and
+   decrypt/import state.
+
+Readers use capability policy history (`policy_revision` and
+`effective_from_seq`) to distinguish allowed legacy `none` envelopes from a
+post-policy downgrade attempt.
+
+Because routing fields are opaque, the server cannot provide recipient routing,
+search, or per-recipient delivery. Clients download the team stream and project
+recipients locally; wake notification is team-wide. E2EE protects blob contents,
+not metadata: team relationship, random wire ID, server receipt time, envelope
+version, cipher identifier, key identifier, blob size, traffic frequency, and
+sequence remain visible. Random UUIDv4 removes avoidable embedded generation
+time but does not make metadata private.
+
 ## `GET /v1/members`
 
 Returns the current team roster:
@@ -295,6 +475,7 @@ Returns the current team roster:
 ```json
 {
   "protocol_version": 1,
+  "server_instance_id": "018f3f7e-0000-7000-8000-000000000000",
   "team_id": "018f3f7e-0000-7000-8000-000000000001",
   "team_name": "example-team",
   "min_available_seq": "0",
@@ -317,7 +498,7 @@ Returns the current team roster:
 
 Members are sorted by `member_id`; registrations are sorted by
 `registration_id`. All IDs are immutable UUIDv7 values. `name` follows the
-agent-name rules above, `type` is a non-empty driver type string, and an agent
+agent-name rules above. `type` is a non-empty driver type string, and an agent
 with no registrations has an empty array. `installation_id` identifies the
 installation that owns a registration. Machine-local project paths MUST NOT be
 uploaded or returned.
@@ -325,12 +506,25 @@ uploaded or returned.
 V1 HTTP is read-only for members. The authoritative source is an operator
 provisioning document applied by the reference server's local admin CLI. That
 document contains `team_id`, `team_name`, and the complete `members` array in
-the response schema above. Applying it is an atomic replace for that team:
+the response schema above; input MUST NOT contain `members_revision`. Applying
+it is an atomic replace for that team:
 unchanged IDs update mutable fields, new IDs are created, omitted IDs are
 removed, and `members_revision` increments transactionally. The server MUST NOT
 infer members from message senders or recipients, and MUST NOT require direct
 database edits. Other implementations MAY use another administrative control
 plane, but MUST provide the same ID/lifecycle semantics and GET representation.
+`members_revision` is a server-assigned signed-BIGINT canonical decimal string,
+initially `0`. Provisioning at its maximum MUST fail atomically rather than wrap.
+
+Within a team, member IDs, normalized member names, and registration IDs MUST be
+unique. A registration belongs to exactly one member. Reusing one
+`installation_id` across multiple registrations is allowed. Provisioning MUST
+reject the entire document on a duplicate or ownership conflict. Renaming a
+member retains its `member_id`; removing a member or registration permanently
+retires its ID, which MUST NOT later identify a different object. A normalized
+member name, once assigned, MUST NOT later be assigned to a different
+`member_id`; this prevents historical opaque sender/recipient names from being
+projected onto a new identity.
 
 ## `GET /v1/health`
 
@@ -348,6 +542,7 @@ Agmsg-Protocol-Version: 1
 ```json
 {
   "status": "ok",
+  "server_instance_id": "018f3f7e-0000-7000-8000-000000000000",
   "protocol": {
     "supported_versions": [1]
   },
@@ -385,26 +580,36 @@ also supports newer versions. Supported alternatives are advertised only in
 
 ## Error and retry semantics
 
-All application-generated non-2xx responses use the common error envelope.
+All application-generated non-2xx responses use the common error envelope,
+except the unauthenticated readiness shape from `GET /v1/health`.
 
 | HTTP | Error code | Meaning | Client action |
 | --- | --- | --- | --- |
 | 400 | `invalid-request` | Malformed JSON, header, team ID, cursor, or schema | Do not retry unchanged |
 | 401 | `unauthenticated` | Credentials absent or invalid | Stop and refresh credentials |
 | 403 | `forbidden` | Credentials cannot access this team | Stop |
+| 403 | `cipher-policy-violation` | Recognized cipher is not currently write-allowed | Refresh capabilities; do not retry unchanged |
 | 404 | `team-not-found` | Immutable team ID is not provisioned | Stop; never create implicitly |
 | 409 | `message-uuid-conflict` | UUID payload differs | Stop and surface corruption/conflict |
 | 410 | `resync-required` | Cursor is below retention floor | Enter terminal resync state |
-| 413 | `request-too-large` | Body exceeds 2 MiB | Split/reduce without changing UUIDs |
+| 413 | `request-too-large` | Body exceeds 2 MiB | Split/reduce while preserving exact durable IDs/envelopes |
+| 422 | `unsupported-cipher` | Envelope version/cipher is not supported by this server | Stop or upgrade/reconfigure |
 | 426 | `unsupported-protocol-version` | Header absent or differs from path/supported versions | Stop or explicitly reconfigure |
 | 429 | `rate-limited` | Temporary admission limit | Retry with backoff and `Retry-After` |
+| 500 | `internal-error` | Temporary unclassified server failure | Retry exact request with backoff |
+| 502 | `unavailable` | Temporary upstream failure | Retry exact request with backoff |
 | 503 | `unavailable` | Temporary server/database failure | Retry with backoff |
+| 504 | `unavailable` | Temporary upstream timeout | Retry exact request with backoff |
 | 507 | `sequence-exhausted` | Team sequence reached signed BIGINT maximum | Stop writes; reads remain available |
 
-A POST timeout, transport loss, or `5xx` has unknown outcome. The client MUST
-retry the same UUID/payload batch and rely on complete ack mapping; it MUST NOT
-mint replacement UUIDs. `409` is not retryable. Servers SHOULD include
+A POST timeout, transport loss, or `500`, `502`, `503`, or `504` has unknown
+outcome. The client MUST retry the exact durable ID/envelope batch and rely on
+complete ack mapping; it MUST NOT mint replacement UUIDs. `409`, `422`, and
+`507` are definitive and non-retryable. Servers SHOULD include
 `Retry-After` on `429` and MAY include it on `503`.
+An HTTP intermediary may generate `502`, `503`, or `504` without the protocol
+error envelope; clients still apply the status-based retry rule and MUST verify
+all binding IDs on the eventual protocol response.
 
 ## Team sequence allocation and visibility
 
@@ -418,12 +623,15 @@ transaction performs the following steps:
 1. Verify that operator provisioning created the immutable team row; otherwise
    return `404 team-not-found` without creating it from an untrusted header.
 2. Lock that row with `SELECT ... FOR UPDATE`.
-3. Load every UUID in the batch and reject any payload conflict.
-4. In input first-occurrence order, increment the locked row's `current_seq`
+3. Load every UUID in the batch, reject conflicts, enforce new-ID policy, and
+   count distinct new IDs as `K` (duplicate occurrences count once).
+4. Before allocation, if `K > 9223372036854775807 - current_seq`, reject the
+   whole batch with `507 sequence-exhausted`.
+5. In input first-occurrence order, increment the locked row's `current_seq`
    once for each new UUID and insert that message with the resulting value.
-5. Select all UUIDs again inside the transaction and build the complete,
+6. Select all UUIDs again inside the transaction and build the complete,
    input-ordered ack mapping.
-6. Commit the messages, mappings, and updated `current_seq` atomically.
+7. Commit the messages, mappings, and updated `current_seq` atomically.
 
 Transactions for one team serialize on its team row. A later writer cannot
 allocate a sequence until the prior holder commits or rolls back, so committed
@@ -431,19 +639,28 @@ allocate a sequence until the prior holder commits or rolls back, so committed
 different teams do not share this lock and MAY proceed concurrently. A rollback
 MUST leave neither messages nor consumed team sequence values.
 
-If `current_seq` is `9223372036854775807`, the server MUST reject new UUIDs with
-`507 sequence-exhausted` and MUST NOT wrap, become negative, or partially store
-the batch. Duplicate UUID lookups and existing reads remain available.
+The preflight covers both an already-exhausted counter and a batch crossing the
+boundary. The server MUST NOT wrap, become negative, or rely on a database
+overflow error. Duplicate UUID lookups and existing reads remain available.
 
 Retention changes to `min_available_seq` MUST lock the same team row and commit
 the new floor atomically with deletion/archival of the covered delivery rows.
 The server MUST retain, for the lifetime of the immutable team ID, a dedupe
-tombstone containing `(team_id, id, created_at, envelope, original team_seq)`.
+tombstone containing `(team_id, id, envelope_digest, original team_seq)`.
+`envelope_digest` is SHA-256 over: ASCII `agmsg-envelope-v1` followed by a zero
+byte; envelope `v` as unsigned 32-bit big-endian; unsigned 32-bit big-endian
+length plus UTF-8 bytes of `cipher`; one byte `0` for null `key_id`, otherwise
+byte `1` then its length+UTF-8 bytes; and unsigned 32-bit big-endian length plus
+the base64-decoded opaque blob bytes. This exact length-prefixed preimage is the
+canonical immutable payload digest. Decoded bytes used for hashing are not
+persisted or logged.
+
 Retention MUST NOT permit a replayed UUID to acquire a new
 sequence. An identical replay returns `duplicate` with its original sequence;
 a differing replay remains `409`, even when its delivery row is below the pull
-floor. V1 intentionally specifies permanent idempotency metadata and advertises
-no finite replay window.
+floor. V1 intentionally retains only permanent digest/idempotency metadata, not
+the envelope/body, and advertises no finite replay window. SHA-256 collision
+risk is accepted as the protocol's idempotency tradeoff.
 
 ## Reference server technology (non-normative)
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,183 @@
+import { timingSafeEqual } from "node:crypto";
+import Fastify, {
+  type FastifyInstance,
+  type FastifyRequest,
+} from "fastify";
+import * as duplicateKeyJson from "json-dup-key-validator";
+import type { Pool } from "pg";
+import { ZodError, z } from "zod";
+import type { Config } from "./config.js";
+import { errorBody, ProtocolError } from "./errors.js";
+import {
+  MAX_REQUEST_BYTES,
+  messagesQuerySchema,
+  parseSequence,
+  postMessagesSchema,
+  uuidV7Schema,
+} from "./protocol.js";
+import {
+  getCapabilities,
+  getMembers,
+  getMessages,
+  health,
+  postMessages,
+} from "./storage.js";
+
+const emptyQuerySchema = z.object({}).strict();
+
+function tokenMatches(expected: string, actual: string): boolean {
+  const left = Buffer.from(expected);
+  const right = Buffer.from(actual);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+function scopedTeamId(request: FastifyRequest, token: string): string {
+  const version = request.headers["agmsg-protocol-version"];
+  if (version !== "1") {
+    throw new ProtocolError(
+      426,
+      "unsupported-protocol-version",
+      "Agmsg-Protocol-Version must match /v1",
+      { requested_version: version ?? null, supported_versions: [1] },
+    );
+  }
+  const authorization = request.headers.authorization;
+  if (
+    typeof authorization !== "string" ||
+    !authorization.startsWith("Bearer ") ||
+    !tokenMatches(token, authorization.slice("Bearer ".length))
+  ) {
+    throw new ProtocolError(401, "unauthenticated", "valid credentials are required");
+  }
+  const parsed = uuidV7Schema.safeParse(request.headers["agmsg-team-id"]);
+  if (!parsed.success) {
+    throw new ProtocolError(400, "invalid-request", "Agmsg-Team-ID is invalid");
+  }
+  return parsed.data;
+}
+
+export function createApp(pool: Pool, config: Config): FastifyInstance {
+  const app = Fastify({
+    logger: config.logLevel === "silent" ? false : { level: config.logLevel },
+    bodyLimit: MAX_REQUEST_BYTES,
+  });
+
+  app.removeContentTypeParser("application/json");
+  app.addContentTypeParser(
+    "application/json",
+    { parseAs: "buffer" },
+    (_request, body, done) => {
+      try {
+        const bytes = typeof body === "string" ? Buffer.from(body) : body;
+        const source = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+        done(null, duplicateKeyJson.parse(source, false));
+      } catch (error) {
+        const parsingError = error instanceof Error ? error : new Error("invalid JSON");
+        Object.assign(parsingError, { statusCode: 400 });
+        done(parsingError, undefined);
+      }
+    },
+  );
+
+  app.addHook("onRequest", async (request) => {
+    const encoding = request.headers["content-encoding"];
+    if (encoding !== undefined && encoding !== "identity") {
+      throw new ProtocolError(
+        400,
+        "invalid-request",
+        "Content-Encoding must be identity",
+      );
+    }
+  });
+
+  app.addHook("onSend", async (_request, reply, payload) => {
+    reply.header("Agmsg-Protocol-Version", "1");
+    return payload;
+  });
+
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof ProtocolError) {
+      void reply.status(error.statusCode).send(errorBody(error));
+      return;
+    }
+    if (
+      error instanceof ZodError ||
+      error instanceof SyntaxError ||
+      statusCode(error) === 400 ||
+      statusCode(error) === 415
+    ) {
+      const protocolError = new ProtocolError(
+        400,
+        "invalid-request",
+        "request body, query, or JSON framing is invalid",
+      );
+      void reply.status(400).send(errorBody(protocolError));
+      return;
+    }
+    if (statusCode(error) === 413) {
+      const protocolError = new ProtocolError(
+        413,
+        "request-too-large",
+        "request body exceeds 2 MiB",
+      );
+      void reply.status(413).send(errorBody(protocolError));
+      return;
+    }
+    requestLog(reply, error);
+    const protocolError = new ProtocolError(
+      500,
+      "internal-error",
+      "an internal server error occurred",
+    );
+    void reply.status(500).send(errorBody(protocolError));
+  });
+
+  app.get("/v1/health", async (_request, reply) => {
+    try {
+      return await health(pool);
+    } catch {
+      return reply.status(503).send({
+        status: "unavailable",
+        protocol: { supported_versions: [1] },
+        database: "unavailable",
+      });
+    }
+  });
+
+  app.get("/v1/capabilities", async (request, reply) => {
+    emptyQuerySchema.parse(request.query);
+    const teamId = scopedTeamId(request, config.token);
+    reply.header("Cache-Control", "no-store");
+    return getCapabilities(pool, teamId);
+  });
+
+  app.get("/v1/members", async (request) => {
+    emptyQuerySchema.parse(request.query);
+    return getMembers(pool, scopedTeamId(request, config.token));
+  });
+
+  app.get("/v1/messages", async (request) => {
+    const teamId = scopedTeamId(request, config.token);
+    const query = messagesQuerySchema.parse(request.query);
+    return getMessages(pool, teamId, parseSequence(query.after), query.limit);
+  });
+
+  app.post("/v1/messages", async (request) => {
+    const teamId = scopedTeamId(request, config.token);
+    const body = postMessagesSchema.parse(request.body);
+    return postMessages(pool, teamId, body.messages);
+  });
+
+  return app;
+}
+
+function requestLog(reply: { log: { error: (value: unknown) => void } }, error: unknown) {
+  reply.log.error(error);
+}
+
+function statusCode(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null || !("statusCode" in error)) {
+    return undefined;
+  }
+  return typeof error.statusCode === "number" ? error.statusCode : undefined;
+}

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+const environmentSchema = z.object({
+  DATABASE_URL: z.string().min(1),
+  AGMSG_SERVER_TOKEN: z.string().min(16),
+  HOST: z.string().default("127.0.0.1"),
+  PORT: z.coerce.number().int().min(1).max(65535).default(8787),
+  LOG_LEVEL: z
+    .enum(["fatal", "error", "warn", "info", "debug", "trace", "silent"])
+    .default("info"),
+});
+
+export type Config = {
+  databaseUrl: string;
+  token: string;
+  host: string;
+  port: number;
+  logLevel: z.infer<typeof environmentSchema>["LOG_LEVEL"];
+};
+
+export function loadConfig(environment: NodeJS.ProcessEnv = process.env): Config {
+  const parsed = environmentSchema.parse(environment);
+  return {
+    databaseUrl: parsed.DATABASE_URL,
+    token: parsed.AGMSG_SERVER_TOKEN,
+    host: parsed.HOST,
+    port: parsed.PORT,
+    logLevel: parsed.LOG_LEVEL,
+  };
+}

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,0 +1,55 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { Pool, type PoolClient } from "pg";
+import { v7 as uuidv7 } from "uuid";
+
+export function createPool(connectionString: string): Pool {
+  return new Pool({ connectionString, max: 10 });
+}
+
+export async function migrate(pool: Pool): Promise<void> {
+  const migrationPath = fileURLToPath(
+    new URL("../migrations/001_initial.sql", import.meta.url),
+  );
+  const sql = await readFile(migrationPath, "utf8");
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(sql);
+    await client.query(
+      `INSERT INTO server_metadata (singleton, server_instance_id)
+       VALUES (TRUE, $1)
+       ON CONFLICT (singleton) DO NOTHING`,
+      [uuidv7()],
+    );
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function inTransaction<T>(
+  pool: Pool,
+  operation: (client: PoolClient) => Promise<T>,
+  options: { readOnly?: boolean; repeatableRead?: boolean } = {},
+): Promise<T> {
+  const client = await pool.connect();
+  try {
+    const clauses = [
+      options.repeatableRead ? "ISOLATION LEVEL REPEATABLE READ" : "",
+      options.readOnly ? "READ ONLY" : "",
+    ].filter(Boolean);
+    await client.query(`BEGIN${clauses.length > 0 ? ` ${clauses.join(" ")}` : ""}`);
+    const value = await operation(client);
+    await client.query("COMMIT");
+    return value;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -1,0 +1,27 @@
+export class ProtocolError extends Error {
+  constructor(
+    readonly statusCode: number,
+    readonly code: string,
+    message: string,
+    readonly details: Record<string, unknown> = {},
+    readonly binding: { serverInstanceId?: string; teamId?: string } = {},
+  ) {
+    super(message);
+    this.name = "ProtocolError";
+  }
+}
+
+export function errorBody(error: ProtocolError): Record<string, unknown> {
+  return {
+    protocol_version: 1,
+    ...(error.binding.serverInstanceId
+      ? { server_instance_id: error.binding.serverInstanceId }
+      : {}),
+    ...(error.binding.teamId ? { team_id: error.binding.teamId } : {}),
+    error: {
+      code: error.code,
+      message: error.message,
+      details: error.details,
+    },
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,17 @@
+import { createApp } from "./app.js";
+import { loadConfig } from "./config.js";
+import { createPool, migrate } from "./db.js";
+
+const config = loadConfig();
+const pool = createPool(config.databaseUrl);
+await migrate(pool);
+
+const app = createApp(pool, config);
+const shutdown = async () => {
+  await app.close();
+  await pool.end();
+};
+process.once("SIGINT", () => void shutdown());
+process.once("SIGTERM", () => void shutdown());
+
+await app.listen({ host: config.host, port: config.port });

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -1,0 +1,10 @@
+import { loadConfig } from "./config.js";
+import { createPool, migrate } from "./db.js";
+
+const config = loadConfig();
+const pool = createPool(config.databaseUrl);
+try {
+  await migrate(pool);
+} finally {
+  await pool.end();
+}

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+export const MAX_SEQUENCE = 9_223_372_036_854_775_807n;
+export const MAX_REQUEST_BYTES = 2 * 1024 * 1024;
+export const MAX_BLOB_BYTES = 1024 * 1024;
+
+const uuidV4Pattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const uuidV7Pattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const sequencePattern = /^(0|[1-9][0-9]*)$/;
+const cipherPattern = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const timestampPattern =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/;
+
+export const uuidV4Schema = z.string().regex(uuidV4Pattern);
+export const uuidV7Schema = z.string().regex(uuidV7Pattern);
+export const timestampSchema = z.string().regex(timestampPattern);
+
+export const sequenceSchema = z.string().regex(sequencePattern).refine((value) => {
+  try {
+    return BigInt(value) <= MAX_SEQUENCE;
+  } catch {
+    return false;
+  }
+});
+
+export function parseSequence(value: string): bigint {
+  return BigInt(sequenceSchema.parse(value));
+}
+
+function canonicalBlob(value: string): boolean {
+  if (value.length < 1 || value.length > 1_398_104) return false;
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+    return false;
+  }
+  const bytes = Buffer.from(value, "base64");
+  return bytes.length <= MAX_BLOB_BYTES && bytes.toString("base64") === value;
+}
+
+const keyIdSchema = z.union([
+  z.null(),
+  z.string().refine((value) => {
+    const bytes = Buffer.byteLength(value, "utf8");
+    return (
+      value === value.normalize("NFC") &&
+      bytes >= 1 &&
+      bytes <= 256 &&
+      !/[\u0000-\u001f\u007f]/u.test(value)
+    );
+  }),
+]);
+
+export const envelopeSchema = z
+  .object({
+    v: z.number().int().nonnegative(),
+    cipher: z.string().regex(cipherPattern),
+    key_id: keyIdSchema,
+    blob: z.string().refine(canonicalBlob),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.cipher === "none" && value.key_id !== null) {
+      context.addIssue({
+        code: "custom",
+        path: ["key_id"],
+        message: "key_id must be null for cipher none",
+      });
+    }
+  });
+
+export const messageInputSchema = z
+  .object({ id: uuidV4Schema, envelope: envelopeSchema })
+  .strict();
+
+export const postMessagesSchema = z
+  .object({ messages: z.array(messageInputSchema).min(1).max(1000) })
+  .strict();
+
+export type Envelope = z.infer<typeof envelopeSchema>;
+export type MessageInput = z.infer<typeof messageInputSchema>;
+
+export const messagesQuerySchema = z.object({
+  after: sequenceSchema,
+  limit: z.preprocess(
+    (value) => value ?? "100",
+    z
+      .string()
+      .regex(/^[1-9][0-9]*$/)
+      .transform(Number)
+      .refine((value) => value >= 1 && value <= 1000),
+  ),
+}).strict();
+
+export const agentNameSchema = z.string().refine((value) => {
+  const scalars = [...value];
+  return (
+    value === value.normalize("NFC") &&
+    scalars.length >= 1 &&
+    scalars.length <= 128 &&
+    !value.startsWith("-") &&
+    value !== "." &&
+    value !== ".." &&
+    !/[./\\"\[\]\u0000-\u001f\u007f]/u.test(value)
+  );
+});
+
+function u32(value: number): Buffer {
+  const buffer = Buffer.allocUnsafe(4);
+  buffer.writeUInt32BE(value);
+  return buffer;
+}
+
+function sized(value: Buffer): Buffer {
+  return Buffer.concat([u32(value.length), value]);
+}
+
+export function envelopeDigest(envelope: Envelope): Buffer {
+  const cipher = Buffer.from(envelope.cipher, "utf8");
+  const blob = Buffer.from(envelope.blob, "base64");
+  const key =
+    envelope.key_id === null
+      ? Buffer.from([0])
+      : Buffer.concat([Buffer.from([1]), sized(Buffer.from(envelope.key_id, "utf8"))]);
+  return createHash("sha256")
+    .update(
+      Buffer.concat([
+        Buffer.from("agmsg-envelope-v1\0", "ascii"),
+        u32(envelope.v),
+        sized(cipher),
+        key,
+        sized(blob),
+      ]),
+    )
+    .digest();
+}

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -54,7 +54,7 @@ const keyIdSchema = z.union([
 
 export const envelopeSchema = z
   .object({
-    v: z.number().int().nonnegative(),
+    v: z.number().int().min(0).max(0xffff_ffff),
     cipher: z.string().regex(cipherPattern),
     key_id: keyIdSchema,
     blob: z.string().refine(canonicalBlob),

--- a/server/src/provision.ts
+++ b/server/src/provision.ts
@@ -1,0 +1,189 @@
+import { readFile } from "node:fs/promises";
+import * as duplicateKeyJson from "json-dup-key-validator";
+import { z } from "zod";
+import { loadConfig } from "./config.js";
+import { createPool, inTransaction, migrate } from "./db.js";
+import { agentNameSchema, MAX_SEQUENCE, uuidV7Schema } from "./protocol.js";
+
+const registrationSchema = z
+  .object({
+    registration_id: uuidV7Schema,
+    installation_id: uuidV7Schema,
+    type: z.string().min(1).max(64).regex(/^[a-z0-9][a-z0-9._-]*$/),
+  })
+  .strict();
+
+const memberSchema = z
+  .object({
+    member_id: uuidV7Schema,
+    name: agentNameSchema,
+    registrations: z.array(registrationSchema),
+  })
+  .strict();
+
+const manifestSchema = z
+  .object({
+    team_id: uuidV7Schema,
+    team_name: z
+      .string()
+      .refine(
+        (value) =>
+          value === value.normalize("NFC") &&
+          [...value].length >= 1 &&
+          [...value].length <= 128,
+      ),
+    members: z.array(memberSchema),
+  })
+  .strict();
+
+const manifestPath = process.argv[2];
+if (!manifestPath) {
+  throw new Error("Usage: npm run provision -- <manifest.json>");
+}
+
+const manifestSource = await readFile(manifestPath, "utf8");
+const manifest = manifestSchema.parse(duplicateKeyJson.parse(manifestSource, false));
+const memberIds = new Set<string>();
+const memberNames = new Set<string>();
+const registrationIds = new Set<string>();
+for (const member of manifest.members) {
+  if (memberIds.has(member.member_id) || memberNames.has(member.name)) {
+    throw new Error("manifest contains duplicate member ID or name");
+  }
+  memberIds.add(member.member_id);
+  memberNames.add(member.name);
+  for (const registration of member.registrations) {
+    if (registrationIds.has(registration.registration_id)) {
+      throw new Error("manifest contains a duplicate registration ID");
+    }
+    registrationIds.add(registration.registration_id);
+  }
+}
+
+const config = loadConfig();
+const pool = createPool(config.databaseUrl);
+try {
+  await migrate(pool);
+  const revision = await inTransaction(pool, async (client) => {
+    const existing = await client.query<{ members_revision: string }>(
+      `SELECT members_revision::text FROM teams
+        WHERE team_id = $1 FOR UPDATE`,
+      [manifest.team_id],
+    );
+    const currentMembers = new Set(
+      (
+        await client.query<{ member_id: string }>(
+          "SELECT member_id::text FROM members WHERE team_id = $1",
+          [manifest.team_id],
+        )
+      ).rows.map((row) => row.member_id),
+    );
+    const currentRegistrations = new Set(
+      (
+        await client.query<{ registration_id: string }>(
+          "SELECT registration_id::text FROM registrations WHERE team_id = $1",
+          [manifest.team_id],
+        )
+      ).rows.map((row) => row.registration_id),
+    );
+
+    let nextRevision = 0n;
+    if (existing.rows[0]) {
+      const current = BigInt(existing.rows[0].members_revision);
+      if (current === MAX_SEQUENCE) throw new Error("members revision is exhausted");
+      nextRevision = current + 1n;
+      await client.query(
+        "UPDATE teams SET team_name = $2, members_revision = $3 WHERE team_id = $1",
+        [manifest.team_id, manifest.team_name, nextRevision.toString()],
+      );
+    } else {
+      await client.query(
+        `INSERT INTO teams (team_id, team_name, members_revision)
+         VALUES ($1, $2, 0)`,
+        [manifest.team_id, manifest.team_name],
+      );
+      await client.query(
+        `INSERT INTO team_policy_history
+           (team_id, policy_revision, effective_from_seq,
+            accepted_envelope_versions, write_allowed_ciphers)
+         VALUES ($1, 0, 1, ARRAY[1], ARRAY['none']::TEXT[])`,
+        [manifest.team_id],
+      );
+    }
+
+    for (const member of manifest.members) {
+      const memberSeen = await client.query<{ present: boolean }>(
+        `SELECT TRUE AS present FROM member_identity_history
+          WHERE team_id = $1 AND member_id = $2 LIMIT 1`,
+        [manifest.team_id, member.member_id],
+      );
+      if (memberSeen.rows[0] && !currentMembers.has(member.member_id)) {
+        throw new Error(`member ${member.member_id} is retired`);
+      }
+      const nameOwner = await client.query<{ member_id: string }>(
+        `SELECT member_id::text FROM member_identity_history
+          WHERE team_id = $1 AND name = $2`,
+        [manifest.team_id, member.name],
+      );
+      if (nameOwner.rows[0] && nameOwner.rows[0].member_id !== member.member_id) {
+        throw new Error(`member name ${member.name} is retired by another member`);
+      }
+      await client.query(
+        `INSERT INTO member_identity_history (team_id, member_id, name)
+         VALUES ($1, $2, $3) ON CONFLICT (team_id, name) DO NOTHING`,
+        [manifest.team_id, member.member_id, member.name],
+      );
+      for (const registration of member.registrations) {
+        const owner = await client.query<{ member_id: string }>(
+          `SELECT member_id::text FROM registration_identity_history
+            WHERE team_id = $1 AND registration_id = $2`,
+          [manifest.team_id, registration.registration_id],
+        );
+        if (owner.rows[0] && !currentRegistrations.has(registration.registration_id)) {
+          throw new Error(`registration ${registration.registration_id} is retired`);
+        }
+        if (owner.rows[0] && owner.rows[0].member_id !== member.member_id) {
+          throw new Error(
+            `registration ${registration.registration_id} is retired by another member`,
+          );
+        }
+        await client.query(
+          `INSERT INTO registration_identity_history
+             (team_id, registration_id, member_id)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (team_id, registration_id) DO NOTHING`,
+          [manifest.team_id, registration.registration_id, member.member_id],
+        );
+      }
+    }
+
+    await client.query("DELETE FROM registrations WHERE team_id = $1", [manifest.team_id]);
+    await client.query("DELETE FROM members WHERE team_id = $1", [manifest.team_id]);
+    for (const member of manifest.members) {
+      await client.query(
+        "INSERT INTO members (team_id, member_id, name) VALUES ($1, $2, $3)",
+        [manifest.team_id, member.member_id, member.name],
+      );
+      for (const registration of member.registrations) {
+        await client.query(
+          `INSERT INTO registrations
+             (team_id, registration_id, member_id, installation_id, type)
+           VALUES ($1, $2, $3, $4, $5)`,
+          [
+            manifest.team_id,
+            registration.registration_id,
+            member.member_id,
+            registration.installation_id,
+            registration.type,
+          ],
+        );
+      }
+    }
+    return nextRevision.toString();
+  });
+  process.stdout.write(
+    `${JSON.stringify({ team_id: manifest.team_id, members_revision: revision })}\n`,
+  );
+} finally {
+  await pool.end();
+}

--- a/server/src/retain.ts
+++ b/server/src/retain.ts
@@ -1,0 +1,15 @@
+import { loadConfig } from "./config.js";
+import { createPool, migrate } from "./db.js";
+import { parseSequence, uuidV7Schema } from "./protocol.js";
+import { retainThrough } from "./storage.js";
+
+const teamId = uuidV7Schema.parse(process.argv[2]);
+const through = parseSequence(process.argv[3] ?? "");
+const config = loadConfig();
+const pool = createPool(config.databaseUrl);
+try {
+  await migrate(pool);
+  process.stdout.write(`${JSON.stringify(await retainThrough(pool, teamId, through))}\n`);
+} finally {
+  await pool.end();
+}

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -280,6 +280,59 @@ export async function postMessages(
   });
 }
 
+export async function retainThrough(
+  pool: Pool,
+  teamId: string,
+  through: bigint,
+): Promise<Record<string, unknown>> {
+  return inTransaction(pool, async (client) => {
+    const serverId = await serverInstanceId(client);
+    const team = await teamRow(client, teamId, true);
+    if (!team) throw notFound(serverId, teamId);
+    const currentFloor = BigInt(team.min_available_seq);
+    const currentSequence = BigInt(team.current_seq);
+    if (through < currentFloor || through > currentSequence) {
+      throw new ProtocolError(
+        400,
+        "invalid-request",
+        "retention floor must be between the current floor and current sequence",
+        {
+          through: through.toString(),
+          min_available_seq: team.min_available_seq,
+          current_seq: team.current_seq,
+        },
+        { serverInstanceId: serverId, teamId },
+      );
+    }
+
+    const tombstones = await client.query(
+      `INSERT INTO message_tombstones
+         (team_id, id, original_team_seq, envelope_digest)
+       SELECT team_id, id, team_seq, envelope_digest
+         FROM messages
+        WHERE team_id = $1 AND team_seq <= $2
+       RETURNING id`,
+      [teamId, through.toString()],
+    );
+    const deleted = await client.query(
+      "DELETE FROM messages WHERE team_id = $1 AND team_seq <= $2",
+      [teamId, through.toString()],
+    );
+    if (deleted.rowCount !== tombstones.rowCount) {
+      throw new Error("retention tombstone and deletion counts differ");
+    }
+    await client.query(
+      "UPDATE teams SET min_available_seq = $2 WHERE team_id = $1",
+      [teamId, through.toString()],
+    );
+    return {
+      ...common(serverId, { ...team, min_available_seq: through.toString() }),
+      retained_through: through.toString(),
+      tombstones_created: String(tombstones.rowCount ?? 0),
+    };
+  });
+}
+
 export async function getMessages(
   pool: Pool,
   teamId: string,

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -1,0 +1,446 @@
+import type { Pool, PoolClient } from "pg";
+import { ProtocolError } from "./errors.js";
+import {
+  MAX_SEQUENCE,
+  envelopeDigest,
+  type Envelope,
+  type MessageInput,
+} from "./protocol.js";
+import { inTransaction } from "./db.js";
+
+type TeamRow = {
+  team_id: string;
+  team_name: string;
+  current_seq: string;
+  min_available_seq: string;
+  policy_revision: string;
+  accepted_envelope_versions: number[];
+  write_allowed_ciphers: string[];
+  max_blob_bytes: number;
+  members_revision: string;
+};
+
+type LiveMessageRow = {
+  id: string;
+  team_seq: string;
+  server_received_at: string;
+  envelope_v: number;
+  cipher: string;
+  key_id: string | null;
+  blob: string;
+  envelope_digest: Buffer;
+};
+
+type ExistingRecord =
+  | { kind: "live"; row: LiveMessageRow }
+  | { kind: "tombstone"; sequence: string; digest: Buffer };
+
+const timestampSql = `to_char(server_received_at AT TIME ZONE 'UTC',
+  'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`;
+
+async function serverInstanceId(client: PoolClient): Promise<string> {
+  const result = await client.query<{ server_instance_id: string }>(
+    "SELECT server_instance_id::text FROM server_metadata WHERE singleton = TRUE",
+  );
+  const id = result.rows[0]?.server_instance_id;
+  if (!id) throw new Error("server metadata is not initialized");
+  return id;
+}
+
+async function teamRow(
+  client: PoolClient,
+  id: string,
+  lock = false,
+): Promise<TeamRow | undefined> {
+  const result = await client.query<TeamRow>(
+    `SELECT team_id::text, team_name, current_seq::text, min_available_seq::text,
+            policy_revision::text, accepted_envelope_versions,
+            write_allowed_ciphers, max_blob_bytes, members_revision::text
+       FROM teams WHERE team_id = $1${lock ? " FOR UPDATE" : ""}`,
+    [id],
+  );
+  return result.rows[0];
+}
+
+function common(serverId: string, team: TeamRow): Record<string, unknown> {
+  return {
+    protocol_version: 1,
+    server_instance_id: serverId,
+    team_id: team.team_id,
+    team_name: team.team_name,
+    min_available_seq: team.min_available_seq,
+  };
+}
+
+function notFound(serverId: string, teamId: string): ProtocolError {
+  return new ProtocolError(404, "team-not-found", "team is not provisioned", {}, {
+    serverInstanceId: serverId,
+    teamId,
+  });
+}
+
+function envelopeMatches(row: LiveMessageRow, envelope: Envelope): boolean {
+  return (
+    row.envelope_v === envelope.v &&
+    row.cipher === envelope.cipher &&
+    row.key_id === envelope.key_id &&
+    row.blob === envelope.blob
+  );
+}
+
+function inputFingerprint(message: MessageInput): string {
+  return JSON.stringify([
+    message.envelope.v,
+    message.envelope.cipher,
+    message.envelope.key_id,
+    message.envelope.blob,
+  ]);
+}
+
+export async function postMessages(
+  pool: Pool,
+  teamId: string,
+  messages: MessageInput[],
+): Promise<Record<string, unknown>> {
+  return inTransaction(pool, async (client) => {
+    const serverId = await serverInstanceId(client);
+    const team = await teamRow(client, teamId, true);
+    if (!team) throw notFound(serverId, teamId);
+    const binding = { serverInstanceId: serverId, teamId };
+
+    const firstById = new Map<string, MessageInput>();
+    for (const message of messages) {
+      const first = firstById.get(message.id);
+      if (first && inputFingerprint(first) !== inputFingerprint(message)) {
+        throw new ProtocolError(
+          409,
+          "message-uuid-conflict",
+          "message id is repeated with a different payload",
+          { id: message.id },
+          binding,
+        );
+      }
+      firstById.set(message.id, first ?? message);
+    }
+
+    const ids = [...firstById.keys()];
+    const liveResult = await client.query<LiveMessageRow>(
+      `SELECT id::text, team_seq::text, ${timestampSql} AS server_received_at,
+              envelope_v, cipher, key_id, blob, envelope_digest
+         FROM messages WHERE team_id = $1 AND id = ANY($2::uuid[])`,
+      [teamId, ids],
+    );
+    const tombstoneResult = await client.query<{
+      id: string;
+      original_team_seq: string;
+      envelope_digest: Buffer;
+    }>(
+      `SELECT id::text, original_team_seq::text, envelope_digest
+         FROM message_tombstones WHERE team_id = $1 AND id = ANY($2::uuid[])`,
+      [teamId, ids],
+    );
+    const existing = new Map<string, ExistingRecord>();
+    for (const row of liveResult.rows) existing.set(row.id, { kind: "live", row });
+    for (const row of tombstoneResult.rows) {
+      existing.set(row.id, {
+        kind: "tombstone",
+        sequence: row.original_team_seq,
+        digest: row.envelope_digest,
+      });
+    }
+
+    for (const [id, message] of firstById) {
+      const record = existing.get(id);
+      if (!record) continue;
+      const matches =
+        record.kind === "live"
+          ? envelopeMatches(record.row, message.envelope)
+          : record.digest.equals(envelopeDigest(message.envelope));
+      if (!matches) {
+        throw new ProtocolError(
+          409,
+          "message-uuid-conflict",
+          "message id already exists with a different payload",
+          { id },
+          binding,
+        );
+      }
+    }
+
+    const fresh = [...firstById.values()].filter((message) => !existing.has(message.id));
+    for (const message of fresh) {
+      const { envelope, id } = message;
+      if (envelope.v !== 1 || envelope.cipher !== "none") {
+        throw new ProtocolError(
+          422,
+          "unsupported-cipher",
+          "envelope version or cipher is not supported",
+          {
+            id,
+            v: envelope.v,
+            cipher: envelope.cipher,
+            accepted_envelope_versions: team.accepted_envelope_versions,
+            write_allowed_ciphers: team.write_allowed_ciphers,
+            policy_revision: team.policy_revision,
+          },
+          binding,
+        );
+      }
+      if (
+        !team.accepted_envelope_versions.includes(envelope.v) ||
+        !team.write_allowed_ciphers.includes(envelope.cipher)
+      ) {
+        throw new ProtocolError(
+          403,
+          "cipher-policy-violation",
+          "cipher is not currently write-allowed",
+          {
+            id,
+            v: envelope.v,
+            cipher: envelope.cipher,
+            write_allowed_ciphers: team.write_allowed_ciphers,
+            policy_revision: team.policy_revision,
+          },
+          binding,
+        );
+      }
+      if (Buffer.from(envelope.blob, "base64").length > team.max_blob_bytes) {
+        throw new ProtocolError(
+          413,
+          "request-too-large",
+          "message blob exceeds the team capability limit",
+          { id, max_blob_bytes: String(team.max_blob_bytes) },
+          binding,
+        );
+      }
+    }
+
+    let next = BigInt(team.current_seq);
+    if (BigInt(fresh.length) > MAX_SEQUENCE - next) {
+      throw new ProtocolError(
+        507,
+        "sequence-exhausted",
+        "team sequence is exhausted",
+        {},
+        binding,
+      );
+    }
+
+    const inserted = new Map<string, LiveMessageRow>();
+    for (const message of fresh) {
+      next += 1n;
+      const digest = envelopeDigest(message.envelope);
+      const result = await client.query<LiveMessageRow>(
+        `INSERT INTO messages
+           (team_id, id, team_seq, envelope_v, cipher, key_id, blob, envelope_digest)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         RETURNING id::text, team_seq::text, ${timestampSql} AS server_received_at,
+                   envelope_v, cipher, key_id, blob, envelope_digest`,
+        [
+          teamId,
+          message.id,
+          next.toString(),
+          message.envelope.v,
+          message.envelope.cipher,
+          message.envelope.key_id,
+          message.envelope.blob,
+          digest,
+        ],
+      );
+      const row = result.rows[0];
+      if (!row) throw new Error("insert did not return a message");
+      inserted.set(message.id, row);
+      existing.set(message.id, { kind: "live", row });
+    }
+    if (fresh.length > 0) {
+      await client.query("UPDATE teams SET current_seq = $2 WHERE team_id = $1", [
+        teamId,
+        next.toString(),
+      ]);
+    }
+
+    const seen = new Set<string>();
+    const acks = messages.map((message) => {
+      const record = existing.get(message.id);
+      if (!record) throw new Error("missing canonical ack record");
+      const stored = inserted.has(message.id) && !seen.has(message.id);
+      seen.add(message.id);
+      return {
+        id: message.id,
+        server_seq: record.kind === "live" ? record.row.team_seq : record.sequence,
+        disposition: stored ? "stored" : "duplicate",
+      };
+    });
+
+    return {
+      ...common(serverId, { ...team, current_seq: next.toString() }),
+      policy_revision: team.policy_revision,
+      acks,
+    };
+  });
+}
+
+export async function getMessages(
+  pool: Pool,
+  teamId: string,
+  after: bigint,
+  limit: number,
+): Promise<Record<string, unknown>> {
+  return inTransaction(
+    pool,
+    async (client) => {
+      const serverId = await serverInstanceId(client);
+      const team = await teamRow(client, teamId);
+      if (!team) throw notFound(serverId, teamId);
+      if (after < BigInt(team.min_available_seq)) {
+        throw new ProtocolError(
+          410,
+          "resync-required",
+          "cursor predates retained history",
+          { after: after.toString(), min_available_seq: team.min_available_seq },
+          { serverInstanceId: serverId, teamId },
+        );
+      }
+      const result = await client.query<LiveMessageRow>(
+        `SELECT id::text, team_seq::text, ${timestampSql} AS server_received_at,
+                envelope_v, cipher, key_id, blob, envelope_digest
+           FROM messages
+          WHERE team_id = $1 AND team_seq > $2
+          ORDER BY team_seq ASC
+          LIMIT $3`,
+        [teamId, after.toString(), limit + 1],
+      );
+      const hasMore = result.rows.length > limit;
+      const page = result.rows.slice(0, limit);
+      return {
+        ...common(serverId, team),
+        messages: page.map((row) => ({
+          server_seq: row.team_seq,
+          id: row.id,
+          server_received_at: row.server_received_at,
+          envelope: {
+            v: row.envelope_v,
+            cipher: row.cipher,
+            key_id: row.key_id,
+            blob: row.blob,
+          },
+        })),
+        next_after: page.at(-1)?.team_seq ?? after.toString(),
+        has_more: hasMore,
+      };
+    },
+    { readOnly: true, repeatableRead: true },
+  );
+}
+
+export async function getCapabilities(
+  pool: Pool,
+  teamId: string,
+): Promise<Record<string, unknown>> {
+  return inTransaction(
+    pool,
+    async (client) => {
+      const serverId = await serverInstanceId(client);
+      const team = await teamRow(client, teamId);
+      if (!team) throw notFound(serverId, teamId);
+      const historyResult = await client.query<{
+        policy_revision: string;
+        effective_from_seq: string;
+        accepted_envelope_versions: number[];
+        write_allowed_ciphers: string[];
+      }>(
+        `SELECT policy_revision::text, effective_from_seq::text,
+                accepted_envelope_versions, write_allowed_ciphers
+           FROM (
+             SELECT DISTINCT ON (effective_from_seq)
+                    policy_revision, effective_from_seq,
+                    accepted_envelope_versions, write_allowed_ciphers
+               FROM team_policy_history
+              WHERE team_id = $1
+              ORDER BY effective_from_seq, policy_revision DESC
+           ) effective
+          ORDER BY effective_from_seq, policy_revision`,
+        [teamId],
+      );
+      if (historyResult.rows.length > 4096) {
+        throw new Error("team policy history exceeds protocol limit");
+      }
+      const current = BigInt(team.current_seq);
+      return {
+        ...common(serverId, team),
+        current_seq: team.current_seq,
+        next_sequence_boundary:
+          current === MAX_SEQUENCE ? null : (current + 1n).toString(),
+        accepted_envelope_versions: team.accepted_envelope_versions,
+        write_allowed_ciphers: team.write_allowed_ciphers,
+        policy_revision: team.policy_revision,
+        effective_from_seq:
+          historyResult.rows.at(-1)?.effective_from_seq ?? "1",
+        max_blob_bytes: String(team.max_blob_bytes),
+        policy_history: historyResult.rows,
+      };
+    },
+    { readOnly: true, repeatableRead: true },
+  );
+}
+
+export async function getMembers(
+  pool: Pool,
+  teamId: string,
+): Promise<Record<string, unknown>> {
+  return inTransaction(
+    pool,
+    async (client) => {
+      const serverId = await serverInstanceId(client);
+      const team = await teamRow(client, teamId);
+      if (!team) throw notFound(serverId, teamId);
+      const members = await client.query<{ member_id: string; name: string }>(
+        `SELECT member_id::text, name FROM members
+          WHERE team_id = $1 ORDER BY member_id`,
+        [teamId],
+      );
+      const registrations = await client.query<{
+        registration_id: string;
+        member_id: string;
+        installation_id: string;
+        type: string;
+      }>(
+        `SELECT registration_id::text, member_id::text, installation_id::text, type
+           FROM registrations WHERE team_id = $1
+          ORDER BY registration_id`,
+        [teamId],
+      );
+      return {
+        ...common(serverId, team),
+        members_revision: team.members_revision,
+        members: members.rows.map((member) => ({
+          member_id: member.member_id,
+          name: member.name,
+          registrations: registrations.rows
+            .filter((registration) => registration.member_id === member.member_id)
+            .map(({ member_id: _memberId, ...registration }) => registration),
+        })),
+      };
+    },
+    { readOnly: true, repeatableRead: true },
+  );
+}
+
+export async function health(pool: Pool): Promise<{
+  status: "ok";
+  server_instance_id: string;
+  protocol: { supported_versions: number[] };
+  database: "ok";
+}> {
+  const client = await pool.connect();
+  try {
+    return {
+      status: "ok",
+      server_instance_id: await serverInstanceId(client),
+      protocol: { supported_versions: [1] },
+      database: "ok",
+    };
+  } finally {
+    client.release();
+  }
+}

--- a/server/src/types/json-dup-key-validator.d.ts
+++ b/server/src/types/json-dup-key-validator.d.ts
@@ -1,0 +1,7 @@
+declare module "json-dup-key-validator" {
+  export function parse(source: string, allowDuplicatedKeys?: boolean): unknown;
+  export function validate(
+    source: string,
+    allowDuplicatedKeys?: boolean,
+  ): Error | undefined;
+}

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -9,6 +9,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApp } from "../src/app.js";
 import type { Config } from "../src/config.js";
 import { migrate } from "../src/db.js";
+import { retainThrough } from "../src/storage.js";
 
 const databaseUrl = process.env.TEST_DATABASE_URL;
 const describeDatabase = databaseUrl ? describe : describe.skip;
@@ -84,13 +85,19 @@ describeDatabase("remote storage HTTP API v1", () => {
   });
 
   function message(id: string, text: string) {
+    const plaintext = JSON.stringify({
+      body: text,
+      created_at: "2026-07-20T06:30:00.000000Z",
+      from_agent: "leader",
+      to_agent: "worker-1",
+    });
     return {
       id,
       envelope: {
         v: 1,
         cipher: "none",
         key_id: null,
-        blob: Buffer.from(text).toString("base64"),
+        blob: Buffer.from(plaintext).toString("base64"),
       },
     };
   }
@@ -259,27 +266,52 @@ describeDatabase("remote storage HTTP API v1", () => {
     ).toEqual(["3", "4"]);
   });
 
-  it("keeps retained IDs idempotent while enforcing the pull floor", async () => {
-    const moved = await pool.query<{
-      id: string;
-      team_seq: string;
-      envelope_digest: Buffer;
+  it("retains atomically under the writer lock and keeps tombstones idempotent", async () => {
+    await pool.query(
+      `CREATE FUNCTION fail_tombstone_insert() RETURNS trigger AS $$
+       BEGIN RAISE EXCEPTION 'injected retention failure'; END;
+       $$ LANGUAGE plpgsql`,
+    );
+    await pool.query(
+      `CREATE TRIGGER fail_tombstone_insert
+       BEFORE INSERT ON message_tombstones
+       FOR EACH ROW EXECUTE FUNCTION fail_tombstone_insert()`,
+    );
+    await expect(retainThrough(pool, teamId, 1n)).rejects.toThrow(
+      /injected retention failure/,
+    );
+    const rolledBack = await pool.query<{
+      messages: string;
+      tombstones: string;
+      floor: string;
     }>(
-      `DELETE FROM messages WHERE team_id = $1 AND team_seq = 1
-       RETURNING id::text, team_seq::text, envelope_digest`,
+      `SELECT
+         (SELECT count(*)::text FROM messages WHERE team_id = $1) AS messages,
+         (SELECT count(*)::text FROM message_tombstones WHERE team_id = $1) AS tombstones,
+         (SELECT min_available_seq::text FROM teams WHERE team_id = $1) AS floor`,
       [teamId],
     );
-    const row = moved.rows[0];
-    expect(row).toBeDefined();
-    await pool.query(
-      `INSERT INTO message_tombstones
-         (team_id, id, original_team_seq, envelope_digest)
-       VALUES ($1, $2, $3, $4)`,
-      [teamId, row?.id, row?.team_seq, row?.envelope_digest],
-    );
-    await pool.query("UPDATE teams SET min_available_seq = 1 WHERE team_id = $1", [
-      teamId,
+    expect(rolledBack.rows[0]).toEqual({ messages: "4", tombstones: "0", floor: "0" });
+    await pool.query("DROP TRIGGER fail_tombstone_insert ON message_tombstones");
+    await pool.query("DROP FUNCTION fail_tombstone_insert()");
+
+    const concurrent = message("750e8400-e29b-41d4-a716-446655440007", "after-floor");
+    const [retained, posted] = await Promise.all([
+      retainThrough(pool, teamId, 4n),
+      app.inject({
+        method: "POST",
+        url: "/v1/messages",
+        headers,
+        payload: { messages: [concurrent] },
+      }),
     ]);
+    expect(retained).toMatchObject({
+      min_available_seq: "4",
+      retained_through: "4",
+      tombstones_created: "4",
+    });
+    expect(posted.statusCode).toBe(200);
+    expect(posted.json().acks[0].server_seq).toBe("5");
 
     const belowFloor = await app.inject({
       method: "GET",
@@ -301,6 +333,46 @@ describeDatabase("remote storage HTTP API v1", () => {
       server_seq: "1",
       disposition: "duplicate",
     });
+
+    await pool.query(
+      "UPDATE teams SET write_allowed_ciphers = ARRAY[]::TEXT[] WHERE team_id = $1",
+      [teamId],
+    );
+    const duplicateUnderNewPolicy = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: {
+        messages: [message("550e8400-e29b-41d4-a716-446655440000", "first")],
+      },
+    });
+    expect(duplicateUnderNewPolicy.statusCode).toBe(200);
+    expect(duplicateUnderNewPolicy.json().acks[0].disposition).toBe("duplicate");
+    const rejectedFresh = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: { messages: [message("750e8400-e29b-41d4-a716-446655440008", "fresh")] },
+    });
+    expect(rejectedFresh.statusCode).toBe(403);
+    await pool.query(
+      "UPDATE teams SET write_allowed_ciphers = ARRAY['none']::TEXT[] WHERE team_id = $1",
+      [teamId],
+    );
+
+    const invalidVersion = message(
+      "550e8400-e29b-41d4-a716-446655440000",
+      "first",
+    );
+    invalidVersion.envelope.v = 0x1_0000_0000;
+    const outOfRange = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: { messages: [invalidVersion] },
+    });
+    expect(outOfRange.statusCode).toBe(400);
+    expect(outOfRange.json().error.code).toBe("invalid-request");
   });
 
   it("atomically provisions the operator roster and permanently retires IDs", async () => {

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -1,0 +1,409 @@
+import { randomBytes } from "node:crypto";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createApp } from "../src/app.js";
+import type { Config } from "../src/config.js";
+import { migrate } from "../src/db.js";
+
+const databaseUrl = process.env.TEST_DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const execFileAsync = promisify(execFile);
+
+describeDatabase("remote storage HTTP API v1", () => {
+  const schema = `agmsg_test_${randomBytes(8).toString("hex")}`;
+  const token = "integration-test-token-32-bytes";
+  const teamId = "018f3f7e-0000-7000-8000-000000000001";
+  const memberId = "018f3f7e-0000-7000-8000-000000000010";
+  const registrationId = "018f3f7e-0000-7000-8000-000000000011";
+  const installationId = "018f3f7e-0000-7000-8000-000000000012";
+  let admin: Pool;
+  let pool: Pool;
+  let app: ReturnType<typeof createApp>;
+
+  const config: Config = {
+    databaseUrl: databaseUrl ?? "",
+    token,
+    host: "127.0.0.1",
+    port: 8787,
+    logLevel: "silent",
+  };
+
+  const headers = {
+    authorization: `Bearer ${token}`,
+    "agmsg-protocol-version": "1",
+    "agmsg-team-id": teamId,
+  };
+
+  beforeAll(async () => {
+    admin = new Pool({ connectionString: databaseUrl });
+    await admin.query(`CREATE SCHEMA ${schema}`);
+    pool = new Pool({
+      connectionString: databaseUrl,
+      options: `-c search_path=${schema}`,
+    });
+    await migrate(pool);
+    await pool.query(
+      `INSERT INTO teams (team_id, team_name) VALUES ($1, 'example-team')`,
+      [teamId],
+    );
+    await pool.query(
+      `INSERT INTO team_policy_history
+         (team_id, policy_revision, effective_from_seq,
+          accepted_envelope_versions, write_allowed_ciphers)
+       VALUES ($1, 0, 1, ARRAY[1], ARRAY['none']::TEXT[])`,
+      [teamId],
+    );
+    await pool.query(
+      `INSERT INTO members (team_id, member_id, name)
+       VALUES ($1, $2, 'worker-1')`,
+      [teamId, memberId],
+    );
+    await pool.query(
+      `INSERT INTO registrations
+         (team_id, registration_id, member_id, installation_id, type)
+       VALUES ($1, $2, $3, $4, 'codex')`,
+      [teamId, registrationId, memberId, installationId],
+    );
+    app = createApp(pool, config);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+    if (!/^agmsg_test_[0-9a-f]{16}$/.test(schema)) {
+      throw new Error("refusing to remove an unexpected test schema");
+    }
+    await admin.query(`DROP SCHEMA ${schema} CASCADE`);
+    await admin.end();
+  });
+
+  function message(id: string, text: string) {
+    return {
+      id,
+      envelope: {
+        v: 1,
+        cipher: "none",
+        key_id: null,
+        blob: Buffer.from(text).toString("base64"),
+      },
+    };
+  }
+
+  it("reports readiness and fixes the response protocol version", async () => {
+    const response = await app.inject({ method: "GET", url: "/v1/health" });
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["agmsg-protocol-version"]).toBe("1");
+    expect(response.json()).toMatchObject({
+      status: "ok",
+      protocol: { supported_versions: [1] },
+      database: "ok",
+    });
+  });
+
+  it("requires matching protocol, credentials, and immutable team ID", async () => {
+    const noVersion = await app.inject({
+      method: "GET",
+      url: "/v1/members",
+      headers: { authorization: `Bearer ${token}`, "agmsg-team-id": teamId },
+    });
+    expect(noVersion.statusCode).toBe(426);
+    expect(noVersion.json().error.code).toBe("unsupported-protocol-version");
+
+    const noAuth = await app.inject({
+      method: "GET",
+      url: "/v1/members",
+      headers: {
+        "agmsg-protocol-version": "1",
+        "agmsg-team-id": teamId,
+      },
+    });
+    expect(noAuth.statusCode).toBe(401);
+  });
+
+  it("stores a batch atomically and returns complete input-order acknowledgements", async () => {
+    const first = message("550e8400-e29b-41d4-a716-446655440000", "first");
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: { messages: [first, first] },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json().acks).toEqual([
+      { id: first.id, server_seq: "1", disposition: "stored" },
+      { id: first.id, server_seq: "1", disposition: "duplicate" },
+    ]);
+
+    const replay = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: { messages: [first] },
+    });
+    expect(replay.json().acks[0]).toEqual({
+      id: first.id,
+      server_seq: "1",
+      disposition: "duplicate",
+    });
+
+    const conflict = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: {
+        messages: [
+          message("750e8400-e29b-41d4-a716-446655440001", "would-roll-back"),
+          message(first.id, "different"),
+        ],
+      },
+    });
+    expect(conflict.statusCode).toBe(409);
+    expect(conflict.json()).toMatchObject({
+      team_id: teamId,
+      error: { code: "message-uuid-conflict" },
+    });
+
+    const count = await pool.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM messages WHERE team_id = $1",
+      [teamId],
+    );
+    expect(count.rows[0]?.count).toBe("1");
+  });
+
+  it("allocates team sequence without a rollback gap and pages one snapshot", async () => {
+    const second = message("750e8400-e29b-41d4-a716-446655440002", "second");
+    const stored = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: { messages: [second] },
+    });
+    expect(stored.json().acks[0].server_seq).toBe("2");
+
+    const page = await app.inject({
+      method: "GET",
+      url: "/v1/messages?after=0&limit=1",
+      headers,
+    });
+    expect(page.statusCode).toBe(200);
+    expect(page.json()).toMatchObject({
+      next_after: "1",
+      has_more: true,
+      messages: [{ server_seq: "1" }],
+    });
+    expect(page.json().messages[0].server_received_at).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/,
+    );
+  });
+
+  it("advertises one-snapshot capabilities and operator-provisioned members", async () => {
+    const capabilities = await app.inject({
+      method: "GET",
+      url: "/v1/capabilities",
+      headers,
+    });
+    expect(capabilities.statusCode).toBe(200);
+    expect(capabilities.headers["cache-control"]).toBe("no-store");
+    expect(capabilities.json()).toMatchObject({
+      current_seq: "2",
+      next_sequence_boundary: "3",
+      accepted_envelope_versions: [1],
+      write_allowed_ciphers: ["none"],
+      policy_revision: "0",
+      effective_from_seq: "1",
+      policy_history: [{ policy_revision: "0", effective_from_seq: "1" }],
+    });
+
+    const members = await app.inject({
+      method: "GET",
+      url: "/v1/members",
+      headers,
+    });
+    expect(members.json()).toMatchObject({
+      members_revision: "0",
+      members: [
+        {
+          member_id: memberId,
+          name: "worker-1",
+          registrations: [{ registration_id: registrationId, type: "codex" }],
+        },
+      ],
+    });
+  });
+
+  it("serializes concurrent writers on the team row", async () => {
+    const writes = await Promise.all(
+      [
+        message("750e8400-e29b-41d4-a716-446655440005", "concurrent-a"),
+        message("750e8400-e29b-41d4-a716-446655440006", "concurrent-b"),
+      ].map((entry) =>
+        app.inject({
+          method: "POST",
+          url: "/v1/messages",
+          headers,
+          payload: { messages: [entry] },
+        }),
+      ),
+    );
+    expect(writes.map((response) => response.statusCode)).toEqual([200, 200]);
+    expect(
+      writes
+        .map((response) => response.json().acks[0].server_seq)
+        .sort((left, right) => Number(left) - Number(right)),
+    ).toEqual(["3", "4"]);
+  });
+
+  it("keeps retained IDs idempotent while enforcing the pull floor", async () => {
+    const moved = await pool.query<{
+      id: string;
+      team_seq: string;
+      envelope_digest: Buffer;
+    }>(
+      `DELETE FROM messages WHERE team_id = $1 AND team_seq = 1
+       RETURNING id::text, team_seq::text, envelope_digest`,
+      [teamId],
+    );
+    const row = moved.rows[0];
+    expect(row).toBeDefined();
+    await pool.query(
+      `INSERT INTO message_tombstones
+         (team_id, id, original_team_seq, envelope_digest)
+       VALUES ($1, $2, $3, $4)`,
+      [teamId, row?.id, row?.team_seq, row?.envelope_digest],
+    );
+    await pool.query("UPDATE teams SET min_available_seq = 1 WHERE team_id = $1", [
+      teamId,
+    ]);
+
+    const belowFloor = await app.inject({
+      method: "GET",
+      url: "/v1/messages?after=0",
+      headers,
+    });
+    expect(belowFloor.statusCode).toBe(410);
+    expect(belowFloor.json().error.code).toBe("resync-required");
+
+    const replay = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: {
+        messages: [message("550e8400-e29b-41d4-a716-446655440000", "first")],
+      },
+    });
+    expect(replay.json().acks[0]).toMatchObject({
+      server_seq: "1",
+      disposition: "duplicate",
+    });
+  });
+
+  it("atomically provisions the operator roster and permanently retires IDs", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "agmsg-provision-test-"));
+    const manifestPath = join(directory, "team.json");
+    const provisionTeam = "018f3f7e-0000-7000-8000-000000000101";
+    const provisionMember = "018f3f7e-0000-7000-8000-000000000110";
+    const provisionRegistration = "018f3f7e-0000-7000-8000-000000000111";
+    const connection = new URL(databaseUrl ?? "");
+    connection.searchParams.set("options", `-c search_path=${schema}`);
+    const environment = {
+      ...process.env,
+      DATABASE_URL: connection.toString(),
+      AGMSG_SERVER_TOKEN: token,
+    };
+    const runProvision = () =>
+      execFileAsync(
+        process.execPath,
+        ["node_modules/tsx/dist/cli.mjs", "src/provision.ts", manifestPath],
+        { cwd: process.cwd(), env: environment },
+      );
+
+    try {
+      const member = {
+        member_id: provisionMember,
+        name: "provisioned-worker",
+        registrations: [
+          {
+            registration_id: provisionRegistration,
+            installation_id: "018f3f7e-0000-7000-8000-000000000112",
+            type: "codex",
+          },
+        ],
+      };
+      await writeFile(
+        manifestPath,
+        JSON.stringify({
+          team_id: provisionTeam,
+          team_name: "provisioned-team",
+          members: [member],
+        }),
+      );
+      const first = await runProvision();
+      expect(JSON.parse(first.stdout)).toMatchObject({ members_revision: "0" });
+
+      await writeFile(
+        manifestPath,
+        JSON.stringify({
+          team_id: provisionTeam,
+          team_name: "provisioned-team",
+          members: [],
+        }),
+      );
+      const second = await runProvision();
+      expect(JSON.parse(second.stdout)).toMatchObject({ members_revision: "1" });
+
+      await writeFile(
+        manifestPath,
+        JSON.stringify({
+          team_id: provisionTeam,
+          team_name: "provisioned-team",
+          members: [member],
+        }),
+      );
+      await expect(runProvision()).rejects.toThrow(/retired/);
+    } finally {
+      if (!directory.startsWith(join(tmpdir(), "agmsg-provision-test-"))) {
+        throw new Error("refusing to remove an unexpected temporary directory");
+      }
+      await rm(directory, { recursive: true });
+    }
+  });
+
+  it("rejects duplicate JSON keys and rolls back a sequence-crossing batch", async () => {
+    const duplicateKeys = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers: { ...headers, "content-type": "application/json" },
+      payload: '{"messages":[],"messages":[]}',
+    });
+    expect(duplicateKeys.statusCode).toBe(400);
+
+    await pool.query(
+      "UPDATE teams SET current_seq = 9223372036854775806 WHERE team_id = $1",
+      [teamId],
+    );
+    const exhausted = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: {
+        messages: [
+          message("750e8400-e29b-41d4-a716-446655440003", "a"),
+          message("750e8400-e29b-41d4-a716-446655440004", "b"),
+        ],
+      },
+    });
+    expect(exhausted.statusCode).toBe(507);
+    expect(exhausted.json().error.code).toBe("sequence-exhausted");
+    const rows = await pool.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM messages WHERE id = ANY($1::uuid[])",
+      [["750e8400-e29b-41d4-a716-446655440003", "750e8400-e29b-41d4-a716-446655440004"]],
+    );
+    expect(rows.rows[0]?.count).toBe("0");
+  });
+});

--- a/server/test/sync-client.integration.test.ts
+++ b/server/test/sync-client.integration.test.ts
@@ -10,6 +10,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApp } from "../src/app.js";
 import type { Config } from "../src/config.js";
 import { migrate } from "../src/db.js";
+import { envelopeDigest } from "../src/protocol.js";
 
 const databaseUrl = process.env.TEST_DATABASE_URL;
 const describeDatabase = databaseUrl ? describe : describe.skip;
@@ -130,6 +131,45 @@ storage_history "$2"`;
       "fixture from machine A", "fixture reply from machine B",
     ]);
     expect(b.map((message) => message.body)).toEqual([
+      "fixture from machine A", "fixture reply from machine B",
+    ]);
+
+    const futureEnvelope = {
+      v: 1, cipher: "future-aead", key_id: "epoch-1",
+      blob: Buffer.from("opaque future ciphertext").toString("base64"),
+    };
+    await pool.query("BEGIN");
+    await pool.query(
+      `UPDATE teams SET current_seq=3,policy_revision=1,
+         accepted_envelope_versions=ARRAY[1],
+         write_allowed_ciphers=ARRAY['future-aead']::TEXT[]
+       WHERE team_id=$1`,
+      [teamId],
+    );
+    await pool.query(
+      `INSERT INTO team_policy_history
+         (team_id,policy_revision,effective_from_seq,
+          accepted_envelope_versions,write_allowed_ciphers)
+       VALUES($1,1,3,ARRAY[1],ARRAY['future-aead']::TEXT[])`,
+      [teamId],
+    );
+    await pool.query(
+      `INSERT INTO messages
+         (team_id,id,team_seq,envelope_v,cipher,key_id,blob,envelope_digest)
+       VALUES($1,'550e8400-e29b-41d4-a716-446655440099',3,1,
+              'future-aead','epoch-1',$2,$3)`,
+      [teamId, futureEnvelope.blob, envelopeDigest(futureEnvelope)],
+    );
+    await pool.query("COMMIT");
+
+    const policyTransition = await sync(storeA, "once", "--team", localTeam);
+    expect(policyTransition.stdout).toContain('"event":"push.blocked"');
+    expect(policyTransition.stdout).toContain('"event":"pull.quarantined"');
+    expect(policyTransition.stdout).toContain('"status":"unsupported_cipher"');
+    const quarantined = await execFileAsync("sqlite3", [join(storeA, "messages.db"),
+      "SELECT status || ':' || server_seq FROM sync_quarantine WHERE wire_id='550e8400-e29b-41d4-a716-446655440099';"]);
+    expect(quarantined.stdout.trim()).toBe("unsupported_cipher:3");
+    expect((await history(storeA)).map((message) => message.body)).toEqual([
       "fixture from machine A", "fixture reply from machine B",
     ]);
   });

--- a/server/test/sync-client.integration.test.ts
+++ b/server/test/sync-client.integration.test.ts
@@ -1,0 +1,136 @@
+import { randomBytes } from "node:crypto";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createApp } from "../src/app.js";
+import type { Config } from "../src/config.js";
+import { migrate } from "../src/db.js";
+
+const databaseUrl = process.env.TEST_DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const execFileAsync = promisify(execFile);
+const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+describeDatabase("Stage-1 polling sync client", () => {
+  const schema = `agmsg_sync_${randomBytes(8).toString("hex")}`;
+  const token = "sync-integration-token-32-bytes";
+  const teamId = "018f3f7e-0000-7000-8000-000000000101";
+  const localTeam = "dogfood-team";
+  let admin: Pool;
+  let pool: Pool;
+  let app: ReturnType<typeof createApp>;
+  let serverUrl: string;
+  let root: string;
+  let storeA: string;
+  let storeB: string;
+
+  beforeAll(async () => {
+    admin = new Pool({ connectionString: databaseUrl });
+    await admin.query(`CREATE SCHEMA ${schema}`);
+    pool = new Pool({ connectionString: databaseUrl, options: `-c search_path=${schema}` });
+    await migrate(pool);
+    await pool.query("INSERT INTO teams(team_id,team_name) VALUES($1,$2)", [teamId, localTeam]);
+    await pool.query(
+      `INSERT INTO team_policy_history
+         (team_id,policy_revision,effective_from_seq,
+          accepted_envelope_versions,write_allowed_ciphers)
+       VALUES($1,0,1,ARRAY[1],ARRAY['none']::TEXT[])`,
+      [teamId],
+    );
+    const config: Config = {
+      databaseUrl: databaseUrl ?? "", token, host: "127.0.0.1", port: 8787, logLevel: "silent",
+    };
+    app = createApp(pool, config);
+    serverUrl = await app.listen({ host: "127.0.0.1", port: 0 });
+    root = await mkdtemp(join(tmpdir(), "agmsg-stage1-sync-"));
+    storeA = join(root, "machine-a");
+    storeB = join(root, "machine-b");
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+    if (!/^agmsg_sync_[0-9a-f]{16}$/.test(schema)) throw new Error("unsafe sync test schema");
+    await admin.query(`DROP SCHEMA ${schema} CASCADE`);
+    await admin.end();
+    if (!root.startsWith(join(tmpdir(), "agmsg-stage1-sync-"))) throw new Error("unsafe sync test root");
+    await rm(root, { recursive: true });
+  });
+
+  function environment(store: string) {
+    return {
+      ...process.env,
+      AGMSG_STORAGE_PATH: store,
+      AGMSG_STORAGE_DRIVER: "sqlite",
+      AGMSG_SYNC_TOKEN: token,
+      AGMSG_NODE: process.execPath,
+      HOME: join(store, "home"),
+    };
+  }
+
+  async function sync(store: string, ...args: string[]) {
+    return execFileAsync("bash", [join(repositoryRoot, "scripts/remote-sync.sh"), ...args], {
+      cwd: repositoryRoot,
+      env: environment(store),
+      maxBuffer: 4 * 1024 * 1024,
+    });
+  }
+
+  async function localSend(store: string, from: string, to: string, body: string) {
+    const script = `. "$1/scripts/lib/storage.sh"
+agmsg_storage_load
+storage_init >/dev/null
+storage_send "$2" "$3" "$4" "$5"`;
+    return execFileAsync("bash", ["-c", script, "stage1-test", repositoryRoot, localTeam, from, to, body], {
+      cwd: repositoryRoot,
+      env: environment(store),
+    });
+  }
+
+  async function history(store: string) {
+    const script = `. "$1/scripts/lib/storage.sh"
+agmsg_storage_load
+storage_history "$2"`;
+    const result = await execFileAsync("bash", ["-c", script, "stage1-test", repositoryRoot, localTeam], {
+      cwd: repositoryRoot,
+      env: environment(store),
+    });
+    return result.stdout.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+  }
+
+  it("synchronizes two isolated AGMSG_STORAGE_PATH stores without echo duplicates", async () => {
+    for (const store of [storeA, storeB]) {
+      await sync(store, "configure", "--team", localTeam, "--server", serverUrl,
+        "--team-id", teamId, "--minimum-security", "plaintext-allowed");
+    }
+
+    await localSend(storeA, "machine-a", "machine-b", "fixture from machine A");
+    const pushedA = await sync(storeA, "once", "--team", localTeam);
+    expect(pushedA.stdout).toContain('"event":"push.ack"');
+    expect(pushedA.stdout).toContain('"event":"pull.applied"');
+
+    const pulledB = await sync(storeB, "once", "--team", localTeam);
+    expect(pulledB.stdout).toContain('"event":"pull.import"');
+    expect(await history(storeB)).toMatchObject([
+      { from: "machine-a", to: "machine-b", body: "fixture from machine A" },
+    ]);
+
+    await localSend(storeB, "machine-b", "machine-a", "fixture reply from machine B");
+    await sync(storeB, "once", "--team", localTeam);
+    await sync(storeA, "once", "--team", localTeam);
+
+    const a = await history(storeA);
+    const b = await history(storeB);
+    expect(a.map((message) => message.body)).toEqual([
+      "fixture from machine A", "fixture reply from machine B",
+    ]);
+    expect(b.map((message) => message.body)).toEqual([
+      "fixture from machine A", "fixture reply from machine B",
+    ]);
+  });
+});

--- a/server/tsconfig.build.json
+++ b/server/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["test"]
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -7,7 +7,9 @@ import {
   driver,
   isRetryable,
   plaintextWriteEligible,
+  request,
   validateAckMapping,
+  validateCapabilities,
   validateErrorBinding,
 } from "../scripts/internal/remote-sync.mjs";
 
@@ -63,6 +65,48 @@ test("run retry classification excludes permanent HTTP and validation failures",
   assert.equal(isRetryable(new Error("binding mismatch")), false);
 });
 
+test("headerless non-JSON intermediary failures remain retryable", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousToken = process.env.AGMSG_SYNC_TOKEN;
+  process.env.AGMSG_SYNC_TOKEN = "fixture-token";
+  try {
+    for (const status of [502, 503, 504]) {
+      globalThis.fetch = async () => new Response("temporary proxy failure", { status });
+      await assert.rejects(request({ ...config, server_url: "https://sync.example" }, "/v1/messages"),
+        (error) => error.status === status && error.retryable === true);
+    }
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousToken === undefined) delete process.env.AGMSG_SYNC_TOKEN;
+    else process.env.AGMSG_SYNC_TOKEN = previousToken;
+  }
+});
+
+test("request distinguishes config errors from response transport loss", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousToken = process.env.AGMSG_SYNC_TOKEN;
+  process.env.AGMSG_SYNC_TOKEN = "fixture-token";
+  let fetchCalled = false;
+  try {
+    globalThis.fetch = async () => { fetchCalled = true; throw new Error("unexpected fetch"); };
+    await assert.rejects(request({ ...config, server_url: "not a URL" }, "/v1/messages"),
+      (error) => error.retryable !== true);
+    assert.equal(fetchCalled, false);
+
+    globalThis.fetch = async () => ({
+      ok: true, status: 200,
+      headers: { get: () => "1" },
+      text: async () => { throw new Error("body stream reset"); },
+    });
+    await assert.rejects(request({ ...config, server_url: "https://sync.example" }, "/v1/messages"),
+      (error) => error.retryable === true);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousToken === undefined) delete process.env.AGMSG_SYNC_TOKEN;
+    else process.env.AGMSG_SYNC_TOKEN = previousToken;
+  }
+});
+
 test("write-ineligible capabilities still validate for pull", () => {
   const base = {
     protocol_version: 1,
@@ -82,7 +126,43 @@ test("write-ineligible capabilities still validate for pull", () => {
     }],
   };
   assert.equal(plaintextWriteEligible(config, base), false);
-  assert.equal(plaintextWriteEligible(config, { ...base, next_sequence_boundary: null }), false);
+  assert.equal(plaintextWriteEligible(config, {
+    ...base,
+    current_seq: "9223372036854775807",
+    next_sequence_boundary: null,
+  }), false);
+});
+
+test("capability policy history must be canonical and match current policy", () => {
+  const base = {
+    protocol_version: 1,
+    server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id,
+    min_available_seq: "0", current_seq: "4", next_sequence_boundary: "5",
+    accepted_envelope_versions: [1], write_allowed_ciphers: ["future-aead"],
+    policy_revision: "2", effective_from_seq: "3", max_blob_bytes: "1048576",
+    policy_history: [
+      { policy_revision: "0", effective_from_seq: "1",
+        accepted_envelope_versions: [1], write_allowed_ciphers: ["none"] },
+      { policy_revision: "2", effective_from_seq: "3",
+        accepted_envelope_versions: [1], write_allowed_ciphers: ["future-aead"] },
+    ],
+  };
+  assert.doesNotThrow(() => validateCapabilities(config, base));
+  assert.throws(() => validateCapabilities(config, {
+    ...base, write_allowed_ciphers: ["none"],
+  }), /does not match/u);
+  assert.throws(() => validateCapabilities(config, {
+    ...base,
+    policy_history: [...base.policy_history,
+      { policy_revision: "3", effective_from_seq: "3",
+        accepted_envelope_versions: [1], write_allowed_ciphers: ["future-aead"] }],
+    policy_revision: "3",
+  }), /canonical ascending/u);
+  assert.throws(() => validateCapabilities(config, {
+    ...base,
+    policy_history: [base.policy_history[1], base.policy_history[0]],
+  }), /canonical ascending|begin at sequence 1/u);
 });
 
 test("storage driver subprocess cannot observe the bearer token", async () => {

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  driver,
+  isRetryable,
+  plaintextWriteEligible,
+  validateAckMapping,
+  validateErrorBinding,
+} from "../scripts/internal/remote-sync.mjs";
+
+const config = {
+  local_team: "demo",
+  server_instance_id: "018f3f7e-0000-7000-8000-000000000000",
+  remote_team_id: "018f3f7e-0000-7000-8000-000000000001",
+  protocol_version: 1,
+  local_security_history: [{
+    local_security_revision: "0", effective_from_seq: "1",
+    minimum_security_mode: "plaintext-allowed",
+  }],
+};
+
+const candidates = [
+  { local_position: "1", id: "550e8400-e29b-41d4-a716-446655440001" },
+  { local_position: "2", id: "550e8400-e29b-41d4-a716-446655440002" },
+];
+
+test("ack mapping rejects reversed and duplicate server sequences", () => {
+  assert.throws(() => validateAckMapping(candidates, [
+    { id: candidates[0].id, server_seq: "2", disposition: "stored" },
+    { id: candidates[1].id, server_seq: "1", disposition: "stored" },
+  ]), /strictly increasing/u);
+  assert.throws(() => validateAckMapping(candidates, [
+    { id: candidates[0].id, server_seq: "1", disposition: "stored" },
+    { id: candidates[1].id, server_seq: "1", disposition: "stored" },
+  ]), /strictly increasing/u);
+  assert.throws(() => validateAckMapping(candidates, [
+    { id: candidates[0].id, server_seq: "1", disposition: "stored", extra: true },
+    { id: candidates[1].id, server_seq: "2", disposition: "stored" },
+  ]), /shape/u);
+});
+
+test("resolved protocol errors enforce the immutable binding", () => {
+  for (const status of [403, 410]) {
+    assert.throws(() => validateErrorBinding(config, status, {
+      protocol_version: 1,
+      server_instance_id: "018f3f7e-0000-7000-8000-000000000099",
+      team_id: config.remote_team_id,
+      error: { code: status === 410 ? "resync-required" : "cipher-policy-violation" },
+    }), /binding mismatch/u);
+  }
+  assert.doesNotThrow(() => validateErrorBinding(config, 401, {
+    protocol_version: 1, error: { code: "unauthenticated" },
+  }));
+});
+
+test("run retry classification excludes permanent HTTP and validation failures", () => {
+  assert.equal(isRetryable({ retryable: true }), true);
+  for (const status of [408, 429, 500, 502, 503, 504]) assert.equal(isRetryable({ status }), true);
+  for (const status of [400, 401, 403, 404, 409, 410, 422, 426]) assert.equal(isRetryable({ status }), false);
+  assert.equal(isRetryable(new Error("binding mismatch")), false);
+});
+
+test("write-ineligible capabilities still validate for pull", () => {
+  const base = {
+    protocol_version: 1,
+    server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id,
+    min_available_seq: "0",
+    current_seq: "4",
+    next_sequence_boundary: "5",
+    accepted_envelope_versions: [1],
+    write_allowed_ciphers: ["future-aead"],
+    policy_revision: "1",
+    effective_from_seq: "1",
+    max_blob_bytes: "1048576",
+    policy_history: [{
+      policy_revision: "1", effective_from_seq: "1",
+      accepted_envelope_versions: [1], write_allowed_ciphers: ["future-aead"],
+    }],
+  };
+  assert.equal(plaintextWriteEligible(config, base), false);
+  assert.equal(plaintextWriteEligible(config, { ...base, next_sequence_boundary: null }), false);
+});
+
+test("storage driver subprocess cannot observe the bearer token", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-env-"));
+  const mock = join(root, "driver.sh");
+  await writeFile(mock, `#!/usr/bin/env bash
+[ -z "\${AGMSG_SYNC_TOKEN:-}" ] || exit 99
+printf '{"type":"mock-ok"}\\n'
+`, { mode: 0o700 });
+  const previousDriver = process.env.AGMSG_SYNC_DRIVER;
+  const previousToken = process.env.AGMSG_SYNC_TOKEN;
+  process.env.AGMSG_SYNC_DRIVER = mock;
+  process.env.AGMSG_SYNC_TOKEN = "must-not-cross-driver-boundary";
+  try {
+    assert.deepEqual(await driver("prepare", config, [], ["1"]), [{ type: "mock-ok" }]);
+  } finally {
+    if (previousDriver === undefined) delete process.env.AGMSG_SYNC_DRIVER;
+    else process.env.AGMSG_SYNC_DRIVER = previousDriver;
+    if (previousToken === undefined) delete process.env.AGMSG_SYNC_TOKEN;
+    else process.env.AGMSG_SYNC_TOKEN = previousToken;
+    if (!root.startsWith(join(tmpdir(), "agmsg-sync-driver-env-"))) throw new Error("unsafe test root");
+    await rm(root, { recursive: true });
+  }
+});

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -984,11 +984,12 @@ JSON
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" t-sid "$TEST_PROJECT" claude-code bob > /tmp/agmsg-as-bob 2>&1 &
   local pid=$!
-  # High-water-mark = MAX(id) at startup, so prior messages aren't replayed.
-  # Insert NEW messages and wait for several poll iterations.
+  # The watcher seeds its cursor from the storage tip at startup, so prior
+  # messages aren't replayed. Send NEW messages through the facade (storage_send
+  # writes the event log the watcher now streams) and wait for several polls.
   sleep 1
-  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'system', 'alice', 'new-for-alice');"
-  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'system', 'bob', 'new-for-bob');"
+  bash "$SCRIPTS/send.sh" myteam system alice "new-for-alice" >/dev/null
+  bash "$SCRIPTS/send.sh" myteam system bob "new-for-bob" >/dev/null
   sleep 3
   kill -TERM "$pid" 2>/dev/null
   wait "$pid" 2>/dev/null || true
@@ -1086,10 +1087,10 @@ JSON
   # Join `bob` to the same (project, type) after the watcher is running.
   bash "$SCRIPTS/join.sh" myteam bob claude-code "$TEST_PROJECT"
 
-  # Insert messages for both. alice should arrive (alice was in the original
-  # subscription set); bob should NOT arrive (joined after launch).
-  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'sys', 'alice', 'for-alice-static');"
-  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'sys', 'bob',   'for-bob-static');"
+  # Send messages for both via the facade. alice should arrive (alice was in the
+  # original subscription set); bob should NOT arrive (joined after launch).
+  bash "$SCRIPTS/send.sh" myteam sys alice "for-alice-static" >/dev/null
+  bash "$SCRIPTS/send.sh" myteam sys bob   "for-bob-static" >/dev/null
 
   sleep 3
   kill -TERM "$pid" 2>/dev/null

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -988,8 +988,8 @@ JSON
   # messages aren't replayed. Send NEW messages through the facade (storage_send
   # writes the event log the watcher now streams) and wait for several polls.
   sleep 1
-  bash "$SCRIPTS/send.sh" myteam system alice "new-for-alice" >/dev/null
-  bash "$SCRIPTS/send.sh" myteam system bob "new-for-bob" >/dev/null
+  bash "$SCRIPTS/send.sh" myteam system alice "new-for-alice" --force >/dev/null
+  bash "$SCRIPTS/send.sh" myteam system bob "new-for-bob" --force >/dev/null
   sleep 3
   kill -TERM "$pid" 2>/dev/null
   wait "$pid" 2>/dev/null || true
@@ -1089,8 +1089,8 @@ JSON
 
   # Send messages for both via the facade. alice should arrive (alice was in the
   # original subscription set); bob should NOT arrive (joined after launch).
-  bash "$SCRIPTS/send.sh" myteam sys alice "for-alice-static" >/dev/null
-  bash "$SCRIPTS/send.sh" myteam sys bob   "for-bob-static" >/dev/null
+  bash "$SCRIPTS/send.sh" myteam sys alice "for-alice-static" --force >/dev/null
+  bash "$SCRIPTS/send.sh" myteam sys bob   "for-bob-static" --force >/dev/null
 
   sleep 3
   kill -TERM "$pid" 2>/dev/null

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -6,7 +6,6 @@ setup() {
   setup_test_env
   bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a
   bash "$SCRIPTS/join.sh" testteam bob claude-code /tmp/project-a
-  DBPATH="$TEST_SKILL_DIR/db/messages.db"
   BARRIER="$TEST_SKILL_DIR/mark-barrier"
 }
 
@@ -14,8 +13,15 @@ teardown() {
   teardown_test_env
 }
 
+# Counts unread via the storage facade (send.sh now writes the event log, not
+# the legacy messages table's read_at column — a raw "read_at IS NULL" count
+# would silently always read 0 post-flip and never catch a real regression).
 unread_count() {
-  sqlite3 "$DBPATH" "SELECT COUNT(*) FROM messages WHERE team='testteam' AND to_agent='$1' AND read_at IS NULL;" | tr -d '\r'
+  bash -c '
+    source "'"$SCRIPTS"'/lib/storage.sh"
+    agmsg_storage_load
+    storage_list_unread testteam "$1"
+  ' _ "$1" | grep -c .
 }
 
 # Wait until the script under test has displayed and is paused before its

--- a/tests/test_messaging.bats
+++ b/tests/test_messaging.bats
@@ -57,7 +57,7 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" =~ "Sent to nobody" ]]
   local n
-  n=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COUNT(*) FROM messages WHERE team='brandnewteam';")
+  n=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" "SELECT COUNT(*) FROM events WHERE type='message_sent' AND team='brandnewteam';")
   [ "$n" -eq 1 ]
 }
 

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=sqlite
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  storage_init >/dev/null
+  SERVER_ID=018f3f7e-0000-7000-8000-000000000000
+  TEAM_ID=018f3f7e-0000-7000-8000-000000000001
+  PREPARE='{"type":"sync_prepare","envelope_v":1,"cipher":"none","key_id":null,"max_blob_bytes":1048576}'
+}
+
+teardown() { teardown_test_env; }
+
+prepare_push() {
+  printf '%s\n' "$PREPARE" | storage_sync_prepare_push demo "$SERVER_ID" "$TEAM_ID" 1 "${1:-100}"
+}
+
+@test "sync contract: prepare is re-entrant and byte-stable before reconcile" {
+  storage_send demo alice bob "preserve these exact bytes" >/dev/null
+  local first second
+  first=$(prepare_push)
+  second=$(prepare_push)
+  [ "$first" = "$second" ]
+  [ "$(printf '%s\n' "$first" | jq -s '[.[] | select(.type=="sync_push_candidate")] | length')" -eq 1 ]
+  printf '%s\n' "$first" | jq -e 'select(.type=="sync_push_candidate")
+    | (.id | test("^[0-9a-f]{8}-[0-9a-f]{4}-4"))
+      and (.envelope.cipher=="none") and (.envelope.key_id==null)' >/dev/null
+}
+
+@test "sync contract: reconcile advances only the acknowledged contiguous prefix" {
+  storage_send demo alice bob one >/dev/null
+  storage_send demo alice bob two >/dev/null
+  storage_send demo alice bob three >/dev/null
+  local candidates late early result
+  candidates=$(prepare_push 3)
+  late=$(printf '%s\n' "$candidates" | jq -c '
+    select(.type=="sync_push_candidate" and (.local_position|tonumber)>1)
+    | {type:"sync_push_ack",local_position,id,server_seq:.local_position,disposition:"stored"}')
+  result=$(printf '%s\n' "$late" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r '.push_cursor')" = 0 ]
+  early=$(printf '%s\n' "$candidates" | jq -c '
+    select(.type=="sync_push_candidate" and .local_position=="1")
+    | {type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}')
+  result=$(printf '%s\n' "$early" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r '.push_cursor')" = 3 ]
+}
+
+@test "sync contract: pull reconciles echoes, imports wire IDs once, and keeps read state separate" {
+  storage_send demo alice bob "outgoing" >/dev/null
+  local prepared candidate ack envelope echo remote page result
+  prepared=$(prepare_push)
+  candidate=$(printf '%s\n' "$prepared" | jq -c 'select(.type=="sync_push_candidate")')
+  ack=$(printf '%s\n' "$candidate" | jq -c \
+    '{type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}')
+  printf '%s\n' "$ack" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  envelope=$(printf '%s\n' "$candidate" | jq -c '.envelope')
+  echo=$(jq -nc --argjson envelope "$envelope" --arg id "$(printf '%s\n' "$candidate" | jq -r '.id')" '
+    {type:"sync_pull_message",server_seq:"1",id:$id,
+     server_received_at:"2026-07-20T13:00:00.000000Z",envelope:$envelope,
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"outgoing",created_at:"2026-07-20T13:00:00.000000Z",
+                 from_agent:"alice",to_agent:"bob"}}')
+  remote=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"2",
+     id:"550e8400-e29b-41d4-a716-446655440000",
+     server_received_at:"2026-07-20T13:00:01.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"incoming",created_at:"2026-07-20T13:00:01.000000Z",
+        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"incoming",created_at:"2026-07-20T13:00:01.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
+  page=$(printf '%s\n%s\n%s\n' "$echo" "$remote" '{"type":"sync_pull_cursor","next_after":"2"}')
+  result=$(printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r '.transport_cursor')" = 2 ]
+  [ "$(storage_history demo | jq -s 'length')" -eq 2 ]
+  [ "$(storage_history demo | jq -s '[.[]|select(.body=="outgoing")]|length')" -eq 1 ]
+  [ "$(storage_history demo | jq -s '[.[]|select(.body=="incoming")]|length')" -eq 1 ]
+  [ "$(storage_list_unread demo bob | jq -s '[.[]|select(.body=="incoming")]|length')" -eq 1 ]
+  # Re-applying a durable page cannot create a second local event.
+  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  [ "$(storage_history demo | jq -s 'length')" -eq 2 ]
+}

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -107,6 +107,34 @@ prepare_push() {
   [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_conflicts;" | tr -d '\r')" -eq 1 ]
 }
 
+@test "sync contract: pull conflicts with an acked mapping before its echo arrives" {
+  storage_send demo alice bob "acked without echo" >/dev/null
+  local prepared candidate ack remote page result db
+  prepared=$(prepare_push)
+  candidate=$(printf '%s\n' "$prepared" | jq -c 'select(.type=="sync_push_candidate")')
+  ack=$(printf '%s\n' "$candidate" | jq -c \
+    '{type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}')
+  printf '%s\n' "$ack" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  remote=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"1",
+     id:"550e8400-e29b-41d4-a716-446655440012",
+     server_received_at:"2026-07-20T13:01:30.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"conflicting remote",created_at:"2026-07-20T13:01:30.000000Z",
+        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"conflicting remote",created_at:"2026-07-20T13:01:30.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
+  page=$(printf '%s\n%s\n' "$remote" '{"type":"sync_pull_cursor","next_after":"1"}')
+  result=$(printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -sr '.[0].corrupt_count')" -ge 1 ]
+  [ "$(printf '%s\n' "$result" | jq -sr '[.[]|select(.id=="550e8400-e29b-41d4-a716-446655440012")][0].status')" = corrupt_state ]
+  [ "$(storage_history demo | jq -s 'length')" -eq 1 ]
+  db=$(agmsg_db_path)
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_messages WHERE server_seq='1';" | tr -d '\r')" -eq 1 ]
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_conflicts;" | tr -d '\r')" -eq 1 ]
+}
+
 @test "sync contract: a mapped echo keeps its blocking policy evaluation" {
   storage_send demo alice bob "mapped" >/dev/null
   local prepared candidate ack blocked page result db wire

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -13,7 +13,7 @@ setup() {
   storage_init >/dev/null
   SERVER_ID=018f3f7e-0000-7000-8000-000000000000
   TEAM_ID=018f3f7e-0000-7000-8000-000000000001
-  PREPARE='{"type":"sync_prepare","envelope_v":1,"cipher":"none","key_id":null,"max_blob_bytes":1048576}'
+  PREPARE='{"type":"sync_prepare","envelope_v":1,"cipher":"none","key_id":null,"max_blob_bytes":1048576,"allow_new":true}'
 }
 
 teardown() { teardown_test_env; }
@@ -79,7 +79,7 @@ prepare_push() {
                  from_agent:"carol",to_agent:"bob"}}')
   page=$(printf '%s\n%s\n%s\n' "$echo" "$remote" '{"type":"sync_pull_cursor","next_after":"2"}')
   result=$(printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1)
-  [ "$(printf '%s\n' "$result" | jq -r '.transport_cursor')" = 2 ]
+  [ "$(printf '%s\n' "$result" | jq -sr '.[0].transport_cursor')" = 2 ]
   [ "$(storage_history demo | jq -s 'length')" -eq 2 ]
   [ "$(storage_history demo | jq -s '[.[]|select(.body=="outgoing")]|length')" -eq 1 ]
   [ "$(storage_history demo | jq -s '[.[]|select(.body=="incoming")]|length')" -eq 1 ]
@@ -87,4 +87,44 @@ prepare_push() {
   # Re-applying a durable page cannot create a second local event.
   printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
   [ "$(storage_history demo | jq -s 'length')" -eq 2 ]
+}
+
+@test "sync contract: a server sequence reused by another wire ID is durably corrupt" {
+  local first second first_page second_page result db
+  first=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"1",id:"550e8400-e29b-41d4-a716-446655440010",
+     server_received_at:"2026-07-20T13:01:00.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:"e30="},status:"malformed",
+     policy_revision:"0",local_security_revision:"0",reason:"fixture"}')
+  first_page=$(printf '%s\n%s\n' "$first" '{"type":"sync_pull_cursor","next_after":"1"}')
+  printf '%s\n' "$first_page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  second=$(printf '%s\n' "$first" | jq -c '.id="550e8400-e29b-41d4-a716-446655440011"')
+  second_page=$(printf '%s\n%s\n' "$second" '{"type":"sync_pull_cursor","next_after":"1"}')
+  result=$(printf '%s\n' "$second_page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -s '.[0].corrupt_count')" -ge 1 ]
+  [ "$(printf '%s\n' "$result" | jq -s '[.[]|select(.id=="550e8400-e29b-41d4-a716-446655440011" and .status=="corrupt_state")]|length')" -eq 1 ]
+  db=$(agmsg_db_path)
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_conflicts;" | tr -d '\r')" -eq 1 ]
+}
+
+@test "sync contract: a mapped echo keeps its blocking policy evaluation" {
+  storage_send demo alice bob "mapped" >/dev/null
+  local prepared candidate ack blocked page result db wire
+  prepared=$(prepare_push)
+  candidate=$(printf '%s\n' "$prepared" | jq -c 'select(.type=="sync_push_candidate")')
+  ack=$(printf '%s\n' "$candidate" | jq -c \
+    '{type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}')
+  printf '%s\n' "$ack" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  wire=$(printf '%s\n' "$candidate" | jq -r '.id')
+  blocked=$(printf '%s\n' "$candidate" | jq -c '
+    {type:"sync_pull_message",server_seq:"1",id,
+     server_received_at:"2026-07-20T13:02:00.000000Z",envelope,
+     status:"policy_violation",policy_revision:"2",local_security_revision:"1",
+     reason:"E2EE required"}')
+  page=$(printf '%s\n%s\n' "$blocked" '{"type":"sync_pull_cursor","next_after":"1"}')
+  result=$(printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -sr --arg wire "$wire" '[.[]|select(.id==$wire)][0].status')" = policy_violation ]
+  db=$(agmsg_db_path)
+  [ "$(agmsg_sqlite "$db" "SELECT status FROM sync_quarantine WHERE wire_id='$wire';" | tr -d '\r')" = policy_violation ]
+  [ "$(storage_history demo | jq -s 'length')" -eq 1 ]
 }

--- a/tests/test_remote_sync_engine.bats
+++ b/tests/test_remote_sync_engine.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "Stage-1 sync engine protocol and security boundaries" {
+  run node --test "$BATS_TEST_DIRNAME/remote_sync_engine.test.mjs"
+  [ "$status" -eq 0 ]
+}

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -174,7 +174,7 @@ SH
   wait
   local n
   n=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" \
-    "SELECT COUNT(*) FROM messages WHERE from_agent='leader';")
+    "SELECT COUNT(*) FROM events WHERE type='message_sent' AND from_agent='leader';")
   [ "$n" -eq 10 ]
 }
 
@@ -189,6 +189,6 @@ SH
   done
   wait
   local n
-  n=$(sqlite3 "$AGMSG_STORAGE_PATH/messages.db" "SELECT COUNT(*) FROM messages;")
+  n=$(sqlite3 "$AGMSG_STORAGE_PATH/messages.db" "SELECT COUNT(*) FROM events WHERE type='message_sent';")
   [ "$n" -eq 10 ]
 }

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -161,7 +161,7 @@ SH
 
   [ "$(agmsg_runtime_lock_acquire codex-dispatcher:test 111)" = 111 ]
   bash "$SCRIPTS/send.sh" team alice bob "after lock init" --force
-  [ "$(agmsg_sqlite "$(agmsg_db_path)" "SELECT COUNT(*) FROM messages WHERE body = 'after lock init';")" = 1 ]
+  [ "$(agmsg_sqlite "$(agmsg_db_path)" "SELECT COUNT(*) FROM events WHERE type='message_sent' AND body = 'after lock init';")" = 1 ]
 }
 
 @test "send: concurrent fan-out to N recipients all land (no SQLITE_BUSY)" {

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -95,6 +95,34 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [[ "$output" == *h2* ]]
 }
 
+@test "contract: history without an agent returns the whole team (§2.1 G3)" {
+  storage_send agsuite alice bob "tw1"
+  storage_send agsuite carol dave "tw2"   # involves neither alice nor bob
+  run storage_history agsuite              # omitted agent = whole team
+  [ "$status" -eq 0 ]
+  [[ "$output" == *tw1* ]]
+  [[ "$output" == *tw2* ]]
+  # the agent-scoped form still filters (additive, existing behaviour intact)
+  run storage_history agsuite carol
+  [[ "$output" == *tw2* ]]
+  [[ "$output" != *tw1* ]]
+}
+
+@test "contract: history --limit returns the most recent N in chronological order" {
+  storage_send agsuite alice bob "old1"
+  storage_send agsuite alice bob "old2"
+  storage_send agsuite alice bob "new3"
+  run storage_history agsuite bob --limit 2
+  [ "$status" -eq 0 ]
+  [[ "$output" == *old2* ]]      # the two most recent
+  [[ "$output" == *new3* ]]
+  [[ "$output" != *old1* ]]      # the oldest dropped
+  local l2 l3
+  l2=$(printf '%s\n' "$output" | grep -n old2 | head -1 | cut -d: -f1)
+  l3=$(printf '%s\n' "$output" | grep -n new3 | head -1 | cut -d: -f1)
+  [ "$l2" -lt "$l3" ]            # chronological order, not reverse
+}
+
 @test "contract: export then import round-trips the event log" {
   local id; id=$(storage_send agsuite alice bob "keep")
   storage_mark_read_batch agsuite bob "$id"

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -198,6 +198,19 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   fi
   run storage_list_unread agsuite bob
   [ "$status" -ne 0 ]
+  run storage_watch_tip agsuite:bob   # the tip read must also fail, not report 0
+  [ "$status" -ne 0 ]
+}
+
+@test "contract(jsonl): mark_read_batch fails non-zero when the lock is unavailable" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = jsonl ] || skip "jsonl-specific (mkdir write lock)"
+  local id; id=$(storage_send agsuite alice bob "x")
+  # Hold the write lock so the mark can't acquire it; cap retries so it fails fast.
+  mkdir "$(dirname "$(agmsg_db_path)")/events.jsonl.lock"
+  AGMSG_JSONL_LOCK_TRIES=2 run storage_mark_read_batch agsuite bob "$id"
+  rmdir "$(dirname "$(agmsg_db_path)")/events.jsonl.lock" 2>/dev/null || true
+  [ "$status" -ne 0 ]                  # control op surfaces the failure
+  [[ "$output" != *ok* ]]             # never a false "ok"
 }
 
 # --- compaction contract (§2.7) --------------------------------------------

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -213,26 +213,68 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
 
 # --- sqlite-specific: compaction physically shrinks the log -----------------
 
-@test "contract(sqlite): compact coalesces duplicate read markers and shrinks the log" {
+@test "contract(sqlite): compact coalesces tail duplicates AND high-water keeps the tip/cursor safe" {
+  # This is the test that actually EXERCISES cursor-safety: mark_read_batch is
+  # write-idempotent, so the driver-agnostic cursor tests above never create the
+  # tail-duplicate rows whose deletion would regress a naive MAX(seq) tip. Here we
+  # inject those duplicates directly (the highest seqs in the log), then compact —
+  # the case that distinguishes the AUTOINCREMENT high-water from MAX(seq).
   local db; db="$(agmsg_db_path)"
-  local id; id=$(storage_send agsuite alice bob "s1")
-  # mark_read_batch is write-idempotent (a NOT EXISTS guard), so duplicate
-  # message_read rows only arise from a racing writer or a merged import. Inject
-  # them directly — that race/import residue is exactly what compact cleans up.
+  storage_send agsuite alice bob "s1"
+  # cursor taken before a later send — must still deliver that later message.
+  local cur0; cur0=$(storage_watch_tip agsuite:bob)
+  storage_send agsuite alice bob "s2-late"
+  local id; id=$(storage_send agsuite alice bob "s3")
+  # duplicate read markers as the TAIL rows (highest seq): compact deletes these,
+  # dropping MAX(seq) but NOT the high-water.
   agmsg_sqlite "$db" "INSERT INTO events (type,id,team,agent,msg_id,at) VALUES
     ('message_read','r1','agsuite','bob','$id','2026-01-01T00:00:01Z'),
     ('message_read','r2','agsuite','bob','$id','2026-01-01T00:00:02Z'),
     ('message_read','r3','agsuite','bob','$id','2026-01-01T00:00:03Z');"
-  local reads_before total_before
+  local reads_before total_before tip_before
   reads_before=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events WHERE type='message_read';" | tr -d '\r')
   total_before=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events;" | tr -d '\r')
+  tip_before=$(storage_watch_tip agsuite:bob)
   [ "$reads_before" -eq 3 ]
+
   storage_compact
-  local reads_after total_after
+
+  local reads_after total_after tip_after
   reads_after=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events WHERE type='message_read';" | tr -d '\r')
   total_after=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events;" | tr -d '\r')
+  tip_after=$(storage_watch_tip agsuite:bob)
   [ "$reads_after" -eq 1 ]                 # coalesced to one
-  [ "$total_after" -lt "$total_before" ]   # strictly shrank (2 dupes removed)
+  [ "$total_after" -lt "$total_before" ]   # strictly shrank (2 tail dupes removed)
+  # high-water: the tip did NOT regress even though the tail rows (= old MAX seq)
+  # were deleted. A MAX(seq) implementation would fail here.
+  [ "$tip_after" -ge "$tip_before" ]
+  # and the cursor issued before s2-late still delivers it — no message_sent lost.
+  run storage_watch_after "$cur0" agsuite:bob
+  [[ "$output" == *"s2-late"* ]]
+}
+
+@test "contract(sqlite): forward-compat — export/list/history ignore an unknown event type" {
+  local db; db="$(agmsg_db_path)"
+  storage_send agsuite alice bob "known"
+  # a v2-style event a v1 reader has never seen — must be skipped, not leaked.
+  agmsg_sqlite "$db" "INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
+    VALUES ('message_reaction','x1','agsuite','bob','alice','👍','2026-02-02T00:00:00Z');"
+  # export stays clean JSONL: no blank line, no unknown type, every line valid JSON.
+  local f="$TEST_SKILL_DIR/fc.jsonl"
+  storage_export "$f"
+  [ "$(grep -c '^$' "$f")" -eq 0 ]          # no blank line leaked by the unknown type
+  ! grep -q 'message_reaction' "$f"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    [ "$(sqlite3 :memory: "SELECT json_valid('$(printf '%s' "$line" | sed "s/'/''/g")')")" = "1" ]
+  done < "$f"
+  # the known message is still visible; the unknown event perturbs nothing.
+  run storage_list_unread agsuite bob
+  [[ "$output" == *known* ]]
+  [[ "$output" != *message_reaction* ]]
+  run storage_history agsuite bob
+  [[ "$output" == *known* ]]
+  [[ "$output" != *message_reaction* ]]
 }
 
 # --- sqlite-specific: legacy messages-table compatibility (§2.4) ------------

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -118,3 +118,65 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
     [ "$(sqlite3 :memory: "SELECT json_valid('$(printf '%s' "$line" | sed "s/'/''/g")')")" = "1" ]
   done <<< "$output"
 }
+
+@test "contract: list_unread / history records carry a type field" {
+  storage_send agsuite alice bob "t1"
+  run storage_list_unread agsuite bob
+  [[ "$output" == *'"type":"message_sent"'* ]]
+  run storage_history agsuite bob
+  [[ "$output" == *'"type":"message_sent"'* ]]
+}
+
+@test "contract: the delivery cursor is a single whitespace-free token" {
+  local tip; tip=$(storage_watch_tip agsuite:bob)
+  [ -n "$tip" ]
+  [ "$(printf '%s' "$tip" | wc -l | tr -d ' ')" = "0" ]   # one line, no trailing newline
+  [[ "$tip" != *" "* ]]
+  [[ "$tip" != *$'\t'* ]]
+}
+
+@test "contract: watch_after's trailing cursor record is the final line" {
+  local tip; tip=$(storage_watch_tip agsuite:bob)
+  storage_send agsuite alice bob "w1"
+  local out; out=$(storage_watch_after "$tip" agsuite:bob)
+  [[ "$(printf '%s\n' "$out" | tail -1)" == *'"type":"cursor"'* ]]
+}
+
+@test "contract: a data op fails non-zero on a broken store (no silent success)" {
+  # pipefail must surface the backend error instead of tr swallowing it.
+  local db; db="$(agmsg_db_path)"
+  rm -f "$db"-wal "$db"-shm
+  printf 'not a sqlite database' > "$db"
+  run storage_list_unread agsuite bob
+  [ "$status" -ne 0 ]
+}
+
+# --- sqlite-specific: legacy messages-table compatibility (§2.4) ------------
+# These assert the sqlite driver's read-only UNION of the pre-event-log store;
+# they are intentionally NOT driver-agnostic (a fresh jsonl/redis store has no
+# legacy table). Existing installs must keep their inbox + history at cutover.
+
+@test "contract(sqlite): legacy messages rows surface in unread and history" {
+  local db; db="$(agmsg_db_path)"
+  agmsg_sqlite "$db" "INSERT INTO messages (team,from_agent,to_agent,body,read_at)
+    VALUES ('agsuite','alice','bob','legacy-unread',NULL),
+           ('agsuite','alice','bob','legacy-read','2026-01-01T00:00:00Z');"
+  run storage_list_unread agsuite bob
+  [[ "$output" == *legacy-unread* ]]
+  [[ "$output" != *legacy-read* ]]
+  run storage_history agsuite bob
+  [[ "$output" == *legacy-unread* ]]
+  [[ "$output" == *legacy-read* ]]
+}
+
+@test "contract(sqlite): marking a legacy id read hides it without mutating the row" {
+  local db; db="$(agmsg_db_path)"
+  agmsg_sqlite "$db" "INSERT INTO messages (team,from_agent,to_agent,body)
+    VALUES ('agsuite','alice','bob','legacy-x');"
+  local lid; lid=$(agmsg_sqlite "$db" "SELECT id FROM messages WHERE body='legacy-x';" | tr -d '\r')
+  storage_mark_read_batch agsuite bob "$lid"
+  run storage_list_unread agsuite bob
+  [[ "$output" != *legacy-x* ]]
+  # the legacy row is never mutated (read_at stays NULL) — no destructive migration.
+  [ -z "$(agmsg_sqlite "$db" "SELECT read_at FROM messages WHERE body='legacy-x';" | tr -d '\r')" ]
+}

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -151,6 +151,90 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [ "$status" -ne 0 ]
 }
 
+# --- compaction contract (§2.7) --------------------------------------------
+# These pin storage_compact's behavioural guarantees through the facade, so they
+# hold for every driver: idempotent, state-preserving, cursor-safe, monotonic tip.
+
+@test "contract: compact is state-preserving (unread + history unchanged)" {
+  local a b c
+  a=$(storage_send agsuite alice bob "p1")
+  b=$(storage_send agsuite alice bob "p2")
+  c=$(storage_send agsuite bob alice "p3")
+  storage_mark_read_batch agsuite bob "$a"
+  # redundant markers — fodder compaction should coalesce away invisibly
+  storage_mark_read_batch agsuite bob "$a"
+  storage_mark_read_batch agsuite bob "$a"
+  local unread_before history_before
+  unread_before=$(storage_list_unread agsuite bob)
+  history_before=$(storage_history agsuite bob)
+  storage_compact
+  [ "$(storage_list_unread agsuite bob)" = "$unread_before" ]
+  [ "$(storage_history agsuite bob)" = "$history_before" ]
+}
+
+@test "contract: compact is idempotent (second compact is a no-op for visible state)" {
+  local id; id=$(storage_send agsuite alice bob "i1")
+  storage_mark_read_batch agsuite bob "$id"
+  storage_mark_read_batch agsuite bob "$id"
+  storage_compact
+  local after_one; after_one=$(storage_export "$TEST_SKILL_DIR/c1.jsonl"; cat "$TEST_SKILL_DIR/c1.jsonl")
+  storage_compact
+  storage_export "$TEST_SKILL_DIR/c2.jsonl"
+  [ "$(cat "$TEST_SKILL_DIR/c2.jsonl")" = "$after_one" ]
+}
+
+@test "contract: compact is cursor-safe (a pre-compact cursor skips nothing)" {
+  local tip; tip=$(storage_watch_tip agsuite:bob)
+  storage_send agsuite alice bob "c1"
+  storage_send agsuite alice bob "c2"
+  # pile up redundant read markers AFTER the sends, so compaction deletes the
+  # highest-seq rows — the case that would regress a naive MAX(seq) cursor.
+  local x; x=$(storage_send agsuite alice carol "noise")
+  storage_mark_read_batch agsuite carol "$x"
+  storage_mark_read_batch agsuite carol "$x"
+  storage_mark_read_batch agsuite carol "$x"
+  storage_compact
+  run storage_watch_after "$tip" agsuite:bob
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"c1"* ]]
+  [[ "$output" == *"c2"* ]]
+}
+
+@test "contract: the delivery tip never regresses across a compact (monotonic)" {
+  storage_send agsuite alice bob "m1"
+  local id; id=$(storage_send agsuite alice bob "m2")
+  storage_mark_read_batch agsuite bob "$id"
+  storage_mark_read_batch agsuite bob "$id"   # redundant tail markers
+  local tip_before; tip_before=$(storage_watch_tip agsuite:bob)
+  storage_compact
+  local tip_after; tip_after=$(storage_watch_tip agsuite:bob)
+  [ "$tip_after" -ge "$tip_before" ]
+}
+
+# --- sqlite-specific: compaction physically shrinks the log -----------------
+
+@test "contract(sqlite): compact coalesces duplicate read markers and shrinks the log" {
+  local db; db="$(agmsg_db_path)"
+  local id; id=$(storage_send agsuite alice bob "s1")
+  # mark_read_batch is write-idempotent (a NOT EXISTS guard), so duplicate
+  # message_read rows only arise from a racing writer or a merged import. Inject
+  # them directly — that race/import residue is exactly what compact cleans up.
+  agmsg_sqlite "$db" "INSERT INTO events (type,id,team,agent,msg_id,at) VALUES
+    ('message_read','r1','agsuite','bob','$id','2026-01-01T00:00:01Z'),
+    ('message_read','r2','agsuite','bob','$id','2026-01-01T00:00:02Z'),
+    ('message_read','r3','agsuite','bob','$id','2026-01-01T00:00:03Z');"
+  local reads_before total_before
+  reads_before=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events WHERE type='message_read';" | tr -d '\r')
+  total_before=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events;" | tr -d '\r')
+  [ "$reads_before" -eq 3 ]
+  storage_compact
+  local reads_after total_after
+  reads_after=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events WHERE type='message_read';" | tr -d '\r')
+  total_after=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events;" | tr -d '\r')
+  [ "$reads_after" -eq 1 ]                 # coalesced to one
+  [ "$total_after" -lt "$total_before" ]   # strictly shrank (2 dupes removed)
+}
+
 # --- sqlite-specific: legacy messages-table compatibility (§2.4) ------------
 # These assert the sqlite driver's read-only UNION of the pre-event-log store;
 # they are intentionally NOT driver-agnostic (a fresh jsonl/redis store has no

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -181,10 +181,15 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
 }
 
 @test "contract: a data op fails non-zero on a broken store (no silent success)" {
-  # pipefail must surface the backend error instead of tr swallowing it.
-  local db; db="$(agmsg_db_path)"
-  rm -f "$db"-wal "$db"-shm
-  printf 'not a sqlite database' > "$db"
+  # A backend error must surface as a non-zero exit, never a silent empty result.
+  # Corruption is store-specific, so break whichever store the active driver reads.
+  if [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = jsonl ]; then
+    printf 'not json at all {{{\n' > "$(dirname "$(agmsg_db_path)")/events.jsonl"
+  else
+    local db; db="$(agmsg_db_path)"
+    rm -f "$db"-wal "$db"-shm
+    printf 'not a sqlite database' > "$db"
+  fi
   run storage_list_unread agsuite bob
   [ "$status" -ne 0 ]
 }
@@ -252,6 +257,7 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
 # --- sqlite-specific: compaction physically shrinks the log -----------------
 
 @test "contract(sqlite): compact coalesces tail duplicates AND high-water keeps the tip/cursor safe" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = sqlite ] || skip "sqlite-specific (direct events-table injection / high-water)"
   # This is the test that actually EXERCISES cursor-safety: mark_read_batch is
   # write-idempotent, so the driver-agnostic cursor tests above never create the
   # tail-duplicate rows whose deletion would regress a naive MAX(seq) tip. Here we
@@ -292,6 +298,7 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
 }
 
 @test "contract(sqlite): forward-compat — export/list/history ignore an unknown event type" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = sqlite ] || skip "sqlite-specific (direct events-table injection)"
   local db; db="$(agmsg_db_path)"
   storage_send agsuite alice bob "known"
   # a v2-style event a v1 reader has never seen — must be skipped, not leaked.
@@ -321,6 +328,7 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
 # legacy table). Existing installs must keep their inbox + history at cutover.
 
 @test "contract(sqlite): legacy messages rows surface in unread and history" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = sqlite ] || skip "sqlite-specific (legacy messages table)"
   local db; db="$(agmsg_db_path)"
   agmsg_sqlite "$db" "INSERT INTO messages (team,from_agent,to_agent,body,read_at)
     VALUES ('agsuite','alice','bob','legacy-unread',NULL),
@@ -334,6 +342,7 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
 }
 
 @test "contract(sqlite): marking a legacy id read hides it without mutating the row" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = sqlite ] || skip "sqlite-specific (legacy messages table)"
   local db; db="$(agmsg_db_path)"
   agmsg_sqlite "$db" "INSERT INTO messages (team,from_agent,to_agent,body)
     VALUES ('agsuite','alice','bob','legacy-x');"

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -27,6 +27,12 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [[ "$output" == *ok* ]]
 }
 
+@test "contract: storage_store_exists is true once the store is initialized" {
+  # setup() ran storage_init, so the active driver's store is present.
+  run storage_store_exists
+  [ "$status" -eq 0 ]
+}
+
 @test "contract: send returns an id and list_unread shows the message" {
   local id; id=$(storage_send agsuite alice bob "hi")
   [ -n "$id" ]

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# Driver-agnostic storage-contract tests (docs/spec/driver-interface.md §2,
+# ADR 0003). They exercise the storage_* contract through the facade, so the
+# SAME tests pin every driver: they run against the built-in sqlite driver here,
+# and `AGMSG_STORAGE_DRIVER=<name> bats tests/test_storage_contract.bats` runs the
+# identical contract against jsonl / redis once those land.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  storage_init
+}
+
+teardown() { teardown_test_env; }
+
+# pull the cursor token out of a watch_after stream's trailing cursor record
+_cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]*\)".*/\1/p'; }
+
+@test "contract: storage_check reports ok" {
+  run storage_check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "contract: send returns an id and list_unread shows the message" {
+  local id; id=$(storage_send agsuite alice bob "hi")
+  [ -n "$id" ]
+  run storage_list_unread agsuite bob
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"body":"hi"'* ]]
+  [[ "$output" == *"$id"* ]]
+}
+
+@test "contract: mark_read_batch is idempotent (double mark is a no-op)" {
+  local id; id=$(storage_send agsuite alice bob "x")
+  storage_mark_read_batch agsuite bob "$id"
+  run storage_list_unread agsuite bob
+  [ -z "$output" ]
+  # Re-marking the same id changes nothing — still read, no error.
+  storage_mark_read_batch agsuite bob "$id"
+  run storage_list_unread agsuite bob
+  [ -z "$output" ]
+}
+
+@test "contract: mark_read is recipient-scoped (one agent's read doesn't hide another's)" {
+  local m; m=$(storage_send agsuite alice carol "for carol")
+  # bob records a read of carol's message id — scoped to bob, so carol is unaffected.
+  storage_mark_read_batch agsuite bob "$m"
+  run storage_list_unread agsuite carol
+  [[ "$output" == *"for carol"* ]]
+}
+
+@test "contract: watch_tip + watch_after deliver only post-tip messages, with a cursor" {
+  storage_send agsuite alice bob "before"
+  local tip; tip=$(storage_watch_tip agsuite:bob)
+  storage_send agsuite alice bob "after"
+  run storage_watch_after "$tip" agsuite:bob
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"body":"after"'* ]]
+  [[ "$output" != *'"body":"before"'* ]]
+  [[ "$output" == *'"type":"cursor"'* ]]
+}
+
+@test "contract: watch_after advances the cursor even with zero matching messages" {
+  local tip; tip=$(storage_watch_tip agsuite:bob)
+  storage_send agsuite alice carol "off-subscription"
+  run storage_watch_after "$tip" agsuite:bob
+  [ "$status" -eq 0 ]
+  [[ "$output" != *message_sent* ]]
+  local newcur; newcur=$(_cursor_of "$output")
+  [ -n "$newcur" ]
+  [ "$newcur" != "$tip" ]
+}
+
+@test "contract: cursor round-trips — re-watching from it does not re-scan" {
+  local tip; tip=$(storage_watch_tip agsuite:bob)
+  storage_send agsuite alice bob "m1"
+  local out1; out1=$(storage_watch_after "$tip" agsuite:bob)
+  [[ "$out1" == *m1* ]]
+  local cur1; cur1=$(_cursor_of "$out1")
+  run storage_watch_after "$cur1" agsuite:bob
+  [[ "$output" != *m1* ]]
+}
+
+@test "contract: history returns messages involving the agent" {
+  storage_send agsuite alice bob "h1"
+  storage_send agsuite bob alice "h2"
+  run storage_history agsuite bob
+  [[ "$output" == *h1* ]]
+  [[ "$output" == *h2* ]]
+}
+
+@test "contract: export then import round-trips the event log" {
+  local id; id=$(storage_send agsuite alice bob "keep")
+  storage_mark_read_batch agsuite bob "$id"
+  local f="$TEST_SKILL_DIR/export.jsonl"
+  storage_export "$f"
+  [ -s "$f" ]
+  rm -f "$TEST_SKILL_DIR"/db/messages.db*
+  storage_init
+  storage_import "$f"
+  run storage_history agsuite bob
+  [[ "$output" == *keep* ]]
+}
+
+@test "contract: record-returning ops emit pure JSONL (no status word on stdout)" {
+  storage_send agsuite alice bob "j1"
+  run storage_list_unread agsuite bob
+  [ "$status" -eq 0 ]
+  local line
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    [ "$(sqlite3 :memory: "SELECT json_valid('$(printf '%s' "$line" | sed "s/'/''/g")')")" = "1" ]
+  done <<< "$output"
+}

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -213,6 +213,15 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [[ "$output" != *ok* ]]             # never a false "ok"
 }
 
+@test "contract(jsonl): mark_read_batch fails non-zero on a corrupt log" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = jsonl ] || skip "jsonl-specific (corrupt JSONL)"
+  storage_send agsuite alice bob "x" >/dev/null
+  printf 'not json {{{\n' > "$(dirname "$(agmsg_db_path)")/events.jsonl"
+  run storage_mark_read_batch agsuite bob someid
+  [ "$status" -ne 0 ]                  # the existing-reads scan failure aborts the mark
+  [[ "$output" != *ok* ]]
+}
+
 # --- compaction contract (§2.7) --------------------------------------------
 # These pin storage_compact's behavioural guarantees through the facade, so they
 # hold for every driver: idempotent, state-preserving, cursor-safe, monotonic tip.

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -123,6 +123,16 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [ "$l2" -lt "$l3" ]            # chronological order, not reverse
 }
 
+@test "contract: history <team> --limit (no agent) treats --limit as a flag, not the agent" {
+  storage_send agsuite alice bob "p1"
+  storage_send agsuite carol dave "p2"
+  run storage_history agsuite --limit 1     # --limit must NOT be consumed as <agent>
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c .)" -eq 1 ]   # exactly one record (team-wide)
+  [[ "$output" == *'"type":"message_sent"'* ]]         # pure JSONL, not a parse error
+  [ "$(sqlite3 :memory: "SELECT json_valid('$(printf '%s' "$output" | sed "s/'/''/g")')")" = "1" ]
+}
+
 @test "contract: export then import round-trips the event log" {
   local id; id=$(storage_send agsuite alice bob "keep")
   storage_mark_read_batch agsuite bob "$id"

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -213,6 +213,20 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [[ "$output" != *ok* ]]             # never a false "ok"
 }
 
+@test "contract(jsonl): compact keys reads by tuple, not a space-join (no collision)" {
+  [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = jsonl ] || skip "jsonl-specific (compaction key)"
+  storage_init
+  local log; log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  # Two DISTINCT (team, agent, msg_id) tuples that a space-joined key would merge:
+  #   ("a b","c","1")  and  ("a","b c","1")  both flatten to "a b c 1".
+  printf '%s\n%s\n' \
+    '{"type":"message_read","id":"r1","msg_id":"1","team":"a b","agent":"c","at":"x"}' \
+    '{"type":"message_read","id":"r2","msg_id":"1","team":"a","agent":"b c","at":"y"}' >> "$log"
+  storage_compact
+  run grep -c '"type":"message_read"' "$log"   # both are distinct read-state; keep both
+  [ "$output" -eq 2 ]
+}
+
 @test "contract(jsonl): mark_read_batch fails non-zero on a corrupt log" {
   [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = jsonl ] || skip "jsonl-specific (corrupt JSONL)"
   storage_send agsuite alice bob "x" >/dev/null

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -507,6 +507,61 @@ EOF
   [[ ! "$output" =~ ".parameter" ]]
 }
 
+# --- SQL string-literal escaping for interpolated names (#223, #87) ---
+# Team and agent names may contain a single quote (validate.sh only blocks path
+# traversal). Before escaping, such a name broke the INSERT/UPDATE and was an
+# injection surface (a name could widen the WHERE predicate). These pin the
+# escaping so a quoted name round-trips and a crafted name cannot touch other
+# rows.
+
+@test "rename-team: escapes quoted team names and migrates only the matching team" {
+  bash "$SCRIPTS/join.sh" "a'team"    alice claude-code /tmp/proj-a
+  bash "$SCRIPTS/join.sh" "a'team"    bob   claude-code /tmp/proj-b
+  bash "$SCRIPTS/join.sh" "keep'team" carol claude-code /tmp/proj-c
+  bash "$SCRIPTS/join.sh" "keep'team" dave  claude-code /tmp/proj-d
+  bash "$SCRIPTS/send.sh" "a'team"    alice bob  "moved"
+  bash "$SCRIPTS/send.sh" "keep'team" carol dave "stay"
+
+  run bash "$SCRIPTS/rename-team.sh" "a'team" "n'team"
+  [ "$status" -eq 0 ]
+  [ ! -d "$TEST_SKILL_DIR/teams/a'team" ]
+  [ -f "$TEST_SKILL_DIR/teams/n'team/config.json" ]
+
+  # config "name" field updated to the quoted new name (json_set value escaped)
+  run sqlite_mem "SELECT json_extract(readfile('$(rf "$TEST_SKILL_DIR/teams/n'team/config.json")'), '\$.name');"
+  [ "$output" = "n'team" ]
+
+  # the message moved to the new quoted team name (messages + events UPDATE escaped)
+  run bash "$SCRIPTS/inbox.sh" "n'team" bob
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "moved" ]]
+
+  # the other quoted team is untouched — the WHERE predicate was not widened
+  run bash "$SCRIPTS/inbox.sh" "keep'team" dave
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "stay" ]]
+}
+
+@test "rename: escapes the agent name in the messages UPDATE without widening it" {
+  # rename.sh rewrites the legacy messages table directly. Seed it with the
+  # renamed agent's row plus an unrelated victim row that an unscoped/injection
+  # predicate would wrongly rewrite.
+  local db="$TEST_SKILL_DIR/db/messages.db"
+  sqlite3 "$db" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('t', 'alice', 'x', 'a-msg');"
+  sqlite3 "$db" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('t', 'keepme', 'x', 'k-msg');"
+  bash "$SCRIPTS/join.sh" t alice claude-code /tmp/proj
+
+  run bash "$SCRIPTS/rename.sh" t alice carol
+  [ "$status" -eq 0 ]
+
+  # the renamed agent's row moved to the new name ...
+  run sqlite3 "$db" "SELECT from_agent FROM messages WHERE body='a-msg';"
+  [ "$output" = "carol" ]
+  # ... and the unrelated row was NOT rewritten (predicate stayed scoped)
+  run sqlite3 "$db" "SELECT from_agent FROM messages WHERE body='k-msg';"
+  [ "$output" = "keepme" ]
+}
+
 @test "join: rejects unknown agent type" {
   run bash "$SCRIPTS/join.sh" myteam alice claude /tmp/proj
   [ "$status" -ne 0 ]

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -54,6 +54,16 @@ _max_message_id() {
     agmsg_sqlite "$(agmsg_db_path)" "SELECT COALESCE(MAX(id), 0) FROM messages;" )
 }
 
+# The delivery watermark is now an opaque storage cursor (the event-log
+# high-water), not a legacy messages id. This mirrors what storage_watch_tip
+# issues, so tests can assert the watcher's persisted watermark against it.
+_storage_tip() {
+  ( # shellcheck disable=SC1090
+    source "$SCRIPTS/lib/storage.sh"
+    agmsg_sqlite "$(agmsg_db_path)" \
+      "SELECT COALESCE((SELECT seq FROM sqlite_sequence WHERE name='events'),0);" )
+}
+
 _wait_for_file() {
   local file="$1" i
   for i in $(seq 1 100); do
@@ -168,7 +178,7 @@ _wait_for_file_contains() {
 
   bash "$SCRIPTS/send.sh" team bob alice "M1-delivered" >/dev/null
   _wait_for_file_contains "$out" "M1-delivered"
-  local first_id="$(_max_message_id)"
+  local first_id="$(_storage_tip)"
 
   # Owning session dies (reap it so kill -0 reports gone, not a zombie), then a
   # newer row arrives. The liveness guard runs before the DB poll, so the watcher
@@ -176,7 +186,7 @@ _wait_for_file_contains() {
   kill "$sesspid" 2>/dev/null || true
   wait "$sesspid" 2>/dev/null || true
   bash "$SCRIPTS/send.sh" team bob alice "M2-undelivered" >/dev/null
-  local second_id="$(_max_message_id)"
+  local second_id="$(_storage_tip)"
 
   _wait_for_missing "$pf" || { kill "$w" 2>/dev/null || true; false; }
   run kill -0 "$w"; [ "$status" -ne 0 ]


### PR DESCRIPTION
## Scope

Branch-only dogfood integration. This intentionally combines the unmerged storage-axis rebase and draft reference server with a Stage-1 local-first polling client. It is not a request to merge or announce the remote-storage direction.

## Included

- ADR 0005 and optional three-operation storage sync ABI
- SQLite durable wire-ID/envelope reservations and contiguous push reconciliation
- durable pull quarantine, echo reconciliation, one-time import, and independent transport/import/read layers
- Node polling engine with capability/binding/policy validation and terminal HTTP 410 handling
- two-AGMSG_STORAGE_PATH PostgreSQL end-to-end test

## Verification

- new sync Bats contract: 3/3
- existing SQLite storage contract: 29/29
- existing JSONL storage contract: 29/29
- reference server + sync PostgreSQL tests: 10/10
- server typecheck and build

Depends conceptually on draft #448 and feat/storage-axis-rebase@121ee19. Keep this PR in draft and do not merge without a new explicit koit gate.