### PR TITLE
feat(remote): pull — a second machine takes a team it does not have

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -483,11 +483,23 @@ function endpoint(base, path) {
 
 export async function request(config, path, init = {}) {
   const token = await readConnectedCredential(config);
+  return send(config, path, init, { Authorization: `Bearer ${token}` });
+}
+
+// The pull routes carry no credential, for the reason /v1/connect has none:
+// reaching the server is the permission. Everything after the header -- the
+// protocol check, the binding validation, the retryable classification -- is
+// the same, so it is shared rather than written twice.
+export async function requestPublic(config, path, init = {}) {
+  return send(config, path, init, {});
+}
+
+async function send(config, path, init, authHeaders) {
   const headers = {
     ...init.headers,
     "Agmsg-Protocol-Version": PROTOCOL,
     "Agmsg-Team-ID": config.remote_team_id,
-    Authorization: `Bearer ${token}`,
+    ...authHeaders,
   };
   const url = endpoint(config.server_url, path);
   let response;
@@ -1616,13 +1628,106 @@ export async function resyncCycle(config, acceptedFloor, dependencies = {}) {
   return result;
 }
 
+// A machine that has none of this taking a team from the server. It is not a
+// cycle: there is no local team to reconcile against, no push side, and no
+// credential. What it shares with the normal pull is the part that must not
+// diverge -- evaluatePull decides what may be imported, and the driver applies
+// the same records.
+export async function pullBootstrap(args) {
+  const team = requireName(args.team, "team");
+  const teamId = args["team-id"] ?? "";
+  if (!UUID_V7.test(teamId)) throw new Error("team-id must be a canonical UUIDv7");
+  const serverUrl = args.endpoint ?? "";
+  if (!serverUrl) throw new Error("endpoint is required");
+  const limit = Number(args.limit ?? 1000);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 1000) throw new Error("limit must be 1..1000");
+
+  // Fetched before a config exists, so this one call validates itself rather
+  // than going through the binding checks the rest of the pull relies on.
+  const snapshot = await publicSnapshot(serverUrl, teamId);
+  const config = {
+    format_version: 1,
+    local_team: team,
+    server_url: serverUrl,
+    server_instance_id: snapshot.server_instance_id,
+    remote_team_id: snapshot.team_id,
+    protocol_version: Number(PROTOCOL),
+    cipher_profile: "none",
+    local_security_history: [{
+      local_security_revision: "0", effective_from_seq: "1",
+      minimum_security_mode: "plaintext-allowed",
+    }],
+  };
+  await event("pull.bootstrap.snapshot", {
+    team_id: snapshot.team_id, team_name: snapshot.team_name,
+    members: snapshot.members.length, min_available_seq: snapshot.min_available_seq,
+  });
+
+  let cursor = String(snapshot.min_available_seq ?? "0");
+  let imported = 0;
+  for (;;) {
+    const page = await requestPublic(config,
+      `/v1/teams/${teamId}/messages?after=${cursor}&limit=${limit}`);
+    const records = [];
+    for (const message of page.messages) {
+      records.push({ type: "sync_pull_message", ...message,
+        ...(await evaluatePull(config, snapshot, message)) });
+    }
+    records.push({ type: "sync_pull_cursor", next_after: page.next_after });
+    const applied = await driver("apply", config, records);
+    await event("pull.bootstrap.applied", {
+      after: cursor, next_after: page.next_after,
+      messages: page.messages.length, result: applied[0] ?? null,
+    });
+    imported += page.messages.length;
+    cursor = page.next_after;
+    if (!page.has_more) break;
+  }
+  process.stdout.write(`${JSON.stringify({
+    type: "pull_bootstrap_result", team: config.local_team,
+    team_id: config.remote_team_id, team_name: snapshot.team_name,
+    server_instance_id: config.server_instance_id,
+    members: snapshot.members, imported,
+  })}\n`);
+}
+
+async function publicSnapshot(serverUrl, teamId) {
+  let response;
+  try {
+    response = await fetch(endpoint(serverUrl, `/v1/teams/${teamId}`), {
+      headers: { "Agmsg-Protocol-Version": PROTOCOL },
+      redirect: "error", signal: AbortSignal.timeout(15_000),
+    });
+  } catch (error) {
+    error.retryable = true;
+    throw error;
+  }
+  if (response.headers.get("agmsg-protocol-version") !== PROTOCOL) {
+    throw new Error("response protocol version mismatch");
+  }
+  const body = await response.json();
+  if (!response.ok) {
+    const error = new Error(`HTTP ${response.status} ${body?.error?.code ?? "unknown-error"}`);
+    error.status = response.status;
+    throw error;
+  }
+  if (body.team_id !== teamId || !UUID_V7.test(body.server_instance_id ?? "") ||
+      !Array.isArray(body.members)) {
+    throw new Error("team snapshot is not bound to the requested team");
+  }
+  return body;
+}
+
 async function main() {
   const [command, ...rest] = process.argv.slice(2);
   const args = options(rest);
-  if (!["configure", "once", "run", "reprocess", "resync", "unblock-read"].includes(command)) {
+  if (!["configure", "once", "run", "reprocess", "resync", "unblock-read",
+        "pull-bootstrap"].includes(command)) {
     throw new Error(usage());
   }
   if (command === "configure") { await configure(args); return; }
+  // Before any local team exists, so it cannot go through loadConfig.
+  if (command === "pull-bootstrap") { await pullBootstrap(args); return; }
   const team = requireName(args.team, "team");
   const limit = Number(args.limit ?? 100);
   if (!Number.isInteger(limit) || limit < 1 || limit > 1000) throw new Error("limit must be 1..1000");

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -5,7 +5,8 @@ import { spawn } from "node:child_process";
 import { appendFile, lstat, mkdir, open, readFile, rename, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import process from "node:process";
-import { pathToFileURL } from "node:url";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { ageExecutableVersion, CipherStateError, openEnvelope,
   readNativeAgeIdentity } from "./sync-cipher.mjs";
 import { parseStrictJson, parseStrictJsonl } from "./strict-jsonl.mjs";
@@ -1759,7 +1760,13 @@ async function main() {
   });
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// realpath on both sides: on macOS a temp dir is /var/... symlinked to
+// /private/var/..., and import.meta.url resolves the link while argv[1] does
+// not. Compared as strings the guard silently fails to match, so the process
+// runs main() never, exits 0, and prints nothing -- a no-op that looks like a
+// success. Anything invoked through a symlinked path hits this.
+if (process.argv[1] &&
+    realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1])) {
   main().catch(async (error) => {
     await event("fatal", { message: error.message, code: error.code ?? null });
     process.stderr.write(`${error.message}\n`);

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -750,6 +750,101 @@ _remote_commit() {
   agmsg_write_atomic "$cfg" "$updated"
 }
 
+# Extract one field from a JSON document held in a variable. The file-based
+# reader above cannot be used: this document is the engine's stdout, and
+# writing it out just to read it back would put a team snapshot on disk for no
+# reason.
+_remote_json_field() {
+  local doc="$1" path="$2" escaped
+  escaped=$(printf '%s' "$doc" | sed "s/'/''/g")
+  agmsg_sqlite_mem "SELECT COALESCE(json_extract('$escaped', '$path'), '');"
+}
+
+_remote_json_fragment() {
+  local doc="$1" path="$2" escaped
+  escaped=$(printf '%s' "$doc" | sed "s/'/''/g")
+  agmsg_sqlite_mem "SELECT COALESCE(json_extract('$escaped', '$path'), '[]');"
+}
+
+# Writes the local team for a pull. Unlike _remote_ensure_team this does NOT
+# mint a team_id: the id and every member id came from the server and are
+# recorded as they arrived. Minting here would give one team two identities,
+# which is the whole reason ids exist.
+_remote_write_pulled_team() {
+  local team="$1" team_id="$2" members="$3" cfg agents initial
+  cfg="$(_remote_team_config "$team")"
+  mkdir -p "$TEAMS_DIR/$team"
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
+  # The roster arrives as an array and is stored keyed by name, the shape
+  # join.sh already writes, so team.sh and the delivery paths read it unchanged.
+  agents=$(agmsg_sqlite_mem "
+    SELECT COALESCE(json_group_object(json_extract(value, '\$.name'),
+             json_object('member_id', json_extract(value, '\$.member_id'),
+                         'registrations', json_array())), json_object())
+      FROM json_each('$(printf '%s' "$members" | sed "s/'/''/g")');")
+  initial=$(agmsg_sqlite_mem "
+    SELECT json_object('name','$(_agmsg_sqlesc "$team")',
+                       'team_id','$(_agmsg_sqlesc "$team_id")',
+                       'agents', json('$(printf '%s' "$agents" | sed "s/'/''/g")'),
+                       'created_at','$(date -u +%Y-%m-%dT%H:%M:%SZ)');")
+  agmsg_write_atomic "$cfg" "$initial"
+  agmsg_lock_release
+}
+
+# The other half of connect: this machine takes a team it does not have.
+cmd_pull() {
+  local endpoint="" team_id="" team="" positional=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --endpoint) endpoint="${2:?--endpoint requires a value}"; shift 2 ;;
+      --endpoint=*) endpoint="${1#--endpoint=}"; shift ;;
+      --team-id) team_id="${2:?--team-id requires a value}"; shift 2 ;;
+      --team-id=*) team_id="${1#--team-id=}"; shift ;;
+      *) positional+=("$1"); shift ;;
+    esac
+  done
+  : "${endpoint:?Usage: remote.sh pull --endpoint <url> --team-id <uuid> <team>}"
+  : "${team_id:?Usage: remote.sh pull --endpoint <url> --team-id <uuid> <team>}"
+  _remote_validate_endpoint "$endpoint" || exit 1
+  endpoint="${endpoint%/}"
+  team="${positional[0]:-}"
+  [ -n "$team" ] || { echo "agmsg: pull requires a local team name" >&2; exit 1; }
+  agmsg_validate_team_name "$team" || exit 1
+
+  # Refused for the reason git refuses a non-fast-forward push: two teams that
+  # each grew their own history do not become one by pointing at the same
+  # remote. A second machine arrives empty and clones.
+  local cfg existing
+  cfg="$(_remote_team_config "$team")"
+  if [ -f "$cfg" ]; then
+    existing="$(agmsg_sqlite "$(agmsg_db_path "$team")" \
+      "SELECT COUNT(*) FROM events WHERE type='message_sent';" 2>/dev/null | tr -d '\r')"
+    case "$existing" in ''|*[!0-9]*) existing=0 ;; esac
+    if [ "$existing" -gt 0 ]; then
+      echo "agmsg: local team '$team' already has history; pull clones into an empty team" >&2
+      exit 1
+    fi
+  fi
+
+  local result pulled_id pulled_name imported members
+  result="$(AGMSG_SYNC_CONNECTION_DIR="$CONNECTION_ROOT" \
+    "$SCRIPT_DIR/remote-sync.sh" pull-bootstrap \
+      --team "$team" --team-id "$team_id" --endpoint "$endpoint")" || {
+    echo "agmsg: pull failed" >&2; exit 1; }
+  result="$(printf '%s\n' "$result" | grep '"pull_bootstrap_result"' | tail -1)"
+  [ -n "$result" ] || { echo "agmsg: pull produced no result" >&2; exit 1; }
+
+  pulled_id="$(_remote_json_field "$result" '$.team_id')"
+  pulled_name="$(_remote_json_field "$result" '$.team_name')"
+  imported="$(_remote_json_field "$result" '$.imported')"
+  members="$(_remote_json_fragment "$result" '$.members')"
+  [ "$pulled_id" = "$team_id" ] || {
+    echo "agmsg: server answered with a different team id" >&2; exit 1; }
+
+  _remote_write_pulled_team "$team" "$pulled_id" "$members" || exit 1
+  echo "Pulled '$pulled_name' into local team '$team' ($imported message(s))."
+}
+
 cmd_connect() {
   local endpoint="" token="" token_stdin=0 team="" force=0 positional=() \
     expected_old_credential_id=""
@@ -1381,6 +1476,7 @@ cmd_disconnect() {
 
 case "${1:-}" in
   connect) shift; agmsg_require_python3 "remote connect" || exit 1; cmd_connect "$@" ;;
+  pull) shift; agmsg_require_python3 "remote pull" || exit 1; cmd_pull "$@" ;;
   status) shift; agmsg_require_python3 "remote status" || exit 1; cmd_status "$@" ;;
   disconnect) shift; agmsg_require_python3 "remote disconnect" || exit 1; cmd_disconnect "$@" ;;
   doctor) shift; cmd_doctor "$@" ;;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -37,6 +37,7 @@ import {
 const emptyQuerySchema = z.object({}).strict();
 const pairingExchangeSchema = z.object({ token: z.string().min(32).max(256) }).strict();
 const credentialParamsSchema = z.object({ credentialId: uuidV7Schema }).strict();
+const teamParamsSchema = z.object({ teamId: uuidV7Schema }).strict();
 
 function requireProtocol(request: FastifyRequest): void {
   const version = request.headers["agmsg-protocol-version"];
@@ -267,6 +268,30 @@ async function dataPlaneRoutes(
     const body = connectSchema.parse(request.body);
     reply.header("Cache-Control", "no-store");
     return connectTeam(pool, body);
+  });
+
+  // The other half of connect: a second machine takes a team it does not have.
+  // Scoped by the id in the path rather than by a credential, for the reason
+  // /v1/connect has none — reaching the server is the permission. Knowing a
+  // team_id is therefore enough to read a team, which the design records as
+  // accepted for this minimum rather than overlooked.
+  app.get("/v1/teams/:teamId", async (request, reply) => {
+    requireProtocol(request);
+    emptyQuerySchema.parse(request.query);
+    const params = teamParamsSchema.parse(request.params);
+    reply.header("Cache-Control", "no-store");
+    return getMembers(pool, params.teamId);
+  });
+
+  // History is paged rather than returned whole: a team that has been running
+  // is thousands of messages, and the caller already has to handle a cursor
+  // because retention can move min_available_seq under it mid-pull.
+  app.get("/v1/teams/:teamId/messages", async (request, reply) => {
+    requireProtocol(request);
+    const params = teamParamsSchema.parse(request.params);
+    const query = messagesQuerySchema.parse(request.query);
+    reply.header("Cache-Control", "no-store");
+    return getMessages(pool, params.teamId, parseSequence(query.after), query.limit);
   });
 
   app.post("/v1/credentials/:credentialId/revoke", { bodyLimit: MAX_REQUEST_BYTES }, async (request, reply) => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -28,6 +28,7 @@ import {
   connectTeam,
   getCapabilities,
   getMembers,
+  getTeamSnapshot,
   getMessages,
   health,
   postMessages,
@@ -280,7 +281,7 @@ async function dataPlaneRoutes(
     emptyQuerySchema.parse(request.query);
     const params = teamParamsSchema.parse(request.params);
     reply.header("Cache-Control", "no-store");
-    return getMembers(pool, params.teamId);
+    return getTeamSnapshot(pool, params.teamId);
   });
 
   // History is paged rather than returned whole: a team that has been running

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -806,6 +806,53 @@ export async function connectTeam(
   });
 }
 
