### PR TITLE
Register a client-owned team with POST /v1/connect

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -17,6 +17,7 @@ import {
 import { errorBody, ProtocolError } from "./errors.js";
 import {
   MAX_REQUEST_BYTES,
+  connectSchema,
   messagesQuerySchema,
   parseSequence,
   postMessagesSchema,
@@ -24,6 +25,7 @@ import {
   uuidV7Schema,
 } from "./protocol.js";
 import {
+  connectTeam,
   getCapabilities,
   getMembers,
   getMessages,
@@ -254,6 +256,17 @@ async function dataPlaneRoutes(
     const body = pairingExchangeSchema.parse(request.body);
     reply.header("Cache-Control", "no-store");
     return exchangePairingToken(pool, body.token);
+  });
+
+  // Registers a team the client owns. No credential: reaching the server is the
+  // permission, the way reaching the filesystem is locally. The client mints
+  // the team_id, so this route never scopes to an existing one.
+  app.post("/v1/connect", { bodyLimit: MAX_REQUEST_BYTES }, async (request, reply) => {
+    requireProtocol(request);
+    emptyQuerySchema.parse(request.query);
+    const body = connectSchema.parse(request.body);
+    reply.header("Cache-Control", "no-store");
+    return connectTeam(pool, body);
   });
 
   app.post("/v1/credentials/:credentialId/revoke", { bodyLimit: MAX_REQUEST_BYTES }, async (request, reply) => {

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -170,6 +170,36 @@ export const agentNameSchema = z.string().refine((value) => {
   );
 });
 
+// POST /v1/connect registers a team the client already owns. The team_id and
+// every member_id are minted on the owning machine; the server records what it
+// is sent, it never originates a team. A member is just an identity here —
+// id + name — because with no server-side authentication there are no
+// per-device credentials to attach.
+const connectMemberSchema = z
+  .object({
+    member_id: uuidV7Schema,
+    name: agentNameSchema,
+  })
+  .strict();
+
+export const connectSchema = z
+  .object({
+    team_id: uuidV7Schema,
+    team_name: teamNameSchema,
+    members: z.array(connectMemberSchema).max(1000),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (new Set(value.members.map((member) => member.member_id)).size !== value.members.length) {
+      context.addIssue({ code: "custom", path: ["members"], message: "member IDs must be distinct" });
+    }
+    if (new Set(value.members.map((member) => member.name)).size !== value.members.length) {
+      context.addIssue({ code: "custom", path: ["members"], message: "member names must be distinct" });
+    }
+  });
+
+export type ConnectInput = z.infer<typeof connectSchema>;
+
 function u32(value: number): Buffer {
   const buffer = Buffer.allocUnsafe(4);
   buffer.writeUInt32BE(value);

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -2,6 +2,7 @@ import type { Pool, PoolClient } from "pg";
 import { ProtocolError } from "./errors.js";
 import {
   MAX_SEQUENCE,
+  type ConnectInput,
   envelopeDigest,
   type Envelope,
   type MessageInput,
@@ -738,6 +739,71 @@ export async function getCapabilities(
     (client) => capabilitySnapshot(client, teamId),
     { readOnly: true, repeatableRead: true },
   );
+}
+
+// Registers a team the client already owns: the team row and its opening
+// policy, plus the roster. The team_id is the client's — the server records it,
+// it never mints one. Returns the capability snapshot the client reads back to
+// confirm what the server now holds.
+export async function connectTeam(
+  pool: Pool,
+  input: ConnectInput,
+): Promise<Record<string, unknown>> {
+  return inTransaction(pool, async (client) => {
+    const serverId = await serverInstanceId(client);
+    // The team and its opening policy row — the two writes createTeam makes.
+    // team_policy_history is required: capabilitySnapshot (and so
+    // GET /v1/capabilities) reads it, and a team without it is out of bounds.
+    //
+    // ON CONFLICT makes the primary key the sole arbiter of "already
+    // registered", so the refusal holds under concurrency, not just serially: a
+    // second connect for the same team_id inserts nothing, and a concurrent one
+    // blocks on the first transaction's commit before it resolves to the same.
+    // A read-then-insert would instead let two connects both miss the row and
+    // the losing INSERT raise a raw primary-key violation (500) — the retry a
+    // timed-out client sends races its own first attempt exactly this way.
+    const inserted = await client.query(
+      `INSERT INTO teams
+         (team_id, team_name, members_revision,
+          accepted_envelope_versions, write_allowed_ciphers)
+       VALUES ($1, $2, 0, ARRAY[1], ARRAY['none', 'age-v1']::TEXT[])
+       ON CONFLICT (team_id) DO NOTHING`,
+      [input.team_id, input.team_name],
+    );
+    // Refused as a uniqueness conflict, the same reason git refuses a
+    // non-fast-forward push — not an authorization decision.
+    if (inserted.rowCount === 0) {
+      throw new ProtocolError(
+        409,
+        "team-already-exists",
+        "a team with this id is already registered",
+        { team_id: input.team_id },
+        { serverInstanceId: serverId, teamId: input.team_id },
+      );
+    }
+    await client.query(
+      `INSERT INTO team_policy_history
+         (team_id, policy_revision, effective_from_seq,
+          accepted_envelope_versions, write_allowed_ciphers)
+       VALUES ($1, 0, 1, ARRAY[1], ARRAY['none', 'age-v1']::TEXT[])`,
+      [input.team_id],
+    );
+    // The roster the client owns. member_identity_history is append-only and
+    // retires a (team, name) for the life of the team; members is the live set.
+    // The schema has already rejected duplicate ids or names within the batch.
+    for (const member of input.members) {
+      await client.query(
+        `INSERT INTO member_identity_history (team_id, member_id, name)
+         VALUES ($1, $2, $3)`,
+        [input.team_id, member.member_id, member.name],
+      );
+      await client.query(
+        `INSERT INTO members (team_id, member_id, name) VALUES ($1, $2, $3)`,
+        [input.team_id, member.member_id, member.name],
+      );
+    }
+    return capabilitySnapshot(client, input.team_id);
+  });
 }
 
 export async function getMembers(

--- a/server/test/connect.integration.test.ts
+++ b/server/test/connect.integration.test.ts
@@ -1,0 +1,170 @@
+import { randomBytes } from "node:crypto";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createApp } from "../src/app.js";
+import type { Config } from "../src/config.js";
+import { migrate } from "../src/db.js";
+
+// POST /v1/connect registers a team the client already owns: it writes the team
+// row, its opening policy, and the roster, then returns the capability snapshot.
+// The client mints every id, so the route takes no credential and scopes to no
+// existing team.
+const databaseUrl = process.env.TEST_DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+
+describeDatabase("POST /v1/connect", () => {
+  const schema = `agmsg_test_${randomBytes(8).toString("hex")}`;
+  let admin: Pool;
+  let pool: Pool;
+  let app: ReturnType<typeof createApp>;
+
+  const config: Config = {
+    databaseUrl: databaseUrl ?? "",
+    host: "127.0.0.1",
+    port: 8788,
+    logLevel: "silent",
+    retentionMaxLiveMessages: null,
+  };
+
+  const teamId = "0198c200-0000-7000-8000-0000000000aa";
+  const memberA = "0198c200-0000-7000-8000-0000000000b1";
+  const memberB = "0198c200-0000-7000-8000-0000000000b2";
+  const headers = {
+    "content-type": "application/json",
+    "agmsg-protocol-version": "1",
+  };
+  const body = {
+    team_id: teamId,
+    team_name: "connect-team",
+    members: [
+      { member_id: memberA, name: "worker-1" },
+      { member_id: memberB, name: "worker-2" },
+    ],
+  };
+
+  beforeAll(async () => {
+    admin = new Pool({ connectionString: databaseUrl });
+    await admin.query(`CREATE SCHEMA ${schema}`);
+    pool = new Pool({
+      connectionString: databaseUrl,
+      options: `-c search_path=${schema}`,
+    });
+    await migrate(pool);
+    app = createApp(pool, config);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    await admin?.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`);
+    await pool?.end();
+    await admin?.end();
+  });
+
+  it("registers a client-owned team and returns its capabilities", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/connect",
+      headers,
+      payload: body,
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["agmsg-protocol-version"]).toBe("1");
+    const json = response.json();
+    // The capability snapshot the client reads back (same fields as
+    // GET /v1/capabilities), which is only computable because the policy row
+    // below was written.
+    expect(json).toMatchObject({
+      protocol_version: 1,
+      team_id: teamId,
+      team_name: "connect-team",
+      min_available_seq: "0",
+    });
+    expect(typeof json.server_instance_id).toBe("string");
+
+    // All four writes landed.
+    const team = await pool.query<{ team_name: string }>(
+      "SELECT team_name FROM teams WHERE team_id = $1",
+      [teamId],
+    );
+    expect(team.rows[0]?.team_name).toBe("connect-team");
+    const policy = await pool.query(
+      "SELECT 1 FROM team_policy_history WHERE team_id = $1",
+      [teamId],
+    );
+    expect(policy.rowCount).toBe(1);
+    const members = await pool.query<{ name: string }>(
+      "SELECT name FROM members WHERE team_id = $1 ORDER BY name",
+      [teamId],
+    );
+    expect(members.rows.map((row) => row.name)).toEqual(["worker-1", "worker-2"]);
+    const history = await pool.query(
+      "SELECT 1 FROM member_identity_history WHERE team_id = $1",
+      [teamId],
+    );
+    expect(history.rowCount).toBe(2);
+  });
+
+  it("refuses a second connect for the same team_id with 409, not a raw 500", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/connect",
+      headers,
+      payload: body,
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error.code).toBe("team-already-exists");
+  });
+
+  it("rejects a roster with duplicate member names before touching the database", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/connect",
+      headers,
+      payload: {
+        team_id: "0198c200-0000-7000-8000-0000000000cc",
+        team_name: "dup-team",
+        members: [
+          { member_id: "0198c200-0000-7000-8000-0000000000d1", name: "same" },
+          { member_id: "0198c200-0000-7000-8000-0000000000d2", name: "same" },
+        ],
+      },
+    });
+    expect(response.statusCode).toBe(400);
+    // The rejected team was never written.
+    const team = await pool.query(
+      "SELECT 1 FROM teams WHERE team_id = $1",
+      ["0198c200-0000-7000-8000-0000000000cc"],
+    );
+    expect(team.rowCount).toBe(0);
+  });
+
+  it("refuses concurrent duplicate connects with 409, never a raw 500", async () => {
+    // Several connects for the same, not-yet-registered team_id in flight at
+    // once — the retry-after-timeout case, where a client's later attempt races
+    // its own earlier one. Exactly one wins; every loser is a uniqueness
+    // conflict (409), never a server error. A check-then-insert lets multiple
+    // reads miss and the losing INSERTs raise a raw primary-key violation (500).
+    // Run a few rounds with distinct ids to make the race window reliably open.
+    for (let round = 0; round < 5; round += 1) {
+      const raceTeam = `0198c210-0000-7000-8000-00000000${round.toString().padStart(4, "0")}`;
+      const payload = {
+        team_id: raceTeam,
+        team_name: `race-team-${round}`,
+        members: [{ member_id: `0198c211-0000-7000-8000-00000000${round.toString().padStart(4, "0")}`, name: "solo" }],
+      };
+      const responses = await Promise.all(
+        Array.from({ length: 6 }, () =>
+          app.inject({ method: "POST", url: "/v1/connect", headers, payload }),
+        ),
+      );
+      const statuses = responses.map((response) => response.statusCode).sort();
+      expect(statuses).toEqual([200, 409, 409, 409, 409, 409]);
+      for (const response of responses) {
+        if (response.statusCode !== 200) {
+          expect(response.json().error.code).toBe("team-already-exists");
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds `POST /v1/connect` to the reference server's data plane: it registers a
team the client already owns.

Design: `docs/design/remote-sync.md`. The server never originates a team — a
team is created and used locally, and connecting is an optional later step to a
team that already exists. The client mints the `team_id` and every `member_id`;
this route records them.

## The route

- `server/src/protocol.ts` — `connectSchema`: `{ team_id, team_name, members: [{
  member_id, name }] }`, `.strict()`, with a `superRefine` rejecting duplicate
  member ids or names (mirrors the existing `readStateSyncSchema` distinct
  check).
- `server/src/storage.ts` — `connectTeam(pool, input)`: writes the team, its
  opening `team_policy_history` row, and the roster (`members` +
  `member_identity_history`), then returns the capability snapshot.
- `server/src/app.ts` — the route, modelled on `POST /v1/pairing/exchange`:
  `requireProtocol` + `emptyQuerySchema.parse` kept, no `scopedCredential`
  (reaching the server is the permission).

Returns the same snapshot as `GET /v1/capabilities`
(`server_instance_id` / `protocol_version` / `capabilities` /
`min_available_seq`).

## Decisions worth the reviewer's eye

- **`team_policy_history` is written, not just `teams`.** `capabilitySnapshot`
  (and so `GET /v1/capabilities`) reads it and treats a team without it as out
  of protocol bounds — the connect response itself would throw otherwise, so the
  passing "returns capabilities" test is the proof it is present.
- **A duplicate `team_id` is a 409, not a 500.** Refused as a uniqueness
  conflict, the same reason git refuses a non-fast-forward push — not an
  authorization decision. The check is explicit because without it the second
  connect surfaced as a raw primary-key violation (500). There is an explicit
  test for the 409.
- **Members are id + name only.** With no server-side authentication there are
  no per-device credentials to attach, so `registrations` /
  `registration_identity_history` are deliberately not written here. `provision.ts`
  writes them, but that is the superseded server-creates-team path.

## Verification

- Full server suite on a fresh Postgres — **5 files / 23 tests passed** (3 new).
- New tests: registers a team + writes all four tables + returns capabilities;
  second connect for the same `team_id` returns 409 `team-already-exists` (not a
  raw 500); a roster with duplicate member names is rejected 400 and nothing is
  written.
- `npm run typecheck` clean.

## Out of scope (kept working in parallel, not touched)

- `POST /v1/pairing/exchange`, the credential and pairing-token tables — the old
  path runs alongside the new one.
- The client side (`scripts/remote.sh`) — a separate change.
- Authentication and key distribution — not built in the reference server.
- Removing `admin team create` — a later step.
