### PR TITLE
fix: close #87-class SQLi/path-hazard gaps in rename/leave/reset/rename-team/team/api

### DIFF
--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -37,6 +37,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/validate.sh"
 
 _agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
 
@@ -158,6 +160,10 @@ route_get() {
         return
       fi
       local team="$1"
+      # Rejects path traversal ('/', '\', '..') before $team is ever spliced
+      # into a filesystem path (get_members below) — was previously
+      # unvalidated at this entry point (#87 cluster / F13-F15).
+      agmsg_validate_team_name "$team" || exit 1
       shift
       local sub="${1:?Usage: api.sh get teams <team> members|messages ...}"
       shift

--- a/scripts/leave.sh
+++ b/scripts/leave.sh
@@ -11,7 +11,9 @@ AGENT_ID="${2:?Missing agent_id}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 
-# Reject team names that would escape teams/ as a path segment (#140).
+# Reject team names that would escape teams/ as a path segment (#140), and
+# agent names that would misroute the $.agents.<name> JSON path below (#87
+# cluster — '.', '/', '\', '"', '[', ']' all have path meaning to json1).
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/validate.sh"
 # shellcheck disable=SC1091
@@ -19,6 +21,14 @@ source "$SCRIPT_DIR/lib/storage.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/registry-lock.sh"
 agmsg_validate_team_name "$TEAM" || exit 1
+agmsg_validate_agent_name "$AGENT_ID" || exit 1
+
+# Escape as a SQL string literal (parity with join.sh/rename.sh): concatenated
+# into the JSON path below as `'$.agents.' || '<escaped>'` rather than spliced
+# into the path text, so a single quote in the name can't break the statement
+# (#87 cluster).
+_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
+AGENT_ID_SQL=$(_agmsg_sqlesc "$AGENT_ID")
 
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
 
@@ -33,17 +43,24 @@ fi
 agmsg_lock_acquire "$TEAMS_DIR/$TEAM" || exit 1
 CONFIG_ESCAPED=$(sed "s/'/''/g" "$TEAM_CONFIG")
 
-# Check if agent exists
-EXISTS=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
-  "SELECT json_extract(:json, '$.agents.$AGENT_ID');")
+# Check if agent exists.
+# CONFIG_ESCAPED is spliced as a genuine SQL string literal here, NOT bound
+# via `.param set`: the sqlite3 shell's dot-command tokenizer does not honour
+# SQL '' escaping (unlike a real SQL statement's string literals), so
+# `.param set :json '$CONFIG_ESCAPED'` silently mis-parses as soon as the
+# config contains any single quote — e.g. an existing agent name like
+# "al'ice" — corrupting :json for every query below it (#87 cluster; see
+# resolve-project.sh's `resolve_team` for the same caveat).
+EXISTS=$(agmsg_sqlite_mem \
+  "SELECT json_extract('$CONFIG_ESCAPED', '\$.agents.' || '$AGENT_ID_SQL');")
 if [ -z "$EXISTS" ] || [ "$EXISTS" = "null" ]; then
   echo "Agent $AGENT_ID not in team $TEAM"
   exit 1
 fi
 
 # Remove agent
-UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
-  "SELECT json_remove(:json, '$.agents.$AGENT_ID');")
+UPDATED=$(agmsg_sqlite_mem \
+  "SELECT json_remove('$CONFIG_ESCAPED', '\$.agents.' || '$AGENT_ID_SQL');")
 
 # Check if agents is now empty
 AGENT_COUNT=$(agmsg_sqlite_mem \

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -74,8 +74,21 @@ mv "$OLD_DIR/config.json" "$NEW_DIR/config.json"
 NEW_CONFIG="$NEW_DIR/config.json"
 if [ -f "$NEW_CONFIG" ]; then
   CONFIG_ESCAPED=$(sed "s/'/''/g" "$NEW_CONFIG")
-  UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
-    "SELECT json_set(:json, '\$.name', '$NEW_TEAM');")
+  # NEW_TEAM is a SQL string VALUE here (not a JSON path key), but it still
+  # needs the same single-quote escaping as every other interpolated
+  # identifier in this file — a team name with a quote would otherwise break
+  # out of the '$NEW_TEAM' literal below (#87 cluster; this call site had
+  # been missed).
+  NEW_TEAM_SQL=$(_agmsg_sqlesc "$NEW_TEAM")
+  # CONFIG_ESCAPED is spliced as a genuine SQL string literal below, NOT
+  # bound via `.param set`: the sqlite3 shell's dot-command tokenizer does
+  # not honour SQL '' escaping (unlike a real SQL statement's string
+  # literals), so `.param set :json '...'` silently mis-parses as soon as
+  # the config contains any single quote — e.g. an existing agent name like
+  # "al'ice" — corrupting :json (#87 cluster; see resolve-project.sh's
+  # `resolve_team` for the same caveat).
+  UPDATED=$(agmsg_sqlite_mem \
+    "SELECT json_set('$CONFIG_ESCAPED', '\$.name', '$NEW_TEAM_SQL');")
   agmsg_write_atomic "$NEW_CONFIG" "$UPDATED"
 fi
 

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -13,15 +13,26 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/registry-lock.sh"
-# Reject team names that would escape teams/ as a path segment (#140).
+# Reject team names that would escape teams/ as a path segment (#140), and
+# agent names that would misroute the $.agents.<name> JSON path below (#87
+# cluster — '.', '/', '\', '"', '[', ']' all have path meaning to json1).
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/validate.sh"
 agmsg_validate_team_name "$TEAM" || exit 1
