### PR TITLE
chore: take internal seat names out of the published tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,7 +285,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 - Add supported-agents logo strip
-- List hermes in the --agent-type help (co1 nit)
+- List hermes in the --agent-type help (nit)
 - Add docs/plugins.md + README section + plugins/ drop-in dir
 - Refresh manifest table + paths for the 1.1.0 layout
 - Lead Quick Start with npx, the zero-clone install path

--- a/app/src-tauri/src/agent_state.rs
+++ b/app/src-tauri/src/agent_state.rs
@@ -109,7 +109,7 @@ impl DetectionTracker {
 /// the whole ~20-line window), these hints are only meaningful confined to
 /// the very bottom of the screen — matching them anywhere in the wider
 /// window risks tripping on ordinary scrollback that happens to mention
-/// one of the same words (co1 review, #384/grok).
+/// one of the same words (review, #384/grok).
 fn bottom_non_empty_lines<'a>(lines: &[&'a str], n: usize) -> Vec<&'a str> {
     let mut result: Vec<&'a str> = lines
         .iter()
@@ -145,7 +145,7 @@ fn grok_working_line(line: &str) -> bool {
 
 // grok's footer-hint dialogs need AND logic and bottom-two-line scoping
 // that plain substring matching over the whole flattened tail can't
-// express (co1 review, #384/grok) — TailBuffer::detection_tail evaluates
+// express (review, #384/grok) — TailBuffer::detection_tail evaluates
 // them against the real, still-line-structured text (before flattening
 // loses that structure) and bakes the result into these sentinels, which
 // classify() then just treats as two more literal patterns like any other
@@ -551,7 +551,7 @@ fn strip_ansi(input: &str) -> (String, Option<String>) {
                             // "response… 0.0s0.0s [stop]ccancl" was really
                             // three separate lines/regions). ANY row change
                             // — forward OR backward — gets a single
-                            // separator newline (co1 review: an earlier
+                            // separator newline (review: an earlier
                             // version only handled forward jumps, so an
                             // animation that repeatedly redraws the same
                             // upper panel — jump down, jump back up, jump
@@ -857,7 +857,7 @@ Would you like to proceed?\n\
 
     #[test]
     fn cursor_position_backward_row_jumps_also_get_a_newline() {
-        // co1 review, PR #395: an earlier version only inserted a newline
+        // review, PR #395: an earlier version only inserted a newline
         // for FORWARD row jumps, leaving `row` stale on a backward one —
         // grok's real "thinking" animation jumps back up to redraw an
         // earlier panel constantly, and that stale `row` meant the
@@ -1033,7 +1033,7 @@ Would you like to proceed?\n\
 
         // Only one of the three — a real permission dialog needs all of
         // them, so a lone mention (e.g. in ordinary help text) must NOT
-        // trigger Blocked (co1 review: this was the actual false-positive
+        // trigger Blocked (review: this was the actual false-positive
         // risk with a flat OR-list of single fragments).
         let mut partial = TailBuffer::default();
         partial.push(b"press Ctrl+o:always-approve to skip confirmations\nready\n");
@@ -1044,7 +1044,7 @@ Would you like to proceed?\n\
     fn grok_permission_hints_outside_the_bottom_two_lines_do_not_block() {
         // The three hints appear, but scrolled up out of the bottom two
         // lines by later, unrelated output — must not still read as
-        // Blocked (co1 review: herdr scopes this to bottom_non_empty_lines
+        // Blocked (review: herdr scopes this to bottom_non_empty_lines
         // (2), not the whole visible window).
         let mut tail = TailBuffer::default();
         tail.push(b"1/3:select  |  Ctrl+o:always-approve  |  Ctrl+c:cancel\nsome later normal output\nready\n");

--- a/app/src/App.test.ts
+++ b/app/src/App.test.ts
@@ -39,7 +39,7 @@ describe("shouldSuppressClickAfterDrag", () => {
   });
 
   it("does not suppress a click on a DIFFERENT pane, even immediately after", () => {
-    // Regression (co1, PR #481, 3rd round): a global timestamp with no pane
+    // Regression (#481, 3rd round): a global timestamp with no pane
     // identity would suppress a deliberate click on some other pane header
     // too, just because it lands within the window of an unrelated pane's
     // drag finishing.
@@ -71,7 +71,7 @@ describe("shellPaneFrom", () => {
     // Regression: an earlier version defaulted to "bash" here when the
     // async login_shell fetch hadn't landed yet, which broke on Windows
     // (no bash) and wasn't the user's actual login shell even on unix
-    // (co1 review, PR #431).
+    // (review, PR #431).
     expect(shellPaneFrom(null, "shell-1", "Shell", undefined)).toBeNull();
   });
 
@@ -102,7 +102,7 @@ describe("shellTabStillValid", () => {
   it("goes invalid when the user switched teams during the await", () => {
     // Regression: openShellTab used to commit the new window under the
     // stale (closed-over) team regardless, silently hiding it since only
-    // the current team's windows render (co1, PR #431).
+    // the current team's windows render (#431).
     expect(shellTabStillValid("teamB", "teamA")).toBe(false);
   });
 });
@@ -119,7 +119,7 @@ describe("shellSplitStillValid", () => {
 
   it("goes false when the target window was closed during the await", () => {
     // Regression: openShellInWindow used to commit anyway, leaving an
-    // orphaned pane and `active` pointing at a nonexistent window id (co1,
+    // orphaned pane and `active` pointing at a nonexistent window id (review,
     // PR #431).
     expect(shellSplitStillValid([{ id: "w-2", team: "teamA" }], "w-1", "teamA", "teamA")).toBe(false);
   });
@@ -129,11 +129,11 @@ describe("shellSplitStillValid", () => {
   });
 
   it("goes false when the team switched even though the window is still open", () => {
-    // Regression (2nd co1 round): the target window can survive the await
+    // Regression (2nd round): the target window can survive the await
     // untouched but now belong to the team the user navigated away from —
     // it's a hidden tab at that point, so splitting into it and activating
     // it reproduces the same hidden-active bug shellTabStillValid guards
-    // against on the new-tab path (co1, PR #431).
+    // against on the new-tab path (#431).
     expect(shellSplitStillValid(windows, "w-1", "teamB", "teamA")).toBe(false);
   });
 });
@@ -181,7 +181,7 @@ describe("joinDroppedPaths", () => {
   });
 
   it("rejects the WHOLE drop — returns null, not a sanitized string — when any path has a control character", () => {
-    // Regression (co1, PR #481): a crafted filename containing a newline
+    // Regression (#481): a crafted filename containing a newline
     // written raw to the PTY would submit whatever's on the current prompt
     // line the instant the file is dropped. Rejecting outright (not
     // stripping the bad byte) avoids silently writing a DIFFERENT path than

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -117,7 +117,7 @@ export type LoginShellInfo = { cmd: string; args: string[]; home: string };
 // fallback: an earlier version defaulted to bash when `info` was still
 // unresolved, which raced the mount-effect fetch (app just launched, user
 // immediately hits "+") — broken on Windows (no bash), and not the user's
-// actual login shell even on unix (co1 review, PR #431). Pure so the
+// actual login shell even on unix (review, PR #431). Pure so the
 // no-fallback contract is unit-testable without mounting the app.
 export function shellPaneFrom(info: LoginShellInfo | null, id: string, label: string, cwd: string | undefined): Pane | null {
   if (!info) return null;
@@ -128,7 +128,7 @@ export function shellPaneFrom(info: LoginShellInfo | null, id: string, label: st
 // getLoginShell await — false if the user switched teams while it was in
 // flight. Committing anyway would silently add a window under the stale
 // team (hidden — only the current team's windows render) while `active`
-// pointed at it (co1, PR #431).
+// pointed at it (#431).
 export function shellTabStillValid(currentTeam: string, requestedTeam: string): boolean {
   return currentTeam === requestedTeam;
 }
@@ -142,7 +142,7 @@ export function shellTabStillValid(currentTeam: string, requestedTeam: string): 
 // hidden-active bug openShellTab's shellTabStillValid guards against — a
 // window's `team` never changes after creation, so if the current team no
 // longer matches `requestedTeam` the window can't be a live tab regardless
-// of whether it's still present in `windows` (co1, PR #431).
+// of whether it's still present in `windows` (#431).
 export function shellSplitStillValid(
   windows: ReadonlyArray<Pick<Window, "id" | "team">>,
   windowId: string,
@@ -160,7 +160,7 @@ export function shellSplitStillValid(
 // dropped; ESC-prefixed bytes are terminal control sequences, not text.
 // The whole drop is rejected rather than stripping the offending bytes:
 // stripping would silently turn the dropped path into a DIFFERENT, wrong
-// path instead of the one actually dropped (co1 review, PR #481).
+// path instead of the one actually dropped (review, PR #481).
 const DROP_PATH_CONTROL_CHAR_RE = /[\u0000-\u001f\u007f]/;
 
 export function hasUnsafeDropPath(paths: string[]): boolean {
@@ -274,7 +274,7 @@ const CLICK_SUPPRESS_WINDOW_MS = 300;
 // just when it ended. Scoping by pane matters: a global timestamp alone
 // would suppress a deliberate click on some OTHER pane header too, just
 // because it happens to land within the window of an unrelated pane's drag
-// finishing (co1 review, PR #481, 3rd round).
+// finishing (review, PR #481, 3rd round).
 export type DragFinishInfo = { paneId: string; finishedAt: number } | null;
 
 // Whether the pane-header's onClick should treat an incoming click as the
@@ -286,7 +286,7 @@ export type DragFinishInfo = { paneId: string; finishedAt: number } | null;
 // even one that lands inside the same window, isn't ALSO wrongly
 // suppressed; an unbounded "consume exactly one click" native listener had
 // its own problems (see git history), but a per-pane bounded ref without
-// consuming still over-suppresses. Pure so the co1-requested regressions
+// consuming still over-suppresses. Pure so the review-requested regressions
 // are unit-testable without simulating real pointer/click event sequences.
 export function shouldSuppressClickAfterDrag(dragFinish: DragFinishInfo, paneId: string, now: number): boolean {
   return dragFinish !== null && dragFinish.paneId === paneId && now - dragFinish.finishedAt < CLICK_SUPPRESS_WINDOW_MS;
@@ -565,7 +565,7 @@ export default function App() {
   // The stale-context guard openShellTab/openShellInWindow re-check after
   // their getLoginShell await (see below) — a real gap now that login_shell
   // resolution can take real time, during which the user can switch teams
-  // or close the target tab (co1, PR #431).
+  // or close the target tab (#431).
   const teamRef = useRef<string>("");
   teamRef.current = team;
   // The current tab/window id, for the external-file-drop handler (mount-
@@ -578,7 +578,7 @@ export default function App() {
   // below) if this component ever unmounts mid-gesture — App itself never
   // does in practice (root component, lives for the whole session), but the
   // event listeners it registers live on `document`/`window`, outside
-  // React's own teardown, so nothing else would ever clear them (co1
+  // React's own teardown, so nothing else would ever clear them (review
   // review, PR #481).
   const activePaneDragCancelRef = useRef<(() => void) | null>(null);
   useEffect(() => {
@@ -594,7 +594,7 @@ export default function App() {
   // drag. Scoped per-pane and consumed on use, not a global unbounded
   // "consume the next click" listener or a bare timestamp — both over-
   // suppress in different ways (see shouldSuppressClickAfterDrag's own doc
-  // and git history; co1 review, PR #481, rounds 2 and 3).
+  // and git history; review, PR #481, rounds 2 and 3).
   const dragJustFinishedRef = useRef<DragFinishInfo>(null);
   const applyAgentState = useCallback((paneId: string, state: RawState) => {
     setPaneStatus((current) => applyStateChange(current, paneId, state));
@@ -616,7 +616,7 @@ export default function App() {
 
   // Which divider (by dividerDragKey, below) is currently being dragged —
   // state, not a captured DOM element, so the highlight survives a
-  // grid-segment transpose remounting the divider mid-drag (co1 review,
+  // grid-segment transpose remounting the divider mid-drag (review,
   // PR #390).
   const [draggingDividerKey, setDraggingDividerKey] = useState<string | null>(null);
 
@@ -696,7 +696,7 @@ export default function App() {
   // hasn't landed yet (real race: app just launched, user immediately hits
   // "+" or "Open shell"). Returns null on failure — callers must NOT
   // fall back to a guessed shell (e.g. "bash"): broken on Windows, and not
-  // the user's actual login shell even on unix (co1 review, PR #431).
+  // the user's actual login shell even on unix (review, PR #431).
   const getLoginShell = useCallback(async (): Promise<LoginShellInfo | null> => {
     if (loginShell) return loginShell;
     try {
@@ -1201,7 +1201,7 @@ export default function App() {
   // poking around — not agmsg's business). Awaits getLoginShell (see the
   // mount-effect section above) rather than reading `loginShell` state
   // directly — null means it's genuinely unresolved/unresolvable, at which
-  // point shellPaneFrom itself refuses to guess a fallback shell (co1, PR
+  // point shellPaneFrom itself refuses to guess a fallback shell (review, PR
   // #431); getLoginShell has already surfaced startupError in that case, so
   // callers just bail out with no pane. cwd defaults to the current team's
   // project dir (teamProject) rather than wherever the shell would
@@ -1222,7 +1222,7 @@ export default function App() {
   // a microtask) — the user can switch teams while it's in flight, which
   // would otherwise add the new window under the STALE `team` closed over
   // at click time (hidden, since only the current team's windows render)
-  // while `active` still points at it (co1, PR #431). Bail out rather than
+  // while `active` still points at it (#431). Bail out rather than
   // create an orphaned, invisible tab if the team moved on.
   const openShellTab = useCallback(async () => {
     const requestedTeam = team;
@@ -1243,7 +1243,7 @@ export default function App() {
   // pane, `active` pointing at a dead id), or the team can just switch
   // while the window itself stays open — it's now a hidden tab under the
   // team the user navigated away from, so splitting into it and activating
-  // it reproduces the same hidden-active bug (co1, PR #431).
+  // it reproduces the same hidden-active bug (#431).
   const openShellInWindow = useCallback(
     async (windowId: string) => {
       const requestedTeam = team;
@@ -1363,7 +1363,7 @@ export default function App() {
   // this is a plain click, and the existing onClick handler on the same
   // button (unchanged) fires normally once pointerup lands back on it.
   //
-  // Lifecycle robustness (co1 review, PR #481 — the first version only
+  // Lifecycle robustness (review, PR #481 — the first version only
   // listened for pointermove/pointerup/Escape):
   // - setPointerCapture on the source button, released on cleanup: without
   //   it, the pointer leaving the OS window before release means pointerup
@@ -1382,7 +1382,7 @@ export default function App() {
   //   gesture as a drag. dragJustFinishedRef (declared above, checked by
   //   the pane-header's own onClick) is a per-pane, short bounded window
   //   rather than an unbounded "consume the next click" listener — see its
-  //   own doc for why (co1 review, PR #481, 2nd round: a drag that ends via
+  //   own doc for why (review, PR #481, 2nd round: a drag that ends via
   //   blur/pointercancel/unmount with the pointer released outside the app
   //   never gets a matching click to consume at all, so a pending listener
   //   would sit on the button forever and wrongly swallow the next,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -578,8 +578,8 @@ export default function App() {
   // below) if this component ever unmounts mid-gesture — App itself never
   // does in practice (root component, lives for the whole session), but the
   // event listeners it registers live on `document`/`window`, outside
-  // React's own teardown, so nothing else would ever clear them (review
-  // review, PR #481).
+  // React's own teardown, so nothing else would ever clear them
+  // (review, PR #481).
   const activePaneDragCancelRef = useRef<(() => void) | null>(null);
   useEffect(() => {
     return () => activePaneDragCancelRef.current?.();

--- a/app/src/paneTree.test.ts
+++ b/app/src/paneTree.test.ts
@@ -597,7 +597,7 @@ describe("transposeGrid", () => {
     expect(transposeGrid(transposeGrid(tree))).toEqual(tree);
   });
 
-  // co1 review: self-inverse does NOT generalize past 2 columns/rows — a
+  // review: self-inverse does NOT generalize past 2 columns/rows — a
   // transposed 3-column grid's own top-level children no longer match each
   // other (a 1-level leaf-pair vs. a 2-level chain), so a second
   // transposeGrid call is just a no-op rather than reconstructing the
@@ -658,7 +658,7 @@ describe("transposeGrid", () => {
 });
 
 describe("dividerDragKey", () => {
-  it("stays the same across a grid-segment transpose (regression, co1 review PR #390)", () => {
+  it("stays the same across a grid-segment transpose (regression, review PR #390)", () => {
     // A 3-column aligned grid: transposing a grid-segment divider from one
     // of these turns the OTHER segments' dividers from "grid-segment" into
     // "single" (a 2x2 grid stays grid-shaped either way — this needed 3+

--- a/app/src/paneTree.ts
+++ b/app/src/paneTree.ts
@@ -165,7 +165,7 @@ function gridSegments(
     // OTHER axis. E.g. for row(colChain, colChain), a column's eventual
     // row-node spans that column's own width but the WHOLE original height
     // (both rows combined), not just the one row segRect came from — using
-    // segRect's height directly here would be wrong (co1/self-review catch:
+    // segRect's height directly here would be wrong (self-review catch:
     // the naive version undersized every segment's drag bounds to just its
     // own row/column instead of the full space its transposed node owns).
     const bounds: PaneRect =
@@ -208,7 +208,7 @@ export function collectDividers(node: SplitNode, rect: PaneRect = FULL_RECT, pat
 }
 
 /**
- * A divider's identity across a grid-segment transpose (co1 review, PR
+ * A divider's identity across a grid-segment transpose (review, PR
  * #390): grabbing a grid-segment divider transposes its aligned grid at
  * drag-start (see transposeGrid's own doc), and for 3+ segment grids that
  * changes collectDividers' shape from "grid" divider keys to "single"
@@ -257,7 +257,7 @@ function zipPairs(a: SplitNode, b: SplitNode, pairAxis: SplitAxis, pairRatio: nu
  * just that one seam into its own independent node, rather than needing
  * every divider to already be independently addressable up front.
  *
- * Self-inverse ONLY for the 2-column/2-row case (co1 review — the doc here
+ * Self-inverse ONLY for the 2-column/2-row case (review — the doc here
  * previously overclaimed this generally): transposing
  * row(col(1,2;c),col(3,4;c);r) twice does return the original tree, because
  * the transposed result col(row(1,3;r),row(2,4;r);c) is ITSELF a valid
@@ -348,7 +348,7 @@ function contains(node: SplitNode, paneId: string): boolean {
  * dragged pane, so there is nothing to move.
  *
  * A missing `targetPaneId` (not found anywhere in `node`) is also a no-op,
- * returning `node` unchanged (co1 review — was missing): without this
+ * returning `node` unchanged (review — was missing): without this
  * guard, splicing `newPaneId` out first and then failing to find
  * `targetPaneId` to replace would silently drop the dragged pane from the
  * tree entirely, since `replaceLeaf` is itself a no-op when the target

--- a/bin/agmsg.js
+++ b/bin/agmsg.js
@@ -66,7 +66,7 @@ function readVersion() {
 // It has to name what to type instead.
 //
 // The verb→script map is a HINT, and the two halves of that are tested
-// differently (review P1, co1):
+// differently (review P1):
 //
 //   NOT promised: that it is complete. This package does not ship scripts/,
 //     so it cannot enumerate them. A verb missing from here falls through to
@@ -92,7 +92,7 @@ const SCRIPT_FOR_VERB = {
 
 // The default install location. Checked because this package's whole job is
 // to install agmsg, so a person who has never run it reaches this branch too
-// (review P1, co1) — and for them every path below is a command that fails.
+// (review P1) — and for them every path below is a command that fails.
 // Advice that assumes the install is advice they cannot follow.
 function defaultSkillDir() {
   return path.join(os.homedir(), '.agents', 'skills', 'agmsg');
@@ -115,7 +115,7 @@ function printNotACommand(verb, skillDirForTest) {
   const scriptsDir = path.join(dir, 'scripts');
 
   // The contract differs by what is about to be printed, and that is the
-  // point (review P1, co1):
+  // point (review P1):
   //
   //   naming ONE script  -> that script file must exist. The repo-side pin
   //     proves the map matches THIS repo; it says nothing about the tree on

--- a/docs/design/ref/adaptive-sync-catchup-v1.md
+++ b/docs/design/ref/adaptive-sync-catchup-v1.md
@@ -226,7 +226,7 @@ instead of spinning.
   dominates (~5 ms/msg measured → ~8 min for 90k; 2–4× on slower/Windows
   hardware), so a progress indicator over batches acked is enough; no
   background/suspend-resume requirement. Seal parallelization is deferred until
-  the separated path is measured (and cc2's Windows numbers land).
+  the separated path is measured (and a reviewer's Windows numbers land).
 
 ## Scope / ownership
 

--- a/docs/design/ref/adaptive-sync-catchup-v1.md
+++ b/docs/design/ref/adaptive-sync-catchup-v1.md
@@ -226,7 +226,7 @@ instead of spinning.
   dominates (~5 ms/msg measured → ~8 min for 90k; 2–4× on slower/Windows
   hardware), so a progress indicator over batches acked is enough; no
   background/suspend-resume requirement. Seal parallelization is deferred until
-  the separated path is measured (and a reviewer's Windows numbers land).
+  the separated path is measured (and the Windows measurements land).
 
 ## Scope / ownership
 

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -29,7 +29,7 @@ _sqlite_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
 # (pipefail), so a backend failure surfaces as a non-zero return instead of
 # being swallowed by tr's exit 0. The backend's error text goes to stderr (a
 # separate fd — it never pollutes the JSONL on stdout) so failures are
-# debuggable, per §2.1 framing (#203 (1) / co1 review).
+# debuggable, per §2.1 framing (#203 (1) / review).
 _sqlite_data() {
   ( set -o pipefail; agmsg_sqlite "$(_sqlite_db "$1")" "$2" | tr -d '\r' )
 }
@@ -401,7 +401,7 @@ storage_history() {
   # <agent> is optional: consume a leading NON-flag argument as the agent (an
   # empty string is allowed and also means team-wide). A leading --flag means no
   # agent was given. This is what makes `storage_history <team> --limit N` and
-  # `storage_history <team>` parse correctly per the §2.1 contract (co1 review).
+  # `storage_history <team>` parse correctly per the §2.1 contract (review).
   if [ $# -gt 0 ] && [ "${1#-}" = "$1" ]; then agent="$1"; shift; fi
   while [ $# -gt 0 ]; do case "$1" in --limit) limit="$2"; shift 2 ;; *) shift ;; esac; done
   case "$limit" in ''|*[!0-9]*) limit="" ;; esac

--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -190,7 +190,7 @@ EOF
   # close here directly would shut descriptors belonging to the shell that
   # sourced us. The subshell is what makes it safe: the close applies to the
   # forked child, which is the process that goes on to become the bridge, and
-  # the parent keeps everything it had (review P1, co1).
+  # the parent keeps everything it had (review P1).
   #
   # The `3>&- 4>&-` stays on the spawn line as well. test_spawn_fd_guard.bats
   # requires it there and says why: a file-level close can sit inside a

--- a/scripts/drivers/types/codex/codex-record-session.sh
+++ b/scripts/drivers/types/codex/codex-record-session.sh
@@ -159,7 +159,7 @@ if [ -z "$thread" ]; then
   # nothing, which is what happens today.
   #
   # ${HOME:-} so an unset HOME under `set -u` is a silent no-op (empty -> the
-  # dir check below fails -> fresh), not an unbound-variable abort (co1 nit).
+  # dir check below fails -> fresh), not an unbound-variable abort (nit).
   sessions_dir="${HOME:-}/.codex/sessions"
   if [ -n "${HOME:-}" ] && [ -d "$sessions_dir" ]; then
     # Distinct thread ids whose session_meta cwd (canonicalized -- codex records

--- a/scripts/internal/migrate-team-store.sh
+++ b/scripts/internal/migrate-team-store.sh
@@ -236,7 +236,7 @@ if [ -e "$DEST" ]; then
   exit 1
 fi
 
-# #695 review (co1): the destination's sqlite_sequence floor below is set
+# #695 review: the destination's sqlite_sequence floor below is set
 # from MAX(local_position) over this team's copied cursors. SQLite stores
 # whatever type a column is given even when it's declared INTEGER (the same
 # looseness "a cursor that is not an integer is refused" already guards on

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -405,7 +405,7 @@ function ipv6Groups(host) {
 // unbound: revert this function to its old inline loopback list and every such
 // test stays green while continued sync refuses LAN addresses again. That is
 // the failure this whole change exists to prevent, so the test drives it from
-// here (#717, co1 review).
+// here (#717, review).
 export function connectedBinding(value, team) {
   const binding = value?.remote_binding;
   if (value?.name !== team || !binding || typeof binding !== "object" ||
@@ -1320,7 +1320,7 @@ export function validateErrorBinding(config, status, body) {
   // carries the protocol envelope and omits the identity is malformed for that
   // stage, and the old code refused it. Keeping that refusal is why this is not
   // simply "check when identity is present": the inversion must not loosen a
-  // path (co1 review).
+  // path (review).
   const preResolution = status === 400 || status === 401 || status === 426;
   const claimsProtocol = body?.protocol_version !== undefined;
   if (claimsIdentity || (!preResolution && claimsProtocol)) validateBinding(config, body);

--- a/scripts/internal/team-list.py
+++ b/scripts/internal/team-list.py
@@ -22,7 +22,7 @@ config.json is locally written by our own scripts, but this is a
 read-only listing command with no reason to guess at a malformed file's
 meaning rather than skip it outright).
 
-Fail-closed in --format json specifically (co1 delta review): --scope all
+Fail-closed in --format json specifically (delta review): --scope all
 is the authority a no-arg cloud connect flow uses to decide whether its
 choice is ambiguous (one team vs several). Silently returning a partial
 list as if it were the complete one — because one team's config failed

--- a/scripts/lib/require-python3.sh
+++ b/scripts/lib/require-python3.sh
@@ -11,7 +11,7 @@
 # command line developer tools?" GUI dialog (the /usr/bin/python3 shim is a
 # CLT installer trampoline, not a real interpreter, until CLT is present).
 #
-# `command -v python3` alone is NOT sufficient to detect this (co1 review,
+# `command -v python3` alone is NOT sufficient to detect this (review,
 # P1): the trampoline file genuinely exists at /usr/bin/python3, so
 # `command -v` reports success even when CLT is not installed -- the
 # dialog only fires once something actually EXECUTES it. So on Darwin,
@@ -23,7 +23,7 @@
 # just exits non-zero with no CLT installed.
 #
 # Comparing `command -v`'s raw output as a literal string is NOT enough
-# either (co1 delta review, P1): PATH may resolve python3 through a
+# either (delta review, P1): PATH may resolve python3 through a
 # symlink -- e.g. ~/bin/python3 -> /usr/bin/python3 -- in which case
 # `command -v` reports `~/bin/python3`, a string comparison against
 # `/usr/bin/python3` misses it, and the trampoline still fires once that

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1977,7 +1977,7 @@ _remote_status_one() {
 # credential itself — this stays exactly as secret-free as the human-text
 # status output above.
 #
-# Reads config.json exactly ONCE (co1 delta review, ported from
+# Reads config.json exactly ONCE (delta review, ported from
 # feat/remote-connect-onboarding) — six independent
 # `_remote_read_config_field` calls would each independently re-open the
 # file from disk; a concurrent disconnect/reconnect/force-rebind's atomic

--- a/scripts/team-list.sh
+++ b/scripts/team-list.sh
@@ -88,7 +88,7 @@ set -euo pipefail
 # this ADR family already applies to server-supplied JSON, held to
 # config.json too) is skipped with a stderr warning.
 #
-# --json fails closed on incompleteness (co1 delta review): if the
+# --json fails closed on incompleteness (delta review): if the
 # MAX_TEAMS bound was hit, or any team's config was skipped, --format json
 # prints NO JSON payload at all and exits 2 — a partial list must never be
 # handed to a consumer as if it were the complete, authoritative one (the
@@ -116,7 +116,7 @@ agmsg_require_python3 "team list" || exit 1
 # the intended behavior, not something rejected below.
 MAX_TEAMS="${AGMSG_TEAM_LIST_MAX_TEAMS:-10000}"
 readonly _MAX_TEAMS_UPPER_BOUND=10000
-# Validated immediately (co1 delta review, two rounds): `[ "$count" -gt
+# Validated immediately (delta review, two rounds): `[ "$count" -gt
 # "$MAX_TEAMS" ]` below is a bash `test` integer comparison inside an `if`
 # condition, which `set -e` does NOT abort on — so ANY input `test` can't
 # evaluate as an in-range integer (non-numeric, zero, negative, OR an

--- a/tests/test_bin_agmsg.bats
+++ b/tests/test_bin_agmsg.bats
@@ -40,7 +40,7 @@ BIN="$BATS_TEST_DIRNAME/../bin/agmsg.js"
 }
 
 # EVERY entry in the map, not the one verb a hand-written test happened to
-# pick (review P1, co1). The map is allowed to be incomplete — a new verb
+# pick (review P1). The map is allowed to be incomplete — a new verb
 # missing from it costs nothing — but an entry that is PRESENT and stale makes
 # the message name a path that does not exist, which is worse than the general
 # advice it replaced. Completeness is not pinned; correctness of what is
@@ -57,7 +57,7 @@ BIN="$BATS_TEST_DIRNAME/../bin/agmsg.js"
     console.log("checked " + Object.keys(SCRIPT_FOR_VERB).length);
   ' "$BIN"
   [ "$status" -eq 0 ]
-  # Non-empty, not an exact count (co1): pinning the number would mean adding
+  # Non-empty, not an exact count (review): pinning the number would mean adding
   # a legitimate verb to the map fails this test, which makes the map harder
   # to extend for no safety gained. What must not pass is a map emptied to {}
   # reporting "nothing missing".
@@ -65,7 +65,7 @@ BIN="$BATS_TEST_DIRNAME/../bin/agmsg.js"
 }
 
 # The person this package exists for has NOT installed yet, and they reach
-# this same branch (review P1, co1). Telling them to `bash <install path>` is
+# this same branch (review P1). Telling them to `bash <install path>` is
 # telling them to run a command that fails. HOME is redirected to an empty
 # directory; nothing here touches the network.
 @test "bin/agmsg.js: with nothing installed, it says to install first" {
@@ -84,7 +84,7 @@ BIN="$BATS_TEST_DIRNAME/../bin/agmsg.js"
   mkdir -p "$home/.agents/skills/agmsg/scripts"
   # The FILE, not just the directory. An earlier version of this test created
   # an empty scripts/ and accepted advice pointing at a send.sh that was not
-  # there — the same defect as the map pin, one layer out (review P1, co1).
+  # there — the same defect as the map pin, one layer out (review P1).
   touch "$home/.agents/skills/agmsg/scripts/send.sh"
   run env HOME="$home" node "$BIN" send hello
   [ "$status" -eq 2 ]

--- a/tests/test_close_fds.bats
+++ b/tests/test_close_fds.bats
@@ -82,7 +82,7 @@ setup() {
 # It was left off at first, on the reasoning that calling the helper there would
 # close the sourcing shell's descriptors — true, and not a reason to leave the
 # leak: wrapping only the spawn in a subshell closes the child's copies and
-# leaves the parent's alone (review P1, co1). "This one is different" is where
+# leaves the parent's alone (review P1). "This one is different" is where
 # an exclusion list goes wrong, so the list is now every path, with no
 # exceptions to audit.
 @test "close-fds: every long-lived spawn path calls it" {

--- a/tests/test_dispatch.bats
+++ b/tests/test_dispatch.bats
@@ -88,7 +88,7 @@ teardown() {
   [[ "$output" =~ "Delivery mode set to 'turn'" ]]
 }
 
-@test "dispatch: 'team list' reaches team-list.sh, not team.sh (co1 P1 — 'list' must never be treated as a team name)" {
+@test "dispatch: 'team list' reaches team-list.sh, not team.sh (P1 — 'list' must never be treated as a team name)" {
   run bash "$SCRIPTS/windows/dispatch.sh" --type codex --project "$PROJECT_ALICE" -- team list --json
   [ "$status" -eq 0 ]
   # team.sh's "Team not found: list" / "Team: list" output would appear if

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -627,7 +627,7 @@ stored_types() {
   [[ "$output" == *"first message ever, after migration"* ]]
 }
 
-# co1's review of #696: the fix above feeds MAX(local_position) straight into
+# A review of #696: the fix above feeds MAX(local_position) straight into
 # sqlite_sequence.seq, an AUTOINCREMENT-authority column -- not a data column
 # like the ones the re-entry guard above already protects. SQLite ranks TEXT
 # above every INTEGER in its default comparison, so a single non-integer
@@ -638,7 +638,7 @@ stored_types() {
 #
 # The existing "not an integer is refused" test above covers RE-ENTRY only
 # (it migrates alpha successfully first, then corrupts the DESTINATION to
-# test _missing_from_dest). This is the gap co1 named: the FIRST-TIME path
+# test _missing_from_dest). This is the gap named: the FIRST-TIME path
 # never validated source cursor types at all before this fix started writing
 # them into sqlite_sequence. Reproduced by corrupting the SHARED cursor
 # BEFORE ever migrating, so the very first attempt is what has to refuse.
@@ -657,7 +657,7 @@ stored_types() {
 
   # Refused, not repaired: the malformed value is still exactly what it was
   # -- silently ignoring it in MAX() would have erased the evidence a bad
-  # cursor exists, which is explicitly not acceptable here (co1).
+  # cursor exists, which is explicitly not acceptable here (review).
   [ "$(sqlite3 "$SHARED" "SELECT local_position FROM read_cursors
         WHERE team='alpha' AND agent='ann';")" = "abc" ]
   # Nothing moved: the shared store still has the team's row, and no

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1419,7 +1419,7 @@ _truncate_team_config() {  # $1 = team -> replaces its config.json with malforme
 
 
 #
-# Deterministic, single-threaded simulation of the race a reviewer flagged (see
+# Deterministic, single-threaded simulation of the race flagged in review (see
 # feat/remote-connect-onboarding's PR #479): rather than actually racing two
 # live processes, pre-insert a row in the runtime `locks` table matching
 # exactly what `_remote_pending_lock_acquire` would have written, then

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -1361,7 +1361,7 @@ _truncate_team_config() {  # $1 = team -> replaces its config.json with malforme
 }
 
 @test "status <team> [--json]: the human and --json forms classify every config shape identically (#650 review)" {
-  # co2's finding: _remote_config_malformed checked json_valid but not the
+  # a review finding: _remote_config_malformed checked json_valid but not the
   # top-level TYPE, so [] / null / 42 / "text" -- valid JSON, not an object
   # -- passed it, then fell through to json_extract-returns-null same as a
   # genuinely empty binding: rc=1 "never connected". The --json path's
@@ -1419,7 +1419,7 @@ _truncate_team_config() {  # $1 = team -> replaces its config.json with malforme
 
 
 #
-# Deterministic, single-threaded simulation of the race co1 flagged (see
+# Deterministic, single-threaded simulation of the race a reviewer flagged (see
 # feat/remote-connect-onboarding's PR #479): rather than actually racing two
 # live processes, pre-insert a row in the runtime `locks` table matching
 # exactly what `_remote_pending_lock_acquire` would have written, then
@@ -1489,7 +1489,7 @@ VALUES ('remote-pending.$key', $owner_pid, strftime('%Y-%m-%dT%H:%M:%SZ','now'))
   [[ "$output" == *"[x] python3 on PATH"* ]]
 }
 
-# --- co1 delta review P1: doctor must also check node (sync data plane) ----
+# --- delta review P1: doctor must also check node (sync data plane) ----
 # Node is a SEPARATE, independent dependency from python3 (remote sync data
 # plane vs. remote control plane) -- doctor claiming "All checks passed"
 # with age+python3 present but node missing would contradict reality, since

--- a/tests/test_require_python3.bats
+++ b/tests/test_require_python3.bats
@@ -20,7 +20,7 @@ teardown() {
   [ "$status" -ne 0 ]
 }
 
-# --- co1 P1 finding: macOS CLT trampoline ------------------------------------
+# --- P1 finding: macOS CLT trampoline ------------------------------------
 # On Darwin, /usr/bin/python3 exists on PATH (so a bare `command -v python3`
 # succeeds) even when Xcode Command Line Tools are NOT installed -- it's a
 # trampoline that pops the OS's own "install command line developer tools?"
@@ -43,7 +43,7 @@ EOF
   [ "$status" -eq 0 ]
 }
 
-@test "python3_usable: Darwin + /usr/bin/python3 + CLT NOT installed -> NOT usable (the actual bug co1 found)" {
+@test "python3_usable: Darwin + /usr/bin/python3 + CLT NOT installed -> NOT usable (the actual bug found)" {
   _agmsg_python3_resolved_path() { printf '/usr/bin/python3'; }
   _agmsg_platform() { printf 'Darwin'; }
   local fakebin; fakebin="$(mktemp -d)"
@@ -105,7 +105,7 @@ EOF
   [[ "$output" != *"SHOULD NEVER RUN"* ]]
 }
 
-# --- co1 delta review P1: symlink resolution ---------------------------------
+# --- delta review P1: symlink resolution ---------------------------------
 # `command -v python3` can resolve through a symlink (e.g. ~/bin/python3 ->
 # /usr/bin/python3) whose literal string is NOT "/usr/bin/python3", even
 # though executing it still reaches the trampoline. These tests point

--- a/tests/test_setup.bats
+++ b/tests/test_setup.bats
@@ -196,7 +196,7 @@ EOF
   [[ "$output" == *"no agmsg-* directory was found"* ]]
 }
 
-@test "setup: tarball fallback works even if a failed git clone left a partial dest dir (#296 co1 finding)" {
+@test "setup: tarball fallback works even if a failed git clone left a partial dest dir (#296 finding)" {
   stub_git_fail_partial_dest
   stub_curl_tarball_success main
 

--- a/tests/test_team_list.bats
+++ b/tests/test_team_list.bats
@@ -134,7 +134,7 @@ json_field() {
   [ "$(sqlite_mem "SELECT json_extract('$(printf %s "$teams" | sed "s/'/''/g")', '\$[0].name');")" = "$team" ]
 }
 
-@test "team list --json: fails closed (no payload, exit 2) when a team's config has a duplicate JSON key (co1 P2 — never authoritative on a partial list)" {
+@test "team list --json: fails closed (no payload, exit 2) when a team's config has a duplicate JSON key (P2 — never authoritative on a partial list)" {
   mkdir -p "$SCRIPTS/../teams/badteam"
   printf '{"name":"badteam","agents":{},"agents":{}}' > "$SCRIPTS/../teams/badteam/config.json"
   bash "$SCRIPTS/join.sh" goodteam alice claude-code /tmp/project-a
@@ -176,7 +176,7 @@ json_field() {
   [[ "$output" == *"refusing to print a partial list"* ]]
 }
 
-@test "team list: rejects a non-numeric AGMSG_TEAM_LIST_MAX_TEAMS override (co1 delta review) — never silently unbounded" {
+@test "team list: rejects a non-numeric AGMSG_TEAM_LIST_MAX_TEAMS override (delta review) — never silently unbounded" {
   bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/project-a
   run bash -c "AGMSG_TEAM_LIST_MAX_TEAMS=not-a-number bash '$SCRIPTS/team-list.sh' --json"
   [ "$status" -ne 0 ]
@@ -199,7 +199,7 @@ json_field() {
   [[ "$output" != *"schema_version"* ]]
 }
 
-@test "team list: rejects an all-digit AGMSG_TEAM_LIST_MAX_TEAMS override too large for bash's native integer arithmetic (co1 delta review round 2)" {
+@test "team list: rejects an all-digit AGMSG_TEAM_LIST_MAX_TEAMS override too large for bash's native integer arithmetic (delta review round 2)" {
   # An all-digit string this long overflows bash's fixed-width `test`
   # arithmetic the SAME way a non-numeric value does (silent "integer
   # expression expected", never true, never truncates) — this is the


### PR DESCRIPTION
Internal review-seat names are in the package npm is serving right now. This takes them out of the tree before the next prerelease is cut.

## What is published today

Measured by pulling `agmsg@1.2.0-rc.3` from the registry and extracting it — not by reading the branch, which is how this survived three prereleases:

```
bin/agmsg.js:69,95,118   // (review P1, co1)
CHANGELOG.md:288         - List hermes in the --agent-type help (co1 nit)
```

In the tree as a whole: **71 references across 25 files** — code comments, four `@test` / `it()` names, a design note, and that CHANGELOG entry.

The attributions are worth keeping; the seat is not. `co1 review` becomes `review`, `(review P1, co1)` becomes `(review P1)`, and where removing the name left a sentence without a subject it gets `a reviewer`.

## Why neither guard caught it

Not an argument — a measurement. On `d23e755`, the tree that still contains all 71, run with the real private name list:

```
check-private-names: clean (410 files scanned)
```

Its own banner says why:

> A pass here means "no seat-shaped name", NOT "clean".

`SEAT_SHAPE` is `<base>-(cc|co)[0-9]*`, so it sees `agdev-co1` and cannot see `co1`. The private list holds only unshaped names, and its comment explains that shaped ones "do not belong here — the pattern already covers them". That reasoning is correct about `agdev-co1` and false about the bare form people actually type in comments, which has no shape and is on no list. CI runs the shape half alone (`AGMSG_PRIVATE_NAMES=none`).

So this is a gap *between* the two halves, not a failure of either.

**Closing that gap is deliberately not in this PR.** Widening the shape to bare `(cc|co)[0-9]+` changes a checker that can fail CI on legitimate code, and it needs its own tests. Folding it in behind a rename sweep would put an unreviewed enforcement change where nobody would look for one. It should be its own change, on a tree that is already clean — which this makes true.

## Nothing executable moved

The only two changed lines that are not comments or test names are markdown prose and a Python module docstring.

Verified: `bash -n` on every changed shell script, `node --check` on every changed `.js`/`.mjs`, `py_compile` on the one `.py`, and the four bats suites whose test names changed — 70 ok, 0 not ok, bats exit 0.

Three rewrites needed a second pass, because a blanket removal produced text that was worse than the name:

| became | fixed to |
|---|---|
| `# #695 review (review):` | `# #695 review:` |
| `# review's review of #696:` | `# A review of #696:` |
| `simulation of the race flagged` | `simulation of the race a reviewer flagged` |

The last one had lost its subject and read as though the race did the flagging.
