### PR TITLE
Stop the sync engine inheriting descriptors it never uses

### DIFF
--- a/scripts/remote-sync.sh
+++ b/scripts/remote-sync.sh
@@ -30,27 +30,43 @@ export AGMSG_SYNC_CIPHER_HELPER="$SCRIPT_DIR/internal/sync-cipher.mjs"
 # The engine speaks only over stdin, stdout and stderr; the spawn sites already
 # point those at a log. Nothing above stderr is anything it should keep.
 #
-# The closes are attached to the exec rather than performed before it. One of the
-# descriptors above stderr belongs to the shell itself -- bash keeps the script it
-# is reading open, at 255 -- and closing it from a statement would leave the shell
-# to carry on reading a script through a descriptor it no longer holds. Bash does
-# defend against that (observed: it moves the script to another number), but as a
-# redirection on the exec the question does not arise: nothing of this script runs
-# between the close and the execve.
-_fd_closes=""
-if [ -d /dev/fd ]; then
-  for _fd in /dev/fd/*; do
-    _fd="${_fd##*/}"
-    case "$_fd" in ''|*[!0-9]*) continue ;; esac
-    [ "$_fd" -gt 2 ] || continue
-    _fd_closes="$_fd_closes ${_fd}>&-"
-  done
-else
-  # Nothing to enumerate, so name a range instead. Closing a descriptor that was
-  # never open is not an error, which is what makes the blind form safe.
-  for _fd in $(seq 3 255); do
-    _fd_closes="$_fd_closes ${_fd}>&-"
-  done
-fi
+# Each close is its own statement. Collecting them into redirections on the exec
+# reads better and is wrong: bash 3.2 -- which is /bin/bash on macOS, and what
+# runs this on the macOS runner -- relocates descriptors into the range at and
+# above 10 while it processes an exec's redirections, and the child then inherits
+# those relocated copies. Measured, same script, same enumeration
+# (`10>&- 143>&- 255>&- 3>&-`) both times:
+#
+#   bash 5.3.15   engine sees  0 1 2
+#   bash 3.2.57   engine sees  0 1 2 10 11      <- 143 came back as 11
+#
+# A CI shard hung on exactly that: the engine held bats's pipe at fd 13 while
+# bats held it at 143, and bats sat waiting for an EOF that could not arrive.
+#
+# The hazard that argued for the exec form does not bite. One descriptor above
+# stderr belongs to the shell -- bash keeps the script it is reading open, at 255
+# -- and closing it from a statement might have left the shell reading through a
+# descriptor it had given up. Bash defends itself: given `exec 255>&-` it moves
+# the script to another number (observed as 11), and a script padded to 291 KB,
+# far past any read buffer, still ran to its last line under both 3.2.57 and
+# 5.3.15. Do not "simplify" this back onto the exec line.
+_close_inherited_fds() {
+  local fd
+  if [ -d /dev/fd ]; then
+    for fd in /dev/fd/*; do
+      fd="${fd##*/}"
+      case "$fd" in ''|*[!0-9]*) continue ;; esac
+      [ "$fd" -gt 2 ] || continue
+      eval "exec ${fd}>&-" 2>/dev/null || true
+    done
+  else
+    # Nothing to enumerate, so sweep a range instead. Closing a descriptor that
+    # was never open is not an error, which is what makes the blind form safe.
+    for fd in $(seq 3 255); do
+      eval "exec ${fd}>&-" 2>/dev/null || true
+    done
+  fi
+}
+_close_inherited_fds
 
-eval "exec$_fd_closes \"\$NODE_BIN\" \"\$SCRIPT_DIR/internal/remote-sync.mjs\" \"\$@\""
+exec "$NODE_BIN" "$SCRIPT_DIR/internal/remote-sync.mjs" "$@"

--- a/scripts/remote-sync.sh
+++ b/scripts/remote-sync.sh
@@ -29,23 +29,28 @@ export AGMSG_SYNC_CIPHER_HELPER="$SCRIPT_DIR/internal/sync-cipher.mjs"
 #
 # The engine speaks only over stdin, stdout and stderr; the spawn sites already
 # point those at a log. Nothing above stderr is anything it should keep.
