### PR TITLE
fix(codex): probe the app-server with the local-pid helper, not the tasklist one (#567)

### DIFF
--- a/scripts/drivers/types/codex/codex-monitor.sh
+++ b/scripts/drivers/types/codex/codex-monitor.sh
@@ -175,15 +175,14 @@ if [ -z "$PORT" ]; then
     # `app-server --listen ws://`): no point burning the full timeout before we
     # fail open.
     #
-    # `kill -0`, deliberately, and not the shared _agmsg_pid_alive: this pid is
-    # our OWN background child, taken from $! in this shell, so it is numbered in
-    # the MSYS pid space. Under MSYSTEM the shared helper answers from `tasklist`,
-    # which knows Windows pids only -- it cannot see this one, reports it dead on
-    # the first iteration, and every Windows launch falls back to plain codex with
-    # no bridge (#567). The helper is right for a pid that came from outside this
-    # shell; it is wrong for a pid this shell just minted. Do not re-unify this
-    # call site without settling which pid space the value belongs to.
-    kill -0 "$server_bg" 2>/dev/null || break
+    # _local, deliberately: this pid came from $! in this shell, so it is numbered
+    # in the MSYS pid space, and `tasklist` -- which is what the plain helper asks
+    # under MSYSTEM -- has no record of it. It answered "dead" on the first pass
+    # here, seconds before the banner, and every Windows launch since 1.1.12 fell
+    # back to plain codex with no bridge (#567). Not a bare `kill -0` either: the
+    # EPERM reading still has to hold, or a sandbox that cannot signal our own
+    # child fails us open the same way (#505).
+    _agmsg_pid_alive_local "$server_bg" || break
     sleep 0.1
   done
   if [ -z "$PORT" ]; then

--- a/scripts/drivers/types/codex/codex-monitor.sh
+++ b/scripts/drivers/types/codex/codex-monitor.sh
@@ -174,7 +174,16 @@ if [ -z "$PORT" ]; then
     # Stop waiting the moment the app-server exits (e.g. a codex release dropped
     # `app-server --listen ws://`): no point burning the full timeout before we
     # fail open.
-    _agmsg_pid_alive "$server_bg" || break
+    #
+    # `kill -0`, deliberately, and not the shared _agmsg_pid_alive: this pid is
+    # our OWN background child, taken from $! in this shell, so it is numbered in
+    # the MSYS pid space. Under MSYSTEM the shared helper answers from `tasklist`,
+    # which knows Windows pids only -- it cannot see this one, reports it dead on
+    # the first iteration, and every Windows launch falls back to plain codex with
+    # no bridge (#567). The helper is right for a pid that came from outside this
+    # shell; it is wrong for a pid this shell just minted. Do not re-unify this
+    # call site without settling which pid space the value belongs to.
+    kill -0 "$server_bg" 2>/dev/null || break
     sleep 0.1
   done
   if [ -z "$PORT" ]; then

--- a/scripts/drivers/types/codex/codex-monitor.sh
+++ b/scripts/drivers/types/codex/codex-monitor.sh
@@ -124,8 +124,14 @@ if [ -f "$PORT_FILE" ] && [ -f "$SERVER_PID" ]; then
   # Reuse only when OUR recorded app-server is still alive AND its port answers,
   # so a foreign process that grabbed the same port after ours died is not
   # mistaken for the bridge app-server.
+  #
+  # _local for the same reason as the wait loop below: this file records $! (see
+  # the `> "$SERVER_PID"` further down), and reading it back through a pidfile
+  # does not move the number into the Windows pid space. Asking tasklist about it
+  # never matches, so a live app-server reads as dead and every launch starts
+  # another one beside it.
   if [ -n "$existing_port" ] && [ -n "$existing_pid" ] \
-    && _agmsg_pid_alive "$existing_pid" && port_alive "$existing_port"; then
+    && _agmsg_pid_alive_local "$existing_pid" && port_alive "$existing_port"; then
     # Confirm the recorded pid is actually OUR codex app-server before trusting OR
     # killing it: a recycled pid could belong to an unrelated process while the
     # recorded port happens to answer via something else. Only reuse/kill when the

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -63,9 +63,18 @@ _AGMSG_INSTANCE_ID_SH=1
 # Split out from _agmsg_pid_alive so a caller that kills a recorded pid WITHOUT
 # asking about liveness first can still refuse the values that do not name one
 # process.
+# A ceiling may be passed as $2 to override the platform's. Which one is right is
+# a property of what the value will be USED for, not of the host -- see the call
+# in _agmsg_pid_alive_local, which hands the value to kill(1) even on Windows.
 _agmsg_pid_valid() {
-  local pid="${1:-}" max=2147483647
+  local pid="${1:-}" max="${2:-}"
   case "$pid" in ''|*[!0-9]*|0*) return 1 ;; esac
+  if [ -n "$max" ]; then
+    [ "${#pid}" -le 10 ] || return 1
+    if [ "${#pid}" -eq 10 ] && [ "$pid" \> "$max" ]; then return 1; fi
+    return 0
+  fi
+  max=2147483647
   # The upper bound is the platform's, not one number. A Windows process id is a
   # DWORD, and the liveness path there queries the native process table via
   # tasklist rather than kill(1)'s signed pid_t — applying the POSIX bound to it
@@ -102,7 +111,13 @@ _agmsg_pid_valid() {
 # a pid we minted is still a pid a sandbox may refuse to let us signal (#505).
 _agmsg_pid_alive_local() {
   local pid="$1" err stat
-  _agmsg_pid_valid "$pid" || return 1
+  # The POSIX ceiling, explicitly, whatever the host. _agmsg_pid_valid widens to
+  # the DWORD range when MSYSTEM is set, which is right for a number tasklist
+  # will be asked about and wrong for one kill(1) will parse: past INT32_MAX kill
+  # rejects the ARGUMENT rather than reporting ESRCH, and everything below that
+  # is not ESRCH reads as alive. Inheriting the wide ceiling here would put an
+  # oversized pidfile value back to alive forever -- the shape #505 closed.
+  _agmsg_pid_valid "$pid" 2147483647 || return 1
   # Fast path, and the common answer: the builtin, no fork. Callers poll this in
   # loops whose whole point is to be fork-free (#466), so the alive case must
   # not cost a subshell.

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -89,15 +89,20 @@ _agmsg_pid_valid() {
   return 0
 }
 
-_agmsg_pid_alive() {
+# Liveness for a pid THIS codebase minted: $! or $$ in one of these shells, or
+# read back from a pidfile one of them wrote. A pidfile does not launder the pid
+# space -- the number in it is still whatever the shell that wrote it was given.
+#
+# Under Git Bash such a pid is numbered in the MSYS space, which `tasklist` does
+# not report, so the Windows branch in _agmsg_pid_alive must not run for one:
+# asking tasklist about an MSYS pid answers "dead" for a process that is running,
+# which is how every Windows codex launch lost its bridge (#567).
+#
+# The EPERM reading and the ps cross-check are the same as _agmsg_pid_alive's --
+# a pid we minted is still a pid a sandbox may refuse to let us signal (#505).
+_agmsg_pid_alive_local() {
   local pid="$1" err stat
   _agmsg_pid_valid "$pid" || return 1
-  case "${MSYSTEM:-}" in
-    MINGW*|MSYS*|CLANGARM*)
-      MSYS_NO_PATHCONV=1 tasklist /FI "PID eq $pid" 2>/dev/null | grep -q "$pid"
-      return $?
-      ;;
-  esac
   # Fast path, and the common answer: the builtin, no fork. Callers poll this in
   # loops whose whole point is to be fork-free (#466), so the alive case must
   # not cost a subshell.
@@ -116,6 +121,25 @@ _agmsg_pid_alive() {
   [ -n "$stat" ] || return 1
   case "$stat" in Z*) return 1 ;; esac   # exited, just not reaped yet
   return 0
+}
+
+# Liveness for a pid that came from OUTSIDE these shells -- reached by walking
+# ancestors until the walk leaves the MSYS subsystem, so under Git Bash the
+# number is a Windows pid and kill(1) there cannot see it at all (#134).
+#
+# Which of the two applies is decided by where the pid was minted, not by whether
+# it arrived through a pidfile. For anything $! or $$ produced, and anything read
+# back from a pidfile one of these shells wrote, use _agmsg_pid_alive_local.
+_agmsg_pid_alive() {
+  local pid="$1"
+  _agmsg_pid_valid "$pid" || return 1
+  case "${MSYSTEM:-}" in
+    MINGW*|MSYS*|CLANGARM*)
+      MSYS_NO_PATHCONV=1 tasklist /FI "PID eq $pid" 2>/dev/null | grep -q "$pid"
+      return $?
+      ;;
+  esac
+  _agmsg_pid_alive_local "$pid"
 }
 
 # Compose from an explicit pid. Bare sid when pid is empty/non-numeric.

--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -224,71 +224,70 @@ while True:
   kill "$foreign_pid" 2>/dev/null || true
 }
 
-# --- MSYS pid space (#567) ---
+
+# --- which pid space (#567) ---
+#
+# Both tests below model Git Bash: MSYSTEM set, and a `tasklist` that answers as
+# the real one does for a pid it has no record of -- nothing. The app-server pid
+# is minted by $! in codex-monitor.sh, so it lives in the MSYS pid space and
+# tasklist never reports it; a probe that asks tasklist calls a running server
+# dead. Setting MSYSTEM does not otherwise disturb a POSIX run: compat.sh picks
+# its platform from `uname -s`, and the only other reader is a pid-range bound.
+
+# Answers nothing, like tasklist asked about a pid it does not know.
+_stub_tasklist() {
+  local dir="$1"
+  mkdir -p "$dir"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$dir/tasklist"
+  chmod +x "$dir/tasklist"
+}
 
 @test "codex-monitor: waits for the port when tasklist cannot see the app-server (#567)" {
-  skip_on_windows "stubs tasklist to model Git Bash; the real one is authoritative here"
+  skip_on_windows "stubs tasklist to model Git Bash; the real one is authoritative there"
   run node -e 'const net = require("net"); if (!net) process.exit(1);'
   if [ "$status" -ne 0 ]; then
     skip "node net module is not available in this sandbox"
   fi
 
-  # The app-server is this shell's own background child, so its pid is numbered
-  # in the MSYS pid space. `tasklist` reports Windows pids and cannot see it. A
-  # liveness probe that asks tasklist therefore calls a running app-server dead
-  # on the first iteration and the launch falls back to plain codex (#567).
-  #
-  # MSYSTEM steers the shared helper down its tasklist branch; the stub is what
-  # tasklist would say about a pid it has no record of, which is nothing. Setting
-  # MSYSTEM does not otherwise disturb a macOS run -- compat.sh picks its
-  # platform from `uname -s`, not from this variable.
   local stubdir="$TEST_PROJECT/stub-bin"
-  mkdir -p "$stubdir"
-  cat > "$stubdir/tasklist" <<'EOF'
-#!/usr/bin/env bash
-exit 0
-EOF
-  chmod +x "$stubdir/tasklist"
+  _stub_tasklist "$stubdir"
 
-  # The banner is delayed on purpose. The wait loop reads the log BEFORE it
-  # probes liveness, so an app-server that announces itself immediately breaks
-  # out on the first pass and never reaches the probe -- against which this test
-  # would pass no matter what the probe answered.
-  local slow_codex="$TEST_PROJECT/slow-codex"
-  cat > "$slow_codex" <<'EOF'
+  # Reaching the liveness probe is fixed by ORDER, not by a delay. Each pass of
+  # the wait loop reads the log with sed and only probes when that came back
+  # empty, so a server that has already announced itself breaks out on the first
+  # pass and the probe never runs -- against which this test would pass whatever
+  # the probe answered. An earlier revision leaned on a 600ms banner delay for
+  # that, which is a race: deschedule the parent past it and the seam is gone.
+  #
+  # The shim forces the first port-extracting sed to come back empty, so the
+  # first pass always reaches the probe, and hands every later call to the real
+  # sed so the second pass finds the banner. It matches on the argument rather
+  # than on being the first sed of the run: other sed calls in this script would
+  # otherwise consume the one intercept and the seam would miss silently.
+  export SED_SHIM_MARKER="$TEST_PROJECT/sed-shim-fired"
+  local real_sed; real_sed="$(command -v sed)"
+  cat > "$stubdir/sed" <<EOF
 #!/usr/bin/env bash
-case "${1:-}" in
-  --version) echo "codex-cli 0.144.1"; exit 0 ;;
-  app-server)
-    node - <<'JS' &
-const net = require('net');
-const s = net.createServer((c) => c.destroy());
-setTimeout(() => {
-  s.listen(0, '127.0.0.1', () => {
-    console.log('codex app-server (WebSockets)');
-    console.log('  listening on: ws://127.0.0.1:' + s.address().port);
-  });
-}, 600);
-setTimeout(() => process.exit(0), 60000);
-JS
-    child=$!
-    trap 'kill "$child" 2>/dev/null' TERM INT
-    wait "$child" 2>/dev/null || wait "$child" 2>/dev/null
-    ;;
-  *)
-    printf 'plain-codex' >> "$CALL_LOG"
-    for a in "$@"; do printf ' <%s>' "$a" >> "$CALL_LOG"; done
-    printf '\n' >> "$CALL_LOG"
+case "\$*" in
+  *"listening on"*)
+    if [ ! -e "\$SED_SHIM_MARKER" ]; then
+      : > "\$SED_SHIM_MARKER"
+      exit 0
+    fi
     ;;
 esac
