### PR TITLE
fix(liveness): a process you cannot signal is not a process that is gone

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -245,7 +245,7 @@ agmsg_delivery_runtime_status_default() {
       [ -f "$f" ] || continue
       local pid
       pid=$(cat "$f" 2>/dev/null || echo "")
-      if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      if [ -n "$pid" ] && _agmsg_pid_alive "$pid"; then
         alive=$((alive + 1))
       else
         dead=$((dead + 1))
@@ -356,7 +356,7 @@ stop_codex_bridge() {
       pidfile="$RUN_DIR/codex-bridge.$team.$name.pid"
       [ -f "$pidfile" ] || continue
       bpid=$(cat "$pidfile" 2>/dev/null || true)
-      if [ -n "$bpid" ] && kill -0 "$bpid" 2>/dev/null; then
+      if [ -n "$bpid" ] && _agmsg_pid_alive "$bpid"; then
         kill "$bpid" 2>/dev/null && killed=$((killed + 1))
       fi
       # .appserver records which app-server URL the bridge was bound to (the
@@ -380,7 +380,7 @@ EOF
     server_pidfile="$RUN_DIR/codex-app-server.$project_hash.pid"
     if [ -f "$server_pidfile" ]; then
       server_pid="$(cat "$server_pidfile" 2>/dev/null || true)"
-      if [ -n "$server_pid" ] && kill -0 "$server_pid" 2>/dev/null; then
+      if [ -n "$server_pid" ] && _agmsg_pid_alive "$server_pid"; then
         server_cmd="$(compat_get_cmdline "$server_pid" 2>/dev/null || true)"
         case "$server_cmd" in
           *codex*app-server*) kill "$server_pid" 2>/dev/null || true ;;
@@ -499,7 +499,7 @@ kill_all_watchers() {
       [ -f "$f" ] || continue
       local pid cmd
       pid=$(cat "$f" 2>/dev/null || echo "")
-      if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      if [ -n "$pid" ] && _agmsg_pid_alive "$pid"; then
         # Defensive: only kill if the pid's command line still looks like
         # our watch.sh. Defends against pid recycling — a stale pidfile
         # could point at an unrelated process that reused the pid.

--- a/scripts/drivers/types/codex/_delivery.sh
+++ b/scripts/drivers/types/codex/_delivery.sh
@@ -136,7 +136,7 @@ agmsg_delivery_runtime_status() {
       continue
     fi
 
-    if kill -0 "$pid" 2>/dev/null; then
+    if _agmsg_pid_alive "$pid"; then
       echo "Codex bridge: $team/$name alive (pid $pid)"
       any_alive=1
     else

--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -166,7 +166,7 @@ EOF
   pidfile="$RUN_DIR/codex-bridge.$bridge_key.pid"
   if [ -f "$pidfile" ]; then
     bridge_pid=$(cat "$pidfile" 2>/dev/null || true)
-    if [ -n "$bridge_pid" ] && kill -0 "$bridge_pid" 2>/dev/null; then
+    if [ -n "$bridge_pid" ] && _agmsg_pid_alive "$bridge_pid"; then
       exit 0
     fi
   fi

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -398,7 +398,10 @@ while _agmsg_pid_alive "$PARENT_PID"; do
       if [ -f "$pidfile" ]; then
         old_pid=""
         IFS= read -r old_pid < "$pidfile" 2>/dev/null || true
-        [ -n "$old_pid" ] && kill "$old_pid" 2>/dev/null || true
+        # _agmsg_pid_valid, not just non-empty: `kill 0` signals this
+        # launcher's own process group, so a corrupt pidfile would tear down
+        # the dispatcher and its siblings instead of one stale bridge.
+        _agmsg_pid_valid "$old_pid" && kill "$old_pid" 2>/dev/null || true
       fi
       exit 0
     fi
@@ -415,7 +418,7 @@ while _agmsg_pid_alive "$PARENT_PID"; do
     if [ -f "$pidfile" ]; then
       old_pid=""
       IFS= read -r old_pid < "$pidfile" 2>/dev/null || true
-      [ -n "$old_pid" ] && kill "$old_pid" 2>/dev/null || true
+      _agmsg_pid_valid "$old_pid" && kill "$old_pid" 2>/dev/null || true
     fi
     exec "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID" "$ROLE_PAIR"
   fi

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -26,6 +26,11 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 RUN_DIR="$SKILL_DIR/run"
 # shellcheck source=../../../lib/hash.sh
 source "$SCRIPT_DIR/../../../lib/hash.sh"
+# _agmsg_pid_alive: every lifetime and lock-owner check below goes through it.
+# Sourced explicitly rather than relied on transitively through role-session.sh,
+# which only pulls it in when actas-lock.sh has not already been loaded.
+# shellcheck source=../../../lib/instance-id.sh
+source "$SCRIPT_DIR/../../../lib/instance-id.sh"
 PROJECT_HASH="$(printf '%s' "$PROJECT" | agmsg_sha1)"
 REQUEST_FILE="$RUN_DIR/codex-bridge-request.$PROJECT_HASH"
 DISPATCHER_LOCK_RESOURCE="codex-dispatcher:$PROJECT_HASH"
@@ -56,7 +61,7 @@ mkdir -p "$RUN_DIR"
 # to start first. Tests/older launchers without the sidecar retain parent-PID
 # fallback behavior.
 LIFETIME_PID="$(cat "$SERVER_PID_FILE" 2>/dev/null || true)"
-if [ -z "$LIFETIME_PID" ] || ! kill -0 "$LIFETIME_PID" 2>/dev/null; then
+if [ -z "$LIFETIME_PID" ] || ! _agmsg_pid_alive "$LIFETIME_PID"; then
   LIFETIME_PID="$PARENT_PID"
 fi
 
@@ -89,7 +94,7 @@ acquire_runtime_lock() {
       trap 'exit 0' INT TERM
       return 0
     fi
-    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
+    if [ -n "$owner" ] && _agmsg_pid_alive "$owner"; then
       return 1
     fi
     if [ -n "${AGMSG_TEST_DISPATCHER_STALE_BARRIER:-}" ]; then
@@ -112,7 +117,7 @@ acquire_runtime_lock() {
       trap 'exit 0' INT TERM
       return 0
     fi
-    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
+    if [ -n "$owner" ] && _agmsg_pid_alive "$owner"; then
       return 1
     fi
     sleep 0.05
@@ -237,7 +242,7 @@ if [ -z "$ROLE_PAIR" ]; then
   acquire_runtime_lock "$DISPATCHER_LOCK_RESOURCE" || exit 0
   known_pairs=""
   while agmsg_runtime_lock_verify "$DISPATCHER_LOCK_RESOURCE" "$$" \
-    && kill -0 "$LIFETIME_PID" 2>/dev/null; do
+    && _agmsg_pid_alive "$LIFETIME_PID"; do
     refresh_identity_cache
     current_pairs="$IDENTITY_CACHE"
     [ "$IDENTITY_CACHE_FRESH" = "1" ] || poll_reset
@@ -283,7 +288,7 @@ acquire_runtime_lock "$CHILD_LOCK_RESOURCE" || exit 0
 # its registration disappears, so a re-registered role gets a fresh child.
 ids=""
 startup_attempts=0
-while kill -0 "$PARENT_PID" 2>/dev/null && [ "$startup_attempts" -lt 20 ]; do
+while _agmsg_pid_alive "$PARENT_PID" && [ "$startup_attempts" -lt 20 ]; do
   ids="$(resolve_identity || true)"
   [ -n "$ids" ] && break
   startup_attempts=$((startup_attempts + 1))
@@ -333,7 +338,7 @@ ids="$safe_ids"
 # A role record may be written by actas later in this same first turn. An empty
 # safe set is therefore transient, not terminal: retry while the parent lives.
 if [ -z "$ids" ]; then
-  kill -0 "$PARENT_PID" 2>/dev/null || exit 0
+  _agmsg_pid_alive "$PARENT_PID" || exit 0
   sleep 0.3
   exec "$0" "$TYPE" "$PROJECT" "$APP_SERVER" "$PARENT_PID" "$ROLE_PAIR"
 fi
@@ -373,7 +378,7 @@ else
 fi
 
 deregistered_ticks=0
-while kill -0 "$PARENT_PID" 2>/dev/null; do
+while _agmsg_pid_alive "$PARENT_PID"; do
   # Resolved once per iteration and threaded through the fingerprint, so a tick
   # runs identities.sh once rather than twice — and usually not at all, because
   # the resolve is served from the mtime-guarded cache.
@@ -451,7 +456,7 @@ EOF
   if [ -f "$pidfile" ]; then
     bridge_pid=""
     IFS= read -r bridge_pid < "$pidfile" 2>/dev/null || true
-    if [ -n "$bridge_pid" ] && kill -0 "$bridge_pid" 2>/dev/null; then
+    if [ -n "$bridge_pid" ] && _agmsg_pid_alive "$bridge_pid"; then
       # Reuse only when the live bridge is bound to the CURRENT app-server. A
       # codex upgrade makes codex-monitor.sh kill the stale app-server and start a
       # fresh one on a new port (#237); a bridge still bound to the old URL stays

--- a/scripts/drivers/types/codex/codex-monitor.sh
+++ b/scripts/drivers/types/codex/codex-monitor.sh
@@ -14,6 +14,9 @@ RUN_DIR="$SKILL_DIR/run"
 source "$SCRIPT_DIR/../../../lib/hash.sh"
 # shellcheck source=../../../lib/compat.sh
 source "$SCRIPT_DIR/../../../lib/compat.sh"
+# _agmsg_pid_alive for the app-server reuse decision below.
+# shellcheck source=../../../lib/instance-id.sh
+source "$SCRIPT_DIR/../../../lib/instance-id.sh"
 
 PROJECT="$(pwd)"
 SOCKET_PATH=""
@@ -122,7 +125,7 @@ if [ -f "$PORT_FILE" ] && [ -f "$SERVER_PID" ]; then
   # so a foreign process that grabbed the same port after ours died is not
   # mistaken for the bridge app-server.
   if [ -n "$existing_port" ] && [ -n "$existing_pid" ] \
-    && kill -0 "$existing_pid" 2>/dev/null && port_alive "$existing_port"; then
+    && _agmsg_pid_alive "$existing_pid" && port_alive "$existing_port"; then
     # Confirm the recorded pid is actually OUR codex app-server before trusting OR
     # killing it: a recycled pid could belong to an unrelated process while the
     # recorded port happens to answer via something else. Only reuse/kill when the
@@ -168,7 +171,7 @@ if [ -z "$PORT" ]; then
     # Stop waiting the moment the app-server exits (e.g. a codex release dropped
     # `app-server --listen ws://`): no point burning the full timeout before we
     # fail open.
-    kill -0 "$server_bg" 2>/dev/null || break
+    _agmsg_pid_alive "$server_bg" || break
     sleep 0.1
   done
   if [ -z "$PORT" ]; then

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -64,8 +64,13 @@ _AGMSG_INSTANCE_ID_SH=1
 # asking about liveness first can still refuse the values that do not name one
 # process.
 _agmsg_pid_valid() {
-  local pid="${1:-}"
+  local pid="${1:-}" max=2147483647
   case "$pid" in ''|*[!0-9]*|0*) return 1 ;; esac
+  # The upper bound is the platform's, not one number. A Windows process id is a
+  # DWORD, and the liveness path there queries the native process table via
+  # tasklist rather than kill(1)'s signed pid_t — applying the POSIX bound to it
+  # would call a legitimate native pid dead and its live watcher stale.
+  case "${MSYSTEM:-}" in MINGW*|MSYS*|CLANGARM*) max=4294967295 ;; esac
   # And it has to fit in pid_t. Past INT32_MAX, kill(1) rejects the ARGUMENT
   # ("not a pid or valid job spec") rather than reporting ESRCH — and
   # _agmsg_pid_alive reads every non-ESRCH failure as alive, so an oversized
@@ -77,7 +82,7 @@ _agmsg_pid_valid() {
   # zero, so at equal length a STRING compare is the numeric one. No `$(( ))`
   # and no `-gt` on the untrusted value: both evaluate what they are given.
   [ "${#pid}" -le 10 ] || return 1
-  if [ "${#pid}" -eq 10 ] && [ "$pid" \> "2147483647" ]; then return 1; fi
+  if [ "${#pid}" -eq 10 ] && [ "$pid" \> "$max" ]; then return 1; fi
   return 0
 }
 

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -33,27 +33,48 @@
 [ -n "${_AGMSG_INSTANCE_ID_SH:-}" ] && return 0
 _AGMSG_INSTANCE_ID_SH=1
 
-# Cross-platform pid liveness check. Git Bash's kill(1) only sees MSYS2/Cygwin
-# PIDs; native Windows processes (Claude Code, etc.) are invisible to it, so
-# kill -0 always returns false for them (#134). On Windows we fall back to
-# tasklist.exe which queries the native process table.
+# Cross-platform pid liveness check, and the ONLY one any shipped script should
+# use. A bare `kill -0 "$pid" 2>/dev/null` is not a liveness check: it answers
+# "can I signal this", and the two differ exactly where it matters.
+#
+# Git Bash's kill(1) only sees MSYS2/Cygwin PIDs; native Windows processes
+# (Claude Code, etc.) are invisible to it, so kill -0 always returns false for
+# them (#134). On Windows we fall back to tasklist.exe, which queries the native
+# process table.
+#
+# Everywhere else, saying "dead" requires kill(2) and ps to agree. A failed
+# `kill -0` is ESRCH (dead) or EPERM (alive, but not signalable by us — a
+# sandbox does exactly this). Reading only the exit status reports a live
+# process as gone, which is how a running watcher or bridge gets printed as a
+# stale pidfile, how a live lock owner gets its lock reclaimed out from under
+# it, and how a second app-server gets started beside the first.
 _agmsg_pid_alive() {
-  local pid="$1"
+  local pid="$1" err stat
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
   case "${MSYSTEM:-}" in
     MINGW*|MSYS*|CLANGARM*)
       MSYS_NO_PATHCONV=1 tasklist /FI "PID eq $pid" 2>/dev/null | grep -q "$pid"
       return $?
       ;;
   esac
-  # A non-zero `kill -0` is ESRCH (dead) or EPERM (alive but unsignalable under
-  # the sandbox). Only ESRCH is dead. `export LC_ALL=C` (not a bare prefix, which
-  # misses the builtin on bash 3.2) forces English error text for the match.
-  local err
+  # Fast path, and the common answer: the builtin, no fork. Callers poll this in
+  # loops whose whole point is to be fork-free (#466), so the alive case must
+  # not cost a subshell.
+  kill -0 "$pid" 2>/dev/null && return 0
+  # Only now pay for the error text. `export LC_ALL=C` (not a bare prefix, which
+  # misses the builtin on bash 3.2) forces English for the match below.
   err="$(export LC_ALL=C; kill -0 "$pid" 2>&1)" && return 0
   case "$err" in
-    *[Nn]'o such process'*) return 1 ;;
-    *) return 0 ;;
+    *[Nn]'o such process'*) ;;
+    *) return 0 ;;   # EPERM and anything unrecognised mean "assume alive"
   esac
