### PR TITLE
fix(delivery): validate project_path in set instead of mkdir-ing whatever it is given (#493)

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -423,9 +423,9 @@ EOF
 #   1. empty, or made up entirely of whitespace (spaces/tabs/CR/LF);
 #   2. carrying a CR or LF byte anywhere -- leading, trailing, or embedded
 #      (the #493 repro is exactly a trailing LF from adjacent-quote
-#      concatenation, but a leading or embedded one is equally unable to
-#      round-trip through a shell command line or a JSON hooks entry, so all
-#      three are refused the same way);
+#      concatenation; a leading or embedded one is just as likely to be the
+#      product of a broken command composition, so all three are refused the
+#      same way rather than treated as an intentional path byte);
 #   3. not already an existing directory; or
 #   4. an existing directory this process cannot actually enter.
 # A plain leading/trailing space or tab is a valid POSIX path byte -- some

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -9,6 +9,11 @@ set -euo pipefail
 #   delivery.sh stop
 #   delivery.sh restart [<project_path> <type>]
 #
+# `set`'s <project_path> must already exist as a directory, with no
+# surrounding whitespace/newlines -- it is never created implicitly, and a
+# malformed value is rejected rather than silently cleaned up. See
+# agmsg_validate_project_path below (#493).
+#
 # Modes:
 #   monitor  — SessionStart hook → Claude Code Monitor tool → watch.sh stream
 #   turn     — Stop hook → check-inbox.sh between turns (legacy)
@@ -396,10 +401,105 @@ EOF
   echo "$killed"
 }
 
