### PR TITLE
feat(watch): say when another watcher is receiving for the same roles

### DIFF
--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -221,6 +221,23 @@ if [ -f "$PIDFILE" ]; then
   fi
 fi
 
+# Metadata BEFORE the pidfile, deliberately.
+#
+# A reader treats "live pid, no filter file" as a pre-change watcher, i.e.
+# unfiltered. Written the other way round, every filtered watcher spends its
+# startup window looking exactly like that, and a scan landing in the window
+# warns about a watcher that is not sharing anything. The pidfile is what makes
+# this process visible at all, so nothing may be visible before what describes
+# it (raised in review).
+#
+# The project is part of the record because RUN_DIR is per INSTALL, not per
+# project: two projects using the same install both write here, and their
+# watchers do not share a subscription -- the pairs come from the project's own
+# registrations. Counting across projects would warn about a hazard that does
+# not exist (also raised in review).
+FILTERFILE="$RUN_DIR/watch.$SESSION_ID.filter"
+printf '%s\n%s\n' "${ACTIVE_NAME:-unfiltered}" "$PROJECT_PATH" > "$FILTERFILE" 2>/dev/null || true
+
 echo $$ > "$PIDFILE"
 
 # --- Say when this watcher is sharing an inbox with another (#683). ---
@@ -239,10 +256,6 @@ echo $$ > "$PIDFILE"
 # NOT a lease. This process still subscribes to exactly what it would have
 # subscribed to; it only stops being quiet about the fact that someone else is
 # doing the same. Exclusion is a separate decision.
-FILTERFILE="$RUN_DIR/watch.$SESSION_ID.filter"
-printf '%s
-' "${ACTIVE_NAME:-unfiltered}" > "$FILTERFILE" 2>/dev/null || true
-
 # Only when the hazard is real. A warning printed on every start is a warning
 # nobody reads, and an unfiltered watcher running alone is not in danger.
 if [ -z "$ACTIVE_NAME" ]; then
@@ -257,11 +270,20 @@ if [ -z "$ACTIVE_NAME" ]; then
     # on an installation that has no second watcher at all.
     kill -0 "$_other_pid" 2>/dev/null || continue
     _other_filter="${_pf%.pid}.filter"
-    # An absent filter file means a watcher from before this change: unfiltered
-    # is the only thing it could have been, since filtered ones write the name.
-    if [ ! -f "$_other_filter" ] || [ "$(cat "$_other_filter" 2>/dev/null || true)" = "unfiltered" ]; then
-      _sharing=$((_sharing + 1))
-    fi
+    # An absent filter file is a watcher from BEFORE this change. It cannot be
+    # asked which project it serves, so it is not counted: warning on it would
+    # fire for every unrelated project sharing this install, and this warning is
+    # only worth having if it is true. A pre-change watcher in the SAME project
+    # is a real hazard that goes unreported here -- named in the PR rather than
+    # papered over, and it disappears as installs update.
+    [ -f "$_other_filter" ] || continue
+    _other_name="$(sed -n '1p' "$_other_filter" 2>/dev/null || true)"
+    _other_project="$(sed -n '2p' "$_other_filter" 2>/dev/null || true)"
+    # Same project only. RUN_DIR is per install; the subscription is per
+    # project, so a watcher in another project shares no pairs with this one.
+    [ "$_other_project" = "$PROJECT_PATH" ] || continue
+    [ "$_other_name" = "unfiltered" ] || continue
+    _sharing=$((_sharing + 1))
   done
   if [ "$_sharing" -gt 0 ]; then
     watch_log "another watcher ($_sharing) is receiving for the same unclaimed roles in this project."

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -222,6 +222,53 @@ if [ -f "$PIDFILE" ]; then
 fi
 
 echo $$ > "$PIDFILE"
