### PR TITLE
test: wait for conditions instead of fixed sleeps in the watcher suites

### DIFF
--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1209,7 +1209,14 @@ JSON
 
   run bash "$SCRIPTS/delivery.sh" stop
   [[ "$output" =~ "Killed 2 watch" ]]
+  # BOTH watchers must be waited for. `stop` sends TERM to each and returns;
+  # the order they actually die in is not guaranteed, so waiting only on A and
+  # asserting B in the same breath races B's exit trap. The `sleep 1` this
+  # replaced happened to cover both — the two other project-scoped tests above
+  # wait on one pid only because their second watcher is asserted to still be
+  # ALIVE, which needs no grace period.
   wait_for_pid_exit "$pid_a"
+  wait_for_pid_exit "$pid_b"
   ! kill -0 "$pid_a" 2>/dev/null
   ! kill -0 "$pid_b" 2>/dev/null
 

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -318,13 +318,13 @@ _seed_role_record() {
 JSON
   AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" stop-test "$TEST_PROJECT" claude-code 3>&- &
   local watch_pid=$!
-  sleep 1
+  wait_for_file "$TEST_SKILL_DIR/run/watch.stop-test.pid"
   [ -f "$TEST_SKILL_DIR/run/watch.stop-test.pid" ]
   run bash "$SCRIPTS/delivery.sh" stop
   [[ "$output" =~ "Killed 1 watch" ]]
   [[ "$output" =~ "AGMSG-DIRECTIVE" ]]
   [ ! -f "$TEST_SKILL_DIR/run/watch.stop-test.pid" ]
-  sleep 1
+  wait_for_pid_exit "$watch_pid"
   ! kill -0 "$watch_pid" 2>/dev/null
 }
 
@@ -371,7 +371,7 @@ JSON
   # A live claude-code watcher for this project.
   AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" cc-sess "$TEST_PROJECT" claude-code 3>&- &
   local watch_pid=$!
-  sleep 1
+  wait_for_file "$TEST_SKILL_DIR/run/watch.cc-sess.pid"
   [ -f "$TEST_SKILL_DIR/run/watch.cc-sess.pid" ]
   # Switching a DIFFERENT type's delivery in the SAME project must not touch it.
   run bash "$SCRIPTS/delivery.sh" set turn copilot "$TEST_PROJECT"
@@ -389,12 +389,12 @@ JSON
 JSON
   AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" cc-sess2 "$TEST_PROJECT" claude-code 3>&- &
   local watch_pid=$!
-  sleep 1
+  wait_for_file "$TEST_SKILL_DIR/run/watch.cc-sess2.pid"
   [ -f "$TEST_SKILL_DIR/run/watch.cc-sess2.pid" ]
   run bash "$SCRIPTS/delivery.sh" set off claude-code "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   [ ! -f "$TEST_SKILL_DIR/run/watch.cc-sess2.pid" ]
-  sleep 1
+  wait_for_pid_exit "$watch_pid"
   ! kill -0 "$watch_pid" 2>/dev/null
 }
 
@@ -411,7 +411,7 @@ JSON
 JSON
   AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sp-sess "$sp" claude-code 3>&- &
   local watch_pid=$!
-  sleep 1
+  wait_for_file "$TEST_SKILL_DIR/run/watch.sp-sess.pid"
   [ -f "$TEST_SKILL_DIR/run/watch.sp-sess.pid" ]
   # Another type's set turn in the SAME space-containing project: must NOT kill it.
   run bash "$SCRIPTS/delivery.sh" set turn copilot "$sp"
@@ -422,7 +422,7 @@ JSON
   run bash "$SCRIPTS/delivery.sh" set off claude-code "$sp"
   [ "$status" -eq 0 ]
   [ ! -f "$TEST_SKILL_DIR/run/watch.sp-sess.pid" ]
-  sleep 1
+  wait_for_pid_exit "$watch_pid"
   ! kill -0 "$watch_pid" 2>/dev/null
 }
 
@@ -437,10 +437,10 @@ JSON
 
   AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sigterm-test "$TEST_PROJECT" claude-code 3>&- &
   local pid=$!
-  sleep 1
+  wait_for_file "$TEST_SKILL_DIR/run/watch.sigterm-test.pid"
   [ -f "$TEST_SKILL_DIR/run/watch.sigterm-test.pid" ]
   kill -TERM "$pid"
-  sleep 1
+  wait_for_pid_exit "$pid"
   ! kill -0 "$pid" 2>/dev/null
   [ ! -f "$TEST_SKILL_DIR/run/watch.sigterm-test.pid" ]
 }
@@ -520,7 +520,7 @@ JSON
   [ -f "$pidfile" ]
   prev_p=$(cat "$pidfile")
   kill "$prev_p"
-  sleep 1
+  wait_for_pid_exit "$prev_p"
   ! kill -0 "$prev_p" 2>/dev/null
 }
 
@@ -626,7 +626,7 @@ has_session_end() {
   local target_pid=$!
   echo "$target_pid" > "$TEST_SKILL_DIR/run/watch.sess-A.pid"
   echo '{"session_id":"sess-A"}' | bash "$SCRIPTS/session-end.sh" claude-code "$TEST_PROJECT"
-  sleep 1
+  wait_for_pid_exit "$target_pid"
   ! kill -0 "$target_pid" 2>/dev/null
   [ ! -f "$TEST_SKILL_DIR/run/watch.sess-A.pid" ]
 }
