### PR TITLE
feat: recover from retained remote history

### DIFF
--- a/docs/adr/0005-stage-1-remote-sync.md
+++ b/docs/adr/0005-stage-1-remote-sync.md
@@ -154,15 +154,17 @@ existing atomic import transition. Reprocessing is explicit rather than part of
 every polling cycle, so a permanently invalid ciphertext cannot cause an
 automatic decrypt loop.
 
-The following future operation remains reserved but is not implemented in
-Stage 1:
+ADR 0009 promotes the previously reserved recovery operation behind a separate
+optional `stage1-resync` capability:
 
 ```text
 storage_sync_resync       # operator-approved recovery after HTTP 410
 ```
 
-HTTP 410 remains terminal in Stage 1. The engine must not reset a transport
-cursor automatically.
+HTTP 410 remains terminal during normal Stage-1 polling. Only the explicit
+operator command defined by ADR 0009 may transactionally record the unavailable
+gap and advance to an authenticated retention floor; the engine never resets a
+transport cursor automatically.
 
 ## Consequences
 
@@ -181,4 +183,5 @@ cursor automatically.
 
 - [HTTP API v1](../../server/spec/v1.md)
 - [ADR 0003: storage-axis ABI and scope](0003-storage-axis-driver-abi-and-scope.md)
+- [ADR 0009: retention-gap resynchronization](0009-retention-gap-resynchronization.md)
 - Issue #441 (local-first cross-machine replication proposal)

--- a/docs/adr/0009-retention-gap-resynchronization.md
+++ b/docs/adr/0009-retention-gap-resynchronization.md
@@ -1,0 +1,129 @@
+# ADR 0009: Operator-approved retention-gap resynchronization
+
+**Status:** proposed (dogfood contract)
+**Date:** 2026-07-22
+**Deciders:** @fujibee
+
+## Context
+
+The HTTP v1 message stream returns `410 resync-required` when a client's
+transport cursor predates the team's authenticated `min_available_seq`.
+Stage 1 intentionally treats that response as terminal: silently assigning the
+floor to the cursor would claim that unavailable messages had durable local
+outcomes.
+
+Self-hosted operators nevertheless need bounded live-envelope storage. A
+device that was offline beyond retention must be able to resume without
+deleting its local-first messages, existing remote projections, decrypt
+quarantine, or read state. The missing server prefix cannot be reconstructed,
+so recovery must record an explicit acceptance of that loss rather than call it
+a successful import.
+
+## Decision
+
+### Explicit gap acceptance
+
+`remote-sync.sh resync --team NAME --accept-floor SEQUENCE` is the only v1
+operation that may recover a binding from `410 resync-required`. Invocation is
+an operator approval; polling commands never call it automatically.
+
+Before changing local state, the engine MUST:
+
+1. load and validate the existing immutable binding;
+2. obtain an authenticated capability snapshot;
+3. read the driver's current transport cursor without publishing a new
+   envelope;
+4. reproduce `410 resync-required` by requesting that exact cursor;
+5. validate the error binding and require the error floor, capability floor,
+   and `--accept-floor` value to be identical; and
+6. require `transport_cursor < min_available_seq <= current_seq`.
+
+A stale approval, a changed binding, a non-410 response, or a floor that changes
+during those checks is terminal and leaves local state unchanged. The operator
+must inspect the new floor and invoke the command again.
+
+### Driver transaction and audit record
+
+The optional `stage1-resync` capability adds:
+
+```text
+storage_sync_resync <local-team> <server-instance-id> <remote-team-id> <protocol-version>
+```
+
+The operation consumes exactly one UTF-8 JSONL record:
+
+```json
+{"type":"sync_resync","expected_transport_cursor":"42","min_available_seq":"100","current_seq":"123","reason":"retention-gap-accepted"}
+```
+
+In one storage transaction, the driver MUST revalidate the binding and exact
+expected cursor, insert an immutable audit record for the unavailable inclusive
+range `43..100`, and advance the transport cursor to `100`. The audit key
+contains the binding, driver generation, old cursor, and accepted floor so that
+retry is idempotent. A conflicting retry fails without mutation.
+
+The operation MUST NOT delete or rewrite local messages, remote projections,
+wire mappings, acknowledgements, conflicts, quarantine entries, security
+checkpoints, or read state. In particular:
+
+- an unacknowledged local message remains eligible for byte-identical retry;
+- a replay whose wire ID has become a server tombstone still reconciles to its
+  original `server_seq`;
+- existing blocking quarantine remains available to explicit reprocessing; and
+- Stage-2 read state independently max-merges the authenticated retention floor
+  under ADR 0008.
+
+The transaction emits one `sync_resync_result` with the old cursor, new cursor,
+and accepted gap. After it commits, a normal polling cycle starts at the floor
+and downloads only `server_seq > min_available_seq`. No event is fabricated for
+the unavailable range.
+
+Drivers without `stage1-resync` remain valid Stage-1 drivers. The engine checks
+the advertised capability before the operator command and fails without a
+network or local mutation when it is absent.
+
+### Reference-server retention configuration
+
+The reference server accepts optional
+`AGMSG_RETENTION_MAX_LIVE_MESSAGES=<positive integer>`. It is disabled when
+unset. After a successful message batch has its canonical acknowledgements, the
+same transaction and team-row lock advance the floor to
+`max(existing_floor, current_seq - max_live_messages)` when needed, create
+permanent digest tombstones, delete the covered live prefix, advance read
+frontiers, and garbage-collect covered exact reads before commit.
+
+The manual `npm run retain -- TEAM_ID THROUGH_SEQUENCE` operation remains
+available and uses the same transactional primitive. Automatic and manual
+retention therefore serialize with message sequence allocation and cannot
+expose a floor without complete tombstones.
+
+This setting bounds retained envelope payload rows, not all database bytes.
+Permanent UUID/digest tombstones, credentials, membership, policy history, and
+audit records remain durable protocol state. Operators must include that
+metadata in capacity planning.
+
+## Failure and retry semantics
+
+- `once` and `run` continue to stop on 410 and log the authenticated floor.
+- `resync` is safe to retry only with the same expected cursor and floor; an
+  already committed identical audit record returns the same result.
+- A crash before the driver commit changes nothing. A crash after commit leaves
+  the advanced cursor and audit row together, so the next poll resumes safely.
+- Resync never weakens age-v1 anti-rollback checkpoints or cipher policy.
+
+## Consequences
+
+- Offline devices can recover from self-host retention without a destructive
+  local-store replacement.
+- The UI and logs can distinguish imported history from an operator-accepted
+  unavailable interval.
+- Recovery accepts irreversible message loss for the missing server interval;
+  it cannot promise a full snapshot that HTTP v1 does not provide.
+- Live payload retention is configurable while permanent idempotency metadata
+  preserves exactly-once replay behavior.
+
+## References
+
+- [ADR 0005: Stage-1 remote synchronization](0005-stage-1-remote-sync.md)
+- [ADR 0008: Stage-2 read-state synchronization](0008-stage-2-read-cursor-sync.md)
+- [HTTP API v1](../../server/spec/v1.md)

--- a/docs/adr/0009-retention-gap-resynchronization.md
+++ b/docs/adr/0009-retention-gap-resynchronization.md
@@ -31,8 +31,9 @@ Before changing local state, the engine MUST:
 
 1. load and validate the existing immutable binding;
 2. obtain an authenticated capability snapshot;
-3. read the driver's current transport cursor without publishing a new
-   envelope;
+3. call the read-only resync-status ABI to obtain the driver's current
+   transport cursor and any audit record for the accepted floor, without
+   publishing a new envelope;
 4. reproduce `410 resync-required` by requesting that exact cursor;
 5. validate the error binding and require the error floor, capability floor,
    and `--accept-floor` value to be identical; and
@@ -40,15 +41,28 @@ Before changing local state, the engine MUST:
 
 A stale approval, a changed binding, a non-410 response, or a floor that changes
 during those checks is terminal and leaves local state unchanged. The operator
-must inspect the new floor and invoke the command again.
+must inspect the new floor and invoke the command again. The sole exception is
+an identical audit record returned by status: if its accepted floor equals the
+operator argument and the current cursor is at least that floor, the command
+returns the recorded result idempotently. It does not require the now-impossible
+old-cursor 410 to be reproduced.
 
 ### Driver transaction and audit record
 
 The optional `stage1-resync` capability adds:
 
 ```text
+storage_sync_resync_status <local-team> <server-instance-id> <remote-team-id> <protocol-version> <accepted-floor>
 storage_sync_resync <local-team> <server-instance-id> <remote-team-id> <protocol-version>
 ```
+
+Status is strictly read-only. It emits one `sync_resync_status` containing the
+current transport cursor and either the immutable audit whose accepted floor
+matches the canonical `accepted-floor` argument or `audit: null`. It MUST NOT
+reserve a wire ID, seal an envelope, initialize a new binding, advance a cursor,
+or change any other storage state. This is the normative backend-neutral seam;
+the engine never inspects a driver's database directly and never substitutes
+the mutating Stage-1 prepare operation.
 
 The operation consumes exactly one UTF-8 JSONL record:
 
@@ -58,9 +72,10 @@ The operation consumes exactly one UTF-8 JSONL record:
 
 In one storage transaction, the driver MUST revalidate the binding and exact
 expected cursor, insert an immutable audit record for the unavailable inclusive
-range `43..100`, and advance the transport cursor to `100`. The audit key
-contains the binding, driver generation, old cursor, and accepted floor so that
-retry is idempotent. A conflicting retry fails without mutation.
+range `43..100`, and advance the transport cursor to `100`. The audit has a
+unique `(binding, driver generation, accepted floor)` lookup key and records the
+old cursor. A conflicting record for the same accepted floor fails without
+mutation.
 
 The operation MUST NOT delete or rewrite local messages, remote projections,
 wire mappings, acknowledgements, conflicts, quarantine entries, security
@@ -74,9 +89,12 @@ checkpoints, or read state. In particular:
   under ADR 0008.
 
 The transaction emits one `sync_resync_result` with the old cursor, new cursor,
