### PR TITLE
fix(watch): reap bare-id watchers with no live agent ancestor (#693)

### DIFF
--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -457,6 +457,19 @@ agmsg_reap_orphan_bare_watchers() {
   local self="${1:-$$}" f sid pid cmd mtime now
   [ -d "$run" ] || return 0
   command -v ps >/dev/null 2>&1 || return 0
+  # Detector-blindness gate, checked ONCE for the whole pass rather than per
+  # watcher: if no process anywhere on this machine looks like a known agent
+  # type, "no ancestor" for any individual watcher carries no information —
+  # it is what EVERY bare watcher looks like here, orphaned or not (headless
+  # CI, a container, this test suite's own bats runner). An age floor alone
+  # does not fix that: it only delays the same false-positive reap past
+  # however long the floor is set to, and a normal watcher that outlives it
+  # gets killed on the next session-start with a fully correct-looking sid/
+  # argv match (#737 review, raised independently by two reviewers). Refusing
+  # to reap AT ALL while the detector is demonstrably blind is what keeps
+  # "not found" meaning "checked and absent" instead of "couldn't have found
+  # it either way".
+  agmsg_any_agent_process_exists || return 0
   now=$(date +%s)
   for f in "$run"/watch.*.pid; do
     [ -f "$f" ] || continue
@@ -466,21 +479,11 @@ agmsg_reap_orphan_bare_watchers() {
     _agmsg_pid_valid "$pid" || continue
     [ "$pid" = "$self" ] && continue
     _agmsg_pid_alive "$pid" || continue
-    # Grace period: a bare watcher that just started has had no chance to
-    # prove it is orphaned. "No agent ancestor" is not rare here — it is what
-    # EVERY bare watcher looks like, from the instant it starts, in any
-    # environment where nothing in the process tree is ever a recognizable
-    # agent binary (headless CI, a container, this test suite's own bats
-    # runner). Without an age floor, this reaper would kill a bare watcher
-    # seconds into its life just as readily as one orphaned for a week — and
-    # did: session-start.sh's own "compact dedup" test starts a watcher and
-    # immediately re-fires session-start, and CI (no agent process anywhere)
-    # showed the reaper killing that live, seconds-old watcher on both
-    # ubuntu-latest and macos-latest (#737 review). Requiring the pidfile to
-    # be at least AGMSG_REAP_GRACE_SECONDS old is what keeps "no ancestor"
-    # meaning "had time to prove it and still couldn't" rather than "hasn't
-    # been alive long enough to matter either way". Override exists so tests
-    # can shrink the window instead of sleeping real wall-clock seconds.
+    # Grace period, defense-in-depth alongside the blindness gate above: a
+    # bare watcher that just started has had no chance to prove it is
+    # orphaned even in an environment the gate above has already confirmed is
+    # NOT blind. Override exists so tests can shrink the window instead of
+    # sleeping real wall-clock seconds.
     mtime="$(compat_file_mtime "$f" 2>/dev/null || echo "$now")"
     [ $(( now - mtime )) -ge "${AGMSG_REAP_GRACE_SECONDS:-120}" ] || continue
     agmsg_any_agent_ancestor_pid "$pid" >/dev/null 2>&1 && continue

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -25,7 +25,8 @@
 # so "last dot-segment is numeric" unambiguously marks the composite form.
 #
 # Requires: SKILL_DIR set. agmsg_instance_id / agmsg_normalize_instance_id
-# additionally require resolve-project.sh sourced (for agmsg_agent_pid);
+# additionally require resolve-project.sh sourced (for agmsg_agent_pid), as
+# does agmsg_reap_orphan_bare_watchers (for agmsg_any_agent_ancestor_pid);
 # agmsg_instance_alive and the pure helpers do not.
 
 # Guard against double-source (these are sourced transitively via actas-lock.sh
@@ -386,6 +387,55 @@ agmsg_reap_orphan_grok_watchers() {
   done <<EOF
 $(ps -eo pid=,args= 2>/dev/null)
 EOF
+}
+
+# Reap watch.sh processes whose recorded session id is bare and whose own
+# process now has no live agent-type ancestor of any kind (#693).
+#
+# A composite id is already self-checked every poll cycle, from inside the
+# watcher, against agmsg_instance_alive (#67, watch.sh's liveness guard). A
+# bare id has no equivalent: agmsg_instance_alive's bare branch answers a
+# different question (upgrade compat — does some live cc-instance record
+# still reference this sid from before the composite scheme existed), and a
+# session that never resolved to a pid in the first place never writes a
+# cc-instance record for that branch to find. Extending the composite check's
+# MECHANISM (kill -0 an embedded pid) to bare ids is not available — there is
+# no pid embedded in a bare id to check. This is the other mechanism the gap
+# needs: reap from outside, at a moment some OTHER live session can look, by
+# walking the watcher's OWN pid for ANY known agent ancestor (see
+# agmsg_any_agent_ancestor_pid) rather than trying to resolve the one the
+# watcher itself already failed to find at launch.
+#
+# Generalizes agmsg_reap_orphan_grok_watchers (one type, found via a ps-argv
+# pattern match) to every type, found via the pidfile the watcher itself
+# already writes — no pattern needed, and no dependency on the watcher's argv
+# still containing a recognizable type token.
+#
+# Specific-PID kill ONLY, same as the grok reaper: never a pattern kill.
+# Skips composite ids (self-checked already), <self_pid>, and any watcher
+# whose recorded pid no longer matches a live watch.sh process (pid reuse).
+agmsg_reap_orphan_bare_watchers() {
+  local run="${SKILL_DIR:?agmsg_reap_orphan_bare_watchers requires SKILL_DIR}/run"
+  local self="${1:-$$}" f sid pid cmd
+  [ -d "$run" ] || return 0
+  command -v ps >/dev/null 2>&1 || return 0
+  for f in "$run"/watch.*.pid; do
+    [ -f "$f" ] || continue
+    sid="${f#"$run"/watch.}"; sid="${sid%.pid}"
+    agmsg_instance_is_composite "$sid" && continue
+    pid="$(cat "$f" 2>/dev/null || true)"
+    _agmsg_pid_valid "$pid" || continue
+    [ "$pid" = "$self" ] && continue
+    _agmsg_pid_alive "$pid" || continue
+    agmsg_any_agent_ancestor_pid "$pid" >/dev/null 2>&1 && continue
+    # Defensive, same reason as session-start.sh's stale-pidfile pass: a
+    # recycled pid pointing at an unrelated process must never be signalled.
+    cmd="$(compat_get_cmdline "$pid" 2>/dev/null || true)"
+    case "$cmd" in
+      *"$SKILL_DIR/scripts/watch.sh"*) kill "$pid" 2>/dev/null || true; rm -f "$f" ;;
+      *) ;;
+    esac
+  done
 }
 
 # True iff <token> identifies a still-live instance.

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -454,9 +454,10 @@ EOF
 # wrong session, #737 review).
 agmsg_reap_orphan_bare_watchers() {
   local run="${SKILL_DIR:?agmsg_reap_orphan_bare_watchers requires SKILL_DIR}/run"
-  local self="${1:-$$}" f sid pid cmd
+  local self="${1:-$$}" f sid pid cmd mtime now
   [ -d "$run" ] || return 0
   command -v ps >/dev/null 2>&1 || return 0
+  now=$(date +%s)
   for f in "$run"/watch.*.pid; do
     [ -f "$f" ] || continue
     sid="${f#"$run"/watch.}"; sid="${sid%.pid}"
@@ -465,6 +466,23 @@ agmsg_reap_orphan_bare_watchers() {
     _agmsg_pid_valid "$pid" || continue
     [ "$pid" = "$self" ] && continue
     _agmsg_pid_alive "$pid" || continue
+    # Grace period: a bare watcher that just started has had no chance to
+    # prove it is orphaned. "No agent ancestor" is not rare here — it is what
+    # EVERY bare watcher looks like, from the instant it starts, in any
+    # environment where nothing in the process tree is ever a recognizable
+    # agent binary (headless CI, a container, this test suite's own bats
+    # runner). Without an age floor, this reaper would kill a bare watcher
+    # seconds into its life just as readily as one orphaned for a week — and
+    # did: session-start.sh's own "compact dedup" test starts a watcher and
+    # immediately re-fires session-start, and CI (no agent process anywhere)
+    # showed the reaper killing that live, seconds-old watcher on both
+    # ubuntu-latest and macos-latest (#737 review). Requiring the pidfile to
+    # be at least AGMSG_REAP_GRACE_SECONDS old is what keeps "no ancestor"
+    # meaning "had time to prove it and still couldn't" rather than "hasn't
+    # been alive long enough to matter either way". Override exists so tests
+    # can shrink the window instead of sleeping real wall-clock seconds.
+    mtime="$(compat_file_mtime "$f" 2>/dev/null || echo "$now")"
+    [ $(( now - mtime )) -ge "${AGMSG_REAP_GRACE_SECONDS:-120}" ] || continue
     agmsg_any_agent_ancestor_pid "$pid" >/dev/null 2>&1 && continue
     # Re-read cmdline right before signalling (not a value captured earlier in
     # the loop), narrowing the pid-reuse race to the smallest window this

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -370,6 +370,40 @@ agmsg_args_is_grok_watcher() {
   [ "$saw_type" = 1 ] && [ "$saw_proj" = 1 ]
 }
 
+# True iff <args> is an actual `<shell> <path>/watch.sh <sid> ...` invocation
+# for THIS EXACT <sid> — not merely a watch.sh process for some other session,
+# and not a process whose command line happens to mention watch.sh as text
+# rather than as the executed program. Same boundary agmsg_args_is_grok_watcher
+# already draws (program position, not substring), generalized to check the
+# session-id positional instead of a fixed type/project pair — the reaper has
+# no fixed type or project to check here, only the sid the pidfile's own name
+# promised.
+#
+# Needed because a pidfile's promise can outlive its truth: once its original
+# process exits without cleaning up, the OS can hand that same pid to an
+# unrelated, currently-live `watch.sh <other-sid> ...`. A cmdline-contains-
+# "watch.sh" check cannot tell that apart from the real thing, and would kill
+# a live, legitimate watcher for a different session (#737 review).
+agmsg_args_is_watcher_for_sid() {
+  local args="$1" want_sid="${2:-}" a1 a2
+  [ -n "$args" ] || return 1
+  [ -n "$want_sid" ] || return 1
+  set -f
+  # shellcheck disable=SC2086
+  set -- $args
+  set +f
+  [ "$#" -ge 1 ] || return 1
+  a1="${1##*/}"
+  a2=""; [ "$#" -ge 2 ] && a2="${2##*/}"
+  if [ "$a1" = "watch.sh" ]; then
+    [ "$#" -ge 2 ] && [ "$2" = "$want_sid" ]
+  elif [ "$a2" = "watch.sh" ]; then
+    [ "$#" -ge 3 ] && [ "$3" = "$want_sid" ]
+  else
+    return 1
+  fi
+}
+
 agmsg_reap_orphan_grok_watchers() {
   local project="$1" self="${2:-$$}" pid args
   [ -n "$project" ] || return 0
@@ -413,7 +447,11 @@ EOF
 #
 # Specific-PID kill ONLY, same as the grok reaper: never a pattern kill.
 # Skips composite ids (self-checked already), <self_pid>, and any watcher
-# whose recorded pid no longer matches a live watch.sh process (pid reuse).
+# whose recorded pid is no longer THIS sid's watch.sh — including when it has
+# been reused by an unrelated, currently-live watch.sh for a DIFFERENT
+# session (see agmsg_args_is_watcher_for_sid; a cmdline-contains-"watch.sh"
+# check alone cannot tell the two apart and would kill a live watcher for the
+# wrong session, #737 review).
 agmsg_reap_orphan_bare_watchers() {
   local run="${SKILL_DIR:?agmsg_reap_orphan_bare_watchers requires SKILL_DIR}/run"
   local self="${1:-$$}" f sid pid cmd
@@ -428,13 +466,22 @@ agmsg_reap_orphan_bare_watchers() {
     [ "$pid" = "$self" ] && continue
     _agmsg_pid_alive "$pid" || continue
     agmsg_any_agent_ancestor_pid "$pid" >/dev/null 2>&1 && continue
-    # Defensive, same reason as session-start.sh's stale-pidfile pass: a
-    # recycled pid pointing at an unrelated process must never be signalled.
+    # Re-read cmdline right before signalling (not a value captured earlier in
+    # the loop), narrowing the pid-reuse race to the smallest window this
+    # helper can offer, and verify it is THIS exact sid's watch.sh invocation.
     cmd="$(compat_get_cmdline "$pid" 2>/dev/null || true)"
-    case "$cmd" in
-      *"$SKILL_DIR/scripts/watch.sh"*) kill "$pid" 2>/dev/null || true; rm -f "$f" ;;
-      *) ;;
-    esac
+    agmsg_args_is_watcher_for_sid "$cmd" "$sid" || continue
+    # Signal only; never remove the pidfile here (#737 review). `kill`
+    # succeeding is proof the signal was accepted, not that the process has
+    # exited — watch.sh's own EXIT trap owns that, and only removes PIDFILE
+    # when it still records $$ (the same ownership contract every other
+    # cleanup path in this codebase respects). A kill failure (EPERM,
+    # already-gone-but-not-yet-reaped, anything else `|| true` swallows) must
+    # leave the pidfile in place: it is the only discovery record a future
+    # pass has, and deleting it on a failed signal would turn a live, still-
+    # consuming orphan into one no GC can ever find again — worse than #693's
+    # original "consumes forever", not a fix of it.
+    kill "$pid" 2>/dev/null || true
   done
 }
 

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -372,6 +372,45 @@ agmsg_any_agent_ancestor_pid() {
   return 1
 }
 
+# True iff ANY process anywhere on this machine currently looks like a known
+# agent type (see agmsg_pid_is_agent) — not an ancestor of any particular pid,
+# just a live one somewhere in the whole process table.
+#
+# Exists to tell a blind detector from a true negative. agmsg_any_agent_ancestor_pid
+# failing to find an ancestor for one specific pid means one of two very
+# different things: that pid's own launching session really did end, or ps
+# simply cannot see ANY agent process from anywhere in this environment
+# (headless CI, a container with no agent runtime, a sandbox) — in which case
+# every bare watcher looks ancestor-less from the instant it starts, whether
+# orphaned or not, and "not found" carries no information about that specific
+# watcher at all (#737 review: an age floor alone does not fix this, it only
+# delays a normal watcher's false-positive reap past however long the floor
+# is set to). A caller that only reaps once this returns true is reaping on
+# a specific absence, not a blanket one.
+#
+# Not a proof either way for the *individual* watcher being checked — a
+# machine can have one live session while a DIFFERENT session's watcher is
+# genuinely orphaned — but it is what turns "no ancestor" from meaningless in
+# a blind environment into meaningful in one that demonstrably is not blind.
+#
+# Override hook, same shape as the others: AGMSG_ANY_AGENT_PROCESS_EXISTS set
+# to a non-empty value forces true, set empty forces false, unset runs the
+# real scan.
+agmsg_any_agent_process_exists() {
+  if [ -n "${AGMSG_ANY_AGENT_PROCESS_EXISTS+set}" ]; then
+    [ -n "$AGMSG_ANY_AGENT_PROCESS_EXISTS" ]
+    return
+  fi
+  command -v ps >/dev/null 2>&1 || return 1
+  local pid t
+  for pid in $(ps -eo pid= 2>/dev/null); do
+    for t in claude-code codex gemini antigravity copilot opencode; do
+      agmsg_pid_is_agent "$pid" "$t" && return 0
+    done
+  done
+  return 1
+}
+
 agmsg_project_marker_path() { printf '%s/proj.%s.project' "$(_agmsg_run_dir)" "$1"; }
 
 # Persist <project> as the real root for agent <pid>. Best-effort.

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -315,6 +315,63 @@ agmsg_agent_pid() {
   return 1
 }
 
+# Same walk as agmsg_agent_pid, generalized two ways: it starts from an
+# explicit <pid> (default: $$) instead of always the caller's own process, and
+# it accepts an ancestor of ANY known type instead of one named type. Exists
+# for exactly one caller class: code that must ask "does this OTHER pid still
+# have some owning agent session" without knowing which type launched it —
+# which is precisely the situation a bare instance id leaves behind (#693). A
+# bare id means agmsg_agent_pid already failed once for this same pid asking
+# about one type; asking again for the same single type would just repeat the
+# same negative, so this checks every type the binary map distinguishes.
+#
+# The type list mirrors _agmsg_agent_binaries' named cases, not its wildcard
+# default — the default ("claude codex gemini") is already a subset of what
+# checking "claude-code" and "codex" and "gemini" individually covers, so
+# looping the named cases is exhaustive without a second source of truth to
+# keep in sync (agmsg_known_types walks driver directories on disk and is
+# built for a different question — eligibility to run a session — not "which
+# binary names has this file ever mapped a pid against").
+#
+# Does NOT prove the pid's original launching session is dead. A sandboxed
+# `ps`, an unusual launch topology, or a chain deeper than 20 hops makes this
+# walk blind, and blind looks identical to gone — the same trade-off
+# agmsg_grok_ancestor_pid already ships with for one type. A caller reaping on
+# a miss here is accepting that trade-off, not discovering a new one.
+#
+# Override hook, same shape and same reason as AGMSG_AGENT_PID: when
+# AGMSG_ANY_AGENT_ANCESTOR_PID is set, it pins the answer instead of walking
+# the tree — a non-empty value is echoed as-is, empty forces "no ancestor". A
+# distinct variable rather than reusing AGMSG_AGENT_PID because the two calls
+# answer about different pids (the caller's own vs. an arbitrary <start>); one
+# override pinning both would make a test that needs them to disagree — an
+# orphaned OTHER watcher next to a live self, or vice versa — impossible to
+# express.
+agmsg_any_agent_ancestor_pid() {
+  local start="${1:-$$}"
+  if [ -n "${AGMSG_ANY_AGENT_ANCESTOR_PID+set}" ]; then
+    case "$AGMSG_ANY_AGENT_ANCESTOR_PID" in
+      '')       return 1 ;;
+      *[!0-9]*) return 1 ;;
+      *) printf '%s' "$AGMSG_ANY_AGENT_ANCESTOR_PID"; return 0 ;;
+    esac
+  fi
+  local pid="$start" hops=0 t
+  while [ "${pid:-0}" -gt 1 ] && [ "$hops" -lt 20 ]; do
+    pid=$(compat_get_ppid "$pid" 2>/dev/null || true)
+    [ -z "$pid" ] && return 1
+    [ "$pid" = "0" ] && return 1
+    for t in claude-code codex gemini antigravity copilot opencode; do
+      if agmsg_pid_is_agent "$pid" "$t"; then
+        printf '%s' "$pid"
+        return 0
+      fi
+    done
+    hops=$((hops + 1))
+  done
+  return 1
+}
+
 agmsg_project_marker_path() { printf '%s/proj.%s.project' "$(_agmsg_run_dir)" "$1"; }
 
 # Persist <project> as the real root for agent <pid>. Best-effort.

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -198,6 +198,14 @@ for f in "$RUN_DIR"/watch.*.pid; do
   _agmsg_pid_alive_local "$pid" || rm -f "$f"
 done
 