@@ -985,11 +985,17 @@ JSON
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" t-sid "$TEST_PROJECT" claude-code bob > /tmp/agmsg-as-bob 2>&1 3>&- &
   local pid=$!
   # High-water-mark = MAX(id) at startup, so prior messages aren't replayed.
-  # Insert NEW messages and wait for several poll iterations.
-  sleep 1
+  # The watermark file is written the moment that mark is taken, so waiting for
+  # it — rather than a fixed second — is what actually makes the inserts below
+  # land after the mark.
+  wait_for_file "$TEST_SKILL_DIR/run/watch.t-sid.watermark"
   sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'system', 'alice', 'new-for-alice');"
   sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'system', 'bob', 'new-for-bob');"
-  sleep 3
+  # new-for-bob is the LAST row inserted, so by the time it has been delivered
+  # the watcher has necessarily scanned past new-for-alice. That is what makes
+  # the "alice never arrived" assertion below a real check; the fixed `sleep 3`
+  # it replaces only assumed enough poll iterations had gone by.
+  wait_for_file_contains /tmp/agmsg-as-bob "new-for-bob"
   kill -TERM "$pid" 2>/dev/null
   wait "$pid" 2>/dev/null || true
 
@@ -1081,7 +1087,7 @@ JSON
   # is resolved at launch and not re-evaluated each poll.
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" t-static "$TEST_PROJECT" claude-code > /tmp/agmsg-static 2>&1 3>&- &
   local pid=$!
-  sleep 1
+  wait_for_file "$TEST_SKILL_DIR/run/watch.t-static.watermark"
 
   # Join `bob` to the same (project, type) after the watcher is running.
   bash "$SCRIPTS/join.sh" myteam bob claude-code "$TEST_PROJECT"
@@ -1091,7 +1097,13 @@ JSON
   sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'sys', 'alice', 'for-alice-static');"
   sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'sys', 'bob',   'for-bob-static');"
 
-  sleep 3
+  # A sentinel for alice inserted AFTER bob's row. Its arrival proves the
+  # watcher has already scanned past for-bob-static, which is what makes "bob
+  # never arrived" an assertion rather than a guess. Waiting on
+  # for-alice-static instead would not: it precedes bob's row, so seeing it
+  # says nothing about whether bob's had been reached yet.
+  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'sys', 'alice', 'static-sentinel');"
+  wait_for_file_contains /tmp/agmsg-static "static-sentinel"
   kill -TERM "$pid" 2>/dev/null
   wait "$pid" 2>/dev/null || true
 
@@ -1120,13 +1132,14 @@ JSON
   local pid_a=$!
   AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sid-b "$proj_b" claude-code 3>&- &
   local pid_b=$!
-  sleep 1
+  wait_for_file "$TEST_SKILL_DIR/run/watch.sid-a.pid"
+  wait_for_file "$TEST_SKILL_DIR/run/watch.sid-b.pid"
   [ -f "$TEST_SKILL_DIR/run/watch.sid-a.pid" ]
   [ -f "$TEST_SKILL_DIR/run/watch.sid-b.pid" ]
 
   run bash "$SCRIPTS/delivery.sh" set turn claude-code "$proj_a"
   [ "$status" -eq 0 ]
-  sleep 1
+  wait_for_pid_exit "$pid_a"
 
   # Target project A: watcher killed, pidfile removed.
   ! kill -0 "$pid_a" 2>/dev/null
@@ -1158,11 +1171,12 @@ JSON
   local pid_a=$!
   AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" off-b "$proj_b" claude-code 3>&- &
   local pid_b=$!
-  sleep 1
+  wait_for_file "$TEST_SKILL_DIR/run/watch.off-a.pid"
+  wait_for_file "$TEST_SKILL_DIR/run/watch.off-b.pid"
 
   run bash "$SCRIPTS/delivery.sh" set off claude-code "$proj_a"
   [ "$status" -eq 0 ]
-  sleep 1
+  wait_for_pid_exit "$pid_a"
 
   ! kill -0 "$pid_a" 2>/dev/null
   [ ! -f "$TEST_SKILL_DIR/run/watch.off-a.pid" ]
@@ -1190,11 +1204,12 @@ JSON
   local pid_a=$!
   AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" stop-b "$proj_b" claude-code 3>&- &
   local pid_b=$!
-  sleep 1
+  wait_for_file "$TEST_SKILL_DIR/run/watch.stop-a.pid"
+  wait_for_file "$TEST_SKILL_DIR/run/watch.stop-b.pid"
 
   run bash "$SCRIPTS/delivery.sh" stop
   [[ "$output" =~ "Killed 2 watch" ]]
-  sleep 1
+  wait_for_pid_exit "$pid_a"
   ! kill -0 "$pid_a" 2>/dev/null
   ! kill -0 "$pid_b" 2>/dev/null
 
