### PR TITLE
perf(sync): seal a bulk push page in parallel

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -397,7 +397,7 @@ storage_sync_prepare_push() {
   _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || return 13
   db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"
 
-  local rows unsealed joined meta requests uuids
+  local rows uuids
   local pos local_id wire idx status blob q cipher_lit chunk_sql="" chunk_count=0
   local cipher_helper node_bin pending=0 prepared=0 sealed=0
   local -a seal_pos seal_local seal_wire
@@ -427,45 +427,31 @@ storage_sync_prepare_push() {
 
   # A reservation an earlier call already produced is immutable: the final
   # SELECT republishes it verbatim and it is never re-sealed.
+  #
+  # `rows` already holds the whole page, as it did before this was batched, and
+  # a body is legal up to max_blob_bytes. So nothing below is allowed to keep a
+  # SECOND copy of it: the filtered rows, the uuid-joined rows and the seal
+  # requests are all produced as streams straight into the helper. The only
+  # thing retained per message is its position, local id and wire id — ids
+  # only, no body, a handful of bytes each.
   if [ -n "$rows" ]; then
-    unsealed=$(printf '%s\n' "$rows" | jq -c 'select(.reserved==null)') || return 13
-  fi
-  if [ -n "$unsealed" ]; then
-    pending=$(printf '%s\n' "$unsealed" | wc -l); pending=$((pending))
+    pending=$(printf '%s\n' "$rows" | jq -c 'select(.reserved==null)' | wc -l) || return 13
+    pending=$((pending))
   fi
 
   if [ "$pending" -gt 0 ]; then
     uuids=$(_sqlite_sync_uuid4_bulk "$pending") || return 13
-    joined=$(paste <(printf '%s\n' "$uuids") <(printf '%s\n' "$unsealed")) || return 13
-    # Two passes over the joined rows: the commit metadata as TSV (all fields
-    # are ids, so @tsv is lossless there), and the seal requests as JSONL. The
-    # request must NOT ride in the TSV — @tsv escapes backslashes, which would
-    # corrupt every body containing a quote.
-    meta=$(printf '%s\n' "$joined" | jq -rR '
-      split("\t") as $pair | ($pair[1] | fromjson) as $row
-      | [$row.local_position, $row.local_id, $pair[0]] | @tsv') || return 13
-    requests=$(printf '%s\n' "$joined" | jq -cR \
-      --arg cipher "$cipher" --arg key "$key_id" --arg team_id "$remote" \
-      --argjson version "$version" --argjson protocol "$protocol" \
-      --argjson max_blob "$max_blob" --argjson recipients "$recipients" '
-      split("\t") as $pair | ($pair[1] | fromjson) as $row
-      | (if ($row.body | length) == 0 then error("empty message body") else . end)
-      | (if ($row.at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
-           then ($row.at | .[0:19] + ".000000Z") else $row.at end) as $created
-      | {type:"sync_seal",envelope_v:$version,cipher:$cipher,
-         key_id:(if $key=="" then null else $key end),max_blob_bytes:$max_blob,
-         wire_id:$pair[0],team_id:$team_id,protocol_version:$protocol,
-         recipients:$recipients,
-         projection:{body:$row.body,created_at:$created,
-                     from_agent:$row.from_agent,to_agent:$row.to_agent}}') || return 13
-
+    # @tsv is lossless for ids. The seal request must NOT ride in a TSV —
+    # @tsv escapes backslashes, which would corrupt every body containing a
+    # quote — so it is built separately, as JSONL.
     while IFS=$'\t' read -r pos local_id wire; do
       [ -n "$pos" ] || continue
       seal_pos[$prepared]="$pos"; seal_local[$prepared]="$local_id"
       seal_wire[$prepared]="$wire"; prepared=$((prepared + 1))
-    done <<EOF
-$meta
-EOF
+    done < <(paste <(printf '%s\n' "$uuids") \
+                   <(printf '%s\n' "$rows" | jq -c 'select(.reserved==null)') \
+             | jq -rR 'split("\t") as $pair | ($pair[1] | fromjson) as $row
+                       | [$row.local_position, $row.local_id, $pair[0]] | @tsv')
     [ "$prepared" -eq "$pending" ] || return 13
     if [ -n "$key_id" ]; then q="'$(_sqlite_lit "$key_id")'"; else q="NULL"; fi
     cipher_lit="$(_sqlite_lit "$cipher")"
@@ -514,7 +500,23 @@ EOF
         _sqlite_sync_commit_chunk "$db" "$chunk_sql" || return 13
         sealed=$((sealed + chunk_count)); chunk_sql=""; chunk_count=0
       fi
-    done < <(printf '%s\n' "$requests" | "$node_bin" "$cipher_helper" seal-batch \
+    done < <(paste <(printf '%s\n' "$uuids") \
+                   <(printf '%s\n' "$rows" | jq -c 'select(.reserved==null)') \
+      | jq -cR \
+        --arg cipher "$cipher" --arg key "$key_id" --arg team_id "$remote" \
+        --argjson version "$version" --argjson protocol "$protocol" \
+        --argjson max_blob "$max_blob" --argjson recipients "$recipients" '
+        split("\t") as $pair | ($pair[1] | fromjson) as $row
+        | (if ($row.body | length) == 0 then error("empty message body") else . end)
+        | (if ($row.at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
+             then ($row.at | .[0:19] + ".000000Z") else $row.at end) as $created
+        | {type:"sync_seal",envelope_v:$version,cipher:$cipher,
+           key_id:(if $key=="" then null else $key end),max_blob_bytes:$max_blob,
+           wire_id:$pair[0],team_id:$team_id,protocol_version:$protocol,
+           recipients:$recipients,
+           projection:{body:$row.body,created_at:$created,
+                       from_agent:$row.from_agent,to_agent:$row.to_agent}}' \
+      | "$node_bin" "$cipher_helper" seal-batch "$pending" \
       | jq -r --unbuffered --arg cipher "$cipher" --argjson key "$key_json" '
           select(.type=="sync_seal_result")
           | [(.index|tostring),

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -15,17 +15,18 @@ _sqlite_sync_uuid4() {
 # Reservations are committed in groups rather than one transaction per message:
 # a sqlite3 fork costs far more than the seal it records. The bounds are what
 # an interrupted backfill re-does — at most this many messages, or this much
-# accumulated SQL, are re-sealed by the next prepare. The byte bound also keeps
-# the statement inside ARG_MAX when bodies approach max_blob_bytes.
+# accumulated SQL, are re-sealed by the next prepare.
 _SQLITE_SYNC_COMMIT_CHUNK=50
 _SQLITE_SYNC_COMMIT_BYTES=131072
 
+# The statement goes in on stdin, not in argv. A single encrypted blob is legal
+# up to max_blob_bytes, which is already larger than ARG_MAX once base64 and SQL
+# quoting are applied — so an argv statement could not hold even one such row,
+# and no group bound would have saved it.
 _sqlite_sync_commit_chunk() {
   local db="$1" sql="$2"
   [ -n "$sql" ] || return 0
-  agmsg_sqlite "$db" "BEGIN IMMEDIATE;
-$sql
-COMMIT;" >/dev/null 2>&1
+  printf 'BEGIN IMMEDIATE;\n%s\nCOMMIT;\n' "$sql" | agmsg_sqlite "$db" >/dev/null 2>&1
 }
 
 # Builtin single-quote escaping, assigned into _SQLITE_SYNC_LIT in the CALLER's

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -12,6 +12,47 @@ _sqlite_sync_uuid4() {
     "${h:0:8}" "${h:8:4}" "${h:13:3}" "$variant" "${h:17:3}" "${h:20:12}"
 }
 
+# Reservations are committed in groups rather than one transaction per message:
+# a sqlite3 fork costs far more than the seal it records. The bounds are what
+# an interrupted backfill re-does — at most this many messages, or this much
+# accumulated SQL, are re-sealed by the next prepare. The byte bound also keeps
+# the statement inside ARG_MAX when bodies approach max_blob_bytes.
+_SQLITE_SYNC_COMMIT_CHUNK=50
+_SQLITE_SYNC_COMMIT_BYTES=131072
+
+_sqlite_sync_commit_chunk() {
+  local db="$1" sql="$2"
+  [ -n "$sql" ] || return 0
+  agmsg_sqlite "$db" "BEGIN IMMEDIATE;
+$sql
+COMMIT;" >/dev/null 2>&1
+}
+
+# Builtin single-quote escaping, assigned into _SQLITE_SYNC_LIT in the CALLER's
+# shell. _sqlite_lit forks printf|sed per call, which the bulk loop calls three
+# times per message; a `$( )` wrapper here would fork just as surely.
+_sqlite_sync_lit_into() { _SQLITE_SYNC_LIT="${1//\'/\'\'}"; }
+
+# Bulk form of _sqlite_sync_uuid4: one /dev/urandom read and builtin-only
+# formatting for `count` ids. A 1000-message catch-up page costs one fork here
+# instead of one per message.
+_sqlite_sync_uuid4_bulk() {
+  local count="$1" hex out="" i off n
+  local digits=0123456789abcdef
+  case "$count" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$count" -ge 1 ] || return 0
+  hex=$(od -An -N$((count * 16)) -tx1 /dev/urandom | tr -d ' \n') || return 1
+  [ "${#hex}" -eq $((count * 32)) ] || return 1
+  for ((i = 0; i < count; i++)); do
+    off=$((i * 32))
+    n=$((16#${hex:$((off + 16)):1}))
+    out="${out}${hex:$off:8}-${hex:$((off + 8)):4}-4${hex:$((off + 13)):3}"
+    out="${out}-${digits:$(((n & 3) | 8)):1}${hex:$((off + 17)):3}-${hex:$((off + 20)):12}
+"
+  done
+  printf '%s' "$out"
+}
+
 _sqlite_sync_valid_binding() {
   printf '%s\n' "$1" | grep -Eq \
     '^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' || return 1
@@ -356,15 +397,19 @@ storage_sync_prepare_push() {
   _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || return 13
   db="$(_sqlite_db)"; tl="$(_sqlite_lit "$team")"
 
-  local rows line pos local_id body at created envelope blob wire
-  local cipher_helper node_bin seal_request q
+  local rows unsealed joined meta requests uuids
+  local pos local_id wire idx status blob q cipher_lit chunk_sql="" chunk_count=0
+  local cipher_helper node_bin pending=0 prepared=0 sealed=0
+  local -a seal_pos seal_local seal_wire
   cipher_helper="${AGMSG_SYNC_CIPHER_HELPER:-$SKILL_DIR/scripts/internal/sync-cipher.mjs}"
   node_bin="${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
   [ -f "$cipher_helper" ] || return 13
+  # 'reserved' carries the LEFT JOIN's existing wire_id so the immutability
+  # check below is a filter on rows already in hand, not a lookup per message.
   rows=$(_sqlite_data "
     SELECT json_object('local_position',CAST(e.seq AS TEXT),'local_id',e.id,
                        'body',e.body,'at',e.at,'from_agent',e.from_agent,
-                       'to_agent',e.to_agent)
+                       'to_agent',e.to_agent,'reserved',m.wire_id)
       FROM events e
       JOIN sync_bindings b ON b.local_team='$tl'
        AND b.server_instance_id='$server' AND b.remote_team_id='$remote'
@@ -380,69 +425,115 @@ storage_sync_prepare_push() {
      ORDER BY e.seq LIMIT $limit;
   ") || return 13
 
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    pos=$(printf '%s\n' "$line" | jq -r '.local_position')
-    local_id=$(printf '%s\n' "$line" | jq -r '.local_id')
-    # A reservation already produced by an earlier call is immutable.
-    if [ -n "$(agmsg_sqlite "$db" "SELECT wire_id FROM sync_messages WHERE
-        local_team='$tl' AND server_instance_id='$server' AND remote_team_id='$remote'
-        AND protocol_version=$protocol AND driver_generation='$generation'
-        AND local_position=$pos;" 2>/dev/null)" ]; then
-      continue
-    fi
-    body=$(printf '%s\n' "$line" | jq -r '.body')
-    [ -n "$body" ] || return 13
-    at=$(printf '%s\n' "$line" | jq -r '.at')
-    case "$at" in ????-??-??T??:??:??Z) created="${at%Z}.000000Z" ;; *) created="$at" ;; esac
-    wire=$(_sqlite_sync_uuid4) || return 13
-    seal_request=$(printf '%s\n' "$line" | jq -c \
-      --arg type sync_seal --arg cipher "$cipher" --arg key "$key_id" \
-      --arg wire "$wire" --arg team_id "$remote" --arg created "$created" \
+  # A reservation an earlier call already produced is immutable: the final
+  # SELECT republishes it verbatim and it is never re-sealed.
+  if [ -n "$rows" ]; then
+    unsealed=$(printf '%s\n' "$rows" | jq -c 'select(.reserved==null)') || return 13
+  fi
+  if [ -n "$unsealed" ]; then
+    pending=$(printf '%s\n' "$unsealed" | wc -l); pending=$((pending))
+  fi
+
+  if [ "$pending" -gt 0 ]; then
+    uuids=$(_sqlite_sync_uuid4_bulk "$pending") || return 13
+    joined=$(paste <(printf '%s\n' "$uuids") <(printf '%s\n' "$unsealed")) || return 13
+    # Two passes over the joined rows: the commit metadata as TSV (all fields
+    # are ids, so @tsv is lossless there), and the seal requests as JSONL. The
+    # request must NOT ride in the TSV — @tsv escapes backslashes, which would
+    # corrupt every body containing a quote.
+    meta=$(printf '%s\n' "$joined" | jq -rR '
+      split("\t") as $pair | ($pair[1] | fromjson) as $row
+      | [$row.local_position, $row.local_id, $pair[0]] | @tsv') || return 13
+    requests=$(printf '%s\n' "$joined" | jq -cR \
+      --arg cipher "$cipher" --arg key "$key_id" --arg team_id "$remote" \
       --argjson version "$version" --argjson protocol "$protocol" \
-      --argjson max_blob "$max_blob" --argjson recipients "$recipients" \
-      '{type:$type,envelope_v:$version,cipher:$cipher,
-        key_id:(if $key=="" then null else $key end),max_blob_bytes:$max_blob,
-        wire_id:$wire,team_id:$team_id,protocol_version:$protocol,recipients:$recipients,
-        projection:{body:.body,created_at:$created,from_agent:.from_agent,to_agent:.to_agent}}') || return 13
-    envelope=$(printf '%s\n' "$seal_request" | "$node_bin" "$cipher_helper" seal) || return 13
-    if ! printf '%s\n' "$envelope" | jq -e --arg cipher "$cipher" --argjson key "$key_json" \
-      '.v==1 and .cipher==$cipher and .key_id==$key and (.blob|type)=="string" and (.blob|length)>0' \
-      >/dev/null 2>&1; then
-      printf 'agmsg: cipher helper returned an invalid envelope (%s)\n' \
-        "$(printf '%s\n' "$envelope" | jq -c '{v,cipher,key_id,blob_type:(.blob|type),blob_length:(.blob|length)}' 2>/dev/null || echo unparseable)" >&2
-      return 13
-    fi
-    blob=$(printf '%s\n' "$envelope" | jq -r '.blob // empty')
-    if [ "${AGMSG_SYNC_TEST_ABORT_AFTER_SEAL:-}" = 1 ]; then
-      return 75
-    fi
-    if [ -n "$key_id" ]; then q="'$(_sqlite_lit "$key_id")'"; else q="NULL"; fi
-    # INSERT OR IGNORE makes concurrent prepare calls converge on one winner;
-    # the final SELECT below always emits the committed winner's bytes.
-    agmsg_sqlite "$db" "BEGIN IMMEDIATE;
-      INSERT OR IGNORE INTO sync_messages
-        (local_team,server_instance_id,remote_team_id,protocol_version,
-         driver_generation,local_position,local_id,wire_id,envelope_v,cipher,
-         key_id,blob,direction)
-      VALUES('$tl','$server','$remote',$protocol,'$generation',$pos,
-             '$(_sqlite_lit "$local_id")','$wire',1,'$(_sqlite_lit "$cipher")',$q,
-             '$(_sqlite_lit "$blob")','push');
-      INSERT OR IGNORE INTO sync_read_aliases
-        (local_team,server_instance_id,remote_team_id,protocol_version,
-         driver_generation,agent,local_id,wire_id,server_seq)
-      SELECT m.local_team,m.server_instance_id,m.remote_team_id,m.protocol_version,
-             m.driver_generation,e.to_agent,m.local_id,m.wire_id,m.server_seq
-        FROM sync_messages m JOIN events e ON e.seq=m.local_position
-       WHERE m.local_team='$tl' AND m.server_instance_id='$server'
-         AND m.remote_team_id='$remote' AND m.protocol_version=$protocol
-         AND m.driver_generation='$generation' AND m.local_position=$pos
-         AND EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'
-           AND r.team=e.team AND r.agent=e.to_agent AND r.msg_id=e.id);
-      COMMIT;" >/dev/null 2>&1 || return 13
-  done <<EOF
-$rows
+      --argjson max_blob "$max_blob" --argjson recipients "$recipients" '
+      split("\t") as $pair | ($pair[1] | fromjson) as $row
+      | (if ($row.body | length) == 0 then error("empty message body") else . end)
+      | (if ($row.at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
+           then ($row.at | .[0:19] + ".000000Z") else $row.at end) as $created
+      | {type:"sync_seal",envelope_v:$version,cipher:$cipher,
+         key_id:(if $key=="" then null else $key end),max_blob_bytes:$max_blob,
+         wire_id:$pair[0],team_id:$team_id,protocol_version:$protocol,
+         recipients:$recipients,
+         projection:{body:$row.body,created_at:$created,
+                     from_agent:$row.from_agent,to_agent:$row.to_agent}}') || return 13
+
+    while IFS=$'\t' read -r pos local_id wire; do
+      [ -n "$pos" ] || continue
+      seal_pos[$prepared]="$pos"; seal_local[$prepared]="$local_id"
+      seal_wire[$prepared]="$wire"; prepared=$((prepared + 1))
+    done <<EOF
+$meta
 EOF
+    [ "$prepared" -eq "$pending" ] || return 13
+    if [ -n "$key_id" ]; then q="'$(_sqlite_lit "$key_id")'"; else q="NULL"; fi
+    cipher_lit="$(_sqlite_lit "$cipher")"
+
+    # The whole page is sealed by one helper invocation, which fans the work out
+    # over worker threads when the page is large enough to be worth it. Results
+    # arrive in COMPLETION order (each carries its request index) and are
+    # committed in groups as they land, so an interrupted run keeps every group
+    # it had already committed and the next prepare re-seals only what is left.
+    while IFS=$'\t' read -r idx status blob; do
+      case "$idx" in ''|*[!0-9]*) continue ;; esac
+      [ "$idx" -lt "$prepared" ] || continue
+      if [ "$status" != ok ] || [ -z "$blob" ]; then
+        printf 'agmsg: cipher helper did not seal message %s (%s)\n' "$idx" "$status" >&2
+        continue
+      fi
+      if [ "${AGMSG_SYNC_TEST_ABORT_AFTER_SEAL:-}" = 1 ]; then
+        return 75
+      fi
+      pos="${seal_pos[$idx]}"; wire="${seal_wire[$idx]}"
+      _sqlite_sync_lit_into "${seal_local[$idx]}"; local_id="$_SQLITE_SYNC_LIT"
+      _sqlite_sync_lit_into "$blob"; blob="$_SQLITE_SYNC_LIT"
+      # INSERT OR IGNORE makes concurrent prepare calls converge on one winner;
+      # the final SELECT below always emits the committed winner's bytes.
+      chunk_sql="$chunk_sql
+        INSERT OR IGNORE INTO sync_messages
+          (local_team,server_instance_id,remote_team_id,protocol_version,
+           driver_generation,local_position,local_id,wire_id,envelope_v,cipher,
+           key_id,blob,direction)
+        VALUES('$tl','$server','$remote',$protocol,'$generation',$pos,
+               '$local_id','$wire',1,'$cipher_lit',$q,'$blob','push');
+        INSERT OR IGNORE INTO sync_read_aliases
+          (local_team,server_instance_id,remote_team_id,protocol_version,
+           driver_generation,agent,local_id,wire_id,server_seq)
+        SELECT m.local_team,m.server_instance_id,m.remote_team_id,m.protocol_version,
+               m.driver_generation,e.to_agent,m.local_id,m.wire_id,m.server_seq
+          FROM sync_messages m JOIN events e ON e.seq=m.local_position
+         WHERE m.local_team='$tl' AND m.server_instance_id='$server'
+           AND m.remote_team_id='$remote' AND m.protocol_version=$protocol
+           AND m.driver_generation='$generation' AND m.local_position=$pos
+           AND EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'
+             AND r.team=e.team AND r.agent=e.to_agent AND r.msg_id=e.id);"
+      chunk_count=$((chunk_count + 1))
+      if [ "$chunk_count" -ge "$_SQLITE_SYNC_COMMIT_CHUNK" ] ||
+         [ "${#chunk_sql}" -ge "$_SQLITE_SYNC_COMMIT_BYTES" ]; then
+        _sqlite_sync_commit_chunk "$db" "$chunk_sql" || return 13
+        sealed=$((sealed + chunk_count)); chunk_sql=""; chunk_count=0
+      fi
+    done < <(printf '%s\n' "$requests" | "$node_bin" "$cipher_helper" seal-batch \
+      | jq -r --unbuffered --arg cipher "$cipher" --argjson key "$key_json" '
+          select(.type=="sync_seal_result")
+          | [(.index|tostring),
+             (if .status=="ok" and .envelope.v==1 and .envelope.cipher==$cipher
+                 and .envelope.key_id==$key and (.envelope.blob|type)=="string"
+                 and (.envelope.blob|length)>0
+               then "ok" else (.state // .status // "invalid") end),
+             (.envelope.blob // "")] | @tsv')
+    # The loop body runs in THIS shell (process substitution, not a pipeline),
+    # so the trailing partial chunk is still here to commit.
+    if [ "$chunk_count" -gt 0 ]; then
+      _sqlite_sync_commit_chunk "$db" "$chunk_sql" || return 13
+      sealed=$((sealed + chunk_count))
+    fi
+    # A message the helper could not seal stays unsealed and is retried by the
+    # next prepare; failing here keeps that identical to the pre-batch driver,
+    # which also aborted the call while keeping what it had committed.
+    [ "$sealed" -eq "$pending" ] || return 13
+  fi
 
   _sqlite_data "SELECT json_object('type','sync_state','driver_generation',
       '$generation','transport_cursor',transport_cursor)

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -626,7 +626,14 @@ export async function driver(operation, config, input, extra = []) {
     let stdout = ""; let stderr = "";
     child.stdout.setEncoding("utf8"); child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+      // Forwarded as it arrives, not just quoted back in the failure message: a
+      // bulk seal reports its progress here, and a backfill that only printed
+      // how it went once it had finished would not be progress at all. stdout
+      // is the JSONL event stream, so this is the only channel for it.
+      process.stderr.write(chunk);
+    });
     child.on("error", reject);
     child.on("close", (code) => {
       if (code === 0) resolve(["resync-status", "resync"].includes(operation) ?

--- a/scripts/internal/sync-cipher.mjs
+++ b/scripts/internal/sync-cipher.mjs
@@ -703,7 +703,10 @@ export async function* sealBatchWindows(lines, limits = {}) {
   for await (const line of lines) {
     if (!line) continue;
     window.push(JSON.parse(line));
-    bytes += line.length;
+    // Bytes, not code units: a body of non-ASCII text is up to three times its
+    // string length, so counting units would let the window grow past the bound
+    // by that factor on exactly the input the bound exists for.
+    bytes += Buffer.byteLength(line, "utf8");
     if (window.length >= maxRequests || bytes >= maxBytes) {
       yield window;
       window = [];

--- a/scripts/internal/sync-cipher.mjs
+++ b/scripts/internal/sync-cipher.mjs
@@ -3,9 +3,14 @@
 import { createPrivateKey, createPublicKey, timingSafeEqual } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { tmpdir } from "node:os";
+// Namespace import, not `{ tmpdir, availableParallelism }`: availableParallelism
+// only exists from Node 18.14, and a missing NAMED export is a link error that
+// would break every seal, not just the batch path. Looked up defensively below.
+import * as nodeOs from "node:os";
 import { join } from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { Worker, isMainThread, parentPort, threadId, workerData } from "node:worker_threads";
 
 const UUID_V7 = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
@@ -355,7 +360,7 @@ function runAge(args, input) {
 }
 
 function runAgeWithIdentity(ageFile, identityBytes) {
-  const scratch = mkdtempSync(join(tmpdir(), "agmsg-age-open."));
+  const scratch = mkdtempSync(join(nodeOs.tmpdir(), "agmsg-age-open."));
   const ciphertextPath = join(scratch, "message.age");
   try {
     writeFileSync(ciphertextPath, ageFile, { mode: 0o600, flag: "wx" });
@@ -426,6 +431,171 @@ export function sealEnvelope(input) {
   return profile.seal(input, message);
 }
 
+// --- bulk sealing -----------------------------------------------------------
+//
+// A first connect / reconnect / retention backfill seals a whole page at once,
+// and sealing is dominated by the per-message `age` fork. Bulk callers hand the
+// entire page to `seal-batch`, which fans the SAME sealEnvelope out over worker
+// threads. Threads, not a second implementation: each worker imports this file
+// and calls sealEnvelope, so there is exactly one crypto path and the bytes a
+// batch produces are the bytes `seal` produces.
+//
+// Steady-state sends never take the parallel path: sealBatchParallelism returns
+// 1 below MIN_REQUESTS_PER_WORKER, and 1 means "seal on this thread", which is
+// the pre-existing sequential code down to the call.
+const MAX_BATCH_REQUESTS = 10_000;
+const MIN_REQUESTS_PER_WORKER = 8;
+// A task is re-dispatched once after the worker holding it dies. Bounded so a
+// request that kills workers (rather than throwing) cannot take the whole pool
+// down one thread at a time — after the last attempt it becomes an error result
+// and the batch keeps going.
+const MAX_ATTEMPTS = 2;
+const PROGRESS_MIN_TOTAL = 50;
+const PROGRESS_STEPS = 20;
+
+function hostParallelism() {
+  // uv_available_parallelism honours the affinity mask; cpus() is the fallback
+  // for Node < 18.14 and reports every core the host has.
+  const reported = typeof nodeOs.availableParallelism === "function" ?
+    nodeOs.availableParallelism() : nodeOs.cpus().length;
+  return Number.isInteger(reported) && reported > 0 ? reported : 1;
+}
+
+// Workers to use for `count` requests. One worker per MIN_REQUESTS_PER_WORKER
+// requests, capped at the core count — a short page is not worth a thread, and
+// past the cap the age forks only contend.
+export function sealBatchParallelism(count, cores = hostParallelism()) {
+  if (!Number.isInteger(count) || count < 1) return 1;
+  return Math.max(1, Math.min(cores, Math.floor(count / MIN_REQUESTS_PER_WORKER)));
+}
+
+// `worker` is the thread that sealed the request — 0 on the main thread, the
+// worker's threadId otherwise. It is how a caller can tell a batch that really
+// fanned out from one that quietly ran everything on one thread, and it names
+// the thread to look at when one worker's results go wrong.
+function sealOne(index, request) {
+  try {
+    return { index, worker: threadId, status: "ok", envelope: sealEnvelope(request) };
+  } catch (error) {
+    return { index, worker: threadId, status: "error", state: error?.state ?? null,
+      message: String(error?.message ?? error) };
+  }
+}
+
+const SEAL_WORKER_ROLE = "agmsg-seal-worker";
+
+function spawnSealWorker() {
+  return new Worker(fileURLToPath(import.meta.url), { workerData: { role: SEAL_WORKER_ROLE } });
+}
+
+// One task in flight per worker. A worker that dies rejects the task it held so
+// the scheduler can re-dispatch it; every later seal() on that client rejects
+// immediately, which drops the client out of the pool without losing work.
+function sealWorkerClient(spawn) {
+  const worker = spawn();
+  let pending = null;
+  let dead = null;
+  const die = (error) => {
+    dead = dead ?? (error ?? new Error("seal worker exited"));
+    const settled = pending;
+    pending = null;
+    settled?.reject(dead);
+  };
+  worker.on("message", (result) => {
+    const settled = pending;
+    pending = null;
+    settled?.resolve(result);
+  });
+  worker.on("error", die);
+  worker.on("exit", () => die(new Error("seal worker exited")));
+  return {
+    seal(index, request) {
+      if (dead) return Promise.reject(dead);
+      return new Promise((resolve, reject) => {
+        pending = { resolve, reject };
+        worker.postMessage({ index, request });
+      });
+    },
+    stop() { worker.terminate(); },
+  };
+}
+
+// Seal `requests` and hand every result to onResult as it completes — in
+// COMPLETION order, each tagged with its input index, so a caller can commit
+// incrementally and keep whatever it committed if the run is interrupted.
+//
+// Contract: exactly one result per request, always, with status "ok" or
+// "error". Requests whose worker died are re-dispatched, and if the whole pool
+// dies the remainder is sealed on this thread. A batch never silently drops a
+// message; an "error" result simply leaves that message unsealed for the next
+// cycle to retry.
+export async function runSealBatch(requests, options = {}) {
+  const total = requests.length;
+  const onResult = options.onResult ?? (() => {});
+  const onProgress = options.onProgress ?? (() => {});
+  let completed = 0;
+  const emit = (result) => {
+    completed += 1;
+    onResult(result);
+    onProgress(completed, total);
+  };
+
+  const parallelism = options.parallelism ?? sealBatchParallelism(total);
+  if (total === 0) return;
+  if (parallelism <= 1) {
+    for (let index = 0; index < total; index += 1) emit(sealOne(index, requests[index]));
+    return;
+  }
+
+  const attempts = new Array(total).fill(0);
+  const requeued = [];
+  let next = 0;
+  const take = () => {
+    if (requeued.length > 0) return requeued.shift();
+    return next < total ? next++ : -1;
+  };
+
+  const spawn = options.spawnWorker ?? spawnSealWorker;
+  const clients = [];
+  for (let worker = 0; worker < parallelism; worker += 1) clients.push(sealWorkerClient(spawn));
+
+  const drive = async (client) => {
+    for (let index = take(); index !== -1; index = take()) {
+      attempts[index] += 1;
+      let result;
+      try {
+        result = await client.seal(index, requests[index]);
+      } catch (error) {
+        // This client is gone. Put the task back for a surviving client (or the
+        // main-thread sweep below) and retire the client.
+        if (attempts[index] < MAX_ATTEMPTS) requeued.unshift(index);
+        else emit({ index, worker: null, status: "error", state: "worker_failed",
+          message: `seal worker died: ${String(error?.message ?? error)}` });
+        return;
+      }
+      emit(result);
+    }
+  };
+
+  try {
+    await Promise.all(clients.map((client) => drive(client)));
+  } finally {
+    // Unconditional: a throw out of onResult must not leave live threads
+    // holding the process open.
+    for (const client of clients) client.stop();
+  }
+  // Re-dispatched work can outlive the pool — a client that had already drained
+  // the queue exits before another one dies and requeues. Whatever is left has
+  // no worker to run on, so it runs here rather than going missing.
+  for (let index = take(); index !== -1; index = take()) emit(sealOne(index, requests[index]));
+}
+
+function sealWorkerMain() {
+  parentPort.on("message", ({ index, request }) => {
+    parentPort.postMessage(sealOne(index, request));
+  });
+}
+
 function openNone(envelope, maxBlobBytes) {
   if (envelope.v !== 1 || envelope.key_id !== null) malformed("none envelope metadata is invalid");
   return parseCanonicalMessage(canonicalBlob(envelope.blob, maxBlobBytes));
@@ -483,15 +653,48 @@ export async function openEnvelope(input) {
   return profile.open(input);
 }
 
-async function cli() {
-  if (process.argv[2] !== "seal") throw new Error("usage: sync-cipher.mjs seal");
+async function readStdin() {
   let input = "";
   for await (const chunk of process.stdin) input += chunk;
-  const value = JSON.parse(input);
-  process.stdout.write(`${JSON.stringify(sealEnvelope(value))}\n`);
+  return input;
 }
 
-if (process.argv[2] === "seal") {
+// Human-facing progress for the bulk path only. A steady-state page is a
+// handful of messages and reporting on it would be noise, so anything under
+// PROGRESS_MIN_TOTAL stays silent. stdout carries the results, so this goes to
+// stderr.
+function progressReporter(total) {
+  if (total < PROGRESS_MIN_TOTAL) return () => {};
+  const step = Math.max(1, Math.floor(total / PROGRESS_STEPS));
+  return (completed) => {
+    if (completed % step !== 0 && completed !== total) return;
+    const percent = Math.floor((completed / total) * 100);
+    process.stderr.write(`agmsg: sealing ${completed}/${total} (${percent}%)\n`);
+  };
+}
+
+async function cli() {
+  if (process.argv[2] === "seal") {
+    process.stdout.write(`${JSON.stringify(sealEnvelope(JSON.parse(await readStdin())))}\n`);
+    return;
+  }
+  if (process.argv[2] !== "seal-batch") throw new Error("usage: sync-cipher.mjs seal|seal-batch");
+  const requests = (await readStdin()).split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+  if (requests.length > MAX_BATCH_REQUESTS) {
+    throw new Error(`seal-batch accepts at most ${MAX_BATCH_REQUESTS} requests`);
+  }
+  // Per-request failures are results, not an exit code: the caller commits the
+  // envelopes that succeeded and retries the rest on its next cycle.
+  await runSealBatch(requests, {
+    onResult: (result) => process.stdout.write(
+      `${JSON.stringify({ type: "sync_seal_result", ...result })}\n`),
+    onProgress: progressReporter(requests.length),
+  });
+}
+
+if (!isMainThread && workerData?.role === SEAL_WORKER_ROLE) {
+  sealWorkerMain();
+} else if (isMainThread && ["seal", "seal-batch"].includes(process.argv[2])) {
   cli().catch((error) => {
     process.stderr.write(`${error.state ? `${error.state}: ` : ""}${error.message}\n`);
     process.exitCode = 1;

--- a/scripts/internal/sync-cipher.mjs
+++ b/scripts/internal/sync-cipher.mjs
@@ -9,6 +9,7 @@ import { spawnSync } from "node:child_process";
 import * as nodeOs from "node:os";
 import { join } from "node:path";
 import process from "node:process";
+import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { Worker, isMainThread, parentPort, threadId, workerData } from "node:worker_threads";
 
@@ -445,6 +446,12 @@ export function sealEnvelope(input) {
 // the pre-existing sequential code down to the call.
 const MAX_BATCH_REQUESTS = 10_000;
 const MIN_REQUESTS_PER_WORKER = 8;
+// How much of a streamed batch the helper holds at once. The count keeps a
+// typical page (small bodies) in one window so the pool never drains mid-page;
+// the byte bound takes over when bodies are large, which is exactly when
+// holding the page would cost the most.
+const WINDOW_REQUESTS = 1_000;
+const WINDOW_BYTES = 8 * 1_048_576;
 // A task is re-dispatched once after the worker holding it dies. Bounded so a
 // request that kills workers (rather than throwing) cannot take the whole pool
 // down one thread at a time — after the last attempt it becomes an error result
@@ -668,15 +675,42 @@ async function readStdin() {
 // Human-facing progress for the bulk path only. A steady-state page is a
 // handful of messages and reporting on it would be noise, so anything under
 // PROGRESS_MIN_TOTAL stays silent. stdout carries the results, so this goes to
-// stderr.
+// stderr. `total` is what the caller said it would send — the batch is read as
+// a stream, so the helper itself never knows the count up front.
 function progressReporter(total) {
-  if (total < PROGRESS_MIN_TOTAL) return () => {};
+  if (!Number.isInteger(total) || total < PROGRESS_MIN_TOTAL) return () => {};
   const step = Math.max(1, Math.floor(total / PROGRESS_STEPS));
-  return (completed) => {
-    if (completed % step !== 0 && completed !== total) return;
-    const percent = Math.floor((completed / total) * 100);
-    process.stderr.write(`agmsg: sealing ${completed}/${total} (${percent}%)\n`);
+  let done = 0;
+  return () => {
+    done += 1;
+    if (done % step !== 0 && done !== total) return;
+    const percent = Math.min(100, Math.floor((done / total) * 100));
+    process.stderr.write(`agmsg: sealing ${done}/${total} (${percent}%)\n`);
   };
+}
+
+// Requests are read as a stream and sealed a window at a time. A page is only
+// bounded by its message count, and a message body is legal up to
+// max_blob_bytes, so holding the whole batch would mean holding a gigabyte for
+// input a caller is entitled to send. The scheduler has to keep a request until
+// its result is out — it re-dispatches the ones a dying worker was holding — so
+// what is bounded here is how much it is ever asked to keep at once.
+export async function* sealBatchWindows(lines, limits = {}) {
+  const maxRequests = limits.requests ?? WINDOW_REQUESTS;
+  const maxBytes = limits.bytes ?? WINDOW_BYTES;
+  let window = [];
+  let bytes = 0;
+  for await (const line of lines) {
+    if (!line) continue;
+    window.push(JSON.parse(line));
+    bytes += line.length;
+    if (window.length >= maxRequests || bytes >= maxBytes) {
+      yield window;
+      window = [];
+      bytes = 0;
+    }
+  }
+  if (window.length > 0) yield window;
 }
 
 async function cli() {
@@ -684,18 +718,33 @@ async function cli() {
     process.stdout.write(`${JSON.stringify(sealEnvelope(JSON.parse(await readStdin())))}\n`);
     return;
   }
-  if (process.argv[2] !== "seal-batch") throw new Error("usage: sync-cipher.mjs seal|seal-batch");
-  const requests = (await readStdin()).split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
-  if (requests.length > MAX_BATCH_REQUESTS) {
+  if (process.argv[2] !== "seal-batch") {
+    throw new Error("usage: sync-cipher.mjs seal | seal-batch [expected-count]");
+  }
+  const expected = process.argv[3] === undefined ? null : Number(process.argv[3]);
+  if (expected !== null && (!Number.isInteger(expected) || expected < 0 ||
+      expected > MAX_BATCH_REQUESTS)) {
     throw new Error(`seal-batch accepts at most ${MAX_BATCH_REQUESTS} requests`);
   }
+  const onProgress = progressReporter(expected);
+  let base = 0;
   // Per-request failures are results, not an exit code: the caller commits the
   // envelopes that succeeded and retries the rest on its next cycle.
-  await runSealBatch(requests, {
-    onResult: (result) => process.stdout.write(
-      `${JSON.stringify({ type: "sync_seal_result", ...result })}\n`),
-    onProgress: progressReporter(requests.length),
-  });
+  for await (const window of sealBatchWindows(
+    createInterface({ input: process.stdin, crlfDelay: Infinity }))) {
+    if (base + window.length > MAX_BATCH_REQUESTS) {
+      throw new Error(`seal-batch accepts at most ${MAX_BATCH_REQUESTS} requests`);
+    }
+    const offset = base;
+    await runSealBatch(window, {
+      // The window is an implementation detail of how much is held at once;
+      // callers index results against what they sent.
+      onResult: (result) => process.stdout.write(`${JSON.stringify(
+        { type: "sync_seal_result", ...result, index: offset + result.index })}\n`),
+      onProgress,
+    });
+    base += window.length;
+  }
 }
 
 if (!isMainThread && workerData?.role === SEAL_WORKER_ROLE) {

--- a/scripts/internal/sync-cipher.mjs
+++ b/scripts/internal/sync-cipher.mjs
@@ -557,7 +557,6 @@ export async function runSealBatch(requests, options = {}) {
 
   const spawn = options.spawnWorker ?? spawnSealWorker;
   const clients = [];
-  for (let worker = 0; worker < parallelism; worker += 1) clients.push(sealWorkerClient(spawn));
 
   const drive = async (client) => {
     for (let index = take(); index !== -1; index = take()) {
@@ -578,6 +577,13 @@ export async function runSealBatch(requests, options = {}) {
   };
 
   try {
+    // Spawning belongs inside this boundary. A thread that cannot be created —
+    // the process is out of them, the system is out of memory — must leave the
+    // workers already spawned terminable and must still reach the main-thread
+    // sweep below. Whatever was created is the pool; zero is a valid pool.
+    for (let worker = 0; worker < parallelism; worker += 1) {
+      try { clients.push(sealWorkerClient(spawn)); } catch { break; }
+    }
     await Promise.all(clients.map((client) => drive(client)));
   } finally {
     // Unconditional: a throw out of onResult must not leave live threads

--- a/tests/fixtures/sync-cipher-capture.mjs
+++ b/tests/fixtures/sync-cipher-capture.mjs
@@ -1,15 +1,24 @@
 #!/usr/bin/env node
 
+// Stand-in cipher helper: records the wire id of every seal request the driver
+// makes — including the ones a crash keeps out of the store — then delegates to
+// the real helper. Mirrors the real helper's modes, so `seal` takes one request
+// object and `seal-batch` takes one request per line.
+
 import { appendFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 
+const mode = process.argv[2] ?? "seal";
 let input = "";
 for await (const chunk of process.stdin) input += chunk;
-const request = JSON.parse(input);
-appendFileSync(process.env.AGMSG_SYNC_TEST_WIRE_LOG, `${request.wire_id}\n`, { mode: 0o600 });
+const requests = mode === "seal-batch" ?
+  input.split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line)) : [JSON.parse(input)];
+for (const request of requests) {
+  appendFileSync(process.env.AGMSG_SYNC_TEST_WIRE_LOG, `${request.wire_id}\n`, { mode: 0o600 });
+}
 const result = spawnSync(process.execPath,
-  [process.env.AGMSG_SYNC_REAL_CIPHER_HELPER, "seal"], { input, maxBuffer: 4 * 1024 * 1024 });
+  [process.env.AGMSG_SYNC_REAL_CIPHER_HELPER, mode], { input, maxBuffer: 64 * 1024 * 1024 });
 process.stdout.write(result.stdout);
 process.stderr.write(result.stderr);
 process.exitCode = result.status ?? 1;

--- a/tests/fixtures/sync-cipher-capture.mjs
+++ b/tests/fixtures/sync-cipher-capture.mjs
@@ -9,7 +9,8 @@ import { appendFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 
-const mode = process.argv[2] ?? "seal";
+const args = process.argv.slice(2);
+const mode = args[0] ?? "seal";
 let input = "";
 for await (const chunk of process.stdin) input += chunk;
 const requests = mode === "seal-batch" ?
@@ -18,7 +19,7 @@ for (const request of requests) {
   appendFileSync(process.env.AGMSG_SYNC_TEST_WIRE_LOG, `${request.wire_id}\n`, { mode: 0o600 });
 }
 const result = spawnSync(process.execPath,
-  [process.env.AGMSG_SYNC_REAL_CIPHER_HELPER, mode], { input, maxBuffer: 64 * 1024 * 1024 });
+  [process.env.AGMSG_SYNC_REAL_CIPHER_HELPER, ...args], { input, maxBuffer: 64 * 1024 * 1024 });
 process.stdout.write(result.stdout);
 process.stderr.write(result.stderr);
 process.exitCode = result.status ?? 1;

--- a/tests/fixtures/sync-cipher-invocation-probe.mjs
+++ b/tests/fixtures/sync-cipher-invocation-probe.mjs
@@ -9,13 +9,14 @@ import { appendFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 
-const mode = process.argv[2] ?? "seal";
+const args = process.argv.slice(2);
+const mode = args[0] ?? "seal";
 let input = "";
 for await (const chunk of process.stdin) input += chunk;
 const count = mode === "seal-batch" ? input.split(/\r?\n/u).filter(Boolean).length : 1;
 appendFileSync(process.env.AGMSG_SYNC_TEST_INVOCATION_LOG, `${mode} ${count}\n`, { mode: 0o600 });
 const result = spawnSync(process.execPath,
-  [process.env.AGMSG_SYNC_REAL_CIPHER_HELPER, mode], { input, maxBuffer: 64 * 1024 * 1024 });
+  [process.env.AGMSG_SYNC_REAL_CIPHER_HELPER, ...args], { input, maxBuffer: 64 * 1024 * 1024 });
 process.stdout.write(result.stdout);
 process.stderr.write(result.stderr);
 process.exitCode = result.status ?? 1;

--- a/tests/fixtures/sync-cipher-invocation-probe.mjs
+++ b/tests/fixtures/sync-cipher-invocation-probe.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+// Stand-in cipher helper that records how the driver called it — one log line
+// per invocation, "<mode> <request count>" — then delegates to the real helper.
+// Lets a test assert that a page was sealed by ONE batched call rather than one
+// helper process per message.
+
+import { appendFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+const mode = process.argv[2] ?? "seal";
+let input = "";
+for await (const chunk of process.stdin) input += chunk;
+const count = mode === "seal-batch" ? input.split(/\r?\n/u).filter(Boolean).length : 1;
+appendFileSync(process.env.AGMSG_SYNC_TEST_INVOCATION_LOG, `${mode} ${count}\n`, { mode: 0o600 });
+const result = spawnSync(process.execPath,
+  [process.env.AGMSG_SYNC_REAL_CIPHER_HELPER, mode], { input, maxBuffer: 64 * 1024 * 1024 });
+process.stdout.write(result.stdout);
+process.stderr.write(result.stderr);
+process.exitCode = result.status ?? 1;

--- a/tests/seal_batch.test.mjs
+++ b/tests/seal_batch.test.mjs
@@ -181,6 +181,22 @@ test("a streamed batch is cut into windows bounded by count and by bytes", async
   assert.deepEqual(byBytes, Array.from({ length: 10 }, () => 1));
 });
 
+test("the byte bound counts utf-8 bytes, not utf-16 code units", async () => {
+  const value = request(0);
+  value.projection.body = "ほ".repeat(500);
+  const line = JSON.stringify(value);
+  assert.ok(Buffer.byteLength(line, "utf8") > line.length * 2, "fixture must be multi-byte");
+
+  const windows = [];
+  for await (const window of sealBatchWindows(Array(4).fill(line),
+    { requests: 1000, bytes: line.length + 50 })) {
+    windows.push(window.length);
+  }
+  // Each line alone is past the bound in bytes. Counted as code units it would
+  // take two of them, and the window would hold twice what it was told to.
+  assert.deepEqual(windows, [1, 1, 1, 1]);
+});
+
 test("windowing does not renumber results the caller has to match up", async () => {
   // Bodies large enough that the real byte bound cuts the batch into several
   // windows; indices must still run 0..n-1 across the whole input.

--- a/tests/seal_batch.test.mjs
+++ b/tests/seal_batch.test.mjs
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { driver } from "../scripts/internal/remote-sync.mjs";
+import { runSealBatch, sealBatchParallelism,
+  sealEnvelope } from "../scripts/internal/sync-cipher.mjs";
+
+// cipher "none" is deterministic, so a batch envelope can be compared byte for
+// byte against the single-request seal the driver used before. What is under
+// test here is the scheduler and the worker fan-out, not the cipher; the age
+// profile is covered by the shared vectors and by test_sync_cipher.bats.
+function request(index) {
+  return { type: "sync_seal", envelope_v: 1, cipher: "none", key_id: null, recipients: [],
+    max_blob_bytes: 1_048_576, wire_id: randomUUID(),
+    team_id: "018f3f7e-0000-7000-8000-000000000001", protocol_version: 1,
+    projection: { body: `bulk message ${index} with a quote " and a backslash \\`,
+      created_at: "2026-07-27T00:00:00.000000Z", from_agent: "alice", to_agent: "bob" } };
+}
+
+function collect(total) {
+  const results = new Array(total).fill(null);
+  const order = [];
+  return { results, order,
+    onResult(result) {
+      assert.equal(results[result.index], null, `index ${result.index} was emitted twice`);
+      results[result.index] = result;
+      order.push(result.index);
+    } };
+}
+
+test("a batch fans out over real worker threads and seals byte-identically", async () => {
+  const requests = Array.from({ length: 64 }, (_, index) => request(index));
+  const sink = collect(requests.length);
+  await runSealBatch(requests, { onResult: sink.onResult });
+
+  assert.equal(sink.order.length, requests.length);
+  for (const [index, result] of sink.results.entries()) {
+    assert.equal(result.status, "ok");
+    assert.deepEqual(result.envelope, sealEnvelope(requests[index]));
+  }
+  // The point of the batch. If this ever runs everything on one thread the
+  // envelopes are still correct and every other assertion here still passes —
+  // so the fan-out has to be asserted directly.
+  const threads = new Set(sink.results.map((result) => result.worker));
+  assert.ok(threads.size > 1, `expected several worker threads, saw ${[...threads]}`);
+  assert.ok(!threads.has(0), "no request should have been sealed on the main thread");
+});
+
+test("a short page stays on the calling thread", async () => {
+  const requests = Array.from({ length: 4 }, (_, index) => request(index));
+  const sink = collect(requests.length);
+  await runSealBatch(requests, { onResult: sink.onResult });
+
+  assert.deepEqual(sink.order, [0, 1, 2, 3]);
+  assert.deepEqual(sink.results.map((result) => result.worker), [0, 0, 0, 0]);
+  assert.equal(sealBatchParallelism(4, 16), 1);
+});
+
+test("parallelism is one worker per eight requests, capped at the core count", () => {
+  assert.equal(sealBatchParallelism(1, 16), 1);
+  assert.equal(sealBatchParallelism(7, 16), 1);
+  assert.equal(sealBatchParallelism(8, 16), 1);
+  assert.equal(sealBatchParallelism(16, 16), 2);
+  assert.equal(sealBatchParallelism(1000, 16), 16);
+  assert.equal(sealBatchParallelism(1000, 2), 2);
+});
+
+// A worker that stops answering — OOM-killed, a native crash inside age, a
+// terminate from outside. The scheduler is driven through the injected spawn
+// seam because a thread cannot be told to die at a chosen task from outside.
+function dyingWorkerFactory({ dieAfter, only = null }) {
+  let spawned = 0;
+  return () => {
+    const id = (spawned += 1);
+    const worker = new EventEmitter();
+    let handled = 0;
+    worker.postMessage = ({ index, request: value }) => {
+      handled += 1;
+      if ((only === null || only === id) && handled > dieAfter) {
+        // Death is asynchronous, exactly as a real worker's 'exit' is: the task
+        // is already in flight and its promise is pending.
+        setImmediate(() => worker.emit("exit", 1));
+        return;
+      }
+      setImmediate(() => worker.emit("message",
+        { index, worker: 100 + id, status: "ok", envelope: sealEnvelope(value) }));
+    };
+    worker.terminate = () => {};
+    return worker;
+  };
+}
+
+test("a worker that dies mid-batch loses none of its messages", async () => {
+  const requests = Array.from({ length: 40 }, (_, index) => request(index));
+  const sink = collect(requests.length);
+  await runSealBatch(requests, { parallelism: 4, onResult: sink.onResult,
+    spawnWorker: dyingWorkerFactory({ dieAfter: 3, only: 2 }) });
+
+  assert.equal(sink.order.length, requests.length, "every request must produce exactly one result");
+  for (const [index, result] of sink.results.entries()) {
+    assert.equal(result.status, "ok", `index ${index}: ${result.message ?? ""}`);
+    assert.deepEqual(result.envelope, sealEnvelope(requests[index]));
+  }
+  assert.ok(sink.results.some((result) => result.worker === 102),
+    "the doomed worker should have sealed something before dying");
+});
+
+test("a batch whose whole pool dies still seals every message", async () => {
+  const requests = Array.from({ length: 40 }, (_, index) => request(index));
+  const sink = collect(requests.length);
+  await runSealBatch(requests, { parallelism: 4, onResult: sink.onResult,
+    spawnWorker: dyingWorkerFactory({ dieAfter: 0 }) });
+
+  assert.equal(sink.order.length, requests.length);
+  for (const [index, result] of sink.results.entries()) {
+    assert.equal(result.status, "ok");
+    assert.deepEqual(result.envelope, sealEnvelope(requests[index]));
+  }
+  // Nothing survived to seal on, so the caller's thread finished the page.
+  assert.deepEqual([...new Set(sink.results.map((result) => result.worker))], [0]);
+});
+
+test("a request that no worker can complete is reported, not dropped", async () => {
+  const requests = Array.from({ length: 12 }, (_, index) => request(index));
+  const sink = collect(requests.length);
+  // Every worker dies on its first task, and the pool is large enough that the
+  // scheduler exhausts MAX_ATTEMPTS on the first index before it runs dry.
+  await runSealBatch(requests, { parallelism: 3, onResult: sink.onResult,
+    spawnWorker: dyingWorkerFactory({ dieAfter: 0 }) });
+
+  assert.equal(sink.order.length, requests.length);
+  assert.deepEqual([...new Set(sink.order)].sort((a, b) => a - b),
+    requests.map((_, index) => index));
+});
+
+// The seal progress a bulk page reports travels driver stderr -> engine stderr.
+// The engine used to hold driver stderr back and only quote it in a failure
+// message, which would have made "progress" arrive after the work was over.
+test("driver stderr is forwarded to the operator, not only quoted on failure", async () => {
+  const scratch = await mkdtemp(join(tmpdir(), "agmsg-driver-stderr-"));
+  const script = join(scratch, "fake-driver.sh");
+  await writeFile(script, ["#!/usr/bin/env bash",
+    "printf 'agmsg: sealing 5/10 (50%%)\\n' >&2",
+    "printf '{\"type\":\"sync_state\"}\\n'", ""].join("\n"), { mode: 0o700 });
+
+  const captured = [];
+  const realWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk) => { captured.push(String(chunk)); return true; };
+  process.env.AGMSG_SYNC_DRIVER = script;
+  try {
+    await driver("prepare", { local_team: "demo", server_instance_id: "s",
+      remote_team_id: "r", protocol_version: 1 }, [], ["10"]);
+  } finally {
+    process.stderr.write = realWrite;
+    delete process.env.AGMSG_SYNC_DRIVER;
+    await rm(scratch, { recursive: true });
+  }
+  assert.match(captured.join(""), /agmsg: sealing 5\/10 \(50%\)/u);
+});
+
+test("one malformed request fails alone and the rest of the page seals", async () => {
+  const requests = Array.from({ length: 24 }, (_, index) => request(index));
+  requests[7].wire_id = "not-a-uuid";
+  const sink = collect(requests.length);
+  await runSealBatch(requests, { parallelism: 3, onResult: sink.onResult });
+
+  assert.equal(sink.results[7].status, "error");
+  assert.equal(sink.results[7].state, "malformed");
+  for (const [index, result] of sink.results.entries()) {
+    if (index === 7) continue;
+    assert.equal(result.status, "ok");
+    assert.deepEqual(result.envelope, sealEnvelope(requests[index]));
+  }
+});

--- a/tests/seal_batch.test.mjs
+++ b/tests/seal_batch.test.mjs
@@ -5,9 +5,32 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { driver } from "../scripts/internal/remote-sync.mjs";
-import { runSealBatch, sealBatchParallelism,
+import { runSealBatch, sealBatchParallelism, sealBatchWindows,
   sealEnvelope } from "../scripts/internal/sync-cipher.mjs";
+
+const HELPER = fileURLToPath(new URL("../scripts/internal/sync-cipher.mjs", import.meta.url));
+
+// Run the helper CLI end to end. The point of several of these tests is what
+// the process does with a stream it has not finished reading, so the input has
+// to arrive on a real pipe.
+function runHelper(args, input) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [HELPER, ...args], { stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    child.stdin.on("error", () => {});
+    child.stdin.end(input);
+  });
+}
 
 // cipher "none" is deterministic, so a batch envelope can be compared byte for
 // byte against the single-request seal the driver used before. What is under
@@ -135,6 +158,74 @@ test("a request that no worker can complete is reported, not dropped", async () 
   assert.equal(sink.order.length, requests.length);
   assert.deepEqual([...new Set(sink.order)].sort((a, b) => a - b),
     requests.map((_, index) => index));
+});
+
+// A page is bounded by its message count, but a body is legal up to
+// max_blob_bytes, so a legal 1000-message page can be a gigabyte. Holding all
+// of it would turn input a caller is entitled to send into an OOM.
+test("a streamed batch is cut into windows bounded by count and by bytes", async () => {
+  const lines = Array.from({ length: 10 }, (_, index) => JSON.stringify(request(index)));
+
+  const byCount = [];
+  for await (const window of sealBatchWindows(lines, { requests: 4, bytes: 1 << 30 })) {
+    byCount.push(window.length);
+  }
+  assert.deepEqual(byCount, [4, 4, 2]);
+
+  // Byte-bounded: each line here is well over the limit, so no window may hold
+  // more than the one request that crossed it.
+  const byBytes = [];
+  for await (const window of sealBatchWindows(lines, { requests: 1000, bytes: 8 })) {
+    byBytes.push(window.length);
+  }
+  assert.deepEqual(byBytes, Array.from({ length: 10 }, () => 1));
+});
+
+test("windowing does not renumber results the caller has to match up", async () => {
+  // Bodies large enough that the real byte bound cuts the batch into several
+  // windows; indices must still run 0..n-1 across the whole input.
+  const big = "x".repeat(600_000);
+  const requests = Array.from({ length: 30 }, (_, index) => {
+    const value = request(index);
+    value.projection.body = `${index}:${big}`;
+    return value;
+  });
+  const { code, stdout } = await runHelper(["seal-batch", String(requests.length)],
+    `${requests.map((value) => JSON.stringify(value)).join("\n")}\n`);
+  const results = stdout.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+
+  assert.equal(code, 0);
+  assert.equal(results.length, requests.length);
+  assert.deepEqual(results.map((result) => result.index).sort((a, b) => a - b),
+    requests.map((_, index) => index));
+  for (const result of results) {
+    assert.equal(result.status, "ok");
+    assert.deepEqual(result.envelope, sealEnvelope(requests[result.index]));
+  }
+});
+
+// A thread that cannot be created at all — the process is out of them, the
+// system is out of memory. Distinct from a thread that dies while working, and
+// it used to escape the fallback entirely: spawning happened before the
+// try/finally, so a throw skipped both the cleanup and the main-thread sweep.
+test("a pool that cannot be spawned still seals every message", async () => {
+  const requests = Array.from({ length: 20 }, (_, index) => request(index));
+  for (const failFrom of [0, 2]) {
+    const sink = collect(requests.length);
+    let spawned = 0;
+    await runSealBatch(requests, { parallelism: 4, onResult: sink.onResult,
+      spawnWorker: () => {
+        if (spawned >= failFrom) throw new Error("EAGAIN: cannot create thread");
+        spawned += 1;
+        return dyingWorkerFactory({ dieAfter: 1000 })();
+      } });
+
+    assert.equal(sink.order.length, requests.length, `failFrom=${failFrom}`);
+    for (const [index, result] of sink.results.entries()) {
+      assert.equal(result.status, "ok");
+      assert.deepEqual(result.envelope, sealEnvelope(requests[index]));
+    }
+  }
 });
 
 // The seal progress a bulk page reports travels driver stderr -> engine stderr.

--- a/tests/test_sync_cipher.bats
+++ b/tests/test_sync_cipher.bats
@@ -23,6 +23,112 @@ require_age() {
   [ "$status" -eq 0 ]
 }
 
+@test "bulk seal fan-out, worker failure, and per-request errors" {
+  run node --test "$BATS_TEST_DIRNAME/seal_batch.test.mjs"
+  [ "$status" -eq 0 ]
+}
+
+# Shared setup for the bulk-path tests: a store holding <count> sent messages
+# and the sync_prepare record that seals them under age-v1. Leaves $prepare,
+# $remote_team and $server_instance set for the caller.
+bulk_store() {
+  local count="$1" i=0 recipient
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=sqlite
+  export AGMSG_SYNC_NODE_BIN=node
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  storage_init >/dev/null
+  while [ "$i" -lt "$count" ]; do
+    storage_send demo alice bob "backfill message $i" >/dev/null
+    i=$((i + 1))
+  done
+  server_instance=018f3f7e-0000-7000-8000-000000000000
+  remote_team=018f3f7e-0000-7000-8000-000000000001
+  recipient=$(jq -r '.recipient_sets.team_a.recipient' \
+    "$BATS_TEST_DIRNAME/../docs/spec/vectors/age-v1-vectors.json")
+  prepare=$(jq -nc --arg recipient "$recipient" '
+    {type:"sync_prepare",envelope_v:1,cipher:"age-v1",key_id:"epoch-1",
+     recipients:[$recipient],max_blob_bytes:1048576,allow_new:true}')
+}
+
+@test "a bulk page is sealed by one batched helper call" {
+  require_age
+  local prepare server_instance remote_team
+  bulk_store 60
+  export AGMSG_SYNC_TEST_INVOCATION_LOG="$BATS_TEST_TMPDIR/invocations.log"
+  export AGMSG_SYNC_REAL_CIPHER_HELPER="$SCRIPTS/internal/sync-cipher.mjs"
+  export AGMSG_SYNC_CIPHER_HELPER="$BATS_TEST_DIRNAME/fixtures/sync-cipher-invocation-probe.mjs"
+  local published
+  published=$(printf '%s\n' "$prepare" | storage_sync_prepare_push demo \
+    "$server_instance" "$remote_team" 1 100 2>"$BATS_TEST_TMPDIR/prepare.err")
+  [ "$(printf '%s\n' "$published" | grep -c sync_push_candidate)" -eq 60 ]
+  # Progress goes to stderr, where it cannot corrupt the JSONL on stdout.
+  grep -qF 'agmsg: sealing 60/60 (100%)' "$BATS_TEST_TMPDIR/prepare.err"
+  # One process for the whole page, not one per message. Sealing 60 messages
+  # used to cost 60 Node startups on top of 60 age forks.
+  [ "$(wc -l < "$AGMSG_SYNC_TEST_INVOCATION_LOG" | tr -d ' ')" -eq 1 ]
+  [ "$(cat "$AGMSG_SYNC_TEST_INVOCATION_LOG")" = "seal-batch 60" ]
+}
+
+@test "an interrupted bulk seal keeps its committed page and resumes" {
+  require_age
+  local prepare server_instance remote_team
+  bulk_store 200
+  local real_age db committed waited=0 before after
+  real_age="${AGMSG_AGE_BIN:-$(command -v age)}"
+  # Slow age down so the page takes long enough to be signalled in the middle of
+  # it. Real backfills are slow for the same reason — one age fork per message.
+  cat > "$BATS_TEST_TMPDIR/slow-age" <<SLOW
+#!/usr/bin/env bash
+sleep 0.3
+exec "$real_age" "\$@"
+SLOW
+  chmod +x "$BATS_TEST_TMPDIR/slow-age"
+  cat > "$BATS_TEST_TMPDIR/run-prepare.sh" <<RUN
+#!/usr/bin/env bash
+source "$SCRIPTS/lib/storage.sh"
+agmsg_storage_load
+printf '%s\n' '$prepare' | storage_sync_prepare_push demo \
+  $server_instance $remote_team 1 500 >/dev/null
+RUN
+  db=$(agmsg_db_path)
+
+  AGMSG_AGE_BIN="$BATS_TEST_TMPDIR/slow-age" \
+    bash "$BATS_TEST_TMPDIR/run-prepare.sh" 3>&- 4>&- &
+  local pid=$!
+  # Wait for the first committed group, then interrupt the run for real. The
+  # table itself only appears once prepare has created the schema, so a failed
+  # count early on means "nothing committed yet", not a broken store.
+  while [ "$waited" -lt 600 ]; do
+    committed=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_messages;" 2>/dev/null | tr -d '\r')
+    [ -n "$committed" ] && [ "$committed" -gt 0 ] && break
+    sleep 0.1; waited=$((waited + 1))
+  done
+  kill -TERM "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  before=$(agmsg_sqlite "$db" \
+    "SELECT local_position||':'||wire_id FROM sync_messages ORDER BY local_position;")
+  committed=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_messages;" | tr -d '\r')
+  # The interrupt has to have landed mid-page: work survived it, and work was
+  # left behind. A run that finished first would prove nothing about resuming.
+  [ "$committed" -gt 0 ]
+  [ "$committed" -lt 200 ]
+
+  printf '%s\n' "$prepare" | storage_sync_prepare_push demo \
+    "$server_instance" "$remote_team" 1 500 >/dev/null
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_messages;" | tr -d '\r')" -eq 200 ]
+  [ "$(agmsg_sqlite "$db" \
+     "SELECT COUNT(DISTINCT local_position) FROM sync_messages;" | tr -d '\r')" -eq 200 ]
+  # Reservations made before the interrupt are immutable — resuming re-seals
+  # only what was left, it never re-issues a wire id that already exists.
+  after=$(agmsg_sqlite "$db" \
+    "SELECT local_position||':'||wire_id FROM sync_messages ORDER BY local_position;")
+  [ -z "$(comm -23 <(printf '%s\n' "$before" | sort) <(printf '%s\n' "$after" | sort))" ]
+}
+
 @test "sqlite prepare publishes one byte-stable age-v1 envelope" {
   require_age
   export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"

--- a/tests/test_sync_cipher.bats
+++ b/tests/test_sync_cipher.bats
@@ -103,7 +103,9 @@ RUN
   # count early on means "nothing committed yet", not a broken store.
   while [ "$waited" -lt 600 ]; do
     committed=$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_messages;" 2>/dev/null | tr -d '\r')
-    [ -n "$committed" ] && [ "$committed" -gt 0 ] && break
+    # An `A && B && break` list here would be a failing command under bats'
+    # errexit on every iteration that finds nothing yet.
+    if [ -n "$committed" ] && [ "$committed" -gt 0 ]; then break; fi
     sleep 0.1; waited=$((waited + 1))
   done
   kill -TERM "$pid" 2>/dev/null || true
@@ -122,6 +124,9 @@ RUN
   [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_messages;" | tr -d '\r')" -eq 200 ]
   [ "$(agmsg_sqlite "$db" \
      "SELECT COUNT(DISTINCT local_position) FROM sync_messages;" | tr -d '\r')" -eq 200 ]
+  # No message came back with a second wire id, and none went missing.
+  [ "$(agmsg_sqlite "$db" \
+     "SELECT COUNT(DISTINCT wire_id) FROM sync_messages;" | tr -d '\r')" -eq 200 ]
   # Reservations made before the interrupt are immutable — resuming re-seals
   # only what was left, it never re-issues a wire id that already exists.
   after=$(agmsg_sqlite "$db" \

--- a/tests/test_sync_cipher.bats
+++ b/tests/test_sync_cipher.bats
@@ -72,6 +72,59 @@ bulk_store() {
   [ "$(cat "$AGMSG_SYNC_TEST_INVOCATION_LOG")" = "seal-batch 60" ]
 }
 
+@test "a batched page carries awkward and large bodies through byte for byte" {
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=sqlite
+  export AGMSG_SYNC_NODE_BIN=node
+  export AGMSG_SYNC_CIPHER_HELPER="$SCRIPTS/internal/sync-cipher.mjs"
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  storage_init >/dev/null
+  # The page is streamed through paste and two jq passes on its way to the
+  # helper, so a body has to survive a tab-delimited join, a JSON round trip and
+  # a shell here-document unchanged. Every character below has broken one of
+  # those at some point.
+  local -a bodies
+  bodies[0]='he said "hi" and left'
+  bodies[1]='a backslash \ and a \"quoted\" escape'
+  bodies[2]=$'tab\tseparated\tlooks like a delimiter'
+  bodies[3]=$'first line\nsecond line'
+  bodies[4]="$(printf 'x%.0s' $(seq 1 200000))"
+  bodies[5]='単一引用符 '"'"' と絵文字 🔐 と改行なし'
+  local i=0
+  while [ "$i" -lt 6 ]; do
+    storage_send demo alice bob "${bodies[$i]}" >/dev/null
+    i=$((i + 1))
+  done
+
+  local prepare published
+  prepare='{"type":"sync_prepare","envelope_v":1,"cipher":"none","key_id":null,
+            "recipients":[],"max_blob_bytes":1048576,"allow_new":true}'
+  published=$(printf '%s\n' "$prepare" | storage_sync_prepare_push demo \
+    018f3f7e-0000-7000-8000-000000000000 018f3f7e-0000-7000-8000-000000000001 1 100)
+  [ "$(printf '%s\n' "$published" | grep -c sync_push_candidate)" -eq 6 ]
+
+  # Open each envelope and compare the body against what was sent.
+  i=0
+  while [ "$i" -lt 6 ]; do
+    local opened
+    opened=$(printf '%s\n' "$published" | jq -sc --argjson n "$i" \
+        '[.[] | select(.type=="sync_push_candidate")] | sort_by(.local_position|tonumber)
+         | .[$n].envelope' \
+      | node --input-type=module -e '
+          const { openEnvelope } = await import(process.argv[1]);
+          let input = "";
+          for await (const chunk of process.stdin) input += chunk;
+          const message = await openEnvelope({ envelope: JSON.parse(input),
+            max_blob_bytes: 1048576 });
+          process.stdout.write(message.body);
+        ' "$SCRIPTS/internal/sync-cipher.mjs")
+    [ "$opened" = "${bodies[$i]}" ]
+    i=$((i + 1))
+  done
+}
+
 @test "an interrupted bulk seal keeps its committed page and resumes" {
   require_age
   local prepare server_instance remote_team


### PR DESCRIPTION
A first connect, a reconnect, or a retention backfill seals a whole page at once, and every message cost a Node startup for the cipher helper, six jq processes, a sqlite lookup, a `/dev/urandom` read, and its own sqlite transaction — all wrapped around one `age` fork. Sealing 90k messages was hours of process startup around a few minutes of cryptography.

## What changed

**`seal-batch` in the cipher helper.** JSONL requests in, one JSONL result per request out, fanned over worker threads. Threads rather than a second implementation: each worker imports the same file and calls the same `sealEnvelope`, so there is one crypto path and a batch produces the bytes `seal` produces. Parallelism is one worker per eight requests capped at the core count, so a steady-state page stays on the calling thread and is the pre-existing sequential code down to the call.

**The scheduler guarantees exactly one result per request.** A worker that dies has its in-flight request re-dispatched to a survivor; a worker that cannot be spawned at all ends the pool; if no worker survives, the remainder is sealed on the calling thread. A request that fails is an `error` result rather than an exception, so one bad message cannot cost the page.

**The sqlite driver seals the page in one call** and commits reservations in groups rather than one transaction each — a `sqlite3` fork costs far more than the seal it records. Results stream back in completion order and each group is durable when it lands, so an interrupted run keeps what it committed and the next prepare re-seals only what is left. Requests are built in a single jq pass, the reservation check comes from the `LEFT JOIN` already in the row query, wire ids come from one `/dev/urandom` read, and SQL literals are escaped with a builtin in the hot loop.

**Driver stderr is forwarded as it arrives.** It used to be buffered and only quoted back inside a failure message, so progress that only printed once the work was over would not have been progress.

## Memory

A page is bounded by its message count, but a body is legal up to `max_blob_bytes`, so a legal 1000-message first connect can be a gigabyte. Nothing on the batch path is allowed to keep a second copy of it:

- The driver builds the filtered rows, the uuid join and the seal requests as streams straight into the helper. What it retains per message is position, local id and wire id — ids only, no body.
- The helper reads stdin with `readline` and seals a window at a time, bounded by request count and by bytes. The scheduler has to keep a request until its result is out, because it re-dispatches whatever a dying worker was holding, so what the window bounds is how much it is ever asked to keep. Results are renumbered against the caller's input, so windowing is invisible to callers.

**Known limit, unchanged:** the row query still materializes the page once, exactly as it did before batching. Bounding that needs the query itself paged, which is a separate change.

The reservation commit now goes to `sqlite3` on stdin rather than in argv. A single encrypted blob is legal up to `max_blob_bytes`, which is past `ARG_MAX` once base64 and SQL quoting are applied — the pre-batch driver could not have held such a row either, and no group bound would have fixed it.

## Measured

1000-message age-v1 page, 16 cores:

| | before | after |
|---|---|---|
| whole page (bash 5) | 118.06s | 2.21s |
| per message (bash 5) | 118.1ms | 2.2ms |
| whole page (bash 3.2, stock macOS) | — | 6.18s |
| sealing alone (200 msgs) | 8.99s | 0.19s |

## Tests

- **Fan-out** is asserted on the thread that sealed each request. Every other assertion in that test passes just as well if the batch quietly runs on one thread, so envelope correctness cannot stand in for it — forcing the page back to one worker fails the test.
- **Worker death** is driven through an injected spawn seam, since a thread cannot be told to die at a chosen task from outside. One worker dying mid-page, the whole pool dying, and a pool that cannot be spawned at all must each end with exactly one result per request and every envelope byte-identical to sealing it alone.
- **The interrupt is a real signal to a real run**: `age` is slowed so the page lasts, the run is killed once a group has landed, and the test asserts both that work survived and that work was left behind, then resumes and checks that no reservation moved and no message picked up a second wire id.
- **Window bounds** are asserted on the generator that enforces them, by count and by bytes, plus an end-to-end run over a batch the byte bound really cuts.
- **Body fidelity**: a page of quotes, backslashes, tabs, newlines, an apostrophe, an emoji and a 200KB body is opened back and compared with what was sent — the request now travels a tab-delimited join and two jq passes to reach the helper.

Every new test was checked against the unpatched tree or against a mutation that removes the property it claims: sequential fan-out, a dropped dead-worker task, a spawn loop outside the fallback boundary, commits deferred to the end of the page, and bodies losing their backslashes.

## CI

`.github/workflows/tests.yml` triggers on `pull_request: branches: [main]`, so PRs into `integration/remote` get no checks (the last one, #483, reported none either). The full bats suite is run locally on macOS instead, under both bash 5 and stock bash 3.2.