### PR TITLE
fix(codex-bridge): every log line names the process that wrote it

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -65,6 +65,45 @@ Options:
 Set AGMSG_CODEX_APP_SERVER_CMD to override the app-server command for tests.`);
 }
 
+// EVERY DIAGNOSTIC LINE NAMES THE PROCESS THAT WROTE IT, AND REACHES THE FILE
+// IN ONE WRITE.
+//
+// The launcher appends this process's stderr to a per-identity log
+// (`codex-bridge-launcher.sh`: `>>"$log" 2>&1`), and that file has more than
+// one writer by construction: the bridge that is running, plus every launch
+// attempt that finds it already there, says so, and exits. Two such lines were
+// reported spliced mid-word, and other logs were reported losing their line
+// beginnings (#784).
+//
+// This does not claim to prevent that, and it is deliberately not written as
+// if it did. What it does:
+//
+//   ONE WRITE PER LINE. The newline is part of the same `write` as the text,
+//   so a line is never split into two writes by this side. Whether two
+//   processes' writes can still interleave is a property of the platform's
+//   append, not of this code — and the report is from Windows/Git Bash, where
+//   that is exactly the open question.
+//
+//   THE WRITER IS NAMED. A spliced line now carries two pids, and a line that
+//   lost its beginning no longer starts with `[<pid>] `. Corruption that
+//   cannot be prevented from here can at least stop being invisible: the log
+//   is the only evidence for the other reports on that platform, and one that
+//   is quietly wrong is worse than one that is obviously wrong.
+//
+// stdout is deliberately NOT prefixed. `usage()`, the thread-id list and
+// `--resolve-only` are read by people and asserted by tests; a prefix there
+// would change an interface, not a diagnostic.
+const LOG_PREFIX = `[${process.pid}] `;
+
+function logLine(...args) {
+  process.stderr.write(LOG_PREFIX + require("util").format(...args) + "\n");
+}
+
+// Rebound rather than applied at the forty-odd call sites: a helper that has
+// to be remembered is one a later line will forget, and the point of this
+// change is that EVERY diagnostic carries the pid.
+console.error = logLine;
+
 function die(message) {
   console.error(`codex-bridge: ${message}`);
   process.exit(1);

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -121,12 +121,25 @@ let atLineStart = true;
 
 // The funnel. Streamed content passes through byte-for-byte; all it does is
 // keep the flag honest.
+//
+// A BUFFER IS WRITTEN AS A BUFFER. The first version of this decoded every
+// chunk with `toString()`, which is wrong at exactly the boundary this code
+// exists for: a multi-byte character split across two `data` events decodes to
+// a replacement character in each half, and the child's diagnostic arrives
+// corrupted — a regression the direct `process.stderr.write(chunk)` it replaced
+// did not have (raised in review). "byte-for-byte" has to be true of the code,
+// not only of the comment.
+//
+// The newline flag comes from the last BYTE for a Buffer and the last CHARACTER
+// for a string. Those agree: `\n` is 0x0a and is never part of a multi-byte
+// UTF-8 sequence.
 function writeErr(text) {
-  if (text === undefined || text === null) return;
-  const chunk = typeof text === "string" ? text : String(text);
-  if (chunk.length === 0) return;
-  process.stderr.write(chunk);
-  atLineStart = chunk.endsWith("\n");
+  if (text === undefined || text === null || text.length === 0) return;
+  // One call, string or Buffer alike: `process.stderr.write` takes both, and
+  // keeping it to one is what lets a test assert that nothing writes to stderr
+  // outside this function.
+  process.stderr.write(text);
+  atLineStart = typeof text === "string" ? text.endsWith("\n") : text[text.length - 1] === 0x0a;
 }
 
 function logLine(...args) {
@@ -354,9 +367,9 @@ class AppServerClient {
 
     this.child.stderr.on("data", (chunk) => {
       // Through the funnel so a chunk that does not end in a newline cannot
-      // leave the next diagnostic continuing the child's half-line. The bytes
-      // are unchanged.
-      writeErr(chunk.toString());
+      // leave the next diagnostic continuing the child's half-line. The Buffer
+      // is passed on undecoded: see `writeErr`.
+      writeErr(chunk);
     });
 
     const lines = readline.createInterface({ input: this.child.stdout });

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -93,10 +93,47 @@ Set AGMSG_CODEX_APP_SERVER_CMD to override the app-server command for tests.`);
 // stdout is deliberately NOT prefixed. `usage()`, the thread-id list and
 // `--resolve-only` are read by people and asserted by tests; a prefix there
 // would change an interface, not a diagnostic.
