### PR TITLE
feat: ClaudeとCodexの自動委任を追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -117,7 +117,7 @@ cd agmsg
 - Claude Code / Copilot CLI: `/<cmd>`
 - Codex / Gemini CLI / Antigravity: `$<cmd>`
 
-`--cmd` と `--agent-type` は直接スクリプト経路でのみ利用可能。`npm` とプラグインの経路は常に `agmsg` としてインストールされ、ホストのエージェントタイプを自動検出する。
+`npx agmsg install --cmd <名前> --agent-type <種類>` のように、npm経路でもインストーラーのオプションを渡せる。プラグイン経路の初回ブートストラップは `agmsg` という名前を使う。
 
 インストール後、**エージェントを再起動**して（Claude Code / Codex / Gemini CLI / Copilot CLI / Antigravity / OpenCode）新しいスキルを反映させる。
 
@@ -161,6 +161,34 @@ $agmsg              # Codex, Gemini CLI, Antigravity
 - *「チームに誰がいるか」*
 
 適切なサブコマンドはエージェントが選んで実行してくれる。以下のスクリプトリファレンスは自動化・スクリプト・CI向けであり、暗記する必要はない。
+
+### Claude/Codexへの自動委任
+
+ClaudeとCodexの間で質問・レビュー・タスクを委任する場合は、チーム名やエージェント名の入力は不要だ。`delegate.sh` がプロジェクト用チームとセッション固有の送信者を自動作成する。
+
+```bash
+# CodexからClaudeへ
+~/.agents/skills/agmsg/scripts/delegate.sh "$PWD" codex claude-code \
+  "この変更をレビューして" --session-id "${CODEX_THREAD_ID:-}"
+
+# ClaudeからCodexへ
+~/.agents/skills/agmsg/scripts/delegate.sh "$PWD" claude-code codex \
+  "テスト失敗を調査して" --session-id "${CLAUDE_CODE_SESSION_ID:-}"
+```
+
+出力された `conversation=<id>` を次の呼び出しへ渡すと、同じ相手へ継続送信する。
+
+```bash
+~/.agents/skills/agmsg/scripts/delegate.sh "$PWD" codex claude-code \
+  "続けてDB負荷も確認して" --session-id "${CODEX_THREAD_ID:-}" \
+  --conversation conv-xxxxxxxxxxxxxxxx
+```
+
+同じプロジェクトから複数セッションが同時に呼び出しても、チームだけを共有し、送信者と会話相手はセッションごとに分離される。同じconversationの更新は直列化される。
+
+相手が終了していた場合は、記録済みrole sessionのresumeを試す。resumeできない場合も停止せず、直近のagmsg履歴を引き継ぎ文脈として新しいセッションを起動する。
+
+ターミナルやtmuxの都合でセッションを起動できない場合は、`claude --print` または `codex exec` の1回実行へ自動フォールバックする。回答はagmsg履歴へ保存されるため、次回の呼び出しでも同じconversationを継続できる。
 
 チーム名の変更、離脱、2つ目のプロジェクトから同じチームへの参加、プロジェクトの登録解除については [docs/teams.md](docs/teams.md) を参照。
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,23 +9,41 @@ description: Cross-agent messaging via SQLite. Send messages between Claude Code
 
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/agmsg/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
+## Claude/Codexへの自動委任
+
+Claudeへの質問・レビュー・タスクは、手動のチーム初期設定を行わず `delegate.sh` で送る。
+
+```bash
+if [ ! -x ~/.agents/skills/agmsg/scripts/delegate.sh ]; then
+  if ! npx --yes agmsg install --cmd agmsg --agent-type codex; then
+    installer=$(ls ~/.claude/plugins/cache/fujibee-agmsg/agmsg/*/install.sh 2>/dev/null | head -1)
+    [ -n "$installer" ] && bash "$installer" --cmd agmsg --agent-type codex
+  fi
+fi
+~/.agents/skills/agmsg/scripts/delegate.sh "$(pwd)" codex claude-code "<依頼本文>" --session-id "${CODEX_THREAD_ID:-}"
+```
+
+出力された `conversation=<id>` を保持する。「続けて」「追加で聞いて」は同じIDを `--conversation <id>` で渡す。返答は同じconversationと最新generationだけを採用する。
+
+相手が生存中ならメッセージを送り、不在なら前回のrole sessionをresumeする。resumeできない場合はagmsg履歴を渡して新しいセッションを起動する。spawnが失敗した場合は1回実行の直接CLIへ自動フォールバックし、その回答を採用する。
+
 ## How to use
 
 ### Step 0: First-run bootstrap
 
