### PR TITLE
feat(remote): set-endpoint moves a connected team's address, identity-checked

### DIFF
--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -85,6 +85,14 @@ containers are still starting, retry until it succeeds.
 both machines can reach it. Two accounts on one host can; so can two machines on
 a network you control, using the host's address rather than `127.0.0.1`.
 
+The address is not permanent: a connected team can be moved to a new address of
+the **same** server later — a port-forward replaced by the LAN address, a tunnel
+replaced by a stable name — with `remote.sh set-endpoint --endpoint <new-url>
+<team>`. It verifies the new address answers as the same server instance before
+anything changes, and refuses (naming both ids) when it does not. Only the
+address can move this way; pointing a team at a *different* server is
+deliberately not possible without disconnecting first.
+
 Only when the second machine reaches the server over a network you do not
 control does it need a public HTTPS URL. Then check it from there too:
 

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -40,6 +40,7 @@ function usage() {
   remote-sync.sh reprocess --team NAME [--limit N]
   remote-sync.sh resync --team NAME --accept-floor SEQUENCE
   remote-sync.sh unblock-read --team NAME --member-id UUID
+  remote-sync.sh set-endpoint --team NAME
 
 Run remote.sh connect first. The engine reads that team's connection binding
 directly; the remote-sync data plane carries no per-request credential — see
@@ -3102,12 +3103,53 @@ async function publicSnapshot(serverUrl, teamId) {
   return body;
 }
 
+// Align the stored sync configuration's server_url with the binding's endpoint
+// after remote.sh has moved it. Only the ADDRESS moves: the identity triple
+// (server_instance_id, remote_team_id, protocol_version) must match between the
+// stored config and the binding, or this is not the same connection and nothing
+// is written. The new address is then verified end-to-end -- request() checks
+// the protocol header and validateBinding compares the response's identity
+// against this config -- before the config is replaced. Without this step, an
+// endpoint change would strand any team with a stored sync config: loadConfig
+// refuses a config whose server_url differs from the binding, and configure
+// refuses to replace an existing binding at all.
+export async function setEndpoint(args) {
+  const team = requireName(args.team, "team");
+  const binding = await readConnectedBinding(team);
+  let value;
+  try {
+    value = await readStoredSyncConfig(team);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+    // Plain teams may have no stored sync config: loadConfig synthesizes one
+    // from the binding on every start, so the moved endpoint is already the
+    // one the engine will use. Nothing to write.
+    await event("endpoint.aligned", { team, stored_config: false });
+    return;
+  }
+  if (value.local_team !== team ||
+      value.server_instance_id !== binding.server_instance_id ||
+      value.remote_team_id !== binding.remote_team_id ||
+      value.protocol_version !== binding.protocol_version) {
+    throw new Error("stored sync configuration does not belong to this team's binding");
+  }
+  if (value.server_url === binding.endpoint) {
+    await event("endpoint.aligned", { team, stored_config: true, changed: false });
+    return;
+  }
+  const candidate = { ...value, server_url: binding.endpoint };
+  const capabilities = await request(candidate, "/v1/capabilities");
+  validateCapabilities(candidate, capabilities);
+  await writeConfig(configPath(team), candidate);
+  await event("endpoint.aligned", { team, stored_config: true, changed: true });
+}
+
 async function main() {
   const [command, ...rest] = process.argv.slice(2);
   const args = options(rest);
   if (!["configure", "export-age-snapshot", "verify-age-snapshot", "export-age-handoff",
         "verify-age-handoff", "once", "run", "reprocess", "resync",
-        "unblock-read", "pull-bootstrap", "resolve-team"].includes(command)) {
+        "unblock-read", "pull-bootstrap", "resolve-team", "set-endpoint"].includes(command)) {
     throw new Error(usage());
   }
   if (command === "configure") { await configure(args); return; }
@@ -3118,6 +3160,9 @@ async function main() {
   // Before any local team exists, so neither can go through loadConfig.
   if (command === "resolve-team") { await resolveTeam(args); return; }
   if (command === "pull-bootstrap") { await pullBootstrap(args); return; }
+  // Before loadConfig: mid-change, the stored config's server_url still names
+  // the old address, and loadConfig refuses exactly that mismatch.
+  if (command === "set-endpoint") { await setEndpoint(args); return; }
   const team = requireName(args.team, "team");
   const limit = Number(args.limit ?? 100);
   if (!Number.isInteger(limit) || limit < 1 || limit > 1000) throw new Error("limit must be 1..1000");

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2,7 +2,7 @@
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import { spawn } from "node:child_process";
-import { appendFile, lstat, mkdir, open, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { appendFile, lstat, mkdir, open, readFile, rename, rmdir, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import process from "node:process";
 import { realpathSync } from "node:fs";
@@ -3103,6 +3103,37 @@ async function publicSnapshot(serverUrl, teamId) {
   return body;
 }
 
+// The same per-team registry lock remote.sh takes around every binding write
+// (scripts/lib/registry-lock.sh): mkdir on teams/<team>/.config.lock is the
+// primitive, so the two sides of the connection pair -- the shell writing the
+// binding, this file writing the stored sync config -- serialize against each
+// other, not just against themselves. Spin bounded the same way (~10s).
+async function withTeamConfigLock(team, fn) {
+  const lockDir = join(dirname(teamConfigPath(team)), ".config.lock");
+  for (let attempt = 0; ; attempt += 1) {
+    try { await mkdir(lockDir); break; }
+    catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      // Same exit as the shell side (registry-lock.sh): a holder that died
+      // without its release trap (SIGKILL, power loss) leaves the directory,
+      // and the way out is bounded failure that NAMES it -- never an
+      // unbounded wait. Nothing sweeps stale locks anywhere in this tree;
+      // matching the existing contract rather than inventing liveness
+      // detection on one side of a shared primitive.
+      if (attempt >= 1000) {
+        throw new Error(`timed out acquiring the team registry lock at ${lockDir}; ` +
+          "if no agmsg command is running against this team, remove that directory and re-run");
+      }
+      await new Promise((resolveSleep) => setTimeout(resolveSleep, 10));
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    await rmdir(lockDir).catch(() => {});
+  }
+}
+
 // Align the stored sync configuration's server_url with the binding's endpoint
 // after remote.sh has moved it. Only the ADDRESS moves: the identity triple
 // (server_instance_id, remote_team_id, protocol_version) must match between the
@@ -3113,6 +3144,16 @@ async function publicSnapshot(serverUrl, teamId) {
 // endpoint change would strand any team with a stored sync config: loadConfig
 // refuses a config whose server_url differs from the binding, and configure
 // refuses to replace an existing binding at all.
+//
+// One invariant covers both halves of the pair: EITHER file is written only
+// under the team registry lock, and only against a binding_revision the writer
+// verified. Binding writes (remote.sh) advance the revision under that lock;
+// this write requires it unchanged, re-read under the same lock. Without the
+// re-check, two concurrent set-endpoints interleave so that the slower
+// alignment -- verified against a binding that has since moved again -- lands
+// its stale config over the faster one's completed pair (#739 review). The
+// network verification stays OUTSIDE the lock: holding a spin lock across a
+// 15s-timeout request would starve every concurrent lifecycle command.
 export async function setEndpoint(args) {
   const team = requireName(args.team, "team");
   const binding = await readConnectedBinding(team);
@@ -3140,7 +3181,15 @@ export async function setEndpoint(args) {
   const candidate = { ...value, server_url: binding.endpoint };
   const capabilities = await request(candidate, "/v1/capabilities");
   validateCapabilities(candidate, capabilities);
-  await writeConfig(configPath(team), candidate);
+  await withTeamConfigLock(team, async () => {
+    const current = await readConnectedBinding(team);
+    if (current.endpoint !== binding.endpoint ||
+        current.binding_revision !== binding.binding_revision) {
+      throw new Error(
+        "the team's binding moved while this alignment was verifying; nothing was written -- the newer set-endpoint owns the stored configuration now");
+    }
+    await writeConfig(configPath(team), candidate);
+  });
   await event("endpoint.aligned", { team, stored_config: true, changed: true });
 }
 

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2166,6 +2166,31 @@ cmd_forget() {
   echo "Forgot '$team' on this machine. The server copy was not changed."
 }
 
+# _remote_ensure_binding_revision <team> <cfg> -> prints the numeric revision
+#
+# A binding written before revisions existed has no binding_revision, and both
+# CAS functions (_remote_write_binding, _remote_local_disconnect) skip their
+# comparison entirely for an empty/null expected value -- which silently
+# disables the lifecycle guard for exactly those legacy teams. cmd_forget
+# already carries the compat move for this input (initialize to 1, under the
+# lock); this is that same move, hoisted so a CAS caller can rely on a real
+# number existing before it snapshots one. Initialized and re-read inside the
+# lock, so the number printed is the number on disk.
+_remote_ensure_binding_revision() {
+  local team="$1" cfg="$2" escaped revision updated
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
+  revision="$(_remote_read_config_field "$cfg" '$.remote_binding.binding_revision')"
+  if [ -z "$revision" ] || [ "$revision" = "null" ]; then
+    escaped="$(sed "s/'/''/g" "$cfg")"
+    updated="$(agmsg_sqlite_mem \
+      "SELECT json_set('$escaped', '\$.remote_binding.binding_revision', 1);")"
+    agmsg_write_atomic "$cfg" "$updated"
+    revision=1
+  fi
+  agmsg_lock_release
+  printf '%s\n' "$revision"
+}
+
 # --- set-endpoint ----------------------------------------------------------
 #
 # Move a connected team's binding to a new address. Only the ADDRESS moves:
@@ -2211,7 +2236,6 @@ cmd_set_endpoint() {
   binding_cipher="$(_remote_read_config_field "$cfg" '$.remote_binding.cipher_profile')"
   connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
   disconnected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
-  binding_revision="$(_remote_read_config_field "$cfg" '$.remote_binding.binding_revision')"
   if [ -z "$connected_at" ] || [ "$connected_at" = "null" ] \
     || [ -z "$server_instance" ] || [ "$server_instance" = "null" ]; then
     echo "agmsg: team '$team' has no remote binding; there is no endpoint to move. Connect or pull it first." >&2
@@ -2242,6 +2266,13 @@ cmd_set_endpoint() {
     fi
     exit 0
   fi
+
+  # The CAS below needs a revision that actually exists: a legacy binding has
+  # none, and an empty expected value makes _remote_write_binding skip the
+  # comparison entirely -- the guard this command depends on would be disabled
+  # for exactly those teams. Initialize it (under the lock, cmd_forget's compat
+  # move) and snapshot the number that is really on disk.
+  binding_revision="$(_remote_ensure_binding_revision "$team" "$cfg")" || exit 1
 
   # Test seam: a two-file barrier that lets the lifecycle-race regressions
   # land a concurrent disconnect / sync start deterministically between this

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2149,6 +2149,93 @@ cmd_forget() {
   echo "Forgot '$team' on this machine. The server copy was not changed."
 }
 
+# --- set-endpoint ----------------------------------------------------------
+#
+# Move a connected team's binding to a new address. Only the ADDRESS moves:
+# what the team is bound TO is the identity triple (server_instance_id,
+# remote_team_id, protocol_version), and the server answering at the new
+# address must prove it is that same identity before anything is written.
+# _remote_adopt_registration is both the proof and the only writer: it fetches
+# the new address's capabilities, refuses unless the server instance matches
+# the recorded one (naming both ids when it does not), re-checks that the
+# registration is this team's (name and roster), and only then rewrites the
+# binding -- endpoint included, binding_revision advanced. There is
+# deliberately no unverified path to the write.
+#
+# A disconnected team is refused: disconnect is the operator renouncing the
+# anchor, and `connect --endpoint <new>` is the deliberate re-anchoring move
+# for that state. set-endpoint exists for the live team whose address was
+# never meant to be permanent -- a port-forward, a tunnel, a machine that
+# later got a stable name (#718).
+cmd_set_endpoint() {
+  local endpoint="" team="" positional=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --endpoint) endpoint="${2:?--endpoint requires a value}"; shift 2 ;;
+      --endpoint=*) endpoint="${1#--endpoint=}"; shift ;;
+      *) positional+=("$1"); shift ;;
+    esac
+  done
+  : "${endpoint:?Usage: remote.sh set-endpoint --endpoint <url> <team>}"
+  _remote_validate_endpoint "$endpoint" || exit 1
+  endpoint="${endpoint%/}"
+  team="${positional[0]:-}"
+  [ -n "$team" ] || { echo "agmsg: set-endpoint requires a team: remote.sh set-endpoint --endpoint <url> <team>" >&2; exit 1; }
+  agmsg_validate_team_name "$team" || exit 1
+
+  local cfg old_endpoint server_instance remote_team_id binding_cipher \
+    connected_at disconnected_at engine_state engine_pid was_running=0
+  cfg="$(_remote_team_config "$team")"
+  [ -f "$cfg" ] || { echo "agmsg: team '$team' is not a local team" >&2; exit 1; }
+  old_endpoint="$(_remote_read_config_field "$cfg" '$.remote_binding.endpoint')"
+  server_instance="$(_remote_read_config_field "$cfg" '$.remote_binding.server_instance_id')"
+  remote_team_id="$(_remote_read_config_field "$cfg" '$.remote_binding.remote_team_id')"
+  binding_cipher="$(_remote_read_config_field "$cfg" '$.remote_binding.cipher_profile')"
+  connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
+  disconnected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
+  if [ -z "$connected_at" ] || [ "$connected_at" = "null" ] \
+    || [ -z "$server_instance" ] || [ "$server_instance" = "null" ]; then
+    echo "agmsg: team '$team' has no remote binding; there is no endpoint to move. Connect or pull it first." >&2
+    exit 1
+  fi
+  if [ -n "$disconnected_at" ] && [ "$disconnected_at" != "null" ]; then
+    echo "agmsg: team '$team' is disconnected; set-endpoint moves a live binding only. To re-anchor it deliberately, run connect with the new endpoint." >&2
+    exit 1
+  fi
+  if [ "$old_endpoint" = "$endpoint" ]; then
+    echo "Team '$team' already uses $(_remote_endpoint_display "$endpoint"); nothing to change."
+    exit 0
+  fi
+
+  IFS=$'\t' read -r engine_state engine_pid < <(_remote_sync_engine_status "$team")
+  [ "$engine_state" = "running" ] && was_running=1
+  _remote_sync_engine_stop "$team" || {
+    echo "agmsg: the sync engine did not stop; refusing to move the endpoint under it" >&2
+    exit 1
+  }
+
+  _remote_adopt_registration "$team" "$cfg" "$endpoint" "$remote_team_id" \
+    "$binding_cipher" "$server_instance" || exit 1
+
+  # Two places pin the address: the binding (moved above) and the stored sync
+  # config, whose server_url loadConfig requires to match the binding. The
+  # engine-side subcommand aligns the latter after re-verifying the identity
+  # end to end; a plain team with no stored config is a recorded no-op. On
+  # failure the engine stays stopped and the next start says exactly which
+  # two things disagree -- loud, and repaired by re-running set-endpoint.
+  bash "$SCRIPT_DIR/remote-sync.sh" set-endpoint --team "$team" >/dev/null || {
+    echo "agmsg: the binding now names $(_remote_endpoint_display "$endpoint") but the stored sync configuration still names the old address; re-run set-endpoint (the sync engine stays stopped until both agree)" >&2
+    exit 1
+  }
+
+  if [ "$was_running" -eq 1 ]; then
+    _remote_sync_engine_start "$team"
+    echo "Endpoint for '$team' moved: $(_remote_endpoint_display "$old_endpoint") -> $(_remote_endpoint_display "$endpoint") (same server instance). Sync engine restarted."
+  else
+    echo "Endpoint for '$team' moved: $(_remote_endpoint_display "$old_endpoint") -> $(_remote_endpoint_display "$endpoint") (same server instance)."
+  fi
+}
+
 case "${1:-}" in
   connect) shift; agmsg_require_python3 "remote connect" || exit 1; cmd_connect "$@" ;;
   pull) shift; agmsg_require_python3 "remote pull" || exit 1; cmd_pull "$@" ;;
@@ -2156,9 +2243,10 @@ case "${1:-}" in
   status) shift; agmsg_require_python3 "remote status" || exit 1; cmd_status "$@" ;;
   sync) shift; cmd_sync "$@" ;;
   disconnect) shift; agmsg_require_python3 "remote disconnect" || exit 1; cmd_disconnect "$@" ;;
