### PR TITLE
fix(remote-sync): bridge CURL_CA_BUNDLE into NODE_EXTRA_CA_CERTS

### DIFF
--- a/docs/remote-setup.ja.md
+++ b/docs/remote-setup.ja.md
@@ -257,6 +257,16 @@ Composeスタックはポートを公開し、`compose.yaml` に開発用パス�
 の手前でTLSを終端すること — [`server/README.md` → Compose
 configuration](../server/README.md#compose-configuration) を参照。
 
+### プライベートCAでTLSを終端する場合
+
+手前のリバースプロキシの証明書が公開CA発行でない場合（自己署名や自前CA）、
+`remote.sh` を呼ぶすべてのコマンドに `CURL_CA_BUNDLE=<ca.pemのパス>` を渡す
+こと。`connect` 自体の通信はcurl経由でこの変数をそのまま読む。常駐する同期
+エンジンと`pull`のチーム解決はNodeプロセスで、`remote-sync.sh`経由で起動
+される — `NODE_EXTRA_CA_CERTS`が未設定なら、同じ`CURL_CA_BUNDLE`の値を
+そちらにも渡す。`CURL_CA_BUNDLE`を一度設定すれば両方に効き、curlと異なる
+信頼をNodeに持たせたい場合だけ`NODE_EXTRA_CA_CERTS`を別途指定する。
+
 ### 自前のデータベースを使う場合
 
 すでにPostgreSQLを動かしているなら、それに対してソースからサーバーを起動する。

--- a/docs/remote-setup.ja.md
+++ b/docs/remote-setup.ja.md
@@ -262,10 +262,16 @@ configuration](../server/README.md#compose-configuration) を参照。
 手前のリバースプロキシの証明書が公開CA発行でない場合（自己署名や自前CA）、
 `remote.sh` を呼ぶすべてのコマンドに `CURL_CA_BUNDLE=<ca.pemのパス>` を渡す
 こと。`connect` 自体の通信はcurl経由でこの変数をそのまま読む。常駐する同期
-エンジンと`pull`のチーム解決はNodeプロセスで、`remote-sync.sh`経由で起動
-される — `NODE_EXTRA_CA_CERTS`が未設定なら、同じ`CURL_CA_BUNDLE`の値を
-そちらにも渡す。`CURL_CA_BUNDLE`を一度設定すれば両方に効き、curlと異なる
-信頼をNodeに持たせたい場合だけ`NODE_EXTRA_CA_CERTS`を別途指定する。
+エンジン・`pull`のチーム解決・pull自体のメッセージページ取得は全てNode
+プロセスで、`remote-sync.sh`経由で起動される — `NODE_EXTRA_CA_CERTS`が
+未設定なら、同じ`CURL_CA_BUNDLE`の値をそちらにも渡す。`CURL_CA_BUNDLE`を
+設定すればこれら全てに効き、curlと異なる信頼をNodeに持たせたい場合だけ
+`NODE_EXTRA_CA_CERTS`を別途指定する。
+
+これはコマンド呼び出しごとの挙動で、チームのremote bindingには記憶され
+ない。エンジンがクラッシュしたり再起動した後の`remote.sh sync start <team>`
+も含め、`remote.sh`を実行するシェルには毎回`CURL_CA_BUNDLE`が設定されて
+いる必要がある（最初の`connect`を実行したシェルだけでは足りない）。
 
 ### 自前のデータベースを使う場合
 

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -271,12 +271,18 @@ If the reverse proxy in front of the server carries a certificate from a CA
 that is not publicly trusted (a self-signed cert, or a CA of your own),
 point every `remote.sh` invocation at it with `CURL_CA_BUNDLE=<path-to-ca.pem>`.
 `connect`'s own request goes through curl, which reads that variable
-directly; the persistent sync engine and `pull`'s team lookup are Node
-processes started through `remote-sync.sh`, which passes the same
-`CURL_CA_BUNDLE` value on to Node as `NODE_EXTRA_CA_CERTS` when Node's own
-variable is not already set. Setting `CURL_CA_BUNDLE` is enough for both;
-set `NODE_EXTRA_CA_CERTS` yourself only if Node needs to trust something
-curl does not.
+directly; the persistent sync engine, `pull`'s team lookup, and pull's own
+message-page fetching are all Node processes started through
+`remote-sync.sh`, which passes the same `CURL_CA_BUNDLE` value on to Node
+as `NODE_EXTRA_CA_CERTS` when Node's own variable is not already set.
+Setting `CURL_CA_BUNDLE` is enough for all of these; set
+`NODE_EXTRA_CA_CERTS` yourself only if Node needs to trust something curl
+does not.
+
+This is per-invocation, not remembered by the team's remote binding:
+`CURL_CA_BUNDLE` needs to be set in whatever shell runs `remote.sh`,
+including a later `remote.sh sync start <team>` after the engine crashes or
+the machine reboots — not only the shell that ran the original `connect`.
 
 ### Using your own database instead
 

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -265,6 +265,19 @@ The Compose stack publishes its port and ships a development password in
 before this reaches a network you do not control — see
 [`server/README.md` → Compose configuration](../server/README.md#compose-configuration).
 
+### Terminating TLS with a private CA
+
+If the reverse proxy in front of the server carries a certificate from a CA
+that is not publicly trusted (a self-signed cert, or a CA of your own),
+point every `remote.sh` invocation at it with `CURL_CA_BUNDLE=<path-to-ca.pem>`.
+`connect`'s own request goes through curl, which reads that variable
+directly; the persistent sync engine and `pull`'s team lookup are Node
+processes started through `remote-sync.sh`, which passes the same
+`CURL_CA_BUNDLE` value on to Node as `NODE_EXTRA_CA_CERTS` when Node's own
+variable is not already set. Setting `CURL_CA_BUNDLE` is enough for both;
+set `NODE_EXTRA_CA_CERTS` yourself only if Node needs to trust something
+curl does not.
+
 ### Using your own database instead
 
 If you already run PostgreSQL, start the server from source against it. The

--- a/scripts/remote-sync.sh
+++ b/scripts/remote-sync.sh
@@ -15,6 +15,18 @@ export AGMSG_SYNC_DRIVER="$SCRIPT_DIR/internal/storage-sync-driver.sh"
 NODE_BIN="$(agmsg_resolve_node)"
 export AGMSG_SYNC_NODE_BIN="$NODE_BIN"
 export AGMSG_SYNC_CIPHER_HELPER="$SCRIPT_DIR/internal/sync-cipher.mjs"
+# curl (used by remote.sh's own one-shot connect/pull requests) and Node
+# (used here, and by everything this script execs into) trust a custom CA
+# through two different, unrelated env vars. A user who points --endpoint at
+# a server with a private/self-signed cert and sets only CURL_CA_BUNDLE gets
+# a working `connect`, then a sync engine that fails every cycle forever
+# with no indication why (#744). Node has no equivalent of CURL_CA_BUNDLE, so
+# bridge it: if the caller already trusted curl with a CA bundle and never
+# set Node's own variable, hand Node the same file. An explicit
+# NODE_EXTRA_CA_CERTS is left untouched.
+if [ -z "${NODE_EXTRA_CA_CERTS:-}" ] && [ -n "${CURL_CA_BUNDLE:-}" ]; then
+  export NODE_EXTRA_CA_CERTS="$CURL_CA_BUNDLE"
+fi
 # The engine outlives the command that starts it, so whatever it inherits it
 # holds for as long as it runs — including a descriptor internal to bats,
 # which then waits for an EOF that cannot arrive. Closing 3 and 4 by name

--- a/scripts/remote-sync.sh
+++ b/scripts/remote-sync.sh
@@ -24,7 +24,7 @@ export AGMSG_SYNC_CIPHER_HELPER="$SCRIPT_DIR/internal/sync-cipher.mjs"
 # bridge it: if the caller already trusted curl with a CA bundle and never
 # set Node's own variable, hand Node the same file. An explicit
 # NODE_EXTRA_CA_CERTS is left untouched.
-if [ -z "${NODE_EXTRA_CA_CERTS:-}" ] && [ -n "${CURL_CA_BUNDLE:-}" ]; then
+if [ -z "${NODE_EXTRA_CA_CERTS+x}" ] && [ -n "${CURL_CA_BUNDLE:-}" ]; then
   export NODE_EXTRA_CA_CERTS="$CURL_CA_BUNDLE"
 fi
 # The engine outlives the command that starts it, so whatever it inherits it

--- a/scripts/remote-sync.sh
+++ b/scripts/remote-sync.sh
@@ -24,6 +24,13 @@ export AGMSG_SYNC_CIPHER_HELPER="$SCRIPT_DIR/internal/sync-cipher.mjs"
 # bridge it: if the caller already trusted curl with a CA bundle and never
 # set Node's own variable, hand Node the same file. An explicit
 # NODE_EXTRA_CA_CERTS is left untouched.
+#
+# This is per-invocation, not persisted with the team's remote binding: it
+# only helps when CURL_CA_BUNDLE is set in the environment that runs THIS
+# script, which includes `connect`'s own engine start but not a later
+# `remote.sh sync start <team>` run from a shell that never re-exported it.
+# Restarting the engine after a crash still needs CURL_CA_BUNDLE set again in
+# that shell — nothing here writes the CA path anywhere durable.
 if [ -z "${NODE_EXTRA_CA_CERTS+x}" ] && [ -n "${CURL_CA_BUNDLE:-}" ]; then
   export NODE_EXTRA_CA_CERTS="$CURL_CA_BUNDLE"
 fi

--- a/tests/test_remote_sync_ca_bundle.bats
+++ b/tests/test_remote_sync_ca_bundle.bats
@@ -47,3 +47,11 @@ teardown() { teardown_test_env; }
   [ "$status" -eq 0 ]
   [ "$output" = "NODE_EXTRA_CA_CERTS=<unset>" ]
 }
+
+@test "an explicitly empty NODE_EXTRA_CA_CERTS counts as set and is left untouched" {
+  export CURL_CA_BUNDLE="/tmp/my-ca.pem"
+  export NODE_EXTRA_CA_CERTS=""
+  run bash "$SCRIPTS/remote-sync.sh" status
+  [ "$status" -eq 0 ]
+  [ "$output" = "NODE_EXTRA_CA_CERTS=" ]
+}

--- a/tests/test_remote_sync_ca_bundle.bats
+++ b/tests/test_remote_sync_ca_bundle.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# remote-sync.sh bridges CURL_CA_BUNDLE into NODE_EXTRA_CA_CERTS so a private
+# CA trusted by remote.sh's curl calls (connect) is also trusted by the Node
+# processes remote-sync.sh execs into (the persistent sync engine, and
+# pull's resolve-team lookup). See #744.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+
+  # A stub "node" that prints NODE_EXTRA_CA_CERTS and exits, instead of
+  # running the real engine. AGMSG_NODE (checked before PATH lookup in
+  # lib/node.sh) points remote-sync.sh at it.
+  STUB_NODE="$BATS_TEST_TMPDIR/stub-node"
+  cat > "$STUB_NODE" <<'STUB'
+#!/usr/bin/env bash
+printf 'NODE_EXTRA_CA_CERTS=%s\n' "${NODE_EXTRA_CA_CERTS-<unset>}"
+STUB
+  chmod +x "$STUB_NODE"
+  export AGMSG_NODE="$STUB_NODE"
+}
+
+teardown() { teardown_test_env; }
+
+@test "CURL_CA_BUNDLE is bridged to NODE_EXTRA_CA_CERTS when Node's own var is unset" {
+  export CURL_CA_BUNDLE="/tmp/my-ca.pem"
+  unset NODE_EXTRA_CA_CERTS
+  run bash "$SCRIPTS/remote-sync.sh" status
+  [ "$status" -eq 0 ]
+  [ "$output" = "NODE_EXTRA_CA_CERTS=/tmp/my-ca.pem" ]
+}
+
+@test "an explicit NODE_EXTRA_CA_CERTS is left untouched even when CURL_CA_BUNDLE is set" {
+  export CURL_CA_BUNDLE="/tmp/my-ca.pem"
+  export NODE_EXTRA_CA_CERTS="/tmp/a-different-ca.pem"
+  run bash "$SCRIPTS/remote-sync.sh" status
+  [ "$status" -eq 0 ]
+  [ "$output" = "NODE_EXTRA_CA_CERTS=/tmp/a-different-ca.pem" ]
+}
+
+@test "NODE_EXTRA_CA_CERTS stays unset when neither variable is provided" {
+  unset CURL_CA_BUNDLE
+  unset NODE_EXTRA_CA_CERTS
+  run bash "$SCRIPTS/remote-sync.sh" status
+  [ "$status" -eq 0 ]
+  [ "$output" = "NODE_EXTRA_CA_CERTS=<unset>" ]
+}


