### PR TITLE
fix(codex): close inherited descriptors by range, not by name

### DIFF
--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -183,16 +183,27 @@ EOF
   fi
   local storage_dir
   storage_dir="$(agmsg_storage_dir)"
-  nohup "${bridge_run[@]}" \
-    --project "$PROJECT" \
-    --workspace-root "$storage_dir" \
-    --workspace-root "$SKILL_DIR/teams" \
-    --workspace-root "$SKILL_DIR/run" \
-    --type "$TYPE" \
-    "${bridge_pairs[@]}" \
-    --thread "$thread_id" \
-    --app-server "$app_server" \
-    --inline-inbox \
-    >>"$log" 2>&1 3>&- 4>&- &
+  # The bridge outlives this hook, so it must not carry the harness's
+  # descriptors — the same leak that hung a macOS CI shard from the launcher.
+  #
+  # This file is SOURCED into session-start.sh's global context, so calling the
+  # close here directly would shut descriptors belonging to the shell that
+  # sourced us. The subshell is what makes it safe: the close applies to the
+  # forked child, which is the process that goes on to become the bridge, and
+  # the parent keeps everything it had (review P1, co1).
+  (
+    agmsg_close_inherited_fds
+    nohup "${bridge_run[@]}" \
+      --project "$PROJECT" \
+      --workspace-root "$storage_dir" \
+      --workspace-root "$SKILL_DIR/teams" \
+      --workspace-root "$SKILL_DIR/run" \
+      --type "$TYPE" \
+      "${bridge_pairs[@]}" \
+      --thread "$thread_id" \
+      --app-server "$app_server" \
+      --inline-inbox \
+      >>"$log" 2>&1 &
+  )
   exit 0
 }

--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -191,6 +191,12 @@ EOF
   # sourced us. The subshell is what makes it safe: the close applies to the
   # forked child, which is the process that goes on to become the bridge, and
   # the parent keeps everything it had (review P1, co1).
+  #
+  # The `3>&- 4>&-` stays on the spawn line as well. test_spawn_fd_guard.bats
+  # requires it there and says why: a file-level close can sit inside a
+  # function, inside a branch that never runs, or after the spawn it is meant
+  # to cover, so the guard is checked per line and the redundancy is deliberate.
+  # The subshell close is the part that reaches the descriptors bats numbered.
   (
     agmsg_close_inherited_fds
     nohup "${bridge_run[@]}" \
@@ -203,7 +209,7 @@ EOF
       --thread "$thread_id" \
       --app-server "$app_server" \
       --inline-inbox \
-      >>"$log" 2>&1 &
+      >>"$log" 2>&1 3>&- 4>&- &
   )
   exit 0
 }

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 # The launcher is detached from codex-monitor.sh and may outlive the shell that
 # invoked it. Never retain test-harness result/trace descriptors through the
 # dispatcher -> role child -> bridge process chain.
+#
+# 3 and 4 are closed here, as early as the script can, and then EVERY inherited
+# descriptor is closed once lib/close-fds.sh is reachable (just below). Naming
+# the two we expect is not enough: the harness picks the number, and a bridge
+# that kept it hung a macOS CI shard for 25 minutes with every test already
+# green. See scripts/lib/close-fds.sh.
 exec 3>&- 4>&-
 
 # Runs outside Codex's tool sandbox and owns the app-server connections. The
@@ -24,6 +30,12 @@ ROLE_PAIR="${5:-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 RUN_DIR="$SKILL_DIR/run"
+# Before anything long-lived is spawned. Nothing above forks a process that
+# outlives this script, so closing here is as good as closing at line 1 — and
+# it is the earliest point at which lib/ is resolvable.
+# shellcheck source=../../../lib/close-fds.sh
+source "$SCRIPT_DIR/../../../lib/close-fds.sh"
+agmsg_close_inherited_fds
 # shellcheck source=../../../lib/hash.sh
 source "$SCRIPT_DIR/../../../lib/hash.sh"
 PROJECT_HASH="$(printf '%s' "$PROJECT" | agmsg_sha1)"

