### PR TITLE
storage: write every message to the legacy table again (#689)

### DIFF
--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -190,6 +190,11 @@ get_messages() {
       UNION ALL
       SELECT CAST(id AS TEXT) AS id, team, from_agent, to_agent, body, created_at, id AS ord
       FROM messages
+      -- Skip the copy the event log already carries. Every message is written
+      -- to both tables so external readers of the legacy one keep working
+      -- (#689); without this every message is returned twice, once under its
+      -- event id and once under the legacy rowid.
+      WHERE NOT EXISTS (SELECT 1 FROM events e2 WHERE e2.legacy_id = messages.id)
     )
     SELECT json_object(
       'type', 'message_sent',

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -402,9 +402,14 @@ _sqlite_sync_project_legacy() {
   fi
 
   agmsg_sqlite "$db" "
-    INSERT INTO events(seq,type,id,team,from_agent,to_agent,body,at)
+    INSERT INTO events(seq,type,id,team,from_agent,to_agent,body,at,legacy_id)
       SELECT m.id - $_AGMSG_LEGACY_SEQ_OFFSET,'message_sent',CAST(m.id AS TEXT),
-             m.team,m.from_agent,m.to_agent,m.body,m.created_at
+             m.team,m.from_agent,m.to_agent,m.body,m.created_at,
+             -- Record which legacy row this event IS. The readers dedupe on
+             -- events.legacy_id = messages.id, so a projected row without it is
+             -- returned from both branches -- the same duplicate the mirror
+             -- exists to avoid, arriving from the other direction (#689).
+             m.id
         FROM messages m
        WHERE m.team='$tl'
          AND NOT EXISTS(SELECT 1 FROM events e
@@ -943,7 +948,15 @@ storage_sync_apply_pull() {
     WHERE local_team='$tl' AND server_instance_id='$server' AND remote_team_id='$remote'
       AND protocol_version=$protocol AND driver_generation='$generation';
     COMMIT;" >> "$sql_file"
-  if ! agmsg_sqlite "$db" < "$sql_file" >/dev/null 2>&1; then
+  # -bail, for the reason the local write path already carries it: the CLI
+  # reports a statement error and keeps going, so a failure partway through this
+  # batch would still reach the sync mapping, the transport cursor and the
+  # COMMIT. A non-zero exit afterwards does not undo what was committed. The
+  # batch now spans the event, its legacy mirror and the mapping, so a partial
+  # commit is exactly the asymmetry the mirror exists to prevent — an event with
+  # no copy, or a copy nothing points at (#689). Found in the local path while
+  # building this and not carried across; a reviewer caught that.
+  if ! agmsg_sqlite -bail "$db" < "$sql_file" >/dev/null 2>&1; then
     rm -f "$sql_file"; trap - EXIT INT TERM HUP; return 13
   fi
   rm -f "$sql_file"

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -408,7 +408,14 @@ _sqlite_sync_project_legacy() {
         FROM messages m
        WHERE m.team='$tl'
          AND NOT EXISTS(SELECT 1 FROM events e
-                         WHERE e.seq=m.id - $_AGMSG_LEGACY_SEQ_OFFSET);
+                         WHERE e.seq=m.id - $_AGMSG_LEGACY_SEQ_OFFSET)
+         -- Never project a row this store wrote as the legacy copy of an event
+         -- it already has (#689). Every message is now written to both tables,
+         -- so without this the projection would put the mirror back into the
+         -- event log as a SECOND event -- different id, different seq, no link
+         -- to the first -- and the rewind below would push that duplicate to
+         -- the server and on to every other machine.
+         AND NOT EXISTS(SELECT 1 FROM events e2 WHERE e2.legacy_id = m.id);
     INSERT OR REPLACE INTO storage_metadata(key,value)
       VALUES('legacy_push_projected_v1','1');" >/dev/null 2>&1 || return 13
 }
@@ -900,6 +907,22 @@ storage_sync_apply_pull() {
           AND NOT EXISTS(SELECT 1 FROM sync_conflicts cx
           WHERE cx.server_instance_id='$server' AND cx.remote_team_id='$remote'
             AND cx.protocol_version=$protocol AND cx.wire_id='$wire');
+        -- Mirror into the legacy table, which other software still reads
+        -- (#689). This is the arrival path for anything sent from another
+        -- machine: mirroring only local sends would leave those readers seeing
+        -- one side of a conversation, and that is the side this exists for.
+        --
+        -- Keyed off the event actually having been inserted rather than
+        -- repeating the three-part duplicate guard above. If the event was
+        -- skipped there is no row with this id, so neither statement fires and
+        -- last_insert_rowid() is never read.
+        INSERT INTO messages(team,from_agent,to_agent,body,created_at)
+        SELECT '$tl','$(_sqlite_lit "$from")','$(_sqlite_lit "$to")',
+               '$(_sqlite_lit "$body")','$(_sqlite_lit "$at")'
+         WHERE EXISTS(SELECT 1 FROM events e
+                       WHERE e.id='$local_id' AND e.legacy_id IS NULL);
+        UPDATE events SET legacy_id=last_insert_rowid()
+         WHERE id='$local_id' AND legacy_id IS NULL;
         INSERT OR IGNORE INTO sync_messages
           (local_team,server_instance_id,remote_team_id,protocol_version,
            driver_generation,local_position,local_id,wire_id,envelope_v,cipher,

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -72,6 +72,15 @@ storage_store_exists() { [ -f "$(_sqlite_db "$1")" ]; }
 storage_init() {
   local db; db="$(_sqlite_db "$1")"
   mkdir -p "$(dirname "$db")" 2>/dev/null || true
+  # CREATE TABLE IF NOT EXISTS does nothing to a store that already has the
+  # table, so an existing events table never gains legacy_id from the schema
+  # below. SQLite has no ADD COLUMN IF NOT EXISTS, and a failing statement
+  # aborts the whole batch, so this runs on its own and its failure ("duplicate
+  # column name") is the expected outcome on every run after the first.
+  if [ -f "$db" ]; then
+    agmsg_sqlite "$db" "ALTER TABLE events ADD COLUMN legacy_id INTEGER;" \
+      >/dev/null 2>&1 || true
+  fi
   agmsg_sqlite "$db" "
     PRAGMA journal_mode=WAL;
     CREATE TABLE IF NOT EXISTS events (
@@ -84,7 +93,16 @@ storage_init() {
       body       TEXT,
       msg_id     TEXT,
       agent      TEXT,
-      at         TEXT NOT NULL
+      at         TEXT NOT NULL,
+      -- The rowid of this event's copy in the legacy messages table, when one
+      -- was written. That table is a read interface other software still opens,
+      -- so every message is written to both; this column is what lets a reader
+      -- tell that the two rows are one message. Without it the UNION queries
+      -- below list the same message twice, because the two tables number their
+      -- rows in different spaces (UUID vs rowid) and nothing connects them.
+      -- (#689. No backticks in here: this SQL sits inside a double-quoted shell
+      -- string, where they are command substitution, not quoting.)
+      legacy_id  INTEGER
     );
     CREATE INDEX IF NOT EXISTS events_sent ON events(type, team, to_agent, seq);
     CREATE INDEX IF NOT EXISTS events_read ON events(type, team, agent, msg_id);
@@ -147,15 +165,57 @@ storage_init() {
 
 # --- contract: messages ----------------------------------------------------
 
+# The one place a message becomes rows. Every caller that records a
+# message_sent goes through this, including the one that lands messages pulled
+# from a remote -- mirroring only what this machine sends would leave a reader
+# of the legacy table able to see half a conversation, and the half it could not
+# see is the one that made this worth doing (#689).
+#
+# WHAT THIS DOES NOT COVER. Worth stating where the code is, because "we write
+# to the legacy table" invites the reading that any external viewer will keep
+# working, and three kinds of store are outside it:
+#
+#   * A team on the jsonl driver has no legacy table to mirror into -- that
+#     table is created here and in internal/init-db.sh and nowhere else. Such a
+#     team is invisible to those readers and this cannot change that. Measured,
+#     not assumed: the jsonl driver's only `messages` references are a field of
+#     the sync pull payload.
+#   * A team moved to its own store (drivers.partition=per-team) writes to a
+#     different file. A viewer pointed at the shared store sees nothing for it,
+#     mirrored or not.
+#   * Rows that predate this are unmirrored in the other direction -- they exist
+#     only in the legacy table -- which is what the UNION in list_unread and
+#     history is still for.
+#
+# WHEN IT ENDS. Not on a date, and not "once everyone upgrades": the readers are
+# other people's software and we cannot enumerate them. It ends when someone can
+# show that nothing reads the table any more, and until someone does that work
+# this is a supported interface rather than a migration step. Written down
+# because an unbounded compatibility write with no stated exit becomes permanent
+# by default, and then nobody knows whether it is load-bearing.
+#
+# Both tables in one transaction, and the legacy rowid recorded on the event.
+# The correspondence is not bookkeeping: it is what every reader that unions the
+# two tables uses to recognise one message rather than list it twice.
+_sqlite_message_sent_sql() {
+  local team="$1" from="$2" to="$3" body="$4" id="$5" at="$6"
+  local tl fl ol bl il al
+  tl="$(_sqlite_lit "$team")"; fl="$(_sqlite_lit "$from")"; ol="$(_sqlite_lit "$to")"
+  bl="$(_sqlite_lit "$body")"; il="$(_sqlite_lit "$id")"; al="$(_sqlite_lit "$at")"
+  printf '%s\n' "
+    BEGIN IMMEDIATE;
+    INSERT INTO messages (team,from_agent,to_agent,body,created_at)
+    VALUES ('$tl','$fl','$ol','$bl','$al');
+    INSERT INTO events (type,id,team,from_agent,to_agent,body,at,legacy_id)
+    VALUES ('message_sent','$il','$tl','$fl','$ol','$bl','$al',last_insert_rowid());
+    COMMIT;
+  "
+}
+
 storage_send() {
   local team="$1" from="$2" to="$3" body="$4"
   local id at db; id="$(compat_uuid7)"; at="$(_sqlite_now)"; db="$(_sqlite_db "$team")"
-  local insert="
-    INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
-    VALUES ('message_sent','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
-            '$(_sqlite_lit "$from")','$(_sqlite_lit "$to")','$(_sqlite_lit "$body")',
-            '$(_sqlite_lit "$at")');
-  "
+  local insert; insert="$(_sqlite_message_sent_sql "$team" "$from" "$to" "$body" "$id" "$at")"
   # Try the INSERT first and only fall back to storage_init on failure (the #114
   # pattern). Running storage_init — which issues PRAGMA journal_mode=WAL and the
   # CREATE TABLE/INDEX statements — on EVERY send serializes badly under a
@@ -164,9 +224,15 @@ storage_send() {
   # Keep message bodies out of argv. Linux can impose a much smaller effective
   # argv ceiling than macOS, so a valid large local message must travel on
   # sqlite3's stdin rather than as the final command-line SQL argument.
-  if ! printf '%s\n' "$insert" | agmsg_sqlite "$db" >/dev/null 2>&1; then
+  # -bail, because this is now more than one statement. The CLI's default is to
+  # report an error and keep going, so a batch whose second INSERT fails still
+  # reaches its COMMIT and commits the first one. Measured: the retry below then
+  # inserted the message a second time, leaving one row in the legacy table that
+  # no event points at -- exactly the unlinked copy the correspondence exists to
+  # prevent.
+  if ! printf '%s\n' "$insert" | agmsg_sqlite -bail "$db" >/dev/null 2>&1; then
     storage_init "$team" >/dev/null
-    printf '%s\n' "$insert" | agmsg_sqlite "$db" >/dev/null 2>&1 || return 1
+    printf '%s\n' "$insert" | agmsg_sqlite -bail "$db" >/dev/null 2>&1 || return 1
   fi
   printf '%s\n' "$id"
 }
@@ -196,7 +262,16 @@ storage_read_cursor_consume() {
       SELECT 'message_read','$(_sqlite_lit "$(compat_uuid7)")','$tl','$al',
              '$(_sqlite_lit "$id")','$(_sqlite_lit "$at")'
        WHERE NOT EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'
-         AND r.team='$tl' AND r.agent='$al' AND r.msg_id='$(_sqlite_lit "$id")');"
+         AND r.team='$tl' AND r.agent='$al' AND r.msg_id='$(_sqlite_lit "$id")');
+      -- Mirror the read into the legacy table, through the correspondence
+      -- rather than by guessing an id. Without this an external viewer shows
+      -- every message unread forever, which is a worse thing to hand someone
+      -- than the disagreement it costs (#689).
+      UPDATE messages SET read_at='$(_sqlite_lit "$at")'
+       WHERE read_at IS NULL
+         AND id = (SELECT e.legacy_id FROM events e
+                    WHERE e.type='message_sent' AND e.team='$tl'
+                      AND e.id='$(_sqlite_lit "$id")' AND e.legacy_id IS NOT NULL);"
   done
   agmsg_sqlite "$db" "BEGIN IMMEDIATE;
     $sql
@@ -244,6 +319,12 @@ storage_list_unread() {
       WHERE m.team='$tl' AND m.to_agent='$al' AND m.read_at IS NULL
         AND NOT EXISTS (SELECT 1 FROM events r WHERE r.type='message_read'
                         AND r.team=m.team AND r.agent='$al' AND r.msg_id=CAST(m.id AS TEXT))
+        -- Skip the copy of a message that is already in the event log. Every
+        -- message is written to both tables so external readers of the legacy
+        -- one keep working (#689); without this the union lists it twice, and
+        -- marking one read leaves the other behind because the two branches
+        -- number rows in different spaces.
+        AND NOT EXISTS (SELECT 1 FROM events e2 WHERE e2.legacy_id = m.id)
     )
     ORDER BY ts, src, ord ${limit:+LIMIT $limit};
   "
@@ -339,6 +420,9 @@ storage_history() {
                created_at AS ts, 0 AS src, id AS ord
         FROM messages
         WHERE team='$tl' $afilter
+          -- The event log already carries the mirrored copy (#689); listing
+          -- both shows one message twice.
+          AND NOT EXISTS (SELECT 1 FROM events e2 WHERE e2.legacy_id = messages.id)
       )
       ORDER BY ts DESC, src DESC, ord DESC ${limit:+LIMIT $limit}
     )
@@ -381,15 +465,20 @@ storage_import() {
     t=$(j type); id=$(j id); team=$(j team); at=$(j at)
     if [ "$t" = message_sent ]; then
       frm=$(j from); to=$(j to); body=$(j body)
-      agmsg_sqlite "$db" "INSERT INTO events (type,id,team,from_agent,to_agent,body,at)
-        VALUES ('message_sent','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
-                '$(_sqlite_lit "$frm")','$(_sqlite_lit "$to")','$(_sqlite_lit "$body")',
-                '$(_sqlite_lit "$at")');" >/dev/null 2>&1
+      # Same utility as a live send, so an imported store presents the same
+      # legacy view as the store it came from (#689).
+      printf '%s\n' "$(_sqlite_message_sent_sql "$team" "$frm" "$to" "$body" "$id" "$at")" \
+        | agmsg_sqlite -bail "$db" >/dev/null 2>&1
     elif [ "$t" = message_read ]; then
       agent=$(j agent); msg_id=$(j msg_id)
       agmsg_sqlite "$db" "INSERT INTO events (type,id,team,agent,msg_id,at)
         VALUES ('message_read','$(_sqlite_lit "$id")','$(_sqlite_lit "$team")',
-                '$(_sqlite_lit "$agent")','$(_sqlite_lit "$msg_id")','$(_sqlite_lit "$at")');" \
+                '$(_sqlite_lit "$agent")','$(_sqlite_lit "$msg_id")','$(_sqlite_lit "$at")');
+        UPDATE messages SET read_at='$(_sqlite_lit "$at")'
+         WHERE read_at IS NULL
+           AND id = (SELECT e.legacy_id FROM events e
+                      WHERE e.type='message_sent' AND e.team='$(_sqlite_lit "$team")'
+                        AND e.id='$(_sqlite_lit "$msg_id")' AND e.legacy_id IS NOT NULL);" \
         >/dev/null 2>&1
     fi
   done < "$file"

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -324,7 +324,15 @@ storage_list_unread() {
         -- one keep working (#689); without this the union lists it twice, and
         -- marking one read leaves the other behind because the two branches
         -- number rows in different spaces.
-        AND NOT EXISTS (SELECT 1 FROM events e2 WHERE e2.legacy_id = m.id)
+        --
+        -- Live space only (seq > 0). A legacy row that was PROJECTED for push
+        -- also carries an event, but at a negative seq, deliberately below every
+        -- read cursor -- so the events branch above can never return it. Skipping
+        -- the legacy row on account of that event would remove the message from
+        -- the inbox entirely while history still showed it. Measured: the first
+        -- version of this dedupe did exactly that.
+        AND NOT EXISTS (SELECT 1 FROM events e2
+                         WHERE e2.legacy_id = m.id AND e2.seq > 0)
     )
     ORDER BY ts, src, ord ${limit:+LIMIT $limit};
   "

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2009,7 +2009,24 @@ cmd_forget() {
       # Only legacy rows the event log does not already carry: every message is
       # written to both tables (#689), so counting both in full reports twice
       # the number of messages about to be deleted.
-      event_count="$((event_count + $(agmsg_sqlite "$store_path" "SELECT COUNT(*) FROM messages m WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.legacy_id = m.id);")))"
+      #
+      # The column is asked about rather than assumed. This inspects a store
+      # file directly and deliberately never initializes it, so a store written
+      # before that column existed is a state this path must survive -- and it
+      # has no mirrored rows anyway, which makes the plain count the right
+      # answer there. Naming a column that is not there fails the whole query,
+      # and an empty result then breaks the arithmetic below rather than the
+      # SQL, which is a long way from the cause.
+      legacy_dedupe=""
+      if [ "$(agmsg_sqlite "$store_path" \
+            "SELECT COUNT(*) FROM pragma_table_info('events') WHERE name='legacy_id';" \
+            2>/dev/null | tr -d '\r')" = "1" ]; then
+        legacy_dedupe=" WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.legacy_id = m.id)"
+      fi
+      legacy_count="$(agmsg_sqlite "$store_path" \
+        "SELECT COUNT(*) FROM messages m$legacy_dedupe;" 2>/dev/null | tr -d '\r')"
+      case "$legacy_count" in ''|*[!0-9]*) legacy_count=0 ;; esac
+      event_count="$((event_count + legacy_count))"
     fi
   fi
 

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2006,7 +2006,10 @@ cmd_forget() {
       event_count="$(agmsg_sqlite "$store_path" "SELECT COUNT(*) FROM events;")"
     fi
     if printf '%s\n' "$tables" | grep -qx messages; then
-      event_count="$((event_count + $(agmsg_sqlite "$store_path" "SELECT COUNT(*) FROM messages;")))"
+      # Only legacy rows the event log does not already carry: every message is
+      # written to both tables (#689), so counting both in full reports twice
+      # the number of messages about to be deleted.
+      event_count="$((event_count + $(agmsg_sqlite "$store_path" "SELECT COUNT(*) FROM messages m WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.legacy_id = m.id);")))"
     fi
   fi
 

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2024,8 +2024,22 @@ cmd_forget() {
         legacy_dedupe=" WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.legacy_id = m.id)"
       fi
       legacy_count="$(agmsg_sqlite "$store_path" \
-        "SELECT COUNT(*) FROM messages m$legacy_dedupe;" 2>/dev/null | tr -d '\r')"
-      case "$legacy_count" in ''|*[!0-9]*) legacy_count=0 ;; esac
+        "SELECT COUNT(*) FROM messages m$legacy_dedupe;" | tr -d '\r')" || {
+        echo "agmsg: cannot count messages in team store '$store_path'; refusing to delete it" >&2
+        exit 1
+      }
+      # A count that cannot be proved is not zero. The inspection above already
+      # refuses when it cannot read the table list, and this is the same kind of
+      # claim: normalising a failed query to 0 would tell the operator there is
+      # less to lose than there is, immediately before deleting it. A missing
+      # column is a different thing and is handled by the probe above -- that is
+      # a store shape we support, not a failure.
+      case "$legacy_count" in
+        ''|*[!0-9]*)
+          echo "agmsg: message count in team store '$store_path' was not a number; refusing to delete it" >&2
+          exit 1
+          ;;
+      esac
       event_count="$((event_count + legacy_count))"
     fi
   fi

--- a/tests/test_legacy_mirror.bats
+++ b/tests/test_legacy_mirror.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+
+# The legacy `messages` table is a read interface other software depends on:
+# the desktop app and any external viewer open the store and read that table.
+# Those readers do not restart when we ship, and we cannot enumerate them, so it
+# is a contract rather than a migration step.
+#
+# The event log replaced it as the source of truth and nothing writes to it any
+# more, which means a message sent by a current build is invisible to every one
+# of those readers. These tests read the table the way such a reader does —
+# directly, with no agmsg code in between — because that is the only way to
+# check a promise made to code we do not control.
+#
+# Scope: the legacy table exists only in the sqlite driver (created in
+# drivers/storage/sqlite.sh and internal/init-db.sh, nowhere else). A team on
+# the jsonl driver has no such table at all and is invisible to those readers
+# regardless; mirroring cannot change that and does not try.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  bash "$SCRIPTS/join.sh" mteam alice claude-code /tmp/mp-a
+  bash "$SCRIPTS/join.sh" mteam bob   claude-code /tmp/mp-b
+  DB="$(cd "$TEST_SKILL_DIR" && bash -c '. scripts/lib/storage.sh; agmsg_storage_load; agmsg_db_path mteam')"
+}
+
+teardown() { teardown_test_env; }
+
+# What an external reader runs. No agmsg helpers: if this stops matching what
+# they see, the test has stopped testing the contract.
+legacy_rows() {
+  sqlite3 "$DB" "SELECT count(*) FROM messages WHERE team='mteam' AND to_agent='alice' AND body='$1';" 2>/dev/null | tr -d '\r'
+}
+
+legacy_read_at() {
+  sqlite3 "$DB" "SELECT COALESCE(read_at,'') FROM messages WHERE team='mteam' AND to_agent='alice' AND body='$1';" 2>/dev/null | tr -d '\r'
+}
+
+@test "legacy mirror: a sent message is visible to a reader of the legacy table (#689)" {
+  bash "$SCRIPTS/send.sh" mteam bob alice "visible to old readers"
+  [ "$(legacy_rows 'visible to old readers')" -eq 1 ]
+}
+
+@test "legacy mirror: reading a message marks it read for a reader of the legacy table (#689)" {
+  # koit's call, against my initial recommendation: mirror read state too.
+  # Without it an old viewer shows every message unread forever, which is worse
+  # than the disagreement it was avoiding.
+  bash "$SCRIPTS/send.sh" mteam bob alice "read state travels"
+  [ -z "$(legacy_read_at 'read state travels')" ]
+
+  run bash "$SCRIPTS/inbox.sh" mteam alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"read state travels"* ]]
+
+  [ -n "$(legacy_read_at 'read state travels')" ]
+}
+
+@test "legacy mirror: a mirrored message is still delivered exactly once (#689)" {
+  # The cost of mirroring, and the reason the correspondence has to be recorded
+  # rather than just written: storage_list_unread and storage_history each UNION
+  # the event log with the legacy table, and before this the two branches had no
+  # way to recognise the same message — measured, the same message was listed
+  # twice and inbox announced "2 new message(s)".
+  bash "$SCRIPTS/send.sh" mteam bob alice "exactly once"
+
+  run bash "$SCRIPTS/inbox.sh" mteam alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"1 new message(s)"* ]]
+  [ "$(printf '%s\n' "$output" | grep -c 'exactly once')" -eq 1 ]
+
+  run bash "$SCRIPTS/history.sh" mteam alice
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c 'exactly once')" -eq 1 ]
+}

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -288,20 +288,21 @@ stored_types() {
 # agent had read to. Each table is asserted separately because the comparison
 # is written per table, and one of them getting it right hides the others.
 @test "migrate: a message id reused for different content is refused" {
-  # send.sh writes history to events; the messages table stays empty on this
-  # path, so the row is placed on both sides directly. The table is still copied
-  # and still deleted from the shared store, so it needs the same proof — and
-  # measuring it required checking which tables actually carry rows rather than
-  # assuming.
+  # The row is placed on both sides directly, at an id well clear of the ones a
+  # send allocates. That distance is load-bearing now: a send writes the legacy
+  # table too (#689), so this fixture's id is no longer free by default and a
+  # low one collides with the mirror rather than testing anything. The comment
+  # that used to sit here said the messages table stays empty on this path,
+  # which was true when it was written and is not now.
   bash "$SCRIPTS/send.sh" alpha ann bob "the original message" >/dev/null
   migrate alpha
   local dest; dest="$(store_of alpha)"
 
   sqlite3 "$dest" "INSERT INTO messages(id,team,from_agent,to_agent,body,created_at)
-    VALUES(1,'alpha','ann','bob','what the destination holds',
+    VALUES(9001,'alpha','ann','bob','what the destination holds',
            strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
   sqlite3 "$SHARED" "INSERT INTO messages(id,team,from_agent,to_agent,body,created_at)
-    VALUES(1,'alpha','ann','bob','a different body',
+    VALUES(9001,'alpha','ann','bob','a different body',
            strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
 
   run migrate alpha

--- a/tests/test_remote_forget.bats
+++ b/tests/test_remote_forget.bats
@@ -197,3 +197,36 @@ PY
   [ "$status" -eq 0 ]
   [ -f "$trust_file" ]
 }
+
+# The gate immediately before a deletion. Reporting a count it could not compute
+# tells the operator there is less to lose than there is, at the one moment that
+# is irreversible — so a count that fails is a refusal, not a zero.
+#
+# The store here is one where the table list and the column probe both succeed
+# and only the count fails: events carries legacy_id, so the deduped form of the
+# query is chosen, and the messages table lacks the column that form joins on.
+# That isolates the statement under test; a store that failed earlier would exit
+# through the inspection guard above it and prove nothing about this branch.
+@test "forget: refuses when the message count cannot be computed (#689)" {
+  local store="$TEST_SKILL_DIR/db/teams/testteam/messages.db"
+  local cfg="$TEST_SKILL_DIR/teams/testteam/config.json"
+  [ -f "$store" ]
+
+  # This fixture builds its store directly rather than through storage_init, so
+  # the column the deduped query needs is not there yet. Add it: without it the
+  # probe picks the old-schema branch and the test would pass for the wrong
+  # reason.
+  sqlite3 "$store" "ALTER TABLE events ADD COLUMN legacy_id INTEGER;"
+  sqlite3 "$store" "ALTER TABLE messages RENAME TO messages_original;
+                    CREATE TABLE messages (team TEXT, body TEXT);"
+  # The probe must still say the column is there, or this exercises the
+  # old-schema path instead of the failure path.
+  [ "$(sqlite3 "$store" "SELECT COUNT(*) FROM pragma_table_info('events') WHERE name='legacy_id';" | tr -d '\r')" = "1" ]
+
+  run bash "$SCRIPTS/remote.sh" forget testteam --yes
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refusing to delete it"* ]]
+  # Nothing was destroyed on the way out.
+  [ -f "$store" ]
+  [ -f "$cfg" ]
+}

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -557,3 +557,39 @@ _reconcile_one_ack() {
   # The events table is still there: nothing above reached a statement.
   [ "$(agmsg_sqlite "$(agmsg_db_path demo)" "SELECT COUNT(*) FROM events;" | tr -d '\r')" -gt 0 ]
 }
+
+# The legacy `messages` table is a read interface other software still opens
+# (#689). A message that arrives from another machine lands here and nowhere
+# else, so mirroring only local sends would leave those readers seeing one side
+# of a conversation -- and the side they could not see is the reason this was
+# worth doing at all.
+@test "sync contract: a pulled message is mirrored into the legacy table, once" {
+  local remote page db
+  remote=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"1",
+     id:"550e8400-e29b-41d4-a716-4466554400a1",
+     server_received_at:"2026-07-20T13:00:01.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"arrived from elsewhere",created_at:"2026-07-20T13:00:01.000000Z",
+        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"arrived from elsewhere",created_at:"2026-07-20T13:00:01.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
+  page=$(printf '%s\n%s\n' "$remote" '{"type":"sync_pull_cursor","next_after":"1"}')
+  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+
+  db=$(agmsg_db_path demo)
+  # Visible to a reader of the legacy table — queried the way such a reader
+  # would, with no agmsg code in between.
+  [ "$(sqlite3 "$db" "SELECT count(*) FROM messages WHERE body='arrived from elsewhere';" | tr -d '\r')" -eq 1 ]
+  # And linked, so the readers that union the two tables see one message.
+  [ "$(sqlite3 "$db" "SELECT count(*) FROM events e JOIN messages m ON m.id=e.legacy_id WHERE e.type='message_sent' AND e.body='arrived from elsewhere';" | tr -d '\r')" -eq 1 ]
+  [ "$(storage_history demo | jq -s '[.[]|select(.body=="arrived from elsewhere")]|length')" -eq 1 ]
+  [ "$(storage_list_unread demo bob | jq -s '[.[]|select(.body=="arrived from elsewhere")]|length')" -eq 1 ]
+
+  # Re-applying the same durable page must not add a second legacy row either.
+  # The event is guarded against duplication; the mirror has to inherit that
+  # guard rather than carry its own copy of it.
+  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  [ "$(sqlite3 "$db" "SELECT count(*) FROM messages WHERE body='arrived from elsewhere';" | tr -d '\r')" -eq 1 ]
+}

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -593,3 +593,70 @@ _reconcile_one_ack() {
   printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
   [ "$(sqlite3 "$db" "SELECT count(*) FROM messages WHERE body='arrived from elsewhere';" | tr -d '\r')" -eq 1 ]
 }
+
+# A partial commit is the failure this batch has to be incapable of. It now
+# spans the event, its legacy mirror, the sync mapping and the transport cursor,
+# and the CLI's default is to report a statement error and keep going — so
+# without -bail a failing mirror still reaches COMMIT and leaves an event with
+# no copy, plus a cursor that says the page was applied. A non-zero exit
+# afterwards does not undo any of that.
+#
+# Success and replay tests cannot see this; only a forced failure inside the
+# batch can.
+@test "sync contract: a failure inside the apply commits nothing (#689)" {
+  local remote page db
+  db=$(agmsg_db_path demo)
+  remote=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"1",
+     id:"550e8400-e29b-41d4-a716-4466554400b2",
+     server_received_at:"2026-07-20T13:00:01.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"must not survive",created_at:"2026-07-20T13:00:01.000000Z",
+        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"must not survive",created_at:"2026-07-20T13:00:01.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
+  page=$(printf '%s\n%s\n' "$remote" '{"type":"sync_pull_cursor","next_after":"1"}')
+
+  # Make the mirror — and only the mirror — fail. Dropping the table does not
+  # work: storage_init recreates it with CREATE TABLE IF NOT EXISTS before the
+  # batch runs, so the mirror succeeds and the test proves nothing. A trigger
+  # survives that and aborts exactly the statement under test.
+  sqlite3 "$db" "CREATE TRIGGER block_mirror BEFORE INSERT ON messages
+                 BEGIN SELECT RAISE(ABORT,'mirror blocked for this test'); END;"
+
+  # Called directly, not through `run bash -c`: these are sourced functions and
+  # a child shell does not have them.
+  local rc=0
+  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 \
+    >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ]
+
+  # The event is the batch's FIRST statement, so it is the one that survives a
+  # partial commit. Without -bail it is committed and the mirror is not, which
+  # is precisely the asymmetry this change exists to prevent.
+  [ "$(sqlite3 "$db" "SELECT count(*) FROM events WHERE body='must not survive';" | tr -d '\r')" -eq 0 ]
+}
+
+# The other direction of the same correspondence. A row that was in the legacy
+# table before any of this gets projected into the event log when a team is
+# prepared for push; if that projection does not record which legacy row it is,
+# the readers see the message from both branches and list it twice — the
+# duplicate this change exists to remove, arriving from the other side.
+@test "sync contract: a projected legacy row is not listed twice (#689)" {
+  local db
+  db=$(agmsg_db_path demo)
+  sqlite3 "$db" "INSERT INTO messages (team,from_agent,to_agent,body,created_at)
+                 VALUES ('demo','carol','bob','older than the event log','2026-07-01T00:00:00Z');"
+  local legacy_id
+  legacy_id=$(sqlite3 "$db" "SELECT id FROM messages WHERE body='older than the event log';" | tr -d '\r')
+
+  prepare_push >/dev/null
+
+  # Projected, and carrying the link back to the row it came from.
+  [ "$(sqlite3 "$db" "SELECT COALESCE(legacy_id,-1) FROM events WHERE type='message_sent' AND body='older than the event log';" | tr -d '\r')" = "$legacy_id" ]
+
+  # And therefore counted once by each reader.
+  [ "$(storage_history demo | jq -s '[.[]|select(.body=="older than the event log")]|length')" -eq 1 ]
+  [ "$(storage_list_unread demo bob | jq -s '[.[]|select(.body=="older than the event log")]|length')" -le 1 ]
+}

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -604,38 +604,56 @@ _reconcile_one_ack() {
 # Success and replay tests cannot see this; only a forced failure inside the
 # batch can.
 @test "sync contract: a failure inside the apply commits nothing (#689)" {
-  local remote page db
+  local first second db before_cursor
   db=$(agmsg_db_path demo)
-  remote=$(jq -nc '
+
+  # Apply one page for real first, so the sync mapping and the transport cursor
+  # hold a value that a partial commit could move. Asserting against a store
+  # where they do not exist yet cannot tell "did not advance" from "was never
+  # there".
+  first=$(jq -nc '
     {type:"sync_pull_message",server_seq:"1",
-     id:"550e8400-e29b-41d4-a716-4466554400b2",
+     id:"550e8400-e29b-41d4-a716-4466554400c1",
      server_received_at:"2026-07-20T13:00:01.000000Z",
      envelope:{v:1,cipher:"none",key_id:null,blob:(
-       {body:"must not survive",created_at:"2026-07-20T13:00:01.000000Z",
+       {body:"first arrival",created_at:"2026-07-20T13:00:01.000000Z",
         from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
      status:"importable",policy_revision:"0",local_security_revision:"0",
-     projection:{body:"must not survive",created_at:"2026-07-20T13:00:01.000000Z",
+     projection:{body:"first arrival",created_at:"2026-07-20T13:00:01.000000Z",
                  from_agent:"carol",to_agent:"bob"}}')
-  page=$(printf '%s\n%s\n' "$remote" '{"type":"sync_pull_cursor","next_after":"1"}')
+  printf '%s\n%s\n' "$first" '{"type":"sync_pull_cursor","next_after":"1"}' \
+    | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  before_cursor=$(sqlite3 "$db" "SELECT transport_cursor FROM sync_bindings WHERE local_team='demo';" | tr -d '\r')
+  [ -n "$before_cursor" ]
 
-  # Make the mirror — and only the mirror — fail. Dropping the table does not
-  # work: storage_init recreates it with CREATE TABLE IF NOT EXISTS before the
-  # batch runs, so the mirror succeeds and the test proves nothing. A trigger
-  # survives that and aborts exactly the statement under test.
+  # Now make the mirror — and only the mirror — fail. Removing the table does
+  # not work: storage_init recreates it before the batch runs, so the mirror
+  # succeeds and the test proves nothing. A trigger survives that and aborts
+  # exactly the statement under test.
   sqlite3 "$db" "CREATE TRIGGER block_mirror BEFORE INSERT ON messages
                  BEGIN SELECT RAISE(ABORT,'mirror blocked for this test'); END;"
 
-  # Called directly, not through `run bash -c`: these are sourced functions and
-  # a child shell does not have them.
+  second=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"2",
+     id:"550e8400-e29b-41d4-a716-4466554400c2",
+     server_received_at:"2026-07-20T13:00:02.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"must not survive",created_at:"2026-07-20T13:00:02.000000Z",
+        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"must not survive",created_at:"2026-07-20T13:00:02.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
   local rc=0
-  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 \
-    >/dev/null 2>&1 || rc=$?
+  printf '%s\n%s\n' "$second" '{"type":"sync_pull_cursor","next_after":"2"}' \
+    | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null 2>&1 || rc=$?
   [ "$rc" -ne 0 ]
 
-  # The event is the batch's FIRST statement, so it is the one that survives a
-  # partial commit. Without -bail it is committed and the mirror is not, which
-  # is precisely the asymmetry this change exists to prevent.
+  # All three, not just the event. Asserting the event alone would also pass for
+  # an implementation that deleted the event afterwards and left the mapping and
+  # the cursor advanced -- which is the state that silently loses a message.
   [ "$(sqlite3 "$db" "SELECT count(*) FROM events WHERE body='must not survive';" | tr -d '\r')" -eq 0 ]
+  [ "$(sqlite3 "$db" "SELECT count(*) FROM sync_messages WHERE wire_id='550e8400-e29b-41d4-a716-4466554400c2';" | tr -d '\r')" -eq 0 ]
+  [ "$(sqlite3 "$db" "SELECT transport_cursor FROM sync_bindings WHERE local_team='demo';" | tr -d '\r')" = "$before_cursor" ]
 }
 
 # The other direction of the same correspondence. A row that was in the legacy
@@ -658,5 +676,5 @@ _reconcile_one_ack() {
 
   # And therefore counted once by each reader.
   [ "$(storage_history demo | jq -s '[.[]|select(.body=="older than the event log")]|length')" -eq 1 ]
-  [ "$(storage_list_unread demo bob | jq -s '[.[]|select(.body=="older than the event log")]|length')" -le 1 ]
+  [ "$(storage_list_unread demo bob | jq -s '[.[]|select(.body=="older than the event log")]|length')" -eq 1 ]
 }


### PR DESCRIPTION
Closes #689. rc1 is held on this.

## The contract

The legacy `messages` table is a read interface other software opens — the desktop app, and any external viewer. The event log replaced it as the source of truth and nothing wrote to it any more, so a message sent by a current build was invisible to all of them. They do not restart when we ship and we cannot enumerate them, which makes this a contract rather than a migration step.

Shown failing first, through the interface those readers use: a direct `SELECT` on the table with no agmsg code in between.

## One writer, and why the correspondence is the design

Every `message_sent` goes through one utility that writes both tables in a single transaction and records the legacy rowid on the event. Three places need that link, and two were **measured** breaking without it:

| where | without the link |
|---|---|
| `storage_list_unread` | the mirror is listed as a second unread message — inbox said `2 new message(s)` |
| `storage_history` | same shape, same result — measured, not assumed |
| the legacy projection in `sqlite-sync` | puts the mirror **back** into the event log as a second event, and the push rewind sends that duplicate to the server and on to every other machine |

Read state is mirrored too. That reverses my own recommendation; the reason against me is better — without it an external viewer shows every message unread forever.

## The arrival path

`sqlite-sync`'s pull is where anything sent from another machine lands, and it is not in `sqlite.sh`. Mirroring only local sends would have left those readers seeing one side of a conversation — the side they could not see being the reason this exists. It inherits the existing duplicate guard rather than repeating it, so re-applying a durable page adds no second row.

## Two defects found while building it

- **`-bail`.** The CLI reports an error and keeps going, so a batch whose second `INSERT` failed still reached its `COMMIT` and committed the first. The retry then inserted the message again — a legacy row no event pointed at, the exact unlinked copy this change prevents.
- **Backticks in an SQL comment** inside a double-quoted shell string are command substitution. It ran `messages` as a command.

## What this does not cover

Stated in the code as well, because "we write to the legacy table" invites the reading that any viewer keeps working:

- **jsonl-driver teams have no legacy table at all** — it is created in this driver and `internal/init-db.sh`, nowhere else. **Measured, not assumed**: the jsonl driver's only `messages` references are a field of the sync pull payload. So the answer there is "does not apply", not "also fixed".
- **Per-team stores** write to a different file; a viewer pointed at the shared store sees nothing for them.
- **No end date.** It ends when someone shows nothing reads the table. Until then it is a supported interface, not a temporary shim — written down because an unbounded compatibility write with no stated exit becomes permanent by default.

## Mutation

| mutation | result |
|---|---|
| drop the local mirror insert | 2 red |
| drop the `list_unread` dedup | 1 red |
| drop the read-state mirror | 1 red |
| drop the remote-pull mirror | 1 red |

Restore → **311/311 green** across mirror / remote-sync / messaging / inbox / delivery / storage-contract / export / jsonl-sync / roster, under bash 3.2.
