### PR TITLE
Stage 2: synchronize composite read state

### DIFF
--- a/docs/adr/0008-stage-2-read-cursor-sync.md
+++ b/docs/adr/0008-stage-2-read-cursor-sync.md
@@ -53,6 +53,14 @@ The local team name and mutable member name are not remote identities. A roster
 name is associated durably with its immutable `member_id`; rename preserves the
 association, and retired names cannot be rebound as required by HTTP v1.
 
+The v1 bundled local drivers do not yet assign separate UUIDs to local teams or
+agents, so `local_team_identity` and `local_agent_identity` are their normalized
+names within the persistent driver generation. A successful local rename MUST
+atomically migrate the message projection, exact local reads, local frontier,
+and active member association to the new name in the same storage transaction.
+It MUST NOT create a fresh read layer or reuse a retired name. A future stable
+local UUID may replace this rename discipline without changing the remote key.
+
 The transport cursor, quarantine/decrypt state, composite read state, and the
 existing display/read receipt layer remain distinct. Receiving remote read
 state never imports, decrypts, displays, or marks a blocking quarantine entry as
@@ -287,10 +295,12 @@ other members. It MAY continue read-only pagination so incoming remote facts are
 not lost. It MUST NOT busy-retry the rejected update or discard exact facts.
 
 The error details include the offending `member_id`, per-member and team counts,
-and both limits. Operator remediation is to resolve and reprocess the oldest
-blocking quarantine hole so the frontier can absorb exact rows. A future
-explicit terminal/non-display disposition may provide another monotonic
-remediation, but silently skipping poison or resetting read state is forbidden.
+and both limits. If the oldest hole is a normal imported unread message, operator
+remediation is its ordinary authorized consume. If it is blocking quarantine,
+the cause must be resolved and the envelope reprocessed so the frontier can
+advance. A future explicit terminal/non-display disposition may provide another
+monotonic remediation, but silently skipping poison or resetting read state is
+forbidden.
 
 ### Explicitly out of scope
 

--- a/docs/adr/0008-stage-2-read-cursor-sync.md
+++ b/docs/adr/0008-stage-2-read-cursor-sync.md
@@ -219,6 +219,11 @@ is exactly `{"member_id":"...","kind":"exact","wire_id":"..."}`. The key is
 a comparison boundary and need not still exist when the next page is read.
 Unknown and duplicate fields are rejected under the common v1 JSON rules.
 
+HTTP v1 bounds a team roster to 1,000 active members and rejects larger
+operator provisioning documents atomically. The Stage-2 context therefore fits
+in one authenticated roster response; the read-state item stream is still
+paginated because each member can contribute bounded exact exceptions.
+
 In one transaction the server:
 
 1. locks the team row used by message and policy sequencing;
@@ -272,6 +277,14 @@ Member deletion is learned from the separately authenticated roster and retires
 that member's local remote overlay. Clients apply every page monotonically and
 restart at `page_after: null` on the next polling cycle.
 
+Member rename is a two-sided handshake because local storage and the remote
+operator roster cannot change atomically. The driver retains both the locally
+confirmed agent name and the latest authenticated roster name for each immutable
+member ID. While they differ, that member is durably blocked from emitting
+frontier or exact mutations; message and other-member synchronization continue.
+Either remote-first or local-first rename therefore fails closed until both
+names agree. A name mismatch never authorizes advancing a remote frontier.
+
 An empty update list is the read-only synchronization form. Retrying an update
 is idempotent. The engine sends local updates with the first page request and
 uses empty updates for subsequent pages. It validates response binding,
@@ -305,7 +318,11 @@ forbidden.
 ### Explicitly out of scope
 
 Stage 3 server-sent events and wake delivery are not launch requirements and are
-not part of this ADR. Stage 2 continues to use the existing polling loop.
+not part of this ADR. Stage 2 continues to use the existing polling loop. Stage
+3 should treat SSE and mobile wake as one team-scoped notification layer: a
+future iOS client may register an APNs device token, receive a Signal-style
+silent push, then pull, decrypt, and produce a local notification. The server
+still does not inspect recipients or message bodies.
 
 ## Consequences
 

--- a/docs/adr/0008-stage-2-read-cursor-sync.md
+++ b/docs/adr/0008-stage-2-read-cursor-sync.md
@@ -23,16 +23,16 @@ remote message.
 
 ### Store-owned composite frontier
 
-Each storage driver owns one composite read state per local `(team, agent)` and
-remote binding:
+Each storage driver composes two independently scoped layers:
 
-- `local_position`: the contiguous covered prefix of the driver's local message
-  order;
-- `remote_server_seq`: the contiguous covered prefix of the immutable remote
-  team stream;
-- exact local reads, keyed by stable local message ID until a wire mapping
-  exists; and
-- exact remote reads, keyed by wire ID.
+- the local layer, keyed by `(driver_generation, local_team_identity,
+  local_agent_identity)`, contains `local_position`, the contiguous covered
+  prefix of that store's message order, plus exact local reads keyed by stable
+  local message ID; and
+- the remote overlay, keyed by `(server_instance_id, remote_team_id,
+  protocol_version, member_id)`, contains `remote_server_seq`, the contiguous
+  covered prefix of that immutable remote stream, plus exact remote reads keyed
+  by wire ID.
 
 A projected message is read for an agent when at least one of these facts covers
 that message itself:
@@ -43,10 +43,14 @@ that message itself:
 3. its stable local ID or wire ID is in the corresponding exact-read set.
 
 The driver MUST NOT infer remote coverage for a local message without a durable
-wire/sequence mapping. The remote component and exact remote facts are scoped by
-`(server_instance_id, remote_team_id, protocol_version, member_id)`. The local
-team name and mutable member name are not remote identities. A roster name is
-associated durably with its immutable `member_id`; rename preserves the
+wire/sequence mapping. Local read progress survives remote binding replacement
+because it is not binding-scoped. A previous binding's remote overlay may remain
+durable for audit/recovery, but it is neither copied into nor consulted by a new
+binding. Coverage composes the one local layer with only the currently active
+binding/member overlay selected by authenticated sync configuration.
+
+The local team name and mutable member name are not remote identities. A roster
+name is associated durably with its immutable `member_id`; rename preserves the
 association, and retired names cannot be rebound as required by HTTP v1.
 
 The transport cursor, quarantine/decrypt state, composite read state, and the
@@ -96,8 +100,31 @@ scan advances it even if the scanned span contains no message for the agent.
 The monitor's former per-session watermark is no longer read authority.
 
 An upgrade from the pre-cursor model treats the existing backlog as consumed to
-avoid a full-history monitor storm. Fresh stores begin at zero. Messages that
-arrive after migration remain unread.
+avoid a full-history monitor storm. A fresh local layer begins at zero; its
+remote overlay follows the authenticated retention-floor rule below. Messages
+that arrive after migration remain unread.
+
+### Retention floor
+
+The authenticated `min_available_seq` is a safe lower bound for remote read
+state because the inclusive retained prefix can never again be transported or
+projected. For every member, the effective remote frontier is therefore
+`max(stored_remote_server_seq, min_available_seq)`. A new read-state row or a
+new device starts at the authenticated floor, not at zero when the floor is
+nonzero. This is a server fact, never a client guess.
+
+Prepare begins its contiguous proof at that effective frontier and requires
+durable outcomes only for later sequences. Apply stores the response floor and
+frontier atomically before using them for coverage. A stale response whose floor
+or current sequence contradicts the authenticated binding snapshot is terminal.
+
+Retention already locks the team sequencing row while it creates permanent
+tombstones, deletes the covered message prefix, and advances
+`min_available_seq`. In that same transaction it MUST max-merge every stored
+member frontier to the new floor and remove exact rows whose live `team_seq` or
+tombstone `original_seq` is now covered. Members without stored rows acquire the
+floor logically on response/bootstrap. A migration regression MUST cover a new
+device joining after a nonzero floor and continued compaction above that floor.
 
 ### Wire-ID promotion and atomicity
 
@@ -129,8 +156,10 @@ storage_sync_apply_read_state <local-team> <server-instance-id> <remote-team-id>
 ```
 
 Both operations use UTF-8 JSONL on stdin/stdout. Prepare receives one validated
-`sync_read_roster` record containing the current immutable member IDs and names.
-It emits zero or more `sync_read_frontier` and `sync_read_exact` records:
+`sync_read_context` record containing the current immutable member IDs and
+names, `min_available_seq`, and `current_seq` from one authenticated server
+snapshot. It first max-merges the remote overlay with the authenticated floor,
+then emits zero or more `sync_read_frontier` and `sync_read_exact` records:
 
 ```jsonl
 {"type":"sync_read_frontier","member_id":"018f...","server_seq":"42"}
@@ -144,10 +173,12 @@ to that member that local read state does not cover. Imported messages for other
 members are vacuously covered for this member. It emits exact wire reads above
 the safe prefix only when their mappings and server sequences are durable.
 
-Apply consumes a page of authenticated server `sync_read_frontier` and
-`sync_read_exact` records. In one transaction it max-merges frontiers, set-unions
-exact facts, projects coverage only onto already imported messages, compacts
-each local prefix, and removes only exact facts whose own durable mapping proves
+Apply consumes one authenticated `sync_read_snapshot` record containing the
+response `min_available_seq` and `current_seq`, followed by a page of server
+`sync_read_frontier` and `sync_read_exact` records. In one transaction it
+max-merges the floor and frontiers, set-unions exact facts, projects coverage
+only onto already imported messages, compacts each local prefix, and removes
+only exact facts whose own durable mapping proves
 `server_seq <= remote_server_seq`. It MUST NOT garbage-collect by wire ID alone.
 It never changes transport or decrypt/import progress.
 
@@ -174,7 +205,10 @@ binding/version rules. The strict request is:
 contains distinct canonical UUIDv4 wire IDs, and the request contains at most
 1,000 exact IDs in total. `server_seq` is a canonical signed-BIGINT decimal
 string. `page_limit` is an integer from 1 through 1,000. `page_after` is either
-null or the exact `{member_id, wire_id}` key returned by the previous response.
+null or the exact canonical item key returned by the previous response. A
+frontier key is exactly `{"member_id":"...","kind":"frontier"}`; an exact key
+is exactly `{"member_id":"...","kind":"exact","wire_id":"..."}`. The key is
+a comparison boundary and need not still exist when the next page is read.
 Unknown and duplicate fields are rejected under the common v1 JSON rules.
 
 In one transaction the server:
@@ -186,13 +220,16 @@ In one transaction the server:
 3. max-merges frontiers and set-unions exact reads;
 4. removes an exact row only when the resolved live message `team_seq` or
    tombstone `original_seq` is at or below that member's merged frontier;
-5. verifies the remaining exact set is at most 4,096 rows per member and 65,536
+5. max-merges every stored frontier to at least `min_available_seq` and removes
+   every exact row proven covered by the resulting effective frontier;
+6. verifies the remaining exact set is at most 4,096 rows per member and 65,536
    rows per team, failing the entire update atomically with `409
    read-state-limit-exceeded` otherwise; and
-6. reads the response from the same snapshot.
+7. reads the response page from the same snapshot.
 
-The response contains every active member frontier plus one lexicographically
-ordered page of unabsorbed exact rows:
+The response contains one bounded page from a single canonical item stream.
+Every active member contributes one `frontier` item, and every unabsorbed exact
+row contributes one `exact` item:
 
 ```json
 {
@@ -202,24 +239,30 @@ ordered page of unabsorbed exact rows:
   "team_name": "example-team",
   "min_available_seq": "0",
   "current_seq": "52",
-  "frontiers": [
-    {"member_id":"018f3f7e-0000-7000-8000-000000000010","server_seq":"42"}
+  "items": [
+    {"kind":"frontier","member_id":"018f3f7e-0000-7000-8000-000000000010","server_seq":"42"},
+    {"kind":"exact","member_id":"018f3f7e-0000-7000-8000-000000000010","wire_id":"550e8400-e29b-41d4-a716-446655440000"}
   ],
-  "exact_reads": [
-    {"member_id":"018f3f7e-0000-7000-8000-000000000010","wire_id":"550e8400-e29b-41d4-a716-446655440000"}
-  ],
-  "next_page_after": null,
-  "has_more": false
+  "next_page_after": {"member_id":"018f3f7e-0000-7000-8000-000000000010","kind":"exact","wire_id":"550e8400-e29b-41d4-a716-446655440000"},
+  "has_more": true
 }
 ```
 
-Frontiers are sorted by `member_id`; exact rows are sorted by
-`(member_id, wire_id)`. A member with no row has frontier zero. Pagination is
-keyset-based. Each request is an independent current snapshot: concurrent
-monotonic additions that sort before an in-progress page cursor may be observed
-on the next poll, while an exact row removed by GC is necessarily represented
-by the always-returned frontier. Clients therefore apply every page
-monotonically and restart at `page_after: null` on the next polling cycle.
+Items are sorted by `(member_id, kind_order, wire_id)`, where `frontier` sorts
+before `exact` and its wire component is empty. A member with no stored row has
+the effective frontier `min_available_seq`. `items.length` never exceeds
+`page_limit`; frontier cardinality is therefore bounded by the same pagination
+contract as exact state. `next_page_after` is null exactly when `has_more` is
+false, otherwise it is the final emitted item key.
+
+Pagination is keyset-based. Each request is an independent current snapshot:
+concurrent monotonic additions that sort before an in-progress page cursor may
+be observed on the next poll. An exact row removed by GC is necessarily covered
+by a frontier item; if that item was on an earlier page, the client has already
+applied it, and otherwise it appears in the current or next polling cycle.
+Member deletion is learned from the separately authenticated roster and retires
+that member's local remote overlay. Clients apply every page monotonically and
+restart at `page_after: null` on the next polling cycle.
 
 An empty update list is the read-only synchronization form. Retrying an update
 is idempotent. The engine sends local updates with the first page request and
@@ -229,7 +272,25 @@ canonical ordering, limits, and pagination before giving a page to the driver.
 The server schema is keyed by immutable `(team_id, member_id)` and
 `(team_id, member_id, wire_id)`. Removing a member cascades its read state.
 Member rename preserves it. A team credential may synchronize any active member
-in its own team; cross-team access is impossible.
+in its own team; cross-team access is impossible. Consequently, compromise of a
+team credential can destroy unread availability for every member by advancing
+their read state, in addition to reading and writing the team message stream.
+Stage 2 does not claim per-member credential isolation.
+
+### Limit failure and recovery
+
+`read-state-limit-exceeded` is definitive and non-retryable without a state
+change. The client retains every local frontier/exact fact, marks the identified
+member's read synchronization as blocked, excludes that member from subsequent
+mutation batches, and continues message push/pull plus read synchronization for
+other members. It MAY continue read-only pagination so incoming remote facts are
+not lost. It MUST NOT busy-retry the rejected update or discard exact facts.
+
+The error details include the offending `member_id`, per-member and team counts,
+and both limits. Operator remediation is to resolve and reprocess the oldest
+blocking quarantine hole so the frontier can absorb exact rows. A future
+explicit terminal/non-display disposition may provide another monotonic
+remediation, but silently skipping poison or resetting read state is forbidden.
 
 ### Explicitly out of scope
 

--- a/docs/adr/0008-stage-2-read-cursor-sync.md
+++ b/docs/adr/0008-stage-2-read-cursor-sync.md
@@ -1,0 +1,255 @@
+# ADR 0008: Stage-2 read-state synchronization
+
+**Status:** proposed (dogfood contract)
+**Date:** 2026-07-21
+**Deciders:** @fujibee
+
+## Context
+
+Stage 1 deliberately separates remote transport progress, decrypt/import state,
+and user or agent read state. The first two layers synchronize, but read state
+is still machine-local. A message read on one device can therefore be delivered
+again on another device.
+
+The older Phase-3 storage-cursor branch used one scalar local-log position per
+`(team, agent)`. That scalar cannot represent read state in a local-first remote
+store. For example, an unread, unacknowledged local message may be at local
+position 5 while a remote message at server sequence 10 is imported at local
+position 6. Translating a remote read frontier of 10 into local position 6 would
+hide the unread local message. Refusing to translate it would redeliver the
+remote message.
+
+## Decision
+
+### Store-owned composite frontier
+
+Each storage driver owns one composite read state per local `(team, agent)` and
+remote binding:
+
+- `local_position`: the contiguous covered prefix of the driver's local message
+  order;
+- `remote_server_seq`: the contiguous covered prefix of the immutable remote
+  team stream;
+- exact local reads, keyed by stable local message ID until a wire mapping
+  exists; and
+- exact remote reads, keyed by wire ID.
+
+A projected message is read for an agent when at least one of these facts covers
+that message itself:
+
+1. its local position is at or below `local_position`;
+2. it has a durable mapping whose `server_seq` is at or below
+   `remote_server_seq`; or
+3. its stable local ID or wire ID is in the corresponding exact-read set.
+
+The driver MUST NOT infer remote coverage for a local message without a durable
+wire/sequence mapping. The remote component and exact remote facts are scoped by
+`(server_instance_id, remote_team_id, protocol_version, member_id)`. The local
+team name and mutable member name are not remote identities. A roster name is
+associated durably with its immutable `member_id`; rename preserves the
+association, and retired names cannot be rebound as required by HTTP v1.
+
+The transport cursor, quarantine/decrypt state, composite read state, and the
+existing display/read receipt layer remain distinct. Receiving remote read
+state never imports, decrypts, displays, or marks a blocking quarantine entry as
+read. If reprocessing later imports that message and its sequence or wire ID is
+already covered, the local projection starts read.
+
+### Contiguous-prefix and exact-read rules
+
+Neither frontier may jump over an uncovered message on its own axis. Reading a
+later message creates an exact fact while the frontier remains immediately
+before the first hole. Once the hole becomes covered, the driver compacts the
+now-contiguous prefix and may discard absorbed synchronization exceptions.
+
+For example, if local position 5 is unread and position 6 is read, position 6 is
+an exact read and `local_position` remains 4. Reading position 5 permits a
+single transaction to advance the local frontier to 6 and compact the absorbed
+exact fact. The same prefix-plus-exceptions rule applies to `server_seq`.
+
+The merge algebra is deliberately monotonic:
+
+- remote frontiers merge with `max`;
+- exact wire reads merge with set union; and
+- local frontiers advance only inside their originating store through local
+  contiguous compaction and are never merged between machines.
+
+Read undo is not part of Stage 2. A future non-monotonic unread feature would
+need an explicit generation or epoch rather than weakening these rules.
+
+### Local consume contract
+
+The required storage ABI adds:
+
+```text
+storage_read_cursor_get <team> <agent>
+storage_read_cursor_consume <team> <agent> <delivery-cursor> [<id> ...]
+```
+
+`storage_read_cursor_get` returns the opaque local-position component.
+`storage_read_cursor_consume` records the exact displayed IDs and advances the
+local component only through a contiguous, successfully scanned delivery
+prefix. Drivers MUST max-merge it and MUST NOT move it backwards.
+
+Inbox, turn-hook, and monitor delivery use the same stored cursor. A successful
+scan advances it even if the scanned span contains no message for the agent.
+The monitor's former per-session watermark is no longer read authority.
+
+An upgrade from the pre-cursor model treats the existing backlog as consumed to
+avoid a full-history monitor storm. Fresh stores begin at zero. Messages that
+arrive after migration remain unread.
+
+### Wire-ID promotion and atomicity
+
+An exact read of a local-only message is initially keyed by its stable local
+message ID. Publishing a Stage-1 reservation or reconciling a pull mapping MUST,
+in the same storage transaction, promote or alias that read fact to the durable
+wire ID. The promoted fact becomes eligible for upload only after the mapping
+has a canonical acknowledged `server_seq`; a server MUST NOT be asked to store
+an exact read for a wire ID it does not yet know.
+
+Message import or mapping, exact-read promotion, frontier compaction, and any
+covered projection change that they enable are one local transaction. Durable
+covered rows and exact facts are written before either frontier advances. A
+crash rolls the whole transition back, and replay is idempotent.
+
+An exact remote fact may arrive before its message. The driver stores it by wire
+ID without fabricating a local projection. Import later applies the fact only
+after the envelope has passed policy/decrypt validation and has been durably
+projected.
+
+### Optional Stage-2 driver operations
+
+A Stage-1 SQLite driver may advertise the additional
+`stage2-read-state` capability and implement:
+
+```text
+storage_sync_prepare_read_state <local-team> <server-instance-id> <remote-team-id> <protocol-version>
+storage_sync_apply_read_state <local-team> <server-instance-id> <remote-team-id> <protocol-version>
+```
+
+Both operations use UTF-8 JSONL on stdin/stdout. Prepare receives one validated
+`sync_read_roster` record containing the current immutable member IDs and names.
+It emits zero or more `sync_read_frontier` and `sync_read_exact` records:
+
+```jsonl
+{"type":"sync_read_frontier","member_id":"018f...","server_seq":"42"}
+{"type":"sync_read_exact","member_id":"018f...","wire_id":"550e8400-e29b-41d4-a716-446655440000"}
+```
+
+For each member, prepare computes the largest safe contiguous remote prefix. It
+stops before any sequence whose envelope lacks a durable outcome, any blocking
+quarantine entry whose recipient is unknown, or any imported message addressed
+to that member that local read state does not cover. Imported messages for other
+members are vacuously covered for this member. It emits exact wire reads above
+the safe prefix only when their mappings and server sequences are durable.
+
+Apply consumes a page of authenticated server `sync_read_frontier` and
+`sync_read_exact` records. In one transaction it max-merges frontiers, set-unions
+exact facts, projects coverage only onto already imported messages, compacts
+each local prefix, and removes only exact facts whose own durable mapping proves
+`server_seq <= remote_server_seq`. It MUST NOT garbage-collect by wire ID alone.
+It never changes transport or decrypt/import progress.
+
+### HTTP operation
+
+`POST /v1/read-state/sync` uses the normal team credential and standard HTTP v1
+binding/version rules. The strict request is:
+
+```json
+{
+  "updates": [
+    {
+      "member_id": "018f3f7e-0000-7000-8000-000000000010",
+      "server_seq": "42",
+      "exact_wire_ids": ["550e8400-e29b-41d4-a716-446655440000"]
+    }
+  ],
+  "page_after": null,
+  "page_limit": 1000
+}
+```
+
+`updates` contains at most 1,000 distinct active members, each exact list
+contains distinct canonical UUIDv4 wire IDs, and the request contains at most
+1,000 exact IDs in total. `server_seq` is a canonical signed-BIGINT decimal
+string. `page_limit` is an integer from 1 through 1,000. `page_after` is either
+null or the exact `{member_id, wire_id}` key returned by the previous response.
+Unknown and duplicate fields are rejected under the common v1 JSON rules.
+
+In one transaction the server:
+
+1. locks the team row used by message and policy sequencing;
+2. validates that every member is active in the credential's team, every
+   frontier is at most `current_seq`, and every exact wire ID resolves to a live
+   message or permanent tombstone in that team;
+3. max-merges frontiers and set-unions exact reads;
+4. removes an exact row only when the resolved live message `team_seq` or
+   tombstone `original_seq` is at or below that member's merged frontier;
+5. verifies the remaining exact set is at most 4,096 rows per member and 65,536
+   rows per team, failing the entire update atomically with `409
+   read-state-limit-exceeded` otherwise; and
+6. reads the response from the same snapshot.
+
+The response contains every active member frontier plus one lexicographically
+ordered page of unabsorbed exact rows:
+
+```json
+{
+  "protocol_version": 1,
+  "server_instance_id": "018f3f7e-0000-7000-8000-000000000000",
+  "team_id": "018f3f7e-0000-7000-8000-000000000001",
+  "team_name": "example-team",
+  "min_available_seq": "0",
+  "current_seq": "52",
+  "frontiers": [
+    {"member_id":"018f3f7e-0000-7000-8000-000000000010","server_seq":"42"}
+  ],
+  "exact_reads": [
+    {"member_id":"018f3f7e-0000-7000-8000-000000000010","wire_id":"550e8400-e29b-41d4-a716-446655440000"}
+  ],
+  "next_page_after": null,
+  "has_more": false
+}
+```
+
+Frontiers are sorted by `member_id`; exact rows are sorted by
+`(member_id, wire_id)`. A member with no row has frontier zero. Pagination is
+keyset-based. Each request is an independent current snapshot: concurrent
+monotonic additions that sort before an in-progress page cursor may be observed
+on the next poll, while an exact row removed by GC is necessarily represented
+by the always-returned frontier. Clients therefore apply every page
+monotonically and restart at `page_after: null` on the next polling cycle.
+
+An empty update list is the read-only synchronization form. Retrying an update
+is idempotent. The engine sends local updates with the first page request and
+uses empty updates for subsequent pages. It validates response binding,
+canonical ordering, limits, and pagination before giving a page to the driver.
+
+The server schema is keyed by immutable `(team_id, member_id)` and
+`(team_id, member_id, wire_id)`. Removing a member cascades its read state.
+Member rename preserves it. A team credential may synchronize any active member
+in its own team; cross-team access is impossible.
+
+### Explicitly out of scope
+
+Stage 3 server-sent events and wake delivery are not launch requirements and are
+not part of this ADR. Stage 2 continues to use the existing polling loop.
+
+## Consequences
+
+- A read on one device converges monotonically on every device.
+- Local-first messages are never hidden merely because a later remote sequence
+  was read elsewhere.
+- Out-of-order read state is bounded, paginated, and compacted only from proven
+  wire-to-sequence mappings.
+- The server stores member IDs, wire IDs, and numeric frontiers, but still
+  cannot see sender, recipient, body, or client timestamps.
+- Cursor synchronization cannot advance through an undecryptable envelope,
+  because its recipient is unknown. Transport may continue independently.
+
+## References
+
+- [ADR 0003: storage-axis ABI](0003-storage-axis-driver-abi-and-scope.md)
+- [ADR 0005: Stage-1 remote sync](0005-stage-1-remote-sync.md)
+- [HTTP API v1](../../server/spec/v1.md)

--- a/docs/adr/0008-stage-2-read-cursor-sync.md
+++ b/docs/adr/0008-stage-2-read-cursor-sync.md
@@ -166,7 +166,9 @@ storage_sync_apply_read_state <local-team> <server-instance-id> <remote-team-id>
 Both operations use UTF-8 JSONL on stdin/stdout. Prepare receives one validated
 `sync_read_context` record containing the current immutable member IDs and
 names, `min_available_seq`, and `current_seq` from one authenticated server
-snapshot. It first max-merges the remote overlay with the authenticated floor,
+snapshot, plus `local_agents` from the local team registry as a separate
+authority. Message sender/recipient strings are never roster evidence. It first
+max-merges the remote overlay with the authenticated floor,
 then emits zero or more `sync_read_frontier` and `sync_read_exact` records:
 
 ```jsonl

--- a/docs/adr/0008-stage-2-read-cursor-sync.md
+++ b/docs/adr/0008-stage-2-read-cursor-sync.md
@@ -308,10 +308,15 @@ other members. It MAY continue read-only pagination so incoming remote facts are
 not lost. It MUST NOT busy-retry the rejected update or discard exact facts.
 
 The error details include the offending `member_id`, per-member and team counts,
-and both limits. If the oldest hole is a normal imported unread message, operator
+and both limits. For a team-wide overflow the member is selected from the
+current request's newly added exact facts, not merely from the largest existing
+set, so iterative isolation converges. If the oldest hole is a normal imported unread message, operator
 remediation is its ordinary authorized consume. If it is blocking quarantine,
 the cause must be resolved and the envelope reprocessed so the frontier can
-advance. A future explicit terminal/non-display disposition may provide another
+advance. The durable block is cleared only by the explicit operator command
+`remote-sync.sh unblock-read --team NAME --member-id UUID`; the following
+cycle either succeeds after remediation or durably blocks the member again. A
+future explicit terminal/non-display disposition may provide another
 monotonic remediation, but silently skipping poison or resetting read state is
 forbidden.
 

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -71,7 +71,7 @@ Directives are advisory: the host agent decides whether to surface them to the u
 
 The storage axis is **messages only**: the durable message log and its read /
 replay state. The team registry (`teams/<team>/config.json`) and run-state
-(pidfiles, the per-session delivery cursor, actas locks, ready sentinels) are
+(pidfiles, actas locks, ready sentinels) are
 **not** part of this contract — they stay file-based and form a separate axis
 (see [ADR 0003](../adr/0003-storage-axis-driver-abi-and-scope.md)). A storage driver
 must implement the *entire* contract below: "this driver does only messages,
@@ -88,6 +88,8 @@ storage_store_exists
 storage_send <team> <from> <to> <body>
 storage_list_unread <team> <agent> [--limit N]
 storage_mark_read_batch <team> <agent> <id> [<id> ...]
+storage_read_cursor_get <team> <agent>
+storage_read_cursor_consume <team> <agent> <delivery-cursor> [<id> ...]
 storage_watch_tip <team:agent> [<team:agent> ...]
 storage_watch_after <cursor> <team:agent> [<team:agent> ...]
 storage_history <team> [agent] [--limit N]
@@ -120,11 +122,13 @@ by cross-referencing `storage_list_unread` for the relevant recipient rather tha
 from the history record itself.
 
 **stdout framing.** The **control ops** — `storage_check`, `storage_init`,
-`storage_mark_read_batch`, `storage_compact` — **must** use the §1.4 convention:
+`storage_mark_read_batch`, `storage_read_cursor_consume`, `storage_compact` —
+**must** use the §1.4 convention:
 a status name (`ok` / `missing_deps` / `runtime_error` / …) on the last stdout
 line, with the matching exit code. The **record-returning ops** —
-`storage_send`, `storage_list_unread`, `storage_history`, `storage_watch_tip`,
-`storage_watch_after` — write **data only** to stdout (JSONL records, or a bare
+`storage_send`, `storage_list_unread`, `storage_read_cursor_get`,
+`storage_history`, `storage_watch_tip`, `storage_watch_after` — write **data
+only** to stdout (JSONL records, or a bare
 id / cursor token; one record per line) and signal outcome with the **exit code**
 alone: `0` on success, non-zero with a message on **stderr** on failure. They
 never emit a §1.4 status name to stdout, so a status word can never be misread as
@@ -137,14 +141,14 @@ name, which a metadata consumer would otherwise misread.
 
 ### 2.2 Delivery cursor (watch / replay)
 
-Live delivery (`watch.sh`, `check-inbox.sh`) resumes from a checkpoint instead of
-re-reading the whole log. That checkpoint is an **opaque, driver-issued cursor**
-— a position in the driver's global message order. Core treats it as an opaque
-string: it persists the latest cursor (per session — the successor to the old
-`watch.<sid>.watermark` file) and passes it back unchanged. **Core never parses,
-compares, or orders cursors.** This is what lets one contract serve sqlite
-integer ids, UUIDv7, Redis stream ids, and JSONL byte offsets — the
-`id > watermark` integer assumption is removed from core entirely.
+Live delivery (`watch.sh`, `check-inbox.sh`, and `inbox.sh`) resumes from the
+store-owned read frontier instead of re-reading the whole log. Its local
+component is an **opaque, driver-issued cursor** in the driver's global message
+order, persisted per `(team, agent)`. Core reads it with
+`storage_read_cursor_get`, passes it unchanged to `storage_watch_after`, and
+commits a successfully displayed scan with `storage_read_cursor_consume`.
+**Core never parses, compares, or orders cursors.** This lets one contract serve
+sqlite integer positions, Redis stream IDs, and JSONL logical ordinals.
 
 The cursor is opaque to core but constrained for transport: it must be a
 **single-line, whitespace-free, printable token** that survives being written to
@@ -155,9 +159,7 @@ characters (e.g. a JSONL byte offset bundled with metadata) must encode it
 (base64url or similar) into a single safe token.
 
 - `storage_watch_tip <pairs...>` — print the cursor for "now" (the current tip of
-  the global order) as a single bare line. A fresh watcher starts here, so it
-  delivers only messages that arrive *after* it attached (no history replay; the
-  no-arg inbox check covers the backlog).
+  the global order) as a single bare line.
 - `storage_watch_after <cursor> <pairs...>` — print, as JSONL and in delivery
   order, every `message_sent` after `<cursor>` addressed to one of the
   subscription pairs; then print a final cursor record
@@ -169,6 +171,20 @@ characters (e.g. a JSONL byte offset bundled with metadata) must encode it
   the same span on every poll. Poll-once: it returns what is currently available
   and exits — core loops on its own interval; a streaming backend may implement
   it as one non-blocking drain.
+
+- `storage_read_cursor_get <team> <agent>` — print the local-position component
+  for the pair, defaulting to the driver's zero cursor.
+- `storage_read_cursor_consume <team> <agent> <cursor> [ids...]` — atomically
+  record the exact displayed IDs, then max-merge the pair's local frontier only
+  through the contiguous covered prefix ending no later than `<cursor>`. A
+  missing unread message is a hard gap: a later exact read is retained as an
+  exception and MUST NOT move the frontier across that gap.
+
+The same pair cursor is shared by inbox and monitor delivery and survives
+session termination. A successful empty scan may advance across
+off-subscription traffic. A crash before consume re-delivers; a crash after the
+atomic consume does not. A one-time driver migration treats pre-cursor backlog
+as consumed to avoid a full-history monitor storm; new stores start at zero.
 
 Each `<pair>` is `<team>:<agent>`. Team and agent names cannot contain `:` (the
 name rules enforce this); a driver may additionally reject a pair it cannot split
@@ -186,11 +202,12 @@ storage axis (team membership does not; see the §2 intro):
 ```
 
 `storage_list_unread <team> <agent>` returns the `message_sent` events addressed
