### PR TITLE
feat(sync): upload the history a legacy store already has

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -355,6 +355,84 @@ _sqlite_sync_generation() {
     "SELECT generation FROM sync_store_metadata WHERE singleton=1;" | tr -d '\r'
 }
 
+# Legacy rows live in `messages`, which predates the event log and which nothing
+# writes any more. The push candidate query reads `events` only, so a team whose
+# history is entirely legacy would connect and upload nothing -- silently, since
+# an empty page is a normal answer. This projects those rows into the event log
+# once, per team, at the moment that team first prepares a push.
+#
+# The synthesized seq is `id - _AGMSG_LEGACY_SEQ_OFFSET`, which is negative and
+# therefore below every existing position. That single choice satisfies all
+# three things the position has to be at once:
+#
+#   collision-free  existing seq values are the positive AUTOINCREMENT space
+#   stable          it is a pure function of the legacy row id, so a re-run
+#                   reproduces it and the wire id reserved against it in
+#                   sync_messages stays valid
+#   ordered         legacy ids ascend, so the projected history sorts ahead of
+#                   every event that already exists -- chronologically correct
+#
+# It also leaves read state alone. `read_cursors.local_position` holds positive
+# values and the unread query asks for `seq > cursor`, so projected rows are
+# below every cursor and stay delivered, which is what the phase-3 adoption
+# already decided about them.
+#
+# Explicit negative rowids do not disturb AUTOINCREMENT: sqlite_sequence keeps
+# the high-water it had, so the delivery tip (which reads it) is unaffected.
+_AGMSG_LEGACY_SEQ_OFFSET=1000000000
+
+_sqlite_sync_project_legacy() {
+  local team="$1" db tl done_marker max_id
+  db="$(_sqlite_db "$team")"; tl="$(_sqlite_lit "$team")"
+
+  done_marker=$(agmsg_sqlite "$db" "SELECT value FROM storage_metadata
+    WHERE key='legacy_push_projected_v1';" 2>/dev/null | tr -d '\r')
+  [ -z "$done_marker" ] || return 0
+
+  # A legacy id at or above the offset would project to a NON-negative seq and
+  # collide with the live space. Refuse rather than corrupt: this is a constant
+  # chosen to sit far above any real store, and "far above" is an assumption
+  # worth failing on rather than assuming quietly.
+  max_id=$(agmsg_sqlite "$db" "SELECT COALESCE(MAX(id),0) FROM messages
+    WHERE team='$tl';" 2>/dev/null | tr -d '\r')
+  case "$max_id" in ''|*[!0-9]*) max_id=0 ;; esac
+  if [ "$max_id" -ge "$_AGMSG_LEGACY_SEQ_OFFSET" ]; then
+    echo "agmsg: legacy message id $max_id exceeds the projection offset" >&2
+    return 13
+  fi
+
+  agmsg_sqlite "$db" "
+    INSERT INTO events(seq,type,id,team,from_agent,to_agent,body,at)
+      SELECT m.id - $_AGMSG_LEGACY_SEQ_OFFSET,'message_sent',CAST(m.id AS TEXT),
+             m.team,m.from_agent,m.to_agent,m.body,m.created_at
+        FROM messages m
+       WHERE m.team='$tl'
+         AND NOT EXISTS(SELECT 1 FROM events e
+                         WHERE e.seq=m.id - $_AGMSG_LEGACY_SEQ_OFFSET);
+    INSERT OR REPLACE INTO storage_metadata(key,value)
+      VALUES('legacy_push_projected_v1','1');" >/dev/null 2>&1 || return 13
+}
+
+# Bindings default their push cursor to 0, which is above the projected space,
+# so a team with legacy history would prepare zero candidates. Lower the cursor
+# to just under the oldest projected position -- for a team with no legacy rows
+# the subquery is NULL and this leaves the cursor exactly where it was.
+#
+# Lowering an already-advanced cursor is safe: both the candidate query and the
+# emission filter on `server_seq IS NULL`, so rows the server already
+# acknowledged are skipped rather than resent. The cost is a wider scan.
+_sqlite_sync_rewind_to_legacy() {
+  local team="$1" db tl
+  db="$(_sqlite_db "$team")"; tl="$(_sqlite_lit "$team")"
+  agmsg_sqlite "$db" "
+    UPDATE sync_bindings
+       SET push_cursor = MIN(push_cursor,
+             COALESCE((SELECT MIN(seq)-1 FROM events
+                        WHERE type='message_sent' AND team='$tl' AND seq<0),
+                      push_cursor))
+     WHERE local_team='$tl';" >/dev/null 2>&1 || return 13
+}
+
 _sqlite_sync_ensure_binding() {
   local team="$1" server="$2" remote="$3" protocol="$4" generation="$5"
   agmsg_sqlite "$(_sqlite_db "$team")" "INSERT OR IGNORE INTO sync_bindings
@@ -397,7 +475,9 @@ storage_sync_prepare_push() {
   case "$max_blob" in ''|*[!0-9]*) return 13 ;; esac
 
   generation=$(_sqlite_sync_generation "$team") || return 13
+  _sqlite_sync_project_legacy "$team" || return 13
   _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || return 13
+  _sqlite_sync_rewind_to_legacy "$team" || return 13
   db="$(_sqlite_db "$team")"; tl="$(_sqlite_lit "$team")"
 
   local rows uuids
@@ -573,7 +653,19 @@ storage_sync_reconcile_push() {
     wire=$(printf '%s\n' "$line" | jq -r '.id // empty')
     seq=$(printf '%s\n' "$line" | jq -r '.server_seq // empty')
     disposition=$(printf '%s\n' "$line" | jq -r '.disposition // empty')
-    case "$pos:$seq" in *[!0-9:]*) return 13 ;; esac
+    # $pos and $seq are interpolated into SQL below, so these stay whitelists.
+    # A local position may be negative (projected legacy history sits under the
+    # live space); a server sequence is assigned by the server and never is.
+    case "$pos" in
+      '' | '-') return 13 ;;
+      -*) case "${pos#-}" in
+            '' | *[!0-9]*) return 13 ;;
+          esac ;;
+      *[!0-9]*) return 13 ;;
+    esac
+    case "$seq" in
+      '' | *[!0-9]*) return 13 ;;
+    esac
     case "$disposition" in stored|duplicate) ;; *) return 13 ;; esac
     printf '%s' "$wire" | grep -Eq '^[0-9a-f-]{36}$' || return 13
     values="${values}${values:+,}($pos,'$wire','$seq')"; count=$((count + 1))

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -478,3 +478,53 @@ _seed_legacy_history() {
   [ "$before" = "$after" ]
   [ "$after" -eq 0 ]
 }