-agmsg keeps its SQLite database, team registry, and runtime state under `~/.agents/skills/agmsg/`. The `./install.sh` install path creates that tree; the Claude Code plugin install path does not (the plugin marketplace flow only drops the skill content into `~/.claude/plugins/cache/`). Before any other command, bootstrap if needed:
+agmsg keeps its SQLite database, team registry, and runtime state under `~/.agents/skills/agmsg/`. The `./install.sh` install path creates that tree; the Claude Code plugin install path does not (the plugin marketplace flow only drops the skill content into `~/.claude/plugins/cache/`). Before any other command, bootstrap if needed. Prefer the npm bootstrapper so no repository checkout or plugin path discovery is required:
 
 ```bash
-if [ ! -d ~/.agents/skills/agmsg ]; then
-  # Locate the plugin install script (any version), run it once.
-  installer=$(ls ~/.claude/plugins/cache/fujibee-agmsg/agmsg/*/install.sh 2>/dev/null | head -1)
-  if [ -n "$installer" ]; then
-    bash "$installer" --cmd agmsg
-  else
-    echo "agmsg not installed. Either:" >&2
-    echo "  - run ./install.sh in the agmsg repo, or" >&2
-    echo "  - install via /plugin marketplace add fujibee/agmsg && /plugin install agmsg@fujibee-agmsg" >&2
-    exit 1
+if [ ! -x ~/.agents/skills/agmsg/scripts/delegate.sh ]; then
+  if ! command -v npx >/dev/null 2>&1 \
+      || ! npx --yes agmsg install --cmd agmsg --agent-type codex; then
+    installer=$(ls ~/.claude/plugins/cache/fujibee-agmsg/agmsg/*/install.sh 2>/dev/null | head -1)
+    if [ -n "$installer" ]; then
+      bash "$installer" --cmd agmsg --agent-type codex
+    else
+      echo "agmsg requires npx (Node.js) or an installed agmsg plugin" >&2
+      exit 1
+    fi
   fi
 fi
 ```

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create or recover a deterministic, session-scoped agmsg identity without
+# asking the user to choose a team or agent name.
+#
+# Usage:
+#   bootstrap.sh <project> <type> [--session-id <id>] [--team <team>]
+#                [--instance-id <id>] [--agent <agent>]
+#                [--delivery <mode>|--no-delivery]
+#
+# The team is stable for a physical project path. The agent is stable for the
+# current agent-process instance, so parallel Codex/Claude sessions share the
+# project team without competing for the same inbox identity.
+
+PROJECT="${1:?Usage: bootstrap.sh <project> <type> [options]}"
+TYPE="${2:?Missing agent type}"
+shift 2
+
+SESSION_ID=""
+INSTANCE_ID_OVERRIDE=""
+TEAM=""
+AGENT=""
+AGENT_EXPLICIT=0
+DELIVERY="auto"
+
+while (($#)); do
+  case "$1" in
+    --session-id)
+      [ "$#" -ge 2 ] || { echo "bootstrap: --session-id needs a value" >&2; exit 2; }
+      SESSION_ID="$2"
+      shift 2
+      ;;
+    --instance-id) INSTANCE_ID_OVERRIDE="${2:?--instance-id needs a value}"; shift 2 ;;
+    --team) TEAM="${2:?--team needs a value}"; shift 2 ;;
+    --agent) AGENT="${2:?--agent needs a value}"; AGENT_EXPLICIT=1; shift 2 ;;
+    --delivery) DELIVERY="${2:?--delivery needs a mode}"; shift 2 ;;
+    --no-delivery) DELIVERY="off"; shift ;;
+    -h|--help)
+      sed -n '4,12p' "$0"
+      exit 0
+      ;;
+    *) echo "bootstrap: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/compat.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/hash.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/type-registry.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/validate.sh"
+
+agmsg_is_known_type "$TYPE" || {
+  echo "bootstrap: unknown agent type '$TYPE'" >&2
+  exit 2
+}
+[ -d "$PROJECT" ] || { echo "bootstrap: project path does not exist: $PROJECT" >&2; exit 2; }
+
+# NOTE: use the physical path rather than a Git remote. Two local clones may
+# intentionally carry different work, while every session in one checkout must
+# converge on exactly the same team.
+PROJECT="$(agmsg_canonical_path "$PROJECT")"
+PROJECT="$(agmsg_normalize_project_path "$PROJECT")"
+PROJECT_HASH="$(printf '%s' "$PROJECT" | agmsg_sha1)"
+
+type_label() {
+  case "$1" in
+    claude-code) printf 'claude' ;;
+    grok-build) printf 'grok' ;;
+    *) printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/-/g' ;;
+  esac
+}
+
+project_slug() {
+  local base slug
+  base="${PROJECT##*/}"
+  slug="$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-24)"
+  printf '%s' "${slug:-project}"
+}
+
+if [ -z "$SESSION_ID" ]; then
+  case "$TYPE" in
+    codex) SESSION_ID="${CODEX_THREAD_ID:-}" ;;
+    claude-code) SESSION_ID="${CLAUDE_CODE_SESSION_ID:-}" ;;
+    grok-build) SESSION_ID="${GROK_SESSION_ID:-}" ;;
+  esac
+fi
+
+# A CLI session id is not exposed by every host. The enclosing agent PID is the
+# next strongest signal and remains stable across tool calls in that session.
+# A generated UUID is last-resort only; callers that need cross-process resume
+# should pass --session-id explicitly.
+if [ -z "$SESSION_ID" ]; then
+  AGENT_PID="$(agmsg_agent_pid "$TYPE" 2>/dev/null || true)"
+  if [ -n "$AGENT_PID" ]; then
+    SESSION_ID="process-$AGENT_PID"
+  else
+    SESSION_ID="generated-$(compat_uuidgen | tr '[:upper:]' '[:lower:]')"
+    echo "bootstrap: warning: no host session id or agent pid; generated identity is process-local" >&2
+  fi
+fi
+
+if [ -z "$TEAM" ]; then
+  TEAM="auto-$(project_slug)-${PROJECT_HASH:0:8}"
+fi
+
+if [ -z "$AGENT" ]; then
+  INSTANCE_KEY="$PROJECT|$TYPE|$SESSION_ID"
+  INSTANCE_HASH="$(printf '%s' "$INSTANCE_KEY" | agmsg_sha1)"
+  AGENT="$(type_label "$TYPE")-${INSTANCE_HASH:0:10}"
+fi
+
+agmsg_validate_team_name "$TEAM" || exit 2
+agmsg_validate_agent_name "$AGENT" || exit 2
+
+EXISTING="$("$SCRIPT_DIR/identities.sh" "$PROJECT" "$TYPE" 2>/dev/null || true)"
+PAIR="$(printf '%s\t%s' "$TEAM" "$AGENT")"
+CREATED=0
+if ! printf '%s\n' "$EXISTING" | grep -Fxq "$PAIR"; then
+  AGMSG_RESOLVE_PROJECT=0 "$SCRIPT_DIR/join.sh" "$TEAM" "$AGENT" "$TYPE" "$PROJECT" >/dev/null
+  CREATED=1
+fi
+
+# Prefer a stable role derived from the host session id, but never let two live
+# processes share it. Claude/Codex can run parallel --resume processes with the
+# same bare session id; the per-process instance token detects that case. A
+# concurrent holder gets an instance-suffixed identity, while a later resume
+# after the old process exits reclaims the stable name.
+LOCK_ID="${INSTANCE_ID_OVERRIDE:-$(agmsg_normalize_instance_id "$SESSION_ID" "$TYPE")}"
+CLAIM_RESULT="$(actas_lock_claim "$TEAM" "$AGENT" "$LOCK_ID" 2>/dev/null || true)"
+if [[ "$CLAIM_RESULT" == held:* ]]; then
+  if [ "$AGENT_EXPLICIT" -eq 1 ]; then
+    echo "bootstrap: explicit agent '$AGENT' is held by another live session (${CLAIM_RESULT#held:})" >&2
+    exit 3
+  fi
+  INSTANCE_HASH="$(printf '%s' "$PROJECT|$TYPE|$SESSION_ID|$LOCK_ID" | agmsg_sha1)"
+  AGENT="$(type_label "$TYPE")-${INSTANCE_HASH:0:10}"
+  agmsg_validate_agent_name "$AGENT" || exit 2
+  PAIR="$(printf '%s\t%s' "$TEAM" "$AGENT")"
+  if ! printf '%s\n' "$EXISTING" | grep -Fxq "$PAIR"; then
+    AGMSG_RESOLVE_PROJECT=0 "$SCRIPT_DIR/join.sh" "$TEAM" "$AGENT" "$TYPE" "$PROJECT" >/dev/null
+    CREATED=1
+  fi
+  CLAIM_RESULT="$(actas_lock_claim "$TEAM" "$AGENT" "$LOCK_ID" 2>/dev/null || true)"
+  if [[ "$CLAIM_RESULT" == held:* ]]; then
+    echo "bootstrap: generated agent '$AGENT' is unexpectedly held (${CLAIM_RESULT#held:})" >&2
+    exit 3
+  fi
+fi
+
+if [ "$DELIVERY" = auto ]; then
+  case "$TYPE" in
+    claude-code) DELIVERY=monitor ;;
+    # Codex monitor needs a launcher/shim. turn works immediately, while a
+    # spawned Codex still receives its first task through --boot-prompt.
+    codex) DELIVERY=turn ;;
+    *)
+      if agmsg_type_has "$TYPE" delivery_modes turn; then DELIVERY=turn; else DELIVERY=off; fi
+      ;;
+  esac
+fi
+
+DELIVERY_OUTPUT=""
+DELIVERY_CONFIGURED=0
+if [ "$DELIVERY" != off ]; then
+  RUN_DIR="$SKILL_DIR/run"
+  mkdir -p "$RUN_DIR" 2>/dev/null || true
+  DELIVERY_MARKER="$RUN_DIR/auto-delivery.${PROJECT_HASH:0:16}.$(type_label "$TYPE")"
+  if [ ! -f "$DELIVERY_MARKER" ]; then
+    if DELIVERY_OUTPUT="$("$SCRIPT_DIR/delivery.sh" set "$DELIVERY" "$TYPE" "$PROJECT" 2>&1)"; then
+      tmp="$(mktemp "$RUN_DIR/.auto-delivery.XXXXXX")"
+      printf '%s\n' "$DELIVERY" > "$tmp"
+      mv -f "$tmp" "$DELIVERY_MARKER"
+      DELIVERY_CONFIGURED=1
+    else
+      printf '%s\n' "$DELIVERY_OUTPUT" >&2
+      exit 1
+    fi
+  fi
+fi
+
+if [ "$TYPE" = claude-code ] && { [ "$DELIVERY" = monitor ] || [ "$DELIVERY" = both ]; }; then
+  WATCH_COMMAND="$(printf '%q %q %q %q %q' \
+    "$SCRIPT_DIR/watch.sh" "$LOCK_ID" "$PROJECT" "$TYPE" "$AGENT")"
+  DELIVERY_OUTPUT="AGMSG-DIRECTIVE: Stop any running agmsg inbox Monitor task for this session, then invoke the Monitor tool with:
+  command: $WATCH_COMMAND
+  description: agmsg inbox stream ($AGENT)
+  persistent: true
+
+This identity filter is required so parallel sessions in the same project do not consume each other's replies."
+fi
+
+printf 'status=ready team=%s agent=%s type=%s created=%s delivery=%s delivery_configured=%s\n' \
+  "$TEAM" "$AGENT" "$TYPE" "$CREATED" "$DELIVERY" "$DELIVERY_CONFIGURED"
+
+# delivery.sh may emit an AGMSG-DIRECTIVE that the host agent must execute in
+# the current session. Preserve it after the machine-readable identity line.
+if [ -n "$DELIVERY_OUTPUT" ]; then
+  printf '%s\n' "$DELIVERY_OUTPUT"
+fi
+exit 0

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -66,6 +66,8 @@ SESSION_ID=$(printf '%s' "$INPUT" \
   | sed -n 's/.*"sessionId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
   | head -1)
 [ -z "$SESSION_ID" ] && SESSION_ID="${GROK_SESSION_ID:-}"
