### PR TITLE
feat(spawn): support spawning into herdr panes

### DIFF
--- a/scripts/despawn.sh
+++ b/scripts/despawn.sh
@@ -56,12 +56,19 @@ kill_recorded_placement() {
   local id _proj _type
   IFS=$'\t' read -r id _proj _type < "$SPAWN_REC"
   [ -n "$id" ] || return 1
-  if command -v tmux >/dev/null 2>&1; then
-    case "$id" in
-      %*) tmux kill-pane   -t "$id" 2>/dev/null || true ;;
-      @*) tmux kill-window -t "$id" 2>/dev/null || true ;;
-    esac
-  fi
+  case "$id" in
+    herdr:*)
+      command -v herdr >/dev/null 2>&1 && herdr pane close "${id#herdr:}" 2>/dev/null || true
+      ;;
+    *)
+      if command -v tmux >/dev/null 2>&1; then
+        case "$id" in
+          %*) tmux kill-pane   -t "$id" 2>/dev/null || true ;;
+          @*) tmux kill-window -t "$id" 2>/dev/null || true ;;
+        esac
+      fi
+      ;;
+  esac
   printf '%s\t%s\t%s' "$id" "$_proj" "$_type"   # echo back for the caller
 }
 

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -580,14 +580,56 @@ launch_with_template() {
   bash -c "$cmd"
 }
 