-_close_inherited_fds() {
-  local fd
-  if [ -d /dev/fd ]; then
-    for fd in /dev/fd/*; do
-      fd="${fd##*/}"
-      case "$fd" in ''|*[!0-9]*) continue ;; esac
-      [ "$fd" -gt 2 ] || continue
-      eval "exec ${fd}>&-" 2>/dev/null || true
-    done
-  else
-    # No /dev/fd to enumerate: sweep a range instead. Bounded rather than exact,
-    # which is why it is the fallback and not the method.
-    for fd in $(seq 3 255); do
-      eval "exec ${fd}>&-" 2>/dev/null || true
-    done
-  fi
-}
-_close_inherited_fds
+#
+# The closes are attached to the exec rather than performed before it. One of the
+# descriptors above stderr belongs to the shell itself -- bash keeps the script it
+# is reading open, at 255 -- and closing it from a statement would leave the shell
+# to carry on reading a script through a descriptor it no longer holds. Bash does
+# defend against that (observed: it moves the script to another number), but as a
+# redirection on the exec the question does not arise: nothing of this script runs
+# between the close and the execve.
+_fd_closes=""
+if [ -d /dev/fd ]; then
+  for _fd in /dev/fd/*; do
+    _fd="${_fd##*/}"
+    case "$_fd" in ''|*[!0-9]*) continue ;; esac
+    [ "$_fd" -gt 2 ] || continue
+    _fd_closes="$_fd_closes ${_fd}>&-"
+  done
+else
+  # Nothing to enumerate, so name a range instead. Closing a descriptor that was
+  # never open is not an error, which is what makes the blind form safe.
+  for _fd in $(seq 3 255); do
+    _fd_closes="$_fd_closes ${_fd}>&-"
+  done
+fi
 
-exec "$NODE_BIN" "$SCRIPT_DIR/internal/remote-sync.mjs" "$@"
+eval "exec$_fd_closes \"\$NODE_BIN\" \"\$SCRIPT_DIR/internal/remote-sync.mjs\" \"\$@\""

--- a/scripts/remote-sync.sh
+++ b/scripts/remote-sync.sh
@@ -15,4 +15,37 @@ export AGMSG_SYNC_DRIVER="$SCRIPT_DIR/internal/storage-sync-driver.sh"
 NODE_BIN="$(agmsg_resolve_node)"
 export AGMSG_SYNC_NODE_BIN="$NODE_BIN"
 export AGMSG_SYNC_CIPHER_HELPER="$SCRIPT_DIR/internal/sync-cipher.mjs"
+# The engine outlives the command that starts it, so whatever it inherits it
+# holds for as long as it runs. Under bats that included fd 144 -- a descriptor
+# internal to the harness -- and the shard then ran to the CI job's cap with
+# every test already reported ok, because bats was waiting for an EOF the engine
+# was keeping from arriving. Captured directly: the engine and three bats
+# processes all held the same pipe, 0xc9aea28a590ca110, at fd 144.
+#
+# Closing 3 and 4 by name at the spawn sites, which is what this repo did until
+# now, cannot reach a descriptor whose number the harness chooses. So the close
+# is by range, not by name, and it lives here -- the one place every engine
+# invocation passes through -- rather than at each caller.
+#
+# The engine speaks only over stdin, stdout and stderr; the spawn sites already
+# point those at a log. Nothing above stderr is anything it should keep.
+_close_inherited_fds() {
+  local fd
+  if [ -d /dev/fd ]; then
+    for fd in /dev/fd/*; do
+      fd="${fd##*/}"
+      case "$fd" in ''|*[!0-9]*) continue ;; esac
+      [ "$fd" -gt 2 ] || continue
+      eval "exec ${fd}>&-" 2>/dev/null || true
+    done
+  else
+    # No /dev/fd to enumerate: sweep a range instead. Bounded rather than exact,
+    # which is why it is the fallback and not the method.
+    for fd in $(seq 3 255); do
+      eval "exec ${fd}>&-" 2>/dev/null || true
+    done
+  fi
+}
+_close_inherited_fds
+
 exec "$NODE_BIN" "$SCRIPT_DIR/internal/remote-sync.mjs" "$@"

