### PR TITLE
ci: run the bats suite in parallel shards

### DIFF
--- a/.github/scripts/shard-tests.sh
+++ b/.github/scripts/shard-tests.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Deterministically partition the bats suite into shards, and print the test
+# files belonging to one of them (one path per line).
+#
+#   .github/scripts/shard-tests.sh <index> <total> [tests-dir]
+#
+# The partition is computed from the tree itself, not from a list someone has
+# to remember to update. That is the point: with a hand-maintained matrix, a
+# newly added test file lands in no shard at all and simply never runs — a
+# green CI that silently stopped testing something. Here every `*.bats` file in
+# the directory is assigned to exactly one shard, so the union of all shards is
+# always the whole suite (asserted by tests/test_ci_sharding.bats).
+#
+# Balancing is by @test count, greedy longest-processing-time first, rather
+# than by file count: the suite's files differ by more than an order of
+# magnitude in size, so splitting on names alone would leave one shard doing
+# most of the work and cap the speedup at whatever that shard costs.
+#
+# Test count is a proxy for runtime, and a loose one — measured on macOS, the
+# whole suite is 860s and the count-balanced quarters (197/196/197/197 tests)
+# come out at 125s/298s/366s/71s. Per-test cost varies from ~0.0s to ~8s
+# depending on how much a file forks or waits. So the real speedup here is
+# 860s -> 366s (~2.4x), not 4x.
+#
+# It is still the right weight to ship first. The alternative, a checked-in
+# table of measured per-file seconds, buys ~150s more but goes stale silently:
+# it would be wrong the moment the fixed `sleep`s in the suite are replaced by
+# condition polling, which is the very next CI change queued. Weights are worth
+# revisiting once runtimes stop moving. Note the floor either way is the
+# slowest single file (test_spawn.bats, 199s) — no split beats that, so the
+# ceiling on this approach is ~4.5x, not 4x-and-then-some.
+#
+# Whatever the weights, the property that matters is coverage, not balance: the
+# worst case of a bad weight is an unevenly filled shard, never a missing file.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: ${0##*/} <shard-index> <shard-total> [tests-dir]" >&2
+  echo "  shard-index is 1-based and must be <= shard-total" >&2
+  exit 2
+}
+
+[ "$#" -ge 2 ] || usage
+index="$1"
+total="$2"
+dir="${3:-tests}"
+
+case "$index" in ''|*[!0-9]*) usage ;; esac
+case "$total" in ''|*[!0-9]*) usage ;; esac
+[ "$total" -ge 1 ] || usage
+[ "$index" -ge 1 ] || usage
+[ "$index" -le "$total" ] || usage
+[ -d "$dir" ] || { echo "${0##*/}: no such directory: $dir" >&2; exit 1; }
+
+# LC_ALL=C keeps the enumeration order identical across the GNU and BSD
+# userlands the suite already runs on, so a given tree always produces the same
+# partition regardless of which runner computes it.
+files="$(find "$dir" -maxdepth 1 -name '*.bats' | LC_ALL=C sort)"
+[ -n "$files" ] || { echo "${0##*/}: no .bats files under $dir" >&2; exit 1; }
+
+# Weight each file by its number of test cases. `grep -c` exits 1 on no match
+# after printing 0, which set -e would otherwise treat as fatal.
+weighted=""
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  n="$(grep -c '^[[:space:]]*@test' "$f" || true)"
+  [ -n "$n" ] || n=0
+  weighted="${weighted}${n}	${f}
+"
+done <<EOF
+$files
+EOF
+
+# Heaviest first; ties broken by path so the order is total, not incidental.
+sorted="$(printf '%s' "$weighted" | LC_ALL=C sort -t'	' -k1,1nr -k2,2)"
+
+# Greedy LPT: hand each file to the currently lightest shard.
+i=0
+while [ "$i" -lt "$total" ]; do
+  load[i]=0
+  i=$((i + 1))
+done
+
+while IFS='	' read -r n f; do
+  [ -n "$f" ] || continue
+  best=0
+  best_load=${load[0]}
+  j=1
+  while [ "$j" -lt "$total" ]; do
+    if [ "${load[j]}" -lt "$best_load" ]; then
+      best=$j
+      best_load=${load[j]}
+    fi
+    j=$((j + 1))
+  done
+  load[best]=$((best_load + n))
+  # An `if`, not `[ ... ] && printf`: a false test as the loop's last command
+  # becomes the script's exit status, so the caller would see failure or
+  # success depending on nothing but whether the final file happened to land
+  # in the requested shard.
+  if [ "$best" -eq "$((index - 1))" ]; then
+    printf '%s\n' "$f"
+  fi
+done <<EOF
+$sorted
+EOF
+
+exit 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,20 +1,34 @@
 name: tests
 