+[ -z "$SESSION_ID" ] && SESSION_ID="${CODEX_THREAD_ID:-}"
+[ -z "$SESSION_ID" ] && SESSION_ID="${CLAUDE_CODE_SESSION_ID:-}"
 if [ -n "$SESSION_ID" ]; then
   # The monitor watcher keys its pidfile (and its actas owner, below) on the
   # per-process instance id (#93), not the bare session_id. Normalize to the
@@ -93,14 +95,29 @@ if echo "$WHOAMI" | grep -Eq "not_joined=true|suggest=true"; then
   exit 0
 fi
 
-# Handle multiple identities: use first agent name
-if echo "$WHOAMI" | grep -q "multiple=true"; then
+# When bootstrap-created identities coexist, prefer the pair explicitly owned
+# by this runtime instance. Falling back to the historical first-registration
+# behavior preserves compatibility for sessions that have no lock/session id.
+AGENT=""
+TEAMS=""
+if echo "$WHOAMI" | grep -q "multiple=true" && [ -n "$SESSION_ID" ]; then
+  while IFS=$'\t' read -r candidate_team candidate_agent; do
+    [ -n "$candidate_team" ] || continue
+    if [ "$(actas_lock_state "$candidate_team" "$candidate_agent" "$SESSION_ID")" = mine ]; then
+      AGENT="$candidate_agent"
+      TEAMS="$candidate_team"
+      break
+    fi
+  done < <("$SCRIPT_DIR/identities.sh" "$PROJECT" "$TYPE")
+fi
+
+if [ -z "$AGENT" ] && echo "$WHOAMI" | grep -q "multiple=true"; then
   AGENT=$(echo "$WHOAMI" | sed -n 's/.*agents=\([^,]*\).*/\1/p')
-else
+elif [ -z "$AGENT" ]; then
   # Anchor on a leading "agent=" so "agents=" (multiple/suggest) cannot match.
   AGENT=$(echo "$WHOAMI" | sed -n 's/^agent=\([^ ]*\).*/\1/p')
 fi
-TEAMS=$(echo "$WHOAMI" | sed -n 's/.*teams=\([^ ]*\).*/\1/p')
+[ -n "$TEAMS" ] || TEAMS=$(echo "$WHOAMI" | sed -n 's/.*teams=\([^ ]*\).*/\1/p')
 
 if [ -z "$AGENT" ] || [ -z "$TEAMS" ]; then
   exit 0

