### PR TITLE
fix(check-inbox): deliver with exit 0 when the poll failed part-way (#658)

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -221,16 +221,27 @@ fi
 # New messages found.
 #
 # This is the delivering path, and the rows above were marked read INSIDE the
-# loop before we got here. The hook runtime reads stdout as control JSON only
-# on exit 0, so a non-zero status here does not "re-raise the failure" — it
-# throws away the payload that already cost those rows their unread state. The
-# messages are consumed and never shown, which is a worse outcome than the one
-# the status was protecting against.
+# loop before we got here. The documented hook contract is that stdout is read
+# as control JSON only on exit 0. Measured (Claude Code 2.1.226, one-shot
+# `claude -p`, a synthetic probe hook -- not this script, not an interactive
+# session): the stdout control JSON was processed on exit 0, 1, 2, and 3 alike.
+# So this codebase currently depends on an area where the documented contract
+# and the observed implementation disagree -- see
+# https://github.com/fujibee/agmsg/issues/658 for the measurement.
 #
-# So delivery and the report are separated: the messages go out with exit 0,
-# and the partial failure is stated inside the payload the operator actually
-# reads. Nothing upstream mistakes a partial poll for a complete one, because
-# the text says which team stopped it and that the rest are still unread.
+# This fix is correct either way, which is why it doesn't bet on which
+# behavior is real: if a runtime DOES discard stdout on non-zero exit (as
+# documented), leaving the old `exit "$CLAIM_RC"` here would throw away the
+# payload that already cost these rows their unread state -- consumed and
+# never shown, worse than the failure this status was meant to protect
+# against. If a runtime does NOT discard it (as measured here), the old
+# non-zero exit was not needed to preserve the delivery or report the
+# partial failure, because the payload already carries both.
+# Exiting 0 unconditionally on this path is safe under both, so delivery and
+# the report are separated: the messages go out with exit 0, and the partial
+# failure is stated inside the payload the operator actually reads. Nothing
+# upstream mistakes a partial poll for a complete one, because the text says
+# which team stopped it and that the rest are still unread.
 if [ -n "$OUTPUT" ]; then
   if [ "$CLAIM_RC" -ne 0 ]; then
     OUTPUT+="agmsg: this poll stopped early — team '$CLAIM_FAILED_TEAM' could not be read (status $CLAIM_RC)."$'\n'

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -145,6 +145,7 @@ OUTPUT=""
 # already accumulated still reaches an emit point, teams after the failing one
 # stay untouched (unread), and the failure status is re-raised on exit.
 CLAIM_RC=0
+CLAIM_FAILED_TEAM=""
 IFS=',' read -ra TEAM_LIST <<< "$TEAMS"
 for team in "${TEAM_LIST[@]}"; do
   team_sql="$(_agmsg_sqlesc "$team")"
@@ -159,7 +160,7 @@ for team in "${TEAM_LIST[@]}"; do
   # role. That asymmetry is the Codex caveat documented in README — if a
   # Codex session actas'd into <name>, check-inbox is still polling
   # whatever whoami chose first, not <name>.
-  state=$(actas_lock_state "$team" "$AGENT" "${SESSION_ID:-}") || { CLAIM_RC=$?; break; }
+  state=$(actas_lock_state "$team" "$AGENT" "${SESSION_ID:-}") || { CLAIM_RC=$?; CLAIM_FAILED_TEAM="$team"; break; }
   case "$state" in
     other:*) continue ;;
   esac
@@ -168,7 +169,7 @@ for team in "${TEAM_LIST[@]}"; do
     SELECT id || char(31) || from_agent || char(31) || replace(replace(body, char(10), '\n'), char(9), '\t') || char(31) || created_at
     FROM messages WHERE team='$team_sql' AND to_agent='$AGENT_SQL' AND read_at IS NULL
     ORDER BY created_at ASC;
-  ") || { CLAIM_RC=$?; break; }
+  ") || { CLAIM_RC=$?; CLAIM_FAILED_TEAM="$team"; break; }
   if [ -n "$RESULT" ]; then
     COUNT=$(echo "$RESULT" | wc -l | tr -d ' ')
     OUTPUT+="$COUNT new message(s) in $team:"$'\n'
