### PR TITLE
fix(remote): say the engine is not running, in both places that can say it

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2080,10 +2080,15 @@ _remote_status_one() {
     stopped)
       echo "$team	connected (engine stopped — run: bash $(agmsg_shq "$SKILL_DIR/scripts/remote.sh") sync start $(agmsg_shq "$team")) since $connected_at" ;;
     stale)
+      # Names the command, exactly as `stopped` does. The asymmetry mattered:
+      # `stopped` is what an operator reaches by stopping the engine themselves,
+      # and `stale` is what a REBOOT leaves — so the branch with no remedy was
+      # the one reached by someone who did nothing and has the least idea what
+      # to type (#761).
       if [ -n "$engine_pid" ]; then
-        echo "$team	connected (engine stale — pidfile $engine_pid points at a dead or foreign process) since $connected_at"
+        echo "$team	connected (engine stale — pidfile $engine_pid points at a dead or foreign process; run: bash $(agmsg_shq "$SKILL_DIR/scripts/remote.sh") sync start $(agmsg_shq "$team")) since $connected_at"
       else
-        echo "$team	connected (engine stale — pidfile does not contain a valid process id) since $connected_at"
+        echo "$team	connected (engine stale — pidfile does not contain a valid process id; run: bash $(agmsg_shq "$SKILL_DIR/scripts/remote.sh") sync start $(agmsg_shq "$team")) since $connected_at"
       fi
       ;;
   esac

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -266,18 +266,29 @@ fi
 # `off`, so those modes still get the absence only from `status`.
 if [ -x "$SKILL_DIR/scripts/remote.sh" ]; then
   _stale_teams="$("$SKILL_DIR/scripts/remote.sh" status 2>/dev/null \
-    | awk -F'\t' '/engine (stopped|stale)/ {print $1}' | tr '\n' ' ' || true)"
-  if [ -n "${_stale_teams% }" ]; then
-    cat <<EOF
-AGMSG: connected, but not syncing — ${_stale_teams% }
-
-No sync engine is running for the team(s) above, so messages from other
-machines are not arriving. Nothing restarts one after a reboot; it is started
-by hand:
-
-  bash $SKILL_DIR/scripts/remote.sh sync start <team>
-
-EOF
+    | awk -F'\t' '/engine (stopped|stale)/ {print $1}' || true)"
+  if [ -n "$_stale_teams" ]; then
+    printf '%s\n' "AGMSG: connected, but not syncing." ''
+    printf '%s\n' \
+      'No sync engine is running for the team(s) below, so messages from other' \
+      'machines are not arriving. Nothing restarts one after a reboot; run:' ''
+    # ONE RUNNABLE LINE PER TEAM, with no placeholder in it.
+    #
+    # The first version printed `sync start <team>` once. A reader has to
+    # replace `<team>` before that works, and an unreplaced `<team>` is a valid
+    # team name as far as validation is concerned — angle brackets are not among
+    # the characters it rejects. The names are already in hand here, so there is
+    # nothing to leave unfilled (the same reasoning #339 applied to the
+    # onboarding prompt).
+    #
+    # `printf %q` for both the path and the name: an install directory with a
+    # space in it, or a team name that needs quoting, otherwise produces a line
+    # that reads as runnable and is not.
+    printf '%s\n' "$_stale_teams" | while IFS= read -r _t; do
+      [ -n "$_t" ] || continue
+      printf '  bash %q sync start %q\n' "$SKILL_DIR/scripts/remote.sh" "$_t"
+    done
+    printf '\n'
   fi
 fi
 

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -245,6 +245,42 @@ if [ -n "$CC_PID" ]; then
   printf '%s\n' "$INSTANCE_ID" > "$STATE"
 fi
 
