### PR TITLE
fix(release): cut a release from the branch you are on

### DIFF
--- a/.github/workflows/verify-versions.yml
+++ b/.github/workflows/verify-versions.yml
@@ -6,11 +6,18 @@
 
 name: verify-versions
 
+# `integration/remote` is here because releases are cut from it. Every
+# prerelease so far -- 1.2.0-rc.1 through rc.3 -- was cut from that branch, so
+# its release PR targeted `integration/remote` and this check never ran on any
+# of them. `release.yml` runs the same `--check` at tag time and would have
+# stopped a bad tag, so nothing shipped out of sync; the cost was that the
+# failure would have surfaced at publish instead of at review, on a branch
+# nobody could see it coming from (#679).
 on:
   push:
-    branches: [main]
+    branches: [main, integration/remote]
   pull_request:
-    branches: [main]
+    branches: [main, integration/remote]
 
 jobs:
   check:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -59,26 +59,49 @@ which:
 
 ### Manual steps (if you'd rather not use the script)
 
+The base is a variable here for the same reason it is one in the script: an rc
+is cut from `integration/remote`, and a copy-paste that says `main` puts the
+release commit on the wrong branch.
+
 ```bash
-# On an up-to-date release base (main, or integration/remote for an rc),
-# on a release branch:
-git switch -c release/v1.0.4
-echo 1.0.4 > VERSION
+BASE=main                 # integration/remote for a prerelease
+VER=1.0.4                 # 1.2.0-rc.4 for a prerelease
+
+# On an up-to-date $BASE, on a release branch:
+git switch "$BASE" && git pull --ff-only origin "$BASE"
+git switch -c "release/v$VER"
+echo "$VER" > VERSION
 ./scripts/release/sync-version.sh
-git-cliff --tag v1.0.4 -o CHANGELOG.md
-git add VERSION package.json .claude-plugin/plugin.json CHANGELOG.md
-git commit -m "release: 1.0.4"
-git push -u origin release/v1.0.4
-gh pr create --fill && gh pr merge --squash --auto --delete-branch
-# After it merges:
-git switch main && git pull --ff-only
-git tag v1.0.4 && git push origin v1.0.4
+FILES="VERSION package.json .claude-plugin/plugin.json"
+# A prerelease leaves CHANGELOG.md alone — see "Prereleases skip the changelog"
+# above. For a stable version, and only then:
+case "$VER" in *-*) ;; *)
+  git-cliff --tag "v$VER" -o CHANGELOG.md
+  FILES="$FILES CHANGELOG.md" ;;
+esac
+git add $FILES
+git commit -m "release: $VER"
+git push -u origin "release/v$VER"
+gh pr create --base "$BASE" --fill
 ```
