### PR TITLE
feat(opencode): monitor delivery via opencode-sentinel plugin

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -232,7 +232,7 @@ despawnは指定されたメンバーにのみ作用する — `despawn` を実�
 | モード | 仕組み | レイテンシ | 向いている相手 |
 |---|---|---|---|
 | **`monitor`**（Claude Codeのデフォルト） | SessionStartフック → Monitorツール → ブロッキングSQLiteストリーム | 約5秒 | リアルタイムプッシュを望むClaude Codeユーザー |
-| **`turn`**（Codex / Copilot CLI / OpenCodeのデフォルト） | アシスタントのターン間でStopフックが `check-inbox.sh` を発火 | 次のやり取りまで | Codex / Copilot CLI / OpenCode（Monitorツールなし）、より静かなループを好むClaude Codeユーザー |
+| **`turn`**（Codex / Copilot CLI / OpenCodeのデフォルト） | アシスタントのターン間でStopフックが `check-inbox.sh` を発火 | 次のやり取りまで | monitorを実行していないCodex / Copilot CLI / OpenCodeユーザー、より静かなループを好むClaude Codeユーザー |
 | **`both`** | monitorを主に、turnをセッションごとの安全網として | 約5秒。ウォッチャー障害時はturn相当にフォールバック | 二重の保険をかけたい場合 |
 | **`off`** | 自動配信なし | 手動の `/agmsg` のみ | ミニマリスト |
 
@@ -306,7 +306,7 @@ Copilotインストーラーは `~/.copilot/skills/agmsg/` に `SKILL.md` を配
 $agmsg
 ```
 
-`./install.sh` でインストールする（`~/.config/opencode/` が存在する場合、OpenCode向けスキルがデフォルトのCodex向け共有スキルと並んで自動的に配置される）。`--agent-type opencode` はCodexがインストールされていないOpenCode専用環境でのみ使う。OpenCodeは `mode turn` と `mode off` に対応し、`spawn opencode` は `opencode --prompt`（ブートプロンプトのターンが終わってもTUIが滞在するモード）経由で利用可能。`monitor` と `both` は非対応。
+`./install.sh` でインストールする（`~/.config/opencode/` が存在する場合、OpenCode向けスキルがデフォルトのCodex向け共有スキルと並んで自動的に配置される）。`--agent-type opencode` はCodexがインストールされていないOpenCode専用環境でのみ使う。OpenCodeは `mode monitor`（外部プラグイン [`opencode-sentinel`](https://github.com/tsukimiya/opencode-sentinel) 経由。プラグイン未導入時は turn にフォールバック）、`mode turn`、`mode off` に対応。`spawn opencode` は `opencode --prompt`（ブートプロンプトのターンが終わってもTUIが滞在するモード）経由で利用可能。`both` は非対応。
 
 これによりOpenCodeは、Ollamaのようなローカルプロバイダーを使う構成を含め、ローカルのコーディングエージェントとして役立つ。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -231,8 +231,8 @@ despawnは指定されたメンバーにのみ作用する — `despawn` を実�
 
 | モード | 仕組み | レイテンシ | 向いている相手 |
 |---|---|---|---|
-| **`monitor`**（Claude Codeのデフォルト） | SessionStartフック → Monitorツール → ブロッキングSQLiteストリーム | 約5秒 | リアルタイムプッシュを望むClaude Codeユーザー |
-| **`turn`**（Codex / Copilot CLI / OpenCodeのデフォルト） | アシスタントのターン間でStopフックが `check-inbox.sh` を発火 | 次のやり取りまで | monitorを実行していないCodex / Copilot CLI / OpenCodeユーザー、より静かなループを好むClaude Codeユーザー |
+| **`monitor`**（Claude Codeのデフォルト。OpenCodeではopencode-sentinel pluginで利用可能） | SessionStartフック → Monitorツール → ブロッキングSQLiteストリーム | 約5秒 | リアルタイムプッシュを望むClaude Codeユーザー |
+| **`turn`**（Codex / Copilot CLI / OpenCode（plugin未導入）のデフォルト） | アシスタントのターン間でStopフックが `check-inbox.sh` を発火 | 次のやり取りまで | monitorを実行していないCodex / Copilot CLI / OpenCodeユーザー、より静かなループを好むClaude Codeユーザー |
 | **`both`** | monitorを主に、turnをセッションごとの安全網として | 約5秒。ウォッチャー障害時はturn相当にフォールバック | 二重の保険をかけたい場合 |
 | **`off`** | 自動配信なし | 手動の `/agmsg` のみ | ミニマリスト |
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -306,7 +306,7 @@ Copilotインストーラーは `~/.copilot/skills/agmsg/` に `SKILL.md` を配
 $agmsg
 ```
 
