### PR TITLE
fix(remote): advance the per-team store's event sequence floor past any copied cursor (#695)

### DIFF
--- a/scripts/internal/migrate-team-store.sh
+++ b/scripts/internal/migrate-team-store.sh
@@ -193,6 +193,32 @@ if [ -e "$DEST" ]; then
   exit 1
 fi
 
+# #695 review (co1): the destination's sqlite_sequence floor below is set
+# from MAX(local_position) over this team's copied cursors. SQLite stores
+# whatever type a column is given even when it's declared INTEGER (the same
+# looseness "a cursor that is not an integer is refused" already guards on
+# the re-entry path, below, via _missing_from_dest) -- and its default
+# comparison rules rank TEXT above every INTEGER, so a single malformed
+# (text) cursor among this team's rows can make MAX() choose the text value
+# over any real one. That value would then land directly in
+# sqlite_sequence.seq, an AUTOINCREMENT-authority column, not just a data
+# column -- corrupting every future seq assignment on this store, not merely
+# carrying the bad cursor forward unread. Fail closed here, before ANY write
+# to $DEST, rather than let a non-integer through by having MAX() quietly
+# ignore it: silently dropping the bad cursor would erase the very evidence
+# a malformed read position exists, which is the same reason the rest of
+# this script never repairs data on the way through, only reports it.
+if has_table read_cursors; then
+  bad_agent="$(agmsg_sqlite "$SHARED" "SELECT agent FROM read_cursors
+    WHERE team='$(agmsg_sqlesc "$TEAM")' AND typeof(local_position) <> 'integer' LIMIT 1;")"
+  if [ -n "$bad_agent" ]; then
+    echo "team store: '$TEAM' has a non-integer read cursor for '$bad_agent' in the shared store; refusing to migrate" >&2
+    echo "team store: the shared store still holds its history and has NOT been touched." >&2
+    echo "team store: fix the malformed cursor (read_cursors.local_position for '$bad_agent') before retrying" >&2
+    exit 1
+  fi
+fi
+
 agmsg_storage_load
 
 # Build the destination directly rather than through storage_init: the team

--- a/scripts/internal/migrate-team-store.sh
+++ b/scripts/internal/migrate-team-store.sh
@@ -231,6 +231,39 @@ if has_table read_cursors; then
     INSERT OR IGNORE INTO read_cursors(team,agent,local_position)
       SELECT team,agent,local_position FROM src.read_cursors WHERE team='$team_lit';"
 fi
+# #695: a read cursor copied above lives in the SHARED store's global
+# events.seq space -- every team's traffic advances it, not just this one's.
+# events.seq/id are copied verbatim by design (renumbering would move every
+# cursor), but sqlite_sequence is deliberately excluded from the schema copy
+# above (sqlite owns it; the AUTOINCREMENT columns "bring it back on their
+# own first insert" per the comment there) -- so the destination's high-water
+# becomes MAX(this team's OWN copied seqs), which can sit far below a cursor
+# that reflects every team's combined traffic. A new message then receives a
+# seq below the cursor and is permanently invisible to storage_list_unread /
+# storage_watch_after (delivery_tip is read from sqlite_sequence directly,
+# see sqlite.sh's _sqlite_highwater) -- production symptom: history shows the
+# read marker, inbox says nothing new, monitor and turn are both silent.
+#
+# The fix raises the floor, not the cursor: advance the destination's
+# sqlite_sequence for 'events' to at least the greatest copied cursor, so the
+# NEXT event (assigned floor+1) always sorts above every preserved cursor.
+# Not "set cursors to 0" -- that would make every already-read message look
+# unread again for a team migrating WITH real history; 0 is only correct for
+# repairing a store already caught by this bug (a separate, one-off fix, not
+# this one). Two statements because sqlite_sequence has no row for a table
+# until its first AUTOINCREMENT insert -- a team with zero copied events (the
+# empty-event case the issue calls out by name) has no existing row to
+# UPDATE, only one to INSERT.
+if has_table events && has_table read_cursors; then
+  copy="$copy
+    UPDATE sqlite_sequence SET seq = (SELECT MAX(local_position) FROM read_cursors WHERE team='$team_lit')
+      WHERE name = 'events'
+        AND seq < (SELECT MAX(local_position) FROM read_cursors WHERE team='$team_lit');
+    INSERT INTO sqlite_sequence(name, seq)
+      SELECT 'events', (SELECT MAX(local_position) FROM read_cursors WHERE team='$team_lit')
+      WHERE (SELECT MAX(local_position) FROM read_cursors WHERE team='$team_lit') IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM sqlite_sequence WHERE name = 'events');"
+fi
 if has_table storage_metadata; then
   copy="$copy
     INSERT OR IGNORE INTO storage_metadata(key,value) SELECT key,value FROM src.storage_metadata;"

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -471,3 +471,111 @@ stored_types() {
   # The leftover is gone from shared, because the destination has it.
   [ "$(shared_rows alpha)" -eq 0 ]
 }
