### PR TITLE
fix(check-inbox): never mark a message read that the run then throws away

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -135,7 +135,19 @@ touch "$MARKER"
 # team the moment one of them was uninitialized.
 agmsg_storage_load
 
+# Messages are marked read inside this loop; the whole batch is emitted after
+# it. Under `set -e` an unguarded command substitution ends the script the
+# moment it fails -- and a failure while processing a LATER team lands after
+# an EARLIER team's rows were already stamped read_at, before either emit
+# point. Those messages are read, undelivered, and never offered again.
+# Measured on 8a2fe623: first_deliveries=0 first_read=1 second_unread=1 rc=5.
+#
+# So every substitution in here records the status and stops the loop instead
+# of ending the script. Whatever was already accumulated is emitted below, and
+# the failure is still propagated afterwards -- the run is not pretended to
+# have succeeded, it just stops taking messages down with it.
 OUTPUT=""
+LOOP_RC=0
 IFS=',' read -ra TEAM_LIST <<< "$TEAMS"
 for team in "${TEAM_LIST[@]}"; do
   storage_store_exists "$team" || continue
@@ -150,7 +162,7 @@ for team in "${TEAM_LIST[@]}"; do
   # role. That asymmetry is the Codex caveat documented in README — if a
   # Codex session actas'd into <name>, check-inbox is still polling
   # whatever whoami chose first, not <name>.
-  state=$(actas_lock_state "$team" "$AGENT" "${SESSION_ID:-}")
+  state=$(actas_lock_state "$team" "$AGENT" "${SESSION_ID:-}") || { LOOP_RC=$?; break; }
   case "$state" in
     other:*) continue ;;
   esac
@@ -158,7 +170,7 @@ for team in "${TEAM_LIST[@]}"; do
   # Unread via the storage facade (§2.1 storage_list_unread = events ∪ legacy),
   # JSONL parsed in one pass with sqlite's JSON funcs (no jq; cf. lib/hooks-json.sh).
   # id is kept so the mark step below targets exactly the rows shown.
-  UNREAD_JSONL=$(storage_list_unread "$team" "$AGENT")
+  UNREAD_JSONL=$(storage_list_unread "$team" "$AGENT") || { LOOP_RC=$?; break; }
   if [ -n "$UNREAD_JSONL" ]; then
     _arr="[$(printf '%s' "$UNREAD_JSONL" | paste -sd, -)]"
     RESULT=$(agmsg_sqlite ':memory:' "
@@ -167,8 +179,8 @@ for team in "${TEAM_LIST[@]}"; do
              json_extract(value,'\$.at') || char(31) ||
              json_extract(value,'\$.id')
       FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
-    ")
-    COUNT=$(printf '%s\n' "$RESULT" | wc -l | tr -d ' ')
+    ") || { LOOP_RC=$?; break; }
+    COUNT=$(printf '%s\n' "$RESULT" | wc -l | tr -d ' ') || { LOOP_RC=$?; break; }
     OUTPUT+="$COUNT new message(s) in $team:"$'\n'
     IDS=()
     while IFS=$'\x1f' read -r from body ts id; do
@@ -201,6 +213,12 @@ done
 
 # No new messages
 if [ -z "$OUTPUT" ]; then
+  # Both exits need the guard, not just the one that carries messages. A loop
+  # that stopped on a failure before accumulating anything has not established
+  # that there is nothing to deliver -- it established that it could not look.
+  # Saying "no new messages" and exiting 0 there is the same lie in a quieter
+  # voice, and the hook runtime treats it as a clean turn.
+  [ "$LOOP_RC" -eq 0 ] || exit "$LOOP_RC"
   emit_status_json "agmsg: no new messages"
   exit 0
 fi
@@ -215,5 +233,9 @@ if [ -n "$OUTPUT" ]; then
   "reason": "$ESCAPED"
 }
 ENDJSON
+  # Delivered first, then the failure is reported. Messages already marked read
+  # reach the operator, and the run still exits non-zero so nothing upstream
+  # reads a partial poll as a complete one.
+  [ "$LOOP_RC" -eq 0 ] || exit "$LOOP_RC"
   exit 0
 fi

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -199,7 +199,14 @@ for team in "${TEAM_LIST[@]}"; do
     # (project, type), NOT the session's in-memory actas role — the Codex
     # caveat documented in README.
     state=$(actas_lock_state "$team" "$AGENT" "${SESSION_ID:-}")
