### PR TITLE
fix(sync): the E2EE recovery paths found by the live self-test

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -192,10 +192,10 @@ If argument starts with "remote pull":
 4. Show the output to the user.
 
 If argument starts with "remote unlock":
-1. Parse `<team>`, required `--snapshot <file>`, exactly one of
+1. Parse `<team>`, one or more `--snapshot <file>` arguments in ascending revision order, exactly one of
    `--identity <file>` or `--identity-stdin`, and optional
    `--confirm-digest <sha256>`.
-2. Run: `bash ~/.agents/skills/agmsg/scripts/remote.sh unlock <team> --snapshot <file> (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
+2. Run: `bash ~/.agents/skills/agmsg/scripts/remote.sh unlock <team> --snapshot <file> [--snapshot <file> ...] (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
 3. The snapshot digest must be compared over a separate live channel. Never
    infer or auto-confirm it. Raw identity material is a permanent secret; when
    `--identity-stdin` is needed, tell the user to run the command in their own

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -106,7 +106,7 @@ the handed files and the digest verified over that separate live channel:
 
 ```sh
 bash ~/.agents/skills/agmsg/scripts/remote.sh unlock <team> \
-  --snapshot <snapshot-file> \
+  --snapshot <snapshot-file> [--snapshot <next-snapshot-file> ...] \
   --identity <identity-file> \
   --confirm-digest <verified-sha256>
 ```

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -728,7 +728,7 @@ storage_sync_apply_pull() {
   _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || return 13
   _sqlite_sync_schema "$team" || return $?
   local generation db tl sql_file line type final_cursor="" corrupt=0 outcome_ids=""
-  local seq wire received v cipher key_id blob status policy local_rev reason
+  local seq wire received v cipher key_id blob status policy local_rev reason kind
   local from to body at local_id q
   generation=$(_sqlite_sync_generation "$team"); db="$(_sqlite_db "$team")"; tl="$(_sqlite_lit "$team")"
   _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || return 13
@@ -761,6 +761,7 @@ storage_sync_apply_pull() {
     policy=$(printf '%s\n' "$line" | jq -r '.policy_revision // empty')
     local_rev=$(printf '%s\n' "$line" | jq -r '.local_security_revision // empty')
     reason=$(printf '%s\n' "$line" | jq -r '.reason // empty')
+    kind=$(printf '%s\n' "$line" | jq -r '.projection.kind // empty')
     case "$seq:$v" in *[!0-9:]*) rm -f "$sql_file"; return 13 ;; esac
     case "$status" in importable|unsupported_cipher|pending_key|authentication_failed|malformed|policy_violation) ;; *) rm -f "$sql_file"; return 13 ;; esac
     q="'$(_sqlite_lit "$key_id")'"; [ -n "$key_id" ] || q=NULL
@@ -859,11 +860,31 @@ storage_sync_apply_pull() {
             AND m.protocol_version=$protocol AND m.wire_id='$wire' AND m.server_seq='$seq');" >> "$sql_file"
 
     if [ "$status" = importable ]; then
+      if [ -n "$kind" ]; then
+        case "$kind" in
+          member_joined|member_left|member_renamed|key_rotated) ;;
+          *)
+            echo "agmsg: storage sync apply cannot acknowledge projection kind '$kind'" >&2
+            rm -f "$sql_file"; trap - EXIT INT TERM HUP; return 13 ;;
+        esac
+        # The roster driver has already durably applied this mutation. Storage
+        # owns the quarantine and transport cursor, so it records the matching
+        # terminal outcome without projecting a roster event into messages.
+        printf "%s\n" "
+          UPDATE sync_quarantine SET status='imported'
+           WHERE server_instance_id='$server' AND remote_team_id='$remote'
+             AND protocol_version=$protocol AND wire_id='$wire'
+             AND server_seq='$seq' AND status='importable';" >> "$sql_file"
+        continue
+      fi
       from=$(printf '%s\n' "$line" | jq -r '.projection.from_agent // empty')
       to=$(printf '%s\n' "$line" | jq -r '.projection.to_agent // empty')
       body=$(printf '%s\n' "$line" | jq -r '.projection.body // empty')
       at=$(printf '%s\n' "$line" | jq -r '.projection.created_at // empty')
-      [ -n "$from" ] && [ -n "$to" ] && [ -n "$body" ] && [ -n "$at" ] || { rm -f "$sql_file"; return 13; }
+      [ -n "$from" ] && [ -n "$to" ] && [ -n "$body" ] && [ -n "$at" ] || {
+        echo "agmsg: storage sync apply received an importable message without its projection" >&2
+        rm -f "$sql_file"; trap - EXIT INT TERM HUP; return 13;
+      }
       local_id=$(compat_uuid7) || { rm -f "$sql_file"; return 13; }
       printf "%s\n" "
         INSERT INTO events(type,id,team,from_agent,to_agent,body,at)

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -154,8 +154,8 @@ If argument starts with "remote pull":
 4. Show the output to the user.
 
 If argument starts with "remote unlock":
