### PR TITLE
feat(sync): bridge remote connect into polling engine

### DIFF
--- a/docs/remote-sync-dogfood.md
+++ b/docs/remote-sync-dogfood.md
@@ -5,21 +5,31 @@ local SQLite store first. It is intentionally branch-only and is not installed
 by the released core yet.
 
 Requirements: Node.js 22+, SQLite, jq, base64, and a provisioned team on the
-reference server. The bearer token is accepted only through
-`AGMSG_SYNC_TOKEN`; it is never stored in sync config or passed as an argument.
+reference server. Connect each device with its own single-use pairing token
+before starting the polling engine:
 
-Configure each machine (or each isolated dogfood store) with an explicit local
-plaintext policy:
+```sh
+printf '%s' "$PAIRING_TOKEN" | scripts/remote.sh connect \
+  --endpoint https://sync.example --token-stdin example-team
+```
+
+`remote.sh connect` stores the non-secret binding under
+`teams/<team>/config.json` and the device's bearer credential in a separate
+`0600` file under `run/remote-credentials/`. The engine reads those artifacts
+directly. It does not accept credentials through argv or environment, and it
+never passes them to a storage driver child.
+
+An isolated dogfood client may set `AGMSG_SYNC_CONNECTION_DIR` before both
+`remote.sh` and `remote-sync.sh`; its `teams/` and `run/remote-credentials/`
+paths are then rooted there instead of in the checkout. This is useful for
+two-device rehearsals and must not point at a live fleet's data root.
+
+For a plaintext-capable binding, no second configure step is needed. Select the
+local storage driver and store as usual:
 
 ```sh
 export AGMSG_STORAGE_PATH=/path/to/machine-a-store
-export AGMSG_SYNC_TOKEN='deployment bearer token'
-
-scripts/remote-sync.sh configure \
-  --team example-team \
-  --server http://127.0.0.1:8787 \
-  --team-id 018f3f7e-0000-7000-8000-000000000001 \
-  --minimum-security plaintext-allowed
+export AGMSG_STORAGE_DRIVER=sqlite  # or jsonl
 ```
 
 Run one push/pull cycle:
@@ -78,8 +88,10 @@ below shows its minimum initial-epoch data shape:
 }
 ```
 
-After independently confirming the current revision and lowercase JCS SHA-256
-digest with the epoch authority, configure the binding:
+After connecting and independently confirming the current revision and
+lowercase JCS SHA-256 digest with the epoch authority, configure the
+encryption-specific state. HTTP authentication still comes only from the
+credential created by `remote.sh connect`:
 
 ```sh
 export AGMSG_AGE_BIN=/path/to/age       # optional when age is already on PATH

--- a/scripts/internal/bounded-copy.py
+++ b/scripts/internal/bounded-copy.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Copy stdin to stdout only when the complete stream fits a byte limit."""
+
+import sys
+
+
+def main():
+    if len(sys.argv) != 2 or not sys.argv[1].isdigit():
+        raise SystemExit(2)
+    limit = int(sys.argv[1])
+    value = sys.stdin.buffer.read(limit + 1)
+    if len(value) > limit:
+        print("bounded stream exceeds its byte limit", file=sys.stderr)
+        raise SystemExit(1)
+    sys.stdout.buffer.write(value)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/internal/parse-exchange-response.py
+++ b/scripts/internal/parse-exchange-response.py
@@ -45,15 +45,22 @@ import sys
 
 ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 UUIDV7_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+SEQUENCE_RE = re.compile(r"^(0|[1-9][0-9]*)$")
+MAX_SEQUENCE = 9_223_372_036_854_775_807
 SUPPORTED_PROTOCOL_VERSIONS = (1,)
 ALLOWED_TOP_LEVEL_KEYS = {
     "credential", "credential_id", "server_instance_id", "remote_team_id",
     "remote_team_name", "protocol_version", "capabilities",
 }
 ALLOWED_CAPABILITY_KEYS = {
+    "protocol_version", "server_instance_id", "team_id", "team_name",
     "accepted_envelope_versions", "write_allowed_ciphers", "policy_revision",
     "effective_from_seq", "max_blob_bytes", "current_seq",
     "next_sequence_boundary", "min_available_seq", "policy_history",
+}
+POLICY_KEYS = {
+    "policy_revision", "effective_from_seq", "accepted_envelope_versions",
+    "write_allowed_ciphers",
 }
 
 
@@ -85,6 +92,39 @@ def req_str(d, key):
     if not isinstance(v, str) or not v:
         fail(f"missing or invalid '{key}'")
     return v
+
+
+def req_sequence(d, key, label=None):
+    value = d.get(key)
+    if (
+        not isinstance(value, str)
+        or not SEQUENCE_RE.match(value)
+        or int(value) > MAX_SEQUENCE
+    ):
+        fail(f"capabilities.{label or key} is not a canonical sequence")
+    return value
+
+
+def validate_policy_set(value, label):
+    if (
+        not isinstance(value, list)
+        or not value
+        or not all(isinstance(item, str) and item for item in value)
+        or len(value) != len(set(value))
+    ):
+        fail(f"capabilities.{label} has an unexpected shape")
+    return value
+
+
+def validate_envelope_versions(value, label):
+    if (
+        not isinstance(value, list)
+        or not value
+        or not all(isinstance(item, int) and not isinstance(item, bool) and item >= 1 for item in value)
+        or len(value) != len(set(value))
+    ):
+        fail(f"capabilities.{label} has an unexpected shape")
+    return value
 
 
 def main():
@@ -125,6 +165,10 @@ def main():
     if protocol_version not in SUPPORTED_PROTOCOL_VERSIONS:
         fail(f"unsupported protocol_version {protocol_version!r}")
 
+    for field in (credential, credential_id, server_instance_id, remote_team_id, remote_team_name):
+        if re.search(r"[\x00-\x1f\x7f]", field):
+            fail("a response field unexpectedly contains a control character")
+
     caps = d.get("capabilities", {})
     if not isinstance(caps, dict):
         fail("capabilities has an unexpected type")
@@ -132,15 +176,68 @@ def main():
     if unknown_caps:
         fail(f"unrecognized capabilities field(s): {', '.join(sorted(unknown_caps))}")
 
-    ciphers = caps.get("write_allowed_ciphers", [])
-    if not isinstance(ciphers, list) or not all(isinstance(c, str) for c in ciphers):
-        fail("capabilities.write_allowed_ciphers has an unexpected shape")
+    if (
+        caps.get("protocol_version") != protocol_version
+        or caps.get("server_instance_id") != server_instance_id
+        or caps.get("team_id") != remote_team_id
+        or caps.get("team_name") != remote_team_name
+    ):
+        fail("capabilities binding does not match the exchange response")
+
+    current_seq = req_sequence(caps, "current_seq")
+    min_available_seq = req_sequence(caps, "min_available_seq")
+    policy_revision = req_sequence(caps, "policy_revision")
+    effective_from_seq = req_sequence(caps, "effective_from_seq")
+    req_sequence(caps, "max_blob_bytes")
+    if int(min_available_seq) > int(current_seq):
+        fail("capabilities retention floor exceeds current_seq")
+    next_boundary = caps.get("next_sequence_boundary")
+    if current_seq == str(MAX_SEQUENCE):
+        if next_boundary is not None:
+            fail("capabilities next_sequence_boundary must be null at exhaustion")
+    elif (
+        not isinstance(next_boundary, str)
+        or not SEQUENCE_RE.match(next_boundary)
+        or int(next_boundary) != int(current_seq) + 1
+    ):
+        fail("capabilities next_sequence_boundary is inconsistent")
+
+    versions = validate_envelope_versions(
+        caps.get("accepted_envelope_versions"), "accepted_envelope_versions"
+    )
+    ciphers = validate_policy_set(caps.get("write_allowed_ciphers"), "write_allowed_ciphers")
     if any("," in c for c in ciphers):
         fail("capabilities.write_allowed_ciphers entries must not contain ','")
-
-    current_seq = caps.get("current_seq")
-    if current_seq is not None and (not isinstance(current_seq, int) or isinstance(current_seq, bool)):
-        fail("capabilities.current_seq has an unexpected type")
+    history = caps.get("policy_history")
+    if not isinstance(history, list) or not history or len(history) > 4096:
+        fail("capabilities.policy_history has an unexpected shape")
+    prior_revision = -1
+    prior_boundary = 0
+    for entry in history:
+        if not isinstance(entry, dict) or set(entry.keys()) != POLICY_KEYS:
+            fail("capabilities.policy_history entry has an unexpected shape")
+        revision = req_sequence(entry, "policy_revision", "policy_history.policy_revision")
+        boundary = req_sequence(entry, "effective_from_seq", "policy_history.effective_from_seq")
+        entry_versions = validate_envelope_versions(
+            entry.get("accepted_envelope_versions"), "policy_history.accepted_envelope_versions"
+        )
+        entry_ciphers = validate_policy_set(
+            entry.get("write_allowed_ciphers"), "policy_history.write_allowed_ciphers"
+        )
+        if int(revision) <= prior_revision or int(boundary) <= prior_boundary:
+            fail("capabilities.policy_history is not canonical ascending")
+        prior_revision = int(revision)
+        prior_boundary = int(boundary)
+    if history[0]["effective_from_seq"] != "1":
+        fail("capabilities.policy_history must begin at sequence 1")
+    final = history[-1]
+    if (
+        final["policy_revision"] != policy_revision
+        or final["effective_from_seq"] != effective_from_seq
+        or final["accepted_envelope_versions"] != versions
+        or final["write_allowed_ciphers"] != ciphers
+    ):
+        fail("capabilities current policy does not match policy_history")
 
     caps_json = json.dumps(caps)
     fields = [
@@ -152,7 +249,7 @@ def main():
         str(protocol_version),
         caps_json,
         ",".join(ciphers),
-        str(current_seq if current_seq is not None else -1),
+        current_seq,
     ]
     for f in fields:
         # Reject every ASCII control character (0x00-0x1F, 0x7F), not

--- a/scripts/internal/parse-exchange-response.py
+++ b/scripts/internal/parse-exchange-response.py
@@ -42,6 +42,7 @@ CIPHER_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 SEQUENCE_RE = re.compile(r"^(0|[1-9][0-9]*)$")
 MAX_SEQUENCE = 9_223_372_036_854_775_807
 SUPPORTED_PROTOCOL_VERSIONS = (1,)
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 ALLOWED_TOP_LEVEL_KEYS = {
     "credential", "credential_id", "server_instance_id", "remote_team_id",
     "remote_team_name", "protocol_version", "capabilities",
@@ -124,8 +125,11 @@ def validate_envelope_versions(value, label):
 
 
 def main():
-    raw = sys.stdin.read()
+    raw_bytes = sys.stdin.buffer.read(MAX_RESPONSE_BYTES + 1)
+    if len(raw_bytes) > MAX_RESPONSE_BYTES:
+        fail("response body exceeds its byte limit")
     try:
+        raw = raw_bytes.decode("utf-8")
         d = strict_loads(raw)
     except SystemExit:
         raise

--- a/scripts/internal/parse-exchange-response.py
+++ b/scripts/internal/parse-exchange-response.py
@@ -15,16 +15,10 @@ which would silently destroy NUL-based field boundaries before the caller
 ever sees them. Every field is rejected if it contains a literal newline
 (none legitimately should), so newline is safe as the sole delimiter here.
 
-credential_id is validated against a bounded, URL-path-safe character set
-because it is spliced directly into the revoke endpoint's path — anything
-else risks path/query injection against a malicious or buggy server; its
-exact format isn't pinned by any approved spec (pairing/credential
-exchange is this ADR's own addition), so a conservative bounded charset
-is the right baseline. server_instance_id and team_id (remote_team_id),
-by contrast, ARE pinned: the approved sync HTTP v1 spec (server/spec/v1.md
-@ d1a74db) requires both to be a canonical LOWERCASE UUIDv7 (RFC 9562) —
-validated here as such, not left to a loose bounded charset, since an
-invalid binding must never reach a local commit.
+credential_id, server_instance_id, and team_id (remote_team_id) are all
+pinned to canonical lowercase UUIDv7. The credential identifier is also
+spliced into the revoke endpoint's path, so accepting a looser value here
+would both split client/server validation and risk path/query injection.
 
 This same validator is also used to re-check a previously-saved pending
 record before resuming a commit from it (ADR 0007 review finding R5) — a
@@ -43,8 +37,8 @@ import json
 import re
 import sys
 
-ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 UUIDV7_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+CIPHER_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 SEQUENCE_RE = re.compile(r"^(0|[1-9][0-9]*)$")
 MAX_SEQUENCE = 9_223_372_036_854_775_807
 SUPPORTED_PROTOCOL_VERSIONS = (1,)
@@ -108,8 +102,7 @@ def req_sequence(d, key, label=None):
 def validate_policy_set(value, label):
     if (
         not isinstance(value, list)
-        or not value
-        or not all(isinstance(item, str) and item for item in value)
+        or not all(isinstance(item, str) and CIPHER_RE.match(item) for item in value)
         or len(value) != len(set(value))
     ):
         fail(f"capabilities.{label} has an unexpected shape")
@@ -120,7 +113,10 @@ def validate_envelope_versions(value, label):
     if (
         not isinstance(value, list)
         or not value
-        or not all(isinstance(item, int) and not isinstance(item, bool) and item >= 1 for item in value)
+        or not all(
+            isinstance(item, int) and not isinstance(item, bool)
+            and 0 <= item <= 0xFFFFFFFF for item in value
+        )
         or len(value) != len(set(value))
     ):
         fail(f"capabilities.{label} has an unexpected shape")
@@ -146,8 +142,8 @@ def main():
 
     credential = req_str(d, "credential")
     credential_id = req_str(d, "credential_id")
-    if not ID_RE.match(credential_id):
-        fail("credential_id has an unexpected shape")
+    if not UUIDV7_RE.match(credential_id):
+        fail("credential_id must be a canonical lowercase UUIDv7")
     server_instance_id = req_str(d, "server_instance_id")
     if not UUIDV7_RE.match(server_instance_id):
         fail("server_instance_id must be a canonical lowercase UUIDv7")
@@ -188,7 +184,9 @@ def main():
     min_available_seq = req_sequence(caps, "min_available_seq")
     policy_revision = req_sequence(caps, "policy_revision")
     effective_from_seq = req_sequence(caps, "effective_from_seq")
-    req_sequence(caps, "max_blob_bytes")
+    max_blob_bytes = req_sequence(caps, "max_blob_bytes")
+    if not 1 <= int(max_blob_bytes) <= 1_048_576:
+        fail("capabilities.max_blob_bytes is outside the protocol limit")
     if int(min_available_seq) > int(current_seq):
         fail("capabilities retention floor exceeds current_seq")
     next_boundary = caps.get("next_sequence_boundary")
@@ -206,8 +204,6 @@ def main():
         caps.get("accepted_envelope_versions"), "accepted_envelope_versions"
     )
     ciphers = validate_policy_set(caps.get("write_allowed_ciphers"), "write_allowed_ciphers")
-    if any("," in c for c in ciphers):
-        fail("capabilities.write_allowed_ciphers entries must not contain ','")
     history = caps.get("policy_history")
     if not isinstance(history, list) or not history or len(history) > 4096:
         fail("capabilities.policy_history has an unexpected shape")
@@ -230,6 +226,8 @@ def main():
         prior_boundary = int(boundary)
     if history[0]["effective_from_seq"] != "1":
         fail("capabilities.policy_history must begin at sequence 1")
+    if next_boundary is not None and prior_boundary > int(next_boundary):
+        fail("capabilities.policy_history starts beyond the next sequence boundary")
     final = history[-1]
     if (
         final["policy_revision"] != policy_revision

--- a/scripts/internal/parse-revoke-response.py
+++ b/scripts/internal/parse-revoke-response.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Strictly validate an authenticated credential-revoke response."""
+
+import datetime
+import json
+import re
+import sys
+
+UUIDV7_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$")
+EXPECTED_KEYS = {
+    "protocol_version", "server_instance_id", "team_id", "credential_id",
+    "revoked", "revoked_at",
+}
+MAX_BODY_BYTES = 65_536
+
+
+def fail(message):
+    print(f"invalid revoke response: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def no_duplicate_keys(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            fail(f"duplicate JSON key '{key}'")
+        result[key] = value
+    return result
+
+
+def main():
+    if len(sys.argv) != 4:
+        fail("expected server_instance_id, team_id, and credential_id")
+    expected_server, expected_team, expected_credential = sys.argv[1:]
+    raw = sys.stdin.buffer.read(MAX_BODY_BYTES + 1)
+    if len(raw) > MAX_BODY_BYTES:
+        fail("response body exceeds its byte limit")
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=no_duplicate_keys)
+    except SystemExit:
+        raise
+    except Exception:
+        fail("response body is not strict UTF-8 JSON")
+    if not isinstance(value, dict) or set(value) != EXPECTED_KEYS:
+        fail("response object has an unexpected shape")
+    if value["protocol_version"] != 1 or value["revoked"] is not True:
+        fail("protocol_version or revoked flag is invalid")
+    for key, expected in (
+        ("server_instance_id", expected_server),
+        ("team_id", expected_team),
+        ("credential_id", expected_credential),
+    ):
+        actual = value.get(key)
+        if not isinstance(actual, str) or not UUIDV7_RE.fullmatch(actual) or actual != expected:
+            fail(f"{key} does not match the connected binding")
+    timestamp = value.get("revoked_at")
+    if not isinstance(timestamp, str) or not TIMESTAMP_RE.fullmatch(timestamp):
+        fail("revoked_at is not canonical UTC")
+    try:
+        parsed = datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError:
+        fail("revoked_at is not a real UTC timestamp")
+    if parsed.strftime("%Y-%m-%dT%H:%M:%S.%fZ") != timestamp:
+        fail("revoked_at is not canonical UTC")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
+import { constants } from "node:fs";
 import { spawn } from "node:child_process";
 import { appendFile, lstat, mkdir, open, readFile, rename, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve, sep } from "node:path";