+
+# --- Say when this watcher is sharing an inbox with another (#683). ---
+#
+# A watcher started WITHOUT an active name subscribes to every (team, agent)
+# registered for this project that nobody else has claimed. The read cursor is
+# one per pair, so when two such watchers exist, whoever polls first takes the
+# row and the other sees nothing -- the comment at the subscription site says
+# exactly this. The message is not duplicated and it is not lost loudly: it is
+# delivered to one of them, and the other's `inbox.sh` truthfully answers "no
+# new messages" because the row was read.
+#
+# Nothing observable is left behind, which is why this has to be said at the one
+# moment something can be said: startup.
+#
+# NOT a lease. This process still subscribes to exactly what it would have
+# subscribed to; it only stops being quiet about the fact that someone else is
+# doing the same. Exclusion is a separate decision.
+FILTERFILE="$RUN_DIR/watch.$SESSION_ID.filter"
+printf '%s
+' "${ACTIVE_NAME:-unfiltered}" > "$FILTERFILE" 2>/dev/null || true
+
+# Only when the hazard is real. A warning printed on every start is a warning
+# nobody reads, and an unfiltered watcher running alone is not in danger.
+if [ -z "$ACTIVE_NAME" ]; then
+  _sharing=0
+  for _pf in "$RUN_DIR"/watch.*.pid; do
+    [ -f "$_pf" ] || continue
+    [ "$_pf" = "$PIDFILE" ] && continue
+    _other_pid="$(cat "$_pf" 2>/dev/null || true)"
+    case "$_other_pid" in ''|*[!0-9]*) continue ;; esac
+    # Liveness by the same means the rest of this file uses. A pidfile left by a
+    # crashed watcher names nobody, and counting it would make the warning fire
+    # on an installation that has no second watcher at all.
+    kill -0 "$_other_pid" 2>/dev/null || continue
+    _other_filter="${_pf%.pid}.filter"
+    # An absent filter file means a watcher from before this change: unfiltered
+    # is the only thing it could have been, since filtered ones write the name.
+    if [ ! -f "$_other_filter" ] || [ "$(cat "$_other_filter" 2>/dev/null || true)" = "unfiltered" ]; then
+      _sharing=$((_sharing + 1))
+    fi
+  done
+  if [ "$_sharing" -gt 0 ]; then
+    watch_log "another watcher ($_sharing) is receiving for the same unclaimed roles in this project."
+    watch_log "messages addressed to those roles will reach whichever of us polls first, and the others will not see them."
+    watch_log "to receive only your own: /agmsg actas <name>"
+  fi
+fi
 # Readiness sentinels this watcher created (see #108). Populated once the
 # subscription is resolved; removed on exit so the file is present iff a live
 # watcher is currently receiving for that role.
@@ -233,7 +280,15 @@ cleanup() {
   # would erase the successor's record. See #66.
   local pidfile_pid=""
   [ -f "$PIDFILE" ] && IFS= read -r pidfile_pid < "$PIDFILE" || true
-  [ "$pidfile_pid" = "$$" ] && rm -f "$PIDFILE"
+  # The filter file goes with the pidfile, under the same ownership test. Left
+  # behind, it would keep asserting on behalf of a dead process -- and this one
+  # asserts "I am filtered", which is the direction that SUPPRESSES the warning
+  # for everybody else. A stale pidfile makes the next watcher count a ghost; a
+  # stale filter file makes it count nobody.
+  if [ "$pidfile_pid" = "$$" ]; then
+    rm -f "$PIDFILE"
+    rm -f "$RUN_DIR/watch.$SESSION_ID.filter" 2>/dev/null || true
+  fi
   if [ -n "$READY_FILES" ]; then
     while IFS= read -r _rf; do
       [ -z "$_rf" ] && continue

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -223,12 +223,14 @@ fi
 
 # Metadata BEFORE the pidfile, deliberately.
 #
-# A reader treats "live pid, no filter file" as a pre-change watcher, i.e.
-# unfiltered. Written the other way round, every filtered watcher spends its
-# startup window looking exactly like that, and a scan landing in the window
-# warns about a watcher that is not sharing anything. The pidfile is what makes
-# this process visible at all, so nothing may be visible before what describes
-# it (raised in review).
+# A reader that finds a live pid with no filter file cannot tell what that
+# watcher is doing OR which project it serves, so it SKIPS it. Written the other
+# way round, every filtered watcher spends its startup window in exactly that
+# state, and a scan landing in the window reaches the opposite conclusion from
+# the one this metadata exists to support -- it would count nothing where there
+# is something to count, or, before the project was recorded, warn about a
+# watcher sharing nothing. The pidfile is what makes this process visible at
+# all, so nothing may be visible before what describes it (raised in review).
 #
 # The project is part of the record because RUN_DIR is per INSTALL, not per
 # project: two projects using the same install both write here, and their

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -277,10 +277,17 @@ if [ -z "$ACTIVE_NAME" ]; then
     [ "$_pf" = "$PIDFILE" ] && continue
     _other_pid="$(cat "$_pf" 2>/dev/null || true)"
     case "$_other_pid" in ''|*[!0-9]*) continue ;; esac