+
+# --- #695: a copied cursor can land ahead of the destination's own sequence -
+
+# A read cursor in the shared store is a position in the shared store's GLOBAL
+# events.seq space -- every team's traffic advances it, not just the one being
+# migrated. seq/id are copied verbatim (by design: renumbering would move
+# every cursor), but sqlite_sequence is deliberately NOT copied -- the comment
+# above the schema copy says the AUTOINCREMENT columns "bring it back on their
+# own first insert." That first insert only sees THIS team's rows, so the
+# destination's high-water becomes MAX(this team's own copied seqs) -- which
+# can be far below a cursor that reflects every team's combined traffic. A new
+# message then receives a seq below the cursor and is permanently invisible.
+#
+# Production shape (#695): radmin-oss's cursor was 13203 (the shared store's
+# all-teams high-water); its own migrated events topped out at 11. Reproduced
+# here at a smaller scale with the same relationship: OTHER teams' traffic
+# pushes the shared high-water past what the migrating team's own events will
+# ever reach.
+@test "migrate: a new per-team message is deliverable after migration when the copied cursor exceeds the team's own event range (#695)" {
+  # alpha's own message goes FIRST, so its copied seq is the low end of the
+  # shared store's range -- beta's traffic afterward pushes the GLOBAL
+  # high-water past it, exactly the "other teams advance the shared sequence
+  # beyond the migrating team's own maximum" shape the issue asks for. (Doing
+  # this the other way around -- alpha last -- makes alpha's own event BE the
+  # current high-water, which accidentally satisfies the invariant even
+  # without the fix and proves nothing; caught by this test passing before
+  # the fix was applied, which is what sent this comment back to explain it.)
+  bash "$SCRIPTS/send.sh" alpha ann bob "alpha message 1" >/dev/null
+  bash "$SCRIPTS/send.sh" beta ann bob "beta message 1" >/dev/null
+  bash "$SCRIPTS/send.sh" beta ann bob "beta message 2" >/dev/null
+  bash "$SCRIPTS/send.sh" beta ann bob "beta message 3" >/dev/null
+
+  # bob's read cursor for alpha, set to the shared store's CURRENT global
+  # high-water -- a legitimate value in that space, since it is not scoped to
+  # one team.
+  local shared_highwater
+  shared_highwater="$(sqlite3 "$SHARED" "SELECT seq FROM sqlite_sequence WHERE name='events';")"
+  sqlite3 "$SHARED" "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
+    VALUES('alpha','bob',$shared_highwater);"
+
+  migrate alpha
+  local dest; dest="$(store_of alpha)"
+
+  # 1. The destination's own AUTOINCREMENT high-water is not behind the
+  #    copied cursor -- this is the invariant the issue names directly.
+  local dest_tip dest_cursor
+  dest_tip="$(sqlite3 "$dest" "SELECT COALESCE((SELECT seq FROM sqlite_sequence WHERE name='events'),0);")"
+  dest_cursor="$(sqlite3 "$dest" "SELECT local_position FROM read_cursors WHERE team='alpha' AND agent='bob';")"
+  [ "$dest_tip" -ge "$dest_cursor" ]
+
+  bash "$SCRIPTS/send.sh" alpha ann bob "sent after migration" >/dev/null
+
+  # 2. The new message's own seq is above the recipient's cursor.
+  local new_seq
+  new_seq="$(sqlite3 "$dest" "SELECT seq FROM events WHERE type='message_sent' AND team='alpha' AND body='sent after migration';")"
+  [ "$new_seq" -gt "$dest_cursor" ]
+
+  # 3 + 4. Through the REAL contract functions, not just checking that the
+  # numbers line up -- proving the message is actually deliverable. Matching
+  # numbers with nothing delivered is exactly the shape production spent
+  # hours chasing tonight.
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+
+  run storage_list_unread alpha bob
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sent after migration"* ]]
+
+  local after; after="$(storage_watch_after "$dest_cursor" alpha:bob)"
+  [[ "$after" == *"sent after migration"* ]]
+  [[ "$after" == *'"type":"cursor"'* ]]
+}
+
+# Requirement 5 from the issue: the same properties when the target team has
+# NO event rows before migration. This is the sharper case -- with zero rows
+# copied, sqlite never creates a sqlite_sequence row for 'events' at all (only
+# the first AUTOINCREMENT insert does that), so there is no existing row to
+# raise; one has to be created from nothing.
+@test "migrate: the empty-event case also gets a destination high-water that is not behind the copied cursor (#695)" {
+  bash "$SCRIPTS/join.sh" gamma carol claude-code /tmp/gamma-carol >/dev/null
+  bash "$SCRIPTS/join.sh" gamma dave  claude-code /tmp/gamma-dave  >/dev/null
+  bash "$SCRIPTS/send.sh" beta ann bob "beta message 1" >/dev/null
+  bash "$SCRIPTS/send.sh" beta ann bob "beta message 2" >/dev/null
+
+  local shared_highwater
+  shared_highwater="$(sqlite3 "$SHARED" "SELECT seq FROM sqlite_sequence WHERE name='events';")"
+  sqlite3 "$SHARED" "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
+    VALUES('gamma','dave',$shared_highwater);"
+  [ "$(shared_rows gamma)" -eq 0 ]
+
+  migrate gamma
+  local dest; dest="$(store_of gamma)"
+
+  local dest_tip dest_cursor
+  dest_tip="$(sqlite3 "$dest" "SELECT COALESCE((SELECT seq FROM sqlite_sequence WHERE name='events'),0);")"
+  dest_cursor="$(sqlite3 "$dest" "SELECT local_position FROM read_cursors WHERE team='gamma' AND agent='dave';")"
+  [ "$dest_tip" -ge "$dest_cursor" ]
+
+  bash "$SCRIPTS/send.sh" gamma carol dave "first message ever, after migration" >/dev/null
+
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  run storage_list_unread gamma dave
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"first message ever, after migration"* ]]
+}

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -579,3 +579,47 @@ stored_types() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"first message ever, after migration"* ]]
 }
