### PR TITLE
fix(storage): memoize the sqlite3 -escape probe instead of re-running it

### DIFF
--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -89,8 +89,15 @@ _agmsg_escape_flag() {
 }
 
 agmsg_sqlite() {
-  # shellcheck disable=SC2046  # intentional split: "-escape off" → two args, or none
-  sqlite3 $(_agmsg_escape_flag) -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@"
+  # Probe in THIS shell, not in a command substitution. `$(_agmsg_escape_flag)`
+  # ran the function in a subshell, so the memo it set was discarded on exit and
+  # the probe re-ran on every call — two sqlite3 processes per database access
+  # instead of one (#462). The memo now survives, so the probe runs once per
+  # shell. Note it is once per SHELL, not once per machine: a call made from
+  # inside a command substitution still probes in that subshell.
+  [ -n "$_AGMSG_ESCAPE_PROBED" ] || _agmsg_escape_flag >/dev/null
+  # shellcheck disable=SC2086  # intentional split: "-escape off" → two args, or none
+  sqlite3 $_AGMSG_ESCAPE_FLAG -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@"
 }
 
 # Runtime ownership seam. This is the first run/-state-in-storage primitive for

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -192,3 +192,43 @@ SH
   n=$(sqlite3 "$AGMSG_STORAGE_PATH/messages.db" "SELECT COUNT(*) FROM messages;")
   [ "$n" -eq 10 ]
 }
+
+@test "storage: the -escape probe is memoized, not re-run on every call (#462)" {
+  # `$(_agmsg_escape_flag)` ran the probe in a subshell, so the memo it set was
+  # discarded on exit and every agmsg_sqlite call spawned two sqlite3 processes
+  # instead of one. Count real invocations through a counting shim.
+  source "$SCRIPTS/lib/storage.sh"
+  local count="$BATS_TEST_TMPDIR/sqlite-calls"
+  : > "$count"
+  local real; real="$(command -v sqlite3)"
+  sqlite3() { echo call >> "$count"; "$real" "$@"; }
+
+  local i
+  for i in 1 2 3 4 5; do
+    agmsg_sqlite ":memory:" "SELECT 1;" >/dev/null 2>&1 || true
+  done
+
+  # 5 queries + exactly one probe. Before the fix this was 10.
+  [ "$(wc -l < "$count" | tr -d ' ')" -eq 6 ]
+}
+
+@test "storage: a memoized probe is inherited by command substitutions (#462)" {
+  # Subshells inherit shell variables, so once the probe has run in this shell
+  # every later $(agmsg_sqlite ...) reuses the memo instead of re-probing.
+  # (A call made before any probe still probes inside its own subshell — the
+  # memo is per shell, not per machine.)
+  source "$SCRIPTS/lib/storage.sh"
+  local count="$BATS_TEST_TMPDIR/sqlite-calls-sub"
+  local real; real="$(command -v sqlite3)"
+  sqlite3() { echo call >> "$count"; "$real" "$@"; }
+
+  agmsg_sqlite ":memory:" "SELECT 1;" >/dev/null 2>&1 || true   # primes the memo
+  : > "$count"
+
+  local i out
+  for i in 1 2 3 4 5; do
+    out="$(agmsg_sqlite ":memory:" "SELECT 1;" 2>/dev/null)" || true
+  done
+
+  [ "$(wc -l < "$count" | tr -d ' ')" -eq 5 ]
+}


### PR DESCRIPTION
Fixes #462, reported by @claude-lab-japan with the mechanism, a reproduction harness and invocation counts.

## The defect

`agmsg_sqlite` called `_agmsg_escape_flag` inside a command substitution:

```sh
sqlite3 $(_agmsg_escape_flag) -cmd ".timeout ..." "$@"
```

`$(...)` runs in a subshell, so the `_AGMSG_ESCAPE_PROBED` / `_AGMSG_ESCAPE_FLAG` assignments were discarded when that subshell exited. The probe `sqlite3 -escape off :memory: "SELECT 1;"` therefore ran again on the next call, and **every database access spawned two sqlite3 processes instead of one**. The function's own comment says "probe once", so this was unintended rather than by design.

## The fix

Run the probe in the current shell and expand the flag as a variable, which is the shape proposed in the issue.

## Measured

Counting shim, five queries in one shell:

| | sqlite3 invocations |
|---|---|
| before | 10 |
| after | 6 (five queries + one probe) |

Once the memo is primed, five queries made inside command substitutions drop from 10 invocations to 5, because subshells inherit shell variables.

## What this does not fix

The memo is **per shell, not per machine**. A process whose first database access happens inside a command substitution still probes in that subshell, so a one-shot script making a single query pays the same two invocations as before. Eliminating that would require caching the probe result across processes, which is a separate change with its own staleness questions.

## No behaviour change

`SELECT 'x'||char(31)||'y'` is byte-identical before and after (checked with `od -c`), so the raw-separator behaviour behind #102 / #143 is not regressed.

## Tests

Two regression tests count real sqlite3 invocations through a shim. Both fail on the unfixed code and pass with the fix; the existing storage, inbox and messaging suites (48 tests) stay green.

## Why this one first

#466 and #449 both name this as an amplifier of the subprocess-spawn cost they measure, so halving the per-access sqlite3 count is the cheapest available lever on those reports.