### PR DESCRIPTION
Fixes #744.

## What's broken

`remote.sh connect --endpoint https://... <team>` makes its own one-shot request through curl, so `CURL_CA_BUNDLE=<ca.pem>` is enough to trust a private/self-signed server cert there. `connect` then starts the persistent sync engine — a Node process, execed via `remote-sync.sh` — and Node has no equivalent of `CURL_CA_BUNDLE`; it needs `NODE_EXTRA_CA_CERTS`. Set only `CURL_CA_BUNDLE`, and the engine fails every cycle forever with an undiagnosable `{"event":"cycle.error","message":"fetch failed","code":null}`, while `remote.sh status` still reports `connected (engine running)`. `pull`'s team-name lookup and its own message-page fetch go through the same Node path and hit the same wall.

Reproduced end-to-end on two real machines over Tailscale with a self-signed reverse-proxy cert in front of the reference server (details in #744).

## The fix

`remote-sync.sh` is the single choke point every Node-side entry point (`connect`'s engine start, `pull`'s resolve-team and pull-bootstrap, `unlock`'s engine restart) execs through. It now hands its `CURL_CA_BUNDLE` to Node as `NODE_EXTRA_CA_CERTS` when Node's own variable isn't already set — one env var covers curl and Node both. An explicit `NODE_EXTRA_CA_CERTS` (including one explicitly set to `""`) is left alone; that took a `${VAR+x}` presence check rather than `-z "${VAR:-}"`, per review below.

## What it doesn't fix (flagged in docs, not silently claimed)

- **Not persisted.** `CURL_CA_BUNDLE` is read from the environment on every invocation. `remote.sh sync start <team>` after an engine crash or reboot needs it set again in that shell — nothing here writes the CA path anywhere durable. A config-persisted CA binding is a bigger, separate design question (where to store it, whether that's backward-compatible) and felt like it deserved its own discussion rather than riding in on a bugfix.
- **Trust-widening side effect.** Bridging means agmsg's Node engine now trusts whatever `CURL_CA_BUNDLE` happens to be set to globally — a generic curl variable, not agmsg-specific. If someone has it set for an unrelated tool (e.g. a corporate TLS-inspection proxy CA), agmsg's engine picks that up too, silently, the moment they run any `remote.sh` command in that shell. Reusing the existing variable is what makes one setting cover both HTTP clients without inventing new agmsg-specific config; flagging the tradeoff in case a dedicated variable is preferred instead.

## Testing

New `tests/test_remote_sync_ca_bundle.bats` (4 cases: bridges when unset, leaves an explicit value untouched, leaves an explicit *empty* value untouched, no-op when neither var is set) plus the full `test_remote_sync*.bats` / `test_jsonl_remote_sync.bats` suite — 56 passing, 0 failing. Red-green checked: reverting the fix fails the bridging test; reverting the presence-check fails only the explicit-empty case.

Reviewed with Codex (bounded diff review) — caught the `-z` vs presence-check bug, fixed in the second commit.
