### PR TITLE
watch: release a pair another session has claimed (#683)

### DIFF
--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -271,9 +271,10 @@ if [ -n "$ACTIVE_NAME" ]; then
   done <<< "$PAIRS"
 fi
 
-# Pairs this watcher has given up because another session claimed them, so the
-# announcement happens once each rather than every cycle (#683).
-DROPPED_PAIRS=""
+# Pairs another session currently holds, so each departure and each return is
+# announced once instead of every cycle. Membership is not a decision -- the
+# lock is -- it only records what has already been said (#683).
+HELD_ELSEWHERE=""
 
 while true; do
   # Liveness guard (#67): exit promptly once the originating agent session is
@@ -319,18 +320,39 @@ while true; do
           echo "agmsg watch: messages for it stay unread and reach the session that claimed it." >&2
           exit 0
         fi
-        # Broad subscription: this watcher serves other roles too, so drop the
+        # Broad subscription: this watcher serves other roles too, so skip the
         # pair rather than ending the process -- exiting here would take down a
         # whole session's delivery because one of its roles moved elsewhere.
-        # Announced once per pair; a per-cycle message would bury the log.
-        case " $DROPPED_PAIRS " in
+        #
+        # Skipped FOR AS LONG AS someone else holds it, not permanently. When
+        # the holder goes away the lock reads free again and this watcher takes
+        # the pair back, which is the same rule the startup filter uses (a
+        # stale lock is free). Dropping it for good would be worse: the role is
+        # still registered to this project, so nobody would deliver for it
+        # until the session restarted.
+        #
+        # Announced on each transition, not each cycle -- a per-cycle message
+        # would bury the log, and announcing only the first time would make a
+        # second departure invisible.
+        case " $HELD_ELSEWHERE " in
           *" ${pair_team}/${pair_agent} "*) ;;
           *)
-            DROPPED_PAIRS="${DROPPED_PAIRS:+$DROPPED_PAIRS }${pair_team}/${pair_agent}"
-            echo "agmsg watch: ${pair_team}/${pair_agent} was claimed by session ${pair_state#other:}; dropping it here." >&2
+            HELD_ELSEWHERE="${HELD_ELSEWHERE:+$HELD_ELSEWHERE }${pair_team}/${pair_agent}"
+            echo "agmsg watch: ${pair_team}/${pair_agent} was claimed by session ${pair_state#other:}; not serving it while they hold it." >&2
             ;;
         esac
         continue
+        ;;
+      *)
+        # Free or ours. If we had stepped aside for it, say that we are taking
+        # it back -- otherwise the log shows a role leaving and never returning,
+        # which reads as a permanent drop.
+        case " $HELD_ELSEWHERE " in
+          *" ${pair_team}/${pair_agent} "*)
+            HELD_ELSEWHERE="$(printf '%s' " $HELD_ELSEWHERE " | sed "s| ${pair_team}/${pair_agent} | |g; s|^ *||; s| *$||")"
+            echo "agmsg watch: ${pair_team}/${pair_agent} is unheld again; serving it here." >&2
+            ;;
+        esac
         ;;
     esac
     # Per team: with a store per team, "one team has no store yet" is a

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -274,7 +274,37 @@ fi
 # Pairs another session currently holds, so each departure and each return is
 # announced once instead of every cycle. Membership is not a decision -- the
 # lock is -- it only records what has already been said (#683).
+#
+# Held as newline-separated entries and compared as EXACT strings, never as
+# patterns. A team name is arbitrary UTF-8 minus a path deny-list and an agent
+# name minus a JSON-path deny-list (validate.sh), so either may contain glob
+# metacharacters, a sed delimiter, or a space. A `case` pattern or an
+# `s|…|…|` built out of one is a bug that only appears for some names --
+# the class this repo has paid for before with quotes in names (#87). Newline
+# is the one byte a name cannot contain, control characters being rejected, so
+# it is the safe separator.
 HELD_ELSEWHERE=""
+
+_held_elsewhere_has() {
+  local want="$1" line
+  [ -n "$HELD_ELSEWHERE" ] || return 1
+  while IFS= read -r line; do
+    [ "$line" = "$want" ] && return 0
+  done <<< "$HELD_ELSEWHERE"
+  return 1
+}
+
+_held_elsewhere_without() {
+  local drop="$1" line out=""
+  [ -n "$HELD_ELSEWHERE" ] || return 0
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    [ "$line" = "$drop" ] && continue
+    out="${out:+$out
+}$line"
+  done <<< "$HELD_ELSEWHERE"
+  printf '%s' "$out"
+}
 
 while true; do
   # Liveness guard (#67): exit promptly once the originating agent session is
