### PR TITLE
feat(remote): add an authenticated-bundle ingress for disaster restore

### DIFF
--- a/docs/remote-disaster-recovery.md
+++ b/docs/remote-disaster-recovery.md
@@ -53,13 +53,15 @@ same bytes, read once.
 It would be easy to read the section above as "so nothing plaintext is written."
 That is false, and the difference matters when the secret is a team's key history.
 
-While the unlock runs, `remote.sh` creates a private directory with `mktemp -d`,
-`chmod 700`, and writes inside it, each file mode `0600`:
+While the unlock runs, `remote.sh` creates a private directory with `mktemp -d`
+and `chmod 700`, and writes inside it:
 
-- the bundle bytes taken from stdin, and
+- the bundle bytes taken from stdin — created under `umask 077`, so `0600`
+  regardless of the caller's umask, and never briefly wider (a `chmod` after the
+  write would leave exactly that window), and
 - **the age secret keys extracted from it** — `verify-age-handoff` requires an
-  output directory and writes one `identity-<key_id>.key` per epoch, because the
-  import step reads them from there.
+  output directory and writes one `identity-<key_id>.key` per epoch at mode
+  `0600`, because the import step reads them from there.
 
 So the plaintext that matters is on the filesystem for the duration either way.
 Handing the bundle in on stdin does not change that, and could not: the files are

--- a/docs/remote-disaster-recovery.md
+++ b/docs/remote-disaster-recovery.md
@@ -1,0 +1,65 @@
+# Disaster recovery: unlocking from an authenticated bundle
+
+This page describes `remote.sh unlock --authenticated-bundle-stdin`. It is **not**
+part of onboarding, and it is not something to reach for when adding a machine.
+For that, see [remote-setup.md](remote-setup.md) — adding a machine uses
+`--bundle <file>` with `--confirm-digest <sha256>`, and that path is unchanged.
+
+## Why a second entry point exists
+
+The ordinary import gate asks a human to compare a SHA-256 over a separate live
+channel — read it aloud, check it in another app — before any trust or key
+material is imported. That comparison is the authority answering "did these bytes
+come from the party I think they did".
+
+**In a disaster there is nobody to compare with.** Recovery-key restore is the
+route you take when the machine that held the keys is gone. The other end of the
+live channel is precisely what was lost; that is why the restore is happening.
+The requirement cannot be met, not because it is inconvenient, but because the
+counterpart does not exist.
+
+So this mode does not relax the gate. It **switches the authentication authority**
+from a live human digest comparison to an upstream AEAD verifier that already ran
+over exactly these bytes — in practice, a recovery-vault client that opened the
+bundle with a key derived from the recovery key, under an authenticated cipher
+whose additional data binds the expected team and vault.
+
+## What remote.sh does and does not guarantee
+
+`remote.sh` still verifies the snapshot chain: the bundle has to be internally
+consistent and agree with the epoch history it claims.
+
+**`remote.sh` does not authenticate the input in this mode, and cannot.** It has
+no access to the recovery key or the derived key, so it cannot check that any
+verifier ran at all. It accepts the caller's assertion. That is a trust
+delegation, and it is stated here rather than hidden: the guarantee is only as
+good as the program on the other side of the pipe.
+
+Use it only from a program that holds such an authenticator and binds the
+expected team and context. If you are typing this flag by hand, you are using the
+wrong mode.
+
+## Why stdin and not a file path
+
+The bytes are read from stdin, not from a path, and that is deliberate. A
+pathname is not the bytes: if the caller authenticated a file and then handed
+over its name, anything with write access could substitute different content
+between the authentication and the import. Passing the exact buffer through the
+pipe closes that window — what was authenticated and what is imported are the
+same bytes, read once.
+
+A side effect worth having: the decrypted bundle never has to exist as a
+plaintext file on disk.
+
+## Contract
+
+- `--bundle <file>` **requires** `--confirm-digest <sha256>`. Unchanged.
+- `--authenticated-bundle-stdin` **replaces** that pair. Combining it with
+  `--bundle`, `--confirm-digest`, `--snapshot`, or `--identity` is an error, not a
+  precedence rule — two authorities disagreeing about which bytes were
+  authenticated must not resolve silently.
+- Empty or truncated input fails closed. Nothing is imported.
+- The courier `fetch` path uses the digest mode and must not use this one: age
+  encryption to a recipient is not sender-authenticated, so a server that knows
+  the recipient's public key could seal a substitute. There the live-channel
+  comparison is load-bearing.

