### PR TITLE
fix(team): list members that have no local registration

### DIFF
--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -34,7 +34,12 @@ COUNT=0
 # caveat).
 CONFIG_ESCAPED=$(sed "s/'/''/g" "$CONFIG")
 while IFS='	' read -r name types project registrations; do
-  if [ "${registrations:-0}" -gt 1 ]; then
+  if [ "${registrations:-0}" -eq 0 ]; then
+    # A member this machine has never registered locally: pulled with the team,
+    # real, and correctly without registrations. Saying so beats printing an
+    # empty type and a "?" project, which reads as damage.
+    echo "  $name (remote — no local registration)"
+  elif [ "$registrations" -gt 1 ]; then
     echo "  $name ($types) — $project (+$((registrations - 1)) more)"
   else
     echo "  $name ($types) — $project"
@@ -62,7 +67,11 @@ done < <(sqlite3 -separator '	' :memory: \
        LIMIT 1
      ), '?'),
      json_array_length(registrations)
-   FROM agents, json_each(agents.registrations) AS r
+   -- LEFT JOIN, not a comma join: a member whose registrations array is empty
+   -- produces no rows from json_each, so an inner join dropped them from the
+   -- listing entirely and from the count with it. That is the normal state on
+   -- a machine that pulled the team rather than joining it.
+   FROM agents LEFT JOIN json_each(agents.registrations) AS r
    GROUP BY name, registrations;" | tr -d '\r')
 
 echo ""

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -848,3 +848,45 @@ EOF
   [ "$status" -eq 0 ]
   [ -f "$TEST_SKILL_DIR/teams/myteam/config.json" ]
 }
+
+@test "team: a pulled member with no local registration is listed and counted" {
+  # A machine that pulled a team holds members it has never registered locally:
+  # the roster is real, the registrations are empty, and that is the correct
+  # state rather than a broken one. The listing joined through the
+  # registrations array, so those members produced no row at all and the team
+  # read as empty.
+  mkdir -p "$TEST_SKILL_DIR/teams/pulled"
+  cat > "$TEST_SKILL_DIR/teams/pulled/config.json" <<'JSON'
+{
+  "name": "pulled",
+  "team_id": "018f3f7e-2222-7000-8000-000000000002",
+  "agents": {
+    "alice": { "member_id": "018f3f7e-2222-7000-8000-000000000010", "registrations": [] },
+    "bob":   { "member_id": "018f3f7e-2222-7000-8000-000000000011", "registrations": [] },
+    "carol": { "member_id": "018f3f7e-2222-7000-8000-000000000012",
+               "registrations": [ { "type": "claude-code", "project": "/tmp/p" } ] }
+  },
+  "created_at": "2026-07-29T00:00:00Z"
+}
+JSON
+  run bash "$SCRIPTS/team.sh" pulled
+  [ "$status" -eq 0 ]
+  # Every member appears, not just the one with a registration.
+  [[ "$output" == *"alice"* ]]
+  [[ "$output" == *"bob"* ]]
+  [[ "$output" == *"carol"* ]]
+  # And the count agrees with the roster rather than with the join.
+  [[ "$output" == *"3 member(s)"* ]]
+  # The absence is described, not left blank.
+  [[ "$output" == *"no local registration"* ]]
+}
+
+@test "team: a locally registered member still lists its type and project" {
+  # The fix must not change what a normal member looks like.
+  bash "$SCRIPTS/join.sh" localteam alice claude-code /tmp/project-x >/dev/null
+  run bash "$SCRIPTS/team.sh" localteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"alice (claude-code) — /tmp/project-x"* ]]
+  [[ "$output" == *"1 member(s)"* ]]
+  [[ "$output" != *"no local registration"* ]]
+}


### PR DESCRIPTION
A machine that pulled a team holds members it has never registered locally. The roster is real and the registrations are empty — the correct state on that machine, not a broken one — but the listing joined through the registrations array, so those members produced no rows at all. Observed on the second dogfood machine: seven members in the config, `0 member(s)` on screen.

## The change

The comma join becomes a `LEFT JOIN`, so a member with an empty registrations array survives to the output and to the count.

The line then says what is true of them:

    alice (remote — no local registration)

rather than printing an empty type and a `?` project, which reads as damage rather than as absence.

## What stays the same

Members with local registrations render exactly as before, including the `(+N more)` suffix. That is pinned by its own test rather than assumed — the two cases are one line apart in the same loop, and a later edit that collapses them would otherwise pass.

## Tests

124 green across the five suites that exercise `team.sh` (`test_team`, `test_dispatch`, `test_local_team_ids`, `test_migrate_team_store`, `test_storage`).

The new case asserts all three members appear **and** that `3 member(s)` matches the roster — the count is what actually failed, and a test that only looked for a name would have passed once one member rendered.