+exec "$real_sed" "\$@"
 EOF
-  chmod +x "$slow_codex"
+  chmod +x "$stubdir/sed"
 
-  run env MSYSTEM=MINGW64 PATH="$stubdir:$PATH" AGMSG_REAL_CODEX="$slow_codex" \
+  run env MSYSTEM=MINGW64 PATH="$stubdir:$PATH" AGMSG_REAL_CODEX="$FAKE_CODEX" \
     bash "$TYPES/codex/codex-monitor.sh" --project "$TEST_PROJECT" --codex-command codex --
   [ "$status" -eq 0 ]
-  # The bridged handoff, not the fail-open: the wait outlasted a probe that
-  # could not see the process.
+  # The seam was actually taken. Without this the assertions below could hold
+  # for the wrong reason -- a run that never entered the loop body at all.
+  [ -e "$SED_SHIM_MARKER" ]
+  # Bridged, not the fail-open: the wait outlasted a probe that could not see
+  # the process.
   grep -q 'plain-codex <--remote> <ws://127\.0\.0\.1:[0-9][0-9]*>' "$CALL_LOG"
   [[ "$output" != *"did not report a listening port"* ]]
 }

--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -291,3 +291,34 @@ EOF
   grep -q 'plain-codex <--remote> <ws://127\.0\.0\.1:[0-9][0-9]*>' "$CALL_LOG"
   [[ "$output" != *"did not report a listening port"* ]]
 }
