### PR TITLE
fix(remote): collapse out-of-shape server error codes in send()'s message

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1222,7 +1222,19 @@ async function send(config, path, init, authHeaders) {
   if (!response.ok) {
     validateErrorBinding(config, response.status, body);
     const code = errorCode(body);
-    const error = new Error(`HTTP ${response.status} ${code}`);
+    // The same boundary publicGet() draws (#726/#728), for the message ONLY.
+    // This message reaches raw, unescaping sinks: main()'s stderr write lands
+    // it unescaped in the daemon's logfile (`run >> logfile 2>&1`) and on the
+    // operator's live terminal for the foreground subcommands -- one collapse
+    // at this composition point covers both readers, because the allowed
+    // alphabet is safe for the stricter of them (a terminal). error.code and
+    // error.body keep the server's actual value: their only sinks are the
+    // JSON-escaped event lines (cycle.error/fatal, push.oversized detail),
+    // and collapsing them too would erase the hosted edge's snake_case codes
+    // -- re-creating the "sync stopped with no reason in the log" failure the
+    // errorCode() bridge exists to prevent.
+    const safeCode = /^[a-z][a-z0-9-]{0,63}$/.test(code) ? code : "unknown-error";
+    const error = new Error(`HTTP ${response.status} ${safeCode}`);
     error.status = response.status; error.code = code; error.body = body;
     throw error;
   }

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1261,6 +1261,45 @@ test("request callers cannot override the binding headers, and it sends no Autho
   }
 });
 
