### PR TITLE
feat(remote): pull a team by name

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1902,10 +1902,28 @@ export async function pullBootstrap(args, dependencies = {}) {
   })}\n`);
 }
 
-async function publicSnapshot(serverUrl, teamId) {
+// Resolve a team name to the teams carrying it. Like publicSnapshot this runs
+// before any config exists, so it validates its own answer rather than going
+// through the binding checks the rest of the client relies on.
+export async function resolveTeam(args) {
+  const serverUrl = args.endpoint ?? "";
+  if (!serverUrl) throw new Error("endpoint is required");
+  const name = args.name ?? "";
+  if (!name) throw new Error("name is required");
+  const body = await publicGet(serverUrl,
+    `/v1/teams?name=${encodeURIComponent(name)}`);
+  if (!Array.isArray(body.teams)) {
+    throw new Error("team lookup did not return a list");
+  }
+  process.stdout.write(`${JSON.stringify({
+    type: "team_lookup_result", team_name: name, teams: body.teams,
+  })}\n`);
+}
+
+async function publicGet(serverUrl, path) {
   let response;
   try {
-    response = await fetch(endpoint(serverUrl, `/v1/teams/${teamId}`), {
+    response = await fetch(endpoint(serverUrl, path), {
       headers: { "Agmsg-Protocol-Version": PROTOCOL },
       redirect: "error", signal: AbortSignal.timeout(15_000),
     });
@@ -1922,6 +1940,11 @@ async function publicSnapshot(serverUrl, teamId) {
     error.status = response.status;
     throw error;
   }
+  return body;
+}
+
+async function publicSnapshot(serverUrl, teamId) {
+  const body = await publicGet(serverUrl, `/v1/teams/${teamId}`);
   if (body.team_id !== teamId || !UUID_V7.test(body.server_instance_id ?? "")) {
     throw new Error("team snapshot is not bound to the requested team");
   }
@@ -1932,11 +1955,12 @@ async function main() {
   const [command, ...rest] = process.argv.slice(2);
   const args = options(rest);
   if (!["configure", "once", "run", "reprocess", "resync", "unblock-read",
-        "pull-bootstrap"].includes(command)) {
+        "pull-bootstrap", "resolve-team"].includes(command)) {
     throw new Error(usage());
   }
   if (command === "configure") { await configure(args); return; }
-  // Before any local team exists, so it cannot go through loadConfig.
+  // Before any local team exists, so neither can go through loadConfig.
+  if (command === "resolve-team") { await resolveTeam(args); return; }
   if (command === "pull-bootstrap") { await pullBootstrap(args); return; }
   const team = requireName(args.team, "team");
   const limit = Number(args.limit ?? 100);

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -19,6 +19,10 @@ const TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/;
 const PROTOCOL = "1";
 const MAX_SEQUENCE = 9_223_372_036_854_775_807n;
 const MAX_CONNECTION_CONFIG_BYTES = 2 * 1024 * 1024;
+// Held here as well as on the server, and deliberately not read from the
+// answer: a bound a server can raise by saying so is not a bound. If the two
+// ever disagree, the client refuses rather than accepts the larger list.
+const MAX_TEAMS_PER_NAME = 16;
 
 function usage() {
   return `usage:
