### PR TITLE
refactor(drivers): rename the layout axis to partition

### DIFF
--- a/app/src-tauri/src/agmsg.rs
+++ b/app/src-tauri/src/agmsg.rs
@@ -357,10 +357,10 @@ fn open_ro(path: &std::path::Path) -> Result<rusqlite::Connection, String> {
 /// Every distinct store behind the teams this install knows about.
 ///
 /// Deduplicated by path, which is what makes one function serve both
-/// layouts: under a shared store every team resolves to the same file and
+/// partitions: under a shared store every team resolves to the same file and
 /// this yields one connection — today's behaviour exactly — while under
 /// per-team stores it yields one per team. The app does not branch on the
-/// layout because it does not need to know it.
+/// partition because it does not need to know it.
 ///
 /// Teams whose driver the app cannot read directly are absent here; their
 /// messages arrive through `api.sh` like everyone's history does.
@@ -1386,7 +1386,7 @@ mod tests {
     fn the_store_path_comes_from_agmsg_not_from_a_guess() {
         let _base = fake_base(&[(
             "api.sh",
-            r#"echo '{"team":"alpha","driver":"sqlite","layout":"per-team","path":"/somewhere/else/alpha.db","exists":true}'"#,
+            r#"echo '{"team":"alpha","driver":"sqlite","partition":"per-team","path":"/somewhere/else/alpha.db","exists":true}'"#,
         )]);
         assert_eq!(
             super::direct_store_path("alpha"),
@@ -1404,7 +1404,7 @@ mod tests {
     fn an_unreadable_driver_falls_back_rather_than_showing_an_empty_room() {
         let _base = fake_base(&[(
             "api.sh",
-            r#"echo '{"team":"alpha","driver":"jsonl","layout":"per-team","path":"/x/a.jsonl","exists":true}'"#,
+            r#"echo '{"team":"alpha","driver":"jsonl","partition":"per-team","path":"/x/a.jsonl","exists":true}'"#,
         )]);
         assert_eq!(
             super::direct_store_path("alpha"),
@@ -1427,7 +1427,7 @@ mod tests {
             "api.sh",
             r#"
 if [ "$4" = "store" ]; then
-  echo '{"team":"alpha","driver":"jsonl","layout":"per-team","path":"/x/a.jsonl","exists":true}'
+  echo '{"team":"alpha","driver":"jsonl","partition":"per-team","path":"/x/a.jsonl","exists":true}'
   exit 0
 fi
 echo '{"type":"message_sent","id":"m1","team":"alpha","from":"a","to":"b","body":"first","at":"t1"}'
@@ -1461,7 +1461,7 @@ echo '{"type":"message_sent","id":"m2","team":"alpha","from":"a","to":"b","body"
     fn a_team_with_no_store_yet_is_not_an_error() {
         let _base = fake_base(&[(
             "api.sh",
-            r#"echo '{"team":"alpha","driver":"sqlite","layout":"shared","path":"/x/db.sqlite","exists":false}'"#,
+            r#"echo '{"team":"alpha","driver":"sqlite","partition":"shared","path":"/x/db.sqlite","exists":false}'"#,
         )]);
         assert_eq!(super::direct_store_path("alpha"), None);
     }

--- a/install.sh
+++ b/install.sh
@@ -414,7 +414,7 @@ fi
 # live: programs outside agmsg read the shared store directly, and an install
 # that relocated their data would break them without anything saying so. A team
 # moves to its own store only when connecting requires it, and only that team —
-# see scripts/drivers/layout/ and internal/migrate-team-store.sh.
+# see scripts/drivers/partition/ and internal/migrate-team-store.sh.
 
 # Initialize config
 if [ ! -f "$SKILL_DIR/db/config.yaml" ]; then

--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -80,17 +80,17 @@ get_teams() {
 # database; a consumer that opens it with a SQLite client gets nonsense. Check
 # it before reading, and treat an unfamiliar value as "do not read this".
 get_store() {
-  local team="$1" path driver layout exists
+  local team="$1" path driver partition exists
   path="$(agmsg_db_path "$team")" || return 1
   driver="$(agmsg_storage_driver)"
-  layout="$(agmsg_driver_for_team layout "$team" shared)"
+  partition="$(agmsg_driver_for_team partition "$team" shared)"
   # json(...) so the field is a JSON boolean; a bare 1/0 reads as a number and a
   # consumer testing `=== true` would silently take the wrong branch.
   if [ -e "$path" ]; then exists="json('true')"; else exists="json('false')"; fi
   agmsg_sqlite_mem "SELECT json_object(
     'team', '$(agmsg_sqlesc "$team")',
     'driver', '$(agmsg_sqlesc "$driver")',
-    'layout', '$(agmsg_sqlesc "$layout")',
+    'partition', '$(agmsg_sqlesc "$partition")',
     'path', '$(agmsg_sqlesc "$path")',
     'exists', $exists
   );"

--- a/scripts/drivers/partition/per-team.sh
+++ b/scripts/drivers/partition/per-team.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# layout/per-team — the team owns its own store at teams/<team>/messages.db.
+# partition/per-team — the team owns its own store at teams/<team>/messages.db.
 #
 # A team moves here when connecting to a remote, and not before. The reason is
 # not tidiness: a connected team's rows carry ids where a local team's carry
@@ -10,10 +10,10 @@
 # That is the trade connecting makes, and it is why the move is per team rather
 # than per install.
 #
-# Contract (axis = layout): echo the store path RELATIVE to the storage dir.
+# Contract (axis = partition): echo the store path RELATIVE to the storage dir.
 # The facade joins it and handles the Windows path form.
 
-layout_store_relpath() {
+partition_store_relpath() {
   # The caller validates the team as a path segment before reaching here; this
   # driver would otherwise be the place a '..' escapes the storage tree.
   printf 'teams/%s/messages.db\n' "$1"

--- a/scripts/drivers/partition/shared.sh
+++ b/scripts/drivers/partition/shared.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-# layout/shared — one store holds every team. The default, and the layout the
+# partition/shared — one store holds every team. The default, and the partition the
 # database has always had.
 #
-# This is the layout that external programs read. Several open the store
+# This is the partition that external programs read. Several open the store
 # directly rather than going through agmsg, and they find their messages by
 # filtering on the `team` column of one file. Moving a team out of here breaks
 # every one of them for that team, silently, because the old path still resolves
-# to a real database. That is why nothing leaves this layout by default.
+# to a real database. That is why nothing leaves this partition by default.
 #
-# Contract (axis = layout): echo the store path RELATIVE to the storage dir.
+# Contract (axis = partition): echo the store path RELATIVE to the storage dir.
 # The facade joins it and handles the Windows path form.
 
-layout_store_relpath() {
+partition_store_relpath() {
   # Takes the team for signature parity with per-team; deliberately ignores it.
   printf 'messages.db\n'
 }

--- a/scripts/internal/migrate-team-store.sh
+++ b/scripts/internal/migrate-team-store.sh
@@ -8,7 +8,7 @@
 # store, which is what every external reader of the database depends on.
 #
 # It COPIES. The shared store keeps its rows, so a migration that goes wrong
-# costs nothing but disk — delete the per-team store, clear the layout field,
+# costs nothing but disk — delete the per-team store, clear the partition field,
 # and the team is back where it was. Reclaiming the copied rows is a separate,
 # later decision that wants confidence this one does not.
 
@@ -29,7 +29,7 @@ source "$SCRIPT_DIR/../lib/storage.sh"
 source "$SCRIPT_DIR/../lib/validate.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/../lib/registry-lock.sh"
-# The layout lookup lives here; storage.sh only pulls it in lazily.
+# The partition lookup lives here; storage.sh only pulls it in lazily.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/../lib/driver-registry.sh"
 
@@ -43,7 +43,7 @@ DEST="$(agmsg_storage_dir)/teams/$TEAM/messages.db"
 
 # Drop the team's rows from the shared store. Runs after the copy is verified,
 # and again on re-entry, which is what makes a crashed migration recoverable:
-# the layout is recorded before this, so an interrupted run leaves rows in both
+# the partition is recorded before this, so an interrupted run leaves rows in both
 # stores — readable, but stale in the one external programs watch.
 _drop_from_shared() {
   local lit; lit="$(agmsg_sqlesc "$TEAM")"
@@ -62,9 +62,9 @@ src_tables="$(agmsg_sqlite "$SHARED" \
   "SELECT name FROM sqlite_master WHERE type='table';" 2>/dev/null || true)"
 has_table() { printf '%s\n' "$src_tables" | grep -qx "$1"; }
 
-if [ "$(agmsg_driver_for_team layout "$TEAM" shared)" = per-team ]; then
+if [ "$(agmsg_driver_for_team partition "$TEAM" shared)" = per-team ]; then
   # Already moved. Finish the job if a previous run died between recording the
-  # layout and clearing the shared copy — otherwise external readers keep seeing
+  # partition and clearing the shared copy — otherwise external readers keep seeing
   # this team's history frozen at the moment it moved, which looks like nothing
   # is wrong.
   _drop_from_shared
@@ -149,7 +149,7 @@ done
 # resolves to the shared store, so everything above is a copy nothing reads.
 agmsg_lock_acquire "$CONNECTION_ROOT/teams/$TEAM" || exit 1
 updated="$(agmsg_sqlite_mem "SELECT json_set(CAST(readfile('$(agmsg_sql_readfile_path "$CONFIG")') AS TEXT),
-  '\$.drivers.layout', 'per-team');")"
+  '\$.drivers.partition', 'per-team');")"
 agmsg_write_atomic "$CONFIG" "$updated"
 agmsg_lock_release
 

--- a/scripts/lib/driver-registry.sh
+++ b/scripts/lib/driver-registry.sh
@@ -90,7 +90,7 @@ agmsg_driver_untrust() {
 # Which driver a TEAM uses on <axis>, falling back to <default>.
 #
 # Teams choose independently: one team can sit on a per-team store while its
-# neighbour is still in the shared one. That is the point — the shared layout is
+# neighbour is still in the shared one. That is the point — the shared partition is
 # what every external reader of the database depends on, so a team only leaves
 # it when something (today: connecting to a remote) actually requires it.
 #

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -73,11 +73,11 @@ agmsg_storage_dir() {
 #
 # Echo the full path to a team's message store, in a form sqlite3 can open.
 #
-# WHICH store depends on the team's layout driver, and teams choose separately:
+# WHICH store depends on the team's partition driver, and teams choose separately:
 # `shared` (the default) puts every team in one file, `per-team` gives the team
 # its own. A team only leaves the default when connecting requires it, because
 # external programs read the shared store directly and lose sight of any team
-# that moves out. See scripts/drivers/layout/.
+# that moves out. See scripts/drivers/partition/.
 #
 # The argument is required rather than optional on purpose. An optional one
 # leaves two ways to reach the store, and a caller that forgot the selector
@@ -93,15 +93,15 @@ agmsg_db_path() {
     return 1
   fi
   agmsg_validate_team_name "$team" || return 1
-  _agmsg_layout_load "$team" || return 1
-  _agmsg_db_file "$(layout_store_relpath "$team")"
+  _agmsg_partition_load "$team" || return 1
+  _agmsg_db_file "$(partition_store_relpath "$team")"
 }
 
-# Source the layout driver this team uses, memoized so repeated resolution in
+# Source the partition driver this team uses, memoized so repeated resolution in
 # one process costs nothing. Re-sources when a caller moves between teams on
-# different layouts — watch.sh loops over a subscription that can contain both.
-_AGMSG_LAYOUT_LOADED=""
-_agmsg_layout_load() {
+# different partitions — watch.sh loops over a subscription that can contain both.
+_AGMSG_PARTITION_LOADED=""
+_agmsg_partition_load() {
   # The registry may not be sourced yet — agmsg_db_path is reachable without
   # going through agmsg_storage_load. Same guarded pull-in that uses.
   if ! command -v agmsg_driver_for_team >/dev/null 2>&1; then
@@ -111,15 +111,15 @@ _agmsg_layout_load() {
     [ -n "$_lib" ] && . "$_lib/driver-registry.sh"
   fi
   local name
-  name="$(agmsg_driver_for_team layout "$1" shared)"
-  [ "$name" = "$_AGMSG_LAYOUT_LOADED" ] && return 0
+  name="$(agmsg_driver_for_team partition "$1" shared)"
+  [ "$name" = "$_AGMSG_PARTITION_LOADED" ] && return 0
   local base kind file found=""
   while IFS="$(printf '\t')" read -r kind base; do
     [ -n "$base" ] || continue
-    file="$base/layout/$name.sh"
+    file="$base/partition/$name.sh"
     [ -f "$file" ] || continue
     # Externals stay gated by the same opt-in every other axis uses.
-    if [ "$kind" = external ] && ! agmsg_driver_is_trusted layout "$name" "$file"; then
+    if [ "$kind" = external ] && ! agmsg_driver_is_trusted partition "$name" "$file"; then
       continue
     fi
     found="$file"
@@ -127,15 +127,15 @@ _agmsg_layout_load() {
 $(agmsg_driver_bases)
 EOF
   if [ -z "$found" ]; then
-    # Loud rather than falling back to shared: a team recorded a layout, and
+    # Loud rather than falling back to shared: a team recorded a partition, and
     # quietly reading a different store than the one it names is the exact
     # failure this axis exists to make impossible.
-    echo "Error: no layout driver '$name' for team '$1'" >&2
+    echo "Error: no partition driver '$name' for team '$1'" >&2
     return 1
   fi
   # shellcheck disable=SC1090
   . "$found" || return 1
-  _AGMSG_LAYOUT_LOADED="$name"
+  _AGMSG_PARTITION_LOADED="$name"
 }
 
 # The store that is NOT team-scoped, and the only resolver allowed to take no

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -818,7 +818,7 @@ _remote_write_pulled_team() {
       SELECT json_object('name','$(_agmsg_sqlesc "$team")',
                          'team_id','$(_agmsg_sqlesc "$team_id")',
                          'agents', json_object(),
-                         'drivers', json_object('layout', 'per-team'),
+                         'drivers', json_object('partition', 'per-team'),
                          'created_at','$(date -u +%Y-%m-%dT%H:%M:%SZ)');")
     agmsg_write_atomic "$cfg" "$initial"
   fi
@@ -1894,7 +1894,7 @@ cmd_forget() {
   fi
 
   # A successful remote connection owns this exact directory. Never resolve
-  # through agmsg_db_path here: a malformed or interrupted layout selection
+  # through agmsg_db_path here: a malformed or interrupted partition selection
   # must not turn a team-scoped delete into deletion of the shared store.
   local store_dir store_path event_count=0 tables
   store_dir="$(agmsg_storage_dir)/teams/$team"

--- a/scripts/rename-team.sh
+++ b/scripts/rename-team.sh
@@ -33,11 +33,11 @@ agmsg_validate_team_name "$NEW_TEAM" || exit 1
 TEAMS_DIR="$SCRIPT_DIR/../teams"
 OLD_DIR="$TEAMS_DIR/$OLD_TEAM"
 NEW_DIR="$TEAMS_DIR/$NEW_TEAM"
-# Only a team on the per-team layout owns a directory to move. On the shared
-# layout its rows sit in a file with every other team's, so renaming rewrites
+# Only a team on the per-team partition owns a directory to move. On the shared
+# partition its rows sit in a file with every other team's, so renaming rewrites
 # the `team` column and moves nothing — which is what this script always did.
 MOVES_STORE=false
-if [ "$(agmsg_driver_for_team layout "$OLD_TEAM" shared)" = per-team ]; then
+if [ "$(agmsg_driver_for_team partition "$OLD_TEAM" shared)" = per-team ]; then
   MOVES_STORE=true
   # The store lives under the storage root, which AGMSG_STORAGE_PATH can move
   # independently of the config tree above — so it is resolved, never derived
@@ -105,7 +105,7 @@ fi
 
 # Move the store with it, when the team has one of its own. A team that never
 # sent anything has no store yet, which is not an error — the next send creates
-# one under the new name. On the shared layout there is nothing to move and DB
+# one under the new name. On the shared partition there is nothing to move and DB
 # already names the file both names resolve to.
 if [ "$MOVES_STORE" = true ] && [ -d "$OLD_STORE_DIR" ]; then
   mkdir -p "$(dirname "$NEW_STORE_DIR")"

--- a/server/test/sync-client.integration.test.ts
+++ b/server/test/sync-client.integration.test.ts
@@ -127,8 +127,8 @@ storage_init "$2" >/dev/null`;
     await rm(root, { recursive: true });
   });
 
-  // Where a team's rows live depends on its layout driver. These teams are on
-  // the default `shared` layout — nothing here connects through a path that
+  // Where a team's rows live depends on its partition driver. These teams are on
+  // the default `shared` partition — nothing here connects through a path that
   // moves them — so this is the one store, the same file the client writes.
   // A team that had moved would answer differently, which is why this asks
   // rather than spelling the path out at each call site.
@@ -160,7 +160,7 @@ storage_init "$2" >/dev/null`;
   }
 
   async function localSend(store: string, from: string, to: string, body: string, team = localTeam) {
-    // storage_init takes the team even on the shared layout: which store to
+    // storage_init takes the team even on the shared partition: which store to
     // initialize is a question about a team, and calling it without one reaches
     // the resolver with an empty selector and fails under set -u.
     const script = `. "$1/scripts/lib/storage.sh"

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -97,9 +97,9 @@ shared_rows() {
 }
 
 @test "migrate: a moved team can still be renamed, and its store follows" {
-  # Renaming a shared-layout team rewrites a column; renaming a moved one has to
+  # Renaming a shared-partition team rewrites a column; renaming a moved one has to
   # move a directory as well. Only the second path exists after a migration, so
-  # it is covered here rather than beside the shared-layout rename tests.
+  # it is covered here rather than beside the shared-partition rename tests.
   bash "$SCRIPTS/send.sh" alpha ann bob "carried across" >/dev/null
   migrate alpha
   [ -e "$TEST_SKILL_DIR/db/teams/alpha/messages.db" ]

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -737,9 +737,9 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   [ -f "$cfg" ]
   # Not minted here: the id is the one the server answered with.
   [ "$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.team_id');")" = "$PULL_TEAM_ID" ]
-  [ "$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.drivers.layout');")" = "per-team" ]
+  [ "$(sqlite_mem "SELECT json_extract(readfile('$(rf "$cfg")'), '\$.drivers.partition');")" = "per-team" ]
   [ -f "$TEST_SKILL_DIR/db/teams/cloned/messages.db" ]
-  # Pull arrives into an empty local team, so it can select the isolated layout
+  # Pull arrives into an empty local team, so it can select the isolated partition
   # before bootstrap. Imported remote rows must never leak into the shared
   # store that local-only teams and external readers still use.
   if sqlite3 "$TEST_SKILL_DIR/db/messages.db" \

--- a/tests/test_remote_forget.bats
+++ b/tests/test_remote_forget.bats
@@ -13,7 +13,7 @@ setup() {
   escaped="$(sed "s/'/''/g" "$cfg")"
   updated="$(sqlite_mem "
     SELECT json_set('$escaped',
-      '\$.drivers.layout', 'per-team',
+      '\$.drivers.partition', 'per-team',
       '\$.remote_binding', json_object(
         'endpoint', 'https://remote.example',
         'server_instance_id', '$SERVER_ID',

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -233,7 +233,7 @@ SH
   [ "$(wc -l < "$count" | tr -d ' ')" -eq 5 ]
 }
 
-# --- storage layout axis -----------------------------------------------------
+# --- storage partition axis -----------------------------------------------------
 #
 # Which store a team uses is a per-team driver choice. `shared` is the default
 # and is what programs outside agmsg read; `per-team` is what a team moves to
@@ -241,11 +241,11 @@ SH
 # team in one file, unchanged from before the axis existed) and the isolation a
 # moved team gets.
 
-# Put <team> on the per-team layout the way migrate-team-store.sh does, without
+# Put <team> on the per-team partition the way migrate-team-store.sh does, without
 # copying anything: these tests are about resolution, not migration.
 _use_per_team() {
   mkdir -p "$TEST_SKILL_DIR/teams/$1"
-  printf '{"name":"%s","drivers":{"layout":"per-team"}}\n' "$1" \
+  printf '{"name":"%s","drivers":{"partition":"per-team"}}\n' "$1" \
     > "$TEST_SKILL_DIR/teams/$1/config.json"
 }
 
@@ -253,14 +253,14 @@ _use_per_team() {
   export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/db" SKILL_DIR="$TEST_SKILL_DIR"
   # shellcheck disable=SC1091
   source "$SCRIPTS/lib/storage.sh"
-  # The layout external readers depend on. A team must not leave it by merely
+  # The partition external readers depend on. A team must not leave it by merely
   # existing — only by something that requires the move.
   [ "$(agmsg_db_path alpha)" = "$BATS_TEST_TMPDIR/db/messages.db" ]
   [ "$(agmsg_db_path bravo)" = "$BATS_TEST_TMPDIR/db/messages.db" ]
   [ "$(agmsg_db_path alpha)" = "$(_agmsg_runtime_db_path)" ]
 }
 
-@test "storage: a team on the per-team layout moves, and only that team" {
+@test "storage: a team on the per-team partition moves, and only that team" {
   export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/db" SKILL_DIR="$TEST_SKILL_DIR"
   # shellcheck disable=SC1091
   source "$SCRIPTS/lib/storage.sh"
@@ -272,12 +272,12 @@ _use_per_team() {
   [ "$(agmsg_db_path alpha)" = "$BATS_TEST_TMPDIR/db/teams/alpha/messages.db" ]
 }
 
-@test "storage: an unknown layout is an error, not a fallback" {
+@test "storage: an unknown partition is an error, not a fallback" {
   export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/db" SKILL_DIR="$TEST_SKILL_DIR"
   # shellcheck disable=SC1091
   source "$SCRIPTS/lib/storage.sh"
   mkdir -p "$TEST_SKILL_DIR/teams/gamma"
-  printf '{"name":"gamma","drivers":{"layout":"nope"}}\n' \
+  printf '{"name":"gamma","drivers":{"partition":"nope"}}\n' \
     > "$TEST_SKILL_DIR/teams/gamma/config.json"
   run agmsg_db_path gamma
   [ "$status" -ne 0 ]

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -438,9 +438,9 @@ EOF
   _sqlite_sync_schema oldteam
   local generation db renamed_db store_dir
   generation=$(_sqlite_sync_generation oldteam)
-  # This team is on the default shared layout, so both names resolve to the same
+  # This team is on the default shared partition, so both names resolve to the same
   # file and the rename rewrites columns rather than moving anything. A team that
-  # owns its store is covered separately, in the layout tests.
+  # owns its store is covered separately, in the partition tests.
   db=$(agmsg_db_path oldteam)
   renamed_db="$db"
   store_dir=$(agmsg_storage_dir)


### PR DESCRIPTION
Renames the driver axis `layout` to `partition` on `integration/remote`.

`shared` and `per-team` answer how the store is divided, and that is all the axis decides. "layout" covers that and much else — the word is already in this tree for tmux panes, on-disk transcript shapes, screen copy, and install structure — so an axis named after it reads as any of them.

Hard rename, no compatibility shim: `integration/remote` is unreleased, so nothing in the wild is keyed on the old name.

## What changed

The driver directory (`scripts/drivers/layout/` → `scripts/drivers/partition/`), the `drivers.partition` config key, the axis argument passed to the registry, `partition_store_relpath` and the load helper, and the prose describing the axis.

`scripts/lib/driver-registry.sh` needed nothing structural — it takes the axis as a parameter and never named this one. Only a sentence of prose there mentioned the axis by name.

## Finding the sites took four passes, and that is the interesting part

A single grep would have got this wrong in both directions.

1. Path, config-key, and function-prefix greps — seven files.
2. Reading the loader rather than grepping it added two more: `api.sh` and `rename-team.sh` pass the axis as a bare word (`agmsg_driver_for_team layout …`), which no `layout_`-prefix pattern matches.
3. A full-tree sweep then found a JSON literal in `remote.sh` (`json_object('layout', 'per-team')`) and several tests that spell the key inline as `"drivers":{"layout":…}` — neither matches `drivers.layout`.
4. The bare word `layout` matches 49 files, nearly all of them unrelated. Those were classified by reading, not replaced.

Every remaining `layout` under `scripts/`, `tests/`, and `server/` is the ordinary word: tmux panes, CLI-internal transcript shapes, a pre-1.1.0 install structure, field counts.

## Tests

`bats tests/test_storage.bats tests/test_migrate_team_store.bats tests/test_team.bats tests/test_remote.bats tests/test_remote_forget.bats` — 186/187.

The one failure, `connect: a keyed team fails closed when the remote disallows age-v1`, **is not from this change**: it fails identically on unmodified `integration/remote`. Verified by running it on a clean worktree of the base before concluding that.

The axis's own tests pass, including `a team on the per-team partition moves, and only that team` and `an unknown partition is an error, not a fallback`.

## After landing

Local dogfood installs carry `drivers.layout` in their team config and need a forget-and-pull or a reinstall to pick up the new key.