@@ -334,25 +364,21 @@ while true; do
         # Announced on each transition, not each cycle -- a per-cycle message
         # would bury the log, and announcing only the first time would make a
         # second departure invisible.
-        case " $HELD_ELSEWHERE " in
-          *" ${pair_team}/${pair_agent} "*) ;;
-          *)
-            HELD_ELSEWHERE="${HELD_ELSEWHERE:+$HELD_ELSEWHERE }${pair_team}/${pair_agent}"
-            echo "agmsg watch: ${pair_team}/${pair_agent} was claimed by session ${pair_state#other:}; not serving it while they hold it." >&2
-            ;;
-        esac
+        if ! _held_elsewhere_has "${pair_team}/${pair_agent}"; then
+          HELD_ELSEWHERE="${HELD_ELSEWHERE:+$HELD_ELSEWHERE
+}${pair_team}/${pair_agent}"
+          echo "agmsg watch: ${pair_team}/${pair_agent} was claimed by session ${pair_state#other:}; not serving it while they hold it." >&2
+        fi
         continue
         ;;
       *)
         # Free or ours. If we had stepped aside for it, say that we are taking
         # it back -- otherwise the log shows a role leaving and never returning,
         # which reads as a permanent drop.
-        case " $HELD_ELSEWHERE " in
-          *" ${pair_team}/${pair_agent} "*)
-            HELD_ELSEWHERE="$(printf '%s' " $HELD_ELSEWHERE " | sed "s| ${pair_team}/${pair_agent} | |g; s|^ *||; s| *$||")"
-            echo "agmsg watch: ${pair_team}/${pair_agent} is unheld again; serving it here." >&2
-            ;;
-        esac
+        if _held_elsewhere_has "${pair_team}/${pair_agent}"; then
+          HELD_ELSEWHERE="$(_held_elsewhere_without "${pair_team}/${pair_agent}")"
+          echo "agmsg watch: ${pair_team}/${pair_agent} is unheld again; serving it here." >&2
+        fi
         ;;
     esac
     # Per team: with a store per team, "one team has no store yet" is a

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -271,6 +271,10 @@ if [ -n "$ACTIVE_NAME" ]; then
   done <<< "$PAIRS"
 fi
 
+# Pairs this watcher has given up because another session claimed them, so the
+# announcement happens once each rather than every cycle (#683).
+DROPPED_PAIRS=""
+
 while true; do
   # Liveness guard (#67): exit promptly once the originating agent session is
   # gone. A plain pipe gives no portable way to notice a *downstream* consumer
@@ -286,6 +290,49 @@ while true; do
   fi
   while IFS=$'\t' read -r pair_team pair_agent; do
     [ -z "$pair_team" ] && continue
+    # Ownership is re-read every cycle, because it can change under a running
+    # watcher and nothing else notices. The subscription set and the startup
+    # lock check both happen once, above; a session that claims this role
+    # afterwards moves the lock file and starts its own watcher, and this
+    # process would otherwise keep polling the same pair forever.
+    #
+    # That is not a harmless duplicate. The read cursor is one per
+    # (team, agent) and storage_watch_after excludes rows already read, so
+    # whoever polls first TAKES the row and the other sees nothing. When the
+    # one that takes it is this stale process, its printf succeeds -- stdout is
+    # still an open pipe to a live session -- so the id is marked read and the
+    # message is gone, delivered to a stream nobody is reading (#683).
+    #
+    # Only the lock file is read here, not the whole subscription set: losing a
+    # pair is the half a running process can detect for the price of a file
+    # read. Gaining one is the caller's job, at the point it creates the team.
+    pair_state="$(actas_lock_state "$pair_team" "$pair_agent" "$SESSION_ID" 2>/dev/null || echo free)"
+    case "$pair_state" in
+      other:*)
+        if [ -n "$ACTIVE_NAME" ]; then
+          # This watcher exists to serve exactly this role and no longer owns
+          # it. Stop -- and say so: stderr is the only place a reason survives,
+          # and a watcher that ends without one is indistinguishable from one
+          # that crashed.
+          echo "agmsg watch: ${pair_team}/${pair_agent} is now held by session ${pair_state#other:}." >&2
+          echo "agmsg watch: this watcher no longer owns that role and is stopping." >&2
+          echo "agmsg watch: messages for it stay unread and reach the session that claimed it." >&2
+          exit 0
+        fi
+        # Broad subscription: this watcher serves other roles too, so drop the
+        # pair rather than ending the process -- exiting here would take down a
+        # whole session's delivery because one of its roles moved elsewhere.
+        # Announced once per pair; a per-cycle message would bury the log.
+        case " $DROPPED_PAIRS " in
+          *" ${pair_team}/${pair_agent} "*) ;;
+          *)
+            DROPPED_PAIRS="${DROPPED_PAIRS:+$DROPPED_PAIRS }${pair_team}/${pair_agent}"
+            echo "agmsg watch: ${pair_team}/${pair_agent} was claimed by session ${pair_state#other:}; dropping it here." >&2
+            ;;
+        esac
+        continue
+        ;;
+    esac
     # Per team: with a store per team, "one team has no store yet" is a
     # normal state, and a single check outside this loop would silence
     # delivery for every OTHER team as well.