--- a/scripts/delegate.sh
+++ b/scripts/delegate.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start or continue a session-scoped conversation with another agmsg agent.
+#
+# Usage:
+#   delegate.sh <project> <from-type> <to-type> <message>
+#               [--conversation <id>] [--new] [--team <team>]
+#               [--from-agent <name>] [--fresh] [--model <id>] [--no-wait]
+#               [--no-delivery]
+
+PROJECT="${1:?Usage: delegate.sh <project> <from-type> <to-type> <message> [options]}"
+FROM_TYPE="${2:?Missing source agent type}"
+TO_TYPE="${3:?Missing target agent type}"
+MESSAGE="${4:?Missing task or question}"
+shift 4
+
+CONVERSATION=""
+NEW=0
+TEAM=""
+FROM_AGENT=""
+FRESH=0
+MODEL=""
+NO_WAIT=0
+SESSION_ID=""
+NO_DELIVERY=0
+
+while (($#)); do
+  case "$1" in
+    --conversation) CONVERSATION="${2:?--conversation needs an id}"; shift 2 ;;
+    --new) NEW=1; shift ;;
+    --team) TEAM="${2:?--team needs a name}"; shift 2 ;;
+    --from-agent) FROM_AGENT="${2:?--from-agent needs a name}"; shift 2 ;;
+    --session-id)
+      [ "$#" -ge 2 ] || { echo "delegate: --session-id needs an id" >&2; exit 2; }
+      SESSION_ID="$2"
+      shift 2
+      ;;
+    --fresh) FRESH=1; shift ;;
+    --model) MODEL="${2:?--model needs an id}"; shift 2 ;;
+    --no-wait) NO_WAIT=1; shift ;;
+    --no-delivery) NO_DELIVERY=1; shift ;;
+    -h|--help)
+      sed -n '4,10p' "$0"
+      exit 0
+      ;;
+    *) echo "delegate: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/compat.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/hash.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-project.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/type-registry.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/validate.sh"
+
+agmsg_is_known_type "$FROM_TYPE" || { echo "delegate: unknown source type '$FROM_TYPE'" >&2; exit 2; }
+agmsg_is_known_type "$TO_TYPE" || { echo "delegate: unknown target type '$TO_TYPE'" >&2; exit 2; }
+
+bootstrap_args=("$PROJECT" "$FROM_TYPE")
+[ "$NO_DELIVERY" -eq 1 ] && bootstrap_args+=(--no-delivery)
+[ -n "$SESSION_ID" ] && bootstrap_args+=(--session-id "$SESSION_ID")
+[ -n "$TEAM" ] && bootstrap_args+=(--team "$TEAM")
+[ -n "$FROM_AGENT" ] && bootstrap_args+=(--agent "$FROM_AGENT")
+BOOTSTRAP_OUTPUT="$("$SCRIPT_DIR/bootstrap.sh" "${bootstrap_args[@]}")"
+BOOTSTRAP_LINE="$(printf '%s\n' "$BOOTSTRAP_OUTPUT" | head -n 1)"
+BOOTSTRAP_EXTRA="$(printf '%s\n' "$BOOTSTRAP_OUTPUT" | sed -n '2,$p')"
+
+read_field() {
+  local key="$1" token
+  for token in $BOOTSTRAP_LINE; do
+    case "$token" in "$key"=*) printf '%s' "${token#*=}"; return 0 ;; esac
+  done
+  return 1
+}
+
+TEAM="${TEAM:-$(read_field team)}"
+FROM_AGENT="${FROM_AGENT:-$(read_field agent)}"
+PROJECT="$(agmsg_canonical_path "$PROJECT")"
+PROJECT="$(agmsg_normalize_project_path "$PROJECT")"
+
+short_type() {
+  case "$1" in
+    claude-code) printf 'claude' ;;
+    grok-build) printf 'grok' ;;
+    *) printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/-/g' ;;
+  esac
+}
+
+if [ "$NEW" -eq 1 ]; then
+  [ -z "$CONVERSATION" ] || { echo "delegate: --new and --conversation are mutually exclusive" >&2; exit 2; }
+  CONVERSATION="conv-$(compat_uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]' | cut -c1-16)"
+elif [ -z "$CONVERSATION" ]; then
+  conv_hash="$(printf '%s' "$TEAM|$FROM_AGENT|$TO_TYPE" | agmsg_sha1)"
+  CONVERSATION="conv-${conv_hash:0:16}"
+fi
+
+agmsg_validate_agent_name "$CONVERSATION" || exit 2
+conv_hash="$(printf '%s' "$CONVERSATION" | agmsg_sha1)"
+TO_AGENT="$(short_type "$TO_TYPE")-${conv_hash:0:12}"
+agmsg_validate_agent_name "$TO_AGENT" || exit 2
+
+STATE_DIR="$SKILL_DIR/run/delegations"
+mkdir -p "$STATE_DIR"
+STATE="$STATE_DIR/$CONVERSATION"
+LOCK="$STATE.lock"
+
+# NOTE: serialize updates to one conversation so two callers cannot allocate
+# the same generation or race a send against a replacement spawn. mkdir is the
+# portable atomic primitive (macOS has no flock). The owner pid lets a later
+# call reclaim a lock left by SIGKILL instead of permanently stopping the
+# conversation.
+acquire_conversation_lock() {
+  local i=0 owner reclaim="${LOCK}.reclaim"
+  while [ "$i" -lt 1000 ]; do
+    if mkdir "$LOCK" 2>/dev/null; then
+      printf '%s\n' "$$" > "$LOCK/owner"
+      return 0
+    fi
+    owner="$(cat "$LOCK/owner" 2>/dev/null || true)"
+    if [ -z "$owner" ] || ! _agmsg_pid_alive "$owner"; then
+      if mkdir "$reclaim" 2>/dev/null; then
+        owner="$(cat "$LOCK/owner" 2>/dev/null || true)"
+        if [ -z "$owner" ] || ! _agmsg_pid_alive "$owner"; then
+          rm -f "$LOCK/owner" 2>/dev/null || true
+          rmdir "$LOCK" 2>/dev/null || true
+        fi
+        rmdir "$reclaim" 2>/dev/null || true
+      fi
+    fi
+    i=$((i + 1))
+    sleep 0.01
+  done
+  echo "delegate: timed out waiting for conversation '$CONVERSATION'" >&2
+  return 1
+}
+
+release_conversation_lock() {
+  local owner
+  owner="$(cat "$LOCK/owner" 2>/dev/null || true)"
+  if [ "$owner" = "$$" ]; then
+    rm -f "$LOCK/owner" 2>/dev/null || true
+    rmdir "$LOCK" 2>/dev/null || true
+  fi
+}
+
+acquire_conversation_lock || exit 3
+trap 'release_conversation_lock' EXIT
+trap 'release_conversation_lock; exit 130' INT
+trap 'release_conversation_lock; exit 143' TERM
+
+GENERATION=0
+if [ -f "$STATE" ]; then
+  while IFS='=' read -r key value; do
+    case "$key" in generation) GENERATION="$value" ;; esac
+  done < "$STATE"
+fi
+
+TASK_ID="task-$(compat_uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]' | cut -c1-16)"
+TARGET_STATE="$(actas_lock_state "$TEAM" "$TO_AGENT" "" 2>/dev/null || echo free)"
+
+write_state() {
+  local tmp
+  tmp="$(mktemp "$STATE_DIR/.delegation.XXXXXX")"
+  {
+    printf 'conversation=%s\n' "$CONVERSATION"
+    printf 'team=%s\n' "$TEAM"
+    printf 'project=%s\n' "$PROJECT"
+    printf 'from_type=%s\n' "$FROM_TYPE"
+    printf 'from_agent=%s\n' "$FROM_AGENT"
+    printf 'to_type=%s\n' "$TO_TYPE"
+    printf 'to_agent=%s\n' "$TO_AGENT"
+    printf 'generation=%s\n' "$GENERATION"
+    printf 'last_task=%s\n' "$TASK_ID"
+    printf 'updated_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+  } > "$tmp"
+  mv -f "$tmp" "$STATE"
+}
+
+MARKER="[agmsg-delegate conversation=$CONVERSATION generation=$GENERATION task=$TASK_ID]"
+REPLY_COMMAND="$(printf '%q %q %q %q' "$SCRIPT_DIR/send.sh" "$TEAM" "$TO_AGENT" "$FROM_AGENT")"
+
+if [[ "$TARGET_STATE" == other:* ]]; then
+  BODY="$MARKER
+$MESSAGE
+
+Reply to this exact task with the same conversation, generation, and task marker."
+  "$SCRIPT_DIR/send.sh" "$TEAM" "$FROM_AGENT" "$TO_AGENT" "$BODY" >/dev/null
+  write_state
+  printf 'status=sent conversation=%s task=%s generation=%s team=%s from=%s to=%s\n' \
+    "$CONVERSATION" "$TASK_ID" "$GENERATION" "$TEAM" "$FROM_AGENT" "$TO_AGENT"
+  [ -z "$BOOTSTRAP_EXTRA" ] || printf '%s\n' "$BOOTSTRAP_EXTRA"
+  exit 0
+fi
+
+GENERATION=$((GENERATION + 1))
+MARKER="[agmsg-delegate conversation=$CONVERSATION generation=$GENERATION task=$TASK_ID]"
+
+# The message database is the durable handoff source. Include only this target
+# role's recent history, and cap it so a long-lived conversation cannot overflow
+# a CLI argument or bury the current task.
+HISTORY="$("$SCRIPT_DIR/api.sh" get teams "$TEAM" messages --agent "$TO_AGENT" --limit 30 2>/dev/null || true)"
+if [ "${#HISTORY}" -gt 12000 ]; then
+  HISTORY="${HISTORY: -12000}"
+fi
+[ -n "$HISTORY" ] || HISTORY="(no prior messages recorded)"
+
+BOOT_PROMPT="You are the agmsg peer '$TO_AGENT' for conversation '$CONVERSATION' (generation $GENERATION).
+
+Current task:
+$MARKER
+$MESSAGE
+
+When you have progress, need clarification, or finish, send a message back to '$FROM_AGENT' in team '$TEAM' using:
+  $REPLY_COMMAND \"$MARKER <your message>\"
+
+Recent durable handoff history follows. Use it only to recover context; inspect the current project state before changing files, and do not repeat work already completed:
+$HISTORY"
+
+# A terminal/tmux launch is preferred because it leaves a peer available for
+# follow-up messages. If that launch is impossible, a one-shot CLI call still
+# completes the current request and its answer is persisted in agmsg, so a UI
+# or resume failure cannot strand the caller's conversation.
+run_direct_fallback() {
+  local direct_prompt direct_args=()
+  direct_prompt="$BOOT_PROMPT
+
+This is a one-shot direct fallback. Do not run the reply command above. Return the complete result as your final output; the caller will persist and deliver it."
+
+  case "$TO_TYPE" in
+    claude-code)
+      command -v claude >/dev/null 2>&1 || return 127
+      direct_args=(claude --print)
+      [ -z "$MODEL" ] || direct_args+=(--model "$MODEL")
+      (cd "$PROJECT" && "${direct_args[@]}" "$direct_prompt")
+      ;;
+    codex)
+      command -v codex >/dev/null 2>&1 || return 127
+      direct_args=(codex exec --cd "$PROJECT" --skip-git-repo-check --color never)
+      [ -z "$MODEL" ] || direct_args+=(--model "$MODEL")
+      "${direct_args[@]}" "$direct_prompt"
+      ;;
+    *)
+      return 127
+      ;;
+  esac
+}
+
+spawn_args=("$TO_TYPE" "$TO_AGENT" --project "$PROJECT" --team "$TEAM" --boot-prompt "$BOOT_PROMPT")
+[ "$FRESH" -eq 1 ] && spawn_args+=(--fresh)
+[ -n "$MODEL" ] && spawn_args+=(--model "$MODEL")
+[ "$NO_WAIT" -eq 1 ] && spawn_args+=(--no-wait)
+
+if ! SPAWN_OUTPUT="$("$SCRIPT_DIR/spawn.sh" "${spawn_args[@]}" 2>&1)"; then
+  echo "$SPAWN_OUTPUT" >&2
+  TARGET_AFTER_FAILURE="$(actas_lock_state "$TEAM" "$TO_AGENT" "" 2>/dev/null || echo free)"
+  if [[ "$TARGET_AFTER_FAILURE" == other:* ]]; then
+    # spawn may report a readiness timeout after the peer has already claimed
+    # its role. The boot prompt already contains this task, so sending it again
+    # or launching a direct copy would duplicate work.
+    write_state
+    printf 'status=spawned-unconfirmed conversation=%s task=%s generation=%s team=%s from=%s to=%s\n' \
+      "$CONVERSATION" "$TASK_ID" "$GENERATION" "$TEAM" "$FROM_AGENT" "$TO_AGENT"
+    [ -z "$BOOTSTRAP_EXTRA" ] || printf '%s\n' "$BOOTSTRAP_EXTRA"
+    exit 0
+  fi
+
+  echo "delegate: agmsg spawn failed; running one-shot direct fallback" >&2
+  if ! DIRECT_OUTPUT="$(run_direct_fallback 2>&1)"; then
+    [ -z "$DIRECT_OUTPUT" ] || printf '%s\n' "$DIRECT_OUTPUT" >&2
+    echo "delegate: both agmsg spawn and direct fallback failed" >&2
+    exit 4
+  fi
+  [ -n "$DIRECT_OUTPUT" ] || DIRECT_OUTPUT="(direct fallback completed without textual output)"
+  "$SCRIPT_DIR/send.sh" "$TEAM" "$TO_AGENT" "$FROM_AGENT" "$MARKER
+$DIRECT_OUTPUT" >/dev/null
+  write_state
+  printf 'status=fallback conversation=%s task=%s generation=%s team=%s from=%s to=%s\n' \
+    "$CONVERSATION" "$TASK_ID" "$GENERATION" "$TEAM" "$FROM_AGENT" "$TO_AGENT"
+  printf '%s\n' "$DIRECT_OUTPUT"
+  [ -z "$BOOTSTRAP_EXTRA" ] || printf '%s\n' "$BOOTSTRAP_EXTRA"
+  exit 0
+fi
+
+write_state
+printf 'status=spawned conversation=%s task=%s generation=%s team=%s from=%s to=%s\n' \
+  "$CONVERSATION" "$TASK_ID" "$GENERATION" "$TEAM" "$FROM_AGENT" "$TO_AGENT"
+printf '%s\n' "$SPAWN_OUTPUT"
+[ -z "$BOOTSTRAP_EXTRA" ] || printf '%s\n' "$BOOTSTRAP_EXTRA"

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -6,6 +6,21 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/__SKILL_NAME__/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
+## Codexへの自動委任
+
+Codexへの質問・レビュー・タスクは、手動のチーム初期設定を行わず `delegate.sh` で送る。
+
+```bash
+if [ ! -x ~/.agents/skills/__SKILL_NAME__/scripts/delegate.sh ]; then
+  npx --yes agmsg install --cmd __SKILL_NAME__ --agent-type claude-code
+fi
+~/.agents/skills/__SKILL_NAME__/scripts/delegate.sh "$(pwd)" claude-code codex "<依頼本文>" --session-id "${CLAUDE_CODE_SESSION_ID:-}"
+```
+
+出力された `conversation=<id>` を保持する。「続けて」「追加で頼んで」は同じIDを `--conversation <id>` で渡す。返答は同じconversationと最新generationだけを採用する。
+
+相手が生存中ならメッセージを送り、不在なら前回のrole sessionをresumeする。resumeできない場合はagmsg履歴を渡して新しいCodexセッションを起動する。spawnが失敗した場合は `codex exec` へ自動フォールバックし、その回答を採用する。
+
 ## Identity
 
 If you already know your AGENT and TEAMS from a previous `/__SKILL_NAME__` call in this session, skip to **Execute** below.