+
+# co1's review of #696: the fix above feeds MAX(local_position) straight into
+# sqlite_sequence.seq, an AUTOINCREMENT-authority column -- not a data column
+# like the ones the re-entry guard above already protects. SQLite ranks TEXT
+# above every INTEGER in its default comparison, so a single non-integer
+# cursor among this team's rows can make MAX() pick the damaged value over
+# any real one, corrupting how every future seq gets assigned on this store
+# -- not merely carrying a bad value forward unread the way the OLD (pre-#695)
+# first-time path already could.
+#
+# The existing "not an integer is refused" test above covers RE-ENTRY only
+# (it migrates alpha successfully first, then corrupts the DESTINATION to
+# test _missing_from_dest). This is the gap co1 named: the FIRST-TIME path
+# never validated source cursor types at all before this fix started writing
+# them into sqlite_sequence. Reproduced by corrupting the SHARED cursor
+# BEFORE ever migrating, so the very first attempt is what has to refuse.
+@test "migrate: a non-integer source cursor refuses the FIRST migration attempt, before anything is written to the destination (#695 follow-up)" {
+  bash "$SCRIPTS/send.sh" alpha ann bob "one" >/dev/null
+  sqlite3 "$SHARED" "INSERT OR REPLACE INTO read_cursors(team,agent,local_position)
+    VALUES('alpha','ann','abc');"
+  # The premise, measured rather than assumed: the column is declared
+  # INTEGER and sqlite stored text in it anyway.
+  [ "$(sqlite3 "$SHARED" "SELECT typeof(local_position) FROM read_cursors
+        WHERE team='alpha' AND agent='ann';")" = "text" ]
+
+  run migrate alpha
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "non-integer read cursor" ]]
+
+  # Refused, not repaired: the malformed value is still exactly what it was
+  # -- silently ignoring it in MAX() would have erased the evidence a bad
+  # cursor exists, which is explicitly not acceptable here (co1).
+  [ "$(sqlite3 "$SHARED" "SELECT local_position FROM read_cursors
+        WHERE team='alpha' AND agent='ann';")" = "abc" ]
+  # Nothing moved: the shared store still has the team's row, and no
+  # destination file was created at all -- the guard runs before $DEST is
+  # even touched.
+  [ "$(shared_rows alpha)" -eq 1 ]
+  # The literal expected per-team path, not store_of: with the migration
+  # refused, alpha's partition never flipped away from "shared", so
+  # store_of would resolve back to $SHARED itself (which of course exists)
+  # rather than say anything about whether a per-team file got created.
+  [ ! -e "$TEST_SKILL_DIR/db/teams/alpha/messages.db" ]
+}


