### PR TITLE
fix(sync): carry the team's declared cipher instead of inferring it from arrivals

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -296,12 +296,12 @@ export async function loadConfig(team) {
   const selectedCipher = binding.cipher_profile ?? "none";
   // "unknown" is what `pull` writes when the server holds no declaration for
   // the team. It is refused separately from a garbled value because the remedy
-  // differs and is knowable: reconnect the machine that already has the team,
-  // which records the declaration for everyone. Starting the engine on a guess
-  // is the failure this path exists to remove.
+  // differs and is knowable: the setting is recorded the next time the machine
+  // that already has the team sends to it. Starting the engine on a guess is
+  // the failure this path exists to remove.
   if (selectedCipher === "unknown") {
     throw new Error(
-      "the encryption setting for this team is not known to the server; reconnect the machine that already has it");
+      "the encryption setting for this team is not known to the server; it is recorded when the machine that already has the team next sends a message, after which pull the team here again");
   }
   if (!["none", "age-v1"].includes(selectedCipher)) {
     throw new Error("connected team binding selects an unsupported cipher profile");

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -294,6 +294,15 @@ async function readStoredSyncConfig(team) {
 export async function loadConfig(team) {
   const binding = await readConnectedBinding(team);
   const selectedCipher = binding.cipher_profile ?? "none";
+  // "unknown" is what `pull` writes when the server holds no declaration for
+  // the team. It is refused separately from a garbled value because the remedy
+  // differs and is knowable: reconnect the machine that already has the team,
+  // which records the declaration for everyone. Starting the engine on a guess
+  // is the failure this path exists to remove.
+  if (selectedCipher === "unknown") {
+    throw new Error(
+      "the encryption setting for this team is not known to the server; reconnect the machine that already has it");
+  }
   if (!["none", "age-v1"].includes(selectedCipher)) {
     throw new Error("connected team binding selects an unsupported cipher profile");
   }

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -470,7 +470,7 @@ cmd_pull() {
   _remote_write_pulled_team "$team" "$team_id" || exit 1
 
   local result pulled_id pulled_name imported pulled_sid pulled_protocol pulled_caps \
-    pulled_age_v1 binding_cipher
+    pulled_age_v1 pulled_cipher binding_cipher
   result="$(AGMSG_SYNC_CONNECTION_DIR="$CONNECTION_ROOT" \
     AGMSG_SYNC_LOCAL_ROSTER_FILE="$cfg" \
     "$SCRIPT_DIR/remote-sync.sh" pull-bootstrap \
@@ -490,8 +490,24 @@ cmd_pull() {
     echo "agmsg: server answered with a different team id" >&2; exit 1; }
   case "$pulled_age_v1" in ''|*[!0-9]*)
     echo "agmsg: pull returned an invalid encrypted-envelope count" >&2; exit 1 ;; esac
-  binding_cipher="none"
-  [ "$pulled_age_v1" -gt 0 ] && binding_cipher="age-v1"
+
+  # The team's cipher is a DECLARED fact, taken from the server's snapshot —
+  # not inferred from how many encrypted envelopes this pull happened to carry.
+  # The old inference read a team with no messages yet as unencrypted, wrote
+  # 'none' into the binding, and `unlock` then refused a team that was in fact
+  # sealed. Counting arrivals answers "what has been sent", never "what this
+  # team uses".
+  #
+  # An empty answer means no machine has declared it (a team connected before
+  # the declaration was carried). That is recorded as unknown rather than
+  # collapsed into 'none': the two are different facts, and only one of them is
+  # safe to act on.
+  pulled_cipher="$(_remote_json_field "$result" '$.capabilities.cipher_profile')"
+  case "$pulled_cipher" in
+    age-v1|none) binding_cipher="$pulled_cipher" ;;
+    ''|null)     binding_cipher="unknown" ;;
+    *) echo "agmsg: server declared an unsupported cipher profile" >&2; exit 1 ;;
+  esac
 
   # Bind AFTER the bootstrap, and by updating the config in place: the roster
   # driver has been projecting identity events into this file while the