--- a/tests/test_engine_inherited_fds.bats
+++ b/tests/test_engine_inherited_fds.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+# The sync engine outlives the command that starts it, so every descriptor it
+# inherits it holds for as long as it runs. Under bats that included fd 144 --
+# a descriptor internal to the harness -- and the shard then ran to the CI job's
+# cap with every test already reported ok, because bats was waiting for an EOF
+# the engine was keeping from arriving.
+#
+# Captured from a hung macOS shard: the engine and three bats processes all held
+# the same pipe, 0xc9aea28a590ca110, at fd 144.
+#
+#   node .../remote-sync.mjs   fd 144  PIPE 0xc9aea28a590ca110   (ppid 1)
+#   bats ...                   fd 144  PIPE 0xc9aea28a590ca110
+#   bats ...                   fd 144  PIPE 0xc9aea28a590ca110
+#   bats-format-cat            fd 144  PIPE 0xc9aea28a590ca110
+
+setup() {
+  SCRIPTS="$BATS_TEST_DIRNAME/../scripts"
+  WORK="$(mktemp -d)"
+  FD_REPORT="$WORK/fds.txt"
+  export FD_REPORT
+  # Stands in for node. It reports its descriptors to a file, because command
+  # substitution rearranges descriptors itself and that is the thing being
+  # measured, and it also speaks over all three standard streams so a close that
+  # went too far shows up as silence rather than as a passing test.
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'ls /dev/fd > "$FD_REPORT" 2>/dev/null'
+    printf '%s\n' 'echo MARKER-OUT'
+    printf '%s\n' 'echo MARKER-ERR >&2'
+    printf '%s\n' 'cat > "$FD_REPORT.stdin"'
+  } > "$WORK/fake-node"
+  chmod +x "$WORK/fake-node"
+  export AGMSG_NODE="$WORK/fake-node"
+  export AGMSG_STORAGE_PATH="$WORK/store"
+  mkdir -p "$AGMSG_STORAGE_PATH"
+}
+
+teardown() {
+  [ -n "${WORK:-}" ] && rm -rf "$WORK"
+}
+
+@test "the engine does not inherit descriptors the harness opened" {
+  # 144 is the number seen in the captured hang; 77 is arbitrary, so passing
+  # cannot come from something particular about 144. A closed descriptor is not
+  # reissued at its old number -- reuse takes the lowest free one -- so absence
+  # here is meaningful.
+  bash "$SCRIPTS/remote-sync.sh" probe 144>/dev/null 77>/dev/null \
+    </dev/null >/dev/null 2>/dev/null || true
+
+  # That the stand-in ran at all: with an empty report every "absent" assertion
+  # below would hold for the wrong reason.
+  [ -s "$FD_REPORT" ]
+
+  run grep -qx 144 "$FD_REPORT"
+  [ "$status" -ne 0 ]
+  run grep -qx 77 "$FD_REPORT"
+  [ "$status" -ne 0 ]
+}
+
+@test "the three standard streams still reach the engine" {
+  # The close is by range above stderr, and this is what stops that range from
+  # creeping downwards. Asserted by using the streams, not by listing them: a
+  # closed 0/1/2 is immediately reissued to whatever opens next, so a listing
+  # shows all three either way and cannot tell the two cases apart. An earlier
+  # revision of this file asserted exactly that and passed while the code
+  # closed all three.
+  printf 'ping\n' | bash "$SCRIPTS/remote-sync.sh" probe \
+    > "$WORK/out.txt" 2> "$WORK/err.txt" || true
+
+  grep -qx MARKER-OUT "$WORK/out.txt"
+  grep -qx MARKER-ERR "$WORK/err.txt"
+  grep -qx ping "$FD_REPORT.stdin"
+}