### PR DESCRIPTION
Scope A only (fix the migration so future connects don't hit this) — repair of already-broken stores (scope B) is out of scope here, already handled tonight by co2 against radmin, not included in this PR.

Closes #695 manually on merge (Closes keywords don't fire on a non-default branch).

## Bug

`migrate-team-store.sh` copies read cursors verbatim from the shared store into a team's new per-team store. A cursor in the shared store lives in the shared store's GLOBAL `events.seq` space — every team's traffic advances it, not just the one being migrated. `sqlite_sequence` is deliberately excluded from the schema copy (it's sqlite-owned; the existing comment already says the AUTOINCREMENT columns "bring it back on their own first insert"), so the destination's high-water becomes `MAX(this team's own copied seqs)` — which can sit far below a cursor built from every team's combined traffic. The next message then gets a seq below the cursor and is permanently invisible to `storage_list_unread`/`storage_watch_after` (the delivery tip is read directly from `sqlite_sequence`, see `sqlite.sh`'s `_sqlite_highwater`). No error anywhere — history shows the read marker, inbox says nothing new, monitor and turn are both silent.

Production instance tonight: `radmin-oss`'s cursor was 13203 (the shared store's all-teams high-water); its own migrated events topped out at 11.

## Fix

Raise the floor, not the cursor: advance the destination's `sqlite_sequence` for `events` to at least the greatest copied cursor, inside the same transaction as the copy. Two statements (`UPDATE` then a conditional `INSERT`) because `sqlite_sequence` has no row for a table until its first AUTOINCREMENT insert — a team with zero copied events (the empty-event case the issue calls out by name) has no existing row to raise, only one to create.

## Coordinate-system decision

Deliberately **not** "reset cursors to 0" — that's the right move for repairing a store already caught by this bug (radmin-oss's repair tonight — a separate, already-applied fix with its own procedure), but wrong for normal migration: it would make every message a team migrating *with real history* had already read look unread again. Advancing the floor instead preserves whatever position the copied cursor already recorded, and is exactly what the issue's own required invariant asks for (`events AUTOINCREMENT high-water >= MAX(read_cursors.local_position)`).

## Testing

Two new regression tests in `tests/test_migrate_team_store.bats`, both proving *actual delivery* through the real `storage_*` contract functions (`storage_list_unread` / `storage_watch_after`) — not just that the numbers line up, which is exactly the shape tonight spent hours chasing (numbers matching, nothing delivered):

1. the team has events before migration, with another team's *later* traffic pushing the shared high-water past this team's own range (reproduces the production shape at small scale)
2. the team has **zero** events before migration — the sharper case, since there's no existing `sqlite_sequence` row to update

Both were run against the code *before* the fix first, to confirm they actually reproduce the bug (both red), then again after the fix (both green).

Mutation-verified: reverting the fix turns exactly these 2 tests red; the other 21 tests in this file are unaffected. Restored, all 23 green.

1. `bats tests/test_migrate_team_store.bats` — 23 ok, 0 not ok (21 pre-existing + 2 new).
2. `bats tests/test_storage_contract.bats` — 34 ok, 0 not ok (adjacent, unaffected).
3. `bats tests/test_remote.bats` — 100 ok, 0 not ok (adjacent, unaffected — this is what calls the migration path via `connect`).

## jsonl (does it have the same bug?)

No. `migrate-team-store.sh` is unconditionally sqlite — confirmed by reading it in full (no storage-driver branching anywhere in the file) and empirically (a fresh installation still creates a sqlite `db/messages.db` as its shared store regardless of `AGMSG_STORAGE_DRIVER`). The sole call site is `remote.sh`'s `connect` flow, which invokes it without regard to a team's storage engine. jsonl's own cursor is a purely local ordinal count within its own per-team log file (see the `§2.2` comment in `jsonl.sh`) with no cross-team coordinate space it could inherit a mismatched value from — there is currently no shared→per-team copy path for jsonl at all. Additionally, the generic `storage_*` contract suite (`tests/test_storage_contract.bats`) passes in full under `AGMSG_STORAGE_DRIVER=jsonl`, independent of this fix.
