### PR TITLE
feat(watch): opt-in catch-up drain of unread inbox on fresh attach (#229)

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -139,6 +139,13 @@ delivery:
   monitor:
     # watch.sh SQLite poll interval, seconds
     poll_interval: 5
+    # Opt-in catch-up (#229): a FRESH watcher attach emits the current unread
+    # backlog once (capped) before the live stream. Off by default (the stream
+    # starts from "now"); enable with AGMSG_WATCH_CATCHUP=1 or
+    # `config.sh set delivery.monitor.catchup true`. Comment only, no value
+    # line: yaml_get reads one nesting level, so `set` stores the key as a
+    # flat `monitor.catchup:` entry under delivery — a nested default here
+    # would linger unread next to it and mislead.
   turn:
     # Stop hook cooldown, seconds. Legacy alias: hook.check_interval
     check_interval: 60

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -181,7 +181,9 @@ esac
 # Then an absolute ceiling, because the drained rows are materialized into ONE
 # shell variable: a cap in the millions would trade "floods the Monitor stream"
 # for "exhausts memory building the string", which is not the protection this
-# is here to give. 10k is far above any real backlog and still bounded
+# is here to give. 10k is a bound chosen to keep that string manageable, not a
+# claim about how large a backlog can get — a real one can exceed it, and what
+# does not fit stays reachable via inbox.sh like anything else over the cap
 # (review finding, 2026-07-30).
 CATCHUP_CAP_MAX=10000
 [ "$CATCHUP_CAP" -le 0 ] && CATCHUP_CAP=50
@@ -433,11 +435,13 @@ fi
 # is delivered twice.
 #
 # Control messages (ctrl:*) are excluded. The drain only prints, so it cannot
-# itself act on one — the risk is downstream: a stale ctrl:despawn surfaced
-# into the Monitor stream is a teardown directive presented to a reader that
-# has no way to tell it is weeks old. They stay unread for the live loop, which
-# is where ctrl rows are actually interpreted. The test pins non-emission,
-# which is the part this path controls.
+# itself act on one, and the line it would print carries created_at — a reader
+# is not left guessing the age. The reason is narrower than that: ctrl rows are
+# directives addressed to the live loop, which is the only place their
+# semantics are implemented, and a drain emits into the same stream without
+# that context. Keeping them out of the drain leaves them where they are
+# interpreted. The test pins non-emission, which is the part this path
+# controls.
 #
 # A broad (non-actas) watcher drains ONLY the roles it is the definitive
 # receiver for. mark_read applies the same rule per row on the live path: a

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -23,6 +23,11 @@ source "$(cd "$(dirname "$0")" && pwd)/lib/compat.sh"
 #     a restart of this session's watcher (actas/drop/clear/self-restart)
 #     resumes from the last delivered id and does not drop messages that
 #     arrived during the restart gap. See #107.
+#   - Opt-in catch-up (#229): when AGMSG_WATCH_CATCHUP=1 (or the
+#     delivery.monitor.catchup config key is true), a FRESH session first
+#     emits its current unread backlog once — capped, newest kept — before
+#     entering the live stream. Default stays "start from now". A reconnect
+#     (persisted watermark present) never drains, so history is not replayed.
 #   - Polls the SQLite DB at AGMSG_WATCH_INTERVAL seconds (default 5, also
 #     overridable via the delivery.monitor.poll_interval config key).
 #   - Emits one line per new message:
@@ -150,6 +155,24 @@ if [ -z "$INTERVAL" ]; then
   INTERVAL="$("$SCRIPT_DIR/config.sh" get delivery.monitor.poll_interval 5 2>/dev/null || echo 5)"
 fi
 case "$INTERVAL" in ''|*[!0-9]*) INTERVAL=5 ;; esac
+
+# Resolve the opt-in catch-up drain gate (#229). Env var wins over config,
+# default OFF — the pinned "stream from now, do not replay history" contract
+# is unchanged unless the operator explicitly asks for catch-up.
+CATCHUP="${AGMSG_WATCH_CATCHUP:-}"
+if [ -z "$CATCHUP" ]; then
+  CATCHUP="$("$SCRIPT_DIR/config.sh" get delivery.monitor.catchup 0 2>/dev/null || echo 0)"
+fi
+case "$CATCHUP" in 1|true|yes|on) CATCHUP=1 ;; *) CATCHUP=0 ;; esac
+
+# Hard cap on drained rows so an old, never-read backlog cannot flood the
+# Monitor stream at attach. The env override is a tuning/test seam. The 10#
+# normalization strips leading zeros — bash arithmetic would otherwise parse
+# a value like "08" as bad octal and kill the watcher under set -u.
+CATCHUP_CAP="${AGMSG_WATCH_CATCHUP_CAP:-50}"
+case "$CATCHUP_CAP" in ''|*[!0-9]*) CATCHUP_CAP=50 ;; *) CATCHUP_CAP=$((10#$CATCHUP_CAP)) ;; esac
+# -le also catches a wrapped-negative from an absurdly long digit string.
+[ "$CATCHUP_CAP" -le 0 ] && CATCHUP_CAP=50
 
 mkdir -p "$RUN_DIR" 2>/dev/null || true
 
@@ -352,7 +375,9 @@ if [ -f "$WATERMARK_FILE" ]; then
   LAST="$(cat "$WATERMARK_FILE" 2>/dev/null || true)"
   case "$LAST" in ''|*[!0-9]*) LAST="" ;; esac
 fi
+FRESH_ATTACH=0
 if [ -z "$LAST" ]; then
+  FRESH_ATTACH=1
   LAST=0
   if [ -f "$DB" ]; then
     LAST="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE $WHERE_PAIRS;" 2>/dev/null || echo 0)"
@@ -374,6 +399,62 @@ fi
 if [ -f "$DB" ] && ! agmsg_sqlite "$DB" "SELECT 1;" >/dev/null 2>&1; then
   echo "ERROR: cannot open message DB $DB"
   exit 1
