### PR TITLE
fix(migrate): a cursor that moved on is not a cursor that went missing

### DIFF
--- a/scripts/internal/migrate-team-store.sh
+++ b/scripts/internal/migrate-team-store.sh
@@ -98,9 +98,21 @@ _missing_from_dest() {
                      EXCEPT
                      SELECT id,team,from_agent,to_agent,body,created_at,read_at
                        FROM dst.$t WHERE team='$lit';" ;;
-      *)        sql="SELECT team,agent,local_position FROM $t WHERE team='$lit'
-                     EXCEPT
-                     SELECT team,agent,local_position FROM dst.$t WHERE team='$lit';" ;;
+      # A cursor is a POSITION, and positions only move forward: the writer
+      # updates them with MAX(local_position, ...). So the destination's cursor
+      # being AHEAD of the shared one is the normal state after the config
+      # flips — reads go to the destination from then on, while the shared copy
+      # stays frozen at the moment of the move.
+      #
+      # Requiring the rows to be identical would refuse re-entry as soon as
+      # anyone reads once, which in a recovery window that stays open for a
+      # while is close to always. What has to be refused is a cursor that has
+      # gone BACKWARDS, or one that is absent: either would resume that agent
+      # earlier than they had already read.
+      *)        sql="SELECT s.agent FROM $t s
+                       LEFT JOIN dst.$t d ON d.team = s.team AND d.agent = s.agent
+                      WHERE s.team='$lit'
+                        AND (d.agent IS NULL OR d.local_position < s.local_position);" ;;
     esac
     # A destination that cannot be read, or lacks the table, makes the query
     # fail — which is reported as "not proven complete", never as "nothing is

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -291,6 +291,53 @@ shared_rows() {
   [ "$(sqlite3 "$SHARED"       "SELECT local_position FROM read_cursors WHERE team='alpha' AND agent='ann';")" -eq 999 ]
 }
 
+# A cursor that moved on after the move. Reads go to the destination once the
+# config flips, so its cursor legitimately runs AHEAD of the shared copy, which
+# stays frozen at the moment of the move. An identity comparison refuses this —
+# and it happens as soon as anyone reads once, which in a recovery window that
+# stays open is close to always.
+@test "migrate: a cursor that advanced in the destination does not block re-entry" {
+  bash "$SCRIPTS/send.sh" alpha ann bob "one" >/dev/null
+  migrate alpha
+  local dest; dest="$(store_of alpha)"
+
+  sqlite3 "$dest"   "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
+    VALUES('alpha','ann',1005);"
+  sqlite3 "$SHARED" "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
+    VALUES('alpha','ann',999);"
+
+  run migrate alpha
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "already has its own store" ]]
+  # The stale shared cursor is cleared; the destination keeps the further one.
+  [ "$(sqlite3 "$SHARED" \
+      "SELECT COUNT(*) FROM read_cursors WHERE team='alpha';")" -eq 0 ]
+  [ "$(sqlite3 "$dest" \
+      "SELECT local_position FROM read_cursors WHERE team='alpha' AND agent='ann';")" -eq 1005 ]
+}
+
+# A cursor the destination never received. Deleting the shared copy would lose
+# where that agent had read to entirely — they would resume from the start and
+# re-read everything, or from zero and appear to have read nothing. Absent is
+# not "far enough along"; it is no information at all.
+@test "migrate: a cursor absent from the destination is refused" {
+  bash "$SCRIPTS/send.sh" alpha ann bob "one" >/dev/null
+  migrate alpha
+  local dest; dest="$(store_of alpha)"
+
+  # Only in the shared store. Nothing else is short, so a refusal is about this.
+  sqlite3 "$dest"   "DELETE FROM read_cursors WHERE team='alpha' AND agent='ann';"
+  sqlite3 "$SHARED" "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
+    VALUES('alpha','ann',42);"
+  [ "$(shared_rows alpha)" -eq 0 ]
+
+  run migrate alpha
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "missing rows" ]]
+  [ "$(sqlite3 "$SHARED" \
+      "SELECT local_position FROM read_cursors WHERE team='alpha' AND agent='ann';")" -eq 42 ]
+}
+
 # The normal re-entry this guard must NOT break. After the config flips, new
 # messages land in the destination, so it legitimately holds MORE than the
 # shared store. A guard written as "the counts match" would refuse exactly the


### PR DESCRIPTION
Follow-up to #604, which merged before this correction was pushed. **The defect is on `integration/remote` now.**

#604 compares cursors as whole rows. That refuses a destination whose cursor is *ahead* of the shared one — and that is the normal state: reads go to the destination once the config flips, so its cursor advances while the shared copy stays frozen at the moment of the move. **One read is enough to block re-entry**, in a recovery window that can stay open for a while.

## What changes

Positions only ever move forward — the writer updates them with `MAX(local_position, ...)` (`scripts/drivers/storage/sqlite.sh:140`, `:205`, checked rather than assumed). So the test is direction, not identity:

| destination cursor | verdict |
|---|---|
| at or beyond the shared one | satisfied |
| behind it | refused — would resume that agent earlier than they had read |
| absent | refused — no information at all, not "far enough along" |

The previous round's intent is kept. Going backwards is still refused; only *standing still* was ever required, and that was the mistake.

## Why it was invisible

The re-entry test in #604 only added `events`. A mutation restoring the identity comparison stayed green until a case moved a cursor forward, and the absent-cursor branch had no test at all until it was mutated separately.

| mutation | result |
|---|---|
| control: a no-op rename | GREEN — the harness is honest |
| a cursor that went backwards is accepted | RED |
| a missing cursor is accepted | RED |
| cursors go back to identity comparison | RED |

Local: `test_migrate_team_store.bats` 19/19, `test_storage.bats` 24/24, on top of the merged `integration/remote`.