+
+@test "codex-monitor: reuses a live app-server when tasklist cannot see it (#567)" {
+  skip_on_windows "stubs tasklist to model Git Bash; the real one is authoritative there"
+  skip_on_windows "spawns a python socket listener; flaky on the Windows runner"
+
+  local stubdir="$TEST_PROJECT/stub-bin"
+  _stub_tasklist "$stubdir"
+
+  # First launch records port + pid; the recorded pid is this file's own $!.
+  run env FAKE_CODEX_VERSION=0.142.2 AGMSG_REAL_CODEX="$FAKE_CODEX" \
+    bash "$TYPES/codex/codex-monitor.sh" --project "$TEST_PROJECT" --codex-command codex --
+  [ "$status" -eq 0 ]
+  local resolved hash base first_pid first_port
+  resolved="$(cd "$TEST_PROJECT" && pwd)"
+  hash="$(printf '%s' "$resolved" | ( . "$SCRIPTS/lib/hash.sh"; agmsg_sha1 ))"
+  base="$TEST_SKILL_DIR/run/codex-app-server.$hash"
+  first_pid="$(cat "$base.pid")"
+  first_port="$(cat "$base.port")"
+  [ -n "$first_pid" ] && [ -n "$first_port" ]
+
+  # Second launch, now under Git Bash's pid rules. Reading the pid back out of a
+  # pidfile does not move it into the Windows pid space, so a probe that asks
+  # tasklist calls the live server dead and starts another one beside it.
+  run env FAKE_CODEX_VERSION=0.142.2 MSYSTEM=MINGW64 PATH="$stubdir:$PATH" \
+    AGMSG_REAL_CODEX="$FAKE_CODEX" \
+    bash "$TYPES/codex/codex-monitor.sh" --project "$TEST_PROJECT" --codex-command codex --
+  [ "$status" -eq 0 ]
+  # Same server: same pid on record, same port in the handoff.
+  [ "$(cat "$base.pid")" = "$first_pid" ]
+  grep -q "plain-codex <--remote> <ws://127\.0\.0\.1:$first_port>" "$CALL_LOG"
+}

