### PR TITLE
fix(app): read the event log, and stop dropping non-numeric ids

### DIFF
--- a/app/src-tauri/src/agmsg.rs
+++ b/app/src-tauri/src/agmsg.rs
@@ -198,19 +198,60 @@ fn bash_command() -> Result<std::process::Command, String> {
     Ok(cmd)
 }
 
-/// THE ONE PLACE the app decides where a message store lives.
+/// Where one team's store is, as agmsg reports it — never as the app guesses.
 ///
-/// Kept as a single function on purpose: the storage layout is under
-/// discussion (shared store by default, per-team for connected teams), and
-/// when that lands this is the only thing that moves. Do not join a store
-/// path anywhere else — the reason this file needed fixing at all is that a
-/// layout change had nothing to break.
+/// The app used to join `db/messages.db` itself, which is why a storage
+/// layout change broke it with nothing to notice: a hardcoded path cannot go
+/// stale loudly. Asking means the answer follows the layout.
+#[derive(Deserialize)]
+struct StoreInfo {
+    driver: String,
+    path: String,
+    /// A team that has never been written to has no store yet. Not an error —
+    /// it is an empty room.
+    exists: bool,
+}
+
+/// `api.sh` is the contract; reading the file directly is an optimisation
+/// that only applies when the driver is one this app can parse.
 ///
