### PR TITLE
feat: add `agmsg export` — dump a team's message history as JSONL

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -64,6 +64,12 @@ Do NOT manually edit config files. Always use join.sh. If the name was recently 
 # Message history
 ~/.agents/skills/agmsg/scripts/history.sh <team> [agent_id] [limit]
 
+# Export a team's message history as JSONL — one message_sent record per line,
+# chronological. Default to stdout (pipeable); --out <file> writes a file.
+# --agent limits to one agent; --limit keeps the most recent N (omit = all
+# currently retained). Output is plaintext (the local store is plaintext).
+~/.agents/skills/agmsg/scripts/export.sh --team <team> [--agent <agent>] [--limit N] [--out <file>]
+
 # List team members
 ~/.agents/skills/agmsg/scripts/team.sh <team>
 

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -69,16 +69,30 @@ emit() {
 }
 
 if [ -n "$OUT" ]; then
-  # Stream to a temp file in the SAME directory, then rename on success. A driver
-  # failure mid-export therefore never truncates or corrupts an existing out
-  # file (the old file survives), and the full history is never held in memory.
-  # Empty export still yields an empty file (a valid, zero-record export).
-  tmp="${OUT}.tmp.$$"
+  # Stream to a same-directory temp, then rename on success. Two properties, both
+  # load-bearing (mirrors scripts/key.sh's _key_write_identity_atomic):
+  #  - Atomic: a driver failure mid-export never truncates or corrupts an
+  #    existing out file (the old file survives), and the full history is never
+  #    held in memory.
+  #  - Safe: the temp is created by mktemp (O_EXCL + an UNPREDICTABLE name), so a
+  #    process sharing the out directory cannot pre-plant a symlink at a guessable
+  #    temp path and redirect our plaintext onto an arbitrary file. A predictable
+  #    "$OUT.tmp.$$" opened with plain `>` would make the atomicity fix itself a
+  #    write primitive against any file the caller can write.
+  out_dir="$(cd "$(dirname "$OUT")" && pwd)"
+  tmp="$(mktemp "$out_dir/.export-XXXXXX")" || {
+    printf 'export.sh: cannot create a temp file in %s\n' "$out_dir" >&2; exit 1
+  }
+  chmod 600 "$tmp"
+  # A signal between mktemp and the rename would otherwise leave a 0600-but-never-
+  # renamed plaintext temp behind; clean it on any exit path, then drop the trap
+  # once the rename has happened (an empty export still yields an empty file).
+  trap 'rm -f "$tmp"' EXIT HUP INT TERM
   if emit > "$tmp"; then
     mv -f "$tmp" "$OUT"
+    trap - EXIT HUP INT TERM
   else
     rc=$?
