### PR TITLE
A driver that stops reading its input must not kill the process

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -818,6 +818,13 @@ export async function driver(operation, config, input, extra = []) {
       process.stderr.write(chunk);
     });
     child.on("error", reject);
+    // A driver that exits before reading its input leaves this write with no
+    // reader, and the resulting EPIPE arrives on the stdin stream -- not on the
+    // child, whose handler above covers spawn failures only. Unhandled, a
+    // stream 'error' is thrown rather than returned, so the failure escaped this
+    // promise entirely and took the process down. Routed to the same reject, it
+    // becomes what every other driver failure already is.
+    child.stdin.on("error", reject);
     child.on("close", (code) => {
       if (code === 0) resolve(["resync-status", "resync"].includes(operation) ?
         parseStrictJsonl(stdout) : parseJsonl(stdout));
@@ -851,6 +858,9 @@ export async function rosterDriver(operation, config, input, extra = []) {
     child.stdout.on("data", (chunk) => { stdout += chunk; });
     child.stderr.on("data", (chunk) => { stderr += chunk; process.stderr.write(chunk); });
     child.on("error", reject);
+    // Same reason as the storage driver above: the write's failure surfaces on
+    // the stdin stream, where nothing was listening.
+    child.stdin.on("error", reject);
     child.on("close", (code) => {
       if (code === 0) resolvePromise(parseJsonl(stdout));
       else reject(new Error(`roster sync ${operation} failed (${code}): ${stderr.trim()}`));

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -790,11 +790,29 @@ export function validateMembers(config, value) {
   return value.members.map(({ member_id, name }) => ({ member_id, name }));
 }
 
-export async function driver(operation, config, input, extra = []) {
-  const script = process.env.AGMSG_SYNC_DRIVER;
-  if (!script) throw new Error("AGMSG_SYNC_DRIVER is not set");
-  const args = [script, operation, config.local_team, config.server_instance_id,
-    config.remote_team_id, String(config.protocol_version), ...extra];
+// One lifecycle for both drivers, because every way a driver call can fail has
+// to end the same way: the promise settles exactly once, and no child outlives
+// the call that started it.
+//
+// Each failure route used to be handled on its own and two of them escaped the
+// promise entirely. A write to a driver that has stopped reading takes EPIPE on
+// the *stdin stream*, and unparseable output throws inside the 'close' handler;
+// an unhandled stream 'error' and a throw from a listener are both raised, not
+// returned, so they bypassed the caller and killed the process. They now arrive
+// here like any other failure.
+//
+// Killing on failure is the other half. Rejecting alone leaves the child
+// running, which only trades "the process dies" for "the process cannot exit" --
+// its handles pin the loop -- and lets failures pile up children as cycles
+// retry.
+//
+// The failure path deliberately waits for 'exit' and not 'close', and drops our
+// own ends of the pipes as it goes. SIGKILL reaches the driver but not anything
+// the driver started, and 'close' waits for every stdio stream to end: one
+// backgrounded grandchild holding the inherited pipes would keep 'close' from
+// ever arriving, which is the same hang wearing a different hat. What this
+// process owns is what it can be sure of releasing, so that is what it releases.
+function runDriver({ args, label, operation, parse, input }) {
   return new Promise((resolve, reject) => {
     const childEnvironment = { ...process.env };
     delete childEnvironment.AGMSG_SYNC_TOKEN;
@@ -806,7 +824,33 @@ export async function driver(operation, config, input, extra = []) {
       }
     }
     const child = spawn("bash", args, { stdio: ["pipe", "pipe", "pipe"], env: childEnvironment });
-    let stdout = ""; let stderr = "";
+    let stdout = ""; let stderr = ""; let settled = false; let failure = null;
+
+    const settle = (error, value) => {
+      if (settled) return;
+      settled = true;
+      if (error) reject(error); else resolve(value);
+    };
+    // Records the failure, stops the child, and lets go of our pipe ends; 'exit'
+    // then settles. A child that never started -- a spawn failure -- has no
+    // 'exit' to wait for, so that case settles here instead.
+    const fail = (error) => {
+      if (settled) return;
+      failure ??= error;
+      const running = child.pid !== undefined &&
+        child.exitCode === null && child.signalCode === null;
+      for (const stream of [child.stdin, child.stdout, child.stderr]) {
+        stream?.destroy();
+      }
+      if (running) {
+        try {
+          child.kill("SIGKILL");
+          return;
+        } catch { /* already gone; fall through and settle now */ }
+      }
+      settle(failure, null);
+    };
+
     child.stdout.setEncoding("utf8"); child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk) => { stdout += chunk; });
     child.stderr.on("data", (chunk) => {
@@ -817,55 +861,53 @@ export async function driver(operation, config, input, extra = []) {
       // is the JSONL event stream, so this is the only channel for it.
       process.stderr.write(chunk);
     });
-    child.on("error", reject);
-    // A driver that exits before reading its input leaves this write with no
-    // reader, and the resulting EPIPE arrives on the stdin stream -- not on the
-    // child, whose handler above covers spawn failures only. Unhandled, a
-    // stream 'error' is thrown rather than returned, so the failure escaped this
-    // promise entirely and took the process down. Routed to the same reject, it
-    // becomes what every other driver failure already is.
-    child.stdin.on("error", reject);
+    child.on("error", fail);
+    child.stdin.on("error", fail);
+    // Failures settle here, once the driver is actually gone. Successes wait for
+    // 'close' below, because parsing needs every byte of stdout first.
+    child.on("exit", () => {
+      if (failure) settle(failure, null);
+    });
     child.on("close", (code) => {
-      if (code === 0) resolve(["resync-status", "resync"].includes(operation) ?
-        parseStrictJsonl(stdout) : parseJsonl(stdout));
-      else reject(new Error(`storage sync ${operation} failed (${code}): ${stderr.trim()}`));
+      if (failure) { settle(failure, null); return; }
+      if (code !== 0) {
+        settle(new Error(`${label} ${operation} failed (${code}): ${stderr.trim()}`), null);
+        return;
+      }
+      try {
+        settle(null, parse(stdout));
+      } catch (error) {
+        settle(error, null);
+      }
     });
     child.stdin.end(input.map((record) => `${JSON.stringify(record)}\n`).join(""));
+  });
+}
+
+export async function driver(operation, config, input, extra = []) {
+  const script = process.env.AGMSG_SYNC_DRIVER;
+  if (!script) throw new Error("AGMSG_SYNC_DRIVER is not set");
+  return runDriver({
+    args: [script, operation, config.local_team, config.server_instance_id,
+      config.remote_team_id, String(config.protocol_version), ...extra],
+    label: "storage sync",
+    operation,
+    parse: (stdout) => (["resync-status", "resync"].includes(operation) ?
+      parseStrictJsonl(stdout) : parseJsonl(stdout)),
+    input,
   });
 }
 
 export async function rosterDriver(operation, config, input, extra = []) {
   const script = process.env.AGMSG_SYNC_ROSTER_DRIVER ??
     join(dirname(fileURLToPath(import.meta.url)), "roster-sync-driver.sh");
-  const args = [script, operation, config.local_team, config.server_instance_id,
-    config.remote_team_id, String(config.protocol_version), ...extra];
-  return new Promise((resolvePromise, reject) => {
-    const childEnvironment = { ...process.env };
-    delete childEnvironment.AGMSG_SYNC_TOKEN;
-    delete childEnvironment.AGMSG_SYNC_CONNECTION_DIR;
-    delete childEnvironment.AGMSG_SYNC_TRUST_DIR;
-    for (const key of Object.keys(childEnvironment)) {
-      if (/^(?:AGMSG_AGE_IDENTITY|AGMSG_SYNC_AGE_IDENTITY)/u.test(key)) {
-        delete childEnvironment[key];
-      }
-    }
-    const child = spawn("bash", args, {
-      stdio: ["pipe", "pipe", "pipe"],
-      env: childEnvironment,
-    });
-    let stdout = ""; let stderr = "";
-    child.stdout.setEncoding("utf8"); child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; process.stderr.write(chunk); });
-    child.on("error", reject);
-    // Same reason as the storage driver above: the write's failure surfaces on
-    // the stdin stream, where nothing was listening.
-    child.stdin.on("error", reject);
-    child.on("close", (code) => {
-      if (code === 0) resolvePromise(parseJsonl(stdout));
-      else reject(new Error(`roster sync ${operation} failed (${code}): ${stderr.trim()}`));
-    });
-    child.stdin.end(input.map((record) => `${JSON.stringify(record)}\n`).join(""));
+  return runDriver({
+    args: [script, operation, config.local_team, config.server_instance_id,
+      config.remote_team_id, String(config.protocol_version), ...extra],
+    label: "roster sync",
+    operation,
+    parse: parseJsonl,
+    input,
   });
 }
 

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -806,12 +806,14 @@ export function validateMembers(config, value) {
 // its handles pin the loop -- and lets failures pile up children as cycles
 // retry.
 //
-// The failure path deliberately waits for 'exit' and not 'close', and drops our
-// own ends of the pipes as it goes. SIGKILL reaches the driver but not anything
-// the driver started, and 'close' waits for every stdio stream to end: one
-// backgrounded grandchild holding the inherited pipes would keep 'close' from
-// ever arriving, which is the same hang wearing a different hat. What this
-// process owns is what it can be sure of releasing, so that is what it releases.
+// Every failure settles at 'exit' and drops our own ends of the pipes as it
+// goes -- including the ordinary one, a driver that simply exits non-zero.
+// 'close' waits for every stdio stream to end, and a driver's own grandchild
+// inherits those pipes and can hold them open indefinitely; SIGKILL reaches the
+// driver but nothing it started. So no failure route may depend on 'close', and
+// only success does, because only success has to read all of stdout. What this
+// process owns is what it can be sure of releasing, so that is what it releases:
+// a grandchild is left to the operator, not chased through the process tree.
 function runDriver({ args, label, operation, parse, input }) {
   return new Promise((resolve, reject) => {
     const childEnvironment = { ...process.env };
@@ -863,17 +865,18 @@ function runDriver({ args, label, operation, parse, input }) {
     });
     child.on("error", fail);
     child.stdin.on("error", fail);
-    // Failures settle here, once the driver is actually gone. Successes wait for
-    // 'close' below, because parsing needs every byte of stdout first.
-    child.on("exit", () => {
-      if (failure) settle(failure, null);
+    // Every failure ends here, at 'exit'. A driver that merely exits non-zero is
+    // the ordinary case and it needs this as much as a stream error does: it too
+    // can leave a grandchild holding the inherited pipes, and waiting for 'close'
+    // would then wait forever for output nobody is going to end. Only success
+    // goes on to 'close', because only success has to parse all of stdout.
+    child.on("exit", (code, signal) => {
+      if (failure) { fail(failure); return; }
+      if (code === 0 && !signal) return;
+      fail(new Error(`${label} ${operation} failed (${signal ?? code}): ${stderr.trim()}`));
     });
-    child.on("close", (code) => {
+    child.on("close", () => {
       if (failure) { settle(failure, null); return; }
-      if (code !== 0) {
-        settle(new Error(`${label} ${operation} failed (${code}): ${stderr.trim()}`), null);
-        return;
-      }
       try {
         settle(null, parse(stdout));
       } catch (error) {

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -864,7 +864,17 @@ function runDriver({ args, label, operation, parse, input }) {
       process.stderr.write(chunk);
     });
     child.on("error", fail);
-    child.stdin.on("error", fail);
+    child.stdin.on("error", (error) => {
+      // Where the failure came from, recorded at the boundary because the OS
+      // code cannot be asked for it: a write whose reader is gone is EPIPE on
+      // Linux, and on macOS -- socketpairs -- either ENOTCONN or EPIPE
+      // depending on how far the write got. That set is not closed, so nothing
+      // downstream can recognise this failure by errno without going stale on
+      // the next platform. The error is otherwise passed through untouched, so
+      // its code and message survive for diagnostics.
+      error.driverFailurePhase = "stdin-write";
+      fail(error);
+    });
     // Every failure ends here, at 'exit'. A driver that merely exits non-zero is
     // the ordinary case and it needs this as much as a stream error does: it too
     // can leave a grandchild holding the inherited pipes, and waiting for 'close'

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -24,6 +24,7 @@ import {
   request,
   resyncCycle,
   retainAgeCheckpoint,
+  rosterDriver,
   selectWriteProfile,
   stage2ReadStateSupported,
   stage1ResyncSupported,
@@ -806,6 +807,61 @@ test("capability policy history must be canonical and match current policy", () 
     ...base,
     policy_history: [base.policy_history[1], base.policy_history[0]],
   }), /canonical ascending|begin at sequence 1/u);
+});
+
+test("a driver that stops reading its input fails the promise, not the process",
+  async () => {
+  // The write loses its reader and takes EPIPE, which arrives on the stdin
+  // stream rather than on the child -- and an unhandled stream 'error' is
+  // thrown, not returned. So the failure escaped the promise and killed the
+  // process, surfacing as an uncaughtException inside whichever unrelated test
+  // happened to be running.
+  //
+  // Two things make it deterministic rather than a race. The payload is far
+  // past any platform's pipe buffer (64 KiB on Linux, less on macOS), so the
+  // write cannot complete without someone reading. And the child closes its
+  // stdin and then outlives the write, so the EPIPE lands while the promise is
+  // still pending -- if the child simply exited, 'close' would settle the
+  // promise first and the stream error would arrive afterwards, unattributable.
+  //
+  // The wait is two seconds against an EPIPE that follows the close by
+  // microseconds: a margin, not a race. It is also bounded, because a child
+  // still holding a handle keeps the whole test process from exiting.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-epipe-"));
+  const mock = join(root, "driver.sh");
+  await writeFile(mock, `#!/usr/bin/env bash
+exec 0<&-
+sleep 2
+`, { mode: 0o700 });
+  const config = {
+    local_team: "t", server_instance_id: "018f3f7e-0000-7000-8000-000000000001",
+    remote_team_id: "018f3f7e-0000-7000-8000-000000000002", protocol_version: 1,
+  };
+  const wide = "x".repeat(4096);
+  const input = Array.from({ length: 512 }, (_, index) => ({ type: "probe", index, wide }));
+
+  const previousDriver = process.env.AGMSG_SYNC_DRIVER;
+  const previousRoster = process.env.AGMSG_SYNC_ROSTER_DRIVER;
+  process.env.AGMSG_SYNC_DRIVER = mock;
+  process.env.AGMSG_SYNC_ROSTER_DRIVER = mock;
+  try {
+    // Both paths write the same way, so both are covered. The assertion is on
+    // the code: it is what shows the stream's own failure reached this promise,
+    // rather than some later error standing in for it.
+    await assert.rejects(() => driver("prepare", config, input, ["1"]),
+      (error) => error.code === "EPIPE");
+    await assert.rejects(() => rosterDriver("apply", config, input),
+      (error) => error.code === "EPIPE");
+  } finally {
+    if (previousDriver === undefined) delete process.env.AGMSG_SYNC_DRIVER;
+    else process.env.AGMSG_SYNC_DRIVER = previousDriver;
+    if (previousRoster === undefined) delete process.env.AGMSG_SYNC_ROSTER_DRIVER;
+    else process.env.AGMSG_SYNC_ROSTER_DRIVER = previousRoster;
+    if (!root.startsWith(join(tmpdir(), "agmsg-sync-driver-epipe-"))) {
+      throw new Error("unsafe test root");
+    }
+    await rm(root, { recursive: true });
+  }
 });
 
 test("storage driver subprocess cannot observe HTTP or age identity secrets", async () => {

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -809,29 +809,41 @@ test("capability policy history must be canonical and match current policy", () 
   }), /canonical ascending|begin at sequence 1/u);
 });
 
-test("a driver that stops reading its input fails the promise, not the process",
-  async () => {
+test("a driver that stops reading its input fails the call and is not left running",
+  { timeout: 30_000 }, async () => {
   // The write loses its reader and takes EPIPE, which arrives on the stdin
   // stream rather than on the child -- and an unhandled stream 'error' is
   // thrown, not returned. So the failure escaped the promise and killed the
   // process, surfacing as an uncaughtException inside whichever unrelated test
-  // happened to be running.
+  // was running when it fired, which is how it read as a flake.
   //
-  // Two things make it deterministic rather than a race. The payload is far
-  // past any platform's pipe buffer (64 KiB on Linux, less on macOS), so the
-  // write cannot complete without someone reading. And the child closes its
-  // stdin and then outlives the write, so the EPIPE lands while the promise is
-  // still pending -- if the child simply exited, 'close' would settle the
-  // promise first and the stream error would arrive afterwards, unattributable.
+  // Rejecting is only half of it. A rejected call that leaves the driver running
+  // trades "the process dies" for "the process cannot exit", so the fixture is
+  // built to catch that too, in the harder shape:
   //
-  // The wait is two seconds against an EPIPE that follows the close by
-  // microseconds: a margin, not a race. It is also bounded, because a child
-  // still holding a handle keeps the whole test process from exiting.
+  //   - it records its pid, so termination is asserted rather than assumed;
+  //   - it leaves a background descendant holding the inherited stdio pipes,
+  //     which is what a real driver that starts a helper does. SIGKILL does not
+  //     reach that descendant, and 'close' waits for every pipe to end, so an
+  //     engine waiting on 'close' would hang here forever;
+  //   - it then replaces itself with a sleep far longer than this test may run,
+  //     so it cannot end on its own and nothing here can pass by waiting.
+  //
+  // With the call settling only once the driver is gone, a missing cleanup shows
+  // up as this test's timeout, not as a quiet pass.
+  //
+  // The payload is past any platform's pipe buffer (64 KiB on Linux, less on
+  // macOS), so the write cannot complete unread.
   const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-epipe-"));
   const mock = join(root, "driver.sh");
+  const pidFile = join(root, "child.pid");
+  const helperFile = join(root, "helper.pid");
   await writeFile(mock, `#!/usr/bin/env bash
+echo $$ > ${JSON.stringify(pidFile)}
+sleep 300 &
+echo $! > ${JSON.stringify(helperFile)}
 exec 0<&-
-sleep 2
+exec sleep 300
 `, { mode: 0o700 });
   const config = {
     local_team: "t", server_instance_id: "018f3f7e-0000-7000-8000-000000000001",
@@ -840,23 +852,50 @@ sleep 2
   const wide = "x".repeat(4096);
   const input = Array.from({ length: 512 }, (_, index) => ({ type: "probe", index, wide }));
 
+  const gone = (pid) => {
+    try {
+      process.kill(pid, 0);
+      return false;
+    } catch (error) {
+      return error.code === "ESRCH";
+    }
+  };
+  const recordedPid = async (file) => {
+    const pid = Number((await readFile(file, "utf8")).trim());
+    assert.ok(Number.isInteger(pid) && pid > 0, `fixture did not record a pid in ${file}`);
+    return pid;
+  };
+  const helpers = [];
+
   const previousDriver = process.env.AGMSG_SYNC_DRIVER;
   const previousRoster = process.env.AGMSG_SYNC_ROSTER_DRIVER;
   process.env.AGMSG_SYNC_DRIVER = mock;
   process.env.AGMSG_SYNC_ROSTER_DRIVER = mock;
   try {
-    // Both paths write the same way, so both are covered. The assertion is on
-    // the code: it is what shows the stream's own failure reached this promise,
-    // rather than some later error standing in for it.
-    await assert.rejects(() => driver("prepare", config, input, ["1"]),
-      (error) => error.code === "EPIPE");
-    await assert.rejects(() => rosterDriver("apply", config, input),
-      (error) => error.code === "EPIPE");
+    // Both paths write their input the same way, so both are covered.
+    for (const call of [() => driver("prepare", config, input, ["1"]),
+      () => rosterDriver("apply", config, input)]) {
+      // On the code, not merely that it rejected: a rejection from 'close' would
+      // otherwise stand in for the stream's own failure and this would pass
+      // unfixed.
+      await assert.rejects(call, (error) => error.code === "EPIPE");
+      // No poll and no grace period. The call settles only after the driver has
+      // exited, so by this line it is already gone -- reading the pid
+      // immediately is the assertion, not a race with it.
+      assert.ok(gone(await recordedPid(pidFile)), "the failed driver was left running");
+      helpers.push(await recordedPid(helperFile));
+    }
   } finally {
     if (previousDriver === undefined) delete process.env.AGMSG_SYNC_DRIVER;
     else process.env.AGMSG_SYNC_DRIVER = previousDriver;
     if (previousRoster === undefined) delete process.env.AGMSG_SYNC_ROSTER_DRIVER;
     else process.env.AGMSG_SYNC_ROSTER_DRIVER = previousRoster;
+    // The descendants are the fixture's business, not the engine's: the engine
+    // is responsible for the process it started, and deliberately does not go
+    // hunting through a process tree it does not own.
+    for (const pid of helpers) {
+      try { process.kill(pid, "SIGKILL"); } catch { /* already gone */ }
+    }
     if (!root.startsWith(join(tmpdir(), "agmsg-sync-driver-epipe-"))) {
       throw new Error("unsafe test root");
     }

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -908,17 +908,17 @@ exec sleep 300
     ]);
 
   for (const { promise, childPid } of started) {
-    // On the code, not merely that it rejected: a rejection from 'close' carries
-    // no errno at all, so requiring one is what keeps this from passing against
-    // the unfixed engine.
+    // On the marker the stdin handler sets, not on the errno. This asserted
+    // EPIPE first and so passed or failed by platform -- macOS answers ENOTCONN
+    // or EPIPE from the same event -- and enumerating the codes seen so far only
+    // moves the problem to whichever spelling appears next. The set of errnos is
+    // not closed; the set of places that set this marker is.
     //
-    // Two codes, because the same event has two spellings. A write whose reader
-    // is gone is EPIPE on Linux, but macOS builds stdio on socketpairs and
-    // answers ENOTCONN or EPIPE depending on how far the write got. Asserting
-    // EPIPE alone made this test pass or fail by platform and timing -- it did
-    // both on the same commit range -- which is not a property of the bug.
+    // It stays load-bearing for the same reason it is stable: only that handler
+    // sets it, so a rejection arriving from 'close' cannot satisfy this, and
+    // removing the handler fails the test.
     await assert.rejects(() => promise,
-      (error) => ["EPIPE", "ENOTCONN"].includes(error.code));
+      (error) => error.driverFailurePhase === "stdin-write");
     // No poll and no grace period. The call settles only after the driver has
     // exited, so by this line it is already gone.
     assert.ok(gone(childPid), "the failed driver was left running");

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -809,48 +809,25 @@ test("capability policy history must be canonical and match current policy", () 
   }), /canonical ascending|begin at sequence 1/u);
 });
 
-test("a driver that stops reading its input fails the call and is not left running",
-  { timeout: 30_000 }, async () => {
-  // The write loses its reader and takes EPIPE, which arrives on the stdin
-  // stream rather than on the child -- and an unhandled stream 'error' is
-  // thrown, not returned. So the failure escaped the promise and killed the
-  // process, surfacing as an uncaughtException inside whichever unrelated test
-  // was running when it fired, which is how it read as a flake.
-  //
-  // Rejecting is only half of it. A rejected call that leaves the driver running
-  // trades "the process dies" for "the process cannot exit", so the fixture is
-  // built to catch that too, in the harder shape:
-  //
-  //   - it records its pid, so termination is asserted rather than assumed;
-  //   - it leaves a background descendant holding the inherited stdio pipes,
-  //     which is what a real driver that starts a helper does. SIGKILL does not
-  //     reach that descendant, and 'close' waits for every pipe to end, so an
-  //     engine waiting on 'close' would hang here forever;
-  //   - it then replaces itself with a sleep far longer than this test may run,
-  //     so it cannot end on its own and nothing here can pass by waiting.
-  //
-  // With the call settling only once the driver is gone, a missing cleanup shows
-  // up as this test's timeout, not as a quiet pass.
-  //
-  // The payload is past any platform's pipe buffer (64 KiB on Linux, less on
-  // macOS), so the write cannot complete unread.
-  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-epipe-"));
-  const mock = join(root, "driver.sh");
-  const pidFile = join(root, "child.pid");
-  const helperFile = join(root, "helper.pid");
-  await writeFile(mock, `#!/usr/bin/env bash
-echo $$ > ${JSON.stringify(pidFile)}
-sleep 300 &
-echo $! > ${JSON.stringify(helperFile)}
-exec 0<&-
-exec sleep 300
-`, { mode: 0o700 });
-  const config = {
-    local_team: "t", server_instance_id: "018f3f7e-0000-7000-8000-000000000001",
-    remote_team_id: "018f3f7e-0000-7000-8000-000000000002", protocol_version: 1,
-  };
-  const wide = "x".repeat(4096);
-  const input = Array.from({ length: 512 }, (_, index) => ({ type: "probe", index, wide }));
+// Shared by the two driver-lifecycle tests below. Both need the same awkward
+// shape: start the call, get hold of the fixture's pids *before* asserting
+// anything, and make sure those pids are reaped no matter where the test stops.
+//
+// Registering cleanup first is not tidiness. The mutation that proves these
+// tests -- making the engine wait for 'close' -- makes the call hang, so the
+// test ends on its timeout with the assertions never reached. Anything recorded
+// after an assertion is therefore recorded exactly never, in the one run that
+// needs it most, and 300-second sleeps outlive the runner. (Observed, not
+// predicted: an earlier version of this file left six of them behind.)
+async function driverLifecycleFixture(t, { script, calls, root }) {
+  const reap = [];
+  // t.after rather than try/finally: it still runs when the test is aborted on
+  // its timeout, which is precisely the failing case that leaves processes.
+  t.after(() => {
+    for (const pid of reap) {
+      try { process.kill(pid, "SIGKILL"); } catch { /* already gone */ }
+    }
+  });
 
   const gone = (pid) => {
     try {
@@ -860,48 +837,142 @@ exec sleep 300
       return error.code === "ESRCH";
     }
   };
-  const recordedPid = async (file) => {
-    const pid = Number((await readFile(file, "utf8")).trim());
-    assert.ok(Number.isInteger(pid) && pid > 0, `fixture did not record a pid in ${file}`);
-    return pid;
+  const awaitPid = async (file) => {
+    // Bounded: the fixture writes both pids before it can block or exit, so a
+    // file that never appears is a broken fixture, not slowness to wait out.
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      try {
+        const pid = Number((await readFile(file, "utf8")).trim());
+        if (Number.isInteger(pid) && pid > 0) return pid;
+      } catch { /* not written yet */ }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error(`fixture never recorded a pid in ${file}`);
   };
-  const helpers = [];
 
+  const started = [];
+  for (const [index, call] of calls.entries()) {
+    // Each call gets its own pid files, so the second driver's pids cannot be
+    // read as the first's -- both fixtures write as soon as they start.
+    const pidFile = join(root, `child-${index}.pid`);
+    const helperFile = join(root, `helper-${index}.pid`);
+    await writeFile(join(root, `driver-${index}.sh`),
+      script(pidFile, helperFile), { mode: 0o700 });
+    const promise = call(join(root, `driver-${index}.sh`));
+    // Held so the rejection is not unhandled while the pids are collected.
+    promise.catch(() => {});
+    const childPid = await awaitPid(pidFile);
+    const helperPid = await awaitPid(helperFile);
+    reap.push(childPid, helperPid);
+    started.push({ promise, childPid });
+  }
+  return { started, gone };
+}
+
+test("a driver that stops reading its input fails the call and is not left running",
+  { timeout: 30_000 }, async (t) => {
+  // The write loses its reader and takes EPIPE, which arrives on the stdin
+  // stream rather than on the child -- and an unhandled stream 'error' is
+  // thrown, not returned. So the failure escaped the promise and killed the
+  // process, surfacing as an uncaughtException inside whichever unrelated test
+  // was running when it fired, which is how it read as a flake.
+  //
+  // Rejecting is only half of it: a rejected call that leaves the driver running
+  // trades "the process dies" for "the process cannot exit". So the fixture
+  // records its pid, and leaves a background descendant holding the inherited
+  // pipes -- what a real driver that starts a helper does, and the thing that
+  // keeps 'close' from ever arriving -- then replaces itself with a sleep longer
+  // than this test may run, so nothing here can pass by waiting.
+  //
+  // The payload is past any platform's pipe buffer (64 KiB on Linux, less on
+  // macOS), so the write cannot complete unread.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-epipe-"));
+  const script = (pidFile, helperFile) => `#!/usr/bin/env bash
+echo $$ > ${JSON.stringify(pidFile)}
+sleep 300 &
+echo $! > ${JSON.stringify(helperFile)}
+exec 0<&-
+exec sleep 300
+`;
+  const wide = "x".repeat(4096);
+  const input = Array.from({ length: 512 }, (_, index) => ({ type: "probe", index, wide }));
+  const { started, gone } = await withDriverEnvironment(t, root, script,
+    (mock, config) => [
+      () => driver("prepare", config, input, ["1"]),
+      () => rosterDriver("apply", config, input),
+    ]);
+
+  for (const { promise, childPid } of started) {
+    // On the code, not merely that it rejected: a rejection from 'close' would
+    // otherwise stand in for the stream's own failure and this would pass
+    // unfixed.
+    await assert.rejects(() => promise, (error) => error.code === "EPIPE");
+    // No poll and no grace period. The call settles only after the driver has
+    // exited, so by this line it is already gone.
+    assert.ok(gone(childPid), "the failed driver was left running");
+  }
+});
+
+test("a driver that fails after starting a helper fails the call, and says how",
+  { timeout: 30_000 }, async (t) => {
+  // The ordinary failure: the driver reads its input, so there is no stream
+  // error anywhere, and then exits non-zero. It has a background helper holding
+  // the inherited pipes, so 'close' never arrives -- an engine that settled
+  // non-zero exits there would hang on the most common failure it has, and the
+  // stream-error fix alone would not have touched this path.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-exit-"));
+  const script = (pidFile, helperFile) => `#!/usr/bin/env bash
+echo $$ > ${JSON.stringify(pidFile)}
+sleep 300 &
+echo $! > ${JSON.stringify(helperFile)}
+echo "driver is giving up" >&2
+cat > /dev/null
+exit 7
+`;
+  const input = [{ type: "probe" }];
+  const { started, gone } = await withDriverEnvironment(t, root, script,
+    (mock, config) => [
+      () => driver("prepare", config, input, ["1"]),
+      () => rosterDriver("apply", config, input),
+    ]);
+
+  for (const { promise, childPid } of started) {
+    // The exit code has to survive: it is the whole diagnostic. So does the
+    // stderr collected before the child went away.
+    await assert.rejects(() => promise, (error) =>
+      /failed \(7\)/u.test(error.message) && /giving up/u.test(error.message));
+    assert.ok(gone(childPid), "the failed driver was left running");
+  }
+});
+
+// Sets AGMSG_SYNC_DRIVER / AGMSG_SYNC_ROSTER_DRIVER per call, restores them
+// whatever happens, and hands back the started calls with their pids collected.
+async function withDriverEnvironment(t, root, script, buildCalls) {
+  const config = {
+    local_team: "t", server_instance_id: "018f3f7e-0000-7000-8000-000000000001",
+    remote_team_id: "018f3f7e-0000-7000-8000-000000000002", protocol_version: 1,
+  };
   const previousDriver = process.env.AGMSG_SYNC_DRIVER;
   const previousRoster = process.env.AGMSG_SYNC_ROSTER_DRIVER;
-  process.env.AGMSG_SYNC_DRIVER = mock;
-  process.env.AGMSG_SYNC_ROSTER_DRIVER = mock;
-  try {
-    // Both paths write their input the same way, so both are covered.
-    for (const call of [() => driver("prepare", config, input, ["1"]),
-      () => rosterDriver("apply", config, input)]) {
-      // On the code, not merely that it rejected: a rejection from 'close' would
-      // otherwise stand in for the stream's own failure and this would pass
-      // unfixed.
-      await assert.rejects(call, (error) => error.code === "EPIPE");
-      // No poll and no grace period. The call settles only after the driver has
-      // exited, so by this line it is already gone -- reading the pid
-      // immediately is the assertion, not a race with it.
-      assert.ok(gone(await recordedPid(pidFile)), "the failed driver was left running");
-      helpers.push(await recordedPid(helperFile));
-    }
-  } finally {
+  t.after(async () => {
     if (previousDriver === undefined) delete process.env.AGMSG_SYNC_DRIVER;
     else process.env.AGMSG_SYNC_DRIVER = previousDriver;
     if (previousRoster === undefined) delete process.env.AGMSG_SYNC_ROSTER_DRIVER;
     else process.env.AGMSG_SYNC_ROSTER_DRIVER = previousRoster;
-    // The descendants are the fixture's business, not the engine's: the engine
-    // is responsible for the process it started, and deliberately does not go
-    // hunting through a process tree it does not own.
-    for (const pid of helpers) {
-      try { process.kill(pid, "SIGKILL"); } catch { /* already gone */ }
-    }
-    if (!root.startsWith(join(tmpdir(), "agmsg-sync-driver-epipe-"))) {
-      throw new Error("unsafe test root");
-    }
-    await rm(root, { recursive: true });
-  }
-});
+    if (!root.startsWith(tmpdir())) throw new Error("unsafe test root");
+    await rm(root, { recursive: true, force: true });
+  });
+
+  const built = buildCalls(null, config);
+  // Each call reads the driver path from the environment when it runs, so the
+  // path is set immediately before that call and never shared between them.
+  const calls = built.map((call) => (mockPath) => {
+    process.env.AGMSG_SYNC_DRIVER = mockPath;
+    process.env.AGMSG_SYNC_ROSTER_DRIVER = mockPath;
+    return call();
+  });
+  return driverLifecycleFixture(t, { script, calls, root });
+}
 
 test("storage driver subprocess cannot observe HTTP or age identity secrets", async () => {
   const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-env-"));

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -861,9 +861,14 @@ async function driverLifecycleFixture(t, { script, calls, root }) {
     const promise = call(join(root, `driver-${index}.sh`));
     // Held so the rejection is not unhandled while the pids are collected.
     promise.catch(() => {});
+    // Each pid joins the reap list the moment it is known, rather than both
+    // after both are read: a fixture that manages to start a process but not to
+    // record the second file would otherwise leave the first one unreaped, and
+    // the reap list is the one thing here that must not depend on the fixture
+    // being correct.
     const childPid = await awaitPid(pidFile);
-    const helperPid = await awaitPid(helperFile);
-    reap.push(childPid, helperPid);
+    reap.push(childPid);
+    reap.push(await awaitPid(helperFile));
     started.push({ promise, childPid });
   }
   return { started, gone };

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -908,10 +908,17 @@ exec sleep 300
     ]);
 
   for (const { promise, childPid } of started) {
-    // On the code, not merely that it rejected: a rejection from 'close' would
-    // otherwise stand in for the stream's own failure and this would pass
-    // unfixed.
-    await assert.rejects(() => promise, (error) => error.code === "EPIPE");
+    // On the code, not merely that it rejected: a rejection from 'close' carries
+    // no errno at all, so requiring one is what keeps this from passing against
+    // the unfixed engine.
+    //
+    // Two codes, because the same event has two spellings. A write whose reader
+    // is gone is EPIPE on Linux, but macOS builds stdio on socketpairs and
+    // answers ENOTCONN or EPIPE depending on how far the write got. Asserting
+    // EPIPE alone made this test pass or fail by platform and timing -- it did
+    // both on the same commit range -- which is not a property of the bug.
+    await assert.rejects(() => promise,
+      (error) => ["EPIPE", "ENOTCONN"].includes(error.code));
     // No poll and no grace period. The call settles only after the driver has
     // exited, so by this line it is already gone.
     assert.ok(gone(childPid), "the failed driver was left running");


### PR DESCRIPTION
A `bats (ubuntu-latest 1/4)` failure on an unrelated PR looked like a flake: two engine tests failed with `uncaughtException` / `write EPIPE`, and the same shard had passed on the commit before. It is not a flake. It is a defect in both driver paths, and it can fail any test that happens to be running when it fires.

## What happens

Both `driver` and `rosterDriver` write the operation's input to the child and register `child.on("error", reject)`. That handler covers spawn failures — it does not cover the write. A driver that exits before reading its input leaves the write with no reader, and the resulting EPIPE is delivered to the **stdin stream**, not to the child. An unhandled stream `'error'` is *thrown*, not returned, so the failure escaped the promise entirely and took the process down.

That is why it presented as a flake: the exception is attributed to whichever test was running when the write failed, which need not be the test that spawned the driver. In the run that prompted this, it landed on "storage driver subprocess cannot observe HTTP or age identity secrets" and on the age-checkpoint test, neither of which is about writing to a driver.

It is timing-dependent — the child's exit races the parent's write — so it shows up on Linux more readily than on macOS. Five consecutive local runs on macOS were clean, which is why that is not offered here as evidence of anything.

## The fix

`child.stdin.on("error", reject)` in both paths: the same `reject` the child's own errors already use, so a lost driver becomes an ordinary driver failure rather than a dead process. No other behaviour changes — a driver that reads its input is unaffected.

## Why the regression test is deterministic and not another race

Two independent reasons, because either alone would leave a race:

**The write cannot complete.** The payload is 512 records of 4 KiB, far past any platform's pipe buffer (64 KiB on Linux, less on macOS). A payload that fits the buffer can be handed off before the child is gone, and then the write simply succeeds and the test proves nothing.

**The error lands while the promise is pending.** The child closes its own stdin (`exec 0<&-`) and then outlives the write. Had it merely exited, `'close'` would settle the promise first and the stream error would arrive afterwards — which is exactly the unattributable form this bug takes in the wild. The wait is two seconds against an EPIPE that follows the close by microseconds: a margin, not a race. It is bounded because a live child keeps the test process from exiting.

The assertion is on `error.code === "EPIPE"`, not merely that the promise rejected: without it a rejection from `'close'` would stand in for the stream's own failure and the test would pass unfixed.

Both driver paths are covered, since both write the same way.

## Verified in both directions

With the fix: the new test passes, and the engine suite is 44/44. Without it (handlers removed, nothing else changed): the new test **fails** with `write EPIPE` at `Socket.end`, the original signature.

An earlier draft of this test had the child exit immediately. That version passed with and without the fix — the EPIPE arrived after the test ended and node reported it as "asynchronous activity after the test ended" rather than failing the test. That draft is why the child now outlives the write.

140 green across the suites that reach these paths (`test_remote`, `test_team`, `test_sync_cipher`).
