### PR TITLE
fix(watch): fail loudly on shifted args instead of running with zero subscriptions

### DIFF
--- a/scripts/drivers/types/grok-build/_delivery.sh
+++ b/scripts/drivers/types/grok-build/_delivery.sh
@@ -69,6 +69,12 @@ EOF
       ;;
     monitor)
       mkdir -p "$(dirname "$rule_file")"
+      # The watch.sh command below passes "${GROK_SESSION_ID:--}" (sentinel `-`),
+      # NOT "$GROK_SESSION_ID": Grok's monitor tool re-evaluates the command
+      # line, and a quoted-but-empty expansion is dropped entirely there —
+      # shifting project/type/name one slot left and leaving the watcher
+      # subscribed to nothing. `-` survives the re-eval as a real argument and
+      # watch.sh folds it into its empty-session-id resolution path.
       cat <<EOF > "$rule_file"
 <!-- agmsg-delivery-mode: monitor -->
 # agmsg — keep a real-time inbox watcher running
@@ -94,7 +100,7 @@ it once:
 2. Start the watcher with the \`monitor\` tool (that exact tool — not
    \`run_terminal_command\`), persistent, so each new message streams into the
    conversation as a notification. Pass these three fields verbatim:
-   - command: \`$SKILL_DIR/scripts/watch.sh "\$GROK_SESSION_ID" '$project' $type\`
+   - command: \`$SKILL_DIR/scripts/watch.sh "\${GROK_SESSION_ID:--}" '$project' $type\`
    - description: \`agmsg inbox stream\`
    - persistent: true
    Use the command EXACTLY as written. Do NOT append \`| head\`, \`| tail\`, any
@@ -168,10 +174,12 @@ _agmsg_grok_emit_monitor_directive() {
 
   # Bake GROK_SESSION_ID in when it is set here, so the agent does not invent a
   # value and cleanup can find the pidfile. NOTE: Grok does NOT reliably export
-  # GROK_SESSION_ID into the `monitor` tool's own shell — the rule's literal
-  # "$GROK_SESSION_ID" can expand to empty there — so watch.sh self-generates a
-  # fallback id when its first arg is empty rather than failing. This directive
-  # path still bakes the real id when delivery.sh runs with it in the env.
+  # GROK_SESSION_ID into the `monitor` tool's own shell — that is why the rule
+  # passes "${GROK_SESSION_ID:--}": when unset it resolves to the sentinel `-`,
+  # which watch.sh folds into its empty-arg path and self-generates a fallback
+  # id rather than failing (a bare empty "" would be dropped by the re-eval and
+  # shift the remaining arguments). This directive path still bakes the real id
+  # when delivery.sh runs with it in the env.
   local session_id="${GROK_SESSION_ID:-}"
   if [ -z "$session_id" ]; then
     session_id="agmsg-$(compat_uuidgen | tr 'A-Z' 'a-z')"

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -88,7 +88,7 @@ Four possible outputs:
 
 **Ensure the monitor is running first (monitor mode only).** If the project's delivery mode is `monitor` (check via `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status grok-build "$(pwd)"`) and no `agmsg inbox stream` watcher is running in this session yet, invoke the `monitor` tool now (before the subcommand below):
 
-- command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "$GROK_SESSION_ID" "$(pwd)" grok-build`
+- command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "${GROK_SESSION_ID:--}" "$(pwd)" grok-build`
 - description: `agmsg inbox stream`
 - persistent: true
 
@@ -131,7 +131,7 @@ If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 4. **If delivery mode is `monitor`**, switch the watcher to the new role so receive is restricted to it:
    a. If an `agmsg inbox stream` watcher is already running in this session, stop it with `kill_command_or_subagent` on its task id.
    b. Launch a fresh watcher with the `monitor` tool (persistent):
-      - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "$GROK_SESSION_ID" "$(pwd)" grok-build <name>`
+      - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "${GROK_SESSION_ID:--}" "$(pwd)" grok-build <name>`
       - description: `agmsg inbox stream`
    The 4th argument restricts the subscription to messages addressed to `<name>` only. In `turn`/`off` mode there is no watcher to switch — skip this step.
 5. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
@@ -142,7 +142,7 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" grok-build <name>` to remove that role's registration.
 3. If the session's active FROM was `<name>`, clear that state.
 4. **If delivery mode is `monitor`** and an `agmsg inbox stream` watcher is running in this session, stop it with `kill_command_or_subagent`, then relaunch it with the `monitor` tool using the default (no 4th arg) subscription so receive covers the project's remaining roles:
