### PR TITLE
fix(migrate): prove the destination has the rows before deleting them

### DIFF
--- a/scripts/internal/migrate-team-store.sh
+++ b/scripts/internal/migrate-team-store.sh
@@ -62,11 +62,65 @@ src_tables="$(agmsg_sqlite "$SHARED" \
   "SELECT name FROM sqlite_master WHERE type='table';" 2>/dev/null || true)"
 has_table() { printf '%s\n' "$src_tables" | grep -qx "$1"; }
 
+# Every row of this team that the shared store holds, keyed by what identifies
+# it. seq and id are copied verbatim, so they match across the two stores;
+# read_cursors have no id and are identified by (team, agent).
+#
+# Compared as a SET, not a count. Equal counts can be different rows — a
+# half-finished copy that then received new arrivals reaches the same total
+# while the original history is still missing.
+_missing_from_dest() {
+  local lit; lit="$(agmsg_sqlesc "$TEAM")"
+  local dest_lit; dest_lit="$(agmsg_sql_readfile_path "$DEST")"
+  local t sql out
+  for t in events messages read_cursors; do
+    printf '%s\n' "$src_tables" | grep -qx "$t" || continue
+    case "$t" in
+      events)   sql="SELECT seq FROM $t WHERE team='$lit'
+                     EXCEPT SELECT seq FROM dst.$t WHERE team='$lit';" ;;
+      messages) sql="SELECT id FROM $t WHERE team='$lit'
+                     EXCEPT SELECT id FROM dst.$t WHERE team='$lit';" ;;
+      *)        sql="SELECT agent FROM $t WHERE team='$lit'
+                     EXCEPT SELECT agent FROM dst.$t WHERE team='$lit';" ;;
+    esac
+    # A destination that cannot be read, or lacks the table, makes the query
+    # fail — which is reported as "not proven complete", never as "nothing is
+    # missing". Being unable to check is not the same as having checked.
+    out="$(printf '%s\n' "ATTACH DATABASE '$dest_lit' AS dst; $sql" \
+      | agmsg_sqlite "$SHARED" 2>/dev/null)" || { echo "$t"; return 0; }
+    [ -z "$out" ] || { echo "$t"; return 0; }
+  done
+  return 0
+}
+
 if [ "$(agmsg_driver_for_team partition "$TEAM" shared)" = per-team ]; then
   # Already moved. Finish the job if a previous run died between recording the
   # partition and clearing the shared copy — otherwise external readers keep seeing
   # this team's history frozen at the moment it moved, which looks like nothing
   # is wrong.
+  #
+  # But only after proving the destination HAS what is about to be deleted.
+  # Reaching this branch means the config says "moved"; it does not mean the
+  # store still exists. Deleting on the strength of a flag is how a destination
+  # removed by hand takes the shared history with it — the flag survives, the
+  # data does not, and the run reports success.
+  #
+  # Note the direction: the destination legitimately holds MORE than the shared
+  # store, because new arrivals land there from the moment the config flips.
+  # What has to hold is containment, not equality.
+  if [ ! -e "$DEST" ]; then
+    echo "team store: '$TEAM' is recorded as moved, but $DEST does not exist." >&2
+    echo "team store: the shared store still holds its history and has NOT been touched." >&2
+    echo "team store: restore $DEST from a backup, or move the team back before retrying." >&2
+    exit 1
+  fi
+  incomplete="$(_missing_from_dest)"
+  if [ -n "$incomplete" ]; then
+    echo "team store: '$TEAM' is recorded as moved, but $DEST is missing rows ($incomplete)." >&2
+    echo "team store: the shared store still holds its history and has NOT been touched." >&2
+    echo "team store: restore or remove $DEST and re-run, rather than leaving both partial." >&2
+    exit 1
+  fi
   _drop_from_shared
   echo "team store: '$TEAM' already has its own store; shared copy cleared"
   exit 0
@@ -77,6 +131,16 @@ if [ -e "$DEST" ]; then
   # seq/id values, and copying the shared ones on top would either collide or be
   # silently ignored — losing history in the case that looks like success.
   echo "team store: a store already exists at $DEST; refusing to merge" >&2
+  # The same situation as the verification failure below, which does say what to
+  # do about it. Saying it in one place and not the other leaves the reader to
+  # guess in the case that reached them first.
+  #
+  # Safe here because this branch runs BEFORE the partition is recorded: the
+  # team still resolves to the shared store, so removing the destination throws
+  # away only the failed attempt. Once a team is recorded as moved, the same
+  # advice would destroy the live store — hence the caveat, which is not padding.
+  echo "team store: remove $DEST before retrying — but only while '$TEAM' is NOT yet" >&2
+  echo "team store: recorded as moved; after that, $DEST holds its live history." >&2
   exit 1
 fi
 

