### PR TITLE
feat(doctor): wire into the 9 per-type templates, the Windows dispatcher, and the plugin-path SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -32,6 +32,8 @@ fi
 
 After this runs once, `~/.agents/skills/agmsg/` is populated and you can skip Step 0 on future invocations.
 
+**If the argument/intent is `doctor` (with or without further flags): do NOT run whoami.sh, do NOT enter the join flow (Steps 1-2a). Go straight to the `doctor.sh` line under Step 2b and stop there.** `doctor` reports the health of the whole installation and exists specifically for when registration or delivery is broken — it must work even before you have an identity, so it never goes through Steps 1-2a.
+
 ### Step 1: Check identity
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -155,6 +155,14 @@ Do NOT manually edit config files. Always use join.sh. If the name was recently 
 #   --force              tear down from the recorded placement, no message
 #   --timeout N          seconds to wait for graceful teardown (default 30)
 ~/.agents/skills/agmsg/scripts/despawn.sh <team> <from> <name> [--force] [--timeout N]
+
+# Read-only health check: registrations, actas lock status, and delivery mode
+# per (project, type). Default (no flags) covers the WHOLE installation —
+# every team, project, and type — not just the current one; narrow with
+# --project/--type/--team (combinable) only when asked to. Exit codes: 0
+# clean, 1 one or more warnings, 2 usage/resolution error. --redacted masks
+# paths and names, safe to paste into a report.
+~/.agents/skills/agmsg/scripts/doctor.sh [--project <path>] [--type <type>] [--team <team>] [--redacted]
 ```
 
 ## Permission prompts (Claude Code)

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -7,6 +7,8 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/__SKILL_NAME__/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
+**If the argument is "doctor" (with or without further flags): do NOT run whoami.sh, do NOT enter the join flow below. Go straight to the "doctor" entry under Execute and stop there.** `doctor` reports the health of the whole installation and exists specifically for when registration or delivery is broken — it must work even before you have an identity, so it never goes through the section below.
+
 ## Identity
 
 If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call in this session, skip to **Execute** below.

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -42,6 +42,7 @@ Four possible outputs:
   > - `$__SKILL_NAME__ send <agent> <message>` — send a message
   > - `$__SKILL_NAME__ team` — list team members
   > - `$__SKILL_NAME__ history` — message history
+  > - `$__SKILL_NAME__ doctor` — check registration/lock/delivery health across the installation
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -132,6 +133,15 @@ If argument is "hook on" (legacy alias):
 If argument is "hook off" (legacy alias):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off antigravity "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'off'."
+
+If argument is "doctor" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh`
+2. Show the output to the user. Exit code: 0 = clean, 1 = one or more warnings (the output still shows everything -- show it in full), 2 = usage/resolution error.
+
+If argument starts with "doctor" followed by flags (e.g. "doctor --project /path/to/project"):
+1. Pass the flags straight through: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh <flags>`
+2. Supported flags, all optional and combinable: `--project <path>`, `--type <type>`, `--team <team>`, `--redacted` (masks paths and names, safe to paste into a report). Only use these when the user explicitly asks to narrow the scope -- bare `doctor` (no flags) already covers the whole installation and is the normal way to run it.
+3. Show the output to the user.
 
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" antigravity`

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -6,6 +6,8 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/__SKILL_NAME__/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
+**If the argument is "doctor" (with or without further flags): do NOT run whoami.sh, do NOT enter the join flow below. Go straight to the "doctor" entry under Execute and stop there.** `doctor` reports the health of the whole installation and exists specifically for when registration or delivery is broken — it must work even before you have an identity, so it never goes through the section below.
+
 ## Identity
 
 If you already know your AGENT and TEAMS from a previous `/__SKILL_NAME__` call in this session, skip to **Execute** below.

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -46,6 +46,7 @@ Four possible outputs:
   > - `/__SKILL_NAME__ drop <name>` — remove a role from this project
   > - `/__SKILL_NAME__ spawn <type> <name>` — launch a new agent in a tmux pane / terminal and have it actas <name>
   > - `/__SKILL_NAME__ despawn <name>` — tear down a member you spawned (graceful, or `--force`)