@@ -188,7 +203,7 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 4. Tell the user: "Dropped role `<name>` from this project."
 
 If argument starts with "spawn" (e.g. "spawn codex reviewer", "spawn claude-code alice --window"):
-1. Parse `<type>` (must be `claude-code` or `codex`), `<name>`, and any options (`--project`, `--team`, `--window`, `--split h|v`, `--terminal`, `--no-wait`, `--ready-timeout <secs>`).
+1. Parse `<type>` (must be `claude-code` or `codex`), `<name>`, and any options (`--boot-prompt`, `--project`, `--team`, `--window`, `--split h|v`, `--terminal`, `--no-wait`, `--ready-timeout <secs>`).
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
    - spawn.sh pre-joins `<name>`, then opens a tmux pane/window (when this session is inside tmux) or a new OS terminal, and launches the target CLI with `/__SKILL_NAME__ actas <name>` as its initial prompt.
    - By default it BLOCKS until the new agent's watcher attaches and prints `status=ready` — so you can message `<name>` right away. It prints `status=timeout` and exits 3 if not ready within `--ready-timeout` (default 90s); pass `--no-wait` for fire-and-forget. Codex skips the wait (no Monitor).

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -7,6 +7,21 @@ Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER dir
 
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/__SKILL_NAME__/scripts/send.sh myteam alice bob "hello"'`. Always single-quote the `bash -lc` payload; NEVER use a double-quoted wrapper with escaped inner quotes (e.g. `bash -lc "... \"$PWD\" ..."`) — PowerShell parses `\"` as a literal backslash that terminates the string, silently corrupting the command and dropping everything after it. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
+## Claudeへの自動委任
+
+Claudeへの質問・レビュー・タスクは、手動のチーム初期設定を行わず `delegate.sh` で送る。
+
+```bash
+if [ ! -x ~/.agents/skills/__SKILL_NAME__/scripts/delegate.sh ]; then
+  npx --yes agmsg install --cmd __SKILL_NAME__ --agent-type codex
+fi
+~/.agents/skills/__SKILL_NAME__/scripts/delegate.sh "$(pwd)" codex claude-code "<依頼本文>" --session-id "${CODEX_THREAD_ID:-}"
+```
+
+出力された `conversation=<id>` を保持する。「続けて」「追加で聞いて」は同じIDを `--conversation <id>` で渡す。返答は同じconversationと最新generationだけを採用する。
+
+相手が生存中ならメッセージを送り、不在なら前回のrole sessionをresumeする。resumeできない場合はagmsg履歴を渡して新しいClaudeセッションを起動する。spawnが失敗した場合は `claude --print` へ自動フォールバックし、その回答を採用する。
+
 ## Identity
 
 If you already know your AGENT and TEAMS from a previous `$__SKILL_NAME__` call in this session, skip to **Execute** below.
