### PR TITLE
perf(windows): Node hot paths for the check-inbox hook and CLI entries (implements #449)

### DIFF
--- a/scripts/agmsg-fast.js
+++ b/scripts/agmsg-fast.js
@@ -1,0 +1,295 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { resolveIdentities } = require("./lib/identity-resolver" );
+
+function loadSqlite() {
+  try {
+    return require("node:sqlite");
+  } catch (error) {
+    error.exitCode = 78;
+    throw error;
+  }
+}
+
+function storageDb(skillDir) {
+  const storage = process.env.AGMSG_STORAGE_PATH || path.join(skillDir, "db");
+  return path.join(storage, "messages.db");
+}
+
+function openDb(dbPath, { create = false } = {}) {
+  const { DatabaseSync } = loadSqlite();
+  if (!create && !fs.existsSync(dbPath)) return null;
+  if (create) fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec(`PRAGMA busy_timeout=${Number(process.env.AGMSG_BUSY_TIMEOUT || 5000)}`);
+  if (create) {
+    try {
+      db.exec("PRAGMA journal_mode=WAL");
+    } catch (_) {
+      // WAL is a best-effort optimization, matching init-db.sh.
+    }
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        team TEXT NOT NULL,
+        from_agent TEXT NOT NULL,
+        to_agent TEXT NOT NULL,
+        body TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+        read_at TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_unread
+        ON messages(team, to_agent, read_at) WHERE read_at IS NULL;
+      CREATE INDEX IF NOT EXISTS idx_history
+        ON messages(team, created_at DESC);
+    `);
+  }
+  return db;
+}
+
+function escapeBody(body) {
+  return body.replace(/\n/g, "\\n").replace(/\t/g, "\\t");
+}
+
+function assertTeamName(team) {
+  if (!team || team === "." || team === ".." || /[\\/\0]/.test(team)) {
+    throw Object.assign(new Error(`invalid team name: ${team}`), { exitCode: 1 });
+  }
+}
+
+function teamCommand({ skillDir, team }) {
+  assertTeamName(team);
+  const file = path.join(skillDir, "teams", team, "config.json");
+  if (!fs.existsSync(file)) {
+    return { exitCode: 1, stdout: `Team not found: ${team}\n` };
+  }
+  const config = JSON.parse(fs.readFileSync(file, "utf8"));
+  const lines = [`Team: ${team}`, ""];
+  let count = 0;
+  const agents = Object.entries(config.agents || {});
+  for (const [name, agent] of agents) {
+    const registrations = Array.isArray(agent.registrations)
+      ? agent.registrations
+      : [{ type: agent.type, project: agent.project }];
+    const types = [...new Set(registrations.map((item) => item.type).filter(Boolean))].join(",");
+    const latest = registrations.length ? registrations[registrations.length - 1] : null;
+    const project = (latest && latest.project) || "?";
+    const more = registrations.length > 1 ? ` (+${registrations.length - 1} more)` : "";
+    lines.push(`  ${name} (${types}) — ${project}${more}`);
+    count += 1;
+  }
+  lines.push("", `${count} member(s)`);
+  return { exitCode: 0, stdout: `${lines.join("\n")}\n` };
+}
+
+function registeredAgentNames(skillDir, team) {
+  const file = path.join(skillDir, "teams", team, "config.json");
+  if (!fs.existsSync(file)) return [];
+  const config = JSON.parse(fs.readFileSync(file, "utf8"));
+  return Object.keys(config.agents || {});
+}
+
+function sendCommand({ skillDir, dbPath, team, from, to, body, force = false }) {
+  assertTeamName(team);
+  if (!force) {
+    const roster = registeredAgentNames(skillDir, team);
+    for (const [role, name] of [["from", from], ["to", to]]) {
+      if (!roster.includes(name)) {
+        if (roster.length === 0) {
+          return {
+            exitCode: 1,
+            stdout: "",
+            stderr: `Error: team '${team}' has no registered agents — cannot send as ${role} '${name}' (use --force to bypass).\n`,
+          };
+        }
+        return {
+          exitCode: 1,
+          stdout: "",
+          stderr: `Error: ${role} agent '${name}' is not registered in team '${team}' (registered: ${roster.join(", ")}). Use --force to bypass.\n`,
+        };
+      }
+    }
+  }
+  const db = openDb(dbPath, { create: true });
+  try {
+    db.prepare(
+      "INSERT INTO messages (team, from_agent, to_agent, body) VALUES (?, ?, ?, ?)",
+    ).run(team, from, to, body);
+  } finally {
+    db.close();
+  }
+  return { exitCode: 0, stdout: `Sent to ${to} in team ${team}\n` };
+}
+
+function inboxCommand({ dbPath, team, agent, quiet = false, afterSelect }) {
+  assertTeamName(team);
+  const db = openDb(dbPath);
+  if (!db) {
+    return {
+      exitCode: 0,
+      stdout: quiet ? "" : "No messages (DB not initialized)\n",
+    };
+  }
+  try {
+    const rows = db
+      .prepare(
+        `SELECT id, from_agent AS "from", body, created_at
+           FROM messages
+          WHERE team=? AND to_agent=? AND read_at IS NULL
+          ORDER BY created_at ASC`,
+      )
+      .all(team, agent);
+    if (rows.length === 0) {
+      return { exitCode: 0, stdout: quiet ? "" : "No new messages.\n" };
+    }
+    if (afterSelect) afterSelect({ db, rows });
+    const lines = [`${rows.length} new message(s):`, ""];
+    for (const row of rows) {
+      lines.push(`  [${row.created_at}] ${row.from}: ${escapeBody(row.body)}`);
+    }
+    lines.push("");
+    let marking = false;
+    try {
+      db.exec("BEGIN IMMEDIATE");
+      marking = true;
+      const statement = db.prepare(
+        "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id=? AND read_at IS NULL",
+      );
+      for (const row of rows) statement.run(row.id);
+      db.exec("COMMIT");
+      marking = false;
+    } catch (_) {
+      // Match inbox.sh: displaying the selected rows succeeds even when the
+      // best-effort mark cannot be persisted in a sandbox or lock race.
+      if (marking) {
+        try { db.exec("ROLLBACK"); } catch (_) {}
+      }
+    }
+    return { exitCode: 0, stdout: `${lines.join("\n")}\n` };
+  } finally {
+    db.close();
+  }
+}
+
+function historyCommand({ dbPath, team, agent = "", limit = 20 }) {
+  assertTeamName(team);
+  const db = openDb(dbPath);
+  if (!db) return { exitCode: 0, stdout: "No messages (DB not initialized)\n" };
+  const safeLimit = /^\d+$/.test(String(limit)) ? Number(limit) : 20;
+  try {
+    const where = agent
+      ? "team=? AND (from_agent=? OR to_agent=?)"
+      : "team=?";
+    const values = agent ? [team, agent, agent, safeLimit] : [team, safeLimit];
+    const rows = db
+      .prepare(
+        `SELECT from_agent AS "from", to_agent AS "to", body, created_at, read_at
+           FROM messages WHERE ${where}
+          ORDER BY created_at DESC LIMIT ?`,
+      )
+      .all(...values)
+      .reverse();
+    if (rows.length === 0) return { exitCode: 0, stdout: "No message history.\n" };
+    const stdout = rows
+      .map((row) => {
+        const status = row.read_at === null ? "●" : "○";
+        return `  ${status} [${row.created_at}] ${row.from} → ${row.to}: ${escapeBody(row.body)}`;
+      })
+      .join("\n");
+    return { exitCode: 0, stdout: `${stdout}\n` };
+  } finally {
+    db.close();
+  }
+}
+
+function whoamiCommand({ skillDir, project, type }) {
+  if (!project || !type) {
+    return { exitCode: 64, stdout: "", stderr: "usage: agmsg-fast.js whoami <project> <type>\n" };
+  }
+  const result = resolveIdentities({ skillDir, project, type });
+  const available = result.availableTeams.length ? result.availableTeams.join(",") : "none";
+  if (result.status === "not_joined") {
+    return { exitCode: 0, stdout: `not_joined=true available_teams=${available}\n` };
+  }
+  const names = [...new Set(result.identities.map((identity) => identity.name))];
+  const teams = [...new Set(result.identities.map((identity) => identity.team))];
+  if (result.status === "suggest") {
+    return {
+      exitCode: 0,
+      stdout: `suggest=true agents=${names.join(",")} teams=${teams.join(",")} type=${type} project=${project} available_teams=${available}\n`,
+    };
+  }
+  const prefix = names.length === 1 ? `agent=${names[0]}` : `multiple=true agents=${names.join(",")}`;
+  return {
+    exitCode: 0,
+    stdout: `${prefix} teams=${teams.join(",")} type=${type} project=${project}\n`,
+  };
+}
+
+function run(argv, options = {}) {
+  const skillDir = options.skillDir || process.env.AGMSG_SKILL_DIR || path.resolve(__dirname, "..");
+  const dbPath = options.dbPath || storageDb(skillDir);
+  const [command, ...args] = argv;
+  switch (command) {
+    case "whoami":
+      return whoamiCommand({ skillDir, project: args[0], type: args[1] });
+    case "team":
+      return teamCommand({ skillDir, team: args[0] });
+    case "send":
+      if (args.length < 4 || args.slice(0, 4).some((value) => !value)) {
+        return {
+          exitCode: 64,
+          stdout: "",
+          stderr: "usage: agmsg-fast.js send <team> <from> <to> <message>\n",
+        };
+      }
+      return sendCommand({
+        skillDir,
+        dbPath,
+        team: args[0],
+        from: args[1],
+        to: args[2],
+        body: args[3],
+        force: args[4] === "--force",
+      });
+    case "inbox":
+      return inboxCommand({
+        dbPath,
+        team: args[0],
+        agent: args[1],
+        quiet: args[2] === "--quiet",
+      });
+    case "history":
+      return historyCommand({
+        dbPath,
+        team: args[0],
+        agent: args[1] || "",
+        limit: args[2] || 20,
+      });
+    default:
+      return { exitCode: 64, stdout: "", stderr: `unsupported fast command: ${command}\n` };
+  }
+}
+
+if (require.main === module) {
+  try {
+    const result = run(process.argv.slice(2));
+    process.stdout.write(result.stdout || "");
+    process.stderr.write(result.stderr || "");
+    process.exitCode = result.exitCode;
+  } catch (error) {
+    process.stderr.write(`agmsg-fast: ${error.message}\n`);
+    process.exitCode = error.exitCode || 1;
+  }
+}
+
+module.exports = {
+  historyCommand,
+  inboxCommand,
+  run,
+  sendCommand,
+  teamCommand,
+  whoamiCommand,
+};

--- a/scripts/check-inbox.js
+++ b/scripts/check-inbox.js
@@ -1,0 +1,287 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { resolveIdentities } = require("./lib/identity-resolver");
+
+const PREFLIGHT_UNAVAILABLE = 78;
+
+function loadSqlite() {
+  try {
+    return require("node:sqlite");
+  } catch (error) {
+    error.exitCode = PREFLIGHT_UNAVAILABLE;
+    throw error;
+  }
+}
+
+function stopOutputForType(skillDir, type) {
+  const file = path.join(skillDir, "scripts", "drivers", "types", type, "type.conf");
+  if (!fs.existsSync(file)) return "";
+  const match = /^stop_output=(.*)$/m.exec(fs.readFileSync(file, "utf8"));
+  return match ? match[1].trim() : "";
+}
+
+function parseInput(value) {
+  if (!value || !value.trim()) return {};
+  try {
+    return JSON.parse(value);
+  } catch (_) {
+    return {};
+  }
+}
+
+function emitStatus(stopOutput, systemMessage) {
+  return stopOutput === "json"
+    ? `${JSON.stringify({ continue: true, systemMessage }, null, 2)}\n`
+    : "";
+}
+
+function instancePid(token) {
+  const match = /\.(\d+)$/.exec(token || "");
+  return match ? Number(match[1]) : null;
+}
+
+function pidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function instanceAlive(skillDir, token, injectedPidAlive = pidAlive) {
+  const compositePid = instancePid(token);
+  if (compositePid !== null) return injectedPidAlive(compositePid);
+  const runDir = path.join(skillDir, "run");
+  if (!fs.existsSync(runDir)) return false;
+  for (const entry of fs.readdirSync(runDir)) {
+    if (!entry.startsWith("cc-instance.")) continue;
+    const pid = Number(entry.slice("cc-instance.".length));
+    if (!injectedPidAlive(pid)) continue;
+    const stored = fs.readFileSync(path.join(runDir, entry), "utf8").trim();
+    if (stored === token || stored.startsWith(`${token}.`)) return true;
+  }
+  return false;
+}
+
+function safeToken(value) {
+  return Buffer.from(String(value), "utf8").reduce((encoded, byte) => {
+    const safe =
+      (byte >= 48 && byte <= 57) ||
+      (byte >= 65 && byte <= 90) ||
+      (byte >= 97 && byte <= 122) ||
+      byte === 45 ||
+      byte === 46 ||
+      byte === 95;
+    return encoded + (safe ? String.fromCharCode(byte) : `%${byte.toString(16).toUpperCase().padStart(2, "0")}`);
+  }, "");
+}
+
+function lockOwner(skillDir, team, agent) {
+  const file = path.join(
+    skillDir,
+    "run",
+    `actas.${safeToken(team)}__${safeToken(agent)}.session`,
+  );
+  return fs.existsSync(file) ? fs.readFileSync(file, "utf8").trim() : "";
+}
+
+function normalizeInstanceId(skillDir, token, injectedPidAlive = pidAlive) {
+  if (!token || instancePid(token) !== null) return token;
+  const runDir = path.join(skillDir, "run");
+  if (!fs.existsSync(runDir)) return token;
+  for (const entry of fs.readdirSync(runDir)) {
+    if (!entry.startsWith("cc-instance.")) continue;
+    const pid = Number(entry.slice("cc-instance.".length));
+    if (!injectedPidAlive(pid)) continue;
+    const stored = fs.readFileSync(path.join(runDir, entry), "utf8").trim();
+    if (stored === token || stored.startsWith(`${token}.`)) return stored;
+  }
+  return token;
+}
+
+function yamlScalar(text, keys) {
+  const stack = [];
+  for (const rawLine of text.split(/\r?\n/)) {
+    if (!rawLine.trim() || rawLine.trimStart().startsWith("#")) continue;
+    const match = /^(\s*)([^:#]+):\s*([^#]*?)\s*$/.exec(rawLine);
+    if (!match) continue;
+    const depth = Math.floor(match[1].length / 2);
+    stack.length = depth;
+    stack[depth] = match[2].trim();
+    if (stack.length === keys.length && stack.every((key, index) => key === keys[index])) {
+      return match[3].trim();
+    }
+  }
+  return "";
+}
+
+function configInterval(skillDir) {
+  const file = path.join(skillDir, "db", "config.yaml");
+  if (!fs.existsSync(file)) return 60;
+  const text = fs.readFileSync(file, "utf8");
+  const raw =
+    yamlScalar(text, ["delivery", "turn", "check_interval"]) ||
+    yamlScalar(text, ["hook", "check_interval"]);
+  return /^\d+$/.test(raw) ? Number(raw) : 60;
+}
+function watcherAlive(skillDir, instanceId, injectedPidAlive = pidAlive) {
+  if (!instanceId) return false;
+  const file = path.join(skillDir, "run", `watch.${instanceId}.pid`);
+  if (!fs.existsSync(file)) return false;
+  return injectedPidAlive(Number(fs.readFileSync(file, "utf8").trim()));
+}
+
+function markerFresh(file, intervalSeconds, nowMs) {
+  if (!fs.existsSync(file)) return false;
+  return nowMs - fs.statSync(file).mtimeMs < intervalSeconds * 1000;
+}
+
+function formatBlock(groups) {
+  const reason = groups
+    .map((group) => {
+      let text = `${group.messages.length} new message(s) in ${group.team}:\n`;
+      for (const message of group.messages) {
+        const body = message.body.replace(/\n/g, "\\n").replace(/\t/g, "\\t");
+        text += `  [${message.created_at}] ${message.from}: ${body}\n`;
+      }
+      return text;
+    })
+    .join("\n");
+  return `${JSON.stringify({ decision: "block", reason }, null, 2)}\n`;
+}
+function assertIsolatedPaths(skillDir, dbPath, liveSkillDir) {
+  if (!liveSkillDir) return;
+  const live = path.resolve(liveSkillDir);
+  if (path.resolve(skillDir) === live || path.resolve(dbPath).startsWith(`${live}${path.sep}`)) {
+    throw new Error("refusing to run fixture against live agmsg paths");
+  }
+}
+
+function checkInbox(options) {
+  const {
+    skillDir,
+    type,
+    project,
+    stdin = "",
+    interval,
+    dbPath = path.join(process.env.AGMSG_STORAGE_PATH || path.join(skillDir, "db"), "messages.db"),
+    nowMs = Date.now(),
+    pidIsAlive = pidAlive,
+    afterSelect,
+    liveSkillDir,
+  } = options;
+  assertIsolatedPaths(skillDir, dbPath, liveSkillDir);
+  const { DatabaseSync } = loadSqlite();
+  const input = parseInput(stdin);
+  if (input.stop_hook_active === true) return { stdout: "", markerTouched: false };
+
+  const rawInstanceId = input.session_id || input.sessionId || process.env.GROK_SESSION_ID || "";
+  const instanceId = normalizeInstanceId(skillDir, rawInstanceId, pidIsAlive);
+  if (watcherAlive(skillDir, instanceId, pidIsAlive)) {
+    return { stdout: "", markerTouched: false };
+  }
+
+  const resolved = resolveIdentities({ skillDir, project, type });
+  if (resolved.status === "suggest" || resolved.status === "not_joined") {
+    return { stdout: "", markerTouched: false };
+  }
+  const agent = resolved.identities[0] && resolved.identities[0].name;
+  if (!agent) return { stdout: "", markerTouched: false };
+  const teams = [...new Set(resolved.identities.map((identity) => identity.team))];
+  const stopOutput = stopOutputForType(skillDir, type);
+  const marker = path.join(skillDir, "run", `.lastcheck-${agent}`);
+  const effectiveInterval = interval === undefined ? configInterval(skillDir) : interval;
+  if (markerFresh(marker, effectiveInterval, nowMs)) {
+    return {
+      stdout: emitStatus(stopOutput, "agmsg: check skipped (cooldown)"),
+      markerTouched: false,
+    };
+  }
+
+  fs.mkdirSync(path.dirname(marker), { recursive: true });
+  fs.closeSync(fs.openSync(marker, "a"));
+  fs.utimesSync(marker, nowMs / 1000, nowMs / 1000);
+  if (!fs.existsSync(dbPath)) return { stdout: "", markerTouched: true };
+
+  const db = new DatabaseSync(dbPath);
+  db.exec(`PRAGMA busy_timeout=${Number(process.env.AGMSG_BUSY_TIMEOUT || 5000)}`);
+  const groups = [];
+  try {
+    for (const team of teams) {
+      const owner = lockOwner(skillDir, team, agent);
+      if (owner && owner !== instanceId && instanceAlive(skillDir, owner, pidIsAlive)) continue;
+      const rows = db
+        .prepare(
+          `SELECT id, from_agent AS "from", body, created_at
+             FROM messages
+            WHERE team = ? AND to_agent = ? AND read_at IS NULL
+            ORDER BY created_at ASC`,
+        )
+        .all(team, agent);
+      if (rows.length === 0) continue;
+      if (afterSelect) afterSelect({ db, team, agent, rows });
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        const statement = db.prepare(
+          "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id=? AND read_at IS NULL",
+        );
+        for (const row of rows) statement.run(row.id);
+        db.exec("COMMIT");
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+      groups.push({ team, messages: rows });
+    }
+  } finally {
+    db.close();
+  }
+
+  return {
+    stdout:
+      groups.length === 0
+        ? emitStatus(stopOutput, "agmsg: no new messages")
+        : formatBlock(groups),
+    markerTouched: true,
+  };
+}
+
+function main() {
+  const [, , type, project] = process.argv;
+  if (!type || !project) {
+    process.stderr.write("usage: check-inbox.js <type> <project>\n");
+    return 64;
+  }
+  const skillDir = process.env.AGMSG_SKILL_DIR || path.resolve(__dirname, "..");
+  loadSqlite(); // Capability probe must happen before stdin or any side effect.
+  const stdin = fs.readFileSync(0, "utf8");
+  const interval = process.env.AGMSG_CHECK_INTERVAL === undefined
+    ? undefined
+    : Number(process.env.AGMSG_CHECK_INTERVAL);
+  const result = checkInbox({ skillDir, type, project, stdin, interval });
+  process.stdout.write(result.stdout);
+  process.stderr.write("agmsg: node check-inbox path\n");
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    process.stderr.write(`agmsg: node check-inbox failed: ${error.message}\n`);
+    process.exitCode = error.exitCode || 1;
+  }
+}
+
+module.exports = {
+  PREFLIGHT_UNAVAILABLE,
+  checkInbox,
+  instanceAlive,
+  markerFresh,
+  parseInput,
+  watcherAlive,
+};

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -11,6 +11,28 @@ PROJECT="${2:?Missing project_path}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/node.sh"
+
+# On Windows, avoid paying the MSYS process-launch cost for the entire inbox
+# path. Exit 78 is a side-effect-free capability result (old Node or no
+# node:sqlite); every other Node result is authoritative and must not be
+# replayed through bash, which could mark or deliver a message twice.
+_agmsg_detect_platform
+if [ "$_agmsg_platform" = "msys" ] && [ -f "$SCRIPT_DIR/check-inbox.js" ]; then
+  _agmsg_node_bin="$(agmsg_resolve_node)"
+  if command -v "$_agmsg_node_bin" >/dev/null 2>&1 || [ -x "$_agmsg_node_bin" ]; then
+    set +e
+    AGMSG_SKILL_DIR="$SKILL_DIR" "$_agmsg_node_bin" "$SCRIPT_DIR/check-inbox.js" "$TYPE" "$PROJECT"
+    _agmsg_node_status=$?
+    set -e
+    if [ "$_agmsg_node_status" -ne 78 ]; then
+      exit "$_agmsg_node_status"
+    fi
+  elif [ -n "${AGMSG_NODE:-}" ] || [ -n "${AGMSG_CODEX_NODE:-}" ]; then
+    echo "agmsg: configured Node.js ('$_agmsg_node_bin') was not found" >&2
+    exit 127
+  fi
+fi
 source "$SCRIPT_DIR/lib/storage.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/actas-lock.sh"

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 # Usage: history.sh <team> [agent_id] [limit]
 # Shows message history. If agent_id given, shows only that agent's messages.
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/fast-dispatch.sh"
+agmsg_fast_dispatch history "$@"
+
 TEAM="${1:?Usage: history.sh <team> [agent_id] [limit]}"
 AGENT="${2:-}"
 LIMIT="${3:-20}"
@@ -13,7 +18,6 @@ LIMIT="${3:-20}"
 # used elsewhere (config.sh, watch.sh).
 case "$LIMIT" in ''|*[!0-9]*) LIMIT=20 ;; esac
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 DB="$(agmsg_db_path)"
 

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 # Shows unread messages and marks them as read.
 # --quiet: only output if there are unread messages (for hooks)
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/fast-dispatch.sh"
+agmsg_fast_dispatch inbox "$@"
+
 TEAM="${1:?Usage: inbox.sh <team> <agent_id> [--quiet]}"
 AGENT="${2:?Missing agent_id}"
 QUIET=false
@@ -12,7 +17,6 @@ if [ "${3:-}" = "--quiet" ]; then
   QUIET=true
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 DB="$(agmsg_db_path)"
 

--- a/scripts/lib/fast-dispatch.sh
+++ b/scripts/lib/fast-dispatch.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Windows-only native Node dispatcher for latency-sensitive CLI entry points.
+# Return 78 only when the native path is unavailable before it can perform a
+# side effect. Any other Node exit status is authoritative and must stay loud.
+
+agmsg_fast_try() {
+  [ "${OS:-}" = "Windows_NT" ] || return 78
+
+  local script_dir fast_script node_bin
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  fast_script="$script_dir/agmsg-fast.js"
+  [ -f "$fast_script" ] || return 78
+
+  # shellcheck disable=SC1091
+  source "$script_dir/lib/node.sh"
+  node_bin="$(agmsg_resolve_node)"
+  if ! command -v "$node_bin" >/dev/null 2>&1 && [ ! -x "$node_bin" ]; then
+    if [ -n "${AGMSG_NODE:-}" ] || [ -n "${AGMSG_CODEX_NODE:-}" ]; then
+      # Explicit overrides are authoritative in lib/node.sh. Keep a typo loud
+      # rather than hiding it behind the slower Bash implementation.
+      echo "agmsg: configured Node executable is not runnable: $node_bin" >&2
+      return 127
+    fi
+    return 78
+  fi
+
+  NODE_NO_WARNINGS=1 "$node_bin" "$fast_script" "$@"
+}
+
+agmsg_fast_dispatch() {
+  local status
+  if agmsg_fast_try "$@"; then
+    exit 0
+  else
+    status=$?
+  fi
+  [ "$status" -eq 78 ] || exit "$status"
+}

--- a/scripts/lib/identity-resolver.js
+++ b/scripts/lib/identity-resolver.js
@@ -1,0 +1,110 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function normalizeProjectPath(value) {
+  if (typeof value !== "string" || value.length === 0) return "";
+  let normalized = value.replace(/\\/g, "/").replace(/\/+/g, "/");
+  const drive = /^([A-Za-z]):(?:\/|$)/.exec(normalized);
+  if (drive) {
+    normalized = `/${drive[1].toLowerCase()}${normalized.slice(2)}`;
+  } else if (/^\/[A-Za-z](?:\/|$)/.test(normalized)) {
+    normalized = `/${normalized[1].toLowerCase()}${normalized.slice(2)}`;
+  }
+  if (normalized.length > 1) normalized = normalized.replace(/\/+$/, "");
+  return normalized;
+}
+
+function registrationList(agent) {
+  if (Array.isArray(agent && agent.registrations)) return agent.registrations;
+  if (agent && (agent.type || agent.project)) {
+    return [{ type: agent.type, project: agent.project }];
+  }
+  return [];
+}
+
+function readTeamConfigs(skillDir) {
+  const teamsDir = path.join(skillDir, "teams");
+  if (!fs.existsSync(teamsDir)) return [];
+  return fs
+    .readdirSync(teamsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(teamsDir, entry.name, "config.json"))
+    .filter((file) => fs.existsSync(file))
+    .map((file) => {
+      try {
+        const config = JSON.parse(fs.readFileSync(file, "utf8"));
+        return config && typeof config === "object" ? config : null;
+      } catch (_) {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function dedupeIdentities(identities) {
+  const seen = new Set();
+  return identities.filter((identity) => {
+    const key = `${identity.team}\t${identity.name}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function resolveIdentities({ skillDir, project, type, team, name }) {
+  if (!skillDir || !project || !type) {
+    throw new Error("skillDir, project, and type are required");
+  }
+
+  const wantedProject = normalizeProjectPath(project);
+  const configs = readTeamConfigs(skillDir);
+  const availableTeams = [];
+  const exact = [];
+  const suggestions = [];
+
+  for (const config of configs) {
+    const teamName = typeof config.name === "string" ? config.name : "";
+    if (!teamName) continue;
+    availableTeams.push(teamName);
+    for (const [agentName, agent] of Object.entries(config.agents || {})) {
+      for (const registration of registrationList(agent)) {
+        if (!registration || registration.type !== type) continue;
+        const identity = {
+          team: teamName,
+          name: agentName,
+          project: registration.project || "",
+          type: registration.type,
+        };
+        suggestions.push(identity);
+        if (normalizeProjectPath(registration.project) === wantedProject) {
+          exact.push(identity);
+        }
+      }
+    }
+  }
+
+  const filterExplicit = (identity) =>
+    (!team || identity.team === team) && (!name || identity.name === name);
+  const identities = dedupeIdentities(exact.filter(filterExplicit));
+  const suggested = dedupeIdentities(suggestions.filter(filterExplicit));
+
+  if (identities.length > 0) {
+    const names = new Set(identities.map((identity) => identity.name));
+    return {
+      status: names.size === 1 ? "single" : "multiple",
+      identities,
+      availableTeams,
+    };
+  }
+  if (suggested.length > 0) {
+    return { status: "suggest", identities: suggested, availableTeams };
+  }
+  return { status: "not_joined", identities: [], availableTeams };
+}
+
+module.exports = {
+  normalizeProjectPath,
+  resolveIdentities,
+};

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 # Usage: send.sh <team> <from> <to> <message> [--force]
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/fast-dispatch.sh"
+agmsg_fast_dispatch send "$@"
+
 TEAM="${1:?Usage: send.sh <team> <from> <to> <message> [--force]}"
 FROM="${2:?Missing from agent}"
 TO="${3:?Missing to agent}"
@@ -12,7 +17,6 @@ if [ "${5:-}" = "--force" ]; then
   FORCE=1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/validate.sh"

--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -4,9 +4,12 @@ set -euo pipefail
 # Usage: team.sh <team>
 # Shows team members.
 
-TEAM="${1:?Usage: team.sh <team>}"
-
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/fast-dispatch.sh"
+agmsg_fast_dispatch team "$@"
+
+TEAM="${1:?Usage: team.sh <team>}"
 
 # Reject team names that would escape teams/ as a path segment (#140).
 # shellcheck disable=SC1091

--- a/scripts/whoami.sh
+++ b/scripts/whoami.sh
@@ -12,6 +12,13 @@ set -euo pipefail
 #   If type is omitted, auto-detect from env vars and process tree.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# The native resolver needs an explicit type. Preserve the existing shell's
+# process-tree auto-detection when callers omit it.
+if [ "$#" -ge 2 ]; then
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/lib/fast-dispatch.sh"
+  agmsg_fast_dispatch whoami "$@"
+fi
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/type-registry.sh"
 # shellcheck disable=SC1091

--- a/tests/agmsg-fast.test.js
+++ b/tests/agmsg-fast.test.js
@@ -1,0 +1,98 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { DatabaseSync } = require("node:sqlite");
+const { run } = require("../scripts/agmsg-fast");
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "agmsg-fast-"));
+const skillDir = path.join(root, "skill");
+const dbPath = path.join(root, "store", "messages.db");
+fs.mkdirSync(path.join(skillDir, "teams", "mes"), { recursive: true });
+fs.writeFileSync(
+  path.join(skillDir, "teams", "mes", "config.json"),
+  JSON.stringify({
+    name: "mes",
+    agents: {
+      Codex: {
+        registrations: [{ type: "codex", project: "E:/repo" }],
+      },
+      Claude: {
+        registrations: [
+          { type: "claude-code", project: "E:/one" },
+          { type: "claude-code", project: "E:/two" },
+        ],
+      },
+    },
+  }),
+);
+
+try {
+  const whoami = run(["whoami", "e:\\repo", "codex"], { skillDir, dbPath });
+  assert.equal(whoami.exitCode, 0);
+  assert.equal(whoami.stdout, "agent=Codex teams=mes type=codex project=e:\\repo\n");
+  const suggested = run(["whoami", "E:/other", "codex"], { skillDir, dbPath });
+  assert.match(suggested.stdout, /^suggest=true agents=Codex teams=mes /);
+  const missing = run(["whoami", "E:/other", "unknown"], { skillDir, dbPath });
+  assert.equal(missing.stdout, "not_joined=true available_teams=mes\n");
+
+  const team = run(["team", "mes"], { skillDir, dbPath });
+  assert.equal(team.exitCode, 0);
+  assert.equal(
+    team.stdout,
+    "Team: mes\n\n" +
+      "  Codex (codex) — E:/repo\n" +
+      "  Claude (claude-code) — E:/two (+1 more)\n\n" +
+      "2 member(s)\n",
+  );
+
+  const missingSend = run(["send", "mes", "Claude"], { skillDir, dbPath });
+  assert.equal(missingSend.exitCode, 64);
+  assert.match(missingSend.stderr, /^usage:/);
+
+  const badFrom = run(["send", "mes", "Typo", "Codex", "lost"], { skillDir, dbPath });
+  assert.equal(badFrom.exitCode, 1);
+  assert.match(badFrom.stderr, /from agent 'Typo' is not registered/);
+  const forced = run(["send", "new-team", "ghost", "nobody", "forced", "--force"], {
+    skillDir,
+    dbPath,
+  });
+  assert.equal(forced.exitCode, 0);
+  assert.equal(forced.stdout, "Sent to nobody in team new-team\n");
+
+  const first = run(["send", "mes", "Claude", "Codex", "line 1\nline\t2"], {
+    skillDir,
+    dbPath,
+  });
+  assert.equal(first.stdout, "Sent to Codex in team mes\n");
+  run(["send", "mes", "Codex", "Claude", "reply"], { skillDir, dbPath });
+
+  const before = run(["history", "mes", "Codex", "20"], { skillDir, dbPath });
+  assert.match(before.stdout, /^  ● .*Claude → Codex: line 1\\nline\\t2/m);
+  assert.match(before.stdout, /^  ● .*Codex → Claude: reply/m);
+
+  const inbox = run(["inbox", "mes", "Codex"], { skillDir, dbPath });
+  assert.match(inbox.stdout, /^1 new message\(s\):/);
+  assert.match(inbox.stdout, /Claude: line 1\\nline\\t2/);
+
+  const after = run(["history", "mes", "Codex", "20"], { skillDir, dbPath });
+  assert.match(after.stdout, /^  ○ .*Claude → Codex:/m);
+  assert.match(after.stdout, /^  ● .*Codex → Claude:/m);
+
+  const db = new DatabaseSync(dbPath);
+  const unread = db
+    .prepare("SELECT COUNT(*) AS count FROM messages WHERE to_agent='Codex' AND read_at IS NULL")
+    .get().count;
+  db.close();
+  assert.equal(unread, 0);
+
+  assert.equal(run(["history", "mes", "", "bad"], { skillDir, dbPath }).exitCode, 0);
+  assert.throws(() => run(["team", "../escape"], { skillDir, dbPath }), /invalid team name/);
+
+
+  process.stdout.write("agmsg-fast tests: PASS\n");
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/tests/check-inbox-fixtures.test.js
+++ b/tests/check-inbox-fixtures.test.js
@@ -1,0 +1,222 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { DatabaseSync } = require("node:sqlite");
+const { checkInbox } = require("../scripts/check-inbox");
+
+const fixtureDir = path.join(__dirname, "fixtures", "check-inbox");
+const fixtureFiles = fs.readdirSync(fixtureDir).filter((name) => name.endsWith(".json")).sort();
+const liveSkillDir = process.env.AGMSG_LIVE_SKILL_DIR || "C:\\Users\\Matsu\\.agents\\skills\\agmsg";
+
+function encodeToken(value) {
+  return Buffer.from(String(value), "utf8").reduce((encoded, byte) => {
+    const safe =
+      (byte >= 48 && byte <= 57) ||
+      (byte >= 65 && byte <= 90) ||
+      (byte >= 97 && byte <= 122) ||
+      byte === 45 ||
+      byte === 46 ||
+      byte === 95;
+    return encoded + (safe ? String.fromCharCode(byte) : `%${byte.toString(16).toUpperCase().padStart(2, "0")}`);
+  }, "");
+}
+
+function createDb(dbPath, messages) {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      team TEXT NOT NULL,
+      from_agent TEXT NOT NULL,
+      to_agent TEXT NOT NULL,
+      body TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      read_at TEXT
+    );
+  `);
+  const insert = db.prepare(
+    "INSERT INTO messages(id, team, from_agent, to_agent, body, created_at, read_at) VALUES(?, ?, ?, ?, ?, ?, ?)",
+  );
+  for (const row of messages) {
+    insert.run(row.id, row.team, row.from, row.to, row.body, row.created_at, row.read_at);
+  }
+  db.close();
+}
+
+function writeTeams(skillDir, teams) {
+  for (const team of teams) {
+    const dir = path.join(skillDir, "teams", team.name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "config.json"), JSON.stringify(team));
+  }
+}
+
+function writeType(skillDir, type) {
+  const dir = path.join(skillDir, "scripts", "drivers", "types", type);
+  fs.mkdirSync(dir, { recursive: true });
+  const stopOutput = type === "codex" || type === "copilot" ? "json" : "";
+  fs.writeFileSync(path.join(dir, "type.conf"), `name=${type}\nstop_output=${stopOutput}\n`);
+}
+
+function materializeRun(skillDir, fixture, nowMs) {
+  const runDir = path.join(skillDir, "run");
+  fs.mkdirSync(runDir, { recursive: true });
+  const alivePids = new Set();
+  let nextPid = 41000;
+  const allocate = (alive) => {
+    nextPid += 1;
+    if (alive) alivePids.add(nextPid);
+    return nextPid;
+  };
+
+  if (fixture.run.marker) {
+    const file = path.join(runDir, `.lastcheck-${fixture.run.marker.agent}`);
+    fs.writeFileSync(file, "");
+    const time = (nowMs - fixture.run.marker.ageSeconds * 1000) / 1000;
+    fs.utimesSync(file, time, time);
+  }
+
+  let normalizedSessionId = fixture.input.sessionId || "";
+  for (const lock of fixture.run.locks || []) {
+    let owner = lock.owner;
+    if (owner.includes("SELFPID")) {
+      const pid = allocate(true);
+      owner = owner.replace("SELFPID", String(pid));
+      normalizedSessionId = owner;
+      fs.writeFileSync(path.join(runDir, `cc-instance.${pid}`), owner);
+    } else if (lock.alive) {
+      const pid = allocate(true);
+      fs.writeFileSync(path.join(runDir, `cc-instance.${pid}`), owner);
+    }
+    const file = path.join(
+      runDir,
+      `actas.${encodeToken(lock.team)}__${encodeToken(lock.agent)}.session`,
+    );
+    fs.writeFileSync(file, owner);
+  }
+
+  if (fixture.run.watch) {
+    const pid = allocate(fixture.run.watch.alive);
+    fs.writeFileSync(path.join(runDir, `watch.${fixture.run.watch.instanceId}.pid`), String(pid));
+  }
+  return {
+    normalizedSessionId,
+    pidIsAlive: (pid) => alivePids.has(pid),
+  };
+}
+
+function writeConfig(skillDir, config) {
+  if (!config) return;
+  const value = config["delivery.turn.check_interval"];
+  fs.mkdirSync(path.join(skillDir, "db"), { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, "db", "config.yaml"),
+    `# fixture mirrors the installed nested config shape\ndelivery:\n  monitor:\n    poll_interval: 5\n  turn:\n    # cooldown\n    check_interval: ${value}\n`,
+  );
+}
+
+function semantic(stdout) {
+  if (!stdout) return { kind: "silent" };
+  const parsed = JSON.parse(stdout);
+  if (parsed.systemMessage) return { kind: "status", systemMessage: parsed.systemMessage };
+  assert.equal(parsed.decision, "block");
+  const teams = [];
+  let current = null;
+  for (const line of parsed.reason.split("\n")) {
+    const header = /^(\d+) new message\(s\) in (.+):$/.exec(line);
+    if (header) {
+      current = { team: header[2], messages: [] };
+      teams.push(current);
+      continue;
+    }
+    const message = /^  \[([^\]]+)\] ([^:]+): (.*)$/.exec(line);
+    if (message && current) {
+      current.messages.push({
+        from: message[2],
+        body: message[3].replace(/\\n/g, "\n").replace(/\\t/g, "\t"),
+        created_at: message[1],
+      });
+    }
+  }
+  return { kind: "block", teams };
+}
+
+function readState(dbPath) {
+  const db = new DatabaseSync(dbPath);
+  const rows = db.prepare("SELECT id, read_at FROM messages ORDER BY id").all();
+  db.close();
+  return {
+    unreadIds: rows.filter((row) => row.read_at === null).map((row) => Number(row.id)),
+    readIds: rows.filter((row) => row.read_at !== null).map((row) => Number(row.id)),
+  };
+}
+
+let passed = 0;
+let eligible = 0;
+for (const file of fixtureFiles) {
+  const fixture = JSON.parse(fs.readFileSync(path.join(fixtureDir, file), "utf8"));
+  if (!fixture.runners.includes("node")) continue;
+  eligible += 1;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agmsg-check-inbox-"));
+  const skillDir = path.join(root, "skill");
+  const dbPath = path.join(root, "store", "messages.db");
+  const nowMs = Date.now();
+  try {
+    assert.notEqual(path.resolve(skillDir), path.resolve(liveSkillDir));
+    writeTeams(skillDir, fixture.teams);
+    writeType(skillDir, fixture.input.type);
+    writeConfig(skillDir, fixture.config);
+    createDb(dbPath, fixture.messages);
+    const runtime = materializeRun(skillDir, fixture, nowMs);
+    let stdin = fixture.input.stdin || "";
+    if (!stdin && fixture.input.sessionId) {
+      stdin = JSON.stringify({ sessionId: fixture.input.sessionId });
+    }
+    const interval =
+      fixture.input.interval === null
+        ? 60
+        : fixture.input.interval === "config"
+          ? undefined
+          : fixture.input.interval;
+    const injected = fixture.injectDuringRun?.afterSelect || [];
+    let injectedOnce = false;
+    const result = checkInbox({
+      skillDir,
+      dbPath,
+      liveSkillDir,
+      type: fixture.input.type,
+      project: fixture.input.project,
+      stdin,
+      interval,
+      nowMs,
+      pidIsAlive: runtime.pidIsAlive,
+      afterSelect: injected.length
+        ? ({ db }) => {
+            if (injectedOnce) return;
+            injectedOnce = true;
+            const insert = db.prepare(
+              "INSERT INTO messages(id, team, from_agent, to_agent, body, created_at, read_at) VALUES(?, ?, ?, ?, ?, ?, ?)",
+            );
+            for (const row of injected) {
+              insert.run(row.id, row.team, row.from, row.to, row.body, row.created_at, row.read_at);
+            }
+          }
+        : undefined,
+    });
+    assert.deepEqual(semantic(result.stdout), fixture.expected.stdoutSemantic, `${file}: stdout`);
+    const state = readState(dbPath);
+    assert.deepEqual(state.unreadIds, fixture.expected.unreadIds, `${file}: unread ids`);
+    assert.deepEqual(state.readIds, fixture.expected.readIds, `${file}: read ids`);
+    assert.equal(result.markerTouched, fixture.expected.markerTouched, `${file}: marker`);
+    passed += 1;
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+assert.equal(passed, eligible);
+process.stdout.write(`check-inbox fixtures: ${passed}/${fixtureFiles.length} PASS\n`);

--- a/tests/check-inbox-smoke.test.js
+++ b/tests/check-inbox-smoke.test.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { parseInput } = require("../scripts/check-inbox");
+
+assert.deepEqual(parseInput('{"stop_hook_active":true}'), { stop_hook_active: true });
+assert.deepEqual(parseInput(""), {});
+assert.deepEqual(parseInput("not-json"), {});
+
+process.stdout.write("check-inbox smoke: PASS\n");

--- a/tests/fixtures/check-inbox/g01-no-unread-codex.json
+++ b/tests/fixtures/check-inbox/g01-no-unread-codex.json
@@ -1,0 +1,58 @@
+{
+  "name": "g01-no-unread-codex",
+  "description": "no unread, codex type emits status JSON; marker touched",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "old",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": "2026-07-20T09:00:00Z"
+    }
+  ],
+  "rawChecks": true,
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "status",
+      "systemMessage": "agmsg: no new messages"
+    },
+    "unreadIds": [],
+    "readIds": [
+      1
+    ],
+    "markerTouched": true
+  }
+}

