### PR TITLE
fix(guidance): the caller can own the "what to do next" lines

### DIFF
--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -27,6 +27,8 @@ source "$SCRIPT_DIR/lib/storage.sh"
 source "$SCRIPT_DIR/lib/registry-lock.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/validate.sh"
+# shellcheck source=lib/operator-guidance.sh
+source "$SCRIPT_DIR/lib/operator-guidance.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/roster-journal.sh"
 
@@ -315,15 +317,29 @@ cmd_generate() {
   echo "Generated a new key for team '$team'."
   echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
   echo
-  echo "Back this up now. agmsg does not store a copy of this key anywhere —"
-  echo "if this device is lost, every message encrypted under this key"
-  echo "becomes permanently unreadable. There is no server-side recovery."
-  echo "Run 'key.sh show $team --reveal-secret' to view and save it somewhere"
-  echo "safe — a password manager entry, not a plaintext file. Do NOT copy"
-  echo "it into a dotfiles repo, a git repo of any kind, or any other"
-  echo "synced/backed-up-by-a-tool location you wouldn't also trust with a"
-  echo "production credential. Removing a device later does not revoke its"
-  echo "ability to read history encrypted before removal."
+  # What the key IS, always: true whoever ran this, so it is never held back.
+  # Losing it costs the same either way -- a vault elsewhere holds a sealed
+  # copy of this key, not a second key, so a lost key with no backup of any
+  # kind is still a lost history.
+  echo "If this device is lost, every message encrypted under this key"
+  echo "becomes permanently unreadable. Removing a device later does not"
+  echo "revoke its ability to read history encrypted before removal."
+
+  # What to DO about it: only ours to say when nobody else owns that job.
+  # Both claims below are specific to a plain install -- a larger tool may
+  # keep a sealed copy on a server and have its own way to set that up, and
+  # its operator has never heard of key.sh. Saying this there is not merely
+  # noise; it is false, and it points away from the route they have.
+  if agmsg_operator_guidance_is_ours; then
+    echo
+    echo "Back this up now. agmsg does not store a copy of this key anywhere,"
+    echo "and there is no server-side recovery. Run"
+    echo "'key.sh show $team --reveal-secret' to view and save it somewhere"
+    echo "safe — a password manager entry, not a plaintext file. Do NOT copy"
+    echo "it into a dotfiles repo, a git repo of any kind, or any other"
+    echo "synced/backed-up-by-a-tool location you wouldn't also trust with a"
+    echo "production credential."
+  fi
 }
 
 cmd_show() {

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -318,12 +318,18 @@ cmd_generate() {
   echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
   echo
   # What the key IS, always: true whoever ran this, so it is never held back.
-  # Losing it costs the same either way -- a vault elsewhere holds a sealed
-  # copy of this key, not a second key, so a lost key with no backup of any
-  # kind is still a lost history.
-  echo "If this device is lost, every message encrypted under this key"
-  echo "becomes permanently unreadable. Removing a device later does not"
-  echo "revoke its ability to read history encrypted before removal."
+  #
+  # Stated as KEY loss, not DEVICE loss. Those are the same event only where
+  # nothing keeps a copy, which is this install's situation and not everyone's
+  # -- a caller may hold a sealed copy of this same key and be able to recover
+  # it after the device is gone. "Lose the device and it is unreadable" would
+  # be the very premise this change exists to stop asserting on their behalf.
+  # The condition below holds either way, because a surviving copy is exactly
+  # what makes it not hold.
+  echo "If this key is lost and no copy of it survives anywhere, every"
+  echo "message encrypted under it becomes permanently unreadable. Removing"
+  echo "a device later does not revoke its ability to read history encrypted"
+  echo "before removal."
 
   # What to DO about it: only ours to say when nobody else owns that job.
   # Both claims below are specific to a plain install -- a larger tool may
@@ -333,7 +339,8 @@ cmd_generate() {
   if agmsg_operator_guidance_is_ours; then
     echo
     echo "Back this up now. agmsg does not store a copy of this key anywhere,"
-    echo "and there is no server-side recovery. Run"
+    echo "and there is no server-side recovery — so losing this device loses"
+    echo "the key, and with it the history. Run"
     echo "'key.sh show $team --reveal-secret' to view and save it somewhere"
     echo "safe — a password manager entry, not a plaintext file. Do NOT copy"
     echo "it into a dotfiles repo, a git repo of any kind, or any other"

--- a/scripts/lib/operator-guidance.sh
+++ b/scripts/lib/operator-guidance.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Who tells the operator what to do next.
+#
+# These scripts are run two ways: directly, and by a larger tool that runs them
+# with stdio inherited so their progress and prompts reach the same terminal.
+# That inheritance is deliberate — but it also means guidance written for
+# someone driving agmsg by hand lands in front of someone driving something
+# else, and the route it names may not be the route they have. It can be worse
+# than useless: telling an operator to carry key material out of band, when the
+# tool they are using has a ceremony that exists to make that unnecessary,
+# talks them out of the safer path.
+#
+# So the caller says whether it owns that job, and everything here asks ONE
+# function rather than reading the variable itself. Two readers of one variable
+# is how the two sides drift apart, and a drift here is silent: the screen just
+# says something untrue.
+#
+# The question is "am I the one who should speak", NOT "who called me". A
+# variable naming the caller (AGMSG_CALLED_BY=cloud) would make this file start
+# counting kinds of caller, and grow a branch for every new one. What these
+# scripts need to know has no plural.
+#
+# Facts are NOT guidance. "Losing this key makes its messages unreadable" is
+# true however agmsg was invoked, and stays. What gets held back is only the
+# next step — which route to take, which command to run.
+
+# agmsg_operator_guidance_is_ours -> 0 when this process should print the
+# "what to do next" guidance, 1 when the caller has taken that on.
+#
+# Unset is 0: a plain install must behave exactly as it always has, and the
+# quiet mode has to be asked for explicitly. Any value other than `caller` is
+# also 0 — an unrecognised setting must not silence a page of guidance.
+agmsg_operator_guidance_is_ours() {
+  [ "${AGMSG_OPERATOR_GUIDANCE:-}" = "caller" ] && return 1
+  return 0
+}

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -40,6 +40,8 @@ source "$SCRIPT_DIR/lib/storage.sh"
 source "$SCRIPT_DIR/lib/registry-lock.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/validate.sh"
+# shellcheck source=lib/operator-guidance.sh
+source "$SCRIPT_DIR/lib/operator-guidance.sh"
 # shellcheck source=lib/shquote.sh
 source "$SCRIPT_DIR/lib/shquote.sh"
 # shellcheck disable=SC1091
@@ -1431,7 +1433,12 @@ cmd_connect() {
     server_side=" (on the server: '$remote_team_name')"
   fi
   echo "Connected: team '$team'$server_side ($connection_security). Sync engine running."
-  if [ "$e2ee" -eq 1 ]; then
+  # Carrying the snapshot and key by hand is the plain install's answer to
+  # getting a second machine in. A larger tool may have a ceremony for exactly
+  # that, and this line would talk its operator out of it -- into doing by hand
+  # the thing the ceremony exists to make unnecessary. So it is said only when
+  # nobody else owns the next step.
+  if [ "$e2ee" -eq 1 ] && agmsg_operator_guidance_is_ours; then
     echo "Export the public epoch snapshot with: key.sh show $team --snapshot --out <file>"
     echo "Transfer that snapshot and the key out of band; the other machine must import and live-confirm them before syncing."
   fi

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -99,8 +99,13 @@ EOF
   [[ "$output" == *"no server-side recovery"* ]]
   # The facts ride along with it, and are asserted here too so the split
   # between fact and guidance cannot quietly move.
+  [[ "$output" == *"no copy of it survives anywhere"* ]]
   [[ "$output" == *"becomes permanently unreadable"* ]]
   [[ "$output" == *"revoke its ability to read history"* ]]
+  # Where nothing keeps a copy, losing the device IS losing the key. That
+  # implication belongs to this path only, so it is stated in the guidance
+  # rather than left for the reader to derive.
+  [[ "$output" == *"losing this device loses"* ]]
 }
 
 @test "key generate: a caller that owns the guidance gets the facts without ours" {
@@ -120,6 +125,7 @@ EOF
   # own defect: these are true however agmsg was invoked.
   [[ "$output" == *"Generated a new key for team 'testteam'"* ]]
   [[ "$output" == *"Recipient fingerprint:"* ]]
+  [[ "$output" == *"no copy of it survives anywhere"* ]]
   [[ "$output" == *"becomes permanently unreadable"* ]]
   [[ "$output" == *"revoke its ability to read history"* ]]
 
@@ -128,6 +134,13 @@ EOF
   [[ "$output" != *"no server-side recovery"* ]]
   [[ "$output" != *"--reveal-secret"* ]]
   [[ "$output" != *"password manager"* ]]
+
+  # And does not assert that losing the DEVICE loses the history. That is
+  # true only where nothing keeps a copy; a caller may hold a sealed copy of
+  # this same key and be able to recover it. Asserting it on their behalf is
+  # the same premise this change exists to stop asserting.
+  [[ "$output" != *"losing this device loses"* ]]
+  [[ "$output" != *"If this device is lost"* ]]
 }
 
 @test "key generate: an unrecognised guidance setting still prints the guidance" {

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -97,6 +97,46 @@ EOF
   [[ "$output" == *"Recipient fingerprint:"* ]]
   [[ "$output" == *"Back this up now"* ]]
   [[ "$output" == *"no server-side recovery"* ]]
+  # The facts ride along with it, and are asserted here too so the split
+  # between fact and guidance cannot quietly move.
+  [[ "$output" == *"becomes permanently unreadable"* ]]
+  [[ "$output" == *"revoke its ability to read history"* ]]
+}
+
+@test "key generate: a caller that owns the guidance gets the facts without ours" {
+  skip_if_no_age
+  # A larger tool runs this with stdio inherited, so whatever it prints lands
+  # in front of ITS operator. Guidance written for a plain install names a
+  # route that operator does not have -- and "there is no server-side
+  # recovery" is simply false where the tool keeps a sealed copy on a server.
+  #
+  # Both directions are asserted, here and above: with only the default case,
+  # a suppression that never fires would still be green, and with only this
+  # one, a version that printed nothing at all would be too.
+  AGMSG_OPERATOR_GUIDANCE=caller run bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -eq 0 ]
+
+  # Still speaks, and still says what the key IS. Silence here would be its
+  # own defect: these are true however agmsg was invoked.
+  [[ "$output" == *"Generated a new key for team 'testteam'"* ]]
+  [[ "$output" == *"Recipient fingerprint:"* ]]
+  [[ "$output" == *"becomes permanently unreadable"* ]]
+  [[ "$output" == *"revoke its ability to read history"* ]]
+
+  # And says nothing about what to do next, or where a copy is kept.
+  [[ "$output" != *"Back this up now"* ]]
+  [[ "$output" != *"no server-side recovery"* ]]
+  [[ "$output" != *"--reveal-secret"* ]]
+  [[ "$output" != *"password manager"* ]]
+}
+
+@test "key generate: an unrecognised guidance setting still prints the guidance" {
+  skip_if_no_age
+  # Fail toward speaking. A typo'd or future value must not silence a page of
+  # instructions -- the quiet mode is asked for by name or not at all.
+  AGMSG_OPERATOR_GUIDANCE=cloud run bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no server-side recovery"* ]]
 }
 
 @test "key generate: stores public recipient (not secret) in team config" {

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -466,6 +466,32 @@ _capability_endpoint() {
   [ "$(_remote_endpoint_display "https://host.example.com:443")" = "https://host.example.com:443" ]
 }
 
+@test "connect: the out-of-band handoff line is printed by default" {
+  skip_if_no_age
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Export the public epoch snapshot"* ]]
+  [[ "$output" == *"out of band"* ]]
+}
+
+@test "connect: a caller that owns the guidance does not get the out-of-band line" {
+  skip_if_no_age
+  # Carrying the key by hand is this install's answer to adding a machine. A
+  # tool with a ceremony for that would have its operator talked out of it --
+  # into doing by hand exactly what the ceremony exists to prevent.
+  #
+  # Paired with the test above deliberately: absence alone would pass for a
+  # connect that printed nothing, and presence alone would pass for a
+  # suppression that never fires.
+  AGMSG_OPERATOR_GUIDANCE=caller run bash "$SCRIPTS/remote.sh" connect \
+    --endpoint "$ENDPOINT" --e2ee testteam
+  [ "$status" -eq 0 ]
+  # The result is still reported -- only the next step is withheld.
+  [[ "$output" == *"Connected: team 'testteam'"* ]]
+  [[ "$output" != *"Export the public epoch snapshot"* ]]
+  [[ "$output" != *"out of band"* ]]
+}
+
 @test "connect: requires the response protocol header" {
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" missing-protocol-header-token myteam
   [ "$status" -ne 0 ]


### PR DESCRIPTION
These scripts are run two ways: directly, and by a larger tool that runs them with stdio inherited so their progress and prompts reach the same terminal. That inheritance is deliberate — and it also means guidance written for someone driving agmsg by hand lands in front of someone driving something else.

Three lines are wrong there, and not merely noise:

| where | says | why it's wrong for a caller |
| --- | --- | --- |
| `key.sh` | "agmsg does not store a copy of this key anywhere … **there is no server-side recovery**" | False where the caller keeps a sealed copy on a server — which is a thing that exists |
| `key.sh` | "Run `key.sh show <team> --reveal-secret` to save it" | Names a command that operator has never heard of, instead of the route they have |
| `remote.sh` | "Export the public epoch snapshot … **transfer it out of band**" | Talks someone out of a ceremony that exists to make exactly that unnecessary, and into carrying key material by hand |

## The shape

The caller says whether it owns that job, through **one function** both scripts ask:

```sh
agmsg_operator_guidance_is_ours()   # 0 = we speak, 1 = the caller has it
```

Neither script reads the variable itself. Two readers of one variable is how the sides drift, and a drift here is silent — the screen just says something untrue.

The question is **"should I speak"**, not "who called me". A variable naming the caller would make this file start counting kinds of caller and grow a branch per kind; what these scripts need to know has no plural.

**Unset behaves exactly as before**, and so does any unrecognised value: a typo must not silence a page of instructions.

## Facts are not guidance

Never held back, because they are true however agmsg was invoked:

- losing this key makes its messages permanently unreadable
- removing a device does not revoke what it already read

A vault elsewhere holds a sealed copy of *this* key, not a second one. Suppressed is only the next step.

**When suppressed, the scripts say nothing in place of it.** Carrying a substitute would mean this repo owning another tool's wording, and changing here every time that changes there.

## Verification

Both directions, on both sites — either alone is green for a broken implementation:

- with only the default case, a suppression that never fires passes
- with only the suppressed case, a version that prints nothing at all passes

Confirmed by mutation: forcing the function to always-speak fails the suppressed cases; always-silent fails the default ones.

`tests/test_key.bats` + `tests/test_remote.bats` → `1..120`, no failures.

Design by the cloud side; this is the OSS half. The cloud half follows once this lands.