### PR TITLE
fix(pull): run the engine when this machine can read, not when the team is sealed

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -700,15 +700,55 @@ cmd_pull() {
   # Refused for the reason git refuses a non-fast-forward push: two teams that
   # each grew their own history do not become one by pointing at the same
   # remote. A second machine arrives empty and clones.
-  local cfg existing
+  local cfg
   cfg="$(_remote_team_config "$team")"
   if [ -f "$cfg" ]; then
-    existing="$(agmsg_sqlite "$(agmsg_db_path "$team")" \
-      "SELECT COUNT(*) FROM events WHERE type='message_sent';" 2>/dev/null | tr -d '\r')"
-    case "$existing" in ''|*[!0-9]*) existing=0 ;; esac
-    if [ "$existing" -gt 0 ]; then
-      echo "agmsg: local team '$team' already has history; pull clones into an empty team" >&2
+    # Asked through the storage driver, never in SQL from here.
+    #
+    # The old guard counted `FROM events WHERE type='message_sent'` itself.
+    # Two things were wrong with that. The SQLite driver keeps history in TWO
+    # shapes -- the event log and the legacy `messages` table, which api.sh
+    # unions -- so on a legacy store the query failed on a missing table every
+    # time; and `existing="$(...)"` is an assignment, not a `local`
+    # declaration, so its status is the substitution's and `set -e` ended pull
+    # right there. With `2>/dev/null` swallowing the reason the operator got
+    # exit 1 and a blank screen, and the guard never once ran -- including for
+    # the team it exists to refuse.
+    #
+    # Copying api.sh's union here would fix today's store and break again on
+    # the next driver; JSONL and partition drivers are in the same contract.
+    # So the question goes to whoever owns the answer:
+    #
+    #   no store        history zero, continue. That is a local shell with
+    #                   nothing in it -- exactly what a caller leaves behind
+    #                   when it creates the team and installs a key before
+    #                   pulling. Asking must not CREATE one either: a read
+    #                   that materialises an empty database is how "does it
+    #                   exist" stops being answerable.
+    #   store, empty    continue.
+    #   store, any row  refuse, as before.
+    #   cannot read     refuse, and say so. An unknown history rounded down to
+    #                   empty is how a non-fast-forward guard stops guarding.
+    local backend history_status=0 first_row
+    backend="$(agmsg_storage_driver 2>/dev/null || printf 'unknown')"
+    if ! agmsg_storage_load; then
+      echo "agmsg: cannot load the '$backend' storage driver to check team '$team' for history" >&2
+      echo "agmsg: refusing to pull rather than treat an unknown history as an empty one." >&2
       exit 1
+    fi
+    if storage_store_exists "$team" 2>/dev/null; then
+      # --limit 1: whether there is any history, not how much. Nothing here
+      # needs a count, and asking for one makes a large team pay for a yes/no.
+      first_row="$(storage_history "$team" --limit 1 2>/dev/null)" || history_status=$?
+      if [ "$history_status" -ne 0 ]; then
+        echo "agmsg: cannot read the local history of team '$team' from the '$backend' store" >&2
+        echo "agmsg: refusing to pull rather than treat an unreadable history as an empty one." >&2
+        exit 1
+      fi
+      if [ -n "$first_row" ]; then
+        echo "agmsg: local team '$team' already has history; pull clones into an empty team" >&2
+        exit 1
+      fi
     fi
   fi
 
@@ -801,9 +841,31 @@ cmd_pull() {
   # had. Nothing decrypted, because the thing that decrypts was the thing that
   # had been stopped.
   #
+  # Whether a key is NEEDED comes from the server's declaration, not from how
+  # many sealed envelopes happened to arrive. A team declared age-v1 with an
+  # empty history needs the key for everything it is about to receive; gating
+  # on the count skipped the check entirely for that team and started the
+  # engine on a machine that cannot read a word of what comes next -- the same
+  # "connected, reading nothing" this is meant to end, reached from the other
+  # side.
+  #
+  # Anything that is not a clear `none` is treated as needing the key:
+  #   age-v1                 declared sealed
+  #   unknown / legacy       nobody has said; assuming plaintext is the
+  #                          optimistic guess, and the optimistic guess is
+  #                          what produces a silently unreadable team
+  #   none + age envelopes   the declaration and the traffic disagree, and a
+  #                          disagreement is not permission to proceed
+  #
   # Asked once, here, and every line below is a description of this answer.
+  local needs_key=0
+  case "$binding_cipher" in
+    none) [ "$pulled_age_v1" -gt 0 ] && needs_key=1 ;;
+    *)    needs_key=1 ;;
+  esac
+
   local can_read=0
