### PR TITLE
fix(delivery): keep subscriptions current after join

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -18,6 +18,10 @@ source "$SCRIPT_DIR/lib/actas-lock.sh"
 source "$SCRIPT_DIR/lib/resolve-project.sh"  # agmsg_agent_pid, for instance-id derivation
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/type-registry.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/subscription.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/delivery-cursor.sh"
 
 # Some Stop-hook runtimes (codex, copilot) want an explicit JSON status object
 # even when there is nothing to deliver; others (claude-code) stay silent. This
@@ -66,6 +70,7 @@ SESSION_ID=$(printf '%s' "$INPUT" \
   | sed -n 's/.*"sessionId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
   | head -1)
 [ -z "$SESSION_ID" ] && SESSION_ID="${GROK_SESSION_ID:-}"
+HOOK_SESSION_ID="$SESSION_ID"
 if [ -n "$SESSION_ID" ]; then
   # The monitor watcher keys its pidfile (and its actas owner, below) on the
   # per-process instance id (#93), not the bare session_id. Normalize to the
@@ -82,92 +87,59 @@ if [ -n "$SESSION_ID" ]; then
   fi
 fi
 
-# Identify agent and teams
-WHOAMI=$("$SCRIPT_DIR/whoami.sh" "$PROJECT" "$TYPE")
-# suggest=true means this identity is registered only under a DIFFERENT
-# project, so it is not joined here -> deliver nothing (mirror not_joined).
-# Without this the else-branch extracts "agents=" as the agent name.
-if echo "$WHOAMI" | grep -Eq "not_joined=true|suggest=true"; then
-  exit 0
-fi
+PAIRS="$(agmsg_session_subscription_pairs "$PROJECT" "$TYPE" "${SESSION_ID:-}" "${HOOK_SESSION_ID:-}")"
+[ -n "$PAIRS" ] || exit 0
 
-# Handle multiple identities: use first agent name
-if echo "$WHOAMI" | grep -q "multiple=true"; then
-  AGENT=$(echo "$WHOAMI" | sed -n 's/.*agents=\([^,]*\).*/\1/p')
-else
-  # Anchor on a leading "agent=" so "agents=" (multiple/suggest) cannot match.
-  AGENT=$(echo "$WHOAMI" | sed -n 's/^agent=\([^ ]*\).*/\1/p')
-fi
-TEAMS=$(echo "$WHOAMI" | sed -n 's/.*teams=\([^ ]*\).*/\1/p')
-
-if [ -z "$AGENT" ] || [ -z "$TEAMS" ]; then
-  exit 0
-fi
-
-# Cooldown check. The marker is hook runtime state, not message storage, so it
-# lives in the skill's run dir — independent of AGMSG_STORAGE_PATH. Keeping it
-# out of the store means an overridden/sandboxed store still gets delivery even
-# when the default db dir doesn't exist.
-MARKER="$SKILL_DIR/run/.lastcheck-$AGENT"
-
-if [ -f "$MARKER" ]; then
-  last=$(compat_file_mtime "$MARKER")
-  now=$(date +%s)
-  # Prefer the new delivery.turn.check_interval; fall back to legacy
-  # hook.check_interval for users who haven't migrated.
-  INTERVAL=$("$SCRIPT_DIR/config.sh" get delivery.turn.check_interval "")
-  [ -z "$INTERVAL" ] && INTERVAL=$("$SCRIPT_DIR/config.sh" get hook.check_interval 60)
-  case "$INTERVAL" in ''|*[!0-9]*) INTERVAL=60 ;; esac
-  if [ $(( now - last )) -lt "$INTERVAL" ]; then
-    emit_status_json "agmsg: check skipped (cooldown)"
-    exit 0
-  fi
-fi
-
+# Prefer the new delivery.turn.check_interval; fall back to legacy
+# hook.check_interval for users who haven't migrated.
+INTERVAL=$("$SCRIPT_DIR/config.sh" get delivery.turn.check_interval "")
+[ -z "$INTERVAL" ] && INTERVAL=$("$SCRIPT_DIR/config.sh" get hook.check_interval 60)
+case "$INTERVAL" in ''|*[!0-9]*) INTERVAL=60 ;; esac
 mkdir -p "$SKILL_DIR/run"
-touch "$MARKER"
 
 # Check for unread messages and mark as read
 DB="$(agmsg_db_path)"
 if [ ! -f "$DB" ]; then exit 0; fi
 
 _agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
-AGENT_SQL="$(_agmsg_sqlesc "$AGENT")"
 
 OUTPUT=""
-IFS=',' read -ra TEAM_LIST <<< "$TEAMS"
-for team in "${TEAM_LIST[@]}"; do
+CHECKED_ANY=0
+SKIPPED_ANY=0
+SESSION_KEY="$(_actas_lock_encode "${SESSION_ID:-turn}")"
+while IFS=$'\t' read -r team agent; do
+  [ -n "$team" ] && [ -n "$agent" ] || continue
+  team_key="$(_actas_lock_encode "$team")"
+  agent_key="$(_actas_lock_encode "$agent")"
+  MARKER="$SKILL_DIR/run/.lastcheck.${SESSION_KEY}.${team_key}__${agent_key}"
+  if [ -f "$MARKER" ]; then
+    last=$(compat_file_mtime "$MARKER")
+    now=$(date +%s)
+    if [ $(( now - last )) -lt "$INTERVAL" ]; then
+      SKIPPED_ANY=1
+      continue
+    fi
+  fi
+  touch "$MARKER"
+  CHECKED_ANY=1
   team_sql="$(_agmsg_sqlesc "$team")"
-  # Honor actas exclusivity locks. If (team, AGENT) is currently held by
-  # another live session, that session is the owner of that role's inbox —
-  # don't deliver here. Mirrors the per-pair filtering watch.sh does for
-  # CC sessions (#62), giving Stop-hook delivery (codex / claude-code
-  # turn-mode) the same "respect peer locks" guarantee.
-  #
-  # Note: AGENT comes from whoami.sh, which returns the first registered
-  # agent for (project, type). It is NOT the session's in-memory actas
-  # role. That asymmetry is the Codex caveat documented in README — if a
-  # Codex session actas'd into <name>, check-inbox is still polling
-  # whatever whoami chose first, not <name>.
-  state=$(actas_lock_state "$team" "$AGENT" "${SESSION_ID:-}")
-  case "$state" in
-    other:*) continue ;;
-  esac
+  agent_sql="$(_agmsg_sqlesc "$agent")"
 
   RESULT=$(agmsg_sqlite "$DB" "
     SELECT id || char(31) || from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
-    FROM messages WHERE team='$team_sql' AND to_agent='$AGENT_SQL' AND read_at IS NULL
+    FROM messages WHERE team='$team_sql' AND to_agent='$agent_sql' AND read_at IS NULL
     ORDER BY created_at ASC;
   ")
   if [ -n "$RESULT" ]; then
     COUNT=$(echo "$RESULT" | wc -l | tr -d ' ')
     OUTPUT+="$COUNT new message(s) in $team:"$'\n'
     IDS=""
+    MAX_ID=""
     while IFS=$'\x1f' read -r id from body ts; do
       OUTPUT+="  [$ts] $from: $body"$'\n'
       case "$id" in
         ''|*[!0-9]*) ;; # defensive: never splice a non-numeric value into SQL