+  set-endpoint) shift; agmsg_require_python3 "remote set-endpoint" || exit 1; cmd_set_endpoint "$@" ;;
   forget) shift; agmsg_require_python3 "remote forget" || exit 1; cmd_forget "$@" ;;
   doctor) shift; cmd_doctor "$@" ;;
   *)
-    echo "Usage: remote.sh <connect|pull|unlock|status|sync|disconnect|forget|doctor> ..." >&2
+    echo "Usage: remote.sh <connect|pull|unlock|status|sync|set-endpoint|disconnect|forget|doctor> ..." >&2
     exit 1 ;;
 esac

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2252,7 +2252,7 @@ cmd_set_endpoint() {
     while [ ! -e "$AGMSG_TEST_SET_ENDPOINT_BARRIER.release" ]; do
       sleep 0.05
       _agmsg_barrier_waited=$((_agmsg_barrier_waited + 1))
-      [ "$_agmsg_barrier_waited" -ge 200 ] && break # 10s safety cap
+      [ "$_agmsg_barrier_waited" -ge 1200 ] && break # 60s safety cap
     done
   fi
 

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2166,29 +2166,53 @@ cmd_forget() {
   echo "Forgot '$team' on this machine. The server copy was not changed."
 }
 
-# _remote_ensure_binding_revision <team> <cfg> -> prints the numeric revision
+# _remote_snapshot_binding_for_update <team> <cfg>
+# Prints one tab-separated line:
+#   endpoint  server_instance_id  remote_team_id  cipher_profile
+#   connected_at  disconnected_at  binding_revision
 #
-# A binding written before revisions existed has no binding_revision, and both
-# CAS functions (_remote_write_binding, _remote_local_disconnect) skip their
-# comparison entirely for an empty/null expected value -- which silently
-# disables the lifecycle guard for exactly those legacy teams. cmd_forget
-# already carries the compat move for this input (initialize to 1, under the
-# lock); this is that same move, hoisted so a CAS caller can rely on a real
-# number existing before it snapshots one. Initialized and re-read inside the
-# lock, so the number printed is the number on disk.
-_remote_ensure_binding_revision() {
-  local team="$1" cfg="$2" escaped revision updated
+# ONE lock acquisition covers both the legacy-revision initialization and the
+# reads, so every field describes the same generation of the binding and the
+# revision printed is the revision that generation really has. Read outside a
+# single lock, the pieces can straddle a concurrent write: the caller judges
+# "connected" from one generation and then snapshots the NEXT generation's
+# revision -- at which point its CAS validates a write against a state it
+# never examined, and a disconnect landing in the gap is silently undone
+# (#739 review, round 5).
+#
+# The revision initialization is cmd_forget's compat move, hoisted: a binding
+# written before revisions existed has none, and both CAS functions skip their
+# comparison entirely for an empty expected value -- which would disable the
+# lifecycle guard for exactly those legacy teams.
+_remote_snapshot_binding_for_update() {
+  local team="$1" cfg="$2" escaped updated revision endpoint server_instance \
+    remote_team_id cipher connected_at disconnected_at
   agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
-  revision="$(_remote_read_config_field "$cfg" '$.remote_binding.binding_revision')"
-  if [ -z "$revision" ] || [ "$revision" = "null" ]; then
-    escaped="$(sed "s/'/''/g" "$cfg")"
-    updated="$(agmsg_sqlite_mem \
-      "SELECT json_set('$escaped', '\$.remote_binding.binding_revision', 1);")"
-    agmsg_write_atomic "$cfg" "$updated"
-    revision=1
+  endpoint="$(_remote_read_config_field "$cfg" '$.remote_binding.endpoint')"
+  if [ -n "$endpoint" ] && [ "$endpoint" != "null" ]; then
+    revision="$(_remote_read_config_field "$cfg" '$.remote_binding.binding_revision')"
+    if [ -z "$revision" ] || [ "$revision" = "null" ]; then
+      escaped="$(sed "s/'/''/g" "$cfg")"
+      updated="$(agmsg_sqlite_mem \
+        "SELECT json_set('$escaped', '\$.remote_binding.binding_revision', 1);")"
+      agmsg_write_atomic "$cfg" "$updated"
+      revision=1
+    fi
+  else
+    revision=""
   fi
+  server_instance="$(_remote_read_config_field "$cfg" '$.remote_binding.server_instance_id')"
+  remote_team_id="$(_remote_read_config_field "$cfg" '$.remote_binding.remote_team_id')"
+  cipher="$(_remote_read_config_field "$cfg" '$.remote_binding.cipher_profile')"
+  connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
+  disconnected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
   agmsg_lock_release
-  printf '%s\n' "$revision"
+  # Unit separator, NOT tab: several of these fields are legitimately empty
+  # (a JSON null reads back as ""), and tab is IFS whitespace -- `read`
+  # collapses consecutive whitespace delimiters, shifting every later field
+  # left. A non-whitespace separator keeps empty fields empty.
+  printf '%s\037%s\037%s\037%s\037%s\037%s\037%s\n' "$endpoint" "$server_instance" \
+    "$remote_team_id" "$cipher" "$connected_at" "$disconnected_at" "$revision"
 }
 
 # --- set-endpoint ----------------------------------------------------------
@@ -2230,12 +2254,17 @@ cmd_set_endpoint() {
     engine_state engine_pid end_state end_pid was_running=0
   cfg="$(_remote_team_config "$team")"
   [ -f "$cfg" ] || { echo "agmsg: team '$team' is not a local team" >&2; exit 1; }
-  old_endpoint="$(_remote_read_config_field "$cfg" '$.remote_binding.endpoint')"
-  server_instance="$(_remote_read_config_field "$cfg" '$.remote_binding.server_instance_id')"
-  remote_team_id="$(_remote_read_config_field "$cfg" '$.remote_binding.remote_team_id')"
-  binding_cipher="$(_remote_read_config_field "$cfg" '$.remote_binding.cipher_profile')"
-  connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
-  disconnected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
+  # One atomic snapshot: the fields this command JUDGES from (connected,
+  # disconnected, identity) and the revision its CAS will later verify all
+  # come from the same generation of the binding, read under one lock hold.
+  # Any change after this point -- a disconnect included -- advances the
+  # revision past this snapshot and the write refuses.
+  IFS=$'\037' read -r old_endpoint server_instance remote_team_id binding_cipher \
+    connected_at disconnected_at binding_revision \
+    < <(_remote_snapshot_binding_for_update "$team" "$cfg") || {
+    echo "agmsg: could not snapshot team '$team' state for the update" >&2
+    exit 1
+  }
   if [ -z "$connected_at" ] || [ "$connected_at" = "null" ] \
     || [ -z "$server_instance" ] || [ "$server_instance" = "null" ]; then
     echo "agmsg: team '$team' has no remote binding; there is no endpoint to move. Connect or pull it first." >&2
@@ -2266,13 +2295,6 @@ cmd_set_endpoint() {
     fi
     exit 0
   fi
-
-  # The CAS below needs a revision that actually exists: a legacy binding has
-  # none, and an empty expected value makes _remote_write_binding skip the
-  # comparison entirely -- the guard this command depends on would be disabled
-  # for exactly those teams. Initialize it (under the lock, cmd_forget's compat
-  # move) and snapshot the number that is really on disk.
-  binding_revision="$(_remote_ensure_binding_revision "$team" "$cfg")" || exit 1
 
   # Test seam: a two-file barrier that lets the lifecycle-race regressions
   # land a concurrent disconnect / sync start deterministically between this

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -346,9 +346,11 @@ _remote_http_get_json() {
 # ONE writer for both the first connect and the adopt path below. Two copies of
 # this object would drift, and the second copy is the one nobody re-reads.
 _remote_write_binding() {
-  local cfg="$1" endpoint="$2" binding_cipher="$3" resp_file="$4"
+  local cfg="$1" endpoint="$2" binding_cipher="$3" resp_file="$4" \
+    expected_binding_revision="${5:-}"
   local resp_escaped cfg_escaped connected_at updated \
-    server_instance_id remote_team_id remote_team_name protocol_version
+    server_instance_id remote_team_id remote_team_name protocol_version \
+    current_binding_revision
   resp_escaped="$(sed "s/'/''/g" "$resp_file")"
   {
     IFS= read -r server_instance_id
@@ -362,6 +364,20 @@ _remote_write_binding() {
        SELECT json_extract('$resp_escaped', '\$.protocol_version');")
   connected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   agmsg_lock_acquire "$(dirname "$cfg")" || return 1
+  # Optional compare-and-swap, same contract as _remote_local_disconnect: the
+  # caller snapshotted the binding at revision N, verified against that
+  # snapshot, and must not have its write land on a binding someone else moved
+  # in between -- a concurrent disconnect would otherwise be silently undone
+  # by this write's disconnected_at:null. Checked INSIDE the lock, against the
+  # file as it is now, not as it was read.
+  if [ -n "$expected_binding_revision" ] && [ "$expected_binding_revision" != "null" ]; then
+    current_binding_revision="$(_remote_read_config_field "$cfg" '$.remote_binding.binding_revision')"
+    if [ "$current_binding_revision" != "$expected_binding_revision" ]; then
+      agmsg_lock_release
+      echo "agmsg: the team's binding changed while this command was running (revision is now $current_binding_revision, this command verified revision $expected_binding_revision); nothing was written. Check 'remote status' and re-run." >&2
+      return 2
+    fi
+  fi
   cfg_escaped="$(sed "s/'/''/g" "$cfg")"
   updated=$(agmsg_sqlite_mem \
     "SELECT json_set('$cfg_escaped', '\$.remote_binding', json_object(
@@ -411,7 +427,7 @@ _remote_write_binding() {
 # leaves no recorded id, and there the first fetch IS the anchor.
 _remote_adopt_registration() {
   local team="$1" cfg="$2" endpoint="$3" team_id="$4" binding_cipher="$5" \
-    expected_server_instance="${6:-}"
+    expected_server_instance="${6:-}" expected_binding_revision="${7:-}"
   local caps_file members_file http_code remote_team_name local_team_name \
     local_ids remote_ids cfg_escaped members_escaped \
     fetched_server_instance declared_cipher
@@ -517,7 +533,8 @@ _remote_adopt_registration() {
   esac
 
   echo "Team '$team' is already registered on $(_remote_endpoint_display "$endpoint"); adopting that registration and continuing." >&2
-  _remote_write_binding "$cfg" "$endpoint" "$binding_cipher" "$caps_file" || {
+  _remote_write_binding "$cfg" "$endpoint" "$binding_cipher" "$caps_file" \
+    "$expected_binding_revision" || {
     rm -f "$caps_file" "$members_file"; trap - EXIT INT TERM
     return 1
   }
@@ -2184,7 +2201,8 @@ cmd_set_endpoint() {
   agmsg_validate_team_name "$team" || exit 1
 
   local cfg old_endpoint server_instance remote_team_id binding_cipher \
-    connected_at disconnected_at engine_state engine_pid was_running=0
+    connected_at disconnected_at binding_revision align_out \
+    engine_state engine_pid end_state end_pid was_running=0
   cfg="$(_remote_team_config "$team")"
   [ -f "$cfg" ] || { echo "agmsg: team '$team' is not a local team" >&2; exit 1; }
   old_endpoint="$(_remote_read_config_field "$cfg" '$.remote_binding.endpoint')"
@@ -2193,6 +2211,7 @@ cmd_set_endpoint() {
   binding_cipher="$(_remote_read_config_field "$cfg" '$.remote_binding.cipher_profile')"
   connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
   disconnected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
+  binding_revision="$(_remote_read_config_field "$cfg" '$.remote_binding.binding_revision')"
   if [ -z "$connected_at" ] || [ "$connected_at" = "null" ] \
     || [ -z "$server_instance" ] || [ "$server_instance" = "null" ]; then
     echo "agmsg: team '$team' has no remote binding; there is no endpoint to move. Connect or pull it first." >&2
@@ -2203,8 +2222,38 @@ cmd_set_endpoint() {
     exit 1
   fi
   if [ "$old_endpoint" = "$endpoint" ]; then
-    echo "Team '$team' already uses $(_remote_endpoint_display "$endpoint"); nothing to change."
+    # The binding already names this address -- but the binding is only ONE of
+    # the two places that pin it. A failure between the binding write below
+    # and the stored-config alignment leaves binding=new / stored config=old,
+    # and the remedy this command prints for that state is to re-run itself.
+    # So this path must REPAIR, not return on the binding comparison alone
+    # (#739 review): the alignment runs, fixing a mismatched stored config and
+    # recording a no-op when the two already agree. An engine cannot be
+    # running against a mismatched stored config (loadConfig refuses the
+    # pair), so there is nothing to stop here.
+    align_out="$(bash "$SCRIPT_DIR/remote-sync.sh" set-endpoint --team "$team")" || {
+      echo "agmsg: the stored sync configuration could not be aligned with the binding; the sync engine stays stopped until it is. Fix what the message above names, then re-run set-endpoint." >&2
+      exit 1
+    }
+    if printf '%s' "$align_out" | grep -Fq '"changed":true'; then
+      echo "Team '$team' already had its binding on $(_remote_endpoint_display "$endpoint"); the stored sync configuration has now been aligned to it. Restart sync with: remote.sh sync start $(agmsg_shq "$team")"
+    else
+      echo "Team '$team' already uses $(_remote_endpoint_display "$endpoint"); nothing to change."
+    fi
     exit 0
+  fi
+
+  # Test seam: a two-file barrier that lets the lifecycle-race regressions
+  # land a concurrent disconnect / sync start deterministically between this
+  # command's state snapshot and its write. No-op unless set.
+  if [ -n "${AGMSG_TEST_SET_ENDPOINT_BARRIER:-}" ]; then
+    : > "$AGMSG_TEST_SET_ENDPOINT_BARRIER.reached"
+    _agmsg_barrier_waited=0
+    while [ ! -e "$AGMSG_TEST_SET_ENDPOINT_BARRIER.release" ]; do
+      sleep 0.05
+      _agmsg_barrier_waited=$((_agmsg_barrier_waited + 1))
+      [ "$_agmsg_barrier_waited" -ge 200 ] && break # 10s safety cap
+    done
   fi
 
   IFS=$'\t' read -r engine_state engine_pid < <(_remote_sync_engine_status "$team")
@@ -2214,21 +2263,32 @@ cmd_set_endpoint() {
     exit 1
   }
 
+  # The write is compare-and-swap on the snapshotted binding_revision: a
+  # concurrent disconnect (or any other binding writer) advances the revision,
+  # and this write must refuse rather than overwrite that newer state -- the
+  # adopt path rewrites the whole binding, disconnected_at:null included.
   _remote_adopt_registration "$team" "$cfg" "$endpoint" "$remote_team_id" \
-    "$binding_cipher" "$server_instance" || exit 1
+    "$binding_cipher" "$server_instance" "$binding_revision" || exit 1
 
   # Two places pin the address: the binding (moved above) and the stored sync
   # config, whose server_url loadConfig requires to match the binding. The
   # engine-side subcommand aligns the latter after re-verifying the identity
   # end to end; a plain team with no stored config is a recorded no-op. On
   # failure the engine stays stopped and the next start says exactly which
-  # two things disagree -- loud, and repaired by re-running set-endpoint.
+  # two things disagree -- and re-running set-endpoint reaches the repair
+  # path above, which retries this alignment.
   bash "$SCRIPT_DIR/remote-sync.sh" set-endpoint --team "$team" >/dev/null || {
     echo "agmsg: the binding now names $(_remote_endpoint_display "$endpoint") but the stored sync configuration still names the old address; re-run set-endpoint (the sync engine stays stopped until both agree)" >&2
     exit 1
   }
 
-  if [ "$was_running" -eq 1 ]; then
+  # Decide from BOTH the snapshot and the present: an engine that was running
+  # at the snapshot is restarted, and an engine somebody started while this
+  # command ran is restarted too (never silently left stopped, and a restart
+  # is what hands it the moved address -- a running engine keeps its old
+  # config in memory). _remote_sync_engine_start kills a live engine first.
+  IFS=$'\t' read -r end_state end_pid < <(_remote_sync_engine_status "$team")
+  if [ "$was_running" -eq 1 ] || [ "$end_state" = "running" ]; then
     _remote_sync_engine_start "$team"
     echo "Endpoint for '$team' moved: $(_remote_endpoint_display "$old_endpoint") -> $(_remote_endpoint_display "$endpoint") (same server instance). Sync engine restarted."
   else

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1377,6 +1377,77 @@ test("set-endpoint aligns the stored sync config's server_url with the moved bin
   }
 });
 
+test("set-endpoint cannot land a stale alignment over a newer move (#739 interleave)", async () => {
+  // The review's interleave: A verifies a move to X and stalls in the
+  // capabilities request; B moves the binding on to Y (revision advanced) and
+  // completes its own alignment; A resumes. A's write must refuse -- the
+  // binding it verified is no longer the binding -- and B's completed pair
+  // must survive. The guard is the lock-held re-read of endpoint+revision.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-set-endpoint-race-"));
+  const saved = { connection: process.env.AGMSG_SYNC_CONNECTION_DIR,
+    storage: process.env.AGMSG_SYNC_STORAGE_DIR };
+  const previousFetch = globalThis.fetch;
+  const storedPath = join(root, "store", "remote-sync", "demo.json");
+  const teamCfgPath = join(root, "teams", "demo", "config.json");
+  const bindingFor = (endpoint, revision) => ({ name: "demo", remote_binding: {
+    endpoint, server_instance_id: config.server_instance_id,
+    remote_team_id: config.remote_team_id, protocol_version: 1,
+    capabilities: { write_allowed_ciphers: ["none"] }, cipher_profile: "none",
+    connected_at: "2026-07-29T00:00:00Z", disconnected_at: null,
+    binding_revision: revision } });
+  try {
+    process.env.AGMSG_SYNC_CONNECTION_DIR = root;
+    process.env.AGMSG_SYNC_STORAGE_DIR = join(root, "store");
+    await mkdir(join(root, "teams", "demo"), { recursive: true });
+    await mkdir(join(root, "store", "remote-sync"), { recursive: true });
+    await writeFile(teamCfgPath, `${JSON.stringify(bindingFor("https://x.example", 2))}\n`);
+    const stored = { format_version: 1, local_team: "demo",
+      server_url: "https://o.example",
+      server_instance_id: config.server_instance_id,
+      remote_team_id: config.remote_team_id, protocol_version: 1,
+      cipher_profile: "none",
+      local_security_history: [{ local_security_revision: "0",
+        effective_from_seq: "1", minimum_security_mode: "plaintext-allowed" }] };
+    await writeFile(storedPath, JSON.stringify(stored));
+    const capabilities = { protocol_version: 1,
+      server_instance_id: config.server_instance_id,
+      team_id: config.remote_team_id, team_name: "demo", min_available_seq: "0",
+      current_seq: "0", next_sequence_boundary: "1", accepted_envelope_versions: [1],
+      write_allowed_ciphers: ["none"], policy_revision: "0", effective_from_seq: "1",
+      max_blob_bytes: "1048576", policy_history: [{ policy_revision: "0",
+        effective_from_seq: "1", accepted_envelope_versions: [1],
+        write_allowed_ciphers: ["none"] }] };
+    const respond = () => new Response(JSON.stringify(capabilities), { status: 200,
+      headers: { "Agmsg-Protocol-Version": "1" } });
+    let releaseFetch = null;
+    globalThis.fetch = () => new Promise((resolveFetch) => {
+      releaseFetch = () => resolveFetch(respond());
+    });
+    const stale = setEndpoint({ team: "demo" }); // A: verifying the move to X
+    const staleOutcome = stale.catch((error) => error);
+    while (releaseFetch === null) await new Promise((r) => setTimeout(r, 5));
+    // B: moves the binding on to Y and completes its own alignment.
+    await writeFile(teamCfgPath, `${JSON.stringify(bindingFor("https://y.example", 3))}\n`);
+    await writeFile(storedPath, JSON.stringify({ ...stored, server_url: "https://y.example" }));
+    releaseFetch();
+    const outcome = await staleOutcome;
+    assert.match(String(outcome?.message), /moved while this alignment was verifying/u);
+    // B's completed pair survived A's stale write attempt.
+    assert.equal(JSON.parse(await readFile(storedPath, "utf8")).server_url, "https://y.example");
+    // And the lock was released on the refusal path: a fresh run against the
+    // current binding completes (stored already matches -> recorded no-op).
+    globalThis.fetch = async () => respond();
+    await setEndpoint({ team: "demo" });
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (saved.connection === undefined) delete process.env.AGMSG_SYNC_CONNECTION_DIR;
+    else process.env.AGMSG_SYNC_CONNECTION_DIR = saved.connection;
+    if (saved.storage === undefined) delete process.env.AGMSG_SYNC_STORAGE_DIR;
+    else process.env.AGMSG_SYNC_STORAGE_DIR = saved.storage;
+    await rm(root, { recursive: true });
+  }
+});
+
 test("request distinguishes config errors from response transport loss", async () => {
   const previousFetch = globalThis.fetch;
   let fetchCalled = false;

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -32,6 +32,7 @@ import {
   retainAgeCheckpoint,
   rosterDriver,
   selectWriteProfile,
+  setEndpoint,
   stage2ReadStateSupported,
   stage1ResyncSupported,
   validateAckMapping,
@@ -1297,6 +1298,82 @@ test("send collapses an out-of-shape server error code in the message, keeping c
     });
   } finally {
     globalThis.fetch = previousFetch;
+  }
+});
+
+test("set-endpoint aligns the stored sync config's server_url with the moved binding (#718)", async () => {
+  // remote.sh moves the binding's endpoint only after the new address proved
+  // it is the same server instance. This subcommand then aligns the OTHER
+  // place that pins the address -- the stored sync config, whose server_url
+  // loadConfig requires to match the binding -- re-verifying the identity
+  // end to end against the new address before anything is written.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-set-endpoint-"));
+  const saved = { connection: process.env.AGMSG_SYNC_CONNECTION_DIR,
+    storage: process.env.AGMSG_SYNC_STORAGE_DIR };
+  const previousFetch = globalThis.fetch;
+  const storedPath = join(root, "store", "remote-sync", "demo.json");
+  try {
+    process.env.AGMSG_SYNC_CONNECTION_DIR = root;
+    process.env.AGMSG_SYNC_STORAGE_DIR = join(root, "store");
+    const teamDir = join(root, "teams", "demo");
+    await mkdir(teamDir, { recursive: true });
+    await writeFile(join(teamDir, "config.json"), `${JSON.stringify({ name: "demo",
+      remote_binding: { endpoint: "https://moved.example",
+        server_instance_id: config.server_instance_id,
+        remote_team_id: config.remote_team_id, protocol_version: 1,
+        capabilities: { write_allowed_ciphers: ["none"] },
+        cipher_profile: "none", connected_at: "2026-07-29T00:00:00Z",
+        disconnected_at: null } })}\n`);
+    const stored = { format_version: 1, local_team: "demo",
+      server_url: "http://127.0.0.1:8787",
+      server_instance_id: config.server_instance_id,
+      remote_team_id: config.remote_team_id, protocol_version: 1,
+      cipher_profile: "none",
+      local_security_history: [{ local_security_revision: "0",
+        effective_from_seq: "1", minimum_security_mode: "plaintext-allowed" }] };
+    await mkdir(join(root, "store", "remote-sync"), { recursive: true });
+    await writeFile(storedPath, JSON.stringify(stored));
+    const capabilities = { protocol_version: 1,
+      server_instance_id: config.server_instance_id,
+      team_id: config.remote_team_id, team_name: "demo", min_available_seq: "0",
+      current_seq: "0", next_sequence_boundary: "1", accepted_envelope_versions: [1],
+      write_allowed_ciphers: ["none"], policy_revision: "0", effective_from_seq: "1",
+      max_blob_bytes: "1048576", policy_history: [{ policy_revision: "0",
+        effective_from_seq: "1", accepted_envelope_versions: [1],
+        write_allowed_ciphers: ["none"] }] };
+    let fetchedUrl = null;
+    globalThis.fetch = async (url) => {
+      fetchedUrl = String(url);
+      return new Response(JSON.stringify(capabilities), { status: 200,
+        headers: { "Agmsg-Protocol-Version": "1" } });
+    };
+    await setEndpoint({ team: "demo" });
+    // The identity was re-proved against the NEW address, then written.
+    assert.match(fetchedUrl, /^https:\/\/moved\.example\//u);
+    const rewritten = JSON.parse(await readFile(storedPath, "utf8"));
+    assert.equal(rewritten.server_url, "https://moved.example");
+    assert.equal(rewritten.server_instance_id, config.server_instance_id);
+
+    // A stored config that is not this binding's connection: refused, and the
+    // file keeps its old address -- no unverified path to the write.
+    await writeFile(storedPath, JSON.stringify({ ...stored,
+      server_instance_id: "018f3f7e-9999-7000-8000-00000000000f" }));
+    await assert.rejects(setEndpoint({ team: "demo" }), /does not belong/u);
+    assert.equal(JSON.parse(await readFile(storedPath, "utf8")).server_url,
+      "http://127.0.0.1:8787");
+
+    // No stored config at all (plain teams): a recorded no-op that must not
+    // materialise one.
+    await rm(storedPath);
+    await setEndpoint({ team: "demo" });
+    await assert.rejects(readFile(storedPath, "utf8"), /ENOENT/u);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (saved.connection === undefined) delete process.env.AGMSG_SYNC_CONNECTION_DIR;
+    else process.env.AGMSG_SYNC_CONNECTION_DIR = saved.connection;
+    if (saved.storage === undefined) delete process.env.AGMSG_SYNC_STORAGE_DIR;
+    else process.env.AGMSG_SYNC_STORAGE_DIR = saved.storage;
+    await rm(root, { recursive: true });
   }
 });
 

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -268,8 +268,8 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
 
   run bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam
   [ "$status" -eq 0 ]
-  [[ "$output" == *"moved: http://127.0.0.1:$MOCK_PORT -> http://localhost:$MOCK_PORT"* ]]
-  [[ "$output" == *"Sync engine restarted"* ]]
+  grep -Fq "moved: http://127.0.0.1:$MOCK_PORT -> http://localhost:$MOCK_PORT" <<<"$output"
+  grep -Fq "Sync engine restarted" <<<"$output"
   [ "$(_binding_field testteam endpoint)" = "http://localhost:$MOCK_PORT" ]
   # The ADDRESS moved; the identity did not, and the write was versioned.
   [ "$(_binding_field testteam server_instance_id)" = "$anchored" ]
@@ -279,7 +279,7 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
   revision_before="$(_binding_field testteam binding_revision)"
   run bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam
   [ "$status" -eq 0 ]
-  [[ "$output" == *"nothing to change"* ]]
+  grep -Fq "nothing to change" <<<"$output"
   [ "$(_binding_field testteam binding_revision)" = "$revision_before" ]
 }
 
@@ -298,12 +298,84 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
   run bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam
   [ "$status" -ne 0 ]
   # What differed is SAID, both sides of it -- not a bare "refused".
-  [[ "$output" == *"is now server instance 018f3f7e-2222-7000-8000-0000000000ff"* ]]
-  [[ "$output" == *"bound to $anchored"* ]]
-  [[ "$output" == *"Refusing to re-anchor"* ]]
+  grep -Fq "is now server instance 018f3f7e-2222-7000-8000-0000000000ff" <<<"$output"
+  grep -Fq "bound to $anchored" <<<"$output"
+  grep -Fq "Refusing to re-anchor" <<<"$output"
   # And nothing was written: the binding still names the verified address.
   [ "$(_binding_field testteam endpoint)" = "$ENDPOINT" ]
   [ "$(_binding_field testteam server_instance_id)" = "$anchored" ]
+}
+
+@test "set-endpoint: re-running from the partial state repairs the stored sync config (#739 P1-1)" {
+  # The partial state a failure between the two writes leaves behind:
+  # binding=new address, stored sync config=old address. The printed remedy is
+  # to re-run set-endpoint, so the same-address path must repair the stored
+  # config rather than return on the binding comparison alone.
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  [ "$status" -eq 0 ]
+  local sid tid stored="$TEST_SKILL_DIR/db/remote-sync/testteam.json"
+  sid="$(_binding_field testteam server_instance_id)"
+  tid="$(_binding_field testteam remote_team_id)"
+  mkdir -p "$TEST_SKILL_DIR/db/remote-sync"
+  printf '%s\n' "{\"format_version\":1,\"local_team\":\"testteam\",\"server_url\":\"http://127.0.0.1:9\",\"server_instance_id\":\"$sid\",\"remote_team_id\":\"$tid\",\"protocol_version\":1,\"cipher_profile\":\"none\",\"local_security_history\":[{\"local_security_revision\":\"0\",\"effective_from_seq\":\"1\",\"minimum_security_mode\":\"plaintext-allowed\"}]}" > "$stored"
+
+  # Same address as the binding: before the fix this exited "nothing to
+  # change" without ever looking at the stored config.
+  run bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "$ENDPOINT" testteam
+  [ "$status" -eq 0 ]
+  grep -Fq "aligned" <<<"$output"
+  [ "$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$stored")') AS TEXT), '\$.server_url');")" = "$ENDPOINT" ]
+}
+
+@test "set-endpoint: a concurrent disconnect is not overwritten by the verified write (#739 P1-2)" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  [ "$status" -eq 0 ]
+  local barrier="$TEST_SKILL_DIR/se-barrier" se_rc=0
+  AGMSG_TEST_SET_ENDPOINT_BARRIER="$barrier" \
+    bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam \
+    > "$TEST_SKILL_DIR/se.out" 2>&1 3>&- &
+  local se_pid=$!
+  wait_for_file "$barrier.reached"
+  # The race: the operator disconnects while set-endpoint is verifying. The
+  # disconnect advances binding_revision, so the verified write must refuse
+  # rather than land disconnected_at:null over the newer state.
+  run bash "$SCRIPTS/remote.sh" disconnect testteam
+  [ "$status" -eq 0 ]
+  : > "$barrier.release"
+  wait "$se_pid" || se_rc=$?
+  [ "$se_rc" -ne 0 ]
+  grep -Fq "changed while this command was running" "$TEST_SKILL_DIR/se.out"
+  # The disconnect survived, and the address did not move.
+  [ "$(_binding_field testteam disconnected_at)" != "" ]
+  [ "$(_binding_field testteam disconnected_at)" != "null" ]
+  [ "$(_binding_field testteam endpoint)" = "$ENDPOINT" ]
+}
+
+@test "set-endpoint: an engine started while it runs ends up running on the new address (#739 P1-2)" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  [ "$status" -eq 0 ]
+  # Put the engine into the stopped state first, so the concurrent start is
+  # the only thing that makes it run.
+  local pidfile="$TEST_SKILL_DIR/run/remote-sync.testteam.pid" engine_pid
+  engine_pid="$(cat "$pidfile")"
+  kill "$engine_pid"
+  wait_for_pid_exit "$engine_pid"
+  local barrier="$TEST_SKILL_DIR/se-barrier2" se_rc=0
+  AGMSG_TEST_SET_ENDPOINT_BARRIER="$barrier" \
+    bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam \
+    > "$TEST_SKILL_DIR/se2.out" 2>&1 3>&- &
+  local se_pid=$!
+  wait_for_file "$barrier.reached"
+  run bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -eq 0 ]
+  : > "$barrier.release"
+  wait "$se_pid" || se_rc=$?
+  [ "$se_rc" -eq 0 ]
+  grep -Fq "Sync engine restarted" "$TEST_SKILL_DIR/se2.out"
+  [ "$(_binding_field testteam endpoint)" = "http://localhost:$MOCK_PORT" ]
+  # The operator's engine is not silently gone: one is alive at the end.
+  engine_pid="$(cat "$pidfile")"
+  kill -0 "$engine_pid"
 }
 
 @test "set-endpoint: refuses a disconnected team and names connect as the deliberate move (#718)" {
@@ -313,8 +385,8 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
   [ "$status" -eq 0 ]
   run bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam
   [ "$status" -ne 0 ]
-  [[ "$output" == *"disconnected"* ]]
-  [[ "$output" == *"connect with the new endpoint"* ]]
+  grep -Fq "disconnected" <<<"$output"
+  grep -Fq "connect with the new endpoint" <<<"$output"
   [ "$(_binding_field testteam endpoint)" = "$ENDPOINT" ]
 }
 

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -335,7 +335,12 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
     bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam \
     > "$TEST_SKILL_DIR/se.out" 2>&1 3>&- &
   local se_pid=$!
-  wait_for_file "$barrier.reached"
+  # A wider ceiling than wait_for_file's 10s: under full-suite load the
+  # background command's cold start (node endpoint validation, sqlite reads)
+  # has been measured past 10s, and a barrier miss here fails the test for
+  # timing, not behavior.
+  for _ in $(seq 1 300); do [ -e "$barrier.reached" ] && break; sleep 0.1; done
+  [ -e "$barrier.reached" ]
   # The race: the operator disconnects while set-endpoint is verifying. The
   # disconnect advances binding_revision, so the verified write must refuse
   # rather than land disconnected_at:null over the newer state.
@@ -365,7 +370,9 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
     bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam \
     > "$TEST_SKILL_DIR/se2.out" 2>&1 3>&- &
   local se_pid=$!
-  wait_for_file "$barrier.reached"
+  # Same wider ceiling as the disconnect-race test above.
+  for _ in $(seq 1 300); do [ -e "$barrier.reached" ] && break; sleep 0.1; done
+  [ -e "$barrier.reached" ]
   run bash "$SCRIPTS/remote.sh" sync start testteam
   [ "$status" -eq 0 ]
   : > "$barrier.release"

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -242,6 +242,82 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
   [ "$(_binding_field testteam cipher_profile)" = "age-v1" ]
 }
 
+# --- set-endpoint: move a live binding's address (#718) --------------------
+#
+# The binding's identity is (server_instance_id, remote_team_id,
+# protocol_version); the endpoint is the address used to reach it. These tests
+# pin the three properties the address move must have: same-identity moves
+# succeed (history and all), a different server instance at the new address is
+# refused with both ids named, and there is no path that writes an unverified
+# address.
+
+@test "set-endpoint: moves a connected team with history to a new address of the same server (#718)" {
+  # bob joins BEFORE connect so the server roster matches the local one: the
+  # identity re-check compares rosters, and this test is about the address.
+  run bash "$SCRIPTS/join.sh" testteam bob claude-code /tmp/project-a
+  [ "$status" -eq 0 ]
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  [ "$status" -eq 0 ]
+  # History is exactly what makes the disconnect-then-pull workaround refuse
+  # (#718's dead end), so the team here has some: the move must not care.
+  run bash "$SCRIPTS/send.sh" testteam alice bob "history row"
+  [ "$status" -eq 0 ]
+  local anchored revision_before
+  anchored="$(_binding_field testteam server_instance_id)"
+  revision_before="$(_binding_field testteam binding_revision)"
+
+  run bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"moved: http://127.0.0.1:$MOCK_PORT -> http://localhost:$MOCK_PORT"* ]]
+  [[ "$output" == *"Sync engine restarted"* ]]
+  [ "$(_binding_field testteam endpoint)" = "http://localhost:$MOCK_PORT" ]
+  # The ADDRESS moved; the identity did not, and the write was versioned.
+  [ "$(_binding_field testteam server_instance_id)" = "$anchored" ]
+  [ "$(_binding_field testteam binding_revision)" -gt "$revision_before" ]
+
+  # Same address again: a recorded no-op, not an error and not a rewrite.
+  revision_before="$(_binding_field testteam binding_revision)"
+  run bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing to change"* ]]
+  [ "$(_binding_field testteam binding_revision)" = "$revision_before" ]
+}
+
+@test "set-endpoint: refuses a different server instance at the new address, naming both ids (#718)" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  [ "$status" -eq 0 ]
+  local anchored
+  anchored="$(_binding_field testteam server_instance_id)"
+  [ -n "$anchored" ]
+
+  # Same address family, different server: registrations survive the rotation,
+  # so the recorded instance id is the only thing that can tell them apart.
+  run curl -sS "$ENDPOINT/_test/rotate-server-id"
+  [ "$status" -eq 0 ]
+
+  run bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam
+  [ "$status" -ne 0 ]
+  # What differed is SAID, both sides of it -- not a bare "refused".
+  [[ "$output" == *"is now server instance 018f3f7e-2222-7000-8000-0000000000ff"* ]]
+  [[ "$output" == *"bound to $anchored"* ]]
+  [[ "$output" == *"Refusing to re-anchor"* ]]
+  # And nothing was written: the binding still names the verified address.
+  [ "$(_binding_field testteam endpoint)" = "$ENDPOINT" ]
+  [ "$(_binding_field testteam server_instance_id)" = "$anchored" ]
+}
+
+@test "set-endpoint: refuses a disconnected team and names connect as the deliberate move (#718)" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  [ "$status" -eq 0 ]
+  run bash "$SCRIPTS/remote.sh" disconnect testteam
+  [ "$status" -eq 0 ]
+  run bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"disconnected"* ]]
+  [[ "$output" == *"connect with the new endpoint"* ]]
+  [ "$(_binding_field testteam endpoint)" = "$ENDPOINT" ]
+}
+
 @test "connect: the printed recovery command is shell-safe for a hostile team name (#143)" {
   # This asserts the CALL SITE, not the helper. tests/test_shquote.bats pins
   # what agmsg_shq does; nothing there stops remote.sh from going back to a

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -356,6 +356,35 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
   [ "$(_binding_field testteam endpoint)" = "$ENDPOINT" ]
 }
 
+@test "set-endpoint: a legacy binding without a revision still cannot overwrite a concurrent disconnect (#739)" {
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  [ "$status" -eq 0 ]
+  # Make the binding legacy: bindings written before revisions existed carry
+  # none, and an empty expected revision made both CAS functions skip their
+  # comparison -- disabling the lifecycle guard for exactly these teams.
+  local cfg="$TEST_SKILL_DIR/teams/testteam/config.json"
+  sqlite_mem "SELECT json_remove(CAST(readfile('$(rf "$cfg")') AS TEXT), '\$.remote_binding.binding_revision');" > "$cfg.tmp"
+  mv "$cfg.tmp" "$cfg"
+  [ "$(_binding_field testteam binding_revision)" = "" ]
+
+  local barrier="$TEST_SKILL_DIR/se-barrier3" se_rc=0
+  AGMSG_TEST_SET_ENDPOINT_BARRIER="$barrier" \
+    bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam \
+    > "$TEST_SKILL_DIR/se3.out" 2>&1 3>&- &
+  local se_pid=$!
+  for _ in $(seq 1 300); do [ -e "$barrier.reached" ] && break; sleep 0.1; done
+  [ -e "$barrier.reached" ]
+  run bash "$SCRIPTS/remote.sh" disconnect testteam
+  [ "$status" -eq 0 ]
+  : > "$barrier.release"
+  wait "$se_pid" || se_rc=$?
+  [ "$se_rc" -ne 0 ]
+  grep -Fq "changed while this command was running" "$TEST_SKILL_DIR/se3.out"
+  [ "$(_binding_field testteam disconnected_at)" != "" ]
+  [ "$(_binding_field testteam disconnected_at)" != "null" ]
+  [ "$(_binding_field testteam endpoint)" = "$ENDPOINT" ]
+}
+
 @test "set-endpoint: an engine started while it runs ends up running on the new address (#739 P1-2)" {
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes #718

## Reproduced first

In an isolated install against the mock server: connect on `http://127.0.0.1:<port>`, send one message, `disconnect` (succeeds, "sends/reads continue locally"), then `pull` at a new address spelling — refused with `agmsg: local team 'testteam' already has history; pull clones into an empty team` (the local history guard). The usage surface has no verb that changes the endpoint, and the binding keeps naming the old address. Both guards are individually right and together left no path, exactly as the issue reports.

## What the fix is

`remote.sh set-endpoint --endpoint <url> <team>` moves a live binding to a new address. The design rests on the distinction the code already states (see `_remote_adopt_registration`'s header): what a team is bound to is the identity triple `(server_instance_id, remote_team_id, protocol_version)`; **the endpoint is an address, not an identity**. So only the address may move, and the server answering at the new address must prove the same identity before anything is written.

The proof and the write are one existing function: `_remote_adopt_registration` fetches the new address's capabilities, refuses unless the server instance matches the recorded one — naming both ids when it does not — re-checks that the registration is this team's (name and roster), and only then rewrites the binding with `binding_revision` advanced. There is deliberately no unverified path to the write, and no `--force`. A disconnected team is refused and pointed at `connect`, which is the deliberate re-anchoring move for that state (its refusal text already says so for the replaced-server case).

The address is pinned in a second place for teams with a stored sync config: `loadConfig` refuses a config whose `server_url` differs from the binding, and `configure` refuses to replace a binding at all. A new engine subcommand (`remote-sync.sh set-endpoint --team <t>`) aligns the stored config after re-verifying the identity end to end against the new address (`request()` + `validateCapabilities`, whose `validateBinding` compares the response's identity to this connection's). Plain teams with no stored config are a recorded no-op. If the process dies between the two writes, the next engine start fails loudly on the exact mismatch and re-running `set-endpoint` repairs it.

## The E2EE question, answered by measurement

The age machinery needs nothing else moved: the trust file path is keyed by the identity triple, not the address (`ageTrustPath`), and the retained checkpoint compares identity, epoch, generation and digest — no `server_url` anywhere (`compareRetainedCheckpoint`). The one e2ee-relevant surface is the stored sync config rewrite above, which the engine-side test exercises directly.

## Tests

The bats tests pin the three properties the address move must have: (1) a same-server move succeeds with history present — binding endpoint updated, identity unchanged, revision advanced, engine restarted, and a repeat run is a versioned no-op; (2) a rotated server instance at the new address (the mock's `/_test/rotate-server-id`, same address family, registrations intact) is refused with **both ids named** and nothing written; (3) a disconnected team is refused and pointed at connect. All three fail without the implementation (verified by stashing it).

The invariant's regressions drive the real failure states, each verified red against the head that had the feature but not the guard: the partial state (binding=new / stored=old) repaired by a re-run; a concurrent disconnect surviving the race (barrier seam, revision refusal named, `disconnected_at` intact, address unmoved); a concurrent sync start ending with a running engine on the moved address; and the review's interleave — a stale alignment held in its capabilities request while a faster move completes, refused on resume with the faster pair intact and the lock released. The engine-side tests also cover the stored-config rewrite, the foreign-config refusal, and the no-config no-op.

Suites run locally by exit code: `tests/test_remote.bats` (110), `node --test tests/remote_sync_engine.test.mjs` (69), the six adjacent remote/endpoint suites, `tests/test_delivery.bats` after rebasing over #736/#738, and `tests/test_remote_setup_doc.bats` — all green; the enforceable-assertions checker is at its baseline.

## The consistency guarantee (review rounds 2 and 3)

The first head treated a two-place write (the binding and the stored sync config) as if it were atomic, and three review findings were symptoms of that one structure: the same-address idempotence check looked only at the binding (leaving the partial state unrepairable through the printed remedy), the revision CAS guarded only the binding write (letting a slow stale alignment roll back a faster completed move), and the engine decision looked only at the snapshot (racing a concurrent lifecycle command).

The guarantee now is one invariant: **either half of the pair is written only under the per-team registry lock, and only against a binding_revision the writer verified.** Binding writes advance the revision under that lock (`_remote_write_binding` gained the same expected-revision compare-and-swap contract `_remote_local_disconnect` already had); the stored-config alignment takes the same lock — the same mkdir primitive on `teams/<team>/.config.lock`, so the shell and the engine serialize against each other — re-reads the binding, and refuses when its endpoint or revision moved. The same-address path always runs the alignment (repairing the partial state; a fully aligned pair is a recorded no-op), and the engine decision reads both the snapshot and the present, so a concurrently started engine is restarted onto the new address rather than silently left stopped.

Alternatives considered and why they lose: putting both writes in one lock section either holds a spin lock across a 15s-timeout network verification (starving every concurrent lifecycle command's ~10s lock wait) or requires splitting the engine subcommand into verify/write phases — more moving parts for the same guarantee. Reordering (config first, binding last) still allows a faster mover's config to be overwritten by the slower one unless the config write is also revision-gated, i.e. it needs this fix anyway. Deriving one place from the other (dropping `server_url` from the stored config) is the structural end-state but changes a validated authority-file format mid-rc for every connected team, and removes a cross-check (a stored config from a different connection failing loudly) that has value today — proposed as a follow-up instead.

On the lock's failure mode: nothing sweeps a stale registry lock anywhere in this tree; the existing shell contract is release-by-trap plus a bounded (~10s) wait that fails loudly naming the directory. A holder killed without its trap (SIGKILL, power loss) leaves the lock, and the way out is that named, bounded failure — the engine side adopts the identical contract and its timeout message also states the removal step. This change adds no new stuck-forever path.

## Known edges, stated

- The identity re-check compares the server's roster with the local one, so a member joined locally but not yet propagated to the server makes `set-endpoint` refuse with the roster message until sync catches up; retrying after sync succeeds. This is the existing adopt-path behavior, reused rather than weakened.
- `set-endpoint` reuses the adopt path's stderr note ("adopting that registration and continuing") on success; the final line states the actual move.
- The issue's second ask (warn at choice time that the endpoint is permanent) is resolved by removing the permanence instead; docs/remote-setup.md now says the address can be moved later and names the command, and states that pointing a team at a *different* server deliberately stays impossible without disconnecting first.
- "Starting over cleanly" (the issue comment's second decision) is out of scope here — it is its own product question and is not needed for the endpoint case once the address can move.
