### PR TITLE
fix(compat): take the basename of the whole ps comm path

### DIFF
--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -110,7 +110,14 @@ compat_get_comm() {
       fi
       ;;
     *)
-      ps -o comm= -p "$pid" 2>/dev/null | xargs basename 2>/dev/null
+      # `ps -o comm=` prints the executable path on macOS. Piping it through
+      # `xargs basename` splits that path on whitespace (and eats quotes), so a
+      # binary under e.g. "~/Library/Application Support/..." resolves to
+      # "Application". Take the basename of the whole string instead.
+      local _comm
+      _comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+      [ -n "$_comm" ] || return 1
+      basename -- "$_comm" 2>/dev/null
       ;;
   esac
 }

--- a/tests/test_compat_posix.bats
+++ b/tests/test_compat_posix.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+
+# Tests for compat_get_comm's POSIX (non-MSYS) branch.
+#
+# `ps -o comm=` prints the full executable path on macOS. The previous
+# implementation piped that through `xargs basename`, which word-splits on
+# whitespace and interprets quotes, so any agent installed under a path
+# containing a space -- e.g. the Claude Code desktop app, which always lives
+# under "~/Library/Application Support/Claude/..." -- resolved to "Application"
+# instead of "claude". agmsg_pid_is_agent then never matched, agmsg_agent_pid
+# fell back to a bare session id, and every actas lock was GC'd as stale.
+
+load test_helper
+
+skip_if_msys() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) skip "POSIX-only test (the msys branch is covered by test_compat.bats)" ;;
+  esac
+}
+
+setup() {
+  setup_test_env
+  skip_if_msys
+
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/compat.sh"
+}
+
+teardown() {
+  [ -n "${_PROC_PID:-}" ] && kill "$_PROC_PID" 2>/dev/null
+  [ -n "${_PROC_PID:-}" ] && wait "$_PROC_PID" 2>/dev/null
+  teardown_test_env
+}
+
+# Put a stub `ps` first on PATH that prints $1 as the comm field.
+_stub_ps_printing() {
+  local out="$1" dir="$TEST_SKILL_DIR/psstub"
+  mkdir -p "$dir"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'printf "%%s\\n" %q\n' "$out"
+  } > "$dir/ps"
+  chmod +x "$dir/ps"
+  PATH="$dir:$PATH"
+}
+
+# ── stubbed ps: deterministic on every POSIX platform ────────────────────
+
+@test "compat_get_comm returns the binary name when ps reports a path containing spaces" {
+  _stub_ps_printing "/Users/u/Library/Application Support/Claude/claude-code/2.1.227/claude.app/Contents/MacOS/claude"
+
+  run compat_get_comm 4242
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude" ]
+}
+
+@test "compat_get_comm returns the binary name when ps reports a path containing a quote" {
+  _stub_ps_printing "/opt/it's here/claude"
+
+  run compat_get_comm 4242
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude" ]
+}
+
+@test "compat_get_comm is unchanged for a path without spaces" {
+  _stub_ps_printing "/usr/local/bin/claude"
+
+  run compat_get_comm 4242
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude" ]
+}
+
+@test "compat_get_comm fails for a pid ps knows nothing about" {
+  local dir="$TEST_SKILL_DIR/psstub"
+  mkdir -p "$dir"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$dir/ps"
+  chmod +x "$dir/ps"
+  PATH="$dir:$PATH"
+
+  run compat_get_comm 4242
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+# ── contract drift guard: the real ps, a real process ────────────────────
+#
+# The stub above asserts what we believe `ps` does. This test checks that
+# belief against the real `ps` on this machine, and skips where the platform
+# reports a bare comm (Linux) rather than a path -- there the split is
+# unreachable and the stub does not describe local reality.
+
+@test "compat_get_comm matches the real ps for a binary under a space-containing path" {
+  local dir="$TEST_SKILL_DIR/Application Support/bin" sleep_bin
+  sleep_bin=$(command -v sleep) || skip "no sleep on PATH"
+  mkdir -p "$dir"
+  # A symlink, not a copy: macOS kills a copied system binary for an invalid
+  # code signature (SIGKILL/137), and ps then reports nothing at all.
+  ln -s "$sleep_bin" "$dir/claude" || skip "cannot symlink into the test tree"
+
+  "$dir/claude" 30 3>&- &
+  _PROC_PID=$!
+  sleep 0.5
+
+  local raw
+  raw=$(ps -o comm= -p "$_PROC_PID" 2>/dev/null || true)
+  case "$raw" in
+    */*) ;;
+    *) skip "this platform's ps reports a bare comm ([$raw]); the space-splitting path is unreachable here" ;;
+  esac
+
+  # The real ps hands us a path with a space -- the premise of the stub above.
+  [[ "$raw" == *"Application Support"* ]]
+
+  run compat_get_comm "$_PROC_PID"
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude" ]
+}


### PR DESCRIPTION
Fixes #770.

### What

`compat_get_comm`'s POSIX branch piped `ps -o comm=` through `xargs basename`. On macOS `ps -o comm=` prints the full executable path, and `xargs` splits it on whitespace — so `basename` got the part before the first space as `NAME` and the remainder as `SUFFIX`:

```
basename "/Users/u/Library/Application" "Support/Claude/.../MacOS/claude"  ->  Application
```

The Claude Code desktop app always installs its CLI under `~/Library/Application Support/Claude/claude-code/<ver>/claude.app/Contents/MacOS/claude`, so every desktop-app session resolved its agent to `Application`. `agmsg_pid_is_agent` never matched, `agmsg_agent_pid` walked straight past the agent to launchd and returned 1, the instance id degraded to a bare session id, `cc-instance.<pid>` was never written, and `actas_lock_gc_stale` then removed the lock on the next `session-start.sh` from any other session — with the watcher still alive and still delivering, so nothing surfaced.

Full analysis, the consequence chain with line numbers, and a same-machine control (space-free installs on the same host resolve correctly) are in #770.

### How

Take the basename of the whole string:

```diff
--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -110,7 +110,14 @@ compat_get_comm() {
       fi
       ;;
     *)
-      ps -o comm= -p "$pid" 2>/dev/null | xargs basename 2>/dev/null
+      # `ps -o comm=` prints the executable path on macOS. Piping it through
+      # `xargs basename` splits that path on whitespace (and eats quotes), so a
+      # binary under e.g. "~/Library/Application Support/..." resolves to
+      # "Application". Take the basename of the whole string instead.
+      local _comm
+      _comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+      [ -n "$_comm" ] || return 1
+      basename -- "$_comm" 2>/dev/null
       ;;
   esac
 }
```

Behaviour changes only where the old form was already wrong:

| input | before | after |
|---|---|---|
| `/usr/local/bin/claude` | `claude` | `claude` (unchanged) |
| `/Users/u/Library/Application Support/.../claude` | `Application` | `claude` |
| `/opt/it's here/claude` | *(xargs error, empty)* | `claude` |
| unknown pid | `` + exit 0 | `` + non-zero |

`--` guards a path starting with `-`.

### Scope

POSIX branch only. `compat.sh:96` (msys, `/proc/<pid>/cmdline`) has the same `xargs basename` shape and `C:\Program Files\...` would hit it, but I have no Windows environment to test on, so I left it alone rather than ship an untested change. Happy to extend the PR if you want it. (`:109` reads `awk '{print $NF}'`, which is already whitespace-split, so it is unaffected.)

`agmsg_pid_is_agent`'s `awk '{print $1}'` on `ps -o args=` has the same weakness, but with `comm` fixed it is a fallback that is not normally reached — also left alone.

### Tests

`tests/test_compat_posix.bats`, 5 tests, skipped on MSYS (the msys branch stays covered by `test_compat.bats`).

Four stubbed-`ps` tests are deterministic on any POSIX host: space in the path, quote in the path, no-space regression guard, and unknown pid. A fifth test does not use the stub — it symlinks the real `sleep` under a directory with a space, runs it, and checks the **real** `ps` against `compat_get_comm`, so the stub's premise is verified against the platform rather than assumed. Where `ps` reports a bare comm instead of a path (Linux) that test skips with a message, because the splitting path is unreachable there.

(A copy of `/bin/sleep` rather than a symlink does not work for that test on macOS: the copy is SIGKILLed for an invalid code signature and `ps` then reports nothing, which made the test skip for the wrong reason.)

Break-test contrast on macOS 15.5:

```
# before (compat.sh reverted, tests present)
not ok 1 ... path containing spaces
not ok 2 ... path containing a quote
ok     3 ... unchanged for a path without spaces      <- regression guard, passes both ways
not ok 4 ... fails for a pid ps knows nothing about
not ok 5 ... matches the real ps for a binary under a space-containing path

# after
ok 1 / ok 2 / ok 3 / ok 4 / ok 5
```

`bats tests/` full suite on macOS 15.5: **912 tests, 0 failures, 12 skipped** (exit 0).
