### PR TITLE
fix(remote): say a live engine was left behind, not that a pidfile was kept (#731)

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2106,31 +2106,45 @@ cmd_sync_start() {
       echo "agmsg: sync engine for '$team' did not become ready" >&2
       return 1
     fi
-    # The reap could not stop it, and the engine is still running. Measured
-    # cause: under Codex's sandbox this shell is not allowed to signal other
-    # processes at all -- `kill -0` and `kill -TERM` on the engine we just
-    # started both return "Operation not permitted", while the same signal
-    # from outside the sandbox is allowed. _remote_sync_engine_reap_owned
-    # sends TERM then KILL and gives up, which is correct; what was missing is
-    # saying what it leaves behind.
+    # The reap did not stop it, and the engine is still running.
     #
-    # Saying only "the pidfile was preserved" reads as a file kept for
-    # diagnosis. It is a live process that cannot reach the server, retries on
-    # a backoff forever, and is not stoppable from here -- and since the
-    # pidfile only ever names the most recent one, a second attempt leaves the
-    # first with nothing pointing at it. Measured: one after the first failed
-    # attempt, two after the second.
+    # _remote_sync_engine_reap_owned returns non-zero for two different
+    # reasons, and this branch cannot tell them apart:
+    #
+    #   ownership unproven   it returns BEFORE any kill -- deliberately, since
+    #                        it must never signal a pid it cannot prove is ours
+    #   signalling failed    TERM then KILL were sent and it survived
+    #
+    # So the text below says what is known -- it is running, and this command
+    # did not stop it -- and offers the sandbox as the likely reason rather
+    # than the established one. An earlier version asserted "this shell was not
+    # allowed to signal it" unconditionally, which is false on the first path,
+    # and the test here drives exactly that path. Naming a cause the check did
+    # not establish sends the next reader somewhere the evidence does not.
+    #
+    # The Codex observation is still worth carrying, because it produces BOTH:
+    # measured there, `kill -0` and `kill -TERM` on the engine this shell just
+    # started return "Operation not permitted" while the same signal from
+    # outside is allowed -- so ownership cannot be confirmed from in there
+    # either.
+    #
+    # Saying only "the pidfile was preserved" read as a file kept for
+    # diagnosis. It is a live process that cannot reach the server and retries
+    # on a backoff forever -- and since the pidfile only ever names the most
+    # recent one, a second attempt leaves the first with nothing pointing at
+    # it. Measured: one after the first failed attempt, two after the second.
     agmsg_lock_release
     {
-      echo "agmsg: sync engine for '$team' did not become ready, and could not be stopped."
+      echo "agmsg: sync engine for '$team' did not become ready, and this command did not stop it."
       echo "  pid $started_pid is still running. It cannot reach the server -- that is why"
       echo "  it never became ready -- and it will keep retrying on a backoff."
-      echo "  This shell was not allowed to signal it. If the agent is sandboxed"
-      echo "  (Codex is), signals to other processes are blocked inside that sandbox."
+      echo "  This shell either could not confirm the process was ours or could not signal it."
+      echo "  A sandboxed agent (Codex is one) produces both: signals to other processes are"
+      echo "  blocked inside it, and ownership cannot be confirmed from in there either."
       echo "  Nothing is syncing for this team meanwhile."
       echo "  Running sync start again leaves another one behind, and only the newest"
       echo "  is recorded in $(_remote_sync_engine_pidfile "$team")."
-      echo "  Stop it from a shell outside the sandbox:"
+      echo "  Stop it from a shell that can signal it:"
       echo "    kill $started_pid"
       echo "  or give up the binding entirely:"
       echo "    remote.sh disconnect $(agmsg_shq "$team")"

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2102,11 +2102,39 @@ cmd_sync_start() {
   if [ "$ready" -ne 1 ]; then
     if _remote_sync_engine_reap_owned "$team" "$started_pid"; then
       rm -f "$(_remote_sync_engine_pidfile "$team")"
-    else
-      echo "agmsg: failed engine ownership was preserved in its pidfile for diagnosis" >&2
+      agmsg_lock_release
+      echo "agmsg: sync engine for '$team' did not become ready" >&2
+      return 1
     fi
+    # The reap could not stop it, and the engine is still running. Measured
+    # cause: under Codex's sandbox this shell is not allowed to signal other
+    # processes at all -- `kill -0` and `kill -TERM` on the engine we just
+    # started both return "Operation not permitted", while the same signal
+    # from outside the sandbox is allowed. _remote_sync_engine_reap_owned
+    # sends TERM then KILL and gives up, which is correct; what was missing is
+    # saying what it leaves behind.
+    #
+    # Saying only "the pidfile was preserved" reads as a file kept for
+    # diagnosis. It is a live process that cannot reach the server, retries on
+    # a backoff forever, and is not stoppable from here -- and since the
+    # pidfile only ever names the most recent one, a second attempt leaves the
+    # first with nothing pointing at it. Measured: one after the first failed
+    # attempt, two after the second.
     agmsg_lock_release
-    echo "agmsg: sync engine for '$team' did not become ready" >&2
+    {
+      echo "agmsg: sync engine for '$team' did not become ready, and could not be stopped."
+      echo "  pid $started_pid is still running. It cannot reach the server -- that is why"
+      echo "  it never became ready -- and it will keep retrying on a backoff."
+      echo "  This shell was not allowed to signal it. If the agent is sandboxed"
+      echo "  (Codex is), signals to other processes are blocked inside that sandbox."
+      echo "  Nothing is syncing for this team meanwhile."
+      echo "  Running sync start again leaves another one behind, and only the newest"
+      echo "  is recorded in $(_remote_sync_engine_pidfile "$team")."
+      echo "  Stop it from a shell outside the sandbox:"
+      echo "    kill $started_pid"
+      echo "  or give up the binding entirely:"
+      echo "    remote.sh disconnect $(agmsg_shq "$team")"
+    } >&2
     return 1
   fi
   agmsg_lock_release

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -392,9 +392,15 @@ write_unownable_ps_fixture() {
 
   # What the operator is told. `grep -q`, not `[[ ]]`: a non-last `[[ ]]` is
   # not enforced on bash 3.2 (#670).
-  printf '%s\n' "$output" | grep -q -F "did not become ready, and could not be stopped"
+  printf '%s\n' "$output" | grep -q -F "did not become ready, and this command did not stop it"
   printf '%s\n' "$output" | grep -q -F "pid $child_pid is still running"
   printf '%s\n' "$output" | grep -q -F "keep retrying"
+  # This test drives the ownership-unproven path, where no signal is ever sent.
+  # The text must not claim signalling was refused -- that is the other branch,
+  # and asserting a cause this run did not establish is the defect the wording
+  # was changed for (review on #750).
+  printf '%s\n' "$output" | grep -q -F "either could not confirm the process was ours or could not signal it"
+  refute grep -q -F "was not allowed to signal it" <<<"$output"
   # That repeating the command accumulates them, and that the pidfile only
   # records the newest -- the part that turns one stuck engine into several.
   printf '%s\n' "$output" | grep -q -F "leaves another one behind"

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -347,3 +347,61 @@ remember_engine_pid() {
   [[ "$output" == *"team 'testteam' is disconnected"* ]]
   [ ! -e "$TEST_SKILL_DIR/run/remote-sync.testteam.pid" ]
 }
+
+# A ps fixture that never confirms ownership: every argv query answers with
+# something that is not this team's engine. `_remote_sync_engine_status` then
+# reports the pid as not-running, so `_remote_sync_engine_reap_owned` returns
+# without signalling -- by design, since it must never signal a pid it cannot
+# prove it owns.
+#
+# That models what a sandbox does. Measured under Codex's: `kill -0` and
+# `kill -TERM` on the engine this shell just started both return "Operation
+# not permitted", while the same signal from outside is allowed. The engine
+# survives, and ownership cannot be established from in there either.
+write_unownable_ps_fixture() {
+  local fake_bin="$TEST_SKILL_DIR/fake-ps-unownable"
+  mkdir -p "$fake_bin"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'args=0' \
+    'case " $* " in *" -o args= "*) args=1 ;; esac' \
+    '[ "$args" = 1 ] || exec /bin/ps "$@"' \
+    "printf '%s\\n' 'sleep 30'" > "$fake_bin/ps"
+  chmod +x "$fake_bin/ps"
+  printf '%s\n' "$fake_bin"
+}
+
+@test "sync start says a live engine was left behind when it cannot be reaped (#731)" {
+  local fake_node="$TEST_SKILL_DIR/fake-node-unreapable" fake_bin child_pid_file child_pid
+  child_pid_file="$TEST_SKILL_DIR/unreapable-child.pid"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'echo "$$" > "$AGMSG_TEST_CHILD_PID_FILE"' \
+    'while :; do sleep 1; done' > "$fake_node"
+  chmod +x "$fake_node"
+  fake_bin="$(write_unownable_ps_fixture)"
+
+  run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" \
+    AGMSG_TEST_CHILD_PID_FILE="$child_pid_file" \
+    bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -ne 0 ]
+
+  child_pid="$(cat "$child_pid_file")"
+  # The premise: it really is still running. Without this the assertions below
+  # would pass just as well against a message about a process that had died,
+  # which is the thing the old wording could not distinguish.
+  kill -0 "$child_pid"
+
+  # What the operator is told. `grep -q`, not `[[ ]]`: a non-last `[[ ]]` is
+  # not enforced on bash 3.2 (#670).
+  printf '%s\n' "$output" | grep -q -F "did not become ready, and could not be stopped"
+  printf '%s\n' "$output" | grep -q -F "pid $child_pid is still running"
+  printf '%s\n' "$output" | grep -q -F "keep retrying"
+  # That repeating the command accumulates them, and that the pidfile only
+  # records the newest -- the part that turns one stuck engine into several.
+  printf '%s\n' "$output" | grep -q -F "leaves another one behind"
+  # And a way out that works from where the operator actually is.
+  printf '%s\n' "$output" | grep -q -F "kill $child_pid"
+  printf '%s\n' "$output" | grep -q -F "remote.sh disconnect 'testteam'"
+
+  kill -9 "$child_pid" 2>/dev/null || true
+  wait "$child_pid" 2>/dev/null || true
+}


### PR DESCRIPTION
Closes #731.

When `sync start` cannot reap the engine it just started, that engine keeps running. The message said only that its pidfile was **"preserved for diagnosis"** — which reads as a file kept for later. It is a live process that cannot reach the server, retries on a backoff forever, and cannot be stopped from where the operator is standing.

## Measured cause

On the destination with #735 in, under Codex's sandbox:

```
inside   kill -0 <engine>      Operation not permitted
         kill -TERM <engine>   Operation not permitted, and the process survives
outside  kill -0 <engine>      permitted
```

`_remote_sync_engine_reap_owned` sends TERM then KILL and gives up. **It is right to** — it must never signal a pid whose ownership it cannot establish, and inside the sandbox it cannot establish anything. Nothing about the reap changes here.

## It accumulates

Measured before touching anything, same isolated install, same sandbox, `sync start` twice:

| | engines | pidfile |
|---|---|---|
| after the first failure | 1 | that one |
| after the second | **2** | **only the second** |

So the first is not merely stuck — nothing on disk points at it any more.

## What changed

Only the branch where the reap failed. The message now names the pid, says it is **still running**, why it never became ready, why this shell could not stop it, that repeating the command leaves another one, and two ways out that work from outside the sandbox:

```
agmsg: sync engine for 't731' did not become ready, and could not be stopped.
  pid 4790 is still running. It cannot reach the server -- that is why
  it never became ready -- and it will keep retrying on a backoff.
  This shell was not allowed to signal it. If the agent is sandboxed
  (Codex is), signals to other processes are blocked inside that sandbox.
  Nothing is syncing for this team meanwhile.
  Running sync start again leaves another one behind, and only the newest
  is recorded in <skill>/run/remote-sync.t731.pid.
  Stop it from a shell outside the sandbox:
    kill 4790
  or give up the binding entirely:
    remote.sh disconnect 't731'
```

Shape follows what #735 landed: what is not happening, then what to do. `sync stop` is not offered because there is no such subcommand — `cmd_sync` accepts `start` and nothing else, so `disconnect` is the only way to give up a binding.

**The reap-succeeded path is untouched**, including its message and its removal of the pidfile.

## Test

Drives the branch with a ps fixture that never confirms ownership — the same shape the sandbox produces: the process is alive, and this shell cannot prove it owns it.

It asserts **the child is still running** before asserting anything about the text. That is the premise the old wording could not distinguish: a message about a process that had already died would have satisfied every string check.

Mutation: reverting to the old wording turns it red on the first assertion.

**19/19** across `test_remote_status_liveness.bats` and `test_remote_engine_start_refusal.bats` on `/bin/bash` 3.2.

## Not addressed here

Why the sandbox blocks the signal is not a thing this can fix, and neither is the accumulation itself — an engine that cannot be signalled cannot be cleaned up by the process that started it. This makes the state visible and gives a way out; it does not prevent it.


---

Declared reviewers: 1

A count, not a name: the handles gate refuses names, and the count is what the landing gate is checked against.

