### PR TITLE
feat(remote): status tells the truth about the engine; sync start brings it back

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -194,6 +194,11 @@ If argument starts with "remote status":
 2. Run: `bash ~/.agents/skills/agmsg/scripts/remote.sh status [<team>] [--json]`
 3. Show the output to the user.
 
+If argument starts with "remote sync start":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/agmsg/scripts/remote.sh sync start <team>`
+3. Show the output to the user.
+
 If argument starts with "remote disconnect":
 1. Parse the required `<team>`.
 2. Run: `bash ~/.agents/skills/agmsg/scripts/remote.sh disconnect <team>`

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -158,6 +158,11 @@ If argument starts with "remote status":
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
 3. Show the output to the user.
 
+If argument starts with "remote sync start":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh sync start <team>`
+3. Show the output to the user.
+
 If argument starts with "remote disconnect":
 1. Parse the required `<team>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -238,6 +238,11 @@ If argument starts with "remote status":
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
 3. Show the output to the user.
 
+If argument starts with "remote sync start":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh sync start <team>`
+3. Show the output to the user.
+
 If argument starts with "remote disconnect":
 1. Parse the required `<team>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -186,6 +186,11 @@ If argument starts with "remote status":
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
 3. Show the output to the user.
 
+If argument starts with "remote sync start":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh sync start <team>`
+3. Show the output to the user.
+
 If argument starts with "remote disconnect":
 1. Parse the required `<team>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -158,6 +158,11 @@ If argument starts with "remote status":
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
 3. Show the output to the user.
 
+If argument starts with "remote sync start":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh sync start <team>`
+3. Show the output to the user.
+
 If argument starts with "remote disconnect":
 1. Parse the required `<team>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -161,6 +161,11 @@ If argument starts with "remote status":
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
 3. Show the output to the user.
 
+If argument starts with "remote sync start":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh sync start <team>`
+3. Show the output to the user.
+
 If argument starts with "remote disconnect":
 1. Parse the required `<team>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -158,6 +158,11 @@ If argument starts with "remote status":
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
 3. Show the output to the user.
 
+If argument starts with "remote sync start":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh sync start <team>`
+3. Show the output to the user.
+
 If argument starts with "remote disconnect":
 1. Parse the required `<team>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -189,6 +189,11 @@ If argument starts with "remote status":
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
 3. Show the output to the user.
 
+If argument starts with "remote sync start":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh sync start <team>`
+3. Show the output to the user.
+
 If argument starts with "remote disconnect":
 1. Parse the required `<team>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -146,6 +146,11 @@ If argument starts with "remote status":
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
 3. Show the output to the user.
 
+If argument starts with "remote sync start":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh sync start <team>`
+3. Show the output to the user.
+
 If argument starts with "remote disconnect":
 1. Parse the required `<team>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -161,6 +161,11 @@ If argument starts with "remote status":
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
 3. Show the output to the user.
 
+If argument starts with "remote sync start":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh sync start <team>`
+3. Show the output to the user.
+
 If argument starts with "remote disconnect":
 1. Parse the required `<team>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1619,7 +1619,8 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
   const capabilities = await requestCall(config, "/v1/capabilities");
   validateCapabilities(config, capabilities);
   await eventCall("capabilities", { team: config.local_team, current_seq: capabilities.current_seq,
-    policy_revision: capabilities.policy_revision });
+    policy_revision: capabilities.policy_revision,
+    startup_nonce: process.env.AGMSG_SYNC_START_NONCE || undefined });
 
   const writeProfile = selectWriteProfile(config, capabilities);
   const prepareInput = [{ type: "sync_prepare", envelope_v: 1,

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1387,8 +1387,10 @@ cmd_sync_start() {
     IFS=$'\t' read -r engine_state ready_pid < <(_remote_sync_engine_status "$team")
     if [ "$engine_state" = "running" ] && [ "$ready_pid" = "$started_pid" ] &&
        tail -c "+$log_offset" "$logfile" 2>/dev/null |
-         grep '"event":"capabilities"' |
-         grep -Fq "\"startup_nonce\":\"$startup_nonce\""; then
+         awk -v nonce="\"startup_nonce\":\"$startup_nonce\"" '
+           index($0, "\"event\":\"capabilities\"") && index($0, nonce) { found = 1 }
+           END { exit(found ? 0 : 1) }
+         '; then
       ready=1
       break
     fi

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1016,6 +1016,23 @@ _remote_sync_engine_status() {
   esac
 }
 
+_remote_sync_engine_reap_owned() {
+  local team="$1" owned_pid="$2" state pid signal attempts
+  for signal in TERM KILL; do
+    IFS=$'\t' read -r state pid < <(_remote_sync_engine_status "$team")
+    if ! _agmsg_pid_alive "$owned_pid"; then return 0; fi
+    [ "$state" = "running" ] && [ "$pid" = "$owned_pid" ] || return 1
+    kill "-$signal" "$owned_pid" 2>/dev/null || true
+    attempts=0
+    while [ "$attempts" -lt 100 ]; do
+      _agmsg_pid_alive "$owned_pid" || return 0
+      attempts=$((attempts + 1))
+      sleep 0.01
+    done
+  done
+  ! _agmsg_pid_alive "$owned_pid"
+}
+
 # Upgrade a team that predates local ids: mint a team_id AND a member_id for
 # every current member, in one shot, then persist. connect is the point an old
 # team first needs ids, and the invariant is all-or-none — a team carries ids
@@ -1331,7 +1348,7 @@ cmd_status() {
 
 cmd_sync_start() {
   local team="${1:?Usage: remote.sh sync start <team>}" cfg connected_at disconnected_at \
-    engine_state engine_pid started_pid ready_pid i=0
+    engine_state engine_pid started_pid ready_pid ready=0 i=0 logfile log_offset=1
   [ $# -eq 1 ] || { echo "Usage: remote.sh sync start <team>" >&2; exit 1; }
   agmsg_validate_team_name "$team" || exit 1
   agmsg_lock_acquire "$TEAMS_DIR/$team" || exit 1
@@ -1356,6 +1373,8 @@ cmd_sync_start() {
     return
   fi
 
+  logfile="$CONNECTION_ROOT/run/remote-sync.$team.log"
+  [ -f "$logfile" ] && log_offset=$(( $(wc -c < "$logfile" | tr -d ' ') + 1 ))
   if ! _remote_sync_engine_start "$team"; then
     agmsg_lock_release
     return 1
@@ -1363,15 +1382,20 @@ cmd_sync_start() {
   started_pid="$(cat "$(_remote_sync_engine_pidfile "$team")")"
   while [ "$i" -lt 100 ]; do
     IFS=$'\t' read -r engine_state ready_pid < <(_remote_sync_engine_status "$team")
-    if [ "$engine_state" = "running" ] && [ "$ready_pid" = "$started_pid" ]; then
+    if [ "$engine_state" = "running" ] && [ "$ready_pid" = "$started_pid" ] &&
+       tail -c "+$log_offset" "$logfile" 2>/dev/null | grep -q '"event":"capabilities"'; then
+      ready=1
       break
     fi
     i=$((i + 1))
     sleep 0.01
   done
-  if [ "$engine_state" != "running" ] || [ "$ready_pid" != "$started_pid" ]; then
-    kill "$started_pid" 2>/dev/null || true
-    rm -f "$(_remote_sync_engine_pidfile "$team")"
+  if [ "$ready" -ne 1 ]; then
+    if _remote_sync_engine_reap_owned "$team" "$started_pid"; then
+      rm -f "$(_remote_sync_engine_pidfile "$team")"
+    else
+      echo "agmsg: failed engine ownership was preserved in its pidfile for diagnosis" >&2
+    fi
     agmsg_lock_release
     echo "agmsg: sync engine for '$team' did not become ready" >&2
     return 1

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 #   remote.sh connect --endpoint <url> <team>
 #   remote.sh pull --endpoint <url> [--team-id <uuid>] <team>
 #   remote.sh status [<team>] [--json]
+#   remote.sh sync start <team>
 #   remote.sh disconnect <team>
 #
 # Team-scoped cloud/self-hosted sync connection. The OSS CLI never assumes or
@@ -955,16 +956,16 @@ cmd_pull() {
 _remote_sync_engine_pidfile() { printf '%s' "$CONNECTION_ROOT/run/remote-sync.$1.pid"; }
 
 _remote_sync_engine_start() {
-  local team="$1" pidfile logfile old_pid
+  local team="$1" pidfile logfile old_pid old_state
   pidfile="$(_remote_sync_engine_pidfile "$team")"
   logfile="$CONNECTION_ROOT/run/remote-sync.$team.log"
   mkdir -p "$CONNECTION_ROOT/run" 2>/dev/null || true
-  # Stop a previous engine for this team before claiming the slot; a stale
-  # pidfile (its process already gone) is simply overwritten. _agmsg_pid_alive
-  # guards against a recycled pid pointing at an unrelated process.
-  if [ -f "$pidfile" ]; then
-    old_pid="$(cat "$pidfile" 2>/dev/null || true)"
-    [ -n "$old_pid" ] && _agmsg_pid_alive "$old_pid" && kill "$old_pid" 2>/dev/null || true
+  # Stop only an engine whose argv proves that it owns this team. A stale
+  # pidfile may point at a recycled, unrelated process and must never authorize
+  # signalling that process.
+  IFS=$'\t' read -r old_state old_pid < <(_remote_sync_engine_status "$team")
+  if [ "$old_state" = "running" ]; then
+    kill "$old_pid" 2>/dev/null || true
   fi
   # nohup so the engine outlives this connect; remote-sync.sh execs node, so $!
   # stays the engine's own pid and is exactly what _remote_sync_engine_stop signals.
@@ -984,6 +985,33 @@ _remote_sync_engine_stop() {
   pid="$(cat "$pidfile" 2>/dev/null || true)"
   [ -n "$pid" ] && _agmsg_pid_alive "$pid" && kill "$pid" 2>/dev/null || true
   rm -f "$pidfile"
+}
+
+# Print "<state>\t<pid>", where pid is empty when no valid pid is available.
+# A live PID is not enough: PID reuse can make an unrelated process pass
+# kill -0, so running requires the exact engine script/team suffix in argv.
+_remote_sync_engine_status() {
+  local team="$1" pidfile pid command expected
+  pidfile="$(_remote_sync_engine_pidfile "$team")"
+  if [ ! -f "$pidfile" ]; then
+    printf 'stopped\t\n'
+    return
+  fi
+  pid="$(cat "$pidfile" 2>/dev/null || true)"
+  if ! [[ "$pid" =~ ^[1-9][0-9]{0,9}$ ]]; then
+    printf 'stale\t\n'
+    return
+  fi
+  if ! _agmsg_pid_alive "$pid"; then
+    printf 'stale\t%s\n' "$pid"
+    return
+  fi
+  command="$(compat_get_cmdline "$pid" 2>/dev/null || true)"
+  expected="$SCRIPT_DIR/internal/remote-sync.mjs run --team $team"
+  case "$command" in
+    *"$expected") printf 'running\t%s\n' "$pid" ;;
+    *) printf 'stale\t%s\n' "$pid" ;;
+  esac
 }
 
 # Upgrade a team that predates local ids: mint a team_id AND a member_id for
@@ -1138,7 +1166,8 @@ cmd_connect() {
 # --- status --------------------------------------------------------------
 
 _remote_status_one() {
-  local team="$1" cfg connected_at disconnected_at write_allowed_ciphers key_id
+  local team="$1" cfg connected_at disconnected_at write_allowed_ciphers key_id \
+    engine_state engine_pid
   cfg="$(_remote_team_config "$team")"
   connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
   disconnected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
@@ -1159,7 +1188,20 @@ _remote_status_one() {
     '['*']') [ "$write_allowed_ciphers" != "[]" ] && needs_encryption=1 ;;
   esac
 
-  echo "$team	connected (since $connected_at)"
+  IFS=$'\t' read -r engine_state engine_pid < <(_remote_sync_engine_status "$team")
+  case "$engine_state" in
+    running)
+      echo "$team	connected (engine running, pid $engine_pid) since $connected_at" ;;
+    stopped)
+      echo "$team	connected (engine stopped — run: remote.sh sync start $team) since $connected_at" ;;
+    stale)
+      if [ -n "$engine_pid" ]; then
+        echo "$team	connected (engine stale — pidfile $engine_pid points at a dead or foreign process) since $connected_at"
+      else
+        echo "$team	connected (engine stale — pidfile does not contain a valid process id) since $connected_at"
+      fi
+      ;;
+  esac
   if [ "$needs_encryption" -eq 1 ]; then
     if [ -z "$key_id" ] || [ "$key_id" = "null" ]; then
       echo "		encryption: required, no local key — run 'key.sh generate $team' or 'key.sh import $team'"
@@ -1202,7 +1244,7 @@ _remote_status_one() {
 # containing a quote/backslash must not silently produce malformed JSON the
 # way E3's hand-rolled credential escaping once did.
 _remote_status_json_one() {
-  local team="$1" cfg raw
+  local team="$1" cfg raw engine_state engine_pid
   cfg="$(_remote_team_config "$team")"
   [ -f "$cfg" ] || return 1
 
@@ -1210,9 +1252,10 @@ _remote_status_json_one() {
   raw="$(cat "$cfg" 2>/dev/null)"
   agmsg_lock_release
 
+  IFS=$'\t' read -r engine_state engine_pid < <(_remote_sync_engine_status "$team")
   printf '%s' "$raw" | python3 -c '
 import json, sys
-team = sys.argv[1]
+team, engine_state, engine_pid_text = sys.argv[1:4]
 try:
     cfg = json.loads(sys.stdin.read())
 except Exception:
@@ -1223,6 +1266,10 @@ binding = cfg.get("remote_binding")
 if not isinstance(binding, dict) or not binding.get("connected_at"):
     sys.exit(1)
 state = "disconnected" if binding.get("disconnected_at") else "active"
+engine_pid = int(engine_pid_text) if engine_pid_text else None
+if state == "disconnected":
+    engine_state = "stopped"
+    engine_pid = None
 print(json.dumps({
     "local_team": team,
     "endpoint": binding.get("endpoint"),
@@ -1230,8 +1277,10 @@ print(json.dumps({
     "remote_team_id": binding.get("remote_team_id"),
     "credential_id": binding.get("credential_id"),
     "state": state,
+    "engine_state": engine_state,
+    "engine_pid": engine_pid,
 }, sort_keys=True))
-' "$team"
+' "$team" "$engine_state" "$engine_pid"
 }
 
 cmd_status() {
@@ -1274,6 +1323,44 @@ cmd_status() {
   if [ "$any" -ne 1 ] && [ "$json" -ne 1 ]; then
     echo "No teams are connected."
   fi
+}
+
+# --- sync lifecycle --------------------------------------------------------
+
+cmd_sync_start() {
+  local team="${1:?Usage: remote.sh sync start <team>}" cfg connected_at disconnected_at \
+    engine_state engine_pid started_pid
+  [ $# -eq 1 ] || { echo "Usage: remote.sh sync start <team>" >&2; exit 1; }
+  agmsg_validate_team_name "$team" || exit 1
+  cfg="$(_remote_team_config "$team")"
+  connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
+  disconnected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
+  if [ -z "$connected_at" ] || [ "$connected_at" = "null" ]; then
+    echo "agmsg: team '$team' has no active remote binding; connect or pull it first" >&2
+    exit 1
+  fi
+  if [ -n "$disconnected_at" ] && [ "$disconnected_at" != "null" ]; then
+    echo "agmsg: team '$team' is disconnected; connect or pull it before starting sync" >&2
+    exit 1
+  fi
+
+  IFS=$'\t' read -r engine_state engine_pid < <(_remote_sync_engine_status "$team")
+  if [ "$engine_state" = "running" ]; then
+    echo "Sync engine already running (pid $engine_pid)."
+    return
+  fi
+
+  _remote_sync_engine_start "$team"
+  started_pid="$(cat "$(_remote_sync_engine_pidfile "$team")")"
+  echo "Sync engine started for '$team' (pid $started_pid)."
+}
+
+cmd_sync() {
+  local action="${1:-}"
+  case "$action" in
+    start) shift; cmd_sync_start "$@" ;;
+    *) echo "Usage: remote.sh sync start <team>" >&2; exit 1 ;;
+  esac
 }
 
 # --- disconnect ------------------------------------------------------------
@@ -1348,10 +1435,11 @@ case "${1:-}" in
   connect) shift; agmsg_require_python3 "remote connect" || exit 1; cmd_connect "$@" ;;
   pull) shift; agmsg_require_python3 "remote pull" || exit 1; cmd_pull "$@" ;;
   status) shift; agmsg_require_python3 "remote status" || exit 1; cmd_status "$@" ;;
+  sync) shift; cmd_sync "$@" ;;
   disconnect) shift; agmsg_require_python3 "remote disconnect" || exit 1; cmd_disconnect "$@" ;;
   doctor) shift; cmd_doctor "$@" ;;
   pending) shift; agmsg_require_python3 "remote pending" || exit 1; cmd_pending "$@" ;;
   *)
-    echo "Usage: remote.sh <connect|pull|status|disconnect|doctor|pending> ..." >&2
+    echo "Usage: remote.sh <connect|pull|status|sync|disconnect|doctor|pending> ..." >&2
     exit 1 ;;
 esac

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -979,11 +979,13 @@ _remote_sync_engine_start() {
 }
 
 _remote_sync_engine_stop() {
-  local team="$1" pidfile pid
+  local team="$1" pidfile pid state
   pidfile="$(_remote_sync_engine_pidfile "$team")"
   [ -f "$pidfile" ] || return 0
-  pid="$(cat "$pidfile" 2>/dev/null || true)"
-  [ -n "$pid" ] && _agmsg_pid_alive "$pid" && kill "$pid" 2>/dev/null || true
+  IFS=$'\t' read -r state pid < <(_remote_sync_engine_status "$team")
+  if [ "$state" = "running" ]; then
+    kill "$pid" 2>/dev/null || true
+  fi
   rm -f "$pidfile"
 }
 
@@ -1329,29 +1331,52 @@ cmd_status() {
 
 cmd_sync_start() {
   local team="${1:?Usage: remote.sh sync start <team>}" cfg connected_at disconnected_at \
-    engine_state engine_pid started_pid
+    engine_state engine_pid started_pid ready_pid i=0
   [ $# -eq 1 ] || { echo "Usage: remote.sh sync start <team>" >&2; exit 1; }
   agmsg_validate_team_name "$team" || exit 1
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || exit 1
   cfg="$(_remote_team_config "$team")"
   connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
   disconnected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
   if [ -z "$connected_at" ] || [ "$connected_at" = "null" ]; then
     echo "agmsg: team '$team' has no active remote binding; connect or pull it first" >&2
+    agmsg_lock_release
     exit 1
   fi
   if [ -n "$disconnected_at" ] && [ "$disconnected_at" != "null" ]; then
     echo "agmsg: team '$team' is disconnected; connect or pull it before starting sync" >&2
+    agmsg_lock_release
     exit 1
   fi
 
   IFS=$'\t' read -r engine_state engine_pid < <(_remote_sync_engine_status "$team")
   if [ "$engine_state" = "running" ]; then
     echo "Sync engine already running (pid $engine_pid)."
+    agmsg_lock_release
     return
   fi
 
-  _remote_sync_engine_start "$team"
+  if ! _remote_sync_engine_start "$team"; then
+    agmsg_lock_release
+    return 1
+  fi
   started_pid="$(cat "$(_remote_sync_engine_pidfile "$team")")"
+  while [ "$i" -lt 100 ]; do
+    IFS=$'\t' read -r engine_state ready_pid < <(_remote_sync_engine_status "$team")
+    if [ "$engine_state" = "running" ] && [ "$ready_pid" = "$started_pid" ]; then
+      break
+    fi
+    i=$((i + 1))
+    sleep 0.01
+  done
+  if [ "$engine_state" != "running" ] || [ "$ready_pid" != "$started_pid" ]; then
+    kill "$started_pid" 2>/dev/null || true
+    rm -f "$(_remote_sync_engine_pidfile "$team")"
+    agmsg_lock_release
+    echo "agmsg: sync engine for '$team' did not become ready" >&2
+    return 1
+  fi
+  agmsg_lock_release
   echo "Sync engine started for '$team' (pid $started_pid)."
 }
 

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -956,7 +956,7 @@ cmd_pull() {
 _remote_sync_engine_pidfile() { printf '%s' "$CONNECTION_ROOT/run/remote-sync.$1.pid"; }
 
 _remote_sync_engine_start() {
-  local team="$1" pidfile logfile old_pid old_state
+  local team="$1" startup_nonce="${2:-}" pidfile logfile old_pid old_state
   pidfile="$(_remote_sync_engine_pidfile "$team")"
   logfile="$CONNECTION_ROOT/run/remote-sync.$team.log"
   mkdir -p "$CONNECTION_ROOT/run" 2>/dev/null || true
@@ -973,7 +973,8 @@ _remote_sync_engine_start() {
   # daemon inheriting it keeps the whole test file open until the CI timeout —
   # the last-ok-then-orphan hang this repo has met before, this time spawned by
   # production code rather than a test.
-  nohup bash "$SCRIPT_DIR/remote-sync.sh" run --team "$team" >> "$logfile" 2>&1 3>&- 4>&- &
+  AGMSG_SYNC_START_NONCE="$startup_nonce" \
+    nohup bash "$SCRIPT_DIR/remote-sync.sh" run --team "$team" >> "$logfile" 2>&1 3>&- 4>&- &
   echo $! > "$pidfile"
   disown 2>/dev/null || true
 }
@@ -1348,7 +1349,8 @@ cmd_status() {
 
 cmd_sync_start() {
   local team="${1:?Usage: remote.sh sync start <team>}" cfg connected_at disconnected_at \
-    engine_state engine_pid started_pid ready_pid ready=0 i=0 logfile log_offset=1
+    engine_state engine_pid started_pid ready_pid startup_nonce ready=0 i=0 \
+    logfile log_offset=1
   [ $# -eq 1 ] || { echo "Usage: remote.sh sync start <team>" >&2; exit 1; }
   agmsg_validate_team_name "$team" || exit 1
   agmsg_lock_acquire "$TEAMS_DIR/$team" || exit 1
@@ -1375,15 +1377,18 @@ cmd_sync_start() {
 
   logfile="$CONNECTION_ROOT/run/remote-sync.$team.log"
   [ -f "$logfile" ] && log_offset=$(( $(wc -c < "$logfile" | tr -d ' ') + 1 ))
-  if ! _remote_sync_engine_start "$team"; then
+  startup_nonce="$(compat_uuid7)"
+  if ! _remote_sync_engine_start "$team" "$startup_nonce"; then
     agmsg_lock_release
     return 1
   fi
   started_pid="$(cat "$(_remote_sync_engine_pidfile "$team")")"
-  while [ "$i" -lt 100 ]; do
+  while [ "$i" -lt 1600 ]; do
     IFS=$'\t' read -r engine_state ready_pid < <(_remote_sync_engine_status "$team")
     if [ "$engine_state" = "running" ] && [ "$ready_pid" = "$started_pid" ] &&
-       tail -c "+$log_offset" "$logfile" 2>/dev/null | grep -q '"event":"capabilities"'; then
+       tail -c "+$log_offset" "$logfile" 2>/dev/null |
+         grep '"event":"capabilities"' |
+         grep -Fq "\"startup_nonce\":\"$startup_nonce\""; then
       ready=1
       break
     fi

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -232,6 +232,8 @@ restart_mock_server() {
   [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.local_team');")" = "testteam" ]
   [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.endpoint');")" = "$ENDPOINT" ]
   [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.state');")" = "active" ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.engine_state');")" = "running" ]
+  [ "$(sqlite_mem "SELECT json_type('$(echo "$output" | sed "s/'/''/g")', '\$.engine_pid');")" = "integer" ]
   [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.server_instance_id');")" != "" ]
   [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.remote_team_id');")" != "" ]
   # The register binding carries no credential; the field is still emitted for
@@ -245,6 +247,8 @@ restart_mock_server() {
   run bash "$SCRIPTS/remote.sh" status testteam --json
   [ "$status" -eq 0 ]
   [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.state');")" = "disconnected" ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.engine_state');")" = "stopped" ]
+  [ "$(sqlite_mem "SELECT json_type('$(echo "$output" | sed "s/'/''/g")', '\$.engine_pid');")" = "null" ]
 }
 
 @test "status --json: errors for a team that has never been connected" {

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -65,6 +65,11 @@ write_fake_node() {
     '  exit 0' \
     'fi' \
     'echo "{\"event\":\"capabilities\",\"startup_nonce\":\"${AGMSG_SYNC_START_NONCE:-}\"}"' \
+    'i=0' \
+    'while [ "$i" -lt 512 ]; do' \
+    '  echo "{\"event\":\"capabilities\",\"startup_nonce\":\"other-generation\"}"' \
+    '  i=$((i + 1))' \
+    'done' \
     '[ -z "${AGMSG_TEST_CHILD_PID_FILE:-}" ] || printf '\''%s\\n'\'' "$$" > "$AGMSG_TEST_CHILD_PID_FILE"' \
     'trap "exit 0" TERM INT' \
     'while :; do sleep 1; done' > "$fake_node"

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -70,6 +70,23 @@ write_fake_node() {
   printf '%s\n' "$fake_node"
 }
 
+write_fake_node_ps_fixture() {
+  local fake_node="$1" foreign_pid="${2:-}" fake_bin="$TEST_SKILL_DIR/fake-node-bin"
+  mkdir -p "$fake_bin"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'pid=""' \
+    'while [ $# -gt 0 ]; do' \
+    '  if [ "$1" = "-p" ]; then pid="$2"; shift 2; else shift; fi' \
+    'done' \
+    "if [ \"\$pid\" = '$foreign_pid' ]; then" \
+    "  printf '%s\\n' 'sleep 30'" \
+    'else' \
+    "  printf '%s\\n' 'bash $SCRIPTS/internal/remote-sync.mjs run --team testteam'" \
+    'fi' > "$fake_bin/ps"
+  chmod +x "$fake_bin/ps"
+  printf '%s\n' "$fake_bin"
+}
+
 remember_engine_pid() {
   ENGINE_PID="$(cat "$TEST_SKILL_DIR/run/remote-sync.testteam.pid")"
   ENGINE_PIDS="${ENGINE_PIDS:+$ENGINE_PIDS }$ENGINE_PID"
@@ -140,14 +157,14 @@ remember_engine_pid() {
 @test "sync start: starts a stopped engine and status reports it running" {
   local fake_node fake_bin first_pid
   fake_node="$(write_fake_node)"
+  fake_bin="$(write_fake_node_ps_fixture "$fake_node")"
 
-  run env AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
+  run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
   [ "$status" -eq 0 ]
   [[ "$output" == *"Sync engine started for 'testteam' (pid "* ]]
   remember_engine_pid
   kill -0 "$ENGINE_PID"
 
-  fake_bin="$(write_matching_ps_fixture)"
   run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
   [ "$status" -eq 0 ]
   [[ "$output" == *"connected (engine running, pid $ENGINE_PID)"* ]]
@@ -159,11 +176,10 @@ remember_engine_pid() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"connected (engine stale"* ]]
 
-  run env AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
+  run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
   [ "$status" -eq 0 ]
   remember_engine_pid
   [ "$ENGINE_PID" -ne "$first_pid" ]
-  fake_bin="$(write_matching_ps_fixture)"
   run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
   [ "$status" -eq 0 ]
   [[ "$output" == *"connected (engine running, pid $ENGINE_PID)"* ]]
@@ -172,10 +188,10 @@ remember_engine_pid() {
 @test "sync start: is a no-op when the verified engine is already running" {
   local fake_node fake_bin original_pid
   fake_node="$(write_fake_node)"
-  env AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
+  fake_bin="$(write_fake_node_ps_fixture "$fake_node")"
+  env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
   remember_engine_pid
   original_pid="$ENGINE_PID"
-  fake_bin="$(write_matching_ps_fixture)"
 
   run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" \
     bash "$SCRIPTS/remote.sh" sync start testteam
@@ -190,19 +206,54 @@ remember_engine_pid() {
   fake_node="$(write_fake_node)"
   sleep 30 &
   foreign_pid=$!
+  fake_bin="$(write_fake_node_ps_fixture "$fake_node" "$foreign_pid")"
   ENGINE_PIDS="${ENGINE_PIDS:+$ENGINE_PIDS }$foreign_pid"
   printf '%s\n' "$foreign_pid" > "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
 
-  run env AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
+  run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
   [ "$status" -eq 0 ]
   kill -0 "$foreign_pid"
   remember_engine_pid
   [ "$ENGINE_PID" -ne "$foreign_pid" ]
 
-  fake_bin="$(write_matching_ps_fixture)"
   run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
   [ "$status" -eq 0 ]
   [[ "$output" == *"connected (engine running, pid $ENGINE_PID)"* ]]
+}
+
+@test "disconnect removes stale ownership without signalling a foreign process" {
+  sleep 30 &
+  local foreign_pid=$!
+  ENGINE_PIDS="${ENGINE_PIDS:+$ENGINE_PIDS }$foreign_pid"
+  printf '%s\n' "$foreign_pid" > "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+
+  run bash "$SCRIPTS/remote.sh" disconnect testteam
+  [ "$status" -eq 0 ]
+  kill -0 "$foreign_pid"
+  [ ! -e "$TEST_SKILL_DIR/run/remote-sync.testteam.pid" ]
+}
+
+@test "concurrent sync start serializes ownership to one engine" {
+  local fake_node fake_bin first_out second_out first_status=0 second_status=0
+  fake_node="$(write_fake_node)"
+  fake_bin="$(write_fake_node_ps_fixture "$fake_node")"
+  first_out="$(mktemp)"
+  second_out="$(mktemp)"
+
+  env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam >"$first_out" 2>&1 &
+  local first_start=$!
+  env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam >"$second_out" 2>&1 &
+  local second_start=$!
+  wait "$first_start" || first_status=$?
+  wait "$second_start" || second_status=$?
+  [ "$first_status" -eq 0 ]
+  [ "$second_status" -eq 0 ]
+  [ "$(grep -h -c 'Sync engine started' "$first_out" "$second_out" | awk '{s += $1} END {print s}')" -eq 1 ]
+  [ "$(grep -h -c 'Sync engine already running' "$first_out" "$second_out" | awk '{s += $1} END {print s}')" -eq 1 ]
+
+  remember_engine_pid
+  kill -0 "$ENGINE_PID"
+  rm -f "$first_out" "$second_out"
 }
 
 @test "sync start: rejects a team whose binding is not active" {

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -64,6 +64,7 @@ write_fake_node() {
     '  echo v23.0.0' \
     '  exit 0' \
     'fi' \
+    'echo '\''{"event":"capabilities"}'\''' \
     'trap "exit 0" TERM INT' \
     'while :; do sleep 1; done' > "$fake_node"
   chmod +x "$fake_node"
@@ -254,6 +255,23 @@ remember_engine_pid() {
   remember_engine_pid
   kill -0 "$ENGINE_PID"
   rm -f "$first_out" "$second_out"
+}
+
+@test "sync start reaps a ready-timeout child before releasing ownership" {
+  local fake_node="$TEST_SKILL_DIR/fake-node-timeout" fake_bin lock
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'trap "" TERM' \
+    'while :; do sleep 1; done' > "$fake_node"
+  chmod +x "$fake_node"
+  fake_bin="$(write_fake_node_ps_fixture "$fake_node")"
+
+  run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" \
+    bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"did not become ready"* ]]
+  [ ! -e "$TEST_SKILL_DIR/run/remote-sync.testteam.pid" ]
+  lock="$TEST_SKILL_DIR/teams/testteam/.config.lock"
+  [ ! -d "$lock" ]
 }
 
 @test "sync start: rejects a team whose binding is not active" {

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -66,13 +66,14 @@ write_fake_node() {
     'fi' \
     'echo "{\"event\":\"capabilities\",\"startup_nonce\":\"${AGMSG_SYNC_START_NONCE:-}\"}"' \
     "trailing_records=$trailing_records" \
-    "printf -v padding '%16384s' ''" \
-    'padding="${padding// /x}"' \
-    'i=0' \
-    'while [ "$i" -lt "$trailing_records" ]; do' \
-    '  echo "{\"event\":\"capabilities\",\"startup_nonce\":\"other-generation\",\"padding\":\"$padding\"}"' \
-    '  i=$((i + 1))' \
-    'done' \
+    'awk -v count="$trailing_records" '\''BEGIN {' \
+    '  padding = sprintf("%16384s", "")' \
+    '  gsub(/ /, "x", padding)' \
+    '  for (i = 0; i < count; i++) {' \
+    '    print "{\"event\":\"capabilities\",\"startup_nonce\":\"other-generation\",\"padding\":\"" padding "\"}"' \
+    '  }' \
+    '}'\''' \
+    '[ -z "${AGMSG_TEST_LOG_READY_FILE:-}" ] || : > "$AGMSG_TEST_LOG_READY_FILE"' \
     '[ -z "${AGMSG_TEST_CHILD_PID_FILE:-}" ] || printf '\''%s\\n'\'' "$$" > "$AGMSG_TEST_CHILD_PID_FILE"' \
     'trap "exit 0" TERM INT' \
     'while :; do sleep 1; done' > "$fake_node"
@@ -81,14 +82,15 @@ write_fake_node() {
 }
 
 write_fake_node_ps_fixture() {
-  local fake_node="$1" foreign_pid="${2:-}" fake_bin="$TEST_SKILL_DIR/fake-node-bin"
+  local fake_node="$1" foreign_pid="${2:-}" ready_file="${3:-}" \
+    fake_bin="$TEST_SKILL_DIR/fake-node-bin"
   mkdir -p "$fake_bin"
   printf '%s\n' '#!/usr/bin/env bash' \
     'pid=""' \
     'while [ $# -gt 0 ]; do' \
     '  if [ "$1" = "-p" ]; then pid="$2"; shift 2; else shift; fi' \
     'done' \
-    "if [ \"\$pid\" = '$foreign_pid' ]; then" \
+    "if { [ -n '$ready_file' ] && [ ! -f '$ready_file' ]; } || [ \"\$pid\" = '$foreign_pid' ]; then" \
     "  printf '%s\\n' 'sleep 30'" \
     'else' \
     "  printf '%s\\n' 'bash $SCRIPTS/internal/remote-sync.mjs run --team testteam'" \
@@ -267,13 +269,15 @@ remember_engine_pid() {
 }
 
 @test "sync start reads a complete multi-megabyte handshake log without SIGPIPE" {
-  local fake_node fake_bin
+  local fake_node fake_bin ready_file="$TEST_SKILL_DIR/handshake-log.ready"
   fake_node="$(write_fake_node 512)"
-  fake_bin="$(write_fake_node_ps_fixture "$fake_node")"
+  fake_bin="$(write_fake_node_ps_fixture "$fake_node" "" "$ready_file")"
 
   run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" \
+    AGMSG_TEST_LOG_READY_FILE="$ready_file" \
     bash "$SCRIPTS/remote.sh" sync start testteam
   [ "$status" -eq 0 ]
+  [ -f "$ready_file" ]
   remember_engine_pid
   kill -0 "$ENGINE_PID"
 }

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -58,16 +58,19 @@ write_matching_ps_fixture() {
 }
 
 write_fake_node() {
-  local fake_node="$TEST_SKILL_DIR/fake-node"
+  local trailing_records="${1:-0}" fake_node="$TEST_SKILL_DIR/fake-node"
   printf '%s\n' '#!/usr/bin/env bash' \
     'if [ "${1:-}" = "--version" ]; then' \
     '  echo v23.0.0' \
     '  exit 0' \
     'fi' \
     'echo "{\"event\":\"capabilities\",\"startup_nonce\":\"${AGMSG_SYNC_START_NONCE:-}\"}"' \
+    "trailing_records=$trailing_records" \
+    "printf -v padding '%16384s' ''" \
+    'padding="${padding// /x}"' \
     'i=0' \
-    'while [ "$i" -lt 512 ]; do' \
-    '  echo "{\"event\":\"capabilities\",\"startup_nonce\":\"other-generation\"}"' \
+    'while [ "$i" -lt "$trailing_records" ]; do' \
+    '  echo "{\"event\":\"capabilities\",\"startup_nonce\":\"other-generation\",\"padding\":\"$padding\"}"' \
     '  i=$((i + 1))' \
     'done' \
     '[ -z "${AGMSG_TEST_CHILD_PID_FILE:-}" ] || printf '\''%s\\n'\'' "$$" > "$AGMSG_TEST_CHILD_PID_FILE"' \
@@ -261,6 +264,18 @@ remember_engine_pid() {
   remember_engine_pid
   kill -0 "$ENGINE_PID"
   rm -f "$first_out" "$second_out"
+}
+
+@test "sync start reads a complete multi-megabyte handshake log without SIGPIPE" {
+  local fake_node fake_bin
+  fake_node="$(write_fake_node 512)"
+  fake_bin="$(write_fake_node_ps_fixture "$fake_node")"
+
+  run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" \
+    bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -eq 0 ]
+  remember_engine_pid
+  kill -0 "$ENGINE_PID"
 }
 
 @test "sync start reaps a ready-timeout child before releasing ownership" {

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -64,7 +64,8 @@ write_fake_node() {
     '  echo v23.0.0' \
     '  exit 0' \
     'fi' \
-    'echo '\''{"event":"capabilities"}'\''' \
+    'echo "{\"event\":\"capabilities\",\"startup_nonce\":\"${AGMSG_SYNC_START_NONCE:-}\"}"' \
+    '[ -z "${AGMSG_TEST_CHILD_PID_FILE:-}" ] || printf '\''%s\\n'\'' "$$" > "$AGMSG_TEST_CHILD_PID_FILE"' \
     'trap "exit 0" TERM INT' \
     'while :; do sleep 1; done' > "$fake_node"
   chmod +x "$fake_node"
@@ -258,18 +259,23 @@ remember_engine_pid() {
 }
 
 @test "sync start reaps a ready-timeout child before releasing ownership" {
-  local fake_node="$TEST_SKILL_DIR/fake-node-timeout" fake_bin lock
+  local fake_node="$TEST_SKILL_DIR/fake-node-timeout" fake_bin lock child_pid_file child_pid
+  child_pid_file="$TEST_SKILL_DIR/timeout-child.pid"
   printf '%s\n' '#!/usr/bin/env bash' \
+    'printf '\''%s\\n'\'' "$$" > "$AGMSG_TEST_CHILD_PID_FILE"' \
     'trap "" TERM' \
     'while :; do sleep 1; done' > "$fake_node"
   chmod +x "$fake_node"
   fake_bin="$(write_fake_node_ps_fixture "$fake_node")"
 
   run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" \
+    AGMSG_TEST_CHILD_PID_FILE="$child_pid_file" \
     bash "$SCRIPTS/remote.sh" sync start testteam
   [ "$status" -ne 0 ]
   [[ "$output" == *"did not become ready"* ]]
   [ ! -e "$TEST_SKILL_DIR/run/remote-sync.testteam.pid" ]
+  child_pid="$(cat "$child_pid_file")"
+  ! kill -0 "$child_pid" 2>/dev/null
   lock="$TEST_SKILL_DIR/teams/testteam/.config.lock"
   [ ! -d "$lock" ]
 }

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -1,0 +1,219 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a
+
+  local cfg="$TEST_SKILL_DIR/teams/testteam/config.json" escaped updated
+  escaped="$(sed "s/'/''/g" "$cfg")"
+  updated="$(sqlite_mem "
+    SELECT json_set('$escaped', '\$.remote_binding', json_object(
+      'endpoint', 'https://remote.example',
+      'server_instance_id', '018f0000-0000-7000-8000-000000000001',
+      'remote_team_id', '018f0000-0000-7000-8000-000000000002',
+      'protocol_version', 1,
+      'capabilities', json_object('write_allowed_ciphers', json_array('none')),
+      'connected_at', '2026-07-30T00:00:00Z',
+      'disconnected_at', null
+    ));")"
+  printf '%s\n' "$updated" > "$cfg"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  ENGINE_PIDS=""
+}
+
+teardown() {
+  local pid
+  for pid in $ENGINE_PIDS; do
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
+  teardown_test_env
+}
+
+start_matching_engine() {
+  local engine="$SCRIPTS/internal/remote-sync.mjs"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'trap "exit 0" TERM INT' \
+    'while :; do sleep 1; done' > "$engine"
+  chmod +x "$engine"
+  bash "$engine" run --team testteam &
+  ENGINE_PID=$!
+  ENGINE_PIDS="${ENGINE_PIDS:+$ENGINE_PIDS }$ENGINE_PID"
+  printf '%s\n' "$ENGINE_PID" > "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+}
+
+write_matching_ps_fixture() {
+  local fake_bin="$TEST_SKILL_DIR/fake-bin"
+  mkdir -p "$fake_bin"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    "if [[ \" \$* \" == *\" -p $ENGINE_PID \"* ]]; then" \
+    "  printf '%s\\n' 'bash $SCRIPTS/internal/remote-sync.mjs run --team testteam'" \
+    '  exit 0' \
+    'fi' \
+    'exec /bin/ps "$@"' > "$fake_bin/ps"
+  chmod +x "$fake_bin/ps"
+  printf '%s\n' "$fake_bin"
+}
+
+write_fake_node() {
+  local fake_node="$TEST_SKILL_DIR/fake-node"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'if [ "${1:-}" = "--version" ]; then' \
+    '  echo v23.0.0' \
+    '  exit 0' \
+    'fi' \
+    'trap "exit 0" TERM INT' \
+    'while :; do sleep 1; done' > "$fake_node"
+  chmod +x "$fake_node"
+  printf '%s\n' "$fake_node"
+}
+
+remember_engine_pid() {
+  ENGINE_PID="$(cat "$TEST_SKILL_DIR/run/remote-sync.testteam.pid")"
+  ENGINE_PIDS="${ENGINE_PIDS:+$ENGINE_PIDS }$ENGINE_PID"
+}
+
+@test "status: reports an active binding whose engine is stopped" {
+  run bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"connected (engine stopped"* ]]
+  [[ "$output" == *"remote.sh sync start testteam"* ]]
+
+  run bash "$SCRIPTS/remote.sh" status testteam --json
+  [ "$status" -eq 0 ]
+  [ "$(sqlite_mem "SELECT json_extract('$(printf '%s' "$output" | sed "s/'/''/g")', '\$.engine_state');")" = stopped ]
+  [ "$(sqlite_mem "SELECT json_type('$(printf '%s' "$output" | sed "s/'/''/g")', '\$.engine_pid');")" = null ]
+}
+
+@test "status: reports a live engine only when argv matches this team" {
+  start_matching_engine
+  local fake_bin
+  fake_bin="$(write_matching_ps_fixture)"
+
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"connected (engine running, pid $ENGINE_PID)"* ]]
+
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam --json
+  [ "$status" -eq 0 ]
+  [ "$(sqlite_mem "SELECT json_extract('$(printf '%s' "$output" | sed "s/'/''/g")', '\$.engine_state');")" = running ]
+  [ "$(sqlite_mem "SELECT json_extract('$(printf '%s' "$output" | sed "s/'/''/g")', '\$.engine_pid');")" -eq "$ENGINE_PID" ]
+}
+
+@test "status: rejects a live foreign process behind a recycled pidfile" {
+  sleep 30 &
+  local foreign_pid=$!
+  ENGINE_PIDS="${ENGINE_PIDS:+$ENGINE_PIDS }$foreign_pid"
+  printf '%s\n' "$foreign_pid" > "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+
+  run bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"connected (engine stale"* ]]
+  [[ "$output" == *"pidfile $foreign_pid points at a dead or foreign process"* ]]
+
+  run bash "$SCRIPTS/remote.sh" status testteam --json
+  [ "$status" -eq 0 ]
+  [ "$(sqlite_mem "SELECT json_extract('$(printf '%s' "$output" | sed "s/'/''/g")', '\$.engine_state');")" = stale ]
+  [ "$(sqlite_mem "SELECT json_extract('$(printf '%s' "$output" | sed "s/'/''/g")', '\$.engine_pid');")" -eq "$foreign_pid" ]
+}
+
+@test "status: reports a dead pidfile as stale without changing exit status" {
+  printf '%s\n' 2147483647 > "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+
+  run bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"connected (engine stale"* ]]
+  [[ "$output" == *"pidfile 2147483647 points at a dead or foreign process"* ]]
+}
+
+@test "status: rejects a malformed pidfile without interpreting it as a process" {
+  printf '%s\n' 0123 > "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+
+  run bash "$SCRIPTS/remote.sh" status testteam --json
+  [ "$status" -eq 0 ]
+  [ "$(sqlite_mem "SELECT json_extract('$(printf '%s' "$output" | sed "s/'/''/g")', '\$.engine_state');")" = stale ]
+  [ "$(sqlite_mem "SELECT json_type('$(printf '%s' "$output" | sed "s/'/''/g")', '\$.engine_pid');")" = null ]
+}
+
+@test "sync start: starts a stopped engine and status reports it running" {
+  local fake_node fake_bin first_pid
+  fake_node="$(write_fake_node)"
+
+  run env AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sync engine started for 'testteam' (pid "* ]]
+  remember_engine_pid
+  kill -0 "$ENGINE_PID"
+
+  fake_bin="$(write_matching_ps_fixture)"
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"connected (engine running, pid $ENGINE_PID)"* ]]
+
+  first_pid="$ENGINE_PID"
+  kill "$first_pid"
+  wait_for_pid_exit "$first_pid"
+  run bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"connected (engine stale"* ]]
+
+  run env AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -eq 0 ]
+  remember_engine_pid
+  [ "$ENGINE_PID" -ne "$first_pid" ]
+  fake_bin="$(write_matching_ps_fixture)"
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"connected (engine running, pid $ENGINE_PID)"* ]]
+}
+
+@test "sync start: is a no-op when the verified engine is already running" {
+  local fake_node fake_bin original_pid
+  fake_node="$(write_fake_node)"
+  env AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
+  remember_engine_pid
+  original_pid="$ENGINE_PID"
+  fake_bin="$(write_matching_ps_fixture)"
+
+  run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" \
+    bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -eq 0 ]
+  [ "$output" = "Sync engine already running (pid $original_pid)." ]
+  [ "$(cat "$TEST_SKILL_DIR/run/remote-sync.testteam.pid")" = "$original_pid" ]
+  kill -0 "$original_pid"
+}
+
+@test "sync start: replaces stale ownership without signalling a foreign process" {
+  local fake_node fake_bin foreign_pid
+  fake_node="$(write_fake_node)"
+  sleep 30 &
+  foreign_pid=$!
+  ENGINE_PIDS="${ENGINE_PIDS:+$ENGINE_PIDS }$foreign_pid"
+  printf '%s\n' "$foreign_pid" > "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+
+  run env AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -eq 0 ]
+  kill -0 "$foreign_pid"
+  remember_engine_pid
+  [ "$ENGINE_PID" -ne "$foreign_pid" ]
+
+  fake_bin="$(write_matching_ps_fixture)"
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"connected (engine running, pid $ENGINE_PID)"* ]]
+}
+
+@test "sync start: rejects a team whose binding is not active" {
+  local cfg="$TEST_SKILL_DIR/teams/testteam/config.json" escaped updated
+  escaped="$(sed "s/'/''/g" "$cfg")"
+  updated="$(sqlite_mem \
+    "SELECT json_set('$escaped', '\$.remote_binding.disconnected_at', '2026-07-30T01:00:00Z');")"
+  printf '%s\n' "$updated" > "$cfg"
+
+  run bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"team 'testteam' is disconnected"* ]]
+  [ ! -e "$TEST_SKILL_DIR/run/remote-sync.testteam.pid" ]
+}


### PR DESCRIPTION
The run-2 dogfood found `status` reporting `connected` while no sync engine existed — sends quietly piled up locally behind a green-looking status. The binding was the only thing checked; nothing verified a live engine.

`remote.sh status` now reports engine liveness alongside the binding, in both human and `--json` output:

- **running** — pidfile PID is alive AND its cmdline is this team's engine (PID-reuse cannot fake it)
- **stopped** — no pidfile
- **stale** — pidfile points at a dead or foreign process

JSON adds `engine_state` and `engine_pid` only; existing fields and exit semantics are unchanged — status observes, it does not fail because the engine is down.

`remote.sh sync start <team>` is the public way back: starts from stopped or stale, no-ops with the PID when verifiably running, refuses an inactive binding, and never signals a foreign PID — a stale pidfile is replaced, not killed. The stopped-status hint points here. Root SKILL.md and all nine type templates follow.

Regressions run the round trip both ways: stopped → start → running, and dead/foreign-stale → start → running with the foreign process untouched.

PR opened on the author's behalf — their sandbox blocks GitHub access.