### PR TITLE
feat: add JSONL Stage-1 remote synchronization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -181,6 +181,7 @@ jobs:
           age_bin="$(go env GOPATH)/bin/age"
           AGMSG_AGE_BIN="$age_bin" node --test tests/sync_cipher.test.mjs
           AGMSG_AGE_BIN="$age_bin" bats --print-output-on-failure tests/test_sync_cipher.bats
+          AGMSG_AGE_BIN="$age_bin" bats --print-output-on-failure tests/test_jsonl_remote_sync.bats
           AGE_BIN="$age_bin" node docs/spec/vectors/verify-age-v1-vectors.mjs
 
   # Continuously verify that the storage contract is backend-portable: run the

--- a/docs/adr/0005-stage-1-remote-sync.md
+++ b/docs/adr/0005-stage-1-remote-sync.md
@@ -53,6 +53,34 @@ that preserves the driver's cursor space preserves the generation; replacement
 or reinitialization of that position space creates a new generation. This
 prevents a reused local position from inheriting stale remote state.
 
+### JSONL journal realization (Gate C)
+
+The bundled JSONL driver realizes the same contract without a mutable sidecar
+database. `events.jsonl` is the single append journal for local events and sync
+state. Its Stage-1 local position is the byte offset immediately after the
+originating top-level `message_sent` record, paired with a persistent file
+generation. This sync position is separate from the driver's ordinal delivery
+cursor.
+
+Every Stage-1 operation holds the existing `events.jsonl.lock`, reads a complete
+snapshot through its locked EOF, folds the immutable state records, and appends
+at most one complete transition record with one append write followed by
+`fsync`. Reservation, acknowledgement, quarantine/import outcomes, and the
+transport cursor therefore become durable together. A pull page is one
+`sync_pull_commit`; imported local events are nested in that record and the
+normal inbox/history projection exposes each first committed local event once.
+Replay commits carry no second local event.
+
+Compaction and local rename preserve every sync record and rotate the file
+generation because byte offsets may change. The replacement journal contains
+the new generation before its atomic rename, so there is no rewritten-file /
+old-generation crash window. Durable reservations retain their
+local-ID/wire-ID/envelope identity across that rewrite. Position aliases permit
+an acknowledgement already in flight for the preceding generation to reconcile
+the same reservation, while the current generation's position is used for the
+new contiguous push prefix. A rewrite never creates a new wire ID or envelope
+for an existing reservation.
+
 ### Prepare push
 
 `storage_sync_prepare_push` reads one `sync_prepare` JSONL record from stdin.
@@ -174,8 +202,9 @@ transport cursor automatically.
   synthesizing new wire identities.
 - The transport engine is backend-neutral, while each participating driver can
   make remote reconciliation atomic with its own local message store.
-- SQLite is the initial dogfood backend. JSONL remains local-only until it can
-  provide the same atomic import and cursor guarantees.
+- SQLite and JSONL implement the dogfood contract. JSONL uses its locked,
+  single-record append journal rather than emulating a mutable transaction
+  outside the driver.
 - The client downloads the whole team stream and projects recipients locally;
   the opaque envelope prevents server-side recipient routing.
 

--- a/docs/adr/0005-stage-1-remote-sync.md
+++ b/docs/adr/0005-stage-1-remote-sync.md
@@ -197,6 +197,12 @@ MUST reject a non-advancing, repeated, oversized, or malformed page. One explici
 reprocess invocation walks pages until `has_more=false`; permanently blocking
 records in an early page therefore cannot starve a later newly recoverable record.
 Transport cursor and driver generation MUST remain unchanged across the walk.
+Candidate rows and the page trailer MUST come from one storage snapshot. Across
+the complete walk, each `server_seq` occurs at most once. The engine bounds both
+candidate and page counts by the authenticated lifetime sequence space: the
+locally retained prefix through `min_available_seq` plus the available suffix
+through `current_seq` (with at most one final empty page). This keeps a corrupt
+driver from manufacturing an unbounded walk with ever-changing wire IDs.
 
 ADR 0009 promotes the previously reserved recovery operation behind a separate
 optional `stage1-resync` capability:

--- a/docs/adr/0005-stage-1-remote-sync.md
+++ b/docs/adr/0005-stage-1-remote-sync.md
@@ -22,14 +22,14 @@ never advance a cursor ahead of durable local state.
 
 ### Optional synchronization extension
 
-A storage driver may advertise the Stage-1 extension and implement these three
+A storage driver may advertise the Stage-1 extension and implement these four
 operations in addition to the ADR 0003 ABI:
 
 ```text
 storage_sync_prepare_push <local-team> <server-instance-id> <remote-team-id> <protocol-version> <limit>
 storage_sync_reconcile_push <local-team> <server-instance-id> <remote-team-id> <protocol-version>
 storage_sync_apply_pull <local-team> <server-instance-id> <remote-team-id> <protocol-version>
-storage_sync_reprocess <local-team> <server-instance-id> <remote-team-id> <protocol-version> <limit>
+storage_sync_reprocess <local-team> <server-instance-id> <remote-team-id> <protocol-version> <limit> [<page-after>]
 ```
 
 The SQLite driver is the Stage-1 implementation. Drivers that do not advertise
@@ -181,6 +181,22 @@ policy and installed identities, then passes the outcomes through apply-pull's
 existing atomic import transition. Reprocessing is explicit rather than part of
 every polling cycle, so a permanently invalid ciphertext cannot cause an
 automatic decrypt loop.
+
+Reprocess output is stable keyset pagination ordered by `(server_seq, wire_id)`.
+Each page contains at most `limit` `sync_reprocess_candidate` records and exactly
+one final `sync_reprocess_page` record:
+
+```json
+{"type":"sync_reprocess_page","next_after":"42:550e8400-e29b-41d4-a716-446655440000","has_more":true}
+```
+
+`next_after` is the canonical decimal server sequence, a colon, and the lowercase
+UUIDv4 wire ID of the last candidate. It is non-null exactly when `has_more` is
+true. The engine supplies it unchanged as the optional `page-after` argument and
+MUST reject a non-advancing, repeated, oversized, or malformed page. One explicit
+reprocess invocation walks pages until `has_more=false`; permanently blocking
+records in an early page therefore cannot starve a later newly recoverable record.
+Transport cursor and driver generation MUST remain unchanged across the walk.
 
 ADR 0009 promotes the previously reserved recovery operation behind a separate
 optional `stage1-resync` capability:

--- a/docs/remote-sync-dogfood.md
+++ b/docs/remote-sync-dogfood.md
@@ -131,5 +131,6 @@ on A only confirms its existing local-to-wire mapping and does not create a
 second local message.
 
 HTTP 410 (`resync-required`) is terminal. Stage 1 never rewinds or resets the
-transport cursor automatically. JSONL and other drivers that do not advertise
-`capabilities=stage1-sync` remain valid local-only drivers.
+transport cursor automatically. SQLite and JSONL advertise
+`capabilities=stage1-sync`; other drivers that do not advertise it remain valid
+local-only drivers.

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -310,7 +310,7 @@ may advertise `capabilities=stage1-sync` from `storage_describe` and implement:
 storage_sync_prepare_push <local-team> <server-instance-id> <remote-team-id> <protocol-version> <limit>
 storage_sync_reconcile_push <local-team> <server-instance-id> <remote-team-id> <protocol-version>
 storage_sync_apply_pull <local-team> <server-instance-id> <remote-team-id> <protocol-version>
