### PR TITLE
feat(remote): stop taking a roster from the server

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1661,7 +1661,7 @@ export async function pullBootstrap(args) {
   };
   await event("pull.bootstrap.snapshot", {
     team_id: snapshot.team_id, team_name: snapshot.team_name,
-    members: snapshot.members.length, min_available_seq: snapshot.min_available_seq,
+    min_available_seq: snapshot.min_available_seq,
   });
 
   let cursor = String(snapshot.min_available_seq ?? "0");
@@ -1687,8 +1687,7 @@ export async function pullBootstrap(args) {
   process.stdout.write(`${JSON.stringify({
     type: "pull_bootstrap_result", team: config.local_team,
     team_id: config.remote_team_id, team_name: snapshot.team_name,
-    server_instance_id: config.server_instance_id,
-    members: snapshot.members, imported,
+    server_instance_id: config.server_instance_id, imported,
   })}\n`);
 }
 
@@ -1712,8 +1711,7 @@ async function publicSnapshot(serverUrl, teamId) {
     error.status = response.status;
     throw error;
   }
-  if (body.team_id !== teamId || !UUID_V7.test(body.server_instance_id ?? "") ||
-      !Array.isArray(body.members)) {
+  if (body.team_id !== teamId || !UUID_V7.test(body.server_instance_id ?? "")) {
     throw new Error("team snapshot is not bound to the requested team");
   }
   return body;

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -760,32 +760,24 @@ _remote_json_field() {
   agmsg_sqlite_mem "SELECT COALESCE(json_extract('$escaped', '$path'), '');"
 }
 
-_remote_json_fragment() {
-  local doc="$1" path="$2" escaped
-  escaped=$(printf '%s' "$doc" | sed "s/'/''/g")
-  agmsg_sqlite_mem "SELECT COALESCE(json_extract('$escaped', '$path'), '[]');"
-}
-
 # Writes the local team for a pull. Unlike _remote_ensure_team this does NOT
-# mint a team_id: the id and every member id came from the server and are
-# recorded as they arrived. Minting here would give one team two identities,
-# which is the whole reason ids exist.
+# mint a team_id: the id came from the server and is recorded as it arrived.
+# Minting here would give one team two identities, which is the whole reason
+# ids exist.
+#
+# The roster is deliberately left empty. The server does not hold one -- team
+# membership travels inside the envelope, so under e2ee it cannot -- and a
+# roster taken from anywhere else at this moment would be a guess presented as
+# fact. It is derived by replaying the team journal.
 _remote_write_pulled_team() {
-  local team="$1" team_id="$2" members="$3" cfg agents initial
+  local team="$1" team_id="$2" cfg initial
   cfg="$(_remote_team_config "$team")"
   mkdir -p "$TEAMS_DIR/$team"
   agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
-  # The roster arrives as an array and is stored keyed by name, the shape
-  # join.sh already writes, so team.sh and the delivery paths read it unchanged.
-  agents=$(agmsg_sqlite_mem "
-    SELECT COALESCE(json_group_object(json_extract(value, '\$.name'),
-             json_object('member_id', json_extract(value, '\$.member_id'),
-                         'registrations', json_array())), json_object())
-      FROM json_each('$(printf '%s' "$members" | sed "s/'/''/g")');")
   initial=$(agmsg_sqlite_mem "
     SELECT json_object('name','$(_agmsg_sqlesc "$team")',
                        'team_id','$(_agmsg_sqlesc "$team_id")',
-                       'agents', json('$(printf '%s' "$agents" | sed "s/'/''/g")'),
+                       'agents', json_object(),
                        'created_at','$(date -u +%Y-%m-%dT%H:%M:%SZ)');")
   agmsg_write_atomic "$cfg" "$initial"
   agmsg_lock_release
@@ -826,7 +818,7 @@ cmd_pull() {
     fi
   fi
 
-  local result pulled_id pulled_name imported members
+  local result pulled_id pulled_name imported
   result="$(AGMSG_SYNC_CONNECTION_DIR="$CONNECTION_ROOT" \
     "$SCRIPT_DIR/remote-sync.sh" pull-bootstrap \
       --team "$team" --team-id "$team_id" --endpoint "$endpoint")" || {
@@ -837,11 +829,10 @@ cmd_pull() {
   pulled_id="$(_remote_json_field "$result" '$.team_id')"
   pulled_name="$(_remote_json_field "$result" '$.team_name')"
   imported="$(_remote_json_field "$result" '$.imported')"
-  members="$(_remote_json_fragment "$result" '$.members')"
   [ "$pulled_id" = "$team_id" ] || {
     echo "agmsg: server answered with a different team id" >&2; exit 1; }
 
-  _remote_write_pulled_team "$team" "$pulled_id" "$members" || exit 1
+  _remote_write_pulled_team "$team" "$pulled_id" || exit 1
   echo "Pulled '$pulled_name' into local team '$team' ($imported message(s))."
 }
 

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -835,20 +835,23 @@ async function roster(
   }));
 }
 
-// Everything a machine that has none of this needs before it can read history:
-// which team it is, who is in it, and what the server will accept. One
-// repeatable-read transaction, so the roster and the capabilities it is
-// interpreted under cannot come from two different moments.
+// What a machine that has none of this needs before it can read history: which
+// team it is and what the server will accept.
+//
+// Deliberately NOT who is in it. Membership changes travel inside the envelope,
+// so under e2ee this server cannot read them -- a roster it handed out would be
+// the one frozen at connect, served confidently to every machine that arrives
+// later. Removing the roster from the answer removes that failure rather than
+// managing it, and it follows from what e2ee is for here: if encryption
+// protects you from whoever runs the server, who is on the team is theirs to
+// know too. Each machine derives the roster by replaying the team journal.
 export async function getTeamSnapshot(
   pool: Pool,
   teamId: string,
 ): Promise<Record<string, unknown>> {
   return inTransaction(
     pool,
-    async (client) => {
-      const snapshot = await capabilitySnapshot(client, teamId);
-      return { ...snapshot, members: await roster(client, teamId) };
-    },
+    (client) => capabilitySnapshot(client, teamId),
     { readOnly: true, repeatableRead: true },
   );
 }

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1048,7 +1048,7 @@ VALUES ('remote-pending.$key', $owner_pid, strftime('%Y-%m-%dT%H:%M:%SZ','now'))
 
 PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
 
-@test "remote pull: clones a team, keeping the ids the server gave" {
+@test "remote pull: clones a team, keeping the id the server gave" {
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" cloned
   [ "$status" -eq 0 ]
   local cfg
@@ -1056,11 +1056,22 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   [ -f "$cfg" ]
   # Not minted here: the id is the one the server answered with.
   [ "$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.team_id');")" = "$PULL_TEAM_ID" ]
-  # The roster arrives with it, keyed by name the way join.sh writes it.
-  [ "$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.agents.alice.member_id');")" \
-    = "018f3f7e-2222-7000-8000-000000000010" ]
-  [ "$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.agents.bob.member_id');")" \
-    = "018f3f7e-2222-7000-8000-000000000011" ]
+}
+
+@test "remote pull: does not take a roster from the server" {
+  # The server holds no membership -- it travels inside the envelope, so under
+  # e2ee the server cannot read it. A roster invented here would be a guess
+  # presented as fact; it is derived by replaying the team journal instead.
+  #
+  # The mock deliberately still answers with a members array, so this fails if
+  # the client starts trusting one again rather than merely because none was
+  # offered.
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" cloned
+  [ "$status" -eq 0 ]
+  local cfg agents
+  cfg="$TEST_SKILL_DIR/teams/cloned/config.json"
+  agents="$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.agents');")"
+  [ "$agents" = "{}" ]
 }
 
 @test "remote pull: refuses a team that already has history" {


### PR DESCRIPTION
Membership changes travel inside the envelope, so under e2ee this server cannot read them. A roster it handed out would be the one frozen at connect, served confidently to every machine that arrives afterwards — and the receiving machine has no way to tell that it is stale. Removing the roster from the answer removes that failure rather than managing it.

It also follows from what e2ee is for here: if encryption protects you from whoever runs the server, who is on the team is theirs to know too.

## What changes

`GET /v1/teams/:teamId` returns identity and capabilities only. `roster()` stays, because `/v1/members` still uses it — this is about what a pulling machine is told, not about deleting the server's ability to answer a credentialed query.

Pull writes the local team with an **empty** roster rather than inventing one. The roster is derived by replaying the team journal, which lands separately (#528).

The mock server still answers with a `members` array on purpose. A test that stops seeing a roster because none was offered proves nothing; this one fails if the client starts trusting one again.

## The open judgement: how much journal does pull take?

**Pull takes the journal in full before it reports success.** The alternative — take a seed and let ordinary sync fill in — was considered and rejected:

- **It is not actually lighter.** Pull already fetches the entire history, and the journal is a strict subset of the same stream. The cost is dominated by what we already pay.
- **A pull that finishes with an empty roster gives the user no signal for when the team becomes usable.** That is an operation reporting success while the observable result is not there yet, which is the specific failure this branch's predecessor already had once: `pull` printed "2 message(s)" it had *fetched* while every message sat in quarantine.
- The design describes the second machine as one that "registers, pulls the team down, and continues" — continuing implies the clone is whole first.

The cost is a longer pull. It is paged the same way history is, so the existing progress events cover it.

This decision is recorded here rather than implemented: the journal does not exist yet. What this branch does is remove the dependency on the server's roster, so that landing the journal is the only remaining step.

## Tests

103 green across the remote and sync suites. The pull cases now cover: the clone keeps the server's id, **no roster is taken from the server even though one is offered**, a populated team is refused, the arguments are required, and the cloned history is readable through `history.sh`.
