### PR TITLE
feat(sync): size a push batch in bytes and split it when the server says 413

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2049,21 +2049,35 @@ async function postGroup(config, group, requestCall, eventCall) {
   } catch (error) {
     if (error?.status !== 413) throw error;
     if (group.length === 1) {
-      // The end of the line, and it must be said plainly: this message cannot
-      // be synced by any batching this client can do, and every later cycle
-      // will pick it up and fail here again. Naming the id and the size is
-      // what makes it actionable — without them the operator sees a sync that
-      // stops making progress and nothing that says which message or how big.
+      // The end of the line, and it must be said plainly: this row cannot be
+      // synced by any batching this client can do, and every later cycle will
+      // pick it up and fail here again.
+      //
+      // Named by `local_id`, which is the id of the row in this machine's own
+      // store — that is the thing an operator can look at or remove. `id` is the
+      // wire reservation this push minted; it identifies nothing locally, so a
+      // failure that quoted only that would say "sync is stuck" without saying
+      // on what. The wire id is still reported, for correlating with the
+      // server's logs, and the axis because a candidate can be a message or a
+      // roster mutation and the two live in different places.
       const candidate = group[0];
       const bytes = wireBytes(candidate) - 1;
-      await eventCall("push.oversized", { wire_id: candidate.id, bytes,
+      const where = {
+        local_id: candidate.local_id ?? null,
+        local_position: candidate.local_position ?? null,
+        sync_axis: candidate.sync_axis ?? null,
+        wire_id: candidate.id,
+      };
+      await eventCall("push.oversized", { ...where, bytes,
         detail: error?.body?.error?.code ?? null });
       const stuck = new Error(
-        `message ${candidate.id} is ${bytes} bytes and the server refuses it on its own ` +
-        "(413); it cannot be pushed by splitting and will block this team's sync until " +
-        "it is removed or the server's limit is raised");
+        `${where.sync_axis ?? "message"} ${where.local_id ?? candidate.id} ` +
+        `(local_position ${where.local_position ?? "unknown"}, wire ${candidate.id}) ` +
+        `is ${bytes} bytes and the server refuses it on its own (413); it cannot be ` +
+        "pushed by splitting and will block this team's sync until it is removed or " +
+        "the server's limit is raised");
       stuck.status = 413;
-      stuck.wire_id = candidate.id;
+      Object.assign(stuck, where);
       throw stuck;
     }
     const middle = Math.ceil(group.length / 2);

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2093,8 +2093,13 @@ async function postGroup(config, group, requestCall, eventCall) {
         sync_axis: candidate.sync_axis ?? null,
         wire_id: candidate.id,
       };
+      // Through errorCode(), like every other reader: the caller may already
+      // have parsed it (error.code), and if not, the body still has to be read
+      // in both shapes. Reading `body.error.code` directly here would leave the
+      // one event this change exists for saying `detail: null` against the
+      // hosted edge — the case the whole bridge was added for.
       await eventCall("push.oversized", { ...where, bytes,
-        detail: error?.body?.error?.code ?? null });
+        detail: error?.code ?? errorCode(error?.body) });
       const stuck = new Error(
         `${where.sync_axis ?? "message"} ${where.local_id ?? candidate.id} ` +
         `(local_position ${where.local_position ?? "unknown"}, wire ${candidate.id}) ` +

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1059,14 +1059,24 @@ async function send(config, path, init, authHeaders) {
 // Checking presence instead is also the stronger rule: an error that DOES carry
 // a binding is verified whatever its status, where the allowlist would have
 // skipped a mismatched 400.
-// The error code, from either shape a server in this position may send.
+// The error code.
 //
-// The reference server nests it — `{ error: { code } }` — and the hosted edge
-// sends `{ error: "payload_too_large" }`, a bare string. Reading only the nested
-// form turned every hosted error into `unknown-error`: a 413 arrived saying
-// nothing about being too large, so an operator watching the log saw sync stop
-// with no reason attached. Found by someone walking a real 9,784-message
-// migration, not by a test.
+// THE PROTOCOL SHAPE IS THE NESTED ONE: `{ error: { code, message, details } }`,
+// built by `errorBody()` in the reference server (server/src/errors.ts) — which
+// is the definition, since server/spec/v1.md is marked SUPERSEDED. That is what
+// a new implementation should emit and what a reader here should take as the
+// contract.
+//
+// The bare-string branch is a BRIDGE, not a second valid shape. The hosted edge
+// currently answers `{ error: "payload_too_large" }`, and reading only the
+// nested form turned every one of its errors into `unknown-error` — a 413 that
+// said nothing about being too large, which is how a real 9,784-message
+// migration ended with a stopped sync and no reason in the log.
+//
+// Accepting both keeps that legible today; it does not make both correct. When
+// the edge emits the nested shape, DELETE the string branch — leaving it is how
+// "two shapes" quietly becomes the contract and a third implementation picks
+// whichever it likes.
 export function errorCode(body) {
   const error = body?.error;
   if (typeof error === "string" && error.length > 0) return error;

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1037,7 +1037,7 @@ async function send(config, path, init, authHeaders) {
   }
   if (!response.ok) {
     validateErrorBinding(config, response.status, body);
-    const code = body?.error?.code ?? "unknown-error";
+    const code = errorCode(body);
     const error = new Error(`HTTP ${response.status} ${code}`);
     error.status = response.status; error.code = code; error.body = body;
     throw error;
@@ -1059,6 +1059,21 @@ async function send(config, path, init, authHeaders) {
 // Checking presence instead is also the stronger rule: an error that DOES carry
 // a binding is verified whatever its status, where the allowlist would have
 // skipped a mismatched 400.
+// The error code, from either shape a server in this position may send.
+//
+// The reference server nests it — `{ error: { code } }` — and the hosted edge
+// sends `{ error: "payload_too_large" }`, a bare string. Reading only the nested
+// form turned every hosted error into `unknown-error`: a 413 arrived saying
+// nothing about being too large, so an operator watching the log saw sync stop
+// with no reason attached. Found by someone walking a real 9,784-message
+// migration, not by a test.
+export function errorCode(body) {
+  const error = body?.error;
+  if (typeof error === "string" && error.length > 0) return error;
+  if (typeof error?.code === "string" && error.code.length > 0) return error.code;
+  return "unknown-error";
+}
+
 export function validateErrorBinding(config, status, body) {
   // An identity claim is server_instance_id or team_id. Those name WHICH server
   // and WHICH team, so a reply carrying either is asserting the binding and gets
@@ -2704,7 +2719,7 @@ async function publicGet(serverUrl, path) {
   }
   const body = await response.json();
   if (!response.ok) {
-    const error = new Error(`HTTP ${response.status} ${body?.error?.code ?? "unknown-error"}`);
+    const error = new Error(`HTTP ${response.status} ${errorCode(body)}`);
     error.status = response.status;
     throw error;
   }

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1996,6 +1996,103 @@ export async function readStateCycle(config, limit, dependencies = {}) {
   }
 }
 
+// How many bytes of message JSON to put in one POST before splitting.
+//
+// Deliberately well under the server's 2 MiB body limit, because the client
+// cannot know that limit: a proxy, a gateway, or a self-hosted deployment may
+// impose a smaller one, and the only number we control is our own. Counting
+// bytes rather than messages is the point — a thousand small messages and a
+// thousand large ones were the same batch before this, and only the second kind
+// was ever refused.
+const PUSH_BYTE_BUDGET = 512 * 1024;
+
+// The wire size of one message, measured the way the body is built rather than
+// estimated from the blob. `+1` covers the comma that joins it to the next.
+function wireBytes(candidate) {
+  return Buffer.byteLength(
+    JSON.stringify({ id: candidate.id, envelope: candidate.envelope }), "utf8") + 1;
+}
+
+// Split on the byte budget, never returning an empty group: a single message
+// over the budget goes out alone and the server decides. Refusing to send it
+// here would be this client inventing a limit the server never stated.
+function byBudget(candidates, budget) {
+  const groups = [];
+  let current = [];
+  let size = 0;
+  for (const candidate of candidates) {
+    const bytes = wireBytes(candidate);
+    if (current.length > 0 && size + bytes > budget) {
+      groups.push(current);
+      current = [];
+      size = 0;
+    }
+    current.push(candidate);
+    size += bytes;
+  }
+  if (current.length > 0) groups.push(current);
+  return groups;
+}
+
+// POST one group, halving on 413 until the server accepts it or one message is
+// left. Overlap is safe: a resent id is a no-op server-side and still returns an
+// ack (`disposition: "duplicate"`) carrying its stored position, so a retry that
+// repeats already-stored messages neither duplicates rows nor loses acks.
+//
+// Bounded by construction: each retry halves a group of at least two, so the
+// recursion depth is log2(group size) and a single message never splits again.
+async function postGroup(config, group, requestCall, eventCall) {
+  try {
+    return await requestCall(config, "/v1/messages", { method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: group.map(({ id, envelope }) => ({ id, envelope })) }) });
+  } catch (error) {
+    if (error?.status !== 413) throw error;
+    if (group.length === 1) {
+      // The end of the line, and it must be said plainly: this message cannot
+      // be synced by any batching this client can do, and every later cycle
+      // will pick it up and fail here again. Naming the id and the size is
+      // what makes it actionable — without them the operator sees a sync that
+      // stops making progress and nothing that says which message or how big.
+      const candidate = group[0];
+      const bytes = wireBytes(candidate) - 1;
+      await eventCall("push.oversized", { wire_id: candidate.id, bytes,
+        detail: error?.body?.error?.code ?? null });
+      const stuck = new Error(
+        `message ${candidate.id} is ${bytes} bytes and the server refuses it on its own ` +
+        "(413); it cannot be pushed by splitting and will block this team's sync until " +
+        "it is removed or the server's limit is raised");
+      stuck.status = 413;
+      stuck.wire_id = candidate.id;
+      throw stuck;
+    }
+    const middle = Math.ceil(group.length / 2);
+    await eventCall("push.split", { count: group.length, halves: [middle, group.length - middle] });
+    const first = await postGroup(config, group.slice(0, middle), requestCall, eventCall);
+    const second = await postGroup(config, group.slice(middle), requestCall, eventCall);
+    // Concatenated in send order, so the combined acks line up with the
+    // candidates the caller passed in — validateAckMapping compares positionally.
+    return { ...second, acks: [...first.acks, ...second.acks] };
+  }
+}
+
+// Send every candidate, in order, as one or more POSTs.
+async function postCandidates(config, candidates, requestCall, eventCall) {
+  const groups = byBudget(candidates, PUSH_BYTE_BUDGET);
+  if (groups.length > 1) {
+    await eventCall("push.batched", { count: candidates.length, batches: groups.length });
+  }
+  let last;
+  const acks = [];
+  for (const group of groups) {
+    last = await postGroup(config, group, requestCall, eventCall);
+    acks.push(...last.acks);
+  }
+  // The last response carries the freshest server state (current_seq, floor);
+  // the acks are every group's, in the order they were sent.
+  return { ...last, acks };
+}
+
 // A single sync cycle: push one page (up to pushLimit) + drain the pull side
 // to exhaustion. pushLimit and pullLimit are decoupled — the pull page is
 // sized generously so a large pull backlog drains in few round-trips, while
@@ -2060,9 +2157,7 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
   if (!writeProfile.eligible) {
     await eventCall("push.blocked", { reason: writeProfile.reason });
   } else if (candidates.length > 0) {
-    const posted = await requestCall(config, "/v1/messages", { method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ messages: candidates.map(({ id, envelope }) => ({ id, envelope })) }) });
+    const posted = await postCandidates(config, candidates, requestCall, eventCall);
     const ackRecords = validateAckMapping(candidates, posted.acks);
     await eventCall("push.ack", { acks: ackRecords.map(({ id, server_seq, disposition }) => ({ id, server_seq, disposition })) });
     const messageAcks = ackRecords.filter((_, index) => candidates[index].sync_axis === "messages");

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2633,8 +2633,11 @@ test("push stops at one message rather than splitting forever, and names it", as
     attempts += 1;
     const error = new Error("HTTP 413 request-too-large");
     error.status = 413;
+    // The HOSTED shape on purpose: a bare string, which is what the edge sends.
+    // If this event read body.error.code directly it would report detail:null
+    // for exactly the deployment the bridge was added for.
     error.body = { protocol_version: 1, server_instance_id: config.server_instance_id,
-      team_id: config.remote_team_id, error: { code: "request-too-large" } };
+      team_id: config.remote_team_id, error: "payload_too_large" };
     throw error;
   });
   harness.eventCall = async (name, payload) => { events.push([name, payload]); };
