### PR TITLE
fix(watch): stop a watcher that is running code its installation no longer has (#684)

### DIFF
--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -266,7 +266,21 @@ trap 'exit 0' INT TERM HUP
 #
 # `run/` is deliberately outside the watched tree: pidfiles and readiness
 # sentinels are written by watchers themselves and would trip it immediately.
-INSTALL_STAMP="$RUN_DIR/.watch-start.$SESSION_ID"
+#
+# Keyed on the PID as well as the session id, because two watchers can hold the
+# same session id at once: Monitor re-invoked for one session leaves the old
+# watcher running until the successor kills it (#66), and both run cleanup. A
+# stamp named for the session alone is one file they share, so the loser's EXIT
+# trap deletes the winner's. `_install_changed` returns false when its stamp is
+# missing, so the successor would go on running with the guard silently off --
+# the same shape as the bug this guard exists for, and failing in the same
+# reassuring direction. $PIDFILE and $READY_FILES carry ownership checks for
+# exactly this; a per-process name gets it without a check to keep in sync.
+# Found in review.
+#
+# A SIGKILLed watcher leaves its stamp behind, which is the same exposure the
+# pidfile already has, and the file is empty.
+INSTALL_STAMP="$RUN_DIR/.watch-start.$SESSION_ID.$$"
 : > "$INSTALL_STAMP" 2>/dev/null || true
 
 # True when anything under scripts/ was written after this watcher started.

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -246,9 +246,36 @@ cleanup() {
       [ "$_owner" = "$SESSION_ID" ] && rm -f "$_rf" 2>/dev/null || true
     done <<< "$READY_FILES"
   fi
+  [ -n "${INSTALL_STAMP:-}" ] && rm -f "$INSTALL_STAMP" 2>/dev/null || true
 }
 trap cleanup EXIT
 trap 'exit 0' INT TERM HUP
+
+# A resident process keeps executing the code it was started with. An update
+# rewrites the scripts in place (same inode -- confirmed with lsof, #684), so
+# after one this watcher is running code from before it while everything it
+# talks to has moved on. Measured on the reported pair: a 1.1.13 watcher, after
+# `npx agmsg@1.2.0-rc.1 install` landed under it, stayed ALIVE and stopped
+# delivering -- the message was never printed and never marked read, and
+# nothing was written to stderr. Liveness is exactly what made it invisible.
+#
+# The guard is a timestamp rather than a version comparison, so it does not
+# only catch the table that moved this time. ANY file under scripts/ being
+# newer than this watcher's start means the code it is running is no longer the
+# code on disk, whatever changed -- which is the class, not the instance.
+#
+# `run/` is deliberately outside the watched tree: pidfiles and readiness
+# sentinels are written by watchers themselves and would trip it immediately.
+INSTALL_STAMP="$RUN_DIR/.watch-start.$SESSION_ID"
+: > "$INSTALL_STAMP" 2>/dev/null || true
+
+# True when anything under scripts/ was written after this watcher started.
+# `-print -quit` stops at the first hit, so the common case is one stat-walk
+# that exits early rather than a full tree scan every cycle.
+_install_changed() {
+  [ -f "$INSTALL_STAMP" ] || return 1
+  [ -n "$(find "$SCRIPT_DIR" -newer "$INSTALL_STAMP" -print -quit 2>/dev/null)" ]
+}
 
 # Resolve subscription set.
 PAIRS="$("$SCRIPT_DIR/identities.sh" "$PROJECT_PATH" "$AGENT_TYPE")"
@@ -402,6 +429,15 @@ _held_elsewhere_without() {
 }
 
 while true; do
+  # The installation changed under us (#684). Say it on STDOUT, not stderr:
+  # stdout is the delivery channel the session is reading, and this watcher's
+  # stderr goes to /dev/null in every launcher we ship, which is why the
+  # original failure was silent for hours. Then exit, so "the monitor stopped"
+  # is what the session sees instead of a live process delivering nothing.
+  if _install_changed; then
+    printf 'agmsg watch: the agmsg installation was updated while this watcher was running, so it is still executing the code from before the update. Exiting rather than appearing to work. Restart this session (or run /agmsg actas <name>) to resume delivery.\n'
+    exit 0
+  fi
   # Liveness guard (#67): exit promptly once the originating agent session is
   # gone. A plain pipe gives no portable way to notice a *downstream* consumer
   # that closed silently — printf '' raises no EPIPE, and macOS buffers a final

--- a/tests/test_watch_install_changed.bats
+++ b/tests/test_watch_install_changed.bats
@@ -111,3 +111,41 @@ _wait_for() {
   run grep -c 'installation was updated' "$out"
   [ "$output" = "0" ]
 }
+
+@test "watch: a superseded watcher's cleanup does not disarm its successor (#684)" {
+  # Monitor re-invoked for the same session id leaves the old watcher running
+  # until the successor kills it (#66), and both run cleanup. When the stamp was
+  # named for the session alone it was one file shared between them, so the
+  # loser's EXIT trap deleted the winner's -- and `_install_changed` treats a
+  # missing stamp as "nothing changed", so the successor kept running with the
+  # guard silently off. Found in review, and invisible to the two tests above
+  # because each of them only ever has one watcher.
+  local out1="$BATS_TEST_TMPDIR/first.txt" out2="$BATS_TEST_TMPDIR/second.txt"
+  : > "$out1"; : > "$out2"
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" shared-sid "$PROJ" claude-code >"$out1" 2>/dev/null 3>&- 4>&- &
+  local first=$!
+  _wait_for "[ -s '$TEST_SKILL_DIR/run/watch.shared-sid.pid' ]" || true
+
+  # Same session id: this one takes the slot and stops the first (#66).
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" shared-sid "$PROJ" claude-code >"$out2" 2>/dev/null 3>&- 4>&- &
+  local second=$!
+  _wait_for "! kill -0 $first 2>/dev/null" || true
+  kill "$first" 2>/dev/null || true
+  wait "$first" 2>/dev/null || true
+
+  # The successor must still be armed.
+  bash "$SCRIPTS/send.sh" team bob alice "successor-control" >/dev/null
+  _wait_for "grep -q 'successor-control' '$out2'" || true
+
+  touch "$SCRIPTS/config.sh"
+  _wait_for "! kill -0 $second 2>/dev/null" || true
+
+  local was_alive=0
+  kill -0 "$second" 2>/dev/null && was_alive=1
+  kill "$second" 2>/dev/null || true
+  wait "$second" 2>/dev/null || true
+
+  [ "$was_alive" -eq 0 ]
+  grep -q 'installation was updated' "$out2"
+}

--- a/tests/test_watch_install_changed.bats
+++ b/tests/test_watch_install_changed.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+
+# A watcher must not keep running after its own installation is replaced (#684).
+#
+# An update rewrites the scripts in place -- same inode, confirmed with lsof --
+# so a resident watcher goes on executing the code it started with while
+# everything it talks to has moved on. Measured on real installs, one cause
+# produced two different symptoms depending on which versions were involved:
+#
+#   1.1.13 -> 1.2.0-rc.1   watcher alive, delivered NOTHING, message left unread
+#   1.1.13 -> 1.2.0-rc.3   watcher alive, delivery still worked, read state stuck
+#   1.2.0-rc.1 -> rc.3     nothing observable
+#
+# That spread is why the guard here is not tied to a table or a schema: the
+# symptom moves between releases, the cause does not. Any file under scripts/
+# being newer than the watcher's own start means it is running code that is no
+# longer on disk, whatever changed.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) export AGMSG_AGENT_PID="" ;; esac
+  export PROJ="/tmp/agmsg-watch-install-proj"
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/join.sh" team bob claude-code "$PROJ" >/dev/null
+}
+
+teardown() {
+  teardown_test_env
+}
+
+# Wait until <condition> holds, up to ~15s. Returns non-zero if it never did, so
+# a failure names the thing that did not happen rather than surfacing later as a
+# missing grep. Same reasoning as the helpers in test_watch.bats.
+_wait_for() {
+  local i=0
+  while [ "$i" -lt 150 ]; do
+    if eval "$1"; then return 0; fi
+    i=$((i + 1))
+    sleep 0.1
+  done
+  return 1
+}
+
+@test "watch: exits and says so when its own installation is replaced (#684)" {
+  local out="$BATS_TEST_TMPDIR/out.txt"
+  : > "$out"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" sid-684 "$PROJ" claude-code >"$out" 2>/dev/null 3>&- 4>&- &
+  local pid=$!
+
+  # Positive control FIRST. Without it, a watcher that never started would pass
+  # every assertion below by being equally absent -- and "it exited" would be
+  # measuring the harness rather than the guard.
+  bash "$SCRIPTS/send.sh" team bob alice "before-the-update" >/dev/null
+  _wait_for "grep -q 'before-the-update' '$out'" || true
+  grep -q 'before-the-update' "$out"
+  kill -0 "$pid"
+
+  # The update: something under scripts/ is written after this watcher started.
+  # A real install rewrites many files; one is enough to prove the rule.
+  touch "$SCRIPTS/config.sh"
+
+  # `|| true` is load-bearing. Under bats a bare command that returns non-zero
+  # ends the test THERE, so a `_wait_for` that times out would skip the reap
+  # below and leave the watcher holding the test process open -- which is what
+  # happened: removing the guard hung this file for ten minutes twice instead of
+  # failing in fifteen seconds. The wait not arriving is the interesting case,
+  # so it must not be the case that jumps out of the function.
+  _wait_for "! kill -0 $pid 2>/dev/null" || true
+
+  # Reap BEFORE asserting, for the same reason: bats stops at the first failed
+  # assertion, and a live watcher after that point stalls the runner rather than
+  # reporting anything. A mutation has to produce a red test, not a hang.
+  local was_alive=0
+  kill -0 "$pid" 2>/dev/null && was_alive=1
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  [ "$was_alive" -eq 0 ]
+  # On STDOUT, not stderr. Every launcher we ship sends this watcher's stderr to
+  # /dev/null, which is why the original failure was silent for hours -- so the
+  # notice goes to the channel the session is actually reading.
+  grep -q 'installation was updated' "$out"
+}
+
+@test "watch: keeps running when nothing in the installation changes (#684)" {
+  # The guard watches a directory the watcher itself writes into if scoped
+  # wrongly: pidfiles and readiness sentinels live under run/. Scoped to
+  # scripts/ they cannot trip it -- and this is what says so. Without this, a
+  # guard that fired on its own pidfile would still pass the test above.
+  local out="$BATS_TEST_TMPDIR/out2.txt"
+  : > "$out"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" sid-684b "$PROJ" claude-code >"$out" 2>/dev/null 3>&- 4>&- &
+  local pid=$!
+
+  bash "$SCRIPTS/send.sh" team bob alice "first" >/dev/null
+  _wait_for "grep -q 'first' '$out'" || true
+
+  bash "$SCRIPTS/send.sh" team bob alice "second" >/dev/null
+  _wait_for "grep -q 'second' '$out'" || true
+  grep -q 'second' "$out"
+
+  # Same ordering as above: reap first, assert on what was captured.
+  local was_alive=0
+  kill -0 "$pid" 2>/dev/null && was_alive=1
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  [ "$was_alive" -eq 1 ]
+  run grep -c 'installation was updated' "$out"
+  [ "$output" = "0" ]
+}


