### PR TITLE
fix(remote,key): a printed command carries the path it has to be run from

### DIFF
--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -29,6 +29,10 @@ source "$SCRIPT_DIR/lib/registry-lock.sh"
 source "$SCRIPT_DIR/lib/validate.sh"
 # shellcheck source=lib/operator-guidance.sh
 source "$SCRIPT_DIR/lib/operator-guidance.sh"
+# A printed command is one someone pastes, so the team name in it has to
+# survive a shell. See lib/shquote.sh for why naive `'$var'` is not enough.
+# shellcheck source=lib/shquote.sh
+source "$SCRIPT_DIR/lib/shquote.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/roster-journal.sh"
 
@@ -291,7 +295,8 @@ cmd_generate() {
   existing="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
   if [ -n "$existing" ] && [ "$existing" != "null" ]; then
     agmsg_lock_release
-    echo "agmsg: team '$team' already has a key (key_id=$existing) — use 'key.sh show $team' to view it (rotation is not available in this release)." >&2
+    echo "agmsg: team '$team' already has a key (key_id=$existing); rotation is not available in this release. To view it:" >&2
+    echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/key.sh") show $(agmsg_shq "$team")" >&2
     exit 1
   fi
 
@@ -341,11 +346,11 @@ cmd_generate() {
     echo "Back this up now. agmsg does not store a copy of this key anywhere,"
     echo "and there is no server-side recovery — so losing this device loses"
     echo "the key, and with it the history. Run"
-    echo "'key.sh show $team --reveal-secret' to view and save it somewhere"
-    echo "safe — a password manager entry, not a plaintext file. Do NOT copy"
-    echo "it into a dotfiles repo, a git repo of any kind, or any other"
-    echo "synced/backed-up-by-a-tool location you wouldn't also trust with a"
-    echo "production credential."
+    echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/key.sh") show $(agmsg_shq "$team") --reveal-secret"
+    echo "and save what it prints somewhere safe — a password manager entry,"
+    echo "not a plaintext file. Do NOT copy it into a dotfiles repo, a git repo"
+    echo "of any kind, or any other synced/backed-up-by-a-tool location you"
+    echo "wouldn't also trust with a production credential."
   fi
 }
 
@@ -374,7 +379,9 @@ cmd_show() {
   cfg="$(_key_team_config "$team")"
   key_id="${requested_key_id:-$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')}"
   if [ -z "$key_id" ] || [ "$key_id" = "null" ]; then
-    echo "agmsg: team '$team' has no key yet — run 'key.sh generate $team' or 'key.sh import $team'." >&2
+    echo "agmsg: team '$team' has no key yet — run one of:" >&2
+    echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/key.sh") generate $(agmsg_shq "$team")" >&2
+    echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/key.sh") import $(agmsg_shq "$team")" >&2
     exit 1
   fi
 
@@ -777,7 +784,8 @@ EOF
   echo "Generated replacement key for team '$team' (epoch=$next_epoch, key_id=$key_id)."
   echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
   echo "The private key was not written to the journal; distribute it out of band."
-  echo "Use 'key.sh show $team --key-id $key_id --reveal-secret' on an interactive terminal."
+  echo "On an interactive terminal, run:"
+  echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/key.sh") show $(agmsg_shq "$team") --key-id $(agmsg_shq "$key_id") --reveal-secret"
   echo "Messages before the acknowledged rotation boundary remain readable with the old key."
 }
 

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1571,7 +1571,8 @@ cmd_connect() {
   # the thing the ceremony exists to make unnecessary. So it is said only when
   # nobody else owns the next step.
   if [ "$e2ee" -eq 1 ] && agmsg_operator_guidance_is_ours; then
-    echo "Export the public epoch snapshot with: key.sh show $team --snapshot --out <file>"
+    echo "Export the public epoch snapshot with:"
+    echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/key.sh") show $(agmsg_shq "$team") --snapshot --out <file>"
     echo "Transfer that snapshot and the key out of band; the other machine must import and live-confirm them before syncing."
   fi
 }
@@ -1601,7 +1602,7 @@ _remote_status_one() {
     running)
       echo "$team	connected (engine running, pid $engine_pid) since $connected_at" ;;
     stopped)