+  # kill(2) says gone. ps does not depend on signalling permission at all, so
+  # requiring it to agree is what keeps a sandbox from turning "cannot signal"
+  # into "not running".
+  stat="$(ps -o stat= -p "$pid" 2>/dev/null | tr -d ' ')"
+  [ -n "$stat" ] || return 1
+  case "$stat" in Z*) return 1 ;; esac   # exited, just not reaped yet
+  return 0
 }
 
 # Compose from an explicit pid. Bare sid when pid is empty/non-numeric.

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -71,12 +71,15 @@ _agmsg_pid_valid() {
   # tasklist rather than kill(1)'s signed pid_t — applying the POSIX bound to it
   # would call a legitimate native pid dead and its live watcher stale.
   case "${MSYSTEM:-}" in MINGW*|MSYS*|CLANGARM*) max=4294967295 ;; esac
-  # And it has to fit in pid_t. Past INT32_MAX, kill(1) rejects the ARGUMENT
-  # ("not a pid or valid job spec") rather than reporting ESRCH — and
+  # And it has to fit whichever of those the platform uses. The POSIX ceiling is
+  # what makes the rest of this library safe: past INT32_MAX, kill(1) rejects the
+  # ARGUMENT ("not a pid or valid job spec") rather than reporting ESRCH — and
   # _agmsg_pid_alive reads every non-ESRCH failure as alive, so an oversized