@@ -2663,6 +2666,7 @@ test("push stops at one message rather than splitting forever, and names it", as
   assert.equal(oversized[1].sync_axis, "messages");
   assert.equal(oversized[1].wire_id, candidates[0].id); // still there, for correlation
   assert.ok(oversized[1].bytes > 4096, "the reported size must be the real wire size");
+  assert.equal(oversized[1].detail, "payload_too_large");
 });
 
 test("an overlapping resend acks every message SENT, duplicates included", async () => {

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2641,13 +2641,26 @@ test("push stops at one message rather than splitting forever, and names it", as
     cycle(config, { pushLimit: 100, pullLimit: 1000 }, harness),
     (error) => {
       assert.match(error.message, /cannot be pushed by splitting/u);
+      // The message a human reads has to carry the local coordinate too.
+      assert.ok(error.message.includes(candidates[0].local_id),
+        `error must name local_id, got: ${error.message}`);
+      assert.equal(error.local_id, candidates[0].local_id);
+      assert.equal(error.local_position, candidates[0].local_position);
       assert.equal(error.wire_id, candidates[0].id);
       return true;
     });
   assert.equal(attempts, 1, "a single message must not be split again");
   const oversized = events.find(([name]) => name === "push.oversized");
   assert.ok(oversized, "no push.oversized event was emitted");
-  assert.equal(oversized[1].wire_id, candidates[0].id);
+  // local_id is the coordinate in THIS machine's store — the row an operator can
+  // look at or delete. The wire id is a reservation this push minted and points
+  // at nothing locally, so reporting only that would say "sync is stuck" without
+  // saying on what. The fixture keeps them different on purpose.
+  assert.notEqual(candidates[0].local_id, candidates[0].id);
+  assert.equal(oversized[1].local_id, candidates[0].local_id);
+  assert.equal(oversized[1].local_position, candidates[0].local_position);
+  assert.equal(oversized[1].sync_axis, "messages");
+  assert.equal(oversized[1].wire_id, candidates[0].id); // still there, for correlation
   assert.ok(oversized[1].bytes > 4096, "the reported size must be the real wire size");
 });
 

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -39,6 +39,7 @@ import {
   validateConfiguredAgeIdentities,
   validateCapabilities,
   validateErrorBinding,
+  errorCode,
   validateMembers,
   validateReadStatePage,
   validateResyncResult,
@@ -2684,4 +2685,18 @@ test("an overlapping resend acks every message SENT, duplicates included", async
     }));
   assert.equal(seen.length, 4);
   assert.equal(seen.filter((ack) => ack.disposition === "duplicate").length, 2);
