### PR TITLE
fix(codex): parse the app-server port through ANSI color sequences

### DIFF
--- a/scripts/drivers/types/codex/codex-monitor.sh
+++ b/scripts/drivers/types/codex/codex-monitor.sh
@@ -162,8 +162,11 @@ if [ -z "$PORT" ]; then
   "$REAL_CODEX" app-server --listen "ws://127.0.0.1:0" >>"$SERVER_LOG" 2>&1 &
   server_bg="$!"
   echo "$server_bg" > "$SERVER_PID"
+  # codex 0.144+ colorizes this banner even when stdout is a redirected file
+  # (NO_COLOR is ignored), so strip ANSI SGR sequences before matching.
+  ansi_esc="$(printf '\033')"
   for _ in $(seq 1 100); do
-    PORT="$(sed -n 's#.*listening on: ws://127\.0\.0\.1:\([0-9][0-9]*\).*#\1#p' "$SERVER_LOG" | head -1)"
+    PORT="$(sed -n -e "s/${ansi_esc}\[[0-9;]*m//g" -e 's#.*listening on: ws://127\.0\.0\.1:\([0-9][0-9]*\).*#\1#p' "$SERVER_LOG" | head -1)"
     [ -n "$PORT" ] && break
     # Stop waiting the moment the app-server exits (e.g. a codex release dropped
     # `app-server --listen ws://`): no point burning the full timeout before we

--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -147,7 +147,11 @@ teardown() {
 case "${1:-}" in
   --version) echo "codex-cli 0.144.1"; exit 0 ;;
   app-server)
