### PR TITLE
fix(delivery): let the watcher say what it is doing, and stop the fallback standing down

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -54,8 +54,8 @@ if echo "$INPUT" | grep -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true' 2>/
   exit 0
 fi
 
-# Defer to the monitor watcher when one is alive for this session.
-# Avoids double-delivery when delivery.mode = both. The session id field name
+# The session id is still resolved: the actas-ownership check further down
+# needs it. Only the deferral that used to follow it is gone. The field name
 # differs by vendor: Claude Code emits snake_case "session_id"; Grok Build (and
 # Cursor) emit camelCase "sessionId". Try snake first (claude-code unaffected),
 # then camel, then the GROK_SESSION_ID env Grok injects into every hook.
@@ -66,23 +66,37 @@ SESSION_ID=$(printf '%s' "$INPUT" \
   | sed -n 's/.*"sessionId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
   | head -1)
 [ -z "$SESSION_ID" ] && SESSION_ID="${GROK_SESSION_ID:-}"
-if [ -n "$SESSION_ID" ]; then
-  # The monitor watcher keys its pidfile (and its actas owner, below) on the
-  # per-process instance id (#93), not the bare session_id. Normalize to the
-  # same token so this Stop-hook defers to a live watcher in `both` mode instead
-  # of double-delivering.
-  SESSION_ID="$(agmsg_normalize_instance_id "$SESSION_ID" "$TYPE")"
-  PIDFILE="$SKILL_DIR/run/watch.$SESSION_ID.pid"
-  if [ -f "$PIDFILE" ]; then
-    WATCH_PID=$(cat "$PIDFILE" 2>/dev/null || true)
-    # _agmsg_pid_alive_local: EPERM-aware, so a sandbox-unsignalable watcher is
-    # still alive -- and it does not ask tasklist, which cannot see a pid watch.sh
-    # minted from its own $$ (#567).
-    if [ -n "$WATCH_PID" ] && _agmsg_pid_alive_local "$WATCH_PID"; then
-      exit 0
-    fi
-  fi
-fi
+# Normalized to the per-process instance id (#93), which is the token the
+# actas owner file is keyed on.
+[ -n "$SESSION_ID" ] && SESSION_ID="$(agmsg_normalize_instance_id "$SESSION_ID" "$TYPE")"
+
+# No deferral to a live watcher (#694).
+#
+# This used to exit here whenever a watcher process was alive for this session,
+# to avoid double delivery in `both` mode. The condition was LIVENESS, and the
+# failure `both` exists for preserves liveness exactly: a watcher that is alive
+# and delivering nothing. So the one mode advertised as a safety net stood down
+# in front of the one situation it was wanted for. On 2026-08-08 a session with
+# a broken watcher was switched to `both` to recover delivery and nothing
+# changed; what worked was `mode turn`, which stops the watcher, which removes
+# the liveness signal, which lets this hook run.
+#
+# Removing it does not double-deliver, and that is measured rather than
+# assumed. Both sides consume through the same state:
+#
+#   watcher      storage_read_cursor_consume -> inserts a `message_read` event
+#                per delivered id AND advances read_cursors.local_position
+#   this hook    storage_list_unread -> excludes rows at or below that cursor
+#                AND rows with a `message_read` event
+#
+# So a message the watcher has emitted is not offered here. The remaining
+# window is an interleave: this hook SELECTs, the watcher emits and consumes
+# the same row, then this hook marks it read. Bounded by one poll interval, and
+# the trade is explicit -- a rare duplicate line against a mode that silently
+# delivered nothing at all.
+#
+# Deferral was an optimisation, not a correctness requirement. The read state
+# is the correctness requirement, and it was already there.
 
 # Identify agent and teams
 WHOAMI=$("$SCRIPT_DIR/whoami.sh" "$PROJECT" "$TYPE")

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -145,6 +145,22 @@ compat_uuid7() {
     "${hex:0:8}" "${hex:8:4}" "${rnd:0:3}" "${rnd:3:3}" "${rnd:6:12}"
 }
 
+# Get file size in bytes.
+# Replaces: stat -f %z (macOS) / stat -c %s (Linux/MSYS2)
+#
+# Same split as compat_file_mtime below, and added for the same kind of caller:
+# a bounded log has to know when to rotate, and `wc -c` on a file being
+# appended to is a second read of the whole thing.
+compat_file_size() {
+  local file="$1"
+  [ -z "$file" ] && return 1
+  _agmsg_detect_platform
+  case "$_agmsg_platform" in
+    macos)  stat -f %z "$file" 2>/dev/null ;;
+    *)      stat -c %s "$file" 2>/dev/null ;;
+  esac
+}
+
 # Get file modification time as epoch seconds.
 # Replaces: stat -f %m (macOS) / stat -c %Y (Linux/MSYS2)
 compat_file_mtime() {

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -108,10 +108,23 @@ LOGFILE="$RUN_DIR/watch.$SESSION_ID.log"
 # Beside the pidfile, because this process already owns that directory and the
 # pair is what a reader wants: which pid, and what it thought it was doing.
 #
-# Bounded by rotation at a fixed size, one generation kept. An unbounded log in
-# a directory nobody prunes is its own defect; two files with a known ceiling
-# can be left alone. Rotation happens before the write, so the cap holds even
-# if this is the last line the process ever emits.
+# Bounded by rotation, one generation kept: an unbounded log in a directory
+# nobody prunes is its own defect. The ceiling is stated exactly, because the
+# first version claimed one it did not deliver -- it compared the size BEFORE
+# the write, so a live log at cap-1 could take one more line and end over the
+# cap, and a live log already past the cap was moved to `.1` still oversized.
+#
+# The decision includes the bytes about to be written, so:
+#
+#   live file    never exceeds cap, EXCEPT when one record is itself larger
+#                than cap -- then the file is exactly that record, because
+#                rotating first and writing it whole is better than dropping
+#                the one line someone is looking for.
+#   `.1`         a former live file, so bounded the same way.
+#   on disk      at most 2 x max(cap, longest single record).
+#
+# A record here is one diagnostic line with a timestamp and a pid; the longest
+# realistic one is a few hundred bytes against a 128 KiB default.
 #
 # Still echoed to stderr: when someone runs watch.sh by hand, stderr IS the
 # place they are looking, and losing that to make the file work would trade one
@@ -122,19 +135,23 @@ WATCH_LOG_MAX_BYTES="${AGMSG_WATCH_LOG_MAX_BYTES:-131072}"
 NO_STORE_REPORTED=""
 
 watch_log() {
-  local msg="$*" size=""
+  local msg="$*" record size=0
   printf 'agmsg watch: %s\n' "$msg" >&2
   mkdir -p "$RUN_DIR" 2>/dev/null || return 0
+  # Built first, so the rotation decision can weigh what is actually going to
+  # be appended rather than only what is already there.
+  record="$(printf '%s [%s] %s' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$$" "$msg")"
   if [ -f "$LOGFILE" ]; then
     size="$(compat_file_size "$LOGFILE" 2>/dev/null || echo 0)"
     case "$size" in ''|*[!0-9]*) size=0 ;; esac