--- a/tests/fixtures/check-inbox/g02-no-unread-claude-code.json
+++ b/tests/fixtures/check-inbox/g02-no-unread-claude-code.json
@@ -1,0 +1,44 @@
+{
+  "name": "g02-no-unread-claude-code",
+  "description": "no unread, claude-code type stays silent",
+  "input": {
+    "type": "claude-code",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "claude": {
+          "registrations": [
+            {
+              "type": "claude-code",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "silent"
+    },
+    "unreadIds": [],
+    "readIds": [],
+    "markerTouched": true
+  }
+}

--- a/tests/fixtures/check-inbox/g03-two-unread-ordering.json
+++ b/tests/fixtures/check-inbox/g03-two-unread-ordering.json
@@ -1,0 +1,84 @@
+{
+  "name": "g03-two-unread-ordering",
+  "description": "two unread delivered in created_at ascending order regardless of insert order; both marked read",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 2,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "second",
+      "created_at": "2026-07-20T10:01:00Z",
+      "read_at": null
+    },
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "first",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "rawChecks": true,
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "block",
+      "teams": [
+        {
+          "team": "mes",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "first",
+              "created_at": "2026-07-20T10:00:00Z"
+            },
+            {
+              "from": "claude",
+              "body": "second",
+              "created_at": "2026-07-20T10:01:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "unreadIds": [],
+    "readIds": [
+      1,
+      2
+    ],
+    "markerTouched": true
+  }
+}

--- a/tests/fixtures/check-inbox/g04-body-lf-tab.json
+++ b/tests/fixtures/check-inbox/g04-body-lf-tab.json
@@ -1,0 +1,69 @@
+{
+  "name": "g04-body-lf-tab",
+  "description": "body containing LF and TAB round-trips as literal backslash-n / backslash-t once (no double escaping)",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "line1\nline2\tend",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "rawChecks": true,
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "block",
+      "teams": [
+        {
+          "team": "mes",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "line1\nline2\tend",
+              "created_at": "2026-07-20T10:00:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "unreadIds": [],
+    "readIds": [
+      1
+    ],
+    "markerTouched": true
+  }
+}

--- a/tests/fixtures/check-inbox/g05-body-quote-backslash.json
+++ b/tests/fixtures/check-inbox/g05-body-quote-backslash.json
@@ -1,0 +1,69 @@
+{
+  "name": "g05-body-quote-backslash",
+  "description": "body containing double quote and backslash yields valid JSON with correct unescaped semantics",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "say \"hi\" C:\\path",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "rawChecks": true,
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "block",
+      "teams": [
+        {
+          "team": "mes",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "say \"hi\" C:\\path",
+              "created_at": "2026-07-20T10:00:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "unreadIds": [],
+    "readIds": [
+      1
+    ],
+    "markerTouched": true
+  }
+}

--- a/tests/fixtures/check-inbox/g06-cooldown-inside.json
+++ b/tests/fixtures/check-inbox/g06-cooldown-inside.json
@@ -1,0 +1,60 @@
+{
+  "name": "g06-cooldown-inside",
+  "description": "fresh marker within interval skips: cooldown JSON, DB untouched, marker NOT touched",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": {
+      "agent": "Codex",
+      "ageSeconds": 5
+    },
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "pending",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "status",
+      "systemMessage": "agmsg: check skipped (cooldown)"
+    },
+    "unreadIds": [
+      1
+    ],
+    "readIds": [],
+    "markerTouched": false
+  }
+}

--- a/tests/fixtures/check-inbox/g07-interval-zero.json
+++ b/tests/fixtures/check-inbox/g07-interval-zero.json
@@ -1,0 +1,71 @@
+{
+  "name": "g07-interval-zero",
+  "description": "interval=0 always delivers even with a fresh marker",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": 0
+  },
+  "run": {
+    "marker": {
+      "agent": "Codex",
+      "ageSeconds": 5
+    },
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "pending",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "block",
+      "teams": [
+        {
+          "team": "mes",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "pending",
+              "created_at": "2026-07-20T10:00:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "unreadIds": [],
+    "readIds": [
+      1
+    ],
+    "markerTouched": true
+  }
+}

--- a/tests/fixtures/check-inbox/g08-two-teams-both-unread.json
+++ b/tests/fixtures/check-inbox/g08-two-teams-both-unread.json
@@ -1,0 +1,101 @@
+{
+  "name": "g08-two-teams-both-unread",
+  "description": "member of two teams: both teams' blocks concatenated, both marked read",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "ops",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "m-mes",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    },
+    {
+      "id": 2,
+      "team": "ops",
+      "from": "claude",
+      "to": "Codex",
+      "body": "m-ops",
+      "created_at": "2026-07-20T10:01:00Z",
+      "read_at": null
+    }
+  ],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "block",
+      "teams": [
+        {
+          "team": "mes",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "m-mes",
+              "created_at": "2026-07-20T10:00:00Z"
+            }
+          ]
+        },
+        {
+          "team": "ops",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "m-ops",
+              "created_at": "2026-07-20T10:01:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "unreadIds": [],
+    "readIds": [
+      1,
+      2
+    ],
+    "markerTouched": true
+  }
+}