+agmsg_validate_agent_name "$OLD_NAME" || exit 1
+agmsg_validate_agent_name "$NEW_NAME" || exit 1
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 DB="$(agmsg_db_path)"
 # Escape interpolated identifiers as SQL string literals (parity with
 # send.sh): a team/agent name with a single quote would break the UPDATE.
 _agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
+# Computed up front: every $.agents.<name> path lookup below concatenates
+# these as escaped SQL string literals (`'$.agents.' || '<escaped>'`) rather
+# than splicing the raw name into the path text, so a name containing a
+# single quote can't break out of the surrounding SQL statement (#87 cluster
+# — join.sh's PR272 fix for the same bug class, applied here).
+OLD_NAME_SQL=$(_agmsg_sqlesc "$OLD_NAME")
+NEW_NAME_SQL=$(_agmsg_sqlesc "$NEW_NAME")
 TEAM_CONFIG="$TEAMS_DIR/$TEAM/config.json"
 
 if [ ! -f "$TEAM_CONFIG" ]; then
@@ -36,25 +47,33 @@ agmsg_lock_acquire "$TEAMS_DIR/$TEAM" || exit 1
 # --- Update team config ---
 CONFIG_ESCAPED=$(sed "s/'/''/g" "$TEAM_CONFIG")
 
+# CONFIG_ESCAPED/UPDATED_ESCAPED are spliced as genuine SQL string literals
+# below, NOT bound via `.param set`: the sqlite3 shell's dot-command
+# tokenizer does not honour SQL '' escaping (unlike a real SQL statement's
+# string literals), so `.param set :json '...'` silently mis-parses as soon
+# as the JSON contains any single quote — e.g. an agent name like "al'ice"
+# — corrupting :json for every query below it (#87 cluster; see
+# resolve-project.sh's `resolve_team` for the same caveat).
+
 # Check old exists
-OLD_VAL=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
-  "SELECT json_extract(:json, '$.agents.$OLD_NAME');")
+OLD_VAL=$(agmsg_sqlite_mem \
+  "SELECT json_extract('$CONFIG_ESCAPED', '\$.agents.' || '$OLD_NAME_SQL');")
 if [ -z "$OLD_VAL" ] || [ "$OLD_VAL" = "null" ]; then
   echo "Agent $OLD_NAME not in team $TEAM"
   exit 1
 fi
 
 # Check new doesn't exist
-NEW_VAL=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
-  "SELECT json_extract(:json, '$.agents.$NEW_NAME');")
+NEW_VAL=$(agmsg_sqlite_mem \
+  "SELECT json_extract('$CONFIG_ESCAPED', '\$.agents.' || '$NEW_NAME_SQL');")
 if [ -n "$NEW_VAL" ] && [ "$NEW_VAL" != "null" ]; then
   echo "Agent $NEW_NAME already exists in team $TEAM"
   exit 1
 fi
 
 # Rename: set new key with old value, remove old key
-UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
-  "SELECT json_remove(json_set(:json, '$.agents.$NEW_NAME', json_extract(:json, '$.agents.$OLD_NAME')), '$.agents.$OLD_NAME');")
+UPDATED=$(agmsg_sqlite_mem \
+  "SELECT json_remove(json_set('$CONFIG_ESCAPED', '\$.agents.' || '$NEW_NAME_SQL', json_extract('$CONFIG_ESCAPED', '\$.agents.' || '$OLD_NAME_SQL')), '\$.agents.' || '$OLD_NAME_SQL');")
 
 # Tombstone the old name so a later join/actas can't silently revive it (#360):
 # a CLI's slash-command history can resubmit `/agmsg actas <old_name>` well