-    rm -f "$tmp"
     exit "$rc"
   fi
 else

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: export.sh --team <team> [--agent <agent>] [--limit N] [--out <file>]
+#
+# Exports a team's message history as JSONL — one `message_sent` record per line,
+# in chronological order (oldest first). Default output is stdout (pipeable to
+# the next tool); --out <file> writes to a file instead. --agent limits to one
+# agent's messages (sender or recipient); omitted = the whole team. --limit N
+# keeps the most recent N; omitted = everything retained.
+#
+# "Full" means everything CURRENTLY RETAINED — the sync/retention window for the
+# team's plan — not necessarily everything ever sent.
+#
+# Output is plaintext. agmsg's end-to-end encryption is transport-only: messages
+# are sealed on the wire and the server holds only ciphertext, but each of your
+# machines unseals into a plaintext local store. Export reads that local store,
+# so it needs no key and produces plaintext. (A server-side ciphertext archive,
+# if ever offered, is a separate feature — not this command.)
+
+usage() {
+  sed -n '4,20p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+TEAM=""; AGENT=""; LIMIT=""; OUT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --team)  TEAM="${2:?Missing value for --team}"; shift 2 ;;
+    --agent) AGENT="${2:?Missing value for --agent}"; shift 2 ;;
+    --limit) LIMIT="${2:?Missing value for --limit}"; shift 2 ;;
+    --out)   OUT="${2:?Missing value for --out}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'export.sh: unknown argument: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$TEAM" ] || { printf 'export.sh: --team is required\n' >&2; usage >&2; exit 2; }
+# A non-numeric --limit is treated as unset (full export) rather than passed
+# through, mirroring history.sh's guard; the driver also revalidates.
+case "$LIMIT" in ''|*[!0-9]*) LIMIT="" ;; esac
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/storage.sh"
+agmsg_storage_load
+
+# storage_history would storage_init (create) a missing store, but an export is
+# a read and must not create one. A team never written to reads out as an empty
+# export. Driver-level, so it holds for jsonl too.
+JSONL=""
+if storage_store_exists "$TEAM"; then
+  # <agent> optional (omitted = team-wide); --limit optional (omitted = all).
+  args=("$TEAM")
+  [ -n "$AGENT" ] && args+=("$AGENT")
+  [ -n "$LIMIT" ] && args+=(--limit "$LIMIT")
+  JSONL="$(storage_history "${args[@]}")"
+fi
+
+if [ -n "$OUT" ]; then
+  # Empty history writes an empty file (a valid, zero-record export).
+  if [ -n "$JSONL" ]; then printf '%s\n' "$JSONL" > "$OUT"; else : > "$OUT"; fi
+else
+  # Default: stdout, so it pipes to the next tool. When stdout is a terminal the
+  # plaintext message contents would print straight to the screen — note it on
+  # stderr (data still goes to stdout), the same care as the key-reveal screens.
+  # Plain `if` blocks (not `&&`), so an empty export still exits 0 under set -e.
+  if [ -t 1 ]; then
+    printf 'export.sh: writing plaintext message contents to the terminal; use --out <file> to save to a file.\n' >&2
+  fi
+  if [ -n "$JSONL" ]; then
+    printf '%s\n' "$JSONL"
+  fi
+fi
+exit 0

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# --- usage ---
 # Usage: export.sh --team <team> [--agent <agent>] [--limit N] [--out <file>]
 #
 # Exports a team's message history as JSONL — one `message_sent` record per line,
@@ -8,9 +9,13 @@ set -euo pipefail
 # the next tool); --out <file> writes to a file instead. --agent limits to one
 # agent's messages (sender or recipient); omitted = the whole team. --limit N
 # keeps the most recent N; omitted = everything retained.
+# --- end usage ---
 #
 # "Full" means everything CURRENTLY RETAINED — the sync/retention window for the
-# team's plan — not necessarily everything ever sent.
+# team's plan — not necessarily everything ever sent. Because export is the
+# "give me all of it" command, the history is STREAMED to stdout/the file (never
+# collected into a shell variable first), so an export stays O(1) in memory even
+# for a team with a large retention window.
 #
 # Output is plaintext. agmsg's end-to-end encryption is transport-only: messages
 # are sealed on the wire and the server holds only ciphertext, but each of your
@@ -18,8 +23,11 @@ set -euo pipefail
 # so it needs no key and produces plaintext. (A server-side ciphertext archive,
 # if ever offered, is a separate feature — not this command.)
 
+# usage() reads the marker-delimited block above, not fixed line numbers, so
+# adding a comment elsewhere in the header can't silently misalign --help.
 usage() {
-  sed -n '4,20p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '/^# --- usage ---$/,/^# --- end usage ---$/p' "$0" \
+    | sed -e '/^# --- /d' -e 's/^# \{0,1\}//'
 }
 
 TEAM=""; AGENT=""; LIMIT=""; OUT=""
@@ -43,31 +51,43 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 agmsg_storage_load
 