--- a/tests/fixtures/check-inbox/g09-lock-other-one-team.json
+++ b/tests/fixtures/check-inbox/g09-lock-other-one-team.json
@@ -1,0 +1,99 @@
+{
+  "name": "g09-lock-other-one-team",
+  "description": "actas lock held by other live session on one team: that team skipped (unread kept), other delivered",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [
+      {
+        "team": "mes",
+        "agent": "Codex",
+        "owner": "other-session",
+        "alive": true
+      }
+    ],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "ops",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "locked-away",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    },
+    {
+      "id": 2,
+      "team": "ops",
+      "from": "claude",
+      "to": "Codex",
+      "body": "deliver-me",
+      "created_at": "2026-07-20T10:01:00Z",
+      "read_at": null
+    }
+  ],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "block",
+      "teams": [
+        {
+          "team": "ops",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "deliver-me",
+              "created_at": "2026-07-20T10:01:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "unreadIds": [
+      1
+    ],
+    "readIds": [
+      2
+    ],
+    "markerTouched": true
+  }
+}

--- a/tests/fixtures/check-inbox/g10-not-joined.json
+++ b/tests/fixtures/check-inbox/g10-not-joined.json
@@ -1,0 +1,56 @@
+{
+  "name": "g10-not-joined",
+  "description": "project not joined anywhere: silent exit 0, DB untouched",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/other-project"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "never",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "silent"
+    },
+    "unreadIds": [
+      1
+    ],
+    "readIds": [],
+    "markerTouched": false
+  }
+}

