### PR TITLE
docs(skill): machine B needs its own install, not just its own env vars

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -217,14 +217,6 @@ If argument starts with "remote connect":
 
 If argument starts with "remote pull":
 1. When the user asks to join or bring in a team that already exists on a
-
-Machine B needs its own install, not just its own environment variables.
-Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
-`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
-resolve the team config from the install directory. So a pull driven by
-environment variables alone succeeds, and the send that is supposed to confirm
-it then reports the team as missing — the failure lands one step after the
-cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
    server, NEVER use `join.sh`, create a team, or create a same-named local
    team. Always use remote pull.
 2. Before pulling, check for a same-named local team. If one already exists
@@ -234,6 +226,14 @@ cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
    `--team-id <uuid>`.
 4. Run: `bash ~/.agents/skills/agmsg/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
 5. Show the output to the user.
+
+Machine B needs its own install, not just its own environment variables.
+Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
+`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
+resolve the team config from the install directory. So a pull driven by
+environment variables alone succeeds, and the send that is supposed to confirm
+it then reports the team as missing — the failure lands one step after the
+cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
 
 If argument starts with "remote unlock":
 1. Parse `<team>`, `--bundle <file>`, and `--confirm-digest <sha256>`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -217,6 +217,14 @@ If argument starts with "remote connect":
 
 If argument starts with "remote pull":
 1. When the user asks to join or bring in a team that already exists on a
+
+Machine B needs its own install, not just its own environment variables.
+Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
+`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
+resolve the team config from the install directory. So a pull driven by
+environment variables alone succeeds, and the send that is supposed to confirm
+it then reports the team as missing — the failure lands one step after the
+cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
    server, NEVER use `join.sh`, create a team, or create a same-named local
    team. Always use remote pull.
 2. Before pulling, check for a same-named local team. If one already exists

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -168,6 +168,14 @@ If argument starts with "remote pull":
 4. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
 5. Show the output to the user.
 
+Machine B needs its own install, not just its own environment variables.
+Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
+`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
+resolve the team config from the install directory. So a pull driven by
+environment variables alone succeeds, and the send that is supposed to confirm
+it then reports the team as missing — the failure lands one step after the
+cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
+
 If argument starts with "remote unlock":
 1. Parse `<team>`, `--bundle <file>`, and `--confirm-digest <sha256>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --bundle <file> --confirm-digest <sha256>`

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -248,6 +248,14 @@ If argument starts with "remote pull":
 4. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
 5. Show the output to the user.
 
+Machine B needs its own install, not just its own environment variables.
+Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
+`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
+resolve the team config from the install directory. So a pull driven by
+environment variables alone succeeds, and the send that is supposed to confirm
+it then reports the team as missing — the failure lands one step after the
+cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
+
 If argument starts with "remote unlock":
 1. Parse `<team>`, `--bundle <file>`, and `--confirm-digest <sha256>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --bundle <file> --confirm-digest <sha256>`

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -196,6 +196,14 @@ If argument starts with "remote pull":
 4. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
 5. Show the output to the user.
 
+Machine B needs its own install, not just its own environment variables.
+Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
+`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
+resolve the team config from the install directory. So a pull driven by
+environment variables alone succeeds, and the send that is supposed to confirm
+it then reports the team as missing — the failure lands one step after the
+cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
+
 If argument starts with "remote unlock":
 1. Parse `<team>`, `--bundle <file>`, and `--confirm-digest <sha256>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --bundle <file> --confirm-digest <sha256>`

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -168,6 +168,14 @@ If argument starts with "remote pull":
 4. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
 5. Show the output to the user.
 
+Machine B needs its own install, not just its own environment variables.
+Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
+`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
+resolve the team config from the install directory. So a pull driven by
+environment variables alone succeeds, and the send that is supposed to confirm
+it then reports the team as missing — the failure lands one step after the
+cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
+
 If argument starts with "remote unlock":
 1. Parse `<team>`, `--bundle <file>`, and `--confirm-digest <sha256>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --bundle <file> --confirm-digest <sha256>`

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -171,6 +171,14 @@ If argument starts with "remote pull":
 4. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
 5. Show the output to the user.
 