+});
+
+test("an error code is read from either shape a server sends it in", () => {
+  // The reference server nests it; the hosted edge sends a bare string. Reading
+  // only the nested form turned every hosted error into "unknown-error" — a 413
+  // that said nothing about being too large, which is how a real 9,784-message
+  // migration ended up with a stopped sync and no reason in the log.
+  assert.equal(errorCode({ error: { code: "request-too-large" } }), "request-too-large");
+  assert.equal(errorCode({ error: "payload_too_large" }), "payload_too_large");
+  // Neither shape present, or present but empty: say so rather than inventing one.
+  assert.equal(errorCode({ error: {} }), "unknown-error");
+  assert.equal(errorCode({ error: "" }), "unknown-error");
+  assert.equal(errorCode({}), "unknown-error");
+  assert.equal(errorCode(undefined), "unknown-error");
 });

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2516,3 +2516,159 @@ test("cycle: a batch that fails after prepare re-sends the same candidates and c
   assert.deepEqual(reconcileAcks.map((ack) => ack.id), candidateIds);
   assert.ok(reconcileAcks.every((ack) => ack.disposition === "duplicate"));
 });
+
+// --- push batching: bytes, and the 413 split ------------------------------
+
+// A candidate whose wire size is dominated by `bytes` of blob.
+function bulkyCandidate(index, bytes) {
+  return {
+    type: "sync_push_candidate",
+    local_position: String(index + 1),
+    local_id: `m${index}`,
+    id: `550e8400-e29b-41d4-a716-${String(index + 1).padStart(12, "0")}`,
+    envelope: { v: 1, cipher: "none", key_id: null, blob: "A".repeat(bytes) },
+  };
+}
+
+function pushHarness(candidates, onPost) {
+  const capabilities = {
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, team_name: "demo", min_available_seq: "0",
+    current_seq: "0", next_sequence_boundary: "1", accepted_envelope_versions: [1],
+    write_allowed_ciphers: ["none"], policy_revision: "0", effective_from_seq: "1",
+    max_blob_bytes: "1048576", policy_history: [{ policy_revision: "0",
+      effective_from_seq: "1", accepted_envelope_versions: [1],
+      write_allowed_ciphers: ["none"] }],
+  };
+  return {
+    healthCall: async () => ({ server_instance_id: config.server_instance_id,
+      team_id: config.remote_team_id }),
+    requestCall: async (_config, path, options) => {
+      if (path === "/v1/capabilities") return capabilities;
+      if (path === "/v1/messages") return onPost(JSON.parse(options.body).messages);
+      if (path.startsWith("/v1/messages?after=")) {
+        return { messages: [], next_after: "0", has_more: false };
+      }
+      throw new Error(`unexpected request ${path}`);
+    },
+    driverCall: async (operation) => {
+      if (operation === "prepare") {
+        return [{ type: "sync_state",
+          driver_generation: "018f3f7e-0000-7000-8000-000000000099",
+          transport_cursor: "0" }, ...candidates];
+      }
+      if (operation === "reconcile") return [{ type: "sync_reconcile_result", count: 1 }];
+      if (operation === "apply") return [{ type: "sync_apply_result", transport_cursor: "0" }];
+      throw new Error(`unexpected storage operation ${operation}`);
+    },
+    logApplyCall: async () => {},
+    eventCall: async () => {},
+    readStateCycleCall: async () => {},
+  };
+}
+
+// Sequences come from a counter that keeps advancing across POSTs, the way a
+// real server assigns them. Restarting at 1 per response would make the
+// concatenated acks non-monotonic, and validateAckMapping rejects that — a
+// property of the stub, not of the split, but one that hides the real behaviour
+// if it is wrong.
+function ackAllFrom(counter) {
+  return (messages) => ({
+    protocol_version: 1, server_instance_id: config.server_instance_id,
+    team_id: config.remote_team_id, team_name: "demo", min_available_seq: "0",
+    current_seq: String(counter.value + messages.length), policy_revision: "0",
+    acks: messages.map((message) => ({ id: message.id,
+      server_seq: String(++counter.value), disposition: "stored" })),
+  });
+}
+
+test("push splits a page by BYTES, not by message count", async () => {
+  // The count limit was 1000, so a thousand small messages and a thousand large
+  // ones were the same batch and only the second kind was ever refused. Twelve
+  // messages of 64 KiB is far under any count limit and far over the byte one.
+  const candidates = Array.from({ length: 12 }, (_unused, index) =>
+    bulkyCandidate(index, 64 * 1024));
+  const posts = [];
+  const ack = ackAllFrom({ value: 0 });
+  await cycle(config, { pushLimit: 100, pullLimit: 1000 },
+    pushHarness(candidates, (messages) => { posts.push(messages.length); return ack(messages); }));
+  assert.ok(posts.length > 1, `expected more than one POST, got ${posts.length}`);
+  assert.equal(posts.reduce((sum, n) => sum + n, 0), 12); // every message sent exactly once
+});
+
+test("push halves on 413 and every message still lands, in order", async () => {
+  // The server refuses anything above four at a time. The client does not know
+  // that number and must not need to: it halves until the server accepts.
+  const candidates = Array.from({ length: 8 }, (_unused, index) => bulkyCandidate(index, 64));
+  const accepted = [];
+  const ack = ackAllFrom({ value: 0 });
+  let refusals = 0;
+  await cycle(config, { pushLimit: 100, pullLimit: 1000 },
+    pushHarness(candidates, (messages) => {
+      if (messages.length > 4) {
+        refusals += 1;
+        const error = new Error("HTTP 413 request-too-large");
+        error.status = 413;
+        error.body = { protocol_version: 1, server_instance_id: config.server_instance_id,
+          team_id: config.remote_team_id, error: { code: "request-too-large" } };
+        throw error;
+      }
+      accepted.push(...messages.map((m) => m.id));
+      return ack(messages);
+    }));
+  assert.ok(refusals > 0, "the server never refused, so no split was exercised");
+  assert.deepEqual(accepted, candidates.map((c) => c.id)); // all of them, in send order
+});
+
+test("push stops at one message rather than splitting forever, and names it", async () => {
+  // A single message the server refuses is a permanent dead end: no batching
+  // this client can do will get it across, and every later cycle retries it.
+  // The failure has to say which message and how big, or an operator sees a sync
+  // that stops progressing and nothing that points at the cause.
+  const candidates = [bulkyCandidate(0, 4096)];
+  const events = [];
+  let attempts = 0;
+  const harness = pushHarness(candidates, () => {
+    attempts += 1;
+    const error = new Error("HTTP 413 request-too-large");
+    error.status = 413;
+    error.body = { protocol_version: 1, server_instance_id: config.server_instance_id,
+      team_id: config.remote_team_id, error: { code: "request-too-large" } };
+    throw error;
+  });
+  harness.eventCall = async (name, payload) => { events.push([name, payload]); };
+  await assert.rejects(
+    cycle(config, { pushLimit: 100, pullLimit: 1000 }, harness),
+    (error) => {
+      assert.match(error.message, /cannot be pushed by splitting/u);
+      assert.equal(error.wire_id, candidates[0].id);
+      return true;
+    });
+  assert.equal(attempts, 1, "a single message must not be split again");
+  const oversized = events.find(([name]) => name === "push.oversized");
+  assert.ok(oversized, "no push.oversized event was emitted");
+  assert.equal(oversized[1].wire_id, candidates[0].id);
+  assert.ok(oversized[1].bytes > 4096, "the reported size must be the real wire size");
+});
+
+test("an overlapping resend acks every message SENT, duplicates included", async () => {
+  // The property the split rests on. A retry after a partial success resends
+  // messages the server already has; validateAckMapping compares ack count with
+  // candidate count, so a server that acked only the newly stored ones would
+  // fail the whole push with "incomplete ack mapping". Nothing else in the suite
+  // sends an overlapping batch, so this would break silently.
+  const candidates = Array.from({ length: 4 }, (_unused, index) => bulkyCandidate(index, 64));
+  const alreadyStored = new Set([candidates[0].id, candidates[1].id]);
+  let seen = null;
+  await cycle(config, { pushLimit: 100, pullLimit: 1000 },
+    pushHarness(candidates, (messages) => {
+      seen = messages.map((message) => ({ id: message.id,
+        disposition: alreadyStored.has(message.id) ? "duplicate" : "stored" }));
+      return { protocol_version: 1, server_instance_id: config.server_instance_id,
+        team_id: config.remote_team_id, team_name: "demo", min_available_seq: "0",
+        current_seq: "4", policy_revision: "0",
+        acks: seen.map((ack, index) => ({ ...ack, server_seq: String(index + 1) })) };
+    }));
+  assert.equal(seen.length, 4);
+  assert.equal(seen.filter((ack) => ack.disposition === "duplicate").length, 2);
+});

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2687,13 +2687,13 @@ test("an overlapping resend acks every message SENT, duplicates included", async
   assert.equal(seen.filter((ack) => ack.disposition === "duplicate").length, 2);
 });
 
