### PR TITLE
feat(doctor): add scripts/doctor.sh, a read-only status command

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -22,18 +22,34 @@ set -euo pipefail
 #   1  one or more warnings (see WARNINGS section)
 #   2  usage or resolution error
 
-PROJECT="${1:?Usage: doctor.sh <project_path> <agent_type> [--redacted]}"
-TYPE="${2:?Missing agent_type}"
+_usage() {
+  echo "Usage: doctor.sh <project_path> <agent_type> [--redacted]" >&2
+}
+
+# Scanned for --help before the positional args are required below: with
+# ${1:?...} doing that job instead, `doctor.sh --help` alone reads --help as
+# PROJECT, then dies on the missing TYPE with "Missing agent_type" (bash's own
+# nounset message, exit 1) and never reaches a help branch at all.
+for _arg in "${@:-}"; do
+  case "$_arg" in
+    -h|--help) _usage; exit 0 ;;
+  esac
+done
+unset _arg
+
+if [ "$#" -lt 2 ]; then
+  _usage
+  exit 2
+fi
+
+PROJECT="$1"
+TYPE="$2"
 shift 2
 
 REDACTED=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --redacted) REDACTED=1; shift ;;
-    -h|--help)
-      echo "Usage: doctor.sh <project_path> <agent_type> [--redacted]"
-      exit 0
-      ;;
     *) echo "doctor: unknown option: $1" >&2; exit 2 ;;
   esac
 done
@@ -45,6 +61,17 @@ RUN_DIR="$SKILL_DIR/run"
 . "$SCRIPT_DIR/lib/resolve-project.sh"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/type-registry.sh"
+
+# Rejected here, not left to delivery.sh/identities.sh to fail into: those
+# don't error loudly on an unknown type, they just return empty/quiet, which
+# is exactly the "warning text on screen, exit 0 underneath" shape that made
+# this a blocking finding in review.
+if ! agmsg_is_known_type "$TYPE"; then
+  echo "doctor: unknown agent type: '$TYPE' (supported: $(agmsg_known_types | sort -u | paste -sd, - | sed 's/,/, /g'))" >&2
+  exit 2
+fi
 
 PROJECT="$(agmsg_resolve_project "$PROJECT" "$TYPE")"
 
@@ -116,11 +143,16 @@ _redact_owner() {
     printf '...%s' "${1: -6}"
   fi
 }
+# A path outside $HOME (a shared worktree, /Volumes/..., /Users/Shared/...)
+# has no HOME-relative form to fall back to, and showing it raw would be the
+# exact leak --redacted exists to prevent -- so that case gets a bare
+# placeholder instead of the path. The HOME case keeps the more readable
+# "~/..." form.
 _redact_project() {
   [ "$REDACTED" = 1 ] || { printf '%s' "$1"; return 0; }
   case "$1" in
     "$HOME"*) printf '~%s' "${1#"$HOME"}" ;;
-    *)        printf '%s' "$1" ;;
+    *)        printf '<project>' ;;
   esac
 }
 # Literal (not glob, not regex) substring replace. A quoted portion of a
