### PR TITLE
fix(remote): connect no longer calls the server's team name an org

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1120,7 +1120,21 @@ cmd_connect() {
 
   local connection_security="plain"
   [ "$binding_cipher" = "age-v1" ] && connection_security="age-v1 encrypted"
-  echo "Connected: team '$team'${remote_team_name:+ (org '$remote_team_name')} ($connection_security). Sync engine running."
+  # `remote_team_name` is the team's name ON THE SERVER, read out of the connect
+  # response above. That response carries no org — server_instance_id, team_id,
+  # team_name, min_available_seq — so the word "org" named something the server
+  # had never sent. While the two names match it reads as harmless repetition,
+  # which is why it lasted: every test connected a team whose local and remote
+  # names were the same string.
+  #
+  # So it is said only when it is news. Same name, nothing to add; different
+  # name, the operator is told which one the server is using, under a label
+  # that is true.
+  local server_side=""
+  if [ -n "$remote_team_name" ] && [ "$remote_team_name" != "$team" ]; then
+    server_side=" (on the server: '$remote_team_name')"
+  fi
+  echo "Connected: team '$team'$server_side ($connection_security). Sync engine running."
   if [ "$e2ee" -eq 1 ]; then
     echo "Export the public epoch snapshot with: key.sh show $team --snapshot --out <file>"
     echo "Transfer that snapshot and the key out of band; the other machine must import and live-confirm them before syncing."

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -19,6 +19,9 @@ PULL_AGE = os.environ.get("MOCK_PULL_AGE") == "1"
 PULL_AGE_ENVELOPE_FILE = os.environ.get("MOCK_PULL_AGE_ENVELOPE_FILE", "")
 CONNECT_CIPHERS = (["none"] if os.environ.get("MOCK_CONNECT_NO_AGE") == "1"
                    else ["none", "age-v1"])
+# The name /v1/connect answers with. Empty means "echo back what was asked
+# for", which is the real server's behaviour and what every other case wants.
+CONNECT_TEAM_NAME = os.environ.get("MOCK_CONNECT_TEAM_NAME", "")
 
 # POST /v1/connect registers a client-owned team once. No credential is issued
 # or returned — reaching the server is the permission. A team_id already
@@ -409,7 +412,11 @@ class Handler(BaseHTTPRequestHandler):
                 "protocol_version": 1,
                 "server_instance_id": CONNECT_SERVER_ID,
                 "team_id": team_id,
-                "team_name": data.get("team_name", ""),
+                # Normally the server answers with the name it was given, which
+                # is why local and remote names are the same in every other
+                # case here. MOCK_CONNECT_TEAM_NAME makes them differ, so a
+                # test can see which of the two a message is quoting.
+                "team_name": CONNECT_TEAM_NAME or data.get("team_name", ""),
                 "min_available_seq": "0",
                 "current_seq": "0",
                 "next_sequence_boundary": "1",

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -18,6 +18,7 @@ setup() {
   MOCK_PULL_TEAM_ID="${MOCK_PULL_TEAM_ID:-}" \
   MOCK_HEALTH_TEAM_ID="${MOCK_HEALTH_TEAM_ID:-}" \
   MOCK_CONNECT_NO_AGE="${MOCK_CONNECT_NO_AGE:-}" \
+  MOCK_CONNECT_TEAM_NAME="${MOCK_CONNECT_TEAM_NAME:-}" \
     "$MOCK_PYTHON3" "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
     </dev/null > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" 3>&- &
   MOCK_SERVER_PID=$!
@@ -81,6 +82,7 @@ restart_mock_server() {
   MOCK_PULL_TEAM_ID="${MOCK_PULL_TEAM_ID:-}" \
   MOCK_HEALTH_TEAM_ID="${MOCK_HEALTH_TEAM_ID:-}" \
   MOCK_CONNECT_NO_AGE="${MOCK_CONNECT_NO_AGE:-}" \
+  MOCK_CONNECT_TEAM_NAME="${MOCK_CONNECT_TEAM_NAME:-}" \
     "$MOCK_PYTHON3" "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
       </dev/null > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" 3>&- &
   MOCK_SERVER_PID=$!
@@ -180,11 +182,34 @@ skip_if_no_age() {
 @test "connect: registers a client-owned team (happy path, Done-when 1)" {
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Connected: team 'testteam' (org 'testteam') (plain)."* ]]
+  # Same name on both sides — the ordinary case — so the line says it once.
+  [[ "$output" == *"Connected: team 'testteam' (plain)."* ]]
+  [[ "$output" != *"org"* ]]
   # A binding is recorded on the team config, and it carries no credential:
   # the register model writes none and none is fetched back.
   [ "$(sqlite_mem "SELECT json_extract(CAST(readfile('$SCRIPTS/../teams/testteam/config.json') AS TEXT), '\$.remote_binding.connected_at');")" != "" ]
   [ ! -f "$SCRIPTS/../run/remote-credentials/testteam.json" ]
+}
+
+@test "connect: when the server's name differs, it is quoted AS the server's — never as an org" {
+  # Every other connect case here asks for a team whose remote name comes back
+  # identical, so the two names cannot be told apart in the output. That is how
+  # this line spent its life calling the server's TEAM name an "org": while the
+  # strings match, a wrong label reads as a redundant one. Only a differing
+  # pair can see it, so this test makes them differ.
+  MOCK_CONNECT_TEAM_NAME="renamed-upstream"
+  export MOCK_CONNECT_TEAM_NAME
+  teardown
+  setup
+
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  [ "$status" -eq 0 ]
+  # The local name leads; the server's is offered as the server's.
+  [[ "$output" == *"Connected: team 'testteam' (on the server: 'renamed-upstream') (plain)."* ]]
+  # And nothing in this output claims to be an org: the connect response
+  # carries server_instance_id / team_id / team_name / min_available_seq, and
+  # no org at all, so there is nothing here that could honestly be labelled one.
+  [[ "$output" != *"org"* ]]
 }
 
 @test "connect --e2ee generates a key and establishes age-v1 before engine start" {
@@ -192,7 +217,7 @@ skip_if_no_age() {
 
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Connected: team 'testteam' (org 'testteam') (age-v1 encrypted)."* ]]
+  [[ "$output" == *"Connected: team 'testteam' (age-v1 encrypted)."* ]]
   [[ "$output" == *"Back this up now"* ]]
   [[ "$output" == *"key.sh show testteam --snapshot --out <file>"* ]]
   sync_config="$TEST_SKILL_DIR/db/remote-sync/testteam.json"


### PR DESCRIPTION
Found while walking onboarding end to end on a fresh database.

## What it said

```
Connected: team 'design-team' (org 'design-team') (age-v1 encrypted). Sync engine running.
```

The account in that walk is named **Acme Design**. The team is `design-team`.
The value printed under the word "org" is neither — it is `remote_team_name`,
which `scripts/remote.sh` reads out of the `/v1/connect` response, i.e. the
team's name **on the server**.

The response has no org in it. Measured against a live server:

```
$ curl -H 'Agmsg-Protocol-Version: 1' .../v1/teams/<id> | jq 'keys'
["accepted_envelope_versions","current_seq","effective_from_seq","max_blob_bytes",
 "min_available_seq","next_sequence_boundary","policy_history","policy_revision",
 "protocol_version","server_instance_id","team_id","team_name","write_allowed_ciphers"]
```

and the connect handler returns `server_instance_id`, `team_id`, `team_name`,
`min_available_seq` (`server/src/storage.ts`). There is no org to print.

## Why it lasted

Both tests that pinned this line connected a team whose local and remote names
were the same string:

```
[[ "$output" == *"Connected: team 'testteam' (org 'testteam') (plain)."* ]]
```

While the two names match, a wrong label is indistinguishable from a redundant
one. It took connecting a team whose account had a different name to see it.

## The fix

Option (a) — print the real org name — is unavailable, since the response
carries none. So the line stops claiming an org, and says the server's name only
when it is **news**:

```
Connected: team 'testteam' (plain).                                  # names match
Connected: team 'testteam' (on the server: 'renamed-upstream') (plain).  # they differ
```

## Regression

`tests/helpers/mock_remote_server.py` gains `MOCK_CONNECT_TEAM_NAME`, so the
mock can answer with a name other than the one asked for — the state no test
could previously reach. The new case asserts the differing pair is quoted as the
server's, and that the word `org` appears nowhere in that output.

Verified it fails without the fix:

```
$ git stash push -- scripts/remote.sh && bats tests/test_remote.bats -f differs
not ok 1 connect: when the server's name differs, it is quoted AS the server's — never as an org
  `[[ "$output" == *"Connected: team 'testteam' (on the server: 'renamed-upstream') (plain)."* ]]' failed
```

With the fix, the whole file: **66 passed, 0 failed**.