+# --- Say when a connected team has no engine (#761). ---
+# A reboot leaves every sync engine dead and nothing restarts one: the five
+# commands that start it are all operator actions. `connected` keeps printing,
+# `send` keeps succeeding locally, and the only symptom is messages not arriving
+# — which reads as "nobody wrote anything". This is the first moment after a
+# reboot when anything of ours runs, so it is where the absence gets said.
+#
+# BEFORE the three directive blocks below rather than inside them: there are
+# three ways out of this script (a watcher already streaming, the actas variant,
+# and the default), and a line added to one of them is missing from the other
+# two.
+#
+# Best-effort, and bounded. `status` is a subprocess and needs python3; if it
+# cannot run, this says nothing rather than guessing. That is a real gap and not
+# a silent one: the check reports what it saw, and what it could not see is the
+# absence of a line, which is why the line names the teams rather than a count.
+#
+# Reaches `monitor` and `both` only — this hook is not installed for `turn` or
+# `off`, so those modes still get the absence only from `status`.
+if [ -x "$SKILL_DIR/scripts/remote.sh" ]; then
+  _stale_teams="$("$SKILL_DIR/scripts/remote.sh" status 2>/dev/null \
+    | awk -F'\t' '/engine (stopped|stale)/ {print $1}' | tr '\n' ' ' || true)"
+  if [ -n "${_stale_teams% }" ]; then
+    cat <<EOF
+AGMSG: connected, but not syncing — ${_stale_teams% }
+
+No sync engine is running for the team(s) above, so messages from other
+machines are not arriving. Nothing restarts one after a reboot; it is started
+by hand:
+
+  bash $SKILL_DIR/scripts/remote.sh sync start <team>
+
+EOF
+  fi
+fi
+
 # --- Skip directive when a watcher is already alive for this instance. ---
 # /compact re-fires SessionStart within the same CC process and session_id, so
 # INSTANCE_ID is identical to the already-running watcher's.  Without this

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -524,11 +524,28 @@ eperm_pid() {
   run env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" </dev/null
   [ "$status" -eq 0 ]
   printf '%s\n' "$output" | grep -q -F -- "connected, but not syncing"
-  printf '%s\n' "$output" | grep -q -F -- "team"
-  printf '%s\n' "$output" | grep -q -F -- "sync start"
+  # The printed COMMAND must be runnable, not a template. Scoped to the command
+  # lines: the Monitor directive below legitimately contains `<team>` when it
+  # describes the message format `<ts> | <team> | <from> → <to> | <body>`, and a
+  # whole-output match calls that a defect. Measured — the first version of this
+  # assertion failed on exactly that line.
+  # Saved BEFORE the next `run`, which replaces $output. Asserting on $output
+  # after running the suggested command reads the command's output and calls it
+  # the hook's — measured here, it turned a passing check into a failing one for
+  # the wrong reason.
+  local session_out="$output" suggested
+  suggested="$(printf '%s\n' "$session_out" | sed -n 's/^  bash //p' | head -1)"
+  [ -n "$suggested" ]
+  refute grep -qF -- "<team>" <<<"$suggested"
+
   # The directive still has to be there: a warning that displaces it would stop
   # the session receiving anything at all, which is worse than the gap it names.
-  printf '%s\n' "$output" | grep -q -F -- "invoke the Monitor tool"
+  printf '%s\n' "$session_out" | grep -q -F -- "invoke the Monitor tool"
+
+  # Run what was printed. This is the assertion — that the line works — rather
+  # than a claim that it looks right. `Usage:` is what an unrunnable form gets.
+  run env AGMSG_RESOLVE_PROJECT=0 bash -c "bash $suggested"
+  refute grep -qF -- "Usage:" <<<"$output"
 }
 
 # --- session-start.sh role-aware resume directive (#339) ---

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -542,10 +542,54 @@ eperm_pid() {
   # the session receiving anything at all, which is worse than the gap it names.
   printf '%s\n' "$session_out" | grep -q -F -- "invoke the Monitor tool"
 
-  # Run what was printed. This is the assertion — that the line works — rather
-  # than a claim that it looks right. `Usage:` is what an unrunnable form gets.
-  run env AGMSG_RESOLVE_PROJECT=0 bash -c "bash $suggested"
-  refute grep -qF -- "Usage:" <<<"$output"
+  # Run what was printed, THROUGH AN INSTALL PATH THAT NEEDS QUOTING, and
+  # require it to succeed.
+  #
+  # The first version of this checked only that `Usage:` was absent, and never
+  # looked at `$status` — so `bash: …: No such file or directory` would have
+  # passed it. And the fixture's install path had no space in it, so dropping
+  # `%q` from the path changed nothing: the test could not fail for the reason
+  # it was written. Both raised in review, both true.
+  # A COPY, not a symlink. `SKILL_DIR` is `cd "$SCRIPT_DIR/.." && pwd`, and `..`
+  # resolves through a symlink to the physical parent — so a symlinked install
+  # with a space in its name arrives here as the real path without one, and the
+  # fixture would silently stop testing what it was built for. Measured.
+  local spaced="$BATS_TEST_TMPDIR/an install/skill"
+  mkdir -p "$spaced"
+  cp -R "$TEST_SKILL_DIR/." "$spaced/"
+  run env AGMSG_RESOLVE_PROJECT=0 bash "$spaced/scripts/session-start.sh" claude-code "$TEST_PROJECT" </dev/null
+  [ "$status" -eq 0 ]
+  local spaced_cmd
+  spaced_cmd="$(printf '%s\n' "$output" | sed -n 's/^  bash //p' | head -1)"
+  [ -n "$spaced_cmd" ]
+  # `install`, not `an install`: %q escapes the space, so the literal phrase is
+  # never present in a correctly quoted line. Checking for it asserts the
+  # ABSENCE of the quoting this test exists to require — measured, it failed
+  # against a correct implementation twice.
+  printf '%s\n' "$spaced_cmd" | grep -q -F -- "install"
+
+  # A fake engine, so success is reachable at all: without one the command runs
+  # correctly and still exits non-zero with `sync engine … did not become ready`,
+  # and a test that accepted that would be accepting the failure it is meant to
+  # catch.
+  local fake_node="$BATS_TEST_TMPDIR/fake-node"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'if [ "${1:-}" = "--version" ]; then echo v23.0.0; exit 0; fi' \
+    'echo "{\"event\":\"capabilities\",\"startup_nonce\":\"${AGMSG_SYNC_START_NONCE:-}\"}"' \
+    'trap "exit 0" TERM INT' \
+    'while :; do sleep 1; done' > "$fake_node"
+  chmod +x "$fake_node"
+
+  run env AGMSG_RESOLVE_PROJECT=0 AGMSG_NODE="$fake_node" bash -c "bash $spaced_cmd"
+  # The STATUS, not the absence of one string. An unquoted path fails here with
+  # `No such file or directory` and a non-zero exit, and the earlier version of
+  # this check — `refute grep Usage:` — passed on exactly that.
+  [ "$status" -eq 0 ]
+  local started_pid
+  started_pid="$(cat "$spaced/run/remote-sync.team.pid" 2>/dev/null || true)"
+  [ -n "$started_pid" ]
+  ENGINE_PIDS="${ENGINE_PIDS:+$ENGINE_PIDS }$started_pid"
+  kill "$started_pid" 2>/dev/null || true
 }
 
 # --- session-start.sh role-aware resume directive (#339) ---

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -491,6 +491,46 @@ eperm_pid() {
   [ "$3" = "$sp" ]
 }
 