-        *) IDS="${IDS:+$IDS,}$id" ;;
+        *) IDS="${IDS:+$IDS,}$id"; MAX_ID="$id" ;;
       esac
     done <<< "$RESULT"
     OUTPUT+=$'\n'
@@ -185,14 +157,20 @@ for team in "${TEAM_LIST[@]}"; do
     # Mark as read — only the ids captured above, so a message that arrives
     # between the SELECT and this UPDATE is not marked read unseen.
     if [ -n "$IDS" ]; then
-      agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id IN ($IDS);" 2>/dev/null || true
+      if agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id IN ($IDS);" 2>/dev/null; then
+        agmsg_delivery_cursor_advance "$team" "$agent" "$TYPE" "$PROJECT" "$MAX_ID" 2>/dev/null || true
+      fi
     fi
   fi
-done
+done <<< "$PAIRS"
 
 # No new messages
 if [ -z "$OUTPUT" ]; then
-  emit_status_json "agmsg: no new messages"
+  if [ "$CHECKED_ANY" -eq 0 ] && [ "$SKIPPED_ANY" -eq 1 ]; then
+    emit_status_json "agmsg: check skipped (cooldown)"
+  else
+    emit_status_json "agmsg: no new messages"
+  fi
   exit 0
 fi
 

--- a/scripts/internal/init-db.sh
+++ b/scripts/internal/init-db.sh
@@ -35,4 +35,14 @@ CREATE TABLE IF NOT EXISTS messages (
 
 CREATE INDEX IF NOT EXISTS idx_unread ON messages(team, to_agent, read_at) WHERE read_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_history ON messages(team, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS delivery_cursors (
+  team TEXT NOT NULL,
+  agent TEXT NOT NULL,
+  type TEXT NOT NULL,
+  project TEXT NOT NULL,
+  last_id INTEGER NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (team, agent, type, project)
+);
 SQL

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -27,6 +27,7 @@ if ! agmsg_is_known_type "$AGENT_TYPE"; then
   exit 1
 fi
 
+# shellcheck disable=SC2034  # consumed by sourced delivery-cursor.sh
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 
@@ -45,6 +46,8 @@ agmsg_validate_agent_name "$AGENT_ID" || exit 1
 source "$SCRIPT_DIR/lib/resolve-project.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/storage.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/delivery-cursor.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/registry-lock.sh"
 # Scope resolution to the join target team (#357): a poison registration in an
@@ -149,6 +152,10 @@ else
   if [ "$HAS_REGISTRATION" = "1" ]; then
     AGENT_OBJ="$NORMALIZED"
   else
+    # Publish the cursor before config.json makes this registration sendable.
+    # A job sent immediately after join therefore remains strictly after the
+    # cursor even when the watcher has not refreshed its membership yet.
+    agmsg_delivery_cursor_seed "$TEAM" "$AGENT_ID" "$AGENT_TYPE" "$PROJECT_PATH" >/dev/null
     AGENT_OBJ=$(agmsg_sqlite_mem "
       SELECT json_set(
         '$NORMALIZED_ESCAPED',
@@ -157,6 +164,10 @@ else
       );
     ")
   fi
+fi
+
+if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
+  agmsg_delivery_cursor_seed "$TEAM" "$AGENT_ID" "$AGENT_TYPE" "$PROJECT_PATH" >/dev/null
 fi
 
 AGENT_OBJ_ESCAPED=$(printf '%s' "$AGENT_OBJ" | sed "s/'/''/g")

--- a/scripts/lib/delivery-cursor.sh
+++ b/scripts/lib/delivery-cursor.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Persistent delivery cursor for one registered (team, agent, type, project).
+
+[ -n "${_AGMSG_DELIVERY_CURSOR_SH:-}" ] && return 0
+_AGMSG_DELIVERY_CURSOR_SH=1
+
+: "${SKILL_DIR:?delivery-cursor.sh requires SKILL_DIR}"
+
+# shellcheck disable=SC1091
+. "$SKILL_DIR/scripts/lib/resolve-project.sh"
+
+_agmsg_delivery_cursor_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+_AGMSG_DELIVERY_CURSOR_SCHEMA_READY=""
+agmsg_delivery_cursor_ensure_schema() {
+  [ "$_AGMSG_DELIVERY_CURSOR_SCHEMA_READY" = "1" ] && return 0
+  agmsg_storage_ensure_initialized || return 1
+  agmsg_sqlite "$(agmsg_db_path)" <<'SQL' >/dev/null
+CREATE TABLE IF NOT EXISTS delivery_cursors (
+  team TEXT NOT NULL,
+  agent TEXT NOT NULL,
+  type TEXT NOT NULL,
+  project TEXT NOT NULL,
+  last_id INTEGER NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (team, agent, type, project)
+);
+SQL
+  _AGMSG_DELIVERY_CURSOR_SCHEMA_READY=1
+}
+
+agmsg_delivery_cursor_get() {
+  local team="$1" agent="$2" type="$3" project="$4"
+  local db team_sql agent_sql type_sql project_sql_in
+  agmsg_delivery_cursor_ensure_schema || return 1
+  db="$(agmsg_db_path)"
+  team_sql="$(_agmsg_delivery_cursor_escape "$team")"
+  agent_sql="$(_agmsg_delivery_cursor_escape "$agent")"
+  type_sql="$(_agmsg_delivery_cursor_escape "$type")"
+  project_sql_in="$(agmsg_project_sql_in_list "$project")"
+  agmsg_sqlite "$db" "
+    SELECT MAX(last_id)
+    FROM delivery_cursors
+    WHERE team='$team_sql' AND agent='$agent_sql' AND type='$type_sql'
+      AND project IN ($project_sql_in);
+  " 2>/dev/null
+}
+
+# Start a newly visible registration immediately after the current message id.
+# join.sh calls this before publishing the registration in config.json.
+agmsg_delivery_cursor_seed() {
+  local team="$1" agent="$2" type="$3" project="$4"
+  local db team_sql agent_sql type_sql project_norm project_sql last_id
+  agmsg_delivery_cursor_ensure_schema || return 1
+  db="$(agmsg_db_path)"
+  team_sql="$(_agmsg_delivery_cursor_escape "$team")"
+  agent_sql="$(_agmsg_delivery_cursor_escape "$agent")"
+  type_sql="$(_agmsg_delivery_cursor_escape "$type")"
+  project_norm="$(agmsg_normalize_project_path "$project")"
+  project_sql="$(_agmsg_delivery_cursor_escape "$project_norm")"
+  last_id="$(agmsg_sqlite "$db" "SELECT COALESCE(MAX(id), 0) FROM messages;" 2>/dev/null || printf '0')"
+  case "$last_id" in ''|*[!0-9]*) last_id=0 ;; esac
+  agmsg_sqlite "$db" "
+    INSERT OR REPLACE INTO delivery_cursors(team, agent, type, project, last_id, updated_at)
+    VALUES('$team_sql', '$agent_sql', '$type_sql', '$project_sql', $last_id,
+           strftime('%Y-%m-%dT%H:%M:%SZ','now'));
+  " >/dev/null
+  printf '%s' "$last_id"
+}
+
+# Existing installations have registrations without cursor rows. Seed those at
+# first observation so old live output is not replayed after an upgrade.
+agmsg_delivery_cursor_initialize_missing() {
+  local team="$1" agent="$2" type="$3" project="$4" current
+  current="$(agmsg_delivery_cursor_get "$team" "$agent" "$type" "$project" 2>/dev/null || true)"
+  case "$current" in
+    ''|*[!0-9]*) agmsg_delivery_cursor_seed "$team" "$agent" "$type" "$project" ;;
+    *) printf '%s' "$current" ;;
+  esac
+}
+
+agmsg_delivery_cursor_advance() {
+  local team="$1" agent="$2" type="$3" project="$4" message_id="$5"
+  local db team_sql agent_sql type_sql project_norm project_sql
+  case "$message_id" in ''|*[!0-9]*) return 0 ;; esac
+  agmsg_delivery_cursor_ensure_schema || return 1
+  db="$(agmsg_db_path)"
+  team_sql="$(_agmsg_delivery_cursor_escape "$team")"
+  agent_sql="$(_agmsg_delivery_cursor_escape "$agent")"
+  type_sql="$(_agmsg_delivery_cursor_escape "$type")"
+  project_norm="$(agmsg_normalize_project_path "$project")"
+  project_sql="$(_agmsg_delivery_cursor_escape "$project_norm")"
+  agmsg_sqlite "$db" "
+    INSERT OR IGNORE INTO delivery_cursors(team, agent, type, project, last_id, updated_at)
+    VALUES('$team_sql', '$agent_sql', '$type_sql', '$project_sql', $message_id,
+           strftime('%Y-%m-%dT%H:%M:%SZ','now'));
+    UPDATE delivery_cursors
+    SET last_id=CASE WHEN last_id < $message_id THEN $message_id ELSE last_id END,
+        updated_at=strftime('%Y-%m-%dT%H:%M:%SZ','now')
+    WHERE team='$team_sql' AND agent='$agent_sql' AND type='$type_sql'
+      AND project='$project_sql';
+  " >/dev/null
+}

