### PR TITLE
fix(ci): stop age-v1/jsonl contracts from running on a remote-setup*.md-only diff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,18 @@ name: tests
 # CHANGELOG, etc). SKILL.md is deliberately EXCLUDED — the suite asserts on it
 # (tests/test_install.bats checks it has no unsubstituted placeholder), so a
 # SKILL.md change must run the suite. Anything not on the allowlist runs it too.
+#
+# `docs_only` only decides the bats suite. `age-v1-contract` and
+# `storage-jsonl` are additional, narrower jobs (crypto vectors / the jsonl
+# storage driver) that used to gate on the same flag, so anything that turned
+# `docs_only` false forced both of them to run in full regardless of whether
+# the diff had anything to do with either -- concretely, a
+# `docs/remote-setup*.md`-only diff (which must flip docs_only so the suite
+# that reads it still runs, see below) also ran a ~5-minute age-v1 job and two
+# ~1-minute jsonl jobs that never touch that file (#706). `contracts_needed`
+# is the same classification MINUS that one exception: true whenever
+# `docs_only` would be false for any OTHER reason, false when the only reason
+# was `docs/remote-setup*.md`.
 
 on:
   push:
@@ -51,6 +63,7 @@ jobs:
       app_changed: ${{ steps.detect.outputs.app_changed }}
       server_changed: ${{ steps.detect.outputs.server_changed }}
       sync_changed: ${{ steps.detect.outputs.sync_changed }}