-to `<agent>` in `<team>` that have no matching `message_read` for that same
-`(team, agent)`. Read-marking is **recipient-scoped**: a `message_read` names the
-`(team, agent)` that read the message, so marking one recipient's copy never
-affects another's, and re-marking an already-read id is **idempotent** (a no-op,
-or a duplicate event the projection collapses).
+to `<agent>` in `<team>` that are not covered by the pair's contiguous read
+frontier or an exact `message_read` exception. Read-marking is
+**recipient-scoped**: a `message_read` names the `(team, agent)` that read the
+message, so marking one recipient's copy never affects another's, and re-marking
+an already-read id is **idempotent**. The legacy mutable `messages.read_at`
+field is compatibility/audit input only; new read progress never mutates it.
 
 **Schema version.** This is **event-log schema v1**. The two event types above
 and their fields are the v1 contract. Forward compatibility is a hard rule, not a
@@ -314,6 +331,24 @@ independent. Reprocess emits blocking quarantine records for explicit policy/key
 reevaluation without rewinding transport. The complete framing, record schemas,
 crash boundaries, and future reserved operation names are defined by
 [ADR 0005](../adr/0005-stage-1-remote-sync.md).
+
+The independent Stage-2 extension from
+[ADR 0008](../adr/0008-stage-2-read-cursor-sync.md) is advertised as
+`capabilities=stage1-sync,stage2-read-state` and adds:
+
+```text
+storage_sync_prepare_read_state <local-team> <server-instance-id> <remote-team-id> <protocol-version>
+storage_sync_apply_read_state <local-team> <server-instance-id> <remote-team-id> <protocol-version>
+```
+
+Prepare exports a safe
+contiguous remote `server_seq` frontier plus out-of-order exact `wire_id` reads;
+apply max-merges the frontier and set-unions exact reads. Local-only exact reads
+are promoted from stable local ID to wire ID in the same transaction that
+publishes or reconciles the mapping. Neither operation may change transport or
+decrypt/import progress. Exact remote state is bounded and paginated, and may
+be garbage-collected only after a durable mapping proves that its own sequence
+is covered by the merged remote frontier.
 
 ## 3. CLI mapping
 