-# Run the full Bats suite on every PR and on pushes to main. The suite is
-# fast (~2 min) and this repo is public, so GitHub-hosted runners are free —
-# running everything every time is simpler and safer than selectively running
-# "only the changed tests", which would miss regressions in shared libs
-# (lib/*.sh) that fan out across many scripts.
+# Run the full Bats suite on every PR and on pushes to main. This repo is
+# public, so GitHub-hosted runners are free — running everything every time is
+# simpler and safer than selectively running "only the changed tests", which
+# would miss regressions in shared libs (lib/*.sh) that fan out across many
+# scripts. What we do instead is run the whole suite in parallel shards.
+#
+# Sharding: the suite has grown to ~790 tests, 11 min on ubuntu and 12-17 on
+# macOS, which is the dominant wait on every PR. `bats-shard` splits it across
+# SHARD_TOTAL runners per OS. The split is computed from the tree by
+# .github/scripts/shard-tests.sh, NOT from a list in this file: a static list
+# would put a newly added test file in no shard at all, and CI would go on
+# reporting green while silently not running it. tests/test_ci_sharding.bats
+# pins that the shards stay a partition of tests/*.bats.
 #
 # Docs-only skip (without the paths-ignore trap):
-# `bats (ubuntu-latest)` and `bats (macos-latest)` are REQUIRED status checks
-# on main. A naive `paths-ignore` would mean those checks never report on a
-# docs-only PR, leaving it stuck "pending" forever and unmergeable. So instead
-# the `bats` jobs ALWAYS run and ALWAYS complete green — a `changes` job
-# decides whether the diff is docs-only, and only the heavy steps (install +
-# run) are skipped when it is. The required context is therefore always
-# reported; on docs-only PRs it just reports green in seconds without running
-# the suite.
+# the bats check is REQUIRED on main. A naive `paths-ignore` would mean it
+# never reports on a docs-only PR, leaving it stuck "pending" forever and
+# unmergeable. So instead the shard jobs ALWAYS run and ALWAYS complete green —
+# a `changes` job decides whether the diff is docs-only, and only the heavy
+# steps (install + run) are skipped when it is. The required context is
+# therefore always reported; on docs-only PRs it just reports green in seconds
+# without running the suite.
+#
+# The required context is the `bats` SUMMARY job, not the shards. Shard names
+# carry their index, so changing SHARD_TOTAL would rename every required check
+# and silently stop enforcing the ones branch protection still names. The
+# summary job's name is stable across any future re-shard, and it fails unless
+# the whole matrix succeeded — including when the matrix was skipped, which
+# must never read as green.
 #
 # What counts as "docs-only" (= safe to skip the bash suite): the docs tree
 # (`docs/**`), the marketing site (`site/**` — a standalone Astro app with no
@@ -33,6 +47,14 @@ on:
 
 permissions:
   contents: read
+
+env:
+  # Number of parallel shards per OS. Kept in one place because the matrix, the
+  # job name, and the argument to shard-tests.sh must agree — if they drift, a
+  # shard silently runs the wrong slice of the suite. Raising it is safe (the
+  # split is recomputed, not hardcoded); it only changes the shard job names,
+  # which is exactly why the required check is the summary job below.
+  SHARD_TOTAL: 4
 
 jobs:
   # Cheap gate: is this PR's diff entirely documentation? Pushes to main always