+      contracts_needed: ${{ steps.detect.outputs.contracts_needed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,6 +81,7 @@ jobs:
             echo "app_changed=true" >> "$GITHUB_OUTPUT"
             echo "server_changed=true" >> "$GITHUB_OUTPUT"
             echo "sync_changed=true" >> "$GITHUB_OUTPUT"
+            echo "contracts_needed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
@@ -77,6 +91,7 @@ jobs:
           app_changed=false
           server_changed=false
           sync_changed=false
+          contracts_needed=false
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
@@ -89,23 +104,29 @@ jobs:
               # for an hour, and `docs/remote-setup.ja.md` landed inside that
               # hour carrying the same port, docs-only and unguarded. The next
               # translation is covered without anyone remembering this line.
+              #
+              # contracts_needed is deliberately NOT set here (#706): a
+              # walkthrough is prose the age-v1/jsonl-storage contracts never
+              # read, so forcing the suite that does read it to run is not a
+              # reason to also run those.
               docs/remote-setup*.md) docs_only=false ;;
               docs/*) ;;
               site/*) ;;
               app/*) app_changed=true ;;
-              server/*) docs_only=false; server_changed=true ;;
-              scripts/remote*.sh|scripts/internal/*|scripts/drivers/storage/*|scripts/lib/*|tests/*sync*.*|tests/test_remote*.bats|server/test/sync-client.integration.test.ts|.github/workflows/tests.yml) docs_only=false; sync_changed=true ;;
+              server/*) docs_only=false; server_changed=true; contracts_needed=true ;;
+              scripts/remote*.sh|scripts/internal/*|scripts/drivers/storage/*|scripts/lib/*|tests/*sync*.*|tests/test_remote*.bats|server/test/sync-client.integration.test.ts|.github/workflows/tests.yml) docs_only=false; sync_changed=true; contracts_needed=true ;;
               llms.txt|llms-full.txt) ;;
               README.md|CHANGELOG.md|CONTRIBUTING.md|PRIVACY.md|ARCHITECTURE.md|RELEASING.md|LICENSE) ;;
               # NOTE: SKILL.md is intentionally not here — the suite tests it.
-              *) docs_only=false ;;
+              *) docs_only=false; contracts_needed=true ;;
             esac
           done <<< "$changed"
-          echo "Result: docs_only=$docs_only app_changed=$app_changed server_changed=$server_changed sync_changed=$sync_changed"
+          echo "Result: docs_only=$docs_only app_changed=$app_changed server_changed=$server_changed sync_changed=$sync_changed contracts_needed=$contracts_needed"
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
           echo "app_changed=$app_changed" >> "$GITHUB_OUTPUT"
           echo "server_changed=$server_changed" >> "$GITHUB_OUTPUT"
           echo "sync_changed=$sync_changed" >> "$GITHUB_OUTPUT"
+          echo "contracts_needed=$contracts_needed" >> "$GITHUB_OUTPUT"
 
   bats-shard:
     name: bats (${{ matrix.os }} ${{ matrix.shard }}/4)
@@ -347,16 +368,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Docs-only change — skipping contract
-        if: needs.changes.outputs.docs_only == 'true'
-        run: echo "Diff is documentation-only; skipping the age-v1 contract."
+        if: needs.changes.outputs.contracts_needed == 'false'
+        run: echo "Diff does not touch anything the age-v1 contract reads; skipping."
 
       - uses: actions/setup-go@v5
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.contracts_needed != 'false'
         with:
           go-version: '1.25.x'
 
       - name: Ensure SQLite and jq are available
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.contracts_needed != 'false'
         run: |
           sqlite3 --version >/dev/null 2>&1 && jq --version >/dev/null 2>&1 || {
             sudo apt-get update
@@ -364,7 +385,7 @@ jobs:
           }
 
       - name: Install pinned age implementation
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.contracts_needed != 'false'
         run: |
           go install filippo.io/age/cmd/age@v1.3.1
           go install filippo.io/age/cmd/age-keygen@v1.3.1
@@ -374,7 +395,7 @@ jobs:
           echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
       - name: Run age-v1 shared vectors
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.contracts_needed != 'false'
         run: |
           age_bin="$(go env GOPATH)/bin/age"
           AGMSG_AGE_BIN="$age_bin" node --test tests/sync_cipher.test.mjs
@@ -389,7 +410,7 @@ jobs:
       # age, the shards skip them for want of the binary, and this job named one
       # of them, so 30 were executed nowhere. Two of those were already red.
       - name: Run every age-gated test
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.contracts_needed != 'false'
         run: |
           command -v age >/dev/null
           command -v age-keygen >/dev/null
@@ -423,31 +444,31 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Docs-only change — skipping
-        if: needs.changes.outputs.docs_only == 'true'
-        run: echo "Diff is documentation-only; skipping the jsonl storage contract."
+        if: needs.changes.outputs.contracts_needed == 'false'
+        run: echo "Diff does not touch anything the jsonl storage contract reads; skipping."
 
       - name: Ensure jq + sqlite3 (Linux)
-        if: runner.os == 'Linux' && needs.changes.outputs.docs_only != 'true'
+        if: runner.os == 'Linux' && needs.changes.outputs.contracts_needed != 'false'
         run: |
           jq --version >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y jq; }
           sqlite3 --version >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y sqlite3; }
 
       - name: Install bats
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.contracts_needed != 'false'
         run: |
           npm config set prefix "$HOME/.npm-global"
           npm install -g bats
           echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
       - name: Show tool versions
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.contracts_needed != 'false'
         run: |
           jq --version
           sqlite3 --version
           bats --version
 
       - name: Run the storage contract against the jsonl driver
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.contracts_needed != 'false'
         env:
           AGMSG_STORAGE_DRIVER: jsonl
         run: bats --print-output-on-failure tests/test_storage_contract.bats

--- a/tests/test_remote_setup_doc.bats
+++ b/tests/test_remote_setup_doc.bats
@@ -272,7 +272,7 @@ EOF
 
   # `run bash -c`, not a `$( )` around the eval: bash 3.2 — which is what CI's
   # macOS runner has — cannot parse a `case` inside command substitution.
-  classify='f="$1"; docs_only=true; app_changed=false; server_changed=false; sync_changed=false; eval "$2"; echo "$docs_only"'
+  classify='f="$1"; docs_only=true; app_changed=false; server_changed=false; sync_changed=false; contracts_needed=false; eval "$2"; echo "$docs_only"'
 
   # Every walkthrough that exists, derived — not a list to keep in step.
   while IFS= read -r doc; do
@@ -294,4 +294,38 @@ EOF
   run bash -c "$classify" _ docs/spec/v1.md "$block"
   [ "$status" -eq 0 ] || return 1
   [ "$output" = true ] || return 1
+}
+
+@test "remote-setup: editing a walkthrough runs the suite WITHOUT also forcing the age-v1/jsonl contracts (#706)" {
+  # docs_only=false is necessary to keep the bats suite running on a
+  # walkthrough edit, but it used to be sufficient to also run age-v1-contract
+  # and storage-jsonl, which never read this file. contracts_needed is the
+  # same classifier's independent verdict for those two jobs specifically.
+  workflow="${BATS_TEST_DIRNAME}/../.github/workflows/tests.yml"
+  block="$(awk '/case ".f" in/,/^ *esac$/' "$workflow")"
+  [ -n "$block" ] || return 1
+
+  classify='f="$1"; docs_only=true; app_changed=false; server_changed=false; sync_changed=false; contracts_needed=false; eval "$2"; echo "$contracts_needed"'
+
+  while IFS= read -r doc; do
+    [ -n "$doc" ] || continue
+    rel="docs/$(basename "$doc")"
+    run bash -c "$classify" _ "$rel" "$block"
+    [ "$status" -eq 0 ] || return 1
+    [ "$output" = false ] || { echo "$rel forces the age-v1/jsonl contracts to run" >&2; return 1; }
+  done <<EOF
+$(walkthroughs "$DOCS")
+EOF
+
+  run bash -c "$classify" _ docs/remote-setup.de.md "$block"
+  [ "$status" -eq 0 ] || return 1
+  [ "$output" = false ] || { echo "a future translation forces the age-v1/jsonl contracts to run" >&2; return 1; }
+
+  # Positive control: contracts_needed must be able to become true, or the
+  # assertions above would pass just as well with a flag that is always
+  # false -- indistinguishable from a flag nothing sets. A change to the
+  # storage layer the jsonl contract actually covers must still trigger it.
+  run bash -c "$classify" _ scripts/lib/storage.sh "$block"
+  [ "$status" -eq 0 ] || return 1
+  [ "$output" = true ] || { echo "a storage-layer change no longer triggers the age-v1/jsonl contracts" >&2; return 1; }
 }


### PR DESCRIPTION
## Summary

Part of #706. A diff whose only non-inert content is `docs/remote-setup*.md` currently runs the full `age-v1 contract` job and both `storage contract (jsonl, ...)` jobs, in addition to the bats suite, even though none of the three reads a byte of that file.

Measured on PR #701 (2 markdown files only):

```
age-v1 contract                          pass   4m37s   <- does real work
storage contract (jsonl, macos-latest)   pass   1m0s    <- does real work
storage contract (jsonl, ubuntu-latest)  pass   58s     <- does real work
app typecheck                            pass   9s      <- already skip-gated correctly (app_changed)
app test (windows-latest)                pass   11s     <- already skip-gated correctly (app_changed)
remote server                            pass   18s     <- already skip-gated correctly (server_changed/sync_changed)
```

The check *count* does not change and must not: required checks always run and always report a terminal status (see the workflow's own header comment on the paths-ignore trap this avoids). The cost this PR removes is the real work inside two of those checks — over 6.5 minutes of it on #701 — not the number of green checkmarks on the PR. The last three rows above are cited only as the empirical cost of a correctly-scoped skip step (single digits to ~20s): that is what `age-v1-contract` and `storage-jsonl` will cost on this diff shape once they are gated the same way.

## Why

`docs/remote-setup*.md` deliberately sets `docs_only=false` so `tests/test_remote_setup_doc.bats` (which reads that file) still runs — skipping the suite on a change to the file it guards would defeat the guard. But `age-v1-contract` and `storage-jsonl` gated their heavy steps on that same `docs_only` flag, so anything that flips it also forces both of them to run regardless of relevance.

## What changed

Added `contracts_needed`: the same classification as `docs_only` minus the one exception. Every case that currently sets `docs_only=false` for a reason OTHER than `docs/remote-setup*.md` also sets `contracts_needed=true`, so no other diff shape's behavior changes — only a diff whose sole non-"safe" content is `docs/remote-setup*.md` now skips `age-v1-contract` and `storage-jsonl`. `bats-shard` and `bats-windows` are untouched, still gated on `docs_only` alone, exactly as before — the required-check structure itself is out of scope for this change.

`tests/test_remote_setup_doc.bats`'s existing "editing ANY walkthrough does not skip this suite" test (which extracts and runs the real `case` block from the workflow file, not a reimplementation) is unmodified and still green — this PR's claim does not touch what that test already guarantees. A new adjacent test in the same file binds `contracts_needed` the same way: every real walkthrough (and a not-yet-existing translation) classifies as `contracts_needed=false`, with a positive control — a `scripts/lib/storage.sh` change must still classify as `contracts_needed=true` — so the assertion can't pass with a flag nothing sets.

## Validation

- `bats tests/test_remote_setup_doc.bats tests/test_ci_workflow.bats` — 9/9 ok, exit 0.
- Forced negative control (an assertion that has never gone red is indistinguishable from one that never runs): temporarily removed `contracts_needed=true` from the sync-pattern case arm and reran the new test — it failed exactly on the positive-control assertion ("a storage-layer change no longer triggers the age-v1/jsonl contracts"). Restored, reran, green again.
- Directly exercised the classifier logic (the real extracted `case` block, not a reimplementation) against representative diffs: `docs/remote-setup*.md`-only → `docs_only=false contracts_needed=false`; `scripts/lib/*` → both true; an unrelated catch-all path → both true (unchanged from today); a generic `docs/*` file → both false (unchanged); `app/*` only → `docs_only=true app_changed=true contracts_needed=false` (unchanged).
- YAML parses (`ruby -ryaml`) and the embedded `detect` step's shell extracted cleanly and passed `bash -n`.
- Not measured live on this PR, and deliberately not attempted here: this PR's own diff necessarily touches `.github/workflows/tests.yml`, which the existing (unchanged) sync-pattern arm already and correctly classifies as `contracts_needed=true` — so this PR's own CI run will show `age-v1-contract`/`storage-jsonl` running in full, as expected, and cannot by itself demonstrate the skip on a real `remote-setup*.md`-only diff. What's left unverified before merge is specifically the check set GitHub itself generates from `if:`/`needs` evaluation — that only exists on GitHub's side, and a deliberately-broken walkthrough was intentionally not pushed to a live branch to observe it. The live after-set will be observed once this lands: a walkthrough-only PR is already planned separately (adding a Requirements-verification mechanism to `docs/remote-setup*.md`), and its check set after this merges is the real before/after comparison.