--- a/scripts/lib/role-session.sh
+++ b/scripts/lib/role-session.sh
@@ -234,3 +234,24 @@ agmsg_role_session_lookup_by_sid() {
   done
   return 0
 }
+
+# Print every record matching a bare session id as
+# team<TAB>agent<TAB>type<TAB>project. Callers must treat more than one matching
+# current registration as ambiguous instead of silently choosing the first.
+agmsg_role_session_pairs_by_sid() {
+  local sid="$1" dir f v team agent type project
+  [ -n "$sid" ] || return 0
+  dir="$(_actas_lock_dir)"
+  [ -d "$dir" ] || return 0
+  for f in "$dir"/role-session.*; do
+    [ -f "$f" ] || continue
+    v="$(_agmsg_role_session_field "$f" session)"
+    [ "$v" = "$sid" ] || continue
+    team="$(_agmsg_role_session_field "$f" team)"
+    agent="$(_agmsg_role_session_field "$f" agent)"
+    type="$(_agmsg_role_session_field "$f" type)"
+    project="$(_agmsg_role_session_field "$f" project)"
+    [ -n "$team" ] && [ -n "$agent" ] || continue
+    printf '%s\t%s\t%s\t%s\n' "$team" "$agent" "$type" "$project"
+  done
+}

--- a/scripts/lib/subscription.sh
+++ b/scripts/lib/subscription.sh
@@ -6,6 +6,11 @@
 
 : "${SKILL_DIR:?subscription.sh requires SKILL_DIR}"
 
+# shellcheck disable=SC1091
+. "$SKILL_DIR/scripts/lib/resolve-project.sh"
+# shellcheck disable=SC1091
+. "$SKILL_DIR/scripts/lib/role-session.sh"
+
 agmsg_sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
 
 # Resolve the (team, agent) rows this process should receive for.
@@ -17,16 +22,9 @@ agmsg_sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
 # When `active_name` is set, only that agent name is kept. When the final
 # argument is `claim`, the helper attempts to claim each active pair for
 # `owner_id`, matching watch.sh actas mode.