--- a/tests/fixtures/check-inbox/g11-multiple-first-agent.json
+++ b/tests/fixtures/check-inbox/g11-multiple-first-agent.json
@@ -1,0 +1,88 @@
+{
+  "name": "g11-multiple-first-agent",
+  "description": "multiple identities for (project,type): only the FIRST registered agent's inbox is polled",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Alpha": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        },
+        "Beta": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Alpha",
+      "body": "for-alpha",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    },
+    {
+      "id": 2,
+      "team": "mes",
+      "from": "claude",
+      "to": "Beta",
+      "body": "for-beta",
+      "created_at": "2026-07-20T10:01:00Z",
+      "read_at": null
+    }
+  ],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "block",
+      "teams": [
+        {
+          "team": "mes",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "for-alpha",
+              "created_at": "2026-07-20T10:00:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "unreadIds": [
+      2
+    ],
+    "readIds": [
+      1
+    ],
+    "markerTouched": true,
+    "note": "first agent per teams config iteration order; runner pins Alpha first"
+  }
+}

--- a/tests/fixtures/check-inbox/g12-live-watcher-defers.json
+++ b/tests/fixtures/check-inbox/g12-live-watcher-defers.json
@@ -1,0 +1,60 @@
+{
+  "name": "g12-live-watcher-defers",
+  "description": "live watcher pidfile for this instance: Stop-hook defers silently, DB untouched",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null,
+    "sessionId": "test-instance"
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": {
+      "instanceId": "test-instance",
+      "alive": true
+    }
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "watcher-owns-this",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "silent"
+    },
+    "unreadIds": [
+      1
+    ],
+    "readIds": [],
+    "markerTouched": false
+  }
+}