+
+**Stop there.** Do not add `--auto`: the merge is a gate, not a formality, and
+the script does not enable auto-merge for the same reason. Merge it yourself
+once the required checks are green, then:
+
+```bash
+gh pr merge "release/v$VER" --squash --delete-branch
+git switch "$BASE" && git pull --ff-only origin "$BASE"
+git tag "v$VER" && git push origin "v$VER"
+```
+
+The tag push fires `release.yml`, which waits for the `production` approval
+before it publishes.
 
 ## Manual fallback (CI unavailable)
 
 ```bash
-# (after the release commit is on main via PR)
+# (after the release commit is on its base branch via PR)
 npm publish --access public --provenance
 git-cliff --latest --strip header -o RELEASE_NOTES.md
 gh release create "v$(cat VERSION)" --title "v$(cat VERSION)" --notes-file RELEASE_NOTES.md
@@ -100,8 +123,12 @@ The pipeline layers four defenses against silent drift and malicious publish:
   and linked back to this workflow run. A tarball without provenance — or with
   provenance pointing elsewhere — is distinguishable on npmjs.com.
 - **`verify-versions.yml`.** Runs `sync-version.sh --check` on every push and
-  PR to `main`. A hand-edit of `package.json` or `plugin.json` without a
-  `VERSION` bump fails CI before merge.
+  PR to `main` **and `integration/remote`**. A hand-edit of `package.json` or
+  `plugin.json` without a `VERSION` bump fails CI before merge. It was
+  `main`-only until #679, which meant it never ran on any of the three
+  prereleases cut from `integration/remote` — `release.yml` runs the same check
+  at tag time, so nothing shipped out of sync, but the failure would have
+  surfaced at publish rather than at review.
 
 ## Repository secrets required by the workflow
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,8 +20,23 @@ scripts/release/cut-release.sh 1.0.4   # semver, no leading "v"
 
 It bumps `VERSION`, syncs the derived files, regenerates `CHANGELOG.md` from
 Conventional Commits (via [git-cliff](https://git-cliff.org)), opens a
-`release: <version>` PR, auto-merges it once the required checks pass, then tags
-the merged commit and pushes the tag.
+`release: <version>` PR — **and stops there**.
+
+It does **not** enable auto-merge, does not tag, and does not publish. Merging
+the PR and pushing the tag are the two outward, irreversible steps, and each
+stays behind a person. The script prints the remaining commands when it exits.
+(This paragraph used to say it auto-merged and tagged. It never did.)
+
+**Which branch:** whichever one you are on. The PR targets that same branch, so
+a prerelease cut from `integration/remote` opens against `integration/remote`.
+Releases from a side branch are a real case — 1.2.0-rc.1 through rc.3 were all
+cut that way — and the script used to refuse them outright (#679).
+
+**Prereleases skip the changelog.** A version with a prerelease suffix
+(`1.2.0-rc.4`) leaves `CHANGELOG.md` untouched; the GitHub Release notes come
+from `release.yml`'s own `git-cliff --latest`. Writing the section on an
+integration branch would later merge into `main` a section for a version `main`
+never had.
 
 **Why a PR and not a direct push:** `main` is a protected branch with required
 status checks, so the release commit must land through a PR — a direct push is
@@ -45,7 +60,8 @@ which:
 ### Manual steps (if you'd rather not use the script)
 
 ```bash
-# On an up-to-date main, on a release branch:
+# On an up-to-date release base (main, or integration/remote for an rc),
+# on a release branch:
 git switch -c release/v1.0.4
 echo 1.0.4 > VERSION
 ./scripts/release/sync-version.sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -116,19 +116,35 @@ cannot work and must not be attempted:
 - Even if it could authenticate, it would go around the `production` approval,
   which is the one human gate between a pushed tag and a published package.
 
-So a failed run is re-run, never worked around:
+So a failed run is re-run, never worked around. **Find out which side of the
+publish it failed on first** — a red run does not mean nothing shipped. The
+publish step sits in the middle of the job: the release notes and the GitHub
+Release are created *after* it, so a failure in either leaves an npm version
+that is already public and **immutable**.
 
 ```bash
-gh run list --workflow release.yml --limit 5
-gh run rerun <run-id> --failed      # re-runs the failed jobs; approval still applies
+npm view agmsg@1.0.4 version     # prints the version if it published, else errors
 ```
 
-If the tag itself was wrong, delete it and cut again — the version is not
-published until the run succeeds, so the tag is the only thing to undo:
+**Not on npm** — the run failed before publishing (the tag/`VERSION` guard, the
+derived-files check, or the approval). Nothing is public. Re-run it, or if the
+tag itself was wrong, delete the tag and cut again:
 
 ```bash
+gh run rerun <run-id> --failed         # approval still applies
 git push origin :refs/tags/v1.0.4 && git tag -d v1.0.4
 ```