+test("send collapses an out-of-shape server error code in the message, keeping code and body raw", async () => {
+  // The message reaches raw sinks (the daemon logfile via main()'s stderr
+  // write, the operator's terminal on foreground subcommands), so it may only
+  // carry a code in the protocol's own shape (#729, same boundary as
+  // publicGet's #726/#728). error.code / error.body feed the JSON-escaped
+  // event lines and keep the server's actual value -- collapsing those too
+  // would blind the push.oversized/cycle.error diagnostics.
+  const previousFetch = globalThis.fetch;
+  try {
+    await withConnectedCredential(async () => {
+      // Control bytes plus the exact substring remote.sh's unlock readiness
+      // probe greps for -- the raw-stderr injection this boundary exists to stop.
+      const evil = 'boom\u001b[2J\n"event":"capabilities"';
+      globalThis.fetch = async () => new Response(JSON.stringify({ error: { code: evil } }), {
+        status: 400, headers: { "Agmsg-Protocol-Version": "1" },
+      });
+      await assert.rejects(request({ ...config, server_url: "https://sync.example" }, "/v1/messages"),
+        (error) => error.message === "HTTP 400 unknown-error" &&
+          error.code === evil && error.body?.error?.code === evil);
+      // A code in the protocol's own shape passes through untouched.
+      globalThis.fetch = async () => new Response(JSON.stringify({ error: { code: "not-found" } }), {
+        status: 404, headers: { "Agmsg-Protocol-Version": "1" },
+      });
+      await assert.rejects(request({ ...config, server_url: "https://sync.example" }, "/v1/messages"),
+        (error) => error.message === "HTTP 404 not-found" && error.code === "not-found");
+      // The hosted edge's snake_case bridge code: collapsed in the raw-sink
+      // message, preserved on error.code for the event readers (the split the
+      // push.oversized detail test pins from the other side).
+      globalThis.fetch = async () => new Response(JSON.stringify({ error: "payload_too_large" }), {
+        status: 413, headers: { "Agmsg-Protocol-Version": "1" },
+      });
+      await assert.rejects(request({ ...config, server_url: "https://sync.example" }, "/v1/messages"),
+        (error) => error.message === "HTTP 413 unknown-error" && error.code === "payload_too_large");
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
 test("request distinguishes config errors from response transport loss", async () => {
   const previousFetch = globalThis.fetch;
   let fetchCalled = false;


### PR DESCRIPTION
Fixes #729

## Derivation (routes, before the fix)

Server-controlled bytes enter this process through exactly three functions — the three `fetch()` call sites in `scripts/internal/remote-sync.mjs`: `send()`, `health()`, `publicGet()`. `health()` throws fixed strings only, and `publicGet()` already validates the code shape (#726/#728), so `send()` was the one unvalidated origin: `errorCode(body)` landed raw in `error.message` (`HTTP <status> <code>`), with the raw value also on `error.code` and the parsed body on `error.body`. `send()` backs `request()`/`requestPublic()` and through them every data-plane call (capabilities, read-state sync, messages POST/GET, unblock, pull pages), so its errors surface from every subcommand: the `run` daemon, `once`, `resync`, `reprocess`, `unblock-read`, and `pull-bootstrap`.

The message reaches two raw, unescaping sinks via `main()`'s catch (`process.stderr.write(error.message)`): the daemon's logfile (`remote.sh` starts `run` with `nohup ... >> run/remote-sync.<team>.log 2>&1`), and the operator's live terminal for the foreground subcommands (`reprocess` inside the unlock flow, `pull-bootstrap` inside the pull flow, and manual `once`/`resync`/`unblock-read`). Beyond control bytes on a terminal, a raw logfile line is also a probe target: `remote.sh`'s unlock readiness check greps the log tail for the substring `"event":"capabilities"` with no nonce, and a server-chosen code containing that substring would spoof it (the sync-start probe is nonce-gated and not spoofable; event-line JSON escaping also cannot be spoofed — only this raw-stderr path could).

## Fix

Apply the boundary `publicGet()` already draws, with the same regex, to the message only: a code matching the protocol's own shape (`^[a-z][a-z0-9-]{0,63}$`) passes through; anything else collapses to `unknown-error`. Legitimate server codes keep their full diagnostic value, so this does not trade the injection hole for a silent-failure hole.

**Log vs terminal:** the two raw sinks have different readers, so the choice is explicit — one collapse at the composition point covers both, because the allowed alphabet (lowercase alphanumerics and hyphen) is safe for the stricter reader (a terminal, which reacts to control bytes). Sanitizing at the sink instead would require enumerating readers, and that enumeration is exactly what goes stale.

**What stays raw, deliberately:** `error.code` and `error.body` keep the server's actual value. Their only sinks are the JSON-escaped event lines (`cycle.error`/`fatal`, `push.oversized`'s `detail`), where control bytes cannot land raw, and collapsing them too would erase the hosted edge's snake_case bridge codes (`payload_too_large`) — re-creating the "sync stopped with no reason in the log" failure the `errorCode()` bridge exists to prevent. The existing `push.oversized` detail test pins that side; the new test pins both sides of the split.

## Test

The regression test drives `request()` over a mocked `fetch` three ways: a code carrying ESC bytes plus the unlock-probe substring (message collapses to `HTTP 400 unknown-error`, raw value preserved on `error.code`/`error.body`), a protocol-shaped code (passes through untouched), and the edge's snake_case bridge code (collapsed in the message, preserved on `error.code`). Reverting the fix fails the test (verified both ways). Suites run locally by exit code: `node --test tests/remote_sync_engine.test.mjs` (67/67), `tests/test_remote_sync.bats` + `tests/test_jsonl_remote_sync.bats` + `tests/test_remote_sync_engine.bats` + `tests/test_endpoint_scheme.bats` + `tests/test_endpoint_table_node.bats` (all green after rebasing onto #733).

## Left out of scope, on purpose

(1) The driver child's stderr passthrough (forwarded raw to `process.stderr`) is a different trust domain — a local driver, not server HTTP — and is not touched. (2) `logApplyOutcomes`'s plaintext projection fields in the event log are a documented opt-in (`cipher_profile === "none"` or an explicit env), by design. (3) `push.oversized`'s `detail` keeps reading `errorCode()` unguarded: its only sink is JSON-escaped, and guarding it would blind the bridge case. (4) The nonce-less unlock readiness probe remains structurally weaker than the sync-start one; this fix removes the known injection vector into it, but aligning the probes is a separate hardening worth its own issue.

## For the next person touching this boundary

The validation regex `^[a-z][a-z0-9-]{0,63}$` now exists in two places — `send()` and `publicGet()` — byte-identical at this head (review finding, non-blocking). They are two sites of one rule: if you change what a protocol error code may look like, change both, or hoist the check into a shared helper first. The same two-sites-drifting shape was just fixed for endpoint validation in #722; do not let this pair repeat it silently.