### PR TITLE
docs: user-facing remote setup guide; dogfood doc to ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ That's it. The slash command prompts you for a team name and an agent name on fi
 
 Prefer to inspect the code first, track the latest `main`, or pick a custom command name? See [Install](#install) below for the `setup.sh` one-liner, `git clone`, and the Claude Code plugin marketplace paths.
 
+To sync a team between two installs through the self-hosted reference server, follow [Remote setup](docs/remote-setup.md).
+
 ## How it works
 
 agmsg is a thin transport. Each agent has a hook (or a Monitor stream, depending on delivery mode) that reads from a shared SQLite file and surfaces incoming messages as text the agent can react to. Sending is a `send.sh` call that appends a row. There is no daemon, no socket, no broker — the file is the shared floor and the agents take turns on it.

--- a/docs/design/ref/remote-sync-dogfood.md
+++ b/docs/design/ref/remote-sync-dogfood.md
@@ -1,5 +1,8 @@
 # Stage-1 remote sync dogfood
 
+> Reference only. Delete this document when `integration/remote` merges to
+> `main`.
+
 Stage 1 polls the draft reference server while every `send` still commits to the
 local SQLite store first. It is intentionally branch-only and is not installed
 by the released core yet.
@@ -150,7 +153,7 @@ identity path stays in the engine configuration and is used only while opening
 pulled envelopes. Joining an established rotated binding or rotating an active
 binding requires complete chain verification, quiesce, drain, a server
 authorization fence, and the fresh-boundary procedure in the
-[`age-v1` profile](spec/ref/age-v1-profile.md#multi-writer-cutover-protocol), which
+[`age-v1` profile](../../spec/ref/age-v1-profile.md#multi-writer-cutover-protocol), which
 is not yet automated by this client.
 
 For `age-v1`, lifecycle logs omit imported plaintext fields by default. Set

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -100,11 +100,14 @@ The history should contain:
 
 ## Use a separate install for testing
 
-To keep a test separate from an existing install, give it another command name:
+To keep a test separate from an existing install, clone the repository and run
+this from the checkout root:
 
 ```sh
 bash install.sh --cmd agmsg-test
 ```
+
+That install's commands are under `~/.agents/skills/agmsg-test/scripts/`.
 
 For the single-machine, two-install rehearsal, see
 [Try it on one machine](design/remote-sync.md#try-it-on-one-machine).
@@ -116,6 +119,7 @@ If you want a rollback copy, do this before step 2:
 Here `<storage>` is the install root, normally `~/.agents/skills/agmsg`.
 
 1. Back up `<storage>/db/messages.db` and the entire `<storage>/teams/` directory.
-2. To restore, stop the agmsg watcher and remote sync engine first.
+2. To restore, run `bash <storage>/scripts/delivery.sh stop`, then
+   `bash <storage>/scripts/remote.sh disconnect <team>`.
 3. Copy both backups back to their original paths.
 4. Delete `<storage>/db/teams/<team>/`, then restart your normal delivery mode.

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -83,13 +83,12 @@ Send a message from machine A with member names from the team:
 ```sh
 bash ~/.agents/skills/agmsg/scripts/send.sh \
   <team> <from> <to> "hello from machine A"
-bash ~/.agents/skills/agmsg/scripts/remote-sync.sh once --team <team>
 ```
 
-On machine B, pull the new record and inspect its local history:
+Connect and pull already started the sync engines. Wait a few seconds, then
+inspect machine B's local history:
 
 ```sh
-bash ~/.agents/skills/agmsg/scripts/remote-sync.sh once --team <team>
 bash ~/.agents/skills/agmsg/scripts/history.sh <team> <to>
 ```
 
@@ -99,5 +98,24 @@ The history should contain:
 <from> → <to>: hello from machine A
 ```
 
-For a single-machine developer rehearsal with two custom command names, see
+## Use a separate install for testing
+
+To keep a test separate from an existing install, give it another command name:
+
+```sh
+bash install.sh --cmd agmsg-test
+```
+
+For the single-machine, two-install rehearsal, see
 [Try it on one machine](design/remote-sync.md#try-it-on-one-machine).
+
+## Back up before connecting
+
+If you want a rollback copy, do this before step 2:
+
+Here `<storage>` is the install root, normally `~/.agents/skills/agmsg`.
+
+1. Back up `<storage>/db/messages.db` and the entire `<storage>/teams/` directory.
+2. To restore, stop the agmsg watcher and remote sync engine first.
+3. Copy both backups back to their original paths.
+4. Delete `<storage>/db/teams/<team>/`, then restart your normal delivery mode.

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -1,0 +1,115 @@
+# Remote setup
+
+This walkthrough runs the reference server on localhost and syncs one plaintext
+team between two isolated agmsg installs. It does not change an existing agmsg
+install.
+
+## Requirements
+
+- Docker with Docker Compose
+- Bash, SQLite, and curl
+- Node.js 22 or later
+- A local checkout of this repository
+
+Run every command below from the repository root unless the step says
+otherwise.
+
+## 1. Start the reference server
+
+Use a dedicated Compose project so this walkthrough does not reuse another
+local server's database:
+
+```sh
+export COMPOSE_PROJECT_NAME=agmsg-remote-setup
+docker compose -f server/compose.yaml up -d --build
+curl -fsS http://127.0.0.1:8787/v1/health
+```
+
+The health response should contain `"status":"ok"` and `"database":"ok"`.
+
+## 2. Install two isolated commands
+
+Pick command names that are not used by an existing install. The names below
+create separate skill, team, and message-store directories:
+
+```sh
+bash install.sh --cmd agmsg-remote-a --agent-type claude-code
+bash install.sh --cmd agmsg-remote-b --agent-type claude-code
+```
+
+Set short path variables for the remaining commands:
+
+```sh
+A="$HOME/.agents/skills/agmsg-remote-a/scripts"
+B="$HOME/.agents/skills/agmsg-remote-b/scripts"
+```
+
+## 3. Create a team on install A
+
+Create two temporary project directories, then register two members in a new
+local team:
+
+```sh
+DEMO_ROOT="$(mktemp -d)"
+mkdir -p "$DEMO_ROOT/alice" "$DEMO_ROOT/bob"
+
+bash "$A/join.sh" remote-demo alice claude-code "$DEMO_ROOT/alice"
+bash "$A/join.sh" remote-demo bob claude-code "$DEMO_ROOT/bob"
+```
+
+## 4. Connect install A
+
+Connect the local team to the reference server:
+
+```sh
+bash "$A/remote.sh" connect \
+  --endpoint http://127.0.0.1:8787 \
+  remote-demo
+```
+
+The command registers the team, moves its local history into the team's
+dedicated store, and starts its sync engine.
+
+## 5. Pull the team into install B
+
+Install B starts without a local `remote-demo` team. Pull it by name:
+
+```sh
+bash "$B/remote.sh" pull \
+  --endpoint http://127.0.0.1:8787 \
+  remote-demo
+```
+
+The command creates the local team, imports its current history, and starts a
+second sync engine.
+
+## 6. Send and verify
+
+Send a message from install A:
+
+```sh
+bash "$A/send.sh" remote-demo alice bob "hello from install A"
+```
+
+Run one cycle on each side to make the walkthrough deterministic, then inspect
+install B's local history:
+
+```sh
+bash "$A/remote-sync.sh" once --team remote-demo
+bash "$B/remote-sync.sh" once --team remote-demo
+bash "$B/history.sh" remote-demo bob
+```
+
+The final command should show:
+
+```text
+alice → bob: hello from install A
+```
+
+## Stop the server
+
+Use the same Compose project name from step 1:
+
+```sh
+docker compose -f server/compose.yaml down
+```

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -1,115 +1,103 @@
 # Remote setup
 
-This walkthrough runs the reference server on localhost and syncs one plaintext
-team between two isolated agmsg installs. It does not change an existing agmsg
-install.
+This walkthrough connects an existing team on machine A to the reference
+server, then pulls it into a normal agmsg install on machine B. This setup uses
+plaintext sync.
 
 ## Requirements
 
-- Docker with Docker Compose
-- Bash, SQLite, and curl
+- PostgreSQL 17
 - Node.js 22 or later
-- A local checkout of this repository
+- Bash, SQLite, and curl
+- An agmsg checkout on the server host
+- A server URL that both machines can reach
 
-Run every command below from the repository root unless the step says
-otherwise.
+Use HTTPS when the server is not on localhost.
 
 ## 1. Start the reference server
 
-Use a dedicated Compose project so this walkthrough does not reuse another
-local server's database:
+Create an empty PostgreSQL database, then start the server from the repository
+checkout:
 
 ```sh
-export COMPOSE_PROJECT_NAME=agmsg-remote-setup
-docker compose -f server/compose.yaml up -d --build
-curl -fsS http://127.0.0.1:8787/v1/health
+cd server
+npm ci
+
+export DATABASE_URL="postgresql://<user>:<password>@127.0.0.1:5432/<db>"
+export HOST=0.0.0.0
+export PORT=8787
+npx tsx src/index.ts
 ```
 
-The health response should contain `"status":"ok"` and `"database":"ok"`.
+Replace every value in angle brackets, especially `<db>`, with the real
+PostgreSQL values before running the command. The example will not work until
+you replace them.
 
-## 2. Install two isolated commands
-
-Pick command names that are not used by an existing install. The names below
-create separate skill, team, and message-store directories:
+Make the server available to both machines at an HTTPS URL, then confirm it is
+ready:
 
 ```sh
-bash install.sh --cmd agmsg-remote-a --agent-type claude-code
-bash install.sh --cmd agmsg-remote-b --agent-type claude-code
+curl -fsS https://<server-url>/v1/health
 ```
 
-Set short path variables for the remaining commands:
+The response should contain `"status":"ok"` and `"database":"ok"`.
+
+## 2. Connect the existing team on machine A
+
+Use machine A's normal agmsg install and the team you already use:
 
 ```sh
-A="$HOME/.agents/skills/agmsg-remote-a/scripts"
-B="$HOME/.agents/skills/agmsg-remote-b/scripts"
+bash ~/.agents/skills/agmsg/scripts/remote.sh connect \
+  --endpoint https://<server-url> \
+  <team>
 ```
 
-## 3. Create a team on install A
-
-Create two temporary project directories, then register two members in a new
-local team:
+Connect moves this team from the shared database into a per-team store. If an
+external tool reads the database file directly, resolve the team's new path
+instead of continuing to use the shared database path:
 
 ```sh
-DEMO_ROOT="$(mktemp -d)"
-mkdir -p "$DEMO_ROOT/alice" "$DEMO_ROOT/bob"
-
-bash "$A/join.sh" remote-demo alice claude-code "$DEMO_ROOT/alice"
-bash "$A/join.sh" remote-demo bob claude-code "$DEMO_ROOT/bob"
+bash ~/.agents/skills/agmsg/scripts/api.sh get teams <team> store
 ```
 
-## 4. Connect install A
+## 3. Install and pull on machine B
 
-Connect the local team to the reference server:
+Install agmsg normally on machine B:
 
 ```sh
-bash "$A/remote.sh" connect \
-  --endpoint http://127.0.0.1:8787 \
-  remote-demo
+npx agmsg
 ```
 
-The command registers the team, moves its local history into the team's
-dedicated store, and starts its sync engine.
-
-## 5. Pull the team into install B
-
-Install B starts without a local `remote-demo` team. Pull it by name:
+Pull the connected team by name:
 
 ```sh
-bash "$B/remote.sh" pull \
-  --endpoint http://127.0.0.1:8787 \
-  remote-demo
+bash ~/.agents/skills/agmsg/scripts/remote.sh pull \
+  --endpoint https://<server-url> \
+  <team>
 ```
 
-The command creates the local team, imports its current history, and starts a
-second sync engine.
+## 4. Send and verify
 
-## 6. Send and verify
-
-Send a message from install A:
+Send a message from machine A with member names from the team:
 
 ```sh
-bash "$A/send.sh" remote-demo alice bob "hello from install A"
+bash ~/.agents/skills/agmsg/scripts/send.sh \
+  <team> <from> <to> "hello from machine A"
+bash ~/.agents/skills/agmsg/scripts/remote-sync.sh once --team <team>
 ```
 
-Run one cycle on each side to make the walkthrough deterministic, then inspect
-install B's local history:
+On machine B, pull the new record and inspect its local history:
 
 ```sh
-bash "$A/remote-sync.sh" once --team remote-demo
-bash "$B/remote-sync.sh" once --team remote-demo
-bash "$B/history.sh" remote-demo bob
+bash ~/.agents/skills/agmsg/scripts/remote-sync.sh once --team <team>
+bash ~/.agents/skills/agmsg/scripts/history.sh <team> <to>
 ```
 
-The final command should show:
+The history should contain:
 
 ```text
-alice → bob: hello from install A
+<from> → <to>: hello from machine A
 ```
 
-## Stop the server
-
-Use the same Compose project name from step 1:
-
-```sh
-docker compose -f server/compose.yaml down
-```
+For a single-machine developer rehearsal with two custom command names, see
+[Try it on one machine](design/remote-sync.md#try-it-on-one-machine).


### PR DESCRIPTION
A user-facing `docs/remote-setup.md`: machine A connects the team it already uses, machine B installs normally and pulls. No isolated installs, no custom command names in the main path — those cost more than most operators will pay, and the ones who try on production and fail simply give up. Optional paths (test install via `--cmd`, backup/restore) live in small trailing sections so the main flow stays short.

Also moves `docs/remote-sync-dogfood.md` to `docs/design/ref/` with a header note: reference only, delete when `integration/remote` merges to `main`. README gains a one-line pointer to the new guide.

Shaped by live doc-only dogfood: the entry-point gap (no path from README to any remote how-to), the `DATABASE_URL` placeholder copy-paste failure, and the manual `remote-sync.sh once` steps that misrepresent the auto-started engines were all hit in practice first.

PR opened on the author's behalf — their sandbox blocks GitHub access.

Written per rulings recorded on this branch's review thread.