### PR TITLE
Purge the obsolete token flow from every agent-readable surface

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -169,107 +169,63 @@ Do NOT manually edit config files. Always use join.sh. If the name was recently 
 ~/.agents/skills/agmsg/scripts/despawn.sh <team> <from> <name> [--force] [--timeout N]
 ```
 
-### Remote sync & end-to-end encryption
+### Remote sync
 
-Connects a local team to a cloud/self-hosted sync endpoint and manages the
-team's `age-v1` encryption key. Additive to everything above — a team works
-purely locally without ever touching this. Login/token acquisition is out
-of this script's scope (some provider tooling, or a self-hosted server's
-own admin command, obtains the token); `connect` only ever receives one.
+Remote setup is no-auth. Do not ask for a token or create one.
 
-**Always use the `--*-stdin` forms below from an agent context.** The bare
-positional forms (`<token>`, `<identity>`) exist only as a warned legacy
-path for a human typing directly into their own terminal — from an agent,
-they leak the secret into this session's own transcript/tool-result
-history, which is exactly the kind of exposure `--token-stdin`/
-`--identity-stdin` exist to avoid. Pipe the secret in; never pass it as
-a literal argument in a command you construct.
+If argument starts with "remote connect":
+1. Parse the required `--endpoint <url>` and `<team>`.
+2. Run: `bash ~/.agents/skills/agmsg/scripts/remote.sh connect --endpoint <url> <team>`
+3. Show the output to the user.
+4. End by showing this copy-paste command for the other machine, with the
+   actual endpoint and team substituted:
+   `bash ~/.agents/skills/agmsg/scripts/remote.sh pull --endpoint <actual-url> <actual-team>`
 
-```bash
-# Connect a team to a sync endpoint. <token> is a short-lived, single-use
-# exchange code (never the long-lived credential itself).
-#   --force    rebind an already-connected team to a new token (requires
-#              an explicit <team> — it cannot be inferred for this check)
-printf '%s' "$TOKEN" | ~/.agents/skills/agmsg/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
+If argument starts with "remote pull":
+1. Use this command whenever the user asks to bring in a team that already
+   exists on a server. Never use `join.sh` for that request.
+2. Parse the required `--endpoint <url>` and `<team>`, plus optional
+   `--team-id <uuid>`.
+3. Run: `bash ~/.agents/skills/agmsg/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
+4. Show the output to the user.
 
-# If the team's capability response requires encryption and no local key
-# exists yet, connect pauses to generate or import one before finishing —
-# see the `key` commands below.
+If argument starts with "remote status":
+1. Parse an optional `<team>` and `--json`.
+2. Run: `bash ~/.agents/skills/agmsg/scripts/remote.sh status [<team>] [--json]`
+3. Show the output to the user.
 
-# Show connection state. With no <team>, lists every locally-known
-# connected team (and whether each still needs a local encryption key).
-# --json emits a strict, secret-free machine-readable object instead of
-# the human text above (ADR 0007 addendum) — for a driver correlating its
-# own operation-status record against the local binding, not for a human
-# to read; prefer the plain form above in normal use.
-~/.agents/skills/agmsg/scripts/remote.sh status [<team>] [--json]
+If argument starts with "remote disconnect":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/agmsg/scripts/remote.sh disconnect <team>`
+3. Show the output to the user.
 
-# Disconnect a team: revokes the credential server-side (best-effort —
-# local state is always cleared even if the server is unreachable), then
-# clears the local sync driver override. Sends/reads keep working locally
-# afterward; this does not touch the team's encryption key.
-~/.agents/skills/agmsg/scripts/remote.sh disconnect <team>
+### End-to-end encryption
 
