### PR TITLE
subscription: two facts for a #605 exclusion, no verdict

### DIFF
--- a/scripts/lib/subscription.sh
+++ b/scripts/lib/subscription.sh
@@ -6,7 +6,72 @@
 
 : "${SKILL_DIR:?subscription.sh requires SKILL_DIR}"
 
+# compat_file_mtime, for the diagnostic below.
+# shellcheck disable=SC1091
+. "$SKILL_DIR/scripts/lib/compat.sh"
+
 agmsg_sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+# Diagnose why (team, agent)'s lock reads as owned by `owner` and not by us —
+# printed only when an exclusion empties the whole subscription (#605), never
+# on every skip, so a normal multi-pair session with one busy pair stays
+# quiet. Read-only: makes no decision, changes no behavior, mirrors the same
+# branches agmsg_instance_alive (instance-id.sh) already took to reach its
+# verdict, so a stale/misjudged lock can be told apart from a genuinely live
+# one without reproducing the failure by hand.
+_agmsg_subscription_skip_diag() {
+  local team="$1" agent="$2" owner="$3"
+  local lock_path mtime
+  lock_path="$(actas_lock_path "$team" "$agent")"
+  mtime="$(compat_file_mtime "$lock_path" 2>/dev/null || true)"
+  [ -n "$mtime" ] || mtime="unknown"
+  echo "agmsg watch:   lock file: $lock_path (mtime=$mtime)" >&2
+
+  if agmsg_instance_is_composite "$owner"; then
+    local pid cc_file cc_content cc_state
+    pid="${owner##*.}"
+    echo "agmsg watch:   owner token: composite (pid=$pid)" >&2
+    if _agmsg_pid_alive "$pid" 2>/dev/null; then
+      cc_file="$SKILL_DIR/run/cc-instance.$pid"
+      if [ -f "$cc_file" ]; then
+        cc_content="$(cat "$cc_file" 2>/dev/null || true)"
+        if [ "$cc_content" = "$owner" ]; then
+          cc_state="present, contents match — verdict: alive (confirmed)"
+        else
+          cc_state="present, contents differ ('$cc_content') — verdict: not alive"
+        fi
+      else
+        cc_state="absent — verdict: alive (unconfirmed; no cc-instance record to cross-check the pid against)"
+      fi
+      echo "agmsg watch:   liveness: pid $pid answers alive; cc-instance.$pid $cc_state" >&2
+    else
+      echo "agmsg watch:   liveness: pid $pid does not answer alive — verdict: not alive (re-read a moment after the exclusion decision; a race with the original check is possible but narrow)" >&2
+    fi
+    return 0
+  fi
+
+  echo "agmsg watch:   owner token: bare (no pid embedded)" >&2
+  local run="$SKILL_DIR/run" f p s matched=""
+  if [ -d "$run" ]; then
+    for f in "$run"/cc-instance.*; do
+      [ -f "$f" ] || continue
+      p=${f##*.}
+      case "$p" in ''|*[!0-9]*) continue ;; esac
+      _agmsg_pid_alive "$p" 2>/dev/null || continue
+      s="$(cat "$f" 2>/dev/null || true)"
+      if [ "$s" = "$owner" ] \
+        || { agmsg_instance_is_composite "$s" && [ "${s%.*}" = "$owner" ]; }; then
+        matched="$f"
+        break
+      fi
+    done
+  fi
+  if [ -n "$matched" ]; then
+    echo "agmsg watch:   liveness: matched $matched — verdict: alive" >&2
+  else
+    echo "agmsg watch:   liveness: no live cc-instance.* file matches — verdict: not alive (re-read a moment after the exclusion decision; a race with the original check is possible but narrow)" >&2
+  fi
+}
 
 # Resolve the (team, agent) rows this process should receive for.
 #