--- a/scripts/drivers/types/codex/codex-monitor.sh
+++ b/scripts/drivers/types/codex/codex-monitor.sh
@@ -10,6 +10,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 RUN_DIR="$SKILL_DIR/run"
+# This starts the codex app-server and the bridge launcher, both of which
+# outlive it. The `3>&- 4>&-` on those spawn lines closes the two descriptors
+# we can name; the harness's is not one of them. See lib/close-fds.sh.
+# shellcheck source=../../../lib/close-fds.sh
+source "$SCRIPT_DIR/../../../lib/close-fds.sh"
+agmsg_close_inherited_fds
 # shellcheck source=../../../lib/hash.sh
 source "$SCRIPT_DIR/../../../lib/hash.sh"
 # shellcheck source=../../../lib/compat.sh

--- a/scripts/lib/close-fds.sh
+++ b/scripts/lib/close-fds.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Close every inherited descriptor above stderr, before spawning something that
+# outlives the shell that started it.
+#
+# WHY BY RANGE AND NOT BY NAME. A long-lived child keeps whatever it inherits
+# for as long as it runs. Under bats that includes a descriptor internal to the
+# harness, and the harness then waits for an EOF that cannot arrive: the shard
+# runs to the CI job's cap with every test already reported ok. Observed twice
+# on the same head, ~25 minutes each, with `Terminate orphan process: (node)`
+# at cleanup.
+#
+# `exec 3>&- 4>&-` cannot reach it. The harness chooses the number — 13, 143 and
+# 144 have all been seen — so the close has to enumerate what is actually open
+# rather than name the two descriptors we expect.
+#
+# EACH CLOSE IS ITS OWN STATEMENT, deliberately. Collecting them into
+# redirections on an `exec` reads better and is wrong: bash 3.2 — /bin/bash on
+# macOS, and what runs this on the macOS runner — relocates descriptors into the
+# range at and above 10 while it processes an exec's redirections, and the child
+# inherits those relocated copies. Measured, same enumeration both times:
+#
+#   bash 5.3.15   child sees  0 1 2
+#   bash 3.2.57   child sees  0 1 2 10 11      <- 143 came back as 11
+#
+# Closing 255 (where bash keeps the script it is reading) is safe: bash moves
+# the script elsewhere when asked to close it, and a 291 KB script still ran to
+# its last line under both 3.2.57 and 5.3.15. Do not "simplify" this onto an
+# exec line.
+#
+# This lives in lib/ because more than one spawn path needs it, and the first
+# time it was written it lived in only one of them — remote-sync.sh had the
+# range close while codex-bridge-launcher.sh still closed 3 and 4 by name, so
+# the bridge kept holding the harness pipe and hung the shard.
+agmsg_close_inherited_fds() {
+  local fd
+  if [ -d /dev/fd ]; then
+    for fd in /dev/fd/*; do
+      fd="${fd##*/}"
+      case "$fd" in '' | *[!0-9]*) continue ;; esac
+      [ "$fd" -gt 2 ] || continue
+      eval "exec ${fd}>&-" 2>/dev/null || true
+    done
+  else
+    # Nothing to enumerate, so sweep a range instead. Closing a descriptor that
+    # was never open is not an error, which is what makes the blind form safe.
+    for fd in $(seq 3 255); do
+      eval "exec ${fd}>&-" 2>/dev/null || true
+    done
+  fi
+}

--- a/scripts/remote-sync.sh
+++ b/scripts/remote-sync.sh
@@ -16,57 +16,13 @@ NODE_BIN="$(agmsg_resolve_node)"
 export AGMSG_SYNC_NODE_BIN="$NODE_BIN"
 export AGMSG_SYNC_CIPHER_HELPER="$SCRIPT_DIR/internal/sync-cipher.mjs"
 # The engine outlives the command that starts it, so whatever it inherits it
