### PR TITLE
docs: correct dependency claim -- Node already required for codex/spawn

### DIFF
--- a/docs/design.ja.md
+++ b/docs/design.ja.md
@@ -148,8 +148,22 @@ Claude Code コマンドは別途 `~/.claude/commands/<cmd>.md` にインスト�
 
 ## 依存関係
 
-- **bash** — シェル
-- **sqlite3** — データベースおよび JSON 操作（JSON1 拡張）
-- **awk/sed** — テキスト処理（設定、TOML 編集）
+依存関係はそれを必要とする機能の範囲に閉じる。まとめて一括要求するのでは
+ない（koitの裁定、2026-07-25:「依存は機能の範囲に閉じる」）。
 
-python3 も node も、ネットワークもデーモンも不要。
+- **core（local-onlyのメッセージング）** — `bash`、`sqlite3`（JSON1拡張
+  経由のデータベース操作とJSON操作）、`awk`/`sed`（設定・TOML編集）。上記
+  の表にあるスクリプトすべてをカバーする。python3もネットワークもデーモン
+  も不要。
+- **codex agent type / launcher付きspawn** — coreに加えて `node`
+  （`scripts/lib/node.sh` が解決する。Codex monitorの配送ブリッジ
+  `codex-bridge.js` はNodeプログラム）。launcherを持つagent typeに対して
+  `spawn.sh` は明示的にdieする（`'node' not found on PATH — spawning
+  '<type>' requires Node.js`）。
+
+常駐デーモンはどちらの階層でも不要。coreだけならネットワーク通信も一切
+発生しない。
+
+（意図的に2階層のみとしている。`age`/`python3`依存を追加するE2EEや
+remote-sync機能は`main`ではなく別ブランチに存在するため、それらの階層は
+前もってここに書かず、実際に着地するブランチ側で文書化する。）

--- a/docs/design.md
+++ b/docs/design.md
@@ -168,8 +168,23 @@ Claude Code command is installed separately to `~/.claude/commands/<cmd>.md`.
 
 ## Dependencies
 
-- **bash** — shell
-- **sqlite3** — database and JSON manipulation (JSON1 extension)
-- **awk/sed** — text processing (config, TOML editing)
+Dependencies are scoped to the feature that needs them, not installed up
+front as one bundle (koit's ruling, 2026-07-25: "dependencies stay closed
+to the scope of the feature that needs them").
 
-No python3, no node, no network, no daemon.
+- **core (local-only messaging)** — `bash`, `sqlite3` (database and JSON
+  manipulation via the JSON1 extension), `awk`/`sed` (config, TOML
+  editing). Covers every script in the table above. No python3, no
+  network, no daemon.
+- **codex agent type / launcher-based spawn** — core, plus `node`
+  (`scripts/lib/node.sh` resolves it; the Codex monitor delivery bridge,
+  `codex-bridge.js`, is a Node program). `spawn.sh` dies explicitly
+  (`'node' not found on PATH — spawning '<type>' requires Node.js`) for
+  any agent type with a launcher.
+
+No persistent daemon at either tier. Core alone makes no network calls.
+
+(This is intentionally only 2 tiers. E2EE and remote-sync features that
+add `age`/`python3` dependencies exist on other branches, not `main` —
+their tiers get documented on whichever branch they land on, not here in
+advance.)


### PR DESCRIPTION
## Summary
- `docs/design.md`/`docs/design.ja.md` claimed "no python3, no node, no network, no daemon" project-wide. The python3 half is true today (zero references under `scripts/`), but the node half isn't -- `scripts/lib/node.sh` resolves Node for the Codex monitor delivery bridge, and `spawn.sh` dies explicitly without it for any launcher-based agent type.
- Rewrites the Dependencies section as two explicit tiers: core (bash + sqlite3, still no python3) and codex agent type / launcher-based spawn (+ node).
- Deliberately stops at two tiers -- E2EE and remote-sync features that add age/python3 exist on other branches, not main, and will be documented wherever they land.
- Split out from `fix/python3-dependency-tiering` (an `integration/remote`-based branch) per mentor-cc's ruling: this fix is independent of the remote track and must not wait for it to merge.

## Test plan
- [x] Docs-only change; confirmed no test references `docs/design.md`/`docs/design.ja.md`