+
+@test "sync contract: a legacy history acknowledged once is never offered again" {
+  _seed_legacy_history
+  local candidates acks result second
+  candidates=$(prepare_push)
+  # The server stores each blob under its wire id and answers with a sequence.
+  acks=$(printf '%s\n' "$candidates" | jq -c '
+    select(.type=="sync_push_candidate")
+    | {type:"sync_push_ack",local_position,id,
+       server_seq:((.local_position|tonumber)+1000000000|tostring),
+       disposition:"stored"}')
+  result=$(printf '%s\n' "$acks" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r '.push_cursor')" = "-999999997" ]
+
+  # Connecting again offers nothing: this is what "doing it twice leaves the
+  # server unchanged" means locally, and it holds because the reservation keyed
+  # on the projected position carries the same wire id both times.
+  second=$(prepare_push)
+  [ "$(printf '%s\n' "$second" | jq -s '[.[] | select(.type=="sync_push_candidate")] | length')" -eq 0 ]
+}
+
+# Feeds one hand-built ack through reconcile in THIS shell. Going through
+# `bash -c` would start a shell where the driver functions are undefined, and
+# the 127 that produces looks exactly like the rejection being asserted.
+_reconcile_one_ack() {
+  local pos="$1" seq="$2"
+  printf '{"type":"sync_push_ack","local_position":"%s","id":"%s","server_seq":"%s","disposition":"stored"}\n' \
+    "$pos" "00000000-0000-4000-8000-000000000000" "$seq" \
+    | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1
+}
+
+@test "sync contract: an ack position stays a whitelist after allowing negatives" {
+  # local_position is interpolated straight into SQL, so widening it to accept
+  # projected (negative) positions must not widen it to anything else.
+  _seed_legacy_history
+  prepare_push >/dev/null
+  local bad
+  for bad in "-" "" "1;DROP TABLE events" "-1 OR 1=1" "--1" "1-1" "0x10" " 1" "+1" "1.0"; do
+    run _reconcile_one_ack "$bad" 1
+    # 13 specifically: a "command not found" 127 would also be non-zero and
+    # would pass a laxer check while testing nothing.
+    [ "$status" -eq 13 ]
+  done
+  # A server sequence is assigned by the server and is never negative, so it
+  # did not get the same widening.
+  run _reconcile_one_ack -999999999 -1
+  [ "$status" -eq 13 ]
+  # The events table is still there: nothing above reached a statement.
+  [ "$(agmsg_sqlite "$(agmsg_db_path demo)" "SELECT COUNT(*) FROM events;" | tr -d '\r')" -gt 0 ]
+}

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -429,3 +429,52 @@ prepare_push() {
     storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
   [ "$(printf '%s\n' "$prepared" | jq -s '[.[]|select(.type=="sync_read_frontier")]|length')" -eq 1 ]
 }
+
+# A store that predates the event log keeps its history in the legacy `messages`
+# table; nothing writes that table any more, and the phase-3 adoption marked
+# every row delivered. Connecting such a team has to upload that history — the
+# failure mode is silent (zero candidates, no error), so it is pinned here.
+_seed_legacy_history() {
+  local db; db=$(agmsg_db_path demo)
+  agmsg_sqlite "$db" "
+    DELETE FROM storage_metadata WHERE key='read_cursor_v1';
+    INSERT INTO messages(team,from_agent,to_agent,body,created_at) VALUES
+      ('demo','alice','bob','legacy one','2026-01-01T00:00:00Z'),
+      ('demo','bob','alice','legacy two','2026-01-02T00:00:00Z'),
+      ('demo','alice','bob','legacy three','2026-01-03T00:00:00Z');
+  " >/dev/null
+  # The new build initialising an old store: this is what marks them delivered.
+  storage_init demo >/dev/null
+}
+
+@test "sync contract: a legacy-only team pushes its whole history, in order" {
+  _seed_legacy_history
+  local out positions
+  out=$(prepare_push)
+  [ "$(printf '%s\n' "$out" | jq -s '[.[] | select(.type=="sync_push_candidate")] | length')" -eq 3 ]
+  positions=$(printf '%s\n' "$out" | jq -rs '[.[] | select(.type=="sync_push_candidate") | .local_id] | join(",")')
+  [ "$positions" = "1,2,3" ]
+}
+
+@test "sync contract: pushing a legacy-only team twice is byte-identical" {
+  _seed_legacy_history
+  local first second
+  first=$(prepare_push)
+  second=$(prepare_push)
+  # Non-vacuity first: two empty pages are byte-identical too, and that would
+  # pass this test while proving nothing about wire id stability.
+  [ "$(printf '%s\n' "$first" | jq -s '[.[] | select(.type=="sync_push_candidate")] | length')" -eq 3 ]
+  [ "$first" = "$second" ]
+}
+
+@test "sync contract: projecting legacy history does not resurface it as unread" {
+  _seed_legacy_history
+  local before after
+  before=$(storage_list_unread demo bob | wc -l)
+  # Non-vacuity: the projection must actually have happened, or "the inbox did
+  # not change" is trivially true and this guards nothing.
+  [ "$(prepare_push | jq -s '[.[] | select(.type=="sync_push_candidate")] | length')" -eq 3 ]
+  after=$(storage_list_unread demo bob | wc -l)
+  [ "$before" = "$after" ]
+  [ "$after" -eq 0 ]
+}


### PR DESCRIPTION
The push candidate query selects from the event log only. A team whose messages all predate that log therefore connects and uploads nothing — with no error and no output, because an empty page is a normal answer. Our own store is exactly that shape: every message row sits in the legacy table, and the event log holds only the phase-3 read markers.

## Where the projected history sits

Legacy rows are projected into the event log once per team, at that team's first prepare, with `seq = id - offset`. The positions are negative, and that single choice satisfies all three constraints at once rather than trading two off against one:

| constraint | why negatives satisfy it |
|---|---|
| no collision | the live space is the positive AUTOINCREMENT range |
| stable across retries | a pure function of the row id, so the wire id reserved against that position stays valid |
| history in order | negatives sort ahead of every existing event, so the upload is chronological |

Read state is untouched. `read_cursors.local_position` holds positive values and the unread query asks for `seq > cursor`, so projected rows sit below every cursor and stay delivered — which is what phase-3 already decided about them. Explicit negative rowids also leave `sqlite_sequence` alone, so the delivery tip, which reads the high-water, does not move.

## Two consequences that are not free

**Push cursors default to 0**, which is above the projected space, so a team with legacy history would still prepare zero candidates. They are lowered to just under the oldest projected row. Doing that to an already-advanced cursor is safe because acknowledged rows are excluded by `server_seq IS NULL` in both the candidate query and the emission, not by the cursor — the cost is a wider scan, not a resend.

**Reconcile validated `local_position` as digits only.** It now accepts a leading minus. That value is interpolated directly into SQL, so the whitelist stays narrow, and `server_seq` did not get the same widening — a server sequence is assigned by the server and is never negative.

## Tests

Five, each written so it cannot pass while empty. "Two prepares are byte-identical" and "the inbox did not change" are both trivially true of a store that projected nothing, so each asserts the projection happened first.

- the whole history appears, in legacy order
- a second prepare is byte-identical to the first
- projecting does not resurface delivered rows as unread
- a history acknowledged once is never offered again
- the ack position whitelist still rejects everything that is not an optional minus followed by digits — asserted on the specific status rather than on non-zero, because a "command not found" is also non-zero and would pass a laxer check while testing nothing

108 tests green across the sync, storage, JSONL sync and cipher suites.