+async function roster(
+  client: PoolClient,
+  teamId: string,
+): Promise<Record<string, unknown>[]> {
+  const members = await client.query<{ member_id: string; name: string }>(
+    `SELECT member_id::text, name FROM members
+      WHERE team_id = $1 ORDER BY member_id`,
+    [teamId],
+  );
+  const registrations = await client.query<{
+    registration_id: string;
+    member_id: string;
+    installation_id: string;
+    type: string;
+  }>(
+    `SELECT registration_id::text, member_id::text, installation_id::text, type
+       FROM registrations WHERE team_id = $1
+      ORDER BY registration_id`,
+    [teamId],
+  );
+  return members.rows.map((member) => ({
+    member_id: member.member_id,
+    name: member.name,
+    registrations: registrations.rows
+      .filter((registration) => registration.member_id === member.member_id)
+      .map(({ member_id: _memberId, ...registration }) => registration),
+  }));
+}
+
+// Everything a machine that has none of this needs before it can read history:
+// which team it is, who is in it, and what the server will accept. One
+// repeatable-read transaction, so the roster and the capabilities it is
+// interpreted under cannot come from two different moments.
+export async function getTeamSnapshot(
+  pool: Pool,
+  teamId: string,
+): Promise<Record<string, unknown>> {
+  return inTransaction(
+    pool,
+    async (client) => {
+      const snapshot = await capabilitySnapshot(client, teamId);
+      return { ...snapshot, members: await roster(client, teamId) };
+    },
+    { readOnly: true, repeatableRead: true },
+  );
+}
+
 export async function getMembers(
   pool: Pool,
   teamId: string,
@@ -816,32 +863,10 @@ export async function getMembers(
       const serverId = await serverInstanceId(client);
       const team = await teamRow(client, teamId);
       if (!team) throw notFound(serverId, teamId);
-      const members = await client.query<{ member_id: string; name: string }>(
-        `SELECT member_id::text, name FROM members
-          WHERE team_id = $1 ORDER BY member_id`,
-        [teamId],
-      );
-      const registrations = await client.query<{
-        registration_id: string;
-        member_id: string;
-        installation_id: string;
-        type: string;
-      }>(
-        `SELECT registration_id::text, member_id::text, installation_id::text, type
-           FROM registrations WHERE team_id = $1
-          ORDER BY registration_id`,
-        [teamId],
-      );
       return {
         ...common(serverId, team),
         members_revision: team.members_revision,
-        members: members.rows.map((member) => ({
-          member_id: member.member_id,
-          name: member.name,
-          registrations: registrations.rows
-            .filter((registration) => registration.member_id === member.member_id)
-            .map(({ member_id: _memberId, ...registration }) => registration),
-        })),
+        members: await roster(client, teamId),
       };
     },
     { readOnly: true, repeatableRead: true },

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -49,20 +49,21 @@ PULL_MEMBERS = [
 # is what the client decodes on import.
 def _blob(from_agent, to_agent, body, at):
     import base64
-    payload = json.dumps({"from": from_agent, "to": to_agent, "body": body, "at": at},
+    payload = json.dumps({"body": body, "created_at": at,
+                          "from_agent": from_agent, "to_agent": to_agent},
                          separators=(",", ":"), sort_keys=True)
     return base64.b64encode(payload.encode()).decode()
 
 
 PULL_MESSAGES = [
     {"id": "11111111-1111-4111-8111-111111111111", "server_seq": "1",
-     "server_received_at": "2026-01-01T00:00:00.000Z",
+     "server_received_at": "2026-01-01T00:00:00.000000Z",
      "envelope": {"v": 1, "cipher": "none", "key_id": None,
-                  "blob": _blob("alice", "bob", "history one", "2026-01-01T00:00:00Z")}},
+                  "blob": _blob("alice", "bob", "history one", "2026-01-01T00:00:00.000000Z")}},
     {"id": "22222222-2222-4222-8222-222222222222", "server_seq": "2",
-     "server_received_at": "2026-01-02T00:00:00.000Z",
+     "server_received_at": "2026-01-02T00:00:00.000000Z",
      "envelope": {"v": 1, "cipher": "none", "key_id": None,
-                  "blob": _blob("bob", "alice", "history two", "2026-01-02T00:00:00Z")}},
+                  "blob": _blob("bob", "alice", "history two", "2026-01-02T00:00:00.000000Z")}},
 ]
 
 

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -37,6 +37,35 @@ ISSUED_CREDENTIAL_IDS = set()
 REVOKED_CREDENTIAL_IDS = []
 
 
