### PR TITLE
fix(key): keep the current epoch until the rotation is confirmed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -315,7 +315,11 @@ jobs:
     needs: changes
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Was 10, sized for the vectors and one filtered test. This job now runs
+    # every age-gated test -- about a hundred, across two files -- on top of a
+    # go install, so the old cap would have turned a slow runner into a
+    # cancellation rather than a result.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 
@@ -355,12 +359,25 @@ jobs:
           AGMSG_AGE_BIN="$age_bin" bats --print-output-on-failure tests/test_jsonl_remote_sync.bats
           AGE_BIN="$age_bin" node docs/spec/vectors/verify-age-v1-vectors.mjs
 
-      - name: Run encrypted onboarding CLI roundtrip
+      # Every test that gates itself on age, discovered from the tree rather than
+      # listed here. A list is how #567 happened on the Windows side: a file the
+      # list did not name ran in no job at all, and CI went on reporting green
+      # while never executing it. The same hole was open here -- 31 tests gate on
+      # age, the shards skip them for want of the binary, and this job named one
+      # of them, so 30 were executed nowhere. Two of those were already red.
+      - name: Run every age-gated test
         if: needs.changes.outputs.docs_only != 'true'
         run: |
           command -v age >/dev/null
           command -v age-keygen >/dev/null
-          bats --print-output-on-failure --filter 'remote unlock:' tests/test_remote.bats
+          files="$(grep -rl 'skip_if_no_age' tests/*.bats | sort | tr '\n' ' ')"
+          echo "age-gated files: $files"
+          # A discovery that finds nothing must fail loudly. Silently running no
+          # tests is indistinguishable from running them all successfully, which
+          # is the failure this step exists to end.
+          [ -n "$files" ] || { echo "::error::no age-gated test files found; the discovery is broken"; exit 1; }
+          # shellcheck disable=SC2086
+          bats --print-output-on-failure $files
 
   # Continuously verify that the storage contract is backend-portable: run the
   # SAME driver-agnostic contract suite against the jsonl driver (the sqlite run

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -130,6 +130,76 @@ _key_write_epoch_locked() {
   agmsg_write_atomic "$cfg" "$updated"
 }
 
