### PR TITLE
fix(remote): keep E2EE prompts interactive with token stdin

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -71,33 +71,33 @@ _remote_validate_endpoint() {
 # E2EE bootstrap starts. In a real terminal the choice/identity must therefore
 # come from the controlling TTY; otherwise the secure token path can only see
 # EOF and silently takes the abort branch. Non-interactive callers retain the
-# historical fd-0 fallback. AGMSG_REMOTE_PROMPT_FD is an internal contract-test
-# seam that models a distinct TTY input descriptor without putting secrets in
-# argv or environment values.
+# historical fd-0 fallback.
 _remote_prompt_read() {
-  local output_var="$1" prompt="$2" value="" prompt_fd="${AGMSG_REMOTE_PROMPT_FD:-}"
-  if [ -n "$prompt_fd" ]; then
-    case "$prompt_fd" in
-      [3-9]|[1-9][0-9]*) ;;
-      *)
-        echo "agmsg: invalid internal prompt file descriptor" >&2
-        return 2
-        ;;
-    esac
-    IFS= read -r -u "$prompt_fd" -p "$prompt" value || {
-      printf -v "$output_var" '%s' ""
-      return 1
-    }
-  elif [ -t 2 ]; then
-    IFS= read -r -p "$prompt" value </dev/tty || {
+  local output_var="$1" prompt="$2" silent="${3:-0}" value="" \
+    echo_newline=0 read_flags=(-r)
+  [ "$silent" -eq 1 ] && read_flags+=(-s)
+  if [ -r /dev/tty ] && [ -w /dev/tty ] && ( : </dev/tty ) 2>/dev/null; then
+    echo_newline=1
+    printf '%s' "$prompt" >/dev/tty
+    IFS= read "${read_flags[@]}" value </dev/tty || {
+      [ "$silent" -eq 1 ] && printf '\n' >/dev/tty
       printf -v "$output_var" '%s' ""
       return 1
     }
   else
-    IFS= read -r -p "$prompt" value || {
+    [ -t 0 ] && echo_newline=1
+    IFS= read "${read_flags[@]}" -p "$prompt" value || {
+      [ "$silent" -eq 1 ] && [ "$echo_newline" -eq 1 ] && printf '\n' >&2
       printf -v "$output_var" '%s' ""
       return 1
     }
+  fi
+  if [ "$silent" -eq 1 ] && [ "$echo_newline" -eq 1 ]; then
+    if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+      printf '\n' >/dev/tty
+    else
+      printf '\n' >&2
+    fi
   fi
   printf -v "$output_var" '%s' "$value"
 }
@@ -863,7 +863,7 @@ cmd_connect() {
           echo "  key.sh show $team --reveal-secret"
           echo "and paste its output below."
           local identity
-          _remote_prompt_read identity "Paste identity: " || identity=""
+          _remote_prompt_read identity "Paste identity: " 1 || identity=""
           if [ -z "$identity" ]; then
             echo "agmsg: no identity provided — if the only device that ever held this team's key is gone entirely, there is nothing to import. The historical stream stays permanently unreadable under the lost key, and rotation to start a fresh epoch is not available in this release." >&2
             exit 1

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -66,6 +66,42 @@ _remote_validate_endpoint() {
   python3 "$SCRIPT_DIR/internal/validate-endpoint.py" "$1"
 }
 
+# Read an interactive value without coupling it to the token transport.
+# `connect --token-stdin` intentionally consumes fd 0 through EOF before the
+# E2EE bootstrap starts. In a real terminal the choice/identity must therefore
+# come from the controlling TTY; otherwise the secure token path can only see
+# EOF and silently takes the abort branch. Non-interactive callers retain the
+# historical fd-0 fallback. AGMSG_REMOTE_PROMPT_FD is an internal contract-test
+# seam that models a distinct TTY input descriptor without putting secrets in
+# argv or environment values.
+_remote_prompt_read() {
+  local output_var="$1" prompt="$2" value="" prompt_fd="${AGMSG_REMOTE_PROMPT_FD:-}"
+  if [ -n "$prompt_fd" ]; then
+    case "$prompt_fd" in
+      [3-9]|[1-9][0-9]*) ;;
+      *)
+        echo "agmsg: invalid internal prompt file descriptor" >&2
+        return 2
+        ;;
+    esac
+    IFS= read -r -u "$prompt_fd" -p "$prompt" value || {
+      printf -v "$output_var" '%s' ""
+      return 1
+    }
+  elif [ -t 2 ]; then
+    IFS= read -r -p "$prompt" value </dev/tty || {
+      printf -v "$output_var" '%s' ""
+      return 1
+    }
+  else
+    IFS= read -r -p "$prompt" value || {
+      printf -v "$output_var" '%s' ""
+      return 1
+    }
+  fi
+  printf -v "$output_var" '%s' "$value"
+}
+
 # --- doctor ------------------------------------------------------------
 
 # Standalone, read-only, always-safe-to-run preflight (ADR 0007 §1): no
