### PR TITLE
fix(remote): a sync engine that cannot start says so (#730)

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2525,8 +2525,17 @@ cmd_set_endpoint() {
   # config in memory). _remote_sync_engine_start kills a live engine first.
   IFS=$'\t' read -r end_state end_pid < <(_remote_sync_engine_status "$team")
   if [ "$was_running" -eq 1 ] || [ "$end_state" = "running" ]; then
-    _remote_sync_engine_start "$team"
-    echo "Endpoint for '$team' moved: $(_remote_endpoint_display "$old_endpoint") -> $(_remote_endpoint_display "$endpoint") (same server instance). Sync engine restarted."
+    # Same rule as cmd_pull and cmd_connect: the move is this command's purpose
+    # and it is done by here, so a start failure reports rather than fails --
+    # and, unlike before, does not end the line by claiming a restart that did
+    # not happen. This call site arrived while #730 was in review; without the
+    # capture the bare call would abort here under `set -e`, because the helper
+    # can now return non-zero.
+    local engine_restarted=1
+    _remote_sync_engine_start "$team" || engine_restarted=0
+    local engine_note=" Sync engine restarted."
+    [ "$engine_restarted" -eq 1 ] || engine_note=" The sync engine did not restart; the reason is on stderr."
+    echo "Endpoint for '$team' moved: $(_remote_endpoint_display "$old_endpoint") -> $(_remote_endpoint_display "$endpoint") (same server instance).$engine_note"
   else
     echo "Endpoint for '$team' moved: $(_remote_endpoint_display "$old_endpoint") -> $(_remote_endpoint_display "$endpoint") (same server instance)."
   fi

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -982,7 +982,7 @@ cmd_pull() {
     # error.)
     local engine_started=1
     _remote_sync_engine_start "$team" || engine_started=0
-    local engine_note=" Sync engine running."
+    local engine_note=" Sync engine start requested (remote.sh status $team confirms)."
     [ "$engine_started" -eq 1 ] || engine_note=" The sync engine did not start; the reason is on stderr."
     if [ "$needs_key" -eq 1 ]; then
       # Says what was checked, and stops there. The identity for the current
@@ -1744,11 +1744,20 @@ cmd_connect() {
   if [ -n "$remote_team_name" ] && [ "$remote_team_name" != "$team" ]; then
     server_side=" (on the server: '$remote_team_name')"
   fi
+  # "start requested", not "running": all this path knows is that the engine was
+  # spawned and its pid recorded. The child can still die on its own -- a log
+  # redirection it cannot make, a Node that will not start -- and nothing here
+  # waits to find out. Confirming would mean a readiness wait of up to 16s in a
+  # command whose purpose is the binding, not the engine; the sentence is
+  # narrowed instead, and points at the command that does check. Saying
+  # "running" from a check that only proves "spawned" is the defect this change
+  # exists to remove, one step smaller. Found in review.
+  #
   # Names the stream, not a position. The refusal goes to stderr and this line
   # to stdout, so "above" is only true on a terminal that interleaves them --
   # `remote.sh connect … | tee log` puts them in different places, and a note
   # that points at nothing is the kind of sentence this change exists to remove.
-  local engine_note=" Sync engine running."
+  local engine_note=" Sync engine start requested (remote.sh status $team confirms)."
   [ "$engine_started" -eq 1 ] || engine_note=" The sync engine did not start; the reason is on stderr."
   echo "Connected: team '$team'$server_side ($connection_security).$engine_note"
   # Carrying the snapshot and key by hand is the plain install's answer to

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -972,15 +972,26 @@ cmd_pull() {
     echo "Pulled '$pulled_name' into local team '$team' ($imported message(s))."
     echo "This team is encrypted and this machine does not hold the key for its current epoch, so its sync engine is halted."
   else
-    _remote_sync_engine_start "$team"
+    # Whether a start failure should end the command depends on what the command
+    # was for: if the engine IS the purpose, not having one means the purpose was
+    # not served and the command fails; if it is a side effect, the command
+    # reports and returns. Pull's purpose is to bring the team here, and it has.
+    # So this reports. (cmd_unlock exits 1 on the same failure for the opposite
+    # reason -- its purpose is to make the team readable AND start syncing it.
+    # The three are deliberately not uniform; making them uniform would be the
+    # error.)
+    local engine_started=1
+    _remote_sync_engine_start "$team" || engine_started=0
+    local engine_note=" Sync engine running."
+    [ "$engine_started" -eq 1 ] || engine_note=" The sync engine did not start (above)."
     if [ "$needs_key" -eq 1 ]; then
       # Says what was checked, and stops there. The identity for the current
       # epoch is here; messages sealed to an earlier key are a different
       # question and this did not ask it.
-      echo "Pulled '$pulled_name' into local team '$team' ($imported message(s)). Sync engine running."
+      echo "Pulled '$pulled_name' into local team '$team' ($imported message(s)).$engine_note"
       echo "This team is encrypted; this machine holds the key for its current epoch."
     else
-      echo "Pulled '$pulled_name' into local team '$team' ($imported message(s)). Sync engine running."
+      echo "Pulled '$pulled_name' into local team '$team' ($imported message(s)).$engine_note"
     fi
   fi
   if [ "$cannot_read" -ne 0 ]; then
@@ -1246,7 +1257,17 @@ EOF
   local engine_log="$CONNECTION_ROOT/run/remote-sync.$team.log" log_offset=1
   [ -f "$engine_log" ] &&
     log_offset=$(( $(wc -c < "$engine_log" | tr -d ' ') + 1 ))
-  _remote_sync_engine_start "$team"
+  # A refusal leaves REMOTE_SYNC_ENGINE_PID empty, which the readiness check
+  # below already treats as "did not become ready" and reports with unlock's own
+  # message. Tolerated here only because that handler exists.
+  #
+  # Detection is the handler's; the EXPLANATION is the refusal's, and it is
+  # already on stderr by the time this runs -- `|| true` discards the status,
+  # not the output, so the operator sees both the cause and the outcome. That
+  # only holds while the refusal is printed BEFORE the return: move it after and
+  # the two causes collapse into one message, which is the failure this whole
+  # change is about.
+  _remote_sync_engine_start "$team" || true
   local pid="${REMOTE_SYNC_ENGINE_PID:-}" ready=0 attempts=0
   while [ "$attempts" -lt 50 ]; do
     if [ -z "$pid" ] || ! _agmsg_pid_alive "$pid"; then
@@ -1314,17 +1335,66 @@ _remote_holds_current_key() {
   [ -n "$derived" ] && [ "$derived" = "$recipient" ]
 }
 
+# Why a start failure has to be spoken here rather than left to the caller.
+#
+# This function used to end in `disown … || true`, so it always returned 0. It
+# is called as `if ! _remote_sync_engine_start …` in one place, and `set -e` is
+# suspended inside an `if` condition — so a failed `echo > "$pidfile"` two lines
+# from the end was stepped over, the function reported success, and the command
+# died further down at `cat "$pidfile"` having printed nothing of its own. The
+# three other call sites do not look at the return value at all. Measured with
+# the run dir made unwritable: the caller saw success, then exit 1, silent.
+#
+# The tolerant `mkdir … || true` was half of it. Tolerating the directory and
+# then writing into it unguarded moves the failure to a line that cannot
+# explain itself. Both halves are checked below, and the writability of the
+# pidfile is proven BEFORE the engine is spawned — a spawn whose pidfile cannot
+# be written produces an engine no `status` can see and no `stop` can reach.
+_remote_sync_engine_start_refused() {
+  local team="$1" path="$2" why="$3"
+  {
+    echo "agmsg: could not start the sync engine for '$team': $why"
+    echo "  $path"
+    echo "  Nothing is syncing for this team: messages written here will not"
+    echo "  reach the server, and new ones will not arrive, until an engine runs."
+    echo "  If this machine sandboxes the agent (Codex does), that directory has"
+    echo "  to be writable by it. Then run:"
+    echo "    remote.sh sync start $(agmsg_shq "$team")"
+  } >&2
+}
+
 _remote_sync_engine_start() {
-  local team="$1" startup_nonce="${2:-}" pidfile logfile old_pid old_state
+  local team="$1" startup_nonce="${2:-}" pidfile logfile old_pid old_state rundir
   pidfile="$(_remote_sync_engine_pidfile "$team")"
   logfile="$CONNECTION_ROOT/run/remote-sync.$team.log"
-  mkdir -p "$CONNECTION_ROOT/run" 2>/dev/null || true
+  rundir="$CONNECTION_ROOT/run"
+  # Cleared first: this is a global, and the early returns below happen before
+  # any spawn. Left alone, a caller that reads it after a refusal would get the
+  # pid of whatever this function started the previous time it was called.
+  REMOTE_SYNC_ENGINE_PID=""
+  if ! mkdir -p "$rundir" 2>/dev/null; then
+    _remote_sync_engine_start_refused "$team" "$rundir" \
+      "its run directory could not be created"
+    return 1
+  fi
   # Stop only an engine whose argv proves that it owns this team. A stale
   # pidfile may point at a recycled, unrelated process and must never authorize
   # signalling that process.
   IFS=$'\t' read -r old_state old_pid < <(_remote_sync_engine_status "$team")
   if [ "$old_state" = "running" ]; then
     kill "$old_pid" 2>/dev/null || true
+  fi
+  # Writability proven before the spawn -- but AFTER the block above, not before
+  # it. Truncating the pidfile first destroys the pid that _remote_sync_engine_status
+  # reads to decide whether an old engine owns this team, so the old one is never
+  # signalled and survives the restart: the orphan this guard exists to prevent,
+  # manufactured by the guard. Caught by test_remote.bats "remote unlock … resumes
+  # age-v1 sync"; by this point the previous engine has already been identified
+  # and killed, so the truncation costs nothing.
+  if ! : > "$pidfile" 2>/dev/null; then
+    _remote_sync_engine_start_refused "$team" "$pidfile" \
+      "its pidfile could not be written"
+    return 1
   fi
   # nohup so the engine outlives this connect; remote-sync.sh execs node, so $!
   # stays the engine's own pid and is exactly what _remote_sync_engine_stop signals.
@@ -1335,7 +1405,16 @@ _remote_sync_engine_start() {
   AGMSG_SYNC_START_NONCE="$startup_nonce" \
     nohup bash "$SCRIPT_DIR/remote-sync.sh" run --team "$team" >> "$logfile" 2>&1 3>&- 4>&- &
   REMOTE_SYNC_ENGINE_PID=$!
-  echo "$REMOTE_SYNC_ENGINE_PID" > "$pidfile"
+  if ! echo "$REMOTE_SYNC_ENGINE_PID" > "$pidfile" 2>/dev/null; then
+    # The engine is already running at this point. Leaving it without a pidfile
+    # is the orphan state: invisible to status, and _remote_sync_engine_stop
+    # returns 0 without looking for it. Take it back down rather than create one.
+    kill "$REMOTE_SYNC_ENGINE_PID" 2>/dev/null || true
+    REMOTE_SYNC_ENGINE_PID=""
+    _remote_sync_engine_start_refused "$team" "$pidfile" \
+      "its pidfile could not be written, so the engine was stopped again"
+    return 1
+  fi
   disown 2>/dev/null || true
 }
 
@@ -1640,7 +1719,14 @@ cmd_connect() {
   # Start the polling engine in the background: it pushes what we have, pulls
   # anything already there, and keeps running so new messages flow both ways as
   # they are written. Stop it with 'remote.sh disconnect <team>'.
-  _remote_sync_engine_start "$team"
+  #
+  # Connect's purpose is the binding, and the binding is written by this point,
+  # so a start failure reports rather than fails the command -- same rule as
+  # cmd_pull, opposite of cmd_unlock, and the note there explains why the three
+  # differ. What it must not do is end by saying the engine runs: the line below
+  # made that claim unconditionally, from a function that could not fail.
+  local engine_started=1
+  _remote_sync_engine_start "$team" || engine_started=0
 
   local connection_security="plain"
   [ "$binding_cipher" = "age-v1" ] && connection_security="age-v1 encrypted"
@@ -1658,7 +1744,9 @@ cmd_connect() {
   if [ -n "$remote_team_name" ] && [ "$remote_team_name" != "$team" ]; then
     server_side=" (on the server: '$remote_team_name')"
   fi
-  echo "Connected: team '$team'$server_side ($connection_security). Sync engine running."
+  local engine_note=" Sync engine running."
+  [ "$engine_started" -eq 1 ] || engine_note=" The sync engine did not start (above)."
+  echo "Connected: team '$team'$server_side ($connection_security).$engine_note"
   # Carrying the snapshot and key by hand is the plain install's answer to
   # getting a second machine in. A larger tool may have a ceremony for exactly
   # that, and this line would talk its operator out of it -- into doing by hand

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -983,7 +983,7 @@ cmd_pull() {
     local engine_started=1
     _remote_sync_engine_start "$team" || engine_started=0
     local engine_note=" Sync engine running."
-    [ "$engine_started" -eq 1 ] || engine_note=" The sync engine did not start (above)."
+    [ "$engine_started" -eq 1 ] || engine_note=" The sync engine did not start; the reason is on stderr."
     if [ "$needs_key" -eq 1 ]; then
       # Says what was checked, and stops there. The identity for the current
       # epoch is here; messages sealed to an earlier key are a different
@@ -1744,8 +1744,12 @@ cmd_connect() {
   if [ -n "$remote_team_name" ] && [ "$remote_team_name" != "$team" ]; then
     server_side=" (on the server: '$remote_team_name')"
   fi
+  # Names the stream, not a position. The refusal goes to stderr and this line
+  # to stdout, so "above" is only true on a terminal that interleaves them --
+  # `remote.sh connect … | tee log` puts them in different places, and a note
+  # that points at nothing is the kind of sentence this change exists to remove.
   local engine_note=" Sync engine running."
-  [ "$engine_started" -eq 1 ] || engine_note=" The sync engine did not start (above)."
+  [ "$engine_started" -eq 1 ] || engine_note=" The sync engine did not start; the reason is on stderr."
   echo "Connected: team '$team'$server_side ($connection_security).$engine_note"
   # Carrying the snapshot and key by hand is the plain install's answer to
   # getting a second machine in. A larger tool may have a ceremony for exactly

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1337,13 +1337,29 @@ _remote_holds_current_key() {
 
 # Why a start failure has to be spoken here rather than left to the caller.
 #
-# This function used to end in `disown … || true`, so it always returned 0. It
-# is called as `if ! _remote_sync_engine_start …` in one place, and `set -e` is
-# suspended inside an `if` condition — so a failed `echo > "$pidfile"` two lines
-# from the end was stepped over, the function reported success, and the command
-# died further down at `cat "$pidfile"` having printed nothing of its own. The
-# three other call sites do not look at the return value at all. Measured with
-# the run dir made unwritable: the caller saw success, then exit 1, silent.
+# This function used to end in `disown … || true`, so it always returned 0, and
+# every caller was written around that. `cmd_sync_start` called it as
+# `if ! _remote_sync_engine_start …`, where `set -e` is suspended — so a failed
+# `echo > "$pidfile"` two lines from the end was stepped over, the function
+# reported success, and the command died further down at `cat "$pidfile"` having
+# printed nothing of its own. The others did not look at the return value at
+# all. Measured with the run dir made unwritable: the caller saw success, then
+# exit 1, silent.
+#
+# Five callers now, and they are deliberately not uniform — the rule is whether
+# the engine is what the command was FOR:
+#
+#   cmd_sync_start    `if ! …`     the engine is the purpose; the command fails
+#   cmd_unlock        `|| true`    same, but its own readiness handler converts
+#                                  the empty pid into unlock's failure, and the
+#                                  refusal is already on stderr by then
+#   cmd_pull          capture      purpose already served; reports
+#   cmd_connect       capture      purpose already served; reports
+#   cmd_set_endpoint  capture      purpose already served; reports
+#
+# Derive the set before trusting it: `grep -n '_remote_sync_engine_start "'`.
+# set-endpoint arrived while this change was in review, as a bare call, and the
+# rebase that brought it did not conflict.
 #
 # The tolerant `mkdir … || true` was half of it. Tolerating the directory and
 # then writing into it unguarded moves the failure to a line that cannot

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2026,6 +2026,94 @@ PY_BIND
   [ "$status" -ne 0 ]
 }
 
+# unlock, with a start refusal injected (#730). advisor ruled this had to be
+# pinned rather than described: unlock is the only caller that discards the
+# helper's status with `|| true` and converts it, through
+# REMOTE_SYNC_ENGINE_PID and the readiness loop, into its own failure. A
+# regression that drops the `|| true` or unhooks the readiness handler passes
+# every sync-start, pull and connect test in the tree.
+#
+# The injection is a DIRECTORY at the pidfile path, not a read-only file.
+# unlock runs `_remote_sync_engine_stop` first, which ends in
+# `rm -f "$pidfile"` -- that succeeds on a read-only file in a writable
+# directory and clears the injection before the start it was meant to reach.
+# A directory survives: `[ -f ]` is false so stop returns 0 without touching
+# it, `rm -f` cannot remove it, and `: > "$pidfile"` fails. Measured.
+#
+# The fixture is this test's own rather than one lifted out of the two unlock
+# tests above. They look alike and are not the same: different bundle and
+# envelope paths, a different snapshot export, different ciphertext. Turning
+# them into one parameterised helper is a change to two passing tests in a file
+# that already flakes under load, and it is not what this PR is about.
+@test "remote unlock: a start refusal fails the unlock, and says why (#730)" {
+  skip_if_no_age
+
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam >/dev/null
+  local source_cfg snapshot bundle key_id recipient identity team_id envelope digest
+  source_cfg="$TEST_SKILL_DIR/teams/testteam/config.json"
+  snapshot="$TEST_SKILL_DIR/handed-snapshot.json"
+  bundle="$TEST_SKILL_DIR/handed-bundle.json"
+  envelope="$TEST_SKILL_DIR/handed-envelope.json"
+  bash "$SCRIPTS/key.sh" show testteam --snapshot --out "$snapshot" 2>/dev/null
+  bash "$SCRIPTS/key.sh" handoff testteam --out "$bundle" >/dev/null 2>&1
+  key_id="$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$source_cfg")') AS TEXT), '\$.remote_key.current.key_id');")"
+  recipient="$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$source_cfg")') AS TEXT), '\$.remote_key.current.recipient');")"
+  team_id="$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$source_cfg")') AS TEXT), '\$.team_id');")"
+  identity="$TEST_SKILL_DIR/run/remote-credentials/testteam/keys/$key_id.key"
+  jq -nc \
+    --arg key_id "$key_id" \
+    --arg recipient "$recipient" \
+    --arg team_id "$team_id" \
+    '{
+      type:"sync_seal", envelope_v:1, cipher:"age-v1",
+      key_id:$key_id, recipients:[$recipient], max_blob_bytes:1048576,
+      wire_id:"20000000-0000-4000-8000-000000000001",
+      team_id:$team_id, protocol_version:1,
+      projection:{
+        body:"handed ciphertext", created_at:"2026-01-02T00:00:00.000000Z",
+        from_agent:"member-1", to_agent:"member-1"
+      }
+    }' | node "$SCRIPTS/internal/sync-cipher.mjs" seal > "$envelope"
+  bash "$SCRIPTS/remote.sh" disconnect testteam >/dev/null 2>&1 || true
+
+  MOCK_PULL_AGE=1
+  MOCK_PULL_AGE_ENVELOPE_FILE="$envelope"
+  MOCK_PULL_TEAM_ID="$team_id"
+  restart_mock_server
+
+  # Machine B gets an independent install root. Reusing Machine A's root would
+  # reuse its retained checkpoint and would not test a first trust import.
+  PEER_SKILL_DIR="$(mktemp -d)"
+  export PEER_SKILL_DIR
+  mkdir -p "$PEER_SKILL_DIR"/{scripts,db,teams}
+  cp -R "$BATS_TEST_DIRNAME"/../scripts/. "$PEER_SKILL_DIR/scripts/"
+  chmod +x "$PEER_SKILL_DIR/scripts/"*.sh
+  chmod +x "$PEER_SKILL_DIR/scripts/"*.js 2>/dev/null || true
+  chmod +x "$PEER_SKILL_DIR/scripts/drivers/types/codex/"*.sh 2>/dev/null || true
+  bash "$PEER_SKILL_DIR/scripts/internal/init-db.sh"
+  local peer_scripts="$PEER_SKILL_DIR/scripts"
+
+  run bash "$peer_scripts/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$team_id" encrypted
+  [ "$status" -eq 0 ]
+
+  digest="$(shasum -a 256 "$snapshot" | awk '{print $1}')"
+  mkdir -p "$PEER_SKILL_DIR/run/remote-sync.encrypted.pid"
+
+  run bash "$peer_scripts/remote.sh" unlock encrypted \
+    --bundle "$bundle" --confirm-digest "$digest"
+  rmdir "$PEER_SKILL_DIR/run/remote-sync.encrypted.pid" 2>/dev/null || true
+
+  # unlock's purpose IS to start syncing the team, so unlike pull and connect it
+  # fails rather than reporting.
+  [ "$status" -ne 0 ]
+  # The cause, from the refusal ...
+  grep -qF "could not start the sync engine" <<<"$output"
+  # ... and the outcome, from unlock's own handler. Both, not one: they are
+  # different facts and collapsing them is what this change is about.
+  grep -qF "did not become ready" <<<"$output"
+  refute grep -qF "ready for normal use" <<<"$output"
+}
+
 @test "remote unlock: confirms handed authority, reprocesses, and resumes age-v1 sync" {
   skip_if_no_age
 

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1527,6 +1527,62 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   fi
 }
 
+# The three callers changed by #730, each with a start refusal injected.
+#
+# The refusal itself is covered in tests/test_remote_engine_start_refusal.bats,
+# but only through `sync start`. Without these, the four-path asymmetry that
+# change is about -- unlock fails, pull and connect report and carry on -- is
+# only prose in the commit message. Found in review.
+#
+# The injection is a read-only pidfile rather than an unwritable run dir: the
+# rest of connect and pull write under run/ too, and taking the whole directory
+# away would stop them for reasons that have nothing to do with the engine.
+_deny_engine_pidfile() {
+  # Two statements, not one. `local a="$1" b="…$a…"` builds b before a is
+  # visible, so the pidfile came out as `remote-sync..pid` and the injection
+  # silently missed -- the test then measured an ordinary pull and reported the
+  # claim it was written to catch.
+  local team="$1"
+  local pidfile="$TEST_SKILL_DIR/run/remote-sync.$team.pid"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  printf '%s\n' 2147483647 > "$pidfile"
+  chmod a-w "$pidfile"
+}
+
+@test "remote pull: a start refusal is reported, and the pull still succeeds (#730)" {
+  [ "$(id -u)" -ne 0 ] || skip "chmod does not restrict root"
+  MOCK_TEAM_CIPHER_PROFILE=none
+  restart_mock_server
+  _deny_engine_pidfile cloned
+
+  run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" cloned
+  chmod u+w "$TEST_SKILL_DIR/run/remote-sync.cloned.pid" 2>/dev/null || true
+  # Pull's purpose is to bring the team here, and it did.
+  [ "$status" -eq 0 ]
+  grep -qF "Pulled" <<<"$output"
+  # But it must not claim an engine it could not start.
+  refute grep -qF "Sync engine start requested" <<<"$output"
+  grep -qF "The sync engine did not start" <<<"$output"
+  grep -qF "could not start the sync engine" <<<"$output"
+}
+
+@test "remote connect: a start refusal is reported, and the binding still stands (#730)" {
+  [ "$(id -u)" -ne 0 ] || skip "chmod does not restrict root"
+  MOCK_TEAM_CIPHER_PROFILE=none
+  restart_mock_server
+  bash "$SCRIPTS/join.sh" bound alice claude-code /tmp/project-bound >/dev/null
+  _deny_engine_pidfile bound
+
+  run bash "$SCRIPTS/remote.sh" connect bound --endpoint "$ENDPOINT"
+  chmod u+w "$TEST_SKILL_DIR/run/remote-sync.bound.pid" 2>/dev/null || true
+  # Connect's purpose is the binding, and it is written by this point.
+  [ "$status" -eq 0 ]
+  grep -qF "Connected:" <<<"$output"
+  refute grep -qF "Sync engine start requested" <<<"$output"
+  grep -qF "The sync engine did not start" <<<"$output"
+  grep -qF "could not start the sync engine" <<<"$output"
+}
+
 @test "remote pull: starts a background sync engine that disconnect stops" {
   # This team is a PLAIN one: say so. The fixture's default declaration is
   # age-v1, and the engine now follows the declaration rather than the
@@ -1541,7 +1597,9 @@ PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
   # engine. A pulled team that only cloned would report a send as "Sent" and
   # stay local while status answered "connected"; pin the engine running and the
   # binding it continues against. This is what a green 56/0 slipped past.
-  [[ "$output" == *"Sync engine running."* ]]
+  # "start requested", not "running": this path spawns the engine and records
+  # its pid, and does not wait to see it come up (#730).
+  [[ "$output" == *"Sync engine start requested"* ]]
   local pidfile="$SCRIPTS/../run/remote-sync.cloned.pid"
   wait_for_file "$pidfile"
   local cfg="$TEST_SKILL_DIR/teams/cloned/config.json"
@@ -1832,7 +1890,7 @@ PY_BIND
 
   run bash "$SCRIPTS/remote.sh" pull --endpoint "$ENDPOINT" --team-id "$PULL_TEAM_ID" encrypted
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Sync engine running"* ]]
+  [[ "$output" == *"Sync engine start requested"* ]]
   [[ "$output" == *"holds the key for its current epoch"* ]]
   [[ "$output" != *"does not hold the key"* ]]
   [[ "$output" != *"local but locked"* ]]

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -271,9 +271,13 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
 #                         exits on that instead.
 #
 # Reaching it needs the run dir to become unwritable BETWEEN the stop and the
-# start, which is a race a test cannot stage. Left uncovered and said so, rather
-# than shipping a test that passes against the bare call -- the mutation
-# reverting this call site reds nothing today.
+# start. What was measured is narrower than "impossible": these three injections
+# do not reach it, and the code as it stands offers no seam between the stop and
+# the start for a test to drive. A dedicated barrier or hook in that gap would
+# stage it deterministically -- not proposed here, and said plainly so the limit
+# reads as the current shape of the code rather than a law. Left uncovered and
+# said so, rather than shipping a test that passes against the bare call -- the
+# mutation reverting this call site reds nothing today.
 
 @test "set-endpoint: moves a connected team with history to a new address of the same server (#718)" {
   # bob joins BEFORE connect so the server roster matches the local one: the

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -251,6 +251,30 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
 # refused with both ids named, and there is no path that writes an unverified
 # address.
 
+# NOT COVERED, measured rather than assumed (#730): "set-endpoint reports a
+# failed engine restart instead of claiming one".
+#
+# The capture is in cmd_set_endpoint because the helper can now return non-zero
+# and a bare call would abort the command under `set -e`. No test drives it,
+# and not for want of trying:
+#
+#   read-only pidfile  -- cmd_set_endpoint calls _remote_sync_engine_stop itself
+#                         (remote.sh, inside cmd_set_endpoint) before the
+#                         restart, and that ends in `rm -f "$pidfile"`, which
+#                         succeeds in a writable run dir. Observed: the file
+#                         went -r--r--r-- -> -rw-r--r-- across the command and
+#                         the restart claimed success.
+#   directory at that   -- survives the rm, but `[ -f ]` is then false when
+#   path                  was_running is captured a few lines earlier, so the
+#                         restart branch is never entered at all.
+#   unwritable run dir  -- the stop's own `rm -f` fails first and the command
+#                         exits on that instead.
+#
+# Reaching it needs the run dir to become unwritable BETWEEN the stop and the
+# start, which is a race a test cannot stage. Left uncovered and said so, rather
+# than shipping a test that passes against the bare call -- the mutation
+# reverting this call site reds nothing today.
+
 @test "set-endpoint: moves a connected team with history to a new address of the same server (#718)" {
   # bob joins BEFORE connect so the server roster matches the local one: the
   # identity re-check compares rosters, and this test is about the address.

--- a/tests/test_remote_engine_start_refusal.bats
+++ b/tests/test_remote_engine_start_refusal.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+
+# What a sync engine that cannot start is allowed to leave behind (#730).
+#
+# It used to leave nothing: no message, no exit code the operator saw, and a
+# claim from the caller that the engine was running. `_remote_sync_engine_start`
+# ended in `disown … || true`, so it always returned 0; the one caller that
+# checked used `if ! …`, where `set -e` is suspended, so a failed pidfile write
+# was stepped over and the command died later at `cat "$pidfile"` with nothing
+# printed. Measured on a codex-like sandbox shape: the run dir was not writable,
+# and `sync start` exited without a word of its own.
+#
+# These tests pin the three things that has to produce instead: a non-zero exit,
+# a message naming the path and the way out, and NO half-started engine.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a
+
+  local cfg="$TEST_SKILL_DIR/teams/testteam/config.json" escaped updated
+  escaped="$(sed "s/'/''/g" "$cfg")"
+  updated="$(sqlite_mem "
+    SELECT json_set('$escaped', '\$.remote_binding', json_object(
+      'endpoint', 'https://remote.example',
+      'server_instance_id', '018f0000-0000-7000-8000-000000000001',
+      'remote_team_id', '018f0000-0000-7000-8000-000000000002',
+      'protocol_version', 1,
+      'capabilities', json_object('write_allowed_ciphers', json_array('none')),
+      'connected_at', '2026-07-30T00:00:00Z',
+      'disconnected_at', null
+    ));")"
+  printf '%s\n' "$updated" > "$cfg"
+  mkdir -p "$TEST_SKILL_DIR/run"
+}
+
+teardown() {
+  # Restore before the harness removes the tree, or the unwritable dir defeats
+  # its own cleanup.
+  chmod u+w "$TEST_SKILL_DIR/run" 2>/dev/null || true
+  chmod u+w "$TEST_SKILL_DIR/run/remote-sync.testteam.pid" 2>/dev/null || true
+  chmod u+w "$TEST_SKILL_DIR" 2>/dev/null || true
+  # The control case starts a real engine. cmd_sync_start reaps it when it does
+  # not become ready, but a test file about leaked engines should not be the one
+  # leaking them if that reap ever stops working.
+  local pidfile="$TEST_SKILL_DIR/run/remote-sync.testteam.pid" pid=""
+  [ -f "$pidfile" ] && pid="$(cat "$pidfile" 2>/dev/null || true)"
+  # 0 and 1 are never ours: `kill 0` signals the whole process group (measured:
+  # it killed the bats run) and 1 is init.
+  case "$pid" in
+    ''|*[!0-9]*|0|1) ;;
+    *) kill "$pid" 2>/dev/null || true ;;
+  esac
+  teardown_test_env
+}
+
+# Refuse to run as root: chmod is the whole mechanism here and root ignores it,
+# so the tests would pass without ever reaching the branch they are about.
+skip_if_root() {
+  [ "$(id -u)" -ne 0 ] || skip "chmod does not restrict root, so the refusal path is unreachable"
+}
+
+@test "sync start: an unwritable run dir is refused out loud, not in silence (#730)" {
+  skip_if_root
+  chmod a-w "$TEST_SKILL_DIR/run"
+
+  run bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -ne 0 ]
+  # The path, so the operator knows what to fix rather than what to suspect.
+  grep -qF "remote-sync.testteam.pid" <<<"$output"
+  # What is not happening, in the operator's terms rather than the engine's.
+  grep -qF "Nothing is syncing for this team" <<<"$output"
+  # And the way back. A refusal that names no next step leaves the operator to
+  # invent one, which is how a tunnel got invented for #717.
+  grep -qF "remote.sh sync start" <<<"$output"
+}
+
+@test "sync start: the refusal leaves no engine and no pidfile behind (#730)" {
+  skip_if_root
+  chmod a-w "$TEST_SKILL_DIR/run"
+
+  run bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -ne 0 ]
+  # Companion, not the discriminator: the broken form ALSO leaves no pidfile —
+  # that is exactly what its failed write produces. Measured against the
+  # original body, this assertion stays green. It is here so a future change
+  # cannot start writing a pidfile for a start that was refused; the test below
+  # is the one that separates "refused" from "orphaned".
+  refute test -f "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+}
+
+# NOT COVERED, deliberately: "a refused start leaves no engine process".
+#
+# Proving the orphan-prevention half needs an input where the broken code
+# spawns and then fails to record the pid. Two were tried and neither reaches
+# it. Making the run dir unwritable kills the child at its own log redirection
+# (`>> run/remote-sync.<team>.log`) before node starts. Making only the pidfile
+# read-only lets the spawn happen, but the test could not observe a surviving
+# engine either -- both were measured green against the original function body,
+# which is the definition of a test that does not test its subject.
+#
+# So the guard that proves writability BEFORE the spawn is in the code without
+# a test that would notice its removal. Said here rather than left implicit:
+# the other four tests below and above cover the audible-failure half only.
+
+@test "sync start: the command the refusal prints is the command that works (#730)" {
+  skip_if_root
+  # Not "the refusal mentions a real command" -- that is satisfied by any real
+  # command. The remedy is LIFTED OUT of the refusal and run, so the two cannot
+  # drift apart: change the printed string alone and this fails on whatever it
+  # now prints. A printed route has to be run, not read.
+  printf '%s\n' 2147483647 > "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+  chmod a-w "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+
+  run bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -ne 0 ]
+
+  # Captured before the next `run`, which overwrites $output.
+  local remedy
+  remedy="$(grep -oE 'remote\.sh [a-z].*' <<<"$output" | tail -1)"
+  [ -n "$remedy" ]
+  # Only the arguments are lifted: the leading path is whatever the operator's
+  # install puts there, and the test has its own.
+  local args="${remedy#remote.sh }"
+
+  chmod u+w "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+  rm -f "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+
+  # Run through a shell, not by word-splitting. The remedy is written for a
+  # person to paste into one, so the team name arrives shell-quoted by
+  # agmsg_shq; splitting it here passes the quotes through as characters and the
+  # command fails on a team literally named "'testteam'" -- measured, that is
+  # what the first version of this test did. A printed route has to be run the
+  # way it is meant to be run.
+  run bash -c "bash '$SCRIPTS/remote.sh' $args"
+  # "not refused" is not enough: a remedy that no longer parses is answered with
+  # a usage line, which is also not a refusal. Measured -- changing only the
+  # printed verb (start -> begin) left this test green until the two assertions
+  # below were added. What has to be true is that the lifted command REACHED the
+  # engine-start path, so it must say what became of the engine.
+  refute grep -q "^Usage:" <<<"$output"
+  grep -qE "Sync engine (already running|started)|did not become ready" <<<"$output"
+}
+
+@test "sync start: a run dir that cannot be created is refused the same way (#730)" {
+  skip_if_root
+  # The other half. `mkdir -p … || true` tolerated this and left the failure to
+  # the unguarded write below it, which could not explain itself.
+  rmdir "$TEST_SKILL_DIR/run"
+  chmod a-w "$TEST_SKILL_DIR"
+
+  run bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -ne 0 ]
+  grep -qF "could not start the sync engine" <<<"$output"
+  grep -qF "run" <<<"$output"
+}
+
+@test "sync start: a writable run dir still starts an engine (#730)" {
+  # The control. Without it, every assertion above is satisfied by a
+  # `sync start` that refuses unconditionally.
+  run bash "$SCRIPTS/remote.sh" sync start testteam
+  # The engine is real here and will fail to reach https://remote.example, so
+  # this does not assert success -- only that the refusal above is not what
+  # happened, and that the pidfile path was reachable.
+  refute grep -qF "Nothing is syncing for this team" <<<"$output"
+  refute grep -qF "could not start the sync engine" <<<"$output"
+}


### PR DESCRIPTION
`remote.sh sync start` could fail and say nothing. On Codex in the field it
exited with no output and no message of its own, and `status` kept reporting a
stale engine. This makes the failure audible, and stops three callers claiming
an engine they never checked.

Closes nothing on its own — #730 asks for two rulings (what identifies "the same
engine", and whether there is a revive) and neither is answered here. This is
the part that is right under either ruling.

## Why it was silent

`_remote_sync_engine_start` ended in `disown … || true`, so it always returned 0.
Its only checking caller used `if ! …`, where `set -e` is suspended, so a failed
`echo > "$pidfile"` was stepped over and the function reported success. The
command then died at `cat "$pidfile"` with nothing printed by agmsg.

The tolerant line above it was the other half: `mkdir -p … || true` accepted a
run directory it could not create, moving the failure onto a write that could
not explain itself.

Measured, with the run dir made unwritable:

```
CALLER SAW SUCCESS  <- the write failed and nobody noticed
cat: .../remote-sync.demo.pid: No such file or directory
exit=1
```

## What changed

- both halves checked; the refusal names the path, says what is not happening,
  and gives the command to run
- writability proven **before** the spawn — an engine with no pidfile is
  invisible to `status` and unreachable by `_remote_sync_engine_stop`, which
  opens `[ -f "$pidfile" ] || return 0` and reports success for an engine it
  never looked for
- if the write fails after the spawn anyway, the engine is stopped again
- `REMOTE_SYNC_ENGINE_PID` cleared on entry: it is a global, and the early
  returns happen before any spawn, so a caller reading it after a refusal got
  the pid from the previous call
- `cmd_pull` and `cmd_connect` stop printing "Sync engine running."
  unconditionally

### The three callers are deliberately not uniform

The rule, in tl's words: **if the engine is the command's purpose, a failure
ends the command; if it is a side effect, the command reports and returns.**

| | purpose | on a start failure |
|---|---|---|
| `cmd_unlock` | make the team readable **and start syncing it** | exits 1, as before |
| `cmd_pull` | bring the team here — done by then | reports |
| `cmd_connect` | write the binding — done by then | reports |

Making them uniform would be the error.

### Order matters here

The writability proof runs **after** the block that identifies and kills a
previous engine. Putting it first truncates the pidfile that
`_remote_sync_engine_status` reads, so the old engine is never signalled and
survives the restart — the orphan the guard exists to prevent, manufactured by
the guard. `test_remote.bats "remote unlock … resumes age-v1 sync"` and
`--authenticated-bundle-stdin` caught it. The reason is in the code beside the
line, so that "failing earlier is cheaper" does not move it back.

## Tests

Five, in `tests/test_remote_engine_start_refusal.bats`.

**Mutation** — the original function body restored, verbatim:

```
ok=3  not_ok=2
not ok 1 an unwritable run dir is refused out loud, not in silence
not ok 3 the command the refusal prints is the command that works
ok  5 a writable run dir still starts an engine     <- control
```

The first mutation attempt left one guard in place and all five stayed green. A
partial mutation proves nothing; that is recorded in the test file.

**The remedy is lifted out of the refusal and run**, not read: change only the
printed verb (`start` → `begin`) and the test fails on whatever it now prints.
It runs the line through a shell, because the team name arrives shell-quoted by
`agmsg_shq` and word-splitting passes the quotes through as characters — the
first version of that test did exactly that and asked for a team named
`'testteam'`.

**Not covered, and said so in the file**: "a refused start leaves no engine
process". Two inputs were tried; neither makes the original code produce an
observable orphan (an unwritable run dir kills the child at its own log
redirection before node starts; a read-only pidfile yielded no survivor the test
could see). Both measured green against the broken body, so the test was removed
rather than kept as decoration. The guard stays — it prevents a class — but
nothing would notice its removal.

## Suite

```
test_remote.bats                        100/100
test_remote_status_liveness.bats         13/13
test_remote_forget.bats                   7/7
test_remote_engine_start_refusal.bats      5/5
check-enforced-assertions.sh          616, at the baseline
```

`remote unlock: a health response naming another team` failed once inside a full
run and passes 3/3 in isolation on this branch **and** on
`origin/integration/remote`; a later full run was 100/100. Reported as flake
(#595's shape: a different test each time), not claimed as unrelated on one
observation.
