### PR TITLE
fix(release): derive npm's dist-tag from the version, so an rc is not `latest`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,21 @@ jobs:
             echo "::error::Tag ($version) does not match VERSION file ($file_version). Bump VERSION + run scripts/release/sync-version.sh before tagging." >&2
             exit 1
           fi
+          # A prerelease must not become what `npm install agmsg` gives people.
+          # Decided from the version itself rather than passed in by whoever
+          # pushes the tag, because that is the one mistake this workflow
+          # exists to make impossible.
+          #
+          # npm reads nothing from the version string on its own: with no
+          # --tag, `1.2.0-rc.1` publishes as `latest` exactly like `1.2.0`.
+          # As of 2026-08-07 `npm view agmsg dist-tags` is `{ latest: 1.1.13 }`
+          # and nothing else, so before this there was no tag a prerelease
+          # could have landed on.
+          if [[ "$version" == *-* ]]; then
+            echo "dist_tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Releasing $version"
 
@@ -75,16 +90,23 @@ jobs:
       - name: Publish to npm
         env:
           VERSION: ${{ steps.ver.outputs.version }}
+          DIST_TAG: ${{ steps.ver.outputs.dist_tag }}
         run: |
           published=$(npm view "agmsg@$VERSION" version 2>/dev/null || true)
           if [[ "$published" == "$VERSION" ]]; then
             echo "agmsg@$VERSION already on npm — skipping publish"
             exit 0
           fi
+          echo "publishing agmsg@$VERSION under dist-tag '$DIST_TAG'"
           # --provenance attaches a signed GitHub attestation linking the
           # tarball to this workflow run. No NODE_AUTH_TOKEN — auth comes
           # from the Trusted Publisher OIDC exchange.
-          npm publish --access public --provenance
+          #
+          # Provenance attests a tarball against a PUBLIC source repository,
+          # which this one is. The private copy of this workflow drops the
+          # flag for that reason; the reason is inverted here, not shared, so
+          # it does not travel back with the dist-tag.
+          npm publish --access public --provenance --tag "$DIST_TAG"
 
       # Build release notes for this tag from Conventional Commits, matching
       # the CHANGELOG.md format. `--latest` emits only the newest release's
@@ -102,6 +124,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.ver.outputs.version }}
+          DIST_TAG: ${{ steps.ver.outputs.dist_tag }}
         run: |
           if gh release view "v$VERSION" >/dev/null 2>&1; then
             echo "Release v$VERSION already exists — skipping"
@@ -111,6 +134,21 @@ jobs:
           if [ ! -s RELEASE_NOTES.md ]; then
             echo "Release $VERSION. See [commit history](../../commits/v$VERSION) for details." > RELEASE_NOTES.md
           fi
+          # The same decision, on the other surface it is visible from. A
+          # release candidate that is not npm's `latest` must not be the
+          # repository's latest release either — `gh release create` marks
+          # whatever it makes as latest unless told, so leaving this out
+          # publishes the rc as the release the front page offers.
+          #
+          # A string rather than an array, which is what the private copy
+          # uses. Expanding an EMPTY array as "${arr[@]}" is an unbound
+          # variable under `set -u` in bash 3.2, and this step is one nobody
+          # runs until a release is already half done. The runner's shell does
+          # not set -u today, so the array form works — but "works because of
+          # a flag nobody set" is the kind of thing a later edit removes.
+          prerelease=
+          if [ "$DIST_TAG" != latest ]; then prerelease=--prerelease; fi
           gh release create "v$VERSION" \
             --title "v$VERSION" \
-            --notes-file RELEASE_NOTES.md
+            --notes-file RELEASE_NOTES.md \
+            ${prerelease:+"$prerelease"}

