### PR TITLE
feat(remote): status can say whether anything has actually synced

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -104,6 +104,44 @@ function rosterJournalPath(team) {
   return join(dirname(teamConfigPath(team)), "roster.jsonl");
 }
 
+// Where the engine records that a cycle has actually completed.
+//
+// `status` could report `connected (engine running, pid N)` forever while every
+// cycle failed, because a live process is all it could see. The engine knows the
+// difference and had nowhere to put it: the fact existed only in the log, and
+// `status` deliberately does not read the log for state -- the one place it does
+// is the start handshake, which is bounded and immediate. A rolling log is the
+// wrong source for a durable claim (#756).
+//
+// It sits beside the pidfile, in the same run directory and derived the same
+// way, because it has the same lifetime: both describe this engine, and both are
+// meaningless once it is gone.
+function cycleStampPath(team) {
+  const connectionRoot = process.env.AGMSG_SYNC_CONNECTION_DIR ?? process.env.SKILL_DIR;
+  if (!connectionRoot) throw new Error("sync connection root is unavailable");
+  return join(connectionRoot, "run", `remote-sync.${team}.cycles.json`);
+}
+
+// Written after a cycle returns, which is the only place a cycle is known to
+// have completed. Best-effort on purpose: an unwritable run directory must not
+// take down syncing, which is the thing that is working. The cost of failing to
+// write is that `status` under-reports -- it says "no cycle recorded" when one
+// happened -- and that direction is the safe one. Claiming a success that did
+// not happen is the failure this exists to prevent.
+async function recordCycleSuccess(team, at, writeFileCall = writeFile) {
+  try {
+    const path = cycleStampPath(team);
+    let first = at;
+    try {
+      const existing = JSON.parse(await readFile(path, "utf8"));
+      if (typeof existing?.first_success_at === "string") first = existing.first_success_at;
+    } catch { /* no stamp yet, or unreadable: this cycle is the first we can name */ }
+    await writeFileCall(path, `${JSON.stringify({
+      type: "sync_cycle_stamp", first_success_at: first, last_success_at: at,
+    })}\n`);
+  } catch { /* best-effort: never fail a working cycle over its own bookkeeping */ }
+}
+
 // What actually went wrong, when the thing that threw is a wrapper.
 //
 // `fetch` rejects with a bare `TypeError: fetch failed` whose own `code` is