-# storage_history would storage_init (create) a missing store, but an export is
-# a read and must not create one. A team never written to reads out as an empty
-# export. Driver-level, so it holds for jsonl too.
-JSONL=""
-if storage_store_exists "$TEAM"; then
-  # <agent> optional (omitted = team-wide); --limit optional (omitted = all).
-  args=("$TEAM")
-  [ -n "$AGENT" ] && args+=("$AGENT")
-  [ -n "$LIMIT" ] && args+=(--limit "$LIMIT")
-  JSONL="$(storage_history "${args[@]}")"
-fi
+# <agent> optional (omitted = team-wide); --limit optional (omitted = all).
+args=("$TEAM")
+[ -n "$AGENT" ] && args+=("$AGENT")
+[ -n "$LIMIT" ] && args+=(--limit "$LIMIT")
+
+# emit streams the export to the current stdout. A read must NOT create a missing
+# store (storage_history would storage_init one), so a team never written to
+# reads out as an empty export — return 0, not the falsy storage_store_exists.
+# Driver-level, so it holds for jsonl too.
+emit() {
+  if storage_store_exists "$TEAM"; then
+    storage_history "${args[@]}"
+  else
+    return 0
+  fi
+}
 
 if [ -n "$OUT" ]; then
-  # Empty history writes an empty file (a valid, zero-record export).
-  if [ -n "$JSONL" ]; then printf '%s\n' "$JSONL" > "$OUT"; else : > "$OUT"; fi
+  # Stream to a temp file in the SAME directory, then rename on success. A driver
+  # failure mid-export therefore never truncates or corrupts an existing out
+  # file (the old file survives), and the full history is never held in memory.
+  # Empty export still yields an empty file (a valid, zero-record export).
+  tmp="${OUT}.tmp.$$"
+  if emit > "$tmp"; then
+    mv -f "$tmp" "$OUT"
+  else
+    rc=$?
+    rm -f "$tmp"
+    exit "$rc"
+  fi
 else
-  # Default: stdout, so it pipes to the next tool. When stdout is a terminal the
-  # plaintext message contents would print straight to the screen — note it on
-  # stderr (data still goes to stdout), the same care as the key-reveal screens.
-  # Plain `if` blocks (not `&&`), so an empty export still exits 0 under set -e.
+  # Default: stream to stdout, so it pipes to the next tool. When stdout is a
+  # terminal the plaintext message contents would print straight to the screen —
+  # note it on stderr FIRST (data still goes to stdout), the same care as the
+  # key-reveal screens.
   if [ -t 1 ]; then
     printf 'export.sh: writing plaintext message contents to the terminal; use --out <file> to save to a file.\n' >&2
   fi
-  if [ -n "$JSONL" ]; then
-    printf '%s\n' "$JSONL"
-  fi
+  emit
 fi
-exit 0

--- a/scripts/windows/dispatch.sh
+++ b/scripts/windows/dispatch.sh
@@ -25,6 +25,7 @@ commands:
   inbox
   send <to> <message>
   history [agent] [limit]
+  export [--agent <agent>] [--limit N] [--out <file>]
   team [team]
   config [show|set ...]
   mode [turn|off]
@@ -186,6 +187,21 @@ case "$COMMAND" in
       args+=("$@")
     fi
     run_script history.sh "${args[@]}"
+    ;;
+
+  export)
+    # Resolve only the team export.sh requires; forward the rest of argv so the
+    # flag contract (--agent/--limit/--out) is identical to invoking export.sh
+    # directly. --agent stays opt-in — export is team-wide by default, so this
+    # does NOT inject the acting agent (that would make `agmsg export` filter
+    # differently from `export.sh --team <team>`). An explicit --team in argv
+    # wins over the resolved one (export.sh takes the last --team).
+    resolve_identity 1 0
+    args=(--team "$(first_team "$RESOLVED_TEAM")")
+    if [ "$#" -gt 0 ]; then
+      args+=("$@")
+    fi
+    run_script export.sh "${args[@]}"
     ;;
 
   team)

--- a/tests/test_dispatch.bats
+++ b/tests/test_dispatch.bats
@@ -54,6 +54,30 @@ teardown() {
   [[ "$output" =~ "$message" ]]
 }
 