-test("an error code is read from either shape a server sends it in", () => {
-  // The reference server nests it; the hosted edge sends a bare string. Reading
-  // only the nested form turned every hosted error into "unknown-error" — a 413
-  // that said nothing about being too large, which is how a real 9,784-message
-  // migration ended up with a stopped sync and no reason in the log.
+test("an error code is read from the protocol shape, and from the edge's for now", () => {
+  // The nested form is the protocol. The bare string is a bridge to what the
+  // hosted edge sends today, and this test says so on purpose: when the edge
+  // emits the nested shape, the string case here and the branch it covers both
+  // go away together.
   assert.equal(errorCode({ error: { code: "request-too-large" } }), "request-too-large");
-  assert.equal(errorCode({ error: "payload_too_large" }), "payload_too_large");
+  assert.equal(errorCode({ error: "payload_too_large" }), "payload_too_large"); // bridge
   // Neither shape present, or present but empty: say so rather than inventing one.
   assert.equal(errorCode({ error: {} }), "unknown-error");
   assert.equal(errorCode({ error: "" }), "unknown-error");


### PR DESCRIPTION
## Bytes, not messages

The push page was limited to 1000 messages and nothing counted bytes, so a thousand small messages and a thousand large ones were the same batch. Only the second kind was ever refused, and it was refused as a whole — one oversized page stopped the team's sync with no way through it.

Batches are now cut on a 512 KiB budget of message JSON. Deliberately well under the server's 2 MiB body limit: the client cannot know the real ceiling, because a proxy, a gateway or a self-hosted deployment may impose a smaller one, and the only number we control is our own.

## Splitting on 413

A budget we chose cannot guarantee the server agrees, so a 413 halves the batch and retries until it is accepted. That is the only shape that works without knowing the limit.

Bounded by construction: each retry halves a group of at least two, so the depth is log2(size), and a single message never splits again.

**A single message the server refuses is a permanent dead end.** No batching this client can do will get it across, and every later cycle picks it up and fails on it again. That failure names the message id and its wire size, and emits a `push.oversized` event — otherwise an operator sees sync stop making progress with nothing pointing at the cause.

## Overlap, measured before it was relied on

A split retry resends messages the server may already hold. Two properties had to be true, and both were measured against the reference server and a real Postgres rather than read out of the source:

- **A resent id does not create a second row.** Not just for an identical resend — for the shape a split actually produces: `[0,1]` committed, then `[0,1,2,3]` retried, which added exactly 4 rows with no duplicates.
- **The server acks every message SENT, duplicates included** — 4 sent, 4 acked, `duplicate,duplicate,stored,stored`. This matters because `validateAckMapping` compares ack count against candidate count, so a server that acked only the newly stored ones would fail the whole push with `incomplete ack mapping`.

The second property is now pinned by a test, because nothing else in the suite sends an overlapping batch: if it ever changed, the split would break and CI would say nothing.

## Tests

`tests/remote_sync_engine.test.mjs` 59 passing, `tests/test_remote.bats` 65/65.

Four added: a page splits by bytes where the count limit would not have; a server refusing more than four at a time still receives every message, in order; a single refused message stops instead of splitting forever and is named with its size; an overlapping resend acks every message sent.

Mutation-checked — disabling the byte split fails the first alone, and removing the 413 branch fails the second and third.

One note on the harness, because it briefly looked like a finding: the ack stub first restarted `server_seq` at 1 for each POST, which made the concatenated acks non-monotonic and tripped `validateAckMapping`. That was the stub disagreeing with the real server, not the split — a real server assigns running sequences. Worth recording, since the failure looked exactly like "splitting breaks ack validation".

## Not in this change

`capabilities` does not advertise the server's limit. The halving works without it, and adding it would be an optimisation on top rather than a prerequisite.
