### PR TITLE
fix(roster): convert readfile paths, and say which one could not be read

### DIFF
--- a/scripts/lib/roster-journal.sh
+++ b/scripts/lib/roster-journal.sh
@@ -30,6 +30,27 @@ _agmsg_roster_sqlesc() {
   printf '%s' "$1" | sed "s/'/''/g"
 }
 
+# A PATH bound for readfile(), not a value. The two need different treatment and
+# only one of them is escaping.
+#
+# sqlite3 on Windows is a native binary: it cannot open the `/tmp/...` form Git
+# Bash hands around, so readfile() returns NULL, the projection collapses to
+# empty, and the caller reads that as "no roster" -- join.sh exited 1 right
+# after "Created team:" with nothing on stderr (#669). Every other readfile call
+# site in the repo already converts (agmsg_sql_readfile_path); this file escaped
+# and stopped.
+#
+# Kept local rather than sourcing storage.sh: this library is loaded by six
+# scripts, some of which do not want the storage facade, and the conversion is
+# four lines. It must stay identical to agmsg_sql_readfile_path's.
+_agmsg_roster_readfile_path() {
+  local path="$1"
+  if command -v cygpath >/dev/null 2>&1; then
+    path=$(cygpath -w "$path" 2>/dev/null || printf '%s' "$path")
+  fi
+  printf '%s' "$path" | sed "s/'/''/g"
+}
+
 _agmsg_roster_record() {
   local type="$1" member_id="$2" name="$3" at="$4"
   sqlite3 :memory: "SELECT json_object(
@@ -103,7 +124,7 @@ agmsg_roster_name_owner() {
   local team_dir="$1" name="$2" journal journal_sql name_sql
   journal="$(agmsg_roster_journal_path "$team_dir")"
   [ -f "$journal" ] || return 0
-  journal_sql="$(_agmsg_roster_sqlesc "$journal")"
+  journal_sql="$(_agmsg_roster_readfile_path "$journal")"
   name_sql="$(_agmsg_roster_sqlesc "$name")"
   sqlite3 :memory: "
     WITH source(doc) AS (
@@ -137,7 +158,7 @@ agmsg_roster_ensure() {
   journal="$(agmsg_roster_journal_path "$team_dir")"
   [ -f "$journal" ] && return 0
   [ -f "$config" ] || return 0
-  config_sql="$(_agmsg_roster_sqlesc "$config")"
+  config_sql="$(_agmsg_roster_readfile_path "$config")"
   team_id="$(sqlite3 :memory: \
     "SELECT COALESCE(json_extract(CAST(readfile('$config_sql') AS TEXT), '\$.team_id'),'');" \
     2>/dev/null | tr -d '\r')"
@@ -171,8 +192,8 @@ agmsg_roster_project_config() {
   journal="$(agmsg_roster_journal_path "$team_dir")"
   [ -f "$journal" ] || return 0
   [ -f "$config" ] || return 1
-  journal_sql="$(_agmsg_roster_sqlesc "$journal")"
-  config_sql="$(_agmsg_roster_sqlesc "$config")"
+  journal_sql="$(_agmsg_roster_readfile_path "$journal")"
+  config_sql="$(_agmsg_roster_readfile_path "$config")"
   updated="$(sqlite3 :memory: "
     WITH
     source(doc) AS (
@@ -301,6 +322,28 @@ agmsg_roster_project_config() {
                     '\$.agents',json(agents.value),
                     '\$.retired_members',json(retired.value))
       FROM agents,retired;" 2>/dev/null | tr -d '\r')" || return 1
-  [ -n "$updated" ] || return 1
+  # An empty result has two causes and they are not the same failure: the
+  # projection genuinely produced nothing, or readfile() could not open one of
+  # its arguments and returned NULL, which collapses the whole expression. The
+  # second is what happened on Windows -- and because both arrive here as "",
+  # the caller reported neither. join.sh printed "Created team:" and exited 1
+  # with nothing on stderr (#669).
+  #
+  # `readfile(x) IS NULL` separates them, and the message names the path that
+  # could not be read, in the form sqlite was actually given.
+  if [ -z "$updated" ]; then
+    local unreadable
+    unreadable="$(sqlite3 :memory: "
+      SELECT CASE WHEN readfile('$journal_sql') IS NULL THEN '$journal_sql' ELSE '' END
+      UNION ALL
+      SELECT CASE WHEN readfile('$config_sql') IS NULL THEN '$config_sql' ELSE '' END;" \
+      2>/dev/null | tr -d '\r' | grep -v '^$' || true)"
+    if [ -n "$unreadable" ]; then
+      printf 'agmsg: roster projection could not read:\n%s\n' "$unreadable" >&2
+    else
+      printf 'agmsg: roster projection produced no config for %s\n' "$config" >&2
+    fi
+    return 1
+  fi
   agmsg_write_atomic "$config" "$updated"
 }

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -199,3 +199,29 @@ EOF
   [ ! -d "$team_dir/.config.lock" ]
   [ "$(config_field "$config" '$.agents.alice.member_id')" = "$member_id" ]
 }
+
+# The failure this covers is not "the projection was empty" -- it is that an
+# empty projection had two causes and reported neither. readfile() returns NULL
+# for a path it cannot open, that NULL collapses the whole expression, and the
+# caller saw the same "" a genuinely empty roster produces. join.sh printed
+# "Created team:" and exited 1 with nothing on stderr (#669).
+#
+# An unreadable file is the portable way to make readfile() return NULL. On
+# Windows the same NULL arrived from a path sqlite3.exe could not open, which is
+# what the conversion in _agmsg_roster_readfile_path fixes; this pins the half
+# that can be observed anywhere.
+@test "roster projection names the file it could not read instead of failing silently" {
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local config="$TEST_SKILL_DIR/teams/demo/config.json"
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  [ -f "$config" ]
+
+  chmod 000 "$config"
+  run bash -c '. "$1/lib/roster-journal.sh"; agmsg_roster_project_config "$2" "$3"' _ \
+    "$SCRIPTS" "$team_dir" "$config"
+  chmod 644 "$config"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not read"* ]]
+  [[ "$output" == *"config.json"* ]]
+}


### PR DESCRIPTION
Closes #669.

On Git Bash, `join.sh` exited 1 immediately after printing `Created team: <team>` and printed nothing else. Two defects, and the second is the one that made it expensive.

## A value escaper where a path converter was needed

`scripts/lib/roster-journal.sh` passed `readfile()` an MSYS path. `sqlite3` on Windows is a native binary and cannot open `/tmp/...`, so `readfile()` returned NULL, the projection collapsed to empty, and the caller returned 1.

Every other `readfile()` call site in the repo converts first — `join.sh` itself does at five sites, through `agmsg_sql_readfile_path`. This library escaped quotes and stopped there. `_agmsg_roster_sqlesc` is the right function for a scalar; it was standing in for a path.

Four assignments feed seven `readfile()` sites; all four now convert.

## An unreadable file and an empty file were the same answer

```sh
[ -n "$updated" ] || return 1
```

`readfile()` on a path it cannot open returns NULL, which collapses the expression to empty — the same value a genuinely empty roster produces. Both arrived here as `""`, and the caller reported neither, with nothing on stderr. That is why the symptom was a success line followed by a silent exit 1.

`readfile(x) IS NULL` separates them. The message now names the path that could not be read, in the form sqlite was actually handed.

## The detail worth keeping

`tests/test_helper.bash` has carried this the whole time:

```sh
rf() {
  local p="$1"
  if command -v cygpath >/dev/null 2>&1; then
    p="$(cygpath -w "$p" 2>/dev/null || printf '%s' "$p")"
  fi
  printf '%s' "$p" | sed "s/'/''/g"
}
```

Byte for byte what the fix adds. The tests converted their own paths; the library they exercise did not, so nothing observed the gap.

## Verification

The path-conversion half needs Windows. The reporting half does not — an unreadable file makes `readfile()` return NULL anywhere, and that is what the new test uses.

```
reverting the fix:  not ok  roster projection names the file it could not read
                            `[[ "$output" == *"could not read"* ]]' failed
with the fix:       ok      9/9 in test_roster_journal.bats
adjacent suites:    81 ok   test_local_team_ids.bats + test_team.bats
```

## This PR's green does not prove the Windows fix

Stated plainly, because the section above reads as though it does.

The job that would exercise the path conversion is `bats (windows-latest, windows runtime (#567))`. It **does not run on this PR**: `integration/remote` has no such job. It lives on `main` and arrives with the pending merge — which is the same reason this defect went unseen in the first place.

So the 18 green checks here say one thing: the existing suites still pass. They say nothing about Windows.

The acceptance condition is therefore not on this PR. It is: after this lands and the merge picks it up, `bats (windows-latest, windows runtime (#567))` turns green there. Until that is observed, the path-conversion half is a fix that has been reasoned about and not measured.

## Not a regression

There was no Windows CI job on this branch exercising `join.sh`. The job that catches it comes from `main` and arrives with the pending merge, which is how this surfaced.