+# _key_stage_epoch_locked <config_json_path> <epoch_json_expr>
+# Appends the epoch to remote_key.epochs and leaves remote_key.current alone.
+# Same locking contract as _key_write_epoch_locked.
+#
+# A rotation is announced locally but is not effective until the authority
+# sequences its journal record. remote_key.current means "the latest CONFIRMED
+# epoch" -- every reader of it is entitled to that -- so a rotation stages into
+# epochs and waits. Staging into current instead made key.sh import read the
+# announced replacement as the current key and take the idempotent re-import
+# path, so the announced-replacement install became unreachable on the machine
+# that rotated -- caught by tests/test_key.bats "key import: installs an
+# out-of-band replacement only after its fingerprint is announced".
+_key_stage_epoch_locked() {
+  local cfg="$1" epoch_expr="$2" escaped updated
+  escaped=$(sed "s/'/''/g" "$cfg")
+  updated=$(agmsg_sqlite_mem \
+    "SELECT json_set('$escaped',
+       '\$.remote_key.epochs',
+         json_insert(
+           CASE WHEN json_type(json_extract('$escaped', '\$.remote_key.epochs')) = 'array'
+                THEN json_extract('$escaped', '\$.remote_key.epochs') ELSE json('[]') END,
+           '\$[#]', $epoch_expr
+         )
+     );")
+  agmsg_write_atomic "$cfg" "$updated"
+}
+
+# _key_confirmed_epoch_revision <team>
+# The revision the authority has actually sequenced, read from the exported
+# snapshot chain -- the one place that knows. Empty (and non-zero) when there is
+# no chain to read, which is the caller's cue to leave current where it is
+# rather than guess.
+_key_confirmed_epoch_revision() {
+  local team="$1" snapshot revision
+  snapshot="$(mktemp "${TMPDIR:-/tmp}/agmsg-confirmed-epoch.XXXXXX")" || return 1
+  if ! bash "$SCRIPT_DIR/remote-sync.sh" export-age-snapshot \
+      --team "$team" --out "$snapshot" >/dev/null 2>&1; then
+    rm -f "$snapshot"
+    return 1
+  fi
+  revision="$(agmsg_sqlite_mem \
+    "SELECT json_extract(readfile('$(_agmsg_sqlesc "$snapshot")'), '\$.epoch_revision');")"
+  rm -f "$snapshot"
+  case "$revision" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s' "$revision"
+}
+
+# _key_promote_confirmed_locked <team> <config_json_path>
+# Move remote_key.current forward to the newest epoch the chain has confirmed.
+# Lazy on purpose: the chain is the single source of truth, so nothing has to
+# write back into this ledger at confirmation time -- readers just find current
+# already correct the next time key.sh runs. Same locking contract as above.
+_key_promote_confirmed_locked() {
+  local team="$1" cfg="$2" confirmed cur_revision escaped updated
+  confirmed="$(_key_confirmed_epoch_revision "$team")" || return 0
+  cur_revision="$(_key_read_config_field "$cfg" '$.remote_key.current.epoch_revision')"
+  case "$cur_revision" in ''|null|*[!0-9]*) return 0 ;; esac
+  [ "$confirmed" -gt "$cur_revision" ] 2>/dev/null || return 0
+  escaped=$(sed "s/'/''/g" "$cfg")
+  updated=$(agmsg_sqlite_mem \
+    "SELECT json_set('$escaped', '\$.remote_key.current',
+       (SELECT value FROM json_each(json_extract('$escaped', '\$.remote_key.epochs'))
+         WHERE json_extract(value, '\$.epoch_revision') = $confirmed
+         LIMIT 1));")
+  # No staged entry for that revision: leave the ledger alone rather than write
+  # a null over a live current.
+  case "$updated" in ''|*'"current":null'*) return 0 ;; esac
+  agmsg_write_atomic "$cfg" "$updated"
+}
+
 # _key_write_identity_atomic <dest_path> <content>
 # Writes <content> to <dest_path> without ever truncating an existing file
 # in place: create a same-directory temp file with mktemp (which itself
