### PR TITLE
Mint stable local team identities

### DIFF
--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -90,31 +90,6 @@ _jsonl_read_cursor_migrate() {
   rmdir "$lock" 2>/dev/null || true
 }
 
-# UUIDv7 (§2.5) — python3 preferred, /dev/urandom shell fallback. No counter file.
-_jsonl_uuid7() {
-  if command -v python3 >/dev/null 2>&1; then
-    python3 - <<'PY'
-import os, time
-ms = int(time.time() * 1000) & ((1 << 48) - 1)
-b = bytearray(os.urandom(16))
-b[0] = (ms >> 40) & 0xFF; b[1] = (ms >> 32) & 0xFF
-b[2] = (ms >> 24) & 0xFF; b[3] = (ms >> 16) & 0xFF
-b[4] = (ms >> 8) & 0xFF;  b[5] = ms & 0xFF
-b[6] = 0x70 | (b[6] & 0x0F)
-b[8] = 0x80 | (b[8] & 0x3F)
-h = b.hex()
-print(f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}")
-PY
-    return
-  fi
-  local ms hex rnd
-  ms=$(( $(date -u +%s) * 1000 ))
-  hex=$(printf '%012x' "$ms")
-  rnd=$(head -c 10 /dev/urandom | od -An -tx1 | tr -d ' \n')
-  printf '%s-%s-7%s-8%s-%s\n' \
-    "${hex:0:8}" "${hex:8:4}" "${rnd:0:3}" "${rnd:3:3}" "${rnd:6:12}"
-}
-
 # Serialize all log mutations (append / mark / compact / import) behind a portable
 # mkdir lock; record-returning reads hold the same lock through their snapshot EOF.
 _jsonl_with_lock() {
@@ -234,7 +209,7 @@ storage_sync_reprocess() {
 storage_send() {
   _JSONL_TEAM="$1"
   local team="$1" from="$2" to="$3" body="$4"
-  local id at line; id="$(_jsonl_uuid7)"; at="$(_jsonl_now)"
+  local id at line; id="$(compat_uuid7)"; at="$(_jsonl_now)"
   _jsonl_init_file
   line="$(jq -nc --arg id "$id" --arg team "$team" --arg from "$from" \
     --arg to "$to" --arg body "$body" --arg at "$at" \
@@ -384,7 +359,7 @@ _jsonl_mark() {
   for id in "$@"; do
     printf '%s\n' "$existing" | grep -Fxq "$id" && continue
     at="$(_jsonl_now)"
-    line="$(jq -nc --arg id "$(_jsonl_uuid7)" --arg msg_id "$id" --arg team "$team" \
+    line="$(jq -nc --arg id "$(compat_uuid7)" --arg msg_id "$id" --arg team "$team" \
       --arg agent "$agent" --arg at "$at" \
       '{type:"message_read",id:$id,msg_id:$msg_id,team:$team,agent:$agent,at:$at}')"
     printf '%s\n' "$line" >> "$log"

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -772,7 +772,7 @@ storage_sync_apply_pull() {
       body=$(printf '%s\n' "$line" | jq -r '.projection.body // empty')
       at=$(printf '%s\n' "$line" | jq -r '.projection.created_at // empty')
       [ -n "$from" ] && [ -n "$to" ] && [ -n "$body" ] && [ -n "$at" ] || { rm -f "$sql_file"; return 13; }
-      local_id=$(_sqlite_uuid7) || { rm -f "$sql_file"; return 13; }
+      local_id=$(compat_uuid7) || { rm -f "$sql_file"; return 13; }
       printf "%s\n" "
         INSERT INTO events(type,id,team,from_agent,to_agent,body,at)
         SELECT 'message_sent','$local_id','$tl','$(_sqlite_lit "$from")',

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -34,32 +34,6 @@ _sqlite_data() {
   ( set -o pipefail; agmsg_sqlite "$(_sqlite_db "$1")" "$2" | tr -d '\r' )
 }
 
-# UUIDv7: 48-bit ms timestamp + version/variant + random. python3 preferred;
-# fall back to a /dev/urandom shell build. No counter file (§2.5).
-_sqlite_uuid7() {
-  if command -v python3 >/dev/null 2>&1; then
-    python3 - <<'PY'
-import os, time
-ms = int(time.time() * 1000) & ((1 << 48) - 1)
-b = bytearray(os.urandom(16))
-b[0] = (ms >> 40) & 0xFF; b[1] = (ms >> 32) & 0xFF
-b[2] = (ms >> 24) & 0xFF; b[3] = (ms >> 16) & 0xFF
-b[4] = (ms >> 8) & 0xFF;  b[5] = ms & 0xFF
-b[6] = 0x70 | (b[6] & 0x0F)            # version 7
-b[8] = 0x80 | (b[8] & 0x3F)            # variant 10
-h = b.hex()
-print(f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}")
-PY
-    return
-  fi
-  local ms hex rnd
-  ms=$(( $(date -u +%s) * 1000 ))
-  hex=$(printf '%012x' "$ms")
-  rnd=$(head -c 10 /dev/urandom | od -An -tx1 | tr -d ' \n')
-  printf '%s-%s-7%s-8%s-%s\n' \
-    "${hex:0:8}" "${hex:8:4}" "${rnd:0:3}" "${rnd:3:3}" "${rnd:6:12}"
-}
-
 # IN (...) list of "team:agent" pairs.
 _sqlite_pair_in() {
   local out="" p t a
@@ -175,7 +149,7 @@ storage_init() {
 
 storage_send() {
   local team="$1" from="$2" to="$3" body="$4"
-  local id at db; id="$(_sqlite_uuid7)"; at="$(_sqlite_now)"; db="$(_sqlite_db "$team")"
+  local id at db; id="$(compat_uuid7)"; at="$(_sqlite_now)"; db="$(_sqlite_db "$team")"
   local insert="
     INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
     VALUES ('message_sent','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
@@ -219,7 +193,7 @@ storage_read_cursor_consume() {
   for id in "$@"; do
     sql="$sql
       INSERT INTO events(type,id,team,agent,msg_id,at)
-      SELECT 'message_read','$(_sqlite_lit "$(_sqlite_uuid7)")','$tl','$al',
+      SELECT 'message_read','$(_sqlite_lit "$(compat_uuid7)")','$tl','$al',
              '$(_sqlite_lit "$id")','$(_sqlite_lit "$at")'
        WHERE NOT EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'
          AND r.team='$tl' AND r.agent='$al' AND r.msg_id='$(_sqlite_lit "$id")');"

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -67,8 +67,8 @@ agmsg_lock_acquire "$TEAMS_DIR/$TEAM" || exit 1
 
 # --- Ensure team config exists ---
 if [ ! -f "$TEAM_CONFIG" ]; then
-  INITIAL_CONFIG=$(printf '{\n  "name": "%s",\n  "agents": {},\n  "created_at": "%s"\n}' \
-    "$TEAM" "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
+  INITIAL_CONFIG=$(printf '{\n  "name": "%s",\n  "team_id": "%s",\n  "agents": {},\n  "created_at": "%s"\n}' \
+    "$TEAM" "$(compat_uuid7)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
   agmsg_write_atomic "$TEAM_CONFIG" "$INITIAL_CONFIG"
   echo "Created team: $TEAM"
 fi
@@ -118,15 +118,27 @@ EXISTING=$(agmsg_sqlite_mem "
 ")
 
 if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
-  AGENT_OBJ=$(sqlite3 :memory: "SELECT json_object('registrations', json_array(json('$REGISTRATION_ESCAPED')));")
+  TEAM_HAS_IDS=$(agmsg_sqlite_mem "
+    SELECT json_type(CAST(readfile('$(agmsg_sql_readfile_path "$TEAM_CONFIG")') AS TEXT), '\$.team_id');
+  ")
+  if [ "$TEAM_HAS_IDS" = "text" ]; then
+    AGENT_OBJ=$(sqlite3 :memory: "SELECT json_object(
+      'member_id', '$(compat_uuid7)',
+      'registrations', json_array(json('$REGISTRATION_ESCAPED'))
+    );")
+  else
+    AGENT_OBJ=$(sqlite3 :memory: \
+      "SELECT json_object('registrations', json_array(json('$REGISTRATION_ESCAPED')));")
+  fi
 else
   EXISTING_ESCAPED=$(printf '%s' "$EXISTING" | sed "s/'/''/g")
   NORMALIZED=$(agmsg_sqlite_mem "
     WITH agent(a) AS (SELECT '$EXISTING_ESCAPED')
     SELECT CASE
       WHEN json_type(json_extract(a, '\$.registrations')) = 'array' THEN a
-      ELSE json_object(
-        'registrations',
+      ELSE json_set(
+        a,
+        '\$.registrations',
         json_array(json_object(
           'type', json_extract(a, '\$.type'),
           'project', json_extract(a, '\$.project')

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -132,6 +132,19 @@ compat_uuidgen() {
   fi | tr -d '\r'
 }
 
+# Generate a UUIDv7: 48-bit millisecond timestamp, version 7, RFC 4122
+# variant, and random tail bytes. Keep this in the core dependency tier:
+# /dev/urandom supplies the random bytes without invoking Python or another
+# optional runtime. No counter or other persistent state.
+compat_uuid7() {
+  local ms hex rnd
+  ms=$(( $(date -u +%s) * 1000 ))
+  hex=$(printf '%012x' "$ms")
+  rnd=$(head -c 10 /dev/urandom | od -An -tx1 | tr -d ' \n')
+  printf '%s-%s-7%s-8%s-%s\n' \
+    "${hex:0:8}" "${hex:8:4}" "${rnd:0:3}" "${rnd:3:3}" "${rnd:6:12}"
+}
+
 # Get file modification time as epoch seconds.
 # Replaces: stat -f %m (macOS) / stat -c %Y (Linux/MSYS2)
 compat_file_mtime() {

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -33,6 +33,19 @@ if ! declare -F agmsg_validate_team_name >/dev/null 2>&1; then
   fi
 fi
 
+# Built-in storage drivers use the shared UUIDv7 generator. Keep it available
+# through the storage facade so direct and registry-driven loads use one
+# implementation on every platform.
+if ! declare -F compat_uuid7 >/dev/null 2>&1; then
+  if [ -n "${BASH_SOURCE[0]:-}" ]; then
+    # shellcheck disable=SC1091
+    source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat.sh"
+  elif [ -n "${SKILL_DIR:-}" ]; then
+    # shellcheck disable=SC1091
+    source "$SKILL_DIR/scripts/lib/compat.sh"
+  fi
+fi
+
 # Echo the directory that holds (or will hold) the message store.
 agmsg_storage_dir() {
   if [ -n "${AGMSG_STORAGE_PATH:-}" ]; then

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -69,15 +69,16 @@ _remote_read_config_field() {
 # initial-config shape exactly (no agents registered yet — connect only
 # establishes the sync binding, not an agent identity in the team).
 _remote_ensure_team() {
-  local team="$1" cfg
+  local team="$1" cfg initial
   cfg="$(_remote_team_config "$team")"
+  mkdir -p "$TEAMS_DIR/$team"
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
   if [ ! -f "$cfg" ]; then
-    mkdir -p "$TEAMS_DIR/$team"
-    local initial
-    initial=$(printf '{\n  "name": "%s",\n  "agents": {},\n  "created_at": "%s"\n}' \
-      "$team" "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
+    initial=$(printf '{\n  "name": "%s",\n  "team_id": "%s",\n  "agents": {},\n  "created_at": "%s"\n}' \
+      "$team" "$(compat_uuid7)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
     agmsg_write_atomic "$cfg" "$initial"
   fi
+  agmsg_lock_release
 }
 
 # Reject a non-HTTPS endpoint (token/credential would cross the wire in

--- a/tests/test_local_team_ids.bats
+++ b/tests/test_local_team_ids.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+UUID7_RE='^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+
+setup() {
+  setup_test_env
+}
+
+teardown() {
+  teardown_test_env
+}
+
+config_field() {
+  local cfg="$1" path="$2" escaped
+  escaped="$(sed "s/'/''/g" "$cfg")"
+  sqlite_mem "SELECT json_extract('$escaped', '$path');"
+}
+
+write_legacy_team() {
+  local team="$1" agents="$2"
+  mkdir -p "$TEST_SKILL_DIR/teams/$team"
+  printf '{"name":"%s","agents":%s,"created_at":"2026-01-01T00:00:00Z"}\n' \
+    "$team" "$agents" > "$TEST_SKILL_DIR/teams/$team/config.json"
+}
+
+@test "new joins mint stable UUIDv7 team and member identities" {
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/project-a
+  local cfg="$TEST_SKILL_DIR/teams/demo/config.json"
+  local team_id alice_id first
+  team_id="$(config_field "$cfg" '$.team_id')"
+  alice_id="$(config_field "$cfg" '$.agents.alice.member_id')"
+  [[ "$team_id" =~ $UUID7_RE ]]
+  [[ "$alice_id" =~ $UUID7_RE ]]
+  [ "$team_id" != "$alice_id" ]
+
+  first="$(cat "$cfg")"
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/project-a
+  [ "$(cat "$cfg")" = "$first" ]
+
+  bash "$SCRIPTS/join.sh" demo bob codex /tmp/project-b
+  local bob_id
+  bob_id="$(config_field "$cfg" '$.agents.bob.member_id')"
+  [[ "$bob_id" =~ $UUID7_RE ]]
+  [ "$bob_id" != "$alice_id" ]
+  [ "$(config_field "$cfg" '$.team_id')" = "$team_id" ]
+  [ "$(config_field "$cfg" '$.agents.alice.member_id')" = "$alice_id" ]
+}
+
+@test "a team never mixes members with and without identities" {
+  write_legacy_team legacy \
+    '{"alice":{"type":"claude-code","project":"/tmp/project-a"}}'
+  bash "$SCRIPTS/join.sh" legacy bob codex /tmp/project-b
+  local legacy_cfg="$TEST_SKILL_DIR/teams/legacy/config.json"
+  [ -z "$(config_field "$legacy_cfg" '$.team_id')" ]
+  [ "$(sqlite_mem "SELECT COUNT(*) FROM json_each(
+    json_extract(CAST(readfile('$(rf "$legacy_cfg")') AS TEXT), '\$.agents')
+  ) WHERE json_type(value, '\$.member_id') IS NOT NULL;")" -eq 0 ]
+
+  bash "$SCRIPTS/join.sh" current alice claude-code /tmp/project-a
+  bash "$SCRIPTS/join.sh" current bob codex /tmp/project-b
+  local current_cfg="$TEST_SKILL_DIR/teams/current/config.json"
+  [[ "$(config_field "$current_cfg" '$.team_id')" =~ $UUID7_RE ]]
+  [ "$(sqlite_mem "SELECT COUNT(*) FROM json_each(
+    json_extract(CAST(readfile('$(rf "$current_cfg")') AS TEXT), '\$.agents')
+  ) WHERE json_type(value, '\$.member_id') = 'text';")" -eq 2 ]
+}
+
+@test "agent and team renames preserve identities on a current team" {
+  bash "$SCRIPTS/join.sh" old-team alice claude-code /tmp/a
+  bash "$SCRIPTS/rename.sh" old-team alice renamed
+  local old_cfg="$TEST_SKILL_DIR/teams/old-team/config.json"
+  local team_id member_id
+  team_id="$(config_field "$old_cfg" '$.team_id')"
+  member_id="$(config_field "$old_cfg" '$.agents.renamed.member_id')"
+  [[ "$team_id" =~ $UUID7_RE ]]
+  [[ "$member_id" =~ $UUID7_RE ]]
+
+  bash "$SCRIPTS/rename-team.sh" old-team new-team
+  local new_cfg="$TEST_SKILL_DIR/teams/new-team/config.json"
+  [ "$(config_field "$new_cfg" '$.team_id')" = "$team_id" ]
+  [ "$(config_field "$new_cfg" '$.agents.renamed.member_id')" = "$member_id" ]
+  [ "$(config_field "$new_cfg" '$.name')" = "new-team" ]
+}
+
+@test "remote-created local config starts with a stable team identity" {
+  local python_bin
+  python_bin="$(command -v python3)"
+  "$python_bin" "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
+    </dev/null > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" 3>&- &
+  local server_pid=$!
+  wait_for_file_contains "$TEST_SKILL_DIR/server.port" '^[0-9][0-9]*$'
+  local endpoint="http://127.0.0.1:$(cat "$TEST_SKILL_DIR/server.port")"
+
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$endpoint" good-token remote-demo
+  kill "$server_pid" 2>/dev/null || true
+  wait "$server_pid" 2>/dev/null || true
+
+  local cfg="$TEST_SKILL_DIR/teams/remote-demo/config.json"
+  local team_id
+  team_id="$(config_field "$cfg" '$.team_id')"
+  [[ "$team_id" =~ $UUID7_RE ]]
+  [ "$(config_field "$cfg" '$.agents')" = "{}" ]
+  [ "$(config_field "$cfg" '$.team_id')" = "$team_id" ]
+}
+
+@test "core join does not require python3" {
+  local no_python cmd
+  no_python="$(mktemp -d)"
+  for cmd in bash dirname sqlite3 sed date mkdir rmdir cat mv head od tr sort basename paste; do
+    ln -s "$(command -v "$cmd")" "$no_python/$cmd"
+  done
+
+  env PATH="$no_python" bash "$SCRIPTS/join.sh" demo alice codex /tmp/project
+  local cfg="$TEST_SKILL_DIR/teams/demo/config.json"
+  [[ "$(config_field "$cfg" '$.team_id')" =~ $UUID7_RE ]]
+  [[ "$(config_field "$cfg" '$.agents.alice.member_id')" =~ $UUID7_RE ]]
+  [ ! -d "$TEST_SKILL_DIR/teams/demo/.config.lock" ]
+}
+
+@test "core UUID generation never executes an unusable python3" {
+  local fake_bin marker
+  fake_bin="$(mktemp -d)"
+  marker="$TEST_SKILL_DIR/python-executed"
+  printf '#!/usr/bin/env bash\n: > "$PYTHON_MARKER"\nexit 99\n' > "$fake_bin/python3"
+  chmod +x "$fake_bin/python3"
+
+  PYTHON_MARKER="$marker" PATH="$fake_bin:$PATH" \
+    bash "$SCRIPTS/join.sh" demo alice codex /tmp/project
+  local cfg="$TEST_SKILL_DIR/teams/demo/config.json"
+  [ ! -e "$marker" ]
+  [[ "$(config_field "$cfg" '$.team_id')" =~ $UUID7_RE ]]
+  [[ "$(config_field "$cfg" '$.agents.alice.member_id')" =~ $UUID7_RE ]]
+}


### PR DESCRIPTION
## Summary

- Mint UUIDv7 `team_id` and `member_id` values when a new local team is created.
- Mint a `member_id` for a new member only when the team already has a `team_id`, keeping every team either wholly ID-bearing or wholly name-based.
- Leave legacy teams untouched until connect performs their all-at-once migration.
- Reuse one shell-only UUIDv7 implementation across registry identities and the SQLite/JSONL storage drivers without adding a Python dependency to core.
- Add no readers for the new fields yet.

## Validation

- Rebased onto `integration/remote` at `b00ad3f`.
- `bats tests/test_local_team_ids.bats tests/test_team.bats </dev/null` (80 passed)
- Existing affected suites covering team, remote, key, team-list, storage contracts, and remote sync (266 passed, 3 skipped)
- GitHub Actions: all Ubuntu/macOS Bats shards, Windows helpers, JSONL storage contracts, age-v1, and remote server/PostgreSQL checks passed
- `bash -n` for all changed shell scripts
- `git diff --check`