+# Reap watchers whose recorded session id is bare and whose own process now
+# has no live agent-type ancestor of any kind. The pass above only catches a
+# watcher whose PROCESS died without cleaning up its pidfile; this one is for
+# the opposite shape — the process is still very much alive, but the id it
+# was launched with never resolved to a pid in the first place, so it has no
+# equivalent to the composite branch's per-cycle liveness self-check (#693).
+agmsg_reap_orphan_bare_watchers "$$" 2>/dev/null || true
+
 # Garbage-collect actas exclusivity locks whose owner session_id no longer
 # maps to a live cc-instance. Must run after the dead cc-instance cleanup
 # above, since the liveness check enumerates the remaining cc-instance.*

--- a/tests/test_watcher_bare_id_reap.bats
+++ b/tests/test_watcher_bare_id_reap.bats
@@ -69,6 +69,16 @@ _run_reaper_with_kill_failing() {
     agmsg_reap_orphan_bare_watchers "$$" )
 }
 
+@test "any_agent_process_exists: AGMSG_ANY_AGENT_PROCESS_EXISTS overrides the real scan" {
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/resolve-project.sh"
+  AGMSG_ANY_AGENT_PROCESS_EXISTS="" run agmsg_any_agent_process_exists
+  [ "$status" -ne 0 ]
+  AGMSG_ANY_AGENT_PROCESS_EXISTS=1 run agmsg_any_agent_process_exists
+  [ "$status" -eq 0 ]
+}
+
 @test "any_agent_ancestor_pid: no match when the starting pid does not exist" {
   # A nonexistent pid has no ppid to walk to, so the real walk (no override)
   # must fail at the first hop. Deliberately not testing this against a real
@@ -107,6 +117,11 @@ _run_reaper_with_kill_failing() {
   # for real deployments, not for a test that already controls every other
   # variable (#737 review).
   export AGMSG_REAP_GRACE_SECONDS=0
+  # These tests exercise ancestor/sid/kill-signal logic specifically, not
+  # whether the environment can resolve agent ancestors at all — pin the
+  # blindness gate open (#737 review) so a CI runner (no agent process
+  # anywhere) and a dev machine (a real one right here) behave identically.
+  export AGMSG_ANY_AGENT_PROCESS_EXISTS=1
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
     >"$TEST_SKILL_DIR/out.log" 2>/dev/null 3>&- 4>&- &
@@ -155,6 +170,11 @@ _run_reaper_with_kill_failing() {
   # not the age floor added in #737 review (which would otherwise protect a
   # seconds-old watcher regardless of ancestor).
   export AGMSG_REAP_GRACE_SECONDS=0
+  # These tests exercise ancestor/sid/kill-signal logic specifically, not
+  # whether the environment can resolve agent ancestors at all — pin the
+  # blindness gate open (#737 review) so a CI runner (no agent process
+  # anywhere) and a dev machine (a real one right here) behave identically.
+  export AGMSG_ANY_AGENT_PROCESS_EXISTS=1
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
     >"$TEST_SKILL_DIR/out2.log" 2>/dev/null 3>&- 4>&- &
@@ -190,6 +210,11 @@ _run_reaper_with_kill_failing() {
   # for real deployments, not for a test that already controls every other
   # variable (#737 review).
   export AGMSG_REAP_GRACE_SECONDS=0
+  # These tests exercise ancestor/sid/kill-signal logic specifically, not
+  # whether the environment can resolve agent ancestors at all — pin the
+  # blindness gate open (#737 review) so a CI runner (no agent process
+  # anywhere) and a dev machine (a real one right here) behave identically.
+  export AGMSG_ANY_AGENT_PROCESS_EXISTS=1
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$real_sid" "$PROJ" claude-code \
     >"$TEST_SKILL_DIR/out3.log" 2>/dev/null 3>&- 4>&- &
@@ -228,6 +253,11 @@ _run_reaper_with_kill_failing() {
   # for real deployments, not for a test that already controls every other
   # variable (#737 review).
   export AGMSG_REAP_GRACE_SECONDS=0
+  # These tests exercise ancestor/sid/kill-signal logic specifically, not
+  # whether the environment can resolve agent ancestors at all — pin the
+  # blindness gate open (#737 review) so a CI runner (no agent process
+  # anywhere) and a dev machine (a real one right here) behave identically.
+  export AGMSG_ANY_AGENT_PROCESS_EXISTS=1
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
     >"$TEST_SKILL_DIR/out4.log" 2>/dev/null 3>&- 4>&- &
@@ -267,6 +297,10 @@ _run_reaper_with_kill_failing() {
   # only genuinely orphaned ones).
   export AGMSG_AGENT_PID=""
   export AGMSG_ANY_AGENT_ANCESTOR_PID=""
+  # This test is specifically about the age floor, not the blindness gate
+  # added afterward (#737 review) — pin the gate open so it isolates the
+  # grace period alone.
+  export AGMSG_ANY_AGENT_PROCESS_EXISTS=1
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
     >"$TEST_SKILL_DIR/out5.log" 2>/dev/null 3>&- 4>&- &
@@ -281,6 +315,40 @@ _run_reaper_with_kill_failing() {
   _run_reaper
   sleep 1
   kill -0 "$wpid" 2>/dev/null   # still alive: too young to be a reap candidate yet
+
+  kill "$wpid" 2>/dev/null || true
+  wait "$wpid" 2>/dev/null || true
+}
+
+@test "a normal bare-id watcher is never reaped while the environment cannot resolve any agent ancestor at all (#737 review)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-bare-blind-env"
+
+  # The age floor alone does NOT fix this: a normal, still-alive watcher in an
+  # environment where NO process anywhere is ever a recognizable agent binary
+  # (headless CI, a container) crosses the grace period exactly like an
+  # orphan would, and gets killed on the next session-start with a fully
+  # correct-looking sid/argv match. Zeroing the grace period here isolates
+  # that: with the age floor out of the way, only the blindness gate stands
+  # between this watcher and a kill.
+  export AGMSG_AGENT_PID=""
+  export AGMSG_ANY_AGENT_ANCESTOR_PID=""
+  export AGMSG_REAP_GRACE_SECONDS=0
+  export AGMSG_ANY_AGENT_PROCESS_EXISTS=""
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
+    >"$TEST_SKILL_DIR/out6.log" 2>/dev/null 3>&- 4>&- &
+  local wpid=$!
+  local pf="$TEST_SKILL_DIR/run/watch.$sid.pid"
+  for i in $(seq 1 50); do
+    [ -f "$pf" ] && break
+    sleep 0.1
+  done
+  [ -f "$pf" ]
+
+  _run_reaper
+  sleep 1
+  kill -0 "$wpid" 2>/dev/null   # still alive: the detector is blind here, so it must not act at all
 
   kill "$wpid" 2>/dev/null || true
   wait "$wpid" 2>/dev/null || true

--- a/tests/test_watcher_bare_id_reap.bats
+++ b/tests/test_watcher_bare_id_reap.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+
+# #693: a watcher whose session id could not be resolved to an agent pid (a
+# "bare" instance id) has no liveness gate at all. watch.sh's own per-cycle
+# self-check only fires for composite ids (see watch.sh's liveness guard,
+# #67); a bare id keeps polling and consuming forever once its owning session
+# is gone. These tests prove the mechanism is real (positive control: an
+# orphaned bare-id watcher DOES consume a message) before proving the fix
+# (agmsg_reap_orphan_bare_watchers, run from session-start.sh) stops it.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export PROJ="/tmp/agmsg-watcher-bare-reap-proj"
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/join.sh" team bob claude-code "$PROJ" >/dev/null
+}
+
+teardown() { teardown_test_env; }
+
+_read_cursor() {
+  ( # shellcheck disable=SC1090
+    source "$SCRIPTS/lib/storage.sh"
+    agmsg_storage_load
+    storage_read_cursor_get "$1" "$2" )
+}
+
+_wait_for_file_contains() {
+  local file="$1" needle="$2" i
+  for i in $(seq 1 100); do
+    [ -f "$file" ] && grep -q "$needle" "$file" && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+_wait_for_cursor_above() {
+  local team="$1" agent="$2" before="$3" i cursor
+  for i in $(seq 1 100); do
+    cursor=$(_read_cursor "$team" "$agent" 2>/dev/null || echo 0)
+    [ "${cursor:-0}" -gt "${before:-0}" ] && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+# Run the new reaper against $TEST_SKILL_DIR/run, as session-start.sh would.
+_run_reaper() {
+  ( export SKILL_DIR="$TEST_SKILL_DIR"
+    # shellcheck disable=SC1090
+    source "$SCRIPTS/lib/resolve-project.sh"
+    # shellcheck disable=SC1090
+    source "$SCRIPTS/lib/instance-id.sh"
+    agmsg_reap_orphan_bare_watchers "$$" )
+}
+
+@test "any_agent_ancestor_pid: no match when the starting pid does not exist" {
+  # A nonexistent pid has no ppid to walk to, so the real walk (no override)
+  # must fail at the first hop. Deliberately not testing this against a real
+  # live pid here: this suite may itself be running inside an actual agent
+  # session, in which case a real walk from $$ legitimately finds one (the
+  # override tested below exists precisely so callers are not at the mercy of
+  # that ambient fact).
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/resolve-project.sh"
+  ! agmsg_any_agent_ancestor_pid 999999
+}
+
+@test "any_agent_ancestor_pid: AGMSG_ANY_AGENT_ANCESTOR_PID overrides the walk" {
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/resolve-project.sh"
+  AGMSG_ANY_AGENT_ANCESTOR_PID="" run agmsg_any_agent_ancestor_pid "$$"
+  [ "$status" -ne 0 ]
+  AGMSG_ANY_AGENT_ANCESTOR_PID="$$" run agmsg_any_agent_ancestor_pid 1234
+  [ "$status" -eq 0 ]
+  [ "$output" = "$$" ]
+}
+
+@test "orphaned bare-id watcher consumes a message, then stops after the reap fix (#693)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-bare-orphan"
+
+  # Force this watcher's own id to stay bare, and force the reaper's later
+  # ancestor walk over ITS pid to also come back empty — deterministic
+  # regardless of the ambient process tree this suite happens to run under
+  # (which may or may not itself have a real claude/codex ancestor).
+  export AGMSG_AGENT_PID=""
+  export AGMSG_ANY_AGENT_ANCESTOR_PID=""
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
+    >"$TEST_SKILL_DIR/out.log" 2>/dev/null 3>&- 4>&- &
+  local wpid=$!
+
+  local before
+  before=$(_read_cursor team alice 2>/dev/null || echo 0)
+  bash "$SCRIPTS/send.sh" team bob alice "M1-while-orphaned" >/dev/null
+
+  # --- Positive control: prove the bug's mechanism is real before fixing it.
+  # An orphaned bare-id watcher, with no resolvable owning session, still
+  # delivers and marks the message read. If this does not happen the rest of
+  # the test proves nothing.
+  _wait_for_file_contains "$TEST_SKILL_DIR/out.log" "M1-while-orphaned"
+  _wait_for_cursor_above team alice "$before"
+  grep -q "M1-while-orphaned" "$TEST_SKILL_DIR/out.log"
+  kill -0 "$wpid" 2>/dev/null   # still alive: watch.sh's own loop never self-checks a bare id
+
+  # --- Apply the fix: reap it from outside, the way session-start.sh does on
+  # every new/resumed session.
+  _run_reaper
+  wait_for_pid_exit "$wpid"
+  [ ! -f "$TEST_SKILL_DIR/run/watch.$sid.pid" ]
+
+  # --- After the fix: nobody is left to consume. A second message sent to the
+  # same pair stays unread.
+  local after_reap
+  after_reap=$(_read_cursor team alice 2>/dev/null || echo 0)
+  bash "$SCRIPTS/send.sh" team bob alice "M2-after-reap" >/dev/null
+  sleep 1.5
+  local final
+  final=$(_read_cursor team alice 2>/dev/null || echo 0)
+  [ "$final" = "$after_reap" ]
+}
+
+@test "a bare-id watcher WITH a live ancestor is not reaped (#693 negative control)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-bare-live"
+
+  export AGMSG_AGENT_PID=""
+  # Pin the reaper's ancestor walk to report THIS bats process as a live
+  # "ancestor" — simulating a watcher whose own id happened to come back bare,
+  # but whose owning session is in fact still alive and resolvable.
+  export AGMSG_ANY_AGENT_ANCESTOR_PID="$$"
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
+    >"$TEST_SKILL_DIR/out2.log" 2>/dev/null 3>&- 4>&- &
+  local wpid=$!
+  # Give it one cycle to write its pidfile before the reaper looks for it.
+  for i in $(seq 1 50); do
+    [ -f "$TEST_SKILL_DIR/run/watch.$sid.pid" ] && break
+    sleep 0.1
+  done
+
+  _run_reaper
+  sleep 1
+  kill -0 "$wpid" 2>/dev/null   # still alive: the reaper must not touch it
+
+  kill "$wpid" 2>/dev/null || true
+  wait "$wpid" 2>/dev/null || true
+}

--- a/tests/test_watcher_bare_id_reap.bats
+++ b/tests/test_watcher_bare_id_reap.bats
@@ -55,6 +55,20 @@ _run_reaper() {
     agmsg_reap_orphan_bare_watchers "$$" )
 }
 
+# Same, but with every `kill` call inside the reaper forced to fail — a
+# function definition shadows the builtin for the rest of this subshell, which
+# is the seam: simulates EPERM/signal-refused without touching production code
+# or the real process table.
+_run_reaper_with_kill_failing() {
+  ( export SKILL_DIR="$TEST_SKILL_DIR"
+    # shellcheck disable=SC1090
+    source "$SCRIPTS/lib/resolve-project.sh"
+    # shellcheck disable=SC1090
+    source "$SCRIPTS/lib/instance-id.sh"
+    kill() { return 1; }
+    agmsg_reap_orphan_bare_watchers "$$" )
+}
+
 @test "any_agent_ancestor_pid: no match when the starting pid does not exist" {
   # A nonexistent pid has no ppid to walk to, so the real walk (no override)
   # must fail at the first hop. Deliberately not testing this against a real
@@ -146,6 +160,79 @@ _run_reaper() {
   _run_reaper
   sleep 1
   kill -0 "$wpid" 2>/dev/null   # still alive: the reaper must not touch it
+
+  kill "$wpid" 2>/dev/null || true
+  wait "$wpid" 2>/dev/null || true
+}
+
+@test "a stale pidfile naming a reused pid does not kill the live watcher actually holding it (#737 review)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local real_sid="sess-victim-real"
+  local stale_sid="sess-old-dead"
+
+  # The pid this test cares about is a REAL, live, ancestor-less watch.sh —
+  # exactly the shape the reaper is allowed to reap. The point of this test is
+  # that it must be reaped (if at all) ONLY via ITS OWN pidfile naming its own
+  # sid — never via an unrelated pidfile that merely happens to hold the same
+  # pid, simulating pid reuse after some OTHER watcher's process exited
+  # without cleaning up.
+  export AGMSG_AGENT_PID=""
+  export AGMSG_ANY_AGENT_ANCESTOR_PID=""
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$real_sid" "$PROJ" claude-code \
+    >"$TEST_SKILL_DIR/out3.log" 2>/dev/null 3>&- 4>&- &
+  local wpid=$!
+  local real_pf="$TEST_SKILL_DIR/run/watch.$real_sid.pid"
+  for i in $(seq 1 50); do
+    [ -f "$real_pf" ] && break
+    sleep 0.1
+  done
+  [ -f "$real_pf" ]
+
+  # Craft the reuse: a pidfile for a DIFFERENT, stale sid, holding this SAME
+  # live pid, and remove the real/correct pidfile so the loop's only route to
+  # this pid is the wrong one. This is the scenario, not a proxy for it: some
+  # earlier watch.sh for stale_sid really did exit leaving this pidfile
+  # behind, and the OS handed its pid to today's real_sid watcher.
+  local stale_pf="$TEST_SKILL_DIR/run/watch.$stale_sid.pid"
+  printf '%s' "$wpid" > "$stale_pf"
+  rm -f "$real_pf"
+
+  _run_reaper
+  sleep 1
+  kill -0 "$wpid" 2>/dev/null   # still alive: the stale/wrong pidfile must not authorize this kill
+
+  kill "$wpid" 2>/dev/null || true
+  wait "$wpid" 2>/dev/null || true
+}
+
+@test "a kill failure leaves the pidfile in place for a future retry (#737 review)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-bare-kill-fails"
+
+  export AGMSG_AGENT_PID=""
+  export AGMSG_ANY_AGENT_ANCESTOR_PID=""
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
+    >"$TEST_SKILL_DIR/out4.log" 2>/dev/null 3>&- 4>&- &
+  local wpid=$!
+  local pf="$TEST_SKILL_DIR/run/watch.$sid.pid"
+  for i in $(seq 1 50); do
+    [ -f "$pf" ] && break
+    sleep 0.1
+  done
+  [ -f "$pf" ]
+
+  _run_reaper_with_kill_failing
+  sleep 1
+  # The signal never actually landed (every kill in the reaper was forced to
+  # fail), so both must still be true: the watcher is alive, AND its pidfile
+  # -- the only record a future pass could use to find and retry it -- is
+  # still there. Losing either would turn "could not reap it this time" into
+  # "can never reap it, and no longer even know it exists" (#693 made worse,
+  # not fixed).
+  kill -0 "$wpid" 2>/dev/null
+  [ -f "$pf" ]
 
   kill "$wpid" 2>/dev/null || true
   wait "$wpid" 2>/dev/null || true

--- a/tests/test_watcher_bare_id_reap.bats
+++ b/tests/test_watcher_bare_id_reap.bats
@@ -103,6 +103,10 @@ _run_reaper_with_kill_failing() {
   # (which may or may not itself have a real claude/codex ancestor).
   export AGMSG_AGENT_PID=""
   export AGMSG_ANY_AGENT_ANCESTOR_PID=""
+  # These tests reap seconds-old watchers on purpose; the grace period exists
+  # for real deployments, not for a test that already controls every other
+  # variable (#737 review).
+  export AGMSG_REAP_GRACE_SECONDS=0
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
     >"$TEST_SKILL_DIR/out.log" 2>/dev/null 3>&- 4>&- &
@@ -147,6 +151,10 @@ _run_reaper_with_kill_failing() {
   # "ancestor" — simulating a watcher whose own id happened to come back bare,
   # but whose owning session is in fact still alive and resolvable.
   export AGMSG_ANY_AGENT_ANCESTOR_PID="$$"
+  # Zero the grace period so this test exercises the ancestor check itself,
+  # not the age floor added in #737 review (which would otherwise protect a
+  # seconds-old watcher regardless of ancestor).
+  export AGMSG_REAP_GRACE_SECONDS=0
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
     >"$TEST_SKILL_DIR/out2.log" 2>/dev/null 3>&- 4>&- &
@@ -178,6 +186,10 @@ _run_reaper_with_kill_failing() {
   # without cleaning up.
   export AGMSG_AGENT_PID=""
   export AGMSG_ANY_AGENT_ANCESTOR_PID=""
+  # These tests reap seconds-old watchers on purpose; the grace period exists
+  # for real deployments, not for a test that already controls every other
+  # variable (#737 review).
+  export AGMSG_REAP_GRACE_SECONDS=0
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$real_sid" "$PROJ" claude-code \
     >"$TEST_SKILL_DIR/out3.log" 2>/dev/null 3>&- 4>&- &
@@ -212,6 +224,10 @@ _run_reaper_with_kill_failing() {
 
   export AGMSG_AGENT_PID=""
   export AGMSG_ANY_AGENT_ANCESTOR_PID=""
+  # These tests reap seconds-old watchers on purpose; the grace period exists
+  # for real deployments, not for a test that already controls every other
+  # variable (#737 review).
+  export AGMSG_REAP_GRACE_SECONDS=0
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
     >"$TEST_SKILL_DIR/out4.log" 2>/dev/null 3>&- 4>&- &
@@ -233,6 +249,38 @@ _run_reaper_with_kill_failing() {
   # not fixed).
   kill -0 "$wpid" 2>/dev/null
   [ -f "$pf" ]
+
+  kill "$wpid" 2>/dev/null || true
+  wait "$wpid" 2>/dev/null || true
+}
+
+@test "a bare-id watcher younger than the grace period is not reaped even with no ancestor (#737 review)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  local sid="sess-bare-too-young"
+
+  # No AGMSG_REAP_GRACE_SECONDS override here: the default must protect a
+  # watcher that only just started, in exactly the shape that made
+  # session-start.sh's own "compact dedup" test fail in real CI (ubuntu-latest
+  # and macos-latest both showed the reaper killing that test's seconds-old
+  # watcher, because CI has no claude/codex process anywhere in the tree, so
+  # EVERY bare watcher looks ancestor-less from the instant it starts, not
+  # only genuinely orphaned ones).
+  export AGMSG_AGENT_PID=""
+  export AGMSG_ANY_AGENT_ANCESTOR_PID=""
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
+    >"$TEST_SKILL_DIR/out5.log" 2>/dev/null 3>&- 4>&- &
+  local wpid=$!
+  local pf="$TEST_SKILL_DIR/run/watch.$sid.pid"
+  for i in $(seq 1 50); do
+    [ -f "$pf" ] && break
+    sleep 0.1
+  done
+  [ -f "$pf" ]
+
+  _run_reaper
+  sleep 1
+  kill -0 "$wpid" 2>/dev/null   # still alive: too young to be a reap candidate yet
 
   kill "$wpid" 2>/dev/null || true
   wait "$wpid" 2>/dev/null || true


### PR DESCRIPTION
## Summary

A watcher whose session id could not be resolved to an agent pid (a "bare" instance id) had no liveness gate at all: `watch.sh`'s own per-cycle self-check only fires for composite ids, and `agmsg_instance_alive`'s bare-id branch answers a different question (upgrade compat against old `cc-instance` records — a session that never resolved a pid never writes one). Such a watcher polled forever once its owning session was gone, silently consuming and marking read messages nobody would ever see (#693).

- `agmsg_any_agent_ancestor_pid` (`resolve-project.sh`) generalizes `agmsg_agent_pid`'s ppid walk: explicit starting pid instead of always `$$`, and any known agent type instead of one named type.
- `agmsg_reap_orphan_bare_watchers` (`instance-id.sh`) uses it to reap live `watch.sh` processes whose recorded id is bare and whose own process now has no discoverable agent ancestor — generalizing the existing `agmsg_reap_orphan_grok_watchers` (one type, ps-argv pattern match) to every type, via the pidfile the watcher already writes (no pattern match needed).
- Wired into `session-start.sh` alongside the existing stale-pidfile and actas-lock GC passes — the "known moment" the issue names.
- Composite ids are untouched (already self-checked in `watch.sh`'s own loop); this only covers the previously-unchecked bare shape. Token shape is exhaustively {composite, bare}, so both are now checked.

## What this does NOT close: the reap window

The reaper runs at `session-start.sh` time, not continuously. That means an orphaned bare-id watcher still consumes and marks read messages for the entire span between the moment its owning session ends and the moment some *other* session next starts (or resumes/clears) on this machine:

- On a machine where sessions start frequently, that window is short.
- On a machine with one long-lived session and nothing else starting, the window is open-ended — the orphan keeps consuming until *something* triggers `session-start.sh` again.

#693's title is "never self-expires and keeps consuming" — this PR does not make that zero, it bounds it to "consumes until the next session-start elsewhere on the machine." Read "fixed" here as "the previously-infinite window is now bounded by the next session-start," not "an orphan stops consuming immediately when its session ends."

## Known limitation (reported, not silently accepted)

"No agent ancestor found" for one specific watcher cannot fully distinguish "that watcher's own owning session is dead" from "a sandboxed `ps` / unusual launch topology / a chain deeper than 20 hops makes the walk blind for that pid specifically" — the same trade-off `agmsg_reap_orphan_grok_watchers` already ships with for one type. The blindness-gate fix below (see the last "Fixed in review" section) closes the coarser version of this — an environment where NO process anywhere can ever be resolved — but a machine that has *some* live agent process while this *specific* watcher's own ancestor is unreachable for topology reasons unrelated to its session's actual death is still a residual gap. This reaper accepts that narrower residual trade-off rather than leaving bare watchers with no expiry path at all.

## Fixed in review: pid reuse could kill the wrong watcher

Raised in review and independently confirmed: the first version of `agmsg_reap_orphan_bare_watchers` checked only that a pidfile's recorded pid was alive and its cmdline contained `watch.sh` — not that the pid's cmdline was actually launched with *this pidfile's* sid. A stale pidfile for a dead watcher, if the OS later handed its pid to an unrelated, currently-live `watch.sh <other-sid> ...`, would authorize killing that live, legitimate watcher.

Fixed by adding `agmsg_args_is_watcher_for_sid` (mirrors the existing `agmsg_args_is_grok_watcher`'s program-position check, extended to verify the session-id positional argument matches exactly) and re-reading cmdline immediately before signalling rather than reusing an earlier-captured value. Forced reproduction: temporarily reverted to the old substring check, added `tests/test_watcher_bare_id_reap.bats`'s new "stale pidfile naming a reused pid" test, confirmed it fails (RED — the live watcher gets killed via the wrong pidfile) against the old code, then restored the fix and confirmed it passes (GREEN).

## Fixed in review: a failed reap signal deleted the only record of the orphan

Raised in review and independently confirmed: `agmsg_reap_orphan_bare_watchers` removed the pidfile unconditionally after `kill`, including when `kill` failed (EPERM, already-gone-but-not-reaped, anything `|| true` swallows). `kill` succeeding is proof a signal was accepted, not that the process exited. The pidfile is the only discovery record an orphan leaves; deleting it on a failed signal turns "could not reap it this time" into "can never find it again" — worse than #693's original "consumes forever," not a fix of it.

Fixed by dropping the `rm -f` entirely: `watch.sh`'s own EXIT trap already owns pidfile removal, and only does so when the file still records its own pid (the same ownership contract every other cleanup path here respects) — matching what `agmsg_reap_orphan_grok_watchers` already does (signal only, no rm). Forced reproduction: confirmed the new "kill failure leaves the pidfile in place" test fails (RED) against the unconditional-`rm` code (using a `kill() { return 1; }` shadow function as the failure seam, not a change to production code), then passes (GREEN) with it removed.

## Fixed after CI, not just claimed as a flake: reaping killed a live, seconds-old watcher

An earlier revision of this PR reported one CI failure (`session-start: skips directive when watcher already alive (compact dedup)`, failing on both `ubuntu-latest` and `macos-latest`) as probable pre-existing flakiness, based on it passing repeatedly when rerun in isolation on a dev machine. That read was wrong, and the isolated reruns didn't actually test the failing condition: this dev machine always has a real `claude` ancestor resolvable in its process tree, so the reaper's ancestor check protected the test's watcher locally regardless of the fix. Real CI has no such process anywhere, so **every** bare watcher looks ancestor-less there — including a legitimate one seconds into its life, not only genuinely orphaned ones. `agmsg_reap_orphan_bare_watchers` was killing that test's own live watcher.

Fixed by requiring a pidfile to be at least `AGMSG_REAP_GRACE_SECONDS` old (default 120s, overridable for tests) before it is even a reap candidate. Forced reproduction: reproduced the CI failure locally by forcing both the session id and the ancestor walk to report "no ancestor" (`AGMSG_AGENT_PID=""` + `AGMSG_ANY_AGENT_ANCESTOR_PID=""`) the way an environment with no agent process anywhere naturally does, confirmed both `test_watch.bats`'s pre-existing test and this PR's new grace-period test fail (RED) against the code without this fix under that forced condition, then restored the fix and confirmed both pass (GREEN) under the same forced condition — not just an unforced rerun.

## Fixed in review: the grace period only delayed the same false positive, it didn't close it

Raised independently by two reviewers (converging on the same static finding): the age floor above does not distinguish a normal watcher from an orphan — it only delays the same false-positive kill. In an environment where no process is ever a recognizable agent binary, a normal, still-alive watcher crosses the grace period exactly like an orphan would, and gets killed on the *next* `session-start` with a fully correct-looking sid/argv match. "The startup-time test is fixed, but the same failure reproduces two minutes later" is the accurate description of what the grace period alone did.

Fixed by adding `agmsg_any_agent_process_exists` (`resolve-project.sh`): a system-wide scan for whether *any* process anywhere on the machine looks like a known agent type, independent of any specific pid's ancestry. `agmsg_reap_orphan_bare_watchers` now checks this once per pass, before looking at any individual watcher: if no agent process exists anywhere, the detector is blind, "no ancestor" for any specific watcher carries no information, and the entire pass is skipped. The grace period remains as defense-in-depth for the residual case the gate doesn't cover (see "Known limitation" above), not as the primary protection anymore.

Forced reproduction: confirmed the new "watcher is never reaped while the environment cannot resolve any agent ancestor at all" test fails (RED) against the code without this gate — with the grace period zeroed so only the gate itself is under test — then restored the fix and confirmed it passes (GREEN). Also reconfirmed `test_watch.bats`'s compact-dedup test passes with the blind-environment condition forced explicitly (`AGMSG_ANY_AGENT_PROCESS_EXISTS=""` alongside the other two overrides), not left to this dev machine's own ambient process tree the way the first "fix" for this failure was.

## Test plan

`tests/test_watcher_bare_id_reap.bats`:
- **Positive control**: an orphaned bare-id watcher (forced via `AGMSG_AGENT_PID=""`, ancestor walk forced empty via `AGMSG_ANY_AGENT_ANCESTOR_PID=""`, grace period zeroed for the test) is shown actually consuming and marking read a message *before* the reap. Then `agmsg_reap_orphan_bare_watchers` is run, the watcher process is confirmed killed, and a second message is confirmed to go unread.
- **Negative control**: a bare-id watcher whose ancestor walk resolves (`AGMSG_ANY_AGENT_ANCESTOR_PID=$$`) is left alone by the reaper.
- **Pid-reuse regression**: a stale pidfile for a different, dead sid holding the pid of a real, live, ancestor-less watcher does not get that watcher killed — only its own correctly-named pidfile could authorize that.
- **Kill-failure regression**: with every `kill` in the reaper forced to fail (function-shadowed, not a real signal), the watcher stays alive AND its pidfile stays in place for a future retry.
- **Grace-period regression**: a bare, ancestor-less watcher younger than the default grace period is left alone — the exact shape that broke `test_watch.bats`'s compact-dedup test in real CI.
- **Blindness-gate regression**: a normal, still-alive bare watcher is never reaped, even past the grace period, while nothing anywhere in the process table looks like an agent — the exact shape that would have reproduced the same CI failure two minutes later if only the grace period had shipped.
- Three small unit tests for `agmsg_any_agent_ancestor_pid` / `agmsg_any_agent_process_exists` (no-match on a nonexistent pid, both override behaviors).

Ran the full related suite (`test_watcher_bare_id_reap.bats`, `test_instance_id.bats`, `test_watch.bats`, `test_watch_once.bats`, `test_doctor.bats`) repeatedly, including under the forced no-ancestor and forced-blind conditions above. Final clean run, nothing else running concurrently on the machine: **113/113 pass.**

Two caveats, both investigated rather than waved away:
- One combined run partway through this PR showed several unrelated `test_watch.bats` failures (sentinel/relaunch/etc. tests this PR never touches) at the same time as several other bats invocations I was running concurrently for the RED/GREEN verifications above. Isolated reruns of each individually-failed test, and a full clean rerun with nothing else running, both passed 100% — consistent with resource contention from my own concurrent verification commands, not a logic regression. Noting this rather than silently discarding it as "obviously a fluke."
- `watch: closed stdout exits without advancing the read cursor` (EPIPE/closed-pipe timing, unrelated to anything in this diff) showed one intermittent failure early in this PR's iterations and passed cleanly (8/8 and 8/8) on repeated isolated runs on both this branch and the unmodified base. Unlike the compact-dedup failure, I have not found a forcing condition that reproduces it on demand, so — learning from that mistake — I'm not calling it settled, just reporting what was and wasn't tested.

base: `integration/remote`. Not merging — awaiting review.
