### PR TITLE
test: close inherited bats fd 3 in all backgrounded process launches

### DIFF
--- a/tests/test_actas_integration.bats
+++ b/tests/test_actas_integration.bats
@@ -145,7 +145,7 @@ fake_session() {
 
   # Run watch.sh in background with a tiny interval, capture stderr quickly.
   AGMSG_WATCH_INTERVAL=1 bash "$SKILL_DIR/scripts/watch.sh" "sid-mine" /tmp/p1 claude-code \
-    >/dev/null 2> "$BATS_TEST_TMPDIR/watch.err" &
+    >/dev/null 2> "$BATS_TEST_TMPDIR/watch.err" 3>&- &
   local wpid=$!
   # Give it just enough time to resolve subscription and print stderr.
   sleep 1
@@ -176,7 +176,7 @@ fake_session() {
   fake_register T alice
 
   AGMSG_WATCH_INTERVAL=1 bash "$SKILL_DIR/scripts/watch.sh" "sid-me" /tmp/p1 claude-code alice \
-    >/dev/null 2> "$BATS_TEST_TMPDIR/watch.err" &
+    >/dev/null 2> "$BATS_TEST_TMPDIR/watch.err" 3>&- &
   local wpid=$!
   sleep 1
 

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -243,7 +243,7 @@ const server = net.createServer((socket) => {
 server.listen(sock);
 EOF
 
-  node "$fake" "$sock" "$log" &
+  node "$fake" "$sock" "$log" 3>&- &
   local server_pid="$!"
   for _ in {1..50}; do
     [ -S "$sock" ] && break
@@ -376,7 +376,7 @@ server.listen(0, "127.0.0.1", () => {
 });
 EOF
 
-  node "$fake" "$portfile" "$log" &
+  node "$fake" "$portfile" "$log" 3>&- &
   local server_pid="$!"
   for _ in {1..50}; do
     [ -s "$portfile" ] && break
@@ -428,7 +428,7 @@ server.listen(0, "127.0.0.1", () => {
 });
 EOF
 
-  node "$fake" "$portfile" "$log" &
+  node "$fake" "$portfile" "$log" 3>&- &
   local server_pid="$!"
   for _ in {1..50}; do
     [ -s "$portfile" ] && break
@@ -496,7 +496,7 @@ server.listen(0, "127.0.0.1", () => {
 });
 EOF
 
-  node "$fake" "$portfile" "$log" &
+  node "$fake" "$portfile" "$log" 3>&- &
   local server_pid="$!"
   for _ in {1..50}; do
     [ -s "$portfile" ] && break

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -99,7 +99,7 @@ run_launcher() {
   put_record team alice rec-thread-1 "$PROJ" codex
   export MOCK_BRIDGE_SLEEP=3
   printf '%s\n' 99999999 > "$RUN_DIR/codex-bridge.team.alice.pid"
-  run_launcher & local driver_pid=$!
+  run_launcher 3>&- & local driver_pid=$!
 
   local i recorded=""
   for i in {1..50}; do

--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -143,7 +143,7 @@ while True:
         c, _ = s.accept(); c.close()
     except Exception:
         pass
-' "$portf" &
+' "$portf" 3>&- &
   local foreign_pid=$!
   while [ ! -s "$portf" ]; do sleep 0.05; done
   local foreign_port; foreign_port="$(cat "$portf")"

--- a/tests/test_compat.bats
+++ b/tests/test_compat.bats
@@ -23,7 +23,7 @@ setup() {
   printf '#!/usr/bin/env bash\nsleep 60\n' > "$_STUB"
   chmod +x "$_STUB"
 
-  bash "$_STUB" &
+  bash "$_STUB" 3>&- &
   _STUB_PID=$!
   # Brief pause so the process is visible to ps / CIM.
   sleep 1

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -316,7 +316,7 @@ _seed_role_record() {
   cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
 {"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
 JSON
-  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" stop-test "$TEST_PROJECT" claude-code &
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" stop-test "$TEST_PROJECT" claude-code 3>&- &
   local watch_pid=$!
   sleep 1
   [ -f "$TEST_SKILL_DIR/run/watch.stop-test.pid" ]
@@ -369,7 +369,7 @@ JSON
 {"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
 JSON
   # A live claude-code watcher for this project.
-  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" cc-sess "$TEST_PROJECT" claude-code &
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" cc-sess "$TEST_PROJECT" claude-code 3>&- &
   local watch_pid=$!
   sleep 1
   [ -f "$TEST_SKILL_DIR/run/watch.cc-sess.pid" ]
@@ -387,7 +387,7 @@ JSON
   cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
 {"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
 JSON
-  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" cc-sess2 "$TEST_PROJECT" claude-code &
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" cc-sess2 "$TEST_PROJECT" claude-code 3>&- &
   local watch_pid=$!
   sleep 1
   [ -f "$TEST_SKILL_DIR/run/watch.cc-sess2.pid" ]
@@ -409,7 +409,7 @@ JSON
   cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
 {"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$sp"}]}}}
 JSON
-  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sp-sess "$sp" claude-code &
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sp-sess "$sp" claude-code 3>&- &
   local watch_pid=$!
   sleep 1
   [ -f "$TEST_SKILL_DIR/run/watch.sp-sess.pid" ]
@@ -435,7 +435,7 @@ JSON
 {"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
 JSON
 
-  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sigterm-test "$TEST_PROJECT" claude-code &
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sigterm-test "$TEST_PROJECT" claude-code 3>&- &
   local pid=$!
   sleep 1
   [ -f "$TEST_SKILL_DIR/run/watch.sigterm-test.pid" ]
@@ -982,7 +982,7 @@ JSON
   sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'system', 'alice', 'for-alice');"
   sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'system', 'bob', 'for-bob');"
 
-  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" t-sid "$TEST_PROJECT" claude-code bob > /tmp/agmsg-as-bob 2>&1 &
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" t-sid "$TEST_PROJECT" claude-code bob > /tmp/agmsg-as-bob 2>&1 3>&- &
   local pid=$!
   # High-water-mark = MAX(id) at startup, so prior messages aren't replayed.
   # Insert NEW messages and wait for several poll iterations.
@@ -1079,7 +1079,7 @@ JSON
 
   # Watcher starts with only `alice` registered. Default subscription set
   # is resolved at launch and not re-evaluated each poll.
-  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" t-static "$TEST_PROJECT" claude-code > /tmp/agmsg-static 2>&1 &
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" t-static "$TEST_PROJECT" claude-code > /tmp/agmsg-static 2>&1 3>&- &
   local pid=$!
   sleep 1
 
@@ -1116,9 +1116,9 @@ JSON
 {"name":"team-b","agents":{"bob":{"registrations":[{"type":"claude-code","project":"$proj_b"}]}}}
 JSON
 
-  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sid-a "$proj_a" claude-code &
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sid-a "$proj_a" claude-code 3>&- &
   local pid_a=$!
-  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sid-b "$proj_b" claude-code &
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sid-b "$proj_b" claude-code 3>&- &
   local pid_b=$!
   sleep 1
   [ -f "$TEST_SKILL_DIR/run/watch.sid-a.pid" ]
@@ -1154,9 +1154,9 @@ JSON
 {"name":"team-b","agents":{"bob":{"registrations":[{"type":"claude-code","project":"$proj_b"}]}}}
 JSON
 
-  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" off-a "$proj_a" claude-code &
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" off-a "$proj_a" claude-code 3>&- &
   local pid_a=$!
-  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" off-b "$proj_b" claude-code &
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" off-b "$proj_b" claude-code 3>&- &
   local pid_b=$!
   sleep 1
 
@@ -1186,9 +1186,9 @@ JSON
 {"name":"team-b","agents":{"bob":{"registrations":[{"type":"claude-code","project":"$proj_b"}]}}}
 JSON
 
-  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" stop-a "$proj_a" claude-code &
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" stop-a "$proj_a" claude-code 3>&- &
   local pid_a=$!
-  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" stop-b "$proj_b" claude-code &
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" stop-b "$proj_b" claude-code 3>&- &
   local pid_b=$!
   sleep 1
 
@@ -2043,7 +2043,7 @@ EOF
   cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
 {"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
 JSON
-  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" hermes-preserve-test "$TEST_PROJECT" claude-code &
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" hermes-preserve-test "$TEST_PROJECT" claude-code 3>&- &
   local watch_pid=$!
   sleep 1
   [ -f "$TEST_SKILL_DIR/run/watch.hermes-preserve-test.pid" ]

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -330,7 +330,7 @@ JSON
 
 @test "delivery stop: skips pid whose command line is not watch.sh (pid recycling safety)" {
   mkdir -p "$TEST_SKILL_DIR/run"
-  sleep 30 &
+  sleep 30 3>&- &
   local unrelated_pid=$!
   echo "$unrelated_pid" > "$TEST_SKILL_DIR/run/watch.stale-sess.pid"
   run bash "$SCRIPTS/delivery.sh" stop
@@ -501,7 +501,7 @@ JSON
   mkdir -p "$TEST_SKILL_DIR/run"
 
   # Stand in for the previous watcher: a sleep that updates its own pidfile.
-  sleep 30 &
+  sleep 30 3>&- &
   local prev_pid=$!
   echo "$prev_pid" > "$TEST_SKILL_DIR/run/watch.session-A.pid"
   # Pin the cc-instance state to "session-A" for a fake CC pid we control.
@@ -622,7 +622,7 @@ has_session_end() {
 
 @test "session-end.sh kills the watcher matching session_id and removes pidfile" {
   mkdir -p "$TEST_SKILL_DIR/run"
-  sleep 30 &
+  sleep 30 3>&- &
   local target_pid=$!
   echo "$target_pid" > "$TEST_SKILL_DIR/run/watch.sess-A.pid"
   echo '{"session_id":"sess-A"}' | bash "$SCRIPTS/session-end.sh" claude-code "$TEST_PROJECT"
@@ -633,7 +633,7 @@ has_session_end() {
 
 @test "session-end.sh leaves other sessions' watchers alone" {
   mkdir -p "$TEST_SKILL_DIR/run"
-  sleep 30 &
+  sleep 30 3>&- &
   local other_pid=$!
   echo "$other_pid" > "$TEST_SKILL_DIR/run/watch.sess-B.pid"
   echo '{"session_id":"sess-A"}' | bash "$SCRIPTS/session-end.sh" claude-code "$TEST_PROJECT"
@@ -696,7 +696,7 @@ JSON
 JSON
   bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT" >/dev/null
   mkdir -p "$TEST_SKILL_DIR/run"
-  sleep 30 &
+  sleep 30 3>&- &
   local alive_pid=$!
   echo "$alive_pid" > "$TEST_SKILL_DIR/run/watch.live-session.pid"
   # Bind this watcher to a live CC instance (use $$ as a stand-in).
@@ -711,7 +711,7 @@ JSON
 @test "emit monitor directive: skips when a live watcher already exists for this session" {
   mkdir -p "$TEST_SKILL_DIR/run"
   # Spawn a live process and pretend it's our watcher for this session_id.
-  sleep 30 &
+  sleep 30 3>&- &
   local live_pid=$!
   CLAUDE_CODE_SESSION_ID="live-test-sid"
   export CLAUDE_CODE_SESSION_ID
@@ -927,8 +927,8 @@ EOF
   cat > "$bindir/timeout" <<'EOF'
 #!/usr/bin/env bash
 secs="$1"; shift
-("$@") & cmd_pid=$!
-( sleep "$secs"; kill "$cmd_pid" 2>/dev/null ) & watchdog_pid=$!
+("$@") 3>&- & cmd_pid=$!
+( sleep "$secs"; kill "$cmd_pid" 2>/dev/null ) 3>&- & watchdog_pid=$!
 if wait "$cmd_pid" 2>/dev/null; then
   kill "$watchdog_pid" 2>/dev/null
   exit 0
@@ -1018,7 +1018,7 @@ JSON
   mkdir -p "$TEST_SKILL_DIR/run"
 
   # Orphan: watcher referenced by a cc-instance.<dead-pid> file.
-  sleep 30 &
+  sleep 30 3>&- &
   local orphan_pid=$!
   echo "$orphan_pid" > "$TEST_SKILL_DIR/run/watch.orphan-sid.pid"
   # Use a PID that's almost certainly not in use as the dead CC ancestor.
@@ -1027,7 +1027,7 @@ JSON
 
   # Untracked watcher: no cc-instance points to it. Conservative semantics
   # leave it alone (we have no evidence the CC is dead).
-  sleep 30 &
+  sleep 30 3>&- &
   local untracked_pid=$!
   echo "$untracked_pid" > "$TEST_SKILL_DIR/run/watch.untracked-sid.pid"
 
@@ -1054,7 +1054,7 @@ JSON
   # The session moved from one CC pid to another (claude --continue / resume).
   # cc-instance.<dead> still references the same session_id as
   # cc-instance.<live>. The watcher must NOT be killed.
-  sleep 30 &
+  sleep 30 3>&- &
   local watcher_pid=$!
   echo "$watcher_pid" > "$TEST_SKILL_DIR/run/watch.shared-sid.pid"
   local dead_cc=999999
@@ -1664,7 +1664,7 @@ EOF
   bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
   mkdir -p "$TEST_SKILL_DIR/run"
 
-  sleep 60 &
+  sleep 60 3>&- &
   local bpid=$!
   # shellcheck disable=SC2064  # capture the current child pid for EXIT cleanup
   trap "kill $bpid 2>/dev/null || true" EXIT
@@ -1828,7 +1828,7 @@ EOF
   printf '#!/usr/bin/env bash\necho real\n' > "$other_bin/codex"
   chmod +x "$other_bin/codex"
 
-  sleep 60 &
+  sleep 60 3>&- &
   local bpid=$!
   # shellcheck disable=SC2064  # capture the current child pid for EXIT cleanup
   trap "kill $bpid 2>/dev/null || true" EXIT
@@ -1857,7 +1857,7 @@ EOF
   bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
   mkdir -p "$TEST_SKILL_DIR/run"
 
-  sleep 60 &
+  sleep 60 3>&- &
   local bpid=$!
   # shellcheck disable=SC2064  # capture the current child pid for EXIT cleanup
   trap "kill $bpid 2>/dev/null || true" EXIT
@@ -1975,7 +1975,7 @@ EOF
   bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
   mkdir -p "$TEST_SKILL_DIR/run"
   # Stand in for a live bridge with a real process we can check kill -0 against.
-  sleep 60 &
+  sleep 60 3>&- &
   local bpid=$!
   echo "$bpid" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
   echo "pid=$bpid" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.meta"

--- a/tests/test_despawn.bats
+++ b/tests/test_despawn.bats
@@ -38,7 +38,7 @@ teardown() {
   # manually" branch — role-drop is still asserted.
   AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE -u HERDR_PANE_ID -u HERDR_ENV \
     bash "$SCRIPTS/watch.sh" sess-m "$PROJ" claude-code alice \
-    >/dev/null 2>&1 &
+    >/dev/null 2>&1 3>&- &
   local wpid=$! i
   # Wait for the watcher to attach (it claims the lock + writes the ready sentinel).
   for i in 1 2 3 4 5 6 7 8 9 10; do [ -e "$RUN/ready.team__alice" ] && break; sleep 0.5; done
@@ -71,7 +71,7 @@ _read_at_for_body() {
   setup_live_owner "$RUN" sess-m
 
   AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE bash "$SCRIPTS/watch.sh" sess-m "$PROJ" claude-code alice \
-    >/dev/null 2>&1 &
+    >/dev/null 2>&1 3>&- &
   local wpid=$! i
   for i in 1 2 3 4 5 6 7 8 9 10; do [ -e "$RUN/ready.team__alice" ] && break; sleep 0.5; done
   [ -e "$RUN/ready.team__alice" ]
@@ -133,7 +133,7 @@ _read_at_for_body() {
   # Broad watcher (no actas arg) — subscribes to both alice and leader.
   AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE -u HERDR_PANE_ID -u HERDR_ENV \
     bash "$SCRIPTS/watch.sh" sess-broad "$PROJ" claude-code \
-    >/dev/null 2>&1 &
+    >/dev/null 2>&1 3>&- &
   local wpid=$! i
   for i in 1 2 3 4 5 6 7 8 9 10; do kill -0 "$wpid" 2>/dev/null && break; sleep 0.5; done
 

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -52,7 +52,7 @@ await_barrier_reached() {
   # Pause the run between display and mark, land a message inside the window,
   # then release. With the old blanket "WHERE read_at IS NULL" mark, the late
   # message was silently marked read without ever having been displayed.
-  AGMSG_TEST_MARK_BARRIER="$BARRIER" bash "$SCRIPTS/inbox.sh" testteam alice > "$TEST_SKILL_DIR/first-run.out" &
+  AGMSG_TEST_MARK_BARRIER="$BARRIER" bash "$SCRIPTS/inbox.sh" testteam alice > "$TEST_SKILL_DIR/first-run.out" 3>&- &
   bg_pid=$!
   await_barrier_reached
   bash "$SCRIPTS/send.sh" testteam bob alice "late"
@@ -74,7 +74,7 @@ await_barrier_reached() {
 
 @test "check-inbox: a message arriving between display and mark is NOT marked read unseen" {
   bash "$SCRIPTS/send.sh" testteam bob alice "early"
-  AGMSG_TEST_MARK_BARRIER="$BARRIER" bash "$SCRIPTS/check-inbox.sh" claude-code /tmp/project-a > "$TEST_SKILL_DIR/check-run.out" 2>/dev/null &
+  AGMSG_TEST_MARK_BARRIER="$BARRIER" bash "$SCRIPTS/check-inbox.sh" claude-code /tmp/project-a > "$TEST_SKILL_DIR/check-run.out" 2>/dev/null 3>&- &
   bg_pid=$!
   await_barrier_reached
   bash "$SCRIPTS/send.sh" testteam bob alice "late"

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -329,11 +329,11 @@ PS1
   bash "$SK/scripts/join.sh" demo alice claude-code /tmp/install-projA
   local sid="resue-sid-$$"
 
-  bash "$SK/scripts/watch.sh" "$sid" /tmp/install-projA claude-code &
+  bash "$SK/scripts/watch.sh" "$sid" /tmp/install-projA claude-code 3>&- &
   local first=$!
   wait_for_pidfile_pid "$SK/run/watch.$sid.pid" "$first"
 
-  bash "$SK/scripts/watch.sh" "$sid" /tmp/install-projA claude-code &
+  bash "$SK/scripts/watch.sh" "$sid" /tmp/install-projA claude-code 3>&- &
   local second=$!
   wait_for_pidfile_pid "$SK/run/watch.$sid.pid" "$second"
   # The pidfile can flip to $second a beat before $first's TERM trap has

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -236,8 +236,8 @@ teardown() { teardown_test_env; }
 # treated as distinct owners — the collision that broke the actas lock is gone.
 @test "actas: same session_id, different pid -> distinct live owners (#93)" {
   skip_on_windows "instance-id live PID liveness under Git Bash (#182)"
-  sleep 60 & local pa=$!
-  sleep 60 & local pb=$!
+  sleep 60 3>&- & local pa=$!
+  sleep 60 3>&- & local pb=$!
   local ta="sess.$pa" tb="sess.$pb"
 
   # pa claims; pb is refused because pa is a live, distinct owner.

--- a/tests/test_resolve_project.bats
+++ b/tests/test_resolve_project.bats
@@ -252,7 +252,7 @@ JSON
 
 @test "pid-is-agent: excludes a 'claude daemon run' process even though argv0 matches" {
   skip_on_windows "process argv faking via exec -a (#349)"
-  bash -c 'exec -a "claude daemon run --json-path /tmp/agmsg-test-daemon.json" sleep 5' &
+  bash -c 'exec -a "claude daemon run --json-path /tmp/agmsg-test-daemon.json" sleep 5' 3>&- &
   local p=$!
   sleep 0.3
   run agmsg_pid_is_agent "$p" claude-code
@@ -266,7 +266,7 @@ JSON
   # so it must NOT be an exclusion signal on its own — only "daemon run"
   # identifies the daemon. This is the actual reported shape:
   # ".../claude/versions/2.1.199 --bg-spare ...".
-  bash -c 'exec -a "2.1.199 --bg-spare" sleep 5' &
+  bash -c 'exec -a "2.1.199 --bg-spare" sleep 5' 3>&- &
   local p=$!
   sleep 0.3
   run agmsg_pid_is_agent "$p" claude-code
@@ -276,7 +276,7 @@ JSON
 
 @test "pid-is-agent: accepts a version-named claude-code session binary" {
   skip_on_windows "process argv faking via exec -a (#349)"
-  bash -c 'exec -a "2.1.199" sleep 5' &
+  bash -c 'exec -a "2.1.199" sleep 5' 3>&- &
   local p=$!
   sleep 0.3
   run agmsg_pid_is_agent "$p" claude-code
@@ -286,7 +286,7 @@ JSON
 
 @test "pid-is-agent: accepts a version-named session binary under a full versions/ path" {
   skip_on_windows "process argv faking via exec -a (#349)"
-  bash -c 'exec -a "/home/x/.local/share/claude/versions/2.1.199" sleep 5' &
+  bash -c 'exec -a "/home/x/.local/share/claude/versions/2.1.199" sleep 5' 3>&- &
   local p=$!
   sleep 0.3
   run agmsg_pid_is_agent "$p" claude-code
@@ -296,7 +296,7 @@ JSON
 
 @test "pid-is-agent: a version-named binary is NOT accepted for a non-claude-code type" {
   skip_on_windows "process argv faking via exec -a (#349)"
-  bash -c 'exec -a "2.1.199" sleep 5' &
+  bash -c 'exec -a "2.1.199" sleep 5' 3>&- &
   local p=$!
   sleep 0.3
   run agmsg_pid_is_agent "$p" codex
@@ -356,7 +356,7 @@ JSON
   # Launch the actas watcher (ACTIVE_NAME=alice) from a subdir; without
   # resolution it would see no registration and exit immediately.
   bash "$SKILL_DIR/scripts/watch.sh" sid-w "$ROOT/sub/deep" claude-code alice \
-    >"$BATS_TEST_TMPDIR/w.out" 2>&1 &
+    >"$BATS_TEST_TMPDIR/w.out" 2>&1 3>&- &
   local wpid=$!
   sleep 1
   # A resolving watcher is still alive in its poll loop; an unresolved one has

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -169,7 +169,7 @@ SH
   # sends silently drop. With the wrapper they wait and all land. See #114.
   local x
   for x in 1 2 3 4 5 6 7 8 9 10; do
-    ( bash "$SCRIPTS/send.sh" team leader "tgt$x" "job $x" --force >/dev/null 2>&1 ) &
+    ( bash "$SCRIPTS/send.sh" team leader "tgt$x" "job $x" --force >/dev/null 2>&1 ) 3>&- &
   done
   wait
   local n
@@ -185,7 +185,7 @@ SH
   export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/freshstore"
   local x
   for x in 1 2 3 4 5 6 7 8 9 10; do
-    ( bash "$SCRIPTS/send.sh" team leader "tgt$x" "job $x" --force >/dev/null 2>&1 ) &
+    ( bash "$SCRIPTS/send.sh" team leader "tgt$x" "job $x" --force >/dev/null 2>&1 ) 3>&- &
   done
   wait
   local n

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -121,7 +121,7 @@ EOF
   bash "$SCRIPTS/join.sh" race seed claude-code /tmp/seed
   local pids=() i
   for i in $(seq 1 "$n"); do
-    bash "$SCRIPTS/join.sh" race "agent$i" claude-code "/tmp/p$i" >/dev/null 2>&1 &
+    bash "$SCRIPTS/join.sh" race "agent$i" claude-code "/tmp/p$i" >/dev/null 2>&1 3>&- &
     pids+=($!)
   done
   for i in "${pids[@]}"; do wait "$i"; done

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -445,7 +445,7 @@ _wait_pidfile() {
   local out="$TEST_SKILL_DIR/burst.log"
   local wm="$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark"
 
-  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null &
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
   local w=$!
   _wait_for_file "$wm"          # ready to receive (watermark seeded)
 

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -153,7 +153,7 @@ _wait_for_file_contains() {
   # the composite instance id) makes that deterministic. Cross-restart
   # redelivery itself is covered by "watch: restart delivers messages that
   # arrived while the watcher was down".
-  local sesspid; sleep 600 & sesspid=$!
+  local sesspid; sleep 600 3>&- & sesspid=$!
   local iid="sess-liveness.$sesspid"
   local wm="$TEST_SKILL_DIR/run/watch.$iid.watermark"
   local pf="$TEST_SKILL_DIR/run/watch.$iid.pid"
@@ -288,7 +288,7 @@ _wait_for_file_contains() {
 
   # Start a watcher so a pidfile exists with a live pid.
   AGMSG_WATCH_INTERVAL=60 bash "$SCRIPTS/watch.sh" "sess1" "$PROJ" claude-code \
-    >/dev/null 2>&1 &
+    >/dev/null 2>&1 3>&- &
   local wpid=$!
 
   # Resolve the instance id session-start.sh will compute for "sess1".
@@ -357,7 +357,7 @@ _wait_pidfile() {
   # whose session pid is dead, so use real stand-in session processes rather
   # than fabricated pids (which would pass or fail by accident of what pid
   # happens to exist on the host).
-  local sp1 sp2; sleep 600 & sp1=$!; sleep 600 & sp2=$!
+  local sp1 sp2; sleep 600 3>&- & sp1=$!; sleep 600 3>&- & sp2=$!
   local pf1="$TEST_SKILL_DIR/run/watch.shared.$sp1.pid"
   local pf2="$TEST_SKILL_DIR/run/watch.shared.$sp2.pid"
 
@@ -388,7 +388,7 @@ _wait_pidfile() {
   # liveness guard (#67) exits any watcher whose embedded session pid is dead, so
   # a fabricated dead pid (the old "solo.2002") would self-exit before the
   # relaunch could be observed. Use a real stand-in session process instead.
-  local sesspid; sleep 600 & sesspid=$!
+  local sesspid; sleep 600 3>&- & sesspid=$!
   local iid="solo.$sesspid"
   local pf="$TEST_SKILL_DIR/run/watch.$iid.pid"
 
@@ -653,7 +653,7 @@ _despawn_under_herdr() {
   setup_live_owner "$TEST_SKILL_DIR/run" sess-herdr
   AGMSG_WATCH_INTERVAL=1 env -u TMUX_PANE "$@" PATH="$stub_bin:$PATH" \
     bash "$SCRIPTS/watch.sh" sess-herdr "$PROJ" claude-code alice \
-    >/dev/null 2>"$errlog" &
+    >/dev/null 2>"$errlog" 3>&- &
   local wpid=$! i
   for i in 1 2 3 4 5 6 7 8 9 10; do
     [ -e "$TEST_SKILL_DIR/run/ready.team__alice" ] && break; sleep 0.5


### PR DESCRIPTION
## Summary

bats holds test-file teardown open until every process that inherited its fd 3 has closed it. A backgrounded process launched without `3>&-` keeps that fd for its lifetime, so any launch that survives its cleanup (most easily: an assertion fails before the `kill` line is reached) pins the whole run at the end of the file until the job-level timeout cancels it.

Direct evidence from the v1.1.11 release run (30249251822, attempt 1, `bats (macos-latest)`): the job went silent for 12m58s after its last test line and was cancelled at 25m18s; attempt 3 of the same commit passed in 18m19s. The stall window matches the long-lived background processes fixed here (up to `sleep 600` stand-in session pids).

The earlier fd-3 sweep (#251) covered only the line-final `&` watcher launches in `test_watch.bats`. This PR applies one uniform rule — every backgrounded launch in `tests/` closes fd 3 with `3>&-` — covering the classes the first sweep missed:

- continuation-style launches where the `&` sits on a redirect line (`test_watch.bats`, `test_actas_integration.bats`, `test_despawn.bats`, `test_resolve_project.bats`)
- long-lived helper processes: `sleep 600` stand-in session pids, `sleep 30`/`sleep 60` decoys, the python socket listener, node fake servers, the compat stub
- mid-line launches (`... & pid=$!`), including the timeout watchdog pair in `test_delivery.bats`
- barrier-blocked foreground-script launches (`test_inbox.bats`) and short-lived race senders (`test_storage.bats`, `test_team.bats`), for uniformity so future copy-paste starts from a safe template

12 files, 44 sites, redirect-only (`3>&-` added at each launch); no test logic touched. `tests/test_helper.bash` has no backgrounded launches.

## Testing

- `bats --count tests/*.bats` → 787 (syntax intact)
- Full local run of all 12 changed files: pass