-agmsg_subscription_pairs() {
-  local project="$1" type="$2" owner_id="$3" active_name="${4:-}" claim_mode="${5:-}"
-  local scripts_dir="$SKILL_DIR/scripts"
-  local pairs filtered skipped held state result
-
-  pairs="$("$scripts_dir/identities.sh" "$project" "$type")"
-  if [ -n "$active_name" ]; then
-    pairs=$(printf '%s\n' "$pairs" | awk -v n="$active_name" -F'\t' 'NF >= 2 && $2 == n')
-  fi
-
+_agmsg_subscription_filter_locks() {
+  local pairs="$1" owner_id="$2" active_name="${3:-}" claim_mode="${4:-}"
+  local filtered skipped held state result
   [ -n "$pairs" ] || return 0
 
   filtered=""
@@ -70,6 +68,56 @@ agmsg_subscription_pairs() {
   fi
 
   printf '%s' "$filtered"
+}
+
+_agmsg_subscription_registered_pairs() {
+  local project="$1" type="$2" active_name="${3:-}" pairs
+  pairs="$("$SKILL_DIR/scripts/identities.sh" "$project" "$type")"
+  if [ -n "$active_name" ]; then
+    pairs=$(printf '%s\n' "$pairs" | awk -v n="$active_name" -F'\t' 'NF >= 2 && $2 == n')
+  fi
+  printf '%s' "$pairs"
+}
+
+# Narrow to a role-session record only when it identifies exactly one current
+# registration for this project/type. Zero or multiple matches remain broad.
+_agmsg_subscription_narrow_session() {
+  local pairs="$1" project="$2" type="$3" session_token="$4"
+  local bare_sid project_phys records matches="" team agent record_type record_project record_phys count
+  [ -n "$session_token" ] || { printf '%s' "$pairs"; return 0; }
+  bare_sid="$(agmsg_instance_bare_sid "$session_token")"
+  project_phys="$(agmsg_canonical_path "$project" 2>/dev/null || printf '%s' "$project")"
+  records="$(agmsg_role_session_pairs_by_sid "$bare_sid" 2>/dev/null || true)"
+  while IFS=$'\t' read -r team agent record_type record_project; do
+    [ -n "$team" ] && [ -n "$agent" ] || continue
+    [ -z "$record_type" ] || [ "$record_type" = "$type" ] || continue
+    if [ -n "$record_project" ]; then
+      record_phys="$(agmsg_canonical_path "$record_project" 2>/dev/null || printf '%s' "$record_project")"
+      [ "$record_phys" = "$project_phys" ] || continue
+    fi
+    printf '%s\n' "$pairs" | grep -Fxq "${team}"$'\t'"${agent}" || continue
+    printf '%s\n' "$matches" | grep -Fxq "${team}"$'\t'"${agent}" && continue
+    matches="${matches:+$matches$'\n'}${team}"$'\t'"${agent}"
+  done <<< "$records"
+  count=$(printf '%s\n' "$matches" | awk 'NF { n++ } END { print n+0 }')
+  if [ "$count" -eq 1 ]; then
+    printf '%s' "$matches"
+  else
+    printf '%s' "$pairs"
+  fi
+}
+
+agmsg_subscription_pairs() {
+  local project="$1" type="$2" owner_id="$3" active_name="${4:-}" claim_mode="${5:-}" pairs
+  pairs="$(_agmsg_subscription_registered_pairs "$project" "$type" "$active_name")"
+  _agmsg_subscription_filter_locks "$pairs" "$owner_id" "$active_name" "$claim_mode"
+}
+
+agmsg_session_subscription_pairs() {
+  local project="$1" type="$2" owner_id="$3" session_token="${4:-}" active_name="${5:-}" claim_mode="${6:-}" pairs
+  pairs="$(_agmsg_subscription_registered_pairs "$project" "$type" "$active_name")"
+  pairs="$(_agmsg_subscription_narrow_session "$pairs" "$project" "$type" "$session_token")"
+  _agmsg_subscription_filter_locks "$pairs" "$owner_id" "$active_name" "$claim_mode"
 }
 
 # Build a SQL predicate for a tab-separated pair list.

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -17,12 +17,10 @@ source "$(cd "$(dirname "$0")" && pwd)/lib/compat.sh"
 #     of those pairs.
 #   - When [active_name] is given, narrows the subscription to only pairs
 #     whose agent name matches — useful for `actas` exclusive role mode.
-#   - A fresh session sets the high-water mark to the current MAX(id) at
-#     startup, so the stream begins with whatever arrives after launch — no
-#     replay of historical messages. The mark is persisted per session_id, so
-#     a restart of this session's watcher (actas/drop/clear/self-restart)
-#     resumes from the last delivered id and does not drop messages that
-#     arrived during the restart gap. See #107.
+#   - A persistent cursor per registered (team, agent, type, project) begins at
+#     join time and advances after delivery. Membership and cursors are reread
+#     every poll, so jobs sent after join survive watcher attach/restart gaps.
+#     Rows already marked read are not replayed.
 #   - Polls the SQLite DB at AGMSG_WATCH_INTERVAL seconds (default 5, also
 #     overridable via the delivery.monitor.poll_interval config key).
 #   - Emits one line per new message:
@@ -65,6 +63,10 @@ source "$SCRIPT_DIR/lib/storage.sh"
 source "$SCRIPT_DIR/lib/actas-lock.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/resolve-project.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/subscription.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/delivery-cursor.sh"
 
 # Fail loudly on an unknown agent_type instead of running with zero
 # subscriptions. The dominant real-world cause is a shifted argument list: a
@@ -144,6 +146,22 @@ DB="$(agmsg_db_path)"
 RUN_DIR="$SKILL_DIR/run"
 PIDFILE="$RUN_DIR/watch.$SESSION_ID.pid"
 
+# DB-open healthcheck (#197). The main loop guards every query with
+# `2>/dev/null || true`, so when sqlite3 cannot open the store the watcher keeps
+# spinning and silently delivers nothing — a silent outage. The native
+# sqlite3.exe / Git Bash path mismatch behind #197 is one trigger (now fixed in
+# agmsg_db_path), but permissions, a missing binary, or a corrupt file fail the
+# same way. A *missing* DB file is normal (no messages sent yet), so only flag
+# the case where the file exists but a trivial query cannot run: emit one line
+# on stdout (the Monitor event stream) and exit, turning the silent failure into
+# a visible one. This must run before cursor schema initialization so that a
+# schema write failure cannot hide the health error.
+if [ -f "$DB" ] && ! agmsg_sqlite "$DB" "SELECT 1;" >/dev/null 2>&1; then
+  echo "ERROR: cannot open message DB $DB"
+  exit 1
+fi
+agmsg_delivery_cursor_ensure_schema || exit 1
+
 # Resolve poll interval. Env var wins over config, default 5s.
 INTERVAL="${AGMSG_WATCH_INTERVAL:-}"
 if [ -z "$INTERVAL" ]; then
@@ -207,12 +225,6 @@ cleanup() {
 trap cleanup EXIT
 trap 'exit 0' INT TERM HUP
 
-# Resolve subscription set.
-PAIRS="$("$SCRIPT_DIR/identities.sh" "$PROJECT_PATH" "$AGENT_TYPE")"
-if [ -n "$ACTIVE_NAME" ]; then
-  PAIRS=$(printf '%s\n' "$PAIRS" | awk -v n="$ACTIVE_NAME" -F'\t' 'NF >= 2 && $2 == n')
-fi
-
 # Honor actas exclusivity locks. A (team, agent) pair currently owned by
 # another live session is removed from this watcher's subscription so
 # messages addressed to that role only reach the owning session. Pairs we
@@ -225,52 +237,54 @@ fi
 # claim fails because another live session beat us to it, exit with an
 # error — the user's host agent surfaces stderr and the original (broad)
 # watcher was already stopped by the actas flow, so this state is recoverable
-# by `drop` on the other session.
-if [ -n "$PAIRS" ]; then
-  filtered=""
-  skipped=""
-  held=""
-  while IFS=$'\t' read -r _team _agent; do
-    [ -z "$_team" ] && continue
-    state=$(actas_lock_state "$_team" "$_agent" "$SESSION_ID")
-    case "$state" in
-      other:*)
-        # If the caller is asking specifically for this name (actas flow),
-        # treat the conflict as a hard failure. Otherwise (broad subscribe)
-        # silently skip — peer owns the role, we don't need it.
-        if [ -n "$ACTIVE_NAME" ]; then
-          held="${held:+$held }${_team}/${_agent}(${state#other:})"
-        else
-          skipped="${skipped:+$skipped }${_team}/${_agent}(${state#other:})"
-        fi
-        continue
-        ;;
-    esac
-    if [ -n "$ACTIVE_NAME" ]; then
-      # Implicit claim — `actas` was the invoking flow. Covers the race
-      # where state-check said free but a peer claimed it between then and
-      # now.
-      result=$(actas_lock_claim "$_team" "$_agent" "$SESSION_ID" 2>/dev/null || true)
-      case "$result" in
-        held:*)
-          held="${held:+$held }${_team}/${_agent}(${result#held:})"
-          continue
-          ;;
-      esac
-    fi
-    filtered="${filtered:+$filtered$'\n'}${_team}"$'\t'"${_agent}"
-  done <<< "$PAIRS"
-  PAIRS="$filtered"
-  if [ -n "$skipped" ]; then
-    echo "agmsg watch: skipping pairs held by other sessions: $skipped" >&2
-  fi
-  if [ -n "$held" ]; then
-    echo "agmsg watch: cannot claim (held by other sessions): $held" >&2
-    echo "agmsg watch: run \`/agmsg drop <name>\` in the owning session, then retry." >&2
-    exit 1
-  fi
-fi
+# Build the SQL WHERE clause. Each pair contributes:
+#   (team='<team>' AND to_agent='<agent>')
+# joined by OR. Single quotes inside team/agent names are doubled for SQL.
+sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
 
+PAIRS=""
+WHERE_DELIVERY=""
+READY_ACTIVE=0
+
+sync_ready_files() {
+  local desired="" ready_path old_path owner team agent
+  if [ "$READY_ACTIVE" -eq 1 ] && [ -n "$ACTIVE_NAME" ]; then
+    while IFS=$'\t' read -r team agent; do
+      [ -n "$team" ] || continue
+      ready_path="$(agmsg_ready_path "$team" "$agent")"
+      printf '%s\n' "$SESSION_ID" > "$ready_path" 2>/dev/null || true
+      desired="${desired:+$desired$'\n'}$ready_path"
+    done <<< "$PAIRS"
+  fi
+  while IFS= read -r old_path; do
+    [ -n "$old_path" ] || continue
+    printf '%s\n' "$desired" | grep -Fxq "$old_path" && continue
+    owner=""
+    [ -f "$old_path" ] && IFS= read -r owner < "$old_path" || true
+    [ "$owner" = "$SESSION_ID" ] && rm -f "$old_path" 2>/dev/null || true
+  done <<< "$READY_FILES"
+  READY_FILES="$desired"
+}
+
+refresh_subscription() {
+  local next_pairs next_where="" claim_mode="" team agent t_esc a_esc cursor pair
+  [ -n "$ACTIVE_NAME" ] && claim_mode=claim
+  next_pairs="$(agmsg_session_subscription_pairs "$PROJECT_PATH" "$AGENT_TYPE" "$SESSION_ID" "$SESSION_ID" "$ACTIVE_NAME" "$claim_mode")" || return 1
+  while IFS=$'\t' read -r team agent; do
+    [ -n "$team" ] && [ -n "$agent" ] || continue
+    cursor="$(agmsg_delivery_cursor_initialize_missing "$team" "$agent" "$AGENT_TYPE" "$PROJECT_PATH" 2>/dev/null || true)"
+    case "$cursor" in ''|*[!0-9]*) cursor=0 ;; esac
+    t_esc=$(sql_escape "$team")
+    a_esc=$(sql_escape "$agent")
+    pair="(team='$t_esc' AND to_agent='$a_esc' AND read_at IS NULL AND id > $cursor)"
+    next_where="${next_where:+$next_where OR }$pair"
+  done <<< "$next_pairs"
+  PAIRS="$next_pairs"
+  WHERE_DELIVERY="$next_where"
+  sync_ready_files
+}
+
+refresh_subscription || exit 1
 if [ -z "$PAIRS" ]; then
   if [ -n "$ACTIVE_NAME" ]; then
     echo "agmsg watch: no registration for agent '$ACTIVE_NAME' in $PROJECT_PATH ($AGENT_TYPE); nothing to do"