+fi
+
+# Opt-in catch-up drain (#229). "Unread at attach" is defined against the
+# watermark model as: rows addressed to this subscription with read_at IS NULL
+# and id <= the just-seeded watermark. Draining is gated on a FRESH attach
+# (no persisted watermark existed at startup): the seed already pinned LAST to
+# MAX(id) and persisted it, so a later reconnect resumes from the watermark
+# and never re-drains — the #107 gap-fill covers a reconnect instead. Rows
+# with id > LAST (sent while we were arming) belong to the live loop, so the
+# id <= LAST bound also makes drain + live stream mutually exclusive: nothing
+# is delivered twice.
+#
+# Control messages (ctrl:*) are excluded: they are live teardown directives,
+# and replaying a stale ctrl:despawn at attach could tear down a freshly
+# spawned successor for the same role. They stay unread for the live loop
+# semantics they were designed for.
+#
+# The drain does NOT mark rows read: watch.sh streaming has never advanced
+# read_at (that is inbox.sh's job on display), and keeping that invariant
+# leaves this change orthogonal to any future live-delivery read-marking.
+# Done before the ready sentinel so "ready" implies the backlog notice went
+# out first, and after the DB healthcheck so we never drain from a store the
+# live loop cannot read.
+if [ "$CATCHUP" = 1 ] && [ "$FRESH_ATTACH" = 1 ] && [ -f "$DB" ]; then
+  UNREAD_TOTAL="$(agmsg_sqlite "$DB" "
+    SELECT COUNT(*) FROM messages
+    WHERE id <= $LAST AND read_at IS NULL
+      AND body NOT LIKE 'ctrl:%' AND ($WHERE_PAIRS);
+  " 2>/dev/null || echo 0)"
+  case "$UNREAD_TOTAL" in ''|*[!0-9]*) UNREAD_TOTAL=0 ;; esac
+  if [ "$UNREAD_TOTAL" -gt "$CATCHUP_CAP" ]; then
+    # Keep the NEWEST rows under the cap — recent context is what an
+    # attaching agent needs; the full backlog stays reachable via inbox.sh.
+    echo "agmsg watch: catch-up drained the newest $CATCHUP_CAP of $UNREAD_TOTAL unread messages ($((UNREAD_TOTAL - CATCHUP_CAP)) older not shown; use inbox.sh)"
+  fi
+  if [ "$UNREAD_TOTAL" -gt 0 ]; then
+    DRAIN_ROWS="$(agmsg_sqlite -separator $'\x1f' "$DB" "
+      SELECT id, created_at, team, from_agent, to_agent,
+             replace(replace(body, char(13), ''), char(10), '\\n')
+      FROM (
+        SELECT * FROM messages
+        WHERE id <= $LAST AND read_at IS NULL
+          AND body NOT LIKE 'ctrl:%' AND ($WHERE_PAIRS)
+        ORDER BY id DESC LIMIT $CATCHUP_CAP
+      ) ORDER BY id;
+    " 2>/dev/null || true)"
+    if [ -n "$DRAIN_ROWS" ]; then
+      while IFS=$'\x1f' read -r _cid _cts _cteam _cfrom _cto _cbody; do
+        [ -z "$_cid" ] && continue
+        if ! printf '%s | %s | %s → %s | %s\n' "$_cts" "$_cteam" "$_cfrom" "$_cto" "$_cbody"; then
+          cleanup
+          exit 0
+        fi
+      done <<< "$DRAIN_ROWS"
+    fi
+  fi
 fi
 
 # Signal readiness. Once the subscription is resolved and the watermark is set,

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -170,8 +170,15 @@ case "$CATCHUP" in 1|true|yes|on) CATCHUP=1 ;; *) CATCHUP=0 ;; esac
 # normalization strips leading zeros — bash arithmetic would otherwise parse
 # a value like "08" as bad octal and kill the watcher under set -u.
 CATCHUP_CAP="${AGMSG_WATCH_CATCHUP_CAP:-50}"
-case "$CATCHUP_CAP" in ''|*[!0-9]*) CATCHUP_CAP=50 ;; *) CATCHUP_CAP=$((10#$CATCHUP_CAP)) ;; esac
-# -le also catches a wrapped-negative from an absurdly long digit string.
+# Bound the digit count BEFORE the arithmetic. Relying on a `-le 0` check after
+# the fact is not enough: a long enough digit string wraps to an arbitrary
+# value, which lands positive as easily as negative and would sail through
+# (review finding, 2026-07-30). 9 digits cannot overflow a 64-bit shell int,
+# and no plausible cap needs more.
+case "$CATCHUP_CAP" in
+  ''|*[!0-9]*|??????????*) CATCHUP_CAP=50 ;;
+  *) CATCHUP_CAP=$((10#$CATCHUP_CAP)) ;;
+esac
 [ "$CATCHUP_CAP" -le 0 ] && CATCHUP_CAP=50
 
 mkdir -p "$RUN_DIR" 2>/dev/null || true
@@ -375,9 +382,17 @@ if [ -f "$WATERMARK_FILE" ]; then
   LAST="$(cat "$WATERMARK_FILE" 2>/dev/null || true)"
   case "$LAST" in ''|*[!0-9]*) LAST="" ;; esac
 fi
+# Keyed on the FILE's absence, not on LAST being empty. A watermark that exists
+# but does not parse (truncated by a kill mid-write, hand-edited) also empties
+# LAST and reseeds — but that is a damaged reconnect, not a first attach, and
+# treating it as fresh would replay the backlog to a session that already saw
+# it. "A reconnect never drains" then holds as written instead of only for an
+# intact watermark (review finding, 2026-07-30).
 FRESH_ATTACH=0
-if [ -z "$LAST" ]; then
+if [ ! -f "$WATERMARK_FILE" ]; then
   FRESH_ATTACH=1
+fi
+if [ -z "$LAST" ]; then
   LAST=0
   if [ -f "$DB" ]; then
     LAST="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE $WHERE_PAIRS;" 2>/dev/null || echo 0)"