+@test "dispatch: export routes to export.sh and emits JSONL" {
+  run bash "$SCRIPTS/windows/dispatch.sh" --type codex --project "$PROJECT_ALICE" --team demo --agent alice -- send bob "exported"
+  [ "$status" -eq 0 ]
+
+  run bash "$SCRIPTS/windows/dispatch.sh" --type codex --project "$PROJECT_ALICE" --team demo -- export
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ \"type\":\"message_sent\" ]]
+  [[ "$output" =~ "exported" ]]
+}
+
+@test "dispatch: export forwards --limit and --out to export.sh" {
+  bash "$SCRIPTS/windows/dispatch.sh" --type codex --project "$PROJECT_ALICE" --team demo --agent alice -- send bob "e1"
+  bash "$SCRIPTS/windows/dispatch.sh" --type codex --project "$PROJECT_ALICE" --team demo --agent alice -- send bob "e2"
+  local out="$BATS_TEST_TMPDIR/dispatch-export.jsonl"
+  run bash "$SCRIPTS/windows/dispatch.sh" --type codex --project "$PROJECT_ALICE" --team demo -- export --limit 1 --out "$out"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ -f "$out" ]
+  local count
+  count="$(grep -c '"type":"message_sent"' "$out")"
+  [ "$count" -eq 1 ]
+  grep -q "e2" "$out"
+}
+
 @test "dispatch: codex mode off and turn delegate to delivery" {
   run bash "$SCRIPTS/windows/dispatch.sh" --type codex --project "$PROJECT_ALICE" -- mode off
   [ "$status" -eq 0 ]

--- a/tests/test_export.bats
+++ b/tests/test_export.bats
@@ -136,7 +136,35 @@ STUB
   [ "$status" -ne 0 ]
   # The old file survives untouched — not truncated, not the partial output.
   [ "$(cat "$out")" = "PRE-EXISTING" ]
-  # No leftover temp file next to the target.
-  run bash -c 'ls "$1".tmp.* 2>/dev/null' _ "$out"
+  # The EXIT trap removed the mktemp temp — no plaintext residue in the out dir.
+  run bash -c 'ls "$1"/.export-* 2>/dev/null' _ "$TEST_SKILL_DIR"
   [ -z "$output" ]
+}
+
+@test "export: a symlink at the --out path is replaced, its target untouched" {
+  # rename() over a symlink replaces the LINK, so a victim file the --out path
+  # points at is never overwritten with plaintext. Guards against regressing the
+  # atomic rename to a symlink-following copy (cp / cat > "$OUT").
+  bash "$SCRIPTS/send.sh" testteam alice bob "real"
+  local victim="$TEST_SKILL_DIR/victim.txt"
+  printf 'DO-NOT-OVERWRITE\n' > "$victim"
+  local out="$TEST_SKILL_DIR/link.jsonl"
+  ln -s "$victim" "$out"
+  run bash "$SCRIPTS/export.sh" --team testteam --out "$out"
+  [ "$status" -eq 0 ]
+  # Victim content is unchanged...
+  [ "$(cat "$victim")" = "DO-NOT-OVERWRITE" ]
+  # ...and --out is now a regular file (not a symlink) holding the export.
+  [ -f "$out" ] && [ ! -L "$out" ]
+  grep -q '"type":"message_sent"' "$out"
+  grep -q "real" "$out"
+}
+
+@test "export: --out uses an unpredictable mktemp temp, not a guessable name" {
+  # Anti-regression for the symlink finding: the temp must be created via mktemp
+  # (O_EXCL + random name), never a predictable "$OUT.tmp.$$" opened with plain >,
+  # and its cleanup trap must cover signal exits as well as EXIT.
+  grep -q 'mktemp "\$out_dir/\.export-XXXXXX"' "$SCRIPTS/export.sh"
+  ! grep -qE '\.tmp\.\$\$|\$OUT\.tmp' "$SCRIPTS/export.sh"
+  grep -q "trap 'rm -f \"\$tmp\"' EXIT HUP INT TERM" "$SCRIPTS/export.sh"
 }

--- a/tests/test_export.bats
+++ b/tests/test_export.bats
@@ -98,3 +98,45 @@ teardown() {
   run bash "$SCRIPTS/export.sh" --team testteam --bogus
   [ "$status" -eq 2 ]
 }