-      echo "$team	connected (engine stopped — run: remote.sh sync start $team) since $connected_at" ;;
+      echo "$team	connected (engine stopped — run: bash $(agmsg_shq "$SKILL_DIR/scripts/remote.sh") sync start $(agmsg_shq "$team")) since $connected_at" ;;
     stale)
       if [ -n "$engine_pid" ]; then
         echo "$team	connected (engine stale — pidfile $engine_pid points at a dead or foreign process) since $connected_at"
@@ -1910,7 +1911,8 @@ cmd_forget() {
     exit 1
   fi
   if [ -z "$disconnected_at" ] || [ "$disconnected_at" = "null" ]; then
-    echo "agmsg: team '$team' is still connected; run 'remote.sh disconnect $team' first" >&2
+    echo "agmsg: team '$team' is still connected; run this first:" >&2
+    echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/remote.sh") disconnect $(agmsg_shq "$team")" >&2
     exit 1
   fi
 

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -595,6 +595,56 @@ EOS
   [ "$latest_epoch" = "2" ]
 }
 
+@test "key rotate: the reveal line it prints can be run as printed" {
+  # The seventh printed command (#667). The other six are pinned in
+  # test_printed_command_paths.bats; this one needs the rotate fixture, so it
+  # lives where that fixture already is.
+  #
+  # argv, not a substring: the line carries a key_id as well as a team, and a
+  # substring check cannot tell a correctly quoted line from one that merely
+  # contains the right words. `|| return 1`, and `[ ]` rather than `[[ ]]` —
+  # on bash 3.2 a bare `[[ ]]` mid-body is not enforced (#670).
+  #
+  # The team carries a space and a single quote, both legal (validate.sh
+  # rejects empty / `.` / `..` / `/` / `\\` / a leading `-` / control
+  # characters). Without them, dropping the quoting from this line still parses
+  # to the same argv and the test passes — measured, not assumed.
+  skip_if_no_age
+  local qteam="it's a team"
+  bash "$SCRIPTS/join.sh" "$qteam" alice claude-code /tmp/project-q
+  bash "$SCRIPTS/key.sh" generate "$qteam"
+  stub_current_age_snapshot
+  config="$SCRIPTS/../teams/$qteam/config.json"
+  python3 - "$config" <<'PY_BIND'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d['remote_binding'] = {'server_instance_id': '018f3f7e-0000-7000-8000-000000000000',
+                       'remote_team_id': '018f3f7e-0000-7000-8000-000000000001'}
+open(p, 'w').write(json.dumps(d) + '\n')
+PY_BIND
+  run bash "$SCRIPTS/key.sh" rotate "$qteam"
+  [ "$status" -eq 0 ] || return 1
+  line="$(printf '%s\n' "$output" | grep -F -- "key.sh' show " | head -1)"
+  [ -n "$line" ] || return 1
+  eval "set -- $line"
+  [ "$1" = bash ] || return 1
+  [ -f "$2" ] || return 1
+  [ "$3" = show ] || return 1
+  [ "$4" = "$qteam" ] || return 1
+  [ "$5" = --key-id ] || return 1
+  # The key_id it names is the replacement this run just generated, not the
+  # retired one: the same command pointing at the wrong secret would still
+  # parse. Taken from the run's own "Generated replacement key" line rather
+  # than from the config, because a rotation that is not yet confirmed leaves
+  # `remote_key.current` on the previous key.
+  [ -n "$6" ] || return 1
+  generated="$(printf '%s\n' "$output" | sed -n 's/.*Generated replacement key .*key_id=\([^)]*\)).*/\1/p' | head -1)"
+  [ -n "$generated" ] || return 1
+  [ "$6" = "$generated" ] || return 1
+  [ "$7" = --reveal-secret ] || return 1
+}
+
 @test "key rotate: refuses a team with no current key" {
   run bash "$SCRIPTS/key.sh" rotate testteam
   [ "$status" -ne 0 ]

--- a/tests/test_printed_command_paths.bats
+++ b/tests/test_printed_command_paths.bats
@@ -15,13 +15,19 @@
 # some spelling. A line naming the wrong directory would satisfy a substring
 # check and still not run.
 #
-# `[ ]` rather than `[[ ]]` throughout, deliberately: on bash 3.2 — which is
-# what the macOS shards run — a failing `[[ ]]` does not trip errexit unless it
-# is the body's last statement, so `[[ ]]` assertions in the middle of a test
-# are enforced on ubuntu only (#670). Substring checks go through `grep -q`,
-# which does trip it.
+# Every load-bearing assertion here is `… || return 1`, and never a bare
+# `[[ ]]`. Bats reports a failure through an ERR trap, and on bash 3.2 — which
+# is what the macOS shards run — `[[ ]]` and `(( ))` do not fire that trap, so
+# a bare one mid-body is enforced on ubuntu only (#670). `[ ]` and ordinary
+# commands do fire it there, measured, but an explicit `return 1` does not
+# depend on knowing which constructs the trap covers.
 
 load test_helper
+
+# Legal, and nothing like the fixtures elsewhere: validate.sh rejects empty,
+# `.`, `..`, `/`, `\`, a leading `-` and control characters — a space and a
+# single quote are allowed. A printed command has to survive both.
+QTEAM="it's a team"
 
 setup() {
   setup_test_env
@@ -41,16 +47,38 @@ printed_path() {
   printf '%s\n' "$output" | sed -n "s/.*bash '\([^']*$1\)'.*/\1/p" | head -1
 }
 
+# A connected binding, so the commands that only appear for one can be reached
+# without standing up a server. Parameterised by team, because the point of the
+# tests below is a team name the rest of the suite does not use.
+bind_team() {
+  python3 - "$SCRIPTS/../teams/$1/config.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d['remote_binding'] = {
+    'endpoint': 'https://sync.example.test',
+    'server_instance_id': '018f3f7e-0000-7000-8000-000000000000',
+    'remote_team_id': d['team_id'],
+    'remote_team_name': d['name'],
+    'protocol_version': 1,
+    'capabilities': {'write_allowed_ciphers': ['none', 'age-v1']},
+    'connected_at': '2026-07-30T00:00:00Z',
+    'disconnected_at': None,
+}
+open(p, 'w').write(json.dumps(d) + '\n')
+PY
+}
+
 @test "printed commands: the key-backup notice names a key.sh that exists" {
   skip_if_no_age
   run bash "$SCRIPTS/key.sh" generate testteam
-  [ "$status" -eq 0 ]
-  printf '%s\n' "$output" | grep -q 'Back this up now'
+  [ "$status" -eq 0 ] || return 1
+  printf '%s\n' "$output" | grep -q 'Back this up now' || return 1
   path="$(printed_path 'key\.sh')"
   # Non-empty first: an empty path would make every check below vacuous, and
   # "no printed command at all" is the state this issue was about.
-  [ -n "$path" ]
-  [ -f "$path" ]
+  [ -n "$path" ] || return 1
+  [ -f "$path" ] || return 1
 }
 
 @test "printed commands: that notice is still the --reveal-secret route" {
@@ -58,30 +86,30 @@ printed_path() {
   # if the subcommand stopped being the one that shows the secret.
   skip_if_no_age
   run bash "$SCRIPTS/key.sh" generate testteam
-  [ "$status" -eq 0 ]
-  printf '%s\n' "$output" | grep -q -- "--reveal-secret"
+  [ "$status" -eq 0 ] || return 1
+  printf '%s\n' "$output" | grep -q -- "--reveal-secret" || return 1
 }
 
 @test "printed commands: 'no key yet' names both routes with a path" {
   run bash "$SCRIPTS/key.sh" show testteam
-  [ "$status" -ne 0 ]
-  printf '%s\n' "$output" | grep -q 'has no key yet'
+  [ "$status" -ne 0 ] || return 1
+  printf '%s\n' "$output" | grep -q 'has no key yet' || return 1
   # Both offered commands, each with a path that exists. Counted rather than
   # matched once: the message offers generate AND import, and a fix that
   # repaired only the first would pass a single check.
   n="$(printf '%s\n' "$output" | grep -c "bash '$SCRIPTS/key.sh' ")"
-  [ "$n" -eq 2 ]
+  [ "$n" -eq 2 ] || return 1
 }
 
 @test "printed commands: 'already has a key' names a key.sh that exists" {
   skip_if_no_age
   run bash "$SCRIPTS/key.sh" generate testteam
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 0 ] || return 1
   run bash "$SCRIPTS/key.sh" generate testteam
-  [ "$status" -ne 0 ]
+  [ "$status" -ne 0 ] || return 1
   path="$(printed_path 'key\.sh')"
-  [ -n "$path" ]
-  [ -f "$path" ]
+  [ -n "$path" ] || return 1
+  [ -f "$path" ] || return 1
 }
 
 @test "printed commands: the guidance gate still withholds the backup route" {
@@ -89,9 +117,41 @@ printed_path() {
   # A caller that owns the next step gets the FACT and not the command.
   skip_if_no_age
   AGMSG_OPERATOR_GUIDANCE=caller run bash "$SCRIPTS/key.sh" generate testteam
-  [ "$status" -eq 0 ]
-  printf '%s\n' "$output" | grep -q 'permanently unreadable'
+  [ "$status" -eq 0 ] || return 1
+  printf '%s\n' "$output" | grep -q 'permanently unreadable' || return 1
   run_output_has_backup=0
   printf '%s\n' "$output" | grep -q 'Back this up now' && run_output_has_backup=1
-  [ "$run_output_has_backup" -eq 0 ]
+  [ "$run_output_has_backup" -eq 0 ] || return 1
+}
+
+@test "printed commands: the key route survives a team with a space and a quote" {
+  # A substring check cannot tell correct quoting from a line that merely
+  # contains the right words. This parses the printed command with a shell and
+  # compares argv byte for byte, which is the only thing that proves it.
+  skip_if_no_age
+  bash "$SCRIPTS/join.sh" "$QTEAM" alice claude-code /tmp/project-q
+  run bash "$SCRIPTS/key.sh" generate "$QTEAM"
+  [ "$status" -eq 0 ] || return 1
+  line="$(printf '%s\n' "$output" | grep -F -- "key.sh' show " | head -1)"
+  [ -n "$line" ] || return 1
+  eval "set -- $line"
+  [ "$1" = bash ] || return 1
+  [ -f "$2" ] || return 1
+  [ "$3" = show ] || return 1
+  [ "$4" = "$QTEAM" ] || return 1
+  [ "$5" = --reveal-secret ] || return 1
+}
+
+@test "printed commands: the remote route survives a team with a space and a quote" {
+  bash "$SCRIPTS/join.sh" "$QTEAM" alice claude-code /tmp/project-q
+  bind_team "$QTEAM"
+  run bash "$SCRIPTS/remote.sh" forget --yes "$QTEAM"
+  [ "$status" -ne 0 ] || return 1
+  line="$(printf '%s\n' "$output" | grep -F -- "remote.sh' disconnect " | head -1)"
+  [ -n "$line" ] || return 1
+  eval "set -- $line"
+  [ "$1" = bash ] || return 1
+  [ -f "$2" ] || return 1
+  [ "$3" = disconnect ] || return 1
+  [ "$4" = "$QTEAM" ] || return 1
 }

--- a/tests/test_printed_command_paths.bats
+++ b/tests/test_printed_command_paths.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+# A printed command is one someone pastes (#667).
+#
+# `key.sh` and `remote.sh` are not on PATH — they live inside the install
+# directory, whose name is chosen at install time — so a printed `key.sh show
+# ...` cannot be run as printed, and on a machine with more than one install
+# the reader cannot guess which one printed it.
+#
+# The heaviest instance was the key-backup notice: it sits directly under
+# "losing this key makes every message permanently unreadable" as the only
+# offered way to prevent that, and it produced `command not found`.
+#
+# These assert the printed line names a path that EXISTS, not that it contains
+# some spelling. A line naming the wrong directory would satisfy a substring
+# check and still not run.
+#
+# `[ ]` rather than `[[ ]]` throughout, deliberately: on bash 3.2 — which is
+# what the macOS shards run — a failing `[[ ]]` does not trip errexit unless it
+# is the body's last statement, so `[[ ]]` assertions in the middle of a test
+# are enforced on ubuntu only (#670). Substring checks go through `grep -q`,
+# which does trip it.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a
+}
+
+teardown() {
+  teardown_test_env
+}
+
+skip_if_no_age() {
+  command -v age >/dev/null 2>&1 && command -v age-keygen >/dev/null 2>&1 || skip "age/age-keygen not installed"
+}
+
+# The first path inside a printed `bash '<path>' ...` line naming <script>.
+printed_path() {
+  printf '%s\n' "$output" | sed -n "s/.*bash '\([^']*$1\)'.*/\1/p" | head -1
+}
+
+@test "printed commands: the key-backup notice names a key.sh that exists" {
+  skip_if_no_age
+  run bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q 'Back this up now'
+  path="$(printed_path 'key\.sh')"
+  # Non-empty first: an empty path would make every check below vacuous, and
+  # "no printed command at all" is the state this issue was about.
+  [ -n "$path" ]
+  [ -f "$path" ]
+}
+
+@test "printed commands: that notice is still the --reveal-secret route" {
+  # Paired with the test above. A path pointing at a real file proves nothing
+  # if the subcommand stopped being the one that shows the secret.
+  skip_if_no_age
+  run bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q -- "--reveal-secret"
+}
+
+@test "printed commands: 'no key yet' names both routes with a path" {
+  run bash "$SCRIPTS/key.sh" show testteam
+  [ "$status" -ne 0 ]
+  printf '%s\n' "$output" | grep -q 'has no key yet'
+  # Both offered commands, each with a path that exists. Counted rather than
+  # matched once: the message offers generate AND import, and a fix that
+  # repaired only the first would pass a single check.
+  n="$(printf '%s\n' "$output" | grep -c "bash '$SCRIPTS/key.sh' ")"
+  [ "$n" -eq 2 ]
+}
+
+@test "printed commands: 'already has a key' names a key.sh that exists" {
+  skip_if_no_age
+  run bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -eq 0 ]
+  run bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -ne 0 ]
+  path="$(printed_path 'key\.sh')"
+  [ -n "$path" ]
+  [ -f "$path" ]
+}
+
+@test "printed commands: the guidance gate still withholds the backup route" {
+  # The path work must not have turned a withheld route into a printed one.
+  # A caller that owns the next step gets the FACT and not the command.
+  skip_if_no_age
+  AGMSG_OPERATOR_GUIDANCE=caller run bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q 'permanently unreadable'
+  run_output_has_backup=0
+  printf '%s\n' "$output" | grep -q 'Back this up now' && run_output_has_backup=1
+  [ "$run_output_has_backup" -eq 0 ]
+}

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -503,6 +503,22 @@ _capability_endpoint() {
   [[ "$output" == *"out of band"* ]]
 }
 