--- a/tests/fixtures/check-inbox/g13-stop-hook-active.json
+++ b/tests/fixtures/check-inbox/g13-stop-hook-active.json
@@ -1,0 +1,56 @@
+{
+  "name": "g13-stop-hook-active",
+  "description": "stdin containing stop_hook_active:true exits immediately, everything untouched",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "{\"stop_hook_active\": true}",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "pending",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "silent"
+    },
+    "unreadIds": [
+      1
+    ],
+    "readIds": [],
+    "markerTouched": false
+  }
+}

--- a/tests/fixtures/check-inbox/g14-stale-watcher-delivers.json
+++ b/tests/fixtures/check-inbox/g14-stale-watcher-delivers.json
@@ -1,0 +1,72 @@
+{
+  "name": "g14-stale-watcher-delivers",
+  "description": "stale (dead-pid) watcher pidfile does not defer: delivery continues",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null,
+    "sessionId": "test-instance"
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": {
+      "instanceId": "test-instance",
+      "alive": false
+    }
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "deliver",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "block",
+      "teams": [
+        {
+          "team": "mes",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "deliver",
+              "created_at": "2026-07-20T10:00:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "unreadIds": [],
+    "readIds": [
+      1
+    ],
+    "markerTouched": true
+  }
+}

--- a/tests/fixtures/check-inbox/g15-stale-lock-free.json
+++ b/tests/fixtures/check-inbox/g15-stale-lock-free.json
@@ -1,0 +1,75 @@
+{
+  "name": "g15-stale-lock-free",
+  "description": "actas lock whose owner session is dead is treated as free: delivery continues",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [
+      {
+        "team": "mes",
+        "agent": "Codex",
+        "owner": "dead-session",
+        "alive": false
+      }
+    ],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "deliver",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "block",
+      "teams": [
+        {
+          "team": "mes",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "deliver",
+              "created_at": "2026-07-20T10:00:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "unreadIds": [],
+    "readIds": [
+      1
+    ],
+    "markerTouched": true
+  }
+}

--- a/tests/fixtures/check-inbox/g16-late-row-stays-unread.json
+++ b/tests/fixtures/check-inbox/g16-late-row-stays-unread.json
@@ -1,0 +1,83 @@
+{
+  "name": "g16-late-row-stays-unread",
+  "description": "row inserted after the SELECT stays unread: Node marks only displayed ids (intentional divergence from bash 1.1.6 which would mark it read)",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "displayed",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "injectDuringRun": {
+    "afterSelect": [
+      {
+        "id": 2,
+        "team": "mes",
+        "from": "claude",
+        "to": "Codex",
+        "body": "late-arrival",
+        "created_at": "2026-07-20T10:01:00Z",
+        "read_at": null
+      }
+    ]
+  },
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "block",
+      "teams": [
+        {
+          "team": "mes",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "displayed",
+              "created_at": "2026-07-20T10:00:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "unreadIds": [
+      2
+    ],
+    "readIds": [
+      1
+    ],
+    "markerTouched": true,
+    "note": "bash 1.1.6 would also mark id 2 read without displaying it (known race, upstream-fixed in 1.1.10); Node path is deliberately displayed-ids-only"
+  }
+}

--- a/tests/fixtures/check-inbox/g17-self-composite-lock.json
+++ b/tests/fixtures/check-inbox/g17-self-composite-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "g17-self-composite-lock",
+  "description": "actas lock owner recorded as composite <sid>.<pid> of THIS session (bare sid in stdin): self-match must succeed and delivery proceed",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null,
+    "sessionId": "test-instance"
+  },
+  "run": {
+    "marker": null,
+    "locks": [
+      {
+        "team": "mes",
+        "agent": "Codex",
+        "owner": "test-instance.SELFPID",
+        "alive": true,
+        "note": "runner substitutes SELFPID with its own live pid; owner must normalize-match input.sessionId"
+      }
+    ],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "deliver-to-self",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "block",
+      "teams": [
+        {
+          "team": "mes",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "deliver-to-self",
+              "created_at": "2026-07-20T10:00:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "unreadIds": [],
+    "readIds": [
+      1
+    ],
+    "markerTouched": true,
+    "note": "regression for BLOCKER-1: without composite normalization the live self pid makes the lock look like a live OTHER session and delivery is skipped forever"
+  }
+}

--- a/tests/fixtures/check-inbox/g18-config-interval.json
+++ b/tests/fixtures/check-inbox/g18-config-interval.json
@@ -1,0 +1,64 @@
+{
+  "name": "g18-config-interval",
+  "description": "interval:\"config\" - runner writes delivery.turn.check_interval=120 into the isolated agmsg config and does NOT pass env/explicit interval; fresh marker at age 90s must still be inside cooldown",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": "config"
+  },
+  "run": {
+    "marker": {
+      "agent": "Codex",
+      "ageSeconds": 90
+    },
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Codex": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Codex",
+      "body": "pending",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    }
+  ],
+  "config": {
+    "delivery.turn.check_interval": 120
+  },
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "status",
+      "systemMessage": "agmsg: check skipped (cooldown)"
+    },
+    "unreadIds": [
+      1
+    ],
+    "readIds": [],
+    "markerTouched": false,
+    "note": "regression for BLOCKER-2: env-only implementations would use default 60, treat the 90s marker as stale and deliver - this fixture then fails"
+  }
+}