@@ -157,6 +189,12 @@ _redact_text() {
   local text="$1" i n
   [ "$REDACTED" = 1 ] || { printf '%s' "$text"; return 0; }
   text="$(_replace_literal "$text" "$HOME" "~")"
+  # A project outside $HOME survives the substitution above untouched (no
+  # $HOME prefix to catch), and delivery.sh's own output names it directly
+  # (its settings-hooks-file path is under it) -- so the exact resolved path
+  # is masked here too, the same placeholder _redact_project uses for the
+  # non-HOME case, not just doctor's own "project:" line.
+  text="$(_replace_literal "$text" "$PROJECT" "<project>")"
   n=${#_R_TEAM_K[@]}
   for ((i = 0; i < n; i++)); do
     text="$(_replace_literal "$text" "${_R_TEAM_K[$i]}" "${_R_TEAM_V[$i]}")"
@@ -187,7 +225,8 @@ _redact_text() {
 # -- a duplicated implementation would drift instead of going quiet, which is
 # worse. Flagged here so whoever next changes delivery.sh's status wording
 # knows to check.
-DELIVERY_OUTPUT="$(bash "$SCRIPT_DIR/delivery.sh" status "$TYPE" "$PROJECT" 2>&1 || true)"
+DELIVERY_STATUS=0
+DELIVERY_OUTPUT="$(bash "$SCRIPT_DIR/delivery.sh" status "$TYPE" "$PROJECT" 2>&1)" || DELIVERY_STATUS=$?
 MODE_LINE="$(printf '%s\n' "$DELIVERY_OUTPUT" | head -1)"
 MODE="${MODE_LINE#mode: }"
 
@@ -276,6 +315,15 @@ STALE_COUNT="$(printf '%s\n' "$DELIVERY_OUTPUT" | sed -n 's/.*, \([0-9]*\) stale
 case "$STALE_COUNT" in ''|*[!0-9]*) STALE_COUNT=0 ;; esac
 if [ "$STALE_COUNT" -gt 0 ]; then
   _warn "watcher/bridge pidfile present but process not running (see delivery status above)"
+fi
+
+# TYPE is already validated above, so this is not the "unknown type" case --
+# some other failure inside delivery.sh status itself. Surfaced as a warning
+# rather than swallowed: showing error text on screen while still reporting
+# "no warnings." / exit 0 underneath would be a doctor that lies about its
+# own read.
+if [ "$DELIVERY_STATUS" -ne 0 ]; then
+  _warn "delivery.sh status exited $DELIVERY_STATUS (see delivery status above)"
 fi
 
 # --- now print, in screen order -------------------------------------------

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# doctor.sh — "who holds what" for a (project, type) in one screen. #267/#605.
+#
+# Usage: doctor.sh <project_path> <agent_type> [--redacted]
+#
+# Read-only: never claims, releases, or removes a lock, pidfile, or
+# registration. A stale lock or dead pidfile is reported, not cleaned up --
+# #605's reporter was asked not to remove a lock by hand because it erases
+# the evidence; a doctor that cleaned up would do the same thing to itself.
+#
+# Data sources are the existing helpers this project already has for each
+# fact -- identities.sh for registrations, actas-lock.sh/instance-id.sh for
+# lock ownership and liveness, delivery.sh for mode and watcher/bridge
+# status. Nothing here recomputes a verdict those already reach; #605's
+# diagnostic duplicated agmsg_instance_alive once and that duplication was
+# exactly what review pushed back on.
+#
+# Exit codes:
+#   0  no warnings
+#   1  one or more warnings (see WARNINGS section)
+#   2  usage or resolution error
+
+PROJECT="${1:?Usage: doctor.sh <project_path> <agent_type> [--redacted]}"
+TYPE="${2:?Missing agent_type}"
+shift 2
+
+REDACTED=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --redacted) REDACTED=1; shift ;;
+    -h|--help)
+      echo "Usage: doctor.sh <project_path> <agent_type> [--redacted]"
+      exit 0
+      ;;
+    *) echo "doctor: unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUN_DIR="$SKILL_DIR/run"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/resolve-project.sh"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/actas-lock.sh"
+
+PROJECT="$(agmsg_resolve_project "$PROJECT" "$TYPE")"
+
+# Whether this type already reports its own per-role runtime status (codex's
+# _delivery.sh does, via the embedded delivery-status block above -- one
+# "Codex bridge: team/agent ..." line per role). Everything else (currently
+# claude-code, opencode) falls through to the default runtime status, which
+# is a single project-wide count with no per-role breakdown, so those types
+# get the watcher= field built below instead. Detected structurally (does
+# the type's plug override the function) rather than hardcoding "codex", so
+# a future type with its own per-role reporting is picked up automatically.
+TYPE_HAS_ROLE_RUNTIME=0
+TYPE_DELIVERY_PLUG="$SKILL_DIR/scripts/drivers/types/$TYPE/_delivery.sh"
+if [ -f "$TYPE_DELIVERY_PLUG" ] && grep -q '^agmsg_delivery_runtime_status()' "$TYPE_DELIVERY_PLUG" 2>/dev/null; then
+  TYPE_HAS_ROLE_RUNTIME=1
+fi
+
+WARNINGS=""
+_warn() { WARNINGS="${WARNINGS}$1"$'\n'; }
+
+# --- redaction: consistent pseudonyms, not one-off masking -----------------
+#
+# A fixed team1/agent1 substitution (not a hash) so the same name reads the
+# same way everywhere it appears in one run -- the #605 reporter hand-redacted
+# their own report exactly this way (generic team/agent names, home-relative
+# project path); this does the same substitution instead of leaving it to
+# whoever pastes the output into a bug report.
+# Sets _REDACT_OUT in the CALLER's shell rather than printf+$(...): a pair
+# assigned inside a command substitution is a subshell, and the whole point
+# here is a mutation (_R_TEAM_K/_R_TEAM_V growing) that has to survive past
+# the call. role-session.sh's _agmsg_role_session_path_into hit this same
+# shape first -- "a cache entry is only kept when the helper runs in the
+# caller's own shell" applies just as much to a pseudonym table as a memo.
+_R_TEAM_K=(); _R_TEAM_V=(); _R_AGENT_K=(); _R_AGENT_V=()
+_redact_team() {
+  [ "$REDACTED" = 1 ] || { _REDACT_OUT="$1"; return 0; }
+  local i n=${#_R_TEAM_K[@]}
+  for ((i = 0; i < n; i++)); do
+    if [ "${_R_TEAM_K[$i]}" = "$1" ]; then _REDACT_OUT="${_R_TEAM_V[$i]}"; return 0; fi
+  done
+  _R_TEAM_K[$n]="$1"; _R_TEAM_V[$n]="team$((n + 1))"
+  _REDACT_OUT="${_R_TEAM_V[$n]}"
+}
+_redact_agent() {
+  [ "$REDACTED" = 1 ] || { _REDACT_OUT="$1"; return 0; }
+  local i n=${#_R_AGENT_K[@]}
+  for ((i = 0; i < n; i++)); do
+    if [ "${_R_AGENT_K[$i]}" = "$1" ]; then _REDACT_OUT="${_R_AGENT_V[$i]}"; return 0; fi
+  done
+  _R_AGENT_K[$n]="$1"; _R_AGENT_V[$n]="agent$((n + 1))"
+  _REDACT_OUT="${_R_AGENT_V[$n]}"
+}
+# Plain output shows the owner token IN FULL -- #605 was actually resolved by
+# matching this exact value against a "codex-bridge: resumed thread <uuid>"
+# line in a bridge log, and a shortened token can't be matched that way. This
+# only shortens under --redacted, where the point is the opposite (safe to
+# paste), and even then splits on the LAST "." rather than a fixed tail
+# length: a fixed suffix cuts at a different point depending on how long the
+# leading uuid/sid happens to be, while the part after the last "." is the
+# pid every composite token carries -- consistently shaped, and still useful
+# on its own (`ps -p <pid>`) even with the rest hidden. A bare token (no ".")
+# has no such split point, so that case keeps the old fixed-tail form.
+_redact_owner() {
+  [ "$REDACTED" = 1 ] || { printf '%s' "$1"; return 0; }
+  [ -n "$1" ] || return 0
+  if agmsg_instance_is_composite "$1"; then
+    printf '...%s' "${1##*.}"
+  else
+    printf '...%s' "${1: -6}"
+  fi
+}
+_redact_project() {
+  [ "$REDACTED" = 1 ] || { printf '%s' "$1"; return 0; }
+  case "$1" in
+    "$HOME"*) printf '~%s' "${1#"$HOME"}" ;;
+    *)        printf '%s' "$1" ;;
+  esac
+}
+# Literal (not glob, not regex) substring replace. A quoted portion of a
+# case/parameter-expansion pattern matches literally regardless of what it
+# contains, so this needs no escaping for team/agent names or paths that
+# happen to hold *, ?, [, or other glob/regex metacharacters. Portable to
+# bash 3.2 (macOS).
+_replace_literal() {
+  local rest="$1" needle="$2" repl="$3" out=""
+  [ -n "$needle" ] || { printf '%s' "$rest"; return 0; }
+  while true; do
+    case "$rest" in
+      *"$needle"*)
+        out="$out${rest%%"$needle"*}$repl"
+        rest="${rest#*"$needle"}"
+        ;;
+      *) break ;;
+    esac
+  done
+  printf '%s%s' "$out" "$rest"
+}
+# Applies the SAME substitutions as the fields above to a block of TEXT this
+# script did not format itself (delivery.sh's own output) -- --redacted's
+# only promise is "safe to paste", so text quoted wholesale from elsewhere
+# has to go through the same pseudonym table and $HOME masking as everything
+# doctor.sh builds by hand, not get echoed as-is.
+#
+# No word boundaries: a team/agent name that also occurs as a substring
+# elsewhere in the text (e.g. a team named "agmsg" inside a path like
+# ~/.agents/skills/agmsg/run/...) gets replaced there too. Deliberately not
+# fixed -- the failure direction is over-redaction, not a leak, which is the
+# side --redacted is supposed to fail on.
+_redact_text() {
+  local text="$1" i n
+  [ "$REDACTED" = 1 ] || { printf '%s' "$text"; return 0; }
+  text="$(_replace_literal "$text" "$HOME" "~")"
+  n=${#_R_TEAM_K[@]}
+  for ((i = 0; i < n; i++)); do
+    text="$(_replace_literal "$text" "${_R_TEAM_K[$i]}" "${_R_TEAM_V[$i]}")"
+  done
+  n=${#_R_AGENT_K[@]}
+  for ((i = 0; i < n; i++)); do
+    text="$(_replace_literal "$text" "${_R_AGENT_K[$i]}" "${_R_AGENT_V[$i]}")"
+  done
+  printf '%s' "$text"
+}
+
+# --- gather everything before printing anything ----------------------------
+#
+# Order matters here for one reason: redacting the embedded delivery-status
+# block (below) needs the team/agent pseudonym table already built, and that
+# table is only built by walking registrations. So registrations are walked
+# first (silently, into REG_LINES) and the mode line is read before anything
+# is echoed, even though "registrations" prints after "delivery status" on
+# screen.
+#
+# Shelled out to the real CLI (not sourced): delivery.sh dispatches on argv at
+# file scope, so sourcing it would run that dispatch. Reused verbatim (through
+# _redact_text below) -- the type-specific per-role bridge liveness this
+# project already has (codex's _delivery.sh) is not worth a second
+# implementation here. Trade-off: MODE and the stale-pidfile warnings below
+# are parsed out of this human-readable text, so if delivery.sh's wording
+# changes, both go silent (no warning, not a wrong one) rather than erroring
+# -- a duplicated implementation would drift instead of going quiet, which is
+# worse. Flagged here so whoever next changes delivery.sh's status wording
+# knows to check.
+DELIVERY_OUTPUT="$(bash "$SCRIPT_DIR/delivery.sh" status "$TYPE" "$PROJECT" 2>&1 || true)"
+MODE_LINE="$(printf '%s\n' "$DELIVERY_OUTPUT" | head -1)"
+MODE="${MODE_LINE#mode: }"
+
+PAIRS="$("$SCRIPT_DIR/identities.sh" "$PROJECT" "$TYPE")"
+PAIR_COUNT="$(printf '%s\n' "$PAIRS" | grep -c . || true)"
+
+REG_LINES=""
+FIRST_TEAM="" FIRST_AGENT=""
+if [ "$PAIR_COUNT" -gt 0 ]; then
+  while IFS=$'\t' read -r team agent; do
+    [ -z "$team" ] && continue
+    [ -n "$FIRST_TEAM" ] || { FIRST_TEAM="$team"; FIRST_AGENT="$agent"; }
+
+    _redact_team "$team"; dteam="$_REDACT_OUT"
+    _redact_agent "$agent"; dagent="$_REDACT_OUT"
+    owner="$(actas_lock_owner "$team" "$agent")"
+
+    if [ -z "$owner" ]; then
+      REG_LINES="${REG_LINES}$(printf '  %-22s lock=none' "$dteam/$dagent")"$'\n'
+      continue
+    fi
+
+    if agmsg_instance_alive "$owner"; then
+      alive_word="alive"
+    else
+      alive_word="STALE"
+      _warn "stale lock: $dteam/$dagent (owner=$(_redact_owner "$owner"))"
+    fi
+
+    cc_note=""
+    if agmsg_instance_is_composite "$owner"; then
+      pid="${owner##*.}"
+      if [ -f "$RUN_DIR/cc-instance.$pid" ]; then cc_note=" cc-instance=present"; else cc_note=" cc-instance=absent"; fi
+    fi
+
+    # Per-role watcher liveness -- only for types whose runtime status doesn't
+    # already break this down per role (see TYPE_HAS_ROLE_RUNTIME above).
+    # The pidfile watch.sh's SessionStart directive writes is keyed on the
+    # SAME normalized instance id actas-claim.sh records as the lock owner
+    # (both go through agmsg_normalize_instance_id on the same session id),
+    # so the owner token IS the watcher's pidfile name -- no separate lookup
+    # or correlation needed, and no liveness logic of its own: reuses
+    # _agmsg_pid_alive_local, the same helper delivery.sh's own default
+    # runtime status calls.
+    watcher_note=""
+    if [ "$TYPE_HAS_ROLE_RUNTIME" -eq 0 ]; then
+      wpidfile="$RUN_DIR/watch.$owner.pid"
+      if [ -f "$wpidfile" ]; then
+        wpid="$(cat "$wpidfile" 2>/dev/null || true)"
+        if [ -n "$wpid" ] && _agmsg_pid_alive_local "$wpid" 2>/dev/null; then
+          watcher_note=" watcher=running"
+        else
+          watcher_note=" watcher=stale-pidfile"
+        fi
+      else
+        watcher_note=" watcher=none"
+        # Only when the lock itself is legitimately live: a stale lock having
+        # no watcher is unremarkable (already covered by the warning above),
+        # but an alive lock with no watcher means the role claims exclusivity
+        # and isn't receiving -- the shape #605 and Alice/Bob both were.
+        if [ "$alive_word" = "alive" ]; then
+          _warn "actas lock held but no watcher: $dteam/$dagent (owner=$(_redact_owner "$owner"))"
+        fi
+      fi
+    fi
+
+    REG_LINES="${REG_LINES}$(printf '  %-22s lock=owner(%s)=%s%s%s' "$dteam/$dagent" "$alive_word" "$(_redact_owner "$owner")" "$cc_note" "$watcher_note")"$'\n'
+  done <<< "$PAIRS"
+
+  if [ "$PAIR_COUNT" -gt 1 ] && { [ "$MODE" = "turn" ] || [ "$MODE" = "both" ]; }; then
+    _redact_team "$FIRST_TEAM"; first_dteam="$_REDACT_OUT"
+    _redact_agent "$FIRST_AGENT"; first_dagent="$_REDACT_OUT"
+    _warn "$PAIR_COUNT registrations for this (project, type) under turn-mode delivery -- only the first registered ($first_dteam/$first_dagent) receives Stop-hook delivery; the rest are silent under turn"
+  fi
+fi
+
+# codex's per-role lines always carry a parenthetical reason (e.g. "stale
+# pidfile (pid 123 not running)"); grepping for the "(" excludes the
+# claude-code default's aggregate "N stale pidfiles" line, which is handled
+# by the numeric check below instead and would otherwise false-positive here
+# on its own plural (a literal prefix match of "stale pidfile").
+if printf '%s\n' "$DELIVERY_OUTPUT" | grep -q "stale pidfile ("; then
+  _warn "watcher/bridge pidfile present but process not running (see delivery status above)"
+fi
+STALE_COUNT="$(printf '%s\n' "$DELIVERY_OUTPUT" | sed -n 's/.*, \([0-9]*\) stale pidfiles*$/\1/p' | head -1)"
+case "$STALE_COUNT" in ''|*[!0-9]*) STALE_COUNT=0 ;; esac
+if [ "$STALE_COUNT" -gt 0 ]; then
+  _warn "watcher/bridge pidfile present but process not running (see delivery status above)"
+fi
+
+# --- now print, in screen order -------------------------------------------
+DISPLAY_PROJECT="$(_redact_project "$PROJECT")"
+echo "project: $DISPLAY_PROJECT"
+echo "type:    $TYPE"
+echo
+
+echo "$(_redact_text "$DELIVERY_OUTPUT")"
+echo
+
+echo "registrations ($PAIR_COUNT):"
+if [ "$PAIR_COUNT" -eq 0 ]; then
+  echo "  (none for this project/type)"
+else
+  printf '%s' "$REG_LINES"
+fi
+echo
+
+if [ -n "$WARNINGS" ]; then
+  echo "warnings:"
+  printf '%s' "$WARNINGS" | sed 's/^/  - /'
+  exit 1
+fi
+echo "no warnings."
+exit 0

--- a/tests/test_doctor.bats
+++ b/tests/test_doctor.bats
@@ -56,8 +56,8 @@ teardown() {
   printf '%s\n' "$owner" > "$TEST_SKILL_DIR/run/actas.team__alice.session"
   printf '%s\n' "$owner" > "$TEST_SKILL_DIR/run/cc-instance.$$"
   # No watch.<owner>.pid: the lock is legitimately live, but nothing is
-  # watching for it -- the shape #605's report and koit's Alice/Bob example
-  # both were.
+  # watching for it -- exclusivity claimed, nothing receiving. #605's report
+  # was exactly this shape.
 
   run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
   [ "$status" -ne 0 ]

--- a/tests/test_doctor.bats
+++ b/tests/test_doctor.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export AGMSG_AGENT_PID=""
+  export PROJ="$(mktemp -d)"
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+}
+
+teardown() {
+  teardown_test_env
+  rm -rf "$PROJ"
+}
+
+@test "doctor: exits 0 and reports no warnings when nothing is registered as locked" {
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no warnings."* ]]
+  [[ "$output" == *"team/alice"* ]]
+  [[ "$output" == *"lock=none"* ]]
+}
+
+@test "doctor: exits non-zero and names a stale lock (composite owner, dead pid, no cc-instance)" {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf '%s\n' "deadtoken.999999" > "$TEST_SKILL_DIR/run/actas.team__alice.session"
+
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"stale lock: team/alice"* ]]
+  [[ "$output" == *"cc-instance=absent"* ]]
+}
+
+@test "doctor: a live lock with a confirming cc-instance record and a running watcher is not a warning" {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  local owner="livetoken.$$"
+  printf '%s\n' "$owner" > "$TEST_SKILL_DIR/run/actas.team__alice.session"
+  printf '%s\n' "$owner" > "$TEST_SKILL_DIR/run/cc-instance.$$"
+  # watch.sh's pidfile is keyed on the same token actas-claim.sh records as
+  # the lock owner -- see doctor.sh's comment on TYPE_HAS_ROLE_RUNTIME.
+  printf '%s\n' "$$" > "$TEST_SKILL_DIR/run/watch.$owner.pid"
+
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
+  [ "$status" -eq 0 ]
+  # Plain output shows the owner token in FULL -- shortening only applies
+  # under --redacted (see doctor.sh's comment on _redact_owner: #605 was
+  # resolved by matching this exact value against a bridge log line).
+  [[ "$output" == *"lock=owner(alive)=$owner cc-instance=present watcher=running"* ]]
+  [[ "$output" == *"no warnings."* ]]
+}
+
+@test "doctor: an alive lock with no watcher pidfile is a warning (claims exclusivity, not receiving)" {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  local owner="livetoken.$$"
+  printf '%s\n' "$owner" > "$TEST_SKILL_DIR/run/actas.team__alice.session"
+  printf '%s\n' "$owner" > "$TEST_SKILL_DIR/run/cc-instance.$$"
+  # No watch.<owner>.pid: the lock is legitimately live, but nothing is
+  # watching for it -- the shape #605's report and koit's Alice/Bob example
+  # both were.
+
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"lock=owner(alive)=$owner cc-instance=present watcher=none"* ]]
+  [[ "$output" == *"actas lock held but no watcher: team/alice"* ]]
+}
+
+@test "doctor: a stale lock with no watcher does not double-warn about the missing watcher" {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf '%s\n' "deadtoken.999999" > "$TEST_SKILL_DIR/run/actas.team__alice.session"
+
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"stale lock: team/alice"* ]]
+  [[ "$output" != *"actas lock held but no watcher"* ]]
+}
+
+@test "doctor: codex's per-role bridge line already covers this, so no separate watcher= field is added" {
+  bash "$SCRIPTS/join.sh" team bob codex "$PROJ" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf '%s\n' "livetoken.$$" > "$TEST_SKILL_DIR/run/actas.team__bob.session"
+
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" codex
+  [[ "$output" != *"watcher="* ]]
+}
+
+@test "doctor: --redacted hides the project path, team/agent names, and most of the owner token" {
+  local home_proj="$HOME/redact-me"
+  mkdir -p "$home_proj"
+  bash "$SCRIPTS/join.sh" team alice claude-code "$home_proj" >/dev/null
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf '%s\n' "deadtoken.999999" > "$TEST_SKILL_DIR/run/actas.team__alice.session"
+
+  run bash "$SCRIPTS/doctor.sh" "$home_proj" claude-code --redacted
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"project: ~/redact-me"* ]]
+  [[ "$output" != *"team/alice"* ]]
+  [[ "$output" == *"team1/agent1"* ]]
+  [[ "$output" == *"...999999"* ]]
+  [[ "$output" != *"deadtoken.999999"* ]]
+}
+
+@test "doctor: owner is shown in full by default, and --redacted splits a composite token on its last dot (not a fixed tail length)" {
+  mkdir -p "$TEST_SKILL_DIR/run"
+  # A short pid, deliberately not 6 digits: a fixed-tail-length shortener
+  # would cut into the sid (e.g. "...02.42"); splitting on the last "."
+  # always lands exactly on the pid, whatever its length.
+  local owner="459d8198-3fcf-4c9e-a4ff-5f8fbd18c802.42"
+
+  printf '%s\n' "$owner" > "$TEST_SKILL_DIR/run/actas.team__alice.session"
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
+  [[ "$output" == *"lock=owner(STALE)=$owner"* ]]
+
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code --redacted
+  [[ "$output" == *"lock=owner(STALE)=...42 "* ]]
+  [[ "$output" != *"$owner"* ]]
+}
+
+@test "doctor: warns when more than one registration exists under turn-mode delivery" {
+  bash "$SCRIPTS/join.sh" team bob claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set turn claude-code "$PROJ" >/dev/null
+
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"registrations for this (project, type) under turn-mode delivery"* ]]
+}
+
+@test "doctor: multiple registrations under monitor mode is not a warning" {
+  bash "$SCRIPTS/join.sh" team bob claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/delivery.sh" set monitor claude-code "$PROJ" >/dev/null
+
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"under turn-mode delivery"* ]]
+}
+
+# --- the delivery-status block is QUOTED from delivery.sh, not formatted by
+#     doctor.sh itself -- --redacted has to run it through the same
+#     substitutions or its only promise ("safe to paste") is broken. codex's
+#     per-role bridge line is real-world proof: it names team/agent directly. -
+@test "doctor: --redacted also redacts the embedded delivery-status block, not just its own formatting" {
+  local home_proj="$HOME/embedded-leak-check"
+  mkdir -p "$home_proj"
+  bash "$SCRIPTS/join.sh" agmsg advisor codex "$home_proj" >/dev/null
+  # A live codex bridge for agmsg/advisor, minimal enough for
+  # _delivery.sh's agmsg_delivery_runtime_status to report it "alive": a
+  # pidfile naming a real (this test's own) pid, and a matching metafile.
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf '%s\n' "$$" > "$TEST_SKILL_DIR/run/codex-bridge.agmsg.advisor.pid"
+  {
+    echo "pid=$$"
+    echo "project=$home_proj"
+    echo "type=codex"
+  } > "$TEST_SKILL_DIR/run/codex-bridge.agmsg.advisor.meta"
+
+  run bash "$SCRIPTS/doctor.sh" "$home_proj" codex --redacted
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Codex bridge: team1/agent1 alive"* ]]
+  [[ "$output" != *"agmsg/advisor"* ]]
+  [[ "$output" != *"$HOME"* ]]
+}

