### PR TITLE
fix(codex): compare status metadata project as canonical normalized paths (#459)

### DIFF
--- a/scripts/drivers/types/codex/_delivery.sh
+++ b/scripts/drivers/types/codex/_delivery.sh
@@ -103,7 +103,7 @@ agmsg_delivery_runtime_status() {
     fi
     found=1
 
-    local base pidfile metafile pid meta_pid meta_project meta_type meta_ok
+    local base pidfile metafile pid meta_pid meta_project meta_type meta_ok want_proj have_proj
     base="$RUN_DIR/codex-bridge.$team.$name"
     pidfile="$base.pid"
     metafile="$base.meta"
@@ -129,7 +129,15 @@ agmsg_delivery_runtime_status() {
     meta_project=$(awk -F= '/^project=/{sub(/^project=/, ""); print; exit}' "$metafile" 2>/dev/null || true)
     meta_type=$(awk -F= '/^type=/{sub(/^type=/, ""); print; exit}' "$metafile" 2>/dev/null || true)
     [ -n "$meta_pid" ] && [ "$meta_pid" != "$pid" ] && meta_ok=0
-    [ -n "$meta_project" ] && [ "$meta_project" != "$project" ] && meta_ok=0
+    # The bridge records its project via Node's path.resolve (C:\x\y on
+    # Windows) while callers pass Git Bash spellings (/c/x/y or C:/x/y), so a
+    # verbatim compare mislabels every live bridge stale. Compare canonical
+    # normalized forms instead.
+    if [ -n "$meta_project" ]; then
+      want_proj="$(agmsg_normalize_project_path "$(agmsg_canonical_path "$project")")"
+      have_proj="$(agmsg_normalize_project_path "$(agmsg_canonical_path "$meta_project")")"
+      [ "$have_proj" != "$want_proj" ] && meta_ok=0
+    fi
     [ -n "$meta_type" ] && [ "$meta_type" != "$type" ] && meta_ok=0
     if [ "$meta_ok" -ne 1 ]; then
       echo "Codex bridge: $team/$name stale pidfile (metadata mismatch)"

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1767,6 +1767,54 @@ EOF
   [[ "$output" != *"watch processes:"* ]]
 }
 
+@test "delivery status (codex): metadata project spelling variant is not a mismatch" {
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  # Same directory, different spelling (trailing slash). A verbatim compare
+  # calls this a mismatch; canonical comparison must not.
+  printf '%s\n' "$$" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
+  cat > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.meta" <<EOF
+pid=$$
+project=$TEST_PROJECT/
+team=team
+name=alice
+type=codex
+EOF
+
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Codex bridge: team/alice"* ]]
+  [[ "$output" != *"metadata mismatch"* ]]
+}
+
+@test "delivery status (codex): metadata project in native Windows spelling is not a mismatch" {
+  case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) ;; *) skip "needs a real Windows path spelling (cygpath)" ;; esac
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  # The bridge records the project via Node's path.resolve, i.e. the
+  # backslash form cygpath -w produces — the exact shape that made every
+  # live bridge read as "metadata mismatch" on Windows.
+  local win_project
+  win_project="$(cygpath -w "$TEST_PROJECT")"
+  printf '%s\n' "$$" > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.pid"
+  cat > "$TEST_SKILL_DIR/run/codex-bridge.team.alice.meta" <<EOF
+pid=$$
+project=$win_project
+team=team
+name=alice
+type=codex
+EOF
+
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Codex bridge: team/alice"* ]]
+  [[ "$output" != *"metadata mismatch"* ]]
+}
+
 @test "delivery status (codex): missing bridge metadata is reported as stale" {
   bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
   bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null


### PR DESCRIPTION
Fixes #459.

## Mechanism

The bridge records its `project` through Node's `path.resolve()` — on Windows that is the native spelling (`C:\work\proj`). Callers of `delivery.sh status` pass the Git Bash spelling (`/c/work/proj` or `C:/work/proj`). The verbatim compare in `_delivery.sh` (`[ "$meta_project" != "$project" ]`) therefore labels **every live bridge** `stale pidfile (metadata mismatch)` on Windows.

Because this compare runs *before* the liveness check, it also masks the `kill -0` blindness reported in #415 (and being worked on in #505): on a vanilla Windows install, status never even reaches the liveness layer. Both layers need fixing for `status` to be truthful on Windows; this PR is the metadata layer only.

## Change

Compare canonical normalized forms instead, reusing the existing helpers (`agmsg_canonical_path` + `agmsg_normalize_project_path` from `lib/resolve-project.sh`) — the same normalization the rest of the tree already uses for project identity. 10 lines, no new dependencies.

Known trade-off inherited from the reused normalizer (documented in `lib/resolve-project.sh`): the drive reinterpretation is form-based, not platform-gated, so on POSIX two genuinely distinct paths `/c/foo` and `/C/foo` can normalize to the same drive-like spelling and would compare equal here. In this call site that can only affect the status label; a platform-gated equality comparator would remove the trade-off if you prefer that.

Write-side normalization (making the bridge record the Git Bash spelling) was considered and rejected: it would not repair meta files written by bridges already in the field, and the read side would still need tolerance for them.

## Tests

- `metadata project spelling variant is not a mismatch` — trailing-slash variant of the same directory; runs on all platforms.
- `metadata project in native Windows spelling is not a mismatch` — the exact `cygpath -w` shape the bridge writes; Windows-only (skips elsewhere).

The existing genuinely-different-directory fixture still reports a mismatch after this change. Restore-to-FAIL verified on this branch: with the `_delivery.sh` hunk reverted, both new tests fail.

Exact commands:

```
npx bats --filter 'metadata project spelling variant' tests/test_delivery.bats
npx bats --filter 'metadata project in native Windows spelling' tests/test_delivery.bats
```

Note the current windows-latest CI job runs only the Windows-filtered cases of `tests/test_install.bats`, so `test_delivery.bats` does not execute on Windows in CI — the Windows-spelling result above is from the stated Windows/Git Bash machine; the spelling-variant test runs on the Ubuntu/macOS shards.

## Verification

Measured on Windows 11 + Git Bash (MSYS2 3.4.7) against codex-cli 0.144.6; this diff has been running in our downstream deployment since 2026-07-21. Not measured on macOS/Linux — there the compare is unchanged for identical spellings, and the trailing-slash test covers the canonicalization path on all platforms.

## Note on #505

#505 touches the line just below this hunk (`kill -0` → `_agmsg_pid_alive`). The two text changes are independent and rebase trivially in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjjWN3rwUxE6qWBicECXHC