### PR TITLE
Say that rename leaves run/ alone on purpose

### DIFF
--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -4,6 +4,23 @@ set -euo pipefail
 # Usage: rename.sh <team> <old_name> <new_name>
 #
 # Renames an agent in team config and updates all messages in DB.
+#
+# It deliberately does NOT touch run/. Those files are runtime state, not a
+# record of the team: `actas.<team>__<agent>.session` (the exclusivity lock),
+# `role-session.<team>__<agent>`, `ready.<team>__<agent>`, and the codex bridge's
+# `codex-bridge.<team>.<agent>.*`. Thirteen files read them between them, and
+# rewriting the state of a process that is currently running, because its name
+# changed, is a good way to break the one thing that was working.
+#
+# What that leaves behind is orphans under the old name. They are harmless:
+# nothing is running under that name to read them, and the next start writes
+# fresh ones. The exclusivity lock is the one worth clearing by hand — a lock
+# held by a name that no longer exists is the kind of thing a future reuse check
+# trips over.
+#
+# Written down because two renames in a row produced the same leftovers and the
+# second person asked whether it was intended. It is. A bulk rename would
+# multiply them, and nobody should have to rediscover that it was a choice.
 
 TEAM="${1:?Usage: rename.sh <team> <old_name> <new_name>}"
 OLD_NAME="${2:?Missing old agent name}"


### PR DESCRIPTION
Two renames in a row left the same artefacts under the old name — `actas.<team>__<agent>.session`, `role-session.<team>__<agent>`, `ready.<team>__<agent>`, and the codex bridge's `codex-bridge.<team>.<agent>.*` — and the second person to hit it asked whether that was intended.

It is, and the reason was nowhere.

`run/` holds runtime state, not a record of the team. Rewriting the state of a process that is currently running, because its name changed, is a good way to break the one thing that was working. Thirteen files read those paths between them; which of them assume what is not something to settle in a rename.

The orphans are harmless: nothing runs under the old name to read them, and the next start writes fresh ones. The exclusivity lock is the one worth clearing by hand — a lock held by a name that no longer exists is what a future reuse check trips over.

Comment only; no behaviour change. `test_team.bats` 74/74.

## Why now

A bulk rename multiplies these. The 07-27 role rename produced 11 names whose old form is *not* recorded in `$.renamed` — because it was done by hand rather than through `rename.sh` — and those 11 carry ~9,900 of the sends and receives in our history. Whoever does that migration should not have to rediscover that `run/` was a deliberate omission.