--- a/tests/test_doctor.bats
+++ b/tests/test_doctor.bats
@@ -14,6 +14,45 @@ teardown() {
   rm -rf "$PROJ"
 }
 
+# --- usage-error contract (exit 2), separate from the "found a problem"
+#     contract (exit 1) above -- these used to collapse into bash's own
+#     ${1:?...} exit 1 on a missing argument, which is indistinguishable
+#     from a warning to anything scripting against the exit code. ----------
+
+@test "doctor: no arguments is a usage error (exit 2), not bash's own exit 1" {
+  run bash "$SCRIPTS/doctor.sh"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage: doctor.sh"* ]]
+}
+
+@test "doctor: a missing type argument is a usage error (exit 2)" {
+  run bash "$SCRIPTS/doctor.sh" "$PROJ"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage: doctor.sh"* ]]
+}
+
+@test "doctor: bare --help exits 0 and prints usage, even with no other arguments" {
+  # ${1:?...} alone would consume "--help" as PROJECT, then die on the
+  # missing TYPE with status 1 and never reach a help branch.
+  run bash "$SCRIPTS/doctor.sh" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: doctor.sh"* ]]
+}
+
+@test "doctor: an unknown option is a usage error (exit 2)" {
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code --nonsense
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown option"* ]]
+}
+
+@test "doctor: an unknown agent type is a usage error (exit 2), not a silent clean report" {
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" not-a-real-type
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown agent type"* ]]
+  # Must not fall through to delivery.sh/identities.sh and report clean.
+  [[ "$output" != *"no warnings."* ]]
+}
+
 @test "doctor: exits 0 and reports no warnings when nothing is registered as locked" {
   run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
   [ "$status" -eq 0 ]
@@ -27,7 +66,7 @@ teardown() {
   printf '%s\n' "deadtoken.999999" > "$TEST_SKILL_DIR/run/actas.team__alice.session"
 
   run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 1 ]
   [[ "$output" == *"stale lock: team/alice"* ]]
   [[ "$output" == *"cc-instance=absent"* ]]
 }
