### PR TITLE
test(migrate): pin the declared type the cursor comparisons rest on

### DIFF
--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -31,6 +31,43 @@ shared_rows() {
     "SELECT COUNT(*) FROM events WHERE type='message_sent' AND team='$1';" | tr -d '\r'
 }
 
+declared_type() {
+  sqlite3 "$1" \
+    "SELECT type FROM pragma_table_info('$2') WHERE name='$3';" | tr -d '\r'
+}
+
+# The migration decides what to copy by COMPARING ordering columns across two
+# databases — a cursor is missing if the destination is behind, not merely
+# different. Every one of those comparisons assumes the values order
+# numerically, and in sqlite that assumption lives in the column's declared
+# type.
+#
+# What this catches that the behavioural tests do not, measured rather than
+# assumed:
+#
+#   TEXT     both this and the 1005/999 re-entry test go red — text ordering
+#            puts '1005' before '999', so the advance reads as a retreat
+#   NUMERIC  ONLY this goes red. NUMERIC still orders numerically, so every
+#            behavioural test passes while the declared type has changed
+#
+# That second row is the reason this test exists: the premise can drift
+# without any value comparison noticing. It also names the fault directly —
+# "the column type changed" rather than "re-entry was refused".
+#
+# In BOTH databases, because the comparison spans them: a shared store and a
+# destination store that disagreed on the type would compare a number against
+# a string. seq is here because it decides copy order and re-entry.
+@test "migrate: the columns the comparisons order by are declared INTEGER" {
+  bash "$SCRIPTS/send.sh" alpha ann bob "one" >/dev/null
+  migrate alpha
+  local dest; dest="$(store_of alpha)"
+
+  for db in "$SHARED" "$dest"; do
+    [ "$(declared_type "$db" read_cursors local_position)" = "INTEGER" ]
+    [ "$(declared_type "$db" events seq)" = "INTEGER" ]
+  done
+}
+
 @test "migrate: only the named team moves" {
   bash "$SCRIPTS/send.sh" alpha ann bob "alpha-one" >/dev/null
   bash "$SCRIPTS/send.sh" beta  ann bob "beta-one"  >/dev/null
@@ -301,6 +338,12 @@ shared_rows() {
   migrate alpha
   local dest; dest="$(store_of alpha)"
 
+  # 1005 and 999 are chosen: as text, '1005' sorts BEFORE '999', so a
+  # comparison that became textual reads this advance as a retreat and
+  # refuses. Confirmed by mutation — declaring local_position TEXT turns this
+  # test red. It does NOT cover every way the premise can move: a NUMERIC
+  # column still orders numerically and leaves this green, which is what the
+  # pragma test at the top of this file is for.
   sqlite3 "$dest"   "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
     VALUES('alpha','ann',1005);"
   sqlite3 "$SHARED" "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -31,40 +31,72 @@ shared_rows() {
     "SELECT COUNT(*) FROM events WHERE type='message_sent' AND team='$1';" | tr -d '\r'
 }
 
-declared_type() {
-  sqlite3 "$1" \
-    "SELECT type FROM pragma_table_info('$2') WHERE name='$3';" | tr -d '\r'
+row_count() { sqlite3 "$1" "SELECT COUNT(*) FROM $2;" | tr -d '\r'; }
+
+# Storage classes actually present in a column, one per line, deduplicated.
+stored_types() {
+  sqlite3 "$1" "SELECT DISTINCT typeof($3) FROM $2;" | tr -d '\r'
 }
 
 # The migration decides what to copy by COMPARING ordering columns across two
-# databases — a cursor is missing if the destination is behind, not merely
-# different. Every one of those comparisons assumes the values order
-# numerically, and in sqlite that assumption lives in the column's declared
-# type.
+# databases — a cursor is missing if the destination is BEHIND, not merely
+# different. Every one of those comparisons rests on the values comparing
+# numerically.
 #
-# What this catches that the behavioural tests do not, measured rather than
-# assumed:
+# That premise is about the VALUES, not the column's declaration, and the two
+# come apart in both directions (co1, tl ruling):
 #
-#   TEXT     both this and the 1005/999 re-entry test go red — text ordering
-#            puts '1005' before '999', so the advance reads as a retreat
-#   NUMERIC  ONLY this goes red. NUMERIC still orders numerically, so every
-#            behavioural test passes while the declared type has changed
+#   too loose   sqlite's INTEGER affinity does not reject text it cannot
+#               convert, so a column still declared INTEGER can hold a string
+#               and the premise is broken with the declaration intact
+#   too strict  a NUMERIC column still compares 1005 > 999, so the premise
+#               holds while a declared-type check calls it a fault
 #
-# That second row is the reason this test exists: the premise can drift
-# without any value comparison noticing. It also names the fault directly —
-# "the column type changed" rather than "re-entry was refused".
+# So the check is on the storage class of what is actually stored. Text
+# appears here and it goes red; a NUMERIC declaration does not, because
+# nothing the migration relies on has moved.
+#
+# DETECTION, not enforcement: this observes the rows that exist, it does not
+# stop a bad one being written. Enforcing it needs a schema change — a STRICT
+# table, or CHECK(typeof(local_position)='integer') — and a migration to go
+# with it. Whoever wants that starts here.
 #
 # In BOTH databases, because the comparison spans them: a shared store and a
-# destination store that disagreed on the type would compare a number against
-# a string. seq is here because it decides copy order and re-entry.
-@test "migrate: the columns the comparisons order by are declared INTEGER" {
+# destination store that disagreed would compare a number against a string.
+# seq is here because it decides copy order and re-entry.
+@test "migrate: the values the comparisons order by are stored as integers" {
+  # Asserted at the moment each value is actually READ, not all at one moment.
+  # A migration empties the shared store of the team that left, so a single
+  # loop over both stores at the end checks an empty table on one side and
+  # passes vacuously — which is what the first version of this test did, and
+  # what the row counts below now refuse.
   bash "$SCRIPTS/send.sh" alpha ann bob "one" >/dev/null
+
+  # Before the move: the shared store holds the events the copy orders by.
+  [ "$(row_count "$SHARED" events)" -ge 1 ]
+  [ "$(stored_types "$SHARED" events seq)" = "integer" ]
+
   migrate alpha
   local dest; dest="$(store_of alpha)"
 
+  # After it: the destination holds them, and re-entry orders by these.
+  [ "$(row_count "$dest" events)" -ge 1 ]
+  [ "$(stored_types "$dest" events seq)" = "integer" ]
+
+  # The re-entry state for cursors, set up the way the sibling cursor tests
+  # do: the same agent on BOTH sides at different positions. That is the
+  # comparison this exists for — "behind" versus "missing" — and it is the one
+  # moment both stores hold a value for it. Written through the same INSERT
+  # the product uses, so a column that took a text affinity would store '5'
+  # and '7' as text and typeof would say so.
+  sqlite3 "$dest"   "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
+    VALUES('alpha','ann',7);"
+  sqlite3 "$SHARED" "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
+    VALUES('alpha','ann',5);"
+
   for db in "$SHARED" "$dest"; do
-    [ "$(declared_type "$db" read_cursors local_position)" = "INTEGER" ]
-    [ "$(declared_type "$db" events seq)" = "INTEGER" ]
+    [ "$(row_count "$db" read_cursors)" -ge 1 ]
+    [ "$(stored_types "$db" read_cursors local_position)" = "integer" ]
   done
 }
 
@@ -341,9 +373,9 @@ declared_type() {
   # 1005 and 999 are chosen: as text, '1005' sorts BEFORE '999', so a
   # comparison that became textual reads this advance as a retreat and
   # refuses. Confirmed by mutation — declaring local_position TEXT turns this
-  # test red. It does NOT cover every way the premise can move: a NUMERIC
-  # column still orders numerically and leaves this green, which is what the
-  # pragma test at the top of this file is for.
+  # test red. What it cannot see is a text value in a column still declared
+  # INTEGER, which sqlite permits; the typeof() test at the top of this file
+  # is what looks at the stored values themselves.
   sqlite3 "$dest"   "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
     VALUES('alpha','ann',1005);"
   sqlite3 "$SHARED" "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -38,66 +38,41 @@ stored_types() {
   sqlite3 "$1" "SELECT DISTINCT typeof($3) FROM $2;" | tr -d '\r'
 }
 
-# The migration decides what to copy by COMPARING ordering columns across two
-# databases — a cursor is missing if the destination is BEHIND, not merely
-# different. Every one of those comparisons rests on the values comparing
-# numerically.
+# What this test alone protects: the storage class of events.seq.
 #
-# That premise is about the VALUES, not the column's declaration, and the two
-# come apart in both directions (co1, tl ruling):
+# The containment check compares events with all-column EXCEPT. That catches a
+# row whose seq differs — but not a seq that stopped being a number, because
+# if the column took a text affinity BOTH stores store text and the two sides
+# match. A green EXCEPT then means "identical", not "correct", and the shared
+# rows are deleted on the strength of it.
 #
-#   too loose   sqlite's INTEGER affinity does not reject text it cannot
-#               convert, so a column still declared INTEGER can hold a string
-#               and the premise is broken with the declaration intact
-#   too strict  a NUMERIC column still compares 1005 > 999, so the premise
-#               holds while a declared-type check calls it a fault
+# The values here come from send.sh, so this is a statement about the
+# product's own write path, not about a literal this test inserted. That
+# distinction is the whole point (tl ruling): a typeof() check on a value the
+# test wrote proves the test can write an integer.
 #
-# So the check is on the storage class of what is actually stored. Text
-# appears here and it goes red; a NUMERIC declaration does not, because
-# nothing the migration relies on has moved.
+# read_cursors is NOT here. Its ordering premise is already held by the
+# 1005/999 re-entry test below — a text affinity there turns that test red,
+# so a check on this side would be a second copy of the same catch.
 #
 # DETECTION, not enforcement: this observes the rows that exist, it does not
-# stop a bad one being written. Enforcing it needs a schema change — a STRICT
-# table, or CHECK(typeof(local_position)='integer') — and a migration to go
-# with it. Whoever wants that starts here.
-#
-# In BOTH databases, because the comparison spans them: a shared store and a
-# destination store that disagreed would compare a number against a string.
-# seq is here because it decides copy order and re-entry.
-@test "migrate: the values the comparisons order by are stored as integers" {
-  # Asserted at the moment each value is actually READ, not all at one moment.
-  # A migration empties the shared store of the team that left, so a single
-  # loop over both stores at the end checks an empty table on one side and
-  # passes vacuously — which is what the first version of this test did, and
-  # what the row counts below now refuse.
+# stop a bad one being written. Enforcing needs a schema change — a STRICT
+# table, or CHECK(typeof(seq)='integer') — and a migration with it.
+@test "migrate: the seq the containment check compares is stored as an integer" {
+  # Asserted where each value actually lives, not all at one moment: a
+  # migration empties the shared store of the team that left, so checking both
+  # stores at the end reads an empty table on one side and passes vacuously.
+  # That is what the first version of this test did; the row counts refuse it.
   bash "$SCRIPTS/send.sh" alpha ann bob "one" >/dev/null
 
-  # Before the move: the shared store holds the events the copy orders by.
   [ "$(row_count "$SHARED" events)" -ge 1 ]
   [ "$(stored_types "$SHARED" events seq)" = "integer" ]
 
   migrate alpha
   local dest; dest="$(store_of alpha)"
 
-  # After it: the destination holds them, and re-entry orders by these.
   [ "$(row_count "$dest" events)" -ge 1 ]
   [ "$(stored_types "$dest" events seq)" = "integer" ]
-
-  # The re-entry state for cursors, set up the way the sibling cursor tests
-  # do: the same agent on BOTH sides at different positions. That is the
-  # comparison this exists for — "behind" versus "missing" — and it is the one
-  # moment both stores hold a value for it. Written through the same INSERT
-  # the product uses, so a column that took a text affinity would store '5'
-  # and '7' as text and typeof would say so.
-  sqlite3 "$dest"   "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
-    VALUES('alpha','ann',7);"
-  sqlite3 "$SHARED" "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
-    VALUES('alpha','ann',5);"
-
-  for db in "$SHARED" "$dest"; do
-    [ "$(row_count "$db" read_cursors)" -ge 1 ]
-    [ "$(stored_types "$db" read_cursors local_position)" = "integer" ]
-  done
 }
 
 @test "migrate: only the named team moves" {

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -51,9 +51,11 @@ stored_types() {
 # distinction is the whole point (tl ruling): a typeof() check on a value the
 # test wrote proves the test can write an integer.
 #
-# read_cursors is NOT here. Its ordering premise is already held by the
-# 1005/999 re-entry test below — a text affinity there turns that test red,
-# so a check on this side would be a second copy of the same catch.
+# read_cursors is NOT here. A text AFFINITY on that column turns the 1005/999
+# re-entry test below red, so checking for that would be a second copy of an
+# existing catch. Its storage class is looked at by no test in this
+# repository — see the note on that test for why the gap is worse than
+# undetected.
 #
 # DETECTION, not enforcement: this observes the rows that exist, it does not
 # stop a bad one being written. Enforcing needs a schema change — a STRICT
@@ -348,9 +350,19 @@ stored_types() {
   # 1005 and 999 are chosen: as text, '1005' sorts BEFORE '999', so a
   # comparison that became textual reads this advance as a retreat and
   # refuses. Confirmed by mutation — declaring local_position TEXT turns this
-  # test red. What it cannot see is a text value in a column still declared
-  # INTEGER, which sqlite permits; the typeof() test at the top of this file
-  # is what looks at the stored values themselves.
+  # test red.
+  #
+  # What this test guards is that the ORDER is compared numerically. It does
+  # not look at the storage class of local_position, and NO TEST IN THIS
+  # REPOSITORY does — stated plainly because the alternative is a reader
+  # assuming some other test has it.
+  #
+  # The gap is worse than undetected. A text VALUE in a column still declared
+  # INTEGER is something sqlite permits, and it inverts the guard: `'abc' < 5`
+  # is false, so a text cursor in the destination reads as "not behind", the
+  # row is called present, and the shared cursor is deleted. Closing it means
+  # checking the values inside the guard itself — a change to
+  # migrate-team-store.sh, not to this file.
   sqlite3 "$dest"   "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
     VALUES('alpha','ann',1005);"
   sqlite3 "$SHARED" "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)


### PR DESCRIPTION
Follow-up agreed when #607 landed: the migration's cursor comparisons rest on the ordering columns being numeric, and nothing asserted it. A comment said `local_position` was INTEGER, which is not a check.

## What this adds

An assertion through `pragma_table_info`, in both the shared store and a per-team destination — the comparison spans them, and two stores that disagreed on the type would compare a number against a string. `events.seq` is covered for the same reason: it decides copy order and re-entry.

## What it catches, measured rather than argued

| mutation | result |
| --- | --- |
| `local_position TEXT` | this test **and** the existing 1005/999 re-entry test go red — text ordering puts `'1005'` before `'999'`, so an advance reads as a retreat |
| `local_position NUMERIC` | **only this test** goes red. NUMERIC still orders numerically, so every behavioural test stays green while the declared type has changed |

The second row is why it earns its place: the premise can drift without any value comparison noticing. It also names the fault directly — "the column type changed" rather than "re-entry was refused".

## Correction to an existing comment

The re-entry test's comment claimed the chosen values were "what keeps that true rather than assumed". They are not — they detect one way of breaking it. The comment now says what it covers and what it does not, and points at the pragma test for the rest.

## Verification

`bats tests/test_migrate_team_store.bats` — 20/20 pass. Both mutations above were run and reverted; the schema file is unchanged in this branch.