-`./install.sh` でインストールする（`~/.config/opencode/` が存在する場合、OpenCode向けスキルがデフォルトのCodex向け共有スキルと並んで自動的に配置される）。`--agent-type opencode` はCodexがインストールされていないOpenCode専用環境でのみ使う。OpenCodeは手動およびturn/off配信ワークフローに対応している。現時点では `mode turn` と `mode off` のみサポート — `monitor`、`both`、`spawn opencode` は非対応。
+`./install.sh` でインストールする（`~/.config/opencode/` が存在する場合、OpenCode向けスキルがデフォルトのCodex向け共有スキルと並んで自動的に配置される）。`--agent-type opencode` はCodexがインストールされていないOpenCode専用環境でのみ使う。OpenCodeは `mode turn` と `mode off` に対応し、`spawn opencode` は `opencode --prompt`（ブートプロンプトのターンが終わってもTUIが滞在するモード）経由で利用可能。`monitor` と `both` は非対応。
 
 これによりOpenCodeは、Ollamaのようなローカルプロバイダーを使う構成を含め、ローカルのコーディングエージェントとして役立つ。
 

--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ How incoming messages reach your agent. Pick one at first join via the prompt, o
 
 | mode | mechanism | latency | who it's for |
 |---|---|---|---|
-| **`monitor`** (default on Claude Code) | SessionStart hook → Monitor tool → blocking SQLite stream | ~5s | Claude Code users wanting real-time push |
-| **`turn`** (default on Codex / Copilot CLI / OpenCode) | Stop hook fires `check-inbox.sh` between assistant turns | until your next interaction | Codex / Copilot CLI / OpenCode users not running monitor; Claude Code users on a quieter loop |
+| **`monitor`** (default on Claude Code; on OpenCode with the opencode-sentinel plugin) | SessionStart hook → Monitor tool → blocking SQLite stream | ~5s | Claude Code users wanting real-time push |
+| **`turn`** (default on Codex / Copilot CLI / OpenCode without the plugin) | Stop hook fires `check-inbox.sh` between assistant turns | until your next interaction | Codex / Copilot CLI / OpenCode users not running monitor; Claude Code users on a quieter loop |
 | **`both`** | monitor primary, turn as per-session safety net | ~5s; falls back to turn-end on watcher failure | belt-and-suspenders |
 | **`off`** | no automatic delivery | manual `/agmsg` only | minimalists |
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ The Copilot installer drops a `SKILL.md` at `~/.copilot/skills/agmsg/` so `/agms
 $agmsg
 ```
 