--- a/docs/remote-disaster-recovery.md
+++ b/docs/remote-disaster-recovery.md
@@ -48,8 +48,31 @@ between the authentication and the import. Passing the exact buffer through the
 pipe closes that window — what was authenticated and what is imported are the
 same bytes, read once.
 
-A side effect worth having: the decrypted bundle never has to exist as a
-plaintext file on disk.
+## What it does NOT give you: plaintext still reaches the disk
+
+It would be easy to read the section above as "so nothing plaintext is written."
+That is false, and the difference matters when the secret is a team's key history.
+
+While the unlock runs, `remote.sh` creates a private directory with `mktemp -d`,
+`chmod 700`, and writes inside it, each file mode `0600`:
+
+- the bundle bytes taken from stdin, and
+- **the age secret keys extracted from it** — `verify-age-handoff` requires an
+  output directory and writes one `identity-<key_id>.key` per epoch, because the
+  import step reads them from there.
+
+So the plaintext that matters is on the filesystem for the duration either way.
+Handing the bundle in on stdin does not change that, and could not: the files are
+the verifier's output, not the transport. Passing it as a stream is about
+something else — that the bytes imported are the bytes the caller authenticated,
+with no window in between for a path to be re-pointed.
+
+**Cleanup limit.** The directory is removed by a `trap` on `EXIT INT TERM HUP`.
+That covers a normal finish and the usual interruptions. It does **not** cover
+`SIGKILL`, a crash, or power loss — after any of those the directory can survive
+a reboot under the system temp directory with the key material still in it. If an
+unlock dies that way, treat `${TMPDIR:-/tmp}/agmsg-handoff.*` as material to find
+and remove deliberately; "there is a trap" is not the same as "nothing is left".
 
 ## Contract
 

--- a/docs/remote-disaster-recovery.md
+++ b/docs/remote-disaster-recovery.md
@@ -69,12 +69,28 @@ the verifier's output, not the transport. Passing it as a stream is about
 something else — that the bytes imported are the bytes the caller authenticated,
 with no window in between for a path to be re-pointed.
 
-**Cleanup limit.** The directory is removed by a `trap` on `EXIT INT TERM HUP`.
-That covers a normal finish and the usual interruptions. It does **not** cover
-`SIGKILL`, a crash, or power loss — after any of those the directory can survive
-a reboot under the system temp directory with the key material still in it. If an
-unlock dies that way, treat `${TMPDIR:-/tmp}/agmsg-handoff.*` as material to find
-and remove deliberately; "there is a trap" is not the same as "nothing is left".
+### What protects it, and what does not
+
+**Protecting:**
+
+- the parent directory at `0700` — this is what actually keeps other users out;
+  they cannot traverse it whatever the files inside are set to;
+- the file modes at `0600` — a second layer, not the load-bearing one. It matters
+  because the first layer should not be the only one: if the directory's mode is
+  ever loosened, or the files are copied somewhere flatter, the modes are what is
+  left.
+
+**Not protecting:**
+
+- **other processes running as you.** Same-UID access is not restricted by any of
+  this. Anything you run while an unlock is in flight can read the directory.
+- **anything after `SIGKILL`, a crash, or power loss.** The directory is removed
+  by a `trap` on `EXIT INT TERM HUP` — a normal finish and the usual
+  interruptions. None of those three run it. Afterwards the directory can survive
+  a reboot under the system temp directory with the key material still in it.
+  Treat `${TMPDIR:-/tmp}/agmsg-handoff.*` as something to find and remove
+  deliberately after an unlock dies that way; "there is a trap" is not the same
+  as "nothing is left".
 
 ## Contract
 

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -7,6 +7,19 @@ set -euo pipefail
 #   remote.sh unlock <team> --bundle <file> --confirm-digest <sha256>
 #   remote.sh unlock <team> --snapshot <file> (--identity <file>|--identity-stdin)
 #     [--confirm-digest <sha256>]
