### PR TITLE
fix(remote): report age as optional, because it is

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -140,17 +140,27 @@ cmd_doctor() {
   echo "Checking prerequisites${team:+ for team '$team'}..."
   echo
   local failed=0
+  # age is optional, and the wording has to say so. Remote sync defaults to
+  # cipher "none"; end-to-end encryption is a capability, not a prerequisite.
+  # Reporting its absence as a failure told every new user they were unfit for
+  # a feature they had not asked for -- and, because it set failed=1, doctor
+  # exited non-zero on a machine where everything actually required was present.
+  #
+  # python3 and node below stay required: without them the remote control plane
+  # and data plane do not run at all. The three are not interchangeable and are
+  # deliberately not reported the same way.
   if command -v age >/dev/null 2>&1 && command -v age-keygen >/dev/null 2>&1; then
-    echo "  [x] age / age-keygen on PATH"
+    echo "  [x] age / age-keygen on PATH  (optional)"
   else
-    echo "  [ ] age / age-keygen on PATH"
+    echo "  [ ] age / age-keygen on PATH  (optional)"
     echo
-    echo "'age' is required for end-to-end encryption and was not found on this device. Install it, then retry:"
+    echo "'age' enables end-to-end encryption. Remote sync works without it: teams"
+    echo "default to cipher \"none\", where the server stores blobs it does not read"
+    echo "but which are not encrypted end to end. Install it only if you want E2EE:"
     echo "  macOS (Homebrew):      brew install age"
     echo "  Debian/Ubuntu:         sudo apt install age"
     echo "  Windows (winget):      winget install FiloSottile.age"
     echo "See https://github.com/FiloSottile/age for other install methods."
-    failed=1
   fi
   echo
   if agmsg_python3_usable; then

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -205,6 +205,22 @@ setup_live_owner() {
 # lib/require-python3.sh) -- deliberately NOT built by filtering the real
 # PATH's directories, so it can't accidentally still contain a python3
 # from some other directory.
+# A PATH holding what doctor needs and no age. Shadowing with a stub does not
+# work: `command -v` skips a non-executable entry and finds the real binary
+# further along, so the lookup only fails if the PATH is built from scratch --
+# the same approach path_without_python3 takes.
+path_without_age() {
+  local dir tool
+  dir="$(mktemp -d)"
+  for tool in bash dirname basename readlink python3 node uname sed grep \
+              awk cat tr mktemp; do
+    if command -v "$tool" >/dev/null 2>&1; then
+      ln -s "$(command -v "$tool")" "$dir/$tool" 2>/dev/null || true
+    fi
+  done
+  printf '%s' "$dir"
+}
+
 path_without_python3() {
   local dir
   dir="$(mktemp -d)"

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1037,7 +1037,7 @@ VALUES ('remote-pending.$key', $owner_pid, strftime('%Y-%m-%dT%H:%M:%SZ','now'))
   [[ "$output" == *"[x] node on PATH"* ]]
 }
 
-@test "remote doctor: passes overall only when age, python3, AND node are all usable" {
+@test "remote doctor: passes with the full toolchain installed" {
   command -v age >/dev/null 2>&1 && command -v age-keygen >/dev/null 2>&1 \
     && command -v python3 >/dev/null 2>&1 && command -v node >/dev/null 2>&1 \
     || skip "all doctor prerequisites are not installed"
@@ -1100,4 +1100,26 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   [ "$status" -eq 0 ]
   [[ "$output" == *"history one"* ]]
   [[ "$output" == *"history two"* ]]
+}
+
+@test "remote doctor: age is optional — its absence does not fail the run" {
+  # cipher "none" is the base and e2ee is available rather than required, so a
+  # new user running doctor must not be told they are missing something they
+  # were never obliged to have.
+  local no_age; no_age="$(path_without_age)"
+  run env PATH="$no_age" bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"All checks passed"* ]]
+  [[ "$output" == *"optional"* ]]
+  [[ "$output" != *"is required for end-to-end encryption"* ]]
+}
+
+@test "remote doctor: python3 stays required while age is optional" {
+  # The three are not interchangeable: without python3 the remote control plane
+  # does not run at all, so it keeps failing the check.
+  local no_py3; no_py3="$(path_without_python3)"
+  run env PATH="$no_py3" bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"[ ] python3 on PATH"* ]]
+  [[ "$output" == *"Some checks failed"* ]]
 }


### PR DESCRIPTION
`doctor` set `failed=1` when `age` was absent and exited non-zero, so a machine with everything actually required present was told it had failed. Remote sync defaults to `cipher: "none"` — end-to-end encryption is a capability, not a prerequisite — and a new user running `doctor` was being told they were unfit for a feature they had not asked for.

## What changes

`age` is reported as optional and its absence is described as a choice rather than a defect:

    [ ] age / age-keygen on PATH  (optional)

    age enables end-to-end encryption. Remote sync works without it: teams
    default to cipher "none", where the server stores blobs it does not read
    but which are not encrypted end to end. Install it only if you want E2EE:

`python3` and `node` keep failing the check. Without them the remote control plane and the data plane do not run at all, so the three are deliberately not reported the same way — that difference is the point of the change, not an oversight in it.

## One existing test name was asserting the old rule

`remote doctor: passes overall only when age, python3, AND node are all usable` only ever asserted the positive direction — with everything installed, doctor passes. The "only" was never checked, and it is now false. The name now says what the test does.

## Tests

41 green in the remote suite. Two new cases: age absent still exits 0 and prints "All checks passed", and python3 absent still fails — so the two are pinned apart rather than assumed to have stayed apart.

Building the age-free PATH needed the same approach `path_without_python3` uses. Shadowing `age` with a non-executable stub does not work: `command -v` skips it and finds the real binary further along, which would have made the test pass while age was still present.
