### PR TITLE
fix(liveness): use the local probe for watcher pidfile cleanup

### DIFF
--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -191,7 +191,7 @@ for f in "$RUN_DIR"/watch.*.pid; do
     rm -f "$f"
     continue
   fi
-  _agmsg_pid_alive "$pid" || rm -f "$f"
+  _agmsg_pid_alive_local "$pid" || rm -f "$f"
 done
 
 # Garbage-collect actas exclusivity locks whose owner session_id no longer

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -906,6 +906,67 @@ JSON
   [ ! -f "$TEST_SKILL_DIR/run/watch.empty-pid.pid" ]
 }
 
+# watch.sh records its own $$ into watch.<token>.pid, so the pid recorded there
+# is minted in the MSYS pid space. The stale-pidfile sweep just above this in
+# session-start.sh ("Same defensive pass for stale watcher pidfiles") used to
+# probe it with _agmsg_pid_alive, which under MSYSTEM asks tasklist -- and
+# tasklist has no record of an MSYS-only pid, so a live watcher read as dead
+# and its pidfile got removed, freeing the next session to spawn a duplicate.
+# Routed through _agmsg_pid_alive_local (kill -0) instead. Unlike the "leaves
+# alive watcher pidfiles alone (when bound to a live CC instance)" test below,
+# this one binds NO cc-instance record, so only the sweep itself -- not the
+# separate dead-cc-instance passes above it -- decides the outcome.
+@test "session-start.sh: stale-pidfile sweep keeps a live watcher pidfile tasklist cannot see (#567-style regression)" {
+  skip_on_windows "stubs tasklist to model Git Bash; the real one is authoritative there"
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+  local stubdir="$TEST_SKILL_DIR/stub-bin"
+  mkdir -p "$stubdir"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$stubdir/tasklist"
+  chmod +x "$stubdir/tasklist"
+
+  sleep 30 3>&- &
+  local live_pid=$!
+  echo "$live_pid" > "$TEST_SKILL_DIR/run/watch.sweep-live.pid"
+
+  printf '{"session_id":"x"}' | env MSYSTEM=MINGW64 PATH="$stubdir:$PATH" \
+    bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" >/dev/null
+
+  [ -f "$TEST_SKILL_DIR/run/watch.sweep-live.pid" ]
+
+  kill "$live_pid" 2>/dev/null || true
+  wait "$live_pid" 2>/dev/null || true
+}
+
+# Native-Windows companion of the test above: exercises the real MSYS pid space
+# and the real tasklist.exe instead of a stub, so it proves the fix against the
+# actual environment the bug was found in rather than a model of it. No
+# cc-instance binding here either, for the same isolation reason.
+@test "session-start.sh: stale-pidfile sweep keeps a live watcher pidfile under real Git Bash (#567-style regression, native Windows only)" {
+  skip_unless_windows "exercises the real MSYS pid space and real tasklist"
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  sleep 30 3>&- &
+  local live_pid=$!
+  echo "$live_pid" > "$TEST_SKILL_DIR/run/watch.sweep-live-native.pid"
+
+  printf '{"session_id":"x"}' | bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" >/dev/null
+
+  [ -f "$TEST_SKILL_DIR/run/watch.sweep-live-native.pid" ]
+
+  kill "$live_pid" 2>/dev/null || true
+  wait "$live_pid" 2>/dev/null || true
+}
+
 @test "session-start.sh leaves alive watcher pidfiles alone (when bound to a live CC instance)" {
   mkdir -p "$TEST_SKILL_DIR/teams/myteam"
   cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON


### PR DESCRIPTION
## Summary

Use `_agmsg_pid_alive_local` when `session-start.sh` garbage-collects
`watch.*.pid` files.

This is a one-line follow-up to the PID provenance split introduced around
#567 and completed for the known shell-minted call sites in #582/#584.

## Problem

`watch.sh` writes its own shell PID to the watcher pidfile:

```sh
echo $$ > "$PIDFILE"
```

That value remains a shell-local PID after it has been read back from a file.
Under MSYSTEM, `_agmsg_pid_alive` queries the native Windows process table via
`tasklist`. An MSYS PID is not present in that table, so a live watcher can be
reported as dead.

Most watcher call sites already use `_agmsg_pid_alive_local`, but the defensive
pidfile sweep in `session-start.sh` still uses the generic probe. On a new
session start, that sweep can therefore remove the pidfile of a running watcher.
The watcher itself continues running, but its ownership record is gone, so a
later monitor invocation can start a second watcher for the same session.

## Change

Route that sweep through the local probe:

```diff
-  _agmsg_pid_alive "$pid" || rm -f "$f"
+  _agmsg_pid_alive_local "$pid" || rm -f "$f"
```

No new liveness abstraction is introduced. The change only applies the existing
provenance rule: PIDs produced by `$$` or `$!`, including values later read from
their pidfiles, use `_agmsg_pid_alive_local`; native process PIDs continue to use
the generic helper.

## Test plan

Two regression tests added to `tests/test_delivery.bats`, next to the existing
watcher-pidfile sweep tests:

1. A portable variant (runs on the ubuntu/macOS shards; `skip_on_windows`) that
   spawns a live shell child, records its `$!` in `watch.<token>.pid`, and runs
   `session-start.sh` with `MSYSTEM=MINGW64` and a stubbed `tasklist` that
   returns an empty table — modelling exactly the namespace split: the pid is
   alive in the shell but invisible to the native table. With the generic probe
   the sweep removes the pidfile; with the local probe it is kept.
2. A native Windows companion (`skip_unless_windows`) that exercises the real
   Git Bash pid space and the real `tasklist.exe`, with no stubs.

The important property is that both tests use a PID minted by the test shell
itself, not a mocked probe result — mocking both probes would only test the
call name, not the namespace failure that motivated the fix.

Honest status: the portable variant is expected to run in this repo's PR CI;
the native variant needs a Windows Git Bash runner and was not executed in an
automated harness on our side. The one-line fix itself has been carried in a
downstream Windows working branch since 2026-08-02.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