+@test "connect: the snapshot export it prints names a key.sh that exists" {
+  # The line is the first step of getting a second machine in, and `key.sh` is
+  # not on PATH (#667). Existence, not spelling: a path into the wrong install
+  # would match any substring check and still not run.
+  #
+  # `[ ]` and `grep -q`, not `[[ ]]`: on bash 3.2 a failing `[[ ]]` in the
+  # middle of a body does not trip errexit (#670).
+  skip_if_no_age
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q 'Export the public epoch snapshot'
+  path="$(printf '%s\n' "$output" | sed -n "s/.*bash '\([^']*key\.sh\)'.*/\1/p" | head -1)"
+  [ -n "$path" ]
+  [ -f "$path" ]
+}
+
 @test "connect: a caller that owns the guidance does not get the out-of-band line" {
   skip_if_no_age
   # Carrying the key by hand is this install's answer to adding a machine. A
@@ -607,7 +623,10 @@ _capability_endpoint() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"Connected: team 'testteam' (age-v1 encrypted)."* ]]
   [[ "$output" == *"Back this up now"* ]]
-  [[ "$output" == *"key.sh show testteam --snapshot --out <file>"* ]]
+  # The command carries its install path and quotes its team now (#667), so the
+  # bare spelling is gone. `grep -q`, not `[[ ]]`: a failing `[[ ]]` mid-body is
+  # not enforced on bash 3.2 (#670), and this assertion is one that just moved.
+  printf '%s\n' "$output" | grep -q -F -- "key.sh' show 'testteam' --snapshot --out <file>"
   sync_config="$TEST_SKILL_DIR/db/remote-sync/testteam.json"
   [ -f "$sync_config" ]
   [ "$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$sync_config")') AS TEXT), '\$.cipher_profile');")" = "age-v1" ]

