### PR TITLE
feat(app): drag files onto a pane to insert their path

### DIFF
--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
         "minHeight": 480,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "dragDropEnabled": false
+        "dragDropEnabled": true
       }
     ],
     "security": {

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1144,19 +1144,20 @@ body.resizing-row {
   color: #fff;
   cursor: grabbing;
 }
-/* Off-screen drag image for pane-header drags — see onDragStart in App.tsx.
-   Sized to its text content, not the label's flex-stretched box, so the
-   drag snapshot looks like a name chip instead of the whole header bar. */
-.pane-drag-ghost {
+/* Floating name chip that follows the cursor during a pane-header
+   pointer-drag — see startPaneDrag in App.tsx. pointer-events: none is load
+   -bearing: elementFromPoint-based hit-testing must see through this to
+   whatever's actually underneath (a tab, another pane cell, ...). */
+.pane-drag-chip {
   position: fixed;
-  top: -9999px;
-  left: -9999px;
+  z-index: 100;
   padding: 2px 8px;
   font-size: 11px;
   color: #fff;
   background: var(--accent);
   border-radius: 3px;
   white-space: nowrap;
+  pointer-events: none;
 }
 /* The pane a drag is currently over — see onDragOver in App.tsx. Dashed
    outline (not the focus ring's solid border) so a drop target reads as

--- a/app/src/App.test.ts
+++ b/app/src/App.test.ts
@@ -7,6 +7,7 @@ import {
   shellSplitStillValid,
   shellTabStillValid,
   shouldShowOutdatedBanner,
+  shouldSuppressClickAfterDrag,
   type LoginShellInfo,
 } from "./App";
 
@@ -25,6 +26,29 @@ describe("shouldShowOutdatedBanner", () => {
 
   it("hides once dismissed, independent of updatingCore", () => {
     expect(shouldShowOutdatedBanner({ installed: "1.1.0", pinned: "1.1.8" }, false, true)).toBe(false);
+  });
+});
+
+describe("shouldSuppressClickAfterDrag", () => {
+  it("suppresses a click that lands immediately after a drag finished", () => {
+    expect(shouldSuppressClickAfterDrag(1_000, 1_010)).toBe(true);
+  });
+
+  it("suppresses a click at the tail end of the window", () => {
+    expect(shouldSuppressClickAfterDrag(1_000, 1_299)).toBe(true);
+  });
+
+  it("does not suppress a genuinely separate click once the window has passed", () => {
+    // Regression (co1, PR #481, 2nd round): a drag that ends via blur or
+    // pointercancel with the pointer released outside the app never gets a
+    // matching click to consume — an unbounded "consume the next click"
+    // listener would sit on the button forever and wrongly swallow the
+    // next, wholly unrelated click. The bounded window must let it through.
+    expect(shouldSuppressClickAfterDrag(1_000, 1_301)).toBe(false);
+  });
+
+  it("does not suppress when no drag has ever finished (dragFinishedAt still 0)", () => {
+    expect(shouldSuppressClickAfterDrag(0, 1_000_000)).toBe(false);
   });
 });
 

--- a/app/src/App.test.ts
+++ b/app/src/App.test.ts
@@ -30,25 +30,39 @@ describe("shouldShowOutdatedBanner", () => {
 });
 
 describe("shouldSuppressClickAfterDrag", () => {
-  it("suppresses a click that lands immediately after a drag finished", () => {
-    expect(shouldSuppressClickAfterDrag(1_000, 1_010)).toBe(true);
+  it("suppresses a click on the SAME pane immediately after its drag finished", () => {
+    expect(shouldSuppressClickAfterDrag({ paneId: "p1", finishedAt: 1_000 }, "p1", 1_010)).toBe(true);
   });
 
   it("suppresses a click at the tail end of the window", () => {
-    expect(shouldSuppressClickAfterDrag(1_000, 1_299)).toBe(true);
+    expect(shouldSuppressClickAfterDrag({ paneId: "p1", finishedAt: 1_000 }, "p1", 1_299)).toBe(true);
+  });
+
+  it("does not suppress a click on a DIFFERENT pane, even immediately after", () => {
+    // Regression (co1, PR #481, 3rd round): a global timestamp with no pane
+    // identity would suppress a deliberate click on some other pane header
+    // too, just because it lands within the window of an unrelated pane's
+    // drag finishing.
+    expect(shouldSuppressClickAfterDrag({ paneId: "p1", finishedAt: 1_000 }, "p2", 1_010)).toBe(false);
+  });
+
+  it("does not suppress once consumed — a second click on the same pane isn't ALSO swallowed", () => {
+    // The caller is expected to clear the ref (set it to null) after this
+    // returns true — modeled here as the "already consumed" state.
+    expect(shouldSuppressClickAfterDrag(null, "p1", 1_010)).toBe(false);
   });
 
   it("does not suppress a genuinely separate click once the window has passed", () => {
-    // Regression (co1, PR #481, 2nd round): a drag that ends via blur or
-    // pointercancel with the pointer released outside the app never gets a
-    // matching click to consume — an unbounded "consume the next click"
-    // listener would sit on the button forever and wrongly swallow the
-    // next, wholly unrelated click. The bounded window must let it through.
-    expect(shouldSuppressClickAfterDrag(1_000, 1_301)).toBe(false);
+    // A drag that ends via blur or pointercancel with the pointer released
+    // outside the app never gets a matching click to consume — an
+    // unbounded "consume the next click" listener would sit on the button
+    // forever and wrongly swallow the next, wholly unrelated click. The
+    // bounded window must let it through.
+    expect(shouldSuppressClickAfterDrag({ paneId: "p1", finishedAt: 1_000 }, "p1", 1_301)).toBe(false);
   });
 
-  it("does not suppress when no drag has ever finished (dragFinishedAt still 0)", () => {
-    expect(shouldSuppressClickAfterDrag(0, 1_000_000)).toBe(false);
+  it("does not suppress when no drag has ever finished", () => {
+    expect(shouldSuppressClickAfterDrag(null, "p1", 1_000_000)).toBe(false);
   });
 });
 

--- a/app/src/App.test.ts
+++ b/app/src/App.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  hasUnsafeDropPath,
   joinDroppedPaths,
   resolveFileDropTarget,
   shellPaneFrom,
@@ -99,6 +100,32 @@ describe("shellSplitStillValid", () => {
   });
 });
 
+describe("hasUnsafeDropPath", () => {
+  it("is false for ordinary paths", () => {
+    expect(hasUnsafeDropPath(["/Users/koit/file.txt", "/a/b c.png"])).toBe(false);
+  });
+
+  it("catches a newline — could submit the target prompt on drop alone", () => {
+    expect(hasUnsafeDropPath(["/Users/koit/evil\nrm -rf ~.txt"])).toBe(true);
+  });
+
+  it("catches a carriage return", () => {
+    expect(hasUnsafeDropPath(["/Users/koit/evil\rfile.txt"])).toBe(true);
+  });
+
+  it("catches an ESC byte — terminal control sequence, not text", () => {
+    expect(hasUnsafeDropPath(["/Users/koit/evil\x1bfile.txt"])).toBe(true);
+  });
+
+  it("catches DEL (\\u007f), just outside the C0 range", () => {
+    expect(hasUnsafeDropPath(["/Users/koit/evil\x7ffile.txt"])).toBe(true);
+  });
+
+  it("is false for an empty list", () => {
+    expect(hasUnsafeDropPath([])).toBe(false);
+  });
+});
+
 describe("joinDroppedPaths", () => {
   it("joins multiple paths with a single space, unquoted", () => {
     // Deliberately bare, not shell-quoted — see joinDroppedPaths' own doc:
@@ -113,6 +140,15 @@ describe("joinDroppedPaths", () => {
 
   it("returns an empty string for no paths", () => {
     expect(joinDroppedPaths([])).toBe("");
+  });
+
+  it("rejects the WHOLE drop — returns null, not a sanitized string — when any path has a control character", () => {
+    // Regression (co1, PR #481): a crafted filename containing a newline
+    // written raw to the PTY would submit whatever's on the current prompt
+    // line the instant the file is dropped. Rejecting outright (not
+    // stripping the bad byte) avoids silently writing a DIFFERENT path than
+    // what was actually dropped.
+    expect(joinDroppedPaths(["/Users/koit/evil\nfile.txt", "/Users/koit/fine.txt"])).toBeNull();
   });
 });
 

--- a/app/src/App.test.ts
+++ b/app/src/App.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  joinDroppedPaths,
+  resolveFileDropTarget,
   shellPaneFrom,
   shellSplitStillValid,
   shellTabStillValid,
@@ -94,5 +96,58 @@ describe("shellSplitStillValid", () => {
     // it reproduces the same hidden-active bug shellTabStillValid guards
     // against on the new-tab path (co1, PR #431).
     expect(shellSplitStillValid(windows, "w-1", "teamB", "teamA")).toBe(false);
+  });
+});
+
+describe("joinDroppedPaths", () => {
+  it("joins multiple paths with a single space, unquoted", () => {
+    // Deliberately bare, not shell-quoted — see joinDroppedPaths' own doc:
+    // quoting broke Claude Code's own file-path recognition in live
+    // testing (koit), even though it's fine for Codex.
+    expect(joinDroppedPaths(["/a/b.txt", "/c/d.txt"])).toBe("/a/b.txt /c/d.txt");
+  });
+
+  it("passes a path with a space through unquoted", () => {
+    expect(joinDroppedPaths(["/Users/koit/my file.txt"])).toBe("/Users/koit/my file.txt");
+  });
+
+  it("returns an empty string for no paths", () => {
+    expect(joinDroppedPaths([])).toBe("");
+  });
+});
+
+describe("resolveFileDropTarget", () => {
+  const leaf = (paneId: string) => ({ kind: "leaf" as const, paneId });
+  const windows = [
+    {
+      id: "w-1",
+      root: { kind: "split" as const, axis: "col" as const, ratio: 0.5, a: leaf("p-1"), b: leaf("p-2") },
+    },
+  ];
+
+  it("prefers the pane directly under the cursor when there is one", () => {
+    expect(resolveFileDropTarget("p-hovered", windows, "w-1", null)).toBe("p-hovered");
+  });
+
+  it("falls back to the active tab's focused pane when nothing was hit", () => {
+    // e.g. dropped on the sidebar or tab bar, not any pane cell — koit's
+    // follow-up feedback: prefer the pane the user was actually using, not
+    // just whichever leaf happens to be first in the tree.
+    expect(resolveFileDropTarget(null, windows, "w-1", "p-2")).toBe("p-2");
+  });
+
+  it("falls back to the active window's first pane when nothing was hit and nothing is focused", () => {
+    expect(resolveFileDropTarget(null, windows, "w-1", null)).toBe("p-1");
+  });
+
+  it("ignores a focused pane that belongs to a different (inactive) tab", () => {
+    // lastFocusedPaneId is tracked globally, not per-tab — a stale value
+    // from another tab must not steer a drop away from the active one.
+    expect(resolveFileDropTarget(null, windows, "w-1", "p-from-another-tab")).toBe("p-1");
+  });
+
+  it("returns null when there's no active window to fall back to", () => {
+    // e.g. Team Room is showing (active === "room"), no panes at all.
+    expect(resolveFileDropTarget(null, windows, "room", null)).toBeNull();
   });
 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -263,20 +263,29 @@ const TIMEZONE_KEY = "agmsg-app-timezone";
 const DRAG_THRESHOLD_PX = 4;
 // How long after a real pane-header drag ends its own onClick should still
 // no-op for a same-element native click that follows — see
-// dragJustFinishedAtRef's doc.
+// dragJustFinishedRef's doc.
 const CLICK_SUPPRESS_WINDOW_MS = 300;
+
+// What startPaneDrag's finish() records — which pane the drag was FOR, not
+// just when it ended. Scoping by pane matters: a global timestamp alone
+// would suppress a deliberate click on some OTHER pane header too, just
+// because it happens to land within the window of an unrelated pane's drag
+// finishing (co1 review, PR #481, 3rd round).
+export type DragFinishInfo = { paneId: string; finishedAt: number } | null;
 
 // Whether the pane-header's onClick should treat an incoming click as the
 // tail end of a just-finished drag gesture (no-op) rather than a genuine
-// new click on the button — see dragJustFinishedAtRef's doc for why this is
-// a short bounded window, not an unbounded "consume exactly one click"
-// listener. Pure so the two co1-requested regressions are unit-testable
-// without simulating real pointer/click event sequences: a click shortly
-// after a drag-related finish is suppressed; a click long after (or with no
-// drag having happened at all, i.e. dragFinishedAt still 0) is not (co1
-// review, PR #481, 2nd round).
-export function shouldSuppressClickAfterDrag(dragFinishedAt: number, now: number): boolean {
-  return now - dragFinishedAt < CLICK_SUPPRESS_WINDOW_MS;
+// new click on the button — true only for a click on the SAME pane the
+// drag was for, within a short window. The caller (onClick) is expected to
+// clear dragFinish (set it back to null) whenever this returns true —
+// "consuming" it — so a genuinely separate second click on the same pane,
+// even one that lands inside the same window, isn't ALSO wrongly
+// suppressed; an unbounded "consume exactly one click" native listener had
+// its own problems (see git history), but a per-pane bounded ref without
+// consuming still over-suppresses. Pure so the co1-requested regressions
+// are unit-testable without simulating real pointer/click event sequences.
+export function shouldSuppressClickAfterDrag(dragFinish: DragFinishInfo, paneId: string, now: number): boolean {
+  return dragFinish !== null && dragFinish.paneId === paneId && now - dragFinish.finishedAt < CLICK_SUPPRESS_WINDOW_MS;
 }
 // A spawnable agent type discovered from agmsg's type registry.
 export type AgentType = { name: string; cli: string; options: string[] };
@@ -571,22 +580,18 @@ export default function App() {
   useEffect(() => {
     return () => activePaneDragCancelRef.current?.();
   }, []);
-  // When a real pane-header drag last finished (committed OR cancelled —
-  // Escape/blur/pointercancel can still end with the pointer back over the
-  // source button, which fires a native click there same as any other
-  // same-element press/release pair). The pane-header onClick below checks
-  // this and no-ops if it's recent, so that click doesn't ALSO re-run the
+  // Which pane a real pane-header drag last finished for, and when
+  // (committed OR cancelled — Escape/blur/pointercancel can still end with
+  // the pointer back over the source button, which fires a native click
+  // there same as any other same-element press/release pair). The dragged
+  // pane's own onClick below checks this (shouldSuppressClickAfterDrag) and
+  // no-ops + clears it if it matches, so that click doesn't ALSO re-run the
   // swap-arm toggle right after finish() already handled the gesture as a
-  // drag. A short bounded window, not an unbounded "consume the next click"
-  // listener: a drag that ends via blur/pointercancel/unmount with the
-  // release outside the app never gets a matching click AT ALL, so a
-  // pending single-shot listener would sit on the button forever and wrongly
-  // swallow the NEXT, wholly unrelated real click days later (co1 review,
-  // PR #481, 2nd round). The synthetic click reliably follows pointerup
-  // within the same task in every browser/webview this ships on, so this
-  // only needs to outlast that — generous margin, not a real risk of
-  // masking a genuinely separate later click.
-  const dragJustFinishedAtRef = useRef(0);
+  // drag. Scoped per-pane and consumed on use, not a global unbounded
+  // "consume the next click" listener or a bare timestamp — both over-
+  // suppress in different ways (see shouldSuppressClickAfterDrag's own doc
+  // and git history; co1 review, PR #481, rounds 2 and 3).
+  const dragJustFinishedRef = useRef<DragFinishInfo>(null);
   const applyAgentState = useCallback((paneId: string, state: RawState) => {
     setPaneStatus((current) => applyStateChange(current, paneId, state));
   }, []);
@@ -1370,10 +1375,10 @@ export default function App() {
   //   that DOES fire a native click on it same as any other press/release
   //   pair landing on the same element, which would otherwise also run
   //   onClick's swap-arm toggle right after finish() already handled the
-  //   gesture as a drag. dragJustFinishedAtRef (declared above, checked by
-  //   the pane-header's own onClick) is a short bounded window rather than
-  //   an unbounded "consume the next click" listener — see its own doc for
-  //   why (co1 review, PR #481, 2nd round: a drag that ends via
+  //   gesture as a drag. dragJustFinishedRef (declared above, checked by
+  //   the pane-header's own onClick) is a per-pane, short bounded window
+  //   rather than an unbounded "consume the next click" listener — see its
+  //   own doc for why (co1 review, PR #481, 2nd round: a drag that ends via
   //   blur/pointercancel/unmount with the pointer released outside the app
   //   never gets a matching click to consume at all, so a pending listener
   //   would sit on the button forever and wrongly swallow the next,
@@ -1434,7 +1439,7 @@ export default function App() {
       const finish = (commit: boolean) => {
         cleanup();
         if (!dragging) return; // was a click — let the native click event handle it
-        dragJustFinishedAtRef.current = Date.now();
+        dragJustFinishedRef.current = { paneId, finishedAt: Date.now() };
         const hit = lastHit; // stable narrowed binding — lastHit is a mutable closure var
         if (commit && hit) {
           if (hit.kind === "tab") movePaneToWindow(paneId, hit.windowId);
@@ -2327,9 +2332,14 @@ export default function App() {
                         // A real drag that just ended (committed or
                         // cancelled) can still fire this same-element
                         // native click if the pointer ended up back over
-                        // this button — see dragJustFinishedAtRef's doc.
-                        // Not this gesture's click to act on.
-                        if (shouldSuppressClickAfterDrag(dragJustFinishedAtRef.current, Date.now())) return;
+                        // THIS pane's own button — see dragJustFinishedRef's
+                        // doc. Not this gesture's click to act on; consume
+                        // it (clear the ref) so a genuinely separate second
+                        // click on this same pane isn't ALSO suppressed.
+                        if (shouldSuppressClickAfterDrag(dragJustFinishedRef.current, p.id, Date.now())) {
+                          dragJustFinishedRef.current = null;
+                          return;
+                        }
                         if (swapSource === p.id) {
                           setSwapSource(null);
                         } else if (swapSource && leaves(win.root).includes(swapSource)) {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -149,14 +149,31 @@ export function shellSplitStillValid(
   return windows.some((w) => w.id === windowId && w.team === requestedTeam);
 }
 
-// Multiple dropped files become one space-separated line of bare paths.
-// Deliberately NOT shell-quoted: the target of a drop is almost always an
-// agent CLI's own prompt line (koit's framing — "same as cc/codex"), not a
-// literal shell command, and quoting broke path recognition there in live
-// testing — Claude Code's own file-path heuristic doesn't match a
-// quote-wrapped string, it just reads as plain text (Codex tolerated
-// quotes fine, but the common case has to work for both).
-export function joinDroppedPaths(paths: string[]): string {
+// C0 control characters (\u0000-\u001f) and DEL (\u007f) — legal in a
+// macOS/Linux filename, but this string is about to be written straight
+// into a PTY as literal input. A newline in a filename would submit
+// whatever's currently on the target prompt the instant the file is
+// dropped; ESC-prefixed bytes are terminal control sequences, not text.
+// The whole drop is rejected rather than stripping the offending bytes:
+// stripping would silently turn the dropped path into a DIFFERENT, wrong
+// path instead of the one actually dropped (co1 review, PR #481).
+const DROP_PATH_CONTROL_CHAR_RE = /[\u0000-\u001f\u007f]/;
+
+export function hasUnsafeDropPath(paths: string[]): boolean {
+  return paths.some((p) => DROP_PATH_CONTROL_CHAR_RE.test(p));
+}
+
+// Multiple dropped files become one space-separated line of bare paths, or
+// null if any of them fails the control-character check above (the whole
+// drop is rejected, not just the unsafe path — see its doc). Deliberately
+// NOT shell-quoted: the target of a drop is almost always an agent CLI's
+// own prompt line (koit's framing — "same as cc/codex"), not a literal
+// shell command, and quoting broke path recognition there in live testing
+// — Claude Code's own file-path heuristic doesn't match a quote-wrapped
+// string, it just reads as plain text (Codex tolerated quotes fine, but
+// the common case has to work for both).
+export function joinDroppedPaths(paths: string[]): string | null {
+  if (hasUnsafeDropPath(paths)) return null;
   return paths.join(" ");
 }
 
@@ -527,6 +544,16 @@ export default function App() {
   // specific pane cell — see resolveFileDropTarget below.
   const activeRef = useRef<string>("room");
   activeRef.current = active;
+  // Force-cancels an in-flight pane-header pointer-drag (startPaneDrag
+  // below) if this component ever unmounts mid-gesture — App itself never
+  // does in practice (root component, lives for the whole session), but the
+  // event listeners it registers live on `document`/`window`, outside
+  // React's own teardown, so nothing else would ever clear them (co1
+  // review, PR #481).
+  const activePaneDragCancelRef = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    return () => activePaneDragCancelRef.current?.();
+  }, []);
   const applyAgentState = useCallback((paneId: string, state: RawState) => {
     setPaneStatus((current) => applyStateChange(current, paneId, state));
   }, []);
@@ -1064,6 +1091,8 @@ export default function App() {
           return;
         }
         setExternalDropPaneId(null);
+        const text = joinDroppedPaths(event.payload.paths);
+        if (text === null) return; // control chars in a path — reject the whole drop, write nothing
         const targetPaneId = resolveFileDropTarget(
           hitPaneId,
           windowsRef.current,
@@ -1071,7 +1100,7 @@ export default function App() {
           lastFocusedPaneIdRef.current,
         );
         if (!targetPaneId) return;
-        void invoke("pty_write", { id: targetPaneId, data: joinDroppedPaths(event.payload.paths) });
+        void invoke("pty_write", { id: targetPaneId, data: text });
       });
       if (cancelled) {
         u();
@@ -1290,11 +1319,32 @@ export default function App() {
   // bug). Deliberately does NOT call preventDefault or touch any state
   // until the pointer has actually moved past DRAG_THRESHOLD_PX: below that,
   // this is a plain click, and the existing onClick handler on the same
-  // button (unchanged) fires normally once pointerup lands back on it — the
-  // browser only suppresses that when the up-target differs from the
-  // down-target, i.e. exactly when a real drag moved the pointer elsewhere.
+  // button (unchanged) fires normally once pointerup lands back on it.
+  //
+  // Lifecycle robustness (co1 review, PR #481 — the first version only
+  // listened for pointermove/pointerup/Escape):
+  // - setPointerCapture on the source button, released on cleanup: without
+  //   it, the pointer leaving the OS window before release means pointerup
+  //   never reaches `document` at all, leaking swapSource/preview/chip and
+  //   the listeners themselves forever (a stuck "ghost" drag).
+  // - pointerId is captured at start and checked on every subsequent event
+  //   — a second pointer's events (another touch/pen input) must never
+  //   drive or finish someone else's gesture.
+  // - pointercancel and window blur (app loses focus mid-drag — e.g. an OS
+  //   dialog, Cmd-Tab) both force finish(false), same as Escape.
+  // - a real drag can still end with the pointer back over the SOURCE
+  //   button (drag out and back, or Escape-cancel then release there) —
+  //   that DOES fire a native click on it same as any other press/release
+  //   pair landing on the same element, which would otherwise also run
+  //   onClick's swap-arm toggle right after finish() already handled the
+  //   gesture as a drag. A one-shot capture-phase click listener added only
+  //   once dragging actually started consumes exactly that one click.
+  // - activePaneDragCancelRef (declared above) lets unmount force a cancel;
+  //   real listeners still live on document/window, outside React's tree.
   const startPaneDrag = useCallback(
-    (e: React.PointerEvent, paneId: string) => {
+    (e: React.PointerEvent<HTMLButtonElement>, paneId: string) => {
+      const pointerId = e.pointerId;
+      const target = e.currentTarget;
       const startX = e.clientX;
       const startY = e.clientY;
       let dragging = false;
@@ -1311,7 +1361,13 @@ export default function App() {
         });
       };
 
+      const consumeNextClick = (ev: MouseEvent) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+      };
+
       const onMove = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
         if (!dragging) {
           if (Math.hypot(ev.clientX - startX, ev.clientY - startY) < DRAG_THRESHOLD_PX) return;
           dragging = true;
@@ -1324,13 +1380,23 @@ export default function App() {
       const cleanup = () => {
         document.removeEventListener("pointermove", onMove);
         document.removeEventListener("pointerup", onUp);
+        document.removeEventListener("pointercancel", onCancel);
         document.removeEventListener("keydown", onKeyDown);
+        window.removeEventListener("blur", onBlur);
+        try {
+          target.releasePointerCapture(pointerId);
+        } catch {
+          // already released (e.g. pointercancel released it first) — fine
+        }
+        activePaneDragCancelRef.current = null;
       };
 
-      // commit=false is Escape-cancel: tear down without acting on lastHit.
+      // commit=false is Escape/blur/pointercancel: tear down without acting
+      // on lastHit.
       const finish = (commit: boolean) => {
         cleanup();
         if (!dragging) return; // was a click — let the native click event handle it
+        target.addEventListener("click", consumeNextClick, { capture: true, once: true });
         const hit = lastHit; // stable narrowed binding — lastHit is a mutable closure var
         if (commit && hit) {
           if (hit.kind === "tab") movePaneToWindow(paneId, hit.windowId);
@@ -1349,14 +1415,31 @@ export default function App() {
         setDragOverNewTab(false);
         setDragPointer(null);
       };
-      const onUp = () => finish(true);
+      const onUp = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
+        finish(true);
+      };
+      const onCancel = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return;
+        finish(false);
+      };
       const onKeyDown = (ev: KeyboardEvent) => {
         if (ev.key === "Escape") finish(false);
       };
+      const onBlur = () => finish(false);
 
       document.addEventListener("pointermove", onMove);
       document.addEventListener("pointerup", onUp);
+      document.addEventListener("pointercancel", onCancel);
       document.addEventListener("keydown", onKeyDown);
+      window.addEventListener("blur", onBlur);
+      try {
+        target.setPointerCapture(pointerId);
+      } catch {
+        // best-effort — document-level listeners above are the real
+        // delivery mechanism, capture just improves off-window reliability
+      }
+      activePaneDragCancelRef.current = () => finish(false);
     },
     [hitTestPaneDrag, movePaneToWindow, moveToNewWindow, swapPanesAcrossWindows, splitPaneBeside],
   );

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -261,6 +261,23 @@ const TIMEZONE_KEY = "agmsg-app-timezone";
 // Minimum pointer travel (px) before a pane-header pointerdown counts as a
 // drag rather than a click — see startPaneDrag.
 const DRAG_THRESHOLD_PX = 4;
+// How long after a real pane-header drag ends its own onClick should still
+// no-op for a same-element native click that follows — see
+// dragJustFinishedAtRef's doc.
+const CLICK_SUPPRESS_WINDOW_MS = 300;
+
+// Whether the pane-header's onClick should treat an incoming click as the
+// tail end of a just-finished drag gesture (no-op) rather than a genuine
+// new click on the button — see dragJustFinishedAtRef's doc for why this is
+// a short bounded window, not an unbounded "consume exactly one click"
+// listener. Pure so the two co1-requested regressions are unit-testable
+// without simulating real pointer/click event sequences: a click shortly
+// after a drag-related finish is suppressed; a click long after (or with no
+// drag having happened at all, i.e. dragFinishedAt still 0) is not (co1
+// review, PR #481, 2nd round).
+export function shouldSuppressClickAfterDrag(dragFinishedAt: number, now: number): boolean {
+  return now - dragFinishedAt < CLICK_SUPPRESS_WINDOW_MS;
+}
 // A spawnable agent type discovered from agmsg's type registry.
 export type AgentType = { name: string; cli: string; options: string[] };
 
@@ -554,6 +571,22 @@ export default function App() {
   useEffect(() => {
     return () => activePaneDragCancelRef.current?.();
   }, []);
+  // When a real pane-header drag last finished (committed OR cancelled —
+  // Escape/blur/pointercancel can still end with the pointer back over the
+  // source button, which fires a native click there same as any other
+  // same-element press/release pair). The pane-header onClick below checks
+  // this and no-ops if it's recent, so that click doesn't ALSO re-run the
+  // swap-arm toggle right after finish() already handled the gesture as a
+  // drag. A short bounded window, not an unbounded "consume the next click"
+  // listener: a drag that ends via blur/pointercancel/unmount with the
+  // release outside the app never gets a matching click AT ALL, so a
+  // pending single-shot listener would sit on the button forever and wrongly
+  // swallow the NEXT, wholly unrelated real click days later (co1 review,
+  // PR #481, 2nd round). The synthetic click reliably follows pointerup
+  // within the same task in every browser/webview this ships on, so this
+  // only needs to outlast that — generous margin, not a real risk of
+  // masking a genuinely separate later click.
+  const dragJustFinishedAtRef = useRef(0);
   const applyAgentState = useCallback((paneId: string, state: RawState) => {
     setPaneStatus((current) => applyStateChange(current, paneId, state));
   }, []);
@@ -1337,12 +1370,22 @@ export default function App() {
   //   that DOES fire a native click on it same as any other press/release
   //   pair landing on the same element, which would otherwise also run
   //   onClick's swap-arm toggle right after finish() already handled the
-  //   gesture as a drag. A one-shot capture-phase click listener added only
-  //   once dragging actually started consumes exactly that one click.
+  //   gesture as a drag. dragJustFinishedAtRef (declared above, checked by
+  //   the pane-header's own onClick) is a short bounded window rather than
+  //   an unbounded "consume the next click" listener — see its own doc for
+  //   why (co1 review, PR #481, 2nd round: a drag that ends via
+  //   blur/pointercancel/unmount with the pointer released outside the app
+  //   never gets a matching click to consume at all, so a pending listener
+  //   would sit on the button forever and wrongly swallow the next,
+  //   unrelated real click).
   // - activePaneDragCancelRef (declared above) lets unmount force a cancel;
   //   real listeners still live on document/window, outside React's tree.
+  //   Also force-cancels any still-active PRIOR gesture at the start of a
+  //   new one — multi-pointer input could otherwise overwrite the ref
+  //   without ever tearing down the first gesture's listeners.
   const startPaneDrag = useCallback(
     (e: React.PointerEvent<HTMLButtonElement>, paneId: string) => {
+      activePaneDragCancelRef.current?.();
       const pointerId = e.pointerId;
       const target = e.currentTarget;
       const startX = e.clientX;
@@ -1359,11 +1402,6 @@ export default function App() {
           if (cur?.paneId === hit.paneId && sameZone(cur.zone, hit.zone)) return cur;
           return { paneId: hit.paneId, zone: hit.zone };
         });
-      };
-
-      const consumeNextClick = (ev: MouseEvent) => {
-        ev.preventDefault();
-        ev.stopPropagation();
       };
 
       const onMove = (ev: PointerEvent) => {
@@ -1396,7 +1434,7 @@ export default function App() {
       const finish = (commit: boolean) => {
         cleanup();
         if (!dragging) return; // was a click — let the native click event handle it
-        target.addEventListener("click", consumeNextClick, { capture: true, once: true });
+        dragJustFinishedAtRef.current = Date.now();
         const hit = lastHit; // stable narrowed binding — lastHit is a mutable closure var
         if (commit && hit) {
           if (hit.kind === "tab") movePaneToWindow(paneId, hit.windowId);
@@ -2286,6 +2324,12 @@ export default function App() {
                       }}
                       onClick={(e) => {
                         e.stopPropagation();
+                        // A real drag that just ended (committed or
+                        // cancelled) can still fire this same-element
+                        // native click if the pointer ended up back over
+                        // this button — see dragJustFinishedAtRef's doc.
+                        // Not this gesture's click to act on.
+                        if (shouldSuppressClickAfterDrag(dragJustFinishedAtRef.current, Date.now())) return;
                         if (swapSource === p.id) {
                           setSwapSource(null);
                         } else if (swapSource && leaves(win.root).includes(swapSource)) {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import {
   Maximize2,
@@ -147,6 +148,54 @@ export function shellSplitStillValid(
   if (currentTeam !== requestedTeam) return false;
   return windows.some((w) => w.id === windowId && w.team === requestedTeam);
 }
+
+// Multiple dropped files become one space-separated line of bare paths.
+// Deliberately NOT shell-quoted: the target of a drop is almost always an
+// agent CLI's own prompt line (koit's framing — "same as cc/codex"), not a
+// literal shell command, and quoting broke path recognition there in live
+// testing — Claude Code's own file-path heuristic doesn't match a
+// quote-wrapped string, it just reads as plain text (Codex tolerated
+// quotes fine, but the common case has to work for both).
+export function joinDroppedPaths(paths: string[]): string {
+  return paths.join(" ");
+}
+
+// Which pane, if any, a dropped file should land in when it didn't land on
+// any specific pane cell (dropped on the sidebar, tab bar, Team Room, ...)
+// — the active tab's actually-focused pane if it has one, else its first
+// pane, per koit's spec ("特定できない場合はactiveへ" — koit's follow-up
+// live-testing feedback: prefer the focused pane specifically, not just
+// whichever leaf happens to be first in the tree). A pane found directly
+// under the cursor is always already in the active window (inactive
+// windows' panes are display:none — see the stage render below — so
+// elementFromPoint can never hit one), so this fallback only matters for
+// the "missed every pane cell" case. lastFocusedPaneId is checked against
+// this specific window's own leaves rather than trusted blindly: it's
+// tracked globally across the whole app (TerminalPane's onFocusPane), so a
+// stale value from a pane in some OTHER tab (never focused anything in the
+// current one yet) must fall through to "first leaf", not point outside
+// the active tab entirely.
+export function resolveFileDropTarget(
+  hitPaneId: string | null,
+  windows: ReadonlyArray<Pick<Window, "id" | "root">>,
+  activeWindowId: string,
+  lastFocusedPaneId: string | null,
+): string | null {
+  if (hitPaneId) return hitPaneId;
+  const activeWindow = windows.find((w) => w.id === activeWindowId);
+  if (!activeWindow) return null;
+  const activeLeaves = leaves(activeWindow.root);
+  if (lastFocusedPaneId && activeLeaves.includes(lastFocusedPaneId)) return lastFocusedPaneId;
+  return activeLeaves[0] ?? null;
+}
+
+// The pane cell (if any) at a given viewport point — shared by the internal
+// pointer-drag hit-test and the external file-drop handler. Not unit-
+// testable in isolation (elementFromPoint needs real layout, which jsdom
+// doesn't compute); exercised via manual live testing instead.
+function paneIdAtPoint(x: number, y: number): string | null {
+  return document.elementFromPoint(x, y)?.closest<HTMLElement>("[data-pane-id]")?.dataset.paneId ?? null;
+}
 // A pane being dragged, and where within the target pane it's hovering —
 // drives both the drop classification (paneTree's classifyDrop) and the
 // half-occupied preview highlight (see dropPreview below). null while
@@ -192,11 +241,9 @@ const SUPPRESS_APPUSER_PROMPT_KEY = "agmsg-app-suppress-appuser-prompt";
 // AUTO_TIMEZONE, which tracks the OS timezone live rather than freezing
 // whatever was detected at first launch.
 const TIMEZONE_KEY = "agmsg-app-timezone";
-// Custom drag-and-drop MIME type for pane-swap drags (see PANE_DRAG_MIME
-// usages below) — a made-up type, not text/plain, so a stray OS file drag
-// or an unrelated drag elsewhere on the page never accidentally matches a
-// pane-cell's drop zone.
-const PANE_DRAG_MIME = "application/x-agmsg-pane";
+// Minimum pointer travel (px) before a pane-header pointerdown counts as a
+// drag rather than a click — see startPaneDrag.
+const DRAG_THRESHOLD_PX = 4;
 // A spawnable agent type discovered from agmsg's type registry.
 export type AgentType = { name: string; cli: string; options: string[] };
 
@@ -389,10 +436,10 @@ export default function App() {
   // Swap two panes' positions by name: click one pane's name to "pick it
   // up" (its id goes here), then click another pane's name in the same
   // window to swap. Click the same name again to cancel. Also doubles as
-  // the HTML5 drag source id during a drag-and-drop swap (dragstart sets
-  // it, dragend clears it) — click and drag share this one state and the
-  // same "armed" highlight, since they're just two ways to pick the same
-  // pane up.
+  // the pointer-drag source id during a drag-and-drop swap (startPaneDrag
+  // sets it once the gesture crosses the drag threshold, clears it on
+  // finish/cancel) — click and drag share this one state and the same
+  // "armed" highlight, since they're just two ways to pick the same pane up.
   const [swapSource, setSwapSource] = useState<string | null>(null);
   // The pane currently under the cursor during a drag, and which of
   // paneTree's 16 drop zones it's over — drives both the drop's outcome
@@ -406,6 +453,31 @@ export default function App() {
   // Dropping on the empty strip past the last tab moves the pane to a new
   // tab of its own — same as ctxMenu.pane.moveNewTab, just via drag.
   const [dragOverNewTab, setDragOverNewTab] = useState(false);
+  // Live cursor position while a pane-header pointer-drag is past the
+  // threshold (see startPaneDrag) — null until then, and again once the
+  // gesture ends. Only source of truth for the floating name chip that
+  // replaces the old HTML5 setDragImage ghost (pointer-event drags have no
+  // native drag-image snapshot of their own).
+  const [dragPointer, setDragPointer] = useState<{ x: number; y: number } | null>(null);
+  // Which pane, if any, an in-flight EXTERNAL file drag (from Finder/
+  // Explorer, via Tauri's onDragDropEvent — see the mount effect below) is
+  // currently hovering — reuses the same .pane-cell.drop-target highlight
+  // language as the internal drag-drop preview above, so "this pane will
+  // receive it" reads consistently regardless of what's being dragged.
+  const [externalDropPaneId, setExternalDropPaneId] = useState<string | null>(null);
+  // Most recently focused pane, across the whole app (TerminalPane's
+  // onFocusPane) — the external-file-drop fallback target when a drop
+  // misses every pane cell (koit: prefer the active tab's actual focused
+  // pane over just its first one). A plain ref, not state — nothing renders
+  // off this, it's only read inside the drag-drop effect below, so tracking
+  // it as state would just be a re-render on every pane focus change for no
+  // visible benefit. Whether it's usable depends on whether it's still in
+  // the CURRENT active window — resolveFileDropTarget checks that, not this
+  // ref directly.
+  const lastFocusedPaneIdRef = useRef<string | null>(null);
+  const handleFocusPane = useCallback((id: string) => {
+    lastFocusedPaneIdRef.current = id;
+  }, []);
   // Which tab is currently showing an inline rename input, and its draft text.
   const [renamingWindowId, setRenamingWindowId] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState("");
@@ -449,6 +521,12 @@ export default function App() {
   // or close the target tab (co1, PR #431).
   const teamRef = useRef<string>("");
   teamRef.current = team;
+  // The current tab/window id, for the external-file-drop handler (mount-
+  // once effect, refs so it doesn't need to resubscribe on every tab
+  // switch) to fall back to when a dropped file doesn't land on any
+  // specific pane cell — see resolveFileDropTarget below.
+  const activeRef = useRef<string>("room");
+  activeRef.current = active;
   const applyAgentState = useCallback((paneId: string, state: RawState) => {
     setPaneStatus((current) => applyStateChange(current, paneId, state));
   }, []);
@@ -942,6 +1020,71 @@ export default function App() {
     return () => void p.then((unlisten) => unlisten());
   }, [closeWindowPane]);
 
+  // Dragging a file from Finder/Explorer onto the app used to hand off to
+  // the webview's own default drop navigation — for an image, that meant
+  // the whole window replaced its content with the image and the app was
+  // stuck (koit bug report). Tauri's dragDropEnabled (tauri.conf.json,
+  // flipped on for this feature) intercepts the OS-level drop entirely and
+  // routes it through this native event instead, which is also what makes
+  // the fix and the feature the same change: with nothing left to hand off
+  // to, the webview never gets a chance to navigate.
+  //
+  // Mount-once (refs, not state, for the live team/windows/active lookups)
+  // — matches the teamRef/windowsRef/activeRef pattern used elsewhere for
+  // the same reason: resubscribing a Tauri listener on every tab switch
+  // would be wasteful and isn't needed since the callback always reads
+  // current refs at drop time.
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+    (async () => {
+      const isWindows = navigator.userAgent.toLowerCase().includes("windows");
+      const u = await getCurrentWebview().onDragDropEvent((event) => {
+        if (event.payload.type === "leave") {
+          setExternalDropPaneId(null);
+          return;
+        }
+        // 'enter' and 'over' both carry position. Despite the JS type
+        // being PhysicalPosition on every platform, wry's own macOS
+        // backend (wkwebview/drag_drop.rs) actually reports AppKit view
+        // POINTS — i.e. already logical/CSS-equivalent — mislabeled, not
+        // scaled; tauri-runtime-wry passes those straight through with no
+        // conversion (confirmed by reading both sources directly). Windows
+        // (webview2/drag_drop.rs, via Win32 ScreenToClient) reports real
+        // device pixels, which DOES need the devicePixelRatio divide. Using
+        // .toLogical() unconditionally halved every coordinate on a 2x
+        // Retina Mac, which was consistently landing in/near the top-left
+        // pane regardless of actual drop position (koit bug report).
+        const { x, y } = isWindows
+          ? event.payload.position.toLogical(window.devicePixelRatio)
+          : event.payload.position;
+        const hitPaneId = paneIdAtPoint(x, y);
+        if (event.payload.type !== "drop") {
+          setExternalDropPaneId(hitPaneId);
+          return;
+        }
+        setExternalDropPaneId(null);
+        const targetPaneId = resolveFileDropTarget(
+          hitPaneId,
+          windowsRef.current,
+          activeRef.current,
+          lastFocusedPaneIdRef.current,
+        );
+        if (!targetPaneId) return;
+        void invoke("pty_write", { id: targetPaneId, data: joinDroppedPaths(event.payload.paths) });
+      });
+      if (cancelled) {
+        u();
+        return;
+      }
+      unlisten = u;
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
   // Close a whole tab: kill every pane it holds.
   const closeWindow = useCallback((windowId: string) => {
     const w = windowsRef.current.find((x) => x.id === windowId);
@@ -1110,6 +1253,112 @@ export default function App() {
       setActive(targetWindowId);
     },
     [detachPane],
+  );
+
+  // Where a pane-header pointer-drag currently resolves to: a tab (move into
+  // that tab), the empty strip past the last tab (move to a brand-new tab),
+  // or another pane cell (swap or directional split, per classifyDrop) —
+  // one lookup shared by every pointermove tick during startPaneDrag below.
+  // Elements carry data-window-id/data-pane-id specifically so this can
+  // identify a target without relying on React event delegation (there's no
+  // "real" event routed to the hovered element anymore — see startPaneDrag's
+  // own doc for why).
+  type PaneDragHit =
+    | { kind: "tab"; windowId: string }
+    | { kind: "newTab" }
+    | { kind: "pane"; paneId: string; zone: ReturnType<typeof classifyDrop> };
+  const hitTestPaneDrag = useCallback((x: number, y: number, excludePaneId: string): PaneDragHit | null => {
+    const el = document.elementFromPoint(x, y);
+    if (!el) return null;
+    const tabEl = el.closest<HTMLElement>("[data-window-id]");
+    if (tabEl) return { kind: "tab", windowId: tabEl.dataset.windowId! };
+    if (el.closest(".tabs-drag-spacer")) return { kind: "newTab" };
+    const paneEl = el.closest<HTMLElement>("[data-pane-id]");
+    if (paneEl && paneEl.dataset.paneId && paneEl.dataset.paneId !== excludePaneId) {
+      const box = paneEl.getBoundingClientRect();
+      const zone = classifyDrop((x - box.left) / box.width, (y - box.top) / box.height);
+      return { kind: "pane", paneId: paneEl.dataset.paneId, zone };
+    }
+    return null;
+  }, []);
+
+  // Picks up a pane header for a drag-reorder gesture — the pointer-event
+  // replacement for the old HTML5 draggable/dragstart/dragover/drop system
+  // (removed: Tauri's dragDropEnabled, needed for real absolute paths on
+  // external file drops, disables the webview's native HTML5 drag-and-drop
+  // entirely — the two are mutually exclusive by Tauri's own design, not a
+  // bug). Deliberately does NOT call preventDefault or touch any state
+  // until the pointer has actually moved past DRAG_THRESHOLD_PX: below that,
+  // this is a plain click, and the existing onClick handler on the same
+  // button (unchanged) fires normally once pointerup lands back on it — the
+  // browser only suppresses that when the up-target differs from the
+  // down-target, i.e. exactly when a real drag moved the pointer elsewhere.
+  const startPaneDrag = useCallback(
+    (e: React.PointerEvent, paneId: string) => {
+      const startX = e.clientX;
+      const startY = e.clientY;
+      let dragging = false;
+      let lastHit: PaneDragHit | null = null;
+
+      const applyHit = (hit: PaneDragHit | null) => {
+        lastHit = hit;
+        setDragOverWindowId(hit?.kind === "tab" ? hit.windowId : null);
+        setDragOverNewTab(hit?.kind === "newTab");
+        setDropPreview((cur) => {
+          if (hit?.kind !== "pane") return null;
+          if (cur?.paneId === hit.paneId && sameZone(cur.zone, hit.zone)) return cur;
+          return { paneId: hit.paneId, zone: hit.zone };
+        });
+      };
+
+      const onMove = (ev: PointerEvent) => {
+        if (!dragging) {
+          if (Math.hypot(ev.clientX - startX, ev.clientY - startY) < DRAG_THRESHOLD_PX) return;
+          dragging = true;
+          setSwapSource(paneId);
+        }
+        setDragPointer({ x: ev.clientX, y: ev.clientY });
+        applyHit(hitTestPaneDrag(ev.clientX, ev.clientY, paneId));
+      };
+
+      const cleanup = () => {
+        document.removeEventListener("pointermove", onMove);
+        document.removeEventListener("pointerup", onUp);
+        document.removeEventListener("keydown", onKeyDown);
+      };
+
+      // commit=false is Escape-cancel: tear down without acting on lastHit.
+      const finish = (commit: boolean) => {
+        cleanup();
+        if (!dragging) return; // was a click — let the native click event handle it
+        const hit = lastHit; // stable narrowed binding — lastHit is a mutable closure var
+        if (commit && hit) {
+          if (hit.kind === "tab") movePaneToWindow(paneId, hit.windowId);
+          else if (hit.kind === "newTab") moveToNewWindow(paneId);
+          else {
+            const targetWindow = windowsRef.current.find((w) => leaves(w.root).includes(hit.paneId));
+            if (targetWindow) {
+              if (hit.zone.kind === "swap") swapPanesAcrossWindows(paneId, targetWindow.id, hit.paneId);
+              else splitPaneBeside(paneId, targetWindow.id, hit.paneId, hit.zone.side);
+            }
+          }
+        }
+        setSwapSource(null);
+        setDropPreview(null);
+        setDragOverWindowId(null);
+        setDragOverNewTab(false);
+        setDragPointer(null);
+      };
+      const onUp = () => finish(true);
+      const onKeyDown = (ev: KeyboardEvent) => {
+        if (ev.key === "Escape") finish(false);
+      };
+
+      document.addEventListener("pointermove", onMove);
+      document.addEventListener("pointerup", onUp);
+      document.addEventListener("keydown", onKeyDown);
+    },
+    [hitTestPaneDrag, movePaneToWindow, moveToNewWindow, swapPanesAcrossWindows, splitPaneBeside],
   );
 
   const setWindowLayout = useCallback((windowId: string, layout: PaneLayout) => {
@@ -1414,27 +1663,17 @@ export default function App() {
   }, []);
 
   return (
-    <div
-      className="app"
-      onClick={closeAllMenus}
-      onDragOverCapture={(e) => {
-        // WebKit doesn't reliably show a "no-drop" cursor just from
-        // dropEffect = "none" — it only trusts that value once something in
-        // the chain has preventDefault()'d, otherwise it falls back to a
-        // generic "copy" (+) cursor. So every dragover gets preventDefault()
-        // + dropEffect = "none" here first, in the capture phase (root ->
-        // target, runs before any target's own bubble-phase onDragOver
-        // below) — a real drop target's handler still runs after and
-        // overrides dropEffect back to "move". Since nothing here reads
-        // getData or acts on drop, an invalid area silently accepting the
-        // preventDefault is harmless: releasing there fires a drop event
-        // with no handler attached, i.e. still a no-op.
-        if (e.dataTransfer.types.includes(PANE_DRAG_MIME)) {
-          e.preventDefault();
-          e.dataTransfer.dropEffect = "none";
-        }
-      }}
-    >
+    <div className="app" onClick={closeAllMenus}>
+      {dragPointer && swapSource && (
+        // Follows the cursor during a pane-header pointer-drag — the visible
+        // replacement for the old HTML5 setDragImage ghost (which relied on
+        // native drag-image snapshotting pointer events don't have).
+        // pointer-events: none (App.css) so document.elementFromPoint in
+        // hitTestPaneDrag sees through it to the real target underneath.
+        <div className="pane-drag-chip" style={{ left: dragPointer.x + 10, top: dragPointer.y + 10 }}>
+          {panes.find((p) => p.id === swapSource)?.label}
+        </div>
+      )}
       {installingAgmsg && (
         <div className="startup-installing-banner">
           <span>{t("startupError.installing")}</span>
@@ -1801,6 +2040,7 @@ export default function App() {
             {teamWindows.map((w) => (
               <span
                 key={w.id}
+                data-window-id={w.id}
                 className={[
                   active === w.id ? "tab active" : "tab",
                   dragOverWindowId === w.id && "drop-target",
@@ -1812,24 +2052,6 @@ export default function App() {
                   e.stopPropagation();
                   closeAllMenus();
                   setWindowMenu({ windowId: w.id, x: e.clientX, y: e.clientY });
-                }}
-                onDragOver={(e) => {
-                  if (!e.dataTransfer.types.includes(PANE_DRAG_MIME)) return;
-                  e.preventDefault();
-                  e.dataTransfer.dropEffect = "move";
-                  setDragOverWindowId((cur) => (cur === w.id ? cur : w.id));
-                }}
-                onDragLeave={(e) => {
-                  if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                    setDragOverWindowId((cur) => (cur === w.id ? null : cur));
-                  }
-                }}
-                onDrop={(e) => {
-                  e.preventDefault();
-                  setDragOverWindowId(null);
-                  setSwapSource(null);
-                  const sourceId = e.dataTransfer.getData(PANE_DRAG_MIME);
-                  if (sourceId) movePaneToWindow(sourceId, w.id);
                 }}
               >
                 {renamingWindowId === w.id ? (
@@ -1876,24 +2098,6 @@ export default function App() {
             <div
               className={dragOverNewTab ? "tabs-drag-spacer drop-target" : "tabs-drag-spacer"}
               data-tauri-drag-region
-              onDragOver={(e) => {
-                if (!e.dataTransfer.types.includes(PANE_DRAG_MIME)) return;
-                e.preventDefault();
-                e.dataTransfer.dropEffect = "move";
-                setDragOverNewTab(true);
-              }}
-              onDragLeave={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                  setDragOverNewTab(false);
-                }
-              }}
-              onDrop={(e) => {
-                e.preventDefault();
-                setDragOverNewTab(false);
-                setSwapSource(null);
-                const sourceId = e.dataTransfer.getData(PANE_DRAG_MIME);
-                if (sourceId) moveToNewWindow(sourceId);
-              }}
             />
           </nav>
 
@@ -1951,9 +2155,10 @@ export default function App() {
               return (
                 <div
                   key={p.id}
+                  data-pane-id={p.id}
                   className={[
                     isActiveWindow ? "pane-cell" : "pane-cell inactive",
-                    preview?.kind === "swap" && "drop-target",
+                    (preview?.kind === "swap" || externalDropPaneId === p.id) && "drop-target",
                   ]
                     .filter(Boolean)
                     .join(" ")}
@@ -1974,50 +2179,6 @@ export default function App() {
                     paddingTop: cellSize ? cellSize.h / 2 : undefined,
                     paddingBottom: cellSize ? cellSize.h / 2 : undefined,
                   }}
-                  onDragOver={(e) => {
-                    // Gate on dataTransfer.types, NOT React state: dragover
-                    // fires on whatever element is under the cursor, whose
-                    // closures were made at ITS OWN last render — swapSource
-                    // there can be one render behind the dragstart that just
-                    // set it elsewhere. types is native DataTransfer state,
-                    // always current regardless of React's render timing.
-                    // (getData() itself isn't readable until the drop event —
-                    // that's a browser security restriction — types is.)
-                    if (!e.dataTransfer.types.includes(PANE_DRAG_MIME)) return;
-                    e.preventDefault(); // required to allow dropping
-                    e.dataTransfer.dropEffect = "move";
-                    // Classify by WHERE within this pane's own box the
-                    // cursor is (paneTree's 16-zone rule) — corner/center
-                    // bands mean swap (today's behavior), an edge band
-                    // means a directional split-replace on that side.
-                    const box = e.currentTarget.getBoundingClientRect();
-                    const xFrac = (e.clientX - box.left) / box.width;
-                    const yFrac = (e.clientY - box.top) / box.height;
-                    const zone = classifyDrop(xFrac, yFrac);
-                    setDropPreview((cur) => (cur?.paneId === p.id && sameZone(cur.zone, zone) ? cur : { paneId: p.id, zone }));
-                  }}
-                  onDragLeave={(e) => {
-                    // Only clear if we're leaving this cell for something
-                    // outside it — a child element's dragleave (e.g. moving
-                    // from the header onto the terminal below) shouldn't
-                    // flicker the highlight off.
-                    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                      setDropPreview((cur) => (cur?.paneId === p.id ? null : cur));
-                    }
-                  }}
-                  onDrop={(e) => {
-                    e.preventDefault();
-                    const zone = dropPreview?.paneId === p.id ? dropPreview.zone : null;
-                    setDropPreview(null);
-                    setSwapSource(null);
-                    const sourceId = e.dataTransfer.getData(PANE_DRAG_MIME);
-                    if (!sourceId || sourceId === p.id || !zone) return;
-                    if (zone.kind === "swap") {
-                      swapPanesAcrossWindows(sourceId, win.id, p.id);
-                    } else {
-                      splitPaneBeside(sourceId, win.id, p.id, zone.side);
-                    }
-                  }}
                 >
                   {preview?.kind === "split" && (
                     <div className={`pane-split-preview preview-${preview.side}`} />
@@ -2036,32 +2197,9 @@ export default function App() {
                         swapSource === p.id ? "pane-header-label swap-armed" : "pane-header-label"
                       }
                       title={t("pane.swapTitle")}
-                      draggable
-                      onDragStart={(e) => {
-                        e.dataTransfer.effectAllowed = "move";
-                        // A custom MIME type, not text/plain — so dragover
-                        // elsewhere in the page (or a stray OS file drag)
-                        // never matches PANE_DRAG_MIME and gets treated as
-                        // a valid drop target by accident.
-                        e.dataTransfer.setData(PANE_DRAG_MIME, p.id);
-                        // The label's own box is flex-stretched to fill the
-                        // header, so the browser's default drag snapshot
-                        // would be the whole bar's width. Swap in a ghost
-                        // sized to the text instead, then discard it —
-                        // setDragImage snapshots synchronously here.
-                        const ghost = document.createElement("div");
-                        ghost.textContent = p.label;
-                        ghost.className = "pane-drag-ghost";
-                        document.body.appendChild(ghost);
-                        e.dataTransfer.setDragImage(ghost, 10, 10);
-                        setTimeout(() => ghost.remove(), 0);
-                        setSwapSource(p.id);
-                      }}
-                      onDragEnd={() => {
-                        setSwapSource(null);
-                        setDropPreview(null);
-                        setDragOverWindowId(null);
-                        setDragOverNewTab(false);
+                      onPointerDown={(e) => {
+                        if (e.button !== 0) return; // left button only, same as native drag
+                        startPaneDrag(e, p.id);
                       }}
                       onClick={(e) => {
                         e.stopPropagation();
@@ -2104,6 +2242,7 @@ export default function App() {
                     active={isActiveWindow}
                     onAgentState={applyAgentState}
                     onCellSize={handleCellSize}
+                    onFocusPane={handleFocusPane}
                   />
                 </div>
               );

--- a/app/src/TerminalPane.tsx
+++ b/app/src/TerminalPane.tsx
@@ -25,6 +25,14 @@ type Props = {
   /** Reported on every fit — the pane's current cell size in CSS px, so a
    * divider drag elsewhere can snap to whole terminal rows/cols. */
   onCellSize?: (widthPx: number, heightPx: number) => void;
+  /** Fired when this pane's terminal actually receives keyboard focus (a
+   * click inside it, or Tab-focus) — xterm.js's hidden input textarea is a
+   * focusable descendant of the container div below, so a plain onFocus
+   * there catches it via the bubbled focusin React normalizes to. Lets the
+   * app track "which pane in this tab was last actually used" for the
+   * external file-drop fallback target (koit: prefer the focused pane over
+   * just the tab's first one). */
+  onFocusPane?: (id: string) => void;
 };
 
 function b64ToBytes(b64: string): Uint8Array {
@@ -38,7 +46,17 @@ function b64ToBytes(b64: string): Uint8Array {
  * One embedded agent terminal: an xterm.js view bound to a backend PTY session.
  * Output streams in via `pty-output` events; keystrokes go back via `pty_write`.
  */
-export function TerminalPane({ id, cmd, args = [], cwd, fontSize = 12, active, onAgentState, onCellSize }: Props) {
+export function TerminalPane({
+  id,
+  cmd,
+  args = [],
+  cwd,
+  fontSize = 12,
+  active,
+  onAgentState,
+  onCellSize,
+  onFocusPane,
+}: Props) {
   const ref = useRef<HTMLDivElement>(null);
   // Live handles to the current terminal/fit addon, for the font-size effect
   // below to reach — that effect must NOT be a dependency of the main effect
@@ -252,5 +270,5 @@ export function TerminalPane({ id, cmd, args = [], cwd, fontSize = 12, active, o
     return attachWebglAddon(term, () => new WebglAddon(), webglAddonRef);
   }, [active]);
 
-  return <div className="term-pane" ref={ref} />;
+  return <div className="term-pane" ref={ref} onFocus={() => onFocusPane?.(idRef.current)} />;
 }


### PR DESCRIPTION
## Summary
- Fixes koit's bug report: dragging a file onto the app used to hand off to the webview's default drop navigation (an image replaced the whole window's content and the app got stuck).
- Fix and feature are the same change: `tauri.conf.json`'s `dragDropEnabled: true` routes external OS file drops through Tauri's native `onDragDropEvent` (real absolute paths, nothing left for the webview to navigate to).
- Dropping a file onto a pane types its absolute path into that pane's terminal input (`pty_write`, no auto-Enter) — the pane under the cursor if there is one, else the active tab's most recently focused pane, else its first pane.
- Multiple files become one space-separated line of bare paths — deliberately not shell-quoted; quoting broke Claude Code's own file-path recognition in live testing (Codex tolerated it fine, but the common case needs to work for both).
- `dragDropEnabled` and the webview's native HTML5 drag-and-drop are mutually exclusive by Tauri's own design (confirmed via upstream issues + reading the wry/tauri-runtime-wry source directly). The app's existing pane/tab drag-and-drop (swap, directional split, move to tab/new-tab, cross-window swap/split) was built entirely on HTML5 `draggable`/`dragstart`/`dragover`/`drop`, so it's rewritten here on pointer events (`pointerdown`/`pointermove`/`pointerup`), matching the existing divider-drag implementation's own pattern. The click-to-arm/click-to-swap interaction is untouched — a `pointerdown` that never crosses the drag threshold does nothing, and the native `click` event fires normally.
- `TerminalPane` gains an `onFocusPane` callback (xterm's internal textarea receiving DOM focus) so the app can track which pane was last actually used, for the "drop missed every pane cell" fallback.

Scope note: koit signed off on this being bigger than a typical single-PR change up front, given the drag-and-drop rewrite this forced. One commit (not split further) — the two concerns (DnD infra rewrite, file-drop feature) ended up too interleaved within `App.tsx` across several rounds of live-testing fixes to cleanly separate after the fact without risking a broken intermediate commit.

## Manual re-test (drag-and-drop can't be exercised by unit tests — verified live with koit across several rounds)
- [x] Pane header drag → drop on another pane's center/corner → swap
- [x] Pane header drag → drop on another pane's edge → directional split
- [x] Pane header drag → drop on a different tab → moves into that tab
- [x] Pane header drag → drop on the tab-bar's empty strip → moves to a new tab
- [x] Cross-window swap/split (different tabs)
- [x] Click pane header to arm, click again to cancel (no drag)
- [x] Click pane header to arm, click another pane header to swap (no drag)
- [x] Escape cancels an in-progress drag
- [x] Floating name chip follows the cursor during a drag
- [x] Drop a file directly onto a specific pane → path lands in that pane (not always pane 1 — this needed a follow-up fix: macOS's `DragDropEvent.position` is mislabeled `PhysicalPosition` in Tauri/wry but is actually already-logical AppKit view points; unconditionally calling `.toLogical()` was double-scaling it)
- [x] Drop a file outside any pane (sidebar/tab bar) → lands in the active tab's focused pane (needed a follow-up: originally fell back to the tab's first pane, koit wanted "the pane I was actually using")
- [x] Drop an image → no more fullscreen hijack, path types in as text instead
- [x] Multiple files dropped together → space-separated paths, both present

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 166/166 passing (new coverage: `resolveFileDropTarget`, `joinDroppedPaths`)
- [x] `cargo check --no-default-features` clean