### PR TITLE
fix(lock): say why mkdir failed instead of calling everything a timeout

### DIFF
--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -32,13 +32,52 @@ AGMSG_HELD_LOCKS="${AGMSG_HELD_LOCKS:-}"
 # resurrects a team dir that a concurrent leave/reset just removed. Spins with a
 # short sleep up to AGMSG_LOCK_TRIES attempts (default 1000 = ~10s), then fails
 # non-zero so the caller can abort rather than silently skip the team.
+# Who owns the directory and what this process is, for a failure that is about
+# neither the team nor the lock. `ls -ld` and `id` rather than stat(1), whose
+# flags differ between BSD and GNU, and both are already required here.
+_agmsg_lock_describe_dir() {
+  local dir="$1"
+  echo "agmsg:   $(ls -ld "$dir" 2>/dev/null || printf '%s (cannot stat)' "$dir")" >&2
+  echo "agmsg:   running as: $(id 2>/dev/null || echo 'unknown')" >&2
+}
+
 agmsg_lock_acquire() {
-  local team_dir="$1" lock i=0 max="${AGMSG_LOCK_TRIES:-1000}"
+  local team_dir="$1" lock i=0 max="${AGMSG_LOCK_TRIES:-1000}" err=""
   lock="$team_dir/.config.lock"
-  until mkdir "$lock" 2>/dev/null; do
+  until err="$(mkdir "$lock" 2>&1)"; do
+    # WHY mkdir failed decides whether waiting can help, and only one reason
+    # ever clears on its own: somebody holds the lock. Everything else -- no
+    # write permission on the team dir, a read-only mount -- is a standing
+    # condition, and spinning ten seconds on it then reporting a timeout
+    # describes contention that never existed.
+    #
+    # That mattered in the field. A second machine, running as a different OS
+    # account, pointed at the first one's store; the team dir was 0755 and
+    # owned by the other user, so mkdir could never succeed. The message named
+    # a lock, so the search went to processes: an unrelated sync engine was
+    # killed, and when it happened again with no engine running and no lock
+    # directory present, the same sentence was still the only evidence. The
+    # `2>/dev/null` had thrown away the one line that said EACCES.
+    #
+    # Decided from the lock's presence rather than from the error text, which
+    # is locale-dependent. Checked in this order because the lock existing is
+    # the common case and settles it: only when it is absent is the question
+    # "can we write here at all". Absent AND writable is a lost race with a
+    # holder that has already released -- genuinely transient, so it spins.
+    if [ ! -d "$lock" ] && [ ! -w "$team_dir" ]; then
+      echo "agmsg: cannot create the registry lock in $team_dir" >&2
+      echo "agmsg: mkdir: $err" >&2
+      echo "agmsg: nothing is holding the lock — this directory cannot be written to, so waiting will not clear it." >&2
+      _agmsg_lock_describe_dir "$team_dir"
+      return 1
+    fi
     i=$((i + 1))
     if [ "$i" -ge "$max" ]; then
       echo "agmsg: timed out acquiring registry lock for $team_dir" >&2
+      # The reason travels with the timeout too. If the wait was hopeless for
+      # a cause this function did not anticipate, the errno is the only thing
+      # that will say so.
+      [ -n "$err" ] && echo "agmsg: last mkdir error: $err" >&2
       return 1
     fi
     sleep 0.01

--- a/tests/test_registry_lock.bats
+++ b/tests/test_registry_lock.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+# The lock is a mkdir. mkdir fails for more than one reason, and only one of
+# them ever clears on its own — so the failure the operator is shown has to say
+# which one it was.
+#
+# From the field: a second machine running as a different OS account pointed at
+# the first one's store. The team directory was 0755 and owned by the other
+# user, so mkdir could never succeed. The message said "timed out acquiring
+# registry lock", which sent three separate diagnoses after processes — a sync
+# engine was killed for it — while the cause sat in the directory's mode the
+# whole time.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  LOCKLIB="$SCRIPTS/lib/registry-lock.sh"
+  TEAM_DIR="$BATS_TEST_TMPDIR/teams/someteam"
+  mkdir -p "$TEAM_DIR"
+}
+
+teardown() {
+  # Restore before the harness cleans up, or the tree cannot be removed.
+  chmod u+w "$TEAM_DIR" 2>/dev/null || true
+  teardown_test_env
+}
+
+acquire() {  # runs the acquire in its own shell, with a short spin budget
+  run env AGMSG_LOCK_TRIES="${TRIES:-5}" LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$TEAM_DIR"
+  '
+}
+
+@test "lock: a held lock is contention — it waits, then reports a timeout" {
+  # The reason the spin exists. Nothing here should change.
+  mkdir "$TEAM_DIR/.config.lock"
+  acquire
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"timed out acquiring registry lock"* ]]
+  # And must NOT blame permissions: this directory is perfectly writable.
+  [[ "$output" != *"cannot be written to"* ]]
+}
+
+@test "lock: an unwritable team dir fails immediately and names the cause" {
+  if [ "$(id -u)" = "0" ]; then
+    skip "root ignores the mode bits this is about"
+  fi
+  # No lock directory exists — nothing is holding anything. mkdir still cannot
+  # succeed, and no amount of waiting changes that.
+  chmod a-w "$TEAM_DIR"
+  [ ! -e "$TEAM_DIR/.config.lock" ]
+
+  # A budget large enough that the old code visibly waits (~2s) and small
+  # enough that a regression FAILS rather than hanging CI. The first draft used
+  # 100000 to make the wait unmistakable and instead sat for ten minutes: a
+  # regression must be reported, not survived.
+  TRIES=200 acquire
+  [ "$status" -ne 0 ]
+
+  # Fast-fail, asserted by what it did NOT say rather than by a clock. The old
+  # code reaches the budget and says "timed out"; this path never enters the
+  # spin at all. Timing assertions are flaky; this one is exact.
+  [[ "$output" != *"timed out"* ]]
+
+  # And it says what is actually wrong, in terms someone can act on.
+  [[ "$output" == *"cannot create the registry lock"* ]]
+  [[ "$output" == *"waiting will not clear it"* ]]
+  [[ "$output" == *"mkdir:"* ]]
+  # The evidence: who owns it, and who we are.
+  [[ "$output" == *"running as:"* ]]
+  [[ "$output" == *"uid="* ]]
+}
+
+@test "lock: the timeout carries the mkdir error too" {
+  # Even on the path this function did not anticipate, the errno is not thrown
+  # away. `2>/dev/null` discarding it is what left the field with one sentence
+  # and no cause.
+  mkdir "$TEAM_DIR/.config.lock"
+  acquire
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"last mkdir error:"* ]]
+  [[ "$output" == *"File exists"* || "$output" == *"exists"* ]]
+}
+
+@test "lock: a free, writable team dir is acquired" {
+  # The positive control. Without it, a version that failed every acquire
+  # would satisfy both failure tests above.
+  run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$TEAM_DIR" || exit 1
+    [ -d "$TEAM_DIR/.config.lock" ] || exit 2
+    agmsg_lock_release
+    [ ! -d "$TEAM_DIR/.config.lock" ] || exit 3
+  '
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
The lock is a `mkdir`, and `mkdir` fails for more than one reason. Only one of them — somebody holds it — ever clears on its own. The loop treated them all as contention: it spun for ten seconds, said **"timed out acquiring registry lock"**, and `2>/dev/null` discarded the one line that said which failure it actually was.

## What that cost

A second machine, running as a different OS account, pointed at the first one's store. The team directory was `0755` and owned by the other user, so `mkdir` could never succeed.

The message named a lock, so the search went looking for a **holder** — an unrelated sync engine was killed for it. The next attempt failed identically with no engine running and **no lock directory present**, and that sentence was still the only evidence there was. Three diagnoses went past a cause sitting in the directory's mode.

## The sort

| mkdir failed and… | meaning | behaviour |
| --- | --- | --- |
| the lock directory exists | contention | spin, then time out — **unchanged** |
| it does not, and the team dir is unwritable | a standing condition | **fail now**, print the `mkdir` error plus `ls -ld` and `id` |
| neither | a holder released mid-race | spin |

Decided from the lock's **presence**, not the error text, which is locale-dependent. The errno now rides along with the timeout too, so even a cause this function did not anticipate arrives with something to read.

**"Timed out" is true only where waiting could have worked.**

## Tests

All three outcomes, because any two are green for an implementation that gets the third wrong: contention still waits and still says "timed out"; the unwritable directory fails without ever saying it, and names the cause; a free directory is acquired and released.

The permission case asserts the **absence** of `timed out` rather than a duration — timing assertions are flaky, and the old code reaches its budget and prints it. That budget is deliberately small: the first draft set it to ~17 minutes to make the wait unmistakable, and a regression would then have **hung CI instead of failing it**.

Verified by running the new tests against the current implementation: the two failure cases fail, contention and success are unaffected.

`test_registry_lock` + `test_remote` + `test_key` → `1..124`, no failures.