### PR TITLE
fix(remote): carry every events column through the per-team move (#710)

### DIFF
--- a/scripts/internal/migrate-team-store.sh
+++ b/scripts/internal/migrate-team-store.sh
@@ -62,6 +62,49 @@ src_tables="$(agmsg_sqlite "$SHARED" \
   "SELECT name FROM sqlite_master WHERE type='table';" 2>/dev/null || true)"
 has_table() { printf '%s\n' "$src_tables" | grep -qx "$1"; }
 
+# Every column of events that moves, ASKED OF THE STORE rather than listed
+# here. The copy and the containment check below both use this, and they have to
+# agree: a column carried by one and not the other is either a row that compares
+# equal while differing, or a row the check reports missing forever.
+#
+# A hand-written list is what went wrong. It omitted legacy_id -- the column
+# that links an event to its row in the legacy messages table (#689) -- so every
+# moved message arrived unlinked. That is not a cosmetic loss: the two readers
+# that UNION the two tables list it twice, and the legacy projection in
+# sqlite-sync, whose entire guard is `events.legacy_id = messages.id`, matches
+# nothing and projects the message a SECOND time, which is then pushed to the
+# server and on to every other machine (#710). The containment check carried the
+# same omission, so both sides compared equal and the migration verified clean
+# while dropping the column.
+#
+# Deriving it means the next column added to events is carried without anyone
+# remembering to come here. The destination schema is replayed from this store's
+# own sqlite_master further down, so both stores always have exactly this set --
+# including a shared store old enough to predate legacy_id, which then has no
+# column to lose.
+#
+# Empty is a failure, not "no columns": PRAGMA answering nothing for a table
+# sqlite_master lists means the schema could not be read, and continuing would
+# copy nothing, compare nothing, find nothing missing, and delete the originals.
+#
+# The names are quoted as identifiers before they are interpolated. Nothing in
+# this schema needs it -- agmsg creates the table -- but a name that did would
+# otherwise land in the statement as syntax. `PRAGMA ... | cut -d'|'` is the
+# extraction this repo already uses (drivers/storage/sqlite-sync.sh); a name
+# containing the separator would survive it as two fragments, and quoting turns
+# that into a "no such column" error instead of a statement that means something
+# else.
+EVENT_COLS=""
+if has_table events; then
+  EVENT_COLS="$(agmsg_sqlite "$SHARED" "PRAGMA table_info(events);" \
+    | cut -d'|' -f2 | tr -d '\r' \
+    | sed 's/"/""/g; s/^/"/; s/$/"/' | paste -sd, -)"
+  [ -n "$EVENT_COLS" ] || {
+    echo "team store: could not read the events schema in the shared store" >&2
+    exit 1
+  }
+fi
+
 # Every row of this team that the shared store holds, compared by VALUE.
 #
 # Not a count: equal totals can be different rows. Not a key either: the same
@@ -88,10 +131,10 @@ _missing_from_dest() {
     # destination may be someone else's row, and deleting the shared original on
     # the strength of a matching number would lose it.
     case "$t" in
-      events)   sql="SELECT seq,type,id,team,from_agent,to_agent,body,msg_id,agent,at
+      events)   sql="SELECT $EVENT_COLS
                        FROM $t WHERE team='$lit'
                      EXCEPT
-                     SELECT seq,type,id,team,from_agent,to_agent,body,msg_id,agent,at
+                     SELECT $EVENT_COLS
                        FROM dst.$t WHERE team='$lit';" ;;
       messages) sql="SELECT id,team,from_agent,to_agent,body,created_at,read_at
                        FROM $t WHERE team='$lit'
@@ -242,8 +285,8 @@ team_lit="$(agmsg_sqlesc "$TEAM")"
 copy="BEGIN;"
 if has_table events; then
   copy="$copy
-    INSERT OR IGNORE INTO events(seq,type,id,team,from_agent,to_agent,body,msg_id,agent,at)
-      SELECT seq,type,id,team,from_agent,to_agent,body,msg_id,agent,at
+    INSERT OR IGNORE INTO events($EVENT_COLS)
+      SELECT $EVENT_COLS
         FROM src.events WHERE team='$team_lit';"
 fi
 if has_table messages; then

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -624,3 +624,29 @@ stored_types() {
   # rather than say anything about whether a per-team file got created.
   [ ! -e "$TEST_SKILL_DIR/db/teams/alpha/messages.db" ]
 }