-    if [ "$size" -ge "$WATCH_LOG_MAX_BYTES" ]; then
+    # +1 for the newline. Rotate when this write WOULD cross the cap, not once
+    # it already has.
+    if [ "$(( size + ${#record} + 1 ))" -gt "$WATCH_LOG_MAX_BYTES" ]; then
       mv -f "$LOGFILE" "$LOGFILE.1" 2>/dev/null || true
     fi
   fi
   # Never fatal: a sandbox that cannot write here must not take delivery down.
-  printf '%s [%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$$" "$msg" \
-    >> "$LOGFILE" 2>/dev/null || true
+  printf '%s\n' "$record" >> "$LOGFILE" 2>/dev/null || true
 }
 
 # Resolve poll interval. Env var wins over config, default 5s.

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -93,6 +93,49 @@ SESSION_ID="$(agmsg_normalize_instance_id "$SESSION_ID" "$AGENT_TYPE")"
 
 RUN_DIR="$SKILL_DIR/run"
 PIDFILE="$RUN_DIR/watch.$SESSION_ID.pid"
+LOGFILE="$RUN_DIR/watch.$SESSION_ID.log"
+
+# Everything this process has to say, somewhere a person can read afterwards.
+#
+# stderr alone was not that place (#691). In the configuration this actually
+# runs in, fd2 is /dev/null: the watcher's fd1 is the socket to its session and
+# its fd2 goes nowhere. So every message explaining an otherwise invisible
+# state -- roles skipped, a claim refused, the reason a watcher stopped -- was
+# written to a file descriptor with no reader. A delivery investigation then
+# has to reconstruct from process tables and database state what the one
+# component that knew was unable to say.
+#
+# Beside the pidfile, because this process already owns that directory and the
+# pair is what a reader wants: which pid, and what it thought it was doing.
+#
+# Bounded by rotation at a fixed size, one generation kept. An unbounded log in
+# a directory nobody prunes is its own defect; two files with a known ceiling
+# can be left alone. Rotation happens before the write, so the cap holds even
+# if this is the last line the process ever emits.
+#
+# Still echoed to stderr: when someone runs watch.sh by hand, stderr IS the
+# place they are looking, and losing that to make the file work would trade one
+# silence for another.
+WATCH_LOG_MAX_BYTES="${AGMSG_WATCH_LOG_MAX_BYTES:-131072}"
+
+# Pairs already reported as storeless, so the notice is once per process.
+NO_STORE_REPORTED=""
+
+watch_log() {
+  local msg="$*" size=""
+  printf 'agmsg watch: %s\n' "$msg" >&2
+  mkdir -p "$RUN_DIR" 2>/dev/null || return 0
+  if [ -f "$LOGFILE" ]; then
+    size="$(compat_file_size "$LOGFILE" 2>/dev/null || echo 0)"
+    case "$size" in ''|*[!0-9]*) size=0 ;; esac
+    if [ "$size" -ge "$WATCH_LOG_MAX_BYTES" ]; then
+      mv -f "$LOGFILE" "$LOGFILE.1" 2>/dev/null || true
+    fi
+  fi
+  # Never fatal: a sandbox that cannot write here must not take delivery down.
+  printf '%s [%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$$" "$msg" \
+    >> "$LOGFILE" 2>/dev/null || true
+}
 
 # Resolve poll interval. Env var wins over config, default 5s.
 INTERVAL="${AGMSG_WATCH_INTERVAL:-}"
@@ -317,6 +360,14 @@ while true; do
   # _agmsg_pid_alive). Gated on a composite id only: a bare id (degraded, no
   # resolved agent pid) keeps the prior behavior and is not liveness-gated.
   if agmsg_instance_is_composite "$SESSION_ID" && ! agmsg_instance_alive "$SESSION_ID"; then
+    # Say which condition fired and which token it decided about (#692). The
+    # guard is right; the silence is what costs. A watcher that stops here, one
+    # that was killed, one that crashed early and one that was never started
+    # were four indistinguishable states -- and a test watcher launched with a
+    # session id that does not resolve hits this immediately, so the test then
+    # runs against no watcher at all while looking exactly like one that did.
+    # That happened twice in one investigation before anyone noticed.
+    watch_log "session $SESSION_ID is no longer alive; stopping."
     exit 0
   fi
   while IFS=$'\t' read -r pair_team pair_agent; do
@@ -345,9 +396,9 @@ while true; do
           # it. Stop -- and say so: stderr is the only place a reason survives,
           # and a watcher that ends without one is indistinguishable from one
           # that crashed.