+
+**Already on npm** — the version is permanent; npm does not allow a re-publish
+of the same version, and deleting the tag would only detach the release from
+its source. Do not delete it. Finish the rest:
+
+```bash
+gh run rerun <run-id> --failed
+```
+
+That is safe to repeat: the publish step checks `npm view` first and skips when
+the version is already there, so a re-run picks up at the release notes.
 
 If GitHub Actions is unavailable, the release waits. A release that cannot go
 through the pipeline is a release that has not been reviewed, signed, or

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,8 +19,8 @@ scripts/release/cut-release.sh 1.0.4   # semver, no leading "v"
 ```
 
 It bumps `VERSION`, syncs the derived files, regenerates `CHANGELOG.md` from
-Conventional Commits (via [git-cliff](https://git-cliff.org)), opens a
-`release: <version>` PR — **and stops there**.
+Conventional Commits (via [git-cliff](https://git-cliff.org)) **for a stable
+version only**, opens a `release: <version>` PR — **and stops there**.
 
 It does **not** enable auto-merge, does not tag, and does not publish. Merging
 the PR and pushing the tag are the two outward, irreversible steps, and each
@@ -53,7 +53,11 @@ which:
 1. Verifies the tag matches `VERSION` and that derived files are in sync
    (`sync-version.sh --check`).
 2. Waits for a reviewer to approve the `production` environment.
-3. Runs `npm publish --access public --provenance`.
+3. Runs `npm publish --access public --provenance --tag <dist-tag>`, where the
+   dist-tag is `next` for a version carrying a prerelease suffix and `latest`
+   otherwise. npm reads nothing from the version string on its own — without
+   the flag, `1.2.0-rc.4` would land on `latest` exactly like `1.2.0` and every
+   `npx agmsg` would get it.
 4. Generates the release notes for the tag with git-cliff and creates a
    GitHub Release from them.
 
@@ -98,14 +102,38 @@ git tag "v$VER" && git push origin "v$VER"
 The tag push fires `release.yml`, which waits for the `production` approval
 before it publishes.
 
-## Manual fallback (CI unavailable)
+## If the release run fails
+
+**There is no local publish path, and this section used to print one.** It said
+to run `npm publish --access public --provenance` from a workstation. That
+cannot work and must not be attempted:
+
+- npm accepts a publish for this package **only** from a GitHub Actions run
+  that proves via OIDC it came from this repo, this workflow, and the
+  `production` environment. There is no `NPM_TOKEN` anywhere, and the package
+  is set to require 2FA and disallow tokens — see "Supply-chain guards" below,
+  which the old command contradicted on the same page.
+- Even if it could authenticate, it would go around the `production` approval,
+  which is the one human gate between a pushed tag and a published package.
+
+So a failed run is re-run, never worked around:
 
 ```bash