@@ -62,17 +81,16 @@ UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
 # re-materialize <old_name>, rolling the rename back with no warning.
 # Stored as an array of {from,to,at} entries (rather than keying an object by
 # the old name) so a name containing a single quote can't break the JSON path
-# expression the way `$.agents.$OLD_NAME` above requires it not to — from/to
-# are bound as ordinary SQL string values, never spliced into a path.
-OLD_NAME_SQL=$(_agmsg_sqlesc "$OLD_NAME")
-NEW_NAME_SQL=$(_agmsg_sqlesc "$NEW_NAME")
+# expression the way a raw `$.agents.$OLD_NAME` splice would — from/to are
+# bound as ordinary SQL string values, never spliced into a path.
+# (OLD_NAME_SQL/NEW_NAME_SQL already computed above.)
 RENAMED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 UPDATED_ESCAPED=$(printf '%s' "$UPDATED" | sed "s/'/''/g")
-UPDATED=$(agmsg_sqlite_mem ".param set :json '$UPDATED_ESCAPED'" \
-  "SELECT json_set(:json, '\$.renamed',
+UPDATED=$(agmsg_sqlite_mem \
+  "SELECT json_set('$UPDATED_ESCAPED', '\$.renamed',
      json_insert(
-       CASE WHEN json_type(json_extract(:json, '\$.renamed')) = 'array'
-            THEN json_extract(:json, '\$.renamed') ELSE json('[]') END,
+       CASE WHEN json_type(json_extract('$UPDATED_ESCAPED', '\$.renamed')) = 'array'
+            THEN json_extract('$UPDATED_ESCAPED', '\$.renamed') ELSE json('[]') END,
        '\$[#]', json_object('from', '$OLD_NAME_SQL', 'to', '$NEW_NAME_SQL', 'at', '$RENAMED_AT')
      )
    );")

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -26,6 +26,15 @@ source "$SCRIPT_DIR/lib/resolve-project.sh"
 source "$SCRIPT_DIR/lib/storage.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/registry-lock.sh"
+# Agent names that would misroute the $.agents.<name> JSON path below (#87
+# cluster — '.', '/', '\', '"', '[', ']' all have path meaning to json1).
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/validate.sh"
+# Escape as a SQL string literal (parity with join.sh/rename.sh/leave.sh):
+# concatenated into JSON paths below as `'$.agents.' || '<escaped>'` rather
+# than spliced into the path text, so a single quote can't break the
+# statement (#87 cluster).
+_agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
 
 # Resolve the session's real project root (see #92) so a drop issued from a
 # subdir/worktree clears the registration on the project the session lives in.
@@ -56,6 +65,10 @@ if [ -z "$TARGET_AGENT" ]; then
   fi
 fi
 
+agmsg_validate_agent_name "$TARGET_AGENT" || exit 1
+TARGET_AGENT_SQL=$(_agmsg_sqlesc "$TARGET_AGENT")
+AGENT_TYPE_SQL=$(_agmsg_sqlesc "$AGENT_TYPE")
+
 if [ ! -d "$TEAMS_DIR" ]; then
   echo "No team registrations found."
   exit 0
@@ -81,8 +94,15 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
   fi
   CONFIG_ESCAPED=$(sed "s/'/''/g" "$TEAM_CONFIG")
 
-  AGENT_JSON=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
-    "SELECT json_extract(:json, '$.agents.$TARGET_AGENT');")
+  # CONFIG_ESCAPED is spliced as a genuine SQL string literal below, NOT
+  # bound via `.param set`: the sqlite3 shell's dot-command tokenizer does
+  # not honour SQL '' escaping (unlike a real SQL statement's string
+  # literals), so `.param set :json '...'` silently mis-parses as soon as
+  # the config contains any single quote — e.g. an existing agent name like
+  # "al'ice" — corrupting :json for every query below it (#87 cluster; see
+  # resolve-project.sh's `resolve_team` for the same caveat).
+  AGENT_JSON=$(agmsg_sqlite_mem \
+    "SELECT json_extract('$CONFIG_ESCAPED', '\$.agents.' || '$TARGET_AGENT_SQL');")
   if [ -z "$AGENT_JSON" ] || [ "$AGENT_JSON" = "null" ]; then
     agmsg_lock_release
     continue