-          echo "agmsg watch: ${pair_team}/${pair_agent} is now held by session ${pair_state#other:}." >&2
-          echo "agmsg watch: this watcher no longer owns that role and is stopping." >&2
-          echo "agmsg watch: messages for it stay unread and reach the session that claimed it." >&2
+          watch_log "${pair_team}/${pair_agent} is now held by session ${pair_state#other:}."
+          watch_log "this watcher no longer owns that role and is stopping."
+          watch_log "messages for it stay unread and reach the session that claimed it."
           exit 0
         fi
         # Broad subscription: this watcher serves other roles too, so skip the
@@ -384,7 +435,19 @@ while true; do
     # Per team: with a store per team, "one team has no store yet" is a
     # normal state, and a single check outside this loop would silence
     # delivery for every OTHER team as well.
-    storage_store_exists "$pair_team" || continue
+    # Skipped, and said once. The same "stop quietly" shape as the guard above
+    # (#692): a team with no store yet is a normal state, but a team that
+    # silently stops being delivered every cycle is not distinguishable from
+    # one that is fine. Once per pair per process -- a line every poll interval
+    # would bury the log this exists to make readable.
+    if ! storage_store_exists "$pair_team"; then
+      case " $NO_STORE_REPORTED " in
+        *" $pair_team:$pair_agent "*) ;;
+        *) NO_STORE_REPORTED="$NO_STORE_REPORTED $pair_team:$pair_agent"
+           watch_log "${pair_team}/${pair_agent}: no store yet; skipping this pair until one exists." ;;
+      esac
+      continue
+    fi
     READ_CURSOR="$(storage_read_cursor_get "$pair_team" "$pair_agent" 2>/dev/null || true)"
     [ -n "$READ_CURSOR" ] || READ_CURSOR=0
     OUT="$(storage_watch_after "$READ_CURSOR" "$pair_team:$pair_agent" 2>/dev/null || true)"
@@ -458,7 +521,7 @@ while true; do
       if [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then
         tmux kill-pane -t "$TMUX_PANE" 2>/dev/null || true
       else
-        echo "agmsg watch: despawned '$DESPAWN_TARGET' (role dropped); close this window manually" >&2
+        watch_log "despawned '$DESPAWN_TARGET' (role dropped); close this window manually"
       fi
       exit 0
     fi

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -130,13 +130,22 @@ LOGFILE="$RUN_DIR/watch.$SESSION_ID.log"
 # place they are looking, and losing that to make the file work would trade one
 # silence for another.
 WATCH_LOG_MAX_BYTES="${AGMSG_WATCH_LOG_MAX_BYTES:-131072}"
-# Normalized the way INTERVAL above is, and for a sharper reason: this value
-# reaches `$(( ))`, and under `set -u` a non-numeric like `oops` is read there
-# as a variable name and can take down the watcher. Killing delivery over a
-# mistyped log cap is the opposite of what this whole change is for. Anything
-# that is not a positive integer -- empty, words, 0, negative -- becomes the
-# default, so a misconfigured cap degrades to the shipped one rather than to
-# no watcher.
+# Normalized the way INTERVAL above is. What an un-normalized value costs was
+# measured rather than assumed, because the first version of this comment named
+# a failure that does not happen here: the value never enters `$(( ))`, so it
+# cannot be read as a variable name, and this script sets `-u` but not `-e`, so
+# nothing dies.
+#
+# It reaches the right-hand side of `[ ... -gt "$WATCH_LOG_MAX_BYTES" ]`. A
+# word there makes the test error non-fatally and read as false, forever, so
+# rotation simply never fires and the log grows unbounded -- the one property
+# this design was chosen for. A cap of `0` is the opposite failure: every
+# record is over it, so each one rotates and throws the previous generation
+# away, which is the diagnostics this exists to keep.
+#
+# Anything that is not a positive integer -- empty, words, 0, negative --
+# becomes the default, so a misconfigured cap degrades to the shipped bound
+# rather than to no bound or to a one-line window.
 case "$WATCH_LOG_MAX_BYTES" in
   ''|*[!0-9]*) WATCH_LOG_MAX_BYTES=131072 ;;
   *) [ "$WATCH_LOG_MAX_BYTES" -gt 0 ] || WATCH_LOG_MAX_BYTES=131072 ;;

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -130,6 +130,17 @@ LOGFILE="$RUN_DIR/watch.$SESSION_ID.log"
 # place they are looking, and losing that to make the file work would trade one
 # silence for another.
 WATCH_LOG_MAX_BYTES="${AGMSG_WATCH_LOG_MAX_BYTES:-131072}"
+# Normalized the way INTERVAL above is, and for a sharper reason: this value
+# reaches `$(( ))`, and under `set -u` a non-numeric like `oops` is read there
+# as a variable name and can take down the watcher. Killing delivery over a
+# mistyped log cap is the opposite of what this whole change is for. Anything
+# that is not a positive integer -- empty, words, 0, negative -- becomes the
+# default, so a misconfigured cap degrades to the shipped one rather than to
+# no watcher.
+case "$WATCH_LOG_MAX_BYTES" in
+  ''|*[!0-9]*) WATCH_LOG_MAX_BYTES=131072 ;;
+  *) [ "$WATCH_LOG_MAX_BYTES" -gt 0 ] || WATCH_LOG_MAX_BYTES=131072 ;;
+esac
 
 # Pairs already reported as storeless, so the notice is once per process.
 NO_STORE_REPORTED=""
