### PR TITLE
fix(remote): keep the capability out of the terminal

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -108,6 +108,33 @@ _remote_validate_endpoint() {
   python3 "$SCRIPT_DIR/internal/validate-endpoint.py" "$1"
 }
 
+# An endpoint, safe to print. Keeps the scheme, host and port; DROPS everything
+# else, and the list of what it drops is the point of this function:
+#
+#   path      — a hosted endpoint is `https://host/t/<token>`, and that token IS
+#               the capability. Anyone who reads it off a terminal, a screen
+#               share or a pasted log can connect as this team.
+#   userinfo  — `scheme://user:pass@host` puts a credential before the host, so
+#               a "host and port only" rule that forgets it prints the password.
+#   query, fragment — no current endpoint carries either, and that is exactly
+#               why they would be missed when one does.
+#
+# The caller keeps the team name in the message. That is what makes host-only
+# enough to identify the destination: a team has one endpoint, so `team 'X' to
+# host:port` names it exactly without naming the secret.
+_remote_endpoint_display() {
+  local url="$1" scheme rest
+  case "$url" in
+    *://*) scheme="${url%%://*}://"; rest="${url#*://}" ;;
+    *) scheme=""; rest="$url" ;;
+  esac
+  # Cut the path/query/fragment FIRST. Doing userinfo first would let an `@`
+  # inside a path decide where the host ends.
+  rest="${rest%%/*}"; rest="${rest%%\?*}"; rest="${rest%%#*}"
+  rest="${rest##*@}"
+  printf '%s%s' "$scheme" "$rest"
+}
+
 # Read an interactive value without coupling it to the token transport.
 # `connect --token-stdin` intentionally consumes fd 0 through EOF before the
 # E2EE bootstrap starts. In a real terminal the choice/identity must therefore
@@ -1074,14 +1101,14 @@ cmd_connect() {
         json('[]'))
     );" > "$body_file"
 
-  echo "Connecting team '$team' to $endpoint ..." >&2
+  echo "Connecting team '$team' to $(_remote_endpoint_display "$endpoint") ..." >&2
   http_code="$(_remote_http_post_json "$endpoint/v1/connect" "$body_file" "$resp_file" "$header_file")"
   if [ "$http_code" = "409" ]; then
     echo "agmsg: team '$team' (team_id $team_id) is already registered on this remote. A team_id registers once — this is a uniqueness conflict (like a non-fast-forward push), not a transient error to retry." >&2
     exit 1
   fi
   if [ "$http_code" != "200" ]; then