+//
+// THREE THINGS REACH STDERR FROM THIS FILE, and only one of them is a log
+// record. Derived by grepping every write rather than by listing the ones that
+// came to mind — the first version of this change named only the first and was
+// wrong about the other two (raised in review):
+//
+//   1. DIAGNOSTICS — `console.error`, forty-odd sites. Whole lines, ours.
+//      These are the log records: prefixed, one write each.
+//   2. CHILD DIAGNOSTICS — the app-server's own stderr, forwarded in whatever
+//      chunks it arrives in. Not ours to frame: a chunk is not a line, and
+//      buffering it would delay someone's only view of a child that is hanging.
+//   3. STREAMED AGENT OUTPUT — `agent/message/delta`, partial BY NAME. There is
+//      no newline to wait for; that is what makes it a delta.
+//
+// 2 and 3 are passed through unchanged and are NOT log records. What they must
+// not do is make a log record unreadable, and before this they could: a delta
+// that ends mid-word, followed immediately by a diagnostic, produces one
+// physical line containing both — the exact shape reported in #784, reachable
+// INSIDE ONE PROCESS with no concurrent writer and no platform question.
+//
+// So everything goes through one funnel that remembers whether the last byte
+// was a newline, and a diagnostic starts a fresh line when it was not.
 const LOG_PREFIX = `[${process.pid}] `;
 
+let atLineStart = true;
+
+// The funnel. Streamed content passes through byte-for-byte; all it does is
+// keep the flag honest.
+function writeErr(text) {
+  if (text === undefined || text === null) return;
+  const chunk = typeof text === "string" ? text : String(text);
+  if (chunk.length === 0) return;
+  process.stderr.write(chunk);
+  atLineStart = chunk.endsWith("\n");
+}
+
 function logLine(...args) {
-  process.stderr.write(LOG_PREFIX + require("util").format(...args) + "\n");
+  const line = `${LOG_PREFIX}${require("util").format(...args)}\n`;
+  // The leading newline is the whole point: without it this diagnostic would
+  // continue whatever half-line a delta or a child chunk left open.
+  writeErr(atLineStart ? line : `\n${line}`);
 }
 
 // Rebound rather than applied at the forty-odd call sites: a helper that has
@@ -316,7 +353,10 @@ class AppServerClient {
     });
 
     this.child.stderr.on("data", (chunk) => {
-      process.stderr.write(chunk);
+      // Through the funnel so a chunk that does not end in a newline cannot
+      // leave the next diagnostic continuing the child's half-line. The bytes
+      // are unchanged.
+      writeErr(chunk.toString());
     });
 
     const lines = readline.createInterface({ input: this.child.stdout });
