### PR TITLE
docs(remote-setup): make "Docker with Compose" a checkable requirement (#704)

### DIFF
--- a/docs/remote-setup.ja.md
+++ b/docs/remote-setup.ja.md
@@ -41,11 +41,12 @@ flowchart LR
 ## 必要なもの
 
 - Docker と Compose — 自前のデータベースを使うなら PostgreSQL 17。
-  始める前に確認しておくこと: `docker compose version` を打ってバージョンが
-  出ればよい。Compose プラグインが無いと `docker compose ...` はエラーに
-  なるが、そのエラー文には「compose」の一言も出てこない（Docker が
-  `compose` を未知のコマンドとして扱い、残りの引数の解釈を誤るため）。
-  あとで原因を探すより、先に確認したほうが早い。
+  Compose の経路を使うなら、始める前に確認しておくこと:
+  `docker compose version` を打ってバージョンが出ればよい。今回の報告環境
+  では、Compose プラグインが無いと `docker compose up -d --build` が
+  `unknown shorthand flag: 'd' in -d` で失敗し、そのエラー文には
+  「compose」の一言も出てこなかった。あとで原因を探すより、先に確認した
+  ほうが早い。
 - Node.js 22 以降
 - Bash、SQLite、curl
 - サーバーホスト上の agmsg チェックアウト

--- a/docs/remote-setup.ja.md
+++ b/docs/remote-setup.ja.md
@@ -40,7 +40,12 @@ flowchart LR
 
 ## 必要なもの
 
-- Docker と Compose — 自前のデータベースを使うなら PostgreSQL 17
+- Docker と Compose — 自前のデータベースを使うなら PostgreSQL 17。
+  始める前に確認しておくこと: `docker compose version` を打ってバージョンが
+  出ればよい。Compose プラグインが無いと `docker compose ...` はエラーに
+  なるが、そのエラー文には「compose」の一言も出てこない（Docker が
+  `compose` を未知のコマンドとして扱い、残りの引数の解釈を誤るため）。
+  あとで原因を探すより、先に確認したほうが早い。
 - Node.js 22 以降
 - Bash、SQLite、curl
 - サーバーホスト上の agmsg チェックアウト

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -42,7 +42,12 @@ server, the server could read the messages.
 
 ## Requirements
 
-- Docker with Compose — or PostgreSQL 17, if you bring your own database
+- Docker with Compose — or PostgreSQL 17, if you bring your own database.
+  Confirm it before starting: `docker compose version` should print a
+  version, not an error. Without the Compose plugin, `docker compose ...`
+  fails with an error that never mentions "compose" (Docker reads
+  `compose` as an unrecognized command and misparses the rest), so this is
+  worth checking up front rather than debugging later.
 - Node.js 22 or later
 - Bash, SQLite, and curl
 - An agmsg checkout on the server host

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -43,11 +43,12 @@ server, the server could read the messages.
 ## Requirements
 
 - Docker with Compose — or PostgreSQL 17, if you bring your own database.
-  Confirm it before starting: `docker compose version` should print a
-  version, not an error. Without the Compose plugin, `docker compose ...`
-  fails with an error that never mentions "compose" (Docker reads
-  `compose` as an unrecognized command and misparses the rest), so this is
-  worth checking up front rather than debugging later.
+  If you use the Compose path, confirm it before starting:
+  `docker compose version` should print a version, not an error. On the
+  setup this was reported from, a missing Compose plugin surfaced only as
+  `docker compose up -d --build` failing with `unknown shorthand flag: 'd'
+  in -d` — an error that never mentioned "compose" — so this is worth
+  checking up front rather than debugging later.
 - Node.js 22 or later
 - Bash, SQLite, and curl
 - An agmsg checkout on the server host

--- a/tests/test_remote_setup_doc.bats
+++ b/tests/test_remote_setup_doc.bats
@@ -91,6 +91,9 @@ check_walkthrough() {
   grep -q 'docker compose up -d --build' "$doc" \
     || problems="${problems}${doc}: does not offer the Compose path
 "
+  grep -q 'docker compose version' "$doc" \
+    || problems="${problems}${doc}: does not tell the reader how to confirm Compose is actually present (#704)
+"
   grep -q '/v1/health' "$doc" \
     || problems="${problems}${doc}: never reaches the health check
 "


### PR DESCRIPTION
Closes #704.

## What

A first-hand report from someone following the walkthrough: they got stuck on
its first command.

```
$ docker compose up -d --build
unknown shorthand flag: 'd' in -d
```

On the setup this was reported from, the Compose plugin was missing, and
`docker` dropped `compose`/`up` as unrecognized arguments and parsed `-d` as a
top-level flag, which failed. The error string never mentioned "compose", so it
read as a Docker problem rather than a missing-requirement problem. On that same
setup any unrecognized subcommand produced the identical error, which points at
argument parsing rather than anything compose-specific:

```
$ docker nonexistentcmd up -d --build
unknown shorthand flag: 'd' in -d
```

That is the observation this change rests on — not a claim about how every
Docker version words the failure.

Requirements listed "Docker with Compose" but gave no way to confirm it
before running the first command.

## Fix

- Added a one-line, copy-pasteable check to Requirements in both
  `docs/remote-setup.md` and `docs/remote-setup.ja.md` (own translation,
  not verbatim): `docker compose version`, scoped to readers taking the
  Compose path (the Requirements line already offers "or PostgreSQL 17, if
  you bring your own database", and that reader never runs Compose).
- Extended `tests/test_remote_setup_doc.bats`'s existing per-walkthrough
  contract (`check_walkthrough`, the #676 completeness pattern — files
  found by glob, not named) with the same check, so any future
  walkthrough gets it automatically rather than relying on someone
  remembering to add it.

## Tests

`bats tests/test_remote_setup_doc.bats`: 7/7.
