### PR TITLE
test(migrate): one timestamp per row, and a control that reports the drift (#723)

### DIFF
--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -298,17 +298,51 @@ stored_types() {
   migrate alpha
   local dest; dest="$(store_of alpha)"
 
+  # ONE timestamp, used by both sides. The containment check compares
+  # created_at, so evaluating strftime('now') twice let the two rows differ by a
+  # second -- and then `refused` was satisfied by the timestamps rather than by
+  # the body. Measured: with both bodies made identical, this test failed when
+  # the two inserts shared a second and PASSED when they straddled one. It was
+  # green either way, so nothing ever asked to look at it (#723).
+  local at; at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   sqlite3 "$dest" "INSERT INTO messages(id,team,from_agent,to_agent,body,created_at)
-    VALUES(9001,'alpha','ann','bob','what the destination holds',
-           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
+    VALUES(9001,'alpha','ann','bob','what the destination holds','$at');"
   sqlite3 "$SHARED" "INSERT INTO messages(id,team,from_agent,to_agent,body,created_at)
-    VALUES(9001,'alpha','ann','bob','a different body',
-           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
+    VALUES(9001,'alpha','ann','bob','a different body','$at');"
 
   run migrate alpha
   [ "$status" -ne 0 ]
   [[ "$output" =~ "missing rows" ]]
   [ "$(sqlite3 "$SHARED" "SELECT COUNT(*) FROM messages WHERE team='alpha';")" -eq 1 ]
+}
+
+# The negative control for the test above, and the reason it cannot quietly
+# stop meaning anything again.
+#
+# The test above is green whether it refuses for the right reason or the wrong
+# one, so nothing in it can report that the fixture drifted. This one is red the
+# moment the two sides stop being identical -- which is exactly what a second
+# strftime('now') would do. Reintroduce one and this fails; the test above would
+# not (#723).
+#
+# It is also the behaviour re-entry depends on: a row already carried across is
+# not a conflict, or an interrupted run could never be resumed.
+@test "migrate: a message id reused for the SAME content is not refused" {
+  bash "$SCRIPTS/send.sh" alpha ann bob "the original message" >/dev/null
+  migrate alpha
+  local dest; dest="$(store_of alpha)"
+
+  # Byte-identical on both sides, timestamp included.
+  local at; at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  sqlite3 "$dest" "INSERT INTO messages(id,team,from_agent,to_agent,body,created_at)
+    VALUES(9001,'alpha','ann','bob','what both sides hold','$at');"
+  sqlite3 "$SHARED" "INSERT INTO messages(id,team,from_agent,to_agent,body,created_at)
+    VALUES(9001,'alpha','ann','bob','what both sides hold','$at');"
+
+  run migrate alpha
+  [ "$status" -eq 0 ]
+  # And the shared copy is gone, because the destination already had it.
+  [ "$(sqlite3 "$SHARED" "SELECT COUNT(*) FROM messages WHERE team='alpha';")" -eq 0 ]
 }
 
 @test "migrate: a cursor at a different position is refused" {
@@ -459,12 +493,16 @@ stored_types() {
   # And a leftover in the shared store, which is what re-entry is for. Copied
   # into the destination as an interrupted run would have done.
   local dest; dest="$(store_of alpha)"
+  # ONE timestamp, used by both sides -- this is meant to be the SAME row on
+  # both, and the containment check compares `at`. Evaluating strftime('now')
+  # once per statement made it two different rows whenever the pair straddled a
+  # second, which is the intermittent `missing rows (events)` CI saw. Forcing
+  # the boundary with a sleep reproduces that message exactly (#723).
+  local at; at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   sqlite3 "$SHARED" "INSERT INTO events(seq,type,id,team,from_agent,to_agent,body,at)
-    VALUES(9001,'message_sent','leftover','alpha','ann','bob','left behind',
-           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
+    VALUES(9001,'message_sent','leftover','alpha','ann','bob','left behind','$at');"
   sqlite3 "$dest" "INSERT INTO events(seq,type,id,team,from_agent,to_agent,body,at)
-    VALUES(9001,'message_sent','leftover','alpha','ann','bob','left behind',
-           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
+    VALUES(9001,'message_sent','leftover','alpha','ann','bob','left behind','$at');"
 
   run migrate alpha
   [ "$status" -eq 0 ]

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -341,8 +341,16 @@ stored_types() {
 
   run migrate alpha
   [ "$status" -eq 0 ]
-  # And the shared copy is gone, because the destination already had it.
+  # The shared copy is gone, because the destination already had it.
   [ "$(sqlite3 "$SHARED" "SELECT COUNT(*) FROM messages WHERE team='alpha';")" -eq 0 ]
+  # And the destination still holds it. Without this, a regression that removed
+  # the rows from BOTH stores would satisfy everything above -- status 0, shared
+  # empty -- while destroying the data the move exists to preserve. Found in
+  # review; the shared-side count alone cannot tell "carried across" from "gone".
+  #
+  # Every compared column, not COUNT(*): a count survives the row being replaced
+  # with different content, which is the failure the test above is about.
+  [ "$(sqlite3 "$dest" "SELECT id||'|'||team||'|'||from_agent||'|'||to_agent||'|'||body||'|'||created_at||'|'||COALESCE(read_at,'-') FROM messages WHERE id=9001;")" = "9001|alpha|ann|bob|what both sides hold|$at|-" ]
 }
 
 @test "migrate: a cursor at a different position is refused" {


### PR DESCRIPTION
Closes #723.

Two tests in `tests/test_migrate_team_store.bats` built **one logical row on both sides** and evaluated `strftime('%Y-%m-%dT%H:%M:%SZ','now')` **once per statement**. `_missing_from_dest()` compares the timestamp column — `at` for `events`, `created_at` for `messages` — so whenever the pair straddled a second, the two halves stopped being the same row.

## Same root, opposite signs

| | test | second boundary does |
|---|---|---|
| ① | `re-entry completes when the destination has more than the shared store` | **red** — this is the intermittent `missing rows (events)` CI reported |
| ② | `a message id reused for different content is refused` | **green, and meaningless** |

② asserts `[ "$status" -ne 0 ]`, satisfied by **either** difference. Two controls on `/bin/bash` 3.2, with both bodies made identical so `created_at` is the only thing left that can differ:

| control | change | result |
|---|---|---|
| A | identical bodies, no boundary | **not ok** — the body difference is what it detects |
| B | identical bodies, boundary forced (`sleep 1.1`) | **ok** — "refused" satisfied by the timestamps alone |

B is why this is a change rather than a retry. ① fails only when it straddles; ② means nothing only when it straddles — and it is green either way, so it never asks to be looked at.

## The fix

Take the timestamp **once** and pass that value to both statements. **The column stays in the comparison** — detecting a timestamp mismatch is what that check exists for. The defect was in the fixture, not in what it compares.

**Derived, not enumerated — and here is the derivation, because a count is what three people got wrong.** The PR body first said six/four, one reviewer corrected it to five/four, and re-deriving gave five/eight. Three readings of one table. So the command goes in, not the number:

```
$ git grep -n "strftime('%" -- tests scripts        # at f55cf93
scripts/drivers/storage/sqlite-sync.sh:334:      strftime('%Y-%m-%dT%H:%M:%fZ','now'));
scripts/drivers/storage/sqlite-sync.sh:788:             strftime('%Y-%m-%dT%H:%M:%fZ','now')
scripts/drivers/storage/sqlite-sync.sh:804:             strftime('%Y-%m-%dT%H:%M:%fZ','now')
scripts/drivers/storage/sqlite-sync.sh:1369:           strftime('%Y-%m-%dT%H:%M:%SZ','now')
scripts/drivers/storage/sqlite.sh:127:      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
scripts/drivers/storage/sqlite.sh:139:             strftime('%Y-%m-%dT%H:%M:%SZ','now')
scripts/internal/init-db.sh:35:  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
scripts/lib/storage.sh:273:VALUES('$resource_sql', $owner_pid, strftime('%Y-%m-%dT%H:%M:%SZ','now'));
tests/test_migrate_team_store.bats:210:           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
tests/test_migrate_team_store.bats:232:           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
tests/test_migrate_team_store.bats:249:           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
tests/test_migrate_team_store.bats:276:           strftime('%Y-%m-%dT%H:%M:%SZ','now'));"
tests/test_remote.bats:1033:VALUES ('remote-pending.$key', $owner_pid, strftime('%Y-%m-%dT%H:%M:%SZ','now'));
```

`'%` rather than `(` because it matches the SQL and not prose — the comments this PR adds say `strftime('now')`, and matching those is how "six" happened. The two pairs this PR fixed are absent from that list: they now read `'$at'`.

Every line above writes its row once. The two that look otherwise, checked rather than assumed:

- **`sqlite-sync.sh` 788/804** sit closest together and share a table, but they are different conflict rows — `reason` is `'server sequence maps to another wire id'` on one and `'wire id maps to another sequence or envelope'` on the other.
- **`init-db.sh` 35 and `sqlite.sh` 127** are DEFAULT clauses for the same column in the shared and per-team schemas — *the same shape as this bug*, which is why they were worth opening. They cannot both fire for one row: the move carries the value explicitly rather than letting a default supply it (`migrate-team-store.sh:294`, `INSERT OR IGNORE INTO messages(…,created_at,read_at) SELECT …,created_at,read_at`).

## The part the fix alone would not cover

A test that cannot fail for the right reason cannot report that its own fixture drifted. Fixing ② restores its meaning today and leaves nothing watching it. So this adds the negative control — the same id with the **SAME** content, which completes rather than refusing (also the behaviour re-entry depends on: a row already carried across is not a conflict).

Mutated all three to check the control earns its place, by making the two sides' timestamps differ deterministically:

| mutation | result |
|---|---|
| timestamps diverge in the `events` pair (①) | **RED** |
| timestamps diverge in the `messages` pair (②) | **GREEN** — it cannot self-report |
| timestamps diverge in the new control | **RED** — it catches what ② cannot |

The middle row is the finding: without the new test, reintroducing a second `strftime('now')` in ② is invisible.

## What was run

`bats tests/test_migrate_team_store.bats` on `/bin/bash` 3.2 (what the macOS legs run): **26/26 green**, mutation residue diffed away and confirmed identical to the intended file. `check-enforced-assertions.sh` reports **616, at the baseline** — the new assertions are `[ ]`, so nothing was added to the unenforceable count.

The rest of the suite was not run locally; this touches one test file and CI covers the remainder.

## Review

Please look hardest at the **mutation table** — specifically whether the middle row is a fair demonstration or an artifact of how I mutated. If deterministic divergence is not the same thing as a real second boundary, the claim that ② cannot self-report is weaker than stated.

Found while diagnosing #719's CI red (landed as `f67a481`); ② was found by a second seat sweeping for the same shape, and both controls were re-run here independently before this was written.

---

### The head moved: `f50c781` → `f55cf93`

The first commit message stated the sweep as two counts. A reviewer corrected one; re-deriving found the other was wrong too. The commit message now carries the corrected counts, which stay true because they are pinned to this commit's tree; the body carries the command instead, because a count describing "the repository" does not stay true.

**The tree is byte-identical** (`git diff f50c781 f55cf93` is empty) — only the commit message changed, and only the counts inside the sentence that begins "Derived, not enumerated". That sentence is where the credit for the rest of the claims sits, so it was worth the rebuild while nothing has landed.

Any verdict naming `f50c781` is void. Re-clearing needed at `f55cf93`.

---

### `2b9b959` — the control also has to say the destination kept the row

A reviewer found that the new control asserted only "the run succeeded" and "the shared copy is gone". **A regression that deleted the rows from both stores satisfies both** while destroying what the move exists to preserve.

Written that regression — the drop that clears the shared store, made to run against the destination too — and measured:

| | result |
|---|---|
| with the destination assertion | **RED**, on that line |
| without it (`f55cf93`, the reviewed version) | **ok** |
| with the assertion, no mutation | **ok** (26/26 for the file) |

The gap was real. The assertion compares every column the containment check compares, not `COUNT(*)`: a count survives the row being replaced with different content, which is the failure the test above it is about.

### The claim about "the only two places" was wider than its derivation

Same shape as the finding, so it is corrected the same way. The sweep behind that sentence was SQL `strftime('now')` only — and this PR **itself** introduces `date -u` reads that the sweep cannot see. Sweeping every clock read:

```
$ git grep -nE "strftime\('%|date -u|date \+|EPOCHSECONDS|\$SECONDS" -- tests scripts
… 44 sites
```

**Those 44 were not audited one by one, and nothing here claims they were.** What was checked is narrower and is all that is claimed: within `tests/test_migrate_team_store.bats`, the two pairs fixed here were the only places one logical row was written to both stores from two separate clock reads, and the three `date -u` reads this PR adds are one per test, each feeding both halves of its pair.

Verdicts naming `f50c781` or `f55cf93` are void. Head is now **`2b9b959`**.