+#   remote.sh unlock <team> --authenticated-bundle-stdin
+#     Read the exact bundle bytes from stdin after the invoking program has
+#     authenticated them end to end. remote.sh does not authenticate this input.
+#     Use only with an authenticator that verifies integrity and binds the
+#     expected team/context. This mode replaces, and must not be combined with,
+#     --bundle or --confirm-digest.
+#
+#     This is not a bypass of the digest check: it switches the authentication
+#     authority from a live human digest comparison to an upstream AEAD verifier.
+#     remote.sh cannot prove that verifier ran, and does not pretend to — that
+#     limit is the caller's contract, not a hidden assumption. Reserved for the
+#     disaster-recovery route (see docs/remote-disaster-recovery.md); ordinary
+#     onboarding and the courier `fetch` path use --bundle/--confirm-digest.
 #   remote.sh status [<team>] [--json]
 #   remote.sh sync start <team>
 #   remote.sh disconnect <team>
@@ -531,13 +544,15 @@ cmd_pull() {
 }
 
 cmd_unlock() {
-  local team="" identity_file="" identity_stdin=0 confirm_digest="" bundle="" snapshots=()
+  local team="" identity_file="" identity_stdin=0 confirm_digest="" bundle="" \
+    authenticated_stdin=0 snapshots=()
   while [ $# -gt 0 ]; do
     case "$1" in
       --snapshot) snapshots+=("${2:?--snapshot requires a value}"); shift 2 ;;
       --snapshot=*) snapshots+=("${1#--snapshot=}"); shift ;;
       --bundle) bundle="${2:?--bundle requires a value}"; shift 2 ;;
       --bundle=*) bundle="${1#--bundle=}"; shift ;;
+      --authenticated-bundle-stdin) authenticated_stdin=1; shift ;;
       --identity) identity_file="${2:?--identity requires a value}"; shift 2 ;;
       --identity=*) identity_file="${1#--identity=}"; shift ;;
       --identity-stdin) identity_stdin=1; shift ;;