-and accepted gap. After it commits, a normal polling cycle starts at the floor
-and downloads only `server_seq > min_available_seq`. No event is fabricated for
-the unavailable range.
+and accepted gap. If the process crashes after commit but before observing that
+result, the repeated command obtains the same immutable row through status and
+returns the same result without requiring the old cursor as CLI input. After a
+commit, a normal polling cycle starts at the floor and downloads only
+`server_seq > min_available_seq`. No event is fabricated for the unavailable
+range.
 
 Drivers without `stage1-resync` remain valid Stage-1 drivers. The engine checks
 the advertised capability before the operator command and fails without a
@@ -86,8 +104,10 @@ network or local mutation when it is absent.
 
 The reference server accepts optional
 `AGMSG_RETENTION_MAX_LIVE_MESSAGES=<positive integer>`. It is disabled when
-unset. After a successful message batch has its canonical acknowledgements, the
-same transaction and team-row lock advance the floor to
+unset. The value MUST be canonical decimal, positive, and no greater than the
+signed 64-bit sequence maximum; an invalid value fails server startup before
+listening. After a successful message batch has its canonical acknowledgements,
+the same transaction and team-row lock advance the floor to
 `max(existing_floor, current_seq - max_live_messages)` when needed, create
 permanent digest tombstones, delete the covered live prefix, advance read
 frontiers, and garbage-collect covered exact reads before commit.
@@ -100,13 +120,18 @@ expose a floor without complete tombstones.
 This setting bounds retained envelope payload rows, not all database bytes.
 Permanent UUID/digest tombstones, credentials, membership, policy history, and
 audit records remain durable protocol state. Operators must include that
-metadata in capacity planning.
+metadata in capacity planning. A window smaller than an offline interval, or
+small relative to a large active write batch, can force healthy clients through
+410 recovery. The reference server MUST document this consequence and emit a
+retention log or metric containing the team, old floor, new floor, and removed
+live-row count without logging envelopes or credentials.
 
 ## Failure and retry semantics
 
 - `once` and `run` continue to stop on 410 and log the authenticated floor.
-- `resync` is safe to retry only with the same expected cursor and floor; an
-  already committed identical audit record returns the same result.
+- `resync` is safe to retry with the same accepted floor; an already committed
+  identical audit record returns the same result even though the current cursor
+  has advanced and the original 410 can no longer be reproduced.
 - A crash before the driver commit changes nothing. A crash after commit leaves
   the advanced cursor and audit row together, so the next poll resumes safely.
 - Resync never weakens age-v1 anti-rollback checkpoints or cipher policy.

--- a/docs/adr/0009-retention-gap-resynchronization.md
+++ b/docs/adr/0009-retention-gap-resynchronization.md
@@ -64,11 +64,50 @@ or change any other storage state. This is the normative backend-neutral seam;
 the engine never inspects a driver's database directly and never substitutes
 the mutating Stage-1 prepare operation.
 
+The status output is exactly one JSONL object with no duplicate or unknown
+fields. A lookup without an audit is:
+
+```json
+{"type":"sync_resync_status","driver_generation":"018f3f7e-0000-7000-8000-000000000099","transport_cursor":"42","audit":null}
+```
+
+An accepted audit uses this strict shape:
+
+```json
+{"type":"sync_resync_status","driver_generation":"018f3f7e-0000-7000-8000-000000000099","transport_cursor":"100","audit":{"expected_transport_cursor":"42","accepted_floor":"100","gap_start":"43","gap_end":"100","reason":"retention-gap-accepted"}}
+```
+
+`driver_generation` is the non-empty, immutable generation identifier already
+used by Stage 1 and is limited to 256 UTF-8 bytes without control characters.
+All cursor/floor/gap fields are canonical nonnegative decimal strings no greater
+than the signed 64-bit sequence maximum. The driver confines both cursor and
+audit lookup to the argv binding and returned generation.
+
+The engine MUST reject anything other than exactly one record and MUST reject
+duplicate JSON keys, unknown fields at either object level, noncanonical values,
+or a type other than `sync_resync_status`. For a non-null audit it also verifies:
+
+- `audit.accepted_floor` equals the requested argv floor;
+- `audit.gap_end` equals `audit.accepted_floor`;
+- `audit.gap_start` equals `audit.expected_transport_cursor + 1` without
+  overflow;
+- `audit.expected_transport_cursor < audit.accepted_floor <= transport_cursor`;
+  and
+- `audit.reason` is exactly `retention-gap-accepted`.
+
+`audit: null` is the only no-match representation; omitted audit fields or a
+partial object are invalid.
+
 The operation consumes exactly one UTF-8 JSONL record:
 
 ```json
 {"type":"sync_resync","expected_transport_cursor":"42","min_available_seq":"100","current_seq":"123","reason":"retention-gap-accepted"}
 ```
+
+This input is also strict: those five fields are required, no other or duplicate
+fields are allowed, all three sequences follow the canonical signed-BIGINT
+decimal rule, and
+`expected_transport_cursor < min_available_seq <= current_seq`.
 
 In one storage transaction, the driver MUST revalidate the binding and exact
 expected cursor, insert an immutable audit record for the unavailable inclusive
@@ -88,13 +127,24 @@ checkpoints, or read state. In particular:
 - Stage-2 read state independently max-merges the authenticated retention floor
   under ADR 0008.
 
-The transaction emits one `sync_resync_result` with the old cursor, new cursor,
-and accepted gap. If the process crashes after commit but before observing that
-result, the repeated command obtains the same immutable row through status and
-returns the same result without requiring the old cursor as CLI input. After a
-commit, a normal polling cycle starts at the floor and downloads only
-`server_seq > min_available_seq`. No event is fabricated for the unavailable
-range.
+The transaction emits exactly one strict result object:
+
+```json
+{"type":"sync_resync_result","driver_generation":"018f3f7e-0000-7000-8000-000000000099","expected_transport_cursor":"42","transport_cursor":"100","accepted_floor":"100","gap_start":"43","gap_end":"100","reason":"retention-gap-accepted"}
+```
+
+No duplicate, unknown, or missing field is allowed. Its generation must equal
+the preceding status generation, and its decimals/reason must satisfy the same
+predicates as a non-null status audit, with
+`transport_cursor == accepted_floor`. The engine validates the object before
+reporting success.
+
+If the process crashes after commit but before observing that result, the
+repeated command obtains the immutable row through status, constructs this
+exact same result shape, and returns it without requiring the old cursor as CLI
+input. After a commit, a normal polling cycle starts at the floor and downloads
+only `server_seq > min_available_seq`. No event is fabricated for the
+unavailable range.
 
 Drivers without `stage1-resync` remain valid Stage-1 drivers. The engine checks
 the advertised capability before the operator command and fails without a

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -345,7 +345,9 @@ message. Resync atomically records an authenticated, operator-accepted retention
 gap and advances only the transport cursor. Together they make result-loss
 retry idempotent without exposing driver storage internals. They never make
 HTTP 410 an automatic polling recovery and never delete local messages or
-independent state layers.
+independent state layers. ADR 0009 pins their exact strict JSONL status, input,
+audit, and result objects, including canonical sequence arithmetic and
+duplicate/unknown-field rejection.
 
 The independent Stage-2 extension from
 [ADR 0008](../adr/0008-stage-2-read-cursor-sync.md) is advertised as

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -332,6 +332,17 @@ reevaluation without rewinding transport. The complete framing, record schemas,
 crash boundaries, and future reserved operation names are defined by
 [ADR 0005](../adr/0005-stage-1-remote-sync.md).
 
+A driver may additionally advertise `stage1-resync` and implement the explicit
+operator recovery contract from [ADR 0009](../adr/0009-retention-gap-resynchronization.md):
+
+```text
+storage_sync_resync <local-team> <server-instance-id> <remote-team-id> <protocol-version>
+```
+
+It atomically records an authenticated, operator-accepted retention gap and
+advances only the transport cursor. It never makes HTTP 410 an automatic
+polling recovery and never deletes local messages or independent state layers.
+
 The independent Stage-2 extension from
 [ADR 0008](../adr/0008-stage-2-read-cursor-sync.md) is advertised as
 `capabilities=stage1-sync,stage2-read-state` and adds:

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -336,12 +336,16 @@ A driver may additionally advertise `stage1-resync` and implement the explicit
 operator recovery contract from [ADR 0009](../adr/0009-retention-gap-resynchronization.md):
 
 ```text
+storage_sync_resync_status <local-team> <server-instance-id> <remote-team-id> <protocol-version> <accepted-floor>
 storage_sync_resync <local-team> <server-instance-id> <remote-team-id> <protocol-version>
 ```
 