@@ -401,6 +471,10 @@ cmd_import() {
   # recipient must match it. Checking outside the lock would let a
   # concurrent generate/import race land a different key in between.
   agmsg_lock_acquire "$TEAMS_DIR/$team" || exit 1
+  # Catch up with the chain first: the branch below turns on what current is,
+  # and a rotation confirmed since the last key.sh run has not been copied here
+  # yet. Cheap and idempotent when nothing has moved.
+  _key_promote_confirmed_locked "$team" "$cfg"
   local cur_key_id cur_recipient
   cur_key_id="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
   cur_recipient="$(_key_read_config_field "$cfg" '$.remote_key.current.recipient')"
@@ -480,6 +554,9 @@ cmd_rotate() {
   chmod 700 "$cred_dir" 2>/dev/null || true
 
   agmsg_lock_acquire "$team_dir" || exit 1
+  # The replacement is minted relative to current, so current has to be the
+  # confirmed epoch before anything is computed from it.
+  _key_promote_confirmed_locked "$team" "$cfg"
   current_key="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
   if [ -z "$current_key" ] || [ "$current_key" = "null" ]; then
     agmsg_lock_release
@@ -630,7 +707,7 @@ EOF
   writer_generation="$(agmsg_sqlite_mem \
     "SELECT CAST('$(_agmsg_sqlesc "$(_key_read_config_field "$cfg" '$.remote_key.current.writer_generation')")' AS INTEGER) + 1;")"
   original_cfg="$(cat "$cfg")"
-  if ! _key_write_epoch_locked "$cfg" \
+  if ! _key_stage_epoch_locked "$cfg" \
       "$(_key_epoch_json "$key_id" "$next_epoch" "$writer_generation" "$recipient" "$previous_snapshot_sha" "$created_at")"; then
     rm -f "$identity_file"
     agmsg_lock_release

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -157,45 +157,73 @@ _key_stage_epoch_locked() {
   agmsg_write_atomic "$cfg" "$updated"
 }
 
-# _key_confirmed_epoch_revision <team>
-# The revision the authority has actually sequenced, read from the exported
-# snapshot chain -- the one place that knows. Empty (and non-zero) when there is
-# no chain to read, which is the caller's cue to leave current where it is
-# rather than guess.
-_key_confirmed_epoch_revision() {
-  local team="$1" snapshot revision
+# _key_confirmed_epoch <team>
+# The epoch the authority actually sequenced, as revision<TAB>key_id<TAB>recipient,
+# read from the tail of the exported snapshot chain -- the one place that knows.
+# Non-zero (and silent) when there is no chain to read, which is the caller's cue
+# to leave current where it is rather than guess.
+#
+# The revision alone does not identify it. Two machines can announce a rotation
+# at the same revision; the authority sequences one of them and the chain's tail
+# names THAT one, key and recipient included. Promoting on the revision would let
+# a machine whose local ledger holds the loser install the loser as effective --
+# the exact thing this file is here to prevent, in the case where it matters most.
+_key_confirmed_epoch() {
+  local team="$1" snapshot row
   snapshot="$(mktemp "${TMPDIR:-/tmp}/agmsg-confirmed-epoch.XXXXXX")" || return 1
   if ! bash "$SCRIPT_DIR/remote-sync.sh" export-age-snapshot \
       --team "$team" --out "$snapshot" >/dev/null 2>&1; then
     rm -f "$snapshot"
     return 1
   fi
-  revision="$(agmsg_sqlite_mem \
-    "SELECT json_extract(readfile('$(_agmsg_sqlesc "$snapshot")'), '\$.epoch_revision');")"
+  row="$(agmsg_sqlite_mem "
+    WITH doc(j) AS (SELECT readfile('$(_agmsg_sqlesc "$snapshot")')),
+         tail(e) AS (
+           SELECT value FROM doc, json_each(json_extract(doc.j, '\$.history'))
+            ORDER BY CAST(key AS INTEGER) DESC LIMIT 1)
+    SELECT json_extract(e, '\$.epoch_revision') || char(9) ||
+           json_extract(e, '\$.key_id')         || char(9) ||
+           json_extract(e, '\$.recipients[0]')
+      FROM tail;")"
   rm -f "$snapshot"
-  case "$revision" in ''|*[!0-9]*) return 1 ;; esac
-  printf '%s' "$revision"
+  case "$row" in ''|*'|'*) return 1 ;; esac
+  # A tail missing any of the three is not something to promote against.
+  case "$row" in *$'\t'*$'\t'*) ;; *) return 1 ;; esac
+  printf '%s' "$row"
 }
 
 # _key_promote_confirmed_locked <team> <config_json_path>
-# Move remote_key.current forward to the newest epoch the chain has confirmed.
-# Lazy on purpose: the chain is the single source of truth, so nothing has to
-# write back into this ledger at confirmation time -- readers just find current
-# already correct the next time key.sh runs. Same locking contract as above.
+# Move remote_key.current forward to the epoch the chain has confirmed, and only
+# when the local ledger holds that exact epoch -- revision, key_id and recipient
+# all matching. A machine that staged a competing rotation has no entry to
+# promote and keeps the epoch it has, which is the correct answer: it needs the
+# winner's identity imported before anything of its own becomes effective.
+#
+# Lazy on purpose: the chain is the single source of truth, so nothing writes
+# back into this ledger at confirmation time -- readers find current already
+# correct on the next key.sh run. Same locking contract as above.
 _key_promote_confirmed_locked() {
-  local team="$1" cfg="$2" confirmed cur_revision escaped updated
-  confirmed="$(_key_confirmed_epoch_revision "$team")" || return 0
+  local team="$1" cfg="$2" row confirmed_rev confirmed_key confirmed_rcpt \
+    cur_revision escaped updated
+  row="$(_key_confirmed_epoch "$team")" || return 0
+  confirmed_rev="${row%%	*}"
+  confirmed_key="${row#*	}"; confirmed_key="${confirmed_key%%	*}"
+  confirmed_rcpt="${row##*	}"
+  case "$confirmed_rev" in ''|*[!0-9]*) return 0 ;; esac
+  [ -n "$confirmed_key" ] && [ -n "$confirmed_rcpt" ] || return 0
   cur_revision="$(_key_read_config_field "$cfg" '$.remote_key.current.epoch_revision')"
   case "$cur_revision" in ''|null|*[!0-9]*) return 0 ;; esac