--- a/tests/fixtures/check-inbox/g19-union-teams-unregistered.json
+++ b/tests/fixtures/check-inbox/g19-union-teams-unregistered.json
@@ -1,0 +1,102 @@
+{
+  "name": "g19-union-teams-unregistered",
+  "description": "multiple identities: first agent Alpha registered only in team mes, Beta in team ops; a row addressed to Alpha exists in ops - teams union (bash parity) polls Alpha's inbox in ops too and delivers it",
+  "input": {
+    "type": "codex",
+    "project": "/e/Workspace/mes-reference-impl",
+    "stdin": "",
+    "interval": null
+  },
+  "run": {
+    "marker": null,
+    "locks": [],
+    "watch": null
+  },
+  "runners": [
+    "bash",
+    "node"
+  ],
+  "teams": [
+    {
+      "name": "mes",
+      "agents": {
+        "Alpha": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "ops",
+      "agents": {
+        "Beta": {
+          "registrations": [
+            {
+              "type": "codex",
+              "project": "/e/Workspace/mes-reference-impl"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "team": "mes",
+      "from": "claude",
+      "to": "Alpha",
+      "body": "alpha-in-mes",
+      "created_at": "2026-07-20T10:00:00Z",
+      "read_at": null
+    },
+    {
+      "id": 2,
+      "team": "ops",
+      "from": "claude",
+      "to": "Alpha",
+      "body": "alpha-in-ops",
+      "created_at": "2026-07-20T10:01:00Z",
+      "read_at": null
+    }
+  ],
+  "expected": {
+    "exitCode": 0,
+    "stdoutSemantic": {
+      "kind": "block",
+      "teams": [
+        {
+          "team": "mes",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "alpha-in-mes",
+              "created_at": "2026-07-20T10:00:00Z"
+            }
+          ]
+        },
+        {
+          "team": "ops",
+          "messages": [
+            {
+              "from": "claude",
+              "body": "alpha-in-ops",
+              "created_at": "2026-07-20T10:01:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "unreadIds": [],
+    "readIds": [
+      1,
+      2
+    ],
+    "markerTouched": true,
+    "note": "bash TEAMS is the whoami teams= union across all identities; a team-scoped implementation would leave id 2 unread and fail here"
+  }
+}

--- a/tests/identity-resolver.test.js
+++ b/tests/identity-resolver.test.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  normalizeProjectPath,
+  resolveIdentities,
+} = require("../scripts/lib/identity-resolver");
+
+function fixture(configs, run) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agmsg-identity-"));
+  try {
+    for (const config of configs) {
+      const dir = path.join(root, "teams", config.name);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "config.json"), JSON.stringify(config));
+    }
+    run(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("normalizes Windows, MSYS, separators, drive case, and trailing slash", () => {
+  const variants = [
+    "E:\\Workspace\\mes-reference-impl\\",
+    "e:/Workspace//mes-reference-impl",
+    "/E/Workspace/mes-reference-impl/",
+  ];
+  assert.deepEqual(
+    variants.map(normalizeProjectPath),
+    Array(variants.length).fill("/e/Workspace/mes-reference-impl"),
+  );
+});
+
+test("resolves single identity across mixed path forms", () => {
+  fixture(
+    [{
+      name: "mes",
+      agents: {
+        Codex: { registrations: [{ type: "codex", project: "/e/Workspace/mes-reference-impl" }] },
+      },
+    }],
+    (skillDir) => {
+      const result = resolveIdentities({
+        skillDir,
+        project: "E:\\Workspace\\mes-reference-impl",
+        type: "codex",
+      });
+      assert.equal(result.status, "single");
+      assert.deepEqual(result.identities.map(({ team, name }) => ({ team, name })), [
+        { team: "mes", name: "Codex" },
+      ]);
+    },
+  );
+});
+
+test("reports multiple names and honors explicit team/name", () => {
+  fixture(
+    [{
+      name: "mes",
+      agents: {
+        A: { type: "codex", project: "/e/project" },
+        B: { registrations: [{ type: "codex", project: "E:\\project" }] },
+      },
+    }],
+    (skillDir) => {
+      const multiple = resolveIdentities({ skillDir, project: "/e/project", type: "codex" });
+      assert.equal(multiple.status, "multiple");
+      assert.deepEqual(multiple.identities.map((identity) => identity.name), ["A", "B"]);
+      const single = resolveIdentities({
+        skillDir,
+        project: "/e/project",
+        type: "codex",
+        team: "mes",
+        name: "B",
+      });
+      assert.equal(single.status, "single");
+      assert.equal(single.identities[0].name, "B");
+    },
+  );
+});
+
+test("distinguishes suggest from not_joined", () => {
+  fixture(
+    [{
+      name: "mes",
+      agents: {
+        Codex: { registrations: [{ type: "codex", project: "/e/other" }] },
+      },
+    }],
+    (skillDir) => {
+      assert.equal(
+        resolveIdentities({ skillDir, project: "/e/current", type: "codex" }).status,
+        "suggest",
+      );
+      assert.equal(
+        resolveIdentities({ skillDir, project: "/e/current", type: "antigravity" }).status,
+        "not_joined",
+      );
+    },
+  );
+});

--- a/tests/test_check_inbox_node_dispatch.bats
+++ b/tests/test_check_inbox_node_dispatch.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) ;;
+    *) skip "Windows-only native dispatch" ;;
+  esac
+  export TEST_SKILL_DIR="$(mktemp -d)"
+  mkdir -p "$TEST_SKILL_DIR/scripts"
+  cp -R "$BATS_TEST_DIRNAME"/../scripts/. "$TEST_SKILL_DIR/scripts/"
+  export SCRIPTS="$TEST_SKILL_DIR/scripts"
+  mkdir -p "$TEST_SKILL_DIR/fake-bin"
+  export PATH="$TEST_SKILL_DIR/fake-bin:$PATH"
+  export NODE_LOG="$TEST_SKILL_DIR/node.log"
+}
+
+teardown() {
+  rm -rf "$TEST_SKILL_DIR"
+}
+
+write_fake_node() {
+  cat > "$TEST_SKILL_DIR/fake-bin/agmsg-test-node" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$NODE_LOG"
+exit "${FAKE_NODE_STATUS:?}"
+EOF
+  chmod +x "$TEST_SKILL_DIR/fake-bin/agmsg-test-node"
+  export AGMSG_NODE="$TEST_SKILL_DIR/fake-bin/agmsg-test-node"
+}
+
+@test "Windows check-inbox fails loud for a missing authoritative Node override" {
+  export AGMSG_NODE="$TEST_SKILL_DIR/fake-bin/missing-node"
+  cat > "$SCRIPTS/whoami.sh" <<'EOF'
+#!/usr/bin/env bash
+echo 'legacy fallback must not run' >&2
+exit 42
+EOF
+  chmod +x "$SCRIPTS/whoami.sh"
+
+  run bash "$SCRIPTS/check-inbox.sh" codex "$TEST_SKILL_DIR/project"
+  [ "$status" -eq 127 ]
+  [[ "$output" == *"configured Node.js"* ]]
+  [[ "$output" != *"legacy fallback must not run"* ]]
+}
+
+@test "Windows check-inbox falls back when no Node can be resolved" {
+  unset AGMSG_NODE AGMSG_CODEX_NODE
+  export PATH="/usr/bin:/bin"
+  cat > "$SCRIPTS/whoami.sh" <<'EOF'
+#!/usr/bin/env bash
+echo 'not_joined=true'
+EOF
+  chmod +x "$SCRIPTS/whoami.sh"
+
+  run bash "$SCRIPTS/check-inbox.sh" codex "$TEST_SKILL_DIR/project"
+  [ "$status" -eq 0 ]
+}
+
+@test "Windows check-inbox falls back only for side-effect-free exit 78" {
+  write_fake_node
+  export FAKE_NODE_STATUS=78
+  # Make the legacy path terminate before storage or inbox side effects.
+  cat > "$SCRIPTS/whoami.sh" <<'EOF'
+#!/usr/bin/env bash
+echo 'not_joined=true'
+EOF
+  chmod +x "$SCRIPTS/whoami.sh"
+
+  run bash "$SCRIPTS/check-inbox.sh" codex "$TEST_SKILL_DIR/project"
+  [ "$status" -eq 0 ]
+  grep -q 'check-inbox.js codex' "$NODE_LOG"
+}
+
+@test "Windows check-inbox treats a non-78 Node failure as authoritative" {
+  write_fake_node
+  export FAKE_NODE_STATUS=9
+  cat > "$SCRIPTS/whoami.sh" <<'EOF'
+#!/usr/bin/env bash
+echo 'legacy fallback must not run' >&2
+exit 42
+EOF
+  chmod +x "$SCRIPTS/whoami.sh"
+
+  run bash "$SCRIPTS/check-inbox.sh" codex "$TEST_SKILL_DIR/project"
+  [ "$status" -eq 9 ]
+  [[ "$output" != *"legacy fallback must not run"* ]]
+}

--- a/tests/test_fast_dispatch.bats
+++ b/tests/test_fast_dispatch.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+setup() {
+  SCRIPTS="$(cd "$BATS_TEST_DIRNAME/../scripts" && pwd)"
+}
+
+@test "fast dispatch: non-Windows reports unavailable before side effects" {
+  run env OS=Linux bash -c 'source "'$SCRIPTS'/lib/fast-dispatch.sh"; agmsg_fast_try team demo'
+  [ "$status" -eq 78 ]
+  [ -z "$output" ]
+}
+
+@test "fast dispatch: missing explicit Node override is loud" {
+  run env OS=Windows_NT AGMSG_NODE=__agmsg_missing_node__ bash -c \
+    'source "'$SCRIPTS'/lib/fast-dispatch.sh"; agmsg_fast_try team demo'
+  [ "$status" -eq 127 ]
+  [[ "$output" == *"configured Node executable is not runnable"* ]]
+}
+
+@test "fast dispatch: unsupported native capability returns 78 without fallback inside Node" {
+  fake="$BATS_TEST_TMPDIR/node"
+  printf '#!/usr/bin/env bash\nexit 78\n' > "$fake"
+  chmod +x "$fake"
+  run env OS=Windows_NT AGMSG_NODE="$fake" bash -c \
+    'source "'$SCRIPTS'/lib/fast-dispatch.sh"; agmsg_fast_try team demo'
+  [ "$status" -eq 78 ]
+}


### PR DESCRIPTION
## What

Implements the proposal from #449. On Windows, the measured hot hook / CLI entries today
walk bash -> many short-lived processes (sed / tr / sqlite3 / identity walk),
which costs 40-80 s per invocation on a stock Git Bash install (measured
breakdown in #449). This PR adds first-class Node implementations for the hot
paths and dispatches to them where it pays:

1. **Identity resolver module** (`scripts/lib/identity-resolver.js`) — pure
   lookup: project + type -> identity candidates. Reused by every entry below;
   replaces the per-call `identities.sh` spawn (~70 s of a 77 s SessionStart).
2. **`check-inbox.js`** — the Stop-hook path (cooldown, actas-lock respect,
   unread select, read_at on displayed rows, block/status JSON) via
   `node:sqlite`.
3. **Fast CLI** (`agmsg-fast.js`) — `team` / `send` / `history` / `inbox` /
   `whoami`, byte-parity with the bash output contracts (raw-compared; see
   Behavior notes). Only commands with an existing upstream `.sh` entry are
   included — no upstream-unused code.
(Native SessionStart is deliberately NOT in this PR: open PR #305 already
reworks the Windows hook transport across the same files
(hooks-json/delivery/_delivery). Our measurements strongly support that
direction — the Git Bash entry alone costs 6-9 s, and our local native
SessionStart cut 77 s to ~1-2 s — so we would rather bring those numbers and
review energy to #305 than collide with it. If #305 stalls, a follow-up PR
can carry it.)

Dispatch contract (uniform): Node path only on Windows; each entry
(`check-inbox.js` and the fast CLI) probes `node:sqlite` and falls back to
the existing bash path **only** on a failed probe (exit 78), i.e. before any
side effect. The gating is
deliberately narrow: the bash paths remain the contract of record on every
platform, so the Node paths can be extended to other OSes later without this
PR taking that risk now. `node:sqlite` is still marked experimental upstream
in Node; because every native entry is probe-gated, an API change degrades to
the bash path instead of breaking anything. After
the Node implementation has started, a non-zero exit is loud and does NOT
fall back (a mid-run bash retry could double side effects such as a send
INSERT or read_at updates). Non-Windows platforms are untouched.

## Measured (Windows 11, Git Bash/MSYS2, Node v25)

| path | before | after |
|---|---|---|
| Stop hook check-inbox | 50-80 s per turn | 1.4-2.1 s |
| team / history / inbox / whoami | 8-90 s (timeouts common) | 0.3-1.6 s |
| send | 8.1 s | 0.47 s |

## Behavior notes

- Parity is enforced by 19 golden contract fixtures plus raw byte comparison
  of representative outputs (LF-normalized). `read_at` is set only on the
  rows actually displayed — this matches current main (check-inbox.sh /
  inbox.sh already restrict to displayed IDs), so no behavior divergence
  against the tree this PR targets.
- The package keeps its engines contract (node >= 14): the native paths are
  probe-gated, so an older Node simply keeps the bash path.
- `node:sqlite` needs Node >= 22.5; the capability probe (not a version
  compare) decides, and older/absent Node keeps the bash path.
- In restricted environments where MSYS2 cannot create shared memory
  (CreateFileMapping error 5), the native path is an availability fix, not
  just performance.

## Not in this PR

- No new IPC, no Node port of watcher/bridge internals, no change to the
  launcher's role-session/thread authority or the request-file contract,
  and — matching current behavior — the codex SessionStart still skips the
  post-request cleanup/GC half (upstream's codex plug already exits 0 after
  the request hand-off); other types' cleanup semantics are untouched.
- No fix for #371 (instance/liveness semantics) — this only removes the ppid
  walk from the hot paths. #415 is untouched here (our local install also has
  a native read-only `mode`/`pairs` fast path, but upstream has no wired entry
  for them today, so they are left out of this PR rather than shipped as
  unused code).
- The `config.sh` 3-level key defect found during this work will be filed as
  a separate issue (not yet filed; no existing upstream issue matches).

## Structure (patchless boundary, against main 3f87d60)

This PR does NOT port our local patch artifacts (full-file replacements /
anchor edits were derived against v1.1.6 and are not portable — e.g. the
request file grew from 5 local fields to the current 3-field contract, with
identity authority moved into the launcher). Instead it implements the same
behavior first-class in the current tree:

- `scripts/lib/identity-resolver.js` + `scripts/check-inbox.js` +
  `scripts/agmsg-fast.js` as new files (no runtime deps, `node:sqlite` only);
- OS/type-aware dispatch added where the entry points already branch:
  hook generation (`commandWindows`) and the `.sh` entry heads;
- launcher internals, role-session/thread authority, watcher, and bridge are
  NOT modified.

Minimal seam (5 change areas — 4 runtime files + tests — per on-tree verification against 3f87d60):

| file | change |
|---|---|
| `scripts/lib/identity-resolver.js` (new) | shared identity lookup |
| `scripts/check-inbox.js` (new) + `scripts/check-inbox.sh` head | Stop-hook Node path + Windows-only dispatch |
| `scripts/agmsg-fast.js` (new) + the 5 CLI `.sh` entry heads | team/send/history/inbox/whoami Node paths + dispatch |
| Node units + bats (Linux/macOS legs) | contract fixtures, dispatch exit-78 semantics |

No changes to hooks-json.sh / delivery.sh / _delivery.sh — zero overlap with
open PR #305 (Windows hook transport), by design.

Fallback semantics: diagnostics to stderr and read-only probing are allowed
before falling back (exit 78); once the Node implementation has started, a
non-zero exit is loud and never falls back — a bash retry could double side
effects (a second send INSERT, repeated read_at updates).

Validation gate (before submission): the implementation is built and verified
on an isolated clone of current main. Nothing is transplanted from our
v1.1.6-based local install. Per-leg time boxes (a run is terminated at 5 min
of silence or its cap, and switched to an alternative gate instead of
retried): Node units <= 3 min; real `commandWindows` PowerShell smokes <= 60 s
each; static checks / `bash -n` <= 1 min; full Bats on Linux/macOS (CI or an
equivalent environment) <= 10 min. Windows Bats suites are NOT part of the
gate — measured on this machine they cost 4-7 min for 3 cases (delivery
subset aborted at 15 min), which is the very spawn tax this PR addresses;
the Windows delivery behavior is covered by the PowerShell smokes instead,
and that substitution is recorded openly.
Compatibility gates: shared-path shell code is bash-3.2-safe (macOS ships
3.2); a fixture pins the POSIX `command` field byte-unchanged when
`commandWindows` is added; full Bats pass on the macOS leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