@@ -1946,6 +1961,11 @@ EOF
     > "$rollout_dir/rollout-2020-01-01T00-00-00-stale-by-name-uuid.jsonl"
   printf '%s\n' "{\"type\":\"session_meta\",\"payload\":{\"id\":\"newer-by-name-uuid\",\"cwd\":\"$TEST_PROJECT\"}}" \
     > "$rollout_dir/rollout-2026-06-17T00-00-00-newer-by-name-uuid.jsonl"
+  # Stays a real sleep. This is not waiting for a process to settle — it is
+  # separating two mtimes far enough apart that the code under test can order
+  # them, and filesystem timestamp granularity is a whole second on some of the
+  # filesystems CI runs on. There is no condition to poll for: the thing being
+  # waited on is the clock itself.
   sleep 1
   touch "$rollout_dir/rollout-2020-01-01T00-00-00-stale-by-name-uuid.jsonl"
 
@@ -2045,7 +2065,7 @@ EOF
 JSON
   AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" hermes-preserve-test "$TEST_PROJECT" claude-code 3>&- &
   local watch_pid=$!
-  sleep 1
+  wait_for_file "$TEST_SKILL_DIR/run/watch.hermes-preserve-test.pid"
   [ -f "$TEST_SKILL_DIR/run/watch.hermes-preserve-test.pid" ]
 
   run bash "$SCRIPTS/delivery.sh" set off hermes "$TEST_PROJECT"

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -621,10 +621,20 @@ has_session_end() {
 # --- session-end.sh behavior ---
 
 @test "session-end.sh kills the watcher matching session_id and removes pidfile" {
-  mkdir -p "$TEST_SKILL_DIR/run"
-  sleep 30 3>&- &
+  # The fixture must be a REAL watcher. session-end.sh only kills a pid whose
+  # command line still looks like watch.sh (pid-recycling safety, see its
+  # comment), so the `sleep 30` stand-in this used to launch could never be
+  # killed — and the assertion passed anyway, so the test never checked what its
+  # name claims. Converting the wait to a poll is what surfaced it: polling
+  # reports the process is still there, where the single post-sleep check did
+  # not.
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" sess-A "$TEST_PROJECT" claude-code 3>&- &
   local target_pid=$!
-  echo "$target_pid" > "$TEST_SKILL_DIR/run/watch.sess-A.pid"
+  wait_for_file "$TEST_SKILL_DIR/run/watch.sess-A.pid"
   echo '{"session_id":"sess-A"}' | bash "$SCRIPTS/session-end.sh" claude-code "$TEST_PROJECT"
   wait_for_pid_exit "$target_pid"
   ! kill -0 "$target_pid" 2>/dev/null

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -122,13 +122,45 @@ wait_for_file_contains() {
   return 1
 }
 
+# Positive evidence that a pid is gone. NOT `kill -0 || gone`.
+#
+# A failed `kill -0` is ESRCH (dead) or EPERM (alive, but not signalable by us —
+# sandboxes do exactly this, and a live instance of it was found in
+# delivery.sh status the same day this was written). Treating every failure as
+# "gone" is how a wait-for-exit helper reports success for a running process,
+# which turns every test built on it into a green that proves nothing. That is
+# the defect this file's own callers were just fixed for; the helper must not
+# reintroduce it one level down.
+#
+# Mirrors _agmsg_pid_alive in scripts/lib/instance-id.sh, then cross-checks the
+# process table, which does not depend on signalling permission at all. Saying
+# "gone" now requires kill(2) and ps to agree.
+_pid_gone() {
+  local pid="$1" err stat
+  # `export LC_ALL=C` rather than a bare prefix: a prefix misses the builtin on
+  # bash 3.2, and the ESRCH match below is on English text.
+  err="$(export LC_ALL=C; kill -0 "$pid" 2>&1)" && return 1
+  case "$err" in
+    *[Nn]'o such process'*) ;;
+    *) return 1 ;;   # EPERM and anything unrecognised mean "assume alive"
+  esac
+  stat="$(ps -o stat= -p "$pid" 2>/dev/null | tr -d ' ')"
+  [ -z "$stat" ] && return 0
+  case "$stat" in Z*) return 0 ;; esac   # terminated, just not reaped yet
+  return 1
+}
+
 # Wait for a process to actually be gone. Writing a pidfile and dying are not
 # atomic, so asserting `! kill -0 $pid` the instant a pidfile disappears races
 # the TERM trap (#124).
 wait_for_pid_exit() {
   local pid="$1" i
   for i in $(seq 1 $_WAIT_TICKS); do
-    kill -0 "$pid" 2>/dev/null || return 0
+    # Reap finished children first: an unreaped zombie still answers `kill -0`,
+    # so without this a process that HAS exited can keep looking alive for the
+    # whole timeout. `jobs` is what makes bash collect them.
+    jobs >/dev/null 2>&1 || true
+    _pid_gone "$pid" && return 0
     sleep $_WAIT_INTERVAL
   done
   return 1

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -74,6 +74,79 @@ rf() {
   printf '%s' "$p" | sed "s/'/''/g"
 }
 
+# --- Bounded condition waits -------------------------------------------------
+#
+# Wait for a condition to become true, polling, instead of sleeping a fixed
+# interval and hoping. A fixed `sleep 1` after launching a watcher is wrong in
+# both directions at once: it costs a whole second when the watcher was ready in
+# 40ms, and it still flakes on a loaded runner where the watcher needs 1.2s.
+# Polling is both faster and steadier, which is why the pattern already existed
+# ad hoc in test_watch.bats, test_install.bats and test_codex_bridge_launcher.bats
+# before it was hoisted here.
+#
+# Each returns non-zero on timeout, so a caller can fail with its own message or
+# clean up a background process first. The 10s ceiling is far above any real
+# local transition and well under the per-job CI timeout.
+#
+# NOTE: these replace waits for a condition that will become TRUE. A test that
+# asserts something does NOT happen cannot poll for it — see the comment at the
+# remaining fixed sleeps in test_delivery.bats.
+
+_WAIT_TICKS=100    # x 0.1s = 10s ceiling
+_WAIT_INTERVAL=0.1
+
+wait_for_file() {
+  local file="$1" i
+  for i in $(seq 1 $_WAIT_TICKS); do
+    [ -f "$file" ] && return 0
+    sleep $_WAIT_INTERVAL
+  done
+  return 1
+}
+
+wait_for_missing() {
+  local path="$1" i
+  for i in $(seq 1 $_WAIT_TICKS); do
+    [ ! -e "$path" ] && return 0
+    sleep $_WAIT_INTERVAL
+  done
+  return 1
+}
+
+wait_for_file_contains() {
+  local file="$1" needle="$2" i
+  for i in $(seq 1 $_WAIT_TICKS); do
+    [ -f "$file" ] && grep -q "$needle" "$file" && return 0
+    sleep $_WAIT_INTERVAL
+  done
+  return 1
+}
+
+# Wait for a process to actually be gone. Writing a pidfile and dying are not
+# atomic, so asserting `! kill -0 $pid` the instant a pidfile disappears races
+# the TERM trap (#124).
+wait_for_pid_exit() {
+  local pid="$1" i
+  for i in $(seq 1 $_WAIT_TICKS); do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep $_WAIT_INTERVAL
+  done
+  return 1
+}
+
+# Wait for <file> to contain exactly <expected>, for pidfile handoffs where the
+# file exists throughout but its contents flip to the successor.
+wait_for_file_is() {
+  local file="$1" expected="$2" i
+  for i in $(seq 1 $_WAIT_TICKS); do
+    if [ -f "$file" ] && [ "$(cat "$file" 2>/dev/null)" = "$expected" ]; then
+      return 0
+    fi
+    sleep $_WAIT_INTERVAL
+  done
+  return 1
+}
+
 # Pin a fake-owned session_id under the given run/ directory so the lock
 # liveness check (which runs `kill -0` on cc-instance.<pid>) considers
 # <sid> alive for the duration of the bats process.

--- a/tests/test_wait_helpers.bats
+++ b/tests/test_wait_helpers.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+#
+# The bounded condition waits in test_helper.bash decide whether many other
+# tests' assertions mean anything. `wait_for_pid_exit` in particular is the
+# evidence that a process was killed, so if it can report "gone" for a live
+# process, every test that uses it becomes a green that proves nothing — which
+# is exactly the failure that was found in the session-end test it replaced.
+
+setup() { load 'test_helper'; }
+
+@test "_pid_gone: reports a live process as alive" {
+  sleep 5 &
+  local p=$!
+  run _pid_gone "$p"
+  kill "$p" 2>/dev/null || true
+  wait "$p" 2>/dev/null || true
+  [ "$status" -ne 0 ]
+}
+
+@test "_pid_gone: reports a pid that never existed as gone" {
+  # Far above any live pid on the platforms this suite runs on.
+  run _pid_gone 4194303
+  [ "$status" -eq 0 ]
+}
+
+@test "_pid_gone: reports an exited child as gone, zombie or not" {
+  sleep 0.1 &
+  local p=$!
+  wait "$p" 2>/dev/null || true
+  run _pid_gone "$p"
+  [ "$status" -eq 0 ]
+}
+
+@test "_pid_gone: a failed kill -0 that is not ESRCH counts as ALIVE" {
+  # The EPERM case cannot be produced portably in-suite, so pin the decision
+  # rule itself: anything other than "no such process" must not be read as
+  # death. This is the branch that keeps a sandboxed, unsignalable-but-running
+  # process from being reported as exited.
+  local decided
+  decided=$(
+    kill() { echo "bash: kill: (1234) - Operation not permitted" >&2; return 1; }
+    ps() { return 1; }   # even with no process-table evidence
+    _pid_gone 1234 && echo GONE || echo ALIVE
+  )
+  [ "$decided" = "ALIVE" ]
+}
+
+@test "wait_for_pid_exit: returns promptly once the process is gone" {
+  sleep 0.2 &
+  local p=$!
+  run wait_for_pid_exit "$p"
+  [ "$status" -eq 0 ]
+}
+
+@test "wait_for_pid_exit: times out rather than claiming a live process exited" {
+  sleep 30 &
+  local p=$!
+  # Shrink the budget so the negative case does not cost the full ceiling.
+  _WAIT_TICKS=3 run wait_for_pid_exit "$p"
+  kill "$p" 2>/dev/null || true
+  wait "$p" 2>/dev/null || true
+  [ "$status" -ne 0 ]
+}
+
+@test "wait_for_file / wait_for_missing / wait_for_file_is agree with the filesystem" {
+  local f="$BATS_TEST_TMPDIR/probe"
+  run wait_for_file "$f"
+  [ "$status" -ne 0 ] || false   # absent file must not be reported present
+
+  echo "42" > "$f"
+  run wait_for_file "$f"
+  [ "$status" -eq 0 ]
+  run wait_for_file_is "$f" "42"
+  [ "$status" -eq 0 ]
+  run wait_for_file_is "$f" "43"
+  [ "$status" -ne 0 ]
+
+  rm -f "$f"
+  run wait_for_missing "$f"
+  [ "$status" -eq 0 ]
+}

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -57,33 +57,6 @@ _max_message_id() {
     agmsg_sqlite "$(agmsg_db_path)" "SELECT COALESCE(MAX(id), 0) FROM messages;" )
 }
 
