### PR TITLE
feat: remote connect onboarding (ADR 0007) — remote.sh + key.sh

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -157,6 +157,83 @@ Do NOT manually edit config files. Always use join.sh. If the name was recently 
 ~/.agents/skills/agmsg/scripts/despawn.sh <team> <from> <name> [--force] [--timeout N]
 ```
 
+### Remote sync & end-to-end encryption (ADR 0007)
+
+Connects a local team to a cloud/self-hosted sync endpoint and manages the
+team's `age-v1` encryption key. Additive to everything above — a team works
+purely locally without ever touching this. Login/token acquisition is out
+of this script's scope (some provider tooling, or a self-hosted server's
+own admin command, obtains the token); `connect` only ever receives one.
+
+```bash
+# Connect a team to a sync endpoint. <token> is a short-lived, single-use
+# exchange code (never the long-lived credential itself). Prefer
+# --token-stdin over the positional form — a bare positional token is
+# visible in shell history and `ps`; --token-stdin reads it from stdin
+# instead and is the required form for any programmatic caller.
+#   --force    rebind an already-connected team to a new token
+~/.agents/skills/agmsg/scripts/remote.sh connect --endpoint <url> <token> [<team>] [--force]
+~/.agents/skills/agmsg/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
+
+# If the team's capability response requires encryption and no local key
+# exists yet, connect pauses to generate or import one before finishing —
+# see the `key` commands below.
+
+# Show connection state. With no <team>, lists every locally-known
+# connected team (and whether each still needs a local encryption key).
+~/.agents/skills/agmsg/scripts/remote.sh status [<team>]
+
+# Disconnect a team: revokes the credential server-side (best-effort —
+# local state is always cleared even if the server is unreachable), then
+# clears the local sync driver override. Sends/reads keep working locally
+# afterward; this does not touch the team's encryption key.
+~/.agents/skills/agmsg/scripts/remote.sh disconnect <team>
+
+# Read-only preflight check (currently: is `age` installed?). No token, no
+# state change — safe to run any time, and the thing to point a user at
+# when troubleshooting a missing dependency.
+~/.agents/skills/agmsg/scripts/remote.sh doctor [<team>]
+
+# Generate the first age-v1 key for a team (single-writer onboarding only —
+# NOT the multi-writer cutover protocol). Prints a mandatory backup notice:
+# there is no server-side recovery, and losing the device loses the key.
+~/.agents/skills/agmsg/scripts/key.sh generate [<team>]
+
+# Show the team's public recipient + fingerprint. --reveal-secret prints
+# the private identity instead, after an interactive typed confirmation —
+# refused outright when there's no TTY (i.e. never usable from agent mode).
+~/.agents/skills/agmsg/scripts/key.sh show [<team>] [--reveal-secret]
+
+# Install a private age identity obtained out-of-band (e.g. via
+# `key.sh show <team> --reveal-secret` on another device that already has
+# it). Rejected if it doesn't match the team's already-authorized key.
+~/.agents/skills/agmsg/scripts/key.sh import <team> <identity>
+
+# Start a new epoch for a team with exactly one active writer (this
+# device). Never re-encrypts existing history — only messages sent after
+# rotation use the new key; every prior epoch's key is retained locally.
+~/.agents/skills/agmsg/scripts/key.sh rotate [<team>]
+```
+
+Slash-command surface (SKILL.md / per-type templates), same mapping
+pattern as every command above:
+
+```
+/agmsg remote connect --endpoint <url> <token>
+/agmsg remote status
+/agmsg remote disconnect <team>
+/agmsg remote doctor
+/agmsg key generate [<team>]
+/agmsg key show [<team>] [--reveal-secret]
+/agmsg key import <team> <identity>
+/agmsg key rotate [<team>]
+```
+
+Additional dependencies beyond bash/sqlite3 (only needed if these commands
+are used): `curl` (the exchange/revoke calls), `python3` (parsing the
+exchange response), and `age`/`age-keygen` (E2EE — `remote.sh doctor`
+checks for these and `key.sh`'s own commands refuse to run without them).
+
 ## Sandbox compatibility (Claude Code)
 
 When Claude Code's sandbox is enabled, `watch.sh` (monitor mode) runs inside the sandbox and needs to write pidfiles and SQLite WAL files under `~/.agents/skills/agmsg/`. Add an allowlist entry to `~/.claude/settings.json` (or project-level `.claude/settings.local.json`):
@@ -183,4 +260,4 @@ The allowlist merges across scopes and takes effect immediately — no restart n
 - **Teams**: `~/.agents/skills/agmsg/teams/<name>/config.json`
 - **Concurrency**: WAL allows multiple readers + 1 writer without conflicts
 - **No daemon**: Direct DB access via `sqlite3` CLI
-- **Dependencies**: bash, sqlite3 (no python3 required)
+- **Dependencies**: bash, sqlite3 (no python3 required) for core messaging; `remote`/`key` (ADR 0007) additionally need `curl`, `python3`, and `age`/`age-keygen`, but only if those commands are used

--- a/SKILL.md
+++ b/SKILL.md
@@ -165,15 +165,20 @@ purely locally without ever touching this. Login/token acquisition is out
 of this script's scope (some provider tooling, or a self-hosted server's
 own admin command, obtains the token); `connect` only ever receives one.
 
+**Always use the `--*-stdin` forms below from an agent context.** The bare
+positional forms (`<token>`, `<identity>`) exist only as a warned legacy
+path for a human typing directly into their own terminal — from an agent,
+they leak the secret into this session's own transcript/tool-result
+history, which is exactly the kind of exposure `--token-stdin`/
+`--identity-stdin` exist to avoid. Pipe the secret in; never pass it as
+a literal argument in a command you construct.
+
 ```bash
 # Connect a team to a sync endpoint. <token> is a short-lived, single-use
-# exchange code (never the long-lived credential itself). Prefer
-# --token-stdin over the positional form — a bare positional token is
-# visible in shell history and `ps`; --token-stdin reads it from stdin
-# instead and is the required form for any programmatic caller.
-#   --force    rebind an already-connected team to a new token
-~/.agents/skills/agmsg/scripts/remote.sh connect --endpoint <url> <token> [<team>] [--force]
-~/.agents/skills/agmsg/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
+# exchange code (never the long-lived credential itself).
+#   --force    rebind an already-connected team to a new token (requires
+#              an explicit <team> — it cannot be inferred for this check)
+printf '%s' "$TOKEN" | ~/.agents/skills/agmsg/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
 
 # If the team's capability response requires encryption and no local key
 # exists yet, connect pauses to generate or import one before finishing —
@@ -195,8 +200,9 @@ own admin command, obtains the token); `connect` only ever receives one.
 ~/.agents/skills/agmsg/scripts/remote.sh doctor [<team>]
 
 # Generate the first age-v1 key for a team (single-writer onboarding only —
-# NOT the multi-writer cutover protocol). Prints a mandatory backup notice:
-# there is no server-side recovery, and losing the device loses the key.
+# NOT the multi-writer cutover protocol, and NOT key rotation — see below).
+# Prints a mandatory backup notice: there is no server-side recovery, and
+# losing the device loses the key.
 ~/.agents/skills/agmsg/scripts/key.sh generate [<team>]
 
 # Show the team's public recipient + fingerprint. --reveal-secret prints
@@ -207,26 +213,28 @@ own admin command, obtains the token); `connect` only ever receives one.
 # Install a private age identity obtained out-of-band (e.g. via
 # `key.sh show <team> --reveal-secret` on another device that already has
 # it). Rejected if it doesn't match the team's already-authorized key.
-~/.agents/skills/agmsg/scripts/key.sh import <team> <identity>
-
-# Start a new epoch for a team with exactly one active writer (this
-# device). Never re-encrypts existing history — only messages sent after
-# rotation use the new key; every prior epoch's key is retained locally.
-~/.agents/skills/agmsg/scripts/key.sh rotate [<team>]
+printf '%s' "$IDENTITY" | ~/.agents/skills/agmsg/scripts/key.sh import <team> --identity-stdin
 ```
+
+**`key rotate` is NOT available in this release.** It refuses
+unconditionally and changes no state — a design review found its
+anti-rollback metadata insufficient (it can't detect a wholesale
+config.json rollback, and doesn't use the age-v1 profile's pinned
+canonical epoch-snapshot shape), so it's held back rather than shipping a
+protection that isn't actually there. Do not suggest it as a working
+command.
 
 Slash-command surface (SKILL.md / per-type templates), same mapping
 pattern as every command above:
 
 ```
-/agmsg remote connect --endpoint <url> <token>
+/agmsg remote connect --endpoint <url>   (paste the token when prompted)
 /agmsg remote status
 /agmsg remote disconnect <team>
 /agmsg remote doctor
 /agmsg key generate [<team>]
 /agmsg key show [<team>] [--reveal-secret]