@@ -60,7 +99,7 @@ teardown() {
   # was exactly this shape.
 
   run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 1 ]
   [[ "$output" == *"lock=owner(alive)=$owner cc-instance=present watcher=none"* ]]
   [[ "$output" == *"actas lock held but no watcher: team/alice"* ]]
 }
@@ -70,7 +109,7 @@ teardown() {
   printf '%s\n' "deadtoken.999999" > "$TEST_SKILL_DIR/run/actas.team__alice.session"
 
   run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 1 ]
   [[ "$output" == *"stale lock: team/alice"* ]]
   [[ "$output" != *"actas lock held but no watcher"* ]]
 }
@@ -92,7 +131,7 @@ teardown() {
   printf '%s\n' "deadtoken.999999" > "$TEST_SKILL_DIR/run/actas.team__alice.session"
 
   run bash "$SCRIPTS/doctor.sh" "$home_proj" claude-code --redacted
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 1 ]
   [[ "$output" == *"project: ~/redact-me"* ]]
   [[ "$output" != *"team/alice"* ]]
   [[ "$output" == *"team1/agent1"* ]]
@@ -100,19 +139,45 @@ teardown() {
   [[ "$output" != *"deadtoken.999999"* ]]
 }
 
+@test "doctor: --redacted also masks a project path outside \$HOME (a shared worktree, /Volumes, etc.), including in the embedded block" {
+  # $PROJ (from setup(), a plain mktemp -d) is already outside the sandboxed
+  # $HOME test_helper.bash sets up -- no extra fixture needed to get a
+  # non-HOME path here, which is exactly the case that leaked before: only
+  # the $HOME-relative path was masked, so a project anywhere else (a shared
+  # worktree, /Volumes/..., /Users/Shared/...) passed through raw, in both
+  # doctor's own "project:" line and the embedded delivery.sh block (whose
+  # "settings hooks file:" line names the project directly).
+  case "$PROJ" in
+    "$HOME"*) skip "fixture \$PROJ landed under \$HOME this run; this test needs it outside" ;;
+  esac
+
+  run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code --redacted
+  [[ "$output" == *"project: <project>"* ]]
+  [[ "$output" != *"$PROJ"* ]]
+}
+
 @test "doctor: owner is shown in full by default, and --redacted splits a composite token on its last dot (not a fixed tail length)" {
   mkdir -p "$TEST_SKILL_DIR/run"
-  # A short pid, deliberately not 6 digits: a fixed-tail-length shortener
-  # would cut into the sid (e.g. "...02.42"); splitting on the last "."
-  # always lands exactly on the pid, whatever its length.
-  local owner="459d8198-3fcf-4c9e-a4ff-5f8fbd18c802.42"
+  # A pid genuinely dead by construction (spawn, wait, then use its now-freed
+  # pid) rather than a hardcoded small number: a fixed guess like "42" can
+  # collide with a real process on a container CI runner, where low pids are
+  # far more likely to be in active use than on a real developer machine --
+  # the same class of flake #595's marker-gc investigation found in a
+  # hardcoded pid 4242. Whatever pid the OS actually hands back also isn't
+  # guaranteed to be 6 digits, which is what this test needs: a fixed-tail
+  # shortener would cut into the sid (e.g. "...02.42") on a short one, while
+  # splitting on the last "." always lands exactly on the pid regardless of
+  # its length.
+  ( exit 0 ) & local deadpid=$!
+  wait "$deadpid" 2>/dev/null || true
+  local owner="459d8198-3fcf-4c9e-a4ff-5f8fbd18c802.$deadpid"
 
   printf '%s\n' "$owner" > "$TEST_SKILL_DIR/run/actas.team__alice.session"
   run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
   [[ "$output" == *"lock=owner(STALE)=$owner"* ]]
 
   run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code --redacted
-  [[ "$output" == *"lock=owner(STALE)=...42 "* ]]
+  [[ "$output" == *"lock=owner(STALE)=...$deadpid "* ]]
   [[ "$output" != *"$owner"* ]]
 }
 