-    # Liveness by the same means the rest of this file uses. A pidfile left by a
-    # crashed watcher names nobody, and counting it would make the warning fire
-    # on an installation that has no second watcher at all.
-    kill -0 "$_other_pid" 2>/dev/null || continue
+    # `_agmsg_pid_alive_local`, not a bare `kill -0`. The bare form reads EPERM
+    # as "dead", so a watcher this process cannot signal -- another user, a
+    # sandbox -- would be counted as gone and its inbox-sharing left unsaid. The
+    # repo enforces this (`no shipped script decides liveness with a bare
+    # kill -0`), and it caught this line: the first version used the bare form
+    # while the comment above it claimed to use what the rest of the file uses.
+    #
+    # A pidfile left by a crashed watcher names nobody, which is why liveness is
+    # checked at all: counting one would fire the warning on an installation
+    # that has no second watcher.
+    _agmsg_pid_alive_local "$_other_pid" || continue
     _other_filter="${_pf%.pid}.filter"
     # An absent filter file is a watcher from BEFORE this change. It cannot be
     # asked which project it serves, so it is not counted: warning on it would

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -236,7 +236,17 @@ fi
 # registrations. Counting across projects would warn about a hazard that does
 # not exist (also raised in review).
 FILTERFILE="$RUN_DIR/watch.$SESSION_ID.filter"
-printf '%s\n%s\n' "${ACTIVE_NAME:-unfiltered}" "$PROJECT_PATH" > "$FILTERFILE" 2>/dev/null || true
+# Three lines: role, project, and OWNER PID.
+#
+# The owner is what makes this survive a successor. The replacement path signals
+# the previous watcher and does not wait for it, so the order is: successor
+# writes this file, predecessor's EXIT runs, reads the pidfile (still its own
+# pid), and removes both -- taking the successor's fresh metadata with it. The
+# successor is then live with a pidfile and no filter, which a reader classifies
+# as pre-change and skips, so a real second unfiltered watcher in this project
+# goes unreported. The pidfile transfers ownership by being overwritten; this
+# file has to carry its own (raised in review).
+printf '%s\n%s\n%s\n' "${ACTIVE_NAME:-unfiltered}" "$PROJECT_PATH" "$$" > "$FILTERFILE" 2>/dev/null || true
 
 echo $$ > "$PIDFILE"
 