+  > - `/__SKILL_NAME__ doctor` — check registration/lock/delivery health across the installation
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -231,6 +232,15 @@ If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
 If argument is "version":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/version.sh`
 2. Show the output — the installed version (git-describe provenance recorded at install time).
+
+If argument is "doctor" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh`
+2. Show the output to the user. Exit code: 0 = clean, 1 = one or more warnings (the output still shows everything -- show it in full), 2 = usage/resolution error.
+
+If argument starts with "doctor" followed by flags (e.g. "doctor --project /path/to/project"):
+1. Pass the flags straight through: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh <flags>`
+2. Supported flags, all optional and combinable: `--project <path>`, `--type <type>`, `--team <team>`, `--redacted` (masks paths and names, safe to paste into a report). Only use these when the user explicitly asks to narrow the scope -- bare `doctor` (no flags) already covers the whole installation and is the normal way to run it.
+3. Show the output to the user.
 
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" claude-code`

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -7,6 +7,8 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/__SKILL_NAME__/scripts/send.sh myteam alice bob "hello"'`. Always single-quote the `bash -lc` payload; NEVER use a double-quoted wrapper with escaped inner quotes (e.g. `bash -lc "... \"$PWD\" ..."`) — PowerShell parses `\"` as a literal backslash that terminates the string, silently corrupting the command and dropping everything after it. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
+**If the argument is "doctor" (with or without further flags): do NOT run whoami.sh, do NOT enter the join flow below. Go straight to the "doctor" entry under Execute and stop there.** `doctor` reports the health of the whole installation and exists specifically for when registration or delivery is broken — it must work even before you have an identity, so it never goes through the section below.
+
 ## Identity
 
 If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call in this session, skip to **Execute** below.

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -48,6 +48,7 @@ Four possible outputs:
   > - `$__SKILL_NAME__ send <agent> <message>` — send a message
   > - `$__SKILL_NAME__ team` — list team members
   > - `$__SKILL_NAME__ history` — message history
+  > - `$__SKILL_NAME__ doctor` — check registration/lock/delivery health across the installation
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -166,6 +167,15 @@ If argument is "hook off" (legacy alias):
 If argument is "version":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/version.sh`
 2. Show the output — the installed version (git-describe provenance recorded at install time).
+
+If argument is "doctor" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh`
+2. Show the output to the user. Exit code: 0 = clean, 1 = one or more warnings (the output still shows everything -- show it in full), 2 = usage/resolution error.
+
+If argument starts with "doctor" followed by flags (e.g. "doctor --project /path/to/project"):
+1. Pass the flags straight through: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh <flags>`
+2. Supported flags, all optional and combinable: `--project <path>`, `--type <type>`, `--team <team>`, `--redacted` (masks paths and names, safe to paste into a report). Only use these when the user explicitly asks to narrow the scope -- bare `doctor` (no flags) already covers the whole installation and is the normal way to run it.
+3. Show the output to the user.
 
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" codex`

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -42,6 +42,7 @@ Four possible outputs:
   > - `/__SKILL_NAME__ send <agent> <message>` — send a message
   > - `/__SKILL_NAME__ team` — list team members
   > - `/__SKILL_NAME__ history` — message history
+  > - `/__SKILL_NAME__ doctor` — check registration/lock/delivery health across the installation
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -132,6 +133,15 @@ If argument is "hook on" (legacy alias):
 If argument is "hook off" (legacy alias):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off copilot "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'off'."