-  # value in a pidfile would read as alive forever: its lock never reclaimed,
-  # its bridge never restarted, its status line permanently wrong. Bounding the
-  # input is what keeps "not ESRCH" meaning "EPERM".
+  # value in a pidfile would read as alive forever: its lock never reclaimed, its
+  # bridge never restarted, its status line permanently wrong. Bounding the input
+  # is what keeps "not ESRCH" meaning "EPERM". The Windows ceiling is a plain
+  # range check on the value tasklist will be asked about; nothing there parses
+  # it as a signal target.
   #
   # Length is a builtin, and the digits are already known to have no leading
   # zero, so at equal length a STRING compare is the numeric one. No `$(( ))`

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -48,9 +48,29 @@ _AGMSG_INSTANCE_ID_SH=1
 # process as gone, which is how a running watcher or bridge gets printed as a
 # stale pidfile, how a live lock owner gets its lock reclaimed out from under
 # it, and how a second app-server gets started beside the first.
+# True iff <value> is a plain positive decimal pid, i.e. a value that names one
+# process when handed to kill(1).
+#
+# Digits-only is NOT enough. `kill -0 0` does not ask about pid 0 — 0 means "the
+# caller's own process group" — so it succeeds, and a caller that then runs
+# `kill "$pid"` TERMs the whole group, itself included. A corrupt or hostile
+# pidfile holding 0 is all it takes. A leading zero is rejected for a related
+# reason: nothing here writes one, and kill(1) may read it as octal, so it names
+# an unpredictable process.
+#
+# Patterns only, never `$(( ))`: arithmetic evaluation runs its argument.
+#
+# Split out from _agmsg_pid_alive so a caller that kills a recorded pid WITHOUT
+# asking about liveness first can still refuse the values that do not name one
+# process.
+_agmsg_pid_valid() {
+  case "${1:-}" in ''|*[!0-9]*|0*) return 1 ;; esac
+  return 0
+}
+
 _agmsg_pid_alive() {
   local pid="$1" err stat
-  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  _agmsg_pid_valid "$pid" || return 1
   case "${MSYSTEM:-}" in
     MINGW*|MSYS*|CLANGARM*)
       MSYS_NO_PATHCONV=1 tasklist /FI "PID eq $pid" 2>/dev/null | grep -q "$pid"