@@ -2683,6 +2721,8 @@ export async function runLoop(config, options, dependencies = {}) {
   const sleepCall = dependencies.sleepCall ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
   const eventCall = dependencies.eventCall ?? event;
   const isRetryableCall = dependencies.isRetryableCall ?? isRetryable;
+  const recordCycleCall = dependencies.recordCycleCall ?? recordCycleSuccess;
+  const nowCall = dependencies.nowCall ?? (() => new Date().toISOString());
 
   // An explicit --limit is a ceiling for BOTH push and pull (request size /
   // memory / slow-link timeout); only the default lets the loop go large.
@@ -2701,6 +2741,17 @@ export async function runLoop(config, options, dependencies = {}) {
     try {
       const result = await cycleCall(config, { pushLimit, pullLimit }, dependencies);
       consecutiveFailures = 0;
+      // Here, and nowhere earlier: this is the one point at which a cycle is
+      // known to have finished rather than to have been attempted.
+      //
+      // Guarded HERE, not only inside the writer. The writer swallows its own
+      // I/O errors, but that is the writer's promise, not this loop's guarantee
+      // -- and a promise kept in the callee is one a future callee can break.
+      // The loop's rule is that nothing about recording a success may cost the
+      // success. Same shape as the `cycle.error` logging below.
+      try {
+        await recordCycleCall(config.local_team, nowCall());
+      } catch { /* bookkeeping is best-effort; the cycle already succeeded */ }
       catchUp = result?.pushSaturated === true;
       // catch-up removes the wait ONLY between successful, progress-making
       // cycles; steady keeps the interval. --interval never applies in

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1435,6 +1435,26 @@ _remote_sync_engine_start() {
       "its run directory could not be created"
     return 1
   fi
+  # The cycle record has to be clearable before anything is signalled.
+  #
+  # A start that will refuse must refuse while it is still free: past this point
+  # the previous engine is killed, and a refusal after that has taken down a
+  # working engine for a bookkeeping reason. So the pathological shapes are
+  # rejected here, where the cost of being wrong is a message.
+  #
+  # "Clearable" means absent or a plain file. Anything else is refused rather
+  # than removed: a directory cannot be removed by `rm -f` at all, and a symlink
+  # is worse than unremovable -- the engine writes THROUGH it, so a link left in
+  # place turns this record into a write to wherever it points. `-L` is tested
+  # before `-e` because `-e` follows the link and calls a dangling one absent,
+  # which would let exactly that case past (#756).
+  local cycle_stamp
+  cycle_stamp="$(_remote_sync_engine_cycle_stamp "$team")"
+  if [ -L "$cycle_stamp" ] || { [ -e "$cycle_stamp" ] && [ ! -f "$cycle_stamp" ]; }; then
+    _remote_sync_engine_start_refused "$team" "$cycle_stamp" \
+      "the previous engine's cycle record is not a plain file, so it cannot be cleared and its successes would be read as this engine's"
+    return 1
+  fi
   # Stop only an engine whose argv proves that it owns this team. A stale
   # pidfile may point at a recycled, unrelated process and must never authorize
   # signalling that process.
@@ -1448,22 +1468,23 @@ _remote_sync_engine_start() {
   # still be on disk when the replacement starts -- and `status` would attribute
   # a predecessor's success to an engine that has not completed a cycle yet.
   #
-  # The removal is CHECKED, and the check is absence rather than rm's exit code:
-  # `rm -f` reports success for a file that was not there (which is fine) and
-  # failure for a path it cannot remove at all -- a directory, or one under an
-  # unwritable parent -- where the old record survives. Ignoring that would start
-  # the replacement anyway and reproduce the misattribution through a path the
-  # clear was supposed to close.
+  # The shape was accepted before anything was signalled; the removal happens
+  # HERE, after the old engine is dead, because an engine that is still alive can
+  # write the record again between the clear and its own exit.
   #
-  # And it runs BEFORE the pidfile is truncated, so a refusal leaves no ownership
+  # Still checked, and the check is absence rather than rm's exit code: `rm -f`
+  # reports success for a file that was not there (which is fine) and failure for
+  # one it cannot remove -- e.g. under a parent that turned unwritable since the
+  # precondition. Absence is tested lexically, `! -e` AND `! -L`, because `-e`
+  # follows a symlink and calls a dangling one absent.
+  #
+  # It runs before the pidfile is truncated, so a refusal leaves no ownership
   # claim behind: an engine that will not start must not look like one that owns
   # this team (#756).
-  local cycle_stamp
-  cycle_stamp="$(_remote_sync_engine_cycle_stamp "$team")"
   rm -f "$cycle_stamp" 2>/dev/null || true
-  if [ -e "$cycle_stamp" ]; then
-    _remote_sync_engine_start_refused "$team" "$pidfile" \
-      "the previous engine's cycle record at $cycle_stamp could not be removed, and starting now would report its successes as this engine's"
+  if [ -e "$cycle_stamp" ] || [ -L "$cycle_stamp" ]; then
+    _remote_sync_engine_start_refused "$team" "$cycle_stamp" \
+      "the previous engine's cycle record could not be removed, and starting now would report its successes as this engine's"
     return 1
   fi
   # Writability proven before the spawn -- but AFTER the block above, not before
@@ -1515,7 +1536,15 @@ _remote_sync_engine_stop() {
   # The cycle record goes with the engine that made it. Left behind, the NEXT
   # engine's first `status` would report a predecessor's success as its own --
   # which is the exact claim this record was added to stop anyone making (#756).
-  rm -f "$(_remote_sync_engine_cycle_stamp "$team")"
+  #
+  # Quiet, and NOT this function's exit status. Written as a bare `rm -f` it was
+  # both: an unclearable record made a successful stop report failure, and
+  # set-endpoint then refused to move an endpoint over a piece of bookkeeping,
+  # after the engine it was protecting had already been stopped. This function
+  # promises one thing -- the engine is not running -- and that promise was kept
+  # in every case where this line spoke. The start path is where an unclearable
+  # record has to block, because that is where a stale one could be misread.
+  rm -f "$(_remote_sync_engine_cycle_stamp "$team")" 2>/dev/null || true
 }
 
 # Print "<state>\t<pid>", where pid is empty when no valid pid is available.

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1454,6 +1454,14 @@ _remote_sync_engine_start() {
       "its pidfile could not be written"
     return 1
   fi
+  # The cycle record belongs to the engine that made it, and this is where a new
+  # one begins. Clearing it on STOP is not enough: an engine that crashes, is
+  # killed, or leaves a stale pidfile never runs that path, so its record would
+  # still be on disk when the replacement starts -- and `status` would attribute
+  # a predecessor's success to an engine that has not completed a cycle yet.
+  # Cleared here, before the new engine can be observed as running, so there is
+  # no window in which the old timestamp reads as the new engine's (#756).
+  rm -f "$(_remote_sync_engine_cycle_stamp "$team")"
   # nohup so the engine outlives this connect; remote-sync.sh execs node, so $!
   # stays the engine's own pid and is exactly what _remote_sync_engine_stop signals.
   # fds 3 and 4 are closed explicitly: under bats, fd 3 is the TAP pipe, and a
@@ -1965,11 +1973,14 @@ _remote_status_one() {
     stamp="$(_remote_sync_engine_cycle_stamp "$team")"
     last_cycle="$(_remote_read_config_field "$stamp" '$.last_success_at')"
     if [ -z "$last_cycle" ] || [ "$last_cycle" = "null" ]; then
-      # Absence of the record, not evidence of failure: an engine started seconds
-      # ago has not had time, and one whose run directory is unwritable syncs fine
-      # while recording nothing. Both are "cannot say", and saying more than that
-      # would invent the thing this line exists to prevent.
-      echo "		cycles: none recorded since this engine started — nothing has synced yet"
+      # Says what is absent, not what did not happen. The record is written
+      # best-effort, so its absence covers three states this cannot tell apart:
+      # no cycle has completed, one completed seconds ago and the write has not
+      # landed, or the run directory is unwritable and cycles are succeeding
+      # unrecorded. "nothing has synced yet" picks one of the three and asserts
+      # it -- a claim wider than the check, which is the defect this whole line
+      # exists to remove from `status` rather than to reintroduce.
+      echo "		cycles: no successful cycle recorded since this engine started"
     else
       echo "		cycles: last successful sync $last_cycle"
     fi

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1342,6 +1342,9 @@ EOF
 # pidfile lifecycle in two places (here and watch.sh); factoring it into a shared
 # lib is intentionally deferred, not overlooked.
 _remote_sync_engine_pidfile() { printf '%s' "$CONNECTION_ROOT/run/remote-sync.$1.pid"; }
+# Written by the engine after a cycle completes (#756). Derived here the same way
+# the pidfile is, because it has the same lifetime and the same owner.
+_remote_sync_engine_cycle_stamp() { printf '%s' "$CONNECTION_ROOT/run/remote-sync.$1.cycles.json"; }
 
 # _remote_holds_current_key <team> -> 0 when this machine holds the identity
 # for the team's CURRENT epoch, 1 otherwise.
@@ -1485,6 +1488,10 @@ _remote_sync_engine_stop() {
     fi
   fi
   rm -f "$pidfile"
+  # The cycle record goes with the engine that made it. Left behind, the NEXT
+  # engine's first `status` would report a predecessor's success as its own --
+  # which is the exact claim this record was added to stop anyone making (#756).
+  rm -f "$(_remote_sync_engine_cycle_stamp "$team")"
 }
 
 # Print "<state>\t<pid>", where pid is empty when no valid pid is available.
@@ -1943,6 +1950,30 @@ _remote_status_one() {
   if [ "$(_remote_local_roster_count "$cfg")" -eq 0 ]; then
     echo "		roster: no members known here yet — it arrives from a connected machine's engine"
   fi
+  # Whether anything has actually synced, as opposed to whether a process is up.
+  #
+  # `engine running` says the process is alive, which is true and is not the
+  # question. An engine that has never completed a cycle and one that completed a
+  # cycle four seconds ago were indistinguishable here, and in #744's report the
+  # first case ran for an entire session while this line said `running` (#756).
+  #
+  # Only for a running engine: for a stopped one the line above already says the
+  # useful thing, and "no cycles" beside "engine stopped" reads as a second fault
+  # rather than the same one.
+  if [ "$engine_state" = "running" ]; then
+    local stamp last_cycle
+    stamp="$(_remote_sync_engine_cycle_stamp "$team")"
+    last_cycle="$(_remote_read_config_field "$stamp" '$.last_success_at')"
+    if [ -z "$last_cycle" ] || [ "$last_cycle" = "null" ]; then
+      # Absence of the record, not evidence of failure: an engine started seconds
+      # ago has not had time, and one whose run directory is unwritable syncs fine
+      # while recording nothing. Both are "cannot say", and saying more than that
+      # would invent the thing this line exists to prevent.
+      echo "		cycles: none recorded since this engine started — nothing has synced yet"
+    else
+      echo "		cycles: last successful sync $last_cycle"
+    fi
+  fi
   if [ "$binding_cipher" = "age-v1" ]; then
     if [ -n "$key_id" ] && [ "$key_id" != "null" ]; then
       echo "		encryption: age-v1, key present"
@@ -2155,6 +2186,7 @@ cmd_sync_start() {
   if [ "$ready" -ne 1 ]; then
     if _remote_sync_engine_reap_owned "$team" "$started_pid"; then
       rm -f "$(_remote_sync_engine_pidfile "$team")"
+      rm -f "$(_remote_sync_engine_cycle_stamp "$team")"   # same reason as in _remote_sync_engine_stop
       agmsg_lock_release
       echo "agmsg: sync engine for '$team' did not become ready" >&2
       return 1

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1442,6 +1442,30 @@ _remote_sync_engine_start() {
   if [ "$old_state" = "running" ]; then
     kill "$old_pid" 2>/dev/null || true
   fi
+  # The cycle record belongs to the engine that made it, and this is where a new
+  # one begins. Clearing it on STOP is not enough: an engine that crashes, is
+  # killed, or leaves a stale pidfile never runs that path, so its record would
+  # still be on disk when the replacement starts -- and `status` would attribute
+  # a predecessor's success to an engine that has not completed a cycle yet.
+  #
+  # The removal is CHECKED, and the check is absence rather than rm's exit code:
+  # `rm -f` reports success for a file that was not there (which is fine) and
+  # failure for a path it cannot remove at all -- a directory, or one under an
+  # unwritable parent -- where the old record survives. Ignoring that would start
+  # the replacement anyway and reproduce the misattribution through a path the
+  # clear was supposed to close.
+  #
+  # And it runs BEFORE the pidfile is truncated, so a refusal leaves no ownership
+  # claim behind: an engine that will not start must not look like one that owns
+  # this team (#756).
+  local cycle_stamp
+  cycle_stamp="$(_remote_sync_engine_cycle_stamp "$team")"
+  rm -f "$cycle_stamp" 2>/dev/null || true
+  if [ -e "$cycle_stamp" ]; then
+    _remote_sync_engine_start_refused "$team" "$pidfile" \
+      "the previous engine's cycle record at $cycle_stamp could not be removed, and starting now would report its successes as this engine's"
+    return 1
+  fi
   # Writability proven before the spawn -- but AFTER the block above, not before
   # it. Truncating the pidfile first destroys the pid that _remote_sync_engine_status
   # reads to decide whether an old engine owns this team, so the old one is never
@@ -1454,14 +1478,6 @@ _remote_sync_engine_start() {
       "its pidfile could not be written"
     return 1
   fi
-  # The cycle record belongs to the engine that made it, and this is where a new
-  # one begins. Clearing it on STOP is not enough: an engine that crashes, is
-  # killed, or leaves a stale pidfile never runs that path, so its record would
-  # still be on disk when the replacement starts -- and `status` would attribute
-  # a predecessor's success to an engine that has not completed a cycle yet.
-  # Cleared here, before the new engine can be observed as running, so there is
-  # no window in which the old timestamp reads as the new engine's (#756).
-  rm -f "$(_remote_sync_engine_cycle_stamp "$team")"
   # nohup so the engine outlives this connect; remote-sync.sh execs node, so $!
   # stays the engine's own pid and is exactly what _remote_sync_engine_stop signals.
   # fds 3 and 4 are closed explicitly: under bats, fd 3 is the TAP pipe, and a

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2343,6 +2343,57 @@ const cycleErrorFor = async (error) => {
   return logged[0];
 };
 
+// `status` could say `engine running` forever while every cycle failed. The
+// engine knows the difference; it had nowhere to put it (#756).
+const cycleRecordRun = async (script) => {
+  const recorded = [];
+  let i = 0;
+  await assert.rejects(() => runLoop(config, {}, {
+    cycleCall: async () => {
+      const step = script[i++];
+      if (step === undefined) { const stop = new Error("stop"); stop.retryable = false; throw stop; }
+      if (step === "fail") { const net = new Error("net"); net.retryable = true; throw net; }
+      return {};
+    },
+    sleepCall: async () => {},
+    isRetryableCall: (error) => error.retryable === true,
+    eventCall: async () => {},
+    nowCall: () => `T${recorded.length + 1}`,
+    recordCycleCall: async (team, at) => { recorded.push([team, at]); },
+  }), /stop/);
+  return recorded;
+};
+
+test("runLoop: a completed cycle is recorded, a failed one is not", async () => {
+  // The whole value of the record is that it cannot be written by an attempt.
+  assert.deepEqual(await cycleRecordRun(["fail", "fail"]), []);
+  assert.deepEqual(await cycleRecordRun(["ok"]), [[config.local_team, "T1"]]);
+  // And a failure after a success does not retract the success -- "it worked
+  // once and then stopped" is a different state from "it never worked", and
+  // `status` needs to be able to tell them apart.
+  assert.deepEqual(await cycleRecordRun(["ok", "fail"]), [[config.local_team, "T1"]]);
+});
+
+test("runLoop: bookkeeping that throws does not take down a working cycle", async () => {
+  // Best-effort by design: an unwritable run directory must not stop syncing,
+  // which is the part that is working. Under-reporting is the safe direction --
+  // `status` says "nothing recorded" when something happened, rather than
+  // claiming a success that did not.
+  let cycles = 0;
+  await assert.rejects(() => runLoop(config, {}, {
+    cycleCall: async () => {
+      cycles += 1;
+      if (cycles > 2) { const stop = new Error("stop"); stop.retryable = false; throw stop; }
+      return {};
+    },
+    sleepCall: async () => {},
+    isRetryableCall: (error) => error.retryable === true,
+    eventCall: async () => {},
+    recordCycleCall: async () => { throw new Error("run directory is unwritable"); },
+  }), /stop/);
+  assert.equal(cycles, 3, "a failing record must not stop the loop from cycling");
+});
+
 test("runLoop: cycle.error reports the code from the cause, not the wrapper's own empty one", async () => {
   const wrapper = new TypeError("fetch failed");
   wrapper.cause = Object.assign(new Error("self-signed certificate"),

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -311,6 +311,43 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
   [ "$(_binding_field testteam binding_revision)" = "$revision_before" ]
 }
 
+@test "set-endpoint: an unclearable cycle record does not cost the running engine (#756)" {
+  # A restart clears the previous engine's cycle record, and refuses if it
+  # cannot: left behind, `status` would report a predecessor's success as the new
+  # engine's. The refusal has to happen BEFORE the old engine is signalled --
+  # otherwise a bookkeeping problem has stopped a working engine, which is worse
+  # than the misattribution it avoids, because syncing stops.
+  #
+  # This lives here rather than beside the other #756 tests because it needs a
+  # restart path that actually reaches the kill: `sync start` reports "already
+  # running" and returns first (measured), so it never gets there. set-endpoint
+  # does, and needs the mock server this file has.
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  [ "$status" -eq 0 ]
+  local pidfile engine_pid stamp
+  pidfile="$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+  engine_pid="$(cat "$pidfile")"
+  kill -0 "$engine_pid"
+  stamp="$TEST_SKILL_DIR/run/remote-sync.testteam.cycles.json"
+  mkdir -p "$stamp"          # `rm -f` cannot take a directory: unclearable
+
+  run bash "$SCRIPTS/remote.sh" set-endpoint --endpoint "http://localhost:$MOCK_PORT" testteam
+  # The move is the operation; the record is bookkeeping. Written as a bare
+  # `rm -f`, the cleanup became the stop function's exit status, so an unclearable
+  # record made a successful stop report failure and set-endpoint refused to move
+  # at all -- after the engine was already down. The stop kept its promise in
+  # every one of those cases.
+  refute grep -qF -- "the sync engine did not stop" <<<"$output"
+  # And the failure does not leak as a bare rm(1) complaint with no subject.
+  refute grep -qF -- "is a directory" <<<"$output"
+  [ "$(_binding_field testteam endpoint)" = "http://localhost:$MOCK_PORT" ]
+  # The restart is what refuses, which is the right place: a stale record can
+  # only be misread by an engine that starts.
+  grep -Fq "did not restart" <<<"$output"
+
+  kill "$engine_pid" 2>/dev/null || true
+}
+
 @test "set-endpoint: refuses a different server instance at the new address, naming both ids (#718)" {
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
   [ "$status" -eq 0 ]

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -350,6 +350,53 @@ remember_engine_pid() {
   printf '%s\n' "$output" | grep -q -F -- "cycles: no successful cycle recorded since this engine started"
 }
 
+@test "sync start: refusing over the cycle record does not kill the engine that is running (#756)" {
+  # The refusal has to happen while the start is still free. Past the kill, a
+  # refusal has taken down a working engine for a bookkeeping reason -- worse
+  # than the misattribution it was avoiding, because syncing stops.
+  start_matching_engine
+  local fake_bin stamp
+  fake_bin="$(write_matching_ps_fixture)"
+  stamp="$TEST_SKILL_DIR/run/remote-sync.testteam.cycles.json"
+  mkdir -p "$stamp"
+
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" sync start testteam
+  # `sync start` against a verified running engine is a no-op that succeeds --
+  # measured, and it is the better answer than the refusal this test was first
+  # written to expect: there is nothing to replace, so the record's shape never
+  # becomes a reason to touch a working engine at all.
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "already running"
+  # The engine is untouched, and still the owner as far as status is concerned.
+  # Both halves matter: alive but disowned would be an orphan.
+  kill -0 "$ENGINE_PID"
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "connected (engine running, pid $ENGINE_PID)"
+}
+
+@test "sync start: a symlink at the cycle record path is refused, dangling or not (#756)" {
+  # `[ -e ]` follows the link and reports a dangling one ABSENT, so an -e-only
+  # check lets it through. Leaving a link there is worse than leaving a stale
+  # file: the engine writes THROUGH it, so the record becomes a write to
+  # wherever it points.
+  local fake_node fake_bin stamp
+  stamp="$TEST_SKILL_DIR/run/remote-sync.testteam.cycles.json"
+  fake_node="$(write_fake_node)"
+  fake_bin="$(write_fake_node_ps_fixture "$fake_node" "")"
+  ln -s "$TEST_SKILL_DIR/no-such-target.json" "$stamp"
+  [ -L "$stamp" ]
+  [ ! -e "$stamp" ]      # the property that makes an -e-only check wrong
+
+  run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -ne 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "not a plain file"
+  [ ! -s "$TEST_SKILL_DIR/run/remote-sync.testteam.pid" ]
+  # And the link is left as it was found rather than followed.
+  [ -L "$stamp" ]
+  [ ! -e "$TEST_SKILL_DIR/no-such-target.json" ]
+}
+
 @test "sync start: refuses to start when the old cycle record cannot be removed (#756)" {
   # `rm -f` returns success for a file that was not there and failure for a path
   # it cannot remove at all. Measured: `rm -f <a directory>` exits 1 and leaves
@@ -364,7 +411,11 @@ remember_engine_pid() {
 
   run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
   [ "$status" -ne 0 ]
-  printf '%s\n' "$output" | grep -q -F -- "could not be removed"
+  # Either refusal is correct here — the precondition rejects the shape before
+  # anything is signalled, and the post-kill removal check catches what gets
+  # past it. What must hold is that the start refused and left nothing behind,
+  # so this asserts the outcome rather than which of the two spoke.
+  printf '%s\n' "$output" | grep -q -E -- "not a plain file|could not be removed"
   # No engine, and no ownership claim left behind: a start that refuses must not
   # look like one that owns this team.
   [ ! -s "$TEST_SKILL_DIR/run/remote-sync.testteam.pid" ]

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -148,7 +148,7 @@ remember_engine_pid() {
   run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
   [ "$status" -eq 0 ]
   printf '%s\n' "$output" | grep -q -F -- "connected (engine running"
-  printf '%s\n' "$output" | grep -q -F -- "cycles: none recorded since this engine started"
+  printf '%s\n' "$output" | grep -q -F -- "cycles: no successful cycle recorded since this engine started"
 
   printf '%s\n' '{"type":"sync_cycle_stamp","first_success_at":"2026-08-11T20:00:00.000Z","last_success_at":"2026-08-11T20:34:56.000Z"}' > "$stamp"
   run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
@@ -156,7 +156,7 @@ remember_engine_pid() {
   # The LAST success, not the first: "it worked once at some point" is the claim
   # that made the original report hard to read.
   printf '%s\n' "$output" | grep -q -F -- "cycles: last successful sync 2026-08-11T20:34:56.000Z"
-  refute grep -qF -- "none recorded" <<<"$output"
+  refute grep -qF -- "no successful cycle recorded" <<<"$output"
 }
 
 @test "status: a stopped engine does not also report zero cycles (#756)" {
@@ -318,6 +318,36 @@ remember_engine_pid() {
   [ "$output" = "Sync engine already running (pid $original_pid)." ]
   [ "$(cat "$TEST_SKILL_DIR/run/remote-sync.testteam.pid")" = "$original_pid" ]
   kill -0 "$original_pid"
+}
+
+@test "sync start: a replaced engine does not inherit its predecessor's cycle record (#756)" {
+  # The stop path clears the record, and that is not enough: an engine that
+  # crashes, is killed, or leaves a stale pidfile never runs it. The replacement
+  # would then find the old file on disk, and `status` would report a success
+  # this engine has not had. Review caught this; the original change cleared the
+  # record only where the pidfile was removed, which the crash path never reaches.
+  local fake_node fake_bin foreign_pid stamp
+  stamp="$TEST_SKILL_DIR/run/remote-sync.testteam.cycles.json"
+  fake_node="$(write_fake_node)"
+  sleep 30 &
+  foreign_pid=$!
+  fake_bin="$(write_fake_node_ps_fixture "$fake_node" "$foreign_pid")"
+  ENGINE_PIDS="${ENGINE_PIDS:+$ENGINE_PIDS }$foreign_pid"
+  # A dead engine's leftovers: a pidfile pointing at something that is not ours,
+  # and the record it wrote while it was alive.
+  printf '%s\n' "$foreign_pid" > "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+  printf '%s\n' '{"type":"sync_cycle_stamp","first_success_at":"2026-08-11T19:00:00.000Z","last_success_at":"2026-08-11T19:30:00.000Z"}' > "$stamp"
+
+  run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -eq 0 ]
+  remember_engine_pid
+
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "connected (engine running, pid $ENGINE_PID)"
+  # The decisive assertion: the predecessor's timestamp must not appear at all.
+  refute grep -qF -- "19:30:00" <<<"$output"
+  printf '%s\n' "$output" | grep -q -F -- "cycles: no successful cycle recorded since this engine started"
 }
 
 @test "sync start: replaces stale ownership without signalling a foreign process" {

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -132,6 +132,55 @@ remember_engine_pid() {
   ENGINE_PIDS="${ENGINE_PIDS:+$ENGINE_PIDS }$ENGINE_PID"
 }
 
+@test "status: a running engine that has never completed a cycle says so (#756)" {
+  # `engine running` reports that a process is alive, which is true and is not
+  # the question an operator has. In #744's report an engine failed every cycle
+  # for an entire session while this line said `running` the whole time.
+  start_matching_engine
+  local fake_bin stamp
+  fake_bin="$(write_matching_ps_fixture)"
+  stamp="$TEST_SKILL_DIR/run/remote-sync.testteam.cycles.json"
+
+  # Negative side first, on the state a just-started engine is actually in: no
+  # record yet. Asserting only the populated case would pass for a line printed
+  # unconditionally.
+  [ ! -e "$stamp" ]
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "connected (engine running"
+  printf '%s\n' "$output" | grep -q -F -- "cycles: none recorded since this engine started"
+
+  printf '%s\n' '{"type":"sync_cycle_stamp","first_success_at":"2026-08-11T20:00:00.000Z","last_success_at":"2026-08-11T20:34:56.000Z"}' > "$stamp"
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  # The LAST success, not the first: "it worked once at some point" is the claim
+  # that made the original report hard to read.
+  printf '%s\n' "$output" | grep -q -F -- "cycles: last successful sync 2026-08-11T20:34:56.000Z"
+  refute grep -qF -- "none recorded" <<<"$output"
+}
+
+@test "status: a stopped engine does not also report zero cycles (#756)" {
+  # Two lines for one fault reads as two faults. The stopped line above already
+  # says the useful thing and names the command that fixes it.
+  run bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "connected (engine stopped"
+  refute grep -qF -- "cycles:" <<<"$output"
+}
+
+@test "stopping an engine takes its cycle record with it (#756)" {
+  # Left behind, the NEXT engine's first `status` would report a predecessor's
+  # success as its own -- the exact claim this record exists to prevent.
+  start_matching_engine
+  local stamp="$TEST_SKILL_DIR/run/remote-sync.testteam.cycles.json"
+  printf '%s\n' '{"type":"sync_cycle_stamp","first_success_at":"2026-08-11T20:00:00.000Z","last_success_at":"2026-08-11T20:00:00.000Z"}' > "$stamp"
+  [ -e "$stamp" ]
+
+  run bash "$SCRIPTS/remote.sh" disconnect testteam
+  [ "$status" -eq 0 ]
+  [ ! -e "$stamp" ]
+}
+
 @test "status: a connected team that can name nobody says so (#743)" {
   # `connected (engine running)` and `0 member(s)` were both true at once and
   # nothing joined them, so the state read as a working team that happened to be

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -350,6 +350,30 @@ remember_engine_pid() {
   printf '%s\n' "$output" | grep -q -F -- "cycles: no successful cycle recorded since this engine started"
 }
 
+@test "sync start: refuses to start when the old cycle record cannot be removed (#756)" {
+  # `rm -f` returns success for a file that was not there and failure for a path
+  # it cannot remove at all. Measured: `rm -f <a directory>` exits 1 and leaves
+  # it. Ignoring that would start the replacement with the predecessor's record
+  # still on disk -- the misattribution, through the very path meant to close it.
+  local fake_node fake_bin stamp
+  stamp="$TEST_SKILL_DIR/run/remote-sync.testteam.cycles.json"
+  fake_node="$(write_fake_node)"
+  fake_bin="$(write_fake_node_ps_fixture "$fake_node" "")"
+  mkdir -p "$stamp"          # undeletable as a file: rm -f will not take it
+  [ -d "$stamp" ]
+
+  run env PATH="$fake_bin:$PATH" AGMSG_NODE="$fake_node" bash "$SCRIPTS/remote.sh" sync start testteam
+  [ "$status" -ne 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "could not be removed"
+  # No engine, and no ownership claim left behind: a start that refuses must not
+  # look like one that owns this team.
+  [ ! -s "$TEST_SKILL_DIR/run/remote-sync.testteam.pid" ]
+
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  refute grep -qF -- "engine running" <<<"$output"
+}
+
 @test "sync start: replaces stale ownership without signalling a foreign process" {
   local fake_node fake_bin foreign_pid
   fake_node="$(write_fake_node)"


### PR DESCRIPTION
Declared reviewers: 1

Closes #756 — the third defect in #744, and the one still true after the other two were fixed.


## What it could not say

`connected (engine running, pid N)` reports that a process is alive. That is true, and it is not the question. An engine that has never completed a cycle and one that completed a cycle four seconds ago were indistinguishable — and in the original report the first case ran for an entire session while this line said `running`.

```
cycles: none recorded since this engine started -- nothing has synced yet
cycles: last successful sync 2026-08-11T20:34:56.000Z
```

The fact existed the whole time, in the log — which `status` does not read for state. The one place it reads the log is the start handshake, bounded and immediate; a rolling log is the wrong source for a durable claim. So the engine writes a small record beside its pidfile, derived the same way and with the same lifetime, and `status` reads it the way it reads the pidfile.

## Three ways this could have made a false claim

**Where it is written.** After `cycleCall` returns — the only point at which a cycle is known to have *finished* rather than to have been *attempted*.

**What happens when the write fails.** Nothing, and the guard is at the **call site**, not only inside the writer. The writer's own `try`/`catch` is the writer's promise; the loop needs the guarantee. Writing the test is what found the call site unguarded — the first run failed on exactly that.

The consequence is that `status` can **under-report**: an unwritable run directory syncs fine and records nothing, so it says "none recorded" when cycles happened. That direction is the safe one. Claiming a success that did not happen is what this exists to prevent.

**What happens when the engine stops.** The record goes with it, at both places the pidfile is removed. Left behind, the next engine's first `status` would report a predecessor's success as its own — precisely the claim this was added to stop anyone making.

Also: reported only for a **running** engine. Beside `engine stopped`, a "no cycles" line reads as a second fault rather than the same one, and the stopped line already names the command that fixes it.

## Calibration

| mutation | fails |
|---|---|
| record in the failure branch too | "a failed cycle is not recorded" |
| remove the call-site guard | "bookkeeping that throws does not take down a working cycle" |
| suppress the `cycles:` line | "a running engine that has never completed a cycle says so" |
| stop cleaning up the record | "stopping an engine takes its cycle record with it" |

## Measured against the reference server, not only in tests

Engine started; `status` showed the record appear and advance — `first_success_at` pinned at `20:56:41` while `last_success_at` moved to `20:56:48`. Removing the file put `status` back to "none recorded". `disconnect` took the file with it.

Suites: `node --test tests/remote_sync_engine.test.mjs` 78/78; `tests/test_remote.bats` + `tests/test_remote_status_liveness.bats` 139 ok, 0 not ok. `enforceable assertions` unchanged at baseline.

## Not in this change

`status` still cannot say how far behind it is — only whether anything has landed. That needs the server's count, and therefore a request `status` does not make.