@@ -154,8 +165,13 @@ watch_log() {
     # character-count check and lands over the byte cap, which is the contract
     # this rotation exists to hold. One extra process per diagnostic is nothing:
     # these are emitted a handful of times per watcher, not per poll.
-    bytes="$(printf '%s' "$record" | wc -c | tr -d '[:space:]')"
-    case "$bytes" in ''|*[!0-9]*) bytes=${#record} ;; esac
+    bytes="$(printf '%s' "$record" | wc -c | tr -d '[:space:]' 2>/dev/null)"
+    # If the byte count cannot be had, rotate rather than guess. Falling back
+    # to `${#record}` would reinstate the character count this just replaced --
+    # the exact wrong unit, and fail-OPEN: the bound would quietly stop holding
+    # whenever `wc` is missing or answers oddly. Rotating costs one early
+    # generation; the diagnostic itself is still written whole below.
+    case "$bytes" in ''|*[!0-9]*) bytes="$WATCH_LOG_MAX_BYTES" ;; esac
     if [ "$(( size + bytes + 1 ))" -gt "$WATCH_LOG_MAX_BYTES" ]; then
       mv -f "$LOGFILE" "$LOGFILE.1" 2>/dev/null || true
     fi

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -135,7 +135,7 @@ WATCH_LOG_MAX_BYTES="${AGMSG_WATCH_LOG_MAX_BYTES:-131072}"
 NO_STORE_REPORTED=""
 
 watch_log() {
-  local msg="$*" record size=0
+  local msg="$*" record size=0 bytes
   printf 'agmsg watch: %s\n' "$msg" >&2
   mkdir -p "$RUN_DIR" 2>/dev/null || return 0
   # Built first, so the rotation decision can weigh what is actually going to
@@ -146,7 +146,17 @@ watch_log() {
     case "$size" in ''|*[!0-9]*) size=0 ;; esac
     # +1 for the newline. Rotate when this write WOULD cross the cap, not once
     # it already has.
-    if [ "$(( size + ${#record} + 1 ))" -gt "$WATCH_LOG_MAX_BYTES" ]; then
+    #
+    # Counted in BYTES, with `wc -c`, because the cap is bytes and so is the
+    # size `stat` returns. `${#record}` counts CHARACTERS in a UTF-8 locale, and
+    # a team or agent name may legally be Unicode -- the storeless and actas
+    # diagnostics put those names in the record. A multibyte line then passes a
+    # character-count check and lands over the byte cap, which is the contract
+    # this rotation exists to hold. One extra process per diagnostic is nothing:
+    # these are emitted a handful of times per watcher, not per poll.
+    bytes="$(printf '%s' "$record" | wc -c | tr -d '[:space:]')"
+    case "$bytes" in ''|*[!0-9]*) bytes=${#record} ;; esac
+    if [ "$(( size + bytes + 1 ))" -gt "$WATCH_LOG_MAX_BYTES" ]; then
       mv -f "$LOGFILE" "$LOGFILE.1" 2>/dev/null || true
     fi
   fi

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -2708,6 +2708,61 @@ JSON
   grep -q "no longer alive" "$log" || { cat "$log" >&2; return 1; }
 }
 