--- a/scripts/drivers/storage/jsonl-read-cursor.jq
+++ b/scripts/drivers/storage/jsonl-read-cursor.jq
@@ -1,0 +1,24 @@
+reduce .[] as $event (
+  {sent: 0, addressed: [], read: {}};
+  if $event.type == "message_sent" then
+    .sent += 1
+    | if $event.team == $team and $event.to == $agent then
+        .addressed += [{position: .sent, id: $event.id}]
+      else . end
+  elif $event.type == "message_read"
+       and $event.team == $team
+       and $event.agent == $agent then
+    .read[$event.msg_id] = true
+  else . end
+)
+| . as $state
+| ([
+    $state.addressed[]
+    | select(
+        .position > $current
+        and .position <= $target
+        and (($state.read[.id] // false) | not)
+      )
+    | .position
+  ] | min) as $gap
+| if $gap == null then $target else ($gap - 1) end

--- a/scripts/drivers/storage/jsonl-unread.duckdb.sql
+++ b/scripts/drivers/storage/jsonl-unread.duckdb.sql
@@ -6,15 +6,18 @@
 -- (all already SQL-escaped — apostrophes doubled — before substitution).
 -- Columns are read as explicit VARCHAR, never read_json_auto, whose type
 -- inference would parse `at` as a TIMESTAMP and drop the canonical ISO-8601 T/Z.
+WITH log AS (
+  SELECT * FROM read_json('__LG__', columns={type:'VARCHAR', id:'VARCHAR',
+        team:'VARCHAR', "from":'VARCHAR', "to":'VARCHAR', body:'VARCHAR',
+        at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited')
+), sent AS (
+  SELECT *, row_number() OVER () AS position FROM log WHERE type='message_sent'
+)
 SELECT to_json(struct_pack(type := 'message_sent', id := s.id, team := s.team,
          "from" := s."from", "to" := s."to", body := s.body, at := s.at))
-FROM (SELECT * FROM read_json('__LG__', columns={type:'VARCHAR', id:'VARCHAR',
-        team:'VARCHAR', "from":'VARCHAR', "to":'VARCHAR', body:'VARCHAR',
-        at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited')
-      WHERE type='message_sent' AND team='__TL__' AND "to"='__AL__') s
-WHERE s.id NOT IN (
-  SELECT msg_id FROM read_json('__LG__', columns={type:'VARCHAR', id:'VARCHAR',
-        team:'VARCHAR', "from":'VARCHAR', "to":'VARCHAR', body:'VARCHAR',
-        at:'VARCHAR', msg_id:'VARCHAR', agent:'VARCHAR'}, format='newline_delimited')
+FROM sent s
+WHERE s.position > __CUR__ AND s.team='__TL__' AND s."to"='__AL__'
+AND s.id NOT IN (
+  SELECT msg_id FROM log
   WHERE type='message_read' AND team='__TL__' AND agent='__AL__')
-ORDER BY s.at, s.id;
+ORDER BY s.position;

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -229,10 +229,21 @@ _jsonl_read_cursor_write_locked() {
 
 _jsonl_read_cursor_consume_locked() {
   local team="$1" agent="$2" target="$3"; shift 3
-  local current safe log
+  local current safe log tip normalized
   current=$(storage_read_cursor_get "$team" "$agent") || return 1
   _jsonl_mark "$team" "$agent" "$@" || return 1
   log="$(_jsonl_log)"
+  tip=$(jq -s '[.[] | select(.type=="message_sent")] | length' "$log") || return 1
+  # Cap against the same locked log snapshot. Compare canonical decimal strings
+  # instead of shell integers so a maliciously huge target cannot overflow the
+  # host shell before it is reduced to the real tip.
+  normalized=$(printf '%s' "$target" | sed 's/^0*//'); [ -n "$normalized" ] || normalized=0
+  target="$normalized"
+  if [ "${#target}" -gt "${#tip}" ] || {
+    [ "${#target}" -eq "${#tip}" ] && [[ "$target" > "$tip" ]];
+  }; then
+    target="$tip"
+  fi
   safe=$(jq -r --arg team "$team" --arg agent "$agent" --argjson current "$current" \
     --argjson target "$target" -s -f "$_JSONL_DRIVER_DIR/jsonl-read-cursor.jq" "$log") || return 1
   [ "$safe" -ge "$current" ] || safe="$current"
@@ -292,11 +303,17 @@ storage_watch_after() {
   # One file read = one snapshot: the trailing cursor (total message_sent count)
   # is computed from the same scan, so it never runs ahead of the rows returned.
   jq -c --argjson cursor "$cursor" --argjson pairs "$pairs_json" -s '
-    [.[] | select(.type=="message_sent")] as $sent
+    . as $events
+    | (reduce $events[] as $event ({};
+        if $event.type=="message_read" then
+          .[([$event.team,$event.agent,$event.msg_id] | tojson)] = true
+        else . end)) as $read
+    | [$events[] | select(.type=="message_sent")] as $sent
     | ($sent
         | to_entries
         | map(select((.key >= $cursor)
-              and ((.value.team + ":" + .value.to) as $p | ($pairs | index($p)) != null)))
+              and ((.value.team + ":" + .value.to) as $p | ($pairs | index($p)) != null)
+              and (($read[[.value.team,.value.to,.value.id] | tojson] // false) | not)))
         | .[].value
         | {type:"message_sent",id:.id,team:.team,from:.from,to:.to,body:.body,at:.at}),
       {type:"cursor",cursor:(($sent | length) | tostring)}

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -361,6 +361,77 @@ storage_compact() {
   _jsonl_with_lock _jsonl_compact_do || { echo runtime_error; return 13; }
   echo ok
 }
+
+# Internal rename hooks keep the store-owned cursor beside its rewritten event
+# identity. The cursor file briefly contains both keys before the log flips, so
+# a crash can only leave a redundant cursor key, never a message with no usable
+# read frontier.
+_jsonl_rename_agent_locked() {
+  local team="$1" old="$2" new="$3" log cursors log_tmp dual_tmp clean_tmp
+  log="$(_jsonl_log)"; cursors="$(_jsonl_read_cursors)"
+  log_tmp=$(mktemp "${log}.rename.XXXXXX") || return 1
+  dual_tmp=$(mktemp "${cursors}.rename-dual.XXXXXX") || { rm -f "$log_tmp"; return 1; }
+  clean_tmp=$(mktemp "${cursors}.rename-clean.XXXXXX") || {
+    rm -f "$log_tmp" "$dual_tmp"; return 1;
+  }
+  jq -c --arg team "$team" --arg old "$old" --arg new "$new" '
+    if .team != $team then .
+    elif .type == "message_sent" then
+      (if .from == $old then .from = $new else . end) |
+      (if .to == $old then .to = $new else . end)
+    elif .type == "message_read" and .agent == $old then .agent = $new
+    else . end' "$log" > "$log_tmp" || {
+      rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1;
+    }
+  awk -F '\t' -v OFS='\t' -v team="$team" -v old="$old" -v new="$new" '
+    $1==team && $2==old { print; $2=new; print; next } { print }' "$cursors" > "$dual_tmp" || {
+      rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1;
+    }
+  awk -F '\t' -v OFS='\t' -v team="$team" -v old="$old" '
+    !($1==team && $2==old) { print }' "$dual_tmp" > "$clean_tmp" || {
+      rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1;
+    }
+  mv "$dual_tmp" "$cursors" && mv "$log_tmp" "$log" && mv "$clean_tmp" "$cursors" || {
+    rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1;
+  }
+}
+
+storage_rename_agent() {
+  _jsonl_init_file || { echo runtime_error; return 13; }
+  _jsonl_with_lock _jsonl_rename_agent_locked "$1" "$2" "$3" || {
+    echo runtime_error; return 13;
+  }
+  echo ok
+}
+
+_jsonl_rename_team_locked() {
+  local old="$1" new="$2" log cursors log_tmp dual_tmp clean_tmp
+  log="$(_jsonl_log)"; cursors="$(_jsonl_read_cursors)"
+  log_tmp=$(mktemp "${log}.rename.XXXXXX") || return 1
+  dual_tmp=$(mktemp "${cursors}.rename-dual.XXXXXX") || { rm -f "$log_tmp"; return 1; }
+  clean_tmp=$(mktemp "${cursors}.rename-clean.XXXXXX") || {
+    rm -f "$log_tmp" "$dual_tmp"; return 1;
+  }
+  jq -c --arg old "$old" --arg new "$new" 'if .team == $old then .team = $new else . end' \
+    "$log" > "$log_tmp" || { rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1; }
+  awk -F '\t' -v OFS='\t' -v old="$old" -v new="$new" '
+    $1==old { print; $1=new; print; next } { print }' "$cursors" > "$dual_tmp" || {
+      rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1;
+    }
+  awk -F '\t' -v OFS='\t' -v old="$old" '$1!=old { print }' \
+    "$dual_tmp" > "$clean_tmp" || { rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1; }
+  mv "$dual_tmp" "$cursors" && mv "$log_tmp" "$log" && mv "$clean_tmp" "$cursors" || {
+    rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1;
+  }
+}
+
+storage_rename_team() {
+  _jsonl_init_file || { echo runtime_error; return 13; }
+  _jsonl_with_lock _jsonl_rename_team_locked "$1" "$2" || {
+    echo runtime_error; return 13;
+  }
+  echo ok
+}
 _jsonl_compact_do() {
   local log tmp; log="$(_jsonl_log)"; tmp="$log.compact.$$"
   # Keep every message_sent in order; collapse duplicate message_read for the same

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -30,11 +30,45 @@ _JSONL_DRIVER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)
 
 _jsonl_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 _jsonl_log() { printf '%s\n' "$(dirname "$(agmsg_db_path)")/events.jsonl"; }
+_jsonl_read_cursors() {
+  local log; log="$(_jsonl_log)"
+  printf '%s\n' "$(dirname "$log")/read-cursors.tsv"
+}
+_jsonl_read_cursor_marker() {
+  local log; log="$(_jsonl_log)"
+  printf '%s\n' "$(dirname "$log")/.read-cursor-v1"
+}
 
 _jsonl_init_file() {
   local log; log="$(_jsonl_log)"
   mkdir -p "$(dirname "$log")" 2>/dev/null || true
   [ -f "$log" ] || : > "$log" 2>/dev/null || true
+  _jsonl_read_cursor_migrate || return 1
+}
+
+# One-time Phase-3 adoption. Existing message history is treated as consumed so
+# upgrading a monitor-heavy installation cannot replay its entire log. An empty
+# fresh log writes an empty cursor file and starts naturally at zero.
+_jsonl_read_cursor_migrate() {
+  local marker lock i=0 log cursors tmp tip
+  marker="$(_jsonl_read_cursor_marker)"; [ -f "$marker" ] && return 0
+  lock="$marker.lock"
+  until mkdir "$lock" 2>/dev/null; do
+    [ -f "$marker" ] && return 0
+    i=$((i + 1)); [ "$i" -ge 1000 ] && return 1
+    sleep 0.01
+  done
+  if [ -f "$marker" ]; then rmdir "$lock" 2>/dev/null || true; return 0; fi
+  log="$(_jsonl_log)"; cursors="$(_jsonl_read_cursors)"
+  tmp=$(mktemp "${cursors}.tmp.XXXXXX") || { rmdir "$lock" 2>/dev/null || true; return 1; }
+  tip=$(jq -s '[.[] | select(.type=="message_sent")] | length' "$log") || {
+    rm -f "$tmp"; rmdir "$lock" 2>/dev/null || true; return 1;
+  }
+  jq -r --argjson tip "$tip" -s '[.[] | select(.type=="message_sent") | [.team,.to]] | unique[] | @tsv + "\t" + ($tip|tostring)' "$log" > "$tmp" || { rm -f "$tmp"; rmdir "$lock" 2>/dev/null || true; return 1; }
+  mv "$tmp" "$cursors" || { rm -f "$tmp"; rmdir "$lock" 2>/dev/null || true; return 1; }
+  : > "$marker.tmp.$$" || { rmdir "$lock" 2>/dev/null || true; return 1; }
+  mv "$marker.tmp.$$" "$marker" || { rm -f "$marker.tmp.$$"; rmdir "$lock" 2>/dev/null || true; return 1; }
+  rmdir "$lock" 2>/dev/null || true
 }
 
 # UUIDv7 (§2.5) — python3 preferred, /dev/urandom shell fallback. No counter file.
@@ -137,18 +171,12 @@ storage_list_unread() {
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
   _jsonl_init_file
-  local log out; log="$(_jsonl_log)"
+  local log out cursor; log="$(_jsonl_log)"
+  cursor=$(storage_read_cursor_get "$team" "$agent") || return 1
   if _jsonl_use_duckdb; then
-    out="$(_jsonl_unread_duckdb "$team" "$agent" "$log")" || return 1
+    out="$(_jsonl_unread_duckdb "$team" "$agent" "$log" "$cursor")" || return 1
   else
-    out="$(jq -c --arg team "$team" --arg agent "$agent" -s '
-      (reduce .[] as $e ({};
-        if $e.type=="message_read" and $e.team==$team and $e.agent==$agent
-        then .[$e.msg_id]=true else . end)) as $read
-      | .[]
-      | select(.type=="message_sent" and .team==$team and .to==$agent and ($read[.id] | not))
-      | {type:"message_sent",id:.id,team:.team,from:.from,to:.to,body:.body,at:.at}
-    ' "$log")" || return 1
+    out="$(jq -c --arg team "$team" --arg agent "$agent" --argjson cursor "$cursor" -s '(reduce .[] as $e ({}; if $e.type=="message_read" and $e.team==$team and $e.agent==$agent then .[$e.msg_id]=true else . end)) as $read | [.[] | select(.type=="message_sent")] | to_entries[] | select((.key + 1) > $cursor and .value.team==$team and .value.to==$agent and ($read[.value.id] | not)) | .value | {type:"message_sent",id:.id,team:.team,from:.from,to:.to,body:.body,at:.at}' "$log")" || return 1
   fi
   [ -n "$out" ] || return 0
   if [ -n "$limit" ]; then printf '%s\n' "$out" | head -n "$limit"; else printf '%s\n' "$out"; fi
@@ -159,7 +187,7 @@ storage_list_unread() {
 # read_json_auto, whose type inference would parse `at` as a TIMESTAMP and re-emit
 # it as "Y-M-D H:M:S", losing the canonical ISO-8601 "...T...Z" the jq path keeps.
 _jsonl_unread_duckdb() {
-  local team="$1" agent="$2" log="$3" tl al lg sql tpl
+  local team="$1" agent="$2" log="$3" cursor="$4" tl al lg sql tpl
   # SQL-escape every value spliced into the query (team/agent are not apostrophe-
   # free per validate.sh, and the path may contain one) so a legal team/agent that
   # the jq path handles can't break — or silently misbehave on — the duckdb path.
@@ -176,17 +204,55 @@ _jsonl_unread_duckdb() {
   sql="${sql//__LG__/$lg}"
   sql="${sql//__TL__/$tl}"
   sql="${sql//__AL__/$al}"
+  sql="${sql//__CUR__/$cursor}"
   printf '%s\n' "$sql" | duckdb -noheader -list 2>/dev/null
+}
+
+storage_read_cursor_get() {
+  local team="$1" agent="$2" f
+  _jsonl_init_file || return 1
+  f="$(_jsonl_read_cursors)"
+  [ -f "$f" ] || { printf '0\n'; return 0; }
+  awk -F'\t' -v t="$team" -v a="$agent" '$1==t && $2==a {p=$3}
+    END { print (p=="" ? 0 : p) }' "$f"
+}
+
+_jsonl_read_cursor_write_locked() {
+  local team="$1" agent="$2" pos="$3" f tmp
+  f="$(_jsonl_read_cursors)"; tmp=$(mktemp "${f}.tmp.XXXXXX") || return 1
+  { [ -f "$f" ] && awk -F'\t' -v t="$team" -v a="$agent" '!($1==t && $2==a)' "$f"
+    printf '%s\t%s\t%s\n' "$team" "$agent" "$pos"; } > "$tmp" || {
+      rm -f "$tmp"; return 1;
+    }
+  mv "$tmp" "$f"
+}
+
+_jsonl_read_cursor_consume_locked() {
+  local team="$1" agent="$2" target="$3"; shift 3
+  local current safe log
+  current=$(storage_read_cursor_get "$team" "$agent") || return 1
+  _jsonl_mark "$team" "$agent" "$@" || return 1
+  log="$(_jsonl_log)"
+  safe=$(jq -r --arg team "$team" --arg agent "$agent" --argjson current "$current" \
+    --argjson target "$target" -s -f "$_JSONL_DRIVER_DIR/jsonl-read-cursor.jq" "$log") || return 1
+  [ "$safe" -ge "$current" ] || safe="$current"
+  _jsonl_read_cursor_write_locked "$team" "$agent" "$safe"
+}
+
+storage_read_cursor_consume() {
+  local team="$1" agent="$2" target="$3"; shift 3
+  case "$target" in ''|*[!0-9]*) echo runtime_error; return 13 ;; esac
+  _jsonl_init_file || { echo runtime_error; return 13; }
+  _jsonl_with_lock _jsonl_read_cursor_consume_locked "$team" "$agent" "$target" "$@" \
+    || { echo runtime_error; return 13; }
+  echo ok
 }
 
 storage_mark_read_batch() {
   local team="$1" agent="$2"; shift 2
-  _jsonl_init_file
-  # Propagate a lock-acquire / write failure as a §1.4 control-op error — never
-  # swallow it as ok, or inbox/check-inbox would treat unread as read with no
-  # message_read written (re-delivery loop / stale wake on the read hot path).
-  _jsonl_with_lock _jsonl_mark "$team" "$agent" "$@" || { echo runtime_error; return 13; }
-  echo ok
+  [ $# -gt 0 ] || { echo ok; return 0; }
+  local tip; tip=$(storage_watch_tip "$team:$agent") || { echo runtime_error; return 13; }
+  storage_read_cursor_consume "$team" "$agent" "$tip" "$@"
 }
 _jsonl_mark() {
   local team="$1" agent="$2"; shift 2

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -664,7 +664,8 @@ storage_sync_prepare_read_state() {
   local team="$1" server="$2" remote="$3" protocol="$4"
   _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
   _sqlite_sync_schema || return $?
-  local generation db tl context floor current members count values="" member id name insert_members=""
+  local generation db tl context floor current members local_agents count values="" local_values=""
+  local member id name agent insert_members="" insert_local_agents=""
   generation=$(_sqlite_sync_generation) || return 13
   db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"
   _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || return 13
@@ -672,6 +673,9 @@ storage_sync_prepare_read_state() {
   [ "$(printf '%s\n' "$context" | jq -r '
     select(.type=="sync_read_context" and (.min_available_seq|type)=="string" and
       (.current_seq|type)=="string" and (.members|type)=="array" and
+      (.local_agents|type)=="array" and (.local_agents|length)<=1000 and
+      ((.local_agents|unique|length)==(.local_agents|length)) and all(.local_agents[];
+        (type=="string") and length>0) and
       (.members|length)<=1000 and all(.members[];
         ((.member_id|type)=="string") and ((.name|type)=="string") and (.name|length)>0)) | "ok"' \
       2>/dev/null)" = ok ] || return 13
@@ -693,17 +697,25 @@ storage_sync_prepare_read_state() {
   done <<EOF
 $members
 EOF
+  local_agents=$(printf '%s\n' "$context" | jq -r '.local_agents[]')
+  while IFS= read -r agent; do
+    [ -n "$agent" ] || continue
+    local_values="${local_values}${local_values:+,}('$(_sqlite_lit "$agent")')"
+  done <<EOF
+$local_agents
+EOF
   if [ "$count" -gt 0 ]; then
     insert_members="INSERT INTO incoming_read_members VALUES $values;"
+  fi
+  if [ -n "$local_values" ]; then
+    insert_local_agents="INSERT INTO local_read_agents VALUES $local_values;"
   fi
 
   agmsg_sqlite "$db" "BEGIN IMMEDIATE;
     CREATE TEMP TABLE incoming_read_members(member_id TEXT UNIQUE,agent TEXT UNIQUE);
     CREATE TEMP TABLE local_read_agents(agent TEXT PRIMARY KEY);
     $insert_members
-    INSERT OR IGNORE INTO local_read_agents
-      SELECT to_agent FROM events WHERE type='message_sent' AND team='$tl' AND to_agent IS NOT NULL
-      UNION SELECT agent FROM read_cursors WHERE team='$tl';
+    $insert_local_agents
     UPDATE sync_read_members SET active=0 WHERE local_team='$tl'
       AND server_instance_id='$server' AND remote_team_id='$remote'
       AND protocol_version=$protocol AND driver_generation='$generation';

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -20,6 +20,20 @@ _sqlite_sync_valid_binding() {
   case "$3" in ''|*[!0-9]*) return 1 ;; esac
 }
 
+_sqlite_sync_decimal_le() {
+  local left right
+  left=$(printf '%s' "$1" | sed 's/^0*//')
+  right=$(printf '%s' "$2" | sed 's/^0*//')
+  [ -n "$left" ] || left=0
+  [ -n "$right" ] || right=0
+  if [ "${#left}" -lt "${#right}" ] ||
+     { [ "${#left}" -eq "${#right}" ] && [[ "$left" < "$right" || "$left" = "$right" ]]; }; then
+    echo 1
+  else
+    echo 0
+  fi
+}
+
 _sqlite_sync_schema() {
   command -v jq >/dev/null 2>&1 || {
     echo "agmsg: Stage-1 sync requires jq" >&2
@@ -100,6 +114,58 @@ _sqlite_sync_schema() {
       observed_at TEXT NOT NULL,
       UNIQUE(server_instance_id,remote_team_id,protocol_version,
              server_seq,wire_id,reason)
+    );
+    CREATE TABLE IF NOT EXISTS sync_read_members (
+      local_team TEXT NOT NULL,
+      server_instance_id TEXT NOT NULL,
+      remote_team_id TEXT NOT NULL,
+      protocol_version INTEGER NOT NULL,
+      driver_generation TEXT NOT NULL,
+      member_id TEXT NOT NULL,
+      agent TEXT NOT NULL,
+      active INTEGER NOT NULL DEFAULT 1 CHECK(active IN (0,1)),
+      remote_server_seq TEXT NOT NULL DEFAULT '0',
+      min_available_seq TEXT NOT NULL DEFAULT '0',
+      PRIMARY KEY(local_team,server_instance_id,remote_team_id,
+                  protocol_version,driver_generation,member_id),
+      UNIQUE(local_team,server_instance_id,remote_team_id,
+             protocol_version,driver_generation,agent)
+    );
+    CREATE TABLE IF NOT EXISTS sync_read_remote_exact (
+      local_team TEXT NOT NULL,
+      server_instance_id TEXT NOT NULL,
+      remote_team_id TEXT NOT NULL,
+      protocol_version INTEGER NOT NULL,
+      driver_generation TEXT NOT NULL,
+      member_id TEXT NOT NULL,
+      wire_id TEXT NOT NULL,
+      PRIMARY KEY(local_team,server_instance_id,remote_team_id,
+                  protocol_version,driver_generation,member_id,wire_id)
+    );
+    CREATE TABLE IF NOT EXISTS sync_read_aliases (
+      local_team TEXT NOT NULL,
+      server_instance_id TEXT NOT NULL,
+      remote_team_id TEXT NOT NULL,
+      protocol_version INTEGER NOT NULL,
+      driver_generation TEXT NOT NULL,
+      agent TEXT NOT NULL,
+      local_id TEXT NOT NULL,
+      wire_id TEXT NOT NULL,
+      server_seq TEXT,
+      PRIMARY KEY(local_team,server_instance_id,remote_team_id,
+                  protocol_version,driver_generation,agent,local_id),
+      UNIQUE(server_instance_id,remote_team_id,protocol_version,agent,wire_id)
+    );
+    CREATE TABLE IF NOT EXISTS sync_read_prepared (
+      local_team TEXT NOT NULL,
+      server_instance_id TEXT NOT NULL,
+      remote_team_id TEXT NOT NULL,
+      protocol_version INTEGER NOT NULL,
+      driver_generation TEXT NOT NULL,
+      member_id TEXT NOT NULL,
+      server_seq TEXT NOT NULL,
+      PRIMARY KEY(local_team,server_instance_id,remote_team_id,
+                  protocol_version,driver_generation,member_id)
     );
   " >/dev/null 2>&1 || return 13
   generation=$(agmsg_sqlite "$db" \
@@ -233,6 +299,17 @@ storage_sync_prepare_push() {
       VALUES('$tl','$server','$remote',$protocol,'$generation',$pos,
              '$(_sqlite_lit "$local_id")','$wire',1,'$(_sqlite_lit "$cipher")',$q,
              '$(_sqlite_lit "$blob")','push');
+      INSERT OR IGNORE INTO sync_read_aliases
+        (local_team,server_instance_id,remote_team_id,protocol_version,
+         driver_generation,agent,local_id,wire_id,server_seq)
+      SELECT m.local_team,m.server_instance_id,m.remote_team_id,m.protocol_version,
+             m.driver_generation,e.to_agent,m.local_id,m.wire_id,m.server_seq
+        FROM sync_messages m JOIN events e ON e.seq=m.local_position
+       WHERE m.local_team='$tl' AND m.server_instance_id='$server'
+         AND m.remote_team_id='$remote' AND m.protocol_version=$protocol
+         AND m.driver_generation='$generation' AND m.local_position=$pos
+         AND EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'
+           AND r.team=e.team AND r.agent=e.to_agent AND r.msg_id=e.id);
       COMMIT;" >/dev/null 2>&1 || return 13
   done <<EOF
 $rows
@@ -296,6 +373,15 @@ storage_sync_reconcile_push() {
         AND protocol_version=$protocol AND driver_generation='$generation'
         AND EXISTS(SELECT 1 FROM incoming_sync_acks a
           WHERE a.local_position=sync_messages.local_position AND a.wire_id=sync_messages.wire_id);
+    UPDATE sync_read_aliases AS x SET server_seq=(
+      SELECT m.server_seq FROM sync_messages m
+       WHERE m.local_team=x.local_team AND m.server_instance_id=x.server_instance_id
+         AND m.remote_team_id=x.remote_team_id AND m.protocol_version=x.protocol_version
+         AND m.driver_generation=x.driver_generation AND m.local_id=x.local_id
+         AND m.wire_id=x.wire_id)
+     WHERE x.local_team='$tl' AND x.server_instance_id='$server'
+       AND x.remote_team_id='$remote' AND x.protocol_version=$protocol
+       AND x.driver_generation='$generation';
     UPDATE sync_bindings AS b SET push_cursor=COALESCE((
       SELECT MAX(e.seq) FROM events e
       WHERE e.type='message_sent' AND e.team='$tl' AND e.seq>b.push_cursor
@@ -557,4 +643,299 @@ storage_sync_reprocess() {
       AND status IN ('unsupported_cipher','pending_key','authentication_failed',
                      'malformed','policy_violation')
     ORDER BY CAST(server_seq AS INTEGER),wire_id LIMIT $limit;"
+}
+
+# Derive the remote read frontier and exact wire exceptions from durable local
+# outcomes. The authenticated member roster/floor is supplied by the engine.
+storage_sync_prepare_read_state() {
+  local team="$1" server="$2" remote="$3" protocol="$4"
+  _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
+  _sqlite_sync_schema || return $?
+  local generation db tl context floor current members count values="" member id name insert_members=""
+  generation=$(_sqlite_sync_generation) || return 13
+  db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"
+  _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || return 13
+  context=$(cat)
+  [ "$(printf '%s\n' "$context" | jq -r '
+    select(.type=="sync_read_context" and (.min_available_seq|type)=="string" and
+      (.current_seq|type)=="string" and (.members|type)=="array" and
+      (.members|length)<=1000 and all(.members[];
+        ((.member_id|type)=="string") and ((.name|type)=="string") and (.name|length)>0)) | "ok"' \
+      2>/dev/null)" = ok ] || return 13
+  floor=$(printf '%s\n' "$context" | jq -r '.min_available_seq')
+  current=$(printf '%s\n' "$context" | jq -r '.current_seq')
+  case "$floor:$current" in *[!0-9:]*) return 13 ;; esac
+  [ "$(_sqlite_sync_decimal_le "$floor" "$current")" = 1 ] &&
+    [ "$(_sqlite_sync_decimal_le "$current" 9223372036854775807)" = 1 ] || return 13
+  members=$(printf '%s\n' "$context" | jq -c '.members[]')
+  count=0
+  while IFS= read -r member; do
+    [ -n "$member" ] || continue
+    id=$(printf '%s\n' "$member" | jq -r '.member_id')
+    name=$(printf '%s\n' "$member" | jq -r '.name')
+    printf '%s\n' "$id" | grep -Eq \
+      '^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' || return 13
+    values="${values}${values:+,}('$id','$(_sqlite_lit "$name")')"
+    count=$((count + 1))
+  done <<EOF
+$members
+EOF
+  if [ "$count" -gt 0 ]; then
+    insert_members="INSERT INTO incoming_read_members VALUES $values;"
+  fi
+
+  agmsg_sqlite "$db" "BEGIN IMMEDIATE;
+    CREATE TEMP TABLE incoming_read_members(member_id TEXT UNIQUE,agent TEXT UNIQUE);
+    $insert_members
+    UPDATE sync_read_members SET active=0 WHERE local_team='$tl'
+      AND server_instance_id='$server' AND remote_team_id='$remote'
+      AND protocol_version=$protocol AND driver_generation='$generation';
+    INSERT INTO sync_read_members
+      (local_team,server_instance_id,remote_team_id,protocol_version,
+       driver_generation,member_id,agent,active,remote_server_seq,min_available_seq)
+    SELECT '$tl','$server','$remote',$protocol,'$generation',member_id,agent,1,
+           '$floor','$floor' FROM incoming_read_members WHERE 1
+    ON CONFLICT(local_team,server_instance_id,remote_team_id,protocol_version,
+                driver_generation,member_id) DO UPDATE SET
+      agent=excluded.agent,active=1,
+      remote_server_seq=CAST(MAX(CAST(sync_read_members.remote_server_seq AS INTEGER),$floor) AS TEXT),
+      min_available_seq=CAST(MAX(CAST(sync_read_members.min_available_seq AS INTEGER),$floor) AS TEXT);
+    INSERT OR IGNORE INTO sync_read_aliases
+      (local_team,server_instance_id,remote_team_id,protocol_version,
+       driver_generation,agent,local_id,wire_id,server_seq)
+    SELECT m.local_team,m.server_instance_id,m.remote_team_id,m.protocol_version,
+           m.driver_generation,e.to_agent,m.local_id,m.wire_id,m.server_seq
+      FROM sync_messages m JOIN events e ON e.seq=m.local_position
+     WHERE m.local_team='$tl' AND m.server_instance_id='$server'
+       AND m.remote_team_id='$remote' AND m.protocol_version=$protocol
+       AND m.driver_generation='$generation' AND m.server_seq IS NOT NULL
+       AND EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'
+         AND r.team=e.team AND r.agent=e.to_agent AND r.msg_id=e.id);
+    UPDATE sync_read_aliases AS x SET server_seq=(
+      SELECT m.server_seq FROM sync_messages m
+       WHERE m.local_team=x.local_team AND m.server_instance_id=x.server_instance_id
+         AND m.remote_team_id=x.remote_team_id AND m.protocol_version=x.protocol_version
+         AND m.driver_generation=x.driver_generation AND m.local_id=x.local_id
+         AND m.wire_id=x.wire_id)
+     WHERE x.local_team='$tl' AND x.server_instance_id='$server'
+       AND x.remote_team_id='$remote' AND x.protocol_version=$protocol
+       AND x.driver_generation='$generation' AND x.server_seq IS NULL;
+    DELETE FROM sync_read_prepared WHERE local_team='$tl'
+      AND server_instance_id='$server' AND remote_team_id='$remote'
+      AND protocol_version=$protocol AND driver_generation='$generation';
+    INSERT INTO sync_read_prepared
+      (local_team,server_instance_id,remote_team_id,protocol_version,
+       driver_generation,member_id,server_seq)
+    WITH ordered AS (
+      SELECT rm.member_id,rm.agent,CAST(rm.remote_server_seq AS INTEGER) AS base,
+             CAST(b.transport_cursor AS INTEGER) AS tip,
+             CAST(q.server_seq AS INTEGER) AS seq,q.status,m.local_position,e.to_agent,
+             ROW_NUMBER() OVER(PARTITION BY rm.member_id ORDER BY CAST(q.server_seq AS INTEGER)) AS rn
+        FROM sync_read_members rm JOIN sync_bindings b
+          ON b.local_team=rm.local_team AND b.server_instance_id=rm.server_instance_id
+         AND b.remote_team_id=rm.remote_team_id AND b.protocol_version=rm.protocol_version
+         AND b.driver_generation=rm.driver_generation
+        LEFT JOIN sync_quarantine q ON q.local_team=rm.local_team
+         AND q.server_instance_id=rm.server_instance_id AND q.remote_team_id=rm.remote_team_id
+         AND q.protocol_version=rm.protocol_version AND q.driver_generation=rm.driver_generation
+         AND CAST(q.server_seq AS INTEGER)>CAST(rm.remote_server_seq AS INTEGER)
+         AND CAST(q.server_seq AS INTEGER)<=MIN(CAST(b.transport_cursor AS INTEGER),$current)
+        LEFT JOIN sync_messages m ON m.server_instance_id=rm.server_instance_id
+         AND m.remote_team_id=rm.remote_team_id AND m.protocol_version=rm.protocol_version
+         AND m.wire_id=q.wire_id
+        LEFT JOIN events e ON e.seq=m.local_position
+       WHERE rm.local_team='$tl' AND rm.server_instance_id='$server'
+         AND rm.remote_team_id='$remote' AND rm.protocol_version=$protocol
+         AND rm.driver_generation='$generation' AND rm.active=1
+    ), bad AS (
+      SELECT member_id,MIN(base+rn) AS seq FROM ordered
+       WHERE seq IS NULL OR seq<>base+rn OR status NOT IN ('imported','reconciled')
+          OR local_position IS NULL
+          OR (to_agent=agent AND local_position>COALESCE((SELECT local_position
+                FROM read_cursors c WHERE c.team='$tl' AND c.agent=ordered.agent),0)
+              AND NOT EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'
+                AND r.team='$tl' AND r.agent=ordered.agent
+                AND r.msg_id=(SELECT id FROM events se WHERE se.seq=ordered.local_position)))
+       GROUP BY member_id
+    )
+    SELECT '$tl','$server','$remote',$protocol,'$generation',rm.member_id,
+      CAST(MAX(CAST(rm.remote_server_seq AS INTEGER),
+      MIN(CAST(b.transport_cursor AS INTEGER),$current,COALESCE(bad.seq-1,$current))) AS TEXT)
+      FROM sync_read_members rm JOIN sync_bindings b
+        ON b.local_team=rm.local_team AND b.server_instance_id=rm.server_instance_id
+       AND b.remote_team_id=rm.remote_team_id AND b.protocol_version=rm.protocol_version
+       AND b.driver_generation=rm.driver_generation
+      LEFT JOIN bad ON bad.member_id=rm.member_id
+     WHERE rm.local_team='$tl' AND rm.server_instance_id='$server'
+       AND rm.remote_team_id='$remote' AND rm.protocol_version=$protocol
+       AND rm.driver_generation='$generation' AND rm.active=1;
+    COMMIT;" >/dev/null || return 13
+
+  _sqlite_data "SELECT json_object('type','sync_read_frontier','member_id',member_id,
+      'server_seq',server_seq) FROM sync_read_prepared WHERE local_team='$tl'
+      AND server_instance_id='$server' AND remote_team_id='$remote'
+      AND protocol_version=$protocol AND driver_generation='$generation' ORDER BY member_id;
+    SELECT json_object('type','sync_read_exact','member_id',rm.member_id,'wire_id',x.wire_id)
+      FROM sync_read_aliases x JOIN sync_read_members rm
+        ON rm.local_team=x.local_team AND rm.server_instance_id=x.server_instance_id
+       AND rm.remote_team_id=x.remote_team_id AND rm.protocol_version=x.protocol_version
+       AND rm.driver_generation=x.driver_generation AND rm.agent=x.agent AND rm.active=1
+      JOIN sync_read_prepared f ON f.local_team=rm.local_team
+       AND f.server_instance_id=rm.server_instance_id AND f.remote_team_id=rm.remote_team_id
+       AND f.protocol_version=rm.protocol_version AND f.driver_generation=rm.driver_generation
+       AND f.member_id=rm.member_id
+     WHERE x.local_team='$tl' AND x.server_instance_id='$server'
+       AND x.remote_team_id='$remote' AND x.protocol_version=$protocol
+       AND x.driver_generation='$generation' AND x.server_seq IS NOT NULL
+       AND CAST(x.server_seq AS INTEGER)>f.server_seq
+     ORDER BY rm.member_id,x.wire_id;"
+}
+
+# Merge one authenticated server read-state page and project coverage only onto
+# already imported/reconciled local messages. Transport/decrypt cursors are not
+# touched by this operation.
+storage_sync_apply_read_state() {
+  local team="$1" server="$2" remote="$3" protocol="$4"
+  _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
+  _sqlite_sync_schema || return $?
+  local generation db tl sql_file line type floor="" current="" member seq wire
+  generation=$(_sqlite_sync_generation) || return 13
+  db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"
+  sql_file=$(mktemp "${TMPDIR:-/tmp}/agmsg-read-sync-sql.XXXXXX") || return 13
+  _AGMSG_READ_SYNC_SQL_FILE="$sql_file"
+  trap 'case "${_AGMSG_READ_SYNC_SQL_FILE:-}" in "${TMPDIR:-/tmp}"/agmsg-read-sync-sql.*) rm -f "$_AGMSG_READ_SYNC_SQL_FILE" ;; esac' EXIT INT TERM HUP
+  printf '%s\n' 'BEGIN IMMEDIATE; CREATE TEMP TABLE sync_read_assert(ok INTEGER CHECK(ok=1));' > "$sql_file"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    type=$(printf '%s\n' "$line" | jq -r '.type // empty')
+    case "$type" in
+      sync_read_snapshot)
+        [ -z "$floor" ] || { rm -f "$sql_file"; return 13; }
+        floor=$(printf '%s\n' "$line" | jq -r '.min_available_seq // empty')
+        current=$(printf '%s\n' "$line" | jq -r '.current_seq // empty')
+        case "$floor:$current" in *[!0-9:]*) rm -f "$sql_file"; return 13 ;; esac
+        [ "$(_sqlite_sync_decimal_le "$floor" "$current")" = 1 ] &&
+          [ "$(_sqlite_sync_decimal_le "$current" 9223372036854775807)" = 1 ] || {
+            rm -f "$sql_file"; return 13;
+          }
+        ;;
+      sync_read_frontier)
+        [ -n "$current" ] || { rm -f "$sql_file"; return 13; }
+        member=$(printf '%s\n' "$line" | jq -r '.member_id // empty')
+        seq=$(printf '%s\n' "$line" | jq -r '.server_seq // empty')
+        case "$seq" in ''|*[!0-9]*) rm -f "$sql_file"; return 13 ;; esac
+        printf '%s\n' "$member" | grep -Eq \
+          '^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' \
+          || { rm -f "$sql_file"; return 13; }
+        [ "$(_sqlite_sync_decimal_le "$seq" "$current")" = 1 ] || { rm -f "$sql_file"; return 13; }
+        printf "%s\n" "INSERT INTO sync_read_assert SELECT CASE WHEN EXISTS(
+          SELECT 1 FROM sync_read_members WHERE local_team='$tl'
+            AND server_instance_id='$server' AND remote_team_id='$remote'
+            AND protocol_version=$protocol AND driver_generation='$generation'
+            AND member_id='$member' AND active=1) THEN 1 ELSE 0 END;
+        UPDATE sync_read_members SET remote_server_seq=
+          CAST(MAX(CAST(remote_server_seq AS INTEGER),$seq) AS TEXT)
+          WHERE local_team='$tl' AND server_instance_id='$server' AND remote_team_id='$remote'
+            AND protocol_version=$protocol AND driver_generation='$generation'
+            AND member_id='$member' AND active=1;" >> "$sql_file"
+        ;;
+      sync_read_exact)
+        [ -n "$current" ] || { rm -f "$sql_file"; return 13; }
+        member=$(printf '%s\n' "$line" | jq -r '.member_id // empty')
+        wire=$(printf '%s\n' "$line" | jq -r '.wire_id // empty')
+        printf '%s\n' "$member" | grep -Eq \
+          '^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' \
+          || { rm -f "$sql_file"; return 13; }
+        printf '%s\n' "$wire" | grep -Eq \
+          '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' \
+          || { rm -f "$sql_file"; return 13; }
+        printf "%s\n" "INSERT INTO sync_read_assert SELECT CASE WHEN EXISTS(
+          SELECT 1 FROM sync_read_members WHERE local_team='$tl'
+            AND server_instance_id='$server' AND remote_team_id='$remote'
+            AND protocol_version=$protocol AND driver_generation='$generation'
+            AND member_id='$member' AND active=1) THEN 1 ELSE 0 END;
+        INSERT OR IGNORE INTO sync_read_remote_exact
+          (local_team,server_instance_id,remote_team_id,protocol_version,
+           driver_generation,member_id,wire_id)
+          SELECT '$tl','$server','$remote',$protocol,'$generation','$member','$wire'
+           WHERE EXISTS(SELECT 1 FROM sync_read_members rm WHERE rm.local_team='$tl'
+             AND rm.server_instance_id='$server' AND rm.remote_team_id='$remote'
+             AND rm.protocol_version=$protocol AND rm.driver_generation='$generation'
+             AND rm.member_id='$member' AND rm.active=1);" >> "$sql_file"
+        ;;
+      *) rm -f "$sql_file"; return 13 ;;
+    esac
+  done
+  [ -n "$floor" ] && [ -n "$current" ] || { rm -f "$sql_file"; return 13; }
+  printf "%s\n" "
+    UPDATE sync_read_members SET
+      min_available_seq=CAST(MAX(CAST(min_available_seq AS INTEGER),$floor) AS TEXT),
+      remote_server_seq=CAST(MAX(CAST(remote_server_seq AS INTEGER),$floor) AS TEXT)
+     WHERE local_team='$tl' AND server_instance_id='$server' AND remote_team_id='$remote'
+       AND protocol_version=$protocol AND driver_generation='$generation' AND active=1;
+    INSERT INTO events(type,id,team,agent,msg_id,at)
+    SELECT 'message_read',lower(hex(randomblob(4)))||'-'||lower(hex(randomblob(2)))||
+           '-7'||substr(lower(hex(randomblob(2))),2)||'-8'||substr(lower(hex(randomblob(2))),2)||
+           '-'||lower(hex(randomblob(6))),e.team,rm.agent,e.id,
+           strftime('%Y-%m-%dT%H:%M:%SZ','now')
+      FROM sync_read_members rm JOIN sync_messages m
+        ON m.local_team=rm.local_team AND m.server_instance_id=rm.server_instance_id
+       AND m.remote_team_id=rm.remote_team_id AND m.protocol_version=rm.protocol_version
+       AND m.driver_generation=rm.driver_generation AND m.server_seq IS NOT NULL
+      JOIN events e ON e.seq=m.local_position
+      JOIN sync_quarantine q ON q.server_instance_id=m.server_instance_id
+       AND q.remote_team_id=m.remote_team_id AND q.protocol_version=m.protocol_version
+       AND q.wire_id=m.wire_id AND q.status IN ('imported','reconciled')
+     WHERE rm.local_team='$tl' AND rm.server_instance_id='$server'
+       AND rm.remote_team_id='$remote' AND rm.protocol_version=$protocol
+       AND rm.driver_generation='$generation' AND rm.active=1 AND e.to_agent=rm.agent
+       AND (CAST(m.server_seq AS INTEGER)<=CAST(rm.remote_server_seq AS INTEGER)
+         OR EXISTS(SELECT 1 FROM sync_read_remote_exact x
+           WHERE x.local_team=rm.local_team AND x.server_instance_id=rm.server_instance_id
+             AND x.remote_team_id=rm.remote_team_id AND x.protocol_version=rm.protocol_version
+             AND x.driver_generation=rm.driver_generation AND x.member_id=rm.member_id
+             AND x.wire_id=m.wire_id))
+       AND NOT EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'
+         AND r.team=e.team AND r.agent=rm.agent AND r.msg_id=e.id);
+    INSERT OR IGNORE INTO read_cursors(team,agent,local_position)
+      SELECT '$tl',agent,0 FROM sync_read_members WHERE local_team='$tl'
+       AND server_instance_id='$server' AND remote_team_id='$remote'
+       AND protocol_version=$protocol AND driver_generation='$generation' AND active=1;
+    UPDATE read_cursors SET local_position=MAX(local_position,COALESCE((
+      SELECT MIN(e.seq)-1 FROM events e WHERE e.type='message_sent' AND e.team='$tl'
+       AND e.to_agent=read_cursors.agent AND e.seq>read_cursors.local_position
+       AND NOT EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'
+         AND r.team=e.team AND r.agent=read_cursors.agent AND r.msg_id=e.id)
+    ),$(_sqlite_highwater))) WHERE team='$tl' AND agent IN (
+      SELECT agent FROM sync_read_members WHERE local_team='$tl'
+       AND server_instance_id='$server' AND remote_team_id='$remote'
+       AND protocol_version=$protocol AND driver_generation='$generation' AND active=1);
+    DELETE FROM sync_read_remote_exact AS x WHERE x.local_team='$tl'
+      AND x.server_instance_id='$server' AND x.remote_team_id='$remote'
+      AND x.protocol_version=$protocol AND x.driver_generation='$generation'
+      AND EXISTS(SELECT 1 FROM sync_messages m JOIN sync_read_members rm
+        ON rm.local_team=x.local_team AND rm.server_instance_id=x.server_instance_id
+       AND rm.remote_team_id=x.remote_team_id AND rm.protocol_version=x.protocol_version
+       AND rm.driver_generation=x.driver_generation AND rm.member_id=x.member_id
+       WHERE m.server_instance_id=x.server_instance_id AND m.remote_team_id=x.remote_team_id
+         AND m.protocol_version=x.protocol_version AND m.wire_id=x.wire_id
+         AND m.server_seq IS NOT NULL
+         AND CAST(m.server_seq AS INTEGER)<=CAST(rm.remote_server_seq AS INTEGER));
+    DELETE FROM sync_read_aliases AS x WHERE x.local_team='$tl'
+      AND x.server_instance_id='$server' AND x.remote_team_id='$remote'
+      AND x.protocol_version=$protocol AND x.driver_generation='$generation'
+      AND x.server_seq IS NOT NULL AND EXISTS(SELECT 1 FROM sync_read_members rm
+        WHERE rm.local_team=x.local_team AND rm.server_instance_id=x.server_instance_id
+          AND rm.remote_team_id=x.remote_team_id AND rm.protocol_version=x.protocol_version
+          AND rm.driver_generation=x.driver_generation AND rm.agent=x.agent
+          AND CAST(x.server_seq AS INTEGER)<=CAST(rm.remote_server_seq AS INTEGER));
+    COMMIT;" >> "$sql_file"
+  if ! agmsg_sqlite "$db" < "$sql_file" >/dev/null 2>&1; then
+    rm -f "$sql_file"; trap - EXIT INT TERM HUP; return 13
+  fi
+  rm -f "$sql_file"; trap - EXIT INT TERM HUP; _AGMSG_READ_SYNC_SQL_FILE=""
+  _sqlite_data "SELECT json_object('type','sync_read_apply_result','min_available_seq',
+      MAX(min_available_seq),'member_count',COUNT(*)) FROM sync_read_members
+    WHERE local_team='$tl' AND server_instance_id='$server' AND remote_team_id='$remote'
+      AND protocol_version=$protocol AND driver_generation='$generation' AND active=1;"
 }

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -123,7 +123,10 @@ _sqlite_sync_schema() {
       driver_generation TEXT NOT NULL,
       member_id TEXT NOT NULL,
       agent TEXT NOT NULL,
+      remote_agent TEXT NOT NULL,
       active INTEGER NOT NULL DEFAULT 1 CHECK(active IN (0,1)),
+      name_mismatch INTEGER NOT NULL DEFAULT 0 CHECK(name_mismatch IN (0,1)),
+      blocked_reason TEXT,
       remote_server_seq TEXT NOT NULL DEFAULT '0',
       min_available_seq TEXT NOT NULL DEFAULT '0',
       PRIMARY KEY(local_team,server_instance_id,remote_team_id,
@@ -168,6 +171,16 @@ _sqlite_sync_schema() {
                   protocol_version,driver_generation,member_id)
     );
   " >/dev/null 2>&1 || return 13
+  if ! agmsg_sqlite "$db" "PRAGMA table_info(sync_read_members);" | cut -d'|' -f2 |
+      grep -qx remote_agent; then
+    agmsg_sqlite "$db" "BEGIN IMMEDIATE;
+      ALTER TABLE sync_read_members ADD COLUMN remote_agent TEXT NOT NULL DEFAULT '';
+      ALTER TABLE sync_read_members ADD COLUMN name_mismatch INTEGER NOT NULL DEFAULT 0
+        CHECK(name_mismatch IN (0,1));
+      ALTER TABLE sync_read_members ADD COLUMN blocked_reason TEXT;
+      UPDATE sync_read_members SET remote_agent=agent;
+      COMMIT;" >/dev/null 2>&1 || return 13
+  fi
   generation=$(agmsg_sqlite "$db" \
     "SELECT generation FROM sync_store_metadata WHERE singleton=1;" 2>/dev/null | tr -d '\r')
   if [ -z "$generation" ]; then
@@ -692,12 +705,14 @@ EOF
       AND protocol_version=$protocol AND driver_generation='$generation';
     INSERT INTO sync_read_members
       (local_team,server_instance_id,remote_team_id,protocol_version,
-       driver_generation,member_id,agent,active,remote_server_seq,min_available_seq)
-    SELECT '$tl','$server','$remote',$protocol,'$generation',member_id,agent,1,
+       driver_generation,member_id,agent,remote_agent,active,name_mismatch,
+       remote_server_seq,min_available_seq)
+    SELECT '$tl','$server','$remote',$protocol,'$generation',member_id,agent,agent,1,0,
            '$floor','$floor' FROM incoming_read_members WHERE 1
     ON CONFLICT(local_team,server_instance_id,remote_team_id,protocol_version,
                 driver_generation,member_id) DO UPDATE SET
-      agent=excluded.agent,active=1,
+      remote_agent=excluded.agent,active=1,
+      name_mismatch=CASE WHEN sync_read_members.agent=excluded.agent THEN 0 ELSE 1 END,
       remote_server_seq=CAST(MAX(CAST(sync_read_members.remote_server_seq AS INTEGER),$floor) AS TEXT),
       min_available_seq=CAST(MAX(CAST(sync_read_members.min_available_seq AS INTEGER),$floor) AS TEXT);
     INSERT OR IGNORE INTO sync_read_aliases
@@ -747,6 +762,7 @@ EOF
        WHERE rm.local_team='$tl' AND rm.server_instance_id='$server'
          AND rm.remote_team_id='$remote' AND rm.protocol_version=$protocol
          AND rm.driver_generation='$generation' AND rm.active=1
+         AND rm.name_mismatch=0
     ), bad AS (
       SELECT member_id,MIN(base+rn) AS seq FROM ordered
        WHERE seq IS NULL OR seq<>base+rn OR status NOT IN ('imported','reconciled')
@@ -768,18 +784,51 @@ EOF
       LEFT JOIN bad ON bad.member_id=rm.member_id
      WHERE rm.local_team='$tl' AND rm.server_instance_id='$server'
        AND rm.remote_team_id='$remote' AND rm.protocol_version=$protocol
-       AND rm.driver_generation='$generation' AND rm.active=1;
+       AND rm.driver_generation='$generation' AND rm.active=1
+       AND rm.name_mismatch=0;
+    UPDATE sync_read_members AS rm SET blocked_reason=NULL
+     WHERE rm.local_team='$tl' AND rm.server_instance_id='$server'
+       AND rm.remote_team_id='$remote' AND rm.protocol_version=$protocol
+       AND rm.driver_generation='$generation' AND rm.active=1
+       AND rm.name_mismatch=0 AND rm.blocked_reason='read-state-limit-exceeded'
+       AND (SELECT COUNT(*) FROM (
+         SELECT x.wire_id FROM sync_read_aliases x JOIN sync_read_prepared f
+           ON f.local_team=rm.local_team AND f.server_instance_id=rm.server_instance_id
+          AND f.remote_team_id=rm.remote_team_id AND f.protocol_version=rm.protocol_version
+          AND f.driver_generation=rm.driver_generation AND f.member_id=rm.member_id
+          WHERE x.local_team=rm.local_team AND x.server_instance_id=rm.server_instance_id
+            AND x.remote_team_id=rm.remote_team_id AND x.protocol_version=rm.protocol_version
+            AND x.driver_generation=rm.driver_generation AND x.agent=rm.agent
+            AND x.server_seq IS NOT NULL AND CAST(x.server_seq AS INTEGER)>CAST(f.server_seq AS INTEGER)
+         UNION
+         SELECT x.wire_id FROM sync_read_remote_exact x JOIN sync_read_prepared f
+           ON f.local_team=rm.local_team AND f.server_instance_id=rm.server_instance_id
+          AND f.remote_team_id=rm.remote_team_id AND f.protocol_version=rm.protocol_version
+          AND f.driver_generation=rm.driver_generation AND f.member_id=rm.member_id
+          LEFT JOIN sync_messages m ON m.server_instance_id=x.server_instance_id
+           AND m.remote_team_id=x.remote_team_id AND m.protocol_version=x.protocol_version
+           AND m.wire_id=x.wire_id
+          WHERE x.local_team=rm.local_team AND x.server_instance_id=rm.server_instance_id
+            AND x.remote_team_id=rm.remote_team_id AND x.protocol_version=rm.protocol_version
+            AND x.driver_generation=rm.driver_generation AND x.member_id=rm.member_id
+            AND (m.server_seq IS NULL OR CAST(m.server_seq AS INTEGER)>CAST(f.server_seq AS INTEGER))
+       ))<=4096;
     COMMIT;" >/dev/null || return 13
 
-  _sqlite_data "SELECT json_object('type','sync_read_frontier','member_id',member_id,
-      'server_seq',server_seq) FROM sync_read_prepared WHERE local_team='$tl'
-      AND server_instance_id='$server' AND remote_team_id='$remote'
-      AND protocol_version=$protocol AND driver_generation='$generation' ORDER BY member_id;
+  _sqlite_data "SELECT json_object('type','sync_read_frontier','member_id',f.member_id,
+      'server_seq',f.server_seq) FROM sync_read_prepared f JOIN sync_read_members rm
+      ON rm.local_team=f.local_team AND rm.server_instance_id=f.server_instance_id
+     AND rm.remote_team_id=f.remote_team_id AND rm.protocol_version=f.protocol_version
+     AND rm.driver_generation=f.driver_generation AND rm.member_id=f.member_id
+     WHERE f.local_team='$tl' AND f.server_instance_id='$server' AND f.remote_team_id='$remote'
+      AND f.protocol_version=$protocol AND f.driver_generation='$generation'
+      AND rm.blocked_reason IS NULL ORDER BY f.member_id;
     SELECT json_object('type','sync_read_exact','member_id',rm.member_id,'wire_id',x.wire_id)
       FROM sync_read_aliases x JOIN sync_read_members rm
         ON rm.local_team=x.local_team AND rm.server_instance_id=x.server_instance_id
        AND rm.remote_team_id=x.remote_team_id AND rm.protocol_version=x.protocol_version
        AND rm.driver_generation=x.driver_generation AND rm.agent=x.agent AND rm.active=1
+       AND rm.blocked_reason IS NULL
       JOIN sync_read_prepared f ON f.local_team=rm.local_team
        AND f.server_instance_id=rm.server_instance_id AND f.remote_team_id=rm.remote_team_id
        AND f.protocol_version=rm.protocol_version AND f.driver_generation=rm.driver_generation
@@ -789,6 +838,37 @@ EOF
        AND x.driver_generation='$generation' AND x.server_seq IS NOT NULL
        AND CAST(x.server_seq AS INTEGER)>f.server_seq
      ORDER BY rm.member_id,x.wire_id;"
+  _sqlite_data "SELECT json_object('type','sync_read_blocked','member_id',member_id,
+      'reason',CASE WHEN name_mismatch=1 THEN 'member-name-mismatch' ELSE blocked_reason END)
+      FROM sync_read_members WHERE local_team='$tl' AND server_instance_id='$server'
+       AND remote_team_id='$remote' AND protocol_version=$protocol
+       AND driver_generation='$generation' AND active=1
+       AND (name_mismatch=1 OR blocked_reason IS NOT NULL) ORDER BY member_id;"
+}
+
+# Persist a server-declared exact-set limit for one member. Prepared local facts
+# remain untouched and can be retried after operator remediation.
+storage_sync_block_read_state() {
+  local team="$1" server="$2" remote="$3" protocol="$4"
+  _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
+  _sqlite_sync_schema || return $?
+  local generation db tl input member reason
+  generation=$(_sqlite_sync_generation) || return 13
+  db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"; input=$(cat)
+  member=$(printf '%s\n' "$input" | jq -r 'select(.type=="sync_read_block")|.member_id // empty')
+  reason=$(printf '%s\n' "$input" | jq -r 'select(.type=="sync_read_block")|.reason // empty')
+  printf '%s\n' "$member" | grep -Eq \
+    '^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' || return 13
+  [ "$reason" = read-state-limit-exceeded ] || return 13
+  agmsg_sqlite "$db" "BEGIN IMMEDIATE;
+    CREATE TEMP TABLE sync_read_block_assert(ok INTEGER CHECK(ok=1));
+    UPDATE sync_read_members SET blocked_reason='$reason'
+     WHERE local_team='$tl' AND server_instance_id='$server'
+       AND remote_team_id='$remote' AND protocol_version=$protocol
+       AND driver_generation='$generation' AND member_id='$member' AND active=1;
+    INSERT INTO sync_read_block_assert VALUES(changes());
+    COMMIT;" >/dev/null || return 13
+  printf '{"type":"sync_read_blocked","member_id":"%s","reason":"%s"}\n' "$member" "$reason"
 }
 
 # Merge one authenticated server read-state page and project coverage only onto
@@ -883,12 +963,13 @@ storage_sync_apply_read_state() {
        AND m.remote_team_id=rm.remote_team_id AND m.protocol_version=rm.protocol_version
        AND m.driver_generation=rm.driver_generation AND m.server_seq IS NOT NULL
       JOIN events e ON e.seq=m.local_position
-      JOIN sync_quarantine q ON q.server_instance_id=m.server_instance_id
+      LEFT JOIN sync_quarantine q ON q.server_instance_id=m.server_instance_id
        AND q.remote_team_id=m.remote_team_id AND q.protocol_version=m.protocol_version
-       AND q.wire_id=m.wire_id AND q.status IN ('imported','reconciled')
+       AND q.wire_id=m.wire_id
      WHERE rm.local_team='$tl' AND rm.server_instance_id='$server'
        AND rm.remote_team_id='$remote' AND rm.protocol_version=$protocol
        AND rm.driver_generation='$generation' AND rm.active=1 AND e.to_agent=rm.agent
+       AND (m.direction='push' OR q.status IN ('imported','reconciled'))
        AND (CAST(m.server_seq AS INTEGER)<=CAST(rm.remote_server_seq AS INTEGER)
          OR EXISTS(SELECT 1 FROM sync_read_remote_exact x
            WHERE x.local_team=rm.local_team AND x.server_instance_id=rm.server_instance_id

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -699,7 +699,11 @@ EOF
 
   agmsg_sqlite "$db" "BEGIN IMMEDIATE;
     CREATE TEMP TABLE incoming_read_members(member_id TEXT UNIQUE,agent TEXT UNIQUE);
+    CREATE TEMP TABLE local_read_agents(agent TEXT PRIMARY KEY);
     $insert_members
+    INSERT OR IGNORE INTO local_read_agents
+      SELECT to_agent FROM events WHERE type='message_sent' AND team='$tl' AND to_agent IS NOT NULL
+      UNION SELECT agent FROM read_cursors WHERE team='$tl';
     UPDATE sync_read_members SET active=0 WHERE local_team='$tl'
       AND server_instance_id='$server' AND remote_team_id='$remote'
       AND protocol_version=$protocol AND driver_generation='$generation';
@@ -707,12 +711,16 @@ EOF
       (local_team,server_instance_id,remote_team_id,protocol_version,
        driver_generation,member_id,agent,remote_agent,active,name_mismatch,
        remote_server_seq,min_available_seq)
-    SELECT '$tl','$server','$remote',$protocol,'$generation',member_id,agent,agent,1,0,
+    SELECT '$tl','$server','$remote',$protocol,'$generation',member_id,agent,agent,1,
+           CASE WHEN EXISTS(SELECT 1 FROM local_read_agents l WHERE l.agent=incoming_read_members.agent)
+                THEN 0 ELSE 1 END,
            '$floor','$floor' FROM incoming_read_members WHERE 1
     ON CONFLICT(local_team,server_instance_id,remote_team_id,protocol_version,
                 driver_generation,member_id) DO UPDATE SET
       remote_agent=excluded.agent,active=1,
-      name_mismatch=CASE WHEN sync_read_members.agent=excluded.agent THEN 0 ELSE 1 END,
+      name_mismatch=CASE WHEN sync_read_members.agent=excluded.agent
+        AND EXISTS(SELECT 1 FROM local_read_agents l WHERE l.agent=excluded.agent)
+        THEN 0 ELSE 1 END,
       remote_server_seq=CAST(MAX(CAST(sync_read_members.remote_server_seq AS INTEGER),$floor) AS TEXT),
       min_available_seq=CAST(MAX(CAST(sync_read_members.min_available_seq AS INTEGER),$floor) AS TEXT);
     INSERT OR IGNORE INTO sync_read_aliases
@@ -786,33 +794,6 @@ EOF
        AND rm.remote_team_id='$remote' AND rm.protocol_version=$protocol
        AND rm.driver_generation='$generation' AND rm.active=1
        AND rm.name_mismatch=0;
-    UPDATE sync_read_members AS rm SET blocked_reason=NULL
-     WHERE rm.local_team='$tl' AND rm.server_instance_id='$server'
-       AND rm.remote_team_id='$remote' AND rm.protocol_version=$protocol
-       AND rm.driver_generation='$generation' AND rm.active=1
-       AND rm.name_mismatch=0 AND rm.blocked_reason='read-state-limit-exceeded'
-       AND (SELECT COUNT(*) FROM (
-         SELECT x.wire_id FROM sync_read_aliases x JOIN sync_read_prepared f
-           ON f.local_team=rm.local_team AND f.server_instance_id=rm.server_instance_id
-          AND f.remote_team_id=rm.remote_team_id AND f.protocol_version=rm.protocol_version
-          AND f.driver_generation=rm.driver_generation AND f.member_id=rm.member_id
-          WHERE x.local_team=rm.local_team AND x.server_instance_id=rm.server_instance_id
-            AND x.remote_team_id=rm.remote_team_id AND x.protocol_version=rm.protocol_version
-            AND x.driver_generation=rm.driver_generation AND x.agent=rm.agent
-            AND x.server_seq IS NOT NULL AND CAST(x.server_seq AS INTEGER)>CAST(f.server_seq AS INTEGER)
-         UNION
-         SELECT x.wire_id FROM sync_read_remote_exact x JOIN sync_read_prepared f
-           ON f.local_team=rm.local_team AND f.server_instance_id=rm.server_instance_id
-          AND f.remote_team_id=rm.remote_team_id AND f.protocol_version=rm.protocol_version
-          AND f.driver_generation=rm.driver_generation AND f.member_id=rm.member_id
-          LEFT JOIN sync_messages m ON m.server_instance_id=x.server_instance_id
-           AND m.remote_team_id=x.remote_team_id AND m.protocol_version=x.protocol_version
-           AND m.wire_id=x.wire_id
-          WHERE x.local_team=rm.local_team AND x.server_instance_id=rm.server_instance_id
-            AND x.remote_team_id=rm.remote_team_id AND x.protocol_version=rm.protocol_version
-            AND x.driver_generation=rm.driver_generation AND x.member_id=rm.member_id
-            AND (m.server_seq IS NULL OR CAST(m.server_seq AS INTEGER)>CAST(f.server_seq AS INTEGER))
-       ))<=4096;
     COMMIT;" >/dev/null || return 13
 
   _sqlite_data "SELECT json_object('type','sync_read_frontier','member_id',f.member_id,
@@ -869,6 +850,31 @@ storage_sync_block_read_state() {
     INSERT INTO sync_read_block_assert VALUES(changes());
     COMMIT;" >/dev/null || return 13
   printf '{"type":"sync_read_blocked","member_id":"%s","reason":"%s"}\n' "$member" "$reason"
+}
+
+storage_sync_unblock_read_state() {
+  local team="$1" server="$2" remote="$3" protocol="$4"
+  _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
+  _sqlite_sync_schema || return $?
+  local generation db tl input member
+  generation=$(_sqlite_sync_generation) || return 13
+  db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"; input=$(cat)
+  member=$(printf '%s\n' "$input" | jq -r 'select(.type=="sync_read_unblock")|.member_id // empty')
+  printf '%s\n' "$member" | grep -Eq \
+    '^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' || return 13
+  agmsg_sqlite "$db" "BEGIN IMMEDIATE;
+    CREATE TEMP TABLE sync_read_unblock_assert(ok INTEGER CHECK(ok=1));
+    INSERT INTO sync_read_unblock_assert SELECT COUNT(*) FROM sync_read_members
+     WHERE local_team='$tl' AND server_instance_id='$server'
+       AND remote_team_id='$remote' AND protocol_version=$protocol
+       AND driver_generation='$generation' AND member_id='$member' AND active=1;
+    UPDATE sync_read_members SET blocked_reason=NULL
+     WHERE local_team='$tl' AND server_instance_id='$server'
+       AND remote_team_id='$remote' AND protocol_version=$protocol
+       AND driver_generation='$generation' AND member_id='$member' AND active=1
+       AND blocked_reason='read-state-limit-exceeded';
+    COMMIT;" >/dev/null || return 13
+  printf '{"type":"sync_read_unblocked","member_id":"%s"}\n' "$member"
 }
 
 # Merge one authenticated server read-state page and project coverage only onto

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -80,7 +80,7 @@ storage_check() {
 storage_describe() {
   printf 'name=sqlite\n'
   printf 'backend=SQLite (WAL) event log + legacy messages table\n'
-  printf 'capabilities=stage1-sync\n'
+  printf 'capabilities=stage1-sync,stage2-read-state\n'
   printf 'db=%s\n' "$(_sqlite_db)"
 }
 

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -107,6 +107,16 @@ storage_init() {
     );
     CREATE INDEX IF NOT EXISTS events_sent ON events(type, team, to_agent, seq);
     CREATE INDEX IF NOT EXISTS events_read ON events(type, team, agent, msg_id);
+    CREATE TABLE IF NOT EXISTS read_cursors (
+      team TEXT NOT NULL,
+      agent TEXT NOT NULL,
+      local_position INTEGER NOT NULL DEFAULT 0 CHECK(local_position >= 0),
+      PRIMARY KEY(team, agent)
+    );
+    CREATE TABLE IF NOT EXISTS storage_metadata (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
     -- Legacy store (read-only here). Created so the UNION queries always parse
     -- even on a brand-new install with no pre-event-log data.
     CREATE TABLE IF NOT EXISTS messages (
@@ -118,6 +128,38 @@ storage_init() {
       created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
       read_at TEXT
     );
+    -- Phase-3 adoption is intentionally storm-proof. Everything that existed
+    -- before the cursor model is treated as already delivered. Legacy rows get
+    -- an exact audit marker without mutating read_at; event-log recipients start
+    -- at the current global high-water. Fresh stores have no rows, so they start
+    -- naturally at cursor zero.
+    INSERT INTO events(type,id,team,agent,msg_id,at)
+      SELECT 'message_read',
+             'read-cursor-v1:' || m.team || ':' || m.to_agent || ':' || m.id,
+             m.team,m.to_agent,CAST(m.id AS TEXT),
+             strftime('%Y-%m-%dT%H:%M:%SZ','now')
+        FROM messages m
+       WHERE NOT EXISTS(SELECT 1 FROM storage_metadata
+                         WHERE key='read_cursor_v1')
+         AND NOT EXISTS(SELECT 1 FROM events r
+                         WHERE r.type='message_read' AND r.team=m.team
+                           AND r.agent=m.to_agent
+                           AND r.msg_id=CAST(m.id AS TEXT));
+    INSERT INTO read_cursors(team,agent,local_position)
+      SELECT recipients.team,recipients.agent,
+             COALESCE((SELECT seq FROM sqlite_sequence WHERE name='events'),0)
+        FROM (
+          SELECT team,to_agent AS agent FROM events
+           WHERE type='message_sent' AND team IS NOT NULL AND to_agent IS NOT NULL
+          UNION
+          SELECT team,to_agent AS agent FROM messages
+        ) recipients
+       WHERE NOT EXISTS(SELECT 1 FROM storage_metadata
+                         WHERE key='read_cursor_v1')
+      ON CONFLICT(team,agent) DO UPDATE SET local_position=MAX(
+        read_cursors.local_position,excluded.local_position);
+    INSERT OR IGNORE INTO storage_metadata(key,value)
+      VALUES('read_cursor_v1','1');
   " >/dev/null 2>&1 || { echo runtime_error; return 13; }
   echo ok
 }
@@ -145,8 +187,51 @@ storage_send() {
   printf '%s\n' "$id"
 }
 
+# storage_read_cursor_get <team> <agent> — opaque local read frontier.
+storage_read_cursor_get() {
+  local team="$1" agent="$2"
+  storage_init >/dev/null || return 13
+  _sqlite_data "SELECT COALESCE((SELECT local_position FROM read_cursors
+    WHERE team='$(_sqlite_lit "$team")' AND agent='$(_sqlite_lit "$agent")'),0);"
+}
+
+# Advance one recipient's local read frontier after a successful driver scan.
+# Exact IDs are recorded first; the frontier is then capped immediately before
+# the first still-unread addressed message, so a stale/malformed caller cannot
+# skip an unseen row merely by presenting a later cursor.
+storage_read_cursor_consume() {
+  local team="$1" agent="$2" target="$3"; shift 3
+  case "$target" in ''|*[!0-9]*) echo runtime_error; return 13 ;; esac
+  storage_init >/dev/null || { echo runtime_error; return 13; }
+  local db tl al at id sql=""
+  db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
+  at="$(_sqlite_now)"
+  for id in "$@"; do
+    sql="$sql
+      INSERT INTO events(type,id,team,agent,msg_id,at)
+      SELECT 'message_read','$(_sqlite_lit "$(_sqlite_uuid7)")','$tl','$al',
+             '$(_sqlite_lit "$id")','$(_sqlite_lit "$at")'
+       WHERE NOT EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'
+         AND r.team='$tl' AND r.agent='$al' AND r.msg_id='$(_sqlite_lit "$id")');"
+  done
+  agmsg_sqlite "$db" "BEGIN IMMEDIATE;
+    $sql
+    INSERT OR IGNORE INTO read_cursors(team,agent,local_position)
+      VALUES('$tl','$al',0);
+    UPDATE read_cursors SET local_position=MAX(local_position,COALESCE((
+      SELECT MIN(e.seq)-1 FROM events e
+       WHERE e.type='message_sent' AND e.team='$tl' AND e.to_agent='$al'
+         AND e.seq>read_cursors.local_position AND e.seq<=$target
+         AND NOT EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'
+           AND r.team=e.team AND r.agent='$al' AND r.msg_id=e.id)
+    ),$target)) WHERE team='$tl' AND agent='$al';
+    COMMIT;" >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  echo ok
+}
+
 # storage_list_unread <team> <agent> [--limit N]
-# events-unread ∪ legacy-unread (read_at IS NULL, not superseded by a read event).
+# The local cursor is the fast contiguous boundary; exact message_read events
+# cover safe out-of-order reads. Legacy rows remain a frozen compatibility path.
 storage_list_unread() {
   local team="$1" agent="$2" limit=""
   shift 2
@@ -161,6 +246,8 @@ storage_list_unread() {
              e.at AS ts, 1 AS src, e.seq AS ord
       FROM events e
       WHERE e.type='message_sent' AND e.team='$tl' AND e.to_agent='$al'
+        AND e.seq>COALESCE((SELECT local_position FROM read_cursors
+          WHERE team='$tl' AND agent='$al'),0)
         AND NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
                         AND r.team=e.team AND r.agent='$al' AND r.msg_id=e.id)
       UNION ALL
@@ -180,20 +267,8 @@ storage_list_unread() {
 storage_mark_read_batch() {
   local team="$1" agent="$2"; shift 2
   [ $# -gt 0 ] || { echo ok; return 0; }
-  local db at tl al; db="$(_sqlite_db)"; at="$(_sqlite_now)"
-  tl="$(_sqlite_lit "$team")"; al="$(_sqlite_lit "$agent")"
-  storage_init >/dev/null
-  local id sql=""
-  for id in "$@"; do
-    local idl rid; idl="$(_sqlite_lit "$id")"; rid="$(_sqlite_uuid7)"
-    sql="$sql
-    INSERT INTO events (type,id,team,agent,msg_id,at)
-    SELECT 'message_read','$(_sqlite_lit "$rid")','$tl','$al','$idl','$(_sqlite_lit "$at")'
-    WHERE NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
-                      AND r.team='$tl' AND r.agent='$al' AND r.msg_id='$idl');"
-  done
-  agmsg_sqlite "$db" "$sql" >/dev/null 2>&1 || { echo runtime_error; return 13; }
-  echo ok
+  local tip; tip=$(storage_watch_tip "$team:$agent") || { echo runtime_error; return 13; }
+  storage_read_cursor_consume "$team" "$agent" "$tip" "$@"
 }
 
 # --- contract: delivery cursor ---------------------------------------------

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -221,10 +221,12 @@ storage_read_cursor_consume() {
     UPDATE read_cursors SET local_position=MAX(local_position,COALESCE((
       SELECT MIN(e.seq)-1 FROM events e
        WHERE e.type='message_sent' AND e.team='$tl' AND e.to_agent='$al'
-         AND e.seq>read_cursors.local_position AND e.seq<=$target
+         AND e.seq>read_cursors.local_position
+         AND e.seq<=MIN($target,$(_sqlite_highwater))
          AND NOT EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'
            AND r.team=e.team AND r.agent='$al' AND r.msg_id=e.id)
-    ),$target)) WHERE team='$tl' AND agent='$al';
+    ),MIN($target,$(_sqlite_highwater))))
+    WHERE team='$tl' AND agent='$al';
     COMMIT;" >/dev/null 2>&1 || { echo runtime_error; return 13; }
   echo ok
 }
@@ -303,6 +305,9 @@ storage_watch_after() {
     FROM events
     WHERE type='message_sent' AND seq > $cursor
       AND (team || ':' || to_agent) IN ($pairs)
+      AND NOT EXISTS(SELECT 1 FROM events r
+        WHERE r.type='message_read' AND r.team=events.team
+          AND r.agent=events.to_agent AND r.msg_id=events.id)
     ORDER BY seq ASC;
     SELECT json_object('type','cursor','cursor',
                        CAST(MAX($cursor, $(_sqlite_highwater)) AS TEXT));

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -25,6 +25,7 @@ function usage() {
   remote-sync.sh once --team NAME [--limit N]
   remote-sync.sh run --team NAME [--limit N] [--interval SECONDS]
   remote-sync.sh reprocess --team NAME [--limit N]
+  remote-sync.sh unblock-read --team NAME --member-id UUID
 
 AGMSG_SYNC_TOKEN is required and is never written to config or argv.`;
 }
@@ -967,7 +968,7 @@ export async function readStateCycle(config, limit, dependencies = {}) {
   let page;
   const blockedThisCycle = new Set();
   for (const updates of batches) {
-    let remaining = updates;
+    let remaining = updates.filter((update) => !blockedThisCycle.has(update.member_id));
     for (;;) {
       try {
         page = await requestCall(config, "/v1/read-state/sync", { method: "POST",
@@ -975,9 +976,13 @@ export async function readStateCycle(config, limit, dependencies = {}) {
           body: JSON.stringify({ updates: remaining, page_after: null, page_limit: pageLimit }) });
         break;
       } catch (error) {
-        const memberId = error?.body?.error?.details?.member_id;
-        if (error?.code !== "read-state-limit-exceeded" || !UUID_V7.test(memberId ?? "") ||
-            !members.some((member) => member.member_id === memberId) || blockedThisCycle.has(memberId)) {
+        const reportedMemberId = error?.body?.error?.details?.member_id;
+        const memberId = remaining.some((update) => update.member_id === reportedMemberId)
+          ? reportedMemberId
+          : remaining.find((update) => update.exact_wire_ids.length > 0)?.member_id;
+        if (error?.code !== "read-state-limit-exceeded" || !UUID_V7.test(reportedMemberId ?? "") ||
+            !members.some((member) => member.member_id === reportedMemberId) ||
+            !UUID_V7.test(memberId ?? "") || blockedThisCycle.has(memberId)) {
           throw error;
         }
         blockedThisCycle.add(memberId);
@@ -985,7 +990,7 @@ export async function readStateCycle(config, limit, dependencies = {}) {
           reason: "read-state-limit-exceeded" }]);
         remaining = remaining.filter((update) => update.member_id !== memberId);
         await eventCall("read-state.blocked", { member_id: memberId,
-          reason: "read-state-limit-exceeded" });
+          reported_member_id: reportedMemberId, reason: "read-state-limit-exceeded" });
       }
     }
   }
@@ -1135,12 +1140,22 @@ async function reprocessCycle(config, limit) {
 async function main() {
   const [command, ...rest] = process.argv.slice(2);
   const args = options(rest);
-  if (!["configure", "once", "run", "reprocess"].includes(command)) throw new Error(usage());
+  if (!["configure", "once", "run", "reprocess", "unblock-read"].includes(command)) {
+    throw new Error(usage());
+  }
   if (command === "configure") { await configure(args); return; }
   const team = requireName(args.team, "team");
   const limit = Number(args.limit ?? 100);
   if (!Number.isInteger(limit) || limit < 1 || limit > 1000) throw new Error("limit must be 1..1000");
   const config = await loadConfig(team);
+  if (command === "unblock-read") {
+    if (!UUID_V7.test(args["member-id"] ?? "")) throw new Error("member-id must be a canonical UUIDv7");
+    const result = await driver("read-unblock", config, [{
+      type: "sync_read_unblock", member_id: args["member-id"],
+    }]);
+    await event("read-state.unblocked", { member_id: args["member-id"], result: result[0] ?? null });
+    return;
+  }
   if (command === "reprocess") { await reprocessCycle(config, limit); return; }
   if (command === "once") { await cycle(config, limit); return; }
   const interval = Number(args.interval ?? 5);

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -432,6 +432,7 @@ export function validateMembers(config, value) {
   }
   const ids = new Set();
   const names = new Set();
+  const registrationIds = new Set();
   let previous = "";
   for (const member of value.members) {
     if (!member || !UUID_V7.test(member.member_id) ||
@@ -439,6 +440,21 @@ export function validateMembers(config, value) {
         !Array.isArray(member.registrations) || ids.has(member.member_id) ||
         names.has(member.name) || (previous && member.member_id <= previous)) {
       throw new Error("members response is not canonical");
+    }
+    let priorRegistration = "";
+    for (const registration of member.registrations) {
+      if (Object.keys(registration).sort().join(",") !==
+          "installation_id,registration_id,type" ||
+          !UUID_V7.test(registration.registration_id) ||
+          !UUID_V7.test(registration.installation_id) ||
+          typeof registration.type !== "string" ||
+          !/^[a-z0-9][a-z0-9._-]{0,63}$/u.test(registration.type) ||
+          registrationIds.has(registration.registration_id) ||
+          (priorRegistration && registration.registration_id <= priorRegistration)) {
+        throw new Error("member registrations are not canonical");
+      }
+      registrationIds.add(registration.registration_id);
+      priorRegistration = registration.registration_id;
     }
     ids.add(member.member_id); names.add(member.name); previous = member.member_id;
   }
@@ -708,6 +724,7 @@ export function readStateUpdateBatches(members, records) {
   const memberIds = new Set(members.map((member) => member.member_id));
   const frontiers = new Map();
   const exact = new Map(members.map((member) => [member.member_id, []]));
+  const blocked = new Map();
   for (const record of records) {
     if (!memberIds.has(record.member_id)) throw new Error("driver emitted an unknown read member");
     if (record.type === "sync_read_frontier") {
@@ -716,12 +733,24 @@ export function readStateUpdateBatches(members, records) {
     } else if (record.type === "sync_read_exact") {
       if (!UUID_V4.test(record.wire_id)) throw new Error("driver emitted an invalid exact wire ID");
       exact.get(record.member_id).push(record.wire_id);
+    } else if (record.type === "sync_read_blocked") {
+      if (blocked.has(record.member_id) ||
+          !["member-name-mismatch", "read-state-limit-exceeded"].includes(record.reason)) {
+        throw new Error("driver emitted an invalid blocked read member");
+      }
+      blocked.set(record.member_id, record.reason);
     } else {
       throw new Error("driver emitted an unknown read-state record");
     }
   }
   const entries = [];
   for (const member of members) {
+    if (blocked.has(member.member_id)) {
+      if (frontiers.has(member.member_id) || exact.get(member.member_id).length > 0) {
+        throw new Error("driver emitted updates for a blocked read member");
+      }
+      continue;
+    }
     const serverSeq = frontiers.get(member.member_id);
     if (serverSeq === undefined) throw new Error("driver omitted a member read frontier");
     const wires = exact.get(member.member_id);
@@ -748,15 +777,28 @@ export function readStateUpdateBatches(members, records) {
   return batches.length > 0 ? batches : [[]];
 }
 
-export function validateReadStatePage(config, value, pageLimit) {
+export function stage2ReadStateSupported(records) {
+  if (!Array.isArray(records) || records.length !== 1 ||
+      records[0]?.type !== "sync_driver_capabilities" ||
+      !Array.isArray(records[0].capabilities) ||
+      records[0].capabilities.some((value) => typeof value !== "string")) {
+    throw new Error("driver capability response is invalid");
+  }
+  return records[0].capabilities.includes("stage2-read-state");
+}
+
+export function validateReadStatePage(config, value, pageLimit, pageAfter = null) {
   validateBinding(config, value);
   const floor = BigInt(sequence(value.min_available_seq, "read-state floor"));
   const current = BigInt(sequence(value.current_seq, "read-state current_seq"));
   if (floor > current || !Array.isArray(value.items) || value.items.length > pageLimit ||
+      (value.has_more === true && value.items.length === 0) ||
       typeof value.has_more !== "boolean") {
     throw new Error("read-state response is invalid");
   }
-  let prior = null;
+  const afterKey = pageAfter === null ? null : [pageAfter.member_id,
+    pageAfter.kind === "frontier" ? 0 : 1, pageAfter.wire_id ?? ""];
+  let prior = afterKey;
   for (const item of value.items) {
     const fields = Object.keys(item).sort().join(",");
     if (!UUID_V7.test(item?.member_id) ||
@@ -783,6 +825,22 @@ export function validateReadStatePage(config, value, pageLimit) {
     throw new Error("read-state next page key is inconsistent");
   }
   return value;
+}
+
+export async function consistentReadStateContext(config, initialCapabilities, fetcher = request) {
+  let capabilities = initialCapabilities;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const roster = await fetcher(config, "/v1/members");
+    const members = validateMembers(config, roster);
+    if (roster.min_available_seq === capabilities.min_available_seq) {
+      return { capabilities, members };
+    }
+    capabilities = await fetcher(config, "/v1/capabilities");
+    validateCapabilities(config, capabilities);
+  }
+  const error = new Error("retention changed while loading the read-state context");
+  error.retryable = true;
+  throw error;
 }
 
 function parseCheckpoint(value) {
@@ -887,45 +945,84 @@ async function configure(args) {
     remote_team_id: config.remote_team_id });
 }
 
-async function readStateCycle(config, limit) {
-  const capabilities = await request(config, "/v1/capabilities");
-  validateCapabilities(config, capabilities);
-  const roster = await request(config, "/v1/members");
-  const members = validateMembers(config, roster);
-  if (roster.min_available_seq !== capabilities.min_available_seq) {
-    throw new Error("members and capabilities retention floors differ");
+export async function readStateCycle(config, limit, dependencies = {}) {
+  const driverCall = dependencies.driverCall ?? driver;
+  const requestCall = dependencies.requestCall ?? request;
+  const eventCall = dependencies.eventCall ?? event;
+  const driverCapabilities = await driverCall("capabilities", config, []);
+  if (!stage2ReadStateSupported(driverCapabilities)) {
+    await eventCall("read-state.skipped", { reason: "driver-capability-not-advertised" });
+    return;
   }
-  const prepared = await driver("read-prepare", config, [{ type: "sync_read_context",
+  const initialCapabilities = await requestCall(config, "/v1/capabilities");
+  validateCapabilities(config, initialCapabilities);
+  const { capabilities, members } = await consistentReadStateContext(
+    config, initialCapabilities, requestCall,
+  );
+  const prepared = await driverCall("read-prepare", config, [{ type: "sync_read_context",
     min_available_seq: capabilities.min_available_seq, current_seq: capabilities.current_seq,
     members }]);
   const batches = readStateUpdateBatches(members, prepared);
   const pageLimit = Math.min(limit, 1000);
   let page;
+  const blockedThisCycle = new Set();
   for (const updates of batches) {
-    page = await request(config, "/v1/read-state/sync", { method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ updates, page_after: null, page_limit: pageLimit }) });
+    let remaining = updates;
+    for (;;) {
+      try {
+        page = await requestCall(config, "/v1/read-state/sync", { method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ updates: remaining, page_after: null, page_limit: pageLimit }) });
+        break;
+      } catch (error) {
+        const memberId = error?.body?.error?.details?.member_id;
+        if (error?.code !== "read-state-limit-exceeded" || !UUID_V7.test(memberId ?? "") ||
+            !members.some((member) => member.member_id === memberId) || blockedThisCycle.has(memberId)) {
+          throw error;
+        }
+        blockedThisCycle.add(memberId);
+        await driverCall("read-block", config, [{ type: "sync_read_block", member_id: memberId,
+          reason: "read-state-limit-exceeded" }]);
+        remaining = remaining.filter((update) => update.member_id !== memberId);
+        await eventCall("read-state.blocked", { member_id: memberId,
+          reason: "read-state-limit-exceeded" });
+      }
+    }
   }
   let pageAfter = null;
   let pageCount = 0;
+  const seenFrontiers = new Set();
   for (;;) {
     if (pageAfter !== null) {
-      page = await request(config, "/v1/read-state/sync", { method: "POST",
+      page = await requestCall(config, "/v1/read-state/sync", { method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ updates: [], page_after: pageAfter, page_limit: pageLimit }) });
     }
-    validateReadStatePage(config, page, pageLimit);
+    validateReadStatePage(config, page, pageLimit, pageAfter);
+    for (const item of page.items) {
+      if (item.kind === "frontier" && seenFrontiers.has(item.member_id)) {
+        throw new Error("read-state stream repeated a member frontier");
+      }
+      if (item.kind === "frontier") seenFrontiers.add(item.member_id);
+    }
     const records = [{ type: "sync_read_snapshot",
       min_available_seq: page.min_available_seq, current_seq: page.current_seq },
     ...page.items.map((item) => item.kind === "frontier" ?
       { type: "sync_read_frontier", member_id: item.member_id, server_seq: item.server_seq } :
       { type: "sync_read_exact", member_id: item.member_id, wire_id: item.wire_id })];
-    const applied = await driver("read-apply", config, records);
+    const applied = await driverCall("read-apply", config, records);
     pageCount += 1;
-    await event("read-state.applied", { page: pageCount, item_count: page.items.length,
+    if (pageCount > 65_536 + members.length + 1) {
+      throw new Error("read-state pagination exceeded the bounded stream size");
+    }
+    await eventCall("read-state.applied", { page: pageCount, item_count: page.items.length,
       result: applied[0] ?? null });
     if (!page.has_more) break;
     pageAfter = page.next_page_after;
+  }
+  if (seenFrontiers.size !== members.length ||
+      members.some((member) => !seenFrontiers.has(member.member_id))) {
+    throw new Error("read-state stream omitted a member frontier");
   }
 }
 

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -107,6 +107,22 @@ async function loadConfig(team) {
   return value;
 }
 
+async function localAgentRoster(team) {
+  const supplied = process.env.AGMSG_SYNC_LOCAL_ROSTER_FILE;
+  const skillRoot = process.env.SKILL_DIR;
+  const path = supplied || (skillRoot ? join(skillRoot, "teams", team, "config.json") : "");
+  if (!path) throw new Error("local team roster path is unavailable");
+  const value = JSON.parse(await readFile(path, "utf8"));
+  if (!value?.agents || typeof value.agents !== "object" || Array.isArray(value.agents)) {
+    throw new Error("local team roster is invalid");
+  }
+  const names = Object.keys(value.agents).map((name) => requireName(name, "local agent name")).sort();
+  if (names.length > 1000 || new Set(names).size !== names.length) {
+    throw new Error("local team roster is invalid");
+  }
+  return names;
+}
+
 function requireUnicodeScalars(value, label) {
   for (let index = 0; index < value.length; index += 1) {
     const unit = value.charCodeAt(index);
@@ -950,6 +966,7 @@ export async function readStateCycle(config, limit, dependencies = {}) {
   const driverCall = dependencies.driverCall ?? driver;
   const requestCall = dependencies.requestCall ?? request;
   const eventCall = dependencies.eventCall ?? event;
+  const localAgentsCall = dependencies.localAgentsCall ?? localAgentRoster;
   const driverCapabilities = await driverCall("capabilities", config, []);
   if (!stage2ReadStateSupported(driverCapabilities)) {
     await eventCall("read-state.skipped", { reason: "driver-capability-not-advertised" });
@@ -960,9 +977,10 @@ export async function readStateCycle(config, limit, dependencies = {}) {
   const { capabilities, members } = await consistentReadStateContext(
     config, initialCapabilities, requestCall,
   );
+  const localAgents = await localAgentsCall(config.local_team);
   const prepared = await driverCall("read-prepare", config, [{ type: "sync_read_context",
     min_available_seq: capabilities.min_available_seq, current_seq: capabilities.current_seq,
-    members }]);
+    members, local_agents: localAgents }]);
   const batches = readStateUpdateBatches(members, prepared);
   const pageLimit = Math.min(limit, 1000);
   let page;

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -49,7 +49,7 @@ function options(args) {
 }
 
 function requireName(value, label) {
-  if (typeof value !== "string" || value.length < 1 || value.length > 128 ||
+  if (typeof value !== "string" || [...value].length < 1 || [...value].length > 128 ||
       value.startsWith("-") || value === "." || value === ".." ||
       /[./\\"\[\]\u0000-\u001f\u007f]/u.test(value) || value !== value.normalize("NFC")) {
     throw new Error(`${label} is invalid`);
@@ -423,6 +423,28 @@ function validateBinding(config, body) {
   }
 }
 
+export function validateMembers(config, value) {
+  validateBinding(config, value);
+  sequence(value.min_available_seq, "members min_available_seq");
+  sequence(value.members_revision, "members_revision");
+  if (!Array.isArray(value.members) || value.members.length > 1000) {
+    throw new Error("members response is invalid");
+  }
+  const ids = new Set();
+  const names = new Set();
+  let previous = "";
+  for (const member of value.members) {
+    if (!member || !UUID_V7.test(member.member_id) ||
+        requireName(member.name, "member name") !== member.name ||
+        !Array.isArray(member.registrations) || ids.has(member.member_id) ||
+        names.has(member.name) || (previous && member.member_id <= previous)) {
+      throw new Error("members response is not canonical");
+    }
+    ids.add(member.member_id); names.add(member.name); previous = member.member_id;
+  }
+  return value.members.map(({ member_id, name }) => ({ member_id, name }));
+}
+
 export async function driver(operation, config, input, extra = []) {
   const script = process.env.AGMSG_SYNC_DRIVER;
   if (!script) throw new Error("AGMSG_SYNC_DRIVER is not set");
@@ -682,6 +704,87 @@ export function validateAckMapping(candidates, acks) {
   });
 }
 
+export function readStateUpdateBatches(members, records) {
+  const memberIds = new Set(members.map((member) => member.member_id));
+  const frontiers = new Map();
+  const exact = new Map(members.map((member) => [member.member_id, []]));
+  for (const record of records) {
+    if (!memberIds.has(record.member_id)) throw new Error("driver emitted an unknown read member");
+    if (record.type === "sync_read_frontier") {
+      if (frontiers.has(record.member_id)) throw new Error("driver emitted duplicate read frontier");
+      frontiers.set(record.member_id, sequence(record.server_seq, "prepared read frontier"));
+    } else if (record.type === "sync_read_exact") {
+      if (!UUID_V4.test(record.wire_id)) throw new Error("driver emitted an invalid exact wire ID");
+      exact.get(record.member_id).push(record.wire_id);
+    } else {
+      throw new Error("driver emitted an unknown read-state record");
+    }
+  }
+  const entries = [];
+  for (const member of members) {
+    const serverSeq = frontiers.get(member.member_id);
+    if (serverSeq === undefined) throw new Error("driver omitted a member read frontier");
+    const wires = exact.get(member.member_id);
+    if (new Set(wires).size !== wires.length) throw new Error("driver emitted duplicate exact reads");
+    if (wires.length === 0) {
+      entries.push({ member_id: member.member_id, server_seq: serverSeq, exact_wire_ids: [] });
+    } else {
+      for (let offset = 0; offset < wires.length; offset += 1000) {
+        entries.push({ member_id: member.member_id, server_seq: serverSeq,
+          exact_wire_ids: wires.slice(offset, offset + 1000) });
+      }
+    }
+  }
+  const batches = [];
+  let batch = []; let exactCount = 0; let batchMembers = new Set();
+  for (const entry of entries) {
+    if (batch.length >= 1000 || exactCount + entry.exact_wire_ids.length > 1000 ||
+        batchMembers.has(entry.member_id)) {
+      batches.push(batch); batch = []; exactCount = 0; batchMembers = new Set();
+    }
+    batch.push(entry); exactCount += entry.exact_wire_ids.length; batchMembers.add(entry.member_id);
+  }
+  if (batch.length > 0) batches.push(batch);
+  return batches.length > 0 ? batches : [[]];
+}
+
+export function validateReadStatePage(config, value, pageLimit) {
+  validateBinding(config, value);
+  const floor = BigInt(sequence(value.min_available_seq, "read-state floor"));
+  const current = BigInt(sequence(value.current_seq, "read-state current_seq"));
+  if (floor > current || !Array.isArray(value.items) || value.items.length > pageLimit ||
+      typeof value.has_more !== "boolean") {
+    throw new Error("read-state response is invalid");
+  }
+  let prior = null;
+  for (const item of value.items) {
+    const fields = Object.keys(item).sort().join(",");
+    if (!UUID_V7.test(item?.member_id) ||
+        (item.kind === "frontier" && (fields !== "kind,member_id,server_seq" ||
+          BigInt(sequence(item.server_seq, "read-state frontier")) < floor ||
+          BigInt(item.server_seq) > current)) ||
+        (item.kind === "exact" && (fields !== "kind,member_id,wire_id" || !UUID_V4.test(item.wire_id))) ||
+        !["frontier", "exact"].includes(item.kind)) {
+      throw new Error("read-state item is invalid");
+    }
+    const key = [item.member_id, item.kind === "frontier" ? 0 : 1, item.wire_id ?? ""];
+    if (prior && (key[0] < prior[0] || (key[0] === prior[0] &&
+        (key[1] < prior[1] || (key[1] === prior[1] && key[2] <= prior[2]))))) {
+      throw new Error("read-state page order is not canonical");
+    }
+    prior = key;
+  }
+  const expectedNext = value.has_more && value.items.length > 0 ? (() => {
+    const last = value.items.at(-1);
+    return last.kind === "frontier" ? { member_id: last.member_id, kind: "frontier" } :
+      { member_id: last.member_id, kind: "exact", wire_id: last.wire_id };
+  })() : null;
+  if (JSON.stringify(value.next_page_after) !== JSON.stringify(expectedNext)) {
+    throw new Error("read-state next page key is inconsistent");
+  }
+  return value;
+}
+
 function parseCheckpoint(value) {
   const match = /^(0|[1-9][0-9]*):([0-9a-f]{64})$/u.exec(value ?? "");
   if (!match) throw new Error("age-checkpoint must be REVISION:SHA256");
@@ -784,6 +887,48 @@ async function configure(args) {
     remote_team_id: config.remote_team_id });
 }
 
+async function readStateCycle(config, limit) {
+  const capabilities = await request(config, "/v1/capabilities");
+  validateCapabilities(config, capabilities);
+  const roster = await request(config, "/v1/members");
+  const members = validateMembers(config, roster);
+  if (roster.min_available_seq !== capabilities.min_available_seq) {
+    throw new Error("members and capabilities retention floors differ");
+  }
+  const prepared = await driver("read-prepare", config, [{ type: "sync_read_context",
+    min_available_seq: capabilities.min_available_seq, current_seq: capabilities.current_seq,
+    members }]);
+  const batches = readStateUpdateBatches(members, prepared);
+  const pageLimit = Math.min(limit, 1000);
+  let page;
+  for (const updates of batches) {
+    page = await request(config, "/v1/read-state/sync", { method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ updates, page_after: null, page_limit: pageLimit }) });
+  }
+  let pageAfter = null;
+  let pageCount = 0;
+  for (;;) {
+    if (pageAfter !== null) {
+      page = await request(config, "/v1/read-state/sync", { method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ updates: [], page_after: pageAfter, page_limit: pageLimit }) });
+    }
+    validateReadStatePage(config, page, pageLimit);
+    const records = [{ type: "sync_read_snapshot",
+      min_available_seq: page.min_available_seq, current_seq: page.current_seq },
+    ...page.items.map((item) => item.kind === "frontier" ?
+      { type: "sync_read_frontier", member_id: item.member_id, server_seq: item.server_seq } :
+      { type: "sync_read_exact", member_id: item.member_id, wire_id: item.wire_id })];
+    const applied = await driver("read-apply", config, records);
+    pageCount += 1;
+    await event("read-state.applied", { page: pageCount, item_count: page.items.length,
+      result: applied[0] ?? null });
+    if (!page.has_more) break;
+    pageAfter = page.next_page_after;
+  }
+}
+
 async function cycle(config, limit) {
   const ready = await health(config.server_url);
   if (ready.server_instance_id !== config.server_instance_id) throw new Error("health server instance changed");
@@ -855,6 +1000,7 @@ async function cycle(config, limit) {
     cursor = page.next_after;
     if (!page.has_more) break;
   }
+  await readStateCycle(config, limit);
 }
 
 async function reprocessCycle(config, limit) {

--- a/scripts/internal/rename-sync-config.mjs
+++ b/scripts/internal/rename-sync-config.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { lstat, open, readFile, rename, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import process from "node:process";
+
+const [root, oldTeam, newTeam] = process.argv.slice(2);
+if (!root || !oldTeam || !newTeam) {
+  throw new Error("usage: rename-sync-config.mjs <storage-root> <old-team> <new-team>");
+}
+const directory = join(root, "remote-sync");
+const source = join(directory, `${encodeURIComponent(oldTeam)}.json`);
+const target = join(directory, `${encodeURIComponent(newTeam)}.json`);
+try {
+  await lstat(target);
+  throw new Error("target remote sync config already exists");
+} catch (error) {
+  if (error?.code !== "ENOENT") throw error;
+}
+let metadata;
+try {
+  metadata = await lstat(source);
+} catch (error) {
+  if (error?.code === "ENOENT") process.exit(0);
+  throw error;
+}
+if (!metadata.isFile() || metadata.isSymbolicLink() ||
+    (process.platform !== "win32" && (metadata.mode & 0o077) !== 0)) {
+  throw new Error("remote sync config must be a private regular file");
+}
+const config = JSON.parse(await readFile(source, "utf8"));
+if (config.local_team !== oldTeam) throw new Error("remote sync config local team mismatch");
+config.local_team = newTeam;
+const temporary = `${target}.${process.pid}.tmp`;
+const handle = await open(temporary, "wx", 0o600);
+try {
+  await handle.writeFile(`${JSON.stringify(config, null, 2)}\n`, "utf8");
+  await handle.sync();
+} finally {
+  await handle.close();
+}
+try {
+  await rename(temporary, target);
+  await unlink(source);
+  if (process.platform !== "win32") {
+    const directoryHandle = await open(directory, "r");
+    try { await directoryHandle.sync(); } finally { await directoryHandle.close(); }
+  }
+} catch (error) {
+  try { await unlink(temporary); } catch {}
+  throw error;
+}

--- a/scripts/internal/storage-sync-driver.sh
+++ b/scripts/internal/storage-sync-driver.sh
@@ -11,6 +11,10 @@ agmsg_storage_load
 
 op="${1:-}"; shift || true
 case "$op" in
+  capabilities) command -v storage_describe >/dev/null 2>&1 || exit 14
+                capabilities=$(storage_describe | sed -n 's/^capabilities=//p')
+                jq -nc --arg value "$capabilities" \
+                  '{type:"sync_driver_capabilities",capabilities:($value|split(",")|map(select(length>0)))}' ;;
   prepare)   command -v storage_sync_prepare_push >/dev/null 2>&1 || exit 14
              storage_sync_prepare_push "$@" ;;
   reconcile) command -v storage_sync_reconcile_push >/dev/null 2>&1 || exit 14
@@ -23,5 +27,7 @@ case "$op" in
                 storage_sync_prepare_read_state "$@" ;;
   read-apply) command -v storage_sync_apply_read_state >/dev/null 2>&1 || exit 14
               storage_sync_apply_read_state "$@" ;;
-  *) echo "usage: storage-sync-driver.sh prepare|reconcile|apply|reprocess|read-prepare|read-apply ..." >&2; exit 2 ;;
+  read-block) command -v storage_sync_block_read_state >/dev/null 2>&1 || exit 14
+              storage_sync_block_read_state "$@" ;;
+  *) echo "usage: storage-sync-driver.sh capabilities|prepare|reconcile|apply|reprocess|read-prepare|read-apply|read-block ..." >&2; exit 2 ;;
 esac

--- a/scripts/internal/storage-sync-driver.sh
+++ b/scripts/internal/storage-sync-driver.sh
@@ -29,5 +29,7 @@ case "$op" in
               storage_sync_apply_read_state "$@" ;;
   read-block) command -v storage_sync_block_read_state >/dev/null 2>&1 || exit 14
               storage_sync_block_read_state "$@" ;;
-  *) echo "usage: storage-sync-driver.sh capabilities|prepare|reconcile|apply|reprocess|read-prepare|read-apply|read-block ..." >&2; exit 2 ;;
+  read-unblock) command -v storage_sync_unblock_read_state >/dev/null 2>&1 || exit 14
+                storage_sync_unblock_read_state "$@" ;;
+  *) echo "usage: storage-sync-driver.sh capabilities|prepare|reconcile|apply|reprocess|read-prepare|read-apply|read-block|read-unblock ..." >&2; exit 2 ;;
 esac

--- a/scripts/internal/storage-sync-driver.sh
+++ b/scripts/internal/storage-sync-driver.sh
@@ -19,5 +19,9 @@ case "$op" in
              storage_sync_apply_pull "$@" ;;
   reprocess) command -v storage_sync_reprocess >/dev/null 2>&1 || exit 14
              storage_sync_reprocess "$@" ;;
-  *) echo "usage: storage-sync-driver.sh prepare|reconcile|apply|reprocess ..." >&2; exit 2 ;;
+  read-prepare) command -v storage_sync_prepare_read_state >/dev/null 2>&1 || exit 14
+                storage_sync_prepare_read_state "$@" ;;
+  read-apply) command -v storage_sync_apply_read_state >/dev/null 2>&1 || exit 14
+              storage_sync_apply_read_state "$@" ;;
+  *) echo "usage: storage-sync-driver.sh prepare|reconcile|apply|reprocess|read-prepare|read-apply ..." >&2; exit 2 ;;
 esac

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -116,6 +116,15 @@ if [ "$(agmsg_storage_driver)" = jsonl ]; then
   storage_rename_team "$OLD_TEAM" "$NEW_TEAM" >/dev/null
 fi
 
+SYNC_CONFIG_DIR="$(agmsg_storage_dir)/remote-sync"
+if [ -d "$SYNC_CONFIG_DIR" ]; then
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/lib/node.sh"
+  NODE_BIN=$(agmsg_resolve_node)
+  "$NODE_BIN" "$SCRIPT_DIR/internal/rename-sync-config.mjs" \
+    "$(agmsg_storage_dir)" "$OLD_TEAM" "$NEW_TEAM"
+fi
+
 agmsg_lock_release
 # The old dir no longer holds a team (its config moved out); best-effort remove
 # the now-empty dir. A concurrent join to the old name after this point

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -92,10 +92,28 @@ fi
 if [ -f "$DB" ]; then
   OLD_LIT=$(agmsg_sqlesc "$OLD_TEAM")
   NEW_LIT=$(agmsg_sqlesc "$NEW_TEAM")
-  agmsg_sqlite "$DB" "UPDATE messages SET team='$NEW_LIT' WHERE team='$OLD_LIT';"
-  # events may not exist yet on an install that has not sent since the storage
-  # flip — best-effort, never abort the rename over a missing optional table.
-  agmsg_sqlite "$DB" "UPDATE events SET team='$NEW_LIT' WHERE team='$OLD_LIT';" 2>/dev/null || true
+  RENAME_SQL=""
+  for TABLE in events read_cursors sync_bindings sync_messages sync_quarantine \
+    sync_conflicts sync_read_members sync_read_remote_exact sync_read_aliases \
+    sync_read_prepared; do
+    if [ "$(agmsg_sqlite "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='$TABLE';" | tr -d '\r')" = 1 ]; then
+      case "$TABLE" in
+        events|read_cursors) COLUMN=team ;;
+        *) COLUMN=local_team ;;
+      esac
+      RENAME_SQL="$RENAME_SQL UPDATE $TABLE SET $COLUMN='$NEW_LIT' WHERE $COLUMN='$OLD_LIT';"
+    fi
+  done
+  agmsg_sqlite "$DB" "BEGIN IMMEDIATE;
+    UPDATE messages SET team='$NEW_LIT' WHERE team='$OLD_LIT';
+    $RENAME_SQL
+    COMMIT;"
+fi
+
+
+if [ "$(agmsg_storage_driver)" = jsonl ]; then
+  agmsg_storage_load
+  storage_rename_team "$OLD_TEAM" "$NEW_TEAM" >/dev/null
 fi
 
 agmsg_lock_release

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -88,12 +88,32 @@ if [ -f "$DB" ]; then
   TEAM_LIT=$(agmsg_sqlesc "$TEAM")
   OLD_LIT=$(agmsg_sqlesc "$OLD_NAME")
   NEW_LIT=$(agmsg_sqlesc "$NEW_NAME")
-  agmsg_sqlite "$DB" "UPDATE messages SET from_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND from_agent='$OLD_LIT';"
-  agmsg_sqlite "$DB" "UPDATE messages SET to_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND to_agent='$OLD_LIT';"
-  # events may not exist yet on an install that has not sent since the storage
-  # flip — best-effort, never abort the rename over a missing optional table.
-  agmsg_sqlite "$DB" "UPDATE events SET from_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND from_agent='$OLD_LIT';" 2>/dev/null || true
-  agmsg_sqlite "$DB" "UPDATE events SET to_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND to_agent='$OLD_LIT';" 2>/dev/null || true
+  RENAME_SQL=""
+  if [ "$(agmsg_sqlite "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='events';" | tr -d '\r')" = 1 ]; then
+    RENAME_SQL="$RENAME_SQL
+      UPDATE events SET from_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND from_agent='$OLD_LIT';
+      UPDATE events SET to_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND to_agent='$OLD_LIT';
+      UPDATE events SET agent='$NEW_LIT' WHERE type='message_read' AND team='$TEAM_LIT' AND agent='$OLD_LIT';"
+  fi
+  if [ "$(agmsg_sqlite "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='read_cursors';" | tr -d '\r')" = 1 ]; then
+    RENAME_SQL="$RENAME_SQL
+      UPDATE read_cursors SET agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND agent='$OLD_LIT';"
+  fi
+  if [ "$(agmsg_sqlite "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='sync_read_members';" | tr -d '\r')" = 1 ]; then
+    RENAME_SQL="$RENAME_SQL
+      UPDATE sync_read_members SET agent='$NEW_LIT' WHERE local_team='$TEAM_LIT' AND agent='$OLD_LIT';
+      UPDATE sync_read_aliases SET agent='$NEW_LIT' WHERE local_team='$TEAM_LIT' AND agent='$OLD_LIT';"
+  fi
+  agmsg_sqlite "$DB" "BEGIN IMMEDIATE;
+    UPDATE messages SET from_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND from_agent='$OLD_LIT';
+    UPDATE messages SET to_agent='$NEW_LIT' WHERE team='$TEAM_LIT' AND to_agent='$OLD_LIT';
+    $RENAME_SQL
+    COMMIT;"
+fi
+
+if [ "$(agmsg_storage_driver)" = jsonl ]; then
+  agmsg_storage_load
+  storage_rename_agent "$TEAM" "$OLD_NAME" "$NEW_NAME" >/dev/null
 fi
 
 agmsg_lock_release

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -101,7 +101,9 @@ if [ -f "$DB" ]; then
   fi
   if [ "$(agmsg_sqlite "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='sync_read_members';" | tr -d '\r')" = 1 ]; then
     RENAME_SQL="$RENAME_SQL
-      UPDATE sync_read_members SET agent='$NEW_LIT' WHERE local_team='$TEAM_LIT' AND agent='$OLD_LIT';
+      UPDATE sync_read_members SET agent='$NEW_LIT',
+        name_mismatch=CASE WHEN remote_agent='$NEW_LIT' THEN 0 ELSE 1 END
+        WHERE local_team='$TEAM_LIT' AND agent='$OLD_LIT';
       UPDATE sync_read_aliases SET agent='$NEW_LIT' WHERE local_team='$TEAM_LIT' AND agent='$OLD_LIT';"
   fi
   agmsg_sqlite "$DB" "BEGIN IMMEDIATE;

--- a/scripts/session-end.sh
+++ b/scripts/session-end.sh
@@ -68,9 +68,8 @@ if [ -f "$PIDFILE" ]; then
   rm -f "$PIDFILE"
 fi
 
-# Drop the per-session stream watermark (see #107) — the session is ending, so
-# there is no restart to resume; a future session_id reuse should start fresh.
-rm -f "$RUN_DIR/watch.$INSTANCE_ID.watermark" 2>/dev/null || true
+# Read progress is store-owned and intentionally survives session end. There is
+# no per-session delivery watermark in the unified cursor model.
 
 # Clean the cc-instance entry that points at this instance id. The enclosing
 # CC process may itself be exiting (matcher=logout/etc.), in which case its

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -210,17 +210,9 @@ agmsg_marker_gc_stale 2>/dev/null || true
 AGENT_PID=$(agmsg_agent_pid "$TYPE" 2>/dev/null || true)
 [ -n "$AGENT_PID" ] && agmsg_write_project_marker "$AGENT_PID" "$PROJECT" 2>/dev/null || true
 
-# Garbage-collect stream watermarks (#107) and readiness sentinels (#108) whose
-# owner session_id is no longer alive — left behind when a watcher dies without
-# running its EXIT trap (SIGKILL, terminal crash). Runs after the dead
-# cc-instance cleanup so actas_lock_sid_alive reflects current liveness. Both
-# are advisory (a live watcher rewrites them on attach; spawn clears the
-# sentinel before use), so this is hygiene, not correctness.
-for f in "$RUN_DIR"/watch.*.watermark; do
-  [ -f "$f" ] || continue
-  wm_sid=${f##*/}; wm_sid=${wm_sid#watch.}; wm_sid=${wm_sid%.watermark}
-  actas_lock_sid_alive "$wm_sid" || rm -f "$f"
-done
+# Garbage-collect readiness sentinels (#108) whose owner session_id is no longer
+# alive. Read progress is store-owned, so there is no per-session watermark to
+# collect.
 for f in "$RUN_DIR"/ready.*; do
   [ -f "$f" ] || continue
   rd_sid=$(cat "$f" 2>/dev/null || true)

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -17,12 +17,9 @@ source "$(cd "$(dirname "$0")" && pwd)/lib/compat.sh"
 #     of those pairs.
 #   - When [active_name] is given, narrows the subscription to only pairs
 #     whose agent name matches — useful for `actas` exclusive role mode.
-#   - A fresh session sets the high-water mark to the current MAX(id) at
-#     startup, so the stream begins with whatever arrives after launch — no
-#     replay of historical messages. The mark is persisted per session_id, so
-#     a restart of this session's watcher (actas/drop/clear/self-restart)
-#     resumes from the last delivered id and does not drop messages that
-#     arrived during the restart gap. See #107.
+#   - Inbox and monitor share the driver's persistent per-(team,agent) read
+#     cursor. A restart resumes from consumed state, and a fresh watcher delivers
+#     existing unread messages instead of jumping over them. See ADR 0008.
 #   - Polls the SQLite DB at AGMSG_WATCH_INTERVAL seconds (default 5, also
 #     overridable via the delivery.monitor.poll_interval config key).
 #   - Emits one line per new message:
@@ -84,7 +81,7 @@ fi
 PROJECT_PATH="$(agmsg_resolve_project "$PROJECT_PATH" "$AGENT_TYPE")"
 
 # Disambiguate parallel --continue/--resume sessions that share a session_id
-# (#93). All per-process state below — pidfile, watermark, actas owner, ready
+# (#93). All per-process state below — pidfile, actas owner, ready
 # sentinel — keys on this per-process instance id rather than the bare
 # session_id, so two processes that share a session_id no longer collide on the
 # same pidfile and kill each other (#66 was a within-session dedup; here it must
@@ -231,48 +228,10 @@ if [ -z "$PAIRS" ]; then
   exit 0
 fi
 
-# SUB_PAIRS holds the subscription as <team>:<agent> tokens — the argument form
-# the storage facade's watch ops take (§2.2). Live delivery goes entirely through
-# storage_watch_tip / storage_watch_after now, so no SQL WHERE clause is built here.
-SUB_PAIRS=()
-while IFS=$'\t' read -r team agent; do
-  [ -z "$team" ] && continue
-  SUB_PAIRS+=("$team:$agent")
-done <<< "$PAIRS"
-
-# Determine the starting watermark.
-#
-# The watermark is persisted per session_id so that a *restart* of this
-# session's watcher resumes from the last delivered id instead of jumping to
-# the current MAX(id). Monitor restarts are routine — `actas`/`drop` do
-# TaskStop + relaunch, `/clear`/resume re-fires the SessionStart directive, and
-# a killed watcher self-restarts — and the old "start from MAX(id)" behavior
-# silently dropped every message that landed in the gap between the previous
-# watcher stopping and the new one taking its mark. Resuming from the persisted
-# watermark closes that gap; staying strictly after the last delivered id
-# avoids re-streaming anything already seen. See #107.
-#
-# A *fresh* session (no persisted watermark) still starts from the current
-# MAX(id) — live push, no replay of history (the no-arg inbox check covers
-# historical unread, not this stream).
-# The watermark is now an OPAQUE delivery cursor (§2.2), not an integer id — the
-# active storage driver issues and interprets it; this script only persists the
-# latest token and passes it back unchanged.
-WATERMARK_FILE="$RUN_DIR/watch.$SESSION_ID.watermark"
-persist_watermark() { printf '%s\n' "$LAST" > "$WATERMARK_FILE" 2>/dev/null || true; }
-
-LAST=""
-if [ -f "$WATERMARK_FILE" ]; then
-  # Opaque token: a single whitespace-free line. No integer validation — just
-  # strip stray surrounding whitespace.
-  LAST="$(tr -d '[:space:]' < "$WATERMARK_FILE" 2>/dev/null || true)"
-fi
-if [ -z "$LAST" ]; then
-  # A fresh watcher starts from the current tip (live push, no history replay).
-  LAST="$(storage_watch_tip "${SUB_PAIRS[@]}" 2>/dev/null || true)"
-  case "$LAST" in '') LAST=0 ;; esac
-  persist_watermark
-fi
+# The read frontier lives in the storage driver, once per (team,agent). Core
+# never compares its opaque local-position component. Each pair is scanned and
+# consumed independently so a broad watcher cannot advance one role merely by
+# delivering another role's traffic.
 
 # DB-open healthcheck (#197). The main loop guards every query with
 # `2>/dev/null || true`, so when sqlite3 cannot open the store the watcher keeps
@@ -289,7 +248,7 @@ if [ -f "$DB" ] && ! agmsg_sqlite "$DB" "SELECT 1;" >/dev/null 2>&1; then
   exit 1
 fi
 
-# Signal readiness. Once the subscription is resolved and the watermark is set,
+# Signal readiness. Once the subscription is resolved and the watcher is live,
 # this watcher will deliver anything that arrives from here on, so it is safe
 # for a leader to start sending. Only exclusive (actas) watchers signal — a
 # spawned agent always starts its watcher in actas mode — and the sentinel is
@@ -320,14 +279,13 @@ while true; do
   if agmsg_instance_is_composite "$SESSION_ID" && ! agmsg_instance_alive "$SESSION_ID"; then
     exit 0
   fi
-  if [ -f "$DB" ]; then
-    # Pull messages after the cursor via the storage facade (§2.2). The output is
-    # JSONL: zero or more message_sent records in delivery order, then a trailing
-    # {"type":"cursor","cursor":"<token>"} as the LAST line — the position to
-    # resume from. Parse every record in one pass with sqlite's JSON funcs (the
-    # repo idiom; no jq). Newlines/tabs in the body are escaped to keep one line.
-    OUT="$(storage_watch_after "$LAST" "${SUB_PAIRS[@]}" 2>/dev/null || true)"
-    if [ -n "$OUT" ]; then
+  if storage_store_exists; then
+    while IFS=$'\t' read -r pair_team pair_agent; do
+      [ -z "$pair_team" ] && continue
+      READ_CURSOR="$(storage_read_cursor_get "$pair_team" "$pair_agent" 2>/dev/null || true)"
+      [ -n "$READ_CURSOR" ] || READ_CURSOR=0
+      OUT="$(storage_watch_after "$READ_CURSOR" "$pair_team:$pair_agent" 2>/dev/null || true)"
+      if [ -n "$OUT" ]; then
       _arr="[$(printf '%s' "$OUT" | paste -sd, -)]"
       ROWS="$(agmsg_sqlite ':memory:' "
         SELECT COALESCE(json_extract(value,'\$.type'),'') || char(31) ||
@@ -341,13 +299,13 @@ while true; do
         FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
       " 2>/dev/null || true)"
 
+      FINAL_CURSOR=""
+      DELIVERED_IDS=()
+      DESPAWN_TARGET=""
       while IFS=$'\x1f' read -r kind id ts team from to body cursor; do
         [ -z "$kind" ] && continue
         if [ "$kind" = "cursor" ]; then
-          # Trailing cursor = the resume point. Advance + persist only after the
-          # batch's messages were delivered above; a crash mid-batch re-delivers
-          # from the old cursor (at-least-once, never skip — §2.2).
-          LAST="$cursor"; persist_watermark
+          FINAL_CURSOR="$cursor"
           continue
         fi
         [ "$kind" = "message_sent" ] || continue
@@ -358,6 +316,7 @@ while true; do
         # which also ends the agent CLI sharing it. Deterministic teardown, no
         # dependence on the agent LLM noticing the message. See #109.
         if [ "$body" = "ctrl:despawn" ]; then
+          DELIVERED_IDS+=("$id")
           # Only an EXCLUSIVE watcher dedicated to exactly this role tears
           # itself down. A broad-subscription watcher (e.g. a leader whose
           # default watcher subscribes to every project role, including the
@@ -365,28 +324,35 @@ while true; do
           # own pane, so killing it would take down the leader's session. The
           # spawned member's watcher runs in actas mode (ACTIVE_NAME=$to) in its
           # own pane; that's the one meant to respond. A broad watcher `continue`s
-          # and reaches the trailing cursor at batch end, so its watermark advances
-          # past this control message. The target watcher below exits BEFORE the
-          # cursor record, so it does not persist a cursor — harmless, since it
-          # drops the role and won't resume as it; a same-session resume would
-          # re-read the despawn (at-least-once) and re-tear-down idempotently. See #109.
+          # and consumes the control row without acting. An exclusive target
+          # consumes the complete scanned batch before teardown.
           if [ -z "$ACTIVE_NAME" ] || [ "$to" != "$ACTIVE_NAME" ]; then
             continue
           fi
-          "$SCRIPT_DIR/reset.sh" "$PROJECT_PATH" "$AGENT_TYPE" "$to" "$SESSION_ID" >/dev/null 2>&1 || true
-          if [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then
-            tmux kill-pane -t "$TMUX_PANE" 2>/dev/null || true
-          else
-            echo "agmsg watch: despawned '$to' (role dropped); close this window manually" >&2
-          fi
-          exit 0
+          DESPAWN_TARGET="$to"
+          continue
         fi
         if ! printf '%s | %s | %s → %s | %s\n' "$ts" "$team" "$from" "$to" "$body"; then
           cleanup
           exit 0
         fi
+        DELIVERED_IDS+=("$id")
       done <<< "$ROWS"
-    fi
+      if [ -n "$FINAL_CURSOR" ]; then
+        storage_read_cursor_consume "$pair_team" "$pair_agent" "$FINAL_CURSOR" \
+          "${DELIVERED_IDS[@]}" >/dev/null 2>&1 || true
+      fi
+      if [ -n "$DESPAWN_TARGET" ]; then
+        "$SCRIPT_DIR/reset.sh" "$PROJECT_PATH" "$AGENT_TYPE" "$DESPAWN_TARGET" "$SESSION_ID" >/dev/null 2>&1 || true
+        if [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then
+          tmux kill-pane -t "$TMUX_PANE" 2>/dev/null || true
+        else
+          echo "agmsg watch: despawned '$DESPAWN_TARGET' (role dropped); close this window manually" >&2
+        fi
+        exit 0
+      fi
+      fi
+    done <<< "$PAIRS"
   fi
 
   # Run sleep in the background and `wait` for it so signal traps fire

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -84,6 +84,29 @@ CREATE TABLE IF NOT EXISTS registrations (
     REFERENCES members(team_id, member_id) ON DELETE CASCADE
 );
 
+-- Stage-2 read state stays opaque: the server stores only immutable member and
+-- wire identities plus monotonic sequence frontiers, never message recipients.
+CREATE TABLE IF NOT EXISTS read_frontiers (
+  team_id UUID NOT NULL,
+  member_id UUID NOT NULL,
+  server_seq BIGINT NOT NULL CHECK (server_seq >= 0),
+  PRIMARY KEY (team_id, member_id),
+  FOREIGN KEY (team_id, member_id)
+    REFERENCES members(team_id, member_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS read_exact (
+  team_id UUID NOT NULL,
+  member_id UUID NOT NULL,
+  wire_id UUID NOT NULL,
+  PRIMARY KEY (team_id, member_id, wire_id),
+  FOREIGN KEY (team_id, member_id)
+    REFERENCES members(team_id, member_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS read_exact_team_wire_idx
+  ON read_exact(team_id, wire_id);
+
 CREATE TABLE IF NOT EXISTS registration_identity_history (
   team_id UUID NOT NULL REFERENCES teams(team_id) ON DELETE RESTRICT,
   registration_id UUID NOT NULL,

--- a/server/spec/v1.md
+++ b/server/spec/v1.md
@@ -716,6 +716,11 @@ with no registrations has an empty array. `installation_id` identifies the
 installation that owns a registration. Machine-local project paths MUST NOT be
 uploaded or returned.
 
+A team has at most 1,000 active members. Operator provisioning MUST reject a
+larger manifest atomically. This hard bound also keeps the unpaginated roster
+document finite; read-state frontiers and exact exceptions remain independently
+paginated by `POST /v1/read-state/sync`.
+
 V1 HTTP is read-only for members. The authoritative source is an operator
 provisioning document applied by the reference server's local admin CLI. That
 document contains `team_id`, `team_name`, and the complete `members` array in

--- a/server/spec/v1.md
+++ b/server/spec/v1.md
@@ -8,13 +8,14 @@ be interpreted as described by RFC 2119.
 
 ## Scope and conventions
 
-V1 defines seven endpoints:
+V1 defines eight endpoints:
 
 - `POST /v1/pairing/exchange`
 - `POST /v1/credentials/<credential_id>/revoke`
 - `POST /v1/messages`
 - `GET /v1/messages?after=<team_seq>`
 - `GET /v1/members`
+- `POST /v1/read-state/sync`
 - `GET /v1/capabilities`
 - `GET /v1/health`
 
@@ -738,6 +739,86 @@ member name, once assigned, MUST NOT later be assigned to a different
 `member_id`; this prevents historical opaque sender/recipient names from being
 projected onto a new identity.
 
+## `POST /v1/read-state/sync`
+
+Stage-2 read state is monotonic and member-scoped. The request max-merges one
+or more remote frontiers and set-unions exact out-of-order wire reads, while
+also selecting one bounded response page:
+
+```json
+{
+  "updates": [
+    {
+      "member_id": "018f3f7e-0000-7000-8000-000000000010",
+      "server_seq": "42",
+      "exact_wire_ids": ["550e8400-e29b-41d4-a716-446655440000"]
+    }
+  ],
+  "page_after": null,
+  "page_limit": 1000
+}
+```
+
+The request contains at most 1,000 distinct active members and at most 1,000
+distinct exact IDs in total. A frontier is a canonical sequence no greater than
+the team's `current_seq`. Every exact ID is a canonical UUIDv4 already present
+as a live message or permanent tombstone in this team. An empty update array is
+the read-only form. Duplicate/unknown fields, duplicate members, duplicate IDs
+within one member, inactive members, future sequences, and unresolved wire IDs
+are `400 invalid-request`.
+
+`page_after` is null or the exact last key from a prior response: either
+`{"member_id":"...","kind":"frontier"}` or
+`{"member_id":"...","kind":"exact","wire_id":"..."}`. It is a keyset
+comparison boundary and need not still exist. `page_limit` is an integer from 1
+through 1,000.
+
+The server locks the team sequencing row and performs the update, exact-state
+garbage collection, limit check, and response query in one transaction.
+Frontiers merge with `max`; exact IDs merge with set union. The effective
+frontier for every member is at least the authenticated `min_available_seq`.
+An exact row is removed only after that row's live `team_seq` or tombstone
+`original_seq` proves it is at or below the member's effective frontier.
+
+Unabsorbed exact state is limited to 4,096 rows per member and 65,536 per team.
+Exceeding either limit rejects the whole mutation with `409
+read-state-limit-exceeded`; no partial frontier or exact update commits.
+
+The response is one canonical item page from the same transaction snapshot:
+
+```json
+{
+  "protocol_version": 1,
+  "server_instance_id": "018f3f7e-0000-7000-8000-000000000000",
+  "team_id": "018f3f7e-0000-7000-8000-000000000001",
+  "team_name": "example-team",
+  "min_available_seq": "0",
+  "current_seq": "52",
+  "items": [
+    {"kind":"frontier","member_id":"018f3f7e-0000-7000-8000-000000000010","server_seq":"42"},
+    {"kind":"exact","member_id":"018f3f7e-0000-7000-8000-000000000010","wire_id":"550e8400-e29b-41d4-a716-446655440000"}
+  ],
+  "next_page_after": {"member_id":"018f3f7e-0000-7000-8000-000000000010","kind":"exact","wire_id":"550e8400-e29b-41d4-a716-446655440000"},
+  "has_more": true
+}
+```
+
+Items sort by `(member_id, kind_order, wire_id)`, with `frontier` before
+`exact`. Every active member contributes exactly one effective frontier item;
+unabsorbed exact rows contribute exact items. `items.length` never exceeds
+`page_limit`. `next_page_after` is null exactly when `has_more` is false.
+Clients apply pages monotonically and restart from null on each polling cycle.
+
+Retention uses the same team-row lock. In the transaction that creates
+tombstones, deletes the covered prefix, and advances `min_available_seq`, it
+also max-merges stored read frontiers to that floor and deletes exact rows now
+proven covered. A new member/device therefore bootstraps at the authenticated
+floor rather than creating a permanent retained-prefix hole.
+
+The full local composite-frontier, exact promotion, quarantine separation,
+pagination, and limit-recovery rules are normative in
+[ADR 0008](../../docs/adr/0008-stage-2-read-cursor-sync.md).
+
 ## `GET /v1/health`
 
 This endpoint is a readiness and version-discovery probe, not a process
@@ -808,6 +889,7 @@ except the unauthenticated readiness shape from `GET /v1/health`.
 | 404 | `team-not-found` | Immutable team ID is not provisioned | Stop; never create implicitly |
 | 409 | `message-uuid-conflict` | UUID payload differs | Stop and surface corruption/conflict |
 | 409 | `pairing-token-consumed` | Pairing token was already exchanged | Revoke an orphan if needed; request a new token |
+| 409 | `read-state-limit-exceeded` | Unabsorbed exact reads exceed a member/team bound | Block that member's writes; retain facts; remediate oldest hole |
 | 410 | `resync-required` | Cursor is below retention floor | Enter terminal resync state |
 | 410 | `pairing-token-expired` | Pairing token exceeded its 15-minute TTL | Request a new token |
 | 413 | `request-too-large` | Body exceeds 2 MiB | Split/reduce while preserving exact durable IDs/envelopes |

--- a/server/spec/v1.md
+++ b/server/spec/v1.md
@@ -787,7 +787,11 @@ An exact row is removed only after that row's live `team_seq` or tombstone
 
 Unabsorbed exact state is limited to 4,096 rows per member and 65,536 per team.
 Exceeding either limit rejects the whole mutation with `409
-read-state-limit-exceeded`; no partial frontier or exact update commits.
+read-state-limit-exceeded`; no partial frontier or exact update commits. Its
+`details.member_id` MUST identify a member in the rejected request whose newly
+added exact facts causally contributed to the overflow. Omitting that member's
+update from a retry therefore makes monotonic progress toward a read-only
+request, even when another member owns the largest existing exact set.
 
 The response is one canonical item page from the same transaction snapshot:
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -19,6 +19,7 @@ import {
   messagesQuerySchema,
   parseSequence,
   postMessagesSchema,
+  readStateSyncSchema,
   uuidV7Schema,
 } from "./protocol.js";
 import {
@@ -27,6 +28,7 @@ import {
   getMessages,
   health,
   postMessages,
+  syncReadState,
 } from "./storage.js";
 
 const emptyQuerySchema = z.object({}).strict();
@@ -207,6 +209,14 @@ export function createApp(pool: Pool, config: Config): FastifyInstance {
     const teamId = await scopedTeamId(pool, request);
     const body = postMessagesSchema.parse(request.body);
     return postMessages(pool, teamId, body.messages);
+  });
+
+  app.post("/v1/read-state/sync", async (request, reply) => {
+    emptyQuerySchema.parse(request.query);
+    const teamId = await scopedTeamId(pool, request);
+    const body = readStateSyncSchema.parse(request.body);
+    reply.header("Cache-Control", "no-store");
+    return syncReadState(pool, teamId, body);
   });
 
   app.post("/v1/pairing/exchange", async (request, reply) => {

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -110,6 +110,53 @@ export const messagesQuerySchema = z.object({
   ),
 }).strict();
 
+const readFrontierKeySchema = z
+  .object({ member_id: uuidV7Schema, kind: z.literal("frontier") })
+  .strict();
+const readExactKeySchema = z
+  .object({
+    member_id: uuidV7Schema,
+    kind: z.literal("exact"),
+    wire_id: uuidV4Schema,
+  })
+  .strict();
+
+export const readStateSyncSchema = z
+  .object({
+    updates: z
+      .array(
+        z
+          .object({
+            member_id: uuidV7Schema,
+            server_seq: sequenceSchema,
+            exact_wire_ids: z.array(uuidV4Schema).max(1000),
+          })
+          .strict()
+          .refine(
+            (value) => new Set(value.exact_wire_ids).size === value.exact_wire_ids.length,
+            { message: "exact_wire_ids must be distinct" },
+          ),
+      )
+      .max(1000),
+    page_after: z.union([readFrontierKeySchema, readExactKeySchema]).nullable(),
+    page_limit: z.number().int().min(1).max(1000),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (new Set(value.updates.map((update) => update.member_id)).size !== value.updates.length) {
+      context.addIssue({ code: "custom", path: ["updates"], message: "member IDs must be distinct" });
+    }
+    const exactCount = value.updates.reduce(
+      (count, update) => count + update.exact_wire_ids.length,
+      0,
+    );
+    if (exactCount > 1000) {
+      context.addIssue({ code: "custom", path: ["updates"], message: "too many exact reads" });
+    }
+  });
+
+export type ReadStateSyncInput = z.infer<typeof readStateSyncSchema>;
+
 export const agentNameSchema = z.string().refine((value) => {
   const scalars = [...value];
   return (

--- a/server/src/provision.ts
+++ b/server/src/provision.ts
@@ -30,7 +30,7 @@ const manifestSchema = z
   .object({
     team_id: uuidV7Schema,
     team_name: teamNameSchema,
-    members: z.array(memberSchema),
+    members: z.array(memberSchema).max(1000),
   })
   .strict();
 

--- a/server/src/provision.ts
+++ b/server/src/provision.ts
@@ -158,10 +158,14 @@ try {
     }
 
     await client.query("DELETE FROM registrations WHERE team_id = $1", [manifest.team_id]);
-    await client.query("DELETE FROM members WHERE team_id = $1", [manifest.team_id]);
+    await client.query(
+      "DELETE FROM members WHERE team_id = $1 AND NOT (member_id = ANY($2::uuid[]))",
+      [manifest.team_id, manifest.members.map((member) => member.member_id)],
+    );
     for (const member of manifest.members) {
       await client.query(
-        "INSERT INTO members (team_id, member_id, name) VALUES ($1, $2, $3)",
+        `INSERT INTO members (team_id, member_id, name) VALUES ($1, $2, $3)
+         ON CONFLICT (team_id, member_id) DO UPDATE SET name = EXCLUDED.name`,
         [manifest.team_id, member.member_id, member.name],
       );
       for (const registration of member.registrations) {

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -5,6 +5,7 @@ import {
   envelopeDigest,
   type Envelope,
   type MessageInput,
+  type ReadStateSyncInput,
 } from "./protocol.js";
 import { inTransaction } from "./db.js";
 
@@ -37,6 +38,8 @@ type ExistingRecord =
 
 const timestampSql = `to_char(server_received_at AT TIME ZONE 'UTC',
   'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`;
+const MAX_EXACT_PER_MEMBER = 4096;
+const MAX_EXACT_PER_TEAM = 65536;
 
 async function serverInstanceId(client: PoolClient): Promise<string> {
   const result = await client.query<{ server_instance_id: string }>(
@@ -280,6 +283,229 @@ export async function postMessages(
   });
 }
 
+export async function syncReadState(
+  pool: Pool,
+  teamId: string,
+  input: ReadStateSyncInput,
+): Promise<Record<string, unknown>> {
+  return inTransaction(pool, async (client) => {
+    const serverId = await serverInstanceId(client);
+    const team = await teamRow(client, teamId, true);
+    if (!team) throw notFound(serverId, teamId);
+    const binding = { serverInstanceId: serverId, teamId };
+    const floor = BigInt(team.min_available_seq);
+    const current = BigInt(team.current_seq);
+
+    const memberIds = input.updates.map((update) => update.member_id);
+    if (memberIds.length > 0) {
+      const members = await client.query<{ member_id: string }>(
+        `SELECT member_id::text FROM members
+          WHERE team_id = $1 AND member_id = ANY($2::uuid[])`,
+        [teamId, memberIds],
+      );
+      if (members.rows.length !== memberIds.length) {
+        throw new ProtocolError(
+          400,
+          "invalid-request",
+          "read-state update contains an inactive member",
+          {},
+          binding,
+        );
+      }
+    }
+
+    for (const update of input.updates) {
+      if (BigInt(update.server_seq) > current) {
+        throw new ProtocolError(
+          400,
+          "invalid-request",
+          "read frontier exceeds the current team sequence",
+          { member_id: update.member_id, server_seq: update.server_seq },
+          binding,
+        );
+      }
+    }
+
+    const exactIds = [...new Set(input.updates.flatMap((update) => update.exact_wire_ids))];
+    if (exactIds.length > 0) {
+      const resolved = await client.query<{ id: string }>(
+        `SELECT id::text FROM messages WHERE team_id = $1 AND id = ANY($2::uuid[])
+         UNION
+         SELECT id::text FROM message_tombstones
+          WHERE team_id = $1 AND id = ANY($2::uuid[])`,
+        [teamId, exactIds],
+      );
+      const found = new Set(resolved.rows.map((row) => row.id));
+      const missing = exactIds.find((id) => !found.has(id));
+      if (missing) {
+        throw new ProtocolError(
+          400,
+          "invalid-request",
+          "exact read refers to an unknown wire id",
+          { wire_id: missing },
+          binding,
+        );
+      }
+    }
+
+    // The authenticated retention floor is a safe baseline for every existing
+    // row. Members without a row receive the same floor logically in the page
+    // query below.
+    await client.query(
+      `UPDATE read_frontiers SET server_seq = GREATEST(server_seq, $2)
+        WHERE team_id = $1`,
+      [teamId, floor.toString()],
+    );
+
+    if (input.updates.length > 0) {
+      await client.query(
+        `INSERT INTO read_frontiers(team_id, member_id, server_seq)
+         SELECT $1, member_id, GREATEST(server_seq, $4::bigint)
+           FROM unnest($2::uuid[], $3::bigint[]) AS incoming(member_id, server_seq)
+         ON CONFLICT (team_id, member_id) DO UPDATE
+           SET server_seq = GREATEST(read_frontiers.server_seq, EXCLUDED.server_seq, $4::bigint)`,
+        [
+          teamId,
+          input.updates.map((update) => update.member_id),
+          input.updates.map((update) => update.server_seq),
+          floor.toString(),
+        ],
+      );
+    }
+
+    const exactMembers: string[] = [];
+    const exactWires: string[] = [];
+    for (const update of input.updates) {
+      for (const wireId of update.exact_wire_ids) {
+        exactMembers.push(update.member_id);
+        exactWires.push(wireId);
+      }
+    }
+    if (exactWires.length > 0) {
+      await client.query(
+        `INSERT INTO read_exact(team_id, member_id, wire_id)
+         SELECT $1, member_id, wire_id
+           FROM unnest($2::uuid[], $3::uuid[]) AS incoming(member_id, wire_id)
+         ON CONFLICT DO NOTHING`,
+        [teamId, exactMembers, exactWires],
+      );
+    }
+
+    await deleteCoveredExact(client, teamId, floor);
+
+    const memberOverflow = await client.query<{ member_id: string; exact_count: string }>(
+      `SELECT member_id::text, COUNT(*)::text AS exact_count
+         FROM read_exact WHERE team_id = $1
+        GROUP BY member_id HAVING COUNT(*) > $2
+        ORDER BY COUNT(*) DESC, member_id LIMIT 1`,
+      [teamId, MAX_EXACT_PER_MEMBER],
+    );
+    const teamCountResult = await client.query<{ exact_count: string }>(
+      "SELECT COUNT(*)::text AS exact_count FROM read_exact WHERE team_id = $1",
+      [teamId],
+    );
+    const teamCount = Number(teamCountResult.rows[0]?.exact_count ?? "0");
+    if (memberOverflow.rows[0] || teamCount > MAX_EXACT_PER_TEAM) {
+      const offender = memberOverflow.rows[0] ?? (await client.query<{ member_id: string; exact_count: string }>(
+        `SELECT member_id::text, COUNT(*)::text AS exact_count
+           FROM read_exact WHERE team_id = $1
+          GROUP BY member_id ORDER BY COUNT(*) DESC, member_id LIMIT 1`,
+        [teamId],
+      )).rows[0];
+      throw new ProtocolError(
+        409,
+        "read-state-limit-exceeded",
+        "unabsorbed exact read state exceeds the protocol limit",
+        {
+          member_id: offender?.member_id ?? null,
+          member_exact_count: offender?.exact_count ?? "0",
+          team_exact_count: String(teamCount),
+          max_exact_per_member: MAX_EXACT_PER_MEMBER,
+          max_exact_per_team: MAX_EXACT_PER_TEAM,
+        },
+        binding,
+      );
+    }
+
+    const after = input.page_after;
+    const afterKind = after?.kind === "exact" ? 1 : 0;
+    const afterWire = after?.kind === "exact" ? after.wire_id : null;
+    const result = await client.query<{
+      member_id: string;
+      kind_order: number;
+      server_seq: string | null;
+      wire_id: string | null;
+    }>(
+      `WITH items AS (
+         SELECT m.member_id, 0 AS kind_order,
+                GREATEST(COALESCE(f.server_seq, 0), $2::bigint) AS server_seq,
+                NULL::uuid AS wire_id
+           FROM members m LEFT JOIN read_frontiers f
+             ON f.team_id=m.team_id AND f.member_id=m.member_id
+          WHERE m.team_id=$1
+         UNION ALL
+         SELECT e.member_id, 1 AS kind_order, NULL::bigint AS server_seq, e.wire_id
+           FROM read_exact e WHERE e.team_id=$1
+       )
+       SELECT member_id::text, kind_order, server_seq::text, wire_id::text
+         FROM items
+        WHERE $3::uuid IS NULL OR member_id > $3::uuid
+           OR (member_id = $3::uuid AND
+               (kind_order > $4 OR
+                (kind_order = $4 AND kind_order = 1 AND wire_id > $5::uuid)))
+        ORDER BY member_id, kind_order, wire_id NULLS FIRST
+        LIMIT $6`,
+      [
+        teamId,
+        floor.toString(),
+        after?.member_id ?? null,
+        afterKind,
+        afterWire,
+        input.page_limit + 1,
+      ],
+    );
+    const hasMore = result.rows.length > input.page_limit;
+    const page = result.rows.slice(0, input.page_limit);
+    const items = page.map((row) => row.kind_order === 0
+      ? { kind: "frontier", member_id: row.member_id, server_seq: row.server_seq }
+      : { kind: "exact", member_id: row.member_id, wire_id: row.wire_id });
+    const last = items.at(-1);
+    const nextPageAfter = hasMore && last
+      ? last.kind === "frontier"
+        ? { member_id: last.member_id, kind: "frontier" }
+        : { member_id: last.member_id, kind: "exact", wire_id: last.wire_id }
+      : null;
+
+    return {
+      ...common(serverId, team),
+      current_seq: team.current_seq,
+      items,
+      next_page_after: nextPageAfter,
+      has_more: hasMore,
+    };
+  });
+}
+
+async function deleteCoveredExact(
+  client: PoolClient,
+  teamId: string,
+  floor: bigint,
+): Promise<void> {
+  await client.query(
+    `DELETE FROM read_exact e
+      WHERE e.team_id = $1
+        AND COALESCE(
+          (SELECT m.team_seq FROM messages m
+            WHERE m.team_id=e.team_id AND m.id=e.wire_id),
+          (SELECT t.original_team_seq FROM message_tombstones t
+            WHERE t.team_id=e.team_id AND t.id=e.wire_id)
+        ) <= GREATEST(COALESCE(
+          (SELECT f.server_seq FROM read_frontiers f
+            WHERE f.team_id=e.team_id AND f.member_id=e.member_id), 0), $2::bigint)`,
+    [teamId, floor.toString()],
+  );
+}
+
 export async function retainThrough(
   pool: Pool,
   teamId: string,
@@ -325,6 +551,12 @@ export async function retainThrough(
       "UPDATE teams SET min_available_seq = $2 WHERE team_id = $1",
       [teamId, through.toString()],
     );
+    await client.query(
+      `UPDATE read_frontiers SET server_seq = GREATEST(server_seq, $2)
+        WHERE team_id = $1`,
+      [teamId, through.toString()],
+    );
+    await deleteCoveredExact(client, teamId, through);
     return {
       ...common(serverId, { ...team, min_available_seq: through.toString() }),
       retained_through: through.toString(),

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -326,7 +326,16 @@ export async function syncReadState(
       }
     }
 
-    const exactIds = [...new Set(input.updates.flatMap((update) => update.exact_wire_ids))];
+    const exactMembers: string[] = [];
+    const exactWires: string[] = [];
+    for (const update of input.updates) {
+      for (const wireId of update.exact_wire_ids) {
+        exactMembers.push(update.member_id);
+        exactWires.push(wireId);
+      }
+    }
+    const exactIds = [...new Set(exactWires)];
+    const novelExactMembers = new Set<string>();
     if (exactIds.length > 0) {
       const resolved = await client.query<{ id: string }>(
         `SELECT id::text FROM messages WHERE team_id = $1 AND id = ANY($2::uuid[])
@@ -346,6 +355,16 @@ export async function syncReadState(
           binding,
         );
       }
+      const novel = await client.query<{ member_id: string }>(
+        `SELECT DISTINCT incoming.member_id::text
+           FROM unnest($2::uuid[], $3::uuid[]) AS incoming(member_id, wire_id)
+           LEFT JOIN read_exact existing
+             ON existing.team_id=$1 AND existing.member_id=incoming.member_id
+            AND existing.wire_id=incoming.wire_id
+          WHERE existing.wire_id IS NULL`,
+        [teamId, exactMembers, exactWires],
+      );
+      for (const row of novel.rows) novelExactMembers.add(row.member_id);
     }
 
     // The authenticated retention floor is a safe baseline for every existing
@@ -373,14 +392,6 @@ export async function syncReadState(
       );
     }
 
-    const exactMembers: string[] = [];
-    const exactWires: string[] = [];
-    for (const update of input.updates) {
-      for (const wireId of update.exact_wire_ids) {
-        exactMembers.push(update.member_id);
-        exactWires.push(wireId);
-      }
-    }
     if (exactWires.length > 0) {
       await client.query(
         `INSERT INTO read_exact(team_id, member_id, wire_id)
@@ -406,11 +417,14 @@ export async function syncReadState(
     );
     const teamCount = Number(teamCountResult.rows[0]?.exact_count ?? "0");
     if (memberOverflow.rows[0] || teamCount > MAX_EXACT_PER_TEAM) {
+      const causalMemberId = input.updates.find((update) =>
+        novelExactMembers.has(update.member_id))?.member_id;
       const offender = memberOverflow.rows[0] ?? (await client.query<{ member_id: string; exact_count: string }>(
         `SELECT member_id::text, COUNT(*)::text AS exact_count
            FROM read_exact WHERE team_id = $1
+            AND ($2::uuid IS NULL OR member_id=$2::uuid)
           GROUP BY member_id ORDER BY COUNT(*) DESC, member_id LIMIT 1`,
-        [teamId],
+        [teamId, causalMemberId ?? null],
       )).rows[0];
       throw new ProtocolError(
         409,

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -335,7 +335,7 @@ export async function syncReadState(
       }
     }
     const exactIds = [...new Set(exactWires)];
-    const novelExactMembers = new Set<string>();
+    const novelExactPairs = new Set<string>();
     if (exactIds.length > 0) {
       const resolved = await client.query<{ id: string }>(
         `SELECT id::text FROM messages WHERE team_id = $1 AND id = ANY($2::uuid[])
@@ -355,8 +355,8 @@ export async function syncReadState(
           binding,
         );
       }
-      const novel = await client.query<{ member_id: string }>(
-        `SELECT DISTINCT incoming.member_id::text
+      const novel = await client.query<{ member_id: string; wire_id: string }>(
+        `SELECT incoming.member_id::text, incoming.wire_id::text
            FROM unnest($2::uuid[], $3::uuid[]) AS incoming(member_id, wire_id)
            LEFT JOIN read_exact existing
              ON existing.team_id=$1 AND existing.member_id=incoming.member_id
@@ -364,7 +364,7 @@ export async function syncReadState(
           WHERE existing.wire_id IS NULL`,
         [teamId, exactMembers, exactWires],
       );
-      for (const row of novel.rows) novelExactMembers.add(row.member_id);
+      for (const row of novel.rows) novelExactPairs.add(`${row.member_id}:${row.wire_id}`);
     }
 
     // The authenticated retention floor is a safe baseline for every existing
@@ -404,6 +404,19 @@ export async function syncReadState(
 
     await deleteCoveredExact(client, teamId, floor);
 
+    const survivingRequestExact = exactWires.length === 0
+      ? new Set<string>()
+      : new Set((await client.query<{ member_id: string; wire_id: string }>(
+        `SELECT incoming.member_id::text, incoming.wire_id::text
+           FROM unnest($2::uuid[], $3::uuid[]) AS incoming(member_id, wire_id)
+           JOIN read_exact current
+             ON current.team_id=$1 AND current.member_id=incoming.member_id
+            AND current.wire_id=incoming.wire_id`,
+        [teamId, exactMembers, exactWires],
+      )).rows
+        .filter((row) => novelExactPairs.has(`${row.member_id}:${row.wire_id}`))
+        .map((row) => row.member_id));
+
     const memberOverflow = await client.query<{ member_id: string; exact_count: string }>(
       `SELECT member_id::text, COUNT(*)::text AS exact_count
          FROM read_exact WHERE team_id = $1
@@ -418,7 +431,7 @@ export async function syncReadState(
     const teamCount = Number(teamCountResult.rows[0]?.exact_count ?? "0");
     if (memberOverflow.rows[0] || teamCount > MAX_EXACT_PER_TEAM) {
       const causalMemberId = input.updates.find((update) =>
-        novelExactMembers.has(update.member_id))?.member_id;
+        survivingRequestExact.has(update.member_id))?.member_id;
       const offender = memberOverflow.rows[0] ?? (await client.query<{ member_id: string; exact_count: string }>(
         `SELECT member_id::text, COUNT(*)::text AS exact_count
            FROM read_exact WHERE team_id = $1

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -324,12 +324,19 @@ describeDatabase("remote storage HTTP API v1", () => {
   });
 
   it("attributes a team-wide exact overflow to a causal request member", async () => {
+    const coveredWire = "750e8400-e29b-41d4-a716-446655440008";
     const causalWire = "750e8400-e29b-41d4-a716-446655440009";
+    const coveredMember = "018f3f7e-0000-7000-8000-000000000098";
     const causalMember = "018f3f7e-0000-7000-8000-000000000099";
+    const previousSequence = (await pool.query<{ current_seq: string }>(
+      "SELECT current_seq::text FROM teams WHERE team_id=$1", [teamId],
+    )).rows[0]?.current_seq ?? "0";
+    await pool.query("UPDATE teams SET current_seq=GREATEST(current_seq,2) WHERE team_id=$1", [teamId]);
     await pool.query(
       `INSERT INTO message_tombstones(team_id,id,original_team_seq,envelope_digest)
-       VALUES($1,$2,1,decode(repeat('00',32),'hex'))`,
-      [teamId, causalWire],
+       VALUES($1,$2,1,decode(repeat('00',32),'hex')),
+             ($1,$3,2,decode(repeat('11',32),'hex'))`,
+      [teamId, coveredWire, causalWire],
     );
     await pool.query(
       `INSERT INTO members(team_id, member_id, name)
@@ -340,8 +347,9 @@ describeDatabase("remote storage HTTP API v1", () => {
       [teamId],
     );
     await pool.query(
-      "INSERT INTO members(team_id,member_id,name) VALUES($1,$2,'limit-causal-member')",
-      [teamId, causalMember],
+      `INSERT INTO members(team_id,member_id,name) VALUES
+       ($1,$2,'limit-covered-member'),($1,$3,'limit-causal-member')`,
+      [teamId, coveredMember, causalMember],
     );
     await pool.query(
       `INSERT INTO read_exact(team_id, member_id, wire_id)
@@ -363,7 +371,10 @@ describeDatabase("remote storage HTTP API v1", () => {
         url: "/v1/read-state/sync",
         headers,
         payload: {
-          updates: [{ member_id: causalMember, server_seq: "0", exact_wire_ids: [causalWire] }],
+          updates: [
+            { member_id: coveredMember, server_seq: "1", exact_wire_ids: [coveredWire] },
+            { member_id: causalMember, server_seq: "0", exact_wire_ids: [causalWire] },
+          ],
           page_after: null,
           page_limit: 1,
         },
@@ -379,9 +390,10 @@ describeDatabase("remote storage HTTP API v1", () => {
         [teamId],
       );
       await pool.query(
-        "DELETE FROM message_tombstones WHERE team_id=$1 AND id=$2",
-        [teamId, causalWire],
+        "DELETE FROM message_tombstones WHERE team_id=$1 AND id=ANY($2::uuid[])",
+        [teamId, [coveredWire, causalWire]],
       );
+      await pool.query("UPDATE teams SET current_seq=$2 WHERE team_id=$1", [teamId, previousSequence]);
     }
   });
 

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -251,6 +251,78 @@ describeDatabase("remote storage HTTP API v1", () => {
     });
   });
 
+  it("max-merges and paginates composite read state", async () => {
+    const exactId = "750e8400-e29b-41d4-a716-446655440002";
+    const firstPage = await app.inject({
+      method: "POST",
+      url: "/v1/read-state/sync",
+      headers,
+      payload: {
+        updates: [{ member_id: memberId, server_seq: "1", exact_wire_ids: [exactId] }],
+        page_after: null,
+        page_limit: 1,
+      },
+    });
+    expect(firstPage.statusCode).toBe(200);
+    expect(firstPage.headers["cache-control"]).toBe("no-store");
+    expect(firstPage.json()).toMatchObject({
+      min_available_seq: "0",
+      current_seq: "2",
+      items: [{ kind: "frontier", member_id: memberId, server_seq: "1" }],
+      next_page_after: { member_id: memberId, kind: "frontier" },
+      has_more: true,
+    });
+
+    const secondPage = await app.inject({
+      method: "POST",
+      url: "/v1/read-state/sync",
+      headers,
+      payload: {
+        updates: [],
+        page_after: firstPage.json().next_page_after,
+        page_limit: 1,
+      },
+    });
+    expect(secondPage.json()).toMatchObject({
+      items: [{ kind: "exact", member_id: memberId, wire_id: exactId }],
+      next_page_after: null,
+      has_more: false,
+    });
+
+    const absorbed = await app.inject({
+      method: "POST",
+      url: "/v1/read-state/sync",
+      headers,
+      payload: {
+        updates: [{ member_id: memberId, server_seq: "2", exact_wire_ids: [] }],
+        page_after: null,
+        page_limit: 10,
+      },
+    });
+    expect(absorbed.json()).toMatchObject({
+      items: [{ kind: "frontier", member_id: memberId, server_seq: "2" }],
+      has_more: false,
+    });
+    const exactCount = await pool.query<{ count: string }>(
+      "SELECT COUNT(*)::text AS count FROM read_exact WHERE team_id=$1",
+      [teamId],
+    );
+    expect(exactCount.rows[0]?.count).toBe("0");
+
+    const future = await app.inject({
+      method: "POST",
+      url: "/v1/read-state/sync",
+      headers,
+      payload: {
+        updates: [{ member_id: memberId, server_seq: "3", exact_wire_ids: [] }],
+        page_after: null,
+        page_limit: 10,
+      },
+    });
+    expect(future.statusCode).toBe(400);
+    expect(future.json().error.code).toBe("invalid-request");
+  });
+
   it("serializes concurrent writers on the team row", async () => {
     const writes = await Promise.all(
       [
@@ -319,6 +391,17 @@ describeDatabase("remote storage HTTP API v1", () => {
     });
     expect(posted.statusCode).toBe(200);
     expect(posted.json().acks[0].server_seq).toBe("5");
+
+    const readAfterRetention = await app.inject({
+      method: "POST",
+      url: "/v1/read-state/sync",
+      headers,
+      payload: { updates: [], page_after: null, page_limit: 10 },
+    });
+    expect(readAfterRetention.json()).toMatchObject({
+      min_available_seq: "4",
+      items: [{ kind: "frontier", member_id: memberId, server_seq: "4" }],
+    });
 
     const belowFloor = await app.inject({
       method: "GET",
@@ -424,6 +507,20 @@ describeDatabase("remote storage HTTP API v1", () => {
       const first = await runProvision();
       expect(JSON.parse(first.stdout)).toMatchObject({ members_revision: "0" });
 
+      await pool.query(
+        `INSERT INTO read_frontiers(team_id, member_id, server_seq)
+         VALUES ($1, $2, 7)`,
+        [provisionTeam, provisionMember],
+      );
+      const reprovisioned = await runProvision();
+      expect(JSON.parse(reprovisioned.stdout)).toMatchObject({ members_revision: "1" });
+      const preservedReadState = await pool.query<{ server_seq: string }>(
+        `SELECT server_seq::text FROM read_frontiers
+          WHERE team_id=$1 AND member_id=$2`,
+        [provisionTeam, provisionMember],
+      );
+      expect(preservedReadState.rows[0]?.server_seq).toBe("7");
+
       await writeFile(
         manifestPath,
         JSON.stringify({
@@ -433,7 +530,13 @@ describeDatabase("remote storage HTTP API v1", () => {
         }),
       );
       const second = await runProvision();
-      expect(JSON.parse(second.stdout)).toMatchObject({ members_revision: "1" });
+      expect(JSON.parse(second.stdout)).toMatchObject({ members_revision: "2" });
+      const retiredReadState = await pool.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM read_frontiers
+          WHERE team_id=$1 AND member_id=$2`,
+        [provisionTeam, provisionMember],
+      );
+      expect(retiredReadState.rows[0]?.count).toBe("0");
 
       await writeFile(
         manifestPath,

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -323,6 +323,68 @@ describeDatabase("remote storage HTTP API v1", () => {
     expect(future.json().error.code).toBe("invalid-request");
   });
 
+  it("attributes a team-wide exact overflow to a causal request member", async () => {
+    const causalWire = "750e8400-e29b-41d4-a716-446655440009";
+    const causalMember = "018f3f7e-0000-7000-8000-000000000099";
+    await pool.query(
+      `INSERT INTO message_tombstones(team_id,id,original_team_seq,envelope_digest)
+       VALUES($1,$2,1,decode(repeat('00',32),'hex'))`,
+      [teamId, causalWire],
+    );
+    await pool.query(
+      `INSERT INTO members(team_id, member_id, name)
+       SELECT $1,
+         ('018f3f7e-0000-7000-8000-' || lpad(value::text, 12, '0'))::uuid,
+         'limit-member-' || value::text
+       FROM generate_series(100, 115) AS value`,
+      [teamId],
+    );
+    await pool.query(
+      "INSERT INTO members(team_id,member_id,name) VALUES($1,$2,'limit-causal-member')",
+      [teamId, causalMember],
+    );
+    await pool.query(
+      `INSERT INTO read_exact(team_id, member_id, wire_id)
+       SELECT $1,
+         ('018f3f7e-0000-7000-8000-' ||
+           lpad((100 + ((value - 1) / 4096))::text, 12, '0'))::uuid,
+         ('550e8400-e29b-4000-8000-' || lpad(value::text, 12, '0'))::uuid
+       FROM generate_series(1, 65536) AS value`,
+      [teamId],
+    );
+    const seeded = await pool.query<{ count: string }>(
+      "SELECT COUNT(*)::text AS count FROM read_exact WHERE team_id=$1",
+      [teamId],
+    );
+    expect(seeded.rows[0]?.count).toBe("65536");
+    try {
+      const overflow = await app.inject({
+        method: "POST",
+        url: "/v1/read-state/sync",
+        headers,
+        payload: {
+          updates: [{ member_id: causalMember, server_seq: "0", exact_wire_ids: [causalWire] }],
+          page_after: null,
+          page_limit: 1,
+        },
+      });
+      expect(overflow.statusCode).toBe(409);
+      expect(overflow.json().error).toMatchObject({
+        code: "read-state-limit-exceeded",
+        details: { member_id: causalMember, team_exact_count: "65537" },
+      });
+    } finally {
+      await pool.query(
+        `DELETE FROM members WHERE team_id=$1 AND name LIKE 'limit-%'`,
+        [teamId],
+      );
+      await pool.query(
+        "DELETE FROM message_tombstones WHERE team_id=$1 AND id=$2",
+        [teamId, causalWire],
+      );
+    }
+  });
+
   it("serializes concurrent writers on the team row", async () => {
     const writes = await Promise.all(
       [

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -547,6 +547,20 @@ describeDatabase("remote storage HTTP API v1", () => {
         }),
       );
       await expect(runProvision()).rejects.toThrow(/retired/);
+
+      await writeFile(
+        manifestPath,
+        JSON.stringify({
+          team_id: provisionTeam,
+          team_name: "provisioned-team",
+          members: Array.from({ length: 1001 }, (_, index) => ({
+            member_id: `018f3f7e-0000-7000-8000-${String(index).padStart(12, "0")}`,
+            name: `member-${index}`,
+            registrations: [],
+          })),
+        }),
+      );
+      await expect(runProvision()).rejects.toThrow(/too_big|1000|Array/u);
     } finally {
       if (!directory.startsWith(join(tmpdir(), "agmsg-provision-test-"))) {
         throw new Error("refusing to remove an unexpected temporary directory");

--- a/server/test/sync-client.integration.test.ts
+++ b/server/test/sync-client.integration.test.ts
@@ -22,6 +22,8 @@ describeDatabase("Stage-1 polling sync client", () => {
   const schema = `agmsg_sync_${randomBytes(8).toString("hex")}`;
   let token: string;
   const teamId = "018f3f7e-0000-7000-8000-000000000101";
+  const memberA = "018f3f7e-0000-7000-8000-000000000110";
+  const memberB = "018f3f7e-0000-7000-8000-000000000120";
   const localTeam = "dogfood-team";
   let admin: Pool;
   let pool: Pool;
@@ -43,6 +45,11 @@ describeDatabase("Stage-1 polling sync client", () => {
           accepted_envelope_versions,write_allowed_ciphers)
        VALUES($1,0,1,ARRAY[1],ARRAY['none','age-v1']::TEXT[])`,
       [teamId],
+    );
+    await pool.query(
+      `INSERT INTO members(team_id,member_id,name) VALUES
+       ($1,$2,'machine-a'),($1,$3,'machine-b')`,
+      [teamId, memberA, memberB],
     );
     const config: Config = {
       databaseUrl: databaseUrl ?? "",
@@ -108,6 +115,23 @@ storage_history "$2"`;
     return result.stdout.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
   }
 
+  async function markRead(store: string, agent: string, id: string) {
+    const script = `. "$1/scripts/lib/storage.sh"
+agmsg_storage_load
+storage_mark_read_batch "$2" "$3" "$4" >/dev/null`;
+    await execFileAsync("bash", ["-c", script, "stage2-test", repositoryRoot,
+      localTeam, agent, id], { cwd: repositoryRoot, env: environment(store) });
+  }
+
+  async function unread(store: string, agent: string) {
+    const script = `. "$1/scripts/lib/storage.sh"
+agmsg_storage_load
+storage_list_unread "$2" "$3"`;
+    const result = await execFileAsync("bash", ["-c", script, "stage2-test", repositoryRoot,
+      localTeam, agent], { cwd: repositoryRoot, env: environment(store) });
+    return result.stdout.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+  }
+
   it("synchronizes two isolated AGMSG_STORAGE_PATH stores without echo duplicates", async () => {
     for (const store of [storeA, storeB]) {
       await sync(store, "configure", "--team", localTeam, "--server", serverUrl,
@@ -124,6 +148,11 @@ storage_history "$2"`;
     expect(await history(storeB)).toMatchObject([
       { from: "machine-a", to: "machine-b", body: "fixture from machine A" },
     ]);
+    const receivedOnB = (await history(storeB))[0];
+    await markRead(storeB, "machine-b", receivedOnB.id);
+    await sync(storeB, "once", "--team", localTeam);
+    await sync(storeA, "once", "--team", localTeam);
+    expect(await unread(storeA, "machine-b")).toEqual([]);
 
     await localSend(storeB, "machine-b", "machine-a", "fixture reply from machine B");
     await sync(storeB, "once", "--team", localTeam);

--- a/server/test/sync-client.integration.test.ts
+++ b/server/test/sync-client.integration.test.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { execFile } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -32,6 +32,7 @@ describeDatabase("Stage-1 polling sync client", () => {
   let root: string;
   let storeA: string;
   let storeB: string;
+  let rosterFile: string;
 
   beforeAll(async () => {
     admin = new Pool({ connectionString: databaseUrl });
@@ -62,6 +63,10 @@ describeDatabase("Stage-1 polling sync client", () => {
     root = await mkdtemp(join(tmpdir(), "agmsg-stage1-sync-"));
     storeA = join(root, "machine-a");
     storeB = join(root, "machine-b");
+    rosterFile = join(root, "local-roster.json");
+    await writeFile(rosterFile, JSON.stringify({
+      agents: { "machine-a": {}, "machine-b": {} },
+    }));
   });
 
   afterAll(async () => {
@@ -80,6 +85,7 @@ describeDatabase("Stage-1 polling sync client", () => {
       AGMSG_STORAGE_PATH: store,
       AGMSG_STORAGE_DRIVER: "sqlite",
       AGMSG_SYNC_TOKEN: token,
+      AGMSG_SYNC_LOCAL_ROSTER_FILE: rosterFile,
       AGMSG_NODE: process.execPath,
       HOME: join(store, "home"),
     };

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -8,6 +8,7 @@ import {
   driver,
   isRetryable,
   plaintextWriteEligible,
+  readStateUpdateBatches,
   request,
   retainAgeCheckpoint,
   selectWriteProfile,
@@ -16,6 +17,8 @@ import {
   validateConfiguredAgeIdentities,
   validateCapabilities,
   validateErrorBinding,
+  validateMembers,
+  validateReadStatePage,
 } from "../scripts/internal/remote-sync.mjs";
 
 const config = {
@@ -47,6 +50,37 @@ test("ack mapping rejects reversed and duplicate server sequences", () => {
     { id: candidates[0].id, server_seq: "1", disposition: "stored", extra: true },
     { id: candidates[1].id, server_seq: "2", disposition: "stored" },
   ]), /shape/u);
+});
+
+test("Stage-2 roster, update batches, and response pages are canonical", () => {
+  const members = [{ member_id: "018f3f7e-0000-7000-8000-000000000010", name: "worker-1" }];
+  assert.deepEqual(validateMembers(config, {
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, min_available_seq: "0", members_revision: "1",
+    members: [{ ...members[0], registrations: [] }],
+  }), members);
+  const exact = Array.from({ length: 1001 }, (_, index) =>
+    `550e8400-e29b-41d4-a716-${String(index).padStart(12, "0")}`);
+  const batches = readStateUpdateBatches(members, [
+    { type: "sync_read_frontier", member_id: members[0].member_id, server_seq: "7" },
+    ...exact.map((wire_id) => ({ type: "sync_read_exact", member_id: members[0].member_id, wire_id })),
+  ]);
+  assert.equal(batches.length, 2);
+  assert.equal(batches[0][0].exact_wire_ids.length, 1000);
+  assert.equal(batches[1][0].exact_wire_ids.length, 1);
+
+  assert.doesNotThrow(() => validateReadStatePage(config, {
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, min_available_seq: "4", current_seq: "9",
+    items: [{ kind: "frontier", member_id: members[0].member_id, server_seq: "7" }],
+    next_page_after: { member_id: members[0].member_id, kind: "frontier" }, has_more: true,
+  }, 1));
+  assert.throws(() => validateReadStatePage(config, {
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, min_available_seq: "4", current_seq: "9",
+    items: [{ kind: "frontier", member_id: members[0].member_id, server_seq: "3" }],
+    next_page_after: null, has_more: false,
+  }, 1), /item is invalid/u);
 });
 
 test("resolved protocol errors enforce the immutable binding", () => {

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -129,8 +129,9 @@ test("Stage-1-only driver skips the optional Stage-2 network path", async () => 
 
 test("Stage-2 isolates a limit offender and continues read-only synchronization", async () => {
   const members = [
-    { member_id: "018f3f7e-0000-7000-8000-000000000010", name: "worker-1" },
-    { member_id: "018f3f7e-0000-7000-8000-000000000020", name: "worker-2" },
+    { member_id: "018f3f7e-0000-7000-8000-000000000010", name: "causal-a" },
+    { member_id: "018f3f7e-0000-7000-8000-000000000020", name: "worker-b" },
+    { member_id: "018f3f7e-0000-7000-8000-000000000030", name: "reported-c" },
   ];
   const capabilities = {
     protocol_version: 1, server_instance_id: config.server_instance_id,
@@ -151,9 +152,14 @@ test("Stage-2 isolates a limit offender and continues read-only synchronization"
       if (operation === "capabilities") return [{
         type: "sync_driver_capabilities", capabilities: ["stage1-sync", "stage2-read-state"],
       }];
-      if (operation === "read-prepare") return members.map((member) => ({
-        type: "sync_read_frontier", member_id: member.member_id, server_seq: "0",
-      }));
+      if (operation === "read-prepare") return [
+        { type: "sync_read_frontier", member_id: members[0].member_id, server_seq: "0" },
+        ...Array.from({ length: 5001 }, (_, index) => ({ type: "sync_read_exact",
+          member_id: members[0].member_id,
+          wire_id: `550e8400-e29b-4000-8000-${String(index).padStart(12, "0")}` })),
+        ...members.slice(1).map((member) => ({ type: "sync_read_frontier",
+          member_id: member.member_id, server_seq: "0" })),
+      ];
       if (operation === "read-block") {
         assert.equal(input[0].member_id, members[0].member_id);
         return [{ type: "sync_read_blocked", member_id: members[0].member_id,
@@ -168,15 +174,19 @@ test("Stage-2 isolates a limit offender and continues read-only synchronization"
       assert.equal(path, "/v1/read-state/sync");
       postCount += 1;
       const updates = JSON.parse(init.body).updates;
-      if (postCount === 1) {
-        assert.deepEqual(updates.map((update) => update.member_id),
-          members.map((member) => member.member_id));
+      if (postCount <= 4) {
+        assert.deepEqual(updates.map((update) => update.member_id), [members[0].member_id]);
+      }
+      if (postCount === 5) {
+        assert.deepEqual(updates.map((update) => update.member_id), [members[0].member_id]);
         const error = new Error("limit");
         error.code = "read-state-limit-exceeded";
-        error.body = { error: { details: { member_id: members[0].member_id } } };
+        error.body = { error: { details: { member_id: members[2].member_id } } };
         throw error;
       }
-      assert.deepEqual(updates.map((update) => update.member_id), [members[1].member_id]);
+      if (postCount > 5) {
+        assert.equal(updates.some((update) => update.member_id === members[0].member_id), false);
+      }
       return { protocol_version: 1, server_instance_id: config.server_instance_id,
         team_id: config.remote_team_id, min_available_seq: "0", current_seq: "0",
         items: members.map((member) => ({ kind: "frontier",
@@ -185,7 +195,7 @@ test("Stage-2 isolates a limit offender and continues read-only synchronization"
     },
     eventCall: async () => {},
   });
-  assert.equal(postCount, 2);
+  assert.equal(postCount, 7);
   assert.ok(operations.includes("read-block"));
   assert.ok(operations.includes("read-apply"));
 });

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -194,6 +194,7 @@ test("Stage-2 isolates a limit offender and continues read-only synchronization"
         next_page_after: null, has_more: false };
     },
     eventCall: async () => {},
+    localAgentsCall: async () => members.map((member) => member.name),
   });
   assert.equal(postCount, 7);
   assert.ok(operations.includes("read-block"));

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -5,13 +5,16 @@ import { join } from "node:path";
 import test from "node:test";
 import {
   ageSnapshotDigest,
+  consistentReadStateContext,
   driver,
   isRetryable,
   plaintextWriteEligible,
+  readStateCycle,
   readStateUpdateBatches,
   request,
   retainAgeCheckpoint,
   selectWriteProfile,
+  stage2ReadStateSupported,
   validateAckMapping,
   validateAgeConfiguration,
   validateConfiguredAgeIdentities,
@@ -81,6 +84,128 @@ test("Stage-2 roster, update batches, and response pages are canonical", () => {
     items: [{ kind: "frontier", member_id: members[0].member_id, server_seq: "3" }],
     next_page_after: null, has_more: false,
   }, 1), /item is invalid/u);
+  const after = { member_id: members[0].member_id, kind: "frontier" };
+  assert.throws(() => validateReadStatePage(config, {
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, min_available_seq: "4", current_seq: "9",
+    items: [{ kind: "frontier", member_id: members[0].member_id, server_seq: "7" }],
+    next_page_after: { member_id: members[0].member_id, kind: "frontier" }, has_more: true,
+  }, 1, after), /page order/u);
+  assert.throws(() => validateReadStatePage(config, {
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, min_available_seq: "4", current_seq: "9",
+    items: [], next_page_after: null, has_more: true,
+  }, 1), /response is invalid/u);
+});
+
+test("Stage-2 capability is optional and blocked members emit no mutation", () => {
+  assert.equal(stage2ReadStateSupported([{
+    type: "sync_driver_capabilities", capabilities: ["stage1-sync"],
+  }]), false);
+  assert.equal(stage2ReadStateSupported([{
+    type: "sync_driver_capabilities", capabilities: ["stage1-sync", "stage2-read-state"],
+  }]), true);
+  const member = { member_id: "018f3f7e-0000-7000-8000-000000000010", name: "worker-1" };
+  assert.deepEqual(readStateUpdateBatches([member], [{
+    type: "sync_read_blocked", member_id: member.member_id,
+    reason: "read-state-limit-exceeded",
+  }]), [[]]);
+});
+
+test("Stage-1-only driver skips the optional Stage-2 network path", async () => {
+  const events = [];
+  await readStateCycle(config, 100, {
+    driverCall: async (operation) => {
+      assert.equal(operation, "capabilities");
+      return [{ type: "sync_driver_capabilities", capabilities: ["stage1-sync"] }];
+    },
+    requestCall: async () => { throw new Error("Stage-2 request must be skipped"); },
+    eventCall: async (name, value) => { events.push([name, value]); },
+  });
+  assert.deepEqual(events, [["read-state.skipped", {
+    reason: "driver-capability-not-advertised",
+  }]]);
+});
+
+test("Stage-2 isolates a limit offender and continues read-only synchronization", async () => {
+  const members = [
+    { member_id: "018f3f7e-0000-7000-8000-000000000010", name: "worker-1" },
+    { member_id: "018f3f7e-0000-7000-8000-000000000020", name: "worker-2" },
+  ];
+  const capabilities = {
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, min_available_seq: "0", current_seq: "0",
+    next_sequence_boundary: "1", accepted_envelope_versions: [1],
+    write_allowed_ciphers: ["none"], policy_revision: "0", effective_from_seq: "1",
+    max_blob_bytes: "1048576", policy_history: [{ policy_revision: "0",
+      effective_from_seq: "1", accepted_envelope_versions: [1], write_allowed_ciphers: ["none"] }],
+  };
+  const roster = { protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, min_available_seq: "0", members_revision: "0",
+    members: members.map((member) => ({ ...member, registrations: [] })) };
+  const operations = [];
+  let postCount = 0;
+  await readStateCycle(config, 100, {
+    driverCall: async (operation, _config, input) => {
+      operations.push(operation);
+      if (operation === "capabilities") return [{
+        type: "sync_driver_capabilities", capabilities: ["stage1-sync", "stage2-read-state"],
+      }];
+      if (operation === "read-prepare") return members.map((member) => ({
+        type: "sync_read_frontier", member_id: member.member_id, server_seq: "0",
+      }));
+      if (operation === "read-block") {
+        assert.equal(input[0].member_id, members[0].member_id);
+        return [{ type: "sync_read_blocked", member_id: members[0].member_id,
+          reason: "read-state-limit-exceeded" }];
+      }
+      if (operation === "read-apply") return [{ type: "sync_read_applied", member_count: 2 }];
+      throw new Error(`unexpected driver operation ${operation}`);
+    },
+    requestCall: async (_config, path, init) => {
+      if (path === "/v1/capabilities") return capabilities;
+      if (path === "/v1/members") return roster;
+      assert.equal(path, "/v1/read-state/sync");
+      postCount += 1;
+      const updates = JSON.parse(init.body).updates;
+      if (postCount === 1) {
+        assert.deepEqual(updates.map((update) => update.member_id),
+          members.map((member) => member.member_id));
+        const error = new Error("limit");
+        error.code = "read-state-limit-exceeded";
+        error.body = { error: { details: { member_id: members[0].member_id } } };
+        throw error;
+      }
+      assert.deepEqual(updates.map((update) => update.member_id), [members[1].member_id]);
+      return { protocol_version: 1, server_instance_id: config.server_instance_id,
+        team_id: config.remote_team_id, min_available_seq: "0", current_seq: "0",
+        items: members.map((member) => ({ kind: "frontier",
+          member_id: member.member_id, server_seq: "0" })),
+        next_page_after: null, has_more: false };
+    },
+    eventCall: async () => {},
+  });
+  assert.equal(postCount, 2);
+  assert.ok(operations.includes("read-block"));
+  assert.ok(operations.includes("read-apply"));
+});
+
+test("read-state context refetches a concurrent retention floor", async () => {
+  const capabilities10 = {
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, min_available_seq: "10", current_seq: "20",
+    next_sequence_boundary: "21", accepted_envelope_versions: [1],
+    write_allowed_ciphers: ["none"], policy_revision: "0", effective_from_seq: "1",
+    max_blob_bytes: "1048576", policy_history: [{ policy_revision: "0",
+      effective_from_seq: "1", accepted_envelope_versions: [1], write_allowed_ciphers: ["none"] }],
+  };
+  const capabilities20 = { ...capabilities10, min_available_seq: "20" };
+  const roster = (floor) => ({ protocol_version: 1,
+    server_instance_id: config.server_instance_id, team_id: config.remote_team_id,
+    min_available_seq: floor, members_revision: "0", members: [] });
+  const replies = [roster("20"), capabilities20, roster("20")];
+  const result = await consistentReadStateContext(config, capabilities10, async () => replies.shift());
+  assert.equal(result.capabilities.min_available_seq, "20");
 });
 
 test("resolved protocol errors enforce the immutable binding", () => {

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -253,3 +253,53 @@ prepare_push() {
   db=$(agmsg_db_path)
   [ "$(agmsg_sqlite "$db" "SELECT transport_cursor FROM sync_bindings;" | tr -d '\r')" = 2 ]
 }
+
+@test "Stage-2 rename mismatch blocks remote frontier in either ordering" {
+  local old_context new_context prepared db member
+  member=018f3f7e-0000-7000-8000-000000000010
+  old_context=$(jq -nc --arg member "$member" '
+    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",
+     members:[{member_id:$member,name:"bob"}]}')
+  new_context=$(jq -nc --arg member "$member" '
+    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",
+     members:[{member_id:$member,name:"robert"}]}')
+
+  printf '%s\n' "$old_context" |
+    storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  prepared=$(printf '%s\n' "$new_context" |
+    storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$prepared" | jq -r 'select(.type=="sync_read_blocked")|.reason')" = \
+    member-name-mismatch ]
+  [ "$(printf '%s\n' "$prepared" | jq -s '[.[]|select(.type=="sync_read_frontier")]|length')" -eq 0 ]
+
+  db=$(agmsg_db_path)
+  agmsg_sqlite "$db" "UPDATE sync_read_members SET agent='robert',
+    name_mismatch=CASE WHEN remote_agent='robert' THEN 0 ELSE 1 END
+    WHERE local_team='demo' AND member_id='$member';" >/dev/null
+  prepared=$(printf '%s\n' "$old_context" |
+    storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$prepared" | jq -r 'select(.type=="sync_read_blocked")|.reason')" = \
+    member-name-mismatch ]
+  [ "$(printf '%s\n' "$prepared" | jq -s '[.[]|select(.type=="sync_read_frontier")]|length')" -eq 0 ]
+}
+
+@test "Stage-2 exact limit block is durable and clears only after safe recomputation" {
+  local context member db result prepared
+  member=018f3f7e-0000-7000-8000-000000000010
+  context=$(jq -nc --arg member "$member" '
+    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",
+     members:[{member_id:$member,name:"bob"}]}')
+  printf '%s\n' "$context" |
+    storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  result=$(jq -nc --arg member "$member" '
+    {type:"sync_read_block",member_id:$member,reason:"read-state-limit-exceeded"}' |
+    storage_sync_block_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r '.reason')" = read-state-limit-exceeded ]
+  db=$(agmsg_db_path)
+  [ "$(agmsg_sqlite "$db" "SELECT blocked_reason FROM sync_read_members WHERE member_id='$member';" | tr -d '\r')" = \
+    read-state-limit-exceeded ]
+  prepared=$(printf '%s\n' "$context" |
+    storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$prepared" | jq -s '[.[]|select(.type=="sync_read_frontier")]|length')" -eq 1 ]
+  [ -z "$(agmsg_sqlite "$db" "SELECT blocked_reason FROM sync_read_members WHERE member_id='$member';" | tr -d '\r')" ]
+}

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -257,6 +257,7 @@ prepare_push() {
 @test "Stage-2 rename mismatch blocks remote frontier in either ordering" {
   local old_context new_context prepared db member
   member=018f3f7e-0000-7000-8000-000000000010
+  storage_send demo alice bob "local bob authority" >/dev/null
   old_context=$(jq -nc --arg member "$member" '
     {type:"sync_read_context",min_available_seq:"0",current_seq:"0",
      members:[{member_id:$member,name:"bob"}]}')
@@ -273,6 +274,7 @@ prepare_push() {
   [ "$(printf '%s\n' "$prepared" | jq -s '[.[]|select(.type=="sync_read_frontier")]|length')" -eq 0 ]
 
   db=$(agmsg_db_path)
+  agmsg_sqlite "$db" "UPDATE events SET to_agent='robert' WHERE team='demo' AND to_agent='bob';" >/dev/null
   agmsg_sqlite "$db" "UPDATE sync_read_members SET agent='robert',
     name_mismatch=CASE WHEN remote_agent='robert' THEN 0 ELSE 1 END
     WHERE local_team='demo' AND member_id='$member';" >/dev/null
@@ -283,9 +285,24 @@ prepare_push() {
   [ "$(printf '%s\n' "$prepared" | jq -s '[.[]|select(.type=="sync_read_frontier")]|length')" -eq 0 ]
 }
 
-@test "Stage-2 exact limit block is durable and clears only after safe recomputation" {
+@test "Stage-2 initial remote name without local authority is blocked" {
+  local context prepared member
+  member=018f3f7e-0000-7000-8000-000000000010
+  storage_send demo bob alice "local alice only" >/dev/null
+  context=$(jq -nc --arg member "$member" '
+    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",
+     members:[{member_id:$member,name:"bob"}]}')
+  prepared=$(printf '%s\n' "$context" |
+    storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$prepared" | jq -r 'select(.type=="sync_read_blocked")|.reason')" = \
+    member-name-mismatch ]
+  [ "$(printf '%s\n' "$prepared" | jq -s '[.[]|select(.type=="sync_read_frontier" or .type=="sync_read_exact")]|length')" -eq 0 ]
+}
+
+@test "Stage-2 exact limit block persists until explicit operator unblock" {
   local context member db result prepared
   member=018f3f7e-0000-7000-8000-000000000010
+  storage_send demo alice bob "local bob authority" >/dev/null
   context=$(jq -nc --arg member "$member" '
     {type:"sync_read_context",min_available_seq:"0",current_seq:"0",
      members:[{member_id:$member,name:"bob"}]}')
@@ -300,6 +317,12 @@ prepare_push() {
     read-state-limit-exceeded ]
   prepared=$(printf '%s\n' "$context" |
     storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$prepared" | jq -r 'select(.type=="sync_read_blocked")|.reason')" = \
+    read-state-limit-exceeded ]
+  result=$(jq -nc --arg member "$member" '{type:"sync_read_unblock",member_id:$member}' |
+    storage_sync_unblock_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r '.type')" = sync_read_unblocked ]
+  prepared=$(printf '%s\n' "$context" |
+    storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
   [ "$(printf '%s\n' "$prepared" | jq -s '[.[]|select(.type=="sync_read_frontier")]|length')" -eq 1 ]
-  [ -z "$(agmsg_sqlite "$db" "SELECT blocked_reason FROM sync_read_members WHERE member_id='$member';" | tr -d '\r')" ]
 }

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -212,3 +212,44 @@ prepare_push() {
   db=$(agmsg_db_path)
   [ "$(agmsg_sqlite "$db" "SELECT status FROM sync_quarantine WHERE wire_id='550e8400-e29b-41d4-a716-446655440020';" | tr -d '\r')" = imported ]
 }
+
+@test "Stage-2 sync exports exact reads across holes and applies remote frontier separately" {
+  local first second page ids second_local context prepared applied db
+  first=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"1",id:"550e8400-e29b-41d4-a716-446655440031",
+     server_received_at:"2026-07-21T06:00:00.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:"e30="},status:"importable",
+     policy_revision:"0",local_security_revision:"0",
+     projection:{body:"leave unread",created_at:"2026-07-21T06:00:00.000000Z",
+                 from_agent:"alice",to_agent:"bob"}}')
+  second=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"2",id:"550e8400-e29b-41d4-a716-446655440032",
+     server_received_at:"2026-07-21T06:00:01.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:"e30="},status:"importable",
+     policy_revision:"0",local_security_revision:"0",
+     projection:{body:"read out of order",created_at:"2026-07-21T06:00:01.000000Z",
+                 from_agent:"alice",to_agent:"bob"}}')
+  page=$(printf '%s\n%s\n%s\n' "$first" "$second" \
+    '{"type":"sync_pull_cursor","next_after":"2"}')
+  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  ids=$(storage_history demo | jq -r 'select(.to=="bob")|.id')
+  second_local=$(printf '%s\n' "$ids" | sed -n '2p')
+  storage_read_cursor_consume demo bob "$(storage_watch_tip demo:bob)" "$second_local" >/dev/null
+  context=$(jq -nc --arg member "018f3f7e-0000-7000-8000-000000000010" '
+    {type:"sync_read_context",min_available_seq:"0",current_seq:"2",
+     members:[{member_id:$member,name:"bob"}]}')
+  prepared=$(printf '%s\n' "$context" |
+    storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$prepared" | jq -r 'select(.type=="sync_read_frontier")|.server_seq')" = 0 ]
+  [ "$(printf '%s\n' "$prepared" | jq -r 'select(.type=="sync_read_exact")|.wire_id')" = \
+    550e8400-e29b-41d4-a716-446655440032 ]
+
+  applied=$(printf '%s\n%s\n' \
+    '{"type":"sync_read_snapshot","min_available_seq":"0","current_seq":"2"}' \
+    '{"type":"sync_read_frontier","member_id":"018f3f7e-0000-7000-8000-000000000010","server_seq":"2"}' |
+    storage_sync_apply_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$applied" | jq -r '.member_count')" = 1 ]
+  [ "$(storage_list_unread demo bob | jq -s 'length')" -eq 0 ]
+  db=$(agmsg_db_path)
+  [ "$(agmsg_sqlite "$db" "SELECT transport_cursor FROM sync_bindings;" | tr -d '\r')" = 2 ]
+}

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -236,7 +236,7 @@ prepare_push() {
   second_local=$(printf '%s\n' "$ids" | sed -n '2p')
   storage_read_cursor_consume demo bob "$(storage_watch_tip demo:bob)" "$second_local" >/dev/null
   context=$(jq -nc --arg member "018f3f7e-0000-7000-8000-000000000010" '
-    {type:"sync_read_context",min_available_seq:"0",current_seq:"2",
+    {type:"sync_read_context",min_available_seq:"0",current_seq:"2",local_agents:["bob"],
      members:[{member_id:$member,name:"bob"}]}')
   prepared=$(printf '%s\n' "$context" |
     storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
@@ -255,15 +255,18 @@ prepare_push() {
 }
 
 @test "Stage-2 rename mismatch blocks remote frontier in either ordering" {
-  local old_context new_context prepared db member
+  local old_context new_context local_first_context prepared db member
   member=018f3f7e-0000-7000-8000-000000000010
   storage_send demo alice bob "local bob authority" >/dev/null
   old_context=$(jq -nc --arg member "$member" '
-    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",
+    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",local_agents:["bob"],
      members:[{member_id:$member,name:"bob"}]}')
   new_context=$(jq -nc --arg member "$member" '
-    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",
+    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",local_agents:["bob"],
      members:[{member_id:$member,name:"robert"}]}')
+  local_first_context=$(jq -nc --arg member "$member" '
+    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",local_agents:["robert"],
+     members:[{member_id:$member,name:"bob"}]}')
 
   printf '%s\n' "$old_context" |
     storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
@@ -278,7 +281,7 @@ prepare_push() {
   agmsg_sqlite "$db" "UPDATE sync_read_members SET agent='robert',
     name_mismatch=CASE WHEN remote_agent='robert' THEN 0 ELSE 1 END
     WHERE local_team='demo' AND member_id='$member';" >/dev/null
-  prepared=$(printf '%s\n' "$old_context" |
+  prepared=$(printf '%s\n' "$local_first_context" |
     storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
   [ "$(printf '%s\n' "$prepared" | jq -r 'select(.type=="sync_read_blocked")|.reason')" = \
     member-name-mismatch ]
@@ -289,8 +292,9 @@ prepare_push() {
   local context prepared member
   member=018f3f7e-0000-7000-8000-000000000010
   storage_send demo bob alice "local alice only" >/dev/null
+  storage_send demo alice bob "remote projection cannot self-authorize bob" >/dev/null
   context=$(jq -nc --arg member "$member" '
-    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",
+    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",local_agents:["alice"],
      members:[{member_id:$member,name:"bob"}]}')
   prepared=$(printf '%s\n' "$context" |
     storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
@@ -304,7 +308,7 @@ prepare_push() {
   member=018f3f7e-0000-7000-8000-000000000010
   storage_send demo alice bob "local bob authority" >/dev/null
   context=$(jq -nc --arg member "$member" '
-    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",
+    {type:"sync_read_context",min_available_seq:"0",current_seq:"0",local_agents:["bob"],
      members:[{member_id:$member,name:"bob"}]}')
   printf '%s\n' "$context" |
     storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -92,6 +92,28 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [ "$(storage_read_cursor_get agsuite bob)" = "$tip" ]
 }
 
+@test "contract: read cursor cannot advance beyond the current driver tip" {
+  storage_read_cursor_consume agsuite bob 999999 >/dev/null
+  [ "$(storage_read_cursor_get agsuite bob)" = "0" ]
+  storage_send agsuite alice bob "not-skipped-by-future-cursor" >/dev/null
+  run storage_list_unread agsuite bob
+  [[ "$output" == *not-skipped-by-future-cursor* ]]
+}
+
+@test "contract: watch_after excludes an exact read beyond an earlier gap" {
+  local first second tip
+  first=$(storage_send agsuite alice bob "watch-gap")
+  second=$(storage_send agsuite alice bob "watch-exact")
+  tip=$(storage_watch_tip agsuite:bob)
+  storage_read_cursor_consume agsuite bob "$tip" "$second" >/dev/null
+
+  run storage_watch_after 0 agsuite:bob
+  [[ "$output" == *"$first"* ]]
+  [[ "$output" != *"$second"* ]]
+  [[ "$output" == *watch-gap* ]]
+  [[ "$output" != *watch-exact* ]]
+}
+
 @test "contract: cursor migration consumes existing backlog but not later messages" {
   storage_send agsuite alice bob "before-cursor-migration" >/dev/null
 

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -61,6 +61,59 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
   [[ "$output" == *"for carol"* ]]
 }
 
+@test "contract: read cursor is per-pair and advances only through a covered prefix" {
+  local first second tip
+  first=$(storage_send agsuite alice bob "cursor-first")
+  second=$(storage_send agsuite alice bob "cursor-second")
+  tip=$(storage_watch_tip agsuite:bob)
+
+  [ "$(storage_read_cursor_get agsuite bob)" = "0" ]
+  storage_read_cursor_consume agsuite bob "$tip" "$second" >/dev/null
+  # Reading the later row creates an exact exception but cannot cross the first
+  # unread hole. The later row is nevertheless not redelivered.
+  [ "$(storage_read_cursor_get agsuite bob)" = "0" ]
+  run storage_list_unread agsuite bob
+  [[ "$output" == *cursor-first* ]]
+  [[ "$output" != *cursor-second* ]]
+
+  storage_read_cursor_consume agsuite bob "$tip" "$first" >/dev/null
+  [ "$(storage_read_cursor_get agsuite bob)" = "$tip" ]
+  [ "$(storage_read_cursor_get agsuite carol)" = "0" ]
+  run storage_list_unread agsuite bob
+  [ -z "$output" ]
+}
+
+@test "contract: read cursor max-merges and never moves backwards" {
+  local first tip
+  first=$(storage_send agsuite alice bob "cursor-monotonic")
+  tip=$(storage_watch_tip agsuite:bob)
+  storage_read_cursor_consume agsuite bob "$tip" "$first" >/dev/null
+  storage_read_cursor_consume agsuite bob 0 >/dev/null
+  [ "$(storage_read_cursor_get agsuite bob)" = "$tip" ]
+}
+
+@test "contract: cursor migration consumes existing backlog but not later messages" {
+  storage_send agsuite alice bob "before-cursor-migration" >/dev/null
+
+  if [ "${AGMSG_STORAGE_DRIVER:-sqlite}" = jsonl ]; then
+    local store_dir; store_dir="$(dirname "$(agmsg_db_path)")"
+    rm -f "$store_dir/.read-cursor-v1" "$store_dir/read-cursors.tsv"
+  else
+    agmsg_sqlite "$(agmsg_db_path)" "
+      DELETE FROM storage_metadata WHERE key='read_cursor_v1';
+      DELETE FROM read_cursors;" >/dev/null
+  fi
+
+  storage_init >/dev/null
+  run storage_list_unread agsuite bob
+  [[ "$output" != *before-cursor-migration* ]]
+
+  storage_send agsuite alice bob "after-cursor-migration" >/dev/null
+  run storage_list_unread agsuite bob
+  [[ "$output" == *after-cursor-migration* ]]
+  [[ "$output" != *before-cursor-migration* ]]
+}
+
 @test "contract: watch_tip + watch_after deliver only post-tip messages, with a cursor" {
   storage_send agsuite alice bob "before"
   local tip; tip=$(storage_watch_tip agsuite:bob)

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -369,16 +369,23 @@ EOF
   storage_init >/dev/null
   storage_read_cursor_consume oldteam alice 0 >/dev/null
   _sqlite_sync_schema
-  local generation db
+  local generation db store_dir
   generation=$(_sqlite_sync_generation)
   db=$(agmsg_db_path)
+  store_dir=$(agmsg_storage_dir)
   agmsg_sqlite "$db" "INSERT INTO sync_bindings
     (local_team,server_instance_id,remote_team_id,protocol_version,driver_generation)
     VALUES('oldteam','018f3f7e-0000-7000-8000-000000000000',
       '018f3f7e-0000-7000-8000-000000000001',1,'$generation');"
+  mkdir -p "$store_dir/remote-sync"
+  printf '{"local_team":"oldteam","binding":"fixture"}\n' \
+    > "$store_dir/remote-sync/oldteam.json"
+  chmod 600 "$store_dir/remote-sync/oldteam.json"
   bash "$SCRIPTS/rename-team.sh" oldteam newteam
   [ "$(agmsg_sqlite "$db" "SELECT team FROM read_cursors;" | tr -d '\r')" = newteam ]
   [ "$(agmsg_sqlite "$db" "SELECT local_team FROM sync_bindings;" | tr -d '\r')" = newteam ]
+  [ ! -e "$store_dir/remote-sync/oldteam.json" ]
+  [ "$(jq -r '.local_team' "$store_dir/remote-sync/newteam.json")" = newteam ]
 }
 
 @test "rename-team: JSONL keeps the cursor with the renamed event stream" {
@@ -465,13 +472,14 @@ EOF
   db=$(agmsg_db_path)
   agmsg_sqlite "$db" "INSERT INTO sync_read_members
     (local_team,server_instance_id,remote_team_id,protocol_version,
-     driver_generation,member_id,agent)
+     driver_generation,member_id,agent,remote_agent)
     VALUES('myteam','018f3f7e-0000-7000-8000-000000000000',
       '018f3f7e-0000-7000-8000-000000000001',1,'$generation',
-      '018f3f7e-0000-7000-8000-000000000010','claude');"
+      '018f3f7e-0000-7000-8000-000000000010','claude','claude');"
   bash "$SCRIPTS/rename.sh" myteam claude claude-orchestrator
   [ "$(agmsg_sqlite "$db" "SELECT agent FROM read_cursors;" | tr -d '\r')" = claude-orchestrator ]
   [ "$(agmsg_sqlite "$db" "SELECT agent FROM sync_read_members;" | tr -d '\r')" = claude-orchestrator ]
+  [ "$(agmsg_sqlite "$db" "SELECT name_mismatch FROM sync_read_members;" | tr -d '\r')" = 1 ]
 }
 
 @test "rename: JSONL keeps exact reads and cursor with the new agent name" {

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -361,6 +361,40 @@ EOF
   [[ "$output" =~ "hello" ]]
 }
 
+@test "rename-team: atomically migrates cursor and sync sidecars" {
+  bash "$SCRIPTS/join.sh" oldteam alice claude-code /tmp/proj-a
+  export SKILL_DIR="$TEST_SKILL_DIR" AGMSG_STORAGE_DRIVER=sqlite
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  storage_init >/dev/null
+  storage_read_cursor_consume oldteam alice 0 >/dev/null
+  _sqlite_sync_schema
+  local generation db
+  generation=$(_sqlite_sync_generation)
+  db=$(agmsg_db_path)
+  agmsg_sqlite "$db" "INSERT INTO sync_bindings
+    (local_team,server_instance_id,remote_team_id,protocol_version,driver_generation)
+    VALUES('oldteam','018f3f7e-0000-7000-8000-000000000000',
+      '018f3f7e-0000-7000-8000-000000000001',1,'$generation');"
+  bash "$SCRIPTS/rename-team.sh" oldteam newteam
+  [ "$(agmsg_sqlite "$db" "SELECT team FROM read_cursors;" | tr -d '\r')" = newteam ]
+  [ "$(agmsg_sqlite "$db" "SELECT local_team FROM sync_bindings;" | tr -d '\r')" = newteam ]
+}
+
+@test "rename-team: JSONL keeps the cursor with the renamed event stream" {
+  export SKILL_DIR="$TEST_SKILL_DIR" AGMSG_STORAGE_DRIVER=jsonl
+  bash "$SCRIPTS/join.sh" oldteam alice claude-code /tmp/proj-a
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  local id tip
+  id=$(storage_send oldteam bob alice hello)
+  tip=$(storage_watch_tip oldteam:alice)
+  storage_read_cursor_consume oldteam alice "$tip" "$id" >/dev/null
+  bash "$SCRIPTS/rename-team.sh" oldteam newteam
+  [ "$(storage_read_cursor_get newteam alice)" = "$tip" ]
+  [ "$(storage_history newteam | jq -r '.team')" = newteam ]
+}
+
 @test "rename-team: fails when old team is missing" {
   run bash "$SCRIPTS/rename-team.sh" nope newname
   [ "$status" -ne 0 ]
@@ -416,6 +450,43 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" =~ "hello" ]]
   [[ "$output" =~ "claude-orchestrator" ]]
+}
+
+@test "rename: atomically migrates cursor and remote member association" {
+  bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj-a
+  export SKILL_DIR="$TEST_SKILL_DIR" AGMSG_STORAGE_DRIVER=sqlite
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  storage_init >/dev/null
+  storage_read_cursor_consume myteam claude 0 >/dev/null
+  _sqlite_sync_schema
+  local generation db
+  generation=$(_sqlite_sync_generation)
+  db=$(agmsg_db_path)
+  agmsg_sqlite "$db" "INSERT INTO sync_read_members
+    (local_team,server_instance_id,remote_team_id,protocol_version,
+     driver_generation,member_id,agent)
+    VALUES('myteam','018f3f7e-0000-7000-8000-000000000000',
+      '018f3f7e-0000-7000-8000-000000000001',1,'$generation',
+      '018f3f7e-0000-7000-8000-000000000010','claude');"
+  bash "$SCRIPTS/rename.sh" myteam claude claude-orchestrator
+  [ "$(agmsg_sqlite "$db" "SELECT agent FROM read_cursors;" | tr -d '\r')" = claude-orchestrator ]
+  [ "$(agmsg_sqlite "$db" "SELECT agent FROM sync_read_members;" | tr -d '\r')" = claude-orchestrator ]
+}
+
+@test "rename: JSONL keeps exact reads and cursor with the new agent name" {
+  export SKILL_DIR="$TEST_SKILL_DIR" AGMSG_STORAGE_DRIVER=jsonl
+  bash "$SCRIPTS/join.sh" myteam claude claude-code /tmp/proj-a
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  local id tip
+  id=$(storage_send myteam bob claude hello)
+  tip=$(storage_watch_tip myteam:claude)
+  storage_read_cursor_consume myteam claude "$tip" "$id" >/dev/null
+  bash "$SCRIPTS/rename.sh" myteam claude claude-orchestrator
+  [ "$(storage_read_cursor_get myteam claude-orchestrator)" = "$tip" ]
+  [ "$(storage_history myteam | jq -r '.to')" = claude-orchestrator ]
+  [ "$(storage_list_unread myteam claude-orchestrator | jq -s 'length')" -eq 0 ]
 }
 
 @test "rename: fails when old agent is missing" {

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -1,9 +1,8 @@
 #!/usr/bin/env bats
 
-# Regression tests for the watch.sh per-session watermark (#107): a Monitor
-# restart must deliver messages that arrived during the restart gap, without
-# re-delivering anything already streamed, while a fresh session still starts
-# from "now" rather than replaying history.
+# Regression tests for the store-owned per-(team,agent) read cursor. Inbox and
+# monitor share this frontier, so restarts deliver gaps without replaying rows
+# already consumed by either delivery path.
 
 load test_helper
 
@@ -27,7 +26,7 @@ teardown() {
 # Returns once the watcher has been stopped.
 run_watcher_for() {
   local sid="$1" out="$2" secs="$3"
-  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- 4>&- &
   local pid=$!
   sleep "$secs"
   kill "$pid" 2>/dev/null || true
@@ -54,14 +53,12 @@ _max_message_id() {
     agmsg_sqlite "$(agmsg_db_path)" "SELECT COALESCE(MAX(id), 0) FROM messages;" )
 }
 
-# The delivery watermark is now an opaque storage cursor (the event-log
-# high-water), not a legacy messages id. This mirrors what storage_watch_tip
-# issues, so tests can assert the watcher's persisted watermark against it.
-_storage_tip() {
+# Read one pair's store-owned local frontier.
+_read_cursor() {
   ( # shellcheck disable=SC1090
     source "$SCRIPTS/lib/storage.sh"
-    agmsg_sqlite "$(agmsg_db_path)" \
-      "SELECT COALESCE((SELECT seq FROM sqlite_sequence WHERE name='events'),0);" )
+    agmsg_storage_load
+    storage_read_cursor_get "$1" "$2" )
 }
 
 _wait_for_file() {
@@ -95,9 +92,9 @@ _wait_for_file_contains() {
   skip_on_windows "watcher background launch under Git Bash (#182)"
   local sid="sess-restart"
 
-  # First watcher: fresh session, takes its mark at MAX(id)=0, then streams M1.
+  # First watcher consumes M1 into the shared store frontier.
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
-    >"$TEST_SKILL_DIR/out1.log" 2>/dev/null 3>&- &
+    >"$TEST_SKILL_DIR/out1.log" 2>/dev/null 3>&- 4>&- &
   local w1=$!
   sleep 1.5
   bash "$SCRIPTS/send.sh" team bob alice "M1-before-stop" >/dev/null
@@ -109,7 +106,7 @@ _wait_for_file_contains() {
   # A message arrives while NO watcher is running for this session.
   bash "$SCRIPTS/send.sh" team bob alice "M2-in-gap" >/dev/null
 
-  # Restart the SAME session_id — should resume from the persisted watermark.
+  # Any later watcher resumes from the store frontier (session id is irrelevant).
   run_watcher_for "$sid" "$TEST_SKILL_DIR/out2.log" 2
 
   # In-gap message is delivered on restart...
@@ -118,32 +115,21 @@ _wait_for_file_contains() {
   ! grep -q "M1-before-stop" "$TEST_SKILL_DIR/out2.log"
 }
 
-@test "watch: a fresh session starts from now and does not replay history" {
+@test "watch: a fresh session delivers existing unread; a later watcher does not replay it" {
   skip_on_windows "watcher background launch under Git Bash (#182)"
   # Pre-existing message before any watcher for this session ever runs.
   bash "$SCRIPTS/send.sh" team bob alice "M0-history" >/dev/null
 
-  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-fresh" "$PROJ" claude-code \
-    >"$TEST_SKILL_DIR/fresh.log" 2>/dev/null 3>&- &
-  local w=$!
-  sleep 1.5
+  run_watcher_for "sess-fresh" "$TEST_SKILL_DIR/fresh1.log" 2
+  grep -q "M0-history" "$TEST_SKILL_DIR/fresh1.log"
+
   bash "$SCRIPTS/send.sh" team bob alice "M-live" >/dev/null
-  sleep 2
-  kill "$w" 2>/dev/null || true
-  wait "$w" 2>/dev/null || true
-
-  # Live message after attach is delivered; pre-existing history is not replayed.
-  grep -q "M-live" "$TEST_SKILL_DIR/fresh.log"
-  ! grep -q "M0-history" "$TEST_SKILL_DIR/fresh.log"
+  run_watcher_for "sess-fresh2" "$TEST_SKILL_DIR/fresh2.log" 2
+  grep -q "M-live" "$TEST_SKILL_DIR/fresh2.log"
+  ! grep -q "M0-history" "$TEST_SKILL_DIR/fresh2.log"
 }
 
-@test "watch: persists a watermark file for the session" {
-  skip_on_windows "watcher background launch under Git Bash (#182)"
-  run_watcher_for "sess-wm" "$TEST_SKILL_DIR/wm.log" 1.5
-  [ -f "$TEST_SKILL_DIR/run/watch.$(_iid sess-wm).watermark" ]
-}
-
-@test "watch: exits within one interval when its session dies, without advancing the watermark past an undelivered row (#67)" {
+@test "watch: exits when its session dies without consuming an undelivered row (#67)" {
   skip_on_windows "watcher session liveness under Git Bash (#182)"
   # REWRITTEN from "closed consumer does not advance watermark...". The old test
   # asserted that a closed *downstream* consumer (`watch.sh | head -n 1`) made
@@ -162,23 +148,18 @@ _wait_for_file_contains() {
   # arrived while the watcher was down".
   local sesspid; sleep 600 & sesspid=$!
   local iid="sess-liveness.$sesspid"
-  local wm="$TEST_SKILL_DIR/run/watch.$iid.watermark"
   local pf="$TEST_SKILL_DIR/run/watch.$iid.pid"
   local out="$TEST_SKILL_DIR/liveness-delivery.log"
 
-  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$iid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$iid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- 4>&- &
   local w=$!
-  # Wait for the watermark file, not just the pidfile: the pidfile is written
-  # early (before the subscription is resolved and LAST is seeded), so sending a
-  # message right after it appears would race the seed and the row would land at
-  # or below the initial watermark and never be "new". The watermark file is
-  # written once the watcher is ready to receive.
-  _wait_for_file "$wm"
+  # There is no seed race: a pre-poll message remains unread at cursor zero.
+  _wait_for_file "$pf"
   [ -f "$pf" ]
 
   bash "$SCRIPTS/send.sh" team bob alice "M1-delivered" >/dev/null
   _wait_for_file_contains "$out" "M1-delivered"
-  local first_id="$(_storage_tip)"
+  local first_cursor="$(_read_cursor team alice)"
 
   # Owning session dies (reap it so kill -0 reports gone, not a zombie), then a
   # newer row arrives. The liveness guard runs before the DB poll, so the watcher
@@ -186,29 +167,27 @@ _wait_for_file_contains() {
   kill "$sesspid" 2>/dev/null || true
   wait "$sesspid" 2>/dev/null || true
   bash "$SCRIPTS/send.sh" team bob alice "M2-undelivered" >/dev/null
-  local second_id="$(_storage_tip)"
-
   _wait_for_missing "$pf" || { kill "$w" 2>/dev/null || true; false; }
   run kill -0 "$w"; [ "$status" -ne 0 ]
-  [ "$first_id" != "$second_id" ]
-  [ "$(cat "$wm")" = "$first_id" ]
+  [ "$(_read_cursor team alice)" = "$first_cursor" ]
   ! grep -q "M2-undelivered" "$out"
+  run_watcher_for "after-liveness" "$TEST_SKILL_DIR/liveness-redelivery.log" 2
+  grep -q "M2-undelivered" "$TEST_SKILL_DIR/liveness-redelivery.log"
 }
 
-@test "watch: closed stdout exits without advancing the watermark" {
+@test "watch: closed stdout exits without advancing the read cursor" {
   skip_on_windows "watcher background launch under Git Bash (#182)"
   local sid="sess-stdout-closed"
   local iid="$(_iid "$sid")"
-  local wm="$TEST_SKILL_DIR/run/watch.$iid.watermark"
   local pf="$TEST_SKILL_DIR/run/watch.$iid.pid"
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
-    1>&- 2>/dev/null 3>&- &
+    1>&- 2>/dev/null 3>&- 4>&- &
   local w=$!
 
-  _wait_for_file "$wm"
+  _wait_for_file "$pf"
   [ -f "$pf" ]
-  local initial="$(cat "$wm")"
+  local initial="$(_read_cursor team alice)"
 
   bash "$SCRIPTS/send.sh" team bob alice "M-after-closed-stdout" >/dev/null
 
@@ -219,26 +198,25 @@ _wait_for_file_contains() {
   }
   wait "$w" 2>/dev/null || true
 
-  [ "$(cat "$wm")" = "$initial" ]
+  [ "$(_read_cursor team alice)" = "$initial" ]
 
   run_watcher_for "$sid" "$TEST_SKILL_DIR/closed-redelivery.log" 2
   grep -q "M-after-closed-stdout" "$TEST_SKILL_DIR/closed-redelivery.log"
 }
 
-@test "session-end: removes the session watermark file" {
-  # Key the watermark under the same instance id session-end will derive.
-  local wm="$TEST_SKILL_DIR/run/watch.$(_iid sess-end).watermark"
-  mkdir -p "$TEST_SKILL_DIR/run"
-  echo 5 > "$wm"
+@test "session-end: leaves the store-owned read cursor intact" {
+  bash "$SCRIPTS/send.sh" team bob alice "read-before-end" >/dev/null
+  run bash "$SCRIPTS/inbox.sh" team alice
+  local before="$(_read_cursor team alice)"
   printf '{"session_id":"sess-end"}' | bash "$SCRIPTS/session-end.sh" claude-code "$PROJ" >/dev/null 2>&1 || true
-  [ ! -f "$wm" ]
+  [ "$(_read_cursor team alice)" = "$before" ]
 }
 
 @test "watch: actas-mode watcher creates a ready sentinel and removes it on exit" {
   skip_on_windows "watcher background launch under Git Bash (#182)"
   local ready="$TEST_SKILL_DIR/run/ready.team__alice"
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-ready" "$PROJ" claude-code alice \
-    >/dev/null 2>&1 3>&- &
+    >/dev/null 2>&1 3>&- 4>&- &
   local w=$!
   # Wait for the watcher to attach and signal readiness.
   local i
@@ -264,7 +242,7 @@ _wait_for_file_contains() {
   skip_on_windows "watcher background launch under Git Bash (#182)"
   local ready="$TEST_SKILL_DIR/run/ready.team__alice"
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-own" "$PROJ" claude-code alice \
-    >/dev/null 2>&1 3>&- &
+    >/dev/null 2>&1 3>&- 4>&- &
   local w=$! i
   for i in 1 2 3 4 5 6 7 8 9 10; do [ -e "$ready" ] && break; sleep 0.5; done
   # watch.sh stamps the instance id (composite under an agent ancestor).
@@ -276,7 +254,7 @@ _wait_for_file_contains() {
 @test "watch: cleanup leaves a sentinel that a successor session re-owned" {
   local ready="$TEST_SKILL_DIR/run/ready.team__alice"
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-old" "$PROJ" claude-code alice \
-    >/dev/null 2>&1 3>&- &
+    >/dev/null 2>&1 3>&- 4>&- &
   local w=$! i
   for i in 1 2 3 4 5 6 7 8 9 10; do [ -e "$ready" ] && break; sleep 0.5; done
   # A successor watcher overwrites the sentinel with its own id.
@@ -295,7 +273,7 @@ _wait_for_file_contains() {
 
   # Start a watcher so a pidfile exists with a live pid.
   AGMSG_WATCH_INTERVAL=60 bash "$SCRIPTS/watch.sh" "sess1" "$PROJ" claude-code \
-    >/dev/null 2>&1 &
+    >/dev/null 2>&1 3>&- 4>&- &
   local wpid=$!
 
   # Resolve the instance id session-start.sh will compute for "sess1".
@@ -323,24 +301,20 @@ _wait_for_file_contains() {
   wait "$wpid" 2>/dev/null || true
 }
 
-@test "session-start: GCs stale watermark/ready but keeps live ones" {
+@test "session-start: GCs a stale ready sentinel but keeps a live one" {
   skip_on_windows "watcher live-owner liveness under Git Bash (#182)"
   bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
   mkdir -p "$TEST_SKILL_DIR/run"
   # Stale (owner has no live cc-instance).
-  echo 5 > "$TEST_SKILL_DIR/run/watch.deadsid.watermark"
   echo deadsid > "$TEST_SKILL_DIR/run/ready.team__ghost"
   # Live owner.
   setup_live_owner "$TEST_SKILL_DIR/run" LIVESID
-  echo 7 > "$TEST_SKILL_DIR/run/watch.LIVESID.watermark"
   echo LIVESID > "$TEST_SKILL_DIR/run/ready.team__live"
 
   printf '{"session_id":"somesess"}' \
     | bash "$SCRIPTS/session-start.sh" claude-code "$PROJ" >/dev/null 2>&1 || true
 
-  [ ! -f "$TEST_SKILL_DIR/run/watch.deadsid.watermark" ]
   [ ! -f "$TEST_SKILL_DIR/run/ready.team__ghost" ]
-  [ -f "$TEST_SKILL_DIR/run/watch.LIVESID.watermark" ]
   [ -f "$TEST_SKILL_DIR/run/ready.team__live" ]
 }
 
@@ -368,9 +342,9 @@ _wait_pidfile() {
   local pf1="$TEST_SKILL_DIR/run/watch.shared.$sp1.pid"
   local pf2="$TEST_SKILL_DIR/run/watch.shared.$sp2.pid"
 
-  AGMSG_WATCH_INTERVAL=5 bash "$SCRIPTS/watch.sh" "shared.$sp1" "$PROJ" claude-code >/dev/null 2>&1 3>&- &
+  AGMSG_WATCH_INTERVAL=5 bash "$SCRIPTS/watch.sh" "shared.$sp1" "$PROJ" claude-code >/dev/null 2>&1 3>&- 4>&- &
   local w1=$!
-  AGMSG_WATCH_INTERVAL=5 bash "$SCRIPTS/watch.sh" "shared.$sp2" "$PROJ" claude-code >/dev/null 2>&1 3>&- &
+  AGMSG_WATCH_INTERVAL=5 bash "$SCRIPTS/watch.sh" "shared.$sp2" "$PROJ" claude-code >/dev/null 2>&1 3>&- 4>&- &
   local w2=$!
 
   _wait_pidfile "$pf1" "$w1"
@@ -399,11 +373,11 @@ _wait_pidfile() {
   local iid="solo.$sesspid"
   local pf="$TEST_SKILL_DIR/run/watch.$iid.pid"
 
-  AGMSG_WATCH_INTERVAL=5 bash "$SCRIPTS/watch.sh" "$iid" "$PROJ" claude-code >/dev/null 2>&1 3>&- &
+  AGMSG_WATCH_INTERVAL=5 bash "$SCRIPTS/watch.sh" "$iid" "$PROJ" claude-code >/dev/null 2>&1 3>&- 4>&- &
   local w1=$!
   _wait_pidfile "$pf" "$w1"
 
-  AGMSG_WATCH_INTERVAL=5 bash "$SCRIPTS/watch.sh" "$iid" "$PROJ" claude-code >/dev/null 2>&1 3>&- &
+  AGMSG_WATCH_INTERVAL=5 bash "$SCRIPTS/watch.sh" "$iid" "$PROJ" claude-code >/dev/null 2>&1 3>&- 4>&- &
   local w2=$!
   # Successor claims the pidfile slot...
   _wait_pidfile "$pf" "$w2"
@@ -428,7 +402,7 @@ _wait_pidfile() {
   [ -f "$DB" ]                # init-db.sh created it in setup_test_env
   chmod 000 "$DB"
   local out="$BATS_TEST_TMPDIR/hc.out"
-  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-hc" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-hc" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- 4>&- &
   local pid=$!
   sleep 2                     # > one poll interval; a spinning watcher would re-emit
   kill "$pid" 2>/dev/null || true   # no-op if the healthcheck already exited
@@ -443,18 +417,18 @@ _wait_pidfile() {
 # an id and start, not die with a "Usage" error (which left the monitor down).
 # No silent message loss across a burst (#245): the head-5 truncation bug had a
 # grok agent append `| head -5` to the monitor command, so after the 5th line the
-# consumer closed and later messages were dropped while the watermark advanced
+# consumer closed and later messages were dropped while the cursor advanced
 # past them. With the watcher streaming normally (no downstream truncation), a
 # burst of N>5 consecutive messages must ALL be delivered.
 @test "watch: delivers a burst of 8 consecutive messages without loss (#245)" {
   skip_on_windows "watcher background launch under Git Bash (#182)"
   local sid="sess-burst"
   local out="$TEST_SKILL_DIR/burst.log"
-  local wm="$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark"
+  local pf="$TEST_SKILL_DIR/run/watch.$(_iid "$sid").pid"
 
-  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null &
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- 4>&- &
   local w=$!
-  _wait_for_file "$wm"          # ready to receive (watermark seeded)
+  _wait_for_file "$pf"          # watcher process is live; unread has no seed race
 
   local n
   for n in 1 2 3 4 5 6 7 8; do
@@ -473,7 +447,7 @@ _wait_pidfile() {
 
 @test "watch: empty session_id gets a generated fallback instead of a Usage error (#236)" {
   local out="$BATS_TEST_TMPDIR/empty-sid.out"
-  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "" "$PROJ" claude-code alice >"$out" 2>&1 3>&- &
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "" "$PROJ" claude-code alice >"$out" 2>&1 3>&- 4>&- &
   local pid=$!
   # A fallback id means a watch.agmsg-*.pid appears under run/ as the watcher arms.
   local i started=0

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -33,6 +33,27 @@ run_watcher_for() {
   wait "$pid" 2>/dev/null || true
 }
 
+run_watcher_until() {
+  local sid="$1" out="$2" needle="$3" before
+  before=$(_read_cursor team alice 2>/dev/null || echo 0)
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- 4>&- &
+  local pid=$!
+  _wait_for_file_contains "$out" "$needle"
+  local found=$?
+  if [ "$found" -eq 0 ]; then
+    local i cursor
+    for i in $(seq 1 100); do
+      cursor=$(_read_cursor team alice 2>/dev/null || echo 0)
+      [ "${cursor:-0}" -gt "${before:-0}" ] && break
+      sleep 0.1
+    done
+    [ "${cursor:-0}" -gt "${before:-0}" ] || found=1
+  fi
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  return "$found"
+}
+
 # Compute the per-process instance id (#93) that watch.sh / session-end key on
 # for <sid>, the same way the scripts do. Resolves to a composite "<sid>.<pid>"
 # when an agent ancestor is present (e.g. running the suite under a Claude Code
@@ -67,6 +88,7 @@ _wait_for_file() {
     [ -f "$file" ] && return 0
     sleep 0.1
   done
+  [ "${cursor:-0}" -gt 0 ]
   return 1
 }
 
@@ -98,7 +120,13 @@ _wait_for_file_contains() {
   local w1=$!
   sleep 1.5
   bash "$SCRIPTS/send.sh" team bob alice "M1-before-stop" >/dev/null
-  sleep 2
+  _wait_for_file_contains "$TEST_SKILL_DIR/out1.log" "M1-before-stop"
+  local i cursor
+  for i in $(seq 1 100); do
+    cursor=$(_read_cursor team alice 2>/dev/null || echo 0)
+    [ "${cursor:-0}" -gt 0 ] && break
+    sleep 0.1
+  done
   kill "$w1" 2>/dev/null || true
   wait "$w1" 2>/dev/null || true
   grep -q "M1-before-stop" "$TEST_SKILL_DIR/out1.log"
@@ -120,11 +148,11 @@ _wait_for_file_contains() {
   # Pre-existing message before any watcher for this session ever runs.
   bash "$SCRIPTS/send.sh" team bob alice "M0-history" >/dev/null
 
-  run_watcher_for "sess-fresh" "$TEST_SKILL_DIR/fresh1.log" 2
+  run_watcher_until "sess-fresh" "$TEST_SKILL_DIR/fresh1.log" "M0-history"
   grep -q "M0-history" "$TEST_SKILL_DIR/fresh1.log"
 
   bash "$SCRIPTS/send.sh" team bob alice "M-live" >/dev/null
-  run_watcher_for "sess-fresh2" "$TEST_SKILL_DIR/fresh2.log" 2
+  run_watcher_until "sess-fresh2" "$TEST_SKILL_DIR/fresh2.log" "M-live"
   grep -q "M-live" "$TEST_SKILL_DIR/fresh2.log"
   ! grep -q "M0-history" "$TEST_SKILL_DIR/fresh2.log"
 }


### PR DESCRIPTION
## Summary

This stacked dogfood PR begins Stage 2 read-state synchronization. It defines the composite local/remote frontier and bounded exact-read protocol, then integrates the store-owned local cursor across inbox and monitor delivery.

The remote server and polling-engine implementation is intentionally deferred until the protocol review on ADR 0008 is clear. Stage 3 SSE/wake delivery is explicitly out of scope.

## Contract

- Keep local positions store-local and merge only remote server frontiers across machines.
- Preserve out-of-order reads as exact local IDs, atomically promoting them to wire IDs with the durable message mapping.
- Keep transport, quarantine/decrypt, projection, and read progress independent.
- Bound and paginate exact remote state; garbage-collect it only from a proven wire-to-sequence mapping.
- Bind remote read state to immutable server/team/protocol/member identities.

## Local integration

- Add per-pair read cursors to SQLite and JSONL.
- Share one cursor between inbox and monitor instead of per-session watermarks.
- Advance only through a contiguous covered prefix while retaining exact exceptions.
- Treat pre-cursor backlog as consumed during one-time migration to avoid an upgrade redelivery storm.

## Verification

- SQLite storage contract: 32/32 passed.
- JSONL storage contract: 32/32 passed.
- Watch suite: 16/16 passed and exits cleanly.
- Inbox/check-inbox suite: 4/4 passed.
- Shell syntax and diff checks passed.

This PR must remain Draft and unmerged while the dogfood stack is under review.