+
+If argument is "doctor" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh`
+2. Show the output to the user. Exit code: 0 = clean, 1 = one or more warnings (the output still shows everything -- show it in full), 2 = usage/resolution error.
+
+If argument starts with "doctor" followed by flags (e.g. "doctor --project /path/to/project"):
+1. Pass the flags straight through: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh <flags>`
+2. Supported flags, all optional and combinable: `--project <path>`, `--type <type>`, `--team <team>`, `--redacted` (masks paths and names, safe to paste into a report). Only use these when the user explicitly asks to narrow the scope -- bare `doctor` (no flags) already covers the whole installation and is the normal way to run it.
+3. Show the output to the user.
 
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" copilot`

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -7,6 +7,8 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/__SKILL_NAME__/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
+**If the argument is "doctor" (with or without further flags): do NOT run whoami.sh, do NOT enter the join flow below. Go straight to the "doctor" entry under Execute and stop there.** `doctor` reports the health of the whole installation and exists specifically for when registration or delivery is broken — it must work even before you have an identity, so it never goes through the section below.
+
 ## Identity
 
 If you already know your AGENT and TEAMS from a previous `/__SKILL_NAME__` call in this session, skip to **Execute** below.

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -7,6 +7,8 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/__SKILL_NAME__/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
+**If the argument is "doctor" (with or without further flags): do NOT run whoami.sh, do NOT enter the join flow below. Go straight to the "doctor" entry under Execute and stop there.** `doctor` reports the health of the whole installation and exists specifically for when registration or delivery is broken — it must work even before you have an identity, so it never goes through the section below.
+
 ## Identity
 
 If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call in this session, skip to **Execute** below.

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -42,6 +42,7 @@ Four possible outputs:
   > - `$__SKILL_NAME__ send <agent> <message>` — send a message
   > - `$__SKILL_NAME__ team` — list team members
   > - `$__SKILL_NAME__ history` — message history
+  > - `$__SKILL_NAME__ doctor` — check registration/lock/delivery health across the installation
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -135,6 +136,15 @@ If argument is "hook off" (legacy alias):
 If argument is "version":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/version.sh`
 2. Show the output — the installed version (git-describe provenance recorded at install time).
+
+If argument is "doctor" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh`
+2. Show the output to the user. Exit code: 0 = clean, 1 = one or more warnings (the output still shows everything -- show it in full), 2 = usage/resolution error.
+
+If argument starts with "doctor" followed by flags (e.g. "doctor --project /path/to/project"):
+1. Pass the flags straight through: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh <flags>`
+2. Supported flags, all optional and combinable: `--project <path>`, `--type <type>`, `--team <team>`, `--redacted` (masks paths and names, safe to paste into a report). Only use these when the user explicitly asks to narrow the scope -- bare `doctor` (no flags) already covers the whole installation and is the normal way to run it.
+3. Show the output to the user.
 
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" cursor`

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -7,6 +7,8 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/__SKILL_NAME__/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
+**If the argument is "doctor" (with or without further flags): do NOT run whoami.sh, do NOT enter the join flow below. Go straight to the "doctor" entry under Execute and stop there.** `doctor` reports the health of the whole installation and exists specifically for when registration or delivery is broken — it must work even before you have an identity, so it never goes through the section below.
+
 ## Identity
 
 If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call in this session, skip to **Execute** below.

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -42,6 +42,7 @@ Four possible outputs:
   > - `$__SKILL_NAME__ send <agent> <message>` — send a message
   > - `$__SKILL_NAME__ team` — list team members
   > - `$__SKILL_NAME__ history` — message history
+  > - `$__SKILL_NAME__ doctor` — check registration/lock/delivery health across the installation
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -132,6 +133,15 @@ If argument is "hook on" (legacy alias):
 If argument is "hook off" (legacy alias):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off gemini "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'off'."