@@ -131,7 +146,7 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 4. Tell the user: "Dropped role `<name>` from this project."
 
 If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex reviewer --window"):
-1. Parse `<type>` (must be `claude-code` or `codex`), `<name>`, and any options (`--project`, `--team`, `--window`, `--split h|v`, `--terminal`, `--no-wait`, `--ready-timeout <secs>`).
+1. Parse `<type>` (must be `claude-code` or `codex`), `<name>`, and any options (`--boot-prompt`, `--project`, `--team`, `--window`, `--split h|v`, `--terminal`, `--no-wait`, `--ready-timeout <secs>`).
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
    - spawn.sh pre-joins `<name>`, then opens a tmux pane/window (when this session is inside tmux) or a new OS terminal, and launches the target CLI with `/__SKILL_NAME__ actas <name>` as its initial prompt.
    - By default it BLOCKS until a spawned claude-code agent's watcher attaches (`status=ready`); `status=timeout` + exit 3 if not ready within `--ready-timeout` (default 90s). `--no-wait` for fire-and-forget. Spawning a codex agent skips the wait (codex has no Monitor).

--- a/tests/test_bootstrap.bats
+++ b/tests/test_bootstrap.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  LIVE_PIDS=""
+  export PROJ="$TEST_SKILL_DIR/project"
+  mkdir -p "$PROJ"
+}
+
+teardown() {
+  for pid in $LIVE_PIDS; do kill "$pid" 2>/dev/null || true; done
+  teardown_test_env
+}
+
+@test "bootstrap: creates a deterministic team and session-scoped identity" {
+  run bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id thread-a --no-delivery
+  [ "$status" -eq 0 ]
+  [[ "$output" == status=ready* ]]
+  [[ "$output" == *" type=codex "* ]]
+  [[ "$output" == *" created=1 "* ]]
+
+  first="$output"
+  run bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id thread-a --no-delivery
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" created=0 "* ]]
+
+  first_team="$(printf '%s\n' "$first" | sed -n 's/.* team=\([^ ]*\).*/\1/p')"
+  first_agent="$(printf '%s\n' "$first" | sed -n 's/.* agent=\([^ ]*\).*/\1/p')"
+  [[ "$output" == *" team=$first_team "* ]]
+  [[ "$output" == *" agent=$first_agent "* ]]
+}
+
+@test "bootstrap: an empty optional session id falls back instead of stopping" {
+  run bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id "" --no-delivery
+  [ "$status" -eq 0 ]
+  [[ "$output" == status=ready* ]]
+}
+
+@test "bootstrap: parallel sessions share the project team but not the agent identity" {
+  a="$(bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id thread-a --no-delivery)"
+  b="$(bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id thread-b --no-delivery)"
+
+  team_a="$(printf '%s\n' "$a" | sed -n 's/.* team=\([^ ]*\).*/\1/p')"
+  team_b="$(printf '%s\n' "$b" | sed -n 's/.* team=\([^ ]*\).*/\1/p')"
+  agent_a="$(printf '%s\n' "$a" | sed -n 's/.* agent=\([^ ]*\).*/\1/p')"
+  agent_b="$(printf '%s\n' "$b" | sed -n 's/.* agent=\([^ ]*\).*/\1/p')"
+
+  [ "$team_a" = "$team_b" ]
+  [ "$agent_a" != "$agent_b" ]
+
+  run bash "$SCRIPTS/team.sh" "$team_a"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$agent_a"* ]]
+  [[ "$output" == *"$agent_b"* ]]
+}
+
+@test "bootstrap: concurrent first calls do not lose either session" {
+  bash "$SCRIPTS/bootstrap.sh" "$PROJ" claude-code --session-id session-a --no-delivery > "$TEST_SKILL_DIR/a.out" &
+  pa=$!
+  bash "$SCRIPTS/bootstrap.sh" "$PROJ" claude-code --session-id session-b --no-delivery > "$TEST_SKILL_DIR/b.out" &
+  pb=$!
+  wait "$pa"
+  wait "$pb"
+
+  team="$(sed -n 's/.* team=\([^ ]*\).*/\1/p' "$TEST_SKILL_DIR/a.out")"
+  run bash "$SCRIPTS/team.sh" "$team"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"2 member(s)"* ]]
+}
+
+@test "bootstrap: explicit team and agent preserve an integration-owned identity" {
+  run bash "$SCRIPTS/bootstrap.sh" "$PROJ" claude-code \
+    --session-id session-a --team bridge-team --agent bridge-claude --no-delivery
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" team=bridge-team "* ]]
+  [[ "$output" == *" agent=bridge-claude "* ]]
+}
+
+@test "bootstrap: configures automatic delivery once without overwriting it on later sessions" {
+  run bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id thread-a --delivery turn
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" delivery=turn "* ]]
+  [[ "$output" == *" delivery_configured=1"* ]]
+
+  run bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id thread-b --delivery turn
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" delivery_configured=0"* ]]
+}
+
+@test "bootstrap: Claude monitor directive subscribes only to this session identity" {
+  run bash "$SCRIPTS/bootstrap.sh" "$PROJ" claude-code \
+    --session-id session-a --delivery monitor
+  [ "$status" -eq 0 ]
+  agent="$(printf '%s\n' "$output" | sed -n 's/.* agent=\([^ ]*\).*/\1/p' | head -1)"
+  [[ "$output" == *"watch.sh"* ]]
+  [[ "$output" == *" $agent"* ]]
+  [[ "$output" == *"do not consume each other's replies"* ]]
+}
+
+@test "bootstrap: turn delivery selects the identity owned by this parallel session" {
+  sleep 300 & first_pid=$!
+  sleep 300 & second_pid=$!
+  LIVE_PIDS="$first_pid $second_pid"
+
+  first="$(bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id thread-a \
+    --instance-id "thread-a.$first_pid" --no-delivery)"
+  second="$(bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id thread-b \
+    --instance-id "thread-b.$second_pid" --no-delivery)"
+  team="$(printf '%s\n' "$first" | sed -n 's/.* team=\([^ ]*\).*/\1/p')"
+  old_agent="$(printf '%s\n' "$first" | sed -n 's/.* agent=\([^ ]*\).*/\1/p')"
+  current_agent="$(printf '%s\n' "$second" | sed -n 's/.* agent=\([^ ]*\).*/\1/p')"
+  bash "$SCRIPTS/join.sh" "$team" sender claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/send.sh" "$team" sender "$old_agent" "old-session-reply" >/dev/null
+  bash "$SCRIPTS/send.sh" "$team" sender "$current_agent" "current-session-reply" >/dev/null
+
+  run env AGMSG_AGENT_PID="$second_pid" CODEX_THREAD_ID=thread-b \
+    bash "$SCRIPTS/check-inbox.sh" codex "$PROJ"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"current-session-reply"* ]]
+  [[ "$output" != *"old-session-reply"* ]]
+}
+
+@test "bootstrap: parallel resumes sharing a bare session id get different live identities" {
+  sleep 300 & first_pid=$!
+  sleep 300 & second_pid=$!
+  LIVE_PIDS="$first_pid $second_pid"
+
+  first="$(bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id shared-thread \
+    --instance-id "shared-thread.$first_pid" --no-delivery)"
+  team="$(printf '%s\n' "$first" | sed -n 's/.* team=\([^ ]*\).*/\1/p')"
+  stable_agent="$(printf '%s\n' "$first" | sed -n 's/.* agent=\([^ ]*\).*/\1/p')"
+
+  run bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id shared-thread \
+    --instance-id "shared-thread.$second_pid" --no-delivery
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" team=$team "* ]]
+  [[ "$output" != *" agent=$stable_agent "* ]]
+}

