### PR TITLE
Rotate team keys through the ordered journal

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -151,6 +151,9 @@ export async function activateKeyRotations(config) {
       throw new Error(
         `key rotation epoch ${rotation.epoch} is not the next epoch ${expectedRevision}`);
     }
+    if (BigInt(rotation.server_seq) === MAX_SEQUENCE) {
+      throw new Error("key rotation cannot be activated at the final server sequence");
+    }
     const identityPath = replacementIdentityPath(config.local_team, rotation.key_id);
     try {
       await lstat(identityPath);
@@ -903,7 +906,9 @@ export async function evaluatePull(config, capabilities, message) {
         openedEpoch.key_id !== effectiveEpoch.key_id) {
       const announced = projection?.kind === "key_rotated" &&
         SEQUENCE.test(projection.epoch ?? "") &&
-        BigInt(projection.epoch) === BigInt(openedEpoch.epoch_revision) + 1n;
+        BigInt(projection.epoch) === BigInt(effectiveEpoch.epoch_revision) &&
+        BigInt(openedEpoch.epoch_revision) + 1n ===
+          BigInt(effectiveEpoch.epoch_revision);
       if (!announced) {
         return { status: "policy_violation", reason: "envelope key_id violates effective epoch",
           policy_revision: serverPolicy.policy_revision,

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -90,6 +90,86 @@ function credentialPath(team) {
   return join(connectionRoot, "run", "remote-credentials", `${team}.json`);
 }
 
+function replacementIdentityPath(team, epoch) {
+  const connectionRoot = process.env.AGMSG_SYNC_CONNECTION_DIR ?? process.env.SKILL_DIR;
+  if (!connectionRoot) throw new Error("sync connection root is unavailable");
+  return join(connectionRoot, "run", "remote-credentials", team, "keys", `${epoch}.key`);
+}
+
+function rosterJournalPath(team) {
+  return join(dirname(teamConfigPath(team)), "roster.jsonl");
+}
+
+async function journalKeyRotations(config) {
+  let records;
+  try {
+    records = parseStrictJsonl(await readFile(rosterJournalPath(config.local_team), "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return [];
+    throw error;
+  }
+  const sequences = new Map(records.filter((record) =>
+    record.type === "roster_synced" &&
+    record.server_instance_id === config.server_instance_id &&
+    record.remote_team_id === config.remote_team_id)
+    .map((record) => [record.mutation_id, sequence(record.server_seq, "key rotation server sequence")]));
+  return records.filter((record) => record.type === "key_rotated" && sequences.has(record.id))
+    .map((record) => ({ ...record, server_seq: sequences.get(record.id) }))
+    .sort((left, right) => BigInt(left.server_seq) < BigInt(right.server_seq) ? -1 :
+      BigInt(left.server_seq) > BigInt(right.server_seq) ? 1 : 0);
+}
+
+export async function activateKeyRotations(config) {
+  const rotations = await journalKeyRotations(config);
+  if (rotations.length === 0) {
+    config.age_v1_runtime_history = [];
+    return;
+  }
+  if (config.cipher_profile !== "age-v1" || !config.age_v1) {
+    throw new Error("key rotation requires an age-v1 sync configuration");
+  }
+  const base = config.age_v1.epoch_snapshot.history;
+  let revision = BigInt(base.at(-1).epoch_revision);
+  const runtime = [];
+  for (const rotation of rotations) {
+    if (!UUID_V7.test(rotation.id ?? "") ||
+        !/^[a-z0-9][a-z0-9._-]{0,63}$/u.test(rotation.epoch ?? "") ||
+        !/^[0-9a-f]{64}$/u.test(rotation.fingerprint ?? "")) {
+      throw new Error("key rotation journal record is invalid");
+    }
+    const identityPath = replacementIdentityPath(config.local_team, rotation.epoch);
+    try {
+      await lstat(identityPath);
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        throw new Error(
+          `key rotation at server sequence ${rotation.server_seq} requires replacement epoch ` +
+          `${rotation.epoch}; import that key out of band before sync can continue`);
+      }
+      throw error;
+    }
+    const identity = readNativeAgeIdentity(identityPath);
+    const fingerprint = createHash("sha256").update(identity.recipient, "utf8").digest("hex");
+    if (fingerprint !== rotation.fingerprint) {
+      throw new Error(`replacement key for epoch ${rotation.epoch} does not match the announced fingerprint`);
+    }
+    revision += 1n;
+    config.age_v1.identity_files[rotation.epoch] = identityPath;
+    runtime.push({
+      epoch_revision: revision.toString(),
+      // The announcement itself is sealed with the old epoch so a removed
+      // holder can learn that rotation happened without receiving the new
+      // key. The first envelope that uses the replacement is therefore the
+      // sequence immediately after the announcement.
+      effective_from_seq: (BigInt(rotation.server_seq) + 1n).toString(),
+      cipher: "age-v1",
+      key_id: rotation.epoch,
+      recipients: [identity.recipient],
+    });
+  }
+  config.age_v1_runtime_history = runtime;
+}
+
 function connectedBinding(value, team) {
   const binding = value?.remote_binding;
   if (value?.name !== team || !binding || typeof binding !== "object" ||
@@ -232,6 +312,7 @@ export async function loadConfig(team) {
   if (value.cipher_profile === "age-v1") {
     validateAgeConfiguration(value);
     await validateRetainedAgeCheckpoint(value);
+    await activateKeyRotations(value);
   }
   else if (value.cipher_profile !== "none") throw new Error("sync cipher profile is unsupported");
   await readConnectedCredential(value);
@@ -733,7 +814,10 @@ function currentLocalPolicy(config, serverSeq) {
 }
 
 function currentAgeEpoch(config, serverSeq) {
-  const history = config.age_v1?.epoch_snapshot?.history;
+  const history = [
+    ...(config.age_v1?.epoch_snapshot?.history ?? []),
+    ...(config.age_v1_runtime_history ?? []),
+  ];
   if (!Array.isArray(history) || history.length < 1) return null;
   const target = BigInt(sequence(serverSeq, "age epoch server_seq"));
   const candidates = history.filter((entry) =>
@@ -1340,6 +1424,7 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
   const evaluateCall = dependencies.evaluateCall ?? evaluatePull;
   const logApplyCall = dependencies.logApplyCall ?? logApplyOutcomes;
   const readStateCycleCall = dependencies.readStateCycleCall ?? readStateCycle;
+  const activateKeyRotationsCall = dependencies.activateKeyRotationsCall ?? activateKeyRotations;
 
   const ready = await healthCall(config.server_url);
   if (ready.server_instance_id !== config.server_instance_id) throw new Error("health server instance changed");
@@ -1361,12 +1446,16 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
   // Registry mutations lead the page. They establish the identity needed to
   // interpret every following message, and UUIDv7 values minted in the same
   // millisecond are not a reliable cross-axis ordering key.
-  const candidates = [
-    ...rosterPrepared.filter((record) => record.type === "roster_sync_push_candidate")
-      .map((record) => ({ ...record, sync_axis: "roster" })),
+  const rosterCandidates = rosterPrepared
+    .filter((record) => record.type === "roster_sync_push_candidate")
+    .map((record) => ({ ...record, sync_axis: "roster" }));
+  const rotationIndex = rosterCandidates.findIndex((record) =>
+    record.projection?.kind === "key_rotated");
+  const candidates = (rotationIndex === -1 ? [
+    ...rosterCandidates,
     ...prepared.filter((record) => record.type === "sync_push_candidate")
       .map((record) => ({ ...record, sync_axis: "messages" })),
-  ].slice(0, pushLimit);
+  ] : rosterCandidates.slice(0, rotationIndex + 1)).slice(0, pushLimit);
   if (!state) throw new Error("driver omitted sync_state");
   sequence(state.transport_cursor, "transport_cursor");
   await eventCall("push.prepared", { count: candidates.length, local_positions: candidates.map((item) => item.local_position),
@@ -1386,6 +1475,11 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
       messageAcks.length > 0 ? driverCall("reconcile", config, messageAcks) : [],
       rosterAcks.length > 0 ? rosterDriverCall("reconcile", config, rosterAcks) : [],
     ]);
+    if (rosterAcks.some((_, index) =>
+      candidates.filter((candidate) => candidate.sync_axis === "roster")[index]
+        ?.projection?.kind === "key_rotated")) {
+      await activateKeyRotationsCall(config);
+    }
     await eventCall("push.reconciled", {
       result: reconciled[0] ?? null,
       roster_result: rosterReconciled[0] ?? null,
@@ -1427,7 +1521,13 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
     const records = [];
     for (const message of page.messages) {
       const evaluated = await evaluateCall(config, pullCapabilities, message);
-      records.push({ type: "sync_pull_message", ...message, ...evaluated });
+      const record = { type: "sync_pull_message", ...message, ...evaluated };
+      if (record.status === "importable" && record.projection?.kind === "key_rotated") {
+        await rosterDriverCall("apply", config, [record]);
+        await activateKeyRotationsCall(config);
+      } else {
+        records.push(record);
+      }
     }
     records.push({ type: "sync_pull_cursor", next_after: page.next_after });
     await eventCall("pull.received", { after: cursor, next_after: page.next_after,
@@ -1435,7 +1535,7 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
     const cursorRecord = records.at(-1);
     const rosterRecords = records.filter((record) =>
       record.type === "sync_pull_message" && record.status === "importable" &&
-      record.projection?.kind?.startsWith("member_"));
+      ["member_joined", "member_left", "member_renamed"].includes(record.projection?.kind));
     const messageRecords = records.filter((record) =>
       record.type !== "sync_pull_message" || !record.projection?.kind);
     const rosterApplied = rosterRecords.length > 0 ?

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -130,40 +130,56 @@ export async function activateKeyRotations(config) {
   }
   const base = config.age_v1.epoch_snapshot.history;
   let revision = BigInt(base.at(-1).epoch_revision);
-  const runtime = [];
+  const winners = [];
+  const announcedEpochs = new Set();
   for (const rotation of rotations) {
     if (!UUID_V7.test(rotation.id ?? "") ||
-        !/^[a-z0-9][a-z0-9._-]{0,63}$/u.test(rotation.epoch ?? "") ||
+        !SEQUENCE.test(rotation.epoch ?? "") ||
+        BigInt(rotation.epoch) > MAX_SEQUENCE ||
+        !/^[a-z0-9][a-z0-9._-]{0,63}$/u.test(rotation.key_id ?? "") ||
         !/^[0-9a-f]{64}$/u.test(rotation.fingerprint ?? "")) {
       throw new Error("key rotation journal record is invalid");
     }
-    const identityPath = replacementIdentityPath(config.local_team, rotation.epoch);
+    if (BigInt(rotation.epoch) <= revision || announcedEpochs.has(rotation.epoch)) continue;
+    announcedEpochs.add(rotation.epoch);
+    winners.push(rotation);
+  }
+  const runtime = [];
+  for (const rotation of winners) {
+    const expectedRevision = revision + 1n;
+    if (BigInt(rotation.epoch) !== expectedRevision) {
+      throw new Error(
+        `key rotation epoch ${rotation.epoch} is not the next epoch ${expectedRevision}`);
+    }
+    const identityPath = replacementIdentityPath(config.local_team, rotation.key_id);
     try {
       await lstat(identityPath);
     } catch (error) {
       if (error?.code === "ENOENT") {
         throw new Error(
-          `key rotation at server sequence ${rotation.server_seq} requires replacement epoch ` +
-          `${rotation.epoch}; import that key out of band before sync can continue`);
+          `key rotation at server sequence ${rotation.server_seq} selected epoch ` +
+          `${rotation.epoch} with key_id=${rotation.key_id}; import that key out of band ` +
+          "before sync can continue");
       }
       throw error;
     }
     const identity = readNativeAgeIdentity(identityPath);
     const fingerprint = createHash("sha256").update(identity.recipient, "utf8").digest("hex");
     if (fingerprint !== rotation.fingerprint) {
-      throw new Error(`replacement key for epoch ${rotation.epoch} does not match the announced fingerprint`);
+      throw new Error(
+        `replacement key ${rotation.key_id} for epoch ${rotation.epoch} does not match the announced fingerprint`);
     }
-    revision += 1n;
-    config.age_v1.identity_files[rotation.epoch] = identityPath;
+    revision = expectedRevision;
+    config.age_v1.identity_files[rotation.key_id] = identityPath;
     runtime.push({
-      epoch_revision: revision.toString(),
+      epoch_revision: rotation.epoch,
       // The announcement itself is sealed with the old epoch so a removed
       // holder can learn that rotation happened without receiving the new
       // key. The first envelope that uses the replacement is therefore the
       // sequence immediately after the announcement.
       effective_from_seq: (BigInt(rotation.server_seq) + 1n).toString(),
       cipher: "age-v1",
-      key_id: rotation.epoch,
+      key_id: rotation.key_id,
       recipients: [identity.recipient],
     });
   }
@@ -813,11 +829,15 @@ function currentLocalPolicy(config, serverSeq) {
   return candidates.reduce((best, entry) => BigInt(entry.local_security_revision) > BigInt(best.local_security_revision) ? entry : best);
 }
 
-function currentAgeEpoch(config, serverSeq) {
-  const history = [
+function ageHistory(config) {
+  return [
     ...(config.age_v1?.epoch_snapshot?.history ?? []),
     ...(config.age_v1_runtime_history ?? []),
   ];
+}
+
+function currentAgeEpoch(config, serverSeq) {
+  const history = ageHistory(config);
   if (!Array.isArray(history) || history.length < 1) return null;
   const target = BigInt(sequence(serverSeq, "age epoch server_seq"));
   const candidates = history.filter((entry) =>
@@ -847,27 +867,49 @@ export async function evaluatePull(config, capabilities, message) {
       local_security_revision: localPolicy.local_security_revision };
   }
   let identityFile;
+  let openedEpoch;
+  let effectiveEpoch;
   if (message.envelope.cipher === "age-v1") {
     if (config.cipher_profile !== "age-v1" || !config.age_v1) {
       return { status: "unsupported_cipher", reason: "age-v1 is not configured",
         policy_revision: serverPolicy.policy_revision,
         local_security_revision: localPolicy.local_security_revision };
     }
-    const epoch = currentAgeEpoch(config, message.server_seq);
-    if (!epoch || message.envelope.key_id !== epoch.key_id) {
+    effectiveEpoch = currentAgeEpoch(config, message.server_seq);
+    if (!effectiveEpoch) {
       return { status: "policy_violation", reason: "envelope key_id violates effective epoch",
         policy_revision: serverPolicy.policy_revision,
         local_security_revision: localPolicy.local_security_revision };
     }
-    identityFile = config.age_v1.identity_files?.[epoch.key_id];
+    openedEpoch = ageHistory(config).find((entry) =>
+      entry.key_id === message.envelope.key_id &&
+      BigInt(sequence(entry.effective_from_seq, "age epoch effective_from_seq")) <=
+        BigInt(message.server_seq));
+    if (!openedEpoch) {
+      return { status: "policy_violation", reason: "envelope key_id violates effective epoch",
+        policy_revision: serverPolicy.policy_revision,
+        local_security_revision: localPolicy.local_security_revision };
+    }
+    identityFile = config.age_v1.identity_files?.[openedEpoch.key_id];
   }
   try {
     const projection = await openEnvelope({ envelope: message.envelope,
       protocol_version: config.protocol_version, team_id: config.remote_team_id,
       wire_id: message.id, identity_file: identityFile,
       expected_recipients: message.envelope.cipher === "age-v1" ?
-        currentAgeEpoch(config, message.server_seq).recipients : undefined,
+        openedEpoch.recipients : undefined,
       max_blob_bytes: 1_048_576 });
+    if (message.envelope.cipher === "age-v1" &&
+        openedEpoch.key_id !== effectiveEpoch.key_id) {
+      const announced = projection?.kind === "key_rotated" &&
+        SEQUENCE.test(projection.epoch ?? "") &&
+        BigInt(projection.epoch) === BigInt(openedEpoch.epoch_revision) + 1n;
+      if (!announced) {
+        return { status: "policy_violation", reason: "envelope key_id violates effective epoch",
+          policy_revision: serverPolicy.policy_revision,
+          local_security_revision: localPolicy.local_security_revision };
+      }
+    }
     return { status: "importable", projection,
       policy_revision: serverPolicy.policy_revision,
       local_security_revision: localPolicy.local_security_revision };
@@ -1475,11 +1517,6 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
       messageAcks.length > 0 ? driverCall("reconcile", config, messageAcks) : [],
       rosterAcks.length > 0 ? rosterDriverCall("reconcile", config, rosterAcks) : [],
     ]);
-    if (rosterAcks.some((_, index) =>
-      candidates.filter((candidate) => candidate.sync_axis === "roster")[index]
-        ?.projection?.kind === "key_rotated")) {
-      await activateKeyRotationsCall(config);
-    }
     await eventCall("push.reconciled", {
       result: reconciled[0] ?? null,
       roster_result: rosterReconciled[0] ?? null,

--- a/scripts/internal/roster-sync.mjs
+++ b/scripts/internal/roster-sync.mjs
@@ -60,6 +60,15 @@ function timestamp(value) {
 }
 
 function projection(record) {
+  if (record.type === "key_rotated") {
+    return {
+      kind: record.type,
+      mutation_id: record.id,
+      epoch: record.epoch,
+      fingerprint: record.fingerprint,
+      occurred_at: timestamp(record.at),
+    };
+  }
   const common = {
     kind: record.type,
     mutation_id: record.id,
@@ -72,6 +81,15 @@ function projection(record) {
 }
 
 function mutation(value) {
+  if (value.kind === "key_rotated") {
+    return {
+      type: value.kind,
+      id: value.mutation_id,
+      epoch: value.epoch,
+      fingerprint: value.fingerprint,
+      at: value.occurred_at,
+    };
+  }
   const common = {
     type: value.kind,
     id: value.mutation_id,
@@ -118,7 +136,7 @@ function prepare() {
     record.server_instance_id === serverId &&
     record.remote_team_id === remoteTeamId).map((record) => record.mutation_id));
   const mutations = records.filter((record) =>
-    ["member_joined", "member_left", "member_renamed"].includes(record.type) &&
+    ["member_joined", "member_left", "member_renamed", "key_rotated"].includes(record.type) &&
     !synced.has(record.id) &&
     (request.allow_new || target.reservations[record.id])).slice(0, limit);
 
@@ -156,6 +174,7 @@ function prepare() {
       local_id: record.id,
       id: reserved.wire_id,
       envelope: reserved.envelope,
+      projection: projection(record),
     })}\n`);
   }
 }
@@ -194,7 +213,7 @@ function apply() {
   const state = readState();
   const target = binding(state);
   const mutations = new Map(records.filter((record) =>
-    ["member_joined", "member_left", "member_renamed"].includes(record.type))
+    ["member_joined", "member_left", "member_renamed", "key_rotated"].includes(record.type))
     .map((record) => [record.id, record]));
   const synced = new Set(records.filter((record) =>
     record.type === "roster_synced" &&
@@ -206,7 +225,8 @@ function apply() {
       continue;
     }
     if (item.type !== "sync_pull_message" || item.status !== "importable" ||
-        !item.projection?.kind?.startsWith("member_")) {
+        !["member_joined", "member_left", "member_renamed", "key_rotated"]
+          .includes(item.projection?.kind)) {
       throw new Error("roster pull input is invalid");
     }
     const incoming = mutation(item.projection);

--- a/scripts/internal/roster-sync.mjs
+++ b/scripts/internal/roster-sync.mjs
@@ -65,6 +65,7 @@ function projection(record) {
       kind: record.type,
       mutation_id: record.id,
       epoch: record.epoch,
+      key_id: record.key_id,
       fingerprint: record.fingerprint,
       occurred_at: timestamp(record.at),
     };
@@ -86,6 +87,7 @@ function mutation(value) {
       type: value.kind,
       id: value.mutation_id,
       epoch: value.epoch,
+      key_id: value.key_id,
       fingerprint: value.fingerprint,
       at: value.occurred_at,
     };

--- a/scripts/internal/sync-cipher.mjs
+++ b/scripts/internal/sync-cipher.mjs
@@ -101,11 +101,27 @@ function canonicalMessage(projection) {
 
 function canonicalRosterMutation(projection) {
   if (!projection || Array.isArray(projection) || typeof projection !== "object" ||
-      !["member_joined", "member_left", "member_renamed"].includes(projection.kind) ||
+      !["member_joined", "member_left", "member_renamed", "key_rotated"].includes(projection.kind) ||
       !UUID_V7.test(projection.mutation_id ?? "") ||
-      !UUID_V7.test(projection.member_id ?? "") ||
       typeof projection.occurred_at !== "string" ||
       !TIMESTAMP.test(projection.occurred_at) || !validTimestamp(projection.occurred_at)) {
+    malformed("roster mutation projection is invalid");
+  }
+  if (projection.kind === "key_rotated") {
+    if (!KEY_ID.test(projection.epoch ?? "") ||
+        typeof projection.fingerprint !== "string" ||
+        !/^[0-9a-f]{64}$/u.test(projection.fingerprint)) {
+      malformed("key rotation projection is invalid");
+    }
+    return Buffer.from(JSON.stringify({
+      kind: projection.kind,
+      mutation_id: projection.mutation_id,
+      epoch: projection.epoch,
+      fingerprint: projection.fingerprint,
+      occurred_at: projection.occurred_at,
+    }), "utf8");
+  }
+  if (!UUID_V7.test(projection.member_id ?? "")) {
     malformed("roster mutation projection is invalid");
   }
   if (projection.kind === "member_renamed") {

--- a/scripts/internal/sync-cipher.mjs
+++ b/scripts/internal/sync-cipher.mjs
@@ -17,6 +17,7 @@ const UUID_V7 = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/u;
 const KEY_ID = /^[a-z0-9][a-z0-9._-]{0,63}$/u;
+const EPOCH_REVISION = /^(0|[1-9][0-9]*)$/u;
 const AGE_RECIPIENT = /^age1[0-9a-z]{58}$/u;
 const BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u;
 const MAGIC = Buffer.concat([Buffer.from("agmsg-age-v1", "ascii"), Buffer.alloc(4)]);
@@ -108,7 +109,8 @@ function canonicalRosterMutation(projection) {
     malformed("roster mutation projection is invalid");
   }
   if (projection.kind === "key_rotated") {
-    if (!KEY_ID.test(projection.epoch ?? "") ||
+    if (!EPOCH_REVISION.test(projection.epoch ?? "") ||
+        !KEY_ID.test(projection.key_id ?? "") ||
         typeof projection.fingerprint !== "string" ||
         !/^[0-9a-f]{64}$/u.test(projection.fingerprint)) {
       malformed("key rotation projection is invalid");
@@ -117,6 +119,7 @@ function canonicalRosterMutation(projection) {
       kind: projection.kind,
       mutation_id: projection.mutation_id,
       epoch: projection.epoch,
+      key_id: projection.key_id,
       fingerprint: projection.fingerprint,
       occurred_at: projection.occurred_at,
     }), "utf8");

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -396,7 +396,6 @@ cmd_import() {
 cmd_rotate() {
   local team="${1:?Usage: key.sh rotate [<team>]}"
   agmsg_validate_team_name "$team" || exit 1
-  _key_require_age || exit 1
   local cfg team_dir cred_dir current_key journal journal_sql pending
   cfg="$(_key_team_config "$team")"
   team_dir="$TEAMS_DIR/$team"
@@ -410,6 +409,10 @@ cmd_rotate() {
   if [ -z "$current_key" ] || [ "$current_key" = "null" ]; then
     agmsg_lock_release
     echo "agmsg: team '$team' has no current key — generate or import the first key before rotating." >&2
+    exit 1
+  fi
+  if ! _key_require_age; then
+    agmsg_lock_release
     exit 1
   fi
   agmsg_roster_ensure "$team_dir" "$cfg"

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -361,6 +361,11 @@ cmd_import() {
         echo "agmsg: imported identity does not match the current key or an announced rotation — refusing to import." >&2
         exit 1
       fi
+      printf '%s\n' "$staged_epoch" | grep -Eq '^[a-z0-9][a-z0-9._-]{0,63}$' || {
+        agmsg_lock_release
+        echo "agmsg: announced replacement epoch is invalid — refusing to import." >&2
+        exit 1
+      }
       _key_write_identity_atomic "$cred_dir/$staged_epoch.key" "$identity"
       agmsg_lock_release
       unset identity
@@ -409,6 +414,11 @@ cmd_rotate() {
   fi
   agmsg_roster_ensure "$team_dir" "$cfg"
   journal="$(agmsg_roster_journal_path "$team_dir")"
+  if [ ! -f "$journal" ]; then
+    agmsg_lock_release
+    echo "agmsg: team '$team' has no identity journal; connect or migrate it before rotating." >&2
+    exit 1
+  fi
   journal_sql="$(_agmsg_sqlesc "$journal")"
   pending="$(agmsg_sqlite_mem "
     WITH source(doc) AS (
@@ -448,7 +458,12 @@ cmd_rotate() {
   chmod 600 "$identity_file"
   recipient="$(grep '^# public key:' "$identity_file" | sed 's/^# public key: //')"
   fingerprint="$(_key_fingerprint_sha256 "$recipient")"
-  agmsg_roster_append_key_rotated "$team_dir" "$key_id" "$fingerprint" "$created_at"
+  if ! agmsg_roster_append_key_rotated "$team_dir" "$key_id" "$fingerprint" "$created_at"; then
+    rm -f "$identity_file"
+    agmsg_lock_release
+    echo "agmsg: failed to publish the key rotation; no replacement was announced." >&2
+    exit 1
+  fi
   agmsg_lock_release
 
   echo "Generated replacement key for team '$team' (epoch=$key_id)."

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -3,16 +3,17 @@ set -euo pipefail
 
 # Usage:
 #   key.sh generate [<team>]
-#   key.sh show [<team>] [--reveal-secret]
+#   key.sh show [<team>] [--epoch <key-id>] [--reveal-secret]
 #   key.sh import <team> [<identity>] [--identity-stdin]
-#   key.sh rotate [<team>]   -- NOT READY, see cmd_rotate
+#   key.sh rotate [<team>]
 #
 # Team-scoped end-to-end encryption key management (age-v1 profile,
 # docs/spec/ref/age-v1-profile.md). Scope: initial single-writer onboarding
-# (generate the very first key, or import one obtained out-of-band) — NOT
-# key rotation (see cmd_rotate) and NOT the multi-writer cutover protocol.
-# This script does not implement age-v1's anti-rollback epoch-snapshot
-# hash chain; it only manages key *files* for a team's first epoch.
+# (generate the very first key, import one obtained out-of-band, or announce a
+# replacement through the team journal).
+# This script does not implement age-v1's anti-rollback epoch-snapshot hash
+# chain. Rotation protects messages written after the acknowledged boundary;
+# anyone who retained an old key can still read the history encrypted with it.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -23,6 +24,8 @@ source "$SCRIPT_DIR/lib/storage.sh"
 source "$SCRIPT_DIR/lib/registry-lock.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/validate.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/roster-journal.sh"
 
 TEAMS_DIR="$CONNECTION_ROOT/teams"
 CRED_ROOT="$CONNECTION_ROOT/run/remote-credentials"
@@ -76,6 +79,10 @@ _key_read_config_field() {
 # two people compare this same short string over a separate channel.
 _key_fingerprint() {
   printf '%s' "$1" | shasum -a 256 | cut -c1-16 | sed 's/\(....\)/\1-/g;s/-$//'
+}
+
+_key_fingerprint_sha256() {
+  printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
 }
 
 # A timestamp alone collides when two epochs are minted within the same
@@ -208,10 +215,14 @@ cmd_generate() {
 }
 
 cmd_show() {
-  local team="" reveal=0
+  local team="" epoch="" reveal=0
   while [ $# -gt 0 ]; do
     case "$1" in
       --reveal-secret) reveal=1 ;;
+      --epoch)
+        shift
+        epoch="${1:?Missing value for --epoch}"
+        ;;
       *) team="$1" ;;
     esac
     shift
@@ -219,13 +230,23 @@ cmd_show() {
   : "${team:?Usage: key.sh show [<team>] [--reveal-secret]}"
   agmsg_validate_team_name "$team" || exit 1
 
-  local cfg key_id recipient
+  local cfg key_id recipient identity_file
   cfg="$(_key_team_config "$team")"
-  key_id="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
-  recipient="$(_key_read_config_field "$cfg" '$.remote_key.current.recipient')"
+  key_id="${epoch:-$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')}"
   if [ -z "$key_id" ] || [ "$key_id" = "null" ]; then
     echo "agmsg: team '$team' has no key yet — run 'key.sh generate $team' or 'key.sh import $team'." >&2
     exit 1
+  fi
+  identity_file="$(_key_cred_dir "$team")/$key_id.key"
+  if [ -n "$epoch" ]; then
+    _key_require_age || exit 1
+    [ -f "$identity_file" ] || {
+      echo "agmsg: local identity file missing for key_id=$key_id ($identity_file)" >&2
+      exit 1
+    }
+    recipient="$(age-keygen -y "$identity_file" 2>/dev/null)"
+  else
+    recipient="$(_key_read_config_field "$cfg" '$.remote_key.current.recipient')"
   fi
 
   if [ "$reveal" -eq 0 ]; then
@@ -248,8 +269,6 @@ cmd_show() {
     echo "Aborted." >&2
     exit 1
   fi
-  local identity_file
-  identity_file="$(_key_cred_dir "$team")/$key_id.key"
   if [ ! -f "$identity_file" ]; then
     echo "agmsg: local identity file missing for key_id=$key_id ($identity_file)" >&2
     exit 1
@@ -319,9 +338,35 @@ cmd_import() {
 
   if [ -n "$cur_key_id" ] && [ "$cur_key_id" != "null" ]; then
     if [ "$cur_recipient" != "$recipient" ]; then
+      local journal journal_sql fingerprint staged_epoch
+      journal="$(agmsg_roster_journal_path "$TEAMS_DIR/$team")"
+      fingerprint="$(_key_fingerprint_sha256 "$recipient")"
+      staged_epoch=""
+      if [ -f "$journal" ]; then
+        journal_sql="$(_agmsg_sqlesc "$journal")"
+        staged_epoch="$(agmsg_sqlite_mem "
+          WITH source(doc) AS (
+            SELECT '[' || replace(
+              rtrim(CAST(readfile('$journal_sql') AS TEXT), char(10)),
+              char(10), ',') || ']'
+          )
+          SELECT json_extract(value, '\$.epoch')
+            FROM source, json_each(source.doc)
+           WHERE json_extract(value, '\$.type')='key_rotated'
+             AND json_extract(value, '\$.fingerprint')='$(_agmsg_sqlesc "$fingerprint")'
+           ORDER BY CAST(key AS INTEGER) DESC LIMIT 1;")"
+      fi
+      if [ -z "$staged_epoch" ]; then
+        agmsg_lock_release
+        echo "agmsg: imported identity does not match the current key or an announced rotation — refusing to import." >&2
+        exit 1
+      fi
+      _key_write_identity_atomic "$cred_dir/$staged_epoch.key" "$identity"
       agmsg_lock_release
-      echo "agmsg: imported identity's recipient does not match team '$team's authorized key — refusing to import." >&2
-      exit 1
+      unset identity
+      echo "Imported replacement key for team '$team' (epoch=$staged_epoch)."
+      echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+      return
     fi
     # Matches the existing epoch: just store this device's copy of the
     # identity under the existing key_id (idempotent re-import). Does not
@@ -343,23 +388,74 @@ cmd_import() {
   echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
 }
 
-# key rotate — NOT READY.
-#
-# An adversarial design review found this scope's previous_snapshot_sha256
-# design insufficient: hashing only this script's own ad hoc epoch JSON
-# does not detect a wholesale rollback of config.json to a stale version
-# (the hash chain inside a rolled-back file still looks internally
-# consistent), and does not use the age-v1 profile's pinned canonical
-# epoch-snapshot shape. A real fix needs a durable, binding-scoped private
-# anchor (outside the regular synced config) tracking the highest-seen
-# epoch_revision + snapshot digest, checked on load/rotate, with a
-# crash-safe commit ordering relative to the new identity file — none of
-# which this script implements. Shipping rotate without that anchor would
-# present anti-rollback protection that isn't actually there. Deferred to
-# a follow-up design pass; this command intentionally refuses to run.
 cmd_rotate() {
-  echo "agmsg: 'key rotate' is not available in this release — it needs a durable anti-rollback anchor (age-v1 epoch-snapshot hash chain) this script does not yet implement. No state was changed." >&2
-  exit 1
+  local team="${1:?Usage: key.sh rotate [<team>]}"
+  agmsg_validate_team_name "$team" || exit 1
+  _key_require_age || exit 1
+  local cfg team_dir cred_dir current_key journal journal_sql pending
+  cfg="$(_key_team_config "$team")"
+  team_dir="$TEAMS_DIR/$team"
+  [ -f "$cfg" ] || { echo "agmsg: team not found: $team" >&2; exit 1; }
+  cred_dir="$(_key_cred_dir "$team")"
+  mkdir -p "$cred_dir"
+  chmod 700 "$cred_dir" 2>/dev/null || true
+
+  agmsg_lock_acquire "$team_dir" || exit 1
+  current_key="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
+  if [ -z "$current_key" ] || [ "$current_key" = "null" ]; then
+    agmsg_lock_release
+    echo "agmsg: team '$team' has no current key — generate or import the first key before rotating." >&2
+    exit 1
+  fi
+  agmsg_roster_ensure "$team_dir" "$cfg"
+  journal="$(agmsg_roster_journal_path "$team_dir")"
+  journal_sql="$(_agmsg_sqlesc "$journal")"
+  pending="$(agmsg_sqlite_mem "
+    WITH source(doc) AS (
+      SELECT '[' || replace(
+        rtrim(CAST(readfile('$journal_sql') AS TEXT), char(10)),
+        char(10), ',') || ']'
+    ),
+    rows AS (SELECT value FROM source,json_each(source.doc)),
+    rotations AS (
+      SELECT json_extract(value,'\$.id') AS id FROM rows
+       WHERE json_extract(value,'\$.type')='key_rotated'
+    ),
+    synced AS (
+      SELECT json_extract(value,'\$.mutation_id') AS id FROM rows
+       WHERE json_extract(value,'\$.type')='roster_synced'
+    )
+    SELECT count(*) FROM rotations r LEFT JOIN synced s USING(id)
+     WHERE s.id IS NULL;")"
+  if [ "$pending" -ne 0 ]; then
+    agmsg_lock_release
+    echo "agmsg: team '$team' already has an unacknowledged key rotation." >&2
+    exit 1
+  fi
+
+  local key_id created_at identity_file recipient fingerprint keygen_err
+  key_id="$(_key_new_key_id)"
+  created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  identity_file="$cred_dir/$key_id.key"
+  keygen_err="$(mktemp "${TMPDIR:-/tmp}/agmsg-keygen-err.XXXXXX")"
+  if ! age-keygen -o "$identity_file" 2>"$keygen_err"; then
+    agmsg_lock_release
+    echo "agmsg: age-keygen failed: $(cat "$keygen_err" 2>/dev/null)" >&2
+    rm -f "$keygen_err"
+    exit 1
+  fi
+  rm -f "$keygen_err"
+  chmod 600 "$identity_file"
+  recipient="$(grep '^# public key:' "$identity_file" | sed 's/^# public key: //')"
+  fingerprint="$(_key_fingerprint_sha256 "$recipient")"
+  agmsg_roster_append_key_rotated "$team_dir" "$key_id" "$fingerprint" "$created_at"
+  agmsg_lock_release
+
+  echo "Generated replacement key for team '$team' (epoch=$key_id)."
+  echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+  echo "The private key was not written to the journal; distribute it out of band."
+  echo "Use 'key.sh show $team --epoch $key_id --reveal-secret' on an interactive terminal."
+  echo "Messages before the acknowledged rotation boundary remain readable with the old key."
 }
 
 case "${1:-}" in

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Usage:
 #   key.sh generate [<team>]
-#   key.sh show [<team>] [--epoch <key-id>] [--reveal-secret]
+#   key.sh show [<team>] [--key-id <key-id>] [--reveal-secret]
 #   key.sh import <team> [<identity>] [--identity-stdin]
 #   key.sh rotate [<team>]
 #
@@ -215,13 +215,13 @@ cmd_generate() {
 }
 
 cmd_show() {
-  local team="" epoch="" reveal=0
+  local team="" requested_key_id="" reveal=0
   while [ $# -gt 0 ]; do
     case "$1" in
       --reveal-secret) reveal=1 ;;
-      --epoch)
+      --key-id)
         shift
-        epoch="${1:?Missing value for --epoch}"
+        requested_key_id="${1:?Missing value for --key-id}"
         ;;
       *) team="$1" ;;
     esac
@@ -232,13 +232,13 @@ cmd_show() {
 
   local cfg key_id recipient identity_file
   cfg="$(_key_team_config "$team")"
-  key_id="${epoch:-$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')}"
+  key_id="${requested_key_id:-$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')}"
   if [ -z "$key_id" ] || [ "$key_id" = "null" ]; then
     echo "agmsg: team '$team' has no key yet — run 'key.sh generate $team' or 'key.sh import $team'." >&2
     exit 1
   fi
   identity_file="$(_key_cred_dir "$team")/$key_id.key"
-  if [ -n "$epoch" ]; then
+  if [ -n "$requested_key_id" ]; then
     _key_require_age || exit 1
     [ -f "$identity_file" ] || {
       echo "agmsg: local identity file missing for key_id=$key_id ($identity_file)" >&2
@@ -338,38 +338,38 @@ cmd_import() {
 
   if [ -n "$cur_key_id" ] && [ "$cur_key_id" != "null" ]; then
     if [ "$cur_recipient" != "$recipient" ]; then
-      local journal journal_sql fingerprint staged_epoch
+      local journal journal_sql fingerprint staged_key_id
       journal="$(agmsg_roster_journal_path "$TEAMS_DIR/$team")"
       fingerprint="$(_key_fingerprint_sha256 "$recipient")"
-      staged_epoch=""
+      staged_key_id=""
       if [ -f "$journal" ]; then
         journal_sql="$(_agmsg_sqlesc "$journal")"
-        staged_epoch="$(agmsg_sqlite_mem "
+        staged_key_id="$(agmsg_sqlite_mem "
           WITH source(doc) AS (
             SELECT '[' || replace(
               rtrim(CAST(readfile('$journal_sql') AS TEXT), char(10)),
               char(10), ',') || ']'
           )
-          SELECT json_extract(value, '\$.epoch')
+          SELECT json_extract(value, '\$.key_id')
             FROM source, json_each(source.doc)
            WHERE json_extract(value, '\$.type')='key_rotated'
              AND json_extract(value, '\$.fingerprint')='$(_agmsg_sqlesc "$fingerprint")'
            ORDER BY CAST(key AS INTEGER) DESC LIMIT 1;")"
       fi
-      if [ -z "$staged_epoch" ]; then
+      if [ -z "$staged_key_id" ]; then
         agmsg_lock_release
         echo "agmsg: imported identity does not match the current key or an announced rotation — refusing to import." >&2
         exit 1
       fi
-      printf '%s\n' "$staged_epoch" | grep -Eq '^[a-z0-9][a-z0-9._-]{0,63}$' || {
+      printf '%s\n' "$staged_key_id" | grep -Eq '^[a-z0-9][a-z0-9._-]{0,63}$' || {
         agmsg_lock_release
-        echo "agmsg: announced replacement epoch is invalid — refusing to import." >&2
+        echo "agmsg: announced replacement key id is invalid — refusing to import." >&2
         exit 1
       }
-      _key_write_identity_atomic "$cred_dir/$staged_epoch.key" "$identity"
+      _key_write_identity_atomic "$cred_dir/$staged_key_id.key" "$identity"
       agmsg_lock_release
       unset identity
-      echo "Imported replacement key for team '$team' (epoch=$staged_epoch)."
+      echo "Imported replacement key for team '$team' (key_id=$staged_key_id)."
       echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
       return
     fi
@@ -443,6 +443,86 @@ cmd_rotate() {
     exit 1
   fi
 
+  # A rotation number identifies the transition, while key_id identifies the
+  # locally generated key material. Concurrent machines announce the same
+  # next number; server sequence then selects the first announcement.
+  local base_revision latest accepted_epoch accepted_key_id accepted_fingerprint next_epoch
+  base_revision="$(_key_read_config_field "$cfg" '$.remote_key.current.epoch_revision')"
+  [ -n "$base_revision" ] && [ "$base_revision" != "null" ] || base_revision=0
+  printf '%s\n' "$base_revision" | grep -Eq '^(0|[1-9][0-9]*)$' || {
+    agmsg_lock_release
+    echo "agmsg: current key epoch revision is invalid." >&2
+    exit 1
+  }
+  latest="$(agmsg_sqlite_mem "
+    WITH source(doc) AS (
+      SELECT '[' || replace(
+        rtrim(CAST(readfile('$journal_sql') AS TEXT), char(10)),
+        char(10), ',') || ']'
+    ),
+    rows AS (SELECT value FROM source,json_each(source.doc)),
+    rotations AS (
+      SELECT json_extract(value,'\$.id') AS id,
+             json_extract(value,'\$.epoch') AS epoch,
+             json_extract(value,'\$.key_id') AS key_id,
+             json_extract(value,'\$.fingerprint') AS fingerprint
+        FROM rows WHERE json_extract(value,'\$.type')='key_rotated'
+    ),
+    synced AS (
+      SELECT json_extract(value,'\$.mutation_id') AS id,
+             CAST(json_extract(value,'\$.server_seq') AS INTEGER) AS server_seq
+        FROM rows WHERE json_extract(value,'\$.type')='roster_synced'
+          AND json_extract(value,'\$.server_instance_id')='$(_agmsg_sqlesc "$(_key_read_config_field "$cfg" '$.remote_binding.server_instance_id')")'
+          AND json_extract(value,'\$.remote_team_id')='$(_agmsg_sqlesc "$(_key_read_config_field "$cfg" '$.remote_binding.remote_team_id')")'
+    ),
+    ordered AS (
+      SELECT r.*, s.server_seq,
+             row_number() OVER (
+               PARTITION BY r.epoch ORDER BY s.server_seq, r.id
+             ) AS choice
+        FROM rotations r JOIN synced s USING(id)
+    )
+    SELECT epoch || '|' || key_id || '|' || fingerprint
+      FROM ordered WHERE choice=1
+     ORDER BY CAST(epoch AS INTEGER) DESC LIMIT 1;")"
+  accepted_epoch="$base_revision"
+  accepted_key_id="$current_key"
+  accepted_fingerprint=""
+  if [ -n "$latest" ]; then
+    IFS='|' read -r accepted_epoch accepted_key_id accepted_fingerprint <<EOF
+$latest
+EOF
+    printf '%s\n' "$accepted_epoch" | grep -Eq '^(0|[1-9][0-9]*)$' || {
+      agmsg_lock_release
+      echo "agmsg: accepted key rotation epoch is invalid." >&2
+      exit 1
+    }
+    printf '%s\n' "$accepted_key_id" | grep -Eq '^[a-z0-9][a-z0-9._-]{0,63}$' || {
+      agmsg_lock_release
+      echo "agmsg: accepted replacement key id is invalid." >&2
+      exit 1
+    }
+    if [ ! -f "$cred_dir/$accepted_key_id.key" ]; then
+      agmsg_lock_release
+      echo "agmsg: accepted epoch $accepted_epoch requires replacement key_id=$accepted_key_id; import that key out of band before rotating again." >&2
+      exit 1
+    fi
+    local accepted_recipient
+    accepted_recipient="$(age-keygen -y "$cred_dir/$accepted_key_id.key" 2>/dev/null)" || true
+    if [ -z "$accepted_recipient" ] ||
+       [ "$(_key_fingerprint_sha256 "$accepted_recipient")" != "$accepted_fingerprint" ]; then
+      agmsg_lock_release
+      echo "agmsg: local identity for accepted epoch $accepted_epoch does not match its announced fingerprint." >&2
+      exit 1
+    fi
+  fi
+  next_epoch="$(agmsg_sqlite_mem "SELECT CAST('$(_agmsg_sqlesc "$accepted_epoch")' AS INTEGER) + 1;")"
+  printf '%s\n' "$next_epoch" | grep -Eq '^[1-9][0-9]*$' || {
+    agmsg_lock_release
+    echo "agmsg: next key rotation epoch is outside the supported range." >&2
+    exit 1
+  }
+
   local key_id created_at identity_file recipient fingerprint keygen_err
   key_id="$(_key_new_key_id)"
   created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -458,7 +538,7 @@ cmd_rotate() {
   chmod 600 "$identity_file"
   recipient="$(grep '^# public key:' "$identity_file" | sed 's/^# public key: //')"
   fingerprint="$(_key_fingerprint_sha256 "$recipient")"
-  if ! agmsg_roster_append_key_rotated "$team_dir" "$key_id" "$fingerprint" "$created_at"; then
+  if ! agmsg_roster_append_key_rotated "$team_dir" "$next_epoch" "$key_id" "$fingerprint" "$created_at"; then
     rm -f "$identity_file"
     agmsg_lock_release
     echo "agmsg: failed to publish the key rotation; no replacement was announced." >&2
@@ -466,10 +546,10 @@ cmd_rotate() {
   fi
   agmsg_lock_release
 
-  echo "Generated replacement key for team '$team' (epoch=$key_id)."
+  echo "Generated replacement key for team '$team' (epoch=$next_epoch, key_id=$key_id)."
   echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
   echo "The private key was not written to the journal; distribute it out of band."
-  echo "Use 'key.sh show $team --epoch $key_id --reveal-secret' on an interactive terminal."
+  echo "Use 'key.sh show $team --key-id $key_id --reveal-secret' on an interactive terminal."
   echo "Messages before the acknowledged rotation boundary remain readable with the old key."
 }
 

--- a/scripts/lib/roster-journal.sh
+++ b/scripts/lib/roster-journal.sh
@@ -53,6 +53,17 @@ _agmsg_roster_rename_record() {
   );" | tr -d '\r'
 }
 
+_agmsg_key_rotated_record() {
+  local epoch="$1" fingerprint="$2" at="$3"
+  sqlite3 :memory: "SELECT json_object(
+    'type','key_rotated',
+    'id','$(compat_uuid7)',
+    'epoch','$(_agmsg_roster_sqlesc "$epoch")',
+    'fingerprint','$(_agmsg_roster_sqlesc "$fingerprint")',
+    'at','$(_agmsg_roster_sqlesc "$at")'
+  );" | tr -d '\r'
+}
+
 _agmsg_roster_append_record() {
   local team_dir="$1" record="$2" journal prior=""
   journal="$(agmsg_roster_journal_path "$team_dir")"
@@ -76,6 +87,12 @@ agmsg_roster_append_left() {
 agmsg_roster_append_renamed() {
   local team_dir="$1" member_id="$2" from="$3" to="$4" at="$5" record
   record="$(_agmsg_roster_rename_record "$member_id" "$from" "$to" "$at")" || return 1
+  _agmsg_roster_append_record "$team_dir" "$record"
+}
+
+agmsg_roster_append_key_rotated() {
+  local team_dir="$1" epoch="$2" fingerprint="$3" at="$4" record
+  record="$(_agmsg_key_rotated_record "$epoch" "$fingerprint" "$at")" || return 1
   _agmsg_roster_append_record "$team_dir" "$record"
 }
 

--- a/scripts/lib/roster-journal.sh
+++ b/scripts/lib/roster-journal.sh
@@ -54,11 +54,12 @@ _agmsg_roster_rename_record() {
 }
 
 _agmsg_key_rotated_record() {
-  local epoch="$1" fingerprint="$2" at="$3"
+  local epoch="$1" key_id="$2" fingerprint="$3" at="$4"
   sqlite3 :memory: "SELECT json_object(
     'type','key_rotated',
     'id','$(compat_uuid7)',
     'epoch','$(_agmsg_roster_sqlesc "$epoch")',
+    'key_id','$(_agmsg_roster_sqlesc "$key_id")',
     'fingerprint','$(_agmsg_roster_sqlesc "$fingerprint")',
     'at','$(_agmsg_roster_sqlesc "$at")'
   );" | tr -d '\r'
@@ -91,8 +92,8 @@ agmsg_roster_append_renamed() {
 }
 
 agmsg_roster_append_key_rotated() {
-  local team_dir="$1" epoch="$2" fingerprint="$3" at="$4" record
-  record="$(_agmsg_key_rotated_record "$epoch" "$fingerprint" "$at")" || return 1
+  local team_dir="$1" epoch="$2" key_id="$3" fingerprint="$4" at="$5" record
+  record="$(_agmsg_key_rotated_record "$epoch" "$key_id" "$fingerprint" "$at")" || return 1
   _agmsg_roster_append_record "$team_dir" "$record"
 }
 

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -103,6 +103,58 @@ test("a synced rotation halts until an out-of-band identity matches its fingerpr
   }
 });
 
+test("rotation cutover accepts MAX_SEQUENCE minus one and rejects the final sequence", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agmsg-key-rotation-boundary-"));
+  const previous = process.env.AGMSG_SYNC_CONNECTION_DIR;
+  process.env.AGMSG_SYNC_CONNECTION_DIR = root;
+  const mutationId = "018f3f7e-0000-7000-8000-000000000028";
+  const keyId = "epoch-boundary";
+  const recipient = "age1ykvctct4aklx4f4mnjd8rmzqs7p2le9ufg4faydljsk5mvcy0pls27mu64";
+  const identity = "AGE-SECRET-KEY-14Z7XMNPZTPEMMM6DG2FSKEH042L7UMU79T645GAQJKU2LLJGPM2S7GWNLQ";
+  const fingerprint = createHash("sha256").update(recipient).digest("hex");
+  const rotationConfig = () => ({
+    ...config,
+    cipher_profile: "age-v1",
+    age_v1: {
+      epoch_snapshot: { history: [{
+        epoch_revision: "0", effective_from_seq: "1", cipher: "age-v1",
+        key_id: "epoch-0", recipients: [recipient],
+      }] },
+      identity_files: {},
+    },
+  });
+  try {
+    const teamDir = join(root, "teams", "demo");
+    const keyDir = join(root, "run", "remote-credentials", "demo", "keys");
+    await mkdir(teamDir, { recursive: true });
+    await mkdir(keyDir, { recursive: true });
+    await writeFile(join(keyDir, `${keyId}.key`), `${identity}\n`, { mode: 0o600 });
+    const writeRotation = async (serverSeq) => writeFile(join(teamDir, "roster.jsonl"), [
+      JSON.stringify({ type: "key_rotated", id: mutationId, epoch: "1",
+        key_id: keyId, fingerprint, at: "2026-07-29T01:00:00.000000Z" }),
+      JSON.stringify({ type: "roster_synced", mutation_id: mutationId, server_seq: serverSeq,
+        wire_id: "550e8400-e29b-41d4-a716-446655440009",
+        server_instance_id: config.server_instance_id,
+        remote_team_id: config.remote_team_id }),
+      "",
+    ].join("\n"));
+
+    await writeRotation("9223372036854775806");
+    const accepted = rotationConfig();
+    await activateKeyRotations(accepted);
+    assert.equal(accepted.age_v1_runtime_history[0].effective_from_seq,
+      "9223372036854775807");
+
+    await writeRotation("9223372036854775807");
+    await assert.rejects(activateKeyRotations(rotationConfig()),
+      /final server sequence/u);
+  } finally {
+    if (previous === undefined) delete process.env.AGMSG_SYNC_CONNECTION_DIR;
+    else process.env.AGMSG_SYNC_CONNECTION_DIR = previous;
+    await rm(root, { recursive: true });
+  }
+});
+
 test("concurrent rotations adopt the first server sequence and the loser must import it", async () => {
   const root = await mkdtemp(join(tmpdir(), "agmsg-key-rotation-race-"));
   const previous = process.env.AGMSG_SYNC_CONNECTION_DIR;

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { chmod, mkdir, mkdtemp, readdir, rename, rm, symlink, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
   ageSnapshotDigest,
+  activateKeyRotations,
   consistentReadStateContext,
   configure,
   cycle,
@@ -52,6 +54,52 @@ const candidates = [
 ];
 
 const credentialId = "018f3f7e-0000-7000-8000-000000000020";
+
+test("a synced rotation halts until an out-of-band identity matches its fingerprint", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agmsg-key-rotation-"));
+  const previous = process.env.AGMSG_SYNC_CONNECTION_DIR;
+  process.env.AGMSG_SYNC_CONNECTION_DIR = root;
+  const epoch = "epoch-20260729010000-abcd";
+  const mutationId = "018f3f7e-0000-7000-8000-000000000025";
+  const recipient = "age1ykvctct4aklx4f4mnjd8rmzqs7p2le9ufg4faydljsk5mvcy0pls27mu64";
+  const identity = "AGE-SECRET-KEY-14Z7XMNPZTPEMMM6DG2FSKEH042L7UMU79T645GAQJKU2LLJGPM2S7GWNLQ";
+  const fingerprint = createHash("sha256").update(recipient).digest("hex");
+  const rotationConfig = {
+    ...config,
+    cipher_profile: "age-v1",
+    age_v1: {
+      epoch_snapshot: { history: [{
+        epoch_revision: "0", effective_from_seq: "1", cipher: "age-v1",
+        key_id: "epoch-0", recipients: [recipient],
+      }] },
+      identity_files: {},
+    },
+  };
+  try {
+    await mkdir(join(root, "teams", "demo"), { recursive: true });
+    await writeFile(join(root, "teams", "demo", "roster.jsonl"), [
+      JSON.stringify({ type: "key_rotated", id: mutationId, epoch, fingerprint,
+        at: "2026-07-29T01:00:00.000000Z" }),
+      JSON.stringify({ type: "roster_synced", mutation_id: mutationId, server_seq: "8",
+        wire_id: "550e8400-e29b-41d4-a716-446655440006",
+        server_instance_id: config.server_instance_id,
+        remote_team_id: config.remote_team_id }),
+      "",
+    ].join("\n"));
+    await assert.rejects(activateKeyRotations(rotationConfig), /import that key out of band/u);
+    const keyDir = join(root, "run", "remote-credentials", "demo", "keys");
+    await mkdir(keyDir, { recursive: true });
+    await writeFile(join(keyDir, `${epoch}.key`), `${identity}\n`, { mode: 0o600 });
+    await activateKeyRotations(rotationConfig);
+    assert.equal(rotationConfig.age_v1_runtime_history[0].key_id, epoch);
+    assert.equal(rotationConfig.age_v1_runtime_history[0].effective_from_seq, "9");
+    assert.deepEqual(rotationConfig.age_v1_runtime_history[0].recipients, [recipient]);
+  } finally {
+    if (previous === undefined) delete process.env.AGMSG_SYNC_CONNECTION_DIR;
+    else process.env.AGMSG_SYNC_CONNECTION_DIR = previous;
+    await rm(root, { recursive: true });
+  }
+});
 
 async function withConnectedCredential(callback) {
   const root = await mkdtemp(join(tmpdir(), "agmsg-connected-credential-"));
@@ -1090,6 +1138,117 @@ test("cycle routes roster payloads through the existing message transport", asyn
   });
   assert.equal(posted, true);
   assert.deepEqual(rosterOperations, ["prepare", "reconcile", "apply"]);
+});
+
+test("cycle pushes a key rotation alone and activates its acknowledged boundary", async () => {
+  const rotationWire = "550e8400-e29b-41d4-a716-446655440003";
+  const messageWire = "550e8400-e29b-41d4-a716-446655440004";
+  const projection = {
+    kind: "key_rotated",
+    mutation_id: "018f3f7e-0000-7000-8000-000000000023",
+    epoch: "epoch-20260729010000-abcd",
+    fingerprint: "c".repeat(64),
+    occurred_at: "2026-07-29T01:00:00.000000Z",
+  };
+  let activated = 0;
+  await cycle(config, { pushLimit: 100, pullLimit: 1000 }, {
+    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    requestCall: async (_config, path, init) => {
+      if (path === "/v1/capabilities") return capsFor(["none"]);
+      if (path === "/v1/messages" && init?.method === "POST") {
+        assert.deepEqual(JSON.parse(init.body).messages.map((item) => item.id), [rotationWire]);
+        return { acks: [{ id: rotationWire, server_seq: "1", disposition: "stored" }] };
+      }
+      if (path.startsWith("/v1/messages?after=")) {
+        return { messages: [], next_after: "0", has_more: false };
+      }
+      throw new Error(`unexpected request ${path}`);
+    },
+    driverCall: async (operation) => {
+      if (operation === "prepare") return [{
+        type: "sync_state",
+        driver_generation: "018f3f7e-0000-7000-8000-000000000099",
+        transport_cursor: "0",
+      }, {
+        type: "sync_push_candidate", local_position: "1", local_id: "message",
+        id: messageWire, envelope: { v: 1, cipher: "none", key_id: null, blob: "e30=" },
+      }];
+      if (operation === "apply") return [{ type: "sync_apply_result", transport_cursor: "0" }];
+      throw new Error(`unexpected storage operation ${operation}`);
+    },
+    rosterDriverCall: async (operation) => {
+      if (operation === "prepare") return [{
+        type: "roster_sync_push_candidate",
+        local_position: projection.mutation_id,
+        local_id: projection.mutation_id,
+        id: rotationWire,
+        envelope: { v: 1, cipher: "none", key_id: null, blob: "e30=" },
+        projection,
+      }];
+      if (operation === "reconcile") return [{ type: "roster_sync_reconcile_result", count: 1 }];
+      throw new Error(`unexpected roster operation ${operation}`);
+    },
+    activateKeyRotationsCall: async () => { activated += 1; },
+    logApplyCall: async () => {},
+    eventCall: async () => {},
+    readStateCycleCall: async () => {},
+  });
+  assert.equal(activated, 1);
+});
+
+test("cycle records a pulled key rotation before halting for a missing replacement key", async () => {
+  const projection = {
+    kind: "key_rotated",
+    mutation_id: "018f3f7e-0000-7000-8000-000000000024",
+    epoch: "epoch-20260729010000-bcde",
+    fingerprint: "d".repeat(64),
+    occurred_at: "2026-07-29T01:00:00.000000Z",
+  };
+  let recorded = false;
+  let storageApplied = false;
+  await assert.rejects(cycle(config, { pushLimit: 100, pullLimit: 1000 }, {
+    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    requestCall: async (_config, path) => {
+      if (path === "/v1/capabilities") return {
+        ...capsFor(["none"]), current_seq: "1", next_sequence_boundary: "2",
+      };
+      if (path.startsWith("/v1/messages?after=")) return {
+        messages: [{
+          server_seq: "1", id: "550e8400-e29b-41d4-a716-446655440005",
+          server_received_at: "2026-07-29T01:00:01.000000Z",
+          envelope: { v: 1, cipher: "none", key_id: null, blob: "e30=" },
+        }],
+        next_after: "1", has_more: false,
+      };
+      throw new Error(`unexpected request ${path}`);
+    },
+    driverCall: async (operation) => {
+      if (operation === "prepare") return [{
+        type: "sync_state",
+        driver_generation: "018f3f7e-0000-7000-8000-000000000099",
+        transport_cursor: "0",
+      }];
+      if (operation === "apply") storageApplied = true;
+      return [];
+    },
+    rosterDriverCall: async (operation, _config, input) => {
+      if (operation === "prepare") return [{ type: "roster_sync_state", transport_cursor: "0" }];
+      if (operation === "apply") {
+        assert.equal(input[0].projection.kind, "key_rotated");
+        recorded = true;
+        return [];
+      }
+      return [];
+    },
+    evaluateCall: async () => ({ status: "importable", projection }),
+    activateKeyRotationsCall: async () => {
+      throw new Error("replacement epoch is missing; import that key out of band");
+    },
+    eventCall: async () => {},
+    readStateCycleCall: async () => {},
+  }), /import that key out of band/u);
+  assert.equal(recorded, true);
+  assert.equal(storageApplied, false);
 });
 
 // ---- pushSaturated is computed by cycle itself (B2 test gate) ----

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -59,7 +59,8 @@ test("a synced rotation halts until an out-of-band identity matches its fingerpr
   const root = await mkdtemp(join(tmpdir(), "agmsg-key-rotation-"));
   const previous = process.env.AGMSG_SYNC_CONNECTION_DIR;
   process.env.AGMSG_SYNC_CONNECTION_DIR = root;
-  const epoch = "epoch-20260729010000-abcd";
+  const epoch = "1";
+  const keyId = "epoch-20260729010000-abcd";
   const mutationId = "018f3f7e-0000-7000-8000-000000000025";
   const recipient = "age1ykvctct4aklx4f4mnjd8rmzqs7p2le9ufg4faydljsk5mvcy0pls27mu64";
   const identity = "AGE-SECRET-KEY-14Z7XMNPZTPEMMM6DG2FSKEH042L7UMU79T645GAQJKU2LLJGPM2S7GWNLQ";
@@ -78,7 +79,7 @@ test("a synced rotation halts until an out-of-band identity matches its fingerpr
   try {
     await mkdir(join(root, "teams", "demo"), { recursive: true });
     await writeFile(join(root, "teams", "demo", "roster.jsonl"), [
-      JSON.stringify({ type: "key_rotated", id: mutationId, epoch, fingerprint,
+      JSON.stringify({ type: "key_rotated", id: mutationId, epoch, key_id: keyId, fingerprint,
         at: "2026-07-29T01:00:00.000000Z" }),
       JSON.stringify({ type: "roster_synced", mutation_id: mutationId, server_seq: "8",
         wire_id: "550e8400-e29b-41d4-a716-446655440006",
@@ -89,11 +90,85 @@ test("a synced rotation halts until an out-of-band identity matches its fingerpr
     await assert.rejects(activateKeyRotations(rotationConfig), /import that key out of band/u);
     const keyDir = join(root, "run", "remote-credentials", "demo", "keys");
     await mkdir(keyDir, { recursive: true });
-    await writeFile(join(keyDir, `${epoch}.key`), `${identity}\n`, { mode: 0o600 });
+    await writeFile(join(keyDir, `${keyId}.key`), `${identity}\n`, { mode: 0o600 });
     await activateKeyRotations(rotationConfig);
-    assert.equal(rotationConfig.age_v1_runtime_history[0].key_id, epoch);
+    assert.equal(rotationConfig.age_v1_runtime_history[0].epoch_revision, epoch);
+    assert.equal(rotationConfig.age_v1_runtime_history[0].key_id, keyId);
     assert.equal(rotationConfig.age_v1_runtime_history[0].effective_from_seq, "9");
     assert.deepEqual(rotationConfig.age_v1_runtime_history[0].recipients, [recipient]);
+  } finally {
+    if (previous === undefined) delete process.env.AGMSG_SYNC_CONNECTION_DIR;
+    else process.env.AGMSG_SYNC_CONNECTION_DIR = previous;
+    await rm(root, { recursive: true });
+  }
+});
+
+test("concurrent rotations adopt the first server sequence and the loser must import it", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agmsg-key-rotation-race-"));
+  const previous = process.env.AGMSG_SYNC_CONNECTION_DIR;
+  process.env.AGMSG_SYNC_CONNECTION_DIR = root;
+  const winner = {
+    id: "018f3f7e-0000-7000-8000-000000000026",
+    keyId: "epoch-winner",
+    recipient: "age1mmqjrejftea4f6xh47lhpc0jn4vw0yuhz349sw2e3sfl22k5gcjsv6xcvp",
+    identity: "AGE-SECRET-KEY-1WWJJYKYVUUQNL8ZX7Y6NYRTEW79LHTF0H28EYC0CFYN5A7WECDHQMT4S0V",
+    serverSeq: "8",
+  };
+  const loser = {
+    id: "018f3f7e-0000-7000-8000-000000000027",
+    keyId: "epoch-loser",
+    recipient: "age1ykvctct4aklx4f4mnjd8rmzqs7p2le9ufg4faydljsk5mvcy0pls27mu64",
+    identity: "AGE-SECRET-KEY-14Z7XMNPZTPEMMM6DG2FSKEH042L7UMU79T645GAQJKU2LLJGPM2S7GWNLQ",
+    serverSeq: "9",
+  };
+  const rotationConfig = () => ({
+    ...config,
+    cipher_profile: "age-v1",
+    age_v1: {
+      epoch_snapshot: { history: [{
+        epoch_revision: "0", effective_from_seq: "1", cipher: "age-v1",
+        key_id: "epoch-0", recipients: [winner.recipient],
+      }] },
+      identity_files: {},
+    },
+  });
+  try {
+    const teamDir = join(root, "teams", "demo");
+    const keyDir = join(root, "run", "remote-credentials", "demo", "keys");
+    await mkdir(teamDir, { recursive: true });
+    await mkdir(keyDir, { recursive: true });
+    const rotationRecord = (value) => JSON.stringify({
+      type: "key_rotated", id: value.id, epoch: "1", key_id: value.keyId,
+      fingerprint: createHash("sha256").update(value.recipient).digest("hex"),
+      at: "2026-07-29T01:00:00.000000Z",
+    });
+    const syncedRecord = (value) => JSON.stringify({
+      type: "roster_synced", mutation_id: value.id, server_seq: value.serverSeq,
+      wire_id: value.serverSeq === "8" ?
+        "550e8400-e29b-41d4-a716-446655440007" :
+        "550e8400-e29b-41d4-a716-446655440008",
+      server_instance_id: config.server_instance_id,
+      remote_team_id: config.remote_team_id,
+    });
+    await writeFile(join(teamDir, "roster.jsonl"), [
+      rotationRecord(loser),
+      rotationRecord(winner),
+      syncedRecord(loser),
+      syncedRecord(winner),
+      "",
+    ].join("\n"));
+
+    await writeFile(join(keyDir, `${winner.keyId}.key`), `${winner.identity}\n`, { mode: 0o600 });
+    const winnerConfig = rotationConfig();
+    await activateKeyRotations(winnerConfig);
+    assert.equal(winnerConfig.age_v1_runtime_history.length, 1);
+    assert.equal(winnerConfig.age_v1_runtime_history[0].key_id, winner.keyId);
+    assert.equal(winnerConfig.age_v1_runtime_history[0].effective_from_seq, "9");
+
+    await unlink(join(keyDir, `${winner.keyId}.key`));
+    await writeFile(join(keyDir, `${loser.keyId}.key`), `${loser.identity}\n`, { mode: 0o600 });
+    await assert.rejects(activateKeyRotations(rotationConfig()),
+      /selected epoch 1 with key_id=epoch-winner/u);
   } finally {
     if (previous === undefined) delete process.env.AGMSG_SYNC_CONNECTION_DIR;
     else process.env.AGMSG_SYNC_CONNECTION_DIR = previous;
@@ -1140,13 +1215,14 @@ test("cycle routes roster payloads through the existing message transport", asyn
   assert.deepEqual(rosterOperations, ["prepare", "reconcile", "apply"]);
 });
 
-test("cycle pushes a key rotation alone and activates its acknowledged boundary", async () => {
+test("cycle pushes a key rotation alone and waits for ordered pull before activation", async () => {
   const rotationWire = "550e8400-e29b-41d4-a716-446655440003";
   const messageWire = "550e8400-e29b-41d4-a716-446655440004";
   const projection = {
     kind: "key_rotated",
     mutation_id: "018f3f7e-0000-7000-8000-000000000023",
-    epoch: "epoch-20260729010000-abcd",
+    epoch: "1",
+    key_id: "epoch-20260729010000-abcd",
     fingerprint: "c".repeat(64),
     occurred_at: "2026-07-29T01:00:00.000000Z",
   };
@@ -1193,14 +1269,15 @@ test("cycle pushes a key rotation alone and activates its acknowledged boundary"
     eventCall: async () => {},
     readStateCycleCall: async () => {},
   });
-  assert.equal(activated, 1);
+  assert.equal(activated, 0);
 });
 
 test("cycle records a pulled key rotation before halting for a missing replacement key", async () => {
   const projection = {
     kind: "key_rotated",
     mutation_id: "018f3f7e-0000-7000-8000-000000000024",
-    epoch: "epoch-20260729010000-bcde",
+    epoch: "1",
+    key_id: "epoch-20260729010000-bcde",
     fingerprint: "d".repeat(64),
     occurred_at: "2026-07-29T01:00:00.000000Z",
   };

--- a/tests/roster_sync.test.mjs
+++ b/tests/roster_sync.test.mjs
@@ -158,7 +158,8 @@ test("key rotation is transported as a fingerprint-only journal mutation", async
     await writeFile(join(scratch, "roster.jsonl"), `${JSON.stringify({
       type: "key_rotated",
       id: mutationId,
-      epoch: "epoch-20260729010000-abcd",
+      epoch: "1",
+      key_id: "epoch-20260729010000-abcd",
       fingerprint: "b".repeat(64),
       at: "2026-07-29T01:00:00Z",
     })}\n`);

--- a/tests/roster_sync.test.mjs
+++ b/tests/roster_sync.test.mjs
@@ -146,3 +146,32 @@ test("roster mutations use the message transport and converge by server sequence
     await rm(scratch, { recursive: true });
   }
 });
+
+test("key rotation is transported as a fingerprint-only journal mutation", async () => {
+  const scratch = await mkdtemp(join(tmpdir(), "agmsg-key-rotation-sync-"));
+  try {
+    const config = join(scratch, "config.json");
+    const mutationId = "018f3f7e-0000-7000-8000-000000000022";
+    await writeFile(config, `${JSON.stringify({
+      name: "demo", team_id: teamId, agents: {},
+    })}\n`);
+    await writeFile(join(scratch, "roster.jsonl"), `${JSON.stringify({
+      type: "key_rotated",
+      id: mutationId,
+      epoch: "epoch-20260729010000-abcd",
+      fingerprint: "b".repeat(64),
+      at: "2026-07-29T01:00:00Z",
+    })}\n`);
+    const candidate = call("prepare", config, [{
+      type: "sync_prepare", envelope_v: 1, cipher: "none", key_id: null,
+      recipients: [], max_blob_bytes: 1_048_576, allow_new: true,
+    }], ["10"]).find((record) => record.type === "roster_sync_push_candidate");
+    assert.equal(candidate.projection.kind, "key_rotated");
+    const opened = await openEnvelope({ envelope: candidate.envelope, max_blob_bytes: 1_048_576 });
+    assert.deepEqual(opened, candidate.projection);
+    assert.equal(JSON.stringify(opened).includes("age1"), false);
+    assert.equal(JSON.stringify(opened).includes("AGE-SECRET"), false);
+  } finally {
+    await rm(scratch, { recursive: true });
+  }
+});

--- a/tests/sync_cipher.test.mjs
+++ b/tests/sync_cipher.test.mjs
@@ -141,6 +141,24 @@ test("legacy messages remain discriminator-free while roster mutations use kind"
     envelope: rosterEnvelope,
     max_blob_bytes: 1_048_576,
   }), roster);
+
+  const rotation = {
+    kind: "key_rotated",
+    mutation_id: "018f3f7e-0000-7000-8000-000000000012",
+    epoch: "epoch-20260729010000-abcd",
+    fingerprint: "a".repeat(64),
+    occurred_at: "2026-07-29T01:00:00.000000Z",
+  };
+  const rotationEnvelope = sealEnvelope({
+    ...base,
+    wire_id: "550e8400-e29b-41d4-a716-446655440002",
+    projection: rotation,
+  });
+  assert.deepEqual(await openEnvelope({
+    envelope: rotationEnvelope,
+    max_blob_bytes: 1_048_576,
+  }), rotation);
+  assert.equal(Buffer.from(rotationEnvelope.blob, "base64").toString("utf8").includes("age1"), false);
 });
 
 test("age-v1 accepts only native X25519 identity files", () => {

--- a/tests/sync_cipher.test.mjs
+++ b/tests/sync_cipher.test.mjs
@@ -221,6 +221,19 @@ test("a late concurrent rotation may use the preceding key but ordinary data may
     assert.equal(accepted.status, "importable");
     assert.deepEqual(accepted.projection, rotation);
 
+    raceConfig.age_v1.identity_files["epoch-current"] = newIdentity;
+    raceConfig.age_v1_runtime_history.push({
+      epoch_revision: "2", effective_from_seq: "3", cipher: "age-v1",
+      key_id: "epoch-current", recipients: [manifest.recipient_sets.team_b.recipient],
+    });
+    const stale = await evaluatePull(raceConfig, capabilities(raceConfig, "age-v1"), {
+      server_seq: "3",
+      id: wireId,
+      server_received_at: "2026-07-29T01:00:02.000000Z",
+      envelope: rotationEnvelope,
+    });
+    assert.equal(stale.status, "policy_violation");
+
     const messageId = "550e8400-e29b-41d4-a716-446655440004";
     const oldKeyMessage = sealEnvelope({
       type: "sync_seal",

--- a/tests/sync_cipher.test.mjs
+++ b/tests/sync_cipher.test.mjs
@@ -145,7 +145,8 @@ test("legacy messages remain discriminator-free while roster mutations use kind"
   const rotation = {
     kind: "key_rotated",
     mutation_id: "018f3f7e-0000-7000-8000-000000000012",
-    epoch: "epoch-20260729010000-abcd",
+    epoch: "1",
+    key_id: "epoch-20260729010000-abcd",
     fingerprint: "a".repeat(64),
     occurred_at: "2026-07-29T01:00:00.000000Z",
   };
@@ -159,6 +160,90 @@ test("legacy messages remain discriminator-free while roster mutations use kind"
     max_blob_bytes: 1_048_576,
   }), rotation);
   assert.equal(Buffer.from(rotationEnvelope.blob, "base64").toString("utf8").includes("age1"), false);
+});
+
+test("a late concurrent rotation may use the preceding key but ordinary data may not", async () => {
+  const scratch = await mkdtemp(join(tmpdir(), "agmsg-age-rotation-race-"));
+  const oldIdentity = join(scratch, "old.identity");
+  const newIdentity = join(scratch, "new.identity");
+  await writeFile(oldIdentity, `${manifest.recipient_sets.team_a.identity}\n`, { mode: 0o600 });
+  await writeFile(newIdentity, `${manifest.recipient_sets.team_b.identity}\n`, { mode: 0o600 });
+  const oldKeyId = "epoch-old";
+  const newKeyId = "epoch-winner";
+  const rotation = {
+    kind: "key_rotated",
+    mutation_id: "018f3f7e-0000-7000-8000-000000000013",
+    epoch: "1",
+    key_id: "epoch-loser",
+    fingerprint: "b".repeat(64),
+    occurred_at: "2026-07-29T01:00:00.000000Z",
+  };
+  const wireId = "550e8400-e29b-41d4-a716-446655440003";
+  const rotationEnvelope = sealEnvelope({
+    type: "sync_seal",
+    envelope_v: 1,
+    max_blob_bytes: 1_048_576,
+    wire_id: wireId,
+    team_id: manifest.binding.team_id,
+    protocol_version: 1,
+    cipher: "age-v1",
+    key_id: oldKeyId,
+    recipients: [manifest.recipient_sets.team_a.recipient],
+    projection: rotation,
+  });
+  const raceConfig = {
+    local_team: "demo",
+    server_instance_id: "018f3f7e-0000-7000-8000-000000000000",
+    remote_team_id: manifest.binding.team_id,
+    protocol_version: 1,
+    cipher_profile: "age-v1",
+    local_security_history: [{ local_security_revision: "0", effective_from_seq: "1",
+      minimum_security_mode: "e2ee-required" }],
+    age_v1: {
+      epoch_snapshot: { history: [{
+        epoch_revision: "0", effective_from_seq: "1", cipher: "age-v1",
+        key_id: oldKeyId, recipients: [manifest.recipient_sets.team_a.recipient],
+      }] },
+      identity_files: { [oldKeyId]: oldIdentity, [newKeyId]: newIdentity },
+    },
+    age_v1_runtime_history: [{
+      epoch_revision: "1", effective_from_seq: "2", cipher: "age-v1",
+      key_id: newKeyId, recipients: [manifest.recipient_sets.team_b.recipient],
+    }],
+  };
+  try {
+    const accepted = await evaluatePull(raceConfig, capabilities(raceConfig, "age-v1"), {
+      server_seq: "2",
+      id: wireId,
+      server_received_at: "2026-07-29T01:00:01.000000Z",
+      envelope: rotationEnvelope,
+    });
+    assert.equal(accepted.status, "importable");
+    assert.deepEqual(accepted.projection, rotation);
+
+    const messageId = "550e8400-e29b-41d4-a716-446655440004";
+    const oldKeyMessage = sealEnvelope({
+      type: "sync_seal",
+      envelope_v: 1,
+      max_blob_bytes: 1_048_576,
+      wire_id: messageId,
+      team_id: manifest.binding.team_id,
+      protocol_version: 1,
+      cipher: "age-v1",
+      key_id: oldKeyId,
+      recipients: [manifest.recipient_sets.team_a.recipient],
+      projection: manifest.canonical_message,
+    });
+    const rejected = await evaluatePull(raceConfig, capabilities(raceConfig, "age-v1"), {
+      server_seq: "2",
+      id: messageId,
+      server_received_at: "2026-07-29T01:00:01.000000Z",
+      envelope: oldKeyMessage,
+    });
+    assert.equal(rejected.status, "policy_violation");
+  } finally {
+    await rm(scratch, { recursive: true });
+  }
 });
 
 test("age-v1 accepts only native X25519 identity files", () => {

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -197,23 +197,62 @@ skip_if_no_age() {
   [ "$epochs" -eq 1 ]
 }
 
-# --- rotate (NOT READY) --------------------------------------------------
+# --- rotate ---------------------------------------------------------------
 
-@test "key rotate: refuses unconditionally and changes no state (NOT READY)" {
+@test "key rotate: creates a replacement identity and journals only its fingerprint" {
   skip_if_no_age
   bash "$SCRIPTS/key.sh" generate testteam
-  before=$(cat "$SCRIPTS/../teams/testteam/config.json")
   run bash "$SCRIPTS/key.sh" rotate testteam
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not available in this release"* ]]
-  after=$(cat "$SCRIPTS/../teams/testteam/config.json")
-  [ "$before" = "$after" ]
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Generated replacement key"* ]]
+  journal="$SCRIPTS/../teams/testteam/roster.jsonl"
+  epoch=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['epoch'])")
+  fingerprint=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['fingerprint'])")
+  [[ "$epoch" == epoch-* ]]
+  [[ "$fingerprint" =~ ^[0-9a-f]{64}$ ]]
+  [ -f "$SCRIPTS/../run/remote-credentials/testteam/keys/$epoch.key" ]
+  ! grep -q 'AGE-SECRET-KEY\\|age1' "$journal"
+  run bash "$SCRIPTS/key.sh" show testteam --epoch "$epoch"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Public recipient: age1"* ]]
 }
 
-@test "key rotate: refuses even for a team with no key at all" {
+@test "key rotate: an old identity cannot decrypt data for the replacement epoch" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  old_epoch=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['current']['key_id'])")
+  old_identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$old_epoch.key"
+  bash "$SCRIPTS/key.sh" rotate testteam
+  journal="$SCRIPTS/../teams/testteam/roster.jsonl"
+  new_epoch=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['epoch'])")
+  new_identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$new_epoch.key"
+  new_recipient=$(age-keygen -y "$new_identity")
+  ciphertext="$TEST_SKILL_DIR/replacement.age"
+  printf 'future message' | age -r "$new_recipient" -o "$ciphertext"
+  run age -d -i "$old_identity" "$ciphertext"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"future message"* ]]
+}
+
+@test "key import: installs an out-of-band replacement only after its fingerprint is announced" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  bash "$SCRIPTS/key.sh" rotate testteam
+  journal="$SCRIPTS/../teams/testteam/roster.jsonl"
+  epoch=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['epoch'])")
+  identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$epoch.key"
+  secret=$(grep '^AGE-SECRET-KEY-' "$identity")
+  rm -f "$identity"
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --identity-stdin"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Imported replacement key"* ]]
+  [ -f "$identity" ]
+}
+
+@test "key rotate: refuses a team with no current key" {
   run bash "$SCRIPTS/key.sh" rotate testteam
   [ "$status" -ne 0 ]
-  [[ "$output" == *"not available in this release"* ]]
+  [[ "$output" == *"no current key"* ]]
 }
 
 # --- dispatch --------------------------------------------------------------

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -207,12 +207,14 @@ skip_if_no_age() {
   [[ "$output" == *"Generated replacement key"* ]]
   journal="$SCRIPTS/../teams/testteam/roster.jsonl"
   epoch=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['epoch'])")
+  key_id=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['key_id'])")
   fingerprint=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['fingerprint'])")
-  [[ "$epoch" == epoch-* ]]
+  [ "$epoch" = "1" ]
+  [[ "$key_id" == epoch-* ]]
   [[ "$fingerprint" =~ ^[0-9a-f]{64}$ ]]
-  [ -f "$SCRIPTS/../run/remote-credentials/testteam/keys/$epoch.key" ]
+  [ -f "$SCRIPTS/../run/remote-credentials/testteam/keys/$key_id.key" ]
   ! grep -q 'AGE-SECRET-KEY\\|age1' "$journal"
-  run bash "$SCRIPTS/key.sh" show testteam --epoch "$epoch"
+  run bash "$SCRIPTS/key.sh" show testteam --key-id "$key_id"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Public recipient: age1"* ]]
 }
@@ -224,8 +226,8 @@ skip_if_no_age() {
   old_identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$old_epoch.key"
   bash "$SCRIPTS/key.sh" rotate testteam
   journal="$SCRIPTS/../teams/testteam/roster.jsonl"
-  new_epoch=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['epoch'])")
-  new_identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$new_epoch.key"
+  new_key_id=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['key_id'])")
+  new_identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$new_key_id.key"
   new_recipient=$(age-keygen -y "$new_identity")
   ciphertext="$TEST_SKILL_DIR/replacement.age"
   printf 'future message' | age -r "$new_recipient" -o "$ciphertext"
@@ -239,14 +241,31 @@ skip_if_no_age() {
   bash "$SCRIPTS/key.sh" generate testteam
   bash "$SCRIPTS/key.sh" rotate testteam
   journal="$SCRIPTS/../teams/testteam/roster.jsonl"
-  epoch=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['epoch'])")
-  identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$epoch.key"
+  key_id=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['key_id'])")
+  identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$key_id.key"
   secret=$(grep '^AGE-SECRET-KEY-' "$identity")
   rm -f "$identity"
   run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --identity-stdin"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Imported replacement key"* ]]
   [ -f "$identity" ]
+}
+
+@test "key rotate: advances the shared epoch only after the previous winner is synchronized" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  config="$SCRIPTS/../teams/testteam/config.json"
+  journal="$SCRIPTS/../teams/testteam/roster.jsonl"
+  server_id="018f3f7e-0000-7000-8000-000000000000"
+  team_id="018f3f7e-0000-7000-8000-000000000001"
+  python3 -c "import json; p='$config'; d=json.load(open(p)); d['remote_binding']={'server_instance_id':'$server_id','remote_team_id':'$team_id'}; open(p,'w').write(json.dumps(d)+'\n')"
+  bash "$SCRIPTS/key.sh" rotate testteam
+  mutation_id=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['id'])")
+  printf '%s\n' "{\"type\":\"roster_synced\",\"mutation_id\":\"$mutation_id\",\"server_seq\":\"8\",\"wire_id\":\"550e8400-e29b-41d4-a716-446655440006\",\"server_instance_id\":\"$server_id\",\"remote_team_id\":\"$team_id\"}" >> "$journal"
+  run bash "$SCRIPTS/key.sh" rotate testteam
+  [ "$status" -eq 0 ]
+  latest_epoch=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['epoch'])")
+  [ "$latest_epoch" = "2" ]
 }
 
 @test "key rotate: refuses a team with no current key" {


### PR DESCRIPTION
## Summary

Finish `key.sh rotate` and carry fingerprint-only `key_rotated` facts through the existing roster journal and message transport. The private identity is created and stored locally with mode 0600, is distributed only out of band, and never appears in the journal or wire projection.

Activate a replacement only after its event returns through the contiguous pull stream. The announcement itself is sealed with the immediately preceding epoch; the replacement becomes effective at `server_seq + 1`. Concurrent writers announce the same numeric epoch, and the first server sequence wins. Later conflicting announcements are ignored, so the losing machine stops until it imports the winning key instead of silently diverging.

A machine missing the selected replacement identity halts before advancing its storage cursor and reports the exact epoch and key ID that must be imported. Ordinary messages cannot use an old epoch after the boundary; only a late conflicting `key_rotated` announcement may use the preceding epoch.

Rotation protects future messages only. Anyone who retained an old key can continue reading history encrypted with that key. The epoch snapshot hash chain and rollback resistance remain a separate follow-up.

## Verification

- `bats tests/test_key.bats tests/test_roster_journal.bats` (30 passed)
- `node --test tests/roster_sync.test.mjs tests/sync_cipher.test.mjs tests/remote_sync_engine.test.mjs` (56 passed)
- `git diff --check origin/integration/remote...HEAD`