@@ -815,7 +851,7 @@ cmd_connect() {
       echo "  (i) Import a key you already have — do this if a teammate gave you one, or if unsure"
       echo "  (a) Abort — don't connect yet"
       local choice
-      read -r -p "[i/g/a] (default: a): " choice || choice=""
+      _remote_prompt_read choice "[i/g/a] (default: a): " || choice=""
       choice="${choice:-a}"
 
       case "$choice" in
@@ -827,7 +863,7 @@ cmd_connect() {
           echo "  key.sh show $team --reveal-secret"
           echo "and paste its output below."
           local identity
-          read -r -p "Paste identity: " identity || identity=""
+          _remote_prompt_read identity "Paste identity: " || identity=""
           if [ -z "$identity" ]; then
             echo "agmsg: no identity provided — if the only device that ever held this team's key is gone entirely, there is nothing to import. The historical stream stays permanently unreadable under the lost key, and rotation to start a fresh epoch is not available in this release." >&2
             exit 1

--- a/tests/helpers/run_remote_connect_tty.py
+++ b/tests/helpers/run_remote_connect_tty.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Drive remote connect with token stdin and a distinct controlling TTY.
+
+Token and age identity bytes are read from private files rather than argv.
+The helper waits for the identity prompt and verifies that the terminal echo
+flag is off before writing the permanent secret.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import pty
+import select
+import stat
+import subprocess
+import sys
+import termios
+import time
+
+
+TIMEOUT_SECONDS = 15
+
+
+def private_bytes(path: str, limit: int) -> bytes:
+    file_stat = os.stat(path, follow_symlinks=False)
+    if not stat.S_ISREG(file_stat.st_mode) or file_stat.st_mode & 0o077:
+        raise RuntimeError(f"fixture must be a private regular file: {path}")
+    with open(path, "rb") as handle:
+        value = handle.read(limit + 1)
+    if not value or len(value) > limit:
+        raise RuntimeError(f"fixture has invalid size: {path}")
+    return value
+
+
+def echo_enabled(fd: int) -> bool:
+    return bool(termios.tcgetattr(fd)[3] & termios.ECHO)
+
+
+def main() -> int:
+    if len(sys.argv) not in (5, 6):
+        raise RuntimeError(
+            "usage: run_remote_connect_tty.py SCRIPT ENDPOINT TOKEN_FILE "
+            "(generate|import) [IDENTITY_FILE]"
+        )
+    script, endpoint, token_path, mode = sys.argv[1:5]
+    if mode not in ("generate", "import"):
+        raise RuntimeError("mode must be generate or import")
+    if mode == "import" and len(sys.argv) != 6:
+        raise RuntimeError("import requires an identity file")
+    if mode == "generate" and len(sys.argv) != 5:
+        raise RuntimeError("generate does not accept an identity file")
+
+    token = private_bytes(token_path, 4096)
+    identity = private_bytes(sys.argv[5], 4096) if mode == "import" else None
+    master_fd, slave_fd = pty.openpty()
+    token_read, token_write = os.pipe()
+
+    def make_controlling_tty() -> None:
+        os.setsid()
+        fcntl.ioctl(slave_fd, termios.TIOCSCTTY, 0)
+
+    process = subprocess.Popen(
+        [
+            "bash",
+            script,
+            "connect",
+            "--endpoint",
+            endpoint,
+            "--token-stdin",
+            "myteam",
+        ],
+        stdin=token_read,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        close_fds=True,
+        pass_fds=(slave_fd,),
+        preexec_fn=make_controlling_tty,
+    )
+    os.close(token_read)
+    os.close(slave_fd)
+    os.write(token_write, token)
+    os.close(token_write)
+
+    output = bytearray()
+    choice_sent = False
+    identity_sent = False
+    deadline = time.monotonic() + TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        readable, _, _ = select.select([master_fd], [], [], 0.05)
+        if readable:
+            try:
+                chunk = os.read(master_fd, 65536)
+            except OSError:
+                chunk = b""
+            if not chunk:
+                if process.poll() is not None:
+                    break
+            else:
+                output.extend(chunk)
+
+        if not choice_sent and b"[i/g/a]" in output:
+            os.write(master_fd, b"g\n" if mode == "generate" else b"i\n")
+            choice_sent = True
+
+        if (
+            mode == "import"
+            and choice_sent
+            and not identity_sent
+            and b"Paste identity:" in output
+        ):
+            echo_deadline = time.monotonic() + 2
+            while echo_enabled(master_fd) and time.monotonic() < echo_deadline:
+                time.sleep(0.01)
+            if echo_enabled(master_fd):
+                process.kill()
+                raise RuntimeError("identity prompt did not disable terminal echo")
+            assert identity is not None
+            os.write(master_fd, identity + b"\n")
+            identity_sent = True
+
+        if process.poll() is not None and not readable:
+            break
+
+    if process.poll() is None:
+        process.kill()
+        process.wait()
+        raise RuntimeError("remote connect PTY fixture timed out")
+
+    while True:
+        try:
+            chunk = os.read(master_fd, 65536)
+        except OSError:
+            break
+        if not chunk:
+            break
+        output.extend(chunk)
+    os.close(master_fd)
+    sys.stdout.buffer.write(output)
+    return process.returncode
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        print(f"PTY fixture failed: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -351,13 +351,20 @@ json.dump({
 }
 
 @test "connect: token stdin remains separate from the E2EE generate prompt" {
+  skip_on_windows "PTY-backed secure prompt test requires POSIX controlling-terminal semantics"
   command -v age >/dev/null 2>&1 || skip "age not installed"
-  run bash -c "exec 3<<<'g'; printf 'good-token-enc' | AGMSG_REMOTE_PROMPT_FD=3 bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' --token-stdin myteam"
+  token_file="$(mktemp "$BATS_TEST_TMPDIR/remote-token.XXXXXX")"
+  chmod 600 "$token_file"
+  printf '%s' 'good-token-enc' > "$token_file"
+  run python3 "$BATS_TEST_DIRNAME/helpers/run_remote_connect_tty.py" \
+    "$SCRIPTS/remote.sh" "$ENDPOINT" "$token_file" generate
+  rm -f "$token_file"
   [ "$status" -eq 0 ]
   [[ "$output" == *"requires end-to-end encryption"* ]]
   [[ "$output" == *"Generated a new key for team 'myteam'"* ]]
   [[ "$output" == *"Connected: team 'myteam'"* ]]
   [[ "$output" != *"prefer --token-stdin"* ]]
+  [[ "$output" != *"good-token-enc"* ]]
 }
 
 @test "connect: encryption required + existing history still requires an explicit 'i' to import" {
@@ -372,13 +379,22 @@ json.dump({
 }
 
 @test "connect: token stdin remains separate from the E2EE import prompts" {
+  skip_on_windows "PTY-backed secure prompt test requires POSIX controlling-terminal semantics"
   command -v age >/dev/null 2>&1 || skip "age not installed"
   identity=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
-  run bash -c "exec 3<<<$'i\\n$identity\\n'; printf 'good-token-enc' | AGMSG_REMOTE_PROMPT_FD=3 bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' --token-stdin myteam"
+  token_file="$(mktemp "$BATS_TEST_TMPDIR/remote-token.XXXXXX")"
+  identity_file="$(mktemp "$BATS_TEST_TMPDIR/remote-identity.XXXXXX")"
+  chmod 600 "$token_file" "$identity_file"
+  printf '%s' 'good-token-enc' > "$token_file"
+  printf '%s' "$identity" > "$identity_file"
+  run python3 "$BATS_TEST_DIRNAME/helpers/run_remote_connect_tty.py" \
+    "$SCRIPTS/remote.sh" "$ENDPOINT" "$token_file" import "$identity_file"
+  rm -f "$token_file" "$identity_file"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Imported key for team 'myteam'"* ]]
   [[ "$output" == *"Connected: team 'myteam'"* ]]
   [[ "$output" != *"prefer --token-stdin"* ]]
+  [[ "$output" != *"$identity"* ]]
 }
 
 @test "connect: encryption required + empty/EOF input on the choice prompt safely aborts (never auto-generates)" {

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -350,6 +350,16 @@ json.dump({
   [ "$status" -eq 0 ]
 }
 
+@test "connect: token stdin remains separate from the E2EE generate prompt" {
+  command -v age >/dev/null 2>&1 || skip "age not installed"
+  run bash -c "exec 3<<<'g'; printf 'good-token-enc' | AGMSG_REMOTE_PROMPT_FD=3 bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' --token-stdin myteam"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"requires end-to-end encryption"* ]]
+  [[ "$output" == *"Generated a new key for team 'myteam'"* ]]
+  [[ "$output" == *"Connected: team 'myteam'"* ]]
+  [[ "$output" != *"prefer --token-stdin"* ]]
+}
+
 @test "connect: encryption required + existing history still requires an explicit 'i' to import" {
   command -v age >/dev/null 2>&1 || skip "age not installed"
   bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/project-a >/dev/null
@@ -359,6 +369,16 @@ json.dump({
   [ "$status" -eq 0 ]
   [[ "$output" == *"Imported key for team 'myteam'"* ]]
   [[ "$output" == *"Connected: team 'myteam'"* ]]
+}
+
+@test "connect: token stdin remains separate from the E2EE import prompts" {
+  command -v age >/dev/null 2>&1 || skip "age not installed"
+  identity=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
+  run bash -c "exec 3<<<$'i\\n$identity\\n'; printf 'good-token-enc' | AGMSG_REMOTE_PROMPT_FD=3 bash '$SCRIPTS/remote.sh' connect --endpoint '$ENDPOINT' --token-stdin myteam"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Imported key for team 'myteam'"* ]]
+  [[ "$output" == *"Connected: team 'myteam'"* ]]
+  [[ "$output" != *"prefer --token-stdin"* ]]
 }
 
 @test "connect: encryption required + empty/EOF input on the choice prompt safely aborts (never auto-generates)" {


### PR DESCRIPTION
## Summary
- read E2EE bootstrap choices from the controlling terminal after token stdin reaches EOF
- retain stdin fallback for non-interactive callers
- cover generate and import flows with a distinct prompt descriptor

## Verification
- `bats tests/test_remote.bats` (47/47)
- `bash -n scripts/remote.sh`
- `git diff --check`

Dogfood stack only; keep Draft/unmerged pending review and koit gate.