### PR TITLE
fix(remote): print an unlock command the operator can actually run

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -798,7 +798,15 @@ cmd_pull() {
     echo "Pulled '$pulled_name' into local team '$team' ($imported message(s)). Sync engine running."
   fi
   if [ "$pulled_age_v1" -gt 0 ]; then
-    echo "This team is local but locked. Run remote.sh unlock --bundle with the secret handoff bundle you were given."
+    # Print something that can be typed. `remote.sh` is not on PATH and never
+    # has been: it lives in this install's scripts directory, whose name is
+    # whatever the install was given -- which is why the sibling branch below
+    # already goes through $cmd_name. The old line named a bare script the
+    # shell cannot find, and named only --bundle, while --bundle without
+    # --confirm-digest is refused a few lines into unlock. Both halves have to
+    # be right, or this is a dead end with extra steps.
+    echo "This team is local but locked. Unlock it with the secret handoff bundle you were given:"
+    echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/remote.sh") unlock $(agmsg_shq "$team") --bundle <file> --confirm-digest <sha256>"
   else
     echo "This team is now local and ready for normal use."
     echo "Open your agent and invoke its installed '$cmd_name' command, then join with a new agent name."

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1007,6 +1007,11 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   cmd_name="$(basename "$TEST_SKILL_DIR")"
   [[ "$output" == *"This team is now local and ready for normal use."* ]]
   [[ "$output" == *"Open your agent and invoke its installed '$cmd_name' command, then join with a new agent name."* ]]
+  # And NOT the locked branch's guidance. Asserting only that the right line is
+  # present would pass for an output carrying both, which is what a reader
+  # cannot reconcile -- the shape reported in #147.
+  [[ "$output" != *"local but locked"* ]]
+  [[ "$output" != *"unlock"* ]]
   local cfg
   cfg="$TEST_SKILL_DIR/teams/cloned/config.json"
   [ -f "$cfg" ]
@@ -1160,7 +1165,10 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" encrypted
   [ "$status" -eq 0 ]
   [[ "$output" == *"This team is encrypted"* ]]
-  [[ "$output" == *"Run remote.sh unlock --bundle with the secret handoff bundle you were given."* ]]
+  # The remedy, in a form that can be typed: an absolute path (remote.sh is
+  # not on PATH) and both flags unlock actually requires.
+  [[ "$output" == *"$SCRIPTS/remote.sh"*"unlock"*"--bundle"*"--confirm-digest"* ]]
+  [[ "$output" != *"Run remote.sh unlock"* ]]
 
   local cfg before after
   cfg="$TEST_SKILL_DIR/teams/encrypted/config.json"
@@ -1227,6 +1235,15 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   run bash "$peer_scripts/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$team_id" encrypted
   [ "$status" -eq 0 ]
   [[ "$output" == *"local but locked"* ]]
+  # The remedy has to be typable. `remote.sh` is not on PATH, and --bundle
+  # without --confirm-digest is refused by unlock itself, so a line naming
+  # either alone sends the operator into a wall.
+  [[ "$output" == *"$peer_scripts/remote.sh"* ]]
+  [[ "$output" == *"unlock"*"--bundle"*"--confirm-digest"* ]]
+  [[ "$output" != *"Run remote.sh unlock"* ]]
+  # And NOT the plaintext branch's guidance -- the same output must not also
+  # say the team is ready.
+  [[ "$output" != *"ready for normal use"* ]]
 
   digest="$(shasum -a 256 "$snapshot" | awk '{print $1}')"
   run bash "$peer_scripts/remote.sh" unlock encrypted \
@@ -1634,4 +1651,29 @@ assert_lookup_rejected() {
   assert_lookup_rejected protocol
   assert_lookup_rejected server_id
   assert_lookup_rejected root_name
+}
+
+@test "remote pull: the unlock line it prints can actually be run (#147)" {
+  # Typed, not read. A remedy line is only worth printing if a shell can run
+  # it: this takes the line out of the output, fills the placeholders, and
+  # requires the failure to be about the BUNDLE -- never "command not found"
+  # (remote.sh is not on PATH) and never a usage error (--bundle alone is
+  # refused, so a line naming only --bundle is a dead end with extra steps).
+  MOCK_PULL_AGE=1
+  MOCK_TEAM_CIPHER_PROFILE=age-v1
+  restart_mock_server
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" encrypted
+  [ "$status" -eq 0 ]
+
+  local printed
+  printed="$(printf '%s\n' "$output" | grep -F 'remote.sh' | grep -F 'unlock' | head -1 | sed 's/^ *//')"
+  [ -n "$printed" ]
+
+  local runnable="${printed//<file>/\/nonexistent\/bundle.json}"
+  runnable="${runnable//<sha256>/0000000000000000000000000000000000000000000000000000000000000000}"
+  run eval "$runnable"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"command not found"* ]]
+  [[ "$output" != *"No such file or directory"*"remote.sh"* ]]
+  [[ "$output" != *"Usage: remote.sh unlock"* ]]
 }


### PR DESCRIPTION
The locked branch of `remote.sh pull` printed:

> Run remote.sh unlock --bundle with the secret handoff bundle you were given.

Two things in that sentence do not work.

**`remote.sh` is not on PATH**, and never has been — it lives in the install's scripts directory, whose name is whatever that install was given (this machine carries `agmsg`, `agmsg2`, `e2a`, …). Measured: `command -v remote.sh` → exit 1. The sibling branch four lines below already goes through `$cmd_name` for exactly this reason; the locked branch was the one that did not.

**`--bundle` alone is refused.** `unlock` requires `--confirm-digest` alongside it, about thirty lines into the same file. Naming half the invocation sends the operator into a usage error *after* they have gone and found the bundle.

It now prints the absolute path, the team and both flags, with the path and team quoted through `agmsg_shq` since either may legally contain a space or a quote.

## The regression types it

Rather than assert that a word appears, the new test lifts the line out of the output, fills the placeholders and **runs it**, requiring the failure to be about the bundle — never `command not found`, never a usage error.

Reverting the message to the old wording fails that test. That is what makes it worth having.

## Both directions

Both branches now assert the **absence** of the other's guidance:

| team | says | must not say |
| --- | --- | --- |
| encrypted | `local but locked` + a runnable unlock line | `ready for normal use` |
| plaintext | `now local and ready for normal use` | `local but locked`, `unlock` |

Checking only that the right line appears would pass just as happily for an output carrying both — which is the state reported in JugemuAI/agmsg-cloud#147.

Local: `tests/test_remote.bats` → `1..85`, no failures.