@@ -108,7 +128,7 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
   MATCH_COUNT=$(agmsg_sqlite_mem "
     SELECT count(*)
     FROM json_each(json_extract('$NORMALIZED_ESCAPED', '\$.registrations'))
-    WHERE json_extract(value, '\$.type') = '$AGENT_TYPE'
+    WHERE json_extract(value, '\$.type') = '$AGENT_TYPE_SQL'
       AND json_extract(value, '\$.project') IN ($PROJECT_SQL_IN);
   ")
   if [ "$MATCH_COUNT" -eq 0 ]; then
@@ -123,7 +143,7 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
         SELECT json_group_array(json(value))
         FROM json_each(json_extract('$NORMALIZED_ESCAPED', '\$.registrations'))
         WHERE NOT (
-          json_extract(value, '\$.type') = '$AGENT_TYPE'
+          json_extract(value, '\$.type') = '$AGENT_TYPE_SQL'
           AND json_extract(value, '\$.project') IN ($PROJECT_SQL_IN)
         )
       ), json('[]'))
@@ -135,11 +155,11 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
   ")
 
   if [ "$REMAINING" -eq 0 ]; then
-    UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
-      "SELECT json_remove(:json, '$.agents.$TARGET_AGENT');")
+    UPDATED=$(agmsg_sqlite_mem \
+      "SELECT json_remove('$CONFIG_ESCAPED', '\$.agents.' || '$TARGET_AGENT_SQL');")
   else
-    UPDATED=$(agmsg_sqlite_mem ".param set :json '$CONFIG_ESCAPED'" \
-      "SELECT json_set(:json, '$.agents.$TARGET_AGENT', json('$FILTERED_ESCAPED'));")
+    UPDATED=$(agmsg_sqlite_mem \
+      "SELECT json_set('$CONFIG_ESCAPED', '\$.agents.' || '$TARGET_AGENT_SQL', json('$FILTERED_ESCAPED'));")
   fi
 
   AGENT_COUNT=$(agmsg_sqlite_mem "

--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -24,6 +24,15 @@ echo "Team: $TEAM"
 echo ""
 
 COUNT=0
+# CONFIG_ESCAPED is spliced as a genuine SQL string literal below, NOT bound
+# via `.param set`: the sqlite3 shell's dot-command tokenizer does not
+# honour SQL '' escaping (unlike a real SQL statement's string literals), so
+# `.param set :json '...'` silently mis-parses as soon as the config
+# contains any single quote — e.g. an agent name like "al'ice" — and prints
+# `.parameter`'s own usage help as if it were query output, with exit 0
+# (#87 cluster; see resolve-project.sh's `resolve_team` for the same
+# caveat).
+CONFIG_ESCAPED=$(sed "s/'/''/g" "$CONFIG")
 while IFS='	' read -r name types project registrations; do
   if [ "${registrations:-0}" -gt 1 ]; then
     echo "  $name ($types) — $project (+$((registrations - 1)) more)"
@@ -34,21 +43,20 @@ while IFS='	' read -r name types project registrations; do
 # tr -d '\r': sqlite3.exe on Windows emits CRLF rows; the trailing CR would make
 # the `registrations` field "N\r" and trip the integer test in the loop (#130).
 done < <(sqlite3 -separator '	' :memory: \
-  ".param set :json '$(sed "s/'/''/g" "$CONFIG")'" \
   "WITH agents AS (
      SELECT
        key AS name,
        CASE
-         WHEN json_type(json_extract(value, '$.registrations')) = 'array' THEN json_extract(value, '$.registrations')
-         ELSE json_array(json_object('type', json_extract(value, '$.type'), 'project', json_extract(value, '$.project')))
+         WHEN json_type(json_extract(value, '\$.registrations')) = 'array' THEN json_extract(value, '\$.registrations')
+         ELSE json_array(json_object('type', json_extract(value, '\$.type'), 'project', json_extract(value, '\$.project')))
        END AS registrations
-     FROM json_each(json_extract(:json, '$.agents'))
+     FROM json_each(json_extract('$CONFIG_ESCAPED', '\$.agents'))
    )
    SELECT
      name,
-     group_concat(DISTINCT json_extract(r.value, '$.type')),
+     group_concat(DISTINCT json_extract(r.value, '\$.type')),
      COALESCE((
-       SELECT json_extract(r2.value, '$.project')
+       SELECT json_extract(r2.value, '\$.project')
        FROM json_each(agents.registrations) AS r2
        ORDER BY CAST(r2.key AS INTEGER) DESC
        LIMIT 1

--- a/tests/test_api.bats
+++ b/tests/test_api.bats
@@ -75,6 +75,13 @@ json_valid_line() {
   [ -z "$output" ]
 }
 
+@test "api: rejects a team name with path traversal (../) before it reaches the filesystem (#87 cluster)" {
+  run bash "$SCRIPTS/api.sh" get teams "../../escape-api" members
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "path traversal" ]]
+  [ ! -f "$(dirname "$TEST_SKILL_DIR")/escape-api/config.json" ]
+}
+
 # --- get teams <team> messages ---
 
 @test "api: get teams <team> messages returns sent messages oldest-first" {

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -156,6 +156,26 @@ EOF
   [ ! -d "$TEST_SKILL_DIR/teams/myteam" ]
 }
 
+@test "leave: an agent name containing a single quote doesn't break the underlying SQL statement (#87-class)" {
+  local agent="al'ice"
+  bash "$SCRIPTS/join.sh" myteam "$agent" claude-code /tmp/proj
+  bash "$SCRIPTS/join.sh" myteam bob claude-code /tmp/proj-b
+  run bash "$SCRIPTS/leave.sh" myteam "$agent"
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ "syntax error" ]]
+  [[ ! "$output" =~ ".parameter" ]]
+  run bash "$SCRIPTS/team.sh" myteam
+  [[ ! "$output" =~ "$agent" ]]
+  [[ "$output" =~ "bob" ]]
+}
+
+@test "leave: rejects an agent name containing path-hazard characters" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj
+  run bash "$SCRIPTS/leave.sh" myteam "al.ice"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "must not contain" ]]
+}
+
 # --- team.sh ---
 
 @test "team: shows team members with types" {
@@ -167,6 +187,17 @@ EOF
   [[ "$output" =~ "claude-code" ]]
   [[ "$output" =~ "bob" ]]
   [[ "$output" =~ "codex" ]]
+}
+
+@test "team: an agent name containing a single quote doesn't break the underlying SQL statement (#87-class)" {
+  local agent="al'ice"
+  bash "$SCRIPTS/join.sh" myteam "$agent" claude-code /tmp/proj
+  run bash "$SCRIPTS/team.sh" myteam
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "$agent" ]]
+  [[ ! "$output" =~ ".parameter" ]]
+  [[ ! "$output" =~ "Manage SQL parameter bindings" ]]
+  [ "$(echo "$output" | grep -c "$agent")" -eq 1 ]
 }
 
 # --- whoami.sh ---