+
+@test "export: streams many lines to --out in chronological order" {
+  # More than the 1-2 messages the other tests seed, so the multi-record stream
+  # path (no in-memory materialization) is actually exercised end to end.
+  local i
+  for i in 1 2 3 4 5 6 7 8; do
+    bash "$SCRIPTS/send.sh" testteam alice bob "line-$i"
+  done
+  local out="$TEST_SKILL_DIR/many.jsonl"
+  run bash "$SCRIPTS/export.sh" --team testteam --out "$out"
+  [ "$status" -eq 0 ]
+  [ -f "$out" ]
+  local count
+  count="$(grep -c '"type":"message_sent"' "$out")"
+  [ "$count" -eq 8 ]
+  head -1 "$out" | grep -q "line-1"
+  tail -1 "$out" | grep -q "line-8"
+}
+
+@test "export: a driver failure leaves an existing --out file intact" {
+  # Isolate export.sh with a stub storage lib so storage_history can be forced to
+  # fail deterministically on ANY backend. The contract under test: a mid-export
+  # driver failure must not truncate or replace a pre-existing out file, and must
+  # leave no temp turd behind (temp-in-same-dir + rename-on-success atomicity).
+  local dir="$TEST_SKILL_DIR/fakeexport"
+  mkdir -p "$dir/lib"
+  cp "$SCRIPTS/export.sh" "$dir/export.sh"
+  cat > "$dir/lib/storage.sh" <<'STUB'
+agmsg_storage_load() { :; }
+storage_store_exists() { return 0; }
+storage_history() { printf 'partial line\n'; return 3; }
+STUB
+  local out="$TEST_SKILL_DIR/keep.jsonl"
+  printf 'PRE-EXISTING\n' > "$out"
+  run bash "$dir/export.sh" --team testteam --out "$out"
+  [ "$status" -ne 0 ]
+  # The old file survives untouched — not truncated, not the partial output.
+  [ "$(cat "$out")" = "PRE-EXISTING" ]
+  # No leftover temp file next to the target.
+  run bash -c 'ls "$1".tmp.* 2>/dev/null' _ "$out"
+  [ -z "$output" ]
+}

