### PR TITLE
fix(remote): stop discarding resolve-team's stderr and its actual cause (#726)

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2987,7 +2987,22 @@ async function publicGet(serverUrl, path) {
   if (response.headers.get("agmsg-protocol-version") !== PROTOCOL) {
     throw new Error("response protocol version mismatch");
   }
-  const body = await response.json();
+  // Parsed from the raw text and the parse failure collapsed to a fixed
+  // message, for the same reason the error code below is validated: a
+  // malformed JSON body from an untrusted server reaches Node's own
+  // SyntaxError.message as a fragment of the actual input, and that would
+  // put raw response bytes on the operator's terminal now that this call's
+  // stderr is not redirected away. send() below already avoids this shape
+  // for the authenticated path; the public one needs the same boundary.
+  let text;
+  try { text = await response.text(); } catch (error) {
+    error.retryable = true;
+    throw error;
+  }
+  let body;
+  try { body = JSON.parse(text); } catch {
+    throw new Error(`HTTP ${response.status} returned invalid JSON`);
+  }
   if (!response.ok) {
     // This message is no longer only for a log: the resolve-team CLI
     // subcommand's stderr now reaches the operator's terminal directly, and

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2989,7 +2989,20 @@ async function publicGet(serverUrl, path) {
   }
   const body = await response.json();
   if (!response.ok) {
-    const error = new Error(`HTTP ${response.status} ${errorCode(body)}`);
+    // This message is no longer only for a log: the resolve-team CLI
+    // subcommand's stderr now reaches the operator's terminal directly, and
+    // this call runs before any local team or credential exists, so the
+    // server answering is not trusted. errorCode(body) returns whatever the
+    // server put there with no format guarantee -- that is correct for its
+    // other callers, but here it would let raw server bytes (control
+    // characters, terminal escapes) reach a real terminal. Only a code
+    // shaped like this protocol's own (lowercase kebab-case, the same shape
+    // as every code this project actually defines) is echoed; anything else
+    // collapses to the same fixed word errorCode() itself already falls
+    // back to when no code was given at all.
+    const code = errorCode(body);
+    const safeCode = /^[a-z][a-z0-9-]{0,63}$/.test(code) ? code : "unknown-error";
+    const error = new Error(`HTTP ${response.status} ${safeCode}`);
     error.status = response.status;
     throw error;
   }

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -700,11 +700,18 @@ _remote_resolve_team_id() {
   # stay distinguishable from a name that simply matched nothing. Collapsing
   # those into one message is how a rejected answer would get read as "no such
   # team" -- the wrong conclusion to hand an operator about their own team.
+  #
+  # stderr is NOT redirected here, on purpose (same as pull-bootstrap below):
+  # the engine's own top-level handler already writes a specific message for
+  # whatever actually went wrong -- a fetch failure, a protocol mismatch, a
+  # malformed candidate -- and it needs to reach the operator, not get
+  # replaced by a single line that names two different causes at once and
+  # lets the reader guess which one happened.
   out="$("$SCRIPT_DIR/remote-sync.sh" resolve-team \
-    --endpoint "$endpoint" --name "$name" 2>/dev/null)"
+    --endpoint "$endpoint" --name "$name")"
   status=$?
   if [ "$status" -ne 0 ]; then
-    echo "agmsg: could not look up '$name': the server was unreachable, or its answer was rejected" >&2
+    echo "agmsg: could not look up '$name'" >&2
     return 1
   fi
   result="$(printf '%s\n' "$out" | grep '"team_lookup_result"' | tail -1)" || true

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -396,6 +396,16 @@ class Handler(BaseHTTPRequestHandler):
                     # operator, but the raw marker must not.
                     self._send_json(503, {"error": {"code": "server-error" + poison}})
                     return
+                if bad == "malformed_json":
+                    # Not a well-formed body with a bad field -- not JSON at
+                    # all. Node's own JSON.parse SyntaxError can quote a
+                    # fragment of the input in its message, which is a
+                    # second, independent way an untrusted server's raw bytes
+                    # could reach a terminal once resolve-team's stderr is no
+                    # longer redirected away (#726/#728) -- distinct from the
+                    # error.code path the other cases above exercise.
+                    self._send_raw(200, "{not json " + poison)
+                    return
                 good = {"team_id": PULL_TEAM_ID, "team_name": wanted,
                         "registered_at": "2026-07-29T00:00:00.000000Z",
                         "current_seq": "2"}

--- a/tests/helpers/mock_remote_server.py
+++ b/tests/helpers/mock_remote_server.py
@@ -387,6 +387,15 @@ class Handler(BaseHTTPRequestHandler):
             bad = os.environ.get("MOCK_LOOKUP_BAD", "")
             if bad and wanted:
                 poison = "\x1b[2K\rMARKER-INJECTED"
+                if bad == "http_error":
+                    # Not a 200 with a bad body -- a non-2xx answer whose
+                    # error.code itself carries the marker. The negative
+                    # control for whether resolve-team's HTTP-error path can
+                    # be made to write untrusted server bytes to a terminal
+                    # (#726/#728): the status/reason must still reach the
+                    # operator, but the raw marker must not.
+                    self._send_json(503, {"error": {"code": "server-error" + poison}})
+                    return
                 good = {"team_id": PULL_TEAM_ID, "team_name": wanted,
                         "registered_at": "2026-07-29T00:00:00.000000Z",
                         "current_seq": "2"}

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -495,6 +495,29 @@ _capability_endpoint() {
   [[ "$output" != *"scripts/remote.sh"*"unlock"* ]]
 }
 
+@test "pull: a truly unreachable server is reported as such (#726)" {
+  # Direction 1 of the negative control: nothing listens on this port, so
+  # resolve-team's child process fails before ever reaching a server. name
+  # resolution runs because no --team-id is given.
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "http://127.0.0.1:1" newteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not look up 'newteam'"* ]]
+}
+
+@test "pull: a reachable server whose lookup answer fails validation names that reason, not \"unreachable\" (#726)" {
+  # Direction 2: the mock server answers (HTTP 200, protocol_version wrong),
+  # so this is not a transport failure -- it is the OTHER cause the old
+  # message collapsed into the same sentence as "unreachable". The specific
+  # reason has to surface, and the collapsed wording must not appear at all,
+  # or this is indistinguishable from before the fix.
+  MOCK_LOOKUP_BAD=protocol restart_mock_server
+
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" newteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"team lookup answer is not a lookup result"* ]]
+  [[ "$output" != *"unreachable"* ]]
+}
+
 @test "connect: the handoff-bundle line is printed by default" {
   # #668: this named the snapshot pair while `pull` on the other machine asked
   # for the bundle, so each side named the other's route. It names the bundle
@@ -2022,7 +2045,7 @@ assert_lookup_rejected() {
   MOCK_LOOKUP_BAD="$mode" restart_mock_server
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" pulled-team
   [ "$status" -ne 0 ]
-  [[ "$output" == *"its answer was rejected"* ]]
+  [[ "$output" == *"could not look up 'pulled-team'"* ]]
   [[ "$output" != *"MARKER-INJECTED"* ]]
   [ ! -d "$TEST_SKILL_DIR/teams/pulled-team" ]
 }

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -499,9 +499,18 @@ _capability_endpoint() {
   # Direction 1 of the negative control: nothing listens on this port, so
   # resolve-team's child process fails before ever reaching a server. name
   # resolution runs because no --team-id is given.
+  #
+  # Asserting the wrapper's own line is not enough on its own: that line is
+  # printed on ANY non-zero exit, including the old redirected one, so it
+  # cannot tell "the fix works" apart from "the fix was reverted". The
+  # child's own transport-specific message (what fetch() actually reports
+  # for a refused connection, node's "fetch failed") is what only reaches
+  # the operator because the redirect is gone -- that is the actual claim
+  # this PR makes, so it is what has to be pinned.
   run bash "$SCRIPTS/remote.sh" pull --endpoint "http://127.0.0.1:1" newteam
   [ "$status" -ne 0 ]
-  [[ "$output" == *"could not look up 'newteam'"* ]]
+  [[ "$output" == *"fetch failed"* ]] &&
+    [[ "$output" == *"could not look up 'newteam'"* ]]
 }
 
 @test "pull: a reachable server whose lookup answer fails validation names that reason, not \"unreachable\" (#726)" {
@@ -516,6 +525,23 @@ _capability_endpoint() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"team lookup answer is not a lookup result"* ]] &&
     [[ "$output" != *"unreachable"* ]]
+}
+
+@test "pull: an untrusted server's raw error text does not reach the terminal (#726/#728)" {
+  # A third case, neither transport failure nor a malformed-but-200 body: the
+  # server answers with a real HTTP error whose error.code is server-supplied
+  # text with no format guarantee. Now that resolve-team's stderr is no
+  # longer redirected away, that text is one un-sanitized field away from
+  # reaching the operator's terminal raw -- the same class of risk
+  # resolveTeam's own validation path already guards against for a 200
+  # ("messages quote no server value"). The status and a safe reason still
+  # have to get through; the injected marker must not.
+  MOCK_LOOKUP_BAD=http_error restart_mock_server
+
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" newteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"HTTP 503"* ]] &&
+    [[ "$output" != *"MARKER-INJECTED"* ]]
 }
 
 @test "connect: the handoff-bundle line is printed by default" {

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -544,6 +544,21 @@ _capability_endpoint() {
     [[ "$output" != *"MARKER-INJECTED"* ]]
 }
 
+@test "pull: a malformed (non-JSON) answer does not leak its raw bytes either (#726/#728)" {
+  # A fourth case, and a different mechanism from the one above: not a
+  # well-formed body with a bad field, but a body that is not JSON at all.
+  # Node's own JSON.parse SyntaxError can quote a fragment of the offending
+  # input in its message, which would carry the same marker straight to the
+  # terminal through a path the error.code sanitization above does not
+  # touch -- the parse never gets that far.
+  MOCK_LOOKUP_BAD=malformed_json restart_mock_server
+
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" newteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"HTTP 200"*"invalid JSON"* ]] &&
+    [[ "$output" != *"MARKER-INJECTED"* ]]
+}
+
 @test "connect: the handoff-bundle line is printed by default" {
   # #668: this named the snapshot pair while `pull` on the other machine asked
   # for the bundle, so each side named the other's route. It names the bundle

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -514,8 +514,8 @@ _capability_endpoint() {
 
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" newteam
   [ "$status" -ne 0 ]
-  [[ "$output" == *"team lookup answer is not a lookup result"* ]]
-  [[ "$output" != *"unreachable"* ]]
+  [[ "$output" == *"team lookup answer is not a lookup result"* ]] &&
+    [[ "$output" != *"unreachable"* ]]
 }
 
 @test "connect: the handoff-bundle line is printed by default" {


### PR DESCRIPTION
Closes #726.

## What

`_remote_resolve_team_id` redirected its child process's stderr to
`/dev/null` and turned every non-zero exit into one fixed message naming
two different causes at once: a server that is genuinely unreachable, or
one that answered but whose response failed validation. The function's own
comment states the opposite intent — that these should stay
distinguishable — but the code did not do that.

A prior report attributed a real failure to a team-name case mismatch.
That explanation does not hold: the current server resolves team lookups
with an exact-case query and still answers `HTTP 200` with an empty
`teams: []` array on no match — a normal response the client already turns
into its own specific "no team named" message. Something else failed, and
the redirect is exactly what made the real cause unrecoverable.

## Fix

- Drop the `2>/dev/null` on the `resolve-team` call in
  `_remote_resolve_team_id`, so the child's own specific error (already
  written to stderr by its top-level handler) reaches the operator —
  matching how `pull-bootstrap`'s call a few lines down already behaves.
- The wrapper's own message on top no longer claims to explain the cause;
  the child's message does that now.

## Scope

Deliberately not touched: `_remote_http_post_json`/`_remote_http_get_json`
discard curl's own stderr the same way and reduce a transport failure to
`http_code=000`. Different pair of functions, different callers, and an
existing `http_code`-based reporting convention already built around them
— worth its own PR.

## Tests

Negative control, both directions, in `tests/test_remote.bats`:

1. A genuinely unreachable server (nothing listening on the port) still
   reads as unreachable.
2. A reachable server whose lookup answer fails validation now names that
   specific reason, and the collapsed wording does not appear.

Mutation-tested: reverting the redirect turns (2) red without touching
(1).

Running the full file surfaced a real regression from this change:
`assert_lookup_rejected` (five existing tests covering client-side
candidate validation, e.g. a poisoned server response) pinned on the old
collapsed wording as how it detected rejection. Updated it to check for
the wrapper's own line instead, which every rejection path still prints
regardless of which specific validation failed underneath it.

`bats tests/test_remote.bats`: 102/102.
