### PR TITLE
fix(remote): name the way out, on the two screens that only named the problem

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -599,14 +599,48 @@ _remote_json_array_length() {
 # roster taken from anywhere else at this moment would be a guess presented as
 # fact. It is derived by replaying the team journal.
 _remote_write_pulled_team() {
-  local team="$1" team_id="$2" cfg initial existing_id
+  local team="$1" team_id="$2" endpoint="${3:-<url>}" cfg initial existing_id
   cfg="$(_remote_team_config "$team")"
   mkdir -p "$TEAMS_DIR/$team"
   agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
   if [ -f "$cfg" ]; then
     existing_id="$(_remote_read_config_field "$cfg" '$.team_id')"
     if [ "$existing_id" != "$team_id" ]; then
-      echo "agmsg: local team '$team' has a different team id" >&2
+      # The refusal is right and stays. What was missing is what to do next
+      # (#680): the operator learned that two things disagreed and nothing
+      # else -- not which ids, not that their own team was untouched, not that
+      # there are two ways out and which is safe when.
+      #
+      # `_remote_resolve_team_id` a few lines down already answers the same
+      # class of question this way -- print what tells the candidates apart,
+      # then name the flag that settles it -- so this is that treatment, not a
+      # new convention.
+      {
+        echo "agmsg: local team '$team' is a different team from the one on the server."
+        echo "  local id:  $existing_id"
+        echo "  server id: $team_id"
+        # A fact, so it is said either way: the worst reading of a bare refusal
+        # is that something was half-done.
+        echo "Nothing local was changed."
+        # The routes are the plain install's, so they are held back when a
+        # caller owns the next step -- same split as everywhere else here.
+        if agmsg_operator_guidance_is_ours; then
+          echo "Two ways forward:"
+          echo "  the name matched the wrong team on the server — name the right one:"
+          echo "    bash $(agmsg_shq "$SKILL_DIR/scripts/remote.sh") pull --endpoint $(agmsg_shq "$endpoint") --team-id $(agmsg_shq "$team_id") $(agmsg_shq "$team")"
+          echo "  both teams are real — rename the local one, BEFORE connecting it:"
+          echo "    bash $(agmsg_shq "$SKILL_DIR/scripts/rename-team.sh") $(agmsg_shq "$team") <new-name>"
+          # Why the ordering is worth printing at the moment of refusal rather
+          # than left for the operator to find out: rename-team.sh is local
+          # only. It never reads or writes `remote_binding` and never tells the
+          # server -- so renaming a team that is ALREADY connected leaves the
+          # binding naming the team the server still knows by the old name,
+          # and the other machine with it. Before connecting, it is one local
+          # copy and nothing to disagree with.
+          echo "  Renaming is local only: it does not tell the server, so a team renamed"
+          echo "  after it is connected keeps a binding that names the old one."
+        fi
+      } >&2
       agmsg_lock_release
       return 1
     fi
@@ -755,7 +789,10 @@ cmd_pull() {
   # The roster driver projects imported identity events into this config while
   # the bootstrap is running. Publish the empty identity-bearing shell first;
   # retries reuse it, and the successful projection is never overwritten.
-  _remote_write_pulled_team "$team" "$team_id" || exit 1
+  # The endpoint travels so the refusal above can print a `pull --team-id` line
+  # that runs, rather than one with a placeholder the operator has to fill in
+  # from memory.
+  _remote_write_pulled_team "$team" "$team_id" "$endpoint" || exit 1
 
   local result pulled_id pulled_name imported pulled_sid pulled_protocol pulled_caps \
     pulled_age_v1 pulled_cipher binding_cipher
@@ -1571,9 +1608,25 @@ cmd_connect() {
   # the thing the ceremony exists to make unnecessary. So it is said only when
   # nobody else owns the next step.
   if [ "$e2ee" -eq 1 ] && agmsg_operator_guidance_is_ours; then
-    echo "Export the public epoch snapshot with:"
-    echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/key.sh") show $(agmsg_shq "$team") --snapshot --out <file>"
-    echo "Transfer that snapshot and the key out of band; the other machine must import and live-confirm them before syncing."
+    # The bundle, not the snapshot pair (#668). Both are accepted by `unlock`
+    # and that has not changed; what changed is which one this screen names.
+    #
+    # It named the snapshot, and `pull` on the other machine asks for "the
+    # secret handoff bundle you were given" -- so each side named the other's
+    # route and an operator following the screens produced the wrong artifact.
+    #
+    # The bundle wins on a measurement rather than a preference: the snapshot
+    # route needs the private key too, and the only command that hands it over
+    # is `key.sh show --reveal-secret`, which refuses without a TTY. The
+    # walkthrough that leads here tells the reader to drive this with an agent,
+    # so that route stops at its second step for the reader it is written for.
+    # `key.sh handoff` needs no terminal, is one artifact instead of two, and
+    # is the one `unlock` gates behind a confirmed digest.
+    echo "Export one secret handoff bundle for the other machine:"
+    echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/key.sh") handoff $(agmsg_shq "$team") --out <file>"
+    echo "That file IS the key: transfer it only through a channel you trust, and never"
+    echo "into agent chat. Compare the snapshot digest it prints over a separate live"
+    echo "channel — the other machine's unlock refuses the bundle without it."
   fi
 }
 

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -599,7 +599,7 @@ _remote_json_array_length() {
 # roster taken from anywhere else at this moment would be a guess presented as
 # fact. It is derived by replaying the team journal.
 _remote_write_pulled_team() {
-  local team="$1" team_id="$2" endpoint="${3:-<url>}" cfg initial existing_id
+  local team="$1" team_id="$2" endpoint="${3:-<url>}" cfg initial existing_id local_connected
   cfg="$(_remote_team_config "$team")"
   mkdir -p "$TEAMS_DIR/$team"
   agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
@@ -625,20 +625,33 @@ _remote_write_pulled_team() {
         # The routes are the plain install's, so they are held back when a
         # caller owns the next step -- same split as everywhere else here.
         if agmsg_operator_guidance_is_ours; then
+          # The first route must land somewhere the collision is not (review).
+          # Re-running with --team-id and the SAME local name reproduces the
+          # command that just failed: that flag picks between same-named teams
+          # on the SERVER, and the local name is still taken either way. With a
+          # free local name it is a route that completes -- and it is the one
+          # that works even when the local team is connected and must not move.
           echo "Two ways forward:"
-          echo "  the name matched the wrong team on the server — name the right one:"
-          echo "    bash $(agmsg_shq "$SKILL_DIR/scripts/remote.sh") pull --endpoint $(agmsg_shq "$endpoint") --team-id $(agmsg_shq "$team_id") $(agmsg_shq "$team")"
-          echo "  both teams are real — rename the local one, BEFORE connecting it:"
-          echo "    bash $(agmsg_shq "$SKILL_DIR/scripts/rename-team.sh") $(agmsg_shq "$team") <new-name>"
-          # Why the ordering is worth printing at the moment of refusal rather
-          # than left for the operator to find out: rename-team.sh is local
-          # only. It never reads or writes `remote_binding` and never tells the
-          # server -- so renaming a team that is ALREADY connected leaves the
-          # binding naming the team the server still knows by the old name,
-          # and the other machine with it. Before connecting, it is one local
-          # copy and nothing to disagree with.
-          echo "  Renaming is local only: it does not tell the server, so a team renamed"
-          echo "  after it is connected keeps a binding that names the old one."
+          echo "  keep your local '$team' and take the server's team under a free name:"
+          echo "    bash $(agmsg_shq "$SKILL_DIR/scripts/remote.sh") pull --endpoint $(agmsg_shq "$endpoint") --team-id $(agmsg_shq "$team_id") <a-free-local-name>"
+          # The second route frees THIS name, and only one of the two states can
+          # take it. rename-team.sh is local only: it never reads or writes
+          # `remote_binding` and never tells the server, so renaming a team that
+          # is already connected leaves the binding naming the team the server
+          # still knows by the old name. Which state the operator is in is
+          # knowable here, so it is decided here rather than handed over as a
+          # caveat to apply themselves.
+          local_connected="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
+          if [ -n "$local_connected" ] && [ "$local_connected" != null ]; then
+            echo "  renaming your local '$team' is NOT a way out: it is connected, and a"
+            echo "  rename is local only — it does not tell the server, so the binding"
+            echo "  would keep naming the team the server still knows by the old name."
+          else
+            echo "  or free this name first — your local '$team' is not connected, so:"
+            echo "    bash $(agmsg_shq "$SKILL_DIR/scripts/rename-team.sh") $(agmsg_shq "$team") <a-new-name-for-it>"
+            echo "  then pull again. Rename before connecting, never after: a rename is"
+            echo "  local only and does not tell the server."
+          fi
         fi
       } >&2
       agmsg_lock_release

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -599,7 +599,7 @@ _remote_json_array_length() {
 # roster taken from anywhere else at this moment would be a guess presented as
 # fact. It is derived by replaying the team journal.
 _remote_write_pulled_team() {
-  local team="$1" team_id="$2" endpoint="${3:-<url>}" cfg initial existing_id local_connected
+  local team="$1" team_id="$2" endpoint="${3:-<url>}" cfg initial existing_id local_connected local_disconnected
   cfg="$(_remote_team_config "$team")"
   mkdir -p "$TEAMS_DIR/$team"
   agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
@@ -641,8 +641,16 @@ _remote_write_pulled_team() {
           # still knows by the old name. Which state the operator is in is
           # knowable here, so it is decided here rather than handed over as a
           # caveat to apply themselves.
+          # STILL connected, which is not the same as "has ever connected"
+          # (review). A disconnected team keeps its `connected_at` and gains a
+          # `disconnected_at`, so reading the first alone calls it connected
+          # and withholds a route it is entitled to. This is the same predicate
+          # `_remote_status_one` and `connect`'s re-adoption use: a binding is
+          # live when it has a connected_at and no disconnected_at.
           local_connected="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
-          if [ -n "$local_connected" ] && [ "$local_connected" != null ]; then
+          local_disconnected="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
+          if [ -n "$local_connected" ] && [ "$local_connected" != null ] \
+            && { [ -z "$local_disconnected" ] || [ "$local_disconnected" = null ]; }; then
             echo "  renaming your local '$team' is NOT a way out: it is connected, and a"
             echo "  rename is local only — it does not tell the server, so the binding"
             echo "  would keep naming the team the server still knows by the old name."

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -641,8 +641,8 @@ _remote_write_pulled_team() {
           # still knows by the old name. Which state the operator is in is
           # knowable here, so it is decided here rather than handed over as a
           # caveat to apply themselves.
-          # STILL connected, which is not the same as "has ever connected"
-          #. A disconnected team keeps its `connected_at` and gains a
+          # STILL connected, which is not the same as "has ever connected".
+          # A disconnected team keeps its `connected_at` and gains a
           # `disconnected_at`, so reading the first alone calls it connected
           # and withholds a route it is entitled to. This is the same predicate
           # `_remote_status_one` and `connect`'s re-adoption use: a binding is

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -625,7 +625,7 @@ _remote_write_pulled_team() {
         # The routes are the plain install's, so they are held back when a
         # caller owns the next step -- same split as everywhere else here.
         if agmsg_operator_guidance_is_ours; then
-          # The first route must land somewhere the collision is not (review).
+          # The first route must land somewhere the collision is not.
           # Re-running with --team-id and the SAME local name reproduces the
           # command that just failed: that flag picks between same-named teams
           # on the SERVER, and the local name is still taken either way. With a
@@ -642,7 +642,7 @@ _remote_write_pulled_team() {
           # knowable here, so it is decided here rather than handed over as a
           # caveat to apply themselves.
           # STILL connected, which is not the same as "has ever connected"
-          # (review). A disconnected team keeps its `connected_at` and gains a
+          #. A disconnected team keeps its `connected_at` and gains a
           # `disconnected_at`, so reading the first alone calls it connected
           # and withholds a route it is entitled to. This is the same predicate
           # `_remote_status_one` and `connect`'s re-adoption use: a binding is

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1282,6 +1282,32 @@ PY_BIND
   printf '%s\n' "$out" | grep -q 'it is connected' || return 1
 }
 
+@test "remote pull: a DISCONNECTED local team is still offered the rename (#680)" {
+  # "has ever connected" is not "is connected". A disconnected team keeps its
+  # connected_at and gains a disconnected_at, and reading the first alone
+  # withheld a route it is entitled to (review). Its name is free to move: the
+  # binding it would leave behind is already dead.
+  bash "$SCRIPTS/join.sh" clashoff alice claude-code /tmp/project-off >/dev/null
+  python3 - "$TEST_SKILL_DIR/teams/clashoff/config.json" <<'PY_BIND'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d['remote_binding'] = {'endpoint': 'https://elsewhere.example',
+                       'server_instance_id': '018f3f7e-9999-7000-8000-000000000000',
+                       'remote_team_id': d['team_id'],
+                       'connected_at': '2026-07-30T00:00:00Z',
+                       'disconnected_at': '2026-07-31T00:00:00Z'}
+open(p, 'w').write(json.dumps(d) + '\n')
+PY_BIND
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" clashoff
+  [ "$status" -ne 0 ] || return 1
+  out="$output"
+  printf '%s\n' "$out" | grep -q -F -- "rename-team.sh' " || return 1
+  printf '%s\n' "$out" | grep -q 'not connected' || return 1
+  run bash -c 'printf "%s\n" "$1" | grep -q "it is connected"' _ "$out"
+  [ "$status" -ne 0 ] || { echo "a disconnected team was called connected" >&2; return 1; }
+}
+
 @test "remote pull: the way out survives a team with a space and a quote (#680)" {
   # The printed `pull --team-id` line carries the team name back to a shell.
   local qteam="it's a clash"

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -518,7 +518,7 @@ _capability_endpoint() {
   # contains the right words.
   skip_if_no_age
   local qteam="it's a team"
-  bash "$SCRIPTS/join.sh" "$qteam" alice claude-code /tmp/project-q >/dev/null
+  bash "$SCRIPTS/join.sh" "$qteam" alice claude-code /tmp/project-quoted-team >/dev/null
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee "$qteam"
   [ "$status" -eq 0 ] || return 1
   line="$(printf '%s\n' "$output" | grep -F -- "key.sh' handoff " | head -1)"
@@ -1236,7 +1236,7 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   # Parsing argv only shows the line survives a shell; it does not show the
   # line goes anywhere. The previous version of this route re-ran the command
   # that had just failed -- it parsed perfectly and returned the same refusal
-  # forever (review). A way out has to come out.
+  # forever. A way out has to come out.
   line="$(printf '%s\n' "$output" | grep -F -- "remote.sh' pull " | head -1)"
   [ -n "$line" ] || return 1
   run bash -c "${line%%<*}rescued"
@@ -1254,7 +1254,7 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   # rename-team.sh is local only: it never reads or writes `remote_binding` and
   # never tells the server, so renaming a connected team leaves the binding
   # naming the team the server still knows by the old name.
-  bash "$SCRIPTS/join.sh" clashconn alice claude-code /tmp/project-cc >/dev/null
+  bash "$SCRIPTS/join.sh" clashconn alice claude-code /tmp/project-clash-connected >/dev/null
   python3 - "$TEST_SKILL_DIR/teams/clashconn/config.json" <<'PY_BIND'
 import json, sys
 p = sys.argv[1]
@@ -1285,9 +1285,9 @@ PY_BIND
 @test "remote pull: a DISCONNECTED local team is still offered the rename (#680)" {
   # "has ever connected" is not "is connected". A disconnected team keeps its
   # connected_at and gains a disconnected_at, and reading the first alone
-  # withheld a route it is entitled to (review). Its name is free to move: the
+  # withheld a route it is entitled to. Its name is free to move: the
   # binding it would leave behind is already dead.
-  bash "$SCRIPTS/join.sh" clashoff alice claude-code /tmp/project-off >/dev/null
+  bash "$SCRIPTS/join.sh" clashoff alice claude-code /tmp/project-clash-disconnected >/dev/null
   python3 - "$TEST_SKILL_DIR/teams/clashoff/config.json" <<'PY_BIND'
 import json, sys
 p = sys.argv[1]
@@ -1311,7 +1311,7 @@ PY_BIND
 @test "remote pull: the way out survives a team with a space and a quote (#680)" {
   # The printed `pull --team-id` line carries the team name back to a shell.
   local qteam="it's a clash"
-  bash "$SCRIPTS/join.sh" "$qteam" alice claude-code /tmp/project-qc >/dev/null
+  bash "$SCRIPTS/join.sh" "$qteam" alice claude-code /tmp/project-clash-quoted >/dev/null
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" "$qteam"
   [ "$status" -ne 0 ] || return 1
   out="$output"

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -567,9 +567,12 @@ _capability_endpoint() {
   # The route moved to the handoff bundle (#668); the gate still withholds it.
   # `grep -q` + status, not `[[ ]]`: a failing `[[ ]]` mid-body is not enforced
   # on bash 3.2 (#670), and these are the assertions that just moved.
-  run bash -c 'printf "%s\n" "$1" | grep -q "secret handoff bundle"' _ "$output"
+  # Captured first: `run` overwrites $output, so the second check below would
+  # otherwise grep the first grep's empty stdout and pass for that reason.
+  out="$output"
+  run bash -c 'printf "%s\n" "$1" | grep -q "secret handoff bundle"' _ "$out"
   [ "$status" -ne 0 ] || return 1
-  run bash -c 'printf "%s\n" "$1" | grep -q "key.sh"' _ "$output"
+  run bash -c 'printf "%s\n" "$1" | grep -q "key.sh"' _ "$out"
   [ "$status" -ne 0 ] || return 1
 }
 
@@ -1229,31 +1232,54 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   # The ordering point, which is the one that is expensive to learn late.
   printf '%s\n' "$output" | grep -q 'does not tell the server' || return 1
 
-  # Both routes are runnable as printed, not merely mentioned.
+  # The first route is RUN, with its placeholder replaced by a free local name.
+  # Parsing argv only shows the line survives a shell; it does not show the
+  # line goes anywhere. The previous version of this route re-ran the command
+  # that had just failed -- it parsed perfectly and returned the same refusal
+  # forever (review). A way out has to come out.
   line="$(printf '%s\n' "$output" | grep -F -- "remote.sh' pull " | head -1)"
   [ -n "$line" ] || return 1
-  # Everything up to the first placeholder. `<new-name>` and `<file>` are for
-  # the reader to replace; left in, a shell reads them as redirections and the
-  # parse dies. What must survive a shell is the part that is already complete.
-  eval "set -- ${line%%<*}"
-  [ "$1" = bash ] || return 1
-  [ -f "$2" ] || return 1
-  [ "$3" = pull ] || return 1
-  [ "$4" = --endpoint ] || return 1
-  [ "$5" = "$ENDPOINT" ] || return 1
-  [ "$6" = --team-id ] || return 1
-  [ "$7" = "$PULL_TEAM_ID" ] || return 1
-  [ "$8" = clash ] || return 1
+  run bash -c "${line%%<*}rescued"
+  [ "$status" -eq 0 ] || { echo "the printed way out did not run: $output" >&2; return 1; }
+  [ -f "$TEST_SKILL_DIR/teams/rescued/config.json" ] || return 1
+  # And the local team it refused to touch is still theirs, still its own id.
+  [ -f "$TEST_SKILL_DIR/teams/clash/config.json" ] || return 1
+  still="$(python3 -c "import json;print(json.load(open('$TEST_SKILL_DIR/teams/clash/config.json'))['team_id'])")"
+  [ "$still" != "$PULL_TEAM_ID" ] || return 1
+}
 
-  line="$(printf '%s\n' "$output" | grep -F -- "rename-team.sh' " | head -1)"
-  [ -n "$line" ] || return 1
-  # Everything up to the first placeholder. `<new-name>` and `<file>` are for
-  # the reader to replace; left in, a shell reads them as redirections and the
-  # parse dies. What must survive a shell is the part that is already complete.
-  eval "set -- ${line%%<*}"
-  [ "$1" = bash ] || return 1
-  [ -f "$2" ] || return 1
-  [ "$3" = clash ] || return 1
+@test "remote pull: a CONNECTED local team is not told to rename itself (#680)" {
+  # Only one of the two states can take the rename route, and which one is
+  # knowable here -- so it is decided here rather than handed over as a caveat.
+  # rename-team.sh is local only: it never reads or writes `remote_binding` and
+  # never tells the server, so renaming a connected team leaves the binding
+  # naming the team the server still knows by the old name.
+  bash "$SCRIPTS/join.sh" clashconn alice claude-code /tmp/project-cc >/dev/null
+  python3 - "$TEST_SKILL_DIR/teams/clashconn/config.json" <<'PY_BIND'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d['remote_binding'] = {'endpoint': 'https://elsewhere.example',
+                       'server_instance_id': '018f3f7e-9999-7000-8000-000000000000',
+                       'remote_team_id': d['team_id'],
+                       'connected_at': '2026-07-30T00:00:00Z',
+                       'disconnected_at': None}
+open(p, 'w').write(json.dumps(d) + '\n')
+PY_BIND
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" clashconn
+  [ "$status" -ne 0 ] || return 1
+  # Captured before anything else runs. `run` overwrites $output, so a second
+  # `run` used to check an ABSENCE would be greping the previous grep's empty
+  # stdout -- and passing for that reason.
+  out="$output"
+
+  # The route that still works is offered.
+  printf '%s\n' "$out" | grep -q -F -- "remote.sh' pull " || return 1
+  # The one that would break their binding is not.
+  run bash -c 'printf "%s\n" "$1" | grep -q "rename-team.sh"' _ "$out"
+  [ "$status" -ne 0 ] || { echo "a connected team was told to rename itself" >&2; return 1; }
+  # And it says why, rather than just going quiet.
+  printf '%s\n' "$out" | grep -q 'it is connected' || return 1
 }
 
 @test "remote pull: the way out survives a team with a space and a quote (#680)" {
@@ -1262,19 +1288,26 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   bash "$SCRIPTS/join.sh" "$qteam" alice claude-code /tmp/project-qc >/dev/null
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" "$qteam"
   [ "$status" -ne 0 ] || return 1
-  line="$(printf '%s\n' "$output" | grep -F -- "remote.sh' pull " | head -1)"
+  out="$output"
+  # The pull route no longer carries the local name -- it deliberately ends in
+  # a placeholder for a FREE one -- so what has to survive a shell there is the
+  # endpoint and the id.
+  line="$(printf '%s\n' "$out" | grep -F -- "remote.sh' pull " | head -1)"
   [ -n "$line" ] || return 1
-  # Everything up to the first placeholder. `<new-name>` and `<file>` are for
-  # the reader to replace; left in, a shell reads them as redirections and the
-  # parse dies. What must survive a shell is the part that is already complete.
+  # Everything up to the first placeholder: `<a-free-local-name>` is for the
+  # reader to replace, and a shell reads it as a redirection.
   eval "set -- ${line%%<*}"
-  [ "$8" = "$qteam" ] || return 1
-  line="$(printf '%s\n' "$output" | grep -F -- "rename-team.sh' " | head -1)"
+  [ "$1" = bash ] || return 1
+  [ -f "$2" ] || return 1
+  [ "$5" = "$ENDPOINT" ] || return 1
+  [ "$7" = "$PULL_TEAM_ID" ] || return 1
+
+  # The rename route is where the awkward name has to come back intact.
+  line="$(printf '%s\n' "$out" | grep -F -- "rename-team.sh' " | head -1)"
   [ -n "$line" ] || return 1
-  # Everything up to the first placeholder. `<new-name>` and `<file>` are for
-  # the reader to replace; left in, a shell reads them as redirections and the
-  # parse dies. What must survive a shell is the part that is already complete.
   eval "set -- ${line%%<*}"
+  [ "$1" = bash ] || return 1
+  [ -f "$2" ] || return 1
   [ "$3" = "$qteam" ] || return 1
 }
 

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -495,15 +495,46 @@ _capability_endpoint() {
   [[ "$output" != *"scripts/remote.sh"*"unlock"* ]]
 }
 
-@test "connect: the out-of-band handoff line is printed by default" {
+@test "connect: the handoff-bundle line is printed by default" {
+  # #668: this named the snapshot pair while `pull` on the other machine asked
+  # for the bundle, so each side named the other's route. It names the bundle
+  # now -- the same artifact pull asks for.
   skip_if_no_age
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"Export the public epoch snapshot"* ]]
-  [[ "$output" == *"out of band"* ]]
+  [ "$status" -eq 0 ] || return 1
+  printf '%s\n' "$output" | grep -q 'secret handoff bundle' || return 1
+  # And no longer sends the reader after the artifact the other side will not
+  # accept. An absence, because both routes still exist in `unlock`: what
+  # changed is which one is advertised, and an advertisement creeping back
+  # would be invisible to a presence check.
+  run bash -c 'printf "%s\n" "$1" | grep -q -- "--snapshot"' _ "$output"
+  [ "$status" -ne 0 ] || return 1
 }
 
-@test "connect: the snapshot export it prints names a key.sh that exists" {
+@test "connect: the handoff line survives a team with a space and a quote" {
+  # The route the operator actually takes, proven the way #667 proved the
+  # others: parse the printed command with a shell and compare argv byte for
+  # byte. A substring cannot tell correct quoting from a line that merely
+  # contains the right words.
+  skip_if_no_age
+  local qteam="it's a team"
+  bash "$SCRIPTS/join.sh" "$qteam" alice claude-code /tmp/project-q >/dev/null
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee "$qteam"
+  [ "$status" -eq 0 ] || return 1
+  line="$(printf '%s\n' "$output" | grep -F -- "key.sh' handoff " | head -1)"
+  [ -n "$line" ] || return 1
+  # Everything up to the first placeholder. `<new-name>` and `<file>` are for
+  # the reader to replace; left in, a shell reads them as redirections and the
+  # parse dies. What must survive a shell is the part that is already complete.
+  eval "set -- ${line%%<*}"
+  [ "$1" = bash ] || return 1
+  [ -f "$2" ] || return 1
+  [ "$3" = handoff ] || return 1
+  [ "$4" = "$qteam" ] || return 1
+  [ "$5" = --out ] || return 1
+}
+
+@test "connect: the handoff export it prints names a key.sh that exists" {
   # The line is the first step of getting a second machine in, and `key.sh` is
   # not on PATH (#667). Existence, not spelling: a path into the wrong install
   # would match any substring check and still not run.
@@ -513,7 +544,7 @@ _capability_endpoint() {
   skip_if_no_age
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam
   [ "$status" -eq 0 ]
-  printf '%s\n' "$output" | grep -q 'Export the public epoch snapshot'
+  printf '%s\n' "$output" | grep -q 'secret handoff bundle'
   path="$(printf '%s\n' "$output" | sed -n "s/.*bash '\([^']*key\.sh\)'.*/\1/p" | head -1)"
   [ -n "$path" ]
   [ -f "$path" ]
@@ -533,8 +564,13 @@ _capability_endpoint() {
   [ "$status" -eq 0 ]
   # The result is still reported -- only the next step is withheld.
   [[ "$output" == *"Connected: team 'testteam'"* ]]
-  [[ "$output" != *"Export the public epoch snapshot"* ]]
-  [[ "$output" != *"out of band"* ]]
+  # The route moved to the handoff bundle (#668); the gate still withholds it.
+  # `grep -q` + status, not `[[ ]]`: a failing `[[ ]]` mid-body is not enforced
+  # on bash 3.2 (#670), and these are the assertions that just moved.
+  run bash -c 'printf "%s\n" "$1" | grep -q "secret handoff bundle"' _ "$output"
+  [ "$status" -ne 0 ] || return 1
+  run bash -c 'printf "%s\n" "$1" | grep -q "key.sh"' _ "$output"
+  [ "$status" -ne 0 ] || return 1
 }
 
 @test "connect: requires the response protocol header" {
@@ -623,10 +659,10 @@ _capability_endpoint() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"Connected: team 'testteam' (age-v1 encrypted)."* ]]
   [[ "$output" == *"Back this up now"* ]]
-  # The command carries its install path and quotes its team now (#667), so the
-  # bare spelling is gone. `grep -q`, not `[[ ]]`: a failing `[[ ]]` mid-body is
-  # not enforced on bash 3.2 (#670), and this assertion is one that just moved.
-  printf '%s\n' "$output" | grep -q -F -- "key.sh' show 'testteam' --snapshot --out <file>"
+  # The route moved from the snapshot pair to the handoff bundle (#668); the
+  # path and quoting it gained in #667 stay. `grep -q`, not `[[ ]]`: a failing
+  # `[[ ]]` mid-body is not enforced on bash 3.2 (#670).
+  printf '%s\n' "$output" | grep -q -F -- "key.sh' handoff 'testteam' --out <file>"
   sync_config="$TEST_SKILL_DIR/db/remote-sync/testteam.json"
   [ -f "$sync_config" ]
   [ "$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$sync_config")') AS TEXT), '\$.cipher_profile');")" = "age-v1" ]
@@ -1172,6 +1208,87 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" legacyteam
   [ "$status" -ne 0 ]
   [[ "$output" == *"already has history"* ]]
+}
+
+@test "remote pull: a same-named different team is refused WITH a way out (#680)" {
+  # The refusal was right and said nothing else. An operator learned that two
+  # things disagreed -- not which, not that their own team was untouched, not
+  # that there are two ways forward.
+  #
+  # A team joined locally mints its own id, so this is the everyday collision:
+  # same name, different team, no history to trip the earlier guard.
+  bash "$SCRIPTS/join.sh" clash alice claude-code /tmp/project-clash >/dev/null
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" clash
+  [ "$status" -ne 0 ] || return 1
+
+  # Both ids, labelled, so the operator can tell which is which.
+  printf '%s\n' "$output" | grep -q 'local id:' || return 1
+  printf '%s\n' "$output" | grep -q -F -- "$PULL_TEAM_ID" || return 1
+  # And that nothing was half-done.
+  printf '%s\n' "$output" | grep -q 'Nothing local was changed' || return 1
+  # The ordering point, which is the one that is expensive to learn late.
+  printf '%s\n' "$output" | grep -q 'does not tell the server' || return 1
+
+  # Both routes are runnable as printed, not merely mentioned.
+  line="$(printf '%s\n' "$output" | grep -F -- "remote.sh' pull " | head -1)"
+  [ -n "$line" ] || return 1
+  # Everything up to the first placeholder. `<new-name>` and `<file>` are for
+  # the reader to replace; left in, a shell reads them as redirections and the
+  # parse dies. What must survive a shell is the part that is already complete.
+  eval "set -- ${line%%<*}"
+  [ "$1" = bash ] || return 1
+  [ -f "$2" ] || return 1
+  [ "$3" = pull ] || return 1
+  [ "$4" = --endpoint ] || return 1
+  [ "$5" = "$ENDPOINT" ] || return 1
+  [ "$6" = --team-id ] || return 1
+  [ "$7" = "$PULL_TEAM_ID" ] || return 1
+  [ "$8" = clash ] || return 1
+
+  line="$(printf '%s\n' "$output" | grep -F -- "rename-team.sh' " | head -1)"
+  [ -n "$line" ] || return 1
+  # Everything up to the first placeholder. `<new-name>` and `<file>` are for
+  # the reader to replace; left in, a shell reads them as redirections and the
+  # parse dies. What must survive a shell is the part that is already complete.
+  eval "set -- ${line%%<*}"
+  [ "$1" = bash ] || return 1
+  [ -f "$2" ] || return 1
+  [ "$3" = clash ] || return 1
+}
+
+@test "remote pull: the way out survives a team with a space and a quote (#680)" {
+  # The printed `pull --team-id` line carries the team name back to a shell.
+  local qteam="it's a clash"
+  bash "$SCRIPTS/join.sh" "$qteam" alice claude-code /tmp/project-qc >/dev/null
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" "$qteam"
+  [ "$status" -ne 0 ] || return 1
+  line="$(printf '%s\n' "$output" | grep -F -- "remote.sh' pull " | head -1)"
+  [ -n "$line" ] || return 1
+  # Everything up to the first placeholder. `<new-name>` and `<file>` are for
+  # the reader to replace; left in, a shell reads them as redirections and the
+  # parse dies. What must survive a shell is the part that is already complete.
+  eval "set -- ${line%%<*}"
+  [ "$8" = "$qteam" ] || return 1
+  line="$(printf '%s\n' "$output" | grep -F -- "rename-team.sh' " | head -1)"
+  [ -n "$line" ] || return 1
+  # Everything up to the first placeholder. `<new-name>` and `<file>` are for
+  # the reader to replace; left in, a shell reads them as redirections and the
+  # parse dies. What must survive a shell is the part that is already complete.
+  eval "set -- ${line%%<*}"
+  [ "$3" = "$qteam" ] || return 1
+}
+
+@test "remote pull: a caller that owns the guidance gets the ids, not the routes" {
+  # Same split as everywhere else: the facts are true however agmsg was
+  # invoked; the routes are this install's.
+  bash "$SCRIPTS/join.sh" clash2 alice claude-code /tmp/project-clash2 >/dev/null
+  AGMSG_OPERATOR_GUIDANCE=caller run bash "$SCRIPTS/remote.sh" pull \
+    --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" clash2
+  [ "$status" -ne 0 ] || return 1
+  printf '%s\n' "$output" | grep -q 'local id:' || return 1
+  printf '%s\n' "$output" | grep -q 'Nothing local was changed' || return 1
+  run bash -c 'printf "%s\n" "$1" | grep -q "Two ways forward"' _ "$output"
+  [ "$status" -ne 0 ] || return 1
 }
 
 @test "remote pull: requires an endpoint, a team id and a local name" {


### PR DESCRIPTION
Same class as #667 and the same file: the program states a problem correctly and stops before the thing the operator needs.

## #668 — each side named the other's route

`connect --e2ee` advertised the snapshot pair while `pull` on the other machine asks for *"the secret handoff bundle you were given"*. An operator following the screens produced the artifact the other end would not take. koit hit this twice today.

It names the bundle now, decided on a measurement rather than a preference:

- the snapshot route needs the private key too, and the only command that hands it over is `key.sh show --reveal-secret`, which **refuses without a TTY** — while the walkthrough that leads here tells the reader to drive it with an agent. That route stops at its second step for the reader it is written for.
- `key.sh handoff` needs no terminal, is one artifact instead of two, and is the one `unlock` gates behind a confirmed digest.

`--snapshot`/`--identity` **stay accepted** by `unlock` — ruled, and right: the tests cover both and I have not established that no other caller uses them. Only the advertising changed.

**Every place that advertises it was derived, not recalled.** `SKILL.md` and the nine driver templates already say *"advanced form … when explicitly requested"*, `README` names it nowhere, and both walkthroughs (en and ja) were already bundle-only. `connect` was the one site.

## #680 — refuses correctly, says nothing else

`pull` now prints both ids labelled, that nothing local was changed, and the two ways forward: `--team-id` when the name matched the wrong team, or rename the local one **before** connecting when both are real. The endpoint is threaded in so the printed `pull --team-id` line is complete rather than a template.

### The ordering warning is not the one that was asked for

*"Renaming after connecting rewrites history rows across five tables"* describes `rename.sh` — **member** rename: `events`, `messages`, `read_cursors`, `sync_read_aliases`, `sync_read_members`. `rename-team.sh` is a different command: `messages` plus whichever of ten sync tables exist. Neither is five, so that sentence is not printed.

What is printed is the reason the ordering actually matters, measured:

```
grep 'remote_binding|remote_team_name|endpoint|server' scripts/rename-team.sh  ->  0
```

It never reads or writes the binding and never tells the server, so a team renamed after it is connected keeps a binding naming the team the server still knows by the old name. (pm agreed and withdrew the five-table basis.)

Facts on both screens, routes only when `agmsg_operator_guidance_is_ours` — the ids and "nothing was changed" are true however agmsg was invoked.

## The new lines are held to #667's standard

Parsed with a shell, argv compared byte for byte, against teams named `it's a team` and `it's a clash`. One wrinkle: a line ending in `<new-name>` or `<file>` is a **redirection** to a shell, so the parse takes everything up to the first placeholder — the part that must already be complete.

## Mutations

```
connect advertises the snapshot again      2 red
the ordering warning removed               1 red
the endpoint stops reaching the refusal    2 red
```

Three assertions elsewhere pinned the old snapshot line and moved with it.

Every test file invoking `remote.sh` or `key.sh`, derived by grep: `test_key`, `test_printed_command_paths`, `test_remote`, `test_remote_forget`, `test_remote_status_liveness`, `test_team_list`. No failures under bash 5.

Closes #668
Closes #680
