### PR TITLE
fix: interoperate with bounded age GREASE stanzas

### DIFF
--- a/docs/spec/age-v1-profile.md
+++ b/docs/spec/age-v1-profile.md
@@ -67,8 +67,12 @@ An `age-v1` envelope has:
 - A GREASE stanza tag MUST match `[!-~]{1,8}-grease`. It has zero to four
   arguments, each 1–8 bytes of ASCII VCHAR (`0x21`–`0x7e`), and a 0–100-byte
   body in age's canonical unpadded-base64 wrapping. These are the bounds emitted
-  by `age_core::format::grease_the_joint` in Rust `age` 0.12.1. A stanza outside
-  that grammar is not treated as GREASE and is rejected.
+  by `age_core::format::grease_the_joint` in Rust `age` 0.12.1. Active age
+  namespaces take precedence over that suffix grammar: `scrypt`, `ssh-rsa`,
+  `ssh-ed25519`, and every `plugin-` tag are always rejected. Consequently, the
+  profile accepts a bounded safe subset of Rust-generated GREASE; a random tag
+  that collides with an active namespace is rejected. A stanza outside this
+  safe grammar is not treated as GREASE and is rejected.
 - A header may contain at most 256 X25519 stanzas, 512 total stanzas, and 65536
   bytes through the terminating header MAC line. Each header line remains
   limited to 4096 bytes. A reader MUST reject the file before decryption when

--- a/docs/spec/age-v1-profile.md
+++ b/docs/spec/age-v1-profile.md
@@ -57,11 +57,18 @@ An `age-v1` envelope has:
   compression, and profile-level padding are forbidden.
 - The age header MUST contain one or more native X25519 recipient stanzas.
   Writers MUST use the epoch's X25519 manifest as their only real recipient
-  set. Readers MUST ignore non-X25519 stanza types for age-format extension and
-  GREASE interoperability; ignored stanzas do not satisfy or weaken the X25519
-  manifest check and MUST NOT trigger plugin, passphrase, SSH, or trial-decrypt
-  dispatch. This follows age's unknown-stanza rule while keeping native X25519
-  identities as the only decryption mechanism in this profile.
+  set. Readers MUST ignore only age GREASE stanzas whose tag and arguments
+  match the bounded grammar below. GREASE stanzas do not satisfy or weaken the
+  X25519 manifest check and MUST NOT trigger plugin, passphrase, SSH, or
+  trial-decrypt dispatch. Scrypt, SSH, plugin, and every other non-X25519 stanza
+  type are rejected before invoking the age decryptor. Here, "ignore" means
+  exclude the stanza from decryption dispatch while retaining its authenticated
+  bytes in the complete age header; it does not mean deleting bytes.
+- A GREASE stanza tag MUST match `[!-~]{1,8}-grease`. It has zero to four
+  arguments, each 1–8 bytes of ASCII VCHAR (`0x21`–`0x7e`), and a 0–100-byte
+  body in age's canonical unpadded-base64 wrapping. These are the bounds emitted
+  by `age_core::format::grease_the_joint` in Rust `age` 0.12.1. A stanza outside
+  that grammar is not treated as GREASE and is rejected.
 - A header may contain at most 256 X25519 stanzas, 512 total stanzas, and 65536
   bytes through the terminating header MAC line. Each header line remains
   limited to 4096 bytes. A reader MUST reject the file before decryption when

--- a/docs/spec/age-v1-profile.md
+++ b/docs/spec/age-v1-profile.md
@@ -55,9 +55,18 @@ An `age-v1` envelope has:
 - `blob` MUST be canonical padded RFC 4648 base64 of one complete, unarmored,
   binary age v1 file. ASCII armor, concatenated age files, trailing bytes,
   compression, and profile-level padding are forbidden.
-- The age header MUST contain one or more native X25519 recipient stanzas and
-  no other recipient stanza type. Scrypt/passphrase recipients, plugins, SSH
-  recipients, and hybrid stanza sets are not part of `age-v1`.
+- The age header MUST contain one or more native X25519 recipient stanzas.
+  Writers MUST use the epoch's X25519 manifest as their only real recipient
+  set. Readers MUST ignore non-X25519 stanza types for age-format extension and
+  GREASE interoperability; ignored stanzas do not satisfy or weaken the X25519
+  manifest check and MUST NOT trigger plugin, passphrase, SSH, or trial-decrypt
+  dispatch. This follows age's unknown-stanza rule while keeping native X25519
+  identities as the only decryption mechanism in this profile.
+- A header may contain at most 256 X25519 stanzas, 512 total stanzas, and 65536
+  bytes through the terminating header MAC line. Each header line remains
+  limited to 4096 bytes. A reader MUST reject the file before decryption when
+  any bound is exceeded, when a stanza has no body, or when the header framing
+  is malformed.
 
 The decoded age file must fit the smaller of the HTTP protocol blob limit and
 the authenticated `max_blob_bytes` capability. The server validates only the
