### PR TITLE
test(watch): wait for the watcher instead of sleeping a guess at it

### DIFF
--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -272,16 +272,41 @@ _max_message_id() {
 
 @test "watch: a broad (non-actas) watcher does not create a ready sentinel" {
   bash "$SCRIPTS/join.sh" team bob claude-code "$PROJ" >/dev/null
-  # An absence cannot be waited for, so wait for a POSITIVE signal from the same
-  # startup path instead: the watermark appears once the watcher has taken its
-  # mark, i.e. past the point where an actas watcher would have written its
-  # sentinel. Sleeping a fixed 1.5s here was weaker in a way that never showed up
-  # as a failure — too short a window makes the absence vacuous and the test
-  # passes for the wrong reason.
-  run_watcher_until_file "sess-broad" "$TEST_SKILL_DIR/broad.log" \
-    "$TEST_SKILL_DIR/run/watch.$(_iid sess-broad).watermark"
-  [ ! -e "$TEST_SKILL_DIR/run/ready.team__alice" ]
-  [ ! -e "$TEST_SKILL_DIR/run/ready.team__bob" ]
+  # An absence cannot be waited for, so wait for positive evidence that the
+  # watcher got PAST the point where a sentinel would have been written.
+  #
+  # The watermark is not that evidence: watch.sh persists it, then runs the
+  # DB-open healthcheck, and only then writes the ready sentinel — so observing
+  # the watermark and stopping would leave the ready block unreached, and the
+  # absence would hold for the wrong reason. Streamed delivery is the evidence,
+  # because it happens in the main loop, which is after the ready block.
+  #
+  # The marker is sent only once the watermark exists, so it carries a higher id
+  # than the mark the watcher took at startup and is therefore streamed rather
+  # than absorbed into it.
+  local out="$TEST_SKILL_DIR/broad.log"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "sess-broad" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
+  local w=$!
+  wait_for_file "$TEST_SKILL_DIR/run/watch.$(_iid sess-broad).watermark"
+  bash "$SCRIPTS/send.sh" team bob alice "M-broad-marker" >/dev/null
+  wait_for_file_contains "$out" "M-broad-marker"
+
+  # Asserted while the watcher is STILL RUNNING, and that is the whole point.
+  # cleanup() removes on exit every sentinel this watcher owns, so an assertion
+  # made after the kill cannot tell "never created" from "created, then cleaned
+  # up" — it holds either way. Checking it here is what makes the absence mean
+  # something. Verified by injection: with watch.sh's `[ -n "$ACTIVE_NAME" ]`
+  # guard removed so a broad watcher writes the sentinels, this test fails,
+  # while the kill-then-assert form it replaces still passes.
+  local rc=0 _s
+  for _s in ready.team__alice ready.team__bob; do
+    if [ -e "$TEST_SKILL_DIR/run/$_s" ]; then
+      echo "broad watcher created $_s" >&2
+      rc=1
+    fi
+  done
+  _stop_watcher "$w"
+  return "$rc"
 }
 
 @test "watch: ready sentinel records the owner session_id" {

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -26,15 +26,50 @@ teardown() {
   teardown_test_env
 }
 
-# Run watch.sh in the background for <secs> seconds, capturing stdout to <out>.
-# Returns once the watcher has been stopped.
-run_watcher_for() {
-  local sid="$1" out="$2" secs="$3"
+# Run watch.sh in the background until <condition> holds, capturing stdout to
+# <out>, then stop it. Returns non-zero if the condition never arrived.
+#
+# These wait for the thing the caller is about to assert instead of sleeping a
+# fixed number of seconds. A fixed sleep encodes "the watcher is usually done by
+# now", which is a claim about the machine rather than about the watcher: on a
+# loaded runner it is false, and the test then fails on its own assertion with no
+# hint that timing was the cause. `watch: persists a watermark file for the
+# session` failed exactly that way on main (macos shard 3/4), and `watch: restart
+# delivers messages that arrived while the watcher was down` failed the same way
+# the day before. Same class of defect as #503, same fix.
+#
+# A wait that times out returns non-zero HERE, so the failure names the condition
+# that never happened rather than surfacing later as a missing grep.
+# The launch is written out in each helper rather than factored into a
+# `pid=$(_start_watcher ...)` helper on purpose. A command substitution is a
+# subshell, so the watcher's parent would exit the instant the substitution
+# returned, and watch.sh — which stops within one interval once its session is
+# gone (#67) — would tear itself down before the condition could ever arrive. A
+# function call is not a subshell, so launching here keeps the test process as
+# the watcher's parent, exactly as the fixed-sleep version did.
+_stop_watcher() {
+  kill "$1" 2>/dev/null || true
+  wait "$1" 2>/dev/null || true
+}
+
+# Stop once <file> exists.
+run_watcher_until_file() {
+  local sid="$1" out="$2" file="$3" pid rc=0
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
-  local pid=$!
-  sleep "$secs"
-  kill "$pid" 2>/dev/null || true
-  wait "$pid" 2>/dev/null || true
+  pid=$!
+  wait_for_file "$file" || rc=1
+  _stop_watcher "$pid"
+  return "$rc"
+}
+
+# Stop once <out> contains <needle>.
+run_watcher_until_contains() {
+  local sid="$1" out="$2" needle="$3" pid rc=0
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- &
+  pid=$!
+  wait_for_file_contains "$out" "$needle" || rc=1
+  _stop_watcher "$pid"
+  return "$rc"
 }
 
 # Compute the per-process instance id (#93) that watch.sh / session-end key on
@@ -85,7 +120,7 @@ _max_message_id() {
   bash "$SCRIPTS/send.sh" team bob alice "M2-in-gap" >/dev/null
 
   # Restart the SAME session_id — should resume from the persisted watermark.
-  run_watcher_for "$sid" "$TEST_SKILL_DIR/out2.log" 2
+  run_watcher_until_contains "$sid" "$TEST_SKILL_DIR/out2.log" "M2-in-gap"
 
   # In-gap message is delivered on restart...
   grep -q "M2-in-gap" "$TEST_SKILL_DIR/out2.log"
@@ -117,7 +152,10 @@ _max_message_id() {
 
 @test "watch: persists a watermark file for the session" {
   skip_on_windows "watcher background launch under Git Bash (#182)"
-  run_watcher_for "sess-wm" "$TEST_SKILL_DIR/wm.log" 1.5
+  run_watcher_until_file "sess-wm" "$TEST_SKILL_DIR/wm.log" \
+    "$TEST_SKILL_DIR/run/watch.$(_iid sess-wm).watermark"
+  # Still asserted after the watcher is stopped: the point is that the file
+  # PERSISTS past the session, not merely that it appeared while it ran.
   [ -f "$TEST_SKILL_DIR/run/watch.$(_iid sess-wm).watermark" ]
 }
 
@@ -199,7 +237,8 @@ _max_message_id() {
 
   [ "$(cat "$wm")" = "$initial" ]
 
-  run_watcher_for "$sid" "$TEST_SKILL_DIR/closed-redelivery.log" 2
+  run_watcher_until_contains "$sid" "$TEST_SKILL_DIR/closed-redelivery.log" \
+    "M-after-closed-stdout"
   grep -q "M-after-closed-stdout" "$TEST_SKILL_DIR/closed-redelivery.log"
 }
 
@@ -233,7 +272,14 @@ _max_message_id() {
 
 @test "watch: a broad (non-actas) watcher does not create a ready sentinel" {
   bash "$SCRIPTS/join.sh" team bob claude-code "$PROJ" >/dev/null
-  run_watcher_for "sess-broad" "$TEST_SKILL_DIR/broad.log" 1.5
+  # An absence cannot be waited for, so wait for a POSITIVE signal from the same
+  # startup path instead: the watermark appears once the watcher has taken its
+  # mark, i.e. past the point where an actas watcher would have written its
+  # sentinel. Sleeping a fixed 1.5s here was weaker in a way that never showed up
+  # as a failure — too short a window makes the absence vacuous and the test
+  # passes for the wrong reason.
+  run_watcher_until_file "sess-broad" "$TEST_SKILL_DIR/broad.log" \
+    "$TEST_SKILL_DIR/run/watch.$(_iid sess-broad).watermark"
   [ ! -e "$TEST_SKILL_DIR/run/ready.team__alice" ]
   [ ! -e "$TEST_SKILL_DIR/run/ready.team__bob" ]
 }


### PR DESCRIPTION
`main` has been intermittently red on `bats (macos-latest 3/4)` since 2026-07-27. This is the cause.

## The failure

`watch: persists a watermark file for the session` failed on `c1415e9` (07-28), passed on `9941ebb` and `68744d4`, then failed on `053c358` and again on a re-run of that same job — three failures in five observed runs of the test on `main`, so a re-run is a coin flip rather than a fix. The day before that, `watch: restart delivers messages that arrived while the watcher was down` failed the same way on `e9a5fc29`.

Both tests went through `run_watcher_for`, which slept a fixed 1.5-2s and then asserted. That sleep is a claim about how fast the machine is, not about the watcher — on a loaded runner it is false, and the test then fails on its own assertion with nothing pointing at timing as the cause. This is the same defect class as the watcher-suite sleeps removed in #503; these four call sites were left behind.

## The change

Each call site now waits for the condition it is about to assert, and stops the watcher as soon as it holds. Test-only; no production code is touched.

- `run_watcher_until_file` — stop once the named file exists.
- `run_watcher_until_contains` — stop once the captured stdout contains the needle.

A wait that never completes returns non-zero from the helper, so a genuine regression fails at the helper naming the condition, rather than surfacing later as a missing `grep`. That behaviour is not theoretical here: an earlier iteration of this change accidentally started the watcher inside a command substitution, and the four affected tests failed with `run_watcher_until_file ... failed` pointing straight at the wait.

The broad-watcher test asserts an *absence*, which cannot be waited for. It now waits for the watermark instead — a positive signal from the same startup path, past the point at which an actas watcher would have written its sentinel — and then asserts the sentinel is absent. The fixed sleep there was weak in the opposite direction: too short a window makes the absence vacuous and the test passes for the wrong reason.

The launch is written out in both helpers rather than factored into a `pid=$(_start_watcher ...)`. A command substitution is a subshell, so the watcher's parent would exit immediately and `watch.sh` — which stops within one interval once its session is gone (#67) — would tear itself down before any condition could arrive. That is the bug described above; it is called out in a comment so the factoring is not re-attempted.

## Verification

- `bats tests/test_watch.bats` → 27/27, exit 0.
- Baseline on `origin/main` (`053c358`) → 27/27, exit 0, so the suite is being compared against a green local baseline rather than a red one.
- Wall clock, one run each, not a controlled benchmark: 62s before, 58s after. The old code slept 7s unconditionally across the four sites regardless of readiness; the new code returns as soon as the condition holds, with the existing 10s helper ceiling as the bound.

## What this does not do

It does not make the macOS runner faster or address any other suite. If `main` goes red again on a different watcher test, that is a separate fixed-sleep site or a real regression, not this one recurring.
