### PR TITLE
fix(tests): drop the ESRCH marker-gc test's magic-pid collision

### DIFF
--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -230,6 +230,7 @@ while True:
   [ "$(cat "$base.pid")" != "$foreign_pid" ]
 
   kill "$foreign_pid" 2>/dev/null || true
+  wait "$foreign_pid" 2>/dev/null || true
 }
 
 

--- a/tests/test_resolve_project.bats
+++ b/tests/test_resolve_project.bats
@@ -220,10 +220,16 @@ JSON
 
 @test "marker-gc: drops a marker whose pid is ESRCH-dead" {
   skip_on_windows "POSIX kill path; Windows uses tasklist (#134)"
-  agmsg_write_project_marker 4242 "$ROOT"
-  kill() { echo "bash: kill: (4242) - No such process" >&2; return 1; }
+  # A pid that is genuinely gone, so the real ps agrees with the stubbed kill
+  # (same rationale as test_instance_id.bats's gone_pid helper). The magic
+  # number 4242 this used to hardcode is a live process on some CI runners,
+  # which made the ps cross-check in _agmsg_pid_alive_local report the marker
+  # as still owned by a live agent and skip the GC (#595).
+  local gone; gone="$(bash -c 'echo $$')"; wait_for_pid_exit "$gone" || true
+  agmsg_write_project_marker "$gone" "$ROOT"
+  kill() { echo "bash: kill: ($gone) - No such process" >&2; return 1; }
   agmsg_marker_gc_stale
-  [ ! -f "$(agmsg_project_marker_path 4242)" ]
+  [ ! -f "$(agmsg_project_marker_path "$gone")" ]
 }
 
 @test "marker-gc: sourcing resolve-project.sh alone provides the liveness helper" {


### PR DESCRIPTION
## Summary

Addresses part of #595 (bats suite flakes across the process-lifecycle tests). This PR is test-only and changes no production code. Status of each of the five failure signatures reported in #595:

1. `marker-gc: drops a marker whose pid is ESRCH-dead` (test_resolve_project.bats) — fixed here. `kill()` was stubbed to simulate ESRCH but the real `ps -o stat=` fallback in `_agmsg_pid_alive_local` was not, so a live process happening to sit at the hardcoded pid 4242 on the runner made the marker read as still-owned and skip GC. `test_instance_id.bats` already has the correct pattern for this (`gone_pid`: spawn a real process, wait for it to exit, use its genuinely-dead pid) — this test just hadn't been migrated to it. Switched over; forced reproduction confirms the bug (stubbing `ps()` to answer that pid 4242 is alive makes the unpatched test fail deterministically, not just occasionally).
2. `launcher: a re-registered role gets a fresh child after deregistration (#485)` / the same assertion on a different shard — root cause identified (a synchronous `wait` in `codex-bridge-launcher.sh` that only the `AGMSG_CODEX_BRIDGE_CMD` code path takes) but the fix touches production code, not test files, so it is deferred to a separate PR pending a separate decision on that change. Note: `AGMSG_CODEX_BRIDGE_CMD` is not test-only — it is documented as usable for real custom wrapper commands too, so that fix changes behavior for anyone running a custom bridge wrapper, not just this test suite.
3. `codex-monitor` teardown hitting `Directory not empty` on `rm -rf` — investigated, not reproduced. Code-level finding: `codex-monitor.sh` starts its bridge dispatcher with `"$launcher_cmd" ... &` unconditionally, and the dispatcher's pid is never recorded anywhere. The test file's `teardown()` only kills+waits pids listed in `run/codex-app-server.*.pid`, so the dispatcher (bound to the app-server's lifetime, checked on a poll interval up to 2s) can still be running — and touching `$SKILL_DIR/run` and `$SKILL_DIR/db` — for a beat after teardown kills the app-server and proceeds to `rm -rf`. Three different forced-race attempts (holding the dispatcher alive while hammering the exact `rm -rf` sequence teardown runs, roughly 4600 attempts combined) did not reproduce `Directory not empty` locally on macOS. Non-reproduction is not evidence the bug does not exist; it is recorded here as the next starting point. No code change is included for this signature.
4. A separate, independent defect found while investigating (3): `test_codex_monitor.bats`'s "never kills a non-codex process recorded under a reused pid" test starts a background python listener (`foreign_pid`) and kills it at the end of the test without waiting for it to exit. Fixed here (added `wait`). This is not a fix for the `Directory not empty` failures above — `foreign_pid` only writes under `$TEST_PROJECT`, a different directory from `$TEST_SKILL_DIR`, which is what the observed failures' `rm -rf` targets.
5. `watch: relaunch with the SAME instance id replaces the previous watcher (#66 preserved)`, failing at `_wait_pidfile` (PR #436, `test_watch.bats`) — not attempted in this pass.

## What changed

- `tests/test_resolve_project.bats`: the ESRCH marker-gc test now uses a genuinely-dead pid (spawn + wait) instead of a hardcoded magic number.
- `tests/test_codex_monitor.bats`: added the missing `wait` after killing the foreign-process test's background listener.

## A note on distinguishing flake from a real intermittent bug without relying on reruns

What made forcing signatures 1 and 2 possible, and made signature 3's absence of reproduction informative rather than just inconclusive, was the same question each time: can one side of the race be deliberately forced? A real race generally has a code-visible party on at least one side — a fixed sleep/timeout racing another fixed budget, a magic constant the test assumes is absent from the real environment, or a backgrounded process that is killed but never waited on. All three are mechanically greppable. When a hypothesis like that can be forced and the unpatched code fails deterministically under the forced condition, that is stronger evidence than any number of full-suite reruns.

## Validation

`bats tests/test_resolve_project.bats tests/test_codex_monitor.bats tests/test_role_session.bats` — all green, judged by exit code (not by output pattern-matching). Pre-PR checklist run: tests pass, `install.sh` smoke-tested into an isolated temp HOME with a minimal join/whoami round trip, branch rebased onto latest `origin/main`, clean tree.