+Machine B needs its own install, not just its own environment variables.
+Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
+`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
+resolve the team config from the install directory. So a pull driven by
+environment variables alone succeeds, and the send that is supposed to confirm
+it then reports the team as missing — the failure lands one step after the
+cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
+
 If argument starts with "remote unlock":
 1. Parse `<team>`, `--bundle <file>`, and `--confirm-digest <sha256>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --bundle <file> --confirm-digest <sha256>`

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -168,6 +168,14 @@ If argument starts with "remote pull":
 4. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
 5. Show the output to the user.
 
+Machine B needs its own install, not just its own environment variables.
+Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
+`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
+resolve the team config from the install directory. So a pull driven by
+environment variables alone succeeds, and the send that is supposed to confirm
+it then reports the team as missing — the failure lands one step after the
+cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
+
 If argument starts with "remote unlock":
 1. Parse `<team>`, `--bundle <file>`, and `--confirm-digest <sha256>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --bundle <file> --confirm-digest <sha256>`

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -199,6 +199,14 @@ If argument starts with "remote pull":
 4. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
 5. Show the output to the user.
 
+Machine B needs its own install, not just its own environment variables.
+Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
+`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
+resolve the team config from the install directory. So a pull driven by
+environment variables alone succeeds, and the send that is supposed to confirm
+it then reports the team as missing — the failure lands one step after the
+cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
+
 If argument starts with "remote unlock":
 1. Parse `<team>`, `--bundle <file>`, and `--confirm-digest <sha256>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --bundle <file> --confirm-digest <sha256>`

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -156,6 +156,14 @@ If argument starts with "remote pull":
 4. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
 5. Show the output to the user.
 
+Machine B needs its own install, not just its own environment variables.
+Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
+`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
+resolve the team config from the install directory. So a pull driven by
+environment variables alone succeeds, and the send that is supposed to confirm
+it then reports the team as missing — the failure lands one step after the
+cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
+
 If argument starts with "remote unlock":
 1. Parse `<team>`, `--bundle <file>`, and `--confirm-digest <sha256>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --bundle <file> --confirm-digest <sha256>`

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -171,6 +171,14 @@ If argument starts with "remote pull":
 4. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
 5. Show the output to the user.
 
+Machine B needs its own install, not just its own environment variables.
+Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
+`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
+resolve the team config from the install directory. So a pull driven by
+environment variables alone succeeds, and the send that is supposed to confirm
+it then reports the team as missing — the failure lands one step after the
+cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
+
 If argument starts with "remote unlock":
 1. Parse `<team>`, `--bundle <file>`, and `--confirm-digest <sha256>`.
 2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --bundle <file> --confirm-digest <sha256>`


### PR DESCRIPTION
The remote-pull instruction tells an agent how to bring a server-side team onto a second machine, and stops there. Splitting a second machine off with `AGMSG_SYNC_CONNECTION_DIR` alone gets through that pull and fails on the step after it: only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read that variable, while `send.sh`, `history.sh`, `team.sh` and `inbox.sh` take the team config from the install directory. The pull lands in one place and the confirming send looks in another, so the error says the team is missing and points at the send.

`docs/remote-setup.md` already carries the file-by-file account, added alongside the same finding. What was absent is a pointer from the place an agent is reading when it makes the choice.

That is why this goes into the nine per-type templates and not only `SKILL.md`: `install.sh` renders the per-type template over `SKILL.md` in the user's install, so the repo copy is not the file an agent ends up reading. Adding it in one place would have left it out of every environment where it matters.

Neither document was wrong. They were both right and not connected — the pull instruction never mentioned the constraint, and the constraint lived somewhere an agent following the pull instruction has no reason to open.