--- a/tests/test_actas_integration.bats
+++ b/tests/test_actas_integration.bats
@@ -297,3 +297,58 @@ fake_session() {
   kill "$broad" 2>/dev/null || true
   wait "$broad" 2>/dev/null || true
 }
+
+# Stepping aside is for as long as someone else holds the role, not forever.
+# The review of the first version caught the opposite claim in my own
+# description: the pair stays in the subscription and comes back when the lock
+# reads free again. Permanence would be the worse behaviour -- the role is still
+# registered to this project, so nobody would deliver for it until the session
+# restarted -- so this pins the return rather than the drop.
+@test "watch: a broad watcher takes a pair back once nobody holds it (#683)" {
+  skip_on_windows "actas watcher process mgmt under Git Bash (#182)"
+  fake_register T alice
+  fake_register T carol
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SKILL_DIR/scripts/watch.sh" "sid-broad" /tmp/p1 claude-code \
+    > "$BATS_TEST_TMPDIR/broad.out" 2> "$BATS_TEST_TMPDIR/broad.err" 3>&- &
+  local broad=$!
+  sleep 1
+
+  sleep 60 &
+  local newpid=$!
+  echo "sid-new" > "$RUN_DIR/cc-instance.$newpid"
+  echo "sid-new" > "$(actas_lock_path T alice)"
+  sleep 2
+
+  # It stepped aside while the other session was live.
+  bash "$SKILL_DIR/scripts/send.sh" T carol alice "while it was held" >/dev/null
+  sleep 2
+  run cat "$BATS_TEST_TMPDIR/broad.out"
+  [[ "$output" != *"while it was held"* ]]
+
+  # The holder disappears. The lock file stays behind — a stale owner reads as
+  # free, which is exactly the state the startup filter already treats as
+  # available.
+  kill "$newpid" 2>/dev/null || true
+  wait "$newpid" 2>/dev/null || true
+  rm -f "$RUN_DIR/cc-instance.$newpid"
+  sleep 3
+
+  # Both messages are delivered now: the one that arrived while it was held is
+  # still unread, so taking the pair back means handing it over, not skipping it.
+  bash "$SKILL_DIR/scripts/send.sh" T carol alice "after it was released" >/dev/null
+  sleep 3
+
+  run cat "$BATS_TEST_TMPDIR/broad.out"
+  [[ "$output" == *"while it was held"* ]]
+  [[ "$output" == *"after it was released"* ]]
+
+  # And the log shows both transitions, so a reader is not left thinking the
+  # role went away for good.
+  run cat "$BATS_TEST_TMPDIR/broad.err"
+  [[ "$output" == *"while they hold it"* ]]
+  [[ "$output" == *"unheld again"* ]]
+
+  kill "$broad" 2>/dev/null || true
+  wait "$broad" 2>/dev/null || true
+}

--- a/tests/test_actas_integration.bats
+++ b/tests/test_actas_integration.bats
@@ -186,3 +186,114 @@ fake_session() {
   kill "$wpid" 2>/dev/null || true
   wait "$wpid" 2>/dev/null || true
 }