@@ -327,6 +358,23 @@ EOF
   [ ! -d "$TEST_SKILL_DIR/teams/myteam" ]
 }
 
+@test "reset: an explicit agent_id containing a single quote doesn't break the underlying SQL statement (#87-class)" {
+  local agent="al'ice"
+  bash "$SCRIPTS/join.sh" myteam "$agent" claude-code /tmp/proj-a
+  run bash "$SCRIPTS/reset.sh" /tmp/proj-a claude-code "$agent"
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ "syntax error" ]]
+  [[ ! "$output" =~ ".parameter" ]]
+  [[ "$output" =~ "removed 1 registration" ]]
+  [ ! -d "$TEST_SKILL_DIR/teams/myteam" ]
+}
+
+@test "reset: rejects an explicit agent_id containing path-hazard characters" {
+  run bash "$SCRIPTS/reset.sh" /tmp/proj-a claude-code "al.ice"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "must not contain" ]]
+}
+
 # --- rename-team.sh ---
 
 @test "rename-team: renames the team dir and updates config.json name" {
@@ -338,6 +386,20 @@ EOF
   [ -f "$TEST_SKILL_DIR/teams/newteam/config.json" ]
   run sqlite_mem "SELECT json_extract(readfile('$(rf "$TEST_SKILL_DIR/teams/newteam/config.json")'), '\$.name');"
   [ "$output" = "newteam" ]
+}
+
+@test "rename-team: a new team name containing a single quote doesn't break the underlying SQL statement (#87-class)" {
+  local newteam="o'brien"
+  bash "$SCRIPTS/join.sh" oldteam alice claude-code /tmp/proj
+  run bash "$SCRIPTS/rename-team.sh" oldteam "$newteam"
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ "syntax error" ]]
+  [[ ! "$output" =~ ".parameter" ]]
+  [ -f "$TEST_SKILL_DIR/teams/$newteam/config.json" ]
+  # The "name" field must be the exact, uncorrupted string — not truncated at
+  # the quote, and not left as the old name.
+  run sqlite_mem "SELECT json_extract(readfile('$(rf "$TEST_SKILL_DIR/teams/$newteam/config.json")'), '\$.name');"
+  [ "$output" = "$newteam" ]
 }
 
 @test "rename-team: preserves agents in the team" {
@@ -431,6 +493,28 @@ EOF
   run bash "$SCRIPTS/rename.sh" myteam alice bob
   [ "$status" -ne 0 ]
   [[ "$output" =~ "Agent bob already exists" ]]
+}
+
+@test "rename: an old/new agent name containing a single quote doesn't break the underlying SQL statement (#87-class)" {
+  local old="al'ice" new="bob's-alt"
+  bash "$SCRIPTS/join.sh" myteam "$old" claude-code /tmp/proj
+  run bash "$SCRIPTS/rename.sh" myteam "$old" "$new"
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ "syntax error" ]]
+  [[ ! "$output" =~ ".parameter" ]]
+  run bash "$SCRIPTS/team.sh" myteam
+  [[ "$output" =~ "$new" ]]
+  [[ ! "$output" =~ "$old" ]]
+}
+
+@test "rename: rejects an old/new agent name containing path-hazard characters" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj
+  run bash "$SCRIPTS/rename.sh" myteam alice "al.ice"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "must not contain" ]]
+  run bash "$SCRIPTS/rename.sh" myteam "al[0]" bob
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "must not contain" ]]
 }
 
 # --- rename.sh tombstone / actas revive guard (#360) ---