-  [ "$confirmed" -gt "$cur_revision" ] 2>/dev/null || return 0
+  [ "$confirmed_rev" -gt "$cur_revision" ] 2>/dev/null || return 0
   escaped=$(sed "s/'/''/g" "$cfg")
   updated=$(agmsg_sqlite_mem \
     "SELECT json_set('$escaped', '\$.remote_key.current',
        (SELECT value FROM json_each(json_extract('$escaped', '\$.remote_key.epochs'))
-         WHERE json_extract(value, '\$.epoch_revision') = $confirmed
+         WHERE json_extract(value, '\$.epoch_revision') = $confirmed_rev
+           AND json_extract(value, '\$.key_id')        = '$(_agmsg_sqlesc "$confirmed_key")'
+           AND json_extract(value, '\$.recipient')     = '$(_agmsg_sqlesc "$confirmed_rcpt")'
          LIMIT 1));")
-  # No staged entry for that revision: leave the ledger alone rather than write
-  # a null over a live current.
+  # No local entry for the confirmed winner: leave the ledger alone rather than
+  # write a null over a live current.
   case "$updated" in ''|*'"current":null'*) return 0 ;; esac
   agmsg_write_atomic "$cfg" "$updated"
 }

--- a/tests/test_ci_workflow.bats
+++ b/tests/test_ci_workflow.bats
@@ -15,7 +15,7 @@
   [ "$status" -eq 0 ]
 }
 
-@test "age-v1 CI exercises the encrypted onboarding CLI with pinned tools" {
+@test "age-v1 CI exercises every age-gated test with pinned tools" {
   local workflow="$BATS_TEST_DIRNAME/../.github/workflows/tests.yml"
 
   run grep -F 'filippo.io/age/cmd/age-keygen@v1.3.1' "$workflow"
@@ -26,6 +26,17 @@
   [ "$status" -eq 0 ]
   run grep -F 'command -v age-keygen >/dev/null' "$workflow"
   [ "$status" -eq 0 ]
-  run grep -F "bats --print-output-on-failure --filter 'remote unlock:' tests/test_remote.bats" "$workflow"
+
+  # This used to pin a single filtered invocation, which pinned the hole in
+  # place: 31 tests gate on age, the shards skip them for want of the binary,
+  # and naming one file's worth here left 30 running nowhere -- five of them
+  # red. What has to hold is that the set is DISCOVERED, so a new age-gated
+  # file cannot land outside every job.
+  run grep -F "grep -rl 'skip_if_no_age' tests/*.bats" "$workflow"
+  [ "$status" -eq 0 ]
+  run grep -F 'bats --print-output-on-failure $files' "$workflow"
+  [ "$status" -eq 0 ]
+  # ...and that finding nothing is a failure rather than a quiet pass.
+  run grep -F 'no age-gated test files found' "$workflow"
   [ "$status" -eq 0 ]
 }

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -38,21 +38,25 @@ open(p, 'w').write(json.dumps(d) + '\\n')
 "
 }
 
