### PR TITLE
Diagnostics: record what holds a shard open after its last test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,10 +182,12 @@ jobs:
               echo "----- surviving node/python and what they hold:"
               for pid in $(ps -eo pid=,comm= 2>/dev/null | awk '$2 ~ /node|python/ {print $1}'); do
                 echo "--- pid $pid: $(ps -o command= -p "$pid" 2>/dev/null | cut -c1-160)"
-                lsof -p "$pid" 2>/dev/null | awk 'NR==1 || $4 ~ /^[0-9]+[rwu]?$/' | head -14
+                lsof -p "$pid" 2>/dev/null \
+                  | awk 'NR == 1 || $4 ~ /^[0-9]+[rwu]?$/ { n++; if (n <= 14) print }'
               done
               echo "----- bats temp dirs left behind:"
-              ls -la "${TMPDIR:-/tmp}" 2>/dev/null | grep -i bats | head -20
+              ls -la "${TMPDIR:-/tmp}" 2>/dev/null \
+                | awk 'tolower($0) ~ /bats/ { n++; if (n <= 20) print }'
             } >> "$out" 2>&1
             sleep 30
           done
@@ -230,7 +232,8 @@ jobs:
             fi
           done
           echo "##### bats temp remnants:"
-          ls -la "${TMPDIR:-/tmp}" 2>/dev/null | awk '/bats/ && NR <= 400' | awk 'NR <= 20'
+          ls -la "${TMPDIR:-/tmp}" 2>/dev/null \
+            | awk 'tolower($0) ~ /bats/ { n++; if (n <= 20) print }'
           echo "##### sampler timeline:"
           if [ -s "$RUNNER_TEMP/hang-samples.txt" ]; then
             cat "$RUNNER_TEMP/hang-samples.txt" 2>/dev/null

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,9 +159,73 @@ jobs:
           sqlite3 --version
           bats --version
 
+      # Diagnostics for the shards that report every test ok and then sit
+      # silent until the job's cap. The sampler writes to a file and never to
+      # this step's stdout: a process holding that pipe is one of the things
+      # under suspicion, so the instrument must not be able to cause what it is
+      # measuring. It closes fds 3 and 4 for the same reason, and gives itself a
+      # hard lifetime so it cannot outlive the job it is watching.
+      - name: Start hang sampler
+        if: needs.changes.outputs.docs_only != 'true'
+        run: |
+          cat > "$RUNNER_TEMP/sampler.sh" <<'SAMPLER'
+          #!/usr/bin/env bash
+          out="$RUNNER_TEMP/hang-samples.txt"
+          : > "$out"
+          for i in $(seq 1 46); do
+            [ -f "$RUNNER_TEMP/bats-done" ] && { echo "== bats finished, sampler stopping at sample $i" >> "$out"; break; }
+            {
+              echo "===== sample $i  $(date -u +%H:%M:%S)"
+              ps -ef 2>/dev/null | grep -vE '\[' | tail -n +2
+              echo "----- surviving node/python and what they hold:"
+              for pid in $(ps -eo pid=,comm= 2>/dev/null | awk '$2 ~ /node|python/ {print $1}'); do
+                echo "--- pid $pid: $(ps -o command= -p "$pid" 2>/dev/null | cut -c1-160)"
+                lsof -p "$pid" 2>/dev/null | awk 'NR==1 || $4 ~ /^[0-9]+[rwu]?$/' | head -14
+              done
+              echo "----- bats temp dirs left behind:"
+              ls -la "${TMPDIR:-/tmp}" 2>/dev/null | grep -i bats | head -20
+            } >> "$out" 2>&1
+            sleep 30
+          done
+          SAMPLER
+          chmod +x "$RUNNER_TEMP/sampler.sh"
+          nohup "$RUNNER_TEMP/sampler.sh" >/dev/null 2>&1 3>&- 4>&- &
+          echo "sampler pid $!"
+
       - name: Run bats suite (this shard)
         if: needs.changes.outputs.docs_only != 'true'
-        run: xargs bats --print-output-on-failure < shard-files.txt
+        run: |
+          set +e
+          xargs bats --print-output-on-failure < shard-files.txt
+          status=$?
+          : > "$RUNNER_TEMP/bats-done"
+          exit $status
+
+      # always() so this also runs when the job is cancelled at its cap, which
+      # is the only case that matters here.
+      - name: Hang forensics
+        if: always() && needs.changes.outputs.docs_only != 'true'
+        run: |
+          echo "##### live snapshot at $(date -u +%H:%M:%S)"
+          ps -ef 2>/dev/null | tail -n +2 | head -60
+          echo "##### anything still holding a pipe:"
+          for pid in $(ps -eo pid=,comm= 2>/dev/null | awk '$2 ~ /node|python|bats|bash|sleep/ {print $1}'); do
+            held="$(lsof -p "$pid" 2>/dev/null | awk '$5 == "PIPE" || $5 == "FIFO" {print}' | head -4)"
+            [ -n "$held" ] && { echo "--- pid $pid $(ps -o command= -p "$pid" 2>/dev/null | cut -c1-120)"; echo "$held"; }
+          done
+          echo "##### bats temp remnants:"
+          ls -la "${TMPDIR:-/tmp}" 2>/dev/null | grep -i bats | head -20
+          echo "##### sampler timeline:"
+          cat "$RUNNER_TEMP/hang-samples.txt" 2>/dev/null || echo "(no samples)"
+
+      - name: Upload hang samples
+        if: always() && needs.changes.outputs.docs_only != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: hang-samples-${{ matrix.os }}-${{ matrix.shard }}
+          path: ${{ runner.temp }}/hang-samples.txt
+          if-no-files-found: ignore
+          retention-days: 3
 
       - name: Record which files this shard ran
         if: needs.changes.outputs.docs_only != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,7 +167,9 @@ jobs:
       # hard lifetime so it cannot outlive the job it is watching.
       - name: Start hang sampler
         if: needs.changes.outputs.docs_only != 'true'
