### PR TITLE
test(remote): let the mock refuse age-v1 where the client actually reads it

### DIFF
--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -416,7 +416,7 @@ class Handler(BaseHTTPRequestHandler):
                 "current_seq": "0",
                 "next_sequence_boundary": "1",
                 "accepted_envelope_versions": [1],
-                "write_allowed_ciphers": ["none", "age-v1"],
+                "write_allowed_ciphers": CONNECT_CIPHERS,
                 "policy_revision": "0",
                 "effective_from_seq": "1",
                 "max_blob_bytes": "1048576",


### PR DESCRIPTION
`connect: a keyed team fails closed when the remote disallows age-v1` in `tests/test_remote.bats` never passed. It looked like a Linux-only red because #585 is what first ran this file in CI; before that the step filtered it down to `--filter 'remote unlock:'`. **It fails on macOS too** — the platform was never the variable.

## What the flag actually did

`MOCK_CONNECT_NO_AGE=1` sets `CONNECT_CIPHERS = ["none"]`. On the `/v1/connect` response the mock applied it to `policy_history` but left the top-level field a literal:

```python
"write_allowed_ciphers": ["none", "age-v1"],          # line 419 — hardcoded
…
"policy_history": [{… "write_allowed_ciphers": CONNECT_CIPHERS}],   # line 426 — honoured
```

The client reads the **top level** — `_remote_binding_allows_cipher` queries `$.remote_binding.capabilities.write_allowed_ciphers` — so the condition the test asserts was never staged. Reproduced outside bats by starting the mock with the flag and calling the endpoint:

```
$ MOCK_CONNECT_NO_AGE=1 python3 tests/helpers/mock_remote_server.py 0
$ curl -s -X POST http://127.0.0.1:$PORT/v1/connect -d '{"team":"t"}'
… "write_allowed_ciphers": ["none", "age-v1"] …
… "policy_history": [{… "write_allowed_ciphers": ["none"]}]
```

Two other handlers in the same file pair the fields the other way round, which is what made this one stand out: at line 181/189 both use `CONNECT_CIPHERS`; at line 320/324 the top level uses it and the history is the literal. Only `/v1/connect` had it inverted.

## The product was already right — and is now actually covered

`_remote_configure_keyed_team` (`scripts/remote.sh:1338`) refuses when the binding does not allow `age-v1`, and this PR does not touch it.

That claim needs more than "the test went green", because for as long as the condition was never staged this test could not have caught the refusal breaking. So the refusal itself was mutated:

| state | result |
|---|---|
| refusal removed from `remote.sh:1338` | test **fails** (`[ "$status" -ne 0 ]`) |
| refusal restored | test **passes** |

So the assertion now depends on the product behaviour it names, not merely on the mock's value. (Reverting only the mock line also puts it back to failing, which is the separate check that it depends on the staged condition.)

## Verification

- `tests/test_remote.bats`: **72 passed, 0 failed** on macOS (was 71/1).
- Both mutations above.

## Deliberately not changed

Line 324 — the `policy_history` literal in the `/v1/teams/<id>` handler — is inconsistent in the same way but is not what this test reads, and nothing here establishes it as wrong. Noted rather than swept along.