-    case "$state" in other:*) exit 97 ;; esac
+    # The leading `(` is load-bearing, not style. bash 3.2 -- which is /bin/bash
+    # on macOS, and what the macOS CI jobs run -- scans `$( ... )` for its
+    # closing paren without understanding `case`, so an unbalanced pattern paren
+    # ends the substitution early and the `;;` that follows is a syntax error.
+    # The whole file failed to parse; every check-inbox test on macOS died with
+    # "syntax error near unexpected token `;;'". Balancing the paren fixes it and
+    # is identical under bash 5.
+    case "$state" in (other:*) exit 97 ;; esac
 
     # Unread via the storage facade (§2.1 storage_list_unread = events ∪ legacy),
     # JSONL parsed in one pass with sqlite's JSON funcs (no jq; cf. lib/hooks-json.sh).

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -148,83 +148,102 @@ agmsg_storage_load
 # have succeeded, it just stops taking messages down with it.
 OUTPUT=""
 LOOP_RC=0
+LOOP_FAILED_TEAM=""
 IFS=',' read -ra TEAM_LIST <<< "$TEAMS"
 for team in "${TEAM_LIST[@]}"; do
   storage_store_exists "$team" || continue
-  # Honor actas exclusivity locks. If (team, AGENT) is currently held by
-  # another live session, that session is the owner of that role's inbox —
-  # don't deliver here. Mirrors the per-pair filtering watch.sh does for
-  # CC sessions (#62), giving Stop-hook delivery (codex / claude-code
-  # turn-mode) the same "respect peer locks" guarantee.
-  #
-  # Note: AGENT comes from whoami.sh, which returns the first registered
-  # agent for (project, type). It is NOT the session's in-memory actas
-  # role. That asymmetry is the Codex caveat documented in README — if a
-  # Codex session actas'd into <name>, check-inbox is still polling
-  # whatever whoami chose first, not <name>.
-  state=$(actas_lock_state "$team" "$AGENT" "${SESSION_ID:-}") || { LOOP_RC=$?; break; }
-  case "$state" in
-    other:*) continue ;;
-  esac
 
-  # Unread via the storage facade (§2.1 storage_list_unread = events ∪ legacy),
-  # JSONL parsed in one pass with sqlite's JSON funcs (no jq; cf. lib/hooks-json.sh).
-  # id is kept so the mark step below targets exactly the rows shown.
-  UNREAD_JSONL=$(storage_list_unread "$team" "$AGENT") || { LOOP_RC=$?; break; }
-  if [ -n "$UNREAD_JSONL" ]; then
+  # ONE guarded boundary for everything that reads or formats.
+  #
+  # The first attempt listed the substitutions and guarded each -- and missed
+  # one (`_arr`), which is the whole failure mode this file is about: an
+  # enumeration is short by one and the one it is short by is the defect. A
+  # subshell with its own errexit does not need the list. Anything in here that
+  # fails ends the subshell, and the status arrives at the `||` below instead of
+  # ending the script.
+  #
+  # 97 and 98 are the two ordinary reasons to skip a team, carried as statuses
+  # because a subshell cannot `continue` its caller's loop.
+  RESULT=$(
+    set -euo pipefail
+    # Honor actas exclusivity locks. If (team, AGENT) is held by another live
+    # session, that session owns that role's inbox — don't deliver here.
+    # Mirrors watch.sh's per-pair filtering (#62).
+    #
+    # AGENT comes from whoami.sh: the first registered agent for
+    # (project, type), NOT the session's in-memory actas role — the Codex
+    # caveat documented in README.
+    state=$(actas_lock_state "$team" "$AGENT" "${SESSION_ID:-}")
+    case "$state" in other:*) exit 97 ;; esac
+
+    # Unread via the storage facade (§2.1 storage_list_unread = events ∪ legacy),
+    # JSONL parsed in one pass with sqlite's JSON funcs (no jq; cf. lib/hooks-json.sh).
+    # id is kept so the mark step below targets exactly the rows shown.
+    UNREAD_JSONL=$(storage_list_unread "$team" "$AGENT")
+    [ -n "$UNREAD_JSONL" ] || exit 98
     _arr="[$(printf '%s' "$UNREAD_JSONL" | paste -sd, -)]"
