### PR TITLE
Make the fd-3 spawn rule uniform and enforce it

### DIFF
--- a/scripts/drivers/types/codex/codex-monitor.sh
+++ b/scripts/drivers/types/codex/codex-monitor.sh
@@ -159,7 +159,12 @@ if [ -z "$PORT" ]; then
   # free of any Node dependency — only the bridge (codex-bridge.js) needs Node, and
   # it degrades on its own if Node is missing rather than taking down the TUI. See #170.
   : > "$SERVER_LOG"
-  "$REAL_CODEX" app-server --listen "ws://127.0.0.1:0" >>"$SERVER_LOG" 2>&1 &
+  # fds 3 and 4 are closed for the same reason remote.sh closes them around the
+  # sync engine: under bats, fd 3 is the TAP pipe, and a daemon that inherits it
+  # holds the whole test file open until the CI timeout. This app-server is
+  # built to outlive its caller -- that is what the pidfile and the reuse checks
+  # below are for -- so it is exactly the shape that keeps the pipe open.
+  "$REAL_CODEX" app-server --listen "ws://127.0.0.1:0" >>"$SERVER_LOG" 2>&1 3>&- 4>&- &
   server_bg="$!"
   echo "$server_bg" > "$SERVER_PID"
   for _ in $(seq 1 100); do
@@ -198,7 +203,9 @@ export AGMSG_CODEX_BRIDGE_APP_SERVER="$SOCKET_URL"
 export AGMSG_CODEX_BRIDGE_LAUNCHER=1
 
 launcher_cmd="${AGMSG_CODEX_BRIDGE_LAUNCHER_CMD:-$SCRIPT_DIR/codex-bridge-launcher.sh}"
-"$launcher_cmd" codex "$PROJECT" "$SOCKET_URL" "$$" >/dev/null 2>&1 &
+# Same guard: the launcher is detached on purpose and outlives this script, so
+# an inherited fd 3 would outlive the test file that started it.
+"$launcher_cmd" codex "$PROJECT" "$SOCKET_URL" "$$" >/dev/null 2>&1 3>&- 4>&- &
 
 cd "$PROJECT"
 # Guard the array expansion: under bash 3.2 + `set -u`, "${CODEX_ARGS[@]}" on an

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -203,7 +203,13 @@ _remote_http_post_json() {
   mkfifo "$header_fifo"
   chmod 600 "$cfg"
   trap 'rm -f "$cfg" "$header_fifo"; rmdir "$fifo_dir" 2>/dev/null || true' EXIT INT TERM
-  python3 "$SCRIPT_DIR/internal/bounded-copy.py" 65536 < "$header_fifo" > "$header_file" &
+  # Reaped on both normal paths below (waited on success, killed and waited on
+  # failure), so this is short-lived by construction -- but the EXIT trap only
+  # removes files, it does not kill the copier. A signal arriving before curl
+  # opens the fifo therefore leaves it blocked on open() with no writer ever
+  # coming, and an inherited fd 3 would then hold a bats test file open to the
+  # timeout. Closing the fds costs nothing and removes that one path.
+  python3 "$SCRIPT_DIR/internal/bounded-copy.py" 65536 < "$header_fifo" > "$header_file" 3>&- 4>&- &
   copier_pid=$!
   {
     printf 'url = "%s"\n' "$url"
@@ -248,7 +254,8 @@ _remote_http_post_bearer() {
   mkfifo "$header_fifo"
   chmod 600 "$cfg"
   trap 'rm -f "$cfg" "$header_fifo"; rmdir "$fifo_dir" 2>/dev/null || true' EXIT INT TERM
-  python3 "$SCRIPT_DIR/internal/bounded-copy.py" 65536 < "$header_fifo" > "$header_file" &
+  # Same reaping and the same trap gap as the copier above.
+  python3 "$SCRIPT_DIR/internal/bounded-copy.py" 65536 < "$header_fifo" > "$header_file" 3>&- 4>&- &
   copier_pid=$!
   {
     printf 'url = "%s"\n' "$url"

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -373,6 +373,6 @@ while true; do
   # Run sleep in the background and `wait` for it so signal traps fire
   # immediately. Bash defers traps while a foreground builtin like `sleep`
   # is blocking, which would otherwise delay shutdown by up to $INTERVAL.
-  sleep "$INTERVAL" &
+  sleep "$INTERVAL" 3>&- 4>&- &
   wait $! 2>/dev/null
 done

--- a/tests/test_spawn_fd_guard.bats
+++ b/tests/test_spawn_fd_guard.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+# Under bats, fd 3 is the TAP pipe and fd 4 is used alongside it. A process that
+# inherits either and outlives the command that started it holds the whole test
+# file open, and the shard then runs to the CI job's timeout with every test
+# already reported ok.
+#
+# Every background spawn under scripts/ closes both, on the line itself. There
+# is no file-level exemption: codex-bridge-launcher.sh closes the fds once at
+# the top with `exec` *and* on each of its spawns, so nothing depends on one,
+# and an exemption keyed on "the file contains an exec somewhere" would accept
+# that exec inside a function, inside a branch that never runs, or after the
+# spawn it is supposed to cover. Requiring the guard on the line is redundant
+# where a script-level exec exists, and redundancy is the cheaper mistake.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+}
+
+_unguarded_spawns() {
+  local root="${1:-$REPO_ROOT/scripts}" file line rest
+  while IFS=: read -r file line rest; do
+    [ -n "$file" ] || continue
+    case "$rest" in
+      *"3>&-"*)
+        case "$rest" in *"4>&-"*) continue ;; esac
+        printf '%s:%s: closes fd 3 but not fd 4 -- %s\n' "$file" "$line" "$rest"
+        ;;
+      *) printf '%s:%s: closes neither fd 3 nor fd 4 -- %s\n' "$file" "$line" "$rest" ;;
+    esac
+  done < <(grep -rnE '^[^#]*[^&|]&[[:space:]]*$' "$root" 2>/dev/null)
+}
+
+@test "every background spawn under scripts/ closes bats' fd 3 and fd 4" {
+  local offenders
+  offenders="$(_unguarded_spawns)"
+  if [ -n "$offenders" ]; then
+    printf 'background spawns missing the guard:\n%s\n' "$offenders" >&2
+  fi
+  [ -z "$offenders" ]
+}
+
+@test "the guard check sees the spawns it is meant to police" {
+  # Without this, a pattern that quietly stopped matching would leave a test
+  # passing because it found nothing -- the failure being guarded against is a
+  # silent one, so the count is asserted rather than assumed.
+  local total
+  total="$(grep -rcE '^[^#]*[^&|]&[[:space:]]*$' "$REPO_ROOT/scripts" 2>/dev/null \
+    | awk -F: '{s+=$2} END {print s+0}')"
+  [ "$total" -ge 5 ]
+}
+
+@test "a spawn closing only fd 3 is reported" {
+  # The half-guarded case an earlier revision of this file let through: it
+  # asserted "fd 3 and fd 4" in its message while grepping for fd 3 alone.
+  mkdir -p "$BATS_TEST_TMPDIR/scripts"
+  printf '%s\n' '#!/usr/bin/env bash' 'sleep 300 3>&- &' \
+    > "$BATS_TEST_TMPDIR/scripts/half-guarded.sh"
+  run _unguarded_spawns "$BATS_TEST_TMPDIR/scripts"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"closes fd 3 but not fd 4"* ]]
+}
+
+@test "an exec elsewhere in a file does not excuse an unguarded spawn" {
+  # The loophole a file-level exemption would open, pinned as closed: the exec
+  # here sits in a branch that never runs and after the spawn it would have
+  # covered, which is exactly the shape a "does the file contain an exec?"
+  # check cannot tell apart from a real one.
+  mkdir -p "$BATS_TEST_TMPDIR/scripts"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'sleep 300 &' \
+    'if false; then' \
+    '  exec 3>&- 4>&-' \
+    'fi' \
+    > "$BATS_TEST_TMPDIR/scripts/decoy-exec.sh"
+  run _unguarded_spawns "$BATS_TEST_TMPDIR/scripts"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"closes neither fd 3 nor fd 4"* ]]
+}