@@ -20,7 +85,7 @@ agmsg_sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
 agmsg_subscription_pairs() {
   local project="$1" type="$2" owner_id="$3" active_name="${4:-}" claim_mode="${5:-}"
   local scripts_dir="$SKILL_DIR/scripts"
-  local pairs filtered skipped held state result
+  local pairs filtered skipped skipped_pairs held state result
 
   pairs="$("$scripts_dir/identities.sh" "$project" "$type")"
   if [ -n "$active_name" ]; then
@@ -31,6 +96,7 @@ agmsg_subscription_pairs() {
 
   filtered=""
   skipped=""
+  skipped_pairs=""
   held=""
   local team agent
   while IFS=$'\t' read -r team agent; do
@@ -42,6 +108,7 @@ agmsg_subscription_pairs() {
           held="${held:+$held }${team}/${agent}(${state#other:})"
         else
           skipped="${skipped:+$skipped }${team}/${agent}(${state#other:})"
+          skipped_pairs="${skipped_pairs:+$skipped_pairs$'\n'}${team}"$'\t'"${agent}"$'\t'"${state#other:}"
         fi
         continue
         ;;
@@ -62,6 +129,15 @@ agmsg_subscription_pairs() {
 
   if [ -n "$skipped" ]; then
     echo "agmsg watch: skipping pairs held by other sessions: $skipped" >&2
+    # Diagnostic detail only when the exclusion left nothing to subscribe to
+    # (#605) -- a busy pair alongside others that still got through stays quiet.
+    if [ -z "$filtered" ]; then
+      local diag_team diag_agent diag_owner
+      while IFS=$'\t' read -r diag_team diag_agent diag_owner; do
+        [ -z "$diag_team" ] && continue
+        _agmsg_subscription_skip_diag "$diag_team" "$diag_agent" "$diag_owner"
+      done <<< "$skipped_pairs"
+    fi
   fi
   if [ -n "$held" ]; then
     echo "agmsg watch: cannot claim (held by other sessions): $held" >&2

--- a/scripts/lib/subscription.sh
+++ b/scripts/lib/subscription.sh
@@ -6,72 +6,7 @@
 
 : "${SKILL_DIR:?subscription.sh requires SKILL_DIR}"
 
-# compat_file_mtime, for the diagnostic below.
-# shellcheck disable=SC1091
-. "$SKILL_DIR/scripts/lib/compat.sh"
-
 agmsg_sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
-
-# Diagnose why (team, agent)'s lock reads as owned by `owner` and not by us —
-# printed only when an exclusion empties the whole subscription (#605), never
-# on every skip, so a normal multi-pair session with one busy pair stays
-# quiet. Read-only: makes no decision, changes no behavior, mirrors the same
-# branches agmsg_instance_alive (instance-id.sh) already took to reach its
-# verdict, so a stale/misjudged lock can be told apart from a genuinely live
-# one without reproducing the failure by hand.
-_agmsg_subscription_skip_diag() {
-  local team="$1" agent="$2" owner="$3"
-  local lock_path mtime
-  lock_path="$(actas_lock_path "$team" "$agent")"
-  mtime="$(compat_file_mtime "$lock_path" 2>/dev/null || true)"
-  [ -n "$mtime" ] || mtime="unknown"
-  echo "agmsg watch:   lock file: $lock_path (mtime=$mtime)" >&2
-
-  if agmsg_instance_is_composite "$owner"; then
-    local pid cc_file cc_content cc_state
-    pid="${owner##*.}"
-    echo "agmsg watch:   owner token: composite (pid=$pid)" >&2
-    if _agmsg_pid_alive "$pid" 2>/dev/null; then
-      cc_file="$SKILL_DIR/run/cc-instance.$pid"
-      if [ -f "$cc_file" ]; then
-        cc_content="$(cat "$cc_file" 2>/dev/null || true)"
-        if [ "$cc_content" = "$owner" ]; then
-          cc_state="present, contents match — verdict: alive (confirmed)"
-        else
-          cc_state="present, contents differ ('$cc_content') — verdict: not alive"
-        fi
-      else
-        cc_state="absent — verdict: alive (unconfirmed; no cc-instance record to cross-check the pid against)"
-      fi
-      echo "agmsg watch:   liveness: pid $pid answers alive; cc-instance.$pid $cc_state" >&2
-    else
-      echo "agmsg watch:   liveness: pid $pid does not answer alive — verdict: not alive (re-read a moment after the exclusion decision; a race with the original check is possible but narrow)" >&2
-    fi
-    return 0
-  fi
-
-  echo "agmsg watch:   owner token: bare (no pid embedded)" >&2
-  local run="$SKILL_DIR/run" f p s matched=""
-  if [ -d "$run" ]; then
-    for f in "$run"/cc-instance.*; do
-      [ -f "$f" ] || continue
-      p=${f##*.}
-      case "$p" in ''|*[!0-9]*) continue ;; esac
-      _agmsg_pid_alive "$p" 2>/dev/null || continue
-      s="$(cat "$f" 2>/dev/null || true)"
-      if [ "$s" = "$owner" ] \
-        || { agmsg_instance_is_composite "$s" && [ "${s%.*}" = "$owner" ]; }; then
-        matched="$f"
-        break
-      fi
-    done
-  fi
-  if [ -n "$matched" ]; then
-    echo "agmsg watch:   liveness: matched $matched — verdict: alive" >&2
-  else
-    echo "agmsg watch:   liveness: no live cc-instance.* file matches — verdict: not alive (re-read a moment after the exclusion decision; a race with the original check is possible but narrow)" >&2
-  fi
-}
 
 # Resolve the (team, agent) rows this process should receive for.
 #
@@ -85,7 +20,7 @@ _agmsg_subscription_skip_diag() {
 agmsg_subscription_pairs() {
   local project="$1" type="$2" owner_id="$3" active_name="${4:-}" claim_mode="${5:-}"
   local scripts_dir="$SKILL_DIR/scripts"
-  local pairs filtered skipped skipped_pairs held state result
+  local pairs filtered skipped skip_facts held state result cc
 
   pairs="$("$scripts_dir/identities.sh" "$project" "$type")"
   if [ -n "$active_name" ]; then
@@ -96,7 +31,7 @@ agmsg_subscription_pairs() {
 
   filtered=""
   skipped=""
-  skipped_pairs=""
+  skip_facts=""
   held=""
   local team agent
   while IFS=$'\t' read -r team agent; do
@@ -108,7 +43,17 @@ agmsg_subscription_pairs() {
           held="${held:+$held }${team}/${agent}(${state#other:})"
         else
           skipped="${skipped:+$skipped }${team}/${agent}(${state#other:})"
-          skipped_pairs="${skipped_pairs:+$skipped_pairs$'\n'}${team}"$'\t'"${agent}"$'\t'"${state#other:}"
+          # The two facts #605 needs that the line above doesn't carry: the
+          # lock file's real path (percent-encoded, not reconstructable by
+          # hand) and whether cc-instance.<pid> backs a composite owner --
+          # absent there is instance-id.sh's unconditional-alive branch.
+          skip_facts="${skip_facts}agmsg watch:   lock=$(actas_lock_path "$team" "$agent")"
+          if agmsg_instance_is_composite "${state#other:}"; then
+            cc="absent"
+            [ -f "$SKILL_DIR/run/cc-instance.${state##*.}" ] && cc="present"
+            skip_facts="$skip_facts cc-instance=$cc"
+          fi
+          skip_facts="$skip_facts"$'\n'
         fi
         continue
         ;;
@@ -129,14 +74,10 @@ agmsg_subscription_pairs() {
 
   if [ -n "$skipped" ]; then
     echo "agmsg watch: skipping pairs held by other sessions: $skipped" >&2
-    # Diagnostic detail only when the exclusion left nothing to subscribe to
-    # (#605) -- a busy pair alongside others that still got through stays quiet.
+    # Only when the exclusion left nothing to subscribe to (#605) -- a busy
+    # pair alongside others that still resolve stays quiet.
     if [ -z "$filtered" ]; then
-      local diag_team diag_agent diag_owner
-      while IFS=$'\t' read -r diag_team diag_agent diag_owner; do
-        [ -z "$diag_team" ] && continue
-        _agmsg_subscription_skip_diag "$diag_team" "$diag_agent" "$diag_owner"
-      done <<< "$skipped_pairs"
+      printf '%s' "$skip_facts" >&2
     fi
   fi
   if [ -n "$held" ]; then

--- a/tests/test_watch_once.bats
+++ b/tests/test_watch_once.bats
@@ -144,3 +144,57 @@ _assert_startup_was_delayed() {
   [ "$status" -eq 1 ]
   [[ "$output" =~ "no available subscription" ]]
 }
+
+# --- #605 diagnostic: only fires when the exclusion empties the whole
+#     subscription, and has to name which liveness branch fired ------------
+#
+# The composite/no-cc-instance case is the one worth pinning by name:
+# instance-id.sh's agmsg_instance_alive treats a composite owner as alive
+# whenever its pid answers alive AND there is no cc-instance.<pid> to
+# cross-check against -- an unconfirmed "assume alive", not a verified one.
+# A misjudged lock in that shape is exactly what #605's diagnostic exists to
+# surface, so the test writes that exact shape (composite owner, live pid,
+# no cc-instance file) directly rather than going through actas-claim.sh,
+# whose own instance-id resolution falls back to a bare token here (no real
+# codex agent pid to find in a bats subprocess).
+@test "watch-once: #605 diagnostic names the composite/no-cc-instance branch" {
+  local lock="$TEST_SKILL_DIR/run/actas.team__alice.session"
+  local owner="deadbeef-thread.$$"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf '%s\n' "$owner" > "$lock"
+  bash "$SCRIPTS/send.sh" team bob alice "locked out" >/dev/null
+
+  run bash "$TYPES/codex/watch-once.sh" "$PROJ" codex --name alice --team team --timeout 1 --interval 1
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no available subscription"* ]]
+  [[ "$output" == *"lock file: $lock"* ]]
+  [[ "$output" == *"owner token: composite (pid=$$)"* ]]
+  [[ "$output" == *"cc-instance.$$ absent"* ]]
+  [[ "$output" == *"verdict: alive (unconfirmed"* ]]
+}
+
+@test "watch-once: #605 diagnostic names a confirmed-alive composite owner" {
+  local lock="$TEST_SKILL_DIR/run/actas.team__alice.session"
+  local owner="deadbeef-thread.$$"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf '%s\n' "$owner" > "$lock"
+  printf '%s\n' "$owner" > "$TEST_SKILL_DIR/run/cc-instance.$$"
+  bash "$SCRIPTS/send.sh" team bob alice "locked out" >/dev/null
+
+  run bash "$TYPES/codex/watch-once.sh" "$PROJ" codex --name alice --team team --timeout 1 --interval 1
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"cc-instance.$$ present, contents match — verdict: alive (confirmed)"* ]]
+}
+
+@test "watch-once: #605 diagnostic stays quiet when another pair still gets through" {
+  # alice is locked out, but bob (also registered) is free -- the subscription
+  # is not empty, so the loud per-skip diagnostic must not fire.
+  setup_live_owner "$TEST_SKILL_DIR/run" other-sid
+  bash "$SCRIPTS/actas-claim.sh" "$PROJ" codex alice other-sid >/dev/null
+  bash "$SCRIPTS/send.sh" team alice bob "for bob, not alice" >/dev/null
+
+  run bash "$TYPES/codex/watch-once.sh" "$PROJ" codex --team team --timeout 1 --interval 1
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "status=pending" ]]
+  [[ "$output" != *"lock file:"* ]]
+}

--- a/tests/test_watch_once.bats
+++ b/tests/test_watch_once.bats
@@ -145,50 +145,23 @@ _assert_startup_was_delayed() {
   [[ "$output" =~ "no available subscription" ]]
 }
 
-# --- #605 diagnostic: only fires when the exclusion empties the whole
-#     subscription, and has to name which liveness branch fired ------------
-#
-# The composite/no-cc-instance case is the one worth pinning by name:
-# instance-id.sh's agmsg_instance_alive treats a composite owner as alive
-# whenever its pid answers alive AND there is no cc-instance.<pid> to
-# cross-check against -- an unconfirmed "assume alive", not a verified one.
-# A misjudged lock in that shape is exactly what #605's diagnostic exists to
-# surface, so the test writes that exact shape (composite owner, live pid,
-# no cc-instance file) directly rather than going through actas-claim.sh,
-# whose own instance-id resolution falls back to a bare token here (no real
-# codex agent pid to find in a bats subprocess).
-@test "watch-once: #605 diagnostic names the composite/no-cc-instance branch" {
+# --- #605: when the exclusion above empties the whole subscription, name the
+#     lock file and whether cc-instance.<pid> backs the owner. A composite
+#     owner with no matching cc-instance file is instance-id.sh's
+#     unconditional-alive branch -- the one worth being able to spot. ------
+@test "watch-once: #605 names the lock path and reports cc-instance as absent" {
   local lock="$TEST_SKILL_DIR/run/actas.team__alice.session"
-  local owner="deadbeef-thread.$$"
   mkdir -p "$TEST_SKILL_DIR/run"
-  printf '%s\n' "$owner" > "$lock"
+  printf '%s\n' "deadbeef-thread.$$" > "$lock"
   bash "$SCRIPTS/send.sh" team bob alice "locked out" >/dev/null
 
   run bash "$TYPES/codex/watch-once.sh" "$PROJ" codex --name alice --team team --timeout 1 --interval 1
   [ "$status" -eq 1 ]
-  [[ "$output" == *"no available subscription"* ]]
-  [[ "$output" == *"lock file: $lock"* ]]
-  [[ "$output" == *"owner token: composite (pid=$$)"* ]]
-  [[ "$output" == *"cc-instance.$$ absent"* ]]
-  [[ "$output" == *"verdict: alive (unconfirmed"* ]]
+  [[ "$output" == *"lock=$lock"* ]]
+  [[ "$output" == *"cc-instance=absent"* ]]
 }
 
-@test "watch-once: #605 diagnostic names a confirmed-alive composite owner" {
-  local lock="$TEST_SKILL_DIR/run/actas.team__alice.session"
-  local owner="deadbeef-thread.$$"
-  mkdir -p "$TEST_SKILL_DIR/run"
-  printf '%s\n' "$owner" > "$lock"
-  printf '%s\n' "$owner" > "$TEST_SKILL_DIR/run/cc-instance.$$"
-  bash "$SCRIPTS/send.sh" team bob alice "locked out" >/dev/null
-
-  run bash "$TYPES/codex/watch-once.sh" "$PROJ" codex --name alice --team team --timeout 1 --interval 1
-  [ "$status" -eq 1 ]
-  [[ "$output" == *"cc-instance.$$ present, contents match — verdict: alive (confirmed)"* ]]
-}
-
-@test "watch-once: #605 diagnostic stays quiet when another pair still gets through" {
-  # alice is locked out, but bob (also registered) is free -- the subscription
-  # is not empty, so the loud per-skip diagnostic must not fire.
+@test "watch-once: #605 facts stay quiet when another pair still resolves" {
   setup_live_owner "$TEST_SKILL_DIR/run" other-sid
   bash "$SCRIPTS/actas-claim.sh" "$PROJ" codex alice other-sid >/dev/null
   bash "$SCRIPTS/send.sh" team alice bob "for bob, not alice" >/dev/null
@@ -196,5 +169,5 @@ _assert_startup_was_delayed() {
   run bash "$TYPES/codex/watch-once.sh" "$PROJ" codex --team team --timeout 1 --interval 1
   [ "$status" -eq 0 ]
   [[ "$output" =~ "status=pending" ]]
-  [[ "$output" != *"lock file:"* ]]
+  [[ "$output" != *"lock="* ]]
 }


### PR DESCRIPTION
Adds diagnostics for #605. This does not fix #605. The reporter's failure resolved on its own once the conflicting lock's owning session exited, and the root cause of why that lock existed was not established from the evidence gathered on the issue. What this adds is two facts for the next time a subscription is unexpectedly excluded, so the cause can be read from the log instead of reconstructed by hand.

## What changes

`agmsg_subscription_pairs` (scripts/lib/subscription.sh) already logs `skipping pairs held by other sessions: <team>/<agent>(<owner>)` when a lock excludes a pair. When that exclusion empties the whole subscription, this adds two lines of fact -- not a verdict -- for each excluded pair: the lock file's path (percent-encoded, not something a reader can reconstruct by hand), and, when the owner token is composite (`<sid>.<pid>`), whether a `cc-instance.<pid>` record exists for it. A composite owner whose pid answers alive but has no matching `cc-instance.<pid>` file is read as alive unconditionally by `agmsg_instance_alive` (instance-id.sh) -- an unconfirmed verdict, not a confirmed one. The output states presence or absence of that file; it does not restate the liveness decision instance-id.sh already made, and it does not read or print that file's contents.

The extra lines print only when the exclusion leaves nothing to subscribe to. A busy pair alongside others that still resolve stays quiet, so a normal multi-pair session does not get noisier.

## What does not change

The filter's decision (which pairs get skipped), the function's return value, control flow, and the existing `skipping pairs held by other sessions` line are all unchanged. Exit codes, `actas-claim.sh`, and `reset.sh` are untouched. No new dependency: `actas_lock_path` and `agmsg_instance_is_composite` are already available wherever `agmsg_subscription_pairs` already calls `actas_lock_state`, which uses both.

## Where this is observable

`scripts/drivers/types/codex/watch-once.sh` is the path #605 actually failed through, and its stderr is forwarded into the bridge log as-is (codex-bridge.js's `onProcessExited` joins `params.stderr` into the `watch-once failed` line), so this is observable there.

`scripts/drivers/types/codex/eligible-pairs.sh` calls the same `agmsg_subscription_pairs`, so the same two lines are technically produced there too, but they do not reach the bridge log: codex-bridge.js's `readInboxForPrompt()` runs eligible-pairs.sh via `spawnSync` and reads only its stdout, discarding stderr. Closing that gap means changing a production code path, which is out of scope for a diagnostics-only change. Left as a known limitation rather than hidden.

## Testing

Two tests added to tests/test_watch_once.bats: a composite owner with a live pid and no matching `cc-instance.<pid>` file (the unconfirmed-alive branch above, reproduced directly against a real live pid), asserting both the lock path and `cc-instance=absent` appear; and a case where one pair is excluded but another still resolves, asserting neither line appears. Mutation-checked: reverting the change turns the first test red while the rest of the suite (including the quiet-path test) stays green; re-applying turns the suite green again (10/10).

(1) bats tests/test_watch_once.bats -- 10 ok, 0 not ok, exit 0. This is the only test file that references `agmsg_subscription_pairs` directly.
