### PR TITLE
fix(spawn): add -g to macOS Terminal/iTerm launch so it doesn't steal focus

### DIFF
--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -528,10 +528,15 @@ launch_in_tmux() {
 launch_macos_terminal() {
   # `open -a` is a launch, not an AppleEvent, so it does not trip the
   # Automation (TCC) consent prompts that `osascript ... do script` does.
+  # `-g`/`--background` keeps the newly opened terminal from stealing focus.
+  # This path is taken whenever $TMUX is unset -- notably when the spawning
+  # process itself has no tmux context (e.g. a GUI app, or any non-terminal
+  # caller), where a foreground terminal popup interrupts whatever the user
+  # is currently doing in the foreground app.
   local app="${1:-Terminal}"
   case "$app" in
-    iterm|iterm2|iTerm|iTerm2) open -a iTerm "$BOOT" ;;
-    *)                         open -a Terminal "$BOOT" ;;
+    iterm|iterm2|iTerm|iTerm2) open -g -a iTerm "$BOOT" ;;
+    *)                         open -g -a Terminal "$BOOT" ;;
   esac
 }
 

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -736,6 +736,44 @@ YAML
   fi
 }
 
+@test "spawn: macOS terminal launch does not steal focus (Terminal and iTerm)" {
+  # A no-op-Terminal spawn (no $TMUX, no AGMSG_TERMINAL override) exercises
+  # launch_macos_terminal() itself, which every other test in this file
+  # bypasses via the record.sh {cmd} template. `-g`/`--background` must be
+  # present so `open` never brings the newly launched terminal to the front
+  # -- without it, spawning from a caller with no tmux context (e.g. a GUI
+  # app) interrupts whatever the user is doing in the foreground app.
+  if [ "$(uname -s)" != "Darwin" ]; then
+    skip "launch_macos_terminal() is Darwin-only"
+  fi
+  unset AGMSG_TERMINAL
+  # Deterministic regardless of which terminal actually runs this test suite
+  # (launch_macos_terminal defaults to "iterm" when $TERM_PROGRAM is
+  # iTerm.app, which would otherwise make this assertion flaky on an iTerm
+  # dev machine).
+  unset TERM_PROGRAM
+  cat > "$STUB_BIN/open" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$CAPTURE"
+EOF
+  chmod +x "$STUB_BIN/open"
+
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  run cat "$CAPTURE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-g -a Terminal"* ]]
+
+  rm -f "$CAPTURE"
+  bash "$SCRIPTS/join.sh" myteam existing codex "$PROJ"
+  AGMSG_TERMINAL=iterm run bash "$SCRIPTS/spawn.sh" codex bob --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  run cat "$CAPTURE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-g -a iTerm"* ]]
+}
+
 # --- pre-flight exclusivity check ---
 
 @test "spawn: refuses when the name is held by another live session" {


### PR DESCRIPTION
Fixes #469

## Summary

`launch_macos_terminal()` used a plain `open -a Terminal "$BOOT"` / `open -a iTerm "$BOOT"`, which activates the launched app and steals keyboard focus from whatever the caller was doing. This path runs whenever `$TMUX` is unset at spawn time -- notably when the spawning process itself has no tmux context (e.g. a GUI app), where a foreground terminal popup interrupts the user mid-interaction.

`-g`/`--background` keeps the window opening without bringing it to the front; spawn's behavior (boot script execution, readiness handling) is otherwise unaffected.

## Test plan

- `bash -n scripts/spawn.sh` clean.
- New regression test: the existing suite bypasses `launch_macos_terminal()` entirely via the `AGMSG_TERMINAL={cmd}` stub template used in every other test, so there was no coverage of the real `open` invocation before this. The new test stubs `open` directly (unsetting `AGMSG_TERMINAL` and `TERM_PROGRAM` for determinism across dev machines) and asserts `-g` appears in both the Terminal.app and iTerm code paths. Passes locally (`bats --filter "macOS terminal launch does not steal focus" tests/test_spawn.bats`).
- Full `tests/test_spawn.bats` run in progress locally to confirm no regressions; will report back / update if anything surfaces.
- Verified empirically outside the test suite too: with `$TMUX` unset, `open -g -a Terminal` leaves the previously-frontmost app (checked via `osascript`) unchanged before and after the spawn call, and the resulting agent CLI still comes up normally.