-_wait_for_file() {
-  local file="$1" i
-  for i in $(seq 1 100); do
-    [ -f "$file" ] && return 0
-    sleep 0.1
-  done
-  return 1
-}
-
-_wait_for_missing() {
-  local file="$1" i
-  for i in $(seq 1 100); do
-    [ ! -e "$file" ] && return 0
-    sleep 0.1
-  done
-  return 1
-}
-
-_wait_for_file_contains() {
-  local file="$1" needle="$2" i
-  for i in $(seq 1 100); do
-    [ -f "$file" ] && grep -q "$needle" "$file" && return 0
-    sleep 0.1
-  done
-  return 1
-}
-
 @test "watch: restart delivers messages that arrived while the watcher was down" {
   skip_on_windows "watcher background launch under Git Bash (#182)"
   local sid="sess-restart"
@@ -92,9 +65,11 @@ _wait_for_file_contains() {
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
     >"$TEST_SKILL_DIR/out1.log" 2>/dev/null 3>&- &
   local w1=$!
-  sleep 1.5
+  # The watermark file appears as soon as the mark is taken, which is the
+  # condition the old fixed 1.5s was standing in for.
+  wait_for_file "$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark"
   bash "$SCRIPTS/send.sh" team bob alice "M1-before-stop" >/dev/null
-  sleep 2
+  wait_for_file_contains "$TEST_SKILL_DIR/out1.log" "M1-before-stop"
   kill "$w1" 2>/dev/null || true
   wait "$w1" 2>/dev/null || true
   grep -q "M1-before-stop" "$TEST_SKILL_DIR/out1.log"
@@ -119,9 +94,12 @@ _wait_for_file_contains() {
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-fresh" "$PROJ" claude-code \
     >"$TEST_SKILL_DIR/fresh.log" 2>/dev/null 3>&- &
   local w=$!
-  sleep 1.5
+  wait_for_file "$TEST_SKILL_DIR/run/watch.$(_iid "sess-fresh").watermark"
   bash "$SCRIPTS/send.sh" team bob alice "M-live" >/dev/null
-  sleep 2
+  # M-live has a higher id than M0-history, so once it has been streamed the
+  # watcher has passed the history row too — which is what makes the "history
+  # is not replayed" assertion below meaningful rather than merely untimed.
+  wait_for_file_contains "$TEST_SKILL_DIR/fresh.log" "M-live"
   kill "$w" 2>/dev/null || true
   wait "$w" 2>/dev/null || true
 
@@ -166,11 +144,11 @@ _wait_for_file_contains() {
   # message right after it appears would race the seed and the row would land at
   # or below the initial watermark and never be "new". The watermark file is
   # written once the watcher is ready to receive.
-  _wait_for_file "$wm"
+  wait_for_file "$wm"
   [ -f "$pf" ]
 
   bash "$SCRIPTS/send.sh" team bob alice "M1-delivered" >/dev/null
-  _wait_for_file_contains "$out" "M1-delivered"
+  wait_for_file_contains "$out" "M1-delivered"
   local first_id="$(_max_message_id)"
 
   # Owning session dies (reap it so kill -0 reports gone, not a zombie), then a
@@ -181,7 +159,7 @@ _wait_for_file_contains() {
   bash "$SCRIPTS/send.sh" team bob alice "M2-undelivered" >/dev/null
   local second_id="$(_max_message_id)"
 
-  _wait_for_missing "$pf" || { kill "$w" 2>/dev/null || true; false; }
+  wait_for_missing "$pf" || { kill "$w" 2>/dev/null || true; false; }
   run kill -0 "$w"; [ "$status" -ne 0 ]
   [ "$first_id" != "$second_id" ]
   [ "$(cat "$wm")" = "$first_id" ]
@@ -199,13 +177,13 @@ _wait_for_file_contains() {
     1>&- 2>/dev/null 3>&- &
   local w=$!
 
-  _wait_for_file "$wm"
+  wait_for_file "$wm"
   [ -f "$pf" ]
   local initial="$(cat "$wm")"
 
   bash "$SCRIPTS/send.sh" team bob alice "M-after-closed-stdout" >/dev/null
 
-  _wait_for_missing "$pf" || {
+  wait_for_missing "$pf" || {
     kill "$w" 2>/dev/null || true
     wait "$w" 2>/dev/null || true
     false
@@ -235,9 +213,9 @@ _wait_for_file_contains() {
   local w=$!
   # Wait for the watcher to attach and signal readiness.
   local i
-  for i in 1 2 3 4 5 6 7 8 9 10; do
+  for i in $(seq 1 50); do
     [ -e "$ready" ] && break
-    sleep 0.5
+    sleep 0.1
   done
   [ -e "$ready" ]
   kill "$w" 2>/dev/null || true
@@ -259,7 +237,7 @@ _wait_for_file_contains() {
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-own" "$PROJ" claude-code alice \
     >/dev/null 2>&1 3>&- &
   local w=$! i
-  for i in 1 2 3 4 5 6 7 8 9 10; do [ -e "$ready" ] && break; sleep 0.5; done
+  for i in $(seq 1 50); do [ -e "$ready" ] && break; sleep 0.1; done
   # watch.sh stamps the instance id (composite under an agent ancestor).
   [ "$(cat "$ready")" = "$(_iid sess-own)" ]
   kill "$w" 2>/dev/null || true
@@ -271,7 +249,7 @@ _wait_for_file_contains() {
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-old" "$PROJ" claude-code alice \
     >/dev/null 2>&1 3>&- &
   local w=$! i
-  for i in 1 2 3 4 5 6 7 8 9 10; do [ -e "$ready" ] && break; sleep 0.5; done
+  for i in $(seq 1 50); do [ -e "$ready" ] && break; sleep 0.1; done
   # A successor watcher overwrites the sentinel with its own id.
   printf 'sess-new\n' > "$ready"
   kill "$w" 2>/dev/null || true
@@ -295,7 +273,7 @@ _wait_for_file_contains() {
   local iid
   iid=$(_iid "sess1")
   local pf="$TEST_SKILL_DIR/run/watch.$iid.pid"
-  _wait_for_file "$pf"
+  wait_for_file "$pf"
 
   # Record cc-instance so the dedup path sees "same instance".
   echo "$iid" > "$TEST_SKILL_DIR/run/cc-instance.$$"
@@ -423,7 +401,10 @@ _wait_pidfile() {
   local out="$BATS_TEST_TMPDIR/hc.out"
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-hc" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
   local pid=$!
-  sleep 2                     # > one poll interval; a spinning watcher would re-emit
+  # Stays a fixed sleep, deliberately: the assertion is that NOTHING further is
+  # emitted, and there is no event to poll for when the expected outcome is the
+  # absence of one. Must stay > one poll interval.
+  sleep 2
   kill "$pid" 2>/dev/null || true   # no-op if the healthcheck already exited
   wait "$pid" 2>/dev/null || true
   chmod 644 "$DB" 2>/dev/null || true
@@ -447,7 +428,7 @@ _wait_pidfile() {
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
   local w=$!
-  _wait_for_file "$wm"          # ready to receive (watermark seeded)
+  wait_for_file "$wm"          # ready to receive (watermark seeded)
 
   local n
   for n in 1 2 3 4 5 6 7 8; do
@@ -455,7 +436,7 @@ _wait_pidfile() {
   done
 
   # Wait for the last one to arrive, then assert EVERY message is present.
-  _wait_for_file_contains "$out" "BURST-8" || { kill "$w" 2>/dev/null || true; false; }
+  wait_for_file_contains "$out" "BURST-8" || { kill "$w" 2>/dev/null || true; false; }
   kill "$w" 2>/dev/null || true
   wait "$w" 2>/dev/null || true
 
@@ -470,9 +451,9 @@ _wait_pidfile() {
   local pid=$!
   # A fallback id means a watch.agmsg-*.pid appears under run/ as the watcher arms.
   local i started=0
-  for i in $(seq 1 25); do
+  for i in $(seq 1 50); do
     if ls "$TEST_SKILL_DIR/run"/watch.agmsg-*.pid >/dev/null 2>&1; then started=1; break; fi
-    sleep 0.2
+    sleep 0.1
   done
   kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
   [ "$started" -eq 1 ]
@@ -524,9 +505,9 @@ _wait_pidfile() {
   local pid=$!
   # Folded to empty => a generated fallback id, so a watch.agmsg-*.pid appears.
   local i started=0
-  for i in $(seq 1 25); do
+  for i in $(seq 1 50); do
     if ls "$TEST_SKILL_DIR/run"/watch.agmsg-*.pid >/dev/null 2>&1; then started=1; break; fi
-    sleep 0.2
+    sleep 0.1
   done
   kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
   [ "$started" -eq 1 ]
@@ -556,12 +537,12 @@ _read_at_for_body() {
   # Wait for the watcher to actually attach (watermark file appears) before
   # sending, instead of a fixed sleep — avoids flakiness on a slow/loaded CI
   # runner (2026-07-19 review finding).
-  _wait_for_file "$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark" \
+  wait_for_file "$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark" \
     || { kill "$w" 2>/dev/null || true; false; }
   bash "$SCRIPTS/send.sh" team bob alice "M-readat-check" >/dev/null
 
   # Delivered live...
-  _wait_for_file_contains "$out" "M-readat-check" \
+  wait_for_file_contains "$out" "M-readat-check" \
     || { kill "$w" 2>/dev/null || true; false; }
   # ...and read_at follows shortly after delivery — poll instead of a fixed
   # sleep for the same flakiness reason.
@@ -592,14 +573,14 @@ _read_at_for_body() {
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
     >"$out" 2>/dev/null 3>&- &
   local w=$!
-  _wait_for_file "$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark" \
+  wait_for_file "$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark" \
     || { kill "$w" 2>/dev/null || true; false; }
 
   bash "$SCRIPTS/send.sh" team bob alice "M-broad-guard-alice" >/dev/null
   bash "$SCRIPTS/send.sh" team bob bob "M-broad-guard-bob" >/dev/null
 
   # Both stream through this broad watcher (PAIRS covers every project role)...
-  _wait_for_file_contains "$out" "M-broad-guard-bob" \
+  wait_for_file_contains "$out" "M-broad-guard-bob" \
     || { kill "$w" 2>/dev/null || true; false; }
 
   # ...but only bob's (no exclusive owner) gets marked read by this watcher.
@@ -655,14 +636,14 @@ _despawn_under_herdr() {
     bash "$SCRIPTS/watch.sh" sess-herdr "$PROJ" claude-code alice \
     >/dev/null 2>"$errlog" 3>&- &
   local wpid=$! i
-  for i in 1 2 3 4 5 6 7 8 9 10; do
-    [ -e "$TEST_SKILL_DIR/run/ready.team__alice" ] && break; sleep 0.5
+  for i in $(seq 1 50); do
+    [ -e "$TEST_SKILL_DIR/run/ready.team__alice" ] && break; sleep 0.1
   done
   [ -e "$TEST_SKILL_DIR/run/ready.team__alice" ]
 
   bash "$SCRIPTS/send.sh" team bob alice "ctrl:despawn" >/dev/null
-  for i in 1 2 3 4 5 6 7 8 9 10; do
-    kill -0 "$wpid" 2>/dev/null || break; sleep 0.5
+  for i in $(seq 1 50); do
+    kill -0 "$wpid" 2>/dev/null || break; sleep 0.1
   done
   kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true
 }

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -69,7 +69,14 @@ _max_message_id() {
   # condition the old fixed 1.5s was standing in for.
   wait_for_file "$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark"
   bash "$SCRIPTS/send.sh" team bob alice "M1-before-stop" >/dev/null
+  local m1_id="$(_max_message_id)"
   wait_for_file_contains "$TEST_SKILL_DIR/out1.log" "M1-before-stop"
+  # Kill only once the watermark has been PERSISTED past M1. The stdout line is
+  # not enough: the watcher writes the line first and the mark after, so killing
+  # on the line alone can lose the mark and make the restart re-deliver M1 —
+  # exactly what this test denies. Waiting for the observable event is not the
+  # same as waiting for the durable one.
+  wait_for_file_is "$TEST_SKILL_DIR/run/watch.$(_iid "$sid").watermark" "$m1_id"
   kill "$w1" 2>/dev/null || true
   wait "$w1" 2>/dev/null || true
   grep -q "M1-before-stop" "$TEST_SKILL_DIR/out1.log"


### PR DESCRIPTION
CI speedup, part 2 of 2 (part 1 was #501, sharding). Replaces fixed settling
sleeps in the watcher suites with bounded condition waits, and hoists the
polling helpers that already existed ad hoc in three files into
`tests/test_helper.bash`.

## Measured, not estimated

`sleep` was replaced with a logging shim on `PATH` and the suite re-run, so the
targets came from what actually blocks rather than from what the source says.

**The literal totals are misleading, in two separate ways.**

First, the suite contains ~3400s of `sleep` literals, and **96% of that never
blocks anything**: it is `sleep 30 3>&- &` background stand-ins used as
long-lived fake processes. Deleting them would save nothing.

Second, the shim attributes a sleep by `BATS_TEST_FILENAME`, and that variable
is inherited by the scripts under test. So part of the remaining ~140s is the
watcher's own poll interval (`scripts/watch.sh:488`, `sleep "$INTERVAL"`), not
a test-side wait at all. `test_watch.bats` has **zero** bare `sleep 1` in its
source yet logged 27 of them — every one from `watch.sh`. No amount of
test-side work removes those.

What was actually addressable is therefore a good deal smaller than the raw
number suggests, and the A/B below is the honest measure of it.

## A/B, two rounds, same machine, `git stash` between runs

| | before | after |
|---|---|---|
| `test_delivery.bats` alone, r1 / r2 | 86s / 86s | **75s / 76s** |
| `test_watch.bats` + `test_delivery.bats`, r1 / r2 | 151s / 151s | **135s / 143s** |

Roughly -12s mean on the pair (~8%). Note the "after" column varies (135 vs
143) where "before" does not: fixed sleeps are deterministic, condition waits
finish when the machine lets them. That is the intended trade.

A single non-A/B run early on read 106s against an 86s baseline and looked like
a regression. It was load from a concurrent job. Nothing was reported until the
stash-based A/B was in hand.

## Two negative assertions got stronger, not weaker

Both subscription tests asserted that a message does **not** arrive, after a
fixed `sleep 3` presumed to be "enough poll iterations". That is not an
assertion, it is a guess about timing.

They now wait for a **later** row to be delivered, which proves the watcher has
already scanned past the row the assertion denies. In the static-subscription
test the existing rows would not carry that proof — the alice row precedes the
bob row, so seeing alice says nothing about bob — so a sentinel row is inserted
after bob's and waited on instead.

## A trap worth naming

Tightening a poll from `sleep 0.5` to `sleep 0.1` while leaving the loop at 10
iterations silently cuts the timeout budget from 5s to 1s. That passes locally
and invents a new flake on a loaded runner. Iteration counts were raised to
keep every ceiling exactly where it was. Faster and less tolerant are not the
same change.

## Deliberately left alone

**Two fixed sleeps stay**, each with a comment saying why, so a future sweep
does not "fix" them:

- `test_delivery.bats` — separating two mtimes. The thing being waited on is
  the clock; filesystem timestamp granularity is a whole second on some CI
  filesystems. There is no condition to poll.
- `test_watch.bats` — asserting that nothing further is emitted after one poll
  interval. When the expected outcome is the absence of an event, there is no
  event to wait for.

**`test_codex_bridge_launcher.bats` is not touched here.** It is the most
expensive file per test (8.2s), and none of that is settling waits:

```
sleep 10 3>&- & local parent_a=$!    # stand-in parent
export MOCK_BRIDGE_SLEEP=8           # mock bridge lifetime
...assertions complete in well under 1s...
wait "$parent_a"                     # blocks for the remaining ~10s
```

Per-test timings confirm it: the five tests with `sleep 10`/`sleep 14` parents
run 10.3-11.3s, the five with `sleep 6` run 7.2-7.8s. Duration tracks fixture
lifetime, not work.

Shortening those fixtures is the tempting fix and the dangerous one. The mock
has to outlive the window in which a duplicate dispatcher could appear; if it
exits first, the singleton assertion passes because nothing was left to race —
**a falsely green test, not a flaky one**. Killing the stand-ins after the
assertions instead of waiting them out looks safe, but it changes the teardown
ordering the lock protocol is being exercised under.

Either way it is a scope call rather than a mechanical conversion, so it is
reported rather than taken unilaterally.

## Verification

`bats tests/test_watch.bats tests/test_delivery.bats` — exit 0, 27/27 and
140/140 locally.

---

## What CI caught after the first round (added at head 95da913)

Two failures, only one of them mine.

### The conversion introduced a real race (`test_watch.bats`)

The restart test kills the first watcher, restarts it, and asserts the second
does not re-deliver what the first already streamed. I made it wait for the
message to appear on **stdout** — but `watch.sh` writes the line first and
persists the watermark after. Killing on the line can drop the mark, so the
restart re-delivers, which is precisely what the test denies. It failed on
macOS.

It now waits for the watermark file to hold the delivered row's id. Same
mistake in kind as the global-stop finding: **waiting for the observable event
is not the same as waiting for the durable one.** The `sleep 2` it replaced did
not guarantee the write either — it just usually won the race.

### A test on `main` was asserting nothing (`test_delivery.bats`)

`session-end.sh` only kills a pid whose command line still looks like
`watch.sh` — deliberate protection against pid recycling. The fixture was
`sleep 30`, which can never satisfy that guard, so the kill could never fire.

Measured against `main`'s own code:

```
BEFORE assertion: ps=[sleep 30]        <- alive
! kill -0 "$target_pid" 2>/dev/null    -> passes
AFTER  assertion: ps=[sleep 30]        <- still alive
```

The process is alive on both sides of an assertion that claims it is gone. The
test has never verified the behaviour in its own name.

Converting the wait to a poll is what surfaced it: a single check after a fixed
sleep missed it, repeated checking did not. The fixture is now a real watcher, so the guard is
satisfied and the kill actually happens.

To be exact about what was and was not established: the *behaviour* above is
measured. The mechanism by which `kill -0` reports failure for a live process
in that position is **not** explained here — a reduced bash repro of the same
shape returns 0 three times in a row. Fixing the fixture removes the dependence
on it either way.

Carried in its own commit, per review request.



### Retracted: the helper was not evidence of anything yet

An earlier revision of this description said `wait_for_pid_exit` returning
promptly was the evidence that the process had really died. **That was wrong**,
and review caught it: the helper read *any* failed `kill -0` as "exited". A
failed `kill -0` is ESRCH (dead) or EPERM (alive, but not signalable by us —
sandboxes do this, and a live instance was found in `delivery.sh status` the
same day). So the helper could report "gone" for a running process, which is
the defect the session-end fixture was just fixed for, reintroduced one level
down inside the helper written to prevent it.

Saying "gone" now requires kill(2) and the process table to agree, mirroring
`_agmsg_pid_alive`. The loop also reaps first: an unreaped zombie still answers
`kill -0`, so a process that *had* exited could look alive for the whole
timeout — a separate path to the same class of lie.

`tests/test_wait_helpers.bats` pins this. The EPERM branch cannot be produced
portably in-suite, so the decision rule itself is pinned: with `kill` stubbed to
report "Operation not permitted" and `ps` giving no evidence either way, the
answer must still be ALIVE.

The mechanism behind the original observation is **not** explained. Three
controlled probes — consecutive calls in the test shell, calls in a subshell,
and stderr captured to files — all had `kill -0` return 0 correctly. That it
does not reproduce on demand is itself the argument for not depending on it.