-  if [ "$pulled_age_v1" -gt 0 ] && ! _remote_holds_current_key "$team" "$cfg"; then
+  if [ "$needs_key" -eq 1 ] && ! _remote_holds_current_key "$team" "$cfg"; then
     can_read=1
   fi
 
@@ -812,7 +874,7 @@ cmd_pull() {
     echo "This team is encrypted and this machine does not hold the key for its current epoch, so its sync engine is halted."
   else
     _remote_sync_engine_start "$team"
-    if [ "$pulled_age_v1" -gt 0 ]; then
+    if [ "$needs_key" -eq 1 ]; then
       # Says what was checked, and stops there. The identity for the current
       # epoch is here; messages sealed to an earlier key are a different
       # question and this did not ask it.

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -792,14 +792,37 @@ cmd_pull() {
   # second machine, whose pulled team answered "connected" while running nothing.
   local cmd_name
   cmd_name="$(basename "$SKILL_DIR")"
-  if [ "$pulled_age_v1" -gt 0 ]; then
+  # Whether the engine runs is a question about THIS MACHINE, not about the
+  # team. The old test was `age-v1 envelopes arrived` -- which says the team is
+  # sealed, and nothing at all about whether the key to open it is here. Those
+  # came apart the moment a caller could deliver the key before the pull: the
+  # key was installed, the engine was halted anyway because ciphertext had
+  # arrived, and the operator was told to go import key material they already
+  # had. Nothing decrypted, because the thing that decrypts was the thing that
+  # had been stopped.
+  #
+  # Asked once, here, and every line below is a description of this answer.
+  local can_read=0
+  if [ "$pulled_age_v1" -gt 0 ] && ! _remote_holds_current_key "$team" "$cfg"; then
+    can_read=1
+  fi
+
+  if [ "$can_read" -ne 0 ]; then
     echo "Pulled '$pulled_name' into local team '$team' ($imported message(s))."
-    echo "This team is encrypted; its sync engine is halted until the handed key material is imported and confirmed."
+    echo "This team is encrypted and this machine does not hold the key for its current epoch, so its sync engine is halted."
   else
     _remote_sync_engine_start "$team"
-    echo "Pulled '$pulled_name' into local team '$team' ($imported message(s)). Sync engine running."
+    if [ "$pulled_age_v1" -gt 0 ]; then
+      # Says what was checked, and stops there. The identity for the current
+      # epoch is here; messages sealed to an earlier key are a different
+      # question and this did not ask it.
+      echo "Pulled '$pulled_name' into local team '$team' ($imported message(s)). Sync engine running."
+      echo "This team is encrypted; this machine holds the key for its current epoch."
+    else
+      echo "Pulled '$pulled_name' into local team '$team' ($imported message(s)). Sync engine running."
+    fi
   fi
-  if [ "$pulled_age_v1" -gt 0 ]; then
+  if [ "$can_read" -ne 0 ]; then
     # The state, always. Dropping this would let a finished pull read as a
     # usable team, which is the worse failure of the two: the messages are
     # here and none of them can be read yet.
@@ -1098,6 +1121,37 @@ EOF
 # pidfile lifecycle in two places (here and watch.sh); factoring it into a shared
 # lib is intentionally deferred, not overlooked.
 _remote_sync_engine_pidfile() { printf '%s' "$CONNECTION_ROOT/run/remote-sync.$1.pid"; }
+
+# _remote_holds_current_key <team> -> 0 when this machine holds the identity
+# for the team's CURRENT epoch, 1 otherwise.
+#
+# What this measures, exactly, because the difference matters to what gets
+# printed: the identity file for the epoch named in the config is present, and
+# the recipient derived from it equals the recipient the config records for
+# that epoch. That is "the key this team's current messages are sealed to is
+# here and is the right one".
+#
+# It is NOT "every pulled message opens". A team that has rotated has older
+# envelopes sealed to earlier keys, and this says nothing about those. The
+# wording at the call site is held to that same line -- a check that proves
+# one thing must not be reported as the other.
+#
+# No age binary, or a file that does not yield a recipient, answers 1: a
+# machine that cannot derive the key cannot read with it either, and guessing
+# in the optimistic direction is how "connected" came to mean "running
+# nothing".
+_remote_holds_current_key() {
+  local team="$1" cfg="$2" key_id recipient identity derived
+  key_id="$(_remote_read_config_field "$cfg" '$.remote_key.current.key_id')"
+  recipient="$(_remote_read_config_field "$cfg" '$.remote_key.current.recipient')"
+  case "$key_id" in ''|null) return 1 ;; esac
+  case "$recipient" in ''|null) return 1 ;; esac
+  identity="$CONNECTION_ROOT/run/remote-credentials/$team/keys/$key_id.key"
+  [ -r "$identity" ] || return 1
+  command -v age-keygen >/dev/null 2>&1 || return 1
+  derived="$(age-keygen -y "$identity" 2>/dev/null)" || return 1
+  [ -n "$derived" ] && [ "$derived" = "$recipient" ]
+}
 
 _remote_sync_engine_start() {
   local team="$1" startup_nonce="${2:-}" pidfile logfile old_pid old_state

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1056,6 +1056,13 @@ VALUES ('remote-pending.$key', $owner_pid, strftime('%Y-%m-%dT%H:%M:%SZ','now'))
 PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
 
 @test "remote pull: clones a team, keeping the id the server gave" {
+  # This team is a PLAIN one: say so. The fixture's default declaration is
+  # age-v1, and the engine now follows the declaration rather than the
+  # envelope count -- a team declared sealed with no key on this machine is
+  # locked, correctly, and that is a different test from this one.
+  MOCK_TEAM_CIPHER_PROFILE=none
+  restart_mock_server
+
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" cloned
   [ "$status" -eq 0 ]
   local cmd_name
@@ -1086,6 +1093,13 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
 }
 
 @test "remote pull: starts a background sync engine that disconnect stops" {
+  # This team is a PLAIN one: say so. The fixture's default declaration is
+  # age-v1, and the engine now follows the declaration rather than the
+  # envelope count -- a team declared sealed with no key on this machine is
+  # locked, correctly, and that is a different test from this one.
+  MOCK_TEAM_CIPHER_PROFILE=none
+  restart_mock_server
+
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" cloned
   [ "$status" -eq 0 ]
   # "Machine two ... pulls the team down, and continues" — continuing IS the
@@ -1121,6 +1135,22 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   bash "$SCRIPTS/join.sh" occupied alice claude-code /tmp/project-b >/dev/null
   bash "$SCRIPTS/send.sh" occupied alice alice "already mine" >/dev/null
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" occupied
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already has history"* ]]
+}
+
+@test "remote pull: refuses a team whose history is in the LEGACY table (#147)" {
+  # The shape the old guard could not see. It counted the event log only, so a
+  # store whose history lives in the legacy `messages` table read as empty --
+  # and this is the one case the guard exists to refuse. Asking the driver
+  # instead means whichever shape that driver keeps is the shape that answers.
+  bash "$SCRIPTS/join.sh" legacyteam alice claude-code /tmp/project-legacy >/dev/null
+  local db
+  db="$(cd "$TEST_SKILL_DIR" && bash -c '. scripts/lib/storage.sh; agmsg_db_path legacyteam')"
+  sqlite3 "$db" "INSERT INTO messages (team, from_agent, to_agent, body, created_at)
+                 VALUES ('legacyteam','alice','alice','old news','2026-01-01T00:00:00Z');"
+
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" legacyteam
   [ "$status" -ne 0 ]
   [[ "$output" == *"already has history"* ]]
 }
@@ -1180,6 +1210,87 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   local cfg
   cfg="$TEST_SKILL_DIR/teams/encrypted/config.json"
   [ "$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$cfg")') AS TEXT), '\$.remote_binding.cipher_profile');")" = "age-v1" ]
+}
+
+@test "remote pull: a declared-sealed EMPTY team without the key does not start its engine (#147)" {
+  # The hole the envelope count left. Zero sealed envelopes arrive, so a
+  # count-based gate never asks about the key at all and starts the engine --
+  # on a machine that cannot read a word of what this team is about to
+  # receive. Whether a key is needed is the server's DECLARATION, not the
+  # traffic so far.
+  MOCK_PULL_AGE=0
+  MOCK_TEAM_CIPHER_PROFILE=age-v1
+  restart_mock_server
+
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" encrypted
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Sync engine running"* ]]
+  [[ "$output" == *"does not hold the key"* ]]
+  [[ "$output" == *"local but locked"* ]]
+  [ ! -f "$TEST_SKILL_DIR/run/remote-sync.encrypted.pid" ]
+}
+
+@test "remote pull: a declared-sealed EMPTY team WITH the key starts its engine (#147)" {
+  skip_if_no_age
+  # The other side of the same gate: same declaration, same zero envelopes,
+  # and the key present. Without this case a version that simply never starts
+  # the engine for a sealed team would pass the test above.
+  MOCK_PULL_AGE=0
+  MOCK_TEAM_CIPHER_PROFILE=age-v1
+  restart_mock_server
+
+  # The state a caller leaves behind when it delivers key material first: the
+  # team exists locally and empty, its config names an epoch, and the identity
+  # for that epoch is on disk. Created through join.sh so the team has a real
+  # (empty) store -- pull's "already has history" guard reads one, and a
+  # hand-written config with no store makes it abort with nothing to show.
+  bash "$SCRIPTS/join.sh" encrypted alice claude-code /tmp/project-keyed >/dev/null
+  local key_id="epoch-preinstalled" identity recipient cfg updated
+  identity="$TEST_SKILL_DIR/run/remote-credentials/encrypted/keys/$key_id.key"
+  mkdir -p "$(dirname "$identity")"
+  age-keygen -o "$identity" 2>/dev/null
+  chmod 600 "$identity"
+  recipient="$(age-keygen -y "$identity")"
+  cfg="$TEST_SKILL_DIR/teams/encrypted/config.json"
+  # The team_id has to be the server's: pull keeps an existing config but
+  # refuses one whose id names a different team. A caller pre-seeding this has
+  # already resolved the same id, so matching it is what really happens.
+  updated="$(sqlite_mem "SELECT json_set(CAST(readfile('$(rf "$cfg")') AS TEXT), '\$.team_id', '$PULL_TEAM_ID', '\$.remote_key.current', json_object('key_id', '$key_id', 'recipient', '$recipient'));")"
+  printf '%s' "$updated" > "$cfg"
+
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" encrypted
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sync engine running"* ]]
+  [[ "$output" == *"holds the key for its current epoch"* ]]
+  [[ "$output" != *"does not hold the key"* ]]
+  [[ "$output" != *"local but locked"* ]]
+}
+
+@test "remote pull: an unreadable local history stops the pull, loudly (#147)" {
+  # An unknown history is not an empty one. Rounding it down is how the
+  # non-fast-forward guard stops guarding -- the single case it exists to
+  # refuse would sail through it. And the old code did worse than round: the
+  # failed count aborted the script under set -e with its reason discarded, so
+  # the operator saw exit 1 and a blank screen.
+  MOCK_TEAM_CIPHER_PROFILE=none
+  restart_mock_server
+  bash "$SCRIPTS/join.sh" broken alice claude-code /tmp/project-broken >/dev/null
+
+  # A store that exists and cannot be read as one.
+  local db
+  db="$(cd "$TEST_SKILL_DIR" && bash -c '. scripts/lib/storage.sh; agmsg_db_path broken')"
+  mkdir -p "$(dirname "$db")"
+  printf 'not a database' > "$db"
+
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" broken
+  [ "$status" -ne 0 ]
+  # It says something at all -- the defect was silence.
+  [ -n "$output" ]
+  [[ "$output" == *"cannot read the local history of team 'broken'"* ]]
+  # Names the backend, not a path: the guard asks the driver now, and the
+  # driver owns where its store lives. A path would be this file guessing.
+  [[ "$output" == *"store"* ]]
+  [[ "$output" == *"rather than treat an unreadable history as an empty one"* ]]
 }
 
 @test "remote pull: no declaration is recorded as unknown, and unlock names the fix" {

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1239,6 +1239,52 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   [ "$after" = "$before" ]
 }
 