+
+If argument is "doctor" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh`
+2. Show the output to the user. Exit code: 0 = clean, 1 = one or more warnings (the output still shows everything -- show it in full), 2 = usage/resolution error.
+
+If argument starts with "doctor" followed by flags (e.g. "doctor --project /path/to/project"):
+1. Pass the flags straight through: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh <flags>`
+2. Supported flags, all optional and combinable: `--project <path>`, `--type <type>`, `--team <team>`, `--redacted` (masks paths and names, safe to paste into a report). Only use these when the user explicitly asks to narrow the scope -- bare `doctor` (no flags) already covers the whole installation and is the normal way to run it.
+3. Show the output to the user.
 
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" gemini`

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -7,6 +7,8 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/__SKILL_NAME__/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
+**If the argument is "doctor" (with or without further flags): do NOT run whoami.sh, do NOT enter the join flow below. Go straight to the "doctor" entry under Execute and stop there.** `doctor` reports the health of the whole installation and exists specifically for when registration or delivery is broken — it must work even before you have an identity, so it never goes through the section below.
+
 ## Identity
 
 If you already know your AGENT and TEAMS from a previous `/__SKILL_NAME__` call in this session, skip to **Execute** below.

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -42,6 +42,7 @@ Four possible outputs:
   > - `/__SKILL_NAME__ send <agent> <message>` — send a message
   > - `/__SKILL_NAME__ team` — list team members
   > - `/__SKILL_NAME__ history` — message history
+  > - `/__SKILL_NAME__ doctor` — check registration/lock/delivery health across the installation
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -163,6 +164,15 @@ If argument is "hook on" (legacy alias):
 If argument is "hook off" (legacy alias):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off grok-build "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'off'."
+
+If argument is "doctor" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh`
+2. Show the output to the user. Exit code: 0 = clean, 1 = one or more warnings (the output still shows everything -- show it in full), 2 = usage/resolution error.
+
+If argument starts with "doctor" followed by flags (e.g. "doctor --project /path/to/project"):
+1. Pass the flags straight through: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh <flags>`
+2. Supported flags, all optional and combinable: `--project <path>`, `--type <type>`, `--team <team>`, `--redacted` (masks paths and names, safe to paste into a report). Only use these when the user explicitly asks to narrow the scope -- bare `doctor` (no flags) already covers the whole installation and is the normal way to run it.
+3. Show the output to the user.
 
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" grok-build`

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -42,6 +42,7 @@ Four possible outputs:
   > - ask `send <agent> <message>` — send a message
   > - ask `team` — list team members
   > - ask `history` — message history
+  > - ask `doctor` — check registration/lock/delivery health across the installation
 
   5. Hermes has no agmsg automatic delivery hook. Set manual delivery explicitly:
      `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off hermes "$(pwd)"`
@@ -120,6 +121,15 @@ If argument is "hook on" (legacy alias):
 If argument is "hook off" (legacy alias):
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off hermes "$(pwd)"`
 2. Tell the user: "Delivery mode set to 'off'."
+
+If argument is "doctor" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh`
+2. Show the output to the user. Exit code: 0 = clean, 1 = one or more warnings (the output still shows everything -- show it in full), 2 = usage/resolution error.
+
+If argument starts with "doctor" followed by flags (e.g. "doctor --project /path/to/project"):
+1. Pass the flags straight through: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh <flags>`
+2. Supported flags, all optional and combinable: `--project <path>`, `--type <type>`, `--team <team>`, `--redacted` (masks paths and names, safe to paste into a report). Only use these when the user explicitly asks to narrow the scope -- bare `doctor` (no flags) already covers the whole installation and is the normal way to run it.
+3. Show the output to the user.
 
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" hermes`

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -7,6 +7,8 @@ Hermes Agent skill for agmsg cross-agent messaging. **IMPORTANT: Always use the 
 
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/__SKILL_NAME__/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
+**If the argument is "doctor" (with or without further flags): do NOT run whoami.sh, do NOT enter the join flow below. Go straight to the "doctor" entry under Execute and stop there.** `doctor` reports the health of the whole installation and exists specifically for when registration or delivery is broken — it must work even before you have an identity, so it never goes through the section below.
+
 ## Identity
 
 If you already know your AGENT and TEAMS from a previous `/__SKILL_NAME__` use in this session, skip to **Execute** below.

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -7,6 +7,8 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/__SKILL_NAME__/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
+**If the argument is "doctor" (with or without further flags): do NOT run whoami.sh, do NOT enter the join flow below. Go straight to the "doctor" entry under Execute and stop there.** `doctor` reports the health of the whole installation and exists specifically for when registration or delivery is broken — it must work even before you have an identity, so it never goes through the section below.
+
 ## Identity
 
 If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call in this session, skip to **Execute** below.

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -42,6 +42,7 @@ Four possible outputs:
   > - `$__SKILL_NAME__ send <agent> <message>` — send a message
   > - `$__SKILL_NAME__ team` — list team members
   > - `$__SKILL_NAME__ history` — message history