--- a/tests/test_engine_inherited_fds.bats
+++ b/tests/test_engine_inherited_fds.bats
@@ -40,22 +40,66 @@ teardown() {
   [ -n "${WORK:-}" ] && rm -rf "$WORK"
 }
 
+# Reports its OWN descriptors above stderr. A stand-in that shells out to `ls`
+# would add that child's directory descriptor to the count; this one adds
+# nothing the baseline below does not also see.
+_write_self_reporter() {
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' ': > "$FD_REPORT"'
+    printf '%s\n' 'for f in /dev/fd/*; do'
+    printf '%s\n' '  n="${f##*/}"'
+    printf '%s\n' '  case "$n" in ""|*[!0-9]*) continue ;; esac'
+    printf '%s\n' '  [ "$n" -gt 2 ] && printf "%s " "$n" >> "$FD_REPORT"'
+    printf '%s\n' 'done'
+  } > "$1"
+  chmod +x "$1"
+}
+
 @test "the engine does not inherit descriptors the harness opened" {
-  # 144 is the number seen in the captured hang; 77 is arbitrary, so passing
-  # cannot come from something particular about 144. A closed descriptor is not
-  # reissued at its old number -- reuse takes the lowest free one -- so absence
-  # here is meaningful.
-  bash "$SCRIPTS/remote-sync.sh" probe 144>/dev/null 77>/dev/null \
-    </dev/null >/dev/null 2>/dev/null || true
+  # Run under EVERY bash on this machine, because they disagree. bash 3.2 --
+  # /bin/bash on macOS, and what runs this on the macOS runner -- relocates
+  # descriptors into the range at and above 10 while processing an exec's
+  # redirections, so a close 5.x honours can come back to the child at a new
+  # number. A single-shell version of this test stayed green through exactly
+  # that regression while a CI shard hung.
+  #
+  # Compared against a BASELINE rather than against named numbers: what 3.2
+  # leaves behind is renumbered, so asserting "144 and 77 are absent" cannot
+  # see it. The baseline is the stand-in's own descriptors, measured with
+  # nothing inherited to lose; anything beyond that came through the close.
+  local reporter="$WORK/self-report"
+  _write_self_reporter "$reporter"
+  export AGMSG_NODE="$reporter"
 
-  # That the stand-in ran at all: with an empty report every "absent" assertion
-  # below would hold for the wrong reason.
-  [ -s "$FD_REPORT" ]
+  local sh found=0
+  for sh in /bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash "$(command -v bash)"; do
+    [ -x "$sh" ] || continue
+    found=$((found + 1))
 
-  run grep -qx 144 "$FD_REPORT"
-  [ "$status" -ne 0 ]
-  run grep -qx 77 "$FD_REPORT"
-  [ "$status" -ne 0 ]
+    : > "$FD_REPORT"
+    "$sh" "$SCRIPTS/remote-sync.sh" probe </dev/null >/dev/null 2>/dev/null || true
+    local baseline; baseline="$(cat "$FD_REPORT")"
+
+    # Pipes, not files: the relocation only shows up on pipes, which is what a
+    # harness holds. 143 is the shape seen in the captured hang; 10 is low and
+    # arbitrary, so a pass cannot come from something particular about 143.
+    : > "$FD_REPORT"
+    (
+      exec 143> >(sleep 20)
+      exec 10> >(sleep 20)
+      "$sh" "$SCRIPTS/remote-sync.sh" probe </dev/null >/dev/null 2>/dev/null || true
+    )
+    local measured; measured="$(cat "$FD_REPORT")"
+
+    [ -n "$baseline$measured" ] || { echo "$sh: the stand-in never ran"; false; }
+    [ "$baseline" = "$measured" ] || {
+      echo "$sh ($("$sh" --version 2>/dev/null | head -1))"
+      echo "  baseline [$baseline]  measured [$measured]"
+      false
+    }
+  done
+  [ "$found" -gt 0 ]
 }
 
 @test "the three standard streams still reach the engine" {


### PR DESCRIPTION
Shards have been reporting every test `ok` and then sitting silent until the job's 25-minute cap. Three explanations were tried and each was refuted by observation. This one was not guessed — it was photographed.

## What was holding the job open

From `#566`'s diagnostics, taken while a macOS shard was hung, after 262/262 `ok`:

```
pid 5798   node .../scripts/internal/remote-sync.mjs          (ppid 1)
           fd 144  PIPE 0xc9aea28a590ca110  (65536)

pid 62112  bats --print-output-on-failure tests/test_remote.bats ...
           fd 144  PIPE 0xc9aea28a590ca110
pid 62135  bats ...
           fd 144  PIPE 0xc9aea28a590ca110
pid 62136  bats-format-cat
           fd 144  PIPE 0xc9aea28a590ca110
```

A surviving sync engine holding the same pipe as bats, at the same descriptor. bats had not exited — all three of its processes were alive, waiting for an EOF that could not arrive while the engine held the write end.

Two things follow, and they explain the two fixes that did not work:

- **`ppid 1`.** The engine had already been reparented, so no teardown reaching for a pidfile could have caught it. That is why `#559`'s teardown fix did not stop this.
- **`fd 144`.** Not 3, not 4. The engine's spawn site already closed 3 and 4 by name. A descriptor whose number the harness picks cannot be closed by naming it, which is why yesterday's uniform `3>&- 4>&-` rule did not stop this either.

## The change

Close everything above stderr at the engine's own entry, by range rather than by name, enumerated from `/dev/fd` where it exists and swept otherwise. It lives at the entry, not at the spawn sites, so it covers every way the engine is started rather than each one separately.

The engine speaks only over stdin, stdout and stderr, and the spawn sites already point those at a log.

The closes are attached to the `exec` rather than performed before it:

```sh
eval "exec$_fd_closes \"\$NODE_BIN\" \"\$SCRIPT_DIR/internal/remote-sync.mjs\" \"\$@\""
```

One descriptor above stderr belongs to the shell — bash holds the script it is reading at 255, and an enumeration cannot tell that one from a descriptor bats left open. Closing it from a statement would leave the shell reading the rest of its own script through a descriptor it had just given up. As a redirection on the `exec` the question does not arise: the redirections are applied and the `execve` follows, with no statement of this script in between.

Bash does defend against the statement form, as it turns out. Given `exec 255>&-` it moves the script to another number — observed as 11 under both **3.2.57** (macOS `/bin/bash`) and **5.3.15** — and a script padded to 291 KB, far past any read buffer, still ran to its last line under both. The hazard was right in shape and did not bite. Attaching the closes to the `exec` retires it rather than resting on that defence.

That is also why no test is added for it. A regression exercising a long script **passes against the statement form too**, so it could only ever be green; the measurement above is the evidence instead.

**This supersedes the norm added in `#565`.** That change made `3>&- 4>&-` uniform across `scripts/` and enforced it with a test; the norm was right in shape and too narrow in reach. The history is recorded in the commit body so it lives in one place.

## Tests

Two, and each fails for a different mistake:

| mutation | test 1 (no inherited fds) | test 2 (streams work) |
|---|---|---|
| remove the close | **fails** | passes |
| let the range reach 0/1/2 | passes | **fails** |

Test 2 asserts by *using* the streams — a marker on stdout, one on stderr, a line through stdin — rather than listing them. A closed 0/1/2 is immediately reissued to whatever opens next, so a listing shows all three either way. An earlier draft asserted exactly that and passed while the code closed all three; that draft is why the mutation table above exists.

Locally: the descriptors reaching the engine are `0 1 2` with this change and `0 1 144 2 3 4 77` without it.

## What this does not establish

That it ends the hangs. The mechanism is captured and the fix demonstrably closes it, but whether these shards stop hanging is three consecutive clean runs of the affected shard, not this description.

## Unrelated, found on the way

`connect: a keyed team fails closed when the remote disallows age-v1` in `test_remote.bats` fails on `integration/remote` itself, with or without this change — but only where `age` is installed. CI skips it (`# skip age/age-keygen not installed`), so CI has never run it. Reported separately; not touched here.