@@ -200,16 +201,41 @@ for team in "${TEAM_LIST[@]}"; do
   fi
 done
 
-# No new messages. Both emit points re-raise a loop failure captured above:
-# exiting 0 here would convert "a team's query failed" into "nothing to
-# deliver", which is the silent half of #637.
+# The two emit points are NOT the same case, and treating them alike is what
+# lost messages.
+#
+# Nothing was accumulated: there is no delivery to protect, so the exit status
+# is free to carry the failure — and it must, because "no new messages" would
+# claim something this run never established. That is the half of #637 the
+# original comment here was right about, and it is unchanged.
+#
+# The status line is emitted only when the poll actually completed. Printing
+# "no new messages" and then exiting non-zero states something untrue on a
+# channel that is about to be discarded anyway.
 if [ -z "$OUTPUT" ]; then
+  [ "$CLAIM_RC" -eq 0 ] || exit "$CLAIM_RC"
   emit_status_json "agmsg: no new messages"
-  exit "$CLAIM_RC"
+  exit 0
 fi
 
-# New messages found
+# New messages found.
+#
+# This is the delivering path, and the rows above were marked read INSIDE the
+# loop before we got here. The hook runtime reads stdout as control JSON only
+# on exit 0, so a non-zero status here does not "re-raise the failure" — it
+# throws away the payload that already cost those rows their unread state. The
+# messages are consumed and never shown, which is a worse outcome than the one
+# the status was protecting against.
+#
+# So delivery and the report are separated: the messages go out with exit 0,
+# and the partial failure is stated inside the payload the operator actually
+# reads. Nothing upstream mistakes a partial poll for a complete one, because
+# the text says which team stopped it and that the rest are still unread.
 if [ -n "$OUTPUT" ]; then
+  if [ "$CLAIM_RC" -ne 0 ]; then
+    OUTPUT+="agmsg: this poll stopped early — team '$CLAIM_FAILED_TEAM' could not be read (status $CLAIM_RC)."$'\n'
+    OUTPUT+="agmsg: teams after it were not checked; their messages stay unread and will be offered again."$'\n'
+  fi
   # Escape for JSON: backslash, double-quote, newlines, tabs (macOS/Linux compatible)
   ESCAPED=$(printf '%s' "$OUTPUT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g' | awk '{if(NR>1) printf "\\n"; printf "%s",$0}')
   cat <<ENDJSON
@@ -218,5 +244,5 @@ if [ -n "$OUTPUT" ]; then
   "reason": "$ESCAPED"
 }
 ENDJSON
-  exit "$CLAIM_RC"
+  exit 0
 fi

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -102,13 +102,20 @@ SHIM
   # still have been emitted, or it is lost forever (never re-offered).
   [[ "$output" == *"early"* ]]
   [[ "$output" != *"in-zteam"* ]]
-  # And emitting is not enough: the hook runtime reads this stdout as control
-  # JSON ONLY on exit 0. The previous version of this test asserted status 5
-  # here, which reads as "the failure is not swallowed" but means the payload
-  # above is discarded by the runtime — the message is marked read and never
-  # shown, which is the loss this test exists to prevent (#658). Asserting the
-  # emission while asserting a status that throws it away made the defect look
-  # like the fix.
+  # And emitting is not enough on its own: the documented hook contract is
+  # that stdout is read as control JSON only on exit 0. (Measured separately,
+  # not by this test: Claude Code 2.1.226 via one-shot `claude -p` with a
+  # synthetic probe hook processed the JSON on exit 0, 1, 2, and 3 alike --
+  # https://github.com/fujibee/agmsg/issues/658. This assertion holds
+  # regardless of which behavior a given runtime actually implements, which
+  # is the point: it pins the script's OWN exit code, not a claim about what
+  # any runtime does with it.) The previous version of this test asserted
+  # status 5 here, which reads as "the failure is not swallowed" but leaves
+  # the delivering path dependent on a non-zero exit for something it cannot
+  # both carry a real payload and safely claim failure with -- see the
+  # `check-inbox.sh` comment at this same branch for why exit 0 is correct
+  # either way. Asserting the emission while asserting a non-zero status made
+  # the defect look like the fix.
   [ "$status" -eq 0 ]
   # The failure is not swallowed either — it moved into the payload, which is
   # the channel that survives. Named team and consequence, so a partial poll

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -102,8 +102,20 @@ SHIM
   # still have been emitted, or it is lost forever (never re-offered).
   [[ "$output" == *"early"* ]]
   [[ "$output" != *"in-zteam"* ]]