@@ -296,7 +316,7 @@ agmsg_reap_orphan_grok_watchers() {
   # Default IFS so `read` splits the leading pid column off the rest as args; an
   # empty IFS would put the whole line in $pid and match nothing.
   while read -r pid args; do
-    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    _agmsg_pid_valid "$pid" || continue
     [ -n "${args:-}" ] || continue
     [ "$pid" = "$self" ] && continue
     agmsg_args_is_grok_watcher "$args" "$project" || continue

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -64,7 +64,20 @@ _AGMSG_INSTANCE_ID_SH=1
 # asking about liveness first can still refuse the values that do not name one
 # process.
 _agmsg_pid_valid() {
-  case "${1:-}" in ''|*[!0-9]*|0*) return 1 ;; esac
+  local pid="${1:-}"
+  case "$pid" in ''|*[!0-9]*|0*) return 1 ;; esac
+  # And it has to fit in pid_t. Past INT32_MAX, kill(1) rejects the ARGUMENT
+  # ("not a pid or valid job spec") rather than reporting ESRCH — and
+  # _agmsg_pid_alive reads every non-ESRCH failure as alive, so an oversized
+  # value in a pidfile would read as alive forever: its lock never reclaimed,
+  # its bridge never restarted, its status line permanently wrong. Bounding the
+  # input is what keeps "not ESRCH" meaning "EPERM".
+  #
+  # Length is a builtin, and the digits are already known to have no leading
+  # zero, so at equal length a STRING compare is the numeric one. No `$(( ))`
+  # and no `-gt` on the untrusted value: both evaluate what they are given.
+  [ "${#pid}" -le 10 ] || return 1
+  if [ "${#pid}" -eq 10 ] && [ "$pid" \> "2147483647" ]; then return 1; fi
   return 0
 }
 

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -39,6 +39,13 @@
 # shellcheck disable=SC1091
 . "$SKILL_DIR/scripts/lib/storage.sh"
 
+# _agmsg_pid_alive: the EPERM-aware liveness check both the ancestor walk and the
+# marker GC below need. Sourced here rather than left to the caller — a missing
+# definition used to mean the walk fell back to a bare `kill -0`, which reports a
+# live agent as gone under a sandbox. Double-source guarded.
+# shellcheck disable=SC1091
+. "$SKILL_DIR/scripts/lib/instance-id.sh"
+
 _agmsg_run_dir() { printf '%s/run' "$SKILL_DIR"; }
 
 # Canonicalize a directory path by resolving symlinks to its physical location.
