### PR TITLE
fix(tests): exercise the launcher's default bridge path, not the custom-wrapper one

### DIFF
--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -51,7 +51,34 @@ EOF
   export LAUNCHER="$SCRIPTS/drivers/types/codex/codex-bridge-launcher.sh"
 }
 
-teardown() { teardown_test_env; }
+# PIDs of live per-role child launchers for this test's project (same match as
+# count_child_launchers below: LAUNCHER + PROJ + "alice" in the cmdline, one
+# line per pid). Unlike count_child_launchers, this does not dedupe transient
+# command-substitution subshells by parent pid -- for killing that distinction
+# does not matter, signaling and waiting on a subshell that has already
+# exited on its own is a harmless no-op.
+_launcher_child_pids() {
+  ps -Ao pid=,args= 2>/dev/null \
+    | grep -F "$LAUNCHER" | grep -F "$PROJ" | grep alice \
+    | awk '{print $1}'
+}
+
+# A test's own kill/wait sequence reaches the dispatcher and the short-lived
+# parent it was handed, but a per-role child (nohup'd, independent of both) and
+# the bridge process it launched are not direct children of anything a test
+# holds a pid for, so they are not swept by "kill $dispatcher; kill $parent"
+# alone -- the child only self-exits once it next notices its parent is gone.
+# Reap here, and WAIT for the reap rather than just signaling and moving on, so
+# teardown_test_env's rm -rf never races a process still touching this test's
+# $TEST_SKILL_DIR (#595/#615).
+teardown() {
+  local pid
+  for pid in $(_launcher_child_pids); do
+    kill "$pid" 2>/dev/null || true
+    wait_for_pid_exit "$pid" || true
+  done
+  teardown_test_env
+}
 
 # Write a role-session record (team, agent) -> thread for a project.
 put_record() {

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -3,8 +3,21 @@
 # Unit tests for codex-bridge-launcher.sh thread resolution (#350).
 # The launcher must bind the bridge to the role's RECORDED codex thread instead
 # of the app-server's ambiguous "loaded" thread (which a co-resident codex thread
-# in the same cwd could otherwise capture). A mock bridge (AGMSG_CODEX_BRIDGE_CMD)
-# records the --thread the launcher passes.
+# in the same cwd could otherwise capture). A mock bridge records the --thread
+# the launcher passes.
+#
+# The mock replaces codex-bridge.js itself (the file the launcher's DEFAULT
+# bridge_run resolves to) rather than being swapped in via AGMSG_CODEX_BRIDGE_CMD
+# (#595). AGMSG_CODEX_BRIDGE_CMD is a real, documented user-facing override (a
+# custom bridge wrapper), and codex-bridge-launcher.sh takes a materially
+# different code path for it (a synchronous wait on the launched process) than
+# for its default codex-bridge.js path -- exercising that override path here
+# tested a branch these tests have no interest in and does not run for anyone
+# using agmsg without a custom wrapper, and its wait, sized for a real bridge
+# process's lifetime, raced these tests' shorter deregistration-response
+# assertions. Only tests/ files change here: setup_test_env already copies the
+# whole scripts/ tree into an isolated $TEST_SKILL_DIR per test, so overwriting
+# codex-bridge.js below mutates only that disposable copy.
 
 load test_helper
 
@@ -16,15 +29,19 @@ setup() {
   bash "$SCRIPTS/join.sh" team alice codex "$PROJ" >/dev/null
 
   export CAPTURE="$TEST_SKILL_DIR/thread-capture.txt"
-  export MOCK="$TEST_SKILL_DIR/mock-bridge.sh"
-  cat > "$MOCK" <<EOF
+  # Overwrite the (already-isolated, per-test) copy of codex-bridge.js with a
+  # mock that records its argv. AGMSG_NODE is the documented override for the
+  # Node binary codex-bridge-launcher.sh resolves this file through; pointing
+  # it at bash makes bash the interpreter for this file regardless of its .js
+  # name, so the launcher's default (no-custom-wrapper) path runs unmodified.
+  cat > "$SCRIPTS/drivers/types/codex/codex-bridge.js" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$CAPTURE"
 [ -z "\${MOCK_BRIDGE_SLEEP:-}" ] || sleep "\$MOCK_BRIDGE_SLEEP"
 exit 0
 EOF
-  chmod +x "$MOCK"
-  export AGMSG_CODEX_BRIDGE_CMD="$MOCK"
+  chmod +x "$SCRIPTS/drivers/types/codex/codex-bridge.js"
+  export AGMSG_NODE="$(command -v bash)"
   export LAUNCHER="$SCRIPTS/drivers/types/codex/codex-bridge-launcher.sh"
 }
 

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -29,6 +29,12 @@ setup() {
   bash "$SCRIPTS/join.sh" team alice codex "$PROJ" >/dev/null
 
   export CAPTURE="$TEST_SKILL_DIR/thread-capture.txt"
+  # A leaked AGMSG_CODEX_BRIDGE_CMD from the ambient environment (not this
+  # file, which no longer sets it) would silently put the launcher back on the
+  # override code path this suite is no longer testing -- unset it explicitly
+  # rather than relying on it merely being absent here (#595).
+  unset AGMSG_CODEX_BRIDGE_CMD
+  [ -z "${AGMSG_CODEX_BRIDGE_CMD:-}" ]
   # Overwrite the (already-isolated, per-test) copy of codex-bridge.js with a
   # mock that records its argv. AGMSG_NODE is the documented override for the
   # Node binary codex-bridge-launcher.sh resolves this file through; pointing

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -51,30 +51,52 @@ EOF
   export LAUNCHER="$SCRIPTS/drivers/types/codex/codex-bridge-launcher.sh"
 }
 
-# PIDs of live per-role child launchers for this test's project (same match as
-# count_child_launchers below: LAUNCHER + PROJ + "alice" in the cmdline, one
-# line per pid). Unlike count_child_launchers, this does not dedupe transient
+# PIDs of live per-role child launchers for this test's project: any process
+# whose argv contains both LAUNCHER and PROJ, one line per pid. Not scoped to a
+# single role name -- teardown must reap every role's child a test spawned
+# (e.g. "the identity cache still sees a role added mid-loop" joins a second
+# role, "bob", mid-test), unlike count_child_launchers below, which measures
+# one specific role on purpose. This also does not dedupe transient
 # command-substitution subshells by parent pid -- for killing that distinction
 # does not matter, signaling and waiting on a subshell that has already
 # exited on its own is a harmless no-op.
 _launcher_child_pids() {
-  ps -Ao pid=,args= 2>/dev/null \
-    | grep -F "$LAUNCHER" | grep -F "$PROJ" | grep alice \
-    | awk '{print $1}'
+  ps -Ao pid=,args= 2>/dev/null | grep -F "$LAUNCHER" | grep -F "$PROJ" | awk '{print $1}'
+}
+
+# PIDs of bridge processes this test's launchers started. The bridge itself
+# runs as "bash codex-bridge.js ..." -- its argv never contains LAUNCHER, so
+# _launcher_child_pids cannot see it, and a child launcher's EXIT trap only
+# releases its runtime lock; it does not kill a bridge it already nohup'd. Read
+# from pidfiles instead, which live under this test's own $RUN_DIR ($TEST_
+# SKILL_DIR is unique per test), so this cannot reach another test's process.
+_launcher_bridge_pids() {
+  local f
+  for f in "$RUN_DIR"/codex-bridge.*.pid; do
+    [ -f "$f" ] || continue
+    cat "$f" 2>/dev/null
+  done
 }
 
 # A test's own kill/wait sequence reaches the dispatcher and the short-lived
 # parent it was handed, but a per-role child (nohup'd, independent of both) and
 # the bridge process it launched are not direct children of anything a test
 # holds a pid for, so they are not swept by "kill $dispatcher; kill $parent"
-# alone -- the child only self-exits once it next notices its parent is gone.
-# Reap here, and WAIT for the reap rather than just signaling and moving on, so
-# teardown_test_env's rm -rf never races a process still touching this test's
+# alone -- the child only self-exits once it next notices its parent is gone,
+# and never kills its own bridge except when it does so as part of noticing
+# deregistration. Snapshot the pid set once, signal all of it, then wait for
+# all of it, rather than interleaving kill/wait per pid against a ps/pidfile
+# view that can keep changing underneath. Reaping here, and WAITING for the
+# reap rather than just signaling and moving on, is what keeps
+# teardown_test_env's rm -rf from racing a process still touching this test's
 # $TEST_SKILL_DIR (#595/#615).
 teardown() {
-  local pid
-  for pid in $(_launcher_child_pids); do
+  local pid pids
+  pids="$(_launcher_child_pids; _launcher_bridge_pids)"
+  for pid in $pids; do
     kill "$pid" 2>/dev/null || true
+  done
+  for pid in $pids; do
     wait_for_pid_exit "$pid" || true
   done
   teardown_test_env


### PR DESCRIPTION
## Summary

Addresses part of #595 (bats suite flakes across the process-lifecycle tests). This PR is test-only and changes no production code. Remaining signatures not addressed here: the `codex-monitor` teardown `Directory not empty` failures (investigated in #606, not reproduced), the fifth signature from the original issue (PR #436, `_wait_pidfile`), and three additional samples now concentrated in `test_watch.bats` that a separate line is tracking.

## What was wrong

`codex-bridge-launcher.sh`'s per-role child takes a synchronous `wait` on its launched bridge process, but only when `AGMSG_CODEX_BRIDGE_CMD` is set. That variable is a real, documented override for a user-supplied custom bridge wrapper, not a test-only hook. These tests swapped their mock bridge in through that variable, so they only ever exercised the wrapper's wait-then-continue code path — sized for a real, long-lived bridge process — and never the default path every user without a custom wrapper actually runs. The mock's fixed sleep then raced these tests' much shorter deregistration-response assertions, producing an intermittent failure depending on exactly when deregistration landed relative to the wait.

## What changed

`tests/test_codex_bridge_launcher.bats`'s `setup()`: instead of pointing `AGMSG_CODEX_BRIDGE_CMD` at a separate mock script, it now points `AGMSG_NODE` (the documented Node-binary override) at `bash` and overwrites the disposable per-test copy of `codex-bridge.js` itself with the mock content. `setup_test_env` already copies the whole `scripts/` tree into an isolated `$TEST_SKILL_DIR` per test, so this mutates only that throwaway copy; the checked-in `codex-bridge.js` is untouched. The launcher's default `bridge_run` path (no custom wrapper) now runs unmodified, which is the same code path every real user without a custom wrapper takes.

## Evidence the wait is no longer reached (not just faster)

Bumping the test's `MOCK_BRIDGE_SLEEP` far past its original value and observing wall-clock time, rather than relying on a single green run:

| MOCK_BRIDGE_SLEEP | result | wall time |
|---|---|---|
| 12 (shipped value) | ok | normal |
| 300 (25x) | ok | 3.653s |
| 999999 (~11.5 days) | ok | 4.159s |

If the launcher still reached the synchronous `wait`, runtime would scale with `MOCK_BRIDGE_SLEEP`. It does not — the ~11.5-day value completes in about the same time as the shipped one, which is direct evidence the wait branch is structurally unreached with this setup, not evidence that it merely finishes fast enough this time.

## Validation

`bats tests/test_codex_bridge_launcher.bats` — 16/16 ok, exit 0, run multiple times including immediately after each of the three `MOCK_BRIDGE_SLEEP` values above (each reverted before the final commit). Pre-PR checklist: touched suite green, `install.sh` smoke-tested into an isolated temp HOME with a join/whoami round trip, branch rebased onto latest `main`, clean tree, minimal diff (one file, tests-only).


## Update: an independent teardown gap found while investigating a CI failure on this PR

A `bats (macos-latest 2/4)` run on this branch failed with `Directory not empty` on `tests/test_codex_bridge_launcher.bats`'s own `teardown()`, on the exact test this PR touches. Rather than treating that as unrelated and rerunning, this was investigated directly.

Finding: a test's own end-of-test `kill "$dispatcher"; kill "$parent"` sequence never reaches the per-role child (a separate, `nohup`'d process the dispatcher starts) or the bridge process that child launches. The child only exits once it next notices its parent is gone, which is not instantaneous, so it (and the bridge it started) can still be touching the test's `$TEST_SKILL_DIR` when `teardown_test_env`'s `rm -rf` runs afterward.

This predates and is independent of this PR's earlier commits: the same forced reproduction (spawn, deregister, re-register, then run the test's own kill/wait sequence and check what's still alive) shows one leftover process with both the old `AGMSG_CODEX_BRIDGE_CMD`-based mock and the current default-path one.

Fix: `teardown()` now finds and kills any surviving launcher-family process for this test's project, waiting for each to actually exit, before calling `teardown_test_env`. Verified directly: before this change, one process is reliably still alive right after the test's own cleanup; after it, zero, and the same `rm -rf` that failed now succeeds.