@@ -81,12 +103,17 @@ jobs:
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
           echo "app_changed=$app_changed" >> "$GITHUB_OUTPUT"
 
-  bats:
-    name: bats (${{ matrix.os }})
+  bats-shard:
+    name: bats (${{ matrix.os }} ${{ matrix.shard }}/4)
     needs: changes
     # Run even if `changes` somehow failed/was skipped — fail open to the full
-    # suite rather than leaving this REQUIRED check unreported (which would
+    # suite rather than leaving the required check unreported (which would
     # block the PR). When changes failed, docs_only is empty → heavy steps run.
+    #
+    # This is also why the matrix is a literal list rather than something the
+    # `changes` job computes: a dynamic matrix cannot be evaluated when the job
+    # that feeds it failed, so a broken `changes` would take the whole suite
+    # down instead of falling back to running everything.
     if: ${{ !cancelled() }}
     runs-on: ${{ matrix.os }}
     # Bound a hung runner/test so a stall fails fast (and is re-runnable) instead
@@ -100,10 +127,16 @@ jobs:
     # behaving like a coin flip on PRs that changed nothing relevant. 25 matches
     # the app-test-windows job below.
     #
-    # If the suite grows enough that this cap starts firing again, raise it (or
-    # split the suite) rather than re-running until it passes: a job that always
-    # dies at the same elapsed time is a timeout, not a flaky test.
+    # If a shard starts firing this cap, re-shard (raise SHARD_TOTAL) rather
+    # than re-running until it passes: a job that always dies at the same
+    # elapsed time is a timeout, not a flaky test.
     # bats-windows sets its own timeout; this covers ubuntu/macos.
+    #
+    # Left at the pre-sharding value on purpose. A shard is a quarter of the
+    # suite, so this is now generous headroom rather than a tight bound — and
+    # a cap that only ever fires on a genuine hang is the one that carries no
+    # false positives. (It was 15 against a 12-14 min macOS suite, and killed
+    # ~47% of macOS runs mid-suite at whatever test was running.)
     timeout-minutes: 25
     strategy:
       # Cover both GNU (Linux) and BSD (macOS) userlands — the scripts shell out
@@ -111,12 +144,35 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        # Must list exactly 1..SHARD_TOTAL. The `bats` summary job verifies
+        # end-to-end that the shards actually covered every test file, so a
+        # drift here fails the required check instead of silently dropping a
+        # slice of the suite.
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
 
       - name: Docs-only change — skipping suite
         if: needs.changes.outputs.docs_only == 'true'
         run: echo "Diff is documentation-only; skipping the bats suite and reporting green to satisfy the required check."
+
+      - name: Compute this shard's test files
+        if: needs.changes.outputs.docs_only != 'true'
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          if [ "$SHARD" -gt "$SHARD_TOTAL" ]; then
+            echo "::error::matrix shard $SHARD exceeds SHARD_TOTAL=$SHARD_TOTAL — the matrix and SHARD_TOTAL have drifted apart"
+            exit 1
+          fi
+          .github/scripts/shard-tests.sh "$SHARD" "$SHARD_TOTAL" > shard-files.txt
+          if [ ! -s shard-files.txt ]; then
+            echo "::error::shard $SHARD of $SHARD_TOTAL was assigned no test files"
+            exit 1
+          fi
+          echo "Shard $SHARD/$SHARD_TOTAL runs $(wc -l < shard-files.txt) file(s):"
+          cat shard-files.txt
 
       - name: Ensure sqlite3 is available (Linux)
         if: runner.os == 'Linux' && needs.changes.outputs.docs_only != 'true'
@@ -140,9 +196,100 @@ jobs:
           sqlite3 --version
           bats --version
 
-      - name: Run bats suite
+      - name: Run bats suite (this shard)
         if: needs.changes.outputs.docs_only != 'true'