+
+@test "migrate: the link between an event and its legacy row survives the move (#710)" {
+  # #689 records the legacy rowid on the event so that the two rows other code
+  # UNIONs -- the event log and the legacy messages table -- can be recognised
+  # as one message. The copy here carries whole rows, so it has to carry that
+  # column too: without it every moved message arrives unlinked, and the same
+  # two readers #689 measured list it twice again. The projection in
+  # sqlite-sync then pushes a second copy of each one to the server, which is
+  # how it reaches the other machine.
+  bash "$SCRIPTS/send.sh" alpha ann bob "one message" >/dev/null
+  migrate alpha
+
+  run bash "$SCRIPTS/history.sh" alpha bob
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c 'one message')" -eq 1 ]
+
+  # The column that makes that true. Asserted separately because the reader
+  # above can be right for the wrong reason -- a dedupe that guessed from the
+  # body would pass it and still leave the projection with nothing to match.
+  db="$(store_of alpha)"
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM events
+        WHERE team='alpha' AND type='message_sent' AND legacy_id IS NULL;" | tr -d '\r')" -eq 0 ]
+  [ "$(sqlite3 "$db" "SELECT legacy_id FROM events
+        WHERE team='alpha' AND type='message_sent';" | tr -d '\r')" \
+    = "$(sqlite3 "$db" "SELECT id FROM messages WHERE team='alpha';" | tr -d '\r')" ]
+}


### PR DESCRIPTION
The duplication reported in #710. (Left open for the maintainer to close on
merge rather than auto-closing.)

The copy into a team's own store named its `events` columns by hand, and the
list predated `legacy_id`. That column is the only link between an event and its
mirror row in the legacy `messages` table (#689), so every message that already
existed when a team connected arrived in the new store unlinked.

#698 already names what unlinked costs, in its own table: the two readers that
UNION the tables list the message twice, and the legacy projection in
`sqlite-sync` — whose entire guard is `events.legacy_id = messages.id` — puts it
back into the event log as a second event, which the push rewind then sends to
the server and on to every other machine. That is what happens here; the write
path was fixed, the copy was not.

The containment check carried the same hand-written list, so both sides compared
equal and the migration verified clean while dropping the column.

## Shown failing first

The test is red on `integration/remote` at the assertion a reader makes, with no
server and no `connect` involved — `migrate` alone is enough:

```
not ok 25 migrate: the link between an event and its legacy row survives the move (#710)
# (in test file tests/test_migrate_team_store.bats, line 641)
#   `[ "$(printf '%s\n' "$output" | grep -c 'one message')" -eq 1 ]' failed
# team store: 'alpha' -> .../db/teams/alpha/messages.db (2 messages); removed from the shared store
```

## The change

Both the copy and the containment check now derive the column set from the
source store's own schema instead of naming it. The next column added to
`events` is carried without anyone remembering this file, and the two can no
longer disagree — they read the same list.

A schema that cannot be read is treated as a failure rather than as "no
columns". An empty list would copy nothing, compare nothing, find nothing
missing, and delete the originals on the strength of it.

Deriving from the source is safe against an old store: the destination schema is
replayed from that same `sqlite_master` further down, so a shared store
predating `legacy_id` produces a destination without it too and simply has no
column to lose.

Extraction uses `PRAGMA table_info | cut -d'|'`, which is the idiom already in
`drivers/storage/sqlite-sync.sh`. The names are quoted as identifiers before
interpolation — nothing in this schema needs it, but a name that did would
otherwise arrive as syntax, and a name containing the separator now fails as
"no such column" instead of meaning something else.

## Verification

- New test red before, green after — the assertion is what a reader sees
  (`history.sh` output), with the column checked separately so a dedupe that
  guessed from the body could not pass it.
- End to end against the reference server from `server/compose.yaml`, on a real
  install: one message before connect, `connect`, then **one** row in history
  (was two) and **one** row in `sync_messages` (was two, with different wire
  ids).
- `bats tests/` — 1301 pass. One failure per run, and it is a **different** test
  each run: `watch: surfaces an unopenable DB once instead of spinning silently
  (#197)` in one, `launcher: a replacement dispatcher does not double the role
  children (#485)` in the other. Neither file mentions `migrate-team-store`,
  `EVENT_COLS`, or `legacy_id`, and both pass when their file is run on its own.
  Reported as observed rather than as clean — the host is a machine with live
  agmsg codex/grok watcher processes, which is a plausible source for two tests
  that count processes and watch loops.

## Not in this PR

- **Teams already connected keep their duplicates.** The projection has recorded
  `legacy_push_projected_v1` and both copies are on the server. Repairing an
  existing store is a separate decision, and this file's stated philosophy —
  copy, verify, and leave reclaiming to a later choice — suggests it should be
  made deliberately rather than folded in here.
- **`connect` still reports `(2 messages)` for one message.** With the fix in
  place, history is correct and only one row is pushed, so this is now a
  miscount in the message alone — it appears to count the `events` row and its
  `messages` mirror separately. Left alone to keep this focused; noted on #710.
- `messages` and `read_cursors` still use hand-written lists. `read_cursors`
  deliberately compares differently (positions only move forward), so a shared
  derivation would be wrong there; `messages` has no known drift. Neither was
  touched.
