### PR TITLE
docs(remote-setup): put the short way to start a server in the walkthrough

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,11 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
+              # Not covered by `docs/*` below: tests/test_remote_setup_doc.bats
+              # reads this file, and a guard that skips on a change to the file
+              # it guards is off exactly when it is needed. Same reason as
+              # SKILL.md further down.
+              docs/remote-setup.md) docs_only=false ;;
               docs/*) ;;
               site/*) ;;
               app/*) app_changed=true ;;

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -26,7 +26,7 @@ cd server
 docker compose up -d --build
 ```
 
-Nothing to fill in: the database name, user, password and port are in
+Nothing to fill in: the database name, user and password are in
 `server/compose.yaml`. They are development defaults — read
 [Network boundary](#network-boundary) before this server is reachable by
 anyone else.

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -8,7 +8,7 @@ For encrypted sync, read
 
 ## Requirements
 
-- PostgreSQL 17
+- Docker with Compose — or PostgreSQL 17, if you bring your own database
 - Node.js 22 or later
 - Bash, SQLite, and curl
 - An agmsg checkout on the server host
@@ -18,31 +18,58 @@ Use HTTPS when the server is not on localhost.
 
 ## 1. Start the reference server
 
-Create an empty PostgreSQL database, then start the server from the repository
-checkout:
+The Compose stack brings up PostgreSQL and the server together. Run it from the
+`server` directory:
 
 ```sh
 cd server
-npm ci
-
-export DATABASE_URL="postgresql://<user>:<password>@127.0.0.1:5432/<db>"
-export HOST=0.0.0.0
-export PORT=8787
-npx tsx src/index.ts
+docker compose up -d --build
 ```
 
-Replace every value in angle brackets, especially `<db>`, with the real
-PostgreSQL values before running the command. The example will not work until
-you replace them.
+Nothing to fill in: the database name, user, password and port are in
+`server/compose.yaml`. They are development defaults — read
+[Network boundary](#network-boundary) before this server is reachable by
+anyone else.
 
-Make the server available to both machines at an HTTPS URL, then confirm it is
-ready:
+Confirm the server and database are ready. On the machine running Compose:
+
+```sh
+curl -fsS http://127.0.0.1:8787/v1/health
+```
+
+The response should contain `"status":"ok"` and `"database":"ok"`. If the
+containers are still starting, retry until it succeeds.
+
+Then make the server available to both machines at an HTTPS URL, and check it
+from there too:
 
 ```sh
 curl -fsS https://<server-url>/v1/health
 ```
 
-The response should contain `"status":"ok"` and `"database":"ok"`.
+### Using your own database instead
+
+If you already run PostgreSQL, start the server from source against it. The
+commands live in [`server/README.md` → Run from
+source](../server/README.md#run-from-source), which is the one place they are
+written down.
+
+Either way the server applies its own migrations at startup, so there is no
+schema step to run first.
+
+### Network boundary
+
+The reference profile has no authentication: reaching the server is the
+permission. Anyone who can reach it and name a team can read that team's
+remote stream. Keep it on a network you control, and use HTTPS for anything
+leaving localhost. Encrypting with `age-v1`
+([below](#extra-end-to-end-encryption)) keeps envelope contents from the
+server; it does not replace the boundary.
+
+The Compose stack publishes its port and ships a development password in
+`compose.yaml`. Change that password and terminate TLS in front of the service
+before this reaches a network you do not control — see
+[`server/README.md` → Compose configuration](../server/README.md#compose-configuration).
 
 ## 2. Connect the existing team on machine A
 

--- a/tests/test_remote_setup_doc.bats
+++ b/tests/test_remote_setup_doc.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+
+# The remote-setup walkthrough now offers the Compose path (#665), and points
+# at `server/compose.yaml` for its values instead of restating them.
+#
+# Restating them is the failure this guards. Two copies of a password disagree
+# eventually, and the copy in the walkthrough is the one someone pastes. So the
+# check derives the values FROM compose.yaml rather than listing them here: if
+# the password changes, this still holds, which a hardcoded literal would not.
+#
+# The cross-file links are checked by resolving them, because a walkthrough
+# that sends you to another file is only as good as the anchor it names.
+
+DOC="${BATS_TEST_DIRNAME}/../docs/remote-setup.md"
+COMPOSE="${BATS_TEST_DIRNAME}/../server/compose.yaml"
+SERVER_README="${BATS_TEST_DIRNAME}/../server/README.md"
+
+# An environment value out of compose.yaml, by key.
+compose_value() {
+  sed -n "s/^[[:space:]]*$1:[[:space:]]*//p" "$COMPOSE" | head -1
+}
+
+# GitHub's heading anchor: lowercase, spaces to hyphens, punctuation dropped.
+slug() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr ' ' '-' \
+    | tr -cd 'a-z0-9-'
+}
+
+@test "remote-setup: the walkthrough offers the Compose path" {
+  grep -q 'docker compose up -d --build' "$DOC"
+  # And still reaches the health check, which is what tells you it worked.
+  grep -q '/v1/health' "$DOC"
+}
+
+@test "remote-setup: compose.yaml's password is not restated in the doc" {
+  password="$(compose_value POSTGRES_PASSWORD)"
+  # A positive control. If compose.yaml is restructured so the key stops
+  # parsing, an empty needle would match every file and this would pass while
+  # checking nothing.
+  [ -n "$password" ]
+  run grep -F -q -- "$password" "$DOC"
+  [ "$status" -ne 0 ]
+}
+
+@test "remote-setup: no connection string is spelled out in the doc" {
+  # The from-source path moved to server/README.md rather than being copied.
+  # A `postgresql://` line here means the copy came back.
+  run grep -q 'postgresql://' "$DOC"
+  [ "$status" -ne 0 ]
+}
+
+@test "remote-setup: every link into server/README.md resolves to a heading" {
+  # Extract the anchors this doc points at, rather than checking the ones
+  # someone remembered to list.
+  anchors="$(grep -o '(\.\./server/README\.md#[a-z0-9-]*)' "$DOC" \
+    | sed 's|(\.\./server/README\.md#||; s|)||' | sort -u)"
+  [ -n "$anchors" ]
+
+  headings=""
+  while IFS= read -r line; do
+    case "$line" in
+      '#'*) headings="${headings}$(slug "${line#\#\# }")
+" ;;
+    esac
+  done < "$SERVER_README"
+
+  while IFS= read -r a; do
+    [ -n "$a" ] || continue
+    printf '%s' "$headings" | grep -q -x -- "$a" || {
+      echo "docs/remote-setup.md points at server/README.md#$a, which is not a heading there" >&2
+      echo "headings found: $headings" >&2
+      return 1
+    }
+  done <<EOF
+$anchors
+EOF
+}
+
+@test "remote-setup: editing the guarded doc does not skip this suite" {
+  # Everything above is decoration if the suite does not run on the change it
+  # is watching for. The `changes` job maps `docs/*` to docs_only=true, which
+  # skips every bats shard, so this file has to be pulled out of that arm —
+  # the same reason SKILL.md is. Pinned here rather than trusted, because the
+  # line is one `case` arm and removing it fails nothing else.
+  # The workflow's own `case` is lifted out and RUN, rather than checked for a
+  # line in the right order: order is only one of the ways this arm can stop
+  # working, and the classifier is what actually decides.
+  workflow="${BATS_TEST_DIRNAME}/../.github/workflows/tests.yml"
+  block="$(awk '/case ".f" in/,/^ *esac$/' "$workflow")"
+  # Positive control: an empty block would leave docs_only at whatever it was
+  # initialised to, and every case below would agree with itself.
+  [ -n "$block" ]
+
+  # `run bash -c`, not a `$( )` around the eval: bash 3.2 — which is what CI's
+  # macOS runner has — cannot parse a `case` inside command substitution.
+  classify='f="$1"; docs_only=true; app_changed=false; server_changed=false; sync_changed=false; eval "$2"; echo "$docs_only"'
+
+  run bash -c "$classify" _ docs/remote-setup.md "$block"
+  [ "$status" -eq 0 ]
+  [ "$output" = false ]
+
+  # The arm is specific, not a hole punched through the whole docs tree.
+  run bash -c "$classify" _ docs/spec/v1.md "$block"
+  [ "$status" -eq 0 ]
+  [ "$output" = true ]
+}
+
+@test "remote-setup: the network boundary it links to is in this doc" {
+  # The walkthrough recommends a stack that publishes a port and ships a
+  # development password. The warning used to live only in server/README.md,
+  # which is not where someone standing up a server is reading.
+  grep -q '^### Network boundary' "$DOC"
+  grep -q '(#network-boundary)' "$DOC"
+}