-        run: bats --print-output-on-failure tests/
+        run: |
+          set -euo pipefail
+          # Paths come from shard-tests.sh over tests/*.bats and contain no
+          # spaces; xargs keeps them as separate arguments to one bats run.
+          xargs bats --print-output-on-failure < shard-files.txt
+
+      # What the summary job checks the partition against. Uploaded only when
+      # the suite actually ran, so a docs-only PR produces none — and the
+      # summary skips the check for exactly that case.
+      - name: Record which files this shard ran
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bats-manifest-${{ matrix.os }}-${{ matrix.shard }}
+          path: shard-files.txt
+          retention-days: 1
+
+  # The REQUIRED status check. Shard job names carry their index, so making the
+  # shards required would mean branch protection had to be re-pointed every
+  # time SHARD_TOTAL changed — and until someone did, protection would be
+  # enforcing check names that no longer run. This job's name never changes.
+  #
+  # It fails unless the whole matrix succeeded. `skipped` is treated as failure
+  # too: a suite that did not run is not a suite that passed, and the whole
+  # point of the always-report pattern above is that green means something.
+  bats:
+    name: bats
+    needs: [changes, bats-shard]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check shard results
+        env:
+          RESULT: ${{ needs.bats-shard.result }}
+        run: |
+          set -euo pipefail
+          echo "bats shard matrix result: $RESULT"
+          case "$RESULT" in
+            success) ;;
+            skipped) echo "::error::the bats shards did not run — refusing to report green"; exit 1 ;;
+            *)       echo "::error::the bats shards did not all pass (result: $RESULT)"; exit 1 ;;
+          esac
+
+      - name: Docs-only change — no shard manifests to verify
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Diff is documentation-only; the shards reported green without running, so there is no partition to verify."
+
+      - name: Download shard manifests
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: bats-manifest-*
+          path: manifests
+
+      # The end-to-end guarantee: every tests/*.bats file was actually run, on
+      # every OS. A partition bug in shard-tests.sh, a matrix entry someone
+      # deleted, a new test file that landed nowhere — all of them show up here
+      # as a named missing file rather than as a green run that quietly tested
+      # less than it did yesterday.
+      - name: Verify the shards covered the whole suite
+        if: needs.changes.outputs.docs_only != 'true'
+        run: |
+          set -euo pipefail
+          expected="$(find tests -maxdepth 1 -name '*.bats' | LC_ALL=C sort)"
+          status=0
+          for os in ubuntu-latest macos-latest; do
+            actual="$(cat manifests/bats-manifest-"$os"-*/shard-files.txt | LC_ALL=C sort)"
+            if [ "$actual" = "$expected" ]; then
+              echo "$os: all $(printf '%s\n' "$expected" | wc -l | tr -d ' ') test file(s) ran."
+              continue
+            fi
+            status=1
+            missing="$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$actual" | uniq))"
+            extra="$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$actual" | uniq))"
+            dupes="$(printf '%s\n' "$actual" | uniq -d)"
+            # Plain `if`s, not `[ -n "$x" ] && echo`: under `set -e` a false
+            # test at the end of a && list exits the step, which would report
+            # only the first kind of discrepancy and swallow the rest.
+            if [ -n "$missing" ]; then
+              printf '::error::%s: test file(s) run by no shard:\n%s\n' "$os" "$missing"
+            fi
+            if [ -n "$extra" ]; then
+              printf '::error::%s: shard(s) ran file(s) not in tests/:\n%s\n' "$os" "$extra"
+            fi
+            if [ -n "$dupes" ]; then
+              printf '::error::%s: file(s) run by more than one shard:\n%s\n' "$os" "$dupes"
+            fi
+          done
+          exit "$status"
 
   # Windows coverage for the native helpers shipped in #103 (Git Bash runner,
   # sqlite3 compatibility shim, cygpath normalization). The POSIX-assuming suite