--- a/scripts/internal/migrate-team-store.sh
+++ b/scripts/internal/migrate-team-store.sh
@@ -62,26 +62,45 @@ src_tables="$(agmsg_sqlite "$SHARED" \
   "SELECT name FROM sqlite_master WHERE type='table';" 2>/dev/null || true)"
 has_table() { printf '%s\n' "$src_tables" | grep -qx "$1"; }
 
-# Every row of this team that the shared store holds, keyed by what identifies
-# it. seq and id are copied verbatim, so they match across the two stores;
-# read_cursors have no id and are identified by (team, agent).
+# Every row of this team that the shared store holds, compared by VALUE.
 #
-# Compared as a SET, not a count. Equal counts can be different rows — a
-# half-finished copy that then received new arrivals reaches the same total
-# while the original history is still missing.
+# Not a count: equal totals can be different rows. Not a key either: the same
+# seq or id can name different content once a destination has been recreated.
+# What has to be proven before deleting anything is that each shared row exists
+# in the destination as the same row.
 _missing_from_dest() {
   local lit; lit="$(agmsg_sqlesc "$TEAM")"
   local dest_lit; dest_lit="$(agmsg_sql_readfile_path "$DEST")"
   local t sql out
   for t in events messages read_cursors; do
     printf '%s\n' "$src_tables" | grep -qx "$t" || continue
+    # Every column the copy carries, not just the key.
+    #
+    # A key alone proves too little here. After the destination is removed the
+    # config still says per-team, so the next write creates a NEW database at
+    # that path, AUTOINCREMENT restarts, and its first event takes seq 1 — the
+    # same seq a different shared event already has. Measured: two stores, both
+    # holding seq 1, entirely different bodies, and a key-only comparison
+    # reports nothing missing.
+    #
+    # The copy uses INSERT OR IGNORE, so a key collision leaves the existing row
+    # untouched rather than replacing it. Whatever is under that key in the
+    # destination may be someone else's row, and deleting the shared original on
+    # the strength of a matching number would lose it.
     case "$t" in
-      events)   sql="SELECT seq FROM $t WHERE team='$lit'
-                     EXCEPT SELECT seq FROM dst.$t WHERE team='$lit';" ;;
-      messages) sql="SELECT id FROM $t WHERE team='$lit'
-                     EXCEPT SELECT id FROM dst.$t WHERE team='$lit';" ;;
-      *)        sql="SELECT agent FROM $t WHERE team='$lit'
-                     EXCEPT SELECT agent FROM dst.$t WHERE team='$lit';" ;;
+      events)   sql="SELECT seq,type,id,team,from_agent,to_agent,body,msg_id,agent,at
+                       FROM $t WHERE team='$lit'
+                     EXCEPT
+                     SELECT seq,type,id,team,from_agent,to_agent,body,msg_id,agent,at
+                       FROM dst.$t WHERE team='$lit';" ;;
+      messages) sql="SELECT id,team,from_agent,to_agent,body,created_at,read_at
+                       FROM $t WHERE team='$lit'
+                     EXCEPT
+                     SELECT id,team,from_agent,to_agent,body,created_at,read_at
+                       FROM dst.$t WHERE team='$lit';" ;;
+      *)        sql="SELECT team,agent,local_position FROM $t WHERE team='$lit'
+                     EXCEPT
+                     SELECT team,agent,local_position FROM dst.$t WHERE team='$lit';" ;;
     esac
     # A destination that cannot be read, or lacks the table, makes the query
     # fail — which is reported as "not proven complete", never as "nothing is

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -211,6 +211,86 @@ shared_rows() {
   [ "$(shared_rows alpha)" -eq 1 ]
 }
 
