### PR TITLE
fix(server): narrow /v1/health's catch to actual DB unreachability (#705)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -7,7 +7,7 @@ import * as duplicateKeyJson from "json-dup-key-validator";
 import type { Pool } from "pg";
 import { ZodError, z } from "zod";
 import type { Config } from "./config.js";
-import { errorBody, ProtocolError } from "./errors.js";
+import { errorBody, DatabaseUnavailableError, ProtocolError } from "./errors.js";
 import {
   MAX_REQUEST_BYTES,
   connectSchema,
@@ -211,7 +211,16 @@ async function dataPlaneRoutes(
       // staying 200 — this route is also how "is the server up" is asked, and a
       // 404 would be indistinguishable from "no such route".
       return await health(pool, teamId);
-    } catch {
+    } catch (error) {
+      // Narrowed on purpose: this response claims the DATABASE is
+      // unreachable, so only a DatabaseUnavailableError -- thrown solely when
+      // pool.connect() itself failed -- may produce it. Anything else (a
+      // routing bug, a validation failure, a query-level error after a
+      // connection was already established) is a different problem and must
+      // not be reported as the database being down; rethrowing lets the
+      // plugin's own error handler classify and log it instead.
+      if (!(error instanceof DatabaseUnavailableError)) throw error;
+      requestLog(reply, error);
       return reply.status(503).send({
         status: "unavailable",
         protocol: { supported_versions: [1] },

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -1,3 +1,16 @@
+// Thrown only when the connection to the database itself could not be
+// established -- never for a failure that happened after a connection was
+// already in hand (a query bug, an unexpected value, routing, validation).
+// Those are real failures too, but they are not evidence the database is
+// unreachable, and reporting them as `database: "unavailable"` overwrites the
+// one signal a caller has for telling the two apart.
+export class DatabaseUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super("database connection failed", { cause });
+    this.name = "DatabaseUnavailableError";
+  }
+}
+
 export class ProtocolError extends Error {
   constructor(
     readonly statusCode: number,

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -1,5 +1,5 @@
 import type { Pool, PoolClient } from "pg";
-import { ProtocolError } from "./errors.js";
+import { DatabaseUnavailableError, ProtocolError } from "./errors.js";
 import {
   MAX_SEQUENCE,
   type ConnectInput,
@@ -1083,7 +1083,15 @@ export async function health(
   database: "ok";
   team_id?: string;
 }> {
-  const client = await pool.connect();
+  // Only a failure HERE means the database is actually unreachable. Anything
+  // that goes wrong after a client is in hand -- a query bug, an unexpected
+  // row shape -- had a working connection, so it is not this.
+  let client: PoolClient;
+  try {
+    client = await pool.connect();
+  } catch (error) {
+    throw new DatabaseUnavailableError(error);
+  }
   try {
     const serverId = await serverInstanceId(client);
     const base = {

--- a/server/test/server.integration.test.ts
+++ b/server/test/server.integration.test.ts
@@ -181,6 +181,45 @@ describeDatabase("remote storage HTTP API v1", () => {
     expect(malformed.statusCode).toBe(400);
   });
 
+  it("reports database unavailable only when the connection itself fails, not for a failure after connecting (#705)", async () => {
+    // Negative control, both directions -- proving the two are actually told
+    // apart, not that one of them merely happens to be untested.
+
+    // Direction 1: the database really is unreachable.
+    const unreachablePool = new Pool({
+      host: "127.0.0.1",
+      port: 1, // nothing listens here
+      connectionTimeoutMillis: 500,
+    });
+    const unreachableApp = createApp(unreachablePool, config);
+    await unreachableApp.ready();
+    try {
+      const response = await unreachableApp.inject({ method: "GET", url: "/v1/health" });
+      expect(response.statusCode).toBe(503);
+      expect(response.json()).toMatchObject({
+        status: "unavailable",
+        database: "unavailable",
+      });
+    } finally {
+      await unreachableApp.close();
+      await unreachablePool.end();
+    }
+
+    // Direction 2: the connection succeeds, but the query behind it fails --
+    // a real, non-hypothetical instance of "something else went wrong". This
+    // must not be reported as the database being unavailable; the connection
+    // worked fine.
+    await pool.query(`ALTER TABLE server_metadata RENAME TO server_metadata_moved`);
+    try {
+      const response = await app.inject({ method: "GET", url: "/v1/health" });
+      expect(response.statusCode).toBe(500);
+      expect(response.json()).not.toHaveProperty("database");
+      expect(response.json()).toMatchObject({ error: { code: "internal-error" } });
+    } finally {
+      await pool.query(`ALTER TABLE server_metadata_moved RENAME TO server_metadata`);
+    }
+  });
+
   it("answers a name lookup, and refuses more names than it can disambiguate", async () => {
     const lookupName = "lookup-by-name";
     const ids = Array.from({ length: 17 }, (_, index) =>


### PR DESCRIPTION
Closes #705.

## What

`/v1/health`'s catch swallowed every exception and reported all of them as
`database: "unavailable"`, whether the real cause was the database being
unreachable, a routing bug, or a query error that happened after a
successful connection. It also swallowed the exception silently — no log,
no indication of what was actually caught.

This was hit in production: `/v1/health` was queried against the wrong URL
on a control-plane host, got back `503 database: "unavailable"`, and that
was reported as "production is down" — while RDS was `available`, ECS was
`1/1`, the ALB target was `healthy`, and the app was answering `200` the
whole time.

## Fix

- `health()` (`server/src/storage.ts`) now throws a new
  `DatabaseUnavailableError` (`server/src/errors.ts`) only when
  `pool.connect()` itself fails. Anything that goes wrong after a
  connection is already in hand (a query bug, an unexpected shape) is not
  that error.
- The `/v1/health` route (`server/src/app.ts`) only produces the
  `503 database: "unavailable"` response for `DatabaseUnavailableError`.
  Everything else rethrows and is handled by the plugin's existing global
  error handler (500, already logged via `requestLog`).
- The DB-unavailable path itself now logs via `requestLog` too, instead of
  discarding the exception silently.

## Tests

Added a negative-control test, both directions, in
`server/test/server.integration.test.ts`:

1. A genuinely unreachable database (a `Pool` pointed at a port nothing
   listens on) still returns `503 database: "unavailable"`.
2. A connection that succeeds, but a query that fails afterward (achieved
   by renaming `server_metadata` out from under a live connection and
   restoring it in a `finally`), returns `500 internal-error` — not
   `database: "unavailable"`.

Mutation-tested: reverted the fix, confirmed direction 2 goes red (503
where 500 was expected), restored the fix, confirmed 22/22 green.

Local full suite: 2 pre-existing failures unrelated to this diff
(`sync-client.integration.test.ts`'s polling test and one operator-roster
provisioning test), both reproduced identically against the unmodified
code — traced to a local port-8787 conflict with an already-running dev
stack container on this machine (`server.config.port` is hardcoded to
`8787` in that test file), not to anything in this PR. Should be clean in
CI's isolated environment.
