### PR TITLE
docs(codex): document safe Git Bash quoting from PowerShell (re-land of #437)

### DIFF
--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -13,6 +13,12 @@ If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call 
 
 Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" codex`
 
+**Windows PowerShell:** The Shell requirement above still applies, but a bare `bash` in PowerShell often resolves to the WSL shim. Invoke **Git Bash** explicitly and keep the entire `-lc` payload inside one PowerShell single-quoted string:
+
+`& 'C:\Program Files\Git\bin\bash.exe' -lc '~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" codex'`
+
+Do not use POSIX `'"'"'` quote splicing in PowerShell; it can leave the `-lc` payload unterminated. Windows PowerShell 5.1 strips the embedded double quotes when passing the payload, so `"$(pwd)"` arrives unquoted — fine unless the current directory contains spaces; prefer PowerShell 7.3+ if it does. If Git Bash is installed elsewhere, replace the executable path above with its actual path.
+
 Four possible outputs:
 
 **A) Single identity:**

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -36,6 +36,13 @@ teardown() {
   [[ "$output" =~ "hello from install" ]]
 }
 
+@test "install: Codex skill documents safe Git Bash quoting for Windows PowerShell" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg --agent-type codex
+
+  grep -Fq "& 'C:\\Program Files\\Git\\bin\\bash.exe' -lc '~/.agents/skills/agmsg/scripts/whoami.sh \"\$(pwd)\" codex'" "$SK/SKILL.md"
+  grep -Fq "Do not use POSIX \`'\"'\"'\` quote splicing in PowerShell" "$SK/SKILL.md"
+}
+
 @test "install: --update restores scripts/lib even if it went missing" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
   bash "$SK/scripts/join.sh" demo alice claude-code /tmp/install-update-projA


### PR DESCRIPTION
Re-lands @otsune's #437 unchanged, from a branch in this repository.

The commit is theirs — cherry-picked, so authorship is preserved rather than reattributed. This PR exists only because #437 cannot be merged as it stands: its checks ran before the bats suite was split into shards, so the required context (`bats`, the summary job) has never reported on that head and GitHub blocks the merge regardless of content. The red mark on #437 is a nine-day-old cancelled macOS job, not a test failure. Rather than send an external contributor round for our own CI churn, the change moves here.

## What it documents

Codex on native Windows frequently starts agent commands from PowerShell, where a bare `bash` often resolves to the WSL shim rather than Git Bash, and POSIX `'"'"'` quote splicing can leave a `-lc` payload unterminated. The Codex template gains an explicit Git Bash invocation next to the `whoami.sh` step, and a note that Windows PowerShell 5.1 does not preserve the embedded double quotes when forwarding the payload — so `"$(pwd)"` arrives unquoted and a directory containing spaces breaks, with 7.3+ recommended in that case.

That last point is documented rather than measured: PowerShell 7.3 changed native command argument passing, and Microsoft documents it as a breaking change from the 5.1 behaviour. Neither #437 nor this PR runs PowerShell in CI, so the basis is the published specification, not an observation from this repository.

## Tests

The added smoke test asserts the text in the *installed* `SKILL.md`, which is generated from the type template — so it pins what users actually receive rather than the template source. It lives in `tests/test_install.bats`, which is the file the Windows CI leg runs, so the backslash- and quote-bearing expectations get exercised under Git Bash.

`bats tests/test_install.bats` — 47/47, exit 0.

Closes #437 once this lands.