@@ -280,41 +294,13 @@ if [ -z "$PAIRS" ]; then
   exit 0
 fi
 
-# Build the SQL WHERE clause. Each pair contributes:
-#   (team='<team>' AND to_agent='<agent>')
-# joined by OR. Single quotes inside team/agent names are doubled for SQL.
-sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
-
-WHERE_PAIRS=""
-while IFS=$'\t' read -r team agent; do
-  [ -z "$team" ] && continue
-  t_esc=$(sql_escape "$team")
-  a_esc=$(sql_escape "$agent")
-  pair="(team='$t_esc' AND to_agent='$a_esc')"
-  WHERE_PAIRS="${WHERE_PAIRS:+$WHERE_PAIRS OR }$pair"
-done <<< "$PAIRS"
-
-# Determine the starting watermark.
-#
-# The watermark is persisted per session_id so that a *restart* of this
-# session's watcher resumes from the last delivered id instead of jumping to
-# the current MAX(id). Monitor restarts are routine — `actas`/`drop` do
-# TaskStop + relaunch, `/clear`/resume re-fires the SessionStart directive, and
-# a killed watcher self-restarts — and the old "start from MAX(id)" behavior
-# silently dropped every message that landed in the gap between the previous
-# watcher stopping and the new one taking its mark. Resuming from the persisted
-# watermark closes that gap; staying strictly after the last delivered id
-# avoids re-streaming anything already seen. See #107.
-#
-# A *fresh* session (no persisted watermark) still starts from the current
-# MAX(id) — live push, no replay of history (the no-arg inbox check covers
-# historical unread, not this stream).
+# The durable per-registration cursor selects rows. This session watermark is
+# retained for lifecycle compatibility and records the last output id.
 WATERMARK_FILE="$RUN_DIR/watch.$SESSION_ID.watermark"
 persist_watermark() { printf '%s\n' "$LAST" > "$WATERMARK_FILE" 2>/dev/null || true; }
 
 # Mark a row's read_at so a later inbox.sh call does not re-surface it as
-# unread — the watermark only stops THIS watcher from re-streaming a row, it
-# never touches read_at (see the call sites below for the full rationale).
+# unread, then advance the durable cursor for this registration.
 # Shared by both the normal delivery path and the ctrl:despawn control-row
 # path so the two do not drift (#review finding, 2026-07-19). $1 is trusted
 # to be a DB-sourced id everywhere this is called, but it is guarded anyway