+@test "watch: the cap is bytes, not characters (#691)" {
+  # `${#record}` counts CHARACTERS in a UTF-8 locale while the cap and stat are
+  # BYTES, so a multibyte diagnostic passes a character check and lands over the
+  # byte ceiling. Team names may legally be Unicode and the storeless notice
+  # puts the name in the record, so this is reachable, not theoretical.
+  #
+  # Two attempts failed to measure it before this one, and both failed the same
+  # way -- the mutation stayed green. First the record was the liveness guard's,
+  # which is pure ASCII. Then the padding was large enough that BOTH counts
+  # crossed the cap, so the two answers agreed. The gap only shows in the window
+  # where chars fit and bytes do not, so the padding is computed from the record
+  # this fixture actually produces rather than guessed.
+  local log db record chars bytes pad cap live
+  bash "$SCRIPTS/join.sh" "境界検査のためのとても長い日本語チーム名" alice claude-code "$TEST_PROJECT" >/dev/null
+  db="$(cd "$TEST_SKILL_DIR" && bash -c '. scripts/lib/storage.sh; agmsg_db_path 境界検査のためのとても長い日本語チーム名')"
+  rm -f "$db"
+  log="$TEST_SKILL_DIR/run/watch.mb-session.log"
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  # Pass 1: an effectively unlimited cap, purely to observe the record.
+  AGMSG_WATCH_INTERVAL=1 AGMSG_WATCH_LOG_MAX_BYTES=1000000 \
+    bash "$SCRIPTS/watch.sh" mb-session "$TEST_PROJECT" claude-code >/dev/null 2>/dev/null &
+  local wpid=$! waited=0
+  while [ "$waited" -lt 100 ]; do
+    grep -q 'no store yet' "$log" 2>/dev/null && break
+    sleep 0.1; waited=$((waited + 1))
+  done
+  kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true
+  record="$(grep 'no store yet' "$log" | head -1)"
+  [ -n "$record" ] || { echo "the notice naming the team never appeared" >&2; return 1; }
+  chars=${#record}
+  bytes="$(printf '%s' "$record" | wc -c | tr -d '[:space:]')"
+  # The two answers must actually differ, or this fixture proves nothing.
+  [ "$bytes" -gt "$chars" ] || { echo "record is not multibyte: $chars/$bytes" >&2; return 1; }
+
+  # Pass 2: a cap inside the window -- chars say it fits, bytes say it does not.
+  cap=$(( 120 + chars + 1 ))
+  pad=120
+  rm -f "$log" "$log.1"
+  head -c "$pad" /dev/zero | tr '\0' 'x' > "$log"
+  AGMSG_WATCH_INTERVAL=1 AGMSG_WATCH_LOG_MAX_BYTES=$cap \
+    bash "$SCRIPTS/watch.sh" mb-session "$TEST_PROJECT" claude-code >/dev/null 2>/dev/null &
+  wpid=$!; waited=0
+  while [ "$waited" -lt 100 ]; do
+    grep -q 'no store yet' "$log" 2>/dev/null && break
+    grep -q 'no store yet' "$log.1" 2>/dev/null && break
+    sleep 0.1; waited=$((waited + 1))
+  done
+  kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true
+
+  live="$(bash -c ". '$SCRIPTS/lib/compat.sh'; compat_file_size '$log'")"
+  [ "$live" -le "$cap" ] \
+    || { echo "live log is $live bytes, cap $cap (chars=$chars bytes=$bytes pad=$pad)" >&2; return 1; }
+}
+
 @test "watch: a record larger than the whole cap is kept, not dropped (#691)" {
   # The stated exception. A single diagnostic bigger than the cap cannot fit
   # under it; rotating first and writing it whole beats dropping the one line

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -2851,19 +2851,35 @@ JSON
   grep -q "no longer alive" "$log" || { cat "$log" >&2; return 1; }
 }
 
-@test "watch: a non-numeric log cap still leaves a readable reason (#691)" {
-  # The other half of the contract advisor asked to pin: invalid, not just 0.
-  local dead log
+@test "watch: a non-numeric log cap still rotates at the default (#691)" {
+  # The other half of the contract, as a case that can actually fail. The first
+  # version asserted only that a reason was still readable -- true whether or
+  # not the value is normalized, because an un-normalized word makes `[ -gt ]`
+  # error non-fatally and read as false, and the append then succeeds anyway.
+  # It passed under mutation, so it measured nothing.
+  #
+  # What separates the two: put the live log just under the SHIPPED default and
+  # write one more record. Normalized, `oops` IS the default, so this crosses it
+  # and rotates. Un-normalized, the comparison is false forever and nothing
+  # rotates however large the file gets.
+  local dead log default=131072
   dead="$(bash -c 'echo $$')"
   wait_for_pid_exit "$dead" || true
   bash "$SCRIPTS/join.sh" testteam alice claude-code "$TEST_PROJECT" >/dev/null
   log="$TEST_SKILL_DIR/run/watch.bogus-session.$dead.log"
   mkdir -p "$TEST_SKILL_DIR/run"
-  printf 'previous run\n' > "$log"
+  # 40 bytes short of the default: any diagnostic is longer than that.
+  head -c $(( default - 40 )) /dev/zero | tr '\0' 'x' > "$log"
+
   AGMSG_WATCH_LOG_MAX_BYTES=oops bash "$SCRIPTS/watch.sh" \
     "bogus-session.$dead" "$TEST_PROJECT" claude-code >/dev/null 2>/dev/null &
   wait $! || true
-  [ -f "$log" ] || { echo "the watcher wrote nothing" >&2; return 1; }
+
+  [ -f "$log.1" ] \
+    || { echo "a non-numeric cap did not fall back to the default bound" >&2; return 1; }
+  local live
+  live="$(bash -c ". '$SCRIPTS/lib/compat.sh'; compat_file_size '$log'")"
+  [ "$live" -le "$default" ] || { echo "live log is $live bytes" >&2; return 1; }
   grep -q "no longer alive" "$log" || { cat "$log" >&2; return 1; }
 }
 

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -2678,23 +2678,52 @@ JSON
   grep -q "no longer alive" "$log" || { cat "$log" >&2; return 1; }
 }
 
-@test "watch: the log rotates rather than growing without a bound (#691)" {
-  local dead log
+@test "watch: one diagnostic cannot carry the log past its cap (#691)" {
+  # The boundary, not the already-over case. A live log UNDER the cap takes one
+  # more line and must not end up over it -- the first version compared only
+  # the size already on disk, so cap-1 plus a record ended oversized and no
+  # rotation ever happened. The ceiling is the reason this design was chosen,
+  # so the ceiling is what gets measured.
+  local dead log cap=200 live rotated
   dead="$(bash -c 'echo $$')"
   wait_for_pid_exit "$dead" || true
   bash "$SCRIPTS/join.sh" testteam alice claude-code "$TEST_PROJECT" >/dev/null
   log="$TEST_SKILL_DIR/run/watch.rot-session.$dead.log"
   mkdir -p "$TEST_SKILL_DIR/run"
-  # Already over the cap when the process starts.
-  head -c 400 /dev/zero | tr '\0' 'x' > "$log"
-  AGMSG_WATCH_LOG_MAX_BYTES=200 bash "$SCRIPTS/watch.sh" \
+  # Just UNDER the cap. One diagnostic is ~60-90 bytes, so the next write
+  # crosses it.
+  head -c 190 /dev/zero | tr '\0' 'x' > "$log"
+
+  AGMSG_WATCH_LOG_MAX_BYTES=$cap bash "$SCRIPTS/watch.sh" \
     "rot-session.$dead" "$TEST_PROJECT" claude-code >/dev/null 2>/dev/null &
   wait $! || true
-  [ -f "$log.1" ] || { echo "no rotated generation" >&2; return 1; }
-  # And the live file is the new, small one.
-  local size
-  size="$(bash -c ". '$SCRIPTS/lib/compat.sh'; compat_file_size '$log'")"
-  [ "$size" -lt 400 ] || { echo "live log is $size bytes" >&2; return 1; }
+
+  [ -f "$log.1" ] || { echo "the boundary was crossed without rotating" >&2; return 1; }
+  live="$(bash -c ". '$SCRIPTS/lib/compat.sh'; compat_file_size '$log'")"
+  rotated="$(bash -c ". '$SCRIPTS/lib/compat.sh'; compat_file_size '$log.1'")"
+  # Every generation kept is within the ceiling, which is the documented claim.
+  [ "$live" -le "$cap" ] || { echo "live log is $live bytes, cap $cap" >&2; return 1; }
+  [ "$rotated" -le "$cap" ] || { echo "rotated log is $rotated bytes, cap $cap" >&2; return 1; }
+  # And the reason still survived the rotation rather than being dropped.
+  grep -q "no longer alive" "$log" || { cat "$log" >&2; return 1; }
+}
+
+@test "watch: a record larger than the whole cap is kept, not dropped (#691)" {
+  # The stated exception. A single diagnostic bigger than the cap cannot fit
+  # under it; rotating first and writing it whole beats dropping the one line
+  # someone is looking for. Named so the behaviour is a decision, not a
+  # surprise.
+  local dead log
+  dead="$(bash -c 'echo $$')"
+  wait_for_pid_exit "$dead" || true
+  bash "$SCRIPTS/join.sh" testteam alice claude-code "$TEST_PROJECT" >/dev/null
+  log="$TEST_SKILL_DIR/run/watch.tiny-session.$dead.log"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  AGMSG_WATCH_LOG_MAX_BYTES=1 bash "$SCRIPTS/watch.sh" \
+    "tiny-session.$dead" "$TEST_PROJECT" claude-code >/dev/null 2>/dev/null &
+  wait $! || true
+  [ -f "$log" ] || { echo "the diagnostic was dropped entirely" >&2; return 1; }
+  grep -q "no longer alive" "$log" || { cat "$log" >&2; return 1; }
 }
 
 @test "check-inbox: a live watcher no longer stops the turn side (#694)" {

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -2634,3 +2634,110 @@ JSON
   [[ "$output" == *"Codex bridge: team/bob has no session recorded (the one loaded thread is already seated by another role)"* ]]
   [[ "$output" != *"That combination is unexpected"* ]]
 }
+
+# --- "stops quietly" is what made a delivery bug expensive (#691, #692, #694) ---
+
+@test "watch: the liveness guard says which session it decided about (#692)" {
+  # The guard is right; the silence is what costs. A watcher launched with a
+  # session id that does not resolve exits here immediately, and a test then
+  # runs against no watcher while looking exactly like one that ran against
+  # one -- twice in a row, during a real investigation.
+  #
+  # A composite id whose agent pid is dead is the shape that fires it.
+  local dead
+  dead="$(bash -c 'echo $$')"
+  wait_for_pid_exit "$dead" || true
+  bash "$SCRIPTS/join.sh" testteam alice claude-code "$TEST_PROJECT" >/dev/null
+  # No `timeout` on macOS, and the suite's own idiom is to run it and wait for
+  # it to end on its own -- which this guard makes it do immediately.
+  bash "$SCRIPTS/watch.sh" "gone-session.$dead" "$TEST_PROJECT" claude-code \
+    >/dev/null 2>/dev/null &
+  wait $! || true
+  # Said, and readable AFTERWARDS -- stderr is /dev/null where this really runs.
+  local log="$TEST_SKILL_DIR/run/watch.gone-session.$dead.log"
+  [ -f "$log" ] || { echo "no log at $log" >&2; return 1; }
+  grep -q "no longer alive" "$log" || { cat "$log" >&2; return 1; }
+  grep -q -F -- "gone-session.$dead" "$log" || { cat "$log" >&2; return 1; }
+}
+
+@test "watch: the log is written even when stderr is discarded (#691)" {
+  # The whole point. Not "we pointed stderr somewhere" -- the process is run
+  # with fd2 closed off exactly as it is in production, and the reason still
+  # has to be readable when it is over.
+  local dead
+  dead="$(bash -c 'echo $$')"
+  wait_for_pid_exit "$dead" || true
+  bash "$SCRIPTS/join.sh" testteam alice claude-code "$TEST_PROJECT" >/dev/null
+  run bash -c \
+    "bash '$SCRIPTS/watch.sh' 'silent-session.$dead' '$TEST_PROJECT' claude-code 2>/dev/null"
+  [ "$status" -eq 0 ] || return 1
+  # Nothing reached the caller, which is the configuration being reproduced.
+  [ -z "$output" ] || { echo "expected no output, got: $output" >&2; return 1; }
+  local log="$TEST_SKILL_DIR/run/watch.silent-session.$dead.log"
+  [ -f "$log" ] || { echo "no log at $log" >&2; return 1; }
+  grep -q "no longer alive" "$log" || { cat "$log" >&2; return 1; }
+}
+
+@test "watch: the log rotates rather than growing without a bound (#691)" {
+  local dead log
+  dead="$(bash -c 'echo $$')"
+  wait_for_pid_exit "$dead" || true
+  bash "$SCRIPTS/join.sh" testteam alice claude-code "$TEST_PROJECT" >/dev/null
+  log="$TEST_SKILL_DIR/run/watch.rot-session.$dead.log"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  # Already over the cap when the process starts.
+  head -c 400 /dev/zero | tr '\0' 'x' > "$log"
+  AGMSG_WATCH_LOG_MAX_BYTES=200 bash "$SCRIPTS/watch.sh" \
+    "rot-session.$dead" "$TEST_PROJECT" claude-code >/dev/null 2>/dev/null &
+  wait $! || true
+  [ -f "$log.1" ] || { echo "no rotated generation" >&2; return 1; }
+  # And the live file is the new, small one.
+  local size
+  size="$(bash -c ". '$SCRIPTS/lib/compat.sh'; compat_file_size '$log'")"
+  [ "$size" -lt 400 ] || { echo "live log is $size bytes" >&2; return 1; }
+}
+
+@test "check-inbox: a live watcher no longer stops the turn side (#694)" {
+  # The negative control for `both`. Before this, ANY live watcher pid made
+  # this hook exit 0 -- including a watcher delivering nothing, which is the
+  # one situation `both` is reached for. The watcher here is alive and does
+  # nothing at all, which is precisely the failure.
+  bash "$SCRIPTS/join.sh" testteam alice claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" testteam bob claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/send.sh" testteam bob alice "delivered by neither" >/dev/null
+
+  # A watcher that is alive and delivering nothing.
+  mkdir -p "$TEST_SKILL_DIR/run"
+  sleep 60 &
+  local idle=$!
+  printf '%s\n' "$idle" > "$TEST_SKILL_DIR/run/watch.both-session.pid"
+
+  run bash -c "printf '%s' '{\"session_id\":\"both-session\"}' | bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT'"
+  kill "$idle" 2>/dev/null || true
+  [ "$status" -eq 0 ] || return 1
+  printf '%s\n' "$output" | grep -q 'delivered by neither' \
+    || { echo "the turn side still stood down: $output" >&2; return 1; }
+}
+
+@test "check-inbox: what the watcher already took is not offered twice (#694)" {
+  # Why removing the deferral is safe, measured rather than argued. The watcher
+  # consumes through storage_read_cursor_consume, which records a message_read
+  # event per delivered id AND advances the cursor; storage_list_unread
+  # excludes both. Same state, so no duplicate.
+  bash "$SCRIPTS/join.sh" testteam alice claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/join.sh" testteam bob claude-code "$TEST_PROJECT" >/dev/null
+  bash "$SCRIPTS/send.sh" testteam bob alice "taken by the watcher" >/dev/null
+
+  # Stand in for the watcher's consume, using the same facade it calls.
+  local id
+  id="$(bash -c ". '$SCRIPTS/lib/storage.sh'; agmsg_storage_load; \
+    storage_list_unread testteam alice" | sed -n 's/.*\"id\":\"\([^\"]*\)\".*/\1/p' | head -1)"
+  [ -n "$id" ] || return 1
+  bash -c ". '$SCRIPTS/lib/storage.sh'; agmsg_storage_load; \
+    storage_read_cursor_consume testteam alice 999999 '$id'" >/dev/null
+
+  run bash -c "printf '%s' '{\"session_id\":\"dup-session\"}' | bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT'"
+  [ "$status" -eq 0 ] || return 1
+  run bash -c "printf '%s\n' \"\$1\" | grep -q 'taken by the watcher'" _ "$output"
+  [ "$status" -ne 0 ] || { echo "the hook re-offered a consumed message" >&2; return 1; }
+}

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -2763,6 +2763,110 @@ JSON
     || { echo "live log is $live bytes, cap $cap (chars=$chars bytes=$bytes pad=$pad)" >&2; return 1; }
 }
 
+@test "watch: an unmeasurable record rotates rather than guessing (#691)" {
+  # The fallback used to be `${#record}` -- the character count this had just
+  # been fixed away from, and fail-OPEN: with `wc` missing, the bound quietly
+  # stopped holding. It now rotates when the size cannot be measured.
+  #
+  # The cap has to sit in the window where the character count would NOT
+  # rotate, or the two behaviours agree and the case proves nothing. Same
+  # derivation as the multibyte case: observe the record, then set the cap.
+  local log db record chars bytes cap pad live shim wpid waited
+  bash "$SCRIPTS/join.sh" "境界検査のためのとても長い日本語チーム名" alice claude-code "$TEST_PROJECT" >/dev/null
+  db="$(cd "$TEST_SKILL_DIR" && bash -c '. scripts/lib/storage.sh; agmsg_db_path 境界検査のためのとても長い日本語チーム名')"
+  rm -f "$db"
+  log="$TEST_SKILL_DIR/run/watch.nowc-session.log"
+  mkdir -p "$TEST_SKILL_DIR/run"
+
+  AGMSG_WATCH_INTERVAL=1 AGMSG_WATCH_LOG_MAX_BYTES=1000000 \
+    bash "$SCRIPTS/watch.sh" nowc-session "$TEST_PROJECT" claude-code >/dev/null 2>/dev/null &
+  wpid=$!; waited=0
+  while [ "$waited" -lt 100 ]; do
+    grep -q 'no store yet' "$log" 2>/dev/null && break
+    sleep 0.1; waited=$((waited + 1))
+  done
+  kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true
+  record="$(grep 'no store yet' "$log" | head -1)"
+  [ -n "$record" ] || { echo "no record to size the fixture from" >&2; return 1; }
+  chars=${#record}
+  bytes="$(printf '%s' "$record" | wc -c | tr -d '[:space:]')"
+  [ "$bytes" -gt "$chars" ] || { echo "record is not multibyte" >&2; return 1; }
+
+  # In the window: the character count fits, the real byte count does not.
+  pad=120
+  cap=$(( pad + chars + 1 ))
+  rm -f "$log" "$log.1"
+  head -c "$pad" /dev/zero | tr '\0' 'x' > "$log"
+
+  # A `wc` that fails, first on PATH -- which is the one the watcher finds.
+  shim="$TEST_SKILL_DIR/shim"; mkdir -p "$shim"
+  printf '#!/bin/sh\nexit 1\n' > "$shim/wc"; chmod +x "$shim/wc"
+
+  PATH="$shim:$PATH" AGMSG_WATCH_INTERVAL=1 AGMSG_WATCH_LOG_MAX_BYTES=$cap \
+    bash "$SCRIPTS/watch.sh" nowc-session "$TEST_PROJECT" claude-code >/dev/null 2>/dev/null &
+  wpid=$!; waited=0
+  while [ "$waited" -lt 100 ]; do
+    [ -f "$log.1" ] && break
+    grep -q 'no store yet' "$log" 2>/dev/null && break
+    sleep 0.1; waited=$((waited + 1))
+  done
+  kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true
+
+  live="$(bash -c ". '$SCRIPTS/lib/compat.sh'; compat_file_size '$log'")"
+  [ "$live" -le "$cap" ] \
+    || { echo "live log is $live bytes, cap $cap (chars=$chars bytes=$bytes pad=$pad)" >&2; return 1; }
+  # And the diagnostic was not lost to the conservative choice.
+  grep -q 'no store yet' "$log" || { echo "the record was dropped" >&2; cat "$log" >&2; return 1; }
+}
+
+@test "watch: an invalid log cap falls back to the default, not to no bound (#691)" {
+  # `0` is the value that separates the two behaviours. Normalized, it becomes
+  # the 128 KiB default and a small log is left alone. Unnormalized, every
+  # record is "over" a cap of zero and the log rotates on every line, throwing
+  # away the previous generation each time -- the diagnostics this exists to
+  # keep.
+  #
+  # Note on the failure mode: an invalid cap does NOT kill the watcher. The
+  # value never enters `$(( ))`; it is the right-hand side of `[ -gt ]`, which
+  # errors non-fatally because this script sets `-u`, not `-e`. What it does is
+  # quietly stop the comparison from ever being true -- so the real risk is an
+  # unbounded log, and that is what is pinned here.
+  local dead log
+  dead="$(bash -c 'echo $$')"
+  wait_for_pid_exit "$dead" || true
+  bash "$SCRIPTS/join.sh" testteam alice claude-code "$TEST_PROJECT" >/dev/null
+  log="$TEST_SKILL_DIR/run/watch.zerocap-session.$dead.log"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf 'a previous generation worth keeping\n' > "$log"
+
+  AGMSG_WATCH_LOG_MAX_BYTES=0 bash "$SCRIPTS/watch.sh" \
+    "zerocap-session.$dead" "$TEST_PROJECT" claude-code >/dev/null 2>/dev/null &
+  wait $! || true
+
+  # Treated as the default: nothing was rotated away for a 36-byte file.
+  [ ! -f "$log.1" ] || { echo "a cap of 0 rotated a tiny log" >&2; return 1; }
+  grep -q 'a previous generation worth keeping' "$log" \
+    || { echo "the previous generation was discarded" >&2; cat "$log" >&2; return 1; }
+  # And the run still said why it stopped.
+  grep -q "no longer alive" "$log" || { cat "$log" >&2; return 1; }
+}
+
+@test "watch: a non-numeric log cap still leaves a readable reason (#691)" {
+  # The other half of the contract advisor asked to pin: invalid, not just 0.
+  local dead log
+  dead="$(bash -c 'echo $$')"
+  wait_for_pid_exit "$dead" || true
+  bash "$SCRIPTS/join.sh" testteam alice claude-code "$TEST_PROJECT" >/dev/null
+  log="$TEST_SKILL_DIR/run/watch.bogus-session.$dead.log"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf 'previous run\n' > "$log"
+  AGMSG_WATCH_LOG_MAX_BYTES=oops bash "$SCRIPTS/watch.sh" \
+    "bogus-session.$dead" "$TEST_PROJECT" claude-code >/dev/null 2>/dev/null &
+  wait $! || true
+  [ -f "$log" ] || { echo "the watcher wrote nothing" >&2; return 1; }
+  grep -q "no longer alive" "$log" || { cat "$log" >&2; return 1; }
+}
+
 @test "watch: a record larger than the whole cap is kept, not dropped (#691)" {
   # The stated exception. A single diagnostic bigger than the cap cannot fit
   # under it; rotating first and writing it whole beats dropping the one line


### PR DESCRIPTION
Three ways this system fails without saying so. One root cause took seven hours to find last night; the defects were small and the invisibility was what cost.

## #691 — the diagnostics went to a descriptor with no reader

The watcher writes to stderr, and in the configuration it actually runs in stderr is `/dev/null`: fd1 is the socket to its session, fd2 goes nowhere. Every message explaining an otherwise invisible state was written where nobody could read it.

They now also go to `run/watch.<session>.log`, beside the pidfile this process already owns — which pid, and what it thought it was doing. Bounded by rotation at a fixed size with one generation kept; an unbounded log in a directory nobody prunes is its own defect. Still echoed to stderr, because someone running `watch.sh` by hand is looking there. `compat_file_size` is added beside `compat_file_mtime`, same platform split.

## #692 — the liveness guard exited 0 in silence

A watcher that stopped there, one that was killed, one that crashed early and one that was never started were four indistinguishable states. A test watcher given a session id that does not resolve hits it immediately, and the test then runs against no watcher while looking exactly like one that did. It now says which condition fired and which token it decided about.

The issue asked for a **sweep of the class**, not the one instance. The other silent stop in the same loop — `storage_store_exists || continue`, which drops a team every cycle and says nothing — now says so once per pair per process. Once, not per interval: a line every poll would bury the log this exists to make readable.

## #694 — the fallback stood down in front of the failure it exists for

`both` deferred to a **live** watcher, and the failure it exists for preserves liveness exactly. Measured on 2026-08-08: switching to `both` changed nothing; `mode turn` worked, because it stops the watcher, which removes the liveness signal.

**Option (b), and the reason it is safe was measured rather than assumed.** Both sides consume through the same state:

```
watcher     storage_read_cursor_consume -> a `message_read` event per delivered id,
                                           AND read_cursors.local_position advanced
turn hook   storage_list_unread         -> excludes rows at or below that cursor,
                                           AND rows carrying a `message_read` event
```

A pinned test proves it: consume a message through the facade the watcher uses, then run the hook and require the message **not** to be offered. The remaining window is an interleave bounded by one poll interval, and that trade is written down — a rare duplicate line against a mode that silently delivered nothing.

**No test pinned the deferral.** Removing it broke nothing, which is its own finding.

The session-id derivation stays: the actas-ownership check below it needs the token, and deleting the block wholesale would have passed it empty.

## Mutations, one per item

```
the guard goes silent again          3 red
no durable log, stderr only          3 red
rotation removed                     1 red
the deferral returns                 1 red
```

Five new cases. The two watcher ones run it with fd2 pointed at `/dev/null` — the configuration being reproduced — and require the reason to be readable afterwards. Pointing stderr somewhere is not the claim.

Closes #691
Closes #692
Closes #694