@@ -252,7 +259,7 @@ _agmsg_agent_binaries() {
 agmsg_pid_is_agent() {
   local pid="$1" type="$2"
   [ -n "$pid" ] || return 1
-  kill -0 "$pid" 2>/dev/null || return 1
+  _agmsg_pid_alive "$pid" || return 1
   local binaries comm cmdline first base bin
   binaries=$(_agmsg_agent_binaries "$type")
   comm=$(compat_get_comm "$pid" 2>/dev/null || true)

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -170,6 +170,52 @@ settings_file() {
   [[ "$output" == *"watch processes:"* ]]
 }
 
+# A pid that exists but this user cannot signal, so `kill -0` fails with EPERM
+# rather than ESRCH. pid 1 is that on any normal desktop or CI runner; when the
+# suite runs as root, or in a container where pid 1 is ours, there is no such
+# pid to borrow and the distinction under test cannot be staged.
+eperm_pid() {
+  local err
+  # An `A && skip` list is a FAILING command on exactly the run we want, which
+  # bats' errexit turns into a test failure instead of a skip.
+  if kill -0 1 2>/dev/null; then skip "pid 1 is signalable here; no EPERM fixture available"; fi
+  # `|| true`: the substitution's status is the failing kill, and a bare
+  # assignment carrying it trips errexit before the case can decide anything.
+  err="$(export LC_ALL=C; kill -0 1 2>&1)" || true
+  case "$err" in
+    *[Nn]'o such process'*) skip "pid 1 does not exist here" ;;
+  esac
+  echo 1
+}
+
+@test "delivery status: a live but unsignalable watcher is not counted as stale" {
+  local pid
+  pid="$(eperm_pid)"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT" >/dev/null
+  printf '%s\n' "$pid" > "$TEST_SKILL_DIR/run/watch.eperm-session.pid"
+  run bash "$SCRIPTS/delivery.sh" status claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  # `kill -0` answers "can I signal this", not "is this running". Under a
+  # sandbox every watcher fails it, and reading the exit status alone printed
+  # every live watcher as a stale pidfile.
+  [[ "$output" == *"watch processes: 1 alive, 0 stale pidfiles"* ]]
+}
+
+@test "delivery status: a genuinely dead watcher is still counted as stale" {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT" >/dev/null
+  local dead
+  dead="$(bash -c 'echo $$')"
+  wait_for_pid_exit "$dead" || true
+  printf '%s\n' "$dead" > "$TEST_SKILL_DIR/run/watch.dead-session.pid"
+  run bash "$SCRIPTS/delivery.sh" status claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  # The other half of the fix: treating EPERM as alive must not make everything
+  # look alive.
+  [[ "$output" == *"watch processes: 0 alive, 1 stale pidfiles"* ]]
+}
+
 @test "delivery status: derives 'turn' from settings with Stop only" {
   bash "$SCRIPTS/delivery.sh" set turn claude-code "$TEST_PROJECT" >/dev/null
   run bash "$SCRIPTS/delivery.sh" status claude-code "$TEST_PROJECT"

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -506,6 +506,26 @@ require_eperm_pid() {
   run _agmsg_pid_valid 9999999;    [ "$status" -eq 0 ]
 }
 
+@test "instance-id: the pid ceiling is the platform's, not one number" {
+  # A Windows process id is a DWORD, and liveness there reads the native process
+  # table through tasklist rather than kill(1)'s signed pid_t. Applying the
+  # POSIX ceiling to it would call a legitimate native pid dead and its live
+  # watcher stale. Only the bound depends on MSYSTEM, so both sides are
+  # checkable from either host.
+  run env MSYSTEM=MINGW64 bash -c \
+    'SKILL_DIR="'"$SKILL_DIR"'"; . "$SKILL_DIR/scripts/lib/instance-id.sh"
+     _agmsg_pid_valid 2147483648 || exit 1
+     _agmsg_pid_valid 4294967295 || exit 2
+     _agmsg_pid_valid 4294967296 && exit 3
+     _agmsg_pid_valid 0 && exit 4
+     exit 0'
+  [ "$status" -eq 0 ]
+
+  # POSIX keeps the signed pid_t ceiling.
+  run _agmsg_pid_valid 2147483648; [ "$status" -ne 0 ]
+  run _agmsg_pid_valid 4294967295; [ "$status" -ne 0 ]
+}
+
 @test "instance-id: liveness answers alive on the builtin, before any subshell" {
   # The launcher polls liveness in loops that were deliberately made fork-free
   # (#466/#496). Routing them through a helper is only acceptable while the

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -152,16 +152,39 @@ teardown() { teardown_test_env; }
   _agmsg_pid_alive 12345
 }
 
+# A pid that is genuinely gone, so the real ps agrees with the stubbed kill.
+# Stubbing kill alone stopped being enough once "dead" required ps to agree:
+# a made-up number like 999 IS a running process on some hosts, which is
+# exactly the case the cross-check exists to catch.
+gone_pid() {
+  local pid
+  pid="$(bash -c 'echo $$')"
+  wait_for_pid_exit "$pid" || true
+  echo "$pid"
+}
+
 @test "pid_alive: ESRCH 'No such process' reads as dead" {
   skip_on_windows "POSIX kill path; Windows uses tasklist (#134)"
-  kill() { echo "bash: kill: (999) - No such process" >&2; return 1; }
-  ! _agmsg_pid_alive 999
+  local gone; gone="$(gone_pid)"
+  kill() { echo "bash: kill: ($gone) - No such process" >&2; return 1; }
+  ! _agmsg_pid_alive "$gone"
 }
 
 @test "pid_alive: lowercase 'no such process' (zsh wording) also reads as dead" {
   skip_on_windows "POSIX kill path; Windows uses tasklist (#134)"
-  kill() { echo "kill: (999) - no such process" >&2; return 1; }
-  ! _agmsg_pid_alive 999
+  local gone; gone="$(gone_pid)"
+  kill() { echo "kill: ($gone) - no such process" >&2; return 1; }
+  ! _agmsg_pid_alive "$gone"
+}
+
+@test "pid_alive: ESRCH is not enough while ps still shows the process" {
+  skip_on_windows "POSIX kill path; Windows uses tasklist (#134)"
+  # kill(2) and ps must agree before a pid is called dead. ps does not depend on
+  # signalling permission at all, so it is what stops "cannot signal" from
+  # becoming "not running" — and calling a live pid dead is how a running
+  # owner's lock gets reclaimed out from under it.
+  kill() { echo "bash: kill: ($$) - No such process" >&2; return 1; }
+  _agmsg_pid_alive $$
 }
 
 @test "pid_alive: EPERM 'Operation not permitted' reads as alive (sandbox)" {
@@ -459,6 +482,28 @@ require_eperm_pid() {
   run _agmsg_pid_valid $$;   [ "$status" -eq 0 ]
   run _agmsg_pid_valid "";   [ "$status" -ne 0 ]
   run _agmsg_pid_valid "1x"; [ "$status" -ne 0 ]
+}
+
+@test "instance-id: a pid too large for pid_t is dead, not alive forever" {
+  # Past INT32_MAX kill(1) rejects the ARGUMENT instead of reporting ESRCH, and
+  # everything that is not ESRCH is read as EPERM, i.e. alive. Unbounded, an
+  # oversized value in a pidfile reads as alive forever: its lock is never
+  # reclaimed and its bridge is never restarted.
+  local err
+  err="$(export LC_ALL=C; kill -0 2147483648 2>&1)" || true
+  case "$err" in
+    *[Nn]'o such process'*) skip "kill treats out-of-range pids as ESRCH here" ;;
+  esac
+  local bad
+  for bad in 2147483648 4294967296 999999999999999999999; do
+    run _agmsg_pid_valid "$bad"
+    [ "$status" -ne 0 ] || { echo "_agmsg_pid_valid $bad accepted it"; false; }
+    run _agmsg_pid_alive "$bad"
+    [ "$status" -ne 0 ] || { echo "_agmsg_pid_alive $bad reported alive"; false; }
+  done
+  # The boundary itself is a legal pid value and must still be accepted.
+  run _agmsg_pid_valid 2147483647; [ "$status" -eq 0 ]
+  run _agmsg_pid_valid 9999999;    [ "$status" -eq 0 ]
 }
 
 @test "instance-id: liveness answers alive on the builtin, before any subshell" {

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -443,6 +443,24 @@ require_eperm_pid() {
   run _agmsg_pid_alive $$;     [ "$status" -eq 0 ]
 }
 
+@test "instance-id: 0 is not a live pid, it is this process group" {
+  # `kill -0 0` SUCCEEDS: 0 addresses the caller's own process group, not pid 0.
+  # A digits-only check therefore called 0 alive, and callers kill whatever this
+  # reports alive — `kill 0` TERMs the group, the caller included. All it takes
+  # is a pidfile holding 0.
+  run kill -0 0; [ "$status" -eq 0 ]
+  local bad
+  for bad in 0 00 000 0123; do
+    run _agmsg_pid_alive "$bad"
+    [ "$status" -ne 0 ] || { echo "_agmsg_pid_alive $bad reported alive"; false; }
+    run _agmsg_pid_valid "$bad"
+    [ "$status" -ne 0 ] || { echo "_agmsg_pid_valid $bad accepted it"; false; }
+  done
+  run _agmsg_pid_valid $$;   [ "$status" -eq 0 ]
+  run _agmsg_pid_valid "";   [ "$status" -ne 0 ]
+  run _agmsg_pid_valid "1x"; [ "$status" -ne 0 ]
+}
+
 @test "instance-id: liveness answers alive on the builtin, before any subshell" {
   # The launcher polls liveness in loops that were deliberately made fork-free
   # (#466/#496). Routing them through a helper is only acceptable while the

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -406,3 +406,65 @@ teardown() { teardown_test_env; }
   [ "$status" -eq 0 ]
   kill -0 $$
 }
+
+# --- liveness: "can I signal this" is not "is this running" ---
+
+# A pid that exists but this user cannot signal, so `kill -0` fails with EPERM
+# rather than ESRCH. pid 1 is that on any normal desktop or CI runner; when the
+# suite runs as root, or in a container where pid 1 is ours, there is no such
+# pid to borrow and the distinction under test cannot be staged.
+require_eperm_pid() {
+  local err
+  # An `A && skip` list is a FAILING command on exactly the run we want, which
+  # bats' errexit turns into a test failure instead of a skip.
+  if kill -0 1 2>/dev/null; then skip "pid 1 is signalable here; no EPERM fixture available"; fi
+  # `|| true`: the substitution's status is the failing kill, and a bare
+  # assignment carrying it trips errexit before the case can decide anything.
+  err="$(export LC_ALL=C; kill -0 1 2>&1)" || true
+  case "$err" in
+    *[Nn]'o such process'*) skip "pid 1 does not exist here" ;;
+  esac
+}
+
+@test "instance-id: an unsignalable pid is alive, not dead" {
+  require_eperm_pid
+  run _agmsg_pid_alive 1
+  [ "$status" -eq 0 ]
+}
+
+@test "instance-id: liveness rejects a dead pid, and anything that is not a pid" {
+  local dead
+  dead="$(bash -c 'echo $$')"
+  wait_for_pid_exit "$dead" || true
+  run _agmsg_pid_alive "$dead"; [ "$status" -ne 0 ]
+  run _agmsg_pid_alive "";     [ "$status" -ne 0 ]
+  run _agmsg_pid_alive "abc";  [ "$status" -ne 0 ]
+  run _agmsg_pid_alive "12x";  [ "$status" -ne 0 ]
+  run _agmsg_pid_alive $$;     [ "$status" -eq 0 ]
+}
+
+@test "instance-id: liveness answers alive on the builtin, before any subshell" {
+  # The launcher polls liveness in loops that were deliberately made fork-free
+  # (#466/#496). Routing them through a helper is only acceptable while the
+  # common answer — alive — is still decided by the builtin, so the cheap check
+  # has to come first and has to be able to return on its own.
+  local body fast slow
+  body="$(declare -f _agmsg_pid_alive)"
+  fast="$(printf '%s\n' "$body" | grep -n 'kill -0 .*&& return 0;$' | grep -v '\$(' | head -1 | cut -d: -f1)"
+  slow="$(printf '%s\n' "$body" | grep -n 'kill -0 .*2>&1' | head -1 | cut -d: -f1)"
+  [ -n "$fast" ]
+  [ -n "$slow" ]
+  [ "$fast" -lt "$slow" ]
+}
+
+@test "no shipped script decides liveness with a bare kill -0" {
+  # #500's lesson: a partially-hardened file reads as a fixed one. Every
+  # liveness check must go through _agmsg_pid_alive, which is EPERM-aware and
+  # cross-checks ps; instance-id.sh is where that check is implemented, so it
+  # is the one file allowed to call kill -0 directly.
+  local offenders
+  offenders="$(cd "$BATS_TEST_DIRNAME/.." && grep -rn -e 'kill -0' -e 'kill -s 0' scripts bin 2>/dev/null \
+    | grep -v '^scripts/lib/instance-id.sh:' \
+    | grep -v ':[0-9]*: *#' || true)"
+  [ -z "$offenders" ] || { echo "$offenders"; false; }
+}

--- a/tests/test_resolve_project.bats
+++ b/tests/test_resolve_project.bats
@@ -226,14 +226,28 @@ JSON
   [ ! -f "$(agmsg_project_marker_path 4242)" ]
 }
 
+@test "marker-gc: sourcing resolve-project.sh alone provides the liveness helper" {
+  # The ancestor walk and the marker GC both decide liveness, and a bare
+  # `kill -0` calls a live-but-unsignalable agent dead. Leaving the helper to
+  # whoever sourced this file is what let that happen, so it is pulled in here.
+  run bash -c '
+    export SKILL_DIR="'"$SKILL_DIR"'"
+    source "$SKILL_DIR/scripts/lib/resolve-project.sh"
+    declare -F _agmsg_pid_alive >/dev/null
+  '
+  [ "$status" -eq 0 ]
+}
+
 @test "marker-gc: skips (keeps marker) when _agmsg_pid_alive is unavailable" {
-  # Guard: without the helper, GC must skip rather than `|| rm -f` a live marker.
-  # Isolated shell sources ONLY resolve-project.sh, so the helper is truly absent.
+  # Defense in depth, now that the helper is sourced above: a caller that unsets
+  # or shadows it must still not reach `|| rm -f`, where a command-not-found
+  # would delete a live agent's marker. Unset it to reach the guard.
   agmsg_write_project_marker 4242 "$ROOT"
   run bash -c '
     export SKILL_DIR="'"$SKILL_DIR"'"
     source "$SKILL_DIR/scripts/lib/resolve-project.sh"
-    declare -F _agmsg_pid_alive >/dev/null && { echo "helper unexpectedly present"; exit 2; }
+    unset -f _agmsg_pid_alive
+    declare -F _agmsg_pid_alive >/dev/null && { echo "helper still defined"; exit 2; }
     agmsg_marker_gc_stale
   '
   [ "$status" -eq 0 ]


### PR DESCRIPTION
`delivery.sh status` reports a running bridge and app-server as stale pidfiles under a sandbox. `kill -0` answers "can I signal this", not "is this running", and the two differ exactly where it matters: a failed `kill -0` is ESRCH (gone) **or EPERM (alive, but not signalable by us)**. Every shipped caller read the exit status directly.

The misreport is the mild symptom. The same check decides whether to start a second bridge, whether to reuse the app-server, and whether a lock's owner is dead enough to reclaim.

## What changed

`_agmsg_pid_alive` in `scripts/lib/instance-id.sh` already read the ESRCH/EPERM distinction — it was simply not what anything called. It now also cross-checks `ps`, per the rule #503 settled on for the test helper, so concluding "dead" needs a source that does not depend on signalling permission at all. A fork-free fast path was added first: callers poll this in loops that exist to be fork-free (#466/#496), so the common answer must not cost a subshell.

All **17** liveness sites now go through it. `instance-id.sh` is sourced where it was reachable only transitively (`codex-bridge-launcher.sh`, via a conditional branch of `role-session.sh`) or not at all (`codex-monitor.sh`, `resolve-project.sh`).

| file | sites | what a false "dead" did |
|---|---|---|
| `scripts/delivery.sh` | 4 | printed live watchers as stale; deleted a live watcher's pidfile without killing it; skipped bridge and app-server teardown |
| `codex/_delivery.sh` | 1 | **the reported symptom** — "Codex bridge: … stale pidfile (pid N not running)" for a live bridge |
| `codex/_session-start.sh` | 1 | launched a second bridge beside the running one |
| `codex/codex-monitor.sh` | 2 | started a second app-server; broke the startup wait early |
| `codex/codex-bridge-launcher.sh` | 8 | reclaimed a **live** owner's lock — the #485 duplicate-children shape — and bound child lifetime to the wrong pid |
| `scripts/lib/resolve-project.sh` | 1 | the ancestor walk stopped trusting the real session process |

`resolve-project.sh` was the #500 shape exactly: its marker GC already used the EPERM-aware helper (behind a `declare -F` guard), while `agmsg_pid_is_agent` twelve lines up still used a bare `kill -0`.

## What a pid is allowed to be

Review turned the validation into its own concern, `_agmsg_pid_valid`, because each accepted-but-wrong value fails differently and none of them fail safe:

- **`0` is not a pid.** `kill -0 0` succeeds because 0 addresses the *caller's own process group*. A digits-only check called it alive, and callers kill what liveness reports alive — `kill 0` TERMs the group, the caller included. A corrupt pidfile holding `0` was all it took. Leading zeros go too: nothing writes them and `kill(1)` may read them as octal.
- **Above the platform ceiling, `kill(1)` rejects the *argument*** ("not a pid or valid job spec") instead of reporting ESRCH — and everything that is not ESRCH reads as EPERM, i.e. alive. Unbounded, an oversized value read as alive *forever*: its lock never reclaimed, its bridge never restarted. Bounding the input is what keeps "not ESRCH" meaning "EPERM".
- **The ceiling is the platform's, not one number.** A Windows process id is a DWORD and liveness there reads the native process table through `tasklist`, not `kill(1)`'s signed `pid_t`; the POSIX bound would call a legitimate native pid dead. POSIX gets INT32_MAX, MSYSTEM gets DWORD max.

Comparisons are patterns and `${#pid}` only — never `$(( ))` or `-gt` on the untrusted value, both of which evaluate what they are given.

`_agmsg_pid_valid` also gates the two launcher sites that kill a recorded pid *without* asking about liveness first (`[ -n "$old_pid" ] && kill ...`), which the helper alone would not have covered. Every other `kill` of a file-sourced pid was already behind `_agmsg_pid_alive`; the one remaining (`codex-monitor.sh`'s `kill "$server_bg"`) is our own child from `$!`, not a file.

## Tests

- **pid 1** is a real live process this user cannot signal, so it stages EPERM directly rather than simulating it. The tests skip where no such pid exists (running as root, or a container where pid 1 is ours) instead of quietly passing.
- A dead-pid case guards the other direction: "assume alive on EPERM" must not become "everything looks alive".
- `0` / `00` / `000` / `0123`, and the ceilings on both platforms — the Windows case runs with `MSYSTEM` set, so both halves are checkable from either host, and widening *or* narrowing one side alone fails.
- **The sweep** — no shipped script under `scripts/` or `bin/` may call `kill -0` outside the helper — is #500's lesson as a test. A partially-hardened file reads like a fixed one; this is what stops the next one.
- The fast path is asserted structurally (the builtin check must come before, and be able to return without, the subshell), not by counting forks, which would be flaky.

Every new test was checked against a mutation that removes the property it claims: EPERM treated as dead, the fast path deleted, the ps cross-check dropped, the pid ceiling removed, the ceiling collapsed to one number, the DWORD ceiling applied everywhere, and a fresh bare `kill -0` reintroduced into a shipped script.

**CI caught one thing local runs could not.** Two shards failed on an intermediate head while every other shard and the full local suite passed. The pre-existing ESRCH tests stubbed `kill` and passed the literal `999` — which is a *running process* on some hosts, so the new `ps` cross-check correctly called it alive. The cross-check was right and the test's assumption was host-dependent; those tests now use a pid that is genuinely gone, and the cross-check got a test of its own.

One existing test changed meaning rather than breaking: `marker-gc: skips when _agmsg_pid_alive is unavailable` reached its guard by *not* sourcing the helper, which is the gap this PR closes. It now unsets the helper to reach the same guard, and a companion test pins the new guarantee that sourcing `resolve-project.sh` alone provides it.

## Verification

Full bats suite locally on macOS: **810 passed, 0 failed, 8 skipped** (none of them the new ones), plus every affected suite re-run after each review round.