-# holds for as long as it runs. Under bats that included fd 144 -- a descriptor
-# internal to the harness -- and the shard then ran to the CI job's cap with
-# every test already reported ok, because bats was waiting for an EOF the engine
-# was keeping from arriving. Captured directly: the engine and three bats
-# processes all held the same pipe, 0xc9aea28a590ca110, at fd 144.
-#
-# Closing 3 and 4 by name at the spawn sites, which is what this repo did until
-# now, cannot reach a descriptor whose number the harness chooses. So the close
-# is by range, not by name, and it lives here -- the one place every engine
-# invocation passes through -- rather than at each caller.
-#
-# The engine speaks only over stdin, stdout and stderr; the spawn sites already
-# point those at a log. Nothing above stderr is anything it should keep.
-#
-# Each close is its own statement. Collecting them into redirections on the exec
-# reads better and is wrong: bash 3.2 -- which is /bin/bash on macOS, and what
-# runs this on the macOS runner -- relocates descriptors into the range at and
-# above 10 while it processes an exec's redirections, and the child then inherits
-# those relocated copies. Measured, same script, same enumeration
-# (`10>&- 143>&- 255>&- 3>&-`) both times:
-#
-#   bash 5.3.15   engine sees  0 1 2
-#   bash 3.2.57   engine sees  0 1 2 10 11      <- 143 came back as 11
-#
-# A CI shard hung on exactly that: the engine held bats's pipe at fd 13 while
-# bats held it at 143, and bats sat waiting for an EOF that could not arrive.
-#
-# The hazard that argued for the exec form does not bite. One descriptor above
-# stderr belongs to the shell -- bash keeps the script it is reading open, at 255
-# -- and closing it from a statement might have left the shell reading through a
-# descriptor it had given up. Bash defends itself: given `exec 255>&-` it moves
-# the script to another number (observed as 11), and a script padded to 291 KB,
-# far past any read buffer, still ran to its last line under both 3.2.57 and
-# 5.3.15. Do not "simplify" this back onto the exec line.
-_close_inherited_fds() {
-  local fd
-  if [ -d /dev/fd ]; then
-    for fd in /dev/fd/*; do
-      fd="${fd##*/}"
-      case "$fd" in ''|*[!0-9]*) continue ;; esac
-      [ "$fd" -gt 2 ] || continue
-      eval "exec ${fd}>&-" 2>/dev/null || true
-    done
-  else
-    # Nothing to enumerate, so sweep a range instead. Closing a descriptor that
-    # was never open is not an error, which is what makes the blind form safe.
-    for fd in $(seq 3 255); do
-      eval "exec ${fd}>&-" 2>/dev/null || true
-    done
-  fi
-}
-_close_inherited_fds
+# holds for as long as it runs — including a descriptor internal to bats,
+# which then waits for an EOF that cannot arrive. Closing 3 and 4 by name
+# cannot reach it, because the harness picks the number.
+# The range close and the reasoning behind it now live in lib/close-fds.sh,
+# because codex-bridge-launcher.sh needs exactly the same thing and had the
+# insufficient by-name form until a macOS shard hung on it.
+. "$SCRIPT_DIR/lib/close-fds.sh"
+agmsg_close_inherited_fds
 
 exec "$NODE_BIN" "$SCRIPT_DIR/internal/remote-sync.mjs" "$@"

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -46,6 +46,10 @@ source "$SCRIPT_DIR/lib/storage.sh"
 source "$SCRIPT_DIR/lib/type-registry.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/role-session.sh"  # role->session reverse lookup (#339)
+# Only DEFINES agmsg_close_inherited_fds; nothing is closed here. The type
+# plug calls it inside a subshell around its own long-lived spawn, so this
+# shell's descriptors are untouched. See lib/close-fds.sh.
+source "$SCRIPT_DIR/lib/close-fds.sh"
 
 # Identity sanity check — no point launching a watcher with an empty pair set.
 PAIRS=$("$SCRIPT_DIR/identities.sh" "$PROJECT" "$TYPE" 2>/dev/null || true)

--- a/tests/test_close_fds.bats
+++ b/tests/test_close_fds.bats
@@ -73,14 +73,21 @@ setup() {
   [[ "$output" =~ "CLOSED" ]]
 }
 