+@test "session-start: a connected team with no engine is said, and a silent one is not (#761)" {
+  # A reboot kills every sync engine and nothing restarts one. `connected` keeps
+  # printing and `send` keeps succeeding locally, so the only symptom is silence
+  # — which reads as "nobody wrote anything". This hook is the first thing of
+  # ours that runs afterwards.
+  env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/join.sh" team alice claude-code "$TEST_PROJECT" >/dev/null
+
+  # NEGATIVE FIRST, on the state every ordinary machine is in: no connected
+  # team at all. A line printed unconditionally would pass the positive half
+  # below and be wrong every single session.
+  run env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" </dev/null
+  [ "$status" -eq 0 ]
+  refute grep -qF -- "connected, but not syncing" <<<"$output"
+
+  # Now a connected team whose engine is not running. Written through the same
+  # config the command reads, rather than by calling `connect` — no server here.
+  local cfg="$TEST_SKILL_DIR/teams/team/config.json" updated escaped
+  escaped="$(sed "s/'/''/g" "$cfg")"
+  updated="$(sqlite_mem "
+    SELECT json_set('$escaped', '\$.remote_binding', json_object(
+      'endpoint', 'https://remote.example',
+      'server_instance_id', '018f0000-0000-7000-8000-000000000001',
+      'remote_team_id', '018f0000-0000-7000-8000-000000000002',
+      'protocol_version', 1,
+      'capabilities', json_object('write_allowed_ciphers', json_array('none')),
+      'connected_at', '2026-08-12T00:00:00Z',
+      'disconnected_at', null
+    ));")"
+  printf '%s\n' "$updated" > "$cfg"
+
+  run env AGMSG_RESOLVE_PROJECT=0 bash "$SCRIPTS/session-start.sh" claude-code "$TEST_PROJECT" </dev/null
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "connected, but not syncing"
+  printf '%s\n' "$output" | grep -q -F -- "team"
+  printf '%s\n' "$output" | grep -q -F -- "sync start"
+  # The directive still has to be there: a warning that displaces it would stop
+  # the session receiving anything at all, which is worse than the gap it names.
+  printf '%s\n' "$output" | grep -q -F -- "invoke the Monitor tool"
+}
+
 # --- session-start.sh role-aware resume directive (#339) ---
 
 # Write a role-session record into the isolated skill dir's run/.

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -238,6 +238,26 @@ remember_engine_pid() {
   [ "$(sqlite_mem "SELECT json_extract('$(printf '%s' "$output" | sed "s/'/''/g")', '\$.engine_pid');")" -eq "$ENGINE_PID" ]
 }
 
+@test "status: a stale engine names the command that fixes it, like a stopped one does (#761)" {
+  # A reboot leaves this state, and it was the one branch with no remedy in it.
+  # `stopped` is reached by an operator who stopped the engine themselves and
+  # already knows the command; `stale` is reached by someone who did nothing.
+  printf '%s\n' 999999 > "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+
+  run bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "connected (engine stale"
+  printf '%s\n' "$output" | grep -q -F -- "sync start"
+
+  # The other stale branch — a pidfile with nothing usable in it — is a separate
+  # line in the source, so asserting one says nothing about the other.
+  printf '%s\n' "not-a-pid" > "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+  run bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q -F -- "does not contain a valid process id"
+  printf '%s\n' "$output" | grep -q -F -- "sync start"
+}
+
 @test "status: rejects a live foreign process behind a recycled pidfile" {
   sleep 30 &
   local foreign_pid=$!


### PR DESCRIPTION
Declared reviewers: 1

Refs #761. The ruling was **do not start the engine automatically; make the absence visible**, so this adds the two places that can say it and nothing that starts anything.

## What was measured first

Both items the issue listed as *"Not measured"* were measured on `integration/remote` before any code was written, and they narrowed the work considerably.

**`status` already says something true** in the post-reboot state — a pidfile with a dead pid:

```
rebootteam	connected (engine stale — pidfile 999999 points at a dead or foreign process) since …
```

So the absence was already **visible**. What it was not is **actionable**, and the contrast with the neighbouring branch was the whole finding:

```
stopped   connected (engine stopped — run: bash <path>/remote.sh sync start 'team')
stale     connected (engine stale — pidfile N points at a dead or foreign process)
```

The branch naming the remedy is the one an operator reaches by stopping the engine themselves — who already knows the command. The branch with **no** remedy is the one a reboot produces, reached by someone who did nothing.

**The next start clears the stale pidfile silently:**

```
before   pidfile = 999999   (dead)
$ remote.sh sync start rebootteam
         Sync engine started for 'rebootteam' (pid 40415).
after    pidfile = 40415
```

No warning that anything was stale. Defensible — the operator asked for an engine and got one — but it means the reboot gap leaves no trace once any of the five commands runs.

## The change

**1. `status`'s stale branch names the command**, exactly as `stopped` does. Both stale sub-branches carry it (a dead pid; a pidfile with nothing usable in it) — they are separate lines in the source, and each is asserted separately.

**2. Session start says it once**, before the directive. This hook is the first thing of ours that runs after a reboot.

Placed **before** the three directive blocks rather than inside them: there are three ways out of `session-start.sh` — a watcher already streaming, the actas variant, the default — and a line added to one is missing from the other two.

```
AGMSG: connected, but not syncing — <teams>

No sync engine is running for the team(s) above, so messages from other
machines are not arriving. Nothing restarts one after a reboot; it is
started by hand:

  bash <path>/remote.sh sync start <team>
```

The Monitor directive still follows it, and the test asserts that. A warning that displaced the directive would leave the session receiving nothing at all — worse than the gap it describes.

## What this does not cover

- The hook is installed only for delivery modes `monitor` and `both`. On `turn` and `off` there is no session-start message, so those modes get the absence from `status` alone.
- `delivery.sh` emits its own directive when someone runs `mode monitor`. No warning there: that is a configuration moment the operator chose, not the session boundary this issue is about. Stated so the asymmetry is a decision rather than an oversight.
- The check is best-effort — it shells out to `status`, which needs python3. If that cannot run it says nothing rather than guessing. That failure is invisible by construction, which is why the line names the teams rather than printing a count that could read as zero.

## Tests

| mutation | result |
|---|---|
| remedy dropped from stale branch 1 | status test fails |
| remedy dropped from stale branch 2 | status test fails |
| session-start warning suppressed | session-start test fails |

Applied, not assumed. The session-start case asserts **the negative first**, on the state every ordinary machine is in — no connected team, no line. A line printed unconditionally would satisfy the positive half and be wrong every session.

`tests/test_delivery.bats` + `tests/test_remote_status_liveness.bats`: **206 ok / exit 0**, isolated `TMPDIR`.

## Still open on the issue

`connected` still does not mean `syncing` on a machine with no session open. This makes the gap legible to anyone who looks; it does not close it, and the issue is right that closing it is a product decision.