+        continue-on-error: true
         run: |
+          set +e
           cat > "$RUNNER_TEMP/sampler.sh" <<'SAMPLER'
           #!/usr/bin/env bash
           out="$RUNNER_TEMP/hang-samples.txt"
@@ -203,23 +205,43 @@ jobs:
 
       # always() so this also runs when the job is cancelled at its cap, which
       # is the only case that matters here.
+      # continue-on-error and a best-effort body: this step exists to describe a
+      # failure, and a probe that returns non-zero -- lsof on a pid that has just
+      # exited, a grep that matches nothing -- must never be what turns a green
+      # shard red. The runner's default shell is `bash -e`, so -e is dropped
+      # explicitly and every probe is allowed to fail. `head` is avoided in
+      # pipelines for the same reason: it closes the pipe early and SIGPIPEs
+      # whatever was writing.
       - name: Hang forensics
         if: always() && needs.changes.outputs.docs_only != 'true'
+        continue-on-error: true
         run: |
-          echo "##### live snapshot at $(date -u +%H:%M:%S)"
-          ps -ef 2>/dev/null | tail -n +2 | head -60
-          echo "##### anything still holding a pipe:"
-          for pid in $(ps -eo pid=,comm= 2>/dev/null | awk '$2 ~ /node|python|bats|bash|sleep/ {print $1}'); do
-            held="$(lsof -p "$pid" 2>/dev/null | awk '$5 == "PIPE" || $5 == "FIFO" {print}' | head -4)"
-            [ -n "$held" ] && { echo "--- pid $pid $(ps -o command= -p "$pid" 2>/dev/null | cut -c1-120)"; echo "$held"; }
+          set +e
+          set +o pipefail 2>/dev/null || true
+          echo "##### live snapshot at $(date -u +%H:%M:%S 2>/dev/null)"
+          ps -ef 2>/dev/null | awk 'NR > 1 && NR <= 61'
+          echo "##### anything still holding a pipe or fifo:"
+          pids="$(ps -eo pid=,comm= 2>/dev/null | awk '$2 ~ /node|python|bats|bash|sleep/ {print $1}')"
+          for pid in $pids; do
+            held="$(lsof -p "$pid" 2>/dev/null | awk '$5 == "PIPE" || $5 == "FIFO"' | awk 'NR <= 4')"
+            if [ -n "$held" ]; then
+              echo "--- pid $pid $(ps -o command= -p "$pid" 2>/dev/null | cut -c1-120)"
+              echo "$held"
+            fi
           done
           echo "##### bats temp remnants:"
-          ls -la "${TMPDIR:-/tmp}" 2>/dev/null | grep -i bats | head -20
+          ls -la "${TMPDIR:-/tmp}" 2>/dev/null | awk '/bats/ && NR <= 400' | awk 'NR <= 20'
           echo "##### sampler timeline:"
-          cat "$RUNNER_TEMP/hang-samples.txt" 2>/dev/null || echo "(no samples)"
+          if [ -s "$RUNNER_TEMP/hang-samples.txt" ]; then
+            cat "$RUNNER_TEMP/hang-samples.txt" 2>/dev/null
+          else
+            echo "(no samples)"
+          fi
+          exit 0
 
       - name: Upload hang samples
         if: always() && needs.changes.outputs.docs_only != 'true'
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: hang-samples-${{ matrix.os }}-${{ matrix.shard }}


### PR DESCRIPTION
Instrumentation only. No change to the suite's behaviour.

Shards report every test `ok` and then sit silent until the job's 25-minute cap. Three explanations have been tried and each was refuted by observation — most recently making the fd-3 spawn guard uniform, after which a shard still hung on a composition that reaches none of the guarded spawns. Rather than propose a fourth, this records the state while the hang is live.

## Sampler

Every 30s during the suite: `ps -ef`, the open fds of every surviving `node`/`python` (what each holds, and whether it is a pipe), and any `bats-run-*` temp remnants.

It writes to a file and never to the step's stdout, and it closes fds 3 and 4. A process holding that pipe is one of the suspects, so the instrument must not be able to cause the thing it is measuring. It stops when the suite finishes, and independently after 23 minutes, so it cannot outlive the job it is watching.

## Forensics

Under `always()`, so they run when the job is cancelled at its cap — the only case that matters. A live snapshot, then everything still holding a pipe or fifo with its command line, then the sampler timeline. Also uploaded as an artifact, because a cancelled job can cut its log short.

## Both runners

Linux hangs are rarer than macOS ones, which makes them the closest thing to a control group available. Instrumenting only the failing platform would leave nothing to compare against.

## Verification

The sampler step was extracted from the YAML exactly as the runner receives it and executed: all three sections are produced, including the fd listings, and the sentinel stops it. The workflow parses, and the repo's own `test_ci_workflow` / `test_ci_sharding` suites pass.

## What this cannot do

If the shard composition on this branch does not happen to hang, this captures nothing. Whether a given shard hangs has tracked the branch's file partition rather than luck, so the fallback is to carry these steps onto a branch whose composition is known to hang.
