### PR TITLE
fix(codex): avoid two-line grep -c count breaking record-session integer test

### DIFF
--- a/scripts/drivers/types/codex/codex-record-session.sh
+++ b/scripts/drivers/types/codex/codex-record-session.sh
@@ -71,7 +71,10 @@ else
         done | grep . | sort -u > "$tids_file"
       # Exactly one distinct matching id => unambiguously ours. 0 (nothing) or
       # >1 (concurrent codex sessions in this cwd -> ambiguous) => record nothing.
-      if [ "$(grep -c . "$tids_file" 2>/dev/null || echo 0)" -eq 1 ]; then
+      # grep -c already prints 0 on no match (exit 1), so no echo fallback --
+      # only the unreadable-file case (no output at all) needs the 0 default.
+      tid_count="$(grep -c . "$tids_file" 2>/dev/null || true)"
+      if [ "${tid_count:-0}" -eq 1 ]; then
         thread="$(head -1 "$tids_file")"
       fi
       rm -f "$tids_file"

--- a/tests/test_codex_resume.bats
+++ b/tests/test_codex_resume.bats
@@ -100,6 +100,15 @@ recorded_uuid() {
   [ -z "$(recorded_uuid team alice)" ]
 }
 
+@test "codex record: zero matches are silent (grep -c prints 0 AND exits 1)" {
+  local proj; proj="$(mktemp -d)"
+  make_rollout "elsewhere-uuid" "/some/other/cwd"
+  run env -u CODEX_THREAD_ID bash "$TYPES/codex/codex-record-session.sh" team alice "$proj"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]   # a two-line count would print "[: integer expected" here
+  [ -z "$(recorded_uuid team alice)" ]
+}
+
 @test "codex record: missing args are a no-op" {
   run bash "$TYPES/codex/codex-record-session.sh" team "" /proj
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- `codex-record-session.sh` counts candidate thread ids with `[ "$(grep -c . "$tids_file" 2>/dev/null || echo 0)" -eq 1 ]`. On zero matches `grep -c` prints `0` and exits 1, so the fallback stacks a second `0` and the test dies with `[: 0` / `0: integer expected` — on every `actas` in a cwd with no matching Codex rollout.
- Capture the count first (`|| true`) and default only the no-stdout case (`${tid_count:-0}`, missing/unreadable file). The 1-match and ambiguous >1 behaviors are unchanged.
- Regression test: the zero-match case stays silent and exits 0. Fails on the old code. No other `grep -c … || echo` combinations remain in the repo.

## Test plan
- [x] `bats tests/test_codex_resume.bats` — 10/10
- [x] `bash -n scripts/drivers/types/codex/codex-record-session.sh`, `git diff --check` clean
