### PR TITLE
fix(guidance): the locked team keeps its state, the caller keeps the route

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -800,15 +800,26 @@ cmd_pull() {
     echo "Pulled '$pulled_name' into local team '$team' ($imported message(s)). Sync engine running."
   fi
   if [ "$pulled_age_v1" -gt 0 ]; then
-    # Print something that can be typed. `remote.sh` is not on PATH and never
-    # has been: it lives in this install's scripts directory, whose name is
-    # whatever the install was given -- which is why the sibling branch below
-    # already goes through $cmd_name. The old line named a bare script the
-    # shell cannot find, and named only --bundle, while --bundle without
-    # --confirm-digest is refused a few lines into unlock. Both halves have to
-    # be right, or this is a dead end with extra steps.
-    echo "This team is local but locked. Unlock it with the secret handoff bundle you were given:"
-    echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/remote.sh") unlock $(agmsg_shq "$team") --bundle <file> --confirm-digest <sha256>"
+    # The state, always. Dropping this would let a finished pull read as a
+    # usable team, which is the worse failure of the two: the messages are
+    # here and none of them can be read yet.
+    echo "This team is local but locked."
+
+    # The route, only when nobody else owns it. Both halves of this are the
+    # plain install's: `remote.sh` is not on PATH -- it lives in this
+    # install's scripts directory, whose name is whatever the install was
+    # given -- and "the secret handoff bundle you were given" describes
+    # material a caller's operator was never handed. Theirs arrives through a
+    # different ceremony entirely, and telling them to go find a bundle sends
+    # them looking for something that does not exist.
+    #
+    # --confirm-digest is named alongside --bundle because unlock refuses the
+    # one without the other a few lines in. A route worth printing is one that
+    # runs.
+    if agmsg_operator_guidance_is_ours; then
+      echo "Unlock it with the secret handoff bundle you were given:"
+      echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/remote.sh") unlock $(agmsg_shq "$team") --bundle <file> --confirm-digest <sha256>"
+    fi
   else
     echo "This team is now local and ready for normal use."
     echo "Open your agent and invoke its installed '$cmd_name' command, then join with a new agent name."

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -466,6 +466,35 @@ _capability_endpoint() {
   [ "$(_remote_endpoint_display "https://host.example.com:443")" = "https://host.example.com:443" ]
 }
 
+@test "pull: a caller that owns the guidance keeps the state and loses the route" {
+  skip_if_no_age
+  # The team is locked either way, and saying so is not optional: drop it and
+  # a finished pull reads as a usable team, which is the worse of the two
+  # failures -- the messages are here and none of them can be read yet.
+  #
+  # What goes is the route. `remote.sh` is not on a caller's operator's PATH,
+  # and "the secret handoff bundle you were given" describes material they
+  # were never handed; theirs arrives through a different ceremony. Sending
+  # them to look for a bundle sends them looking for something that does not
+  # exist.
+  MOCK_PULL_AGE=1
+  MOCK_TEAM_CIPHER_PROFILE=age-v1
+  restart_mock_server
+
+  AGMSG_OPERATOR_GUIDANCE=caller run bash "$SCRIPTS/remote.sh" pull \
+    --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" encrypted
+  [ "$status" -eq 0 ]
+
+  # The state survives.
+  [[ "$output" == *"This team is encrypted"* ]]
+  [[ "$output" == *"local but locked"* ]]
+
+  # The route does not.
+  [[ "$output" != *"handoff bundle you were given"* ]]
+  [[ "$output" != *"--confirm-digest"* ]]
+  [[ "$output" != *"scripts/remote.sh"*"unlock"* ]]
+}
+
 @test "connect: the out-of-band handoff line is printed by default" {
   skip_if_no_age
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam


### PR DESCRIPTION
`pull` ends an encrypted team with a **state** and a **remedy** on one line. The state is true wherever it runs. The remedy is this install's:

- `remote.sh` is not on a caller's operator's PATH — it lives in a scripts directory whose name is whatever *that* install was given
- "the secret handoff bundle you were given" describes material they were **never handed**; theirs arrives through a different ceremony

Sent to go find a bundle, they are sent looking for something that does not exist.

## The split

| | printed |
| --- | --- |
| `This team is local but locked.` | always |
| `Unlock it with the secret handoff bundle …` + the invocation | only when nobody else owns the next step |

No new mechanism — the same `agmsg_operator_guidance_is_ours()` that `connect` and `key.sh` already ask (#639).

**The state stays on both paths deliberately.** Dropping it would let a finished pull read as a *usable* team, and that is the worse of the two failures: the messages are here and not one of them can be read yet. The caller replaces the route, not the fact.

## Verification

Both directions, and neither alone is enough:

- with only the default case, a suppression that never fires passes
- with only the suppressed case, a version that stopped printing the state passes

Confirmed by mutation: forcing the function to always-speak fails the suppressed case; always-silent fails the default one.

`test_remote` + `test_key` → `1..121`, no failures.

Design agreed with the cloud side; the cloud half (replacing those two lines with its own route) follows on this SHA.