### PR TITLE
docs(remote): a second machine is a separate install, not three env vars

### DIFF
--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -175,6 +175,28 @@ That install's commands are under `~/.agents/skills/agmsg-test/scripts/`.
 For the single-machine, two-install rehearsal, see
 [Try it on one machine](design/remote-sync.md#try-it-on-one-machine).
 
+**Separate the install, not just the environment.** It is tempting to fake a
+second machine with `AGMSG_SYNC_CONNECTION_DIR`, `AGMSG_STORAGE_PATH` and
+friends, pointed at one install. That separates less than it looks like it
+does, and the part it misses fails quietly:
+
+- `remote.sh`, `remote-sync.sh`, `key.sh` and `internal/migrate-team-store.sh`
+  read `AGMSG_SYNC_CONNECTION_DIR`. Connection state does move.
+- `send.sh`, `history.sh`, `team.sh` and `inbox.sh` do not. They resolve the
+  team config from the install directory — `team.sh` reads
+  `$SCRIPT_DIR/../teams/$TEAM/config.json` — so both "machines" share it.
+
+The result is a second machine that writes into its own store and can read its
+own history, while the config the sync engine works from belongs to the first
+one. Symptoms seen: `team.sh` answering `Team not found`, the roster driver
+failing on a path under the first install, and a sync engine reporting
+`push.prepared count:0` forever while local sends land in the local store.
+
+A real second machine is a separate install, so test one that way: run
+`install.sh --cmd agmsg-test` (or copy the checkout) and give each machine its
+own directory. #610 fixed one instance of this — the roster driver was not
+handed its file — but it was one instance, not the class.
+
 ### Back up before connecting
 
 If you want a rollback copy, do this before step 2:

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -180,8 +180,9 @@ second machine with `AGMSG_SYNC_CONNECTION_DIR`, `AGMSG_STORAGE_PATH` and
 friends, pointed at one install. That separates less than it looks like it
 does, and the part it misses fails quietly:
 
-- `remote.sh`, `remote-sync.sh`, `key.sh` and `internal/migrate-team-store.sh`
-  read `AGMSG_SYNC_CONNECTION_DIR`. Connection state does move.
+- Five files under `scripts/` read `AGMSG_SYNC_CONNECTION_DIR`: `remote.sh`,
+  `remote-sync.sh`, `key.sh`, `internal/migrate-team-store.sh` and
+  `internal/remote-sync.mjs`. Connection state does move.
 - `send.sh`, `history.sh`, `team.sh` and `inbox.sh` do not. They resolve the
   team config from the install directory — `team.sh` reads
   `$SCRIPT_DIR/../teams/$TEAM/config.json` — so both "machines" share it.


### PR DESCRIPTION
Recorded at pm's direction after two people lost time to it today, in sequence: the first hit it and switched to separate installs without writing it down, the second lost an hour to the same wall.

## What is easy to get wrong

Faking a second machine with `AGMSG_SYNC_CONNECTION_DIR` and `AGMSG_STORAGE_PATH` against a single install separates less than it appears to, and the part it misses fails quietly.

| reads the connection dir | does not |
| --- | --- |
| `remote.sh`, `remote-sync.sh`, `key.sh`, `internal/migrate-team-store.sh` | `send.sh`, `history.sh`, `team.sh`, `inbox.sh` |

The second group resolves the team config from the install directory (`team.sh`: `CONFIG="$SCRIPT_DIR/../teams/$TEAM/config.json"`), so both "machines" share it.

The result is a second machine that writes into its own store and reads its own history, while the config its sync engine works from belongs to the first one.

## Observed symptoms

- `team.sh` answering `Team not found` for a team that was just pulled
- the roster driver failing on a path under the *first* install
- a sync engine reporting `push.prepared count:0` indefinitely, while local sends do land in the local store

That last one is the expensive symptom: everything looks healthy from the client side.

## Why this is documentation and not a fix

A real second machine **is** a separate install. Env-var separation is a testing convenience, not a user path, and there is no plan to tell people they can make a second machine with three environment variables — so supporting it is not a requirement (pm ruling). #610 fixed one instance of the class (the roster driver was not handed its file); the class remains, by decision.

Placed in `### Use a separate install for testing`, which is the section someone setting up a test machine already reads.