### PR TITLE
test: state the reason instead of who decided, and drop a seat-shaped fixture path

### DIFF
--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -377,25 +377,25 @@ gone_pid() {
 }
 
 @test "args_is_grok_watcher: matches a real watcher invocation (#245)" {
-  local proj="/Users/x/projects/comms-agent"
+  local proj="/Users/x/projects/notes-app"
   agmsg_args_is_grok_watcher "bash /skills/agmsg/scripts/watch.sh sess.1 $proj grok-build" "$proj"
 }
 
 @test "args_is_grok_watcher: matches an empty-sid watcher (double space) (#245)" {
-  local proj="/Users/x/projects/comms-agent"
+  local proj="/Users/x/projects/notes-app"
   agmsg_args_is_grok_watcher "bash /skills/agmsg/scripts/watch.sh  $proj grok-build" "$proj"
 }
 
 @test "args_is_grok_watcher: excludes a shell that merely mentions the strings (#245)" {
   # A process running `grep watch.sh ... grok-build` would be wrongly killed by a
   # loose substring match. watch.sh is not the executed program here.
-  local proj="/Users/x/projects/comms-agent"
+  local proj="/Users/x/projects/notes-app"
   run agmsg_args_is_grok_watcher "/bin/zsh -c grep watch.sh foo grok-build $proj" "$proj"
   [ "$status" -ne 0 ]
 }
 
 @test "args_is_grok_watcher: excludes a watcher for a different project (#245)" {
-  run agmsg_args_is_grok_watcher "bash /s/watch.sh sess.1 /other/proj grok-build" "/Users/x/comms-agent"
+  run agmsg_args_is_grok_watcher "bash /s/watch.sh sess.1 /other/proj grok-build" "/Users/x/notes-app"
   [ "$status" -ne 0 ]
 }
 

--- a/tests/test_legacy_mirror.bats
+++ b/tests/test_legacy_mirror.bats
@@ -43,9 +43,12 @@ legacy_read_at() {
 }
 
 @test "legacy mirror: reading a message marks it read for a reader of the legacy table (#689)" {
-  # koit's call, against my initial recommendation: mirror read state too.
-  # Without it an old viewer shows every message unread forever, which is worse
-  # than the disagreement it was avoiding.
+  # Read state is mirrored as well as the message, and that is the harder half
+  # to argue for: mirroring it means two copies of the same fact, which can
+  # disagree. Not mirroring it is worse. An old viewer reads read_at from the
+  # legacy table, so leaving it null shows every message as unread forever --
+  # a permanent wrong answer, against a disagreement that only appears if the
+  # two writes come apart.
   bash "$SCRIPTS/send.sh" mteam bob alice "read state travels"
   [ -z "$(legacy_read_at 'read state travels')" ]
 


### PR DESCRIPTION
Two pre-existing findings in the public repository, found by running `scripts/check-private-names.mjs` with an actual name list.

## What changed

**`tests/test_legacy_mirror.bats`** attributed a design decision to a named individual and framed the rest as disagreement with them. The checker's own remedy is to state the reason rather than who gave it — and the reason is the part a reader can use:

> mirroring read state means two copies of one fact, which can disagree; not mirroring it shows every message unread forever in an old viewer — a permanent wrong answer, against a divergence that only appears if the two writes come apart

**`tests/test_instance_id.bats`** used a seat-shaped fixture path in four places, matching the shape the checker screens for. Replaced with a neutral name. The paths are arbitrary strings to the function under test (`agmsg_args_is_grok_watcher` compares them), so nothing about what the tests exercise changes.

Neither is reachable from the npm tarball — `package.json` `files` is `["bin/","README.md","CHANGELOG.md","LICENSE"]` — but both are in the public repo, which is what the rule is about.

## Measured

```
before:  5 finding(s) on 5 line(s) in 2 file(s), out of 408 scanned
after:   clean (407 files scanned)
```

`tests/test_legacy_mirror.bats` + `tests/test_instance_id.bats`: **64/64 on `/bin/bash` 3.2**.

## The reason CI did not catch these

```
.github/workflows/tests.yml:899
  run: AGMSG_PRIVATE_NAMES=none node scripts/check-private-names.mjs
```

`none` runs the **shape half only**, and the tool says so itself when asked to run without a list: *"To run the shape half ALONE and accept that unshaped names go unchecked."* The name half is never run in CI, so a plain name that does not match `SEAT_SHAPE` is invisible there — which is what the first of these two was.

Raised rather than changed here: where a name list could live for a public repo is a design question, not a test fix.

## One correction to my own measurement

My first run supplied short names (two-letter ones among them) and reported **133 findings**. Most were in `scripts/drivers/storage/sqlite-sync.sh` (88) and `sqlite.sh` (21) — matches on ordinary spellings inside SQL. That number was an artifact of my input, not a property of the repo. Restricting the list to unambiguous names gives the 5 above. Recorded because reporting 133 would have invented a problem that is not there.