+# $1 = the epoch revision the authority has confirmed (default 0, i.e. nothing
+# rotated yet has been sequenced). key.sh derives "is this rotation effective"
+# from the exported chain, so this is how a test says confirmed or not.
 stub_current_age_snapshot() {
-  cat > "$SCRIPTS/remote-sync.sh" <<'EOF'
+  local revision="${1:-0}"
+  cat > "$SCRIPTS/remote-sync.sh" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
-[ "$1" = "export-age-snapshot" ]
+[ "\$1" = "export-age-snapshot" ]
 shift
 out=""
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --out) out="$2"; shift 2 ;;
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --out) out="\$2"; shift 2 ;;
     *) shift ;;
   esac
 done
-[ -n "$out" ]
-printf '%s' '{"epoch_revision":"0"}' > "$out"
+[ -n "\$out" ]
+printf '%s' '{"epoch_revision":"${revision}"}' > "\$out"
 EOF
   chmod +x "$SCRIPTS/remote-sync.sh"
 }
@@ -332,6 +336,43 @@ EOF
 
 # --- rotate ---------------------------------------------------------------
 
+@test "key rotate: current moves only when the chain confirms the rotation" {
+  skip_if_no_age
+  # The other half of the staged contract. A rotation is announced locally and
+  # becomes effective when the authority sequences its journal record. The
+  # exported snapshot chain is the only thing that knows, so key.sh derives it
+  # from there and copies it into current on its next run -- nothing writes back
+  # into this ledger at confirmation time.
+  bash "$SCRIPTS/key.sh" generate testteam
+  local cfg_json="$SCRIPTS/../teams/testteam/config.json"
+  local first; first="$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['current']['key_id'])")"
+
+  stub_current_age_snapshot 0
+  bash "$SCRIPTS/key.sh" rotate testteam >/dev/null
+  local staged; staged="$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['epochs'][-1]['key_id'])")"
+  [ "$staged" != "$first" ]
+  # Unconfirmed: current still names the epoch actually in force.
+  [ "$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['current']['key_id'])")" = "$first" ]
+
+  # A staged rotation is visible to the reader that needs it -- rotating again
+  # before the authority has spoken is refused -- without ever being treated as
+  # effective.
+  run bash "$SCRIPTS/key.sh" rotate testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unacknowledged key rotation"* ]]
+  [ "$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['current']['key_id'])")" = "$first" ]
+
+  # The chain now reports the rotation as sequenced. The next key.sh run catches
+  # up, and only then does current name the replacement.
+  stub_current_age_snapshot 1
+  local identity secret
+  identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$staged.key"
+  secret=$(grep '^AGE-SECRET-KEY-' "$identity")
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --key-id '$staged' --identity-stdin"
+  [ "$status" -eq 0 ]
+  [ "$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['current']['key_id'])")" = "$staged" ]
+}
+
 @test "key rotate: creates a replacement identity and journals only its fingerprint" {
   skip_if_no_age
   bash "$SCRIPTS/key.sh" generate testteam
@@ -347,8 +388,13 @@ EOF
   [[ "$key_id" == epoch-* ]]
   [[ "$fingerprint" =~ ^[0-9a-f]{64}$ ]]
   [ -f "$SCRIPTS/../run/remote-credentials/testteam/keys/$key_id.key" ]
-  [ "$(python3 -c "import json; d=json.load(open('$SCRIPTS/../teams/testteam/config.json')); print(d['remote_key']['current']['key_id'])")" = "$key_id" ]
-  [ "$(python3 -c "import json; d=json.load(open('$SCRIPTS/../teams/testteam/config.json')); print(len(d['remote_key']['epochs']))")" -eq 2 ]
+  # Staged, not effective: the chain has not sequenced this rotation, so current
+  # still names the epoch that is actually in force. The replacement is the
+  # trailing entry in epochs.
+  cfg_json="$SCRIPTS/../teams/testteam/config.json"
+  [ "$(python3 -c "import json; d=json.load(open('$cfg_json')); print(d['remote_key']['current']['key_id'])")" != "$key_id" ]
+  [ "$(python3 -c "import json; d=json.load(open('$cfg_json')); print(d['remote_key']['epochs'][-1]['key_id'])")" = "$key_id" ]
+  [ "$(python3 -c "import json; d=json.load(open('$cfg_json')); print(len(d['remote_key']['epochs']))")" -eq 2 ]
   ! grep -q 'AGE-SECRET-KEY\\|age1' "$journal"
   run bash "$SCRIPTS/key.sh" show testteam --key-id "$key_id"
   [ "$status" -eq 0 ]

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -39,10 +39,15 @@ open(p, 'w').write(json.dumps(d) + '\\n')
 }
 
 # $1 = the epoch revision the authority has confirmed (default 0, i.e. nothing