-    echo "agmsg: connect failed — $endpoint/v1/connect returned HTTP $http_code" >&2
+    echo "agmsg: connect failed — $(_remote_endpoint_display "$endpoint")/v1/connect returned HTTP $http_code" >&2
     exit 1
   fi
 

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -23,6 +23,13 @@ CONNECT_CIPHERS = (["none"] if os.environ.get("MOCK_CONNECT_NO_AGE") == "1"
 # for", which is the real server's behaviour and what every other case wants.
 CONNECT_TEAM_NAME = os.environ.get("MOCK_CONNECT_TEAM_NAME", "")
 
+# Force /v1/connect to answer with a given HTTP status. Only a test that needs
+# the client's non-200 branch sets this; everything else leaves it unset and
+# gets the normal handler. Owning the status here is what makes such a test
+# hermetic -- the alternative, pointing the client at a port nobody is listening
+# on, depends on a port being free, which no test owns.
+CONNECT_STATUS = os.environ.get("MOCK_CONNECT_STATUS", "")
+
 # What the server DECLARES this team uses, as distinct from CONNECT_CIPHERS
 # above, which is what it would accept. Empty means "no machine has declared
 # it" and is sent as JSON null — the state a team connected by an older client
@@ -364,6 +371,14 @@ class Handler(BaseHTTPRequestHandler):
     def do_POST(self):
         length = int(self.headers.get("Content-Length", 0))
         raw = self.rfile.read(length) if length else b""
+
+        # Before routing, on purpose. A capability endpoint is
+        # `https://host/t/<token>`, so every request path arrives with that
+        # prefix and would miss a check placed inside a `self.path == "/v1/..."`
+        # branch. Only a test that needs the client's non-200 branch sets this.
+        if CONNECT_STATUS and self.path.endswith("/v1/connect"):
+            self._send_json(int(CONNECT_STATUS), {"error": {"code": "forced-by-fixture"}})
+            return
 
         if self.path == "/v1/messages":
             try:

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -140,6 +140,42 @@ skip_if_no_age() {
   [ "$status" -eq 0 ]
 }
 
+@test "connect: the capability path never reaches the terminal" {
+  # A hosted endpoint is `https://host/t/<token>` and that token IS the
+  # capability -- read it off a terminal, a screen share or a pasted log and you
+  # can connect as this team. `connect` printed the whole URL twice, on every
+  # run, for every user.
+  #
+  # The assertion is that the secret is ABSENT, so it has to also assert that
+  # the line was printed at all: "no token in the output" is trivially true of
+  # no output, and would keep passing if the message were deleted or renamed.
+  local secret="agsy_do_not_print_this_token"
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT/t/$secret" testteam
+  [[ "$output" == *"Connecting team 'testteam' to"* ]]
+  [[ "$output" == *"127.0.0.1:$MOCK_PORT"* ]]
+  [[ "$output" != *"$secret"* ]]
+  [[ "$output" != *"/t/"* ]]
+}
+
+@test "the endpoint shown on the terminal keeps only scheme, host and port" {
+  # Unit-level, because `connect` cannot reach the interesting inputs: the
+  # validator refuses userinfo outright (see the loopback-bypass test below),
+  # so that branch of the redactor is defence in depth and has to be exercised
+  # here or not at all. Query and fragment are the same -- no endpoint carries
+  # one today, which is exactly why one would slip through when it does.
+  # shellcheck disable=SC1090
+  eval "$(sed -n '/^_remote_endpoint_display()/,/^}/p' "$SCRIPTS/remote.sh")"
+  [ "$(_remote_endpoint_display "http://127.0.0.1:8797/t/SECRET")" = "http://127.0.0.1:8797" ]
+  [ "$(_remote_endpoint_display "https://u:pa55@example.com/t/SECRET")" = "https://example.com" ]
+  [ "$(_remote_endpoint_display "https://example.com?token=SECRET")" = "https://example.com" ]
+  [ "$(_remote_endpoint_display "https://example.com#SECRET")" = "https://example.com" ]
+  # An `@` inside the path must not be read as the end of the userinfo.
+  [ "$(_remote_endpoint_display "https://a@b@evil.example/t/SECRET")" = "https://evil.example" ]
+  [ "$(_remote_endpoint_display "http://[::1]:8080/t/SECRET")" = "http://[::1]:8080" ]
+  # Port survives -- it is how two local servers are told apart.
+  [ "$(_remote_endpoint_display "https://host.example.com:443")" = "https://host.example.com:443" ]
+}
+
 @test "connect: requires the response protocol header" {
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" missing-protocol-header-token myteam
   [ "$status" -ne 0 ]

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -157,6 +157,26 @@ skip_if_no_age() {
   [[ "$output" != *"/t/"* ]]
 }
 
+@test "connect: the capability path is absent from the FAILURE message too" {
+  # The failure line matters more than the progress line, and it was the one no
+  # test reached. Successful output scrolls past; failing output gets pasted --
+  # into a bug report, a chat, a screenshot -- and then it is stored, forwarded
+  # and searchable with the capability in it.
+  #
+  # A closed loopback port is what drives it: the endpoint passes validation,
+  # the POST cannot connect, and the HTTP branch prints. Reaching that line at
+  # all is asserted, because "the token is not in the output" is also true of
+  # output that never mentioned the endpoint.
+  local secret="agsy_do_not_print_this_token"
+  local closed_port=1
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "http://127.0.0.1:$closed_port/t/$secret" testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"connect failed"* ]]
+  [[ "$output" == *"127.0.0.1:$closed_port"* ]]
+  [[ "$output" != *"$secret"* ]]
+  [[ "$output" != *"/t/"* ]]
+}
+
 @test "the endpoint shown on the terminal keeps only scheme, host and port" {
   # Unit-level, because `connect` cannot reach the interesting inputs: the
   # validator refuses userinfo outright (see the loopback-bypass test below),

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -9,6 +9,8 @@ setup() {
   # server for each later test — and a case that fails early never gets to
   # put it back.
   MOCK_TEAM_CIPHER_PROFILE=age-v1
+  MOCK_CONNECT_STATUS=""
+  export MOCK_CONNECT_STATUS
   export PEER_SKILL_DIR=""
   # Some cases deliberately remove python3 from PATH to verify the control-plane
   # gate. Resolve the fixture interpreter in each test process before that
@@ -24,6 +26,7 @@ setup() {
   MOCK_HEALTH_TEAM_ID="${MOCK_HEALTH_TEAM_ID:-}" \
   MOCK_CONNECT_NO_AGE="${MOCK_CONNECT_NO_AGE:-}" \
   MOCK_CONNECT_TEAM_NAME="${MOCK_CONNECT_TEAM_NAME:-}" \
+  MOCK_CONNECT_STATUS="${MOCK_CONNECT_STATUS:-}" \
   MOCK_TEAM_CIPHER_PROFILE="${MOCK_TEAM_CIPHER_PROFILE-age-v1}" \
     "$MOCK_PYTHON3" "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
     </dev/null > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" 3>&- &
@@ -89,6 +92,7 @@ restart_mock_server() {
   MOCK_HEALTH_TEAM_ID="${MOCK_HEALTH_TEAM_ID:-}" \
   MOCK_CONNECT_NO_AGE="${MOCK_CONNECT_NO_AGE:-}" \
   MOCK_CONNECT_TEAM_NAME="${MOCK_CONNECT_TEAM_NAME:-}" \
+  MOCK_CONNECT_STATUS="${MOCK_CONNECT_STATUS:-}" \
   MOCK_TEAM_CIPHER_PROFILE="${MOCK_TEAM_CIPHER_PROFILE-age-v1}" \
     "$MOCK_PYTHON3" "$BATS_TEST_DIRNAME/helpers/mock_remote_server.py" 0 \
       </dev/null > "$TEST_SKILL_DIR/server.port" 2>"$TEST_SKILL_DIR/server.log" 3>&- &
@@ -158,21 +162,27 @@ skip_if_no_age() {
 }
 
 @test "connect: the capability path is absent from the FAILURE message too" {
-  # The failure line matters more than the progress line, and it was the one no
-  # test reached. Successful output scrolls past; failing output gets pasted --
-  # into a bug report, a chat, a screenshot -- and then it is stored, forwarded
-  # and searchable with the capability in it.
+  # The failure line matters more than the progress line: successful output
+  # scrolls past, failing output gets pasted -- into a bug report, a chat, a
+  # screenshot -- and is then stored, forwarded and searchable.
   #
-  # A closed loopback port is what drives it: the endpoint passes validation,
-  # the POST cannot connect, and the HTTP branch prints. Reaching that line at
-  # all is asserted, because "the token is not in the output" is also true of
-  # output that never mentioned the endpoint.
+  # The status is forced by the fixture rather than by pointing at a port
+  # nobody is listening on. A free port is not state this test owns: anything
+  # on the runner may be bound to it, and then the POST succeeds and the branch
+  # under test never runs. The mock is started by this suite, so its answer is
+  # ours to decide.
+  #
+  # Reaching the line is asserted too. "The token is not in the output" is also
+  # true of output that never mentioned the endpoint at all.
+  MOCK_CONNECT_STATUS=503
+  export MOCK_CONNECT_STATUS
+  restart_mock_server
   local secret="agsy_do_not_print_this_token"
-  local closed_port=1
-  run bash "$SCRIPTS/remote.sh" connect --endpoint "http://127.0.0.1:$closed_port/t/$secret" testteam
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT/t/$secret" testteam
   [ "$status" -ne 0 ]
   [[ "$output" == *"connect failed"* ]]
-  [[ "$output" == *"127.0.0.1:$closed_port"* ]]
+  [[ "$output" == *"returned HTTP 503"* ]]
+  [[ "$output" == *"127.0.0.1:$MOCK_PORT"* ]]
   [[ "$output" != *"$secret"* ]]
   [[ "$output" != *"/t/"* ]]
 }


### PR DESCRIPTION
## The capability was on the terminal, twice, every run

A hosted endpoint is `https://host/t/<token>`, and that token **is** the capability — anyone who reads it off a terminal, a screen share, or a pasted log can connect as that team. `scripts/remote.sh` printed the whole URL twice on every `connect`:

```
:1077  echo "Connecting team '$team' to $endpoint ..." >&2
:1084  echo "agmsg: connect failed — $endpoint/v1/connect returned HTTP $http_code" >&2
```

Confirmed against a real config whose `endpoint` carries a live token.

## Swept before fixing

Across `scripts/` and the sync engine these two lines are the only places an endpoint value reaches output — the third hit is a usage string with a `<url>` placeholder. The engine's own logs were grepped and carry none. So the fix is bounded to these two lines.

## What is printed now, and why host-only is enough

Scheme, host and port. Not a digest, not a prefix.

tl's objection to host-only was that two capabilities on one host become indistinguishable. They don't, in context: **the line already names the team, and a team has exactly one endpoint.** `Connecting team 'X' to 127.0.0.1:8797 ...` identifies the destination exactly without naming the secret.

A fingerprint of the URL was the other candidate and was dropped on measurement: the repo's portable hash helper (`scripts/lib/hash.sh`) falls back through `shasum → sha1sum → openssl → cksum`, so on a machine that reaches `cksum` the "fingerprint" is 32 bits and two endpoints can collide. A value whose collision behaviour depends on which tools a user has installed is not an identifier.

## The comment enumerates what is dropped

That list is the function:

- **path** — the capability itself
- **userinfo** — `scheme://user:pass@host` puts a credential *before* the host, so a rule phrased as "keep the host and port" prints the password unless it says otherwise. Defence in depth here: the validator already refuses userinfo.
- **query, fragment** — no endpoint carries either today, which is exactly why they would be missed the day one does.

Order matters and is commented: the path is cut first, so an `@` inside a path cannot decide where the host ends. `https://a@b@evil.example/t/SECRET` → `https://evil.example`.

## Tests

**`connect: the capability path never reaches the terminal`** asserts the token is absent **and that the line was printed at all**. "No token in the output" is trivially true of no output, and would keep passing if someone deleted or renamed the message.

**`the endpoint shown on the terminal keeps only scheme, host and port`** drives the redactor directly, because `connect` cannot reach the interesting inputs — the validator rejects userinfo before any printing, so that branch is testable here or nowhere. Covers userinfo, query, fragment, the double-`@`, IPv6, and a bare port.

`tests/test_remote.bats` **70/70**.

**Mutation:** reverting the two call sites fails the first test. Run twice — the first mutation run also showed `remote unlock --authenticated-bundle-stdin` red, which did **not** reproduce on the repeat and passes on the fixed tree; recorded here as a flake rather than left as an unexplained number.
