### PR TITLE
Verify age epoch snapshot chains (rollback resistance)

### DIFF
--- a/docs/remote-sync-dogfood.md
+++ b/docs/remote-sync-dogfood.md
@@ -65,7 +65,8 @@ scripts/remote-sync.sh once --team example-team
 
 For an `age-v1` binding, install the standard `age` CLI and provision a
 freshness-confirmed epoch snapshot outside the message server. Identity files
-must be regular files with mode `0600` on POSIX systems. The snapshot is public
+must be regular files with mode `0600` on POSIX systems. The epoch snapshot is
+public
 key material and its file must use compact RFC 8785 JCS; the expanded example
 below shows its minimum initial-epoch data shape:
 
@@ -111,8 +112,8 @@ scripts/remote-sync.sh configure \
 ```
 
 For a rotated team, pass the complete authority-confirmed chain in ascending
-revision order, repeating `--age-snapshot` once per compact JCS snapshot. The
-checkpoint names the final snapshot:
+revision order, repeating `--age-snapshot` once per compact JCS epoch snapshot.
+The checkpoint names the final epoch snapshot:
 
 ```sh
 scripts/remote-sync.sh configure \
@@ -129,19 +130,20 @@ scripts/remote-sync.sh configure \
   --age-identity epoch-2=/secure/path/epoch-2.identity
 ```
 
-Importing a future snapshot does not activate it. The synchronized
+Importing a future epoch snapshot does not activate it. The synchronized
 `key_rotated` record is the activation trigger, and its epoch, key ID,
 recipient fingerprint, and sequence boundary must all match the provisioned
-snapshot. A missing or mismatched snapshot stops synchronization with an
-explicit error before the new epoch is used.
+epoch snapshot. A missing or mismatched epoch snapshot stops synchronization
+with an explicit error before the new epoch is used.
 
 `AGMSG_SYNC_TRUST_DIR` is the retained anti-rollback trust-anchor store. It is
 mandatory for `age-v1`, must be outside `AGMSG_STORAGE_PATH`, and must not be
 deleted by sync-state reset or local-store replacement. The first configuration
 requires `--age-confirmation operator-live`, which records that the operator
 verified the exact revision and digest through a separate live channel. A lower
-revision, same-revision/different-digest snapshot, broken predecessor hash, or
-missing revision is rejected even if the ordinary sync config has been removed.
+revision, same-revision/different-digest epoch snapshot, broken predecessor
+hash, or missing revision is rejected even if the ordinary sync config has
+been removed.
 
 Only the public recipient list crosses the storage-driver seam. The private
 identity path stays in the engine configuration and is used only while opening

--- a/docs/remote-sync-dogfood.md
+++ b/docs/remote-sync-dogfood.md
@@ -110,20 +110,44 @@ scripts/remote-sync.sh configure \
   --age-identity epoch-1=/secure/path/epoch-1.identity
 ```
 
+For a rotated team, pass the complete authority-confirmed chain in ascending
+revision order, repeating `--age-snapshot` once per compact JCS snapshot. The
+checkpoint names the final snapshot:
+
+```sh
+scripts/remote-sync.sh configure \
+  --team example-team \
+  --server https://sync.example \
+  --team-id 018f3f7e-0000-7000-8000-000000000001 \
+  --minimum-security e2ee-required \
+  --cipher age-v1 \
+  --age-snapshot /authenticated/path/epoch-0.json \
+  --age-snapshot /authenticated/path/epoch-1.json \
+  --age-checkpoint '1:CONFIRMED_LOWERCASE_SHA256' \
+  --age-confirmation operator-live \
+  --age-identity epoch-1=/secure/path/epoch-1.identity \
+  --age-identity epoch-2=/secure/path/epoch-2.identity
+```
+
+Importing a future snapshot does not activate it. The synchronized
+`key_rotated` record is the activation trigger, and its epoch, key ID,
+recipient fingerprint, and sequence boundary must all match the provisioned
+snapshot. A missing or mismatched snapshot stops synchronization with an
+explicit error before the new epoch is used.
+
 `AGMSG_SYNC_TRUST_DIR` is the retained anti-rollback trust-anchor store. It is
 mandatory for `age-v1`, must be outside `AGMSG_STORAGE_PATH`, and must not be
 deleted by sync-state reset or local-store replacement. The first configuration
 requires `--age-confirmation operator-live`, which records that the operator
-verified the exact revision and digest through a separate live channel. A later
-same-revision/different-digest snapshot is rejected even if the ordinary sync
-config has been removed.
+verified the exact revision and digest through a separate live channel. A lower
+revision, same-revision/different-digest snapshot, broken predecessor hash, or
+missing revision is rejected even if the ordinary sync config has been removed.
 
 Only the public recipient list crosses the storage-driver seam. The private
 identity path stays in the engine configuration and is used only while opening