@@ -121,7 +186,7 @@ teardown() {
   bash "$SCRIPTS/delivery.sh" set turn claude-code "$PROJ" >/dev/null
 
   run bash "$SCRIPTS/doctor.sh" "$PROJ" claude-code
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 1 ]
   [[ "$output" == *"registrations for this (project, type) under turn-mode delivery"* ]]
 }
 


### PR DESCRIPTION
Adds `scripts/doctor.sh`, a single-command health surface for a (project, type): delivery mode, registrations, and per-role actas lock status (owner, liveness, and — for a composite owner — whether a cc-instance record backs it). This is an interface addition: a new public command, once shipped a compatibility commitment.

This addresses part of #267, which asked for both a `doctor` command and a `viewer`/`status` dashboard. This PR is the `doctor` half only; the viewer/status half is not included. A reply on #267 (https://github.com/fujibee/agmsg/issues/267#issuecomment-5186194285) already lays out this split and credits the issue's own checklist as the design's starting point.

## Design, with reasons

(1) Read-only. `doctor.sh` never claims, releases, or writes any lock, pidfile, or registration — a stale lock or dead pidfile is reported, never cleaned up. This mirrors how `claude doctor` routes its fixable checks to a separate in-session `/doctor` rather than folding them into the read-only CLI command. The reason here is specific to what this diagnoses: a stale lock or orphaned pidfile is itself the evidence of a delivery problem, and a doctor that cleans up on the way through would erase the evidence it exists to surface.