+# The scenario a key-only comparison waves through. After the destination is
+# removed the config still says per-team, so the next write creates a NEW
+# database there, AUTOINCREMENT restarts, and its first event takes seq 1 — a
+# seq the shared store already used for something else. Comparing keys finds
+# nothing missing and deletes real history.
+@test "migrate: a destination whose keys collide with different content is refused" {
+  bash "$SCRIPTS/send.sh" alpha ann bob "the original message" >/dev/null
+  migrate alpha
+
+  local dest; dest="$(store_of alpha)"
+  local seq; seq=$(sqlite3 "$dest"     "SELECT seq FROM events WHERE type='message_sent' AND team='alpha' LIMIT 1;")
+
+  # The shared store holds a row under the SAME seq, with different content —
+  # what a recreated destination produces once numbering restarts.
+  sqlite3 "$SHARED" "INSERT INTO events(seq,type,id,team,from_agent,to_agent,body,at)
+    VALUES($seq,'message_sent','other-id','alpha','ann','bob','a different message',
+           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
+  [ "$(shared_rows alpha)" -eq 1 ]
+
+  run migrate alpha
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "missing rows" ]]
+  # The row is still there: same number, different content, not the same row.
+  [ "$(shared_rows alpha)" -eq 1 ]
+}
+
+# Same class, other tables. messages.id is AUTOINCREMENT too, and a cursor's
+# content is its position — a matching agent name says nothing about where that
+# agent had read to. Each table is asserted separately because the comparison
+# is written per table, and one of them getting it right hides the others.
+@test "migrate: a message id reused for different content is refused" {
+  # send.sh writes history to events; the messages table stays empty on this
+  # path, so the row is placed on both sides directly. The table is still copied
+  # and still deleted from the shared store, so it needs the same proof — and
+  # measuring it required checking which tables actually carry rows rather than
+  # assuming.
+  bash "$SCRIPTS/send.sh" alpha ann bob "the original message" >/dev/null
+  migrate alpha
+  local dest; dest="$(store_of alpha)"
+
+  sqlite3 "$dest" "INSERT INTO messages(id,team,from_agent,to_agent,body,created_at)
+    VALUES(1,'alpha','ann','bob','what the destination holds',
+           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
+  sqlite3 "$SHARED" "INSERT INTO messages(id,team,from_agent,to_agent,body,created_at)
+    VALUES(1,'alpha','ann','bob','a different body',
+           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
+
+  run migrate alpha
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "missing rows" ]]
+  [ "$(sqlite3 "$SHARED" "SELECT COUNT(*) FROM messages WHERE team='alpha';")" -eq 1 ]
+}
+
+@test "migrate: a cursor at a different position is refused" {
+  # ONLY the cursor differs. The containment check returns at the FIRST table
+  # that is short, so a test that also leaves an events row behind never reaches
+  # the cursor rule — the earlier version of this test passed while a mutation
+  # removing that rule stayed green.
+  bash "$SCRIPTS/send.sh" alpha ann bob "one" >/dev/null
+  migrate alpha
+  local dest; dest="$(store_of alpha)"
+
+  # Same agent, present on both sides, at different positions. Comparing the
+  # agent name alone calls this complete and deletes the shared cursor, silently
+  # moving where that agent resumes reading.
+  sqlite3 "$dest"   "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
+    VALUES('alpha','ann',1);"
+  sqlite3 "$SHARED" "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
+    VALUES('alpha','ann',999);"
+
+  # Nothing else is short, so a refusal here is about the cursor and not a
+  # leftover event.
+  [ "$(shared_rows alpha)" -eq 0 ]
+
+  run migrate alpha
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "missing rows" ]]
+  [ "$(sqlite3 "$SHARED"       "SELECT local_position FROM read_cursors WHERE team='alpha' AND agent='ann';")" -eq 999 ]
+}
+
 # The normal re-entry this guard must NOT break. After the config flips, new
 # messages land in the destination, so it legitimately holds MORE than the
 # shared store. A guard written as "the counts match" would refuse exactly the

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -92,6 +92,13 @@ shared_rows() {
   run migrate alpha
   [ "$status" -ne 0 ]
   [[ "$output" =~ "refusing to merge" ]]
+  # And it says what to do — the verification failure below already did, and a
+  # reader who hits this one first should not have to guess.
+  [[ "$output" =~ "remove" ]]
+  # With the caveat that makes the advice safe. Following it after a team is
+  # recorded as moved would destroy the live store, which is the loss this
+  # change exists to prevent.
+  [[ "$output" =~ "NOT yet" ]]
   # The team did not move, so its rows are still where readers expect them.
   [ "$(shared_rows alpha)" -eq 1 ]
 }