@@ -72,9 +81,10 @@ recipient-set manifest MUST bind the remote `server_instance_id`, `team_id`,
 `key_id`, recipient list, and profile identifier and MUST be distributed over
 an authenticated out-of-band channel. The server never receives private
 identities. A writer MUST encrypt each new envelope to every recipient in the
-selected immutable manifest and to no recipient outside it. The manifest MUST
-contain 1–256 distinct recipients; the age header contains exactly one X25519
-stanza for each. Age intentionally hides recipient identity, so a recipient
+selected immutable manifest and to no real recipient outside it. The manifest
+MUST contain 1–256 distinct recipients; the age header contains exactly one
+X25519 stanza for each, in addition to any ignored extension/GREASE stanzas.
+Age intentionally hides recipient identity, so a recipient
 cannot prove from a ciphertext that the writer included the complete manifest
 or excluded an outsider. This is a writer-side obligation. A malicious writer
 already holds plaintext and is outside the confidentiality boundary; conforming
@@ -387,6 +397,11 @@ byte-for-byte, `envelope_override` mutates trusted outer metadata,
 generating age implementation, SHA-256 of every decoded age file and decrypted
 frame, and exact expected states. The accompanying verifier independently
 checks that provenance and every attack.
+
+[`vectors/age-v1-rust-grease.json`](vectors/age-v1-rust-grease.json) is the
+cross-implementation fixture produced by the Rust `age` crate 0.12.1. It pins a
+valid header containing one X25519 stanza and one GREASE stanza and MUST decrypt
+to the same canonical frame as the primary vector.
 
 Regenerate the randomized ciphertext fixtures with
 [`generate-age-v1-vectors.mjs`](vectors/generate-age-v1-vectors.mjs) and verify

--- a/docs/spec/vectors/age-v1-rust-grease.json
+++ b/docs/spec/vectors/age-v1-rust-grease.json
@@ -1,0 +1,17 @@
+{
+  "profile": "age-v1",
+  "fixture": "rust-age-0.12.1-grease",
+  "producer": "age crate 0.12.1",
+  "binding_from": "age-v1-vectors.json",
+  "recipient_set": "team_a",
+  "x25519_stanza_count": 1,
+  "total_stanza_count": 2,
+  "age_file_sha256": "f5dcf8829c201570ccf855d106ebc52e7339d3250285acd84022a9ffcb6d4603",
+  "decrypted_frame_sha256": "6c12c093ea0471a1c19cd8eb0475723411a72ca848b128289c5d19458487aae9",
+  "envelope": {
+    "v": 1,
+    "cipher": "age-v1",
+    "key_id": "epoch-1",
+    "blob": "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHaVRZNmN6ZFpyOW1HRTlBWC9nRHNnNUc1SXhNUzRmTzFqcXNzdkVmNEVBCmplMVZSOTJJZ0lTS1cyY1d4ZlFJWTVuWUdSN1VHTGlSUU45cDVzckFBdW8KLT4gbj8yaC1ncmVhc2Ugcih2MzggKyBFX1xwegowTGNBUmJBQ1FqOXA2T1VvaFhZUlpEMW1VeFlubzNYN00rYkpvMjZranFvKzZueURiQkF5Ci0tLSB2c1dwZzlXVFhXY2o2OFBkNm05NVZqdm5tMWtrbzdDT3oxdFE3UTdrcUI4CpjSSqhQTD8GyXDn7XdVYpRzq1XVHiFLLnU8o1hN4l8nicrxBt0TtNge3xCa5It9VWaOltXIaHuDIXg6gLJuRRdtE7SgUeME7lL/DUdqcjPotfXmbdaoevikj7QGm/jKWCVGPMIyGjZYIjAm6F4gp5km71Ge1Z9ozgJz1wcHXO23oZX4b/U5h0U85QWSPmfC4t/NQPVYBFVJFKwQppCS2LfCifb+pwHxUk6rT8KF6KCZ2nWX58SyedF0VNJNIJ4pGodcpdEPDJiABS4KLXMy7tvKrM4aX0SbM9kaDPL8slJbmQ=="
+  }
+}