-# (after the release commit is on its base branch via PR)
-npm publish --access public --provenance
-git-cliff --latest --strip header -o RELEASE_NOTES.md
-gh release create "v$(cat VERSION)" --title "v$(cat VERSION)" --notes-file RELEASE_NOTES.md
+gh run list --workflow release.yml --limit 5
+gh run rerun <run-id> --failed      # re-runs the failed jobs; approval still applies
 ```
+
+If the tag itself was wrong, delete it and cut again — the version is not
+published until the run succeeds, so the tag is the only thing to undo:
+
+```bash
+git push origin :refs/tags/v1.0.4 && git tag -d v1.0.4
+```
+
+If GitHub Actions is unavailable, the release waits. A release that cannot go
+through the pipeline is a release that has not been reviewed, signed, or
+attested, and shipping it by hand would remove every guarantee the pipeline
+exists to make.
 
 ## Supply-chain guards
 

--- a/scripts/release/cut-release.sh
+++ b/scripts/release/cut-release.sh
@@ -21,7 +21,15 @@ set -euo pipefail
 #           https://github.com/orhun/git-cliff/releases) and gh authenticated
 #           as the fujibee account (direnv pins GH_TOKEN for this repo).
 #
+# The release branch is whichever branch you are on, not `main`. A prerelease
+# cut from an integration branch is a real case -- 1.2.0-rc.1 through rc.3 were
+# all cut from `integration/remote` -- and this script used to refuse it with
+# "must be on main". The work did not stop when it refused; it got done by hand,
+# and the hand path silently dropped the step this script also does (#679). A
+# checker that declines leaves no trace, so its absence looks like its approval.
+#
 # Usage: scripts/release/cut-release.sh 1.0.4
+#        scripts/release/cut-release.sh 1.2.0-rc.4   # from integration/remote
 
 die() { echo "cut-release: $*" >&2; exit 1; }
 
@@ -40,12 +48,23 @@ command -v git-cliff >/dev/null 2>&1 \
   || die "git-cliff not found — install it (brew install git-cliff) and retry"
 command -v gh >/dev/null 2>&1 || die "gh not found"
 
-# Must be on a clean, up-to-date main, and authenticated as fujibee.
+# Must be on a clean, up-to-date release branch, and authenticated as fujibee.
+#
+# BASE is the branch being released FROM and the branch the PR targets. Taking
+# it from HEAD rather than hardcoding `main` is the whole of #679: the assertion
+# was about where releases usually come from, not about anything that makes a
+# release wrong.
 [ -z "$(git status --porcelain)" ] || die "working tree is not clean"
-[ "$(git rev-parse --abbrev-ref HEAD)" = "main" ] || die "must be on main"
+BASE="$(git rev-parse --abbrev-ref HEAD)"
+case "$BASE" in
+  HEAD) die "HEAD is detached — switch to the branch you are releasing from" ;;
+  release/*) die "already on a release branch ($BASE) — switch to its base first" ;;
+esac
 git fetch origin -q
-[ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] \
-  || die "local main is not in sync with origin/main — pull first"
+git rev-parse --verify -q "origin/$BASE" >/dev/null \
+  || die "origin/$BASE does not exist — push '$BASE' before cutting from it"
+[ "$(git rev-parse HEAD)" = "$(git rev-parse "origin/$BASE")" ] \
+  || die "local $BASE is not in sync with origin/$BASE — pull first"
 who="$(gh api user --jq .login 2>/dev/null || true)"
 [ "$who" = "fujibee" ] || die "gh identity is '$who', expected 'fujibee' (check direnv .envrc)"
 
@@ -53,7 +72,26 @@ TAG="v$VERSION"
 git rev-parse "$TAG" >/dev/null 2>&1 && die "tag $TAG already exists"
 BRANCH="release/$TAG"
 
-echo "==> Preparing $TAG on branch $BRANCH"
+# A prerelease does not get a CHANGELOG section.
+#
+# Not a new rule -- the rule already in force, written down. 1.2.0-rc.1, rc.2
+# and rc.3 were all cut this way, and CHANGELOG.md carries no `rc.` section for
+# any of them; the GitHub Release notes come from release.yml's own
+# `git-cliff --latest` instead. The reason is that the section would be written
+# on the integration branch and later merged into `main`, giving `main` a
+# section for a version it never had.
+#
+# It is decided from the version string rather than the branch, because that is
+# what the claim is about: `1.2.0-rc.4` says prerelease, and a stable version
+# cut from a side branch should still get its section.
+case "$VERSION" in
+  *-*) PRERELEASE=1 ;;
+  *)   PRERELEASE=0 ;;
+esac
+
+echo "==> Preparing $TAG on branch $BRANCH (base: $BASE)"
+[ "$PRERELEASE" -eq 1 ] \
+  && echo "    prerelease: CHANGELOG.md is left alone; release notes come from release.yml"
 git switch -c "$BRANCH"
 
 # 1. bump + sync
@@ -61,34 +99,50 @@ echo "$VERSION" > VERSION
 ./scripts/release/sync-version.sh
 
 # 2. regenerate the changelog including this release's section
-git-cliff --tag "$TAG" -o CHANGELOG.md
+FILES="VERSION package.json .claude-plugin/plugin.json"
+if [ "$PRERELEASE" -eq 0 ]; then
+  git-cliff --tag "$TAG" -o CHANGELOG.md
+  FILES="$FILES CHANGELOG.md"
+fi
 
 # 3. commit + push the release PR
-git add VERSION package.json .claude-plugin/plugin.json CHANGELOG.md
+# shellcheck disable=SC2086
+git add $FILES
 git commit -m "release: $VERSION"
 git push -u origin "$BRANCH"
 
-echo "==> Opening release PR"
-gh pr create --base main --head "$BRANCH" \
+if [ "$PRERELEASE" -eq 1 ]; then
+  CHANGELOG_LINE="- CHANGELOG.md deliberately untouched — prerelease notes come from \`release.yml\`'s own \`git-cliff --latest\`"
+else
+  CHANGELOG_LINE="- CHANGELOG.md regenerated from Conventional Commits"
+fi
+
+echo "==> Opening release PR against $BASE"
+gh pr create --base "$BASE" --head "$BRANCH" \
   --title "release: $VERSION" \
-  --body "Automated release of \`$VERSION\`.
+  --body "Automated release of \`$VERSION\` from \`$BASE\`.
 
 - VERSION bump + synced \`package.json\` / \`.claude-plugin/plugin.json\`
-- CHANGELOG.md regenerated from Conventional Commits
+$CHANGELOG_LINE
 
 Merging this and pushing \`$TAG\` triggers the publish pipeline (npm + GitHub Release)."
 
 # Intentionally STOP here. Auto-merge is never enabled; merging and tagging are
 # human-gated (see the header). Print the remaining manual steps.
+if [ "$PRERELEASE" -eq 1 ]; then
+  CHANGELOG_STEP=" (no CHANGELOG section: prerelease)."
+else
+  CHANGELOG_STEP=" + the CHANGELOG [$VERSION] section."
+fi
 cat <<EOF
 
-==> Release PR opened for $TAG. Auto-merge is intentionally NOT enabled.
+==> Release PR opened for $TAG against $BASE. Auto-merge is intentionally NOT enabled.
     Finish the release by hand — each step is a deliberate gate:
-      1. Review the PR: VERSION bump + the CHANGELOG [$VERSION] section.
+      1. Review the PR: the VERSION bump$CHANGELOG_STEP
       2. Wait for required checks, then merge:
            gh pr merge $BRANCH --squash --delete-branch
-      3. Update main and tag (the tag push fires release.yml → npm publish):
-           git switch main && git pull --ff-only origin main
+      3. Update $BASE and tag (the tag push fires release.yml → npm publish):
+           git switch $BASE && git pull --ff-only origin $BASE
            git tag $TAG && git push origin $TAG
       4. Approve the 'production' deployment when prompted, to publish to npm.
 EOF

--- a/scripts/release/cut-release.sh
+++ b/scripts/release/cut-release.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 # cut-release.sh <version> — prepare a release PR.
 #
 #   1. bump VERSION + sync derived files (package.json, plugin.json)
-#   2. regenerate CHANGELOG.md from Conventional Commits (git-cliff)
-#   3. open a "release: <version>" PR — and STOP.
+#   2. regenerate CHANGELOG.md from Conventional Commits (git-cliff) — for a
+#      STABLE version only; a prerelease leaves the file alone (see below)
+#   3. open a "release: <version>" PR against the branch you are on — and STOP.
 #
 # Merging the PR and pushing the tag are deliberately left to a human: review the
 # version bump + changelog, merge, then push the tag. This script NEVER enables

--- a/tests/test_cut_release.bats
+++ b/tests/test_cut_release.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# cut-release.sh releases from the branch you are on, not from `main` (#679).
+#
+# These run against a throwaway repository with a local bare remote, and with
+# `gh` and `git-cliff` replaced by recorders. Nothing here reaches the network
+# and nothing here opens a real PR: what is measured is the argv the script
+# would have handed to `gh`, which is where the defect lived -- `--base main`,
+# unconditionally, on a release cut from `integration/remote`.
+
+load test_helper
+
+setup() {
+  CUT="$BATS_TEST_DIRNAME/../scripts/release/cut-release.sh"
+  REPO="$BATS_TEST_TMPDIR/repo"
+  REMOTE="$BATS_TEST_TMPDIR/remote.git"
+  BIN="$BATS_TEST_TMPDIR/bin"
+  GH_LOG="$BATS_TEST_TMPDIR/gh.log"
+  CLIFF_LOG="$BATS_TEST_TMPDIR/cliff.log"
+  mkdir -p "$BIN"
+
+  # `gh` answers the identity check and records everything else. `git-cliff`
+  # only records: whether it ran at all is one of the things under test.
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'printf "%s\n" "$*" >> "$GH_LOG"' \
+    'case "$*" in *"api user"*) echo fujibee ;; esac' > "$BIN/gh"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'printf "%s\n" "$*" >> "$CLIFF_LOG"' > "$BIN/git-cliff"
+  chmod +x "$BIN/gh" "$BIN/git-cliff"
+
+  git init -q --bare "$REMOTE"
+  mkdir -p "$REPO/scripts/release" "$REPO/.claude-plugin"
+  cp "$CUT" "$REPO/scripts/release/cut-release.sh"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$REPO/scripts/release/sync-version.sh"
+  chmod +x "$REPO/scripts/release/"*.sh
+  printf '1.2.0-rc.3\n' > "$REPO/VERSION"
+  printf '{"version":"1.2.0-rc.3"}\n' > "$REPO/package.json"
+  printf '{"version":"1.2.0-rc.3"}\n' > "$REPO/.claude-plugin/plugin.json"
+  printf '# Changelog\n' > "$REPO/CHANGELOG.md"
+
+  git -C "$REPO" init -q -b main
+  git -C "$REPO" config user.email t@example.com
+  git -C "$REPO" config user.name t
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm init
+  git -C "$REPO" remote add origin "$REMOTE"
+  git -C "$REPO" push -q -u origin main
+  git -C "$REPO" switch -qc integration/remote
+  git -C "$REPO" push -q -u origin integration/remote
+}
+
+run_cut() {
+  cd "$REPO" || return 1
+  run env PATH="$BIN:$PATH" GH_LOG="$GH_LOG" CLIFF_LOG="$CLIFF_LOG" \
+    bash scripts/release/cut-release.sh "$@"
+}
+
+@test "cut-release: a prerelease from a side branch opens its PR against THAT branch (#679)" {
+  run_cut 1.2.0-rc.4
+  [ "$status" -eq 0 ]
+  # The defect, stated as an assertion: the base must be the branch released
+  # from. Before #679 this was the literal string `main` on every cut.
+  grep -q -F -- "pr create --base integration/remote --head release/v1.2.0-rc.4" "$GH_LOG"
+  refute grep -qF -- "--base main" <<<"$(cat "$GH_LOG")"
+  # And the branch it actually pushed carries the bump.
+  [ "$(git -C "$REPO" show "release/v1.2.0-rc.4:VERSION")" = "1.2.0-rc.4" ]
+}
+
+@test "cut-release: a prerelease leaves CHANGELOG.md alone, and says so" {
+  run_cut 1.2.0-rc.4
+  [ "$status" -eq 0 ]
+  # rc.1, rc.2 and rc.3 were all cut without a CHANGELOG section, and the file
+  # carries no `rc.` heading for any of them. This is that rule, enforced.
+  [ ! -s "$CLIFF_LOG" ]
+  printf '%s\n' "$output" | grep -q -F -- "CHANGELOG.md is left alone"
+  # The commit must not carry it either -- a `git add` of an untouched file is
+  # harmless, but it would mean the decision lived only in the message.
+  run git -C "$REPO" show --stat --name-only "release/v1.2.0-rc.4"
+  refute grep -qF -- "CHANGELOG.md" <<<"$output"
+}
+
+@test "cut-release: a stable version still regenerates the changelog" {
+  # The negative control for the test above. Without it, a script that skipped
+  # git-cliff unconditionally would pass just as well.
+  run_cut 1.3.0
+  [ "$status" -eq 0 ]
+  [ -s "$CLIFF_LOG" ]
+  grep -q -F -- "--tag v1.3.0" "$CLIFF_LOG"
+}
+
+@test "cut-release: a detached HEAD is refused by name, not treated as a branch" {
+  git -C "$REPO" checkout -q --detach
+  run_cut 1.2.0-rc.4
+  [ "$status" -ne 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "HEAD is detached"
+}
+
+@test "cut-release: a branch with no counterpart on origin is refused, naming it" {
+  git -C "$REPO" switch -qc local-only
+  run_cut 1.2.0-rc.4
+  [ "$status" -ne 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "origin/local-only does not exist"
+}
+
+@test "cut-release: cutting from an existing release branch is refused" {
+  git -C "$REPO" switch -qc release/v9.9.9
+  git -C "$REPO" push -q -u origin release/v9.9.9
+  run_cut 1.2.0-rc.4
+  [ "$status" -ne 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "already on a release branch"
+}
+
+@test "cut-release: a branch out of sync with its own origin is refused" {
+  # Was "local main is not in sync with origin/main". The check is the same one;
+  # what changed is which branch it is about. An unpushed commit is enough --
+  # the assertion is equality with origin, in either direction.
+  git -C "$REPO" commit -q --allow-empty -m "not pushed"
+  run_cut 1.2.0-rc.4
+  [ "$status" -ne 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "not in sync with origin/integration/remote"
+}


### PR DESCRIPTION
Closes #679. This is the blocker in front of cutting `1.2.0-rc.4` from `integration/remote`.

## What refused

```sh
[ "$(git rev-parse --abbrev-ref HEAD)" = "main" ] || die "must be on main"
gh pr create --base main --head "$BRANCH"
```

Both unconditional. Every prerelease this project has cut came from `integration/remote`, so the script refused all three — and the work did not stop when it refused, it got done by hand, which silently dropped the step the script also does. That is the shape #679 names: **a checker that declines leaves no trace, so its absence looks exactly like its approval.**

The base comes from HEAD now and the PR targets it. Detached HEAD, a branch with no counterpart on origin, and cutting from an existing release branch are each refused **by name**, rather than falling through into a wrong base.

## Prereleases skip the changelog

Not a new rule — the rule already in force, written down. Measured rather than assumed: `CHANGELOG.md` on `integration/remote` carries **no `rc.` heading at all** for rc.1, rc.2 or rc.3. The Release notes come from `release.yml`'s own `git-cliff --latest`.

It keys off the version string, not the branch, because that is what the claim is about — a stable version cut from a side branch should still get its section, and the negative control in the tests asserts exactly that.

## RELEASING.md described a release path that does not exist

The more dangerous of the two, so it is called out separately. The document said the script

> opens a `release: <version>` PR, auto-merges it once the required checks pass, then tags the merged commit and pushes the tag

The script's own header says the opposite: it **never** enables auto-merge, **never** publishes, and ends with `Intentionally STOP here.` Three claimed steps, none of which happen. Someone following the document waits for a merge that is not coming.

## Tests

This script had none. Seven now, against a throwaway repository with a local bare remote and recorders standing in for `gh` and `git-cliff` — **nothing reaches the network and no PR is opened**. What is measured is the argv the script would hand to `gh`, which is where the defect lived.

| mutation | fails |
|---|---|
| restore `--base main` | 1 — the base assertion |
| run `git-cliff` unconditionally | 1 — the prerelease skip |

The second has a negative control next to it (a stable version *must* still regenerate), so a script that skipped `git-cliff` in every case would not pass by accident.

## Not in this change

The two human gates are untouched: the release PR still has to be merged by a person, and the tag push still stops at the `production` environment approval before npm publish.
