### PR TITLE
refactor(pull): name the flag what it holds

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -864,12 +864,17 @@ cmd_pull() {
     *)    needs_key=1 ;;
   esac
 
-  local can_read=0
+  # Named for what it HOLDS. It is set when the key is missing, so the name
+  # has to say "cannot": a reader who trusts a `can_read` that means the
+  # opposite writes `[ "$can_read" -eq 1 ] && start_engine` and reopens the
+  # hole this decision closed. The value was always right; the label was the
+  # dangerous part.
+  local cannot_read=0
   if [ "$needs_key" -eq 1 ] && ! _remote_holds_current_key "$team" "$cfg"; then
-    can_read=1
+    cannot_read=1
   fi
 
-  if [ "$can_read" -ne 0 ]; then
+  if [ "$cannot_read" -ne 0 ]; then
     echo "Pulled '$pulled_name' into local team '$team' ($imported message(s))."
     echo "This team is encrypted and this machine does not hold the key for its current epoch, so its sync engine is halted."
   else
@@ -884,7 +889,7 @@ cmd_pull() {
       echo "Pulled '$pulled_name' into local team '$team' ($imported message(s)). Sync engine running."
     fi
   fi
-  if [ "$can_read" -ne 0 ]; then
+  if [ "$cannot_read" -ne 0 ]; then
     # The state, always. Dropping this would let a finished pull read as a
     # usable team, which is the worse failure of the two: the messages are
     # here and none of them can be read yet.


### PR DESCRIPTION
**This is what did not make it into #643.** Raised there as a nit after the verdict; a rename is not worth re-taking a clearance for, so it lands separately.

`can_read` was set when the key was **missing**:

```sh
local can_read=0
if [ "$needs_key" -eq 1 ] && ! _remote_holds_current_key "$team" "$cfg"; then
  can_read=1
fi
if [ "$can_read" -ne 0 ]; then
  echo "... does not hold the key ..., so its sync engine is halted."
```

Every use read it correctly, so the behaviour was right and CI and review both agreed. **The label was the dangerous part.**

`_remote_holds_current_key` returns 0 when the key *is* held, so `!` is true when it is not — and the assignment stores "cannot read" under a name promising the opposite. The next person to touch this reads the name and writes

```sh
[ "$can_read" -eq 1 ] && _remote_sync_engine_start "$team"
```

which starts the engine on a machine that cannot read a word, reopening the exact hole the decision was added to close. #643 was even titled *"run the engine when this machine can read"* — the same word used in the true direction in the title and the false one in the code.

Renamed to `cannot_read`. **No conditional is inverted and no branch moves**: this is the name catching up to the value.

`test_remote` → `1..93`, no failures.