-    RESULT=$(agmsg_sqlite ':memory:' "
+    agmsg_sqlite ':memory:' "
       SELECT json_extract(value,'\$.from') || char(31) ||
              replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
              json_extract(value,'\$.at') || char(31) ||
              json_extract(value,'\$.id')
       FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
-    ") || { LOOP_RC=$?; break; }
-    COUNT=$(printf '%s\n' "$RESULT" | wc -l | tr -d ' ') || { LOOP_RC=$?; break; }
-    OUTPUT+="$COUNT new message(s) in $team:"$'\n'
-    IDS=()
-    while IFS=$'\x1f' read -r from body ts id; do
-      [ -n "$id" ] || continue
-      OUTPUT+="  [$ts] $from: $body"$'\n'
-      IDS+=("$id")
-    done <<< "$RESULT"
-    OUTPUT+=$'\n'
-    # Test seam: a two-file barrier that lets the race regression test land a
-    # message deterministically between display and mark. No-op unless set.
-    if [ -n "${AGMSG_TEST_MARK_BARRIER:-}" ]; then
-      : > "$AGMSG_TEST_MARK_BARRIER.reached"
-      _agmsg_barrier_waited=0
-      while [ ! -e "$AGMSG_TEST_MARK_BARRIER.release" ]; do
-        sleep 0.05
-        _agmsg_barrier_waited=$((_agmsg_barrier_waited + 1))
-        [ "$_agmsg_barrier_waited" -ge 200 ] && break # 10s safety cap
-      done
-    fi
-    # Mark read via the facade (§2.1 storage_mark_read_batch): recipient-scoped,
-    # idempotent; a legacy id records a message_read event without mutating the
-    # legacy row (§2.4). Only the ids collected from the rows actually
-    # displayed above — never a blanket match — so a message that arrives
-    # after the SELECT above can never be marked read unseen.
-    if [ "${#IDS[@]}" -gt 0 ]; then
-      storage_mark_read_batch "$team" "$AGENT" "${IDS[@]}" >/dev/null 2>&1 || true
-    fi
+    "
+  ) || {
+    _rc=$?
+    case "$_rc" in
+      97|98) continue ;;
+      *) LOOP_RC=$_rc; LOOP_FAILED_TEAM="$team"; break ;;
+    esac
+  }
+
+  COUNT=$(printf '%s\n' "$RESULT" | grep -c . || true)
+  OUTPUT+="$COUNT new message(s) in $team:"$'\n'
+  IDS=()
+  while IFS=$'\x1f' read -r from body ts id; do
+    [ -n "$id" ] || continue
+    OUTPUT+="  [$ts] $from: $body"$'\n'
+    IDS+=("$id")
+  done <<< "$RESULT"
+  OUTPUT+=$'\n'
+  # Test seam: a two-file barrier that lets the race regression test land a
+  # message deterministically between display and mark. No-op unless set.
+  if [ -n "${AGMSG_TEST_MARK_BARRIER:-}" ]; then
+    : > "$AGMSG_TEST_MARK_BARRIER.reached"
+    _agmsg_barrier_waited=0
+    while [ ! -e "$AGMSG_TEST_MARK_BARRIER.release" ]; do
+      sleep 0.05
+      _agmsg_barrier_waited=$((_agmsg_barrier_waited + 1))
+      [ "$_agmsg_barrier_waited" -ge 200 ] && break # 10s safety cap
+    done
+  fi
+  # Mark read via the facade (§2.1 storage_mark_read_batch): recipient-scoped,
+  # idempotent; a legacy id records a message_read event without mutating the
+  # legacy row (§2.4). Only the ids collected from the rows actually displayed
+  # above — never a blanket match — so a message that arrives after the SELECT
+  # can never be marked read unseen.
+  if [ "${#IDS[@]}" -gt 0 ]; then
+    storage_mark_read_batch "$team" "$AGENT" "${IDS[@]}" >/dev/null 2>&1 || true
   fi
 done
 
-# No new messages
-if [ -z "$OUTPUT" ]; then
-  # Both exits need the guard, not just the one that carries messages. A loop
-  # that stopped on a failure before accumulating anything has not established
-  # that there is nothing to deliver -- it established that it could not look.
-  # Saying "no new messages" and exiting 0 there is the same lie in a quieter
-  # voice, and the hook runtime treats it as a clean turn.
-  [ "$LOOP_RC" -eq 0 ] || exit "$LOOP_RC"
-  emit_status_json "agmsg: no new messages"
-  exit 0
-fi
-
-# New messages found
+# The exit code cannot carry both the delivery and the failure report.
+#
+# The hook runtimes read stdout as control JSON only when the process exits 0;
+# a non-zero exit is logged as a hook failure and the output is discarded. So
+# emitting the messages and THEN exiting non-zero delivers nothing — on exactly
+# the path where messages were already marked read. The first version of this
+# fix did that, and was therefore inert on the only path that was broken.
+#
+# Delivery and the report are separated: the messages go out with exit 0, and
+# the partial failure is stated inside the payload the operator actually reads.
+# Nothing upstream sees a partial poll as a complete one, because the text says
+# so.
 if [ -n "$OUTPUT" ]; then