+is_herdr_env() {
+  [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ] \
+    && command -v herdr >/dev/null 2>&1
+}
+
+launch_in_herdr() {
+  local new_id resp
+  if [ "$TMUX_TARGET" = "window" ]; then
+    local ws="${HERDR_WORKSPACE_ID:-}"
+    if [ -z "$ws" ]; then
+      echo "spawn: --window requested but \$HERDR_WORKSPACE_ID is not set; falling back to split" >&2
+      TMUX_TARGET="pane"
+      launch_in_herdr
+      return $?
+    fi
+    resp="$(herdr tab create --workspace "$ws" --label "$NAME" --cwd "$PROJECT" 2>&1)" \
+      || die "herdr tab create failed: $resp"
+    new_id="$(printf '%s' "$resp" | sed -n 's/.*"root_pane":{[^}]*"pane_id":"\([^"]*\)".*/\1/p')"
+    [ -n "$new_id" ] || die "herdr tab create: could not extract pane_id from response: $resp"
+  else
+    local dir="right"; [ "$SPLIT" = "v" ] && dir="down"
+    resp="$(herdr pane split "$HERDR_PANE_ID" --direction "$dir" --no-focus --cwd "$PROJECT" 2>&1)" \
+      || die "herdr pane split failed: $resp"
+    new_id="$(printf '%s' "$resp" | sed -n 's/.*"pane_id":"\([^"]*\)".*/\1/p')"
+    [ -n "$new_id" ] || die "herdr pane split: could not extract pane_id from response: $resp"
+  fi
+  herdr pane rename "$new_id" "$NAME" 2>/dev/null || true
+  herdr pane run "$new_id" "$BOOT" 2>/dev/null \
+    || die "herdr pane run failed for pane $new_id"
+  # Record placement with herdr: scheme tag. The herdr pane_id contains ":"
+  # (e.g. wC:pN), so despawn strips the prefix with ${id#herdr:}.
+  printf 'herdr:%s\t%s\t%s\n' "$new_id" "$PROJECT" "$AGENT_TYPE" \
+    > "$(agmsg_spawn_path "$TEAM" "$NAME")" 2>/dev/null || true
+}
+
 place_and_launch() {
+  # Priority: $TMUX (tmux-inside-herdr backward compat) → herdr → OS terminal.
   if [ -n "${TMUX:-}" ]; then
     launch_in_tmux
     echo "spawned ${AGENT_TYPE} '${NAME}' in tmux (${TMUX_TARGET})"
     return 0
   fi
 
-  # Non-tmux: open an OS terminal. A {cmd} template wins outright on any OS.
+  if is_herdr_env; then
+    launch_in_herdr
+    echo "spawned ${AGENT_TYPE} '${NAME}' in herdr (${TMUX_TARGET})"
+    return 0
+  fi
+
+  # Non-tmux/herdr: open an OS terminal. A {cmd} template wins outright on any OS.
   if [ -n "$TERMINAL_TMPL" ] && is_terminal_template "$TERMINAL_TMPL"; then
     launch_with_template
     echo "spawned ${AGENT_TYPE} '${NAME}' via custom terminal template"

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -606,13 +606,16 @@ launch_in_herdr() {
     new_id="$(printf '%s' "$resp" | sed -n 's/.*"pane_id":"\([^"]*\)".*/\1/p')"
     [ -n "$new_id" ] || die "herdr pane split: could not extract pane_id from response: $resp"
   fi
-  herdr pane rename "$new_id" "$NAME" 2>/dev/null || true
+  herdr pane rename "$new_id" "$NAME" >/dev/null 2>&1 || true
   herdr pane run "$new_id" "$BOOT" 2>/dev/null \
     || die "herdr pane run failed for pane $new_id"
   # Record placement with herdr: scheme tag. The herdr pane_id contains ":"
   # (e.g. wC:pN), so despawn strips the prefix with ${id#herdr:}.
+  local _spawn_rec
+  _spawn_rec="$(agmsg_spawn_path "$TEAM" "$NAME")"
+  mkdir -p "$(dirname "$_spawn_rec")"
   printf 'herdr:%s\t%s\t%s\n' "$new_id" "$PROJECT" "$AGENT_TYPE" \
-    > "$(agmsg_spawn_path "$TEAM" "$NAME")" 2>/dev/null || true
+    > "$_spawn_rec" 2>/dev/null || true
 }
 
 place_and_launch() {

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -585,6 +585,33 @@ is_herdr_env() {
     && command -v herdr >/dev/null 2>&1
 }
 
+# Extract one string field from a herdr JSON response by explicit path.
+#
+# herdr returns structured JSON, so the pane id must be addressed by path, not
+# by text matching. A greedy regex over the whole response picks the LAST
+# "pane_id" in it, which succeeds against a response carrying more than one
+# pane object and hands back somebody else's pane — the caller would then
+# rename it, run the boot script in it, and persist that id as the placement
+# record. Key order is not a contract either: a reordered or nested field
+# breaks a `[^}]*`-delimited match. sqlite3's JSON1 is already a core
+# dependency (whoami.sh, api.sh), so address the value directly.
+#
+# Fail closed: invalid JSON, a missing path, a non-string value, or an empty
+# string all yield empty output, and every caller treats empty as fatal.
+herdr_json_str() {
+  local resp="$1" path="$2" esc
+  esc="$(printf '%s' "$resp" | sed "s/'/''/g")"
+  agmsg_sqlite_mem "
+    WITH raw(json) AS (SELECT '$esc'),
+    doc(json) AS (SELECT CASE WHEN json_valid(json) THEN json END FROM raw)
+    SELECT CASE
+             WHEN json_type(json, '$path') = 'text'
+             THEN json_extract(json, '$path')
+           END
+    FROM doc;
+  " 2>/dev/null
+}
+
 launch_in_herdr() {
   local new_id resp
   if [ "$TMUX_TARGET" = "window" ]; then
@@ -597,14 +624,14 @@ launch_in_herdr() {
     fi
     resp="$(herdr tab create --workspace "$ws" --label "$NAME" --cwd "$PROJECT" 2>&1)" \
       || die "herdr tab create failed: $resp"
-    new_id="$(printf '%s' "$resp" | sed -n 's/.*"root_pane":{[^}]*"pane_id":"\([^"]*\)".*/\1/p')"
-    [ -n "$new_id" ] || die "herdr tab create: could not extract pane_id from response: $resp"
+    new_id="$(herdr_json_str "$resp" '$.result.root_pane.pane_id')"
+    [ -n "$new_id" ] || die "herdr tab create: could not read result.root_pane.pane_id from response: $resp"
   else
     local dir="right"; [ "$SPLIT" = "v" ] && dir="down"
     resp="$(herdr pane split "$HERDR_PANE_ID" --direction "$dir" --no-focus --cwd "$PROJECT" 2>&1)" \
       || die "herdr pane split failed: $resp"
-    new_id="$(printf '%s' "$resp" | sed -n 's/.*"pane_id":"\([^"]*\)".*/\1/p')"
-    [ -n "$new_id" ] || die "herdr pane split: could not extract pane_id from response: $resp"
+    new_id="$(herdr_json_str "$resp" '$.result.pane.pane_id')"
+    [ -n "$new_id" ] || die "herdr pane split: could not read result.pane.pane_id from response: $resp"
   fi
   herdr pane rename "$new_id" "$NAME" >/dev/null 2>&1 || true
   herdr pane run "$new_id" "$BOOT" 2>/dev/null \

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -437,10 +437,29 @@ while true; do
           if [ -z "$ACTIVE_NAME" ] || [ "$to" != "$ACTIVE_NAME" ]; then
             continue
           fi
+          # Read the placement record BEFORE reset.sh. reset.sh releases the
+          # actas lock, and the leader's despawn deletes the record as soon as
+          # it observes that lock go free — so reading it afterwards races the
+          # cleanup and would intermittently see nothing.
+          placed_id=""
+          spawn_rec="$(agmsg_spawn_path "$team" "$to")"
+          [ -f "$spawn_rec" ] && IFS=$'\t' read -r placed_id _ _ < "$spawn_rec"
           "$SCRIPT_DIR/reset.sh" "$PROJECT_PATH" "$AGENT_TYPE" "$to" "$SESSION_ID" >/dev/null 2>&1 || true
           if [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then
             tmux kill-pane -t "$TMUX_PANE" 2>/dev/null || true
-          elif [ -n "${HERDR_PANE_ID:-}" ] && command -v herdr >/dev/null 2>&1; then
+          # Closing a herdr pane needs more than "a pane id is in the
+          # environment". HERDR_* is inherited by every descendant of a herdr
+          # pane, so a watcher merely STARTED inside one — a developer running
+          # the test suite, or any agent that actas'd by hand — carries the
+          # HOST pane's id. Acting on that closes the host. Require both the
+          # full herdr environment (matching spawn's own detection) and proof
+          # that agmsg itself placed this pane: the recorded placement for this
+          # (team, agent) must name exactly the pane we are sitting in.
+          # Otherwise fall through to the manual branch. This is the herdr
+          # counterpart of the tmux path's ACTIVE_NAME gating (#109).
+          elif [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ] \
+               && [ "$placed_id" = "herdr:$HERDR_PANE_ID" ] \
+               && command -v herdr >/dev/null 2>&1; then
             herdr pane close "$HERDR_PANE_ID" 2>/dev/null || true
           else
             echo "agmsg watch: despawned '$to' (role dropped); close this window manually" >&2

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -440,6 +440,8 @@ while true; do
           "$SCRIPT_DIR/reset.sh" "$PROJECT_PATH" "$AGENT_TYPE" "$to" "$SESSION_ID" >/dev/null 2>&1 || true
           if [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then
             tmux kill-pane -t "$TMUX_PANE" 2>/dev/null || true
+          elif [ -n "${HERDR_PANE_ID:-}" ] && command -v herdr >/dev/null 2>&1; then
+            herdr pane close "$HERDR_PANE_ID" 2>/dev/null || true
           else
             echo "agmsg watch: despawned '$to' (role dropped); close this window manually" >&2
           fi

--- a/tests/test_despawn.bats
+++ b/tests/test_despawn.bats
@@ -23,11 +23,13 @@ teardown() {
   # Make the member session look alive so the leader sees a live lock to wait on.
   setup_live_owner "$RUN" sess-m
 
-  # Unset TMUX_PANE: the ctrl:despawn handler runs `tmux kill-pane -t $TMUX_PANE`,
-  # and a watcher launched from inside the developer's tmux would inherit the
-  # REAL pane id and close the session running the tests. With TMUX_PANE empty,
-  # the handler takes the "close manually" branch — role-drop is still asserted.
-  AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE bash "$SCRIPTS/watch.sh" sess-m "$PROJ" claude-code alice \
+  # Unset TMUX_PANE and HERDR_PANE_ID: the ctrl:despawn handler runs
+  # `tmux kill-pane` / `herdr pane close`, and a watcher launched from inside
+  # the developer's environment would inherit the REAL pane id and close the
+  # session running the tests. With both empty, the handler takes the "close
+  # manually" branch — role-drop is still asserted.
+  AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE -u HERDR_PANE_ID -u HERDR_ENV \
+    bash "$SCRIPTS/watch.sh" sess-m "$PROJ" claude-code alice \
     >/dev/null 2>&1 &
   local wpid=$! i
   # Wait for the watcher to attach (it claims the lock + writes the ready sentinel).
@@ -121,7 +123,8 @@ _read_at_for_body() {
   bash "$SCRIPTS/join.sh" team boss claude-code "$PROJ" >/dev/null
 
   # Broad watcher (no actas arg) — subscribes to both alice and leader.
-  AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE bash "$SCRIPTS/watch.sh" sess-broad "$PROJ" claude-code \
+  AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE -u HERDR_PANE_ID -u HERDR_ENV \
+    bash "$SCRIPTS/watch.sh" sess-broad "$PROJ" claude-code \
     >/dev/null 2>&1 &
   local wpid=$! i
   for i in 1 2 3 4 5 6 7 8 9 10; do kill -0 "$wpid" 2>/dev/null && break; sleep 0.5; done
@@ -142,4 +145,29 @@ _read_at_for_body() {
   run bash "$SCRIPTS/despawn.sh" team leader alice
   [ "$status" -eq 0 ]
   [[ "$output" == *"no-live-lock"* ]]
+}
+
+@test "despawn --force: kills a herdr: placement via herdr pane close" {
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  # Record a herdr-tagged placement (herdr: scheme prefix).
+  printf 'herdr:wC:p99\t%s\tclaude-code\n' "$PROJ" > "$RUN/spawn.team__alice"
+  printf 'somesid\n' > "$RUN/actas.team__alice.session"
+
+  # Stub herdr so we can assert the pane close call without touching real herdr.
+  local stub_bin="$TEST_SKILL_DIR/stub-bin"
+  mkdir -p "$stub_bin"
+  cat > "$stub_bin/herdr" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$HERDR_CALL_LOG"
+echo '{"id":"cli:pane:close","result":{"type":"ok"}}'
+STUB
+  chmod +x "$stub_bin/herdr"
+  export HERDR_CALL_LOG="$TEST_SKILL_DIR/herdr-calls.log"
+
+  run env PATH="$stub_bin:$PATH" bash "$SCRIPTS/despawn.sh" team leader alice --force
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status=forced"* ]]
+  [ ! -f "$RUN/spawn.team__alice" ]
+  # herdr was called with "pane close wC:p99" (prefix stripped).
+  grep -q "pane close wC:p99" "$HERDR_CALL_LOG"
 }

--- a/tests/test_despawn.bats
+++ b/tests/test_despawn.bats
@@ -8,6 +8,14 @@ load test_helper
 
 setup() {
   setup_test_env
+  # Never inherit a real herdr environment from the test runner. A watcher
+  # started here that keeps the host's HERDR_PANE_ID will, on ctrl:despawn,
+  # close the developer's own pane — the suite kills the session running it.
+  # This belongs in setup, not on individual watch.sh launches: guarding each
+  # launch site means every test added later has to remember, and one that
+  # did not (the #439 read_at test, added after this file first grew herdr
+  # awareness) is exactly how a real host pane got closed.
+  unset HERDR_ENV HERDR_PANE_ID HERDR_WORKSPACE_ID
   export PROJ="/tmp/agmsg-despawn-proj"
   export RUN="$TEST_SKILL_DIR/run"
   mkdir -p "$RUN"

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -22,9 +22,13 @@ EOF
   chmod +x "$STUB_BIN/record.sh"
   export PATH="$STUB_BIN:$PATH"
 
-  # Never inherit a real tmux server from the test runner — force the
-  # OS-terminal path, which we redirect into record.sh via a {cmd} template.
+  # Never inherit a real tmux server or herdr env from the test runner —
+  # force the OS-terminal path, which we redirect into record.sh via a {cmd}
+  # template. Unsetting HERDR_ENV/HERDR_PANE_ID is critical when the test
+  # runner itself is inside herdr: a real herdr pane split would affect the
+  # live session.
   unset TMUX
+  unset HERDR_ENV HERDR_PANE_ID HERDR_WORKSPACE_ID
   export AGMSG_TERMINAL="$STUB_BIN/record.sh {cmd}"
 
   export PROJ="$TEST_SKILL_DIR/proj"
@@ -948,4 +952,119 @@ EOF
   # ...and the bare boot path is still the launched command.
   run grep -E 'split-window .* /.*boot-' "$cap"
   [ "$status" -eq 0 ]
+}
+
+# --- herdr placement ---
+
+# Helper: set up a fake herdr binary that records calls and returns canned JSON.
+_setup_fake_herdr() {
+  local herdr_stub="$STUB_BIN/herdr"
+  export HERDR_CALL_LOG="$TEST_SKILL_DIR/herdr-calls.log"
+  cat > "$herdr_stub" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$HERDR_CALL_LOG"
+case "$1/$2" in
+  pane/split)
+    echo '{"id":"cli:pane:split","result":{"pane":{"pane_id":"wT:pN","tab_id":"wT:tA"},"type":"pane_info"}}'
+    ;;
+  pane/rename|pane/run|pane/close)
+    echo '{"id":"cli:pane:'"$2"'","result":{"type":"ok"}}'
+    ;;
+  tab/create)
+    echo '{"id":"cli:tab:create","result":{"root_pane":{"pane_id":"wT:pR","tab_id":"wT:tN"},"tab":{"tab_id":"wT:tN","label":"test"},"type":"tab_created"}}'
+    ;;
+  tab/close)
+    echo '{"id":"cli:tab:close","result":{"type":"ok"}}'
+    ;;
+  *)
+    echo '{"error":"unknown stub call: '"$*"'}' >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$herdr_stub"
+  export HERDR_ENV=1
+  export HERDR_PANE_ID="wT:pSelf"
+  export HERDR_WORKSPACE_ID="wT"
+  # Clear the terminal template so spawn does not take the template path.
+  unset AGMSG_TERMINAL
+  # Ensure the run/ directory exists for placement records.
+  mkdir -p "$TEST_SKILL_DIR/run"
+}
+
+@test "spawn: herdr split — launches in a herdr pane with herdr: placement record" {
+  _setup_fake_herdr
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"spawned claude-code 'alice' in herdr"* ]]
+
+  # herdr was called: pane split, pane rename, pane run.
+  grep -q "pane split wT:pSelf --direction right --no-focus" "$HERDR_CALL_LOG"
+  grep -q "pane rename wT:pN alice" "$HERDR_CALL_LOG"
+  grep -q "pane run wT:pN" "$HERDR_CALL_LOG"
+
+  # Placement record uses herdr: scheme tag.
+  local rec="$TEST_SKILL_DIR/run/spawn.myteam__alice"
+  [ -f "$rec" ]
+  local rec_id
+  IFS=$'\t' read -r rec_id _ _ < "$rec"
+  [ "$rec_id" = "herdr:wT:pN" ]
+}
+
+@test "spawn: herdr split --split v maps to --direction down" {
+  _setup_fake_herdr
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait --split v
+  [ "$status" -eq 0 ]
+  grep -q "pane split wT:pSelf --direction down --no-focus" "$HERDR_CALL_LOG"
+}
+
+@test "spawn: herdr --window uses tab create and extracts root_pane pane_id" {
+  _setup_fake_herdr
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait --window
+  [ "$status" -eq 0 ]
+  grep -q "tab create --workspace wT --label alice" "$HERDR_CALL_LOG"
+  grep -q "pane run wT:pR" "$HERDR_CALL_LOG"
+
+  local rec="$TEST_SKILL_DIR/run/spawn.myteam__alice"
+  [ -f "$rec" ]
+  local rec_id
+  IFS=$'\t' read -r rec_id _ _ < "$rec"
+  [ "$rec_id" = "herdr:wT:pR" ]
+}
+
+@test "spawn: herdr --window falls back to split when HERDR_WORKSPACE_ID is unset" {
+  _setup_fake_herdr
+  unset HERDR_WORKSPACE_ID
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait --window
+  [ "$status" -eq 0 ]
+  # Fell back to split, not tab create.
+  ! grep -q "tab create" "$HERDR_CALL_LOG"
+  grep -q "pane split" "$HERDR_CALL_LOG"
+}
+
+@test "spawn: tmux takes priority over herdr (backward compat for tmux-inside-herdr)" {
+  _setup_fake_herdr
+  # Set $TMUX so the tmux path wins; re-set the terminal template so the test
+  # doesn't actually run tmux (use the stub recorder).
+  export TMUX="/tmp/fake,1,0"
+  export AGMSG_TERMINAL="$STUB_BIN/record.sh {cmd}"
+  # Provide a tmux stub that just records the call.
+  cat > "$STUB_BIN/tmux" <<'TMUXSTUB'
+#!/usr/bin/env bash
+case "$1" in
+  split-window) echo "%99" ;;
+  select-pane|set-window-option) ;;
+esac
+TMUXSTUB
+  chmod +x "$STUB_BIN/tmux"
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"in tmux"* ]]
+  # herdr was NOT called.
+  [ ! -f "$HERDR_CALL_LOG" ] || ! grep -q "pane split" "$HERDR_CALL_LOG"
 }

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -963,15 +963,20 @@ _setup_fake_herdr() {
   cat > "$herdr_stub" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$HERDR_CALL_LOG"
+# Responses are overridable so a test can hand back a differently shaped
+# document (reordered keys, nested fields, extra pane objects) without
+# rewriting the stub.
+DEFAULT_SPLIT='{"id":"cli:pane:split","result":{"pane":{"pane_id":"wT:pN","tab_id":"wT:tA"},"type":"pane_info"}}'
+DEFAULT_TAB='{"id":"cli:tab:create","result":{"root_pane":{"pane_id":"wT:pR","tab_id":"wT:tN"},"tab":{"tab_id":"wT:tN","label":"test"},"type":"tab_created"}}'
 case "$1/$2" in
   pane/split)
-    echo '{"id":"cli:pane:split","result":{"pane":{"pane_id":"wT:pN","tab_id":"wT:tA"},"type":"pane_info"}}'
+    printf '%s\n' "${HERDR_SPLIT_RESPONSE:-$DEFAULT_SPLIT}"
     ;;
   pane/rename|pane/run|pane/close)
     echo '{"id":"cli:pane:'"$2"'","result":{"type":"ok"}}'
     ;;
   tab/create)
-    echo '{"id":"cli:tab:create","result":{"root_pane":{"pane_id":"wT:pR","tab_id":"wT:tN"},"tab":{"tab_id":"wT:tN","label":"test"},"type":"tab_created"}}'
+    printf '%s\n' "${HERDR_TAB_RESPONSE:-$DEFAULT_TAB}"
     ;;
   tab/close)
     echo '{"id":"cli:tab:close","result":{"type":"ok"}}'
@@ -1067,4 +1072,74 @@ TMUXSTUB
   [[ "$output" == *"in tmux"* ]]
   # herdr was NOT called.
   [ ! -f "$HERDR_CALL_LOG" ] || ! grep -q "pane split" "$HERDR_CALL_LOG"
+}
+
+# --- herdr response parsing: address the pane id by path, never by position ---
+#
+# herdr's replies are structured JSON, so key order and neighbouring objects
+# are not part of the contract. Reading the id positionally (last "pane_id" in
+# the text, or the first one inside a `[^}]*` window) silently selects a
+# different pane when the shape shifts — spawn would then rename that pane, run
+# the boot script in it, and persist its id as the placement record. These fix
+# the shapes that break positional matching.
+
+_spawn_recorded_id() {
+  local rec="$TEST_SKILL_DIR/run/spawn.myteam__alice" id
+  [ -f "$rec" ] || return 1
+  IFS=$'\t' read -r id _ _ < "$rec"
+  printf '%s' "$id"
+}
+
+@test "spawn: herdr split picks result.pane.pane_id even when another pane object follows it" {
+  _setup_fake_herdr
+  # A second pane object after the target: a trailing-match reader takes
+  # wT:pWRONG and would drive the wrong pane.
+  export HERDR_SPLIT_RESPONSE='{"id":"cli:pane:split","result":{"pane":{"pane_id":"wT:pRIGHT"},"neighbor":{"pane_id":"wT:pWRONG"}},"type":"pane_info"}'
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  grep -q "pane run wT:pRIGHT" "$HERDR_CALL_LOG"
+  ! grep -q "wT:pWRONG" "$HERDR_CALL_LOG"
+  [ "$(_spawn_recorded_id)" = "herdr:wT:pRIGHT" ]
+}
+
+@test "spawn: herdr split tolerates reordered keys in the pane object" {
+  _setup_fake_herdr
+  export HERDR_SPLIT_RESPONSE='{"result":{"type":"pane_info","pane":{"tab_id":"wT:tA","cwd":"/x","pane_id":"wT:pLAST"}},"id":"cli:pane:split"}'
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+  [ "$(_spawn_recorded_id)" = "herdr:wT:pLAST" ]
+}
+
+@test "spawn: herdr --window reads root_pane.pane_id past a nested object" {
+  _setup_fake_herdr
+  # `scroll` and `agent_session` are real herdr fields that sort before
+  # pane_id; a `[^}]*` window stops at the first closing brace and misses it.
+  export HERDR_TAB_RESPONSE='{"id":"cli:tab:create","result":{"root_pane":{"agent_session":{"kind":"id"},"scroll":{"offset_from_bottom":0},"pane_id":"wT:pNESTED"},"tab":{"tab_id":"wT:tN","pane_id":"wT:pTABWRONG"},"type":"tab_created"}}'
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait --window
+  [ "$status" -eq 0 ]
+  grep -q "pane run wT:pNESTED" "$HERDR_CALL_LOG"
+  ! grep -q "wT:pTABWRONG" "$HERDR_CALL_LOG"
+  [ "$(_spawn_recorded_id)" = "herdr:wT:pNESTED" ]
+}
+
+@test "spawn: herdr split fails closed on a malformed or unusable response" {
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  local body
+  # Not JSON at all; the right path missing; and a non-string value. None may
+  # be treated as a usable pane id, and none may leave a placement record.
+  for body in 'not json at all {{{' \
+              '{"id":"cli:pane:split","result":{"type":"ok"}}' \
+              '{"result":{"pane":{"pane_id":42}}}'; do
+    _setup_fake_herdr
+    export HERDR_SPLIT_RESPONSE="$body"
+    run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"could not read result.pane.pane_id"* ]]
+    [ ! -f "$TEST_SKILL_DIR/run/spawn.myteam__alice" ]
+    # Nothing was renamed or run against a guessed id.
+    ! grep -q "pane run" "$HERDR_CALL_LOG"
+  done
 }

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -231,7 +231,7 @@ nodetype:
   --extra-flag: extra-value
 YAML
 
-  run env -u TMUX AGMSG_TERMINAL="$stub_bin/record.sh {cmd}" \
+  run env -u TMUX -u HERDR_ENV -u HERDR_PANE_ID AGMSG_TERMINAL="$stub_bin/record.sh {cmd}" \
     AGMSG_SPAWN_OPTIONS_FILE="$opts" \
     bash "$SCRIPTS/spawn.sh" nodetype nodeagent --project "$proj" --no-wait
   [ "$status" -eq 0 ]

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -645,7 +645,7 @@ STUB
   done
   [ -e "$TEST_SKILL_DIR/run/ready.team__alice" ]
 
-  bash "$SCRIPTS/send.sh" team boss alice "ctrl:despawn" >/dev/null
+  bash "$SCRIPTS/send.sh" team bob alice "ctrl:despawn" >/dev/null
   # Wait for the watcher to process the message and exit.
   for i in 1 2 3 4 5 6 7 8 9 10; do
     kill -0 "$wpid" 2>/dev/null || break; sleep 0.5

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -618,27 +618,42 @@ _read_at_for_body() {
   [ -z "$(_read_at_for_body "M-broad-guard-alice")" ]
 }
 
-@test "watch: ctrl:despawn calls herdr pane close when HERDR_PANE_ID is set" {
-  skip_on_windows "watcher background launch under Git Bash (#182)"
+# --- ctrl:despawn, herdr placement ---
+#
+# The watcher may only close a herdr pane that agmsg itself placed. HERDR_* is
+# inherited by every descendant of a pane, so "a pane id is in the environment"
+# proves nothing about ownership — a watcher started by hand inside herdr, or
+# by a test suite, carries the HOST pane's id. Acting on that closes the host,
+# which is exactly what happened to a real session while this branch was being
+# reviewed. The gate is HERDR_ENV=1 plus a placement record naming this pane.
 
-  # Set up a fake herdr binary.
-  local stub_bin="$TEST_SKILL_DIR/stub-bin"
+# Stub `herdr` into a private bin dir; every call is appended to $2.
+_stub_herdr() {
+  local stub_bin="$1" log="$2"
   mkdir -p "$stub_bin"
-  local herdr_log="$TEST_SKILL_DIR/herdr-calls.log"
   cat > "$stub_bin/herdr" <<STUB
 #!/usr/bin/env bash
-printf '%s\n' "\$*" >> "$herdr_log"
+printf '%s\n' "\$*" >> "$log"
 echo '{"id":"cli:pane:close","result":{"type":"ok"}}'
 STUB
   chmod +x "$stub_bin/herdr"
+}
 
+# Record a herdr placement for team/alice, as spawn would have written it.
+_record_herdr_placement() {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf 'herdr:%s\t%s\tclaude-code\n' "$1" "$PROJ" \
+    > "$TEST_SKILL_DIR/run/spawn.team__alice"
+}
+
+# Launch an actas watcher for alice under a synthetic herdr environment, send
+# ctrl:despawn, and wait for it to finish. Extra env assignments come from $@.
+_despawn_under_herdr() {
+  local stub_bin="$1" errlog="$2"; shift 2
   setup_live_owner "$TEST_SKILL_DIR/run" sess-herdr
-
-  # Launch watcher with HERDR_PANE_ID set (simulating a herdr-spawned agent).
-  AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE \
-    HERDR_PANE_ID="wC:p42" HERDR_ENV=1 PATH="$stub_bin:$PATH" \
+  AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE "$@" PATH="$stub_bin:$PATH" \
     bash "$SCRIPTS/watch.sh" sess-herdr "$PROJ" claude-code alice \
-    >/dev/null 2>&1 &
+    >/dev/null 2>"$errlog" &
   local wpid=$! i
   for i in 1 2 3 4 5 6 7 8 9 10; do
     [ -e "$TEST_SKILL_DIR/run/ready.team__alice" ] && break; sleep 0.5
@@ -646,14 +661,76 @@ STUB
   [ -e "$TEST_SKILL_DIR/run/ready.team__alice" ]
 
   bash "$SCRIPTS/send.sh" team bob alice "ctrl:despawn" >/dev/null
-  # Wait for the watcher to process the message and exit.
   for i in 1 2 3 4 5 6 7 8 9 10; do
     kill -0 "$wpid" 2>/dev/null || break; sleep 0.5
   done
+  kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true
+}
 
-  # herdr pane close was called with the watcher's own pane id.
+@test "watch: ctrl:despawn closes the herdr pane agmsg placed for this role" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local stub_bin="$TEST_SKILL_DIR/stub-bin"
+  local herdr_log="$TEST_SKILL_DIR/herdr-calls.log"
+  local errlog="$TEST_SKILL_DIR/herdr-stderr.log"
+  _stub_herdr "$stub_bin" "$herdr_log"
+
+  # spawn recorded this pane as alice's placement, so the watcher owns it.
+  _record_herdr_placement wC:p42
+
+  _despawn_under_herdr "$stub_bin" "$errlog" HERDR_PANE_ID="wC:p42" HERDR_ENV=1
+
   [ -f "$herdr_log" ]
   grep -q "pane close wC:p42" "$herdr_log"
+}
 
-  kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true
+@test "watch: ctrl:despawn does NOT close a herdr pane the watcher merely inherited (no placement record)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local stub_bin="$TEST_SKILL_DIR/stub-bin"
+  local herdr_log="$TEST_SKILL_DIR/herdr-calls.log"
+  local errlog="$TEST_SKILL_DIR/herdr-stderr.log"
+  _stub_herdr "$stub_bin" "$herdr_log"
+
+  # No spawn record: this role was never placed by agmsg, so wC:p42 is the
+  # host pane the watcher happened to start in.
+  [ ! -f "$TEST_SKILL_DIR/run/spawn.team__alice" ]
+
+  _despawn_under_herdr "$stub_bin" "$errlog" HERDR_PANE_ID="wC:p42" HERDR_ENV=1
+
+  [ ! -f "$herdr_log" ] || ! grep -q "pane close" "$herdr_log"
+  grep -q "close this window manually" "$errlog"
+}
+
+@test "watch: ctrl:despawn does NOT close a herdr pane when the placement record names a different pane" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local stub_bin="$TEST_SKILL_DIR/stub-bin"
+  local herdr_log="$TEST_SKILL_DIR/herdr-calls.log"
+  local errlog="$TEST_SKILL_DIR/herdr-stderr.log"
+  _stub_herdr "$stub_bin" "$herdr_log"
+
+  # agmsg placed alice in a DIFFERENT pane; this watcher is sitting somewhere
+  # else, so it must not close either one.
+  _record_herdr_placement wC:pOTHER
+
+  _despawn_under_herdr "$stub_bin" "$errlog" HERDR_PANE_ID="wC:p42" HERDR_ENV=1
+
+  [ ! -f "$herdr_log" ] || ! grep -q "pane close" "$herdr_log"
+  grep -q "close this window manually" "$errlog"
+}
+
+@test "watch: ctrl:despawn does NOT close a herdr pane when HERDR_ENV is unset (stale id only)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local stub_bin="$TEST_SKILL_DIR/stub-bin"
+  local herdr_log="$TEST_SKILL_DIR/herdr-calls.log"
+  local errlog="$TEST_SKILL_DIR/herdr-stderr.log"
+  _stub_herdr "$stub_bin" "$herdr_log"
+
+  # Record matches, but the watcher is not running under herdr — only a stale
+  # HERDR_PANE_ID survived in the environment. spawn requires HERDR_ENV=1 to
+  # treat a process as herdr-hosted; the close path must agree.
+  _record_herdr_placement wC:p42
+
+  _despawn_under_herdr "$stub_bin" "$errlog" HERDR_PANE_ID="wC:p42"
+
+  [ ! -f "$herdr_log" ] || ! grep -q "pane close" "$herdr_log"
+  grep -q "close this window manually" "$errlog"
 }

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -14,6 +14,9 @@ setup() {
   # the walk can produce different instance IDs. Pin to bare-sid on MSYS2 so
   # both contexts agree deterministically.
   case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) export AGMSG_AGENT_PID="" ;; esac
