### PR TITLE
role-session: a stale mkdir -p failure shouldn't block writing the record

### DIFF
--- a/scripts/lib/role-session.sh
+++ b/scripts/lib/role-session.sh
@@ -145,7 +145,7 @@ agmsg_role_session_record() {
   _agmsg_role_session_path_into "$team" "$agent"
   path="$_AGMSG_ROLE_SESSION_PATH"
   dir="$(_actas_lock_dir)"
-  mkdir -p "$dir" 2>/dev/null || return 0
+  mkdir -p "$dir" 2>/dev/null || true
   tmp="$(mktemp "$dir/.role-session.XXXXXX" 2>/dev/null)" || return 0
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
   {

--- a/tests/test_role_session.bats
+++ b/tests/test_role_session.bats
@@ -122,6 +122,18 @@ fake_session() {
   [ "$status" -eq 0 ]
 }
 
+@test "record: writes even when mkdir -p fails but the leaf dir already exists (#579)" {
+  # Windows codex sandbox (workspace-write + elevated): mkdir -p walks the
+  # already-existing intermediate path and returns EACCES, not EEXIST -- the
+  # leaf dir itself remains present and writable throughout. Stubbing mkdir to
+  # always fail reproduces that: the real RUN_DIR (made in setup()) is never
+  # touched, so mktemp on it still succeeds and the record must still be written.
+  mkdir() { return 1; }
+  agmsg_role_session_record T alice "sid-x" /tmp/p1
+  unset -f mkdir
+  [ "$(agmsg_role_session_uuid T alice)" = "sid-x" ]
+}
+
 # --- lookups (for PR-D / PR-E) ---
 
 @test "lookup_by_name: returns the record whose name= matches" {


### PR DESCRIPTION
A codex sandbox on Windows (`workspace-write` plus `[windows] sandbox = "elevated"`) can make `mkdir -p` return EACCES while walking an already-existing intermediate path component, rather than the EEXIST that `mkdir -p` normally treats as success. `agmsg_role_session_record` in `scripts/lib/role-session.sh` read any `mkdir -p` failure as fatal (`|| return 0`) and skipped writing the role-session record entirely, even when the target `run/` directory already existed and was writable — the write only needed `mktemp` to succeed, and that call already has its own `|| return 0` guard right after.

This PR changes the `mkdir -p` failure handling from `|| return 0` to `|| true`, so a spurious `mkdir -p` error no longer short-circuits the write. `mktemp` remains the real fail-open guard for the case where the directory genuinely cannot be created.

## Regression test

Added a test to `tests/test_role_session.bats` that stubs `mkdir` to always fail while the target `run/` directory already exists (as `setup()` creates it), and asserts the record still gets written. Mutation-checked by hand: reverting the one-line fix turns this new test red (`not ok`) while every other test in the file stays green; re-applying the fix turns it green again (24/24).

## CI coverage gap

The new test runs in the `bats (ubuntu-latest)` and `bats (macos-latest)` shard that contains `tests/test_role_session.bats`, on every push and PR against `main`. It does not run under `bats-windows`: that job only executes two focused legs (`tests/test_install.bats` filtered to `[Ww]indows`, and `tests/test_codex_monitor.bats` + `tests/test_codex_bridge_launcher.bats` filtered to `windows-native`), and `test_role_session.bats` is in neither. So the test proves the function-level contract ("a `mkdir -p` failure on an already-usable directory must not abort the write") on Linux and macOS, but no CI job exercises the actual trigger — a real Windows/MSYS sandbox returning EACCES on an existing path. This mirrors the gap #567 closed for a different code path; it is called out here rather than addressed, since fixing that gap is a separate piece of work.

## Testing

(1) `bats tests/test_role_session.bats` — 24 ok, 0 not ok
(2) `bats tests/test_boot_command.bats` — 11 ok, 0 not ok
(3) `bats tests/test_codex_bridge_launcher.bats` — 16 ok, 0 not ok
(4) `bats tests/test_codex_resume.bats` — 33 ok, 0 not ok
(5) `bats tests/test_delivery.bats` — 165 ok, 0 not ok
(6) `bats tests/test_resurrect_panes.bats` — 14 ok, 0 not ok
(7) `bats tests/test_spawn.bats` — 74 ok, 0 not ok

All seven suites that exercise `scripts/lib/role-session.sh` (directly or via `actas-claim.sh`), each run individually, each exit 0.