+# Reject a malformed project_path before any delivery-apply implementation
+# gets to build a hooks/rule file path from it and `mkdir -p` the result
+# (#493). Every implementation -- agmsg_delivery_apply_default,
+# rulefile_apply, and the cursor/copilot/grok-build overrides -- shares this
+# file's resolve_hooks_file(), and apply_settings (this function's sole
+# caller) is the only place any of them get invoked from, so validating here
+# once covers every agent type without touching each apply implementation.
+#
+# agmsg's primary callers are LLM agents composing this command from a
+# SKILL.md, so a literal argument carrying a stray trailing newline (unlike a
+# `$(pwd)`-style substitution, which already strips one) is a realistic input,
+# not an exotic edge case -- that is exactly the #493 repro, where such a
+# value got concatenated verbatim into a hooks_file path and mkdir -p'd into a
+# bogus sibling directory nobody asked for.
+#
+# Policy: trim to DETECT (not silently absorb) surrounding whitespace/
+# newlines -- any difference between the raw argument and its trimmed form
+# means the argument was malformed, so it is rejected outright rather than
+# quietly "corrected" to what we guess was meant (a caller that built a bad
+# command deserves a loud error pointing at the exact value it passed, not a
+# value that happens to work this one time and hides the bug in whatever
+# generated it). The existence check + `cd && pwd` canonicalization below
+# mirrors spawn.sh's existing --project handling: an unvalidated project_path
+# must never cause a directory to be created implicitly, so anything that is
+# empty, carries an embedded newline, or does not already exist as a
+# directory is refused rather than created.
+#
+# Echoes the caller's own path spelling back on success (validated, not
+# rewritten); prints an error naming the offending value to stderr and returns
+# non-zero on failure.
+agmsg_validate_project_path() {
+  local raw="$1" trimmed="$1"
+  while :; do
+    case "$trimmed" in
+      " "*|$'\t'*|$'\r'*|$'\n'*) trimmed="${trimmed#?}" ;;
+      *) break ;;
+    esac
+  done
+  while :; do
+    case "$trimmed" in
+      *" "|*$'\t'|*$'\r'|*$'\n') trimmed="${trimmed%?}" ;;
+      *) break ;;
+    esac
+  done
+
+  if [ -z "$trimmed" ]; then
+    echo "delivery.sh: project_path is empty or only whitespace: $(printf '%q' "$raw")" >&2
+    return 1
+  fi
+  if [ "$trimmed" != "$raw" ]; then
+    echo "delivery.sh: project_path has leading/trailing whitespace or a newline -- refusing to guess what was meant: $(printf '%q' "$raw")" >&2
+    echo "  pass a clean path (e.g. the output of \"\$(pwd)\")." >&2
+    return 1
+  fi
+  case "$raw" in
+    *$'\n'*|*$'\r'*)
+      # An embedded (not just leading/trailing) newline or CR -- the trim
+      # above only strips the ends, so this catches one hiding in the middle.
+      echo "delivery.sh: project_path contains an embedded newline or carriage return: $(printf '%q' "$raw")" >&2
+      return 1
+      ;;
+  esac
+  if [ ! -d "$raw" ]; then
+    echo "delivery.sh: project path does not exist: $(printf '%q' "$raw")" >&2
+    echo "  agmsg will not create a project directory implicitly -- pass an existing path (e.g. the output of \"\$(pwd)\")." >&2
+    return 1
+  fi
+  # -d passes for a directory we cannot actually enter, and every apply
+  # implementation goes on to write inside it, so prove traversability here
+  # rather than failing later with a confusing mkdir error. `--` keeps a real
+  # directory named like an option (`-P`, `-L`) from being parsed as one.
+  #
+  # The status is checked explicitly instead of being folded into a
+  # `$(cd ... && pwd)` command substitution: printf returns 0 regardless, so
+  # that shape lets a permission failure sail through as a successful
+  # validation of an empty path -- a validator that fails open is worse than
+  # no validator.
+  if ! ( cd -- "$raw" ) >/dev/null 2>&1; then
+    echo "delivery.sh: project path exists but cannot be entered: $(printf '%q' "$raw")" >&2
+    return 1
+  fi
+
+  # Echo the caller's own spelling back. Canonicalizing here would be a second,
+  # unrequested behavioral change: it rewrites relative paths to absolute and
+  # collapses ./.., so anything downstream that compares or persists this value
+  # would start seeing a different string than the caller passed. #493 is about
+  # refusing malformed input, not about normalizing well-formed input.
+  printf '%s' "$raw"
+}
+
 do_set() {
   local MODE="${1:?Usage: delivery.sh set <mode> <type> <project_path>}"
   local TYPE="${2:?Missing type}"
   local PROJECT="${3:?Missing project_path}"
+
+  # Zeroth stage: the project path itself must be a real, unambiguous
+  # directory before any type-specific logic (which mkdir -p's a path built
+  # from it) runs. See agmsg_validate_project_path above (#493).
+  PROJECT="$(agmsg_validate_project_path "$PROJECT")" || exit 1
 
   # Two-stage validation. First: is this even a real mode? The four mode names
   # are engine vocabulary (not type-specific), so a typo is caught here with a

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -9,10 +9,12 @@ set -euo pipefail
 #   delivery.sh stop
 #   delivery.sh restart [<project_path> <type>]
 #
-# `set`'s <project_path> must already exist as a directory, with no
-# surrounding whitespace/newlines -- it is never created implicitly, and a
-# malformed value is rejected rather than silently cleaned up. See
-# agmsg_validate_project_path below (#493).
+# `set`'s <project_path> must already exist as a directory (and be one this
+# process can enter), must not be empty/whitespace-only, and must not carry a
+# carriage return or newline byte anywhere in it -- it is never created
+# implicitly, and a malformed value is rejected rather than silently cleaned
+# up. Plain leading/trailing spaces or tabs are valid POSIX path characters
+# and are accepted as-is. See agmsg_validate_project_path below (#493).
 #
 # Modes:
 #   monitor  — SessionStart hook → Claude Code Monitor tool → watch.sh stream
@@ -416,17 +418,26 @@ EOF
 # value got concatenated verbatim into a hooks_file path and mkdir -p'd into a
 # bogus sibling directory nobody asked for.
 #
-# Policy: trim to DETECT (not silently absorb) surrounding whitespace/
-# newlines -- any difference between the raw argument and its trimmed form
-# means the argument was malformed, so it is rejected outright rather than
-# quietly "corrected" to what we guess was meant (a caller that built a bad
-# command deserves a loud error pointing at the exact value it passed, not a
-# value that happens to work this one time and hides the bug in whatever
-# generated it). The existence check + `cd && pwd` canonicalization below
-# mirrors spawn.sh's existing --project handling: an unvalidated project_path
-# must never cause a directory to be created implicitly, so anything that is
-# empty, carries an embedded newline, or does not already exist as a
-# directory is refused rather than created.
+# Policy: reject only the input shapes #493 is actually about, and otherwise
+# use the caller's value literally. That is:
+#   1. empty, or made up entirely of whitespace (spaces/tabs/CR/LF);
+#   2. carrying a CR or LF byte anywhere -- leading, trailing, or embedded
+#      (the #493 repro is exactly a trailing LF from adjacent-quote
+#      concatenation, but a leading or embedded one is equally unable to
+#      round-trip through a shell command line or a JSON hooks entry, so all
+#      three are refused the same way);
+#   3. not already an existing directory; or
+#   4. an existing directory this process cannot actually enter.
+# A plain leading/trailing space or tab is a valid POSIX path byte -- some
+# directories are legitimately named that way -- so it is accepted and used
+# as-is, not silently trimmed and not rejected. Rejecting only carries the
+# same "loud error naming the exact value, not a silent guess" spirit for the
+# shapes above: a caller that built a bad command should see why, not have it
+# quietly "corrected" into something that happens to work this one time.
+#
+# The existence check + traversability probe below mirrors spawn.sh's
+# existing --project handling: an unvalidated project_path must never cause a
+# directory to be created implicitly.
 #
 # Echoes the caller's own path spelling back on success (validated, not
 # rewritten); prints an error naming the offending value to stderr and returns
@@ -446,20 +457,20 @@ agmsg_validate_project_path() {
     esac
   done
 
+  # Emptiness is judged after trimming space/tab/CR/LF from both ends, so a
+  # value that is only whitespace (of any of those four bytes) is caught here
+  # regardless of which one(s) it's made of.
   if [ -z "$trimmed" ]; then
     echo "delivery.sh: project_path is empty or only whitespace: $(printf '%q' "$raw")" >&2
     return 1
   fi
-  if [ "$trimmed" != "$raw" ]; then
-    echo "delivery.sh: project_path has leading/trailing whitespace or a newline -- refusing to guess what was meant: $(printf '%q' "$raw")" >&2
-    echo "  pass a clean path (e.g. the output of \"\$(pwd)\")." >&2
-    return 1
-  fi
   case "$raw" in
     *$'\n'*|*$'\r'*)
-      # An embedded (not just leading/trailing) newline or CR -- the trim
-      # above only strips the ends, so this catches one hiding in the middle.
-      echo "delivery.sh: project_path contains an embedded newline or carriage return: $(printf '%q' "$raw")" >&2
+      # Judged against $raw (not $trimmed), so this catches a CR/LF anywhere
+      # in the value -- leading, trailing, or hiding in the middle -- while
+      # leaving plain leading/trailing spaces/tabs (already proven non-empty
+      # above) untouched.
+      echo "delivery.sh: project_path contains a carriage return or newline (leading, trailing, or embedded): $(printf '%q' "$raw")" >&2
       return 1
       ;;
   esac
@@ -477,8 +488,11 @@ agmsg_validate_project_path() {
   # `$(cd ... && pwd)` command substitution: printf returns 0 regardless, so
   # that shape lets a permission failure sail through as a successful
   # validation of an empty path -- a validator that fails open is worse than
-  # no validator.
-  if ! ( cd -- "$raw" ) >/dev/null 2>&1; then
+  # no validator. CDPATH is cleared inside the subshell: with it set, a
+  # RELATIVE project_path can `cd` into a same-named directory somewhere on
+  # CDPATH instead of the one `-d` just checked -- an un-enterable local
+  # directory would then validate against a different, enterable one.
+  if ! ( CDPATH='' cd -- "$raw" ) >/dev/null 2>&1; then
     echo "delivery.sh: project path exists but cannot be entered: $(printf '%q' "$raw")" >&2
     return 1
   fi

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -210,7 +210,7 @@ settings_file() {
   local bogus="$TEST_PROJECT"$'\n'
   run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$bogus"
   [ "$status" -ne 0 ]
-  [[ "$output" =~ "leading/trailing whitespace or a newline" ]]
+  [[ "$output" =~ "carriage return or newline" ]]
   # No sibling "<real project>\n" directory (or anything else) was created.
   [ ! -e "$bogus" ]
   ! has_session_start "$(settings_file)"
@@ -252,10 +252,41 @@ settings_file() {
   [[ "$output" =~ "empty or only whitespace" ]]
 }
 
-@test "delivery set: rejects a project_path with leading/trailing spaces, even though the trimmed path exists" {
+@test "delivery set: accepts a project_path with leading/trailing spaces, using it literally (#493 scope follow-up)" {
+  # A plain leading/trailing space is a valid POSIX path byte -- #493 is
+  # about CR/LF, not about whitespace in general -- so a directory legitimately
+  # named with padding must be accepted and used as-is, not rejected.
+  local padded="$TEST_PROJECT/  padded name  "
+  mkdir -p -- "$padded"
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$padded"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Delivery mode set to 'monitor'" ]]
+  [ -f "$padded/.claude/settings.local.json" ]
+  has_session_start "$padded/.claude/settings.local.json"
+}
+
+@test "delivery set: accepts a project_path with leading/trailing tabs, using it literally (#493 scope follow-up)" {
+  local padded="$TEST_PROJECT/"$'\t'"tabbed name"$'\t'
+  mkdir -p -- "$padded"
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$padded"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Delivery mode set to 'monitor'" ]]
+  [ -f "$padded/.claude/settings.local.json" ]
+  has_session_start "$padded/.claude/settings.local.json"
+}
+
+@test "delivery set: a space-padded spelling of an EXISTING dir is used literally, never trimmed into the real one" {
+  # "  $TEST_PROJECT  " names a (nonexistent) sibling whose first and last
+  # bytes are spaces -- NOT the real project. Accepting spaces as literal path
+  # bytes must not come with a silent fallback that trims the padding and
+  # resolves to the directory the caller probably meant: the value is used
+  # as-is, found not to exist, and rejected -- with the real project left
+  # untouched. (This pins the "accept literally" half of the #493 follow-up
+  # from the other side: the old trim-then-compare rejection also prevented
+  # this fallback, so its removal must not quietly introduce one.)
   run bash "$SCRIPTS/delivery.sh" set monitor claude-code "  $TEST_PROJECT  "
   [ "$status" -ne 0 ]
-  [[ "$output" =~ "leading/trailing whitespace or a newline" ]]
+  [[ "$output" =~ "does not exist" ]]
   ! has_session_start "$(settings_file)"
 }
 