@@ -7,8 +8,8 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { ageExecutableVersion, CipherStateError, openEnvelope,
   readNativeAgeIdentity } from "./sync-cipher.mjs";
-import { parseStrictJsonl } from "./strict-jsonl.mjs";
-export { parseStrictJsonl } from "./strict-jsonl.mjs";
+import { parseStrictJson, parseStrictJsonl } from "./strict-jsonl.mjs";
+export { parseStrictJson, parseStrictJsonl } from "./strict-jsonl.mjs";
 
 const UUID_V7 = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -16,10 +17,10 @@ const SEQUENCE = /^(0|[1-9][0-9]*)$/;
 const TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/;
 const PROTOCOL = "1";
 const MAX_SEQUENCE = 9_223_372_036_854_775_807n;
+const CREDENTIAL_ID = /^[A-Za-z0-9._-]{1,128}$/u;
 
 function usage() {
   return `usage:
-  remote-sync.sh configure --team NAME --server URL --team-id UUID --minimum-security plaintext-allowed
   remote-sync.sh configure --team NAME --server URL --team-id UUID --minimum-security e2ee-required \\
     --cipher age-v1 --age-snapshot FILE --age-checkpoint REVISION:SHA256 \\
     --age-confirmation operator-live \\
@@ -30,7 +31,8 @@ function usage() {
   remote-sync.sh resync --team NAME --accept-floor SEQUENCE
   remote-sync.sh unblock-read --team NAME --member-id UUID
 
-AGMSG_SYNC_TOKEN is required and is never written to config or argv.`;
+Run remote.sh connect first. The engine reads that team's private credential
+file directly; credentials are never accepted through argv or environment.`;
 }
 
 function options(args) {
@@ -74,6 +76,78 @@ function configPath(team) {
   return join(root, "remote-sync", `${encodeURIComponent(team)}.json`);
 }
 
+function teamConfigPath(team) {
+  const connectionRoot = process.env.AGMSG_SYNC_CONNECTION_DIR ?? process.env.SKILL_DIR;
+  if (!connectionRoot) throw new Error("sync connection root is unavailable");
+  return join(connectionRoot, "teams", team, "config.json");
+}
+
+function credentialPath(team) {
+  const connectionRoot = process.env.AGMSG_SYNC_CONNECTION_DIR ?? process.env.SKILL_DIR;
+  if (!connectionRoot) throw new Error("sync connection root is unavailable");
+  return join(connectionRoot, "run", "remote-credentials", `${team}.json`);
+}
+
+function connectedBinding(value, team) {
+  const binding = value?.remote_binding;
+  if (value?.name !== team || !binding || typeof binding !== "object" ||
+      typeof binding.endpoint !== "string" || binding.endpoint.length < 1 ||
+      !CREDENTIAL_ID.test(binding.credential_id ?? "") ||
+      !UUID_V7.test(binding.server_instance_id ?? "") ||
+      !UUID_V7.test(binding.remote_team_id ?? "") || binding.protocol_version !== 1 ||
+      typeof binding.connected_at !== "string" || Number.isNaN(Date.parse(binding.connected_at)) ||
+      binding.disconnected_at !== null || !binding.capabilities ||
+      !Array.isArray(binding.capabilities.write_allowed_ciphers) ||
+      binding.capabilities.write_allowed_ciphers.some((cipher) => typeof cipher !== "string")) {
+    throw new Error("connected team binding is invalid or disconnected");
+  }
+  const connectedEndpoint = new URL(binding.endpoint);
+  if (connectedEndpoint.protocol !== "https:" &&
+      (connectedEndpoint.protocol !== "http:" ||
+       !["127.0.0.1", "localhost", "[::1]"].includes(connectedEndpoint.hostname))) {
+    throw new Error("connected team endpoint must use HTTPS or exact loopback HTTP");
+  }
+  endpoint(binding.endpoint, "/v1/health");
+  return binding;
+}
+
+async function readConnectedBinding(team) {
+  const bytes = await readFile(teamConfigPath(team));
+  const source = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  return connectedBinding(parseStrictJson(source), team);
+}
+
+export async function readConnectedCredential(config) {
+  const path = credentialPath(config.local_team);
+  const before = await lstat(path);
+  if (!before.isFile() || before.isSymbolicLink() ||
+      (process.platform !== "win32" && (before.mode & 0o077) !== 0)) {
+    throw new Error("remote credential must be a private regular file");
+  }
+  const handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  try {
+    const metadata = await handle.stat();
+    if (!metadata.isFile() || metadata.dev !== before.dev || metadata.ino !== before.ino ||
+        (process.platform !== "win32" && (metadata.mode & 0o077) !== 0)) {
+      throw new Error("remote credential changed while it was being opened");
+    }
+    const source = new TextDecoder("utf-8", { fatal: true }).decode(await handle.readFile());
+    const records = parseStrictJsonl(source);
+    const value = records[0];
+    if (records.length !== 1 || !value || typeof value !== "object" || Array.isArray(value) ||
+        Object.keys(value).sort().join(",") !== "credential,credential_id" ||
+        typeof value.credential !== "string" || value.credential.length < 1 ||
+        /[\u0000-\u001f\u007f]/u.test(value.credential) ||
+        !CREDENTIAL_ID.test(value.credential_id) ||
+        (config.credential_id && value.credential_id !== config.credential_id)) {
+      throw new Error("remote credential file is invalid or does not match the binding");
+    }
+    return value.credential;
+  } finally {
+    await handle.close();
+  }
+}
+
 function ageTrustPath(config) {
   const root = process.env.AGMSG_SYNC_TRUST_DIR;
   if (!root) throw new Error("AGMSG_SYNC_TRUST_DIR is required for age-v1 and must survive sync-state reset");
@@ -94,8 +168,36 @@ async function writeConfig(path, value) {
   await rename(temporary, path);
 }
 
-async function loadConfig(team) {
-  const value = JSON.parse(await readFile(configPath(team), "utf8"));
+export async function loadConfig(team) {
+  const binding = await readConnectedBinding(team);
+  let value;
+  try {
+    const bytes = await readFile(configPath(team));
+    value = parseStrictJson(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+    if (!binding.capabilities.write_allowed_ciphers.includes("none")) {
+      throw new Error("connected team requires an authenticated age-v1 sync configuration");
+    }
+    value = {
+      format_version: 1,
+      local_team: team,
+      server_url: binding.endpoint,
+      server_instance_id: binding.server_instance_id,
+      remote_team_id: binding.remote_team_id,
+      protocol_version: binding.protocol_version,
+      cipher_profile: "none",
+      local_security_history: [{ local_security_revision: "0", effective_from_seq: "1",
+        minimum_security_mode: "plaintext-allowed" }],
+    };
+  }
+  if (value.server_url !== binding.endpoint ||
+      value.server_instance_id !== binding.server_instance_id ||
+      value.remote_team_id !== binding.remote_team_id ||
+      value.protocol_version !== binding.protocol_version) {
+    throw new Error("sync configuration does not match the connected team binding");
+  }
+  value.credential_id = binding.credential_id;
   if (value.local_team !== team || value.protocol_version !== 1 ||
       !UUID_V7.test(value.server_instance_id) || !UUID_V7.test(value.remote_team_id)) {
     throw new Error("sync config binding is invalid");
@@ -107,6 +209,7 @@ async function loadConfig(team) {
     await validateRetainedAgeCheckpoint(value);
   }
   else if (value.cipher_profile !== "none") throw new Error("sync cipher profile is unsupported");
+  await readConnectedCredential(value);
   return value;
 }
 
@@ -355,8 +458,7 @@ function endpoint(base, path) {
 }
 
 export async function request(config, path, init = {}) {
-  const token = process.env.AGMSG_SYNC_TOKEN;
-  if (!token) throw new Error("AGMSG_SYNC_TOKEN is required");
+  const token = await readConnectedCredential(config);
   const headers = {
     "Agmsg-Protocol-Version": PROTOCOL,
     "Agmsg-Team-ID": config.remote_team_id,
@@ -489,6 +591,7 @@ export async function driver(operation, config, input, extra = []) {
   return new Promise((resolve, reject) => {
     const childEnvironment = { ...process.env };
     delete childEnvironment.AGMSG_SYNC_TOKEN;
+    delete childEnvironment.AGMSG_SYNC_CONNECTION_DIR;
     delete childEnvironment.AGMSG_SYNC_TRUST_DIR;
     for (const key of Object.keys(childEnvironment)) {
       if (/^(?:AGMSG_AGE_IDENTITY|AGMSG_SYNC_AGE_IDENTITY)/u.test(key)) {
@@ -988,13 +1091,19 @@ async function configure(args) {
       (cipherProfile === "age-v1" && minimumSecurity !== "e2ee-required")) {
     throw new Error(`${cipherProfile} requires its explicit matching minimum-security mode`);
   }
-  if (!process.env.AGMSG_SYNC_TOKEN) throw new Error("AGMSG_SYNC_TOKEN is required");
   const serverUrl = new URL(args.server).toString().replace(/\/$/, "");
+  const binding = await readConnectedBinding(team);
+  if (serverUrl !== binding.endpoint || args["team-id"] !== binding.remote_team_id) {
+    throw new Error("configure binding does not match remote.sh connect");
+  }
   const ready = await health(serverUrl);
+  if (ready.server_instance_id !== binding.server_instance_id) {
+    throw new Error("health server instance does not match remote.sh connect");
+  }
   const config = {
     format_version: 1, local_team: team, server_url: serverUrl,
     server_instance_id: ready.server_instance_id, remote_team_id: args["team-id"],
-    protocol_version: 1, cipher_profile: cipherProfile,
+    protocol_version: 1, credential_id: binding.credential_id, cipher_profile: cipherProfile,
     local_security_history: [{ local_security_revision: "0", effective_from_seq: "1",
       minimum_security_mode: minimumSecurity }],
   };

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -17,7 +17,8 @@ const SEQUENCE = /^(0|[1-9][0-9]*)$/;
 const TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/;
 const PROTOCOL = "1";
 const MAX_SEQUENCE = 9_223_372_036_854_775_807n;
-const CREDENTIAL_ID = /^[A-Za-z0-9._-]{1,128}$/u;
+const MAX_CONNECTION_CONFIG_BYTES = 2 * 1024 * 1024;
+const MAX_CREDENTIAL_BYTES = 64 * 1024;
 
 function usage() {
   return `usage:
@@ -92,7 +93,7 @@ function connectedBinding(value, team) {
   const binding = value?.remote_binding;
   if (value?.name !== team || !binding || typeof binding !== "object" ||
       typeof binding.endpoint !== "string" || binding.endpoint.length < 1 ||
-      !CREDENTIAL_ID.test(binding.credential_id ?? "") ||
+      !UUID_V7.test(binding.credential_id ?? "") ||
       !UUID_V7.test(binding.server_instance_id ?? "") ||
       !UUID_V7.test(binding.remote_team_id ?? "") || binding.protocol_version !== 1 ||
       typeof binding.connected_at !== "string" || Number.isNaN(Date.parse(binding.connected_at)) ||
@@ -111,41 +112,59 @@ function connectedBinding(value, team) {
   return binding;
 }
 
+async function readBoundedAuthorityFile(path, maxBytes, privateFile) {
+  const before = await lstat(path);
+  const unsafeMode = process.platform !== "win32" &&
+    (before.mode & (privateFile ? 0o077 : 0o022)) !== 0;
+  if (!before.isFile() || before.isSymbolicLink() || unsafeMode || before.size > maxBytes) {
+    throw new Error(privateFile ? "remote credential must be a private regular file" :
+      "connected team binding must be a non-writable regular file");
+  }
+  const handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  try {
+    const metadata = await handle.stat();
+    const changed = !metadata.isFile() || metadata.dev !== before.dev || metadata.ino !== before.ino ||
+      metadata.size > maxBytes || (process.platform !== "win32" &&
+      (metadata.mode & (privateFile ? 0o077 : 0o022)) !== 0);
+    if (changed) throw new Error("connection authority changed while it was being opened");
+    const chunks = [];
+    let total = 0;
+    for (;;) {
+      const buffer = Buffer.alloc(Math.min(64 * 1024, maxBytes - total + 1));
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      if (total > maxBytes) throw new Error("connection authority exceeds its byte limit");
+      chunks.push(buffer.subarray(0, bytesRead));
+    }
+    return Buffer.concat(chunks);
+  } finally {
+    await handle.close();
+  }
+}
+
 async function readConnectedBinding(team) {
-  const bytes = await readFile(teamConfigPath(team));
+  const bytes = await readBoundedAuthorityFile(
+    teamConfigPath(team), MAX_CONNECTION_CONFIG_BYTES, false);
   const source = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   return connectedBinding(parseStrictJson(source), team);
 }
 
 export async function readConnectedCredential(config) {
   const path = credentialPath(config.local_team);
-  const before = await lstat(path);
-  if (!before.isFile() || before.isSymbolicLink() ||
-      (process.platform !== "win32" && (before.mode & 0o077) !== 0)) {
-    throw new Error("remote credential must be a private regular file");
+  const source = new TextDecoder("utf-8", { fatal: true }).decode(
+    await readBoundedAuthorityFile(path, MAX_CREDENTIAL_BYTES, true));
+  const records = parseStrictJsonl(source);
+  const value = records[0];
+  if (records.length !== 1 || !value || typeof value !== "object" || Array.isArray(value) ||
+      Object.keys(value).sort().join(",") !== "credential,credential_id" ||
+      typeof value.credential !== "string" || value.credential.length < 1 ||
+      /[\u0000-\u001f\u007f]/u.test(value.credential) ||
+      !UUID_V7.test(value.credential_id) ||
+      (config.credential_id && value.credential_id !== config.credential_id)) {
+    throw new Error("remote credential file is invalid or does not match the binding");
   }
-  const handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
-  try {
-    const metadata = await handle.stat();
-    if (!metadata.isFile() || metadata.dev !== before.dev || metadata.ino !== before.ino ||
-        (process.platform !== "win32" && (metadata.mode & 0o077) !== 0)) {
-      throw new Error("remote credential changed while it was being opened");
-    }
-    const source = new TextDecoder("utf-8", { fatal: true }).decode(await handle.readFile());
-    const records = parseStrictJsonl(source);
-    const value = records[0];
-    if (records.length !== 1 || !value || typeof value !== "object" || Array.isArray(value) ||
-        Object.keys(value).sort().join(",") !== "credential,credential_id" ||
-        typeof value.credential !== "string" || value.credential.length < 1 ||
-        /[\u0000-\u001f\u007f]/u.test(value.credential) ||
-        !CREDENTIAL_ID.test(value.credential_id) ||
-        (config.credential_id && value.credential_id !== config.credential_id)) {
-      throw new Error("remote credential file is invalid or does not match the binding");
-    }
-    return value.credential;
-  } finally {
-    await handle.close();
-  }
+  return value.credential;
 }
 
 function ageTrustPath(config) {
@@ -169,7 +188,8 @@ async function writeConfig(path, value) {
 }
 
 async function readStoredSyncConfig(team) {
-  const bytes = await readFile(configPath(team));
+  const bytes = await readBoundedAuthorityFile(
+    configPath(team), MAX_CONNECTION_CONFIG_BYTES, false);
   return parseStrictJson(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
 }
 
@@ -464,10 +484,10 @@ function endpoint(base, path) {
 export async function request(config, path, init = {}) {
   const token = await readConnectedCredential(config);
   const headers = {
+    ...init.headers,
     "Agmsg-Protocol-Version": PROTOCOL,
     "Agmsg-Team-ID": config.remote_team_id,
     Authorization: `Bearer ${token}`,
-    ...init.headers,
   };
   const url = endpoint(config.server_url, path);
   let response;
@@ -1088,7 +1108,7 @@ async function existingConfig(team) {
   }
 }
 
-async function configure(args) {
+export async function configure(args) {
   const team = requireName(args.team, "team");
   if (!UUID_V7.test(args["team-id"] ?? "")) throw new Error("team-id must be a canonical UUIDv7");
   const cipherProfile = args.cipher ?? "none";
@@ -1137,8 +1157,6 @@ async function configure(args) {
     };
     validateAgeConfiguration(config);
     validateConfiguredAgeIdentities(config);
-    const retained = await retainAgeCheckpoint(config, confirmation);
-    config.age_v1.checkpoint.confirmed_at = retained.confirmation.confirmed_at;
   } else if (args["age-snapshot"] || args["age-checkpoint"] || args["age-confirmation"] ||
       args["age-identity"]) {
     throw new Error("age options require --cipher age-v1");
@@ -1156,6 +1174,10 @@ async function configure(args) {
   }
   const capabilities = await request(config, "/v1/capabilities");
   validateCapabilities(config, capabilities);
+  if (cipherProfile === "age-v1") {
+    const retained = await retainAgeCheckpoint(config, args["age-confirmation"]);
+    config.age_v1.checkpoint.confirmed_at = retained.confirmation.confirmed_at;
+  }
   await writeConfig(configPath(team), config);
   await event("configured", { team, server_instance_id: config.server_instance_id,
     remote_team_id: config.remote_team_id });

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -168,12 +168,16 @@ async function writeConfig(path, value) {
   await rename(temporary, path);
 }
 
+async function readStoredSyncConfig(team) {
+  const bytes = await readFile(configPath(team));
+  return parseStrictJson(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+}
+
 export async function loadConfig(team) {
   const binding = await readConnectedBinding(team);
   let value;
   try {
-    const bytes = await readFile(configPath(team));
-    value = parseStrictJson(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+    value = await readStoredSyncConfig(team);
   } catch (error) {
     if (error?.code !== "ENOENT") throw error;
     if (!binding.capabilities.write_allowed_ciphers.includes("none")) {
@@ -1074,7 +1078,10 @@ async function identityFiles(values) {
 }
 
 async function existingConfig(team) {
-  try { return await loadConfig(team); }
+  try {
+    await readStoredSyncConfig(team);
+    return await loadConfig(team);
+  }
   catch (error) {
     if (error?.code === "ENOENT") return null;
     throw error;

--- a/scripts/internal/strict-jsonl.mjs
+++ b/scripts/internal/strict-jsonl.mjs
@@ -56,11 +56,15 @@ function rejectDuplicateJsonKeys(source) {
   if (offset !== source.length) throw new Error("JSON framing is invalid");
 }
 
+export function parseStrictJson(value) {
+  rejectDuplicateJsonKeys(value);
+  return JSON.parse(value);
+}
+
 export function parseStrictJsonl(value) {
   const lines = value.split(/\r?\n/u).filter((line) => line.trim().length > 0);
   return lines.map((line) => {
-    rejectDuplicateJsonKeys(line);
-    return JSON.parse(line);
+    return parseStrictJson(line);
   });
 }
 

--- a/scripts/internal/validate-protocol-header.py
+++ b/scripts/internal/validate-protocol-header.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Validate the final HTTP response block's v1 protocol header."""
+
+import re
+import sys
+
+MAX_HEADER_BYTES = 65_536
+STATUS_RE = re.compile(r"^HTTP/\S+ ([0-9]{3})(?: |$)")
+
+
+def fail(message):
+    print(f"invalid protocol response header: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main():
+    raw = sys.stdin.buffer.read(MAX_HEADER_BYTES + 1)
+    if len(raw) > MAX_HEADER_BYTES:
+        fail("header block exceeds its byte limit")
+    try:
+        text = raw.decode("iso-8859-1")
+    except UnicodeDecodeError:
+        fail("header block is not decodable")
+
+    blocks = []
+    current = []
+    for line in text.replace("\r\n", "\n").split("\n"):
+        if line == "":
+            if current:
+                blocks.append(current)
+                current = []
+            continue
+        current.append(line)
+    if current:
+        blocks.append(current)
+
+    final = None
+    for block in blocks:
+        match = STATUS_RE.match(block[0]) if block else None
+        if not match:
+            fail("malformed HTTP status line")
+        if int(match.group(1)) >= 200:
+            final = block
+    if final is None:
+        fail("no final HTTP response block")
+
+    values = []
+    for line in final[1:]:
+        if line[:1] in (" ", "\t") or ":" not in line:
+            fail("malformed response header field")
+        name, value = line.split(":", 1)
+        if name.lower() == "agmsg-protocol-version":
+            values.append(value.strip())
+    if values != ["1"]:
+        fail("Agmsg-Protocol-Version must occur exactly once with value 1")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONNECTION_ROOT="${AGMSG_SYNC_CONNECTION_DIR:-$SKILL_DIR}"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/storage.sh"
 # shellcheck disable=SC1091
@@ -23,8 +24,8 @@ source "$SCRIPT_DIR/lib/registry-lock.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/validate.sh"
 
-TEAMS_DIR="$SCRIPT_DIR/../teams"
-CRED_ROOT="$SKILL_DIR/run/remote-credentials"
+TEAMS_DIR="$CONNECTION_ROOT/teams"
+CRED_ROOT="$CONNECTION_ROOT/run/remote-credentials"
 
 # Escape interpolated identifiers as SQL string literals (parity with
 # rename.sh/send.sh): a value with a single quote would break the query.

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -101,20 +101,43 @@ cmd_doctor() {
 # body (which holds the token) never appears in curl's own argv/ps. The
 # config file is 0600 and removed immediately after the call.
 _remote_http_post_json() {
-  local url="$1" body_file="$2" out_file="$3" header_file="$4" cfg http_code
+  local url="$1" body_file="$2" out_file="$3" header_file="$4" cfg http_code \
+    fifo_dir header_fifo copier_pid curl_output curl_status=0
   cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
+  fifo_dir="$(mktemp -d "${TMPDIR:-/tmp}/agmsg-header-pipe.XXXXXX")"
+  header_fifo="$fifo_dir/header"
+  mkfifo "$header_fifo"
   chmod 600 "$cfg"
-  trap 'rm -f "$cfg"' EXIT INT TERM
+  trap 'rm -f "$cfg" "$header_fifo"; rmdir "$fifo_dir" 2>/dev/null || true' EXIT INT TERM
+  python3 "$SCRIPT_DIR/internal/bounded-copy.py" 65536 < "$header_fifo" > "$header_file" &
+  copier_pid=$!
   {
     printf 'url = "%s"\n' "$url"
     printf 'request = "POST"\n'
     printf 'header = "Content-Type: application/json"\n'
     printf 'header = "Agmsg-Protocol-Version: 1"\n'
-    printf 'dump-header = "%s"\n' "$header_file"
+    printf 'dump-header = "%s"\n' "$header_fifo"
+    printf 'connect-timeout = "10"\n'
+    printf 'max-time = "15"\n'
+    printf 'max-filesize = "2097152"\n'
     printf 'data = "@%s"\n' "$body_file"
   } > "$cfg"
-  http_code=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>/dev/null) || http_code="000"
-  rm -f "$cfg"
+  if curl_output=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>/dev/null); then
+    :
+  else
+    curl_status=$?
+  fi
+  if [ "$curl_status" -ne 0 ]; then
+    kill "$copier_pid" 2>/dev/null || true
+    wait "$copier_pid" 2>/dev/null || true
+    http_code="000"
+  elif wait "$copier_pid"; then
+    http_code="$curl_output"
+  else
+    http_code="000"
+  fi
+  rm -f "$cfg" "$header_fifo"
+  rmdir "$fifo_dir" 2>/dev/null || true
   trap - EXIT INT TERM
   printf '%s' "$http_code"
 }
@@ -123,20 +146,43 @@ _remote_http_post_json() {
 # -> prints http_code
 # Same argv-safety property for the Authorization header (revoke calls).
 _remote_http_post_bearer() {
-  local url="$1" team_id="$2" token="$3" out_file="$4" header_file="$5" cfg http_code
+  local url="$1" team_id="$2" token="$3" out_file="$4" header_file="$5" cfg http_code \
+    fifo_dir header_fifo copier_pid curl_output curl_status=0
   cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
+  fifo_dir="$(mktemp -d "${TMPDIR:-/tmp}/agmsg-header-pipe.XXXXXX")"
+  header_fifo="$fifo_dir/header"
+  mkfifo "$header_fifo"
   chmod 600 "$cfg"
-  trap 'rm -f "$cfg"' EXIT INT TERM
+  trap 'rm -f "$cfg" "$header_fifo"; rmdir "$fifo_dir" 2>/dev/null || true' EXIT INT TERM
+  python3 "$SCRIPT_DIR/internal/bounded-copy.py" 65536 < "$header_fifo" > "$header_file" &
+  copier_pid=$!
   {
     printf 'url = "%s"\n' "$url"
     printf 'request = "POST"\n'
     printf 'header = "Authorization: Bearer %s"\n' "$token"
     printf 'header = "Agmsg-Protocol-Version: 1"\n'
     printf 'header = "Agmsg-Team-ID: %s"\n' "$team_id"
-    printf 'dump-header = "%s"\n' "$header_file"
+    printf 'dump-header = "%s"\n' "$header_fifo"
+    printf 'connect-timeout = "10"\n'
+    printf 'max-time = "15"\n'
+    printf 'max-filesize = "65536"\n'
   } > "$cfg"
-  http_code=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>/dev/null) || http_code="000"
-  rm -f "$cfg"
+  if curl_output=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>/dev/null); then
+    :
+  else
+    curl_status=$?
+  fi
+  if [ "$curl_status" -ne 0 ]; then
+    kill "$copier_pid" 2>/dev/null || true
+    wait "$copier_pid" 2>/dev/null || true
+    http_code="000"
+  elif wait "$copier_pid"; then
+    http_code="$curl_output"
+  else
+    http_code="000"
+  fi
+  rm -f "$cfg" "$header_fifo"
+  rmdir "$fifo_dir" 2>/dev/null || true
   trap - EXIT INT TERM
   printf '%s' "$http_code"
 }
@@ -265,7 +311,8 @@ import json, sys
 resp_path, endpoint = sys.argv[1], sys.argv[2]
 with open(resp_path) as f:
     raw_response_text = f.read()
-print(json.dumps({"endpoint": endpoint, "raw_response_text": raw_response_text}))
+print(json.dumps({"endpoint": endpoint, "protocol_header_verified": True,
+                  "raw_response_text": raw_response_text}))
 ' "$resp_file" "$endpoint")
   tmp="$(mktemp "$PENDING_DIR/.pending-XXXXXX")"
   chmod 600 "$tmp"
@@ -292,6 +339,9 @@ import json, sys
 pending_path, out_path = sys.argv[1], sys.argv[2]
 with open(pending_path) as f:
     pending = json.load(f)
+if set(pending) != {"endpoint", "protocol_header_verified", "raw_response_text"} or \
+        pending["protocol_header_verified"] is not True:
+    raise SystemExit("pending record predates mandatory protocol-header verification")
 with open(out_path, "w") as f:
     f.write(pending["raw_response_text"])
 print(pending["endpoint"])
@@ -436,7 +486,11 @@ cmd_connect() {
     local pending_resp_file pending_endpoint parsed_file
     pending_resp_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-pending-resp.XXXXXX")"
     chmod 600 "$pending_resp_file"
-    pending_endpoint="$(_remote_load_pending "$pending_file" "$pending_resp_file")"
+    if ! pending_endpoint="$(_remote_load_pending "$pending_file" "$pending_resp_file")"; then
+      rm -f "$pending_file" "$pending_resp_file"
+      echo "agmsg: discarded a legacy pending exchange without a verified protocol header; issue a fresh pairing token and retry." >&2
+      exit 1
+    fi
     if [ -z "$pending_endpoint" ] || [ "$pending_endpoint" != "$endpoint" ]; then
       rm -f "$pending_resp_file"
       echo "agmsg: pending record's endpoint does not match — refusing to resume." >&2

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -337,15 +337,44 @@ _remote_load_pending() {
   python3 -c '
 import json, sys
 pending_path, out_path = sys.argv[1], sys.argv[2]
-with open(pending_path) as f:
-    pending = json.load(f)
+def strict_object(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError("duplicate pending key")
+        value[key] = item
+    return value
+with open(pending_path, "rb") as f:
+    encoded = f.read(16 * 1024 * 1024 + 1)
+if len(encoded) > 16 * 1024 * 1024:
+    raise SystemExit(1)
+pending = json.loads(encoded.decode("utf-8"), object_pairs_hook=strict_object)
+if not isinstance(pending, dict) or not isinstance(pending.get("endpoint"), str) or \
+        not 1 <= len(pending["endpoint"].encode("utf-8")) <= 2048 or \
+        not isinstance(pending.get("raw_response_text"), str) or \
+        len(pending["raw_response_text"].encode("utf-8")) > 2 * 1024 * 1024:
+    raise SystemExit(1)
+if set(pending) == {"endpoint", "raw_response_text"}:
+    raise SystemExit(42)
 if set(pending) != {"endpoint", "protocol_header_verified", "raw_response_text"} or \
         pending["protocol_header_verified"] is not True:
-    raise SystemExit("pending record predates mandatory protocol-header verification")
+    raise SystemExit(1)
 with open(out_path, "w") as f:
     f.write(pending["raw_response_text"])
 print(pending["endpoint"])
 ' "$pending_file" "$out_resp_file"
+}
+
+# Preserve an exchange response that cannot be resumed automatically. It may
+# be the only remaining recovery material for an already-issued credential;
+# deleting it would orphan a still-active server credential. The path remains
+# inside the private pending directory and is forced to 0600.
+_remote_quarantine_pending() {
+  local pending_file="$1" reason="$2" target
+  target="${pending_file}.${reason}.$(date -u +%Y%m%dT%H%M%SZ).$$"
+  mv "$pending_file" "$target" || return 1
+  chmod 600 "$target"
+  printf '%s' "$target"
 }
 
 # _remote_commit <team> <cfg> <endpoint> <credential> <credential_id>
@@ -486,9 +515,24 @@ cmd_connect() {
     local pending_resp_file pending_endpoint parsed_file
     pending_resp_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-pending-resp.XXXXXX")"
     chmod 600 "$pending_resp_file"
-    if ! pending_endpoint="$(_remote_load_pending "$pending_file" "$pending_resp_file")"; then
-      rm -f "$pending_file" "$pending_resp_file"
-      echo "agmsg: discarded a legacy pending exchange without a verified protocol header; issue a fresh pairing token and retry." >&2
+    local pending_load_status=0 quarantine_reason quarantine_path
+    if pending_endpoint="$(_remote_load_pending "$pending_file" "$pending_resp_file")"; then
+      :
+    else
+      pending_load_status=$?
+      rm -f "$pending_resp_file"
+      if [ "$pending_load_status" -eq 42 ]; then
+        quarantine_reason="unverified"
+        echo "agmsg: refusing to resume a legacy pending exchange without a verified protocol header." >&2
+      else
+        quarantine_reason="invalid"
+        echo "agmsg: refusing to resume a malformed pending exchange record." >&2
+      fi
+      if quarantine_path="$(_remote_quarantine_pending "$pending_file" "$quarantine_reason")"; then
+        echo "agmsg: preserved the 0600 recovery record at $quarantine_path. Do not share it; use the server admin credential list/revoke workflow before issuing a fresh pairing token." >&2
+      else
+        echo "agmsg: could not quarantine the recovery record; it remains at $pending_file. Do not delete or share it." >&2
+      fi
       exit 1
     fi
     if [ -z "$pending_endpoint" ] || [ "$pending_endpoint" != "$endpoint" ]; then

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -96,12 +96,12 @@ cmd_doctor() {
 
 # --- shared HTTP helpers (B1: never put secrets in curl's own argv/ps) ---
 
-# _remote_http_post_json <url> <body_file> <out_body_file> -> prints http_code
+# _remote_http_post_json <url> <body_file> <out_body_file> <out_header_file> -> prints http_code
 # Posts <body_file> as the request body via a curl -K config file, so the
 # body (which holds the token) never appears in curl's own argv/ps. The
 # config file is 0600 and removed immediately after the call.
 _remote_http_post_json() {
-  local url="$1" body_file="$2" out_file="$3" cfg http_code
+  local url="$1" body_file="$2" out_file="$3" header_file="$4" cfg http_code
   cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
   chmod 600 "$cfg"
   trap 'rm -f "$cfg"' EXIT INT TERM
@@ -110,6 +110,7 @@ _remote_http_post_json() {
     printf 'request = "POST"\n'
     printf 'header = "Content-Type: application/json"\n'
     printf 'header = "Agmsg-Protocol-Version: 1"\n'
+    printf 'dump-header = "%s"\n' "$header_file"
     printf 'data = "@%s"\n' "$body_file"
   } > "$cfg"
   http_code=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>/dev/null) || http_code="000"
@@ -118,10 +119,11 @@ _remote_http_post_json() {
   printf '%s' "$http_code"
 }
 
-# _remote_http_post_bearer <url> <team_id> <bearer_token> -> prints http_code
+# _remote_http_post_bearer <url> <team_id> <bearer_token> <out_body_file> <out_header_file>
+# -> prints http_code
 # Same argv-safety property for the Authorization header (revoke calls).
 _remote_http_post_bearer() {
-  local url="$1" team_id="$2" token="$3" cfg http_code
+  local url="$1" team_id="$2" token="$3" out_file="$4" header_file="$5" cfg http_code
   cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
   chmod 600 "$cfg"
   trap 'rm -f "$cfg"' EXIT INT TERM
@@ -131,14 +133,16 @@ _remote_http_post_bearer() {
     printf 'header = "Authorization: Bearer %s"\n' "$token"
     printf 'header = "Agmsg-Protocol-Version: 1"\n'
     printf 'header = "Agmsg-Team-ID: %s"\n' "$team_id"
+    printf 'dump-header = "%s"\n' "$header_file"
   } > "$cfg"
-  http_code=$(curl -sS -o /dev/null -w '%{http_code}' -K "$cfg" 2>/dev/null) || http_code="000"
+  http_code=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>/dev/null) || http_code="000"
   rm -f "$cfg"
   trap - EXIT INT TERM
   printf '%s' "$http_code"
 }
 
-# _remote_revoke <endpoint> <team_id> <credential_id> <credential> -> 0 revoked, 1 not
+# _remote_revoke <endpoint> <server_instance_id> <team_id> <credential_id> <credential>
+# -> 0 revoked and response-bound, 1 not
 # STRICTLY 200 only (E2 — reverted from an earlier "200 or 404 both
 # count" version): a bare HTTP 404 status is not trustworthy proof the
 # credential is actually gone. It's equally consistent with a wrong
@@ -152,9 +156,21 @@ _remote_http_post_bearer() {
 # anything but 200 — a stuck retry (requiring a console-side revoke) is
 # the correct failure mode here, not a false "confirmed revoked."
 _remote_revoke() {
-  local endpoint="$1" team_id="$2" credential_id="$3" credential="$4" http_code
-  http_code="$(_remote_http_post_bearer "$endpoint/v1/credentials/$credential_id/revoke" "$team_id" "$credential")"
-  [ "$http_code" = "200" ]
+  (
+    local endpoint="$1" server_instance_id="$2" team_id="$3" credential_id="$4" \
+      credential="$5" http_code body_file header_file
+    body_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-revoke-body.XXXXXX")"
+    header_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-revoke-header.XXXXXX")"
+    chmod 600 "$body_file" "$header_file"
+    trap 'rm -f "$body_file" "$header_file"' EXIT INT TERM
+    http_code="$(_remote_http_post_bearer \
+      "$endpoint/v1/credentials/$credential_id/revoke" "$team_id" "$credential" \
+      "$body_file" "$header_file")"
+    [ "$http_code" = "200" ] || exit 1
+    python3 "$SCRIPT_DIR/internal/validate-protocol-header.py" < "$header_file" || exit 1
+    python3 "$SCRIPT_DIR/internal/parse-revoke-response.py" \
+      "$server_instance_id" "$team_id" "$credential_id" < "$body_file" || exit 1
+  )
 }
 
 # _remote_local_disconnect <team> <cfg> [expected_credential_id]
@@ -468,14 +484,17 @@ cmd_connect() {
         # does not yet build a durable orphan/revocation-pending queue for
         # the unreachable case; it fails closed and asks the operator to
         # retry or revoke from the console/admin side.
-        local old_endpoint old_remote_team_id old_credential
+        local old_endpoint old_server_instance_id old_remote_team_id old_credential
         old_endpoint="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.endpoint')"
+        old_server_instance_id="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.server_instance_id')"
         old_remote_team_id="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.remote_team_id')"
         old_credential="$(python3 -c "import json,sys; print(json.load(open('$(_remote_cred_file "$team")')).get('credential',''))" 2>/dev/null || true)"
         if [ -z "$existing_credential_id" ] || [ "$existing_credential_id" = "null" ] \
           || [ -z "$old_endpoint" ] || [ "$old_endpoint" = "null" ] || [ -z "$old_credential" ] \
+          || [ -z "$old_server_instance_id" ] || [ "$old_server_instance_id" = "null" ] \
           || [ -z "$old_remote_team_id" ] || [ "$old_remote_team_id" = "null" ] \
-          || ! _remote_revoke "$old_endpoint" "$old_remote_team_id" "$existing_credential_id" "$old_credential"; then
+          || ! _remote_revoke "$old_endpoint" "$old_server_instance_id" "$old_remote_team_id" \
+            "$existing_credential_id" "$old_credential"; then
           echo "agmsg: --force rebind refused — could not confirm the existing credential ($existing_credential_id) was revoked. Revoke it from the console/admin side, or retry once the server is reachable, before rebinding." >&2
           exit 1
         fi
@@ -509,12 +528,14 @@ cmd_connect() {
     fi
 
     # The only network call that can fail before any local state changes.
-    local body_file resp_file http_code token_json
+    local body_file resp_file header_file http_code token_json
     body_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-connect-body.XXXXXX")"
     chmod 600 "$body_file"
     resp_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-connect-resp.XXXXXX")"
     chmod 600 "$resp_file"
-    trap 'rm -f "$body_file" "$resp_file"' EXIT INT TERM
+    header_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-connect-header.XXXXXX")"
+    chmod 600 "$header_file"
+    trap 'rm -f "$body_file" "$resp_file" "$header_file"' EXIT INT TERM
 
     token_json="$(printf '%s' "$token" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null)"
     unset token
@@ -525,7 +546,8 @@ cmd_connect() {
     printf '{"token":%s}' "$token_json" > "$body_file"
     unset token_json
 
-    http_code="$(_remote_http_post_json "$endpoint/v1/pairing/exchange" "$body_file" "$resp_file")"
+    http_code="$(_remote_http_post_json "$endpoint/v1/pairing/exchange" \
+      "$body_file" "$resp_file" "$header_file")"
     rm -f "$body_file"
 
     if [ "$http_code" != "200" ]; then
@@ -533,6 +555,11 @@ cmd_connect() {
       rm -f "$resp_file"
       exit 1
     fi
+    if ! python3 "$SCRIPT_DIR/internal/validate-protocol-header.py" < "$header_file"; then
+      rm -f "$resp_file" "$header_file"
+      exit 1
+    fi
+    rm -f "$header_file"
 
     # Strict validation (B6) BEFORE any field is used — a malformed/
     # malicious response must not reach state mutation, and credential_id
@@ -784,9 +811,10 @@ cmd_disconnect() {
     exit 1
   fi
 
-  local cred_file endpoint remote_team_id credential_id credential
+  local cred_file endpoint server_instance_id remote_team_id credential_id credential
   cred_file="$(_remote_cred_file "$team")"
   endpoint="$(_remote_read_config_field "$cfg" '$.remote_binding.endpoint')"
+  server_instance_id="$(_remote_read_config_field "$cfg" '$.remote_binding.server_instance_id')"
   remote_team_id="$(_remote_read_config_field "$cfg" '$.remote_binding.remote_team_id')"
   credential_id="$(_remote_read_config_field "$cfg" '$.remote_binding.credential_id')"
 
@@ -796,8 +824,10 @@ cmd_disconnect() {
   local revoke_ok=0
   if [ -f "$cred_file" ] && [ -n "$endpoint" ] && [ "$endpoint" != "null" ] && [ -n "$credential_id" ] && [ "$credential_id" != "null" ]; then
     credential="$(python3 -c "import json,sys; print(json.load(open('$cred_file')).get('credential',''))" 2>/dev/null)"
-    if [ -n "$credential" ] && [ -n "$remote_team_id" ] && [ "$remote_team_id" != "null" ] \
-      && _remote_revoke "$endpoint" "$remote_team_id" "$credential_id" "$credential"; then
+    if [ -n "$credential" ] && [ -n "$server_instance_id" ] && [ "$server_instance_id" != "null" ] \
+      && [ -n "$remote_team_id" ] && [ "$remote_team_id" != "null" ] \
+      && _remote_revoke "$endpoint" "$server_instance_id" "$remote_team_id" \
+        "$credential_id" "$credential"; then
       revoke_ok=1
     fi
     unset credential

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONNECTION_ROOT="${AGMSG_SYNC_CONNECTION_DIR:-$SKILL_DIR}"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/storage.sh"
 # shellcheck disable=SC1091
@@ -22,9 +23,9 @@ source "$SCRIPT_DIR/lib/registry-lock.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/validate.sh"
 
-TEAMS_DIR="$SCRIPT_DIR/../teams"
-CRED_ROOT="$SKILL_DIR/run/remote-credentials"
-PENDING_DIR="$SKILL_DIR/run/remote-connect-pending"
+TEAMS_DIR="$CONNECTION_ROOT/teams"
+CRED_ROOT="$CONNECTION_ROOT/run/remote-credentials"
+PENDING_DIR="$CONNECTION_ROOT/run/remote-connect-pending"
 
 _agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
 
@@ -108,6 +109,7 @@ _remote_http_post_json() {
     printf 'url = "%s"\n' "$url"
     printf 'request = "POST"\n'
     printf 'header = "Content-Type: application/json"\n'
+    printf 'header = "Agmsg-Protocol-Version: 1"\n'
     printf 'data = "@%s"\n' "$body_file"
   } > "$cfg"
   http_code=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>/dev/null) || http_code="000"
@@ -116,10 +118,10 @@ _remote_http_post_json() {
   printf '%s' "$http_code"
 }
 
-# _remote_http_post_bearer <url> <bearer_token> -> prints http_code
+# _remote_http_post_bearer <url> <team_id> <bearer_token> -> prints http_code
 # Same argv-safety property for the Authorization header (revoke calls).
 _remote_http_post_bearer() {
-  local url="$1" token="$2" cfg http_code
+  local url="$1" team_id="$2" token="$3" cfg http_code
   cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
   chmod 600 "$cfg"
   trap 'rm -f "$cfg"' EXIT INT TERM
@@ -127,6 +129,8 @@ _remote_http_post_bearer() {
     printf 'url = "%s"\n' "$url"
     printf 'request = "POST"\n'
     printf 'header = "Authorization: Bearer %s"\n' "$token"
+    printf 'header = "Agmsg-Protocol-Version: 1"\n'
+    printf 'header = "Agmsg-Team-ID: %s"\n' "$team_id"
   } > "$cfg"
   http_code=$(curl -sS -o /dev/null -w '%{http_code}' -K "$cfg" 2>/dev/null) || http_code="000"
   rm -f "$cfg"
@@ -134,7 +138,7 @@ _remote_http_post_bearer() {
   printf '%s' "$http_code"
 }
 
-# _remote_revoke <endpoint> <credential_id> <credential> -> 0 revoked, 1 not
+# _remote_revoke <endpoint> <team_id> <credential_id> <credential> -> 0 revoked, 1 not
 # STRICTLY 200 only (E2 — reverted from an earlier "200 or 404 both
 # count" version): a bare HTTP 404 status is not trustworthy proof the
 # credential is actually gone. It's equally consistent with a wrong
@@ -148,8 +152,8 @@ _remote_http_post_bearer() {
 # anything but 200 — a stuck retry (requiring a console-side revoke) is
 # the correct failure mode here, not a false "confirmed revoked."
 _remote_revoke() {
-  local endpoint="$1" credential_id="$2" credential="$3" http_code
-  http_code="$(_remote_http_post_bearer "$endpoint/v1/credentials/$credential_id/revoke" "$credential")"
+  local endpoint="$1" team_id="$2" credential_id="$3" credential="$4" http_code
+  http_code="$(_remote_http_post_bearer "$endpoint/v1/credentials/$credential_id/revoke" "$team_id" "$credential")"
   [ "$http_code" = "200" ]
 }
 
@@ -464,12 +468,14 @@ cmd_connect() {
         # does not yet build a durable orphan/revocation-pending queue for
         # the unreachable case; it fails closed and asks the operator to
         # retry or revoke from the console/admin side.
-        local old_endpoint old_credential
+        local old_endpoint old_remote_team_id old_credential
         old_endpoint="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.endpoint')"
+        old_remote_team_id="$(_remote_read_config_field "$(_remote_team_config "$team")" '$.remote_binding.remote_team_id')"
         old_credential="$(python3 -c "import json,sys; print(json.load(open('$(_remote_cred_file "$team")')).get('credential',''))" 2>/dev/null || true)"
         if [ -z "$existing_credential_id" ] || [ "$existing_credential_id" = "null" ] \
           || [ -z "$old_endpoint" ] || [ "$old_endpoint" = "null" ] || [ -z "$old_credential" ] \
-          || ! _remote_revoke "$old_endpoint" "$existing_credential_id" "$old_credential"; then
+          || [ -z "$old_remote_team_id" ] || [ "$old_remote_team_id" = "null" ] \
+          || ! _remote_revoke "$old_endpoint" "$old_remote_team_id" "$existing_credential_id" "$old_credential"; then
           echo "agmsg: --force rebind refused — could not confirm the existing credential ($existing_credential_id) was revoked. Revoke it from the console/admin side, or retry once the server is reachable, before rebinding." >&2
           exit 1
         fi
@@ -778,9 +784,10 @@ cmd_disconnect() {
     exit 1
   fi
 
-  local cred_file endpoint credential_id credential
+  local cred_file endpoint remote_team_id credential_id credential
   cred_file="$(_remote_cred_file "$team")"
   endpoint="$(_remote_read_config_field "$cfg" '$.remote_binding.endpoint')"
+  remote_team_id="$(_remote_read_config_field "$cfg" '$.remote_binding.remote_team_id')"
   credential_id="$(_remote_read_config_field "$cfg" '$.remote_binding.credential_id')"
 
   # Server-side revoke first, local cleanup always — local deletion alone
@@ -789,7 +796,8 @@ cmd_disconnect() {
   local revoke_ok=0
   if [ -f "$cred_file" ] && [ -n "$endpoint" ] && [ "$endpoint" != "null" ] && [ -n "$credential_id" ] && [ "$credential_id" != "null" ]; then
     credential="$(python3 -c "import json,sys; print(json.load(open('$cred_file')).get('credential',''))" 2>/dev/null)"
-    if [ -n "$credential" ] && _remote_revoke "$endpoint" "$credential_id" "$credential"; then
+    if [ -n "$credential" ] && [ -n "$remote_team_id" ] && [ "$remote_team_id" != "null" ] \
+      && _remote_revoke "$endpoint" "$remote_team_id" "$credential_id" "$credential"; then
       revoke_ok=1
     fi
     unset credential

--- a/server/README.md
+++ b/server/README.md
@@ -15,12 +15,6 @@ non-secret `credential_id`.
 Use an endpoint that both machines can reach. Pairing tokens expire after 15
 minutes, are valid for one exchange, and create one device credential each.
 
-> Client dependency: the server-side flow in this branch is complete, but the
-> `agmsg remote connect` client command lands separately after its UX review.
-> Until that client branch is stacked, step 4 is the exact intended paste block
-> but is illustrative rather than executable. The cross-machine quickstart E2E
-> is gated on that dependency.
-
 1. Start the reference server and PostgreSQL:
 
    ```sh

--- a/server/test/sync-client.integration.test.ts
+++ b/server/test/sync-client.integration.test.ts
@@ -9,7 +9,7 @@ import { Pool } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApp } from "../src/app.js";
 import type { Config } from "../src/config.js";
-import { exchangePairingToken, issuePairingToken } from "../src/credentials.js";
+import { issuePairingToken } from "../src/credentials.js";
 import { migrate } from "../src/db.js";
 import { envelopeDigest } from "../src/protocol.js";
 import { retainThrough } from "../src/storage.js";
@@ -21,7 +21,6 @@ const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
 
 describeDatabase("Stage-1 polling sync client", () => {
   const schema = `agmsg_sync_${randomBytes(8).toString("hex")}`;
-  let token: string;
   const teamId = "018f3f7e-0000-7000-8000-000000000101";
   const memberA = "018f3f7e-0000-7000-8000-000000000110";
   const memberB = "018f3f7e-0000-7000-8000-000000000120";
@@ -33,6 +32,8 @@ describeDatabase("Stage-1 polling sync client", () => {
   let root: string;
   let storeA: string;
   let storeB: string;
+  let connectionA: string;
+  let connectionB: string;
   let rosterFile: string;
 
   beforeAll(async () => {
@@ -58,13 +59,21 @@ describeDatabase("Stage-1 polling sync client", () => {
       host: "127.0.0.1", port: 8787, logLevel: "silent",
       retentionMaxLiveMessages: null,
     };
-    const issued = await issuePairingToken(pool, teamId);
-    token = String((await exchangePairingToken(pool, issued.token)).credential);
     app = createApp(pool, config);
     serverUrl = await app.listen({ host: "127.0.0.1", port: 0 });
     root = await mkdtemp(join(tmpdir(), "agmsg-stage1-sync-"));
     storeA = join(root, "machine-a");
     storeB = join(root, "machine-b");
+    connectionA = join(root, "connection-a");
+    connectionB = join(root, "connection-b");
+    for (const connectionRoot of [connectionA, connectionB]) {
+      const issued = await issuePairingToken(pool, teamId);
+      await execFileAsync("bash", [join(repositoryRoot, "scripts/remote.sh"), "connect",
+        "--endpoint", serverUrl, issued.token, localTeam], {
+        cwd: repositoryRoot,
+        env: { ...process.env, AGMSG_SYNC_CONNECTION_DIR: connectionRoot },
+      });
+    }
     rosterFile = join(root, "local-roster.json");
     await writeFile(rosterFile, JSON.stringify({
       agents: { "machine-a": {}, "machine-b": {} },
@@ -82,11 +91,12 @@ describeDatabase("Stage-1 polling sync client", () => {
   });
 
   function environment(store: string) {
+    const connectionRoot = store === storeA ? connectionA : connectionB;
     return {
       ...process.env,
       AGMSG_STORAGE_PATH: store,
       AGMSG_STORAGE_DRIVER: "sqlite",
-      AGMSG_SYNC_TOKEN: token,
+      AGMSG_SYNC_CONNECTION_DIR: connectionRoot,
       AGMSG_SYNC_LOCAL_ROSTER_FILE: rosterFile,
       AGMSG_NODE: process.execPath,
       HOME: join(store, "home"),
@@ -141,11 +151,6 @@ storage_list_unread "$2" "$3"`;
   }
 
   it("synchronizes two isolated AGMSG_STORAGE_PATH stores without echo duplicates", async () => {
-    for (const store of [storeA, storeB]) {
-      await sync(store, "configure", "--team", localTeam, "--server", serverUrl,
-        "--team-id", teamId, "--minimum-security", "plaintext-allowed");
-    }
-
     await localSend(storeA, "machine-a", "machine-b", "fixture from machine A");
     const pushedA = await sync(storeA, "once", "--team", localTeam);
     expect(pushedA.stdout).toContain('"event":"push.ack"');
@@ -231,5 +236,15 @@ storage_list_unread "$2" "$3"`;
     const retried = await sync(storeB, "resync", "--team", localTeam,
       "--accept-floor", "3");
     expect(retried.stdout).toContain('"disposition":"already-accepted"');
+
+    const disconnected = await execFileAsync("bash", [join(repositoryRoot, "scripts/remote.sh"),
+      "disconnect", localTeam], {
+      cwd: repositoryRoot,
+      env: { ...process.env, AGMSG_SYNC_CONNECTION_DIR: connectionB },
+    });
+    expect(disconnected.stdout).toContain("Revoking credential with server... ok.");
+    await expect(sync(storeB, "once", "--team", localTeam)).rejects.toMatchObject({
+      stderr: expect.stringContaining("invalid or disconnected"),
+    });
   }, 20_000);
 });

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -152,12 +152,24 @@ class Handler(BaseHTTPRequestHandler):
                 "remote_team_name": "myteam",
                 "protocol_version": 1,
                 "capabilities": {
+                    "protocol_version": 1,
+                    "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
+                    "team_id": "018f3f7e-2222-7000-8000-000000000002",
+                    "team_name": "myteam",
                     "accepted_envelope_versions": [1],
                     "write_allowed_ciphers": ciphers,
-                    "policy_revision": 1,
-                    "effective_from_seq": 0,
-                    "current_seq": 0,
-                    "max_blob_bytes": 1048576,
+                    "policy_revision": "0",
+                    "effective_from_seq": "1",
+                    "current_seq": "0",
+                    "next_sequence_boundary": "1",
+                    "min_available_seq": "0",
+                    "max_blob_bytes": "1048576",
+                    "policy_history": [{
+                        "policy_revision": "0",
+                        "effective_from_seq": "1",
+                        "accepted_envelope_versions": [1],
+                        "write_allowed_ciphers": ciphers,
+                    }],
                 },
             })
             return

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -12,8 +12,8 @@ Token -> response behavior, so tests can pick a scenario by token value:
   missing-field-token           -> 200, but protocol_version is omitted
                                     entirely — for B6
 
-credential_id is derived deterministically from the token
-("cred-<token>") for every other token value, so a test can reconnect
+credential_id is a deterministic canonical UUIDv7 derived from the token
+for every other token value, so a test can reconnect
 with a fresh/different token and assert the OLD credential_id (tied to
 the OLD token) specifically got revoked before the new one was issued.
 
@@ -22,13 +22,15 @@ server has ever issued, else 404; each revoked id is recorded so tests
 can assert on it via GET /_test/revoked. Set MOCK_REVOKE_FAIL=1 to make
 every revoke call fail (returns 500) for the server-unreachable test.
 """
+import hashlib
 import json
 import os
-import re
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 REVOKE_FAIL = os.environ.get("MOCK_REVOKE_FAIL") == "1"
+REVOKE_BAD_HEADER = os.environ.get("MOCK_REVOKE_BAD_HEADER") == "1"
+REVOKE_BAD_BODY = os.environ.get("MOCK_REVOKE_BAD_BODY") == "1"
 ISSUED_CREDENTIAL_IDS = set()
 REVOKED_CREDENTIAL_IDS = []
 
@@ -37,13 +39,15 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, fmt, *args):
         pass  # keep test output quiet
 
-    def _send_json(self, code, obj):
-        self._send_raw(code, json.dumps(obj))
+    def _send_json(self, code, obj, protocol="1"):
+        self._send_raw(code, json.dumps(obj), protocol)
 
-    def _send_raw(self, code, text):
+    def _send_raw(self, code, text, protocol="1"):
         body = text.encode()
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
+        if protocol is not None:
+            self.send_header("Agmsg-Protocol-Version", protocol)
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
@@ -132,7 +136,7 @@ class Handler(BaseHTTPRequestHandler):
                 # downstream write being fixed.
                 self._send_json(200, {
                     "credential": "session-credential\twith-a-tab",
-                    "credential_id": "cred-control-char",
+                    "credential_id": "018f3f7e-7777-7000-8000-000000000007",
                     "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
                     "remote_team_id": "018f3f7e-2222-7000-8000-000000000002",
                     "remote_team_name": "myteam",
@@ -142,36 +146,59 @@ class Handler(BaseHTTPRequestHandler):
                 return
 
             ciphers = ["age-v1"] if token == "good-token-enc" else ["none"]
-            credential_id = "cred-" + re.sub(r"[^A-Za-z0-9_-]", "-", token)
+            digest = hashlib.sha256(token.encode()).hexdigest()
+            credential_id = (
+                f"018f3f7e-{digest[:4]}-7{digest[4:7]}-8{digest[7:10]}-{digest[10:22]}"
+            )
             ISSUED_CREDENTIAL_IDS.add(credential_id)
-            self._send_json(200, {
+            capabilities = {
+                "protocol_version": 1,
+                "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
+                "team_id": "018f3f7e-2222-7000-8000-000000000002",
+                "team_name": "myteam",
+                "accepted_envelope_versions": [1],
+                "write_allowed_ciphers": ciphers,
+                "policy_revision": "0",
+                "effective_from_seq": "1",
+                "current_seq": "0",
+                "next_sequence_boundary": "1",
+                "min_available_seq": "0",
+                "max_blob_bytes": "1048576",
+                "policy_history": [{
+                    "policy_revision": "0",
+                    "effective_from_seq": "1",
+                    "accepted_envelope_versions": [1],
+                    "write_allowed_ciphers": ciphers,
+                }],
+            }
+            if token == "max-blob-zero-token":
+                capabilities["max_blob_bytes"] = "0"
+            elif token == "max-blob-over-token":
+                capabilities["max_blob_bytes"] = "1048577"
+            elif token == "future-policy-boundary-token":
+                capabilities["policy_revision"] = "1"
+                capabilities["effective_from_seq"] = "2"
+                capabilities["policy_history"].append({
+                    "policy_revision": "1",
+                    "effective_from_seq": "2",
+                    "accepted_envelope_versions": [1],
+                    "write_allowed_ciphers": ciphers,
+                })
+            response = {
                 "credential": "session-credential-" + token,
                 "credential_id": credential_id,
                 "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
                 "remote_team_id": "018f3f7e-2222-7000-8000-000000000002",
                 "remote_team_name": "myteam",
                 "protocol_version": 1,
-                "capabilities": {
-                    "protocol_version": 1,
-                    "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
-                    "team_id": "018f3f7e-2222-7000-8000-000000000002",
-                    "team_name": "myteam",
-                    "accepted_envelope_versions": [1],
-                    "write_allowed_ciphers": ciphers,
-                    "policy_revision": "0",
-                    "effective_from_seq": "1",
-                    "current_seq": "0",
-                    "next_sequence_boundary": "1",
-                    "min_available_seq": "0",
-                    "max_blob_bytes": "1048576",
-                    "policy_history": [{
-                        "policy_revision": "0",
-                        "effective_from_seq": "1",
-                        "accepted_envelope_versions": [1],
-                        "write_allowed_ciphers": ciphers,
-                    }],
-                },
-            })
+                "capabilities": capabilities,
+            }
+            if token == "missing-protocol-header-token":
+                self._send_json(200, response, protocol=None)
+            elif token == "wrong-protocol-header-token":
+                self._send_json(200, response, protocol="2")
+            else:
+                self._send_json(200, response)
             return
 
         if self.path.startswith("/v1/credentials/") and self.path.endswith("/revoke"):
@@ -181,14 +208,17 @@ class Handler(BaseHTTPRequestHandler):
             cred_id = self.path.split("/")[3]
             if cred_id in ISSUED_CREDENTIAL_IDS:
                 REVOKED_CREDENTIAL_IDS.append(cred_id)
-                self._send_json(200, {
+                response = {
                     "protocol_version": 1,
                     "server_instance_id": "018f3f7e-1111-7000-8000-000000000001",
                     "team_id": "018f3f7e-2222-7000-8000-000000000002",
                     "credential_id": cred_id,
                     "revoked": True,
-                    "revoked_at": "2026-01-01T00:00:00Z",
-                })
+                    "revoked_at": "2026-01-01T00:00:00.000000Z",
+                }
+                if REVOKE_BAD_BODY:
+                    response["team_id"] = "018f3f7e-9999-7000-8000-000000000009"
+                self._send_json(200, response, protocol=None if REVOKE_BAD_HEADER else "1")
             else:
                 self._send_json(404, {"error": "unknown credential_id"})
             return

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -31,6 +31,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 REVOKE_FAIL = os.environ.get("MOCK_REVOKE_FAIL") == "1"
 REVOKE_BAD_HEADER = os.environ.get("MOCK_REVOKE_BAD_HEADER") == "1"
 REVOKE_BAD_BODY = os.environ.get("MOCK_REVOKE_BAD_BODY") == "1"
+REVOKE_LARGE_BODY = os.environ.get("MOCK_REVOKE_LARGE_BODY") == "1"
 ISSUED_CREDENTIAL_IDS = set()
 REVOKED_CREDENTIAL_IDS = []
 
@@ -39,15 +40,17 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, fmt, *args):
         pass  # keep test output quiet
 
-    def _send_json(self, code, obj, protocol="1"):
-        self._send_raw(code, json.dumps(obj), protocol)
+    def _send_json(self, code, obj, protocol="1", oversized_header=False):
+        self._send_raw(code, json.dumps(obj), protocol, oversized_header)
 
-    def _send_raw(self, code, text, protocol="1"):
+    def _send_raw(self, code, text, protocol="1", oversized_header=False):
         body = text.encode()
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
         if protocol is not None:
             self.send_header("Agmsg-Protocol-Version", protocol)
+        if oversized_header:
+            self.send_header("X-Oversized-Header", "x" * 70_000)
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
@@ -71,6 +74,12 @@ class Handler(BaseHTTPRequestHandler):
             token = data.get("token", "")
             if token == "bad-token":
                 self._send_json(401, {"error": "invalid token"})
+                return
+            if token == "large-body-token":
+                self._send_raw(200, "x" * (2 * 1024 * 1024 + 1))
+                return
+            if token == "large-header-token":
+                self._send_json(200, {"unexpected": "body"}, oversized_header=True)
                 return
 
             if token == "missing-field-token":
@@ -218,6 +227,8 @@ class Handler(BaseHTTPRequestHandler):
                 }
                 if REVOKE_BAD_BODY:
                     response["team_id"] = "018f3f7e-9999-7000-8000-000000000009"
+                if REVOKE_LARGE_BODY:
+                    response["padding"] = "x" * 70_000
                 self._send_json(200, response, protocol=None if REVOKE_BAD_HEADER else "1")
             else:
                 self._send_json(404, {"error": "unknown credential_id"})

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, symlink, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -8,9 +8,11 @@ import {
   consistentReadStateContext,
   driver,
   isRetryable,
+  loadConfig,
   plaintextWriteEligible,
   parseStrictJsonl,
   readStateCycle,
+  readConnectedCredential,
   readStateUpdateBatches,
   reprocessCycle,
   request,
@@ -45,6 +47,90 @@ const candidates = [
   { local_position: "1", id: "550e8400-e29b-41d4-a716-446655440001" },
   { local_position: "2", id: "550e8400-e29b-41d4-a716-446655440002" },
 ];
+
+const credentialId = "018f3f7e-0000-7000-8000-000000000020";
+
+async function withConnectedCredential(callback) {
+  const root = await mkdtemp(join(tmpdir(), "agmsg-connected-credential-"));
+  const previous = process.env.AGMSG_SYNC_CONNECTION_DIR;
+  process.env.AGMSG_SYNC_CONNECTION_DIR = root;
+  await mkdir(join(root, "run", "remote-credentials"), { recursive: true });
+  await writeFile(join(root, "run", "remote-credentials", "demo.json"),
+    `${JSON.stringify({ credential: "fixture-token", credential_id: credentialId })}\n`,
+    { mode: 0o600 });
+  try {
+    return await callback(root);
+  } finally {
+    if (previous === undefined) delete process.env.AGMSG_SYNC_CONNECTION_DIR;
+    else process.env.AGMSG_SYNC_CONNECTION_DIR = previous;
+    await rm(root, { recursive: true });
+  }
+}
+
+async function writeConnectedTeam(root, overrides = {}) {
+  await mkdir(join(root, "teams", "demo"), { recursive: true });
+  const remoteBinding = {
+    endpoint: "https://sync.example",
+    credential_id: credentialId,
+    server_instance_id: config.server_instance_id,
+    remote_team_id: config.remote_team_id,
+    remote_team_name: "demo",
+    protocol_version: 1,
+    capabilities: { write_allowed_ciphers: ["none", "age-v1"] },
+    connected_at: "2026-07-23T00:00:00Z",
+    disconnected_at: null,
+    ...overrides,
+  };
+  await writeFile(join(root, "teams", "demo", "config.json"),
+    `${JSON.stringify({ name: "demo", agents: {}, remote_binding: remoteBinding }, null, 2)}\n`);
+}
+
+test("connected binding and private credential are the default engine configuration", async () => {
+  await withConnectedCredential(async (root) => {
+    await writeConnectedTeam(root);
+    const previousStorage = process.env.AGMSG_SYNC_STORAGE_DIR;
+    const previousAmbient = process.env.AGMSG_SYNC_TOKEN;
+    process.env.AGMSG_SYNC_STORAGE_DIR = join(root, "store");
+    process.env.AGMSG_SYNC_TOKEN = "ambient-token-must-not-win";
+    try {
+      const loaded = await loadConfig("demo");
+      assert.equal(loaded.server_url, "https://sync.example");
+      assert.equal(loaded.remote_team_id, config.remote_team_id);
+      assert.equal(loaded.credential_id, credentialId);
+      assert.equal(loaded.cipher_profile, "none");
+      assert.equal(await readConnectedCredential(loaded), "fixture-token");
+    } finally {
+      if (previousStorage === undefined) delete process.env.AGMSG_SYNC_STORAGE_DIR;
+      else process.env.AGMSG_SYNC_STORAGE_DIR = previousStorage;
+      if (previousAmbient === undefined) delete process.env.AGMSG_SYNC_TOKEN;
+      else process.env.AGMSG_SYNC_TOKEN = previousAmbient;
+    }
+  });
+});
+
+test("credential loader rejects binding mismatch and non-private files", async () => {
+  await withConnectedCredential(async (root) => {
+    const path = join(root, "run", "remote-credentials", "demo.json");
+    await writeFile(path, `${JSON.stringify({ credential: "fixture-token",
+      credential_id: "other-credential" })}\n`, { mode: 0o600 });
+    await assert.rejects(readConnectedCredential({ ...config, credential_id: credentialId }),
+      /does not match/u);
+    if (process.platform !== "win32") {
+      await writeFile(path, `${JSON.stringify({ credential: "fixture-token",
+        credential_id: credentialId })}\n`, { mode: 0o600 });
+      await chmod(path, 0o644);
+      await assert.rejects(readConnectedCredential({ ...config, credential_id: credentialId }),
+        /private regular file/u);
+      await unlink(path);
+      const target = join(root, "credential-target.json");
+      await writeFile(target, `${JSON.stringify({ credential: "fixture-token",
+        credential_id: credentialId })}\n`, { mode: 0o600 });
+      await symlink(target, path);
+      await assert.rejects(readConnectedCredential({ ...config, credential_id: credentialId }),
+        /private regular file/u);
+    }
+  });
+});
 
 test("ack mapping rejects reversed and duplicate server sequences", () => {
   assert.throws(() => validateAckMapping(candidates, [
@@ -430,43 +516,42 @@ test("run retry classification excludes permanent HTTP and validation failures",
 
 test("headerless non-JSON intermediary failures remain retryable", async () => {
   const previousFetch = globalThis.fetch;
-  const previousToken = process.env.AGMSG_SYNC_TOKEN;
-  process.env.AGMSG_SYNC_TOKEN = "fixture-token";
   try {
-    for (const status of [502, 503, 504]) {
-      globalThis.fetch = async () => new Response("temporary proxy failure", { status });
-      await assert.rejects(request({ ...config, server_url: "https://sync.example" }, "/v1/messages"),
+    await withConnectedCredential(async () => {
+      for (const status of [502, 503, 504]) {
+        globalThis.fetch = async () => new Response("temporary proxy failure", { status });
+        await assert.rejects(request({ ...config, credential_id: credentialId,
+          server_url: "https://sync.example" }, "/v1/messages"),
         (error) => error.status === status && error.retryable === true);
-    }
+      }
+    });
   } finally {
     globalThis.fetch = previousFetch;
-    if (previousToken === undefined) delete process.env.AGMSG_SYNC_TOKEN;
-    else process.env.AGMSG_SYNC_TOKEN = previousToken;
   }
 });
 
 test("request distinguishes config errors from response transport loss", async () => {
   const previousFetch = globalThis.fetch;
-  const previousToken = process.env.AGMSG_SYNC_TOKEN;
-  process.env.AGMSG_SYNC_TOKEN = "fixture-token";
   let fetchCalled = false;
   try {
-    globalThis.fetch = async () => { fetchCalled = true; throw new Error("unexpected fetch"); };
-    await assert.rejects(request({ ...config, server_url: "not a URL" }, "/v1/messages"),
+    await withConnectedCredential(async () => {
+      globalThis.fetch = async () => { fetchCalled = true; throw new Error("unexpected fetch"); };
+      await assert.rejects(request({ ...config, credential_id: credentialId,
+        server_url: "not a URL" }, "/v1/messages"),
       (error) => error.retryable !== true);
-    assert.equal(fetchCalled, false);
+      assert.equal(fetchCalled, false);
 
-    globalThis.fetch = async () => ({
-      ok: true, status: 200,
-      headers: { get: () => "1" },
-      text: async () => { throw new Error("body stream reset"); },
-    });
-    await assert.rejects(request({ ...config, server_url: "https://sync.example" }, "/v1/messages"),
+      globalThis.fetch = async () => ({
+        ok: true, status: 200,
+        headers: { get: () => "1" },
+        text: async () => { throw new Error("body stream reset"); },
+      });
+      await assert.rejects(request({ ...config, credential_id: credentialId,
+        server_url: "https://sync.example" }, "/v1/messages"),
       (error) => error.retryable === true);
+    });
   } finally {
     globalThis.fetch = previousFetch;
-    if (previousToken === undefined) delete process.env.AGMSG_SYNC_TOKEN;
-    else process.env.AGMSG_SYNC_TOKEN = previousToken;
   }
 });
 

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, rename, rm, symlink, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
   ageSnapshotDigest,
   consistentReadStateContext,
+  configure,
   driver,
   isRetryable,
   loadConfig,
@@ -129,6 +130,27 @@ test("credential loader rejects binding mismatch and non-private files", async (
       await assert.rejects(readConnectedCredential({ ...config, credential_id: credentialId }),
         /private regular file/u);
     }
+  });
+});
+
+test("connected binding is a bounded non-writable nofollow authority", async () => {
+  await withConnectedCredential(async (root) => {
+    await writeConnectedTeam(root);
+    const path = join(root, "teams", "demo", "config.json");
+    if (process.platform !== "win32") {
+      await chmod(path, 0o666);
+      await assert.rejects(loadConfig("demo"), /non-writable regular file/u);
+      await unlink(path);
+      const target = join(root, "binding-target.json");
+      await writeConnectedTeam(root);
+      await rename(path, target);
+      await symlink(target, path);
+      await assert.rejects(loadConfig("demo"), /non-writable regular file/u);
+      await unlink(path);
+      await rename(target, path);
+    }
+    await writeFile(path, "x".repeat(2 * 1024 * 1024 + 1), { mode: 0o644 });
+    await assert.rejects(loadConfig("demo"), /non-writable regular file|byte limit/u);
   });
 });
 
@@ -530,6 +552,33 @@ test("headerless non-JSON intermediary failures remain retryable", async () => {
   }
 });
 
+test("request callers cannot override binding or credential headers", async () => {
+  const previousFetch = globalThis.fetch;
+  let captured;
+  try {
+    await withConnectedCredential(async () => {
+      globalThis.fetch = async (_url, init) => {
+        captured = init.headers;
+        return new Response(JSON.stringify({ protocol_version: 1,
+          server_instance_id: config.server_instance_id, team_id: config.remote_team_id }), {
+          status: 200, headers: { "Agmsg-Protocol-Version": "1" },
+        });
+      };
+      await request({ ...config, credential_id: credentialId,
+        server_url: "https://sync.example" }, "/v1/messages", { headers: {
+        Authorization: "Bearer attacker-value",
+        "Agmsg-Team-ID": "018f3f7e-9999-7000-8000-000000000009",
+        "Agmsg-Protocol-Version": "99",
+      } });
+      assert.equal(captured.Authorization, "Bearer fixture-token");
+      assert.equal(captured["Agmsg-Team-ID"], config.remote_team_id);
+      assert.equal(captured["Agmsg-Protocol-Version"], "1");
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
 test("request distinguishes config errors from response transport loss", async () => {
   const previousFetch = globalThis.fetch;
   let fetchCalled = false;
@@ -761,6 +810,70 @@ test("retained age checkpoint survives sync config reset and rejects same-revisi
     else process.env.AGMSG_SYNC_STORAGE_DIR = previousStorage;
     await rm(root, { recursive: true });
   }
+});
+
+test("age configure authenticates the connected credential before retaining trust", async () => {
+  const previousFetch = globalThis.fetch;
+  await withConnectedCredential(async (root) => {
+    await writeConnectedTeam(root, { capabilities: { write_allowed_ciphers: ["age-v1"] } });
+    const snapshot = {
+      authorized_writers: ["writer-a"],
+      epoch_revision: "0",
+      history: [{ cipher: "age-v1", effective_from_seq: "1", epoch_revision: "0",
+        key_id: "epoch-1", recipients: [
+          "age1mmqjrejftea4f6xh47lhpc0jn4vw0yuhz349sw2e3sfl22k5gcjsv6xcvp",
+        ] }],
+      previous_snapshot_sha256: null,
+      profile: "age-v1",
+      server_instance_id: config.server_instance_id,
+      team_id: config.remote_team_id,
+      writer_generation: "0",
+    };
+    const snapshotPath = join(root, "snapshot.json");
+    await writeFile(snapshotPath, JSON.stringify(snapshot));
+    const fakeAge = join(root, "age");
+    await writeFile(fakeAge, "#!/bin/sh\necho v1.3.1\n", { mode: 0o700 });
+    const saved = {
+      storage: process.env.AGMSG_SYNC_STORAGE_DIR,
+      trust: process.env.AGMSG_SYNC_TRUST_DIR,
+      age: process.env.AGMSG_AGE_BIN,
+    };
+    process.env.AGMSG_SYNC_STORAGE_DIR = join(root, "store");
+    process.env.AGMSG_SYNC_TRUST_DIR = join(root, "trust");
+    process.env.AGMSG_AGE_BIN = fakeAge;
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return new Response(JSON.stringify({ status: "ok", database: "ok",
+          server_instance_id: config.server_instance_id }), {
+          status: 200, headers: { "Agmsg-Protocol-Version": "1" },
+        });
+      }
+      return new Response(JSON.stringify({ protocol_version: 1,
+        error: { code: "unauthenticated" } }), {
+        status: 401, headers: { "Agmsg-Protocol-Version": "1" },
+      });
+    };
+    try {
+      await assert.rejects(configure({ team: "demo", server: "https://sync.example",
+        "team-id": config.remote_team_id, "minimum-security": "e2ee-required",
+        cipher: "age-v1", "age-snapshot": snapshotPath,
+        "age-checkpoint": `0:${ageSnapshotDigest(snapshot)}`,
+        "age-confirmation": "operator-live" }), /unauthenticated/u);
+      assert.equal(calls, 2);
+      await assert.rejects(readdir(process.env.AGMSG_SYNC_TRUST_DIR),
+        (error) => error.code === "ENOENT");
+    } finally {
+      globalThis.fetch = previousFetch;
+      if (saved.storage === undefined) delete process.env.AGMSG_SYNC_STORAGE_DIR;
+      else process.env.AGMSG_SYNC_STORAGE_DIR = saved.storage;
+      if (saved.trust === undefined) delete process.env.AGMSG_SYNC_TRUST_DIR;
+      else process.env.AGMSG_SYNC_TRUST_DIR = saved.trust;
+      if (saved.age === undefined) delete process.env.AGMSG_AGE_BIN;
+      else process.env.AGMSG_AGE_BIN = saved.age;
+    }
+  });
 });
 
 test("configured native identity must belong to its epoch recipient manifest", async () => {

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -219,7 +219,22 @@ response = {
     'remote_team_id': '018f3f7e-2222-7000-8000-000000000002',
     'remote_team_name': 'myteam',
     'protocol_version': 1,
-    'capabilities': {'write_allowed_ciphers': ['none']},
+    'capabilities': {
+        'protocol_version': 1,
+        'server_instance_id': '018f3f7e-1111-7000-8000-000000000001',
+        'team_id': '018f3f7e-2222-7000-8000-000000000002',
+        'team_name': 'myteam',
+        'accepted_envelope_versions': [1],
+        'write_allowed_ciphers': ['none'],
+        'policy_revision': '0', 'effective_from_seq': '1',
+        'current_seq': '0', 'next_sequence_boundary': '1',
+        'min_available_seq': '0', 'max_blob_bytes': '1048576',
+        'policy_history': [{
+            'policy_revision': '0', 'effective_from_seq': '1',
+            'accepted_envelope_versions': [1],
+            'write_allowed_ciphers': ['none'],
+        }],
+    },
 }
 json.dump({
     'endpoint': '$ENDPOINT',
@@ -350,7 +365,22 @@ response = {
     'remote_team_id': '018f3f7e-4444-7000-8000-000000000004',
     'remote_team_name': 'resumedteam',
     'protocol_version': 1,
-    'capabilities': {'write_allowed_ciphers': ['none']},
+    'capabilities': {
+        'protocol_version': 1,
+        'server_instance_id': '018f3f7e-3333-7000-8000-000000000003',
+        'team_id': '018f3f7e-4444-7000-8000-000000000004',
+        'team_name': 'resumedteam',
+        'accepted_envelope_versions': [1],
+        'write_allowed_ciphers': ['none'],
+        'policy_revision': '0', 'effective_from_seq': '1',
+        'current_seq': '0', 'next_sequence_boundary': '1',
+        'min_available_seq': '0', 'max_blob_bytes': '1048576',
+        'policy_history': [{
+            'policy_revision': '0', 'effective_from_seq': '1',
+            'accepted_envelope_versions': [1],
+            'write_allowed_ciphers': ['none'],
+        }],
+    },
 }
 json.dump({
     'endpoint': '$ENDPOINT',
@@ -396,7 +426,22 @@ response = {
     'remote_team_id': '018f3f7e-2222-7000-8000-000000000002',
     'remote_team_name': 'myteam',
     'protocol_version': 1,
-    'capabilities': {'write_allowed_ciphers': ['none']},
+    'capabilities': {
+        'protocol_version': 1,
+        'server_instance_id': '018f3f7e-1111-7000-8000-000000000001',
+        'team_id': '018f3f7e-2222-7000-8000-000000000002',
+        'team_name': 'myteam',
+        'accepted_envelope_versions': [1],
+        'write_allowed_ciphers': ['none'],
+        'policy_revision': '0', 'effective_from_seq': '1',
+        'current_seq': '0', 'next_sequence_boundary': '1',
+        'min_available_seq': '0', 'max_blob_bytes': '1048576',
+        'policy_history': [{
+            'policy_revision': '0', 'effective_from_seq': '1',
+            'accepted_envelope_versions': [1],
+            'write_allowed_ciphers': ['none'],
+        }],
+    },
 }
 json.dump({
     'endpoint': '$ENDPOINT',

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -413,19 +413,27 @@ json.dump({
 
 # --- connect: pending/resume (B5) -----------------------------------------
 
-@test "connect: discards legacy pending records without a protocol-header verification fact" {
+@test "connect: quarantines legacy pending recovery material without committing it" {
   local token="legacy-pending-token"
   local key
   key=$(python3 -c "import hashlib; print(hashlib.sha256('$ENDPOINT'.encode()+b'\x00'+'$token'.encode()).hexdigest())")
   pending_dir="$SCRIPTS/../run/remote-connect-pending"
   mkdir -p "$pending_dir"
-  printf '%s\n' '{"endpoint":"'$ENDPOINT'","raw_response_text":"{}"}' > "$pending_dir/$key.json"
+  printf '%s\n' '{"endpoint":"'$ENDPOINT'","raw_response_text":"{\"credential_id\":\"018f3f7e-8888-7000-8000-000000000008\"}"}' > "$pending_dir/$key.json"
   chmod 600 "$pending_dir/$key.json"
 
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" "$token" myteam
   [ "$status" -ne 0 ]
-  [[ "$output" == *"discarded a legacy pending exchange"* ]]
+  [[ "$output" == *"refusing to resume a legacy pending exchange"* ]]
+  [[ "$output" == *"preserved the 0600 recovery record"* ]]
   [ ! -f "$pending_dir/$key.json" ]
+  local quarantined=("$pending_dir/$key.json.unverified."*)
+  [ "${#quarantined[@]}" -eq 1 ]
+  [ -f "${quarantined[0]}" ]
+  mode=$(stat -f '%Lp' "${quarantined[0]}" 2>/dev/null || stat -c '%a' "${quarantined[0]}")
+  [ "$mode" = "600" ]
+  recovered_id=$(python3 -c "import json; p=json.load(open('${quarantined[0]}')); print(json.loads(p['raw_response_text'])['credential_id'])")
+  [ "$recovered_id" = "018f3f7e-8888-7000-8000-000000000008" ]
 }
 
 @test "connect: resumes from a hand-crafted pending record without a fresh network call" {

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -7,7 +7,10 @@ setup() {
   bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a
 
   # Start the mock pairing-exchange/revoke server on an OS-assigned port.
-  MOCK_REVOKE_FAIL="${MOCK_REVOKE_FAIL:-}" python3 "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
+  MOCK_REVOKE_FAIL="${MOCK_REVOKE_FAIL:-}" \
+  MOCK_REVOKE_BAD_HEADER="${MOCK_REVOKE_BAD_HEADER:-}" \
+  MOCK_REVOKE_BAD_BODY="${MOCK_REVOKE_BAD_BODY:-}" \
+    python3 "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
     > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" &
   MOCK_SERVER_PID=$!
   for _ in $(seq 1 50); do
@@ -21,6 +24,24 @@ setup() {
 teardown() {
   kill "$MOCK_SERVER_PID" 2>/dev/null || true
   teardown_test_env
+}
+
+restart_mock_server() {
+  kill "$MOCK_SERVER_PID" 2>/dev/null || true
+  wait "$MOCK_SERVER_PID" 2>/dev/null || true
+  : > "$TEST_SKILL_DIR/server.port"
+  MOCK_REVOKE_FAIL="${MOCK_REVOKE_FAIL:-}" \
+  MOCK_REVOKE_BAD_HEADER="${MOCK_REVOKE_BAD_HEADER:-}" \
+  MOCK_REVOKE_BAD_BODY="${MOCK_REVOKE_BAD_BODY:-}" \
+    python3 "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
+      > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" &
+  MOCK_SERVER_PID=$!
+  for _ in $(seq 1 50); do
+    [ -s "$TEST_SKILL_DIR/server.port" ] && break
+    sleep 0.05
+  done
+  MOCK_PORT="$(cat "$TEST_SKILL_DIR/server.port")"
+  ENDPOINT="http://127.0.0.1:$MOCK_PORT"
 }
 
 # --- doctor ------------------------------------------------------------
@@ -56,6 +77,24 @@ teardown() {
 @test "connect: http://127.0.0.1 (loopback) is accepted without https" {
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
   [ "$status" -eq 0 ]
+}
+
+@test "connect: requires the response protocol header" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" missing-protocol-header-token myteam
+  [ "$status" -ne 0 ]
+  [ ! -f "$SCRIPTS/../run/remote-credentials/myteam.json" ]
+
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" wrong-protocol-header-token myteam
+  [ "$status" -ne 0 ]
+  [ ! -f "$SCRIPTS/../run/remote-credentials/myteam.json" ]
+}
+
+@test "connect: rejects capability limits that differ from the engine validator" {
+  for token in max-blob-zero-token max-blob-over-token future-policy-boundary-token; do
+    run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" "$token" myteam
+    [ "$status" -ne 0 ]
+    [ ! -f "$SCRIPTS/../run/remote-credentials/myteam.json" ]
+  done
 }
 
 @test "connect: refuses subdomain-suffix bypass of the loopback exception (127.0.0.1.evil.com)" {
@@ -189,6 +228,17 @@ teardown() {
   [[ "$output" == *"connected"* ]]
 }
 
+@test "connect: --force rejects a 200 revoke body that does not match the binding" {
+  MOCK_REVOKE_BAD_BODY=1
+  restart_mock_server
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token-one myteam
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token-two myteam --force
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not confirm the existing credential"* ]]
+  run bash "$SCRIPTS/remote.sh" status myteam
+  [[ "$output" == *"connected"* ]]
+}
+
 @test "connect: --force requires an explicit <team> (refuses when omitted)" {
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token --force
   [ "$status" -ne 0 ]
@@ -214,7 +264,7 @@ teardown() {
 import json
 response = {
     'credential': 'unrelated-credential-value',
-    'credential_id': 'cred-unrelated-c',
+    'credential_id': '018f3f7e-5555-7000-8000-000000000005',
     'server_instance_id': '018f3f7e-1111-7000-8000-000000000001',
     'remote_team_id': '018f3f7e-2222-7000-8000-000000000002',
     'remote_team_name': 'myteam',
@@ -360,7 +410,7 @@ json.dump({
 import json
 response = {
     'credential': 'resumed-credential-value',
-    'credential_id': 'cred-resumed-xyz',
+    'credential_id': '018f3f7e-6666-7000-8000-000000000006',
     'server_instance_id': '018f3f7e-3333-7000-8000-000000000003',
     'remote_team_id': '018f3f7e-4444-7000-8000-000000000004',
     'remote_team_name': 'resumedteam',
@@ -399,7 +449,7 @@ json.dump({
   # Committed content must match the PENDING record's data, not a fresh
   # exchange (there was no live server to get one from).
   credential_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/myteam/config.json'))['remote_binding']['credential_id'])")
-  [ "$credential_id" = "cred-resumed-xyz" ]
+  [ "$credential_id" = "018f3f7e-6666-7000-8000-000000000006" ]
   # Pending record consumed on success — not left behind.
   [ ! -f "$pending_dir/$key.json" ]
 }
@@ -485,6 +535,17 @@ json.dump({
   run bash "$SCRIPTS/remote.sh" disconnect myteam
   [ "$status" -eq 0 ]
   [[ "$output" == *"could not be reached to revoke"* ]]
+  [ ! -f "$SCRIPTS/../run/remote-credentials/myteam.json" ]
+}
+
+@test "disconnect: does not claim revoke success without the protocol response header" {
+  MOCK_REVOKE_BAD_HEADER=1
+  restart_mock_server
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token myteam
+  run bash "$SCRIPTS/remote.sh" disconnect myteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"could not be reached to revoke"* ]]
+  [[ "$output" != *"Revoking credential with server... ok."* ]]
   [ ! -f "$SCRIPTS/../run/remote-credentials/myteam.json" ]
 }
 

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -10,6 +10,7 @@ setup() {
   MOCK_REVOKE_FAIL="${MOCK_REVOKE_FAIL:-}" \
   MOCK_REVOKE_BAD_HEADER="${MOCK_REVOKE_BAD_HEADER:-}" \
   MOCK_REVOKE_BAD_BODY="${MOCK_REVOKE_BAD_BODY:-}" \
+  MOCK_REVOKE_LARGE_BODY="${MOCK_REVOKE_LARGE_BODY:-}" \
     python3 "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
     > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" &
   MOCK_SERVER_PID=$!
@@ -33,6 +34,7 @@ restart_mock_server() {
   MOCK_REVOKE_FAIL="${MOCK_REVOKE_FAIL:-}" \
   MOCK_REVOKE_BAD_HEADER="${MOCK_REVOKE_BAD_HEADER:-}" \
   MOCK_REVOKE_BAD_BODY="${MOCK_REVOKE_BAD_BODY:-}" \
+  MOCK_REVOKE_LARGE_BODY="${MOCK_REVOKE_LARGE_BODY:-}" \
     python3 "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
       > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" &
   MOCK_SERVER_PID=$!
@@ -91,6 +93,14 @@ restart_mock_server() {
 
 @test "connect: rejects capability limits that differ from the engine validator" {
   for token in max-blob-zero-token max-blob-over-token future-policy-boundary-token; do
+    run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" "$token" myteam
+    [ "$status" -ne 0 ]
+    [ ! -f "$SCRIPTS/../run/remote-credentials/myteam.json" ]
+  done
+}
+
+@test "connect: bounds response body and header capture before validation" {
+  for token in large-body-token large-header-token; do
     run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" "$token" myteam
     [ "$status" -ne 0 ]
     [ ! -f "$SCRIPTS/../run/remote-credentials/myteam.json" ]
@@ -239,6 +249,15 @@ restart_mock_server() {
   [[ "$output" == *"connected"* ]]
 }
 
+@test "connect: --force bounds revoke response before validation" {
+  MOCK_REVOKE_LARGE_BODY=1
+  restart_mock_server
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token-one myteam
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token-two myteam --force
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not confirm the existing credential"* ]]
+}
+
 @test "connect: --force requires an explicit <team> (refuses when omitted)" {
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" good-token --force
   [ "$status" -ne 0 ]
@@ -288,6 +307,7 @@ response = {
 }
 json.dump({
     'endpoint': '$ENDPOINT',
+    'protocol_header_verified': True,
     'raw_response_text': json.dumps(response),
 }, open('$pending_dir/$key.json', 'w'))
 "
@@ -364,7 +384,7 @@ json.dump({
   # by replacing all of $PATH (which would also break curl/python3/sqlite3
   # and make this fail for the wrong reason).
   fakebin=$(mktemp -d)
-  for tool in bash sh sqlite3 curl python3 mkdir chmod date mktemp rm cat sed mv grep dirname tr basename env sleep; do
+  for tool in bash sh sqlite3 curl python3 mkdir chmod date mktemp mkfifo rmdir rm cat sed mv grep dirname tr basename env sleep; do
     p="$(command -v "$tool" 2>/dev/null)" && ln -s "$p" "$fakebin/$tool"
   done
   run bash -c "PATH='$fakebin' bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' good-token-enc myteam"
@@ -392,6 +412,21 @@ json.dump({
 }
 
 # --- connect: pending/resume (B5) -----------------------------------------
+
+@test "connect: discards legacy pending records without a protocol-header verification fact" {
+  local token="legacy-pending-token"
+  local key
+  key=$(python3 -c "import hashlib; print(hashlib.sha256('$ENDPOINT'.encode()+b'\x00'+'$token'.encode()).hexdigest())")
+  pending_dir="$SCRIPTS/../run/remote-connect-pending"
+  mkdir -p "$pending_dir"
+  printf '%s\n' '{"endpoint":"'$ENDPOINT'","raw_response_text":"{}"}' > "$pending_dir/$key.json"
+  chmod 600 "$pending_dir/$key.json"
+
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" "$token" myteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"discarded a legacy pending exchange"* ]]
+  [ ! -f "$pending_dir/$key.json" ]
+}
 
 @test "connect: resumes from a hand-crafted pending record without a fresh network call" {
   # Simulates the crash-recovery scenario: an exchange already succeeded
@@ -434,6 +469,7 @@ response = {
 }
 json.dump({
     'endpoint': '$ENDPOINT',
+    'protocol_header_verified': True,
     'raw_response_text': json.dumps(response),
 }, open('$pending_dir/$key.json', 'w'))
 "
@@ -495,6 +531,7 @@ response = {
 }
 json.dump({
     'endpoint': '$ENDPOINT',
+    'protocol_header_verified': True,
     'raw_response_text': json.dumps(response),
 }, open('$pending_dir/$key.json', 'w'))
 "


### PR DESCRIPTION
## Summary
- load per-team remote binding and 0600 credential artifacts directly in the polling engine
- remove ambient bearer-token authentication and keep private credentials out of argv, logs, and driver children
- align pairing exchange and self-revoke requests with the v1 protocol/team binding headers
- validate the complete canonical capability snapshot before committing onboarding state
- exercise real remote connect, two device credentials, message/read sync, retention resync, and revoke in the PostgreSQL E2E

## Compatibility
- plaintext-capable bindings need no separate sync configure step
- age-v1 keeps the explicit authenticated snapshot/checkpoint configure path; the engine refuses to synthesize authority state from the simpler onboarding key record
- branch remains Draft/unmerged for dogfood

## Verification
- remote onboarding Bats: 38 tests
- key Bats: 19 tests
- remote sync engine Node: 25 tests
- JSONL/SQLite/engine Bats: 41 tests
- PostgreSQL server/integration: 17 tests
- server typecheck and build