+  # Never inherit real herdr env from the test runner to prevent accidental
+  # pane close on ctrl:despawn.
+  unset HERDR_PANE_ID HERDR_ENV
   export PROJ="/tmp/agmsg-watch-proj"
   bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
   bash "$SCRIPTS/join.sh" team bob claude-code "$PROJ" >/dev/null
@@ -613,4 +616,44 @@ _read_at_for_body() {
   # Alice's exclusive ready sentinel means this broad watcher must defer —
   # it must NOT have consumed the read state that alice's own watcher owns.
   [ -z "$(_read_at_for_body "M-broad-guard-alice")" ]
+}
+
+@test "watch: ctrl:despawn calls herdr pane close when HERDR_PANE_ID is set" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+
+  # Set up a fake herdr binary.
+  local stub_bin="$TEST_SKILL_DIR/stub-bin"
+  mkdir -p "$stub_bin"
+  local herdr_log="$TEST_SKILL_DIR/herdr-calls.log"
+  cat > "$stub_bin/herdr" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$herdr_log"
+echo '{"id":"cli:pane:close","result":{"type":"ok"}}'
+STUB
+  chmod +x "$stub_bin/herdr"
+
+  setup_live_owner "$TEST_SKILL_DIR/run" sess-herdr
+
+  # Launch watcher with HERDR_PANE_ID set (simulating a herdr-spawned agent).
+  AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE \
+    HERDR_PANE_ID="wC:p42" HERDR_ENV=1 PATH="$stub_bin:$PATH" \
+    bash "$SCRIPTS/watch.sh" sess-herdr "$PROJ" claude-code alice \
+    >/dev/null 2>&1 &
+  local wpid=$! i
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    [ -e "$TEST_SKILL_DIR/run/ready.team__alice" ] && break; sleep 0.5
+  done
+  [ -e "$TEST_SKILL_DIR/run/ready.team__alice" ]
+
+  bash "$SCRIPTS/send.sh" team boss alice "ctrl:despawn" >/dev/null
+  # Wait for the watcher to process the message and exit.
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    kill -0 "$wpid" 2>/dev/null || break; sleep 0.5
+  done
+
+  # herdr pane close was called with the watcher's own pane id.
+  [ -f "$herdr_log" ]
+  grep -q "pane close wC:p42" "$herdr_log"
+
+  kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true
 }