+  > - `$__SKILL_NAME__ doctor` — check registration/lock/delivery health across the installation
 
   5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
 
@@ -160,6 +161,15 @@ If argument is "hook off" (legacy alias):
 If argument is "version":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/version.sh`
 2. Show the output — the installed version (git-describe provenance recorded at install time).
+
+If argument is "doctor" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh`
+2. Show the output to the user. Exit code: 0 = clean, 1 = one or more warnings (the output still shows everything -- show it in full), 2 = usage/resolution error.
+
+If argument starts with "doctor" followed by flags (e.g. "doctor --project /path/to/project"):
+1. Pass the flags straight through: `~/.agents/skills/__SKILL_NAME__/scripts/doctor.sh <flags>`
+2. Supported flags, all optional and combinable: `--project <path>`, `--type <type>`, `--team <team>`, `--redacted` (masks paths and names, safe to paste into a report). Only use these when the user explicitly asks to narrow the scope -- bare `doctor` (no flags) already covers the whole installation and is the normal way to run it.
+3. Show the output to the user.
 
 If argument is "reset":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" opencode`

--- a/scripts/windows/dispatch.sh
+++ b/scripts/windows/dispatch.sh
@@ -32,6 +32,7 @@ commands:
   reset [agent]
   actas <agent>
   drop <agent>
+  doctor [--project <path>] [--type <type>] [--team <team>] [--redacted]
 EOF
 }
 
@@ -278,6 +279,16 @@ case "$COMMAND" in
     fi
     echo "To act as '$name' in this PowerShell session, run:"
     echo "  \$env:AGMSG_TEAM = '$team_name'; \$env:AGMSG_AGENT = '$name'"
+    ;;
+
+  doctor)
+    # No identity resolution -- doctor.sh needs no TEAM/AGENT, and this
+    # dispatcher's own --project/--type/--team globals are for resolving
+    # identity context for OTHER commands, a different purpose from doctor's
+    # own same-named flags (which scope its report, not an identity). Passed
+    # straight through: whatever follows "doctor" on the command line is
+    # doctor.sh's own argv verbatim, exactly as documented in the templates.
+    run_script doctor.sh "$@"
     ;;
 
   *)

--- a/tests/test_dispatch.bats
+++ b/tests/test_dispatch.bats
@@ -63,3 +63,19 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" =~ "Delivery mode set to 'turn'" ]]
 }
+
+@test "dispatch: doctor needs no identity and covers the whole installation by default" {
+  # No --team/--agent (unlike every other command above) -- doctor.sh needs
+  # no identity, only its own flags, and the default scope is everything.
+  run bash "$SCRIPTS/windows/dispatch.sh" -- doctor
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "$PROJECT_ALICE" ]]
+  [[ "$output" =~ "$PROJECT_BOB" ]]
+}
+
+@test "dispatch: doctor flags pass straight through, not through this dispatcher's own --project/--type globals" {
+  run bash "$SCRIPTS/windows/dispatch.sh" -- doctor --project "$PROJECT_ALICE"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "$PROJECT_ALICE" ]]
+  [[ "$output" != *"$PROJECT_BOB"* ]]
+}


