### PR TITLE
test(key): read a mode by platform, not by letting the BSD form fail

### DIFF
--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -58,6 +58,25 @@ skip_on_windows() {
 # This is the test-side mirror of scripts/lib/storage.sh's agmsg_sqlite_mem.
 sqlite_mem() { sqlite3 :memory: "$@" | tr -d '\r'; }
 
+# Permission bits of <path> as octal, e.g. 700.
+#
+# NOT `stat -f "%Lp" "$p" 2>/dev/null || stat -c "%a" "$p"`. That idiom leans on
+# the BSD form FAILING under GNU. It does fail — but only after writing
+# filesystem information to STDOUT, because GNU reads `-f` as `--file-system`
+# and the format string as a second file operand. `2>/dev/null` hides the error
+# it then prints, not the output already written, so the capture becomes that
+# block with the real mode appended and no comparison can match. Green on macOS,
+# red on any GNU host, and the reason is invisible at the call site.
+#
+# Branch on the platform instead, the way scripts/lib/compat.sh already does for
+# mtime. One implementation so a fourth call site cannot reintroduce it.
+file_mode() {
+  case "$(uname -s)" in
+    Darwin*) stat -f "%Lp" "$1" ;;
+    *)       stat -c "%a" "$1" ;;
+  esac
+}
+
 # Resolve a file path for use inside a sqlite3 readfile('...') call in a test.
 # On native Windows, sqlite3 only reads a Windows path (C:\Users\...), not a Git
 # Bash POSIX path (/c/Users/... or /tmp/...): an unconverted path reads back as

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -104,7 +104,7 @@ EOF
   key_id=$(python3 -c "import json; print(json.load(open('$SCRIPTS/../teams/testteam/config.json'))['remote_key']['current']['key_id'])")
   identity_file="$SCRIPTS/../run/remote-credentials/testteam/keys/$key_id.key"
   [ -f "$identity_file" ]
-  perms=$(stat -f "%Lp" "$identity_file" 2>/dev/null || stat -c "%a" "$identity_file")
+  perms=$(file_mode "$identity_file")
   [ "$perms" = "600" ]
   run grep -c "AGE-SECRET-KEY" "$SCRIPTS/../teams/testteam/config.json"
   [ "$output" -eq 0 ]
@@ -217,7 +217,7 @@ EOF
   [ -f "$private_bundle" ]
   [[ "$output" == *"Handoff bundle written to: $private_bundle"* ]]
   local perms
-  perms=$(stat -f "%Lp" "$(dirname "$private_bundle")" 2>/dev/null || stat -c "%a" "$(dirname "$private_bundle")")
+  perms=$(file_mode "$(dirname "$private_bundle")")
   [ "$perms" = "700" ]
 }
 
@@ -281,7 +281,7 @@ EOF
   run bash -c "printf '%s' '$secret' | bash '$SCRIPTS/key.sh' import testteam --identity-stdin"
   [ "$status" -eq 0 ]
   [ -f "$identity_file" ]
-  perms=$(stat -f "%Lp" "$identity_file" 2>/dev/null || stat -c "%a" "$identity_file")
+  perms=$(file_mode "$identity_file")
   [ "$perms" = "600" ]
   run bash -c "age-keygen -y < '$identity_file'"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Three tests in `tests/test_key.bats` are green on macOS and red on any GNU host. #585 is what exposed them — it replaced a hardcoded `--filter 'remote unlock:'` with discovery of every file containing `skip_if_no_age`, so these ran in CI for the first time.

## The idiom

```bash
perms=$(stat -f "%Lp" "$p" 2>/dev/null || stat -c "%a" "$p")
```

at lines 107, 220 and 284 — one per failing test.

It is written as if `-f` were rejected under GNU and the fallback took over cleanly. Measured on `ubuntu:24.04`:

```
$ stat -f "%Lp" /tmp/d ; echo "exit=$?"
  File: "/tmp/d"
    ID: a07832daad6b43d6 Namelen: 255     Type: overlayfs
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 479186302  Free: 447528050  Available: 423168281
Inodes: Total: 121782272  Free: 120481724
stat: cannot read file system information for '%Lp': No such file or directory
exit=1
```

GNU reads `-f` as `--file-system` and `"%Lp"` as a second file operand. The missing operand makes it exit 1, so `||` **does** fire — but the filesystem block for the real path is already on **stdout**. `2>/dev/null` suppresses the error it prints afterwards, not the output written before it. The capture ends up as that block with `700` appended, and no comparison can match:

```
old idiom on GNU = [  File: "/tmp/d"|    ID: … Type: overlayfs|Block size: 4096 …|700|]
new helper on GNU = [700]
```

## The fix

One `file_mode` helper in `tests/test_helper.bash` that branches on the platform — the shape `scripts/lib/compat.sh` already uses for mtime — and three call sites converted. One implementation, so a fourth site cannot reintroduce it.

Swept the repo: no other `stat -f`/`stat -c` fallback pair remains. The only survivors are `compat.sh` (already branching) and the new helper.

## Two claims this rules out

- **Not age 1.3.1.** Local macOS runs age v1.3.1 and these three are green there, so the age version is not the variable. "Red under GNU coreutils" is the accurate statement, and it collapses the "Linux *or* age 1.3.1" disjunction to one cause.
- **Not the product.** The idiom is only in the test file; `compat.sh` was already correct.

## Verification

- `ubuntu:24.04`: old idiom yields the filesystem block + mode; the helper yields `700`.
- macOS `tests/test_key.bats`: 27 passed, 1 failed — the one failure is `key import: installs an out-of-band replacement only after its fingerprint is announced`, which is a separate red owned elsewhere and unchanged by this PR.

## Not in this PR

`tests/test_remote.bats` — `connect: a keyed team fails closed when the remote disallows age-v1`. It has a different cause and is **not** platform-specific: it fails on macOS too, and was hidden by the old CI filter rather than by the platform. Separate PR.