### PR TITLE
fix(bin): an unknown verb names the command to run instead

### DIFF
--- a/bin/agmsg.js
+++ b/bin/agmsg.js
@@ -77,8 +77,12 @@ function readVersion() {
 //     of this comment claimed only precision could degrade; that was wrong,
 //     and it was wrong for exactly the entries most likely to rot.
 //
-// test_bin_agmsg.bats pins every value against the repo's scripts/. Adding a
-// verb is free; renaming a script fails the suite.
+// test_bin_agmsg.bats pins every value against the repo's scripts/ — the
+// list is asserted non-empty, not at a fixed size, so adding a verb here
+// costs nothing while renaming a script fails the suite.
+//
+// That pin is about THIS repo. It cannot speak for the tree on a user's
+// disk, so printNotACommand checks the actual file there before naming it.
 const SCRIPT_FOR_VERB = {
   send: 'send.sh', history: 'history.sh', inbox: 'inbox.sh', join: 'join.sh',
   team: 'team.sh', key: 'key.sh', remote: 'remote.sh', whoami: 'whoami.sh',
@@ -94,27 +98,49 @@ function defaultSkillDir() {
   return path.join(os.homedir(), '.agents', 'skills', 'agmsg');
 }
 
+function exists(p) {
+  try {
+    return fs.existsSync(p);
+  } catch (_) {
+    return false;
+  }
+}
+
 function printNotACommand(verb, skillDirForTest) {
   const dir = skillDirForTest || defaultSkillDir();
-  let installed = false;
-  try {
-    installed = fs.existsSync(path.join(dir, 'scripts'));
-  } catch (_) {
-    installed = false;
-  }
   const skill = '~/.agents/skills/agmsg/scripts';
   const script = Object.prototype.hasOwnProperty.call(SCRIPT_FOR_VERB, verb)
     ? SCRIPT_FOR_VERB[verb]
     : null;
+  const scriptsDir = path.join(dir, 'scripts');
+
+  // The contract differs by what is about to be printed, and that is the
+  // point (review P1, co1):
+  //
+  //   naming ONE script  -> that script file must exist. The repo-side pin
+  //     proves the map matches THIS repo; it says nothing about the tree on
+  //     the user's disk, which can be an old version, a partial update, or a
+  //     broken install. Checking only that scripts/ exists reproduces the
+  //     previous P1 one layer out — a directory is not the file.
+  //   naming the DIRECTORY -> the directory must exist. Nothing more is
+  //     claimed, so nothing more is checked.
+  const haveScripts = exists(scriptsDir);
+  const usable = script ? exists(path.join(scriptsDir, script)) : haveScripts;
+
   const lines = ['agmsg: `agmsg ' + verb + '` is not a command.', ''];
 
-  if (!installed) {
-    // Two different situations, kept apart on purpose: "never installed" and
-    // "installed under another name" need different next steps, and folding
-    // them into one sentence leaves whoever is in the first one without a
-    // recovery step.
-    lines.push('agmsg does not look installed on this machine — this package is');
-    lines.push('the installer for it. Install first:');
+  if (!usable) {
+    // Three situations that need different next steps, kept apart: never
+    // installed, installed but without this command, and installed under
+    // another name. Folding them together leaves someone without a recovery
+    // step — which is what the first version of this message did.
+    if (haveScripts) {
+      lines.push('Your agmsg install does not contain that command. It may be an');
+      lines.push('older version — update it:');
+    } else {
+      lines.push('agmsg does not look installed on this machine — this package is');
+      lines.push('the installer for it. Install first:');
+    }
     lines.push('');
     lines.push('  npx agmsg install');
     lines.push('');

--- a/bin/agmsg.js
+++ b/bin/agmsg.js
@@ -56,6 +56,53 @@ function readVersion() {
   }
 }
 
+// `agmsg <verb>` is the single most common wrong guess about this project,
+// and it is a guess the documentation taught: a sweep of docs/design and
+// docs/spec found 34 backticked commands written as `agmsg send …`,
+// `agmsg key show …`, `agmsg team list …`. There is no such CLI. This package
+// installs agmsg; the commands are scripts inside the install.
+//
+// Saying only "unknown argument" leaves the person exactly where they were.
+// It has to name what to type instead.
+//
+// The verb→script map is a HINT and is allowed to be incomplete. This package
+// does not ship scripts/, so it cannot enumerate them, and a hardcoded list
+// will drift. Nothing depends on it being complete: a verb that is not here
+// still gets the general form, which is always correct. Only the extra
+// precision degrades, never the answer.
+const SCRIPT_FOR_VERB = {
+  send: 'send.sh', history: 'history.sh', inbox: 'inbox.sh', join: 'join.sh',
+  team: 'team.sh', key: 'key.sh', remote: 'remote.sh', whoami: 'whoami.sh',
+  leave: 'leave.sh', rename: 'rename.sh', export: 'export.sh', config: 'config.sh',
+  watch: 'watch.sh', spawn: 'spawn.sh', version: 'version.sh', api: 'api.sh',
+};
+
+function printNotACommand(verb) {
+  const skill = '~/.agents/skills/agmsg/scripts';
+  const lines = ['agmsg: `agmsg ' + verb + '` is not a command.', ''];
+  const script = Object.prototype.hasOwnProperty.call(SCRIPT_FOR_VERB, verb)
+    ? SCRIPT_FOR_VERB[verb]
+    : null;
+  if (script) {
+    lines.push('This package only installs agmsg. That one lives in your install:');
+    lines.push('');
+    lines.push('  bash ' + skill + '/' + script + ' …');
+  } else {
+    lines.push('This package only installs agmsg. The commands live in your install:');
+    lines.push('');
+    lines.push('  ls ' + skill + '/');
+    lines.push('  bash ' + skill + '/<name>.sh …');
+  }
+  lines.push('');
+  // The skill command is the path most people actually want — it is what the
+  // install sets up, and it needs no paths.
+  lines.push('Or ask your agent: run the agmsg skill command (/agmsg in Claude Code).');
+  lines.push('');
+  lines.push('If you installed with a different name, substitute it for `agmsg` in');
+  lines.push('the path above. `npx agmsg --help` covers what THIS package does.');
+  console.error(lines.join('\n'));
+}
+
 function printHelp() {
   process.stdout.write([
     'agmsg — npm bootstrapper for cross-agent messaging',
@@ -152,8 +199,7 @@ function main() {
     process.stdout.write('canonical project: ' + REPO_URL + '\n');
     process.exit(0);
   } else {
-    console.error('agmsg: unknown argument: ' + args[0]);
-    console.error('Run `npx agmsg --help` for usage.');
+    printNotACommand(args[0]);
     process.exit(2);
   }
 }

--- a/bin/agmsg.js
+++ b/bin/agmsg.js
@@ -65,11 +65,20 @@ function readVersion() {
 // Saying only "unknown argument" leaves the person exactly where they were.
 // It has to name what to type instead.
 //
-// The verb→script map is a HINT and is allowed to be incomplete. This package
-// does not ship scripts/, so it cannot enumerate them, and a hardcoded list
-// will drift. Nothing depends on it being complete: a verb that is not here
-// still gets the general form, which is always correct. Only the extra
-// precision degrades, never the answer.
+// The verb→script map is a HINT, and the two halves of that are tested
+// differently (review P1, co1):
+//
+//   NOT promised: that it is complete. This package does not ship scripts/,
+//     so it cannot enumerate them. A verb missing from here falls through to
+//     the general form, which stays correct.
+//   PROMISED: that every entry present is real. A renamed or deleted script
+//     would otherwise make this print a specific path that does not exist —
+//     WORSE than the general form, not merely less precise. The first version
+//     of this comment claimed only precision could degrade; that was wrong,
+//     and it was wrong for exactly the entries most likely to rot.
+//
+// test_bin_agmsg.bats pins every value against the repo's scripts/. Adding a
+// verb is free; renaming a script fails the suite.
 const SCRIPT_FOR_VERB = {
   send: 'send.sh', history: 'history.sh', inbox: 'inbox.sh', join: 'join.sh',
   team: 'team.sh', key: 'key.sh', remote: 'remote.sh', whoami: 'whoami.sh',
@@ -77,13 +86,46 @@ const SCRIPT_FOR_VERB = {
   watch: 'watch.sh', spawn: 'spawn.sh', version: 'version.sh', api: 'api.sh',
 };
 
-function printNotACommand(verb) {
+// The default install location. Checked because this package's whole job is
+// to install agmsg, so a person who has never run it reaches this branch too
+// (review P1, co1) — and for them every path below is a command that fails.
+// Advice that assumes the install is advice they cannot follow.
+function defaultSkillDir() {
+  return path.join(os.homedir(), '.agents', 'skills', 'agmsg');
+}
+
+function printNotACommand(verb, skillDirForTest) {
+  const dir = skillDirForTest || defaultSkillDir();
+  let installed = false;
+  try {
+    installed = fs.existsSync(path.join(dir, 'scripts'));
+  } catch (_) {
+    installed = false;
+  }
   const skill = '~/.agents/skills/agmsg/scripts';
-  const lines = ['agmsg: `agmsg ' + verb + '` is not a command.', ''];
   const script = Object.prototype.hasOwnProperty.call(SCRIPT_FOR_VERB, verb)
     ? SCRIPT_FOR_VERB[verb]
     : null;
-  if (script) {
+  const lines = ['agmsg: `agmsg ' + verb + '` is not a command.', ''];
+
+  if (!installed) {
+    // Two different situations, kept apart on purpose: "never installed" and
+    // "installed under another name" need different next steps, and folding
+    // them into one sentence leaves whoever is in the first one without a
+    // recovery step.
+    lines.push('agmsg does not look installed on this machine — this package is');
+    lines.push('the installer for it. Install first:');
+    lines.push('');
+    lines.push('  npx agmsg install');
+    lines.push('');
+    lines.push('After that, ' + (script ? 'that command is:' : 'the commands are:'));
+    lines.push('');
+    lines.push(script ? '  bash ' + skill + '/' + script + ' …'
+                      : '  bash ' + skill + '/<name>.sh …');
+    lines.push('');
+    lines.push('(Already installed under a different name? Substitute it for');
+    lines.push('`agmsg` in that path — nothing is put on your PATH.)');
+  } else if (script) {
     lines.push('This package only installs agmsg. That one lives in your install:');
     lines.push('');
     lines.push('  bash ' + skill + '/' + script + ' …');
@@ -93,13 +135,12 @@ function printNotACommand(verb) {
     lines.push('  ls ' + skill + '/');
     lines.push('  bash ' + skill + '/<name>.sh …');
   }
+
   lines.push('');
   // The skill command is the path most people actually want — it is what the
   // install sets up, and it needs no paths.
   lines.push('Or ask your agent: run the agmsg skill command (/agmsg in Claude Code).');
-  lines.push('');
-  lines.push('If you installed with a different name, substitute it for `agmsg` in');
-  lines.push('the path above. `npx agmsg --help` covers what THIS package does.');
+  lines.push('`npx agmsg --help` covers what THIS package does.');
   console.error(lines.join('\n'));
 }
 
@@ -208,4 +249,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { toBashPath };
+module.exports = { toBashPath, SCRIPT_FOR_VERB, printNotACommand };

--- a/tests/test_bin_agmsg.bats
+++ b/tests/test_bin_agmsg.bats
@@ -14,6 +14,31 @@ BIN="$BATS_TEST_DIRNAME/../bin/agmsg.js"
   [[ "$output" =~ "npm bootstrapper for cross-agent messaging" ]]
 }
 
+# `agmsg <verb>` is the wrong guess the docs taught — a sweep of docs/design
+# and docs/spec found 34 backticked commands assuming a CLI that does not
+# exist. Fixing the documents does not help the person who types from memory,
+# so the refusal has to name the real form.
+#
+# Asserted on the PATH being present, not on the wording: the value of this
+# message is that it tells you what to type instead, and a test that only
+# checked for "not a command" would pass on the old text.
+@test "bin/agmsg.js: an unknown verb names the script to run instead" {
+  run node "$BIN" send hello
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "is not a command" ]]
+  [[ "$output" =~ "scripts/send.sh" ]]
+}
+
+# A verb with no mapping still has to answer "then what do I type", because
+# the mapping is a hint that is allowed to be incomplete. `storage` is one the
+# docs use and no script implements.
+@test "bin/agmsg.js: an unmapped verb still points at the install" {
+  run node "$BIN" storage list
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "is not a command" ]]
+  [[ "$output" =~ "scripts/" ]]
+}
+
 @test "bin/agmsg.js: toBashPath converts backslashes to forward slashes (#262)" {
   run node -e 'const { toBashPath } = require(process.argv[1]); const input = String.raw`C:\Users\me\AppData\Local\Temp\agmsg-bootstrap-abc123\setup.sh`; const expected = "C:/Users/me/AppData/Local/Temp/agmsg-bootstrap-abc123/setup.sh"; if (toBashPath(input) !== expected) process.exit(1);' "$BIN"
   [ "$status" -eq 0 ]

--- a/tests/test_bin_agmsg.bats
+++ b/tests/test_bin_agmsg.bats
@@ -57,8 +57,11 @@ BIN="$BATS_TEST_DIRNAME/../bin/agmsg.js"
     console.log("checked " + Object.keys(SCRIPT_FOR_VERB).length);
   ' "$BIN"
   [ "$status" -eq 0 ]
-  # The count is echoed so a map emptied to {} cannot pass as "nothing missing".
-  [[ "$output" =~ "checked 16" ]]
+  # Non-empty, not an exact count (co1): pinning the number would mean adding
+  # a legitimate verb to the map fails this test, which makes the map harder
+  # to extend for no safety gained. What must not pass is a map emptied to {}
+  # reporting "nothing missing".
+  [[ "$output" =~ checked\ [1-9] ]]
 }
 
 # The person this package exists for has NOT installed yet, and they reach
@@ -76,13 +79,44 @@ BIN="$BATS_TEST_DIRNAME/../bin/agmsg.js"
   [[ "$output" =~ "scripts/send.sh" ]]
 }
 
-@test "bin/agmsg.js: with an install present, it does not tell you to install" {
+@test "bin/agmsg.js: with the script present, it names it and says nothing about installing" {
   local home="$BATS_TEST_TMPDIR/has-install"
   mkdir -p "$home/.agents/skills/agmsg/scripts"
+  # The FILE, not just the directory. An earlier version of this test created
+  # an empty scripts/ and accepted advice pointing at a send.sh that was not
+  # there — the same defect as the map pin, one layer out (review P1, co1).
+  touch "$home/.agents/skills/agmsg/scripts/send.sh"
   run env HOME="$home" node "$BIN" send hello
   [ "$status" -eq 2 ]
   [[ ! "$output" =~ "does not look installed" ]]
+  [[ ! "$output" =~ "does not contain that command" ]]
   [[ "$output" =~ "scripts/send.sh" ]]
+}
+
+# An install that exists but lacks the command — an old version, or a partial
+# update. The repo-side pin cannot see this: it proves the map matches THIS
+# repo, not the tree on someone's disk. Distinct from "never installed"
+# because the recovery is update, not install.
+@test "bin/agmsg.js: an install without that script says update, not install" {
+  local home="$BATS_TEST_TMPDIR/stale-install"
+  mkdir -p "$home/.agents/skills/agmsg/scripts"
+  touch "$home/.agents/skills/agmsg/scripts/history.sh"   # some other command
+  run env HOME="$home" node "$BIN" send hello
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "does not contain that command" ]]
+  [[ ! "$output" =~ "does not look installed" ]]
+  [[ "$output" =~ "npx agmsg install" ]]
+}
+
+# An unmapped verb names the DIRECTORY, so the directory is all that is
+# checked — the contract matches what is printed.
+@test "bin/agmsg.js: an unmapped verb is satisfied by the directory alone" {
+  local home="$BATS_TEST_TMPDIR/dir-only"
+  mkdir -p "$home/.agents/skills/agmsg/scripts"
+  run env HOME="$home" node "$BIN" storage list
+  [ "$status" -eq 2 ]
+  [[ ! "$output" =~ "does not look installed" ]]
+  [[ "$output" =~ "ls " ]]
 }
 
 @test "bin/agmsg.js: toBashPath converts backslashes to forward slashes (#262)" {

--- a/tests/test_bin_agmsg.bats
+++ b/tests/test_bin_agmsg.bats
@@ -39,6 +39,52 @@ BIN="$BATS_TEST_DIRNAME/../bin/agmsg.js"
   [[ "$output" =~ "scripts/" ]]
 }
 
+# EVERY entry in the map, not the one verb a hand-written test happened to
+# pick (review P1, co1). The map is allowed to be incomplete — a new verb
+# missing from it costs nothing — but an entry that is PRESENT and stale makes
+# the message name a path that does not exist, which is worse than the general
+# advice it replaced. Completeness is not pinned; correctness of what is
+# listed is.
+@test "bin/agmsg.js: every mapped verb names a script that exists" {
+  run node -e '
+    const { SCRIPT_FOR_VERB } = require(process.argv[1]);
+    const fs = require("fs"), path = require("path");
+    const dir = path.join(path.dirname(process.argv[1]), "..", "scripts");
+    const missing = Object.entries(SCRIPT_FOR_VERB)
+      .filter(([, s]) => !fs.existsSync(path.join(dir, s)))
+      .map(([v, s]) => v + " -> " + s);
+    if (missing.length) { console.error(missing.join("\n")); process.exit(1); }
+    console.log("checked " + Object.keys(SCRIPT_FOR_VERB).length);
+  ' "$BIN"
+  [ "$status" -eq 0 ]
+  # The count is echoed so a map emptied to {} cannot pass as "nothing missing".
+  [[ "$output" =~ "checked 16" ]]
+}
+
+# The person this package exists for has NOT installed yet, and they reach
+# this same branch (review P1, co1). Telling them to `bash <install path>` is
+# telling them to run a command that fails. HOME is redirected to an empty
+# directory; nothing here touches the network.
+@test "bin/agmsg.js: with nothing installed, it says to install first" {
+  local fresh="$BATS_TEST_TMPDIR/fresh-home"
+  mkdir -p "$fresh"
+  run env HOME="$fresh" node "$BIN" send hello
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "does not look installed" ]]
+  [[ "$output" =~ "npx agmsg install" ]]
+  # Still names the eventual command, so the person knows where they are going.
+  [[ "$output" =~ "scripts/send.sh" ]]
+}
+
+@test "bin/agmsg.js: with an install present, it does not tell you to install" {
+  local home="$BATS_TEST_TMPDIR/has-install"
+  mkdir -p "$home/.agents/skills/agmsg/scripts"
+  run env HOME="$home" node "$BIN" send hello
+  [ "$status" -eq 2 ]
+  [[ ! "$output" =~ "does not look installed" ]]
+  [[ "$output" =~ "scripts/send.sh" ]]
+}
+
 @test "bin/agmsg.js: toBashPath converts backslashes to forward slashes (#262)" {
   run node -e 'const { toBashPath } = require(process.argv[1]); const input = String.raw`C:\Users\me\AppData\Local\Temp\agmsg-bootstrap-abc123\setup.sh`; const expected = "C:/Users/me/AppData/Local/Temp/agmsg-bootstrap-abc123/setup.sh"; if (toBashPath(input) !== expected) process.exit(1);' "$BIN"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Assigned by pm after the design/spec command sweep. The sweep's headline number was that **34 backticked commands across the design docs assume an `agmsg <verb>` shell CLI that does not exist** — and pm's point was that fixing the documents does not help the person who types from memory.

## Measured, before

```
$ agmsg send hello
agmsg: unknown argument: send
Run `npx agmsg --help` for usage.
```

True and useless. It does not say what to type instead, and `--help` describes *this package*, not the thing the person was reaching for.

## After

```
$ agmsg send hello
agmsg: `agmsg send` is not a command.

This package only installs agmsg. That one lives in your install:

  bash ~/.agents/skills/agmsg/scripts/send.sh …

Or ask your agent: run the agmsg skill command (/agmsg in Claude Code).
```

An unmapped verb — `storage`, which the docs use and no script implements — still gets an answer:

```
  ls ~/.agents/skills/agmsg/scripts/
  bash ~/.agents/skills/agmsg/scripts/<name>.sh …
```

## Why the map is allowed to be incomplete

This package does not ship `scripts/`, so it cannot enumerate them, and a hardcoded list will drift from the real set. Nothing rests on it being complete: an unmapped verb falls through to the general form, which is always correct. **Only the precision degrades, never the answer** — so the list going stale is a cosmetic loss, not a wrong instruction.

## Ground truth

- `command -v agmsg` → nothing. `install.sh` creates `~/.agents/skills/<cmd>/` and a slash-command file; `grep -nE '/usr/local/bin|\.local/bin|PATH|ln -s'` over it finds no PATH write.
- `bin/agmsg.js` accepts `install` / `--help` / `--version` only.

## Tests

Assert the **path is named**, not the wording — a test for "not a command" alone would have passed on the old text. Both new tests go red if the old message is restored; the four existing tests stay green. 6/6 locally.