+PULL_SERVER_ID = "018f3f7e-2222-7000-8000-000000000001"
+PULL_TEAM_ID = "018f3f7e-2222-7000-8000-000000000002"
+PULL_MEMBERS = [
+    {"member_id": "018f3f7e-2222-7000-8000-000000000010",
+     "name": "alice", "registrations": []},
+    {"member_id": "018f3f7e-2222-7000-8000-000000000011",
+     "name": "bob", "registrations": []},
+]
+# cipher "none" carries the message as the base64 of its canonical JSON, which
+# is what the client decodes on import.
+def _blob(from_agent, to_agent, body, at):
+    import base64
+    payload = json.dumps({"from": from_agent, "to": to_agent, "body": body, "at": at},
+                         separators=(",", ":"), sort_keys=True)
+    return base64.b64encode(payload.encode()).decode()
+
+
+PULL_MESSAGES = [
+    {"id": "11111111-1111-4111-8111-111111111111", "server_seq": "1",
+     "server_received_at": "2026-01-01T00:00:00.000Z",
+     "envelope": {"v": 1, "cipher": "none", "key_id": None,
+                  "blob": _blob("alice", "bob", "history one", "2026-01-01T00:00:00Z")}},
+    {"id": "22222222-2222-4222-8222-222222222222", "server_seq": "2",
+     "server_received_at": "2026-01-02T00:00:00.000Z",
+     "envelope": {"v": 1, "cipher": "none", "key_id": None,
+                  "blob": _blob("bob", "alice", "history two", "2026-01-02T00:00:00Z")}},
+]
+
+
 class LoopbackHTTPServer(HTTPServer):
     """HTTPServer without a reverse-DNS lookup during fixture startup."""
 