+  if [ "$LOOP_RC" -ne 0 ]; then
+    OUTPUT+="agmsg: this poll stopped early — team '$LOOP_FAILED_TEAM' could not be read (status $LOOP_RC)."$'\n'
+    OUTPUT+="agmsg: teams after it were not checked; their messages stay unread and will be offered again."$'\n'
+  fi
   # Escape for JSON: backslash, double-quote, newlines, tabs (macOS/Linux compatible)
   ESCAPED=$(printf '%s' "$OUTPUT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g' | awk '{if(NR>1) printf "\\n"; printf "%s",$0}')
   cat <<ENDJSON
@@ -233,9 +252,14 @@ if [ -n "$OUTPUT" ]; then
   "reason": "$ESCAPED"
 }
 ENDJSON
-  # Delivered first, then the failure is reported. Messages already marked read
-  # reach the operator, and the run still exits non-zero so nothing upstream
-  # reads a partial poll as a complete one.
-  [ "$LOOP_RC" -eq 0 ] || exit "$LOOP_RC"
+  # Exit 0 even when the poll failed part-way: this is the delivering path, and
+  # a non-zero status here throws the delivery away.
   exit 0
 fi
+
+# Nothing was accumulated. There is no delivery to protect, so the status is
+# free to carry the failure — and it must, because "no new messages" here would
+# claim something this run never established.
+[ "$LOOP_RC" -eq 0 ] || exit "$LOOP_RC"
+emit_status_json "agmsg: no new messages"
+exit 0

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -153,7 +153,26 @@ IFS=',' read -ra TEAM_LIST <<< "$TEAMS"
 for team in "${TEAM_LIST[@]}"; do
   storage_store_exists "$team" || continue
 
-  # ONE guarded boundary for everything that reads or formats.
+  # ONE guarded boundary for everything that reads or formats — and it must NOT
+  # be invoked from a condition context.
+  #
+  # `RESULT=$(...) || _rc=$?` looks equivalent and is not. Putting the
+  # substitution on the left of `||` makes the whole thing a tested command, and
+  # errexit is then suppressed for what runs inside it — including the `set -e`
+  # the subshell sets for itself. Measured: storage_init returned 13,
+  # storage_list_unread carried on regardless, the assignment landed empty and
+  # SUCCEEDED, and the `[ -n "" ] || exit 98` two lines later became the
+  # subshell's status. A backend failure arrived at the caller as "this team has
+  # no unread messages", and the poll reported a clean turn.
+  #
+  # A single non-conditional assignment with errexit lifted around it does not
+  # have that property: the subshell's own `set -e` aborts at the first failure
+  # and its status is what `$?` holds. The lift is two lines wide and restored
+  # immediately.
+  #
+  # This is also why the failing operations are not listed with `|| return`
+  # inside: an enumeration is short by one the next time an operation is added,
+  # which is the defect this file exists to fix.
   #
   # The first attempt listed the substitutions and guarded each -- and missed
   # one (`_arr`), which is the whole failure mode this file is about: an
@@ -164,6 +183,7 @@ for team in "${TEAM_LIST[@]}"; do
   #
   # 97 and 98 are the two ordinary reasons to skip a team, carried as statuses
   # because a subshell cannot `continue` its caller's loop.
+  set +e
   RESULT=$(
     set -euo pipefail
     # Honor actas exclusivity locks. If (team, AGENT) is held by another live
@@ -189,13 +209,14 @@ for team in "${TEAM_LIST[@]}"; do
              json_extract(value,'\$.id')
       FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
     "
-  ) || {
-    _rc=$?
-    case "$_rc" in
-      97|98) continue ;;
-      *) LOOP_RC=$_rc; LOOP_FAILED_TEAM="$team"; break ;;
-    esac
-  }
+  )
+  _rc=$?
+  set -e
+  case "$_rc" in
+    0)     ;;
+    97|98) continue ;;
+    *)     LOOP_RC=$_rc; LOOP_FAILED_TEAM="$team"; break ;;
+  esac
 
   COUNT=$(printf '%s\n' "$RESULT" | grep -c . || true)
   OUTPUT+="$COUNT new message(s) in $team:"$'\n'

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -142,10 +142,15 @@ agmsg_storage_load
 # point. Those messages are read, undelivered, and never offered again.
 # Measured on 8a2fe623: first_deliveries=0 first_read=1 second_unread=1 rc=5.
 #
