### PR TITLE
fix(migrate): a cursor that is not a number is not proof of containment

### DIFF
--- a/scripts/internal/migrate-team-store.sh
+++ b/scripts/internal/migrate-team-store.sh
@@ -109,10 +109,28 @@ _missing_from_dest() {
       # while is close to always. What has to be refused is a cursor that has
       # gone BACKWARDS, or one that is absent: either would resume that agent
       # earlier than they had already read.
+      # A position that is not stored as an integer counts as MISSING, not as
+      # a position to compare. sqlite orders integers before text, so
+      # `'abc' < 5` is false: a text cursor in the destination would answer
+      # "not behind" to the very comparison meant to catch being behind, this
+      # check would report nothing, and the shared cursor — the agent's real
+      # read position — would be deleted on the strength of it.
+      #
+      # Both sides are checked. The contract here is that the destination is
+      # deleted only once containment has been PROVEN, and a comparison whose
+      # operands are not numbers has proven nothing, whichever side is wrong.
+      #
+      # Not CAST. `CAST('abc' AS INTEGER)` is 0, which reads as a position at
+      # the very beginning and would be quietly accepted as "behind" — a
+      # damaged value painted over as a normal comparison. Refusing keeps the
+      # data and asks a person to look.
       *)        sql="SELECT s.agent FROM $t s
                        LEFT JOIN dst.$t d ON d.team = s.team AND d.agent = s.agent
                       WHERE s.team='$lit'
-                        AND (d.agent IS NULL OR d.local_position < s.local_position);" ;;
+                        AND (d.agent IS NULL
+                             OR typeof(d.local_position) <> 'integer'
+                             OR typeof(s.local_position) <> 'integer'
+                             OR d.local_position < s.local_position);" ;;
     esac
     # A destination that cannot be read, or lacks the table, makes the query
     # fail — which is reported as "not proven complete", never as "nothing is

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -338,6 +338,49 @@ shared_rows() {
       "SELECT local_position FROM read_cursors WHERE team='alpha' AND agent='ann';")" -eq 42 ]
 }
 
+# A cursor that is not a number cannot be compared, so it is not proof.
+#
+# This is the case the ordering guard is blind to on its own: sqlite orders
+# integers before text, so `'abc' < 5` is FALSE. A text cursor in the
+# destination answers "not behind" to the very comparison meant to catch being
+# behind — the check reports nothing missing, and the shared cursor is deleted
+# with the rest of the team's rows. The agent resumes from wherever the
+# damaged value puts them, and their real read position is gone.
+#
+# Written as "the shared cursor survives", because survival is the point. A
+# guard that refused but deleted anyway would pass a message-only assertion.
+#
+# How a non-integer gets into the column is NOT established. sqlite permits it
+# in a column declared INTEGER, and this is a defence against an entry point
+# that has not been found, not a fix for a reproduced one.
+@test "migrate: a cursor that is not an integer is refused, and the shared copy survives" {
+  bash "$SCRIPTS/send.sh" alpha ann bob "one" >/dev/null
+  migrate alpha
+  local dest; dest="$(store_of alpha)"
+
+  # The destination is genuinely AHEAD in every honest reading — 'abc' is not
+  # a position at all. Under the old comparison this row answered "not
+  # behind", so nothing was reported and the shared row was deleted.
+  sqlite3 "$dest"   "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
+    VALUES('alpha','ann','abc');"
+  sqlite3 "$SHARED" "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
+    VALUES('alpha','ann',42);"
+  # The premise this test rests on, measured rather than assumed: the column
+  # is declared INTEGER and sqlite stored text in it anyway.
+  [ "$(sqlite3 "$dest" "SELECT typeof(local_position) FROM read_cursors
+        WHERE team='alpha' AND agent='ann';")" = "text" ]
+
+  # Nothing else is short, so a refusal here is about the cursor.
+  [ "$(shared_rows alpha)" -eq 0 ]
+
+  run migrate alpha
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "missing rows" ]]
+  # The whole point: the position the agent had actually reached is still here.
+  [ "$(sqlite3 "$SHARED" \
+      "SELECT local_position FROM read_cursors WHERE team='alpha' AND agent='ann';")" -eq 42 ]
+}
+
 # The normal re-entry this guard must NOT break. After the config flips, new
 # messages land in the destination, so it legitimately holds MORE than the
 # shared store. A guard written as "the counts match" would refuse exactly the


### PR DESCRIPTION
Found while narrowing #614. Separate PR because #614 is tests only and this is a product fix (tl ruling).

## The defect

The re-entry guard deletes the shared store's rows once it has proven the destination holds them. For cursors it proves that by comparing positions — `d.local_position < s.local_position` means the destination is behind, so the shared copy must stay.

sqlite orders integers before text, so `'abc' < 5` is **false**. A cursor that is not a number answers "not behind" to the comparison meant to catch being behind.

Measured with the guard as it was — destination cursor `'abc'`, shared cursor `42`:

```
migrate exit status: 0
shared cursor rows remaining: 0
```

The migration reported success and deleted the agent's real read position. The guard was silent in exactly the case it exists for.

With the fix:

```
migrate exit status: 1
shared cursor rows remaining: 1, value 42
```

## Not CAST

`CAST('abc' AS INTEGER)` is `0`, which reads as a position at the very beginning and would be quietly accepted as "behind" — a damaged value painted over as a normal comparison. A position that cannot be compared is counted as MISSING instead, on both sides, because the contract is to delete only once containment is PROVEN, and a comparison whose operands are not numbers has proven nothing.

## What is NOT established

**How a non-integer reaches that column has not been found.** sqlite permits one in a column declared INTEGER, and no entry point has been identified. This is a defence against an unknown entry point, not a fix for a reproduced path — stated plainly rather than implied.

It is worth it on cost alone: one condition, against the permanent loss of where an agent had read to.

## The regression

Written as "the shared cursor survives", not as the refusal message. Survival is the point — a guard that refused but deleted anyway would pass a message-only assertion. The test also asserts its own premise (`typeof` is `text` in a column declared INTEGER) so it cannot pass on a setup that failed to create the condition.

Reverting the condition turns it red, and the loss above is what it reports.

## Verification

`bats tests/test_migrate_team_store.bats` — 20/20, control green before mutating.