--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -223,3 +223,72 @@ while True:
 
   kill "$foreign_pid" 2>/dev/null || true
 }
+
+# --- MSYS pid space (#567) ---
+
+@test "codex-monitor: waits for the port when tasklist cannot see the app-server (#567)" {
+  skip_on_windows "stubs tasklist to model Git Bash; the real one is authoritative here"
+  run node -e 'const net = require("net"); if (!net) process.exit(1);'
+  if [ "$status" -ne 0 ]; then
+    skip "node net module is not available in this sandbox"
+  fi
+
+  # The app-server is this shell's own background child, so its pid is numbered
+  # in the MSYS pid space. `tasklist` reports Windows pids and cannot see it. A
+  # liveness probe that asks tasklist therefore calls a running app-server dead
+  # on the first iteration and the launch falls back to plain codex (#567).
+  #
+  # MSYSTEM steers the shared helper down its tasklist branch; the stub is what
+  # tasklist would say about a pid it has no record of, which is nothing. Setting
+  # MSYSTEM does not otherwise disturb a macOS run -- compat.sh picks its
+  # platform from `uname -s`, not from this variable.
+  local stubdir="$TEST_PROJECT/stub-bin"
+  mkdir -p "$stubdir"
+  cat > "$stubdir/tasklist" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$stubdir/tasklist"
+
+  # The banner is delayed on purpose. The wait loop reads the log BEFORE it
+  # probes liveness, so an app-server that announces itself immediately breaks
+  # out on the first pass and never reaches the probe -- against which this test
+  # would pass no matter what the probe answered.
+  local slow_codex="$TEST_PROJECT/slow-codex"
+  cat > "$slow_codex" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) echo "codex-cli 0.144.1"; exit 0 ;;
+  app-server)
+    node - <<'JS' &
+const net = require('net');
+const s = net.createServer((c) => c.destroy());
+setTimeout(() => {
+  s.listen(0, '127.0.0.1', () => {
+    console.log('codex app-server (WebSockets)');
+    console.log('  listening on: ws://127.0.0.1:' + s.address().port);
+  });
+}, 600);
+setTimeout(() => process.exit(0), 60000);
+JS
+    child=$!
+    trap 'kill "$child" 2>/dev/null' TERM INT
+    wait "$child" 2>/dev/null || wait "$child" 2>/dev/null
+    ;;
+  *)
+    printf 'plain-codex' >> "$CALL_LOG"
+    for a in "$@"; do printf ' <%s>' "$a" >> "$CALL_LOG"; done
+    printf '\n' >> "$CALL_LOG"
+    ;;
+esac
+EOF
+  chmod +x "$slow_codex"
+
+  run env MSYSTEM=MINGW64 PATH="$stubdir:$PATH" AGMSG_REAL_CODEX="$slow_codex" \
+    bash "$TYPES/codex/codex-monitor.sh" --project "$TEST_PROJECT" --codex-command codex --
+  [ "$status" -eq 0 ]
+  # The bridged handoff, not the fail-open: the wait outlasted a probe that
+  # could not see the process.
+  grep -q 'plain-codex <--remote> <ws://127\.0\.0\.1:[0-9][0-9]*>' "$CALL_LOG"
+  [[ "$output" != *"did not report a listening port"* ]]
+}

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -532,12 +532,46 @@ require_eperm_pid() {
   # common answer — alive — is still decided by the builtin, so the cheap check
   # has to come first and has to be able to return on its own.
   local body fast slow
-  body="$(declare -f _agmsg_pid_alive)"
+  # The fast path lives in the _local helper now; _agmsg_pid_alive delegates to
+  # it once the Windows branch declines. A function call is not a fork, so the
+  # property this test exists for is unchanged -- but it has to be read where
+  # the code is.
+  body="$(declare -f _agmsg_pid_alive_local)"
   fast="$(printf '%s\n' "$body" | grep -n 'kill -0 .*&& return 0;$' | grep -v '\$(' | head -1 | cut -d: -f1)"
   slow="$(printf '%s\n' "$body" | grep -n 'kill -0 .*2>&1' | head -1 | cut -d: -f1)"
   [ -n "$fast" ]
   [ -n "$slow" ]
   [ "$fast" -lt "$slow" ]
+  # And the delegation is a plain call, not a subshell, so the fork-free claim
+  # survives the split.
+  printf '%s\n' "$(declare -f _agmsg_pid_alive)" | grep -q '^ *_agmsg_pid_alive_local "\$pid"$'
+}
+
+# --- which pid space (#567) ---
+
+@test "pid_alive_local: a pid we minted is alive even where tasklist cannot see it" {
+  skip_on_windows "stubs tasklist; the real one is authoritative on Windows"
+  # MSYSTEM steers _agmsg_pid_alive into its tasklist branch. tasklist reports
+  # Windows pids, and a pid from $! or $$ in one of these shells is numbered in
+  # the MSYS space, so it is absent -- which the plain helper reads as dead.
+  # _local is the one that must not ask.
+  local stub="$BATS_TEST_TMPDIR/stub-bin"
+  mkdir -p "$stub"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$stub/tasklist"
+  chmod +x "$stub/tasklist"
+
+  MSYSTEM=MINGW64 PATH="$stub:$PATH" _agmsg_pid_alive_local $$
+  # The counterpart, pinned so the split is not a distinction without a
+  # difference: the same live pid reads as dead through the plain helper.
+  ! MSYSTEM=MINGW64 PATH="$stub:$PATH" _agmsg_pid_alive $$
+}
+
+@test "pid_alive_local: EPERM still reads as alive (sandbox)" {
+  skip_on_windows "POSIX kill path"
+  # The reason the fix is not a bare `kill -0`: a pid we minted is still a pid a
+  # sandbox may refuse to let us signal, and #505 is what made that not mean dead.
+  kill() { echo "bash: kill: (1) - Operation not permitted" >&2; return 1; }
+  _agmsg_pid_alive_local 1
 }
 
 @test "no shipped script decides liveness with a bare kill -0" {

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -566,6 +566,32 @@ require_eperm_pid() {
   ! MSYSTEM=MINGW64 PATH="$stub:$PATH" _agmsg_pid_alive $$
 }
 
+@test "pid_alive_local: an oversized pid is dead on Windows too" {
+  skip_on_windows "POSIX kill path; the ceiling is what is under test"
+  # The validator widens to the DWORD range when MSYSTEM is set, because a
+  # Windows pid is a DWORD and tasklist is only asked to match a number. But
+  # _local hands the value to kill(1) even there, and past INT32_MAX kill
+  # rejects the argument rather than reporting ESRCH -- which reads as alive.
+  # Inheriting the wide ceiling would make an oversized pidfile value alive
+  # forever: lock never reclaimed, bridge never restarted (#505).
+  local err
+  err="$(export LC_ALL=C; kill -0 2147483648 2>&1)" || true
+  case "$err" in
+    *[Nn]'o such process'*) skip "kill treats out-of-range pids as ESRCH here" ;;
+  esac
+  local bad
+  for bad in 2147483648 4294967295; do
+    run env MSYSTEM=MINGW64 bash -c \
+      ". '$SCRIPTS/lib/instance-id.sh'; _agmsg_pid_alive_local $bad"
+    [ "$status" -ne 0 ] || { echo "_agmsg_pid_alive_local $bad reported alive"; false; }
+  done
+  # The platform ceiling itself is untouched: the same value is still a legal
+  # thing to ask tasklist about.
+  run env MSYSTEM=MINGW64 bash -c \
+    ". '$SCRIPTS/lib/instance-id.sh'; _agmsg_pid_valid 4294967295"
+  [ "$status" -eq 0 ]
+}
+
 @test "pid_alive_local: EPERM still reads as alive (sandbox)" {
   skip_on_windows "POSIX kill path"
   # The reason the fix is not a bare `kill -0`: a pid we minted is still a pid a


### PR DESCRIPTION
Since 1.1.12, launching codex on Windows always falls back to plain codex — no bridge, no real-time delivery. Reported in #567 with an xtrace from NNK-github.

## Why it broke

`#505` routed every liveness check through the shared helper. At this call site the pid being probed is the app-server the same shell has just started:

```sh
"$REAL_CODEX" app-server --listen "ws://127.0.0.1:0" >>"$SERVER_LOG" 2>&1 &
server_bg="$!"
```

Under `MSYSTEM` the helper answers from `tasklist`, which reports Windows pids. That pid is not one. The probe returns "dead" on the first pass of the wait loop, roughly 200 ms in and seconds before the banner, so no port is found and the launch fails open.

The helper is not wrong in general — `#134` added the `tasklist` branch because Git Bash's `kill(1)` genuinely cannot see a **native Windows** process reached by walking ancestors. The two cases want opposite probes, and which applies is decided by where the pid was minted.

## Measured, not assumed

A throwaway job on our own Windows runner ([run](https://github.com/fujibee/agmsg/actions/runs/30681121480)) probed every way this codebase obtains a pid:

```
self ($$)                pid=1237  winpid=8568  tasklist_hits=0  kill0=yes
bash fork ($!)           pid=1245  winpid=7272  tasklist_hits=0  kill0=yes
native direct ($!)       pid=1253  winpid=4652  tasklist_hits=0  kill0=yes
via sh launcher ($!)     pid=1262  winpid=4592  tasklist_hits=0  kill0=yes
read back from pidfile   pid=1245  winpid=7272  tasklist_hits=0  kill0=yes
```

```
tasklist /FI "PID eq 1245"  ->  INFO: No tasks are running which match the specified criteria.
tasklist /FI "PID eq 7272"  ->  sleep.exe   7272        <- the same process, by WINPID
```

Every pid reachable from bash is an MSYS pid, invisible to `tasklist`, and answered correctly by `kill -0`. A pidfile does not change the number, and an `sh` launcher — the shape npm installs a bin as — behaves no differently from a plain fork.

## The change

The probe is split by provenance rather than special-cased per site.

- `_agmsg_pid_alive_local` — keeps the EPERM reading and the `ps` cross-check, never asks `tasklist`. For a pid **we** minted: `$!`, `$$`, or one read back from a pidfile one of these shells wrote.
- `_agmsg_pid_alive` — keeps the `tasklist` branch for a pid from outside the MSYS subsystem, then delegates.

A bare `kill -0` was the first attempt and was wrong: a pid we minted is still a pid a sandbox may refuse to let us signal, which is the regression `#505` fixed at this very file. The repo already enforces that — `no shipped script decides liveness with a bare kill -0` fails against it.

Two call sites take the local helper: the wait loop, and the reuse decision that reads the pid back out of `codex-app-server.<hash>.pid`. The second is unreachable today (no port is ever recorded, so the branch needing both files never runs) and **becomes reachable by fixing the first** — which is why it is here and not in a follow-up.

## Tests

Reaching the liveness probe is fixed by **order, not by a delay**. Each pass reads the log with `sed` and only probes when that came back empty, so a server that has already announced itself breaks out on the first pass and the probe never runs — a test written against that passes whatever the probe answers. A shim on `PATH` matches the port-extracting `sed` **by its argument** (not by being the first `sed` of the run, which another call would consume) and returns empty once, then defers to the real `sed`. A marker asserts the seam was actually taken.

An earlier revision used a 600 ms banner delay instead. A descheduled parent turns that straight back into the trap it was meant to close.

**Mutation evidence** — each kills exactly one test:

| mutation | effect |
|---|---|
| wait loop → `_agmsg_pid_alive` | `not ok 7` waits for the port when tasklist cannot see the app-server |
| reuse → `_agmsg_pid_alive` | `not ok 8` reuses a live app-server when tasklist cannot see it |
| wait loop → bare `kill -0` | `not ok` no shipped script decides liveness with a bare kill -0 |
| shim seam removed | `not ok 7` (marker absent) |

Full local suite: **840 ok, exit 0**, no failures. The whole suite rather than the reachable subset, because a shared lib changed.

## Correction

An earlier revision of this PR (`3dfed95`) was described here as passing 148 local tests. It was not: the bare-`kill -0` guard was failing, and the filter on my test command dropped `not ok` lines while letting the plan line through. The claim was wrong when written.

## Scope

`#505` converted **17** call sites. The probe above confirms **16** of them read a pid `tasklist` cannot see; the exception is `resolve-project.sh`'s ancestor walk, which can leave the MSYS subsystem and is the one place the `tasklist` branch belongs. Two are fixed here. The remaining 14 are untouched pending a scope decision — among them `codex-bridge-launcher.sh:341`, which exits the launcher outright, so **this PR alone restores the bridged handoff but not message delivery on Windows**.