+
+# --- watch.sh releasing a pair it no longer owns (#683) ---
+
+# The subscription set and the lock check both happen once, before the polling
+# loop (watch.sh 159-211 vs the loop at 274). So a watcher that is already
+# running never notices that another session took its role: it keeps polling the
+# same pair, and because the read cursor is one per (team, agent) and
+# storage_watch_after excludes rows already read, WHOEVER POLLS FIRST takes the
+# row and the other sees nothing.
+#
+# When the one that takes it is the older process, its printf succeeds -- its
+# stdout is still an open pipe to a live session -- so the id is appended to
+# DELIVERED_IDS and the message is marked read. Nothing surfaces it. That is the
+# reported symptom: consumed, marked read, and never delivered.
+@test "watch: a pair claimed by another session is released, not consumed (#683)" {
+  skip_on_windows "actas watcher process mgmt under Git Bash (#182)"
+  fake_register T alice
+  fake_register T bob
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SKILL_DIR/scripts/watch.sh" "sid-old" /tmp/p1 claude-code alice \
+    > "$BATS_TEST_TMPDIR/old.out" 2> "$BATS_TEST_TMPDIR/old.err" 3>&- &
+  local old=$!
+  local i
+  for i in $(seq 1 50); do
+    [ "$(actas_lock_owner T alice)" = "sid-old" ] && break
+    sleep 0.1
+  done
+  [ "$(actas_lock_owner T alice)" = "sid-old" ]
+
+  # A second session takes the role — what `/agmsg actas` does from a new
+  # session. It needs to look ALIVE, or the lock reads as stale and free.
+  sleep 60 &
+  local newpid=$!
+  echo "sid-new" > "$RUN_DIR/cc-instance.$newpid"
+  echo "sid-new" > "$(actas_lock_path T alice)"
+
+  bash "$SKILL_DIR/scripts/send.sh" T bob alice "after the handover" >/dev/null
+
+  # Several poll cycles at the 1s interval set above.
+  sleep 4
+  kill "$newpid" 2>/dev/null || true
+
+  # It must not have taken a message addressed to a role it no longer owns.
+  run cat "$BATS_TEST_TMPDIR/old.out"
+  [[ "$output" != *"after the handover"* ]]
+
+  # It must have stopped. A watcher that keeps running is what consumes the
+  # next message too.
+  ! kill -0 "$old" 2>/dev/null
+
+  # And it must say why. Exiting silently is the same defect class -- this
+  # watcher's stderr is the only place a reason can survive.
+  run cat "$BATS_TEST_TMPDIR/old.err"
+  [[ "$output" == *"T/alice"* ]]
+  [[ "$output" == *"sid-new"* ]]
+
+  # The message is still unread, so the session that now owns the role is
+  # offered it. Without this, "did not print it" would also pass for a watcher
+  # that consumed the row and threw it away.
+  local left
+  left="$(bash -c '
+    source "'"$SKILL_DIR"'/scripts/lib/storage.sh"
+    agmsg_storage_load
+    storage_list_unread T alice
+  ' | grep -c .)"
+  [ "$left" -eq 1 ]
+
+  kill "$old" 2>/dev/null || true
+  wait "$old" 2>/dev/null || true
+}
+
+# The other half, and the one that decides whether this fix is safe: a watcher
+# with a BROAD subscription serves several roles, so a role moving elsewhere
+# must cost it that role and nothing else. Exiting here would take down a whole
+# session's delivery because one member ran `actas` somewhere -- a worse failure
+# than the one being fixed.
+@test "watch: a broad watcher drops only the claimed pair and keeps serving the rest (#683)" {
+  skip_on_windows "actas watcher process mgmt under Git Bash (#182)"
+  fake_register T alice
+  fake_register T bob
+  fake_register T carol
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SKILL_DIR/scripts/watch.sh" "sid-broad" /tmp/p1 claude-code \
+    > "$BATS_TEST_TMPDIR/broad.out" 2> "$BATS_TEST_TMPDIR/broad.err" 3>&- &
+  local broad=$!
+  sleep 1
+
+  sleep 60 &
+  local newpid=$!
+  echo "sid-new" > "$RUN_DIR/cc-instance.$newpid"
+  echo "sid-new" > "$(actas_lock_path T alice)"
+
+  bash "$SKILL_DIR/scripts/send.sh" T carol alice "for the role that moved" >/dev/null
+  bash "$SKILL_DIR/scripts/send.sh" T carol bob   "for the role that stayed" >/dev/null
+  sleep 4
+  kill "$newpid" 2>/dev/null || true
+
+  # Still running — this is the assertion the fix has to earn.
+  kill -0 "$broad" 2>/dev/null
+
+  run cat "$BATS_TEST_TMPDIR/broad.out"
+  [[ "$output" == *"for the role that stayed"* ]]
+  [[ "$output" != *"for the role that moved"* ]]
+
+  # And it said which pair it gave up.
+  run cat "$BATS_TEST_TMPDIR/broad.err"
+  [[ "$output" == *"T/alice"* ]]
+
+  kill "$broad" 2>/dev/null || true
+  wait "$broad" 2>/dev/null || true
+}