@@ -426,6 +441,14 @@ fi
 # reused from WHERE_PAIRS so it sees the sentinels as they stand now, and it
 # runs before this watcher writes its own sentinels below, so an exclusive
 # watcher never excludes itself (it is exempt from the rule anyway).
+#
+# The check and the drain are not atomic: an exclusive watcher that writes its
+# sentinel in that window still gets its backlog emitted here. Deliberately not
+# locked. mark_read carries the same race per row on the live path and is
+# documented as best-effort, the window is one clause build wide, and the
+# failure mode is a role seeing its backlog twice rather than losing it — the
+# drain marks nothing, so the other watcher's read state is untouched. A lock
+# spanning attach would cost more than the duplicate it prevents.
 #
 # The drain deliberately does NOT mark rows read, and that is now a choice
 # rather than an invariant: watch.sh's live loop DOES advance read_at via

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -173,13 +173,19 @@ CATCHUP_CAP="${AGMSG_WATCH_CATCHUP_CAP:-50}"
 # Bound the digit count BEFORE the arithmetic. Relying on a `-le 0` check after
 # the fact is not enough: a long enough digit string wraps to an arbitrary
 # value, which lands positive as easily as negative and would sail through
-# (review finding, 2026-07-30). 9 digits cannot overflow a 64-bit shell int,
-# and no plausible cap needs more.
+# (review finding, 2026-07-30). 10 digits cannot overflow a 64-bit shell int.
 case "$CATCHUP_CAP" in
-  ''|*[!0-9]*|??????????*) CATCHUP_CAP=50 ;;
+  ''|*[!0-9]*|???????????*) CATCHUP_CAP=50 ;;
   *) CATCHUP_CAP=$((10#$CATCHUP_CAP)) ;;
 esac
+# Then an absolute ceiling, because the drained rows are materialized into ONE
+# shell variable: a cap in the millions would trade "floods the Monitor stream"
+# for "exhausts memory building the string", which is not the protection this
+# is here to give. 10k is far above any real backlog and still bounded
+# (review finding, 2026-07-30).
+CATCHUP_CAP_MAX=10000
 [ "$CATCHUP_CAP" -le 0 ] && CATCHUP_CAP=50
+[ "$CATCHUP_CAP" -gt "$CATCHUP_CAP_MAX" ] && CATCHUP_CAP="$CATCHUP_CAP_MAX"
 
 mkdir -p "$RUN_DIR" 2>/dev/null || true
 
@@ -426,10 +432,12 @@ fi
 # id <= LAST bound also makes drain + live stream mutually exclusive: nothing
 # is delivered twice.
 #
-# Control messages (ctrl:*) are excluded: they are live teardown directives,
-# and replaying a stale ctrl:despawn at attach could tear down a freshly
-# spawned successor for the same role. They stay unread for the live loop
-# semantics they were designed for.
+# Control messages (ctrl:*) are excluded. The drain only prints, so it cannot
+# itself act on one — the risk is downstream: a stale ctrl:despawn surfaced
+# into the Monitor stream is a teardown directive presented to a reader that
+# has no way to tell it is weeks old. They stay unread for the live loop, which
+# is where ctrl rows are actually interpreted. The test pins non-emission,
+# which is the part this path controls.
 #
 # A broad (non-actas) watcher drains ONLY the roles it is the definitive
 # receiver for. mark_read applies the same rule per row on the live path: a
@@ -484,11 +492,6 @@ if [ -n "$WHERE_DRAIN" ]; then
       AND body NOT LIKE 'ctrl:%' AND ($WHERE_DRAIN);
   " 2>/dev/null || echo 0)"
   case "$UNREAD_TOTAL" in ''|*[!0-9]*) UNREAD_TOTAL=0 ;; esac
-  if [ "$UNREAD_TOTAL" -gt "$CATCHUP_CAP" ]; then
-    # Keep the NEWEST rows under the cap — recent context is what an
-    # attaching agent needs; the full backlog stays reachable via inbox.sh.
-    echo "agmsg watch: catch-up drained the newest $CATCHUP_CAP of $UNREAD_TOTAL unread messages ($((UNREAD_TOTAL - CATCHUP_CAP)) older not shown; use inbox.sh)"
-  fi
   if [ "$UNREAD_TOTAL" -gt 0 ]; then
     DRAIN_ROWS="$(agmsg_sqlite -separator $'\x1f' "$DB" "
       SELECT id, created_at, team, from_agent, to_agent,
@@ -500,6 +503,16 @@ if [ -n "$WHERE_DRAIN" ]; then
         ORDER BY id DESC LIMIT $CATCHUP_CAP
       ) ORDER BY id;
     " 2>/dev/null || true)"
+    # The notice is emitted only once rows are actually in hand. Counting and
+    # fetching are two queries, and the fetch's failure is swallowed — printing
+    # the notice off the count alone would announce a drain that then emitted
+    # nothing, which is the sort of claim this branch keeps having to correct
+    # (review finding, 2026-07-30).
+    if [ -n "$DRAIN_ROWS" ] && [ "$UNREAD_TOTAL" -gt "$CATCHUP_CAP" ]; then
+      # Keep the NEWEST rows under the cap — recent context is what an
+      # attaching agent needs; the full backlog stays reachable via inbox.sh.
+      echo "agmsg watch: catch-up drained the newest $CATCHUP_CAP of $UNREAD_TOTAL unread messages ($((UNREAD_TOTAL - CATCHUP_CAP)) older not shown; use inbox.sh)"
+    fi
     if [ -n "$DRAIN_ROWS" ]; then
       while IFS=$'\x1f' read -r _cid _cts _cteam _cfrom _cto _cbody; do
         [ -z "$_cid" ] && continue

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -416,17 +416,49 @@ fi
 # spawned successor for the same role. They stay unread for the live loop
 # semantics they were designed for.
 #