-# Read-only preflight check (currently: is `age` installed?). No token, no
-# state change — safe to run any time, and the thing to point a user at
-# when troubleshooting a missing dependency.
-~/.agents/skills/agmsg/scripts/remote.sh doctor [<team>]
+If argument starts with "key generate" followed by an optional team name:
+1. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh generate [<team>]`
+2. Show the full output to the user, including the mandatory key-backup notice.
 
-# List (and, if orphaned, clean up) a `connect` exchange that succeeded
-# server-side but never finished committing locally — e.g. the process died
-# between the exchange call and writing local state (ADR 0007 addendum).
-# pending_id is an opaque, content-derived key; abort always works on it
-# alone, even for a record whose content doesn't fully validate (a
-# separately quarantined record — see remote.sh's own comments — is not
-# enumerated or abortable here; that's a human/admin recovery path). Not a
-# normal-use command — this exists for a driver doing its own crash
-# recovery, not for a human to run routinely.
-~/.agents/skills/agmsg/scripts/remote.sh pending list [--json]
-~/.agents/skills/agmsg/scripts/remote.sh pending abort <pending_id>
+If argument starts with "key show":
+1. Parse an optional team name and `--reveal-secret`.
+2. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh show [<team>] [--reveal-secret]`
+3. `--reveal-secret` requires a real interactive terminal and is refused in
+   agent mode. Tell the user to run it directly in their own terminal.
+4. Show the output to the user.
 
-# Generate the first age-v1 key for a team (single-writer onboarding only —
-# NOT the multi-writer cutover protocol, and NOT key rotation — see below).
-# Prints a mandatory backup notice: there is no server-side recovery, and
-# losing the device loses the key.
-~/.agents/skills/agmsg/scripts/key.sh generate [<team>]
+If argument starts with "key import" followed by a team name:
+1. Do not ask the user to paste the private identity into this chat, and do not
+   run the command yourself. Tell the user to run this in their own terminal:
+   ```
+   read -rsp 'Identity: ' IDENTITY; echo
+   printf '%s' "$IDENTITY" | ~/.agents/skills/agmsg/scripts/key.sh import <team> --identity-stdin
+   unset IDENTITY
+   ```
+2. Ask them to paste back only the command output, never the identity itself.
+3. Do not offer an environment-variable path. An identity file is a permanent
+   secret; always use the human-in-own-terminal flow above.
 
-# Show the team's public recipient + fingerprint. --reveal-secret prints
-# the private identity instead, after an interactive typed confirmation —
-# refused outright when there's no TTY (i.e. never usable from agent mode).
-~/.agents/skills/agmsg/scripts/key.sh show [<team>] [--reveal-secret]
-
-# Install a private age identity obtained out-of-band (e.g. via
-# `key.sh show <team> --reveal-secret` on another device that already has
-# it). Rejected if it doesn't match the team's already-authorized key.
-printf '%s' "$IDENTITY" | ~/.agents/skills/agmsg/scripts/key.sh import <team> --identity-stdin
-```
-
-**`key rotate` is NOT available in this release.** It refuses
-unconditionally and changes no state — a design review found its
-anti-rollback metadata insufficient (it can't detect a wholesale
-config.json rollback, and doesn't use the age-v1 profile's pinned
-canonical epoch-snapshot shape), so it's held back rather than shipping a
-protection that isn't actually there. Do not suggest it as a working
-command.
-
-Slash-command surface (SKILL.md / per-type templates), same mapping
-pattern as every command above:
-
-```
-/agmsg remote connect --endpoint <url>   (paste the token when prompted)
-/agmsg remote status
-/agmsg remote disconnect <team>
-/agmsg remote doctor
-/agmsg key generate [<team>]
-/agmsg key show [<team>] [--reveal-secret]
-/agmsg key import <team>   (paste the identity when prompted)
-```
-
-Additional dependencies beyond bash/sqlite3 (only needed if these commands
-are used): `curl` (the exchange/revoke calls), `python3` (parsing the
-exchange response), and `age`/`age-keygen` (E2EE — `remote.sh doctor`
-checks for these and `key.sh`'s own commands refuse to run without them).
-`team-list.sh` needs only `python3`.
+`key rotate` and device-pairing `key request`/`key approve` are not available
+yet. If the user asks for one, tell them so instead of attempting to run it.
 
 ## Sandbox compatibility (Claude Code)
 

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -64,7 +64,8 @@ that machine A's agent displayed. Do not create a same-named local team first;
 pull imports the team that already exists on the server.
 
 After pull succeeds, the team is local and works like any other local team.
-Open `/agmsg` in your agent and join it with a new agent name.
+Open your agent, invoke its installed `agmsg` command, and join the team with a
+new agent name.
 
 ## 4. Send and verify
 

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -63,6 +63,9 @@ Install agmsg normally on machine B, then paste the `remote.sh pull` command
 that machine A's agent displayed. Do not create a same-named local team first;
 pull imports the team that already exists on the server.
 
+After pull succeeds, the team is local and works like any other local team.
+Open `/agmsg` in your agent and join it with a new agent name.
+
 ## 4. Send and verify
 
 On machine A, ask your local agent:

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -1,8 +1,8 @@
 # Remote setup
 
 This walkthrough connects an existing team on machine A to the reference
-server, then pulls it into a normal agmsg install on machine B. This setup uses
-plaintext sync.
+server, then pulls it into a normal agmsg install on machine B. Your local
+agents handle the client commands. This setup uses plaintext sync.
 
 ## Requirements
 
@@ -44,53 +44,33 @@ The response should contain `"status":"ok"` and `"database":"ok"`.
 
 ## 2. Connect the existing team on machine A
 
-Use machine A's normal agmsg install and the team you already use:
+Open your usual local agent on machine A and ask:
 
-```sh
-bash ~/.agents/skills/agmsg/scripts/remote.sh connect \
-  --endpoint https://<server-url> \
-  <team>
-```
+> Connect my existing agmsg team `<team>` to `https://<server-url>`.
+
+The agent will connect the local team and report the result. It will finish by
+showing a copy-paste `remote.sh pull` command with your server URL and team
+name already filled in.
 
 Connect moves this team from the shared database into a per-team store. If an
 external tool reads the database file directly, resolve the team's new path