--- a/tests/test_release_dist_tag.bats
+++ b/tests/test_release_dist_tag.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+
+# The release workflow decides npm's dist-tag from the version string (#663).
+#
+# Without it, `npm publish` has no --tag and npm reads nothing from the version
+# on its own: `v1.2.0-rc.1` would publish as `latest`, and the next
+# `npm i -g agmsg` anywhere would install the release candidate. When this was
+# written `npm view agmsg dist-tags` was `{ latest: 1.1.13 }` and nothing else,
+# so a prerelease had no other tag to land on.
+#
+# The derivation is RUN here, not described: the block is lifted out of the
+# workflow and evaluated, so the rule has one home. A copy of the condition in
+# this file would pass forever after someone edited the workflow's copy.
+#
+# What is only pinned structurally is the wiring — which step exports the
+# output and which flag consumes it — because that part is YAML, not shell.
+
+WORKFLOW="${BATS_TEST_DIRNAME}/../.github/workflows/release.yml"
+
+# The `if` that sets dist_tag, taken from the workflow itself.
+#
+# `.version` rather than an escaped `$version` in the pattern: awk would need
+# the dollar escaped, and the escape behaves differently across the GNU and BSD
+# awks this suite runs on. Matching any character there costs nothing.
+extract_derivation() {
+  awk '/if \[\[ ".version" == \*-\* \]\]; then/,/^ *fi$/' "$WORKFLOW"
+}
+
+# What the workflow would write to GITHUB_OUTPUT for a given version.
+dist_tag_for() {
+  local version="$1"
+  local block
+  block="$(extract_derivation)"
+  # A positive control. If the workflow is reformatted so the range stops
+  # matching, every case below would evaluate an empty string and read the
+  # tag as empty — which must be a failure, not a quiet pass.
+  [ -n "$block" ]
+  GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_output"
+  : > "$GITHUB_OUTPUT"
+  export GITHUB_OUTPUT
+  eval "$block"
+  sed -n 's/^dist_tag=//p' "$GITHUB_OUTPUT"
+}
+
+@test "release: the derivation is present and lifts out of the workflow" {
+  # Stated separately from the cases so a failure says WHICH half broke: a
+  # missing derivation and a wrong one are different repairs.
+  run extract_derivation
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  [[ "$output" == *"dist_tag=next"* ]]
+  [[ "$output" == *"dist_tag=latest"* ]]
+}
+
+@test "release: a plain version publishes as latest" {
+  [ "$(dist_tag_for 1.2.3)" = "latest" ]
+  [ "$(dist_tag_for 10.0.0)" = "latest" ]
+}
+
+@test "release: any prerelease publishes as next, not latest" {
+  # rc is the one being cut, but the rule is the hyphen, so the others have to
+  # hold too — a rule that only works for the spelling in front of us is the
+  # kind that admits the next one silently.
+  [ "$(dist_tag_for 1.2.0-rc.1)" = "next" ]
+  [ "$(dist_tag_for 1.2.0-beta.1)" = "next" ]
+  [ "$(dist_tag_for 1.2.0-alpha)" = "next" ]
+  [ "$(dist_tag_for 2.0.0-0)" = "next" ]
+}
+
+@test "release: publish consumes the derived tag, and keeps provenance" {
+  # --tag without the export is a publish under an empty tag; the export
+  # without --tag is what this issue was. Both halves, or neither means
+  # anything.
+  grep -q 'DIST_TAG: ${{ steps.ver.outputs.dist_tag }}' "$WORKFLOW"
+  grep -q 'npm publish --access public --provenance --tag "\$DIST_TAG"' "$WORKFLOW"
+}
+
+@test "release: provenance is not dropped the way the private copy dropped it" {
+  # `run` + status, not a bare `!`: bats enables set -e for the body, which
+  # exempts a negated command, so a bare `! grep` would not abort and only the
+  # last statement's status would decide the test.
+  #
+  # The private copy of this workflow publishes without --provenance because
+  # provenance attests against a PUBLIC source repository and that one is not.
+  # This one is. The reason is inverted, not shared, so it must not travel back
+  # with the dist-tag it was sitting next to.
+  run grep -q 'npm publish --access public --tag' "$WORKFLOW"
+  [ "$status" -ne 0 ]
+}
+
+@test "release: a prerelease is not the repository's latest release either" {
+  # The same decision on the other surface. `gh release create` marks whatever
+  # it makes as latest unless told otherwise, so an rc would sit on the front
+  # page as the current release while npm correctly served 1.1.13.
+  grep -q 'if \[ "\$DIST_TAG" != latest \]; then prerelease=--prerelease; fi' "$WORKFLOW"
+  grep -q '\${prerelease:+"\$prerelease"}' "$WORKFLOW"
+}
+
+@test "release: the prerelease flag survives set -u, both ways" {
+  # Run, not asserted about. The private copy builds this as an array, and
+  # expanding an EMPTY array is an unbound variable under `set -u` in bash
+  # 3.2 — the release step is the last place to discover that. The runner
+  # does not set -u today; this holds whether or not that stays true.
+  #
+  # bash, explicitly: this must hold under the oldest shell CI runs (macOS
+  # /bin/bash is 3.2), not under whatever the developer's login shell is.
+  run bash -euo pipefail -c '
+    DIST_TAG=latest
+    prerelease=
+    if [ "$DIST_TAG" != latest ]; then prerelease=--prerelease; fi
+    set -- create v1 ${prerelease:+"$prerelease"}
+    echo "$#"
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" = "2" ]
+
+  run bash -euo pipefail -c '
+    DIST_TAG=next
+    prerelease=
+    if [ "$DIST_TAG" != latest ]; then prerelease=--prerelease; fi
+    set -- create v1 ${prerelease:+"$prerelease"}
+    echo "$# $3"
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" = "3 --prerelease" ]
+}
+
+@test "release: the version guard this sits next to is untouched" {
+  # Not in scope, and worth a line: the derivation was inserted into the step
+  # that already refuses a tag disagreeing with VERSION, and inserting it
+  # there must not have displaced that refusal.
+  grep -q 'Tag ($version) does not match VERSION file' "$WORKFLOW"
+  guard_line="$(grep -n 'does not match VERSION file' "$WORKFLOW" | head -1 | cut -d: -f1)"
+  derive_line="$(grep -n 'dist_tag=next' "$WORKFLOW" | head -1 | cut -d: -f1)"
+  [ -n "$guard_line" ]
+  [ -n "$derive_line" ]
+  # The guard exits non-zero before anything is derived for a tag that should
+  # not be releasing at all.
+  [ "$guard_line" -lt "$derive_line" ]
+}