@@ -1329,7 +1369,9 @@ class CodexBridge {
 
   onAgentMessageDelta(params) {
     if (params.threadId !== this.threadId) return;
-    process.stderr.write(params.delta);
+    // Same funnel: a delta is partial by name, so the flag it leaves behind is
+    // what stops the next diagnostic from joining it into one line (#784).
+    writeErr(params.delta);
     // Watchdog re-arm on this activity is handled generically by
     // client.onThreadActivity (see run()), covering every notification type,
     // not just this one.
@@ -1582,4 +1624,8 @@ if (require.main === module) {
   main().catch((error) => die(error.message));
 }
 
-module.exports = { toPosixPath };
+// `writeErr` and `logLine` are exported for the same reason `toPosixPath` is:
+// the property that matters — a diagnostic never continues someone else's
+// half-line — is a property of these two together, and driving them directly
+// is the only way to state it without standing up an app-server.
+module.exports = { toPosixPath, writeErr, logLine };

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -108,9 +108,38 @@ EOF
   # A future `process.stderr.write` added elsewhere would silently reopen the
   # hole this test exists to close, so the count is pinned rather than the
   # behaviour of the writers that exist today.
-  run grep -c 'process\.stderr\.write' "$TYPES/codex/codex-bridge.js"
+  # Comment lines are stripped first: this file explains the funnel by naming
+  # `process.stderr.write` in prose, and counting those would make the check
+  # measure the commentary rather than the calls.
+  run bash -c "grep -v '^[[:space:]]*\(//\|\*\)' \"\$1\" | grep -c 'process\.stderr\.write'" _ "$TYPES/codex/codex-bridge.js"
   [ "$status" -eq 0 ]
   [ "$output" = "1" ]
+}
+
+@test "codex-bridge: a multi-byte character split across child stderr chunks survives byte-for-byte" {
+  # THROUGH THE PRODUCTION WIRING, not by calling the funnel directly: what is
+  # being pinned is that the child's stderr reaches the log undecoded, and only
+  # the real `child.stderr` handler can show that.
+  #
+  # The app-server writes a 3-byte character with the split INSIDE it, in two
+  # `data` events. Decoding each chunk on arrival — which an earlier revision of
+  # this change did — turns both halves into replacement characters and destroys
+  # the child's diagnostic. That is data loss the direct Buffer write it
+  # replaced did not have.
+  local fake="$TEST_SKILL_DIR/fake-split-utf8.js"
+  cat >"$fake" <<'EOF'
+const full = Buffer.from("日本語\n", "utf8");
+process.stderr.write(full.subarray(0, 4));       // ends mid-character
+setTimeout(() => {
+  process.stderr.write(full.subarray(4));
+  setTimeout(() => process.exit(0), 20);
+}, 20);
+EOF
+
+  AGMSG_CODEX_APP_SERVER_CMD="node $fake" run bash -c 'node "$1" --project "$2" --team team --name alice --timeout 1 --interval 1 --max-wakes 1 2>&1 >/dev/null' _ "$TYPES/codex/codex-bridge.js" "$PROJ"
+  printf '%s\n' "$output" | grep -q '日本語'
+  # `refute`, not `!`: a bare `! cmd` does not trip errexit on either bash.
+  refute grep -q $'\ufffd' <<<"$output"
 }
 
 @test "codex-bridge: stdout is NOT prefixed — it is an interface, not a diagnostic" {

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -61,6 +61,34 @@ EOF
   [[ "$output" =~ "Codex app-server bridge" ]]
 }
 
+# --- the log names who wrote each line (#784) ---------------------------
+#     The launcher appends this process's stderr to a per-identity log that has
+#     more than one writer by construction, and lines were reported spliced
+#     mid-word. These two pin the half that can be pinned from here: every
+#     diagnostic says which process wrote it, and stdout is left alone.
+
+@test "codex-bridge: every diagnostic line carries the pid that wrote it" {
+  # stderr only, so a prefix leaking into stdout cannot be mistaken for this
+  # passing. `2>&1 >/dev/null` in that order keeps stderr and drops stdout —
+  # `run --separate-stderr` would do the same but needs a minimum-version
+  # declaration this suite does not otherwise carry.
+  run bash -c 'node "$1" 2>&1 >/dev/null' _ "$TYPES/codex/codex-bridge.js"
+  [ "$status" -eq 1 ]
+  # `[<digits>] ` and then the message, on the same line — the prefix is what
+  # makes a spliced line show two pids instead of reading as one line.
+  [[ "$output" =~ ^\[[0-9]+\]\ codex-bridge:\ --project\ is\ required$ ]]
+}
+
+@test "codex-bridge: stdout is NOT prefixed — it is an interface, not a diagnostic" {
+  # `--resolve-only`, the thread-id list and `usage()` are read by people and
+  # asserted by other tests here. Prefixing them would change a contract, so
+  # this fails if the prefix ever spreads to stdout.
+  run node "$TYPES/codex/codex-bridge.js" --help
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" =~ ^Usage: ]]
+  [[ ! "$output" =~ \[[0-9]+\]\  ]]
+}
+
 @test "codex-bridge: toPosixPath maps Windows drive paths to POSIX paths" {
   run node -e 'const { toPosixPath } = require(process.argv[1]); const expected = "/c/Users/me/OneDrive/codex-work"; if (toPosixPath(String.raw`C:\Users\me\OneDrive\codex-work`) !== expected) process.exit(1); if (toPosixPath("C:/Users/me/OneDrive/codex-work") !== expected) process.exit(1);' "$TYPES/codex/codex-bridge.js"
   [ "$status" -eq 0 ]

--- a/tests/test_codex_bridge.bats
+++ b/tests/test_codex_bridge.bats
@@ -64,19 +64,53 @@ EOF
 # --- the log names who wrote each line (#784) ---------------------------
 #     The launcher appends this process's stderr to a per-identity log that has
 #     more than one writer by construction, and lines were reported spliced
-#     mid-word. These two pin the half that can be pinned from here: every
-#     diagnostic says which process wrote it, and stdout is left alone.
+#     mid-word. Three things reach that file from the bridge and only one is a
+#     log record: diagnostics (ours, whole lines), the child app-server's own
+#     stderr (arbitrary chunks), and agent message deltas (partial by name).
+#     These pin what can be pinned from a POSIX machine: a diagnostic says who
+#     wrote it, it never continues someone else's half-line, and stdout is left
+#     alone.
+#
+#     `grep -q` rather than `[[ ]]` in the non-last positions: on bash 3.2,
+#     which is what macOS CI runs, a false `[[ ]]` there reports ok.
 
 @test "codex-bridge: every diagnostic line carries the pid that wrote it" {
   # stderr only, so a prefix leaking into stdout cannot be mistaken for this
-  # passing. `2>&1 >/dev/null` in that order keeps stderr and drops stdout —
-  # `run --separate-stderr` would do the same but needs a minimum-version
-  # declaration this suite does not otherwise carry.
+  # passing. `2>&1 >/dev/null` in that order keeps stderr and drops stdout.
   run bash -c 'node "$1" 2>&1 >/dev/null' _ "$TYPES/codex/codex-bridge.js"
   [ "$status" -eq 1 ]
-  # `[<digits>] ` and then the message, on the same line — the prefix is what
-  # makes a spliced line show two pids instead of reading as one line.
-  [[ "$output" =~ ^\[[0-9]+\]\ codex-bridge:\ --project\ is\ required$ ]]
+  # `[<digits>] ` and then the message, on one line — the prefix is what makes
+  # a spliced line show two pids instead of reading as a single line.
+  printf '%s\n' "$output" | grep -qE '^\[[0-9]+\] codex-bridge: --project is required$'
+}
+
+@test "codex-bridge: a diagnostic never continues the half-line streamed output left open" {
+  # THE SHAPE #784 REPORTED, REACHED INSIDE ONE PROCESS. An agent message delta
+  # is partial by name, so it ends mid-word; before the funnel, the diagnostic
+  # that followed it landed on the same physical line and the record was
+  # unreadable without any second writer and without any platform question.
+  run bash -c 'node -e "
+    const { writeErr, logLine } = require(process.argv[1]);
+    writeErr(\"delta-ending-mid\");
+    logLine(\"codex-bridge: the diagnostic after it\");
+  " "$1" 2>&1 >/dev/null' _ "$TYPES/codex/codex-bridge.js"
+  [ "$status" -eq 0 ]
+  # The streamed bytes are unchanged and on their own line...
+  printf '%s\n' "$output" | grep -qx 'delta-ending-mid'
+  # ...and the diagnostic starts a line of its own, prefix first.
+  printf '%s\n' "$output" | grep -qE '^\[[0-9]+\] codex-bridge: the diagnostic after it$'
+  # `refute`, not `!`: a bare `! cmd` does not trip errexit on either bash.
+  refute grep -q 'delta-ending-midcodex-bridge' <<<"$output"
+}
+
+@test "codex-bridge: only one place writes to stderr, so the funnel cannot be bypassed" {
+  # The property above is only true while every write goes through `writeErr`.
+  # A future `process.stderr.write` added elsewhere would silently reopen the
+  # hole this test exists to close, so the count is pinned rather than the
+  # behaviour of the writers that exist today.
+  run grep -c 'process\.stderr\.write' "$TYPES/codex/codex-bridge.js"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
 }
 
 @test "codex-bridge: stdout is NOT prefixed — it is an interface, not a diagnostic" {
@@ -85,7 +119,7 @@ EOF
   # this fails if the prefix ever spreads to stdout.
   run node "$TYPES/codex/codex-bridge.js" --help
   [ "$status" -eq 0 ]
-  [[ "${lines[0]}" =~ ^Usage: ]]
+  printf '%s\n' "${lines[0]}" | grep -q '^Usage:'
   [[ ! "$output" =~ \[[0-9]+\]\  ]]
 }
 


### PR DESCRIPTION
> **The regression quoted below is fixed and pushed.** The head that converted child stderr with `toString()` (`afee2a30…`) is no longer the head; `c5cb40a53950eb1d8ff2f01c123219cb32870cf6` writes Buffers as Buffers. The warning is kept here rather than deleted so that anyone who read it can see what became of it.

Declared reviewers: 1

**Refs #784** — no closing keyword. This lands on `integration/remote`, where GitHub does not act on one, and it does not finish the issue.

## The causal boundary, twice corrected

**First claim, wrong:** "the remaining question is Windows' append." Grepping every write to stderr returns **three** paths, not one:

| path | what it is |
|---|---|
| `console.error` — forty-odd sites | whole lines, ours. **These are the log records.** |
| `child.stderr` chunk | the app-server's own stderr, in whatever chunks it arrives in |
| `agent/message/delta` | **partial by name** — there is no newline to wait for |

The last two went straight to `process.stderr.write`, so **a delta ending mid-word followed by a diagnostic produced one physical line carrying both** — the shape the issue reports, reachable **inside a single process**, with no second writer and no platform involved.

**Second claim, also wrong:** the fix for that said streamed content passes "byte-for-byte" while the code called `toString()` on it. The comment was true and the implementation was not. That is the regression quoted at the top.

## What the change is, as it now stands locally

**One funnel.** Everything reaching stderr goes through `writeErr`, which remembers whether the last byte it wrote was a newline; a diagnostic opens a fresh line when it was not.

**Buffers stay Buffers.** `process.stderr.write` takes both, so the funnel is a single call and nothing is decoded on the way through. The newline flag reads the last **byte** (`0x0a`) for a Buffer and the last **character** for a string — those agree, because `\n` is never part of a multi-byte sequence.

**Diagnostics carry `[<pid>] `.** A line spliced by two *processes* shows two pids; a line that lost its beginning no longer starts with the prefix.

**stdout is untouched** — `usage()`, the thread-id list and `--resolve-only` are read by people and asserted by tests here.

## Still not answered

Whether two **processes'** appends can splice on Windows is **unmeasured**. This is a POSIX machine, and the issue does not say which of the reporter's three environments produced the sample. The prefix makes that case visible; it does not prevent it. Asking which environment it came from remains cheaper than any further change.

## Mutations — six, each red in exactly one place

| mutation | the test that goes red |
|---|---|
| decode the child chunk with `toString()` again | `a multi-byte character split across child stderr chunks survives byte-for-byte` |
| `String()` the value inside the funnel | *(same)* |
| drop the newline insertion in `logLine` | `a diagnostic never continues the half-line streamed output left open` |
| send the delta straight to `process.stderr.write` | `only one place writes to stderr, so the funnel cannot be bypassed` |
| remove `console.error = logLine` | `every diagnostic line carries the pid that wrote it` |
| prefix `usage()` on stdout too | `stdout is NOT prefixed — it is an interface, not a diagnostic` |

None is inert, and no test stands in for another. Two notes worth reading rather than skimming:

- **The first two mutations hit the same control**, which is correct — both re-introduce decoding, by different routes, and the control catches either.
- **The delta path is guarded by the writer count, not by the funnel test.** That test drives the funnel directly, so it stays green when the delta is re-routed around it. The two are only equivalent together, which is why the count test exists rather than being trusted to the first.

The UTF-8 control runs through the **production wiring** — a fake app-server writing a 3-byte character split inside itself, across two `data` events — rather than by calling `writeErr`, because what is being pinned is that the real handler forwards undecoded.

## Suites

This head: `test_codex_bridge` **42 pass, 0 fail** locally. `test_codex_bridge_launcher` 16, `test_close_fds` 4, `test_spawn_fd_guard` 4.

New assertions use `grep -q` rather than `[[ ]]` in non-last positions — on bash 3.2, which macOS CI runs, a false `[[ ]]` there reports ok — and `refute` rather than `!`, which trips errexit on neither bash. `check-enforced-assertions` reports **638, at the baseline**: not raised.