-# Both spawn paths must use it. This is a source check on purpose — it is not
-# asserting behaviour, it is asserting that neither caller was left behind, and
-# being left behind is exactly how the bridge came to hang a shard while the
-# engine was already fixed.
+# Every long-lived spawn path must use it. A source check on purpose: it is not
+# asserting behaviour, it is asserting that no caller was left behind, and being
+# left behind is exactly how the bridge came to hang a shard while the engine
+# was already fixed.
+#
+# NOT listed, deliberately: scripts/drivers/types/codex/_session-start.sh. It
+# spawns a long-lived child the same way, but it is SOURCED into
+# session-start.sh's global context, so calling this there would close the
+# descriptors of the shell that sourced it rather than of a process about to
+# exec. It needs a different treatment and has not had one.
 @test "close-fds: every long-lived spawn path calls it" {
   for f in \
     "$BATS_TEST_DIRNAME/../scripts/remote-sync.sh" \
-    "$BATS_TEST_DIRNAME/../scripts/drivers/types/codex/codex-bridge-launcher.sh"
+    "$BATS_TEST_DIRNAME/../scripts/drivers/types/codex/codex-bridge-launcher.sh" \
+    "$BATS_TEST_DIRNAME/../scripts/drivers/types/codex/codex-monitor.sh"
   do
     grep -q 'agmsg_close_inherited_fds' "$f" || {
       echo "no fd close in $f"

--- a/tests/test_close_fds.bats
+++ b/tests/test_close_fds.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+# A long-lived child must not inherit descriptors above stderr.
+#
+# The failure this guards is silent and expensive: bats hands its result and
+# trace descriptors to whatever it runs, a spawned engine or bridge keeps them
+# for as long as it lives, and bats then waits for an EOF that cannot arrive.
+# Every test reports ok and the CI shard runs to the job cap — observed twice on
+# one head, ~25 minutes each, with `Terminate orphan process: (node)` at
+# cleanup. Nothing in the test output says what happened.
+#
+# Asserted on what the child SEES, not on the source of the launcher. A grep for
+# `agmsg_close_inherited_fds` would pass on a script that calls it too late, or
+# after it has already forked.
+
+LIB="$BATS_TEST_DIRNAME/../scripts/lib/close-fds.sh"
+
+# Descriptors a child can see, one per line. Uses /dev/fd, the same enumeration
+# the implementation uses, so a platform without it skips rather than lies.
+fds_visible_to_child() {
+  ls /dev/fd 2>/dev/null | sort -n
+}
+
+setup() {
+  [ -d /dev/fd ] || skip "/dev/fd is not available on this platform"
+}
+
+# THE HAZARD, shown first: run under bats, a plain child already inherits
+# descriptors nobody opened. Measured here rather than asserted from the code —
+# on this harness the baseline is `0 1 2 3 4 5 6`, and 5 and 6 are bats's own.
+# Those are what a bridge or engine would hold for its whole life.
+#
+# 3 and 4 belong to the measurement itself (the command-substitution pipe and
+# the directory handle), which is why the check below is "nothing above 4"
+# rather than a fixed list — the first version of this test asserted 3 and 4
+# were absent and failed against a correct implementation.
+@test "close-fds: under bats, a child does inherit the harness's descriptors" {
+  run bash -c 'ls /dev/fd | sort -n | tr "\n" " "'
+  [ "$status" -eq 0 ]
+  local leaked=0
+  for fd in $output; do
+    [ "$fd" -gt 4 ] && leaked=1
+  done
+  [ "$leaked" -eq 1 ] || skip "this harness leaks nothing; the guard cannot be demonstrated here"
+}
+
+@test "close-fds: after the close, the child sees nothing above stderr" {
+  run bash -c '
+    . "'"$LIB"'"
+    exec 13>/dev/null 143>/dev/null
+    agmsg_close_inherited_fds
+    ls /dev/fd | sort -n | tr "\n" " "
+  '
+  [ "$status" -eq 0 ]
+  # Everything bats handed down, and everything opened above, is gone. Only the
+  # measurement's own descriptors remain.
+  for fd in $output; do
+    [ "$fd" -le 4 ]
+  done
+}
+
+# The regression that actually bit: closing by name leaves the harness's own
+# descriptor open. This fails against `exec 3>&- 4>&-` and passes against the
+# range close, which is the whole point of the change.
+@test "close-fds: a descriptor the harness chose is closed too" {
+  run bash -c '
+    . "'"$LIB"'"
+    exec 143>/dev/null
+    agmsg_close_inherited_fds
+    if [ -e /dev/fd/143 ]; then echo LEAKED; else echo CLOSED; fi
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "CLOSED" ]]
+}
+
+# Both spawn paths must use it. This is a source check on purpose — it is not
+# asserting behaviour, it is asserting that neither caller was left behind, and
+# being left behind is exactly how the bridge came to hang a shard while the
+# engine was already fixed.
+@test "close-fds: every long-lived spawn path calls it" {
+  for f in \
+    "$BATS_TEST_DIRNAME/../scripts/remote-sync.sh" \
+    "$BATS_TEST_DIRNAME/../scripts/drivers/types/codex/codex-bridge-launcher.sh"
+  do
+    grep -q 'agmsg_close_inherited_fds' "$f" || {
+      echo "no fd close in $f"
+      false
+    }
+  done
+}