@@ -341,10 +327,14 @@ mark_read() {
     ''|*[!0-9]*) return 0 ;;
   esac
   if [ -z "$ACTIVE_NAME" ] && [ -n "$team" ] && [ -n "$to" ]; then
-    [ -e "$(agmsg_ready_path "$team" "$to")" ] && return 0
+    [ -e "$(agmsg_ready_path "$team" "$to")" ] && return 1
   fi
-  agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id=$mid AND read_at IS NULL;" 2>/dev/null \
-    || echo "agmsg watch: could not mark message $mid read (db busy/unavailable); a later inbox.sh call will re-surface it" >&2
+  if agmsg_sqlite "$DB" "UPDATE messages SET read_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id=$mid AND read_at IS NULL;" 2>/dev/null; then
+    agmsg_delivery_cursor_advance "$team" "$to" "$AGENT_TYPE" "$PROJECT_PATH" "$mid" 2>/dev/null || return 1
+    return 0
+  fi
+  echo "agmsg watch: could not mark message $mid read (db busy/unavailable); a later inbox.sh call will re-surface it" >&2
+  return 1
 }
 
 LAST=""
@@ -355,25 +345,10 @@ fi
 if [ -z "$LAST" ]; then
   LAST=0
   if [ -f "$DB" ]; then
-    LAST="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages WHERE $WHERE_PAIRS;" 2>/dev/null || echo 0)"
+    LAST="$(agmsg_sqlite "$DB" "SELECT COALESCE(MAX(id), 0) FROM messages;" 2>/dev/null || echo 0)"
   fi
   case "$LAST" in ''|*[!0-9]*) LAST=0 ;; esac
   persist_watermark
-fi
-
-# DB-open healthcheck (#197). The main loop guards every query with
-# `2>/dev/null || true`, so when sqlite3 cannot open the store the watcher keeps
-# spinning and silently delivers nothing — a silent outage. The native
-# sqlite3.exe / Git Bash path mismatch behind #197 is one trigger (now fixed in
-# agmsg_db_path), but permissions, a missing binary, or a corrupt file fail the
-# same way. A *missing* DB file is normal (no messages sent yet), so only flag
-# the case where the file exists but a trivial query cannot run: emit one line
-# on stdout (the Monitor event stream) and exit, turning the silent failure into
-# a visible one. Done before the ready sentinel so we never signal "ready" for a
-# watcher that cannot read the store.
-if [ -f "$DB" ] && ! agmsg_sqlite "$DB" "SELECT 1;" >/dev/null 2>&1; then
-  echo "ERROR: cannot open message DB $DB"
-  exit 1
 fi
 
 # Signal readiness. Once the subscription is resolved and the watermark is set,
@@ -382,17 +357,8 @@ fi
 # spawned agent always starts its watcher in actas mode — and the sentinel is
 # removed on exit (cleanup), so it tracks "a live watcher is receiving for this
 # role". `spawn --wait-ready` polls for it. See #108.
-if [ -n "$ACTIVE_NAME" ]; then
-  while IFS=$'\t' read -r _rt _ra; do
-    [ -z "$_rt" ] && continue
-    _rp="$(agmsg_ready_path "$_rt" "$_ra")"
-    # Stamp our session_id so cleanup (and a successor watcher) can tell whose
-    # sentinel it is — keeps "present iff a live watcher is receiving" honest
-    # across a quick actas restart. See #108 review.
-    printf '%s\n' "$SESSION_ID" > "$_rp" 2>/dev/null || true
-    READY_FILES="${READY_FILES:+$READY_FILES$'\n'}$_rp"
-  done <<< "$PAIRS"
-fi
+READY_ACTIVE=1
+sync_ready_files
 
 while true; do
   # Liveness guard (#67): exit promptly once the originating agent session is
@@ -407,12 +373,13 @@ while true; do
   if agmsg_instance_is_composite "$SESSION_ID" && ! agmsg_instance_alive "$SESSION_ID"; then
     exit 0
   fi
-  if [ -f "$DB" ]; then
+  refresh_subscription || exit 1
+  if [ -f "$DB" ] && [ -n "$WHERE_DELIVERY" ]; then
     ROWS="$(agmsg_sqlite -separator $'\x1f' "$DB" "
       SELECT id, created_at, team, from_agent, to_agent,
              replace(replace(body, char(13), ''), char(10), '\\n')
       FROM messages
-      WHERE id > $LAST AND ($WHERE_PAIRS)
+      WHERE $WHERE_DELIVERY
       ORDER BY id;
     " 2>/dev/null || true)"
 

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -133,6 +133,38 @@ run_launcher() {
   grep -q -- $'--pair team\tbob --thread thread-bob' "$CAPTURE"
 }
 
+@test "launcher: starts a role bridge joined after the dispatcher and leaves its gap job unread" {
+  put_record team alice thread-alice "$PROJ" codex
+  sleep 6 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- &
+  local launcher_pid=$!
+
+  local i
+  for i in {1..50}; do
+    grep -q -- $'--pair team\talice --thread thread-alice' "$CAPTURE" 2>/dev/null && break
+    sleep 0.1
+  done
+  grep -q -- $'--pair team\talice --thread thread-alice' "$CAPTURE"
+
+  bash "$SCRIPTS/join.sh" task-late executor-task-late codex "$PROJ" >/dev/null
+  put_record task-late executor-task-late thread-late "$PROJ" codex
+  bash "$SCRIPTS/send.sh" task-late alice executor-task-late "late bridge job" --force >/dev/null
+
+  for i in {1..50}; do
+    grep -q -- $'--pair task-late\texecutor-task-late --thread thread-late' "$CAPTURE" 2>/dev/null && break
+    sleep 0.1
+  done
+  grep -q -- $'--pair task-late\texecutor-task-late --thread thread-late' "$CAPTURE"
+
+  run bash "$TYPES/codex/watch-once.sh" "$PROJ" codex \
+    --pair $'task-late\texecutor-task-late' --timeout 1 --interval 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status=pending"* ]]
+
+  wait "$launcher_pid" 2>/dev/null || true
+  wait "$parent" 2>/dev/null || true
+}
+
 @test "launcher: only one dispatcher runs per project" {
   put_record team alice thread-alice "$PROJ" codex
   export MOCK_BRIDGE_SLEEP=8

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -971,6 +971,86 @@ EOF
   [[ "$output" =~ "ping copilot" ]]
 }
 
