### PR TITLE
fix(sync): keep the acks a failed split already earned

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2171,6 +2171,20 @@ async function postGroup(config, group, requestCall, eventCall) {
 // this whole path exists to avoid. So the error carries them: every layer that
 // concatenates acks concatenates them onto the failure too, and the top of the
 // push sees one prefix no matter how deep the split recursed.
+// Emit a diagnostic on a path that is already failing. Every other eventCall in
+// this file is awaited bare, and should be: on the success path an unwritable
+// event log is a real fault and failing the cycle is right. Here it is not —
+// the cycle has already failed, an error is already on its way up, and letting
+// the sink throw would replace that error with one about logging. Nothing is
+// swallowed silently: the caller still throws what actually went wrong.
+async function note(eventCall, name, payload) {
+  try {
+    await eventCall(name, payload);
+  } catch {
+    // Deliberately ignored; see above.
+  }
+}
+
 async function carryAcks(earned, attempt) {
   try {
     return await attempt();
@@ -2274,13 +2288,16 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
       // what makes the mapping's positional id check an assertion that this
       // really is an unbroken prefix — a gap shows up as an id mismatch.
       const ackRecords = validateAckMapping(candidates.slice(0, acks.length), acks);
-      await eventCall("push.ack", { acks: ackRecords.map(({ id, server_seq, disposition }) => ({ id, server_seq, disposition })) });
       const messageAcks = ackRecords.filter((_, index) => candidates[index].sync_axis === "messages");
       const rosterAcks = ackRecords.filter((_, index) => candidates[index].sync_axis === "roster");
+      // The durable write comes before either event. An event sink that throws
+      // between them would otherwise skip the reconcile the acks exist for —
+      // reporting must not be able to cost the recording.
       const [reconciled, rosterReconciled] = await Promise.all([
         messageAcks.length > 0 ? driverCall("reconcile", config, messageAcks) : [],
         rosterAcks.length > 0 ? rosterDriverCall("reconcile", config, rosterAcks) : [],
       ]);
+      await eventCall("push.ack", { acks: ackRecords.map(({ id, server_seq, disposition }) => ({ id, server_seq, disposition })) });
       await eventCall("push.reconciled", {
         result: reconciled[0] ?? null,
         roster_result: rosterReconciled[0] ?? null,
@@ -2292,17 +2309,26 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
     } catch (error) {
       const earned = Array.isArray(error?.acks) ? error.acks : [];
       if (earned.length > 0) {
-        await eventCall("push.partial", { acked: earned.length, of: candidates.length });
+        // Recovery first, reporting after, and the reporting cannot break
+        // either: an event sink that throws on this path would otherwise skip
+        // the very recording this branch exists for, and surface itself as the
+        // cycle's error in place of the transport failure that caused it.
+        let recorded;
         try {
           await reconcileAcks(earned);
+          recorded = null;
         } catch (reconcileFailure) {
-          // Recording the prefix failed too. Report it — the client now has
-          // neither the rows nor a note of them — but do not let it replace the
-          // transport error that started this, or the cause disappears.
-          await eventCall("push.partial-unrecorded", { reason: reconcileFailure.message });
+          recorded = reconcileFailure;
+          // Neither the rows nor a note of them. Report it, but keep it under
+          // the transport error rather than in front of it — that error is the
+          // reason any of this happened.
           if (error && typeof error === "object" && error.cause === undefined) {
             error.cause = reconcileFailure;
           }
+        }
+        await note(eventCall, "push.partial", { acked: earned.length, of: candidates.length });
+        if (recorded) {
+          await note(eventCall, "push.partial-unrecorded", { reason: recorded.message });
         }
       }
       throw error;

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2156,10 +2156,29 @@ async function postGroup(config, group, requestCall, eventCall) {
     const middle = Math.ceil(group.length / 2);
     await eventCall("push.split", { count: group.length, halves: [middle, group.length - middle] });
     const first = await postGroup(config, group.slice(0, middle), requestCall, eventCall);
-    const second = await postGroup(config, group.slice(middle), requestCall, eventCall);
+    const second = await carryAcks(first.acks, () =>
+      postGroup(config, group.slice(middle), requestCall, eventCall));
     // Concatenated in send order, so the combined acks line up with the
     // candidates the caller passed in — validateAckMapping compares positionally.
     return { ...second, acks: [...first.acks, ...second.acks] };
+  }
+}
+
+// One POST is atomic; several are not. When a later POST dies — 4xx, 5xx, a
+// dropped socket — the rows the earlier ones stored are already committed on
+// the server, and the acks proving it are in hand. Throwing them away leaves
+// the client with no record of messages the server holds, which is the state
+// this whole path exists to avoid. So the error carries them: every layer that
+// concatenates acks concatenates them onto the failure too, and the top of the
+// push sees one prefix no matter how deep the split recursed.
+async function carryAcks(earned, attempt) {
+  try {
+    return await attempt();
+  } catch (error) {
+    if (earned.length > 0 && error && typeof error === "object") {
+      error.acks = [...earned, ...(error.acks ?? [])];
+    }
+    throw error;
   }
 }
 
@@ -2172,7 +2191,7 @@ async function postCandidates(config, candidates, requestCall, eventCall) {
   let last;
   const acks = [];
   for (const group of groups) {
-    last = await postGroup(config, group, requestCall, eventCall);
+    last = await carryAcks(acks, () => postGroup(config, group, requestCall, eventCall));
     acks.push(...last.acks);
   }
   // The last response carries the freshest server state (current_seq, floor);
@@ -2244,19 +2263,51 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
   if (!writeProfile.eligible) {
     await eventCall("push.blocked", { reason: writeProfile.reason });
   } else if (candidates.length > 0) {
-    const posted = await postCandidates(config, candidates, requestCall, eventCall);
-    const ackRecords = validateAckMapping(candidates, posted.acks);
-    await eventCall("push.ack", { acks: ackRecords.map(({ id, server_seq, disposition }) => ({ id, server_seq, disposition })) });
-    const messageAcks = ackRecords.filter((_, index) => candidates[index].sync_axis === "messages");
-    const rosterAcks = ackRecords.filter((_, index) => candidates[index].sync_axis === "roster");
-    const [reconciled, rosterReconciled] = await Promise.all([
-      messageAcks.length > 0 ? driverCall("reconcile", config, messageAcks) : [],
-      rosterAcks.length > 0 ? rosterDriverCall("reconcile", config, rosterAcks) : [],
-    ]);
-    await eventCall("push.reconciled", {
-      result: reconciled[0] ?? null,
-      roster_result: rosterReconciled[0] ?? null,
-    });
+    // Record whatever the server acknowledged, then let the failure through.
+    // Both have to reach the caller: the cycle failed, and some of it durably
+    // succeeded. Reconciling first means a retry resends only what is actually
+    // missing — and the acks arrive as `duplicate` for anything it does resend,
+    // which the mapping already accepts.
+    const reconcileAcks = async (acks) => {
+      // Only a front prefix can be reconciled: the acks are in send order, so
+      // acks[i] belongs to candidates[i]. Slicing to the acks' own length is
+      // what makes the mapping's positional id check an assertion that this
+      // really is an unbroken prefix — a gap shows up as an id mismatch.
+      const ackRecords = validateAckMapping(candidates.slice(0, acks.length), acks);
+      await eventCall("push.ack", { acks: ackRecords.map(({ id, server_seq, disposition }) => ({ id, server_seq, disposition })) });
+      const messageAcks = ackRecords.filter((_, index) => candidates[index].sync_axis === "messages");
+      const rosterAcks = ackRecords.filter((_, index) => candidates[index].sync_axis === "roster");
+      const [reconciled, rosterReconciled] = await Promise.all([
+        messageAcks.length > 0 ? driverCall("reconcile", config, messageAcks) : [],
+        rosterAcks.length > 0 ? rosterDriverCall("reconcile", config, rosterAcks) : [],
+      ]);
+      await eventCall("push.reconciled", {
+        result: reconciled[0] ?? null,
+        roster_result: rosterReconciled[0] ?? null,
+      });
+    };
+    let posted;
+    try {
+      posted = await postCandidates(config, candidates, requestCall, eventCall);
+    } catch (error) {
+      const earned = Array.isArray(error?.acks) ? error.acks : [];
+      if (earned.length > 0) {
+        await eventCall("push.partial", { acked: earned.length, of: candidates.length });
+        try {
+          await reconcileAcks(earned);
+        } catch (reconcileFailure) {
+          // Recording the prefix failed too. Report it — the client now has
+          // neither the rows nor a note of them — but do not let it replace the
+          // transport error that started this, or the cause disappears.
+          await eventCall("push.partial-unrecorded", { reason: reconcileFailure.message });
+          if (error && typeof error === "object" && error.cause === undefined) {
+            error.cause = reconcileFailure;
+          }
+        }
+      }
+      throw error;
+    }
+    await reconcileAcks(posted.acks);
   }
   // A full push page (and eligible) means at least a full page was available,
   // so the loop treats it as "more remains" and stays in catch-up. An exactly-

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2282,7 +2282,11 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
     // succeeded. Reconciling first means a retry resends only what is actually
     // missing — and the acks arrive as `duplicate` for anything it does resend,
     // which the mapping already accepts.
-    const reconcileAcks = async (acks) => {
+    // Recording and reporting are separate calls on purpose. Folded together,
+    // the caller cannot tell "the prefix was never written" from "the prefix
+    // was written and the log was not" — and the failing path acts on exactly
+    // that distinction.
+    const recordAcks = async (acks) => {
       // Only a front prefix can be reconciled: the acks are in send order, so
       // acks[i] belongs to candidates[i]. Slicing to the acks' own length is
       // what makes the mapping's positional id check an assertion that this
@@ -2290,15 +2294,17 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
       const ackRecords = validateAckMapping(candidates.slice(0, acks.length), acks);
       const messageAcks = ackRecords.filter((_, index) => candidates[index].sync_axis === "messages");
       const rosterAcks = ackRecords.filter((_, index) => candidates[index].sync_axis === "roster");
-      // The durable write comes before either event. An event sink that throws
-      // between them would otherwise skip the reconcile the acks exist for —
-      // reporting must not be able to cost the recording.
       const [reconciled, rosterReconciled] = await Promise.all([
         messageAcks.length > 0 ? driverCall("reconcile", config, messageAcks) : [],
         rosterAcks.length > 0 ? rosterDriverCall("reconcile", config, rosterAcks) : [],
       ]);
-      await eventCall("push.ack", { acks: ackRecords.map(({ id, server_seq, disposition }) => ({ id, server_seq, disposition })) });
-      await eventCall("push.reconciled", {
+      return { ackRecords, reconciled, rosterReconciled };
+    };
+    // `emit` is the bare eventCall on the success path and note() on the failing
+    // one. Nothing here runs before the write above.
+    const reportAcks = async (emit, { ackRecords, reconciled, rosterReconciled }) => {
+      await emit("push.ack", { acks: ackRecords.map(({ id, server_seq, disposition }) => ({ id, server_seq, disposition })) });
+      await emit("push.reconciled", {
         result: reconciled[0] ?? null,
         roster_result: rosterReconciled[0] ?? null,
       });
@@ -2309,31 +2315,38 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
     } catch (error) {
       const earned = Array.isArray(error?.acks) ? error.acks : [];
       if (earned.length > 0) {
-        // Recovery first, reporting after, and the reporting cannot break
-        // either: an event sink that throws on this path would otherwise skip
-        // the very recording this branch exists for, and surface itself as the
-        // cycle's error in place of the transport failure that caused it.
-        let recorded;
+        // The try covers the durable write and nothing else. Widen it by one
+        // event and a log failure starts arriving here as a write failure —
+        // `push.partial-unrecorded` for a prefix that is on disk, and the next
+        // reader resends what must not be resent. The boundary is the write,
+        // not the function.
+        let written = null;
+        let writeFailure = null;
         try {
-          await reconcileAcks(earned);
-          recorded = null;
-        } catch (reconcileFailure) {
-          recorded = reconcileFailure;
+          written = await recordAcks(earned);
+        } catch (failure) {
+          writeFailure = failure;
           // Neither the rows nor a note of them. Report it, but keep it under
           // the transport error rather than in front of it — that error is the
           // reason any of this happened.
           if (error && typeof error === "object" && error.cause === undefined) {
-            error.cause = reconcileFailure;
+            error.cause = failure;
           }
         }
-        await note(eventCall, "push.partial", { acked: earned.length, of: candidates.length });
-        if (recorded) {
-          await note(eventCall, "push.partial-unrecorded", { reason: recorded.message });
+        // Everything below is reporting, on a path that has already failed, so
+        // none of it may throw: an unwritable log must not replace the
+        // transport error on its way up.
+        const emit = (name, payload) => note(eventCall, name, payload);
+        await emit("push.partial", { acked: earned.length, of: candidates.length });
+        if (written) {
+          await reportAcks(emit, written);
+        } else {
+          await emit("push.partial-unrecorded", { reason: writeFailure.message });
         }
       }
       throw error;
     }
-    await reconcileAcks(posted.acks);
+    await reportAcks(eventCall, await recordAcks(posted.acks));
   }
   // A full push page (and eligible) means at least a full page was available,
   // so the loop treats it as "more remains" and stays in catch-up. An exactly-

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2858,7 +2858,8 @@ test("an event sink that fails costs neither the prefix nor the transport error"
     committed.push(...messages.map((message) => message.id));
     return ack(messages);
   });
-  await assert.rejects(cycle(config, { pushLimit: 100, pullLimit: 1000 }, {
+  const attempted = [];
+  const failed = await cycle(config, { pushLimit: 100, pullLimit: 1000 }, {
     ...harness,
     // Every event reachable once the push has failed throws — the two this
     // change added, and the two that report the reconcile. None of them may sit
@@ -2866,6 +2867,7 @@ test("an event sink that fails costs neither the prefix nor the transport error"
     eventCall: async (name) => {
       if (["push.partial", "push.partial-unrecorded", "push.ack", "push.reconciled"]
         .includes(name)) {
+        attempted.push(name);
         throw new Error("event log is unwritable");
       }
     },
@@ -2876,9 +2878,20 @@ test("an event sink that fails costs neither the prefix nor the transport error"
       }
       return harness.driverCall(operation, driverConfig, input);
     },
-  }), (error) => error.status === 409 && /409 conflict/u.test(error.message));
+  }).then(() => null, (error) => error);
+  assert.ok(failed, "the cycle resolved, so the transport failure was swallowed");
+  assert.equal(failed.status, 409);
+  assert.match(failed.message, /409 conflict/u);
   assert.ok(committed.length > 0, "the first POST stored nothing, so nothing was at risk");
   assert.deepEqual(reconciled, committed);
+  // The write succeeded and only the log failed. Saying "unrecorded" here would
+  // send the next reader to resend a prefix that is already durable, so the
+  // classification is the assertion — a log failure is not a write failure.
+  assert.ok(!attempted.includes("push.partial-unrecorded"),
+    "a durable prefix was reported as unrecorded");
+  assert.equal(failed.cause, undefined, "an event failure took the cause slot");
+  // Reporting was still attempted, in order, after the write.
+  assert.deepEqual(attempted, ["push.partial", "push.ack", "push.reconciled"]);
 });
 
 test("push stops at one message rather than splitting forever, and names it", async () => {

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2750,6 +2750,93 @@ test("push halves on 413 and every message still lands, in order", async () => {
   assert.deepEqual(accepted, candidates.map((c) => c.id)); // all of them, in send order
 });
 
+test("a POST that fails after earlier ones succeeded still records their acks", async () => {
+  // Several POSTs cannot be atomic the way one was: when a later one dies, the
+  // rows the earlier ones stored are committed and their acks are in hand.
+  // Dropping them leaves the client with no record of messages the server holds
+  // — the exact state the split has to keep from happening. Both the failure and
+  // the prefix have to reach the caller.
+  const candidates = Array.from({ length: 8 }, (_unused, index) =>
+    bulkyCandidate(index, 256 * 1024));
+  const committed = [];
+  const reconciled = [];
+  const events = [];
+  let posts = 0;
+  const ack = ackAllFrom({ value: 0 });
+  const harness = pushHarness(candidates, (messages) => {
+    posts += 1;
+    if (posts === 2) {
+      const error = new Error("HTTP 409 conflict");
+      error.status = 409;
+      throw error;
+    }
+    committed.push(...messages.map((message) => message.id));
+    return ack(messages);
+  });
+  const dependencies = {
+    ...harness,
+    eventCall: async (name, payload) => { events.push([name, payload]); },
+    driverCall: async (operation, driverConfig, input) => {
+      if (operation === "reconcile") {
+        reconciled.push(...input.map((record) => record.id));
+        return [{ type: "sync_reconcile_result", count: input.length }];
+      }
+      return harness.driverCall(operation, driverConfig, input);
+    },
+  };
+  await assert.rejects(cycle(config, { pushLimit: 100, pullLimit: 1000 }, dependencies),
+    (error) => error.status === 409);
+  assert.ok(posts > 1, `expected the page to split, got ${posts} POST(s)`);
+  assert.ok(committed.length > 0, "the first POST stored nothing, so nothing was at risk");
+  // What the server kept is exactly what the client wrote down — no more (it
+  // must not claim rows the failed POST never stored) and no less.
+  assert.deepEqual(reconciled, committed);
+  assert.deepEqual(events.filter(([name]) => name === "push.partial")
+    .map(([, payload]) => payload), [{ acked: committed.length, of: candidates.length }]);
+});
+
+test("a half that fails after its sibling succeeded still records the sibling's acks", async () => {
+  // The same loss, one level down: the 413 halving is recursive, so a failure in
+  // the second half discards the first half's acks unless every layer carries
+  // them. Small messages, so the byte budget makes one group and the only split
+  // is the recursive one — this reaches code the batch-level test does not.
+  const candidates = Array.from({ length: 4 }, (_unused, index) => bulkyCandidate(index, 64));
+  const committed = [];
+  const reconciled = [];
+  let refused = false;
+  const ack = ackAllFrom({ value: 0 });
+  const harness = pushHarness(candidates, (messages) => {
+    if (messages.length > 2) { // refuse the whole group once, forcing the halving
+      refused = true;
+      const error = new Error("HTTP 413 request-too-large");
+      error.status = 413;
+      error.body = { protocol_version: 1, server_instance_id: config.server_instance_id,
+        team_id: config.remote_team_id, error: { code: "request-too-large" } };
+      throw error;
+    }
+    if (committed.length > 0) { // the second half, after the first one stored
+      const error = new Error("HTTP 503 unavailable");
+      error.status = 503;
+      throw error;
+    }
+    committed.push(...messages.map((message) => message.id));
+    return ack(messages);
+  });
+  await assert.rejects(cycle(config, { pushLimit: 100, pullLimit: 1000 }, {
+    ...harness,
+    driverCall: async (operation, driverConfig, input) => {
+      if (operation === "reconcile") {
+        reconciled.push(...input.map((record) => record.id));
+        return [{ type: "sync_reconcile_result", count: input.length }];
+      }
+      return harness.driverCall(operation, driverConfig, input);
+    },
+  }), (error) => error.status === 503);
+  assert.ok(refused, "the server never refused, so the recursive halving never ran");
+  assert.deepEqual(reconciled, committed);
+  assert.equal(committed.length, 2);
+});
+
 test("push stops at one message rather than splitting forever, and names it", async () => {
   // A single message the server refuses is a permanent dead end: no batching
   // this client can do will get it across, and every later cycle retries it.

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2837,6 +2837,50 @@ test("a half that fails after its sibling succeeded still records the sibling's 
   assert.equal(committed.length, 2);
 });
 
+test("an event sink that fails costs neither the prefix nor the transport error", async () => {
+  // The recovery must not depend on the reporting. An event log that cannot be
+  // written is a reason to say so, never a reason to skip the durable write the
+  // acks exist for, or to surface itself as the cycle's error in place of the
+  // transport failure that caused it.
+  const candidates = Array.from({ length: 8 }, (_unused, index) =>
+    bulkyCandidate(index, 256 * 1024));
+  const committed = [];
+  const reconciled = [];
+  let posts = 0;
+  const ack = ackAllFrom({ value: 0 });
+  const harness = pushHarness(candidates, (messages) => {
+    posts += 1;
+    if (posts === 2) {
+      const error = new Error("HTTP 409 conflict");
+      error.status = 409;
+      throw error;
+    }
+    committed.push(...messages.map((message) => message.id));
+    return ack(messages);
+  });
+  await assert.rejects(cycle(config, { pushLimit: 100, pullLimit: 1000 }, {
+    ...harness,
+    // Every event reachable once the push has failed throws — the two this
+    // change added, and the two that report the reconcile. None of them may sit
+    // between the acks and the durable write.
+    eventCall: async (name) => {
+      if (["push.partial", "push.partial-unrecorded", "push.ack", "push.reconciled"]
+        .includes(name)) {
+        throw new Error("event log is unwritable");
+      }
+    },
+    driverCall: async (operation, driverConfig, input) => {
+      if (operation === "reconcile") {
+        reconciled.push(...input.map((record) => record.id));
+        return [{ type: "sync_reconcile_result", count: input.length }];
+      }
+      return harness.driverCall(operation, driverConfig, input);
+    },
+  }), (error) => error.status === 409 && /409 conflict/u.test(error.message));
+  assert.ok(committed.length > 0, "the first POST stored nothing, so nothing was at risk");
+  assert.deepEqual(reconciled, committed);
+});
+
 test("push stops at one message rather than splitting forever, and names it", async () => {
   // A single message the server refuses is a permanent dead end: no batching
   // this client can do will get it across, and every later cycle retries it.


### PR DESCRIPTION
## The acks a failed split already earned

#622 sized a push batch in bytes, so a page can now leave as several POSTs. One POST is atomic — the server wraps it in a transaction. Several are not, and the loop threw away everything it had collected the moment a later one failed:

```js
for (const group of groups) { last = await postGroup(...); acks.push(...last.acks) }
```

Those earlier POSTs are committed. Their rows are on the server. Discarding the acks leaves the client with **no record of messages the server holds** — which is the state the split has to avoid producing, not produce.

Measured against `ff1f642`, eight messages that split, second POST dropped:

```
rows the server COMMITTED:   1
acks the client RECONCILED:  0
```

Control, same input, nothing dropped: `8 / 8`.

The recursive 413 halving had the same shape one level down — a failing second half discarded the first half's acks. Both are fixed; both have a test.

## How

The failure carries the prefix. `carryAcks` wraps each attempt, and every layer that concatenates acks concatenates them onto the error too, so the top of the push sees one front prefix however deep the recursion went. The cycle reconciles that prefix, emits `push.partial`, and rethrows. Failure and durable success both reach the caller — neither replaces the other.

## The contract is not relaxed

`validateAckMapping` is unchanged and still called with a candidate list the same length as the acks: `candidates.slice(0, acks.length)`. That slice is what turns its positional id check into the prefix assertion — acks are in send order, so `acks[i]` must be `candidates[i]`, and a gap surfaces as an id mismatch instead of being absorbed. Making the function tolerate short input would have weakened it for the all-succeed path too, where a missing ack is a real defect.

A retry after this resends what was not acked. Anything the server already has comes back `duplicate`, which the mapping accepts — pinned by the existing test `an overlapping resend acks every message SENT, duplicates included`.

## If recording the prefix itself fails

Reported as `push.partial-unrecorded` and attached as the transport error's `cause`. It must not replace the error that started this, or the reason disappears.

## Tests

Two added, both failing against the parent commit — checked by restoring `ff1f642`'s `remote-sync.mjs` and re-running:

```
✖ a POST that fails after earlier ones succeeded still records their acks
✖ a half that fails after its sibling succeeded still records the sibling's acks
```

With the change: `remote_sync_engine` + `roster_sync` + `sync_cipher` **79/79**; `test_remote_sync`, `test_remote_sync_engine`, `test_remote`, `test_jsonl_remote_sync` **114 ok, 0 failures**.

The second test reaches the recursive path specifically: small messages, so the byte budget makes one group and the only split is the 413 halving.

## Why this was not in #622

It was ruled on when #609 was reverted — "the real defect is that a throw in a later group discards the acks collected so far" — and did not make the re-land. This PR is that ruling, on its own.

## What this changes about the contract

**Partial success is now a normal outcome, not an anomaly.** Stating the four points plainly, because a caller reading only the code would not find them:

1. **A push is no longer atomic.** One POST was; several cannot be, and no client-side change recovers that — the server will not span a transaction across requests.
2. **Groups sent before the failure stay committed.** They are not rolled back and must not be assumed absent.
3. **The same state already arose from a network drop**, before any splitting existed. The single-POST shape only made it *look* atomic.
4. **The remainder is not lost.** It stays unpushed locally and goes out on the next cycle; anything the server already holds comes back as a `duplicate` ack. That is the self-repair path, and it is why dropping the prefix — rather than recording it — was the actual harm.

The prefix property is a property of *today's* send order: groups go out sequentially, so acks concatenate front-to-back. The code does not guarantee it, and sending groups in parallel would break it the moment it is tried. That is why the assertion is not optional. It is carried by two checks inside `validateAckMapping`, both reached by passing the slice:

- `acks.length <= candidates.length` — a longer ack list makes the slice shorter than the acks and fails as `incomplete ack mapping`.
- `ack.id === candidates[i].id` at every position — length alone would accept N acks in the wrong order; the id check is the one that matters.