-1. Parse `<team>`, required `--snapshot <file>`, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
-2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
+1. Parse `<team>`, one or more `--snapshot <file>` arguments in ascending revision order, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> [--snapshot <file> ...] (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
 3. The snapshot digest must be compared over a separate live channel. Never infer or auto-confirm it. Raw identity material is a permanent secret; when `--identity-stdin` is needed, tell the user to run the command in their own terminal rather than asking them to paste the identity into agent chat.
 4. Show the complete result, including the imported-envelope count and engine PID.
 

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -234,8 +234,8 @@ If argument starts with "remote pull":
 4. Show the output to the user.
 
 If argument starts with "remote unlock":
-1. Parse `<team>`, required `--snapshot <file>`, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
-2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
+1. Parse `<team>`, one or more `--snapshot <file>` arguments in ascending revision order, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> [--snapshot <file> ...] (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
 3. The snapshot digest must be compared over a separate live channel. Never infer or auto-confirm it. Raw identity material is a permanent secret; when `--identity-stdin` is needed, tell the user to run the command in their own terminal rather than asking them to paste the identity into agent chat.
 4. Show the complete result, including the imported-envelope count and engine PID.
 

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -182,8 +182,8 @@ If argument starts with "remote pull":
 4. Show the output to the user.
 
 If argument starts with "remote unlock":
-1. Parse `<team>`, required `--snapshot <file>`, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
-2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
+1. Parse `<team>`, one or more `--snapshot <file>` arguments in ascending revision order, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> [--snapshot <file> ...] (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
 3. The snapshot digest must be compared over a separate live channel. Never infer or auto-confirm it. Raw identity material is a permanent secret; when `--identity-stdin` is needed, tell the user to run the command in their own terminal rather than asking them to paste the identity into agent chat.
 4. Show the complete result, including the imported-envelope count and engine PID.
 

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -154,8 +154,8 @@ If argument starts with "remote pull":
 4. Show the output to the user.
 
 If argument starts with "remote unlock":
-1. Parse `<team>`, required `--snapshot <file>`, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
-2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
+1. Parse `<team>`, one or more `--snapshot <file>` arguments in ascending revision order, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> [--snapshot <file> ...] (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
 3. The snapshot digest must be compared over a separate live channel. Never infer or auto-confirm it. Raw identity material is a permanent secret; when `--identity-stdin` is needed, tell the user to run the command in their own terminal rather than asking them to paste the identity into agent chat.
 4. Show the complete result, including the imported-envelope count and engine PID.
 

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -157,8 +157,8 @@ If argument starts with "remote pull":
 4. Show the output to the user.
 
 If argument starts with "remote unlock":
-1. Parse `<team>`, required `--snapshot <file>`, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
-2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
+1. Parse `<team>`, one or more `--snapshot <file>` arguments in ascending revision order, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> [--snapshot <file> ...] (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
 3. The snapshot digest must be compared over a separate live channel. Never infer or auto-confirm it. Raw identity material is a permanent secret; when `--identity-stdin` is needed, tell the user to run the command in their own terminal rather than asking them to paste the identity into agent chat.
 4. Show the complete result, including the imported-envelope count and engine PID.
 

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -154,8 +154,8 @@ If argument starts with "remote pull":
 4. Show the output to the user.
 
 If argument starts with "remote unlock":
-1. Parse `<team>`, required `--snapshot <file>`, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
-2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
+1. Parse `<team>`, one or more `--snapshot <file>` arguments in ascending revision order, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> [--snapshot <file> ...] (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
 3. The snapshot digest must be compared over a separate live channel. Never infer or auto-confirm it. Raw identity material is a permanent secret; when `--identity-stdin` is needed, tell the user to run the command in their own terminal rather than asking them to paste the identity into agent chat.
 4. Show the complete result, including the imported-envelope count and engine PID.
 

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -185,8 +185,8 @@ If argument starts with "remote pull":
 4. Show the output to the user.
 
 If argument starts with "remote unlock":
-1. Parse `<team>`, required `--snapshot <file>`, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
-2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
+1. Parse `<team>`, one or more `--snapshot <file>` arguments in ascending revision order, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> [--snapshot <file> ...] (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
 3. The snapshot digest must be compared over a separate live channel. Never infer or auto-confirm it. Raw identity material is a permanent secret; when `--identity-stdin` is needed, tell the user to run the command in their own terminal rather than asking them to paste the identity into agent chat.
 4. Show the complete result, including the imported-envelope count and engine PID.
 

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -142,8 +142,8 @@ If argument starts with "remote pull":
 4. Show the output to the user.
 
 If argument starts with "remote unlock":
-1. Parse `<team>`, required `--snapshot <file>`, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
-2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
+1. Parse `<team>`, one or more `--snapshot <file>` arguments in ascending revision order, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> [--snapshot <file> ...] (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
 3. The snapshot digest must be compared over a separate live channel. Never infer or auto-confirm it. Raw identity material is a permanent secret; when `--identity-stdin` is needed, tell the user to run the command in their own terminal rather than asking them to paste the identity into agent chat.
 4. Show the complete result, including the imported-envelope count and engine PID.
 

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -157,8 +157,8 @@ If argument starts with "remote pull":
 4. Show the output to the user.
 
 If argument starts with "remote unlock":
-1. Parse `<team>`, required `--snapshot <file>`, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
-2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
+1. Parse `<team>`, one or more `--snapshot <file>` arguments in ascending revision order, exactly one of `--identity <file>` or `--identity-stdin`, and optional `--confirm-digest <sha256>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --snapshot <file> [--snapshot <file> ...] (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]`
 3. The snapshot digest must be compared over a separate live channel. Never infer or auto-confirm it. Raw identity material is a permanent secret; when `--identity-stdin` is needed, tell the user to run the command in their own terminal rather than asking them to paste the identity into agent chat.
 4. Show the complete result, including the imported-envelope count and engine PID.
 

--- a/scripts/internal/jsonl-sync.mjs
+++ b/scripts/internal/jsonl-sync.mjs
@@ -468,12 +468,15 @@ function validatePull(records) {
     sequence(message.server_seq, "pull server_seq");
     if (BigInt(message.server_seq) <= previous) fail("pull messages are not ordered");
     previous = BigInt(message.server_seq);
-    if (message.status === "importable" && (!message.projection ||
-        typeof message.projection.body !== "string" ||
-        typeof message.projection.from_agent !== "string" ||
-        typeof message.projection.to_agent !== "string" ||
-        typeof message.projection.created_at !== "string")) {
-      fail("importable pull message has no projection");
+    if (message.status === "importable") {
+      const rosterKind = ["member_joined", "member_left", "member_renamed", "key_rotated"]
+        .includes(message.projection?.kind);
+      const chatProjection = message.projection && message.projection.kind === undefined &&
+        typeof message.projection.body === "string" &&
+        typeof message.projection.from_agent === "string" &&
+        typeof message.projection.to_agent === "string" &&
+        typeof message.projection.created_at === "string";
+      if (!rosterKind && !chatProjection) fail("importable pull message has no supported projection");
     }
   }
   return { messages, cursor: cursor.next_after };
@@ -525,9 +528,11 @@ function apply(path, target, inputText) {
     } else if (reservation && status === "importable") {
       status = "reconciled";
     } else if (!reservation && status === "importable") {
-      localEvent = prior?.local_event ?? { type: "message_sent", id: uuid7(), team: target.local_team,
-        from: source.projection.from_agent, to: source.projection.to_agent,
-        body: source.projection.body, at: source.projection.created_at };
+      if (source.projection.kind === undefined) {
+        localEvent = prior?.local_event ?? { type: "message_sent", id: uuid7(), team: target.local_team,
+          from: source.projection.from_agent, to: source.projection.to_agent,
+          body: source.projection.body, at: source.projection.created_at };
+      }
       status = "imported";
     }
     const storedLocalEvent = prior?.local_event ? null : localEvent;

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1968,6 +1968,8 @@ export async function reprocessCycle(config, limit, dependencies = {}) {
   const evaluateCall = dependencies.evaluateCall ?? evaluatePull;
   const eventCall = dependencies.eventCall ?? event;
   const logApplyCall = dependencies.logApplyCall ?? logApplyOutcomes;
+  const rosterDriverCall = dependencies.rosterDriverCall ?? rosterDriver;
+  const activateKeyRotationsCall = dependencies.activateKeyRotationsCall ?? activateKeyRotations;
   const ready = await healthCall(config.server_url);
   if (ready.server_instance_id !== config.server_instance_id) throw new Error("health server instance changed");
   const capabilities = await requestCall(config, "/v1/capabilities");
@@ -2000,6 +2002,8 @@ export async function reprocessCycle(config, limit, dependencies = {}) {
     }
     stableState ??= state;
     const records = [];
+    const storageRecords = [];
+    const rotationRecords = [];
     for (const candidate of candidates) {
       const token = reprocessCandidateToken(candidate);
       if (seenTokens.has(token)) throw new Error("driver reprocess repeated a candidate");
@@ -2020,12 +2024,33 @@ export async function reprocessCycle(config, limit, dependencies = {}) {
       const message = { server_seq: candidate.server_seq, id: candidate.id,
         server_received_at: candidate.server_received_at, envelope: candidate.envelope };
       const evaluated = await evaluateCall(config, capabilities, message);
-      records.push({ type: "sync_pull_message", ...message, ...evaluated });
+      const record = { type: "sync_pull_message", ...message, ...evaluated };
+      storageRecords.push(record);
+      if (record.status === "importable" && record.projection?.kind === "key_rotated") {
+        await rosterDriverCall("apply", config, [record]);
+        await activateKeyRotationsCall(config);
+        rotationRecords.push(record);
+      } else {
+        records.push(record);
+      }
     }
-    if (records.length > 0) {
-      records.push({ type: "sync_pull_cursor", next_after: state.transport_cursor });
-      const applied = await driverCall("apply", config, records);
-      await logApplyCall(config, records, applied);
+    if (candidates.length > 0) {
+      const cursorRecord = { type: "sync_pull_cursor", next_after: state.transport_cursor };
+      const rosterRecords = records.filter((record) =>
+        record.status === "importable" &&
+        ["member_joined", "member_left", "member_renamed"].includes(record.projection?.kind));
+      const messageRecords = records.filter((record) => !record.projection?.kind);
+      if (rosterRecords.length + messageRecords.length + rotationRecords.length !==
+          storageRecords.length) {
+        throw new Error("reprocess cannot apply this projection kind");
+      }
+      if (rosterRecords.length > 0) {
+        await rosterDriverCall("apply", config, [...rosterRecords, cursorRecord]);
+      }
+      const applied = await driverCall("apply", config, [...storageRecords, cursorRecord]);
+      const messageIds = new Set(messageRecords.map((record) => record.id));
+      await logApplyCall(config, messageRecords, applied.filter((record) =>
+        record.type !== "sync_apply_outcome" || messageIds.has(record.id)));
       const candidateIds = new Set(candidates.map((candidate) => candidate.id));
       imported += applied.filter((record) =>
         record.type === "sync_apply_outcome" &&

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -539,14 +539,17 @@ export async function verifyAgeSnapshot(args) {
   if (!args["age-snapshot"]) throw new Error("age-snapshot is required");
   const snapshotPaths = Array.isArray(args["age-snapshot"]) ?
     args["age-snapshot"] : [args["age-snapshot"]];
-  if (snapshotPaths.length !== 1 || typeof snapshotPaths[0] !== "string") {
-    throw new Error("verify-age-snapshot requires exactly one age-snapshot");
+  if (snapshotPaths.length < 1 || snapshotPaths.some((path) => typeof path !== "string"))
+    throw new Error("verify-age-snapshot requires at least one age-snapshot");
+  const snapshots = [];
+  for (const path of snapshotPaths) {
+    const snapshotText = await readFile(resolve(path), "utf8");
+    const value = parseStrictJson(snapshotText);
+    if (snapshotText.trim() !== canonicalJson(value))
+      throw new Error("age snapshot must be RFC 8785 JCS without duplicate or noncanonical fields");
+    snapshots.push(value);
   }
-  const snapshotText = await readFile(resolve(snapshotPaths[0]), "utf8");
-  const snapshot = parseStrictJson(snapshotText);
-  if (snapshotText.trim() !== canonicalJson(snapshot)) {
-    throw new Error("age snapshot must be RFC 8785 JCS without duplicate or noncanonical fields");
-  }
+  const snapshot = snapshots.at(-1);
   const binding = await readConnectedBinding(team);
   const digest = ageSnapshotDigest(snapshot);
   const config = {
@@ -563,7 +566,7 @@ export async function verifyAgeSnapshot(args) {
       minimum_security_mode: "e2ee-required",
     }],
     age_v1: {
-      epoch_snapshots: [snapshot],
+      epoch_snapshots: snapshots,
       checkpoint: {
         epoch_revision: snapshot.epoch_revision,
         snapshot_sha256: digest,

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -154,7 +154,11 @@ export async function activateKeyRotations(config) {
         `key rotation epoch ${rotation.epoch} is not the next epoch ${expectedRevision}`);
     }
     const ageSnapshot = ageSnapshots[Number(expectedRevision)];
-    if (!ageSnapshot) {
+    if (!ageSnapshot && await provisionLocalAgeSnapshot(config, rotation)) {
+      ageSnapshots.push(ageSnapshotChain(config.age_v1).at(-1));
+    }
+    const confirmedAgeSnapshot = ageSnapshots[Number(expectedRevision)];
+    if (!confirmedAgeSnapshot) {
       throw new Error(
         `key rotation at server sequence ${rotation.server_seq} selected epoch ` +
         `${rotation.epoch}; import its authority-confirmed epoch snapshot before sync can continue`);
@@ -162,7 +166,7 @@ export async function activateKeyRotations(config) {
     if (BigInt(rotation.server_seq) === MAX_SEQUENCE) {
       throw new Error("key rotation cannot be activated at the final server sequence");
     }
-    const epoch = ageSnapshot.history.at(-1);
+    const epoch = confirmedAgeSnapshot.history.at(-1);
     const effectiveFrom = (BigInt(rotation.server_seq) + 1n).toString();
     if (epoch.epoch_revision !== rotation.epoch ||
         epoch.key_id !== rotation.key_id ||
@@ -332,8 +336,12 @@ export async function loadConfig(team) {
   validateLocalSecurityHistory(value.local_security_history);
   if (value.cipher_profile === "age-v1") {
     validateAgeConfiguration(value);
-    await validateRetainedAgeCheckpoint(value);
+    // A local authority advance retains its checkpoint before atomically
+    // replacing the sync config. Let that narrowly authenticated transition
+    // finish first so a crash between those writes is retryable; every other
+    // rollback still fails the retained-checkpoint comparison below.
     await activateKeyRotations(value);
+    await validateRetainedAgeCheckpoint(value);
   }
   else if (value.cipher_profile !== "none") throw new Error("sync cipher profile is unsupported");
   return value;
@@ -426,12 +434,92 @@ export function initialAgeSnapshot(teamConfig, team = teamConfig?.name) {
   };
 }
 
-async function exportAgeSnapshot(args) {
+export function nextLocalAgeSnapshot(config, teamConfig, rotation) {
+  const ageSnapshots = ageSnapshotChain(config.age_v1);
+  const previous = ageSnapshots.at(-1);
+  const localEpoch = teamConfig?.remote_key?.current;
+  const localEpochs = teamConfig?.remote_key?.epochs;
+  if (!previous || !localEpoch || !Array.isArray(localEpochs) ||
+      canonicalJson(localEpochs.at(-1)) !== canonicalJson(localEpoch) ||
+      String(localEpoch.epoch_revision) !== rotation.epoch ||
+      localEpoch.key_id !== rotation.key_id ||
+      localEpoch.recipient === undefined ||
+      createHash("sha256").update(localEpoch.recipient, "utf8").digest("hex") !==
+        rotation.fingerprint ||
+      localEpoch.previous_snapshot_sha256 !== ageSnapshotDigest(previous)) {
+    return null;
+  }
+  if (BigInt(rotation.server_seq) === MAX_SEQUENCE) {
+    throw new Error("key rotation cannot be activated at the final server sequence");
+  }
+  const revision = sequence(rotation.epoch, "local key epoch revision");
+  const writerGeneration = sequence(
+    String(localEpoch.writer_generation), "local key writer generation");
+  const snapshot = {
+    ...previous,
+    epoch_revision: revision,
+    writer_generation: writerGeneration,
+    authorized_writers: [localEpoch.key_id],
+    previous_snapshot_sha256: ageSnapshotDigest(previous),
+    history: [...previous.history, {
+      epoch_revision: revision,
+      effective_from_seq: (BigInt(rotation.server_seq) + 1n).toString(),
+      cipher: "age-v1",
+      key_id: localEpoch.key_id,
+      recipients: [localEpoch.recipient],
+    }],
+  };
+  return snapshot;
+}
+
+async function provisionLocalAgeSnapshot(config, rotation) {
+  let bytes;
+  try {
+    bytes = await readBoundedAuthorityFile(
+      teamConfigPath(config.local_team), MAX_CONNECTION_CONFIG_BYTES, false);
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+  const teamConfig = parseStrictJson(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  const snapshot = nextLocalAgeSnapshot(config, teamConfig, rotation);
+  if (!snapshot) return false;
+  const identityPath = replacementIdentityPath(config.local_team, rotation.key_id);
+  const proposed = structuredClone(config);
+  delete proposed.age_v1_runtime_history;
+  proposed.age_v1.epoch_snapshots = [...ageSnapshotChain(config.age_v1), snapshot];
+  delete proposed.age_v1.epoch_snapshot;
+  proposed.age_v1.checkpoint = {
+    epoch_revision: snapshot.epoch_revision,
+    snapshot_sha256: ageSnapshotDigest(snapshot),
+    writer_generation: snapshot.writer_generation,
+    confirmed_at: new Date().toISOString(),
+  };
+  proposed.age_v1.identity_files[rotation.key_id] = identityPath;
+  validateAgeConfiguration(proposed);
+  validateConfiguredAgeIdentities(proposed);
+  const retained = await retainAgeCheckpoint(proposed, "operator-live");
+  proposed.age_v1.checkpoint.confirmed_at = retained.confirmation.confirmed_at;
+  await writeConfig(configPath(config.local_team), proposed);
+  Object.assign(config, proposed);
+  return true;
+}
+
+export async function exportAgeSnapshot(args) {
   const team = requireName(args.team, "team");
   const bytes = await readBoundedAuthorityFile(
     teamConfigPath(team), MAX_CONNECTION_CONFIG_BYTES, false);
   const teamConfig = parseStrictJson(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
-  const snapshot = initialAgeSnapshot(teamConfig, team);
+  let snapshot;
+  try {
+    const config = await readStoredSyncConfig(team);
+    if (config.cipher_profile !== "age-v1") throw new Error("team is not configured for age-v1");
+    validateAgeConfiguration(config);
+    snapshot = ageSnapshotChain(config.age_v1).at(-1);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+    snapshot = initialAgeSnapshot(teamConfig, team);
+  }
   const canonical = canonicalJson(snapshot);
   const outputPath = args.out ? resolve(args.out) : null;
   if (outputPath) {

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1008,7 +1008,9 @@ function runDriver({ args, label, operation, parse, input }) {
     child.on("exit", (code, signal) => {
       if (failure) { fail(failure); return; }
       if (code === 0 && !signal) return;
-      fail(new Error(`${label} ${operation} failed (${signal ?? code}): ${stderr.trim()}`));
+      const diagnostic = stderr.trim() ||
+        "driver returned a non-zero exit without diagnostics; inspect its team storage and binding";
+      fail(new Error(`${label} ${operation} failed (${signal ?? code}): ${diagnostic}`));
     });
     child.on("close", () => {
       if (failure) { settle(failure, null); return; }

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2092,6 +2092,13 @@ export async function reprocessCycle(config, limit, dependencies = {}) {
     const records = [];
     const storageRecords = [];
     const rotationRecords = [];
+    let pendingRosterRecords = [];
+    const flushRosterRecords = async (cursorRecord) => {
+      if (pendingRosterRecords.length === 0) return;
+      await rosterDriverCall("apply", config,
+        cursorRecord ? [...pendingRosterRecords, cursorRecord] : pendingRosterRecords);
+      pendingRosterRecords = [];
+    };
     for (const candidate of candidates) {
       const token = reprocessCandidateToken(candidate);
       if (seenTokens.has(token)) throw new Error("driver reprocess repeated a candidate");
@@ -2115,11 +2122,20 @@ export async function reprocessCycle(config, limit, dependencies = {}) {
       const record = { type: "sync_pull_message", ...message, ...evaluated };
       storageRecords.push(record);
       if (record.status === "importable" && record.projection?.kind === "key_rotated") {
+        // A rotation changes how every later sequence is interpreted. Flush
+        // earlier roster mutations before publishing and activating it; a
+        // page may interleave both kinds, and the journal is append-only.
+        await flushRosterRecords(null);
         await rosterDriverCall("apply", config, [record]);
         await activateKeyRotationsCall(config);
         rotationRecords.push(record);
       } else {
         records.push(record);
+        if (record.status === "importable" &&
+            ["member_joined", "member_left", "member_renamed"].includes(
+              record.projection?.kind)) {
+          pendingRosterRecords.push(record);
+        }
       }
     }
     if (candidates.length > 0) {
@@ -2132,9 +2148,7 @@ export async function reprocessCycle(config, limit, dependencies = {}) {
           storageRecords.length) {
         throw new Error("reprocess cannot apply this projection kind");
       }
-      if (rosterRecords.length > 0) {
-        await rosterDriverCall("apply", config, [...rosterRecords, cursorRecord]);
-      }
+      await flushRosterRecords(cursorRecord);
       const applied = await driverCall("apply", config, [...storageRecords, cursorRecord]);
       const messageIds = new Set(messageRecords.map((record) => record.id));
       await logApplyCall(config, messageRecords, applied.filter((record) =>

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1636,8 +1636,7 @@ async function identityFiles(values) {
 
 async function existingConfig(team) {
   try {
-    await readStoredSyncConfig(team);
-    return await loadConfig(team);
+    return await readStoredSyncConfig(team);
   }
   catch (error) {
     if (error?.code === "ENOENT") return null;
@@ -1706,9 +1705,38 @@ export async function configure(args) {
     throw new Error("age options require --cipher age-v1");
   }
   const previous = await existingConfig(team);
-  if (previous && (previous.server_instance_id !== config.server_instance_id ||
-      previous.remote_team_id !== config.remote_team_id || previous.cipher_profile !== config.cipher_profile)) {
-    throw new Error("configure cannot replace an existing binding or cipher profile");
+  if (previous) {
+    previous.cipher_profile ??= "none";
+    if (previous.local_team !== team || previous.protocol_version !== 1 ||
+        !UUID_V7.test(previous.server_instance_id ?? "") ||
+        !UUID_V7.test(previous.remote_team_id ?? "")) {
+      throw new Error("existing sync config binding is invalid");
+    }
+    validateLocalSecurityHistory(previous.local_security_history);
+    if (previous.server_instance_id !== config.server_instance_id ||
+        previous.remote_team_id !== config.remote_team_id ||
+        previous.server_url !== config.server_url ||
+        previous.cipher_profile !== config.cipher_profile) {
+      throw new Error("configure cannot replace an existing binding or cipher profile");
+    }
+    if (cipherProfile === "age-v1") {
+      validateAgeConfiguration(previous);
+      await validateRetainedAgeCheckpoint(previous);
+      const previousSnapshots = ageSnapshotChain(previous.age_v1);
+      const proposedSnapshots = ageSnapshotChain(config.age_v1);
+      const prefixMatches = previousSnapshots.every((snapshot, index) =>
+        proposedSnapshots[index] !== undefined &&
+        ageSnapshotDigest(proposedSnapshots[index]) === ageSnapshotDigest(snapshot));
+      if (!prefixMatches || proposedSnapshots.length < previousSnapshots.length) {
+        throw new Error("configure cannot replace or truncate a confirmed age snapshot chain");
+      }
+      config.age_v1.identity_files = {
+        ...previous.age_v1.identity_files,
+        ...config.age_v1.identity_files,
+      };
+      validateAgeConfiguration(config);
+      validateConfiguredAgeIdentities(config);
+    }
   }
   const capabilities = await request(config, "/v1/capabilities");
   validateCapabilities(config, capabilities);

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -437,11 +437,10 @@ export function initialAgeSnapshot(teamConfig, team = teamConfig?.name) {
 export function nextLocalAgeSnapshot(config, teamConfig, rotation) {
   const ageSnapshots = ageSnapshotChain(config.age_v1);
   const previous = ageSnapshots.at(-1);
-  const localEpoch = teamConfig?.remote_key?.current;
   const localEpochs = teamConfig?.remote_key?.epochs;
-  if (!previous || !localEpoch || !Array.isArray(localEpochs) ||
-      canonicalJson(localEpochs.at(-1)) !== canonicalJson(localEpoch) ||
-      String(localEpoch.epoch_revision) !== rotation.epoch ||
+  const localEpoch = Array.isArray(localEpochs) ? localEpochs.find((epoch) =>
+    String(epoch?.epoch_revision) === rotation.epoch && epoch?.key_id === rotation.key_id) : null;
+  if (!previous || !localEpoch ||
       localEpoch.key_id !== rotation.key_id ||
       localEpoch.recipient === undefined ||
       createHash("sha256").update(localEpoch.recipient, "utf8").digest("hex") !==
@@ -515,6 +514,7 @@ export async function exportAgeSnapshot(args) {
     const config = await readStoredSyncConfig(team);
     if (config.cipher_profile !== "age-v1") throw new Error("team is not configured for age-v1");
     validateAgeConfiguration(config);
+    await validateRetainedAgeCheckpoint(config);
     snapshot = ageSnapshotChain(config.age_v1).at(-1);
   } catch (error) {
     if (error?.code !== "ENOENT") throw error;

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -574,7 +574,8 @@ EOF
     exit 1
   }
 
-  local key_id created_at identity_file recipient fingerprint keygen_err
+  local key_id created_at identity_file recipient fingerprint keygen_err previous_snapshot \
+    previous_snapshot_sha writer_generation original_cfg
   key_id="$(_key_new_key_id)"
   created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   identity_file="$cred_dir/$key_id.key"
@@ -589,7 +590,28 @@ EOF
   chmod 600 "$identity_file"
   recipient="$(grep '^# public key:' "$identity_file" | sed 's/^# public key: //')"
   fingerprint="$(_key_fingerprint_sha256 "$recipient")"
+  previous_snapshot="$(mktemp "${TMPDIR:-/tmp}/agmsg-age-snapshot.XXXXXX")"
+  if ! bash "$SCRIPT_DIR/remote-sync.sh" export-age-snapshot \
+      --team "$team" --out "$previous_snapshot" >/dev/null; then
+    rm -f "$previous_snapshot" "$identity_file"
+    agmsg_lock_release
+    echo "agmsg: could not read the current authority-confirmed epoch snapshot." >&2
+    exit 1
+  fi
+  previous_snapshot_sha="$(shasum -a 256 "$previous_snapshot" | awk '{print $1}')"
+  rm -f "$previous_snapshot"
+  writer_generation="$(agmsg_sqlite_mem \
+    "SELECT CAST('$(_agmsg_sqlesc "$(_key_read_config_field "$cfg" '$.remote_key.current.writer_generation')")' AS INTEGER) + 1;")"
+  original_cfg="$(cat "$cfg")"
+  if ! _key_write_epoch_locked "$cfg" \
+      "$(_key_epoch_json "$key_id" "$next_epoch" "$writer_generation" "$recipient" "$previous_snapshot_sha" "$created_at")"; then
+    rm -f "$identity_file"
+    agmsg_lock_release
+    echo "agmsg: failed to stage the replacement epoch." >&2
+    exit 1
+  fi
   if ! agmsg_roster_append_key_rotated "$team_dir" "$next_epoch" "$key_id" "$fingerprint" "$created_at"; then
+    agmsg_write_atomic "$cfg" "$original_cfg"
     rm -f "$identity_file"
     agmsg_lock_release
     echo "agmsg: failed to publish the key rotation; no replacement was announced." >&2

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -380,12 +380,8 @@ cmd_import() {
   cur_recipient="$(_key_read_config_field "$cfg" '$.remote_key.current.recipient')"
 
   if [ -n "$cur_key_id" ] && [ "$cur_key_id" != "null" ]; then
-    if [ -n "$requested_key_id" ] && [ "$requested_key_id" != "$cur_key_id" ]; then
-      agmsg_lock_release
-      echo "agmsg: imported authority key id does not match the team's current key." >&2
-      exit 1
-    fi
-    if [ "$cur_recipient" != "$recipient" ]; then
+    if { [ -n "$requested_key_id" ] && [ "$requested_key_id" != "$cur_key_id" ]; } ||
+       [ "$cur_recipient" != "$recipient" ]; then
       local journal journal_sql fingerprint staged_key_id
       journal="$(agmsg_roster_journal_path "$TEAMS_DIR/$team")"
       fingerprint="$(_key_fingerprint_sha256 "$recipient")"
@@ -407,6 +403,11 @@ cmd_import() {
       if [ -z "$staged_key_id" ]; then
         agmsg_lock_release
         echo "agmsg: imported identity does not match the current key or an announced rotation — refusing to import." >&2
+        exit 1
+      fi
+      if [ -n "$requested_key_id" ] && [ "$requested_key_id" != "$staged_key_id" ]; then
+        agmsg_lock_release
+        echo "agmsg: imported authority key id does not match the announced rotation." >&2
         exit 1
       fi
       printf '%s\n' "$staged_key_id" | grep -Eq '^[a-z0-9][a-z0-9._-]{0,63}$' || {

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -964,11 +964,11 @@ cmd_pull() {
 }
 
 cmd_unlock() {
-  local team="" snapshot="" identity_file="" identity_stdin=0 confirm_digest=""
+  local team="" identity_file="" identity_stdin=0 confirm_digest="" snapshots=()
   while [ $# -gt 0 ]; do
     case "$1" in
-      --snapshot) snapshot="${2:?--snapshot requires a value}"; shift 2 ;;
-      --snapshot=*) snapshot="${1#--snapshot=}"; shift ;;
+      --snapshot) snapshots+=("${2:?--snapshot requires a value}"); shift 2 ;;
+      --snapshot=*) snapshots+=("${1#--snapshot=}"); shift ;;
       --identity) identity_file="${2:?--identity requires a value}"; shift 2 ;;
       --identity=*) identity_file="${1#--identity=}"; shift ;;
       --identity-stdin) identity_stdin=1; shift ;;
@@ -980,7 +980,7 @@ cmd_unlock() {
     esac
   done
   : "${team:?Usage: remote.sh unlock <team> --snapshot <file> (--identity <file>|--identity-stdin) [--confirm-digest <sha256>]}"
-  : "${snapshot:?--snapshot is required}"
+  [ "${#snapshots[@]}" -gt 0 ] || { echo "agmsg: --snapshot is required" >&2; exit 1; }
   agmsg_validate_team_name "$team" || exit 1
   if { [ -n "$identity_file" ] && [ "$identity_stdin" -eq 1 ]; } ||
       { [ -z "$identity_file" ] && [ "$identity_stdin" -eq 0 ]; }; then
@@ -996,8 +996,10 @@ cmd_unlock() {
     echo "agmsg: team '$team' is not an encrypted pulled team awaiting unlock" >&2
     exit 1
   }
+  local snapshot_args=() snapshot
+  for snapshot in "${snapshots[@]}"; do snapshot_args+=(--age-snapshot "$snapshot"); done
   metadata="$(bash "$SCRIPT_DIR/remote-sync.sh" verify-age-snapshot \
-    --team "$team" --age-snapshot "$snapshot")" || exit 1
+    --team "$team" "${snapshot_args[@]}")" || exit 1
   metadata="$(printf '%s\n' "$metadata" | grep '"age_snapshot_verified"' | tail -1)"
   [ -n "$metadata" ] || { echo "agmsg: snapshot verification produced no result" >&2; exit 1; }
   digest="$(_remote_json_field "$metadata" '$.snapshot_sha256')"
@@ -1057,7 +1059,7 @@ cmd_unlock() {
     --team-id "$remote_team_id" \
     --minimum-security e2ee-required \
     --cipher age-v1 \
-    --age-snapshot "$snapshot" \
+    "${snapshot_args[@]}" \
     --age-checkpoint "$epoch_revision:$digest" \
     --age-confirmation operator-live \
     --age-identity "$key_id=$identity_dest")" || exit 1

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -153,14 +153,31 @@ test("a rotator provisions its confirmed snapshot at the server boundary", async
     const exported = JSON.parse(await readFile(exportedPath, "utf8"));
     assert.equal(exported.epoch_revision, "1");
     assert.equal(exported.history.length, 2);
+    const confirmedStored = structuredClone(stored);
+    const rolledBack = structuredClone(confirmedStored);
+    rolledBack.age_v1.epoch_snapshots = [initial];
+    rolledBack.age_v1.checkpoint = { ...rolledBack.age_v1.checkpoint,
+      epoch_revision: "0", writer_generation: "0", snapshot_sha256: ageSnapshotDigest(initial) };
+    await writeFile(join(root, "store", "remote-sync", "demo.json"), JSON.stringify(rolledBack));
+    await assert.rejects(exportAgeSnapshot({ team: "demo", out: join(root, "rollback.json") }),
+      /rollback/u);
+    const conflictingStored = structuredClone(confirmedStored);
+    const conflicting = { ...snapshot, authorized_writers: ["conflicting-writer"] };
+    conflictingStored.age_v1.epoch_snapshots[1] = conflicting;
+    conflictingStored.age_v1.checkpoint.snapshot_sha256 = ageSnapshotDigest(conflicting);
+    await writeFile(join(root, "store", "remote-sync", "demo.json"),
+      JSON.stringify(conflictingStored));
+    await assert.rejects(exportAgeSnapshot({ team: "demo", out: join(root, "conflict.json") }),
+      /same-revision conflict/u);
+    const advancedStored = structuredClone(confirmedStored);
     const unconfirmed = { ...snapshot, epoch_revision: "2", writer_generation: "2",
       previous_snapshot_sha256: ageSnapshotDigest(snapshot),
       history: [...snapshot.history, { ...snapshot.history.at(-1), epoch_revision: "2",
         effective_from_seq: "10", key_id: "epoch-unconfirmed" }] };
-    stored.age_v1.epoch_snapshots.push(unconfirmed);
-    stored.age_v1.checkpoint = { ...stored.age_v1.checkpoint, epoch_revision: "2",
+    advancedStored.age_v1.epoch_snapshots.push(unconfirmed);
+    advancedStored.age_v1.checkpoint = { ...advancedStored.age_v1.checkpoint, epoch_revision: "2",
       writer_generation: "2", snapshot_sha256: ageSnapshotDigest(unconfirmed) };
-    await writeFile(join(root, "store", "remote-sync", "demo.json"), JSON.stringify(stored));
+    await writeFile(join(root, "store", "remote-sync", "demo.json"), JSON.stringify(advancedStored));
     await assert.rejects(exportAgeSnapshot({ team: "demo", out: join(root, "unsafe.json") }),
       /retained age checkpoint/u);
     assert.match(await readFile(join(root, "trust",

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -498,6 +498,80 @@ test("reprocess completion counts imported outcomes and requires empty blocking 
   assert.equal(result.blocking_remaining, false);
 });
 
+test("reprocess routes recovered roster mutations away from message storage", async () => {
+  const capabilities = {
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, team_name: "demo", min_available_seq: "0",
+    current_seq: "2", next_sequence_boundary: "3", accepted_envelope_versions: [1],
+    write_allowed_ciphers: ["age-v1"], policy_revision: "0", effective_from_seq: "1",
+    max_blob_bytes: "1048576", policy_history: [{ policy_revision: "0",
+      effective_from_seq: "1", accepted_envelope_versions: [1],
+      write_allowed_ciphers: ["age-v1"] }],
+  };
+  const rosterId = "80dc98aa-a3a1-4a75-becb-9397347875b0";
+  const messageId = "900f3ee4-eca6-44a1-a288-4e9c72b941ac";
+  let rosterApplied = false;
+  let messageApplied = false;
+  const result = await reprocessCycle(config, 100, {
+    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    requestCall: async () => capabilities,
+    driverCall: async (operation, _config, input) => {
+      if (operation === "apply") {
+        assert.deepEqual(input.map((record) => record.id).filter(Boolean), [rosterId, messageId]);
+        assert.deepEqual(input.at(-1), { type: "sync_pull_cursor", next_after: "2" });
+        messageApplied = true;
+        return [
+          { type: "sync_apply_result", transport_cursor: "2", corrupt_count: 0 },
+          { type: "sync_apply_outcome", id: rosterId, server_seq: "1", status: "imported" },
+          { type: "sync_apply_outcome", id: messageId, server_seq: "2", status: "imported" },
+        ];
+      }
+      assert.equal(operation, "reprocess");
+      return [
+        { type: "sync_state", driver_generation: "generation-1", transport_cursor: "2" },
+        ...(!rosterApplied || !messageApplied ? [{
+          type: "sync_reprocess_candidate", server_seq: "1", id: rosterId,
+          server_received_at: "2026-07-30T20:33:33.000000Z",
+          envelope: { v: 1, cipher: "age-v1", key_id: "epoch-initial", blob: "roster" },
+          prior_status: "unsupported_cipher",
+        }, {
+          type: "sync_reprocess_candidate", server_seq: "2", id: messageId,
+          server_received_at: "2026-07-30T20:33:43.000000Z",
+          envelope: { v: 1, cipher: "age-v1", key_id: "epoch-initial", blob: "message" },
+          prior_status: "unsupported_cipher",
+        }] : []),
+        { type: "sync_reprocess_page", next_after: null, has_more: false },
+      ];
+    },
+    rosterDriverCall: async (operation, _config, input) => {
+      assert.equal(operation, "apply");
+      assert.deepEqual(input.map((record) => record.id).filter(Boolean), [rosterId]);
+      assert.deepEqual(input.at(-1), { type: "sync_pull_cursor", next_after: "2" });
+      rosterApplied = true;
+      return [{ type: "roster_sync_apply_outcome", id: rosterId,
+        server_seq: "1", status: "imported" }];
+    },
+    evaluateCall: async (_config, _capabilities, message) => message.id === rosterId ? ({
+      status: "importable", projection: {
+        kind: "member_joined",
+        mutation_id: "019fb4bb-7948-7520-8c16-ab64753e2012",
+        member_id: "019fb4bb-7948-7ce9-8e4f-61229dc726cf",
+        name: "dana", occurred_at: "2026-07-30T20:33:33.000000Z",
+      }, policy_revision: "0", local_security_revision: "0",
+    }) : ({
+      status: "importable", projection: {
+        body: "first sealed message", created_at: "2026-07-30T20:33:43.000000Z",
+        from_agent: "dana", to_agent: "dana",
+      }, policy_revision: "0", local_security_revision: "0",
+    }),
+    eventCall: async () => {},
+    logApplyCall: async () => {},
+  });
+  assert.equal(result.count, 2);
+  assert.equal(result.imported_count, 2);
+  assert.equal(result.blocking_remaining, false);
+});
+
 test("explicit reprocess rejects an unbounded walk through duplicate server sequences", async () => {
   const capabilities = {
     protocol_version: 1, server_instance_id: config.server_instance_id,

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -507,10 +507,19 @@ test("unlock snapshot verification is canonical and bound to the pulled team", a
       team: "demo",
       "age-snapshot": [path],
     }), /RFC 8785 JCS/u);
-    await assert.rejects(verifyAgeSnapshot({
-      team: "demo",
-      "age-snapshot": [path, path],
-    }), /exactly one age-snapshot/u);
+    await writeFile(path, canonicalJson(snapshot), { mode: 0o600 });
+    const next = { ...snapshot, epoch_revision: "1", writer_generation: "1",
+      previous_snapshot_sha256: ageSnapshotDigest(snapshot),
+      history: [...snapshot.history, { ...snapshot.history[0], epoch_revision: "1",
+        effective_from_seq: "3", key_id: "epoch-next" }] };
+    const nextPath = join(root, "snapshot-next.json");
+    await writeFile(nextPath, canonicalJson(next), { mode: 0o600 });
+    const rotated = await verifyAgeSnapshot({ team: "demo",
+      "age-snapshot": [path, nextPath] });
+    assert.equal(rotated.epoch_revision, "1");
+    assert.equal(rotated.snapshot_sha256, ageSnapshotDigest(next));
+    await assert.rejects(verifyAgeSnapshot({ team: "demo",
+      "age-snapshot": [nextPath, path] }), /missing revision/u);
   });
 });
 

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1773,7 +1773,6 @@ test("age configure extends a stored chain and activates its announced epoch", a
   const previousFetch = globalThis.fetch;
   await withConnectedCredential(async (root) => {
     await writeConnectedTeam(root, { capabilities: { write_allowed_ciphers: ["age-v1"] } });
-    const recipient0 = "age1mmqjrejftea4f6xh47lhpc0jn4vw0yuhz349sw2e3sfl22k5gcjsv6xcvp";
     const identityDir = join(root, "run", "remote-credentials", "demo", "keys");
     const identity1 = join(identityDir, "epoch-1.key");
     await mkdir(identityDir, { recursive: true });
@@ -1781,6 +1780,7 @@ test("age configure extends a stored chain and activates its announced epoch", a
       "AGE-SECRET-KEY-14Z7XMNPZTPEMMM6DG2FSKEH042L7UMU79T645GAQJKU2LLJGPM2S7GWNLQ\n",
       { mode: 0o600 });
     const recipient1 = readNativeAgeIdentity(identity1).recipient;
+    const recipient0 = recipient1;
     const ageSnapshot0 = {
       authorized_writers: ["writer-a"],
       epoch_revision: "0",
@@ -1829,7 +1829,7 @@ test("age configure extends a stored chain and activates its announced epoch", a
         "team-id": config.remote_team_id, "minimum-security": "e2ee-required",
         cipher: "age-v1", "age-snapshot": [ageSnapshot0Path],
         "age-checkpoint": `0:${ageSnapshotDigest(ageSnapshot0)}`,
-        "age-confirmation": "operator-live" });
+        "age-confirmation": "operator-live", "age-identity": [`epoch-0=${identity1}`] });
       const mutationId = "018f3f7e-0000-7000-8000-000000000025";
       await writeFile(join(root, "teams", "demo", "roster.jsonl"), [
         JSON.stringify({ type: "key_rotated", id: mutationId, epoch: "1",
@@ -1848,6 +1848,8 @@ test("age configure extends a stored chain and activates its announced epoch", a
       const stored = JSON.parse(await readFile(
         join(process.env.AGMSG_SYNC_STORAGE_DIR, "remote-sync", "demo.json"), "utf8"));
       assert.equal(stored.age_v1.epoch_snapshots.length, 2);
+      assert.equal(stored.age_v1.identity_files["epoch-0"], identity1);
+      assert.equal(stored.age_v1.identity_files["epoch-1"], identity1);
       const loaded = await loadConfig("demo");
       assert.equal(loaded.age_v1_runtime_history.length, 1);
       assert.equal(loaded.age_v1_runtime_history[0].key_id, "epoch-1");

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -13,10 +13,12 @@ import {
   configure,
   cycle,
   driver,
+  exportAgeSnapshot,
   isRetryable,
   initialAgeSnapshot,
   runLoop,
   loadConfig,
+  nextLocalAgeSnapshot,
   plaintextWriteEligible,
   pullBootstrap,
   parseStrictJsonl,
@@ -59,6 +61,105 @@ const candidates = [
 ];
 
 const credentialId = "018f3f7e-0000-7000-8000-000000000020";
+
+test("a rotator provisions its confirmed snapshot at the server boundary", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agmsg-local-key-rotation-"));
+  const saved = {
+    connection: process.env.AGMSG_SYNC_CONNECTION_DIR,
+    storage: process.env.AGMSG_SYNC_STORAGE_DIR,
+    trust: process.env.AGMSG_SYNC_TRUST_DIR,
+  };
+  const oldKeyId = "epoch-old";
+  const newKeyId = "epoch-new";
+  const recipient = "age1ykvctct4aklx4f4mnjd8rmzqs7p2le9ufg4faydljsk5mvcy0pls27mu64";
+  const identity = "AGE-SECRET-KEY-14Z7XMNPZTPEMMM6DG2FSKEH042L7UMU79T645GAQJKU2LLJGPM2S7GWNLQ";
+  const initial = {
+    profile: "age-v1",
+    server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id,
+    epoch_revision: "0",
+    writer_generation: "0",
+    authorized_writers: [oldKeyId],
+    previous_snapshot_sha256: null,
+    history: [{ epoch_revision: "0", effective_from_seq: "1", cipher: "age-v1",
+      key_id: oldKeyId, recipients: [recipient] }],
+  };
+  const rotation = {
+    id: "018f3f7e-0000-7000-8000-000000000025",
+    epoch: "1",
+    key_id: newKeyId,
+    fingerprint: createHash("sha256").update(recipient).digest("hex"),
+    server_seq: "8",
+  };
+  const localEpoch = { key_id: newKeyId, epoch_revision: 1, writer_generation: 1,
+    recipient, previous_snapshot_sha256: ageSnapshotDigest(initial),
+    created_at: "2026-07-30T00:00:00Z" };
+  const teamConfig = { name: "demo", remote_key: { current: localEpoch,
+    epochs: [{ key_id: oldKeyId, epoch_revision: 0, writer_generation: 0,
+      recipient, previous_snapshot_sha256: null, created_at: "2026-07-29T00:00:00Z" },
+    localEpoch] } };
+  const rotationConfig = {
+    ...config,
+    server_url: "https://sync.example.test",
+    cipher_profile: "age-v1",
+    local_security_history: [{ local_security_revision: "0", effective_from_seq: "1",
+      minimum_security_mode: "e2ee-required" }],
+    age_v1: {
+      epoch_snapshots: [initial],
+      checkpoint: { epoch_revision: "0", writer_generation: "0",
+        snapshot_sha256: ageSnapshotDigest(initial), confirmed_at: "2026-07-29T00:00:00Z" },
+      identity_files: {},
+      age_version: "v1.3.1",
+    },
+  };
+  try {
+    process.env.AGMSG_SYNC_CONNECTION_DIR = root;
+    process.env.AGMSG_SYNC_STORAGE_DIR = join(root, "store");
+    process.env.AGMSG_SYNC_TRUST_DIR = join(root, "trust");
+    const teamDir = join(root, "teams", "demo");
+    const keyDir = join(root, "run", "remote-credentials", "demo", "keys");
+    await mkdir(teamDir, { recursive: true });
+    await mkdir(keyDir, { recursive: true });
+    await writeFile(join(teamDir, "config.json"), `${JSON.stringify(teamConfig)}\n`);
+    await writeFile(join(teamDir, "roster.jsonl"), [
+      JSON.stringify({ type: "key_rotated", ...rotation,
+        at: "2026-07-30T00:00:00.000000Z", server_seq: undefined }),
+      JSON.stringify({ type: "roster_synced", mutation_id: rotation.id,
+        server_seq: rotation.server_seq,
+        wire_id: "550e8400-e29b-41d4-a716-446655440006",
+        server_instance_id: config.server_instance_id,
+        remote_team_id: config.remote_team_id }), "",
+    ].join("\n"));
+    await writeFile(join(keyDir, `${newKeyId}.key`), `${identity}\n`, { mode: 0o600 });
+    const snapshot = nextLocalAgeSnapshot(rotationConfig, teamConfig, rotation);
+    assert.equal(snapshot.epoch_revision, "1");
+    assert.equal(snapshot.writer_generation, "1");
+    assert.equal(snapshot.previous_snapshot_sha256, ageSnapshotDigest(initial));
+    assert.equal(snapshot.history.at(-1).effective_from_seq, "9");
+    await activateKeyRotations(rotationConfig);
+    assert.equal(rotationConfig.age_v1_runtime_history.at(-1).key_id, newKeyId);
+    const stored = JSON.parse(await readFile(join(root, "store", "remote-sync", "demo.json"), "utf8"));
+    assert.equal(stored.age_v1.epoch_snapshots.length, 2);
+    assert.equal(stored.age_v1.epoch_snapshots.at(-1).epoch_revision, "1");
+    assert.equal(stored.age_v1.checkpoint.snapshot_sha256, ageSnapshotDigest(snapshot));
+    const exportedPath = join(root, "exported-age-snapshot.json");
+    await exportAgeSnapshot({ team: "demo", out: exportedPath });
+    const exported = JSON.parse(await readFile(exportedPath, "utf8"));
+    assert.equal(exported.epoch_revision, "1");
+    assert.equal(exported.history.length, 2);
+    assert.match(await readFile(join(root, "trust",
+      `age-v1-${config.server_instance_id}-${config.remote_team_id}-v1.json`), "utf8"),
+    new RegExp(ageSnapshotDigest(snapshot), "u"));
+  } finally {
+    if (saved.connection === undefined) delete process.env.AGMSG_SYNC_CONNECTION_DIR;
+    else process.env.AGMSG_SYNC_CONNECTION_DIR = saved.connection;
+    if (saved.storage === undefined) delete process.env.AGMSG_SYNC_STORAGE_DIR;
+    else process.env.AGMSG_SYNC_STORAGE_DIR = saved.storage;
+    if (saved.trust === undefined) delete process.env.AGMSG_SYNC_TRUST_DIR;
+    else process.env.AGMSG_SYNC_TRUST_DIR = saved.trust;
+    await rm(root, { recursive: true });
+  }
+});
 
 test("a synced rotation halts until an out-of-band identity matches its fingerprint", async () => {
   const root = await mkdtemp(join(tmpdir(), "agmsg-key-rotation-"));

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -689,6 +689,106 @@ test("reprocess routes recovered roster mutations away from message storage", as
   assert.equal(result.blocking_remaining, false);
 });
 
+test("reprocess preserves server order across roster mutations and rotations", async () => {
+  const capabilities = {
+    ...capsFor(["age-v1"]), current_seq: "6", next_sequence_boundary: "7",
+  };
+  const ids = Array.from({ length: 6 }, (_, index) =>
+    `550e8400-e29b-41d4-a716-44665544000${index + 1}`);
+  let completed = false;
+  let activeEpoch = 0;
+  const rosterOrder = [];
+  const result = await reprocessCycle(config, 100, {
+    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    requestCall: async () => capabilities,
+    driverCall: async (operation, _config, input) => {
+      if (operation === "apply") {
+        assert.deepEqual(input.filter((record) => record.id).map((record) => record.server_seq),
+          ["1", "2", "3", "4", "5", "6"]);
+        completed = true;
+        return [{ type: "sync_apply_result", transport_cursor: "6", corrupt_count: 0 },
+          ...ids.map((id, index) => ({ type: "sync_apply_outcome", id,
+            server_seq: String(index + 1), status: "imported" }))];
+      }
+      assert.equal(operation, "reprocess");
+      return [
+        { type: "sync_state", driver_generation: "generation-ordered", transport_cursor: "6" },
+        ...(!completed ? ids.map((id, index) => ({ type: "sync_reprocess_candidate",
+          server_seq: String(index + 1), id,
+          server_received_at: "2026-07-30T20:33:33.000000Z",
+          envelope: { v: 1, cipher: "age-v1", key_id: "epoch-initial", blob: id },
+          prior_status: "pending_key" })) : []),
+        { type: "sync_reprocess_page", next_after: null, has_more: false },
+      ];
+    },
+    rosterDriverCall: async (operation, _config, input) => {
+      assert.equal(operation, "apply");
+      rosterOrder.push(...input.filter((record) => record.id).map((record) => record.server_seq));
+      return [];
+    },
+    activateKeyRotationsCall: async () => { activeEpoch += 1; },
+    evaluateCall: async (_config, _capabilities, message) => {
+      const seq = Number(message.server_seq);
+      if (seq === 2 || seq === 5) return { status: "importable", projection: {
+        kind: "key_rotated", mutation_id: `018f3f7e-0000-7000-8000-00000000002${seq}`,
+        epoch: String(seq === 2 ? 1 : 2), key_id: `epoch-${seq}`,
+        fingerprint: "a".repeat(64), occurred_at: "2026-07-30T20:33:33.000000Z",
+      }, policy_revision: "0", local_security_revision: "0" };
+      if (seq === 4) {
+        assert.equal(activeEpoch, 1);
+        return { status: "importable", projection: { body: "after rotation",
+          created_at: "2026-07-30T20:33:33.000000Z", from_agent: "a", to_agent: "b" },
+        policy_revision: "0", local_security_revision: "0" };
+      }
+      return { status: "importable", projection: { kind: "member_joined",
+        mutation_id: `018f3f7e-0000-7000-8000-00000000001${seq}`,
+        member_id: `018f3f7e-0000-7000-8000-00000000003${seq}`,
+        name: `member-${seq}`, occurred_at: "2026-07-30T20:33:33.000000Z" },
+      policy_revision: "0", local_security_revision: "0" };
+    },
+    eventCall: async () => {}, logApplyCall: async () => {},
+  });
+  assert.deepEqual(rosterOrder, ["1", "2", "3", "5", "6"]);
+  assert.equal(activeEpoch, 2);
+  assert.equal(result.imported_count, 6);
+});
+
+test("reprocess does not advance storage when an ordered roster flush fails", async () => {
+  const ids = ["550e8400-e29b-41d4-a716-446655440001",
+    "550e8400-e29b-41d4-a716-446655440002"];
+  let storageApplied = false;
+  let activated = false;
+  await assert.rejects(reprocessCycle(config, 100, {
+    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    requestCall: async () => ({ ...capsFor(["age-v1"]), current_seq: "2",
+      next_sequence_boundary: "3" }),
+    driverCall: async (operation) => {
+      if (operation === "apply") { storageApplied = true; return []; }
+      return [{ type: "sync_state", driver_generation: "generation-fail", transport_cursor: "2" },
+        ...ids.map((id, index) => ({ type: "sync_reprocess_candidate",
+          server_seq: String(index + 1), id,
+          server_received_at: "2026-07-30T20:33:33.000000Z",
+          envelope: { v: 1, cipher: "age-v1", key_id: "epoch-initial", blob: id },
+          prior_status: "pending_key" })),
+        { type: "sync_reprocess_page", next_after: null, has_more: false }];
+    },
+    rosterDriverCall: async () => { throw new Error("roster append failed"); },
+    activateKeyRotationsCall: async () => { activated = true; },
+    evaluateCall: async (_config, _capabilities, message) => ({ status: "importable",
+      projection: message.server_seq === "1" ? { kind: "member_joined",
+        mutation_id: "018f3f7e-0000-7000-8000-000000000011",
+        member_id: "018f3f7e-0000-7000-8000-000000000031", name: "member-1",
+        occurred_at: "2026-07-30T20:33:33.000000Z" } : { kind: "key_rotated",
+        mutation_id: "018f3f7e-0000-7000-8000-000000000022", epoch: "1",
+        key_id: "epoch-1", fingerprint: "a".repeat(64),
+        occurred_at: "2026-07-30T20:33:33.000000Z" },
+      policy_revision: "0", local_security_revision: "0" }),
+    eventCall: async () => {}, logApplyCall: async () => {},
+  }), /roster append failed/u);
+  assert.equal(storageApplied, false);
+  assert.equal(activated, false);
+});
+
 test("explicit reprocess rejects an unbounded walk through duplicate server sequences", async () => {
   const capabilities = {
     protocol_version: 1, server_instance_id: config.server_instance_id,

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -136,6 +136,12 @@ test("a rotator provisions its confirmed snapshot at the server boundary", async
     assert.equal(snapshot.writer_generation, "1");
     assert.equal(snapshot.previous_snapshot_sha256, ageSnapshotDigest(initial));
     assert.equal(snapshot.history.at(-1).effective_from_seq, "9");
+    const laterEpoch = { ...localEpoch, key_id: "epoch-later", epoch_revision: 2,
+      writer_generation: 2 };
+    const replayed = nextLocalAgeSnapshot(rotationConfig, { ...teamConfig, remote_key: {
+      current: laterEpoch, epochs: [...teamConfig.remote_key.epochs, laterEpoch],
+    } }, rotation);
+    assert.equal(replayed.history.at(-1).key_id, newKeyId);
     await activateKeyRotations(rotationConfig);
     assert.equal(rotationConfig.age_v1_runtime_history.at(-1).key_id, newKeyId);
     const stored = JSON.parse(await readFile(join(root, "store", "remote-sync", "demo.json"), "utf8"));
@@ -147,6 +153,16 @@ test("a rotator provisions its confirmed snapshot at the server boundary", async
     const exported = JSON.parse(await readFile(exportedPath, "utf8"));
     assert.equal(exported.epoch_revision, "1");
     assert.equal(exported.history.length, 2);
+    const unconfirmed = { ...snapshot, epoch_revision: "2", writer_generation: "2",
+      previous_snapshot_sha256: ageSnapshotDigest(snapshot),
+      history: [...snapshot.history, { ...snapshot.history.at(-1), epoch_revision: "2",
+        effective_from_seq: "10", key_id: "epoch-unconfirmed" }] };
+    stored.age_v1.epoch_snapshots.push(unconfirmed);
+    stored.age_v1.checkpoint = { ...stored.age_v1.checkpoint, epoch_revision: "2",
+      writer_generation: "2", snapshot_sha256: ageSnapshotDigest(unconfirmed) };
+    await writeFile(join(root, "store", "remote-sync", "demo.json"), JSON.stringify(stored));
+    await assert.rejects(exportAgeSnapshot({ team: "demo", out: join(root, "unsafe.json") }),
+      /retained age checkpoint/u);
     assert.match(await readFile(join(root, "trust",
       `age-v1-${config.server_instance_id}-${config.remote_team_id}-v1.json`), "utf8"),
     new RegExp(ageSnapshotDigest(snapshot), "u"));

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -5,6 +5,7 @@ import { chmod, mkdir, mkdtemp, readFile, readdir, rename, rm, symlink, unlink,
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { readNativeAgeIdentity } from "../scripts/internal/sync-cipher.mjs";
 import {
   ageSnapshotDigest,
   activateKeyRotations,
@@ -1768,12 +1769,18 @@ test("age configure authenticates the connected credential before retaining trus
   });
 });
 
-test("age configure imports a complete chain without activating its future epoch", async () => {
+test("age configure extends a stored chain and activates its announced epoch", async () => {
   const previousFetch = globalThis.fetch;
   await withConnectedCredential(async (root) => {
     await writeConnectedTeam(root, { capabilities: { write_allowed_ciphers: ["age-v1"] } });
     const recipient0 = "age1mmqjrejftea4f6xh47lhpc0jn4vw0yuhz349sw2e3sfl22k5gcjsv6xcvp";
-    const recipient1 = "age1ykvctct4aklx4f4mnjd8rmzqs7p2le9ufg4faydljsk5mvcy0pls27mu64";
+    const identityDir = join(root, "run", "remote-credentials", "demo", "keys");
+    const identity1 = join(identityDir, "epoch-1.key");
+    await mkdir(identityDir, { recursive: true });
+    await writeFile(identity1,
+      "AGE-SECRET-KEY-14Z7XMNPZTPEMMM6DG2FSKEH042L7UMU79T645GAQJKU2LLJGPM2S7GWNLQ\n",
+      { mode: 0o600 });
+    const recipient1 = readNativeAgeIdentity(identity1).recipient;
     const ageSnapshot0 = {
       authorized_writers: ["writer-a"],
       epoch_revision: "0",
@@ -1809,10 +1816,8 @@ test("age configure imports a complete chain without activating its future epoch
     process.env.AGMSG_SYNC_STORAGE_DIR = join(root, "store");
     process.env.AGMSG_SYNC_TRUST_DIR = join(root, "trust");
     process.env.AGMSG_AGE_BIN = fakeAge;
-    let calls = 0;
-    globalThis.fetch = async () => {
-      calls += 1;
-      const body = calls === 1 ?
+    globalThis.fetch = async (url) => {
+      const body = String(url).endsWith("/v1/health") ?
         { status: "ok", database: "ok", server_instance_id: config.server_instance_id } :
         capsFor(["age-v1"]);
       return new Response(JSON.stringify(body), {
@@ -1822,18 +1827,34 @@ test("age configure imports a complete chain without activating its future epoch
     try {
       await configure({ team: "demo", server: "https://sync.example",
         "team-id": config.remote_team_id, "minimum-security": "e2ee-required",
+        cipher: "age-v1", "age-snapshot": [ageSnapshot0Path],
+        "age-checkpoint": `0:${ageSnapshotDigest(ageSnapshot0)}`,
+        "age-confirmation": "operator-live" });
+      const mutationId = "018f3f7e-0000-7000-8000-000000000025";
+      await writeFile(join(root, "teams", "demo", "roster.jsonl"), [
+        JSON.stringify({ type: "key_rotated", id: mutationId, epoch: "1",
+          key_id: "epoch-1", fingerprint: createHash("sha256").update(recipient1).digest("hex"),
+          at: "2026-07-30T00:00:00.000000Z" }),
+        JSON.stringify({ type: "roster_synced", mutation_id: mutationId, server_seq: "1",
+          wire_id: "550e8400-e29b-41d4-a716-446655440006",
+          server_instance_id: config.server_instance_id,
+          remote_team_id: config.remote_team_id }), "",
+      ].join("\n"));
+      await configure({ team: "demo", server: "https://sync.example",
+        "team-id": config.remote_team_id, "minimum-security": "e2ee-required",
         cipher: "age-v1", "age-snapshot": [ageSnapshot0Path, ageSnapshot1Path],
         "age-checkpoint": `1:${ageSnapshotDigest(ageSnapshot1)}`,
-        "age-confirmation": "operator-live" });
+        "age-confirmation": "operator-live", "age-identity": [`epoch-1=${identity1}`] });
       const stored = JSON.parse(await readFile(
         join(process.env.AGMSG_SYNC_STORAGE_DIR, "remote-sync", "demo.json"), "utf8"));
       assert.equal(stored.age_v1.epoch_snapshots.length, 2);
       const loaded = await loadConfig("demo");
-      assert.equal(loaded.age_v1_runtime_history.length, 0);
+      assert.equal(loaded.age_v1_runtime_history.length, 1);
+      assert.equal(loaded.age_v1_runtime_history[0].key_id, "epoch-1");
       const afterFirstSequence = {
         ...capsFor(["age-v1"]), current_seq: "1", next_sequence_boundary: "2",
       };
-      assert.equal(selectWriteProfile(loaded, afterFirstSequence).key_id, "epoch-0");
+      assert.equal(selectWriteProfile(loaded, afterFirstSequence).key_id, "epoch-1");
     } finally {
       globalThis.fetch = previousFetch;
       if (saved.storage === undefined) delete process.env.AGMSG_SYNC_STORAGE_DIR;

--- a/tests/test_jsonl_remote_sync.bats
+++ b/tests/test_jsonl_remote_sync.bats
@@ -335,6 +335,33 @@ EOF
     jq -s '[.[]|select(.type=="sync_reprocess_candidate")]|length')" -eq 0 ]
 }
 
+@test "jsonl reprocess acknowledges a roster projection without making a message" {
+  local wire blocked page reevaluated result
+  wire=550e8400-e29b-41d4-a716-446655440021
+  blocked=$(jq -nc --arg id "$wire" '{type:"sync_pull_message",server_seq:"1",id:$id,
+    server_received_at:"2026-07-30T20:33:33.000000Z",
+    envelope:{v:1,cipher:"age-v1",key_id:"epoch-1",blob:"YWdl"},
+    status:"unsupported_cipher",reason:"age-v1 is not configured",
+    policy_revision:"0",local_security_revision:"0"}')
+  page=$(printf '%s\n%s\n' "$blocked" '{"type":"sync_pull_cursor","next_after":"1"}')
+  printf '%s\n' "$page" |
+    storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  reevaluated=$(printf '%s\n' "$blocked" | jq -c '
+    .status="importable" | .reason="" |
+    .projection={kind:"member_joined",
+      mutation_id:"019fb4bb-7948-7520-8c16-ab64753e2012",
+      member_id:"019fb4bb-7948-7ce9-8e4f-61229dc726cf",
+      name:"dana",occurred_at:"2026-07-30T20:33:33.000000Z"}')
+  result=$(printf '%s\n%s\n' "$reevaluated" \
+    '{"type":"sync_pull_cursor","next_after":"1"}' |
+    storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r --arg id "$wire" \
+    'select(.type=="sync_apply_outcome" and .id==$id)|.status')" = imported ]
+  [ "$(storage_history demo | jq -s 'length')" -eq 0 ]
+  [ "$(storage_sync_reprocess demo "$SERVER_ID" "$TEAM_ID" 1 100 |
+    jq -s '[.[]|select(.type=="sync_reprocess_candidate")]|length')" -eq 0 ]
+}
+
 @test "jsonl reprocess keyset pages reach candidates beyond a permanent first page" {
   local records="" page first token second
   local index wire

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -176,7 +176,7 @@ EOF
 @test "key import --identity-stdin: establishes the first epoch for a team with no key yet" {
   skip_if_no_age
   secret=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
-  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --identity-stdin"
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --key-id '$key_id' --identity-stdin"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Imported key for team 'testteam'"* ]]
 }
@@ -337,6 +337,17 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"Imported replacement key"* ]]
   [ -f "$identity" ]
+}
+
+@test "key import: rejects an authority key id absent from announced rotations" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  secret=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
+
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --key-id epoch-unannounced --identity-stdin"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not match the current key or an announced rotation"* ]]
+  [ ! -f "$SCRIPTS/../run/remote-credentials/testteam/keys/epoch-unannounced.key" ]
 }
 
 @test "key rotate: advances the shared epoch only after the previous winner is synchronized" {

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -176,7 +176,7 @@ EOF
 @test "key import --identity-stdin: establishes the first epoch for a team with no key yet" {
   skip_if_no_age
   secret=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
-  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --key-id '$key_id' --identity-stdin"
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --identity-stdin"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Imported key for team 'testteam'"* ]]
 }
@@ -333,7 +333,13 @@ EOF
   identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$key_id.key"
   secret=$(grep '^AGE-SECRET-KEY-' "$identity")
   rm -f "$identity"
-  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --identity-stdin"
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --key-id wrong-announced-id --identity-stdin"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not match the announced rotation"* ]]
+  [ ! -f "$identity" ]
+  [ ! -f "$SCRIPTS/../run/remote-credentials/testteam/keys/wrong-announced-id.key" ]
+
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --key-id '$key_id' --identity-stdin"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Imported replacement key"* ]]
   [ -f "$identity" ]

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -38,6 +38,25 @@ open(p, 'w').write(json.dumps(d) + '\\n')
 "
 }
 
+stub_current_age_snapshot() {
+  cat > "$SCRIPTS/remote-sync.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "export-age-snapshot" ]
+shift
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --out) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$out" ]
+printf '%s' '{"epoch_revision":"0"}' > "$out"
+EOF
+  chmod +x "$SCRIPTS/remote-sync.sh"
+}
+
 # --- generate --------------------------------------------------------------
 
 @test "key generate: creates a first epoch and prints the backup notice" {
@@ -266,6 +285,7 @@ open(p, 'w').write(json.dumps(d) + '\\n')
 @test "key rotate: creates a replacement identity and journals only its fingerprint" {
   skip_if_no_age
   bash "$SCRIPTS/key.sh" generate testteam
+  stub_current_age_snapshot
   run bash "$SCRIPTS/key.sh" rotate testteam
   [ "$status" -eq 0 ]
   [[ "$output" == *"Generated replacement key"* ]]
@@ -277,6 +297,8 @@ open(p, 'w').write(json.dumps(d) + '\\n')
   [[ "$key_id" == epoch-* ]]
   [[ "$fingerprint" =~ ^[0-9a-f]{64}$ ]]
   [ -f "$SCRIPTS/../run/remote-credentials/testteam/keys/$key_id.key" ]
+  [ "$(python3 -c "import json; d=json.load(open('$SCRIPTS/../teams/testteam/config.json')); print(d['remote_key']['current']['key_id'])")" = "$key_id" ]
+  [ "$(python3 -c "import json; d=json.load(open('$SCRIPTS/../teams/testteam/config.json')); print(len(d['remote_key']['epochs']))")" -eq 2 ]
   ! grep -q 'AGE-SECRET-KEY\\|age1' "$journal"
   run bash "$SCRIPTS/key.sh" show testteam --key-id "$key_id"
   [ "$status" -eq 0 ]
@@ -286,6 +308,7 @@ open(p, 'w').write(json.dumps(d) + '\\n')
 @test "key rotate: an old identity cannot decrypt data for the replacement epoch" {
   skip_if_no_age
   bash "$SCRIPTS/key.sh" generate testteam
+  stub_current_age_snapshot
   old_epoch=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['current']['key_id'])")
   old_identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$old_epoch.key"
   bash "$SCRIPTS/key.sh" rotate testteam
@@ -303,6 +326,7 @@ open(p, 'w').write(json.dumps(d) + '\\n')
 @test "key import: installs an out-of-band replacement only after its fingerprint is announced" {
   skip_if_no_age
   bash "$SCRIPTS/key.sh" generate testteam
+  stub_current_age_snapshot
   bash "$SCRIPTS/key.sh" rotate testteam
   journal="$SCRIPTS/../teams/testteam/roster.jsonl"
   key_id=$(python3 -c "import json; print([json.loads(x) for x in open('$journal') if json.loads(x).get('type') == 'key_rotated'][-1]['key_id'])")
@@ -318,6 +342,7 @@ open(p, 'w').write(json.dumps(d) + '\\n')
 @test "key rotate: advances the shared epoch only after the previous winner is synchronized" {
   skip_if_no_age
   bash "$SCRIPTS/key.sh" generate testteam
+  stub_current_age_snapshot
   config="$SCRIPTS/../teams/testteam/config.json"
   journal="$SCRIPTS/../teams/testteam/roster.jsonl"
   server_id="018f3f7e-0000-7000-8000-000000000000"

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -213,6 +213,35 @@ prepare_push() {
   [ "$(agmsg_sqlite "$db" "SELECT status FROM sync_quarantine WHERE wire_id='550e8400-e29b-41d4-a716-446655440020';" | tr -d '\r')" = imported ]
 }
 
+@test "sync contract: reprocess acknowledges a roster projection without making a message" {
+  local wire blocked page reevaluated result db
+  wire=550e8400-e29b-41d4-a716-446655440021
+  blocked=$(jq -nc --arg id "$wire" '
+    {type:"sync_pull_message",server_seq:"1",id:$id,
+     server_received_at:"2026-07-30T20:33:33.000000Z",
+     envelope:{v:1,cipher:"age-v1",key_id:"epoch-1",blob:"YWdl"},
+     status:"unsupported_cipher",reason:"age-v1 is not configured",
+     policy_revision:"0",local_security_revision:"0"}')
+  page=$(printf '%s\n%s\n' "$blocked" '{"type":"sync_pull_cursor","next_after":"1"}')
+  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  reevaluated=$(printf '%s\n' "$blocked" | jq -c '
+    .status="importable" | .reason="" |
+    .projection={kind:"member_joined",
+      mutation_id:"019fb4bb-7948-7520-8c16-ab64753e2012",
+      member_id:"019fb4bb-7948-7ce9-8e4f-61229dc726cf",
+      name:"dana",occurred_at:"2026-07-30T20:33:33.000000Z"}')
+  result=$(printf '%s\n%s\n' "$reevaluated" \
+    '{"type":"sync_pull_cursor","next_after":"1"}' |
+    storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r --arg id "$wire" \
+    'select(.type=="sync_apply_outcome" and .id==$id)|.status')" = imported ]
+  [ "$(storage_history demo | jq -s 'length')" -eq 0 ]
+  db=$(agmsg_db_path demo)
+  [ "$(agmsg_sqlite "$db" "SELECT status FROM sync_quarantine WHERE wire_id='$wire';" | tr -d '\r')" = imported ]
+  [ "$(storage_sync_reprocess demo "$SERVER_ID" "$TEAM_ID" 1 100 |
+    jq -s '[.[]|select(.type=="sync_reprocess_candidate")]|length')" -eq 0 ]
+}
+
 @test "sync contract: reprocess candidate body and trailer share one keyset page" {
   local records="" page first token second index wire
   for index in 1 2 3; do


### PR DESCRIPTION
Three fixes, one investigation: the first live end-to-end E2EE run walked `unlock` and `rotate` for the first time and each fix below reproduces against real machine state.

**1. reprocess routes roster events to the roster driver** (`f9da77f`)
`reprocess` lacked the roster/message split normal pull has had since #538: a quarantined `member_joined` went into the SQLite chat apply, which requires from/to/body, and the driver exited 13. Every encrypted team hits this — its first quarantined envelopes are the roster events sealed at connect. Verified: with this fix the previously-failing machine-B state unlocks (`imported 2 envelope(s); engine running`), reads sealed history, and replies sealed.

**2. a driver that dies silently now says so** (`5990388`)
The failure above surfaced as `storage sync apply failed (13):` — reason empty. `runDriver` now names the condition instead of handing the operator a bare exit code.

**3. rotate self-provisions the snapshot it announces** (`c1d478b`)
`key.sh rotate` minted the key and journaled `key_rotated`, but never staged the epoch in the team ledger nor provisioned the rotator's own snapshot — so the rotating machine halted on its own rotation (observed live) and `show --snapshot` kept exporting revision 0, leaving no way to produce the material machine B needs. Now rotate stages the epoch, and when the announcement wins server ordering the rotator self-provisions the chain (revision+1, writer_generation+1, previous digest, effective_from_seq = boundary+1) and `show --snapshot` exports the confirmed chain. A losing concurrent rotation still halts, per design.

Node engine 51/51, key Bats 25/25, SQLite 23/23, JSONL 24/24 locally; loopback bats ride on CI.

PR opened on the author's behalf — their sandbox blocks GitHub access.