### PR TITLE
fix(remote): distinguish an unreadable team config from never-connected (#650)

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1672,20 +1672,52 @@ cmd_connect() {
 
 # --- status --------------------------------------------------------------
 
-# _remote_config_malformed <cfg> -> true (0) when the file EXISTS but does not
-# parse as a JSON object; false (1) when it's missing (the ordinary "never
-# connected" case _remote_read_config_field already answers with "null") or
-# genuinely valid. #650: a config that exists but cannot be read is a
-# FAILURE, not the same answer as "there is nothing to read" -- callers below
-# must check this before treating field-read results as meaningful, or a
-# parse failure quietly reads as "no binding" (and, via _remote_read_config_field,
-# leaks a raw sqlite error line onto stdout/stderr first).
+# _remote_config_shape_ok <content> -> true (0) if <content> parses as a
+# JSON OBJECT; false (1) for invalid JSON, or valid JSON that isn't an
+# object (`[]`, `null`, `42`, `"text"`). The ONE predicate both status
+# forms call for this question (review): a first version of this fix put
+# an equivalent check only on the human-text path (as bash+sqlite), while
+# _remote_status_json_one kept its own separate python
+# `isinstance(cfg, dict)` check. Two implementations of one question drift
+# -- exactly what happened here: tightening the --json side's check left
+# the human side still falling through to json_extract-returns-null,
+# rc=1 "never connected", for the same file the --json side correctly
+# called unreadable. Same structural mistake as #722 (two independent
+# implementations of one endpoint-validity question), fixed the same way:
+# collapse to one function, both callers use its answer.
+#
+# Takes CONTENT, not a path, on purpose: _remote_status_json_one already
+# does one locked read of the file for its own strict-ABI reasons (see its
+# header comment) and must not read it a second time here, unlocked --
+# that would reopen exactly the TOCTOU race that single read exists to
+# close. Callers that only have a path (the human-text side) read the
+# file themselves and pass the content in.
+#
+# `json_type` only runs inside the CASE branch taken when json_valid is
+# true (SQLite's CASE WHEN is lazy per-branch), specifically so it is
+# never asked to type a string that failed to parse at all -- evaluating
+# it unconditionally would risk erroring on the same invalid input this
+# function exists to classify, rather than answering false.
+_remote_config_shape_ok() {
+  local content="$1" escaped top_type
+  escaped=$(printf '%s' "$content" | sed "s/'/''/g")
+  top_type=$(agmsg_sqlite_mem "SELECT CASE WHEN json_valid('$escaped') THEN json_type('$escaped') ELSE 'invalid' END;" 2>/dev/null || echo "")
+  [ "$top_type" = "object" ]
+}
+
+# _remote_config_malformed <cfg> -> true (0) when the file EXISTS but its
+# content does not satisfy _remote_config_shape_ok; false (1) when it's
+# missing (the ordinary "never connected" case _remote_read_config_field
+# already answers with "null") or genuinely a valid object. #650: a config
+# that exists but cannot be read is a FAILURE, not the same answer as
+# "there is nothing to read" -- callers below must check this before
+# treating field-read results as meaningful, or a parse failure quietly
+# reads as "no binding" (and, via _remote_read_config_field, leaks a raw
+# sqlite error line onto stdout/stderr first).
 _remote_config_malformed() {
-  local cfg="$1" escaped valid
+  local cfg="$1"
   [ -f "$cfg" ] || return 1
-  escaped=$(sed "s/'/''/g" "$cfg")
-  valid=$(agmsg_sqlite_mem "SELECT json_valid('$escaped');" 2>/dev/null || echo "")
-  [ "$valid" = "1" ] && return 1
+  _remote_config_shape_ok "$(cat "$cfg" 2>/dev/null)" && return 1
   return 0
 }
 
@@ -1782,6 +1814,15 @@ _remote_status_json_one() {
   agmsg_lock_acquire "$TEAMS_DIR/$team" || return 2
   raw="$(cat "$cfg" 2>/dev/null)"
   agmsg_lock_release
+
+  # Authoritative shape gate (review, #650): the same _remote_config_shape_ok
+  # the human-text path uses, called here against the already-locked-read
+  # $raw rather than re-reading the file. Python's own json.loads/isinstance
+  # below stays as defensive-only belt-and-suspenders after this -- it should
+  # never actually trigger once this has passed, but a shell string escape
+  # and a SQLite JSON parser are not literally the same implementation as
+  # Python's, so it stays rather than assuming they can never disagree.
+  _remote_config_shape_ok "$raw" || return 2
 
   IFS=$'\t' read -r engine_state engine_pid < <(_remote_sync_engine_status "$team")
   printf '%s' "$raw" | python3 -c '

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1672,10 +1672,30 @@ cmd_connect() {
 
 # --- status --------------------------------------------------------------
 
+# _remote_config_malformed <cfg> -> true (0) when the file EXISTS but does not
+# parse as a JSON object; false (1) when it's missing (the ordinary "never
+# connected" case _remote_read_config_field already answers with "null") or
+# genuinely valid. #650: a config that exists but cannot be read is a
+# FAILURE, not the same answer as "there is nothing to read" -- callers below
+# must check this before treating field-read results as meaningful, or a
+# parse failure quietly reads as "no binding" (and, via _remote_read_config_field,
+# leaks a raw sqlite error line onto stdout/stderr first).
+_remote_config_malformed() {
+  local cfg="$1" escaped valid
+  [ -f "$cfg" ] || return 1
+  escaped=$(sed "s/'/''/g" "$cfg")
+  valid=$(agmsg_sqlite_mem "SELECT json_valid('$escaped');" 2>/dev/null || echo "")
+  [ "$valid" = "1" ] && return 1
+  return 0
+}
+
 _remote_status_one() {
   local team="$1" cfg connected_at disconnected_at write_allowed_ciphers key_id \
     binding_cipher engine_state engine_pid
   cfg="$(_remote_team_config "$team")"
+  if _remote_config_malformed "$cfg"; then
+    return 2
+  fi
   connected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.connected_at')"
   disconnected_at="$(_remote_read_config_field "$cfg" '$.remote_binding.disconnected_at')"
   if [ -z "$connected_at" ] || [ "$connected_at" = "null" ]; then
@@ -1720,9 +1740,14 @@ _remote_status_one() {
 }
 
 # _remote_status_json_one <team> — prints one JSONL object for <team>'s
-# binding, or returns 1 (no output) if the team has never been connected,
-# matching _remote_status_one's own gate exactly (same "never connected"
-# definition for both surfaces).
+# binding. Return code carries which of two different answers a caller got
+# (#650): 1 means the team has never been connected (no config, or a valid
+# config with no remote_binding) -- ordinary, matches _remote_status_one's
+# own gate. 2 means the team's config could not actually be read (its lock
+# could not be acquired, or its file exists but is not parseable JSON) --
+# a FAILURE distinct from "never connected", because a caller enumerating
+# every locally-known team (e.g. deciding what to back up) must not treat a
+# team it failed to read as identical to one that was genuinely never bound.
 #
 # Strict, machine-consumed ABI (ADR 0007 addendum): a cloud/self-hosted
 # driver correlates this against its own operation-status record to decide
@@ -1754,7 +1779,7 @@ _remote_status_json_one() {
   cfg="$(_remote_team_config "$team")"
   [ -f "$cfg" ] || return 1
 
-  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 1
+  agmsg_lock_acquire "$TEAMS_DIR/$team" || return 2
   raw="$(cat "$cfg" 2>/dev/null)"
   agmsg_lock_release
 
@@ -1765,9 +1790,9 @@ team, engine_state, engine_pid_text = sys.argv[1:4]
 try:
     cfg = json.loads(sys.stdin.read())
 except Exception:
-    sys.exit(1)
+    sys.exit(2)
 if not isinstance(cfg, dict):
-    sys.exit(1)
+    sys.exit(2)
 binding = cfg.get("remote_binding")
 if not isinstance(binding, dict) or not binding.get("connected_at"):
     sys.exit(1)
@@ -1800,11 +1825,17 @@ cmd_status() {
 
   if [ -n "$team" ]; then
     agmsg_validate_team_name "$team" || exit 1
+    local rc=0
     if [ "$json" -eq 1 ]; then
-      _remote_status_json_one "$team" || { echo "agmsg: team '$team' has never been connected" >&2; exit 1; }
+      _remote_status_json_one "$team" || rc=$?
     else
-      _remote_status_one "$team" || { echo "agmsg: team '$team' has never been connected" >&2; exit 1; }
+      _remote_status_one "$team" || rc=$?
     fi
+    case "$rc" in
+      0) : ;;
+      2) echo "agmsg: team '$team' could not be read -- its config exists but could not be parsed (or its lock could not be acquired); connection state is unknown, not confirmed unconnected (#650)" >&2; exit 2 ;;
+      *) echo "agmsg: team '$team' has never been connected" >&2; exit 1 ;;
+    esac
     return
   fi
 
@@ -1813,17 +1844,27 @@ cmd_status() {
     [ "$json" -eq 1 ] || echo "No teams found."
     return
   fi
+  local rc
   for t in "$TEAMS_DIR"/*/; do
     [ -d "$t" ] || continue
     t="$(basename "$t")"
     if [ "$json" -eq 1 ]; then
-      if _remote_status_json_one "$t"; then
-        any=1
-      fi
+      rc=0; _remote_status_json_one "$t" || rc=$?
+      case "$rc" in
+        0) any=1 ;;
+        # #650: absence of a line must mean "never connected", nothing else --
+        # a team whose config could not be read gets an explicit line instead
+        # of silently vanishing from what a caller treats as the full set.
+        2) python3 -c 'import json, sys; print(json.dumps({"local_team": sys.argv[1], "state": "unreadable"}))' "$t"
+           any=1 ;;
+      esac
     else
-      if _remote_status_one "$t"; then
-        any=1
-      fi
+      rc=0; _remote_status_one "$t" || rc=$?
+      case "$rc" in
+        0) any=1 ;;
+        2) echo "$t	could not be read (config exists but could not be parsed) (#650)"
+           any=1 ;;
+      esac
     fi
   done
   if [ "$any" -ne 1 ] && [ "$json" -ne 1 ]; then

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1148,6 +1148,54 @@ _truncate_team_config() {  # $1 = team -> replaces its config.json with malforme
   [[ "$output" == *"could not be read"* ]] && [[ "$output" != *"has never been connected"* ]]
 }
 
+@test "status <team> [--json]: the human and --json forms classify every config shape identically (#650 review)" {
+  # co2's finding: _remote_config_malformed checked json_valid but not the
+  # top-level TYPE, so [] / null / 42 / "text" -- valid JSON, not an object
+  # -- passed it, then fell through to json_extract-returns-null same as a
+  # genuinely empty binding: rc=1 "never connected". The --json path's
+  # python isinstance(dict) check already rejected these (rc=2), so the
+  # same file classified differently on the two paths.
+  #
+  # Fixing the bash side alone (tightening its check to match python's)
+  # would leave two independent implementations of one question, the exact
+  # shape that produced this gap in the first place -- the same structural
+  # mistake as #722 (also fixed by collapsing to one implementation both
+  # callers use). This test pins that AGREEMENT, not just each side's own
+  # correctness: it fails if either side's classifier ever changes without
+  # the other, even though _remote_config_shape_ok is now the single
+  # implementation both call, in case a future edit reintroduces a
+  # divergent path.
+  bash "$SCRIPTS/join.sh" beta dave claude-code /tmp/project-beta
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" beta
+  local cfg="$TEST_SKILL_DIR/teams/beta/config.json"
+  local valid_cfg
+  valid_cfg="$(cat "$cfg")"
+
+  local shape content expect
+  for shape in valid never_connected array null number string truncated; do
+    case "$shape" in
+      valid)           content="$valid_cfg"; expect=0 ;;
+      never_connected) content='{}'; expect=1 ;;
+      array)           content='[]'; expect=2 ;;
+      null)            content='null'; expect=2 ;;
+      number)          content='42'; expect=2 ;;
+      string)          content='"text"'; expect=2 ;;
+      truncated)       content='{"remote_binding": {"connected_at": "2026-01-01T00:00'; expect=2 ;;
+    esac
+    printf '%s' "$content" > "$cfg"
+
+    run bash "$SCRIPTS/remote.sh" status beta
+    local human_status="$status"
+    run bash "$SCRIPTS/remote.sh" status beta --json
+    local json_status="$status"
+
+    [ "$human_status" -eq "$expect" ] \
+      || { echo "shape=$shape: human form expected exit $expect, got $human_status" >&2; false; }
+    [ "$json_status" -eq "$expect" ] \
+      || { echo "shape=$shape: --json form expected exit $expect, got $json_status" >&2; false; }
+  done
+}
+
 
 
 

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1067,6 +1067,87 @@ PY
   [ "$(sqlite_mem "SELECT json_extract('$(echo "$output" | sed "s/'/''/g")', '\$.local_team');")" = "$team" ]
 }
 
+_truncate_team_config() {  # $1 = team -> replaces its config.json with malformed JSON
+  local cfg="$TEST_SKILL_DIR/teams/$1/config.json"
+  [ -f "$cfg" ] || { echo "no config.json for $1 to truncate" >&2; return 1; }
+  printf '{"remote_binding": {"connected_at": "2026-01-01T00:00' > "$cfg"
+}
+
+@test "status --json (aggregate): a team whose config could not be read gets an explicit line, not silence (#650)" {
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  bash "$SCRIPTS/join.sh" beta dave claude-code /tmp/project-beta
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" beta
+  _truncate_team_config beta
+  bash "$SCRIPTS/join.sh" gamma erin claude-code /tmp/project-gamma  # joined, never connected
+
+  run bash "$SCRIPTS/remote.sh" status --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 2 ]
+  local testteam_line beta_line
+  testteam_line="$(echo "$output" | grep testteam)"
+  beta_line="$(echo "$output" | grep beta)"
+  [ -n "$testteam_line" ]
+  [ -n "$beta_line" ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$beta_line" | sed "s/'/''/g")', '\$.local_team');")" = "beta" ]
+  [ "$(sqlite_mem "SELECT json_extract('$(echo "$beta_line" | sed "s/'/''/g")', '\$.state');")" = "unreadable" ]
+  # gamma was joined but never connected -- ordinary, stays silent. Its
+  # absence here is the OTHER half of #650: a line must not be manufactured
+  # for a team that was genuinely never bound, only for one that failed to
+  # read.
+  [[ "$output" != *"gamma"* ]]
+}
+
+@test "status <team> --json: an unreadable config is distinguishable from a genuinely unconnected team (#650)" {
+  bash "$SCRIPTS/join.sh" beta dave claude-code /tmp/project-beta
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" beta
+  _truncate_team_config beta
+
+  run bash "$SCRIPTS/remote.sh" status beta --json
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"could not be read"* ]] && [[ "$output" != *"has never been connected"* ]]
+
+  run bash "$SCRIPTS/remote.sh" status ghostteam --json
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"has never been connected"* ]] && [[ "$output" != *"could not be read"* ]]
+}
+
+@test "status <team>: the text form distinguishes unreadable from unconnected too, with no leaked sqlite error (#650)" {
+  bash "$SCRIPTS/join.sh" beta dave claude-code /tmp/project-beta
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" beta
+  _truncate_team_config beta
+
+  run bash "$SCRIPTS/remote.sh" status beta
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"could not be read"* ]] && [[ "$output" != *"has never been connected"* ]]
+  # The pre-fix leak: a raw sqlite parse error reached stdout/stderr before
+  # the (wrong) "has never been connected" line. The malformed check now
+  # short-circuits before any field read is attempted.
+  [[ "$output" != *"Error: stepping"* ]]
+}
+
+@test "status (aggregate, text): an unreadable team is reported and suppresses the false-reassuring 'No teams are connected' (#650)" {
+  bash "$SCRIPTS/join.sh" beta dave claude-code /tmp/project-beta
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" beta
+  _truncate_team_config beta
+
+  run bash "$SCRIPTS/remote.sh" status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"beta"* ]] && [[ "$output" == *"could not be read"* ]]
+  [[ "$output" != *"No teams are connected."* ]]
+}
+
+@test "status <team> --json: a lock that cannot be acquired is reported as unreadable, not never-connected (#650)" {
+  bash "$SCRIPTS/join.sh" beta dave claude-code /tmp/project-beta
+  bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" beta
+  local lock="$TEST_SKILL_DIR/teams/beta/.config.lock"
+  mkdir "$lock"
+
+  run env AGMSG_LOCK_TRIES=2 bash "$SCRIPTS/remote.sh" status beta --json
+  rmdir "$lock"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"could not be read"* ]] && [[ "$output" != *"has never been connected"* ]]
+}
+
 
 
 


### PR DESCRIPTION
Closes #650.

## What

`remote.sh status --json` with no team silently dropped a team whose
`config.json` could not be read, and exited 0. A caller enumerating
every locally-known team (e.g. deciding what to back up) could not
tell "this team has no remote binding" from "this team could not be
read" — one is ordinary, the other is a failure a caller must stop
on, and both looked identical: the unreadable team simply wasn't in
the output.

The single-team form collapsed the same two facts into one answer.
`_remote_status_json_one` returned 1 for three unrelated causes — no
config at all (ordinary), a lock that could not be acquired (a
failure), and JSON that failed to parse or wasn't an object (a
failure) — and `cmd_status` printed the same `"agmsg: team '<t>' has
never been connected"` and exit 1 for all three.

## Positive control

Reproduced a team with a truncated `config.json` and confirmed
byte-for-byte, before writing any fix:

- `remote.sh status --json` (no team): the unreadable team produced no
  line at all; exit 0.
- `remote.sh status <team> --json`: identical message and exit code as
  a genuinely unknown team that was never even joined.

Also found while reproducing (not in the issue text): the human-text
`status <team>` form has the identical collapse, and is actually
worse — a raw sqlite parse error (`Error: stepping, malformed JSON`)
leaked onto output *before* the same wrong message, because
`_remote_read_config_field` only special-cases a *missing* file
(returns `"null"`), not a malformed one.

## Fix

A new `_remote_config_malformed <cfg>` check runs before either status
path trusts a field read from the config: true only when the file
*exists* but does not parse as a JSON object — distinct from
"missing", which stays the ordinary, silent case exactly as before.

`_remote_status_one` and `_remote_status_json_one` now return **2**
(not 1) for "could not be read" — a lock that couldn't be acquired, or
a config that exists but won't parse — reserving **1** for the one
answer that's genuinely ordinary: a valid config with no binding at
all (or no config file). `_remote_status_json_one`'s existing
single-locked-read design (documented in its own header comment,
added for the strict ADR 0007 ABI) is preserved — the malformed check
for that path happens *inside* the same read, via the existing
python parse's exit code, not a second file read. `_remote_status_one`
already tolerates a multi-read, cosmetically-stale shape by design (a
human glancing at status doesn't need atomicity the way a driver
correlating a strict ABI does), so one extra read for the boolean
malformed-check there is consistent with what's already there, not a
new correctness concern.

`cmd_status`'s single-team paths now branch on the return code: `2`
gets a distinct `"...could not be read..."` message and **exit 2**;
`1`'s `"...has never been connected"` + exit 1 is unchanged. The
no-team aggregate paths now emit something for an `rc=2` team instead
of skipping it — `{"local_team": "<t>", "state": "unreadable"}` for
`--json` (the shape the issue suggested), a plain "could not be read"
line for the text form. The text form's aggregate also no longer
prints the falsely-reassuring `"No teams are connected."` when the
only team present is an unreadable one. An `rc=1` team still produces
**no line at all**, in either form, unchanged — absence still means,
and only means, "never connected."

## A `set -e` bug found while wiring this in

`remote.sh` runs under `set -e`. My first pass wrote
`_remote_status_json_one "$team"; rc=$?` — under `-e`, a bare
command's non-zero exit isn't protected the way it is inside
`if`/`while`/`&&`/`||`, so the script exited right at that call and
`rc=$?` never ran. Every call site now uses `cmd || rc=$?` instead.
Caught by running the new tests directly rather than trusting the
diff — they failed with "no output, exit 2" instead of the expected
message, which is what pointed at this.

## Tests

Five new cases in `test_remote.bats`:

1. Aggregate `--json` emits the unreadable line for a truncated
   config, while a team that was joined but genuinely never connected
   stays silent (both halves of the fix, in one test).
2. Single-team `--json`: unreadable (exit 2, `"could not be read"`,
   not `"has never been connected"`) vs. genuinely unknown (exit 1,
   the reverse).
3. Same distinction for the text form, plus asserting the old sqlite
   error leak (`"Error: stepping"`) is gone.
4. Aggregate text form: an unreadable team is reported and the
   `"No teams are connected."` line is suppressed.
5. A held lock (`mkdir` on `.config.lock` directly, mirroring an
   existing test's own pattern a few hundred lines up) is reported as
   unreadable, not never-connected.

Mutation-tested: swapped in the pre-fix `remote.sh` (from
`origin/integration/remote`), confirmed all 5 new assertions go red
reproducing the exact issue text; restored, all green.

`check-enforced-assertions`: 616 (baseline, unchanged — 8 new
non-final `[[ ]]` pairs chained with `&&`, matching this file's
existing convention for that checker).

`bats tests/test_remote.bats` (109/109), `tests/test_remote_status_liveness.bats`
(13/13): all green.

## Note for the consumer mentioned in the issue's provenance

The issue names an `agmsg-cloud` PR that reads this output to
enumerate teams and refuses a line it can't parse. That consumer is
in a different repository this PR doesn't touch — but its refuse-on-
unparseable-line behavior means the new `{"local_team": "<t>",
"state": "unreadable"}` line is a *new, well-formed* shape it hasn't
seen before, not a malformed one it would already refuse. Whether
that consumer should recognize `state: "unreadable"` explicitly (skip
gracefully vs. surface it) is a separate, consumer-side decision —
flagging it here since I can't make that call from this repo.

## Review fix: two implementations of one question, not one

Static review found that `_remote_config_malformed` checked
`json_valid` but not the top-level *type*: `[]`, `null`, `42`,
`"text"` are all valid JSON but not an object, so they passed the
check, then fell through to `json_extract` returning null for every
field path — exactly the same silent "never connected" collapse this
PR exists to close, just reached from a shape the validity-only check
couldn't see. `_remote_status_json_one`'s python `isinstance(cfg,
dict)` check already rejected these — so the same file classified
*differently* between the two status forms.

Tightening only the bash-side check would have left two independent
implementations of one question, which is exactly what produced this
gap: the `--json` side's classifier was tightened at some point and
the human-text side wasn't. Same structural mistake as an earlier
incident with two independent implementations of an endpoint-validity
question, fixed the same way there — collapse to one function, both
callers use its answer.

Fix: extracted `_remote_config_shape_ok <content>` — checks
`json_valid` **and** `json_type = 'object'` (the type check only runs
inside the `CASE` branch taken when valid, so it's never asked to
type unparseable input). `_remote_config_malformed` (human-text path)
now reads the file once and calls it. `_remote_status_json_one` now
calls it too, against the `$raw` content its own single locked read
already produced — not a second file read, which would reopen the
exact TOCTOU race that locked single-read exists to close (documented
in the function's own header comment). Python's
`json.loads`/`isinstance` stays as defensive-only belt-and-suspenders
after the shared gate.

New test drives 7 config shapes (a valid connected config, `{}` as
the ordinary ongoing never-connected case, and the 5 shapes above as
unreadable) through **both** status forms and asserts they agree —
not just each form's own correctness, so a future edit to only one
side's classifier fails this test instead of silently drifting again.

Mutation-tested: reverted just the shape-type check back to
validity-only, confirmed the new agreement test goes red reproducing
the exact finding (human form returns exit 1 for `[]`, expected 2);
restored, green.

`check-enforced-assertions`: 616 (baseline, unchanged).
`bats tests/test_remote.bats tests/test_remote_status_liveness.bats`: all green.

Base `integration/remote` — landing this myself once the gate (all
reviewers' CLEARED on the exact head, CI green, drift confirmed
immediately before merging) is satisfied, no separate go needed for
this destination.

