### PR TITLE
AASES計画を本来目的から再構成-2 (#453)

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod agmsg;
 mod agent_state;
+mod managed_session;
 mod menu_i18n;
 mod pty;
 
@@ -650,6 +651,11 @@ pub fn run() {
             agmsg::agmsg_default_project,
             agmsg::agmsg_command_name,
             agmsg::agmsg_spawnable_types,
+            managed_session::managed_session_start,
+            managed_session::managed_session_status,
+            managed_session::managed_session_turn,
+            managed_session::managed_session_ack,
+            managed_session::managed_session_end,
             set_menu_language,
             set_team_room_visible,
             set_user_chat_visible,

--- a/app/src-tauri/src/managed_session.rs
+++ b/app/src-tauri/src/managed_session.rs
@@ -1,0 +1,205 @@
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SessionState {
+    Active,
+    Draining,
+    Inactive,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SessionResult {
+    Pass,
+    Deny,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Presence {
+    Present,
+    Absent,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum FinalAck {
+    Acknowledged,
+    Pending,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorktreeInventory {
+    pub status: Presence,
+    pub dirty: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SessionInventory {
+    pub registration: Presence,
+    pub process: Presence,
+    pub pane: Presence,
+    pub worktree: WorktreeInventory,
+    pub generation: Option<u64>,
+    pub active_turn: Option<bool>,
+    pub final_ack: Option<FinalAck>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ManagedSessionResponse {
+    pub schema_version: String,
+    pub state: SessionState,
+    pub result: SessionResult,
+    pub reason_code: Option<String>,
+    pub session_id: String,
+    pub inventory: Option<SessionInventory>,
+}
+
+fn required_env(name: &str) -> Result<String, String> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| format!("{name} is not configured"))
+}
+
+fn run_runtime(project: String, args: Vec<String>) -> Result<ManagedSessionResponse, String> {
+    if project.trim().is_empty() {
+        return Err("managed session project is empty".into());
+    }
+
+    let binary = required_env("AASES_SESSION_BIN")?;
+    let runtime_root = required_env("AASES_SESSION_RUNTIME_ROOT")?;
+    let mut command = Command::new(binary);
+    command
+        .args(args)
+        .env("AASES_SESSION_RUNTIME_ROOT", runtime_root)
+        .env("AASES_SESSION_PROJECT_ROOT", project);
+    if let Some(path) = crate::imported_path() {
+        command.env("PATH", path);
+    }
+
+    let output = command
+        .output()
+        .map_err(|error| format!("could not run AASES session runtime: {error}"))?;
+    let response: ManagedSessionResponse = serde_json::from_slice(&output.stdout).map_err(|error| {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        format!("invalid AASES session response: {error}; stderr: {}", stderr.trim())
+    })?;
+    if response.schema_version != "1" {
+        return Err(format!(
+            "unsupported AASES session schema: {}",
+            response.schema_version
+        ));
+    }
+    Ok(response)
+}
+
+#[tauri::command]
+pub fn managed_session_start(
+    project: String,
+    team: String,
+    director_argv: Vec<String>,
+) -> Result<ManagedSessionResponse, String> {
+    if team.trim().is_empty() || director_argv.is_empty() {
+        return Err("managed session start requires a team and director argv".into());
+    }
+    let mut args = vec!["start".into(), team, "--".into()];
+    args.extend(director_argv);
+    run_runtime(project, args)
+}
+
+#[tauri::command]
+pub fn managed_session_status(project: String) -> Result<ManagedSessionResponse, String> {
+    run_runtime(project, vec!["status".into()])
+}
+
+#[tauri::command]
+pub fn managed_session_turn(
+    project: String,
+    signal: String,
+    generation: u64,
+) -> Result<ManagedSessionResponse, String> {
+    if signal != "active" && signal != "idle" {
+        return Err("managed session turn signal must be active or idle".into());
+    }
+    run_runtime(
+        project,
+        vec!["turn".into(), signal, generation.to_string()],
+    )
+}
+
+#[tauri::command]
+pub fn managed_session_ack(
+    project: String,
+    generation: u64,
+) -> Result<ManagedSessionResponse, String> {
+    run_runtime(project, vec!["ack".into(), generation.to_string()])
+}
+
+#[tauri::command]
+pub fn managed_session_end(project: String) -> Result<ManagedSessionResponse, String> {
+    run_runtime(project, vec!["end".into()])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_known_deny_as_a_typed_response() {
+        let response: ManagedSessionResponse = serde_json::from_str(
+            r#"{
+                "schema_version":"1",
+                "state":"ACTIVE",
+                "result":"DENY",
+                "reason_code":"ACTIVE_TURN",
+                "session_id":"aases-session-123",
+                "inventory":{
+                    "registration":"PRESENT",
+                    "process":"PRESENT",
+                    "pane":"PRESENT",
+                    "worktree":{"status":"PRESENT","dirty":false},
+                    "generation":1,
+                    "active_turn":true,
+                    "final_ack":"PENDING"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(response.result, SessionResult::Deny);
+        assert_eq!(response.reason_code.as_deref(), Some("ACTIVE_TURN"));
+        assert_eq!(response.inventory.unwrap().active_turn, Some(true));
+    }
+
+    #[test]
+    fn rejects_an_inventory_with_unrecognized_fields() {
+        let parsed = serde_json::from_str::<ManagedSessionResponse>(
+            r#"{
+                "schema_version":"1",
+                "state":"INACTIVE",
+                "result":"PASS",
+                "reason_code":null,
+                "session_id":"aases-session-123",
+                "inventory":{
+                    "registration":"ABSENT",
+                    "process":"ABSENT",
+                    "pane":"ABSENT",
+                    "worktree":{"status":"ABSENT","dirty":null},
+                    "generation":null,
+                    "active_turn":null,
+                    "final_ack":null,
+                    "unexpected":true
+                }
+            }"#,
+        );
+
+        assert!(parsed.is_err());
+    }
+}

--- a/app/src-tauri/src/pty.rs
+++ b/app/src-tauri/src/pty.rs
@@ -146,6 +146,7 @@ pub fn pty_spawn(
     id: String,
     cmd: String,
     args: Vec<String>,
+    detection_type: Option<String>,
     cwd: Option<String>,
     rows: Option<u16>,
     cols: Option<u16>,
@@ -205,10 +206,18 @@ pub fn pty_spawn(
     let mut reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
     let tail = Arc::new(Mutex::new(TailBuffer::default()));
-    let agent_type = std::path::Path::new(&cmd)
-        .file_stem()
-        .and_then(|name| name.to_str())
-        .unwrap_or(&cmd)
+    // A managed pane runs `tmux attach`, but its visible output belongs to the
+    // registered director type. Direct panes omit this override and preserve
+    // the original command-derived classifier identity.
+    let agent_type = detection_type
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| {
+            std::path::Path::new(&cmd)
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .unwrap_or(&cmd)
+                .to_string()
+        })
         .to_ascii_lowercase();
     let detection = Arc::new(Mutex::new(DetectionTracker::new(agent_type)));
 

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -685,6 +685,82 @@ body.resizing-row {
 .team-status-dot.status-idle { background: var(--green); }
 .team-status-dot.status-unknown { background: var(--green); }
 .team-status-dot.status-empty { background: var(--muted); }
+.managed-session-control {
+  padding: 8px;
+  border-bottom: 1px solid var(--border);
+  font-size: 10px;
+}
+.managed-session-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  color: var(--fg);
+  font-size: 11px;
+  font-weight: 600;
+}
+.managed-session-state {
+  color: var(--muted);
+  font-size: 9px;
+}
+.managed-session-state.state-active { color: var(--green); }
+.managed-session-state.state-draining { color: #e0af68; }
+.managed-session-project {
+  margin: 5px 0;
+  overflow: hidden;
+  color: var(--muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.managed-session-inventory {
+  display: grid;
+  gap: 2px;
+  margin: 0 0 6px;
+}
+.managed-session-inventory > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 6px;
+}
+.managed-session-inventory dt { color: var(--muted); }
+.managed-session-inventory dd {
+  margin: 0;
+  overflow: hidden;
+  color: var(--fg);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.managed-session-error {
+  max-height: 38px;
+  margin-bottom: 6px;
+  overflow: auto;
+  color: #f7768e;
+  overflow-wrap: anywhere;
+}
+.managed-session-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px;
+}
+.managed-session-actions button {
+  min-width: 0;
+  padding: 4px 3px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--panel-2);
+  color: var(--fg);
+  cursor: pointer;
+  font: inherit;
+}
+.managed-session-actions button:hover:not(:disabled) { border-color: var(--accent); }
+.managed-session-actions button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.managed-session-actions .managed-session-end {
+  grid-column: 1 / -1;
+  color: #f7768e;
+}
 .collapsed-team-status {
   width: 28px;
   padding: 2px;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -15,6 +15,14 @@ import {
 } from "lucide-react";
 import { TerminalPane } from "./TerminalPane";
 import { aggregateTeamStatus, applyStateChange, type PaneStatusMap, type RawState } from "./agentStatus";
+import {
+  canFinalAck,
+  directorArgv,
+  exactDirector,
+  inventoryRows,
+  observedTurnSignal,
+  type ManagedSessionResponse,
+} from "./managedSession";
 import { AUTO_TIMEZONE, formatMessageTime, isValidTimeZone, resolveTimeZone } from "./time";
 import {
   AgentModal,
@@ -72,6 +80,12 @@ export type Pane = {
    *  False for actas-booted types with no monitor of their own (codex,
    *  grok-build, hermes, ...): the app's stdin-inject IS their only delivery. */
   native: boolean;
+  /** This PTY is only a tmux attach client. Closing it detaches from the
+   * managed director session; lifecycle cleanup stays behind the explicit
+   * managed-session End action. */
+  managedSessionId?: string;
+  managedProject?: string;
+  detectionType?: string;
   /** A free login shell (the "+" tab, or a tab's "Open shell" context menu
    *  item) — unattached to any agent. Drives the sidebar-click "spawn beside
    *  the shell instead of a new tab" behavior below: it has to be an
@@ -242,6 +256,7 @@ export default function App() {
   const [teams, setTeams] = useState<string[]>([]);
   const [team, setTeam] = useState<string>("");
   const [members, setMembers] = useState<Member[]>([]);
+  const [membersTeam, setMembersTeam] = useState<string>("");
   const [messages, setMessages] = useState<Message[]>([]);
   const [panes, setPanes] = useState<Pane[]>([]);
   const [paneStatus, setPaneStatus] = useState<PaneStatusMap>({});
@@ -261,6 +276,10 @@ export default function App() {
   const [newMenu, setNewMenu] = useState(false);
   const [cmdName, setCmdName] = useState("agmsg");
   const [spawnTypes, setSpawnTypes] = useState<AgentType[]>([]);
+  const [managedSession, setManagedSession] = useState<ManagedSessionResponse | null>(null);
+  const [managedSessionError, setManagedSessionError] = useState<string | null>(null);
+  const [managedSessionBusy, setManagedSessionBusy] = useState(false);
+  const [managedTurnSyncTick, setManagedTurnSyncTick] = useState(0);
   const [sidebarWidth, setSidebarWidth] = useState(200);
   const [chatHeight, setChatHeight] = useState(160);
   // Terminal font size, adjustable from the Settings modal and persisted
@@ -449,6 +468,8 @@ export default function App() {
   // or close the target tab (co1, PR #431).
   const teamRef = useRef<string>("");
   teamRef.current = team;
+  const managedTurnInFlightRef = useRef(false);
+  const lastManagedTurnAttemptRef = useRef<string>("");
   const applyAgentState = useCallback((paneId: string, state: RawState) => {
     setPaneStatus((current) => applyStateChange(current, paneId, state));
   }, []);
@@ -480,6 +501,7 @@ export default function App() {
   const teamProject = appUserMember?.project ?? "";
   // Everyone else is a spawnable/messageable agent.
   const others = members.filter((m) => !m.types.includes(APP_USER_TYPE));
+  const managedDirector = membersTeam === team ? exactDirector(members) : null;
   // The app user's own send/receive thread.
   const myThread = messages.filter((m) => m.from === appUser || m.to === appUser);
 
@@ -521,6 +543,7 @@ export default function App() {
   const loadMembers = useCallback(async (t: string) => {
     const m = await invoke<Member[]>("agmsg_members", { team: t });
     setMembers(m);
+    setMembersTeam(t);
     return m;
   }, []);
 
@@ -933,9 +956,11 @@ export default function App() {
       // (TerminalPane's own pty-exit listener writes that inline) — its own
       // exit/Ctrl-D is a deliberate "done here" (koit), so the pane (and its
       // tab, if it was the last one) just goes away instead of sitting on a
-      // dead prompt. Agent panes are untouched — this only fires for panes
-      // flagged `shell`.
-      if (panesRef.current.find((pane) => pane.id === e.payload.id)?.shell) {
+      // dead prompt. A managed pane is likewise only an attach client, so an
+      // exited client disappears without ending its tmux session. Direct
+      // agent panes are untouched.
+      const exitedPane = panesRef.current.find((pane) => pane.id === e.payload.id);
+      if (exitedPane?.shell || exitedPane?.managedSessionId) {
         closeWindowPane(e.payload.id);
       }
     });
@@ -952,6 +977,221 @@ export default function App() {
     setWindows((prev) => prev.filter((x) => x.id !== windowId));
     setActive((a) => (a === windowId ? "room" : a));
   }, []);
+
+  const refreshManagedStatus = useCallback(async (project: string, expectedTeam: string) => {
+    const response = await invoke<ManagedSessionResponse>("managed_session_status", { project });
+    if (teamRef.current === expectedTeam) setManagedSession(response);
+    return response;
+  }, []);
+
+  const attachManagedSession = useCallback(
+    async (response: ManagedSessionResponse, director: Member) => {
+      if (response.state !== "ACTIVE" || !response.session_id) return;
+      const existing = panesRef.current.find((pane) => pane.managedSessionId === response.session_id);
+      if (existing) {
+        const owner = windowsRef.current.find((window) => leaves(window.root).includes(existing.id));
+        if (owner) setActive(owner.id);
+        return;
+      }
+
+      const requestedTeam = team;
+      const types = await invoke<AgentType[]>("agmsg_spawnable_types").catch(() => spawnTypes);
+      setSpawnTypes(types);
+      const type = director.types.find((name) => types.some((candidate) => candidate.name === name));
+      let monitors = false;
+      if (type) {
+        try {
+          const mode = await invoke<string>("agmsg_delivery_mode", {
+            agentType: type,
+            project: director.project,
+          });
+          monitors = mode === "monitor" || mode === "both";
+        } catch (error) {
+          console.error(error);
+        }
+      }
+      if (teamRef.current !== requestedTeam) return;
+
+      const paneId = `managed-director-${seq.current++}`;
+      const windowId = `w-${seq.current++}`;
+      const pane: Pane = {
+        id: paneId,
+        label: director.name,
+        cmd: "tmux",
+        args: ["attach-session", "-t", `=${response.session_id}`],
+        cwd: director.project,
+        native: monitors,
+        managedSessionId: response.session_id,
+        managedProject: director.project,
+        detectionType: type,
+      };
+      setPanes((current) => [...current, pane]);
+      setWindows((current) => [
+        ...current,
+        { id: windowId, root: { kind: "leaf", paneId }, team: requestedTeam },
+      ]);
+      setActive(windowId);
+    },
+    [spawnTypes, team],
+  );
+
+  const startManagedSession = useCallback(async () => {
+    if (!managedDirector) {
+      setManagedSessionError(t("managedSession.error.noDirector"));
+      return;
+    }
+    const requestedTeam = team;
+    setManagedSessionBusy(true);
+    setManagedSessionError(null);
+    try {
+      const types = await invoke<AgentType[]>("agmsg_spawnable_types");
+      setSpawnTypes(types);
+      const argv = directorArgv(managedDirector, types, cmdName);
+      if (!argv) {
+        setManagedSessionError(t("managedSession.error.notSpawnable"));
+        return;
+      }
+      const response = await invoke<ManagedSessionResponse>("managed_session_start", {
+        project: managedDirector.project,
+        team: requestedTeam,
+        directorArgv: argv,
+      });
+      if (teamRef.current !== requestedTeam) return;
+      setManagedSession(response);
+      if (response.result === "DENY") {
+        setManagedSessionError(response.reason_code ?? "DENY");
+        return;
+      }
+      await attachManagedSession(response, managedDirector);
+    } catch (error) {
+      if (teamRef.current === requestedTeam) setManagedSessionError(String(error));
+    } finally {
+      setManagedSessionBusy(false);
+    }
+  }, [attachManagedSession, cmdName, managedDirector, t, team]);
+
+  const detachManagedSession = useCallback(() => {
+    if (!managedSession?.session_id) return;
+    const pane = panesRef.current.find((candidate) => candidate.managedSessionId === managedSession.session_id);
+    if (pane) closeWindowPane(pane.id);
+  }, [closeWindowPane, managedSession]);
+
+  const reconnectManagedSession = useCallback(async () => {
+    if (!managedDirector || !managedSession || managedSession.state !== "ACTIVE") return;
+    setManagedSessionError(null);
+    try {
+      await attachManagedSession(managedSession, managedDirector);
+    } catch (error) {
+      setManagedSessionError(String(error));
+    }
+  }, [attachManagedSession, managedDirector, managedSession]);
+
+  const acknowledgeManagedSession = useCallback(async () => {
+    const generation = managedSession?.inventory?.generation;
+    if (!managedDirector || generation == null || !canFinalAck(managedSession)) return;
+    const requestedTeam = team;
+    setManagedSessionBusy(true);
+    setManagedSessionError(null);
+    try {
+      const response = await invoke<ManagedSessionResponse>("managed_session_ack", {
+        project: managedDirector.project,
+        generation,
+      });
+      if (teamRef.current !== requestedTeam) return;
+      if (response.result === "DENY") setManagedSessionError(response.reason_code ?? "DENY");
+      await refreshManagedStatus(managedDirector.project, requestedTeam);
+    } catch (error) {
+      if (teamRef.current === requestedTeam) setManagedSessionError(String(error));
+    } finally {
+      setManagedSessionBusy(false);
+    }
+  }, [managedDirector, managedSession, refreshManagedStatus, team]);
+
+  const endManagedSession = useCallback(async () => {
+    if (!managedDirector || !managedSession || managedSession.state === "INACTIVE") return;
+    const requestedTeam = team;
+    const sessionId = managedSession.session_id;
+    setManagedSessionBusy(true);
+    setManagedSessionError(null);
+    try {
+      const response = await invoke<ManagedSessionResponse>("managed_session_end", {
+        project: managedDirector.project,
+      });
+      if (teamRef.current !== requestedTeam) return;
+      setManagedSession(response);
+      if (response.result === "DENY") {
+        setManagedSessionError(response.reason_code ?? "DENY");
+      } else if (response.state === "INACTIVE") {
+        const pane = panesRef.current.find((candidate) => candidate.managedSessionId === sessionId);
+        if (pane) closeWindowPane(pane.id);
+      }
+    } catch (error) {
+      if (teamRef.current === requestedTeam) setManagedSessionError(String(error));
+    } finally {
+      setManagedSessionBusy(false);
+    }
+  }, [closeWindowPane, managedDirector, managedSession, team]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setManagedSession(null);
+    setManagedSessionError(null);
+    lastManagedTurnAttemptRef.current = "";
+    if (!team || membersTeam !== team) return;
+    if (!managedDirector) {
+      setManagedSessionError(t("managedSession.error.noDirector"));
+      return;
+    }
+    invoke<ManagedSessionResponse>("managed_session_status", { project: managedDirector.project })
+      .then((response) => {
+        if (cancelled) return;
+        setManagedSession(response);
+        if (response.result === "DENY") setManagedSessionError(response.reason_code ?? "DENY");
+      })
+      .catch((error) => {
+        if (!cancelled) setManagedSessionError(String(error));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [managedDirector, membersTeam, t, team]);
+
+  useEffect(() => {
+    const inventory = managedSession?.inventory;
+    const generation = inventory?.generation;
+    if (!managedDirector || managedSession?.state !== "ACTIVE" || !inventory || generation == null) return;
+    const pane = panes.find((candidate) => candidate.managedSessionId === managedSession.session_id);
+    if (!pane) return;
+    const paneState = paneStatus[pane.id]?.state;
+    if (!paneState) return;
+    const signal = observedTurnSignal(paneState);
+    if (!signal) return;
+    const nextActive = signal === "active";
+    if (inventory.active_turn === nextActive) return;
+    const attemptKey = `${managedSession.session_id}:${generation}:${signal}:${paneState}`;
+    if (managedTurnInFlightRef.current || lastManagedTurnAttemptRef.current === attemptKey) return;
+    managedTurnInFlightRef.current = true;
+    lastManagedTurnAttemptRef.current = attemptKey;
+    invoke<ManagedSessionResponse>("managed_session_turn", {
+      project: managedDirector.project,
+      signal,
+      generation,
+    })
+      .then((response) => {
+        if (teamRef.current === team) {
+          if (response.result === "DENY") setManagedSessionError(response.reason_code ?? "DENY");
+          else setManagedSessionError(null);
+        }
+        return refreshManagedStatus(managedDirector.project, team);
+      })
+      .catch((error) => {
+        if (teamRef.current === team) setManagedSessionError(String(error));
+      })
+      .finally(() => {
+        managedTurnInFlightRef.current = false;
+        setManagedTurnSyncTick((tick) => tick + 1);
+      });
+  }, [managedDirector, managedSession, managedTurnSyncTick, paneStatus, panes, refreshManagedStatus, team]);
 
   // Move a pane into another tab, adding it to that tab's side-by-side split
   // (uncapped — N panes in a tab render as N equal columns, see
@@ -1155,6 +1395,10 @@ export default function App() {
       }),
     );
   }, [teams, windows, paneStatus]);
+  const attachedManagedPane = managedSession?.session_id
+    ? panes.find((pane) => pane.managedSessionId === managedSession.session_id)
+    : undefined;
+  const managedInventoryRows = inventoryRows(managedSession);
 
   // If Show Team Room gets switched off while it's the active tab, land on
   // whichever pane tab exists instead — the room tab itself is about to
@@ -1665,6 +1909,60 @@ export default function App() {
                   );
                 })}
               </div>
+              <section className="managed-session-control" aria-label={t("managedSession.title")}>
+                <div className="managed-session-heading">
+                  <span>{t("managedSession.title")}</span>
+                  <span className={`managed-session-state state-${managedSession?.state.toLowerCase() ?? "unknown"}`}>
+                    {managedSession?.state ?? "UNKNOWN"}
+                  </span>
+                </div>
+                <div className="managed-session-project" title={managedDirector?.project}>
+                  {managedDirector?.project ?? t("managedSession.noProject")}
+                </div>
+                <dl className="managed-session-inventory">
+                  {managedInventoryRows.map((row) => (
+                    <div key={row.key}>
+                      <dt>{t(`managedSession.inventory.${row.key}`)}</dt>
+                      <dd>{row.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+                {managedSessionError && <div className="managed-session-error">{managedSessionError}</div>}
+                <div className="managed-session-actions">
+                  <button
+                    onClick={() => void startManagedSession()}
+                    disabled={
+                      !managedDirector ||
+                      managedSessionBusy ||
+                      (managedSession != null && managedSession.state !== "INACTIVE")
+                    }
+                  >
+                    {t("managedSession.action.start")}
+                  </button>
+                  <button onClick={detachManagedSession} disabled={!attachedManagedPane}>
+                    {t("managedSession.action.detach")}
+                  </button>
+                  <button
+                    onClick={() => void reconnectManagedSession()}
+                    disabled={managedSessionBusy || managedSession?.state !== "ACTIVE" || Boolean(attachedManagedPane)}
+                  >
+                    {t("managedSession.action.reconnect")}
+                  </button>
+                  <button
+                    onClick={() => void acknowledgeManagedSession()}
+                    disabled={managedSessionBusy || !canFinalAck(managedSession)}
+                  >
+                    {t("managedSession.action.ack")}
+                  </button>
+                  <button
+                    className="managed-session-end"
+                    onClick={() => void endManagedSession()}
+                    disabled={managedSessionBusy || !managedSession || managedSession.state === "INACTIVE"}
+                  >
+                    {t("managedSession.action.end")}
+                  </button>
+                </div>
+              </section>
               <div className="sidebar-title">
                 <span className="sidebar-title-label">
                   {t("sidebar.title")}
@@ -2099,6 +2397,7 @@ export default function App() {
                     id={p.id}
                     cmd={p.cmd}
                     args={p.args}
+                    detectionType={p.detectionType}
                     cwd={p.cwd}
                     fontSize={terminalFontSize}
                     active={isActiveWindow}
@@ -2318,15 +2617,29 @@ export default function App() {
         (() => {
           const win = windows.find((w) => w.id === modal.windowId);
           if (!win) return null;
-          const names = leaves(win.root)
-            .map((pid) => panes.find((p) => p.id === pid)?.label)
-            .filter((n): n is string => Boolean(n));
+          const windowPanes = leaves(win.root)
+            .map((pid) => panes.find((p) => p.id === pid))
+            .filter((pane): pane is Pane => Boolean(pane));
+          const hasManaged = windowPanes.some((pane) => Boolean(pane.managedSessionId));
+          const directNames = windowPanes.filter((pane) => !pane.managedSessionId).map((pane) => pane.label);
+          const names = windowPanes.map((pane) => pane.label);
           return (
             <ConfirmModal
-              title={t("modal.closeWindow.title")}
-              body={t("modal.closeWindow.body", { names: names.join(", ") })}
-              confirmLabel={t("modal.closeWindow.confirmLabel")}
-              danger
+              title={hasManaged ? t("managedSession.modal.detachTab.title") : t("modal.closeWindow.title")}
+              body={
+                hasManaged
+                  ? t(
+                      directNames.length > 0
+                        ? "managedSession.modal.detachTab.mixedBody"
+                        : "managedSession.modal.detachTab.body",
+                      { names: directNames.join(", ") },
+                    )
+                  : t("modal.closeWindow.body", { names: names.join(", ") })
+              }
+              confirmLabel={
+                hasManaged ? t("managedSession.modal.detachTab.confirm") : t("modal.closeWindow.confirmLabel")
+              }
+              danger={directNames.length > 0 || !hasManaged}
               onConfirm={() => closeWindow(modal.windowId)}
               onClose={() => setModal(null)}
             />
@@ -2338,10 +2651,22 @@ export default function App() {
           if (!pane) return null;
           return (
             <ConfirmModal
-              title={t("modal.closePane.title", { name: pane.label })}
-              body={t("modal.closePane.body", { name: pane.label })}
-              confirmLabel={t("modal.closePane.confirmLabel")}
-              danger
+              title={
+                pane.managedSessionId
+                  ? t("managedSession.modal.detachPane.title")
+                  : t("modal.closePane.title", { name: pane.label })
+              }
+              body={
+                pane.managedSessionId
+                  ? t("managedSession.modal.detachPane.body")
+                  : t("modal.closePane.body", { name: pane.label })
+              }
+              confirmLabel={
+                pane.managedSessionId
+                  ? t("managedSession.modal.detachPane.confirm")
+                  : t("modal.closePane.confirmLabel")
+              }
+              danger={!pane.managedSessionId}
               onConfirm={() => closeWindowPane(modal.paneId)}
               onClose={() => setModal(null)}
             />

--- a/app/src/TerminalPane.tsx
+++ b/app/src/TerminalPane.tsx
@@ -14,6 +14,10 @@ type Props = {
   id: string;
   cmd: string;
   args?: string[];
+  /** Optional classifier identity when the PTY command is only a transport
+   * (the managed tmux attach client). Direct panes leave this unset and keep
+   * deriving detection from cmd in Rust. */
+  detectionType?: string;
   cwd?: string;
   fontSize?: number;
   /** Whether this pane is the currently visible one. Every pane across
@@ -38,7 +42,17 @@ function b64ToBytes(b64: string): Uint8Array {
  * One embedded agent terminal: an xterm.js view bound to a backend PTY session.
  * Output streams in via `pty-output` events; keystrokes go back via `pty_write`.
  */
-export function TerminalPane({ id, cmd, args = [], cwd, fontSize = 12, active, onAgentState, onCellSize }: Props) {
+export function TerminalPane({
+  id,
+  cmd,
+  args = [],
+  detectionType,
+  cwd,
+  fontSize = 12,
+  active,
+  onAgentState,
+  onCellSize,
+}: Props) {
   const ref = useRef<HTMLDivElement>(null);
   // Live handles to the current terminal/fit addon, for the font-size effect
   // below to reach — that effect must NOT be a dependency of the main effect
@@ -151,7 +165,7 @@ export function TerminalPane({ id, cmd, args = [], cwd, fontSize = 12, active, o
       term.onData((data) => void invoke("pty_write", { id, data }));
       fitNow(); // size the PTY to the pane if it's already laid out
       try {
-        await invoke("pty_spawn", { id, cmd, args, cwd, rows: term.rows, cols: term.cols });
+        await invoke("pty_spawn", { id, cmd, args, detectionType, cwd, rows: term.rows, cols: term.cols });
       } catch (err) {
         // A failed spawn (missing CLI on PATH, bad cwd, ...) would otherwise
         // leave this pane blank forever with zero indication anything went
@@ -192,7 +206,7 @@ export function TerminalPane({ id, cmd, args = [], cwd, fontSize = 12, active, o
       termRef.current = null;
       fitRef.current = null;
     };
-  }, [id, cmd, cwd, onAgentState, onCellSize]);
+  }, [id, cmd, detectionType, cwd, onAgentState, onCellSize]);
 
   // Apply a fontSize change live, without recreating the terminal (which
   // would kill and respawn the PTY). Skips its very first run — at that

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -59,6 +59,43 @@
       "title": "app-user in {{team}}"
     }
   },
+  "managedSession": {
+    "title": "Managed session",
+    "noProject": "No exact director registration",
+    "inventory": {
+      "registration": "registration",
+      "process": "process",
+      "pane": "pane",
+      "worktree": "worktree",
+      "generation": "generation",
+      "active_turn": "active turn",
+      "final_ack": "final ACK"
+    },
+    "action": {
+      "start": "Start session",
+      "detach": "Detach",
+      "reconnect": "Reconnect",
+      "ack": "Final ACK",
+      "end": "End session"
+    },
+    "error": {
+      "noDirector": "Register an exact \"director\" with a project in this team first.",
+      "notSpawnable": "The director's registered type has no spawnable CLI."
+    },
+    "modal": {
+      "detachPane": {
+        "title": "Detach from the managed session?",
+        "body": "This closes only the tmux attach client. The director and managed session keep running.",
+        "confirm": "Detach"
+      },
+      "detachTab": {
+        "title": "Close this tab?",
+        "body": "The tmux attach client will close, but the director and managed session keep running.",
+        "mixedBody": "The managed session stays running, but these direct agents will stop: {{names}}.",
+        "confirm": "Close tab"
+      }
+    }
+  },
   "tabs": {
     "roomLabel": "# team room",
     "close": "×",

--- a/app/src/i18n/locales/ja.json
+++ b/app/src/i18n/locales/ja.json
@@ -49,6 +49,43 @@
       "title": "{{team}} のapp-user"
     }
   },
+  "managedSession": {
+    "title": "Managed session",
+    "noProject": "exact director登録がありません",
+    "inventory": {
+      "registration": "registration",
+      "process": "process",
+      "pane": "pane",
+      "worktree": "worktree",
+      "generation": "generation",
+      "active_turn": "active turn",
+      "final_ack": "final ACK"
+    },
+    "action": {
+      "start": "Start session",
+      "detach": "Detach",
+      "reconnect": "Reconnect",
+      "ack": "Final ACK",
+      "end": "End session"
+    },
+    "error": {
+      "noDirector": "このチームにproject付きのexact name \"director\" を登録してください。",
+      "notSpawnable": "directorの登録typeには起動可能なCLIがありません。"
+    },
+    "modal": {
+      "detachPane": {
+        "title": "managed sessionからdetachしますか？",
+        "body": "tmux attach clientだけを閉じます。directorとmanaged sessionは継続します。",
+        "confirm": "Detach"
+      },
+      "detachTab": {
+        "title": "このタブを閉じますか？",
+        "body": "tmux attach clientだけを閉じ、directorとmanaged sessionは継続します。",
+        "mixedBody": "managed sessionは継続しますが、次のdirect agentは停止します: {{names}}。",
+        "confirm": "タブを閉じる"
+      }
+    }
+  },
   "tabs": {
     "roomLabel": "# チームルーム",
     "close": "×",

--- a/app/src/managedSession.test.ts
+++ b/app/src/managedSession.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  canFinalAck,
+  directorArgv,
+  exactDirector,
+  inventoryRows,
+  observedTurnSignal,
+  type ManagedSessionResponse,
+} from "./managedSession";
+
+const activeResponse = (activeTurn: boolean | null): ManagedSessionResponse => ({
+  schema_version: "1",
+  state: "ACTIVE",
+  result: "PASS",
+  reason_code: null,
+  session_id: "aases-session-123",
+  inventory: {
+    registration: "PRESENT",
+    process: "PRESENT",
+    pane: "PRESENT",
+    worktree: { status: "PRESENT", dirty: false },
+    generation: 4,
+    active_turn: activeTurn,
+    final_ack: "PENDING",
+  },
+});
+
+describe("managed session activation", () => {
+  it("selects only an exact registered director with a project", () => {
+    expect(
+      exactDirector([
+        { name: "Director", types: ["codex"], project: "/tmp/a" },
+        { name: "director", types: ["codex"], project: "" },
+      ]),
+    ).toBeNull();
+    expect(exactDirector([{ name: "director", types: ["codex"], project: "/tmp/a" }])?.project).toBe("/tmp/a");
+  });
+
+  it("builds the director command as argv without a shell string", () => {
+    expect(
+      directorArgv(
+        { name: "director", types: ["codex"], project: "/tmp/a" },
+        [{ name: "codex", cli: "codex", options: ["--full-auto"] }],
+        "agmsg",
+      ),
+    ).toEqual(["codex", "--full-auto", "/agmsg actas director"]);
+  });
+});
+
+describe("managed session safety state", () => {
+  it("maps only working and idle observations to turn signals", () => {
+    expect(observedTurnSignal("working")).toBe("active");
+    expect(observedTurnSignal("idle")).toBe("idle");
+    expect(observedTurnSignal("blocked")).toBeNull();
+    expect(observedTurnSignal("unknown")).toBeNull();
+  });
+
+  it("permits a final ACK only for a current generation observed idle", () => {
+    expect(canFinalAck(activeResponse(false))).toBe(true);
+    expect(canFinalAck(activeResponse(true))).toBe(false);
+    expect(canFinalAck(activeResponse(null))).toBe(false);
+  });
+
+  it("keeps all seven inventory concepts distinct", () => {
+    expect(inventoryRows(activeResponse(false)).map((row) => row.key)).toEqual([
+      "registration",
+      "process",
+      "pane",
+      "worktree",
+      "generation",
+      "active_turn",
+      "final_ack",
+    ]);
+  });
+});

--- a/app/src/managedSession.ts
+++ b/app/src/managedSession.ts
@@ -1,0 +1,93 @@
+import type { RawState } from "./agentStatus";
+
+export type Presence = "PRESENT" | "ABSENT" | "UNKNOWN";
+export type ManagedSessionState = "ACTIVE" | "DRAINING" | "INACTIVE";
+export type ManagedSessionResult = "PASS" | "DENY";
+export type FinalAck = "ACKNOWLEDGED" | "PENDING";
+
+export type ManagedSessionInventory = {
+  registration: Presence;
+  process: Presence;
+  pane: Presence;
+  worktree: { status: Presence; dirty: boolean | null };
+  generation: number | null;
+  active_turn: boolean | null;
+  final_ack: FinalAck | null;
+};
+
+export type ManagedSessionResponse = {
+  schema_version: "1";
+  state: ManagedSessionState;
+  result: ManagedSessionResult;
+  reason_code: string | null;
+  session_id: string;
+  inventory: ManagedSessionInventory | null;
+};
+
+export type ManagedDirector = {
+  name: string;
+  types: string[];
+  project: string;
+};
+
+export type SpawnableType = {
+  name: string;
+  cli: string;
+  options: string[];
+};
+
+export type InventoryRow = {
+  key: keyof ManagedSessionInventory;
+  value: string;
+};
+
+export function exactDirector(members: ManagedDirector[]): ManagedDirector | null {
+  return members.find((member) => member.name === "director" && member.project.trim() !== "") ?? null;
+}
+
+export function directorArgv(
+  director: ManagedDirector,
+  spawnableTypes: SpawnableType[],
+  commandName: string,
+): string[] | null {
+  const type = director.types.find((name) => spawnableTypes.some((candidate) => candidate.name === name));
+  const spawnable = type ? spawnableTypes.find((candidate) => candidate.name === type) : undefined;
+  if (!spawnable?.cli) return null;
+  return [spawnable.cli, ...spawnable.options, `/${commandName} actas director`];
+}
+
+export function observedTurnSignal(state: RawState): "active" | "idle" | null {
+  if (state === "working") return "active";
+  if (state === "idle") return "idle";
+  return null;
+}
+
+export function canFinalAck(response: ManagedSessionResponse | null): boolean {
+  return Boolean(
+    response?.state === "ACTIVE" &&
+      response.inventory?.generation != null &&
+      response.inventory.active_turn === false,
+  );
+}
+
+export function inventoryRows(response: ManagedSessionResponse | null): InventoryRow[] {
+  const inventory = response?.inventory;
+  const unavailable = "UNKNOWN";
+  return [
+    { key: "registration", value: inventory?.registration ?? unavailable },
+    { key: "process", value: inventory?.process ?? unavailable },
+    { key: "pane", value: inventory?.pane ?? unavailable },
+    {
+      key: "worktree",
+      value: inventory
+        ? `${inventory.worktree.status} / ${inventory.worktree.dirty == null ? "UNKNOWN" : inventory.worktree.dirty ? "DIRTY" : "CLEAN"}`
+        : unavailable,
+    },
+    { key: "generation", value: inventory?.generation == null ? unavailable : String(inventory.generation) },
+    {
+      key: "active_turn",
+      value: inventory?.active_turn == null ? unavailable : inventory.active_turn ? "ACTIVE" : "IDLE",
+    },
+    { key: "final_ack", value: inventory?.final_ack ?? unavailable },
+  ];
+}


### PR DESCRIPTION
Closes #453

## Outcome

Adds the minimal opt-in agmsg app lifecycle for one project-owned managed tmux session:

- explicit Start session for the selected team's exact `director`
- seven-field inventory for registration/process/pane/worktree/generation/active turn/final ACK
- Detach, app close, and Reconnect without ending the director
- runtime-enforced refusal for active turn, pending ACK, dirty worktree, and UNKNOWN
- graceful End only after clean + idle + final ACK

## Scope

The app calls the external Issue #22 runtime only when both `AASES_SESSION_BIN` and `AASES_SESSION_RUNTIME_ROOT` are explicitly configured. It does not vendor the runtime or add distribution, generic shell execution, browser/crawler, incident, or rollout infrastructure.

Managed panes are tmux attach clients. Existing direct-agent pane behavior remains unchanged. A narrow PTY detection-type override lets the existing state detector classify the director behind `tmux` without changing the launched command.

## Evidence

Final candidate `572498737b7cd015c9fa49629a4c85d55a74d1c3`:

- managed-session TypeScript test: 5 passed
- frontend TypeScript/Vite build: passed
- `cargo test managed_session`: 2 passed, 59 filtered out
- `git diff --check`: passed
- real macOS app canary with one Codex director: passed
  - explicit start and all seven inventory fields
  - active-turn End denied with `ACTIVE_TURN`
  - idle/unacknowledged End denied with `ACK_PENDING`
  - dirty End denied with `DIRTY`
  - pane detach and app close preserved the tmux session
  - app restart found ACTIVE state and reconnected without respawn
  - final ACK followed by graceful End returned INACTIVE and removed the exact tmux session

Review was limited to one change-diff review, one mandatory correction, and one focused confirmation.

## Deferred

Runtime distribution/installer, release packaging, all-project rollout, browser/crawler, generic Git/shell control, incident framework, and broad conformance suites remain out of scope.