--- a/scripts/internal/sync-cipher.mjs
+++ b/scripts/internal/sync-cipher.mjs
@@ -157,16 +157,23 @@ export function agePlaintextFrame(binding, projection) {
   return Buffer.concat([MAGIC, u32(context.length), context, u32(message.length), message]);
 }
 
-function validateAgeHeader(ageFile) {
+const MAX_AGE_HEADER_BYTES = 65_536;
+const MAX_AGE_STANZAS = 512;
+const MAX_AGE_X25519_STANZAS = 256;
+
+export function validateAgeHeader(ageFile) {
   let offset = 0;
-  let stanzaCount = 0;
+  let totalStanzaCount = 0;
+  let x25519StanzaCount = 0;
   let insideStanza = false;
+  let stanzaHasBody = false;
   function line() {
     const end = ageFile.indexOf(0x0a, offset);
     if (end === -1 || end - offset > 4096) malformed("age header is incomplete");
     const value = ageFile.subarray(offset, end).toString("ascii");
     if (!/^[\x20-\x7e]+$/u.test(value)) malformed("age header is not canonical ASCII");
     offset = end + 1;
+    if (offset > MAX_AGE_HEADER_BYTES) malformed("age header size limit exceeded");
     return value;
   }
   if (line() !== "age-encryption.org/v1") malformed("blob is not an age v1 file");
@@ -174,19 +181,31 @@ function validateAgeHeader(ageFile) {
     const value = line();
     if (value.startsWith("-> ")) {
       const fields = value.split(" ");
-      if (fields.length !== 3 || fields[1] !== "X25519" || fields[2].length < 1) {
-        malformed("age-v1 permits only native X25519 recipient stanzas");
+      if ((insideStanza && !stanzaHasBody) || fields.length < 3 ||
+          fields.some((field) => field.length < 1)) {
+        malformed("age recipient stanza header is invalid");
       }
-      stanzaCount += 1;
-      if (stanzaCount > 256) malformed("age-v1 recipient stanza limit exceeded");
+      totalStanzaCount += 1;
+      if (totalStanzaCount > MAX_AGE_STANZAS) malformed("age total stanza limit exceeded");
+      if (fields[1] === "X25519") {
+        if (fields.length !== 3) malformed("age X25519 stanza header is invalid");
+        x25519StanzaCount += 1;
+        if (x25519StanzaCount > MAX_AGE_X25519_STANZAS) {
+          malformed("age-v1 X25519 stanza limit exceeded");
+        }
+      }
       insideStanza = true;
+      stanzaHasBody = false;
     } else if (value.startsWith("--- ")) {
-      if (!insideStanza || stanzaCount < 1 || value.split(" ").length !== 2 || offset >= ageFile.length) {
+      if (!insideStanza || !stanzaHasBody || x25519StanzaCount < 1 ||
+          value.split(" ").length !== 2 || offset >= ageFile.length) {
         malformed("age header footer is invalid");
       }
-      return stanzaCount;
+      return { totalStanzaCount, x25519StanzaCount };
     } else if (!insideStanza || !/^[A-Za-z0-9+/]+={0,2}$/u.test(value)) {
       malformed("age recipient stanza body is invalid");
+    } else {
+      stanzaHasBody = true;
     }
   }
   malformed("age header footer is missing");
@@ -346,7 +365,7 @@ function sealAge(input) {
   if (result.stdout.length > input.max_blob_bytes || result.stdout.length > MAX_BLOB_BYTES) {
     malformed("encrypted age file exceeds max_blob_bytes");
   }
-  if (validateAgeHeader(result.stdout) !== input.recipients.length) {
+  if (validateAgeHeader(result.stdout).x25519StanzaCount !== input.recipients.length) {
     malformed("age recipient stanza count differs from the manifest");
   }
   return { v: 1, cipher: "age-v1", key_id: input.key_id, blob: result.stdout.toString("base64") };
@@ -394,7 +413,7 @@ async function openAge({ envelope, protocol_version: protocolVersion, team_id: t
     authenticationFailed("age identity does not match the expected recipient manifest");
   }
   const ageFile = canonicalBlob(envelope.blob, maxBlobBytes);
-  if (validateAgeHeader(ageFile) !== expectedRecipients.length) {
+  if (validateAgeHeader(ageFile).x25519StanzaCount !== expectedRecipients.length) {
     authenticationFailed("age recipient stanza count differs from the manifest");
   }
   const result = runAgeWithIdentity(ageFile, identity.bytes);

--- a/scripts/internal/sync-cipher.mjs
+++ b/scripts/internal/sync-cipher.mjs
@@ -169,7 +169,18 @@ export function validateAgeHeader(ageFile) {
   let stanzaHasBody = false;
   let stanzaIsGrease = false;
   let stanzaBodyBytes = 0;
+  let greaseBodyBase64 = "";
   let greaseShortBodySeen = false;
+  function finishStanza() {
+    if (!insideStanza || !stanzaHasBody) malformed("age recipient stanza header is invalid");
+    if (stanzaIsGrease) {
+      const canonical = Buffer.from(greaseBodyBase64, "base64")
+        .toString("base64").replace(/=+$/u, "");
+      if (canonical !== greaseBodyBase64) {
+        malformed("age GREASE stanza body is not canonical base64");
+      }
+    }
+  }
   function line() {
     const end = ageFile.indexOf(0x0a, offset);
     if (end === -1 || end - offset > 4096) malformed("age header is incomplete");
@@ -184,8 +195,8 @@ export function validateAgeHeader(ageFile) {
     const value = line();
     if (value.startsWith("-> ")) {
       const fields = value.split(" ");
-      if ((insideStanza && !stanzaHasBody) || fields.length < 2 ||
-          fields.some((field) => field.length < 1)) {
+      if (insideStanza) finishStanza();
+      if (fields.length < 2 || fields.some((field) => field.length < 1)) {
         malformed("age recipient stanza header is invalid");
       }
       totalStanzaCount += 1;
@@ -198,17 +209,20 @@ export function validateAgeHeader(ageFile) {
         }
         stanzaIsGrease = false;
       } else {
-        stanzaIsGrease = /^[!-~]{1,8}-grease$/u.test(fields[1]) &&
+        const activeType = fields[1] === "scrypt" || fields[1] === "ssh-rsa" ||
+          fields[1] === "ssh-ed25519" || fields[1].startsWith("plugin-");
+        stanzaIsGrease = !activeType && /^[!-~]{1,8}-grease$/u.test(fields[1]) &&
           fields.length <= 6 && fields.slice(2).every((field) => /^[!-~]{1,8}$/u.test(field));
         if (!stanzaIsGrease) malformed("age-v1 rejects active non-X25519 recipient stanzas");
       }
       insideStanza = true;
       stanzaHasBody = false;
       stanzaBodyBytes = 0;
+      greaseBodyBase64 = "";
       greaseShortBodySeen = false;
     } else if (value.startsWith("--- ")) {
-      if (!insideStanza || !stanzaHasBody || x25519StanzaCount < 1 ||
-          value.split(" ").length !== 2 || offset >= ageFile.length) {
+      finishStanza();
+      if (x25519StanzaCount < 1 || value.split(" ").length !== 2 || offset >= ageFile.length) {
         malformed("age header footer is invalid");
       }
       return { totalStanzaCount, x25519StanzaCount };
@@ -223,6 +237,7 @@ export function validateAgeHeader(ageFile) {
         }
         stanzaBodyBytes += Math.floor(value.length * 3 / 4);
         if (stanzaBodyBytes > 100) malformed("age GREASE stanza body limit exceeded");
+        greaseBodyBase64 += value;
         greaseShortBodySeen = value.length < 64;
       }
     }

--- a/scripts/internal/sync-cipher.mjs
+++ b/scripts/internal/sync-cipher.mjs
@@ -167,11 +167,14 @@ export function validateAgeHeader(ageFile) {
   let x25519StanzaCount = 0;
   let insideStanza = false;
   let stanzaHasBody = false;
+  let stanzaIsGrease = false;
+  let stanzaBodyBytes = 0;
+  let greaseShortBodySeen = false;
   function line() {
     const end = ageFile.indexOf(0x0a, offset);
     if (end === -1 || end - offset > 4096) malformed("age header is incomplete");
     const value = ageFile.subarray(offset, end).toString("ascii");
-    if (!/^[\x20-\x7e]+$/u.test(value)) malformed("age header is not canonical ASCII");
+    if (!/^[\x20-\x7e]*$/u.test(value)) malformed("age header is not canonical ASCII");
     offset = end + 1;
     if (offset > MAX_AGE_HEADER_BYTES) malformed("age header size limit exceeded");
     return value;
@@ -181,7 +184,7 @@ export function validateAgeHeader(ageFile) {
     const value = line();
     if (value.startsWith("-> ")) {
       const fields = value.split(" ");
-      if ((insideStanza && !stanzaHasBody) || fields.length < 3 ||
+      if ((insideStanza && !stanzaHasBody) || fields.length < 2 ||
           fields.some((field) => field.length < 1)) {
         malformed("age recipient stanza header is invalid");
       }
@@ -193,19 +196,35 @@ export function validateAgeHeader(ageFile) {
         if (x25519StanzaCount > MAX_AGE_X25519_STANZAS) {
           malformed("age-v1 X25519 stanza limit exceeded");
         }
+        stanzaIsGrease = false;
+      } else {
+        stanzaIsGrease = /^[!-~]{1,8}-grease$/u.test(fields[1]) &&
+          fields.length <= 6 && fields.slice(2).every((field) => /^[!-~]{1,8}$/u.test(field));
+        if (!stanzaIsGrease) malformed("age-v1 rejects active non-X25519 recipient stanzas");
       }
       insideStanza = true;
       stanzaHasBody = false;
+      stanzaBodyBytes = 0;
+      greaseShortBodySeen = false;
     } else if (value.startsWith("--- ")) {
       if (!insideStanza || !stanzaHasBody || x25519StanzaCount < 1 ||
           value.split(" ").length !== 2 || offset >= ageFile.length) {
         malformed("age header footer is invalid");
       }
       return { totalStanzaCount, x25519StanzaCount };
-    } else if (!insideStanza || !/^[A-Za-z0-9+/]+={0,2}$/u.test(value)) {
+    } else if (!insideStanza ||
+        !(stanzaIsGrease ? /^[A-Za-z0-9+/]*$/u : /^[A-Za-z0-9+/]+={0,2}$/u).test(value)) {
       malformed("age recipient stanza body is invalid");
     } else {
       stanzaHasBody = true;
+      if (stanzaIsGrease) {
+        if (value.length > 64 || value.length % 4 === 1 || greaseShortBodySeen) {
+          malformed("age GREASE stanza body framing is invalid");
+        }
+        stanzaBodyBytes += Math.floor(value.length * 3 / 4);
+        if (stanzaBodyBytes > 100) malformed("age GREASE stanza body limit exceeded");
+        greaseShortBodySeen = value.length < 64;
+      }
     }
   }
   malformed("age header footer is missing");

--- a/tests/sync_cipher.test.mjs
+++ b/tests/sync_cipher.test.mjs
@@ -4,10 +4,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { evaluatePull } from "../scripts/internal/remote-sync.mjs";
-import { nativeAgeIdentity, openEnvelope, sealEnvelope } from "../scripts/internal/sync-cipher.mjs";
+import { nativeAgeIdentity, openEnvelope, sealEnvelope,
+  validateAgeHeader } from "../scripts/internal/sync-cipher.mjs";
 
 const manifest = JSON.parse(await readFile(
   new URL("../docs/spec/vectors/age-v1-vectors.json", import.meta.url), "utf8"));
+const rustGrease = JSON.parse(await readFile(
+  new URL("../docs/spec/vectors/age-v1-rust-grease.json", import.meta.url), "utf8"));
 const byName = new Map(manifest.vectors.map((vector) => [vector.name, vector]));
 
 function resolveEnvelope(vector) {
@@ -134,6 +137,51 @@ test("age-v1 recipient stanza count must match the effective manifest", async ()
       team_id: base.team_id, wire_id: base.wire_id, identity_file: identity,
       expected_recipients: [manifest.recipient_sets.team_a.recipient], max_blob_bytes: 1_048_576 }),
     (error) => error.state === "authentication_failed");
+  } finally {
+    await rm(scratch, { recursive: true });
+  }
+});
+
+test("age-v1 ignores bounded GREASE stanzas without weakening X25519 count", () => {
+  const header = (...lines) => Buffer.concat([
+    Buffer.from(`${lines.join("\n")}\n`, "ascii"), Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+  ]);
+  const x25519 = [
+    "-> X25519 UHwSYuqz0nETnk0k8pTzWX5dUSwX32+mdzrgiooZ5FM",
+    "fHRC1X2S0nMkexfGaMYo7k1WeRjMXouDB6VI1ERX1ho",
+  ];
+  const grease = ["-> grease test-extension", "ZmFrZS13cmFwcGVkLWZpbGUta2V5"];
+  const footer = "--- 1D+zVTAq2TisMsHnBKk0agnk0N0xNzkdHc07l8O8we0";
+  assert.deepEqual(validateAgeHeader(header("age-encryption.org/v1", ...grease,
+    ...x25519, footer)), { totalStanzaCount: 2, x25519StanzaCount: 1 });
+  assert.throws(() => validateAgeHeader(header("age-encryption.org/v1", ...grease, footer)),
+    /footer/u);
+  const excessive = Array.from({ length: 513 }, (_, index) => [
+    `-> grease extension-${index}`, "YQ==",
+  ]).flat();
+  assert.throws(() => validateAgeHeader(header("age-encryption.org/v1", ...x25519,
+    ...excessive, footer)), /total stanza limit/u);
+  assert.throws(() => validateAgeHeader(header("age-encryption.org/v1", ...x25519,
+    `-> grease ${"a".repeat(4090)}`, "YQ==", footer)), /incomplete/u);
+  assert.throws(() => validateAgeHeader(header("age-encryption.org/v1", ...x25519,
+    "-> grease bounded-extension", ...Array(17).fill("A".repeat(4000)), footer)),
+  /size limit/u);
+});
+
+test("age-v1 opens the Rust age 0.12.1 GREASE interoperability fixture", async () => {
+  const scratch = await mkdtemp(join(tmpdir(), "agmsg-age-v1-rust-grease-"));
+  try {
+    const identity = join(scratch, "identity");
+    await writeFile(identity, `${manifest.recipient_sets.team_a.identity}\n`, { mode: 0o600 });
+    assert.deepEqual(validateAgeHeader(Buffer.from(rustGrease.envelope.blob, "base64")), {
+      totalStanzaCount: rustGrease.total_stanza_count,
+      x25519StanzaCount: rustGrease.x25519_stanza_count,
+    });
+    assert.deepEqual(await openEnvelope({ envelope: rustGrease.envelope,
+      protocol_version: 1, team_id: manifest.binding.team_id,
+      wire_id: manifest.binding.wire_id, identity_file: identity,
+      expected_recipients: [manifest.recipient_sets.team_a.recipient],
+      max_blob_bytes: 1_048_576 }), manifest.canonical_message);
   } finally {
     await rm(scratch, { recursive: true });
   }

--- a/tests/sync_cipher.test.mjs
+++ b/tests/sync_cipher.test.mjs
@@ -203,7 +203,8 @@ test("age-v1 rejects active non-X25519 stanzas before spawning the decryptor", a
       { mode: 0o700 });
     process.env.AGMSG_AGE_BIN = fakeAge;
     process.env.AGMSG_AGE_SPAWN_MARKER = marker;
-    const active = ["scrypt salt 10", "ssh-rsa key", "plugin-example data", "future-recipient data"];
+    const active = ["scrypt salt 10", "ssh-rsa key", "ssh-ed25519 key",
+      "plugin-example data", "plugin-x-grease data", "future-recipient data"];
     for (const stanza of active) {
       const bytes = Buffer.concat([Buffer.from([
         "age-encryption.org/v1",
@@ -221,6 +222,47 @@ test("age-v1 rejects active non-X25519 stanzas before spawning the decryptor", a
         expected_recipients: [manifest.recipient_sets.team_a.recipient],
         max_blob_bytes: 1_048_576,
       }), (error) => error.state === "malformed");
+      await assert.rejects(readFile(marker), (error) => error.code === "ENOENT");
+    }
+  } finally {
+    if (originalAgeBin === undefined) delete process.env.AGMSG_AGE_BIN;
+    else process.env.AGMSG_AGE_BIN = originalAgeBin;
+    if (originalMarker === undefined) delete process.env.AGMSG_AGE_SPAWN_MARKER;
+    else process.env.AGMSG_AGE_SPAWN_MARKER = originalMarker;
+    await rm(scratch, { recursive: true });
+  }
+});
+
+test("age-v1 rejects noncanonical GREASE base64 before spawning the decryptor", async () => {
+  const scratch = await mkdtemp(join(tmpdir(), "agmsg-age-v1-grease-base64-"));
+  const originalAgeBin = process.env.AGMSG_AGE_BIN;
+  const originalMarker = process.env.AGMSG_AGE_SPAWN_MARKER;
+  try {
+    const identity = join(scratch, "identity");
+    const fakeAge = join(scratch, "fake-age");
+    const marker = join(scratch, "spawned");
+    await writeFile(identity, `${manifest.recipient_sets.team_a.identity}\n`, { mode: 0o600 });
+    await writeFile(fakeAge, "#!/bin/sh\nprintf invoked > \"$AGMSG_AGE_SPAWN_MARKER\"\nexit 99\n",
+      { mode: 0o700 });
+    process.env.AGMSG_AGE_BIN = fakeAge;
+    process.env.AGMSG_AGE_SPAWN_MARKER = marker;
+    for (const body of ["AB", "AAB"]) {
+      const bytes = Buffer.concat([Buffer.from([
+        "age-encryption.org/v1",
+        "-> x-grease",
+        body,
+        "-> X25519 UHwSYuqz0nETnk0k8pTzWX5dUSwX32+mdzrgiooZ5FM",
+        "fHRC1X2S0nMkexfGaMYo7k1WeRjMXouDB6VI1ERX1ho",
+        "--- 1D+zVTAq2TisMsHnBKk0agnk0N0xNzkdHc07l8O8we0",
+        "",
+      ].join("\n"), "ascii"), Buffer.from([0xde, 0xad, 0xbe, 0xef])]);
+      await assert.rejects(openEnvelope({
+        envelope: { ...rustGrease.envelope, blob: bytes.toString("base64") },
+        protocol_version: 1, team_id: manifest.binding.team_id,
+        wire_id: manifest.binding.wire_id, identity_file: identity,
+        expected_recipients: [manifest.recipient_sets.team_a.recipient],
+        max_blob_bytes: 1_048_576,
+      }), (error) => error.state === "malformed" && /canonical base64/u.test(error.message));
       await assert.rejects(readFile(marker), (error) => error.code === "ENOENT");
     }
   } finally {

--- a/tests/sync_cipher.test.mjs
+++ b/tests/sync_cipher.test.mjs
@@ -150,22 +150,25 @@ test("age-v1 ignores bounded GREASE stanzas without weakening X25519 count", () 
     "-> X25519 UHwSYuqz0nETnk0k8pTzWX5dUSwX32+mdzrgiooZ5FM",
     "fHRC1X2S0nMkexfGaMYo7k1WeRjMXouDB6VI1ERX1ho",
   ];
-  const grease = ["-> grease test-extension", "ZmFrZS13cmFwcGVkLWZpbGUta2V5"];
+  const grease = ["-> test-grease ext", "ZmFrZS13cmFwcGVkLWZpbGUta2V5"];
   const footer = "--- 1D+zVTAq2TisMsHnBKk0agnk0N0xNzkdHc07l8O8we0";
   assert.deepEqual(validateAgeHeader(header("age-encryption.org/v1", ...grease,
     ...x25519, footer)), { totalStanzaCount: 2, x25519StanzaCount: 1 });
   assert.throws(() => validateAgeHeader(header("age-encryption.org/v1", ...grease, footer)),
     /footer/u);
-  const excessive = Array.from({ length: 513 }, (_, index) => [
-    `-> grease extension-${index}`, "YQ==",
+  const excessive = Array.from({ length: 513 }, () => [
+    "-> x-grease", "",
   ]).flat();
   assert.throws(() => validateAgeHeader(header("age-encryption.org/v1", ...x25519,
     ...excessive, footer)), /total stanza limit/u);
   assert.throws(() => validateAgeHeader(header("age-encryption.org/v1", ...x25519,
-    `-> grease ${"a".repeat(4090)}`, "YQ==", footer)), /incomplete/u);
+    `-> x-grease ${"a".repeat(4090)}`, "", footer)), /incomplete/u);
+  const largeHeader = Array.from({ length: 400 }, () => [
+    "-> abcdefgh-grease abcdefgh abcdefgh abcdefgh abcdefgh",
+    "A".repeat(64), "A".repeat(64), "A".repeat(6),
+  ]).flat();
   assert.throws(() => validateAgeHeader(header("age-encryption.org/v1", ...x25519,
-    "-> grease bounded-extension", ...Array(17).fill("A".repeat(4000)), footer)),
-  /size limit/u);
+    ...largeHeader, footer)), /size limit/u);
 });
 
 test("age-v1 opens the Rust age 0.12.1 GREASE interoperability fixture", async () => {
@@ -183,6 +186,48 @@ test("age-v1 opens the Rust age 0.12.1 GREASE interoperability fixture", async (
       expected_recipients: [manifest.recipient_sets.team_a.recipient],
       max_blob_bytes: 1_048_576 }), manifest.canonical_message);
   } finally {
+    await rm(scratch, { recursive: true });
+  }
+});
+
+test("age-v1 rejects active non-X25519 stanzas before spawning the decryptor", async () => {
+  const scratch = await mkdtemp(join(tmpdir(), "agmsg-age-v1-active-stanza-"));
+  const originalAgeBin = process.env.AGMSG_AGE_BIN;
+  const originalMarker = process.env.AGMSG_AGE_SPAWN_MARKER;
+  try {
+    const identity = join(scratch, "identity");
+    const fakeAge = join(scratch, "fake-age");
+    const marker = join(scratch, "spawned");
+    await writeFile(identity, `${manifest.recipient_sets.team_a.identity}\n`, { mode: 0o600 });
+    await writeFile(fakeAge, "#!/bin/sh\nprintf invoked > \"$AGMSG_AGE_SPAWN_MARKER\"\nexit 99\n",
+      { mode: 0o700 });
+    process.env.AGMSG_AGE_BIN = fakeAge;
+    process.env.AGMSG_AGE_SPAWN_MARKER = marker;
+    const active = ["scrypt salt 10", "ssh-rsa key", "plugin-example data", "future-recipient data"];
+    for (const stanza of active) {
+      const bytes = Buffer.concat([Buffer.from([
+        "age-encryption.org/v1",
+        "-> X25519 UHwSYuqz0nETnk0k8pTzWX5dUSwX32+mdzrgiooZ5FM",
+        "fHRC1X2S0nMkexfGaMYo7k1WeRjMXouDB6VI1ERX1ho",
+        `-> ${stanza}`,
+        "YQ",
+        "--- 1D+zVTAq2TisMsHnBKk0agnk0N0xNzkdHc07l8O8we0",
+        "",
+      ].join("\n"), "ascii"), Buffer.from([0xde, 0xad, 0xbe, 0xef])]);
+      await assert.rejects(openEnvelope({
+        envelope: { ...rustGrease.envelope, blob: bytes.toString("base64") },
+        protocol_version: 1, team_id: manifest.binding.team_id,
+        wire_id: manifest.binding.wire_id, identity_file: identity,
+        expected_recipients: [manifest.recipient_sets.team_a.recipient],
+        max_blob_bytes: 1_048_576,
+      }), (error) => error.state === "malformed");
+      await assert.rejects(readFile(marker), (error) => error.code === "ENOENT");
+    }
+  } finally {
+    if (originalAgeBin === undefined) delete process.env.AGMSG_AGE_BIN;
+    else process.env.AGMSG_AGE_BIN = originalAgeBin;
+    if (originalMarker === undefined) delete process.env.AGMSG_AGE_SPAWN_MARKER;
+    else process.env.AGMSG_AGE_SPAWN_MARKER = originalMarker;
     await rm(scratch, { recursive: true });
   }
 });


### PR DESCRIPTION
## Summary
- revise the unpublished age-v1 profile to follow age unknown-stanza/GREASE interoperability
- preserve exact X25519 manifest-count enforcement and native-identity-only decryption
- bound header parsing to 256 X25519 / 512 total stanzas, 64 KiB header bytes, and 4096-byte lines
- add a real Rust age crate 0.12.1 GREASE fixture plus adversarial parser tests

## Validation
- node --test tests/sync_cipher.test.mjs (8/8)
- bats tests/test_sync_cipher.bats (3/3)
- node docs/spec/vectors/verify-age-v1-vectors.mjs (19 vectors)
- node --test tests/remote_sync_engine.test.mjs (21/21)
- diff/syntax checks clean

Draft/unmerged dogfood stack. Merge remains koit-gated.