-pulled envelopes. The current dogfood command accepts only an initial revision-0
-snapshot. Joining an established rotated binding or rotating an active binding
-requires complete chain verification, quiesce, drain, a server authorization
-fence, and the fresh-boundary procedure in the
+pulled envelopes. Joining an established rotated binding or rotating an active
+binding requires complete chain verification, quiesce, drain, a server
+authorization fence, and the fresh-boundary procedure in the
 [`age-v1` profile](spec/ref/age-v1-profile.md#multi-writer-cutover-protocol), which
 is not yet automated by this client.
 

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -123,8 +123,8 @@ export async function activateKeyRotations(config) {
   if (config.cipher_profile !== "age-v1" || !config.age_v1) {
     throw new Error("key rotation requires an age-v1 sync configuration");
   }
-  const snapshots = ageSnapshotChain(config.age_v1);
-  const base = snapshots[0].history;
+  const ageSnapshots = ageSnapshotChain(config.age_v1);
+  const base = ageSnapshots[0].history;
   let revision = BigInt(base.at(-1).epoch_revision);
   const winners = [];
   const announcedEpochs = new Set();
@@ -147,8 +147,8 @@ export async function activateKeyRotations(config) {
       throw new Error(
         `key rotation epoch ${rotation.epoch} is not the next epoch ${expectedRevision}`);
     }
-    const snapshot = snapshots[Number(expectedRevision)];
-    if (!snapshot) {
+    const ageSnapshot = ageSnapshots[Number(expectedRevision)];
+    if (!ageSnapshot) {
       throw new Error(
         `key rotation at server sequence ${rotation.server_seq} selected epoch ` +
         `${rotation.epoch}; import its authority-confirmed epoch snapshot before sync can continue`);
@@ -156,7 +156,7 @@ export async function activateKeyRotations(config) {
     if (BigInt(rotation.server_seq) === MAX_SEQUENCE) {
       throw new Error("key rotation cannot be activated at the final server sequence");
     }
-    const epoch = snapshot.history.at(-1);
+    const epoch = ageSnapshot.history.at(-1);
     const effectiveFrom = (BigInt(rotation.server_seq) + 1n).toString();
     if (epoch.epoch_revision !== rotation.epoch ||
         epoch.key_id !== rotation.key_id ||
@@ -356,21 +356,21 @@ function requireUnicodeScalars(value, label) {
 function canonicalJson(value) {
   if (value === null || typeof value === "boolean") return JSON.stringify(value);
   if (typeof value === "string") {
-    requireUnicodeScalars(value, "snapshot string");
+    requireUnicodeScalars(value, "age snapshot string");
     return JSON.stringify(value);
   }
   if (typeof value === "number") {
-    if (!Number.isFinite(value)) throw new Error("snapshot contains a non-finite number");
+    if (!Number.isFinite(value)) throw new Error("age snapshot contains a non-finite number");
     return JSON.stringify(value);
   }
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
   if (typeof value === "object") {
     return `{${Object.keys(value).sort().map((key) => {
-      requireUnicodeScalars(key, "snapshot key");
+      requireUnicodeScalars(key, "age snapshot key");
       return `${JSON.stringify(key)}:${canonicalJson(value[key])}`;
     }).join(",")}}`;
   }
-  throw new Error("snapshot contains a non-JSON value");
+  throw new Error("age snapshot contains a non-JSON value");
 }
 
 export function ageSnapshotDigest(value) {
@@ -403,46 +403,52 @@ function validateLocalSecurityHistory(history) {
 
 export function validateAgeConfiguration(config) {
   const age = config.age_v1;
-  const snapshots = ageSnapshotChain(age);
-  const snapshot = snapshots.at(-1);
+  const ageSnapshots = ageSnapshotChain(age);
+  const latestAgeSnapshot = ageSnapshots.at(-1);
   const checkpoint = age?.checkpoint;
-  if (!age || snapshots.length < 1 || snapshots.length > 4096 || !checkpoint ||
+  if (!age || ageSnapshots.length < 1 || ageSnapshots.length > 4096 || !checkpoint ||
       !age.identity_files || typeof age.identity_files !== "object" || Array.isArray(age.identity_files) ||
       Object.entries(age.identity_files).some(([keyId, path]) =>
         !/^[a-z0-9][a-z0-9._-]{0,63}$/u.test(keyId) || typeof path !== "string" || path.length < 1) ||
       typeof age.age_version !== "string" || age.age_version.length < 1) {
     throw new Error("age-v1 configuration is invalid");
   }
-  let previousSnapshot;
+  let previousAgeSnapshot;
   let previousGeneration = -1n;
   const recipientManifests = new Map();
-  for (let snapshotIndex = 0; snapshotIndex < snapshots.length; snapshotIndex += 1) {
-    const item = snapshots[snapshotIndex];
-    if (!item || item.profile !== "age-v1" ||
-        item.server_instance_id !== config.server_instance_id ||
-        item.team_id !== config.remote_team_id ||
-        !Array.isArray(item.authorized_writers) || item.authorized_writers.length < 1 ||
-        new Set(item.authorized_writers).size !== item.authorized_writers.length ||
-        item.authorized_writers.some((writer) => typeof writer !== "string" || writer.length < 1) ||
-        !Array.isArray(item.history) || item.history.length < 1 || item.history.length > 4096) {
+  for (let ageSnapshotIndex = 0;
+    ageSnapshotIndex < ageSnapshots.length;
+    ageSnapshotIndex += 1) {
+    const ageSnapshot = ageSnapshots[ageSnapshotIndex];
+    if (!ageSnapshot || ageSnapshot.profile !== "age-v1" ||
+        ageSnapshot.server_instance_id !== config.server_instance_id ||
+        ageSnapshot.team_id !== config.remote_team_id ||
+        !Array.isArray(ageSnapshot.authorized_writers) ||
+        ageSnapshot.authorized_writers.length < 1 ||
+        new Set(ageSnapshot.authorized_writers).size !== ageSnapshot.authorized_writers.length ||
+        ageSnapshot.authorized_writers.some((writer) =>
+          typeof writer !== "string" || writer.length < 1) ||
+        !Array.isArray(ageSnapshot.history) || ageSnapshot.history.length < 1 ||
+        ageSnapshot.history.length > 4096) {
       throw new Error("age epoch snapshot is invalid");
     }
-    const snapshotRevision = BigInt(sequence(item.epoch_revision, "epoch_revision"));
-    const writerGeneration = BigInt(sequence(item.writer_generation, "writer_generation"));
-    if (snapshotRevision !== BigInt(snapshotIndex)) {
+    const ageSnapshotRevision = BigInt(
+      sequence(ageSnapshot.epoch_revision, "epoch_revision"));
+    const writerGeneration = BigInt(sequence(ageSnapshot.writer_generation, "writer_generation"));
+    if (ageSnapshotRevision !== BigInt(ageSnapshotIndex)) {
       throw new Error("age epoch snapshot chain has a missing revision");
     }
     if (writerGeneration <= previousGeneration) {
       throw new Error("age epoch snapshot writer generation is not strictly increasing");
     }
-    const expectedPrevious = previousSnapshot ? ageSnapshotDigest(previousSnapshot) : null;
-    if (item.previous_snapshot_sha256 !== expectedPrevious) {
+    const expectedPrevious = previousAgeSnapshot ? ageSnapshotDigest(previousAgeSnapshot) : null;
+    if (ageSnapshot.previous_snapshot_sha256 !== expectedPrevious) {
       throw new Error("age epoch snapshot hash chain is broken");
     }
     let priorRevision = -1n;
     let priorBoundary = 0n;
-    for (let historyIndex = 0; historyIndex < item.history.length; historyIndex += 1) {
-      const entry = item.history[historyIndex];
+    for (let historyIndex = 0; historyIndex < ageSnapshot.history.length; historyIndex += 1) {
+      const entry = ageSnapshot.history[historyIndex];
       const revision = BigInt(sequence(entry.epoch_revision, "epoch history revision"));
       const boundary = BigInt(sequence(entry.effective_from_seq, "epoch history boundary"));
       if (revision !== BigInt(historyIndex) || boundary <= priorBoundary ||
@@ -464,29 +470,31 @@ export function validateAgeConfiguration(config) {
       priorRevision = revision;
       priorBoundary = boundary;
     }
-    if (item.history[0].effective_from_seq !== "1" ||
-        priorRevision !== snapshotRevision ||
-        (previousSnapshot &&
-          canonicalJson(item.history.slice(0, -1)) !== canonicalJson(previousSnapshot.history))) {
+    if (ageSnapshot.history[0].effective_from_seq !== "1" ||
+        priorRevision !== ageSnapshotRevision ||
+        (previousAgeSnapshot &&
+          canonicalJson(ageSnapshot.history.slice(0, -1)) !==
+            canonicalJson(previousAgeSnapshot.history))) {
       throw new Error("age epoch snapshot does not contain the complete immutable history");
     }
-    previousSnapshot = item;
+    previousAgeSnapshot = ageSnapshot;
     previousGeneration = writerGeneration;
   }
-  const digest = ageSnapshotDigest(snapshot);
-  if (checkpoint.epoch_revision !== snapshot.epoch_revision || checkpoint.snapshot_sha256 !== digest ||
-      checkpoint.writer_generation !== snapshot.writer_generation ||
+  const digest = ageSnapshotDigest(latestAgeSnapshot);
+  if (checkpoint.epoch_revision !== latestAgeSnapshot.epoch_revision ||
+      checkpoint.snapshot_sha256 !== digest ||
+      checkpoint.writer_generation !== latestAgeSnapshot.writer_generation ||
       typeof checkpoint.confirmed_at !== "string" || Number.isNaN(Date.parse(checkpoint.confirmed_at))) {
-    throw new Error("age epoch checkpoint does not match the snapshot");
+    throw new Error("age epoch checkpoint does not match the epoch snapshot");
   }
   return digest;
 }
 
 export function validateConfiguredAgeIdentities(config) {
-  const snapshot = ageSnapshotChain(config.age_v1).at(-1);
+  const latestAgeSnapshot = ageSnapshotChain(config.age_v1).at(-1);
   for (const [keyId, path] of Object.entries(config.age_v1.identity_files)) {
     const identity = readNativeAgeIdentity(path);
-    const matchingEpochs = snapshot.history.filter((entry) => entry.key_id === keyId);
+    const matchingEpochs = latestAgeSnapshot.history.filter((entry) => entry.key_id === keyId);
     if (matchingEpochs.length < 1 || matchingEpochs.some((entry) => !entry.recipients.includes(identity.recipient))) {
       throw new Error(`age identity for ${keyId} does not match its recipient manifest`);
     }
@@ -523,12 +531,12 @@ function compareRetainedCheckpoint(config, retained) {
   const proposedRevision = BigInt(sequence(proposed.epoch_revision, "proposed epoch revision"));
   const retainedGeneration = BigInt(sequence(retained.writer_generation, "retained writer generation"));
   const proposedGeneration = BigInt(sequence(proposed.writer_generation, "proposed writer generation"));
-  const retainedSnapshot = ageSnapshotChain(config.age_v1)
-    .find((snapshot) => snapshot.epoch_revision === retained.epoch_revision);
+  const retainedAgeSnapshot = ageSnapshotChain(config.age_v1)
+    .find((ageSnapshot) => ageSnapshot.epoch_revision === retained.epoch_revision);
   if (proposedRevision < retainedRevision || proposedGeneration < retainedGeneration ||
-      !retainedSnapshot ||
-      ageSnapshotDigest(retainedSnapshot) !== retained.snapshot_sha256 ||
-      retainedSnapshot.writer_generation !== retained.writer_generation) {
+      !retainedAgeSnapshot ||
+      ageSnapshotDigest(retainedAgeSnapshot) !== retained.snapshot_sha256 ||
+      retainedAgeSnapshot.writer_generation !== retained.writer_generation) {
     throw new Error("age checkpoint rollback or same-revision conflict detected");
   }
   if (proposedRevision === retainedRevision &&
@@ -1384,26 +1392,26 @@ export async function configure(args) {
     if (!args["age-snapshot"] || !args["age-checkpoint"]) {
       throw new Error("age-v1 requires --age-snapshot and --age-checkpoint");
     }
-    const snapshotPaths = Array.isArray(args["age-snapshot"]) ?
+    const ageSnapshotPaths = Array.isArray(args["age-snapshot"]) ?
       args["age-snapshot"] : [args["age-snapshot"]];
-    const snapshots = [];
-    for (const snapshotPath of snapshotPaths) {
-      const snapshotText = await readFile(resolve(snapshotPath), "utf8");
-      const snapshot = parseStrictJson(snapshotText);
-      if (snapshotText.trim() !== canonicalJson(snapshot)) {
+    const ageSnapshots = [];
+    for (const ageSnapshotPath of ageSnapshotPaths) {
+      const ageSnapshotText = await readFile(resolve(ageSnapshotPath), "utf8");
+      const ageSnapshot = parseStrictJson(ageSnapshotText);
+      if (ageSnapshotText.trim() !== canonicalJson(ageSnapshot)) {
         throw new Error("age snapshot must be RFC 8785 JCS without duplicate or noncanonical fields");
       }
-      snapshots.push(snapshot);
+      ageSnapshots.push(ageSnapshot);
     }
-    const snapshot = snapshots.at(-1);
+    const latestAgeSnapshot = ageSnapshots.at(-1);
     const checkpoint = parseCheckpoint(args["age-checkpoint"]);
     const confirmation = args["age-confirmation"];
     if (confirmation !== "operator-live") {
       throw new Error("age-v1 requires explicit --age-confirmation operator-live");
     }
     config.age_v1 = {
-      epoch_snapshots: snapshots,
-      checkpoint: { ...checkpoint, writer_generation: snapshot.writer_generation,
+      epoch_snapshots: ageSnapshots,
+      checkpoint: { ...checkpoint, writer_generation: latestAgeSnapshot.writer_generation,
         confirmed_at: new Date().toISOString() },
       identity_files: await identityFiles(args["age-identity"]),
       age_version: ageExecutableVersion(),
@@ -1926,13 +1934,13 @@ export async function pullBootstrap(args, dependencies = {}) {
 
   // There is no connected binding yet, so this one call validates itself
   // rather than going through the checks the rest of the pull relies on.
-  const snapshot = await publicSnapshotCall(serverUrl, teamId);
+  const teamSnapshot = await publicSnapshotCall(serverUrl, teamId);
   const config = {
     format_version: 1,
     local_team: team,
     server_url: serverUrl,
-    server_instance_id: snapshot.server_instance_id,
-    remote_team_id: snapshot.team_id,
+    server_instance_id: teamSnapshot.server_instance_id,
+    remote_team_id: teamSnapshot.team_id,
     protocol_version: Number(PROTOCOL),
     cipher_profile: "none",
     local_security_history: [{
@@ -1941,11 +1949,11 @@ export async function pullBootstrap(args, dependencies = {}) {
     }],
   };
   await eventCall("pull.bootstrap.snapshot", {
-    team_id: snapshot.team_id, team_name: snapshot.team_name,
-    min_available_seq: snapshot.min_available_seq,
+    team_id: teamSnapshot.team_id, team_name: teamSnapshot.team_name,
+    min_available_seq: teamSnapshot.min_available_seq,
   });
 
-  let cursor = String(snapshot.min_available_seq ?? "0");
+  let cursor = String(teamSnapshot.min_available_seq ?? "0");
   let imported = 0;
   for (;;) {
     const page = await requestPublicCall(config,
@@ -1953,7 +1961,7 @@ export async function pullBootstrap(args, dependencies = {}) {
     const records = [];
     for (const message of page.messages) {
       records.push({ type: "sync_pull_message", ...message,
-        ...(await evaluateCall(config, snapshot, message)) });
+        ...(await evaluateCall(config, teamSnapshot, message)) });
     }
     const cursorRecord = { type: "sync_pull_cursor", next_after: page.next_after };
     const rosterRecords = records.filter((record) =>
@@ -1977,14 +1985,14 @@ export async function pullBootstrap(args, dependencies = {}) {
   }
   process.stdout.write(`${JSON.stringify({
     type: "pull_bootstrap_result", team: config.local_team,
-    team_id: config.remote_team_id, team_name: snapshot.team_name,
+    team_id: config.remote_team_id, team_name: teamSnapshot.team_name,
     server_instance_id: config.server_instance_id,
     // The binding the second machine records so it keeps syncing (the design's
     // "and continues"): the same capability snapshot connect stores, plus the
     // protocol version. Without it the pulled team has no connected binding and
     // the sync engine refuses to run.
     protocol_version: config.protocol_version,
-    capabilities: snapshot,
+    capabilities: teamSnapshot,
     imported,
   })}\n`);
 }

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -23,7 +23,8 @@ const MAX_CONNECTION_CONFIG_BYTES = 2 * 1024 * 1024;
 function usage() {
   return `usage:
   remote-sync.sh configure --team NAME --server URL --team-id UUID --minimum-security e2ee-required \\
-    --cipher age-v1 --age-snapshot FILE --age-checkpoint REVISION:SHA256 \\
+    --cipher age-v1 --age-snapshot FILE [--age-snapshot FILE ...] \\
+    --age-checkpoint REVISION:SHA256 \\
     --age-confirmation operator-live \\
     [--age-identity KEY_ID=FILE ...]
   remote-sync.sh once --team NAME [--limit N]
@@ -45,7 +46,7 @@ function options(args) {
     const next = args[index + 1];
     if (next === undefined || next.startsWith("--")) throw new Error(`missing value for ${value}`);
     const key = value.slice(2);
-    if (key === "age-identity") {
+    if (key === "age-identity" || key === "age-snapshot") {
       if (!Array.isArray(result[key])) result[key] = [];
       result[key].push(next);
     } else {
@@ -122,7 +123,8 @@ export async function activateKeyRotations(config) {
   if (config.cipher_profile !== "age-v1" || !config.age_v1) {
     throw new Error("key rotation requires an age-v1 sync configuration");
   }
-  const base = config.age_v1.epoch_snapshot.history;
+  const snapshots = ageSnapshotChain(config.age_v1);
+  const base = snapshots[0].history;
   let revision = BigInt(base.at(-1).epoch_revision);
   const winners = [];
   const announcedEpochs = new Set();
@@ -145,8 +147,26 @@ export async function activateKeyRotations(config) {
       throw new Error(
         `key rotation epoch ${rotation.epoch} is not the next epoch ${expectedRevision}`);
     }
+    const snapshot = snapshots[Number(expectedRevision)];
+    if (!snapshot) {
+      throw new Error(
+        `key rotation at server sequence ${rotation.server_seq} selected epoch ` +
+        `${rotation.epoch}; import its authority-confirmed epoch snapshot before sync can continue`);
+    }
     if (BigInt(rotation.server_seq) === MAX_SEQUENCE) {
       throw new Error("key rotation cannot be activated at the final server sequence");
+    }
+    const epoch = snapshot.history.at(-1);
+    const effectiveFrom = (BigInt(rotation.server_seq) + 1n).toString();
+    if (epoch.epoch_revision !== rotation.epoch ||
+        epoch.key_id !== rotation.key_id ||
+        epoch.effective_from_seq !== effectiveFrom ||
+        epoch.recipients.length !== 1 ||
+        createHash("sha256").update(epoch.recipients[0], "utf8").digest("hex") !==
+          rotation.fingerprint) {
+      throw new Error(
+        `authority-confirmed epoch snapshot ${rotation.epoch} does not match ` +
+        `the key rotation at server sequence ${rotation.server_seq}`);
     }
     const identityPath = replacementIdentityPath(config.local_team, rotation.key_id);
     try {
@@ -161,24 +181,14 @@ export async function activateKeyRotations(config) {
       throw error;
     }
     const identity = readNativeAgeIdentity(identityPath);
-    const fingerprint = createHash("sha256").update(identity.recipient, "utf8").digest("hex");
-    if (fingerprint !== rotation.fingerprint) {
+    if (identity.recipient !== epoch.recipients[0]) {
       throw new Error(
-        `replacement key ${rotation.key_id} for epoch ${rotation.epoch} does not match the announced fingerprint`);
+        `replacement key ${rotation.key_id} for epoch ${rotation.epoch} does not match ` +
+        "the authority-confirmed recipient manifest");
     }
     revision = expectedRevision;
     config.age_v1.identity_files[rotation.key_id] = identityPath;
-    runtime.push({
-      epoch_revision: rotation.epoch,
-      // The announcement itself is sealed with the old epoch so a removed
-      // holder can learn that rotation happened without receiving the new
-      // key. The first envelope that uses the replacement is therefore the
-      // sequence immediately after the announcement.
-      effective_from_seq: (BigInt(rotation.server_seq) + 1n).toString(),
-      cipher: "age-v1",
-      key_id: rotation.key_id,
-      recipients: [identity.recipient],
-    });
+    runtime.push(epoch);
   }
   config.age_v1_runtime_history = runtime;
 }
@@ -367,6 +377,11 @@ export function ageSnapshotDigest(value) {
   return createHash("sha256").update(canonicalJson(value), "utf8").digest("hex");
 }
 
+function ageSnapshotChain(age) {
+  if (Array.isArray(age?.epoch_snapshots)) return age.epoch_snapshots;
+  return age?.epoch_snapshot ? [age.epoch_snapshot] : [];
+}
+
 function validateLocalSecurityHistory(history) {
   if (!Array.isArray(history) || history.length < 1 || history.length > 4096) {
     throw new Error("local security history is invalid");
@@ -388,48 +403,75 @@ function validateLocalSecurityHistory(history) {
 
 export function validateAgeConfiguration(config) {
   const age = config.age_v1;
-  const snapshot = age?.epoch_snapshot;
+  const snapshots = ageSnapshotChain(age);
+  const snapshot = snapshots.at(-1);
   const checkpoint = age?.checkpoint;
-  if (!age || !snapshot || !checkpoint || snapshot.profile !== "age-v1" ||
-      snapshot.server_instance_id !== config.server_instance_id || snapshot.team_id !== config.remote_team_id ||
-      !Array.isArray(snapshot.authorized_writers) || snapshot.authorized_writers.length < 1 ||
-      new Set(snapshot.authorized_writers).size !== snapshot.authorized_writers.length ||
-      snapshot.authorized_writers.some((writer) => typeof writer !== "string" || writer.length < 1) ||
-      !Array.isArray(snapshot.history) || snapshot.history.length < 1 || snapshot.history.length > 4096 ||
+  if (!age || snapshots.length < 1 || snapshots.length > 4096 || !checkpoint ||
       !age.identity_files || typeof age.identity_files !== "object" || Array.isArray(age.identity_files) ||
       Object.entries(age.identity_files).some(([keyId, path]) =>
         !/^[a-z0-9][a-z0-9._-]{0,63}$/u.test(keyId) || typeof path !== "string" || path.length < 1) ||
       typeof age.age_version !== "string" || age.age_version.length < 1) {
     throw new Error("age-v1 configuration is invalid");
   }
-  const snapshotRevision = sequence(snapshot.epoch_revision, "epoch_revision");
-  sequence(snapshot.writer_generation, "writer_generation");
-  if (snapshotRevision !== "0") {
-    throw new Error("age-v1 dogfood currently accepts only an initial revision-0 epoch snapshot");
-  }
-  if ((snapshotRevision === "0" && snapshot.previous_snapshot_sha256 !== null) ||
-      (snapshotRevision !== "0" && (typeof snapshot.previous_snapshot_sha256 !== "string" ||
-        !/^[0-9a-f]{64}$/u.test(snapshot.previous_snapshot_sha256)))) {
-    throw new Error("epoch snapshot previous digest is invalid");
-  }
-  let priorRevision = -1n;
-  let priorBoundary = 0n;
-  for (const entry of snapshot.history) {
-    const revision = BigInt(sequence(entry.epoch_revision, "epoch history revision"));
-    const boundary = BigInt(sequence(entry.effective_from_seq, "epoch history boundary"));
-    if (revision <= priorRevision || boundary <= priorBoundary || entry.cipher !== "age-v1" ||
-        typeof entry.key_id !== "string" || !/^[a-z0-9][a-z0-9._-]{0,63}$/u.test(entry.key_id) ||
-        !Array.isArray(entry.recipients) || entry.recipients.length < 1 || entry.recipients.length > 256 ||
-        new Set(entry.recipients).size !== entry.recipients.length ||
-        entry.recipients.some((recipient) => typeof recipient !== "string" || !/^age1[0-9a-z]{58}$/u.test(recipient))) {
-      throw new Error("age epoch history is not canonical");
+  let previousSnapshot;
+  let previousGeneration = -1n;
+  const recipientManifests = new Map();
+  for (let snapshotIndex = 0; snapshotIndex < snapshots.length; snapshotIndex += 1) {
+    const item = snapshots[snapshotIndex];
+    if (!item || item.profile !== "age-v1" ||
+        item.server_instance_id !== config.server_instance_id ||
+        item.team_id !== config.remote_team_id ||
+        !Array.isArray(item.authorized_writers) || item.authorized_writers.length < 1 ||
+        new Set(item.authorized_writers).size !== item.authorized_writers.length ||
+        item.authorized_writers.some((writer) => typeof writer !== "string" || writer.length < 1) ||
+        !Array.isArray(item.history) || item.history.length < 1 || item.history.length > 4096) {
+      throw new Error("age epoch snapshot is invalid");
     }
-    priorRevision = revision;
-    priorBoundary = boundary;
-  }
-  if (snapshot.history[0].effective_from_seq !== "1" ||
-      snapshot.history.at(-1).epoch_revision !== snapshot.epoch_revision) {
-    throw new Error("age epoch history does not cover the snapshot revision");
+    const snapshotRevision = BigInt(sequence(item.epoch_revision, "epoch_revision"));
+    const writerGeneration = BigInt(sequence(item.writer_generation, "writer_generation"));
+    if (snapshotRevision !== BigInt(snapshotIndex)) {
+      throw new Error("age epoch snapshot chain has a missing revision");
+    }
+    if (writerGeneration <= previousGeneration) {
+      throw new Error("age epoch snapshot writer generation is not strictly increasing");
+    }
+    const expectedPrevious = previousSnapshot ? ageSnapshotDigest(previousSnapshot) : null;
+    if (item.previous_snapshot_sha256 !== expectedPrevious) {
+      throw new Error("age epoch snapshot hash chain is broken");
+    }
+    let priorRevision = -1n;
+    let priorBoundary = 0n;
+    for (let historyIndex = 0; historyIndex < item.history.length; historyIndex += 1) {
+      const entry = item.history[historyIndex];
+      const revision = BigInt(sequence(entry.epoch_revision, "epoch history revision"));
+      const boundary = BigInt(sequence(entry.effective_from_seq, "epoch history boundary"));
+      if (revision !== BigInt(historyIndex) || boundary <= priorBoundary ||
+          entry.cipher !== "age-v1" ||
+          typeof entry.key_id !== "string" || !/^[a-z0-9][a-z0-9._-]{0,63}$/u.test(entry.key_id) ||
+          !Array.isArray(entry.recipients) || entry.recipients.length < 1 ||
+          entry.recipients.length > 256 ||
+          new Set(entry.recipients).size !== entry.recipients.length ||
+          entry.recipients.some((recipient) =>
+            typeof recipient !== "string" || !/^age1[0-9a-z]{58}$/u.test(recipient))) {
+        throw new Error("age epoch history is not canonical");
+      }
+      const manifest = canonicalJson(entry.recipients);
+      const existingManifest = recipientManifests.get(entry.key_id);
+      if (existingManifest !== undefined && existingManifest !== manifest) {
+        throw new Error("age key_id is bound to conflicting recipient manifests");
+      }
+      recipientManifests.set(entry.key_id, manifest);
+      priorRevision = revision;
+      priorBoundary = boundary;
+    }
+    if (item.history[0].effective_from_seq !== "1" ||
+        priorRevision !== snapshotRevision ||
+        (previousSnapshot &&
+          canonicalJson(item.history.slice(0, -1)) !== canonicalJson(previousSnapshot.history))) {
+      throw new Error("age epoch snapshot does not contain the complete immutable history");
+    }
+    previousSnapshot = item;
+    previousGeneration = writerGeneration;
   }
   const digest = ageSnapshotDigest(snapshot);
   if (checkpoint.epoch_revision !== snapshot.epoch_revision || checkpoint.snapshot_sha256 !== digest ||
@@ -441,9 +483,10 @@ export function validateAgeConfiguration(config) {
 }
 
 export function validateConfiguredAgeIdentities(config) {
+  const snapshot = ageSnapshotChain(config.age_v1).at(-1);
   for (const [keyId, path] of Object.entries(config.age_v1.identity_files)) {
     const identity = readNativeAgeIdentity(path);
-    const matchingEpochs = config.age_v1.epoch_snapshot.history.filter((entry) => entry.key_id === keyId);
+    const matchingEpochs = snapshot.history.filter((entry) => entry.key_id === keyId);
     if (matchingEpochs.length < 1 || matchingEpochs.some((entry) => !entry.recipients.includes(identity.recipient))) {
       throw new Error(`age identity for ${keyId} does not match its recipient manifest`);
     }
@@ -468,21 +511,32 @@ function compareRetainedCheckpoint(config, retained) {
   const proposed = checkpointRecord(config, retained.confirmation?.method);
   if (retained.format_version !== 1 || retained.profile !== "age-v1" ||
       retained.server_instance_id !== proposed.server_instance_id || retained.team_id !== proposed.team_id ||
-      retained.protocol_version !== proposed.protocol_version || retained.confirmation?.method !== "operator-live") {
+      retained.protocol_version !== proposed.protocol_version ||
+      typeof retained.snapshot_sha256 !== "string" ||
+      !/^[0-9a-f]{64}$/u.test(retained.snapshot_sha256) ||
+      retained.confirmation?.method !== "operator-live" ||
+      typeof retained.confirmation.confirmed_at !== "string" ||
+      Number.isNaN(Date.parse(retained.confirmation.confirmed_at))) {
     throw new Error("retained age checkpoint is invalid");
   }
   const retainedRevision = BigInt(sequence(retained.epoch_revision, "retained epoch revision"));
   const proposedRevision = BigInt(sequence(proposed.epoch_revision, "proposed epoch revision"));
   const retainedGeneration = BigInt(sequence(retained.writer_generation, "retained writer generation"));
   const proposedGeneration = BigInt(sequence(proposed.writer_generation, "proposed writer generation"));
+  const retainedSnapshot = ageSnapshotChain(config.age_v1)
+    .find((snapshot) => snapshot.epoch_revision === retained.epoch_revision);
   if (proposedRevision < retainedRevision || proposedGeneration < retainedGeneration ||
-      (proposedRevision === retainedRevision && retained.snapshot_sha256 !== proposed.snapshot_sha256)) {
+      !retainedSnapshot ||
+      ageSnapshotDigest(retainedSnapshot) !== retained.snapshot_sha256 ||
+      retainedSnapshot.writer_generation !== retained.writer_generation) {
     throw new Error("age checkpoint rollback or same-revision conflict detected");
   }
-  if (proposedRevision !== retainedRevision || proposedGeneration !== retainedGeneration) {
-    throw new Error("age checkpoint advancement requires the fenced rotation workflow");
+  if (proposedRevision === retainedRevision &&
+      (proposed.snapshot_sha256 !== retained.snapshot_sha256 ||
+       proposedGeneration !== retainedGeneration)) {
+    throw new Error("age checkpoint rollback or same-revision conflict detected");
   }
-  return retained;
+  return proposedRevision === retainedRevision ? "same" : "advance";
 }
 
 async function readRetainedCheckpointFile(path) {
@@ -491,18 +545,43 @@ async function readRetainedCheckpointFile(path) {
       (process.platform !== "win32" && (metadata.mode & 0o077) !== 0)) {
     throw new Error("retained age checkpoint must be a private regular file");
   }
-  return JSON.parse(await readFile(path, "utf8"));
+  const records = parseStrictJsonl(await readFile(path, "utf8"));
+  if (records.length < 1 || records.length > 4096) {
+    throw new Error("retained age checkpoint history is invalid");
+  }
+  return records;
 }
 
 export async function retainAgeCheckpoint(config, confirmation) {
   const path = ageTrustPath(config);
+  let records;
   try {
-    return compareRetainedCheckpoint(config, await readRetainedCheckpointFile(path));
+    records = await readRetainedCheckpointFile(path);
   } catch (error) {
     if (error?.code !== "ENOENT") throw error;
   }
   if (confirmation !== "operator-live") {
-    throw new Error("initial age checkpoint requires --age-confirmation operator-live");
+    throw new Error("age checkpoint import requires --age-confirmation operator-live");
+  }
+  if (records) {
+    let current;
+    for (const retained of records) {
+      const relation = compareRetainedCheckpoint(config, retained);
+      if (relation === "same") current = retained;
+    }
+    if (current) return current;
+    if (records.length >= 4096) {
+      throw new Error("retained age checkpoint history reached the 4096 entry limit");
+    }
+    const retained = checkpointRecord(config, confirmation);
+    const handle = await open(path, "a", 0o600);
+    try {
+      await handle.writeFile(`${JSON.stringify(retained)}\n`, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    return retained;
   }
   const retained = checkpointRecord(config, confirmation);
   await mkdir(dirname(path), { recursive: true, mode: 0o700 });
@@ -530,13 +609,19 @@ export async function retainAgeCheckpoint(config, confirmation) {
     return retained;
   } catch (error) {
     if (error?.code !== "EEXIST") throw error;
-    return compareRetainedCheckpoint(config, await readRetainedCheckpointFile(path));
+    return retainAgeCheckpoint(config, confirmation);
   }
 }
 
 export async function validateRetainedAgeCheckpoint(config) {
-  const retained = await readRetainedCheckpointFile(ageTrustPath(config));
-  compareRetainedCheckpoint(config, retained);
+  const records = await readRetainedCheckpointFile(ageTrustPath(config));
+  let retained;
+  for (const record of records) {
+    if (compareRetainedCheckpoint(config, record) === "same") retained = record;
+  }
+  if (!retained) {
+    throw new Error("sync config is behind the retained age checkpoint");
+  }
   if (retained.confirmation.confirmed_at !== config.age_v1.checkpoint.confirmed_at) {
     throw new Error("sync config does not match the retained age checkpoint confirmation");
   }
@@ -810,8 +895,9 @@ function currentLocalPolicy(config, serverSeq) {
 }
 
 function ageHistory(config) {
+  const initial = ageSnapshotChain(config.age_v1)[0]?.history ?? [];
   return [
-    ...(config.age_v1?.epoch_snapshot?.history ?? []),
+    ...initial,
     ...(config.age_v1_runtime_history ?? []),
   ];
 }
@@ -1298,18 +1384,25 @@ export async function configure(args) {
     if (!args["age-snapshot"] || !args["age-checkpoint"]) {
       throw new Error("age-v1 requires --age-snapshot and --age-checkpoint");
     }
-    const snapshotText = await readFile(resolve(args["age-snapshot"]), "utf8");
-    const snapshot = JSON.parse(snapshotText);
-    if (snapshotText.trim() !== canonicalJson(snapshot)) {
-      throw new Error("age snapshot must be RFC 8785 JCS without duplicate or noncanonical fields");
+    const snapshotPaths = Array.isArray(args["age-snapshot"]) ?
+      args["age-snapshot"] : [args["age-snapshot"]];
+    const snapshots = [];
+    for (const snapshotPath of snapshotPaths) {
+      const snapshotText = await readFile(resolve(snapshotPath), "utf8");
+      const snapshot = parseStrictJson(snapshotText);
+      if (snapshotText.trim() !== canonicalJson(snapshot)) {
+        throw new Error("age snapshot must be RFC 8785 JCS without duplicate or noncanonical fields");
+      }
+      snapshots.push(snapshot);
     }
+    const snapshot = snapshots.at(-1);
     const checkpoint = parseCheckpoint(args["age-checkpoint"]);
     const confirmation = args["age-confirmation"];
     if (confirmation !== "operator-live") {
       throw new Error("age-v1 requires explicit --age-confirmation operator-live");
     }
     config.age_v1 = {
-      epoch_snapshot: snapshot,
+      epoch_snapshots: snapshots,
       checkpoint: { ...checkpoint, writer_generation: snapshot.writer_generation,
         confirmed_at: new Date().toISOString() },
       identity_files: await identityFiles(args["age-identity"]),
@@ -1325,12 +1418,6 @@ export async function configure(args) {
   if (previous && (previous.server_instance_id !== config.server_instance_id ||
       previous.remote_team_id !== config.remote_team_id || previous.cipher_profile !== config.cipher_profile)) {
     throw new Error("configure cannot replace an existing binding or cipher profile");
-  }
-  if (previous?.cipher_profile === "age-v1" &&
-      (previous.age_v1.checkpoint.epoch_revision !== config.age_v1.checkpoint.epoch_revision ||
-       previous.age_v1.checkpoint.snapshot_sha256 !== config.age_v1.checkpoint.snapshot_sha256 ||
-       previous.age_v1.checkpoint.writer_generation !== config.age_v1.checkpoint.writer_generation)) {
-    throw new Error("age epoch changes require the fenced cutover procedure");
   }
   const capabilities = await request(config, "/v1/capabilities");
   validateCapabilities(config, capabilities);

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -11,9 +11,10 @@ set -euo pipefail
 # docs/spec/ref/age-v1-profile.md). Scope: initial single-writer onboarding
 # (generate the very first key, import one obtained out-of-band, or announce a
 # replacement through the team journal).
-# This script does not implement age-v1's anti-rollback epoch-snapshot hash
-# chain. Rotation protects messages written after the acknowledged boundary;
-# anyone who retained an old key can still read the history encrypted with it.
+# Authority-confirmed epoch snapshots are imported separately through
+# remote-sync configure. Rotation protects messages written after the
+# acknowledged boundary; anyone who retained an old key can still read the
+# history encrypted with it.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -876,10 +876,10 @@ test("age-v1 write selection exposes only public epoch material", () => {
   assert.equal(JSON.stringify(selected).includes("identity"), false);
 });
 
-test("age-v1 configuration verifies the complete snapshot hash chain", () => {
+test("age-v1 configuration verifies the complete epoch snapshot hash chain", () => {
   assert.throws(() => ageSnapshotDigest({ bad: "\ud800" }), /lone surrogate/u);
   assert.throws(() => ageSnapshotDigest({ ["\udc00"]: "bad-key" }), /lone surrogate/u);
-  const snapshot = {
+  const initialAgeSnapshot = {
     profile: "age-v1",
     server_instance_id: config.server_instance_id,
     team_id: config.remote_team_id,
@@ -893,9 +893,10 @@ test("age-v1 configuration verifies the complete snapshot hash chain", () => {
       ] }],
   };
   const ageConfig = { ...config, cipher_profile: "age-v1", age_v1: {
-    epoch_snapshot: snapshot,
+    epoch_snapshot: initialAgeSnapshot,
     checkpoint: { epoch_revision: "0", writer_generation: "0",
-      snapshot_sha256: ageSnapshotDigest(snapshot), confirmed_at: "2026-07-21T00:00:00.000Z" },
+      snapshot_sha256: ageSnapshotDigest(initialAgeSnapshot),
+      confirmed_at: "2026-07-21T00:00:00.000Z" },
     identity_files: {}, age_version: "v1.3.1",
   } };
   assert.doesNotThrow(() => validateAgeConfiguration(ageConfig));
@@ -904,49 +905,52 @@ test("age-v1 configuration verifies the complete snapshot hash chain", () => {
       snapshot_sha256: "0".repeat(64) },
   } }), /checkpoint/u);
   assert.throws(() => validateAgeConfiguration({ ...ageConfig, age_v1: {
-    ...ageConfig.age_v1, epoch_snapshot: { ...snapshot, previous_snapshot_sha256: "1".repeat(64) },
-  } }), /hash chain/u);
-  const rotated = { ...snapshot, epoch_revision: "1",
-    writer_generation: "1", previous_snapshot_sha256: ageSnapshotDigest(snapshot),
-    history: [...snapshot.history, { ...snapshot.history[0], epoch_revision: "1",
-      effective_from_seq: "2", key_id: "epoch-2" }] };
-  const chained = { ...ageConfig, age_v1: {
     ...ageConfig.age_v1,
-    epoch_snapshots: [snapshot, rotated],
+    epoch_snapshot: { ...initialAgeSnapshot, previous_snapshot_sha256: "1".repeat(64) },
+  } }), /hash chain/u);
+  const rotatedAgeSnapshot = { ...initialAgeSnapshot, epoch_revision: "1",
+    writer_generation: "1", previous_snapshot_sha256: ageSnapshotDigest(initialAgeSnapshot),
+    history: [...initialAgeSnapshot.history, { ...initialAgeSnapshot.history[0], epoch_revision: "1",
+      effective_from_seq: "2", key_id: "epoch-2" }] };
+  const chainedAgeConfig = { ...ageConfig, age_v1: {
+    ...ageConfig.age_v1,
+    epoch_snapshots: [initialAgeSnapshot, rotatedAgeSnapshot],
     epoch_snapshot: undefined,
     checkpoint: { ...ageConfig.age_v1.checkpoint, epoch_revision: "1",
       writer_generation: "1",
-      snapshot_sha256: ageSnapshotDigest(rotated) },
+      snapshot_sha256: ageSnapshotDigest(rotatedAgeSnapshot) },
   } };
-  assert.doesNotThrow(() => validateAgeConfiguration(chained));
+  assert.doesNotThrow(() => validateAgeConfiguration(chainedAgeConfig));
 
-  const tamperedInitial = { ...snapshot, authorized_writers: ["writer-b"] };
-  assert.throws(() => validateAgeConfiguration({ ...chained, age_v1: {
-    ...chained.age_v1, epoch_snapshots: [tamperedInitial, rotated],
+  const tamperedInitial = { ...initialAgeSnapshot, authorized_writers: ["writer-b"] };
+  assert.throws(() => validateAgeConfiguration({ ...chainedAgeConfig, age_v1: {
+    ...chainedAgeConfig.age_v1,
+    epoch_snapshots: [tamperedInitial, rotatedAgeSnapshot],
   } }), /hash chain/u);
 
   const reusedKeyId = {
-    ...rotated,
-    history: [...snapshot.history, {
-      ...rotated.history.at(-1),
-      key_id: snapshot.history[0].key_id,
+    ...rotatedAgeSnapshot,
+    history: [...initialAgeSnapshot.history, {
+      ...rotatedAgeSnapshot.history.at(-1),
+      key_id: initialAgeSnapshot.history[0].key_id,
       recipients: ["age1ykvctct4aklx4f4mnjd8rmzqs7p2le9ufg4faydljsk5mvcy0pls27mu64"],
     }],
   };
-  assert.throws(() => validateAgeConfiguration({ ...chained, age_v1: {
-    ...chained.age_v1,
-    epoch_snapshots: [snapshot, reusedKeyId],
-    checkpoint: { ...chained.age_v1.checkpoint,
+  assert.throws(() => validateAgeConfiguration({ ...chainedAgeConfig, age_v1: {
+    ...chainedAgeConfig.age_v1,
+    epoch_snapshots: [initialAgeSnapshot, reusedKeyId],
+    checkpoint: { ...chainedAgeConfig.age_v1.checkpoint,
       snapshot_sha256: ageSnapshotDigest(reusedKeyId) },
   } }), /conflicting recipient manifests/u);
 
-  const revisionTwo = { ...rotated, epoch_revision: "2", writer_generation: "2",
-    previous_snapshot_sha256: ageSnapshotDigest(rotated),
-    history: [...rotated.history, { ...rotated.history.at(-1), epoch_revision: "2",
+  const revisionTwo = { ...rotatedAgeSnapshot, epoch_revision: "2", writer_generation: "2",
+    previous_snapshot_sha256: ageSnapshotDigest(rotatedAgeSnapshot),
+    history: [...rotatedAgeSnapshot.history, {
+      ...rotatedAgeSnapshot.history.at(-1), epoch_revision: "2",
       effective_from_seq: "3", key_id: "epoch-3" }] };
-  assert.throws(() => validateAgeConfiguration({ ...chained, age_v1: {
-    ...chained.age_v1, epoch_snapshots: [snapshot, revisionTwo],
-    checkpoint: { ...chained.age_v1.checkpoint, epoch_revision: "2",
+  assert.throws(() => validateAgeConfiguration({ ...chainedAgeConfig, age_v1: {
+    ...chainedAgeConfig.age_v1, epoch_snapshots: [initialAgeSnapshot, revisionTwo],
+    checkpoint: { ...chainedAgeConfig.age_v1.checkpoint, epoch_revision: "2",
       writer_generation: "2", snapshot_sha256: ageSnapshotDigest(revisionTwo) },
   } }), /missing revision/u);
 });
@@ -957,7 +961,7 @@ test("retained age checkpoint survives sync config reset and rejects same-revisi
   const previousStorage = process.env.AGMSG_SYNC_STORAGE_DIR;
   process.env.AGMSG_SYNC_TRUST_DIR = join(root, "trust");
   process.env.AGMSG_SYNC_STORAGE_DIR = join(root, "resettable-store");
-  const snapshot = {
+  const initialAgeSnapshot = {
     profile: "age-v1", server_instance_id: config.server_instance_id,
     team_id: config.remote_team_id, epoch_revision: "0", writer_generation: "0",
     authorized_writers: ["writer-a"], previous_snapshot_sha256: null,
@@ -973,35 +977,38 @@ test("retained age checkpoint survives sync config reset and rejects same-revisi
     identity_files: {}, age_version: "v1.3.1",
   } });
   try {
-    await assert.rejects(retainAgeCheckpoint(makeConfig(snapshot), undefined), /operator-live/u);
-    const retained = await retainAgeCheckpoint(makeConfig(snapshot), "operator-live");
-    assert.equal(retained.snapshot_sha256, ageSnapshotDigest(snapshot));
+    await assert.rejects(
+      retainAgeCheckpoint(makeConfig(initialAgeSnapshot), undefined), /operator-live/u);
+    const retained = await retainAgeCheckpoint(
+      makeConfig(initialAgeSnapshot), "operator-live");
+    assert.equal(retained.snapshot_sha256, ageSnapshotDigest(initialAgeSnapshot));
     const resettableConfig = join(process.env.AGMSG_SYNC_STORAGE_DIR, "remote-sync", "demo.json");
     await mkdir(join(process.env.AGMSG_SYNC_STORAGE_DIR, "remote-sync"), { recursive: true });
     await writeFile(resettableConfig, "{}\n");
     await unlink(resettableConfig);
-    const conflicting = { ...snapshot, authorized_writers: ["writer-b"] };
+    const conflicting = { ...initialAgeSnapshot, authorized_writers: ["writer-b"] };
     await assert.rejects(retainAgeCheckpoint(makeConfig(conflicting), "operator-live"),
       /same-revision conflict/u);
-    const rotated = {
-      ...snapshot,
+    const rotatedAgeSnapshot = {
+      ...initialAgeSnapshot,
       epoch_revision: "1",
       writer_generation: "1",
-      previous_snapshot_sha256: ageSnapshotDigest(snapshot),
-      history: [...snapshot.history, {
-        ...snapshot.history[0], epoch_revision: "1",
+      previous_snapshot_sha256: ageSnapshotDigest(initialAgeSnapshot),
+      history: [...initialAgeSnapshot.history, {
+        ...initialAgeSnapshot.history[0], epoch_revision: "1",
         effective_from_seq: "2", key_id: "epoch-2",
       }],
     };
     const advanced = { ...config, cipher_profile: "age-v1", age_v1: {
-      epoch_snapshots: [snapshot, rotated],
+      epoch_snapshots: [initialAgeSnapshot, rotatedAgeSnapshot],
       checkpoint: { epoch_revision: "1", writer_generation: "1",
-        snapshot_sha256: ageSnapshotDigest(rotated), confirmed_at: "2026-07-22T00:00:00.000Z" },
+        snapshot_sha256: ageSnapshotDigest(rotatedAgeSnapshot),
+        confirmed_at: "2026-07-22T00:00:00.000Z" },
       identity_files: {}, age_version: "v1.3.1",
     } };
     const retainedAdvanced = await retainAgeCheckpoint(advanced, "operator-live");
     assert.equal(retainedAdvanced.epoch_revision, "1");
-    await assert.rejects(retainAgeCheckpoint(makeConfig(snapshot), "operator-live"),
+    await assert.rejects(retainAgeCheckpoint(makeConfig(initialAgeSnapshot), "operator-live"),
       /rollback/u);
   } finally {
     if (previousTrust === undefined) delete process.env.AGMSG_SYNC_TRUST_DIR;
@@ -1016,7 +1023,7 @@ test("age configure authenticates the connected credential before retaining trus
   const previousFetch = globalThis.fetch;
   await withConnectedCredential(async (root) => {
     await writeConnectedTeam(root, { capabilities: { write_allowed_ciphers: ["age-v1"] } });
-    const snapshot = {
+    const ageSnapshot = {
       authorized_writers: ["writer-a"],
       epoch_revision: "0",
       history: [{ cipher: "age-v1", effective_from_seq: "1", epoch_revision: "0",
@@ -1029,8 +1036,8 @@ test("age configure authenticates the connected credential before retaining trus
       team_id: config.remote_team_id,
       writer_generation: "0",
     };
-    const snapshotPath = join(root, "snapshot.json");
-    await writeFile(snapshotPath, JSON.stringify(snapshot));
+    const ageSnapshotPath = join(root, "epoch-snapshot.json");
+    await writeFile(ageSnapshotPath, JSON.stringify(ageSnapshot));
     const fakeAge = join(root, "age");
     await writeFile(fakeAge, "#!/bin/sh\necho v1.3.1\n", { mode: 0o700 });
     const saved = {
@@ -1058,8 +1065,8 @@ test("age configure authenticates the connected credential before retaining trus
     try {
       await assert.rejects(configure({ team: "demo", server: "https://sync.example",
         "team-id": config.remote_team_id, "minimum-security": "e2ee-required",
-        cipher: "age-v1", "age-snapshot": snapshotPath,
-        "age-checkpoint": `0:${ageSnapshotDigest(snapshot)}`,
+        cipher: "age-v1", "age-snapshot": ageSnapshotPath,
+        "age-checkpoint": `0:${ageSnapshotDigest(ageSnapshot)}`,
         "age-confirmation": "operator-live" }), /unauthenticated/u);
       assert.equal(calls, 2);
       await assert.rejects(readdir(process.env.AGMSG_SYNC_TRUST_DIR),
@@ -1082,7 +1089,7 @@ test("age configure imports a complete chain without activating its future epoch
     await writeConnectedTeam(root, { capabilities: { write_allowed_ciphers: ["age-v1"] } });
     const recipient0 = "age1mmqjrejftea4f6xh47lhpc0jn4vw0yuhz349sw2e3sfl22k5gcjsv6xcvp";
     const recipient1 = "age1ykvctct4aklx4f4mnjd8rmzqs7p2le9ufg4faydljsk5mvcy0pls27mu64";
-    const snapshot0 = {
+    const ageSnapshot0 = {
       authorized_writers: ["writer-a"],
       epoch_revision: "0",
       history: [{ cipher: "age-v1", effective_from_seq: "1", epoch_revision: "0",
@@ -1093,20 +1100,20 @@ test("age configure imports a complete chain without activating its future epoch
       team_id: config.remote_team_id,
       writer_generation: "0",
     };
-    const snapshot1 = {
-      ...snapshot0,
+    const ageSnapshot1 = {
+      ...ageSnapshot0,
       epoch_revision: "1",
-      history: [...snapshot0.history, {
+      history: [...ageSnapshot0.history, {
         cipher: "age-v1", effective_from_seq: "2", epoch_revision: "1",
         key_id: "epoch-1", recipients: [recipient1],
       }],
-      previous_snapshot_sha256: ageSnapshotDigest(snapshot0),
+      previous_snapshot_sha256: ageSnapshotDigest(ageSnapshot0),
       writer_generation: "1",
     };
-    const snapshot0Path = join(root, "snapshot-0.json");
-    const snapshot1Path = join(root, "snapshot-1.json");
-    await writeFile(snapshot0Path, JSON.stringify(snapshot0));
-    await writeFile(snapshot1Path, JSON.stringify(snapshot1));
+    const ageSnapshot0Path = join(root, "epoch-snapshot-0.json");
+    const ageSnapshot1Path = join(root, "epoch-snapshot-1.json");
+    await writeFile(ageSnapshot0Path, JSON.stringify(ageSnapshot0));
+    await writeFile(ageSnapshot1Path, JSON.stringify(ageSnapshot1));
     const fakeAge = join(root, "age");
     await writeFile(fakeAge, "#!/bin/sh\necho v1.3.1\n", { mode: 0o700 });
     const saved = {
@@ -1130,8 +1137,8 @@ test("age configure imports a complete chain without activating its future epoch
     try {
       await configure({ team: "demo", server: "https://sync.example",
         "team-id": config.remote_team_id, "minimum-security": "e2ee-required",
-        cipher: "age-v1", "age-snapshot": [snapshot0Path, snapshot1Path],
-        "age-checkpoint": `1:${ageSnapshotDigest(snapshot1)}`,
+        cipher: "age-v1", "age-snapshot": [ageSnapshot0Path, ageSnapshot1Path],
+        "age-checkpoint": `1:${ageSnapshotDigest(ageSnapshot1)}`,
         "age-confirmation": "operator-live" });
       const stored = JSON.parse(await readFile(
         join(process.env.AGMSG_SYNC_STORAGE_DIR, "remote-sync", "demo.json"), "utf8"));
@@ -1409,7 +1416,7 @@ test("pull bootstrap dispatches a real mixed roster and message page", async () 
       messages: [...roster, ...messages].map(({ projection: _projection, ...message }) => message),
       next_after: "80", has_more: false,
     }),
-    evaluateCall: async (_config, _snapshot, message) => ({
+    evaluateCall: async (_config, _teamSnapshot, message) => ({
       status: "importable",
       projection: [...roster, ...messages].find((entry) => entry.id === message.id).projection,
       policy_revision: "0", local_security_revision: "0",

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { chmod, mkdir, mkdtemp, readdir, rename, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, rename, rm, symlink, unlink,
+  writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -87,6 +88,16 @@ test("a synced rotation halts until an out-of-band identity matches its fingerpr
         remote_team_id: config.remote_team_id }),
       "",
     ].join("\n"));
+    await assert.rejects(activateKeyRotations(rotationConfig),
+      /import its authority-confirmed epoch snapshot/u);
+    rotationConfig.age_v1.epoch_snapshots = [
+      rotationConfig.age_v1.epoch_snapshot,
+      { history: [
+        ...rotationConfig.age_v1.epoch_snapshot.history,
+        { epoch_revision: epoch, effective_from_seq: "9", cipher: "age-v1",
+          key_id: keyId, recipients: [recipient] },
+      ] },
+    ];
     await assert.rejects(activateKeyRotations(rotationConfig), /import that key out of band/u);
     const keyDir = join(root, "run", "remote-credentials", "demo", "keys");
     await mkdir(keyDir, { recursive: true });
@@ -112,14 +123,19 @@ test("rotation cutover accepts MAX_SEQUENCE minus one and rejects the final sequ
   const recipient = "age1ykvctct4aklx4f4mnjd8rmzqs7p2le9ufg4faydljsk5mvcy0pls27mu64";
   const identity = "AGE-SECRET-KEY-14Z7XMNPZTPEMMM6DG2FSKEH042L7UMU79T645GAQJKU2LLJGPM2S7GWNLQ";
   const fingerprint = createHash("sha256").update(recipient).digest("hex");
-  const rotationConfig = () => ({
+  const rotationConfig = (serverSeq) => ({
     ...config,
     cipher_profile: "age-v1",
     age_v1: {
-      epoch_snapshot: { history: [{
+      epoch_snapshots: [{ history: [{
         epoch_revision: "0", effective_from_seq: "1", cipher: "age-v1",
         key_id: "epoch-0", recipients: [recipient],
-      }] },
+      }] }, { history: [
+        { epoch_revision: "0", effective_from_seq: "1", cipher: "age-v1",
+          key_id: "epoch-0", recipients: [recipient] },
+        { epoch_revision: "1", effective_from_seq: (BigInt(serverSeq) + 1n).toString(),
+          cipher: "age-v1", key_id: keyId, recipients: [recipient] },
+      ] }],
       identity_files: {},
     },
   });
@@ -140,13 +156,13 @@ test("rotation cutover accepts MAX_SEQUENCE minus one and rejects the final sequ
     ].join("\n"));
 
     await writeRotation("9223372036854775806");
-    const accepted = rotationConfig();
+    const accepted = rotationConfig("9223372036854775806");
     await activateKeyRotations(accepted);
     assert.equal(accepted.age_v1_runtime_history[0].effective_from_seq,
       "9223372036854775807");
 
     await writeRotation("9223372036854775807");
-    await assert.rejects(activateKeyRotations(rotationConfig()),
+    await assert.rejects(activateKeyRotations(rotationConfig("9223372036854775807")),
       /final server sequence/u);
   } finally {
     if (previous === undefined) delete process.env.AGMSG_SYNC_CONNECTION_DIR;
@@ -177,10 +193,15 @@ test("concurrent rotations adopt the first server sequence and the loser must im
     ...config,
     cipher_profile: "age-v1",
     age_v1: {
-      epoch_snapshot: { history: [{
+      epoch_snapshots: [{ history: [{
         epoch_revision: "0", effective_from_seq: "1", cipher: "age-v1",
         key_id: "epoch-0", recipients: [winner.recipient],
-      }] },
+      }] }, { history: [
+        { epoch_revision: "0", effective_from_seq: "1", cipher: "age-v1",
+          key_id: "epoch-0", recipients: [winner.recipient] },
+        { epoch_revision: "1", effective_from_seq: "9", cipher: "age-v1",
+          key_id: winner.keyId, recipients: [winner.recipient] },
+      ] }],
       identity_files: {},
     },
   });
@@ -855,7 +876,7 @@ test("age-v1 write selection exposes only public epoch material", () => {
   assert.equal(JSON.stringify(selected).includes("identity"), false);
 });
 
-test("age-v1 configuration binds its checkpoint and initial history", () => {
+test("age-v1 configuration verifies the complete snapshot hash chain", () => {
   assert.throws(() => ageSnapshotDigest({ bad: "\ud800" }), /lone surrogate/u);
   assert.throws(() => ageSnapshotDigest({ ["\udc00"]: "bad-key" }), /lone surrogate/u);
   const snapshot = {
@@ -884,16 +905,50 @@ test("age-v1 configuration binds its checkpoint and initial history", () => {
   } }), /checkpoint/u);
   assert.throws(() => validateAgeConfiguration({ ...ageConfig, age_v1: {
     ...ageConfig.age_v1, epoch_snapshot: { ...snapshot, previous_snapshot_sha256: "1".repeat(64) },
-  } }), /previous digest/u);
-  const rotated = { ...snapshot, epoch_revision: "1", previous_snapshot_sha256: "1".repeat(64),
+  } }), /hash chain/u);
+  const rotated = { ...snapshot, epoch_revision: "1",
+    writer_generation: "1", previous_snapshot_sha256: ageSnapshotDigest(snapshot),
     history: [...snapshot.history, { ...snapshot.history[0], epoch_revision: "1",
       effective_from_seq: "2", key_id: "epoch-2" }] };
-  assert.throws(() => validateAgeConfiguration({ ...ageConfig, age_v1: {
+  const chained = { ...ageConfig, age_v1: {
     ...ageConfig.age_v1,
-    epoch_snapshot: rotated,
+    epoch_snapshots: [snapshot, rotated],
+    epoch_snapshot: undefined,
     checkpoint: { ...ageConfig.age_v1.checkpoint, epoch_revision: "1",
+      writer_generation: "1",
       snapshot_sha256: ageSnapshotDigest(rotated) },
-  } }), /only an initial revision-0/u);
+  } };
+  assert.doesNotThrow(() => validateAgeConfiguration(chained));
+
+  const tamperedInitial = { ...snapshot, authorized_writers: ["writer-b"] };
+  assert.throws(() => validateAgeConfiguration({ ...chained, age_v1: {
+    ...chained.age_v1, epoch_snapshots: [tamperedInitial, rotated],
+  } }), /hash chain/u);
+
+  const reusedKeyId = {
+    ...rotated,
+    history: [...snapshot.history, {
+      ...rotated.history.at(-1),
+      key_id: snapshot.history[0].key_id,
+      recipients: ["age1ykvctct4aklx4f4mnjd8rmzqs7p2le9ufg4faydljsk5mvcy0pls27mu64"],
+    }],
+  };
+  assert.throws(() => validateAgeConfiguration({ ...chained, age_v1: {
+    ...chained.age_v1,
+    epoch_snapshots: [snapshot, reusedKeyId],
+    checkpoint: { ...chained.age_v1.checkpoint,
+      snapshot_sha256: ageSnapshotDigest(reusedKeyId) },
+  } }), /conflicting recipient manifests/u);
+
+  const revisionTwo = { ...rotated, epoch_revision: "2", writer_generation: "2",
+    previous_snapshot_sha256: ageSnapshotDigest(rotated),
+    history: [...rotated.history, { ...rotated.history.at(-1), epoch_revision: "2",
+      effective_from_seq: "3", key_id: "epoch-3" }] };
+  assert.throws(() => validateAgeConfiguration({ ...chained, age_v1: {
+    ...chained.age_v1, epoch_snapshots: [snapshot, revisionTwo],
+    checkpoint: { ...chained.age_v1.checkpoint, epoch_revision: "2",
+      writer_generation: "2", snapshot_sha256: ageSnapshotDigest(revisionTwo) },
+  } }), /missing revision/u);
 });
 
 test("retained age checkpoint survives sync config reset and rejects same-revision conflict", async () => {
@@ -928,6 +983,26 @@ test("retained age checkpoint survives sync config reset and rejects same-revisi
     const conflicting = { ...snapshot, authorized_writers: ["writer-b"] };
     await assert.rejects(retainAgeCheckpoint(makeConfig(conflicting), "operator-live"),
       /same-revision conflict/u);
+    const rotated = {
+      ...snapshot,
+      epoch_revision: "1",
+      writer_generation: "1",
+      previous_snapshot_sha256: ageSnapshotDigest(snapshot),
+      history: [...snapshot.history, {
+        ...snapshot.history[0], epoch_revision: "1",
+        effective_from_seq: "2", key_id: "epoch-2",
+      }],
+    };
+    const advanced = { ...config, cipher_profile: "age-v1", age_v1: {
+      epoch_snapshots: [snapshot, rotated],
+      checkpoint: { epoch_revision: "1", writer_generation: "1",
+        snapshot_sha256: ageSnapshotDigest(rotated), confirmed_at: "2026-07-22T00:00:00.000Z" },
+      identity_files: {}, age_version: "v1.3.1",
+    } };
+    const retainedAdvanced = await retainAgeCheckpoint(advanced, "operator-live");
+    assert.equal(retainedAdvanced.epoch_revision, "1");
+    await assert.rejects(retainAgeCheckpoint(makeConfig(snapshot), "operator-live"),
+      /rollback/u);
   } finally {
     if (previousTrust === undefined) delete process.env.AGMSG_SYNC_TRUST_DIR;
     else process.env.AGMSG_SYNC_TRUST_DIR = previousTrust;
@@ -989,6 +1064,84 @@ test("age configure authenticates the connected credential before retaining trus
       assert.equal(calls, 2);
       await assert.rejects(readdir(process.env.AGMSG_SYNC_TRUST_DIR),
         (error) => error.code === "ENOENT");
+    } finally {
+      globalThis.fetch = previousFetch;
+      if (saved.storage === undefined) delete process.env.AGMSG_SYNC_STORAGE_DIR;
+      else process.env.AGMSG_SYNC_STORAGE_DIR = saved.storage;
+      if (saved.trust === undefined) delete process.env.AGMSG_SYNC_TRUST_DIR;
+      else process.env.AGMSG_SYNC_TRUST_DIR = saved.trust;
+      if (saved.age === undefined) delete process.env.AGMSG_AGE_BIN;
+      else process.env.AGMSG_AGE_BIN = saved.age;
+    }
+  });
+});
+
+test("age configure imports a complete chain without activating its future epoch", async () => {
+  const previousFetch = globalThis.fetch;
+  await withConnectedCredential(async (root) => {
+    await writeConnectedTeam(root, { capabilities: { write_allowed_ciphers: ["age-v1"] } });
+    const recipient0 = "age1mmqjrejftea4f6xh47lhpc0jn4vw0yuhz349sw2e3sfl22k5gcjsv6xcvp";
+    const recipient1 = "age1ykvctct4aklx4f4mnjd8rmzqs7p2le9ufg4faydljsk5mvcy0pls27mu64";
+    const snapshot0 = {
+      authorized_writers: ["writer-a"],
+      epoch_revision: "0",
+      history: [{ cipher: "age-v1", effective_from_seq: "1", epoch_revision: "0",
+        key_id: "epoch-0", recipients: [recipient0] }],
+      previous_snapshot_sha256: null,
+      profile: "age-v1",
+      server_instance_id: config.server_instance_id,
+      team_id: config.remote_team_id,
+      writer_generation: "0",
+    };
+    const snapshot1 = {
+      ...snapshot0,
+      epoch_revision: "1",
+      history: [...snapshot0.history, {
+        cipher: "age-v1", effective_from_seq: "2", epoch_revision: "1",
+        key_id: "epoch-1", recipients: [recipient1],
+      }],
+      previous_snapshot_sha256: ageSnapshotDigest(snapshot0),
+      writer_generation: "1",
+    };
+    const snapshot0Path = join(root, "snapshot-0.json");
+    const snapshot1Path = join(root, "snapshot-1.json");
+    await writeFile(snapshot0Path, JSON.stringify(snapshot0));
+    await writeFile(snapshot1Path, JSON.stringify(snapshot1));
+    const fakeAge = join(root, "age");
+    await writeFile(fakeAge, "#!/bin/sh\necho v1.3.1\n", { mode: 0o700 });
+    const saved = {
+      storage: process.env.AGMSG_SYNC_STORAGE_DIR,
+      trust: process.env.AGMSG_SYNC_TRUST_DIR,
+      age: process.env.AGMSG_AGE_BIN,
+    };
+    process.env.AGMSG_SYNC_STORAGE_DIR = join(root, "store");
+    process.env.AGMSG_SYNC_TRUST_DIR = join(root, "trust");
+    process.env.AGMSG_AGE_BIN = fakeAge;
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      const body = calls === 1 ?
+        { status: "ok", database: "ok", server_instance_id: config.server_instance_id } :
+        capsFor(["age-v1"]);
+      return new Response(JSON.stringify(body), {
+        status: 200, headers: { "Agmsg-Protocol-Version": "1" },
+      });
+    };
+    try {
+      await configure({ team: "demo", server: "https://sync.example",
+        "team-id": config.remote_team_id, "minimum-security": "e2ee-required",
+        cipher: "age-v1", "age-snapshot": [snapshot0Path, snapshot1Path],
+        "age-checkpoint": `1:${ageSnapshotDigest(snapshot1)}`,
+        "age-confirmation": "operator-live" });
+      const stored = JSON.parse(await readFile(
+        join(process.env.AGMSG_SYNC_STORAGE_DIR, "remote-sync", "demo.json"), "utf8"));
+      assert.equal(stored.age_v1.epoch_snapshots.length, 2);
+      const loaded = await loadConfig("demo");
+      assert.equal(loaded.age_v1_runtime_history.length, 0);
+      const afterFirstSequence = {
+        ...capsFor(["age-v1"]), current_seq: "1", next_sequence_boundary: "2",
+      };
+      assert.equal(selectWriteProfile(loaded, afterFirstSequence).key_id, "epoch-0");
     } finally {
       globalThis.fetch = previousFetch;
       if (saved.storage === undefined) delete process.env.AGMSG_SYNC_STORAGE_DIR;


### PR DESCRIPTION
Implements the epoch-snapshot chain age-v1 already specifies, closing the last gap in the OSS E2EE minimum: a server can no longer rewind every machine to a consistent older state without detection.

Per the ruling on the branch (option A): the snapshot — `epoch_revision`, `writer_generation`, the authorized-writer roster, the key-epoch history, and `previous_snapshot_sha256` — is carried out of band and taken in through import, its authority and chain verified on the way. A `key_rotated` event only **activates** a snapshot already provisioned; it never synthesizes one. No matching snapshot means the machine stops, the same as any missing key.

Detection covers the three failure shapes: a tampered snapshot, a gap in the revision chain, and a rollback (a valid older snapshot re-presented) all fail verification and halt with a reason.

Design: `docs/design/remote-sync.md` "Rollback resistance" + "the event activates a snapshot, it is not one" (#543).

Targeted tests green as pushed: Node 55/55, key Bats 22/22.

> PR opened on the implementer's behalf — their sandbox denied GitHub API access. Authored by the epoch-chain work on `feat/epoch-chain` (e451775).

Naming note requested of the author: keep epoch snapshots named distinctly (`ageSnapshot`/`epochSnapshot`) from the existing team snapshots (`capabilitySnapshot`/`publicSnapshot`/`getTeamSnapshot`) so the two senses of "snapshot" don't merge.