--- a/tests/test_remote_setup_doc.bats
+++ b/tests/test_remote_setup_doc.bats
@@ -3,10 +3,20 @@
 # The remote-setup walkthrough now offers the Compose path (#665), and points
 # at `server/compose.yaml` for its values instead of restating them.
 #
-# Restating them is the failure this guards. Two copies of a password disagree
-# eventually, and the copy in the walkthrough is the one someone pastes. So the
-# check derives the values FROM compose.yaml rather than listing them here: if
-# the password changes, this still holds, which a hardcoded literal would not.
+# The contract is narrower than "no compose value appears here", and the
+# difference is the point (review):
+#
+#   credentials and database settings   NOT duplicated. Two copies of a
+#                                       password disagree eventually, and the
+#                                       copy in the walkthrough is the one
+#                                       someone pastes.
+#   the published port                  IS written. A reader needs it to run
+#                                       the health check, so hiding it behind
+#                                       a link would be worse. It is pinned
+#                                       against compose.yaml instead.
+#
+# Both are derived FROM compose.yaml rather than listed here: after the
+# password or the port changes, these still hold, which a literal would not.
 #
 # The cross-file links are checked by resolving them, because a walkthrough
 # that sends you to another file is only as good as the anchor it names.
@@ -42,6 +52,20 @@ slug() {
   [ -n "$password" ]
   run grep -F -q -- "$password" "$DOC"
   [ "$status" -ne 0 ]
+}
+
+@test "remote-setup: the localhost health check uses compose's published port" {
+  # The one compose value the doc DOES carry, kept in sync rather than trusted.
+  # Published as "<host>:<container>"; the host side is what a reader curls.
+  port="$(sed -n 's/^[[:space:]]*-[[:space:]]*"\([0-9][0-9]*\):[0-9][0-9]*"[[:space:]]*$/\1/p' "$COMPOSE" | head -1)"
+  [ -n "$port" ]
+
+  # Every localhost URL in the doc, derived rather than the one I remembered
+  # to look at: a second one added later with the old port is exactly the
+  # drift this exists for.
+  used="$(grep -o 'http://127\.0\.0\.1:[0-9]*' "$DOC" | sed 's|.*:||' | sort -u)"
+  [ -n "$used" ]
+  [ "$used" = "$port" ]
 }
 
 @test "remote-setup: no connection string is spelled out in the doc" {


### PR DESCRIPTION
§1 told you to create a PostgreSQL database yourself, export `DATABASE_URL` and run the server from source, and Requirements opened with PostgreSQL 17. The short way — `docker compose up -d --build` and a health check — was only in `server/README.md`, so someone reading the walkthrough never learned it existed.

Compose first, "use your own database" second. Requirements now asks for Docker **or** PostgreSQL, depending on which one you take.

## What is copied from compose.yaml, and what is not

The contract is narrower than "no compose value appears here", and the difference is the point:

- **Credentials and database settings are not duplicated.** Two copies of a password disagree eventually, and the copy in the walkthrough is the one someone pastes. The doc points at the file.
- **The published port IS written.** A reader needs it to run the health check, and hiding it behind a link would be worse than carrying it. It is pinned against `compose.yaml` rather than trusted.

Both are derived **from** `compose.yaml`, so both survive the value changing — the port check reads every `127.0.0.1:<n>` in the doc and requires the set to be exactly compose's host port, so a second URL added later with the old port fails too.

The from-source commands are not copied either. The walkthrough ran `npx tsx src/index.ts` while `server/README.md` ran `npm run build` then `npm start`. Both work (`tsx` is a devDependency); two homes for one instruction is what goes stale. The doc links to the README's section, and a test resolves every such link against the headings actually in that file.

## The network boundary paragraph now exists here too

Recommending a stack that publishes `8787:8787` and ships a development password makes it sharper, and the person standing up a server is reading this file, not the server README.

## The guard would have been asleep for the change it guards

The `changes` job maps `docs/*` to `docs_only=true`, which skips every bats shard — so a PR editing only this doc would run none of the above. `docs/remote-setup.md` follows `SKILL.md` out of that arm, which already carries the same NOTE for the same reason.

## Mutations, one at a time

```
break a cross-file anchor                    1 red, naming the anchor
copy the compose password into the doc       1 red
change compose's host port, leave the doc    1 red
add a second localhost URL with a stale port 1 red
delete the docs_only arm                     1 red
move the arm AFTER the catch-all             1 red
```

That last one is why the arm is tested by **running** the workflow's own `case` rather than by checking a line's position — order is one of the ways it can stop working, not the only one. The classifier also has to still say `docs_only=true` for `docs/spec/v1.md`, so this is an exception, not a hole through the docs tree.

7/7, run under `/bin/bash` 3.2 as well, since CI runs bats on macOS. `case` inside `$( )` is a 3.2 syntax error, so the extracted block goes through `run bash -c`. Shard 4 of 4 — the partition is weighted by `@test` count, so adding the port case moved this file out of shard 3; re-measured rather than carried forward.

Closes #665