### PR DESCRIPTION
Origin: the implementation comes from @asayamakk's fork branch `feat/herdr-placement`, offered in #343. Their commits are rebased onto current `main` with authorship preserved; the implementation itself was not rewritten. Review fixes on top are separate commits.

Closes #343

## What this adds

`spawn` currently places an agent in a tmux pane or window, and otherwise falls back to an OS terminal. This adds [herdr](https://herdr.dev) as a third placement target, detected the same way tmux is — from environment variables the multiplexer itself sets.

- `spawn` splits a herdr pane, with `--split v` mapping to a downward split.
- `spawn --window` creates a herdr tab, and falls back to a split when `HERDR_WORKSPACE_ID` is absent.
- `despawn --force` closes a herdr-placed pane.
- A watcher that receives `ctrl:despawn` closes its own herdr pane, mirroring the existing tmux behaviour.
- Placement records gain a `herdr:` scheme tag, so `despawn` can distinguish a herdr pane id from a tmux `%pane` / `@window` id.

Detection requires `HERDR_ENV=1`, a non-empty `HERDR_PANE_ID`, and the `herdr` binary on `PATH`. `$TMUX` keeps priority, so running tmux inside herdr behaves exactly as before. There are no new flags, no new configuration keys, and no new dependency for users who do not run herdr.

## Changes made while rebasing

(1) Two test files conflicted textually with tests added on `main` after the fork point (`tests/test_spawn.bats`, `tests/test_watch.bats`). Both sides were purely additive, so all tests from both sides are kept.

(2) The new herdr `ctrl:despawn` test sent its control message from an unregistered sender (`boss`), which current `main` rejects, so the test failed before the watcher ever saw the message. The sender is now `bob`, which that suite's setup registers, and the assertion is unchanged.

## Review fixes

(1) **Pane ids are addressed by JSON path, not by text position.** herdr replies with structured JSON, but the id was pulled out with `sed`. The split reader matched the *last* `"pane_id"` in the whole response, so a reply carrying a second pane object after the target one parsed successfully and returned a different pane — `spawn` would then rename it, run the boot script inside it, and persist that id as the placement record. The tab-create reader delimited `root_pane` with `[^}]*`, so a nested field ahead of `pane_id` (`scroll`, `agent_session` — both real herdr fields that sort before it) ended the match early. Object key order is not a consumer contract. Both now read the value by explicit path with sqlite3's JSON1, already a core dependency here, gated on the value actually being a string; invalid JSON, a missing path, a null, a number, and an empty string all fail closed.

(2) **A watcher only closes a herdr pane that agmsg placed for its role.** On `ctrl:despawn` the watcher previously closed a pane whenever `HERDR_PANE_ID` was non-empty. That is not evidence of ownership: every descendant of a herdr pane inherits `HERDR_*`, so a watcher merely *started* inside one carries the host pane's id, and acting on it closes the host. This is not hypothetical — it killed a live session while this branch was under review. The close path now requires `HERDR_ENV=1` (matching `spawn`'s own detection) *and* a placement record naming exactly this pane. Anything else takes the existing "close this window manually" branch. This is the herdr counterpart of the tmux path's `ACTIVE_NAME` gating (#109).

