### PR TITLE
fix(codex): stop the bridge launcher duplicating children and burning a core

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -60,16 +60,31 @@ if [ -z "$LIFETIME_PID" ] || ! kill -0 "$LIFETIME_PID" 2>/dev/null; then
   LIFETIME_PID="$PARENT_PID"
 fi
 
-release_dispatcher_lock() {
-  agmsg_runtime_lock_release "$DISPATCHER_LOCK_RESOURCE" "$$"
+# Resource currently owned by this process, so the EXIT trap releases whichever
+# lock was taken (dispatcher or role child) without a second trap installer.
+HELD_LOCK_RESOURCE=""
+
+release_held_lock() {
+  [ -n "$HELD_LOCK_RESOURCE" ] || return 0
+  agmsg_runtime_lock_release "$HELD_LOCK_RESOURCE" "$$"
 }
 
-acquire_dispatcher_lock() {
+# Acquire <resource>, reclaiming it only from a provably dead owner. Returns 1
+# when a LIVE process already holds it — the caller is then a duplicate and must
+# exit. Used for both the per-project dispatcher lock and the per-role child
+# lock; the semantics (CAS reclaim of a stale generation) are identical.
+#
+# Re-entrant across `exec "$0" ...`: exec keeps the pid, so the row this process
+# already owns is re-acquired by the plain INSERT-OR-IGNORE path on the way back
+# in, which is also what re-installs the trap the exec discarded.
+acquire_runtime_lock() {
+  local resource="$1"
   local owner="" attempt _barrier_attempt _barrier_count
   for attempt in {1..20}; do
-    owner="$(agmsg_runtime_lock_acquire "$DISPATCHER_LOCK_RESOURCE" "$$" 2>/dev/null || true)"
+    owner="$(agmsg_runtime_lock_acquire "$resource" "$$" 2>/dev/null || true)"
     if [ "$owner" = "$$" ]; then
-      trap release_dispatcher_lock EXIT
+      HELD_LOCK_RESOURCE="$resource"
+      trap release_held_lock EXIT
       trap 'exit 0' INT TERM
       return 0
     fi
@@ -89,9 +104,10 @@ acquire_dispatcher_lock() {
     # Replace only the exact stale generation observed above. SQLite serializes
     # both statements with competing reclaimers, so once A replaces stale S
     # with live A, B's `owner = S` delete cannot remove A (true CAS semantics).
-    owner="$(agmsg_runtime_lock_acquire "$DISPATCHER_LOCK_RESOURCE" "$$" "${owner:-0}" 2>/dev/null || true)"
+    owner="$(agmsg_runtime_lock_acquire "$resource" "$$" "${owner:-0}" 2>/dev/null || true)"
     if [ "$owner" = "$$" ]; then
-      trap release_dispatcher_lock EXIT
+      HELD_LOCK_RESOURCE="$resource"
+      trap release_held_lock EXIT
       trap 'exit 0' INT TERM
       return 0
     fi
@@ -113,11 +129,15 @@ resolve_identity() {  # prints "team<TAB>name" lines for the project's codex rol
 # Any change here can change the safe subscription set. Include the request
 # thread plus each role's recorded session/project, not merely registrations:
 # actas/resume rewrites a role record without changing identities.sh output.
+# $1 is this tick's already-resolved identity list. It is passed in rather than
+# re-resolved so one iteration runs identities.sh once, not twice.
 safety_fingerprint() {
+  local identity="$1"
   local request="" team name rec rec_project
   [ -f "$REQUEST_FILE" ] && request="$(cat "$REQUEST_FILE" 2>/dev/null || true)"
   printf 'request=%s\n' "$request"
-  resolve_identity | while IFS="$TAB" read -r team name; do
+  printf '%s\n' "$identity" | while IFS="$TAB" read -r team name; do
+    [ -n "$team" ] || continue
     rec="$(agmsg_role_session_uuid "$team" "$name" 2>/dev/null || true)"
     rec_project="$(agmsg_role_session_get "$team" "$name" project 2>/dev/null || true)"
     printf '%s\t%s\t%s\t%s\n' "$team" "$name" "$rec" "$rec_project"
@@ -129,11 +149,21 @@ safety_fingerprint() {
 # The parent only dispatches. Every role receives an independent child launcher
 # and therefore an independent bridge bound to its own recorded thread.
 if [ -z "$ROLE_PAIR" ]; then
-  acquire_dispatcher_lock || exit 0
+  acquire_runtime_lock "$DISPATCHER_LOCK_RESOURCE" || exit 0
   known_pairs=""
   while agmsg_runtime_lock_verify "$DISPATCHER_LOCK_RESOURCE" "$$" \
     && kill -0 "$LIFETIME_PID" 2>/dev/null; do
     current_pairs="$(resolve_identity || true)"
+    # Forget pairs that are no longer registered. A child now exits by itself
+    # once its own registration is gone, so a stale known_pairs entry would
+    # suppress the respawn if that same pair were registered again later.
+    retained=""
+    while IFS= read -r seen_pair; do
+      [ -n "$seen_pair" ] || continue
+      printf '%s\n' "$current_pairs" | grep -Fxq "$seen_pair" || continue
+      retained="${retained:+$retained$'\n'}$seen_pair"
+    done <<< "$known_pairs"
+    known_pairs="$retained"
     while IFS="$TAB" read -r child_team child_name; do
       [ -n "$child_team" ] || continue
       child_pair="$child_team"$'\t'"$child_name"
@@ -148,14 +178,31 @@ if [ -z "$ROLE_PAIR" ]; then
   exit 0
 fi
 
+# One live child per (project, role) — #485. Children are `nohup`'d and bound to
+# the shared app-server, while the dispatcher runs in the TUI's process group and
+# is killed by the SIGHUP a pane teardown delivers. A replacement dispatcher
+# starts with an empty known_pairs and re-spawns the ENTIRE child set, so without
+# this lock every dispatcher generation left another full set of children behind.
+# The lock makes those re-spawns exit on arrival instead of accumulating.
+CHILD_LOCK_RESOURCE="codex-child:$PROJECT_HASH:$(printf '%s' "$ROLE_PAIR" | agmsg_sha1)"
+acquire_runtime_lock "$CHILD_LOCK_RESOURCE" || exit 0
+
+# Bounded, not open-ended. The dispatcher only spawns a child for a pair it has
+# already seen registered, so an empty list here is either the brief actas write
+# lag or a role that has genuinely gone away — and the latter arrives via the
+# re-exec below, which would otherwise park the child in this loop for as long as
+# the app-server lives. Giving up is safe: the dispatcher now forgets a pair when
+# its registration disappears, so a re-registered role gets a fresh child.
 ids=""
-while kill -0 "$PARENT_PID" 2>/dev/null; do
+startup_attempts=0
+while kill -0 "$PARENT_PID" 2>/dev/null && [ "$startup_attempts" -lt 20 ]; do
   ids="$(resolve_identity || true)"
   [ -n "$ids" ] && break
+  startup_attempts=$((startup_attempts + 1))
   sleep 0.3
 done
 [ -n "$ids" ] || exit 0
-safety_state="$(safety_fingerprint)"
+safety_state="$(safety_fingerprint "$ids")"
 
 # Safety over delivery (#150): a role-session record identifies the thread that
 # owns a role. Never inject that role's inbox into a different live TUI. Roles
@@ -237,11 +284,36 @@ else
   bridge_run=("$NODE_BIN" "$SCRIPT_DIR/codex-bridge.js")
 fi
 
+deregistered_ticks=0
 while kill -0 "$PARENT_PID" 2>/dev/null; do
+  # Resolved once per iteration and threaded through the fingerprint, so a tick
+  # runs identities.sh once rather than twice.
+  current_ids="$(resolve_identity || true)"
+  # This child is scoped to one role (`resolve_identity` filters on ROLE_PAIR),
+  # so an empty list means the role itself is gone. Nothing upstream retires a
+  # child: losing the registration only sends it back through the re-exec, whose
+  # pre-loop then spins for as long as the parent lives. Verified: the child was
+  # still running 10 s after its role was removed. Two consecutive empties are
+  # required because identities.sh also reports empty on a transient read
+  # failure, and exiting on one of those would drop a healthy role's delivery.
+  if [ -z "$current_ids" ]; then
+    deregistered_ticks=$((deregistered_ticks + 1))
+    if [ "$deregistered_ticks" -ge 2 ]; then
+      if [ -f "$pidfile" ]; then
+        old_pid="$(cat "$pidfile" 2>/dev/null || true)"
+        [ -n "$old_pid" ] && kill "$old_pid" 2>/dev/null || true
+      fi
+      exit 0
+    fi
+    sleep 0.3
+    continue
+  fi
+  deregistered_ticks=0
+
   # actas can join a second role after SessionStart. Re-exec through the same
   # safety filter when the registration set changes, replacing the old bridge
   # so the new role is actually subscribed instead of being stranded.
-  latest_state="$(safety_fingerprint)"
+  latest_state="$(safety_fingerprint "$current_ids")"
   if [ "$latest_state" != "$safety_state" ]; then
     if [ -f "$pidfile" ]; then
       old_pid="$(cat "$pidfile" 2>/dev/null || true)"

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -209,19 +209,24 @@ poll_sleep() {
 # actas/resume rewrites a role record without changing identities.sh output.
 # $1 is this tick's already-resolved identity list. It is passed in rather than
 # re-resolved so one iteration runs identities.sh once, not twice.
-safety_fingerprint() {
+#
+# Assigns to SAFETY_STATE instead of printing, and reads the roles with a
+# herestring rather than a pipeline, so the whole thing runs in the caller's
+# shell. Both matter: agmsg_role_session_load memoizes the record path, and a
+# memo written inside a command substitution or a pipeline subshell is
+# discarded the moment it is useful.
+build_safety_state() {
   local identity="$1"
-  local request="" team name rec rec_project
+  local request="" team name
   if [ -f "$REQUEST_FILE" ]; then
     IFS= read -r request < "$REQUEST_FILE" 2>/dev/null || true
   fi
-  printf 'request=%s\n' "$request"
-  printf '%s\n' "$identity" | while IFS="$TAB" read -r team name; do
+  SAFETY_STATE="request=$request"
+  while IFS="$TAB" read -r team name; do
     [ -n "$team" ] || continue
-    rec="$(agmsg_role_session_uuid "$team" "$name" 2>/dev/null || true)"
-    rec_project="$(agmsg_role_session_get "$team" "$name" project 2>/dev/null || true)"
-    printf '%s\t%s\t%s\t%s\n' "$team" "$name" "$rec" "$rec_project"
-  done
+    agmsg_role_session_load "$team" "$name" 2>/dev/null || true
+    SAFETY_STATE="$SAFETY_STATE"$'\n'"$team$TAB$name$TAB$AGMSG_ROLE_SESSION_UUID$TAB$AGMSG_ROLE_SESSION_PROJECT"
+  done <<< "$identity"
 }
 
 # actas may register the role a moment after launch, so retry while the parent
@@ -285,7 +290,8 @@ while kill -0 "$PARENT_PID" 2>/dev/null && [ "$startup_attempts" -lt 20 ]; do
   sleep 0.3
 done
 [ -n "$ids" ] || exit 0
-safety_state="$(safety_fingerprint "$ids")"
+build_safety_state "$ids"
+safety_state="$SAFETY_STATE"
 
 # Safety over delivery (#150): a role-session record identifies the thread that
 # owns a role. Never inject that role's inbox into a different live TUI. Roles
@@ -303,9 +309,12 @@ safe_ids=""
 raw_identity_count="$(printf '%s\n' "$ids" | grep -c . || true)"
 while IFS="$TAB" read -r candidate_team candidate_name; do
   [ -n "$candidate_team" ] || continue
-  candidate_thread="$(agmsg_role_session_uuid "$candidate_team" "$candidate_name" 2>/dev/null || true)"
+  # This loop runs in the launcher's own shell (herestring, not a pipeline), so
+  # it is also what warms the record-path memo for the rest of the process.
+  agmsg_role_session_load "$candidate_team" "$candidate_name" 2>/dev/null || true
+  candidate_thread="$AGMSG_ROLE_SESSION_UUID"
   if [ -n "$candidate_thread" ]; then
-    candidate_project="$(agmsg_role_session_get "$candidate_team" "$candidate_name" project 2>/dev/null || true)"
+    candidate_project="$AGMSG_ROLE_SESSION_PROJECT"
     candidate_project_phys="$(agmsg_canonical_path "$candidate_project" 2>/dev/null || printf '%s' "$candidate_project")"
     # A record for another project proves this role's current seat is elsewhere:
     # never consume its unread rows from this project. A lone same-project role keeps #350's legacy recorded-thread affinity even
@@ -396,8 +405,8 @@ while kill -0 "$PARENT_PID" 2>/dev/null; do
   # actas can join a second role after SessionStart. Re-exec through the same
   # safety filter when the registration set changes, replacing the old bridge
   # so the new role is actually subscribed instead of being stranded.
-  latest_state="$(safety_fingerprint "$current_ids")"
-  if [ "$latest_state" != "$safety_state" ]; then
+  build_safety_state "$current_ids"
+  if [ "$SAFETY_STATE" != "$safety_state" ]; then
     if [ -f "$pidfile" ]; then
       old_pid=""
       IFS= read -r old_pid < "$pidfile" 2>/dev/null || true
@@ -424,8 +433,9 @@ while kill -0 "$PARENT_PID" 2>/dev/null; do
   IFS="$TAB" read -r team name <<EOF
 $ids
 EOF
-  rec_thread="$(agmsg_role_session_uuid "$team" "$name" 2>/dev/null || true)"
-  rec_project="$(agmsg_role_session_get "$team" "$name" project 2>/dev/null || true)"
+  agmsg_role_session_load "$team" "$name" 2>/dev/null || true
+  rec_thread="$AGMSG_ROLE_SESSION_UUID"
+  rec_project="$AGMSG_ROLE_SESSION_PROJECT"
   rec_project_phys="$(agmsg_canonical_path "$rec_project" 2>/dev/null || printf '%s' "$rec_project")"
   if [ -z "$rec_thread" ] || [ "$rec_project_phys" != "$PROJECT_PHYS" ]; then
     # A role with no record (or one seated in another project) stays

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -65,6 +65,7 @@ fi
 HELD_LOCK_RESOURCE=""
 
 release_held_lock() {
+  rm -f "$IDENTITY_CACHE_MARKER" 2>/dev/null || true
   [ -n "$HELD_LOCK_RESOURCE" ] || return 0
   agmsg_runtime_lock_release "$HELD_LOCK_RESOURCE" "$$"
 }
@@ -126,6 +127,83 @@ resolve_identity() {  # prints "team<TAB>name" lines for the project's codex rol
     | sort -u
 }
 
+# identities.sh opens and parses EVERY teams/*/config.json on every call: two
+# sqlite3 processes per team file, ~57 processes and ~145 ms total on an
+# eight-team install, and a poll loop was paying that several times a second.
+# The registrations it reads change only when join / leave / actas rewrite a
+# config, so the answer is cached and re-derived only when one of those files
+# has actually moved.
+#
+# Freshness is decided with builtins alone -- glob expansion and `[ -nt ]` -- so
+# a hit costs no processes at all. The marker is touched BEFORE the resolve, and
+# a config is treated as changed unless the marker is STRICTLY newer than it:
+# bash 3.2 compares whole seconds, so "same second as the marker" has to count
+# as changed or a write landing inside that second would be missed. That errs
+# toward re-resolving for at most one second after a write, never toward
+# serving a stale set. The file count is compared too, since removing a team
+# leaves nothing behind for `-nt` to notice.
+#
+# Sets IDENTITY_CACHE in the CURRENT shell — never call it inside $(...), or the
+# cache would be written in a subshell and thrown away.
+TEAMS_DIR="$SKILL_DIR/teams"
+IDENTITY_CACHE=""
+IDENTITY_CACHE_COUNT=-1
+IDENTITY_CACHE_MARKER="$RUN_DIR/.identity-cache.$$"
+IDENTITY_CACHE_FRESH=0   # 1 when the last refresh served the cache unchanged
+
+identity_cache_is_fresh() {
+  local f count=0
+  [ -f "$IDENTITY_CACHE_MARKER" ] || return 1
+  for f in "$TEAMS_DIR"/*/config.json; do
+    [ -f "$f" ] || continue
+    count=$((count + 1))
+    [ "$IDENTITY_CACHE_MARKER" -nt "$f" ] || return 1
+  done
+  [ "$count" = "$IDENTITY_CACHE_COUNT" ] || return 1
+  return 0
+}
+
+refresh_identity_cache() {
+  if identity_cache_is_fresh; then
+    IDENTITY_CACHE_FRESH=1
+    return 0
+  fi
+  IDENTITY_CACHE_FRESH=0
+  : > "$IDENTITY_CACHE_MARKER" 2>/dev/null || true
+  local f count=0
+  for f in "$TEAMS_DIR"/*/config.json; do
+    [ -f "$f" ] || continue
+    count=$((count + 1))
+  done
+  IDENTITY_CACHE_COUNT=$count
+  IDENTITY_CACHE="$(resolve_identity || true)"
+}
+
+# Poll fast while something is happening, then stand down. The startup race the
+# tight interval exists for (actas writing the role record just after launch)
+# resolves in the first moments; after that a launcher that keeps waking every
+# 0.3 s is pure cost, and the delivery it feeds is documented at ~5 s anyway.
+# Any observed change resets to the fast step, so responsiveness is unchanged
+# exactly when it matters. Deliberately no env override: an interval knob would
+# be an interface addition, and nothing here needs to differ per user.
+# Exact line membership without the `printf | grep -Fxq` pipeline, which cost
+# a process per pair per iteration. Pairs contain a tab but never a newline.
+pair_registered() {  # $1 = pair, $2 = newline-separated list
+  case $'\n'"$2"$'\n' in
+    *$'\n'"$1"$'\n'*) return 0 ;;
+  esac
+  return 1
+}
+
+POLL_STEPS=(0.3 0.6 1.2 2)
+poll_index=0
+poll_reset() { poll_index=0; }
+poll_sleep() {
+  sleep "${POLL_STEPS[$poll_index]}"
+  [ "$poll_index" -lt 3 ] && poll_index=$((poll_index + 1))
+  return 0
+}
+
 # Any change here can change the safe subscription set. Include the request
 # thread plus each role's recorded session/project, not merely registrations:
 # actas/resume rewrites a role record without changing identities.sh output.
@@ -134,7 +212,9 @@ resolve_identity() {  # prints "team<TAB>name" lines for the project's codex rol
 safety_fingerprint() {
   local identity="$1"
   local request="" team name rec rec_project
-  [ -f "$REQUEST_FILE" ] && request="$(cat "$REQUEST_FILE" 2>/dev/null || true)"
+  if [ -f "$REQUEST_FILE" ]; then
+    IFS= read -r request < "$REQUEST_FILE" 2>/dev/null || true
+  fi
   printf 'request=%s\n' "$request"
   printf '%s\n' "$identity" | while IFS="$TAB" read -r team name; do
     [ -n "$team" ] || continue
@@ -153,27 +233,30 @@ if [ -z "$ROLE_PAIR" ]; then
   known_pairs=""
   while agmsg_runtime_lock_verify "$DISPATCHER_LOCK_RESOURCE" "$$" \
     && kill -0 "$LIFETIME_PID" 2>/dev/null; do
-    current_pairs="$(resolve_identity || true)"
+    refresh_identity_cache
+    current_pairs="$IDENTITY_CACHE"
+    [ "$IDENTITY_CACHE_FRESH" = "1" ] || poll_reset
     # Forget pairs that are no longer registered. A child now exits by itself
     # once its own registration is gone, so a stale known_pairs entry would
     # suppress the respawn if that same pair were registered again later.
     retained=""
     while IFS= read -r seen_pair; do
       [ -n "$seen_pair" ] || continue
-      printf '%s\n' "$current_pairs" | grep -Fxq "$seen_pair" || continue
+      pair_registered "$seen_pair" "$current_pairs" || continue
       retained="${retained:+$retained$'\n'}$seen_pair"
     done <<< "$known_pairs"
     known_pairs="$retained"
     while IFS="$TAB" read -r child_team child_name; do
       [ -n "$child_team" ] || continue
       child_pair="$child_team"$'\t'"$child_name"
-      printf '%s\n' "$known_pairs" | grep -Fxq "$child_pair" && continue
+      pair_registered "$child_pair" "$known_pairs" && continue
       # Close bats' result fd when present; a detached child must not keep the
       # test harness pipe open after its test has completed.
       nohup "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$LIFETIME_PID" "$child_pair" >/dev/null 2>&1 3>&- 4>&- &
       known_pairs="${known_pairs:+$known_pairs$'\n'}$child_pair"
+      poll_reset
     done <<< "$current_pairs"
-    sleep 0.3
+    poll_sleep
   done
   exit 0
 fi
@@ -212,13 +295,9 @@ safety_state="$(safety_fingerprint "$ids")"
 # next SessionStart.
 thread_hint="loaded"
 if [ -f "$REQUEST_FILE" ]; then
-  request="$(cat "$REQUEST_FILE" 2>/dev/null || true)"
-  if [ -n "$request" ]; then
-    IFS="$TAB" read -r _hint_type _hint_thread _hint_app <<EOF
-$request
-EOF
-    [ -n "${_hint_thread:-}" ] && thread_hint="$_hint_thread"
-  fi
+  _hint_type=""; _hint_thread=""; _hint_app=""
+  IFS="$TAB" read -r _hint_type _hint_thread _hint_app < "$REQUEST_FILE" 2>/dev/null || true
+  [ -n "${_hint_thread:-}" ] && thread_hint="$_hint_thread"
 fi
 safe_ids=""
 raw_identity_count="$(printf '%s\n' "$ids" | grep -c . || true)"
@@ -287,8 +366,11 @@ fi
 deregistered_ticks=0
 while kill -0 "$PARENT_PID" 2>/dev/null; do
   # Resolved once per iteration and threaded through the fingerprint, so a tick
-  # runs identities.sh once rather than twice.
-  current_ids="$(resolve_identity || true)"
+  # runs identities.sh once rather than twice — and usually not at all, because
+  # the resolve is served from the mtime-guarded cache.
+  refresh_identity_cache
+  current_ids="$IDENTITY_CACHE"
+  [ "$IDENTITY_CACHE_FRESH" = "1" ] || poll_reset
   # This child is scoped to one role (`resolve_identity` filters on ROLE_PAIR),
   # so an empty list means the role itself is gone. Nothing upstream retires a
   # child: losing the registration only sends it back through the re-exec, whose
@@ -300,7 +382,8 @@ while kill -0 "$PARENT_PID" 2>/dev/null; do
     deregistered_ticks=$((deregistered_ticks + 1))
     if [ "$deregistered_ticks" -ge 2 ]; then
       if [ -f "$pidfile" ]; then
-        old_pid="$(cat "$pidfile" 2>/dev/null || true)"
+        old_pid=""
+        IFS= read -r old_pid < "$pidfile" 2>/dev/null || true
         [ -n "$old_pid" ] && kill "$old_pid" 2>/dev/null || true
       fi
       exit 0
@@ -316,7 +399,8 @@ while kill -0 "$PARENT_PID" 2>/dev/null; do
   latest_state="$(safety_fingerprint "$current_ids")"
   if [ "$latest_state" != "$safety_state" ]; then
     if [ -f "$pidfile" ]; then
-      old_pid="$(cat "$pidfile" 2>/dev/null || true)"
+      old_pid=""
+      IFS= read -r old_pid < "$pidfile" 2>/dev/null || true
       [ -n "$old_pid" ] && kill "$old_pid" 2>/dev/null || true
     fi
     exec "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID" "$ROLE_PAIR"
@@ -328,14 +412,10 @@ while kill -0 "$PARENT_PID" 2>/dev/null; do
   thread_id="loaded"
   req_app_server="$APP_SERVER"
   if [ -f "$REQUEST_FILE" ]; then
-    request="$(cat "$REQUEST_FILE" 2>/dev/null || true)"
-    if [ -n "$request" ]; then
-      IFS="$TAB" read -r _rtype _rthread _rapp <<EOF
-$request
-EOF
-      [ -n "${_rthread:-}" ] && thread_id="$_rthread"
-      [ -n "${_rapp:-}" ] && req_app_server="$_rapp"
-    fi
+    _rtype=""; _rthread=""; _rapp=""
+    IFS="$TAB" read -r _rtype _rthread _rapp < "$REQUEST_FILE" 2>/dev/null || true
+    [ -n "${_rthread:-}" ] && thread_id="$_rthread"
+    [ -n "${_rapp:-}" ] && req_app_server="$_rapp"
   fi
 
   # A child launcher is role-scoped. The project request file only supplies a
@@ -348,7 +428,10 @@ EOF
   rec_project="$(agmsg_role_session_get "$team" "$name" project 2>/dev/null || true)"
   rec_project_phys="$(agmsg_canonical_path "$rec_project" 2>/dev/null || printf '%s' "$rec_project")"
   if [ -z "$rec_thread" ] || [ "$rec_project_phys" != "$PROJECT_PHYS" ]; then
-    sleep 0.3
+    # A role with no record (or one seated in another project) stays
+    # deliberately unsubscribed (#150) and waits for a record to appear. That
+    # wait is open-ended, so it has to be the cheapest path in the file.
+    poll_sleep
     continue
   fi
   thread_id="$rec_thread"
@@ -356,7 +439,8 @@ EOF
   # The role-session record is the sole thread authority (#150 phase 2/#350).
 
   if [ -f "$pidfile" ]; then
-    bridge_pid="$(cat "$pidfile" 2>/dev/null || true)"
+    bridge_pid=""
+    IFS= read -r bridge_pid < "$pidfile" 2>/dev/null || true
     if [ -n "$bridge_pid" ] && kill -0 "$bridge_pid" 2>/dev/null; then
       # Reuse only when the live bridge is bound to the CURRENT app-server. A
       # codex upgrade makes codex-monitor.sh kill the stale app-server and start a
@@ -369,10 +453,11 @@ EOF
       # first launched on the ambiguous "loaded" thread rebind once this role's
       # recorded thread becomes known -- otherwise the app-server match alone
       # would keep the wrong-thread bridge alive indefinitely.
-      bound_url="$(cat "$appserver_file" 2>/dev/null || true)"
-      bound_thread="$(cat "$thread_file" 2>/dev/null || true)"
+      bound_url=""; bound_thread=""
+      IFS= read -r bound_url < "$appserver_file" 2>/dev/null || true
+      IFS= read -r bound_thread < "$thread_file" 2>/dev/null || true
       if [ "$bound_url" = "$req_app_server" ] && [ "$bound_thread" = "$thread_id" ]; then
-        sleep 0.3
+        poll_sleep
         continue
       fi
       kill "$bridge_pid" 2>/dev/null || true
@@ -397,11 +482,13 @@ EOF
   printf '%s\n' "$launched_pid" > "$pidfile"
   if [ -n "${AGMSG_CODEX_BRIDGE_CMD:-}" ]; then
     wait "$launched_pid" 2>/dev/null || true
-    recorded_pid="$(cat "$pidfile" 2>/dev/null || true)"
+    recorded_pid=""
+    IFS= read -r recorded_pid < "$pidfile" 2>/dev/null || true
     [ "$recorded_pid" != "$launched_pid" ] || rm -f "$pidfile"
   fi
   # Record what this bridge is bound to so a later launcher can detect staleness.
   printf '%s' "$req_app_server" > "$appserver_file"
   printf '%s' "$thread_id" > "$thread_file"
+  poll_reset
   sleep 1
 done

--- a/scripts/lib/role-session.sh
+++ b/scripts/lib/role-session.sh
@@ -43,10 +43,41 @@ fi
 
 # Compute the record file path for (team, agent). Same encoding + dir as the
 # actas lock, distinct prefix (role-session. vs actas.), no .session suffix.
+#
+# Memoized per process. The result is a pure function of (SKILL_DIR, team,
+# agent), but computing it costs three command substitutions and two awk
+# processes, and the codex bridge launcher re-derives it for the same handful of
+# pairs on every poll iteration for the lifetime of an app-server. SKILL_DIR is
+# part of the key so a caller that relocates the skill root mid-process (tests
+# do) simply misses the cache rather than reading a stale path.
+#
+# Parallel arrays, not an associative array: macOS ships bash 3.2, which has
+# none. The pair count is a handful, so the linear scan is cheaper than the
+# awk processes it replaces. Encoding itself is deliberately NOT reimplemented
+# here -- _actas_lock_encode is shared with the actas lock filenames, and any
+# divergence would orphan live state files.
+_AGMSG_RS_PATH_KEYS=()
+_AGMSG_RS_PATH_VALS=()
+_AGMSG_RS_PATH_MAX=64
+
 _agmsg_role_session_path() {
-  local team="$1" agent="$2" t a
+  local team="$1" agent="$2" t a key i n
+  key="${SKILL_DIR}"$'\x1f'"${team}"$'\x1f'"${agent}"
+  n=${#_AGMSG_RS_PATH_KEYS[@]}
+  for ((i = 0; i < n; i++)); do
+    if [ "${_AGMSG_RS_PATH_KEYS[$i]}" = "$key" ]; then
+      printf '%s' "${_AGMSG_RS_PATH_VALS[$i]}"
+      return 0
+    fi
+  done
+  local path
   t="$(_actas_lock_encode "$team")"; a="$(_actas_lock_encode "$agent")"
-  printf '%s/role-session.%s__%s' "$(_actas_lock_dir)" "$t" "$a"
+  path="$(_actas_lock_dir)/role-session.${t}__${a}"
+  if [ "$n" -lt "$_AGMSG_RS_PATH_MAX" ]; then
+    _AGMSG_RS_PATH_KEYS[$n]="$key"
+    _AGMSG_RS_PATH_VALS[$n]="$path"
+  fi
+  printf '%s' "$path"
 }
 
 # Record (team, agent) -> <bare_sid> for <project>. Latest session wins
@@ -99,11 +130,21 @@ agmsg_role_session_get() {
 }
 
 # Read a single field from a record file. Empty if file/field absent.
+#
+# Builtins only. This was `sed -n | head -1`, i.e. two processes per field, and
+# the codex bridge launcher reads two fields per role on every poll iteration.
+# The record is a handful of short key=value lines, so reading it in the shell
+# is both cheaper and exactly equivalent: first match wins, and the value is
+# everything after the first '='.
 _agmsg_role_session_field() {
-  local path="$1" key="$2"
+  local path="$1" key="$2" line
   [ -f "$path" ] || return 0
-  # First match only; value is everything after the first '='.
-  sed -n "s/^${key}=//p" "$path" 2>/dev/null | head -1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "$key"=*) printf '%s\n' "${line#"$key"=}"; return 0 ;;
+    esac
+  done < "$path" 2>/dev/null
+  return 0
 }
 
 # Read back the recorded bare session id for (team, agent). Empty if no record.

--- a/scripts/lib/role-session.sh
+++ b/scripts/lib/role-session.sh
@@ -44,12 +44,19 @@ fi
 # Compute the record file path for (team, agent). Same encoding + dir as the
 # actas lock, distinct prefix (role-session. vs actas.), no .session suffix.
 #
-# Memoized per process. The result is a pure function of (SKILL_DIR, team,
-# agent), but computing it costs three command substitutions and two awk
-# processes, and the codex bridge launcher re-derives it for the same handful of
-# pairs on every poll iteration for the lifetime of an app-server. SKILL_DIR is
-# part of the key so a caller that relocates the skill root mid-process (tests
-# do) simply misses the cache rather than reading a stale path.
+# Memoized per shell. The result is a pure function of (SKILL_DIR, team, agent),
+# but computing it costs three command substitutions and two awk processes, and
+# the codex bridge launcher re-derives it for the same handful of pairs on every
+# poll iteration for the lifetime of an app-server. SKILL_DIR is part of the key
+# so a caller that relocates the skill root mid-process (tests do) simply misses
+# the cache rather than reading a stale path.
+#
+# IMPORTANT: a cache entry is only kept when the helper runs in the caller's own
+# shell. `path="$(_agmsg_role_session_path ...)"` computes the entry inside a
+# command substitution and throws it away with the subshell, so a caller that
+# only ever invokes it that way pays full price every time. Use the _into form
+# below from a long-lived shell; subshells forked afterwards inherit the warm
+# cache and read from it.
 #
 # Parallel arrays, not an associative array: macOS ships bash 3.2, which has
 # none. The pair count is a handful, so the linear scan is cheaper than the
@@ -60,24 +67,57 @@ _AGMSG_RS_PATH_KEYS=()
 _AGMSG_RS_PATH_VALS=()
 _AGMSG_RS_PATH_MAX=64
 
-_agmsg_role_session_path() {
+# Sets _AGMSG_ROLE_SESSION_PATH in the CALLER's shell, so the memo survives.
+_agmsg_role_session_path_into() {
   local team="$1" agent="$2" t a key i n
   key="${SKILL_DIR}"$'\x1f'"${team}"$'\x1f'"${agent}"
   n=${#_AGMSG_RS_PATH_KEYS[@]}
   for ((i = 0; i < n; i++)); do
     if [ "${_AGMSG_RS_PATH_KEYS[$i]}" = "$key" ]; then
-      printf '%s' "${_AGMSG_RS_PATH_VALS[$i]}"
+      _AGMSG_ROLE_SESSION_PATH="${_AGMSG_RS_PATH_VALS[$i]}"
       return 0
     fi
   done
-  local path
   t="$(_actas_lock_encode "$team")"; a="$(_actas_lock_encode "$agent")"
-  path="$(_actas_lock_dir)/role-session.${t}__${a}"
+  _AGMSG_ROLE_SESSION_PATH="$(_actas_lock_dir)/role-session.${t}__${a}"
   if [ "$n" -lt "$_AGMSG_RS_PATH_MAX" ]; then
     _AGMSG_RS_PATH_KEYS[$n]="$key"
-    _AGMSG_RS_PATH_VALS[$n]="$path"
+    _AGMSG_RS_PATH_VALS[$n]="$_AGMSG_ROLE_SESSION_PATH"
   fi
-  printf '%s' "$path"
+  return 0
+}
+
+# stdout form, for callers that are not in a hot loop.
+_agmsg_role_session_path() {
+  _agmsg_role_session_path_into "$1" "$2"
+  printf '%s' "$_AGMSG_ROLE_SESSION_PATH"
+}
+
+# Read the two fields the codex bridge launcher needs in ONE pass, into the
+# caller's shell: AGMSG_ROLE_SESSION_UUID and AGMSG_ROLE_SESSION_PROJECT. Both
+# are empty when the record or the field is absent. This exists so the poll path
+# can resolve a role without a single command substitution -- the getters below
+# are fine one-shot, but each one costs a subshell and its own read of the same
+# file, and the launcher wants both fields for the same pair several times a
+# second. First match wins per field, matching the getters exactly.
+agmsg_role_session_load() {
+  local team="$1" agent="$2" line path have_uuid=0 have_project=0
+  AGMSG_ROLE_SESSION_UUID=""
+  AGMSG_ROLE_SESSION_PROJECT=""
+  _agmsg_role_session_path_into "$team" "$agent"
+  path="$_AGMSG_ROLE_SESSION_PATH"
+  [ -f "$path" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      session=*)
+        [ "$have_uuid" = "1" ] || { AGMSG_ROLE_SESSION_UUID="${line#session=}"; have_uuid=1; }
+        ;;
+      project=*)
+        [ "$have_project" = "1" ] || { AGMSG_ROLE_SESSION_PROJECT="${line#project=}"; have_project=1; }
+        ;;
+    esac
+  done < "$path" 2>/dev/null
+  return 0
 }
 
 # Record (team, agent) -> <bare_sid> for <project>. Latest session wins
@@ -102,7 +142,8 @@ agmsg_role_session_record() {
   local team="$1" agent="$2" bare_sid="$3" project="${4:-}" type="${5:-}"
   [ -n "$team" ] && [ -n "$agent" ] && [ -n "$bare_sid" ] || return 0
   local path dir tmp ts
-  path="$(_agmsg_role_session_path "$team" "$agent")" || return 0
+  _agmsg_role_session_path_into "$team" "$agent"
+  path="$_AGMSG_ROLE_SESSION_PATH"
   dir="$(_actas_lock_dir)"
   mkdir -p "$dir" 2>/dev/null || return 0
   tmp="$(mktemp "$dir/.role-session.XXXXXX" 2>/dev/null)" || return 0
@@ -125,8 +166,8 @@ agmsg_role_session_record() {
 # hook reading `type`); mirrors agmsg_role_session_uuid's read of `session`.
 agmsg_role_session_get() {
   local team="$1" agent="$2" key="$3" path
-  path="$(_agmsg_role_session_path "$team" "$agent")" || return 0
-  _agmsg_role_session_field "$path" "$key"
+  _agmsg_role_session_path_into "$team" "$agent"
+  _agmsg_role_session_field "$_AGMSG_ROLE_SESSION_PATH" "$key"
 }
 
 # Read a single field from a record file. Empty if file/field absent.
@@ -151,8 +192,8 @@ _agmsg_role_session_field() {
 # This is the primary getter used by the boot wrapper (PR-C).
 agmsg_role_session_uuid() {
   local team="$1" agent="$2" path
-  path="$(_agmsg_role_session_path "$team" "$agent")" || return 0
-  _agmsg_role_session_field "$path" session
+  _agmsg_role_session_path_into "$team" "$agent"
+  _agmsg_role_session_field "$_AGMSG_ROLE_SESSION_PATH" session
 }
 
 # Scan run/role-session.* for the record whose name= field equals <name> and

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -227,11 +227,31 @@ run_launcher() {
 # distinguished from a dispatcher by carrying the role pair as its 5th argument;
 # match on the agent name rather than the whole pair, because macOS ps renders
 # the tab inside that argument as the escape sequence \011, not a literal tab.
+#
+# Only processes whose parent is not itself a match are counted. Every command
+# substitution the launcher runs forks a subshell that inherits the launcher's
+# argv, so those subshells are indistinguishable from a real child by command
+# line alone -- a naive count reads 3 where there is one child, depending purely
+# on when the sample lands. Filtering on ppid counts independent children, which
+# is the property these tests are actually about.
 count_child_launchers() {
-  ps -Ao pid=,args= 2>/dev/null \
+  ps -Ao pid=,ppid=,args= 2>/dev/null \
     | grep -F "$LAUNCHER" \
     | grep -F "$PROJ" \
-    | grep -c alice || true
+    | grep alice \
+    | awk '{ pid[$1] = 1; parent[$1] = $2 }
+           END { n = 0; for (p in pid) if (!(parent[p] in pid)) n++; print n }'
+}
+
+# Block until the child count settles on <n>, then return it. Spawn and exit are
+# both asynchronous, so sampling on the first sighting races the transition.
+wait_for_child_count() {
+  local want="$1" i
+  for i in {1..100}; do
+    [ "$(count_child_launchers)" -eq "$want" ] && break
+    sleep 0.1
+  done
+  count_child_launchers
 }
 
 @test "launcher: a replacement dispatcher does not double the role children (#485)" {
@@ -243,34 +263,24 @@ count_child_launchers() {
   # Dispatcher A spawns the role child, which is nohup'd and outlives A.
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent_a" >/dev/null 2>&1 3>&- &
   local dispatcher_a=$!
-  local i
-  for i in {1..80}; do
-    [ "$(count_child_launchers)" -ge 1 ] && break
-    sleep 0.1
-  done
-  [ "$(count_child_launchers)" -eq 1 ]
+  [ "$(wait_for_child_count 1)" -eq 1 ]
 
   # SIGKILL is what a pane teardown effectively does to a dispatcher that never
   # trapped the signal: the EXIT trap does not run, so the lock row is left
   # behind owned by a dead pid, exactly the state a replacement dispatcher hits.
   kill -9 "$dispatcher_a" 2>/dev/null || true
   wait "$dispatcher_a" 2>/dev/null || true
-  [ "$(count_child_launchers)" -eq 1 ]
+  [ "$(wait_for_child_count 1)" -eq 1 ]
 
   # Dispatcher B reclaims the stale lock and, with an empty known_pairs, spawns
   # a second child for the SAME pair. Without the per-role lock that child would
   # live on and poll forever alongside the first.
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent_b" >/dev/null 2>&1 3>&- &
   local dispatcher_b=$!
-  for i in {1..40}; do
-    sleep 0.1
-    [ "$(count_child_launchers)" -gt 1 ] && break
-  done
-  # Settle: any duplicate must have exited by now.
-  for i in {1..40}; do
-    [ "$(count_child_launchers)" -eq 1 ] && break
-    sleep 0.1
-  done
+  # The duplicate is spawned and then has to lose the lock race; settle on the
+  # steady state rather than on whichever side of that transition we land.
+  [ "$(wait_for_child_count 1)" -eq 1 ]
+  sleep 1
   [ "$(count_child_launchers)" -eq 1 ]
 
   kill "$dispatcher_b" 2>/dev/null || true
@@ -286,31 +296,18 @@ count_child_launchers() {
   sleep 20 3>&- & local parent=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- &
   local dispatcher=$!
-  local i
-  for i in {1..80}; do
-    [ "$(count_child_launchers)" -ge 1 ] && break
-    sleep 0.1
-  done
-  [ "$(count_child_launchers)" -eq 1 ]
+  [ "$(wait_for_child_count 1)" -eq 1 ]
 
   # Deregistering the role retires its child through the existing re-exec path.
   bash "$SCRIPTS/leave.sh" team alice >/dev/null 2>&1 || true
-  for i in {1..80}; do
-    [ "$(count_child_launchers)" -eq 0 ] && break
-    sleep 0.1
-  done
-  [ "$(count_child_launchers)" -eq 0 ]
+  [ "$(wait_for_child_count 0)" -eq 0 ]
 
   # The dispatcher must have forgotten the pair. Otherwise known_pairs still
   # lists it, the re-spawn is suppressed, and the role silently never gets a
   # bridge again for the rest of the app-server's life.
   bash "$SCRIPTS/join.sh" team alice codex "$PROJ" >/dev/null
   put_record team alice thread-alice "$PROJ" codex
-  for i in {1..80}; do
-    [ "$(count_child_launchers)" -ge 1 ] && break
-    sleep 0.1
-  done
-  [ "$(count_child_launchers)" -eq 1 ]
+  [ "$(wait_for_child_count 1)" -eq 1 ]
 
   kill "$dispatcher" 2>/dev/null || true
   wait "$dispatcher" 2>/dev/null || true

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -222,3 +222,98 @@ run_launcher() {
   grep -q -- $'--pair team\talice --thread thread-after' "$CAPTURE"
   ! grep -q -- '--pair team bob' "$CAPTURE"
 }
+
+# Count live role-child launcher processes for this test's project. A child is
+# distinguished from a dispatcher by carrying the role pair as its 5th argument;
+# match on the agent name rather than the whole pair, because macOS ps renders
+# the tab inside that argument as the escape sequence \011, not a literal tab.
+count_child_launchers() {
+  ps -Ao pid=,args= 2>/dev/null \
+    | grep -F "$LAUNCHER" \
+    | grep -F "$PROJ" \
+    | grep -c alice || true
+}
+
+@test "launcher: a replacement dispatcher does not double the role children (#485)" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=12
+  sleep 14 3>&- & local parent_a=$!
+  sleep 14 3>&- & local parent_b=$!
+
+  # Dispatcher A spawns the role child, which is nohup'd and outlives A.
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent_a" >/dev/null 2>&1 3>&- &
+  local dispatcher_a=$!
+  local i
+  for i in {1..80}; do
+    [ "$(count_child_launchers)" -ge 1 ] && break
+    sleep 0.1
+  done
+  [ "$(count_child_launchers)" -eq 1 ]
+
+  # SIGKILL is what a pane teardown effectively does to a dispatcher that never
+  # trapped the signal: the EXIT trap does not run, so the lock row is left
+  # behind owned by a dead pid, exactly the state a replacement dispatcher hits.
+  kill -9 "$dispatcher_a" 2>/dev/null || true
+  wait "$dispatcher_a" 2>/dev/null || true
+  [ "$(count_child_launchers)" -eq 1 ]
+
+  # Dispatcher B reclaims the stale lock and, with an empty known_pairs, spawns
+  # a second child for the SAME pair. Without the per-role lock that child would
+  # live on and poll forever alongside the first.
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent_b" >/dev/null 2>&1 3>&- &
+  local dispatcher_b=$!
+  for i in {1..40}; do
+    sleep 0.1
+    [ "$(count_child_launchers)" -gt 1 ] && break
+  done
+  # Settle: any duplicate must have exited by now.
+  for i in {1..40}; do
+    [ "$(count_child_launchers)" -eq 1 ] && break
+    sleep 0.1
+  done
+  [ "$(count_child_launchers)" -eq 1 ]
+
+  kill "$dispatcher_b" 2>/dev/null || true
+  wait "$dispatcher_b" 2>/dev/null || true
+  kill "$parent_a" "$parent_b" 2>/dev/null || true
+  wait "$parent_a" 2>/dev/null || true
+  wait "$parent_b" 2>/dev/null || true
+}
+
+@test "launcher: a re-registered role gets a fresh child after deregistration (#485)" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=12
+  sleep 20 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- &
+  local dispatcher=$!
+  local i
+  for i in {1..80}; do
+    [ "$(count_child_launchers)" -ge 1 ] && break
+    sleep 0.1
+  done
+  [ "$(count_child_launchers)" -eq 1 ]
+
+  # Deregistering the role retires its child through the existing re-exec path.
+  bash "$SCRIPTS/leave.sh" team alice >/dev/null 2>&1 || true
+  for i in {1..80}; do
+    [ "$(count_child_launchers)" -eq 0 ] && break
+    sleep 0.1
+  done
+  [ "$(count_child_launchers)" -eq 0 ]
+
+  # The dispatcher must have forgotten the pair. Otherwise known_pairs still
+  # lists it, the re-spawn is suppressed, and the role silently never gets a
+  # bridge again for the rest of the app-server's life.
+  bash "$SCRIPTS/join.sh" team alice codex "$PROJ" >/dev/null
+  put_record team alice thread-alice "$PROJ" codex
+  for i in {1..80}; do
+    [ "$(count_child_launchers)" -ge 1 ] && break
+    sleep 0.1
+  done
+  [ "$(count_child_launchers)" -eq 1 ]
+
+  kill "$dispatcher" 2>/dev/null || true
+  wait "$dispatcher" 2>/dev/null || true
+  kill "$parent" 2>/dev/null || true
+  wait "$parent" 2>/dev/null || true
+}

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -317,3 +317,38 @@ count_child_launchers() {
   kill "$parent" 2>/dev/null || true
   wait "$parent" 2>/dev/null || true
 }
+
+@test "launcher: the identity cache still sees a role added mid-loop (#466)" {
+  # The poll no longer re-runs identities.sh every tick; it serves a cache
+  # guarded on the team configs' mtimes. This is the test that fails if that
+  # guard never invalidates: a role joined while the dispatcher is already
+  # looping has to be picked up anyway.
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=20
+  sleep 25 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- &
+  local dispatcher=$!
+  local i
+  for i in {1..80}; do
+    grep -q -- $'--pair team\talice' "$CAPTURE" 2>/dev/null && break
+    sleep 0.1
+  done
+  grep -q -- $'--pair team\talice' "$CAPTURE"
+
+  # Let the loop settle into its backed-off steady state before changing
+  # anything, so this exercises a cache hit being invalidated rather than a
+  # loop that happened to still be resolving every tick.
+  sleep 3
+  bash "$SCRIPTS/join.sh" team bob codex "$PROJ" >/dev/null
+  put_record team bob thread-bob "$PROJ" codex
+  for i in {1..100}; do
+    grep -q -- $'--pair team\tbob' "$CAPTURE" 2>/dev/null && break
+    sleep 0.1
+  done
+  grep -q -- $'--pair team\tbob --thread thread-bob' "$CAPTURE"
+
+  kill "$dispatcher" 2>/dev/null || true
+  wait "$dispatcher" 2>/dev/null || true
+  kill "$parent" 2>/dev/null || true
+  wait "$parent" 2>/dev/null || true
+}

--- a/tests/test_role_session.bats
+++ b/tests/test_role_session.bats
@@ -201,3 +201,69 @@ fake_session() {
   bash "$SKILL_DIR/scripts/actas-claim.sh" /tmp/p1 claude-code alice "sid-me" >/dev/null
   [ "$(agmsg_role_session_uuid T alice)" = "sid-me" ]
 }
+
+@test "role-session: resolving the same pair twice re-uses the memoized path (#466)" {
+  # The memo only counts if it survives the call. A helper that mutates state
+  # inside `$(...)` writes it into a subshell that is discarded immediately,
+  # which is the regression this pins: once a pair has been resolved in a shell,
+  # neither a repeat there nor a later subshell may re-run the encode.
+  run bash -c '
+    set -uo pipefail
+    export SKILL_DIR="'"$TEST_SKILL_DIR"'"
+    . "$SKILL_DIR/scripts/lib/role-session.sh"
+    eval "$(declare -f _actas_lock_encode | sed "1s/_actas_lock_encode/_orig_encode/")"
+    # The counter is a file, not a variable: _actas_lock_encode is itself
+    # invoked as $(...), so an in-memory counter would be incremented inside
+    # that subshell and never seen here.
+    TALLY="$(mktemp)"
+    _actas_lock_encode() { echo x >> "$TALLY"; _orig_encode "$@"; }
+    calls() { wc -l < "$TALLY" | tr -d " "; }
+
+    : > "$TALLY"
+    agmsg_role_session_load team alice
+    cold=$(calls)
+
+    : > "$TALLY"
+    agmsg_role_session_load team alice
+    repeat=$(calls)
+
+    # A subshell forked after the memo is warm inherits it and must stay free.
+    : > "$TALLY"
+    u="$(agmsg_role_session_uuid team alice)"
+    via_subshell=$(calls)
+
+    : > "$TALLY"
+    agmsg_role_session_load team bob
+    other=$(calls)
+
+    rm -f "$TALLY"
+    echo "cold=$cold repeat=$repeat via_subshell=$via_subshell other=$other"
+  '
+  [ "$status" -eq 0 ]
+  eval "$(printf '%s\n' "$output" | tr ' ' '\n')"
+  # A cold pair pays the encode; nothing after it does, in this shell or in a
+  # subshell forked from it. A different pair is cold again.
+  [ "$cold" -ge 1 ]
+  [ "$repeat" -eq 0 ]
+  [ "$via_subshell" -eq 0 ]
+  [ "$other" -ge 1 ]
+}
+
+@test "role-session: load returns the same values as the single-field getters" {
+  run bash -c '
+    set -uo pipefail
+    export SKILL_DIR="'"$TEST_SKILL_DIR"'"
+    . "$SKILL_DIR/scripts/lib/role-session.sh"
+    agmsg_role_session_record "team x" "エージェント/1" sid-9 "/p/q r" codex
+    agmsg_role_session_load "team x" "エージェント/1"
+    u="$(agmsg_role_session_uuid "team x" "エージェント/1")"
+    p="$(agmsg_role_session_get "team x" "エージェント/1" project)"
+    [ "$AGMSG_ROLE_SESSION_UUID" = "$u" ] || { echo "uuid mismatch: [$AGMSG_ROLE_SESSION_UUID] vs [$u]"; exit 1; }
+    [ "$AGMSG_ROLE_SESSION_PROJECT" = "$p" ] || { echo "project mismatch: [$AGMSG_ROLE_SESSION_PROJECT] vs [$p]"; exit 1; }
+    agmsg_role_session_load nosuch nobody
+    [ -z "$AGMSG_ROLE_SESSION_UUID" ] && [ -z "$AGMSG_ROLE_SESSION_PROJECT" ] || { echo "absent record not empty"; exit 1; }
+    echo "OK u=$u p=$p"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK u=sid-9 p=/p/q r"* ]]
+}


### PR DESCRIPTION
Two independent defects behind the two reports. They need separate fixes — fixing either one alone leaves the other's symptom intact.

| Axis | Symptom | Issue | Root cause |
|---|---|---|---|
| Process count | 1013 launcher processes over 24h across 7 roles | #485 | every dispatcher replacement re-spawns the whole child set, and the previous generation survives |
| Cost per tick | load average 99-332 | #466 | one poll iteration cost ~157 processes / ~410 ms against a 300 ms sleep |

Thanks to the reporters for the measurements that made both of these findable — the 1013-process count, the load averages, and the observation that 55 of 77 new processes in a 5-second sample came from the launcher. The 5-second polling suggestion in #466 was directionally right, and is part of what this PR does.

## #485 — duplicate role children

Two facts in the existing code are the whole mechanism:

1. **The dispatcher is not detached; its children are.** `codex-monitor.sh` starts the dispatcher with a plain `&`, so it stays in the TUI's process group. The dispatcher starts each role child with `nohup`.
2. **The dispatcher holds a lock; the children hold nothing.** `known_pairs` is a plain shell variable — the in-process memory of one dispatcher.

A pane teardown delivers SIGHUP. The dispatcher traps `INT` and `TERM` but not `HUP`, so the default action kills it without running its `EXIT` trap, leaving the dispatcher lock row owned by a dead pid. Its children keep running: they are `nohup`'d and their lifetime pid is the shared app-server. The next launcher reclaims the stale lock, starts with an empty `known_pairs`, and re-spawns the entire child set. One extra full set per dispatcher generation. 1013 / 7 roles is about 145 generations, which fits.

`known_pairs` cannot fix this by construction — by the time the duplicate is created, the process holding that memory is already dead.

Worth noting for triage: the duplicates are launchers, not bridges. The bridge pidfile already dedups delivery, so a duplicate child sees a live bridge and just polls. The 1013 processes carried no delivery state.

The fix gives each role child its own runtime lock keyed on (project, pair), using the existing resource-generic `agmsg_runtime_lock_*` primitive. A re-spawned duplicate fails to acquire it and exits on arrival.

Two related lifecycle gaps had to close for that to be safe:

- A child whose own registration disappears never exited — losing the registration only sent it back through the re-exec, whose startup loop then spun for as long as the app-server lived. Measured still running 10 seconds after its role was removed. It now retires itself, and the startup loop is bounded as the backstop.
- The dispatcher never removed a pair from `known_pairs`. With children now able to exit, a re-registered role would otherwise never get a bridge again for the rest of the app-server's life.

## #466 — polling cost

The measurement that frames this: **the loop body took longer than the interval it slept for.** Role-child body 412 ms, sleep 300 ms, so each child ran shell work roughly 58% of wall-clock time, permanently. Seven roles put about four cores' worth of bash in flight before the dispatcher is counted.

Cost scales as O(teams on disk) x O(roles in project) — note "teams on disk", not teams relevant to the current project. That is why severity differs between the two reports.

Three sources, all removed with builtins. No new dependency; bash 3.2 safe.

- **`identities.sh` was re-run every tick.** It opens and parses every `teams/*/config.json` — two sqlite3 processes per team file, 57 processes and 145 ms on an eight-team install. Registrations change only when join/leave/actas rewrite a config, so the result is now cached behind an mtime guard evaluated with glob expansion and `[ -nt ]` alone, meaning a cache hit costs no processes at all.
- **`_agmsg_role_session_path` is memoized per process.** It is a pure function of (SKILL_DIR, team, agent) but cost two awk processes, and the launcher re-derived it for the same few pairs every tick. `_actas_lock_encode` itself is deliberately untouched — it is shared with the actas lock filenames, so a divergent reimplementation would orphan live state files.
- **`_agmsg_role_session_field` was `sed -n | head -1`**, two processes per field and two fields per role per tick. It is a shell read loop now, verified equivalent against the old implementation across empty values, values containing `=`, records with no trailing newline, and a key that prefixes another. The `cat` reads and the `printf | grep -Fxq` membership test go the same way.

The interval also backs off, 0.3s through 2s, resetting to fast on any observed change — a config moving, a child spawning, a bridge launching. The startup race the tight interval exists for is unaffected, because it is a change. No env override was added: an interval knob would be an interface addition, and nothing here needs to differ per user.

### Measured effect

Same harness both sides — eight teams, four roles, one dispatcher plus its children, steady state over a 10-second window, counting every external process the poll path spawns:

| | before | after |
|---|---|---|
| total spawns / 10s | 1059 (105.9/s) | **28 (2.8/s)** |
| sqlite3 | 288 | 10 |
| sed | 320 | 5 |
| tr | 289 | 6 |

#462 / #494 halved the sqlite3 count earlier; all figures here are measured on top of that fix, and neither root cause was touched by it.

## Tests

Three added, each verified to fail without its fix:

- a replacement dispatcher does not double the role children — fails on `main`
- a re-registered role gets a fresh child after deregistration — fails on `main`
- the identity cache still sees a role added mid-loop — fails when the mtime guard is stubbed to never invalidate

The existing 11 launcher tests are unchanged and pass. Locally green: 14 launcher, 53 role-session/actas, 72 codex bridge/monitor/resume/shim. Also smoke-tested through `install.sh` into an isolated HOME, exercising the installed tree end-to-end.

Closes #485
Closes #466