-    node - <<'JS'
+    # Run the listener as a CHILD and forward teardown's kill to it, so it dies
+    # with this wrapper instead of holding the bats capture fd until its timer
+    # fires — the same dies-with-parent model as the python fake above. The
+    # wrapper stays the recorded pid (its argv is what the cmdline check reads).
+    node - <<'JS' &
 const net = require('net');
 const s = net.createServer((c) => c.destroy());
 s.listen(0, '127.0.0.1', () => {
@@ -155,8 +159,11 @@ s.listen(0, '127.0.0.1', () => {
   console.log(e + '[36;1mcodex app-server (WebSockets)' + e + '[0m');
   console.log('  ' + e + '[2mlistening on:' + e + '[0m ' + e + '[32mws://127.0.0.1:' + s.address().port + e + '[0m');
 });
-setTimeout(() => process.exit(0), 60000); // bound the listener if teardown misses it
+setTimeout(() => process.exit(0), 60000); // backstop if the forwarded kill never arrives
 JS
+    child=$!
+    trap 'kill "$child" 2>/dev/null' TERM INT
+    wait "$child" 2>/dev/null || wait "$child" 2>/dev/null
     ;;
   *)
     printf 'plain-codex' >> "$CALL_LOG"

--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -128,6 +128,54 @@ teardown() {
   [ "$(cat "$pidf")" = "$first_pid" ]
 }
 
+# --- port discovery vs colorized banner (codex 0.144+) ---
+
+@test "codex-monitor: discovers the port when codex colorizes the banner (0.144+)" {
+  run node -e 'const net = require("net"); if (!net) process.exit(1);'
+  if [ "$status" -ne 0 ]; then
+    skip "node net module is not available in this sandbox"
+  fi
+
+  # codex 0.144.1 writes ANSI SGR sequences into the banner even when stdout is
+  # a redirected file (NO_COLOR is ignored), so this fake reproduces the
+  # colorized "listening on:" line verbatim. The python fake above prints a
+  # plain banner and can never catch a color regression; this one uses a node
+  # listener so it also runs on the Windows runner where the python fake skips.
+  local ansi_codex="$TEST_PROJECT/ansi-codex"
+  cat > "$ansi_codex" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) echo "codex-cli 0.144.1"; exit 0 ;;
+  app-server)
+    node - <<'JS'
+const net = require('net');
+const s = net.createServer((c) => c.destroy());
+s.listen(0, '127.0.0.1', () => {
+  const e = '\x1b';
+  console.log(e + '[36;1mcodex app-server (WebSockets)' + e + '[0m');
+  console.log('  ' + e + '[2mlistening on:' + e + '[0m ' + e + '[32mws://127.0.0.1:' + s.address().port + e + '[0m');
+});
+setTimeout(() => process.exit(0), 60000); // bound the listener if teardown misses it
+JS
+    ;;
+  *)
+    printf 'plain-codex' >> "$CALL_LOG"
+    for a in "$@"; do printf ' <%s>' "$a" >> "$CALL_LOG"; done
+    printf '\n' >> "$CALL_LOG"
+    ;;
+esac
+EOF
+  chmod +x "$ansi_codex"
+
+  run env AGMSG_REAL_CODEX="$ansi_codex" \
+    bash "$TYPES/codex/codex-monitor.sh" --project "$TEST_PROJECT" --codex-command codex --
+  [ "$status" -eq 0 ]
+  # The port was parsed out of the colorized banner: the handoff must be the
+  # BRIDGED form (--remote ws://...), not the plain-codex fail-open.
+  grep -q 'plain-codex <--remote> <ws://127\.0\.0\.1:[0-9][0-9]*>' "$CALL_LOG"
+  [[ "$output" != *"did not report a listening port"* ]]
+}
+
 @test "codex-monitor: never kills a non-codex process recorded under a reused pid" {
   skip_on_windows "spawns a python socket listener; flaky on the Windows runner"
 


### PR DESCRIPTION
## Mechanism

On our Windows 11 + Git Bash host, npm codex-cli 0.144.1 emitted ANSI SGR sequences in the **redirected** app-server log, with `NO_COLOR` set (verified with `od` on the captured log). `codex-monitor.sh` discovers the port by matching the literal text `listening on: ws://127.0.0.1:` in that log; whenever the banner carries SGR sequences between the label and the URL, the sed never matches.

Effect of a non-matching banner on a monitored launch:

1. the port poll burns its full 10 s timeout,
2. the monitor kills the fresh app-server it just started,
3. it prints its explicit `codex-monitor:` / `agmsg:` warnings and falls back to a usable plain-codex session, with real-time delivery off for that session.

The fail-open works as designed — but because codex itself opens normally, the warning is easy to miss, and the user just stops receiving messages. With #497 making monitor the recommended default, a host whose codex emits the colorized banner loses delivery on every monitored launch until someone reads the log.

Scope honesty: we can attest the colorized-banner emission only for the npm build we measured (0.144.1, Windows). The parser's failure to match *any* colorized banner is host-independent, and that is the property the new test pins.

## Change

Strip ANSI SGR sequences in the same sed invocation before matching — one expression added, no new dependency, bash 3.2-safe. This banner sed is the only scrape site: the reuse path reads the `.port` file (bare digits), and `codex --version` prints plain text.

## Test

Adds a fake codex that reproduces the colorized banner **verbatim** over a node listener. The existing python-listener fakes print a plain banner and skip on Windows, which is why this class of breakage was invisible to the suite; the new fake has no Windows skip and passed in our manual Windows run. Note the current windows-latest CI job runs only the Windows-filtered cases of `tests/test_install.bats`, so in CI this suite still runs on the Ubuntu/macOS shards. Exact command:

```
npx bats --filter 'discovers the port when codex colorizes the banner' tests/test_codex_monitor.bats
```

Restore-to-FAIL verified on this branch: with the monitor sed reverted, the test fails.

## Verification

Found live on Windows 11 + Git Bash + npm codex-cli 0.144.1 (2026-07-16); the fix has been running in our downstream deployment since. Mechanism re-checked against current `main` — the banner sed is unchanged (greppable as `listening on: ws://127\.0\.0\.1:`). The parser property is verifiable on any host via the test above; the banner emission itself we measured only on the stated Windows host.

## Note on #505

The text hunks merge cleanly. However, #505 routes the same startup loop's `$!` liveness check (`server_bg`) through a tasklist-only helper, and our Windows probe shows it reports that live MSYS pid dead — we are reporting that on #505 separately. Re-testing the combined head on Windows before merging both is advisable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjjWN3rwUxE6qWBicECXHC