@@ -69,6 +98,52 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/_test/revoked":
             self._send_json(200, {"revoked": REVOKED_CREDENTIAL_IDS})
+            return
+        # The pull side: a machine that has none of this asking for a team by
+        # id. No credential, matching /v1/connect -- reaching the server is the
+        # permission.
+        parts = self.path.split("?", 1)
+        route = parts[0]
+        query = parts[1] if len(parts) > 1 else ""
+        if route == "/v1/teams/%s" % PULL_TEAM_ID:
+            self._send_json(200, {
+                "protocol_version": 1,
+                "server_instance_id": PULL_SERVER_ID,
+                "team_id": PULL_TEAM_ID,
+                "team_name": "pulled-team",
+                "min_available_seq": "0",
+                "current_seq": str(len(PULL_MESSAGES)),
+                "policy_revision": "0",
+                "accepted_envelope_versions": [1],
+                "write_allowed_ciphers": ["none", "age-v1"],
+                "policy_history": [{
+                    "policy_revision": "0", "effective_from_seq": "1",
+                    "accepted_envelope_versions": [1],
+                    "write_allowed_ciphers": ["none", "age-v1"],
+                }],
+                "members_revision": 0,
+                "members": PULL_MEMBERS,
+            })
+            return
+        if route == "/v1/teams/%s/messages" % PULL_TEAM_ID:
+            after = 0
+            for pair in query.split("&"):
+                if pair.startswith("after="):
+                    try:
+                        after = int(pair[len("after="):])
+                    except ValueError:
+                        after = 0
+            page = [m for m in PULL_MESSAGES if int(m["server_seq"]) > after]
+            self._send_json(200, {
+                "protocol_version": 1,
+                "server_instance_id": PULL_SERVER_ID,
+                "team_id": PULL_TEAM_ID,
+                "team_name": "pulled-team",
+                "min_available_seq": "0",
+                "messages": page,
+                "next_after": page[-1]["server_seq"] if page else str(after),
+                "has_more": False,
+            })
             return
         self._send_json(404, {"error": "not found"})
 

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1079,3 +1079,14 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID"
   [ "$status" -ne 0 ]
 }