### PR DESCRIPTION
Wires `doctor` (default = whole install, `--project`/`--type`/`--team`/`--redacted`) into the command reference every install path deploys. `doctor` itself already shipped (#654); this PR is purely wiring, no behavior changes to `doctor.sh`.

Addresses part of #267.

## Why 11 files, not 9 or 10

There are **two separate install paths, each deploying its own copy of the command reference**, and both needed wiring:

1. `./install.sh` deploys `scripts/drivers/types/<type>/template.md`, one per agent type — **9 files** (`agmsg-app` has no template; it's `spawnable=no`, the desktop app's own identity, not a spawnable CLI type, so it's correctly excluded, not a 10th type I missed).
2. The Claude Code **plugin-marketplace** install path does not run `install.sh` at all — it drops this repo's root `SKILL.md` straight into `~/.claude/plugins/cache/` as the deployed skill content (see `SKILL.md`'s own Step 0 comment). This is a **10th file**, easy to miss by only looking at `install.sh`'s deployment tree.

Plus `scripts/windows/dispatch.sh` (the one dispatch/router file in the repo, confirmed via `tests/test_dispatch.bats` as its regression coverage) — **11th file**.

**Checklist — please verify all 11 are present and non-trivially changed:**

- [ ] `scripts/drivers/types/antigravity/template.md`
- [ ] `scripts/drivers/types/claude-code/template.md`
- [ ] `scripts/drivers/types/codex/template.md`
- [ ] `scripts/drivers/types/copilot/template.md`
- [ ] `scripts/drivers/types/cursor/template.md`
- [ ] `scripts/drivers/types/gemini/template.md`
- [ ] `scripts/drivers/types/grok-build/template.md`
- [ ] `scripts/drivers/types/hermes/template.md`
- [ ] `scripts/drivers/types/opencode/template.md`
- [ ] `scripts/windows/dispatch.sh`
- [ ] `SKILL.md` (repo root — the plugin-path deployed copy, not a per-type template)

Mechanical check used while writing this: `grep -c doctor <file>` on all 11 before/after — every target went from 0 mentions to a non-zero count; no target already mentioned `doctor` beforehand (no partial/stale-reference risk).

## What each file gets

**The 9 templates**: a bare `doctor` bullet in the post-join command summary, plus an argument-dispatch block. Each matches that template's *own* existing conventions (invocation prefix — `/__SKILL_NAME__` vs `$__SKILL_NAME__`; hermes's natural-language "ask X" phrasing instead of a slash form) rather than one block copy-pasted into all nine — a template that doesn't match its own type's conventions can still pass CI silently.

Every dispatch block documents **bare `doctor` (no flags) as the normal form**, with `--project`/`--type`/`--team`/`--redacted` described as optional narrowing — not the headline usage — since the default scope is already the whole installation.

**`scripts/windows/dispatch.sh`**: a `doctor` case that passes its argv straight through, with no identity resolution. `doctor` needs no `TEAM`/`AGENT`, and this dispatcher's own `--project`/`--type`/`--team` globals serve a different purpose (identity-resolution context for other commands) than `doctor`'s own same-named scope flags — conflating them would silently change what a Windows user's `--project`/`--type` meant depending on which subcommand followed. Two new tests in `tests/test_dispatch.bats` cover: no-identity-needed default scan, and flags passing through untouched by the dispatcher's own globals.

**`SKILL.md`** (root): one addition to the "Shell (any agent)" command block, written in that section's own existing prose-comment style, not the templates' numbered-dispatch style — it's a different kind of document (a distributed end-product, not a per-type instruction template), so it follows its own existing shape rather than the templates'.

## Testing

1. `bats tests/test_doctor.bats` — 35 ok, 0 not ok (unchanged from #654; doctor.sh itself is untouched by this PR).
2. `bats tests/test_dispatch.bats` — 8 ok, 0 not ok (6 pre-existing + 2 new for the `doctor` case).
3. `bats tests/test_delivery.bats` — adjacent suite, all green.
4. Packaging smoke: ran `install.sh` into an isolated `HOME`, confirmed the deployed `claude-code/template.md` mentions `doctor` and the deployed `scripts/windows/dispatch.sh` routes `-- doctor` to the real `doctor.sh`, reporting a clean empty installation end-to-end.