### PR DESCRIPTION
## Summary

join.sh's #87/PR272 fix validated and SQL-escaped agent/team names before using them, but never spliced them into a raw JSON path string. Its sibling scripts did neither, leaving the same bug class open:

- `rename.sh`, `leave.sh`, `reset.sh` spliced `OLD_NAME`/`NEW_NAME`/`AGENT_ID`/`TARGET_AGENT` directly into `'$.agents.<name>'` JSON path literals with no validation and no escaping — a name containing a single quote could break out of the surrounding SQL statement, and one containing `.`, `/`, `[`, `]`, or `"` could misroute the path to the wrong key.
- `reset.sh` also spliced `AGENT_TYPE` unescaped into a SQL literal.
- `rename-team.sh` set the renamed team's `$.name` field from an unescaped `NEW_TEAM` value.
- `api.sh`'s `get teams <team> members` never validated `<team>` before splicing it into a filesystem path (path traversal).

Fixed by wiring in the existing `agmsg_validate_agent_name`/`agmsg_validate_team_name` gates at every entry point (mirroring join.sh), and switching every `$.agents.<name>` lookup to concatenate an escaped SQL string literal (`'$.agents.' || '<escaped>'`) instead of splicing the raw name into the path text.

### A deeper bug this surfaced

Fixing the above the "obvious" way would have silently inherited a second, pre-existing bug: `rename.sh`/`leave.sh`/`reset.sh`/`rename-team.sh`/`team.sh` all read a team's config via `.param set :json '<escaped>'` — but the sqlite3 shell's dot-command tokenizer does **not** honour SQL `''` escaping (confirmed directly: `.param set :x 'a''b'` errors out instead of binding `a'b`), so this call silently mis-parsed for any config that already contained a single quote (e.g. one pre-existing agent already named with a quote), corrupting every query built on top of it. `team.sh`'s case was worst: it printed `.param`'s own usage help text as fake member rows, with exit code 0 (false success). Fixed every such call site to splice the (already-escaped) JSON blob as a genuine SQL string literal instead of binding it through `.param set` — the same pattern `resolve-project.sh`'s `resolve_team` already uses for the identical reason.

## Test plan
- [x] `test_team.bats` — added quote-SQLi and path-hazard-rejection tests for `rename.sh`, `leave.sh`, `reset.sh`, `rename-team.sh`, `team.sh`; full suite green (96/96)
- [x] `test_api.bats` — added a path-traversal rejection test for `get teams <team> members`; full suite green
- [x] `test_actas_integration.bats` — unaffected, still green
- [x] No regressions in any of the 3 bats files touching the changed scripts