### PR DESCRIPTION
`npm publish` had no `--tag`, and npm reads nothing from the version string on its own: a `v1.2.0-rc.1` tag would have published as **latest**, and the next `npm i -g agmsg` anywhere would have installed the release candidate.

Measured before writing it — `npm view agmsg dist-tags` is `{ "latest": "1.1.13" }` and nothing else, so a prerelease had no other tag to land on.

The private copy of this workflow (`JugemuAI/agmsg-cloud`, `release-cli.yml`) already derives it, and its header says it was copied from here. What was added there never came back.

## The same defect on the other surface

`gh release create` marks whatever it makes as latest unless told, so the rc would have been the release the front page offers while npm correctly served 1.1.13. Both steps now read the same output.

## What did NOT travel back with it

- **`--provenance` stays.** The private copy drops it because provenance attests against a PUBLIC source repository and that one is not. This one is, so the reason is inverted, not shared.
- **Its environment comment does not apply.** That copy says naming `production` gates nothing there. Checked here rather than assumed: `gh api repos/fujibee/agmsg/environments` reports `production: protection_rules=required_reviewers`. A pushed tag really does wait for a human, so the existing comment in this file is true and stays.
- **The array form of the flag.** Expanding an EMPTY array as `"${arr[@]}"` is an unbound variable under `set -u` in bash 3.2. The runner's shell does not set `-u`, so the array works today — but "works because of a flag nobody set" is what a later edit removes, in the step nobody runs until a release is already half done. A plain string instead, with a test that runs both branches under `bash -euo pipefail`.
- The tag-matches-`VERSION` guard is untouched, and a test pins that the guard still sits ahead of the derivation.

## The test runs the rule rather than describing it

The `if` block is lifted out of the workflow and evaluated, so the rule has one home. A copy of the condition in the test would pass forever after someone edited the workflow's copy. Extraction failing is a test failure, not a quiet pass.

## Mutations, one at a time

```
swap the two branch bodies      2 red   (the semantics; extraction untouched)
drop --tag from publish         1 red
drop the --prerelease line      1 red
back to the array form          1 red
```

An earlier mutation — inverting the condition — turned 3 red and is **not** offered as evidence: it also broke the extractor's pattern, so two of those failed on the positive control rather than on the rule.

8/8, run under `/bin/bash` 3.2 as well as the default shell, since CI runs bats on macOS. `.github/scripts/shard-tests.sh` puts the file in shard 2 of 4, so it actually runs.

Closes #663