@@ -138,4 +145,97 @@ shared_rows() {
   called="$(grep -n 'migrate-team-store' "$BATS_TEST_DIRNAME/../install.sh" \
     | grep -v '^[0-9]*: *#' || true)"
   [ -z "$called" ] || { echo "$called"; false; }
+}
+
+# The loss pm's advisory describes: a run interrupted after the config flipped
+# leaves rows in BOTH stores, and re-running with the destination gone deletes
+# the shared copy on the strength of the flag alone.
+#
+# Written as "the rows survive". Remove the guard and the shared store is
+# emptied, so this fails by losing data rather than by a changed message.
+@test "migrate: a destination that vanished does not take the shared rows with it" {
+  bash "$SCRIPTS/send.sh" alpha ann bob "one" >/dev/null
+  migrate alpha
+
+  # Re-enter the window the advisory describes: the config says per-team, and
+  # the shared store still holds rows for this team.
+  sqlite3 "$SHARED" "INSERT INTO events(type,id,team,from_agent,to_agent,body,at)
+    VALUES('message_sent','stray-1','alpha','ann','bob','still in shared',
+           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
+  [ "$(shared_rows alpha)" -eq 1 ]
+
+  rm -f "$(store_of alpha)"
+  run migrate alpha
+
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "does not exist" ]]
+  [[ "$output" =~ "NOT been touched" ]]
+  # The point of the test: the rows are still there.
+  [ "$(shared_rows alpha)" -eq 1 ]
+}
+
+@test "migrate: a destination missing some of the shared rows is refused" {
+  bash "$SCRIPTS/send.sh" alpha ann bob "one" >/dev/null
+  migrate alpha
+
+  # A row the destination never received — an interrupted copy, or one the
+  # destination lost. Same count is not the test; this row is simply absent
+  # there.
+  sqlite3 "$SHARED" "INSERT INTO events(type,id,team,from_agent,to_agent,body,at)
+    VALUES('message_sent','never-copied','alpha','ann','bob','missing there',
+           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
+
+  run migrate alpha
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "missing rows" ]]
+  [ "$(shared_rows alpha)" -eq 1 ]
+}
+
+# A destination that exists but cannot be read. Being unable to check is not
+# the same as having checked: if an unreadable store counted as complete, the
+# guard would pass in exactly the situation where it knows least.
+@test "migrate: a destination that cannot be read is refused, not assumed complete" {
+  bash "$SCRIPTS/send.sh" alpha ann bob "one" >/dev/null
+  migrate alpha
+
+  sqlite3 "$SHARED" "INSERT INTO events(type,id,team,from_agent,to_agent,body,at)
+    VALUES('message_sent','stray-1','alpha','ann','bob','still in shared',
+           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
+
+  # Present, non-empty, and not a database.
+  local dest; dest="$(store_of alpha)"
+  printf 'this is not a sqlite file' > "$dest"
+
+  run migrate alpha
+  [ "$status" -ne 0 ]
+  [ "$(shared_rows alpha)" -eq 1 ]
+}
+
+# The normal re-entry this guard must NOT break. After the config flips, new
+# messages land in the destination, so it legitimately holds MORE than the
+# shared store. A guard written as "the counts match" would refuse exactly the
+# case it exists to complete.
+@test "migrate: re-entry completes when the destination has more than the shared store" {
+  bash "$SCRIPTS/send.sh" alpha ann bob "before the move" >/dev/null
+  migrate alpha
+
+  # Arrivals after the move: they go to the destination, as they do in life.
+  bash "$SCRIPTS/send.sh" alpha ann bob "after the move" >/dev/null
+  bash "$SCRIPTS/send.sh" alpha ann bob "also after" >/dev/null
+
+  # And a leftover in the shared store, which is what re-entry is for. Copied
+  # into the destination as an interrupted run would have done.
+  local dest; dest="$(store_of alpha)"
+  sqlite3 "$SHARED" "INSERT INTO events(seq,type,id,team,from_agent,to_agent,body,at)
+    VALUES(9001,'message_sent','leftover','alpha','ann','bob','left behind',
+           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
+  sqlite3 "$dest" "INSERT INTO events(seq,type,id,team,from_agent,to_agent,body,at)
+    VALUES(9001,'message_sent','leftover','alpha','ann','bob','left behind',
+           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
+
+  run migrate alpha
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "already has its own store" ]]
+  # The leftover is gone from shared, because the destination has it.
+  [ "$(shared_rows alpha)" -eq 0 ]
 }


### PR DESCRIPTION
The already-moved branch of `migrate-team-store.sh` trusted the config flag alone. Reaching it means the config says "moved"; it does not mean the store still exists. With the destination removed by hand, the flag survives, the shared rows are deleted, and the run reports success.

Measured on a throwaway store, never on real data:

```
send 2 → migrate → rm $DEST → migrate again
  before: shared_rows = 2
  after:  shared_rows = 0        "already has its own store; shared copy cleared"
```

## What the guard checks

**Containment by key, not a count.** New messages land in the destination from the moment the config flips, so it legitimately holds MORE than the shared store — a rule written as "the counts match" would refuse exactly the interrupted re-entry this branch exists to complete. Equal counts can also be different rows; `seq` and `id` are copied verbatim so they compare directly, and `read_cursors` go by agent.

**An unreadable destination is refused, not assumed complete.** Being unable to check is not the same as having checked, and this is the moment with the least information and the most to lose.

**The merge refusal now says what to do.** The verification failure already did; whoever hits this one first should not have to guess. It carries the caveat that the advice is only safe *before* the team is recorded as moved — afterwards the same step destroys the live store, which is the loss this change prevents.

## Tests

Written as "the rows survive", so removing the guard fails them by losing data rather than by changing a message.

| mutation | result |
|---|---|
| control: a no-op comment edit | GREEN — the harness is honest |
| the guard removed entirely | RED |
| existence checked, contents not | RED |
| containment replaced by a count comparison | RED |
| an unreadable destination treated as complete | RED |

Local: `test_migrate_team_store.bats` 14/14, `test_storage.bats` 24/24.