### PR TITLE
fix(tests): widen _wait_pidfile's window and name what it saw (#595)

### DIFF
--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -395,13 +395,21 @@ _max_message_id() {
 
 # --- #93: parallel --continue/--resume sessions sharing a session_id ---
 
-# Poll up to ~3s for <pidfile> to record <want_pid>.
+# Poll up to ~10s for <pidfile> to record <want_pid>. A watcher relaunch does
+# a real fork + lock-acquire + SIGTERM-the-predecessor + self-write before the
+# pidfile reflects it, and a loaded CI runner can push that past the 3s this
+# used to allow -- the flake #595 caught on a macos-latest shard. On timeout,
+# reports what it was waiting for and what it last saw, per #595's ask for a
+# failure message that distinguishes "never arrived" from "arrived as
+# something else" rather than a bare assertion failure.
 _wait_pidfile() {
-  local pf="$1" want="$2" i
-  for i in $(seq 1 30); do
-    [ -f "$pf" ] && [ "$(cat "$pf" 2>/dev/null)" = "$want" ] && return 0
+  local pf="$1" want="$2" i seen
+  for i in $(seq 1 100); do
+    seen="$(cat "$pf" 2>/dev/null || true)"
+    [ -f "$pf" ] && [ "$seen" = "$want" ] && return 0
     sleep 0.1
   done
+  echo "_wait_pidfile: timed out waiting for '$pf' to record pid $want (last saw: '${seen:-<missing>}')" >&2
   return 1
 }
 


### PR DESCRIPTION
Closes the last of #595's four sites.

## What this fixes

`_wait_pidfile` in `tests/test_watch.bats` polled up to 3s for a relaunched
watcher's pidfile to record the new pid. A relaunch is a real fork +
lock-acquire + SIGTERM-the-predecessor + self-write before the pidfile
reflects it, and 3s could lose that race on a loaded CI runner — the flake
#595 caught on PR #436's `macos-latest 4/4` shard, at `_wait_pidfile "$pf" "$w2"`.

Of #595's four sites, three turned out to already be fixed independently
since I filed it: marker-gc and codex-monitor by #606, the launcher
re-registration race by #615. This PR is the fourth and last — `_wait_pidfile`
itself, still on its original budget.

## What changed

- Widened the poll window from 3s to 10s, matching the launcher suite's
  `wait_for_child_count` budget (`test_codex_bridge_launcher.bats`) rather
  than inventing a new number.
- On timeout, the helper now reports the pidfile path, the wanted pid, and
  what it last read instead of that — #595 asked for a failure message that
  can tell "never arrived" from "arrived as something else"; a bare
  assertion failure at that line couldn't.

## What this deliberately doesn't do

#595 also suggested hoisting a shared predicate-wait helper across all four
sites. I didn't do that here: `wait_for_child_count` is a different
predicate shape (process count, not pidfile content) with no shared caller
today, and unifying the pattern is a design call rather than something this
one-site fix implies. Happy to take that separately if it's still wanted now
that three of the four sites are gone.

## Verification

- `bats tests/test_watch.bats`: 27/27 pass, before and after.
- The target test individually: pass.
- The timeout path's message format tested standalone against a forced
  -unreachable pid — confirmed it reports the actual stale value read from
  the pidfile, not a generic failure.