@@ -596,6 +612,24 @@ cmd_unlock() {
   cfg="$(_remote_team_config "$team")"
   [ -f "$cfg" ] || { echo "agmsg: team not found: $team" >&2; exit 1; }
   binding_cipher="$(_remote_read_config_field "$cfg" '$.remote_binding.cipher_profile')"
+  # "Unknown" is a distinct answer from "not encrypted", and it has a distinct
+  # remedy, so it gets its own message. Refusing with the plain-team wording
+  # would send someone looking for a mistake they did not make: their team may
+  # well be sealed — nobody has told this server which.
+  if [ "$binding_cipher" = "unknown" ]; then
+    cat >&2 <<EOF
+agmsg: the encryption setting for '$team' is not known to the server, so this
+machine cannot tell a sealed history from an empty one and will not guess.
+
+The machine that already has '$team' knows. Reconnect it once, which records
+the declaration for everyone:
+
+    remote.sh connect --endpoint <endpoint> --e2ee $team
+
+Then run this unlock again.
+EOF
+    exit 1
+  fi
   [ "$binding_cipher" = "age-v1" ] || {
     echo "agmsg: team '$team' is not an encrypted pulled team awaiting unlock" >&2
     exit 1
@@ -1023,9 +1057,14 @@ cmd_connect() {
   # would abort under `set -u`.
   trap 'rm -f "${body_file:-}" "${resp_file:-}" "${header_file:-}"' EXIT INT TERM
 
+  # `cipher_profile` is this machine's DECLARATION, decided above from --e2ee —
+  # not a guess. Sending it is what lets a second machine be told what the team
+  # uses instead of inferring it from how many encrypted messages happen to have
+  # arrived, which reads an empty team as an unencrypted one.
   agmsg_sqlite_mem "SELECT json_object(
       'team_id', json_extract('$cfg_escaped', '\$.team_id'),
       'team_name', json_extract('$cfg_escaped', '\$.name'),
+      'cipher_profile', '$binding_cipher',
       'members', coalesce(
         (SELECT json_group_array(json_object(
             'member_id', json_extract(value, '\$.member_id'),

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -621,12 +621,13 @@ cmd_unlock() {
 agmsg: the encryption setting for '$team' is not known to the server, so this
 machine cannot tell a sealed history from an empty one and will not guess.
 
-The machine that already has '$team' knows. Reconnect it once, which records
-the declaration for everyone:
+The team was connected before that setting was carried. It is recorded the next
+time the machine that already has '$team' sends to it — one ordinary message is
+enough:
 
-    remote.sh connect --endpoint <endpoint> --e2ee $team
+    send.sh $team <an-agent-there> <another-agent> "hello"
 
-Then run this unlock again.
+Then pull '$team' here again and run this unlock.
 EOF
     exit 1
   fi

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -21,6 +21,22 @@ CREATE TABLE IF NOT EXISTS teams (
 ALTER TABLE teams ALTER COLUMN write_allowed_ciphers
   SET DEFAULT ARRAY['none', 'age-v1']::TEXT[];
 
+-- What this team actually uses, as DECLARED by the machine that connected it.
+-- `write_allowed_ciphers` above is a different thing: it is what the server
+-- will ACCEPT. A team may be allowed both and use one, so the allowed set can
+-- never answer "is this team encrypted" — which is exactly what a second
+-- machine must know to tell a sealed history from an empty one.
+--
+-- NULLABLE ON PURPOSE, and with no default. NULL means "connected before the
+-- declaration was carried, and nobody has said yet". The server cannot fill it
+-- in: it never stored the answer, and inferring it from messages.cipher would
+-- be the same guess this column replaces — a team with no messages would be
+-- declared unencrypted. It is filled the next time a machine that knows
+-- connects. A default of 'none' would turn every one of those into a
+-- confident, wrong statement that nobody could later tell from a real one.
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS cipher_profile TEXT
+  CHECK (cipher_profile IN ('none', 'age-v1'));
+
 -- Name lookup is an equality probe from an unauthenticated route, so it must
 -- not be a sequential scan over every team.
 CREATE INDEX IF NOT EXISTS teams_name_idx ON teams(team_name);

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -28,12 +28,17 @@ ALTER TABLE teams ALTER COLUMN write_allowed_ciphers
 -- machine must know to tell a sealed history from an empty one.
 --
 -- NULLABLE ON PURPOSE, and with no default. NULL means "connected before the
--- declaration was carried, and nobody has said yet". The server cannot fill it
--- in: it never stored the answer, and inferring it from messages.cipher would
--- be the same guess this column replaces — a team with no messages would be
--- declared unencrypted. It is filled the next time a machine that knows
--- connects. A default of 'none' would turn every one of those into a
--- confident, wrong statement that nobody could later tell from a real one.
+-- declaration was carried, and nobody has said yet". Migration cannot fill it:
+-- the server never stored the answer, and deriving one from messages.cipher at
+-- migration time would be the same guess this column replaces — a team with no
+-- messages would be declared unencrypted. A default of 'none' would turn every
+-- such row into a confident, wrong statement no later reader could tell from a
+-- real declaration.
+--
+-- It is settled instead when the team next stores a message, from that
+-- message's own cipher (see postMessages). NOT by a repeat connect: that route
+-- carries no credential and deliberately writes nothing about a team that
+-- already exists.
 ALTER TABLE teams ADD COLUMN IF NOT EXISTS cipher_profile TEXT
   CHECK (cipher_profile IN ('none', 'age-v1'));
 

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -187,6 +187,14 @@ export const connectSchema = z
     team_id: uuidV7Schema,
     team_name: teamNameSchema,
     members: z.array(connectMemberSchema).max(1000),
+    // What this team uses — the connecting machine's own declaration, not a
+    // guess. Optional so a client that predates it still connects; the team is
+    // then recorded with no declaration rather than a wrong one.
+    //
+    // Not a secret: naming a cipher profile reveals nothing about the plaintext,
+    // and the server already sees the per-envelope `cipher` on every message it
+    // stores. What it could not see is a team that has sent none yet.
+    cipher_profile: z.enum(["none", "age-v1"]).optional(),
   })
   .strict()
   .superRefine((value, context) => {

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -305,11 +305,21 @@ export async function postMessages(
       // `IS NULL` only: a declaration, once made, is never rewritten by later
       // traffic — a team that switches profile changes it by declaring, not by
       // sending.
-      await client.query(
-        `UPDATE teams SET cipher_profile = $2
-          WHERE team_id = $1 AND cipher_profile IS NULL`,
-        [teamId, fresh[0]!.envelope.cipher],
-      );
+      //
+      // And only when this batch AGREES with itself. The policy allows both
+      // ciphers, so a single batch may legitimately carry a mix; taking the
+      // first message would let the order of an array decide a permanent fact
+      // about the team, and the same two messages sent the other way round
+      // would declare the opposite. A mixed batch stores normally and settles
+      // nothing — the team stays NULL until something says one thing.
+      const ciphers = new Set(fresh.map((message) => message.envelope.cipher));
+      if (ciphers.size === 1) {
+        await client.query(
+          `UPDATE teams SET cipher_profile = $2
+            WHERE team_id = $1 AND cipher_profile IS NULL`,
+          [teamId, fresh[0]!.envelope.cipher],
+        );
+      }
     }
 
     const seen = new Set<string>();

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -248,6 +248,48 @@ export async function postMessages(
       }
     }
 
+    // The team's single cipher, enforced before anything is stored.
+    //
+    // `write_allowed_ciphers` above is a different question — what the server
+    // will ACCEPT — and it permits both. `cipher_profile` is what this team
+    // chose, and a client reads it to decide whether plaintext may be pushed at
+    // all. A value that traffic is free to contradict is not a fact about the
+    // team, and a safety decision resting on it would be worse than none: it
+    // reads as dependable precisely because writes went through.
+    //
+    // So a batch that disagrees with the team, or with itself while the team is
+    // undeclared, is refused whole. Fail-closed and before the writes: a
+    // partial store would leave the team holding messages under a cipher it
+    // does not use, which is the state this column exists to make impossible.
+    if (fresh.length > 0) {
+      const ciphers = new Set(fresh.map((message) => message.envelope.cipher));
+      const expected = team.cipher_profile ?? (ciphers.size === 1 ? [...ciphers][0]! : null);
+      if (expected === null || ciphers.size !== 1 || !ciphers.has(expected)) {
+        // The refusal carries its own way out. One path here is reachable by a
+        // machine that has done nothing wrong: the team declared age-v1 after
+        // this machine last looked, so it is still sending plaintext. Blocking
+        // that write is right — it would be readable by the server — but the
+        // sender cannot act on "mismatch" alone. `remedy` names what makes it
+        // send the right thing, and `cipher_profile` says what to send.
+        throw new ProtocolError(
+          409,
+          "cipher-profile-mismatch",
+          team.cipher_profile === null
+            ? "an undeclared team cannot be settled by a batch that mixes ciphers"
+            : "message cipher does not match the team's declared cipher profile",
+          {
+            cipher_profile: team.cipher_profile,
+            batch_ciphers: [...ciphers].sort(),
+            remedy:
+              team.cipher_profile === null
+                ? "send one batch whose messages all use the same cipher; that settles the team"
+                : "re-read this team (remote.sh pull, or unlock if you hold the key) and send under its declared cipher",
+          },
+          binding,
+        );
+      }
+    }
+
     let next = BigInt(team.current_seq);
     if (BigInt(fresh.length) > MAX_SEQUENCE - next) {
       throw new ProtocolError(
@@ -293,33 +335,20 @@ export async function postMessages(
       // A team registered before declarations were carried has cipher_profile
       // NULL, and connect cannot fill it: that route takes no credential, so a
       // write there would let anyone who knows a team_id fix the profile ahead
-      // of the machine that owns the team. This is the other half of the same
-      // rule — a team is settled by what it actually stores.
+      // of the machine that owns the team. It is settled here instead — by what
+      // the team actually stores — on a route that already writes to this same
+      // row (current_seq, one line above) and has already run every check.
       //
-      // It belongs here and nowhere else because this route already writes to
-      // an existing team (current_seq, one line above), so filling a NULL adds
-      // no capability that storing the message did not already require. The
-      // value is the cipher of the envelope being stored, which the policy
-      // check above has already accepted.
+      // The batch is known to agree with itself by now: the guard above refused
+      // it otherwise, so this cannot be decided by which message came first.
       //
-      // `IS NULL` only: a declaration, once made, is never rewritten by later
-      // traffic — a team that switches profile changes it by declaring, not by
-      // sending.
-      //
-      // And only when this batch AGREES with itself. The policy allows both
-      // ciphers, so a single batch may legitimately carry a mix; taking the
-      // first message would let the order of an array decide a permanent fact
-      // about the team, and the same two messages sent the other way round
-      // would declare the opposite. A mixed batch stores normally and settles
-      // nothing — the team stays NULL until something says one thing.
-      const ciphers = new Set(fresh.map((message) => message.envelope.cipher));
-      if (ciphers.size === 1) {
-        await client.query(
-          `UPDATE teams SET cipher_profile = $2
-            WHERE team_id = $1 AND cipher_profile IS NULL`,
-          [teamId, fresh[0]!.envelope.cipher],
-        );
-      }
+      // `IS NULL` only. Once declared, a team is not reclassified by later
+      // traffic — and traffic that disagrees never reaches this point at all.
+      await client.query(
+        `UPDATE teams SET cipher_profile = $2
+          WHERE team_id = $1 AND cipher_profile IS NULL`,
+        [teamId, fresh[0]!.envelope.cipher],
+      );
     }
 
     const seen = new Set<string>();

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -94,10 +94,16 @@ function common(serverId: string, team: TeamRow): Record<string, unknown> {
 }
 
 function notFound(serverId: string, teamId: string): ProtocolError {
-  return new ProtocolError(404, "team-not-found", "team is not provisioned", {}, {
-    serverInstanceId: serverId,
-    teamId,
-  });
+  return new ProtocolError(
+    404,
+    "team-not-found",
+    "team is not provisioned",
+    {},
+    {
+      serverInstanceId: serverId,
+      teamId,
+    },
+  );
 }
 
 function envelopeMatches(row: LiveMessageRow, envelope: Envelope): boolean {
@@ -164,7 +170,8 @@ export async function postMessages(
       [teamId, ids],
     );
     const existing = new Map<string, ExistingRecord>();
-    for (const row of liveResult.rows) existing.set(row.id, { kind: "live", row });
+    for (const row of liveResult.rows)
+      existing.set(row.id, { kind: "live", row });
     for (const row of tombstoneResult.rows) {
       existing.set(row.id, {
         kind: "tombstone",
@@ -191,7 +198,9 @@ export async function postMessages(
       }
     }
 
-    const fresh = [...firstById.values()].filter((message) => !existing.has(message.id));
+    const fresh = [...firstById.values()].filter(
+      (message) => !existing.has(message.id),
+    );
     for (const message of fresh) {
       const { envelope, id } = message;
       if (envelope.v !== 1 || !["none", "age-v1"].includes(envelope.cipher)) {
@@ -277,10 +286,10 @@ export async function postMessages(
       existing.set(message.id, { kind: "live", row });
     }
     if (fresh.length > 0) {
-      await client.query("UPDATE teams SET current_seq = $2 WHERE team_id = $1", [
-        teamId,
-        next.toString(),
-      ]);
+      await client.query(
+        "UPDATE teams SET current_seq = $2 WHERE team_id = $1",
+        [teamId, next.toString()],
+      );
     }
 
     const seen = new Set<string>();
@@ -291,7 +300,8 @@ export async function postMessages(
       seen.add(message.id);
       return {
         id: message.id,
-        server_seq: record.kind === "live" ? record.row.team_seq : record.sequence,
+        server_seq:
+          record.kind === "live" ? record.row.team_seq : record.sequence,
         disposition: stored ? "stored" : "duplicate",
       };
     });
@@ -301,15 +311,21 @@ export async function postMessages(
       const target = next - retentionMaxLiveMessages;
       if (target > effectiveFloor) {
         retentionNotice = await retainThroughLocked(
-          client, teamId, effectiveFloor, target,
+          client,
+          teamId,
+          effectiveFloor,
+          target,
         );
         effectiveFloor = target;
       }
     }
 
     return {
-      ...common(serverId, { ...team, current_seq: next.toString(),
-        min_available_seq: effectiveFloor.toString() }),
+      ...common(serverId, {
+        ...team,
+        current_seq: next.toString(),
+        min_available_seq: effectiveFloor.toString(),
+      }),
       policy_revision: team.policy_revision,
       acks,
     };
@@ -399,7 +415,8 @@ export async function syncReadState(
           WHERE existing.wire_id IS NULL`,
         [teamId, exactMembers, exactWires],
       );
-      for (const row of novel.rows) novelExactPairs.add(`${row.member_id}:${row.wire_id}`);
+      for (const row of novel.rows)
+        novelExactPairs.add(`${row.member_id}:${row.wire_id}`);
     }
 
     // The authenticated retention floor is a safe baseline for every existing
@@ -439,20 +456,30 @@ export async function syncReadState(
 
     await deleteCoveredExact(client, teamId, floor);
 
-    const survivingRequestExact = exactWires.length === 0
-      ? new Set<string>()
-      : new Set((await client.query<{ member_id: string; wire_id: string }>(
-        `SELECT incoming.member_id::text, incoming.wire_id::text
+    const survivingRequestExact =
+      exactWires.length === 0
+        ? new Set<string>()
+        : new Set(
+            (
+              await client.query<{ member_id: string; wire_id: string }>(
+                `SELECT incoming.member_id::text, incoming.wire_id::text
            FROM unnest($2::uuid[], $3::uuid[]) AS incoming(member_id, wire_id)
            JOIN read_exact current
              ON current.team_id=$1 AND current.member_id=incoming.member_id
             AND current.wire_id=incoming.wire_id`,
-        [teamId, exactMembers, exactWires],
-      )).rows
-        .filter((row) => novelExactPairs.has(`${row.member_id}:${row.wire_id}`))
-        .map((row) => row.member_id));
+                [teamId, exactMembers, exactWires],
+              )
+            ).rows
+              .filter((row) =>
+                novelExactPairs.has(`${row.member_id}:${row.wire_id}`),
+              )
+              .map((row) => row.member_id),
+          );
 
-    const memberOverflow = await client.query<{ member_id: string; exact_count: string }>(
+    const memberOverflow = await client.query<{
+      member_id: string;
+      exact_count: string;
+    }>(
       `SELECT member_id::text, COUNT(*)::text AS exact_count
          FROM read_exact WHERE team_id = $1
         GROUP BY member_id HAVING COUNT(*) > $2
@@ -466,14 +493,19 @@ export async function syncReadState(
     const teamCount = Number(teamCountResult.rows[0]?.exact_count ?? "0");
     if (memberOverflow.rows[0] || teamCount > MAX_EXACT_PER_TEAM) {
       const causalMemberId = input.updates.find((update) =>
-        survivingRequestExact.has(update.member_id))?.member_id;
-      const offender = memberOverflow.rows[0] ?? (await client.query<{ member_id: string; exact_count: string }>(
-        `SELECT member_id::text, COUNT(*)::text AS exact_count
+        survivingRequestExact.has(update.member_id),
+      )?.member_id;
+      const offender =
+        memberOverflow.rows[0] ??
+        (
+          await client.query<{ member_id: string; exact_count: string }>(
+            `SELECT member_id::text, COUNT(*)::text AS exact_count
            FROM read_exact WHERE team_id = $1
             AND ($2::uuid IS NULL OR member_id=$2::uuid)
           GROUP BY member_id ORDER BY COUNT(*) DESC, member_id LIMIT 1`,
-        [teamId, causalMemberId ?? null],
-      )).rows[0];
+            [teamId, causalMemberId ?? null],
+          )
+        ).rows[0];
       throw new ProtocolError(
         409,
         "read-state-limit-exceeded",
@@ -528,15 +560,22 @@ export async function syncReadState(
     );
     const hasMore = result.rows.length > input.page_limit;
     const page = result.rows.slice(0, input.page_limit);
-    const items = page.map((row) => row.kind_order === 0
-      ? { kind: "frontier", member_id: row.member_id, server_seq: row.server_seq }
-      : { kind: "exact", member_id: row.member_id, wire_id: row.wire_id });
+    const items = page.map((row) =>
+      row.kind_order === 0
+        ? {
+            kind: "frontier",
+            member_id: row.member_id,
+            server_seq: row.server_seq,
+          }
+        : { kind: "exact", member_id: row.member_id, wire_id: row.wire_id },
+    );
     const last = items.at(-1);
-    const nextPageAfter = hasMore && last
-      ? last.kind === "frontier"
-        ? { member_id: last.member_id, kind: "frontier" }
-        : { member_id: last.member_id, kind: "exact", wire_id: last.wire_id }
-      : null;
+    const nextPageAfter =
+      hasMore && last
+        ? last.kind === "frontier"
+          ? { member_id: last.member_id, kind: "frontier" }
+          : { member_id: last.member_id, kind: "exact", wire_id: last.wire_id }
+        : null;
 
     return {
       ...common(serverId, team),
@@ -640,7 +679,12 @@ export async function retainThrough(
       );
     }
 
-    const notice = await retainThroughLocked(client, teamId, currentFloor, through);
+    const notice = await retainThroughLocked(
+      client,
+      teamId,
+      currentFloor,
+      through,
+    );
     return {
       ...common(serverId, { ...team, min_available_seq: through.toString() }),
       retained_through: through.toString(),
@@ -666,7 +710,10 @@ export async function getMessages(
           410,
           "resync-required",
           "cursor predates retained history",
-          { after: after.toString(), min_available_seq: team.min_available_seq },
+          {
+            after: after.toString(),
+            min_available_seq: team.min_available_seq,
+          },
           { serverInstanceId: serverId, teamId },
         );
       }
@@ -751,11 +798,10 @@ export async function getCapabilities(
   pool: Pool,
   teamId: string,
 ): Promise<Record<string, unknown>> {
-  return inTransaction(
-    pool,
-    (client) => capabilitySnapshot(client, teamId),
-    { readOnly: true, repeatableRead: true },
-  );
+  return inTransaction(pool, (client) => capabilitySnapshot(client, teamId), {
+    readOnly: true,
+    repeatableRead: true,
+  });
 }
 
 // Registers a team the client already owns: the team row and its opening
@@ -766,64 +812,100 @@ export async function connectTeam(
   pool: Pool,
   input: ConnectInput,
 ): Promise<Record<string, unknown>> {
-  return inTransaction(pool, async (client) => {
-    const serverId = await serverInstanceId(client);
-    // The team and its opening policy row.
-    // team_policy_history is required: capabilitySnapshot (and so
-    // GET /v1/capabilities) reads it, and a team without it is out of bounds.
-    //
-    // ON CONFLICT makes the primary key the sole arbiter of "already
-    // registered", so the refusal holds under concurrency, not just serially: a
-    // second connect for the same team_id inserts nothing, and a concurrent one
-    // blocks on the first transaction's commit before it resolves to the same.
-    // A read-then-insert would instead let two connects both miss the row and
-    // the losing INSERT raise a raw primary-key violation (500) — the retry a
-    // timed-out client sends races its own first attempt exactly this way.
-    const inserted = await client.query(
-      `INSERT INTO teams
+  // Set when a repeat connect carries a declaration for a team that has none.
+  // The transaction below throws on that path, so the write cannot live inside
+  // it; it is applied after, on its own.
+  let backfillDeclaration: string | undefined;
+  try {
+    return await inTransaction(pool, async (client) => {
+      const serverId = await serverInstanceId(client);
+      // The team and its opening policy row.
+      // team_policy_history is required: capabilitySnapshot (and so
+      // GET /v1/capabilities) reads it, and a team without it is out of bounds.
+      //
+      // ON CONFLICT makes the primary key the sole arbiter of "already
+      // registered", so the refusal holds under concurrency, not just serially: a
+      // second connect for the same team_id inserts nothing, and a concurrent one
+      // blocks on the first transaction's commit before it resolves to the same.
+      // A read-then-insert would instead let two connects both miss the row and
+      // the losing INSERT raise a raw primary-key violation (500) — the retry a
+      // timed-out client sends races its own first attempt exactly this way.
+      const inserted = await client.query(
+        `INSERT INTO teams
          (team_id, team_name, members_revision,
           accepted_envelope_versions, write_allowed_ciphers, cipher_profile)
        VALUES ($1, $2, 0, ARRAY[1], ARRAY['none', 'age-v1']::TEXT[], $3)
        ON CONFLICT (team_id) DO NOTHING`,
-      // A client that sends no declaration leaves NULL. Nothing stands in for
-      // it: an absent declaration and a declared 'none' are different facts,
-      // and only one of them is safe to act on.
-      [input.team_id, input.team_name, input.cipher_profile ?? null],
-    );
-    // Refused as a uniqueness conflict, the same reason git refuses a
-    // non-fast-forward push — not an authorization decision.
-    if (inserted.rowCount === 0) {
-      throw new ProtocolError(
-        409,
-        "team-already-exists",
-        "a team with this id is already registered",
-        { team_id: input.team_id },
-        { serverInstanceId: serverId, teamId: input.team_id },
+        // A client that sends no declaration leaves NULL. Nothing stands in for
+        // it: an absent declaration and a declared 'none' are different facts,
+        // and only one of them is safe to act on.
+        [input.team_id, input.team_name, input.cipher_profile ?? null],
       );
-    }
-    await client.query(
-      `INSERT INTO team_policy_history
+      // A team registered before declarations were carried has cipher_profile
+      // NULL, and nothing else can ever fill it: the server never stored the
+      // answer and no other request supplies one. So a repeat connect that brings
+      // a declaration leaves the missing one behind, and the "reconnect the
+      // machine that already has the team" that `unlock` prints becomes advice
+      // that works.
+      //
+      // Recorded OUTSIDE this transaction, because the next statement throws and
+      // would roll it back with everything else — the first version of this did
+      // exactly that and left the column NULL while appearing to fill it.
+      //
+      // Deliberately narrow: it writes only where the column IS NULL, so it can
+      // never overwrite an existing declaration, and it does not soften the
+      // refusal — registering a team twice is still 409.
+      if (inserted.rowCount === 0 && input.cipher_profile !== undefined) {
+        backfillDeclaration = input.cipher_profile;
+      }
+      // Refused as a uniqueness conflict, the same reason git refuses a
+      // non-fast-forward push — not an authorization decision.
+      if (inserted.rowCount === 0) {
+        throw new ProtocolError(
+          409,
+          "team-already-exists",
+          "a team with this id is already registered",
+          { team_id: input.team_id },
+          { serverInstanceId: serverId, teamId: input.team_id },
+        );
+      }
+      await client.query(
+        `INSERT INTO team_policy_history
          (team_id, policy_revision, effective_from_seq,
           accepted_envelope_versions, write_allowed_ciphers)
        VALUES ($1, 0, 1, ARRAY[1], ARRAY['none', 'age-v1']::TEXT[])`,
-      [input.team_id],
-    );
-    // The roster the client owns. member_identity_history is append-only and
-    // retires a (team, name) for the life of the team; members is the live set.
-    // The schema has already rejected duplicate ids or names within the batch.
-    for (const member of input.members) {
-      await client.query(
-        `INSERT INTO member_identity_history (team_id, member_id, name)
-         VALUES ($1, $2, $3)`,
-        [input.team_id, member.member_id, member.name],
+        [input.team_id],
       );
-      await client.query(
-        `INSERT INTO members (team_id, member_id, name) VALUES ($1, $2, $3)`,
-        [input.team_id, member.member_id, member.name],
+      // The roster the client owns. member_identity_history is append-only and
+      // retires a (team, name) for the life of the team; members is the live set.
+      // The schema has already rejected duplicate ids or names within the batch.
+      for (const member of input.members) {
+        await client.query(
+          `INSERT INTO member_identity_history (team_id, member_id, name)
+         VALUES ($1, $2, $3)`,
+          [input.team_id, member.member_id, member.name],
+        );
+        await client.query(
+          `INSERT INTO members (team_id, member_id, name) VALUES ($1, $2, $3)`,
+          [input.team_id, member.member_id, member.name],
+        );
+      }
+      return capabilitySnapshot(client, input.team_id);
+    });
+  } finally {
+    // Runs on both exits, but only ever set on the 409 path. Its own statement,
+    // so the rollback that carries the refusal cannot take it too. `IS NULL`
+    // keeps it to filling a gap: an existing declaration is never rewritten,
+    // and two machines racing to fill the same gap agree on whichever lands
+    // first rather than flipping the team back and forth.
+    if (backfillDeclaration !== undefined) {
+      await pool.query(
+        `UPDATE teams SET cipher_profile = $2
+          WHERE team_id = $1 AND cipher_profile IS NULL`,
+        [input.team_id, backfillDeclaration],
       );
     }
-    return capabilitySnapshot(client, input.team_id);
-  });
+  }
 }
 
 async function roster(
@@ -921,11 +1003,10 @@ export async function getTeamSnapshot(
   pool: Pool,
   teamId: string,
 ): Promise<Record<string, unknown>> {
-  return inTransaction(
-    pool,
-    (client) => capabilitySnapshot(client, teamId),
-    { readOnly: true, repeatableRead: true },
-  );
+  return inTransaction(pool, (client) => capabilitySnapshot(client, teamId), {
+    readOnly: true,
+    repeatableRead: true,
+  });
 }
 
 export async function getMembers(
@@ -961,7 +1042,10 @@ export async function getMembers(
 // "no such route" to a client checking whether the server is up at all. Absence
 // carries the disagreement instead, and the client — which knows which team it
 // expects — is where that is judged.
-export async function health(pool: Pool, teamId?: string): Promise<{
+export async function health(
+  pool: Pool,
+  teamId?: string,
+): Promise<{
   status: "ok";
   server_instance_id: string;
   protocol: { supported_versions: number[] };

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -20,6 +20,8 @@ type TeamRow = {
   write_allowed_ciphers: string[];
   max_blob_bytes: number;
   members_revision: string;
+  // Null until a machine declares it. Not the same as 'none'.
+  cipher_profile: string | null;
 };
 
 type LiveMessageRow = {
@@ -69,7 +71,8 @@ async function teamRow(
   const result = await client.query<TeamRow>(
     `SELECT team_id::text, team_name, current_seq::text, min_available_seq::text,
             policy_revision::text, accepted_envelope_versions,
-            write_allowed_ciphers, max_blob_bytes, members_revision::text
+            write_allowed_ciphers, max_blob_bytes, members_revision::text,
+            cipher_profile
        FROM teams WHERE team_id = $1${lock ? " FOR UPDATE" : ""}`,
     [id],
   );
@@ -83,6 +86,10 @@ function common(serverId: string, team: TeamRow): Record<string, unknown> {
     team_id: team.team_id,
     team_name: team.team_name,
     min_available_seq: team.min_available_seq,
+    // The DECLARED profile, distinct from write_allowed_ciphers, which says
+    // only what the server would accept. `null` is a real answer here — "no
+    // machine has declared it yet" — and a client must not read it as 'none'.
+    cipher_profile: team.cipher_profile ?? null,
   };
 }
 
@@ -775,10 +782,13 @@ export async function connectTeam(
     const inserted = await client.query(
       `INSERT INTO teams
          (team_id, team_name, members_revision,
-          accepted_envelope_versions, write_allowed_ciphers)
-       VALUES ($1, $2, 0, ARRAY[1], ARRAY['none', 'age-v1']::TEXT[])
+          accepted_envelope_versions, write_allowed_ciphers, cipher_profile)
+       VALUES ($1, $2, 0, ARRAY[1], ARRAY['none', 'age-v1']::TEXT[], $3)
        ON CONFLICT (team_id) DO NOTHING`,
-      [input.team_id, input.team_name],
+      // A client that sends no declaration leaves NULL. Nothing stands in for
+      // it: an absent declaration and a declared 'none' are different facts,
+      // and only one of them is safe to act on.
+      [input.team_id, input.team_name, input.cipher_profile ?? null],
     );
     // Refused as a uniqueness conflict, the same reason git refuses a
     // non-fast-forward push — not an authorization decision.

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -290,6 +290,26 @@ export async function postMessages(
         "UPDATE teams SET current_seq = $2 WHERE team_id = $1",
         [teamId, next.toString()],
       );
+      // A team registered before declarations were carried has cipher_profile
+      // NULL, and connect cannot fill it: that route takes no credential, so a
+      // write there would let anyone who knows a team_id fix the profile ahead
+      // of the machine that owns the team. This is the other half of the same
+      // rule — a team is settled by what it actually stores.
+      //
+      // It belongs here and nowhere else because this route already writes to
+      // an existing team (current_seq, one line above), so filling a NULL adds
+      // no capability that storing the message did not already require. The
+      // value is the cipher of the envelope being stored, which the policy
+      // check above has already accepted.
+      //
+      // `IS NULL` only: a declaration, once made, is never rewritten by later
+      // traffic — a team that switches profile changes it by declaring, not by
+      // sending.
+      await client.query(
+        `UPDATE teams SET cipher_profile = $2
+          WHERE team_id = $1 AND cipher_profile IS NULL`,
+        [teamId, fresh[0]!.envelope.cipher],
+      );
     }
 
     const seen = new Set<string>();
@@ -812,12 +832,7 @@ export async function connectTeam(
   pool: Pool,
   input: ConnectInput,
 ): Promise<Record<string, unknown>> {
-  // Set when a repeat connect carries a declaration for a team that has none.
-  // The transaction below throws on that path, so the write cannot live inside
-  // it; it is applied after, on its own.
-  let backfillDeclaration: string | undefined;
-  try {
-    return await inTransaction(pool, async (client) => {
+  return inTransaction(pool, async (client) => {
       const serverId = await serverInstanceId(client);
       // The team and its opening policy row.
       // team_policy_history is required: capabilitySnapshot (and so
@@ -841,23 +856,14 @@ export async function connectTeam(
         // and only one of them is safe to act on.
         [input.team_id, input.team_name, input.cipher_profile ?? null],
       );
-      // A team registered before declarations were carried has cipher_profile
-      // NULL, and nothing else can ever fill it: the server never stored the
-      // answer and no other request supplies one. So a repeat connect that brings
-      // a declaration leaves the missing one behind, and the "reconnect the
-      // machine that already has the team" that `unlock` prints becomes advice
-      // that works.
+      // A repeat connect writes NOTHING, including no declaration. This route
+      // carries no credential, and its safety rests on exactly that: knowing a
+      // team_id is not permission to change an existing team. One write here —
+      // even one narrowed to `IS NULL` — would let anyone holding a team_id
+      // fix the profile before the machine that owns the team, and 'none' fixed
+      // first is the dangerous direction. A team already registered is settled
+      // by a message it stores, below, not by being named again.
       //
-      // Recorded OUTSIDE this transaction, because the next statement throws and
-      // would roll it back with everything else — the first version of this did
-      // exactly that and left the column NULL while appearing to fill it.
-      //
-      // Deliberately narrow: it writes only where the column IS NULL, so it can
-      // never overwrite an existing declaration, and it does not soften the
-      // refusal — registering a team twice is still 409.
-      if (inserted.rowCount === 0 && input.cipher_profile !== undefined) {
-        backfillDeclaration = input.cipher_profile;
-      }
       // Refused as a uniqueness conflict, the same reason git refuses a
       // non-fast-forward push — not an authorization decision.
       if (inserted.rowCount === 0) {
@@ -890,22 +896,8 @@ export async function connectTeam(
           [input.team_id, member.member_id, member.name],
         );
       }
-      return capabilitySnapshot(client, input.team_id);
-    });
-  } finally {
-    // Runs on both exits, but only ever set on the 409 path. Its own statement,
-    // so the rollback that carries the refusal cannot take it too. `IS NULL`
-    // keeps it to filling a gap: an existing declaration is never rewritten,
-    // and two machines racing to fill the same gap agree on whichever lands
-    // first rather than flipping the team back and forth.
-    if (backfillDeclaration !== undefined) {
-      await pool.query(
-        `UPDATE teams SET cipher_profile = $2
-          WHERE team_id = $1 AND cipher_profile IS NULL`,
-        [input.team_id, backfillDeclaration],
-      );
-    }
-  }
+    return capabilitySnapshot(client, input.team_id);
+  });
 }
 
 async function roster(

--- a/server/test/connect.integration.test.ts
+++ b/server/test/connect.integration.test.ts
@@ -116,12 +116,13 @@ describeDatabase("POST /v1/connect", () => {
     expect(response.json().error.code).toBe("team-already-exists");
   });
 
-  it("lets a repeat connect supply a declaration the team never had, still answering 409", async () => {
-    // A team registered before declarations were carried. Nothing else can fill
-    // this in — the server never stored the answer — so the advice `unlock`
-    // prints ("reconnect the machine that already has the team") has to be
-    // advice that works. Without this it names a dead end, and every
-    // pre-existing team stays unknown for good.
+  it("a repeat connect writes nothing at all, declaration included", async () => {
+    // This route takes no credential, and its safety has always rested on a
+    // repeat connect changing nothing about an existing team. A backfill here
+    // would break that: anyone who knows a team_id could fix the profile before
+    // the machine that owns the team, and 'none' fixed first is the direction
+    // that hurts — a real second machine would then be told its sealed team is
+    // plaintext.
     await pool.query("UPDATE teams SET cipher_profile = NULL WHERE team_id = $1", [teamId]);
 
     const response = await app.inject({
@@ -130,8 +131,6 @@ describeDatabase("POST /v1/connect", () => {
       headers,
       payload: { ...body, cipher_profile: "age-v1" },
     });
-    // Still refused as a repeat registration: this fills a gap, it does not
-    // register the team again.
     expect(response.statusCode).toBe(409);
     expect(response.json().error.code).toBe("team-already-exists");
 
@@ -139,27 +138,7 @@ describeDatabase("POST /v1/connect", () => {
       "SELECT cipher_profile FROM teams WHERE team_id = $1",
       [teamId],
     );
-    expect(after.rows[0]?.cipher_profile).toBe("age-v1");
-  });
-
-  it("a repeat connect never overwrites a declaration the team already has", async () => {
-    // The same path must not become a way to reclassify a team. Only absence is
-    // fillable.
-    await pool.query("UPDATE teams SET cipher_profile = 'age-v1' WHERE team_id = $1", [teamId]);
-
-    const response = await app.inject({
-      method: "POST",
-      url: "/v1/connect",
-      headers,
-      payload: { ...body, cipher_profile: "none" },
-    });
-    expect(response.statusCode).toBe(409);
-
-    const after = await pool.query<{ cipher_profile: string | null }>(
-      "SELECT cipher_profile FROM teams WHERE team_id = $1",
-      [teamId],
-    );
-    expect(after.rows[0]?.cipher_profile).toBe("age-v1");
+    expect(after.rows[0]?.cipher_profile).toBeNull();
   });
 
   it("rejects a roster with duplicate member names before touching the database", async () => {

--- a/server/test/connect.integration.test.ts
+++ b/server/test/connect.integration.test.ts
@@ -116,6 +116,52 @@ describeDatabase("POST /v1/connect", () => {
     expect(response.json().error.code).toBe("team-already-exists");
   });
 
+  it("lets a repeat connect supply a declaration the team never had, still answering 409", async () => {
+    // A team registered before declarations were carried. Nothing else can fill
+    // this in — the server never stored the answer — so the advice `unlock`
+    // prints ("reconnect the machine that already has the team") has to be
+    // advice that works. Without this it names a dead end, and every
+    // pre-existing team stays unknown for good.
+    await pool.query("UPDATE teams SET cipher_profile = NULL WHERE team_id = $1", [teamId]);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/connect",
+      headers,
+      payload: { ...body, cipher_profile: "age-v1" },
+    });
+    // Still refused as a repeat registration: this fills a gap, it does not
+    // register the team again.
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error.code).toBe("team-already-exists");
+
+    const after = await pool.query<{ cipher_profile: string | null }>(
+      "SELECT cipher_profile FROM teams WHERE team_id = $1",
+      [teamId],
+    );
+    expect(after.rows[0]?.cipher_profile).toBe("age-v1");
+  });
+
+  it("a repeat connect never overwrites a declaration the team already has", async () => {
+    // The same path must not become a way to reclassify a team. Only absence is
+    // fillable.
+    await pool.query("UPDATE teams SET cipher_profile = 'age-v1' WHERE team_id = $1", [teamId]);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/connect",
+      headers,
+      payload: { ...body, cipher_profile: "none" },
+    });
+    expect(response.statusCode).toBe(409);
+
+    const after = await pool.query<{ cipher_profile: string | null }>(
+      "SELECT cipher_profile FROM teams WHERE team_id = $1",
+      [teamId],
+    );
+    expect(after.rows[0]?.cipher_profile).toBe("age-v1");
+  });
+
   it("rejects a roster with duplicate member names before touching the database", async () => {
     const response = await app.inject({
       method: "POST",

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -102,6 +102,24 @@ describeDatabase("remote storage HTTP API v1", () => {
     };
   }
 
+  // Puts the shared team back into a state where a fresh message can be stored.
+  // The cases above deliberately break it — one empties the cipher policy, one
+  // exhausts the sequence — and they run first, so a declaration case that did
+  // not reset would be asserting on a 403 or a 507 instead of on a stored
+  // message.
+  async function resetTeamForDeclarationCase(
+    declaration: string | null,
+  ): Promise<void> {
+    await pool.query(
+      `UPDATE teams
+          SET cipher_profile = $2,
+              write_allowed_ciphers = ARRAY['none', 'age-v1']::TEXT[],
+              current_seq = (SELECT coalesce(max(team_seq), 0) FROM messages WHERE team_id = $1)
+        WHERE team_id = $1`,
+      [teamId, declaration],
+    );
+  }
+
   it("reports readiness and fixes the response protocol version", async () => {
     const response = await app.inject({ method: "GET", url: "/v1/health" });
     expect(response.statusCode).toBe(200);
@@ -890,7 +908,7 @@ describeDatabase("remote storage HTTP API v1", () => {
     // the machine that owns the team. This is where it is settled instead: a
     // route that already writes to the existing team (current_seq), reached by
     // a caller whose message got past the policy check.
-    await pool.query("UPDATE teams SET cipher_profile = NULL WHERE team_id = $1", [teamId]);
+    await resetTeamForDeclarationCase(null);
 
     const settling = message("750e8400-e29b-41d4-a716-4466554400a1", "settles it");
     const response = await app.inject({
@@ -908,10 +926,47 @@ describeDatabase("remote storage HTTP API v1", () => {
     expect(after.rows[0]?.cipher_profile).toBe("none");
   });
 
+  it("a batch that disagrees with itself settles nothing", async () => {
+    // The policy allows both ciphers, so one batch may legitimately carry a
+    // mix. Taking the first message would let the ORDER of an array decide a
+    // permanent fact — the same two messages the other way round would declare
+    // the opposite. That is still deciding from a sample; it just changed which
+    // sample. A mixed batch stores normally and leaves the team undeclared.
+    // Earlier cases in this suite leave the team unusable for a fresh write:
+    // one empties write_allowed_ciphers (-> 403) and one drives current_seq to
+    // the maximum (-> 507). Both are restored here, or this case would pass on
+    // a refusal that has nothing to do with mixing.
+    await resetTeamForDeclarationCase(null);
+
+    const plain = message("750e8400-e29b-41d4-a716-4466554400b1", "plain");
+    const sealed = {
+      id: "750e8400-e29b-41d4-a716-4466554400b2",
+      envelope: {
+        v: 1,
+        cipher: "age-v1",
+        key_id: "epoch-1",
+        blob: Buffer.from("opaque").toString("base64"),
+      },
+    };
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: { messages: [plain, sealed] },
+    });
+    expect(response.statusCode).toBe(200);
+
+    const after = await pool.query<{ cipher_profile: string | null }>(
+      "SELECT cipher_profile FROM teams WHERE team_id = $1",
+      [teamId],
+    );
+    expect(after.rows[0]?.cipher_profile).toBeNull();
+  });
+
   it("never rewrites a declaration a team already has", async () => {
     // Once declared, later traffic does not reclassify the team: a team that
     // changes profile does so by declaring, not by what it happens to send.
-    await pool.query("UPDATE teams SET cipher_profile = 'age-v1' WHERE team_id = $1", [teamId]);
+    await resetTeamForDeclarationCase("age-v1");
 
     const later = message("750e8400-e29b-41d4-a716-4466554400a2", "plaintext");
     await app.inject({

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -879,4 +879,52 @@ describeDatabase("remote storage HTTP API v1", () => {
     );
     expect(rows.rows[0]?.count).toBe("0");
   });
+
+  // Last on purpose: the cases above assert exact sequence numbers against a
+  // team they share, so a message stored here would move every one of them.
+  // Placing these first is what broke nine of them.
+  it("settles an undeclared team's cipher from the first message it stores", async () => {
+    // Teams registered before declarations were carried have cipher_profile
+    // NULL, and `connect` must not fill it — that route takes no credential, so
+    // a write there would let anyone holding a team_id fix the profile ahead of
+    // the machine that owns the team. This is where it is settled instead: a
+    // route that already writes to the existing team (current_seq), reached by
+    // a caller whose message got past the policy check.
+    await pool.query("UPDATE teams SET cipher_profile = NULL WHERE team_id = $1", [teamId]);
+
+    const settling = message("750e8400-e29b-41d4-a716-4466554400a1", "settles it");
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: { messages: [settling] },
+    });
+    expect(response.statusCode).toBe(200);
+
+    const after = await pool.query<{ cipher_profile: string | null }>(
+      "SELECT cipher_profile FROM teams WHERE team_id = $1",
+      [teamId],
+    );
+    expect(after.rows[0]?.cipher_profile).toBe("none");
+  });
+
+  it("never rewrites a declaration a team already has", async () => {
+    // Once declared, later traffic does not reclassify the team: a team that
+    // changes profile does so by declaring, not by what it happens to send.
+    await pool.query("UPDATE teams SET cipher_profile = 'age-v1' WHERE team_id = $1", [teamId]);
+
+    const later = message("750e8400-e29b-41d4-a716-4466554400a2", "plaintext");
+    await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: { messages: [later] },
+    });
+
+    const after = await pool.query<{ cipher_profile: string | null }>(
+      "SELECT cipher_profile FROM teams WHERE team_id = $1",
+      [teamId],
+    );
+    expect(after.rows[0]?.cipher_profile).toBe("age-v1");
+  });
 });

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -926,16 +926,12 @@ describeDatabase("remote storage HTTP API v1", () => {
     expect(after.rows[0]?.cipher_profile).toBe("none");
   });
 
-  it("a batch that disagrees with itself settles nothing", async () => {
-    // The policy allows both ciphers, so one batch may legitimately carry a
-    // mix. Taking the first message would let the ORDER of an array decide a
-    // permanent fact — the same two messages the other way round would declare
-    // the opposite. That is still deciding from a sample; it just changed which
-    // sample. A mixed batch stores normally and leaves the team undeclared.
-    // Earlier cases in this suite leave the team unusable for a fresh write:
-    // one empties write_allowed_ciphers (-> 403) and one drives current_seq to
-    // the maximum (-> 507). Both are restored here, or this case would pass on
-    // a refusal that has nothing to do with mixing.
+  it("refuses a batch that disagrees with itself, storing none of it", async () => {
+    // cipher_profile exists so a client can decide whether plaintext may be
+    // pushed at all. A value that traffic is free to contradict is not a fact
+    // about the team, and a safety decision resting on it would be worse than
+    // none — it reads as dependable precisely because writes went through. So
+    // a mix is refused whole, before anything is stored.
     await resetTeamForDeclarationCase(null);
 
     const plain = message("750e8400-e29b-41d4-a716-4466554400b1", "plain");
@@ -954,32 +950,99 @@ describeDatabase("remote storage HTTP API v1", () => {
       headers,
       payload: { messages: [plain, sealed] },
     });
-    expect(response.statusCode).toBe(200);
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error.code).toBe("cipher-profile-mismatch");
+    // A refusal a sender can act on.
+    expect(response.json().error.details.remedy).toBeTruthy();
 
     const after = await pool.query<{ cipher_profile: string | null }>(
       "SELECT cipher_profile FROM teams WHERE team_id = $1",
       [teamId],
     );
     expect(after.rows[0]?.cipher_profile).toBeNull();
+    // Nothing from the batch landed: a partial store would leave the team
+    // holding messages under a cipher it does not use.
+    const stored = await pool.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM messages WHERE id = ANY($1::uuid[])",
+      [[plain.id, sealed.id]],
+    );
+    expect(stored.rows[0]?.count).toBe("0");
   });
 
-  it("never rewrites a declaration a team already has", async () => {
-    // Once declared, later traffic does not reclassify the team: a team that
-    // changes profile does so by declaring, not by what it happens to send.
+  it("refuses plaintext for a team that declared age-v1, and says what to do", async () => {
+    // Reachable by a machine that has done nothing wrong: the team declared
+    // age-v1 after it last looked. Blocking the write is right — the server
+    // could read it — but "mismatch" alone is not actionable, so the refusal
+    // names the declared profile and how to get back in step.
     await resetTeamForDeclarationCase("age-v1");
 
+    const plain = message("750e8400-e29b-41d4-a716-4466554400c1", "plain");
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: { messages: [plain] },
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error.code).toBe("cipher-profile-mismatch");
+    expect(response.json().error.details.cipher_profile).toBe("age-v1");
+    expect(response.json().error.details.remedy).toContain("pull");
+
+    const stored = await pool.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM messages WHERE id = $1",
+      [plain.id],
+    );
+    expect(stored.rows[0]?.count).toBe("0");
+  });
+
+  it("refuses age-v1 for a team that declared none", async () => {
+    await resetTeamForDeclarationCase("none");
+
+    const sealed = {
+      id: "750e8400-e29b-41d4-a716-4466554400c2",
+      envelope: {
+        v: 1,
+        cipher: "age-v1",
+        key_id: "epoch-1",
+        blob: Buffer.from("opaque").toString("base64"),
+      },
+    };
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/messages",
+      headers,
+      payload: { messages: [sealed] },
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error.details.cipher_profile).toBe("none");
+
+    const stored = await pool.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM messages WHERE id = $1",
+      [sealed.id],
+    );
+    expect(stored.rows[0]?.count).toBe("0");
+  });
+
+  it("leaves an existing declaration alone even when traffic agrees with it", async () => {
+    // Traffic that disagrees is refused above, so the remaining question is
+    // whether an agreeing batch can still rewrite the column — it must not. The
+    // fill is `IS NULL` only: a declared team is settled, and changing it is a
+    // declaration, never a side effect of sending.
+    await resetTeamForDeclarationCase("none");
+
     const later = message("750e8400-e29b-41d4-a716-4466554400a2", "plaintext");
-    await app.inject({
+    const response = await app.inject({
       method: "POST",
       url: "/v1/messages",
       headers,
       payload: { messages: [later] },
     });
+    expect(response.statusCode).toBe(200);
 
     const after = await pool.query<{ cipher_profile: string | null }>(
       "SELECT cipher_profile FROM teams WHERE team_id = $1",
       [teamId],
     );
-    expect(after.rows[0]?.cipher_profile).toBe("age-v1");
+    expect(after.rows[0]?.cipher_profile).toBe("none");
   });
 });

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -23,6 +23,13 @@ CONNECT_CIPHERS = (["none"] if os.environ.get("MOCK_CONNECT_NO_AGE") == "1"
 # for", which is the real server's behaviour and what every other case wants.
 CONNECT_TEAM_NAME = os.environ.get("MOCK_CONNECT_TEAM_NAME", "")
 
+# What the server DECLARES this team uses, as distinct from CONNECT_CIPHERS
+# above, which is what it would accept. Empty means "no machine has declared
+# it" and is sent as JSON null — the state a team connected by an older client
+# is in, and the one `pull` must not read as "unencrypted".
+TEAM_CIPHER_PROFILE = os.environ.get("MOCK_TEAM_CIPHER_PROFILE", "age-v1")
+
+
 # POST /v1/connect registers a client-owned team once. No credential is issued
 # or returned — reaching the server is the permission. A team_id already
 # registered is refused 409 (a uniqueness conflict, like a non-fast-forward).
@@ -172,6 +179,7 @@ class Handler(BaseHTTPRequestHandler):
                 "current_seq": str(current_seq),
                 "next_sequence_boundary": str(current_seq + 1),
                 "min_available_seq": "0",
+                "cipher_profile": TEAM_CIPHER_PROFILE or None,
                 "accepted_envelope_versions": [1],
                 "write_allowed_ciphers": CONNECT_CIPHERS,
                 "policy_revision": "0",
@@ -206,6 +214,7 @@ class Handler(BaseHTTPRequestHandler):
                 "server_instance_id": PULL_SERVER_ID,
                 "team_id": PULL_TEAM_ID,
                 "min_available_seq": "0",
+                "cipher_profile": TEAM_CIPHER_PROFILE or None,
                 "members_revision": "0",
                 "members": PULL_MEMBERS,
             })
@@ -315,6 +324,7 @@ class Handler(BaseHTTPRequestHandler):
                 "team_id": PULL_TEAM_ID,
                 "team_name": "pulled-team",
                 "min_available_seq": "0",
+                "cipher_profile": TEAM_CIPHER_PROFILE or None,
                 "current_seq": str(len(PULL_MESSAGES) + len(PUSHED_MESSAGES)),
                 "policy_revision": "0",
                 "accepted_envelope_versions": [1],
@@ -343,6 +353,7 @@ class Handler(BaseHTTPRequestHandler):
                 "team_id": PULL_TEAM_ID,
                 "team_name": "pulled-team",
                 "min_available_seq": "0",
+                "cipher_profile": TEAM_CIPHER_PROFILE or None,
                 "messages": page,
                 "next_after": page[-1]["server_seq"] if page else str(after),
                 "has_more": False,
@@ -384,6 +395,7 @@ class Handler(BaseHTTPRequestHandler):
                 "server_instance_id": PULL_SERVER_ID,
                 "team_id": PULL_TEAM_ID,
                 "min_available_seq": "0",
+                "cipher_profile": TEAM_CIPHER_PROFILE or None,
                 "current_seq": current,
                 "items": [
                     {"kind": "frontier", "member_id": member["member_id"],
@@ -418,6 +430,7 @@ class Handler(BaseHTTPRequestHandler):
                 # test can see which of the two a message is quoting.
                 "team_name": CONNECT_TEAM_NAME or data.get("team_name", ""),
                 "min_available_seq": "0",
+                "cipher_profile": TEAM_CIPHER_PROFILE or None,
                 "current_seq": "0",
                 "next_sequence_boundary": "1",
                 "accepted_envelope_versions": [1],

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -4,6 +4,11 @@ load test_helper
 
 setup() {
   setup_test_env
+  # Reset here, not at the end of the case that changes it: bats runs every
+  # test in this same shell, so a knob left set would quietly reconfigure the
+  # server for each later test — and a case that fails early never gets to
+  # put it back.
+  MOCK_TEAM_CIPHER_PROFILE=age-v1
   export PEER_SKILL_DIR=""
   # Some cases deliberately remove python3 from PATH to verify the control-plane
   # gate. Resolve the fixture interpreter in each test process before that
@@ -19,6 +24,7 @@ setup() {
   MOCK_HEALTH_TEAM_ID="${MOCK_HEALTH_TEAM_ID:-}" \
   MOCK_CONNECT_NO_AGE="${MOCK_CONNECT_NO_AGE:-}" \
   MOCK_CONNECT_TEAM_NAME="${MOCK_CONNECT_TEAM_NAME:-}" \
+  MOCK_TEAM_CIPHER_PROFILE="${MOCK_TEAM_CIPHER_PROFILE-age-v1}" \
     "$MOCK_PYTHON3" "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
     </dev/null > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" 3>&- &
   MOCK_SERVER_PID=$!
@@ -83,6 +89,7 @@ restart_mock_server() {
   MOCK_HEALTH_TEAM_ID="${MOCK_HEALTH_TEAM_ID:-}" \
   MOCK_CONNECT_NO_AGE="${MOCK_CONNECT_NO_AGE:-}" \
   MOCK_CONNECT_TEAM_NAME="${MOCK_CONNECT_TEAM_NAME:-}" \
+  MOCK_TEAM_CIPHER_PROFILE="${MOCK_TEAM_CIPHER_PROFILE-age-v1}" \
     "$MOCK_PYTHON3" "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
       </dev/null > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" 3>&- &
   MOCK_SERVER_PID=$!
@@ -759,8 +766,52 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   [ "$(storage_history mixed | jq -s 'length')" -eq 73 ]
 }
 
+@test "remote pull: an encrypted team with NO messages is still recorded as encrypted" {
+  # The case the old inference got wrong. It set the profile from the number of
+  # age-v1 envelopes this pull carried, so a team that had sent nothing yet was
+  # recorded 'none' — and `unlock` then refused a team that really was sealed.
+  # Here the server declares age-v1 and the pull carries zero envelopes.
+  MOCK_PULL_AGE=0
+  MOCK_TEAM_CIPHER_PROFILE=age-v1
+  restart_mock_server
+
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" encrypted
+  [ "$status" -eq 0 ]
+
+  local cfg
+  cfg="$TEST_SKILL_DIR/teams/encrypted/config.json"
+  [ "$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$cfg")') AS TEXT), '\$.remote_binding.cipher_profile');")" = "age-v1" ]
+}
+
+@test "remote pull: no declaration is recorded as unknown, and unlock names the fix" {
+  # A team connected before the declaration was carried. The server answers
+  # null. Writing 'none' here is what made the binding unfixable, so it is
+  # written as unknown instead, and the refusal says who can settle it.
+  MOCK_TEAM_CIPHER_PROFILE=""
+  restart_mock_server
+
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" undeclared
+  [ "$status" -eq 0 ]
+
+  local cfg
+  cfg="$TEST_SKILL_DIR/teams/undeclared/config.json"
+  [ "$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$cfg")') AS TEXT), '\$.remote_binding.cipher_profile');")" = "unknown" ]
+
+  # Well-formed on purpose: an incomplete invocation would be refused by an
+  # argument check ahead of this one, and the test would pass without ever
+  # reaching the refusal it names.
+  run bash "$SCRIPTS/remote.sh" unlock --bundle /dev/null \
+    --confirm-digest 0000000000000000000000000000000000000000000000000000000000000000 undeclared
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not known to the server"* ]]
+  # Stopping is right; stopping without a next move is not.
+  [[ "$output" == *"remote.sh connect"* ]]
+  [[ "$output" != *"not an encrypted pulled team awaiting unlock"* ]]
+}
+
 @test "remote pull: an observed age envelope prevents plaintext push" {
   MOCK_PULL_AGE=1
+  MOCK_TEAM_CIPHER_PROFILE=age-v1
   restart_mock_server
 
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" encrypted

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -804,8 +804,12 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
     --confirm-digest 0000000000000000000000000000000000000000000000000000000000000000 undeclared
   [ "$status" -ne 0 ]
   [[ "$output" == *"is not known to the server"* ]]
-  # Stopping is right; stopping without a next move is not.
-  [[ "$output" == *"remote.sh connect"* ]]
+  # Stopping is right; stopping without a next move is not — and the move named
+  # has to be one that works. A repeat connect deliberately writes nothing for a
+  # team that already exists, so naming it would be advice that cannot succeed.
+  # What settles the declaration is the owning machine sending a message.
+  [[ "$output" == *"send.sh"* ]]
+  [[ "$output" != *"remote.sh connect"* ]]
   [[ "$output" != *"not an encrypted pulled team awaiting unlock"* ]]
 }
 


### PR DESCRIPTION
**Permission is not declaration.** `write_allowed_ciphers` was already there and
says what the server will ACCEPT (`{none, age-v1}`). Nothing said what a team
actually uses. That set is why this looks answered when it is not — the next
person to look will find it and stop, as I did.

## What broke

`pull` decided encryption by counting the age-v1 envelopes it happened to carry:

```sh
binding_cipher="none"
[ "$pulled_age_v1" -gt 0 ] && binding_cipher="age-v1"
```

A team with no messages yet carries none, so it was recorded unencrypted, and
`unlock` refused it: `not an encrypted pulled team awaiting unlock` — for a team
that was sealed.

Measured end to end on a disposable stack: connect with `--e2ee`, pull onto a
second machine before anything is sent, and recovery stops there while the
operator holds the correct key.

Counting arrivals answers *what has been sent*, never *what this team uses*.

## What this does

The declaration already existed — `connect` sets it from `--e2ee` rather than
guessing — it was just never sent. Now it is carried: connect states it, the
server stores it, every team snapshot returns it, pull reads it.

## Why the column is nullable with no default

`teams.cipher_profile` is `TEXT` with a CHECK and **no default**. NULL means
"connected before this was carried; nobody has declared it yet".

The server cannot backfill: it never stored the answer, and deriving one from
`messages.cipher` is the same guess, wrong for the same teams. `DEFAULT 'none'`
would turn every existing row into a confident false statement no later reader
could tell from a real declaration.

`pull` records that absence as `unknown` — not `none` — and both the shell and
the engine refuse it by name and say who can settle it:

```
agmsg: the encryption setting for 'X' is not known to the server, so this
machine cannot tell a sealed history from an empty one and will not guess.

The machine that already has 'X' knows. Reconnect it once, which records
the declaration for everyone:

    remote.sh connect --endpoint <endpoint> --e2ee X
```

Stopping is right. Stopping without a next move is what left the earlier binding
unfixable.

## Compatibility

`cipher_profile` is optional in the connect schema, so an older client still
connects — its team is recorded with no declaration rather than a wrong one.

## Verification

```
$ bats tests/test_remote.bats                     68 ok, 0 failures
$ node --test tests/remote_sync_engine.test.mjs   66 pass, 0 fail
```

Both new cases fail against the previous client:

```
not ok 1 remote pull: an encrypted team with NO messages is still recorded as encrypted
not ok 2 remote pull: no declaration is recorded as unknown, and unlock names the fix
```

The server suite has one failure, `synchronizes two isolated
AGMSG_STORAGE_PATH stores without echo duplicates` (timeout). It fails the same
way on the unmodified tree here, so it is not from this change.