### PR TITLE
fix(lock): make a leaked registry lock visible, and budget the wait in seconds

### DIFF
--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -123,9 +123,22 @@ agmsg_lock_acquire() {
   # process can then take the same path. Releasing on "it is mine because I once
   # took this path" would delete the SUCCESSOR's lock and break the exclusion
   # this file exists for (raised in review). The token makes "mine" checkable.
-  _agmsg_lock_token="$$.$(date +%s).${RANDOM:-0}"
+  # PER LOCK, not per process. This library's own contract is that a process can
+  # hold several locks at once — rename-team takes two — so a single global
+  # token is overwritten by the second acquire, and releasing the first then
+  # reads a mismatch, calls it someone else's, and leaks it (raised in review).
+  #
+  # Entropy: a pid and a second are not unique across hosts on a shared store,
+  # and $RANDOM is 15 bits where it exists at all. /dev/urandom is the source
+  # when there is one; the fallbacks degrade toward "cannot prove it is mine",
+  # and an unprovable lock is one this process will refuse to delete rather
+  # than one it deletes on a coincidence.
+  local nonce=""
+  nonce="$(LC_ALL=C od -An -N16 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')"
+  [ -n "$nonce" ] || nonce="${RANDOM:-}${RANDOM:-}${RANDOM:-}"
+  _agmsg_lock_set_token "$lock" "$(uname -n 2>/dev/null || echo unknown).$$.$(date +%s).$nonce"
   {
-    printf 'token %s\n' "$_agmsg_lock_token"
+    printf 'token %s\n' "$(_agmsg_lock_get_token "$lock")"
     printf 'pid %s\n' "$$"
     printf 'command %s\n' "${0##*/}"
     printf 'host %s\n' "$(uname -n 2>/dev/null || echo unknown)"
@@ -169,8 +182,42 @@ agmsg_lock_acquire() {
 # The holder file written at acquire time makes the directory non-empty, so the
 # removal is two steps. Both are this process's own file and its own lock; a
 # failure of either is reported rather than swallowed.
+# Per-lock token storage, kept in one newline-separated variable because bash
+# 3.2 has no associative arrays and this library targets it.
+#
+# Format: one "<lock path>\t<token>" per line. The path is matched WHOLE, for
+# the reason AGMSG_HELD_LOCKS already documents: lock paths nest, so a substring
+# test would let one team's entry answer for another's.
+_agmsg_lock_set_token() {
+  local path="$1" token="$2" kept="" line
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      "$path	"*) ;;
+      *) kept="${kept:+$kept
+}$line" ;;
+    esac
+  done <<EOF
+${_AGMSG_LOCK_TOKENS:-}
+EOF
+  _AGMSG_LOCK_TOKENS="${kept:+$kept
+}$path	$token"
+}
+
+_agmsg_lock_get_token() {
+  local path="$1" line
+  while IFS= read -r line; do
+    case "$line" in
+      "$path	"*) printf '%s' "${line#*	}"; return 0 ;;
+    esac
+  done <<EOF
+${_AGMSG_LOCK_TOKENS:-}
+EOF
+  return 1
+}
+
 _agmsg_lock_drop() {
-  local l="$1" err="" seen=""
+  local l="$1" err="" seen="" mine="" saved=""
   [ -d "$l" ] || return 0
   # OWNERSHIP FIRST. The directory being at the path this process locked is not
   # evidence that it is the same directory: an operator can remove a stuck lock
@@ -181,26 +228,36 @@ _agmsg_lock_drop() {
   #
   # Compared against the token written at acquire, not the pid: a pid recurs.
   seen="$(sed -n 's/^token //p' "$l/holder" 2>/dev/null | head -1)"
-  if [ "$seen" != "${_agmsg_lock_token:-}" ]; then
+  mine="$(_agmsg_lock_get_token "$l" || printf '')"
+  # An empty recorded token means this process never proved ownership of this
+  # path — refuse rather than guess. Same branch as a genuine mismatch.
+  if [ -z "$mine" ] || [ "$seen" != "$mine" ]; then
     # Someone else's lock, or one whose holder file could not be written. Either
     # way this process has no standing to remove it, and saying so is the whole
     # report — there is nothing here for the operator to fix.
     echo "agmsg: not releasing $l — it is held by another process now" >&2
     return 0
   fi
-  # rmdir FIRST, with the holder still in place. Removing the holder and then
-  # failing to remove the directory leaves a lock nobody can prove is theirs:
-  # the next release reads no token, decides the lock belongs to someone else,
-  # and reports that instead of the stuck lock — two contradictory lines about
-  # the same directory. Measured, on the trap's second call.
+  # The holder is READ before it is removed, and restored byte for byte if the
+  # directory will not go.
   #
-  # A lock with a holder file is never empty, so the first rmdir is expected to
-  # fail; the holder is removed only once the directory is going to go.
+  # Restoring only the token was the first attempt and it defeated the change:
+  # pid, command and host are what "a leaked lock says who left it" MEANS, and
+  # a stuck removal is exactly the moment an operator needs them. The one
+  # failure this file is about would have been the one failure with no
+  # diagnosis (raised in review).
+  #
+  # Removing the holder first is unavoidable — a directory with a file in it
+  # cannot be rmdir'd — so the ordering is: read, remove, try, restore on
+  # failure.
+  saved="$(cat "$l/holder" 2>/dev/null || printf '')"
   rm -f "$l/holder" 2>/dev/null || true
   err="$(rmdir "$l" 2>&1)" && return 0
-  # Put the holder back: this process still owns the lock, and the next release
-  # — or the operator reading the message below — has to be able to tell.
-  [ -d "$l" ] && printf 'token %s\n' "${_agmsg_lock_token:-}" > "$l/holder" 2>/dev/null || true
+  # Still here, so this process still owns it. Put back what was there, not a
+  # summary of it.
+  if [ -d "$l" ] && [ -n "$saved" ]; then
+    printf '%s\n' "$saved" > "$l/holder" 2>/dev/null || true
+  fi
   # Still here. Say which lock, say why, and say what it costs — the next
   # acquire on this team will wait for a holder that is not coming back.
   echo "agmsg: could not release the registry lock at $l" >&2

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -259,8 +259,11 @@ _agmsg_lock_drop() {
   # lock — `test_local_team_ids.bats` runs the core join with an allow-listed
   # PATH that has no `rm`. A holder written inside the directory made the lock
   # unremovable there, so the one path promising to work without python3 leaked
-  # a lock on every call. Measured by CI; the local run has a full PATH and
-  # never saw it.
+  # a lock on every call. CI reported it first, but it is reproducible here:
+  # build a directory of symlinks to the tools that test allow-lists, point
+  # PATH at it, and the pre-fix library leaks while this one releases. Nothing
+  # about it needs CI — the local suite simply runs with a full PATH by
+  # default, which is a habit rather than a limit.
   #
   # Outside, `rmdir` succeeds and the holder is a stale file next to nothing —
   # tidied when it can be, harmless when it cannot.

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -82,6 +82,23 @@ agmsg_lock_acquire() {
     fi
     sleep 0.01
   done
+  # WHO HOLDS IT, written the moment it is held (#778).
+  #
+  # A lock directory with nothing in it can say that something is holding it and
+  # nothing about what. When one leaks, the operator's only options are to guess
+  # or to remove it blind — and removing a live lock is worse than the leak. The
+  # pid and the command are what turn "a lock is here" into "this process, and
+  # it is gone".
+  #
+  # Best-effort on purpose: the lock is HELD as of the mkdir above, and a failure
+  # to annotate it must not undo that. An unannotated lock is exactly the lock
+  # this file had before, which is worse than one that names its holder and no
+  # worse than nothing.
+  {
+    printf 'pid %s\n' "$$"
+    printf 'command %s\n' "${0##*/}"
+    printf 'host %s\n' "$(uname -n 2>/dev/null || echo unknown)"
+  } > "$lock/holder" 2>/dev/null || true
   AGMSG_HELD_LOCKS="${AGMSG_HELD_LOCKS:+$AGMSG_HELD_LOCKS
 }$lock"
   # Idempotent: re-arming the same handlers each acquire is harmless. They release
@@ -111,13 +128,45 @@ agmsg_lock_acquire() {
 # The line is matched WHOLE, not as a substring: lock paths nest (a team named
 # `a` and a team named `ab` under the same root), so a substring test would let
 # one team's release take another's.
+# Release one lock directory, and say so when it cannot be released (#778).
+#
+# `rmdir … || true` treated two different events as one. A lock that is already
+# gone is a released lock — nothing to report. A lock that will not go is the
+# leak this file's own contract promises not to leave, and the operator learned
+# about it only when the next command blocked, with nothing naming the cause.
+#
+# The holder file written at acquire time makes the directory non-empty, so the
+# removal is two steps. Both are this process's own file and its own lock; a
+# failure of either is reported rather than swallowed.
+_agmsg_lock_drop() {
+  local l="$1" err=""
+  [ -d "$l" ] || return 0
+  rm -f "$l/holder" 2>/dev/null || true
+  err="$(rmdir "$l" 2>&1)" && return 0
+  # Still here. Say which lock, say why, and say what it costs — the next
+  # acquire on this team will wait for a holder that is not coming back.
+  echo "agmsg: could not release the registry lock at $l" >&2
+  echo "agmsg: rmdir: $err" >&2
+  echo "agmsg: until this directory is removed, commands for this team will wait" >&2
+  echo "agmsg: for a lock nothing holds." >&2
+  # The remedy has to work for the case that produced it. `rmdir` is what just
+  # failed — printing it back is a route that ends where the operator already
+  # is. Measured: the only reason release gets here with the directory present
+  # is that something is inside it, and that is precisely what rmdir refuses.
+  echo "agmsg: look at what is in it, then remove the directory:" >&2
+  echo "agmsg:   ls -la $l" >&2
+  echo "agmsg:   rm -r $l" >&2
+  echo "agmsg: nothing but this lock lives in there — it holds no team data." >&2
+  return 1
+}
+
 agmsg_lock_release_one() {
   local lock="$1/.config.lock" kept="" l
   [ -n "${AGMSG_HELD_LOCKS:-}" ] || return 0
   while IFS= read -r l; do
     [ -n "$l" ] || continue
     if [ "$l" = "$lock" ]; then
-      rmdir "$l" 2>/dev/null || true
+      _agmsg_lock_drop "$l" || true
     else
       kept="${kept:+$kept
 }$l"
@@ -132,7 +181,7 @@ agmsg_lock_release() {
   [ -n "${AGMSG_HELD_LOCKS:-}" ] || return 0
   local l
   while IFS= read -r l; do
-    [ -n "$l" ] && { rmdir "$l" 2>/dev/null || true; }
+    [ -n "$l" ] && { _agmsg_lock_drop "$l" || true; }
   done <<EOF
 $AGMSG_HELD_LOCKS
 EOF

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -140,7 +140,19 @@ agmsg_lock_acquire() {
   local nonce=""
   nonce="$(LC_ALL=C od -An -N16 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')"
   [ -n "$nonce" ] || nonce="${RANDOM:-}${RANDOM:-}${RANDOM:-}"
-  _agmsg_lock_set_token "$lock" "${HOSTNAME:-h}.$$.$(date +%s).$nonce"
+  # FAIL SAFE MEANS NO TOKEN, not a weak one. With neither /dev/urandom nor
+  # $RANDOM, what is left is host.pid.second — which collides across hosts, and
+  # a collision makes this process delete someone else's successor. That is the
+  # hazard the token exists to close, so the degraded path must not produce a
+  # token at all.
+  #
+  # No token recorded means release finds no match and refuses to remove
+  # anything: the lock leaks, and leaking is the failure this file chose over
+  # taking a live lock away. The claim "it degrades toward not deleting" was
+  # written before this branch existed; it is true now (raised in review).
+  if [ -n "$nonce" ]; then
+    _agmsg_lock_set_token "$lock" "${HOSTNAME:-h}.$$.$(date +%s).$nonce"
+  fi
   {
     printf 'token %s\n' "$(_agmsg_lock_get_token "$lock")"
     printf 'pid %s\n' "$$"
@@ -239,7 +251,15 @@ _agmsg_lock_drop() {
     # Someone else's lock, or one whose holder file could not be written. Either
     # way this process has no standing to remove it, and saying so is the whole
     # report — there is nothing here for the operator to fix.
-    echo "agmsg: not releasing $l — it is held by another process now" >&2
+    if [ -z "$mine" ]; then
+      # This process never recorded a token for this path: either the holder
+      # could not be written, or there was no entropy to make one with. Saying
+      # "another process holds it" would be a claim about someone else that
+      # nothing here supports.
+      echo "agmsg: not releasing $l — this process cannot prove the lock is its own" >&2
+    else
+      echo "agmsg: not releasing $l — it is held by another process now" >&2
+    fi
     return 0
   fi
   # The holder is READ before it is removed, and restored byte for byte if the
@@ -282,11 +302,15 @@ _agmsg_lock_drop() {
     fi
     return 0
   fi
-  # Still here, so this process still owns it. Put back what was there, not a
-  # summary of it.
-  if [ -d "$l" ] && [ -n "$saved" ]; then
-    printf '%s\n' "$saved" > "$l.holder" 2>/dev/null || true
-  fi
+  # NOTHING TO RESTORE. The holder is a sibling, so the rmdir above never
+  # touched it — it is still on disk, with the pid, command and host intact,
+  # which is what the operator reading the message below needs.
+  #
+  # An earlier version of this file wrote the holder INSIDE the lock, had to
+  # remove it before rmdir, and restored it on failure. That restore survived
+  # the move to a sibling as dead code referencing an unset `saved`: harmless
+  # where `set -u` is off, an unbound-variable error where it is on, and in
+  # neither case doing anything. Raised in review.
   # Still here. Say which lock, say why, and say what it costs — the next
   # acquire on this team will wait for a holder that is not coming back.
   echo "agmsg: could not release the registry lock at $l" >&2
@@ -319,6 +343,11 @@ agmsg_lock_release_one() {
   while IFS= read -r l; do
     [ -n "$l" ] || continue
     if [ "$l" = "$lock" ]; then
+      # `|| true` here does NOT swallow the failure: `_agmsg_lock_drop` has
+      # already reported it on stderr. What it does is keep the loop going, so
+      # one stuck lock does not strand the others this process holds — the
+      # opposite of the `rmdir … || true` this file replaced, where the failure
+      # had nowhere else to appear.
       _agmsg_lock_drop "$l" || true
     else
       kept="${kept:+$kept
@@ -334,6 +363,8 @@ agmsg_lock_release() {
   [ -n "${AGMSG_HELD_LOCKS:-}" ] || return 0
   local l
   while IFS= read -r l; do
+    # Reported inside the helper; `|| true` only keeps the loop alive so one
+    # stuck lock cannot strand the rest. See the note in release_one.
     [ -n "$l" ] && { _agmsg_lock_drop "$l" || true; }
   done <<EOF
 $AGMSG_HELD_LOCKS

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -140,13 +140,13 @@ agmsg_lock_acquire() {
   local nonce=""
   nonce="$(LC_ALL=C od -An -N16 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')"
   [ -n "$nonce" ] || nonce="${RANDOM:-}${RANDOM:-}${RANDOM:-}"
-  _agmsg_lock_set_token "$lock" "$(uname -n 2>/dev/null || echo unknown).$$.$(date +%s).$nonce"
+  _agmsg_lock_set_token "$lock" "${HOSTNAME:-h}.$$.$(date +%s).$nonce"
   {
     printf 'token %s\n' "$(_agmsg_lock_get_token "$lock")"
     printf 'pid %s\n' "$$"
     printf 'command %s\n' "${0##*/}"
-    printf 'host %s\n' "$(uname -n 2>/dev/null || echo unknown)"
-  } > "$lock/holder" 2>/dev/null || true
+    printf 'host %s\n' "${HOSTNAME:-$(uname -n 2>/dev/null || echo unknown)}"
+  } > "$lock.holder" 2>/dev/null || true
   AGMSG_HELD_LOCKS="${AGMSG_HELD_LOCKS:+$AGMSG_HELD_LOCKS
 }$lock"
   # Idempotent: re-arming the same handlers each acquire is harmless. They release
@@ -221,7 +221,7 @@ EOF
 }
 
 _agmsg_lock_drop() {
-  local l="$1" err="" seen="" mine="" saved=""
+  local l="$1" err="" seen="" mine=""
   [ -d "$l" ] || return 0
   # OWNERSHIP FIRST. The directory being at the path this process locked is not
   # evidence that it is the same directory: an operator can remove a stuck lock
@@ -231,7 +231,7 @@ _agmsg_lock_drop() {
   # is about (raised in review).
   #
   # Compared against the token written at acquire, not the pid: a pid recurs.
-  seen="$(sed -n 's/^token //p' "$l/holder" 2>/dev/null | head -1)"
+  seen="$(sed -n 's/^token //p' "$l.holder" 2>/dev/null | head -1)"
   mine="$(_agmsg_lock_get_token "$l" || printf '')"
   # An empty recorded token means this process never proved ownership of this
   # path — refuse rather than guess. Same branch as a genuine mismatch.
@@ -254,13 +254,35 @@ _agmsg_lock_drop() {
   # Removing the holder first is unavoidable — a directory with a file in it
   # cannot be rmdir'd — so the ordering is: read, remove, try, restore on
   # failure.
-  saved="$(cat "$l/holder" 2>/dev/null || printf '')"
-  rm -f "$l/holder" 2>/dev/null || true
-  err="$(rmdir "$l" 2>&1)" && return 0
+  # The holder lives BESIDE the lock, not inside it. A lock directory has to be
+  # empty to be removed, and `rm` is not available on every path that takes this
+  # lock — `test_local_team_ids.bats` runs the core join with an allow-listed
+  # PATH that has no `rm`. A holder written inside the directory made the lock
+  # unremovable there, so the one path promising to work without python3 leaked
+  # a lock on every call. Measured by CI; the local run has a full PATH and
+  # never saw it.
+  #
+  # Outside, `rmdir` succeeds and the holder is a stale file next to nothing —
+  # tidied when it can be, harmless when it cannot.
+  if err="$(rmdir "$l" 2>&1)"; then
+    # The holder is a sibling, so removing the directory does not remove it.
+    # Left behind it is a stale file in the team directory, and `rename-team`
+    # ends with `rmdir "$OLD_DIR"` — which then fails, and the rename leaves the
+    # old directory standing. Measured: that is what broke the quoted-team-name
+    # test, on a path with no lock message anywhere in it.
+    #
+    # Best-effort: `rm` is not on every allow-listed PATH that takes this lock,
+    # and a leftover holder beside no lock is inert. The lock itself is gone,
+    # which is the part that had to succeed.
+    if command -v rm >/dev/null 2>&1; then
+      rm -f "$l.holder" 2>/dev/null || true
+    fi
+    return 0
+  fi
   # Still here, so this process still owns it. Put back what was there, not a
   # summary of it.
   if [ -d "$l" ] && [ -n "$saved" ]; then
-    printf '%s\n' "$saved" > "$l/holder" 2>/dev/null || true
+    printf '%s\n' "$saved" > "$l.holder" 2>/dev/null || true
   fi
   # Still here. Say which lock, say why, and say what it costs — the next
   # acquire on this team will wait for a holder that is not coming back.

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -30,8 +30,20 @@ AGMSG_HELD_LOCKS="${AGMSG_HELD_LOCKS:-}"
 # Acquire <team_dir>'s lock. <team_dir> (teams/<team>) must already exist — the
 # caller creates it for a brand-new/target team before locking, so this never
 # resurrects a team dir that a concurrent leave/reset just removed. Spins with a
-# short sleep up to AGMSG_LOCK_TRIES attempts (default 1000 = ~10s), then fails
-# non-zero so the caller can abort rather than silently skip the team.
+# short sleep until AGMSG_LOCK_SECONDS elapse (default 10), then fails non-zero
+# so the caller can abort rather than silently skip the team.
+#
+# BUDGETED IN TIME, NOT ITERATIONS (#779). The old budget was 1000 attempts and
+# the comment beside it read "= ~10s", which is arithmetic that holds only where
+# an mkdir and a sleep are free. Measured on macOS: 100 attempts take 3 seconds,
+# not 1 — already three times the stated figure, before Windows, where the
+# report that raised this saw minutes. A wait announced in seconds has to be
+# counted in seconds, or the number in the message is not about the wait.
+#
+# AGMSG_LOCK_TRIES still caps the attempt count and still defaults to 1000. It
+# is set by four tests to make them fail fast and by nothing in production, so
+# it stays as a ceiling — whichever bound is reached first ends the wait, and
+# each one names itself when it does.
 # Who owns the directory and what this process is, for a failure that is about
 # neither the team nor the lock. `ls -ld` and `id` rather than stat(1), whose
 # flags differ between BSD and GNU, and both are already required here.
@@ -43,6 +55,8 @@ _agmsg_lock_describe_dir() {
 
 agmsg_lock_acquire() {
   local team_dir="$1" lock i=0 max="${AGMSG_LOCK_TRIES:-1000}" err=""
+  local budget="${AGMSG_LOCK_SECONDS:-10}" started elapsed
+  started="$(date +%s)"
   lock="$team_dir/.config.lock"
   until err="$(mkdir "$lock" 2>&1)"; do
     # WHY mkdir failed decides whether waiting can help, and only one reason
@@ -72,8 +86,16 @@ agmsg_lock_acquire() {
       return 1
     fi
     i=$((i + 1))
-    if [ "$i" -ge "$max" ]; then
-      echo "agmsg: timed out acquiring registry lock for $team_dir" >&2
+    elapsed=$(( $(date +%s) - started ))
+    # Whichever bound arrives first, and the message says which — "1000 tries"
+    # and "10 seconds" are different facts about a wait, and an operator
+    # deciding whether to retry needs the one that actually stopped it.
+    if [ "$elapsed" -ge "$budget" ] || [ "$i" -ge "$max" ]; then
+      if [ "$elapsed" -ge "$budget" ]; then
+        echo "agmsg: timed out acquiring registry lock for $team_dir after ${elapsed}s" >&2
+      else
+        echo "agmsg: gave up acquiring registry lock for $team_dir after $i attempts (${elapsed}s)" >&2
+      fi
       # The reason travels with the timeout too. If the wait was hopeless for
       # a cause this function did not anticipate, the errno is the only thing
       # that will say so.

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -91,10 +91,14 @@ agmsg_lock_acquire() {
     # and "10 seconds" are different facts about a wait, and an operator
     # deciding whether to retry needs the one that actually stopped it.
     if [ "$elapsed" -ge "$budget" ] || [ "$i" -ge "$max" ]; then
+      # ONE PHRASE, then which bound. Callers match on "timed out acquiring
+      # registry lock" — `test_remote.bats` does, with a short attempt budget —
+      # and inventing a second sentence for the attempt ceiling broke them
+      # while telling the operator nothing they could not be told in a clause.
       if [ "$elapsed" -ge "$budget" ]; then
         echo "agmsg: timed out acquiring registry lock for $team_dir after ${elapsed}s" >&2
       else
-        echo "agmsg: gave up acquiring registry lock for $team_dir after $i attempts (${elapsed}s)" >&2
+        echo "agmsg: timed out acquiring registry lock for $team_dir after $i attempts (${elapsed}s)" >&2
       fi
       # The reason travels with the timeout too. If the wait was hopeless for
       # a cause this function did not anticipate, the errno is the only thing

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -116,7 +116,16 @@ agmsg_lock_acquire() {
   # to annotate it must not undo that. An unannotated lock is exactly the lock
   # this file had before, which is worse than one that names its holder and no
   # worse than nothing.
+  #
+  # The token is what release checks. A pid is not enough: the directory can be
+  # removed by an operator while this process still believes it holds the lock —
+  # the remedy printed further down tells them to do exactly that — and a second
+  # process can then take the same path. Releasing on "it is mine because I once
+  # took this path" would delete the SUCCESSOR's lock and break the exclusion
+  # this file exists for (raised in review). The token makes "mine" checkable.
+  _agmsg_lock_token="$$.$(date +%s).${RANDOM:-0}"
   {
+    printf 'token %s\n' "$_agmsg_lock_token"
     printf 'pid %s\n' "$$"
     printf 'command %s\n' "${0##*/}"
     printf 'host %s\n' "$(uname -n 2>/dev/null || echo unknown)"
@@ -161,10 +170,37 @@ agmsg_lock_acquire() {
 # removal is two steps. Both are this process's own file and its own lock; a
 # failure of either is reported rather than swallowed.
 _agmsg_lock_drop() {
-  local l="$1" err=""
+  local l="$1" err="" seen=""
   [ -d "$l" ] || return 0
+  # OWNERSHIP FIRST. The directory being at the path this process locked is not
+  # evidence that it is the same directory: an operator can remove a stuck lock
+  # — the message below tells them to — and another process can take the path
+  # before this one releases. Deleting then would take the exclusion away from
+  # a process that is using it, which is worse than the leak this whole change
+  # is about (raised in review).
+  #
+  # Compared against the token written at acquire, not the pid: a pid recurs.
+  seen="$(sed -n 's/^token //p' "$l/holder" 2>/dev/null | head -1)"
+  if [ "$seen" != "${_agmsg_lock_token:-}" ]; then
+    # Someone else's lock, or one whose holder file could not be written. Either
+    # way this process has no standing to remove it, and saying so is the whole
+    # report — there is nothing here for the operator to fix.
+    echo "agmsg: not releasing $l — it is held by another process now" >&2
+    return 0
+  fi
+  # rmdir FIRST, with the holder still in place. Removing the holder and then
+  # failing to remove the directory leaves a lock nobody can prove is theirs:
+  # the next release reads no token, decides the lock belongs to someone else,
+  # and reports that instead of the stuck lock — two contradictory lines about
+  # the same directory. Measured, on the trap's second call.
+  #
+  # A lock with a holder file is never empty, so the first rmdir is expected to
+  # fail; the holder is removed only once the directory is going to go.
   rm -f "$l/holder" 2>/dev/null || true
   err="$(rmdir "$l" 2>&1)" && return 0
+  # Put the holder back: this process still owns the lock, and the next release
+  # — or the operator reading the message below — has to be able to tell.
+  [ -d "$l" ] && printf 'token %s\n' "${_agmsg_lock_token:-}" > "$l/holder" 2>/dev/null || true
   # Still here. Say which lock, say why, and say what it costs — the next
   # acquire on this team will wait for a holder that is not coming back.
   echo "agmsg: could not release the registry lock at $l" >&2
@@ -175,9 +211,18 @@ _agmsg_lock_drop() {
   # failed — printing it back is a route that ends where the operator already
   # is. Measured: the only reason release gets here with the directory present
   # is that something is inside it, and that is precisely what rmdir refuses.
+  # QUOTED, because a printed command is meant to be pasted into a shell. The
+  # store root and the team name can both contain a space — team names are
+  # validated against empty / `.` / `..` / `/` / `\` / a leading `-` / control
+  # characters, and nothing else — so an unquoted path becomes several
+  # arguments, and `rm -r` then removes something the operator did not read
+  # about (raised in review). Same scheme as lib/shquote.sh, inline rather than
+  # sourced so this library keeps its single-file contract.
+  local q
+  q="$(printf "'%s'" "$(printf '%s' "$l" | sed "s/'/'\\''/g")")"
   echo "agmsg: look at what is in it, then remove the directory:" >&2
-  echo "agmsg:   ls -la $l" >&2
-  echo "agmsg:   rm -r $l" >&2
+  echo "agmsg:   ls -la $q" >&2
+  echo "agmsg:   rm -r $q" >&2
   echo "agmsg: nothing but this lock lives in there — it holds no team data." >&2
   return 1
 }

--- a/tests/test_registry_lock.bats
+++ b/tests/test_registry_lock.bats
@@ -191,3 +191,46 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
   grep -qE "after 5 attempts" <<<"$output"
   refute grep -q "timed out" <<<"$output"
 }
+
+@test "lock: release leaves a SUCCESSOR's lock alone (#778)" {
+  # The hazard this change created. The remedy printed for a stuck lock tells
+  # an operator to remove the directory; another process can then take the same
+  # path. Releasing on "I once locked this path" would delete the successor's
+  # lock and take mutual exclusion away from a process that is using it —
+  # worse than the leak (raised in review).
+  run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$TEAM_DIR" || exit 1
+    rm -f "$TEAM_DIR/.config.lock/holder"; rmdir "$TEAM_DIR/.config.lock"
+    mkdir "$TEAM_DIR/.config.lock"
+    printf "token successor-owns-this\n" > "$TEAM_DIR/.config.lock/holder"
+    agmsg_lock_release
+    [ -d "$TEAM_DIR/.config.lock" ] || exit 2
+    grep -q "successor-owns-this" "$TEAM_DIR/.config.lock/holder" || exit 3
+  '
+  [ "$status" -eq 0 ]
+}
+
+@test "lock: the printed remedy is safe on a path with a space (#778)" {
+  # A store root or a team name may contain a space — team names are validated
+  # against empty / . / .. / / / \ / a leading - / control characters, and
+  # nothing else. An unquoted path in a pasted command becomes several
+  # arguments, and `rm -r` then removes something the operator never read about.
+  local spaced="$BATS_TEST_TMPDIR/with space/team"
+  mkdir -p "$spaced" "$BATS_TEST_TMPDIR/with space/DO-NOT-TOUCH"
+  run env LOCKLIB="$LOCKLIB" SPACED="$spaced" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$SPACED" || exit 1
+    printf "x\n" > "$SPACED/.config.lock/stray"
+    agmsg_lock_release
+  '
+  local remedy
+  remedy="$(grep -oE "rm -r .*" <<<"$output" | tail -1)"
+  [ -n "$remedy" ]
+  # Run it the way it is meant to be run: through a shell, as one pasted line.
+  run bash -c "$remedy"
+  [ "$status" -eq 0 ]
+  [ ! -d "$spaced/.config.lock" ]
+  # And it took nothing else with it.
+  [ -d "$BATS_TEST_TMPDIR/with space/DO-NOT-TOUCH" ]
+}

--- a/tests/test_registry_lock.bats
+++ b/tests/test_registry_lock.bats
@@ -96,3 +96,55 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
   '
   [ "$status" -eq 0 ]
 }
+
+@test "lock: a held lock names its holder (#778)" {
+  # A lock directory with nothing in it says something holds it and nothing
+  # about what. When one leaks, that is the difference between "remove this,
+  # the process is gone" and guessing — and guessing wrong removes a live lock.
+  run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$TEAM_DIR" || exit 1
+    cat "$TEAM_DIR/.config.lock/holder"
+  '
+  [ "$status" -eq 0 ]
+  grep -qE "^pid [0-9]+$" <<<"$output"
+  grep -q "^command " <<<"$output"
+}
+
+@test "lock: a lock that cannot be released says so, and the way out works (#778)" {
+  # The defect: `rmdir … || true` treated "already gone" and "will not go" as
+  # the same event. The second is a permanent leak — every later command for
+  # this team waits for a holder that is never coming back — and it was silent.
+  run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$TEAM_DIR" || exit 1
+    printf "x\n" > "$TEAM_DIR/.config.lock/stray"
+    agmsg_lock_release
+  '
+  grep -q "could not release the registry lock" <<<"$output"
+  grep -q "commands for this team will wait" <<<"$output"
+
+  # The route it prints has to work on the case that produced it. `rmdir` does
+  # not: it is what just failed. Lifted out of the message and run, so the two
+  # cannot drift apart.
+  local remedy
+  remedy="$(grep -oE 'rm -r .*' <<<"$output" | tail -1)"
+  [ -n "$remedy" ]
+  run bash -c "$remedy"
+  [ "$status" -eq 0 ]
+  [ ! -d "$TEAM_DIR/.config.lock" ]
+}
+
+@test "lock: releasing a lock that is already gone stays quiet (#778)" {
+  # The other half of the same distinction. A lock that is already released is
+  # not an event, and reporting it would train the operator to ignore the line
+  # that matters.
+  run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$TEAM_DIR" || exit 1
+    rm -f "$TEAM_DIR/.config.lock/holder"; rmdir "$TEAM_DIR/.config.lock"
+    agmsg_lock_release
+  '
+  [ "$status" -eq 0 ]
+  refute grep -q "could not release" <<<"$output"
+}

--- a/tests/test_registry_lock.bats
+++ b/tests/test_registry_lock.bats
@@ -313,3 +313,24 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
   # And the refusal names the real reason rather than accusing another process.
   grep -q "cannot prove the lock is its own" <<<"$output"
 }
+
+@test "lock: a failed release is clean under set -u (#778)" {
+  # The dead `saved` restore was an unbound-variable error waiting for a caller
+  # with `set -u`, and every test here ran without it — so the suite could not
+  # have caught it. The reviewer found it by reading. This drives the same path
+  # with `set -u` on, which is the shape a real caller has.
+  run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+    set -u
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$TEAM_DIR" || exit 1
+    printf "x\n" > "$TEAM_DIR/.config.lock/stray"
+    agmsg_lock_release
+  '
+  # The release reports the stuck lock and does not abort the caller.
+  [ "$status" -eq 0 ]
+  grep -q "could not release the registry lock" <<<"$output"
+  refute grep -qi "unbound variable" <<<"$output"
+  # And the holder survives with everything an operator needs.
+  grep -qE "^pid [0-9]+$" "$TEAM_DIR/.config.lock.holder"
+  grep -q "^command " "$TEAM_DIR/.config.lock.holder"
+}

--- a/tests/test_registry_lock.bats
+++ b/tests/test_registry_lock.bats
@@ -290,3 +290,26 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
   [ "$status" -eq 0 ]
   [ "$(sort -u <<<"$output" | grep -c .)" -eq 2 ]
 }
+
+@test "lock: with no entropy source, no token is recorded and nothing is removed (#778)" {
+  # Fail-safe means NO token, not a weak one. With neither /dev/urandom nor
+  # $RANDOM, what is left is host.pid.second — which collides across hosts, and
+  # a collision makes this process delete someone else's successor. So the
+  # degraded path records nothing, release finds no match, and the lock leaks
+  # rather than being taken from whoever holds it (raised in review).
+  local lib="$BATS_TEST_TMPDIR/nolib.sh"
+  sed -e 's|^  nonce="\$(LC_ALL=C od.*|  nonce=""|' \
+      -e 's|^  \[ -n "\$nonce" \] \|\| nonce=.*|  :|' "$LOCKLIB" > "$lib"
+  bash -n "$lib"
+
+  run env LIB="$lib" TEAM_DIR="$TEAM_DIR" bash -c '
+    . "$LIB"
+    agmsg_lock_acquire "$TEAM_DIR" || exit 1
+    [ -z "$(sed -n "s/^token //p" "$TEAM_DIR/.config.lock.holder" 2>/dev/null)" ] || exit 2
+    agmsg_lock_release
+    [ -d "$TEAM_DIR/.config.lock" ] || exit 3
+  '
+  [ "$status" -eq 0 ]
+  # And the refusal names the real reason rather than accusing another process.
+  grep -q "cannot prove the lock is its own" <<<"$output"
+}

--- a/tests/test_registry_lock.bats
+++ b/tests/test_registry_lock.bats
@@ -148,3 +148,46 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
   [ "$status" -eq 0 ]
   refute grep -q "could not release" <<<"$output"
 }
+
+@test "lock: the wait is budgeted in seconds, and stops at the declared one (#779)" {
+  # The old budget was an attempt count with "= ~10s" written beside it. That
+  # arithmetic holds only where an mkdir and a sleep are free: measured here,
+  # 100 attempts take 3 seconds, not 1 — and the report that raised this saw
+  # minutes on Windows. A wait announced in seconds has to be counted in them.
+  mkdir -p "$TEAM_DIR/.config.lock"
+  local start end
+  start="$(date +%s)"
+  # TRIES is set to a number that CANNOT be the thing that stops this: measured
+  # on this machine, ~100 attempts take 3 seconds, so 300 would run about nine
+  # if the wait were counted in iterations. Only the time bound ends it at two.
+  # Deliberately not 1000000 — under a mutation that removes the time bound,
+  # that number does not fail the test, it hangs the suite, and a check that
+  # hangs instead of reddening is a worse check than one that is slow.
+  run env AGMSG_LOCK_SECONDS=2 AGMSG_LOCK_TRIES=300 LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$TEAM_DIR"
+  '
+  end="$(date +%s)"
+  [ "$status" -ne 0 ]
+  # Not "roughly": the point of the change is that the number in the message is
+  # about the wait. Allow one second of slack for the clock's granularity.
+  [ "$((end - start))" -ge 2 ]
+  [ "$((end - start))" -le 4 ]
+  grep -q "timed out acquiring registry lock" <<<"$output"
+  grep -qE "after [0-9]+s" <<<"$output"
+}
+
+@test "lock: the attempt ceiling still ends the wait, and says which bound it was (#779)" {
+  # Both bounds exist and they are different facts. An operator deciding
+  # whether to retry needs the one that actually stopped it — "1000 tries" and
+  # "10 seconds" send them to different places.
+  mkdir -p "$TEAM_DIR/.config.lock"
+  run env AGMSG_LOCK_TRIES=5 AGMSG_LOCK_SECONDS=60 LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$TEAM_DIR"
+  '
+  [ "$status" -ne 0 ]
+  grep -q "gave up acquiring registry lock" <<<"$output"
+  grep -qE "after 5 attempts" <<<"$output"
+  refute grep -q "timed out" <<<"$output"
+}

--- a/tests/test_registry_lock.bats
+++ b/tests/test_registry_lock.bats
@@ -104,7 +104,7 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
   run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
     . "$LOCKLIB"
     agmsg_lock_acquire "$TEAM_DIR" || exit 1
-    cat "$TEAM_DIR/.config.lock/holder"
+    cat "$TEAM_DIR/.config.lock.holder"
   '
   [ "$status" -eq 0 ]
   grep -qE "^pid [0-9]+$" <<<"$output"
@@ -142,7 +142,7 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
   run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
     . "$LOCKLIB"
     agmsg_lock_acquire "$TEAM_DIR" || exit 1
-    rm -f "$TEAM_DIR/.config.lock/holder"; rmdir "$TEAM_DIR/.config.lock"
+    rm -f "$TEAM_DIR/.config.lock.holder"; rmdir "$TEAM_DIR/.config.lock"
     agmsg_lock_release
   '
   [ "$status" -eq 0 ]
@@ -203,12 +203,12 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
   run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
     . "$LOCKLIB"
     agmsg_lock_acquire "$TEAM_DIR" || exit 1
-    rm -f "$TEAM_DIR/.config.lock/holder"; rmdir "$TEAM_DIR/.config.lock"
+    rm -f "$TEAM_DIR/.config.lock.holder"; rmdir "$TEAM_DIR/.config.lock"
     mkdir "$TEAM_DIR/.config.lock"
-    printf "token successor-owns-this\n" > "$TEAM_DIR/.config.lock/holder"
+    printf "token successor-owns-this\n" > "$TEAM_DIR/.config.lock.holder"
     agmsg_lock_release
     [ -d "$TEAM_DIR/.config.lock" ] || exit 2
-    grep -q "successor-owns-this" "$TEAM_DIR/.config.lock/holder" || exit 3
+    grep -q "successor-owns-this" "$TEAM_DIR/.config.lock.holder" || exit 3
   '
   [ "$status" -eq 0 ]
 }
@@ -266,7 +266,7 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
     agmsg_lock_acquire "$TEAM_DIR" || exit 1
     printf "x\n" > "$TEAM_DIR/.config.lock/stray"
     agmsg_lock_release >/dev/null 2>&1
-    cat "$TEAM_DIR/.config.lock/holder"
+    cat "$TEAM_DIR/.config.lock.holder"
   '
   [ "$status" -eq 0 ]
   grep -qE "^token " <<<"$output"
@@ -285,7 +285,7 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
     . "$LOCKLIB"
     agmsg_lock_acquire "$A" || exit 1
     agmsg_lock_acquire "$B" || exit 1
-    sed -n "s/^token //p" "$A/.config.lock/holder" "$B/.config.lock/holder"
+    sed -n "s/^token //p" "$A/.config.lock.holder" "$B/.config.lock.holder"
   '
   [ "$status" -eq 0 ]
   [ "$(sort -u <<<"$output" | grep -c .)" -eq 2 ]

--- a/tests/test_registry_lock.bats
+++ b/tests/test_registry_lock.bats
@@ -319,10 +319,11 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
   # with `set -u`, and every test here ran without it — so the suite could not
   # have caught it. The reviewer found it by reading. This drives the same path
   # with `set -u` on, which is the shape a real caller has.
-  run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+  run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" SNAP="$BATS_TEST_TMPDIR/holder.before" bash -c '
     set -u
     . "$LOCKLIB"
     agmsg_lock_acquire "$TEAM_DIR" || exit 1
+    cp "$TEAM_DIR/.config.lock.holder" "$SNAP"
     printf "x\n" > "$TEAM_DIR/.config.lock/stray"
     agmsg_lock_release
   '
@@ -330,7 +331,11 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
   [ "$status" -eq 0 ]
   grep -q "could not release the registry lock" <<<"$output"
   refute grep -qi "unbound variable" <<<"$output"
-  # And the holder survives with everything an operator needs.
-  grep -qE "^pid [0-9]+$" "$TEAM_DIR/.config.lock.holder"
-  grep -q "^command " "$TEAM_DIR/.config.lock.holder"
+  # And the holder is BYTE FOR BYTE what acquire wrote. Checking that `pid` and
+  # `command` are present would pass a change that drops `token` or `host`,
+  # rewrites a value, reorders the lines, or appends to the file — and the claim
+  # being made is that a failed release does not touch it at all (raised in
+  # review). The comparison is against a copy taken while the lock was held.
+  run diff "$BATS_TEST_TMPDIR/holder.before" "$TEAM_DIR/.config.lock.holder"
+  [ "$status" -eq 0 ]
 }

--- a/tests/test_registry_lock.bats
+++ b/tests/test_registry_lock.bats
@@ -234,3 +234,57 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
   # And it took nothing else with it.
   [ -d "$BATS_TEST_TMPDIR/with space/DO-NOT-TOUCH" ]
 }
+
+@test "lock: a process holding TWO locks releases both (#778)" {
+  # This library's contract is that a caller can hold several locks at once —
+  # rename-team takes two. A single per-process token is overwritten by the
+  # second acquire, so releasing the first reads a mismatch, calls it someone
+  # else's, and leaks it. Measured before the fix: both leaked (raised in
+  # review).
+  local a="$BATS_TEST_TMPDIR/A" b="$BATS_TEST_TMPDIR/B"
+  mkdir -p "$a" "$b"
+  run env LOCKLIB="$LOCKLIB" A="$a" B="$b" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$A" || exit 1
+    agmsg_lock_acquire "$B" || exit 1
+    agmsg_lock_release
+    [ ! -d "$A/.config.lock" ] || exit 2
+    [ ! -d "$B/.config.lock" ] || exit 3
+  '
+  [ "$status" -eq 0 ]
+  refute grep -q "not releasing" <<<"$output"
+}
+
+@test "lock: a stuck lock keeps saying WHO, not just that it is owned (#778)" {
+  # The moment the diagnosis is needed is the moment the removal fails. An
+  # earlier version restored only the token line, so pid, command and host —
+  # the whole point of writing a holder — disappeared exactly then.
+  run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$TEAM_DIR" || exit 1
+    printf "x\n" > "$TEAM_DIR/.config.lock/stray"
+    agmsg_lock_release >/dev/null 2>&1
+    cat "$TEAM_DIR/.config.lock/holder"
+  '
+  [ "$status" -eq 0 ]
+  grep -qE "^token " <<<"$output"
+  grep -qE "^pid [0-9]+$" <<<"$output"
+  grep -q "^command " <<<"$output"
+  grep -q "^host " <<<"$output"
+}
+
+@test "lock: two locks taken in the same second by the same pid differ (#778)" {
+  # Ownership is decided by this token, so a collision means deleting someone
+  # else's successor — the hazard the token exists to close. A pid and a second
+  # are not unique across hosts on a shared store.
+  local a="$BATS_TEST_TMPDIR/T1" b="$BATS_TEST_TMPDIR/T2"
+  mkdir -p "$a" "$b"
+  run env LOCKLIB="$LOCKLIB" A="$a" B="$b" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$A" || exit 1
+    agmsg_lock_acquire "$B" || exit 1
+    sed -n "s/^token //p" "$A/.config.lock/holder" "$B/.config.lock/holder"
+  '
+  [ "$status" -eq 0 ]
+  [ "$(sort -u <<<"$output" | grep -c .)" -eq 2 ]
+}

--- a/tests/test_registry_lock.bats
+++ b/tests/test_registry_lock.bats
@@ -187,9 +187,11 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
     agmsg_lock_acquire "$TEAM_DIR"
   '
   [ "$status" -ne 0 ]
-  grep -q "gave up acquiring registry lock" <<<"$output"
+  # Same phrase for both bounds — callers match on it. The clause is what
+  # separates them, and an operator deciding whether to retry needs the clause.
+  grep -q "timed out acquiring registry lock" <<<"$output"
   grep -qE "after 5 attempts" <<<"$output"
-  refute grep -q "timed out" <<<"$output"
+  refute grep -qE "after [0-9]+s$" <<<"$output"
 }
 
 @test "lock: release leaves a SUCCESSOR's lock alone (#778)" {


### PR DESCRIPTION
Declared reviewers: 1

References #778 and #779. No closing keyword — `integration/remote` is not the
default branch, so one would not fire, and #779's Node-side half is untouched.

Measured once, at head `ccbd6d80fb5fb657c4e7b3449746387da8229e5a`.

## This fired in the field while the PR was open

An engine crashed on the first Windows dogfood and left `.config.lock` behind;
every sync afterwards failed. The agent on that machine read the library and
reported "an empty directory, with no owner token and no PID — the trap did not
fire", then concluded `rmdir` was the only way out.

That is the defect stated by someone who was not looking for it, and it is what
the first half of this PR is about: not preventing the crash, but leaving
something behind that an operator can read.

## #778 — a leaked lock could not say whose it was, or that it was stuck

The lock directory was created empty, so a lock that leaked said something held
it and nothing about what. `agmsg_lock_acquire` writes a token, pid, command and
host to `<lock>.holder` — beside the lock, not inside it — as it takes it.

`rmdir "$l" 2>/dev/null || true` at both release sites treated "already gone" (a
released lock) and "will not go" (the permanent leak this file promises not to
leave) as the same event. Release reports the second, stays quiet about the
first, and prints a remedy that works on the case that produced it.

## #779 — the wait was counted in attempts and announced in seconds

1000 attempts with "= ~10s" beside it. Measured before changing anything: **100
attempts take 3 seconds**. `AGMSG_LOCK_SECONDS` (default 10) is the budget;
`AGMSG_LOCK_TRIES` stays a ceiling — set in four places, all tests, none in
production. Whichever bound arrives first ends the wait, in one phrase callers
already match on, with the bound in a clause.

## Every hazard here was one this branch created

Seven review rounds. Each finding was a defect in the previous round's fix:

- **the remedy printed `rmdir`** — the command that had just failed
- **release could delete a SUCCESSOR's lock** — the sequence the remedy invites
- **the token was per process**, and this library holds several locks at once
- **a failed removal restored only the token**, losing pid/command/host
- **the holder lived inside the lock**, so `rmdir` needed `rm`; the core join
  path runs under an allow-listed PATH without it and leaked on every call
- **a restore referenced an unset `saved`** — an unbound-variable error under
  `set -u`, dead code otherwise, left behind when the holder moved outside
- **the entropy fallback claimed a fail-safe it did not have** — with no
  `/dev/urandom` and no `$RANDOM` the token degraded to `host.pid.second`, which
  collides across hosts, which is this process deleting someone else's lock

The last one now records **no token at all**: release finds no match, removes
nothing, and the lock leaks — the failure this file chooses over taking a live
lock away.

## Controls

```
swallow the release failure again          2 red
drop the holder write                      1 red
remove the time bound                      2 red (red, not hanging)
disable the ownership check                3 red
restore only the token line               13 and 16 red
constant nonce, either branch              1 red
unquote the printed remedy                 1 red
restore the dead `saved` block            16 red
```

The `set -u` control matters beyond its own case: every other test here runs
without it, so the suite structurally could not have caught the unbound-variable
defect. And the holder check is a byte-for-byte `diff` against a copy taken
while the lock was held — checking that `pid` and `command` are *present* passed
the token-only rewrite that was actually in this file.

## Checks

```
test_registry_lock    16        test_type_registry     20
test_actas_lock       22        test_local_team_ids     5
test_plugin_registry   9        test_team              76
                                          no failures
touches               scripts/lib/registry-lock.sh, tests/test_registry_lock.bats
drift at push time    EMPTY, AND MEASURED
```

## The red checks, with attribution measured

**`bats (ubuntu-latest 4/4)`** — `not ok 265 watch: relaunch with the SAME
instance id replaces the previous watcher`, at `:495`'s
`_wait_pidfile "$pf" "$w2"`. #595 named that test and that assertion on
2026-08-01T20:25:42Z; this branch's first commit is 2026-08-14T10:50:08Z.

**`remote server`** — `sync-client.integration.test.ts`, "synchronizes two
isolated AGMSG_STORAGE_PATH stores without echo duplicates". Run locally against
one database on this head and on the base: both fail, both at 20s.

**`bats`** — the shard rollup (`the bats shards did not all pass`).

No inversion (same SHA, red → green) was observed. What is held is the other
kind of evidence: the same failure on a tree without this change.

## Reachability, and what it does not prove

Three paths measured from `watch.sh` to `registry-lock.sh`: direct (0), through
the dynamic storage loader (0), and backwards from the twelve files that source
it — only `reset.sh`, guarded by `if [ -n "$DESPAWN_TARGET" ]`, which the
failing test never sets.

That is three paths closed, not a proof. A `source` assembled from a variable
would not appear in any of them.

## Not in this change

Cleaning up a lock left by a dead process — a real hazard (deciding a live lock
is dead), and not what #778 asks for. The Node-side iteration budgets #779 also
mentions are in `remote-sync.mjs`, which other branches are editing.