--- a/tests/test_actas_integration.bats
+++ b/tests/test_actas_integration.bats
@@ -352,3 +352,55 @@ fake_session() {
   kill "$broad" 2>/dev/null || true
   wait "$broad" 2>/dev/null || true
 }
+
+# Names are arbitrary UTF-8 minus a deny-list (validate.sh): a team name may
+# contain a regex metacharacter or a sed delimiter. The first version of this
+# bookkeeping tested membership with a `case` glob and removed entries with an
+# `s|…|…|` built from the name, and my first attempt at a test for it did not
+# discriminate -- it used one hostile name, and a removal that failed outright
+# still left the list empty, which looks the same from outside. Measured: the
+# broken version passed it.
+#
+# What separates them is a removal that takes MORE than it was asked for. Two
+# teams whose names differ only where the metacharacter sits, both held
+# elsewhere, and only one released: a regex removal drops both entries, so the
+# still-held one is announced a second time. The lock, not this list, decides
+# delivery -- so the assertion is on the log, which is the only thing the
+# bookkeeping controls.
+@test "watch: releasing one held pair does not forget another whose name it matches (#683)" {
+  skip_on_windows "actas watcher process mgmt under Git Bash (#182)"
+  fake_register 't.m' alice
+  fake_register 'txm' alice
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SKILL_DIR/scripts/watch.sh" "sid-broad" /tmp/p1 claude-code \
+    > "$BATS_TEST_TMPDIR/n.out" 2> "$BATS_TEST_TMPDIR/n.err" 3>&- &
+  local broad=$!
+  sleep 1
+
+  sleep 60 &
+  local newpid=$!
+  echo "sid-new" > "$RUN_DIR/cc-instance.$newpid"
+  echo "sid-new" > "$(actas_lock_path 't.m' alice)"
+  echo "sid-new" > "$(actas_lock_path 'txm' alice)"
+  sleep 3
+
+  # Release ONLY t.m. txm stays held, so nothing about it has changed.
+  rm -f "$(actas_lock_path 't.m' alice)"
+  sleep 4
+  kill "$newpid" 2>/dev/null || true
+
+  # t.m came back, exactly once.
+  run cat "$BATS_TEST_TMPDIR/n.err"
+  [[ "$output" == *"t.m/alice is unheld again"* ]]
+  [[ "$output" != *"txm/alice is unheld again"* ]]
+
+  # And txm was announced as held once, not twice: a removal that also dropped
+  # txm from the list makes the next cycle treat it as newly held and say so
+  # again.
+  local claims
+  claims="$(grep -c 'txm/alice was claimed' "$BATS_TEST_TMPDIR/n.err" || true)"
+  [ "$claims" -eq 1 ]
+
+  kill "$broad" 2>/dev/null || true
+  wait "$broad" 2>/dev/null || true
+}


### PR DESCRIPTION
Closes #683.

## The reproduction came first

Before any fix: two watchers on the same pair, the second one holding the lock. The **older** process printed a message addressed to a role it no longer owned. That is the reported symptom reproduced in the suite — consumed, marked read, delivered to a stream nobody is watching.

## What changed

Ownership is re-read on every polling cycle. Only the lock file — not the whole subscription set. Losing a pair is the half a running process can detect for the price of a file read; gaining one belongs to whoever creates the team, and re-resolving the set every cycle would put `identities.sh` on the hot path to answer a question that only changes at a known moment.

Two behaviours, because the roles differ:

- an **exclusive** watcher (`actas`) that loses its only role **stops**;
- a **broad** watcher **drops that pair** and keeps serving the others. Exiting there would take down a whole session's delivery because one member ran `actas` somewhere else — worse than the defect being fixed. There is a test for exactly that.

The stop is not silent. This watcher's stderr is the only place a reason can survive, and an exit with no reason cannot be told apart from a crash.

## Not fixed here

The other half of the same root fact — a running watcher never re-resolves its subscription set, so a team created afterwards is never subscribed to — is left alone deliberately. It wants an event at the point the team is created, not a poll.

## Mutation

Neuter the per-cycle check → 2 red (the stale watcher takes the message; the broad watcher takes one meant for a role that moved). Restore → 285/285 green across actas / watch / despawn / instance-id / delivery, under bash 3.2.