-It atomically records an authenticated, operator-accepted retention gap and
-advances only the transport cursor. It never makes HTTP 410 an automatic
-polling recovery and never deletes local messages or independent state layers.
+Status is a strictly read-only cursor/audit lookup; it cannot reserve or seal a
+message. Resync atomically records an authenticated, operator-accepted retention
+gap and advances only the transport cursor. Together they make result-loss
+retry idempotent without exposing driver storage internals. They never make
+HTTP 410 an automatic polling recovery and never delete local messages or
+independent state layers.
 
 The independent Stage-2 extension from
 [ADR 0008](../adr/0008-stage-2-read-cursor-sync.md) is advertised as

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -250,11 +250,12 @@ storage_sync_resync_status() {
 storage_sync_resync() {
   local team="$1" server="$2" remote="$3" protocol="$4"
   _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
-  _sqlite_sync_schema || return $?
-  local line extra expected floor current reason generation db tl gap_start
-  IFS= read -r line || return 13
-  IFS= read -r extra && [ -n "$extra" ] && return 13
-  [ -n "$line" ] || return 13
+  local line expected floor current reason generation db tl gap_start node_bin strict_parser
+  node_bin="${AGMSG_NODE:-node}"
+  strict_parser="$SKILL_DIR/scripts/internal/strict-jsonl.mjs"
+  command -v "$node_bin" >/dev/null 2>&1 && [ -f "$strict_parser" ] || return 10
+  line=$("$node_bin" "$strict_parser" current_seq expected_transport_cursor \
+    min_available_seq reason type) || return 13
   printf '%s\n' "$line" | jq -e '
     (keys == ["current_seq","expected_transport_cursor","min_available_seq","reason","type"])
     and .type == "sync_resync" and .reason == "retention-gap-accepted"
@@ -271,6 +272,7 @@ storage_sync_resync() {
   [ "$(_sqlite_sync_decimal_le "$floor" "$current")" = 1 ] || return 13
   gap_start=$((10#$expected + 1))
   _sqlite_sync_sequence "$gap_start" || return 13
+  _sqlite_sync_schema || return $?
   generation=$(_sqlite_sync_generation); db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"
 
   agmsg_sqlite "$db" "BEGIN IMMEDIATE;

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -34,6 +34,11 @@ _sqlite_sync_decimal_le() {
   fi
 }
 
+_sqlite_sync_sequence() {
+  case "$1" in ''|*[!0-9]*|0[0-9]*) return 1 ;; esac
+  [ "$(_sqlite_sync_decimal_le "$1" 9223372036854775807)" = 1 ]
+}
+
 _sqlite_sync_schema() {
   command -v jq >/dev/null 2>&1 || {
     echo "agmsg: Stage-1 sync requires jq" >&2
@@ -115,6 +120,21 @@ _sqlite_sync_schema() {
       UNIQUE(server_instance_id,remote_team_id,protocol_version,
              server_seq,wire_id,reason)
     );
+    CREATE TABLE IF NOT EXISTS sync_resync_audits (
+      local_team TEXT NOT NULL,
+      server_instance_id TEXT NOT NULL,
+      remote_team_id TEXT NOT NULL,
+      protocol_version INTEGER NOT NULL,
+      driver_generation TEXT NOT NULL,
+      expected_transport_cursor TEXT NOT NULL,
+      accepted_floor TEXT NOT NULL,
+      gap_start TEXT NOT NULL,
+      gap_end TEXT NOT NULL,
+      reason TEXT NOT NULL CHECK(reason='retention-gap-accepted'),
+      accepted_at TEXT NOT NULL,
+      PRIMARY KEY(local_team,server_instance_id,remote_team_id,
+                  protocol_version,driver_generation,accepted_floor)
+    );
     CREATE TABLE IF NOT EXISTS sync_read_members (
       local_team TEXT NOT NULL,
       server_instance_id TEXT NOT NULL,
@@ -188,6 +208,100 @@ _sqlite_sync_schema() {
     agmsg_sqlite "$db" "INSERT OR IGNORE INTO sync_store_metadata(singleton,generation)
       VALUES(1,'$(_sqlite_lit "$generation")');" >/dev/null 2>&1 || return 13
   fi
+}
+
+# Read-only cursor/audit lookup for explicit retention-gap recovery. This
+# deliberately does not call _sqlite_sync_schema or initialize a binding.
+storage_sync_resync_status() {
+  local team="$1" server="$2" remote="$3" protocol="$4" floor="$5"
+  _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
+  _sqlite_sync_sequence "$floor" || return 13
+  local db tl generation table_count
+  db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"
+  [ -f "$db" ] || return 13
+  table_count=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sqlite_master
+    WHERE type='table' AND name IN ('sync_store_metadata','sync_bindings','sync_resync_audits');" \
+    2>/dev/null | tr -d '\r') || return 13
+  [ "$table_count" = 3 ] || return 13
+  generation=$(agmsg_sqlite "$db" "SELECT generation FROM sync_store_metadata WHERE singleton=1;" \
+    2>/dev/null | tr -d '\r') || return 13
+  [ -n "$generation" ] || return 13
+  local output
+  output=$(_sqlite_data "SELECT json_object(
+      'type','sync_resync_status','driver_generation',b.driver_generation,
+      'transport_cursor',b.transport_cursor,'audit',CASE WHEN a.accepted_floor IS NULL
+        THEN NULL ELSE json_object(
+          'expected_transport_cursor',a.expected_transport_cursor,
+          'accepted_floor',a.accepted_floor,'gap_start',a.gap_start,
+          'gap_end',a.gap_end,'reason',a.reason) END)
+    FROM sync_bindings b LEFT JOIN sync_resync_audits a
+      ON a.local_team=b.local_team AND a.server_instance_id=b.server_instance_id
+     AND a.remote_team_id=b.remote_team_id AND a.protocol_version=b.protocol_version
+     AND a.driver_generation=b.driver_generation AND a.accepted_floor='$floor'
+    WHERE b.local_team='$tl' AND b.server_instance_id='$server'
+      AND b.remote_team_id='$remote' AND b.protocol_version=$protocol
+      AND b.driver_generation='$(_sqlite_lit "$generation")';") || return 13
+  [ -n "$output" ] || return 13
+  printf '%s\n' "$output"
+}
+
+# Atomically records an operator-accepted unavailable interval and advances
+# only the pull transport cursor.
+storage_sync_resync() {
+  local team="$1" server="$2" remote="$3" protocol="$4"
+  _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
+  _sqlite_sync_schema || return $?
+  local line extra expected floor current reason generation db tl gap_start
+  IFS= read -r line || return 13
+  IFS= read -r extra && [ -n "$extra" ] && return 13
+  [ -n "$line" ] || return 13
+  printf '%s\n' "$line" | jq -e '
+    (keys == ["current_seq","expected_transport_cursor","min_available_seq","reason","type"])
+    and .type == "sync_resync" and .reason == "retention-gap-accepted"
+    and (.expected_transport_cursor|type)=="string"
+    and (.min_available_seq|type)=="string" and (.current_seq|type)=="string"' \
+    >/dev/null 2>&1 || return 13
+  expected=$(printf '%s\n' "$line" | jq -r '.expected_transport_cursor')
+  floor=$(printf '%s\n' "$line" | jq -r '.min_available_seq')
+  current=$(printf '%s\n' "$line" | jq -r '.current_seq')
+  reason=$(printf '%s\n' "$line" | jq -r '.reason')
+  _sqlite_sync_sequence "$expected" && _sqlite_sync_sequence "$floor" &&
+    _sqlite_sync_sequence "$current" || return 13
+  [ "$(_sqlite_sync_decimal_le "$expected" "$floor")" = 1 ] && [ "$expected" != "$floor" ] || return 13
+  [ "$(_sqlite_sync_decimal_le "$floor" "$current")" = 1 ] || return 13
+  gap_start=$((10#$expected + 1))
+  _sqlite_sync_sequence "$gap_start" || return 13
+  generation=$(_sqlite_sync_generation); db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"
+
+  agmsg_sqlite "$db" "BEGIN IMMEDIATE;
+    CREATE TEMP TABLE resync_assert(ok INTEGER CHECK(ok=1));
+    INSERT INTO resync_assert SELECT CASE WHEN COUNT(*)=1 THEN 1 ELSE 0 END
+      FROM sync_bindings WHERE local_team='$tl' AND server_instance_id='$server'
+       AND remote_team_id='$remote' AND protocol_version=$protocol
+       AND driver_generation='$(_sqlite_lit "$generation")'
+       AND transport_cursor='$expected';
+    INSERT INTO sync_resync_audits
+      (local_team,server_instance_id,remote_team_id,protocol_version,
+       driver_generation,expected_transport_cursor,accepted_floor,gap_start,
+       gap_end,reason,accepted_at)
+    VALUES('$tl','$server','$remote',$protocol,'$(_sqlite_lit "$generation")',
+      '$expected','$floor','$gap_start','$floor','$reason',
+      strftime('%Y-%m-%dT%H:%M:%fZ','now'));
+    UPDATE sync_bindings SET transport_cursor='$floor'
+     WHERE local_team='$tl' AND server_instance_id='$server'
+       AND remote_team_id='$remote' AND protocol_version=$protocol
+       AND driver_generation='$(_sqlite_lit "$generation")'
+       AND transport_cursor='$expected';
+    COMMIT;" >/dev/null 2>&1 || return 13
+
+  _sqlite_data "SELECT json_object(
+      'type','sync_resync_result','driver_generation',driver_generation,
+      'expected_transport_cursor',expected_transport_cursor,
+      'transport_cursor',accepted_floor,'accepted_floor',accepted_floor,
+      'gap_start',gap_start,'gap_end',gap_end,'reason',reason)
+    FROM sync_resync_audits WHERE local_team='$tl' AND server_instance_id='$server'
+      AND remote_team_id='$remote' AND protocol_version=$protocol
+      AND driver_generation='$(_sqlite_lit "$generation")' AND accepted_floor='$floor';"
 }
 
 _sqlite_sync_generation() {

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -251,7 +251,7 @@ storage_sync_resync() {
   local team="$1" server="$2" remote="$3" protocol="$4"
   _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
   local line expected floor current reason generation db tl gap_start node_bin strict_parser
-  node_bin="${AGMSG_NODE:-node}"
+  node_bin="${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
   strict_parser="$SKILL_DIR/scripts/internal/strict-jsonl.mjs"
   command -v "$node_bin" >/dev/null 2>&1 && [ -f "$strict_parser" ] || return 10
   line=$("$node_bin" "$strict_parser" current_seq expected_transport_cursor \

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -80,7 +80,7 @@ storage_check() {
 storage_describe() {
   printf 'name=sqlite\n'
   printf 'backend=SQLite (WAL) event log + legacy messages table\n'
-  printf 'capabilities=stage1-sync,stage2-read-state\n'
+  printf 'capabilities=stage1-sync,stage1-resync,stage2-read-state\n'
   printf 'db=%s\n' "$(_sqlite_db)"
 }
 

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -25,6 +25,7 @@ function usage() {
   remote-sync.sh once --team NAME [--limit N]
   remote-sync.sh run --team NAME [--limit N] [--interval SECONDS]
   remote-sync.sh reprocess --team NAME [--limit N]
+  remote-sync.sh resync --team NAME --accept-floor SEQUENCE
   remote-sync.sh unblock-read --team NAME --member-id UUID
 
 AGMSG_SYNC_TOKEN is required and is never written to config or argv.`;
@@ -499,7 +500,8 @@ export async function driver(operation, config, input, extra = []) {
     child.stderr.on("data", (chunk) => { stderr += chunk; });
     child.on("error", reject);
     child.on("close", (code) => {
-      if (code === 0) resolve(parseJsonl(stdout));
+      if (code === 0) resolve(["resync-status", "resync"].includes(operation) ?
+        parseStrictJsonl(stdout) : parseJsonl(stdout));
       else reject(new Error(`storage sync ${operation} failed (${code}): ${stderr.trim()}`));
     });
     child.stdin.end(input.map((record) => `${JSON.stringify(record)}\n`).join(""));
@@ -508,6 +510,68 @@ export async function driver(operation, config, input, extra = []) {
 
 function parseJsonl(value) {
   return value.split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+}
+
+function rejectDuplicateJsonKeys(source) {
+  let offset = 0;
+  const whitespace = () => { while (/\s/u.test(source[offset] ?? "")) offset += 1; };
+  const string = () => {
+    const start = offset;
+    if (source[offset] !== '"') throw new Error("driver JSON framing is invalid");
+    offset += 1;
+    while (offset < source.length) {
+      if (source[offset] === "\\") { offset += 2; continue; }
+      if (source[offset] === '"') {
+        offset += 1;
+        return JSON.parse(source.slice(start, offset));
+      }
+      offset += 1;
+    }
+    throw new Error("driver JSON framing is invalid");
+  };
+  const value = () => {
+    whitespace();
+    if (source[offset] === "{") {
+      offset += 1; whitespace();
+      const keys = new Set();
+      if (source[offset] === "}") { offset += 1; return; }
+      for (;;) {
+        const key = string();
+        if (keys.has(key)) throw new Error("driver JSON contains a duplicate key");
+        keys.add(key); whitespace();
+        if (source[offset] !== ":") throw new Error("driver JSON framing is invalid");
+        offset += 1; value(); whitespace();
+        if (source[offset] === "}") { offset += 1; return; }
+        if (source[offset] !== ",") throw new Error("driver JSON framing is invalid");
+        offset += 1; whitespace();
+      }
+    }
+    if (source[offset] === "[") {
+      offset += 1; whitespace();
+      if (source[offset] === "]") { offset += 1; return; }
+      for (;;) {
+        value(); whitespace();
+        if (source[offset] === "]") { offset += 1; return; }
+        if (source[offset] !== ",") throw new Error("driver JSON framing is invalid");
+        offset += 1;
+      }
+    }
+    if (source[offset] === '"') { string(); return; }
+    const start = offset;
+    while (offset < source.length && !/[\s,}\]]/u.test(source[offset])) offset += 1;
+    if (start === offset) throw new Error("driver JSON framing is invalid");
+    JSON.parse(source.slice(start, offset));
+  };
+  value(); whitespace();
+  if (offset !== source.length) throw new Error("driver JSON framing is invalid");
+}
+
+export function parseStrictJsonl(value) {
+  const lines = value.split(/\r?\n/u).filter(Boolean);
+  return lines.map((line) => {
+    rejectDuplicateJsonKeys(line);
+    return JSON.parse(line);
+  });
 }
 
 async function event(name, fields = {}) {
@@ -802,6 +866,85 @@ export function stage2ReadStateSupported(records) {
     throw new Error("driver capability response is invalid");
   }
   return records[0].capabilities.includes("stage2-read-state");
+}
+
+export function stage1ResyncSupported(records) {
+  if (!Array.isArray(records) || records.length !== 1 ||
+      records[0]?.type !== "sync_driver_capabilities" ||
+      !Array.isArray(records[0].capabilities) ||
+      records[0].capabilities.some((value) => typeof value !== "string") ||
+      new Set(records[0].capabilities).size !== records[0].capabilities.length) {
+    throw new Error("driver capability response is invalid");
+  }
+  return records[0].capabilities.includes("stage1-resync");
+}
+
+function strictKeys(value, expected, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value) ||
+      Object.keys(value).sort().join(",") !== [...expected].sort().join(",")) {
+    throw new Error(`${label} shape is invalid`);
+  }
+}
+
+function validDriverGeneration(value) {
+  return typeof value === "string" && Buffer.byteLength(value, "utf8") >= 1 &&
+    Buffer.byteLength(value, "utf8") <= 256 && !/[\u0000-\u001f\u007f]/u.test(value);
+}
+
+function validateResyncAudit(audit, floor, transportCursor, label) {
+  strictKeys(audit, ["expected_transport_cursor", "accepted_floor", "gap_start",
+    "gap_end", "reason"], label);
+  const expected = BigInt(sequence(audit.expected_transport_cursor, `${label} expected cursor`));
+  const accepted = BigInt(sequence(audit.accepted_floor, `${label} accepted floor`));
+  const start = BigInt(sequence(audit.gap_start, `${label} gap start`));
+  const end = BigInt(sequence(audit.gap_end, `${label} gap end`));
+  const current = BigInt(sequence(transportCursor, `${label} transport cursor`));
+  if (audit.accepted_floor !== floor || end !== accepted || start !== expected + 1n ||
+      expected >= accepted || accepted > current || audit.reason !== "retention-gap-accepted") {
+    throw new Error(`${label} is inconsistent`);
+  }
+  return audit;
+}
+
+export function validateResyncStatus(records, floor) {
+  sequence(floor, "accepted floor");
+  if (!Array.isArray(records) || records.length !== 1) {
+    throw new Error("driver must emit exactly one resync status");
+  }
+  const status = records[0];
+  strictKeys(status, ["type", "driver_generation", "transport_cursor", "audit"],
+    "resync status");
+  if (status.type !== "sync_resync_status" || !validDriverGeneration(status.driver_generation)) {
+    throw new Error("resync status is invalid");
+  }
+  sequence(status.transport_cursor, "resync transport cursor");
+  if (status.audit !== null) {
+    validateResyncAudit(status.audit, floor, status.transport_cursor, "resync audit");
+  }
+  return status;
+}
+
+export function validateResyncResult(records, status, floor) {
+  if (!Array.isArray(records) || records.length !== 1) {
+    throw new Error("driver must emit exactly one resync result");
+  }
+  const result = records[0];
+  strictKeys(result, ["type", "driver_generation", "expected_transport_cursor",
+    "transport_cursor", "accepted_floor", "gap_start", "gap_end", "reason"],
+  "resync result");
+  if (result.type !== "sync_resync_result" ||
+      result.driver_generation !== status.driver_generation ||
+      result.transport_cursor !== floor) {
+    throw new Error("resync result is invalid");
+  }
+  validateResyncAudit({
+    expected_transport_cursor: result.expected_transport_cursor,
+    accepted_floor: result.accepted_floor,
+    gap_start: result.gap_start,
+    gap_end: result.gap_end,
+    reason: result.reason,
+  }, floor, result.transport_cursor, "resync result");
+  return result;
 }
 
 export function validateReadStatePage(config, value, pageLimit, pageAfter = null) {
@@ -1155,10 +1298,77 @@ async function reprocessCycle(config, limit) {
     transport_cursor: state.transport_cursor, result: applied[0] ?? null });
 }
 
+function resultFromResyncAudit(status) {
+  return {
+    type: "sync_resync_result",
+    driver_generation: status.driver_generation,
+    expected_transport_cursor: status.audit.expected_transport_cursor,
+    transport_cursor: status.audit.accepted_floor,
+    accepted_floor: status.audit.accepted_floor,
+    gap_start: status.audit.gap_start,
+    gap_end: status.audit.gap_end,
+    reason: status.audit.reason,
+  };
+}
+
+export async function resyncCycle(config, acceptedFloor, dependencies = {}) {
+  const driverCall = dependencies.driverCall ?? driver;
+  const requestCall = dependencies.requestCall ?? request;
+  const eventCall = dependencies.eventCall ?? event;
+  const floor = sequence(acceptedFloor, "accepted floor");
+  const driverCapabilities = await driverCall("capabilities", config, []);
+  if (!stage1ResyncSupported(driverCapabilities)) {
+    throw new Error("storage driver does not advertise stage1-resync");
+  }
+  const capabilities = await requestCall(config, "/v1/capabilities");
+  validateCapabilities(config, capabilities);
+  const status = validateResyncStatus(
+    await driverCall("resync-status", config, [], [floor]), floor);
+  const serverFloor = BigInt(capabilities.min_available_seq);
+  const serverCurrent = BigInt(capabilities.current_seq);
+  if (status.audit !== null) {
+    if (BigInt(floor) > serverFloor || BigInt(status.transport_cursor) > serverCurrent) {
+      throw new Error("recorded resync audit contradicts authenticated server state");
+    }
+    const result = resultFromResyncAudit(status);
+    validateResyncResult([result], status, floor);
+    await eventCall("resync.complete", { disposition: "already-accepted", result });
+    return result;
+  }
+  if (floor !== capabilities.min_available_seq ||
+      BigInt(status.transport_cursor) >= BigInt(floor) || BigInt(floor) > serverCurrent) {
+    throw new Error("accepted floor does not match the active retention gap");
+  }
+  let retentionError;
+  try {
+    await requestCall(config,
+      `/v1/messages?after=${encodeURIComponent(status.transport_cursor)}&limit=1`);
+  } catch (error) {
+    retentionError = error;
+  }
+  const details = retentionError?.body?.error?.details;
+  if (retentionError?.status !== 410 || retentionError?.code !== "resync-required" ||
+      retentionError.body?.min_available_seq !== floor ||
+      details?.after !== status.transport_cursor || details?.min_available_seq !== floor) {
+    throw new Error("server did not reproduce the authenticated retention gap");
+  }
+  const input = [{
+    type: "sync_resync",
+    expected_transport_cursor: status.transport_cursor,
+    min_available_seq: floor,
+    current_seq: capabilities.current_seq,
+    reason: "retention-gap-accepted",
+  }];
+  const result = validateResyncResult(
+    await driverCall("resync", config, input), status, floor);
+  await eventCall("resync.complete", { disposition: "accepted", result });
+  return result;
+}
+
 async function main() {
   const [command, ...rest] = process.argv.slice(2);
   const args = options(rest);
-  if (!["configure", "once", "run", "reprocess", "unblock-read"].includes(command)) {
+  if (!["configure", "once", "run", "reprocess", "resync", "unblock-read"].includes(command)) {
     throw new Error(usage());
   }
   if (command === "configure") { await configure(args); return; }
@@ -1172,6 +1382,10 @@ async function main() {
       type: "sync_read_unblock", member_id: args["member-id"],
     }]);
     await event("read-state.unblocked", { member_id: args["member-id"], result: result[0] ?? null });
+    return;
+  }
+  if (command === "resync") {
+    await resyncCycle(config, args["accept-floor"] ?? "");
     return;
   }
   if (command === "reprocess") { await reprocessCycle(config, limit); return; }

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -7,6 +7,8 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { ageExecutableVersion, CipherStateError, openEnvelope,
   readNativeAgeIdentity } from "./sync-cipher.mjs";
+import { parseStrictJsonl } from "./strict-jsonl.mjs";
+export { parseStrictJsonl } from "./strict-jsonl.mjs";
 
 const UUID_V7 = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -510,68 +512,6 @@ export async function driver(operation, config, input, extra = []) {
 
 function parseJsonl(value) {
   return value.split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
-}
-
-function rejectDuplicateJsonKeys(source) {
-  let offset = 0;
-  const whitespace = () => { while (/\s/u.test(source[offset] ?? "")) offset += 1; };
-  const string = () => {
-    const start = offset;
-    if (source[offset] !== '"') throw new Error("driver JSON framing is invalid");
-    offset += 1;
-    while (offset < source.length) {
-      if (source[offset] === "\\") { offset += 2; continue; }
-      if (source[offset] === '"') {
-        offset += 1;
-        return JSON.parse(source.slice(start, offset));
-      }
-      offset += 1;
-    }
-    throw new Error("driver JSON framing is invalid");
-  };
-  const value = () => {
-    whitespace();
-    if (source[offset] === "{") {
-      offset += 1; whitespace();
-      const keys = new Set();
-      if (source[offset] === "}") { offset += 1; return; }
-      for (;;) {
-        const key = string();
-        if (keys.has(key)) throw new Error("driver JSON contains a duplicate key");
-        keys.add(key); whitespace();
-        if (source[offset] !== ":") throw new Error("driver JSON framing is invalid");
-        offset += 1; value(); whitespace();
-        if (source[offset] === "}") { offset += 1; return; }
-        if (source[offset] !== ",") throw new Error("driver JSON framing is invalid");
-        offset += 1; whitespace();
-      }
-    }
-    if (source[offset] === "[") {
-      offset += 1; whitespace();
-      if (source[offset] === "]") { offset += 1; return; }
-      for (;;) {
-        value(); whitespace();
-        if (source[offset] === "]") { offset += 1; return; }
-        if (source[offset] !== ",") throw new Error("driver JSON framing is invalid");
-        offset += 1;
-      }
-    }
-    if (source[offset] === '"') { string(); return; }
-    const start = offset;
-    while (offset < source.length && !/[\s,}\]]/u.test(source[offset])) offset += 1;
-    if (start === offset) throw new Error("driver JSON framing is invalid");
-    JSON.parse(source.slice(start, offset));
-  };
-  value(); whitespace();
-  if (offset !== source.length) throw new Error("driver JSON framing is invalid");
-}
-
-export function parseStrictJsonl(value) {
-  const lines = value.split(/\r?\n/u).filter(Boolean);
-  return lines.map((line) => {
-    rejectDuplicateJsonKeys(line);
-    return JSON.parse(line);
-  });
 }
 
 async function event(name, fields = {}) {

--- a/scripts/internal/storage-sync-driver.sh
+++ b/scripts/internal/storage-sync-driver.sh
@@ -23,6 +23,10 @@ case "$op" in
              storage_sync_apply_pull "$@" ;;
   reprocess) command -v storage_sync_reprocess >/dev/null 2>&1 || exit 14
              storage_sync_reprocess "$@" ;;
+  resync-status) command -v storage_sync_resync_status >/dev/null 2>&1 || exit 14
+                 storage_sync_resync_status "$@" ;;
+  resync) command -v storage_sync_resync >/dev/null 2>&1 || exit 14
+          storage_sync_resync "$@" ;;
   read-prepare) command -v storage_sync_prepare_read_state >/dev/null 2>&1 || exit 14
                 storage_sync_prepare_read_state "$@" ;;
   read-apply) command -v storage_sync_apply_read_state >/dev/null 2>&1 || exit 14
@@ -31,5 +35,5 @@ case "$op" in
               storage_sync_block_read_state "$@" ;;
   read-unblock) command -v storage_sync_unblock_read_state >/dev/null 2>&1 || exit 14
                 storage_sync_unblock_read_state "$@" ;;
-  *) echo "usage: storage-sync-driver.sh capabilities|prepare|reconcile|apply|reprocess|read-prepare|read-apply|read-block|read-unblock ..." >&2; exit 2 ;;
+  *) echo "usage: storage-sync-driver.sh capabilities|prepare|reconcile|apply|reprocess|resync-status|resync|read-prepare|read-apply|read-block|read-unblock ..." >&2; exit 2 ;;
 esac

--- a/scripts/internal/strict-jsonl.mjs
+++ b/scripts/internal/strict-jsonl.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+function rejectDuplicateJsonKeys(source) {
+  let offset = 0;
+  const whitespace = () => { while (/\s/u.test(source[offset] ?? "")) offset += 1; };
+  const string = () => {
+    const start = offset;
+    if (source[offset] !== '"') throw new Error("JSON framing is invalid");
+    offset += 1;
+    while (offset < source.length) {
+      if (source[offset] === "\\") { offset += 2; continue; }
+      if (source[offset] === '"') {
+        offset += 1;
+        return JSON.parse(source.slice(start, offset));
+      }
+      offset += 1;
+    }
+    throw new Error("JSON framing is invalid");
+  };
+  const value = () => {
+    whitespace();
+    if (source[offset] === "{") {
+      offset += 1; whitespace();
+      const keys = new Set();
+      if (source[offset] === "}") { offset += 1; return; }
+      for (;;) {
+        const key = string();
+        if (keys.has(key)) throw new Error("JSON contains a duplicate key");
+        keys.add(key); whitespace();
+        if (source[offset] !== ":") throw new Error("JSON framing is invalid");
+        offset += 1; value(); whitespace();
+        if (source[offset] === "}") { offset += 1; return; }
+        if (source[offset] !== ",") throw new Error("JSON framing is invalid");
+        offset += 1; whitespace();
+      }
+    }
+    if (source[offset] === "[") {
+      offset += 1; whitespace();
+      if (source[offset] === "]") { offset += 1; return; }
+      for (;;) {
+        value(); whitespace();
+        if (source[offset] === "]") { offset += 1; return; }
+        if (source[offset] !== ",") throw new Error("JSON framing is invalid");
+        offset += 1;
+      }
+    }
+    if (source[offset] === '"') { string(); return; }
+    const start = offset;
+    while (offset < source.length && !/[\s,}\]]/u.test(source[offset])) offset += 1;
+    if (start === offset) throw new Error("JSON framing is invalid");
+    JSON.parse(source.slice(start, offset));
+  };
+  value(); whitespace();
+  if (offset !== source.length) throw new Error("JSON framing is invalid");
+}
+
+export function parseStrictJsonl(value) {
+  const lines = value.split(/\r?\n/u).filter((line) => line.trim().length > 0);
+  return lines.map((line) => {
+    rejectDuplicateJsonKeys(line);
+    return JSON.parse(line);
+  });
+}
+
+async function main() {
+  const expectedKeys = process.argv.slice(2).sort();
+  if (expectedKeys.length < 1 || new Set(expectedKeys).size !== expectedKeys.length) {
+    throw new Error("expected object keys are required");
+  }
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const source = new TextDecoder("utf-8", { fatal: true }).decode(Buffer.concat(chunks));
+  const records = parseStrictJsonl(source);
+  if (records.length !== 1 || !records[0] || typeof records[0] !== "object" ||
+      Array.isArray(records[0]) ||
+      Object.keys(records[0]).sort().join(",") !== expectedKeys.join(",")) {
+    throw new Error("exactly one strict JSON object is required");
+  }
+  process.stdout.write(`${JSON.stringify(records[0])}\n`);
+}
+
+let isMain = false;
+try {
+  isMain = Boolean(process.argv[1]) &&
+    realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+} catch {
+  isMain = false;
+}
+if (isMain) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/server/README.md
+++ b/server/README.md
@@ -63,6 +63,23 @@ not capture request or response bodies there. Then run:
 docker compose up --build
 ```
 
+Live-envelope retention is disabled by default. To bound each team's live
+payload rows while keeping permanent idempotency tombstones, set a canonical
+positive signed-BIGINT value before starting Compose:
+
+```sh
+export AGMSG_RETENTION_MAX_LIVE_MESSAGES=100000
+docker compose up --build
+```
+
+After a successful write, the reference server applies the configured floor in
+the same team transaction as sequence allocation and logs only the team ID, old
+and new floors, and removed row count. Tombstones and other protocol metadata
+remain durable, so this is not a hard bound on total database bytes. A window
+smaller than a device's offline interval—or small relative to an active write
+burst—causes `410 resync-required`; recovery requires the client's explicit
+operator-approved `remote-sync.sh resync --accept-floor` flow.
+
 `GET /v1/health` is available without credentials. The message, member, and
 capability endpoints require the credential returned by pairing plus these
 headers:

--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -19,9 +19,10 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://agmsg:agmsg-local-only@postgres:5432/agmsg
-      HOST: 0.0.0.0
-      PORT: 8787
+      - DATABASE_URL=postgresql://agmsg:agmsg-local-only@postgres:5432/agmsg
+      - HOST=0.0.0.0
+      - PORT=8787
+      - AGMSG_RETENTION_MAX_LIVE_MESSAGES
     ports:
       - "8787:8787"
 

--- a/server/spec/v1.md
+++ b/server/spec/v1.md
@@ -630,8 +630,17 @@ messages:
 
 The client MUST enter a terminal `resync-required` state, stop incremental
 sync, and surface operator action. It MUST NOT reset the cursor or discard local
-state automatically. V1 provides no full-snapshot operation; recovery is a
-manual or driver-specific operation outside this protocol.
+state automatically. V1 provides no full-snapshot operation. A client MAY offer
+the explicit, operator-approved retention-gap recovery defined by ADR 0009: it
+revalidates this 410 against a fresh authenticated capability snapshot, records
+the unavailable interval durably, and advances only its transport cursor to the
+exact authenticated floor. Normal polling MUST NOT invoke that operation.
+
+Such recovery acknowledges irreversible unavailability; it MUST NOT fabricate
+messages or durable outcomes for the missing interval, reset local-first
+messages, discard quarantine, or weaken decrypt/read state. A client that does
+not implement the optional operation remains terminal until its local binding
+is rebuilt by an operator-specific procedure.
 
 ### Pull state layers
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -208,7 +208,11 @@ export function createApp(pool: Pool, config: Config): FastifyInstance {
   app.post("/v1/messages", async (request) => {
     const teamId = await scopedTeamId(pool, request);
     const body = postMessagesSchema.parse(request.body);
-    return postMessages(pool, teamId, body.messages);
+    return postMessages(pool, teamId, body.messages,
+      config.retentionMaxLiveMessages, (notice) => {
+        app.log.info({ event: "retention.applied", ...notice },
+          "automatic live-message retention applied");
+      });
   });
 
   app.post("/v1/read-state/sync", async (request, reply) => {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -7,6 +7,11 @@ const environmentSchema = z.object({
   LOG_LEVEL: z
     .enum(["fatal", "error", "warn", "info", "debug", "trace", "silent"])
     .default("info"),
+  AGMSG_RETENTION_MAX_LIVE_MESSAGES: z.string()
+    .regex(/^[1-9][0-9]*$/u)
+    .refine((value) => BigInt(value) <= 9_223_372_036_854_775_807n,
+      "retention maximum exceeds signed BIGINT")
+    .optional(),
 });
 
 export type Config = {
@@ -14,6 +19,7 @@ export type Config = {
   host: string;
   port: number;
   logLevel: z.infer<typeof environmentSchema>["LOG_LEVEL"];
+  retentionMaxLiveMessages: bigint | null;
 };
 
 export function loadConfig(environment: NodeJS.ProcessEnv = process.env): Config {
@@ -23,5 +29,8 @@ export function loadConfig(environment: NodeJS.ProcessEnv = process.env): Config
     host: parsed.HOST,
     port: parsed.PORT,
     logLevel: parsed.LOG_LEVEL,
+    retentionMaxLiveMessages: parsed.AGMSG_RETENTION_MAX_LIVE_MESSAGES === undefined
+      ? null
+      : BigInt(parsed.AGMSG_RETENTION_MAX_LIVE_MESSAGES),
   };
 }

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -18,6 +18,10 @@ export function errorBody(error: ProtocolError): Record<string, unknown> {
       ? { server_instance_id: error.binding.serverInstanceId }
       : {}),
     ...(error.binding.teamId ? { team_id: error.binding.teamId } : {}),
+    ...(error.code === "resync-required" &&
+      typeof error.details.min_available_seq === "string"
+      ? { min_available_seq: error.details.min_available_seq }
+      : {}),
     error: {
       code: error.code,
       message: error.message,

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -104,8 +104,11 @@ export async function postMessages(
   pool: Pool,
   teamId: string,
   messages: MessageInput[],
+  retentionMaxLiveMessages: bigint | null = null,
+  retentionObserver?: (notice: RetentionNotice) => void,
 ): Promise<Record<string, unknown>> {
-  return inTransaction(pool, async (client) => {
+  let retentionNotice: RetentionNotice | undefined;
+  const response = await inTransaction(pool, async (client) => {
     const serverId = await serverInstanceId(client);
     const team = await teamRow(client, teamId, true);
     if (!team) throw notFound(serverId, teamId);
@@ -275,12 +278,26 @@ export async function postMessages(
       };
     });
 
+    let effectiveFloor = BigInt(team.min_available_seq);
+    if (retentionMaxLiveMessages !== null && next > retentionMaxLiveMessages) {
+      const target = next - retentionMaxLiveMessages;
+      if (target > effectiveFloor) {
+        retentionNotice = await retainThroughLocked(
+          client, teamId, effectiveFloor, target,
+        );
+        effectiveFloor = target;
+      }
+    }
+
     return {
-      ...common(serverId, { ...team, current_seq: next.toString() }),
+      ...common(serverId, { ...team, current_seq: next.toString(),
+        min_available_seq: effectiveFloor.toString() }),
       policy_revision: team.policy_revision,
       acks,
     };
   });
+  if (retentionNotice) retentionObserver?.(retentionNotice);
+  return response;
 }
 
 export async function syncReadState(
@@ -533,6 +550,53 @@ async function deleteCoveredExact(
   );
 }
 
+export type RetentionNotice = {
+  team_id: string;
+  old_floor: string;
+  new_floor: string;
+  removed_live_rows: number;
+};
+
+async function retainThroughLocked(
+  client: PoolClient,
+  teamId: string,
+  currentFloor: bigint,
+  through: bigint,
+): Promise<RetentionNotice> {
+  const tombstones = await client.query(
+    `INSERT INTO message_tombstones
+       (team_id, id, original_team_seq, envelope_digest)
+     SELECT team_id, id, team_seq, envelope_digest
+       FROM messages
+      WHERE team_id = $1 AND team_seq <= $2
+     RETURNING id`,
+    [teamId, through.toString()],
+  );
+  const deleted = await client.query(
+    "DELETE FROM messages WHERE team_id = $1 AND team_seq <= $2",
+    [teamId, through.toString()],
+  );
+  if (deleted.rowCount !== tombstones.rowCount) {
+    throw new Error("retention tombstone and deletion counts differ");
+  }
+  await client.query(
+    "UPDATE teams SET min_available_seq = $2 WHERE team_id = $1",
+    [teamId, through.toString()],
+  );
+  await client.query(
+    `UPDATE read_frontiers SET server_seq = GREATEST(server_seq, $2)
+      WHERE team_id = $1`,
+    [teamId, through.toString()],
+  );
+  await deleteCoveredExact(client, teamId, through);
+  return {
+    team_id: teamId,
+    old_floor: currentFloor.toString(),
+    new_floor: through.toString(),
+    removed_live_rows: deleted.rowCount ?? 0,
+  };
+}
+
 export async function retainThrough(
   pool: Pool,
   teamId: string,
@@ -558,36 +622,11 @@ export async function retainThrough(
       );
     }
 
-    const tombstones = await client.query(
-      `INSERT INTO message_tombstones
-         (team_id, id, original_team_seq, envelope_digest)
-       SELECT team_id, id, team_seq, envelope_digest
-         FROM messages
-        WHERE team_id = $1 AND team_seq <= $2
-       RETURNING id`,
-      [teamId, through.toString()],
-    );
-    const deleted = await client.query(
-      "DELETE FROM messages WHERE team_id = $1 AND team_seq <= $2",
-      [teamId, through.toString()],
-    );
-    if (deleted.rowCount !== tombstones.rowCount) {
-      throw new Error("retention tombstone and deletion counts differ");
-    }
-    await client.query(
-      "UPDATE teams SET min_available_seq = $2 WHERE team_id = $1",
-      [teamId, through.toString()],
-    );
-    await client.query(
-      `UPDATE read_frontiers SET server_seq = GREATEST(server_seq, $2)
-        WHERE team_id = $1`,
-      [teamId, through.toString()],
-    );
-    await deleteCoveredExact(client, teamId, through);
+    const notice = await retainThroughLocked(client, teamId, currentFloor, through);
     return {
       ...common(serverId, { ...team, min_available_seq: through.toString() }),
       retained_through: through.toString(),
-      tombstones_created: String(tombstones.rowCount ?? 0),
+      tombstones_created: String(notice.removed_live_rows),
     };
   });
 }

--- a/server/test/config.test.ts
+++ b/server/test/config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "../src/config.js";
+
+describe("reference server configuration", () => {
+  it("keeps automatic retention disabled when unset", () => {
+    expect(loadConfig({ DATABASE_URL: "postgresql://example/agmsg" })
+      .retentionMaxLiveMessages).toBeNull();
+  });
+
+  it("accepts only canonical positive signed-BIGINT retention limits", () => {
+    expect(loadConfig({ DATABASE_URL: "postgresql://example/agmsg",
+      AGMSG_RETENTION_MAX_LIVE_MESSAGES: "100000" })
+      .retentionMaxLiveMessages).toBe(100000n);
+    for (const value of ["", "0", "01", "-1", "1.0", "9223372036854775808"]) {
+      expect(() => loadConfig({ DATABASE_URL: "postgresql://example/agmsg",
+        AGMSG_RETENTION_MAX_LIVE_MESSAGES: value })).toThrow();
+    }
+  });
+});

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -14,7 +14,7 @@ import {
   issuePairingToken,
 } from "../src/credentials.js";
 import { migrate } from "../src/db.js";
-import { retainThrough } from "../src/storage.js";
+import { postMessages, retainThrough } from "../src/storage.js";
 
 const databaseUrl = process.env.TEST_DATABASE_URL;
 const describeDatabase = databaseUrl ? describe : describe.skip;
@@ -36,6 +36,7 @@ describeDatabase("remote storage HTTP API v1", () => {
     host: "127.0.0.1",
     port: 8787,
     logLevel: "silent",
+    retentionMaxLiveMessages: null,
   };
 
   let headers: Record<string, string>;
@@ -484,6 +485,7 @@ describeDatabase("remote storage HTTP API v1", () => {
     });
     expect(belowFloor.statusCode).toBe(410);
     expect(belowFloor.json().error.code).toBe("resync-required");
+    expect(belowFloor.json().min_available_seq).toBe("4");
 
     const replay = await app.inject({
       method: "POST",
@@ -537,6 +539,89 @@ describeDatabase("remote storage HTTP API v1", () => {
     });
     expect(outOfRange.statusCode).toBe(400);
     expect(outOfRange.json().error.code).toBe("invalid-request");
+  });
+
+  it("applies configured live-message retention in the writer transaction", async () => {
+    const automaticTeam = "018f3f7e-0000-7000-8000-000000000051";
+    await pool.query("INSERT INTO teams(team_id,team_name) VALUES($1,'automatic-retention')",
+      [automaticTeam]);
+    await pool.query(
+      `INSERT INTO team_policy_history
+         (team_id,policy_revision,effective_from_seq,
+          accepted_envelope_versions,write_allowed_ciphers)
+       VALUES($1,0,1,ARRAY[1],ARRAY['none','age-v1']::TEXT[])`,
+      [automaticTeam],
+    );
+    const notices: unknown[] = [];
+    const entries = [
+      message("750e8400-e29b-41d4-a716-446655440051", "retained-1"),
+      message("750e8400-e29b-41d4-a716-446655440052", "live-2"),
+      message("750e8400-e29b-41d4-a716-446655440053", "live-3"),
+    ];
+    const response = await postMessages(pool, automaticTeam, entries, 2n,
+      (notice) => notices.push(notice));
+    expect(response).toMatchObject({ min_available_seq: "1",
+      acks: [{ server_seq: "1" }, { server_seq: "2" }, { server_seq: "3" }] });
+    expect(notices).toEqual([{ team_id: automaticTeam, old_floor: "0",
+      new_floor: "1", removed_live_rows: 1 }]);
+    const stored = await pool.query<{ live: string; tombstones: string; floor: string }>(
+      `SELECT (SELECT count(*)::text FROM messages WHERE team_id=$1) AS live,
+              (SELECT count(*)::text FROM message_tombstones WHERE team_id=$1) AS tombstones,
+              (SELECT min_available_seq::text FROM teams WHERE team_id=$1) AS floor`,
+      [automaticTeam],
+    );
+    expect(stored.rows[0]).toEqual({ live: "2", tombstones: "1", floor: "1" });
+    const replay = await postMessages(pool, automaticTeam, [entries[0]!], 2n);
+    expect(replay.acks).toEqual([
+      { id: entries[0]!.id, server_seq: "1", disposition: "duplicate" },
+    ]);
+  });
+
+  it("rolls automatic retention back with the triggering message batch", async () => {
+    const rollbackTeam = "018f3f7e-0000-7000-8000-000000000052";
+    await pool.query("INSERT INTO teams(team_id,team_name) VALUES($1,'retention-rollback')",
+      [rollbackTeam]);
+    await pool.query(
+      `INSERT INTO team_policy_history
+         (team_id,policy_revision,effective_from_seq,
+          accepted_envelope_versions,write_allowed_ciphers)
+       VALUES($1,0,1,ARRAY[1],ARRAY['none','age-v1']::TEXT[])`,
+      [rollbackTeam],
+    );
+    await pool.query(
+      `CREATE FUNCTION fail_automatic_retention() RETURNS trigger AS $$
+       BEGIN
+         IF OLD.team_id = '${rollbackTeam}'::uuid THEN
+           RAISE EXCEPTION 'injected automatic retention failure';
+         END IF;
+         RETURN OLD;
+       END;
+       $$ LANGUAGE plpgsql`,
+    );
+    await pool.query(
+      `CREATE TRIGGER fail_automatic_retention BEFORE DELETE ON messages
+       FOR EACH ROW EXECUTE FUNCTION fail_automatic_retention()`,
+    );
+    const notices: unknown[] = [];
+    await expect(postMessages(pool, rollbackTeam, [
+      message("750e8400-e29b-41d4-a716-446655440061", "rollback-1"),
+      message("750e8400-e29b-41d4-a716-446655440062", "rollback-2"),
+    ], 1n, (notice) => notices.push(notice))).rejects.toThrow(
+      /injected automatic retention failure/,
+    );
+    expect(notices).toEqual([]);
+    const state = await pool.query<{
+      messages: string; tombstones: string; current: string; floor: string;
+    }>(
+      `SELECT (SELECT count(*)::text FROM messages WHERE team_id=$1) AS messages,
+              (SELECT count(*)::text FROM message_tombstones WHERE team_id=$1) AS tombstones,
+              current_seq::text AS current,min_available_seq::text AS floor
+         FROM teams WHERE team_id=$1`,
+      [rollbackTeam],
+    );
+    expect(state.rows[0]).toEqual({ messages: "0", tombstones: "0", current: "0", floor: "0" });
+    await pool.query("DROP TRIGGER fail_automatic_retention ON messages");
+    await pool.query("DROP FUNCTION fail_automatic_retention()");
   });
 
   it("atomically provisions the operator roster and permanently retires IDs", async () => {

--- a/server/test/sync-client.integration.test.ts
+++ b/server/test/sync-client.integration.test.ts
@@ -12,6 +12,7 @@ import type { Config } from "../src/config.js";
 import { exchangePairingToken, issuePairingToken } from "../src/credentials.js";
 import { migrate } from "../src/db.js";
 import { envelopeDigest } from "../src/protocol.js";
+import { retainThrough } from "../src/storage.js";
 
 const databaseUrl = process.env.TEST_DATABASE_URL;
 const describeDatabase = databaseUrl ? describe : describe.skip;
@@ -55,6 +56,7 @@ describeDatabase("Stage-1 polling sync client", () => {
     const config: Config = {
       databaseUrl: databaseUrl ?? "",
       host: "127.0.0.1", port: 8787, logLevel: "silent",
+      retentionMaxLiveMessages: null,
     };
     const issued = await issuePairingToken(pool, teamId);
     token = String((await exchangePairingToken(pool, issued.token)).credential);
@@ -211,5 +213,23 @@ storage_list_unread "$2" "$3"`;
     expect((await history(storeA)).map((message) => message.body)).toEqual([
       "fixture from machine A", "fixture reply from machine B",
     ]);
+
+    await retainThrough(pool, teamId, 3n);
+    await expect(sync(storeB, "once", "--team", localTeam)).rejects.toMatchObject({
+      stderr: expect.stringContaining("HTTP 410 resync-required"),
+    });
+    const beforeResync = await history(storeB);
+    const recovered = await sync(storeB, "resync", "--team", localTeam,
+      "--accept-floor", "3");
+    expect(recovered.stdout).toContain('"event":"resync.complete"');
+    expect(recovered.stdout).toContain('"disposition":"accepted"');
+    expect(await history(storeB)).toEqual(beforeResync);
+    const resyncState = await execFileAsync("sqlite3", [join(storeB, "messages.db"),
+      `SELECT transport_cursor || ':' ||
+         (SELECT count(*) FROM sync_resync_audits) FROM sync_bindings;`]);
+    expect(resyncState.stdout.trim()).toBe("3:1");
+    const retried = await sync(storeB, "resync", "--team", localTeam,
+      "--accept-floor", "3");
+    expect(retried.stdout).toContain('"disposition":"already-accepted"');
   }, 20_000);
 });

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -9,12 +9,15 @@ import {
   driver,
   isRetryable,
   plaintextWriteEligible,
+  parseStrictJsonl,
   readStateCycle,
   readStateUpdateBatches,
   request,
+  resyncCycle,
   retainAgeCheckpoint,
   selectWriteProfile,
   stage2ReadStateSupported,
+  stage1ResyncSupported,
   validateAckMapping,
   validateAgeConfiguration,
   validateConfiguredAgeIdentities,
@@ -22,6 +25,8 @@ import {
   validateErrorBinding,
   validateMembers,
   validateReadStatePage,
+  validateResyncResult,
+  validateResyncStatus,
 } from "../scripts/internal/remote-sync.mjs";
 
 const config = {
@@ -110,6 +115,103 @@ test("Stage-2 capability is optional and blocked members emit no mutation", () =
     type: "sync_read_blocked", member_id: member.member_id,
     reason: "read-state-limit-exceeded",
   }]), [[]]);
+});
+
+test("resync framing rejects duplicate keys and inconsistent audits", () => {
+  assert.throws(() => parseStrictJsonl(
+    '{"type":"sync_resync_status","type":"sync_resync_status"}\n'), /duplicate key/u);
+  assert.throws(() => parseStrictJsonl(
+    '{"type":"sync_resync_status","audit":{"gap_end":"5","gap_end":"6"}}\n'),
+  /duplicate key/u);
+  const generation = "018f3f7e-0000-7000-8000-000000000099";
+  const status = { type: "sync_resync_status", driver_generation: generation,
+    transport_cursor: "5", audit: { expected_transport_cursor: "0", accepted_floor: "5",
+      gap_start: "1", gap_end: "5", reason: "retention-gap-accepted" } };
+  assert.deepEqual(validateResyncStatus([status], "5"), status);
+  assert.throws(() => validateResyncStatus([{ ...status,
+    audit: { ...status.audit, gap_start: "2" } }], "5"), /inconsistent/u);
+  assert.throws(() => validateResyncStatus([{ ...status, extra: true }], "5"), /shape/u);
+  const result = { type: "sync_resync_result", driver_generation: generation,
+    expected_transport_cursor: "0", transport_cursor: "5", accepted_floor: "5",
+    gap_start: "1", gap_end: "5", reason: "retention-gap-accepted" };
+  assert.deepEqual(validateResyncResult([result], status, "5"), result);
+});
+
+test("resync requires an authenticated 410 before atomically accepting a gap", async () => {
+  const generation = "018f3f7e-0000-7000-8000-000000000099";
+  const operations = [];
+  const capabilities = {
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, team_name: "demo", min_available_seq: "5",
+    current_seq: "7", next_sequence_boundary: "8", accepted_envelope_versions: [1],
+    write_allowed_ciphers: ["none"], policy_revision: "0", effective_from_seq: "1",
+    max_blob_bytes: "1048576", policy_history: [{ policy_revision: "0",
+      effective_from_seq: "1", accepted_envelope_versions: [1], write_allowed_ciphers: ["none"] }],
+  };
+  const result = await resyncCycle(config, "5", {
+    driverCall: async (operation, _config, input, extra) => {
+      operations.push(operation);
+      if (operation === "capabilities") return [{ type: "sync_driver_capabilities",
+        capabilities: ["stage1-sync", "stage1-resync"] }];
+      if (operation === "resync-status") {
+        assert.deepEqual(extra, ["5"]);
+        return [{ type: "sync_resync_status", driver_generation: generation,
+          transport_cursor: "0", audit: null }];
+      }
+      assert.equal(operation, "resync");
+      assert.deepEqual(input, [{ type: "sync_resync", expected_transport_cursor: "0",
+        min_available_seq: "5", current_seq: "7", reason: "retention-gap-accepted" }]);
+      return [{ type: "sync_resync_result", driver_generation: generation,
+        expected_transport_cursor: "0", transport_cursor: "5", accepted_floor: "5",
+        gap_start: "1", gap_end: "5", reason: "retention-gap-accepted" }];
+    },
+    requestCall: async (_config, path) => {
+      if (path === "/v1/capabilities") return capabilities;
+      const error = new Error("retained");
+      error.status = 410; error.code = "resync-required";
+      error.body = { protocol_version: 1, server_instance_id: config.server_instance_id,
+        team_id: config.remote_team_id, min_available_seq: "5",
+        error: { code: "resync-required", details: { after: "0", min_available_seq: "5" } } };
+      throw error;
+    },
+    eventCall: async () => {},
+  });
+  assert.equal(result.transport_cursor, "5");
+  assert.deepEqual(operations, ["capabilities", "resync-status", "resync"]);
+});
+
+test("resync output-loss retry returns the immutable audit without replaying 410", async () => {
+  const generation = "018f3f7e-0000-7000-8000-000000000099";
+  let messageRequest = false;
+  const result = await resyncCycle(config, "5", {
+    driverCall: async (operation) => {
+      if (operation === "capabilities") return [{ type: "sync_driver_capabilities",
+        capabilities: ["stage1-sync", "stage1-resync"] }];
+      assert.equal(operation, "resync-status");
+      return [{ type: "sync_resync_status", driver_generation: generation,
+        transport_cursor: "5", audit: { expected_transport_cursor: "0", accepted_floor: "5",
+          gap_start: "1", gap_end: "5", reason: "retention-gap-accepted" } }];
+    },
+    requestCall: async (_config, path) => {
+      if (path !== "/v1/capabilities") messageRequest = true;
+      return { protocol_version: 1, server_instance_id: config.server_instance_id,
+        team_id: config.remote_team_id, team_name: "demo", min_available_seq: "5",
+        current_seq: "7", next_sequence_boundary: "8", accepted_envelope_versions: [1],
+        write_allowed_ciphers: ["none"], policy_revision: "0", effective_from_seq: "1",
+        max_blob_bytes: "1048576", policy_history: [{ policy_revision: "0",
+          effective_from_seq: "1", accepted_envelope_versions: [1], write_allowed_ciphers: ["none"] }] };
+    },
+    eventCall: async () => {},
+  });
+  assert.equal(messageRequest, false);
+  assert.deepEqual(result, { type: "sync_resync_result", driver_generation: generation,
+    expected_transport_cursor: "0", transport_cursor: "5", accepted_floor: "5",
+    gap_start: "1", gap_end: "5", reason: "retention-gap-accepted" });
+});
+
+test("resync remains optional for Stage-1 drivers", () => {
+  assert.equal(stage1ResyncSupported([{ type: "sync_driver_capabilities",
+    capabilities: ["stage1-sync"] }]), false);
 });
 
 test("Stage-1-only driver skips the optional Stage-2 network path", async () => {

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -213,6 +213,54 @@ prepare_push() {
   [ "$(agmsg_sqlite "$db" "SELECT status FROM sync_quarantine WHERE wire_id='550e8400-e29b-41d4-a716-446655440020';" | tr -d '\r')" = imported ]
 }
 
+@test "sync contract: retention resync records one immutable gap and preserves local state" {
+  storage_send demo alice bob "local survives retention" >/dev/null
+  local prepared status input result repeated db wire
+  prepared=$(prepare_push)
+  wire=$(printf '%s\n' "$prepared" | jq -r 'select(.type=="sync_push_candidate")|.id')
+  status=$(storage_sync_resync_status demo "$SERVER_ID" "$TEAM_ID" 1 5)
+  printf '%s\n' "$status" | jq -e '
+    keys==["audit","driver_generation","transport_cursor","type"]
+    and .type=="sync_resync_status" and .transport_cursor=="0" and .audit==null' >/dev/null
+
+  input='{"type":"sync_resync","expected_transport_cursor":"0","min_available_seq":"5","current_seq":"7","reason":"retention-gap-accepted"}'
+  result=$(printf '%s\n' "$input" |
+    storage_sync_resync demo "$SERVER_ID" "$TEAM_ID" 1)
+  printf '%s\n' "$result" | jq -e '
+    keys==["accepted_floor","driver_generation","expected_transport_cursor","gap_end","gap_start","reason","transport_cursor","type"]
+    and .type=="sync_resync_result" and .expected_transport_cursor=="0"
+    and .transport_cursor=="5" and .accepted_floor=="5"
+    and .gap_start=="1" and .gap_end=="5"
+    and .reason=="retention-gap-accepted"' >/dev/null
+
+  status=$(storage_sync_resync_status demo "$SERVER_ID" "$TEAM_ID" 1 5)
+  printf '%s\n' "$status" | jq -e '
+    .transport_cursor=="5" and .audit=={
+      expected_transport_cursor:"0",accepted_floor:"5",gap_start:"1",gap_end:"5",
+      reason:"retention-gap-accepted"}' >/dev/null
+  db=$(agmsg_db_path)
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_resync_audits;" | tr -d '\r')" -eq 1 ]
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events WHERE body='local survives retention';" | tr -d '\r')" -eq 1 ]
+  [ "$(agmsg_sqlite "$db" "SELECT wire_id FROM sync_messages WHERE direction='push';" | tr -d '\r')" = "$wire" ]
+
+  run storage_sync_resync demo "$SERVER_ID" "$TEAM_ID" 1 <<< "$input"
+  [ "$status" -ne 0 ]
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_resync_audits;" | tr -d '\r')" -eq 1 ]
+}
+
+@test "sync contract: resync status is read-only and absent bindings fail closed" {
+  local before after other
+  prepare_push >/dev/null
+  before=$(agmsg_sqlite "$(agmsg_db_path)" "SELECT total_changes();" | tr -d '\r')
+  storage_sync_resync_status demo "$SERVER_ID" "$TEAM_ID" 1 10 >/dev/null
+  after=$(agmsg_sqlite "$(agmsg_db_path)" "SELECT total_changes();" | tr -d '\r')
+  [ "$before" = "$after" ]
+  other=018f3f7e-0000-7000-8000-000000000002
+  run storage_sync_resync_status demo "$SERVER_ID" "$other" 1 10
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
 @test "Stage-2 sync exports exact reads across holes and applies remote frontier separately" {
   local first second page ids second_local context prepared applied db
   first=$(jq -nc '

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -274,6 +274,20 @@ prepare_push() {
   [ "$(agmsg_sqlite "$db" "SELECT transport_cursor FROM sync_bindings;" | tr -d '\r')" = 0 ]
 }
 
+@test "sync contract: resync uses the resolved Node runtime when literal node is unavailable" {
+  prepare_push >/dev/null
+  local resolved_node input result
+  resolved_node=$(command -v node)
+  [ -x "$resolved_node" ]
+  input='{"type":"sync_resync","expected_transport_cursor":"0","min_available_seq":"5","current_seq":"7","reason":"retention-gap-accepted"}'
+  node() { return 127; }
+  export AGMSG_SYNC_NODE_BIN="$resolved_node"
+  unset AGMSG_NODE
+  result=$(storage_sync_resync demo "$SERVER_ID" "$TEAM_ID" 1 <<< "$input")
+  unset -f node
+  [ "$(printf '%s\n' "$result" | jq -r '.transport_cursor')" = 5 ]
+}
+
 @test "Stage-2 sync exports exact reads across holes and applies remote frontier separately" {
   local first second page ids second_local context prepared applied db
   first=$(jq -nc '

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -224,8 +224,7 @@ prepare_push() {
     and .type=="sync_resync_status" and .transport_cursor=="0" and .audit==null' >/dev/null
 
   input='{"type":"sync_resync","expected_transport_cursor":"0","min_available_seq":"5","current_seq":"7","reason":"retention-gap-accepted"}'
-  result=$(printf '%s\n' "$input" |
-    storage_sync_resync demo "$SERVER_ID" "$TEAM_ID" 1)
+  result=$(storage_sync_resync demo "$SERVER_ID" "$TEAM_ID" 1 <<< "$input")
   printf '%s\n' "$result" | jq -e '
     keys==["accepted_floor","driver_generation","expected_transport_cursor","gap_end","gap_start","reason","transport_cursor","type"]
     and .type=="sync_resync_result" and .expected_transport_cursor=="0"
@@ -259,6 +258,20 @@ prepare_push() {
   run storage_sync_resync_status demo "$SERVER_ID" "$other" 1 10
   [ "$status" -ne 0 ]
   [ -z "$output" ]
+}
+
+@test "sync contract: resync input rejects duplicate keys and later records" {
+  prepare_push >/dev/null
+  local duplicate multiple db
+  duplicate='{"type":"sync_resync","expected_transport_cursor":"0","min_available_seq":"4","min_available_seq":"5","current_seq":"7","reason":"retention-gap-accepted"}'
+  run storage_sync_resync demo "$SERVER_ID" "$TEAM_ID" 1 <<< "$duplicate"
+  [ "$status" -ne 0 ]
+  multiple=$'{"type":"sync_resync","expected_transport_cursor":"0","min_available_seq":"5","current_seq":"7","reason":"retention-gap-accepted"}\n\n{"type":"sync_resync","expected_transport_cursor":"0","min_available_seq":"6","current_seq":"7","reason":"retention-gap-accepted"}'
+  run storage_sync_resync demo "$SERVER_ID" "$TEAM_ID" 1 <<< "$multiple"
+  [ "$status" -ne 0 ]
+  db=$(agmsg_db_path)
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_resync_audits;" | tr -d '\r')" -eq 0 ]
+  [ "$(agmsg_sqlite "$db" "SELECT transport_cursor FROM sync_bindings;" | tr -d '\r')" = 0 ]
 }
 
 @test "Stage-2 sync exports exact reads across holes and applies remote frontier separately" {


### PR DESCRIPTION
## Summary

- define explicit operator-approved recovery after HTTP 410
- add strict read-only status plus atomic SQLite gap audit/cursor advancement
- preserve local messages, quarantine, read state, and age trust
- add optional automatic live-message retention to the reference server

## Validation

- Node remote sync engine: 21/21
- SQLite Stage-1/2 Bats: 14/14
- reference server with PostgreSQL 17: 17/17
- server typecheck and build
- Compose configuration validation

## Status

Draft/unmerged dogfood work stacked on #464. Merge remains a separate koit gate.