+@test "check-inbox: multiple identities process only registered team-agent pairs" {
+  bash "$SCRIPTS/join.sh" task-a executor-task-a claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" task-a planner-task-a  claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" task-b executor-task-b claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" task-b planner-task-b  claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/config.sh" set delivery.turn.check_interval 0 >/dev/null
+
+  bash "$SCRIPTS/send.sh" task-a planner-task-a executor-task-a "job for task a" >/dev/null
+  bash "$SCRIPTS/send.sh" task-b planner-task-b executor-task-b "job for task b" >/dev/null
+  bash "$SCRIPTS/send.sh" task-b planner-task-b executor-task-a "nonexistent cross pair" --force >/dev/null
+
+  run bash -c "echo '{}' | bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"job for task a"* ]]
+  [[ "$output" == *"job for task b"* ]]
+  [[ "$output" != *"nonexistent cross pair"* ]]
+
+  local cross_read
+  cross_read=$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" \
+    "SELECT COALESCE(read_at, '') FROM messages WHERE body='nonexistent cross pair';")
+  [ -z "$cross_read" ]
+}
+
+@test "check-inbox: role-session record selects one exact pair" {
+  bash "$SCRIPTS/join.sh" task-a executor-task-a claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" task-a planner-task-a  claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" task-b executor-task-b claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" task-b planner-task-b  claude-code "$TEST_PROJECT" >/dev/null
+  _seed_role_record task-b executor-task-b session-b "$TEST_PROJECT" claude-code
+  bash "$SCRIPTS/config.sh" set delivery.turn.check_interval 0 >/dev/null
+
+  bash "$SCRIPTS/send.sh" task-a planner-task-a executor-task-a "leave task a unread" >/dev/null
+  bash "$SCRIPTS/send.sh" task-b planner-task-b executor-task-b "deliver task b only" >/dev/null
+
+  run bash -c "printf '%s' '{\"session_id\":\"session-b\"}' | bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deliver task b only"* ]]
+  [[ "$output" != *"leave task a unread"* ]]
+
+  run bash "$SCRIPTS/inbox.sh" task-a executor-task-a --quiet
+  [[ "$output" == *"leave task a unread"* ]]
+}
+
+@test "check-inbox: ambiguous role-session records fall back to all registered pairs" {
+  bash "$SCRIPTS/join.sh" task-a executor-task-a claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" task-a planner-task-a  claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" task-b executor-task-b claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" task-b planner-task-b  claude-code "$TEST_PROJECT" >/dev/null
+  _seed_role_record task-a executor-task-a shared-session "$TEST_PROJECT" claude-code
+  _seed_role_record task-b executor-task-b shared-session "$TEST_PROJECT" claude-code
+  bash "$SCRIPTS/config.sh" set delivery.turn.check_interval 0 >/dev/null
+
+  bash "$SCRIPTS/send.sh" task-a planner-task-a executor-task-a "ambiguous task a" >/dev/null
+  bash "$SCRIPTS/send.sh" task-b planner-task-b executor-task-b "ambiguous task b" >/dev/null
+
+  run bash -c "printf '%s' '{\"session_id\":\"shared-session\"}' | bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ambiguous task a"* ]]
+  [[ "$output" == *"ambiguous task b"* ]]
+}
+
+@test "check-inbox: cooldown is isolated by session and registered pair" {
+  bash "$SCRIPTS/join.sh" task-a executor-task-a claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" task-a planner-task-a  claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" task-b executor-task-b claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" task-b planner-task-b  claude-code "$TEST_PROJECT" >/dev/null
+  _seed_role_record task-a executor-task-a session-a "$TEST_PROJECT" claude-code
+  _seed_role_record task-b executor-task-b session-b "$TEST_PROJECT" claude-code
+  bash "$SCRIPTS/config.sh" set delivery.turn.check_interval 60 >/dev/null
+
+  bash "$SCRIPTS/send.sh" task-a planner-task-a executor-task-a "first session job" >/dev/null
+  run bash -c "printf '%s' '{\"session_id\":\"session-a\"}' | bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT'"
+  [[ "$output" == *"first session job"* ]]
+
+  bash "$SCRIPTS/send.sh" task-b planner-task-b executor-task-b "second session job" >/dev/null
+  run bash -c "printf '%s' '{\"session_id\":\"session-b\"}' | bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"second session job"* ]]
+}
+
 @test "check-inbox: does not hang when stdin is a non-TTY pipe that never reaches EOF (#381)" {
   # A minimal `timeout` shim so this test exercises check-inbox.sh's own
   # `command -v timeout` code path deterministically, regardless of whether
@@ -1132,40 +1212,41 @@ JSON
   kill "$watcher_pid" 2>/dev/null || true
 }
 