-# The drain does NOT mark rows read: watch.sh streaming has never advanced
-# read_at (that is inbox.sh's job on display), and keeping that invariant
-# leaves this change orthogonal to any future live-delivery read-marking.
+# A broad (non-actas) watcher drains ONLY the roles it is the definitive
+# receiver for. mark_read applies the same rule per row on the live path: a
+# role with its own exclusive ready sentinel has its own watcher, and a broad
+# watcher must not act on its behalf. Without the equivalent check here, a
+# broad watcher's fresh attach would emit the backlog belonging to every such
+# role — the leader's default SessionStart watcher dumping what each actas'd
+# member's own watcher is responsible for. Evaluated at drain time rather than
+# reused from WHERE_PAIRS so it sees the sentinels as they stand now, and it
+# runs before this watcher writes its own sentinels below, so an exclusive
+# watcher never excludes itself (it is exempt from the rule anyway).
+#
+# The drain deliberately does NOT mark rows read, and that is now a choice
+# rather than an invariant: watch.sh's live loop DOES advance read_at via
+# mark_read, so the drain sits next to a live path that marks. The consequence
+# is deliberate and worth stating plainly — drained rows stay unread, so a
+# later inbox.sh re-surfaces exactly what was just shown. That is the
+# conservative direction: catch-up is an additive convenience at attach, and
+# having it silently consume the backlog would make the one command an
+# operator uses to audit unread mail lie about what is outstanding.
 # Done before the ready sentinel so "ready" implies the backlog notice went
 # out first, and after the DB healthcheck so we never drain from a store the
 # live loop cannot read.
+WHERE_DRAIN=""
 if [ "$CATCHUP" = 1 ] && [ "$FRESH_ATTACH" = 1 ] && [ -f "$DB" ]; then
+  while IFS=$'\t' read -r team agent; do
+    [ -z "$team" ] && continue
+    if [ -z "$ACTIVE_NAME" ] && [ -e "$(agmsg_ready_path "$team" "$agent")" ]; then
+      continue
+    fi
+    t_esc=$(sql_escape "$team")
+    a_esc=$(sql_escape "$agent")
+    WHERE_DRAIN="${WHERE_DRAIN:+$WHERE_DRAIN OR }(team='$t_esc' AND to_agent='$a_esc')"
+  done <<< "$PAIRS"
+fi
+# An empty clause means every subscribed role has its own exclusive watcher, so
+# this broad watcher has nothing it may drain. It must also short-circuit the
+# whole block: an empty $WHERE_DRAIN would interpolate as `AND ()` and make the
+# query a syntax error.
+if [ -n "$WHERE_DRAIN" ]; then
   UNREAD_TOTAL="$(agmsg_sqlite "$DB" "
     SELECT COUNT(*) FROM messages
     WHERE id <= $LAST AND read_at IS NULL
-      AND body NOT LIKE 'ctrl:%' AND ($WHERE_PAIRS);
+      AND body NOT LIKE 'ctrl:%' AND ($WHERE_DRAIN);
   " 2>/dev/null || echo 0)"
   case "$UNREAD_TOTAL" in ''|*[!0-9]*) UNREAD_TOTAL=0 ;; esac
   if [ "$UNREAD_TOTAL" -gt "$CATCHUP_CAP" ]; then