--- a/tests/test_bootstrap.bats
+++ b/tests/test_bootstrap.bats
@@ -17,7 +17,7 @@ teardown() {
 @test "bootstrap: creates a deterministic team and session-scoped identity" {
   run bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id thread-a --no-delivery
   [ "$status" -eq 0 ]
-  [[ "$output" == status=ready* ]]
+  [[ "$output" == *"status=ready"* ]]
   [[ "$output" == *" type=codex "* ]]
   [[ "$output" == *" created=1 "* ]]
 
@@ -35,7 +35,7 @@ teardown() {
 @test "bootstrap: an empty optional session id falls back instead of stopping" {
   run bash "$SCRIPTS/bootstrap.sh" "$PROJ" codex --session-id "" --no-delivery
   [ "$status" -eq 0 ]
-  [[ "$output" == status=ready* ]]
+  [[ "$output" == *"status=ready"* ]]
 }
 
 @test "bootstrap: parallel sessions share the project team but not the agent identity" {

--- a/tests/test_delegate.bats
+++ b/tests/test_delegate.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  LIVE_PID=""
+
+  export STUB_BIN="$TEST_SKILL_DIR/stub-bin"
+  mkdir -p "$STUB_BIN"
+  for bin in claude codex; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB_BIN/$bin"
+    chmod +x "$STUB_BIN/$bin"
+  done
+  export CAPTURE="$TEST_SKILL_DIR/launch-capture.txt"
+  cat > "$STUB_BIN/record.sh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$CAPTURE"
+EOF
+  chmod +x "$STUB_BIN/record.sh"
+  export PATH="$STUB_BIN:$PATH"
+  export AGMSG_TERMINAL="$STUB_BIN/record.sh {cmd}"
+  unset TMUX HERDR_ENV HERDR_PANE_ID HERDR_WORKSPACE_ID
+
+  export PROJ="$TEST_SKILL_DIR/project"
+  mkdir -p "$PROJ"
+}
+
+teardown() {
+  [ -z "$LIVE_PID" ] || kill "$LIVE_PID" 2>/dev/null || true
+  teardown_test_env
+}
+
+field() {
+  local line="$1" key="$2"
+  printf '%s\n' "$line" | sed -n "s/.* $key=\\([^ ]*\\).*/\\1/p"
+}
+
+@test "delegate: first task auto-bootstraps and spawns the opposite agent" {
+  run bash "$SCRIPTS/delegate.sh" "$PROJ" codex claude-code "review this change" \
+    --session-id codex-thread-a --no-wait --no-delivery
+  [ "$status" -eq 0 ]
+  [[ "$output" == status=spawned* ]]
+  [[ "$output" == *"conversation=conv-"* ]]
+  [[ "$output" == *" to=claude-"* ]]
+
+  boot="$(cat "$CAPTURE")"
+  [ -f "$boot" ]
+  run cat "$boot"
+  [[ "$output" == *"review this change"* ]]
+  [[ "$output" == *"agmsg-delegate conversation="* ]]
+  [[ "$output" == *"send.sh"* ]]
+}
+
+@test "delegate: different caller sessions get different conversations and workers" {
+  a="$(bash "$SCRIPTS/delegate.sh" "$PROJ" codex claude-code "task a" --session-id thread-a --no-wait --no-delivery)"
+  b="$(bash "$SCRIPTS/delegate.sh" "$PROJ" codex claude-code "task b" --session-id thread-b --no-wait --no-delivery)"
+
+  [ "$(field "$a" conversation)" != "$(field "$b" conversation)" ]
+  [ "$(field "$a" to)" != "$(field "$b" to)" ]
+  [ "$(field "$a" team)" = "$(field "$b" team)" ]
+}
+
+@test "delegate: a live worker receives a continuation instead of another spawn" {
+  first="$(bash "$SCRIPTS/delegate.sh" "$PROJ" codex claude-code "first" --session-id thread-a --no-wait --no-delivery)"
+  conv="$(field "$first" conversation)"
+  team="$(field "$first" team)"
+  target="$(field "$first" to)"
+
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/actas-lock.sh"
+  sleep 300 &
+  live_pid=$!
+  LIVE_PID="$live_pid"
+  actas_lock_claim "$team" "$target" "target-owner.$live_pid" >/dev/null
+  : > "$CAPTURE"
+
+  run bash "$SCRIPTS/delegate.sh" "$PROJ" codex claude-code "continue" \
+    --session-id thread-a --conversation "$conv" --no-wait \
+    --no-delivery
+  [ "$status" -eq 0 ]
+  [[ "$output" == status=sent* ]]
+  [ ! -s "$CAPTURE" ]
+
+  source_agent="$(field "$first" from)"
+  run bash "$SCRIPTS/inbox.sh" "$team" "$target"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$source_agent"* ]]
+  [[ "$output" == *"continue"* ]]
+}
+
+@test "delegate: replacement worker receives durable history and a higher generation" {
+  first="$(bash "$SCRIPTS/delegate.sh" "$PROJ" claude-code codex "first task" --session-id claude-a --no-wait --no-delivery)"
+  conv="$(field "$first" conversation)"
+  team="$(field "$first" team)"
+  source_agent="$(field "$first" from)"
+  target="$(field "$first" to)"
+
+  bash "$SCRIPTS/send.sh" "$team" "$target" "$source_agent" \
+    "[agmsg-delegate conversation=$conv generation=1 task=old] completed the scan" >/dev/null
+  : > "$CAPTURE"
+
+  run bash "$SCRIPTS/delegate.sh" "$PROJ" claude-code codex "next task" \
+    --session-id claude-a --conversation "$conv" --fresh --no-wait \
+    --no-delivery
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" generation=2 "* ]]
+
+  boot="$(cat "$CAPTURE")"
+  run cat "$boot"
+  [[ "$output" == *"completed the scan"* ]]
+  [[ "$output" == *"next task"* ]]
+  [[ "$output" == *"generation=2"* ]]
+}
+
+@test "delegate: concurrent updates to one conversation allocate distinct generations" {
+  conv="conv-concurrent"
+  bash "$SCRIPTS/delegate.sh" "$PROJ" codex claude-code "task a" \
+    --session-id thread-a --conversation "$conv" --no-wait --no-delivery \
+    > "$TEST_SKILL_DIR/a.out" &
+  pa=$!
+  bash "$SCRIPTS/delegate.sh" "$PROJ" codex claude-code "task b" \
+    --session-id thread-a --conversation "$conv" --no-wait --no-delivery \
+    > "$TEST_SKILL_DIR/b.out" &
+  pb=$!
+  wait "$pa"
+  wait "$pb"
+
+  generations="$(sed -n 's/.* generation=\([^ ]*\).*/\1/p' "$TEST_SKILL_DIR/a.out" "$TEST_SKILL_DIR/b.out" | sort -n | paste -sd, -)"
+  [ "$generations" = "1,2" ]
+}
+
+@test "delegate: reclaims a conversation lock whose owner process is gone" {
+  conv="conv-stale-lock"
+  mkdir -p "$TEST_SKILL_DIR/run/delegations/$conv.lock"
+  printf '%s\n' 999999 > "$TEST_SKILL_DIR/run/delegations/$conv.lock/owner"
+
+  run bash "$SCRIPTS/delegate.sh" "$PROJ" codex claude-code "recover" \
+    --session-id thread-a --conversation "$conv" --no-wait --no-delivery
+  [ "$status" -eq 0 ]
+  [[ "$output" == status=spawned* ]]
+  [ ! -d "$TEST_SKILL_DIR/run/delegations/$conv.lock" ]
+}
+
+@test "delegate: a failed session launch completes through the direct CLI fallback" {
+  cat > "$STUB_BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+printf 'direct fallback answer\n'
+EOF
+  chmod +x "$STUB_BIN/claude"
+  export AGMSG_TERMINAL='false {cmd}'
+
+  run bash "$SCRIPTS/delegate.sh" "$PROJ" codex claude-code "recover without a terminal" \
+    --session-id thread-a --no-delivery
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status=fallback"* ]]
+  [[ "$output" == *"direct fallback answer"* ]]
+
+  team="$(field "$output" team)"
+  source_agent="$(field "$output" from)"
+  run bash "$SCRIPTS/inbox.sh" "$team" "$source_agent"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"direct fallback answer"* ]]
+}