+
+@test "remote pull: the cloned team can be read with the ordinary commands" {
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" cloned
+  [ "$status" -eq 0 ]
+  # The point of the whole step: the history is here, not just the team.
+  [[ "$output" == *"2 message(s)"* ]]
+  run bash "$SCRIPTS/history.sh" cloned alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"history one"* ]]
+  [[ "$output" == *"history two"* ]]
+}

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1045,3 +1045,37 @@ VALUES ('remote-pending.$key', $owner_pid, strftime('%Y-%m-%dT%H:%M:%SZ','now'))
   [ "$status" -eq 0 ]
   [[ "$output" == *"All checks passed."* ]]
 }
+
+PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
+
+@test "remote pull: clones a team, keeping the ids the server gave" {
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" cloned
+  [ "$status" -eq 0 ]
+  local cfg
+  cfg="$TEST_SKILL_DIR/teams/cloned/config.json"
+  [ -f "$cfg" ]
+  # Not minted here: the id is the one the server answered with.
+  [ "$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.team_id');")" = "$PULL_TEAM_ID" ]
+  # The roster arrives with it, keyed by name the way join.sh writes it.
+  [ "$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.agents.alice.member_id');")" \
+    = "018f3f7e-2222-7000-8000-000000000010" ]
+  [ "$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.agents.bob.member_id');")" \
+    = "018f3f7e-2222-7000-8000-000000000011" ]
+}
+
+@test "remote pull: refuses a team that already has history" {
+  bash "$SCRIPTS/join.sh" occupied alice claude-code /tmp/project-b >/dev/null
+  bash "$SCRIPTS/send.sh" occupied alice alice "already mine" >/dev/null
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" occupied
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already has history"* ]]
+}
+
+@test "remote pull: requires an endpoint, a team id and a local name" {
+  run bash "$SCRIPTS/remote.sh" pull --team-id "$PULL_TEAM_ID" cloned
+  [ "$status" -ne 0 ]
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" cloned
+  [ "$status" -ne 0 ]
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Connect registers a team this machine owns. Nothing was the other half of it — a second machine taking a team that already exists somewhere else — so dogfood stops halfway: one installation can push, and the other has no way to arrive.

## The shape

**Server.** Two routes beside `/v1/connect`, scoped by the id in the path rather than by a credential, for the reason connect has none: reaching the server is the permission. `GET /v1/teams/:teamId` answers with one snapshot — identity, capabilities and roster taken in a single repeatable-read transaction, so the roster and the policy it is read under cannot come from two different moments. `GET /v1/teams/:teamId/messages` pages history, because a team that has been running is thousands of messages and retention can move `min_available_seq` under a cursor mid-pull.

**Engine.** `pull-bootstrap` runs before any local team exists, so it cannot go through `loadConfig`, which reads a binding and a credential. It shares the part that must not diverge: `evaluatePull` decides what may be imported, and the same driver applies the same records. Two answers to "may this be imported" would drift and nothing would say which was right.

**Client.** `agmsg remote pull --endpoint <url> --team-id <uuid> <team>` mints nothing. The `team_id` and every `member_id` arrive from the server and are written down as they came — minting here would give one team two identities, which is what ids were introduced to prevent, and it is why this cannot reuse the existing team bootstrap, which mints a fresh id by design.

A team that already has history is refused, for the reason git refuses a non-fast-forward push: two histories do not become one by pointing at the same remote.

## A production bug the tests found

The engine's entry guard compared `import.meta.url` against `process.argv[1]` as strings. `import.meta.url` resolves symlinks and `argv[1]` does not, so anything invoked through a symlinked path — on macOS every `mktemp -d`, since `/var` links to `/private/var` — never matched, `main()` never ran, and the process **exited 0 having printed nothing**. A no-op that looks like a success, which is exactly why it had survived: nothing fails. Both sides now compare real paths.

## What the last test was for

Three tests passed — the team lands, the roster lands, a populated team is refused — while every message went to quarantine and `history.sh` printed nothing. The command reported "2 message(s)" because it counted what it fetched, not what was stored.

Reading the clone back with an ordinary command is what catches that, and behind it were two more fixture defects: `server_received_at` needs microsecond precision, and a `cipher: "none"` blob is a canonical projection of `body`/`created_at`/`from_agent`/`to_agent` rather than the shape the fixture had invented.

## Tests

136 green across the remote, sync and storage-contract suites. The pull cases cover: the clone keeps the server's ids and roster, a team with history is refused, the arguments are required, and the cloned history is readable through `history.sh`.

## Not in this change

Client connect rework, the id columns, and the removal of the old credentialed routes are separate steps. This adds routes beside the existing ones and does not touch them.