### PR DESCRIPTION
Closes #684.

A watcher started before an update keeps executing the code it began with. The update rewrites the scripts **in place** — same inode, confirmed with `lsof` in the issue — so the process stays up, `delivery.sh status` counts it healthy, and its stderr goes to `/dev/null` in every launcher we ship. That combination is why this was invisible for hours.

## What was measured

Real installs from npm into a throwaway `HOME` (the live install untouched), **control taken first every time**: send one message, see it reach stdout *and* get marked read, before changing anything.

| update | watcher | stdout | read state |
|---|---|---|---|
| `1.1.13` → `1.2.0-rc.1` | **alive** | **0** | unread |
| **`1.1.13` → `1.2.0-rc.3`** | **alive** | **1** | **unread** |
| `1.2.0-rc.1` → `rc.3` | alive | 1 | read |

The middle row is the shipping line, and it is why **this is not the outage the issue describes**. rc.3 writes the legacy `messages` table again (#698), so an old watcher still finds messages. What stops is read state advancing. A fresh watcher started afterwards delivered **nothing**, so nothing is replayed either — the observable cost is an inbox that shows already-delivered messages as unread, permanently.

**Why the read state stops advancing is not investigated.** Only the outcome above was measured. Whoever picks that up should not read this PR as covered ground.

## Why the guard is not tied to a table

One cause produced two different symptoms depending on which versions were involved — silent non-delivery in one pair, stuck read state in another, nothing in the third. A check written against the table that moved this time would be wrong at the next release for the same underlying reason.

So it compares timestamps instead:

```
INSTALL_STAMP="$RUN_DIR/.watch-start.$SESSION_ID"     # written at watcher start
find "$SCRIPT_DIR" -newer "$INSTALL_STAMP" -print -quit
```

Anything under `scripts/` newer than this watcher's own start means the code being executed is no longer the code on disk, whatever changed. `-print -quit` stops at the first hit, so the common case is a walk that exits early rather than a full scan each cycle.

`run/` is deliberately **outside** the watched tree: pidfiles and readiness sentinels are written by watchers themselves and would trip it instantly.

## The notice goes to stdout

Not stderr. stderr is the channel that made the original failure silent — every launcher we ship sends this watcher's fd2 to `/dev/null`. stdout is what the session is reading, so that is where a watcher gets to say why it stopped.

## Positive control

Same build, stock vs patched, identical harness:

| | control | after the tree changed |
|---|---|---|
| stock | delivered | **alive, said nothing** |
| patched | delivered | **exited in 1s, notice on stdout** |

## Tests

Two, and the second earns its place: a guard scoped one directory wider would fire on the watcher's own pidfile and **still pass the first test**. The second says it does not.

Mutation — removing the four guard lines (diffed, nothing else touched) turns the first test red.

It also **hung the file for ten minutes, twice**, before the waits were made non-aborting. Under bats a bare command returning non-zero ends the test at that line, which skipped the reap and left the watcher holding the runner open. A mutation has to produce a red test, not a stalled one. What is not established: which assertion reports the failure under mutation — the red/green split is attributed to the guard's absence because the mutation diff is those four lines and the same harness is green without it.

`tests/test_watch.bats` is **16/16 on `/bin/bash` 3.2 both with and without this change** (72s vs 67s), so the guard does not disturb the existing harness.

## Measurements discarded along the way

Kept because each one failed in the reassuring direction, and reporting any of them would have produced the opposite conclusion:

- a run labelled "overwrite with a different version" that was **29585 → 29585 bytes** — the file was identical between those two versions, so nothing was varied
- measuring `rc.1 → rc.3` while the report was about `1.1.13 → rc.1` — wrong version pair entirely
- a patched watcher that "died immediately" — it was a stale `actas` lock from the previous case, and the harness was discarding stderr, so the reason was invisible
- a 10-minute timeout on `test_watch.bats` blamed on this change until a stock-vs-patched comparison showed 16/16 in ~70s either way — **not reproduced**