--- a/tests/test_ci_sharding.bats
+++ b/tests/test_ci_sharding.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+#
+# The CI suite is split across parallel shards by .github/scripts/shard-tests.sh.
+# If that split ever stops being a partition of tests/*.bats, CI keeps reporting
+# green while quietly running less than it did before — the failure mode this
+# file exists to make impossible.
+
+setup() {
+  load 'test_helper'
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SHARD="$REPO_ROOT/.github/scripts/shard-tests.sh"
+}
+
+all_test_files() {
+  find "$REPO_ROOT/tests" -maxdepth 1 -name '*.bats' -exec basename {} \; | LC_ALL=C sort
+}
+
+union_of_shards() {
+  local total="$1" i
+  for ((i = 1; i <= total; i++)); do
+    (cd "$REPO_ROOT" && bash "$SHARD" "$i" "$total")
+  done | sed 's|.*/||' | LC_ALL=C sort
+}
+
+@test "shard-tests.sh is executable and self-documents its usage" {
+  [ -x "$SHARD" ]
+  run bash "$SHARD"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"usage:"* ]]
+}
+
+@test "the shards cover every test file exactly once" {
+  # Checked across several totals: an off-by-one in the greedy loop can easily
+  # be invisible at one shard count and drop a file at another.
+  local total
+  for total in 1 2 3 4 5 8; do
+    run union_of_shards "$total"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$(all_test_files)" ] || {
+      echo "shard total $total did not reproduce the suite" >&2
+      diff <(echo "$output") <(all_test_files) >&2 || true
+      return 1
+    }
+  done
+}
+
+@test "this test file is itself assigned to a shard" {
+  # Guards the specific regression the partition property is meant to prevent:
+  # a new test file that lands in no shard and therefore never runs in CI.
+  run union_of_shards 4
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test_ci_sharding.bats"* ]]
+}
+
+@test "the split is deterministic across repeated runs" {
+  local first second
+  first="$(cd "$REPO_ROOT" && bash "$SHARD" 2 4)"
+  second="$(cd "$REPO_ROOT" && bash "$SHARD" 2 4)"
+  [ "$first" = "$second" ]
+}
+
+@test "no shard is empty at the shard count CI uses" {
+  local i out
+  for i in 1 2 3 4; do
+    out="$(cd "$REPO_ROOT" && bash "$SHARD" "$i" 4)"
+    [ -n "$out" ]
+  done
+}
+
+@test "the heaviest file does not share a shard with the second heaviest" {
+  # Not a correctness property — a balance smoke test. Greedy LPT should never
+  # put the two largest files together while lighter shards exist; if it does,
+  # the weighting has broken and CI is slower than it looks.
+  local heaviest second
+  heaviest="$(cd "$REPO_ROOT" && grep -c '^[[:space:]]*@test' tests/*.bats \
+    | sort -t: -k2 -rn | sed -n '1s/:.*//p')"
+  second="$(cd "$REPO_ROOT" && grep -c '^[[:space:]]*@test' tests/*.bats \
+    | sort -t: -k2 -rn | sed -n '2s/:.*//p')"
+  local i shard_files
+  for i in 1 2 3 4; do
+    shard_files="$(cd "$REPO_ROOT" && bash "$SHARD" "$i" 4)"
+    if [[ "$shard_files" == *"$heaviest"* ]]; then
+      [[ "$shard_files" != *"$second"* ]]
+    fi
+  done
+}
+
+@test "shard-tests.sh rejects out-of-range and non-numeric arguments" {
+  run bash "$SHARD" 0 4
+  [ "$status" -eq 2 ]
+  run bash "$SHARD" 5 4
+  [ "$status" -eq 2 ]
+  run bash "$SHARD" abc 4
+  [ "$status" -eq 2 ]
+  run bash "$SHARD" 1 0
+  [ "$status" -eq 2 ]
+}
+
+@test "shard-tests.sh fails loudly on a directory with no test files" {
+  local empty="$BATS_TEST_TMPDIR/empty"
+  mkdir -p "$empty"
+  run bash "$SHARD" 1 4 "$empty"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no .bats files"* ]]
+
+  run bash "$SHARD" 1 4 "$BATS_TEST_TMPDIR/does-not-exist"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no such directory"* ]]
+}
+
+@test "the CI workflow shard matrix matches the SHARD_TOTAL it passes" {
+  # The matrix is a literal list (so a broken `changes` job cannot take the
+  # whole suite down with an unevaluatable dynamic matrix), which means these
+  # two numbers have to be kept in step by hand. CI verifies coverage
+  # end-to-end from the shard manifests as well; this catches the drift here,
+  # where the fix is obvious.
+  local wf="$REPO_ROOT/.github/workflows/tests.yml"
+  local total matrix_entries
+  total="$(sed -n 's/^  SHARD_TOTAL: \([0-9]*\)$/\1/p' "$wf")"
+  [ -n "$total" ]
+  matrix_entries="$(sed -n 's/^ *shard: \[\(.*\)\]$/\1/p' "$wf" | tr ',' '\n' | grep -c '[0-9]')"
+  [ "$matrix_entries" -eq "$total" ]
+  # ...and the shard job's display name must name the same total, or the run
+  # log claims a split the workflow is not performing.
+  grep -q "bats (\${{ matrix.os }} \${{ matrix.shard }}/$total)" "$wf"
+}