--- a/tests/test_export.bats
+++ b/tests/test_export.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a
+  bash "$SCRIPTS/join.sh" testteam bob claude-code /tmp/project-b
+}
+
+teardown() {
+  teardown_test_env
+}
+
+# --- export.sh (plaintext JSONL over the storage contract) ---
+
+@test "export: emits message_sent JSONL to stdout" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "msg1"
+  bash "$SCRIPTS/send.sh" testteam bob alice "msg2"
+  run bash "$SCRIPTS/export.sh" --team testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ \"type\":\"message_sent\" ]]
+  [[ "$output" =~ "msg1" ]]
+  [[ "$output" =~ "msg2" ]]
+}
+
+@test "export: every line is a JSON object with the message_sent fields" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "hello"
+  run bash "$SCRIPTS/export.sh" --team testteam
+  [ "$status" -eq 0 ]
+  # Each line parses as JSON and carries the contract fields (id/team/from/to/body/at).
+  # Count validated lines so an empty output cannot pass this vacuously.
+  local n=0
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    echo "$line" | jq -e '.type=="message_sent" and .id and .team and .from and .to and (.body!=null) and .at' >/dev/null
+    n=$((n + 1))
+  done <<< "$output"
+  [ "$n" -ge 1 ]
+}
+
+@test "export: chronological order — oldest line first" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "first"
+  bash "$SCRIPTS/send.sh" testteam alice bob "second"
+  run bash "$SCRIPTS/export.sh" --team testteam
+  [ "$status" -eq 0 ]
+  local first_line second_line
+  first_line="$(printf '%s\n' "$output" | sed -n '1p')"
+  second_line="$(printf '%s\n' "$output" | sed -n '2p')"
+  [[ "$first_line" =~ "first" ]]
+  [[ "$second_line" =~ "second" ]]
+}
+
+@test "export: --agent limits to that agent" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "to-bob"
+  bash "$SCRIPTS/send.sh" testteam bob alice "to-alice"
+  # carol never joined; filtering to her yields no records
+  run bash "$SCRIPTS/export.sh" --team testteam --agent carol
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "export: --limit keeps the most recent N" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "m1"
+  bash "$SCRIPTS/send.sh" testteam alice bob "m2"
+  bash "$SCRIPTS/send.sh" testteam alice bob "m3"
+  run bash "$SCRIPTS/export.sh" --team testteam --limit 1
+  [ "$status" -eq 0 ]
+  local count
+  count="$(printf '%s\n' "$output" | grep -c '"type":"message_sent"')"
+  [ "$count" -eq 1 ]
+  [[ "$output" =~ "m3" ]]
+}
+
+@test "export: --out writes the JSONL to a file, stdout stays empty" {
+  bash "$SCRIPTS/send.sh" testteam alice bob "saved"
+  local out="$TEST_SKILL_DIR/export.jsonl"
+  run bash "$SCRIPTS/export.sh" --team testteam --out "$out"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ -f "$out" ]
+  grep -q '"type":"message_sent"' "$out"
+  grep -q "saved" "$out"
+}
+
+@test "export: an empty team exports nothing, exit 0" {
+  run bash "$SCRIPTS/export.sh" --team testteam
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "export: --team is required" {
+  run bash "$SCRIPTS/export.sh"
+  [ "$status" -eq 2 ]
+}
+
+@test "export: an unknown flag is rejected" {
+  run bash "$SCRIPTS/export.sh" --team testteam --bogus
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## Summary

Adds `agmsg export`, a storage-axis subcommand that dumps a team's message
history as JSONL — one `message_sent` record per line, in chronological order.
It wraps the existing `storage_history` contract (no new storage operation) and
emits raw JSONL rather than the human-readable reformat `history` produces.

## Why plaintext

agmsg's end-to-end encryption is transport-only: messages are sealed on the wire
and the server holds only ciphertext, but each of your machines unseals into a
plaintext local store. Export reads that local store, so it needs no key and
produces plaintext. A server-side ciphertext archive, if ever offered, is a
separate feature — not this command.

## Command

```
agmsg export --team <team> [--agent <agent>] [--limit N] [--out <file>]
```

- Default output is stdout (pipeable to the next tool); `--out` writes a file.
- `--agent` limits to one agent's messages (sender or recipient); omitted = the
  whole team.
- `--limit N` keeps the most recent N; omitted = everything currently retained
  (the sync/retention window for the team's plan).

## Notable design points

- **Streamed, not materialized** — output streams directly to stdout / `--out`;
  the full history is never collected into a shell variable, so an export stays
  O(1) in memory even for a team with a large retention window.
- **Atomic, safe `--out`** — writes to an unpredictable `mktemp` temp (O_EXCL,
  mode 0600) in the destination directory, then renames on success. A driver
  failure never truncates or corrupts an existing out file, and a process sharing
  the out directory cannot pre-plant a symlink to redirect the plaintext onto an
  arbitrary file. Mirrors `scripts/key.sh`'s `_key_write_identity_atomic` idiom;
  cleanup is trapped on EXIT/HUP/INT/TERM and dropped once the rename succeeds.
- **A read never creates a store** — guarded by `storage_store_exists`, so a team
  never written to exports empty rather than being created on read (driver-level,
  so it holds for both backends).
- **Windows parity** — routed through `scripts/windows/dispatch.sh` so
  `agmsg export` exists on the installed Windows helper, not just as a script
  path. Only the required `--team` is resolved from identity; the rest of argv is
  forwarded so the flag contract matches invoking `export.sh` directly.

## Tests

`tests/test_export.bats` (13 cases) plus `tests/test_dispatch.bats` routing (2),
covering: JSONL fields/order, `--agent` / `--limit` / `--out`, empty and error
exit codes, multi-line streaming to `--out`, a symlink at `--out` leaving its
target untouched, driver-failure preservation of an existing out file with no
temp residue, and dispatch routing + flag forwarding. Green on both the sqlite
and jsonl storage backends; the atomicity and symlink defenses are mutation-checked.

## Base

Targets `integration/remote` — this ships with the remote track.