(2) Exit codes: 0 clean, 1 one or more warnings, 2 usage/resolution error.

(3) `--redacted`, for pasting into a report: masks the project path (`$HOME`-relative), team/agent names (consistent per-run pseudonyms — the same real name always maps to the same pseudonym within one invocation), and owner tokens. This also applies to the `delivery.sh status` block this command embeds verbatim, not only to doctor's own formatting — an earlier draft of this redaction only covered doctor's own output and let real names in the embedded block through unredacted, caught in review before merge.

(4) Outside `--redacted`, the owner token is shown in full rather than shortened. This is deliberate: the actual troubleshooting step that resolves a case like #267/#605 is comparing this value against a bridge log line (`codex-bridge: resumed thread <uuid>`) byte for byte, and a shortened token can't be compared that way. `--redacted` shortens by splitting a composite token (`<sid>.<pid>`) on its last `.`, which lands on the pid regardless of how long the leading sid is; a bare token has no such split point and keeps a fixed-tail form.

(5) Per-role watcher liveness, for types that don't already report this per role (currently claude-code and opencode; codex's own `_delivery.sh` already reports bridge liveness per role, so nothing is added there). Detected structurally — whether the type's `_delivery.sh` overrides `agmsg_delivery_runtime_status` — not by name, so a future type with its own per-role reporting is excluded automatically. A new warning fires when a lock is alive but no watcher backs it: exclusivity is claimed but nothing is receiving, which is the shape both #605 and an example koit raised were.