-   - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "$GROK_SESSION_ID" "$(pwd)" grok-build`
+   - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "${GROK_SESSION_ID:--}" "$(pwd)" grok-build`
    - description: `agmsg inbox stream`
    - persistent: true
 5. Tell the user: "Dropped role `<name>` from this project."

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -36,8 +36,14 @@ source "$(cd "$(dirname "$0")" && pwd)/lib/compat.sh"
 # GROK_SESSION_ID). An empty first arg is tolerated and resolved below (after the
 # libs are sourced) rather than failing hard, so a runtime that cannot bake one
 # in — notably Grok Build's `monitor` tool, where "$GROK_SESSION_ID" expands to
-# empty — still starts the watcher. project_path and agent_type are required.
+# empty — still starts the watcher. A literal `-` first arg is the caller-side
+# sentinel for the same "no session id" case: some launcher shells re-evaluate
+# the command line and DROP a quoted-but-empty argument entirely (shifting every
+# later argument one slot left), so command templates pass
+# "${GROK_SESSION_ID:--}" and `-` is folded into the empty-arg path here.
+# project_path and agent_type are required.
 SESSION_ID="${1:-}"
+[ "$SESSION_ID" = "-" ] && SESSION_ID=""
 PROJECT_PATH="${2:?Missing project_path}"
 AGENT_TYPE="${3:?Missing agent_type}"
 ACTIVE_NAME="${4:-}"
@@ -49,6 +55,35 @@ source "$SCRIPT_DIR/lib/storage.sh"
 source "$SCRIPT_DIR/lib/actas-lock.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/resolve-project.sh"