### PR DESCRIPTION
The bats suite is ~790 tests and takes 11 min on ubuntu, 12-17 on macOS. It is
the dominant wait on every PR. This splits it across four runners per OS.

## How the split is decided

`.github/scripts/shard-tests.sh <index> <total>` computes the partition from
the tree, and the workflow calls it. It is deliberately not a list of files in
the workflow: a static list has one specific failure mode, where a newly added
test file is in no shard and CI keeps reporting green while silently no longer
running it.

Balancing is by `@test` count, greedy longest-processing-time first.

## Coverage is verified end to end, not assumed

Each shard uploads the list of files it ran. The summary job downloads all of
them and asserts that their union, per OS, is exactly `tests/*.bats`. A
partition bug, a matrix entry someone deleted, or a new file that landed
nowhere surfaces as a named missing file and fails the required check.

`tests/test_ci_sharding.bats` pins the same property at several shard counts,
plus determinism, argument validation, and that the workflow's matrix length
and `SHARD_TOTAL` agree. It caught a real bug while being written: the script
ended in `[ test ] && printf`, so its exit status depended on whether the last
file processed happened to belong to the requested shard.

## The required check changes name

**This needs a branch protection update before it can merge**, and the order
matters:

1. Add `bats` to the required checks on `main`.
2. Remove `bats (ubuntu-latest)` and `bats (macos-latest)`.

Until step 2, this PR reports a `bats` check that protection does not know
about, while waiting on two contexts that no longer run.

The reason the summary job is the required one rather than the shards: shard
names carry their index, so making them required would mean re-pointing
protection every time the shard count changed, and enforcing stale names until
someone did. The summary job's name is stable, and it fails unless the whole
matrix succeeded -- including when the matrix was skipped, since a suite that
did not run is not a suite that passed.

## What is unchanged

- The docs-only fast path. Shards always run and always report; only the heavy
  steps are gated, so the required context is never left pending.
- Fail-open behaviour. The matrix is a literal list, not something the
  `changes` job emits, because a dynamic matrix cannot be evaluated when the
  job feeding it failed -- that would turn a broken `changes` into a dead
  suite instead of falling back to running everything.
- The Windows leg, `app typecheck`, and `app test (windows-latest)`.

## Measured, not estimated

macOS, this machine:

| | |
|---|---|
| whole suite | 860s |
| count-balanced quarters | 125s / 298s / 366s / 71s |
| critical path | 366s (~2.4x, not 4x) |
| floor | 199s -- `test_spawn.bats` alone; no split beats it |

Per-test cost ranges from ~0s to ~8s, so test count is a loose proxy for
runtime. A table of measured per-file seconds would buy roughly 150s more, and
is deliberately not included here: it goes stale the moment the suite's fixed
`sleep`s become condition polling, which is the next CI change queued. Worth
revisiting once runtimes stop moving.

Out of scope by decision: changed-tests-only, and `bats --jobs`.