### PR TITLE
docs(design): mark the superseded onboarding designs as superseded

### DIFF
--- a/docs/design/ref/authentication-result-handoff.md
+++ b/docs/design/ref/authentication-result-handoff.md
@@ -1,5 +1,11 @@
 # Handing an authentication result to a host's authorization decision
 
+> **SUPERSEDED.** The onboarding this describes was replaced by
+> [`docs/design/remote-sync.md`](../remote-sync.md), which states the replacement
+> from its own side. Kept as design history: the reasoning here is why the
+> current shape is what it is, and the findings it records were closed rather
+> than dropped. Do not build to it.
+
 **Status: review passed; adoption undecided.** Revision 5. Design study for a
 seam the reference server does not have yet. It is deliberately narrow: it does
 not change who may connect, it changes how many times a request establishes

--- a/docs/design/ref/device-pairing.md
+++ b/docs/design/ref/device-pairing.md
@@ -1,5 +1,11 @@
 # Device pairing (`key request` / `key approve`)
 
+> **SUPERSEDED.** The onboarding this describes was replaced by
+> [`docs/design/remote-sync.md`](../remote-sync.md), which states the replacement
+> from its own side. Kept as design history: the reasoning here is why the
+> current shape is what it is, and the findings it records were closed rather
+> than dropped. Do not build to it.
+
 **Status: draft, revision 7.** Replaces the NOT READY subsection of
 `remote-connect-onboarding.md` §8, which recorded five findings from an
 adversarial review. A2 (one-directional authentication) was closed by the

--- a/docs/design/ref/local-first-onboarding.md
+++ b/docs/design/ref/local-first-onboarding.md
@@ -1,5 +1,11 @@
 # Local-first onboarding and convergent roster design
 
+> **SUPERSEDED.** The onboarding this describes was replaced by
+> [`docs/design/remote-sync.md`](../remote-sync.md), which states the replacement
+> from its own side. Kept as design history: the reasoning here is why the
+> current shape is what it is, and the findings it records were closed rather
+> than dropped. Do not build to it.
+
 **Status:** design gate
 **Last updated:** 2026-07-25
 **Owner:** @fujibee

--- a/docs/design/ref/remote-connect-onboarding.md
+++ b/docs/design/ref/remote-connect-onboarding.md
@@ -1,5 +1,11 @@
 # Remote connect onboarding design
 
+> **SUPERSEDED.** The onboarding this describes was replaced by
+> [`docs/design/remote-sync.md`](../remote-sync.md), which states the replacement
+> from its own side. Kept as design history: the reasoning here is why the
+> current shape is what it is, and the findings it records were closed rather
+> than dropped. Do not build to it.
+
 **Status:** implemented dogfood design — §1/§1a-§1c/§8's four key commands (generate/show/
 import) and §0-§7's connect/status/disconnect/doctor are approved and
 implemented (this PR). `key rotate` remains NOT READY — see §8 — and is


### PR DESCRIPTION
First of the cleanup PRs from the phase-1 inventory. Docs only.

`remote-sync.md` has stated since it was written that it replaces the onboarding halves of `remote-connect-onboarding.md`, `local-first-onboarding.md`, `device-pairing.md` and `authentication-result-handoff.md`. The four said nothing back — a reader arriving at one of them from a search had no way to know it describes a shape nobody is building to.

Marked rather than deleted, per the ADR discipline: the reasoning in them is why the current design looks the way it does, and the adversarial findings they record were closed rather than dropped. That belongs in `ref/`.

No code, no tests. The remaining cleanup PRs (pairing exchange, the `pairing_tokens` drop, the dead pending writer, the pending surface) follow separately, one concern each.