--- a/tests/test_remote_forget.bats
+++ b/tests/test_remote_forget.bats
@@ -64,9 +64,28 @@ set_disconnected_at() {
   run bash "$SCRIPTS/remote.sh" forget --yes testteam
   [ "$status" -ne 0 ]
   [[ "$output" == *"still connected"* ]]
-  [[ "$output" == *"remote.sh disconnect testteam"* ]]
+  # The command now carries its install path and quotes its team (#667), so the
+  # bare spelling is gone. `grep -q`, not `[[ ]]`: a failing `[[ ]]` mid-body is
+  # not enforced on bash 3.2 (#670), and this assertion is one that just moved.
+  printf '%s\n' "$output" | grep -q -F -- "remote.sh' disconnect 'testteam'"
   [ -f "$TEST_SKILL_DIR/teams/testteam/config.json" ]
   [ -f "$store" ]
+}
+
+@test "forget: the disconnect it tells you to run first can be run as printed" {
+  # `remote.sh` is not on PATH (#667). The refusal is only useful if the
+  # command it offers resolves — checked by existence, not by spelling, since
+  # a line naming the wrong install would satisfy a substring match.
+  #
+  # `[ ]` and `grep -q`, not `[[ ]]`: on bash 3.2 a failing `[[ ]]` in the
+  # middle of a body does not trip errexit (#670).
+  set_disconnected_at null
+  run bash "$SCRIPTS/remote.sh" forget --yes testteam
+  [ "$status" -ne 0 ]
+  printf '%s\n' "$output" | grep -q 'still connected'
+  path="$(printf '%s\n' "$output" | sed -n "s/.*bash '\([^']*remote\.sh\)'.*/\1/p" | head -1)"
+  [ -n "$path" ]
+  [ -f "$path" ]
 }
 
 @test "forget: shows its scope and rejects noninteractive deletion without --yes" {

--- a/tests/test_remote_forget.bats
+++ b/tests/test_remote_forget.bats
@@ -72,10 +72,15 @@ set_disconnected_at() {
   [ -f "$store" ]
 }
 
-@test "forget: the disconnect it tells you to run first can be run as printed" {
+@test "forget: the disconnect it tells you to run first names a remote.sh that exists" {
   # `remote.sh` is not on PATH (#667). The refusal is only useful if the
   # command it offers resolves — checked by existence, not by spelling, since
   # a line naming the wrong install would satisfy a substring match.
+  #
+  # Existence only, which is what the name says. That the line PARSES back to
+  # the original team is a separate claim and a separate fixture, because
+  # `testteam` needs no quoting: it is pinned in
+  # test_printed_command_paths.bats against a team with a space and a quote.
   #
   # `[ ]` and `grep -q`, not `[[ ]]`: on bash 3.2 a failing `[[ ]]` in the
   # middle of a body does not trip errexit (#670).

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -108,7 +108,10 @@ remember_engine_pid() {
   run bash "$SCRIPTS/remote.sh" status testteam
   [ "$status" -eq 0 ]
   [[ "$output" == *"connected (engine stopped"* ]]
-  [[ "$output" == *"remote.sh sync start testteam"* ]]
+  # The command carries its install path and quotes its team now (#667), so the
+  # bare spelling is gone. `grep -q`, not `[[ ]]`: a failing `[[ ]]` mid-body is
+  # not enforced on bash 3.2 (#670), and this assertion is one that just moved.
+  printf '%s\n' "$output" | grep -q -F -- "remote.sh' sync start 'testteam'"
 
   run bash "$SCRIPTS/remote.sh" status testteam --json
   [ "$status" -eq 0 ]


### PR DESCRIPTION
`key.sh` and `remote.sh` are not on `PATH` — they live inside the install directory, whose name is chosen at install time — so a printed `key.sh show <team> --reveal-secret` gives `command not found`, and on a machine with more than one install the reader cannot work out which one printed it.

The heaviest instance is the key-backup notice. It sits directly under *"losing this key makes every message permanently unreadable"* as the only offered way to prevent that, and it did not run.

## No new convention

This is the shape already used for the unlock line (#642):

```sh
bash $(agmsg_shq "$SKILL_DIR/scripts/<x>.sh") <verb> $(agmsg_shq "$team")
```

`key.sh` had no quoting helper, so it now sources `lib/shquote.sh` — a team name may legally contain a space or a quote.

## Seven printed commands, derived rather than taken from the issue

```
remote.sh  the snapshot export after connect --e2ee
           the sync-start hint in status
           the disconnect that forget refuses without
key.sh     the key-backup notice
           "already has a key"
           "has no key yet"  (both routes — generate and import)
           the post-rotate reveal line
```

**Deliberately not changed: the 16 `Usage:` synopses.** They are placeholders with nothing to paste, and an install path in a usage line is noise. Listed because a rule about printed commands that silently exempts a class gets read as covering it.

**No printed-command checker here.** Whether the sibling repository's belongs in this one is a separate decision, and this PR is not where to take it.

## The tests check the path exists, not how it is spelled

A line naming the wrong install satisfies a substring check and still does not run. They use `[ ]` and `grep -q`, never `[[ ]]`, because a failing `[[ ]]` mid-body does not trip errexit on bash 3.2 and the macOS shards run 3.2 (#670).

Three existing assertions pinned the bare spelling and moved with it. One — `remote.sh disconnect testteam` in `test_remote_forget.bats` — **passed under 3.2 and failed under bash 5**, which is #670 happening inside this change.

## Mutations

```
the backup notice back to the bare form   1 red
repair only generate, leaving import      1 red
```

## Run

Every test file that invokes either script, derived by grep: `test_key`, `test_remote`, `test_remote_forget`, `test_remote_status_liveness`, `test_team_list`, `test_printed_command_paths`. No failures under bash 5. Both scripts pass `bash -n` under 3.2 and 5. The new file lands in shard 2 of 4 and the rotate case in shard 3 of 4 — re-measured after adding it, since the partition is weighted by `@test` count and adding a case moves files between shards. Confirmed in CI on both platforms: `bats (ubuntu-latest 2/4)` and `bats (macos-latest 2/4)` each report the 7 printed-command cases, `3/4` on both reports the rotate case.

Closes #667