@@ -263,8 +294,50 @@ settings_file() {
   local bogus="$TEST_PROJECT"$'\n'"extra"
   run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$bogus"
   [ "$status" -ne 0 ]
-  [[ "$output" =~ "embedded newline" ]]
+  [[ "$output" =~ "carriage return or newline" ]]
   [ ! -e "$bogus" ]
+}
+
+@test "delivery set: rejects a project_path with a trailing carriage return (CRLF line endings)" {
+  # The CR half of the CR/LF rule: a command composed on (or pasted from) a
+  # CRLF-line-ending environment leaves a bare \r on the value once the shell
+  # strips the \n. Same class of defect as the #493 repro, same rejection.
+  local bogus="$TEST_PROJECT"$'\r'
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$bogus"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "carriage return or newline" ]]
+  [ ! -e "$bogus" ]
+}
+
+@test "delivery set: rejects a project_path with a leading newline or an embedded carriage return" {
+  # The remaining corners of the "CR or LF anywhere" rule: leading (not just
+  # trailing) LF, and CR hiding mid-value rather than at an end.
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code $'\n'"$TEST_PROJECT"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "carriage return or newline" ]]
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"$'\r'"extra"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "carriage return or newline" ]]
+}
+
+@test "delivery set: an un-enterable relative path cannot validate via a same-named CDPATH match" {
+  # With CDPATH set, a bare `cd proj` can land in <cdpath-entry>/proj instead
+  # of ./proj -- so the traversability probe would test a DIFFERENT directory
+  # than the one `-d` just checked. The validator clears CDPATH for the probe;
+  # this pins that an un-enterable ./proj is still rejected even when an
+  # enterable sibling of the same name sits on CDPATH.
+  local decoy_root="$TEST_PROJECT/cdpath-decoy"
+  mkdir -p "$decoy_root/proj"            # enterable decoy on CDPATH
+  mkdir -p "$TEST_PROJECT/here/proj"     # the real target, made un-enterable
+  chmod 000 "$TEST_PROJECT/here/proj"
+  cd "$TEST_PROJECT/here"
+  CDPATH="$decoy_root" run bash "$SCRIPTS/delivery.sh" set monitor claude-code "proj"
+  chmod 755 "$TEST_PROJECT/here/proj"
+  cd "$TEST_PROJECT"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "cannot be entered" ]]
+  # Nothing was written into the enterable decoy.
+  [ ! -e "$decoy_root/proj/.claude" ]
 }
 
 @test "delivery set: a normal valid project_path (the documented \$(pwd) shape) still works end to end" {

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -276,8 +276,8 @@ settings_file() {
 }
 
 @test "delivery set: a space-padded spelling of an EXISTING dir is used literally, never trimmed into the real one" {
-  # "  $TEST_PROJECT  " names a (nonexistent) sibling whose first and last
-  # bytes are spaces -- NOT the real project. Accepting spaces as literal path
+  # "  $TEST_PROJECT  " is a RELATIVE pathname whose first byte is a space --
+  # NOT the real (absolute) project path. Accepting spaces as literal path
   # bytes must not come with a silent fallback that trims the padding and
   # resolves to the directory the caller probably meant: the value is used
   # as-is, found not to exist, and rejected -- with the real project left
@@ -325,7 +325,10 @@ settings_file() {
   # of ./proj -- so the traversability probe would test a DIFFERENT directory
   # than the one `-d` just checked. The validator clears CDPATH for the probe;
   # this pins that an un-enterable ./proj is still rejected even when an
-  # enterable sibling of the same name sits on CDPATH.
+  # enterable directory of the same name sits on CDPATH.
+  if [ "$(id -u)" -eq 0 ]; then
+    skip "running as root: permission bits do not restrict traversal"
+  fi
   local decoy_root="$TEST_PROJECT/cdpath-decoy"
   mkdir -p "$decoy_root/proj"            # enterable decoy on CDPATH
   mkdir -p "$TEST_PROJECT/here/proj"     # the real target, made un-enterable

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -189,6 +189,91 @@ settings_file() {
   [[ "$output" =~ "Unknown mode" ]]
 }
 
+# --- project_path validation (#493) ---
+# `set` used to build a hooks/rule-file path directly from an unvalidated
+# project_path and `mkdir -p` it, so a malformed argument -- e.g. a literal
+# trailing newline byte, the kind an LLM-agent-composed command can produce,
+# as opposed to a `$(pwd)`-style substitution which already strips one --
+# silently created a bogus sibling directory (the exact "myproject\n" repro
+# in #493) and installed hooks into it. agmsg_validate_project_path now
+# rejects a malformed value before any file or directory is touched, rather
+# than silently correcting it -- a caller that built a bad command should see
+# a loud error naming the exact value it passed, not a value that happens to
+# work this one time and hides the bug in whatever generated it.
+
+@test "delivery set: rejects a project_path with a trailing newline and creates no directory (#493 exact repro)" {
+  # Adjacent-quote concatenation appends a literal newline byte to the
+  # argument -- this is the exact #493 repro shape, not a $(cmd) substitution
+  # (which would already have stripped it). $TEST_PROJECT itself exists, so
+  # this also proves the fix does not silently fall back to the trimmed,
+  # pre-existing directory -- it refuses the malformed value outright.
+  local bogus="$TEST_PROJECT"$'\n'
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$bogus"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "leading/trailing whitespace or a newline" ]]
+  # No sibling "<real project>\n" directory (or anything else) was created.
+  [ ! -e "$bogus" ]
+  ! has_session_start "$(settings_file)"
+}
+
+@test "delivery set: rejects a nonexistent project_path and creates no directory" {
+  local bogus="$TEST_PROJECT/does-not-exist"
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$bogus"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "project path does not exist" ]]
+  [ ! -e "$bogus" ]
+}
+
+@test "delivery set: rejects an empty project_path" {
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code ""
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Missing project_path" ]]
+}
+
+@test "delivery set: rejects a project_path that exists but cannot be entered" {
+  # -d passes for a directory with no execute bit, but every apply
+  # implementation then writes inside it. Prove we fail here with a clear
+  # message instead of later with a confusing mkdir error.
+  if [ "$(id -u)" -eq 0 ]; then
+    skip "running as root: permission bits do not restrict traversal"
+  fi
+  local locked="$TEST_PROJECT/locked"
+  mkdir -p "$locked"
+  chmod 000 "$locked"
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$locked"
+  chmod 755 "$locked"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "cannot be entered" ]]
+}
+
+@test "delivery set: rejects a project_path that is only whitespace" {
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "   "
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "empty or only whitespace" ]]
+}
+
+@test "delivery set: rejects a project_path with leading/trailing spaces, even though the trimmed path exists" {
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "  $TEST_PROJECT  "
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "leading/trailing whitespace or a newline" ]]
+  ! has_session_start "$(settings_file)"
+}
+
+@test "delivery set: rejects a project_path with an embedded newline" {
+  local bogus="$TEST_PROJECT"$'\n'"extra"
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$bogus"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "embedded newline" ]]
+  [ ! -e "$bogus" ]
+}
+
+@test "delivery set: a normal valid project_path (the documented \$(pwd) shape) still works end to end" {
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Delivery mode set to 'monitor'" ]]
+  has_session_start "$(settings_file)"
+}
+
 # --- in-session directives ---
 
 @test "delivery set monitor: emits AGMSG-DIRECTIVE for Monitor invocation" {


### PR DESCRIPTION
Part of #493.

`delivery.sh set` didn't validate `<project_path>` at all, so `resolve_hooks_file` concatenated whatever it was given and `agmsg_delivery_apply` `mkdir -p`'d the result — which is how a directory literally named `myproject\n` ended up next to the real one, containing only `.codex/hooks.json` with the newline baked into the hook commands' project path.

`agmsg_validate_project_path()` now runs once in `do_set`, before any type-specific apply logic.

## The policy, and why

**Reject, don't correct.** A trailing newline is *detected* by trimming, then the value is refused because the trimmed form differs from what was passed. Silently "fixing" it would make a malformed command work this one time and hide the bug in whatever generated it. As the issue notes, agmsg's callers are largely LLM agents composing commands from SKILL.md — for that audience a loud error naming the exact value is worth more than a lucky save.

**Never create implicitly.** A path that doesn't already exist as a directory is refused rather than created. That is the actual defect from the report: a directory nobody asked for.

Also rejected: empty or whitespace-only, an embedded newline or carriage return, and a directory that exists but can't be entered (`-d` passes for a directory with no execute bit, and every apply implementation then tries to write inside it — better to fail here with a clear message than later with a confusing `mkdir` error).

## Two things I changed after review

- **The validator was failing open.** It ended with `printf '%s' "$(cd "$raw" && pwd)"`. `printf` returns 0 regardless, so a permission failure or race inside the substitution would have produced a *successful* validation of an empty path. The status is now checked explicitly, and `cd -- "$raw"` keeps a real directory named like an option (`-P`, `-L`) from being parsed as one. A validator that fails open is worse than no validator.
- **Dropped the canonicalization.** The first version returned `cd && pwd`, mirroring `spawn.sh:188`. But that's a second, unrequested behavioral change — it rewrites relative paths to absolute and collapses `./..`, so anything downstream comparing or persisting this value would start seeing a different string than the caller passed. #493 is about refusing malformed input, not normalizing well-formed input. The function now echoes the caller's own spelling back.

## Verification

- `bats tests/test_delivery.bats` → **148 ok, 0 not ok**, exit 0.
- 7 new tests: the exact `myproject\n` repro (asserting **no directory is created**), nonexistent path, empty, whitespace-only, leading/trailing spaces where the *trimmed* path does exist (proving it doesn't quietly fall back), embedded newline, and the un-enterable directory (skipped when running as root, where permission bits don't restrict traversal).
- **Mutation-tested, twice.** Making the validator a no-op fails 5 of the new tests; neutralising the traversability check fails the un-enterable test. Both restored and re-confirmed green.
- Reviewed with `codex exec` (gpt-5.6-sol, high). The fail-open `printf` and the `cd --` hardening are its findings.

## Scope notes

- Validation lives in `do_set` rather than in each apply implementation. That covers the default JSON-hooks path and `rulefile_apply` as far as I traced, but I have **not** done a full call-graph audit, so I'm not claiming categorically that no other entry point can reach the same `mkdir`. If you know of one, say so and I'll extend it.
- On MSYS, `pwd`-style normalization can rewrite `C:/repo` to `/c/repo`; dropping the canonicalization sidesteps that question entirely rather than answering it.
- The trim detects space, tab, CR and LF specifically — not every Unicode whitespace character.
- Deliberately not touching #378 (stdin input) or #355 (recipient validation), though they're the same front-door family.