@@ -441,7 +473,7 @@ if [ "$CATCHUP" = 1 ] && [ "$FRESH_ATTACH" = 1 ] && [ -f "$DB" ]; then
       FROM (
         SELECT * FROM messages
         WHERE id <= $LAST AND read_at IS NULL
-          AND body NOT LIKE 'ctrl:%' AND ($WHERE_PAIRS)
+          AND body NOT LIKE 'ctrl:%' AND ($WHERE_DRAIN)
         ORDER BY id DESC LIMIT $CATCHUP_CAP
       ) ORDER BY id;
     " 2>/dev/null || true)"

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -582,9 +582,15 @@ _wait_pidfile() {
   wait "$w1" 2>/dev/null || true
   grep -q "M0-queued" "$TEST_SKILL_DIR/cu1.log"
 
-  # M0 is still unread — the drain does not mark read — while M1 went through
-  # the live loop, which does. Either way a reconnect resumes from the persisted
-  # watermark and must NOT re-emit them; only the in-gap row arrives.
+  # Assert the read state directly rather than leaving it to prose: the
+  # watermark alone suppresses replay whether or not a row was marked, so the
+  # absence of M0 below would prove nothing about the drain's no-mark choice.
+  # M0 was drained (stays unread); M1 went through the live loop (marked).
+  [ -z "$(_read_at_for_body "M0-queued")" ]
+  [ -n "$(_read_at_for_body "M1-live")" ]
+
+  # A reconnect resumes from the persisted watermark and must NOT re-emit
+  # either of them; only the in-gap row arrives.
   bash "$SCRIPTS/send.sh" team bob alice "M2-in-gap" >/dev/null
   AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
     bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$TEST_SKILL_DIR/cu2.log" 2>/dev/null 3>&- &
@@ -687,6 +693,49 @@ _wait_pidfile() {
   wait "$w" 2>/dev/null || true
 
   grep -q "M-cfg-queued" "$out"
+}
+
+# A watermark that exists but does not parse is a damaged reconnect, not a
+# first attach. Keying the drain on the parsed value being empty (rather than
+# the file being absent) would replay the backlog to a session that already saw
+# it — the reconnect test above cannot catch that, since its watermark is
+# intact (review finding, 2026-07-30).
+@test "watch: a corrupt watermark reconnects without re-draining (#229)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-catchup-corrupt-wm"
+  local wm="$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark"
+
+  bash "$SCRIPTS/send.sh" team bob alice "M-corrupt-queued" >/dev/null
+
+  # A watermark truncated mid-write: present, but not a number.
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf '' > "$wm"
+
+  local out="$TEST_SKILL_DIR/catchup-corrupt.log"
+  AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
+    bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
+  local w=$!
+  # The file already exists, so its presence is not a sync point here — wait for
+  # the reseed to write a parsable value. Sending before that races the seed:
+  # the row would land at id <= LAST and the live loop (id > LAST) would skip it.
+  local i seeded=""
+  for i in $(seq 1 100); do
+    seeded="$(cat "$wm" 2>/dev/null || true)"
+    case "$seeded" in ''|*[!0-9]*) ;; *) break ;; esac
+    seeded=""
+    sleep 0.1
+  done
+  [ -n "$seeded" ] || { kill "$w" 2>/dev/null || true; false; }
+
+  # The watcher reseeds and serves live traffic normally...
+  bash "$SCRIPTS/send.sh" team bob alice "M-corrupt-live" >/dev/null
+  wait_for_file_contains "$out" "M-corrupt-live" \
+    || { kill "$w" 2>/dev/null || true; false; }
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  # ...but must not treat the damaged reconnect as a fresh attach and replay.
+  ! grep -q "M-corrupt-queued" "$out"
 }
 
 # The live path's mark_read refuses to act for a role that owns an exclusive

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -685,7 +685,12 @@ _wait_pidfile() {
   bash "$SCRIPTS/config.sh" set delivery.monitor.catchup true >/dev/null
   bash "$SCRIPTS/send.sh" team bob alice "M-cfg-queued" >/dev/null
 
-  AGMSG_WATCH_INTERVAL=1 \
+  # Clear the env var explicitly — bats inherits the caller's environment, so an
+  # exported AGMSG_WATCH_CATCHUP=1 would let this pass with the config lookup
+  # broken, and =0 would fail it with the lookup working. Either way the test
+  # would be reporting on the environment, not the config key it names
+  # (review finding, 2026-07-30).
+  AGMSG_WATCH_CATCHUP= AGMSG_WATCH_INTERVAL=1 \
     bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
   local w=$!
   wait_for_file_contains "$out" "M-cfg-queued" || { kill "$w" 2>/dev/null || true; false; }
@@ -811,10 +816,12 @@ _wait_pidfile() {
 @test "watch: catch-up drain is a clean no-op when every role is owned elsewhere (#229)" {
   skip_on_windows "watcher background launch under Git Bash (#182)"
   mkdir -p "$TEST_SKILL_DIR/run"
-  local r
-  for r in $(bash "$SCRIPTS/identities.sh" "$PROJ" claude-code | cut -f2); do
-    [ -n "$r" ] && touch "$TEST_SKILL_DIR/run/ready.team__$r"
-  done
+  # read loop, not `for r in $(...)`: the latter word-splits and glob-expands,
+  # which an identity name with a space or a bracket would break.
+  local _t _r
+  while IFS=$'\t' read -r _t _r; do
+    [ -n "$_r" ] && touch "$TEST_SKILL_DIR/run/ready.${_t}__${_r}"
+  done < <(bash "$SCRIPTS/identities.sh" "$PROJ" claude-code)
 
   local sid="sess-catchup-all-owned"
   local out="$TEST_SKILL_DIR/catchup-all-owned.log"

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -523,6 +523,157 @@ _wait_pidfile() {
   done
 }
 
+# --- #229: opt-in catch-up drain of unread inbox on fresh attach ---
+# Default-OFF behavior is pinned by "watch: a fresh session starts from now
+# and does not replay history" above — these tests cover the opt-in path.
+
+@test "watch: catch-up ON drains queued unread on fresh attach, exactly once (#229)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-catchup"
+  local out="$TEST_SKILL_DIR/catchup.log"
+  local wm="$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark"
+
+  # Queued BEFORE the watcher ever attaches — the #229 miss.
+  bash "$SCRIPTS/send.sh" team bob alice "M0-queued" >/dev/null
+
+  AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
+    bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
+  local w=$!
+  _wait_for_file "$wm"
+  bash "$SCRIPTS/send.sh" team bob alice "M-live-after" >/dev/null
+  _wait_for_file_contains "$out" "M-live-after" || { kill "$w" 2>/dev/null || true; false; }
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  # Queued message drained once (not doubled by the live loop), live still works.
+  [ "$(grep -c "M0-queued" "$out")" -eq 1 ]
+  grep -q "M-live-after" "$out"
+}
+
+@test "watch: catch-up ON does not re-drain on reconnect with a persisted watermark (#229)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-catchup-reconnect"
+  local wm="$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark"
+
+  bash "$SCRIPTS/send.sh" team bob alice "M0-queued" >/dev/null
+
+  # First attach: fresh, drains M0 and streams M1.
+  AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
+    bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$TEST_SKILL_DIR/cu1.log" 2>/dev/null 3>&- &
+  local w1=$!
+  _wait_for_file "$wm"
+  bash "$SCRIPTS/send.sh" team bob alice "M1-live" >/dev/null
+  _wait_for_file_contains "$TEST_SKILL_DIR/cu1.log" "M1-live" || { kill "$w1" 2>/dev/null || true; false; }
+  kill "$w1" 2>/dev/null || true
+  wait "$w1" 2>/dev/null || true
+  grep -q "M0-queued" "$TEST_SKILL_DIR/cu1.log"
+
+  # M0/M1 are still unread (the drain does not mark read); a reconnect with the
+  # persisted watermark must NOT re-drain them — only the in-gap row arrives.
+  bash "$SCRIPTS/send.sh" team bob alice "M2-in-gap" >/dev/null
+  AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
+    bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$TEST_SKILL_DIR/cu2.log" 2>/dev/null 3>&- &
+  local w2=$!
+  _wait_for_file_contains "$TEST_SKILL_DIR/cu2.log" "M2-in-gap" || { kill "$w2" 2>/dev/null || true; false; }
+  kill "$w2" 2>/dev/null || true
+  wait "$w2" 2>/dev/null || true
+
+  ! grep -q "M0-queued" "$TEST_SKILL_DIR/cu2.log"
+  ! grep -q "M1-live" "$TEST_SKILL_DIR/cu2.log"
+}
+
+@test "watch: catch-up drain skips already-read messages (#229)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-catchup-read"
+  local out="$TEST_SKILL_DIR/catchup-read.log"
+  local wm="$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark"
+
+  bash "$SCRIPTS/send.sh" team bob alice "M-was-read" >/dev/null
+  bash "$SCRIPTS/inbox.sh" team alice >/dev/null   # displays + marks read
+  bash "$SCRIPTS/send.sh" team bob alice "M-still-unread" >/dev/null
+
+  AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
+    bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
+  local w=$!
+  _wait_for_file_contains "$out" "M-still-unread" || { kill "$w" 2>/dev/null || true; false; }
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  ! grep -q "M-was-read" "$out"
+}
+
+@test "watch: catch-up drain caps at the newest N with a notice (#229)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-catchup-cap"
+  local out="$TEST_SKILL_DIR/catchup-cap.log"
+
+  local n
+  for n in 1 2 3 4 5; do
+    bash "$SCRIPTS/send.sh" team bob alice "CAP-$n" >/dev/null
+  done
+
+  AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_CATCHUP_CAP=3 AGMSG_WATCH_INTERVAL=1 \
+    bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
+  local w=$!
+  _wait_for_file_contains "$out" 'CAP-5$' || { kill "$w" 2>/dev/null || true; false; }
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  # Newest 3 kept, oldest 2 dropped, and the notice says so.
+  grep -q 'CAP-3$' "$out"
+  grep -q 'CAP-4$' "$out"
+  grep -q 'CAP-5$' "$out"
+  ! grep -q 'CAP-1$' "$out"
+  ! grep -q 'CAP-2$' "$out"
+  grep -q "catch-up drained the newest 3 of 5 unread" "$out"
+}
+
+@test "watch: catch-up drain never replays control messages (#229)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-catchup-ctrl"
+  local out="$TEST_SKILL_DIR/catchup-ctrl.log"
+  local ready="$TEST_SKILL_DIR/run/ready.team__alice"
+
+  # A stale, unread despawn directive queued before attach. Replaying it would
+  # tear down the fresh actas watcher for the same role.
+  bash "$SCRIPTS/send.sh" team bob alice "ctrl:despawn" >/dev/null
+  bash "$SCRIPTS/send.sh" team bob alice "M-normal-queued" >/dev/null
+
+  AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
+    bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code alice >"$out" 2>/dev/null 3>&- &
+  local w=$! i
+  for i in $(seq 1 20); do [ -e "$ready" ] && break; sleep 0.5; done
+  [ -e "$ready" ]
+
+  # The watcher survived attach (did not act on the stale despawn) and still
+  # delivers live traffic.
+  bash "$SCRIPTS/send.sh" team bob alice "M-live-ctrl-test" >/dev/null
+  _wait_for_file_contains "$out" "M-live-ctrl-test" || { kill "$w" 2>/dev/null || true; false; }
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  grep -q "M-normal-queued" "$out"
+  ! grep -q "ctrl:despawn" "$out"
+}
+
+@test "watch: catch-up via the delivery.monitor.catchup config key (#229)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-catchup-cfg"
+  local out="$TEST_SKILL_DIR/catchup-cfg.log"
+
+  bash "$SCRIPTS/config.sh" set delivery.monitor.catchup true >/dev/null
+  bash "$SCRIPTS/send.sh" team bob alice "M-cfg-queued" >/dev/null
+
+  AGMSG_WATCH_INTERVAL=1 \
+    bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
+  local w=$!
+  _wait_for_file_contains "$out" "M-cfg-queued" || { kill "$w" 2>/dev/null || true; false; }
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  grep -q "M-cfg-queued" "$out"
+}
+
 @test "watch: empty session_id gets a generated fallback instead of a Usage error (#236)" {
   local out="$BATS_TEST_TMPDIR/empty-sid.out"
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "" "$PROJ" claude-code alice >"$out" 2>&1 3>&- &

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -539,9 +539,9 @@ _wait_pidfile() {
   AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
     bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
   local w=$!
-  _wait_for_file "$wm"
+  wait_for_file "$wm"
   bash "$SCRIPTS/send.sh" team bob alice "M-live-after" >/dev/null
-  _wait_for_file_contains "$out" "M-live-after" || { kill "$w" 2>/dev/null || true; false; }
+  wait_for_file_contains "$out" "M-live-after" || { kill "$w" 2>/dev/null || true; false; }
   kill "$w" 2>/dev/null || true
   wait "$w" 2>/dev/null || true
 
@@ -561,20 +561,35 @@ _wait_pidfile() {
   AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
     bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$TEST_SKILL_DIR/cu1.log" 2>/dev/null 3>&- &
   local w1=$!
-  _wait_for_file "$wm"
+  wait_for_file "$wm"
+  local wm_before
+  wm_before="$(cat "$wm" 2>/dev/null || true)"
   bash "$SCRIPTS/send.sh" team bob alice "M1-live" >/dev/null
-  _wait_for_file_contains "$TEST_SKILL_DIR/cu1.log" "M1-live" || { kill "$w1" 2>/dev/null || true; false; }
+  wait_for_file_contains "$TEST_SKILL_DIR/cu1.log" "M1-live" || { kill "$w1" 2>/dev/null || true; false; }
+  # The live loop prints the line BEFORE it persists the watermark, so killing
+  # on the log line alone can strand the watermark at its pre-M1 value. The
+  # reconnect would then re-deliver M1 legitimately, and the last assertion
+  # would be measuring this kill's timing rather than the no-re-drain contract
+  # it names. Sync on the watermark actually advancing instead.
+  local i wm_after=""
+  for i in $(seq 1 100); do
+    wm_after="$(cat "$wm" 2>/dev/null || true)"
+    [ -n "$wm_after" ] && [ "$wm_after" != "$wm_before" ] && break
+    sleep 0.1
+  done
+  [ "$wm_after" != "$wm_before" ]
   kill "$w1" 2>/dev/null || true
   wait "$w1" 2>/dev/null || true
   grep -q "M0-queued" "$TEST_SKILL_DIR/cu1.log"
 
-  # M0/M1 are still unread (the drain does not mark read); a reconnect with the
-  # persisted watermark must NOT re-drain them — only the in-gap row arrives.
+  # M0 is still unread — the drain does not mark read — while M1 went through
+  # the live loop, which does. Either way a reconnect resumes from the persisted
+  # watermark and must NOT re-emit them; only the in-gap row arrives.
   bash "$SCRIPTS/send.sh" team bob alice "M2-in-gap" >/dev/null
   AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
     bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$TEST_SKILL_DIR/cu2.log" 2>/dev/null 3>&- &
   local w2=$!
-  _wait_for_file_contains "$TEST_SKILL_DIR/cu2.log" "M2-in-gap" || { kill "$w2" 2>/dev/null || true; false; }
+  wait_for_file_contains "$TEST_SKILL_DIR/cu2.log" "M2-in-gap" || { kill "$w2" 2>/dev/null || true; false; }
   kill "$w2" 2>/dev/null || true
   wait "$w2" 2>/dev/null || true
 
@@ -595,7 +610,7 @@ _wait_pidfile() {
   AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
     bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
   local w=$!
-  _wait_for_file_contains "$out" "M-still-unread" || { kill "$w" 2>/dev/null || true; false; }
+  wait_for_file_contains "$out" "M-still-unread" || { kill "$w" 2>/dev/null || true; false; }
   kill "$w" 2>/dev/null || true
   wait "$w" 2>/dev/null || true
 
@@ -615,7 +630,7 @@ _wait_pidfile() {
   AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_CATCHUP_CAP=3 AGMSG_WATCH_INTERVAL=1 \
     bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
   local w=$!
-  _wait_for_file_contains "$out" 'CAP-5$' || { kill "$w" 2>/dev/null || true; false; }
+  wait_for_file_contains "$out" 'CAP-5$' || { kill "$w" 2>/dev/null || true; false; }
   kill "$w" 2>/dev/null || true
   wait "$w" 2>/dev/null || true
 
@@ -648,7 +663,7 @@ _wait_pidfile() {
   # The watcher survived attach (did not act on the stale despawn) and still
   # delivers live traffic.
   bash "$SCRIPTS/send.sh" team bob alice "M-live-ctrl-test" >/dev/null
-  _wait_for_file_contains "$out" "M-live-ctrl-test" || { kill "$w" 2>/dev/null || true; false; }
+  wait_for_file_contains "$out" "M-live-ctrl-test" || { kill "$w" 2>/dev/null || true; false; }
   kill "$w" 2>/dev/null || true
   wait "$w" 2>/dev/null || true
 
@@ -667,11 +682,112 @@ _wait_pidfile() {
   AGMSG_WATCH_INTERVAL=1 \
     bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
   local w=$!
-  _wait_for_file_contains "$out" "M-cfg-queued" || { kill "$w" 2>/dev/null || true; false; }
+  wait_for_file_contains "$out" "M-cfg-queued" || { kill "$w" 2>/dev/null || true; false; }
   kill "$w" 2>/dev/null || true
   wait "$w" 2>/dev/null || true
 
   grep -q "M-cfg-queued" "$out"
+}
+
+# The live path's mark_read refuses to act for a role that owns an exclusive
+# ready sentinel; the drain has to refuse the same roles or a broad watcher's
+# fresh attach dumps backlog that belongs to each actas'd member's own watcher.
+# This is the case single-role manual testing never shows (review, 2026-07-29).
+@test "watch: catch-up drain skips roles with their own exclusive ready sentinel (#229)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  # Sentinel presence IS the protocol (#108) — no live process needed, matching
+  # the mark_read guard's own test above.
+  mkdir -p "$TEST_SKILL_DIR/run"
+  touch "$TEST_SKILL_DIR/run/ready.team__alice"
+
+  local sid="sess-catchup-broad-guard"
+  local out="$TEST_SKILL_DIR/catchup-broad-guard.log"
+
+  # Both queued BEFORE any watcher attaches, so both are drain candidates.
+  bash "$SCRIPTS/send.sh" team bob alice "M-drain-alice-owned" >/dev/null
+  bash "$SCRIPTS/send.sh" team bob bob "M-drain-bob-unowned" >/dev/null
+
+  AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
+    bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
+  local w=$!
+  wait_for_file_contains "$out" "M-drain-bob-unowned" \
+    || { kill "$w" 2>/dev/null || true; false; }
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  # bob has no exclusive owner, so this broad watcher is his definitive
+  # receiver and drains him...
+  grep -q "M-drain-bob-unowned" "$out"
+  # ...while alice's backlog belongs to alice's own watcher and must not appear.
+  ! grep -q "M-drain-alice-owned" "$out"
+}
+
+# The exclusion is specific to BROAD watchers. Without this companion, the test
+# above would also pass if the drain simply skipped every role with a sentinel,
+# including the actas watcher's own role — which would break catch-up for the
+# spawned agents that need it most (every actas watcher writes that sentinel).
+@test "watch: catch-up drain still covers an actas watcher's own role despite its sentinel (#229)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  touch "$TEST_SKILL_DIR/run/ready.team__alice"
+
+  local sid="sess-catchup-actas-self"
+  local out="$TEST_SKILL_DIR/catchup-actas-self.log"
+
+  bash "$SCRIPTS/send.sh" team bob alice "M-drain-actas-self" >/dev/null
+
+  AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
+    bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code alice >"$out" 2>/dev/null 3>&- &
+  local w=$!
+  wait_for_file_contains "$out" "M-drain-actas-self" \
+    || { kill "$w" 2>/dev/null || true; false; }
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  grep -q "M-drain-actas-self" "$out"
+}
+
+# Every subscribed role owned elsewhere leaves an empty clause. What this pins
+# is the OBSERVABLE contract in that state: the watcher still arms, drains
+# nothing, prints no notice, and its live loop is unaffected.
+#
+# It deliberately does NOT claim to pin the `-n "$WHERE_DRAIN"` guard itself.
+# Dropping that guard interpolates `AND ()`, and the drain's
+# `2>/dev/null || echo 0` swallows the resulting SQL error into UNREAD_TOTAL=0
+# — which is the same no-drain, no-notice outcome this test asserts. Verified
+# by mutation: removing the guard leaves the whole suite green. The error is
+# unreachable from the watcher's own stderr too, so no assertion here can tell
+# the two apart; the guard is a correctness-by-construction stop, not a tested
+# branch. Saying so beats a comment that implies coverage this does not have.
+@test "watch: catch-up drain is a clean no-op when every role is owned elsewhere (#229)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  local r
+  for r in $(bash "$SCRIPTS/identities.sh" "$PROJ" claude-code | cut -f2); do
+    [ -n "$r" ] && touch "$TEST_SKILL_DIR/run/ready.team__$r"
+  done
+
+  local sid="sess-catchup-all-owned"
+  local out="$TEST_SKILL_DIR/catchup-all-owned.log"
+  local wm="$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark"
+
+  bash "$SCRIPTS/send.sh" team bob alice "M-all-owned-queued" >/dev/null
+
+  AGMSG_WATCH_CATCHUP=1 AGMSG_WATCH_INTERVAL=1 \
+    bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
+  local w=$!
+  # The watcher must still arm normally — the empty clause is a skip, not a crash.
+  wait_for_file "$wm" || { kill "$w" 2>/dev/null || true; false; }
+
+  # And the live loop is unaffected: it uses WHERE_PAIRS, not the drain clause.
+  bash "$SCRIPTS/send.sh" team bob alice "M-all-owned-live" >/dev/null
+  wait_for_file_contains "$out" "M-all-owned-live" \
+    || { kill "$w" 2>/dev/null || true; false; }
+  kill "$w" 2>/dev/null || true
+  wait "$w" 2>/dev/null || true
+
+  ! grep -q "M-all-owned-queued" "$out"
+  ! grep -q "catch-up drained" "$out"
 }
 
 @test "watch: empty session_id gets a generated fallback instead of a Usage error (#236)" {


### PR DESCRIPTION
Implements the proposal in #229: an OPT-IN, flag/config-gated catch-up drain — on a fresh attach, emit the current unread inbox once before entering the live stream, with the watermark model preventing any replay on reconnect. Default behavior stays "start from now".

## Motivation — a live occurrence of the race

Beyond the spawn-then-send case in #229, the same miss happens in the "send, then arm the monitor" order. Observed on a production team on 2026-07-23:

- 20:14:27Z — leader sends a consultation request (message id 163)
- 20:16:16Z — the peer replies (message id 164)
- 20:16:17Z — the leader's own watcher attaches, **one second after the reply**, and seeds its fresh watermark at MAX(id) = 164

The reply was never pushed to the leader (it sat at the just-seeded watermark) and was only discovered by manually running `inbox.sh`. With `delivery.monitor.catchup` enabled, the attach would have drained it immediately.

## What counts as "unread at attach" (defined against the watermark model)

As #229 asks, the definition is fixed first and drives the implementation:

> Rows addressed to the watcher's subscription (team, to_agent) with `read_at IS NULL` **and `id <=` the just-seeded watermark**, drained only on a **fresh** attach (no persisted watermark existed at startup).

Consequences:

- **Reconnect never re-drains.** A restart with a persisted watermark takes the existing #107 gap-fill path (resume strictly after the last delivered id) and skips the drain entirely — so history is not replayed on every reconnect, the failure mode #229 warns about.
- **Drain and live stream are mutually exclusive.** The drain covers `id <= LAST`; the live loop covers `id > LAST`. A message that lands between watermark seeding and the drain query belongs to the live loop. Nothing is delivered twice.
- **Control messages (`ctrl:*`) are excluded.** They are live teardown directives; replaying a stale `ctrl:despawn` at attach could tear down a freshly spawned successor for the same role.
- **The drain does not advance `read_at`.** Streaming has never marked rows read (that is `inbox.sh`'s job on display); keeping that invariant makes this change purely additive on the delivery path.

## Gating and cap

- Opt-in via `AGMSG_WATCH_CATCHUP=1` (env wins) or `config.sh set delivery.monitor.catchup true`. Default OFF — the pinned "fresh session starts from now and does not replay history" test passes unchanged.
- Drained rows are capped (default 50, `AGMSG_WATCH_CATCHUP_CAP` as a tuning/test seam). When the backlog exceeds the cap, the **newest** rows are kept — recent context is what an attaching agent needs — and a single notice line reports how many older rows to fetch via `inbox.sh`.

## Relationship to #439 (live delivery marking `read_at`)

Independent but complementary. This PR does not depend on #439 and stands alone: it defines "unread at attach" purely against `read_at IS NULL` + the watermark, and deliberately does not mark drained rows read. If #439 lands, live-streamed messages start advancing `read_at`, which makes "unread" a more precise proxy for "never delivered" — the combination moves attach-time delivery close to exactly-once. Until then, the only overlap cost is that a drained-but-unread row may also appear in a later manual `inbox.sh` check, which is the current behavior for live-streamed rows too.

## Notes for review

- `config.sh`'s YAML helpers read one nesting level, so dotted keys round-trip as a flat `monitor.catchup:` entry under `delivery:` (same pre-existing behavior as `delivery.monitor.poll_interval`). The default template therefore documents the key with a comment only — no nested value line that `yaml_get` would never read. A parser extension felt out of scope for this PR.
- Bash 3.2 compatible (macOS default): no bash-4 expansions; the cap value is `10#`-normalized so a leading-zero override cannot kill the watcher via octal arithmetic.

## Tests

Six new bats tests in `tests/test_watch.bats` (all pass; existing watch-watermark suite 23/23 green locally):

1. catch-up ON drains queued unread on fresh attach, exactly once (live stream still works, no double delivery)
2. catch-up ON does not re-drain on reconnect with a persisted watermark
3. drain skips already-read messages
4. drain caps at the newest N with a notice
5. drain never replays control messages (stale `ctrl:despawn` does not tear down a fresh actas watcher)
6. enablement via the `delivery.monitor.catchup` config key

🤖 Generated with [Claude Code](https://claude.com/claude-code)