+
+# Fail loudly on an unknown agent_type instead of running with zero
+# subscriptions. The dominant real-world cause is a shifted argument list: a
+# launcher shell that drops an empty first argument (see the session_id note
+# above) makes project_path land in $2 and agent_type receive whatever was in
+# $4 — typically an agent/role name. identities.sh then resolves nothing and,
+# without this guard, the watcher keeps polling forever while delivering
+# nothing: a silent zero-subscription outage that looks alive from the
+# outside. Same shape as the DB-open healthcheck (#197): one loud line on
+# stdout (the monitor event stream), then exit.
+#
+# Hot path stays free: a built-in type is confirmed by a single manifest stat
+# (path-segment names only — a name with '/' or '..' never confirms). Only a
+# non-builtin name pays for the registry (trusted external plugins can
+# legitimately add types), and the full type enumeration runs only in the
+# error message.
+_agmsg_type_confirmed=""
+case "$AGENT_TYPE" in
+  */*|*..*) ;;
+  *) [ -f "$SCRIPT_DIR/drivers/types/$AGENT_TYPE/type.conf" ] && _agmsg_type_confirmed=1 ;;
+esac
+if [ -z "$_agmsg_type_confirmed" ]; then
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/lib/type-registry.sh"
+  if ! agmsg_type_dir "$AGENT_TYPE" >/dev/null 2>&1; then
+    echo "ERROR: unknown agent type '$AGENT_TYPE' (supported: $(agmsg_known_types | sort -u | paste -sd, - | sed 's/,/, /g')). Arguments may have shifted: a caller shell can drop an empty session_id argument entirely. Pass the sentinel '-' (e.g. \"\${GROK_SESSION_ID:--}\") instead of an empty string."
+    exit 1
+  fi
+fi
 
 # Resolve a session id when the launcher could not bake one in (empty first arg).
 # Grok Build's `monitor` tool runs the watcher with $GROK_SESSION_ID unset, so

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -44,9 +44,19 @@ source "$(cd "$(dirname "$0")" && pwd)/lib/compat.sh"
 # project_path and agent_type are required.
 SESSION_ID="${1:-}"
 [ "$SESSION_ID" = "-" ] && SESSION_ID=""
-PROJECT_PATH="${2:?Missing project_path}"
-AGENT_TYPE="${3:?Missing agent_type}"
+PROJECT_PATH="${2:-}"
+AGENT_TYPE="${3:-}"
 ACTIVE_NAME="${4:-}"
+
+# Missing required args fail on STDOUT, not via ${n:?}: bash prints the :?
+# message to stderr, which the monitor tool consuming this stream never
+# surfaces — the launch would die invisibly. A short arg list is also how a
+# shifted three-argument launch (no active_name; empty session id dropped by
+# the caller shell, see above) presents, so name that cause here too.
+if [ -z "$PROJECT_PATH" ] || [ -z "$AGENT_TYPE" ]; then
+  echo "ERROR: watch.sh needs <session_id> <project_path> <agent_type> [active_name]; got $# argument(s). A caller shell may have dropped an empty session_id argument and shifted the rest. Pass the sentinel '-' (e.g. \"\${GROK_SESSION_ID:--}\") instead of an empty string."
+  exit 1
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -66,17 +76,20 @@ source "$SCRIPT_DIR/lib/resolve-project.sh"
 # outside. Same shape as the DB-open healthcheck (#197): one loud line on
 # stdout (the monitor event stream), then exit.
 #
-# Hot path stays free: a built-in type is confirmed by a single manifest stat
-# (path-segment names only — a name with '/' or '..' never confirms). Only a
-# non-builtin name pays for the registry (trusted external plugins can
-# legitimately add types), and the full type enumeration runs only in the
+# Hot path stays free: a built-in type is confirmed by a single manifest stat.
+# A name with '/' or '..' is rejected outright — it is never a type name, and
+# letting it reach the registry would concatenate it into a filesystem path
+# (e.g. '../types/claude-code' would resolve to a builtin manifest and pass).
+# Only a legitimate non-builtin name pays for the registry (trusted external
+# plugins can add types), and the full type enumeration runs only in the
 # error message.
-_agmsg_type_confirmed=""
 case "$AGENT_TYPE" in
-  */*|*..*) ;;
-  *) [ -f "$SCRIPT_DIR/drivers/types/$AGENT_TYPE/type.conf" ] && _agmsg_type_confirmed=1 ;;
+  */*|*..*)
+    echo "ERROR: invalid agent type '$AGENT_TYPE' (type names never contain '/' or '..'). Arguments may have shifted: a caller shell can drop an empty session_id argument entirely. Pass the sentinel '-' (e.g. \"\${GROK_SESSION_ID:--}\") instead of an empty string."
+    exit 1
+    ;;
 esac
-if [ -z "$_agmsg_type_confirmed" ]; then
+if [ ! -f "$SCRIPT_DIR/drivers/types/$AGENT_TYPE/type.conf" ]; then
   # shellcheck disable=SC1091
   source "$SCRIPT_DIR/lib/type-registry.sh"
   if ! agmsg_type_dir "$AGENT_TYPE" >/dev/null 2>&1; then

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -2078,6 +2078,10 @@ JSON
   [[ "$output" == *"agmsg-delivery-mode: monitor"* ]]
   [[ "$output" == *"monitor"* ]]
   [[ "$output" == *"watch.sh"* ]]
+  # The rule bakes the sentinel form, not a droppable empty expansion: grok's
+  # monitor tool re-evaluates the command line and deletes a quoted-but-empty
+  # "$GROK_SESSION_ID" argument, shifting every later argument one slot left.
+  [[ "$output" == *'watch.sh "${GROK_SESSION_ID:--}"'* ]]
 }
 
 @test "delivery status (grok-build): reports monitor when the monitor rule is present" {

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -490,6 +490,28 @@ _wait_pidfile() {
   ! ls "$TEST_SKILL_DIR/run"/watch.*.pid >/dev/null 2>&1
 }
 
+# A shifted THREE-argument launch (no active_name) leaves only two arguments.
+# The old ${3:?} guard died on stderr, which a monitor tool consuming stdout
+# never surfaces — the failure must land on stdout instead.
+@test "watch: shifted three-arg launch (missing agent_type) fails loudly on stdout" {
+  local out rc=0
+  out="$(bash "$SCRIPTS/watch.sh" "$PROJ" claude-code 2>/dev/null)" || rc=$?
+  [ "$rc" -ne 0 ]
+  [[ "$out" == *"ERROR: watch.sh needs"* ]]
+  [[ "$out" == *"shifted"* ]]
+  ! ls "$TEST_SKILL_DIR/run"/watch.*.pid >/dev/null 2>&1
+}
+
+# A path-like value in the type slot must be rejected outright, not fed to the
+# registry where it would concatenate into a filesystem path and could resolve
+# to a builtin manifest (e.g. ../types/claude-code).
+@test "watch: path-like agent type is rejected outright" {
+  run bash "$SCRIPTS/watch.sh" sid-path "$PROJ" "../types/claude-code"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ERROR: invalid agent type"* ]]
+  ! ls "$TEST_SKILL_DIR/run"/watch.*.pid >/dev/null 2>&1
+}
+
 # The caller-side companion of the guard above: command templates pass the
 # sentinel "-" ("${GROK_SESSION_ID:--}") instead of a droppable empty string.
 # watch.sh must fold "-" into the same generated-fallback path as "" (#236).

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -475,3 +475,38 @@ _wait_pidfile() {
   [ "$started" -eq 1 ]
   ! grep -q "Usage: watch.sh" "$out"
 }
+
+# Shifted-argument guard: some launcher shells (grok monitor tool re-eval) DROP
+# a quoted-but-empty first argument entirely, so the watcher is invoked as
+# `watch.sh <project> <type> <name>` — agent_type receives an agent name, the
+# subscription resolves to zero pairs, and pre-guard the watcher kept polling
+# silently while delivering nothing. It must fail loudly instead.
+@test "watch: shifted arguments (agent name in the type slot) fail loudly instead of running with zero subscriptions" {
+  run bash "$SCRIPTS/watch.sh" "$PROJ" claude-code alice
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ERROR: unknown agent type 'alice'"* ]]
+  [[ "$output" == *"shifted"* ]]
+  # It never armed: no pidfile was written for any derived id.
+  ! ls "$TEST_SKILL_DIR/run"/watch.*.pid >/dev/null 2>&1
+}
+
+# The caller-side companion of the guard above: command templates pass the
+# sentinel "-" ("${GROK_SESSION_ID:--}") instead of a droppable empty string.
+# watch.sh must fold "-" into the same generated-fallback path as "" (#236).
+@test "watch: sentinel '-' session_id resolves like an empty one" {
+  local out="$BATS_TEST_TMPDIR/dash-sid.out"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" - "$PROJ" claude-code alice >"$out" 2>&1 3>&- &
+  local pid=$!
+  # Folded to empty => a generated fallback id, so a watch.agmsg-*.pid appears.
+  local i started=0
+  for i in $(seq 1 25); do
+    if ls "$TEST_SKILL_DIR/run"/watch.agmsg-*.pid >/dev/null 2>&1; then started=1; break; fi
+    sleep 0.2
+  done
+  kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
+  [ "$started" -eq 1 ]
+  # No literal "-" session id leaked into the run dir key space.
+  ! ls "$TEST_SKILL_DIR/run"/watch.-*.pid >/dev/null 2>&1
+  ! grep -q "Usage: watch.sh" "$out"
+  ! grep -q "ERROR: unknown agent type" "$out"
+}


### PR DESCRIPTION
Related to #475 (and the launch path introduced in #236, refined by #245).

## Problem

A grok-build monitor watcher launched from the rule template can run with **zero subscriptions, silently**. The template bakes `watch.sh "$GROK_SESSION_ID" '<project>' grok-build` into the command line; grok's monitor tool re-evaluates that line in a shell where `GROK_SESSION_ID` is unset, and the quoted-but-empty expansion is **dropped as a word** — every later argument shifts one slot left. `watch.sh` then parses the project path as the session id, the type as the project, and the agent name as the type; `identities.sh` resolves no pairs, and the watcher polls forever delivering nothing. Observed in production (macOS zsh, v1.1.10-1-g5f8d0b7); full evidence in #475.

The existing empty-first-arg tolerance (#236) assumes the empty argument stays **positionally present**. It does not survive a caller shell that deletes the word entirely.

## Fix (two minimal layers)

1. **Caller side** — the grok-build templates (`_delivery.sh` monitor rule, `template.md` x3) now pass `"${GROK_SESSION_ID:--}"`. When unset, this yields the literal sentinel `-`, which survives re-evaluation as a real argument. `watch.sh` folds `-` into the existing empty-arg resolution path, so #236 behavior (self-generated fallback id) is preserved bit-for-bit.
2. **watch.sh defense** — validate `AGENT_TYPE` against the registered types (discovered dynamically, no hardcoded list) and **fail loudly** when it is unknown, with a message that names the shifted-args cause and the sentinel remedy. Follows the #197 healthcheck pattern: one line on stdout (the monitor event stream), then exit 1. This guards every caller, not just grok. Cost design: a built-in type is confirmed by a single `type.conf` stat (watch.sh launches are a hot path — `actas`/`drop`/SessionStart relaunch it routinely); only a non-builtin name loads the type registry (`agmsg_type_dir`, so trusted external plugin types still validate), and the full type enumeration runs only inside the error message. An earlier draft used `agmsg_is_known_type` unconditionally and measurably tightened the 1s timing window of the `excludes pairs held by another live session` test; the stat fast path restored it to green 8/8.

Auto-detecting the shift (path-looking `$1` + known-type `$2`) and re-shifting was considered and **rejected**: it stacks guessing on an already subtle launch path, and a loud error already surfaces the bug immediately with a precise remedy.

## Tests

Review follow-ups folded in (multi-model review, 2 rounds): a shifted **three**-argument launch (no active_name) leaves only two args and the old `${3:?}` guard died on **stderr** — invisible to a stdout-consuming monitor tool — so required-arg validation now fails explicitly on stdout; and a path-like value in the type slot (`../types/claude-code`) is rejected outright instead of reaching the registry where path concatenation could resolve it.

`tests/test_watch.bats`:
- shifted arguments (agent name in the type slot) exit non-zero with the unknown-agent-type error and never arm a pidfile;
- shifted three-arg launch (missing agent_type) fails loudly on stdout;
- path-like agent type is rejected outright;
- sentinel `-` resolves exactly like an empty session id (fallback `agmsg-*` pidfile appears, no `-`-keyed run files, no error).

`tests/test_delivery.bats`:
- the grok monitor rule bakes `watch.sh "${GROK_SESSION_ID:--}"` (regression guard for the caller-side layer).

Ran locally: the two new watch tests and all 7 grok-build delivery tests pass; pre-existing environment-specific failures in test_watch.bats (1, 2, 3, 5 — watcher-delivery timing under a live agent ancestor) fail identically on a clean upstream/main checkout with this branch's changes stashed, i.e. unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
