### PR TITLE
fix(pull): a pulled team lands in its per-team store, not the shared one

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -787,6 +787,7 @@ _remote_write_pulled_team() {
       SELECT json_object('name','$(_agmsg_sqlesc "$team")',
                          'team_id','$(_agmsg_sqlesc "$team_id")',
                          'agents', json_object(),
+                         'drivers', json_object('layout', 'per-team'),
                          'created_at','$(date -u +%Y-%m-%dT%H:%M:%SZ)');")
     agmsg_write_atomic "$cfg" "$initial"
   fi

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -620,6 +620,17 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   [ -f "$cfg" ]
   # Not minted here: the id is the one the server answered with.
   [ "$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.team_id');")" = "$PULL_TEAM_ID" ]
+  [ "$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.drivers.layout');")" = "per-team" ]
+  [ -f "$TEST_SKILL_DIR/db/teams/cloned/messages.db" ]
+  # Pull arrives into an empty local team, so it can select the isolated layout
+  # before bootstrap. Imported remote rows must never leak into the shared
+  # store that local-only teams and external readers still use.
+  if sqlite3 "$TEST_SKILL_DIR/db/messages.db" \
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='events';" |
+      grep -qx events; then
+    [ "$(sqlite3 "$TEST_SKILL_DIR/db/messages.db" \
+      "SELECT COUNT(*) FROM events WHERE team='cloned';")" -eq 0 ]
+  fi
 }
 
 @test "remote pull: starts a background sync engine that disconnect stops" {


### PR DESCRIPTION
Found while wiring `forget`: `_remote_write_pulled_team` never wrote `drivers.layout`, so pull-bootstrapped teams landed in the shared `db/messages.db` while connected teams live under `db/teams/<team>/`. Verified live on the second dogfood machine — its pulled team sits in the shared store with no `db/teams/` at all.

Machine B arrives empty, so no external direct-DB reader can depend on a pulled team being in the shared store — the compatibility argument that keeps unconnected teams shared does not apply. Writing `layout=per-team` before bootstrap restores the invariant that every remote-bound team lives in its own store, which is also what `forget` (#562) relies on to delete exactly one team's data.

No migration for already-pulled teams: the only installs in that state are our own dogfood ones, which will be refreshed with forget + re-pull once #562 lands.

Regression pins: config selection, `db/teams/<team>/messages.db` exists, zero rows for the team in the shared store — and drops without the production line.

PR opened on the author's behalf — their sandbox blocks GitHub access.