@@ -1912,11 +1916,35 @@ export async function resolveTeam(args) {
   if (!name) throw new Error("name is required");
   const body = await publicGet(serverUrl,
     `/v1/teams?name=${encodeURIComponent(name)}`);
-  if (!Array.isArray(body.teams)) {
-    throw new Error("team lookup did not return a list");
+  // Nothing here is trusted. One candidate's team_id becomes this machine's
+  // team identity; several are printed for an operator to read. Both happen
+  // before a local team exists, so a bad answer has to stop the command rather
+  // than thin out into "no such team" or reach a terminal as raw bytes. The
+  // messages below deliberately quote no server value, for the same reason.
+  const keysOf = (value) => Object.keys(value).sort().join(",");
+  if (body.protocol_version !== 1 || !UUID_V7.test(body.server_instance_id ?? "") ||
+      body.team_name !== name || !Array.isArray(body.teams)) {
+    throw new Error("team lookup answer is not a lookup result for the requested name");
   }
+  if (body.teams.length > MAX_TEAMS_PER_NAME) {
+    throw new Error("team lookup returned more candidates than the protocol allows");
+  }
+  const teams = body.teams.map((candidate) => {
+    if (!candidate || typeof candidate !== "object" ||
+        keysOf(candidate) !== "current_seq,registered_at,team_id,team_name" ||
+        !UUID_V7.test(candidate.team_id ?? "") || candidate.team_name !== name ||
+        !TIMESTAMP.test(candidate.registered_at ?? "")) {
+      throw new Error("a team lookup candidate is not a valid candidate");
+    }
+    sequence(candidate.current_seq, "team lookup current_seq");
+    // Rebuilt field by field so only what was checked travels onward.
+    return {
+      team_id: candidate.team_id, team_name: candidate.team_name,
+      registered_at: candidate.registered_at, current_seq: candidate.current_seq,
+    };
+  });
   process.stdout.write(`${JSON.stringify({
-    type: "team_lookup_result", team_name: name, teams: body.teams,
+    type: "team_lookup_result", team_name: name, teams,
   })}\n`);
 }
 

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -809,6 +809,44 @@ _remote_write_pulled_team() {
   agmsg_lock_release
 }
 
+# Resolve a team name to one team_id, or explain why it cannot be resolved.
+#
+# A name is not unique on the server -- only team_id is -- so the answer is a
+# list. One entry settles it. Several is not bad data: it is a question only the
+# operator can answer, so the candidates are printed with what tells them apart
+# and --team-id is offered.
+_remote_resolve_team_id() {
+  local endpoint="$1" name="$2" result count doc
+  result="$("$SCRIPT_DIR/remote-sync.sh" resolve-team \
+    --endpoint "$endpoint" --name "$name" 2>/dev/null \
+    | grep '"team_lookup_result"' | tail -1)" || true
+  [ -n "$result" ] || { echo "agmsg: could not reach the server to look up '$name'" >&2; return 1; }
+
+  doc="$(printf '%s' "$result" | sed "s/'/''/g")"
+  count="$(agmsg_sqlite_mem "SELECT json_array_length(json_extract('$doc', '\$.teams'));")"
+  case "$count" in ''|*[!0-9]*) count=0 ;; esac
+
+  if [ "$count" -eq 0 ]; then
+    echo "agmsg: no team named '$name' on this server" >&2
+    return 1
+  fi
+  if [ "$count" -eq 1 ]; then
+    agmsg_sqlite_mem "SELECT json_extract('$doc', '\$.teams[0].team_id');"
+    return 0
+  fi
+
+  {
+    echo "agmsg: $count teams are named '$name' on this server:"
+    agmsg_sqlite_mem "
+      SELECT '  ' || json_extract(value, '\$.team_id') ||
+             '   registered ' || substr(json_extract(value, '\$.registered_at'), 1, 10) ||
+             '   ' || json_extract(value, '\$.current_seq') || ' messages'
+        FROM json_each('$doc', '\$.teams');"
+    echo "re-run with --team-id <one of the above>"
+  } >&2
+  return 1
+}
+
 # The other half of connect: this machine takes a team it does not have.
 cmd_pull() {
   local endpoint="" team_id="" team="" positional=()
@@ -821,13 +859,20 @@ cmd_pull() {
       *) positional+=("$1"); shift ;;
     esac
   done
-  : "${endpoint:?Usage: remote.sh pull --endpoint <url> --team-id <uuid> <team>}"
-  : "${team_id:?Usage: remote.sh pull --endpoint <url> --team-id <uuid> <team>}"
+  : "${endpoint:?Usage: remote.sh pull --endpoint <url> [--team-id <uuid>] <team>}"
   _remote_validate_endpoint "$endpoint" || exit 1
   endpoint="${endpoint%/}"
   team="${positional[0]:-}"
   [ -n "$team" ] || { echo "agmsg: pull requires a local team name" >&2; exit 1; }
   agmsg_validate_team_name "$team" || exit 1
+
+  # The name is normally enough. A team_id had to be carried between machines by
+  # hand only because it stood in for authentication, and this server has none
+  # to stand in for. --team-id remains for the case a name cannot settle -- two
+  # teams sharing it -- and for anyone who scripted the old form.
+  if [ -z "$team_id" ]; then
+    team_id="$(_remote_resolve_team_id "$endpoint" "$team")" || exit 1
+  fi
 
   # Refused for the reason git refuses a non-fast-forward push: two teams that
   # each grew their own history do not become one by pointing at the same

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -816,11 +816,21 @@ _remote_write_pulled_team() {
 # operator can answer, so the candidates are printed with what tells them apart
 # and --team-id is offered.
 _remote_resolve_team_id() {
-  local endpoint="$1" name="$2" result count doc
-  result="$("$SCRIPT_DIR/remote-sync.sh" resolve-team \
-    --endpoint "$endpoint" --name "$name" 2>/dev/null \
-    | grep '"team_lookup_result"' | tail -1)" || true
-  [ -n "$result" ] || { echo "agmsg: could not reach the server to look up '$name'" >&2; return 1; }
+  local endpoint="$1" name="$2" out status result count doc
+  # The engine's exit status is read on its own rather than through a pipeline,
+  # so a server that is unreachable and a server whose answer failed validation
+  # stay distinguishable from a name that simply matched nothing. Collapsing
+  # those into one message is how a rejected answer would get read as "no such
+  # team" -- the wrong conclusion to hand an operator about their own team.
+  out="$("$SCRIPT_DIR/remote-sync.sh" resolve-team \
+    --endpoint "$endpoint" --name "$name" 2>/dev/null)"
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "agmsg: could not look up '$name': the server was unreachable, or its answer was rejected" >&2
+    return 1
+  fi
+  result="$(printf '%s\n' "$out" | grep '"team_lookup_result"' | tail -1)" || true
+  [ -n "$result" ] || { echo "agmsg: the server did not answer the lookup for '$name'" >&2; return 1; }
 
   doc="$(printf '%s' "$result" | sed "s/'/''/g")"
   count="$(agmsg_sqlite_mem "SELECT json_array_length(json_extract('$doc', '\$.teams'));")"

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -21,6 +21,10 @@ CREATE TABLE IF NOT EXISTS teams (
 ALTER TABLE teams ALTER COLUMN write_allowed_ciphers
   SET DEFAULT ARRAY['none', 'age-v1']::TEXT[];
 
+-- Name lookup is an equality probe from an unauthenticated route, so it must
+-- not be a sequential scan over every team.
+CREATE INDEX IF NOT EXISTS teams_name_idx ON teams(team_name);
+
 CREATE TABLE IF NOT EXISTS team_policy_history (
   team_id UUID NOT NULL REFERENCES teams(team_id) ON DELETE RESTRICT,
   policy_revision BIGINT NOT NULL CHECK (policy_revision >= 0),

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -21,29 +21,6 @@ CREATE TABLE IF NOT EXISTS teams (
 ALTER TABLE teams ALTER COLUMN write_allowed_ciphers
   SET DEFAULT ARRAY['none', 'age-v1']::TEXT[];
 
--- When this team was registered, so a human choosing between two teams that
--- share a name has something to choose by. Added in three steps rather than one
--- because this file is re-executed on every start: the column arrives nullable,
--- rows without a value are filled once, and only then does it become NOT NULL.
---
--- The backfill takes the team's first message rather than the migration clock.
--- Stamping "now" would say a team registered in July was registered today,
--- which is a lie told by the exact field a human is about to trust. It is also
--- why the fill is restricted to NULL rows: retention can delete old messages,
--- so MIN() moves forward over time, and an unrestricted UPDATE would push a
--- team's registration date later on every restart.
-ALTER TABLE teams ADD COLUMN IF NOT EXISTS registered_at TIMESTAMPTZ(6);
-
-UPDATE teams t
-   SET registered_at = COALESCE(
-         (SELECT MIN(m.server_received_at) FROM messages m
-           WHERE m.team_id = t.team_id),
-         clock_timestamp())
- WHERE t.registered_at IS NULL;
-
-ALTER TABLE teams ALTER COLUMN registered_at SET DEFAULT clock_timestamp();
-ALTER TABLE teams ALTER COLUMN registered_at SET NOT NULL;
-
 CREATE TABLE IF NOT EXISTS team_policy_history (
   team_id UUID NOT NULL REFERENCES teams(team_id) ON DELETE RESTRICT,
   policy_revision BIGINT NOT NULL CHECK (policy_revision >= 0),
@@ -168,3 +145,32 @@ CREATE TABLE IF NOT EXISTS pairing_tokens (
 
 CREATE INDEX IF NOT EXISTS pairing_tokens_team_expiry_idx
   ON pairing_tokens(team_id, expires_at);
+
+-- Column additions that read another table live here, after every table above
+-- exists. This file runs top to bottom against a database that may be empty, so
+-- a backfill placed beside the table it extends can reference a table that has
+-- not been created yet -- which fails only on a first-ever start, never against
+-- a database that has been up before.
+
+-- When this team was registered, so a human choosing between two teams that
+-- share a name has something to choose by. Added in three steps rather than one
+-- because this file is re-executed on every start: the column arrives nullable,
+-- rows without a value are filled once, and only then does it become NOT NULL.
+--
+-- The backfill takes the team's first message rather than the migration clock.
+-- Stamping "now" would say a team registered in July was registered today,
+-- which is a lie told by the exact field a human is about to trust. It is also
+-- why the fill is restricted to NULL rows: retention can delete old messages,
+-- so MIN() moves forward over time, and an unrestricted UPDATE would push a
+-- team's registration date later on every restart.
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS registered_at TIMESTAMPTZ(6);
+
+UPDATE teams t
+   SET registered_at = COALESCE(
+         (SELECT MIN(m.server_received_at) FROM messages m
+           WHERE m.team_id = t.team_id),
+         clock_timestamp())
+ WHERE t.registered_at IS NULL;
+
+ALTER TABLE teams ALTER COLUMN registered_at SET DEFAULT clock_timestamp();
+ALTER TABLE teams ALTER COLUMN registered_at SET NOT NULL;

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -21,6 +21,29 @@ CREATE TABLE IF NOT EXISTS teams (
 ALTER TABLE teams ALTER COLUMN write_allowed_ciphers
   SET DEFAULT ARRAY['none', 'age-v1']::TEXT[];
 
+-- When this team was registered, so a human choosing between two teams that
+-- share a name has something to choose by. Added in three steps rather than one
+-- because this file is re-executed on every start: the column arrives nullable,
+-- rows without a value are filled once, and only then does it become NOT NULL.
+--
+-- The backfill takes the team's first message rather than the migration clock.
+-- Stamping "now" would say a team registered in July was registered today,
+-- which is a lie told by the exact field a human is about to trust. It is also
+-- why the fill is restricted to NULL rows: retention can delete old messages,
+-- so MIN() moves forward over time, and an unrestricted UPDATE would push a
+-- team's registration date later on every restart.
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS registered_at TIMESTAMPTZ(6);
+
+UPDATE teams t
+   SET registered_at = COALESCE(
+         (SELECT MIN(m.server_received_at) FROM messages m
+           WHERE m.team_id = t.team_id),
+         clock_timestamp())
+ WHERE t.registered_at IS NULL;
+
+ALTER TABLE teams ALTER COLUMN registered_at SET DEFAULT clock_timestamp();
+ALTER TABLE teams ALTER COLUMN registered_at SET NOT NULL;
+
 CREATE TABLE IF NOT EXISTS team_policy_history (
   team_id UUID NOT NULL REFERENCES teams(team_id) ON DELETE RESTRICT,
   policy_revision BIGINT NOT NULL CHECK (policy_revision >= 0),

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -22,6 +22,7 @@ import {
   parseSequence,
   postMessagesSchema,
   readStateSyncSchema,
+  teamNameSchema,
   uuidV7Schema,
 } from "./protocol.js";
 import {
@@ -29,6 +30,7 @@ import {
   getCapabilities,
   getMembers,
   getTeamSnapshot,
+  resolveTeamsByName,
   getMessages,
   health,
   postMessages,
@@ -39,6 +41,7 @@ const emptyQuerySchema = z.object({}).strict();
 const pairingExchangeSchema = z.object({ token: z.string().min(32).max(256) }).strict();
 const credentialParamsSchema = z.object({ credentialId: uuidV7Schema }).strict();
 const teamParamsSchema = z.object({ teamId: uuidV7Schema }).strict();
+const teamLookupQuerySchema = z.object({ name: teamNameSchema }).strict();
 
 function requireProtocol(request: FastifyRequest): void {
   const version = request.headers["agmsg-protocol-version"];
@@ -288,6 +291,17 @@ async function dataPlaneRoutes(
   // /v1/connect has none — reaching the server is the permission. Knowing a
   // team_id is therefore enough to read a team, which the design records as
   // accepted for this minimum rather than overlooked.
+  // Look a team up by name, so a second machine does not have to be handed a
+  // UUID by a human. A name is not unique -- only team_id is -- so this always
+  // answers with a list and the caller decides; one match is the ordinary case,
+  // not a guarantee.
+  app.get("/v1/teams", async (request, reply) => {
+    requireProtocol(request);
+    const query = teamLookupQuerySchema.parse(request.query);
+    reply.header("Cache-Control", "no-store");
+    return resolveTeamsByName(pool, query.name);
+  });
+
   app.get("/v1/teams/:teamId", async (request, reply) => {
     requireProtocol(request);
     emptyQuerySchema.parse(request.query);

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -37,7 +37,10 @@ type ExistingRecord =
   | { kind: "live"; row: LiveMessageRow }
   | { kind: "tombstone"; sequence: string; digest: Buffer };
 
-const timestampSql = `to_char(server_received_at AT TIME ZONE 'UTC',
+// Takes the column, the way credentials.ts already does: this file needs the
+// same rendering for more than one timestamp now, and two spellings of the same
+// format string is how they drift apart.
+const timestampSql = (column: string) => `to_char(${column} AT TIME ZONE 'UTC',
   'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`;
 const MAX_EXACT_PER_MEMBER = 4096;
 const MAX_EXACT_PER_TEAM = 65536;
@@ -132,7 +135,7 @@ export async function postMessages(
 
     const ids = [...firstById.keys()];
     const liveResult = await client.query<LiveMessageRow>(
-      `SELECT id::text, team_seq::text, ${timestampSql} AS server_received_at,
+      `SELECT id::text, team_seq::text, ${timestampSql("server_received_at")} AS server_received_at,
               envelope_v, cipher, key_id, blob, envelope_digest
          FROM messages WHERE team_id = $1 AND id = ANY($2::uuid[])`,
       [teamId, ids],
@@ -241,7 +244,7 @@ export async function postMessages(
         `INSERT INTO messages
            (team_id, id, team_seq, envelope_v, cipher, key_id, blob, envelope_digest)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-         RETURNING id::text, team_seq::text, ${timestampSql} AS server_received_at,
+         RETURNING id::text, team_seq::text, ${timestampSql("server_received_at")} AS server_received_at,
                    envelope_v, cipher, key_id, blob, envelope_digest`,
         [
           teamId,
@@ -654,7 +657,7 @@ export async function getMessages(
         );
       }
       const result = await client.query<LiveMessageRow>(
-        `SELECT id::text, team_seq::text, ${timestampSql} AS server_received_at,
+        `SELECT id::text, team_seq::text, ${timestampSql("server_received_at")} AS server_received_at,
                 envelope_v, cipher, key_id, blob, envelope_digest
            FROM messages
           WHERE team_id = $1 AND team_seq > $2::bigint
@@ -845,6 +848,48 @@ async function roster(
 // managing it, and it follows from what e2ee is for here: if encryption
 // protects you from whoever runs the server, who is on the team is theirs to
 // know too. Each machine derives the roster by replaying the team journal.
+// Every team registered under a name. A name is not unique -- only team_id is
+// -- so this answers with a list and lets the caller decide, rather than
+// picking one and being right most of the time.
+//
+// What comes back is deliberately thin: the id to pull with, when the team was
+// registered, and how much history it holds. That is enough for a human to tell
+// two same-named teams apart, and it is all operational metadata that lives
+// outside the envelope. The roster is not here, and must not be: it travels
+// inside the envelope, so an e2ee team could not offer it and a plaintext one
+// offering it anyway would make plaintext the better-featured choice.
+export async function resolveTeamsByName(
+  pool: Pool,
+  teamName: string,
+): Promise<Record<string, unknown>> {
+  return inTransaction(
+    pool,
+    async (client) => {
+      const serverId = await serverInstanceId(client);
+      const rows = await client.query<{
+        team_id: string;
+        team_name: string;
+        registered_at: string;
+        current_seq: string;
+      }>(
+        `SELECT team_id::text, team_name,
+                ${timestampSql("registered_at")} AS registered_at,
+                current_seq::text
+           FROM teams WHERE team_name = $1
+          ORDER BY registered_at, team_id`,
+        [teamName],
+      );
+      return {
+        protocol_version: 1,
+        server_instance_id: serverId,
+        team_name: teamName,
+        teams: rows.rows,
+      };
+    },
+    { readOnly: true, repeatableRead: true },
+  );
+}
+
 export async function getTeamSnapshot(
   pool: Pool,
   teamId: string,

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -44,6 +44,13 @@ const timestampSql = (column: string) => `to_char(${column} AT TIME ZONE 'UTC',
   'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`;
 const MAX_EXACT_PER_MEMBER = 4096;
 const MAX_EXACT_PER_TEAM = 65536;
+// A name matching more teams than this is answered with an error, not a
+// truncated list. Truncation would be the worse failure: a caller shown "the
+// first N" cannot tell whether its own team is among them, so it would choose
+// from a set that may not contain the right answer. The bound is also what
+// keeps the row count of an unauthenticated response from being chosen by
+// outside input -- every other public route answers about one known team.
+const MAX_TEAMS_PER_NAME = 16;
 
 async function serverInstanceId(client: PoolClient): Promise<string> {
   const result = await client.query<{ server_instance_id: string }>(
@@ -876,9 +883,19 @@ export async function resolveTeamsByName(
                 ${timestampSql("registered_at")} AS registered_at,
                 current_seq::text
            FROM teams WHERE team_name = $1
-          ORDER BY registered_at, team_id`,
-        [teamName],
+          ORDER BY registered_at, team_id
+          LIMIT $2`,
+        [teamName, MAX_TEAMS_PER_NAME + 1],
       );
+      if (rows.rows.length > MAX_TEAMS_PER_NAME) {
+        throw new ProtocolError(
+          409,
+          "team-name-match-limit-exceeded",
+          "too many teams share this name to choose between them",
+          { team_name: teamName, limit: MAX_TEAMS_PER_NAME },
+          { serverInstanceId: serverId },
+        );
+      }
       return {
         protocol_version: 1,
         server_instance_id: serverId,

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -121,6 +121,45 @@ describeDatabase("remote storage HTTP API v1", () => {
     });
   });
 
+  it("answers a name lookup, and refuses more names than it can disambiguate", async () => {
+    const lookupName = "lookup-by-name";
+    const ids = Array.from({ length: 17 }, (_, index) =>
+      `018f3f7e-0000-7000-8000-0000000004${(index + 10).toString()}`);
+    await pool.query(
+      "INSERT INTO teams(team_id, team_name) SELECT unnest($1::uuid[]), $2",
+      [ids.slice(0, 1), lookupName],
+    );
+
+    const one = await app.inject({
+      method: "GET",
+      url: `/v1/teams?name=${encodeURIComponent(lookupName)}`,
+      headers: { "agmsg-protocol-version": "1" },
+    });
+    expect(one.statusCode).toBe(200);
+    expect(one.json().teams).toHaveLength(1);
+    // Exactly the four agreed fields travel. The roster is absent by design: it
+    // lives inside the envelope, so an e2ee team could not offer it and a
+    // plaintext one offering it anyway would be the better-featured choice.
+    expect(Object.keys(one.json().teams[0]).sort()).toEqual([
+      "current_seq", "registered_at", "team_id", "team_name",
+    ]);
+
+    // One past the bound. The answer has to be an error, not the first sixteen:
+    // a caller cannot tell whether a truncated list contains its own team, so it
+    // would be choosing from a set that may not hold the right answer.
+    await pool.query(
+      "INSERT INTO teams(team_id, team_name) SELECT unnest($1::uuid[]), $2",
+      [ids.slice(1), lookupName],
+    );
+    const tooMany = await app.inject({
+      method: "GET",
+      url: `/v1/teams?name=${encodeURIComponent(lookupName)}`,
+      headers: { "agmsg-protocol-version": "1" },
+    });
+    expect(tooMany.statusCode).toBe(409);
+    expect(tooMany.json().error.code).toBe("team-name-match-limit-exceeded");
+  });
+
   it("requires a matching protocol and a valid team ID, with no data-plane credential", async () => {
     const noVersion = await app.inject({
       method: "GET",

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -144,6 +144,43 @@ class Handler(BaseHTTPRequestHandler):
         parts = self.path.split("?", 1)
         route = parts[0]
         query = parts[1] if len(parts) > 1 else ""
+        if route == "/v1/teams":
+            # MOCK_DUPLICATE_NAME makes the lookup answer with two teams sharing
+            # the requested name, which is the branch the client cannot resolve
+            # on its own.
+            wanted = ""
+            for pair in query.split("&"):
+                if pair.startswith("name="):
+                    from urllib.parse import unquote
+                    wanted = unquote(pair[len("name="):])
+            if os.environ.get("MOCK_DUPLICATE_NAME") == wanted and wanted:
+                self._send_json(200, {
+                    "protocol_version": 1,
+                    "server_instance_id": PULL_SERVER_ID,
+                    "team_name": wanted,
+                    "teams": [
+                        {"team_id": PULL_TEAM_ID, "team_name": wanted,
+                         "registered_at": "2026-07-29T00:00:00.000000Z",
+                         "current_seq": "2"},
+                        {"team_id": "018f3f7e-2222-7000-8000-0000000000ff",
+                         "team_name": wanted,
+                         "registered_at": "2026-07-12T00:00:00.000000Z",
+                         "current_seq": "4"},
+                    ],
+                })
+                return
+            teams = []
+            if wanted == "pulled-team":
+                teams = [{"team_id": PULL_TEAM_ID, "team_name": wanted,
+                          "registered_at": "2026-07-29T00:00:00.000000Z",
+                          "current_seq": str(len(PULL_MESSAGES))}]
+            self._send_json(200, {
+                "protocol_version": 1,
+                "server_instance_id": PULL_SERVER_ID,
+                "team_name": wanted,
+                "teams": teams,
+            })
+            return
         if route == "/v1/teams/%s" % PULL_TEAM_ID:
             self._send_json(200, {
                 "protocol_version": 1,

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -153,6 +153,48 @@ class Handler(BaseHTTPRequestHandler):
                 if pair.startswith("name="):
                     from urllib.parse import unquote
                     wanted = unquote(pair[len("name="):])
+            # A server the client must not believe. Each mode carries a marker
+            # that would be visible on a terminal if the value reached one, so a
+            # test can assert on its absence rather than on an exit status
+            # alone. MOCK_LOOKUP_BAD names which field goes wrong.
+            bad = os.environ.get("MOCK_LOOKUP_BAD", "")
+            if bad and wanted:
+                poison = "\x1b[2K\rMARKER-INJECTED"
+                good = {"team_id": PULL_TEAM_ID, "team_name": wanted,
+                        "registered_at": "2026-07-29T00:00:00.000000Z",
+                        "current_seq": "2"}
+                other = dict(good, team_id="018f3f7e-2222-7000-8000-0000000000ff",
+                             registered_at="2026-07-12T00:00:00.000000Z")
+                teams, root = [good], {}
+                if bad == "team_id":
+                    teams = [dict(good, team_id="not-a-uuid" + poison)]
+                elif bad == "name_mismatch":
+                    teams = [dict(good, team_name=wanted + poison)]
+                elif bad == "timestamp":
+                    teams = [dict(good, registered_at="2026-07-29" + poison)]
+                elif bad == "sequence":
+                    teams = [dict(good, current_seq="-1" + poison)]
+                elif bad == "extra_field":
+                    teams = [dict(good, roster=poison)]
+                elif bad == "multiple":
+                    teams = [good, dict(other, registered_at="2026-07-12" + poison)]
+                elif bad == "flood":
+                    teams = [dict(good, team_id="018f3f7e-%04d-7000-8000-0000000000ff" % i)
+                             for i in range(40)]
+                elif bad == "protocol":
+                    root = {"protocol_version": 2}
+                elif bad == "server_id":
+                    root = {"server_instance_id": "not-a-uuid" + poison}
+                elif bad == "root_name":
+                    root = {"team_name": wanted + poison}
+                self._send_json(200, {
+                    **{"protocol_version": 1,
+                       "server_instance_id": PULL_SERVER_ID,
+                       "team_name": wanted,
+                       "teams": teams},
+                    **root,
+                })
+                return
             if os.environ.get("MOCK_DUPLICATE_NAME") == wanted and wanted:
                 self._send_json(200, {
                     "protocol_version": 1,

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -764,3 +764,51 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   [ "$status" -eq 0 ]
   [ -f "$TEST_SKILL_DIR/teams/pulled-team/config.json" ]
 }
+
+# A lookup answer decides this machine's team identity and gets printed for an
+# operator to read, so each of these asserts three things: the command failed,
+# no local team was built from the answer, and the poisoned value never reached
+# the terminal. The message is pinned too -- a bare non-zero status would also
+# be produced by the very fail-open this guards against.
+assert_lookup_rejected() {
+  local mode="$1"
+  MOCK_LOOKUP_BAD="$mode" restart_mock_server
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" pulled-team
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"its answer was rejected"* ]]
+  [[ "$output" != *"MARKER-INJECTED"* ]]
+  [ ! -d "$TEST_SKILL_DIR/teams/pulled-team" ]
+}
+
+@test "remote pull: a candidate failing field validation is refused, not shown" {
+  # team_id/timestamp/sequence are the fields that would reach a terminal or a
+  # config; name_mismatch is a server answering about a different team.
+  assert_lookup_rejected team_id
+  assert_lookup_rejected timestamp
+  assert_lookup_rejected sequence
+  assert_lookup_rejected name_mismatch
+}
+
+@test "remote pull: an otherwise valid candidate with an extra field is refused" {
+  # The strongest of these cases: everything the client uses is well formed, so
+  # without the key-set check the pull would succeed and the unasked-for field
+  # would have travelled with it.
+  assert_lookup_rejected extra_field
+}
+
+@test "remote pull: a poisoned second candidate is refused before listing" {
+  # The duplicate-name path prints candidates, which is exactly where an
+  # unvalidated value would be rendered.
+  assert_lookup_rejected multiple
+}
+
+@test "remote pull: more candidates than the bound are refused, not listed" {
+  # Forty candidates. Without the client-side bound this lists all of them.
+  assert_lookup_rejected flood
+}
+
+@test "remote pull: a wrong protocol, server id, or root name is refused" {
+  assert_lookup_rejected protocol
+  assert_lookup_rejected server_id
+  assert_lookup_rejected root_name
+}

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -719,3 +719,48 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   [[ "$output" == *"[ ] python3 on PATH"* ]]
   [[ "$output" == *"Some checks failed"* ]]
 }
+
+@test "remote pull: a name is enough — no UUID is carried by hand" {
+  # The team_id requirement existed to stand in for authentication, and this
+  # server has none to stand in for. The second machine should never need a
+  # UUID typed across from the first.
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" pulled-team
+  [ "$status" -eq 0 ]
+  local cfg
+  cfg="$TEST_SKILL_DIR/teams/pulled-team/config.json"
+  [ -f "$cfg" ]
+  # And the id still ends up recorded, resolved rather than typed.
+  [ "$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.team_id');")" = "$PULL_TEAM_ID" ]
+}
+
+@test "remote pull: an unknown name fails without inventing a team" {
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" nosuchteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no team named"* ]]
+  [ ! -d "$TEST_SKILL_DIR/teams/nosuchteam" ]
+}
+
+@test "remote pull: two teams sharing a name list the candidates and stop" {
+  # Not bad data — a question only the operator can answer. The listing has to
+  # carry what tells them apart, and must not pull one of them on a guess.
+  MOCK_DUPLICATE_NAME=pulled-team restart_mock_server
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" pulled-team
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"2 teams are named"* ]]
+  [[ "$output" == *"$PULL_TEAM_ID"* ]]
+  [[ "$output" == *"018f3f7e-2222-7000-8000-0000000000ff"* ]]
+  # What distinguishes them, and only from outside the envelope.
+  [[ "$output" == *"registered 2026-07-29"* ]]
+  [[ "$output" == *"registered 2026-07-12"* ]]
+  [[ "$output" == *"messages"* ]]
+  [[ "$output" == *"--team-id"* ]]
+  # Nothing was pulled on a guess.
+  [ ! -d "$TEST_SKILL_DIR/teams/pulled-team" ]
+}
+
+@test "remote pull: --team-id still resolves a shared name" {
+  MOCK_DUPLICATE_NAME=pulled-team restart_mock_server
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" pulled-team
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_SKILL_DIR/teams/pulled-team/config.json" ]
+}


### PR DESCRIPTION
Pulling required a `team_id`, so a human carried a UUID from one machine to the other. That requirement was standing in for authentication, and this server has none to stand in for — reaching it is the permission — so the friction bought nothing.

    remote.sh pull --endpoint <url> apptest

## Same-named teams

A name is not unique; only `team_id` is. Two teams sharing a name is not bad data — it is a question only the operator can answer — so the lookup always returns a list, and the client refuses to guess:

    agmsg: 2 teams are named 'demo' on this server:
      019fac2d-…cb50   registered 2026-07-29   83 messages
      019fb1a4-…77e2   registered 2026-07-12    4 messages
    re-run with --team-id <one of the above>

`--team-id` stays for exactly this case, and for anyone who scripted the old form.

**What the candidates carry is bounded on purpose**: the id to pull with, when the team was registered, and how much history it holds. All of that is operational metadata from outside the envelope. The roster is not there and must not be — it travels inside the envelope, so an e2ee team could not offer it, and a plaintext team offering it anyway would make plaintext the better-featured choice.

## `registered_at`

New column, because nothing recorded when a team was registered and the date is what actually separates two same-named teams — message counts can match.

It is backfilled from the team's **first message**, not the migration clock. Stamping `now()` would date a July team to today, which is a lie told by the very field a human is about to trust. The fill is also restricted to `NULL` rows: retention deletes old messages, so `MIN(server_received_at)` moves forward over time, and this migration file re-runs on every server start — an unrestricted `UPDATE` would push a team's registration date later each restart. A team with no messages falls back to the migration clock, which is all there is.

The column arrives nullable, is filled, and only then becomes `NOT NULL DEFAULT clock_timestamp()`, so the whole file stays safe to re-execute.

## Where the lookup lives

In the engine, beside the existing pre-config snapshot fetch, not in the shell. The shell had neither a GET helper nor URL encoding, and adding both would have been more new surface than reusing the one place that already speaks HTTP. Both public fetches now share a transport rather than repeating the protocol-header and error handling.

`timestampSql` in `storage.ts` becomes a function of the column, matching what `credentials.ts` already had — this file needed it for a second timestamp, and two spellings of one format string is how they drift.

## Tests

61 green in the remote suite. Four new cases: a name alone pulls and still records the resolved id; an unknown name fails without creating a local team; two same-named teams list the candidates, print what distinguishes them, and pull nothing; `--team-id` resolves the ambiguity.

The duplicate-name case asserts the id that **only** the duplicate branch of the mock produces, so it cannot pass while that branch is inactive.

`/Users/Shared/agmsg-dogfood/README.md` step 3 drops the team id, with a note that it is only needed when a name is ambiguous.
