### PR TITLE
test(remote-sync): let the roster driver stubs read their stdin

### DIFF
--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2882,7 +2882,15 @@ test("the roster driver is handed a resolved file path, from the connection root
   await mkdir(join(connection, "teams", "demo"), { recursive: true });
   await mkdir(skill, { recursive: true });
   const script = join(root, "driver.sh");
+  // The `cat` is load-bearing, not tidiness: without it this test fails on a
+  // loaded CI runner with `write EPIPE` and nothing to do with what it asserts.
+  // `rosterDriver` writes the driver's stdin and then ends it; a stub that only
+  // prints has already exited by then, so the `end()` lands on a closed pipe and
+  // `runDriver` reports a driver failure -- correctly, since a real driver reads
+  // its input. Locally the parent always wins the race and it passes. It blocked
+  // three unrelated landings before the mechanism was named (#755).
   await writeFile(script, `#!/usr/bin/env bash
+cat >/dev/null
 printf '{"type":"seen","roster":"%s","connection_dir":"%s","trust_dir":"%s"}\\n' \\
   "\${AGMSG_SYNC_LOCAL_ROSTER_FILE:-}" "\${AGMSG_SYNC_CONNECTION_DIR:-}" "\${AGMSG_SYNC_TRUST_DIR:-}"
 `, { mode: 0o700 });
@@ -2954,7 +2962,11 @@ test("a secret handed in as the roster file cannot reach the driver as a secret"
   // today's callers behave; the parameter list proves a future one cannot.
   const root = await mkdtemp(join(tmpdir(), "agmsg-roster-allowlist-"));
   const script = join(root, "driver.sh");
+  // Same race as the stub above, same reason for the `cat`. This one has not
+  // been seen to fail, which is not a reason to leave it: it is the same shape,
+  // and the one next door failed three times before anyone looked.
   await writeFile(script, `#!/usr/bin/env bash
+cat >/dev/null
 printf '{"type":"seen","token":"%s","trust":"%s","conn":"%s","identity":"%s","roster":"%s"}\\n' \\
   "\${AGMSG_SYNC_TOKEN:-}" "\${AGMSG_SYNC_TRUST_DIR:-}" "\${AGMSG_SYNC_CONNECTION_DIR:-}" \\
   "\${AGMSG_AGE_IDENTITY:-}" "\${AGMSG_SYNC_LOCAL_ROSTER_FILE:-}"


### PR DESCRIPTION
Closes #755.

Declared reviewers: 1

## The race

Two fixtures write a driver stub that prints and exits **without reading stdin**. `rosterDriver` writes the driver's input and then ends it, so when the child has already gone the `end()` lands on a closed pipe, `runDriver`'s stdin error handler fires, and the call is reported as a driver failure — correctly, since a real driver reads its input:

```js
child.stdin.on("error", (error) => {
  error.driverFailurePhase = "stdin-write";
  fail(error);
});
```

Whether it fails is a race between the parent's write and the child's exit. It has never failed locally. On CI it took down **three unrelated landings tonight** — #751, #754, and the rc.4 release PR twice.

Both stubs get `cat >/dev/null`. Only one has been seen to fail; the other is the same shape, and the one next door failed three times before anyone looked at why.

## What this change does NOT establish

**There is no failing-before / passing-after demonstration here.** A reduced reproduction — child exits, parent then writes and ends — does not fire on macOS (its pipes are socketpairs, and the code comments say so), and did not fire in a Linux container either. So the mechanism is argued from the CI stack trace

```
Writable.end (node:internal/streams/writable:823:17)
Socket.end (node:net:738:31)
scripts/internal/remote-sync.mjs:1486:17
```

and the handler it lands in — not from a reproduction that can be run on demand.

**That also means a green CI on this PR proves nothing by itself.** The same commit that failed twice went green once before it. If this fix is wrong, the evidence will be the same test failing again with the `cat` in place, and the next step is then the driver-contract question #755 raises and this deliberately does not answer: whether a driver that ignores its input and exits 0 should be reported as failed at all.

Local suite unchanged: 76/76.

## Why this branch and not `main`

Tonight's standing instruction is that OSS work lands only on `integration/remote`. Independently of that, a fix on `main` would not help the case that prompted it: `pull_request` checks run against the merge of the PR head and its **base**, and the release PR's base is `integration/remote`, so a fix parked on `main` would not appear in its checks at all.
