### PR TITLE
fix(check-inbox): stop losing earlier teams' messages when a later team's query fails

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -137,6 +137,14 @@ _agmsg_sqlesc() { printf %s "$1" | sed "s/'/''/g"; }
 AGENT_SQL="$(_agmsg_sqlesc "$AGENT")"
 
 OUTPUT=""
+# Messages are marked read per team INSIDE this loop, but emitted only AFTER
+# it. Under errexit, a failure while processing a later team (either command
+# substitution below) would abort between those two points: earlier teams'
+# messages end up read_at-stamped yet never delivered, and never re-offered
+# (#637). So loop failures stop the loop instead of the script — whatever was
+# already accumulated still reaches an emit point, teams after the failing one
+# stay untouched (unread), and the failure status is re-raised on exit.
+CLAIM_RC=0
 IFS=',' read -ra TEAM_LIST <<< "$TEAMS"
 for team in "${TEAM_LIST[@]}"; do
   team_sql="$(_agmsg_sqlesc "$team")"
@@ -151,7 +159,7 @@ for team in "${TEAM_LIST[@]}"; do
   # role. That asymmetry is the Codex caveat documented in README — if a
   # Codex session actas'd into <name>, check-inbox is still polling
   # whatever whoami chose first, not <name>.
-  state=$(actas_lock_state "$team" "$AGENT" "${SESSION_ID:-}")
+  state=$(actas_lock_state "$team" "$AGENT" "${SESSION_ID:-}") || { CLAIM_RC=$?; break; }
   case "$state" in
     other:*) continue ;;
   esac
@@ -160,7 +168,7 @@ for team in "${TEAM_LIST[@]}"; do
     SELECT id || char(31) || from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
     FROM messages WHERE team='$team_sql' AND to_agent='$AGENT_SQL' AND read_at IS NULL
     ORDER BY created_at ASC;
-  ")
+  ") || { CLAIM_RC=$?; break; }
   if [ -n "$RESULT" ]; then
     COUNT=$(echo "$RESULT" | wc -l | tr -d ' ')
     OUTPUT+="$COUNT new message(s) in $team:"$'\n'
@@ -192,10 +200,12 @@ for team in "${TEAM_LIST[@]}"; do
   fi
 done
 
-# No new messages
+# No new messages. Both emit points re-raise a loop failure captured above:
+# exiting 0 here would convert "a team's query failed" into "nothing to
+# deliver", which is the silent half of #637.
 if [ -z "$OUTPUT" ]; then
   emit_status_json "agmsg: no new messages"
-  exit 0
+  exit "$CLAIM_RC"
 fi
 
 # New messages found
@@ -208,5 +218,5 @@ if [ -n "$OUTPUT" ]; then
   "reason": "$ESCAPED"
 }
 ENDJSON
-  exit 0
+  exit "$CLAIM_RC"
 fi

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -72,6 +72,43 @@ await_barrier_reached() {
 
 # --- check-inbox.sh ------------------------------------------------------
 
+@test "check-inbox: a later team's query failure does not lose earlier teams' messages (#637)" {
+  # alice is in two teams; glob order enumerates testteam before zteam.
+  bash "$SCRIPTS/join.sh" zteam alice claude-code /tmp/project-a
+  bash "$SCRIPTS/join.sh" zteam bob claude-code /tmp/project-a
+  bash "$SCRIPTS/send.sh" testteam bob alice "early"
+  bash "$SCRIPTS/send.sh" zteam bob alice "in-zteam"
+
+  # PATH shim: fail (SQLITE_BUSY-style rc=5) exactly the unread SELECT for the
+  # second team; everything else passes through to the real sqlite3. testteam's
+  # messages are read_at-stamped inside the loop before zteam is queried, so
+  # without the loop-failure guard this abort loses them silently.
+  REAL_SQLITE3="$(command -v sqlite3)"
+  mkdir -p "$TEST_SKILL_DIR/shim"
+  cat > "$TEST_SKILL_DIR/shim/sqlite3" <<SHIM
+#!/usr/bin/env bash
+for a in "\$@"; do
+  case "\$a" in
+    *"team='zteam'"*"read_at IS NULL"*) exit 5 ;;
+  esac
+done
+exec "$REAL_SQLITE3" "\$@"
+SHIM
+  chmod +x "$TEST_SKILL_DIR/shim/sqlite3"
+
+  run env PATH="$TEST_SKILL_DIR/shim:$PATH" \
+    bash "$SCRIPTS/check-inbox.sh" claude-code /tmp/project-a < /dev/null
+  # testteam's message was already marked read when zteam failed — it MUST
+  # still have been emitted, or it is lost forever (never re-offered).
+  [[ "$output" == *"early"* ]]
+  [[ "$output" != *"in-zteam"* ]]
+  # The failure is not swallowed: the loop's status is re-raised on exit.
+  [ "$status" -eq 5 ]
+  # testteam delivered-and-read; zteam untouched, so its message re-surfaces.
+  [ "$(unread_count alice)" -eq 0 ]
+  [ "$(sqlite3 "$DBPATH" "SELECT COUNT(*) FROM messages WHERE team='zteam' AND to_agent='alice' AND read_at IS NULL;" | tr -d '\r')" -eq 1 ]
+}
+
 @test "check-inbox: a message arriving between display and mark is NOT marked read unseen" {
   bash "$SCRIPTS/send.sh" testteam bob alice "early"
   AGMSG_TEST_MARK_BARRIER="$BARRIER" bash "$SCRIPTS/check-inbox.sh" claude-code /tmp/project-a > "$TEST_SKILL_DIR/check-run.out" 2>/dev/null 3>&- &


### PR DESCRIPTION
Fixes #637

## Problem

`check-inbox.sh` marks messages read per team inside its team loop, but emits output only after the loop finishes. The script runs under `set -euo pipefail`, and two command substitutions inside the loop (`state=$(actas_lock_state ...)` and `RESULT=$(agmsg_sqlite ... SELECT ...)`) take the substitution's exit status, so a failure while processing a later team (locked DB, `SQLITE_BUSY`, read-only store, ...) aborts the script between those two points. Earlier teams' messages are already `read_at`-stamped at that moment but have not reached either emit point: they are never delivered and never re-offered. Credit to @salsato for reporting this and pinning down the exact mechanism, including why the id-scoped `UPDATE` is not the trigger (#637).

## Fix

Loop failures now stop the loop instead of the script: both command substitutions capture a non-zero status into `CLAIM_RC` and `break`. Whatever was already accumulated still reaches an emit point, and teams after the failing one are left untouched (unread), so their messages re-surface on the next check. Both emit points then re-raise the captured status via `exit "$CLAIM_RC"` instead of `exit 0` -- the failure is surfaced, not swallowed into "nothing to deliver". When no failure occurs, `CLAIM_RC` is 0 and behavior is unchanged.

## Test

The regression test registers the agent in two teams (glob order enumerates `testteam` before `zteam`) with one unread message in each, then forces the failure with a `sqlite3` PATH shim that exits 5 (SQLITE_BUSY-style) for exactly the second team's unread `SELECT` and passes everything else through to the real binary. It asserts the three observations from the issue's harness: (1) the first team's message is emitted even though it was already marked read when the second team failed, (2) the second team's message stays unread and is absent from the output, (3) the run exits 5. Before the fix the run emits nothing and the assertion on the first team's message fails, reproducing the silent loss; after the fix the suite is green (verified both ways).

Suites run locally: `tests/test_inbox.bats`, `tests/test_delivery.bats`, `tests/test_messaging.bats`, `tests/test_storage.bats` -- all green by exit code.