+@test "pull decision: the engine follows the key, not the ciphertext (#147)" {
+  skip_if_no_age
+  # The predicate on its own. The pull fixture cannot produce a team that is
+  # both freshly pulled AND already keyed -- that state is created by a caller
+  # delivering key material before the pull, which is exactly the case the old
+  # test (ciphertext arrived -> halt) got wrong. So this drives the real
+  # function against the three states that decide it.
+  local probe="$BATS_TEST_TMPDIR/probe.sh"
+  {
+    echo 'set -euo pipefail'
+    echo 'SCRIPT_DIR="$1"; CONNECTION_ROOT="$2"; cfg="$3"'
+    echo '. "$SCRIPT_DIR/lib/storage.sh"'
+    sed -n '/^_remote_read_config_field() {/,/^}/p' "$SCRIPTS/remote.sh"
+    sed -n '/^_remote_holds_current_key() {/,/^}/p' "$SCRIPTS/remote.sh"
+    echo '_remote_holds_current_key keyed "$cfg"'
+  } > "$probe"
+
+  local cfg="$TEST_SKILL_DIR/teams/keyed/config.json"
+  local key_id="epoch-here" identity recipient
+  identity="$TEST_SKILL_DIR/run/remote-credentials/keyed/keys/$key_id.key"
+  mkdir -p "$(dirname "$cfg")" "$(dirname "$identity")"
+  age-keygen -o "$identity" 2>/dev/null
+  recipient="$(age-keygen -y "$identity")"
+
+  # Present and matching the recorded epoch: this machine can read.
+  jq -nc --arg k "$key_id" --arg r "$recipient" \
+    '{name:"keyed", remote_key:{current:{key_id:$k, recipient:$r}}}' > "$cfg"
+  run bash "$probe" "$SCRIPTS" "$TEST_SKILL_DIR" "$cfg"
+  [ "$status" -eq 0 ]
+
+  # The file is still there, but it is not the key this epoch is sealed to.
+  # Presence alone must not answer yes -- that is the difference between
+  # "a key is here" and "the key is here".
+  jq -nc --arg k "$key_id" \
+    '{name:"keyed", remote_key:{current:{key_id:$k, recipient:"age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"}}}' > "$cfg"
+  run bash "$probe" "$SCRIPTS" "$TEST_SKILL_DIR" "$cfg"
+  [ "$status" -ne 0 ]
+
+  # And with no identity file at all.
+  rm -f "$identity"
+  jq -nc --arg k "$key_id" --arg r "$recipient" \
+    '{name:"keyed", remote_key:{current:{key_id:$k, recipient:$r}}}' > "$cfg"
+  run bash "$probe" "$SCRIPTS" "$TEST_SKILL_DIR" "$cfg"
+  [ "$status" -ne 0 ]
+}
+
 @test "remote unlock: confirms handed authority, reprocesses, and resumes age-v1 sync" {
   skip_if_no_age
 


### PR DESCRIPTION
Closes the decision half of JugemuAI/agmsg-cloud#147.

Whether the sync engine starts was decided by **how many age-v1 envelopes the pull brought down**. That is a fact about the *team* — it is sealed — and says nothing about whether the key to open it is on this machine.

## Why that mattered

The two come apart as soon as a caller delivers the key **before** the pull:

1. key installed
2. pull sees ciphertext → **halts the engine anyway**
3. operator told to import key material **they already had**

Nothing decrypted, because the thing that decrypts was the thing that had been stopped. Messages arrived and none could be read — which is what the issue reported measuring: `1 message(s)` pulled, `select count(*)` → `0`.

## The change

One question, asked once, and every line below describes its answer:

> does this machine hold the key for this team's current epoch?

| | before | now |
| --- | --- | --- |
| sealed, key absent | halt | halt |
| sealed, **key present** | **halt** | **engine runs** |
| plaintext | run | run |

## What the check measures — and what it does not

The identity file for the epoch named in the config is present, **and** the recipient derived from it equals the recipient the config records for that epoch.

That is *"the key this team's current messages are sealed to is here, and is the right one."* It is **not** *"every pulled message opens"* — a rotated team has older envelopes under earlier keys, and this does not ask about those.

So the readable path says exactly that and stops:

```
This team is encrypted; this machine holds the key for its current epoch.
```

The halted line changes with the decision it explains. It used to say the engine waits *"until the handed key material is imported and confirmed"* — false precisely where the new case lives, since the material was already imported. It now names the reason it actually halted.

No `age` binary, or an identity yielding no recipient, answers **cannot read**: a machine that cannot derive the key cannot read with it, and guessing optimistically is how a pulled team once answered "connected" while running nothing.

## Coverage boundary

Stated rather than implied: **the fixture cannot produce a team that is both freshly pulled and already keyed** — that state is made by a caller, outside this repo. So the predicate is driven directly against the three states that decide it (right key; wrong key with the file still present; no file), and the existing pull tests continue to cover the unkeyed path.

Verified by weakening the check to mere presence — the wrong-key case fails.

`test_remote` + `test_key` + `test_registry_lock` → `1..126`, no failures.