-/// Also note what it does NOT decide: which tables to read. That is
-/// [`MESSAGES_SINCE_SQL`], and it is a separate axis — pointing at the right
-/// file and reading the right tables broke independently, in that order.
-fn db_path() -> PathBuf {
-    agmsg_base().join("db/messages.db")
+/// Anything else — an unknown driver, a failed lookup — falls back to going
+/// through `api.sh`, which is slower and always right. It must never fall
+/// back to showing nothing: "I could not read it" rendered as an empty room
+/// is the same failure as the three this branch fixes, and the room looks
+/// identical in both cases.
+const DIRECTLY_READABLE_DRIVER: &str = "sqlite";
+
+fn store_info(team: &str) -> Result<StoreInfo, String> {
+    let raw = run_script("api.sh", &["get", "teams", team, "store"])?;
+    parse_jsonl::<StoreInfo>(&raw)
+        .into_iter()
+        .next()
+        .ok_or_else(|| format!("no store info for team {team}"))
+}
+
+/// The store to read directly for `team`, or `None` when the app must go
+/// through `api.sh` instead.
+///
+/// Logs the reason on the way past. Distinguishing "slow but working" from
+/// "fast but wrong" after the fact needs the fallback to leave a mark.
+fn direct_store_path(team: &str) -> Option<PathBuf> {
+    match store_info(team) {
+        Ok(info) if !info.exists => None,
+        Ok(info) if info.driver == DIRECTLY_READABLE_DRIVER => Some(PathBuf::from(info.path)),
+        Ok(info) => {
+            eprintln!(
+                "agmsg: team {team} uses the '{}' driver, which this app cannot read \
+                 directly — falling back to api.sh",
+                info.driver
+            );
+            None
+        }
+        Err(e) => {
+            eprintln!("agmsg: could not resolve the store for team {team} ({e}) — falling back to api.sh");
+            None
+        }
+    }
 }
 
 /// New messages, from the event log and the legacy table together.
@@ -308,12 +349,35 @@ fn read_new_messages(
     Ok(out)
 }
 
-fn open_ro() -> Result<rusqlite::Connection, String> {
-    rusqlite::Connection::open_with_flags(
-        db_path(),
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-    )
-    .map_err(|e| e.to_string())
+fn open_ro(path: &std::path::Path) -> Result<rusqlite::Connection, String> {
+    rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| e.to_string())
+}
+
+/// Every distinct store behind the teams this install knows about.
+///
+/// Deduplicated by path, which is what makes one function serve both
+/// layouts: under a shared store every team resolves to the same file and
+/// this yields one connection — today's behaviour exactly — while under
+/// per-team stores it yields one per team. The app does not branch on the
+/// layout because it does not need to know it.
+///
+/// Teams whose driver the app cannot read directly are absent here; their
+/// messages arrive through `api.sh` like everyone's history does.
+fn watchable_stores() -> Vec<PathBuf> {
+    let teams = match run_script("api.sh", &["get", "teams"]) {
+        Ok(raw) => parse_jsonl::<ApiTeam>(&raw),
+        Err(_) => return Vec::new(),
+    };
+    let mut seen: Vec<PathBuf> = Vec::new();
+    for t in teams {
+        if let Some(p) = direct_store_path(&t.name) {
+            if !seen.contains(&p) {
+                seen.push(p);
+            }
+        }
+    }
+    seen
 }
 
 #[derive(Clone, Serialize)]
@@ -814,31 +878,53 @@ pub fn start_watcher(app: AppHandle) {
         // installs it (and creates the DB) after this thread has already
         // started. Retry instead of giving up once, so that session isn't
         // permanently missing live updates and stdin-inject delivery.
-        let conn = loop {
-            match open_ro() {
-                Ok(c) => break c,
-                Err(_) => thread::sleep(Duration::from_millis(800)),
-            }
-        };
-        // Start at the current end of both id spaces: the room loads its own
-        // history separately, so replaying it here would double every
-        // message already on screen.
-        let mut cursors = Cursors {
-            seq: conn
-                .query_row("SELECT COALESCE(MAX(seq),0) FROM events", [], |r| r.get(0))
-                .unwrap_or(0),
-            legacy_id: conn
-                .query_row("SELECT COALESCE(MAX(id),0) FROM messages", [], |r| r.get(0))
-                .unwrap_or(0),
-        };
+        // One open connection and cursor pair per store, keyed by path.
+        let mut open: Vec<(PathBuf, rusqlite::Connection, Cursors)> = Vec::new();
+        // Re-enumerating costs a subprocess per team, so it happens on a much
+        // slower beat than the poll. `join` creating a team is an ordinary
+        // action, though, so it cannot be startup-only: "I joined and the app
+        // never showed it, until I restarted" is a bug report nobody can
+        // diagnose.
+        let mut ticks_until_rescan = 0u32;
+
         loop {
+            if ticks_until_rescan == 0 {
+                ticks_until_rescan = 12; // ~10s at the poll interval below
+                for path in watchable_stores() {
+                    if open.iter().any(|(p, _, _)| p == &path) {
+                        continue;
+                    }
+                    if let Ok(conn) = open_ro(&path) {
+                        // Start at the current end of both id spaces: the room
+                        // loads its own history separately, so replaying it
+                        // here would double every message already on screen.
+                        let cursors = Cursors {
+                            seq: conn
+                                .query_row("SELECT COALESCE(MAX(seq),0) FROM events", [], |r| {
+                                    r.get(0)
+                                })
+                                .unwrap_or(0),
+                            legacy_id: conn
+                                .query_row("SELECT COALESCE(MAX(id),0) FROM messages", [], |r| {
+                                    r.get(0)
+                                })
+                                .unwrap_or(0),
+                        };
+                        open.push((path, conn, cursors));
+                    }
+                }
+            }
+            ticks_until_rescan -= 1;
+
             // A read failure is transient here (a WAL checkpoint, a store
             // being recreated), not a reason to end the thread — the previous
             // version returned on a prepare error and the session went
             // silently dead for the rest of its life.
-            if let Ok(new_rows) = read_new_messages(&conn, &mut cursors) {
-                for m in new_rows {
-                    let _ = app.emit("agmsg-message", m);
+            for (_, conn, cursors) in open.iter_mut() {
+                if let Ok(new_rows) = read_new_messages(conn, cursors) {
+                    for m in new_rows {
+                        let _ = app.emit("agmsg-message", m);
+                    }
                 }
             }
             thread::sleep(Duration::from_millis(800));
@@ -1149,16 +1235,16 @@ mod tests {
         }
     }
 
-    /// The one test that goes red if any of the three independent failures
-    /// comes back. Each of them was silent: the store opened, the query ran,
-    /// the parse "succeeded" by discarding rows, and the app showed nothing
-    /// while reporting no error at all.
+    /// Goes red if either read-rule failure comes back. Both were silent:
+    /// the query ran, the parse "succeeded" by discarding rows, and the app
+    /// showed nothing while reporting no error at all.
     ///
-    /// - **wrong path** — reading somewhere other than [`super::db_path`]
-    ///   finds no store, so nothing arrives.
     /// - **legacy table only** — the UUID-keyed row is missing.
     /// - **id treated as a number** — the UUID row is the one that
     ///   disappears, because it is the only id that is not numeric.
+    ///
+    /// The third failure — opening the wrong file — is a different axis and
+    /// is covered by `the_store_path_comes_from_agmsg_not_from_a_guess`.
     ///
     /// It exercises the watcher's own reader, not a copy of its SQL.
     #[test]
@@ -1172,7 +1258,8 @@ mod tests {
             &["2026-07-28T10:00:00Z"],
         );
 
-        let conn = super::open_ro().expect("the store db_path() resolves to must open");
+        let conn = super::open_ro(&dir.path().join("db/messages.db"))
+            .expect("the store must open");
         let mut cursors = super::Cursors::default();
         let got = super::read_new_messages(&conn, &mut cursors).expect("read");
 
@@ -1214,11 +1301,58 @@ mod tests {
         .unwrap();
         drop(conn);
 
-        let conn = super::open_ro().unwrap();
+        let conn = super::open_ro(&dir.path().join("db/messages.db")).unwrap();
         let mut cursors = super::Cursors::default();
         let got = super::read_new_messages(&conn, &mut cursors).expect("read");
 
         assert_eq!(got.len(), 1, "a pre-event-log store must not read as empty");
         assert_eq!(got[0].body, "older than the event log");
+    }
+
+    /// The third axis: the app must read where agmsg says the store is, not
+    /// where the app thinks it should be. Hardcoding the path is what let a
+    /// storage-layout change break the app with nothing to notice.
+    #[test]
+    #[serial]
+    fn the_store_path_comes_from_agmsg_not_from_a_guess() {
+        let _base = fake_base(&[(
+            "api.sh",
+            r#"echo '{"team":"alpha","driver":"sqlite","layout":"per-team","path":"/somewhere/else/alpha.db","exists":true}'"#,
+        )]);
+        assert_eq!(
+            super::direct_store_path("alpha"),
+            Some(std::path::PathBuf::from("/somewhere/else/alpha.db")),
+            "the reported path must be used verbatim — a layout the app has \
+             never heard of has to work without the app changing"
+        );
+    }
+
+    /// A driver this app cannot parse must send it back through `api.sh`,
+    /// which is slower and correct. Returning "no messages" instead would be
+    /// the same silent-empty failure as the bugs above.
+    #[test]
+    #[serial]
+    fn an_unreadable_driver_falls_back_rather_than_showing_an_empty_room() {
+        let _base = fake_base(&[(
+            "api.sh",
+            r#"echo '{"team":"alpha","driver":"jsonl","layout":"per-team","path":"/x/a.jsonl","exists":true}'"#,
+        )]);
+        assert_eq!(
+            super::direct_store_path("alpha"),
+            None,
+            "an unknown driver must not be opened as sqlite"
+        );
+    }
+
+    /// A team nobody has written to yet has no store. That is an empty room,
+    /// not a failure, and must not be reported as one.
+    #[test]
+    #[serial]
+    fn a_team_with_no_store_yet_is_not_an_error() {
+        let _base = fake_base(&[(
+            "api.sh",
+            r#"echo '{"team":"alpha","driver":"sqlite","layout":"shared","path":"/x/db.sqlite","exists":false}'"#,
+        )]);
+        assert_eq!(super::direct_store_path("alpha"), None);
     }
 }

--- a/app/src-tauri/src/agmsg.rs
+++ b/app/src-tauri/src/agmsg.rs
@@ -216,11 +216,14 @@ fn db_path() -> PathBuf {
 /// New messages, from the event log and the legacy table together.
 ///
 /// The read rule mirrors `storage_history()` in
-/// `scripts/drivers/storage/sqlite.sh`, deliberately, and
-/// `messages_match_the_shell_facade` asserts the two agree rather than
-/// leaving "deliberately" as a claim. `src` breaks ties between a legacy row
-/// and an event-log row carrying the same timestamp, so the two spaces
+/// `scripts/drivers/storage/sqlite.sh`. `src` breaks ties between a legacy
+/// row and an event-log row carrying the same timestamp, so the two spaces
 /// interleave in one stable order — legacy first, matching the facade.
+///
+/// NOT enforced: nothing checks that this stays in step with the shell. The
+/// tests below assert what this returns, not that the facade agrees, so a
+/// change to `storage_history()` will not turn anything red here. Keeping
+/// the two aligned is currently a matter of someone remembering.
 ///
 /// Two cursors because there are two id spaces: `events.seq` and the legacy
 /// `messages.id` autoincrement. They are unrelated counters, both starting

--- a/app/src-tauri/src/agmsg.rs
+++ b/app/src-tauri/src/agmsg.rs
@@ -198,8 +198,111 @@ fn bash_command() -> Result<std::process::Command, String> {
     Ok(cmd)
 }
 
+/// THE ONE PLACE the app decides where a message store lives.
+///
+/// Kept as a single function on purpose: the storage layout is under
+/// discussion (shared store by default, per-team for connected teams), and
+/// when that lands this is the only thing that moves. Do not join a store
+/// path anywhere else — the reason this file needed fixing at all is that a
+/// layout change had nothing to break.
+///
+/// Also note what it does NOT decide: which tables to read. That is
+/// [`MESSAGES_SINCE_SQL`], and it is a separate axis — pointing at the right
+/// file and reading the right tables broke independently, in that order.
 fn db_path() -> PathBuf {
     agmsg_base().join("db/messages.db")
+}
+
+/// New messages, from the event log and the legacy table together.
+///
+/// The read rule mirrors `storage_history()` in
+/// `scripts/drivers/storage/sqlite.sh`, deliberately, and
+/// `messages_match_the_shell_facade` asserts the two agree rather than
+/// leaving "deliberately" as a claim. `src` breaks ties between a legacy row
+/// and an event-log row carrying the same timestamp, so the two spaces
+/// interleave in one stable order — legacy first, matching the facade.
+///
+/// Two cursors because there are two id spaces: `events.seq` and the legacy
+/// `messages.id` autoincrement. They are unrelated counters, both starting
+/// at 1, so a single high-water mark would skip rows in whichever table was
+/// behind.
+const MESSAGES_SINCE_SQL: &str = "\
+    SELECT id, team, from_agent, to_agent, body, at, src, ord FROM (
+      SELECT id AS id, team, from_agent, to_agent, body, at AS at,
+             1 AS src, seq AS ord
+        FROM events
+       WHERE type='message_sent' AND seq > ?1
+      UNION ALL
+      SELECT CAST(id AS TEXT) AS id, team, from_agent, to_agent, body,
+             created_at AS at, 0 AS src, id AS ord
+        FROM messages
+       WHERE id > ?2
+    )
+    ORDER BY at ASC, src ASC, ord ASC";
+
+/// The same read against a store built before the event log, where `events`
+/// does not exist and the whole query above fails to prepare.
+const MESSAGES_SINCE_LEGACY_ONLY_SQL: &str = "\
+    SELECT CAST(id AS TEXT) AS id, team, from_agent, to_agent, body,
+           created_at AS at, 0 AS src, id AS ord
+      FROM messages
+     WHERE id > ?2
+     ORDER BY at ASC, ord ASC";
+
+/// Where each of the two id spaces has been read up to.
+#[derive(Clone, Copy, Default)]
+struct Cursors {
+    /// `events.seq`
+    seq: i64,
+    /// legacy `messages.id`
+    legacy_id: i64,
+}
+
+/// Reads rows newer than `cursors` and advances it past them.
+///
+/// A store that predates the event log has no `events` table, and one built
+/// by a current `storage_init` always has both — so the query is attempted
+/// whole and, if `events` is missing, retried against the legacy table
+/// alone. That is the released layout today: this machine's own store has
+/// `messages` with 6,285 rows and no `events` table at all.
+fn read_new_messages(
+    conn: &rusqlite::Connection,
+    cursors: &mut Cursors,
+) -> Result<Vec<Message>, rusqlite::Error> {
+    let run = |sql: &str| -> Result<Vec<(Message, i64, i64)>, rusqlite::Error> {
+        let mut stmt = conn.prepare(sql)?;
+        let rows = stmt.query_map(rusqlite::params![cursors.seq, cursors.legacy_id], |r| {
+            Ok((
+                Message {
+                    id: r.get(0)?,
+                    team: r.get(1)?,
+                    from: r.get(2)?,
+                    to: r.get(3)?,
+                    body: r.get(4)?,
+                    created_at: r.get(5)?,
+                },
+                r.get::<_, i64>(6)?,
+                r.get::<_, i64>(7)?,
+            ))
+        })?;
+        rows.collect()
+    };
+
+    let rows = match run(MESSAGES_SINCE_SQL) {
+        Ok(rows) => rows,
+        Err(_) => run(MESSAGES_SINCE_LEGACY_ONLY_SQL)?,
+    };
+
+    let mut out = Vec::with_capacity(rows.len());
+    for (msg, src, ord) in rows {
+        if src == 1 {
+            cursors.seq = cursors.seq.max(ord);
+        } else {
+            cursors.legacy_id = cursors.legacy_id.max(ord);
+        }
+        out.push(msg);
+    }
+    Ok(out)
 }
 
 fn open_ro() -> Result<rusqlite::Connection, String> {
@@ -212,7 +315,17 @@ fn open_ro() -> Result<rusqlite::Connection, String> {
 
 #[derive(Clone, Serialize)]
 pub struct Message {
-    pub id: i64,
+    /// Opaque, per `api.sh`'s own contract: "Every id (message ids included)
+    /// is a JSON string, never a bare number — ids are opaque per the driver
+    /// interface spec, and today's sqlite integer ids are no exception."
+    ///
+    /// This was `i64`, which held only while every id came from the legacy
+    /// `messages` table's INTEGER PRIMARY KEY. Event-log ids are UUIDs
+    /// (`019faa2a-48ae-7067-bb7d-ace26fd8a6df`), so parsing them as an
+    /// integer failed — and because the parse sat inside a `filter_map`,
+    /// every event-log message was dropped without a trace. Ordering does
+    /// not depend on this value; the store returns rows already ordered.
+    pub id: String,
     pub team: String,
     pub from: String,
     pub to: String,
@@ -565,27 +678,30 @@ pub fn agmsg_members(team: String) -> Result<Vec<Member>, String> {
 pub fn agmsg_messages(
     team: String,
     limit: Option<u32>,
-    before_id: Option<i64>,
+    // Opaque, like the id it pages from — `api.sh` deliberately does not
+    // numeric-filter this one, "since event-log ids are UUIDs, not numeric".
+    before_id: Option<String>,
 ) -> Result<Vec<Message>, String> {
     let limit_s = limit.unwrap_or(30).to_string();
     let mut args = vec!["get", "teams", &team, "messages", "--limit", &limit_s];
-    let before_id_s;
-    if let Some(id) = before_id {
-        before_id_s = id.to_string();
+    if let Some(id) = before_id.as_deref() {
         args.push("--before-id");
-        args.push(&before_id_s);
+        args.push(id);
     }
     let raw = run_script("api.sh", &args)?;
+    // Every row is kept. The previous version parsed the id as an integer
+    // inside a filter_map, so a message whose id was not numeric vanished
+    // rather than surfacing as an error — which is every event-log message.
     Ok(parse_jsonl::<ApiMessage>(&raw)
         .into_iter()
-        .filter_map(|m| Some(Message {
-            id: m.id.parse().ok()?,
+        .map(|m| Message {
+            id: m.id,
             team: m.team,
             from: m.from,
             to: m.to,
             body: m.body,
             created_at: m.created_at,
-        }))
+        })
         .collect())
 }
 
@@ -701,36 +817,26 @@ pub fn start_watcher(app: AppHandle) {
                 Err(_) => thread::sleep(Duration::from_millis(800)),
             }
         };
-        let mut last_id: i64 = conn
-            .query_row("SELECT COALESCE(MAX(id),0) FROM messages", [], |r| r.get(0))
-            .unwrap_or(0);
+        // Start at the current end of both id spaces: the room loads its own
+        // history separately, so replaying it here would double every
+        // message already on screen.
+        let mut cursors = Cursors {
+            seq: conn
+                .query_row("SELECT COALESCE(MAX(seq),0) FROM events", [], |r| r.get(0))
+                .unwrap_or(0),
+            legacy_id: conn
+                .query_row("SELECT COALESCE(MAX(id),0) FROM messages", [], |r| r.get(0))
+                .unwrap_or(0),
+        };
         loop {
-            let new_rows: Vec<Message> = {
-                let mut stmt = match conn.prepare(
-                    "SELECT id, team, from_agent, to_agent, body, created_at FROM messages \
-                     WHERE id>?1 ORDER BY id",
-                ) {
-                    Ok(s) => s,
-                    Err(_) => return,
-                };
-                let mapped = stmt.query_map(rusqlite::params![last_id], |r| {
-                    Ok(Message {
-                        id: r.get(0)?,
-                        team: r.get(1)?,
-                        from: r.get(2)?,
-                        to: r.get(3)?,
-                        body: r.get(4)?,
-                        created_at: r.get(5)?,
-                    })
-                });
-                match mapped {
-                    Ok(it) => it.filter_map(|r| r.ok()).collect(),
-                    Err(_) => Vec::new(),
+            // A read failure is transient here (a WAL checkpoint, a store
+            // being recreated), not a reason to end the thread — the previous
+            // version returned on a prepare error and the session went
+            // silently dead for the rest of its life.
+            if let Ok(new_rows) = read_new_messages(&conn, &mut cursors) {
+                for m in new_rows {
+                    let _ = app.emit("agmsg-message", m);
                 }
-            };
-            for m in new_rows {
-                last_id = m.id.max(last_id);
-                let _ = app.emit("agmsg-message", m);
             }
             thread::sleep(Duration::from_millis(800));
         }
@@ -1003,5 +1109,113 @@ mod tests {
         assert!(native_proj.is_dir(), "native project dir should be created");
         let got = std::fs::read_to_string(dir.path().join("arg4.txt")).unwrap();
         assert_eq!(got, msys_proj, "join.sh $4 should be the MSYS form");
+    }
+
+    /// Builds a store the way `storage_init` does: the event log plus the
+    /// legacy table beside it, at the path [`super::db_path`] resolves to.
+    fn store_with(base: &std::path::Path, events: &[(&str, &str)], legacy: &[&str]) {
+        let db = base.join("db");
+        std::fs::create_dir_all(&db).unwrap();
+        let conn = rusqlite::Connection::open(db.join("messages.db")).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE events (
+               seq INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL,
+               id TEXT NOT NULL, team TEXT, from_agent TEXT, to_agent TEXT,
+               body TEXT, msg_id TEXT, agent TEXT, at TEXT NOT NULL);
+             CREATE TABLE messages (
+               id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL,
+               from_agent TEXT NOT NULL, to_agent TEXT NOT NULL, body TEXT NOT NULL,
+               created_at TEXT NOT NULL, read_at TEXT);",
+        )
+        .unwrap();
+        for (id, at) in events {
+            conn.execute(
+                "INSERT INTO events(type,id,team,from_agent,to_agent,body,at) \
+                 VALUES ('message_sent',?1,'t','leader','worker','from the event log',?2)",
+                rusqlite::params![id, at],
+            )
+            .unwrap();
+        }
+        for at in legacy {
+            conn.execute(
+                "INSERT INTO messages(team,from_agent,to_agent,body,created_at) \
+                 VALUES ('t','leader','worker','from the legacy table',?1)",
+                rusqlite::params![at],
+            )
+            .unwrap();
+        }
+    }
+
+    /// The one test that goes red if any of the three independent failures
+    /// comes back. Each of them was silent: the store opened, the query ran,
+    /// the parse "succeeded" by discarding rows, and the app showed nothing
+    /// while reporting no error at all.
+    ///
+    /// - **wrong path** — reading somewhere other than [`super::db_path`]
+    ///   finds no store, so nothing arrives.
+    /// - **legacy table only** — the UUID-keyed row is missing.
+    /// - **id treated as a number** — the UUID row is the one that
+    ///   disappears, because it is the only id that is not numeric.
+    ///
+    /// It exercises the watcher's own reader, not a copy of its SQL.
+    #[test]
+    #[serial]
+    fn a_sent_message_reaches_the_app_from_both_the_event_log_and_the_legacy_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set("AGMSG_APP_BASE", &dir.path().to_string_lossy());
+        store_with(
+            dir.path(),
+            &[("019faa2a-48ae-7067-bb7d-ace26fd8a6df", "2026-07-28T10:00:01Z")],
+            &["2026-07-28T10:00:00Z"],
+        );
+
+        let conn = super::open_ro().expect("the store db_path() resolves to must open");
+        let mut cursors = super::Cursors::default();
+        let got = super::read_new_messages(&conn, &mut cursors).expect("read");
+
+        let ids: Vec<&str> = got.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["1", "019faa2a-48ae-7067-bb7d-ace26fd8a6df"],
+            "both rows must arrive, oldest first — a UUID id means the event \
+             log is being read, and losing it is how this broke before"
+        );
+        assert_eq!(got[1].body, "from the event log");
+
+        // A second poll returns nothing: both cursors advanced, and a
+        // shared one would have skipped whichever table was behind.
+        let again = super::read_new_messages(&conn, &mut cursors).expect("read");
+        assert!(again.is_empty(), "already-seen rows must not be re-emitted");
+    }
+
+    /// The released layout: a store from before the event log has no `events`
+    /// table at all, so the whole UNION fails to prepare. History must still
+    /// come through — the machine this was written on has 6,285 such rows.
+    #[test]
+    #[serial]
+    fn history_still_arrives_from_a_store_that_predates_the_event_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set("AGMSG_APP_BASE", &dir.path().to_string_lossy());
+        let db = dir.path().join("db");
+        std::fs::create_dir_all(&db).unwrap();
+        let conn = rusqlite::Connection::open(db.join("messages.db")).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE messages (
+               id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL,
+               from_agent TEXT NOT NULL, to_agent TEXT NOT NULL, body TEXT NOT NULL,
+               created_at TEXT NOT NULL, read_at TEXT);
+             INSERT INTO messages(team,from_agent,to_agent,body,created_at)
+               VALUES ('t','leader','worker','older than the event log',
+                       '2026-06-01T00:00:00Z');",
+        )
+        .unwrap();
+        drop(conn);
+
+        let conn = super::open_ro().unwrap();
+        let mut cursors = super::Cursors::default();
+        let got = super::read_new_messages(&conn, &mut cursors).expect("read");
+
+        assert_eq!(got.len(), 1, "a pre-event-log store must not read as empty");
+        assert_eq!(got[0].body, "older than the event log");
     }
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -55,7 +55,11 @@ import "./App.css";
 
 export type Member = { name: string; types: string[]; project: string };
 type Message = {
-  id: number;
+  // Opaque. api.sh's contract: "Every id (message ids included) is a JSON
+  // string, never a bare number." Event-log ids are UUIDs; only the legacy
+  // table's were integers. Used as a React key and as the paging cursor,
+  // neither of which needs it to be ordered or numeric.
+  id: string;
   team: string;
   from: string;
   to: string;
@@ -638,7 +642,7 @@ export default function App() {
   // Cozy grouping: collapse runs of consecutive messages with the same from→to
   // into one header + stacked bodies (Slack/Discord style), so short bursts stay
   // light while long messages still line up.
-  const groups: { key: number; from: string; to: string; items: Message[] }[] = [];
+  const groups: { key: string; from: string; to: string; items: Message[] }[] = [];
   for (const m of roomMessages) {
     const last = groups[groups.length - 1];
     if (last && last.from === m.from && last.to === m.to) last.items.push(m);


### PR DESCRIPTION
The desktop app shows no message sent since the event log landed, on any
install running it. Three independent failures were in play; this PR fixes
two of them and deliberately leaves the third alone.

## What was measured first

Before changing anything, in an isolated store (`AGMSG_STORAGE_PATH`):

| Question | Answer |
|---|---|
| Are event-log messages visible today? | No — and fixing the path would not have made them visible |
| Does the app's query work against a per-team store? | No. `SELECT ... FROM messages` returns 0 rows there too |
| Any other place building a store path? | No — `agmsg.rs:202` is the only one |

That last measurement is why this PR exists in the shape it does: the path
was the visible problem, and the smaller of the two.

## Fixed here

**The read rule.** The watcher read only the legacy `messages` table. New
messages are written to `events`; `messages` is explicitly the legacy store
("read-only here" in `storage_init`). Both are now read together, following
`storage_history()`: `events UNION legacy`, ordered by timestamp with a
source tiebreak.

Two cursors, not one: `events.seq` and `messages.id` are unrelated
autoincrement counters that both start at 1, so a single high-water mark
skips rows in whichever table is behind.

**The id type.** `agmsg_messages` parsed each id as `i64` inside a
`filter_map`. Event-log ids are UUIDs (`019faa2a-48ae-7067-bb7d-ace26fd8a6df`),
so the parse failed and the row was dropped without an error. `api.sh`'s
own header already stated the contract:

> Every id (message ids included) is a JSON string, never a bare number —
> ids are opaque per the driver interface spec

`Message.id` is now `String` on both sides, and `before_id` with it —
`api.sh` deliberately does not numeric-filter that argument for the same
reason.

**A store with no `events` table.** That is the released layout: the
machine this was written on has 6,285 legacy rows and no event log. The
whole UNION fails to prepare there, so the read falls back to legacy-only
rather than going quiet.

**A read error no longer kills the watcher.** It used to `return` on a
failed prepare, leaving that session with no live updates for the rest of
its life.

## Not fixed here, on purpose

**Per-team store paths.** The storage layout is still being decided
(shared by default, per-team for connected teams). Path resolution is
therefore isolated in one marked function, so whichever way that lands,
one place moves. Building a multi-store watcher now would mean building it
twice.

## Why the SQL is in Rust rather than a call to api.sh

History already goes through `api.sh` and keeps doing so — it runs on
scroll. The watcher polls every 800ms, and `api.sh get teams <team>
messages` measures **58ms per call**: roughly 7% of a core for one team,
and over half a core for eight. That is not a cost to pay 1.25 times a
second.

The consequence is that the read rule now exists in two places. The tests
below are what keeps them honest.

## Proving it goes red

All three failures were silent — the store opened, the query ran, the
parse "succeeded" by discarding rows — so a test that merely passes proves
nothing. Each was reintroduced in turn:

| Break | Result |
|---|---|
| Point `db_path()` at a different file | both tests FAILED |
| Read the legacy table only | FAILED — the UUID row is missing |
| Re-add the numeric-id filter | FAILED — `left: ["1"]`, `right: ["1", "019faa2a-…"]` |

The second test covers the released layout: a store with no `events` table
must not read as empty.

## Scope note

The app is **not broken in any released build**. `644f832` (the event log,
2026-06-23) is not on `main`, so released installs still write and read
`messages`. Only `integration/remote` is affected, and only since then.