-instead of continuing to use the shared database path:
-
-```sh
-bash ~/.agents/skills/agmsg/scripts/api.sh get teams <team> store
-```
+instead of continuing to use the shared database path. Ask the agent for the
+team's store path, or use the command in [Reference](#reference).
 
 ## 3. Install and pull on machine B
 
-Install agmsg normally on machine B:
-
-```sh
-npx agmsg
-```
-
-Pull the connected team by name:
-
-```sh
-bash ~/.agents/skills/agmsg/scripts/remote.sh pull \
-  --endpoint https://<server-url> \
-  <team>
-```
+Install agmsg normally on machine B, then paste the `remote.sh pull` command
+that machine A's agent displayed. Do not create a same-named local team first;
+pull imports the team that already exists on the server.
 
 ## 4. Send and verify
 
-Send a message from machine A with member names from the team:
+On machine A, ask your local agent:
 
-```sh
-bash ~/.agents/skills/agmsg/scripts/send.sh \
-  <team> <from> <to> "hello from machine A"
-```
+> Send `hello from machine A` from `<from>` to `<to>` in team `<team>`.
 
 Connect and pull already started the sync engines. Wait a few seconds, then
-inspect machine B's local history:
-
-```sh
-bash ~/.agents/skills/agmsg/scripts/history.sh <team> <to>
-```
+use the [history command](#client-commands-send-and-verify) on machine B.
 
 The history should contain:
 
@@ -98,7 +78,48 @@ The history should contain:
 <from> → <to>: hello from machine A
 ```
 
-## Use a separate install for testing
+## Reference
+
+### Install on machine B
+
+Use the standard installation entry point:
+
+```sh
+npx agmsg
+```
+
+### Connect machine A
+
+```sh
+bash ~/.agents/skills/agmsg/scripts/remote.sh connect \
+  --endpoint https://<server-url> \
+  <team>
+```
+
+### Resolve the team store
+
+```sh
+bash ~/.agents/skills/agmsg/scripts/api.sh get teams <team> store
+```
+
+### Pull on machine B
+
+```sh
+bash ~/.agents/skills/agmsg/scripts/remote.sh pull \
+  --endpoint https://<server-url> \
+  <team>
+```
+
+### Client commands: send and verify
+
+```sh
+bash ~/.agents/skills/agmsg/scripts/send.sh \
+  <team> <from> <to> "hello from machine A"
+
+bash ~/.agents/skills/agmsg/scripts/history.sh <team> <to>
+```
+
+### Use a separate install for testing
 
 To keep a test separate from an existing install, clone the repository and run
 this from the checkout root:
@@ -112,7 +133,7 @@ That install's commands are under `~/.agents/skills/agmsg-test/scripts/`.
 For the single-machine, two-install rehearsal, see
 [Try it on one machine](design/remote-sync.md#try-it-on-one-machine).
 
-## Back up before connecting
+### Back up before connecting
 
 If you want a rollback copy, do this before step 2:
 

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -141,29 +141,27 @@ If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" antigravity`
 2. Tell the user the result.
 
-If argument starts with "remote connect" (cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
-2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
-   ```
-   read -rsp 'Token: ' TOKEN; echo
-   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
-   unset TOKEN
-   ```
-3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
-4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
+If argument starts with "remote connect":
+1. Parse the required `--endpoint <url>` and `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> <team>`
+3. Show the output to the user. No token or credential is required.
+4. End by showing this copy-paste command for the other machine, with the actual endpoint and team substituted: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <actual-url> <actual-team>`
 
-If argument is "remote status" (optionally followed by a team name):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
-2. Show the output to the user.
+If argument starts with "remote pull":
+1. Use this command whenever the user asks to bring in a team that already exists on a server. Never use `join.sh` for that request.
+2. Parse the required `--endpoint <url>` and `<team>`, plus optional `--team-id <uuid>`.
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
+4. Show the output to the user.
 
-If argument starts with "remote disconnect" followed by a team name:
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
-2. Show the output to the user.
+If argument starts with "remote status":
+1. Parse an optional `<team>` and `--json`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
+3. Show the output to the user.
 
-If argument starts with "remote doctor":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
-2. Show the output to the user.
+If argument starts with "remote disconnect":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+3. Show the output to the user.
 
 If argument starts with "key generate" followed by an optional team name:
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
@@ -183,6 +181,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
-3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -174,7 +174,7 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself.** This identity is a permanent secret. Tell the user to run this directly in their own terminal:
    ```
    read -rsp 'Identity: ' IDENTITY; echo
    printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -221,29 +221,27 @@ If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" claude-code`
 2. Tell the user the result.
 
-If argument starts with "remote connect" (cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
-2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
-   ```
-   read -rsp 'Token: ' TOKEN; echo
-   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
-   unset TOKEN
-   ```
-3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
-4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
+If argument starts with "remote connect":
+1. Parse the required `--endpoint <url>` and `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> <team>`
+3. Show the output to the user. No token or credential is required.
+4. End by showing this copy-paste command for the other machine, with the actual endpoint and team substituted: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <actual-url> <actual-team>`
 
-If argument is "remote status" (optionally followed by a team name):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
-2. Show the output to the user.
+If argument starts with "remote pull":
+1. Use this command whenever the user asks to bring in a team that already exists on a server. Never use `join.sh` for that request.
+2. Parse the required `--endpoint <url>` and `<team>`, plus optional `--team-id <uuid>`.
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
+4. Show the output to the user.
 
-If argument starts with "remote disconnect" followed by a team name:
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
-2. Show the output to the user.
+If argument starts with "remote status":
+1. Parse an optional `<team>` and `--json`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
+3. Show the output to the user.
 
-If argument starts with "remote doctor":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
-2. Show the output to the user.
+If argument starts with "remote disconnect":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+3. Show the output to the user.
 
 If argument starts with "key generate" followed by an optional team name:
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
@@ -263,6 +261,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
-3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -254,7 +254,7 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself.** This identity is a permanent secret. Tell the user to run this directly in their own terminal:
    ```
    read -rsp 'Identity: ' IDENTITY; echo
    printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -202,7 +202,7 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself.** This identity is a permanent secret. Tell the user to run this directly in their own terminal:
    ```
    read -rsp 'Identity: ' IDENTITY; echo
    printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -169,29 +169,27 @@ If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" codex`
 2. Tell the user the result.
 
-If argument starts with "remote connect" (cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
-2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
-   ```
-   read -rsp 'Token: ' TOKEN; echo
-   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
-   unset TOKEN
-   ```
-3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
-4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
+If argument starts with "remote connect":
+1. Parse the required `--endpoint <url>` and `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> <team>`
+3. Show the output to the user. No token or credential is required.
+4. End by showing this copy-paste command for the other machine, with the actual endpoint and team substituted: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <actual-url> <actual-team>`
 
-If argument is "remote status" (optionally followed by a team name):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
-2. Show the output to the user.
+If argument starts with "remote pull":
+1. Use this command whenever the user asks to bring in a team that already exists on a server. Never use `join.sh` for that request.
+2. Parse the required `--endpoint <url>` and `<team>`, plus optional `--team-id <uuid>`.
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
+4. Show the output to the user.
 
-If argument starts with "remote disconnect" followed by a team name:
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
-2. Show the output to the user.
+If argument starts with "remote status":
+1. Parse an optional `<team>` and `--json`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
+3. Show the output to the user.
 
-If argument starts with "remote doctor":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
-2. Show the output to the user.
+If argument starts with "remote disconnect":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+3. Show the output to the user.
 
 If argument starts with "key generate" followed by an optional team name:
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
@@ -211,6 +209,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
-3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -141,29 +141,27 @@ If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" copilot`
 2. Tell the user the result.
 
-If argument starts with "remote connect" (cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
-2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
-   ```
-   read -rsp 'Token: ' TOKEN; echo
-   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
-   unset TOKEN
-   ```
-3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
-4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
+If argument starts with "remote connect":
+1. Parse the required `--endpoint <url>` and `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> <team>`
+3. Show the output to the user. No token or credential is required.
+4. End by showing this copy-paste command for the other machine, with the actual endpoint and team substituted: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <actual-url> <actual-team>`
 
-If argument is "remote status" (optionally followed by a team name):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
-2. Show the output to the user.
+If argument starts with "remote pull":
+1. Use this command whenever the user asks to bring in a team that already exists on a server. Never use `join.sh` for that request.
+2. Parse the required `--endpoint <url>` and `<team>`, plus optional `--team-id <uuid>`.
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
+4. Show the output to the user.
 
-If argument starts with "remote disconnect" followed by a team name:
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
-2. Show the output to the user.
+If argument starts with "remote status":
+1. Parse an optional `<team>` and `--json`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
+3. Show the output to the user.
 
-If argument starts with "remote doctor":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
-2. Show the output to the user.
+If argument starts with "remote disconnect":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+3. Show the output to the user.
 
 If argument starts with "key generate" followed by an optional team name:
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
@@ -183,6 +181,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
-3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -174,7 +174,7 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself.** This identity is a permanent secret. Tell the user to run this directly in their own terminal:
    ```
    read -rsp 'Identity: ' IDENTITY; echo
    printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -144,29 +144,27 @@ If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" cursor`
 2. Tell the user the result.
 
-If argument starts with "remote connect" (cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
-2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
-   ```
-   read -rsp 'Token: ' TOKEN; echo
-   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
-   unset TOKEN
-   ```
-3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
-4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
+If argument starts with "remote connect":
+1. Parse the required `--endpoint <url>` and `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> <team>`
+3. Show the output to the user. No token or credential is required.
+4. End by showing this copy-paste command for the other machine, with the actual endpoint and team substituted: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <actual-url> <actual-team>`
 
-If argument is "remote status" (optionally followed by a team name):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
-2. Show the output to the user.
+If argument starts with "remote pull":
+1. Use this command whenever the user asks to bring in a team that already exists on a server. Never use `join.sh` for that request.
+2. Parse the required `--endpoint <url>` and `<team>`, plus optional `--team-id <uuid>`.
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
+4. Show the output to the user.
 
-If argument starts with "remote disconnect" followed by a team name:
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
-2. Show the output to the user.
+If argument starts with "remote status":
+1. Parse an optional `<team>` and `--json`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
+3. Show the output to the user.
 
-If argument starts with "remote doctor":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
-2. Show the output to the user.
+If argument starts with "remote disconnect":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+3. Show the output to the user.
 
 If argument starts with "key generate" followed by an optional team name:
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
@@ -186,6 +184,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
-3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -177,7 +177,7 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself.** This identity is a permanent secret. Tell the user to run this directly in their own terminal:
    ```
    read -rsp 'Identity: ' IDENTITY; echo
    printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -141,29 +141,27 @@ If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" gemini`
 2. Tell the user the result.
 
-If argument starts with "remote connect" (cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
-2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
-   ```
-   read -rsp 'Token: ' TOKEN; echo
-   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
-   unset TOKEN
-   ```
-3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
-4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
+If argument starts with "remote connect":
+1. Parse the required `--endpoint <url>` and `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> <team>`
+3. Show the output to the user. No token or credential is required.
+4. End by showing this copy-paste command for the other machine, with the actual endpoint and team substituted: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <actual-url> <actual-team>`
 
-If argument is "remote status" (optionally followed by a team name):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
-2. Show the output to the user.
+If argument starts with "remote pull":
+1. Use this command whenever the user asks to bring in a team that already exists on a server. Never use `join.sh` for that request.
+2. Parse the required `--endpoint <url>` and `<team>`, plus optional `--team-id <uuid>`.
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
+4. Show the output to the user.
 
-If argument starts with "remote disconnect" followed by a team name:
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
-2. Show the output to the user.
+If argument starts with "remote status":
+1. Parse an optional `<team>` and `--json`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
+3. Show the output to the user.
 
-If argument starts with "remote doctor":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
-2. Show the output to the user.
+If argument starts with "remote disconnect":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+3. Show the output to the user.
 
 If argument starts with "key generate" followed by an optional team name:
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
@@ -183,6 +181,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
-3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -174,7 +174,7 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself.** This identity is a permanent secret. Tell the user to run this directly in their own terminal:
    ```
    read -rsp 'Identity: ' IDENTITY; echo
    printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -172,29 +172,27 @@ If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" grok-build`
 2. Tell the user the result.
 
-If argument starts with "remote connect" (cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
-2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
-   ```
-   read -rsp 'Token: ' TOKEN; echo
-   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
-   unset TOKEN
-   ```
-3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
-4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
+If argument starts with "remote connect":
+1. Parse the required `--endpoint <url>` and `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> <team>`
+3. Show the output to the user. No token or credential is required.
+4. End by showing this copy-paste command for the other machine, with the actual endpoint and team substituted: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <actual-url> <actual-team>`
 
-If argument is "remote status" (optionally followed by a team name):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
-2. Show the output to the user.
+If argument starts with "remote pull":
+1. Use this command whenever the user asks to bring in a team that already exists on a server. Never use `join.sh` for that request.
+2. Parse the required `--endpoint <url>` and `<team>`, plus optional `--team-id <uuid>`.
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
+4. Show the output to the user.
 
-If argument starts with "remote disconnect" followed by a team name:
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
-2. Show the output to the user.
+If argument starts with "remote status":
+1. Parse an optional `<team>` and `--json`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
+3. Show the output to the user.
 
-If argument starts with "remote doctor":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
-2. Show the output to the user.
+If argument starts with "remote disconnect":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+3. Show the output to the user.
 
 If argument starts with "key generate" followed by an optional team name:
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
@@ -214,6 +212,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
-3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -205,7 +205,7 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself.** This identity is a permanent secret. Tell the user to run this directly in their own terminal:
    ```
    read -rsp 'Identity: ' IDENTITY; echo
    printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -129,29 +129,27 @@ If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" hermes`
 2. Tell the user the result.
 
-If argument starts with "remote connect" (cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
-2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
-   ```
-   read -rsp 'Token: ' TOKEN; echo
-   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
-   unset TOKEN
-   ```
-3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
-4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
+If argument starts with "remote connect":
+1. Parse the required `--endpoint <url>` and `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> <team>`
+3. Show the output to the user. No token or credential is required.
+4. End by showing this copy-paste command for the other machine, with the actual endpoint and team substituted: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <actual-url> <actual-team>`
 
-If argument is "remote status" (optionally followed by a team name):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
-2. Show the output to the user.
+If argument starts with "remote pull":
+1. Use this command whenever the user asks to bring in a team that already exists on a server. Never use `join.sh` for that request.
+2. Parse the required `--endpoint <url>` and `<team>`, plus optional `--team-id <uuid>`.
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
+4. Show the output to the user.
 
-If argument starts with "remote disconnect" followed by a team name:
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
-2. Show the output to the user.
+If argument starts with "remote status":
+1. Parse an optional `<team>` and `--json`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
+3. Show the output to the user.
 
-If argument starts with "remote doctor":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
-2. Show the output to the user.
+If argument starts with "remote disconnect":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+3. Show the output to the user.
 
 If argument starts with "key generate" followed by an optional team name:
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
@@ -171,6 +169,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
-3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -162,7 +162,7 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself.** This identity is a permanent secret. Tell the user to run this directly in their own terminal:
    ```
    read -rsp 'Identity: ' IDENTITY; echo
    printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -144,29 +144,27 @@ If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" opencode`
 2. Tell the user the result.
 
-If argument starts with "remote connect" (cloud/self-hosted sync connection):
-1. Parse `--endpoint <url>` and an optional `<team>`/`--force`.
-2. **Do not ask the user to paste the token into this chat, and do not run this command yourself.** The token must never enter this session's own transcript — constructing and running a command that embeds it (even piped to `--token-stdin`) would do exactly that, since the command text itself becomes part of this session's tool-call record. Instead, tell the user to run this directly in their own terminal:
-   ```
-   read -rsp 'Token: ' TOKEN; echo
-   printf '%s' "$TOKEN" | ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin [<team>] [--force]
-   unset TOKEN
-   ```
-3. If that pauses for an encryption-bootstrap choice (`[i/g/a]`) or an identity paste, those also happen entirely within the user's own terminal session — they choose and paste directly, without your involvement.
-4. Ask the user to paste back only the command's final output (never the token or an identity) once it finishes, and continue from there.
-5. **Advanced/automation path**: only if the user says the token is already in an environment variable set *before this session started* (env vars set afterward, in another terminal, do not propagate into an already-running agent process — this path needs a fresh restart with the variable already in place), you may reference that variable by NAME only — never ask them to reveal its value. Confirm the exact variable name with them explicitly first (never guess or invent one). **Before using it, validate that the confirmed name matches a portable shell identifier: `^[A-Za-z_][A-Za-z0-9_]*$` (letters/digits/underscore, not starting with a digit).** If it fails this check, refuse the advanced path and use the default human-in-own-terminal flow instead — an unvalidated name becomes part of the shell command you construct, so anything else risks injection or misexpansion. Once validated, substitute the confirmed name itself in place of the variable name shown below (e.g. a confirmed name of `PAIRING_TOKEN` becomes `"$PAIRING_TOKEN"` — never leave the literal placeholder text in the command you run): `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> --token-stdin <<< "$CONFIRMED_VAR_NAME" [<team>] [--force]`.
+If argument starts with "remote connect":
+1. Parse the required `--endpoint <url>` and `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> <team>`
+3. Show the output to the user. No token or credential is required.
+4. End by showing this copy-paste command for the other machine, with the actual endpoint and team substituted: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <actual-url> <actual-team>`
 
-If argument is "remote status" (optionally followed by a team name):
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>]`
-2. Show the output to the user.
+If argument starts with "remote pull":
+1. Use this command whenever the user asks to bring in a team that already exists on a server. Never use `join.sh` for that request.
+2. Parse the required `--endpoint <url>` and `<team>`, plus optional `--team-id <uuid>`.
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
+4. Show the output to the user.
 
-If argument starts with "remote disconnect" followed by a team name:
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
-2. Show the output to the user.
+If argument starts with "remote status":
+1. Parse an optional `<team>` and `--json`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
+3. Show the output to the user.
 
-If argument starts with "remote doctor":
-1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/remote.sh doctor [<team>]`
-2. Show the output to the user.
+If argument starts with "remote disconnect":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+3. Show the output to the user.
 
 If argument starts with "key generate" followed by an optional team name:
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
@@ -186,6 +184,6 @@ If argument starts with "key import" followed by a team name:
    unset IDENTITY
    ```
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
-3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. Unlike a short-lived pairing token, an identity file is a permanent secret; always use the human-in-own-terminal flow above.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
 `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -177,7 +177,7 @@ If argument starts with "key show":
 4. Show the output to the user.
 
 If argument starts with "key import" followed by a team name:
-1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself** — same reasoning as `remote connect` above, and more important here: this is a permanent key, not a short-lived token. Tell the user to run this directly in their own terminal:
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself.** This identity is a permanent secret. Tell the user to run this directly in their own terminal:
    ```
    read -rsp 'Identity: ' IDENTITY; echo
    printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -938,7 +938,11 @@ cmd_pull() {
   # second machine, whose pulled team answered "connected" while running nothing.
   _remote_sync_engine_start "$team"
 
+  local cmd_name
+  cmd_name="$(basename "$SKILL_DIR")"
   echo "Pulled '$pulled_name' into local team '$team' ($imported message(s)). Sync engine running."
+  echo "This team is now local and ready for normal use."
+  echo "Open /$cmd_name in your agent, then join with a new agent name."
 }
 
 # The remote-sync engine runs as a background daemon: one per connected team,

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -942,7 +942,7 @@ cmd_pull() {
   cmd_name="$(basename "$SKILL_DIR")"
   echo "Pulled '$pulled_name' into local team '$team' ($imported message(s)). Sync engine running."
   echo "This team is now local and ready for normal use."
-  echo "Open /$cmd_name in your agent, then join with a new agent name."
+  echo "Open your agent and invoke its installed '$cmd_name' command, then join with a new agent name."
 }
 
 # The remote-sync engine runs as a background daemon: one per connected team,

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2,31 +2,15 @@
 set -euo pipefail
 
 # Usage:
-#   remote.sh connect --endpoint <url> [<token>] [--token-stdin] [<team>] [--force]
-#   remote.sh pull --endpoint <url> --team-id <uuid> <team>
+#   remote.sh connect --endpoint <url> <team>
+#   remote.sh pull --endpoint <url> [--team-id <uuid>] <team>
 #   remote.sh status [<team>] [--json]
 #   remote.sh disconnect <team>
-#   remote.sh doctor [<team>]
-#   remote.sh pending list [--json]
-#   remote.sh pending abort <pending_id>
 #
-# Team-scoped cloud/self-hosted sync connection. The OSS CLI never
-# assumes or defaults to any particular server — <endpoint> is always
-# required. Login/token acquisition is out of this repo's scope (remote-connect
-# §1a-§1c) — some provider tooling (or a self-hosted server's own admin
-# command) obtains the token; this script only ever receives one.
-#
-# `status --json` and `pending list/abort` (ADR 0007 addendum) are a
-# strict, secret-free ABI a cloud/self-hosted driver polls/acts on for crash
-# recovery: after a connect's exchange call, the driver may not know whether
-# its child `connect` invocation actually committed locally before dying.
-# `status --json` lets it correlate its own operation-status record against
-# the local binding by credential_id/server_instance_id/remote_team_id;
-# `pending list/abort` lets it enumerate and clean up an orphaned exchange
-# that never reached a local commit at all (so it isn't stuck holding a
-# server-issued credential neither side will ever use) — scoped to normal,
-# non-quarantined pending records only (see the comment above
-# `_remote_validate_pending_id`).
+# Team-scoped cloud/self-hosted sync connection. The OSS CLI never assumes or
+# defaults to a server, so <endpoint> is always required. `connect` registers a
+# local team directly; reaching the server is the permission. `pull` clones a
+# remote team into an empty local team. Both start the background sync engine.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -614,7 +614,7 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   local cmd_name
   cmd_name="$(basename "$TEST_SKILL_DIR")"
   [[ "$output" == *"This team is now local and ready for normal use."* ]]
-  [[ "$output" == *"Open /$cmd_name in your agent, then join with a new agent name."* ]]
+  [[ "$output" == *"Open your agent and invoke its installed '$cmd_name' command, then join with a new agent name."* ]]
   local cfg
   cfg="$TEST_SKILL_DIR/teams/cloned/config.json"
   [ -f "$cfg" ]

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -611,6 +611,10 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
 @test "remote pull: clones a team, keeping the id the server gave" {
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" cloned
   [ "$status" -eq 0 ]
+  local cmd_name
+  cmd_name="$(basename "$TEST_SKILL_DIR")"
+  [[ "$output" == *"This team is now local and ready for normal use."* ]]
+  [[ "$output" == *"Open /$cmd_name in your agent, then join with a new agent name."* ]]
   local cfg
   cfg="$TEST_SKILL_DIR/teams/cloned/config.json"
   [ -f "$cfg" ]


### PR DESCRIPTION
Live UX dogfood caught agents being misled twice in one hour: a static reviewer and then a real user's agent both read stale surfaces describing the deleted pairing-token flow, and the agent walked the user through a token ceremony that no longer exists.

The stale surfaces were wider than one file. Installed skills are generated from `scripts/drivers/types/*/template.md`, and all nine templates still carried the token-stdin ceremony — so every fresh install kept poisoning its agent. This PR aligns every agent-readable surface with the current no-auth model:

- `scripts/remote.sh` header usage/comments (comment-only; code untouched)
- root `SKILL.md` and all nine type templates: a real `remote` section — connect/pull/status/disconnect with exact invocations, so agents never have to self-study the script source
- Division of labor per ruling: machine A (connect) is agent-driven and **ends by printing the exact pull command for the other machine**; machine B is command-line-first, and agents asked to import a server-side team must use `pull`, never `join`
- `cmd_pull` success output now tells the user the next step (the team is local now; open your agent, join with a new name) — the exact point where the live test stalled
- `docs/remote-setup.md` restructured to match

`rg` confirms no token-stdin / pairing-token references remain in SKILL.md or templates. Author's sandbox blocks the bats fixture port bind, so `test_remote.bats` runs ride on CI; a regression assertion covers the new pull output contract.

PR opened on the author's behalf — their sandbox blocks GitHub access.