-# So every substitution in here records the status and stops the loop instead
-# of ending the script. Whatever was already accumulated is emitted below, and
-# the failure is still propagated afterwards -- the run is not pretended to
-# have succeeded, it just stops taking messages down with it.
+# So a failure stops the loop instead of ending the script, and what was
+# already accumulated is delivered.
+#
+# The failure is reported IN THE PAYLOAD, not by the exit status. The runtimes
+# read stdout as control JSON only on exit 0, so a non-zero exit throws the
+# delivery away -- which is what the first attempt at this fix did, on exactly
+# the path that was broken. When there are messages to hand over the status is
+# 0 and the text says the poll was partial; only when there is nothing to
+# deliver does the status carry the failure.
 OUTPUT=""
 LOOP_RC=0
 LOOP_FAILED_TEAM=""
@@ -178,7 +183,7 @@ for team in "${TEAM_LIST[@]}"; do
   # one (`_arr`), which is the whole failure mode this file is about: an
   # enumeration is short by one and the one it is short by is the defect. A
   # subshell with its own errexit does not need the list. Anything in here that
-  # fails ends the subshell, and the status arrives at the `||` below instead of
+  # fails ends the subshell, and its status is read from `$?` below instead of
   # ending the script.
   #
   # 97 and 98 are the two ordinary reasons to skip a team, carried as statuses

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -148,6 +148,37 @@ delivered_to_operator() {
   [[ "$output" != *"no new messages"* ]]
 }
 