-/agmsg key import <team> <identity>
-/agmsg key rotate [<team>]
+/agmsg key import <team>   (paste the identity when prompted)
 ```
 
 Additional dependencies beyond bash/sqlite3 (only needed if these commands

--- a/SKILL.md
+++ b/SKILL.md
@@ -186,7 +186,11 @@ printf '%s' "$TOKEN" | ~/.agents/skills/agmsg/scripts/remote.sh connect --endpoi
 
 # Show connection state. With no <team>, lists every locally-known
 # connected team (and whether each still needs a local encryption key).
-~/.agents/skills/agmsg/scripts/remote.sh status [<team>]
+# --json emits a strict, secret-free machine-readable object instead of
+# the human text above (ADR 0007 addendum) — for a driver correlating its
+# own operation-status record against the local binding, not for a human
+# to read; prefer the plain form above in normal use.
+~/.agents/skills/agmsg/scripts/remote.sh status [<team>] [--json]
 
 # Disconnect a team: revokes the credential server-side (best-effort —
 # local state is always cleared even if the server is unreachable), then
@@ -198,6 +202,16 @@ printf '%s' "$TOKEN" | ~/.agents/skills/agmsg/scripts/remote.sh connect --endpoi
 # state change — safe to run any time, and the thing to point a user at
 # when troubleshooting a missing dependency.
 ~/.agents/skills/agmsg/scripts/remote.sh doctor [<team>]
+
+# List (and, if orphaned, clean up) a `connect` exchange that succeeded
+# server-side but never finished committing locally — e.g. the process died
+# between the exchange call and writing local state (ADR 0007 addendum).
+# pending_id is an opaque, content-derived key; abort always works on it
+# alone, even for a record whose content doesn't fully validate. Not a
+# normal-use command — this exists for a driver doing its own crash
+# recovery, not for a human to run routinely.
+~/.agents/skills/agmsg/scripts/remote.sh pending list [--json]
+~/.agents/skills/agmsg/scripts/remote.sh pending abort <pending_id>
 
 # Generate the first age-v1 key for a team (single-writer onboarding only —
 # NOT the multi-writer cutover protocol, and NOT key rotation — see below).

--- a/docs/adr/0007-remote-connect-onboarding-ux.md
+++ b/docs/adr/0007-remote-connect-onboarding-ux.md
@@ -1,0 +1,992 @@
+# ADR 0007: Remote connect onboarding UX
+
+**Status:** accepted — §1/§1a-§1c/§8's four key commands (generate/show/
+import) and §0-§7's connect/status/disconnect/doctor are approved and
+implemented (this PR). `key request`/`approve` (device-pairing key
+delivery) and `key rotate` remain NOT READY — see §8 — and are explicitly
+out of this PR's scope pending their own follow-up design/review passes.
+**Date:** 2026-07-21 (implementation landed 2026-07-23)
+**Deciders:** @fujibee
+
+## Context
+
+The landing page commits to: *"Connect a team. One token links a team to your
+cloud org. That is the whole setup."* This ADR turns that promise into an
+actual CLI (and companion cloud-console) design, sitting on top of the
+Stage-1 remote sync ABI ([ADR 0005](0005-stage-1-remote-sync.md), draft PR
+#450, `storage_sync_prepare_push` / `storage_sync_reconcile_push` /
+`storage_sync_apply_pull`) and the rebased storage-axis driver contract
+([ADR 0003](0003-storage-axis-driver-abi-and-scope.md)).
+
+This was an **interface addition** (a new command surface, a new
+credential storage location, a new team-config field), reviewed and
+approved by the maintainer before implementation began, per standing
+policy. The implementation went through several rounds of adversarial
+security review (see References) before landing.
+
+Seven questions were posed and are answered below: (1) command shape, (2)
+token shape, (3) what "connect" actually does, (4) idempotency, (5) failure
+UX, (6) where E2EE's key-bootstrap step attaches, (7) the cloud-console
+side of the same flow. Cloud onboarding defaulting new teams to end-to-end
+encryption (`age-v1`, already an approved profile) added an eighth: (8) the
+key management commands (`generate`/`show`/`import`) that step needs,
+folded into this same document/review pass rather than a second one. A
+review pass afterward settled a foundational point stated first, as §0:
+`connect` is scoped to exactly one team, never a machine or an org.
+
+## Decision
+
+### 0. Connection unit: team, not machine or org
+
+**Settled during review, stated up front because it shapes every other
+section:** `connect` operates on exactly one team per invocation, never a
+machine-wide or org-wide binding.
+
+- **A token is team-scoped.** It is minted for one specific cloud team and
+  the exchange response identifies that team; it is not a credential that
+  lets the CLI pick from a list. Connecting N cloud teams to one machine
+  means running `connect` N times with N distinct tokens — never one token
+  that fans out to multiple teams.
+- **Org-wide tokens (the console's admin/automation token tier) are
+  explicitly not part of this onboarding flow.** They exist for
+  provisioning automation, not for `agmsg remote connect`. Reasons this
+  ADR treats that as a hard boundary rather than a convenience to add
+  later: (a) blast radius — a leaked team token compromises one team; a
+  leaked org token compromises every team in the org, and the "one
+  argument you can paste anywhere without much thought" ergonomics this
+  ADR designs for a team token are the wrong ergonomics for something with
+  org-wide reach; (b) it doesn't compose with §8 — a key is a *team* key
+  (one `age-v1` epoch snapshot per team), so an org-wide connect would have
+  no single team to attach the key-bootstrap step to.
+- **This mirrors two decisions already made elsewhere in this design, not
+  a new one invented for its own sake:** the per-team active storage
+  driver switch (§3.5) and the per-team encryption key (§8) both already
+  assume "team" is the unit that gets bound/keyed/switched independently
+  of every other team. Making `connect` itself team-scoped is the
+  connection-establishment step lining up with the unit the other two
+  already committed to — a machine-wide or org-wide `connect` would have
+  left those two either unreachable (which team does an org-wide binding
+  switch the driver for?) or requiring their own separate team-selection
+  step immediately after, duplicating work `connect` should have done
+  once.
+
+### 1. Command shape
+
+**Role split (settled during review): the OSS CLI is a generic client with
+no commercial endpoint baked in. It never assumes or defaults to any
+particular server — `<endpoint>` is a required argument, always.** The "one
+token, one paste" experience the landing page promises is delivered by the
+**hosted console generating a complete, ready-to-paste command** (endpoint
+included) — see §7. The CLI's job is to be correct and endpoint-agnostic;
+the "feels like one token" UX is a hosted-onboarding presentation concern
+layered on top, not a CLI default.
+
+**Pinned format (reconciled with the cloud-console side's own proposal):**
+`--endpoint` is a **named flag**, not a bare positional, specifically
+because a labeled flag can never be mistaken for the token even out of
+context (a support screenshot, a truncated paste, re-typing from memory) —
+stronger on "hard to get argument order wrong" than two adjacent bare
+positional strings, which was this draft's original proposal.
+
+**Decision (interface addition, added after review — the pairing token is
+a bearer secret and gets the same discipline as §3.4's session credential
+and §8's key material): the bare-positional `<token>` is kept only as a
+legacy, warned option; `--token-stdin` (reading the token from stdin/an
+inherited FD, reusing §8's sealed-fd handling rather than a new mechanism)
+is the mandatory path for provider tooling spawning `connect`
+programmatically.** A positional argument is visible in `ps`, shell
+history, and any tool/agent transcript that logs invocations — acceptable
+for a human manually pasting a token copied from the console (Path B,
+§1a), not for an automated handoff. The positional form stays available
+and simply warns on stderr, since Path B's console-copy-paste UX (§7)
+genuinely is a human typing/pasting a visible argument.
+
+**`doctor`** (adopted into v1 scope): a standalone, read-only,
+always-safe-to-run command that surfaces the same preflight checks
+`connect` runs internally (currently just §8's `age`-binary-presence
+check) — no token, no state change, usable whether or not the team is
+already connected. Exists so console/support flows can point a user at
+one command to diagnose a missing dependency without a real `connect`
+attempt.
+
+Self-hosted and hosted use the **identical shape** — only the `<url>` value
+differs, never the command's structure, which is the third criterion this
+format was chosen against.
+
+**`<team>` is a local-name override, not a team selector.** The connection
+unit is the **cloud team the token itself refers to** (§0 above) — the
+token already answers "which team", so `<team>` on `connect` is only for
+naming the *local* team the binding attaches to, and defaults to the cloud
+team's own name (returned in the exchange response) when omitted. Supply
+it only to bind under a different local name (e.g. an existing local team
+already has that name for an unrelated reason). `status`/`disconnect`'s
+`<team>` is the ordinary local-team-name argument every other command in
+this codebase already takes — no special resolution logic, no
+multi-team-disambiguation prompt to design.
+
+### 1a. Onboarding paths: agent-driven (Path A) vs. console-driven (Path B)
+
+**Boundary: this is provider tooling's design, not this OSS repo's
+implementation scope. This ADR names no specific product** — only the
+contract: some **provider tooling** (a vendor CLI, or a vendor console)
+owns login, org/team management, and pairing-token acquisition, then
+simply **calls this repo's unmodified §1-5 `connect`**
+(`scripts/remote.sh connect --endpoint ... --token-stdin`) with the token
+it obtained — the same shape as `gh`/Tailscale's CLIs, where a
+provider-specific tool handles auth and a separate protocol client just
+receives a credential. **This OSS repo's interface does not change at
+all** — `connect` still just receives a bearer token exactly as §2-§3
+already specify; it has no awareness of whatever login flow happened
+upstream of that token, and doesn't need to. A **self-hosted server's own
+admin command**, issuing a token directly with no "login" concept at all,
+is exactly as valid a token-issuing entity as any hosted provider tooling
+— this ADR treats the two as peers, not a primary path and a fallback.
+The design below is kept here as **context for why the boundary sits
+where it does**, not as OSS-implemented scope:
+
+- **Path A (existing agmsg users, agent-first):** the human's agent runs a
+  device-authorization login (RFC 8628-style) on the human's behalf; the
+  human's only action is **one browser-side click to approve** (§1c —
+  the entire credential boundary). Org/team select-or-create, `connect`,
+  and key generation follow automatically. A second device joining the
+  same team goes through the same login, then `key request`, and the
+  human manually carries the resulting confirmation code to the first
+  device to `approve` it (§8's `key request`/`approve`, still NOT READY
+  pending its own open findings).
+- **Path B (new users, console-first):** console-driven, building on §7's
+  existing copy-paste block — the block leads with instruction text meant
+  to be pasted to an agent, with the raw shell command as a secondary
+  form for a human running it directly.
+- **Single-path presentation rule:** the CLI/console never shows both
+  paths at once — which one is offered is decided by local state (an
+  existing agmsg installation → Path A; a genuinely new user → Path B).
+  Presenting both simultaneously was an explicit review finding to avoid.
+- **Convergence:** both paths drive the *same* underlying state machine —
+  login → select/create → connect → key — which is exactly §3's connect
+  flow underneath, just reached through two different front doors.
+  Interrupting partway through is expected and supported via a resume
+  token, so a half-completed flow picks back up rather than restarting
+  from scratch.
+
+### 1b. Endpoint discovery (`.well-known`)
+
+**Same boundary as §1a: this moves entirely to provider tooling, out of
+OSS scope.** A domain-to-endpoint discovery step only matters upstream of
+the login flow §1a now owns; this OSS repo's `connect` always takes an
+explicit `--endpoint` (§1) and never resolves one itself. Kept below as
+the hardening list provider tooling needs to satisfy, not as an OSS
+implementation task — every item is a concrete finding from adversarial
+review, not a nice-to-have:
+
+- IDNA-normalize the input domain and **explicitly display the punycode
+  form** — never silently render only the Unicode form a homograph could
+  spoof.
+- **No fuzzy/auto-corrected domain matching** — a typo'd domain is a hard
+  failure, never "did you mean...".
+- Discovery `fetch` **disallows redirects** (or, at most, same-origin
+  redirects only).
+- Strict limits: response size cap, `content-type` allowlist, strict JSON
+  parsing (no lenient/tolerant parsing), bounded caching.
+- The resolved API endpoint defaults to **same-origin HTTPS**.
+- **Cross-origin delegation**, if ever allowed, requires: the delegated
+  origin shown explicitly on *both* the CLI and the browser approval
+  page, an explicit human confirmation of the delegation itself (separate
+  from the main approval), and the response's `issuer` field matching the
+  originally-entered origin.
+- The discovery URL itself may carry **no userinfo, query, or fragment**.
+- **SSRF protections**: reject loopback / private / link-local / metadata
+  IP ranges and guard against DNS rebinding, in hosted/default mode. Self-
+  hosted setups get an explicit opt-out flag — this is not available by
+  default.
+- **First-connect pinning**: `(origin, api, server_instance_id)` is
+  durably pinned the first time a team connects. Any later mismatch on
+  any of those three is a **hard fail**; changing them requires an
+  explicit, deliberate rebind operation, never a silent follow. A typo on
+  the very first connect can't be caught cryptographically — which is
+  exactly why the browser approval page (§1c) must display the issuer
+  prominently at that moment, since that's the one point a human actually
+  has a chance to catch it.
+
+### 1c. Device-flow trust model: the terminal is not the trust anchor
+
+**Same boundary: this is provider tooling's trust model to implement, not
+OSS's** — kept here because it explains *why* §1a/§1b's design looks the
+way it does, useful context even though this repo doesn't build it.
+
+**Terminal output is never the basis for approval.** A prompt-injected
+agent could display a fabricated URL or a fabricated code — trusting
+whatever text an agent prints as the thing to approve would make the
+whole device-flow login only as trustworthy as the agent's own integrity,
+which is exactly the assumption this model must not make.
+
+The actual trust anchor is the **browser approval page** (owned by
+whoever owns the console/hosted-onboarding surface — not designed here,
+same alignment-note pattern as §7). It must prominently display: the
+canonical issuer/domain, the requesting client's name, the requested
+scope, the target org/team, the flow's start time, and the device code
+for the human to match against what their agent displayed — and it is
+**deny-by-default**. Code matching is never skipped, even when a
+`verification_uri_complete`-style URL (one that pre-fills the code) is
+used — pre-filling is a convenience, not a reason to drop the check.
+
+### Human-in-the-loop gates (cross-cutting — split across provider tooling and this repo's §8)
+
+Four conditions, deliberately not automatable except through an
+independent, already-authenticated channel (e.g. SSH, or a future QR
+path — §8's forward-looking note). **Only 2-4 are this repo's concern —
+gate 1 belongs to provider tooling (§1a-§1c), listed here for
+completeness since all four were reviewed together:**
+
+1. *(provider-tooling scope)* **Browser approval** — the boundary that keeps
+   auth material from ever passing through the agent at all.
+2. **Carrying the pairing code** — manual, by design; this *is* the MITM
+   defense (§8, `key request`/`approve`).
+3. **Storing the key backup** — a human action, not something the CLI
+   automates on someone's behalf (§8).
+4. **Post-decryption bidirectional confirmation (SAS)** — added after
+   review specifically closed the earlier one-directional-auth gap (§8's
+   A2 finding): a one-way code alone cannot stop a fake team-key
+   injection from an attacker posing as a legitimate sender, so both
+   sides must independently derive and display the same
+   post-decryption confirmation string before the receiver commits.
+
+### Secret hygiene (cross-cutting — applies to §1's pairing token, §3.4's session credential, and §8's key material alike)
+
+- **Never in stdout, argv, or environment variables** — these leak into
+  agent transcripts, shell history, and `ps` output respectively, none of
+  which this design can assume are private. This now explicitly includes
+  the **pairing token itself** (§1's `--token-stdin` correction) — it is
+  short-lived and single-use, but still a bearer secret while it's live,
+  and gets the same treatment as the longer-lived session credential and
+  key material rather than an exception for being "just a token."
+- Secrets pass between the CLI and its own subprocesses via an
+  **internal file descriptor**, sealed, never as a printed or logged
+  value — the same mechanism §1's `--token-stdin` reuses rather than
+  inventing a second one.
+- `key show --reveal-secret` requires an interactive human TTY plus an
+  explicit typed confirmation (§8, unchanged) — and is **refused
+  outright when invoked in agent mode**, full stop, no override.
+- `key approve` (§8) **never displays key material at all** — structured
+  redaction, not "redact unless asked."
+- Nine distinct leak paths are named individually here so none get
+  silently missed by an implementation that only thinks about the obvious
+  one: (1) a reveal command's own output as captured by a tool-result
+  channel, (2) session transcripts / shell `xtrace`, (3) shell history or
+  `argv` (visible via `ps`), (4) environment variables, (5) debug-mode
+  HTTP logging, (6) exception messages or stack traces, (7) the system
+  clipboard, (8) backup/export pipes, (9) `approve`'s own log output.
+
+### Command surface across install paths (decided)
+
+There are multiple ways this codebase gets installed, with more
+plausibly coming: `install.sh` directly, `npx agmsg install`, a possible
+future default via the separate skills-CLI effort (`#201` — not this
+ADR's to decide), and an existing CC-plugin form. A bare PATH shim in
+`install.sh` only covers the first case, so it's rejected. **Decision:**
+the npm bootstrapper (the existing `agmsg` package) gains subcommand
+passthrough, so `npx agmsg remote connect ...` works identically
+regardless of install path or `$PATH` state, guiding the user through
+install if it isn't present yet. A per-install-path shim matrix was
+considered and rejected as unnecessary once the bootstrapper covers every
+path uniformly. Leading with agent-instruction text (§1a/§7) over a raw
+shell command further reduces how often a human-facing literal command
+needs to be shown at all — it doesn't replace the bootstrapper decision,
+it just shrinks how often the question comes up.
+
+This is separate from §8's internal-dispatch correction
+(`scripts/key.sh <verb>`, not a bare `agmsg key <verb>`) — that's about
+which script a slash command invokes internally; this section is about
+what a human types directly into a terminal.
+
+### 2. Token shape
+
+The token is not the long-lived credential — it is a short-lived,
+single-use **exchange code** that the CLI POSTs to `<endpoint>` to receive
+back the actual session credential plus the team/org binding
+(`server_instance_id`, `remote_team_id`, `protocol_version`, capability
+document).
+
+Considered and rejected: **encoding the endpoint inside the token itself**
+(e.g. `<base64url(endpoint)>.<code>`), which was the original recommendation
+before review settled that the CLI must not carry any endpoint assumption,
+implicit or encoded. Beyond that settled point, embedding still has the
+same independent problem: it reintroduces a second argument's worth of
+information into one string a human has to copy-paste correctly, with no
+visible seam to sanity-check ("does this token point at the URL I
+expect?") — a copy-paste truncation or a substituted token is
+indistinguishable from a valid one until the exchange call fails or
+(worse) succeeds against the wrong server. A separate, visible `<endpoint>`
+argument is safer on both counts.
+
+The token itself: opaque, single-use, short TTL (recommend 15 minutes —
+long enough to paste from a browser tab into a terminal, short enough that
+a token pasted into Slack/a ticket by mistake is worthless soon after).
+Format is an implementation detail for whoever builds the exchange endpoint;
+the CLI treats it as an opaque string it never parses, matching the "opaque
+to core" principle ADR 0003/0005 already established for cursors and wire
+IDs.
+
+### 3. What "connect" does
+
+1. `remote.sh connect --endpoint <url> <token> [<team>]` — `<team>`, if
+   given, is only the local-name override (§0/§1); it is never sent to
+   `<url>` and never used to pick which cloud team gets connected.
+2. POST the token to `<url>`. This is the **only** network call that
+   can fail before any local state changes — see §5. The token alone
+   identifies the cloud team (§0) — there is nothing else to disambiguate.
+3. On success, the response carries: a session credential (the actual
+   secret used for subsequent sync calls), a **`credential_id`** (a
+   stable, non-secret identifier for *this specific device's* binding —
+   distinct from the secret value itself; see step 4 and §4's revoke
+   note), `server_instance_id`, `remote_team_id` (the cloud team's
+   identifier), a human-readable cloud team name (used as the local
+   team's default name when `<team>` was not given), `protocol_version`,
+   and the capability document (per ADR 0005's `GET /v1/capabilities`
+   shape: `accepted_envelope_versions`, `write_allowed_ciphers`,
+   `policy_revision`, `effective_from_seq`, `max_blob_bytes`).
+4. The **secret is written to an engine-side credential store, never to
+   `teams/<team>/config.json` or any other binding file that gets read,
+   `cat`'d, or diffed as part of normal operation.** Concretely: a new file
+   per team under the skill's own state directory, e.g.
+   `~/.agents/skills/agmsg/run/remote-credentials/<team>.json`, created
+   `0600`, outside the git-trackable/config-diffable surface — the same
+   `0600`-plaintext-file mechanism §8 settles on as the *default* for the
+   E2EE key too (not an OS keychain — see §8's "Key storage" for why),
+   since both this credential and the age identity must be readable by an
+   unattended background process with no TTY to prompt against. The
+   secret itself is an **opaque bearer string** — the CLI never parses,
+   decodes, or interprets its structure, mirroring §2's stance on the
+   connect token (it is *not* the same value: the token is single-use and
+   spent during exchange; this credential is the longer-lived secret used
+   for every sync call thereafter). The **binding** (server_instance_id /
+   remote_team_id / `credential_id` / protocol_version / capability
+   snapshot / connected_at) is a separate, secret-free record — this is
+   the ABI condition stated in the task: binding-json holds identifiers,
+   never auth material.
+5. The team's active storage driver is switched to the sync-capable
+   (`capabilities=stage1-sync`) driver for that team specifically — this is
+   a **per-team** setting, not the machine-wide `storage` config key
+   `docs/spec/driver-interface.md` §4 currently describes. That per-team
+   override did not exist before Stage-1 sync; this ADR's implementation
+   will need a small, additive change to how the active driver is resolved
+   (per-team lookup falling back to the machine-wide default), not a
+   contract change to the driver ABI itself.
+6. `remote.sh connect` prints a short human-readable confirmation (team
+   name, org name from the capability/exchange response, "connected") —
+   no secret, no raw token, ever echoed back.
+
+### 4. Idempotency
+
+- **Re-running `connect` with the same token** (before it expires/is
+  consumed): the exchange endpoint is expected to be idempotent for a
+  short window (mirrors the sync ABI's own "durable reserve, retry-safe"
+  principle) — the CLI does not need special client-side handling beyond
+  "the call either succeeds again or reports already-consumed", and either
+  outcome is safe to surface as-is.
+- **Re-running `connect <newtoken>` on a team that is already connected**:
+  refused by default with a clear message naming the existing binding
+  (org/team, connected_at) and pointing at `disconnect` first — mirrors
+  this codebase's established pattern of refusing a silent overwrite and
+  offering an explicit escape hatch (`send.sh`'s roster guard, `join.sh`'s
+  rename-tombstone guard). Add `--force` to intentionally rebind (e.g.
+  moving a team to a different org) — same shape as those two.
+- **Multiple teams**: one token per team (§0) — connecting N cloud teams
+  to one machine is N separate `connect` invocations with N distinct
+  tokens, never a single fan-out. Each team's binding and credential file
+  are fully independent; connecting team B never touches team A's
+  binding, driver selection, or credential file. `remote.sh status` with
+  no `<team>` lists every locally-known team's connection state in one
+  pass (not just the one team just connected), since "what's connected
+  right now" is exactly the kind of thing worth seeing in aggregate.
+- **`disconnect`**: removes the per-team driver override (falls back to
+  local-only), deletes the credential file, and marks the binding record
+  disconnected (kept, not deleted outright, so `status` can still show
+  "was connected until <time>" — useful for debugging a "why did my
+  messages stop syncing" report) rather than silently vanishing all trace.
+  **Server-side revoke, ordered as: revoke attempt first, local cleanup
+  always.** Local deletion of the credential file alone does not stop the
+  credential from continuing to authenticate server-side — the same "one
+  action alone isn't enough" gap already called out for keys in §8's
+  incident-response note, restated here for the sync-credential side of
+  the same story. `disconnect` therefore first calls a server-side revoke
+  keyed by `credential_id` (§3.3/§3.4) — never the secret value itself.
+  If the revoke call succeeds, proceed to local cleanup as above. If the
+  server is unreachable, **still perform local cleanup** (a user must
+  always be able to locally disconnect regardless of network state) but
+  print an explicit warning: "Local state cleared, but the server could
+  not be reached to revoke this credential — if this device may be
+  compromised, revoke it from the console/admin side directly." The
+  revoke endpoint's own wire shape is a server-side implementation detail
+  this ADR does not own (mirrors §3.2's stance on the exchange endpoint
+  itself) — this ADR only fixes that `disconnect` must attempt it, keyed
+  by `credential_id`, in this best-effort order.
+
+### 5. Failure UX (local-first, doesn't break)
+
+- **`connect` itself, server unreachable**: fails loudly and immediately,
+  before touching any local state (step 2 in §3 is the only point of
+  failure that can happen before any write). Nothing is half-connected.
+- **Already connected, server later unreachable**: this is exactly the
+  case Stage-1 sync's local-first design already exists for — sends and
+  reads keep working against the local store; the sync client's own
+  polling/retry loop (ADR 0005) is what's degraded, not agmsg itself.
+  `remote status <team>` surfaces this plainly (e.g. "connected, last
+  synced 4m ago, N messages pending push" vs. "connected, in sync") so a
+  user who notices something feels stale has one command that tells them
+  whether it's a sync problem or a "nobody's replied yet" problem — never
+  a scary error, never a hang.
+- **Capability mismatch discovered later** (e.g. org admin tightens
+  `write_allowed_ciphers` after connect): surfaced via `status`, not a
+  crash on the next send — a send that would violate the current policy
+  queues locally with a clear reason rather than being silently dropped or
+  blocking the caller.
+
+### 6. E2EE insertion point (reserved, not built)
+
+**Update: cloud onboarding now defaults new teams to E2EE (`age-v1`, approved
+profile — see `docs/spec/age-v1-profile.md`), so this is no longer a future
+placeholder — it is concretized below and in §8.** The `age-v1` profile
+itself (envelope framing, recipient-set epochs, the multi-writer cutover
+protocol) is already pinned; this ADR only designs the **onboarding-time**
+slice of it — generating or importing the *first* key for a device, not
+rotating keys across an already-multi-writer team (see §8's explicit scope
+line).
+
+- Step 3.3 (reading the capability document) is exactly where the
+  "this org requires encryption" branch lives: if `write_allowed_ciphers`
+  excludes `none`, `connect` pauses **after** the token exchange and
+  **before** "switch driver to remote" to run the key-bootstrap sub-flow —
+  §8 gives its exact shape. If a key already exists locally for the team
+  (imported ahead of time via `agmsg key import`, or generated on a
+  previous run that was interrupted before the driver switch), the pause
+  is skipped and connect proceeds straight through.
+- The credential store introduced in §3.4 is the same mechanism the
+  private age identity lives in: one per-team, per-epoch `0600` plaintext
+  file, one storage mechanism built once for both the sync session
+  credential and the encryption key — not two. See §8's "Key storage" for
+  why this is a plain file by default rather than an OS keychain.
+- `remote status` prints a capability summary (§5); it also reports
+  whether a local key is present for the team's current cipher policy
+  (e.g. "encryption: age-v1, key present" / "encryption: age-v1 required,
+  **no local key** — run `agmsg key generate <team>`"), so a
+  half-bootstrapped state (connected, driver not yet switched because the
+  key step was skipped or interrupted) is always visible, never silent.
+
+### 7. Cloud console side (token issuance) — this is where "one token" lives
+
+Since the CLI itself always requires an explicit `--endpoint` (§1), the
+"whole setup is one token" experience is **entirely a hosted-onboarding
+presentation choice**, not a CLI behavior: the console generates and shows
+the **complete command line**, endpoint and token both already filled in
+— e.g. `agmsg remote connect --endpoint https://api.example-cloud.invalid
+abcd1234 --team myteam` — as one copy-paste-able block. The user
+experiences "paste one thing"; the CLI underneath still just took ordinary
+arguments it never defaulted.
+
+For the CLI flow above to make sense, the console needs a **"Connect a
+team" screen** that:
+
+- Lets an org admin pick/name the team being connected (or create one) and
+  press a single "Generate connect command" action (not just "generate
+  token" — the deliverable is the full command, per the role split above).
+- Displays the **generated command** (not the bare token) as a **one-time,
+  copy-once** block (shown once, reconfirmed with a "copy to clipboard",
+  not retrievable again after leaving the page) — consistent with the
+  token being single-use/short-TTL, and standard practice for any
+  bootstrap-secret display.
+- States the TTL plainly next to it ("expires in 15 minutes") so a user
+  doesn't paste a stale value and get a confusing failure.
+- After a successful exchange, the same screen (or a "Connected teams"
+  list) shows: team name, connected-since timestamp, and last-sync status
+  — the console-side mirror of `remote status`, so an admin doesn't need
+  CLI access to see whether onboarding actually completed. **The natural
+  row unit here is (team, `credential_id`), not team alone** — one
+  `connect` call issues one credential to one device, and `age-v1`
+  already anticipates multiple devices per team (multi-writer), so a
+  team with 3 connected devices shows 3 independently-revocable rows,
+  each with its own connected-since/last-active, not a single
+  team-level toggle. A single device's own `remote status` (§5) only
+  ever sees its own row — it has no visibility into other devices'
+  `credential_id`s — so the full per-device list/revoke view is a
+  console-only capability, since only the server holds the complete
+  picture across every connected device. Revoking a row here is the
+  server-side half of `disconnect`'s revoke step (§4) — the same action,
+  triggered from the other side when the device itself is unreachable to
+  run `disconnect` locally (e.g. lost/stolen hardware).
+- When the target team requires encryption, the copy-paste block also
+  carries a conditional "install `age` first if you don't have it" line,
+  using the **exact** OS-specific install commands §8 pins in the CLI's
+  own preflight message — this is the one piece of console copy this ADR
+  does fix precisely (not layout, just this wording), since the whole
+  point of pinning it is that the CLI's error text and the console's
+  pre-emptive hint must never say two different things for the same
+  missing dependency.
+- Alignment note: the exact screen layout/copy, and the concrete hosted
+  endpoint value it fills in, are a console (desktop-app-adjacent) surface
+  this ADR has no authority over — that design belongs to whoever owns the
+  cloud console/onboarding surface, reviewed independently. This ADR fixes
+  only the **contract** the console and CLI must agree on: that the CLI
+  takes `--endpoint <url> <token> [<team>]` with no default, what the
+  token encodes/expires like, and what the exchange response shape is
+  (§3) — not pixels, and not what the hosted endpoint's URL actually is.
+
+### 8. Key management commands (`agmsg key ...`)
+
+**Scope of this section: single-writer-per-team onboarding and rotation
+only** — generating the very first key for a team, installing a key a
+device already received out-of-band, or starting a new epoch when there is
+exactly one active writer. The `age-v1` **multi-writer** cutover protocol
+(rotating an already-established recipient set while more than one device
+is actively writing, adding/removing a device from a team that already has
+other active writers) is a separate, harder operational flow with its own
+quiesce/fence/commit barrier (`docs/spec/age-v1-profile.md`, "Multi-writer
+cutover protocol") and needs its own design pass — not folded into any verb
+below.
+
+A new top-level noun, `key` — not nested under `remote` — because a team's
+key is conceptually independent of the sync connection itself (it survives
+`disconnect`/`connect` cycles; it's the thing a user reaches for with "show
+me my key", not "show me my remote status").
+
+**Decision: commands live in `scripts/key.sh` (dispatching on
+`generate`/`show`/`import`/`rotate`), matching the `scripts/<name>.sh`
+pattern every existing command uses** — there is no unified `agmsg`
+dispatcher on `$PATH` today (the npm package's `bin` is an install-time
+bootstrapper, not a runtime front-door; see the separate, undecided
+`#201` front-door-CLI effort, which this ADR does not depend on).
+`remote` (§1) already used this shape; an earlier draft of this section
+didn't, and is corrected here to match.
+
+**`key generate [<team>]`** — for the first device establishing a team's
+encryption:
+
+1. Generates a native X25519 age identity (per the `age-v1` profile) and
+   its recipient.
+2. Mints a `key_id` matching the profile's required shape
+   (`[a-z0-9][a-z0-9._-]{0,63}`) — e.g. `epoch-<date>` — and creates the
+   team's first epoch snapshot: `epoch_revision=0`, `writer_generation=0`,
+   a single-recipient manifest (this device), `previous_snapshot_sha256`
+   null.
+3. Stores the private identity in the same per-team credential store
+   `connect` already established (§3.4) — never in `teams/<team>/
+   config.json`, never logged.
+4. Stores the **public recipient** in a binding-scoped config record (not
+   secret — safe to sit next to the rest of the team's remote binding).
+5. Prints the recipient's fingerprint (a short, human-comparable digest)
+   and a **mandatory-reading backup notice** — not a dismissible
+   one-liner, stated plainly once at creation time: back the key up now
+   (a password manager entry, never a dotfiles/git repo or other
+   synced-by-a-tool location); there is no server-side recovery; losing
+   the device means permanent, unrecoverable data loss for everything
+   encrypted under this key; removing a device later does not revoke its
+   ability to read history from before removal. These are the H7
+   operational facts (`lost key = unrecoverable`, `no server-side
+   recovery`, `removal does not revoke history`) — exact wording belongs
+   in implementation-time usage docs, not repeated here.
+
+**`key show [<team>] [--reveal-secret]`** — default (no flag): prints only
+the **public** recipient and its fingerprint, safe to run routinely (e.g.
+to compare fingerprints with a teammate over a separate channel — the H7
+"fingerprint verification" step: two people read/compare the same short
+string over a phone call or in person, confirming neither is looking at a
+substituted key). `--reveal-secret` prints the private identity material
+and requires an explicit interactive confirmation (typing a confirmation
+phrase, not just accepting a `y/N` — this is the one place in the whole
+flow a raw secret ever reaches stdout, so it should feel deliberately
+harder to trigger by accident than the rest of the CLI).
+
+**`key import <team> <identity>`** — for a device that already possesses a
+private age identity obtained through a secure out-of-band channel (e.g.
+handed off by an existing team member, or retrieved from wherever the
+`age-v1` profile's "epoch authority" distributes it). Validates the
+identity parses as a well-formed age identity, stores it in the credential
+store (same as `generate` step 3), and — if the team's capability response
+already carries an epoch snapshot for this team — verifies the imported
+identity's recipient is a member of the current authorized manifest before
+accepting it (fail closed: an identity that decrypts nothing useful for
+this team is more confusing to discover later than to reject up front).
+Does **not** itself create a new epoch or snapshot — that only happens via
+`generate` (for a brand-new team) or `rotate` below.
+
+**`key rotate [<team>]`** — starts a new epoch for a team **that has
+exactly one active writer** (this device). Explicitly not a general
+multi-device rotation tool (see scope note above and §8's own boundary in
+Alternatives).
+
+1. Generates a fresh X25519 identity/recipient and a new `key_id`
+   (`epoch_revision` incremented, `writer_generation` unchanged — single
+   writer, no cutover barrier needed).
+2. **Never re-encrypts existing envelopes** (H1): every message already
+   sealed under a prior epoch stays exactly as it is. Only messages sent
+   *after* rotation use the new key.
+3. The local keyring retains **all** prior epochs, not just the newest —
+   needed to decrypt history, and because `age-v1` explicitly requires
+   clients to retain authorized old identities (§ "Rotation and
+   revocation are prospective").
+4. Distribution in this (v1, single-writer) design is **manual**: `rotate`
+   does not push the new key anywhere by itself. Sharing it with anyone
+   else who needs to read new messages is a fresh `key show` / hand-off,
+   the same manual step as initial onboarding (§8's `import`). Automated
+   multi-device distribution is exactly the piece deferred to the future
+   multi-writer design.
+
+Two operational notes this ADR states explicitly rather than leaving
+implicit, since they're easy to get wrong once and hard to notice:
+
+- **New-member history visibility is a deliberate choice, not automatic.**
+  Handing a newly-joined member only the *current* epoch's key (not the
+  full keyring) means they can decrypt everything from here forward but
+  nothing from before they joined — a legitimate, useful option for "new
+  hires shouldn't see old history", but it only happens if whoever
+  onboards them chooses to share just the latest epoch rather than the
+  full keyring. `key show` should make it possible to select this (e.g. a
+  future `--epoch <key_id>` scoping flag), but this ADR does not commit to
+  that flag's exact shape — only that the choice must be possible and
+  is not automatic.
+- **Incident response is two commands, not one, and both matter.** If a
+  device (and its stored key) is compromised, the response is `remote`
+  credential revocation **and** `key rotate` together: revoking only the
+  sync credential stops the compromised device from *pushing/pulling new
+  traffic* but does nothing about a key it already copied being used to
+  read messages obtained another way (a prior local export, a stolen
+  disk); rotating only the key stops *future* messages from being
+  readable with the old key but does nothing if the compromised
+  credential can still reach the transport. A future incident-response
+  doc/runbook should state this pairing explicitly, not leave it to be
+  independently rediscovered during an actual incident.
+- **Member removal requires rotation.** Because §8 already established
+  that removing a recipient from a later epoch does not revoke its
+  ability to decrypt *earlier* ciphertext, "remove a team member" is not
+  a complete operation on its own — it must be paired with `key rotate` to
+  actually stop that member's copy of the key from reading anything new.
+  This should be a **documented requirement** (onboarding docs / a future
+  "remove a member" runbook), not left as an inference a team admin has to
+  make correctly under pressure. The cloud console's own member-removal
+  UI guiding an admin through revoke-plus-rotate together is a natural
+  future requirement for whoever owns that surface — referenced here as a
+  dependency, not designed here.
+
+**Preflight: `age` binary presence.** Before the key-bootstrap prompt
+below runs at all — and only when the capability response actually
+requires encryption — `connect` verifies the `age`/`age-keygen` binaries
+are present on `$PATH`, since a device's very first `connect` is
+plausibly its first-ever encounter with agmsg's encryption path. On
+failure it stops with an OS-appropriate install command rather than a
+silent no-op or bundled fallback. **Decision: this install-command text
+must be pinned identically between the CLI's own message and the console's
+copy-paste block (§7)** — exact wording is an implementation-time detail
+(usage docs), but the two surfaces must never drift into saying different
+things for the same missing dependency.
+
+**Connect-flow integration** (concretizing §6's reserved insertion point):
+once the `age`-presence preflight above has passed (or was skipped as
+not required), when `connect`'s capability fetch shows
+`write_allowed_ciphers` excludes `none` and no local key exists yet for
+the team, `connect` pauses right there. **The default choice offered is
+picked by whether the team's message stream is empty**, not left as an
+arbitrary "generate is option 1":
+
+- **Stream empty** (nothing has ever been sent to this team): defaults to
+  **generate** — an empty stream is the strongest available signal that
+  this device is plausibly the *first* one ever connecting this team, so
+  generating a brand-new key is the common case.
+- **Stream has messages already**: defaults to **import** — existing
+  history is a strong signal that at least one other writer already
+  established this team's encryption; generating a fresh, unrelated key
+  here would silently create a second key with no relationship to
+  whatever already-existing history is encrypted under the real one
+  (exactly the accidental-divergent-writer scenario §8 already declines
+  to auto-handle) — so the safer nudge is toward import.
+
+The prompt offers three explicit choices — generate, import, or abort,
+with the default pre-selected per the stream-state rule above (exact
+wording is a usage-docs detail, not repeated here).
+
+Choosing **abort** exits with no binding created and no driver
+switch — the same "nothing half-connected" guarantee §5 already commits
+to for the token-exchange failure case, extended here to a
+user-initiated stop.
+
+Choosing **import** when there's no key on hand yet is guided
+in-line: "On another machine that already has this team's key, run
+`agmsg key show <team> --reveal-secret` and paste its output into
+`agmsg key import <team> <identity>` here."
+
+**Key-loss edge case, stated explicitly rather than left implicit:** if
+the only device that ever held this team's key is gone entirely — no
+other machine has a copy, no backup was made per `key generate`'s
+warning (§8) — there is nothing to import. The historical stream stays
+permanently unreadable under the lost key; this is not a bug to work
+around. The only forward path is `agmsg key rotate <team>` to start a
+fresh epoch for messages sent from now on — it does not, and cannot,
+recover anything encrypted under the key that was lost.
+
+— then runs the corresponding `key generate`/`key import` sub-flow inline,
+and only *then* continues to "switch driver to remote". If a key is
+already present (imported earlier, or left over from an interrupted prior
+run), this prompt is skipped entirely and connect proceeds straight
+through — matching §6's "never silently half-connected" principle: the
+team is not marked connected until both the binding *and* (when required)
+the key exist.
+
+**Key storage (default, and why)**
+
+- **Default: a `0600` plaintext file, one per team per epoch**, in the
+  same per-team credential store §3.4 already introduced (not a new
+  location) — e.g. `~/.agents/skills/agmsg/run/remote-credentials/
+  <team>/keys/<epoch>.key`, holding the raw age identity. This is the
+  *only* default; there is no passphrase prompt and no OS-keychain path
+  in v1.
+- **Why not passphrase-protected:** both message decryption (inbox/history
+  rendering) and the sync engine's own background push/pull loop must be
+  able to read the key with **no TTY and no human present** — `watch.sh`
+  and any cron/headless invocation depend on this. A passphrase-locked
+  key either blocks forever waiting for a prompt that will never come in
+  that context, or forces caching the passphrase somewhere else on disk —
+  which is exactly the same exposure as not having a passphrase, with
+  extra failure modes and none of the benefit.
+- **Why not OS keychain by default:** the same background-access
+  requirement rules it out — macOS Keychain / GNOME Keyring / etc. are
+  bound to an unlocked login session, and agmsg's own background watcher
+  routinely runs detached (a backgrounded tmux pane, an SSH session with
+  no unlocked session behind it, a headless CI-like runner). Making
+  keychain the default would turn "decrypt silently fails because the
+  keychain is locked" into the common case for exactly the always-on
+  background usage agmsg is built around — a strictly worse default than
+  a plain file. Keychain integration remains a plausible **future,
+  explicitly opt-in** hardening flag for a user who only ever runs agmsg
+  interactively on a single desktop session with no background watcher —
+  not something this ADR designs now.
+- **Honest threat model:** on a single-user machine, protecting the key
+  file alone is close to security theater — the key and the decrypted
+  plaintext message history (and, in most setups, the local sqlite/jsonl
+  store itself) sit on the same disk, under the same account. Anyone who
+  can read that account can already read both; the `0600` bit only keeps
+  out *other local accounts* on a shared machine, which is worth having
+  but is not the real boundary. The actual protection is whole-disk /
+  home-directory encryption (FileVault, LUKS, BitLocker) plus ordinary
+  account hygiene — agmsg's E2EE model defends data in transit and at
+  rest on a **compromised or untrusted server**, not against a
+  compromised local account that already holds the key. `key generate`'s
+  backup warning (above) and this threat-model note should be read
+  together, not in isolation.
+- **Re-confirmed: the server never holds the key, at any point.** The
+  session credential (§3.4) and the age identity (this section) are both
+  local-only by construction — the exchange/capability responses (§3)
+  never carry key material, and no `key` subcommand ever transmits the
+  private identity anywhere. This is not a new design decision; it is the
+  literal definition of end-to-end encryption restated here because it is
+  the one guarantee every other bullet above assumes.
+
+**`key request` / `key approve` (renamed from `send`/`receive`) —
+device-pairing key delivery. STATUS: NOT READY — under redesign, split
+off as a separate follow-on track, not part of this ADR's launch scope.**
+An internal adversarial design review found five separate, fundamental problems
+with the design as first drafted below (one-directional authentication
+only — a malicious server or writer could inject a fake team key toward
+the receiver; the confirmation code as originally specified is
+grind-able by a malicious server; no formal request/delivery state
+machine — replay and epoch-rollback are unaddressed; incompatibility
+with `age-v1`'s existing key_id policy gate, possibly requiring a
+dedicated profile/version; and undefined behavior for non-receiver
+clients encountering the pairing blob on a shared/broadcast stream).
+These are not fixable as a naming or UX tweak — see the review thread for
+detail. The flow below is kept as-drafted, for historical/reference
+context only, and should not be treated as a spec to implement against.
+The rename to `request`/`approve` (mirroring the AWS SSO / `gh` device-
+authorization-flow convention: the new device *requests*, the privileged
+device *approves*) and passing the confirmation code as `approve`'s
+argument (making the transcription itself the matching act, instead of a
+separately-clickable "yes it matches" that degrades into confirmation
+fatigue) are accepted UX directions for whenever the redesign lands, but
+neither addresses the five findings above on its own.
+
+**Status update — one finding closed, four still open.** The onboarding
+pivot's human-gate condition 4 (post-decryption bidirectional SAS
+confirmation — see "Human-in-the-loop gates" after §1) directly closes
+the one-directional-authentication finding (A2) above: both sides now
+independently derive and display the same post-decryption confirmation
+before the receiver commits, so a fake team-key injected by a malicious
+server or writer no longer decrypts-and-imports silently. **The other
+four findings are not confirmed closed by this pivot** and this command
+pair stays NOT READY until they are: the confirmation code's own
+grinding-resistance derivation (A1), the request/delivery state machine
+(B — CAS single-use states, replay/rollback defense), the `age-v1`
+policy-gate compatibility question (E1), and broadcast-stream quarantine
+behavior for non-receiver clients (E2). Treat A2-closed as one checkbox
+out of five, not as the redesign being done.
+
+(Same `scripts/key.sh request|approve` dispatch shape as the rest of §8.)
+
+Flow:
+
+1. **Machine 2 (receiver), `agmsg key receive <team>`:** generates a
+   **temporary, single-use** age identity — *not* the team's real key,
+   purely a one-time pairing keypair — registers a pairing request with
+   the server, and displays a short **confirmation code** derived from
+   the temporary public key's fingerprint. Then waits.
+2. **Machine 1 (sender), `agmsg key send <team>`:** lists pending pairing
+   requests for the team, shows the confirmation code for the selected
+   one, and pauses for **explicit human confirmation that this code
+   matches what machine 2 is showing**. This visual match is the *entire*
+   MITM defense: if the server substituted its own key material in the
+   pairing request to intercept the handoff, the fingerprint shown here
+   would not match what machine 2 generated locally. This step is
+   deliberately not skippable or auto-confirmable.
+3. On explicit confirm, machine 1 encrypts the team's current key
+   material to the temporary public key as an **age recipient** (age's
+   own native encrypt-to-recipient feature — no new cryptography) and
+   sends it as a new **control-message type** over the existing message
+   stream (server-blind preserved: the server relays only an opaque
+   encrypted blob, exactly like every other envelope it already handles).
+4. **Machine 2 completes automatically**: pulls the control message,
+   decrypts with its own temporary private identity, and runs the
+   equivalent of `key import` without any manual paste — validates and
+   stores the key, prints a completion confirmation, and discards the
+   now-spent temporary pairing identity (it is single-use, not part of
+   the team's ongoing key material).
+
+Constraints this design is built under (stated explicitly, not
+negotiable within this ADR):
+
+1. **Zero new cryptography.** The whole mechanism is age's existing
+   recipient-encryption feature, reused. No new key-exchange protocol,
+   no new primitive.
+2. **No new transport.** Delivery rides the existing message stream, as
+   one more control-message type — the same extension point `despawn`'s
+   control messages already established, not a new endpoint or channel.
+3. **The confirmation code's exact shape is the security-critical part of
+   this design — explicitly NOT finalized here.** Its length, what
+   fingerprint it's derived from, and what else it needs to bind (e.g. a
+   pairing-session nonce, to disambiguate concurrent pending requests
+   from being visually confused with each other) determine whether the
+   MITM defense in step 2 actually holds. This needs its own adversarial
+   review pass, the same way the `age-v1` profile itself got one (see
+   References) — this ADR proposes the flow's *skeleton* and explicitly
+   defers the code's cryptographic shape to that review, rather than
+   asserting a strawman as final.
+4. **Manual `key show --reveal-secret` / `key import` remain**, permanently
+   — not deprecated by this feature, since self-hosted/offline setups may
+   have no live pairing channel at all.
+5. **Power-user one-liner, documented as a fallback, not a replacement:**
+   `agmsg key show <team> --reveal-secret | ssh machine2 agmsg key import <team>`
+   — for a user who trusts their own already-established SSH channel more
+   than a new interactive flow.
+6. **The pairing skeleton is deliberately generic**: request-register →
+   out-of-band verify → approve → encrypted delivery. The "out-of-band
+   verify" step is visual code-matching in v1, but the skeleton is kept
+   general enough that a future QR-code scan (the same "device pairing"
+   concept mobile platforms already use for key handoff) could substitute
+   for it later without redesigning the rest of the flow.
+7. **Console dependency, not designed here:** onboarding step 5's current
+   "paste this" language (§3.4/§8 above) will need rewording once this
+   exists as an alternative path. The exact command name shown and the
+   screen copy is a contract point with whoever owns the console surface,
+   to be pinned on both sides once this design itself is finalized — flagged
+   here as a dependency, not resolved here.
+
+## Alternatives considered
+
+- **A single `agmsg connect <token>` top-level command** (no `remote`
+  noun). Rejected: agmsg's existing top-level surface is entirely
+  messaging verbs (`send`, `history`, `team`, `mode`, `spawn`...); `remote`
+  as a noun groups three related, symmetric actions
+  (`connect`/`status`/`disconnect`) the same way `delivery.sh` groups
+  `set`/`status`, and leaves room for a future `remote reconnect` or
+  `remote rotate-credential` without inventing new top-level verbs each
+  time.
+- **A default/hardcoded hosted endpoint in the OSS CLI**, with `--endpoint`
+  only as an override. This was the original proposal; rejected during
+  review — the OSS client must not bake in any particular commercial
+  service as its default. `<endpoint>` is a required positional argument
+  with no fallback, full stop; the "one thing to paste" UX is recovered
+  entirely on the hosted-console side (§7), not by the CLI defaulting
+  anywhere.
+- **Encode the endpoint in the token** (see §2) — rejected there, on
+  independent grounds (a substituted/truncated token becomes
+  indistinguishable from a valid one).
+- **Store the secret in `teams/<team>/config.json`** alongside the
+  binding. Rejected: that file is read by many existing code paths (some
+  of which log it, echo it, or hand it to `readfile()` in SQL contexts)
+  and is the most-likely-to-be-pasted-into-a-bug-report file in the
+  codebase. Secrets do not belong anywhere near it.
+- **Machine-wide (not per-team) remote driver switch.** Rejected: the
+  landing-page promise and the sync ABI's binding key are both team-scoped
+  (`remote_team_id` is part of the binding tuple); a user with two teams,
+  only one of which is an org team, should be able to connect exactly one.
+- **Let `connect` accept an org-wide token** (connect to every team in an
+  org in one shot, or select from a list). Rejected as the default path
+  (§0): an org-wide credential's leak blast radius is every team in the
+  org, not one — the wrong ergonomics for something meant to be pasted
+  from a browser tab into a terminal without much ceremony. It also has no
+  single team to attach §8's key-bootstrap step to. Org-wide tokens still
+  exist for admin/automation tooling; they are simply not what
+  `agmsg remote connect` accepts.
+- **Nest key commands under `remote`** (`remote key generate`, etc.)
+  instead of a top-level `key` noun. Rejected: a team's key outlives its
+  connection state (disconnecting doesn't destroy it, and a key can exist
+  before a first `connect` if imported ahead of time), so nesting it under
+  `remote` implies a lifetime coupling that isn't real.
+- **Fold single-writer key rotation into `key generate`** (regenerate =
+  rotate). Rejected: generate and rotate have different preconditions and
+  different failure modes (generate assumes no prior key; rotate assumes
+  one and must not disturb ciphertext already sealed under it) — collapsing
+  them risks an accidental overwrite of an existing epoch. Given its own
+  verb instead (§8).
+- **Fold multi-writer-onboarding into any of these four verbs** (e.g.
+  having `key rotate` also "add me as a new writer to an existing
+  multi-writer team"). Rejected: that path requires the full
+  quiesce/fence/commit barrier the `age-v1` profile specifies for a
+  reason — collapsing it into a single local command would either skip
+  the barrier (unsafe: two active writers could straddle a cutover) or
+  silently block/hang inside what looks like a simple local command. Left
+  as an explicitly separate, future design; every command in §8 assumes a
+  single writer per team.
+
+## Consequences
+
+- Positive: the OSS CLI stays a genuinely generic, endpoint-agnostic
+  client — no commercial default to maintain, question, or explain away
+  for self-hosted/enterprise users; the landing-page "one token" promise
+  is still delivered, just entirely as a hosted-onboarding UX choice (§7)
+  rather than a CLI default, which is the more honest place for a
+  commercial-product promise to live anyway; reuses established codebase
+  conventions (subcommand verb grouping, `--force` escape hatches,
+  per-team scoping) instead of inventing new ones; leaves an explicit,
+  named slot for E2EE onboarding without committing to its UI yet; keeps
+  secrets out of every file that is already read/diffed/logged elsewhere.
+- Negative: introduces a **per-team active storage driver** concept that
+  the current spec (§4) does not have (today's `storage` config key is
+  machine-wide) — a small, additive spec change, not a breaking one, but
+  real work beyond "just call the three sync functions." Also: a
+  self-hosted/OSS-only user's onboarding doc must now show the full
+  `--endpoint <url> <token>` command explicitly (no default to omit),
+  which is marginally more to write in docs/README than a bare-token
+  example would have been.
+- Neutral: the cloud-console screen itself, and the concrete hosted
+  endpoint value, are explicitly out of this ADR's authority (contract
+  only) pending review from whoever owns that surface.
+- Neutral: `key generate`/`show`/`import` cover onboarding (first key,
+  first device) only. Removing/adding a device from an already-multi-writer
+  team, and any UI for the `age-v1` profile's quiesce/fence/commit
+  rotation barrier, are explicitly deferred to a follow-up design — this
+  ADR does not claim to have solved key rotation.
+
+## References
+
+- Builds on [ADR 0003](0003-storage-axis-driver-abi-and-scope.md) and
+  [ADR 0005](0005-stage-1-remote-sync.md) (draft PR #450).
+- [`docs/spec/age-v1-profile.md`](../spec/age-v1-profile.md) (approved
+  cipher profile, commit `eea3307`) — the key format, epoch model, and
+  multi-writer cutover protocol §8 is scoped against.
+- Internal adversarial design review, rounds 1 (sync gates A-G) and 2 (E2EE
+  gates H1-H8) — the profile this ADR's §6/§8 defer to.
+- Standing policy: any interface addition requires explicit maintainer
+  approval of the design doc before implementation (this document).
+- Implementation-time adversarial security review of `scripts/remote.sh`/
+  `scripts/key.sh` (this PR): an initial 7-finding pass (B1-B7) and three
+  delta re-review rounds (R1-R5, D1-D5, E1-E3) — covering secret-argv
+  leakage, transport/response validation, connect transactionality and
+  idempotent resume, and the decision to hold `key request`/`approve` and
+  `key rotate` back as NOT READY. Cleared with no blocking findings as of
+  this PR.

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -136,3 +136,40 @@ If argument is "hook off" (legacy alias):
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" antigravity`
 2. Tell the user the result.
+
+If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
+1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
+2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
+   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
+3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
+4. Show the command's output to the user.
+
+If argument is "remote status" (optionally followed by a team name):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
+2. Show the output to the user.
+
+If argument starts with "remote disconnect" followed by a team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+2. Show the output to the user.
+
+If argument starts with "remote doctor":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
+2. Show the output to the user.
+
+If argument starts with "key generate" followed by an optional team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
+2. Show the full output to the user, including the mandatory key-backup notice — do not summarize it away.
+
+If argument starts with "key show":
+1. Parse an optional team name and `--reveal-secret`.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh show [<team>] [--reveal-secret]`
+3. `--reveal-secret` requires a real interactive terminal and is refused in agent mode — if the user wants to reveal a secret, tell them to run it themselves directly in their own terminal rather than through you.
+4. Show the output to the user.
+
+If argument starts with "key import" followed by a team name:
+1. Ask the user to paste the private identity — never type or construct one yourself.
+2. **Never pass it as a literal argument.** Pipe it via stdin instead:
+   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
+3. Show the output to the user.
+
+`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -138,11 +138,16 @@ If argument is "reset":
 2. Tell the user the result.
 
 If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
-2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
-   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
-3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
-4. Show the command's output to the user.
+1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
+2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Token: ' TOKEN; echo
+   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
+   unset TOKEN
+   ```
+3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
+4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -167,9 +172,12 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. Ask the user to paste the private identity — never type or construct one yourself.
-2. **Never pass it as a literal argument.** Pipe it via stdin instead:
-   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
-3. Show the output to the user.
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Identity: ' IDENTITY; echo
+   printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin
+   unset IDENTITY
+   ```
+2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -147,7 +147,7 @@ If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync co
    ```
 3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
 4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -179,5 +179,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -216,3 +216,40 @@ If argument is "version":
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" claude-code`
 2. Tell the user the result.
+
+If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
+1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
+2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
+   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
+3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
+4. Show the command's output to the user.
+
+If argument is "remote status" (optionally followed by a team name):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
+2. Show the output to the user.
+
+If argument starts with "remote disconnect" followed by a team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+2. Show the output to the user.
+
+If argument starts with "remote doctor":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
+2. Show the output to the user.
+
+If argument starts with "key generate" followed by an optional team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
+2. Show the full output to the user, including the mandatory key-backup notice — do not summarize it away.
+
+If argument starts with "key show":
+1. Parse an optional team name and `--reveal-secret`.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh show [<team>] [--reveal-secret]`
+3. `--reveal-secret` requires a real interactive terminal and is refused in agent mode — if the user wants to reveal a secret, tell them to run it themselves directly in their own terminal rather than through you.
+4. Show the output to the user.
+
+If argument starts with "key import" followed by a team name:
+1. Ask the user to paste the private identity — never type or construct one yourself.
+2. **Never pass it as a literal argument.** Pipe it via stdin instead:
+   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
+3. Show the output to the user.
+
+`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -227,7 +227,7 @@ If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync co
    ```
 3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
 4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -259,5 +259,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -218,11 +218,16 @@ If argument is "reset":
 2. Tell the user the result.
 
 If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
-2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
-   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
-3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
-4. Show the command's output to the user.
+1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
+2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Token: ' TOKEN; echo
+   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
+   unset TOKEN
+   ```
+3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
+4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -247,9 +252,12 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. Ask the user to paste the private identity — never type or construct one yourself.
-2. **Never pass it as a literal argument.** Pipe it via stdin instead:
-   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
-3. Show the output to the user.
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Identity: ' IDENTITY; echo
+   printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin
+   unset IDENTITY
+   ```
+2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -174,7 +174,7 @@ If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync co
    ```
 3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
 4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -206,5 +206,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -163,3 +163,40 @@ If argument is "version":
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" codex`
 2. Tell the user the result.
+
+If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
+1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
+2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
+   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
+3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
+4. Show the command's output to the user.
+
+If argument is "remote status" (optionally followed by a team name):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
+2. Show the output to the user.
+
+If argument starts with "remote disconnect" followed by a team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+2. Show the output to the user.
+
+If argument starts with "remote doctor":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
+2. Show the output to the user.
+
+If argument starts with "key generate" followed by an optional team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
+2. Show the full output to the user, including the mandatory key-backup notice — do not summarize it away.
+
+If argument starts with "key show":
+1. Parse an optional team name and `--reveal-secret`.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh show [<team>] [--reveal-secret]`
+3. `--reveal-secret` requires a real interactive terminal and is refused in agent mode — if the user wants to reveal a secret, tell them to run it themselves directly in their own terminal rather than through you.
+4. Show the output to the user.
+
+If argument starts with "key import" followed by a team name:
+1. Ask the user to paste the private identity — never type or construct one yourself.
+2. **Never pass it as a literal argument.** Pipe it via stdin instead:
+   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
+3. Show the output to the user.
+
+`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -165,11 +165,16 @@ If argument is "reset":
 2. Tell the user the result.
 
 If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
-2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
-   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
-3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
-4. Show the command's output to the user.
+1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
+2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Token: ' TOKEN; echo
+   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
+   unset TOKEN
+   ```
+3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
+4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -194,9 +199,12 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. Ask the user to paste the private identity — never type or construct one yourself.
-2. **Never pass it as a literal argument.** Pipe it via stdin instead:
-   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
-3. Show the output to the user.
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Identity: ' IDENTITY; echo
+   printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin
+   unset IDENTITY
+   ```
+2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -136,3 +136,40 @@ If argument is "hook off" (legacy alias):
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" copilot`
 2. Tell the user the result.
+
+If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
+1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
+2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
+   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
+3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
+4. Show the command's output to the user.
+
+If argument is "remote status" (optionally followed by a team name):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
+2. Show the output to the user.
+
+If argument starts with "remote disconnect" followed by a team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+2. Show the output to the user.
+
+If argument starts with "remote doctor":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
+2. Show the output to the user.
+
+If argument starts with "key generate" followed by an optional team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
+2. Show the full output to the user, including the mandatory key-backup notice — do not summarize it away.
+
+If argument starts with "key show":
+1. Parse an optional team name and `--reveal-secret`.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh show [<team>] [--reveal-secret]`
+3. `--reveal-secret` requires a real interactive terminal and is refused in agent mode — if the user wants to reveal a secret, tell them to run it themselves directly in their own terminal rather than through you.
+4. Show the output to the user.
+
+If argument starts with "key import" followed by a team name:
+1. Ask the user to paste the private identity — never type or construct one yourself.
+2. **Never pass it as a literal argument.** Pipe it via stdin instead:
+   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
+3. Show the output to the user.
+
+`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -138,11 +138,16 @@ If argument is "reset":
 2. Tell the user the result.
 
 If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
-2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
-   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
-3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
-4. Show the command's output to the user.
+1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
+2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Token: ' TOKEN; echo
+   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
+   unset TOKEN
+   ```
+3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
+4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -167,9 +172,12 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. Ask the user to paste the private identity — never type or construct one yourself.
-2. **Never pass it as a literal argument.** Pipe it via stdin instead:
-   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
-3. Show the output to the user.
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Identity: ' IDENTITY; echo
+   printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin
+   unset IDENTITY
+   ```
+2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -147,7 +147,7 @@ If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync co
    ```
 3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
 4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -179,5 +179,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -150,7 +150,7 @@ If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync co
    ```
 3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
 4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -182,5 +182,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -141,11 +141,16 @@ If argument is "reset":
 2. Tell the user the result.
 
 If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
-2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
-   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
-3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
-4. Show the command's output to the user.
+1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
+2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Token: ' TOKEN; echo
+   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
+   unset TOKEN
+   ```
+3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
+4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -170,9 +175,12 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. Ask the user to paste the private identity — never type or construct one yourself.
-2. **Never pass it as a literal argument.** Pipe it via stdin instead:
-   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
-3. Show the output to the user.
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Identity: ' IDENTITY; echo
+   printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin
+   unset IDENTITY
+   ```
+2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -139,3 +139,40 @@ If argument is "version":
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" cursor`
 2. Tell the user the result.
+
+If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
+1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
+2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
+   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
+3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
+4. Show the command's output to the user.
+
+If argument is "remote status" (optionally followed by a team name):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
+2. Show the output to the user.
+
+If argument starts with "remote disconnect" followed by a team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+2. Show the output to the user.
+
+If argument starts with "remote doctor":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
+2. Show the output to the user.
+
+If argument starts with "key generate" followed by an optional team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
+2. Show the full output to the user, including the mandatory key-backup notice — do not summarize it away.
+
+If argument starts with "key show":
+1. Parse an optional team name and `--reveal-secret`.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh show [<team>] [--reveal-secret]`
+3. `--reveal-secret` requires a real interactive terminal and is refused in agent mode — if the user wants to reveal a secret, tell them to run it themselves directly in their own terminal rather than through you.
+4. Show the output to the user.
+
+If argument starts with "key import" followed by a team name:
+1. Ask the user to paste the private identity — never type or construct one yourself.
+2. **Never pass it as a literal argument.** Pipe it via stdin instead:
+   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
+3. Show the output to the user.
+
+`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -138,11 +138,16 @@ If argument is "reset":
 2. Tell the user the result.
 
 If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
-2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
-   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
-3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
-4. Show the command's output to the user.
+1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
+2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Token: ' TOKEN; echo
+   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
+   unset TOKEN
+   ```
+3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
+4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -167,9 +172,12 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. Ask the user to paste the private identity — never type or construct one yourself.
-2. **Never pass it as a literal argument.** Pipe it via stdin instead:
-   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
-3. Show the output to the user.
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Identity: ' IDENTITY; echo
+   printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin
+   unset IDENTITY
+   ```
+2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -136,3 +136,40 @@ If argument is "hook off" (legacy alias):
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" gemini`
 2. Tell the user the result.
+
+If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
+1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
+2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
+   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
+3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
+4. Show the command's output to the user.
+
+If argument is "remote status" (optionally followed by a team name):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
+2. Show the output to the user.
+
+If argument starts with "remote disconnect" followed by a team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+2. Show the output to the user.
+
+If argument starts with "remote doctor":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
+2. Show the output to the user.
+
+If argument starts with "key generate" followed by an optional team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
+2. Show the full output to the user, including the mandatory key-backup notice — do not summarize it away.
+
+If argument starts with "key show":
+1. Parse an optional team name and `--reveal-secret`.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh show [<team>] [--reveal-secret]`
+3. `--reveal-secret` requires a real interactive terminal and is refused in agent mode — if the user wants to reveal a secret, tell them to run it themselves directly in their own terminal rather than through you.
+4. Show the output to the user.
+
+If argument starts with "key import" followed by a team name:
+1. Ask the user to paste the private identity — never type or construct one yourself.
+2. **Never pass it as a literal argument.** Pipe it via stdin instead:
+   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
+3. Show the output to the user.
+
+`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -147,7 +147,7 @@ If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync co
    ```
 3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
 4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -179,5 +179,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -167,3 +167,40 @@ If argument is "hook off" (legacy alias):
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" grok-build`
 2. Tell the user the result.
+
+If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
+1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
+2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
+   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
+3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
+4. Show the command's output to the user.
+
+If argument is "remote status" (optionally followed by a team name):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
+2. Show the output to the user.
+
+If argument starts with "remote disconnect" followed by a team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+2. Show the output to the user.
+
+If argument starts with "remote doctor":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
+2. Show the output to the user.
+
+If argument starts with "key generate" followed by an optional team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
+2. Show the full output to the user, including the mandatory key-backup notice — do not summarize it away.
+
+If argument starts with "key show":
+1. Parse an optional team name and `--reveal-secret`.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh show [<team>] [--reveal-secret]`
+3. `--reveal-secret` requires a real interactive terminal and is refused in agent mode — if the user wants to reveal a secret, tell them to run it themselves directly in their own terminal rather than through you.
+4. Show the output to the user.
+
+If argument starts with "key import" followed by a team name:
+1. Ask the user to paste the private identity — never type or construct one yourself.
+2. **Never pass it as a literal argument.** Pipe it via stdin instead:
+   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
+3. Show the output to the user.
+
+`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -178,7 +178,7 @@ If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync co
    ```
 3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
 4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -210,5 +210,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -169,11 +169,16 @@ If argument is "reset":
 2. Tell the user the result.
 
 If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
-2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
-   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
-3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
-4. Show the command's output to the user.
+1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
+2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Token: ' TOKEN; echo
+   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
+   unset TOKEN
+   ```
+3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
+4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -198,9 +203,12 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. Ask the user to paste the private identity — never type or construct one yourself.
-2. **Never pass it as a literal argument.** Pipe it via stdin instead:
-   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
-3. Show the output to the user.
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Identity: ' IDENTITY; echo
+   printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin
+   unset IDENTITY
+   ```
+2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -135,7 +135,7 @@ If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync co
    ```
 3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
 4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -167,5 +167,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -124,3 +124,40 @@ If argument is "hook off" (legacy alias):
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" hermes`
 2. Tell the user the result.
+
+If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
+1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
+2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
+   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
+3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
+4. Show the command's output to the user.
+
+If argument is "remote status" (optionally followed by a team name):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
+2. Show the output to the user.
+
+If argument starts with "remote disconnect" followed by a team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+2. Show the output to the user.
+
+If argument starts with "remote doctor":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
+2. Show the output to the user.
+
+If argument starts with "key generate" followed by an optional team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
+2. Show the full output to the user, including the mandatory key-backup notice — do not summarize it away.
+
+If argument starts with "key show":
+1. Parse an optional team name and `--reveal-secret`.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh show [<team>] [--reveal-secret]`
+3. `--reveal-secret` requires a real interactive terminal and is refused in agent mode — if the user wants to reveal a secret, tell them to run it themselves directly in their own terminal rather than through you.
+4. Show the output to the user.
+
+If argument starts with "key import" followed by a team name:
+1. Ask the user to paste the private identity — never type or construct one yourself.
+2. **Never pass it as a literal argument.** Pipe it via stdin instead:
+   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
+3. Show the output to the user.
+
+`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -126,11 +126,16 @@ If argument is "reset":
 2. Tell the user the result.
 
 If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
-2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
-   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
-3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
-4. Show the command's output to the user.
+1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
+2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Token: ' TOKEN; echo
+   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
+   unset TOKEN
+   ```
+3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
+4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -155,9 +160,12 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. Ask the user to paste the private identity — never type or construct one yourself.
-2. **Never pass it as a literal argument.** Pipe it via stdin instead:
-   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
-3. Show the output to the user.
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Identity: ' IDENTITY; echo
+   printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin
+   unset IDENTITY
+   ```
+2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -139,3 +139,40 @@ If argument is "version":
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" opencode`
 2. Tell the user the result.
+
+If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
+1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
+2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
+   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
+3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
+4. Show the command's output to the user.
+
+If argument is "remote status" (optionally followed by a team name):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
+2. Show the output to the user.
+
+If argument starts with "remote disconnect" followed by a team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+2. Show the output to the user.
+
+If argument starts with "remote doctor":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
+2. Show the output to the user.
+
+If argument starts with "key generate" followed by an optional team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
+2. Show the full output to the user, including the mandatory key-backup notice — do not summarize it away.
+
+If argument starts with "key show":
+1. Parse an optional team name and `--reveal-secret`.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh show [<team>] [--reveal-secret]`
+3. `--reveal-secret` requires a real interactive terminal and is refused in agent mode — if the user wants to reveal a secret, tell them to run it themselves directly in their own terminal rather than through you.
+4. Show the output to the user.
+
+If argument starts with "key import" followed by a team name:
+1. Ask the user to paste the private identity — never type or construct one yourself.
+2. **Never pass it as a literal argument.** Pipe it via stdin instead:
+   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
+3. Show the output to the user.
+
+`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -150,7 +150,7 @@ If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync co
    ```
 3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
 4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -182,5 +182,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -141,11 +141,16 @@ If argument is "reset":
 2. Tell the user the result.
 
 If argument starts with "remote connect" (ADR 0007 — cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>`, the token, and an optional `<team>`/`--force`.
-2. **Never pass the token as a literal argument you construct.** Pipe it via stdin instead:
-   `printf '%s' '<token>' | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]`
-3. If the command pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, relay the prompt to the user verbatim and wait for their real answer — never choose `g`/`i` or fabricate an identity on their behalf.
-4. Show the command's output to the user.
+1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
+2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Token: ' TOKEN; echo
+   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
+   unset TOKEN
+   ```
+3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
+4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
+5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only. Confirm the exact variable name with them explicitly first — never guess or invent one — and never ask them to reveal its value: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$THEIR_CONFIRMED_VAR_NAME" [<team>] [--force]`.
 
 If argument is "remote status" (optionally followed by a team name):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
@@ -170,9 +175,12 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. Ask the user to paste the private identity — never type or construct one yourself.
-2. **Never pass it as a literal argument.** Pipe it via stdin instead:
-   `printf '%s' '<identity>' | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin`
-3. Show the output to the user.
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Identity: ' IDENTITY; echo
+   printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin
+   unset IDENTITY
+   ```
+2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/internal/parse-exchange-response.py
+++ b/scripts/internal/parse-exchange-response.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Strictly validate a pairing-exchange response before remote.sh mutates
+any local state (ADR 0007 review finding B6). Reads the raw response body
+on stdin; on success prints one field per line to stdout (credential,
+credential_id, server_instance_id, remote_team_id, remote_team_name,
+protocol_version, capabilities JSON, write_allowed_ciphers joined by
+comma, current_seq or -1 if absent) and exits 0. On any malformed/missing/
+wrong-typed field, prints a one-line reason to stderr and exits 1 WITHOUT
+printing partial output — callers must not proceed past a non-zero exit
+here.
+
+Newline-delimited rather than NUL-delimited deliberately: bash's command
+substitution `$(...)` strips embedded NUL bytes from captured output,
+which would silently destroy NUL-based field boundaries before the caller
+ever sees them. Every field is rejected if it contains a literal newline
+(none legitimately should), so newline is safe as the sole delimiter here.
+
+credential_id is validated against a bounded, URL-path-safe character set
+because it is spliced directly into the revoke endpoint's path — anything
+else risks path/query injection against a malicious or buggy server.
+"""
+import json
+import re
+import sys
+
+ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+
+def fail(msg):
+    print(f"invalid exchange response: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def req_str(d, key):
+    v = d.get(key)
+    if not isinstance(v, str) or not v:
+        fail(f"missing or invalid '{key}'")
+    return v
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        d = json.loads(raw)
+    except Exception:
+        fail("response body is not valid JSON")
+        return
+    if not isinstance(d, dict):
+        fail("response body is not a JSON object")
+        return
+
+    credential = req_str(d, "credential")
+    credential_id = req_str(d, "credential_id")
+    if not ID_RE.match(credential_id):
+        fail("credential_id has an unexpected shape")
+    server_instance_id = req_str(d, "server_instance_id")
+    remote_team_id = req_str(d, "remote_team_id")
+
+    remote_team_name = d.get("remote_team_name", "")
+    if not isinstance(remote_team_name, str):
+        fail("remote_team_name has an unexpected type")
+
+    protocol_version = d.get("protocol_version")
+    if not isinstance(protocol_version, int) or isinstance(protocol_version, bool):
+        fail("protocol_version has an unexpected type")
+
+    caps = d.get("capabilities", {})
+    if not isinstance(caps, dict):
+        fail("capabilities has an unexpected type")
+
+    ciphers = caps.get("write_allowed_ciphers", [])
+    if not isinstance(ciphers, list) or not all(isinstance(c, str) for c in ciphers):
+        fail("capabilities.write_allowed_ciphers has an unexpected shape")
+    if any("," in c for c in ciphers):
+        fail("capabilities.write_allowed_ciphers entries must not contain ','")
+
+    current_seq = caps.get("current_seq")
+    if current_seq is not None and (not isinstance(current_seq, int) or isinstance(current_seq, bool)):
+        fail("capabilities.current_seq has an unexpected type")
+
+    caps_json = json.dumps(caps)
+    fields = [
+        credential,
+        credential_id,
+        server_instance_id,
+        remote_team_id,
+        remote_team_name,
+        str(protocol_version),
+        caps_json,
+        ",".join(ciphers),
+        str(current_seq if current_seq is not None else -1),
+    ]
+    for f in fields:
+        if "\n" in f:
+            fail("a response field unexpectedly contains a newline")
+
+    sys.stdout.write("\n".join(fields) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/internal/parse-exchange-response.py
+++ b/scripts/internal/parse-exchange-response.py
@@ -155,8 +155,15 @@ def main():
         str(current_seq if current_seq is not None else -1),
     ]
     for f in fields:
-        if "\n" in f:
-            fail("a response field unexpectedly contains a newline")
+        # Reject every ASCII control character (0x00-0x1F, 0x7F), not
+        # just newline (E3) — a raw tab/CR/etc. reaching a downstream
+        # hand-built JSON string (e.g. the credential file) that only
+        # escapes backslash/quote produces invalid JSON, discovered only
+        # when that file is next read. Rejecting here means a
+        # conforming server payload never contains one in the first
+        # place, on top of any downstream escaping fix.
+        if re.search(r"[\x00-\x1f\x7f]", f):
+            fail("a response field unexpectedly contains a control character")
 
     sys.stdout.write("\n".join(fields) + "\n")
 

--- a/scripts/internal/parse-exchange-response.py
+++ b/scripts/internal/parse-exchange-response.py
@@ -17,13 +17,26 @@ ever sees them. Every field is rejected if it contains a literal newline
 
 credential_id is validated against a bounded, URL-path-safe character set
 because it is spliced directly into the revoke endpoint's path — anything
-else risks path/query injection against a malicious or buggy server.
+else risks path/query injection against a malicious or buggy server; its
+exact format isn't pinned by any approved spec (pairing/credential
+exchange is this ADR's own addition), so a conservative bounded charset
+is the right baseline. server_instance_id and team_id (remote_team_id),
+by contrast, ARE pinned: the approved sync HTTP v1 spec (server/spec/v1.md
+@ d1a74db) requires both to be a canonical LOWERCASE UUIDv7 (RFC 9562) —
+validated here as such, not left to a loose bounded charset, since an
+invalid binding must never reach a local commit.
+
+This same validator is also used to re-check a previously-saved pending
+record before resuming a commit from it (ADR 0007 review finding R5) — a
+pending file is not inherently more trustworthy than a fresh response.
 """
 import json
 import re
 import sys
 
 ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+UUIDV7_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+SUPPORTED_PROTOCOL_VERSIONS = (1,)
 
 
 def fail(msg):
@@ -54,7 +67,11 @@ def main():
     if not ID_RE.match(credential_id):
         fail("credential_id has an unexpected shape")
     server_instance_id = req_str(d, "server_instance_id")
+    if not UUIDV7_RE.match(server_instance_id):
+        fail("server_instance_id must be a canonical lowercase UUIDv7")
     remote_team_id = req_str(d, "remote_team_id")
+    if not UUIDV7_RE.match(remote_team_id):
+        fail("remote_team_id must be a canonical lowercase UUIDv7")
 
     remote_team_name = d.get("remote_team_name", "")
     if not isinstance(remote_team_name, str):
@@ -63,6 +80,8 @@ def main():
     protocol_version = d.get("protocol_version")
     if not isinstance(protocol_version, int) or isinstance(protocol_version, bool):
         fail("protocol_version has an unexpected type")
+    if protocol_version not in SUPPORTED_PROTOCOL_VERSIONS:
+        fail(f"unsupported protocol_version {protocol_version!r}")
 
     caps = d.get("capabilities", {})
     if not isinstance(caps, dict):

--- a/scripts/internal/parse-exchange-response.py
+++ b/scripts/internal/parse-exchange-response.py
@@ -29,6 +29,15 @@ invalid binding must never reach a local commit.
 This same validator is also used to re-check a previously-saved pending
 record before resuming a commit from it (ADR 0007 review finding R5) — a
 pending file is not inherently more trustworthy than a fresh response.
+
+Duplicate JSON object keys and unrecognized fields are both rejected
+(ADR 0007 review finding D4): plain `json.loads` silently keeps only the
+LAST occurrence of a duplicated key with no signal that a duplicate ever
+existed, which a malicious/buggy server could use to smuggle a value past
+a naive review of "the response has the right fields" — and would
+otherwise vanish for good once re-serialized (e.g. by the pending-file
+writer). An exact top-level and `capabilities` field allow-list closes
+the same gap for fields this validator doesn't otherwise look at.
 """
 import json
 import re
@@ -37,11 +46,38 @@ import sys
 ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 UUIDV7_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
 SUPPORTED_PROTOCOL_VERSIONS = (1,)
+ALLOWED_TOP_LEVEL_KEYS = {
+    "credential", "credential_id", "server_instance_id", "remote_team_id",
+    "remote_team_name", "protocol_version", "capabilities",
+}
+ALLOWED_CAPABILITY_KEYS = {
+    "accepted_envelope_versions", "write_allowed_ciphers", "policy_revision",
+    "effective_from_seq", "max_blob_bytes", "current_seq",
+    "next_sequence_boundary", "min_available_seq", "policy_history",
+}
 
 
 def fail(msg):
     print(f"invalid exchange response: {msg}", file=sys.stderr)
     sys.exit(1)
+
+
+def _no_duplicate_keys(pairs):
+    seen = set()
+    out = {}
+    for k, v in pairs:
+        if k in seen:
+            fail(f"duplicate JSON key '{k}'")
+        seen.add(k)
+        out[k] = v
+    return out
+
+
+def strict_loads(raw):
+    """json.loads that rejects any object with a duplicate key, at any
+    nesting depth (object_pairs_hook runs for every object, not just the
+    top level)."""
+    return json.loads(raw, object_pairs_hook=_no_duplicate_keys)
 
 
 def req_str(d, key):
@@ -54,13 +90,19 @@ def req_str(d, key):
 def main():
     raw = sys.stdin.read()
     try:
-        d = json.loads(raw)
+        d = strict_loads(raw)
+    except SystemExit:
+        raise
     except Exception:
         fail("response body is not valid JSON")
         return
     if not isinstance(d, dict):
         fail("response body is not a JSON object")
         return
+
+    unknown = set(d.keys()) - ALLOWED_TOP_LEVEL_KEYS
+    if unknown:
+        fail(f"unrecognized field(s): {', '.join(sorted(unknown))}")
 
     credential = req_str(d, "credential")
     credential_id = req_str(d, "credential_id")
@@ -86,6 +128,9 @@ def main():
     caps = d.get("capabilities", {})
     if not isinstance(caps, dict):
         fail("capabilities has an unexpected type")
+    unknown_caps = set(caps.keys()) - ALLOWED_CAPABILITY_KEYS
+    if unknown_caps:
+        fail(f"unrecognized capabilities field(s): {', '.join(sorted(unknown_caps))}")
 
     ciphers = caps.get("write_allowed_ciphers", [])
     if not isinstance(ciphers, list) or not all(isinstance(c, str) for c in ciphers):

--- a/scripts/internal/parse-exchange-response.py
+++ b/scripts/internal/parse-exchange-response.py
@@ -9,6 +9,17 @@ wrong-typed field, prints a one-line reason to stderr and exits 1 WITHOUT
 printing partial output — callers must not proceed past a non-zero exit
 here.
 
+--metadata-only: same full validation, but the `credential` field is
+never written to stdout at all (the other 8 fields keep their positions,
+shifted up by one). For a caller that only needs to know whether a
+record's content validates and to read its non-secret fields — e.g.
+`remote pending list` — printing the credential to stdout would put it in
+that caller's own captured output/temp file even though the caller never
+intends to use it (ADR 0007 addendum review finding: an earlier version
+of the pending-list path read and discarded this field, which still
+copied the secret into a 0600 temp file and a shell variable it never
+needed to touch).
+
 Newline-delimited rather than NUL-delimited deliberately: bash's command
 substitution `$(...)` strips embedded NUL bytes from captured output,
 which would silently destroy NUL-based field boundaries before the caller
@@ -88,6 +99,7 @@ def req_str(d, key):
 
 
 def main():
+    metadata_only = "--metadata-only" in sys.argv[1:]
     raw = sys.stdin.read()
     try:
         d = strict_loads(raw)
@@ -144,7 +156,6 @@ def main():
 
     caps_json = json.dumps(caps)
     fields = [
-        credential,
         credential_id,
         server_instance_id,
         remote_team_id,
@@ -154,6 +165,8 @@ def main():
         ",".join(ciphers),
         str(current_seq if current_seq is not None else -1),
     ]
+    if not metadata_only:
+        fields.insert(0, credential)
     for f in fields:
         # Reject every ASCII control character (0x00-0x1F, 0x7F), not
         # just newline (E3) — a raw tab/CR/etc. reaching a downstream

--- a/scripts/internal/validate-endpoint.py
+++ b/scripts/internal/validate-endpoint.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Strictly validate a --endpoint value (ADR 0007 review finding R2).
+
+A naive shell glob/prefix check (`case $endpoint in http://127.0.0.1*)`)
+is bypassable: `http://127.0.0.1.evil.com`, `http://localhost.evil.com`,
+and `http://localhost@evil.com` (userinfo trick — the real host is
+evil.com) all match a bare string-prefix test while actually pointing
+somewhere else, silently sending the token/credential to that host in
+plaintext. This does real structural URL parsing instead: scheme must be
+exactly "https", OR exactly "http" with the parsed hostname (never the
+raw string) equal to one of the loopback literals AND no userinfo/port
+trickery involved.
+
+Exits 0 (silent) if <endpoint> (argv[1]) is acceptable; exits 1 with a
+one-line reason on stderr otherwise.
+"""
+import sys
+from urllib.parse import urlsplit
+
+LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+
+def fail(msg):
+    print(f"agmsg: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) != 2:
+        fail("internal error: validate-endpoint.py needs exactly one argument")
+        return
+    endpoint = sys.argv[1]
+
+    try:
+        parts = urlsplit(endpoint)
+    except Exception:
+        fail("--endpoint could not be parsed as a URL")
+        return
+
+    if parts.scheme == "https":
+        if not parts.hostname:
+            fail("--endpoint has no host")
+        return
+
+    if parts.scheme == "http":
+        if parts.username is not None or parts.password is not None:
+            fail("--endpoint must not contain userinfo (user@ or user:pass@)")
+        if parts.hostname not in LOOPBACK_HOSTS:
+            fail(
+                "--endpoint must be https:// (plaintext http:// would send the "
+                "token/credential unencrypted) — loopback (127.0.0.1/localhost/::1) "
+                "is the only exception, and only for the exact hostname"
+            )
+        return
+
+    fail("--endpoint must start with https://")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -4,14 +4,15 @@ set -euo pipefail
 # Usage:
 #   key.sh generate [<team>]
 #   key.sh show [<team>] [--reveal-secret]
-#   key.sh import <team> <identity>
-#   key.sh rotate [<team>]
+#   key.sh import <team> [<identity>] [--identity-stdin]
+#   key.sh rotate [<team>]   -- NOT READY, see cmd_rotate
 #
 # Team-scoped end-to-end encryption key management (age-v1 profile,
-# docs/spec/age-v1-profile.md). Scope: single-writer-per-team onboarding and
-# rotation only (ADR 0007 §8) — NOT the multi-writer cutover protocol
-# (adding/removing a device from a team that already has other active
-# writers needs its own quiesce/fence/commit design, not this script).
+# docs/spec/age-v1-profile.md). Scope: initial single-writer onboarding
+# (generate the very first key, or import one obtained out-of-band) — NOT
+# key rotation (see cmd_rotate) and NOT the multi-writer cutover protocol.
+# This script does not implement age-v1's anti-rollback epoch-snapshot
+# hash chain; it only manages key *files* for a team's first epoch.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -69,7 +70,7 @@ _key_fingerprint() {
   printf '%s' "$1" | shasum -a 256 | cut -c1-16 | sed 's/\(....\)/\1-/g;s/-$//'
 }
 
-# A timestamp alone collides when generate/rotate run twice within the same
+# A timestamp alone collides when two epochs are minted within the same
 # second (age-keygen refuses to overwrite an existing identity file, which
 # would otherwise fail *silently* under our error handling) — append a short
 # random suffix so the key_id (and its identity filename) is always unique.
@@ -89,12 +90,12 @@ _key_epoch_json() {
     "$(_agmsg_sqlesc "$1")" "$2" "$3" "$(_agmsg_sqlesc "$4")" "$prev_sql" "$(_agmsg_sqlesc "$6")"
 }
 
-# _key_write_epoch <team> <config_json_path> <epoch_json_expr> [existing_epochs_array_or_empty]
-# Writes remote_key.current = the new epoch and appends it to remote_key.epochs,
-# under the per-team config lock.
-_key_write_epoch() {
-  local team="$1" cfg="$2" epoch_expr="$3" escaped updated
-  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
+# _key_write_epoch_locked <config_json_path> <epoch_json_expr>
+# Assumes the caller ALREADY holds this team's config lock (agmsg_lock_acquire)
+# — does not acquire/release it itself. Writes remote_key.current = the new
+# epoch and appends it to remote_key.epochs.
+_key_write_epoch_locked() {
+  local cfg="$1" epoch_expr="$2" escaped updated
   escaped=$(sed "s/'/''/g" "$cfg")
   updated=$(agmsg_sqlite_mem ".param set :json '$escaped'" \
     "SELECT json_set(:json,
@@ -107,7 +108,24 @@ _key_write_epoch() {
          )
      );")
   agmsg_write_atomic "$cfg" "$updated"
-  agmsg_lock_release
+}
+
+# _key_write_identity_atomic <dest_path> <content>
+# Writes <content> to <dest_path> without ever truncating an existing file
+# in place: create a same-directory temp file with mktemp (which itself
+# opens O_EXCL, so it can never collide with or follow an existing path —
+# in particular never follows a symlink at <dest_path>), 0600 it before any
+# content touches disk, write, best-effort fsync, then atomically rename
+# over the destination. A crash or full disk during the write leaves the
+# temp file incomplete and the real <dest_path> (if any) untouched (B4).
+_key_write_identity_atomic() {
+  local dest="$1" content="$2" dir tmp
+  dir="$(dirname "$dest")"
+  tmp="$(mktemp "$dir/.identity-XXXXXX")"
+  chmod 600 "$tmp"
+  printf '%s\n' "$content" > "$tmp"
+  sync 2>/dev/null || true
+  mv "$tmp" "$dest"
 }
 
 cmd_generate() {
@@ -122,24 +140,32 @@ cmd_generate() {
     exit 1
   fi
 
-  local existing
-  existing="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
-  if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-    echo "agmsg: team '$team' already has a key (key_id=$existing) — use 'key.sh rotate $team' to start a new epoch, or 'key.sh show $team' to view the current one." >&2
-    exit 1
-  fi
-
-  local cred_dir key_id created_at identity_file recipient
+  local cred_dir
   cred_dir="$(_key_cred_dir "$team")"
   mkdir -p "$cred_dir"
   chmod 700 "$cred_dir" 2>/dev/null || true
+
+  # The existence check and the write happen inside the SAME team-config
+  # lock (B4) — otherwise two concurrent `generate` (or `generate` racing
+  # `import`) calls can both pass the check before either writes, minting
+  # two unrelated epoch-0 keys for the same team.
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || exit 1
+  local existing
+  existing="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
+  if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+    agmsg_lock_release
+    echo "agmsg: team '$team' already has a key (key_id=$existing) — use 'key.sh show $team' to view it (rotation is not available in this release)." >&2
+    exit 1
+  fi
+
+  local key_id created_at identity_file recipient keygen_err
   key_id="$(_key_new_key_id)"
   created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   identity_file="$cred_dir/$key_id.key"
 
-  local keygen_err
   keygen_err="$(mktemp "${TMPDIR:-/tmp}/agmsg-keygen-err.XXXXXX")"
   if ! age-keygen -o "$identity_file" 2>"$keygen_err"; then
+    agmsg_lock_release
     echo "agmsg: age-keygen failed: $(cat "$keygen_err" 2>/dev/null)" >&2
     rm -f "$keygen_err"
     exit 1
@@ -148,7 +174,8 @@ cmd_generate() {
   chmod 600 "$identity_file"
   recipient="$(grep '^# public key:' "$identity_file" | sed 's/^# public key: //')"
 
-  _key_write_epoch "$team" "$cfg" "$(_key_epoch_json "$key_id" 0 0 "$recipient" null "$created_at")" || exit 1
+  _key_write_epoch_locked "$cfg" "$(_key_epoch_json "$key_id" 0 0 "$recipient" null "$created_at")"
+  agmsg_lock_release
 
   echo "Generated a new key for team '$team'."
   echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
@@ -181,7 +208,7 @@ cmd_show() {
   key_id="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
   recipient="$(_key_read_config_field "$cfg" '$.remote_key.current.recipient')"
   if [ -z "$key_id" ] || [ "$key_id" = "null" ]; then
-    echo "agmsg: team '$team' has no key yet — run 'key.sh generate $team' or 'key.sh import $team <identity>'." >&2
+    echo "agmsg: team '$team' has no key yet — run 'key.sh generate $team' or 'key.sh import $team'." >&2
     exit 1
   fi
 
@@ -215,9 +242,27 @@ cmd_show() {
 }
 
 cmd_import() {
-  local team="${1:?Usage: key.sh import <team> <identity>}"
-  local identity="${2:?Missing identity}"
+  local identity_stdin=0 positional=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --identity-stdin) identity_stdin=1; shift ;;
+      *) positional+=("$1"); shift ;;
+    esac
+  done
+  local team="${positional[0]:?Usage: key.sh import <team> [<identity>] [--identity-stdin]}"
   agmsg_validate_team_name "$team" || exit 1
+
+  local identity
+  if [ "$identity_stdin" -eq 1 ]; then
+    if [ "${#positional[@]}" -gt 1 ]; then
+      echo "agmsg: too many arguments with --identity-stdin (expected only <team>)" >&2
+      exit 1
+    fi
+    identity="$(cat)"
+  else
+    identity="${positional[1]:?Missing identity (positional argument, or use --identity-stdin)}"
+    echo "agmsg: passing the identity as an argument may expose it via shell history, 'ps', or a caller's own argv/transcript; prefer --identity-stdin" >&2
+  fi
 
   case "$identity" in
     AGE-SECRET-KEY-1*) : ;;
@@ -242,99 +287,63 @@ cmd_import() {
     exit 1
   fi
 
-  # Fail closed: if the team already has an authorized epoch, the imported
-  # identity's recipient must match it — an identity that decrypts nothing
-  # useful for this team is more confusing to discover later than to reject
-  # up front (ADR 0007 §8).
-  local cur_key_id cur_recipient
-  cur_key_id="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
-  cur_recipient="$(_key_read_config_field "$cfg" '$.remote_key.current.recipient')"
-  if [ -n "$cur_key_id" ] && [ "$cur_key_id" != "null" ] && [ "$cur_recipient" != "$recipient" ]; then
-    echo "agmsg: imported identity's recipient does not match team '$team's authorized key — refusing to import." >&2
-    exit 1
-  fi
-
-  local cred_dir key_id created_at identity_file
+  local cred_dir
   cred_dir="$(_key_cred_dir "$team")"
   mkdir -p "$cred_dir"
   chmod 700 "$cred_dir" 2>/dev/null || true
 
-  if [ -z "$cur_key_id" ] || [ "$cur_key_id" = "null" ]; then
-    # No epoch yet for this team: importing establishes the first one.
-    key_id="epoch-$(date -u +%Y%m%d%H%M%S)"
-    created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    identity_file="$cred_dir/$key_id.key"
-    printf '%s\n' "$identity" > "$identity_file"
-    chmod 600 "$identity_file"
-    _key_write_epoch "$team" "$cfg" "$(_key_epoch_json "$key_id" 0 0 "$recipient" null "$created_at")" || exit 1
+  # Fail closed, and check-then-act atomically under the team lock (B4):
+  # if the team already has an authorized epoch, the imported identity's
+  # recipient must match it. Checking outside the lock would let a
+  # concurrent generate/import race land a different key in between.
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || exit 1
+  local cur_key_id cur_recipient
+  cur_key_id="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
+  cur_recipient="$(_key_read_config_field "$cfg" '$.remote_key.current.recipient')"
+
+  if [ -n "$cur_key_id" ] && [ "$cur_key_id" != "null" ]; then
+    if [ "$cur_recipient" != "$recipient" ]; then
+      agmsg_lock_release
+      echo "agmsg: imported identity's recipient does not match team '$team's authorized key — refusing to import." >&2
+      exit 1
+    fi
+    # Matches the existing epoch: just store this device's copy of the
+    # identity under the existing key_id (idempotent re-import). Does not
+    # create a new epoch/snapshot — that only happens via generate.
+    _key_write_identity_atomic "$cred_dir/$cur_key_id.key" "$identity"
+    agmsg_lock_release
   else
-    # Matches the existing epoch (checked above): just store this device's
-    # copy of the identity under the existing key_id. Does not create a new
-    # epoch/snapshot — that only happens via generate (new team) or rotate.
-    key_id="$cur_key_id"
-    identity_file="$cred_dir/$key_id.key"
-    printf '%s\n' "$identity" > "$identity_file"
-    chmod 600 "$identity_file"
+    # No epoch yet for this team: importing establishes the first one.
+    local key_id created_at
+    key_id="$(_key_new_key_id)"
+    created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    _key_write_identity_atomic "$cred_dir/$key_id.key" "$identity"
+    _key_write_epoch_locked "$cfg" "$(_key_epoch_json "$key_id" 0 0 "$recipient" null "$created_at")"
+    agmsg_lock_release
   fi
+  unset identity
 
   echo "Imported key for team '$team'."
   echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
 }
 
+# key rotate — NOT READY.
+#
+# An adversarial design review found this scope's previous_snapshot_sha256
+# design insufficient: hashing only this script's own ad hoc epoch JSON
+# does not detect a wholesale rollback of config.json to a stale version
+# (the hash chain inside a rolled-back file still looks internally
+# consistent), and does not use the age-v1 profile's pinned canonical
+# epoch-snapshot shape. A real fix needs a durable, binding-scoped private
+# anchor (outside the regular synced config) tracking the highest-seen
+# epoch_revision + snapshot digest, checked on load/rotate, with a
+# crash-safe commit ordering relative to the new identity file — none of
+# which this script implements. Shipping rotate without that anchor would
+# present anti-rollback protection that isn't actually there. Deferred to
+# a follow-up design pass; this command intentionally refuses to run.
 cmd_rotate() {
-  local team="${1:?Usage: key.sh rotate [<team>]}"
-  agmsg_validate_team_name "$team" || exit 1
-  _key_require_age || exit 1
-
-  local cfg
-  cfg="$(_key_team_config "$team")"
-  if [ ! -f "$cfg" ]; then
-    echo "agmsg: team not found: $team" >&2
-    exit 1
-  fi
-
-  local cur_key_id cur_epoch cur_writer_gen
-  cur_key_id="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
-  if [ -z "$cur_key_id" ] || [ "$cur_key_id" = "null" ]; then
-    echo "agmsg: team '$team' has no existing key to rotate — run 'key.sh generate $team' first." >&2
-    exit 1
-  fi
-  cur_epoch="$(_key_read_config_field "$cfg" '$.remote_key.current.epoch_revision')"
-  cur_writer_gen="$(_key_read_config_field "$cfg" '$.remote_key.current.writer_generation')"
-
-  local cred_dir new_key_id created_at identity_file new_epoch recipient
-  cred_dir="$(_key_cred_dir "$team")"
-  mkdir -p "$cred_dir"
-  chmod 700 "$cred_dir" 2>/dev/null || true
-  new_key_id="$(_key_new_key_id)"
-  created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  new_epoch=$((cur_epoch + 1))
-  identity_file="$cred_dir/$new_key_id.key"
-
-  local keygen_err
-  keygen_err="$(mktemp "${TMPDIR:-/tmp}/agmsg-keygen-err.XXXXXX")"
-  if ! age-keygen -o "$identity_file" 2>"$keygen_err"; then
-    echo "agmsg: age-keygen failed: $(cat "$keygen_err" 2>/dev/null)" >&2
-    rm -f "$keygen_err"
-    exit 1
-  fi
-  rm -f "$keygen_err"
-  chmod 600 "$identity_file"
-  recipient="$(grep '^# public key:' "$identity_file" | sed 's/^# public key: //')"
-
-  # Never re-encrypts existing envelopes (H1): only the config's "current"
-  # epoch pointer moves. Every prior epoch stays in remote_key.epochs and its
-  # identity file stays on disk — retaining old epochs is required to decrypt
-  # history (single-writer rotation, no cutover barrier needed).
-  _key_write_epoch "$team" "$cfg" "$(_key_epoch_json "$new_key_id" "$new_epoch" "$cur_writer_gen" "$recipient" null "$created_at")" || exit 1
-
-  echo "Started a new epoch for team '$team' (epoch_revision $cur_epoch -> $new_epoch)."
-  echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
-  echo
-  echo "This device's prior key is retained locally and still used to decrypt"
-  echo "older history. Messages sent from now on use the new key. Sharing the"
-  echo "new key with anyone else who needs to read new messages is a manual"
-  echo "'key.sh show' hand-off, same as initial onboarding."
+  echo "agmsg: 'key rotate' is not available in this release — it needs a durable anti-rollback anchor (age-v1 epoch-snapshot hash chain) this script does not yet implement. No state was changed." >&2
+  exit 1
 }
 
 case "${1:-}" in

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   key.sh generate [<team>]
+#   key.sh show [<team>] [--reveal-secret]
+#   key.sh import <team> <identity>
+#   key.sh rotate [<team>]
+#
+# Team-scoped end-to-end encryption key management (age-v1 profile,
+# docs/spec/age-v1-profile.md). Scope: single-writer-per-team onboarding and
+# rotation only (ADR 0007 §8) — NOT the multi-writer cutover protocol
+# (adding/removing a device from a team that already has other active
+# writers needs its own quiesce/fence/commit design, not this script).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/storage.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/registry-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/validate.sh"
+
+TEAMS_DIR="$SCRIPT_DIR/../teams"
+CRED_ROOT="$SKILL_DIR/run/remote-credentials"
+
+# Escape interpolated identifiers as SQL string literals (parity with
+# rename.sh/send.sh): a value with a single quote would break the query.
+_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
+
+_key_team_config() {
+  printf '%s' "$TEAMS_DIR/$1/config.json"
+}
+
+_key_cred_dir() {
+  printf '%s' "$CRED_ROOT/$1/keys"
+}
+
+# Refuse to proceed without a working age/age-keygen — this is the same
+# preflight `remote.sh connect` runs before its own key-bootstrap prompt
+# (ADR 0007 §8), duplicated here since key.sh can also be invoked directly
+# (e.g. `key.sh import` ahead of ever running `connect`).
+_key_require_age() {
+  if ! command -v age >/dev/null 2>&1 || ! command -v age-keygen >/dev/null 2>&1; then
+    echo "agmsg: 'age' is required for end-to-end encryption and was not found on this device." >&2
+    echo "Install it, then retry:" >&2
+    echo "  macOS (Homebrew):      brew install age" >&2
+    echo "  Debian/Ubuntu:         sudo apt install age" >&2
+    echo "  Windows (winget):      winget install FiloSottile.age" >&2
+    echo "See https://github.com/FiloSottile/age for other install methods." >&2
+    return 1
+  fi
+}
+
+# _key_read_config_field <config_json_path> <json_path> — "null" (string) if
+# the file or the field doesn't exist, matching json_extract's own convention.
+_key_read_config_field() {
+  local cfg="$1" path="$2" escaped
+  [ -f "$cfg" ] || { echo "null"; return; }
+  escaped=$(sed "s/'/''/g" "$cfg")
+  agmsg_sqlite_mem ".param set :json '$escaped'" "SELECT json_extract(:json, '$path');"
+}
+
+# Short, human-comparable digest of a recipient string (SSH-key-fingerprint
+# style grouping) — for the H7 "fingerprint verification" step (ADR 0007 §8):
+# two people compare this same short string over a separate channel.
+_key_fingerprint() {
+  printf '%s' "$1" | shasum -a 256 | cut -c1-16 | sed 's/\(....\)/\1-/g;s/-$//'
+}
+
+# A timestamp alone collides when generate/rotate run twice within the same
+# second (age-keygen refuses to overwrite an existing identity file, which
+# would otherwise fail *silently* under our error handling) — append a short
+# random suffix so the key_id (and its identity filename) is always unique.
+# Still matches the age-v1 profile's required key_id shape
+# ([a-z0-9][a-z0-9._-]{0,63}).
+_key_new_key_id() {
+  printf 'epoch-%s-%04x' "$(date -u +%Y%m%d%H%M%S)" "$((RANDOM % 65536))"
+}
+
+_key_epoch_json() {
+  # _key_epoch_json <key_id> <epoch_revision> <writer_generation> <recipient> <previous_snapshot_sha256|null> <created_at>
+  local prev_sql="null"
+  if [ "$5" != "null" ]; then
+    prev_sql="'$(_agmsg_sqlesc "$5")'"
+  fi
+  printf "json_object('key_id', '%s', 'epoch_revision', %s, 'writer_generation', %s, 'recipient', '%s', 'previous_snapshot_sha256', %s, 'created_at', '%s')" \
+    "$(_agmsg_sqlesc "$1")" "$2" "$3" "$(_agmsg_sqlesc "$4")" "$prev_sql" "$(_agmsg_sqlesc "$6")"
+}
+
+# _key_write_epoch <team> <config_json_path> <epoch_json_expr> [existing_epochs_array_or_empty]
+# Writes remote_key.current = the new epoch and appends it to remote_key.epochs,
+# under the per-team config lock.
+_key_write_epoch() {
+  local team="$1" cfg="$2" epoch_expr="$3" escaped updated
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
+  escaped=$(sed "s/'/''/g" "$cfg")
+  updated=$(agmsg_sqlite_mem ".param set :json '$escaped'" \
+    "SELECT json_set(:json,
+       '\$.remote_key.current', $epoch_expr,
+       '\$.remote_key.epochs',
+         json_insert(
+           CASE WHEN json_type(json_extract(:json, '\$.remote_key.epochs')) = 'array'
+                THEN json_extract(:json, '\$.remote_key.epochs') ELSE json('[]') END,
+           '\$[#]', $epoch_expr
+         )
+     );")
+  agmsg_write_atomic "$cfg" "$updated"
+  agmsg_lock_release
+}
+
+cmd_generate() {
+  local team="${1:?Usage: key.sh generate [<team>]}"
+  agmsg_validate_team_name "$team" || exit 1
+  _key_require_age || exit 1
+
+  local cfg
+  cfg="$(_key_team_config "$team")"
+  if [ ! -f "$cfg" ]; then
+    echo "agmsg: team not found: $team" >&2
+    exit 1
+  fi
+
+  local existing
+  existing="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
+  if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+    echo "agmsg: team '$team' already has a key (key_id=$existing) — use 'key.sh rotate $team' to start a new epoch, or 'key.sh show $team' to view the current one." >&2
+    exit 1
+  fi
+
+  local cred_dir key_id created_at identity_file recipient
+  cred_dir="$(_key_cred_dir "$team")"
+  mkdir -p "$cred_dir"
+  chmod 700 "$cred_dir" 2>/dev/null || true
+  key_id="$(_key_new_key_id)"
+  created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  identity_file="$cred_dir/$key_id.key"
+
+  local keygen_err
+  keygen_err="$(mktemp "${TMPDIR:-/tmp}/agmsg-keygen-err.XXXXXX")"
+  if ! age-keygen -o "$identity_file" 2>"$keygen_err"; then
+    echo "agmsg: age-keygen failed: $(cat "$keygen_err" 2>/dev/null)" >&2
+    rm -f "$keygen_err"
+    exit 1
+  fi
+  rm -f "$keygen_err"
+  chmod 600 "$identity_file"
+  recipient="$(grep '^# public key:' "$identity_file" | sed 's/^# public key: //')"
+
+  _key_write_epoch "$team" "$cfg" "$(_key_epoch_json "$key_id" 0 0 "$recipient" null "$created_at")" || exit 1
+
+  echo "Generated a new key for team '$team'."
+  echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+  echo
+  echo "Back this up now. agmsg does not store a copy of this key anywhere —"
+  echo "if this device is lost, every message encrypted under this key"
+  echo "becomes permanently unreadable. There is no server-side recovery."
+  echo "Run 'key.sh show $team --reveal-secret' to view and save it somewhere"
+  echo "safe — a password manager entry, not a plaintext file. Do NOT copy"
+  echo "it into a dotfiles repo, a git repo of any kind, or any other"
+  echo "synced/backed-up-by-a-tool location you wouldn't also trust with a"
+  echo "production credential. Removing a device later does not revoke its"
+  echo "ability to read history encrypted before removal."
+}
+
+cmd_show() {
+  local team="" reveal=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --reveal-secret) reveal=1 ;;
+      *) team="$1" ;;
+    esac
+    shift
+  done
+  : "${team:?Usage: key.sh show [<team>] [--reveal-secret]}"
+  agmsg_validate_team_name "$team" || exit 1
+
+  local cfg key_id recipient
+  cfg="$(_key_team_config "$team")"
+  key_id="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
+  recipient="$(_key_read_config_field "$cfg" '$.remote_key.current.recipient')"
+  if [ -z "$key_id" ] || [ "$key_id" = "null" ]; then
+    echo "agmsg: team '$team' has no key yet — run 'key.sh generate $team' or 'key.sh import $team <identity>'." >&2
+    exit 1
+  fi
+
+  if [ "$reveal" -eq 0 ]; then
+    echo "Team: $team"
+    echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+    echo "Public recipient: $recipient"
+    return
+  fi
+
+  # Refused outright in agent mode — no TTY, no reveal, no override
+  # (ADR 0007 secret-hygiene: this is the one place a raw secret can reach
+  # stdout, so it must be harder to trigger than the rest of the CLI).
+  if [ ! -t 0 ] || [ ! -t 1 ]; then
+    echo "agmsg: --reveal-secret requires an interactive terminal and is refused in agent mode." >&2
+    exit 1
+  fi
+  echo "This will print your private key material to the terminal."
+  read -r -p "Type 'reveal' to confirm: " confirm
+  if [ "$confirm" != "reveal" ]; then
+    echo "Aborted." >&2
+    exit 1
+  fi
+  local identity_file
+  identity_file="$(_key_cred_dir "$team")/$key_id.key"
+  if [ ! -f "$identity_file" ]; then
+    echo "agmsg: local identity file missing for key_id=$key_id ($identity_file)" >&2
+    exit 1
+  fi
+  grep '^AGE-SECRET-KEY-' "$identity_file"
+}
+
+cmd_import() {
+  local team="${1:?Usage: key.sh import <team> <identity>}"
+  local identity="${2:?Missing identity}"
+  agmsg_validate_team_name "$team" || exit 1
+
+  case "$identity" in
+    AGE-SECRET-KEY-1*) : ;;
+    *)
+      echo "agmsg: not a well-formed age identity (expected AGE-SECRET-KEY-1...)" >&2
+      exit 1 ;;
+  esac
+
+  local cfg
+  cfg="$(_key_team_config "$team")"
+  if [ ! -f "$cfg" ]; then
+    echo "agmsg: team not found: $team" >&2
+    exit 1
+  fi
+
+  _key_require_age || exit 1
+
+  local recipient
+  recipient="$(printf '%s\n' "$identity" | age-keygen -y 2>/dev/null)" || true
+  if [ -z "$recipient" ]; then
+    echo "agmsg: failed to derive a recipient from the given identity — not a valid age identity." >&2
+    exit 1
+  fi
+
+  # Fail closed: if the team already has an authorized epoch, the imported
+  # identity's recipient must match it — an identity that decrypts nothing
+  # useful for this team is more confusing to discover later than to reject
+  # up front (ADR 0007 §8).
+  local cur_key_id cur_recipient
+  cur_key_id="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
+  cur_recipient="$(_key_read_config_field "$cfg" '$.remote_key.current.recipient')"
+  if [ -n "$cur_key_id" ] && [ "$cur_key_id" != "null" ] && [ "$cur_recipient" != "$recipient" ]; then
+    echo "agmsg: imported identity's recipient does not match team '$team's authorized key — refusing to import." >&2
+    exit 1
+  fi
+
+  local cred_dir key_id created_at identity_file
+  cred_dir="$(_key_cred_dir "$team")"
+  mkdir -p "$cred_dir"
+  chmod 700 "$cred_dir" 2>/dev/null || true
+
+  if [ -z "$cur_key_id" ] || [ "$cur_key_id" = "null" ]; then
+    # No epoch yet for this team: importing establishes the first one.
+    key_id="epoch-$(date -u +%Y%m%d%H%M%S)"
+    created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    identity_file="$cred_dir/$key_id.key"
+    printf '%s\n' "$identity" > "$identity_file"
+    chmod 600 "$identity_file"
+    _key_write_epoch "$team" "$cfg" "$(_key_epoch_json "$key_id" 0 0 "$recipient" null "$created_at")" || exit 1
+  else
+    # Matches the existing epoch (checked above): just store this device's
+    # copy of the identity under the existing key_id. Does not create a new
+    # epoch/snapshot — that only happens via generate (new team) or rotate.
+    key_id="$cur_key_id"
+    identity_file="$cred_dir/$key_id.key"
+    printf '%s\n' "$identity" > "$identity_file"
+    chmod 600 "$identity_file"
+  fi
+
+  echo "Imported key for team '$team'."
+  echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+}
+
+cmd_rotate() {
+  local team="${1:?Usage: key.sh rotate [<team>]}"
+  agmsg_validate_team_name "$team" || exit 1
+  _key_require_age || exit 1
+
+  local cfg
+  cfg="$(_key_team_config "$team")"
+  if [ ! -f "$cfg" ]; then
+    echo "agmsg: team not found: $team" >&2
+    exit 1
+  fi
+
+  local cur_key_id cur_epoch cur_writer_gen
+  cur_key_id="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
+  if [ -z "$cur_key_id" ] || [ "$cur_key_id" = "null" ]; then
+    echo "agmsg: team '$team' has no existing key to rotate — run 'key.sh generate $team' first." >&2
+    exit 1
+  fi
+  cur_epoch="$(_key_read_config_field "$cfg" '$.remote_key.current.epoch_revision')"
+  cur_writer_gen="$(_key_read_config_field "$cfg" '$.remote_key.current.writer_generation')"
+
+  local cred_dir new_key_id created_at identity_file new_epoch recipient
+  cred_dir="$(_key_cred_dir "$team")"
+  mkdir -p "$cred_dir"
+  chmod 700 "$cred_dir" 2>/dev/null || true
+  new_key_id="$(_key_new_key_id)"
+  created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  new_epoch=$((cur_epoch + 1))
+  identity_file="$cred_dir/$new_key_id.key"
+
+  local keygen_err
+  keygen_err="$(mktemp "${TMPDIR:-/tmp}/agmsg-keygen-err.XXXXXX")"
+  if ! age-keygen -o "$identity_file" 2>"$keygen_err"; then
+    echo "agmsg: age-keygen failed: $(cat "$keygen_err" 2>/dev/null)" >&2
+    rm -f "$keygen_err"
+    exit 1
+  fi
+  rm -f "$keygen_err"
+  chmod 600 "$identity_file"
+  recipient="$(grep '^# public key:' "$identity_file" | sed 's/^# public key: //')"
+
+  # Never re-encrypts existing envelopes (H1): only the config's "current"
+  # epoch pointer moves. Every prior epoch stays in remote_key.epochs and its
+  # identity file stays on disk — retaining old epochs is required to decrypt
+  # history (single-writer rotation, no cutover barrier needed).
+  _key_write_epoch "$team" "$cfg" "$(_key_epoch_json "$new_key_id" "$new_epoch" "$cur_writer_gen" "$recipient" null "$created_at")" || exit 1
+
+  echo "Started a new epoch for team '$team' (epoch_revision $cur_epoch -> $new_epoch)."
+  echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+  echo
+  echo "This device's prior key is retained locally and still used to decrypt"
+  echo "older history. Messages sent from now on use the new key. Sharing the"
+  echo "new key with anyone else who needs to read new messages is a manual"
+  echo "'key.sh show' hand-off, same as initial onboarding."
+}
+
+case "${1:-}" in
+  generate) shift; cmd_generate "$@" ;;
+  show) shift; cmd_show "$@" ;;
+  import) shift; cmd_import "$@" ;;
+  rotate) shift; cmd_rotate "$@" ;;
+  *)
+    echo "Usage: key.sh <generate|show|import|rotate> ..." >&2
+    exit 1 ;;
+esac

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -123,9 +123,15 @@ _key_write_identity_atomic() {
   dir="$(dirname "$dest")"
   tmp="$(mktemp "$dir/.identity-XXXXXX")"
   chmod 600 "$tmp"
+  # Cleanup trap: a kill signal between mktemp and the rename below would
+  # otherwise leave a 0600-but-never-renamed temp copy of the key sitting
+  # in the credential store indefinitely (same nonblocking finding raised
+  # against remote.sh's analogous credential-file write).
+  trap 'rm -f "$tmp"' EXIT INT TERM
   printf '%s\n' "$content" > "$tmp"
   sync 2>/dev/null || true
   mv "$tmp" "$dest"
+  trap - EXIT INT TERM
 }
 
 cmd_generate() {

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -56,11 +56,18 @@ _key_require_age() {
 
 # _key_read_config_field <config_json_path> <json_path> — "null" (string) if
 # the file or the field doesn't exist, matching json_extract's own convention.
+# <escaped> is spliced as a genuine SQL string literal below, NOT bound via
+# `.param set`: the sqlite3 shell's dot-command tokenizer does not honour SQL
+# '' escaping (unlike a real SQL statement's string literals), so
+# `.param set :json '...'` silently mis-parses as soon as the config
+# contains any single quote (#87 cluster; see resolve-project.sh's
+# `resolve_team` for the same caveat, and PR #482 for the sibling-script
+# fix this mirrors).
 _key_read_config_field() {
   local cfg="$1" path="$2" escaped
   [ -f "$cfg" ] || { echo "null"; return; }
   escaped=$(sed "s/'/''/g" "$cfg")
-  agmsg_sqlite_mem ".param set :json '$escaped'" "SELECT json_extract(:json, '$path');"
+  agmsg_sqlite_mem "SELECT json_extract('$escaped', '$path');"
 }
 
 # Short, human-comparable digest of a recipient string (SSH-key-fingerprint
@@ -97,13 +104,15 @@ _key_epoch_json() {
 _key_write_epoch_locked() {
   local cfg="$1" epoch_expr="$2" escaped updated
   escaped=$(sed "s/'/''/g" "$cfg")
-  updated=$(agmsg_sqlite_mem ".param set :json '$escaped'" \
-    "SELECT json_set(:json,
+  # <escaped> is spliced as a genuine SQL string literal, NOT bound via
+  # `.param set` (same tokenizer caveat as `_key_read_config_field` above).
+  updated=$(agmsg_sqlite_mem \
+    "SELECT json_set('$escaped',
        '\$.remote_key.current', $epoch_expr,
        '\$.remote_key.epochs',
          json_insert(
-           CASE WHEN json_type(json_extract(:json, '\$.remote_key.epochs')) = 'array'
-                THEN json_extract(:json, '\$.remote_key.epochs') ELSE json('[]') END,
+           CASE WHEN json_type(json_extract('$escaped', '\$.remote_key.epochs')) = 'array'
+                THEN json_extract('$escaped', '\$.remote_key.epochs') ELSE json('[]') END,
            '\$[#]', $epoch_expr
          )
      );")

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -103,6 +103,7 @@ _remote_http_post_json() {
   local url="$1" body_file="$2" out_file="$3" cfg http_code
   cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
   chmod 600 "$cfg"
+  trap 'rm -f "$cfg"' EXIT INT TERM
   {
     printf 'url = "%s"\n' "$url"
     printf 'request = "POST"\n'
@@ -111,6 +112,7 @@ _remote_http_post_json() {
   } > "$cfg"
   http_code=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>/dev/null) || http_code="000"
   rm -f "$cfg"
+  trap - EXIT INT TERM
   printf '%s' "$http_code"
 }
 
@@ -120,6 +122,7 @@ _remote_http_post_bearer() {
   local url="$1" token="$2" cfg http_code
   cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
   chmod 600 "$cfg"
+  trap 'rm -f "$cfg"' EXIT INT TERM
   {
     printf 'url = "%s"\n' "$url"
     printf 'request = "POST"\n'
@@ -127,14 +130,41 @@ _remote_http_post_bearer() {
   } > "$cfg"
   http_code=$(curl -sS -o /dev/null -w '%{http_code}' -K "$cfg" 2>/dev/null) || http_code="000"
   rm -f "$cfg"
+  trap - EXIT INT TERM
   printf '%s' "$http_code"
 }
 
 # _remote_revoke <endpoint> <credential_id> <credential> -> 0 revoked, 1 not
+# 404 counts as success (D2): a retry after a crash right after a prior
+# successful revoke would otherwise see "unknown credential_id" and be
+# unable to ever make progress — 404 for a credential_id we ourselves
+# issued and are trying to revoke is just as strong evidence that it's
+# not active anymore as a 200 is.
 _remote_revoke() {
   local endpoint="$1" credential_id="$2" credential="$3" http_code
   http_code="$(_remote_http_post_bearer "$endpoint/v1/credentials/$credential_id/revoke" "$credential")"
-  [ "$http_code" = "200" ]
+  [ "$http_code" = "200" ] || [ "$http_code" = "404" ]
+}
+
+# _remote_local_disconnect <team> <cfg>
+# The local-state half of disconnect (credential file removal + marking
+# the binding disconnected) — factored out so the --force rebind path can
+# apply it immediately after a successful revoke, before ever attempting
+# the new exchange (D2): otherwise a crash between "old credential
+# revoked" and "new connection fully committed" leaves local state
+# claiming to still be connected to a credential that the server has
+# already invalidated, with no way to tell from local state alone.
+_remote_local_disconnect() {
+  local team="$1" cfg="$2" cred_file escaped updated disconnected_at
+  cred_file="$(_remote_cred_file "$team")"
+  rm -f "$cred_file"
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
+  disconnected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  escaped=$(sed "s/'/''/g" "$cfg")
+  updated=$(agmsg_sqlite_mem ".param set :json '$escaped'" \
+    "SELECT json_set(:json, '\$.remote_binding.disconnected_at', '$(_agmsg_sqlesc "$disconnected_at")');")
+  agmsg_write_atomic "$cfg" "$updated"
+  agmsg_lock_release
 }
 
 # --- connect -------------------------------------------------------------
@@ -162,14 +192,20 @@ _remote_pending_file() { printf '%s' "$PENDING_DIR/$1.json"; }
 # instead of needing (and orphaning a credential for) a fresh single-use
 # token (B5).
 #
-# Takes the RAW response file and re-serializes its exact bytes as-is
-# (never the individually-extracted credential/credential_id/etc as their
-# own values) — <resp_file> and <endpoint> are passed to python3 by PATH
-# and as a non-secret string respectively, so the secret itself is read
-# only via file I/O inside the python process and never appears as any
-# process's own argv element (R1: an earlier version of this function
+# Takes the RAW response file and embeds its exact bytes VERBATIM as a
+# JSON string value (never re-parsed/re-serialized as a nested object,
+# and never the individually-extracted credential/credential_id/etc as
+# their own values) — <resp_file> and <endpoint> are passed to python3 by
+# PATH and as a non-secret string respectively, so the secret itself is
+# read only via file I/O inside the python process and never appears as
+# any process's own argv element (R1: an earlier version of this function
 # passed the credential as a positional python3 argument, which any
 # concurrent `ps` could read for as long as that process was alive).
+# Storing the raw bytes verbatim rather than round-tripping through
+# json.load()+json.dumps() also closes D4: a reparse/reserialize step
+# would silently collapse duplicate keys with no trace, before resume
+# ever gets a chance to run the duplicate-detecting strict validator
+# against them.
 _remote_write_pending() {
   local key="$1" resp_file="$2" endpoint="$3" pending_file tmp json
   mkdir -p "$PENDING_DIR"
@@ -179,8 +215,8 @@ _remote_write_pending() {
 import json, sys
 resp_path, endpoint = sys.argv[1], sys.argv[2]
 with open(resp_path) as f:
-    response = json.load(f)
-print(json.dumps({"endpoint": endpoint, "response": response}))
+    raw_response_text = f.read()
+print(json.dumps({"endpoint": endpoint, "raw_response_text": raw_response_text}))
 ' "$resp_file" "$endpoint")
   tmp="$(mktemp "$PENDING_DIR/.pending-XXXXXX")"
   chmod 600 "$tmp"
@@ -190,12 +226,14 @@ print(json.dumps({"endpoint": endpoint, "response": response}))
 }
 
 # _remote_load_pending <pending_file> <out_resp_file> -> prints endpoint
-# Extracts the embedded raw response back out to its own file (so it can
-# be re-run through the SAME strict parse-exchange-response.py validator
-# a fresh exchange uses — R5: a pending file is not inherently more
-# trustworthy than a live response and must not skip validation) and
-# prints the (non-secret) endpoint string. <pending_file>'s path is
-# passed by PATH, never its contents, as a python3 argument.
+# Extracts the embedded raw response bytes back out to its own file,
+# byte-for-byte as originally received, so it can be re-run through the
+# SAME strict parse-exchange-response.py validator (including its
+# duplicate-key detection) a fresh exchange uses (R5/D4) — a pending file
+# is not inherently more trustworthy than a live response and must not
+# skip validation, and nothing about the original bytes may have been
+# lost in between. <pending_file>'s path is passed by PATH, never its
+# contents, as a python3 argument.
 _remote_load_pending() {
   local pending_file="$1" out_resp_file="$2"
   python3 -c '
@@ -204,7 +242,7 @@ pending_path, out_path = sys.argv[1], sys.argv[2]
 with open(pending_path) as f:
     pending = json.load(f)
 with open(out_path, "w") as f:
-    json.dump(pending["response"], f)
+    f.write(pending["raw_response_text"])
 print(pending["endpoint"])
 ' "$pending_file" "$out_resp_file"
 }
@@ -223,10 +261,24 @@ _remote_commit() {
   mkdir -p "$CRED_ROOT"
   chmod 700 "$CRED_ROOT" 2>/dev/null || true
   cred_file="$(_remote_cred_file "$team")"
+  # Escape backslash BEFORE quote (order matters: escaping quote first
+  # would double-escape any backslash the first substitution just
+  # inserted) — the previous version only escaped quotes, so a credential
+  # containing a literal backslash would have produced invalid JSON (D3).
   cred_json="$(printf '{"credential":"%s","credential_id":"%s"}' \
-    "$(printf '%s' "$credential" | sed 's/"/\\"/g')" \
-    "$(printf '%s' "$credential_id" | sed 's/"/\\"/g')")"
-  ( umask 077; printf '%s\n' "$cred_json" > "$cred_file" )
+    "$(printf '%s' "$credential" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+    "$(printf '%s' "$credential_id" | sed 's/\\/\\\\/g; s/"/\\"/g')")"
+  # Atomic write (temp file in the same dir, 0600 before any content is
+  # written, best-effort fsync, then rename) — never truncate the real
+  # path in place (D3): a crash mid-write, or a re-commit racing another
+  # reader, must not leave a half-written/corrupt credential file as the
+  # only copy of the secret.
+  local cred_tmp
+  cred_tmp="$(mktemp "$CRED_ROOT/.cred-XXXXXX")"
+  chmod 600 "$cred_tmp"
+  printf '%s\n' "$cred_json" > "$cred_tmp"
+  sync 2>/dev/null || true
+  mv "$cred_tmp" "$cred_file"
   unset cred_json
 
   connected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -247,7 +299,8 @@ _remote_commit() {
 }
 
 cmd_connect() {
-  local endpoint="" token="" token_stdin=0 team="" force=0 positional=()
+  local endpoint="" token="" token_stdin=0 team="" force=0 positional=() \
+    expected_old_credential_id=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --endpoint) endpoint="${2:?--endpoint requires a value}"; shift 2 ;;
@@ -379,6 +432,21 @@ cmd_connect() {
           exit 1
         fi
         unset old_credential
+        # D2: durably reflect the revoke locally right now, before the new
+        # exchange even starts — otherwise a crash between here and the
+        # new connection's commit leaves local state claiming to still be
+        # connected to a credential the server has already invalidated,
+        # with no local signal that anything is wrong. This also makes a
+        # retry idempotent: a second attempt sees the team as already
+        # (locally) disconnected and skips straight to a fresh exchange
+        # instead of trying to revoke an already-revoked credential again.
+        _remote_local_disconnect "$team" "$(_remote_team_config "$team")" || exit 1
+        # D1: remember exactly which credential we confirmed revoked, so
+        # the post-exchange CAS check (below) only proceeds if nothing
+        # else has touched this team's binding since — --force authorizes
+        # overriding *this specific* old credential, not "whatever is
+        # there by the time the exchange finishes."
+        expected_old_credential_id="$existing_credential_id"
       fi
     fi
 
@@ -458,16 +526,26 @@ cmd_connect() {
   cfg="$(_remote_team_config "$team")"
 
   agmsg_lock_acquire "$TEAMS_DIR/$team" || exit 1
-  # Re-check under the lock (CAS): if something else connected this team
-  # in the window since our pre-flight check (or since the exchange, for
-  # the omitted-team case where no pre-check was possible), fail closed
-  # rather than mixing old/new bindings (B5) — UNLESS the existing binding
-  # is EXACTLY this same operation's own prior (partial) commit (its
-  # credential_id/server_instance_id/remote_team_id all match what we're
-  # about to write) — that's the resume-after-commit-but-before-pending-
-  # cleanup crash case (R3): idempotently finish (drop the pending file,
-  # skip re-writing an identical binding) rather than treating our own
-  # completed work as a foreign conflict.
+  # Re-check under the lock (CAS). Three cases are safe to commit into;
+  # everything else fails closed, INCLUDING under --force (D1: force
+  # authorizes overriding the *specific* old credential this operation
+  # already confirmed revoked pre-exchange — it is not a blanket bypass
+  # of this check, or a third party's differing credential could get
+  # silently clobbered and permanently orphaned server-side):
+  #   1. Not currently connected (fresh connect, or --force's pre-check
+  #      already revoked-and-locally-disconnected the prior credential —
+  #      D2 — so nothing conflicting remains to protect).
+  #   2. Already connected, but to EXACTLY this same operation's own
+  #      prior (partial) commit (credential_id/server_instance_id/
+  #      remote_team_id all match) — the resume-after-commit-but-before-
+  #      pending-cleanup crash case (R3). Re-commits (self-healing —
+  #      D3 — rather than trusting the binding metadata alone and just
+  #      deleting pending: if the credential FILE write never finished,
+  #      re-running commit repairs it, since committing identical data
+  #      twice is always safe).
+  #   3. Already connected to a DIFFERENT credential, but --force is set
+  #      AND that credential is exactly the one we revoked pre-exchange
+  #      (nothing else touched this team's binding in between).
   local recheck_connected recheck_disconnected recheck_credential_id \
     recheck_server_instance_id recheck_remote_team_id
   recheck_connected="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
@@ -480,22 +558,28 @@ cmd_connect() {
     && { [ -z "$recheck_disconnected" ] || [ "$recheck_disconnected" = "null" ]; }; then
     already_connected=1
   fi
-  if [ "$already_connected" -eq 1 ] \
-    && [ "$recheck_credential_id" = "$credential_id" ] \
+
+  local safe_to_commit=0
+  if [ "$already_connected" -eq 0 ]; then
+    safe_to_commit=1
+  elif [ "$recheck_credential_id" = "$credential_id" ] \
     && [ "$recheck_server_instance_id" = "$server_instance_id" ] \
     && [ "$recheck_remote_team_id" = "$remote_team_id" ]; then
-    # Already fully committed by this exact operation — idempotent no-op.
-    rm -f "$pending_file"
-    agmsg_lock_release
-  elif [ "$already_connected" -eq 1 ] && [ "$force" -ne 1 ]; then
-    agmsg_lock_release
-    echo "agmsg: team '$team' became connected by another process just now — the credential just issued for it was NOT committed locally. Revoke it (credential_id=$credential_id) via the console/admin side if it should not remain active, then retry." >&2
-    exit 1
-  else
+    safe_to_commit=1
+  elif [ "$force" -eq 1 ] && [ -n "$expected_old_credential_id" ] \
+    && [ "$recheck_credential_id" = "$expected_old_credential_id" ]; then
+    safe_to_commit=1
+  fi
+
+  if [ "$safe_to_commit" -eq 1 ]; then
     _remote_commit "$team" "$cfg" "$endpoint" "$credential" "$credential_id" \
       "$server_instance_id" "$remote_team_id" "$remote_team_name" "$protocol_version" "$capabilities_json"
     rm -f "$pending_file"
     agmsg_lock_release
+  else
+    agmsg_lock_release
+    echo "agmsg: team '$team' has a different, unexpected binding than expected — the credential just issued for it was NOT committed locally. Revoke it (credential_id=$credential_id) via the console/admin side if it should not remain active, then retry." >&2
+    exit 1
   fi
   unset credential
 
@@ -659,16 +743,7 @@ cmd_disconnect() {
     unset credential
   fi
 
-  rm -f "$cred_file"
-
-  agmsg_lock_acquire "$TEAMS_DIR/$team" || exit 1
-  local escaped updated disconnected_at
-  disconnected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  escaped=$(sed "s/'/''/g" "$cfg")
-  updated=$(agmsg_sqlite_mem ".param set :json '$escaped'" \
-    "SELECT json_set(:json, '\$.remote_binding.disconnected_at', '$(_agmsg_sqlesc "$disconnected_at")');")
-  agmsg_write_atomic "$cfg" "$updated"
-  agmsg_lock_release
+  _remote_local_disconnect "$team" "$cfg" || exit 1
 
   if [ "$revoke_ok" -eq 1 ]; then
     echo "Revoking credential with server... ok."

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -24,6 +24,7 @@ source "$SCRIPT_DIR/lib/validate.sh"
 
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 CRED_ROOT="$SKILL_DIR/run/remote-credentials"
+PENDING_DIR="$SKILL_DIR/run/remote-connect-pending"
 
 _agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
 
@@ -39,7 +40,7 @@ _remote_read_config_field() {
 
 # Bootstrap a brand-new local team dir/config, mirroring join.sh's own
 # initial-config shape exactly (no agents registered yet — connect only
-# establishes the sync binding, not a agent identity in the team).
+# establishes the sync binding, not an agent identity in the team).
 _remote_ensure_team() {
   local team="$1" cfg
   cfg="$(_remote_team_config "$team")"
@@ -50,6 +51,23 @@ _remote_ensure_team() {
       "$team" "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
     agmsg_write_atomic "$cfg" "$initial"
   fi
+}
+
+# Reject a non-HTTPS endpoint (token/credential would cross the wire in
+# plaintext) except for loopback, which self-host/dev setups need without a
+# cert (ADR 0007 review finding B6).
+_remote_validate_endpoint() {
+  local endpoint="$1"
+  case "$endpoint" in
+    https://*) return 0 ;;
+    http://127.0.0.1*|http://localhost*|http://\[::1\]*) return 0 ;;
+    http://*)
+      echo "agmsg: --endpoint must be https:// (plaintext http:// would send the token/credential unencrypted) — loopback (127.0.0.1/localhost) is the only exception" >&2
+      return 1 ;;
+    *)
+      echo "agmsg: --endpoint must start with https://" >&2
+      return 1 ;;
+  esac
 }
 
 # --- doctor ------------------------------------------------------------
@@ -80,16 +98,124 @@ cmd_doctor() {
   fi
 }
 
+# --- shared HTTP helpers (B1: never put secrets in curl's own argv/ps) ---
+
+# _remote_http_post_json <url> <body_file> <out_body_file> -> prints http_code
+# Posts <body_file> as the request body via a curl -K config file, so the
+# body (which holds the token) never appears in curl's own argv/ps. The
+# config file is 0600 and removed immediately after the call.
+_remote_http_post_json() {
+  local url="$1" body_file="$2" out_file="$3" cfg http_code
+  cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
+  chmod 600 "$cfg"
+  {
+    printf 'url = "%s"\n' "$url"
+    printf 'request = "POST"\n'
+    printf 'header = "Content-Type: application/json"\n'
+    printf 'data = "@%s"\n' "$body_file"
+  } > "$cfg"
+  http_code=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>/dev/null) || http_code="000"
+  rm -f "$cfg"
+  printf '%s' "$http_code"
+}
+
+# _remote_http_post_bearer <url> <bearer_token> -> prints http_code
+# Same argv-safety property for the Authorization header (revoke calls).
+_remote_http_post_bearer() {
+  local url="$1" token="$2" cfg http_code
+  cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
+  chmod 600 "$cfg"
+  {
+    printf 'url = "%s"\n' "$url"
+    printf 'request = "POST"\n'
+    printf 'header = "Authorization: Bearer %s"\n' "$token"
+  } > "$cfg"
+  http_code=$(curl -sS -o /dev/null -w '%{http_code}' -K "$cfg" 2>/dev/null) || http_code="000"
+  rm -f "$cfg"
+  printf '%s' "$http_code"
+}
+
+# _remote_revoke <endpoint> <credential_id> <credential> -> 0 revoked, 1 not
+_remote_revoke() {
+  local endpoint="$1" credential_id="$2" credential="$3" http_code
+  http_code="$(_remote_http_post_bearer "$endpoint/v1/credentials/$credential_id/revoke" "$credential")"
+  [ "$http_code" = "200" ]
+}
+
 # --- connect -------------------------------------------------------------
 
-_remote_write_binding() {
-  # _remote_write_binding <team> <cfg> <endpoint> <credential_id> <server_instance_id>
-  #   <remote_team_id> <remote_team_name> <protocol_version> <capabilities_json>
-  local team="$1" cfg="$2" endpoint="$3" credential_id="$4" server_instance_id="$5" \
-    remote_team_id="$6" remote_team_name="$7" protocol_version="$8" capabilities_json="$9" \
-    connected_at escaped updated
+# A resumability key derived from (endpoint, token) — known BEFORE any
+# network call, so it doesn't depend on the local team name, which may not
+# be known until the exchange response comes back (B5: the earlier design
+# keyed pending state by team name, which couldn't cover that case at all).
+# The token itself is never written to disk or logged — only this
+# irreversible digest of it, so the pending record can't be used to recover
+# the token, and repeating the exact same (endpoint, token) pair after a
+# crash resumes instead of re-consuming a token that may already be spent.
+_remote_pending_key() {
+  local endpoint="$1" token="$2"
+  printf '%s\0%s' "$endpoint" "$token" | python3 -c "import sys,hashlib; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())"
+}
+
+_remote_pending_file() { printf '%s' "$PENDING_DIR/$1.json"; }
+
+# _remote_write_pending <key> <credential> <credential_id> <server_instance_id>
+#   <remote_team_id> <remote_team_name> <protocol_version> <capabilities_json> <endpoint>
+# Durable, atomic (temp+rename), 0600 record of a successful exchange whose
+# local commit has not (yet) fully completed — deliberately does NOT
+# include the token. A crash between the exchange and _remote_commit
+# finishing resumes from here on a retry with the same (endpoint, token),
+# instead of needing (and orphaning a credential for) a fresh single-use
+# token (B5).
+_remote_write_pending() {
+  local key="$1" credential="$2" credential_id="$3" server_instance_id="$4" \
+    remote_team_id="$5" remote_team_name="$6" protocol_version="$7" \
+    capabilities_json="$8" endpoint="$9" pending_file tmp json
+  mkdir -p "$PENDING_DIR"
+  chmod 700 "$PENDING_DIR" 2>/dev/null || true
+  pending_file="$(_remote_pending_file "$key")"
+  json=$(python3 -c '
+import json, sys
+credential, credential_id, server_instance_id, remote_team_id, remote_team_name, protocol_version, capabilities_json, endpoint = sys.argv[1:9]
+print(json.dumps({
+    "credential": credential,
+    "credential_id": credential_id,
+    "server_instance_id": server_instance_id,
+    "remote_team_id": remote_team_id,
+    "remote_team_name": remote_team_name,
+    "protocol_version": int(protocol_version),
+    "capabilities": json.loads(capabilities_json),
+    "endpoint": endpoint,
+}))
+' "$credential" "$credential_id" "$server_instance_id" "$remote_team_id" "$remote_team_name" "$protocol_version" "$capabilities_json" "$endpoint")
+  tmp="$(mktemp "$PENDING_DIR/.pending-XXXXXX")"
+  chmod 600 "$tmp"
+  printf '%s\n' "$json" > "$tmp"
+  sync 2>/dev/null || true
+  mv "$tmp" "$pending_file"
+}
+
+# _remote_commit <team> <cfg> <endpoint> <credential> <credential_id>
+#   <server_instance_id> <remote_team_id> <remote_team_name> <protocol_version>
+#   <capabilities_json>
+# Assumes the caller ALREADY holds this team's config lock. Writes the 0600
+# credential file and the (secret-free) binding record.
+_remote_commit() {
+  local team="$1" cfg="$2" endpoint="$3" credential="$4" credential_id="$5" \
+    server_instance_id="$6" remote_team_id="$7" remote_team_name="$8" \
+    protocol_version="$9" capabilities_json="${10}" \
+    cred_file cred_json connected_at escaped updated
+
+  mkdir -p "$CRED_ROOT"
+  chmod 700 "$CRED_ROOT" 2>/dev/null || true
+  cred_file="$(_remote_cred_file "$team")"
+  cred_json="$(printf '{"credential":"%s","credential_id":"%s"}' \
+    "$(printf '%s' "$credential" | sed 's/"/\\"/g')" \
+    "$(printf '%s' "$credential_id" | sed 's/"/\\"/g')")"
+  ( umask 077; printf '%s\n' "$cred_json" > "$cred_file" )
+  unset cred_json
+
   connected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
   escaped=$(sed "s/'/''/g" "$cfg")
   updated=$(agmsg_sqlite_mem ".param set :json '$escaped'" ".param set :caps '$(printf '%s' "$capabilities_json" | sed "s/'/''/g")'" \
     "SELECT json_set(:json, '\$.remote_binding', json_object(
@@ -98,13 +224,12 @@ _remote_write_binding() {
        'server_instance_id', '$(_agmsg_sqlesc "$server_instance_id")',
        'remote_team_id', '$(_agmsg_sqlesc "$remote_team_id")',
        'remote_team_name', '$(_agmsg_sqlesc "$remote_team_name")',
-       'protocol_version', '$(_agmsg_sqlesc "$protocol_version")',
+       'protocol_version', $protocol_version,
        'capabilities', json(:caps),
        'connected_at', '$(_agmsg_sqlesc "$connected_at")',
        'disconnected_at', null
      ));")
   agmsg_write_atomic "$cfg" "$updated"
-  agmsg_lock_release
 }
 
 cmd_connect() {
@@ -119,6 +244,12 @@ cmd_connect() {
     esac
   done
   : "${endpoint:?Usage: remote.sh connect --endpoint <url> [<token>] [--token-stdin] [<team>] [--force]}"
+  _remote_validate_endpoint "$endpoint" || exit 1
+  # Canonicalize once (strip a trailing slash) so every use below — the
+  # pending-key hash, the exchange/revoke URLs, and the stored binding —
+  # agrees on the same endpoint string; a mismatch here would silently
+  # break pending-record resumability (B5) for no user-visible reason.
+  endpoint="${endpoint%/}"
 
   if [ "$token_stdin" -eq 1 ]; then
     if [ "${#positional[@]}" -gt 1 ]; then
@@ -144,58 +275,126 @@ cmd_connect() {
 
   if [ -n "$team" ]; then
     agmsg_validate_team_name "$team" || exit 1
-    local existing_disconnected
-    existing_disconnected="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.disconnected_at')"
-    local existing_connected_at
-    existing_connected_at="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.connected_at')"
-    if [ -n "$existing_connected_at" ] && [ "$existing_connected_at" != "null" ] \
-      && { [ -z "$existing_disconnected" ] || [ "$existing_disconnected" = "null" ]; } \
-      && [ "$force" -ne 1 ]; then
-      echo "agmsg: team '$team' is already connected (since $existing_connected_at) — run 'remote.sh disconnect $team' first, or pass --force to rebind." >&2
+  fi
+
+  # Resumability key, known before any network call regardless of whether
+  # <team> was given (B5).
+  local pending_key pending_file
+  pending_key="$(_remote_pending_key "$endpoint" "$token")"
+  pending_file="$(_remote_pending_file "$pending_key")"
+
+  local credential credential_id server_instance_id remote_team_id remote_team_name \
+    protocol_version capabilities_json write_allowed_ciphers current_seq
+
+  if [ -f "$pending_file" ]; then
+    echo "agmsg: resuming an exchange that already succeeded but wasn't fully committed locally (avoids consuming a fresh token)." >&2
+    credential="$(python3 -c "import json,sys; print(json.load(open('$pending_file')).get('credential',''))" 2>/dev/null)"
+    credential_id="$(python3 -c "import json,sys; print(json.load(open('$pending_file')).get('credential_id',''))" 2>/dev/null)"
+    server_instance_id="$(python3 -c "import json,sys; print(json.load(open('$pending_file')).get('server_instance_id',''))" 2>/dev/null)"
+    remote_team_id="$(python3 -c "import json,sys; print(json.load(open('$pending_file')).get('remote_team_id',''))" 2>/dev/null)"
+    remote_team_name="$(python3 -c "import json,sys; print(json.load(open('$pending_file')).get('remote_team_name',''))" 2>/dev/null)"
+    protocol_version="$(python3 -c "import json,sys; print(json.load(open('$pending_file')).get('protocol_version',0))" 2>/dev/null)"
+    capabilities_json="$(python3 -c "import json,sys; print(json.dumps(json.load(open('$pending_file')).get('capabilities',{})))" 2>/dev/null)"
+    write_allowed_ciphers="$(python3 -c "import json,sys; print(','.join(json.load(open('$pending_file')).get('capabilities',{}).get('write_allowed_ciphers',[])))" 2>/dev/null)"
+    current_seq="$(python3 -c "import json,sys; v=json.load(open('$pending_file')).get('capabilities',{}).get('current_seq'); print(v if v is not None else -1)" 2>/dev/null)"
+    unset token
+  else
+    # --force pre-check only applies when <team> is known upfront — when
+    # omitted, whether "this team" is already connected can't be known
+    # until the exchange response names it (checked again post-exchange
+    # under the lock either way).
+    if [ -n "$team" ]; then
+      local existing_disconnected existing_connected_at existing_credential_id
+      existing_disconnected="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.disconnected_at')"
+      existing_connected_at="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.connected_at')"
+      existing_credential_id="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.credential_id')"
+      if [ -n "$existing_connected_at" ] && [ "$existing_connected_at" != "null" ] \
+        && { [ -z "$existing_disconnected" ] || [ "$existing_disconnected" = "null" ]; }; then
+        if [ "$force" -ne 1 ]; then
+          echo "agmsg: team '$team' is already connected (since $existing_connected_at) — run 'remote.sh disconnect $team' first, or pass --force to rebind." >&2
+          exit 1
+        fi
+        # --force: revoke the OLD credential before ever asking for a new
+        # one. If revoke can't be confirmed, abort rather than leaving the
+        # old credential active-but-unreferenced (B5). This intentionally
+        # does not yet build a durable orphan/revocation-pending queue for
+        # the unreachable case; it fails closed and asks the operator to
+        # retry or revoke from the console/admin side.
+        local old_endpoint old_credential
+        old_endpoint="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.endpoint')"
+        old_credential="$(python3 -c "import json,sys; print(json.load(open('$(_remote_cred_file "$team")')).get('credential',''))" 2>/dev/null || true)"
+        if [ -z "$existing_credential_id" ] || [ "$existing_credential_id" = "null" ] \
+          || [ -z "$old_endpoint" ] || [ "$old_endpoint" = "null" ] || [ -z "$old_credential" ] \
+          || ! _remote_revoke "$old_endpoint" "$existing_credential_id" "$old_credential"; then
+          echo "agmsg: --force rebind refused — could not confirm the existing credential ($existing_credential_id) was revoked. Revoke it from the console/admin side, or retry once the server is reachable, before rebinding." >&2
+          exit 1
+        fi
+        unset old_credential
+      fi
+    fi
+
+    # The only network call that can fail before any local state changes.
+    local body_file resp_file http_code token_json
+    body_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-connect-body.XXXXXX")"
+    chmod 600 "$body_file"
+    resp_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-connect-resp.XXXXXX")"
+    chmod 600 "$resp_file"
+    trap 'rm -f "$body_file" "$resp_file"' EXIT INT TERM
+
+    token_json="$(printf '%s' "$token" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null)"
+    unset token
+    if [ -z "$token_json" ]; then
+      echo "agmsg: internal error encoding token" >&2
       exit 1
     fi
-  fi
+    printf '{"token":%s}' "$token_json" > "$body_file"
+    unset token_json
 
-  # The only network call that can fail before any local state changes.
-  local resp_body http_code tmp_body token_escaped
-  tmp_body="$(mktemp "${TMPDIR:-/tmp}/agmsg-connect-resp.XXXXXX")"
-  token_escaped="$(printf '%s' "$token" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null)"
-  unset token
-  if [ -z "$token_escaped" ]; then
-    rm -f "$tmp_body"
-    echo "agmsg: internal error encoding token" >&2
-    exit 1
-  fi
-  http_code=$(curl -sS -o "$tmp_body" -w '%{http_code}' \
-    -X POST "${endpoint%/}/v1/pairing/exchange" \
-    -H 'Content-Type: application/json' \
-    -d "{\"token\":$token_escaped}" \
-    2>/dev/null) || http_code="000"
-  unset token_escaped
+    http_code="$(_remote_http_post_json "$endpoint/v1/pairing/exchange" "$body_file" "$resp_file")"
+    rm -f "$body_file"
 
-  if [ "$http_code" != "200" ]; then
-    echo "agmsg: connect failed — exchange endpoint returned HTTP $http_code" >&2
-    rm -f "$tmp_body"
-    exit 1
-  fi
+    if [ "$http_code" != "200" ]; then
+      echo "agmsg: connect failed — exchange endpoint returned HTTP $http_code" >&2
+      rm -f "$resp_file"
+      exit 1
+    fi
 
-  resp_body="$(cat "$tmp_body")"
-  rm -f "$tmp_body"
+    # Strict validation (B6) BEFORE any field is used — a malformed/
+    # malicious response must not reach state mutation, and credential_id
+    # in particular must be shape-checked before it's ever spliced into a
+    # revoke URL. Parsed fields go to a FILE, not a command substitution —
+    # bash's `$(...)` silently strips embedded NUL bytes from its captured
+    # output, which would have destroyed NUL-delimited field boundaries
+    # before `read` ever saw them (caught in testing). Newline-delimited
+    # and file-based avoids that entirely.
+    local parsed_file
+    parsed_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-connect-parsed.XXXXXX")"
+    chmod 600 "$parsed_file"
+    if ! python3 "$SCRIPT_DIR/internal/parse-exchange-response.py" < "$resp_file" > "$parsed_file"; then
+      rm -f "$resp_file" "$parsed_file"
+      exit 1
+    fi
+    rm -f "$resp_file"
+    {
+      IFS= read -r credential
+      IFS= read -r credential_id
+      IFS= read -r server_instance_id
+      IFS= read -r remote_team_id
+      IFS= read -r remote_team_name
+      IFS= read -r protocol_version
+      IFS= read -r capabilities_json
+      IFS= read -r write_allowed_ciphers
+      IFS= read -r current_seq
+    } < "$parsed_file"
+    rm -f "$parsed_file"
+    trap - EXIT INT TERM
 
-  local credential credential_id server_instance_id remote_team_id remote_team_name protocol_version capabilities_json write_allowed_ciphers
-  credential="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('credential',''))" 2>/dev/null)"
-  credential_id="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('credential_id',''))" 2>/dev/null)"
-  server_instance_id="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('server_instance_id',''))" 2>/dev/null)"
-  remote_team_id="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('remote_team_id',''))" 2>/dev/null)"
-  remote_team_name="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('remote_team_name',''))" 2>/dev/null)"
-  protocol_version="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('protocol_version',''))" 2>/dev/null)"
-  capabilities_json="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.dumps(json.load(sys.stdin).get('capabilities',{})))" 2>/dev/null)"
-  write_allowed_ciphers="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(','.join(json.load(sys.stdin).get('capabilities',{}).get('write_allowed_ciphers',[])))" 2>/dev/null)"
-  unset resp_body
-
-  if [ -z "$credential" ] || [ -z "$credential_id" ]; then
-    echo "agmsg: connect failed — exchange response missing credential/credential_id" >&2
-    exit 1
+    # Durable pending record before the local commit (B5): if the process
+    # dies between here and _remote_commit finishing, retrying with the
+    # same (endpoint, token) resumes from this file instead of needing a
+    # fresh token.
+    _remote_write_pending "$pending_key" "$credential" "$credential_id" "$server_instance_id" \
+      "$remote_team_id" "$remote_team_name" "$protocol_version" "$capabilities_json" "$endpoint"
   fi
 
   [ -n "$team" ] || team="$remote_team_name"
@@ -208,21 +407,27 @@ cmd_connect() {
   local cfg
   cfg="$(_remote_team_config "$team")"
 
-  # The secret never touches config.json or any other read/diffed/logged
-  # file — a dedicated, 0600, engine-side credential file (ADR 0007 §3.4).
-  mkdir -p "$CRED_ROOT"
-  chmod 700 "$CRED_ROOT" 2>/dev/null || true
-  local cred_file cred_json
-  cred_file="$(_remote_cred_file "$team")"
-  cred_json="$(printf '{"credential":"%s","credential_id":"%s"}' \
-    "$(printf '%s' "$credential" | sed 's/"/\\"/g')" \
-    "$(printf '%s' "$credential_id" | sed 's/"/\\"/g')")"
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || exit 1
+  # Re-check under the lock (CAS): if something else connected this team
+  # in the window since our pre-flight check (or since the exchange, for
+  # the omitted-team case where no pre-check was possible), fail closed
+  # rather than mixing old/new bindings (B5) — the pending record survives
+  # this abort so a deliberate retry can still resume it.
+  local recheck_connected recheck_disconnected
+  recheck_connected="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
+  recheck_disconnected="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
+  if [ -n "$recheck_connected" ] && [ "$recheck_connected" != "null" ] \
+    && { [ -z "$recheck_disconnected" ] || [ "$recheck_disconnected" = "null" ]; } \
+    && [ "$force" -ne 1 ]; then
+    agmsg_lock_release
+    echo "agmsg: team '$team' became connected by another process just now — the credential just issued for it was NOT committed locally. Revoke it (credential_id=$credential_id) via the console/admin side if it should not remain active, then retry." >&2
+    exit 1
+  fi
+  _remote_commit "$team" "$cfg" "$endpoint" "$credential" "$credential_id" \
+    "$server_instance_id" "$remote_team_id" "$remote_team_name" "$protocol_version" "$capabilities_json"
+  rm -f "$pending_file"
+  agmsg_lock_release
   unset credential
-  ( umask 077; printf '%s\n' "$cred_json" > "$cred_file" )
-  unset cred_json
-
-  _remote_write_binding "$team" "$cfg" "$endpoint" "$credential_id" "$server_instance_id" \
-    "$remote_team_id" "$remote_team_name" "$protocol_version" "$capabilities_json" || exit 1
 
   # E2EE insertion point (ADR 0007 §6/§8): only when the capability response
   # actually requires encryption and no local key exists yet for this team.
@@ -245,25 +450,29 @@ cmd_connect() {
         exit 1
       fi
 
-      local db msg_count default_choice
-      db="$(agmsg_db_path)"
-      msg_count=0
-      if [ -f "$db" ]; then
-        msg_count="$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM messages WHERE team='$(_agmsg_sqlesc "$team")';" 2>/dev/null || echo 0)"
-      fi
-      if [ "$msg_count" -eq 0 ] 2>/dev/null; then
-        default_choice="g"
-      else
-        default_choice="i"
+      # STATUS: current_seq==0 only ever SUGGESTS the generate option — it
+      # is never chosen as an automatic default. An adversarial review
+      # found that local-only signals (message counts, and even an honest
+      # server's current_seq==0) cannot prove "I am the first writer": two
+      # devices can both see an empty/unseeded stream at once and both
+      # auto-generate, producing two incompatible keys with no way to tell
+      # which is authoritative (split-brain) — and a malicious/equivocating
+      # server can trivially induce the same outcome on purpose. Until a
+      # trusted, transactional first-writer claim exists, the only safe
+      # defaults are import or abort; generate requires an explicit,
+      # deliberate 'g' and is never selected on empty/EOF input.
+      local seq_hint=""
+      if [ "$current_seq" = "0" ]; then
+        seq_hint=" (this team's stream looks empty — (g) may be safe, but only you can be sure no one else is the first writer)"
       fi
 
-      echo "This team requires end-to-end encryption. No key found for this device."
-      echo "  (g) Generate a new key — do this if you are the first person connecting this team"
-      echo "  (i) Import a key you already have — do this if a teammate gave you one, or if this team already has message history"
+      echo "This team requires end-to-end encryption. No key found for this device.${seq_hint}"
+      echo "  (g) Generate a new key — ONLY if you are certain you are the first person connecting this team"
+      echo "  (i) Import a key you already have — do this if a teammate gave you one, or if unsure"
       echo "  (a) Abort — don't connect yet"
       local choice
-      read -r -p "[g/i/a] (default: $default_choice): " choice || choice=""
-      choice="${choice:-$default_choice}"
+      read -r -p "[i/g/a] (default: a): " choice || choice=""
+      choice="${choice:-a}"
 
       case "$choice" in
         g)
@@ -276,10 +485,11 @@ cmd_connect() {
           local identity
           read -r -p "Paste identity: " identity || identity=""
           if [ -z "$identity" ]; then
-            echo "agmsg: no identity provided — if the only device that ever held this team's key is gone entirely, there is nothing to import. The historical stream stays permanently unreadable under the lost key. The only forward path is 'key.sh rotate $team' to start a fresh epoch for messages sent from now on." >&2
+            echo "agmsg: no identity provided — if the only device that ever held this team's key is gone entirely, there is nothing to import. The historical stream stays permanently unreadable under the lost key, and rotation to start a fresh epoch is not available in this release." >&2
             exit 1
           fi
-          bash "$SCRIPT_DIR/key.sh" import "$team" "$identity" || exit 1
+          printf '%s' "$identity" | bash "$SCRIPT_DIR/key.sh" import "$team" --identity-stdin || exit 1
+          unset identity
           ;;
         a|*)
           echo "Aborted. No driver switch performed; the binding record is present but the team is not fully connected until a key exists — see 'remote status $team'." >&2
@@ -319,7 +529,7 @@ _remote_status_one() {
   echo "$team	connected (since $connected_at)"
   if [ "$needs_encryption" -eq 1 ]; then
     if [ -z "$key_id" ] || [ "$key_id" = "null" ]; then
-      echo "		encryption: required, no local key — run 'key.sh generate $team' or 'key.sh import $team <identity>'"
+      echo "		encryption: required, no local key — run 'key.sh generate $team' or 'key.sh import $team'"
     else
       echo "		encryption: age-v1, key present"
     fi
@@ -373,15 +583,10 @@ cmd_disconnect() {
   local revoke_ok=0
   if [ -f "$cred_file" ] && [ -n "$endpoint" ] && [ "$endpoint" != "null" ] && [ -n "$credential_id" ] && [ "$credential_id" != "null" ]; then
     credential="$(python3 -c "import json,sys; print(json.load(open('$cred_file')).get('credential',''))" 2>/dev/null)"
-    if [ -n "$credential" ]; then
-      local http_code
-      http_code=$(curl -sS -o /dev/null -w '%{http_code}' \
-        -X POST "${endpoint%/}/v1/credentials/$credential_id/revoke" \
-        -H "Authorization: Bearer $credential" \
-        2>/dev/null) || http_code="000"
-      unset credential
-      [ "$http_code" = "200" ] && revoke_ok=1
+    if [ -n "$credential" ] && _remote_revoke "$endpoint" "$credential_id" "$credential"; then
+      revoke_ok=1
     fi
+    unset credential
   fi
 
   rm -f "$cred_file"

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1,0 +1,415 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   remote.sh connect --endpoint <url> [<token>] [--token-stdin] [<team>] [--force]
+#   remote.sh status [<team>]
+#   remote.sh disconnect <team>
+#   remote.sh doctor [<team>]
+#
+# Team-scoped cloud/self-hosted sync connection (ADR 0007). The OSS CLI never
+# assumes or defaults to any particular server — <endpoint> is always
+# required. Login/token acquisition is out of this repo's scope (ADR 0007
+# §1a-§1c) — some provider tooling (or a self-hosted server's own admin
+# command) obtains the token; this script only ever receives one.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/storage.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/registry-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/validate.sh"
+
+TEAMS_DIR="$SCRIPT_DIR/../teams"
+CRED_ROOT="$SKILL_DIR/run/remote-credentials"
+
+_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
+
+_remote_team_config() { printf '%s' "$TEAMS_DIR/$1/config.json"; }
+_remote_cred_file() { printf '%s' "$CRED_ROOT/$1.json"; }
+
+_remote_read_config_field() {
+  local cfg="$1" path="$2" escaped
+  [ -f "$cfg" ] || { echo "null"; return; }
+  escaped=$(sed "s/'/''/g" "$cfg")
+  agmsg_sqlite_mem ".param set :json '$escaped'" "SELECT json_extract(:json, '$path');"
+}
+
+# Bootstrap a brand-new local team dir/config, mirroring join.sh's own
+# initial-config shape exactly (no agents registered yet — connect only
+# establishes the sync binding, not a agent identity in the team).
+_remote_ensure_team() {
+  local team="$1" cfg
+  cfg="$(_remote_team_config "$team")"
+  if [ ! -f "$cfg" ]; then
+    mkdir -p "$TEAMS_DIR/$team"
+    local initial
+    initial=$(printf '{\n  "name": "%s",\n  "agents": {},\n  "created_at": "%s"\n}' \
+      "$team" "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
+    agmsg_write_atomic "$cfg" "$initial"
+  fi
+}
+
+# --- doctor ------------------------------------------------------------
+
+# Standalone, read-only, always-safe-to-run preflight (ADR 0007 §1): no
+# token, no state change, safe whether or not the team is already connected.
+# Currently just the age-binary-presence check (§8) — the natural home for
+# any future preflight check added later.
+cmd_doctor() {
+  local team="${1:-}"
+  echo "Checking prerequisites${team:+ for team '$team'}..."
+  echo
+  if command -v age >/dev/null 2>&1 && command -v age-keygen >/dev/null 2>&1; then
+    echo "  [x] age / age-keygen on PATH"
+    echo
+    echo "All checks passed."
+  else
+    echo "  [ ] age / age-keygen on PATH"
+    echo
+    echo "'age' is required for end-to-end encryption and was not found on this device. Install it, then retry:"
+    echo "  macOS (Homebrew):      brew install age"
+    echo "  Debian/Ubuntu:         sudo apt install age"
+    echo "  Windows (winget):      winget install FiloSottile.age"
+    echo "See https://github.com/FiloSottile/age for other install methods."
+    echo
+    echo "1 check failed."
+    exit 1
+  fi
+}
+
+# --- connect -------------------------------------------------------------
+
+_remote_write_binding() {
+  # _remote_write_binding <team> <cfg> <endpoint> <credential_id> <server_instance_id>
+  #   <remote_team_id> <remote_team_name> <protocol_version> <capabilities_json>
+  local team="$1" cfg="$2" endpoint="$3" credential_id="$4" server_instance_id="$5" \
+    remote_team_id="$6" remote_team_name="$7" protocol_version="$8" capabilities_json="$9" \
+    connected_at escaped updated
+  connected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
+  escaped=$(sed "s/'/''/g" "$cfg")
+  updated=$(agmsg_sqlite_mem ".param set :json '$escaped'" ".param set :caps '$(printf '%s' "$capabilities_json" | sed "s/'/''/g")'" \
+    "SELECT json_set(:json, '\$.remote_binding', json_object(
+       'endpoint', '$(_agmsg_sqlesc "$endpoint")',
+       'credential_id', '$(_agmsg_sqlesc "$credential_id")',
+       'server_instance_id', '$(_agmsg_sqlesc "$server_instance_id")',
+       'remote_team_id', '$(_agmsg_sqlesc "$remote_team_id")',
+       'remote_team_name', '$(_agmsg_sqlesc "$remote_team_name")',
+       'protocol_version', '$(_agmsg_sqlesc "$protocol_version")',
+       'capabilities', json(:caps),
+       'connected_at', '$(_agmsg_sqlesc "$connected_at")',
+       'disconnected_at', null
+     ));")
+  agmsg_write_atomic "$cfg" "$updated"
+  agmsg_lock_release
+}
+
+cmd_connect() {
+  local endpoint="" token="" token_stdin=0 team="" force=0 positional=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --endpoint) endpoint="${2:?--endpoint requires a value}"; shift 2 ;;
+      --endpoint=*) endpoint="${1#--endpoint=}"; shift ;;
+      --token-stdin) token_stdin=1; shift ;;
+      --force) force=1; shift ;;
+      *) positional+=("$1"); shift ;;
+    esac
+  done
+  : "${endpoint:?Usage: remote.sh connect --endpoint <url> [<token>] [--token-stdin] [<team>] [--force]}"
+
+  if [ "$token_stdin" -eq 1 ]; then
+    if [ "${#positional[@]}" -gt 1 ]; then
+      echo "agmsg: too many arguments with --token-stdin (expected only an optional <team>)" >&2
+      exit 1
+    fi
+    # cat (not `read`) so a caller piping the token without a trailing
+    # newline doesn't hit EOF-as-failure under `read -r` (which would abort
+    # here silently under `set -e` before printing anything) — a real
+    # concern since programmatic token handoff commonly omits the newline.
+    token="$(cat)"
+    team="${positional[0]:-}"
+  else
+    if [ "${#positional[@]}" -lt 1 ]; then
+      echo "agmsg: missing token (positional argument, or use --token-stdin)" >&2
+      exit 1
+    fi
+    token="${positional[0]}"
+    team="${positional[1]:-}"
+    echo "agmsg: passing the token as an argument may expose it via shell history or 'ps'; prefer --token-stdin" >&2
+  fi
+  [ -n "$token" ] || { echo "agmsg: empty token" >&2; exit 1; }
+
+  if [ -n "$team" ]; then
+    agmsg_validate_team_name "$team" || exit 1
+    local existing_disconnected
+    existing_disconnected="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.disconnected_at')"
+    local existing_connected_at
+    existing_connected_at="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.connected_at')"
+    if [ -n "$existing_connected_at" ] && [ "$existing_connected_at" != "null" ] \
+      && { [ -z "$existing_disconnected" ] || [ "$existing_disconnected" = "null" ]; } \
+      && [ "$force" -ne 1 ]; then
+      echo "agmsg: team '$team' is already connected (since $existing_connected_at) — run 'remote.sh disconnect $team' first, or pass --force to rebind." >&2
+      exit 1
+    fi
+  fi
+
+  # The only network call that can fail before any local state changes.
+  local resp_body http_code tmp_body token_escaped
+  tmp_body="$(mktemp "${TMPDIR:-/tmp}/agmsg-connect-resp.XXXXXX")"
+  token_escaped="$(printf '%s' "$token" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null)"
+  unset token
+  if [ -z "$token_escaped" ]; then
+    rm -f "$tmp_body"
+    echo "agmsg: internal error encoding token" >&2
+    exit 1
+  fi
+  http_code=$(curl -sS -o "$tmp_body" -w '%{http_code}' \
+    -X POST "${endpoint%/}/v1/pairing/exchange" \
+    -H 'Content-Type: application/json' \
+    -d "{\"token\":$token_escaped}" \
+    2>/dev/null) || http_code="000"
+  unset token_escaped
+
+  if [ "$http_code" != "200" ]; then
+    echo "agmsg: connect failed — exchange endpoint returned HTTP $http_code" >&2
+    rm -f "$tmp_body"
+    exit 1
+  fi
+
+  resp_body="$(cat "$tmp_body")"
+  rm -f "$tmp_body"
+
+  local credential credential_id server_instance_id remote_team_id remote_team_name protocol_version capabilities_json write_allowed_ciphers
+  credential="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('credential',''))" 2>/dev/null)"
+  credential_id="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('credential_id',''))" 2>/dev/null)"
+  server_instance_id="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('server_instance_id',''))" 2>/dev/null)"
+  remote_team_id="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('remote_team_id',''))" 2>/dev/null)"
+  remote_team_name="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('remote_team_name',''))" 2>/dev/null)"
+  protocol_version="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('protocol_version',''))" 2>/dev/null)"
+  capabilities_json="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(json.dumps(json.load(sys.stdin).get('capabilities',{})))" 2>/dev/null)"
+  write_allowed_ciphers="$(printf '%s' "$resp_body" | python3 -c "import json,sys; print(','.join(json.load(sys.stdin).get('capabilities',{}).get('write_allowed_ciphers',[])))" 2>/dev/null)"
+  unset resp_body
+
+  if [ -z "$credential" ] || [ -z "$credential_id" ]; then
+    echo "agmsg: connect failed — exchange response missing credential/credential_id" >&2
+    exit 1
+  fi
+
+  [ -n "$team" ] || team="$remote_team_name"
+  if [ -z "$team" ]; then
+    echo "agmsg: could not determine a local team name (exchange response had no remote_team_name and none was given)" >&2
+    exit 1
+  fi
+  agmsg_validate_team_name "$team" || exit 1
+  _remote_ensure_team "$team"
+  local cfg
+  cfg="$(_remote_team_config "$team")"
+
+  # The secret never touches config.json or any other read/diffed/logged
+  # file — a dedicated, 0600, engine-side credential file (ADR 0007 §3.4).
+  mkdir -p "$CRED_ROOT"
+  chmod 700 "$CRED_ROOT" 2>/dev/null || true
+  local cred_file cred_json
+  cred_file="$(_remote_cred_file "$team")"
+  cred_json="$(printf '{"credential":"%s","credential_id":"%s"}' \
+    "$(printf '%s' "$credential" | sed 's/"/\\"/g')" \
+    "$(printf '%s' "$credential_id" | sed 's/"/\\"/g')")"
+  unset credential
+  ( umask 077; printf '%s\n' "$cred_json" > "$cred_file" )
+  unset cred_json
+
+  _remote_write_binding "$team" "$cfg" "$endpoint" "$credential_id" "$server_instance_id" \
+    "$remote_team_id" "$remote_team_name" "$protocol_version" "$capabilities_json" || exit 1
+
+  # E2EE insertion point (ADR 0007 §6/§8): only when the capability response
+  # actually requires encryption and no local key exists yet for this team.
+  local needs_encryption=0
+  case ",$write_allowed_ciphers," in
+    *,none,*) needs_encryption=0 ;;
+    *) [ -n "$write_allowed_ciphers" ] && needs_encryption=1 ;;
+  esac
+
+  if [ "$needs_encryption" -eq 1 ]; then
+    local existing_key
+    existing_key="$(_remote_read_config_field "$cfg" '$.remote_key.current.key_id')"
+    if [ -z "$existing_key" ] || [ "$existing_key" = "null" ]; then
+      if ! command -v age >/dev/null 2>&1 || ! command -v age-keygen >/dev/null 2>&1; then
+        echo "'age' is required for this team's end-to-end encryption and was not found on this device. Install it, then re-run 'remote.sh connect ...':" >&2
+        echo "  macOS (Homebrew):      brew install age" >&2
+        echo "  Debian/Ubuntu:         sudo apt install age" >&2
+        echo "  Windows (winget):      winget install FiloSottile.age" >&2
+        echo "See https://github.com/FiloSottile/age for other install methods." >&2
+        exit 1
+      fi
+
+      local db msg_count default_choice
+      db="$(agmsg_db_path)"
+      msg_count=0
+      if [ -f "$db" ]; then
+        msg_count="$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM messages WHERE team='$(_agmsg_sqlesc "$team")';" 2>/dev/null || echo 0)"
+      fi
+      if [ "$msg_count" -eq 0 ] 2>/dev/null; then
+        default_choice="g"
+      else
+        default_choice="i"
+      fi
+
+      echo "This team requires end-to-end encryption. No key found for this device."
+      echo "  (g) Generate a new key — do this if you are the first person connecting this team"
+      echo "  (i) Import a key you already have — do this if a teammate gave you one, or if this team already has message history"
+      echo "  (a) Abort — don't connect yet"
+      local choice
+      read -r -p "[g/i/a] (default: $default_choice): " choice || choice=""
+      choice="${choice:-$default_choice}"
+
+      case "$choice" in
+        g)
+          bash "$SCRIPT_DIR/key.sh" generate "$team" || exit 1
+          ;;
+        i)
+          echo "On another machine that already has this team's key, run:"
+          echo "  key.sh show $team --reveal-secret"
+          echo "and paste its output below."
+          local identity
+          read -r -p "Paste identity: " identity || identity=""
+          if [ -z "$identity" ]; then
+            echo "agmsg: no identity provided — if the only device that ever held this team's key is gone entirely, there is nothing to import. The historical stream stays permanently unreadable under the lost key. The only forward path is 'key.sh rotate $team' to start a fresh epoch for messages sent from now on." >&2
+            exit 1
+          fi
+          bash "$SCRIPT_DIR/key.sh" import "$team" "$identity" || exit 1
+          ;;
+        a|*)
+          echo "Aborted. No driver switch performed; the binding record is present but the team is not fully connected until a key exists — see 'remote status $team'." >&2
+          exit 1
+          ;;
+      esac
+    fi
+  fi
+
+  echo "Connected: team '$team'${remote_team_name:+ (org '$remote_team_name')}."
+}
+
+# --- status --------------------------------------------------------------
+
+_remote_status_one() {
+  local team="$1" cfg connected_at disconnected_at write_allowed_ciphers key_id
+  cfg="$(_remote_team_config "$team")"
+  connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
+  disconnected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
+  if [ -z "$connected_at" ] || [ "$connected_at" = "null" ]; then
+    return 1
+  fi
+  if [ -n "$disconnected_at" ] && [ "$disconnected_at" != "null" ]; then
+    echo "$team	disconnected (was connected until $disconnected_at)"
+    return 0
+  fi
+
+  write_allowed_ciphers="$(_remote_read_config_field "$cfg" '$.remote_binding.capabilities.write_allowed_ciphers')"
+  key_id="$(_remote_read_config_field "$cfg" '$.remote_key.current.key_id')"
+
+  local needs_encryption=0
+  case "$write_allowed_ciphers" in
+    *none*) needs_encryption=0 ;;
+    '['*']') [ "$write_allowed_ciphers" != "[]" ] && needs_encryption=1 ;;
+  esac
+
+  echo "$team	connected (since $connected_at)"
+  if [ "$needs_encryption" -eq 1 ]; then
+    if [ -z "$key_id" ] || [ "$key_id" = "null" ]; then
+      echo "		encryption: required, no local key — run 'key.sh generate $team' or 'key.sh import $team <identity>'"
+    else
+      echo "		encryption: age-v1, key present"
+    fi
+  else
+    echo "		encryption: none"
+  fi
+}
+
+cmd_status() {
+  local team="${1:-}"
+  if [ -n "$team" ]; then
+    agmsg_validate_team_name "$team" || exit 1
+    _remote_status_one "$team" || { echo "agmsg: team '$team' has never been connected" >&2; exit 1; }
+    return
+  fi
+
+  local any=0 t
+  [ -d "$TEAMS_DIR" ] || { echo "No teams found."; return; }
+  for t in "$TEAMS_DIR"/*/; do
+    [ -d "$t" ] || continue
+    t="$(basename "$t")"
+    if _remote_status_one "$t"; then
+      any=1
+    fi
+  done
+  [ "$any" -eq 1 ] || echo "No teams are connected."
+}
+
+# --- disconnect ------------------------------------------------------------
+
+cmd_disconnect() {
+  local team="${1:?Usage: remote.sh disconnect <team>}"
+  agmsg_validate_team_name "$team" || exit 1
+  local cfg
+  cfg="$(_remote_team_config "$team")"
+  local connected_at
+  connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
+  if [ -z "$connected_at" ] || [ "$connected_at" = "null" ]; then
+    echo "agmsg: team '$team' is not connected" >&2
+    exit 1
+  fi
+
+  local cred_file endpoint credential_id credential
+  cred_file="$(_remote_cred_file "$team")"
+  endpoint="$(_remote_read_config_field "$cfg" '$.remote_binding.endpoint')"
+  credential_id="$(_remote_read_config_field "$cfg" '$.remote_binding.credential_id')"
+
+  # Server-side revoke first, local cleanup always — local deletion alone
+  # does not stop the credential from continuing to authenticate
+  # server-side (ADR 0007 §4).
+  local revoke_ok=0
+  if [ -f "$cred_file" ] && [ -n "$endpoint" ] && [ "$endpoint" != "null" ] && [ -n "$credential_id" ] && [ "$credential_id" != "null" ]; then
+    credential="$(python3 -c "import json,sys; print(json.load(open('$cred_file')).get('credential',''))" 2>/dev/null)"
+    if [ -n "$credential" ]; then
+      local http_code
+      http_code=$(curl -sS -o /dev/null -w '%{http_code}' \
+        -X POST "${endpoint%/}/v1/credentials/$credential_id/revoke" \
+        -H "Authorization: Bearer $credential" \
+        2>/dev/null) || http_code="000"
+      unset credential
+      [ "$http_code" = "200" ] && revoke_ok=1
+    fi
+  fi
+
+  rm -f "$cred_file"
+
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || exit 1
+  local escaped updated disconnected_at
+  disconnected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  escaped=$(sed "s/'/''/g" "$cfg")
+  updated=$(agmsg_sqlite_mem ".param set :json '$escaped'" \
+    "SELECT json_set(:json, '\$.remote_binding.disconnected_at', '$(_agmsg_sqlesc "$disconnected_at")');")
+  agmsg_write_atomic "$cfg" "$updated"
+  agmsg_lock_release
+
+  if [ "$revoke_ok" -eq 1 ]; then
+    echo "Revoking credential with server... ok."
+  else
+    echo "Revoking credential with server... failed."
+    echo "Local state cleared, but the server could not be reached to revoke this credential — if this device may be compromised, revoke it from the console/admin side directly." >&2
+  fi
+  echo "Disconnected '$team'. Local sync state cleared; sends/reads continue locally."
+}
+
+case "${1:-}" in
+  connect) shift; cmd_connect "$@" ;;
+  status) shift; cmd_status "$@" ;;
+  disconnect) shift; cmd_disconnect "$@" ;;
+  doctor) shift; cmd_doctor "$@" ;;
+  *)
+    echo "Usage: remote.sh <connect|status|disconnect|doctor> ..." >&2
+    exit 1 ;;
+esac

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -249,9 +249,11 @@ print(json.dumps({"endpoint": endpoint, "raw_response_text": raw_response_text})
 ' "$resp_file" "$endpoint")
   tmp="$(mktemp "$PENDING_DIR/.pending-XXXXXX")"
   chmod 600 "$tmp"
+  trap 'rm -f "$tmp"' EXIT INT TERM
   printf '%s\n' "$json" > "$tmp"
   sync 2>/dev/null || true
   mv "$tmp" "$pending_file"
+  trap - EXIT INT TERM
 }
 
 # _remote_load_pending <pending_file> <out_resp_file> -> prints endpoint
@@ -311,9 +313,14 @@ _remote_commit() {
   local cred_tmp
   cred_tmp="$(mktemp "$CRED_ROOT/.cred-XXXXXX")"
   chmod 600 "$cred_tmp"
+  # Cleanup trap (nonblocking follow-up noted after E1-E3): a kill signal
+  # between mktemp and the rename below would otherwise leave a 0600-but-
+  # never-renamed temp copy of the secret sitting in CRED_ROOT indefinitely.
+  trap 'rm -f "$cred_tmp"' EXIT INT TERM
   printf '%s\n' "$cred_json" > "$cred_tmp"
   sync 2>/dev/null || true
   mv "$cred_tmp" "$cred_file"
+  trap - EXIT INT TERM
   unset cred_json
 
   connected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -667,9 +667,16 @@ cmd_connect() {
       # trusted, transactional first-writer claim exists, the only safe
       # defaults are import or abort; generate requires an explicit,
       # deliberate 'g' and is never selected on empty/EOF input.
+      # Wording condition from maintainer sign-off on this default-removal
+      # (B3): a first-time user must be able to tell, at a glance, that
+      # (g) is the one for them — not just be warned that (g) *might* be
+      # risky. State the recommendation directly, then immediately follow
+      # it with the honest caveat (empty history is a strong hint, not
+      # proof) so the choice stays deliberate rather than becoming a new
+      # rubber-stamped default.
       local seq_hint=""
       if [ "$current_seq" = "0" ]; then
-        seq_hint=" (this team's stream looks empty — (g) may be safe, but only you can be sure no one else is the first writer)"
+        seq_hint=" This team has no message history yet — if you are the one setting it up for the first time, that's exactly when you choose (g). (Empty history is a strong hint, not proof: if you know someone else already has a key for this team, choose (i) instead.)"
       fi
 
       echo "This team requires end-to-end encryption. No key found for this device.${seq_hint}"

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -55,19 +55,14 @@ _remote_ensure_team() {
 
 # Reject a non-HTTPS endpoint (token/credential would cross the wire in
 # plaintext) except for loopback, which self-host/dev setups need without a
-# cert (ADR 0007 review finding B6).
+# cert (ADR 0007 review findings B6/R2). Delegates to a real URL parser —
+# a shell glob/prefix check here was bypassable by
+# http://127.0.0.1.evil.com, http://localhost.evil.com, and the userinfo
+# trick http://localhost@evil.com, all of which matched a naive
+# `http://127.0.0.1*`/`http://localhost*` case pattern while actually
+# pointing at a different host.
 _remote_validate_endpoint() {
-  local endpoint="$1"
-  case "$endpoint" in
-    https://*) return 0 ;;
-    http://127.0.0.1*|http://localhost*|http://\[::1\]*) return 0 ;;
-    http://*)
-      echo "agmsg: --endpoint must be https:// (plaintext http:// would send the token/credential unencrypted) — loopback (127.0.0.1/localhost) is the only exception" >&2
-      return 1 ;;
-    *)
-      echo "agmsg: --endpoint must start with https://" >&2
-      return 1 ;;
-  esac
+  python3 "$SCRIPT_DIR/internal/validate-endpoint.py" "$1"
 }
 
 # --- doctor ------------------------------------------------------------
@@ -159,40 +154,59 @@ _remote_pending_key() {
 
 _remote_pending_file() { printf '%s' "$PENDING_DIR/$1.json"; }
 
-# _remote_write_pending <key> <credential> <credential_id> <server_instance_id>
-#   <remote_team_id> <remote_team_name> <protocol_version> <capabilities_json> <endpoint>
+# _remote_write_pending <key> <resp_file> <endpoint>
 # Durable, atomic (temp+rename), 0600 record of a successful exchange whose
 # local commit has not (yet) fully completed — deliberately does NOT
 # include the token. A crash between the exchange and _remote_commit
 # finishing resumes from here on a retry with the same (endpoint, token),
 # instead of needing (and orphaning a credential for) a fresh single-use
 # token (B5).
+#
+# Takes the RAW response file and re-serializes its exact bytes as-is
+# (never the individually-extracted credential/credential_id/etc as their
+# own values) — <resp_file> and <endpoint> are passed to python3 by PATH
+# and as a non-secret string respectively, so the secret itself is read
+# only via file I/O inside the python process and never appears as any
+# process's own argv element (R1: an earlier version of this function
+# passed the credential as a positional python3 argument, which any
+# concurrent `ps` could read for as long as that process was alive).
 _remote_write_pending() {
-  local key="$1" credential="$2" credential_id="$3" server_instance_id="$4" \
-    remote_team_id="$5" remote_team_name="$6" protocol_version="$7" \
-    capabilities_json="$8" endpoint="$9" pending_file tmp json
+  local key="$1" resp_file="$2" endpoint="$3" pending_file tmp json
   mkdir -p "$PENDING_DIR"
   chmod 700 "$PENDING_DIR" 2>/dev/null || true
   pending_file="$(_remote_pending_file "$key")"
   json=$(python3 -c '
 import json, sys
-credential, credential_id, server_instance_id, remote_team_id, remote_team_name, protocol_version, capabilities_json, endpoint = sys.argv[1:9]
-print(json.dumps({
-    "credential": credential,
-    "credential_id": credential_id,
-    "server_instance_id": server_instance_id,
-    "remote_team_id": remote_team_id,
-    "remote_team_name": remote_team_name,
-    "protocol_version": int(protocol_version),
-    "capabilities": json.loads(capabilities_json),
-    "endpoint": endpoint,
-}))
-' "$credential" "$credential_id" "$server_instance_id" "$remote_team_id" "$remote_team_name" "$protocol_version" "$capabilities_json" "$endpoint")
+resp_path, endpoint = sys.argv[1], sys.argv[2]
+with open(resp_path) as f:
+    response = json.load(f)
+print(json.dumps({"endpoint": endpoint, "response": response}))
+' "$resp_file" "$endpoint")
   tmp="$(mktemp "$PENDING_DIR/.pending-XXXXXX")"
   chmod 600 "$tmp"
   printf '%s\n' "$json" > "$tmp"
   sync 2>/dev/null || true
   mv "$tmp" "$pending_file"
+}
+
+# _remote_load_pending <pending_file> <out_resp_file> -> prints endpoint
+# Extracts the embedded raw response back out to its own file (so it can
+# be re-run through the SAME strict parse-exchange-response.py validator
+# a fresh exchange uses — R5: a pending file is not inherently more
+# trustworthy than a live response and must not skip validation) and
+# prints the (non-secret) endpoint string. <pending_file>'s path is
+# passed by PATH, never its contents, as a python3 argument.
+_remote_load_pending() {
+  local pending_file="$1" out_resp_file="$2"
+  python3 -c '
+import json, sys
+pending_path, out_path = sys.argv[1], sys.argv[2]
+with open(pending_path) as f:
+    pending = json.load(f)
+with open(out_path, "w") as f:
+    json.dump(pending["response"], f)
+print(pending["endpoint"])
+' "$pending_file" "$out_resp_file"
 }
 
 # _remote_commit <team> <cfg> <endpoint> <credential> <credential_id>
@@ -273,6 +287,16 @@ cmd_connect() {
   fi
   [ -n "$token" ] || { echo "agmsg: empty token" >&2; exit 1; }
 
+  # --force requires an explicit <team> (R4): the revoke-old-credential-
+  # first step below only runs when <team> is known upfront. If <team>
+  # were left to be discovered from the exchange response, that step
+  # would be skipped entirely and --force could silently overwrite an
+  # active binding without ever revoking its old credential.
+  if [ "$force" -eq 1 ] && [ -z "$team" ]; then
+    echo "agmsg: --force requires an explicit <team> — omitting it and letting the exchange response name the team would skip revoking any existing credential for that team first." >&2
+    exit 1
+  fi
+
   if [ -n "$team" ]; then
     agmsg_validate_team_name "$team" || exit 1
   fi
@@ -288,16 +312,41 @@ cmd_connect() {
 
   if [ -f "$pending_file" ]; then
     echo "agmsg: resuming an exchange that already succeeded but wasn't fully committed locally (avoids consuming a fresh token)." >&2
-    credential="$(python3 -c "import json,sys; print(json.load(open('$pending_file')).get('credential',''))" 2>/dev/null)"
-    credential_id="$(python3 -c "import json,sys; print(json.load(open('$pending_file')).get('credential_id',''))" 2>/dev/null)"
-    server_instance_id="$(python3 -c "import json,sys; print(json.load(open('$pending_file')).get('server_instance_id',''))" 2>/dev/null)"
-    remote_team_id="$(python3 -c "import json,sys; print(json.load(open('$pending_file')).get('remote_team_id',''))" 2>/dev/null)"
-    remote_team_name="$(python3 -c "import json,sys; print(json.load(open('$pending_file')).get('remote_team_name',''))" 2>/dev/null)"
-    protocol_version="$(python3 -c "import json,sys; print(json.load(open('$pending_file')).get('protocol_version',0))" 2>/dev/null)"
-    capabilities_json="$(python3 -c "import json,sys; print(json.dumps(json.load(open('$pending_file')).get('capabilities',{})))" 2>/dev/null)"
-    write_allowed_ciphers="$(python3 -c "import json,sys; print(','.join(json.load(open('$pending_file')).get('capabilities',{}).get('write_allowed_ciphers',[])))" 2>/dev/null)"
-    current_seq="$(python3 -c "import json,sys; v=json.load(open('$pending_file')).get('capabilities',{}).get('current_seq'); print(v if v is not None else -1)" 2>/dev/null)"
     unset token
+
+    # A pending file is not inherently more trustworthy than a fresh
+    # response (R5) — extract its embedded raw response and run it
+    # through the SAME strict validator a live exchange uses, rather than
+    # reading fields ad hoc with no shape/type checks.
+    local pending_resp_file pending_endpoint parsed_file
+    pending_resp_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-pending-resp.XXXXXX")"
+    chmod 600 "$pending_resp_file"
+    pending_endpoint="$(_remote_load_pending "$pending_file" "$pending_resp_file")"
+    if [ -z "$pending_endpoint" ] || [ "$pending_endpoint" != "$endpoint" ]; then
+      rm -f "$pending_resp_file"
+      echo "agmsg: pending record's endpoint does not match — refusing to resume." >&2
+      exit 1
+    fi
+    parsed_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-connect-parsed.XXXXXX")"
+    chmod 600 "$parsed_file"
+    if ! python3 "$SCRIPT_DIR/internal/parse-exchange-response.py" < "$pending_resp_file" > "$parsed_file"; then
+      rm -f "$pending_resp_file" "$parsed_file"
+      echo "agmsg: pending record failed validation — refusing to resume." >&2
+      exit 1
+    fi
+    rm -f "$pending_resp_file"
+    {
+      IFS= read -r credential
+      IFS= read -r credential_id
+      IFS= read -r server_instance_id
+      IFS= read -r remote_team_id
+      IFS= read -r remote_team_name
+      IFS= read -r protocol_version
+      IFS= read -r capabilities_json
+      IFS= read -r write_allowed_ciphers
+      IFS= read -r current_seq
+    } < "$parsed_file"
+    rm -f "$parsed_file"
   else
     # --force pre-check only applies when <team> is known upfront — when
     # omitted, whether "this team" is already connected can't be known
@@ -374,7 +423,6 @@ cmd_connect() {
       rm -f "$resp_file" "$parsed_file"
       exit 1
     fi
-    rm -f "$resp_file"
     {
       IFS= read -r credential
       IFS= read -r credential_id
@@ -387,14 +435,16 @@ cmd_connect() {
       IFS= read -r current_seq
     } < "$parsed_file"
     rm -f "$parsed_file"
-    trap - EXIT INT TERM
 
     # Durable pending record before the local commit (B5): if the process
     # dies between here and _remote_commit finishing, retrying with the
     # same (endpoint, token) resumes from this file instead of needing a
-    # fresh token.
-    _remote_write_pending "$pending_key" "$credential" "$credential_id" "$server_instance_id" \
-      "$remote_team_id" "$remote_team_name" "$protocol_version" "$capabilities_json" "$endpoint"
+    # fresh token. Takes resp_file by PATH — the raw bytes (including the
+    # secret) are read inside python3 via file I/O, never passed as any
+    # process's own argv element (R1).
+    _remote_write_pending "$pending_key" "$resp_file" "$endpoint"
+    rm -f "$resp_file"
+    trap - EXIT INT TERM
   fi
 
   [ -n "$team" ] || team="$remote_team_name"
@@ -411,22 +461,42 @@ cmd_connect() {
   # Re-check under the lock (CAS): if something else connected this team
   # in the window since our pre-flight check (or since the exchange, for
   # the omitted-team case where no pre-check was possible), fail closed
-  # rather than mixing old/new bindings (B5) — the pending record survives
-  # this abort so a deliberate retry can still resume it.
-  local recheck_connected recheck_disconnected
+  # rather than mixing old/new bindings (B5) — UNLESS the existing binding
+  # is EXACTLY this same operation's own prior (partial) commit (its
+  # credential_id/server_instance_id/remote_team_id all match what we're
+  # about to write) — that's the resume-after-commit-but-before-pending-
+  # cleanup crash case (R3): idempotently finish (drop the pending file,
+  # skip re-writing an identical binding) rather than treating our own
+  # completed work as a foreign conflict.
+  local recheck_connected recheck_disconnected recheck_credential_id \
+    recheck_server_instance_id recheck_remote_team_id
   recheck_connected="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
   recheck_disconnected="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
+  recheck_credential_id="$(_remote_read_config_field "$cfg" '$.remote_binding.credential_id')"
+  recheck_server_instance_id="$(_remote_read_config_field "$cfg" '$.remote_binding.server_instance_id')"
+  recheck_remote_team_id="$(_remote_read_config_field "$cfg" '$.remote_binding.remote_team_id')"
+  local already_connected=0
   if [ -n "$recheck_connected" ] && [ "$recheck_connected" != "null" ] \
-    && { [ -z "$recheck_disconnected" ] || [ "$recheck_disconnected" = "null" ]; } \
-    && [ "$force" -ne 1 ]; then
+    && { [ -z "$recheck_disconnected" ] || [ "$recheck_disconnected" = "null" ]; }; then
+    already_connected=1
+  fi
+  if [ "$already_connected" -eq 1 ] \
+    && [ "$recheck_credential_id" = "$credential_id" ] \
+    && [ "$recheck_server_instance_id" = "$server_instance_id" ] \
+    && [ "$recheck_remote_team_id" = "$remote_team_id" ]; then
+    # Already fully committed by this exact operation — idempotent no-op.
+    rm -f "$pending_file"
+    agmsg_lock_release
+  elif [ "$already_connected" -eq 1 ] && [ "$force" -ne 1 ]; then
     agmsg_lock_release
     echo "agmsg: team '$team' became connected by another process just now — the credential just issued for it was NOT committed locally. Revoke it (credential_id=$credential_id) via the console/admin side if it should not remain active, then retry." >&2
     exit 1
+  else
+    _remote_commit "$team" "$cfg" "$endpoint" "$credential" "$credential_id" \
+      "$server_instance_id" "$remote_team_id" "$remote_team_name" "$protocol_version" "$capabilities_json"
+    rm -f "$pending_file"
+    agmsg_lock_release
   fi
-  _remote_commit "$team" "$cfg" "$endpoint" "$credential" "$credential_id" \
-    "$server_instance_id" "$remote_team_id" "$remote_team_name" "$protocol_version" "$capabilities_json"
-  rm -f "$pending_file"
-  agmsg_lock_release
   unset credential
 
   # E2EE insertion point (ADR 0007 §6/§8): only when the capability response

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -135,18 +135,25 @@ _remote_http_post_bearer() {
 }
 
 # _remote_revoke <endpoint> <credential_id> <credential> -> 0 revoked, 1 not
-# 404 counts as success (D2): a retry after a crash right after a prior
-# successful revoke would otherwise see "unknown credential_id" and be
-# unable to ever make progress — 404 for a credential_id we ourselves
-# issued and are trying to revoke is just as strong evidence that it's
-# not active anymore as a 200 is.
+# STRICTLY 200 only (E2 — reverted from an earlier "200 or 404 both
+# count" version): a bare HTTP 404 status is not trustworthy proof the
+# credential is actually gone. It's equally consistent with a wrong
+# path/protocol-version mismatch, a proxy returning 404, or a server that
+# doesn't implement this route at all — none of which mean the credential
+# is inactive. Treating any of those as "revoked" would let the CLI
+# report success while the credential stays fully active server-side,
+# exactly the failure this check exists to prevent. Absent a pinned
+# server contract for an authenticated "credential not found" response
+# body distinct from a generic 404, the safe default is fail-closed on
+# anything but 200 — a stuck retry (requiring a console-side revoke) is
+# the correct failure mode here, not a false "confirmed revoked."
 _remote_revoke() {
   local endpoint="$1" credential_id="$2" credential="$3" http_code
   http_code="$(_remote_http_post_bearer "$endpoint/v1/credentials/$credential_id/revoke" "$credential")"
-  [ "$http_code" = "200" ] || [ "$http_code" = "404" ]
+  [ "$http_code" = "200" ]
 }
 
-# _remote_local_disconnect <team> <cfg>
+# _remote_local_disconnect <team> <cfg> [expected_credential_id]
 # The local-state half of disconnect (credential file removal + marking
 # the binding disconnected) — factored out so the --force rebind path can
 # apply it immediately after a successful revoke, before ever attempting
@@ -154,11 +161,33 @@ _remote_revoke() {
 # revoked" and "new connection fully committed" leaves local state
 # claiming to still be connected to a credential that the server has
 # already invalidated, with no way to tell from local state alone.
+#
+# When <expected_credential_id> is given, the credential_id check AND the
+# cred-file removal AND the disconnected_at write all happen under ONE
+# lock acquisition, and only if the binding's CURRENT credential_id still
+# equals it (E1): the earlier version removed the cred file before ever
+# taking the lock and unmarked "whatever binding is currently there"
+# unconditionally, with no check that it was still the same one this
+# caller revoked — a second concurrent operation's legitimately newer
+# binding (for a different credential this call never touched or
+# revoked) could get silently clobbered and its own credential file
+# deleted, orphaning it exactly like the bug this was meant to fix.
+# Returns 0 on success, 1 on lock failure, 2 if <expected_credential_id>
+# no longer matches (caller must treat this as "someone else already
+# changed this team's binding — abort, don't proceed").
 _remote_local_disconnect() {
-  local team="$1" cfg="$2" cred_file escaped updated disconnected_at
+  local team="$1" cfg="$2" expected_credential_id="${3:-}" \
+    cred_file escaped updated disconnected_at current_credential_id
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
+  if [ -n "$expected_credential_id" ]; then
+    current_credential_id="$(_remote_read_config_field "$cfg" '$.remote_binding.credential_id')"
+    if [ "$current_credential_id" != "$expected_credential_id" ]; then
+      agmsg_lock_release
+      return 2
+    fi
+  fi
   cred_file="$(_remote_cred_file "$team")"
   rm -f "$cred_file"
-  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
   disconnected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   escaped=$(sed "s/'/''/g" "$cfg")
   updated=$(agmsg_sqlite_mem ".param set :json '$escaped'" \
@@ -261,13 +290,19 @@ _remote_commit() {
   mkdir -p "$CRED_ROOT"
   chmod 700 "$CRED_ROOT" 2>/dev/null || true
   cred_file="$(_remote_cred_file "$team")"
-  # Escape backslash BEFORE quote (order matters: escaping quote first
-  # would double-escape any backslash the first substitution just
-  # inserted) — the previous version only escaped quotes, so a credential
-  # containing a literal backslash would have produced invalid JSON (D3).
-  cred_json="$(printf '{"credential":"%s","credential_id":"%s"}' \
-    "$(printf '%s' "$credential" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
-    "$(printf '%s' "$credential_id" | sed 's/\\/\\\\/g; s/"/\\"/g')")"
+  # A real JSON serializer (python3 json.dumps), not hand-rolled sed
+  # escaping (E3): sed only ever escaped backslash/quote, so a credential
+  # containing any OTHER JSON control character (tab, CR, etc. — an
+  # opaque bearer string is never validated against a fixed alphabet, per
+  # this ADR's own "opaque to core" principle, so nothing rules these
+  # out) would have produced invalid JSON — permanently unreadable on the
+  # next load, discovered only when the credential was needed. The value
+  # is piped in via stdin, never passed as a python3 argv element, so
+  # this doesn't reopen R1's credential-in-argv leak.
+  local credential_json_str credential_id_json_str
+  credential_json_str="$(printf '%s' "$credential" | python3 -c 'import json,sys; sys.stdout.write(json.dumps(sys.stdin.read()))')"
+  credential_id_json_str="$(printf '%s' "$credential_id" | python3 -c 'import json,sys; sys.stdout.write(json.dumps(sys.stdin.read()))')"
+  cred_json="{\"credential\":${credential_json_str},\"credential_id\":${credential_id_json_str}}"
   # Atomic write (temp file in the same dir, 0600 before any content is
   # written, best-effort fsync, then rename) — never truncate the real
   # path in place (D3): a crash mid-write, or a re-commit racing another
@@ -432,15 +467,25 @@ cmd_connect() {
           exit 1
         fi
         unset old_credential
-        # D2: durably reflect the revoke locally right now, before the new
-        # exchange even starts — otherwise a crash between here and the
-        # new connection's commit leaves local state claiming to still be
-        # connected to a credential the server has already invalidated,
-        # with no local signal that anything is wrong. This also makes a
-        # retry idempotent: a second attempt sees the team as already
-        # (locally) disconnected and skips straight to a fresh exchange
-        # instead of trying to revoke an already-revoked credential again.
-        _remote_local_disconnect "$team" "$(_remote_team_config "$team")" || exit 1
+        # D2/E1: durably reflect the revoke locally right now, before the
+        # new exchange even starts — otherwise a crash between here and
+        # the new connection's commit leaves local state claiming to
+        # still be connected to a credential the server has already
+        # invalidated, with no local signal that anything is wrong. Pass
+        # the credential_id we just confirmed revoked as the expected
+        # value so this only touches the SAME binding — a concurrent
+        # operation's already-newer binding for a different credential
+        # must not be clobbered (E1: an earlier version had no such CAS
+        # check here at all, and could disconnect/delete a legitimately
+        # different concurrent connection's state).
+        _remote_local_disconnect "$team" "$(_remote_team_config "$team")" "$existing_credential_id"
+        local local_disconnect_status=$?
+        if [ "$local_disconnect_status" -eq 2 ]; then
+          echo "agmsg: team '$team's binding changed to something else during this operation — aborting rather than risk clobbering a concurrent connection." >&2
+          exit 1
+        elif [ "$local_disconnect_status" -ne 0 ]; then
+          exit 1
+        fi
         # D1: remember exactly which credential we confirmed revoked, so
         # the post-exchange CAS check (below) only proceeds if nothing
         # else has touched this team's binding since — --force authorizes
@@ -743,7 +788,24 @@ cmd_disconnect() {
     unset credential
   fi
 
-  _remote_local_disconnect "$team" "$cfg" || exit 1
+  # Pass the credential_id we just (attempted to) revoke as the expected
+  # value (E1) — if the binding changed to something else in the window
+  # since we read it above (a concurrent reconnect), disconnecting THAT
+  # would silently tear down a connection this call never touched. Only
+  # pass it when it's a real value — "null"/empty means this binding
+  # never had one, so there's nothing meaningful to CAS against.
+  local expected_credential_id_for_disconnect=""
+  if [ -n "$credential_id" ] && [ "$credential_id" != "null" ]; then
+    expected_credential_id_for_disconnect="$credential_id"
+  fi
+  _remote_local_disconnect "$team" "$cfg" "$expected_credential_id_for_disconnect"
+  local local_disconnect_status=$?
+  if [ "$local_disconnect_status" -eq 2 ]; then
+    echo "agmsg: team '$team's binding changed to something else during disconnect — aborting rather than risk clobbering a concurrent connection. Retry if you still want to disconnect the CURRENT binding." >&2
+    exit 1
+  elif [ "$local_disconnect_status" -ne 0 ]; then
+    exit 1
+  fi
 
   if [ "$revoke_ok" -eq 1 ]; then
     echo "Revoking credential with server... ok."

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -3,15 +3,27 @@ set -euo pipefail
 
 # Usage:
 #   remote.sh connect --endpoint <url> [<token>] [--token-stdin] [<team>] [--force]
-#   remote.sh status [<team>]
+#   remote.sh status [<team>] [--json]
 #   remote.sh disconnect <team>
 #   remote.sh doctor [<team>]
+#   remote.sh pending list [--json]
+#   remote.sh pending abort <pending_id>
 #
 # Team-scoped cloud/self-hosted sync connection (ADR 0007). The OSS CLI never
 # assumes or defaults to any particular server — <endpoint> is always
 # required. Login/token acquisition is out of this repo's scope (ADR 0007
 # §1a-§1c) — some provider tooling (or a self-hosted server's own admin
 # command) obtains the token; this script only ever receives one.
+#
+# `status --json` and `pending list/abort` (ADR 0007 addendum) are a
+# strict, secret-free ABI a cloud/self-hosted driver polls/acts on for crash
+# recovery: after a connect's exchange call, the driver may not know whether
+# its child `connect` invocation actually committed locally before dying.
+# `status --json` lets it correlate its own operation-status record against
+# the local binding by credential_id/server_instance_id/remote_team_id;
+# `pending list/abort` lets it enumerate and clean up an orphaned exchange
+# that never reached a local commit at all (so it isn't stuck holding a
+# server-issued credential neither side will ever use).
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -31,11 +43,19 @@ _agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
 _remote_team_config() { printf '%s' "$TEAMS_DIR/$1/config.json"; }
 _remote_cred_file() { printf '%s' "$CRED_ROOT/$1.json"; }
 
+# <escaped> is spliced as a genuine SQL string literal below, NOT bound via
+# `.param set`: the sqlite3 shell's dot-command tokenizer does not honour SQL
+# '' escaping (unlike a real SQL statement's string literals), so
+# `.param set :json '...'` silently mis-parses as soon as the config
+# contains any single quote (#87 cluster; see resolve-project.sh's
+# `resolve_team` for the same caveat, and PR #482 for the sibling-script fix
+# this mirrors — e.g. a remote_team_name containing an apostrophe, which
+# _remote_commit below stores as ordinary, unremarkable JSON text).
 _remote_read_config_field() {
   local cfg="$1" path="$2" escaped
   [ -f "$cfg" ] || { echo "null"; return; }
   escaped=$(sed "s/'/''/g" "$cfg")
-  agmsg_sqlite_mem ".param set :json '$escaped'" "SELECT json_extract(:json, '$path');"
+  agmsg_sqlite_mem "SELECT json_extract('$escaped', '$path');"
 }
 
 # Bootstrap a brand-new local team dir/config, mirroring join.sh's own
@@ -190,8 +210,10 @@ _remote_local_disconnect() {
   rm -f "$cred_file"
   disconnected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   escaped=$(sed "s/'/''/g" "$cfg")
-  updated=$(agmsg_sqlite_mem ".param set :json '$escaped'" \
-    "SELECT json_set(:json, '\$.remote_binding.disconnected_at', '$(_agmsg_sqlesc "$disconnected_at")');")
+  # <escaped> is spliced as a genuine SQL string literal, NOT bound via
+  # `.param set` (same tokenizer caveat as `_remote_read_config_field` above).
+  updated=$(agmsg_sqlite_mem \
+    "SELECT json_set('$escaped', '\$.remote_binding.disconnected_at', '$(_agmsg_sqlesc "$disconnected_at")');")
   agmsg_write_atomic "$cfg" "$updated"
   agmsg_lock_release
 }
@@ -325,15 +347,22 @@ _remote_commit() {
 
   connected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   escaped=$(sed "s/'/''/g" "$cfg")
-  updated=$(agmsg_sqlite_mem ".param set :json '$escaped'" ".param set :caps '$(printf '%s' "$capabilities_json" | sed "s/'/''/g")'" \
-    "SELECT json_set(:json, '\$.remote_binding', json_object(
+  local caps_escaped
+  caps_escaped=$(printf '%s' "$capabilities_json" | sed "s/'/''/g")
+  # <escaped>/<caps_escaped> are spliced as genuine SQL string literals below,
+  # NOT bound via `.param set` (same tokenizer caveat as
+  # `_remote_read_config_field` above) — capabilities_json in particular
+  # comes straight from the server's exchange response, so it is exactly
+  # the kind of value that could legitimately contain a quote.
+  updated=$(agmsg_sqlite_mem \
+    "SELECT json_set('$escaped', '\$.remote_binding', json_object(
        'endpoint', '$(_agmsg_sqlesc "$endpoint")',
        'credential_id', '$(_agmsg_sqlesc "$credential_id")',
        'server_instance_id', '$(_agmsg_sqlesc "$server_instance_id")',
        'remote_team_id', '$(_agmsg_sqlesc "$remote_team_id")',
        'remote_team_name', '$(_agmsg_sqlesc "$remote_team_name")',
        'protocol_version', $protocol_version,
-       'capabilities', json(:caps),
+       'capabilities', json('$caps_escaped'),
        'connected_at', '$(_agmsg_sqlesc "$connected_at")',
        'disconnected_at', null
      ));")
@@ -751,24 +780,100 @@ _remote_status_one() {
   fi
 }
 
+# _remote_status_json_one <team> — prints one JSONL object for <team>'s
+# binding, or returns 1 (no output) if the team has never been connected,
+# matching _remote_status_one's own gate exactly (same "never connected"
+# definition for both surfaces).
+#
+# Strict, machine-consumed ABI (ADR 0007 addendum): a cloud/self-hosted
+# driver correlates this against its own operation-status record to decide
+# whether a given connect attempt is the one that actually committed, or a
+# stale retry against an already-superseded binding — so the field set and
+# "null on unknown" contract are load-bearing, not just a debugging aid.
+# credential_id/server_instance_id/remote_team_id are opaque ids, never the
+# credential itself — this stays exactly as secret-free as the human-text
+# status output above. Built with a real JSON serializer (python3
+# json.dumps, values passed as argv — none of these are secret, unlike
+# credential/identity elsewhere in this file, so argv exposure isn't a
+# concern here), not hand-rolled string concatenation: this is a strict
+# schema a driver parses, so a value containing a quote/backslash (e.g. a
+# server-supplied remote_team_name-adjacent field) must not silently
+# produce malformed JSON the way E3's hand-rolled credential escaping once
+# did.
+_remote_status_json_one() {
+  local team="$1" cfg connected_at disconnected_at endpoint server_instance_id \
+    remote_team_id credential_id state
+  cfg="$(_remote_team_config "$team")"
+  connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
+  if [ -z "$connected_at" ] || [ "$connected_at" = "null" ]; then
+    return 1
+  fi
+  disconnected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
+  endpoint="$(_remote_read_config_field "$cfg" '$.remote_binding.endpoint')"
+  server_instance_id="$(_remote_read_config_field "$cfg" '$.remote_binding.server_instance_id')"
+  remote_team_id="$(_remote_read_config_field "$cfg" '$.remote_binding.remote_team_id')"
+  credential_id="$(_remote_read_config_field "$cfg" '$.remote_binding.credential_id')"
+  if [ -n "$disconnected_at" ] && [ "$disconnected_at" != "null" ]; then
+    state="disconnected"
+  else
+    state="active"
+  fi
+  python3 -c '
+import json, sys
+local_team, endpoint, server_instance_id, remote_team_id, credential_id, state = sys.argv[1:7]
+def norm(v):
+    return None if v in ("", "null") else v
+print(json.dumps({
+    "local_team": local_team,
+    "endpoint": norm(endpoint),
+    "server_instance_id": norm(server_instance_id),
+    "remote_team_id": norm(remote_team_id),
+    "credential_id": norm(credential_id),
+    "state": state,
+}, sort_keys=True))
+' "$team" "$endpoint" "$server_instance_id" "$remote_team_id" "$credential_id" "$state"
+}
+
 cmd_status() {
-  local team="${1:-}"
+  local team="" json=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --json) json=1; shift ;;
+      *) team="$1"; shift ;;
+    esac
+  done
+
   if [ -n "$team" ]; then
     agmsg_validate_team_name "$team" || exit 1
-    _remote_status_one "$team" || { echo "agmsg: team '$team' has never been connected" >&2; exit 1; }
+    if [ "$json" -eq 1 ]; then
+      _remote_status_json_one "$team" || { echo "agmsg: team '$team' has never been connected" >&2; exit 1; }
+    else
+      _remote_status_one "$team" || { echo "agmsg: team '$team' has never been connected" >&2; exit 1; }
+    fi
     return
   fi
 
   local any=0 t
-  [ -d "$TEAMS_DIR" ] || { echo "No teams found."; return; }
+  if [ ! -d "$TEAMS_DIR" ]; then
+    [ "$json" -eq 1 ] || echo "No teams found."
+    return
+  fi
   for t in "$TEAMS_DIR"/*/; do
     [ -d "$t" ] || continue
     t="$(basename "$t")"
-    if _remote_status_one "$t"; then
-      any=1
+    if [ "$json" -eq 1 ]; then
+      if _remote_status_json_one "$t"; then
+        any=1
+      fi
+    else
+      if _remote_status_one "$t"; then
+        any=1
+      fi
     fi
   done
-  [ "$any" -eq 1 ] || echo "No teams are connected."
+  if [ "$any" -ne 1 ] && [ "$json" -ne 1 ]; then
+    echo "No teams are connected."
+  fi
 }
 
 # --- disconnect ------------------------------------------------------------
@@ -830,12 +935,160 @@ cmd_disconnect() {
   echo "Disconnected '$team'. Local sync state cleared; sends/reads continue locally."
 }
 
+# --- pending ---------------------------------------------------------------
+
+# A cloud/self-hosted driver enumerates and (if orphaned by a crashed child
+# `connect` invocation) aborts pending exchange records independently of any
+# team name it can yet supply — the exchange may have succeeded server-side
+# with no local commit at all (ADR 0007 addendum). pending_id (the sha256
+# hex digest already used as the pending record's filename, see
+# `_remote_pending_key`) is the authoritative, opaque abort key: it is
+# derived from (endpoint, token) BEFORE the exchange ever ran, so
+# re-deriving the identical id requires the identical (endpoint, token)
+# pair — i.e. the identical logical retry, not an unrelated operation
+# coincidentally "reusing" an id. That content-derived uniqueness is why no
+# separate generation counter is introduced here for ABA protection.
+_remote_validate_pending_id() {
+  printf '%s' "$1" | grep -qE '^[0-9a-f]{64}$'
+}
+
+# _remote_pending_json_one <pending_file> — always prints exactly one JSONL
+# object (never skips a record just because its content doesn't validate):
+# pending_id and endpoint come from the pending envelope itself (written
+# before any exchange validation ever ran), so they're recoverable even for
+# a record whose raw_response_text fails parse-exchange-response.py's
+# strict checks (a legacy/corrupt record — exactly the case a crash-
+# recovery driver most needs to still be able to see and abort). "valid"
+# reports whether the embedded response passed that validator; when it
+# didn't (or the envelope itself couldn't even be read), server_instance_id/
+# remote_team_id/credential_id are null rather than guessed at. The
+# credential itself is never read into this function at all, let alone
+# printed — parse-exchange-response.py's first output field (the raw
+# credential) is deliberately discarded immediately after reading it.
+_remote_pending_json_one() {
+  local pending_file="$1" pending_id endpoint="" valid="false" \
+    credential_id="" server_instance_id="" remote_team_id="" \
+    resp_file parsed_file
+  pending_id="$(basename "$pending_file" .json)"
+
+  resp_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-pending-list-resp.XXXXXX")"
+  chmod 600 "$resp_file"
+  if endpoint="$(_remote_load_pending "$pending_file" "$resp_file" 2>/dev/null)"; then
+    parsed_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-pending-list-parsed.XXXXXX")"
+    chmod 600 "$parsed_file"
+    if python3 "$SCRIPT_DIR/internal/parse-exchange-response.py" < "$resp_file" > "$parsed_file" 2>/dev/null; then
+      valid="true"
+      local _discard_credential
+      {
+        IFS= read -r _discard_credential
+        IFS= read -r credential_id
+        IFS= read -r server_instance_id
+        IFS= read -r remote_team_id
+      } < "$parsed_file"
+      unset _discard_credential
+    fi
+    rm -f "$parsed_file"
+  else
+    endpoint=""
+  fi
+  rm -f "$resp_file"
+
+  python3 -c '
+import json, sys
+pending_id, endpoint, credential_id, server_instance_id, remote_team_id, valid = sys.argv[1:7]
+def norm(v):
+    return None if v == "" else v
+print(json.dumps({
+    "pending_id": pending_id,
+    "endpoint": norm(endpoint),
+    "server_instance_id": norm(server_instance_id),
+    "remote_team_id": norm(remote_team_id),
+    "credential_id": norm(credential_id),
+    "valid": valid == "true",
+}, sort_keys=True))
+' "$pending_id" "$endpoint" "$credential_id" "$server_instance_id" "$remote_team_id" "$valid"
+}
+
+cmd_pending_list() {
+  local json=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --json) json=1; shift ;;
+      *) echo "agmsg: unknown argument to 'pending list': $1" >&2; exit 1 ;;
+    esac
+  done
+
+  if [ ! -d "$PENDING_DIR" ]; then
+    [ "$json" -eq 1 ] || echo "No pending connect records."
+    return
+  fi
+
+  local any=0 f
+  for f in "$PENDING_DIR"/*.json; do
+    [ -f "$f" ] || continue
+    any=1
+    if [ "$json" -eq 1 ]; then
+      _remote_pending_json_one "$f"
+    else
+      local pid ep
+      pid="$(basename "$f" .json)"
+      ep="$(_remote_load_pending "$f" /dev/null 2>/dev/null)" || ep="(unreadable record)"
+      echo "$pid	$ep"
+    fi
+  done
+  if [ "$any" -eq 0 ] && [ "$json" -eq 0 ]; then
+    echo "No pending connect records."
+  fi
+}
+
+# Locked against $PENDING_DIR (coarse — every pending record, not just this
+# one) rather than left unlocked: without it, an abort racing a `connect`
+# invocation that is mid-way through resuming this exact pending_id could
+# delete the file out from under that resume's read. `connect`'s resume
+# path itself does not take this lock (unchanged, already-reviewed
+# behavior) — a race there surfaces as connect's existing "pending record's
+# endpoint does not match"/read-failure handling, the same class of
+# tolerance the rest of that path already has for a vanished/changed file,
+# not a crash.
+cmd_pending_abort() {
+  local pending_id="${1:?Usage: remote.sh pending abort <pending_id>}"
+  _remote_validate_pending_id "$pending_id" || {
+    echo "agmsg: invalid pending_id (expected a 64-character lowercase hex sha256 digest)" >&2
+    exit 1
+  }
+  mkdir -p "$PENDING_DIR"
+  chmod 700 "$PENDING_DIR" 2>/dev/null || true
+  local pending_file
+  pending_file="$(_remote_pending_file "$pending_id")"
+
+  agmsg_lock_acquire "$PENDING_DIR" || exit 1
+  if [ ! -f "$pending_file" ]; then
+    agmsg_lock_release
+    echo "agmsg: no pending connect record for pending_id=$pending_id (already aborted, already committed, or never existed)" >&2
+    exit 1
+  fi
+  rm -f "$pending_file"
+  agmsg_lock_release
+  echo "Aborted pending connect record $pending_id."
+}
+
+cmd_pending() {
+  local sub="${1:?Usage: remote.sh pending <list|abort> ...}"
+  shift
+  case "$sub" in
+    list) cmd_pending_list "$@" ;;
+    abort) cmd_pending_abort "$@" ;;
+    *) echo "Usage: remote.sh pending <list|abort> ..." >&2; exit 1 ;;
+  esac
+}
+
 case "${1:-}" in
   connect) shift; cmd_connect "$@" ;;
   status) shift; cmd_status "$@" ;;
   disconnect) shift; cmd_disconnect "$@" ;;
   doctor) shift; cmd_doctor "$@" ;;
+  pending) shift; cmd_pending "$@" ;;
   *)
-    echo "Usage: remote.sh <connect|status|disconnect|doctor> ..." >&2
+    echo "Usage: remote.sh <connect|status|disconnect|doctor|pending> ..." >&2
     exit 1 ;;
 esac

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -235,6 +235,31 @@ _remote_pending_key() {
 
 _remote_pending_file() { printf '%s' "$PENDING_DIR/$1.json"; }
 
+# A dedicated, empty per-pending-id directory used ONLY as a lock target —
+# never the `<id>.json` data file itself — so `pending list`'s `*.json` glob
+# never picks it up. Shared by `cmd_connect`'s resume path and
+# `cmd_pending_abort` (co1 delta review, ADR 0007 addendum): without a
+# shared lock, `connect` could read+validate a pending record, `abort` could
+# then delete that same record and report success, and `connect` would
+# still go on to commit a real binding from its own already-in-hand copy —
+# meaning "abort succeeded" and "an active binding now exists for that
+# exact operation" could both become true. Locking (not just reading) the
+# whole span from "does this pending record still exist" through to either
+# a successful commit (which itself deletes the file) or giving up makes
+# the two operations mutually exclusive: whichever acquires the lock first
+# determines the pending record's fate, and the other sees that outcome
+# once it gets the lock. Per-id (not PENDING_DIR-wide) so unrelated
+# connects/aborts for DIFFERENT pending records never serialize against
+# each other.
+_remote_pending_lock_dir() { printf '%s' "$PENDING_DIR/.locks/$1"; }
+
+_remote_pending_lock_acquire() {
+  local pending_id="$1" lock_dir
+  lock_dir="$(_remote_pending_lock_dir "$pending_id")"
+  mkdir -p "$lock_dir"
+  agmsg_lock_acquire "$lock_dir"
+}
+
 # _remote_write_pending <key> <resp_file> <endpoint>
 # Durable, atomic (temp+rename), 0600 record of a successful exchange whose
 # local commit has not (yet) fully completed — deliberately does NOT
@@ -430,6 +455,16 @@ cmd_connect() {
   local pending_key pending_file
   pending_key="$(_remote_pending_key "$endpoint" "$token")"
   pending_file="$(_remote_pending_file "$pending_key")"
+
+  # Claim this exact pending_id for the rest of this invocation (co1 delta
+  # review, ADR 0007 addendum) — held until process exit via the same
+  # EXIT/INT/TERM trap agmsg_lock_acquire always installs, so it covers
+  # every exit path below (both the resume branch and the fresh-exchange
+  # branch, through commit-or-fail) without needing an explicit release.
+  # Serializes only against `pending abort <pending_key>` and another
+  # `connect` for this exact (endpoint, token) — unrelated pending records
+  # never contend for this lock.
+  _remote_pending_lock_acquire "$pending_key" || exit 1
 
   local credential credential_id server_instance_id remote_team_id remote_team_name \
     protocol_version capabilities_json write_allowed_ciphers current_seq
@@ -792,46 +827,55 @@ _remote_status_one() {
 # "null on unknown" contract are load-bearing, not just a debugging aid.
 # credential_id/server_instance_id/remote_team_id are opaque ids, never the
 # credential itself — this stays exactly as secret-free as the human-text
-# status output above. Built with a real JSON serializer (python3
-# json.dumps, values passed as argv — none of these are secret, unlike
-# credential/identity elsewhere in this file, so argv exposure isn't a
-# concern here), not hand-rolled string concatenation: this is a strict
-# schema a driver parses, so a value containing a quote/backslash (e.g. a
-# server-supplied remote_team_name-adjacent field) must not silently
+# status output above.
+#
+# Reads config.json exactly ONCE (co1 delta review) — the original version
+# called `_remote_read_config_field` six separate times, each independently
+# re-opening the file from disk; a concurrent disconnect/reconnect/
+# force-rebind's atomic rename could swap in a new version in between any
+# two of those six reads, so the assembled object could mix fields from two
+# different on-disk versions that never actually coexisted at any instant —
+# a real defect for a strict ABI another process correlates fields against
+# (unlike the human-text status path above, which is read for a person to
+# glance at and where this same multi-read shape is only cosmetically
+# stale, not a spec violation). Also acquired under the team's own write
+# lock, so the single read can't land mid-write either. All six fields are
+# derived from that one in-memory snapshot by a single python parse — not
+# hand-rolled string concatenation, since this is a strict schema a driver
+# parses and a value containing a quote/backslash must not silently
 # produce malformed JSON the way E3's hand-rolled credential escaping once
 # did.
 _remote_status_json_one() {
-  local team="$1" cfg connected_at disconnected_at endpoint server_instance_id \
-    remote_team_id credential_id state
+  local team="$1" cfg raw
   cfg="$(_remote_team_config "$team")"
-  connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
-  if [ -z "$connected_at" ] || [ "$connected_at" = "null" ]; then
-    return 1
-  fi
-  disconnected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
-  endpoint="$(_remote_read_config_field "$cfg" '$.remote_binding.endpoint')"
-  server_instance_id="$(_remote_read_config_field "$cfg" '$.remote_binding.server_instance_id')"
-  remote_team_id="$(_remote_read_config_field "$cfg" '$.remote_binding.remote_team_id')"
-  credential_id="$(_remote_read_config_field "$cfg" '$.remote_binding.credential_id')"
-  if [ -n "$disconnected_at" ] && [ "$disconnected_at" != "null" ]; then
-    state="disconnected"
-  else
-    state="active"
-  fi
-  python3 -c '
+  [ -f "$cfg" ] || return 1
+
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
+  raw="$(cat "$cfg" 2>/dev/null)"
+  agmsg_lock_release
+
+  printf '%s' "$raw" | python3 -c '
 import json, sys
-local_team, endpoint, server_instance_id, remote_team_id, credential_id, state = sys.argv[1:7]
-def norm(v):
-    return None if v in ("", "null") else v
+team = sys.argv[1]
+try:
+    cfg = json.loads(sys.stdin.read())
+except Exception:
+    sys.exit(1)
+if not isinstance(cfg, dict):
+    sys.exit(1)
+binding = cfg.get("remote_binding")
+if not isinstance(binding, dict) or not binding.get("connected_at"):
+    sys.exit(1)
+state = "disconnected" if binding.get("disconnected_at") else "active"
 print(json.dumps({
-    "local_team": local_team,
-    "endpoint": norm(endpoint),
-    "server_instance_id": norm(server_instance_id),
-    "remote_team_id": norm(remote_team_id),
-    "credential_id": norm(credential_id),
+    "local_team": team,
+    "endpoint": binding.get("endpoint"),
+    "server_instance_id": binding.get("server_instance_id"),
+    "remote_team_id": binding.get("remote_team_id"),
+    "credential_id": binding.get("credential_id"),
     "state": state,
 }, sort_keys=True))
-' "$team" "$endpoint" "$server_instance_id" "$remote_team_id" "$credential_id" "$state"
+' "$team"
 }
 
 cmd_status() {
@@ -961,10 +1005,17 @@ _remote_validate_pending_id() {
 # recovery driver most needs to still be able to see and abort). "valid"
 # reports whether the embedded response passed that validator; when it
 # didn't (or the envelope itself couldn't even be read), server_instance_id/
-# remote_team_id/credential_id are null rather than guessed at. The
-# credential itself is never read into this function at all, let alone
-# printed — parse-exchange-response.py's first output field (the raw
-# credential) is deliberately discarded immediately after reading it.
+# remote_team_id/credential_id are null rather than guessed at.
+#
+# Calls parse-exchange-response.py with --metadata-only (co1 delta review):
+# an earlier version ran the validator's default (full) output, read its
+# first line (the raw credential) into a shell variable purely to discard
+# it, and — since that output was captured via `> parsed_file` — had
+# already written the credential to a 0600 temp file regardless of never
+# printing it further. Neither the temp file nor the shell variable is
+# needed at all for a metadata-only listing, so --metadata-only ensures
+# the credential is never emitted to that file, never read into this
+# function's process, in the first place.
 _remote_pending_json_one() {
   local pending_file="$1" pending_id endpoint="" valid="false" \
     credential_id="" server_instance_id="" remote_team_id="" \
@@ -976,16 +1027,13 @@ _remote_pending_json_one() {
   if endpoint="$(_remote_load_pending "$pending_file" "$resp_file" 2>/dev/null)"; then
     parsed_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-pending-list-parsed.XXXXXX")"
     chmod 600 "$parsed_file"
-    if python3 "$SCRIPT_DIR/internal/parse-exchange-response.py" < "$resp_file" > "$parsed_file" 2>/dev/null; then
+    if python3 "$SCRIPT_DIR/internal/parse-exchange-response.py" --metadata-only < "$resp_file" > "$parsed_file" 2>/dev/null; then
       valid="true"
-      local _discard_credential
       {
-        IFS= read -r _discard_credential
         IFS= read -r credential_id
         IFS= read -r server_instance_id
         IFS= read -r remote_team_id
       } < "$parsed_file"
-      unset _discard_credential
     fi
     rm -f "$parsed_file"
   else
@@ -1041,34 +1089,28 @@ cmd_pending_list() {
   fi
 }
 
-# Locked against $PENDING_DIR (coarse — every pending record, not just this
-# one) rather than left unlocked: without it, an abort racing a `connect`
-# invocation that is mid-way through resuming this exact pending_id could
-# delete the file out from under that resume's read. `connect`'s resume
-# path itself does not take this lock (unchanged, already-reviewed
-# behavior) — a race there surfaces as connect's existing "pending record's
-# endpoint does not match"/read-failure handling, the same class of
-# tolerance the rest of that path already has for a vanished/changed file,
-# not a crash.
+# Uses the SAME per-pending-id lock `cmd_connect`'s resume path claims
+# (co1 delta review) — see `_remote_pending_lock_acquire`'s comment above
+# for why a shared lock (not an unlocked read, and not a PENDING_DIR-wide
+# one) is required: it's what makes "abort succeeded" and "connect went on
+# to commit a binding for that exact operation anyway" mutually exclusive,
+# while still letting abort/connect on UNRELATED pending records run fully
+# concurrently.
 cmd_pending_abort() {
   local pending_id="${1:?Usage: remote.sh pending abort <pending_id>}"
   _remote_validate_pending_id "$pending_id" || {
     echo "agmsg: invalid pending_id (expected a 64-character lowercase hex sha256 digest)" >&2
     exit 1
   }
-  mkdir -p "$PENDING_DIR"
-  chmod 700 "$PENDING_DIR" 2>/dev/null || true
   local pending_file
   pending_file="$(_remote_pending_file "$pending_id")"
 
-  agmsg_lock_acquire "$PENDING_DIR" || exit 1
+  _remote_pending_lock_acquire "$pending_id" || exit 1
   if [ ! -f "$pending_file" ]; then
-    agmsg_lock_release
     echo "agmsg: no pending connect record for pending_id=$pending_id (already aborted, already committed, or never existed)" >&2
     exit 1
   fi
   rm -f "$pending_file"
-  agmsg_lock_release
   echo "Aborted pending connect record $pending_id."
 }
 

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -235,9 +235,7 @@ _remote_pending_key() {
 
 _remote_pending_file() { printf '%s' "$PENDING_DIR/$1.json"; }
 
-# A dedicated, empty per-pending-id directory used ONLY as a lock target —
-# never the `<id>.json` data file itself — so `pending list`'s `*.json` glob
-# never picks it up. Shared by `cmd_connect`'s resume path and
+# Per-pending-id lock, shared by `cmd_connect`'s resume path and
 # `cmd_pending_abort` (co1 delta review, ADR 0007 addendum): without a
 # shared lock, `connect` could read+validate a pending record, `abort` could
 # then delete that same record and report success, and `connect` would
@@ -251,13 +249,57 @@ _remote_pending_file() { printf '%s' "$PENDING_DIR/$1.json"; }
 # once it gets the lock. Per-id (not PENDING_DIR-wide) so unrelated
 # connects/aborts for DIFFERENT pending records never serialize against
 # each other.
-_remote_pending_lock_dir() { printf '%s' "$PENDING_DIR/.locks/$1"; }
+#
+# Backed by the owner_pid-tracked runtime lock (agmsg_runtime_lock_*,
+# lib/storage.sh) rather than a plain `mkdir`-based one — a first version
+# of this used a bare mkdir lock dir, which has no owner/liveness concept
+# at all: if the process holding it died via SIGKILL/OOM/an OS crash
+# (exactly the scenario this whole pending/abort feature exists to help
+# recover from), the lock would never be cleaned up, permanently blocking
+# both resume and abort of that exact record forever (co1 delta review).
+# This is the same primitive and staleness-reclaim pattern the codex
+# dispatcher lock already uses (codex-bridge-launcher.sh's
+# acquire_dispatcher_lock): a dead owner_pid (`kill -0` fails) is
+# atomically replaced via compare-and-swap, so a crash simply leaves a
+# reclaimable row rather than a stuck lock — no separate release-on-exit
+# trap is needed for correctness, since a crash (or any exit that skips
+# the explicit release below) just leaves this process's owner_pid dead
+# for the NEXT acquire attempt to reclaim; the explicit release at the end
+# of a normal run is purely a promptness optimization. Accepts the same
+# bare-PID reuse risk window that primitive's existing caller already
+# does — no separate nonce/start-time disambiguation, matching established
+# precedent rather than inventing a stronger (and platform-fragile) scheme.
+_remote_pending_runtime_resource() { printf 'remote-pending.%s' "$1"; }
 
 _remote_pending_lock_acquire() {
-  local pending_id="$1" lock_dir
-  lock_dir="$(_remote_pending_lock_dir "$pending_id")"
-  mkdir -p "$lock_dir"
-  agmsg_lock_acquire "$lock_dir"
+  local pending_id="$1" resource owner attempt=0 max="${AGMSG_PENDING_LOCK_TRIES:-200}"
+  resource="$(_remote_pending_runtime_resource "$pending_id")"
+  while [ "$attempt" -lt "$max" ]; do
+    owner="$(agmsg_runtime_lock_acquire "$resource" "$$" 2>/dev/null || true)"
+    if [ "$owner" = "$$" ]; then
+      return 0
+    fi
+    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
+      attempt=$((attempt + 1))
+      sleep 0.05
+      continue
+    fi
+    # Dead (or missing) owner: reclaim only this EXACT stale generation via
+    # compare-and-swap, so a peer that raced in a live owner between our
+    # check above and now is never clobbered.
+    owner="$(agmsg_runtime_lock_acquire "$resource" "$$" "${owner:-0}" 2>/dev/null || true)"
+    if [ "$owner" = "$$" ]; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.05
+  done
+  echo "agmsg: timed out acquiring pending lock for pending_id=$pending_id" >&2
+  return 1
+}
+
+_remote_pending_lock_release() {
+  agmsg_runtime_lock_release "$(_remote_pending_runtime_resource "$1")" "$$"
 }
 
 # _remote_write_pending <key> <resp_file> <endpoint>
@@ -692,8 +734,13 @@ cmd_connect() {
       "$server_instance_id" "$remote_team_id" "$remote_team_name" "$protocol_version" "$capabilities_json"
     rm -f "$pending_file"
     agmsg_lock_release
+    # Done with this pending_id — release promptly (not required for
+    # correctness: a crash here just leaves a reclaimable dead-owner row
+    # for the next attempt, see _remote_pending_lock_acquire's comment).
+    _remote_pending_lock_release "$pending_key"
   else
     agmsg_lock_release
+    _remote_pending_lock_release "$pending_key"
     echo "agmsg: team '$team' has a different, unexpected binding than expected — the credential just issued for it was NOT committed locally. Revoke it (credential_id=$credential_id) via the console/admin side if it should not remain active, then retry." >&2
     exit 1
   fi
@@ -1107,10 +1154,12 @@ cmd_pending_abort() {
 
   _remote_pending_lock_acquire "$pending_id" || exit 1
   if [ ! -f "$pending_file" ]; then
+    _remote_pending_lock_release "$pending_id"
     echo "agmsg: no pending connect record for pending_id=$pending_id (already aborted, already committed, or never existed)" >&2
     exit 1
   fi
   rm -f "$pending_file"
+  _remote_pending_lock_release "$pending_id"
   echo "Aborted pending connect record $pending_id."
 }
 

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -124,6 +124,23 @@ class Handler(BaseHTTPRequestHandler):
                 })
                 return
 
+            if token == "control-char-credential-token":
+                # A tab in the credential is what previously survived the
+                # newline-only check and then broke the hand-rolled
+                # sed-based JSON escaping in _remote_commit (E3) — reject
+                # it at the validator instead of relying only on the
+                # downstream write being fixed.
+                self._send_json(200, {
+                    "credential": "session-credential\twith-a-tab",
+                    "credential_id": "cred-control-char",
+                    "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
+                    "remote_team_id": "018f3f7e-2222-7000-8000-000000000002",
+                    "remote_team_name": "myteam",
+                    "protocol_version": 1,
+                    "capabilities": {"write_allowed_ciphers": ["none"]},
+                })
+                return
+
             ciphers = ["age-v1"] if token == "good-token-enc" else ["none"]
             credential_id = "cred-" + re.sub(r"[^A-Za-z0-9_-]", "-", token)
             ISSUED_CREDENTIAL_IDS.add(credential_id)

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -38,7 +38,10 @@ class Handler(BaseHTTPRequestHandler):
         pass  # keep test output quiet
 
     def _send_json(self, code, obj):
-        body = json.dumps(obj).encode()
+        self._send_raw(code, json.dumps(obj))
+
+    def _send_raw(self, code, text):
+        body = text.encode()
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
@@ -86,6 +89,38 @@ class Handler(BaseHTTPRequestHandler):
                     "remote_team_name": "myteam",
                     "protocol_version": 1,
                     "capabilities": {"write_allowed_ciphers": ["none"]},
+                })
+                return
+
+            if token == "duplicate-key-token":
+                # json.dumps() can't produce a duplicate key from a dict
+                # (dicts can't have one) — hand-build the raw text so the
+                # SECOND "credential_id" is what a naive `.get()`-based
+                # parser would silently keep (python's own json.loads also
+                # keeps only the last occurrence unless duplicate-key
+                # detection is deliberately added).
+                self._send_raw(200, """{
+                    "credential": "session-credential-xyz",
+                    "credential_id": "cred-visible-in-review",
+                    "credential_id": "cred-smuggled-in-second-copy",
+                    "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
+                    "remote_team_id": "018f3f7e-2222-7000-8000-000000000002",
+                    "remote_team_name": "myteam",
+                    "protocol_version": 1,
+                    "capabilities": {"write_allowed_ciphers": ["none"]}
+                }""")
+                return
+
+            if token == "unknown-field-token":
+                self._send_json(200, {
+                    "credential": "session-credential-xyz",
+                    "credential_id": "cred-unknown-field",
+                    "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
+                    "remote_team_id": "018f3f7e-2222-7000-8000-000000000002",
+                    "remote_team_name": "myteam",
+                    "protocol_version": 1,
+                    "capabilities": {"write_allowed_ciphers": ["none"]},
+                    "unexpected_extra_field": "smuggled-value",
                 })
                 return
 

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -4,23 +4,33 @@ bats tests exercising scripts/remote.sh without a real server. Not part of
 the shipped product — test-only.
 
 Token -> response behavior, so tests can pick a scenario by token value:
-  good-token           -> 200, capabilities.write_allowed_ciphers = ["none"]
-  good-token-enc       -> 200, capabilities.write_allowed_ciphers = ["age-v1"]
-  bad-token            -> 401
+  good-token                    -> 200, write_allowed_ciphers = ["none"]
+  good-token-enc                -> 200, write_allowed_ciphers = ["age-v1"]
+  bad-token                     -> 401
+  malformed-credential-id-token -> 200, but credential_id contains '/'
+                                    (path-injection shape) — for B6
+  missing-field-token           -> 200, but protocol_version is omitted
+                                    entirely — for B6
 
-Revoke: POST /v1/credentials/<id>/revoke -> 200 if the id matches the one
-minted for "good-token"/"good-token-enc", else 404. Set
-MOCK_REVOKE_FAIL=1 in the environment to make every revoke call time out
-(simulated by just not responding 200 — returns 500) for the
-server-unreachable disconnect test.
+credential_id is derived deterministically from the token
+("cred-<token>") for every other token value, so a test can reconnect
+with a fresh/different token and assert the OLD credential_id (tied to
+the OLD token) specifically got revoked before the new one was issued.
+
+Revoke: POST /v1/credentials/<id>/revoke -> 200 if <id> is one this
+server has ever issued, else 404; each revoked id is recorded so tests
+can assert on it via GET /_test/revoked. Set MOCK_REVOKE_FAIL=1 to make
+every revoke call fail (returns 500) for the server-unreachable test.
 """
 import json
 import os
+import re
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
-CREDENTIAL_ID = "cred-abc123"
 REVOKE_FAIL = os.environ.get("MOCK_REVOKE_FAIL") == "1"
+ISSUED_CREDENTIAL_IDS = set()
+REVOKED_CREDENTIAL_IDS = []
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -34,6 +44,12 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/_test/revoked":
+            self._send_json(200, {"revoked": REVOKED_CREDENTIAL_IDS})
+            return
+        self._send_json(404, {"error": "not found"})
 
     def do_POST(self):
         length = int(self.headers.get("Content-Length", 0))
@@ -49,10 +65,36 @@ class Handler(BaseHTTPRequestHandler):
             if token == "bad-token":
                 self._send_json(401, {"error": "invalid token"})
                 return
+
+            if token == "missing-field-token":
+                self._send_json(200, {
+                    "credential": "session-credential-xyz",
+                    "credential_id": "cred-missing-field",
+                    "server_instance_id": "srv-1",
+                    "remote_team_id": "rt-1",
+                    "remote_team_name": "myteam",
+                    "capabilities": {"write_allowed_ciphers": ["none"]},
+                })
+                return
+
+            if token == "malformed-credential-id-token":
+                self._send_json(200, {
+                    "credential": "session-credential-xyz",
+                    "credential_id": "../../etc/passwd",
+                    "server_instance_id": "srv-1",
+                    "remote_team_id": "rt-1",
+                    "remote_team_name": "myteam",
+                    "protocol_version": 1,
+                    "capabilities": {"write_allowed_ciphers": ["none"]},
+                })
+                return
+
             ciphers = ["age-v1"] if token == "good-token-enc" else ["none"]
+            credential_id = "cred-" + re.sub(r"[^A-Za-z0-9_-]", "-", token)
+            ISSUED_CREDENTIAL_IDS.add(credential_id)
             self._send_json(200, {
-                "credential": "session-credential-xyz",
-                "credential_id": CREDENTIAL_ID,
+                "credential": "session-credential-" + token,
+                "credential_id": credential_id,
                 "server_instance_id": "srv-1",
                 "remote_team_id": "rt-1",
                 "remote_team_name": "myteam",
@@ -62,6 +104,7 @@ class Handler(BaseHTTPRequestHandler):
                     "write_allowed_ciphers": ciphers,
                     "policy_revision": 1,
                     "effective_from_seq": 0,
+                    "current_seq": 0,
                     "max_blob_bytes": 1048576,
                 },
             })
@@ -72,7 +115,8 @@ class Handler(BaseHTTPRequestHandler):
                 self._send_json(500, {"error": "simulated failure"})
                 return
             cred_id = self.path.split("/")[3]
-            if cred_id == CREDENTIAL_ID:
+            if cred_id in ISSUED_CREDENTIAL_IDS:
+                REVOKED_CREDENTIAL_IDS.append(cred_id)
                 self._send_json(200, {
                     "protocol_version": 1,
                     "server_instance_id": "srv-1",

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -70,8 +70,8 @@ class Handler(BaseHTTPRequestHandler):
                 self._send_json(200, {
                     "credential": "session-credential-xyz",
                     "credential_id": "cred-missing-field",
-                    "server_instance_id": "srv-1",
-                    "remote_team_id": "rt-1",
+                    "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
+                    "remote_team_id": "018f3f7e-2222-7000-8000-000000000002",
                     "remote_team_name": "myteam",
                     "capabilities": {"write_allowed_ciphers": ["none"]},
                 })
@@ -81,8 +81,8 @@ class Handler(BaseHTTPRequestHandler):
                 self._send_json(200, {
                     "credential": "session-credential-xyz",
                     "credential_id": "../../etc/passwd",
-                    "server_instance_id": "srv-1",
-                    "remote_team_id": "rt-1",
+                    "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
+                    "remote_team_id": "018f3f7e-2222-7000-8000-000000000002",
                     "remote_team_name": "myteam",
                     "protocol_version": 1,
                     "capabilities": {"write_allowed_ciphers": ["none"]},
@@ -95,8 +95,8 @@ class Handler(BaseHTTPRequestHandler):
             self._send_json(200, {
                 "credential": "session-credential-" + token,
                 "credential_id": credential_id,
-                "server_instance_id": "srv-1",
-                "remote_team_id": "rt-1",
+                "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
+                "remote_team_id": "018f3f7e-2222-7000-8000-000000000002",
                 "remote_team_name": "myteam",
                 "protocol_version": 1,
                 "capabilities": {
@@ -119,8 +119,8 @@ class Handler(BaseHTTPRequestHandler):
                 REVOKED_CREDENTIAL_IDS.append(cred_id)
                 self._send_json(200, {
                     "protocol_version": 1,
-                    "server_instance_id": "srv-1",
-                    "team_id": "rt-1",
+                    "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
+                    "team_id": "018f3f7e-2222-7000-8000-000000000002",
                     "credential_id": cred_id,
                     "revoked": True,
                     "revoked_at": "2026-01-01T00:00:00Z",

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Minimal mock of the ADR 0007 pairing-exchange + revoke endpoints, for
+bats tests exercising scripts/remote.sh without a real server. Not part of
+the shipped product — test-only.
+
+Token -> response behavior, so tests can pick a scenario by token value:
+  good-token           -> 200, capabilities.write_allowed_ciphers = ["none"]
+  good-token-enc       -> 200, capabilities.write_allowed_ciphers = ["age-v1"]
+  bad-token            -> 401
+
+Revoke: POST /v1/credentials/<id>/revoke -> 200 if the id matches the one
+minted for "good-token"/"good-token-enc", else 404. Set
+MOCK_REVOKE_FAIL=1 in the environment to make every revoke call time out
+(simulated by just not responding 200 — returns 500) for the
+server-unreachable disconnect test.
+"""
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+CREDENTIAL_ID = "cred-abc123"
+REVOKE_FAIL = os.environ.get("MOCK_REVOKE_FAIL") == "1"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass  # keep test output quiet
+
+    def _send_json(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b""
+
+        if self.path == "/v1/pairing/exchange":
+            try:
+                data = json.loads(raw) if raw else {}
+            except Exception:
+                self._send_json(400, {"error": "bad json"})
+                return
+            token = data.get("token", "")
+            if token == "bad-token":
+                self._send_json(401, {"error": "invalid token"})
+                return
+            ciphers = ["age-v1"] if token == "good-token-enc" else ["none"]
+            self._send_json(200, {
+                "credential": "session-credential-xyz",
+                "credential_id": CREDENTIAL_ID,
+                "server_instance_id": "srv-1",
+                "remote_team_id": "rt-1",
+                "remote_team_name": "myteam",
+                "protocol_version": 1,
+                "capabilities": {
+                    "accepted_envelope_versions": [1],
+                    "write_allowed_ciphers": ciphers,
+                    "policy_revision": 1,
+                    "effective_from_seq": 0,
+                    "max_blob_bytes": 1048576,
+                },
+            })
+            return
+
+        if self.path.startswith("/v1/credentials/") and self.path.endswith("/revoke"):
+            if REVOKE_FAIL:
+                self._send_json(500, {"error": "simulated failure"})
+                return
+            cred_id = self.path.split("/")[3]
+            if cred_id == CREDENTIAL_ID:
+                self._send_json(200, {
+                    "protocol_version": 1,
+                    "server_instance_id": "srv-1",
+                    "team_id": "rt-1",
+                    "credential_id": cred_id,
+                    "revoked": True,
+                    "revoked_at": "2026-01-01T00:00:00Z",
+                })
+            else:
+                self._send_json(404, {"error": "unknown credential_id"})
+            return
+
+        self._send_json(404, {"error": "not found"})
+
+
+def main():
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+    server = HTTPServer(("127.0.0.1", port), Handler)
+    print(server.server_port, flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -56,7 +56,6 @@ skip_if_no_age() {
   run bash "$SCRIPTS/key.sh" generate testteam
   [ "$status" -ne 0 ]
   [[ "$output" == *"already has a key"* ]]
-  [[ "$output" == *"rotate"* ]]
 }
 
 @test "key generate: fails for an unknown team" {
@@ -103,12 +102,22 @@ skip_if_no_age() {
 
 # --- import --------------------------------------------------------------
 
-@test "key import: establishes the first epoch for a team with no key yet" {
+@test "key import --identity-stdin: establishes the first epoch for a team with no key yet" {
+  skip_if_no_age
+  secret=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --identity-stdin"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Imported key for team 'testteam'"* ]]
+}
+
+@test "key import: legacy positional identity warns on stderr; --identity-stdin does not" {
   skip_if_no_age
   secret=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
   run bash "$SCRIPTS/key.sh" import testteam "$secret"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"Imported key for team 'testteam'"* ]]
+  [[ "$output" == *"prefer --identity-stdin"* ]]
+  bash "$SCRIPTS/key.sh" import testteam "$secret" >/dev/null
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --identity-stdin"
+  [[ "$output" != *"prefer --identity-stdin"* ]]
 }
 
 @test "key import: matching identity for an already-keyed team succeeds without a new epoch" {
@@ -117,72 +126,94 @@ skip_if_no_age() {
   key_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['current']['key_id'])")
   secret=$(grep '^AGE-SECRET-KEY-' "$SCRIPTS/../run/remote-credentials/testteam/keys/$key_id.key")
   before=$(python3 -c "import json; print(len(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['epochs']))")
-  run bash "$SCRIPTS/key.sh" import testteam "$secret"
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --identity-stdin"
   [ "$status" -eq 0 ]
   after=$(python3 -c "import json; print(len(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['epochs']))")
   [ "$before" = "$after" ]
+}
+
+@test "key import: identity file is still valid and intact after a re-import (atomic write, no truncation)" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  key_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['current']['key_id'])")
+  identity_file="$SCRIPTS/../run/remote-credentials/testteam/keys/$key_id.key"
+  secret=$(grep '^AGE-SECRET-KEY-' "$identity_file")
+  # Re-import the SAME identity. The write goes through a temp file (0600,
+  # never colliding, never following a symlink at the destination) + atomic
+  # rename — the real path is never truncated in place, so a crash mid-write
+  # can't leave it half-written. The file's own comment header is expected
+  # to differ (re-import only ever has the bare secret to write), but the
+  # secret itself, and a fresh age-keygen -y round-trip against it, must
+  # still be intact and valid.
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --identity-stdin"
+  [ "$status" -eq 0 ]
+  [ -f "$identity_file" ]
+  perms=$(stat -f "%Lp" "$identity_file" 2>/dev/null || stat -c "%a" "$identity_file")
+  [ "$perms" = "600" ]
+  run bash -c "age-keygen -y < '$identity_file'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == age1* ]]
 }
 
 @test "key import: mismatched identity for an already-keyed team is rejected (fail closed)" {
   skip_if_no_age
   bash "$SCRIPTS/key.sh" generate testteam
   other_secret=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
-  run bash "$SCRIPTS/key.sh" import testteam "$other_secret"
+  run bash -c "printf '%s' '$other_secret' | bash '$SCRIPTS/key.sh' import testteam --identity-stdin"
   [ "$status" -ne 0 ]
   [[ "$output" == *"does not match"* ]]
 }
 
 @test "key import: rejects a malformed identity string" {
   skip_if_no_age
-  run bash "$SCRIPTS/key.sh" import testteam "not-a-real-identity"
+  run bash -c "printf 'not-a-real-identity' | bash '$SCRIPTS/key.sh' import testteam --identity-stdin"
   [ "$status" -ne 0 ]
   [[ "$output" == *"not a well-formed age identity"* ]]
 }
 
-# --- rotate --------------------------------------------------------------
-
-@test "key rotate: starts a new epoch and increments epoch_revision" {
+@test "key generate: concurrent calls for the same never-before-keyed team don't both mint an epoch" {
   skip_if_no_age
-  bash "$SCRIPTS/key.sh" generate testteam
-  run bash "$SCRIPTS/key.sh" rotate testteam
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"epoch_revision 0 -> 1"* ]]
-  epoch=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['current']['epoch_revision'])")
-  [ "$epoch" = "1" ]
-}
-
-@test "key rotate: never re-encrypts, retains all prior epochs and their identity files" {
-  skip_if_no_age
-  bash "$SCRIPTS/key.sh" generate testteam
-  first_key_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['current']['key_id'])")
-  bash "$SCRIPTS/key.sh" rotate testteam
-  bash "$SCRIPTS/key.sh" rotate testteam
+  local gen1_out gen2_out
+  gen1_out="$(mktemp)"
+  gen2_out="$(mktemp)"
+  bash "$SCRIPTS/key.sh" generate testteam >"$gen1_out" 2>&1 &
+  p1=$!
+  bash "$SCRIPTS/key.sh" generate testteam >"$gen2_out" 2>&1 &
+  p2=$!
+  # `wait` returns the backgrounded job's own exit status, and one of these
+  # two is SUPPOSED to fail (exactly one racer wins) — under bats' implicit
+  # `set -e`, a bare `wait` returning non-zero would abort the test right
+  # here, so capture with `|| s=$?` instead of asserting on `wait` itself.
+  s1=0; wait "$p1" || s1=$?
+  s2=0; wait "$p2" || s2=$?
+  rm -f "$gen1_out" "$gen2_out"
+  # Exactly one succeeds, the other sees "already has a key" — never two
+  # successes (which would mean two unrelated epoch-0 keys got minted).
+  successes=0
+  [ "$s1" -eq 0 ] && successes=$((successes + 1))
+  [ "$s2" -eq 0 ] && successes=$((successes + 1))
+  [ "$successes" -eq 1 ]
   epochs=$(python3 -c "import json; print(len(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['epochs']))")
-  [ "$epochs" -eq 3 ]
-  [ -f "$SCRIPTS/../run/remote-credentials/testteam/keys/$first_key_id.key" ]
+  [ "$epochs" -eq 1 ]
 }
 
-@test "key rotate: repeated rotations within the same second each get a distinct key_id" {
+# --- rotate (NOT READY) --------------------------------------------------
+
+@test "key rotate: refuses unconditionally and changes no state (NOT READY)" {
   skip_if_no_age
   bash "$SCRIPTS/key.sh" generate testteam
-  bash "$SCRIPTS/key.sh" rotate testteam
-  bash "$SCRIPTS/key.sh" rotate testteam
-  ids=$(python3 -c "import json; d=json.load(open('$SCRIPTS/../teams/testteam/config.json')); print(len(set(e['key_id'] for e in d['remote_key']['epochs'])))")
-  [ "$ids" = "3" ]
-}
-
-@test "key rotate: fails when the team has no existing key" {
-  skip_if_no_age
+  before=$(cat "$SCRIPTS/../teams/testteam/config.json")
   run bash "$SCRIPTS/key.sh" rotate testteam
   [ "$status" -ne 0 ]
-  [[ "$output" == *"no existing key to rotate"* ]]
+  [[ "$output" == *"not available in this release"* ]]
+  after=$(cat "$SCRIPTS/../teams/testteam/config.json")
+  [ "$before" = "$after" ]
 }
 
-@test "key rotate: fails for an unknown team" {
-  skip_if_no_age
-  run bash "$SCRIPTS/key.sh" rotate notateam
+@test "key rotate: refuses even for a team with no key at all" {
+  run bash "$SCRIPTS/key.sh" rotate testteam
   [ "$status" -ne 0 ]
-  [[ "$output" == *"team not found"* ]]
+  [[ "$output" == *"not available in this release"* ]]
 }
 
 # --- dispatch --------------------------------------------------------------

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a
+  bash "$SCRIPTS/join.sh" testteam bob claude-code /tmp/project-a
+}
+
+teardown() {
+  teardown_test_env
+}
+
+# key.sh needs the real `age`/`age-keygen` binaries (ADR 0007 §8) — skip
+# gracefully rather than failing when they're not installed on the runner.
+skip_if_no_age() {
+  command -v age >/dev/null 2>&1 && command -v age-keygen >/dev/null 2>&1 || skip "age/age-keygen not installed"
+}
+
+# --- generate --------------------------------------------------------------
+
+@test "key generate: creates a first epoch and prints the backup notice" {
+  skip_if_no_age
+  run bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Generated a new key for team 'testteam'"* ]]
+  [[ "$output" == *"Recipient fingerprint:"* ]]
+  [[ "$output" == *"Back this up now"* ]]
+  [[ "$output" == *"no server-side recovery"* ]]
+}
+
+@test "key generate: stores public recipient (not secret) in team config" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  run bash -c "python3 -c \"import json; d=json.load(open('$SCRIPTS/../teams/testteam/config.json')); print(d['remote_key']['current']['recipient'])\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == age1* ]]
+}
+
+@test "key generate: private identity file is 0600 and not inside config.json" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  key_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['current']['key_id'])")
+  identity_file="$SCRIPTS/../run/remote-credentials/testteam/keys/$key_id.key"
+  [ -f "$identity_file" ]
+  perms=$(stat -f "%Lp" "$identity_file" 2>/dev/null || stat -c "%a" "$identity_file")
+  [ "$perms" = "600" ]
+  run grep -c "AGE-SECRET-KEY" "$SCRIPTS/../teams/testteam/config.json"
+  [ "$output" -eq 0 ]
+}
+
+@test "key generate: refuses to run twice for the same team" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  run bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already has a key"* ]]
+  [[ "$output" == *"rotate"* ]]
+}
+
+@test "key generate: fails for an unknown team" {
+  skip_if_no_age
+  run bash "$SCRIPTS/key.sh" generate notateam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"team not found"* ]]
+}
+
+@test "key generate: rejects a path-traversal team name" {
+  skip_if_no_age
+  run bash "$SCRIPTS/key.sh" generate "../escape"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid team name"* ]]
+}
+
+# --- show --------------------------------------------------------------
+
+@test "key show: default prints only public recipient and fingerprint" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  run bash "$SCRIPTS/key.sh" show testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Recipient fingerprint:"* ]]
+  [[ "$output" == *"Public recipient: age1"* ]]
+  [[ "$output" != *"AGE-SECRET-KEY"* ]]
+}
+
+@test "key show: fails when the team has no key yet" {
+  skip_if_no_age
+  run bash "$SCRIPTS/key.sh" show testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"has no key yet"* ]]
+}
+
+@test "key show --reveal-secret: refused without a TTY (agent mode)" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  run bash "$SCRIPTS/key.sh" show testteam --reveal-secret
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refused in agent mode"* ]]
+  [[ "$output" != *"AGE-SECRET-KEY"* ]]
+}
+
+# --- import --------------------------------------------------------------
+
+@test "key import: establishes the first epoch for a team with no key yet" {
+  skip_if_no_age
+  secret=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
+  run bash "$SCRIPTS/key.sh" import testteam "$secret"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Imported key for team 'testteam'"* ]]
+}
+
+@test "key import: matching identity for an already-keyed team succeeds without a new epoch" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  key_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['current']['key_id'])")
+  secret=$(grep '^AGE-SECRET-KEY-' "$SCRIPTS/../run/remote-credentials/testteam/keys/$key_id.key")
+  before=$(python3 -c "import json; print(len(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['epochs']))")
+  run bash "$SCRIPTS/key.sh" import testteam "$secret"
+  [ "$status" -eq 0 ]
+  after=$(python3 -c "import json; print(len(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['epochs']))")
+  [ "$before" = "$after" ]
+}
+
+@test "key import: mismatched identity for an already-keyed team is rejected (fail closed)" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  other_secret=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
+  run bash "$SCRIPTS/key.sh" import testteam "$other_secret"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not match"* ]]
+}
+
+@test "key import: rejects a malformed identity string" {
+  skip_if_no_age
+  run bash "$SCRIPTS/key.sh" import testteam "not-a-real-identity"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not a well-formed age identity"* ]]
+}
+
+# --- rotate --------------------------------------------------------------
+
+@test "key rotate: starts a new epoch and increments epoch_revision" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  run bash "$SCRIPTS/key.sh" rotate testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"epoch_revision 0 -> 1"* ]]
+  epoch=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['current']['epoch_revision'])")
+  [ "$epoch" = "1" ]
+}
+
+@test "key rotate: never re-encrypts, retains all prior epochs and their identity files" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  first_key_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['current']['key_id'])")
+  bash "$SCRIPTS/key.sh" rotate testteam
+  bash "$SCRIPTS/key.sh" rotate testteam
+  epochs=$(python3 -c "import json; print(len(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['epochs']))")
+  [ "$epochs" -eq 3 ]
+  [ -f "$SCRIPTS/../run/remote-credentials/testteam/keys/$first_key_id.key" ]
+}
+
+@test "key rotate: repeated rotations within the same second each get a distinct key_id" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  bash "$SCRIPTS/key.sh" rotate testteam
+  bash "$SCRIPTS/key.sh" rotate testteam
+  ids=$(python3 -c "import json; d=json.load(open('$SCRIPTS/../teams/testteam/config.json')); print(len(set(e['key_id'] for e in d['remote_key']['epochs'])))")
+  [ "$ids" = "3" ]
+}
+
+@test "key rotate: fails when the team has no existing key" {
+  skip_if_no_age
+  run bash "$SCRIPTS/key.sh" rotate testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no existing key to rotate"* ]]
+}
+
+@test "key rotate: fails for an unknown team" {
+  skip_if_no_age
+  run bash "$SCRIPTS/key.sh" rotate notateam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"team not found"* ]]
+}
+
+# --- dispatch --------------------------------------------------------------
+
+@test "key.sh: unknown subcommand prints usage and exits non-zero" {
+  run bash "$SCRIPTS/key.sh" bogus testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage:"* ]]
+}

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1,0 +1,215 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a
+
+  # Start the mock pairing-exchange/revoke server on an OS-assigned port.
+  MOCK_REVOKE_FAIL="${MOCK_REVOKE_FAIL:-}" python3 "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
+    > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" &
+  MOCK_SERVER_PID=$!
+  for _ in $(seq 1 50); do
+    [ -s "$TEST_SKILL_DIR/server.port" ] && break
+    sleep 0.05
+  done
+  MOCK_PORT="$(cat "$TEST_SKILL_DIR/server.port")"
+  ENDPOINT="http://127.0.0.1:$MOCK_PORT"
+}
+
+teardown() {
+  kill "$MOCK_SERVER_PID" 2>/dev/null || true
+  teardown_test_env
+}
+
+# --- doctor ------------------------------------------------------------
+
+@test "remote doctor: passes when age is installed" {
+  command -v age >/dev/null 2>&1 || skip "age not installed"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"age / age-keygen on PATH"* ]]
+  [[ "$output" == *"All checks passed."* ]]
+}
+
+@test "remote doctor: is read-only (no token required, no state touched)" {
+  run bash "$SCRIPTS/remote.sh" doctor testteam
+  run grep -c "remote_binding" "$SCRIPTS/../teams/testteam/config.json"
+  [ "$output" -eq 0 ]
+}
+
+# --- connect -------------------------------------------------------------
+
+@test "connect: happy path, no encryption required" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Connected: team 'myteam'"* ]]
+  [ -f "$SCRIPTS/../run/remote-credentials/myteam.json" ]
+}
+
+@test "connect: credential file is 0600 and never appears in team config.json" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  perms=$(stat -f "%Lp" "$SCRIPTS/../run/remote-credentials/myteam.json" 2>/dev/null || stat -c "%a" "$SCRIPTS/../run/remote-credentials/myteam.json")
+  [ "$perms" = "600" ]
+  run grep -c "session-credential" "$SCRIPTS/../teams/myteam/config.json"
+  [ "$output" -eq 0 ]
+}
+
+@test "connect: bare positional token warns on stderr; --token-stdin does not" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  [[ "$output" == *"prefer --token-stdin"* ]]
+  bash "$SCRIPTS/remote.sh" disconnect myteam >/dev/null
+  run bash -c "printf 'good-token' | bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' --token-stdin myteam"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"prefer --token-stdin"* ]]
+}
+
+@test "connect: bad token surfaces the exchange endpoint's HTTP error" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" bad-token myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"HTTP 401"* ]]
+}
+
+@test "connect: refuses to rebind an already-connected team without --force" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already connected"* ]]
+  [[ "$output" == *"--force"* ]]
+}
+
+@test "connect: --force allows rebinding an already-connected team" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam --force
+  [ "$status" -eq 0 ]
+}
+
+@test "connect: after disconnect, reconnecting the same team needs no --force" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  bash "$SCRIPTS/remote.sh" disconnect myteam
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  [ "$status" -eq 0 ]
+}
+
+@test "connect: uses the exchange response's remote_team_name when <team> is omitted" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token
+  [ "$status" -eq 0 ]
+  [ -f "$SCRIPTS/../teams/myteam/config.json" ]
+}
+
+@test "connect: encryption required + empty stream defaults to generate" {
+  # read -p's prompt text is only ever shown on a real TTY (bash suppresses
+  # it entirely when stdin is piped, as it is here) — so this asserts the
+  # FUNCTIONAL result of accepting the default (a key gets generated), not
+  # the literal prompt string, which piped stdin never surfaces either way.
+  command -v age >/dev/null 2>&1 || skip "age not installed"
+  run bash -c "echo | bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' good-token-enc myteam"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"requires end-to-end encryption"* ]]
+  [[ "$output" == *"Generated a new key for team 'myteam'"* ]]
+  [[ "$output" == *"Connected: team 'myteam'"* ]]
+  run bash -c "python3 -c \"import json; print(json.load(open('$SCRIPTS/../teams/myteam/config.json'))['remote_key']['current']['key_id'])\""
+  [ "$status" -eq 0 ]
+}
+
+@test "connect: encryption required + existing history defaults to import" {
+  command -v age >/dev/null 2>&1 || skip "age not installed"
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/project-a >/dev/null
+  bash "$SCRIPTS/send.sh" myteam alice alice "seed message so the stream isn't empty" >/dev/null
+  identity=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
+  # Empty input (just Enter) accepts the default, which must be "import"
+  # here — feeding no explicit "i" isolates that the default itself picked
+  # import, not that we forced it.
+  run bash -c "printf '\n%s\n' '$identity' | bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' good-token-enc myteam"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Imported key for team 'myteam'"* ]]
+  [[ "$output" == *"Connected: team 'myteam'"* ]]
+}
+
+@test "connect: aborting the encryption prompt leaves the binding but no key, visible via status" {
+  command -v age >/dev/null 2>&1 || skip "age not installed"
+  run bash -c "echo a | bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' good-token-enc myteam"
+  [ "$status" -ne 0 ]
+  run bash "$SCRIPTS/remote.sh" status myteam
+  [[ "$output" == *"no local key"* ]]
+}
+
+@test "connect: missing age binary blocks the encryption bootstrap with an install hint" {
+  # Build a PATH containing everything connect's call chain needs EXCEPT
+  # age/age-keygen, so the absence check is exercised for real rather than
+  # by replacing all of $PATH (which would also break curl/python3/sqlite3
+  # and make this fail for the wrong reason).
+  fakebin=$(mktemp -d)
+  for tool in bash sh sqlite3 curl python3 mkdir chmod date mktemp rm cat sed mv grep dirname tr basename env sleep; do
+    p="$(command -v "$tool" 2>/dev/null)" && ln -s "$p" "$fakebin/$tool"
+  done
+  run bash -c "PATH='$fakebin' bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' good-token-enc myteam"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"'age' is required"* ]]
+  [[ "$output" == *"brew install age"* ]]
+}
+
+# --- status --------------------------------------------------------------
+
+@test "status: reports 'never connected' for an unknown team" {
+  run bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"never been connected"* ]]
+}
+
+@test "status: with no <team> lists every locally-known connected team" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  bash "$SCRIPTS/join.sh" secondteam alice claude-code /tmp/project-a >/dev/null
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token secondteam --force >/dev/null
+  run bash "$SCRIPTS/remote.sh" status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"myteam"* ]]
+  [[ "$output" == *"secondteam"* ]]
+}
+
+# --- disconnect ------------------------------------------------------------
+
+@test "disconnect: revokes server-side then clears local state" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  run bash "$SCRIPTS/remote.sh" disconnect myteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Revoking credential with server... ok."* ]]
+  [ ! -f "$SCRIPTS/../run/remote-credentials/myteam.json" ]
+  run bash "$SCRIPTS/remote.sh" status myteam
+  [[ "$output" == *"was connected until"* ]]
+}
+
+@test "disconnect: server unreachable for revoke still clears local state, with a warning" {
+  MOCK_REVOKE_FAIL=1
+  kill "$MOCK_SERVER_PID" 2>/dev/null
+  MOCK_REVOKE_FAIL=1 python3 "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
+    > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" &
+  MOCK_SERVER_PID=$!
+  for _ in $(seq 1 50); do
+    [ -s "$TEST_SKILL_DIR/server.port" ] && break
+    sleep 0.05
+  done
+  MOCK_PORT="$(cat "$TEST_SKILL_DIR/server.port")"
+  ENDPOINT="http://127.0.0.1:$MOCK_PORT"
+
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  run bash "$SCRIPTS/remote.sh" disconnect myteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"could not be reached to revoke"* ]]
+  [ ! -f "$SCRIPTS/../run/remote-credentials/myteam.json" ]
+}
+
+@test "disconnect: fails for a team that isn't connected" {
+  run bash "$SCRIPTS/remote.sh" disconnect testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not connected"* ]]
+}
+
+# --- dispatch --------------------------------------------------------------
+
+@test "remote.sh: unknown subcommand prints usage and exits non-zero" {
+  run bash "$SCRIPTS/remote.sh" bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage:"* ]]
+}

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -58,6 +58,24 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "connect: refuses subdomain-suffix bypass of the loopback exception (127.0.0.1.evil.com)" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "http://127.0.0.1.evil.invalid:${MOCK_PORT}" good-token myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be https://"* ]]
+}
+
+@test "connect: refuses subdomain-suffix bypass of the loopback exception (localhost.evil.com)" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "http://localhost.evil.invalid:${MOCK_PORT}" good-token myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be https://"* ]]
+}
+
+@test "connect: refuses the userinfo bypass of the loopback exception (localhost@evil.com)" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "http://localhost@evil.invalid" good-token myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"userinfo"* ]]
+}
+
 @test "connect: rejects an exchange response with a path-injection-shaped credential_id" {
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" malformed-credential-id-token myteam
   [ "$status" -ne 0 ]
@@ -142,6 +160,12 @@ teardown() {
   # Old binding must still be intact — refusal must not have half-applied.
   run bash "$SCRIPTS/remote.sh" status myteam
   [[ "$output" == *"connected"* ]]
+}
+
+@test "connect: --force requires an explicit <team> (refuses when omitted)" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token --force
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--force requires an explicit"* ]]
 }
 
 @test "connect: after disconnect, reconnecting the same team needs no --force" {
@@ -252,14 +276,16 @@ teardown() {
   python3 -c "
 import json
 json.dump({
-    'credential': 'resumed-credential-value',
-    'credential_id': 'cred-resumed-xyz',
-    'server_instance_id': 'srv-1',
-    'remote_team_id': 'rt-resumed',
-    'remote_team_name': 'resumedteam',
-    'protocol_version': 1,
-    'capabilities': {'write_allowed_ciphers': ['none']},
     'endpoint': '$ENDPOINT',
+    'response': {
+        'credential': 'resumed-credential-value',
+        'credential_id': 'cred-resumed-xyz',
+        'server_instance_id': '018f3f7e-3333-7000-8000-000000000003',
+        'remote_team_id': '018f3f7e-4444-7000-8000-000000000004',
+        'remote_team_name': 'resumedteam',
+        'protocol_version': 1,
+        'capabilities': {'write_allowed_ciphers': ['none']},
+    },
 }, open('$pending_dir/$key.json', 'w'))
 "
   chmod 600 "$pending_dir/$key.json"
@@ -276,6 +302,42 @@ json.dump({
   credential_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/myteam/config.json'))['remote_binding']['credential_id'])")
   [ "$credential_id" = "cred-resumed-xyz" ]
   # Pending record consumed on success — not left behind.
+  [ ! -f "$pending_dir/$key.json" ]
+}
+
+@test "connect: resuming after the commit already fully succeeded is an idempotent no-op (R3)" {
+  # Simulates a crash AFTER _remote_commit finished but BEFORE the pending
+  # file was removed: the binding is already correct, so a retry must not
+  # treat its own prior work as a foreign "someone else connected this
+  # team" conflict.
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" resume-idempotent-token myteam
+  committed_credential_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/myteam/config.json'))['remote_binding']['credential_id'])")
+
+  local token="resume-idempotent-token"
+  local key
+  key=$(python3 -c "import hashlib; print(hashlib.sha256('$ENDPOINT'.encode()+b'\x00'+'$token'.encode()).hexdigest())")
+  pending_dir="$SCRIPTS/../run/remote-connect-pending"
+  mkdir -p "$pending_dir"
+  python3 -c "
+import json
+json.dump({
+    'endpoint': '$ENDPOINT',
+    'response': {
+        'credential': 'session-credential-resume-idempotent-token',
+        'credential_id': '$committed_credential_id',
+        'server_instance_id': '018f3f7e-1111-7000-8000-000000000001',
+        'remote_team_id': '018f3f7e-2222-7000-8000-000000000002',
+        'remote_team_name': 'myteam',
+        'protocol_version': 1,
+        'capabilities': {'write_allowed_ciphers': ['none']},
+    },
+}, open('$pending_dir/$key.json', 'w'))
+"
+  chmod 600 "$pending_dir/$key.json"
+
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" "$token" myteam
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"became connected by another process"* ]]
   [ ! -f "$pending_dir/$key.json" ]
 }
 

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -39,6 +39,41 @@ teardown() {
   [ "$output" -eq 0 ]
 }
 
+# --- connect: endpoint/response validation (B6) --------------------------
+
+@test "connect: refuses a non-HTTPS, non-loopback endpoint" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "http://example.invalid" good-token myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be https://"* ]]
+}
+
+@test "connect: refuses an endpoint with no scheme at all" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "example.invalid" good-token myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must start with https://"* ]]
+}
+
+@test "connect: http://127.0.0.1 (loopback) is accepted without https" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  [ "$status" -eq 0 ]
+}
+
+@test "connect: rejects an exchange response with a path-injection-shaped credential_id" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" malformed-credential-id-token myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid exchange response"* ]]
+  # Must not have mutated any local state on the way to rejecting it.
+  run bash "$SCRIPTS/remote.sh" status myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"never been connected"* ]]
+}
+
+@test "connect: rejects an exchange response missing a required field" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" missing-field-token myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid exchange response"* ]]
+}
+
 # --- connect -------------------------------------------------------------
 
 @test "connect: happy path, no encryption required" {
@@ -85,6 +120,30 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "connect: --force revokes the OLD credential before establishing the new one (B5)" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token-one myteam
+  old_credential_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/myteam/config.json'))['remote_binding']['credential_id'])")
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token-two myteam --force
+  [ "$status" -eq 0 ]
+  new_credential_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/myteam/config.json'))['remote_binding']['credential_id'])")
+  [ "$old_credential_id" != "$new_credential_id" ]
+  revoked=$(curl -s "$ENDPOINT/_test/revoked")
+  [[ "$revoked" == *"$old_credential_id"* ]]
+}
+
+@test "connect: --force refuses to rebind if the old credential can't be confirmed revoked" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token-one myteam
+  # Kill the mock server so revoke can't be reached at all.
+  kill "$MOCK_SERVER_PID" 2>/dev/null
+  wait "$MOCK_SERVER_PID" 2>/dev/null || true
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token-two myteam --force
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not confirm the existing credential"* ]]
+  # Old binding must still be intact — refusal must not have half-applied.
+  run bash "$SCRIPTS/remote.sh" status myteam
+  [[ "$output" == *"connected"* ]]
+}
+
 @test "connect: after disconnect, reconnecting the same team needs no --force" {
   bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
   bash "$SCRIPTS/remote.sh" disconnect myteam
@@ -98,13 +157,14 @@ teardown() {
   [ -f "$SCRIPTS/../teams/myteam/config.json" ]
 }
 
-@test "connect: encryption required + empty stream defaults to generate" {
-  # read -p's prompt text is only ever shown on a real TTY (bash suppresses
-  # it entirely when stdin is piped, as it is here) — so this asserts the
-  # FUNCTIONAL result of accepting the default (a key gets generated), not
-  # the literal prompt string, which piped stdin never surfaces either way.
+@test "connect: encryption required + empty stream still requires an explicit 'g' to generate" {
+  # B3 (adversarial review): local/server "stream empty" signals cannot
+  # prove first-writer status (an honest server can show current_seq==0 to
+  # two simultaneous devices; a malicious one can fake it to either) — so
+  # generate is never an automatic default, empty stream or not. Explicit
+  # 'g' still works.
   command -v age >/dev/null 2>&1 || skip "age not installed"
-  run bash -c "echo | bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' good-token-enc myteam"
+  run bash -c "echo g | bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' good-token-enc myteam"
   [ "$status" -eq 0 ]
   [[ "$output" == *"requires end-to-end encryption"* ]]
   [[ "$output" == *"Generated a new key for team 'myteam'"* ]]
@@ -113,18 +173,24 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
-@test "connect: encryption required + existing history defaults to import" {
+@test "connect: encryption required + existing history still requires an explicit 'i' to import" {
   command -v age >/dev/null 2>&1 || skip "age not installed"
   bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/project-a >/dev/null
   bash "$SCRIPTS/send.sh" myteam alice alice "seed message so the stream isn't empty" >/dev/null
   identity=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
-  # Empty input (just Enter) accepts the default, which must be "import"
-  # here — feeding no explicit "i" isolates that the default itself picked
-  # import, not that we forced it.
-  run bash -c "printf '\n%s\n' '$identity' | bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' good-token-enc myteam"
+  run bash -c "printf 'i\n%s\n' '$identity' | bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' good-token-enc myteam"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Imported key for team 'myteam'"* ]]
   [[ "$output" == *"Connected: team 'myteam'"* ]]
+}
+
+@test "connect: encryption required + empty/EOF input on the choice prompt safely aborts (never auto-generates)" {
+  command -v age >/dev/null 2>&1 || skip "age not installed"
+  run bash -c "echo | bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' good-token-enc myteam"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"Generated a new key"* ]]
+  run bash -c "python3 -c \"import json; print(json.load(open('$SCRIPTS/../teams/myteam/config.json')).get('remote_key'))\""
+  [[ "$output" == "None" ]]
 }
 
 @test "connect: aborting the encryption prompt leaves the binding but no key, visible via status" {
@@ -166,6 +232,51 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"myteam"* ]]
   [[ "$output" == *"secondteam"* ]]
+}
+
+# --- connect: pending/resume (B5) -----------------------------------------
+
+@test "connect: resumes from a hand-crafted pending record without a fresh network call" {
+  # Simulates the crash-recovery scenario: an exchange already succeeded
+  # once (its result was durably saved to the pending file) but the local
+  # commit never finished. Re-running `connect` with the SAME
+  # (endpoint, token) must complete the commit from the pending record
+  # rather than attempting a new exchange — proven here by killing the
+  # mock server first: if connect still succeeds, it didn't need the
+  # network.
+  local token="resume-test-token"
+  local key
+  key=$(python3 -c "import hashlib; print(hashlib.sha256('$ENDPOINT'.encode()+b'\x00'+'$token'.encode()).hexdigest())")
+  pending_dir="$SCRIPTS/../run/remote-connect-pending"
+  mkdir -p "$pending_dir"
+  python3 -c "
+import json
+json.dump({
+    'credential': 'resumed-credential-value',
+    'credential_id': 'cred-resumed-xyz',
+    'server_instance_id': 'srv-1',
+    'remote_team_id': 'rt-resumed',
+    'remote_team_name': 'resumedteam',
+    'protocol_version': 1,
+    'capabilities': {'write_allowed_ciphers': ['none']},
+    'endpoint': '$ENDPOINT',
+}, open('$pending_dir/$key.json', 'w'))
+"
+  chmod 600 "$pending_dir/$key.json"
+
+  kill "$MOCK_SERVER_PID" 2>/dev/null
+  wait "$MOCK_SERVER_PID" 2>/dev/null || true
+
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" "$token" myteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"resuming an exchange"* ]]
+  [[ "$output" == *"Connected: team 'myteam'"* ]]
+  # Committed content must match the PENDING record's data, not a fresh
+  # exchange (there was no live server to get one from).
+  credential_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/myteam/config.json'))['remote_binding']['credential_id'])")
+  [ "$credential_id" = "cred-resumed-xyz" ]
+  # Pending record consumed on success — not left behind.
+  [ ! -f "$pending_dir/$key.json" ]
 }
 
 # --- disconnect ------------------------------------------------------------

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -109,6 +109,16 @@ teardown() {
   [[ "$output" == *"unrecognized"* ]]
 }
 
+@test "connect: rejects a credential containing a raw control character (E3)" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" control-char-credential-token myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid exchange response"* ]]
+  [[ "$output" == *"control character"* ]]
+  run bash "$SCRIPTS/remote.sh" status myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"never been connected"* ]]
+}
+
 # --- connect -------------------------------------------------------------
 
 @test "connect: happy path, no encryption required" {

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -92,6 +92,23 @@ teardown() {
   [[ "$output" == *"invalid exchange response"* ]]
 }
 
+@test "connect: rejects an exchange response with a duplicate JSON key (D4)" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" duplicate-key-token myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid exchange response"* ]]
+  [[ "$output" == *"duplicate"* ]]
+  run bash "$SCRIPTS/remote.sh" status myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"never been connected"* ]]
+}
+
+@test "connect: rejects an exchange response with an unrecognized field (D4)" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" unknown-field-token myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid exchange response"* ]]
+  [[ "$output" == *"unrecognized"* ]]
+}
+
 # --- connect -------------------------------------------------------------
 
 @test "connect: happy path, no encryption required" {
@@ -166,6 +183,47 @@ teardown() {
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token --force
   [ "$status" -ne 0 ]
   [[ "$output" == *"--force requires an explicit"* ]]
+}
+
+@test "connect: --force does not blindly overwrite an unexpected binding it never revoked (D1)" {
+  # Simulates the race D1 flagged: an exchange already completed (its
+  # result sits in a pending record — reachable without --force's own
+  # pre-check/revoke step, exactly like a resumed crash-recovery would
+  # be) for a credential the team's CURRENT binding was never revoked
+  # against. --force must still refuse here rather than treat "force" as
+  # an unconditional license to overwrite whatever's there.
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token-one myteam
+  current_credential_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/myteam/config.json'))['remote_binding']['credential_id'])")
+
+  local token="unrelated-inflight-token"
+  local key
+  key=$(python3 -c "import hashlib; print(hashlib.sha256('$ENDPOINT'.encode()+b'\x00'+'$token'.encode()).hexdigest())")
+  pending_dir="$SCRIPTS/../run/remote-connect-pending"
+  mkdir -p "$pending_dir"
+  python3 -c "
+import json
+response = {
+    'credential': 'unrelated-credential-value',
+    'credential_id': 'cred-unrelated-c',
+    'server_instance_id': '018f3f7e-1111-7000-8000-000000000001',
+    'remote_team_id': '018f3f7e-2222-7000-8000-000000000002',
+    'remote_team_name': 'myteam',
+    'protocol_version': 1,
+    'capabilities': {'write_allowed_ciphers': ['none']},
+}
+json.dump({
+    'endpoint': '$ENDPOINT',
+    'raw_response_text': json.dumps(response),
+}, open('$pending_dir/$key.json', 'w'))
+"
+  chmod 600 "$pending_dir/$key.json"
+
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" "$token" myteam --force
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unexpected binding"* ]]
+  # The original binding must be untouched — no silent overwrite.
+  after_credential_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/myteam/config.json'))['remote_binding']['credential_id'])")
+  [ "$after_credential_id" = "$current_credential_id" ]
 }
 
 @test "connect: after disconnect, reconnecting the same team needs no --force" {
@@ -275,17 +333,18 @@ teardown() {
   mkdir -p "$pending_dir"
   python3 -c "
 import json
+response = {
+    'credential': 'resumed-credential-value',
+    'credential_id': 'cred-resumed-xyz',
+    'server_instance_id': '018f3f7e-3333-7000-8000-000000000003',
+    'remote_team_id': '018f3f7e-4444-7000-8000-000000000004',
+    'remote_team_name': 'resumedteam',
+    'protocol_version': 1,
+    'capabilities': {'write_allowed_ciphers': ['none']},
+}
 json.dump({
     'endpoint': '$ENDPOINT',
-    'response': {
-        'credential': 'resumed-credential-value',
-        'credential_id': 'cred-resumed-xyz',
-        'server_instance_id': '018f3f7e-3333-7000-8000-000000000003',
-        'remote_team_id': '018f3f7e-4444-7000-8000-000000000004',
-        'remote_team_name': 'resumedteam',
-        'protocol_version': 1,
-        'capabilities': {'write_allowed_ciphers': ['none']},
-    },
+    'raw_response_text': json.dumps(response),
 }, open('$pending_dir/$key.json', 'w'))
 "
   chmod 600 "$pending_dir/$key.json"
@@ -320,17 +379,18 @@ json.dump({
   mkdir -p "$pending_dir"
   python3 -c "
 import json
+response = {
+    'credential': 'session-credential-resume-idempotent-token',
+    'credential_id': '$committed_credential_id',
+    'server_instance_id': '018f3f7e-1111-7000-8000-000000000001',
+    'remote_team_id': '018f3f7e-2222-7000-8000-000000000002',
+    'remote_team_name': 'myteam',
+    'protocol_version': 1,
+    'capabilities': {'write_allowed_ciphers': ['none']},
+}
 json.dump({
     'endpoint': '$ENDPOINT',
-    'response': {
-        'credential': 'session-credential-resume-idempotent-token',
-        'credential_id': '$committed_credential_id',
-        'server_instance_id': '018f3f7e-1111-7000-8000-000000000001',
-        'remote_team_id': '018f3f7e-2222-7000-8000-000000000002',
-        'remote_team_name': 'myteam',
-        'protocol_version': 1,
-        'capabilities': {'write_allowed_ciphers': ['none']},
-    },
+    'raw_response_text': json.dumps(response),
 }, open('$pending_dir/$key.json', 'w'))
 "
   chmod 600 "$pending_dir/$key.json"

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -654,10 +654,26 @@ json.dump({'endpoint': '$ENDPOINT', 'raw_response_text': '{}'}, open('$pending_d
 # --- pending/connect lock barrier (co1 delta review) ------------------------
 #
 # Deterministic, single-threaded simulation of the race co1 flagged: rather
-# than actually racing two live processes, pre-acquire the exact lock dir
-# `_remote_pending_lock_acquire` would take, then assert the OTHER
-# operation blocks (times out, changes nothing) instead of proceeding as if
-# uncontended. AGMSG_LOCK_TRIES keeps the timeout fast for a test.
+# than actually racing two live processes, pre-insert a row in the runtime
+# `locks` table matching exactly what `_remote_pending_lock_acquire` would
+# have written, then assert the OTHER operation either blocks (live owner)
+# or reclaims (dead owner) as appropriate. AGMSG_PENDING_LOCK_TRIES keeps
+# the timeout fast for a test.
+
+# Pre-insert a runtime-lock row for pending_id <key> owned by <owner_pid>,
+# matching lib/storage.sh's `locks` table schema exactly.
+_insert_pending_lock_row() {
+  local key="$1" owner_pid="$2" db="$SCRIPTS/../db/messages.db"
+  sqlite3 "$db" "
+CREATE TABLE IF NOT EXISTS locks (
+  resource TEXT PRIMARY KEY,
+  owner_pid INTEGER NOT NULL,
+  acquired_at TEXT NOT NULL
+);
+INSERT OR REPLACE INTO locks(resource, owner_pid, acquired_at)
+VALUES ('remote-pending.$key', $owner_pid, strftime('%Y-%m-%dT%H:%M:%SZ','now'));
+"
+}
 
 @test "pending abort: blocks (not deletes) when a concurrent connect resume already holds this pending_id's lock (barrier test)" {
   local token="lock-barrier-abort-token"
@@ -670,13 +686,12 @@ import json
 json.dump({'endpoint': '$ENDPOINT', 'raw_response_text': '{}'}, open('$pending_dir/$key.json', 'w'))
 "
   # Simulate an in-flight connect resume already holding this exact
-  # pending_id's lock (same dir _remote_pending_lock_acquire would mkdir).
-  local lock_dir="$pending_dir/.locks/$key"
-  mkdir -p "$lock_dir/.config.lock"
+  # pending_id's lock, owned by this test's own (genuinely live) pid.
+  _insert_pending_lock_row "$key" "$$"
 
-  AGMSG_LOCK_TRIES=3 run bash "$SCRIPTS/remote.sh" pending abort "$key"
+  AGMSG_PENDING_LOCK_TRIES=3 run bash "$SCRIPTS/remote.sh" pending abort "$key"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"timed out acquiring"* ]]
+  [[ "$output" == *"timed out acquiring pending lock"* ]]
   # The pending record must still exist — abort never got past the lock,
   # so it can never have raced ahead of an in-flight resume's decision.
   [ -f "$pending_dir/$key.json" ]
@@ -705,19 +720,44 @@ json.dump({
 }, open('$pending_dir/$key.json', 'w'))
 "
   # Simulate a concurrent `pending abort` already holding this exact
-  # pending_id's lock.
-  local lock_dir="$pending_dir/.locks/$key"
-  mkdir -p "$lock_dir/.config.lock"
+  # pending_id's lock, owned by this test's own (genuinely live) pid.
+  _insert_pending_lock_row "$key" "$$"
 
-  AGMSG_LOCK_TRIES=3 run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" "$token" barrierteam
+  AGMSG_PENDING_LOCK_TRIES=3 run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" "$token" barrierteam
   [ "$status" -ne 0 ]
-  [[ "$output" == *"timed out acquiring"* ]]
+  [[ "$output" == *"timed out acquiring pending lock"* ]]
   # No binding was committed while the lock was contended — connect never
   # got past claiming the pending_id, so it can never have raced ahead of
   # a concurrent abort's decision.
   [ ! -f "$SCRIPTS/../teams/barrierteam/config.json" ]
   # The pending record itself is also untouched (neither side acted on it).
   [ -f "$pending_dir/$key.json" ]
+}
+
+@test "pending abort: reclaims a stale lock left by a dead owner instead of blocking forever (barrier test)" {
+  # This is the exact crash-recovery invariant co1 flagged: a lock whose
+  # owner died via SIGKILL/OOM/an OS crash (simulated here by spawning and
+  # immediately reaping a subshell, guaranteeing its pid is no longer
+  # live) must be reclaimable, not permanently stuck.
+  local token="lock-barrier-stale-token"
+  local key
+  key=$(python3 -c "import hashlib; print(hashlib.sha256('$ENDPOINT'.encode()+b'\x00'+'$token'.encode()).hexdigest())")
+  pending_dir="$SCRIPTS/../run/remote-connect-pending"
+  mkdir -p "$pending_dir"
+  python3 -c "
+import json
+json.dump({'endpoint': '$ENDPOINT', 'raw_response_text': '{}'}, open('$pending_dir/$key.json', 'w'))
+"
+  ( : ) &
+  local dead_pid=$!
+  wait "$dead_pid" 2>/dev/null || true
+
+  _insert_pending_lock_row "$key" "$dead_pid"
+
+  AGMSG_PENDING_LOCK_TRIES=20 run bash "$SCRIPTS/remote.sh" pending abort "$key"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Aborted pending connect record $key"* ]]
+  [ ! -f "$pending_dir/$key.json" ]
 }
 
 # --- dispatch --------------------------------------------------------------

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -651,6 +651,75 @@ json.dump({'endpoint': '$ENDPOINT', 'raw_response_text': '{}'}, open('$pending_d
   [[ "$output" == *"no pending connect record"* ]]
 }
 
+# --- pending/connect lock barrier (co1 delta review) ------------------------
+#
+# Deterministic, single-threaded simulation of the race co1 flagged: rather
+# than actually racing two live processes, pre-acquire the exact lock dir
+# `_remote_pending_lock_acquire` would take, then assert the OTHER
+# operation blocks (times out, changes nothing) instead of proceeding as if
+# uncontended. AGMSG_LOCK_TRIES keeps the timeout fast for a test.
+
+@test "pending abort: blocks (not deletes) when a concurrent connect resume already holds this pending_id's lock (barrier test)" {
+  local token="lock-barrier-abort-token"
+  local key
+  key=$(python3 -c "import hashlib; print(hashlib.sha256('$ENDPOINT'.encode()+b'\x00'+'$token'.encode()).hexdigest())")
+  pending_dir="$SCRIPTS/../run/remote-connect-pending"
+  mkdir -p "$pending_dir"
+  python3 -c "
+import json
+json.dump({'endpoint': '$ENDPOINT', 'raw_response_text': '{}'}, open('$pending_dir/$key.json', 'w'))
+"
+  # Simulate an in-flight connect resume already holding this exact
+  # pending_id's lock (same dir _remote_pending_lock_acquire would mkdir).
+  local lock_dir="$pending_dir/.locks/$key"
+  mkdir -p "$lock_dir/.config.lock"
+
+  AGMSG_LOCK_TRIES=3 run bash "$SCRIPTS/remote.sh" pending abort "$key"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"timed out acquiring"* ]]
+  # The pending record must still exist — abort never got past the lock,
+  # so it can never have raced ahead of an in-flight resume's decision.
+  [ -f "$pending_dir/$key.json" ]
+}
+
+@test "connect: blocks (does not resume/commit) when a concurrent pending abort already holds this pending_id's lock (barrier test)" {
+  local token="lock-barrier-connect-token"
+  local key
+  key=$(python3 -c "import hashlib; print(hashlib.sha256('$ENDPOINT'.encode()+b'\x00'+'$token'.encode()).hexdigest())")
+  pending_dir="$SCRIPTS/../run/remote-connect-pending"
+  mkdir -p "$pending_dir"
+  python3 -c "
+import json
+response = {
+    'credential': 'barrier-credential-value',
+    'credential_id': 'cred-barrier-xyz',
+    'server_instance_id': '018f3f7e-3333-7000-8000-000000000003',
+    'remote_team_id': '018f3f7e-4444-7000-8000-000000000004',
+    'remote_team_name': 'barrierteam',
+    'protocol_version': 1,
+    'capabilities': {'write_allowed_ciphers': ['none']},
+}
+json.dump({
+    'endpoint': '$ENDPOINT',
+    'raw_response_text': json.dumps(response),
+}, open('$pending_dir/$key.json', 'w'))
+"
+  # Simulate a concurrent `pending abort` already holding this exact
+  # pending_id's lock.
+  local lock_dir="$pending_dir/.locks/$key"
+  mkdir -p "$lock_dir/.config.lock"
+
+  AGMSG_LOCK_TRIES=3 run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" "$token" barrierteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"timed out acquiring"* ]]
+  # No binding was committed while the lock was contended — connect never
+  # got past claiming the pending_id, so it can never have raced ahead of
+  # a concurrent abort's decision.
+  [ ! -f "$SCRIPTS/../teams/barrierteam/config.json" ]
+  # The pending record itself is also untouched (neither side acted on it).
+  [ -f "$pending_dir/$key.json" ]
+}
+
 # --- dispatch --------------------------------------------------------------
 
 @test "remote.sh: unknown subcommand prints usage and exits non-zero" {

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -449,10 +449,218 @@ json.dump({
   [[ "$output" == *"is not connected"* ]]
 }
 
+# --- status --json (ADR 0007 addendum) --------------------------------------
+
+@test "status --json: reports the strict schema for an active connection" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  run bash "$SCRIPTS/remote.sh" status myteam --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 1 ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.local_team');")" = "myteam" ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.endpoint');")" = "$ENDPOINT" ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.credential_id');")" = "cred-good-token" ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.state');")" = "active" ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.server_instance_id');")" != "" ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.remote_team_id');")" != "" ]
+}
+
+@test "status --json: reports state=disconnected after disconnect" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  bash "$SCRIPTS/remote.sh" disconnect myteam
+  run bash "$SCRIPTS/remote.sh" status myteam --json
+  [ "$status" -eq 0 ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.state');")" = "disconnected" ]
+  # credential_id from the old binding is still informative, not a live secret.
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.credential_id');")" = "cred-good-token" ]
+}
+
+@test "status --json: errors for a team that has never been connected" {
+  run bash "$SCRIPTS/remote.sh" status ghostteam --json
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"has never been connected"* ]]
+}
+
+@test "status --json: with no <team>, empty output when nothing is connected" {
+  run bash "$SCRIPTS/remote.sh" status --json
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "status --json: with no <team>, emits one JSONL line per connected team" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  bash "$SCRIPTS/join.sh" otherteam bob claude-code /tmp/project-b
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token otherteam
+  run bash "$SCRIPTS/remote.sh" status --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 2 ]
+  local myteam_line otherteam_line
+  myteam_line="$(echo "$output" | grep myteam | grep -v otherteam)"
+  otherteam_line="$(echo "$output" | grep otherteam)"
+  [ -n "$myteam_line" ]
+  [ -n "$otherteam_line" ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$myteam_line" | sed "s/'/''/g")', '\$.local_team');")" = "myteam" ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$otherteam_line" | sed "s/'/''/g")', '\$.local_team');")" = "otherteam" ]
+}
+
+@test "status: a team name containing a single quote doesn't break status or status --json (#87-class / .param set fix)" {
+  local team="o'brien-team"
+  bash "$SCRIPTS/join.sh" "$team" carol claude-code /tmp/project-c
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token "$team"
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ ".parameter" ]]
+  run bash "$SCRIPTS/remote.sh" status "$team"
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ ".parameter" ]]
+  [[ "$output" == *"connected"* ]]
+  run bash "$SCRIPTS/remote.sh" status "$team" --json
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ ".parameter" ]]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.local_team');")" = "$team" ]
+}
+
+# --- pending list / abort (ADR 0007 addendum) -------------------------------
+
+@test "pending list: reports nothing when there are no pending records" {
+  run bash "$SCRIPTS/remote.sh" pending list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No pending connect records"* ]]
+  run bash "$SCRIPTS/remote.sh" pending list --json
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "pending list: does not list a record that already fully committed" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  run bash "$SCRIPTS/remote.sh" pending list --json
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "pending list --json: reports a valid orphaned record with its metadata, no credential" {
+  local token="orphan-test-token"
+  local key
+  key=$(python3 -c "import hashlib; print(hashlib.sha256('$ENDPOINT'.encode()+b'\x00'+'$token'.encode()).hexdigest())")
+  pending_dir="$SCRIPTS/../run/remote-connect-pending"
+  mkdir -p "$pending_dir"
+  python3 -c "
+import json
+response = {
+    'credential': 'super-secret-credential-value',
+    'credential_id': 'cred-orphan-xyz',
+    'server_instance_id': '018f3f7e-3333-7000-8000-000000000003',
+    'remote_team_id': '018f3f7e-4444-7000-8000-000000000004',
+    'remote_team_name': 'orphanteam',
+    'protocol_version': 1,
+    'capabilities': {'write_allowed_ciphers': ['none']},
+}
+json.dump({
+    'endpoint': '$ENDPOINT',
+    'raw_response_text': json.dumps(response),
+}, open('$pending_dir/$key.json', 'w'))
+"
+  run bash "$SCRIPTS/remote.sh" pending list --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 1 ]
+  local escaped; escaped="$(echo "$output" | sed "s/'/''/g")"
+  [ "$(sqlite_mem "SELECT json_extract('$escaped', '\$.pending_id');")" = "$key" ]
+  [ "$(sqlite_mem "SELECT json_extract('$escaped', '\$.endpoint');")" = "$ENDPOINT" ]
+  [ "$(sqlite_mem "SELECT json_extract('$escaped', '\$.credential_id');")" = "cred-orphan-xyz" ]
+  [ "$(sqlite_mem "SELECT json_extract('$escaped', '\$.valid');")" = "1" ]
+  # The raw credential must never appear anywhere in the listing output.
+  [[ "$output" != *"super-secret-credential-value"* ]]
+}
+
+@test "pending list --json: reports valid:false and null metadata for a record whose content fails validation" {
+  pending_dir="$SCRIPTS/../run/remote-connect-pending"
+  mkdir -p "$pending_dir"
+  local key; key="$(printf 'a%.0s' $(seq 1 64))"
+  python3 -c "
+import json
+json.dump({
+    'endpoint': '$ENDPOINT',
+    'raw_response_text': '{not valid json',
+}, open('$pending_dir/$key.json', 'w'))
+"
+  run bash "$SCRIPTS/remote.sh" pending list --json
+  [ "$status" -eq 0 ]
+  local escaped; escaped="$(echo "$output" | sed "s/'/''/g")"
+  [ "$(sqlite_mem "SELECT json_extract('$escaped', '\$.pending_id');")" = "$key" ]
+  [ "$(sqlite_mem "SELECT json_extract('$escaped', '\$.endpoint');")" = "$ENDPOINT" ]
+  [ "$(sqlite_mem "SELECT json_extract('$escaped', '\$.valid');")" = "0" ]
+  [ "$(sqlite_mem "SELECT json_extract('$escaped', '\$.credential_id');")" = "" ]
+}
+
+@test "pending list --json: still reports pending_id even when the envelope itself is corrupt" {
+  pending_dir="$SCRIPTS/../run/remote-connect-pending"
+  mkdir -p "$pending_dir"
+  local key; key="$(printf 'b%.0s' $(seq 1 64))"
+  printf 'not even json' > "$pending_dir/$key.json"
+  run bash "$SCRIPTS/remote.sh" pending list --json
+  [ "$status" -eq 0 ]
+  local escaped; escaped="$(echo "$output" | sed "s/'/''/g")"
+  [ "$(sqlite_mem "SELECT json_extract('$escaped', '\$.pending_id');")" = "$key" ]
+  [ "$(sqlite_mem "SELECT json_extract('$escaped', '\$.endpoint');")" = "" ]
+  [ "$(sqlite_mem "SELECT json_extract('$escaped', '\$.valid');")" = "0" ]
+}
+
+@test "pending abort: rejects a malformed pending_id" {
+  run bash "$SCRIPTS/remote.sh" pending abort "not-a-valid-id"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid pending_id"* ]]
+  run bash "$SCRIPTS/remote.sh" pending abort "../../escape"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid pending_id"* ]]
+}
+
+@test "pending abort: removes a valid pending record" {
+  local token="abort-test-token"
+  local key
+  key=$(python3 -c "import hashlib; print(hashlib.sha256('$ENDPOINT'.encode()+b'\x00'+'$token'.encode()).hexdigest())")
+  pending_dir="$SCRIPTS/../run/remote-connect-pending"
+  mkdir -p "$pending_dir"
+  python3 -c "
+import json
+json.dump({'endpoint': '$ENDPOINT', 'raw_response_text': '{}'}, open('$pending_dir/$key.json', 'w'))
+"
+  run bash "$SCRIPTS/remote.sh" pending abort "$key"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Aborted pending connect record $key"* ]]
+  [ ! -f "$pending_dir/$key.json" ]
+}
+
+@test "pending abort: fails clearly for an unknown pending_id" {
+  local key; key="$(printf 'c%.0s' $(seq 1 64))"
+  run bash "$SCRIPTS/remote.sh" pending abort "$key"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no pending connect record"* ]]
+}
+
+@test "pending abort: aborting the same pending_id twice is not silently treated as success" {
+  local token="double-abort-token"
+  local key
+  key=$(python3 -c "import hashlib; print(hashlib.sha256('$ENDPOINT'.encode()+b'\x00'+'$token'.encode()).hexdigest())")
+  pending_dir="$SCRIPTS/../run/remote-connect-pending"
+  mkdir -p "$pending_dir"
+  python3 -c "
+import json
+json.dump({'endpoint': '$ENDPOINT', 'raw_response_text': '{}'}, open('$pending_dir/$key.json', 'w'))
+"
+  bash "$SCRIPTS/remote.sh" pending abort "$key"
+  run bash "$SCRIPTS/remote.sh" pending abort "$key"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no pending connect record"* ]]
+}
+
 # --- dispatch --------------------------------------------------------------
 
 @test "remote.sh: unknown subcommand prints usage and exits non-zero" {
   run bash "$SCRIPTS/remote.sh" bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "remote.sh: unknown pending subcommand prints usage and exits non-zero" {
+  run bash "$SCRIPTS/remote.sh" pending bogus
   [ "$status" -ne 0 ]
   [[ "$output" == *"Usage:"* ]]
 }


### PR DESCRIPTION
## Summary

Implements ADR 0007 (`docs/adr/0007-remote-connect-onboarding-ux.md`, included in this PR): team-scoped cloud/self-hosted sync connection (`scripts/remote.sh`) and onboarding-time `age-v1` key management (`scripts/key.sh`).

- `remote.sh connect|status|disconnect|doctor` — connects a local team to a sync endpoint via a single-use exchange token, with `--token-stdin` as the required path for any programmatic/agent caller (bare positional token kept only as a warned legacy form for a human's own terminal).
- `key.sh generate|show|import` — first-epoch `age-v1` key management for a team (single-writer onboarding only).

## Explicitly NOT in scope for this PR

- **`key rotate`** — refuses unconditionally, changes no state. Its `previous_snapshot_sha256` design doesn't use the age-v1 profile's pinned canonical epoch-snapshot shape and can't detect a wholesale `config.json` rollback; needs a durable anti-rollback anchor design before it ships.
- **`key request`/`key approve` (device-pairing key delivery)** — not implemented at all. An adversarial design review found five separate fundamental problems (grinding-attack-vulnerable confirmation code, one-directional auth allowing fake-key injection, missing request/delivery state machine, incompatibility with `age-v1`'s policy gate, undefined broadcast-stream behavior). Deferred to a follow-up design pass.
- **Login/token acquisition** — out of this repo's scope entirely (ADR 0007 §1a-§1c). Some provider tooling, or a self-hosted server's own admin command, obtains the token; `connect` only ever receives one.

## Note on §8/B3 (encryption-bootstrap default choice)

The originally-approved design let `connect` auto-select "generate" as the default when a team's stream looked empty (based on local message count or server `current_seq`). An adversarial review found this unsafe — neither signal can prove "I am the first writer" (two devices can see an empty stream simultaneously; a malicious/equivocating server can fake it deliberately) — so the shipped behavior never auto-selects generate; it always requires an explicit, deliberate `g`, defaulting to abort on empty/EOF input. **koit approved this default-removal, conditional on the first-time-user wording being unambiguous at a glance — that wording is implemented** (the empty-stream hint now states the recommendation directly before the caveat).

## Addendum: status --json + pending list/abort (koit-approved OSS interface addition)

Two more commits add a strict, secret-free ABI for cloud/self-hosted crash recovery (a driver's child `connect` invocation may die between a successful server-side exchange and the local commit finishing):

- `remote.sh status [<team>] [--json]` — `{local_team, endpoint, server_instance_id, remote_team_id, credential_id, state: active|disconnected}`.
- `remote.sh pending list [--json]` / `remote.sh pending abort <pending_id>` — enumerate and clean up an orphaned exchange that never reached a local commit. `pending_id` is the existing content-derived sha256(endpoint, token) digest already used as the pending record's filename; `list` still reports `pending_id`/`endpoint` for a record whose content fails strict validation (a legacy/corrupt record), so crash recovery can still abort it by id.

Building this surfaced the same `.param set`-vs-tokenizer bug PR #482 fixed in the sibling registry scripts, present in `remote.sh`/`key.sh` too — fixed identically in the first of the two addendum commits.

## Security review

Went through an initial 7-finding adversarial review (B1-B7) plus three delta re-review rounds (R1-R5, D1-D5, E1-E3) — secret-argv leakage via curl/python3, transport/response validation (HTTPS enforcement bypassable via URL parsing tricks, strict exchange-response schema incl. duplicate-JSON-key detection and UUIDv7 validation per the pinned server spec), `--force` rebind transactionality (CAS races, orphaned-credential recovery), and credential-file write atomicity. Cleared with no blocking findings as of the current head.

## Test plan

- [x] `tests/test_key.bats` — 19 tests, run against real `age`/`age-keygen`
- [x] `tests/test_remote.bats` — 54 tests (16 new for the addendum), run against a local mock pairing-exchange/revoke HTTP server (`tests/helpers/mock_remote_server.py`, test-only)
- [x] Manual `ps`-sampling verification that no secret ever appears in any process's argv during `connect`
- [ ] CI run on this PR

## Dependencies

Base: `main` (co2's server-side integration branch isn't set up yet — will rebase onto `integration/remote` once that lands, per coordination with co2).