-  # The failure is not swallowed: the loop's status is re-raised on exit.
-  [ "$status" -eq 5 ]
+  # And emitting is not enough: the hook runtime reads this stdout as control
+  # JSON ONLY on exit 0. The previous version of this test asserted status 5
+  # here, which reads as "the failure is not swallowed" but means the payload
+  # above is discarded by the runtime — the message is marked read and never
+  # shown, which is the loss this test exists to prevent (#658). Asserting the
+  # emission while asserting a status that throws it away made the defect look
+  # like the fix.
+  [ "$status" -eq 0 ]
+  # The failure is not swallowed either — it moved into the payload, which is
+  # the channel that survives. Named team and consequence, so a partial poll
+  # cannot be read as a complete one.
+  [[ "$output" == *"stopped early"* ]]
+  [[ "$output" == *"zteam"* ]]
+  [[ "$output" == *"stay unread"* ]]
   # testteam delivered-and-read; zteam untouched, so its message re-surfaces.
   [ "$(unread_count alice)" -eq 0 ]
   [ "$(sqlite3 "$DBPATH" "SELECT COUNT(*) FROM messages WHERE team='zteam' AND to_agent='alice' AND read_at IS NULL;" | tr -d '\r')" -eq 1 ]


### PR DESCRIPTION
Closes #658.

## What

`main`'s `check-inbox.sh` marks a team's rows read *inside* its per-team loop, then emits the accumulated payload only after the loop ends. Both of the script's exit points end with `exit "$CLAIM_RC"` — the same status the loop uses to record that a later team's lookup failed. That single value is made to carry two different signals at once: "here is the payload" and "the poll didn't fully complete."

## Why this needs fixing (revised — see "Measurement" below for what changed)

The documented hook contract is that a non-zero exit causes the runtime to discard whatever the process printed to stdout. Read literally, that would mean: when a later team's query fails after an earlier team's messages were already collected, the block-JSON payload containing those messages *is* printed, but the non-zero `$CLAIM_RC` throws it away — and those rows are already `read_at`-stamped from inside the loop, so they'd be gone for good. That was this PR's original motivation, and it turned out not to be what's actually happening today (measured — see below).

What's actually true is arguably more important: **`main` currently runs by depending on behavior that contradicts its own documented contract.** Even on a non-zero exit, the stdout control JSON is processed (measured — Claude Code 2.1.226 processes it on exit `0`, `1`, `2`, and `3` alike). So `main`'s current state stands on behavior its own documentation says shouldn't happen. If that behavior is ever brought into line with the documented contract in a future runtime release, the loss #658 describes would start happening, with no code change on this side to explain why delivery started failing.

This fix removes that dependency rather than betting on which behavior is real: the delivering path now always exits `0`, with any partial-poll failure named inside the payload text instead of carried by the exit code. That holds regardless of which behavior a given runtime actually implements, so `main` stops depending on an area where its documented contract and its observed implementation disagree.

`main`'s own comment on this code names a real, adjacent concern: exiting 0 unconditionally would let "the team lookup failed" read as "nothing to deliver," which is the silent half of #637. That concern is correct and is preserved here — see "Fix" below; it just doesn't apply to the path this PR changes.

## Measurement

The runtime-discard claim above was not established when this PR was first opened — it was carried from the linked issue's own reasoning and the documented hook contract, neither of which had been directly measured at the time. It has since been measured:

- **Claude Code 2.1.226**: exit `0`, `1`, `2`, and `3` all processed the stdout control JSON (exit `2`'s arm showed a different marker/answer display order than the others; every arm processed the JSON, not necessarily in the same presentation). A discriminating control (non-zero exit held constant, stdout removed) showed the effect disappears with the stdout, not with the exit code — so stdout presence, not exit code, is what this runtime actually keys on. Not established beyond this: only a one-shot `claude -p` invocation was tested (not an interactive session), and only a synthetic probe hook (not `scripts/check-inbox.sh` itself). Full arms: https://github.com/fujibee/agmsg/issues/658#issuecomment-5242277607 and https://github.com/fujibee/agmsg/issues/658#issuecomment-5242457240.
- **Copilot command-hook**: not measured. The CLI refused to run under the test policy and the hook never fired in any attempted arm — this is an absence of data, not a negative result. https://github.com/fujibee/agmsg/issues/658#issuecomment-5242595657.

This does not disprove #658/#637 as a future risk — see "Why this needs fixing" above for why the fix still applies regardless of which behavior turns out to be real, on any given runtime, at any given time.

## Positive control

`tests/test_inbox.bats` already had a test constructing exactly this state (a `PATH` shim that fails only the second team's `sqlite3` SELECT), and its own assertion asserted both halves of the contradiction at once: it required the payload to have been emitted (`[[ "$output" == *"early"* ]]`) **and** required `[ "$status" -eq 5 ]` — a non-zero status, which is precisely the shape this PR argues should never carry a real delivery, independent of what any given runtime does with it. A comment on the old assertion read "the failure is not swallowed" — true of the *script's own output*, but silent on what a caller does with that non-zero status.

## Fix

The two exit points are not the same case, and treating them identically is what made this fix necessary:

- **Nothing accumulated** (`OUTPUT` empty): there is no delivery to protect, so the exit status is still free to carry the failure. `[ "$CLAIM_RC" -eq 0 ] || exit "$CLAIM_RC"` runs before the "no new messages" emit — unchanged in spirit from today, and this is the half of #637 the original comment was right about.
- **Messages accumulated** (`OUTPUT` non-empty): this path now always `exit 0`, regardless of `$CLAIM_RC`. When `$CLAIM_RC` is non-zero, two lines naming the failure are appended to `OUTPUT` before the JSON is built — which team stopped the poll, and that later teams stay unread and will be offered again. The failure isn't carried by the exit code on this path anymore; it moves into the channel that's actually read.

`integration/remote` reached the same shape independently while closing #637 there (#649) — same reasoning, different code path (it also carries a separate, larger storage-facade refactor this PR does not touch; only the exit-code/payload-separation idea is shared, not the diff). This PR is written against `main`'s own current code and naming (`CLAIM_RC`), not ported from that branch.

## Tests

`tests/test_inbox.bats`'s existing partial-failure test is corrected to assert what actually happens: `exit 0`, the payload containing `"stopped early"` / the failed team's name / `"stay unread"`, and — unchanged from before — that the first team's message is delivered-and-read while the second team's stays unread via direct `sqlite3` queries against the DB (not just text matching on stdout).

Mutation-tested: reverted just the delivering path's `exit 0` back to `exit "$CLAIM_RC"`, confirmed the test fails on `[ "$status" -eq 0 ]` reproducing the exact defect; restored, green.

`bats tests/test_inbox.bats`: 5/5.

## Urgency

`setup.sh:9` is `REF="${AGMSG_REF:-main}"` — a fresh `curl`/`npx` install pulls `main` by default, so this ships to every new install today regardless of the reasoning above.

## Process note

Base `main`. Per this line's standing rule, **not landing this myself** — landing `main` requires the project maintainer's explicit go-ahead. Re-review requested to cover the revised reasoning above (the earlier clearance was withdrawn against the *original* reasoning, which no longer applies as stated — this is a fresh request against the *current* reasoning, not a re-assertion of the old one).
