### PR TITLE
probe: run the ubuntu 4/4 shard against an unchanged integration/remote (do not merge)

### DIFF
--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -1,3 +1,12 @@
+# MEASUREMENT PROBE — not for merge (fujibee/agmsg#769).
+#
+# One comment, in a shell file, so `tests.yml`'s docs-only detector does NOT
+# skip the suite. The point is to run `bats (ubuntu-latest 4/4)` against an
+# otherwise unchanged `integration/remote`, because that shard cannot be
+# observed any other way: the workflow runs on pull requests only, and the
+# failing assertion does not reproduce on a macOS machine.
+#
+# This branch is closed without merging once the shard has reported.
 #!/usr/bin/env bash
 set -u
 # shellcheck disable=SC1091


### PR DESCRIPTION
Declared reviewers: 0

**Measurement only. Do not merge — this is closed as soon as the shard reports.**

## What this measures

Whether `bats (ubuntu-latest 4/4)` fails on `integration/remote` **with no change applied**, which is the one thing nobody has been able to observe tonight.

Three PRs (#775, #792, #794) fail that shard. On #792 the same SHA was re-run and failed again with the same assertion — `not ok 265 watch: relaunch with the SAME instance id replaces the previous watcher (#66 preserved)` — so it is not a flake by that discriminator. `fujibee/agmsg#769` says the base reproduces it standalone, but that measurement is from 2026-08-13 and has not been repeated since.

## Why a pull request, and why not a doc

- `tests.yml` runs on `push: [main]` and `pull_request: [main, integration/remote]`. **A push to `integration/remote` does not run the matrix** — that branch's runs are `verify-versions` only. There is no branch history of this shard to read.
- The assertion **does not reproduce on a macOS machine**: a clean checkout of `d0b762d` passes it locally. So a local run cannot see this failure at all.
- The change is a **comment in a shell file**. A docs-only diff makes the workflow skip the suite and report the shard **green anyway** — `#776`'s `bats (ubuntu-latest 4/4)` shows `conclusion=success` with `Run bats suite (this shard)` **skipped**. That green was used as evidence tonight, and it had measured nothing.

## Reading the result

```
ubuntu 4/4 red    the base reproduces it; the three branches are not the cause
ubuntu 4/4 green  the base is healthy; the three reds belong to their branches
```

Either answer settles it. Both are recorded on #769 afterwards, along with the re-run result and the fact that #776 was not a measurement.

## Controls already taken

`bats (ubuntu-latest 4/4)` **has** run and passed on this lineage — #765 (`1743dc8`) and #766 (`9b05e7a`) both show `step 9` executed with `conclusion=success`. So the shard is not uniformly red on ubuntu, which is why the current base has to be measured rather than assumed.