### PR DESCRIPTION
**This makes no claim about the CI hang.** It was written while chasing one, and the chase failed — see the last section. What is left is a rule this repository already had, applied everywhere instead of at one call site, and enforced by a test instead of a comment.

## The rule

`remote.sh`, where it starts the sync engine:

> fds 3 and 4 are closed explicitly: under bats, fd 3 is the TAP pipe, and a daemon inheriting it keeps the whole test file open until the CI timeout.

That reasoning was written down once and applied once. `codex-monitor.sh` starts two processes that outlive their caller without it:

- **`app-server`** — a daemon *designed* to persist: it writes a pidfile, a portfile and a version file, and its tests are named "reuses a live app-server" and "recreates a stale app-server".
- **the bridge launcher** — detached on purpose.

`watch.sh`'s interval sleep is bounded and its parent is already guarded, so it was never at risk; it is included to make the rule uniform, because the alternative is deciding per site which daemons are "long-lived enough to matter" — and that judgement is precisely what left the app-server unguarded a few files away from the comment explaining why it should not be.

## The two `bounded-copy` spawns

Reaped on both normal paths — waited on success, killed and waited on failure — so they are short by construction. But the `EXIT` trap only removes files; it does not kill the copier. A signal arriving before curl opens the fifo leaves it blocked in `open()` with no writer ever coming. Narrow, but it is the one path where a bounded spawn stops being bounded, so they are guarded and the reasoning sits at the call site.

## Enforcement

`tests/test_spawn_fd_guard.bats` asserts that no background spawn under `scripts/` is missing the guard, and names the offending line when one is. A second case asserts the pattern still matches at least five spawns, so a pattern that quietly stops matching cannot leave a test that passes by finding nothing. Removing any single guard fails it.

## Why the hang claim is gone

This PR was opened believing the unguarded `app-server` explained shards that report every test `ok` and then sit silent until the job's 25-minute cap.

Its own CI refuted that. `bats (macos-latest 4/4)` hung here, with these guards in place, on a shard whose thirteen files include **no test that reaches any spawn this PR touches** — `codex-monitor.sh` is not executed there at all. Every spawn reachable in that shard, in `scripts/` and in the tests, was already guarded.

So the fd-3 inheritance story does not explain these jobs, and the correlation it rested on (hanging shards tending to contain a codex-reaching test) now has counterexamples including this one. The hang is being investigated separately, with diagnostics rather than another guess.

249 green across the suites the diff reaches.