--- a/tests/test_delegate.bats
+++ b/tests/test_delegate.bats
@@ -40,7 +40,7 @@ field() {
   run bash "$SCRIPTS/delegate.sh" "$PROJ" codex claude-code "review this change" \
     --session-id codex-thread-a --no-wait --no-delivery
   [ "$status" -eq 0 ]
-  [[ "$output" == status=spawned* ]]
+  [[ "$output" == *"status=spawned"* ]]
   [[ "$output" == *"conversation=conv-"* ]]
   [[ "$output" == *" to=claude-"* ]]
 
@@ -80,7 +80,7 @@ field() {
     --session-id thread-a --conversation "$conv" --no-wait \
     --no-delivery
   [ "$status" -eq 0 ]
-  [[ "$output" == status=sent* ]]
+  [[ "$output" == *"status=sent"* ]]
   [ ! -s "$CAPTURE" ]
 
   source_agent="$(field "$first" from)"
@@ -139,7 +139,7 @@ field() {
   run bash "$SCRIPTS/delegate.sh" "$PROJ" codex claude-code "recover" \
     --session-id thread-a --conversation "$conv" --no-wait --no-delivery
   [ "$status" -eq 0 ]
-  [[ "$output" == status=spawned* ]]
+  [[ "$output" == *"status=spawned"* ]]
   [ ! -d "$TEST_SKILL_DIR/run/delegations/$conv.lock" ]
 }
 

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -24,6 +24,8 @@ teardown() {
 @test "install: fresh install ships scripts/lib and the commands actually run" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
   [ -f "$SK/scripts/lib/storage.sh" ]
+  [ -x "$SK/scripts/bootstrap.sh" ]
+  [ -x "$SK/scripts/delegate.sh" ]
 
   # End-to-end through the installed scripts — a missing sourced helper would
   # surface here, not just as a stat on a file.
@@ -308,16 +310,24 @@ PS1
   [ ! -d "$SK" ]  # canonical agmsg location absent
 
   # Run the same shell snippet our SKILL.md prescribes as Step 0.
-  HOME="$FAKE_HOME" bash -c '
-    if [ ! -d ~/.agents/skills/agmsg ]; then
-      installer=$(ls ~/.claude/plugins/cache/fujibee-agmsg/agmsg/*/install.sh 2>/dev/null | head -1)
-      [ -n "$installer" ] && bash "$installer" --cmd agmsg
+  local fake_bin="$FAKE_HOME/fake-bin"
+  mkdir -p "$fake_bin"
+  printf "#!/usr/bin/env bash\nexit 1\n" > "$fake_bin/npx"
+  chmod +x "$fake_bin/npx"
+  PATH="$fake_bin:/bin:/usr/bin" HOME="$FAKE_HOME" bash -c '
+    if [ ! -x ~/.agents/skills/agmsg/scripts/delegate.sh ]; then
+      if ! command -v npx >/dev/null 2>&1 \
+          || ! npx --yes agmsg install --cmd agmsg --agent-type codex; then
+        installer=$(ls ~/.claude/plugins/cache/fujibee-agmsg/agmsg/*/install.sh 2>/dev/null | head -1)
+        [ -n "$installer" ] && bash "$installer" --cmd agmsg --agent-type codex
+      fi
     fi
   '
 
   [ -d "$SK" ]
   [ -f "$SK/db/messages.db" ]
   [ -f "$SK/scripts/whoami.sh" ]
+  [ -x "$SK/scripts/delegate.sh" ]
   # The substituted SKILL.md the installer drops should not still carry the
   # __SKILL_NAME__ placeholder (Codex / Gemini / Antigravity all read it).
   ! grep -q "__SKILL_NAME__" "$SK/SKILL.md"


### PR DESCRIPTION
## 概要

- プロジェクト単位のチームとセッション単位のIDを自動作成する `bootstrap.sh` を追加
- Claude Code と Codex の双方向タスク委任・継続会話・履歴復旧を行う `delegate.sh` を追加
- 相手セッションのresumeができない場合は新規セッション、spawnできない場合は直接CLIへ自動フォールバック
- 同一プロジェクトの並列セッションが別ID・別conversationとして受信を分離
- 未インストール時は `npx agmsg install` を優先し、プラグインキャッシュへフォールバック

## 検証

- Bats全42ファイル・921テストを確認（並列干渉した既存watchテストを含むshardは直列再実行し230/230合格）
- 新規・インストール・受信分離テスト 68/68合格
- 配信・dispatch・watch-once回帰テスト 183/183合格
- `bash -n`、ShellCheck、`git diff --check` 合格
- `npm test` 合格