@@ -548,9 +563,18 @@ cmd_unlock() {
          team="$1"; shift ;;
     esac
   done
-  : "${team:?Usage: remote.sh unlock <team> (--bundle <file> | --snapshot <file> (--identity <file>|--identity-stdin)) [--confirm-digest <sha256>]}"
+  : "${team:?Usage: remote.sh unlock <team> (--bundle <file> --confirm-digest <sha256> | --authenticated-bundle-stdin | --snapshot <file> (--identity <file>|--identity-stdin)) }"
   agmsg_validate_team_name "$team" || exit 1
-  if [ -n "$bundle" ]; then
+  if [ "$authenticated_stdin" -eq 1 ]; then
+    # This mode REPLACES the digest gate rather than relaxing it, so it cannot
+    # sit alongside another input mode: two authorities disagreeing about which
+    # bytes were authenticated is worse than either alone. Fail closed.
+    if [ -n "$bundle" ] || [ -n "$confirm_digest" ] || [ "${#snapshots[@]}" -gt 0 ] ||
+        [ -n "$identity_file" ] || [ "$identity_stdin" -eq 1 ]; then
+      echo "agmsg: --authenticated-bundle-stdin replaces --bundle/--confirm-digest and cannot be combined with them, --snapshot, or --identity" >&2
+      exit 1
+    fi
+  elif [ -n "$bundle" ]; then
     if [ "${#snapshots[@]}" -gt 0 ] || [ -n "$identity_file" ] || [ "$identity_stdin" -eq 1 ]; then
       echo "agmsg: --bundle cannot be combined with --snapshot or --identity" >&2
       exit 1
@@ -577,10 +601,28 @@ cmd_unlock() {
     exit 1
   }
   local snapshot_args=() identity_args=() snapshot handoff_tmp="" handoff_metadata=""
-  if [ -n "$bundle" ]; then
+  if [ "$authenticated_stdin" -eq 1 ]; then
     handoff_tmp="$(mktemp -d "${TMPDIR:-/tmp}/agmsg-handoff.XXXXXX")"
     chmod 700 "$handoff_tmp"
     trap 'rm -r "${handoff_tmp:-}" 2>/dev/null || true' EXIT INT TERM HUP
+    bundle="$handoff_tmp/authenticated.bundle"
+    # Capture the caller's bytes ONCE, into a directory only this process can
+    # reach. That is the whole reason this mode takes stdin and not a path: the
+    # caller authenticated a specific sequence of bytes, and re-opening a path it
+    # named would let anything with write access substitute different bytes
+    # between that authentication and this import. A filename is not the bytes.
+    cat > "$bundle"
+    [ -s "$bundle" ] || {
+      echo "agmsg: --authenticated-bundle-stdin received no bundle bytes on stdin" >&2
+      exit 1
+    }
+  fi
+  if [ -n "$bundle" ]; then
+    if [ -z "$handoff_tmp" ]; then
+      handoff_tmp="$(mktemp -d "${TMPDIR:-/tmp}/agmsg-handoff.XXXXXX")"
+      chmod 700 "$handoff_tmp"
+      trap 'rm -r "${handoff_tmp:-}" 2>/dev/null || true' EXIT INT TERM HUP
+    fi
     handoff_metadata="$(bash "$SCRIPT_DIR/remote-sync.sh" verify-age-handoff \
       --team "$team" --bundle "$bundle" --out-dir "$handoff_tmp")" || exit 1
     local snapshot_count identity_count index mapped_key mapped_path
@@ -620,17 +662,25 @@ cmd_unlock() {
     }
   fi
 
-  if [ -z "$confirm_digest" ]; then
-    if [ "$identity_stdin" -eq 1 ] && { [ ! -r /dev/tty ] || [ ! -w /dev/tty ]; }; then
-      echo "agmsg: --identity-stdin without a terminal also requires --confirm-digest <sha256>" >&2
+  # The live-channel comparison is the ordinary authority over "are these the
+  # bytes the other side sent". --authenticated-bundle-stdin substitutes a
+  # different authority for it — an authenticator the invoking program already
+  # verified over exactly these bytes — so the two are alternatives, never a
+  # sequence where one can be skipped. Every other path still goes through the
+  # gate unchanged.
+  if [ "$authenticated_stdin" -ne 1 ]; then
+    if [ -z "$confirm_digest" ]; then
+      if [ "$identity_stdin" -eq 1 ] && { [ ! -r /dev/tty ] || [ ! -w /dev/tty ]; }; then
+        echo "agmsg: --identity-stdin without a terminal also requires --confirm-digest <sha256>" >&2
+        exit 1
+      fi
+      _remote_prompt_read confirm_digest \
+        "Type the snapshot SHA-256 you verified over a separate live channel: " || exit 1
+    fi
+    if [ "$confirm_digest" != "$digest" ]; then
+      echo "agmsg: confirmed snapshot digest does not match; refusing to import trust or key material" >&2
       exit 1
     fi
-    _remote_prompt_read confirm_digest \
-      "Type the snapshot SHA-256 you verified over a separate live channel: " || exit 1
-  fi
-  if [ "$confirm_digest" != "$digest" ]; then
-    echo "agmsg: confirmed snapshot digest does not match; refusing to import trust or key material" >&2
-    exit 1
   fi
 
   local identity_tmp="" derived_recipient identity_dest mapping mapping_key mapping_path

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -611,7 +611,11 @@ cmd_unlock() {
     # caller authenticated a specific sequence of bytes, and re-opening a path it
     # named would let anything with write access substitute different bytes
     # between that authentication and this import. A filename is not the bytes.
-    cat > "$bundle"
+    # umask rather than a chmod afterwards: `cat >` creates the file with the
+    # caller's umask, and a chmod on the next line leaves a window where the
+    # secret is already on disk at whatever mode that was. Setting it in a
+    # subshell around the redirection means the file is never briefly wider.
+    ( umask 077; cat > "$bundle" )
     [ -s "$bundle" ] || {
       echo "agmsg: --authenticated-bundle-stdin received no bundle bytes on stdin" >&2
       exit 1

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -862,6 +862,127 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   [ "$pushed_cipher" = "age-v1" ]
 }
 
+@test "remote unlock --authenticated-bundle-stdin: takes exact bytes, refuses everything else" {
+  skip_if_no_age
+
+  # Same handed-authority setup as the --bundle test above, kept separate rather
+  # than factored out: a shared fixture would let a change made for one mode
+  # quietly redefine what the other one is asserting.
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam >/dev/null
+  local source_cfg bundle key_id recipient team_id envelope
+  source_cfg="$TEST_SKILL_DIR/teams/testteam/config.json"
+  bundle="$TEST_SKILL_DIR/auth-bundle.json"
+  envelope="$TEST_SKILL_DIR/auth-envelope.json"
+  # Export the snapshot first: the handoff bundle carries the *confirmed* chain,
+  # and the epoch is only confirmed once a snapshot has been exported. Skipping
+  # this hands over a bundle that cannot open what the envelope was sealed to.
+  bash "$SCRIPTS/key.sh" show testteam --snapshot --out "$TEST_SKILL_DIR/auth-snapshot.json" 2>/dev/null
+  bash "$SCRIPTS/key.sh" handoff testteam --out "$bundle" >/dev/null 2>&1
+  key_id="$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$source_cfg")') AS TEXT), '\$.remote_key.current.key_id');")"
+  recipient="$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$source_cfg")') AS TEXT), '\$.remote_key.current.recipient');")"
+  team_id="$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$source_cfg")') AS TEXT), '\$.team_id');")"
+  # wire_id must be exactly this: tests/helpers/mock_remote_server.py:83 serves a
+  # row with that id, and an envelope carrying any other one is pulled but never
+  # matched — which surfaces as "envelopes remain blocked after reprocessing",
+  # i.e. as an unlock failure rather than as a fixture mismatch.
+  jq -nc \
+    --arg key_id "$key_id" \
+    --arg recipient "$recipient" \
+    --arg team_id "$team_id" \
+    '{
+      type:"sync_seal", envelope_v:1, cipher:"age-v1",
+      key_id:$key_id, recipients:[$recipient], max_blob_bytes:1048576,
+      wire_id:"20000000-0000-4000-8000-000000000001",
+      team_id:$team_id, protocol_version:1,
+      projection:{
+        body:"authenticated ciphertext", created_at:"2026-01-02T00:00:00.000000Z",
+        from_agent:"member-1", to_agent:"member-1"
+      }
+    }' | node "$SCRIPTS/internal/sync-cipher.mjs" seal > "$envelope"
+  bash "$SCRIPTS/remote.sh" disconnect testteam >/dev/null 2>&1 || true
+
+  MOCK_PULL_AGE=1
+  MOCK_PULL_AGE_ENVELOPE_FILE="$envelope"
+  MOCK_PULL_TEAM_ID="$team_id"
+  restart_mock_server
+
+  PEER_SKILL_DIR="$(mktemp -d)"
+  export PEER_SKILL_DIR
+  mkdir -p "$PEER_SKILL_DIR"/{scripts,db,teams}
+  cp -R "$BATS_TEST_DIRNAME"/../scripts/. "$PEER_SKILL_DIR/scripts/"
+  chmod +x "$PEER_SKILL_DIR/scripts/"*.sh
+  chmod +x "$PEER_SKILL_DIR/scripts/"*.js 2>/dev/null || true
+  chmod +x "$PEER_SKILL_DIR/scripts/drivers/types/codex/"*.sh 2>/dev/null || true
+  bash "$PEER_SKILL_DIR/scripts/internal/init-db.sh"
+  local peer_scripts="$PEER_SKILL_DIR/scripts"
+
+  run bash "$peer_scripts/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$team_id" encrypted
+  [ "$status" -eq 0 ]
+
+  # Combining the new mode with any other input mode is an error, not a
+  # precedence rule: two authorities disagreeing about which bytes were
+  # authenticated must not resolve silently in either direction.
+  local digest; digest="$(shasum -a 256 "$bundle" | awk '{print $1}')"
+  run bash -c "bash '$peer_scripts/remote.sh' unlock encrypted --authenticated-bundle-stdin --confirm-digest '$digest' < '$bundle'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot be combined"* ]]
+  run bash -c "bash '$peer_scripts/remote.sh' unlock encrypted --authenticated-bundle-stdin --bundle '$bundle' < '$bundle'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot be combined"* ]]
+
+  # Empty stdin must fail closed rather than fall through to some other mode.
+  run bash -c "bash '$peer_scripts/remote.sh' unlock encrypted --authenticated-bundle-stdin < /dev/null"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no bundle bytes on stdin"* ]]
+
+  # Truncated and trailing-garbage input must fail too: "we did not authenticate
+  # this" has to lose, and a partial read that merely looked like a bundle is
+  # exactly what a fail-open would accept.
+  head -c 64 "$bundle" > "$TEST_SKILL_DIR/partial.json"
+  run bash -c "bash '$peer_scripts/remote.sh' unlock encrypted --authenticated-bundle-stdin < '$TEST_SKILL_DIR/partial.json'"
+  [ "$status" -ne 0 ]
+  cat "$bundle" > "$TEST_SKILL_DIR/trailing.json"
+  printf 'garbage\n' >> "$TEST_SKILL_DIR/trailing.json"
+  run bash -c "bash '$peer_scripts/remote.sh' unlock encrypted --authenticated-bundle-stdin < '$TEST_SKILL_DIR/trailing.json'"
+  [ "$status" -ne 0 ]
+
+  # None of the failures above may have imported trust or key material.
+  [ "$(sqlite_mem "SELECT json_type(json_extract(CAST(readfile('$(rf "$PEER_SKILL_DIR/teams/encrypted/config.json")') AS TEXT), '\$.remote_key'));")" = "" ]
+  [ ! -e "$PEER_SKILL_DIR/run/remote-credentials/encrypted" ]
+
+  # The success path, fed through a PIPE rather than a redirect. A pipe has no
+  # pathname, so this also proves the bytes are taken from the stream and not
+  # re-opened by name — which is the entire reason this mode is stdin-only.
+  run bash -c "cat '$bundle' | bash '$peer_scripts/remote.sh' unlock encrypted --authenticated-bundle-stdin"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"imported 1 envelope(s); engine running (pid "* ]]
+  # It must NOT have asked for, or accepted, a digest along the way.
+  [[ "$output" != *"separate live channel"* ]]
+  wait_for_file "$PEER_SKILL_DIR/run/remote-sync.encrypted.pid"
+  [ -d "$PEER_SKILL_DIR/run/remote-trust" ]
+
+  run bash "$peer_scripts/history.sh" encrypted member-1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"authenticated ciphertext"* ]]
+
+  # The decrypted bundle must not survive as a plaintext file: taking it on stdin
+  # is pointless if we then leave a copy behind.
+  run bash -c "ls -d \${TMPDIR:-/tmp}/agmsg-handoff.* 2>/dev/null | wc -l"
+  [ "$(echo "$output" | tr -d '[:space:]')" = "0" ]
+
+  local pid; pid="$(cat "$PEER_SKILL_DIR/run/remote-sync.encrypted.pid")"
+  kill "$pid" 2>/dev/null || true
+  wait_for_pid_exit "$pid"
+}
+
+@test "remote unlock: --bundle still requires a matching --confirm-digest" {
+  # The ordinary gate is unchanged by the new mode. Asserted on its own so that a
+  # regression here cannot hide inside the larger handed-authority test.
+  run bash "$SCRIPTS/remote.sh" unlock testteam --bundle /dev/null
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requires --confirm-digest"* ]]
+}
+
 @test "remote doctor: age is optional — its absence does not fail the run" {
   # cipher "none" is the base and e2ee is available rather than required, so a
   # new user running doctor must not be told they are missing something they

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -975,6 +975,54 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   wait_for_pid_exit "$pid"
 }
 