-# rotated yet has been sequenced). key.sh derives "is this rotation effective"
-# from the exported chain, so this is how a test says confirmed or not.
+# rotated yet has been sequenced). $2/$3 = the key_id and recipient it sequenced.
+# The chain's tail names the WINNER, not just the revision: competing rotations
+# share a revision and the authority picks one, so a test that wants a rotation
+# confirmed has to say which one.
 stub_current_age_snapshot() {
-  local revision="${1:-0}"
+  local revision="${1:-0}" key_id="${2:-}" recipient="${3:-}" history=""
+  if [ -n "$key_id" ]; then
+    history=",\"history\":[{\"epoch_revision\":\"${revision}\",\"key_id\":\"${key_id}\",\"recipients\":[\"${recipient}\"]}]"
+  fi
   cat > "$SCRIPTS/remote-sync.sh" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
@@ -56,7 +61,7 @@ while [ \$# -gt 0 ]; do
   esac
 done
 [ -n "\$out" ]
-printf '%s' '{"epoch_revision":"${revision}"}' > "\$out"
+printf '%s' '{"epoch_revision":"${revision}"${history}}' > "\$out"
 EOF
   chmod +x "$SCRIPTS/remote-sync.sh"
 }
@@ -364,13 +369,80 @@ EOF
 
   # The chain now reports the rotation as sequenced. The next key.sh run catches
   # up, and only then does current name the replacement.
-  stub_current_age_snapshot 1
+  local staged_rcpt
+  staged_rcpt="$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['epochs'][-1]['recipient'])")"
+  stub_current_age_snapshot 1 "$staged" "$staged_rcpt"
   local identity secret
   identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$staged.key"
   secret=$(grep '^AGE-SECRET-KEY-' "$identity")
   run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --key-id '$staged' --identity-stdin"
   [ "$status" -eq 0 ]
   [ "$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['current']['key_id'])")" = "$staged" ]
