### PR TITLE
Fix bootstrap pull for roster journal events

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1896,6 +1896,9 @@ export async function pullBootstrap(args, dependencies = {}) {
       record.status === "importable" &&
       ["member_joined", "member_left", "member_renamed"].includes(record.projection?.kind));
     const messageRecords = records.filter((record) => !record.projection?.kind);
+    if (rosterRecords.length + messageRecords.length !== records.length) {
+      throw new Error("pull bootstrap cannot apply this projection kind");
+    }
     const rosterApplied = rosterRecords.length > 0 ?
       await rosterDriverCall("apply", config, [...rosterRecords, cursorRecord]) : [];
     const applied = await driverCall("apply", config, [...messageRecords, cursorRecord]);

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1843,9 +1843,15 @@ export async function resyncCycle(config, acceptedFloor, dependencies = {}) {
 // A machine that has none of this taking a team from the server. It is not a
 // cycle: there is no local team to reconcile against, no push side, and no
 // credential. What it shares with the normal pull is the part that must not
-// diverge -- evaluatePull decides what may be imported, and the driver applies
-// the same records.
-export async function pullBootstrap(args) {
+// diverge -- evaluatePull decides what may be imported, then roster mutations
+// and chat records go through the same two drivers as a connected cycle.
+export async function pullBootstrap(args, dependencies = {}) {
+  const publicSnapshotCall = dependencies.publicSnapshotCall ?? publicSnapshot;
+  const requestPublicCall = dependencies.requestPublicCall ?? requestPublic;
+  const evaluateCall = dependencies.evaluateCall ?? evaluatePull;
+  const driverCall = dependencies.driverCall ?? driver;
+  const rosterDriverCall = dependencies.rosterDriverCall ?? rosterDriver;
+  const eventCall = dependencies.eventCall ?? event;
   const team = requireName(args.team, "team");
   const teamId = args["team-id"] ?? "";
   if (!UUID_V7.test(teamId)) throw new Error("team-id must be a canonical UUIDv7");
@@ -1854,9 +1860,9 @@ export async function pullBootstrap(args) {
   const limit = Number(args.limit ?? 1000);
   if (!Number.isInteger(limit) || limit < 1 || limit > 1000) throw new Error("limit must be 1..1000");
 
-  // Fetched before a config exists, so this one call validates itself rather
-  // than going through the binding checks the rest of the pull relies on.
-  const snapshot = await publicSnapshot(serverUrl, teamId);
+  // There is no connected binding yet, so this one call validates itself
+  // rather than going through the checks the rest of the pull relies on.
+  const snapshot = await publicSnapshotCall(serverUrl, teamId);
   const config = {
     format_version: 1,
     local_team: team,
@@ -1870,7 +1876,7 @@ export async function pullBootstrap(args) {
       minimum_security_mode: "plaintext-allowed",
     }],
   };
-  await event("pull.bootstrap.snapshot", {
+  await eventCall("pull.bootstrap.snapshot", {
     team_id: snapshot.team_id, team_name: snapshot.team_name,
     min_available_seq: snapshot.min_available_seq,
   });
@@ -1878,18 +1884,25 @@ export async function pullBootstrap(args) {
   let cursor = String(snapshot.min_available_seq ?? "0");
   let imported = 0;
   for (;;) {
-    const page = await requestPublic(config,
+    const page = await requestPublicCall(config,
       `/v1/teams/${teamId}/messages?after=${cursor}&limit=${limit}`);
     const records = [];
     for (const message of page.messages) {
       records.push({ type: "sync_pull_message", ...message,
-        ...(await evaluatePull(config, snapshot, message)) });
+        ...(await evaluateCall(config, snapshot, message)) });
     }
-    records.push({ type: "sync_pull_cursor", next_after: page.next_after });
-    const applied = await driver("apply", config, records);
-    await event("pull.bootstrap.applied", {
+    const cursorRecord = { type: "sync_pull_cursor", next_after: page.next_after };
+    const rosterRecords = records.filter((record) =>
+      record.status === "importable" &&
+      ["member_joined", "member_left", "member_renamed"].includes(record.projection?.kind));
+    const messageRecords = records.filter((record) => !record.projection?.kind);
+    const rosterApplied = rosterRecords.length > 0 ?
+      await rosterDriverCall("apply", config, [...rosterRecords, cursorRecord]) : [];
+    const applied = await driverCall("apply", config, [...messageRecords, cursorRecord]);
+    await eventCall("pull.bootstrap.applied", {
       after: cursor, next_after: page.next_after,
       messages: page.messages.length, result: applied[0] ?? null,
+      roster_result: rosterApplied[0] ?? null,
     });
     imported += page.messages.length;
     cursor = page.next_after;

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Usage:
 #   remote.sh connect --endpoint <url> [<token>] [--token-stdin] [<team>] [--force]
+#   remote.sh pull --endpoint <url> --team-id <uuid> <team>
 #   remote.sh status [<team>] [--json]
 #   remote.sh disconnect <team>
 #   remote.sh doctor [<team>]
@@ -780,16 +781,25 @@ _remote_json_field() {
 # roster taken from anywhere else at this moment would be a guess presented as
 # fact. It is derived by replaying the team journal.
 _remote_write_pulled_team() {
-  local team="$1" team_id="$2" cfg initial
+  local team="$1" team_id="$2" cfg initial existing_id
   cfg="$(_remote_team_config "$team")"
   mkdir -p "$TEAMS_DIR/$team"
   agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
-  initial=$(agmsg_sqlite_mem "
-    SELECT json_object('name','$(_agmsg_sqlesc "$team")',
-                       'team_id','$(_agmsg_sqlesc "$team_id")',
-                       'agents', json_object(),
-                       'created_at','$(date -u +%Y-%m-%dT%H:%M:%SZ)');")
-  agmsg_write_atomic "$cfg" "$initial"
+  if [ -f "$cfg" ]; then
+    existing_id="$(_remote_read_config_field "$cfg" '$.team_id')"
+    if [ "$existing_id" != "$team_id" ]; then
+      echo "agmsg: local team '$team' has a different team id" >&2
+      agmsg_lock_release
+      return 1
+    fi
+  else
+    initial=$(agmsg_sqlite_mem "
+      SELECT json_object('name','$(_agmsg_sqlesc "$team")',
+                         'team_id','$(_agmsg_sqlesc "$team_id")',
+                         'agents', json_object(),
+                         'created_at','$(date -u +%Y-%m-%dT%H:%M:%SZ)');")
+    agmsg_write_atomic "$cfg" "$initial"
+  fi
   agmsg_lock_release
 }
 
@@ -828,8 +838,14 @@ cmd_pull() {
     fi
   fi
 
+  # The roster driver projects imported identity events into this config while
+  # the bootstrap is running. Publish the empty identity-bearing shell first;
+  # retries reuse it, and the successful projection is never overwritten.
+  _remote_write_pulled_team "$team" "$team_id" || exit 1
+
   local result pulled_id pulled_name imported
   result="$(AGMSG_SYNC_CONNECTION_DIR="$CONNECTION_ROOT" \
+    AGMSG_SYNC_LOCAL_ROSTER_FILE="$cfg" \
     "$SCRIPT_DIR/remote-sync.sh" pull-bootstrap \
       --team "$team" --team-id "$team_id" --endpoint "$endpoint")" || {
     echo "agmsg: pull failed" >&2; exit 1; }
@@ -842,7 +858,6 @@ cmd_pull() {
   [ "$pulled_id" = "$team_id" ] || {
     echo "agmsg: server answered with a different team id" >&2; exit 1; }
 
-  _remote_write_pulled_team "$team" "$pulled_id" || exit 1
   echo "Pulled '$pulled_name' into local team '$team' ($imported message(s))."
 }
 
@@ -1483,6 +1498,6 @@ case "${1:-}" in
   doctor) shift; cmd_doctor "$@" ;;
   pending) shift; agmsg_require_python3 "remote pending" || exit 1; cmd_pending "$@" ;;
   *)
-    echo "Usage: remote.sh <connect|status|disconnect|doctor|pending> ..." >&2
+    echo "Usage: remote.sh <connect|pull|status|disconnect|doctor|pending> ..." >&2
     exit 1 ;;
 esac

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -33,6 +33,7 @@ REVOKE_FAIL = os.environ.get("MOCK_REVOKE_FAIL") == "1"
 REVOKE_BAD_HEADER = os.environ.get("MOCK_REVOKE_BAD_HEADER") == "1"
 REVOKE_BAD_BODY = os.environ.get("MOCK_REVOKE_BAD_BODY") == "1"
 REVOKE_LARGE_BODY = os.environ.get("MOCK_REVOKE_LARGE_BODY") == "1"
+PULL_MIXED = os.environ.get("MOCK_PULL_MIXED") == "1"
 ISSUED_CREDENTIAL_IDS = set()
 REVOKED_CREDENTIAL_IDS = []
 
@@ -54,8 +55,18 @@ def _blob(from_agent, to_agent, body, at):
                          separators=(",", ":"), sort_keys=True)
     return base64.b64encode(payload.encode()).decode()
 
+def _roster_blob(index):
+    import base64
+    payload = json.dumps({
+        "kind": "member_joined",
+        "mutation_id": "018f3f7e-3333-7000-8000-%012d" % (index + 1),
+        "member_id": "018f3f7e-4444-7000-8000-%012d" % (index + 1),
+        "name": "member-%d" % (index + 1),
+        "occurred_at": "2026-01-01T00:00:%02d.000000Z" % index,
+    }, separators=(",", ":"))
+    return base64.b64encode(payload.encode()).decode()
 
-PULL_MESSAGES = [
+BASE_PULL_MESSAGES = [
     {"id": "11111111-1111-4111-8111-111111111111", "server_seq": "1",
      "server_received_at": "2026-01-01T00:00:00.000000Z",
      "envelope": {"v": 1, "cipher": "none", "key_id": None,
@@ -65,6 +76,27 @@ PULL_MESSAGES = [
      "envelope": {"v": 1, "cipher": "none", "key_id": None,
                   "blob": _blob("bob", "alice", "history two", "2026-01-02T00:00:00.000000Z")}},
 ]
+
+if PULL_MIXED:
+    PULL_MESSAGES = [
+        {"id": "10000000-0000-4000-8000-%012d" % (index + 1),
+         "server_seq": str(index + 1),
+         "server_received_at": "2026-01-01T00:00:%02d.000000Z" % index,
+         "envelope": {"v": 1, "cipher": "none", "key_id": None,
+                      "blob": _roster_blob(index)}}
+        for index in range(7)
+    ] + [
+        {"id": "20000000-0000-4000-8000-%012d" % (index + 1),
+         "server_seq": str(index + 8),
+         "server_received_at": "2026-01-02T00:00:00.000000Z",
+         "envelope": {"v": 1, "cipher": "none", "key_id": None,
+                      "blob": _blob("member-1", "member-2",
+                                    "mixed history %d" % (index + 1),
+                                    "2026-01-02T00:00:00.000000Z")}}
+        for index in range(73)
+    ]
+else:
+    PULL_MESSAGES = BASE_PULL_MESSAGES
 
 
 class LoopbackHTTPServer(HTTPServer):

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1334,6 +1334,44 @@ test("pull bootstrap dispatches a real mixed roster and message page", async () 
   assert.deepEqual(storageInputs[0].at(-1), { type: "sync_pull_cursor", next_after: "80" });
 });
 
+test("pull bootstrap rejects unsupported projection kinds before either cursor advances", async () => {
+  const teamId = "018f3f7e-0000-7000-8000-000000000001";
+  const serverId = "018f3f7e-0000-7000-8000-000000000002";
+  let storageApplied = false;
+  let rosterApplied = false;
+  await assert.rejects(pullBootstrap({
+    team: "clone", "team-id": teamId, endpoint: "http://127.0.0.1:8787",
+  }, {
+    publicSnapshotCall: async () => ({
+      server_instance_id: serverId, team_id: teamId, team_name: "source",
+      min_available_seq: "0",
+    }),
+    requestPublicCall: async () => ({
+      messages: [{
+        server_seq: "1", id: "10000000-0000-4000-8000-000000000001",
+        server_received_at: "2026-07-29T05:00:00.000000Z",
+        envelope: { v: 1, cipher: "none", key_id: null, blob: "e30=" },
+      }],
+      next_after: "1", has_more: false,
+    }),
+    evaluateCall: async () => ({
+      status: "importable",
+      projection: {
+        kind: "key_rotated",
+        mutation_id: "018f3f7e-0000-7000-8000-000000000010",
+        epoch: "1", key_id: "epoch-1", fingerprint: "a".repeat(64),
+        occurred_at: "2026-07-29T05:00:00.000000Z",
+      },
+      policy_revision: "0", local_security_revision: "0",
+    }),
+    driverCall: async () => { storageApplied = true; },
+    rosterDriverCall: async () => { rosterApplied = true; },
+    eventCall: async () => {},
+  }), /cannot apply this projection kind/u);
+  assert.equal(storageApplied, false);
+  assert.equal(rosterApplied, false);
+});
+
 test("cycle pushes a key rotation alone and waits for ordered pull before activation", async () => {
   const rotationWire = "550e8400-e29b-41d4-a716-446655440003";
   const messageWire = "550e8400-e29b-41d4-a716-446655440004";

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -15,6 +15,7 @@ import {
   runLoop,
   loadConfig,
   plaintextWriteEligible,
+  pullBootstrap,
   parseStrictJsonl,
   readStateCycle,
   readConnectedCredential,
@@ -1265,6 +1266,72 @@ test("cycle routes roster payloads through the existing message transport", asyn
   });
   assert.equal(posted, true);
   assert.deepEqual(rosterOperations, ["prepare", "reconcile", "apply"]);
+});
+
+test("pull bootstrap dispatches a real mixed roster and message page", async () => {
+  const teamId = "018f3f7e-0000-7000-8000-000000000001";
+  const serverId = "018f3f7e-0000-7000-8000-000000000002";
+  const roster = Array.from({ length: 7 }, (_, index) => ({
+    server_seq: String(index + 1),
+    id: `10000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`,
+    server_received_at: "2026-07-29T05:00:00.000000Z",
+    envelope: { v: 1, cipher: "none", key_id: null, blob: "e30=" },
+    projection: {
+      kind: "member_joined",
+      mutation_id: `018f3f7e-0000-7000-8000-${String(index + 10).padStart(12, "0")}`,
+      member_id: `018f3f7e-0000-7000-8000-${String(index + 20).padStart(12, "0")}`,
+      name: `member-${index + 1}`,
+      occurred_at: "2026-07-29T05:00:00.000000Z",
+    },
+  }));
+  const messages = Array.from({ length: 73 }, (_, index) => ({
+    server_seq: String(index + 8),
+    id: `20000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`,
+    server_received_at: "2026-07-29T05:00:00.000000Z",
+    envelope: { v: 1, cipher: "none", key_id: null, blob: "e30=" },
+    projection: {
+      body: `message-${index + 1}`,
+      created_at: "2026-07-29T05:00:00.000000Z",
+      from_agent: "member-1",
+      to_agent: "member-2",
+    },
+  }));
+  const storageInputs = [];
+  const rosterInputs = [];
+  await pullBootstrap({
+    team: "clone", "team-id": teamId, endpoint: "http://127.0.0.1:8787",
+  }, {
+    publicSnapshotCall: async () => ({
+      server_instance_id: serverId, team_id: teamId, team_name: "source",
+      min_available_seq: "0",
+    }),
+    requestPublicCall: async () => ({
+      messages: [...roster, ...messages].map(({ projection: _projection, ...message }) => message),
+      next_after: "80", has_more: false,
+    }),
+    evaluateCall: async (_config, _snapshot, message) => ({
+      status: "importable",
+      projection: [...roster, ...messages].find((entry) => entry.id === message.id).projection,
+      policy_revision: "0", local_security_revision: "0",
+    }),
+    driverCall: async (operation, _config, input) => {
+      assert.equal(operation, "apply");
+      storageInputs.push(input);
+      return [{ type: "sync_apply_result", transport_cursor: "80", corrupt_count: 0 }];
+    },
+    rosterDriverCall: async (operation, _config, input) => {
+      assert.equal(operation, "apply");
+      rosterInputs.push(input);
+      return [{ type: "roster_sync_apply_outcome", status: "imported" }];
+    },
+    eventCall: async () => {},
+  });
+  assert.equal(rosterInputs.length, 1);
+  assert.equal(rosterInputs[0].filter((record) => record.type === "sync_pull_message").length, 7);
+  assert.deepEqual(rosterInputs[0].at(-1), { type: "sync_pull_cursor", next_after: "80" });
+  assert.equal(storageInputs.length, 1);
+  assert.equal(storageInputs[0].filter((record) => record.type === "sync_pull_message").length, 73);
+  assert.deepEqual(storageInputs[0].at(-1), { type: "sync_pull_cursor", next_after: "80" });
 });
 
 test("cycle pushes a key rotation alone and waits for ordered pull before activation", async () => {

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -15,6 +15,7 @@ setup() {
   MOCK_REVOKE_BAD_HEADER="${MOCK_REVOKE_BAD_HEADER:-}" \
   MOCK_REVOKE_BAD_BODY="${MOCK_REVOKE_BAD_BODY:-}" \
   MOCK_REVOKE_LARGE_BODY="${MOCK_REVOKE_LARGE_BODY:-}" \
+  MOCK_PULL_MIXED="${MOCK_PULL_MIXED:-}" \
     "$MOCK_PYTHON3" "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
     </dev/null > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" 3>&- &
   MOCK_SERVER_PID=$!
@@ -36,6 +37,7 @@ restart_mock_server() {
   MOCK_REVOKE_BAD_HEADER="${MOCK_REVOKE_BAD_HEADER:-}" \
   MOCK_REVOKE_BAD_BODY="${MOCK_REVOKE_BAD_BODY:-}" \
   MOCK_REVOKE_LARGE_BODY="${MOCK_REVOKE_LARGE_BODY:-}" \
+  MOCK_PULL_MIXED="${MOCK_PULL_MIXED:-}" \
     "$MOCK_PYTHON3" "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
       </dev/null > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" 3>&- &
   MOCK_SERVER_PID=$!
@@ -973,6 +975,7 @@ VALUES ('remote-pending.$key', $owner_pid, strftime('%Y-%m-%dT%H:%M:%SZ','now'))
   run bash "$SCRIPTS/remote.sh" bogus
   [ "$status" -ne 0 ]
   [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"pull"* ]]
 }
 
 # --- python3 preflight (dependency tiering: remote = +python3) -------------
@@ -1100,6 +1103,26 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   [ "$status" -eq 0 ]
   [[ "$output" == *"history one"* ]]
   [[ "$output" == *"history two"* ]]
+}
+
+@test "remote pull: applies seven roster events alongside seventy-three messages" {
+  MOCK_PULL_MIXED=1
+  restart_mock_server
+
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" mixed
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"80 message(s)"* ]]
+
+  local cfg journal
+  cfg="$TEST_SKILL_DIR/teams/mixed/config.json"
+  journal="$TEST_SKILL_DIR/teams/mixed/roster.jsonl"
+  [ "$(sqlite_mem "SELECT COUNT(*) FROM json_each(
+      json_extract(readfile('$(rf "$cfg")'), '\$.agents'));")" -eq 7 ]
+  [ "$(jq -s '[.[] | select(.type=="member_joined")] | length' "$journal")" -eq 7 ]
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  [ "$(storage_history mixed | jq -s 'length')" -eq 73 ]
 }
 
 @test "remote doctor: age is optional — its absence does not fail the run" {


### PR DESCRIPTION
## Summary

Bootstrap pull now mirrors the connected sync cycle: member roster projections go to the roster journal driver while ordinary chat projections go to the storage driver. The local team config is published before replay and preserved afterward so the journal can project the imported roster instead of being overwritten with an empty object.

The fallback usage banner also lists the existing `pull` command.

## Why

The bootstrap path previously sent every importable projection to the SQLite storage apply operation. That operation correctly requires chat fields, so the first `member_joined` record returned status 13 and the Node writer subsequently surfaced EPIPE. Routing at the engine boundary keeps roster state out of the chat storage ABI and uses the same journal/projection mechanism as ordinary connected pulls.

## Validation

- `node --test tests/remote_sync_engine.test.mjs`
- `bats --filter 'remote pull: applies seven roster events|remote.sh: unknown subcommand' tests/test_remote.bats`
- Full `tests/test_remote.bats` reached the new mixed-data test; its unrelated optional-age doctor case remains a pre-existing environment failure.

The regression fixture reproduces the observed page shape exactly: seven `member_joined` records plus seventy-three chat records. It asserts seven projected members, seven durable journal mutations, and seventy-three stored chat messages.