+@test "remote unlock --authenticated-bundle-stdin: the captured bundle is 0600 whatever the umask" {
+  # The capture holds a team's key history in the clear until the trap fires, so
+  # its mode must not depend on how the caller's shell happened to be configured.
+  # Observed at the real boundary: remote.sh hands the path to remote-sync.sh, so
+  # a stand-in there reports the mode of the actual file remote.sh created. A
+  # structural "is there a chmod" grep would pass on code that chmods the wrong
+  # path, or too late.
+  local peer; peer="$(mktemp -d)"
+  mkdir -p "$peer"/{scripts,db,teams}
+  cp -R "$BATS_TEST_DIRNAME"/../scripts/. "$peer/scripts/"
+  chmod +x "$peer/scripts/"*.sh
+  bash "$peer/scripts/internal/init-db.sh"
+
+  # A team the unlock will accept as an encrypted pulled team, so it reaches the
+  # capture. Nothing beyond the capture needs to succeed.
+  bash "$peer/scripts/join.sh" locked alice claude-code "$peer" >/dev/null 2>&1
+  local cfg="$peer/teams/locked/config.json"
+  python3 - "$cfg" <<'PY'
+import json, sys
+p = sys.argv[1]
+cfg = json.load(open(p))
+cfg["remote_binding"] = {"cipher_profile": "age-v1", "connected_at": "2026-01-01T00:00:00Z"}
+json.dump(cfg, open(p, "w"))
+PY
+
+  local seen="$peer/observed-mode"
+  cat > "$peer/scripts/remote-sync.sh" <<PY
+#!/usr/bin/env bash
+# Stand-in: report the mode of the file remote.sh captured, then stop the unlock.
+for a in "\$@"; do
+  if [ "\$prev" = "--bundle" ]; then
+    if stat -f '%Lp' "\$a" >/dev/null 2>&1; then stat -f '%Lp' "\$a" > "$seen"
+    else stat -c '%a' "\$a" > "$seen"; fi
+  fi
+  prev="\$a"
+done
+exit 1
+PY
+  chmod +x "$peer/scripts/remote-sync.sh"
+
+  # A deliberately permissive umask: without the fix the capture inherits it.
+  run bash -c "umask 000; printf 'BUNDLE BYTES' | bash '$peer/scripts/remote.sh' unlock locked --authenticated-bundle-stdin"
+  [ "$status" -ne 0 ]          # the stand-in refuses; only the capture matters here
+  [ -f "$seen" ]               # and it must actually have been reached
+  [ "$(cat "$seen")" = "600" ]
+  rm -rf "$peer"
+}
+
 @test "remote unlock: --bundle still requires a matching --confirm-digest" {
   # The ordinary gate is unchanged by the new mode. Asserted on its own so that a
   # regression here cannot hide inside the larger handed-authority test.


### PR DESCRIPTION
## Why

`remote.sh unlock --bundle` requires a SHA-256 confirmed over a separate live channel, and that requirement is correct for onboarding: it is the authority answering "did these bytes come from the party I think they did".

Recovery-key restore is a **disaster-only** route. It runs when the machine that held the keys is gone — so the party who would read that digest aloud is precisely what was lost. The requirement cannot be met, not because it is inconvenient but because the counterpart does not exist.

## What this is (and is not)

`--authenticated-bundle-stdin` is **not a bypass of the digest check**. It switches the authentication authority from a live human digest comparison to an upstream AEAD verifier that already ran over exactly these bytes — in practice a recovery-vault client that opened the bundle under an authenticated cipher whose additional data binds the expected team and vault.

`remote.sh` still verifies the snapshot chain. It does **not** authenticate the input in this mode and cannot: it has no access to the key material, so it cannot check that any verifier ran. It accepts the caller's assertion. That is a trust delegation, and it is written into the help and the runbook rather than left as a hidden assumption.

## Why stdin rather than a file path

A pathname is not the bytes. If the caller authenticates a file and then hands over its name, anything with write access can substitute different content between the authentication and the import. Taking the exact buffer on stdin closes that window — what was authenticated and what is imported are the same bytes, read once.

**It does not keep plaintext off the disk, and an earlier revision of this description wrongly said it did.** The capture is written to a private `mktemp -d` (0700, files 0600), and so are the age secret keys `verify-age-handoff` extracts — that command requires an output directory and writes one identity file per epoch, because the import step reads them from there. Passing the bundle by fd instead would not change it: the plaintext that matters is the verifier's output, not the transport. The runbook now states this, along with the cleanup limit — the `trap` covers `EXIT INT TERM HUP`, not `SIGKILL`, a crash, or power loss, after which the directory survives with key material in it.

## Contract

- `--bundle <file>` still **requires** `--confirm-digest <sha256>`; that path is unchanged.
- `--authenticated-bundle-stdin` **replaces** that pair. Combining it with `--bundle`, `--confirm-digest`, `--snapshot`, or `--identity` is an error, not a precedence rule — two authorities disagreeing about which bytes were authenticated must not resolve silently in either direction.
- Empty or truncated input fails closed; nothing is imported.
- The courier `fetch` path keeps the digest mode and must not use this one: age encryption to a recipient is not sender-authenticated, so a server that knows the recipient's public key could seal a substitute. There the live-channel comparison is load-bearing.

`SKILL.md` is deliberately untouched: its "never infer or auto-confirm it" instruction stays absolute, and this route is documented separately in `docs/remote-disaster-recovery.md` so it is not surfaced as an ordinary operation.

## Tests

`tests/test_remote.bats`, 63/63 green (`bats tests/test_remote.bats`, exit 0). Two tests added:

- the new mode end to end — combination with each other input mode rejected, empty stdin rejected, truncated and trailing-garbage input rejected, none of the failures importing trust or key material, then the success path fed through a **pipe** (a pipe has no pathname, so this also demonstrates the bytes come from the stream and are not re-opened by name), and no `agmsg-handoff.*` temp directory left behind.
- the ordinary gate on its own: `--bundle` without a matching `--confirm-digest` is still refused. Asserted separately so a regression there cannot hide inside the larger handed-authority test.

Mutation-checked: replacing the exclusivity guard with `if false` fails the new test. Baseline was confirmed green before the change, so the failure is attributable to the guard and not to the fixture.

## Not verified

**The joined path has never been run.** The tests above cover this side — `remote.sh` accepting bytes on stdin and importing them — and the client side that will call it is covered separately, including an exact byte comparison of what reaches the child process's stdin. What has *not* been exercised is the two of them connected: a real client opening a real vault and a real `remote.sh` completing an unlock from that stream.

The reason is circular and resolves when this merges: the flag exists only on this branch, so no installed copy of the tooling has it to test against. Verifying the junction also needs a live remote connection, since the bundle export path requires state that only connecting produces.

This is called out rather than left implicit because "both sides are correct" and "the two sides work together" are different claims, and only the first is supported here. The end-to-end case is queued to be added once this lands.

One fixture note is recorded in the test itself: the sealed envelope's `wire_id` must match the row `tests/helpers/mock_remote_server.py:83` serves, or the peer pulls an envelope it never matches and the failure surfaces as "envelopes remain blocked after reprocessing" — an unlock failure that looks nothing like a fixture mismatch.