-@test "watch.sh subscription is static — newly joined identities don't appear in a running watcher" {
+@test "watch.sh dynamically receives a job sent between join and subscription refresh" {
   mkdir -p "$TEST_SKILL_DIR/teams/myteam"
   cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
 {"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
 JSON
   DB="$TEST_SKILL_DIR/db/messages.db"
 
-  # Watcher starts with only `alice` registered. Default subscription set
-  # is resolved at launch and not re-evaluated each poll.
-  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" t-static "$TEST_PROJECT" claude-code > /tmp/agmsg-static 2>&1 3>&- &
+  local out="$TEST_SKILL_DIR/dynamic-watch.out"
+  local watermark="$TEST_SKILL_DIR/run/watch.t-static.watermark"
+  AGMSG_WATCH_INTERVAL=2 bash "$SCRIPTS/watch.sh" t-static "$TEST_PROJECT" claude-code >"$out" 2>&1 3>&- &
   local pid=$!
-  wait_for_file "$TEST_SKILL_DIR/run/watch.t-static.watermark"
+  wait_for_file "$watermark"
 
-  # Join `bob` to the same (project, type) after the watcher is running.
+  # The job lands immediately after join, before the watcher's next poll.
   bash "$SCRIPTS/join.sh" myteam bob claude-code "$TEST_PROJECT"
+  bash "$SCRIPTS/send.sh" myteam alice bob "for-bob-dynamic" >/dev/null
 
-  # Insert messages for both. alice should arrive (alice was in the original
-  # subscription set); bob should NOT arrive (joined after launch).
-  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'sys', 'alice', 'for-alice-static');"
-  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'sys', 'bob',   'for-bob-static');"
-
-  # A sentinel for alice inserted AFTER bob's row. Its arrival proves the
-  # watcher has already scanned past for-bob-static, which is what makes "bob
-  # never arrived" an assertion rather than a guess. Waiting on
-  # for-alice-static instead would not: it precedes bob's row, so seeing it
-  # says nothing about whether bob's had been reached yet.
-  sqlite3 "$DB" "INSERT INTO messages (team, from_agent, to_agent, body) VALUES ('myteam', 'sys', 'alice', 'static-sentinel');"
-  wait_for_file_contains /tmp/agmsg-static "static-sentinel"
+  wait_for_file_contains "$out" "for-bob-dynamic"
+  local cursor=""
+  local i
+  for i in {1..50}; do
+    if cursor=$(sqlite3 -cmd ".timeout 5000" "$DB" \
+      "SELECT last_id FROM delivery_cursors WHERE team='myteam' AND agent='bob' AND type='claude-code';" \
+      2>/dev/null); then
+      [ "${cursor:-0}" -gt 0 ] && break
+    fi
+    sleep 0.1
+  done
   kill -TERM "$pid" 2>/dev/null
   wait "$pid" 2>/dev/null || true
 
-  grep -q "for-alice-static" /tmp/agmsg-static
-  ! grep -q "for-bob-static" /tmp/agmsg-static
-  rm -f /tmp/agmsg-static
+  cursor=$(sqlite3 -cmd ".timeout 5000" "$DB" \
+    "SELECT last_id FROM delivery_cursors WHERE team='myteam' AND agent='bob' AND type='claude-code';")
+  grep -q "for-bob-dynamic" "$out"
+  [ "$cursor" -gt 0 ]
 }
 
 # --- set turn/off is project-scoped: must not kill other projects' watchers ---

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -85,7 +85,16 @@ _max_message_id() {
   bash "$SCRIPTS/send.sh" team bob alice "M2-in-gap" >/dev/null
 
   # Restart the SAME session_id — should resume from the persisted watermark.
-  run_watcher_for "$sid" "$TEST_SKILL_DIR/out2.log" 2
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
+    >"$TEST_SKILL_DIR/out2.log" 2>/dev/null 3>&- &
+  local w2=$!
+  wait_for_file_contains "$TEST_SKILL_DIR/out2.log" "M2-in-gap" || {
+    kill "$w2" 2>/dev/null || true
+    wait "$w2" 2>/dev/null || true
+    false
+  }
+  kill "$w2" 2>/dev/null || true
+  wait "$w2" 2>/dev/null || true
 
   # In-gap message is delivered on restart...
   grep -q "M2-in-gap" "$TEST_SKILL_DIR/out2.log"

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -93,10 +93,11 @@ _max_message_id() {
   ! grep -q "M1-before-stop" "$TEST_SKILL_DIR/out2.log"
 }
 
-@test "watch: a fresh session starts from now and does not replay history" {
+@test "watch: a fresh session does not replay history already displayed by inbox" {
   skip_on_windows "watcher background launch under Git Bash (#182)"
-  # Pre-existing message before any watcher for this session ever runs.
+  # A displayed row is historical even though this session is fresh.
   bash "$SCRIPTS/send.sh" team bob alice "M0-history" >/dev/null
+  bash "$SCRIPTS/inbox.sh" team alice >/dev/null
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-fresh" "$PROJ" claude-code \
     >"$TEST_SKILL_DIR/fresh.log" 2>/dev/null 3>&- &
@@ -110,15 +111,65 @@ _max_message_id() {
   kill "$w" 2>/dev/null || true
   wait "$w" 2>/dev/null || true
 
-  # Live message after attach is delivered; pre-existing history is not replayed.
+  # Live message after attach is delivered; displayed history is not replayed.
   grep -q "M-live" "$TEST_SKILL_DIR/fresh.log"
   ! grep -q "M0-history" "$TEST_SKILL_DIR/fresh.log"
 }
 
+@test "watch: a fresh watcher receives a job sent after join but before attach" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  bash "$SCRIPTS/join.sh" task-late executor-task-late claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/join.sh" task-late planner-task-late  claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/send.sh" task-late planner-task-late executor-task-late "M-join-attach-gap" >/dev/null
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-join-gap" "$PROJ" claude-code executor-task-late \
+    >"$TEST_SKILL_DIR/join-gap.log" 2>/dev/null 3>&- &
+  local watcher_pid=$!
+  wait_for_file_contains "$TEST_SKILL_DIR/join-gap.log" "M-join-attach-gap" || {
+    kill "$watcher_pid" 2>/dev/null || true
+    false
+  }
+  kill "$watcher_pid" 2>/dev/null || true
+  wait "$watcher_pid" 2>/dev/null || true
+
+  grep -q "M-join-attach-gap" "$TEST_SKILL_DIR/join-gap.log"
+}
+
+@test "join: repeating an existing registration does not skip its pending job" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  bash "$SCRIPTS/join.sh" task-repeat executor-repeat claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/join.sh" task-repeat planner-repeat  claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/send.sh" task-repeat planner-repeat executor-repeat "M-before-repeat-join" >/dev/null
+  bash "$SCRIPTS/join.sh" task-repeat executor-repeat claude-code "$PROJ" >/dev/null
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-repeat-join" "$PROJ" claude-code executor-repeat \
+    >"$TEST_SKILL_DIR/repeat-join.log" 2>/dev/null 3>&- &
+  local watcher_pid=$!
+  wait_for_file_contains "$TEST_SKILL_DIR/repeat-join.log" "M-before-repeat-join" || {
+    kill "$watcher_pid" 2>/dev/null || true
+    false
+  }
+  kill "$watcher_pid" 2>/dev/null || true
+  wait "$watcher_pid" 2>/dev/null || true
+
+  grep -q "M-before-repeat-join" "$TEST_SKILL_DIR/repeat-join.log"
+}
+
 @test "watch: persists a watermark file for the session" {
   skip_on_windows "watcher background launch under Git Bash (#182)"
-  run_watcher_for "sess-wm" "$TEST_SKILL_DIR/wm.log" 1.5
-  [ -f "$TEST_SKILL_DIR/run/watch.$(_iid sess-wm).watermark" ]
+  local watermark="$TEST_SKILL_DIR/run/watch.$(_iid sess-wm).watermark"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-wm" "$PROJ" claude-code \
+    >"$TEST_SKILL_DIR/wm.log" 2>/dev/null 3>&- &
+  local watcher_pid=$!
+  wait_for_file "$watermark" || {
+    kill "$watcher_pid" 2>/dev/null || true
+    wait "$watcher_pid" 2>/dev/null || true
+    false
+  }
+  kill "$watcher_pid" 2>/dev/null || true
+  wait "$watcher_pid" 2>/dev/null || true
+
+  [ -f "$watermark" ]
 }
 
 @test "watch: exits within one interval when its session dies, without advancing the watermark past an undelivered row (#67)" {


### PR DESCRIPTION
## Summary

- Refresh delivery subscriptions as identities join and persist a cursor for each registration from join time.
- Keep task-per-team roles reachable when they are added after watcher or bridge startup, without a restart or missed jobs.
- Scope turn cooldowns by session and registered pair so one task cannot suppress another.

## Tests

- `npx --yes bats --print-output-on-failure tests/test_watch.bats tests/test_delivery.bats tests/test_codex_bridge_launcher.bats` — 189/190; the remaining fixed-sleep watermark check was changed to wait for readiness
- `npx --yes bats --print-output-on-failure --filter '^watch: persists a watermark file for the session$' tests/test_watch.bats` — 1/1