-Install with `./install.sh` (when `~/.config/opencode/` exists, the OpenCode-typed skill is placed automatically alongside the default Codex-typed shared skill). Use `--agent-type opencode` only for OpenCode-only environments where Codex is not installed. OpenCode is supported for manual and turn/off delivery workflows. It currently supports `mode turn` and `mode off`; `monitor`, `both`, and `spawn opencode` are not supported.
+Install with `./install.sh` (when `~/.config/opencode/` exists, the OpenCode-typed skill is placed automatically alongside the default Codex-typed shared skill). Use `--agent-type opencode` only for OpenCode-only environments where Codex is not installed. OpenCode supports `mode turn` and `mode off`, and `spawn opencode` is available via `opencode --prompt` (TUI mode, which stays resident after the boot prompt's turn). `monitor` and `both` are not supported.
 
 This makes OpenCode useful as a local coding agent, including configurations backed by local providers such as Ollama.
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ How incoming messages reach your agent. Pick one at first join via the prompt, o
 | mode | mechanism | latency | who it's for |
 |---|---|---|---|
 | **`monitor`** (default on Claude Code) | SessionStart hook → Monitor tool → blocking SQLite stream | ~5s | Claude Code users wanting real-time push |
-| **`turn`** (default on Codex / Copilot CLI / OpenCode) | Stop hook fires `check-inbox.sh` between assistant turns | until your next interaction | Codex / Copilot CLI / OpenCode (no Monitor tool); Claude Code users on a quieter loop |
+| **`turn`** (default on Codex / Copilot CLI / OpenCode) | Stop hook fires `check-inbox.sh` between assistant turns | until your next interaction | Codex / Copilot CLI / OpenCode users not running monitor; Claude Code users on a quieter loop |
 | **`both`** | monitor primary, turn as per-session safety net | ~5s; falls back to turn-end on watcher failure | belt-and-suspenders |
 | **`off`** | no automatic delivery | manual `/agmsg` only | minimalists |
 
@@ -320,7 +320,7 @@ The Copilot installer drops a `SKILL.md` at `~/.copilot/skills/agmsg/` so `/agms
 $agmsg
 ```
 
-Install with `./install.sh` (when `~/.config/opencode/` exists, the OpenCode-typed skill is placed automatically alongside the default Codex-typed shared skill). Use `--agent-type opencode` only for OpenCode-only environments where Codex is not installed. OpenCode supports `mode turn` and `mode off`, and `spawn opencode` is available via `opencode --prompt` (TUI mode, which stays resident after the boot prompt's turn). `monitor` and `both` are not supported.
+Install with `./install.sh` (when `~/.config/opencode/` exists, the OpenCode-typed skill is placed automatically alongside the default Codex-typed shared skill). Use `--agent-type opencode` only for OpenCode-only environments where Codex is not installed. OpenCode supports `mode monitor` (via the external [`opencode-sentinel`](https://github.com/tsukimiya/opencode-sentinel) plugin, with a turn-mode fallback when the plugin is absent), `mode turn`, and `mode off`. `spawn opencode` is available via `opencode --prompt` (TUI mode, which stays resident after the boot prompt's turn). `both` is not supported.
 
 This makes OpenCode useful as a local coding agent, including configurations backed by local providers such as Ollama.
 

--- a/docs/agent-types.md
+++ b/docs/agent-types.md
@@ -21,11 +21,11 @@ a manifest cannot execute code. Multi-value keys are whitespace-separated.
 | `template` | yes | the `/agmsg` command template filename, relative to the type dir (e.g. `template.md`); becomes `SKILL.md` |
 | `detect` | — | env-var names whose presence selects this type. `explicit` = never auto-detected from the environment |
 | `detect_proc` | — | parent-process-name glob patterns that select this type (e.g. `codex codex-*`) |
-| `cli` | spawnable types | the launch command. Usually a single binary name, but may be a fixed multi-word prefix (subcommand and/or flags a CLI needs ahead of its own options, e.g. `opencode run --interactive`) — only the first word is resolved/checked as the executable; the rest are passed through as-is. Safe because this is manifest data agmsg ships, not runtime user input |
+| `cli` | spawnable types | the launch command. Usually a single binary name, but may be a fixed multi-word prefix (subcommand and/or flags a CLI needs ahead of its own options) — only the first word is resolved/checked as the executable; the rest are passed through as-is. Safe because this is manifest data agmsg ships, not runtime user input |
 | `spawnable` | — | `yes` if `spawn.sh` can launch this type |
 | `spawn` | — | a `.mjs` node-launcher (beside the manifest) `spawn.sh` runs via Node; also marks the type spawnable |
 | `model_arg` | — | the `--model`/`-m`-style flag `spawn --model <id>` passes through to the CLI; a type with no `model_arg` refuses `--model` |
-| `prompt_arg` | — | for a CLI that does not accept the actas prompt as a bare positional argument, the named flag whose value IS the prompt (e.g. antigravity's `--prompt-interactive`, copilot's `--interactive`) — `spawn.sh` inserts it immediately before the (already-quoted) prompt. Unset = bare positional, the default |
+| `prompt_arg` | — | for a CLI that does not accept the actas prompt as a bare positional argument, the named flag whose value IS the prompt (e.g. antigravity's `--prompt-interactive`, copilot's `--interactive`, opencode's `--prompt`) — `spawn.sh` inserts it immediately before the (already-quoted) prompt. Unset = bare positional, the default |
 | `hooks_file` | yes | project-relative delivery hooks file (e.g. `.codex/hooks.json`) |
 | `monitor` | — | `yes` if the type exposes a native Monitor tool; `spawn` skips the readiness wait when `no` |
 | `delivery_modes` | — | space-separated delivery modes the type's CLI accepts (e.g. `monitor turn off`); `delivery.sh`'s gate rejects anything else. Defaults to `monitor turn both off` when omitted |

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -1,8 +1,8 @@
 # agmsg for OpenCode
 
-OpenCode is supported for **manual and turn/off delivery workflows**.
+OpenCode supports **manual, turn/off, and real-time `monitor` delivery**.
 
-`monitor` and `both` are not supported in this release (real-time push delivery requires a Monitor-tool equivalent that OpenCode does not have built in). `spawn opencode` is supported via `opencode --prompt`. OpenCode + Ollama is a useful local coding agent that can participate in an agmsg team alongside Claude Code, Codex, Gemini CLI, and other CLI agents.
+`monitor` mode routes incoming messages through the external [`opencode-sentinel`](https://github.com/tsukimiya/opencode-sentinel) plugin (a Monitor-tool equivalent for OpenCode), with a turn-mode fallback when the plugin is not installed. `spawn opencode` is supported via `opencode --prompt` (TUI mode). `both` is not supported. OpenCode + Ollama is a useful local coding agent that can participate in an agmsg team alongside Claude Code, Codex, Gemini CLI, and other CLI agents.
 
 ## Install
 
@@ -49,7 +49,7 @@ From OpenCode, run:
 $agmsg
 ```
 
-On first run it prompts for a team name and agent name, then joins you to the team. Choose delivery mode `turn` or `off` when prompted.
+On first run it prompts for a team name and agent name, then joins you to the team. Choose delivery mode `monitor`, `turn`, or `off` when prompted (`monitor` requires the `opencode-sentinel` plugin — see [Delivery modes](#delivery-modes) below).
 
 Or join directly from the shell:
 
@@ -88,23 +88,40 @@ $agmsg history
 
 | Mode      | Supported | Notes |
 |-----------|:---------:|-------|
+| `monitor` | ✓         | Real-time push via the [`opencode-sentinel`](https://github.com/tsukimiya/opencode-sentinel) plugin's `sentinel_monitor` tool — same shape as Claude Code's Monitor. Falls back to turn-mode self-checks when the tool is unavailable |
 | `turn`    | ✓         | Instruction rule runs check-inbox after each tool call |
 | `off`     | ✓         | Manual `$agmsg` only |
-| `monitor` | ✗         | Requires Monitor tool — not available in OpenCode |
-| `both`    | ✗         | Requires monitor |
+| `both`    | ✗         | Not applicable to opencode (the sentinel tool already provides the real-time path, with turn as its in-band fallback) |
 
 Switch mode:
 
 ```
+$agmsg mode monitor    # real-time push (requires opencode-sentinel plugin)
 $agmsg mode turn
 $agmsg mode off
 ```
 
-Requesting `monitor` or `both` returns an error:
+### Real-time push (`monitor` mode)
+
+`monitor` mode streams incoming agmsg messages into the OpenCode session as
+they arrive, using the [`opencode-sentinel`](https://github.com/tsukimiya/opencode-sentinel)
+plugin's `sentinel_monitor` tool — the same shape as Claude Code's Monitor
+tool. Install the plugin first:
 
 ```
-Error: 'monitor' mode is not supported for opencode (no Monitor-tool equivalent). Use 'turn' or 'off'.
+opencode plugin opencode-sentinel
 ```
+
+Then set the mode and follow the rule's instruction to launch a resident
+watcher via `sentinel_monitor`:
+
+```
+$agmsg mode monitor
+```
+
+If `sentinel_monitor` is unavailable (plugin not installed, or the OpenCode
+build does not expose the tool), the rule falls back to turn-mode self-checks
+— so `monitor` never silently drops messages, it just degrades to `turn`.
 
 ## Spawn
 
@@ -137,7 +154,7 @@ OpenCode + Ollama is well-suited for local, low-cost tasks such as:
 
 ## Known limitations
 
-- No real-time push delivery (`monitor` mode requires a Monitor-tool equivalent, not available in OpenCode itself)
+- `monitor` mode depends on the external `opencode-sentinel` plugin — without it, delivery degrades to `turn` rather than failing
 - No native OpenCode plugin integration
 
 These may be addressed in future releases.

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -2,7 +2,7 @@
 
 OpenCode is supported for **manual and turn/off delivery workflows**.
 
-`monitor`, `both`, and `spawn opencode` are not supported in this release. OpenCode + Ollama is a useful local coding agent that can participate in an agmsg team alongside Claude Code, Codex, Gemini CLI, and other CLI agents.
+`monitor` and `both` are not supported in this release (real-time push delivery requires a Monitor-tool equivalent that OpenCode does not have built in). `spawn opencode` is supported via `opencode --prompt`. OpenCode + Ollama is a useful local coding agent that can participate in an agmsg team alongside Claude Code, Codex, Gemini CLI, and other CLI agents.
 
 ## Install
 
@@ -108,7 +108,16 @@ Error: 'monitor' mode is not supported for opencode (no Monitor-tool equivalent)
 
 ## Spawn
 
-`spawn opencode` is not supported. Spawn is limited to `claude-code` and `codex`.
+`spawn opencode` is supported via the existing `prompt_arg=` mechanism. The
+manifest declares `cli=opencode` + `prompt_arg=--prompt`, so `spawn.sh` emits
+`opencode --model <id> --prompt "<actas text>"`.
+
+TUI mode (`opencode --prompt`, not `opencode run --interactive`) is required:
+`run --interactive` exits as soon as the boot prompt's turn completes, so the
+spawned worker would never stay resident to receive further agmsg messages.
+`--prompt` auto-sends the initial prompt and keeps the TUI open.
+
+See the main spawn documentation in [README.md](../README.md#spawn-a-new-agent-spawn).
 
 ## Typical team setup
 
@@ -128,8 +137,7 @@ OpenCode + Ollama is well-suited for local, low-cost tasks such as:
 
 ## Known limitations
 
-- No real-time push delivery (`monitor` mode requires Claude Code's Monitor tool)
-- No `spawn opencode` support
+- No real-time push delivery (`monitor` mode requires a Monitor-tool equivalent, not available in OpenCode itself)
 - No native OpenCode plugin integration
 
 These may be addressed in future releases.

--- a/scripts/drivers/types/opencode/_delivery.sh
+++ b/scripts/drivers/types/opencode/_delivery.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
-# opencode delivery plug — markdown rule-file. Only turn|off reach this function:
-# opencode's manifest declares delivery_modes=turn off, so delivery.sh's central
-# gate rejects monitor/both before apply runs. Uses resolve_hooks_file + SKILL_DIR
-# from delivery.sh's sourced context.
+# opencode delivery plug — markdown rule-file. delivery_modes=monitor turn off,
+# so mode=both never reaches this function (rejected by delivery.sh's central
+# gate before apply runs). Uses resolve_hooks_file + SKILL_DIR from delivery.sh's
+# sourced context.
+#
+# monitor mode: opencode-sentinel's `sentinel_monitor` tool runs a shell command
+# resident and streams its stdout lines into idle sessions too — the same shape
+# as Claude Code's Monitor tool. The rule instructs the agent to launch
+# watch.sh under it at session start (or on /agmsg). watch.sh is runtime-agnostic
+# and tolerates an empty session-id arg, so the command is safe even when
+# $SENTINEL_SESSION_ID is unset in the tool's own shell. A fallback (turn-mode
+# self-poll) is included for the case where `sentinel_monitor` is unavailable.
 agmsg_delivery_apply() {
   local type="$1"
   local project="$2"
@@ -12,15 +20,58 @@ agmsg_delivery_apply() {
 
   rm -f "$rule_file"
 
-  if [ "$mode" = "turn" ]; then
-    mkdir -p "$(dirname "$rule_file")"
-    cat <<EOF > "$rule_file"
+  case "$mode" in
+    turn)
+      mkdir -p "$(dirname "$rule_file")"
+      cat <<EOF > "$rule_file"
+<!-- agmsg-delivery-mode: turn -->
 # agmsg Integration Rule
 
 ## PostToolUse
 After each tool call, automatically check the agmsg inbox for unread messages.
 - Command: '$SKILL_DIR/scripts/check-inbox.sh' '$type' '$project'
 EOF
+      ;;
+    monitor)
+      mkdir -p "$(dirname "$rule_file")"
+      cat <<EOF > "$rule_file"
+<!-- agmsg-delivery-mode: monitor -->
+# agmsg Integration Rule
+
+## Real-time inbox watcher
+
+At session start (or the first time you run /agmsg this session), launch a
+resident inbox watcher with the \`sentinel_monitor\` tool so incoming agmsg
+messages stream into this conversation as they arrive:
+
+- command: '$SKILL_DIR/scripts/watch.sh' "\$SENTINEL_SESSION_ID" '$project' $type
+- description: agmsg inbox stream
+
+Do not launch it more than once per session — if a watcher is already
+streaming, skip this step.
+
+### Fallback (no sentinel_monitor tool)
+
+If the \`sentinel_monitor\` tool is not available, fall back to a turn-based
+self-check instead: after each tool call, run
+'$SKILL_DIR/scripts/check-inbox.sh' '$type' '$project'
+to check the agmsg inbox for unread messages.
+EOF
+      ;;
+    off)
+      : # rule file already removed
+      ;;
+  esac
+}
+agmsg_delivery_status() {
+  local type="$1" project="$2"
+  local rule_file
+  rule_file="$(resolve_hooks_file "$type" "$project")"
+  if [ ! -f "$rule_file" ]; then
+    echo "mode: off"
+  elif grep -q "agmsg-delivery-mode: monitor" "$rule_file" 2>/dev/null; then
+    echo "mode: monitor"
+  else
+    echo "mode: turn"
   fi
 }
-agmsg_delivery_status() { rulefile_status "$@"; }

--- a/scripts/drivers/types/opencode/_delivery.sh
+++ b/scripts/drivers/types/opencode/_delivery.sh
@@ -44,7 +44,7 @@ At session start (or the first time you run /agmsg this session), launch a
 resident inbox watcher with the \`sentinel_monitor\` tool so incoming agmsg
 messages stream into this conversation as they arrive:
 
-- command: '$SKILL_DIR/scripts/watch.sh' "\$SENTINEL_SESSION_ID" '$project' $type
+- command: '$SKILL_DIR/scripts/watch.sh' "\${SENTINEL_SESSION_ID:--}" '$project' $type
 - description: agmsg inbox stream
 
 Do not launch it more than once per session — if a watcher is already

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -86,7 +86,7 @@ Four possible outputs:
 
 **Ensure monitor is running first (monitor mode only).** If the project's delivery mode is `monitor` (check via `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status opencode "$(pwd)"`) and no `agmsg inbox stream` watcher is already streaming into this session, launch one now with the `sentinel_monitor` tool:
 
-- command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "$SENTINEL_SESSION_ID" "$(pwd)" opencode`
+- command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "${SENTINEL_SESSION_ID:--}" "$(pwd)" opencode`
 - description: `agmsg inbox stream`
 
 Pass the command to `sentinel_monitor` exactly as written. If `sentinel_monitor` is not available in this environment, fall back to a turn-based self-check instead: after each tool call, run `~/.agents/skills/__SKILL_NAME__/scripts/check-inbox.sh opencode "$(pwd)"` to check the agmsg inbox for unread messages.
@@ -122,12 +122,12 @@ If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 1. Parse the new role name. If none was given (e.g. bare "actas", or the user asks you to suggest one), run `~/.agents/skills/__SKILL_NAME__/scripts/team.sh <team>` for each TEAM to see the current roster. Look for a naming convention already in play (e.g. a shared base name with role/number suffixes like `aggie-cc1`/`aggie-cc2`, or names derived from the team name) and, when one exists, propose 2-3 unused names that extend it; otherwise propose 2-3 short, distinctive identity names (not a bare tool-type label). Either way, names must not collide with the roster. Ask the user to pick one or type their own before continuing.
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" opencode` to see whether the role is already registered for this (project, type).
 3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> opencode "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
-4. **If delivery mode is `monitor`**, switch the watcher to the new role so receive is restricted to it:
+4. **If delivery mode is `monitor`**, switch the watcher to the new role so receive is restricted to it. (If the sentinel tools are unavailable — plugin not installed — skip this step; the rule's turn-mode self-check still covers your roles.)
    a. Run `sentinel_list` to find a running monitor described `agmsg inbox stream`; if one is running in this session, stop it with `sentinel_stop` on its id.
    b. Launch a fresh watcher with the `sentinel_monitor` tool:
-      - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "$SENTINEL_SESSION_ID" "$(pwd)" opencode <name>`
+      - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "${SENTINEL_SESSION_ID:--}" "$(pwd)" opencode <name>`
       - description: `agmsg inbox stream`
-   The 4th argument restricts the subscription to messages addressed to `<name>` only. In `turn`/`off` mode there is no watcher to switch — skip this step.
+    The 4th argument restricts the subscription to messages addressed to `<name>` only. In `turn`/`off` mode there is no watcher to switch — skip this step too.
 5. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
 6. Tell the user: "Now acting as `<name>`. Sends use `<name>` as from. In monitor mode, receive is restricted to `<name>`; in turn/off mode receive still covers all your registered roles."
 
@@ -135,8 +135,8 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" opencode <name>` to remove that role's registration.
 3. If the session's active FROM was `<name>`, clear that state.
-4. **If delivery mode is `monitor`**: run `sentinel_list` to find a running monitor described `agmsg inbox stream`; if one is running in this session, stop it with `sentinel_stop` on its id, then relaunch it with the `sentinel_monitor` tool using the default (no 4th arg) subscription so receive covers the project's remaining roles:
-   - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "$SENTINEL_SESSION_ID" "$(pwd)" opencode`
+4. **If delivery mode is `monitor`** and the sentinel tools are available: run `sentinel_list` to find a running monitor described `agmsg inbox stream`; if one is running in this session, stop it with `sentinel_stop` on its id, then relaunch it with the `sentinel_monitor` tool using the default (no 4th arg) subscription so receive covers the project's remaining roles. If the sentinel tools are unavailable (plugin not installed), skip this step.
+   - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "${SENTINEL_SESSION_ID:--}" "$(pwd)" opencode`
    - description: `agmsg inbox stream`
 5. Tell the user: "Dropped role `<name>` from this project."
 

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -48,19 +48,25 @@ Four possible outputs:
      ```
      Choose delivery mode for incoming messages:
 
-       1) turn — Check inbox at the end of each assistant turn
-                  Stop hook pulls after each response.
+       1) monitor — Real-time push via the `sentinel_monitor` tool (recommended)
+                     Launches watch.sh through `sentinel_monitor`; each new
+                     message streams in as a notification. Falls back to
+                     turn-mode self-checks if `sentinel_monitor` is unavailable.
 
-       2) off  — No automatic delivery
-                  Manual $__SKILL_NAME__ only.
+       2) turn    — Check inbox at the end of each assistant turn
+                     A rule has you self-check the inbox after each tool call.
+
+       3) off     — No automatic delivery
+                     Manual $__SKILL_NAME__ only.
 
      [1]:
      ```
 
-     - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
-     - Map the chosen number to a mode (`1`→`turn`, `2`→`off`) and run:
+     - **Wait for the user's answer before proceeding.** Empty input means `1` (monitor).
+     - Map the chosen number to a mode (`1`→`monitor`, `2`→`turn`, `3`→`off`) and run:
        `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> opencode "$(pwd)"`
-     - OpenCode has no Monitor tool, so `monitor` and `both` modes are not offered here.
+     - `both` is not supported for opencode.
+     - If you chose `monitor`, follow the "Ensure monitor is running first" step below now, so the watcher starts streaming into this session immediately.
 
   6. Then check inbox for the newly joined team.
 
@@ -77,6 +83,15 @@ Four possible outputs:
 ## Execute
 
 **Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
+
+**Ensure monitor is running first (monitor mode only).** If the project's delivery mode is `monitor` (check via `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status opencode "$(pwd)"`) and no `agmsg inbox stream` watcher is already streaming into this session, launch one now with the `sentinel_monitor` tool:
+
+- command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "$SENTINEL_SESSION_ID" "$(pwd)" opencode`
+- description: `agmsg inbox stream`
+
+Pass the command to `sentinel_monitor` exactly as written. If `sentinel_monitor` is not available in this environment, fall back to a turn-based self-check instead: after each tool call, run `~/.agents/skills/__SKILL_NAME__/scripts/check-inbox.sh opencode "$(pwd)"` to check the agmsg inbox for unread messages.
+
+Launch the watcher only once per session — if it is already streaming, do not start a second one. In `turn`/`off` mode there is no watcher; skip this.
 
 **If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
 1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
@@ -107,22 +122,32 @@ If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
 1. Parse the new role name. If none was given (e.g. bare "actas", or the user asks you to suggest one), run `~/.agents/skills/__SKILL_NAME__/scripts/team.sh <team>` for each TEAM to see the current roster. Look for a naming convention already in play (e.g. a shared base name with role/number suffixes like `aggie-cc1`/`aggie-cc2`, or names derived from the team name) and, when one exists, propose 2-3 unused names that extend it; otherwise propose 2-3 short, distinctive identity names (not a bare tool-type label). Either way, names must not collide with the roster. Ask the user to pick one or type their own before continuing.
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" opencode` to see whether the role is already registered for this (project, type).
 3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> opencode "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
-4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
-5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. (OpenCode has no Monitor tool, so receive still covers all of your registered roles in this project.)"
+4. **If delivery mode is `monitor`**, switch the watcher to the new role so receive is restricted to it:
+   a. Run `sentinel_list` to find a running monitor described `agmsg inbox stream`; if one is running in this session, stop it with `sentinel_stop` on its id.
+   b. Launch a fresh watcher with the `sentinel_monitor` tool:
+      - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "$SENTINEL_SESSION_ID" "$(pwd)" opencode <name>`
+      - description: `agmsg inbox stream`
+   The 4th argument restricts the subscription to messages addressed to `<name>` only. In `turn`/`off` mode there is no watcher to switch — skip this step.
+5. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`.
+6. Tell the user: "Now acting as `<name>`. Sends use `<name>` as from. In monitor mode, receive is restricted to `<name>`; in turn/off mode receive still covers all your registered roles."
 
 If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 1. Parse the role name.
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" opencode <name>` to remove that role's registration.
 3. If the session's active FROM was `<name>`, clear that state.
-4. Tell the user: "Dropped role `<name>` from this project."
+4. **If delivery mode is `monitor`**: run `sentinel_list` to find a running monitor described `agmsg inbox stream`; if one is running in this session, stop it with `sentinel_stop` on its id, then relaunch it with the `sentinel_monitor` tool using the default (no 4th arg) subscription so receive covers the project's remaining roles:
+   - command: `~/.agents/skills/__SKILL_NAME__/scripts/watch.sh "$SENTINEL_SESSION_ID" "$(pwd)" opencode`
+   - description: `agmsg inbox stream`
+5. Tell the user: "Dropped role `<name>` from this project."
 
 If argument is "mode" (no further args):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status opencode "$(pwd)"`
 2. Show the output to the user.
 
 If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
-1. Parse the mode. OpenCode supports only `turn` and `off` — reject `monitor` and `both` with: "OpenCode has no Monitor tool; only `turn` or `off` modes are supported."
+1. Parse the mode. OpenCode supports `monitor`, `turn`, and `off` — reject `both` with: "OpenCode does not support `both`; use `monitor`, `turn`, or `off`."
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> opencode "$(pwd)"`
+3. If the mode is `monitor`, follow the "Ensure monitor is running first" step above to launch the watcher in this session now.
 
 If argument is "hook on" (legacy alias):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn opencode "$(pwd)"`

--- a/scripts/drivers/types/opencode/type.conf
+++ b/scripts/drivers/types/opencode/type.conf
@@ -1,9 +1,10 @@
 # agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
 name=opencode
 template=template.md
-cli=opencode run --interactive
+cli=opencode
 spawnable=yes
 model_arg=--model
+prompt_arg=--prompt
 detect_proc=opencode opencode-*
 hooks_file=.opencode/rules/agmsg.md
 monitor=no

--- a/scripts/drivers/types/opencode/type.conf
+++ b/scripts/drivers/types/opencode/type.conf
@@ -3,6 +3,8 @@ name=opencode
 template=template.md
 cli=opencode
 spawnable=yes
+# opencode invokes a skill with "$", not Claude Code's "/" (see spawn.sh, #283).
+cmd_prefix=$
 model_arg=--model
 prompt_arg=--prompt
 detect_proc=opencode opencode-*

--- a/scripts/drivers/types/opencode/type.conf
+++ b/scripts/drivers/types/opencode/type.conf
@@ -9,5 +9,5 @@ model_arg=--model
 prompt_arg=--prompt
 detect_proc=opencode opencode-*
 hooks_file=.opencode/rules/agmsg.md
-monitor=no
-delivery_modes=turn off
+monitor=yes
+delivery_modes=monitor turn off

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1700,13 +1700,6 @@ JSON
   [ ! -f "$TEST_PROJECT/.opencode/rules/agmsg.md" ]
 }
 
-@test "opencode rejects monitor mode" {
-  run bash "$SCRIPTS/delivery.sh" set monitor opencode "$TEST_PROJECT"
-  [ "$status" -ne 0 ]
-  [[ "$output" =~ "not supported" ]]
-  [ ! -f "$TEST_PROJECT/.opencode/rules/agmsg.md" ]
-}
-
 @test "opencode rejects both mode" {
   run bash "$SCRIPTS/delivery.sh" set both opencode "$TEST_PROJECT"
   [ "$status" -ne 0 ]
@@ -1714,15 +1707,45 @@ JSON
   [ ! -f "$TEST_PROJECT/.opencode/rules/agmsg.md" ]
 }
 
-@test "opencode rejects monitor: does NOT delete an existing turn rule" {
+@test "opencode rejects both: does NOT delete an existing turn rule" {
   bash "$SCRIPTS/delivery.sh" set turn opencode "$TEST_PROJECT" >/dev/null
   [ -f "$TEST_PROJECT/.opencode/rules/agmsg.md" ]
-  run bash "$SCRIPTS/delivery.sh" set monitor opencode "$TEST_PROJECT"
+  run bash "$SCRIPTS/delivery.sh" set both opencode "$TEST_PROJECT"
   [ "$status" -ne 0 ]
   [ -f "$TEST_PROJECT/.opencode/rules/agmsg.md" ]
 }
 
-@test "opencode supports turn and off modes: status derives mode from rule file existence" {
+@test "opencode set monitor: passes the delivery_modes gate and writes a sentinel_monitor rule" {
+  run bash "$SCRIPTS/delivery.sh" set monitor opencode "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Delivery mode set to 'monitor'" ]]
+  local rule_file="$TEST_PROJECT/.opencode/rules/agmsg.md"
+  [ -f "$rule_file" ]
+  run cat "$rule_file"
+  [[ "$output" == *"agmsg-delivery-mode: monitor"* ]]
+  [[ "$output" == *"sentinel_monitor"* ]]
+  [[ "$output" == *"watch.sh"* ]]
+  [[ "$output" == *"SENTINEL_SESSION_ID"* ]]
+  # Fallback instructions for when sentinel_monitor is unavailable.
+  [[ "$output" == *"check-inbox.sh"* ]]
+}
+
+@test "opencode status: reports monitor when the monitor rule is present" {
+  bash "$SCRIPTS/delivery.sh" set monitor opencode "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status opencode "$TEST_PROJECT"
+  [[ "$output" =~ "mode: monitor" ]]
+}
+
+@test "opencode set turn then monitor: rewrites the rule from turn to monitor" {
+  bash "$SCRIPTS/delivery.sh" set turn opencode "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status opencode "$TEST_PROJECT"
+  [[ "$output" =~ "mode: turn" ]]
+  bash "$SCRIPTS/delivery.sh" set monitor opencode "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status opencode "$TEST_PROJECT"
+  [[ "$output" =~ "mode: monitor" ]]
+}
+
+@test "opencode supports turn/monitor/off modes: status derives mode from rule file content" {
   run bash "$SCRIPTS/delivery.sh" status opencode "$TEST_PROJECT"
   [[ "$output" =~ "mode: off" ]]
 

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -454,16 +454,14 @@ seed_resumable() {
   [[ "$output" == *"actas"* ]]
 }
 
-@test "spawn: opencode launches its 'run --interactive' fixed subcommand prefix" {
+@test "spawn: opencode launches opencode with --prompt (not a bare positional)" {
   bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
   run bash "$SCRIPTS/spawn.sh" opencode alice --project "$PROJ" --model anthropic/claude-opus-4-8 --no-wait
   [ "$status" -eq 0 ]
   boot="$(cat "$CAPTURE")"
   run cat "$boot"
-  [[ "$output" == *"opencode run --interactive --model anthropic/claude-opus-4-8"* ]]
+  [[ "$output" == *"opencode --model anthropic/claude-opus-4-8 --prompt"* ]]
   [[ "$output" == *"actas"* ]]
-  # no bare 'opencode' invocation without the fixed prefix
-  [[ "$output" != *$'\n''opencode --model'* ]]
 }
 
 @test "spawn: prompt_arg lands after spawn-options, immediately before the prompt" {

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -461,7 +461,12 @@ seed_resumable() {
   boot="$(cat "$CAPTURE")"
   run cat "$boot"
   [[ "$output" == *"opencode --model anthropic/claude-opus-4-8 --prompt"* ]]
-  [[ "$output" == *"actas"* ]]
+  # opencode's actas prompt uses the '$' skill prefix, not Claude Code's '/' (#283).
+  local cmd; cmd="$(basename "$TEST_SKILL_DIR")"
+  run grep -F "\$$cmd"'\ actas' "$boot"
+  [ "$status" -eq 0 ]
+  run grep -F "/$cmd"'\ actas' "$boot"
+  [ "$status" -ne 0 ]
 }
 
 @test "spawn: prompt_arg lands after spawn-options, immediately before the prompt" {


### PR DESCRIPTION
## What

Adds `monitor` mode to the opencode agent type, routing real-time delivery through the [`opencode-sentinel`](https://github.com/tsukimiya/opencode-sentinel) plugin's `sentinel_monitor` tool (same shape as Claude Code's Monitor tool). Falls back to turn-mode self-checks when the plugin is absent.

## Why

opencode has no built-in Monitor-tool equivalent, so until now it could only use `turn` or `off` — messages wait until the next tool call to surface. With the external opencode-sentinel plugin installed, opencode sessions gain a resident command-runner whose stdout lines arrive as steer notifications even in idle sessions — exactly what agmsg's `watch.sh` needs to stream incoming messages in real time.

The rule instructs the agent to launch `watch.sh` under `sentinel_monitor` at session start (or on `/agmsg`), passing `$SENTINEL_SESSION_ID` so the watcher persists its watermark per session. `watch.sh` is runtime-agnostic and tolerates an empty session-id arg, so the command is safe even when the variable is unset. A fallback (turn-mode self-poll) is included for when `sentinel_monitor` is unavailable.

## Scope

- `scripts/drivers/types/opencode/type.conf`: `monitor=yes`, `delivery_modes=monitor turn off`
- `scripts/drivers/types/opencode/_delivery.sh`: `monitor` case writes the sentinel_monitor rule; `status` reports mode from rule content
- `scripts/drivers/types/opencode/template.md`: monitor added to the mode picker, plus an "ensure monitor is running" step and the actas/drop watcher-switch flow
- `tests/test_delivery.bats`: monitor-mode coverage (rule content, status, turn→monitor rewrite, `both` still rejected)
- `README.md` / `README.ja.md` / `docs/opencode.md`: monitor listed as supported via the plugin, with the turn-fallback note

Depends on the companion spawn PR (#546) — the two commits below it are that PR's.

## Tests

`bats tests/test_delivery.bats -f opencode` → 9/9 pass.

## Related

- Companion spawn PR: https://github.com/fujibee/agmsg/pull/546
- opencode-sentinel plugin: https://github.com/tsukimiya/opencode-sentinel