+}
+
+# Two machines can announce a rotation at the same revision. The authority
+# sequences one, and the chain's tail names that one -- key and recipient
+# included. Promoting on the revision alone would let a machine holding the
+# other candidate install it as effective, which is the failure this whole
+# change exists to prevent, in the case where it costs the most.
+_add_competing_epoch() {   # $1 = config path, $2 = key_id, $3 = revision
+  python3 - "$1" "$2" "$3" <<'EOS'
+import json, sys
+path, key_id, revision = sys.argv[1], sys.argv[2], int(sys.argv[3])
+cfg = json.load(open(path))
+epochs = cfg["remote_key"]["epochs"]
+rival = dict(epochs[-1])
+rival["key_id"] = key_id
+rival["epoch_revision"] = revision
+rival["recipient"] = "age1" + "r" * 58
+epochs.insert(len(epochs) - 1, rival)      # the rival lands FIRST
+json.dump(cfg, open(path, "w"), indent=2)
+EOS
+}
+
+@test "key rotate: a competing epoch at the same revision is not promoted in the winner's place" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  local cfg_json="$SCRIPTS/../teams/testteam/config.json"
+  stub_current_age_snapshot 0
+  bash "$SCRIPTS/key.sh" rotate testteam >/dev/null
+  local winner winner_rcpt
+  winner="$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['epochs'][-1]['key_id'])")"
+  winner_rcpt="$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['epochs'][-1]['recipient'])")"
+  _add_competing_epoch "$cfg_json" "epoch-rival-0001" 1
+  # The rival is ahead of the winner in the ledger, so a revision-only match
+  # would pick it.
+  [ "$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['epochs'][-2]['key_id'])")" = "epoch-rival-0001" ]
+
+  stub_current_age_snapshot 1 "$winner" "$winner_rcpt"
+  bash "$SCRIPTS/key.sh" show testteam >/dev/null 2>&1 || true
+  local identity secret
+  identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$winner.key"
+  secret=$(grep '^AGE-SECRET-KEY-' "$identity")
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --key-id '$winner' --identity-stdin"
+  [ "$status" -eq 0 ]
+  [ "$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['current']['key_id'])")" = "$winner" ]
+}
+
+@test "key rotate: current stays put when the ledger has no entry for the confirmed winner" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  local cfg_json="$SCRIPTS/../teams/testteam/config.json"
+  local first; first="$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['current']['key_id'])")"
+  stub_current_age_snapshot 0
+  bash "$SCRIPTS/key.sh" rotate testteam >/dev/null
+
+  # This machine announced a rotation the authority did NOT sequence. It has no
+  # copy of the winner, so there is nothing here that may become effective --
+  # the winner's identity has to be imported first.
+  stub_current_age_snapshot 1 "epoch-someone-elses-0001" "age1$(printf 'w%.0s' $(seq 58))"
+  bash "$SCRIPTS/key.sh" show testteam >/dev/null 2>&1 || true
+  local staged; staged="$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['epochs'][-1]['key_id'])")"
+  local identity secret
+  identity="$SCRIPTS/../run/remote-credentials/testteam/keys/$staged.key"
+  secret=$(grep '^AGE-SECRET-KEY-' "$identity")
+  run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --key-id '$staged' --identity-stdin"
+  [ "$(python3 -c "import json; print(json.load(open('$cfg_json'))['remote_key']['current']['key_id'])")" = "$first" ]
 }
 
 @test "key rotate: creates a replacement identity and journals only its fingerprint" {


### PR DESCRIPTION
Draft. The CI change lands first so the pre-existing failures are visible in CI before the fix goes on top.

**Correction:** an earlier revision of this description said two tests were red, and the first commit body says the same. It is **five**. Three of them pass on macOS and fail on Linux, so a local run understated it. All five are pre-existing on `integration/remote` — this branch's only change so far is `.github/workflows/tests.yml`.

## The hole

`age` gates 31 tests. The shards run their files without the binary, so they skip; this job had the binary and named one file's worth. 30 ran nowhere, and five of those are red.

The set is now discovered from the tree rather than listed. A list is how the same hole opened on the Windows side in #567 — a file the list did not name ran in no job at all while CI reported green. A discovery that finds nothing fails the step, because running no tests and running them all successfully look identical from outside.

## What is red

```
tests/test_key.bats
  "key generate: private identity file is 0600 and not inside config.json"
  "key handoff without --out never writes the secret bundle under cwd"
  "key import: identity file is still valid and intact after a re-import (atomic write, no truncation)"
  "key import: installs an out-of-band replacement only after its fingerprint is announced"
tests/test_remote.bats
  "connect: a keyed team fails closed when the remote disallows age-v1"
```

Tests are named by file and test name, not by their position in a run: that position moves with sharding, filters and file order, and the numbers collide with real issue numbers.

The three `stat`-idiom failures and the `connect` one are being handled separately. **This PR carries only the CI change and the `key import` fix.**

## The `key import` fix

`key.sh rotate` advanced `remote_key.current` to the newly minted epoch. `key.sh import` decides between "idempotent re-import of the current key" and "install of an announced replacement" by comparing against `remote_key.current`, so on the machine that rotated the replacement path became unreachable. Bisected to `c1d478b` (07-30), whose own message says the old epoch should stay effective until the authority sequences the rotation — the config had no way to express that.

`current` now means "the latest **confirmed** epoch". A rotation stages into `remote_key.epochs` and waits; the confirmed revision is derived from the exported snapshot chain, which is the one place that knows, and `current` is promoted lazily when the chain has moved on. Nothing writes back into this ledger at confirmation time.
