### PR TITLE
fix(spawn): keep opencode worker resident via TUI --prompt (re-land of #546)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -306,7 +306,7 @@ Copilotインストーラーは `~/.copilot/skills/agmsg/` に `SKILL.md` を配
 $agmsg
 ```
 
-`./install.sh` でインストールする（`~/.config/opencode/` が存在する場合、OpenCode向けスキルがデフォルトのCodex向け共有スキルと並んで自動的に配置される）。`--agent-type opencode` はCodexがインストールされていないOpenCode専用環境でのみ使う。OpenCodeは手動およびturn/off配信ワークフローに対応している。現時点では `mode turn` と `mode off` のみサポート — `monitor`、`both`、`spawn opencode` は非対応。
+`./install.sh` でインストールする（`~/.config/opencode/` が存在する場合、OpenCode向けスキルがデフォルトのCodex向け共有スキルと並んで自動的に配置される）。`--agent-type opencode` はCodexがインストールされていないOpenCode専用環境でのみ使う。OpenCodeは `mode turn` と `mode off` に対応し、`spawn opencode` は `opencode --prompt`（ブートプロンプトのターンが終わってもTUIが滞在するモード）経由で利用可能。`monitor` と `both` は非対応。
 
 これによりOpenCodeは、Ollamaのようなローカルプロバイダーを使う構成を含め、ローカルのコーディングエージェントとして役立つ。
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ The Copilot installer drops a `SKILL.md` at `~/.copilot/skills/agmsg/` so `/agms
 $agmsg
 ```
 
-Install with `./install.sh` (when `~/.config/opencode/` exists, the OpenCode-typed skill is placed automatically alongside the default Codex-typed shared skill). Use `--agent-type opencode` only for OpenCode-only environments where Codex is not installed. OpenCode is supported for manual and turn/off delivery workflows. It currently supports `mode turn` and `mode off`; `monitor`, `both`, and `spawn opencode` are not supported.
+Install with `./install.sh` (when `~/.config/opencode/` exists, the OpenCode-typed skill is placed automatically alongside the default Codex-typed shared skill). Use `--agent-type opencode` only for OpenCode-only environments where Codex is not installed. OpenCode supports `mode turn` and `mode off`, and `spawn opencode` is available via `opencode --prompt` (TUI mode, which stays resident after the boot prompt's turn). `monitor` and `both` are not supported.
 
 This makes OpenCode useful as a local coding agent, including configurations backed by local providers such as Ollama.
 

--- a/docs/agent-types.md
+++ b/docs/agent-types.md
@@ -21,11 +21,11 @@ a manifest cannot execute code. Multi-value keys are whitespace-separated.
 | `template` | yes | the `/agmsg` command template filename, relative to the type dir (e.g. `template.md`); becomes `SKILL.md` |
 | `detect` | — | env-var names whose presence selects this type. `explicit` = never auto-detected from the environment |
 | `detect_proc` | — | parent-process-name glob patterns that select this type (e.g. `codex codex-*`) |
-| `cli` | spawnable types | the launch command. Usually a single binary name, but may be a fixed multi-word prefix (subcommand and/or flags a CLI needs ahead of its own options, e.g. `opencode run --interactive`) — only the first word is resolved/checked as the executable; the rest are passed through as-is. Safe because this is manifest data agmsg ships, not runtime user input |
+| `cli` | spawnable types | the launch command. Usually a single binary name, but may be a fixed multi-word prefix (subcommand and/or flags a CLI needs ahead of its own options) — only the first word is resolved/checked as the executable; the rest are passed through as-is. Safe because this is manifest data agmsg ships, not runtime user input |
 | `spawnable` | — | `yes` if `spawn.sh` can launch this type |
 | `spawn` | — | a `.mjs` node-launcher (beside the manifest) `spawn.sh` runs via Node; also marks the type spawnable |
 | `model_arg` | — | the `--model`/`-m`-style flag `spawn --model <id>` passes through to the CLI; a type with no `model_arg` refuses `--model` |
-| `prompt_arg` | — | for a CLI that does not accept the actas prompt as a bare positional argument, the named flag whose value IS the prompt (e.g. antigravity's `--prompt-interactive`, copilot's `--interactive`) — `spawn.sh` inserts it immediately before the (already-quoted) prompt. Unset = bare positional, the default |
+| `prompt_arg` | — | for a CLI that does not accept the actas prompt as a bare positional argument, the named flag whose value IS the prompt (e.g. antigravity's `--prompt-interactive`, copilot's `--interactive`, opencode's `--prompt`) — `spawn.sh` inserts it immediately before the (already-quoted) prompt. Unset = bare positional, the default |
 | `hooks_file` | yes | project-relative delivery hooks file (e.g. `.codex/hooks.json`) |
 | `monitor` | — | `yes` if the type exposes a native Monitor tool; `spawn` skips the readiness wait when `no` |
 | `delivery_modes` | — | space-separated delivery modes the type's CLI accepts (e.g. `monitor turn off`); `delivery.sh`'s gate rejects anything else. Defaults to `monitor turn both off` when omitted |

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -2,7 +2,7 @@
 
 OpenCode is supported for **manual and turn/off delivery workflows**.
 
-`monitor`, `both`, and `spawn opencode` are not supported in this release. OpenCode + Ollama is a useful local coding agent that can participate in an agmsg team alongside Claude Code, Codex, Gemini CLI, and other CLI agents.
+`monitor` and `both` are not supported in this release (real-time push delivery requires a Monitor-tool equivalent that OpenCode does not have built in). `spawn opencode` is supported via `opencode --prompt`. OpenCode + Ollama is a useful local coding agent that can participate in an agmsg team alongside Claude Code, Codex, Gemini CLI, and other CLI agents.
 
 ## Install
 
@@ -108,7 +108,16 @@ Error: 'monitor' mode is not supported for opencode (no Monitor-tool equivalent)
 
 ## Spawn
 
-`spawn opencode` is not supported. Spawn is limited to `claude-code` and `codex`.
+`spawn opencode` is supported via the existing `prompt_arg=` mechanism. The
+manifest declares `cli=opencode` + `prompt_arg=--prompt`, so `spawn.sh` emits
+`opencode --model <id> --prompt "<actas text>"`.
+
+TUI mode (`opencode --prompt`, not `opencode run --interactive`) is required:
+`run --interactive` exits as soon as the boot prompt's turn completes, so the
+spawned worker would never stay resident to receive further agmsg messages.
+`--prompt` auto-sends the initial prompt and keeps the TUI open.
+
+See the main spawn documentation in [README.md](../README.md#spawn-a-new-agent-spawn).
 
 ## Typical team setup
 
@@ -128,8 +137,7 @@ OpenCode + Ollama is well-suited for local, low-cost tasks such as:
 
 ## Known limitations
 
-- No real-time push delivery (`monitor` mode requires Claude Code's Monitor tool)
-- No `spawn opencode` support
+- No real-time push delivery (`monitor` mode requires a Monitor-tool equivalent, not available in OpenCode itself)
 - No native OpenCode plugin integration
 
 These may be addressed in future releases.

--- a/scripts/drivers/types/opencode/type.conf
+++ b/scripts/drivers/types/opencode/type.conf
@@ -1,9 +1,10 @@
 # agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
 name=opencode
 template=template.md
-cli=opencode run --interactive
+cli=opencode
 spawnable=yes
 model_arg=--model
+prompt_arg=--prompt
 detect_proc=opencode opencode-*
 hooks_file=.opencode/rules/agmsg.md
 monitor=no

--- a/scripts/drivers/types/opencode/type.conf
+++ b/scripts/drivers/types/opencode/type.conf
@@ -3,6 +3,8 @@ name=opencode
 template=template.md
 cli=opencode
 spawnable=yes
+# opencode invokes a skill with "$", not Claude Code's "/" (see spawn.sh, #283).
+cmd_prefix=$
 model_arg=--model
 prompt_arg=--prompt
 detect_proc=opencode opencode-*

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -454,16 +454,14 @@ seed_resumable() {
   [[ "$output" == *"actas"* ]]
 }
 
-@test "spawn: opencode launches its 'run --interactive' fixed subcommand prefix" {
+@test "spawn: opencode launches opencode with --prompt (not a bare positional)" {
   bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
   run bash "$SCRIPTS/spawn.sh" opencode alice --project "$PROJ" --model anthropic/claude-opus-4-8 --no-wait
   [ "$status" -eq 0 ]
   boot="$(cat "$CAPTURE")"
   run cat "$boot"
-  [[ "$output" == *"opencode run --interactive --model anthropic/claude-opus-4-8"* ]]
+  [[ "$output" == *"opencode --model anthropic/claude-opus-4-8 --prompt"* ]]
   [[ "$output" == *"actas"* ]]
-  # no bare 'opencode' invocation without the fixed prefix
-  [[ "$output" != *$'\n''opencode --model'* ]]
 }
 
 @test "spawn: prompt_arg lands after spawn-options, immediately before the prompt" {

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -461,7 +461,12 @@ seed_resumable() {
   boot="$(cat "$CAPTURE")"
   run cat "$boot"
   [[ "$output" == *"opencode --model anthropic/claude-opus-4-8 --prompt"* ]]
-  [[ "$output" == *"actas"* ]]
+  # opencode's actas prompt uses the '$' skill prefix, not Claude Code's '/' (#283).
+  local cmd; cmd="$(basename "$TEST_SKILL_DIR")"
+  run grep -F "\$$cmd"'\ actas' "$boot"
+  [ "$status" -eq 0 ]
+  run grep -F "/$cmd"'\ actas' "$boot"
+  [ "$status" -ne 0 ]
 }
 
 @test "spawn: prompt_arg lands after spawn-options, immediately before the prompt" {


### PR DESCRIPTION
Re-lands @tsukimiya's #546 unchanged, from a branch in this repository. The three commits are cherry-picked with `-x`, so they keep their original authorship and reference the commits they came from.

This detour is mechanical. #546's checks ran before the bats suite was split into shards, so the required context has never reported on that head and GitHub holds it blocked regardless of content. The red macOS job on it is also not a real failure — it is the `watch: persists a watermark file for the session` flake that #541 fixed, from a run that predates that fix landing. Rather than send an external contributor round for our own CI churn, the commits move here.

## What it does

`opencode run --interactive` exits as soon as the boot prompt's turn completes, so a spawned worker did not stay resident. The manifest now declares `cli=opencode` with `prompt_arg=--prompt`, which makes `spawn.sh` emit `opencode --model <id> --prompt "<actas text>"` — TUI mode, which stays up. It also sets `cmd_prefix=$`, so the boot command uses `$agmsg actas` rather than Claude Code's `/agmsg actas`.

No script changes. Both `prompt_arg` and `cmd_prefix` are existing manifest keys, already consumed by `scripts/lib/boot-command.sh` and already used by the antigravity, codex, copilot, and gemini manifests. This is configuration of a mechanism that was already there, which is why the diff is as small as it is.

## Tests

`bats tests/test_spawn.bats` — 74/74, exit 0, against current `main`.

Closes #546 once this lands.
