### PR TITLE
fix(ci): stop tests/test_remote_setup_doc.bats from forcing the age-v1/jsonl contracts (#706)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,9 +34,13 @@ name: tests
 # `docs/remote-setup*.md`-only diff (which must flip docs_only so the suite
 # that reads it still runs, see below) also ran a ~5-minute age-v1 job and two
 # ~1-minute jsonl jobs that never touch that file (#706). `contracts_needed`
-# is the same classification MINUS that one exception: true whenever
-# `docs_only` would be false for any OTHER reason, false when the only reason
-# was `docs/remote-setup*.md`.
+# is the same classification MINUS that exception: true whenever `docs_only`
+# would be false for any OTHER reason, false when the only reason was
+# `docs/remote-setup*.md` or its own guard test,
+# `tests/test_remote_setup_doc.bats` -- which needs the same exception for
+# the same reason, and initially did not have it: its name happens to start
+# the same way `test_remote.bats` (a real sync-engine test) does, so it fell
+# through into that pattern by coincidence rather than by relevance.
 
 on:
   push:
@@ -109,7 +113,17 @@ jobs:
               # walkthrough is prose the age-v1/jsonl-storage contracts never
               # read, so forcing the suite that does read it to run is not a
               # reason to also run those.
-              docs/remote-setup*.md) docs_only=false ;;
+              #
+              # tests/test_remote_setup_doc.bats belongs in this arm for the
+              # same reason, not the sync-engine one below: it is the guard
+              # for the walkthroughs, not a test of the sync engine, and it
+              # reads none of what age-v1/jsonl-storage cover either. Without
+              # this line it fell through to the broader `test_remote*.bats`
+              # pattern purely because its name happens to start the same way
+              # test_remote.bats's does -- a glob doing name-matching, not
+              # relevance-matching, is exactly how #706 partially recurred
+              # after being fixed once.
+              docs/remote-setup*.md|tests/test_remote_setup_doc.bats) docs_only=false ;;
               docs/*) ;;
               site/*) ;;
               app/*) app_changed=true ;;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,13 +34,16 @@ name: tests
 # `docs/remote-setup*.md`-only diff (which must flip docs_only so the suite
 # that reads it still runs, see below) also ran a ~5-minute age-v1 job and two
 # ~1-minute jsonl jobs that never touch that file (#706). `contracts_needed`
-# is the same classification MINUS that exception: true whenever `docs_only`
-# would be false for any OTHER reason, false when the only reason was
-# `docs/remote-setup*.md` or its own guard test,
-# `tests/test_remote_setup_doc.bats` -- which needs the same exception for
-# the same reason, and initially did not have it: its name happens to start
-# the same way `test_remote.bats` (a real sync-engine test) does, so it fell
-# through into that pattern by coincidence rather than by relevance.
+# is `docs_only`'s negation for most paths, but for `tests/test_remote*.bats`
+# specifically it is a membership check against a DERIVED read-set (the
+# explicit entry points age-v1-contract/storage-jsonl invoke, plus whichever
+# bats files currently `grep -rl 'skip_if_no_age'`) rather than "the glob
+# matched, so true". A hand exception for the one file that first exposed
+# this (`tests/test_remote_setup_doc.bats`) fixed that one file and left four
+# more real files the same glob sweeps in without reading either contract
+# (`test_remote_forget`/`test_remote_status_liveness`/`test_remote_sync`/
+# `test_remote_sync_engine`) — see the classifier below for the derivation
+# itself.
 
 on:
   push:
@@ -96,39 +99,49 @@ jobs:
           server_changed=false
           sync_changed=false
           contracts_needed=false
+          # The actual test-file read-set for age-v1-contract/storage-jsonl,
+          # DERIVED rather than named (#706 recurred once already from a hand
+          # exception, and a hand exception is what this replaces): the four
+          # explicit entry points those two jobs invoke below, plus whichever
+          # bats files currently gate on age -- computed the exact same way
+          # age-v1-contract discovers its own age-gated files further down in
+          # this file (`grep -rl 'skip_if_no_age'`), so a file gaining or
+          # losing that marker is picked up here without anyone touching this
+          # workflow. `tests/test_remote*.bats` alone matches six files by
+          # name and only one of them (test_remote.bats) is in this set; the
+          # other five (including the walkthroughs' own guard test) do not
+          # read either contract, and naming each one as its own exception is
+          # the same defect this replaces, just moved.
+          contract_test_files="$(printf '%s\n' \
+            tests/sync_cipher.test.mjs \
+            tests/test_sync_cipher.bats \
+            tests/test_jsonl_remote_sync.bats \
+            tests/test_storage_contract.bats \
+            $(grep -rl 'skip_if_no_age' tests/*.bats 2>/dev/null || true))"
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              # Not covered by `docs/*` below: tests/test_remote_setup_doc.bats
-              # reads these, and a guard that skips on a change to the file it
-              # guards is off exactly when it is needed. Same reason as
-              # SKILL.md further down.
-              #
-              # A pattern, not a filename. This arm named `docs/remote-setup.md`
-              # for an hour, and `docs/remote-setup.ja.md` landed inside that
-              # hour carrying the same port, docs-only and unguarded. The next
-              # translation is covered without anyone remembering this line.
-              #
-              # contracts_needed is deliberately NOT set here (#706): a
-              # walkthrough is prose the age-v1/jsonl-storage contracts never
-              # read, so forcing the suite that does read it to run is not a
-              # reason to also run those.
-              #
-              # tests/test_remote_setup_doc.bats belongs in this arm for the
-              # same reason, not the sync-engine one below: it is the guard
-              # for the walkthroughs, not a test of the sync engine, and it
-              # reads none of what age-v1/jsonl-storage cover either. Without
-              # this line it fell through to the broader `test_remote*.bats`
-              # pattern purely because its name happens to start the same way
-              # test_remote.bats's does -- a glob doing name-matching, not
-              # relevance-matching, is exactly how #706 partially recurred
-              # after being fixed once.
-              docs/remote-setup*.md|tests/test_remote_setup_doc.bats) docs_only=false ;;
+              docs/remote-setup*.md) docs_only=false ;;
               docs/*) ;;
               site/*) ;;
               app/*) app_changed=true ;;
               server/*) docs_only=false; server_changed=true; contracts_needed=true ;;
-              scripts/remote*.sh|scripts/internal/*|scripts/drivers/storage/*|scripts/lib/*|tests/*sync*.*|tests/test_remote*.bats|server/test/sync-client.integration.test.ts|.github/workflows/tests.yml) docs_only=false; sync_changed=true; contracts_needed=true ;;
+              # Split from the broad sync-engine arm below on purpose:
+              # `tests/test_remote*.bats` decides `sync_changed` for six real
+              # bats files (all of them ARE the sync engine's own tests, or
+              # at least reachable from this glob by name), but only some of
+              # them are in `contract_test_files` above. contracts_needed is
+              # therefore a membership check against the derived set, not an
+              # unconditional true the way `sync_changed` on the same line
+              # is -- that half of this arm is correct as broad, this half
+              # was not.
+              tests/test_remote*.bats)
+                docs_only=false; sync_changed=true
+                if printf '%s\n' "$contract_test_files" | grep -qxF -- "$f"; then
+                  contracts_needed=true
+                fi
+                ;;
+              scripts/remote*.sh|scripts/internal/*|scripts/drivers/storage/*|scripts/lib/*|tests/*sync*.*|server/test/sync-client.integration.test.ts|.github/workflows/tests.yml) docs_only=false; sync_changed=true; contracts_needed=true ;;
               llms.txt|llms-full.txt) ;;
               README.md|CHANGELOG.md|CONTRIBUTING.md|PRIVACY.md|ARCHITECTURE.md|RELEASING.md|LICENSE) ;;
               # NOTE: SKILL.md is intentionally not here — the suite tests it.

--- a/tests/test_remote_setup_doc.bats
+++ b/tests/test_remote_setup_doc.bats
@@ -270,12 +270,12 @@ EOF
   # The workflow's own `case` is lifted out and RUN: order is only one of the
   # ways an arm can stop working, and the classifier is what actually decides.
   workflow="${BATS_TEST_DIRNAME}/../.github/workflows/tests.yml"
-  block="$(awk '/case ".f" in/,/^ *esac$/' "$workflow")"
+  block="$(awk '/contract_test_files=/,/^ *done <<< "\$changed"$/' "$workflow")"
   [ -n "$block" ] || return 1
 
   # `run bash -c`, not a `$( )` around the eval: bash 3.2 — which is what CI's
   # macOS runner has — cannot parse a `case` inside command substitution.
-  classify='f="$1"; docs_only=true; app_changed=false; server_changed=false; sync_changed=false; contracts_needed=false; eval "$2"; echo "$docs_only"'
+  classify='changed="$1"; docs_only=true; app_changed=false; server_changed=false; sync_changed=false; contracts_needed=false; eval "$2"; echo "$docs_only"'
 
   # Every walkthrough that exists, derived — not a list to keep in step.
   while IFS= read -r doc; do
@@ -311,10 +311,10 @@ EOF
   # and storage-jsonl, which never read this file. contracts_needed is the
   # same classifier's independent verdict for those two jobs specifically.
   workflow="${BATS_TEST_DIRNAME}/../.github/workflows/tests.yml"
-  block="$(awk '/case ".f" in/,/^ *esac$/' "$workflow")"
+  block="$(awk '/contract_test_files=/,/^ *done <<< "\$changed"$/' "$workflow")"
   [ -n "$block" ] || return 1
 
-  classify='f="$1"; docs_only=true; app_changed=false; server_changed=false; sync_changed=false; contracts_needed=false; eval "$2"; echo "$contracts_needed"'
+  classify='changed="$1"; docs_only=true; app_changed=false; server_changed=false; sync_changed=false; contracts_needed=false; eval "$2"; echo "$contracts_needed"'
 
   while IFS= read -r doc; do
     [ -n "$doc" ] || continue
@@ -330,19 +330,36 @@ EOF
   [ "$status" -eq 0 ] || return 1
   [ "$output" = false ] || { echo "a future translation forces the age-v1/jsonl contracts to run" >&2; return 1; }
 
-  # The bug this test file's own name almost recreated: test_remote_setup_doc
-  # .bats starts with the same "test_remote" prefix as test_remote.bats (a
-  # real sync-engine test), so a name-matching pattern for the latter can
-  # catch the former by coincidence. It reads none of what these contracts
-  # cover any more than the walkthroughs it guards do.
-  run bash -c "$classify" _ tests/test_remote_setup_doc.bats "$block"
-  [ "$status" -eq 0 ] || return 1
-  [ "$output" = false ] || { echo "tests/test_remote_setup_doc.bats forces the age-v1/jsonl contracts to run" >&2; return 1; }
+  # The bug `tests/test_remote_setup_doc.bats` alone exposed, and the bug an
+  # earlier fix here left standing for these four: `tests/test_remote*.bats`
+  # matches all five by name, and only test_remote.bats (checked below) is
+  # a file either contract actually reads. Naming test_remote_setup_doc.bats
+  # as its own exception fixed one of five and left the other four
+  # unmeasured -- checking only "one representative passes" is how that
+  # went unnoticed the first time, so every non-contract file this glob
+  # matches is asserted here, not a sample of them.
+  for f in tests/test_remote_setup_doc.bats tests/test_remote_forget.bats \
+    tests/test_remote_status_liveness.bats tests/test_remote_sync.bats \
+    tests/test_remote_sync_engine.bats; do
+    run bash -c "$classify" _ "$f" "$block"
+    [ "$status" -eq 0 ] || return 1
+    [ "$output" = false ] || { echo "$f forces the age-v1/jsonl contracts to run" >&2; return 1; }
+  done
 
-  # Positive control: contracts_needed must be able to become true, or the
-  # assertions above would pass just as well with a flag that is always
-  # false -- indistinguishable from a flag nothing sets. A change to the
-  # storage layer the jsonl contract actually covers must still trigger it.
+  # Positive control, part 1: contracts_needed must be able to become true
+  # for a file the derived set actually holds, or the assertions above would
+  # pass just as well with a flag that is always false. test_remote.bats is
+  # the sixth file this SAME glob matches, and the one real reason the glob
+  # cannot simply be deleted -- it has age-gated tests and must keep being
+  # discovered as one. (Its own marker string is not spelled out here on
+  # purpose: this file would then match the very derivation it is testing.)
+  run bash -c "$classify" _ tests/test_remote.bats "$block"
+  [ "$status" -eq 0 ] || return 1
+  [ "$output" = true ] || { echo "tests/test_remote.bats no longer triggers the age-v1/jsonl contracts" >&2; return 1; }
+
+  # Positive control, part 2: a change entirely outside the test_remote*.bats
+  # glob, through the separate scripts/* arm, must still trigger it too --
+  # that arm is untouched by this fix and this proves it stayed that way.
   run bash -c "$classify" _ scripts/lib/storage.sh "$block"
   [ "$status" -eq 0 ] || return 1
   [ "$output" = true ] || { echo "a storage-layer change no longer triggers the age-v1/jsonl contracts" >&2; return 1; }

--- a/tests/test_remote_setup_doc.bats
+++ b/tests/test_remote_setup_doc.bats
@@ -293,6 +293,12 @@ EOF
   [ "$status" -eq 0 ] || return 1
   [ "$output" = false ] || { echo "a future translation is treated as docs-only" >&2; return 1; }
 
+  # The guard test itself: editing this file has to run the suite too, same
+  # as editing what it guards.
+  run bash -c "$classify" _ tests/test_remote_setup_doc.bats "$block"
+  [ "$status" -eq 0 ] || return 1
+  [ "$output" = false ] || { echo "tests/test_remote_setup_doc.bats is treated as docs-only" >&2; return 1; }
+
   # Still an exception, not a hole through the docs tree.
   run bash -c "$classify" _ docs/spec/v1.md "$block"
   [ "$status" -eq 0 ] || return 1
@@ -323,6 +329,15 @@ EOF
   run bash -c "$classify" _ docs/remote-setup.de.md "$block"
   [ "$status" -eq 0 ] || return 1
   [ "$output" = false ] || { echo "a future translation forces the age-v1/jsonl contracts to run" >&2; return 1; }
+
+  # The bug this test file's own name almost recreated: test_remote_setup_doc
+  # .bats starts with the same "test_remote" prefix as test_remote.bats (a
+  # real sync-engine test), so a name-matching pattern for the latter can
+  # catch the former by coincidence. It reads none of what these contracts
+  # cover any more than the walkthroughs it guards do.
+  run bash -c "$classify" _ tests/test_remote_setup_doc.bats "$block"
+  [ "$status" -eq 0 ] || return 1
+  [ "$output" = false ] || { echo "tests/test_remote_setup_doc.bats forces the age-v1/jsonl contracts to run" >&2; return 1; }
 
   # Positive control: contracts_needed must be able to become true, or the
   # assertions above would pass just as well with a flag that is always


### PR DESCRIPTION
Closes #706.

## What

#706's original fix (`4813aad`) excluded a `docs/remote-setup*.md`-only
diff from forcing `age-v1-contract`/`storage-jsonl` to run in full — but a
PR that also touches `tests/test_remote_setup_doc.bats` (the walkthroughs'
own guard test, which correctly must still run the bats suite) still
forced both contract jobs to run.

Root cause: `tests/test_remote_setup_doc.bats`'s name starts the same way
`tests/test_remote.bats`'s does (a real sync-engine test with age-gated
tests), so it fell into the broader `tests/test_remote*.bats` pattern by
name coincidence — the classifier is a hand-maintained glob, and this is
exactly the shape of bug that produces: relevance decided by
string-matching, not by what a file actually reads. Independent review
found the same glob also sweeps in four more files that read neither
contract: `test_remote_forget.bats`, `test_remote_status_liveness.bats`,
`test_remote_sync.bats`, `test_remote_sync_engine.bats`.

## Fix

Not a hand-picked exception (an earlier version of this PR added one for
`tests/test_remote_setup_doc.bats` alone, which is the same defect this
closes, just moved). `contracts_needed` for `tests/test_remote*.bats` is
now a derivation: `contract_test_files` is computed once, the same way
`age-v1-contract` already discovers its own age-gated files further down
in this same workflow (`grep -rl 'skip_if_no_age' tests/*.bats`), plus the
explicit entry points the two contract jobs actually invoke. The glob is
split into its own case arm so `sync_changed` still fires unconditionally
for all six files it matches (unchanged, correct — every one of them is a
real bats test), while `contracts_needed` is a membership check against
the derived set.

## Tests

Extended both classifier-extraction tests in
`tests/test_remote_setup_doc.bats` (which lift the workflow's own logic
out with `awk` and run it against real filenames):

- All five non-contract files are checked explicitly, not a sample of
  them.
- Two positive controls: `test_remote.bats` must still trigger
  `contracts_needed` (proves the flag can become true, not just stay
  false), and `scripts/lib/storage.sh` through the untouched separate
  `scripts/*` arm (proves that arm wasn't collaterally affected).

Mutation-tested three ways: the derivation split reverted to
unconditional true for the whole glob (all five non-contract assertions
go red); the arm reverted to never setting it at all (the positive
control goes red); the extraction range change (now starts before the
case statement) confirmed to fail loudly rather than silently pass
against an unrelated shape.

`bats tests/test_remote_setup_doc.bats`: 7/7.
`check-enforced-assertions`: 616 (baseline, unchanged).


## Is the derivation itself derived from the right input?

Checked whether a test could use age indirectly without writing the literal
`skip_if_no_age` string:

- The 3 real age-gated bats files (`test_key.bats`, `test_printed_command_paths.bats`,
  `test_remote.bats`) each define their own local `skip_if_no_age()` — it is
  not sourced from `test_helper.bash`, so there is no shared-helper path that
  could reach a test without that literal string appearing in its own file.
- Two files (`test_jsonl_remote_sync.bats`, `test_sync_cipher.bats`) skip age
  tests with a different inline pattern instead of that function — both are
  already in the explicit 4-file list, not relying on the grep.
- `test_ci_workflow.bats` matches the grep too (it asserts the workflow file
  contains that exact string, as a meta-test of the discovery mechanism
  itself), but that file is not matched by the `tests/test_remote*.bats` arm
  this derivation gates, so its presence in `contract_test_files` is inert —
  verified by checking which case arm it actually falls into.
- The grep is the exact expression `age-v1-contract`'s own "run every
  age-gated test" step already uses. If a future file used a differently
  named guard, that job would already fail to discover and run it regardless
  of this PR — the same blind spot in both places, not a new one this PR
  introduces on top of an otherwise-correct execution.

No indirect path exists today.

Positive control on the derivation mechanism itself: temporarily appended a
`# skip_if_no_age` comment to `tests/test_remote_forget.bats` (currently
excluded) and re-ran the classifier against it directly — `contracts_needed`
flipped to `true`, confirming the derivation reads live tree state rather
than a stale or cached set. Reverted immediately after.