@@ -307,9 +317,14 @@ cleanup() {
   # asserts "I am filtered", which is the direction that SUPPRESSES the warning
   # for everybody else. A stale pidfile makes the next watcher count a ghost; a
   # stale filter file makes it count nobody.
-  if [ "$pidfile_pid" = "$$" ]; then
-    rm -f "$PIDFILE"
-    rm -f "$RUN_DIR/watch.$SESSION_ID.filter" 2>/dev/null || true
+  [ "$pidfile_pid" = "$$" ] && rm -f "$PIDFILE"
+  # The filter file is judged on ITS OWN recorded owner, not on the pidfile.
+  # During a replacement the pidfile still names the predecessor while the
+  # successor's metadata is already on disk, so deciding by the pidfile lets the
+  # predecessor delete a file it did not write.
+  _ff="$RUN_DIR/watch.$SESSION_ID.filter"
+  if [ -f "$_ff" ] && [ "$(sed -n '3p' "$_ff" 2>/dev/null || true)" = "$$" ]; then
+    rm -f "$_ff" 2>/dev/null || true
   fi
   if [ -n "$READY_FILES" ]; then
     while IFS= read -r _rf; do

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -314,11 +314,15 @@ cleanup() {
   # would erase the successor's record. See #66.
   local pidfile_pid=""
   [ -f "$PIDFILE" ] && IFS= read -r pidfile_pid < "$PIDFILE" || true
-  # The filter file goes with the pidfile, under the same ownership test. Left
-  # behind, it would keep asserting on behalf of a dead process -- and this one
-  # asserts "I am filtered", which is the direction that SUPPRESSES the warning
-  # for everybody else. A stale pidfile makes the next watcher count a ghost; a
-  # stale filter file makes it count nobody.
+  # Both files are removed by their owner, but they do not share an owner test:
+  # the pidfile's owner is whoever it names, and the filter file's is whoever it
+  # records. See below for why the pidfile cannot answer for both.
+  #
+  # Neither may be left behind. A stale pidfile makes the next watcher count a
+  # ghost. A stale filter file is worse in the direction that matters: it keeps
+  # asserting a role on behalf of a dead process, and if that role is a name,
+  # every other watcher reads it as "filtered, not sharing" -- so the warning is
+  # SUPPRESSED by a process that no longer exists.
   [ "$pidfile_pid" = "$$" ] && rm -f "$PIDFILE"
   # The filter file is judged on ITS OWN recorded owner, not on the pidfile.
   # During a replacement the pidfile still names the predecessor while the

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -596,10 +596,10 @@ run_named_watcher_for() {
   # its filter file exists too, and names this watcher's role. That is the
   # property the ordering buys, and it holds at every instant rather than at the
   # one this test happened to look.
-  # Read WHILE IT RUNS. The filter file is removed on exit under the same owner
-  # check as the pidfile, so inspecting after the watcher stops measures the
-  # cleanup, not the ordering — measured, that is how the first version of this
-  # failed.
+  # Read WHILE IT RUNS. The filter file is removed on exit by its own recorded
+  # owner (not by the pidfile's), so inspecting after the watcher stops measures
+  # the cleanup rather than the ordering — measured, that is how the first
+  # version of this failed.
   local run_dir="$TEST_SKILL_DIR/run" named_id="named-order.$$"
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$named_id" "$PROJ" claude-code alice \
     >"$BATS_TEST_TMPDIR/named.out" 2>/dev/null 3>&- &

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -508,6 +508,69 @@ _wait_pidfile() {
 # DB-open healthcheck (#197): a store that exists but cannot be opened (the
 # native sqlite3.exe / Git Bash /c/ path mismatch, or bad perms) must surface a
 # loud error rather than spin silently delivering nothing.
+# Run watch.sh for <secs> with an active name (actas mode), then stop it.
+run_named_watcher_for() {
+  local sid="$1" out="$2" secs="$3" name="$4" pid
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code "$name" >"$out" 2>/dev/null 3>&- &
+  pid=$!
+  sleep "$secs"
+  _stop_watcher "$pid"
+}
+
+@test "watch: a second unfiltered watcher says it is sharing, and a lone one does not (#683)" {
+  # Two watchers with no active name subscribe to the same unclaimed pairs. The
+  # read cursor is one per (team, agent), so whoever polls first takes the row
+  # and the other never sees it — and `inbox.sh` then truthfully says "no new
+  # messages", because it was read. Nothing observable is left behind, so this
+  # is said at the only moment it can be: startup.
+  #
+  # Asserted from the LOG. In the configuration this runs in, fd2 is /dev/null
+  # (#691) — the helpers above redirect it too — so a warning written only to
+  # stderr would be invisible here and in production.
+  #
+  # Composite ids: a bare token is normalized on the way in (watch.sh:92), so
+  # naming the pidfile from a bare id waits for a file never written. Measured.
+  local run_dir="$TEST_SKILL_DIR/run"
+  local solo_id="solo-sid.$$" first_id="first-sid.$$" second_id="second-sid.$$" third_id="third-sid.$$"
+
+  # NEGATIVE FIRST, on the ordinary case: one watcher, alone. An implementation
+  # that always warns passes the positive half below and is wrong every start.
+  # Given seconds rather than a file to wait for, because the assertion is an
+  # ABSENCE — there is no arrival to synchronise on, and waiting longer only
+  # makes the negative stronger.
+  run_watcher_for "$solo_id" "$BATS_TEST_TMPDIR/solo.out" 2
+  refute grep -qF -- "another watcher" "$run_dir/watch.$solo_id.log"
+
+  # Now a live one, and a second started while it runs.
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$first_id" "$PROJ" claude-code \
+    >"$BATS_TEST_TMPDIR/first.out" 2>/dev/null 3>&- &
+  local first_pid=$!
+  wait_for_file "$run_dir/watch.$first_id.pid"
+
+  # Waits for the LAST of the three lines, not for the pidfile: the pidfile is
+  # written before the warning, so a test that waits on it kills the watcher
+  # mid-sentence and sees a partial message. Measured — that is how this failed.
+  local second_log="$run_dir/watch.$second_id.log"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$second_id" "$PROJ" claude-code \
+    >"$BATS_TEST_TMPDIR/second.out" 2>/dev/null 3>&- &
+  local second_pid=$!
+  wait_for_file_contains "$second_log" "/agmsg actas"
+  _stop_watcher "$second_pid"
+
+  grep -q -F -- "another watcher" "$second_log"
+  # The remedy, not only the cause. A warning that names neither what is lost
+  # nor what to type leaves the reader stopped.
+  grep -q -F -- "polls first" "$second_log"
+  grep -q -F -- "/agmsg actas" "$second_log"
+
+  # And a filtered watcher stays quiet even with the same unfiltered one alive:
+  # it is not sharing anything.
+  run_named_watcher_for "$third_id" "$BATS_TEST_TMPDIR/third.out" 2 alice
+  refute grep -qF -- "another watcher" "$run_dir/watch.$third_id.log"
+
+  _stop_watcher "$first_pid"
+}
+
 @test "watch: surfaces an unopenable DB once instead of spinning silently (#197)" {
   [ "$(id -u)" -eq 0 ] && skip "chmod 000 is ineffective as root"
   # The watcher opens the subscribed team's store, so that is the file to make

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -615,6 +615,45 @@ run_named_watcher_for() {
   _stop_watcher "$named_pid"
 }
 
+@test "watch: a watcher does not delete filter metadata it did not write (#683)" {
+  # The replacement path signals the previous watcher for this session id and
+  # does not wait for it, so a successor writes its filter file while the
+  # pidfile still names the predecessor. Deciding the filter's fate by the
+  # PIDFILE lets the predecessor delete metadata the successor just wrote — and
+  # the successor is then live with a pidfile and no filter, which a reader
+  # classifies as pre-change and skips. A second unfiltered watcher in the same
+  # project then goes unreported, which is the whole point of the warning.
+  #
+  # Driven deterministically rather than by racing two watchers: the race window
+  # is real but does not reproduce on demand, and a control that only sometimes
+  # enters the window is a control that only sometimes tests anything. Measured
+  # — the racing version passed with the ownership check removed.
+  #
+  # What is driven is the real `cleanup` in the real process: the file on disk
+  # is made to belong to somebody else, and the watcher is then stopped.
+  local run_dir="$TEST_SKILL_DIR/run" sid="owner.$$"
+  local pf="$run_dir/watch.$sid.pid" ff="$run_dir/watch.$sid.filter"
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code \
+    >"$BATS_TEST_TMPDIR/owner.out" 2>/dev/null 3>&- &
+  local w=$!
+  wait_for_file "$pf"
+  [ -f "$ff" ]
+  # Its own pid while it runs — the ordinary case, and the premise of the swap
+  # below. Without this the test could pass on a watcher that never wrote one.
+  [ "$(sed -n '3p' "$ff")" = "$(cat "$pf")" ]
+
+  # Now the file belongs to a successor: same role and project, different owner.
+  printf '%s\n%s\n%s\n' alice "$PROJ" 999999 > "$ff"
+
+  _stop_watcher "$w"
+
+  # The watcher owned the PIDFILE and removed it. It did not own the filter.
+  refute test -f "$pf"
+  [ -f "$ff" ]
+  [ "$(sed -n '3p' "$ff")" = "999999" ]
+}
+
 @test "watch: surfaces an unopenable DB once instead of spinning silently (#197)" {
   [ "$(id -u)" -eq 0 ] && skip "chmod 000 is ineffective as root"
   # The watcher opens the subscribed team's store, so that is the file to make

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -586,10 +586,11 @@ run_named_watcher_for() {
 }
 
 @test "watch: a filtered watcher is never mistaken for unfiltered while starting (#683)" {
-  # The reader treats "live pid, no filter file" as a pre-change watcher. If the
-  # pidfile were published first, every filtered watcher would look exactly like
-  # that for the length of its startup window, and a scan landing inside it
-  # would warn about a watcher that shares nothing.
+  # A reader that finds a live pid with no filter file SKIPS it: it cannot tell
+  # the role or the project. If the pidfile were published first, every filtered
+  # watcher would sit in exactly that state for the length of its startup
+  # window, and a scan landing inside it would reach the wrong conclusion about
+  # a watcher whose metadata was already on its way.
   #
   # Asserted on the ARTEFACTS rather than by racing: whenever a pidfile exists,
   # its filter file exists too, and names this watcher's role. That is the

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -568,7 +568,51 @@ run_named_watcher_for() {
   run_named_watcher_for "$third_id" "$BATS_TEST_TMPDIR/third.out" 2 alice
   refute grep -qF -- "another watcher" "$run_dir/watch.$third_id.log"
 
+  # A DIFFERENT PROJECT does not warn, even with this project's unfiltered
+  # watcher still live. `RUN_DIR` is per install, so the scan sees that pidfile
+  # — but the subscription is per project and they share no pairs. Without the
+  # project in the metadata this case warns, which is a false alarm on every
+  # installation serving two projects (raised in review).
+  local other_proj="/tmp/agmsg-watch-proj-other" other_id="other-proj-sid.$$"
+  bash "$SCRIPTS/join.sh" otherteam carol claude-code "$other_proj" >/dev/null
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$other_id" "$other_proj" claude-code \
+    >"$BATS_TEST_TMPDIR/other.out" 2>/dev/null 3>&- &
+  local other_pid=$!
+  sleep 2
+  _stop_watcher "$other_pid"
+  refute grep -qF -- "another watcher" "$run_dir/watch.$other_id.log"
+
   _stop_watcher "$first_pid"
+}
+
+@test "watch: a filtered watcher is never mistaken for unfiltered while starting (#683)" {
+  # The reader treats "live pid, no filter file" as a pre-change watcher. If the
+  # pidfile were published first, every filtered watcher would look exactly like
+  # that for the length of its startup window, and a scan landing inside it
+  # would warn about a watcher that shares nothing.
+  #
+  # Asserted on the ARTEFACTS rather than by racing: whenever a pidfile exists,
+  # its filter file exists too, and names this watcher's role. That is the
+  # property the ordering buys, and it holds at every instant rather than at the
+  # one this test happened to look.
+  # Read WHILE IT RUNS. The filter file is removed on exit under the same owner
+  # check as the pidfile, so inspecting after the watcher stops measures the
+  # cleanup, not the ordering — measured, that is how the first version of this
+  # failed.
+  local run_dir="$TEST_SKILL_DIR/run" named_id="named-order.$$"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$named_id" "$PROJ" claude-code alice \
+    >"$BATS_TEST_TMPDIR/named.out" 2>/dev/null 3>&- &
+  local named_pid=$!
+  wait_for_file "$run_dir/watch.$named_id.pid"
+
+  # Whenever the pidfile exists, the filter file exists too and names the role.
+  # That is what publishing the metadata first buys, and it holds at every
+  # instant rather than at the one this test happened to look at.
+  [ -f "$run_dir/watch.$named_id.filter" ]
+  [ "$(sed -n '1p' "$run_dir/watch.$named_id.filter")" = "alice" ]
+  [ "$(sed -n '2p' "$run_dir/watch.$named_id.filter")" = "$PROJ" ]
+
+  _stop_watcher "$named_pid"
 }
 
 @test "watch: surfaces an unopenable DB once instead of spinning silently (#197)" {


### PR DESCRIPTION
Declared reviewers: 1

Refs #683. A watcher stops being quiet about sharing an inbox. **No lease** — exclusion is a separate decision and is deliberately not taken here.

## What happens today

A watcher started without an active name subscribes to every `(team, agent)` registered for this project that nobody has claimed. The read cursor is one per pair, and the subscription site already spells out the consequence (`watch.sh:483-488`):

> That is not a harmless duplicate. The read cursor is one per (team, agent) and `storage_watch_after` excludes rows already read, so **whoever polls first TAKES the row and the other sees nothing** … the message is gone, delivered to a stream nobody is reading (#683).

Nothing said this to the person it happens to. `inbox.sh` answers *"no new messages"*, and that answer is **true** — the row was read, by someone else. There is no trace to find afterwards, which is why this is said at the one moment it can be: startup.

Measured while writing it: two seats lost four messages between them, one of which was a ruling the other was waiting on. Both sides spent over an hour believing the other had not replied.

## The change

- A filter file beside the pidfile records what this watcher is doing: the active name, or `unfiltered`. The pidfile already establishes that this process owns that directory (`watch.sh:108`).
- At startup, an unfiltered watcher counts **live** unfiltered watchers other than itself — liveness by `kill -0`, the same means the rest of the file uses, so a pidfile left by a crashed watcher does not make this fire on an installation with no second watcher.
- It warns **only when the count is non-zero**. A warning on every start is a warning nobody reads.
- The message names the loss *and* the remedy (`/agmsg actas <name>`). Naming the cause without the fix leaves the reader stopped.
- The filter file records its **own owner pid** and is removed only by that owner. The pidfile transfers ownership by being overwritten; this file has no such moment, and deciding by the pidfile lets a predecessor delete a successor's metadata during a replacement (see below).
- An absent filter file is **skipped**, not counted: it cannot be asked which project it serves. See the note below for what that leaves unreported.

## One departure from the proposal

The proposal said stderr. This file records why that is not enough — in the configuration it actually runs in, **fd2 is `/dev/null`** (#691), which is also true of the test harness. `watch_log` writes both stderr and the log and already exists, so no new mechanism was added.

## Scoped to one project, after review

`RUN_DIR` is per **install**; the subscription is per **project**. Two watchers in different projects share no cursor and cannot take each other's rows, so counting across the directory warns about a hazard that does not exist.

Measured on this machine while the review was open: **four unfiltered watchers, in four different projects, and no project with two** — every warning the first version would have printed here was false.

The filter file records the resolved project beside the name, and the scan counts only matching ones. The metadata is also written **before** the pidfile now: published the other way round, a reader seeing "live pid, no filter file" **skips** it — it cannot tell the role or the project — so every filtered watcher would spend its startup window in a state that makes it invisible to the scan.

**One hazard is deliberately left unreported.** A watcher with no filter file — from before this change — is skipped rather than counted, because it cannot be asked which project it serves and counting it reintroduces the false positive above. A pre-change watcher in the *same* project therefore goes unwarned. It disappears as installs update.

## Ownership, after the third round

The replacement path signals the previous watcher for a session id and does not wait for it, so a successor writes its filter file while the pidfile still names the predecessor. A cleanup deciding by the **pidfile** therefore deletes metadata it did not write, leaving a **live watcher with a pidfile and no filter** — which a reader skips, so a second unfiltered watcher in the same project goes unreported.

Line three of the filter file is the owner pid, and cleanup removes the file only when that is this process.

The control for it is deterministic rather than a race: while the watcher runs, its filter file is rewritten to belong to somebody else, the watcher is stopped, and the file has to survive. The premise is asserted first (while running, the owner is the watcher's own pid). The racing version of this control **passed with the ownership check removed** — the window is real but does not reproduce on demand, and a control that only sometimes enters the window only sometimes tests anything.

## Tests

| case | expected |
|---|---|
| a second unfiltered watcher, one already live | warns |
| one watcher alone | silent |
| a filtered watcher, unfiltered one still live | silent |

Mutations, both directions:

| mutation | result |
|---|---|
| warning branch removed | the positive fails |
| warning made constant | **the negatives fail** |

The second is why the negatives are there: a test with only the positive is green for an implementation that shouts on every start.

`tests/test_watch.bats` + `tests/test_delivery.bats`: **198 ok / exit 0**, isolated `TMPDIR`.

Three defects in the test itself, all found by running it and worth knowing for the next one: `$TMP` is not this suite's temp variable; a **bare session id is normalized** on the way in (`watch.sh:92`), so naming the pidfile from one waits for a file never written; and **waiting on the pidfile is a race** — it is written before the warning, so the watcher was killed mid-sentence and the assertion saw two lines of three.

## Not in this change

The lease. Whether a watcher should *claim* the pairs it subscribes to is the other half of #683 and belongs to whoever decides when and how.