## Not in this cut

Dependency checks (bash/sqlite3/node/agent CLI availability), Windows-specific path checks, unread message counts, and wiring into the per-type templates or the Windows dispatcher are all out of scope for this version. All can be added later without changing what's here.

## Known limitations, stated rather than hidden

`--redacted`'s substitution does not respect word boundaries: a team/agent name that also happens to appear as a substring elsewhere in the output (for example inside a path) gets replaced there too. This is accepted rather than fixed, because the failure direction is over-redaction, not a leak — the side `--redacted` is supposed to fail toward.

The delivery-mode line and the stale-pidfile detection are both parsed out of `delivery.sh status`'s human-readable English output, not a structured source. If that wording changes, both go silent (no warning, not a wrong one) rather than erroring. This is a deliberate trade-off against reimplementing that logic a second time, which would risk drifting from what `delivery.sh` actually decides rather than failing loudly when it changes.

## Built from existing helpers, not reimplemented

`identities.sh` for registrations, `actas-lock.sh`/`instance-id.sh` for lock ownership and liveness (`actas_lock_owner`, `agmsg_instance_alive`, `agmsg_instance_is_composite`), `delivery.sh status` (run as a subprocess and its output reused, not sourced — it dispatches on argv at file scope) for mode and watcher/bridge status, and `_agmsg_pid_alive_local` for the new per-role watcher check, the same helper `delivery.sh`'s own default runtime status already uses.

## Testing

11 tests added to tests/test_doctor.bats covering: a clean project (exit 0), a stale lock (exit non-zero, names the lock, distinguishes cc-instance present/absent/composite-vs-bare), a live lock with a confirmed cc-instance and a running watcher (no warning), an alive lock with no watcher (exit non-zero, names the new warning), a stale lock with no watcher (does not double-warn), codex's own per-role reporting is left untouched (no separate watcher= field), full `--redacted` coverage including the embedded delivery-status block, and the owner token's default-full / redacted-split-on-dot behavior.

(1) bats tests/test_doctor.bats -- 11 ok, 0 not ok, exit 0.