(3) **`tests/test_despawn.bats` strips the herdr environment in `setup`.** It previously guarded individual `watch.sh` launches, and the `read_at` test added later (#439) did not carry the guard — which is how the host pane above got closed. Unsetting once in `setup`, as `test_spawn.bats` and `test_watch.bats` already do, means a new test cannot reintroduce the gap by omission.

## Verification

Suites run locally: `test_spawn.bats`, `test_despawn.bats`, `test_watch.bats`, `test_type_registry.bats` — 126 tests, all passing.

Regression coverage added for the review fixes: responses that carry a second pane object, that reorder keys, and that nest an object ahead of `root_pane.pane_id`; the fail-closed paths, asserting no placement record is written and no pane is driven; and, for the close guard, a positive case plus three negative cases (no record, a record naming a different pane, `HERDR_ENV` unset).

Verified against a real herdr 0.7.3 install, not only against stubs:

- `spawn` placed a live pane, wrote a `herdr:<pane_id>` placement record, and `despawn --force` closed that pane.
- `spawn --window` created a live tab, and closing its root pane removed the tab. Focus was not taken from the active tab.
- The CLI surface used here (`pane split|rename|run|close`, `tab create --workspace --cwd --label`, `--direction`, `--no-focus`) matches herdr 0.7.3.
- `herdr pane rename` does print JSON on stdout, which is what the second commit suppresses.