--- a/tests/test_close_fds.bats
+++ b/tests/test_close_fds.bats
@@ -78,16 +78,19 @@ setup() {
 # left behind is exactly how the bridge came to hang a shard while the engine
 # was already fixed.
 #
-# NOT listed, deliberately: scripts/drivers/types/codex/_session-start.sh. It
-# spawns a long-lived child the same way, but it is SOURCED into
-# session-start.sh's global context, so calling this there would close the
-# descriptors of the shell that sourced it rather than of a process about to
-# exec. It needs a different treatment and has not had one.
+# _session-start.sh is on this list even though it is SOURCED rather than run.
+# It was left off at first, on the reasoning that calling the helper there would
+# close the sourcing shell's descriptors — true, and not a reason to leave the
+# leak: wrapping only the spawn in a subshell closes the child's copies and
+# leaves the parent's alone (review P1, co1). "This one is different" is where
+# an exclusion list goes wrong, so the list is now every path, with no
+# exceptions to audit.
 @test "close-fds: every long-lived spawn path calls it" {
   for f in \
     "$BATS_TEST_DIRNAME/../scripts/remote-sync.sh" \
     "$BATS_TEST_DIRNAME/../scripts/drivers/types/codex/codex-bridge-launcher.sh" \
-    "$BATS_TEST_DIRNAME/../scripts/drivers/types/codex/codex-monitor.sh"
+    "$BATS_TEST_DIRNAME/../scripts/drivers/types/codex/codex-monitor.sh" \
+    "$BATS_TEST_DIRNAME/../scripts/drivers/types/codex/_session-start.sh"
   do
     grep -q 'agmsg_close_inherited_fds' "$f" || {
       echo "no fd close in $f"


### PR DESCRIPTION
Found while triaging #574, whose CI had been red since 7/31. The red was not that PR's content.

## What was happening

A macOS bats shard hung twice on the same head, and the timing is the tell:

| attempt | shard `macos-latest 4/4` | duration |
| --- | --- | --- |
| 1 | CANCELLED | 25m 18s |
| 2 | success | 5m 31s |
| 3 | CANCELLED | 25m 19s |

Two cancellations, both at the job cap, seconds apart in duration. Random noise does not do that.

**The suite was not failing.** Both the passing and the hanging runs reached `ok 269`, which is the shard's *last* test. The hang is entirely in teardown:

```
02:47:08  ok 269 Stage-1 sync engine protocol and security boundaries
          (21 minutes, no output)
03:08:49  Terminate orphan process: pid (67171) (node)
03:08:51  cancelled
```

## The cause was already written down

`scripts/remote-sync.sh` explains this exact failure in its own comments:

> the shard then ran to the CI job's cap **with every test already reported ok**, because bats was waiting for an EOF the engine was keeping from arriving

and:

> Closing 3 and 4 by name at the spawn sites, which is what this repo did until now, **cannot reach a descriptor whose number the harness chooses.**

The engine got the range-based close. `codex-bridge-launcher.sh` — which `nohup`s a bridge that lives as long as its parent — still had `exec 3>&- 4>&-`. `tests/test_codex_shim.bats` runs in that shard.

## Measured, not inferred

Under bats on this machine, a plain child inherits descriptors nobody opened:

```
baseline under bats:  0 1 2 3 4 5 6      <- 5 and 6 are the harness's
after the range close: 0 1 2 3 4          <- only the measurement's own
```

## The change

The implementation moves to `scripts/lib/close-fds.sh`, used by both spawn paths. **Two copies is how this happened**: the reasoning was written once, applied once, and the other path kept the very form that comment had just finished explaining was insufficient.

## Tests

They assert what a child **sees**, not that the call exists — a call made too late, or after a fork, would satisfy a grep. They also pin the hazard itself (that the harness does leak descriptors), so an implementation that silently did nothing could not pass by comparing a baseline against itself. Reverting to the by-name form turns two of them red.

One source-level check is deliberate: both spawn paths must call it. That one is not about behaviour, it is about neither being left behind a second time.

`test_close_fds` 4/4, and `test_remote_sync_engine` / `test_codex_shim` / `test_spawn_options` / `test_dispatch` all still pass locally.

## Effect on #574

#574 stays unlanded and untouched. If this is the cause, its CI should stop hanging; if it still hangs, the diagnosis was incomplete and I will say so.