### PR TITLE
fix(sync): say which condition failed, and which field an exit came from

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1629,12 +1629,34 @@ export function describeChildExit(code, signal) {
 // it cannot. `teamConfigPath` throws without a connection root, and a caller
 // that has none is a caller that still has to be able to run -- the path is for
 // a sentence in a failure message, so it must not become a new way to fail.
-function bindingPathIfKnown(team) {
+// The team's binding path, or WHY there is none.
+//
+// `teamConfigPath` throws without a connection root, and a caller that has none
+// still has to run -- the path is for a sentence in a failure message, so it
+// must not become a new way to fail. That much was right the first time.
+//
+// What was wrong was returning `undefined` and dropping the reason. A failure
+// turned into an ordinary value with nothing recorded is the shape #802
+// collects, and it had no business being in a change whose whole subject is
+// messages that say what actually happened. Swallowing is fine here. Going
+// silent is not, so the reason travels with the fallback.
+export function bindingPathOrReason(team, resolve = teamConfigPath) {
   try {
-    return teamConfigPath(team);
-  } catch {
-    return undefined;
+    return { path: resolve(team) };
+  } catch (error) {
+    return { unavailable: error instanceof Error ? error.message : String(error) };
   }
+}
+
+// What the diagnostic says about the binding: where it is, or why it cannot be
+// named. Never nothing -- "and its binding" alone is the sentence that sent a
+// reader looking for a file this process could not even locate.
+function bindingNote(binding) {
+  if (binding?.path !== undefined) return ` and its binding at ${binding.path}`;
+  if (binding?.unavailable !== undefined) {
+    return ` and its binding (its path could not be resolved: ${binding.unavailable})`;
+  }
+  return " and its binding";
 }
 
 function runDriver({ args, label, operation, parse, input, rosterFile, team, bindingPath }) {
@@ -1722,7 +1744,7 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
       const subject = team === undefined ? "" : ` for team '${team}'`;
       const diagnostic = stderr.trim() ||
         "driver returned a non-zero exit without diagnostics; inspect that team's storage" +
-          (bindingPath === undefined ? " and its binding" : ` and its binding at ${bindingPath}`);
+          bindingNote(bindingPath);
       fail(new Error(
         `${label} ${operation} failed${subject} (${describeChildExit(code, signal)}): ${diagnostic}`));
     });
@@ -1747,7 +1769,7 @@ export async function driver(operation, config, input, extra = []) {
     label: "storage sync",
     operation,
     team: config.local_team,
-    bindingPath: bindingPathIfKnown(config.local_team),
+    bindingPath: bindingPathOrReason(config.local_team),
     parse: (stdout) => (["resync-status", "resync"].includes(operation) ?
       parseStrictJsonl(stdout) : parseJsonl(stdout)),
     input,
@@ -1777,7 +1799,7 @@ export async function rosterDriver(operation, config, input, extra = []) {
     label: "roster sync",
     operation,
     team: config.local_team,
-    bindingPath: bindingPathIfKnown(config.local_team),
+    bindingPath: bindingPathOrReason(config.local_team),
     parse: parseJsonl,
     input,
     // The roster file, resolved here and handed over as one path — not the

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -570,13 +570,44 @@ export function connectedBinding(value, team) {
   return binding;
 }
 
+// What disqualifies a file this process is about to trust, said in the words of
+// the condition that actually failed -- or null when nothing does.
+//
+// One function rather than a condition here and a sentence there. The two had
+// drifted: the sentence named a permission problem while the condition had
+// already excluded permissions on win32 (#781), so a Windows operator who hit a
+// missing file, a symlink or an oversized one was told to go and look at modes
+// that platform never carried. Someone did, after the same message on Linux had
+// been a real `0664`. The message was right once and wrong once, for the same
+// bytes.
+//
+// Returning the fault instead of throwing lets each caller name its own subject
+// while the reason stays derived from the check that produced it.
+export function authorityFileFault(stats, { maxBytes, privateFile }) {
+  if (stats.isSymbolicLink()) return "must not be a symbolic link";
+  if (!stats.isFile()) return "must be a regular file";
+  if (maxBytes !== undefined && stats.size > maxBytes) {
+    return `must not be larger than ${maxBytes} bytes (it is ${stats.size})`;
+  }
+  // POSIX modes only. Windows does not carry them, so this is not consulted
+  // there -- and because it is the LAST thing consulted, no message above can
+  // be about it. That ordering is the fix, not a detail of it.
+  if (process.platform !== "win32" && (stats.mode & (privateFile ? 0o077 : 0o022)) !== 0) {
+    return privateFile
+      ? "must not be readable or writable by group or others"
+      : "must not be writable by group or others";
+  }
+  return null;
+}
+
 async function readBoundedAuthorityFile(path, maxBytes, privateFile) {
   const before = await lstat(path);
-  const unsafeMode = process.platform !== "win32" &&
-    (before.mode & (privateFile ? 0o077 : 0o022)) !== 0;
-  if (!before.isFile() || before.isSymbolicLink() || unsafeMode || before.size > maxBytes) {
-    throw new Error(privateFile ? "remote credential must be a private regular file" :
-      "connected team binding must be a non-writable regular file");
+  const fault = authorityFileFault(before, { maxBytes, privateFile });
+  if (fault) {
+    // The path too: the previous message named a property without naming what
+    // had it, on a machine that may hold several.
+    throw new Error(
+      `${privateFile ? "remote credential" : "connected team binding"} ${fault}: ${path}`);
   }
   const handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
   try {
@@ -1235,10 +1266,8 @@ function compareRetainedCheckpoint(config, retained) {
 
 async function readRetainedCheckpointFile(path) {
   const metadata = await lstat(path);
-  if (!metadata.isFile() || metadata.isSymbolicLink() ||
-      (process.platform !== "win32" && (metadata.mode & 0o077) !== 0)) {
-    throw new Error("retained age checkpoint must be a private regular file");
-  }
+  const fault = authorityFileFault(metadata, { privateFile: true });
+  if (fault) throw new Error(`retained age checkpoint ${fault}: ${path}`);
   const records = parseStrictJsonl(await readFile(path, "utf8"));
   if (records.length < 1 || records.length > 4096) {
     throw new Error("retained age checkpoint history is invalid");
@@ -1279,10 +1308,18 @@ export async function retainAgeCheckpoint(config, confirmation) {
   }
   const retained = checkpointRecord(config, confirmation);
   await mkdir(dirname(path), { recursive: true, mode: 0o700 });
-  const directoryMetadata = await lstat(dirname(path));
-  if (!directoryMetadata.isDirectory() ||
-      (process.platform !== "win32" && (directoryMetadata.mode & 0o077) !== 0)) {
-    throw new Error("AGMSG_SYNC_TRUST_DIR must be a private directory");
+  const trustDirectory = dirname(path);
+  const directoryMetadata = await lstat(trustDirectory);
+  // Not in the report that prompted this, and the same shape as the two above:
+  // on win32 "private" is the half that was never checked, so it was the half
+  // the message must not lead with. Fixing the other two and leaving this one
+  // would have reproduced the defect from here.
+  if (!directoryMetadata.isDirectory()) {
+    throw new Error(`AGMSG_SYNC_TRUST_DIR must be a directory: ${trustDirectory}`);
+  }
+  if (process.platform !== "win32" && (directoryMetadata.mode & 0o077) !== 0) {
+    throw new Error(
+      `AGMSG_SYNC_TRUST_DIR must not be readable or writable by group or others: ${trustDirectory}`);
   }
   try {
     const handle = await open(path, "wx", 0o600);
@@ -1566,7 +1603,41 @@ export function validateMembers(config, value) {
 // only success does, because only success has to read all of stdout. What this
 // process owns is what it can be sure of releasing, so that is what it releases:
 // a grandchild is left to the operator, not chased through the process tree.
-function runDriver({ args, label, operation, parse, input, rosterFile }) {
+// A child's ending, said so that every platform's answer is legible.
+//
+// `signal ?? code` printed one number and hid which field produced it. On
+// Windows/Git Bash a driver that died to a signal arrives through `code` as a
+// raw wait status -- one report carried `3840` -- and the operator got a bare
+// number with no way to tell it from an ordinary exit status (#782).
+//
+// Both fields are named, and a `code` outside the range an exit status can take
+// is additionally shown DECOMPOSED rather than decoded. Under the POSIX
+// encoding 3840 is `WIFEXITED` with status 15, while the report that raised it
+// described a signal; nobody reproducing this has the platform to settle which
+// layer produced the number. Printing both components lets the operator see
+// which one is non-zero. Asserting one of them would put a second wrong
+// sentence exactly where the first one was, which is the defect this fixes.
+export function describeChildExit(code, signal) {
+  if (signal) return `signal ${signal}`;
+  if (typeof code !== "number") return "no exit status";
+  if (code >= 0 && code <= 255) return `exit ${code}`;
+  return `exit ${code}, outside the 0-255 an exit status can take; ` +
+    `read as a wait status that is exit ${(code >> 8) & 0xff}, signal ${code & 0x7f}`;
+}
+
+// The team's binding path when this process can work one out, and nothing when
+// it cannot. `teamConfigPath` throws without a connection root, and a caller
+// that has none is a caller that still has to be able to run -- the path is for
+// a sentence in a failure message, so it must not become a new way to fail.
+function bindingPathIfKnown(team) {
+  try {
+    return teamConfigPath(team);
+  } catch {
+    return undefined;
+  }
+}
+
+function runDriver({ args, label, operation, parse, input, rosterFile, team, bindingPath }) {
   return new Promise((resolve, reject) => {
     const childEnvironment = { ...process.env };
     delete childEnvironment.AGMSG_SYNC_TOKEN;
@@ -1642,9 +1713,18 @@ function runDriver({ args, label, operation, parse, input, rosterFile }) {
     child.on("exit", (code, signal) => {
       if (failure) { fail(failure); return; }
       if (code === 0 && !signal) return;
+      // The team and the binding path, because the previous fallback said
+      // "inspect its team storage and binding" and named neither -- on a
+      // machine that may hold several teams, that is an instruction with no
+      // object. Both values are the caller's; this function is handed them
+      // rather than reading them back out of `args`, where they sit behind a
+      // positional index that has already been miscounted once.
+      const subject = team === undefined ? "" : ` for team '${team}'`;
       const diagnostic = stderr.trim() ||
-        "driver returned a non-zero exit without diagnostics; inspect its team storage and binding";
-      fail(new Error(`${label} ${operation} failed (${signal ?? code}): ${diagnostic}`));
+        "driver returned a non-zero exit without diagnostics; inspect that team's storage" +
+          (bindingPath === undefined ? " and its binding" : ` and its binding at ${bindingPath}`);
+      fail(new Error(
+        `${label} ${operation} failed${subject} (${describeChildExit(code, signal)}): ${diagnostic}`));
     });
     child.on("close", () => {
       if (failure) { settle(failure, null); return; }
@@ -1666,6 +1746,8 @@ export async function driver(operation, config, input, extra = []) {
       config.remote_team_id, String(config.protocol_version), ...extra],
     label: "storage sync",
     operation,
+    team: config.local_team,
+    bindingPath: bindingPathIfKnown(config.local_team),
     parse: (stdout) => (["resync-status", "resync"].includes(operation) ?
       parseStrictJsonl(stdout) : parseJsonl(stdout)),
     input,
@@ -1694,6 +1776,8 @@ export async function rosterDriver(operation, config, input, extra = []) {
       config.remote_team_id, String(config.protocol_version), ...extra],
     label: "roster sync",
     operation,
+    team: config.local_team,
+    bindingPath: bindingPathIfKnown(config.local_team),
     parse: parseJsonl,
     input,
     // The roster file, resolved here and handed over as one path — not the

--- a/scripts/internal/rename-sync-config.mjs
+++ b/scripts/internal/rename-sync-config.mjs
@@ -23,9 +23,19 @@ try {
   if (error?.code === "ENOENT") process.exit(0);
   throw error;
 }
-if (!metadata.isFile() || metadata.isSymbolicLink() ||
-    (process.platform !== "win32" && (metadata.mode & 0o077) !== 0)) {
-  throw new Error("remote sync config must be a private regular file");
+// Each condition names itself, and the mode test is last so that no message
+// above it can be about permissions -- on win32 that test does not run at all,
+// and a message about privacy was the one thing a Windows operator could not
+// act on (#781, same shape as remote-sync.mjs).
+if (metadata.isSymbolicLink()) {
+  throw new Error(`remote sync config must not be a symbolic link: ${source}`);
+}
+if (!metadata.isFile()) {
+  throw new Error(`remote sync config must be a regular file: ${source}`);
+}
+if (process.platform !== "win32" && (metadata.mode & 0o077) !== 0) {
+  throw new Error(
+    `remote sync config must not be readable or writable by group or others: ${source}`);
 }
 const config = JSON.parse(await readFile(source, "utf8"));
 if (config.local_team !== oldTeam) throw new Error("remote sync config local team mismatch");

--- a/scripts/internal/sync-cipher.mjs
+++ b/scripts/internal/sync-cipher.mjs
@@ -398,19 +398,31 @@ export function nativeAgeIdentity(bytes) {
 
 export function readNativeAgeIdentity(path) {
   try {
-    // Each reason is raised as a CipherStateError so it SURVIVES the catch
-    // below, which otherwise replaces every failure with one sentence about
-    // privacy. On win32 the mode test does not run at all, so that sentence
-    // could not have been earned there -- and a missing file or an unparseable
-    // one produced it just the same (#781, the same shape as remote-sync.mjs).
+    // These reasons are raised as CipherStateError so they SURVIVE the catch
+    // below.
+    //
+    // What that catch collapses is a PLAIN Error: the stat and read failures.
+    // The parser's own CipherStateError already passed through it untouched on
+    // the way in, and still does -- an unparseable identity was never one of
+    // the failures that lost its reason, and the test below pins that it stays
+    // that way.
+    //
+    // What DID lose its reason was a missing file, a directory, an unreadable
+    // one, and a mode this platform may never have checked: on win32 that test
+    // does not run at all, so "not private" was the one thing a Windows
+    // operator could not act on -- and did (#781).
     let metadata;
     try {
       metadata = statSync(path);
     } catch (error) {
-      if (error?.code === "ENOENT") {
-        throw new CipherStateError("pending_key", `age identity was not found: ${path}`);
-      }
-      throw error;
+      // Every stat failure names itself, not just the common one. Leaving the
+      // rest to the generic sentence would keep this defect alive for EACCES
+      // and EPERM, which is where a permissions claim would at least be about
+      // something -- and still not about what happened.
+      const reason = error?.code === "ENOENT"
+        ? "was not found"
+        : `could not be read (${error?.code ?? "unknown error"})`;
+      throw new CipherStateError("pending_key", `age identity ${reason}: ${path}`);
     }
     if (!metadata.isFile()) {
       throw new CipherStateError("pending_key", `age identity must be a regular file: ${path}`);
@@ -420,7 +432,14 @@ export function readNativeAgeIdentity(path) {
       throw new CipherStateError("pending_key",
         `age identity must not be readable or writable by group or others: ${path}`);
     }
-    return nativeAgeIdentity(readFileSync(path));
+    let bytes;
+    try {
+      bytes = readFileSync(path);
+    } catch (error) {
+      throw new CipherStateError("pending_key",
+        `age identity could not be read (${error?.code ?? "unknown error"}): ${path}`);
+    }
+    return nativeAgeIdentity(bytes);
   } catch (error) {
     if (error instanceof CipherStateError) throw error;
     throw new CipherStateError("pending_key", "age identity is not securely readable");

--- a/scripts/internal/sync-cipher.mjs
+++ b/scripts/internal/sync-cipher.mjs
@@ -398,9 +398,27 @@ export function nativeAgeIdentity(bytes) {
 
 export function readNativeAgeIdentity(path) {
   try {
-    const metadata = statSync(path);
-    if (!metadata.isFile() || (process.platform !== "win32" && (metadata.mode & 0o077) !== 0)) {
-      throw new Error("identity file is not private");
+    // Each reason is raised as a CipherStateError so it SURVIVES the catch
+    // below, which otherwise replaces every failure with one sentence about
+    // privacy. On win32 the mode test does not run at all, so that sentence
+    // could not have been earned there -- and a missing file or an unparseable
+    // one produced it just the same (#781, the same shape as remote-sync.mjs).
+    let metadata;
+    try {
+      metadata = statSync(path);
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        throw new CipherStateError("pending_key", `age identity was not found: ${path}`);
+      }
+      throw error;
+    }
+    if (!metadata.isFile()) {
+      throw new CipherStateError("pending_key", `age identity must be a regular file: ${path}`);
+    }
+    // Last, so nothing above it can be mistaken for a permission problem.
+    if (process.platform !== "win32" && (metadata.mode & 0o077) !== 0) {
+      throw new CipherStateError("pending_key",
+        `age identity must not be readable or writable by group or others: ${path}`);
     }
     return nativeAgeIdentity(readFileSync(path));
   } catch (error) {

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -9,6 +9,8 @@ import { readNativeAgeIdentity } from "../scripts/internal/sync-cipher.mjs";
 import {
   ageSnapshotDigest,
   activateKeyRotations,
+  authorityFileFault,
+  describeChildExit,
   canonicalJson,
   consistentReadStateContext,
   configure,
@@ -444,24 +446,79 @@ async function writeConnectedTeam(root, overrides = {}) {
 }
 
 test("connected binding is a bounded non-writable nofollow authority", async () => {
+  // Each refusal names the condition that actually failed. This test used to
+  // accept one sentence about permissions for all three, which is how a
+  // Windows operator -- where the permission test does not run at all -- was
+  // sent to look at modes for a symlink and for an oversized file (#781).
   await withConnectedCredential(async (root) => {
     await writeConnectedTeam(root);
     const path = join(root, "teams", "demo", "config.json");
     if (process.platform !== "win32") {
       await chmod(path, 0o666);
-      await assert.rejects(loadConfig("demo"), /non-writable regular file/u);
+      await assert.rejects(loadConfig("demo"), /must not be writable by group or others/u);
       await unlink(path);
       const target = join(root, "binding-target.json");
       await writeConnectedTeam(root);
       await rename(path, target);
       await symlink(target, path);
-      await assert.rejects(loadConfig("demo"), /non-writable regular file/u);
+      await assert.rejects(loadConfig("demo"), (error) =>
+        // NEGATIVE CONTROL, and the whole point: a symlink must not be
+        // reported as a permission problem. The old message did exactly that.
+        /must not be a symbolic link/u.test(error.message) &&
+        !/writable|group or others/u.test(error.message));
       await unlink(path);
       await rename(target, path);
     }
     await writeFile(path, "x".repeat(2 * 1024 * 1024 + 1), { mode: 0o644 });
-    await assert.rejects(loadConfig("demo"), /non-writable regular file|byte limit/u);
+    await assert.rejects(loadConfig("demo"), (error) =>
+      /must not be larger than \d+ bytes/u.test(error.message) &&
+      !/writable|symbolic link/u.test(error.message));
   });
+});
+
+test("a file fault names the condition that failed, and permissions last", () => {
+  // Directly, because the ordering is the fix: the mode test is consulted only
+  // after the others, so no message above it can be about permissions -- which
+  // is what makes the win32 case (where it is never consulted) safe.
+  const stats = (over = {}) => ({
+    isSymbolicLink: () => false, isFile: () => true, size: 10, mode: 0o600, ...over,
+  });
+  assert.equal(authorityFileFault(stats(), { maxBytes: 100, privateFile: true }), null);
+  assert.match(
+    authorityFileFault(stats({ isSymbolicLink: () => true }), { maxBytes: 100 }),
+    /symbolic link/u);
+  assert.match(
+    authorityFileFault(stats({ isFile: () => false }), { maxBytes: 100 }), /regular file/u);
+  assert.match(
+    authorityFileFault(stats({ size: 101 }), { maxBytes: 100 }), /larger than 100 bytes/u);
+  // A symlink that is ALSO group-writable reports the symlink: the caller can
+  // only act on one, and the one it can act on is the one that is true on
+  // every platform.
+  assert.match(
+    authorityFileFault(stats({ isSymbolicLink: () => true, mode: 0o666 }), { maxBytes: 100 }),
+    /symbolic link/u);
+  if (process.platform !== "win32") {
+    assert.match(
+      authorityFileFault(stats({ mode: 0o666 }), { maxBytes: 100, privateFile: true }),
+      /readable or writable by group or others/u);
+    assert.match(
+      authorityFileFault(stats({ mode: 0o666 }), { maxBytes: 100 }),
+      /must not be writable by group or others/u);
+  }
+});
+
+test("a child's ending is named by field, and an out-of-range code is decomposed", () => {
+  assert.equal(describeChildExit(7, null), "exit 7");
+  assert.equal(describeChildExit(0, "SIGTERM"), "signal SIGTERM");
+  assert.equal(describeChildExit(null, null), "no exit status");
+  // The reported case: 3840 arrived through `code` with no signal. Both
+  // components are shown and NEITHER is asserted as the reading -- under the
+  // POSIX encoding this is an exit status of 15, while the report that raised
+  // it described a signal, and no one reproducing it has that platform.
+  const decomposed = describeChildExit(3840, null);
+  assert.match(decomposed, /exit 3840/u);
+  assert.match(decomposed, /exit 15/u);
+  assert.match(decomposed, /signal 0/u);
 });
 
 test("an age-selected binding never synthesizes a plaintext config", async () => {
@@ -1770,7 +1827,10 @@ exit 7
     // The exit code has to survive: it is the whole diagnostic. So does the
     // stderr collected before the child went away.
     await assert.rejects(() => promise, (error) =>
-      /failed \(7\)/u.test(error.message) && /giving up/u.test(error.message));
+      // The number is labelled and the team is named: `failed (7)` did not say
+      // which field 7 came from, nor which team it was about (#782).
+      /failed for team 't' \(exit 7\)/u.test(error.message) &&
+      /giving up/u.test(error.message));
     assert.ok(gone(childPid), "the failed driver was left running");
   }
 });

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -509,6 +509,56 @@ test("a file fault names the condition that failed, and permissions last", () =>
   }
 });
 
+test("a driver failure names the binding, or says why it cannot be named", async () => {
+  // THE PRODUCTION ENTRY, not the helper beside it: `driver()` resolves the
+  // binding path itself, so this drives the same call a sync makes.
+  //
+  // Two cases, and the second is the one that was silent. `teamConfigPath`
+  // throws without a connection root, and a caller that has none still has to
+  // run -- so the run continues either way, and the difference is what the
+  // failure message can say. Returning `undefined` and dropping the reason is
+  // what #802 collects; reverting to it turns the second half of this red.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-binding-"));
+  const previousDriver = process.env.AGMSG_SYNC_DRIVER;
+  const previousConnection = process.env.AGMSG_SYNC_CONNECTION_DIR;
+  const previousSkill = process.env.SKILL_DIR;
+  try {
+    const script = join(root, "driver.sh");
+    // Exits non-zero with NOTHING on stderr, so the fallback diagnostic -- the
+    // one that names the binding -- is the sentence under test.
+    await writeFile(script, "#!/usr/bin/env bash\ncat > /dev/null\nexit 9\n", { mode: 0o755 });
+    process.env.AGMSG_SYNC_DRIVER = script;
+    const config = {
+      local_team: "t", server_instance_id: "018f3f7e-0000-7000-8000-000000000001",
+      remote_team_id: "018f3f7e-0000-7000-8000-000000000002", protocol_version: 1,
+    };
+
+    process.env.AGMSG_SYNC_CONNECTION_DIR = root;
+    delete process.env.SKILL_DIR;
+    await assert.rejects(() => driver("prepare", config, []), (error) =>
+      error.message.includes(join(root, "teams", "t", "config.json")) &&
+      /failed for team 't'/u.test(error.message));
+
+    // No connection root: the path cannot be resolved. The run still reaches
+    // the driver and still reports its exit -- and now says WHY there is no
+    // path instead of quietly leaving the sentence short.
+    delete process.env.AGMSG_SYNC_CONNECTION_DIR;
+    delete process.env.SKILL_DIR;
+    await assert.rejects(() => driver("prepare", config, []), (error) =>
+      /failed for team 't' \(exit 9\)/u.test(error.message) &&
+      /its path could not be resolved: sync connection root is unavailable/u.test(error.message));
+  } finally {
+    if (previousDriver === undefined) delete process.env.AGMSG_SYNC_DRIVER;
+    else process.env.AGMSG_SYNC_DRIVER = previousDriver;
+    if (previousConnection === undefined) delete process.env.AGMSG_SYNC_CONNECTION_DIR;
+    else process.env.AGMSG_SYNC_CONNECTION_DIR = previousConnection;
+    if (previousSkill === undefined) delete process.env.SKILL_DIR;
+    else process.env.SKILL_DIR = previousSkill;
+    if (!root.startsWith(tmpdir())) throw new Error("unsafe test root");
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("an unreadable age identity says which condition failed, and keeps the parser's own reason", async () => {
   // The real entry point, not a helper beside it. Reverting the change in
   // sync-cipher.mjs turns each of the first three red; the fourth is here to

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmod, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, symlink, unlink,
   writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import { readNativeAgeIdentity } from "../scripts/internal/sync-cipher.mjs";
 import {
   ageSnapshotDigest,
@@ -504,6 +506,94 @@ test("a file fault names the condition that failed, and permissions last", () =>
     assert.match(
       authorityFileFault(stats({ mode: 0o666 }), { maxBytes: 100 }),
       /must not be writable by group or others/u);
+  }
+});
+
+test("an unreadable age identity says which condition failed, and keeps the parser's own reason", async () => {
+  // The real entry point, not a helper beside it. Reverting the change in
+  // sync-cipher.mjs turns each of the first three red; the fourth is here to
+  // pin what must NOT change -- the parser's own reason already survived the
+  // catch on the base, and a fix that started routing it through the generic
+  // sentence would be a regression this file would otherwise not notice.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-identity-"));
+  try {
+    const missing = join(root, "absent.key");
+    assert.throws(() => readNativeAgeIdentity(missing), (error) =>
+      /was not found/u.test(error.message) &&
+      error.message.includes(missing) &&
+      !/securely readable/u.test(error.message));
+
+    const directory = join(root, "a-directory");
+    await mkdir(directory);
+    assert.throws(() => readNativeAgeIdentity(directory), (error) =>
+      /must be a regular file/u.test(error.message) &&
+      error.message.includes(directory) &&
+      !/securely readable|group or others/u.test(error.message));
+
+    const malformedPath = join(root, "malformed.key");
+    await writeFile(malformedPath, "not an age key\nnor is this\n", { mode: 0o600 });
+    assert.throws(() => readNativeAgeIdentity(malformedPath), (error) =>
+      // The parser's own CipherStateError, unchanged: state "malformed", and
+      // NOT the privacy sentence. This already held before this change.
+      error.state === "malformed" && !/securely readable/u.test(error.message));
+
+    if (process.platform !== "win32") {
+      const loose = join(root, "loose.key");
+      await writeFile(loose, "x\n", { mode: 0o666 });
+      assert.throws(() => readNativeAgeIdentity(loose), (error) =>
+        /readable or writable by group or others/u.test(error.message) &&
+        error.message.includes(loose) &&
+        !/regular file|was not found/u.test(error.message));
+    }
+  } finally {
+    if (!root.startsWith(tmpdir())) throw new Error("unsafe test root");
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the rename script says which condition failed, and names the file", async () => {
+  // Driven as the script, because that is how it runs. A helper extracted for
+  // the test would leave the file's own entry point unbound -- which is what
+  // this test exists to stop.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-rename-"));
+  try {
+    const directory = join(root, "remote-sync");
+    await mkdir(directory, { recursive: true });
+    const source = join(directory, "old.json");
+    const script = fileURLToPath(
+      new URL("../scripts/internal/rename-sync-config.mjs", import.meta.url));
+    const run = () => spawnSync(process.execPath, [script, root, "old", "new"], {
+      encoding: "utf8",
+    });
+
+    await writeFile(join(root, "elsewhere.json"), "{}\n", { mode: 0o600 });
+    await symlink(join(root, "elsewhere.json"), source);
+    let result = run();
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /must not be a symbolic link/u);
+    assert.ok(result.stderr.includes(source), "the message names the file");
+    assert.doesNotMatch(result.stderr, /group or others/u);
+    await unlink(source);
+
+    await mkdir(source);
+    result = run();
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /must be a regular file/u);
+    assert.ok(result.stderr.includes(source), "the message names the file");
+    assert.doesNotMatch(result.stderr, /symbolic link|group or others/u);
+    await rm(source, { recursive: true });
+
+    if (process.platform !== "win32") {
+      await writeFile(source, "{}\n", { mode: 0o666 });
+      result = run();
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /must not be readable or writable by group or others/u);
+      assert.ok(result.stderr.includes(source), "the message names the file");
+      assert.doesNotMatch(result.stderr, /symbolic link|must be a regular file/u);
+    }
+  } finally {
+    if (!root.startsWith(tmpdir())) throw new Error("unsafe test root");
+    await rm(root, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
Declared reviewers: 1

**`Refs #781` / `Refs #782`, not `Closes`** — a closing keyword does not fire off
the default branch, and this lands on `integration/remote`. Both issues need
closing by hand afterwards.

Head: **`33f2287554a1b9c039d235ea06f16a28c4e235af`**, rebased onto `integration/remote`
at **`5d3cc9eba4bbaf22ef94e2d652722ff552c2fe13`**. **Every number below is from that
head.**

**This body carried a false sentence about the old behaviour, and a correction
is below rather than a quiet edit.** See *"What the first commit got wrong"*.

---

Two reports, one shape: **a message that states something the run never
established.** One names a permission problem on a platform where permissions
were not consulted; the other prints a number without saying which field it came
from, for a team it does not name.

## #781 — the set is five throws, in three files

The report named two. Deriving the set instead — every
`process.platform !== "win32"` under `scripts/` — gives **nine** guards on the
base, of which **five** throw a message about a condition that guard has already
excluded. The whole set is listed, including what is deliberately untouched,
because a count with no list is the shape that lost the three extra sites in the
first place:

| file | what it said | |
|---|---|---|
| `remote-sync.mjs` bounded authority read | `must be a private / non-writable regular file` | **fixed** |
| `remote-sync.mjs` retained checkpoint | `must be a private regular file` | **fixed** |
| `remote-sync.mjs` `AGMSG_SYNC_TRUST_DIR` | `must be a private directory` | **fixed** — not in the report |
| `rename-sync-config.mjs` | `must be a private regular file` | **fixed** — not in the report |
| `sync-cipher.mjs` age identity | `identity file is not private` | **fixed** — not in the report |
| `remote-sync.mjs` post-open re-check | `changed while it was being opened` | unchanged — true on every platform |
| `remote-sync.mjs` age identity, end of file | *(guarded in full)* | unchanged — on win32 it throws nothing, so it says nothing untrue |
| `remote-sync.mjs` directory `fsync` guard | *(no message)* | unchanged |
| `rename-sync-config.mjs` directory `fsync` guard | *(no message)* | unchanged |

**The fix is an ordering, not a wording.** `authorityFileFault` returns the
condition that actually failed, and the mode test is the **last** thing it
consults — so no message above it can be about permissions, on any platform.
That is what makes the win32 case safe rather than merely reworded. Callers add
the path, which the old messages omitted: they named a property without naming
what had it, on machines that hold several teams.

`readNativeAgeIdentity` needed more than a reworded throw. Its `catch` replaces
a **plain `Error`** with `age identity is not securely readable`, so the stat
and read failures lost their reason. Each of them names itself now — with its
`code` and the path — including `EACCES` and `EPERM`, which an earlier version
of this branch left on the generic sentence while claiming to have covered
"every failure".

## #782 — decomposed, not decoded

`signal ?? code` printed one number and hid which field produced it.

Both fields are named now, and a `code` outside the 0–255 an exit status can
take is additionally shown **decomposed**. **Not decoded, and the report's
reading is corrected**: under the POSIX encoding `3840` is `WIFEXITED` with
status 15, not "terminated by signal 15" — a signal death puts the number in the
**low** bits, and a `bash` in the middle reports `143` rather than passing a
wait status along at all. Nobody reproducing this has the platform to settle
which layer produced the number, so both components are printed and neither is
asserted.

The fallback said *"inspect its team storage and binding"* and named neither.
`runDriver` is handed the team and the binding path rather than reading them
back out of `args` — where they sit behind a positional index the report itself
miscounted, placing the team at `args[1]` where the operation is. Both
corrections are recorded on the issues.

## What the first commit got wrong

`4a804f4`'s message, and the source comment it added, said the old
`readNativeAgeIdentity` collapsed an **unparseable** identity into the privacy
sentence. **That is false.** The parser fails through `malformed()`, which is a
`CipherStateError`, and that `catch` has always begun
`if (error instanceof CipherStateError) throw error` — so a malformed identity
kept its own reason on the base and keeps it now. **The risk this change carried
was breaking that pass-through, not restoring it**, which is the opposite of
what the message claimed. A test pins it.

The correction is in `e7941d1`'s message rather than in a rewritten `4a804f4`.
(Both were `2a6a9ec` and `a5b1ce2` before this branch was rebased onto the
landed base; the rebase renamed them, and this body names the SHAs that exist.)
`git commit --amend` is refused here — *"fix it in the next commit; only ask for
help when the message itself must change"* — and rebuilding the branch would be
the same operation wearing a different name. So the wrong sentence stays in the
history with its correction beside it, touching the same lines, where
`git log -p` and `git blame` both show them together.

## What was claimed and not carried

The first head asserted "five sites fixed" while **`rename-sync-config.mjs` and
`sync-cipher.mjs` could be reverted whole with every test still green.** Review
found that; it was not measured before the request.

Both are bound at their **real entry points** now, not beside them:

- `readNativeAgeIdentity` is called for a missing file, a directory, a loose
  mode, and a malformed key — the last pinning what must **not** change.
- `rename-sync-config.mjs` is **run, as a script**, for a symlink, a directory
  and a loose mode.

Each case asserts its own condition, the path, and the **absence of the other
conditions' words**.

## A fourth silent failure, found here and fixed here

While checking this branch against a pattern being collected elsewhere, the
helper it added for #782 turned out to be an instance of it:

```js
function bindingPathIfKnown(team) {
  try { return teamConfigPath(team); }
  catch { return undefined; }        // the reason goes nowhere
}
```

`teamConfigPath` throws without a connection root, and a caller that has none
still has to run — **swallowing is right here and stays.** What was wrong was
dropping the reason, so a diagnostic that could not name the binding said *"and
its binding"* and stopped. **Being non-fatal was never the defect. Being silent
was.**

The fallback carries it now — `{ path }` or `{ unavailable }` — and the
diagnostic says which it got. Filed as #802 with the other three instances,
including the line between them: two `|| true` left in a diagnostic dump are
correct and are deliberately not changed.

**Driven at the production entry**, not beside it: the new case calls
`driver()`, which resolves the path itself — once with a connection root (the
message names the file) and once without (the message names the reason). Both
halves also assert the run still reached the driver and still reported its
exit, because *continuing* is the property that must not change.

## Tests, on this head

`tests/remote_sync_engine.test.mjs`: **87 pass, 0 fail** (local, this head).

For bats, **CI on this head is the stronger statement** — it runs every shard on
three platforms. Every one is green except `bats (ubuntu-latest 4/4)` and the
`bats` aggregate that depends on it:

```
ubuntu   1/4 2/4 3/4 success        4/4 FAILURE
macos    1/4 2/4 3/4 4/4 success
windows  install helpers, windows runtime (#567)  success
```

The test covering the first site accepted one sentence for all three of its
cases — it was pinning the defect. It now requires each case to name its own
condition, including the negative: a symlink must not be reported as a
permission problem.

| mutation | result |
|---|---|
| the mode test consulted **first** again | **1 failed** |
| `describeChildExit` back to `signal ?? code` | **2 failed** (unit and integration) |
| `sync-cipher.mjs` reverted to base | **1 failed** — the identity control only |
| `rename-sync-config.mjs` reverted to base | **1 failed** — the rename control only |
| the binding-path catch back to `return undefined` | **1 failed** — the production-entry case |

The last two failing **one each** is itself the check: a control that went red
for both reverts would not be binding the file it names.

**One honest limit.** The *integration* symlink case does not discriminate on
this platform: a symlink's mode here is `0o755`, which does not trip the `0o022`
mask, so it would stay green with the order reversed. The unit test around
`authorityFileFault` is what pins the ordering, with a case built to be both a
symlink and group-writable.

Windows itself is not measured — nobody reproducing this has the platform. What
is claimed here is what the code does on the branch `process.platform` takes
there, read from the source and exercised where the guard allows.

`check-private-names`: **clean, 412 files** — and it fires, controlled with a
seat-shaped name injected into a tracked file (1 finding), removed again.

## The one red, and why it is not this branch

`not ok 265 watch: relaunch with the SAME instance id replaces the previous
watcher (#66 preserved)`, failing at `_wait_pidfile "$pf" "$w2"`
(`tests/test_watch.bats:442`). Confirmed on this exact head, not carried over.

**#595 was opened `2026-08-01T20:25:42Z`** and its body names this test *and*
this assertion; its title is *"bats suite flakes across the process-lifecycle
tests: `main` itself fails ~half its runs, a different test each time"*. **This
branch's first commit is `2026-08-14T11:18:42Z`.** The signature is older than
the branch, and it is recorded against `main` itself.

Reachability, re-measured on this head because the head moved:

- the four files this branch changes are `remote-sync.mjs`,
  `rename-sync-config.mjs`, `sync-cipher.mjs`, and the engine test
- `scripts/watch.sh` and `tests/test_watch.bats` reference **none** of them
- `watch.sh` **does** reach `sqlite-sync.sh` — `lib/storage.sh` →
  `agmsg_storage_load` → `storage.sh:382` → `sqlite.sh:510` — and that file
  names `sync-cipher.mjs`. **But the assignment sits inside
  `storage_sync_prepare_push`, and the spawn is inside the same function**;
  the failing test never calls it, and this branch changes no line of
  `sqlite-sync.sh`

That is *"reached, but the failing test does not execute the changed hunk"* —
not *"no direct reference"*.