-storage_sync_reprocess <local-team> <server-instance-id> <remote-team-id> <protocol-version> <limit>
+storage_sync_reprocess <local-team> <server-instance-id> <remote-team-id> <protocol-version> <limit> [<page-after>]
 ```
 
 The extension is optional: a driver without it remains a conforming local-only
@@ -332,7 +332,10 @@ prefix. Apply-pull atomically quarantines unchanged envelopes, reconciles mapped
 echoes or imports unmapped wire IDs once, and advances the transport cursor only
 after durable local outcomes. Transport, decrypt/import, and read progress are
 independent. Reprocess emits blocking quarantine records for explicit policy/key
-reevaluation without rewinding transport. The complete framing, record schemas,
+reevaluation without rewinding transport. It uses ADR 0005's stable
+`(server_seq,wire_id)` keyset page and mandatory `sync_reprocess_page` trailer,
+so one explicit engine invocation reaches every candidate without an early
+permanent failure starving later records. The complete framing, record schemas,
 crash boundaries, and future reserved operation names are defined by
 [ADR 0005](../adr/0005-stage-1-remote-sync.md).
 

--- a/docs/spec/driver-interface.md
+++ b/docs/spec/driver-interface.md
@@ -318,6 +318,10 @@ storage driver. Bulk input and output are UTF-8 JSONL on stdin/stdout; only the
 non-secret binding identifiers and limits above may use argv. The binding key
 is `(server_instance_id, remote_team_id, protocol_version)`, and every local
 position is additionally paired with the driver's persistent generation.
+The bundled SQLite and JSONL drivers advertise this capability. JSONL uses a
+locked snapshot through EOF plus one fsynced append record per transition; its
+sync local position is a byte offset paired with the file generation, not its
+separate ordinal delivery cursor.
 
 Prepare publishes a wire ID and complete canonical envelope together in one
 durable transaction before emitting it and is re-entrant by local position.

--- a/scripts/drivers/storage/jsonl-read-cursor.jq
+++ b/scripts/drivers/storage/jsonl-read-cursor.jq
@@ -1,4 +1,10 @@
-reduce .[] as $event (
+def logical_events:
+  .[]
+  | if .type == "sync_pull_commit" then
+      .messages[]? | select(.status == "imported") | .local_event // empty
+    else . end;
+
+reduce logical_events as $event (
   {sent: 0, addressed: [], read: {}};
   if $event.type == "message_sent" then
     .sent += 1

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -27,6 +27,7 @@
 # time so the optional duckdb path can read the query from a data file rather than
 # carry apostrophe-laden SQL inline (which the macOS bash 3.2 parser mis-handles).
 _JSONL_DRIVER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+_JSONL_SYNC_HELPER_DEFAULT="$_JSONL_DRIVER_DIR/../../internal/jsonl-sync.mjs"
 
 _jsonl_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 _jsonl_log() { printf '%s\n' "$(dirname "$(agmsg_db_path)")/events.jsonl"; }
@@ -61,10 +62,16 @@ _jsonl_read_cursor_migrate() {
   if [ -f "$marker" ]; then rmdir "$lock" 2>/dev/null || true; return 0; fi
   log="$(_jsonl_log)"; cursors="$(_jsonl_read_cursors)"
   tmp=$(mktemp "${cursors}.tmp.XXXXXX") || { rmdir "$lock" 2>/dev/null || true; return 1; }
-  tip=$(jq -s '[.[] | select(.type=="message_sent")] | length' "$log") || {
+  tip=$(jq -s 'def logical_events: .[] | if .type=="sync_pull_commit" then
+    .messages[]? | select(.status=="imported") | .local_event // empty else . end;
+    [logical_events | select(.type=="message_sent")] | length' "$log") || {
     rm -f "$tmp"; rmdir "$lock" 2>/dev/null || true; return 1;
   }
-  jq -r --argjson tip "$tip" -s '[.[] | select(.type=="message_sent") | [.team,.to]] | unique[] | @tsv + "\t" + ($tip|tostring)' "$log" > "$tmp" || { rm -f "$tmp"; rmdir "$lock" 2>/dev/null || true; return 1; }
+  jq -r --argjson tip "$tip" -s 'def logical_events: .[] |
+    if .type=="sync_pull_commit" then .messages[]? | select(.status=="imported") |
+      .local_event // empty else . end;
+    [logical_events | select(.type=="message_sent") | [.team,.to]] | unique[] |
+    @tsv + "\t" + ($tip|tostring)' "$log" > "$tmp" || { rm -f "$tmp"; rmdir "$lock" 2>/dev/null || true; return 1; }
   mv "$tmp" "$cursors" || { rm -f "$tmp"; rmdir "$lock" 2>/dev/null || true; return 1; }
   : > "$marker.tmp.$$" || { rmdir "$lock" 2>/dev/null || true; return 1; }
   mv "$marker.tmp.$$" "$marker" || { rm -f "$marker.tmp.$$"; rmdir "$lock" 2>/dev/null || true; return 1; }
@@ -97,7 +104,7 @@ PY
 }
 
 # Serialize all log mutations (append / mark / compact / import) behind a portable
-# mkdir lock; record-returning reads take a single file read as their snapshot.
+# mkdir lock; record-returning reads hold the same lock through their snapshot EOF.
 _jsonl_with_lock() {
   local lock i=0 rc=0 max="${AGMSG_JSONL_LOCK_TRIES:-1000}"
   lock="$(_jsonl_log).lock"
@@ -120,6 +127,10 @@ _jsonl_use_duckdb() {
   esac
   command -v duckdb >/dev/null 2>&1 || return 1
   local log sz; log="$(_jsonl_log)"
+  # Imported messages live inside one atomic sync_pull_commit journal record.
+  # The jq projection understands that nested record; the optional flat DuckDB
+  # query does not, so keep the correctness path once remote state is present.
+  grep -q '"type":"sync_pull_commit"' "$log" 2>/dev/null && return 1
   sz=$(wc -c < "$log" 2>/dev/null | tr -d ' ') || return 1
   [ "${sz:-0}" -ge "${AGMSG_JSONL_DUCKDB_BYTES:-5242880}" ]
 }
@@ -139,6 +150,7 @@ storage_describe() {
   printf 'name=jsonl\n'
   printf 'backend=append-only JSONL event log (jq; duckdb opt-in accelerator)\n'
   printf 'log=%s\n' "$(_jsonl_log)"
+  if _jsonl_sync_available; then printf 'capabilities=stage1-sync\n'; fi
 }
 
 storage_init() {
@@ -149,6 +161,44 @@ storage_init() {
 # Does a store already exist? (does NOT create one.) The log is the store, so a
 # read call-site can answer "no messages yet" without lazily creating events.jsonl.
 storage_store_exists() { [ -f "$(_jsonl_log)" ]; }
+
+# --- optional Stage-1 remote synchronization -------------------------------
+
+_jsonl_sync_node() {
+  printf '%s\n' "${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
+}
+
+_jsonl_sync_helper() {
+  printf '%s\n' "$_JSONL_SYNC_HELPER_DEFAULT"
+}
+
+_jsonl_sync_available() {
+  local node helper; node="$(_jsonl_sync_node)"; helper="$(_jsonl_sync_helper)"
+  [ -f "$helper" ] || return 1
+  if [ "${node#*/}" != "$node" ]; then [ -x "$node" ]; else command -v "$node" >/dev/null 2>&1; fi
+}
+
+_jsonl_sync_exec_locked() {
+  local operation="$1"; shift
+  local node helper; node="$(_jsonl_sync_node)"; helper="$(_jsonl_sync_helper)"
+  _jsonl_sync_available || return 10
+  "$node" "$helper" "$operation" "$(_jsonl_log)" "$@"
+}
+
+storage_sync_prepare_push() {
+  _jsonl_init_file || return 13
+  _jsonl_with_lock _jsonl_sync_exec_locked prepare "$@"
+}
+
+storage_sync_reconcile_push() {
+  _jsonl_init_file || return 13
+  _jsonl_with_lock _jsonl_sync_exec_locked reconcile "$@"
+}
+
+storage_sync_apply_pull() {
+  _jsonl_init_file || return 13
+  _jsonl_with_lock _jsonl_sync_exec_locked apply "$@"
+}
 
 # --- contract: messages -----------------------------------------------------
 
@@ -165,18 +215,39 @@ storage_send() {
 }
 _jsonl_append() { printf '%s\n' "$1" >> "$(_jsonl_log)"; }
 
+_jsonl_prepare_rotated_generation_locked() {
+  local target="$1" log; log="$(_jsonl_log)"
+  grep -q '"type":"sync_generation"' "$log" 2>/dev/null || return 0
+  local node helper; node="$(_jsonl_sync_node)"; helper="$(_jsonl_sync_helper)"
+  _jsonl_sync_available || return 10
+  "$node" "$helper" rotate-generation "$target" >/dev/null
+}
+
 storage_list_unread() {
+  _jsonl_init_file || return 1
+  _jsonl_with_lock _jsonl_list_unread_locked "$@"
+}
+
+_jsonl_list_unread_locked() {
   local team="$1" agent="$2" limit=""
   shift 2
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac
-  _jsonl_init_file
   local log out cursor; log="$(_jsonl_log)"
   cursor=$(storage_read_cursor_get "$team" "$agent") || return 1
   if _jsonl_use_duckdb; then
     out="$(_jsonl_unread_duckdb "$team" "$agent" "$log" "$cursor")" || return 1
   else
-    out="$(jq -c --arg team "$team" --arg agent "$agent" --argjson cursor "$cursor" -s '(reduce .[] as $e ({}; if $e.type=="message_read" and $e.team==$team and $e.agent==$agent then .[$e.msg_id]=true else . end)) as $read | [.[] | select(.type=="message_sent")] | to_entries[] | select((.key + 1) > $cursor and .value.team==$team and .value.to==$agent and ($read[.value.id] | not)) | .value | {type:"message_sent",id:.id,team:.team,from:.from,to:.to,body:.body,at:.at}' "$log")" || return 1
+    out="$(jq -c --arg team "$team" --arg agent "$agent" --argjson cursor "$cursor" -s '
+      def logical_events: .[] | if .type=="sync_pull_commit" then
+    .messages[]? | select(.status=="imported") | .local_event // empty else . end;
+      [logical_events] as $events |
+      (reduce $events[] as $e ({}; if $e.type=="message_read" and
+        $e.team==$team and $e.agent==$agent then .[$e.msg_id]=true else . end)) as $read |
+      [$events[] | select(.type=="message_sent")] | to_entries[] |
+      select((.key + 1) > $cursor and .value.team==$team and .value.to==$agent and
+        ($read[.value.id] | not)) | .value |
+      {type:"message_sent",id:.id,team:.team,from:.from,to:.to,body:.body,at:.at}' "$log")" || return 1
   fi
   [ -n "$out" ] || return 0
   if [ -n "$limit" ]; then printf '%s\n' "$out" | head -n "$limit"; else printf '%s\n' "$out"; fi
@@ -233,7 +304,9 @@ _jsonl_read_cursor_consume_locked() {
   current=$(storage_read_cursor_get "$team" "$agent") || return 1
   _jsonl_mark "$team" "$agent" "$@" || return 1
   log="$(_jsonl_log)"
-  tip=$(jq -s '[.[] | select(.type=="message_sent")] | length' "$log") || return 1
+  tip=$(jq -s 'def logical_events: .[] | if .type=="sync_pull_commit" then
+    .messages[]? | select(.status=="imported") | .local_event // empty else . end;
+    [logical_events | select(.type=="message_sent")] | length' "$log") || return 1
   # Cap against the same locked log snapshot. Compare canonical decimal strings
   # instead of shell integers so a maliciously huge target cannot overflow the
   # host shell before it is reduced to the real tip.
@@ -288,22 +361,34 @@ _jsonl_mark() {
 # --- contract: watch (delivery cursor §2.2) ---------------------------------
 
 storage_watch_tip() {
-  _jsonl_init_file
+  _jsonl_init_file || return 1
+  _jsonl_with_lock _jsonl_watch_tip_locked
+}
+
+_jsonl_watch_tip_locked() {
   # An empty log makes jq return 0 with exit 0; a CORRUPT log makes jq fail, and
   # that must surface as a non-zero exit (data-op framing §2.1) — no `|| echo 0`
   # fallback that would mask a broken store as a fresh tip of 0.
-  jq -s '[.[] | select(.type=="message_sent")] | length' "$(_jsonl_log)"
+  jq -s 'def logical_events: .[] | if .type=="sync_pull_commit" then
+    .messages[]? | select(.status=="imported") | .local_event // empty else . end;
+    [logical_events | select(.type=="message_sent")] | length' "$(_jsonl_log)"
 }
 
 storage_watch_after() {
+  _jsonl_init_file || return 1
+  _jsonl_with_lock _jsonl_watch_after_locked "$@"
+}
+
+_jsonl_watch_after_locked() {
   local cursor="$1"; shift
   case "$cursor" in ''|*[!0-9]*) cursor=0 ;; esac
-  _jsonl_init_file
   local pairs_json; pairs_json="$(printf '%s\n' "$@" | jq -Rsc 'split("\n") | map(select(length>0))')"
   # One file read = one snapshot: the trailing cursor (total message_sent count)
   # is computed from the same scan, so it never runs ahead of the rows returned.
   jq -c --argjson cursor "$cursor" --argjson pairs "$pairs_json" -s '
-    . as $events
+    def logical_events: .[] | if .type=="sync_pull_commit" then
+    .messages[]? | select(.status=="imported") | .local_event // empty else . end;
+    [logical_events] as $events
     | (reduce $events[] as $event ({};
         if $event.type=="message_read" then
           .[([$event.team,$event.agent,$event.msg_id] | tojson)] = true
@@ -323,14 +408,20 @@ storage_watch_after() {
 # --- contract: history ------------------------------------------------------
 
 storage_history() {
+  _jsonl_init_file || return 1
+  _jsonl_with_lock _jsonl_history_locked "$@"
+}
+
+_jsonl_history_locked() {
   local team="$1"; shift
   local agent="" limit=""
   if [ $# -gt 0 ] && [ "${1#-}" = "$1" ]; then agent="$1"; shift; fi
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="-1" ;; esac
-  _jsonl_init_file
   jq -c --arg team "$team" --arg agent "$agent" --argjson limit "$limit" -s '
-    [.[] | select(.type=="message_sent" and .team==$team
+    def logical_events: .[] | if .type=="sync_pull_commit" then
+    .messages[]? | select(.status=="imported") | .local_event // empty else . end;
+    [logical_events | select(.type=="message_sent" and .team==$team
             and ($agent=="" or .to==$agent or .from==$agent))
      | {type:"message_sent",id:.id,team:.team,from:.from,to:.to,body:.body,at:.at}]
     | (if $limit >= 0 and (length > $limit) then .[length-$limit:] else . end)
@@ -341,10 +432,17 @@ storage_history() {
 # --- contract: export / import / compact ------------------------------------
 
 storage_export() {
-  _jsonl_init_file
+  _jsonl_init_file || return 1
+  _jsonl_with_lock _jsonl_export_locked "$@"
+}
+
+_jsonl_export_locked() {
   # Forward-compat (§2.3): only the v1 event types are projected; unknown types
   # are dropped rather than leaked.
-  jq -c 'select(.type=="message_sent" or .type=="message_read")' "$(_jsonl_log)" > "$1"
+  jq -c -s 'def logical_events: .[] | if .type=="sync_pull_commit" then
+    .messages[]? | select(.status=="imported") | .local_event // empty else . end;
+    logical_events | select(.type=="message_sent" or .type=="message_read")' \
+    "$(_jsonl_log)" > "$1"
 }
 
 storage_import() {
@@ -375,7 +473,11 @@ _jsonl_rename_agent_locked() {
     rm -f "$log_tmp" "$dual_tmp"; return 1;
   }
   jq -c --arg team "$team" --arg old "$old" --arg new "$new" '
-    if .team != $team then .
+    if .type == "sync_pull_commit" then
+      .messages |= map(if .local_event != null and .local_event.team == $team then
+        .local_event |= ((if .from == $old then .from = $new else . end) |
+          (if .to == $old then .to = $new else . end)) else . end)
+    elif .team != $team then .
     elif .type == "message_sent" then
       (if .from == $old then .from = $new else . end) |
       (if .to == $old then .to = $new else . end)
@@ -383,6 +485,9 @@ _jsonl_rename_agent_locked() {
     else . end' "$log" > "$log_tmp" || {
       rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1;
     }
+  _jsonl_prepare_rotated_generation_locked "$log_tmp" || {
+    rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1;
+  }
   awk -F '\t' -v OFS='\t' -v team="$team" -v old="$old" -v new="$new" '
     $1==team && $2==old { print; $2=new; print; next } { print }' "$cursors" > "$dual_tmp" || {
       rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1;
@@ -412,8 +517,16 @@ _jsonl_rename_team_locked() {
   clean_tmp=$(mktemp "${cursors}.rename-clean.XXXXXX") || {
     rm -f "$log_tmp" "$dual_tmp"; return 1;
   }
-  jq -c --arg old "$old" --arg new "$new" 'if .team == $old then .team = $new else . end' \
+  jq -c --arg old "$old" --arg new "$new" '
+    if .binding.local_team == $old then .binding.local_team = $new else . end |
+    if .type == "sync_pull_commit" then
+      .messages |= map(if .local_event != null and .local_event.team == $old then
+        .local_event.team = $new else . end)
+    elif .team == $old then .team = $new else . end' \
     "$log" > "$log_tmp" || { rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1; }
+  _jsonl_prepare_rotated_generation_locked "$log_tmp" || {
+    rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1;
+  }
   awk -F '\t' -v OFS='\t' -v old="$old" -v new="$new" '
     $1==old { print; $1=new; print; next } { print }' "$cursors" > "$dual_tmp" || {
       rm -f "$log_tmp" "$dual_tmp" "$clean_tmp"; return 1;
@@ -441,6 +554,7 @@ _jsonl_compact_do() {
   # single-quoted jq string in this position desyncs the macOS system bash 3.2
   # parser and breaks the rest of the file (a no-error `bash -n`, but a real
   # source failure). Keep new jq one-liners here.
-  jq -c -s 'reduce .[] as $e ({out:[], seen:{}}; if $e.type=="message_sent" then .out += [$e] elif $e.type=="message_read" then ([$e.team,$e.agent,$e.msg_id]|tojson) as $k | if .seen[$k] then . else .seen[$k]=true | .out += [$e] end else . end) | .out[]' "$log" > "$tmp" || { rm -f "$tmp"; return 1; }
-  mv "$tmp" "$log"
+  jq -c -s 'reduce .[] as $e ({out:[], seen:{}}; if $e.type=="message_read" then ([$e.team,$e.agent,$e.msg_id]|tojson) as $k | if .seen[$k] then . else .seen[$k]=true | .out += [$e] end else .out += [$e] end) | .out[]' "$log" > "$tmp" || { rm -f "$tmp"; return 1; }
+  _jsonl_prepare_rotated_generation_locked "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$log" || { rm -f "$tmp"; return 1; }
 }

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -222,7 +222,7 @@ _jsonl_append() { printf '%s\n' "$1" >> "$(_jsonl_log)"; }
 
 _jsonl_prepare_rotated_generation_locked() {
   local target="$1" log; log="$(_jsonl_log)"
-  grep -q '"type":"sync_generation"' "$log" 2>/dev/null || return 0
+  grep -Eq '"type":"sync_generation"|"driver_generation":' "$log" 2>/dev/null || return 0
   local node helper; node="$(_jsonl_sync_node)"; helper="$(_jsonl_sync_helper)"
   _jsonl_sync_available || return 10
   "$node" "$helper" rotate-generation "$target" >/dev/null

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -121,16 +121,16 @@ _jsonl_with_lock() {
 # is byte-size based (file-direct I/O is size-bound, FINDINGS.md): ~5 MB ≈ tens of
 # thousands of events. AGMSG_JSONL_ENGINE=jq|duckdb forces a choice (tests/bench).
 _jsonl_use_duckdb() {
+  local log sz; log="$(_jsonl_log)"
+  # Imported messages live inside one atomic sync_pull_commit journal record.
+  # The jq projection understands that nested record; the optional flat DuckDB
+  # query does not. This correctness guard also overrides a forced engine.
+  grep -q '"type":"sync_pull_commit"' "$log" 2>/dev/null && return 1
   case "${AGMSG_JSONL_ENGINE:-}" in
     jq) return 1 ;;
     duckdb) command -v duckdb >/dev/null 2>&1 && return 0 || return 1 ;;
   esac
   command -v duckdb >/dev/null 2>&1 || return 1
-  local log sz; log="$(_jsonl_log)"
-  # Imported messages live inside one atomic sync_pull_commit journal record.
-  # The jq projection understands that nested record; the optional flat DuckDB
-  # query does not, so keep the correctness path once remote state is present.
-  grep -q '"type":"sync_pull_commit"' "$log" 2>/dev/null && return 1
   sz=$(wc -c < "$log" 2>/dev/null | tr -d ' ') || return 1
   [ "${sz:-0}" -ge "${AGMSG_JSONL_DUCKDB_BYTES:-5242880}" ]
 }
@@ -198,6 +198,11 @@ storage_sync_reconcile_push() {
 storage_sync_apply_pull() {
   _jsonl_init_file || return 13
   _jsonl_with_lock _jsonl_sync_exec_locked apply "$@"
+}
+
+storage_sync_reprocess() {
+  _jsonl_init_file || return 13
+  _jsonl_with_lock _jsonl_sync_exec_locked reprocess "$@"
 }
 
 # --- contract: messages -----------------------------------------------------

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -772,19 +772,9 @@ storage_sync_reprocess() {
     FROM sync_bindings WHERE local_team='$tl' AND server_instance_id='$server'
       AND remote_team_id='$remote' AND protocol_version=$protocol
       AND driver_generation='$generation';
-    SELECT json_object('type','sync_reprocess_candidate','server_seq',server_seq,
-      'id',wire_id,'server_received_at',server_received_at,
-      'envelope',json_object('v',envelope_v,'cipher',cipher,'key_id',key_id,'blob',blob),
-      'prior_status',status)
-    FROM sync_quarantine WHERE local_team='$tl' AND server_instance_id='$server'
-      AND remote_team_id='$remote' AND protocol_version=$protocol
-      AND driver_generation='$generation'
-      AND status IN ('unsupported_cipher','pending_key','authentication_failed',
-                     'malformed','policy_violation')
-      $after_sql
-    ORDER BY CAST(server_seq AS INTEGER),wire_id LIMIT $limit;
     WITH candidates AS (
-      SELECT server_seq,wire_id FROM sync_quarantine
+      SELECT server_seq,wire_id,server_received_at,envelope_v,cipher,key_id,blob,status
+        FROM sync_quarantine
        WHERE local_team='$tl' AND server_instance_id='$server'
          AND remote_team_id='$remote' AND protocol_version=$protocol
          AND driver_generation='$generation'
@@ -792,13 +782,26 @@ storage_sync_reprocess() {
                         'malformed','policy_violation')
          $after_sql
        ORDER BY CAST(server_seq AS INTEGER),wire_id LIMIT $((limit + 1))
+    ), output AS (
+      SELECT 0 AS trailer,CAST(server_seq AS INTEGER) AS sequence_order,wire_id,
+        json_object('type','sync_reprocess_candidate','server_seq',server_seq,
+          'id',wire_id,'server_received_at',server_received_at,
+          'envelope',json_object('v',envelope_v,'cipher',cipher,'key_id',key_id,'blob',blob),
+          'prior_status',status) AS record
+      FROM candidates ORDER BY CAST(server_seq AS INTEGER),wire_id LIMIT $limit
+    ), trailer AS (
+      SELECT 1 AS trailer,NULL AS sequence_order,NULL AS wire_id,
+        json_object('type','sync_reprocess_page','next_after',
+          CASE WHEN COUNT(*)>$limit THEN (
+            SELECT server_seq||':'||wire_id FROM candidates
+             ORDER BY CAST(server_seq AS INTEGER),wire_id LIMIT 1 OFFSET $((limit - 1)))
+            ELSE NULL END,
+          'has_more',CASE WHEN COUNT(*)>$limit THEN json('true') ELSE json('false') END
+        ) AS record
+      FROM candidates
     )
-    SELECT json_object('type','sync_reprocess_page','next_after',
-      CASE WHEN COUNT(*)>$limit THEN (
-        SELECT server_seq||':'||wire_id FROM candidates LIMIT 1 OFFSET $((limit - 1)))
-        ELSE NULL END,
-      'has_more',CASE WHEN COUNT(*)>$limit THEN json('true') ELSE json('false') END)
-    FROM candidates;"
+    SELECT record FROM (SELECT * FROM output UNION ALL SELECT * FROM trailer)
+     ORDER BY trailer,sequence_order,wire_id;"
 }
 
 # Derive the remote read frontier and exact wire exceptions from durable local

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -748,12 +748,22 @@ storage_sync_apply_pull() {
 # This never changes the transport cursor; apply performs any resulting state
 # transition atomically against that already-advanced cursor.
 storage_sync_reprocess() {
-  local team="$1" server="$2" remote="$3" protocol="$4" limit="$5"
+  local team="$1" server="$2" remote="$3" protocol="$4" limit="$5" after="${6:-}"
   _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
   case "$limit" in ''|*[!0-9]*) return 13 ;; esac
   [ "$limit" -ge 1 ] && [ "$limit" -le 1000 ] || return 13
   _sqlite_sync_schema || return $?
-  local generation tl
+  local generation tl after_seq after_wire after_sql=""
+  if [ -n "$after" ]; then
+    case "$after" in *:*) ;; *) return 13 ;; esac
+    after_seq="${after%%:*}"; after_wire="${after#*:}"
+    case "$after_seq" in ''|*[!0-9]*) return 13 ;; esac
+    [ "$after_seq" = 0 ] || [ "${after_seq#0}" = "$after_seq" ] || return 13
+    [ "$after_seq" -le 9223372036854775807 ] 2>/dev/null || return 13
+    printf '%s' "$after_wire" | grep -Eq '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' || return 13
+    after_sql="AND (CAST(server_seq AS INTEGER)>$after_seq OR
+      (CAST(server_seq AS INTEGER)=$after_seq AND wire_id>'$after_wire'))"
+  fi
   generation=$(_sqlite_sync_generation) || return 13
   tl=$(_sqlite_lit "$team")
   _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || return 13
@@ -771,7 +781,24 @@ storage_sync_reprocess() {
       AND driver_generation='$generation'
       AND status IN ('unsupported_cipher','pending_key','authentication_failed',
                      'malformed','policy_violation')
-    ORDER BY CAST(server_seq AS INTEGER),wire_id LIMIT $limit;"
+      $after_sql
+    ORDER BY CAST(server_seq AS INTEGER),wire_id LIMIT $limit;
+    WITH candidates AS (
+      SELECT server_seq,wire_id FROM sync_quarantine
+       WHERE local_team='$tl' AND server_instance_id='$server'
+         AND remote_team_id='$remote' AND protocol_version=$protocol
+         AND driver_generation='$generation'
+         AND status IN ('unsupported_cipher','pending_key','authentication_failed',
+                        'malformed','policy_violation')
+         $after_sql
+       ORDER BY CAST(server_seq AS INTEGER),wire_id LIMIT $((limit + 1))
+    )
+    SELECT json_object('type','sync_reprocess_page','next_after',
+      CASE WHEN COUNT(*)>$limit THEN (
+        SELECT server_seq||':'||wire_id FROM candidates LIMIT 1 OFFSET $((limit - 1)))
+        ELSE NULL END,
+      'has_more',CASE WHEN COUNT(*)>$limit THEN json('true') ELSE json('false') END)
+    FROM candidates;"
 }
 
 # Derive the remote read frontier and exact wire exceptions from durable local

--- a/scripts/internal/jsonl-sync.mjs
+++ b/scripts/internal/jsonl-sync.mjs
@@ -185,13 +185,15 @@ function fold(records, target) {
   for (const { value } of records) {
     if (!sameBinding(value, target)) continue;
     if (value.type === "sync_prepare_commit") {
-      if (!Array.isArray(value.reservations) || !Array.isArray(value.conflicts)) {
+      if (!Array.isArray(value.reservations) ||
+          (value.conflicts !== undefined && !Array.isArray(value.conflicts))) {
         fail("JSONL reservation commit is invalid");
       }
-      applyConflicts(value.conflicts);
+      applyConflicts(value.conflicts ?? []);
       for (const reservation of value.reservations ?? []) {
         if (!UUID_V4.test(reservation.id) || typeof reservation.local_id !== "string" ||
-            !/^[0-9a-f]{64}$/u.test(reservation.payload_digest) ||
+            (reservation.payload_digest !== undefined &&
+              !/^[0-9a-f]{64}$/u.test(reservation.payload_digest)) ||
             !reservation.envelope || typeof reservation.driver_generation !== "string") {
           fail("JSONL reservation is invalid");
         }
@@ -199,7 +201,9 @@ function fold(records, target) {
         const priorLocal = reservationsByLocalId.get(reservation.local_id);
         const priorWire = reservationsByWire.get(reservation.id);
         if ((priorLocal && (priorLocal.id !== reservation.id ||
-              priorLocal.payload_digest !== reservation.payload_digest ||
+              (priorLocal.payload_digest !== undefined &&
+                reservation.payload_digest !== undefined &&
+                priorLocal.payload_digest !== reservation.payload_digest) ||
               !envelopeEqual(priorLocal.envelope, reservation.envelope))) ||
             (priorWire && (priorWire.local_id !== reservation.local_id ||
               !envelopeEqual(priorWire.envelope, reservation.envelope)))) {
@@ -217,7 +221,8 @@ function fold(records, target) {
       }
       applyConflicts(value.conflicts);
     } else if (value.type === "sync_reconcile_commit") {
-      if (!Array.isArray(value.acks) || !Array.isArray(value.conflicts)) {
+      if (!Array.isArray(value.acks) ||
+          (value.conflicts !== undefined && !Array.isArray(value.conflicts))) {
         fail("JSONL acknowledgement commit is invalid");
       }
       sequence(value.push_cursor, "stored push_cursor");
@@ -235,7 +240,7 @@ function fold(records, target) {
         acknowledgements.set(ack.id, ack);
         wireBySequence.set(ack.server_seq, ack.id);
       }
-      applyConflicts(value.conflicts);
+      applyConflicts(value.conflicts ?? []);
     } else if (value.type === "sync_pull_commit") {
       sequence(value.transport_cursor, "stored transport_cursor");
       if (BigInt(value.transport_cursor) < BigInt(transportCursor) || !Array.isArray(value.messages)) {
@@ -349,7 +354,7 @@ function prepare(path, target, limit, inputText) {
     const existing = state.reservationsByLocalId.get(message.local_id);
     if (existing && !state.acknowledgements.has(existing.id)) {
       const rebound = { ...existing, driver_generation: generation,
-        local_position: message.local_position };
+        local_position: message.local_position, payload_digest: payloadDigest };
       pending.push(rebound);
       if (existing.driver_generation !== generation ||
           existing.local_position !== message.local_position) newReservations.push(rebound);
@@ -568,6 +573,7 @@ function afterReprocessToken(message, after) {
 }
 
 function reprocess(path, target, limit, afterText) {
+  const after = parseReprocessToken(afterText);
   let records = readRecords(path);
   let generation = storedGeneration(records);
   if (!generation) {
@@ -578,7 +584,6 @@ function reprocess(path, target, limit, afterText) {
     records = readRecords(path);
   }
   const state = fold(records, target);
-  const after = parseReprocessToken(afterText);
   process.stdout.write(`${JSON.stringify({ type: "sync_state", driver_generation: generation,
     transport_cursor: state.transportCursor })}\n`);
   const eligible = [...state.quarantineByWire.values()]

--- a/scripts/internal/jsonl-sync.mjs
+++ b/scripts/internal/jsonl-sync.mjs
@@ -125,21 +125,22 @@ function localPayloadDigest(message) {
   return hash.digest("hex");
 }
 
-function currentGeneration(records, path) {
+function storedGeneration(records) {
   let generation = null;
   for (const { value } of records) {
-    if (value.type === "sync_generation") {
-      if (!UUID_V4.test(value.generation) && !UUID_V7.test(value.generation)) {
+    const candidate = value.type === "sync_generation" ? value.generation : value.driver_generation;
+    if (candidate !== undefined) {
+      if (!UUID_V4.test(candidate) && !UUID_V7.test(candidate)) {
         fail("JSONL sync generation is invalid");
       }
-      generation = value.generation;
+      generation = candidate;
     }
   }
-  if (generation) return generation;
-  generation = randomUUID();
-  appendRecord(path, { type: "sync_generation", generation,
-    created_at: new Date().toISOString() });
   return generation;
+}
+
+function currentGeneration(records) {
+  return storedGeneration(records) ?? randomUUID();
 }
 
 function fold(records, target) {
@@ -152,11 +153,42 @@ function fold(records, target) {
   const conflictsByLocalId = new Map();
   const conflictsByWire = new Map();
   let transportCursor = "0";
-  let durablePushCursor = "0";
+  const applyConflicts = (conflicts) => {
+    if (!Array.isArray(conflicts)) fail("JSONL conflict list is invalid");
+    for (const conflict of conflicts) {
+      if (conflict?.kind === "local_payload_conflict" &&
+          conflict.status === "corrupt_state" &&
+          typeof conflict.local_id === "string" &&
+          /^[0-9a-f]{64}$/u.test(conflict.expected_digest) &&
+          /^[0-9a-f]{64}$/u.test(conflict.observed_digest) &&
+          conflict.expected_digest !== conflict.observed_digest) {
+        conflictsByLocalId.set(conflict.local_id, conflict);
+      } else if (conflict?.kind === "ack_sequence_conflict" &&
+          conflict.status === "corrupt_state" && UUID_V4.test(conflict.id)) {
+        sequence(conflict.expected_server_seq, "conflict expected_server_seq");
+        sequence(conflict.observed_server_seq, "conflict observed_server_seq");
+        if (conflict.expected_server_seq === conflict.observed_server_seq) {
+          fail("JSONL acknowledgement conflict is not conflicting");
+        }
+        conflictsByWire.set(conflict.id, conflict);
+      } else if (conflict?.kind === "ack_wire_conflict" &&
+          conflict.status === "corrupt_state" &&
+          UUID_V4.test(conflict.id) && UUID_V4.test(conflict.expected_id) &&
+          conflict.id !== conflict.expected_id) {
+        sequence(conflict.server_seq, "conflict server_seq");
+        conflictsByWire.set(conflict.id, conflict);
+      } else {
+        fail("JSONL conflict is invalid");
+      }
+    }
+  };
   for (const { value } of records) {
     if (!sameBinding(value, target)) continue;
     if (value.type === "sync_prepare_commit") {
-      if (!Array.isArray(value.reservations)) fail("JSONL reservation commit is invalid");
+      if (!Array.isArray(value.reservations) || !Array.isArray(value.conflicts)) {
+        fail("JSONL reservation commit is invalid");
+      }
+      applyConflicts(value.conflicts);
       for (const reservation of value.reservations ?? []) {
         if (!UUID_V4.test(reservation.id) || typeof reservation.local_id !== "string" ||
             !/^[0-9a-f]{64}$/u.test(reservation.payload_digest) ||
@@ -183,38 +215,12 @@ function fold(records, target) {
       if (!Array.isArray(value.conflicts) || value.conflicts.length < 1) {
         fail("JSONL conflict commit is invalid");
       }
-      for (const conflict of value.conflicts) {
-        if (conflict?.kind === "local_payload_conflict" &&
-            conflict.status === "corrupt_state" &&
-            typeof conflict.local_id === "string" &&
-            /^[0-9a-f]{64}$/u.test(conflict.expected_digest) &&
-            /^[0-9a-f]{64}$/u.test(conflict.observed_digest) &&
-            conflict.expected_digest !== conflict.observed_digest) {
-          conflictsByLocalId.set(conflict.local_id, conflict);
-        } else if (conflict?.kind === "ack_sequence_conflict" &&
-            conflict.status === "corrupt_state" && UUID_V4.test(conflict.id)) {
-          sequence(conflict.expected_server_seq, "conflict expected_server_seq");
-          sequence(conflict.observed_server_seq, "conflict observed_server_seq");
-          if (conflict.expected_server_seq === conflict.observed_server_seq) {
-            fail("JSONL acknowledgement conflict is not conflicting");
-          }
-          conflictsByWire.set(conflict.id, conflict);
-        } else if (conflict?.kind === "ack_wire_conflict" &&
-            conflict.status === "corrupt_state" &&
-            UUID_V4.test(conflict.id) && UUID_V4.test(conflict.expected_id) &&
-            conflict.id !== conflict.expected_id) {
-          sequence(conflict.server_seq, "conflict server_seq");
-          conflictsByWire.set(conflict.id, conflict);
-        } else {
-          fail("JSONL conflict is invalid");
-        }
-      }
+      applyConflicts(value.conflicts);
     } else if (value.type === "sync_reconcile_commit") {
-      if (!Array.isArray(value.acks)) fail("JSONL acknowledgement commit is invalid");
-      sequence(value.push_cursor, "stored push_cursor");
-      if (BigInt(value.push_cursor) < BigInt(durablePushCursor)) {
-        fail("JSONL push cursor moves backwards");
+      if (!Array.isArray(value.acks) || !Array.isArray(value.conflicts)) {
+        fail("JSONL acknowledgement commit is invalid");
       }
+      sequence(value.push_cursor, "stored push_cursor");
       for (const ack of value.acks) {
         sequence(ack.server_seq, "stored acknowledgement server_seq");
         sequence(ack.local_position, "stored acknowledgement local_position");
@@ -229,7 +235,7 @@ function fold(records, target) {
         acknowledgements.set(ack.id, ack);
         wireBySequence.set(ack.server_seq, ack.id);
       }
-      durablePushCursor = value.push_cursor;
+      applyConflicts(value.conflicts);
     } else if (value.type === "sync_pull_commit") {
       sequence(value.transport_cursor, "stored transport_cursor");
       if (BigInt(value.transport_cursor) < BigInt(transportCursor) || !Array.isArray(value.messages)) {
@@ -272,7 +278,7 @@ function fold(records, target) {
   }
   return { reservationsByLocalId, reservationsByWire, acknowledgements,
     reservationPositionsByWire, quarantineByWire, wireBySequence, transportCursor,
-    conflictsByLocalId, conflictsByWire, durablePushCursor };
+    conflictsByLocalId, conflictsByWire };
 }
 
 function localMessages(records, localTeam) {
@@ -282,12 +288,10 @@ function localMessages(records, localTeam) {
 }
 
 function pushCursor(messages, state) {
-  let cursor = state.durablePushCursor;
+  let cursor = "0";
   for (const message of messages) {
-    if (BigInt(message.local_position) <= BigInt(cursor)) continue;
     if (state.conflictsByLocalId.has(message.local_id)) break;
     const reservation = state.reservationsByLocalId.get(message.local_id);
-    if (reservation && state.conflictsByWire.has(reservation.id)) break;
     if (!reservation || !state.acknowledgements.has(reservation.id)) break;
     cursor = message.local_position;
   }
@@ -314,8 +318,8 @@ function validatePrepare(records) {
 function prepare(path, target, limit, inputText) {
   const input = validatePrepare(parseStrictJsonl(inputText));
   let records = readRecords(path);
-  const generation = currentGeneration(records, path);
-  records = readRecords(path);
+  const generationWasMissing = storedGeneration(records) === null;
+  const generation = currentGeneration(records);
   const state = fold(records, target);
   const messages = localMessages(records, target.local_team);
   const pending = [];
@@ -365,14 +369,9 @@ function prepare(path, target, limit, inputText) {
       payload_digest: payloadDigest, id: wireId, envelope };
     pending.push(reservation); newReservations.push(reservation);
   }
-  if (newReservations.length > 0) {
+  if (generationWasMissing || newReservations.length > 0 || newConflicts.length > 0) {
     appendRecord(path, { type: "sync_prepare_commit", binding: target,
-      driver_generation: generation, reservations: newReservations,
-      committed_at: new Date().toISOString() });
-  }
-  if (newConflicts.length > 0) {
-    appendRecord(path, { type: "sync_conflict_commit", binding: target,
-      driver_generation: generation, conflicts: newConflicts,
+      driver_generation: generation, reservations: newReservations, conflicts: newConflicts,
       committed_at: new Date().toISOString() });
   }
   process.stdout.write(`${JSON.stringify({ type: "sync_state", driver_generation: generation,
@@ -407,13 +406,11 @@ function reconcile(path, target, inputText) {
     seenSequences.add(ack.server_seq); previousSequence = BigInt(ack.server_seq);
   }
   const records = readRecords(path);
-  const generation = currentGeneration(records, path);
-  const refreshed = readRecords(path);
-  const state = fold(refreshed, target);
-  const messages = localMessages(refreshed, target.local_team);
+  const generation = currentGeneration(records);
+  const state = fold(records, target);
+  const messages = localMessages(records, target.local_team);
   const accepted = [];
   const conflicts = [];
-  let conflictDetected = false;
   for (const ack of acks) {
     const reservation = state.reservationsByWire.get(ack.id);
     if (!reservation || !state.reservationPositionsByWire.get(ack.id)?.has(ack.local_position)) {
@@ -422,11 +419,9 @@ function reconcile(path, target, inputText) {
     const prior = state.acknowledgements.get(ack.id);
     const sequenceWire = state.wireBySequence.get(ack.server_seq);
     if (state.conflictsByWire.has(ack.id)) {
-      conflictDetected = true;
       continue;
     }
     if (prior && prior.server_seq !== ack.server_seq) {
-      conflictDetected = true;
       conflicts.push({ kind: "ack_sequence_conflict", status: "corrupt_state",
         reason: "one wire id has different immutable server sequences", id: ack.id,
         expected_server_seq: prior.server_seq,
@@ -434,7 +429,6 @@ function reconcile(path, target, inputText) {
       continue;
     }
     if (sequenceWire && sequenceWire !== ack.id) {
-      conflictDetected = true;
       conflicts.push({ kind: "ack_wire_conflict", status: "corrupt_state",
         reason: "one server sequence maps to different wire ids", id: ack.id,
         expected_id: sequenceWire, server_seq: ack.server_seq });
@@ -442,21 +436,12 @@ function reconcile(path, target, inputText) {
     }
     accepted.push(ack);
   }
-  if (conflictDetected) {
-    if (conflicts.length > 0) {
-      appendRecord(path, { type: "sync_conflict_commit", binding: target,
-        driver_generation: generation, conflicts,
-        committed_at: new Date().toISOString() });
-    }
-    for (const conflict of conflicts) state.conflictsByWire.set(conflict.id, conflict);
-    process.stdout.write(`${JSON.stringify({ type: "sync_reconcile_result",
-      push_cursor: pushCursor(messages, state) })}\n`);
-    return;
-  }
   for (const ack of accepted) state.acknowledgements.set(ack.id, ack);
-  if (accepted.length > 0) appendRecord(path, { type: "sync_reconcile_commit",
-    binding: target, driver_generation: generation, acks: accepted,
-    push_cursor: pushCursor(messages, state), committed_at: new Date().toISOString() });
+  for (const conflict of conflicts) state.conflictsByWire.set(conflict.id, conflict);
+  if (accepted.length > 0 || conflicts.length > 0) appendRecord(path, {
+    type: "sync_reconcile_commit", binding: target, driver_generation: generation,
+    acks: accepted, conflicts, push_cursor: pushCursor(messages, state),
+    committed_at: new Date().toISOString() });
   process.stdout.write(`${JSON.stringify({ type: "sync_reconcile_result",
     push_cursor: pushCursor(messages, state) })}\n`);
 }
@@ -492,8 +477,8 @@ function validatePull(records) {
 function apply(path, target, inputText) {
   const input = validatePull(parseStrictJsonl(inputText));
   const records = readRecords(path);
-  const generation = currentGeneration(records, path);
-  const state = fold(readRecords(path), target);
+  const generation = currentGeneration(records);
+  const state = fold(records, target);
   if (BigInt(input.cursor) < BigInt(state.transportCursor)) {
     fail("pull cursor cannot move backwards");
   }
@@ -562,24 +547,57 @@ function apply(path, target, inputText) {
   }
 }
 
-function reprocess(path, target, limit) {
-  const records = readRecords(path);
-  const generation = currentGeneration(records, path);
-  const state = fold(readRecords(path), target);
+function reprocessToken(message) {
+  return `${message.server_seq}:${message.id}`;
+}
+
+function parseReprocessToken(value) {
+  if (value === undefined || value === "") return null;
+  const separator = value.indexOf(":");
+  if (separator < 1) fail("reprocess page token is invalid");
+  const serverSeq = sequence(value.slice(0, separator), "reprocess page server_seq");
+  const id = value.slice(separator + 1);
+  if (!UUID_V4.test(id)) fail("reprocess page wire id is invalid");
+  return { server_seq: serverSeq, id };
+}
+
+function afterReprocessToken(message, after) {
+  if (!after) return true;
+  const sequenceOrder = BigInt(message.server_seq) - BigInt(after.server_seq);
+  return sequenceOrder > 0n || (sequenceOrder === 0n && message.id > after.id);
+}
+
+function reprocess(path, target, limit, afterText) {
+  let records = readRecords(path);
+  let generation = storedGeneration(records);
+  if (!generation) {
+    generation = randomUUID();
+    appendRecord(path, { type: "sync_prepare_commit", binding: target,
+      driver_generation: generation, reservations: [], conflicts: [],
+      committed_at: new Date().toISOString() });
+    records = readRecords(path);
+  }
+  const state = fold(records, target);
+  const after = parseReprocessToken(afterText);
   process.stdout.write(`${JSON.stringify({ type: "sync_state", driver_generation: generation,
     transport_cursor: state.transportCursor })}\n`);
-  const candidates = [...state.quarantineByWire.values()]
+  const eligible = [...state.quarantineByWire.values()]
     .filter((message) => ["unsupported_cipher", "pending_key", "authentication_failed",
       "malformed", "policy_violation"].includes(message.status))
     .sort((left, right) => BigInt(left.server_seq) < BigInt(right.server_seq) ? -1 :
       BigInt(left.server_seq) > BigInt(right.server_seq) ? 1 : left.id.localeCompare(right.id))
-    .slice(0, limit);
+    .filter((message) => afterReprocessToken(message, after));
+  const candidates = eligible.slice(0, limit);
   for (const message of candidates) {
     process.stdout.write(`${JSON.stringify({ type: "sync_reprocess_candidate",
       server_seq: message.server_seq, id: message.id,
       server_received_at: message.server_received_at, envelope: message.envelope,
       prior_status: message.status })}\n`);
   }
+  const hasMore = eligible.length > limit;
+  process.stdout.write(`${JSON.stringify({ type: "sync_reprocess_page",
+    next_after: hasMore ? reprocessToken(candidates.at(-1)) : null,
+    has_more: hasMore })}\n`);
 }
 
 async function stdin() {
@@ -589,7 +607,8 @@ async function stdin() {
 }
 
 async function main() {
-  const [operation, path, localTeam, server, remote, protocolText, extra] = process.argv.slice(2);
+  const [operation, path, localTeam, server, remote, protocolText, extra, pageAfter] =
+    process.argv.slice(2);
   if (operation === "rotate-generation") {
     readRecords(path);
     appendRecord(path, { type: "sync_generation", generation: randomUUID(),
@@ -614,7 +633,7 @@ async function main() {
     if (input.trim() !== "" || !Number.isInteger(limit) || limit < 1 || limit > 1000) {
       fail("reprocess input or limit is invalid");
     }
-    reprocess(path, target, limit);
+    reprocess(path, target, limit, pageAfter);
   } else {
     fail("unknown JSONL sync operation", 2);
   }

--- a/scripts/internal/jsonl-sync.mjs
+++ b/scripts/internal/jsonl-sync.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+
+import { closeSync, fsyncSync, openSync, readFileSync, writeSync } from "node:fs";
+import { randomBytes, randomUUID } from "node:crypto";
+import process from "node:process";
+import { parseStrictJsonl } from "./strict-jsonl.mjs";
+import { sealEnvelope } from "./sync-cipher.mjs";
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const UUID_V7 = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const SEQUENCE = /^(?:0|[1-9][0-9]*)$/u;
+const MAX_SEQUENCE = 9_223_372_036_854_775_807n;
+
+function fail(message, code = 13) {
+  const error = new Error(message);
+  error.exitCode = code;
+  throw error;
+}
+
+function sequence(value, label) {
+  if (typeof value !== "string" || !SEQUENCE.test(value) || BigInt(value) > MAX_SEQUENCE) {
+    fail(`${label} is invalid`);
+  }
+  return value;
+}
+
+function binding(localTeam, serverInstanceId, remoteTeamId, protocolVersion) {
+  if (!localTeam || !UUID_V7.test(serverInstanceId) || !UUID_V7.test(remoteTeamId) ||
+      protocolVersion !== 1) fail("sync binding is invalid");
+  return { local_team: localTeam, server_instance_id: serverInstanceId,
+    remote_team_id: remoteTeamId, protocol_version: protocolVersion };
+}
+
+function sameBinding(record, target) {
+  return record?.binding?.local_team === target.local_team &&
+    record.binding.server_instance_id === target.server_instance_id &&
+    record.binding.remote_team_id === target.remote_team_id &&
+    record.binding.protocol_version === target.protocol_version;
+}
+
+function readRecords(path) {
+  const bytes = readFileSync(path);
+  const records = [];
+  let start = 0;
+  while (start < bytes.length) {
+    const newline = bytes.indexOf(0x0a, start);
+    if (newline === -1) fail("JSONL log ends with an incomplete record");
+    if (newline > start) {
+      let value;
+      try {
+        const line = new TextDecoder("utf-8", { fatal: true })
+          .decode(bytes.subarray(start, newline + 1));
+        const parsed = parseStrictJsonl(line);
+        if (parsed.length !== 1) fail("JSONL log contains an invalid record");
+        [value] = parsed;
+      }
+      catch { fail("JSONL log contains an invalid record"); }
+      records.push({ value, start, end: newline + 1 });
+    }
+    start = newline + 1;
+  }
+  return records;
+}
+
+function appendRecord(path, value) {
+  const bytes = Buffer.from(`${JSON.stringify(value)}\n`, "utf8");
+  const fd = openSync(path, "a", 0o600);
+  try {
+    const written = writeSync(fd, bytes, 0, bytes.length);
+    if (written !== bytes.length) fail("JSONL append was not one complete write");
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function uuid7() {
+  const bytes = randomBytes(16);
+  const millis = BigInt(Date.now()) & ((1n << 48n) - 1n);
+  for (let index = 0; index < 6; index += 1) {
+    bytes[index] = Number((millis >> BigInt((5 - index) * 8)) & 0xffn);
+  }
+  bytes[6] = 0x70 | (bytes[6] & 0x0f);
+  bytes[8] = 0x80 | (bytes[8] & 0x3f);
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function canonicalCreatedAt(value) {
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/u.test(value) ?
+    `${value.slice(0, -1)}.000000Z` : value;
+}
+
+function envelopeEqual(left, right) {
+  return left?.v === right?.v && left?.cipher === right?.cipher &&
+    left?.key_id === right?.key_id && left?.blob === right?.blob;
+}
+
+function currentGeneration(records, path) {
+  let generation = null;
+  for (const { value } of records) {
+    if (value.type === "sync_generation") {
+      if (!UUID_V4.test(value.generation) && !UUID_V7.test(value.generation)) {
+        fail("JSONL sync generation is invalid");
+      }
+      generation = value.generation;
+    }
+  }
+  if (generation) return generation;
+  generation = randomUUID();
+  appendRecord(path, { type: "sync_generation", generation,
+    created_at: new Date().toISOString() });
+  return generation;
+}
+
+function fold(records, target) {
+  const reservationsByLocalId = new Map();
+  const reservationsByWire = new Map();
+  const reservationPositionsByWire = new Map();
+  const acknowledgements = new Map();
+  const quarantineByWire = new Map();
+  const wireBySequence = new Map();
+  let transportCursor = "0";
+  for (const { value } of records) {
+    if (!sameBinding(value, target)) continue;
+    if (value.type === "sync_prepare_commit") {
+      if (!Array.isArray(value.reservations)) fail("JSONL reservation commit is invalid");
+      for (const reservation of value.reservations ?? []) {
+        if (!UUID_V4.test(reservation.id) || typeof reservation.local_id !== "string" ||
+            !reservation.envelope || typeof reservation.driver_generation !== "string") {
+          fail("JSONL reservation is invalid");
+        }
+        sequence(reservation.local_position, "reservation local_position");
+        const priorLocal = reservationsByLocalId.get(reservation.local_id);
+        const priorWire = reservationsByWire.get(reservation.id);
+        if ((priorLocal && (priorLocal.id !== reservation.id ||
+              !envelopeEqual(priorLocal.envelope, reservation.envelope))) ||
+            (priorWire && (priorWire.local_id !== reservation.local_id ||
+              !envelopeEqual(priorWire.envelope, reservation.envelope)))) {
+          fail("JSONL reservation identity conflicts with prior state");
+        }
+        reservationsByLocalId.set(reservation.local_id, reservation);
+        reservationsByWire.set(reservation.id, reservation);
+        const positions = reservationPositionsByWire.get(reservation.id) ?? new Set();
+        positions.add(reservation.local_position);
+        reservationPositionsByWire.set(reservation.id, positions);
+      }
+    } else if (value.type === "sync_reconcile_commit") {
+      if (!Array.isArray(value.acks)) fail("JSONL acknowledgement commit is invalid");
+      for (const ack of value.acks) {
+        sequence(ack.server_seq, "stored acknowledgement server_seq");
+        sequence(ack.local_position, "stored acknowledgement local_position");
+        const reservation = reservationsByWire.get(ack.id);
+        const prior = acknowledgements.get(ack.id);
+        const sequenceWire = wireBySequence.get(ack.server_seq);
+        if (!reservation || !reservationPositionsByWire.get(ack.id)?.has(ack.local_position) ||
+            (prior && prior.server_seq !== ack.server_seq) ||
+            (sequenceWire && sequenceWire !== ack.id)) {
+          fail("JSONL acknowledgement conflicts with prior state");
+        }
+        acknowledgements.set(ack.id, ack);
+        wireBySequence.set(ack.server_seq, ack.id);
+      }
+    } else if (value.type === "sync_pull_commit") {
+      sequence(value.transport_cursor, "stored transport_cursor");
+      if (BigInt(value.transport_cursor) < BigInt(transportCursor) || !Array.isArray(value.messages)) {
+        fail("JSONL pull commit is invalid");
+      }
+      for (const message of value.messages ?? []) {
+        sequence(message.server_seq, "stored pull server_seq");
+        if (!UUID_V4.test(message.id) || !message.envelope ||
+            !["imported", "reconciled", "corrupt_state", "unsupported_cipher", "pending_key",
+              "authentication_failed", "malformed", "policy_violation"].includes(message.status)) {
+          fail("JSONL pull outcome is invalid");
+        }
+        const prior = quarantineByWire.get(message.id);
+        const priorSequenceWire = wireBySequence.get(message.server_seq);
+        const immutableConflict = (priorSequenceWire && priorSequenceWire !== message.id) ||
+          (prior && (prior.server_seq !== message.server_seq ||
+            !envelopeEqual(prior.envelope, message.envelope)));
+        if (immutableConflict && message.status !== "corrupt_state") {
+          fail("JSONL pull outcome hides an immutable conflict");
+        }
+        quarantineByWire.set(message.id, {
+          ...prior, ...message, local_event: message.local_event ?? prior?.local_event ?? null,
+        });
+        if (!wireBySequence.has(message.server_seq)) {
+          wireBySequence.set(message.server_seq, message.id);
+        }
+        const reservation = reservationsByWire.get(message.id);
+        if (message.status === "reconciled" && reservation) {
+          const priorAck = acknowledgements.get(message.id);
+          if (priorAck && priorAck.server_seq !== message.server_seq) {
+            fail("JSONL pull echo conflicts with its acknowledgement");
+          }
+          acknowledgements.set(message.id, { type: "sync_push_ack", id: message.id,
+            local_position: reservation.local_position, server_seq: message.server_seq,
+            disposition: "duplicate" });
+        }
+      }
+      transportCursor = value.transport_cursor;
+    }
+  }
+  return { reservationsByLocalId, reservationsByWire, acknowledgements,
+    reservationPositionsByWire, quarantineByWire, wireBySequence, transportCursor };
+}
+
+function localMessages(records, localTeam) {
+  return records.filter(({ value }) => value.type === "message_sent" && value.team === localTeam)
+    .map(({ value, end }) => ({ local_position: String(end), local_id: value.id,
+      body: value.body, at: value.at, from_agent: value.from, to_agent: value.to }));
+}
+
+function pushCursor(messages, state) {
+  let cursor = "0";
+  for (const message of messages) {
+    const reservation = state.reservationsByLocalId.get(message.local_id);
+    if (!reservation || !state.acknowledgements.has(reservation.id)) break;
+    cursor = message.local_position;
+  }
+  return cursor;
+}
+
+function validatePrepare(records) {
+  if (records.length !== 1) fail("prepare requires exactly one record");
+  const input = records[0];
+  const keys = Object.keys(input).sort().join(",");
+  if (keys !== "allow_new,cipher,envelope_v,key_id,max_blob_bytes,recipients,type" ||
+      input.type !== "sync_prepare" || input.envelope_v !== 1 ||
+      !["none", "age-v1"].includes(input.cipher) || typeof input.allow_new !== "boolean" ||
+      !Number.isInteger(input.max_blob_bytes) || input.max_blob_bytes < 1 ||
+      !Array.isArray(input.recipients)) fail("sync_prepare record is invalid");
+  if ((input.cipher === "none" && (input.key_id !== null || input.recipients.length !== 0)) ||
+      (input.cipher === "age-v1" && (typeof input.key_id !== "string" ||
+        input.recipients.length < 1 || input.recipients.length > 256))) {
+    fail("sync_prepare cipher selection is invalid");
+  }
+  return input;
+}
+
+function prepare(path, target, limit, inputText) {
+  const input = validatePrepare(parseStrictJsonl(inputText));
+  let records = readRecords(path);
+  const generation = currentGeneration(records, path);
+  records = readRecords(path);
+  const state = fold(records, target);
+  const messages = localMessages(records, target.local_team);
+  const pending = [];
+  const newReservations = [];
+  for (const message of messages) {
+    if (pending.length >= limit) break;
+    const existing = state.reservationsByLocalId.get(message.local_id);
+    if (existing && !state.acknowledgements.has(existing.id)) {
+      const rebound = { ...existing, driver_generation: generation,
+        local_position: message.local_position };
+      pending.push(rebound);
+      if (existing.driver_generation !== generation ||
+          existing.local_position !== message.local_position) newReservations.push(rebound);
+      continue;
+    }
+    if (existing || !input.allow_new) continue;
+    const wireId = randomUUID();
+    const envelope = sealEnvelope({ type: "sync_seal", envelope_v: 1,
+      cipher: input.cipher, key_id: input.key_id, recipients: input.recipients,
+      max_blob_bytes: input.max_blob_bytes, wire_id: wireId,
+      team_id: target.remote_team_id, protocol_version: target.protocol_version,
+      projection: { body: message.body, created_at: canonicalCreatedAt(message.at),
+        from_agent: message.from_agent, to_agent: message.to_agent } });
+    if (process.env.AGMSG_SYNC_TEST_ABORT_AFTER_SEAL === "1") fail("aborted after seal", 75);
+    const reservation = { driver_generation: generation,
+      local_position: message.local_position, local_id: message.local_id,
+      id: wireId, envelope };
+    pending.push(reservation); newReservations.push(reservation);
+  }
+  if (newReservations.length > 0) {
+    appendRecord(path, { type: "sync_prepare_commit", binding: target,
+      driver_generation: generation, reservations: newReservations,
+      committed_at: new Date().toISOString() });
+  }
+  process.stdout.write(`${JSON.stringify({ type: "sync_state", driver_generation: generation,
+    transport_cursor: state.transportCursor })}\n`);
+  for (const reservation of pending) {
+    process.stdout.write(`${JSON.stringify({ type: "sync_push_candidate",
+      local_position: reservation.local_position, local_id: reservation.local_id,
+      id: reservation.id, envelope: reservation.envelope })}\n`);
+  }
+}
+
+function reconcile(path, target, inputText) {
+  const acks = parseStrictJsonl(inputText);
+  if (acks.length < 1 || acks.length > 1000) fail("reconcile requires 1..1000 acknowledgements");
+  const records = readRecords(path);
+  const generation = currentGeneration(records, path);
+  const refreshed = readRecords(path);
+  const state = fold(refreshed, target);
+  const messages = localMessages(refreshed, target.local_team);
+  const accepted = [];
+  const seenPositions = new Set();
+  const seenWires = new Set();
+  const seenSequences = new Set();
+  let previousSequence = -1n;
+  for (const ack of acks) {
+    if (!ack || Object.keys(ack).sort().join(",") !==
+        "disposition,id,local_position,server_seq,type" || ack.type !== "sync_push_ack" ||
+        !UUID_V4.test(ack.id) || !["stored", "duplicate"].includes(ack.disposition)) {
+      fail("sync_push_ack is invalid");
+    }
+    sequence(ack.local_position, "ack local_position");
+    sequence(ack.server_seq, "ack server_seq");
+    if (seenPositions.has(ack.local_position) || seenWires.has(ack.id) ||
+        seenSequences.has(ack.server_seq) || BigInt(ack.server_seq) <= previousSequence) {
+      fail("ack mapping is not unique and ordered");
+    }
+    seenPositions.add(ack.local_position); seenWires.add(ack.id);
+    seenSequences.add(ack.server_seq); previousSequence = BigInt(ack.server_seq);
+    const reservation = state.reservationsByWire.get(ack.id);
+    if (!reservation || !state.reservationPositionsByWire.get(ack.id)?.has(ack.local_position)) {
+      fail("ack does not match a durable reservation");
+    }
+    const prior = state.acknowledgements.get(ack.id);
+    if (prior && prior.server_seq !== ack.server_seq) fail("ack sequence conflicts with prior state");
+    accepted.push(ack);
+    state.acknowledgements.set(ack.id, ack);
+  }
+  if (accepted.length > 0) appendRecord(path, { type: "sync_reconcile_commit",
+    binding: target, driver_generation: generation, acks: accepted,
+    push_cursor: pushCursor(messages, state), committed_at: new Date().toISOString() });
+  process.stdout.write(`${JSON.stringify({ type: "sync_reconcile_result",
+    push_cursor: pushCursor(messages, state) })}\n`);
+}
+
+function validatePull(records) {
+  if (records.length < 1 || records.at(-1)?.type !== "sync_pull_cursor") {
+    fail("pull page must end with a cursor");
+  }
+  const cursor = records.at(-1);
+  sequence(cursor.next_after, "pull cursor");
+  const messages = records.slice(0, -1);
+  let previous = -1n;
+  for (const message of messages) {
+    if (message?.type !== "sync_pull_message" || !UUID_V4.test(message.id) ||
+        !message.envelope || !["importable", "unsupported_cipher", "pending_key",
+          "authentication_failed", "malformed", "policy_violation"].includes(message.status)) {
+      fail("sync_pull_message is invalid");
+    }
+    sequence(message.server_seq, "pull server_seq");
+    if (BigInt(message.server_seq) <= previous) fail("pull messages are not ordered");
+    previous = BigInt(message.server_seq);
+    if (message.status === "importable" && (!message.projection ||
+        typeof message.projection.body !== "string" ||
+        typeof message.projection.from_agent !== "string" ||
+        typeof message.projection.to_agent !== "string" ||
+        typeof message.projection.created_at !== "string")) {
+      fail("importable pull message has no projection");
+    }
+  }
+  if (messages.length > 0 && cursor.next_after !== messages.at(-1).server_seq) {
+    fail("pull cursor does not cover the page");
+  }
+  return { messages, cursor: cursor.next_after };
+}
+
+function apply(path, target, inputText) {
+  const input = validatePull(parseStrictJsonl(inputText));
+  const records = readRecords(path);
+  const generation = currentGeneration(records, path);
+  const state = fold(readRecords(path), target);
+  if (BigInt(input.cursor) < BigInt(state.transportCursor)) {
+    fail("pull cursor cannot move backwards");
+  }
+  const replay = input.messages.length > 0 && input.cursor === state.transportCursor;
+  if (!replay) {
+    let expected = BigInt(state.transportCursor) + 1n;
+    for (const message of input.messages) {
+      if (BigInt(message.server_seq) !== expected) fail("pull page is not contiguous");
+      expected += 1n;
+    }
+  }
+  if (input.messages.length === 0 && input.cursor !== state.transportCursor) {
+    fail("empty pull page cannot advance the cursor");
+  }
+  const committed = [];
+  for (const source of input.messages) {
+    const prior = state.quarantineByWire.get(source.id);
+    if (replay && !prior) fail("pull replay has no durable prior outcome");
+    const reservation = state.reservationsByWire.get(source.id);
+    const acknowledgement = state.acknowledgements.get(source.id);
+    const sequenceWire = state.wireBySequence.get(source.server_seq);
+    let status = source.status;
+    let reason = source.reason ?? "";
+    let localEvent = null;
+    if ((sequenceWire && sequenceWire !== source.id) ||
+        (acknowledgement && acknowledgement.server_seq !== source.server_seq) ||
+        (prior && (prior.server_seq !== source.server_seq ||
+          !envelopeEqual(prior.envelope, source.envelope))) ||
+        (reservation && !envelopeEqual(reservation.envelope, source.envelope))) {
+      status = "corrupt_state"; reason = "wire, sequence, or envelope mapping conflict";
+    } else if (["imported", "reconciled", "corrupt_state"].includes(prior?.status)) {
+      status = prior.status; reason = prior.reason ?? reason;
+    } else if (reservation && status === "importable") {
+      status = "reconciled";
+    } else if (!reservation && status === "importable") {
+      localEvent = prior?.local_event ?? { type: "message_sent", id: uuid7(), team: target.local_team,
+        from: source.projection.from_agent, to: source.projection.to_agent,
+        body: source.projection.body, at: source.projection.created_at };
+      status = "imported";
+    }
+    const storedLocalEvent = prior?.local_event ? null : localEvent;
+    const message = { ...source, status, reason, local_event: storedLocalEvent };
+    committed.push(message);
+    state.quarantineByWire.set(source.id, { ...message,
+      local_event: localEvent ?? prior?.local_event ?? null });
+    if (!state.wireBySequence.has(source.server_seq)) {
+      state.wireBySequence.set(source.server_seq, source.id);
+    }
+  }
+  appendRecord(path, { type: "sync_pull_commit", binding: target,
+    driver_generation: generation, messages: committed,
+    transport_cursor: input.cursor, committed_at: new Date().toISOString() });
+  const corruptCount = [...state.quarantineByWire.values()]
+    .filter((message) => message.status === "corrupt_state").length;
+  process.stdout.write(`${JSON.stringify({ type: "sync_apply_result",
+    transport_cursor: input.cursor, corrupt_count: corruptCount })}\n`);
+  for (const message of committed) {
+    process.stdout.write(`${JSON.stringify({ type: "sync_apply_outcome", id: message.id,
+      server_seq: message.server_seq, status: message.status })}\n`);
+  }
+}
+
+async function stdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function main() {
+  const [operation, path, localTeam, server, remote, protocolText, extra] = process.argv.slice(2);
+  if (operation === "rotate-generation") {
+    readRecords(path);
+    appendRecord(path, { type: "sync_generation", generation: randomUUID(),
+      created_at: new Date().toISOString() });
+    if (process.env.AGMSG_SYNC_TEST_ABORT_AFTER_ROTATE_APPEND === "1") {
+      fail("aborted after replacement generation append", 75);
+    }
+    return;
+  }
+  const target = binding(localTeam, server, remote, Number(protocolText));
+  const input = await stdin();
+  if (operation === "prepare") {
+    const limit = Number(extra);
+    if (!Number.isInteger(limit) || limit < 1 || limit > 1000) fail("prepare limit is invalid");
+    prepare(path, target, limit, input);
+  } else if (operation === "reconcile") {
+    reconcile(path, target, input);
+  } else if (operation === "apply") {
+    apply(path, target, input);
+  } else {
+    fail("unknown JSONL sync operation", 2);
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exitCode = error.exitCode ?? 13;
+});

--- a/scripts/internal/jsonl-sync.mjs
+++ b/scripts/internal/jsonl-sync.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
-import { closeSync, fsyncSync, openSync, readFileSync, writeSync } from "node:fs";
-import { randomBytes, randomUUID } from "node:crypto";
+import { closeSync, fstatSync, fsyncSync, ftruncateSync, openSync, readFileSync,
+  writeSync } from "node:fs";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import process from "node:process";
 import { parseStrictJsonl } from "./strict-jsonl.mjs";
 import { sealEnvelope } from "./sync-cipher.mjs";
@@ -64,11 +65,27 @@ function readRecords(path) {
 
 function appendRecord(path, value) {
   const bytes = Buffer.from(`${JSON.stringify(value)}\n`, "utf8");
-  const fd = openSync(path, "a", 0o600);
+  const fd = openSync(path, "a+", 0o600);
+  const oldSize = fstatSync(fd).size;
   try {
-    const written = writeSync(fd, bytes, 0, bytes.length);
+    let written;
+    const injectedPartial = Number(process.env.AGMSG_SYNC_TEST_PARTIAL_APPEND_BYTES ?? "0");
+    if (Number.isInteger(injectedPartial) && injectedPartial > 0) {
+      written = writeSync(fd, bytes, 0, Math.min(injectedPartial, bytes.length));
+      fail("injected JSONL partial append", 75);
+    }
+    written = writeSync(fd, bytes, 0, bytes.length);
     if (written !== bytes.length) fail("JSONL append was not one complete write");
     fsyncSync(fd);
+  } catch (error) {
+    try {
+      ftruncateSync(fd, oldSize);
+      fsyncSync(fd);
+    } catch (rollbackError) {
+      rollbackError.cause = error;
+      throw rollbackError;
+    }
+    throw error;
   } finally {
     closeSync(fd);
   }
@@ -96,6 +113,18 @@ function envelopeEqual(left, right) {
     left?.key_id === right?.key_id && left?.blob === right?.blob;
 }
 
+function localPayloadDigest(message) {
+  const hash = createHash("sha256");
+  for (const value of [message.local_id, message.from_agent, message.to_agent,
+    message.body, canonicalCreatedAt(message.at)]) {
+    const bytes = Buffer.from(value, "utf8");
+    const length = Buffer.allocUnsafe(4);
+    length.writeUInt32BE(bytes.length);
+    hash.update(length); hash.update(bytes);
+  }
+  return hash.digest("hex");
+}
+
 function currentGeneration(records, path) {
   let generation = null;
   for (const { value } of records) {
@@ -120,13 +149,17 @@ function fold(records, target) {
   const acknowledgements = new Map();
   const quarantineByWire = new Map();
   const wireBySequence = new Map();
+  const conflictsByLocalId = new Map();
+  const conflictsByWire = new Map();
   let transportCursor = "0";
+  let durablePushCursor = "0";
   for (const { value } of records) {
     if (!sameBinding(value, target)) continue;
     if (value.type === "sync_prepare_commit") {
       if (!Array.isArray(value.reservations)) fail("JSONL reservation commit is invalid");
       for (const reservation of value.reservations ?? []) {
         if (!UUID_V4.test(reservation.id) || typeof reservation.local_id !== "string" ||
+            !/^[0-9a-f]{64}$/u.test(reservation.payload_digest) ||
             !reservation.envelope || typeof reservation.driver_generation !== "string") {
           fail("JSONL reservation is invalid");
         }
@@ -134,6 +167,7 @@ function fold(records, target) {
         const priorLocal = reservationsByLocalId.get(reservation.local_id);
         const priorWire = reservationsByWire.get(reservation.id);
         if ((priorLocal && (priorLocal.id !== reservation.id ||
+              priorLocal.payload_digest !== reservation.payload_digest ||
               !envelopeEqual(priorLocal.envelope, reservation.envelope))) ||
             (priorWire && (priorWire.local_id !== reservation.local_id ||
               !envelopeEqual(priorWire.envelope, reservation.envelope)))) {
@@ -145,8 +179,42 @@ function fold(records, target) {
         positions.add(reservation.local_position);
         reservationPositionsByWire.set(reservation.id, positions);
       }
+    } else if (value.type === "sync_conflict_commit") {
+      if (!Array.isArray(value.conflicts) || value.conflicts.length < 1) {
+        fail("JSONL conflict commit is invalid");
+      }
+      for (const conflict of value.conflicts) {
+        if (conflict?.kind === "local_payload_conflict" &&
+            conflict.status === "corrupt_state" &&
+            typeof conflict.local_id === "string" &&
+            /^[0-9a-f]{64}$/u.test(conflict.expected_digest) &&
+            /^[0-9a-f]{64}$/u.test(conflict.observed_digest) &&
+            conflict.expected_digest !== conflict.observed_digest) {
+          conflictsByLocalId.set(conflict.local_id, conflict);
+        } else if (conflict?.kind === "ack_sequence_conflict" &&
+            conflict.status === "corrupt_state" && UUID_V4.test(conflict.id)) {
+          sequence(conflict.expected_server_seq, "conflict expected_server_seq");
+          sequence(conflict.observed_server_seq, "conflict observed_server_seq");
+          if (conflict.expected_server_seq === conflict.observed_server_seq) {
+            fail("JSONL acknowledgement conflict is not conflicting");
+          }
+          conflictsByWire.set(conflict.id, conflict);
+        } else if (conflict?.kind === "ack_wire_conflict" &&
+            conflict.status === "corrupt_state" &&
+            UUID_V4.test(conflict.id) && UUID_V4.test(conflict.expected_id) &&
+            conflict.id !== conflict.expected_id) {
+          sequence(conflict.server_seq, "conflict server_seq");
+          conflictsByWire.set(conflict.id, conflict);
+        } else {
+          fail("JSONL conflict is invalid");
+        }
+      }
     } else if (value.type === "sync_reconcile_commit") {
       if (!Array.isArray(value.acks)) fail("JSONL acknowledgement commit is invalid");
+      sequence(value.push_cursor, "stored push_cursor");
+      if (BigInt(value.push_cursor) < BigInt(durablePushCursor)) {
+        fail("JSONL push cursor moves backwards");
+      }
       for (const ack of value.acks) {
         sequence(ack.server_seq, "stored acknowledgement server_seq");
         sequence(ack.local_position, "stored acknowledgement local_position");
@@ -161,6 +229,7 @@ function fold(records, target) {
         acknowledgements.set(ack.id, ack);
         wireBySequence.set(ack.server_seq, ack.id);
       }
+      durablePushCursor = value.push_cursor;
     } else if (value.type === "sync_pull_commit") {
       sequence(value.transport_cursor, "stored transport_cursor");
       if (BigInt(value.transport_cursor) < BigInt(transportCursor) || !Array.isArray(value.messages)) {
@@ -202,7 +271,8 @@ function fold(records, target) {
     }
   }
   return { reservationsByLocalId, reservationsByWire, acknowledgements,
-    reservationPositionsByWire, quarantineByWire, wireBySequence, transportCursor };
+    reservationPositionsByWire, quarantineByWire, wireBySequence, transportCursor,
+    conflictsByLocalId, conflictsByWire, durablePushCursor };
 }
 
 function localMessages(records, localTeam) {
@@ -212,9 +282,12 @@ function localMessages(records, localTeam) {
 }
 
 function pushCursor(messages, state) {
-  let cursor = "0";
+  let cursor = state.durablePushCursor;
   for (const message of messages) {
+    if (BigInt(message.local_position) <= BigInt(cursor)) continue;
+    if (state.conflictsByLocalId.has(message.local_id)) break;
     const reservation = state.reservationsByLocalId.get(message.local_id);
+    if (reservation && state.conflictsByWire.has(reservation.id)) break;
     if (!reservation || !state.acknowledgements.has(reservation.id)) break;
     cursor = message.local_position;
   }
@@ -247,8 +320,28 @@ function prepare(path, target, limit, inputText) {
   const messages = localMessages(records, target.local_team);
   const pending = [];
   const newReservations = [];
+  const newConflicts = [];
+  const observedDigests = new Map();
+  for (const message of messages) {
+    const digest = localPayloadDigest(message);
+    const priorDigest = observedDigests.get(message.local_id) ??
+      state.reservationsByLocalId.get(message.local_id)?.payload_digest;
+    if (priorDigest && priorDigest !== digest &&
+        !state.conflictsByLocalId.has(message.local_id) &&
+        !newConflicts.some((conflict) => conflict.local_id === message.local_id)) {
+      newConflicts.push({ kind: "local_payload_conflict", status: "corrupt_state",
+        reason: "one local message id has different immutable payloads", local_id: message.local_id,
+        expected_digest: priorDigest, observed_digest: digest });
+    }
+    if (!observedDigests.has(message.local_id)) observedDigests.set(message.local_id, digest);
+  }
+  const newlyConflictedIds = new Set(newConflicts.map((conflict) => conflict.local_id));
   for (const message of messages) {
     if (pending.length >= limit) break;
+    if (state.conflictsByLocalId.has(message.local_id) || newlyConflictedIds.has(message.local_id)) {
+      continue;
+    }
+    const payloadDigest = localPayloadDigest(message);
     const existing = state.reservationsByLocalId.get(message.local_id);
     if (existing && !state.acknowledgements.has(existing.id)) {
       const rebound = { ...existing, driver_generation: generation,
@@ -269,12 +362,17 @@ function prepare(path, target, limit, inputText) {
     if (process.env.AGMSG_SYNC_TEST_ABORT_AFTER_SEAL === "1") fail("aborted after seal", 75);
     const reservation = { driver_generation: generation,
       local_position: message.local_position, local_id: message.local_id,
-      id: wireId, envelope };
+      payload_digest: payloadDigest, id: wireId, envelope };
     pending.push(reservation); newReservations.push(reservation);
   }
   if (newReservations.length > 0) {
     appendRecord(path, { type: "sync_prepare_commit", binding: target,
       driver_generation: generation, reservations: newReservations,
+      committed_at: new Date().toISOString() });
+  }
+  if (newConflicts.length > 0) {
+    appendRecord(path, { type: "sync_conflict_commit", binding: target,
+      driver_generation: generation, conflicts: newConflicts,
       committed_at: new Date().toISOString() });
   }
   process.stdout.write(`${JSON.stringify({ type: "sync_state", driver_generation: generation,
@@ -289,12 +387,6 @@ function prepare(path, target, limit, inputText) {
 function reconcile(path, target, inputText) {
   const acks = parseStrictJsonl(inputText);
   if (acks.length < 1 || acks.length > 1000) fail("reconcile requires 1..1000 acknowledgements");
-  const records = readRecords(path);
-  const generation = currentGeneration(records, path);
-  const refreshed = readRecords(path);
-  const state = fold(refreshed, target);
-  const messages = localMessages(refreshed, target.local_team);
-  const accepted = [];
   const seenPositions = new Set();
   const seenWires = new Set();
   const seenSequences = new Set();
@@ -313,15 +405,55 @@ function reconcile(path, target, inputText) {
     }
     seenPositions.add(ack.local_position); seenWires.add(ack.id);
     seenSequences.add(ack.server_seq); previousSequence = BigInt(ack.server_seq);
+  }
+  const records = readRecords(path);
+  const generation = currentGeneration(records, path);
+  const refreshed = readRecords(path);
+  const state = fold(refreshed, target);
+  const messages = localMessages(refreshed, target.local_team);
+  const accepted = [];
+  const conflicts = [];
+  let conflictDetected = false;
+  for (const ack of acks) {
     const reservation = state.reservationsByWire.get(ack.id);
     if (!reservation || !state.reservationPositionsByWire.get(ack.id)?.has(ack.local_position)) {
       fail("ack does not match a durable reservation");
     }
     const prior = state.acknowledgements.get(ack.id);
-    if (prior && prior.server_seq !== ack.server_seq) fail("ack sequence conflicts with prior state");
+    const sequenceWire = state.wireBySequence.get(ack.server_seq);
+    if (state.conflictsByWire.has(ack.id)) {
+      conflictDetected = true;
+      continue;
+    }
+    if (prior && prior.server_seq !== ack.server_seq) {
+      conflictDetected = true;
+      conflicts.push({ kind: "ack_sequence_conflict", status: "corrupt_state",
+        reason: "one wire id has different immutable server sequences", id: ack.id,
+        expected_server_seq: prior.server_seq,
+        observed_server_seq: ack.server_seq });
+      continue;
+    }
+    if (sequenceWire && sequenceWire !== ack.id) {
+      conflictDetected = true;
+      conflicts.push({ kind: "ack_wire_conflict", status: "corrupt_state",
+        reason: "one server sequence maps to different wire ids", id: ack.id,
+        expected_id: sequenceWire, server_seq: ack.server_seq });
+      continue;
+    }
     accepted.push(ack);
-    state.acknowledgements.set(ack.id, ack);
   }
+  if (conflictDetected) {
+    if (conflicts.length > 0) {
+      appendRecord(path, { type: "sync_conflict_commit", binding: target,
+        driver_generation: generation, conflicts,
+        committed_at: new Date().toISOString() });
+    }
+    for (const conflict of conflicts) state.conflictsByWire.set(conflict.id, conflict);
+    process.stdout.write(`${JSON.stringify({ type: "sync_reconcile_result",
+      push_cursor: pushCursor(messages, state) })}\n`);
+    return;
+  }
+  for (const ack of accepted) state.acknowledgements.set(ack.id, ack);
   if (accepted.length > 0) appendRecord(path, { type: "sync_reconcile_commit",
     binding: target, driver_generation: generation, acks: accepted,
     push_cursor: pushCursor(messages, state), committed_at: new Date().toISOString() });
@@ -354,9 +486,6 @@ function validatePull(records) {
       fail("importable pull message has no projection");
     }
   }
-  if (messages.length > 0 && cursor.next_after !== messages.at(-1).server_seq) {
-    fail("pull cursor does not cover the page");
-  }
   return { messages, cursor: cursor.next_after };
 }
 
@@ -375,6 +504,12 @@ function apply(path, target, inputText) {
       if (BigInt(message.server_seq) !== expected) fail("pull page is not contiguous");
       expected += 1n;
     }
+    if (input.messages.length > 0 && input.cursor !== input.messages.at(-1).server_seq) {
+      fail("pull cursor does not cover the page");
+    }
+  } else if (input.messages.some((message) =>
+    BigInt(message.server_seq) > BigInt(state.transportCursor))) {
+    fail("pull replay exceeds the durable cursor");
   }
   if (input.messages.length === 0 && input.cursor !== state.transportCursor) {
     fail("empty pull page cannot advance the cursor");
@@ -427,6 +562,26 @@ function apply(path, target, inputText) {
   }
 }
 
+function reprocess(path, target, limit) {
+  const records = readRecords(path);
+  const generation = currentGeneration(records, path);
+  const state = fold(readRecords(path), target);
+  process.stdout.write(`${JSON.stringify({ type: "sync_state", driver_generation: generation,
+    transport_cursor: state.transportCursor })}\n`);
+  const candidates = [...state.quarantineByWire.values()]
+    .filter((message) => ["unsupported_cipher", "pending_key", "authentication_failed",
+      "malformed", "policy_violation"].includes(message.status))
+    .sort((left, right) => BigInt(left.server_seq) < BigInt(right.server_seq) ? -1 :
+      BigInt(left.server_seq) > BigInt(right.server_seq) ? 1 : left.id.localeCompare(right.id))
+    .slice(0, limit);
+  for (const message of candidates) {
+    process.stdout.write(`${JSON.stringify({ type: "sync_reprocess_candidate",
+      server_seq: message.server_seq, id: message.id,
+      server_received_at: message.server_received_at, envelope: message.envelope,
+      prior_status: message.status })}\n`);
+  }
+}
+
 async function stdin() {
   const chunks = [];
   for await (const chunk of process.stdin) chunks.push(chunk);
@@ -454,6 +609,12 @@ async function main() {
     reconcile(path, target, input);
   } else if (operation === "apply") {
     apply(path, target, input);
+  } else if (operation === "reprocess") {
+    const limit = Number(extra);
+    if (input.trim() !== "" || !Number.isInteger(limit) || limit < 1 || limit > 1000) {
+      fail("reprocess input or limit is invalid");
+    }
+    reprocess(path, target, limit);
   } else {
     fail("unknown JSONL sync operation", 2);
   }

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1206,36 +1206,106 @@ async function cycle(config, limit) {
   await readStateCycle(config, limit);
 }
 
-async function reprocessCycle(config, limit) {
-  const ready = await health(config.server_url);
-  if (ready.server_instance_id !== config.server_instance_id) throw new Error("health server instance changed");
-  const capabilities = await request(config, "/v1/capabilities");
-  validateCapabilities(config, capabilities);
-  const pending = await driver("reprocess", config, [], [String(limit)]);
-  const state = pending.find((record) => record.type === "sync_state");
+function reprocessCandidateToken(candidate) {
+  return `${candidate.server_seq}:${candidate.id}`;
+}
+
+function validateReprocessDriverPage(pending, limit, requestedAfter) {
+  const recordKeys = (value) => Object.keys(value).sort().join(",");
+  const states = pending.filter((record) => record.type === "sync_state");
   const candidates = pending.filter((record) => record.type === "sync_reprocess_candidate");
-  if (!state) throw new Error("driver omitted sync_state while reprocessing");
-  sequence(state.transport_cursor, "transport_cursor");
-  const records = [];
+  const pages = pending.filter((record) => record.type === "sync_reprocess_page");
+  if (states.length !== 1 || pages.length !== 1 || candidates.length > limit ||
+      pending.length !== states.length + candidates.length + pages.length) {
+    throw new Error("driver reprocess page shape is invalid");
+  }
+  const page = pages[0];
+  if (recordKeys(page) !== "has_more,next_after,type" || typeof page.has_more !== "boolean" ||
+      (page.has_more ? typeof page.next_after !== "string" : page.next_after !== null) ||
+      (page.has_more && candidates.length === 0)) {
+    throw new Error("driver reprocess pagination is invalid");
+  }
+  let previous = requestedAfter;
   for (const candidate of candidates) {
-    sequence(candidate.server_seq, "reprocess server_seq");
-    if (BigInt(candidate.server_seq) > BigInt(capabilities.current_seq)) {
-      throw new Error("quarantine sequence exceeds authenticated server state");
+    if (recordKeys(candidate) !==
+        "envelope,id,prior_status,server_received_at,server_seq,type" ||
+        candidate.type !== "sync_reprocess_candidate" || !UUID_V4.test(candidate.id) ||
+        typeof candidate.server_received_at !== "string" ||
+        typeof candidate.prior_status !== "string" || !candidate.envelope) {
+      throw new Error("driver reprocess candidate is invalid");
     }
-    const message = { server_seq: candidate.server_seq, id: candidate.id,
-      server_received_at: candidate.server_received_at, envelope: candidate.envelope };
-    const evaluated = await evaluatePull(config, capabilities, message);
-    records.push({ type: "sync_pull_message", ...message, ...evaluated });
+    sequence(candidate.server_seq, "reprocess server_seq");
+    const token = reprocessCandidateToken(candidate);
+    if (previous !== null) {
+      const separator = previous.indexOf(":");
+      const previousSequence = sequence(previous.slice(0, separator), "reprocess page server_seq");
+      const previousId = previous.slice(separator + 1);
+      if (separator < 1 || !UUID_V4.test(previousId) ||
+          BigInt(candidate.server_seq) < BigInt(previousSequence) ||
+          (candidate.server_seq === previousSequence && candidate.id <= previousId)) {
+        throw new Error("driver reprocess page did not advance");
+      }
+    }
+    previous = token;
   }
-  if (records.length === 0) {
-    await event("reprocess.complete", { count: 0, transport_cursor: state.transport_cursor });
-    return;
+  if (page.has_more && page.next_after !== previous) {
+    throw new Error("driver reprocess next page token is inconsistent");
   }
-  records.push({ type: "sync_pull_cursor", next_after: state.transport_cursor });
-  const applied = await driver("apply", config, records);
-  await logApplyOutcomes(config, records, applied);
-  await event("reprocess.complete", { count: candidates.length,
-    transport_cursor: state.transport_cursor, result: applied[0] ?? null });
+  return { state: states[0], candidates, page };
+}
+
+export async function reprocessCycle(config, limit, dependencies = {}) {
+  const healthCall = dependencies.healthCall ?? health;
+  const requestCall = dependencies.requestCall ?? request;
+  const driverCall = dependencies.driverCall ?? driver;
+  const evaluateCall = dependencies.evaluateCall ?? evaluatePull;
+  const eventCall = dependencies.eventCall ?? event;
+  const logApplyCall = dependencies.logApplyCall ?? logApplyOutcomes;
+  const ready = await healthCall(config.server_url);
+  if (ready.server_instance_id !== config.server_instance_id) throw new Error("health server instance changed");
+  const capabilities = await requestCall(config, "/v1/capabilities");
+  validateCapabilities(config, capabilities);
+  let after = null;
+  let stableState = null;
+  let total = 0;
+  const seenTokens = new Set();
+  for (;;) {
+    const extra = [String(limit), ...(after === null ? [] : [after])];
+    const pending = await driverCall("reprocess", config, [], extra);
+    const { state, candidates, page } = validateReprocessDriverPage(pending, limit, after);
+    sequence(state.transport_cursor, "transport_cursor");
+    if (stableState && (state.transport_cursor !== stableState.transport_cursor ||
+        state.driver_generation !== stableState.driver_generation)) {
+      throw new Error("driver reprocess state changed between pages");
+    }
+    stableState ??= state;
+    const records = [];
+    for (const candidate of candidates) {
+      const token = reprocessCandidateToken(candidate);
+      if (seenTokens.has(token)) throw new Error("driver reprocess repeated a candidate");
+      seenTokens.add(token);
+      if (BigInt(candidate.server_seq) > BigInt(capabilities.current_seq)) {
+        throw new Error("quarantine sequence exceeds authenticated server state");
+      }
+      const message = { server_seq: candidate.server_seq, id: candidate.id,
+        server_received_at: candidate.server_received_at, envelope: candidate.envelope };
+      const evaluated = await evaluateCall(config, capabilities, message);
+      records.push({ type: "sync_pull_message", ...message, ...evaluated });
+    }
+    if (records.length > 0) {
+      records.push({ type: "sync_pull_cursor", next_after: state.transport_cursor });
+      const applied = await driverCall("apply", config, records);
+      await logApplyCall(config, records, applied);
+      total += candidates.length;
+    }
+    if (!page.has_more) break;
+    if (seenTokens.has(page.next_after) && page.next_after === after) {
+      throw new Error("driver reprocess pagination looped");
+    }
+    after = page.next_after;
+  }
+  await eventCall("reprocess.complete", { count: total,
+    transport_cursor: stableState.transport_cursor });
 }
 
 function resultFromResyncAudit(status) {

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1268,8 +1268,20 @@ export async function reprocessCycle(config, limit, dependencies = {}) {
   let after = null;
   let stableState = null;
   let total = 0;
+  let pageCount = 0n;
+  const retentionFloor = BigInt(capabilities.min_available_seq);
+  // Locally retained quarantine may cover both the server-retained suffix and
+  // the unavailable prefix, so the authenticated lifetime sequence space is
+  // floor + (current-floor), rather than only the current retained window.
+  const authenticatedSequenceSpace = retentionFloor +
+    (BigInt(capabilities.current_seq) - retentionFloor);
   const seenTokens = new Set();
+  const seenSequences = new Set();
   for (;;) {
+    pageCount += 1n;
+    if (pageCount > authenticatedSequenceSpace + 1n) {
+      throw new Error("driver reprocess walk exceeds authenticated sequence space");
+    }
     const extra = [String(limit), ...(after === null ? [] : [after])];
     const pending = await driverCall("reprocess", config, [], extra);
     const { state, candidates, page } = validateReprocessDriverPage(pending, limit, after);
@@ -1284,6 +1296,16 @@ export async function reprocessCycle(config, limit, dependencies = {}) {
       const token = reprocessCandidateToken(candidate);
       if (seenTokens.has(token)) throw new Error("driver reprocess repeated a candidate");
       seenTokens.add(token);
+      if (candidate.server_seq === "0") {
+        throw new Error("driver reprocess candidate has no canonical server sequence");
+      }
+      if (seenSequences.has(candidate.server_seq)) {
+        throw new Error("driver reprocess mapped one server sequence to multiple wire ids");
+      }
+      seenSequences.add(candidate.server_seq);
+      if (BigInt(seenSequences.size) > authenticatedSequenceSpace) {
+        throw new Error("driver reprocess candidate count exceeds authenticated sequence space");
+      }
       if (BigInt(candidate.server_seq) > BigInt(capabilities.current_seq)) {
         throw new Error("quarantine sequence exceeds authenticated server state");
       }

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -12,6 +12,7 @@ import {
   parseStrictJsonl,
   readStateCycle,
   readStateUpdateBatches,
+  reprocessCycle,
   request,
   resyncCycle,
   retainAgeCheckpoint,
@@ -58,6 +59,52 @@ test("ack mapping rejects reversed and duplicate server sequences", () => {
     { id: candidates[0].id, server_seq: "1", disposition: "stored", extra: true },
     { id: candidates[1].id, server_seq: "2", disposition: "stored" },
   ]), /shape/u);
+});
+
+test("explicit reprocess walks past a permanent first keyset page", async () => {
+  const capabilities = {
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, team_name: "demo", min_available_seq: "0",
+    current_seq: "2", next_sequence_boundary: "3", accepted_envelope_versions: [1],
+    write_allowed_ciphers: ["none"], policy_revision: "0", effective_from_seq: "1",
+    max_blob_bytes: "1048576", policy_history: [{ policy_revision: "0",
+      effective_from_seq: "1", accepted_envelope_versions: [1],
+      write_allowed_ciphers: ["none"] }],
+  };
+  const ids = ["550e8400-e29b-41d4-a716-446655440001",
+    "550e8400-e29b-41d4-a716-446655440002"];
+  const applied = [];
+  const driverCall = async (operation, _config, input, extra) => {
+    if (operation === "apply") {
+      applied.push(...input.filter((record) => record.type === "sync_pull_message")
+        .map((record) => record.id));
+      return [{ type: "sync_apply_result", transport_cursor: "2", corrupt_count: 0 }];
+    }
+    assert.equal(operation, "reprocess");
+    const pageIndex = extra.length === 1 ? 0 : 1;
+    if (pageIndex === 1) assert.equal(extra[1], `1:${ids[0]}`);
+    const seq = String(pageIndex + 1);
+    return [
+      { type: "sync_state", driver_generation: "018f3f7e-0000-7000-8000-000000000099",
+        transport_cursor: "2" },
+      { type: "sync_reprocess_candidate", server_seq: seq, id: ids[pageIndex],
+        server_received_at: "2026-07-22T11:00:00.000000Z",
+        envelope: { v: 1, cipher: "none", key_id: null, blob: "e30=" },
+        prior_status: "authentication_failed" },
+      { type: "sync_reprocess_page", next_after: pageIndex === 0 ? `1:${ids[0]}` : null,
+        has_more: pageIndex === 0 },
+    ];
+  };
+  await reprocessCycle(config, 1, {
+    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    requestCall: async () => capabilities,
+    driverCall,
+    evaluateCall: async () => ({ status: "authentication_failed", reason: "still blocked",
+      policy_revision: "0", local_security_revision: "0" }),
+    eventCall: async () => {},
+    logApplyCall: async () => {},
+  });
+  assert.deepEqual(applied, ids);
 });
 
 test("Stage-2 roster, update batches, and response pages are canonical", () => {

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -107,6 +107,45 @@ test("explicit reprocess walks past a permanent first keyset page", async () => 
   assert.deepEqual(applied, ids);
 });
 
+test("explicit reprocess rejects an unbounded walk through duplicate server sequences", async () => {
+  const capabilities = {
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, team_name: "demo", min_available_seq: "0",
+    current_seq: "2", next_sequence_boundary: "3", accepted_envelope_versions: [1],
+    write_allowed_ciphers: ["none"], policy_revision: "0", effective_from_seq: "1",
+    max_blob_bytes: "1048576", policy_history: [{ policy_revision: "0",
+      effective_from_seq: "1", accepted_envelope_versions: [1],
+      write_allowed_ciphers: ["none"] }],
+  };
+  const ids = ["550e8400-e29b-41d4-a716-446655440001",
+    "550e8400-e29b-41d4-a716-446655440002"];
+  let pageIndex = 0;
+  await assert.rejects(() => reprocessCycle(config, 1, {
+    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    requestCall: async () => capabilities,
+    driverCall: async (operation) => {
+      if (operation === "apply") {
+        return [{ type: "sync_apply_result", transport_cursor: "2", corrupt_count: 0 }];
+      }
+      const id = ids[pageIndex];
+      pageIndex += 1;
+      return [
+        { type: "sync_state", driver_generation: "018f3f7e-0000-7000-8000-000000000099",
+          transport_cursor: "2" },
+        { type: "sync_reprocess_candidate", server_seq: "1", id,
+          server_received_at: "2026-07-22T11:00:00.000000Z",
+          envelope: { v: 1, cipher: "none", key_id: null, blob: "e30=" },
+          prior_status: "authentication_failed" },
+        { type: "sync_reprocess_page", next_after: pageIndex === 1 ? `1:${id}` : null,
+          has_more: pageIndex === 1 },
+      ];
+    },
+    evaluateCall: async () => ({ status: "authentication_failed", reason: "still blocked",
+      policy_revision: "0", local_security_revision: "0" }),
+    eventCall: async () => {}, logApplyCall: async () => {},
+  }), /one server sequence to multiple wire ids/u);
+});
+
 test("Stage-2 roster, update batches, and response pages are canonical", () => {
   const members = [{ member_id: "018f3f7e-0000-7000-8000-000000000010", name: "worker-1" }];
   assert.deepEqual(validateMembers(config, {

--- a/tests/test_jsonl_remote_sync.bats
+++ b/tests/test_jsonl_remote_sync.bats
@@ -73,6 +73,22 @@ candidate_of() { printf '%s\n' "$1" | jq -c 'select(.type=="sync_push_candidate"
   [ "$(printf '%s\n' "$output" | jq -s '[.[]|select(.type=="sync_push_candidate")]|length')" -eq 2 ]
 }
 
+@test "jsonl append rollback removes a partial transition before releasing the lock" {
+  storage_send demo alice bob partial-append >/dev/null
+  local log before after
+  log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  before=$(cksum "$log")
+  export AGMSG_SYNC_TEST_PARTIAL_APPEND_BYTES=17
+  run prepare_push
+  [ "$status" -eq 75 ]
+  unset AGMSG_SYNC_TEST_PARTIAL_APPEND_BYTES
+  after=$(cksum "$log")
+  [ "$before" = "$after" ]
+  run prepare_push
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | jq -s '[.[]|select(.type=="sync_push_candidate")]|length')" -eq 1 ]
+}
+
 @test "jsonl sync rejects duplicate-key input and journal records before mutation" {
   storage_send demo alice bob strict >/dev/null
   local log input; log="$(dirname "$(agmsg_db_path)")/events.jsonl"
@@ -111,6 +127,57 @@ candidate_of() { printf '%s\n' "$1" | jq -c 'select(.type=="sync_push_candidate"
   [ "$(printf '%s\n' "$result" | jq -r '.push_cursor')" = "$last_position" ]
 }
 
+@test "jsonl reconcile durably records a conflicting immutable server sequence" {
+  storage_send demo alice bob conflict >/dev/null
+  local prepared candidate first second log before_cursor after_cursor
+  prepared=$(prepare_push); candidate=$(candidate_of "$prepared")
+  first=$(printf '%s\n' "$candidate" | jq -c '
+    {type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}')
+  before_cursor=$(printf '%s\n' "$first" |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 | jq -r .push_cursor)
+  second=$(printf '%s\n' "$candidate" | jq -c '
+    {type:"sync_push_ack",local_position,id,server_seq:"2",disposition:"stored"}')
+  after_cursor=$(printf '%s\n' "$second" |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 | jq -r .push_cursor)
+  [ "$after_cursor" = "$before_cursor" ]
+  log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  [ "$(jq -s '[.[]|select(.type=="sync_conflict_commit")|.conflicts[]|
+    select(.kind=="ack_sequence_conflict" and .expected_server_seq=="1" and
+           .observed_server_seq=="2")]|length' "$log")" -eq 1 ]
+  [ "$(jq -s '[.[]|select(.type=="sync_reconcile_commit")]|length' "$log")" -eq 1 ]
+  printf '%s\n' "$second" |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  [ "$(jq -s '[.[]|select(.type=="sync_conflict_commit")]|length' "$log")" -eq 1 ]
+}
+
+@test "jsonl prepare durably rejects one local id with different payloads" {
+  local id log first_at
+  id=$(storage_send demo alice bob first-payload)
+  log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  first_at=$(jq -r --arg id "$id" 'select(.id==$id)|.at' "$log")
+  jq -nc --arg id "$id" --arg at "$first_at" '
+    {type:"message_sent",id:$id,team:"demo",from:"alice",to:"bob",
+     body:"different-payload",at:$at}' >> "$log"
+  run prepare_push
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | jq -s '[.[]|select(.type=="sync_push_candidate")]|length')" -eq 0 ]
+  [ "$(jq -s '[.[]|select(.type=="sync_conflict_commit")|.conflicts[]|
+    select(.kind=="local_payload_conflict")]|length' "$log")" -eq 1 ]
+  run prepare_push
+  [ "$status" -eq 0 ]
+  [ "$(jq -s '[.[]|select(.type=="sync_conflict_commit")]|length' "$log")" -eq 1 ]
+}
+
+@test "jsonl reconcile validates every ack before creating sync state" {
+  local log
+  log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  run storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 <<'EOF'
+{"type":"sync_push_ack","local_position":"1","id":"not-a-wire-id","server_seq":"1","disposition":"stored"}
+EOF
+  [ "$status" -ne 0 ]
+  [ "$(jq -s '[.[]|select(.type|startswith("sync_"))]|length' "$log")" -eq 0 ]
+}
+
 @test "jsonl pull atomically reconciles echo, imports once, and projects normal local views" {
   storage_send demo alice bob outgoing >/dev/null
   local prepared candidate ack echo remote page result log
@@ -140,6 +207,16 @@ candidate_of() { printf '%s\n' "$1" | jq -c 'select(.type=="sync_push_candidate"
   [ "$(storage_history demo | jq -s 'length')" -eq 2 ]
   [ "$(storage_history demo | jq -s '[.[]|select(.body=="incoming")]|length')" -eq 1 ]
   [ "$(storage_list_unread demo bob | jq -s '[.[]|select(.body=="incoming")]|length')" -eq 1 ]
+  local fake_bin="$BATS_TEST_TMPDIR/fake-bin" marker="$BATS_TEST_TMPDIR/duckdb-called"
+  mkdir -p "$fake_bin"
+  printf '#!/usr/bin/env bash\n: > %q\nexit 99\n' "$marker" > "$fake_bin/duckdb"
+  chmod +x "$fake_bin/duckdb"
+  run env PATH="$fake_bin:$PATH" AGMSG_JSONL_ENGINE=duckdb bash -c '
+    source "$1"; agmsg_storage_load; storage_list_unread demo bob
+  ' _ "$SCRIPTS/lib/storage.sh"
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | jq -s '[.[]|select(.body=="incoming")]|length')" -eq 1 ]
+  [ ! -e "$marker" ]
   printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
   [ "$(storage_history demo | jq -s '[.[]|select(.body=="incoming")]|length')" -eq 1 ]
   [ "$(prepare_push | jq -s '[.[]|select(.type=="sync_push_candidate")]|length')" -eq 0 ]
@@ -149,6 +226,35 @@ candidate_of() { printf '%s\n' "$1" | jq -c 'select(.type=="sync_push_candidate"
   jq -e -s '[.[]|select(.type=="sync_pull_commit")][0]
     | (.transport_cursor=="2" and ([.messages[]|select(.local_event!=null)]|length)==1)' \
     "$log" >/dev/null
+}
+
+@test "jsonl reprocess promotes a durable blocking envelope without moving transport" {
+  local blocked page pending reevaluated result
+  blocked=$(jq -nc '{type:"sync_pull_message",server_seq:"1",
+    id:"550e8400-e29b-41d4-a716-446655440020",
+    server_received_at:"2026-07-22T11:03:00.000000Z",
+    envelope:{v:1,cipher:"age-v1",key_id:"epoch-1",blob:"YWdl"},
+    status:"pending_key",reason:"identity unavailable",
+    policy_revision:"0",local_security_revision:"0"}')
+  page=$(printf '%s\n%s\n' "$blocked" '{"type":"sync_pull_cursor","next_after":"1"}')
+  printf '%s\n' "$page" |
+    storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  pending=$(storage_sync_reprocess demo "$SERVER_ID" "$TEAM_ID" 1 100)
+  [ "$(printf '%s\n' "$pending" | jq -sr '[.[]|select(.type=="sync_state")][0].transport_cursor')" = 1 ]
+  [ "$(printf '%s\n' "$pending" | jq -s '[.[]|select(.type=="sync_reprocess_candidate")]|length')" -eq 1 ]
+  reevaluated=$(printf '%s\n' "$pending" | jq -c '
+    select(.type=="sync_reprocess_candidate") |
+    {type:"sync_pull_message",server_seq,id,server_received_at,envelope,
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"decrypted",created_at:"2026-07-22T11:03:00.000000Z",
+                 from_agent:"alice",to_agent:"bob"}}')
+  result=$(printf '%s\n%s\n' "$reevaluated" \
+    '{"type":"sync_pull_cursor","next_after":"1"}' |
+    storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -sr '.[0].transport_cursor')" = 1 ]
+  [ "$(storage_history demo | jq -s '[.[]|select(.body=="decrypted")]|length')" -eq 1 ]
+  [ "$(storage_sync_reprocess demo "$SERVER_ID" "$TEAM_ID" 1 100 |
+    jq -s '[.[]|select(.type=="sync_reprocess_candidate")]|length')" -eq 0 ]
 }
 
 @test "jsonl pull durably rejects a pre-echo server sequence conflict" {

--- a/tests/test_jsonl_remote_sync.bats
+++ b/tests/test_jsonl_remote_sync.bats
@@ -141,13 +141,41 @@ candidate_of() { printf '%s\n' "$1" | jq -c 'select(.type=="sync_push_candidate"
     storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 | jq -r .push_cursor)
   [ "$after_cursor" = "$before_cursor" ]
   log="$(dirname "$(agmsg_db_path)")/events.jsonl"
-  [ "$(jq -s '[.[]|select(.type=="sync_conflict_commit")|.conflicts[]|
+  [ "$(jq -s '[.[]|select(.type=="sync_reconcile_commit")|.conflicts[]|
     select(.kind=="ack_sequence_conflict" and .expected_server_seq=="1" and
            .observed_server_seq=="2")]|length' "$log")" -eq 1 ]
-  [ "$(jq -s '[.[]|select(.type=="sync_reconcile_commit")]|length' "$log")" -eq 1 ]
+  [ "$(jq -s '[.[]|select(.type=="sync_reconcile_commit")]|length' "$log")" -eq 2 ]
   printf '%s\n' "$second" |
     storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
-  [ "$(jq -s '[.[]|select(.type=="sync_conflict_commit")]|length' "$log")" -eq 1 ]
+  [ "$(jq -s '[.[]|select(.type=="sync_reconcile_commit")]|length' "$log")" -eq 2 ]
+}
+
+@test "jsonl reconcile atomically keeps valid acks beside a conflicting ack" {
+  storage_send demo alice bob first >/dev/null
+  local first first_candidate first_ack second second_candidate batch result log
+  first=$(prepare_push); first_candidate=$(candidate_of "$first")
+  first_ack=$(printf '%s\n' "$first_candidate" | jq -c '
+    {type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}')
+  printf '%s\n' "$first_ack" |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  storage_send demo alice bob second >/dev/null
+  second=$(prepare_push); second_candidate=$(candidate_of "$second")
+  batch=$(printf '%s\n%s\n' \
+    "$(printf '%s\n' "$second_candidate" | jq -c '
+      {type:"sync_push_ack",local_position,id,server_seq:"2",disposition:"stored"}')" \
+    "$(printf '%s\n' "$first_candidate" | jq -c '
+      {type:"sync_push_ack",local_position,id,server_seq:"3",disposition:"duplicate"}')")
+  result=$(printf '%s\n' "$batch" |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r .push_cursor)" = \
+    "$(printf '%s\n' "$second_candidate" | jq -r .local_position)" ]
+  log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  jq -e -s '[.[]|select(.type=="sync_reconcile_commit")][-1] |
+    (.acks|length)==1 and (.acks[0].server_seq=="2") and
+    (.conflicts|length)==1 and (.conflicts[0].observed_server_seq=="3")' "$log" >/dev/null
+  run prepare_push
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | jq -s '[.[]|select(.type=="sync_push_candidate")]|length')" -eq 0 ]
 }
 
 @test "jsonl prepare durably rejects one local id with different payloads" {
@@ -161,11 +189,33 @@ candidate_of() { printf '%s\n' "$1" | jq -c 'select(.type=="sync_push_candidate"
   run prepare_push
   [ "$status" -eq 0 ]
   [ "$(printf '%s\n' "$output" | jq -s '[.[]|select(.type=="sync_push_candidate")]|length')" -eq 0 ]
-  [ "$(jq -s '[.[]|select(.type=="sync_conflict_commit")|.conflicts[]|
+  [ "$(jq -s '[.[]|select(.type=="sync_prepare_commit")|.conflicts[]|
     select(.kind=="local_payload_conflict")]|length' "$log")" -eq 1 ]
   run prepare_push
   [ "$status" -eq 0 ]
-  [ "$(jq -s '[.[]|select(.type=="sync_conflict_commit")]|length' "$log")" -eq 1 ]
+  [ "$(jq -s '[.[]|select(.type=="sync_prepare_commit")]|length' "$log")" -eq 1 ]
+}
+
+@test "jsonl prepare commits clean reservations and payload conflicts in one transition" {
+  local clean conflict_id at log before
+  clean=$(storage_send demo alice bob clean)
+  conflict_id=$(storage_send demo alice bob first)
+  log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  at=$(jq -r --arg id "$conflict_id" 'select(.id==$id)|.at' "$log")
+  jq -nc --arg id "$conflict_id" --arg at "$at" '
+    {type:"message_sent",id:$id,team:"demo",from:"alice",to:"bob",body:"second",at:$at}' >> "$log"
+  before=$(cksum "$log")
+  export AGMSG_SYNC_TEST_PARTIAL_APPEND_BYTES=31
+  run prepare_push
+  [ "$status" -eq 75 ]
+  unset AGMSG_SYNC_TEST_PARTIAL_APPEND_BYTES
+  [ "$(cksum "$log")" = "$before" ]
+  run prepare_push
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | jq -sr '[.[]|select(.type=="sync_push_candidate")][0].local_id')" = "$clean" ]
+  [ "$(jq -s '[.[]|select(.type=="sync_prepare_commit")]|length' "$log")" -eq 1 ]
+  jq -e -s '[.[]|select(.type=="sync_prepare_commit")][0] |
+    (.reservations|length)==1 and (.conflicts|length)==1' "$log" >/dev/null
 }
 
 @test "jsonl reconcile validates every ack before creating sync state" {
@@ -173,6 +223,11 @@ candidate_of() { printf '%s\n' "$1" | jq -c 'select(.type=="sync_push_candidate"
   log="$(dirname "$(agmsg_db_path)")/events.jsonl"
   run storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 <<'EOF'
 {"type":"sync_push_ack","local_position":"1","id":"not-a-wire-id","server_seq":"1","disposition":"stored"}
+EOF
+  [ "$status" -ne 0 ]
+  [ "$(jq -s '[.[]|select(.type|startswith("sync_"))]|length' "$log")" -eq 0 ]
+  run storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 <<'EOF'
+{"type":"sync_push_ack","local_position":"1","id":"550e8400-e29b-41d4-a716-446655440099","server_seq":"1","disposition":"stored"}
 EOF
   [ "$status" -ne 0 ]
   [ "$(jq -s '[.[]|select(.type|startswith("sync_"))]|length' "$log")" -eq 0 ]
@@ -257,6 +312,31 @@ EOF
     jq -s '[.[]|select(.type=="sync_reprocess_candidate")]|length')" -eq 0 ]
 }
 
+@test "jsonl reprocess keyset pages reach candidates beyond a permanent first page" {
+  local records="" page first token second
+  local index wire
+  for index in 1 2 3; do
+    wire=$(printf '550e8400-e29b-41d4-a716-%012d' "$((30 + index))")
+    records="${records}$(jq -nc --arg seq "$index" --arg id "$wire" '
+      {type:"sync_pull_message",server_seq:$seq,id:$id,
+       server_received_at:"2026-07-22T11:04:00.000000Z",
+       envelope:{v:1,cipher:"age-v1",key_id:"epoch-1",blob:"YWdl"},
+       status:"authentication_failed",reason:"permanent in this round",
+       policy_revision:"0",local_security_revision:"0"}')"$'\n'
+  done
+  page="${records}{\"type\":\"sync_pull_cursor\",\"next_after\":\"3\"}"
+  printf '%s\n' "$page" |
+    storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  first=$(storage_sync_reprocess demo "$SERVER_ID" "$TEAM_ID" 1 2)
+  [ "$(printf '%s\n' "$first" | jq -s '[.[]|select(.type=="sync_reprocess_candidate")]|length')" -eq 2 ]
+  token=$(printf '%s\n' "$first" | jq -r 'select(.type=="sync_reprocess_page")|.next_after')
+  [ "$(printf '%s\n' "$first" | jq -r 'select(.type=="sync_reprocess_page")|.has_more')" = true ]
+  second=$(storage_sync_reprocess demo "$SERVER_ID" "$TEAM_ID" 1 2 "$token")
+  [ "$(printf '%s\n' "$second" | jq -s '[.[]|select(.type=="sync_reprocess_candidate")]|length')" -eq 1 ]
+  [ "$(printf '%s\n' "$second" | jq -r 'select(.type=="sync_reprocess_candidate")|.server_seq')" = 3 ]
+  [ "$(printf '%s\n' "$second" | jq -r 'select(.type=="sync_reprocess_page")|.has_more')" = false ]
+}
+
 @test "jsonl pull durably rejects a pre-echo server sequence conflict" {
   storage_send demo alice bob outgoing >/dev/null
   local prepared candidate ack conflict page result
@@ -316,6 +396,26 @@ EOF
     storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1)
   [ "$(printf '%s\n' "$result" | jq -r '.push_cursor')" = \
     "$(printf '%s\n' "$new_candidate" | jq -r '.local_position')" ]
+}
+
+@test "jsonl compaction does not reuse a physical push offset as the new generation cursor" {
+  storage_send demo alice bob before-compact >/dev/null
+  local first candidate ack second later result
+  first=$(prepare_push); candidate=$(candidate_of "$first")
+  ack=$(printf '%s\n' "$candidate" | jq -c '
+    {type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}')
+  printf '%s\n' "$ack" |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  storage_compact >/dev/null
+  storage_send demo alice bob after-compact >/dev/null
+  second=$(prepare_push); later=$(candidate_of "$second")
+  [ "$(printf '%s\n' "$later" | jq -r .local_id)" != "$(printf '%s\n' "$candidate" | jq -r .local_id)" ]
+  ack=$(printf '%s\n' "$later" | jq -c '
+    {type:"sync_push_ack",local_position,id,server_seq:"2",disposition:"stored"}')
+  result=$(printf '%s\n' "$ack" |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r .push_cursor)" = \
+    "$(printf '%s\n' "$later" | jq -r .local_position)" ]
 }
 
 @test "jsonl rewrite crash after new generation append leaves the original journal untouched" {

--- a/tests/test_jsonl_remote_sync.bats
+++ b/tests/test_jsonl_remote_sync.bats
@@ -1,0 +1,258 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=jsonl
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  storage_init >/dev/null
+  SERVER_ID=018f3f7e-0000-7000-8000-000000000000
+  TEAM_ID=018f3f7e-0000-7000-8000-000000000001
+  PREPARE='{"type":"sync_prepare","envelope_v":1,"cipher":"none","key_id":null,"recipients":[],"max_blob_bytes":1048576,"allow_new":true}'
+}
+
+teardown() { teardown_test_env; }
+
+prepare_push() {
+  printf '%s\n' "$PREPARE" |
+    storage_sync_prepare_push demo "$SERVER_ID" "$TEAM_ID" 1 "${1:-100}"
+}
+
+candidate_of() { printf '%s\n' "$1" | jq -c 'select(.type=="sync_push_candidate")'; }
+
+@test "jsonl sync advertises Stage-1 only when its runtime seam is available" {
+  run storage_describe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"capabilities=stage1-sync"* ]]
+}
+
+@test "jsonl prepare publishes a byte-stable age-v1 envelope through the cipher seam" {
+  local age_bin="${AGMSG_AGE_BIN:-age}"
+  command -v "$age_bin" >/dev/null 2>&1 || skip "age CLI is not installed"
+  local recipient age_prepare first second
+  recipient=$(jq -r '.recipient_sets.team_a.recipient' \
+    "$BATS_TEST_DIRNAME/../docs/spec/vectors/age-v1-vectors.json")
+  age_prepare=$(jq -nc --arg recipient "$recipient" '
+    {type:"sync_prepare",envelope_v:1,cipher:"age-v1",key_id:"epoch-1",
+     recipients:[$recipient],max_blob_bytes:1048576,allow_new:true}')
+  storage_send demo alice bob encrypted >/dev/null
+  first=$(printf '%s\n' "$age_prepare" |
+    storage_sync_prepare_push demo "$SERVER_ID" "$TEAM_ID" 1 100)
+  second=$(printf '%s\n' "$age_prepare" |
+    storage_sync_prepare_push demo "$SERVER_ID" "$TEAM_ID" 1 100)
+  [ "$(candidate_of "$first" | jq -c '{local_id,id,envelope}')" = \
+    "$(candidate_of "$second" | jq -c '{local_id,id,envelope}')" ]
+  candidate_of "$first" | jq -e '
+    .envelope.cipher=="age-v1" and .envelope.key_id=="epoch-1" and
+    (.envelope.blob|type)=="string" and (.envelope.blob|length)>0' >/dev/null
+}
+
+@test "jsonl sync publishes one byte-stable reservation and abandons a pre-commit seal" {
+  storage_send demo alice bob stable >/dev/null
+  local first second log
+  first=$(prepare_push)
+  second=$(prepare_push)
+  [ "$(candidate_of "$first" | jq -c '{local_position,local_id,id,envelope}')" = \
+    "$(candidate_of "$second" | jq -c '{local_position,local_id,id,envelope}')" ]
+
+  storage_send demo alice bob crash-before-publish >/dev/null
+  export AGMSG_SYNC_TEST_ABORT_AFTER_SEAL=1
+  run prepare_push
+  [ "$status" -eq 75 ]
+  unset AGMSG_SYNC_TEST_ABORT_AFTER_SEAL
+  log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  [ "$(jq -s '[.[]|select(.type=="sync_prepare_commit")|.reservations[]|
+    select(.local_id as $id | $id != null)]|length' "$log")" -eq 1 ]
+  run prepare_push
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | jq -s '[.[]|select(.type=="sync_push_candidate")]|length')" -eq 2 ]
+}
+
+@test "jsonl sync rejects duplicate-key input and journal records before mutation" {
+  storage_send demo alice bob strict >/dev/null
+  local log input; log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  input="$BATS_TEST_TMPDIR/duplicate-input.jsonl"
+  printf '%s\n' '{"type":"sync_prepare","envelope_v":1,"cipher":"none","key_id":null,"recipients":[],"max_blob_bytes":1048576,"allow_new":true,"allow_new":false}' > "$input"
+  run storage_sync_prepare_push demo "$SERVER_ID" "$TEAM_ID" 1 100 < "$input"
+  [ "$status" -ne 0 ]
+  [ "$(jq -s '[.[]|select(.type|startswith("sync_"))]|length' "$log")" -eq 0 ]
+
+  printf '%s\n' '{"type":"sync_generation","generation":"550e8400-e29b-41d4-a716-446655440000","generation":"550e8400-e29b-41d4-a716-446655440001"}' >> "$log"
+  run prepare_push
+  [ "$status" -ne 0 ]
+  [ "$(grep -c '"type":"sync_prepare_commit"' "$log" || true)" -eq 0 ]
+}
+
+@test "jsonl reconcile advances only an acknowledged contiguous byte-offset prefix" {
+  storage_send demo alice bob one >/dev/null
+  storage_send demo alice bob two >/dev/null
+  storage_send demo alice bob three >/dev/null
+  local prepared first later result last_position
+  prepared=$(prepare_push 3)
+  first=$(printf '%s\n' "$prepared" | jq -c 'select(.type=="sync_push_candidate")' | sed -n '1p')
+  later=$(printf '%s\n' "$prepared" | jq -cs '
+    [ .[] | select(.type=="sync_push_candidate") ][1:]
+    | to_entries[]
+    | {type:"sync_push_ack",local_position:.value.local_position,id:.value.id,
+       server_seq:((.key + 2)|tostring),disposition:"stored"}')
+  result=$(printf '%s\n' "$later" |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r '.push_cursor')" = 0 ]
+  result=$(printf '%s\n' "$first" | jq -c '
+    {type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}' |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1)
+  last_position=$(printf '%s\n' "$prepared" |
+    jq -r 'select(.type=="sync_push_candidate")|.local_position' | tail -n 1)
+  [ "$(printf '%s\n' "$result" | jq -r '.push_cursor')" = "$last_position" ]
+}
+
+@test "jsonl pull atomically reconciles echo, imports once, and projects normal local views" {
+  storage_send demo alice bob outgoing >/dev/null
+  local prepared candidate ack echo remote page result log
+  prepared=$(prepare_push); candidate=$(candidate_of "$prepared")
+  ack=$(printf '%s\n' "$candidate" | jq -c '
+    {type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}')
+  printf '%s\n' "$ack" |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  echo=$(printf '%s\n' "$candidate" | jq -c '
+    {type:"sync_pull_message",server_seq:"1",id,envelope,
+     server_received_at:"2026-07-22T11:00:00.000000Z",status:"importable",
+     policy_revision:"0",local_security_revision:"0",
+     projection:{body:"outgoing",created_at:"2026-07-22T11:00:00.000000Z",
+                 from_agent:"alice",to_agent:"bob"}}')
+  remote=$(jq -nc '{type:"sync_pull_message",server_seq:"2",
+    id:"550e8400-e29b-41d4-a716-446655440000",
+    server_received_at:"2026-07-22T11:00:01.000000Z",
+    envelope:{v:1,cipher:"none",key_id:null,blob:"e30="},status:"importable",
+    policy_revision:"0",local_security_revision:"0",
+    projection:{body:"incoming",created_at:"2026-07-22T11:00:01.000000Z",
+                from_agent:"carol",to_agent:"bob"}}')
+  page=$(printf '%s\n%s\n%s\n' "$echo" "$remote" \
+    '{"type":"sync_pull_cursor","next_after":"2"}')
+  result=$(printf '%s\n' "$page" |
+    storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -sr '.[0].transport_cursor')" = 2 ]
+  [ "$(storage_history demo | jq -s 'length')" -eq 2 ]
+  [ "$(storage_history demo | jq -s '[.[]|select(.body=="incoming")]|length')" -eq 1 ]
+  [ "$(storage_list_unread demo bob | jq -s '[.[]|select(.body=="incoming")]|length')" -eq 1 ]
+  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  [ "$(storage_history demo | jq -s '[.[]|select(.body=="incoming")]|length')" -eq 1 ]
+  [ "$(prepare_push | jq -s '[.[]|select(.type=="sync_push_candidate")]|length')" -eq 0 ]
+  storage_compact >/dev/null
+  [ "$(storage_history demo | jq -s '[.[]|select(.body=="incoming")]|length')" -eq 1 ]
+  log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  jq -e -s '[.[]|select(.type=="sync_pull_commit")][0]
+    | (.transport_cursor=="2" and ([.messages[]|select(.local_event!=null)]|length)==1)' \
+    "$log" >/dev/null
+}
+
+@test "jsonl pull durably rejects a pre-echo server sequence conflict" {
+  storage_send demo alice bob outgoing >/dev/null
+  local prepared candidate ack conflict page result
+  prepared=$(prepare_push); candidate=$(candidate_of "$prepared")
+  ack=$(printf '%s\n' "$candidate" | jq -c '
+    {type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}')
+  printf '%s\n' "$ack" |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  conflict=$(jq -nc '{type:"sync_pull_message",server_seq:"1",
+    id:"550e8400-e29b-41d4-a716-446655440010",
+    server_received_at:"2026-07-22T11:01:00.000000Z",
+    envelope:{v:1,cipher:"none",key_id:null,blob:"e30="},status:"importable",
+    policy_revision:"0",local_security_revision:"0",
+    projection:{body:"must-not-import",created_at:"2026-07-22T11:01:00.000000Z",
+                from_agent:"mallory",to_agent:"bob"}}')
+  page=$(printf '%s\n%s\n' "$conflict" \
+    '{"type":"sync_pull_cursor","next_after":"1"}')
+  result=$(printf '%s\n' "$page" |
+    storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r 'select(.type=="sync_apply_outcome")|.status')" = \
+    corrupt_state ]
+  [ "$(storage_history demo | jq -s '[.[]|select(.body=="must-not-import")]|length')" -eq 0 ]
+}
+
+@test "jsonl pull echo before POST acknowledgement durably reconciles the reservation" {
+  storage_send demo alice bob early-echo >/dev/null
+  local prepared candidate echo page after
+  prepared=$(prepare_push); candidate=$(candidate_of "$prepared")
+  echo=$(printf '%s\n' "$candidate" | jq -c '
+    {type:"sync_pull_message",server_seq:"1",id,envelope,
+     server_received_at:"2026-07-22T11:02:00.000000Z",status:"importable",
+     policy_revision:"0",local_security_revision:"0",
+     projection:{body:"early-echo",created_at:"2026-07-22T11:02:00.000000Z",
+                 from_agent:"alice",to_agent:"bob"}}')
+  page=$(printf '%s\n%s\n' "$echo" \
+    '{"type":"sync_pull_cursor","next_after":"1"}')
+  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  after=$(prepare_push)
+  [ "$(printf '%s\n' "$after" | jq -s '[.[]|select(.type=="sync_push_candidate")]|length')" -eq 0 ]
+  [ "$(storage_history demo | jq -s '[.[]|select(.body=="early-echo")]|length')" -eq 1 ]
+}
+
+@test "jsonl compaction rotates generation but preserves in-flight wire acknowledgement" {
+  storage_send demo alice bob compact-safe >/dev/null
+  local before candidate old_generation after new_candidate new_generation ack result
+  before=$(prepare_push); candidate=$(candidate_of "$before")
+  old_generation=$(printf '%s\n' "$before" | jq -r 'select(.type=="sync_state")|.driver_generation')
+  storage_compact >/dev/null
+  after=$(prepare_push); new_candidate=$(candidate_of "$after")
+  new_generation=$(printf '%s\n' "$after" | jq -r 'select(.type=="sync_state")|.driver_generation')
+  [ "$old_generation" != "$new_generation" ]
+  [ "$(printf '%s\n' "$candidate" | jq -c '{local_id,id,envelope}')" = \
+    "$(printf '%s\n' "$new_candidate" | jq -c '{local_id,id,envelope}')" ]
+  ack=$(printf '%s\n' "$candidate" | jq -c '
+    {type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}')
+  result=$(printf '%s\n' "$ack" |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r '.push_cursor')" = \
+    "$(printf '%s\n' "$new_candidate" | jq -r '.local_position')" ]
+}
+
+@test "jsonl rewrite crash after new generation append leaves the original journal untouched" {
+  storage_send demo alice bob rewrite-crash >/dev/null
+  prepare_push >/dev/null
+  local log before after
+  log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  before=$(cksum "$log")
+  export AGMSG_SYNC_TEST_ABORT_AFTER_ROTATE_APPEND=1
+  run storage_compact
+  [ "$status" -eq 13 ]
+  unset AGMSG_SYNC_TEST_ABORT_AFTER_ROTATE_APPEND
+  after=$(cksum "$log")
+  [ "$before" = "$after" ]
+  run prepare_push
+  [ "$status" -eq 0 ]
+}
+
+@test "jsonl concurrent prepare converges on one journal winner" {
+  storage_send demo alice bob concurrent >/dev/null
+  local first="$BATS_TEST_TMPDIR/first" second="$BATS_TEST_TMPDIR/second" log
+  (printf '%s\n' "$PREPARE" |
+    storage_sync_prepare_push demo "$SERVER_ID" "$TEAM_ID" 1 100 >"$first") 3>&- 4>&- &
+  local first_pid=$!
+  (printf '%s\n' "$PREPARE" |
+    storage_sync_prepare_push demo "$SERVER_ID" "$TEAM_ID" 1 100 >"$second") 3>&- 4>&- &
+  local second_pid=$!
+  wait "$first_pid"; wait "$second_pid"
+  [ "$(candidate_of "$(cat "$first")" | jq -c '{local_id,id,envelope}')" = \
+    "$(candidate_of "$(cat "$second")" | jq -c '{local_id,id,envelope}')" ]
+  log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  [ "$(jq -s '[.[]|select(.type=="sync_prepare_commit")]|length' "$log")" -eq 1 ]
+}
+
+@test "jsonl team rename rotates offsets and preserves the durable wire mapping" {
+  storage_send demo alice bob rename-safe >/dev/null
+  local before candidate after rebound
+  before=$(prepare_push); candidate=$(candidate_of "$before")
+  storage_rename_team demo renamed >/dev/null
+  after=$(printf '%s\n' "$PREPARE" |
+    storage_sync_prepare_push renamed "$SERVER_ID" "$TEAM_ID" 1 100)
+  rebound=$(candidate_of "$after")
+  [ "$(printf '%s\n' "$candidate" | jq -c '{local_id,id,envelope}')" = \
+    "$(printf '%s\n' "$rebound" | jq -c '{local_id,id,envelope}')" ]
+  [ "$(storage_history renamed | jq -s '[.[]|select(.body=="rename-safe")]|length')" -eq 1 ]
+}

--- a/tests/test_jsonl_remote_sync.bats
+++ b/tests/test_jsonl_remote_sync.bats
@@ -104,6 +104,29 @@ candidate_of() { printf '%s\n' "$1" | jq -c 'select(.type=="sync_push_candidate"
   [ "$(grep -c '"type":"sync_prepare_commit"' "$log" || true)" -eq 0 ]
 }
 
+@test "jsonl fold accepts pre-integration commits without conflict or digest fields" {
+  storage_send demo alice bob legacy >/dev/null
+  local prepared candidate ack log rewritten later
+  prepared=$(prepare_push); candidate=$(candidate_of "$prepared")
+  ack=$(printf '%s\n' "$candidate" | jq -c '
+    {type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}')
+  printf '%s\n' "$ack" |
+    storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  rewritten="$BATS_TEST_TMPDIR/legacy-events.jsonl"
+  jq -c 'if .type=="sync_prepare_commit" then del(.conflicts) |
+      .reservations |= map(del(.payload_digest))
+    elif .type=="sync_reconcile_commit" then del(.conflicts) else . end' \
+    "$log" > "$rewritten"
+  mv "$rewritten" "$log"
+  storage_send demo alice bob after-upgrade >/dev/null
+  run prepare_push
+  [ "$status" -eq 0 ]
+  later=$(candidate_of "$output")
+  [ "$(printf '%s\n' "$later" | jq -r .local_id)" != \
+    "$(printf '%s\n' "$candidate" | jq -r .local_id)" ]
+}
+
 @test "jsonl reconcile advances only an acknowledged contiguous byte-offset prefix" {
   storage_send demo alice bob one >/dev/null
   storage_send demo alice bob two >/dev/null
@@ -335,6 +358,15 @@ EOF
   [ "$(printf '%s\n' "$second" | jq -s '[.[]|select(.type=="sync_reprocess_candidate")]|length')" -eq 1 ]
   [ "$(printf '%s\n' "$second" | jq -r 'select(.type=="sync_reprocess_candidate")|.server_seq')" = 3 ]
   [ "$(printf '%s\n' "$second" | jq -r 'select(.type=="sync_reprocess_page")|.has_more')" = false ]
+}
+
+@test "jsonl reprocess rejects a malformed page token before state initialization" {
+  local log before
+  log="$(dirname "$(agmsg_db_path)")/events.jsonl"
+  before=$(cksum "$log")
+  run storage_sync_reprocess demo "$SERVER_ID" "$TEAM_ID" 1 2 malformed-token
+  [ "$status" -ne 0 ]
+  [ "$(cksum "$log")" = "$before" ]
 }
 
 @test "jsonl pull durably rejects a pre-echo server sequence conflict" {

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -213,6 +213,30 @@ prepare_push() {
   [ "$(agmsg_sqlite "$db" "SELECT status FROM sync_quarantine WHERE wire_id='550e8400-e29b-41d4-a716-446655440020';" | tr -d '\r')" = imported ]
 }
 
+@test "sync contract: reprocess candidate body and trailer share one keyset page" {
+  local records="" page first token second index wire
+  for index in 1 2 3; do
+    wire=$(printf '550e8400-e29b-41d4-a716-%012d' "$((40 + index))")
+    records="${records}$(jq -nc --arg seq "$index" --arg id "$wire" '
+      {type:"sync_pull_message",server_seq:$seq,id:$id,
+       server_received_at:"2026-07-20T13:04:00.000000Z",
+       envelope:{v:1,cipher:"age-v1",key_id:"epoch-1",blob:"YWdl"},
+       status:"authentication_failed",reason:"blocked",
+       policy_revision:"0",local_security_revision:"0"}')"$'\n'
+  done
+  page="${records}{\"type\":\"sync_pull_cursor\",\"next_after\":\"3\"}"
+  printf '%s\n' "$page" |
+    storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  first=$(storage_sync_reprocess demo "$SERVER_ID" "$TEAM_ID" 1 2)
+  [ "$(printf '%s\n' "$first" | jq -s '[.[]|select(.type=="sync_reprocess_candidate")]|length')" -eq 2 ]
+  token=$(printf '%s\n' "$first" | jq -r 'select(.type=="sync_reprocess_page")|.next_after')
+  [ "$token" = "2:550e8400-e29b-41d4-a716-000000000042" ]
+  [ "$(printf '%s\n' "$first" | jq -r 'select(.type=="sync_reprocess_page")|.has_more')" = true ]
+  second=$(storage_sync_reprocess demo "$SERVER_ID" "$TEAM_ID" 1 2 "$token")
+  [ "$(printf '%s\n' "$second" | jq -sr '[.[]|select(.type=="sync_reprocess_candidate")][0].server_seq')" = 3 ]
+  [ "$(printf '%s\n' "$second" | jq -r 'select(.type=="sync_reprocess_page")|.has_more')" = false ]
+}
+
 @test "sync contract: retention resync records one immutable gap and preserves local state" {
   storage_send demo alice bob "local survives retention" >/dev/null
   local prepared status input result repeated db wire


### PR DESCRIPTION
## Summary
- implement JSONL `prepare_push`, `reconcile_push`, and `apply_pull` behind the existing journal lock
- persist byte-stable wire reservations, acknowledgements, quarantine/import outcomes, and transport cursor as one-record fsynced transitions
- pair byte-offset sync positions with an atomically rotated file generation across compaction and rename
- project imported events through existing inbox/watch/history/export views without echo re-push

## Validation
- `bats tests/test_jsonl_remote_sync.bats` (12 contract/crash/concurrency cases; age-v1 when available)
- `AGMSG_STORAGE_DRIVER=jsonl bats tests/test_storage_contract.bats` (34)
- `bats tests/test_remote_sync.bats` (16)
- `node --test tests/remote_sync_engine.test.mjs` (21)

Draft/unmerged dogfood stack. Base is `dogfood/retention-resync`; no main merge is requested.