### PR TITLE
fix(codex): seat a role from the app-server's loaded threads, not rollout files

### DIFF
--- a/scripts/drivers/types/codex/_delivery.sh
+++ b/scripts/drivers/types/codex/_delivery.sh
@@ -87,12 +87,37 @@ agmsg_codex_shim_path_note() {
   fi
 }
 
+# Loaded-thread count for this project, resolved AT MOST ONCE per status run and
+# left in _AGMSG_CODEX_LOADED_COUNT (empty = could not ask). Two reasons not to do
+# this per identity: `status` should not take N network round-trips to print, and
+# a stale port file whose port is held by something that accepts but never speaks
+# WebSocket would stall on each one. The timeouts are deliberately far below the
+# bridge's own defaults -- this is a status line, not a delivery path, and a slow
+# answer here is worth less than a prompt one.
+agmsg_codex_probe_loaded_count() {
+  local project="$1" port_file port node_bin
+  [ -n "${_AGMSG_CODEX_LOADED_PROBED:-}" ] && return 0
+  _AGMSG_CODEX_LOADED_PROBED=1
+  _AGMSG_CODEX_LOADED_COUNT=""
+  port_file="$RUN_DIR/codex-app-server.$(printf '%s' "$project" | agmsg_sha1 2>/dev/null).port"
+  port="$(cat "$port_file" 2>/dev/null || true)"
+  [ -n "$port" ] || return 0
+  node_bin="$(agmsg_resolve_node 2>/dev/null || true)"
+  [ -n "$node_bin" ] || return 0
+  { command -v "$node_bin" >/dev/null 2>&1 || [ -x "$node_bin" ]; } || return 0
+  _AGMSG_CODEX_LOADED_COUNT="$("$node_bin" "$SCRIPT_DIR/drivers/types/codex/codex-bridge.js" \
+    --app-server "ws://127.0.0.1:$port" --print-loaded-threads \
+    --connect-timeout-ms "${AGMSG_CODEX_STATUS_PROBE_TIMEOUT_MS:-1500}" \
+    --request-timeout-ms "${AGMSG_CODEX_STATUS_PROBE_TIMEOUT_MS:-1500}" 2>/dev/null | grep -c . || true)"
+  return 0
+}
+
 # Why a role has no bridge. A seat (role-session record) is what every layer of
 # the monitor path requires, so its absence -- not a dead process -- is the usual
 # reason nothing is running. When the seat is missing, the loaded-thread count is
 # what decides whether the next session can seed one, so report that too (#579).
 agmsg_codex_report_missing_bridge() {
-  local team="$1" name="$2" project="$3" seat loaded_count port_file port node_bin
+  local team="$1" name="$2" project="$3" seat
   # shellcheck disable=SC1091
   . "$SKILL_DIR/scripts/lib/role-session.sh"
   seat="$(agmsg_role_session_uuid "$team" "$name" 2>/dev/null || true)"
@@ -101,16 +126,9 @@ agmsg_codex_report_missing_bridge() {
     return 0
   fi
 
-  loaded_count=""
-  port_file="$RUN_DIR/codex-app-server.$(printf '%s' "$project" | agmsg_sha1 2>/dev/null).port"
-  port="$(cat "$port_file" 2>/dev/null || true)"
-  node_bin="$(agmsg_resolve_node 2>/dev/null || true)"
-  if [ -n "$port" ] && [ -n "$node_bin" ] && { command -v "$node_bin" >/dev/null 2>&1 || [ -x "$node_bin" ]; }; then
-    loaded_count="$("$node_bin" "$SCRIPT_DIR/drivers/types/codex/codex-bridge.js" \
-      --app-server "ws://127.0.0.1:$port" --print-loaded-threads 2>/dev/null | grep -c . || true)"
-  fi
+  agmsg_codex_probe_loaded_count "$project"
 
-  case "${loaded_count:-}" in
+  case "${_AGMSG_CODEX_LOADED_COUNT:-}" in
     "")
       echo "Codex bridge: $team/$name has no session recorded, and no app-server to ask"
       echo "  Start Codex through monitor mode in this project; the seat is recorded then."
@@ -124,7 +142,7 @@ agmsg_codex_report_missing_bridge() {
       echo "  That combination is unexpected -- the seat is normally written for it."
       ;;
     *)
-      echo "Codex bridge: $team/$name has no session recorded ($loaded_count threads loaded, none identifiable as its session)"
+      echo "Codex bridge: $team/$name has no session recorded ($_AGMSG_CODEX_LOADED_COUNT threads loaded, none identifiable as its session)"
       echo "  Recreate this project's app-server so the next session can be identified:"
       echo "    $SCRIPT_DIR/delivery.sh set off codex $project"
       echo "    $SCRIPT_DIR/delivery.sh set monitor codex $project"
@@ -136,6 +154,8 @@ agmsg_codex_report_missing_bridge() {
 agmsg_delivery_runtime_status() {
   local type="$1" project="$2"
   local pairs found=0 any_alive=0
+  _AGMSG_CODEX_LOADED_PROBED=""
+  _AGMSG_CODEX_LOADED_COUNT=""
   pairs=$("$SCRIPT_DIR/identities.sh" "$project" "$type" 2>/dev/null || true)
 
   if [ -z "$pairs" ]; then

--- a/scripts/drivers/types/codex/_delivery.sh
+++ b/scripts/drivers/types/codex/_delivery.sh
@@ -87,6 +87,52 @@ agmsg_codex_shim_path_note() {
   fi
 }
 
+# Why a role has no bridge. A seat (role-session record) is what every layer of
+# the monitor path requires, so its absence -- not a dead process -- is the usual
+# reason nothing is running. When the seat is missing, the loaded-thread count is
+# what decides whether the next session can seed one, so report that too (#579).
+agmsg_codex_report_missing_bridge() {
+  local team="$1" name="$2" project="$3" seat loaded_count port_file port node_bin
+  # shellcheck disable=SC1091
+  . "$SKILL_DIR/scripts/lib/role-session.sh"
+  seat="$(agmsg_role_session_uuid "$team" "$name" 2>/dev/null || true)"
+  if [ -n "$seat" ]; then
+    echo "Codex bridge: $team/$name not running (seat recorded: $seat)"
+    return 0
+  fi
+
+  loaded_count=""
+  port_file="$RUN_DIR/codex-app-server.$(printf '%s' "$project" | agmsg_sha1 2>/dev/null).port"
+  port="$(cat "$port_file" 2>/dev/null || true)"
+  node_bin="$(agmsg_resolve_node 2>/dev/null || true)"
+  if [ -n "$port" ] && [ -n "$node_bin" ] && { command -v "$node_bin" >/dev/null 2>&1 || [ -x "$node_bin" ]; }; then
+    loaded_count="$("$node_bin" "$SCRIPT_DIR/drivers/types/codex/codex-bridge.js" \
+      --app-server "ws://127.0.0.1:$port" --print-loaded-threads 2>/dev/null | grep -c . || true)"
+  fi
+
+  case "${loaded_count:-}" in
+    "")
+      echo "Codex bridge: $team/$name has no session recorded, and no app-server to ask"
+      echo "  Start Codex through monitor mode in this project; the seat is recorded then."
+      ;;
+    0)
+      echo "Codex bridge: $team/$name has no session recorded (no Codex thread is loaded yet)"
+      echo "  Start Codex through monitor mode in this project; the seat is recorded then."
+      ;;
+    1)
+      echo "Codex bridge: $team/$name has no session recorded, though one thread is loaded"
+      echo "  That combination is unexpected -- the seat is normally written for it."
+      ;;
+    *)
+      echo "Codex bridge: $team/$name has no session recorded ($loaded_count threads loaded, none identifiable as its session)"
+      echo "  Recreate this project's app-server so the next session can be identified:"
+      echo "    $SCRIPT_DIR/delivery.sh set off codex $project"
+      echo "    $SCRIPT_DIR/delivery.sh set monitor codex $project"
+      echo "  This also stops any other Codex bridge for this project."
+      ;;
+  esac
+}
+
 agmsg_delivery_runtime_status() {
   local type="$1" project="$2"
   local pairs found=0 any_alive=0
@@ -109,7 +155,11 @@ agmsg_delivery_runtime_status() {
     metafile="$base.meta"
 
     if [ ! -f "$pidfile" ]; then
-      echo "Codex bridge: $team/$name not running"
+      # "not running" reads as "the bridge process died". The far more common
+      # cause is that this role has no seat, which no layer of the monitor path
+      # says out loud: the SessionStart hook exits 0, the launcher re-execs, and
+      # the only visible symptom is this line. Say which one it is.
+      agmsg_codex_report_missing_bridge "$team" "$name" "$project"
       continue
     fi
 

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -56,6 +56,10 @@ Options:
                           of total duration — only true silence trips it.
   --inline-inbox          Read inbox in the bridge and include message text in the turn input.
   --resolve-only          Print resolved team/name and exit.
+  --print-loaded-threads  Print the app-server's loaded thread ids (one per
+                          line) and exit. Needs --app-server. Used by
+                          codex-record-session.sh to seat a role without
+                          guessing from rollout files (#579).
   --help                  Show this help.
 
 Set AGMSG_CODEX_APP_SERVER_CMD to override the app-server command for tests.`);
@@ -104,6 +108,8 @@ function parseArgs(argv) {
       opts.help = true;
     } else if (arg === "--resolve-only") {
       opts.resolveOnly = true;
+    } else if (arg === "--print-loaded-threads") {
+      opts.printLoadedThreads = true;
     } else if (arg === "--project") {
       opts.project = argv[++i];
     } else if (arg === "--workspace-root") {
@@ -148,6 +154,14 @@ function parseArgs(argv) {
   }
 
   if (opts.help) return opts;
+  // The loaded-thread probe neither watches an inbox nor resolves an identity,
+  // so every option below is meaningless to it. --project in particular is the
+  // one thing its caller cannot supply usefully: a project is how you find a
+  // ROLE, and the probe exists precisely because no role is seated yet.
+  if (opts.printLoadedThreads) {
+    if (!opts.appServer) die("--print-loaded-threads requires --app-server");
+    return opts;
+  }
   if (!opts.project) die("--project is required");
   if (opts.workspaceRoots.some((root) => !root)) die("--workspace-root requires a path");
   opts.workspaceRoots = [...new Set([opts.project, ...opts.workspaceRoots])];
@@ -874,7 +888,31 @@ class CodexBridge {
     await this.client.ready?.();
     await this.initialize();
     await this.ensureThread();
+    this.recordSeat();
     await this.armWatch();
+  }
+
+  // Write the seat from the thread the bridge actually armed on (#579). Seating
+  // before this point can only ever be inference -- the app-server is the one
+  // that knows which thread this session got, and it does not know it until the
+  // resume above succeeded. So whatever seeded the seat earlier, the value it
+  // guessed is replaced here by one the app-server confirmed.
+  //
+  // Best-effort by design: a failure to record costs the NEXT session a resume,
+  // not this one, which is already armed and delivering. Never let it take the
+  // bridge down.
+  recordSeat() {
+    if (!this.threadId || this.threadId === "loaded") return;
+    for (const pair of this.identities) {
+      try {
+        spawnSync(BASH_BIN, [
+          path.join(SCRIPT_DIR, "codex-record-session.sh"),
+          pair.team, pair.name, toPosixPath(this.opts.project),
+        ], { cwd: SKILL_DIR, encoding: "utf8", env: { ...process.env, CODEX_THREAD_ID: this.threadId } });
+      } catch (error) {
+        console.error(`codex-bridge: could not record seat for ${pair.team}/${pair.name}: ${error.message}`);
+      }
+    }
   }
 
   clientHandler(method, handler) {
@@ -1457,6 +1495,31 @@ async function main() {
   const opts = parseArgs(process.argv.slice(2));
   if (opts.help) {
     usage();
+    return;
+  }
+
+  // Read-only probe: no identities, no pidfile, no thread resumed. Runs before
+  // resolveIdentities because seating a role is exactly what has not happened
+  // yet when this is called -- requiring an identity here would be circular.
+  if (opts.printLoadedThreads) {
+    const client = createAppServerClient(opts);
+    try {
+      // start() arms the connection; ready() is what resolves once the WebSocket
+      // handshake has completed. Awaiting start() alone sends the first request
+      // into a socket that is not connected yet.
+      client.start();
+      await client.ready?.();
+      await client.request("initialize", {
+        clientInfo: { name: "agmsg-codex-bridge", title: "agmsg Codex bridge", version: readVersion() },
+        capabilities: { experimentalApi: true, requestAttestation: false, optOutNotificationMethods: [] },
+      });
+      client.notify("initialized");
+      const response = await client.request("thread/loaded/list", {});
+      const ids = response && Array.isArray(response.data) ? response.data : [];
+      if (ids.length > 0) console.log(ids.join("\n"));
+    } finally {
+      client.stop();
+    }
     return;
   }
 

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -888,8 +888,10 @@ class CodexBridge {
     await this.client.ready?.();
     await this.initialize();
     await this.ensureThread();
-    this.recordSeat();
     await this.armWatch();
+    // After armWatch, not before: the seat is a claim that this role is being
+    // delivered to, and until the watch is armed that is not yet true.
+    this.recordSeat();
   }
 
   // Write the seat from the thread the bridge actually armed on (#579). Seating

--- a/scripts/drivers/types/codex/codex-record-session.sh
+++ b/scripts/drivers/types/codex/codex-record-session.sh
@@ -83,7 +83,23 @@ fi
 # Exactly one leftover => ours. Zero or several => record nothing, exactly as
 # before: this stays biased toward a fresh boot, because a resume mis-fire
 # (waking someone else's conversation) is worse than no resume at all.
+#
+# probe_ran distinguishes "the app-server answered and the answer was ambiguous"
+# from "there was no app-server to ask". Only the second may fall through to the
+# rollout scan: an ambiguous answer is a firm statement that this session cannot
+# be identified, and letting a weaker source overrule it is how a wrong thread
+# gets seated.
+probe_ran=0
 if [ -z "$thread" ] && [ -n "${AGMSG_CODEX_BRIDGE_APP_SERVER:-}" ]; then
+  # An inference may only claim a role that has no seat. The subtraction removes
+  # every recorded thread INCLUDING this role's own, so a seated role running
+  # this again would find its own thread gone from the set and adopt whatever
+  # else was left -- overwriting a correct seat with a stranger's thread. Only
+  # CODEX_THREAD_ID, which is not an inference, may re-seat a seated role (that
+  # is how the bridge rewrites the seat after arming).
+  if [ -n "$(agmsg_role_session_uuid "$TEAM" "$AGENT" 2>/dev/null || true)" ]; then
+    exit 0
+  fi
   # shellcheck disable=SC1091
   . "$SKILL_DIR/scripts/lib/node.sh"
   node_bin="$(agmsg_resolve_node 2>/dev/null || true)"
@@ -91,25 +107,40 @@ if [ -z "$thread" ] && [ -n "${AGMSG_CODEX_BRIDGE_APP_SERVER:-}" ]; then
     loaded_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-codexloaded.XXXXXX" 2>/dev/null || true)"
     seated_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-codexseated.XXXXXX" 2>/dev/null || true)"
     if [ -n "$loaded_file" ] && [ -n "$seated_file" ]; then
-      "$node_bin" "$SCRIPT_DIR/codex-bridge.js" --app-server "$AGMSG_CODEX_BRIDGE_APP_SERVER" \
-        --print-loaded-threads 2>/dev/null | grep . | sort -u > "$loaded_file" || true
+      # Exit status, not output: an empty list is a valid answer ("nothing is
+      # loaded"), while a failure to reach the app-server is not an answer at all.
+      if "$node_bin" "$SCRIPT_DIR/codex-bridge.js" --app-server "$AGMSG_CODEX_BRIDGE_APP_SERVER" \
+           --print-loaded-threads >"$loaded_file.raw" 2>/dev/null; then
+        probe_ran=1
+      fi
+      grep . "$loaded_file.raw" 2>/dev/null | sort -u > "$loaded_file" || true
+      rm -f "$loaded_file.raw"
       # Every recorded codex seat, not just this project's. Over-subtracting can
       # only drop a thread that some role already owns, which is never the one we
       # want to claim; under-subtracting would leave a stale thread in the set and
       # make the count ambiguous.
       agmsg_role_session_recorded_uuids codex 2>/dev/null | grep . | sort -u > "$seated_file" || true
-      cand_count="$(comm -23 "$loaded_file" "$seated_file" | grep -c . || true)"
-      if [ "${cand_count:-0}" -eq 1 ]; then
-        thread="$(comm -23 "$loaded_file" "$seated_file" | grep . | head -1)"
+      if [ "$probe_ran" = "1" ]; then
+        cand_count="$(comm -23 "$loaded_file" "$seated_file" | grep -c . || true)"
+        if [ "${cand_count:-0}" -eq 1 ]; then
+          thread="$(comm -23 "$loaded_file" "$seated_file" | grep . | head -1)"
+        fi
       fi
     fi
     rm -f "$loaded_file" "$seated_file"
   fi
 fi
 
+# An answered-but-ambiguous probe ends here: the app-server has already said this
+# session cannot be told apart, and no weaker signal may overturn that.
+if [ "$probe_ran" = "1" ]; then
+  [ -n "$thread" ] || exit 0
+fi
+
 if [ -z "$thread" ]; then
-  # No app-server to ask (a codex session outside monitor mode). The rollout scan
-  # is the only signal left, so it stays as the fallback -- it still resolves the
+  # No app-server to ask, or it could not be reached -- a codex session outside
+  # monitor mode, a missing Node, a server that is not answering. The rollout scan
+  # is the only signal left, so it stays as the fallback: it still resolves the
   # single-rollout case it always did, and on a project with history it records
   # nothing, which is what happens today.
   #

--- a/scripts/drivers/types/codex/codex-record-session.sh
+++ b/scripts/drivers/types/codex/codex-record-session.sh
@@ -68,6 +68,20 @@ if [ -n "${CODEX_THREAD_ID:-}" ]; then
   thread="$CODEX_THREAD_ID"
 fi
 
+# Past this point every remaining path is an INFERENCE, and an inference may not
+# change a seat that already exists -- not the loaded-set subtraction below, and
+# not the rollout scan either. The subtraction fails by removing this role's own
+# thread and adopting what is left; the rollout scan fails by picking whatever
+# happens to be unique in the cwd. Both replace a correct seat with a stranger's
+# thread, so the rule belongs to the whole inference, not to one branch of it.
+#
+# CODEX_THREAD_ID is exempt because it is not an inference: it is either exported
+# by the session itself or passed by the bridge with the thread the app-server
+# confirmed, which is exactly how a seeded seat gets corrected after arming.
+if [ -z "$thread" ] && [ -n "$(agmsg_role_session_uuid "$TEAM" "$AGENT" 2>/dev/null || true)" ]; then
+  exit 0
+fi
+
 # Ask the app-server which threads it has loaded, and subtract the ones a role
 # already sits in (#579). The rollout files below cannot answer "which thread is
 # THIS session" on a project that has been worked in before: every past session
@@ -91,15 +105,6 @@ fi
 # gets seated.
 probe_ran=0
 if [ -z "$thread" ] && [ -n "${AGMSG_CODEX_BRIDGE_APP_SERVER:-}" ]; then
-  # An inference may only claim a role that has no seat. The subtraction removes
-  # every recorded thread INCLUDING this role's own, so a seated role running
-  # this again would find its own thread gone from the set and adopt whatever
-  # else was left -- overwriting a correct seat with a stranger's thread. Only
-  # CODEX_THREAD_ID, which is not an inference, may re-seat a seated role (that
-  # is how the bridge rewrites the seat after arming).
-  if [ -n "$(agmsg_role_session_uuid "$TEAM" "$AGENT" 2>/dev/null || true)" ]; then
-    exit 0
-  fi
   # shellcheck disable=SC1091
   . "$SKILL_DIR/scripts/lib/node.sh"
   node_bin="$(agmsg_resolve_node 2>/dev/null || true)"

--- a/scripts/drivers/types/codex/codex-record-session.sh
+++ b/scripts/drivers/types/codex/codex-record-session.sh
@@ -66,7 +66,53 @@ esac
 thread=""
 if [ -n "${CODEX_THREAD_ID:-}" ]; then
   thread="$CODEX_THREAD_ID"
-else
+fi
+
+# Ask the app-server which threads it has loaded, and subtract the ones a role
+# already sits in (#579). The rollout files below cannot answer "which thread is
+# THIS session" on a project that has been worked in before: every past session
+# in this cwd matches, the count is never one, and the seat is never written --
+# so on such a project the bridge can never arm, in this session or any later
+# one.
+#
+# The subtraction is what makes the remainder unique. A thread stays loaded in
+# the app-server after its window is gone, so `loaded` is every thread this
+# server has opened, not the live ones; but each of those already has a seat, so
+# taking the recorded ids away leaves the session that has not been seated yet.
+#
+# Exactly one leftover => ours. Zero or several => record nothing, exactly as
+# before: this stays biased toward a fresh boot, because a resume mis-fire
+# (waking someone else's conversation) is worse than no resume at all.
+if [ -z "$thread" ] && [ -n "${AGMSG_CODEX_BRIDGE_APP_SERVER:-}" ]; then
+  # shellcheck disable=SC1091
+  . "$SKILL_DIR/scripts/lib/node.sh"
+  node_bin="$(agmsg_resolve_node 2>/dev/null || true)"
+  if [ -n "$node_bin" ] && { command -v "$node_bin" >/dev/null 2>&1 || [ -x "$node_bin" ]; }; then
+    loaded_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-codexloaded.XXXXXX" 2>/dev/null || true)"
+    seated_file="$(mktemp "${TMPDIR:-/tmp}/agmsg-codexseated.XXXXXX" 2>/dev/null || true)"
+    if [ -n "$loaded_file" ] && [ -n "$seated_file" ]; then
+      "$node_bin" "$SCRIPT_DIR/codex-bridge.js" --app-server "$AGMSG_CODEX_BRIDGE_APP_SERVER" \
+        --print-loaded-threads 2>/dev/null | grep . | sort -u > "$loaded_file" || true
+      # Every recorded codex seat, not just this project's. Over-subtracting can
+      # only drop a thread that some role already owns, which is never the one we
+      # want to claim; under-subtracting would leave a stale thread in the set and
+      # make the count ambiguous.
+      agmsg_role_session_recorded_uuids codex 2>/dev/null | grep . | sort -u > "$seated_file" || true
+      cand_count="$(comm -23 "$loaded_file" "$seated_file" | grep -c . || true)"
+      if [ "${cand_count:-0}" -eq 1 ]; then
+        thread="$(comm -23 "$loaded_file" "$seated_file" | grep . | head -1)"
+      fi
+    fi
+    rm -f "$loaded_file" "$seated_file"
+  fi
+fi
+
+if [ -z "$thread" ]; then
+  # No app-server to ask (a codex session outside monitor mode). The rollout scan
+  # is the only signal left, so it stays as the fallback -- it still resolves the
+  # single-rollout case it always did, and on a project with history it records
+  # nothing, which is what happens today.
+  #
   # ${HOME:-} so an unset HOME under `set -u` is a silent no-op (empty -> the
   # dir check below fails -> fresh), not an unbound-variable abort (co1 nit).
   sessions_dir="${HOME:-}/.codex/sessions"

--- a/scripts/lib/role-session.sh
+++ b/scripts/lib/role-session.sh
@@ -216,6 +216,25 @@ agmsg_role_session_lookup_by_name() {
   return 0
 }
 
+# Print the session id of every record of <type>, one per line (unordered, may
+# repeat across teams). Empty if none. Used by codex seat resolution (#579) to
+# subtract already-claimed threads from the app-server's loaded set: what is left
+# is the session that has not been seated yet.
+agmsg_role_session_recorded_uuids() {
+  local type="$1" dir f t v
+  [ -n "$type" ] || return 0
+  dir="$(_actas_lock_dir)"
+  [ -d "$dir" ] || return 0
+  for f in "$dir"/role-session.*; do
+    [ -f "$f" ] || continue
+    t="$(_agmsg_role_session_field "$f" type)"
+    [ "$t" = "$type" ] || continue
+    v="$(_agmsg_role_session_field "$f" session)"
+    [ -n "$v" ] && printf '%s\n' "$v"
+  done
+  return 0
+}
+
 # Scan run/role-session.* for the record whose session= field equals <sid> and
 # print its full body (all key=value lines). Empty if none. Used by role-aware
 # SessionStart (PR-E) to map a resumed session id back to its (team, agent).

--- a/tests/test_codex_resume.bats
+++ b/tests/test_codex_resume.bats
@@ -334,3 +334,16 @@ fake_node_failing() {
     bash "$TYPES/codex/codex-record-session.sh" team alice "$proj"
   [ "$(recorded_uuid team alice)" = "confirmed-thread" ]
 }
+
+@test "codex record: the rollout scan does not re-seat a seated role either" {
+  # The guard belongs to the whole inference, not to the app-server branch. With
+  # no app-server the rollout scan is the inference, and a unique rollout must not
+  # replace a seat that is already there.
+  local proj; proj="$(mktemp -d)"
+  make_rollout "rollout-unique-uuid" "$proj"
+  source "$SKILL_DIR/scripts/lib/role-session.sh"
+  agmsg_role_session_record team alice thread-A "$proj" codex
+  ( unset CODEX_THREAD_ID AGMSG_CODEX_BRIDGE_APP_SERVER
+    bash "$TYPES/codex/codex-record-session.sh" team alice "$proj" )
+  [ "$(recorded_uuid team alice)" = "thread-A" ]
+}

--- a/tests/test_codex_resume.bats
+++ b/tests/test_codex_resume.bats
@@ -262,3 +262,75 @@ record_with_loaded() {   # <ids-file> <team> <agent> <project>
   record_with_loaded "$ids" team alice "$proj"
   [ -z "$(recorded_uuid team alice)" ]
 }
+
+# A stand-in for node that FAILS, i.e. the app-server could not be reached at all.
+# Distinct from a probe that answers with an empty or ambiguous list: only this
+# case may fall through to the rollout scan.
+fake_node_failing() {
+  local out="$TEST_SKILL_DIR/fake-node-fail"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$out"
+  chmod +x "$out"
+  printf '%s' "$out"
+}
+
+@test "codex record: an ambiguous probe is NOT overruled by a unique rollout" {
+  # The rollout scan is the weaker source. Once the app-server has said it cannot
+  # tell this session apart, a rollout that happens to be unique must not seat a
+  # thread on top of that answer.
+  local proj ids; proj="$(mktemp -d)"; ids="$TEST_SKILL_DIR/loaded.txt"
+  printf 'thr-one\nthr-two\n' > "$ids"
+  make_rollout "rollout-unique-uuid" "$proj"
+  record_with_loaded "$ids" team alice "$proj"
+  [ -z "$(recorded_uuid team alice)" ]
+}
+
+@test "codex record: an empty probe is NOT overruled by a unique rollout" {
+  local proj ids; proj="$(mktemp -d)"; ids="$TEST_SKILL_DIR/loaded.txt"
+  : > "$ids"
+  make_rollout "rollout-unique-uuid" "$proj"
+  record_with_loaded "$ids" team alice "$proj"
+  [ -z "$(recorded_uuid team alice)" ]
+}
+
+@test "codex record: an unreachable app-server DOES fall back to the rollout scan" {
+  local proj; proj="$(mktemp -d)"
+  make_rollout "rollout-unique-uuid" "$proj"
+  ( unset CODEX_THREAD_ID
+    AGMSG_NODE="$(fake_node_failing)" \
+    AGMSG_CODEX_BRIDGE_APP_SERVER="ws://127.0.0.1:1" \
+      bash "$TYPES/codex/codex-record-session.sh" team alice "$proj" )
+  [ "$(recorded_uuid team alice)" = "rollout-unique-uuid" ]
+}
+
+@test "codex record: a role that already has a seat is never re-seated by inference" {
+  # The subtraction removes this role's own thread along with everyone else's, so
+  # a seated role running the inference again would find its own gone and adopt
+  # whatever was left -- replacing a correct seat with a stranger's thread.
+  local proj ids; proj="$(mktemp -d)"; ids="$TEST_SKILL_DIR/loaded.txt"
+  printf 'thread-A\nthread-B\n' > "$ids"
+  source "$SKILL_DIR/scripts/lib/role-session.sh"
+  agmsg_role_session_record team alice thread-A "$proj" codex
+  record_with_loaded "$ids" team alice "$proj"
+  [ "$(recorded_uuid team alice)" = "thread-A" ]
+}
+
+@test "codex record: an unseated role still gets the remainder while a seated one keeps its own" {
+  local proj ids; proj="$(mktemp -d)"; ids="$TEST_SKILL_DIR/loaded.txt"
+  printf 'thread-A\nthread-B\n' > "$ids"
+  source "$SKILL_DIR/scripts/lib/role-session.sh"
+  agmsg_role_session_record team alice thread-A "$proj" codex
+  record_with_loaded "$ids" team bob "$proj"
+  [ "$(recorded_uuid team bob)" = "thread-B" ]
+  [ "$(recorded_uuid team alice)" = "thread-A" ]
+}
+
+@test "codex record: CODEX_THREAD_ID still re-seats a seated role (bridge write-back)" {
+  # The guard above is for INFERENCE only. The bridge rewrites the seat after
+  # arming with a thread the app-server confirmed, which must still land.
+  local proj; proj="$(mktemp -d)"
+  source "$SKILL_DIR/scripts/lib/role-session.sh"
+  agmsg_role_session_record team alice guessed-thread "$proj" codex
+  CODEX_THREAD_ID="confirmed-thread" \
+    bash "$TYPES/codex/codex-record-session.sh" team alice "$proj"
+  [ "$(recorded_uuid team alice)" = "confirmed-thread" ]
+}

--- a/tests/test_codex_resume.bats
+++ b/tests/test_codex_resume.bats
@@ -183,3 +183,82 @@ recorded_project() {
   [ "$(recorded_uuid team alice)" = "sym-thread" ]
   [ "$(recorded_project team alice)" = "$want" ]
 }
+
+# --- codex-record-session.sh: seat from the app-server's loaded set (#579) ---
+#
+# The rollout scan cannot answer "which thread is THIS session" on a project that
+# has been worked in before -- every past session in that cwd matches, so the
+# count is never one and the seat is never written. These cover the replacement:
+# ask the app-server what it has loaded, subtract the threads a role already sits
+# in, and take the remainder only when it is unique.
+
+# A stand-in for node that ignores the bridge path and its flags and prints the
+# ids the test staged. agmsg_resolve_node honours AGMSG_NODE, so this is the seam
+# the production call already goes through -- no test-only branch in the script.
+fake_node_printing() {
+  local out="$TEST_SKILL_DIR/fake-node"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'cat %q\n' "$1"
+  } > "$out"
+  chmod +x "$out"
+  printf '%s' "$out"
+}
+
+record_with_loaded() {   # <ids-file> <team> <agent> <project>
+  ( unset CODEX_THREAD_ID
+    AGMSG_NODE="$(fake_node_printing "$1")" \
+    AGMSG_CODEX_BRIDGE_APP_SERVER="ws://127.0.0.1:1" \
+      bash "$TYPES/codex/codex-record-session.sh" "$2" "$3" "$4" )
+}
+
+@test "codex record: seats the loaded thread that no role has claimed yet" {
+  local proj ids; proj="$(mktemp -d)"; ids="$TEST_SKILL_DIR/loaded.txt"
+  printf 'thr-seated\nthr-unclaimed\n' > "$ids"
+  source "$SKILL_DIR/scripts/lib/role-session.sh"
+  agmsg_role_session_record team bob thr-seated "$proj" codex
+  record_with_loaded "$ids" team alice "$proj"
+  [ "$(recorded_uuid team alice)" = "thr-unclaimed" ]
+}
+
+@test "codex record: a long history in the cwd no longer blocks the seat" {
+  # The exact shape of #579: many past sessions in this project. Under the rollout
+  # scan this is the ambiguous case that records nothing forever; the loaded set
+  # is unaffected by how much history the project has.
+  local proj ids i; proj="$(mktemp -d)"; ids="$TEST_SKILL_DIR/loaded.txt"
+  for i in 1 2 3 4 5; do
+    make_rollout "hist-uuid-$i" "$proj" "2026/07/05" "2026-07-05T1$i-00-00"
+  done
+  printf 'thr-live\n' > "$ids"
+  record_with_loaded "$ids" team alice "$proj"
+  [ "$(recorded_uuid team alice)" = "thr-live" ]
+}
+
+@test "codex record: two unclaimed loaded threads record nothing (stays fail-closed)" {
+  local proj ids; proj="$(mktemp -d)"; ids="$TEST_SKILL_DIR/loaded.txt"
+  printf 'thr-one\nthr-two\n' > "$ids"
+  record_with_loaded "$ids" team alice "$proj"
+  [ -z "$(recorded_uuid team alice)" ]
+}
+
+@test "codex record: every loaded thread already claimed records nothing" {
+  local proj ids; proj="$(mktemp -d)"; ids="$TEST_SKILL_DIR/loaded.txt"
+  printf 'thr-a\nthr-b\n' > "$ids"
+  source "$SKILL_DIR/scripts/lib/role-session.sh"
+  agmsg_role_session_record team bob thr-a "$proj" codex
+  agmsg_role_session_record team carol thr-b "$proj" codex
+  record_with_loaded "$ids" team alice "$proj"
+  [ -z "$(recorded_uuid team alice)" ]
+}
+
+@test "codex record: a claimed thread of another TYPE is not subtracted" {
+  # claude-code records session ids in the same directory. Subtracting those
+  # would silently shrink the codex candidate set and could make an ambiguous
+  # pair look unique -- the one way this subtraction could seat a wrong thread.
+  local proj ids; proj="$(mktemp -d)"; ids="$TEST_SKILL_DIR/loaded.txt"
+  printf 'thr-x\nthr-y\n' > "$ids"
+  source "$SKILL_DIR/scripts/lib/role-session.sh"
+  agmsg_role_session_record team bob thr-x "$proj" claude-code
+  record_with_loaded "$ids" team alice "$proj"
+  [ -z "$(recorded_uuid team alice)" ]
+}

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -2088,14 +2088,17 @@ EOF
   [[ "$output" != *"watch processes:"* ]]
 }
 
-@test "delivery status (codex): identity with no bridge reports not running" {
+@test "delivery status (codex): identity with no bridge and no seat says so, not \"not running\"" {
   bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
   bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
 
   run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"mode: monitor"* ]]
-  [[ "$output" == *"Codex bridge: team/alice not running"* ]]
+  # No seat is the reason here, and it is a different problem from a process
+  # that died -- the old wording named the wrong one (#579).
+  [[ "$output" == *"Codex bridge: team/alice has no session recorded"* ]]
+  [[ "$output" != *"Codex bridge: team/alice not running"* ]]
   [[ "$output" != *"watch processes:"* ]]
 }
 
@@ -2212,7 +2215,7 @@ EOF
   run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Codex bridge: team/alice alive (pid $bpid)"* ]]
-  [[ "$output" == *"Codex bridge: team/bob not running"* ]]
+  [[ "$output" == *"Codex bridge: team/bob has no session recorded"* ]]
   [[ "$output" != *"watch processes:"* ]]
 
   kill "$bpid" 2>/dev/null || true
@@ -2481,4 +2484,19 @@ JSON
   bash "$SCRIPTS/delivery.sh" set turn grok-build "$TEST_PROJECT"
   run bash "$SCRIPTS/delivery.sh" status grok-build "$TEST_PROJECT"
   [[ "$output" =~ "mode: turn" ]]
+}
+
+@test "delivery status (codex): a recorded seat makes \"not running\" mean the process (#579)" {
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+  # shellcheck disable=SC1090
+  SKILL_DIR="$TEST_SKILL_DIR" source "$SCRIPTS/lib/role-session.sh"
+  SKILL_DIR="$TEST_SKILL_DIR" agmsg_role_session_record team alice seat-uuid-1 "$TEST_PROJECT" codex
+
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  # With a seat on record, the bridge really is just absent -- and the seat is
+  # printed so the reader can tell the two states apart at a glance.
+  [[ "$output" == *"Codex bridge: team/alice not running (seat recorded: seat-uuid-1)"* ]]
+  [[ "$output" != *"has no session recorded"* ]]
 }

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -2500,3 +2500,80 @@ JSON
   [[ "$output" == *"Codex bridge: team/alice not running (seat recorded: seat-uuid-1)"* ]]
   [[ "$output" != *"has no session recorded"* ]]
 }
+
+@test "delivery status (codex): a port that accepts but never answers does not stall status (#579)" {
+  # A stale port file whose port is now held by something that completes the TCP
+  # connect and then says nothing is the worst case for a diagnostic probe: the
+  # bridge's own defaults would wait 10s to connect plus 30s for a reply, per
+  # identity. status has to stay a status line.
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" team bob   codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+
+  # Silent listener: accepts, then holds the socket open without ever replying.
+  local portfile="$TEST_SKILL_DIR/silent.port"
+  node -e '
+    const net = require("net");
+    const srv = net.createServer(() => {});
+    srv.listen(0, "127.0.0.1", () => {
+      require("fs").writeFileSync(process.argv[1], String(srv.address().port));
+    });
+  ' "$portfile" >/dev/null 2>&1 3>&- &
+  local listener=$!
+  local waited=0
+  while [ ! -s "$portfile" ] && [ "$waited" -lt 50 ]; do sleep 0.1; waited=$((waited + 1)); done
+  [ -s "$portfile" ]
+
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/hash.sh"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  cp "$portfile" "$TEST_SKILL_DIR/run/codex-app-server.$(printf '%s' "$TEST_PROJECT" | agmsg_sha1).port"
+
+  local start finish elapsed
+  start=$(date +%s)
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  finish=$(date +%s)
+  elapsed=$((finish - start))
+
+  kill "$listener" 2>/dev/null || true
+  wait "$listener" 2>/dev/null || true
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"mode: monitor"* ]]
+  # Tight enough to fail on the bridge's own 10s connect default: this probe must
+  # carry a status-sized timeout of its own, not inherit a delivery-sized one.
+  [ "$elapsed" -lt 8 ]
+}
+
+@test "delivery status (codex): the loaded-thread probe runs once, not once per identity (#579)" {
+  # Bounding the timeout is not enough on its own -- N identities with no seat
+  # would still pay it N times. Counted rather than timed, so it cannot pass by
+  # being fast.
+  bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" team bob   codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" team carol codex "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null
+
+  local calls="$TEST_SKILL_DIR/probe-calls"
+  local fake="$TEST_SKILL_DIR/counting-node"
+  {
+    printf '#!/usr/bin/env bash
+'
+    printf 'printf x >> %q
+' "$calls"
+    printf 'printf "thr-a\nthr-b\n"
+'
+  } > "$fake"
+  chmod +x "$fake"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/hash.sh"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf '1' > "$TEST_SKILL_DIR/run/codex-app-server.$(printf '%s' "$TEST_PROJECT" | agmsg_sha1).port"
+
+  AGMSG_NODE="$fake" run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  # Three seatless identities, one probe.
+  [ "$(wc -c < "$calls" | tr -d ' ')" = "1" ]
+  [[ "$output" == *"2 threads loaded"* ]]
+}


### PR DESCRIPTION
Closes #579.

A codex role's seat was recorded only when exactly one of the 40 newest rollouts
had a `session_meta` cwd matching the project. On a project worked in more than
once that count is never one, so the seat was never written — and every layer of
the monitor path requires it, so the bridge could not arm in that session or any
later one. The reporter measured 17 matching rollouts; a machine here has 44.

## Why not the three directions the report offers

Measured against a machine with the same shape (44 rollouts sharing one project
cwd, 6 among the 40 newest).

**Newest-matching-rollout fallback.** The two functions that pick a rollout do
not sort by the same key: `codex-record-session.sh` sorts by filename (creation
time), `agmsg_resolve_codex_thread` by mtime (last write). A resume appends to
the existing rollout rather than creating one, so creation order systematically
misses the thread in use. At measurement time the two disagreed — filename-newest
was last written 2.7 days earlier, mtime-newest 2 minutes earlier.

**Seat with what `agmsg_resolve_codex_thread` resolved.** Reconstructed at all 77
historical session starts across two projects: correct up to 2s of hook delay,
first wrong at 3s, shortest observed gap to another session's write 2.6s. The
decisive part is that its retry does not cover this — it returns the first match
in mtime order and only sleeps when there are *zero* matches, and a project with
history always has matches. Today a wrong resolution fails the seat comparison
and delivery stops; writing it into the seat turns the same value into a resume
that wakes the wrong conversation. Harmless becomes harmful.

**`--thread loaded`.** Recommended internally, then measured and dropped.
`thread/loaded/list` returned 3 ids while 2 Codex windows were running — the
app-server keeps a thread loaded after its window closes — and its order is
ascending by thread id, which for UUIDv7 is creation order, so `ids[0]` is the
*oldest* loaded thread: on that machine, another running agent's live session.

## What this does

Keep the rule — exactly one candidate or record nothing — and change what is
counted. Instead of rollouts matching the cwd, count the app-server's loaded
threads minus the threads a role already sits in. Stale loaded entries are
precisely the seated ones, so the remainder is the session not yet seated. A
unique remainder is recorded; anything else records nothing, leaving the bias
toward a fresh boot over a resume mis-fire unchanged.

The rollout scan stays as the fallback where there is no app-server to ask, and
the bridge rewrites the seat once armed, so the stored value is one the
app-server confirmed rather than one anything inferred.

`delivery.sh status` also stops reporting "not running" for a role that simply
has no seat, and in the ambiguous case says how many threads are loaded and what
recreates the app-server.

## Known limit

The subtraction needs at least one seat to subtract. An app-server already
holding several threads with no seat ever written — the state an upgrade lands
in — stays ambiguous until it is recreated. After one seat exists it is
consistent from then on. Recorded in #579 rather than left implicit.

## Verification

`--print-loaded-threads` was run against a live app-server, and the whole path
was exercised by driving a real Codex TUI through `codex-monitor.sh` under a pty
(the loaded set is 1 for a fresh session; adding a second role sequentially
leaves exactly one unclaimed id).

Mutation evidence, each breaking only what it should:

| mutation | fails |
| --- | --- |
| drop the subtraction | seats-the-unclaimed-thread |
| remove the app-server path (rollout scan only) | seats-the-unclaimed-thread, long-history |
| drop the type filter in `agmsg_role_session_recorded_uuids` | other-type-not-subtracted |
| restore the old single status line | both status tests |
