### PR TITLE
fix(codex): bound watch-once by its lifetime, not by its polling (#558)

### DIFF
--- a/scripts/drivers/types/codex/watch-once.sh
+++ b/scripts/drivers/types/codex/watch-once.sh
@@ -15,6 +15,24 @@ set -euo pipefail
 # `inbox.sh` remains the only read cursor; watch-once simply waits until the
 # inbox cursor says there is something to handle.
 
+# Taken before any startup work, because the deadline below has to bound this
+# process's LIFETIME, not just its polling. The bridge force-kills the child at
+# (timeout + interval + 10) seconds measured from spawn (codex-bridge.js,
+# process/spawn timeoutMs), so a deadline computed after startup makes the real
+# wall time startup + TIMEOUT. Where startup is slower than interval + 10 — MSYS
+# fork emulation measured at 55-300ms per spawn puts a Windows host at ~29s — the
+# bridge kills the child before it can reach its own deadline, so it exits 124
+# instead of the clean 2 on every single re-arm, the bridge counts three failures
+# and self-destructs, and the launcher restarts it forever. Reported with
+# measurements by 東リ屋 (#558). Startup on Linux is ~0.2s, which is why this has
+# never surfaced here.
+#
+# Making the deadline lifetime-based means a slow startup eats into the polling
+# window rather than overrunning the ceiling. It cannot skip the inbox check
+# entirely: the loop queries before it tests the deadline, so even a deadline
+# that is already past yields one full check first.
+_AGMSG_WO_START="$(date +%s)"
+
 PROJECT_PATH="${1:?Usage: watch-once.sh <project_path> <agent_type> [--name <agent>] [--team <team>] [--timeout <sec>] [--interval <sec>]}"
 AGENT_TYPE="${2:?Missing agent_type}"
 shift 2
@@ -79,7 +97,7 @@ if [ -z "$PAIRS" ]; then
 fi
 
 WHERE_PAIRS="$(agmsg_subscription_where "$PAIRS")"
-deadline=$(( $(date +%s) + TIMEOUT ))
+deadline=$(( _AGMSG_WO_START + TIMEOUT ))
 
 while true; do
   if [ -f "$DB" ]; then

--- a/tests/test_watch_once.bats
+++ b/tests/test_watch_once.bats
@@ -13,6 +13,66 @@ teardown() {
   teardown_test_env
 }
 
+# --- lifetime bound vs slow startup (#558) -----------------------------------
+#
+# The bridge force-kills this child at (timeout + interval + 10) seconds from
+# spawn, so the deadline has to bound the whole process, not just the polling.
+# The bug these pin is a deadline computed AFTER startup, which makes the real
+# wall time startup + TIMEOUT and produces exit 124 on hosts where startup is
+# slow (Windows/MSYS fork emulation, ~29s measured).
+#
+# Startup here is ~0.2s, so the difference is invisible unless startup is made
+# slow deliberately. `_slow_startup_path` does that with an `awk` shim: startup
+# resolves subscription pairs through awk, while the polling loop queries through
+# sqlite3, so delaying awk lengthens startup without touching the poll. The shim
+# sleeps once (marker file) so the delay is exactly N regardless of how many awk
+# calls startup makes.
+_slow_startup_path() {
+  local secs="$1" dir="$BATS_TEST_TMPDIR/slowbin"
+  mkdir -p "$dir"
+  cat > "$dir/awk" <<EOF
+#!/usr/bin/env bash
+if [ ! -e "$BATS_TEST_TMPDIR/awk-delayed" ]; then
+  : > "$BATS_TEST_TMPDIR/awk-delayed"
+  sleep $secs
+fi
+exec $(command -v awk) "\$@"
+EOF
+  chmod +x "$dir/awk"
+  printf '%s' "$dir"
+}
+
+@test "watch-once: total lifetime stays within the timeout even when startup is slow (#558)" {
+  local bin start end elapsed
+  bin="$(_slow_startup_path 3)"
+
+  start=$(date +%s)
+  PATH="$bin:$PATH" run bash "$TYPES/codex/watch-once.sh" "$PROJ" codex \
+    --name alice --team team --timeout 4 --interval 1
+  end=$(date +%s)
+  elapsed=$(( end - start ))
+
+  [ "$status" -eq 2 ]
+  # The contract is the ceiling, not a precise duration: with the deadline taken
+  # after startup this runs ~3+4=7s, so a 6s bound separates the two without
+  # being tight enough to flake on a loaded runner.
+  [ "$elapsed" -le 6 ] || { echo "lifetime ${elapsed}s exceeded the 4s timeout by more than slack"; false; }
+}
+
+@test "watch-once: a deadline already past still performs one inbox check (#558)" {
+  # Startup longer than the whole timeout, so the deadline is in the past by the
+  # time the loop starts. The pending message must still be found: the fix must
+  # bound the lifetime, not skip the work.
+  bash "$SCRIPTS/send.sh" team bob alice "pending despite slow startup" >/dev/null
+  local bin
+  bin="$(_slow_startup_path 3)"
+
+  PATH="$bin:$PATH" run bash "$TYPES/codex/watch-once.sh" "$PROJ" codex \
+    --name alice --team team --timeout 1 --interval 1
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "status=pending" ]]
+}
+
 @test "watch-once: exits 2 on timeout when no unread inbound exists" {
   run bash "$TYPES/codex/watch-once.sh" "$PROJ" codex --name alice --team team --timeout 1 --interval 1
   [ "$status" -eq 2 ]

--- a/tests/test_watch_once.bats
+++ b/tests/test_watch_once.bats
@@ -42,6 +42,17 @@ EOF
   printf '%s' "$dir"
 }
 
