### PR TITLE
fix(sync): stop reporting every server error as a binding mismatch

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1046,16 +1046,33 @@ async function send(config, path, init, authHeaders) {
   return body;
 }
 
+// Check the binding when the body actually carries one — not when the status
+// code happens to be outside a list.
+//
+// The list was {400,401,426}, so every other error ran through validateBinding,
+// which compares `body.team_id` to the configured one. An error body without a
+// binding has `undefined` there, so it failed the comparison and every 403, 404,
+// 409 and 500 arrived as "server/team binding mismatch". The one message that
+// means "you are talking to the wrong team" was what a caller saw for a
+// forbidden request, a missing team, a conflict, and a server crash alike.
+//
+// Checking presence instead is also the stronger rule: an error that DOES carry
+// a binding is verified whatever its status, where the allowlist would have
+// skipped a mismatched 400.
 export function validateErrorBinding(config, status, body) {
-  const preResolution = status === 400 || status === 401 || status === 426;
   const carriesBinding = body?.server_instance_id !== undefined || body?.team_id !== undefined;
-  if (!preResolution || carriesBinding) validateBinding(config, body);
+  if (carriesBinding) validateBinding(config, body);
 }
 
-async function health(serverUrl) {
+// `teamId` is required, not optional: a health check that does not say which
+// team it is asking about cannot be answered per-team, and an edge that routes
+// by team would have to guess. Same header name as send() — one name for one
+// fact, so a gateway does not have to know two.
+async function health(serverUrl, teamId) {
   let response;
   try {
     response = await fetch(endpoint(serverUrl, "/v1/health"), {
+      headers: { "Agmsg-Team-ID": teamId },
       redirect: "error", signal: AbortSignal.timeout(15_000),
     });
   } catch (error) {
@@ -1773,9 +1790,26 @@ export async function configure(args) {
   if (serverUrl !== binding.endpoint || args["team-id"] !== binding.remote_team_id) {
     throw new Error("configure binding does not match remote.sh connect");
   }
-  const ready = await health(serverUrl);
+  const ready = await health(serverUrl, binding.remote_team_id);
   if (ready.server_instance_id !== binding.server_instance_id) {
     throw new Error("health server instance does not match remote.sh connect");
+  }
+  // Read back what the server says the team is, and refuse if it disagrees.
+  //
+  // Sending the header alone would change nothing observable here — it would be
+  // a field that exists and that nobody consults, which this file already has
+  // one of (the handoff bundle's format_version is checked for `!== 1` and never
+  // used to negotiate). The check is the reason the header is worth adding.
+  //
+  // Until now `remote_team_id` was whatever was passed in on the command line,
+  // stored without ever being compared to the server. A mismatch stayed
+  // invisible until the first push failed, far from the step that caused it.
+  // Strict equality, with no exemption for a server that omits the field. An
+  // `!== undefined` guard would let exactly the case this is meant to catch pass
+  // silently — an endpoint that does not answer per-team looks identical to one
+  // that agrees with us. Absent is not agreement.
+  if (ready.team_id !== binding.remote_team_id) {
+    throw new Error("health team does not match remote.sh connect");
   }
   const config = {
     format_version: 1, local_team: team, server_url: serverUrl,
@@ -1970,8 +2004,13 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
   const readStateCycleCall = dependencies.readStateCycleCall ?? readStateCycle;
   const activateKeyRotationsCall = dependencies.activateKeyRotationsCall ?? activateKeyRotations;
 
-  const ready = await healthCall(config.server_url);
+  const ready = await healthCall(config.server_url, config.remote_team_id);
   if (ready.server_instance_id !== config.server_instance_id) throw new Error("health server instance changed");
+  // Read back the team as well. Sending the header without checking the answer
+  // would leave a field that exists and that nobody consults; the check is what
+  // makes a server that has been re-pointed at another team fail here rather
+  // than at the first push.
+  if (ready.team_id !== config.remote_team_id) throw new Error("health team changed");
   const capabilities = await requestCall(config, "/v1/capabilities");
   validateCapabilities(config, capabilities);
   await eventCall("capabilities", { team: config.local_team, current_seq: capabilities.current_seq,
@@ -2204,8 +2243,13 @@ export async function reprocessCycle(config, limit, dependencies = {}) {
   const logApplyCall = dependencies.logApplyCall ?? logApplyOutcomes;
   const rosterDriverCall = dependencies.rosterDriverCall ?? rosterDriver;
   const activateKeyRotationsCall = dependencies.activateKeyRotationsCall ?? activateKeyRotations;
-  const ready = await healthCall(config.server_url);
+  const ready = await healthCall(config.server_url, config.remote_team_id);
   if (ready.server_instance_id !== config.server_instance_id) throw new Error("health server instance changed");
+  // Read back the team as well. Sending the header without checking the answer
+  // would leave a field that exists and that nobody consults; the check is what
+  // makes a server that has been re-pointed at another team fail here rather
+  // than at the first push.
+  if (ready.team_id !== config.remote_team_id) throw new Error("health team changed");
   const capabilities = await requestCall(config, "/v1/capabilities");
   validateCapabilities(config, capabilities);
   let after = null;

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1060,8 +1060,20 @@ async function send(config, path, init, authHeaders) {
 // a binding is verified whatever its status, where the allowlist would have
 // skipped a mismatched 400.
 export function validateErrorBinding(config, status, body) {
-  const carriesBinding = body?.server_instance_id !== undefined || body?.team_id !== undefined;
-  if (carriesBinding) validateBinding(config, body);
+  // An identity claim is server_instance_id or team_id. Those name WHICH server
+  // and WHICH team, so a reply carrying either is asserting the binding and gets
+  // checked at any status.
+  const claimsIdentity = body?.server_instance_id !== undefined || body?.team_id !== undefined;
+  // `protocol_version` alone is not an identity claim — every well-formed reply
+  // in this protocol has one, including a plain 401. But once the server has
+  // resolved the request far enough to answer 403/404/409/500, a body that
+  // carries the protocol envelope and omits the identity is malformed for that
+  // stage, and the old code refused it. Keeping that refusal is why this is not
+  // simply "check when identity is present": the inversion must not loosen a
+  // path (co1 review).
+  const preResolution = status === 400 || status === 401 || status === 426;
+  const claimsProtocol = body?.protocol_version !== undefined;
+  if (claimsIdentity || (!preResolution && claimsProtocol)) validateBinding(config, body);
 }
 
 // `teamId` is required, not optional: a health check that does not say which

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -207,7 +207,9 @@ async function dataPlaneRoutes(
       // The team comes back from the DB, never from the header we were handed.
       // Returning the caller's own value would let it compare its value with
       // itself and read that as agreement — true even for a team this server has
-      // never had. health() reads the row and 404s when there is none.
+      // never had. health() reads the row and omits team_id when there is none,
+      // staying 200 — this route is also how "is the server up" is asked, and a
+      // 404 would be indistinguishable from "no such route".
       return await health(pool, teamId);
     } catch {
       return reply.status(503).send({

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -183,9 +183,29 @@ async function dataPlaneRoutes(
     void reply.status(500).send(errorBody(protocolError));
   });
 
-  app.get("/v1/health", async (_request, reply) => {
+  app.get("/v1/health", async (request, reply) => {
+    // Parsed OUTSIDE the try: the catch below turns anything thrown into 503
+    // "database unavailable", so a malformed header validated in there would be
+    // reported as a dead server. Same substitution this branch is fixing on the
+    // client, one layer down.
+    const teamId = request.headers["agmsg-team-id"] === undefined
+      ? undefined
+      : requestedTeamId(request);
     try {
-      return await health(pool);
+      // The team header is OPTIONAL here, and only here.
+      //
+      // /v1/health answers two different questions. "Is this server up" is asked
+      // before any team exists — by an operator checking an endpoint, by a
+      // probe, by a client that has not connected yet — and requiring a team
+      // would make that unanswerable. "Am I still bound to the team I think I
+      // am" is asked by a configured client, which always has one to send.
+      //
+      // So: echo the team back when asked about one, and stay answerable when
+      // not. A client that sends the header and gets no team_id treats that as a
+      // disagreement rather than as consent, which is what makes the optional
+      // side safe — the check lives on the side that knows what it expects.
+      const body = await health(pool);
+      return teamId === undefined ? body : { ...body, team_id: teamId };
     } catch {
       return reply.status(503).send({
         status: "unavailable",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -204,8 +204,11 @@ async function dataPlaneRoutes(
       // not. A client that sends the header and gets no team_id treats that as a
       // disagreement rather than as consent, which is what makes the optional
       // side safe — the check lives on the side that knows what it expects.
-      const body = await health(pool);
-      return teamId === undefined ? body : { ...body, team_id: teamId };
+      // The team comes back from the DB, never from the header we were handed.
+      // Returning the caller's own value would let it compare its value with
+      // itself and read that as agreement — true even for a team this server has
+      // never had. health() reads the row and 404s when there is none.
+      return await health(pool, teamId);
     } catch {
       return reply.status(503).send({
         status: "unavailable",

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -938,20 +938,38 @@ export async function getMembers(
   );
 }
 
-export async function health(pool: Pool): Promise<{
+// `teamId` asks a second question: does this server actually have that team?
+//
+// The answer comes from the database, never from the request. Echoing the header
+// back would let a client compare its own value with itself and call that
+// agreement — true even for a team this server has never heard of, which is the
+// case the check exists for.
+//
+// An unknown team is a 200 without `team_id`, not a 404. Health stays a liveness
+// answer: an edge in front of this may route by team and cannot always turn "no
+// such team" into a status code, and a 404 here would be indistinguishable from
+// "no such route" to a client checking whether the server is up at all. Absence
+// carries the disagreement instead, and the client — which knows which team it
+// expects — is where that is judged.
+export async function health(pool: Pool, teamId?: string): Promise<{
   status: "ok";
   server_instance_id: string;
   protocol: { supported_versions: number[] };
   database: "ok";
+  team_id?: string;
 }> {
   const client = await pool.connect();
   try {
-    return {
-      status: "ok",
-      server_instance_id: await serverInstanceId(client),
+    const serverId = await serverInstanceId(client);
+    const base = {
+      status: "ok" as const,
+      server_instance_id: serverId,
       protocol: { supported_versions: [1] },
-      database: "ok",
+      database: "ok" as const,
     };
+    if (teamId === undefined) return base;
+    const team = await teamRow(client, teamId);
+    return team ? { ...base, team_id: team.team_id } : base;
   } finally {
     client.release();
   }

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -113,6 +113,41 @@ describeDatabase("remote storage HTTP API v1", () => {
     });
   });
 
+  it("echoes the team on health when asked about one, and stays answerable when not", async () => {
+    // Two questions share this route. "Is the server up" is asked before any
+    // team exists — by an operator, a probe, a client that has not connected —
+    // so the header is optional and its absence must not be an error. "Am I
+    // still bound to the team I think I am" comes from a configured client,
+    // which always has one; that answer is what makes the client's check
+    // possible at all.
+    const teamId = "018f3f7e-0000-7000-8000-0000000000c1";
+    const withTeam = await app.inject({
+      method: "GET",
+      url: "/v1/health",
+      headers: { "Agmsg-Team-ID": teamId },
+    });
+    expect(withTeam.statusCode).toBe(200);
+    expect(withTeam.json()).toMatchObject({ status: "ok", team_id: teamId });
+
+    // Without the header: still 200, and no team_id invented. A client that
+    // sends the header and gets nothing back treats that as disagreement, so
+    // answering with someone else's team would be worse than answering with
+    // none.
+    const withoutTeam = await app.inject({ method: "GET", url: "/v1/health" });
+    expect(withoutTeam.statusCode).toBe(200);
+    expect(withoutTeam.json()).not.toHaveProperty("team_id");
+
+    // A malformed header is a bad request, not a dead database. The 503 handler
+    // wraps everything thrown inside the route, so validating in there would
+    // report "database unavailable" for a client's typo.
+    const malformed = await app.inject({
+      method: "GET",
+      url: "/v1/health",
+      headers: { "Agmsg-Team-ID": "not-a-uuid" },
+    });
+    expect(malformed.statusCode).toBe(400);
+  });
+
   it("answers a name lookup, and refuses more names than it can disambiguate", async () => {
     const lookupName = "lookup-by-name";
     const ids = Array.from({ length: 17 }, (_, index) =>

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -120,7 +120,7 @@ describeDatabase("remote storage HTTP API v1", () => {
     // still bound to the team I think I am" comes from a configured client,
     // which always has one; that answer is what makes the client's check
     // possible at all.
-    const teamId = "018f3f7e-0000-7000-8000-0000000000c1";
+    // The provisioned team, so the answer comes from a row that exists.
     const withTeam = await app.inject({
       method: "GET",
       url: "/v1/health",
@@ -128,6 +128,21 @@ describeDatabase("remote storage HTTP API v1", () => {
     });
     expect(withTeam.statusCode).toBe(200);
     expect(withTeam.json()).toMatchObject({ status: "ok", team_id: teamId });
+
+    // The case that separates a real answer from an echo: a well-formed id this
+    // server does not have. Still 200 — health is a liveness answer, and an edge
+    // routing by team cannot always turn "no such team" into a status code — but
+    // with no team_id. Echoing the header would make this indistinguishable from
+    // the provisioned case, and the client would compare its own value with
+    // itself and call it agreement.
+    const unknown = await app.inject({
+      method: "GET",
+      url: "/v1/health",
+      headers: { "Agmsg-Team-ID": "018f3f7e-0000-7000-8000-0000000000c1" },
+    });
+    expect(unknown.statusCode).toBe(200);
+    expect(unknown.json()).toMatchObject({ status: "ok" });
+    expect(unknown.json()).not.toHaveProperty("team_id");
 
     // Without the header: still 200, and no team_id invented. A client that
     // sends the header and gets nothing back treats that as disagreement, so

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -24,6 +24,10 @@ CONNECT_CIPHERS = (["none"] if os.environ.get("MOCK_CONNECT_NO_AGE") == "1"
 # or returned — reaching the server is the permission. A team_id already
 # registered is refused 409 (a uniqueness conflict, like a non-fast-forward).
 CONNECT_SERVER_ID = "018f3f7e-3333-7000-8000-000000000001"
+# What /v1/health reports as the team. Empty means "echo the requested one",
+# which is what a per-team edge does; a test sets it via /_test/health-team= to
+# make the server disagree with the client's binding.
+HEALTH_TEAM_ID = os.environ.get("MOCK_HEALTH_TEAM_ID", "")
 REGISTERED_TEAM_IDS = set()
 
 
@@ -138,11 +142,20 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def do_GET(self):
+        # Declared for the whole method: /_test/health-team assigns it, and
+        # Python requires the declaration to precede the first mention anywhere
+        # in the function — including the read in the /v1/health branch below.
+        global HEALTH_TEAM_ID
         if self.path == "/v1/health":
+            # Echo the team the caller asked about, the way a real per-team edge
+            # answers. MOCK_HEALTH_TEAM_ID overrides it so a test can make the
+            # server disagree with the local binding.
+            team_id = HEALTH_TEAM_ID or self.headers.get("Agmsg-Team-ID", "")
             self._send_json(200, {
                 "status": "ok",
                 "database": "ok",
                 "server_instance_id": CONNECT_SERVER_ID,
+                "team_id": team_id,
             })
             return
         if self.path == "/v1/capabilities":
@@ -171,6 +184,15 @@ class Handler(BaseHTTPRequestHandler):
             return
         if self.path == "/_test/pushed":
             self._send_json(200, {"messages": PUSHED_MESSAGES})
+            return
+        # Change what /v1/health claims the team is, without restarting — a
+        # restart moves the port, and a client that already recorded the old one
+        # then fails to connect for a reason unrelated to what is under test.
+        if self.path.startswith("/_test/health-team"):
+            from urllib.parse import unquote
+            _, _, override = self.path.partition("=")
+            HEALTH_TEAM_ID = unquote(override)
+            self._send_json(200, {"health_team_id": HEALTH_TEAM_ID})
             return
         parts = self.path.split("?", 1)
         route = parts[0]

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1168,6 +1168,24 @@ test("an error that carries no binding is reported as itself, not as a mismatch"
       `status ${status} must not be reported as a binding mismatch`,
     );
   }
+  // A PARTIAL binding is still a binding claim, and the partial one is what
+  // matters: a body with only protocol_version reached validateBinding under the
+  // allowlist and was refused for the missing pair. Triggering on two of the
+  // three fields would have let it through — the inversion loosening a path
+  // instead of tightening it. The value being the correct 1 is the sharp case:
+  // it is right, and the rest is still missing.
+  for (const status of [403, 500]) {
+    assert.throws(() => validateErrorBinding(config, status, {
+      protocol_version: 1, error: { code: "partial-binding" },
+    }), /binding mismatch/u, `status ${status} with only protocol_version must be refused`);
+  }
+  // But protocol_version is not itself an identity claim — every well-formed
+  // reply carries one, including an ordinary 401. Treating it as one everywhere
+  // would turn "your credential was rejected" back into "binding mismatch",
+  // which is the bug this whole change exists to remove.
+  assert.doesNotThrow(() => validateErrorBinding(config, 401, {
+    protocol_version: 1, error: { code: "unauthenticated" },
+  }));
   // Presence is the trigger, so a mismatched binding on a status the old
   // allowlist skipped is now caught rather than waved through.
   assert.throws(() => validateErrorBinding(config, 400, {

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -604,7 +604,7 @@ test("explicit reprocess walks past a permanent first keyset page", async () => 
     ];
   };
   const result = await reprocessCycle(config, 1, {
-    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    healthCall: async () => ({ server_instance_id: config.server_instance_id, team_id: config.remote_team_id }),
     requestCall: async () => capabilities,
     driverCall,
     evaluateCall: async () => ({ status: "authentication_failed", reason: "still blocked",
@@ -630,7 +630,7 @@ test("reprocess completion counts imported outcomes and requires empty blocking 
   const id = "550e8400-e29b-41d4-a716-446655440001";
   let imported = false;
   const result = await reprocessCycle(config, 100, {
-    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    healthCall: async () => ({ server_instance_id: config.server_instance_id, team_id: config.remote_team_id }),
     requestCall: async () => capabilities,
     driverCall: async (operation, _config, input) => {
       if (operation === "apply") {
@@ -679,7 +679,7 @@ test("reprocess routes recovered roster mutations away from message storage", as
   let rosterApplied = false;
   let messageApplied = false;
   const result = await reprocessCycle(config, 100, {
-    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    healthCall: async () => ({ server_instance_id: config.server_instance_id, team_id: config.remote_team_id }),
     requestCall: async () => capabilities,
     driverCall: async (operation, _config, input) => {
       if (operation === "apply") {
@@ -748,7 +748,7 @@ test("reprocess preserves server order across roster mutations and rotations", a
   let activeEpoch = 0;
   const rosterOrder = [];
   const result = await reprocessCycle(config, 100, {
-    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    healthCall: async () => ({ server_instance_id: config.server_instance_id, team_id: config.remote_team_id }),
     requestCall: async () => capabilities,
     driverCall: async (operation, _config, input) => {
       if (operation === "apply") {
@@ -808,7 +808,7 @@ test("reprocess does not advance storage when an ordered roster flush fails", as
   let storageApplied = false;
   let activated = false;
   await assert.rejects(reprocessCycle(config, 100, {
-    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    healthCall: async () => ({ server_instance_id: config.server_instance_id, team_id: config.remote_team_id }),
     requestCall: async () => ({ ...capsFor(["age-v1"]), current_seq: "2",
       next_sequence_boundary: "3" }),
     driverCall: async (operation) => {
@@ -852,7 +852,7 @@ test("explicit reprocess rejects an unbounded walk through duplicate server sequ
     "550e8400-e29b-41d4-a716-446655440002"];
   let pageIndex = 0;
   await assert.rejects(() => reprocessCycle(config, 1, {
-    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    healthCall: async () => ({ server_instance_id: config.server_instance_id, team_id: config.remote_team_id }),
     requestCall: async () => capabilities,
     driverCall: async (operation) => {
       if (operation === "apply") {
@@ -1150,6 +1150,46 @@ test("resolved protocol errors enforce the immutable binding", () => {
   assert.doesNotThrow(() => validateErrorBinding(config, 401, {
     protocol_version: 1, error: { code: "unauthenticated" },
   }));
+});
+
+test("an error that carries no binding is reported as itself, not as a mismatch", () => {
+  // The allowlist was {400,401,426}, so everything else went through
+  // validateBinding — which compares body.team_id, `undefined` in an ordinary
+  // error body. Every 403, 404, 409 and 500 therefore arrived as "server/team
+  // binding mismatch": the one message meaning "you are talking to the wrong
+  // team" stood in for forbidden, missing, conflicting, and crashed alike.
+  //
+  // Whether a body carries a binding is the real question, so that is what is
+  // asked. Statuses listed explicitly rather than looped from a range: each one
+  // is a diagnosis a caller acts on differently.
+  for (const status of [403, 404, 409, 500]) {
+    assert.doesNotThrow(
+      () => validateErrorBinding(config, status, { error: { code: "some-server-error" } }),
+      `status ${status} must not be reported as a binding mismatch`,
+    );
+  }
+  // Presence is the trigger, so a mismatched binding on a status the old
+  // allowlist skipped is now caught rather than waved through.
+  assert.throws(() => validateErrorBinding(config, 400, {
+    protocol_version: 1,
+    server_instance_id: "018f3f7e-0000-7000-8000-000000000099",
+    team_id: config.remote_team_id,
+    error: { code: "bad-request" },
+  }), /binding mismatch/u);
+});
+
+test("a masked 500 becomes retryable again", () => {
+  // Not a side effect — the point. While validateBinding swallowed it, the
+  // caller never built the Error that carries `status`, and isRetryable saw
+  // `undefined`: a 500 was treated as permanent even though it is in the
+  // retryable set. Passing the body through restores that.
+  assert.doesNotThrow(() =>
+    validateErrorBinding(config, 500, { error: { code: "internal" } }));
+  const escalated = Object.assign(new Error("HTTP 500 internal"), { status: 500 });
+  assert.equal(isRetryable(escalated), true);
+  // And the mismatch itself stays permanent: retrying a wrong-team binding
+  // would just repeat it.
+  assert.equal(isRetryable(new Error("server/team binding mismatch")), false);
 });
 
 test("run retry classification excludes permanent HTTP and validation failures", () => {
@@ -1760,8 +1800,12 @@ test("age configure authenticates the connected credential before retaining trus
     globalThis.fetch = async () => {
       calls += 1;
       if (calls === 1) {
+        // The health reply has to name the team, or configure refuses here and
+        // the credential check below is never reached — this test would then
+        // pass on the wrong rejection.
         return new Response(JSON.stringify({ status: "ok", database: "ok",
-          server_instance_id: config.server_instance_id }), {
+          server_instance_id: config.server_instance_id,
+          team_id: config.remote_team_id }), {
           status: 200, headers: { "Agmsg-Protocol-Version": "1" },
         });
       }
@@ -1840,7 +1884,11 @@ test("age configure extends a stored chain and activates its announced epoch", a
     process.env.AGMSG_AGE_BIN = fakeAge;
     globalThis.fetch = async (url) => {
       const body = String(url).endsWith("/v1/health") ?
-        { status: "ok", database: "ok", server_instance_id: config.server_instance_id } :
+        // team_id too: configure now reads it back and refuses a server that
+        // names a different team, so a stub that omits it is a server which
+        // does not answer per-team.
+        { status: "ok", database: "ok", server_instance_id: config.server_instance_id,
+          team_id: config.remote_team_id } :
         capsFor(["age-v1"]);
       return new Response(JSON.stringify(body), {
         status: 200, headers: { "Agmsg-Protocol-Version": "1" },
@@ -1994,7 +2042,7 @@ test("cycle: a large pull page (backlog present) is requested and accepted at pu
   }));
   let pullPath = null;
   const result = await cycle(config, { pushLimit: 100, pullLimit: 1000 }, {
-    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    healthCall: async () => ({ server_instance_id: config.server_instance_id, team_id: config.remote_team_id }),
     requestCall: async (_config, path) => {
       if (path === "/v1/capabilities") return capabilities;
       if (path.startsWith("/v1/messages?after=")) { pullPath = path; return { messages, next_after: "500", has_more: false }; }
@@ -2037,7 +2085,7 @@ test("cycle routes roster payloads through the existing message transport", asyn
   });
   const rosterOperations = [];
   await cycle(config, { pushLimit: 100, pullLimit: 1000 }, {
-    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    healthCall: async () => ({ server_instance_id: config.server_instance_id, team_id: config.remote_team_id }),
     requestCall: async (_config, path, init) => {
       if (path === "/v1/capabilities") return capability();
       if (path === "/v1/messages" && init?.method === "POST") {
@@ -2226,7 +2274,7 @@ test("cycle pushes a key rotation alone and waits for ordered pull before activa
   };
   let activated = 0;
   await cycle(config, { pushLimit: 100, pullLimit: 1000 }, {
-    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    healthCall: async () => ({ server_instance_id: config.server_instance_id, team_id: config.remote_team_id }),
     requestCall: async (_config, path, init) => {
       if (path === "/v1/capabilities") return capsFor(["none"]);
       if (path === "/v1/messages" && init?.method === "POST") {
@@ -2282,7 +2330,7 @@ test("cycle records a pulled key rotation before halting for a missing replaceme
   let recorded = false;
   let storageApplied = false;
   await assert.rejects(cycle(config, { pushLimit: 100, pullLimit: 1000 }, {
-    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    healthCall: async () => ({ server_instance_id: config.server_instance_id, team_id: config.remote_team_id }),
     requestCall: async (_config, path) => {
       if (path === "/v1/capabilities") return {
         ...capsFor(["none"]), current_seq: "1", next_sequence_boundary: "2",
@@ -2355,7 +2403,7 @@ async function runCycleWithPush({ writeCiphers, candidateCount, pushLimit }) {
   let posted = false;
   let reconcileCalled = false;
   const result = await cycle(config, { pushLimit, pullLimit: 1000 }, {
-    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    healthCall: async () => ({ server_instance_id: config.server_instance_id, team_id: config.remote_team_id }),
     requestCall: async (_config, path, init) => {
       if (path === "/v1/capabilities") return capabilities;
       if (path === "/v1/messages" && init?.method === "POST") {
@@ -2407,7 +2455,7 @@ test("cycle: a batch that fails after prepare re-sends the same candidates and c
   let reconcileAcks = null;
   const postedIdsPerAttempt = [];
   const deps = {
-    healthCall: async () => ({ server_instance_id: config.server_instance_id }),
+    healthCall: async () => ({ server_instance_id: config.server_instance_id, team_id: config.remote_team_id }),
     requestCall: async (_config, path, init) => {
       if (path === "/v1/capabilities") return capabilities;
       if (path === "/v1/messages" && init?.method === "POST") {

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -16,6 +16,7 @@ setup() {
   MOCK_PULL_AGE="${MOCK_PULL_AGE:-}" \
   MOCK_PULL_AGE_ENVELOPE_FILE="${MOCK_PULL_AGE_ENVELOPE_FILE:-}" \
   MOCK_PULL_TEAM_ID="${MOCK_PULL_TEAM_ID:-}" \
+  MOCK_HEALTH_TEAM_ID="${MOCK_HEALTH_TEAM_ID:-}" \
   MOCK_CONNECT_NO_AGE="${MOCK_CONNECT_NO_AGE:-}" \
     "$MOCK_PYTHON3" "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
     </dev/null > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" 3>&- &
@@ -78,6 +79,7 @@ restart_mock_server() {
   MOCK_PULL_AGE="${MOCK_PULL_AGE:-}" \
   MOCK_PULL_AGE_ENVELOPE_FILE="${MOCK_PULL_AGE_ENVELOPE_FILE:-}" \
   MOCK_PULL_TEAM_ID="${MOCK_PULL_TEAM_ID:-}" \
+  MOCK_HEALTH_TEAM_ID="${MOCK_HEALTH_TEAM_ID:-}" \
   MOCK_CONNECT_NO_AGE="${MOCK_CONNECT_NO_AGE:-}" \
     "$MOCK_PYTHON3" "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
       </dev/null > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" 3>&- &
@@ -1021,6 +1023,75 @@ PY
   [ -f "$seen" ]               # and it must actually have been reached
   [ "$(cat "$seen")" = "600" ]
   rm -rf "$peer"
+}
+
+@test "remote unlock: a health response naming another team stops the configure" {
+  skip_if_no_age
+
+  # `configure` is the only caller of health(), and `cmd_unlock` is the only
+  # caller of configure — so this is the path where reading the answer back can
+  # be observed at all. Before this check, remote_team_id was whatever was passed
+  # in and was never compared against the server, so a disagreement stayed
+  # invisible until the first push failed, far from the step that caused it.
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam >/dev/null
+  local source_cfg bundle key_id recipient team_id envelope snapshot digest
+  source_cfg="$TEST_SKILL_DIR/teams/testteam/config.json"
+  bundle="$TEST_SKILL_DIR/hm-bundle.json"
+  snapshot="$TEST_SKILL_DIR/hm-snapshot.json"
+  envelope="$TEST_SKILL_DIR/hm-envelope.json"
+  bash "$SCRIPTS/key.sh" show testteam --snapshot --out "$snapshot" 2>/dev/null
+  bash "$SCRIPTS/key.sh" handoff testteam --out "$bundle" >/dev/null 2>&1
+  key_id="$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$source_cfg")') AS TEXT), '\$.remote_key.current.key_id');")"
+  recipient="$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$source_cfg")') AS TEXT), '\$.remote_key.current.recipient');")"
+  team_id="$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$source_cfg")') AS TEXT), '\$.team_id');")"
+  jq -nc --arg key_id "$key_id" --arg recipient "$recipient" --arg team_id "$team_id" \
+    '{ type:"sync_seal", envelope_v:1, cipher:"age-v1",
+       key_id:$key_id, recipients:[$recipient], max_blob_bytes:1048576,
+       wire_id:"20000000-0000-4000-8000-000000000001",
+       team_id:$team_id, protocol_version:1,
+       projection:{ body:"hm ciphertext", created_at:"2026-01-02T00:00:00.000000Z",
+         from_agent:"member-1", to_agent:"member-1" } }' |
+    node "$SCRIPTS/internal/sync-cipher.mjs" seal > "$envelope"
+  bash "$SCRIPTS/remote.sh" disconnect testteam >/dev/null 2>&1 || true
+
+  MOCK_PULL_AGE=1
+  MOCK_PULL_AGE_ENVELOPE_FILE="$envelope"
+  MOCK_PULL_TEAM_ID="$team_id"
+  # The server answers /v1/health with a DIFFERENT team than the one this
+  # machine is bound to.
+  MOCK_HEALTH_TEAM_ID="018f3f7e-9999-7999-8999-999999999999"
+  restart_mock_server
+
+  PEER_SKILL_DIR="$(mktemp -d)"
+  export PEER_SKILL_DIR
+  mkdir -p "$PEER_SKILL_DIR"/{scripts,db,teams}
+  cp -R "$BATS_TEST_DIRNAME"/../scripts/. "$PEER_SKILL_DIR/scripts/"
+  chmod +x "$PEER_SKILL_DIR/scripts/"*.sh
+  bash "$PEER_SKILL_DIR/scripts/internal/init-db.sh"
+  local peer_scripts="$PEER_SKILL_DIR/scripts"
+
+  run bash "$peer_scripts/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$team_id" encrypted
+  [ "$status" -eq 0 ]
+
+  digest="$(shasum -a 256 "$snapshot" | awk '{print $1}')"
+  run bash "$peer_scripts/remote.sh" unlock encrypted --bundle "$bundle" --confirm-digest "$digest"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"health team does not match"* ]]
+
+  # Fail closed: no sync state and no engine for a binding the server disowns.
+  [ ! -e "$PEER_SKILL_DIR/db/remote-sync/encrypted.json" ]
+  [ ! -e "$PEER_SKILL_DIR/run/remote-sync.encrypted.pid" ]
+
+  # The same unlock succeeds once the server agrees, so the failure above is the
+  # mismatch and not something else in this setup. Switched in place rather than
+  # by restarting: a restart moves the port, and the peer would then fail to
+  # reach the endpoint it recorded at pull time — a green-looking pass for the
+  # wrong reason, or a red one.
+  curl -sS "$ENDPOINT/_test/health-team=" >/dev/null
+  run bash "$peer_scripts/remote.sh" unlock encrypted --bundle "$bundle" --confirm-digest "$digest"
+  [ "$status" -eq 0 ]
+  local pid; pid="$(cat "$PEER_SKILL_DIR/run/remote-sync.encrypted.pid" 2>/dev/null || true)"
+  [ -n "$pid" ] && { kill "$pid" 2>/dev/null || true; wait_for_pid_exit "$pid"; }
 }
 
 @test "remote unlock: --bundle still requires a matching --confirm-digest" {


### PR DESCRIPTION
## Every server error was calling itself a binding mismatch

`validateErrorBinding` skipped the binding check for `{400, 401, 426}` and ran it for everything else — including error bodies that carry no binding at all. In those, `body.team_id` is `undefined`, so the comparison always failed and the error became `server/team binding mismatch`. A 403, a 404, a 409 and a 500 were all reported with the one message that means "you are talking to the wrong team", and whatever the server actually said was discarded.

Whether the body carries a binding is the real question, so that is what is asked now. This is also stricter than the allowlist in one direction: a 400 that *does* carry a mismatched binding is caught, where before it was waved through.

### One deliberate behaviour change

A masked error became a bare `Error` with no `status`, so `isRetryable` saw `undefined` and returned false. A 500 was therefore treated as permanent despite being in the retryable set. Letting the body through means the caller builds the error that carries the status, and 500 is retryable again — that is the fix, not a side effect. A genuine binding mismatch stays permanent: retrying the wrong team would only repeat it.

## Health carries the team, and the answer is read back

`/v1/health` now sends `Agmsg-Team-ID` — the same header name `send()` uses, not a new one — and `configure` refuses a reply that names a different team.

The read-back is the point. Sending the header without checking the response would add a field that exists and that nobody consults; this file already has one of those (the handoff bundle's `format_version` is checked for `!== 1` and never used to negotiate). Until now `remote_team_id` was whatever was passed on the command line, stored without ever being compared against the server, so a disagreement stayed invisible until the first push failed — far from the step that caused it.

The equality is strict, with no exemption for a server that omits the field: an endpoint that does not answer per-team would otherwise look identical to one that agrees.

`validateBinding` is unchanged.

### Two call sites the brief did not mention

`health()` is reached from three places, not one: `configure`, and `healthCall` in both the run cycle and the reprocess cycle. The latter two also pass the team now and make the same check, because sending a header from two of three callers would have left `Agmsg-Team-ID: undefined` on the wire for the other two.

## What this does not do

**It will not make a failing sync pass.** The pushes that fail go through `send()`, which already sends this header; what the gateway returns is the problem, and that fix is cloud-side. This change makes the disagreement fail at `configure` instead of at the first push.

## Tests

`tests/test_remote.bats` 65/65 and `tests/remote_sync_engine.test.mjs` green.

- a health reply naming another team stops the unlock, leaving no sync state and no engine — then the same unlock succeeds once the server agrees, so the failure is the mismatch and not the setup. Removing the check makes it pass, which is what it is there to prevent.
- errors carrying no binding (403, 404, 409, 500) are reported as themselves; a 400 that carries a mismatched binding is still refused; a 500 is retryable again. Restoring the allowlist fails all of these.

The mock now echoes the requested team on `/v1/health`, the way a per-team edge does, with a `/_test/health-team=` switch so a test can make it disagree. Switched in place rather than by restarting the server: a restart moves the port, and the client would then fail to reach the endpoint it recorded earlier — a red for the wrong reason.