+@test "bash: a condition context suppresses a nested set -e, even after a later sentinel (#637)" {
+  # The property the boundary depends on, pinned on its own so nobody has to
+  # rediscover it from a broken poll.
+  #
+  # A subshell that sets its own `set -e` still does not abort when the whole
+  # substitution is the left side of `||` — and the trap is not that the status
+  # is lost, it is that a LATER command supplies a different one. Checking only
+  # "does a failure come out" misses it whenever a sentinel follows the failure,
+  # which is exactly the shape that made a backend error read as "no unread".
+  run bash -c '
+    set -euo pipefail
+    out=$( set -euo pipefail; false; [ -n "" ] || exit 98; echo unreachable ) || rc=$?
+    printf "conditional=%s\n" "${rc:-0}"
+  '
+  [ "$status" -eq 0 ]
+  # 98, not 1: the false did not stop it, the sentinel two commands later did.
+  [[ "$output" == *"conditional=98"* ]]
+
+  run bash -c '
+    set -euo pipefail
+    set +e
+    out=$( set -euo pipefail; false; [ -n "" ] || exit 98; echo unreachable )
+    rc=$?
+    set -e
+    printf "plain=%s\n" "$rc"
+  '
+  [ "$status" -eq 0 ]
+  # 1: the failure is what came out, because nothing ran after it.
+  [[ "$output" == *"plain=1"* ]]
+}
+
 @test "check-inbox: a message arriving between display and mark is NOT marked read unseen" {
   bash "$SCRIPTS/send.sh" testteam bob alice "early"
   AGMSG_TEST_MARK_BARRIER="$BARRIER" bash "$SCRIPTS/check-inbox.sh" claude-code /tmp/project-a \

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -77,7 +77,60 @@ await_barrier_reached() {
   [ "$(unread_count alice)" -eq 0 ]
 }
 
+
+# Make ONE team's store unreadable without touching any other team's.
+#
+# Teams share a single store until they are partitioned, so corrupting the file
+# a team resolves to by default breaks every team at once -- and then the FIRST
+# team fails, which is the harmless case, not the one under test. Switching this
+# team to its own partition first is what makes the failure land where the
+# defect needs it: after an earlier team has already been marked read.
+_break_only_this_teams_store() {
+  local team="$1" cfg="$TEST_SKILL_DIR/teams/$1/config.json" updated db
+  updated="$(sqlite_mem "SELECT json_set(CAST(readfile('$(rf "$cfg")') AS TEXT), '\$.drivers.partition', 'per-team');")"
+  printf '%s' "$updated" > "$cfg"
+  db="$(cd "$TEST_SKILL_DIR" && bash -c '. scripts/lib/storage.sh; agmsg_storage_load; agmsg_db_path '"$team" 2>/dev/null)"
+  [ -n "$db" ] || return 1
+  mkdir -p "$(dirname "$db")"
+  printf 'not a database' > "$db"
+}
+
 # --- check-inbox.sh ------------------------------------------------------
+
+@test "check-inbox: a later team's failure does not swallow an earlier team's messages (#637)" {
+  # Marking happens inside the loop; emitting happens after it. Under set -e an
+  # unguarded substitution ended the script the moment a LATER team failed --
+  # after an EARLIER team's rows were stamped read_at and before either emit
+  # point. Those messages were read, undelivered, and never offered again.
+  #
+  # The failing team is named to sort AFTER the one holding the message: the
+  # loop walks teams in order, and the whole defect is a failure that lands
+  # after an earlier team was already marked read. A name that sorted first
+  # would fail before anything was accumulated -- a different, harmless case.
+  bash "$SCRIPTS/join.sh" zzlastteam alice claude-code /tmp/project-a >/dev/null
+  bash "$SCRIPTS/send.sh" testteam bob alice "first team message" >/dev/null
+  _break_only_this_teams_store zzlastteam
+
+  run bash "$SCRIPTS/check-inbox.sh" claude-code /tmp/project-a </dev/null
+
+  # The failure is still reported -- this is not "carry on regardless".
+  [ "$status" -ne 0 ]
+  # And the message that was marked read reached the operator.
+  [[ "$output" == *"first team message"* ]]
+}
+
+@test "check-inbox: a failure with nothing accumulated does not report 'no new messages' (#637)" {
+  # The quieter half of the same lie. A loop that stopped before accumulating
+  # anything has not established that there is nothing to deliver -- only that
+  # it could not look. Exiting 0 with "no new messages" tells the hook runtime
+  # the turn was clean.
+  bash "$SCRIPTS/join.sh" zzlastteam alice claude-code /tmp/project-a >/dev/null
+  _break_only_this_teams_store zzlastteam
+
+  run bash "$SCRIPTS/check-inbox.sh" claude-code /tmp/project-a </dev/null
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"no new messages"* ]]
+}
 
 @test "check-inbox: a message arriving between display and mark is NOT marked read unseen" {
   bash "$SCRIPTS/send.sh" testteam bob alice "early"

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -103,37 +103,71 @@ _break_only_this_teams_store() {
 # The contract is theirs, not ours: stdout is read as control JSON only when
 # the process exits 0. A non-zero exit is logged as a hook failure and the
 # output is DISCARDED. Asserting on the shell's stdout alone cannot see that —
-# and the first version of this fix emitted the messages and then exited
-# non-zero, so it was inert on the only path that was broken while its tests
-# passed.
+# the first attempt at this fix emitted the messages and then exited non-zero,
+# so it was inert on the only path that was broken while its tests passed.
 #
-# Prints what the operator would actually receive, or nothing.
+# The parse is part of the contract too. Returning raw stdout would stay green
+# for malformed JSON, for a payload under some other key, or for text outside
+# `reason` — none of which an operator would ever see. So this parses, requires
+# `decision` to be `block`, and returns ONLY `reason`: exactly the bytes the
+# runtime puts in front of a person.
+#
+# Prints that text, or nothing at all.
 delivered_to_operator() {
   local out status
   out="$(bash "$SCRIPTS/check-inbox.sh" claude-code /tmp/project-a </dev/null 2>/dev/null)" && status=0 || status=$?
-  # The runtime's rule, in one line.
-  [ "$status" -eq 0 ] || return 0
-  printf '%s' "$out"
+  [ "$status" -eq 0 ] || return 0                 # the runtime's rule
+  [ -n "$out" ] || return 0
+  # Valid JSON, decision=block, and then the reason — each a separate gate so a
+  # payload that fails any one of them delivers nothing.
+  local esc parsed
+  esc="$(printf '%s' "$out" | sed "s/'/''/g")"
+  parsed="$(sqlite_mem "SELECT CASE
+      WHEN json_valid('$esc') = 0 THEN ''
+      WHEN json_extract('$esc', '\$.decision') IS NOT 'block' THEN ''
+      ELSE COALESCE(json_extract('$esc', '\$.reason'), '') END;")"
+  printf '%s' "$parsed"
 }
 
-@test "check-inbox: a later team's failure still DELIVERS the earlier team's messages (#637)" {
-  # Marking happens inside the loop; emitting happens after it. A failure on a
-  # later team lands after an earlier team's rows were stamped read_at — so
-  # whatever this run fails to deliver is lost for good.
+@test "check-inbox: a broken team stops the poll without losing either side (#637)" {
+  # Three teams, so the payload's own claim can be checked against reality:
+  #   aateam  succeeds and is marked read   -> must be DELIVERED
+  #   mmteam  store unreadable              -> stops the loop
+  #   zzteam  holds an unread message       -> must stay unread, undelivered
   #
-  # Measured through the runtime's rule, not the shell's stdout: the point is
-  # that the message REACHES someone, and an exit code that discards the
-  # payload does not achieve that however well-formed the payload is.
-  bash "$SCRIPTS/join.sh" zzlastteam alice claude-code /tmp/project-a >/dev/null
-  bash "$SCRIPTS/send.sh" testteam bob alice "first team message" >/dev/null
-  _break_only_this_teams_store zzlastteam
+  # Two teams could not test this. The text says "teams after it were not
+  # checked; their messages stay unread" — with nothing after the failure that
+  # sentence was unverified, and a version that silently consumed the rest
+  # would have passed.
+  bash "$SCRIPTS/join.sh" aateam alice claude-code /tmp/project-a >/dev/null
+  bash "$SCRIPTS/join.sh" aateam bob claude-code /tmp/project-a >/dev/null
+  bash "$SCRIPTS/join.sh" mmteam alice claude-code /tmp/project-a >/dev/null
+  bash "$SCRIPTS/join.sh" zzteam alice claude-code /tmp/project-a >/dev/null
+  bash "$SCRIPTS/join.sh" zzteam bob claude-code /tmp/project-a >/dev/null
+  bash "$SCRIPTS/send.sh" aateam bob alice "before the break" >/dev/null
+  bash "$SCRIPTS/send.sh" zzteam bob alice "after the break" >/dev/null
+  _break_only_this_teams_store mmteam
 
   run delivered_to_operator
-  [[ "$output" == *"first team message"* ]]
-  # And the operator is told the poll was partial, so a short answer is not
-  # read as a complete one.
+
+  # The earlier team's message reached a person.
+  [[ "$output" == *"before the break"* ]]
+  # The later team's did not.
+  [[ "$output" != *"after the break"* ]]
+  # And the payload says why, naming the team it stopped on.
   [[ "$output" == *"stopped early"* ]]
-  [[ "$output" == *"zzlastteam"* ]]
+  [[ "$output" == *"mmteam"* ]]
+  [[ "$output" == *"stay unread"* ]]
+
+  # The claim matches the store: the later team's message is still unread, so
+  # the next poll will offer it.
+  local left
+  left="$(bash -c '
+    source "'"$SCRIPTS"'/lib/storage.sh"
+    agmsg_storage_load
+    storage_list_unread zzteam alice
+  ' | grep -c .)"
+  [ "$left" -eq 1 ]
 }
 
 @test "check-inbox: a failure with nothing accumulated does not report 'no new messages' (#637)" {

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -97,33 +97,49 @@ _break_only_this_teams_store() {
 
 # --- check-inbox.sh ------------------------------------------------------
 
-@test "check-inbox: a later team's failure does not swallow an earlier team's messages (#637)" {
-  # Marking happens inside the loop; emitting happens after it. Under set -e an
-  # unguarded substitution ended the script the moment a LATER team failed --
-  # after an EARLIER team's rows were stamped read_at and before either emit
-  # point. Those messages were read, undelivered, and never offered again.
+# What the hook runtimes actually do with a Stop-hook run, applied to a real
+# invocation of check-inbox.sh.
+#
+# The contract is theirs, not ours: stdout is read as control JSON only when
+# the process exits 0. A non-zero exit is logged as a hook failure and the
+# output is DISCARDED. Asserting on the shell's stdout alone cannot see that —
+# and the first version of this fix emitted the messages and then exited
+# non-zero, so it was inert on the only path that was broken while its tests
+# passed.
+#
+# Prints what the operator would actually receive, or nothing.
+delivered_to_operator() {
+  local out status
+  out="$(bash "$SCRIPTS/check-inbox.sh" claude-code /tmp/project-a </dev/null 2>/dev/null)" && status=0 || status=$?
+  # The runtime's rule, in one line.
+  [ "$status" -eq 0 ] || return 0
+  printf '%s' "$out"
+}
+
+@test "check-inbox: a later team's failure still DELIVERS the earlier team's messages (#637)" {
+  # Marking happens inside the loop; emitting happens after it. A failure on a
+  # later team lands after an earlier team's rows were stamped read_at — so
+  # whatever this run fails to deliver is lost for good.
   #
-  # The failing team is named to sort AFTER the one holding the message: the
-  # loop walks teams in order, and the whole defect is a failure that lands
-  # after an earlier team was already marked read. A name that sorted first
-  # would fail before anything was accumulated -- a different, harmless case.
+  # Measured through the runtime's rule, not the shell's stdout: the point is
+  # that the message REACHES someone, and an exit code that discards the
+  # payload does not achieve that however well-formed the payload is.
   bash "$SCRIPTS/join.sh" zzlastteam alice claude-code /tmp/project-a >/dev/null
   bash "$SCRIPTS/send.sh" testteam bob alice "first team message" >/dev/null
   _break_only_this_teams_store zzlastteam
 
-  run bash "$SCRIPTS/check-inbox.sh" claude-code /tmp/project-a </dev/null
-
-  # The failure is still reported -- this is not "carry on regardless".
-  [ "$status" -ne 0 ]
-  # And the message that was marked read reached the operator.
+  run delivered_to_operator
   [[ "$output" == *"first team message"* ]]
+  # And the operator is told the poll was partial, so a short answer is not
+  # read as a complete one.
+  [[ "$output" == *"stopped early"* ]]
+  [[ "$output" == *"zzlastteam"* ]]
 }
 
 @test "check-inbox: a failure with nothing accumulated does not report 'no new messages' (#637)" {
-  # The quieter half of the same lie. A loop that stopped before accumulating
-  # anything has not established that there is nothing to deliver -- only that
-  # it could not look. Exiting 0 with "no new messages" tells the hook runtime
-  # the turn was clean.
+  # The other half. With nothing to deliver there is no payload to protect, so
+  # the status is free to carry the failure — and it must, because claiming
+  # "no new messages" states something this run never established.
   bash "$SCRIPTS/join.sh" zzlastteam alice claude-code /tmp/project-a >/dev/null
   _break_only_this_teams_store zzlastteam
 


### PR DESCRIPTION
Closes #637.

Messages are stamped `read_at` **inside** the per-team loop; the batch is emitted **after** it. Under `set -euo pipefail` an unguarded command substitution ends the script the moment it fails — and a failure while processing a *later* team lands after an *earlier* team's rows were already marked, before either emit point.

Those messages are read, undelivered, and never offered again. Measured on `8a2fe623`: `first_deliveries=0 first_read=1 second_unread=1 rc=5`.

## The change

Three substitutions in the loop were unguarded — the actas lock state, the unread listing, and the row-formatting SELECT. Each now records the status and stops the loop instead of ending the script. What was already accumulated is emitted, and the failure propagates **after** that: the run is not pretended to have succeeded, it just stops taking messages down with it.

**Both exits need the guard**, not only the one carrying messages. A loop that stopped before accumulating anything has not established that there is nothing to deliver — only that it could not look. Emitting "no new messages" and exiting 0 there is the same lie in a quieter voice, and the hook runtime reads it as a clean turn.

Emitting each team's block as it is marked would also fix the loss, and was rejected in the issue: it changes output ordering, `--quiet` behaviour and the Stop-hook JSON shape.

## What each regression would take to fail

They fail for **different** reasons, and neither is redundant:

| test | fails when |
| --- | --- |
| a later team's failure does not swallow an earlier team's messages | run against the current code — it swallows the first team's message entirely |
| a failure with nothing accumulated does not report "no new messages" | **not** on the current code (that version aborts before reaching either exit, so it satisfies the same assertions by accident). It fails when the new guard is removed — which is what it is there to hold |

Both verified by running them that way, rather than assuming.

## Fixture note

The failing team needed its own store partition first. Teams share one store by default, so corrupting the file a team resolves to breaks **every** team — and then the *first* team fails, which is the harmless case rather than the one under test. My first attempt did exactly that and passed for the wrong reason.

`test_inbox` + `test_delivery` → `1..145`, no failures.