+# The shim IS the premise: without the delay, an unfixed watch-once finishes in
+# about TIMEOUT and satisfies the ceiling, so the test would go green against the
+# very bug it exists for. Requiring the marker turns "startup no longer routes
+# through awk" into a loud failure instead of a silent pass.
+_assert_startup_was_delayed() {
+  [ -e "$BATS_TEST_TMPDIR/awk-delayed" ] || {
+    echo "the awk shim never fired — startup no longer routes through awk, so this test proves nothing; re-pick the seam"
+    false
+  }
+}
+
 @test "watch-once: total lifetime stays within the timeout even when startup is slow (#558)" {
   local bin start end elapsed
   bin="$(_slow_startup_path 3)"
@@ -53,6 +64,7 @@ EOF
   elapsed=$(( end - start ))
 
   [ "$status" -eq 2 ]
+  _assert_startup_was_delayed
   # The contract is the ceiling, not a precise duration: with the deadline taken
   # after startup this runs ~3+4=7s, so a 6s bound separates the two without
   # being tight enough to flake on a loaded runner.
@@ -70,6 +82,7 @@ EOF
   PATH="$bin:$PATH" run bash "$TYPES/codex/watch-once.sh" "$PROJ" codex \
     --name alice --team team --timeout 1 --interval 1
   [ "$status" -eq 0 ]
+  _assert_startup_was_delayed
   [[ "$output" =~ "status=pending" ]]
 }
 


### PR DESCRIPTION
Fixes bug 1 of #558, reported with root-cause analysis, this fix, and measurements by 東リ屋 (@8CEVSmSRMT32119).

## The bug

`watch-once.sh` took its deadline after the startup work, so its real wall time was `startup + TIMEOUT`. The bridge force-kills the child at `(timeout + interval + 10)` seconds measured from spawn. Once startup exceeds `interval + 10` — about 12s at defaults — the child is killed before it can reach its own deadline and the clean `exit 2`, so it exits 124 on *every* re-arm rather than intermittently. Three of those and the bridge self-destructs; the launcher restarts it; orphan `watch-once` processes accumulate, which is the retention half of #149.

Startup is ~0.2s on Linux and ~29s under MSYS fork emulation, which is why this only ever appeared on Windows.

Confirmed independently against `main` before implementing: the deadline at `watch-once.sh` was computed after four library sources plus project and subscription-pair resolution, and `codex-bridge.js` sets `timeoutMs: (this.opts.timeout + this.opts.interval + 10) * 1000` on the spawn.

## The fix

Take the timestamp before any startup work and base the deadline on it. Two lines, as the reporter proposed.

A slow startup now eats into the polling window instead of overrunning the ceiling. It cannot degrade into skipping the work: the loop queries the inbox *before* testing the deadline, so even a deadline that is already past yields one full check first.

## Testing the Linux-invisible

The difference is ~startup, which is 0.2s here — too small to assert. So the tests make startup slow on purpose: an `awk` shim delays once, and startup resolves subscription pairs through `awk` while the polling loop queries through `sqlite3`, so the delay lengthens startup without touching the poll. The shim sleeps on first call only, so the delay is exactly N regardless of how many `awk` calls startup makes.

Two tests, and they are not the same kind of evidence:

- **`total lifetime stays within the timeout even when startup is slow`** — pins the ceiling the bridge depends on. Verified load-bearing: with the fix reverted and the test kept, it fails with `lifetime 8s exceeded the 4s timeout by more than slack`.
- **`a deadline already past still performs one inbox check`** — startup longer than the whole timeout, message pending, must still exit 0. This one **passes without the fix too**, so it does not catch the bug; it guards against a fix that bounds the lifetime by skipping the check. Recorded as such rather than presented as a second regression test.

The assertion is a ceiling with slack (6s against a 4s timeout) rather than a precise duration, so it separates the two behaviours without being tight enough to flake on a loaded runner.

`bats tests/test_watch_once.bats` — 8/8, exit 0.

## Not in this PR

Bugs 2 and 3 from #558 (codex join skipping the seat record; `identities.sh` cost) are recorded on that issue. Bug 2 touches the join/seat-record contract and wants a decision rather than a patch. The `AGMSG_WATCH_ONCE_TIMEOUT` default and the re-arm-period-vs-poll-interval documentation the reporter raises are also left for that discussion.
