### PR TITLE
fix(tests): widen _wait_pidfile's window and name what it saw (#595)

### DIFF
--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -449,12 +449,22 @@ _wait_for_file_contains() {
 # not exist, a file that exists and is empty, and a file that exists and
 # cannot be read; collapsing them into one `<missing>` loses the difference
 # this trail exists to show (raised in review). They are named apart.
+#
+# Existence is decided by a test; readability is decided by THE READ. `-r`
+# only predicts what a read would do, and a read can still fail after it
+# passes -- a permission change, a replacement, a path that is not a regular
+# file, an I/O error. Classifying on `-r` and then swallowing the read's
+# failure with `|| true` reports `<empty>`, merging the two states this
+# exists to separate (raised in review; the chmod control drove the `-r`
+# branch and never reached the failing read).
 _observe_pidfile() {
   local pf="$1" v
   if [ ! -e "$pf" ]; then printf '<no-file>'; return 0; fi
-  if [ ! -r "$pf" ]; then printf '<unreadable>'; return 0; fi
-  v="$(cat "$pf" 2>/dev/null || true)"
-  if [ -z "$v" ]; then printf '<empty>'; else printf '%s' "$v"; fi
+  if v="$(cat "$pf" 2>/dev/null)"; then
+    if [ -z "$v" ]; then printf '<empty>'; else printf '%s' "$v"; fi
+  else
+    printf '<unreadable>'
+  fi
 }
 
 _wait_pidfile() {

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -439,14 +439,35 @@ _wait_for_file_contains() {
 # reports what it was waiting for and what it last saw, per #595's ask for a
 # failure message that distinguishes "never arrived" from "arrived as
 # something else" rather than a bare assertion failure.
+#
+# `last saw` alone is the LAST poll and nothing else, so it cannot separate
+# "the file never appeared" from "it appeared, then went away again" -- and
+# those two have different causes. The distinct values, with the poll they
+# were first seen at, are kept instead, and whether the wanted pid is still
+# alive at the timeout, which separates "the successor died before writing"
+# from "the successor is running and something removed its record".
 _wait_pidfile() {
-  local pf="$1" want="$2" i seen
+  # `last` starts at a value no read can produce -- seeded with "" it would
+  # swallow the first observation in the case that matters most, a file that
+  # is missing from the very first poll.
+  local pf="$1" want="$2" i seen last="__no_poll_yet__" trail=""
   for i in $(seq 1 100); do
     seen="$(cat "$pf" 2>/dev/null || true)"
     [ -f "$pf" ] && [ "$seen" = "$want" ] && return 0
+    if [ "$seen" != "$last" ]; then
+      trail="$trail poll$i='${seen:-<missing>}'"
+      last="$seen"
+    fi
     sleep 0.1
   done
   echo "_wait_pidfile: timed out waiting for '$pf' to record pid $want (last saw: '${seen:-<missing>}')" >&2
+  echo "_wait_pidfile: distinct observations, first poll each:$trail" >&2
+  if kill -0 "$want" 2>/dev/null; then
+    echo "_wait_pidfile: pid $want is ALIVE at the timeout" >&2
+  else
+    echo "_wait_pidfile: pid $want is GONE at the timeout" >&2
+  fi
+  ls -la "$(dirname "$pf")" >&2 2>/dev/null || true
   return 1
 }
 

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -432,13 +432,21 @@ _wait_for_file_contains() {
 
 # --- #93: parallel --continue/--resume sessions sharing a session_id ---
 
-# Poll up to ~3s for <pidfile> to record <want_pid>.
+# Poll up to ~10s for <pidfile> to record <want_pid>. A watcher relaunch does
+# a real fork + lock-acquire + SIGTERM-the-predecessor + self-write before the
+# pidfile reflects it, and a loaded CI runner can push that past the 3s this
+# used to allow -- the flake #595 caught on a macos-latest shard. On timeout,
+# reports what it was waiting for and what it last saw, per #595's ask for a
+# failure message that distinguishes "never arrived" from "arrived as
+# something else" rather than a bare assertion failure.
 _wait_pidfile() {
-  local pf="$1" want="$2" i
-  for i in $(seq 1 30); do
-    [ -f "$pf" ] && [ "$(cat "$pf" 2>/dev/null)" = "$want" ] && return 0
+  local pf="$1" want="$2" i seen
+  for i in $(seq 1 100); do
+    seen="$(cat "$pf" 2>/dev/null || true)"
+    [ -f "$pf" ] && [ "$seen" = "$want" ] && return 0
     sleep 0.1
   done
+  echo "_wait_pidfile: timed out waiting for '$pf' to record pid $want (last saw: '${seen:-<missing>}')" >&2
   return 1
 }
 

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -442,32 +442,57 @@ _wait_for_file_contains() {
 #
 # `last saw` alone is the LAST poll and nothing else, so it cannot separate
 # "the file never appeared" from "it appeared, then went away again" -- and
-# those two have different causes. The distinct values, with the poll they
-# were first seen at, are kept instead, and whether the wanted pid is still
-# alive at the timeout, which separates "the successor died before writing"
-# from "the successor is running and something removed its record".
+# those two have different causes. The distinct values are kept instead, with
+# the poll each was first seen at.
+#
+# Four states, not two. `cat` returns the empty string for a path that does
+# not exist, a file that exists and is empty, and a file that exists and
+# cannot be read; collapsing them into one `<missing>` loses the difference
+# this trail exists to show (raised in review). They are named apart.
+_observe_pidfile() {
+  local pf="$1" v
+  if [ ! -e "$pf" ]; then printf '<no-file>'; return 0; fi
+  if [ ! -r "$pf" ]; then printf '<unreadable>'; return 0; fi
+  v="$(cat "$pf" 2>/dev/null || true)"
+  if [ -z "$v" ]; then printf '<empty>'; else printf '%s' "$v"; fi
+}
+
 _wait_pidfile() {
   # `last` starts at a value no read can produce -- seeded with "" it would
   # swallow the first observation in the case that matters most, a file that
   # is missing from the very first poll.
   local pf="$1" want="$2" i seen last="__no_poll_yet__" trail=""
   for i in $(seq 1 100); do
-    seen="$(cat "$pf" 2>/dev/null || true)"
-    [ -f "$pf" ] && [ "$seen" = "$want" ] && return 0
+    seen="$(_observe_pidfile "$pf")"
+    [ "$seen" = "$want" ] && return 0
     if [ "$seen" != "$last" ]; then
-      trail="$trail poll$i='${seen:-<missing>}'"
+      trail="$trail poll$i='$seen'"
       last="$seen"
     fi
     sleep 0.1
   done
-  echo "_wait_pidfile: timed out waiting for '$pf' to record pid $want (last saw: '${seen:-<missing>}')" >&2
+  echo "_wait_pidfile: timed out waiting for '$pf' to record pid $want (last saw: '$seen')" >&2
   echo "_wait_pidfile: distinct observations, first poll each:$trail" >&2
+  # What this can say about $want, and no more: signal 0 reaching a pid does
+  # not establish that the pid is still the process we started -- pids are
+  # reused (raised in review). So the command line is printed rather than a
+  # liveness verdict, and the reader decides.
   if kill -0 "$want" 2>/dev/null; then
-    echo "_wait_pidfile: pid $want is ALIVE at the timeout" >&2
+    echo "_wait_pidfile: signal 0 reaches pid $want; its command line now is:" >&2
+    ps -o pid=,stat=,etime=,command= -p "$want" >&2 2>/dev/null || echo "  (ps could not describe it)" >&2
   else
-    echo "_wait_pidfile: pid $want is GONE at the timeout" >&2
+    echo "_wait_pidfile: signal 0 does not reach pid $want (exited, or never ours)" >&2
   fi
+  # The watcher writes its own log beside the pidfile and says there what it
+  # was doing. A successor that is running and has not yet claimed the slot is
+  # waiting on something, and this is the only place that says what.
+  echo "_wait_pidfile: run dir and watcher logs:" >&2
   ls -la "$(dirname "$pf")" >&2 2>/dev/null || true
+  for _l in "$(dirname "$pf")"/watch.*.log; do
+    [ -f "$_l" ] || continue
+    echo "--- $_l" >&2
+    tail -20 "$_l" >&2 2>/dev/null || true
+  done
   return 1
 }
 


### PR DESCRIPTION
Declared reviewers: 1

Refs #595, #758.

Landing on `integration/remote`. Head `cfc642428c6ce1111f087fa9698343e396ed5b18`.

**This PR does not fix the failing assertion.** It was opened as a candidate fix, CI refuted that, and what it is now is the instrument that produced the first real information about the failure in three days. Read the next two sections before the rest.

## The window hypothesis is dead, and this PR is what killed it

Commit 1 is #758's fix, ported here: `_wait_pidfile`'s poll window widened from ~3s to ~10s.

It ran **on an idle queue** — every other run was frozen, so this was the only thing on CI — and `bats (ubuntu-latest 4/4)` **failed anyway**, on the same assertion, in 7m27s:

```
not ok 265 watch: relaunch with the SAME instance id replaces the previous watcher (#66 preserved)
#   `_wait_pidfile "$pf" "$w2"' failed
# _wait_pidfile: timed out waiting for '/tmp/…/run/watch.solo.168226.pid' to record pid 168580 (last saw: '<missing>')
```

So: **not the window**, and the "loaded runner" account is weaker too, since this was the least-loaded state all night. Every other check on that run was green (14 success, 1 failure) and the shard's only failure was this one line.

Reading it the other way — that a widened window *proves* the machine was not slow — would be reading more than the log carries, and the same log is why (below).

## The number is #595, not #769

Both issues are about **the same test**, and they are **different assertions**:

```
tests/test_watch.bats:495   _wait_pidfile "$pf" "$w2"        the successor's pid never appears
tests/test_watch.bats:501   run kill -0 "$w1"; [ $status -ne 0 ]   the predecessor is still alive
```

#769 is `:501` — its body quotes that line. #595 is `:495`, and names the assertion outright: *"failing at `_wait_pidfile "$pf" "$w2"`"*. **What fails on CI tonight is `:495`.** An earlier version of this body cited #769 for a property measured about the other assertion; it does not, and the reference is removed.

## What the failure now says, and what it still does not

`last saw: '<missing>'` is **the last poll only**. It cannot tell "the file never appeared" from "it appeared and then went away", because each poll overwrites the previous value — raised in review, and correct. What the log supports is exactly this:

> at the timeout, the expected pid had not been observed within ~10s, and the file was not readable at that moment.

Commit 2 closes that gap. Every **distinct** value is kept with the poll it first appeared at, and the timeout also reports whether the wanted pid is **still alive** — which separates a successor that died before writing from a successor that is running while something else removes its record:

```
(a) never arrived, wanted pid dead    poll1='<missing>'                            GONE
(b) arrived as another pid            poll1='9999'                                 ALIVE
(c) appeared, then removed            poll1='9999' poll11='4242' poll20='<missing>'  ALIVE
```

**(c) is the case `last saw` could not express**, and it is the one that would point at ownership rather than timing.

All three were forced locally and printed — including the wanted-pid liveness line in both directions. A first draft got (a) wrong: `last` was seeded with `""`, so a file missing from the very first poll produced an **empty** trail — the one case that matters most, silently dropped. It is seeded with a value no read can produce now, and (a) prints.

The directory listing is dumped too, so "the file is gone" can be told from "something else is in there".

## Commit 2 is beyond #758

Commit 1 is byte-identical to #758's added lines — verified with `diff`, not by reading:

```
gh pr diff 758 | grep '^+' | grep -v '^+++' | sed 's/^+//'  >  a
git diff       | grep '^+' | grep -v '^+++' | sed 's/^+//'  >  b
diff a b   →   no output
```

Commit 2 is **not** in #758. It answers the same ask #595 made — a failure message that distinguishes what happened — with what the CI run showed to be necessary. If #758 lands on `main` later, commit 1 is the same change from the other direction and commit 2 is additive.

## Why land a change that fixes nothing

Because the next occurrence answers the question instead of restating it. Tonight's log could not distinguish three causes; the next one can. Against that:

- **`scripts/` is untouched.** Nothing here can change what any shipped code does.
- The window going 3s → 10s costs ~7s **only on a test that is already failing**. A passing run returns on the first matching poll, as before.
- It does not make the red go away, and this body does not claim it does.

## Measurements, at this head

```
bats tests/test_watch.bats                     19 tests, 0 failures
.github/scripts/check-enforced-assertions.sh   638, at the baseline (638)
```

**That green proves only that nothing regressed.** The assertion under investigation passes locally on this machine every time — #769 records the same thing for its own assertion — so a local pass is what both hypotheses predict and it discriminates nothing. The CI run is the evidence.

No mutation table: this changes a test helper's **timing and its diagnostics**, not a behaviour. There is no property to break. The forced (a)/(b)/(c) cases above are what stands in for one — each print was made to appear rather than assumed.

## Drift

From the repo root, immediately before the push, against `origin/integration/remote`:

```
HEAD                       cfc642428c6ce1111f087fa9698343e396ed5b18
merge-base                 d0b762d47747682e5a466cc1ad0df903c2712ac1
origin/integration/remote  d0b762d47747682e5a466cc1ad0df903c2712ac1
RESULT: STRUCTURAL, NOT MEASURED — merge-base == destination.
```

Re-measured immediately before landing.

## Boundaries

- **#758 observed this on `macos-latest 4/4`; tonight's runs are `ubuntu-latest 4/4`.** Same helper, same assertion, different shard and OS.
- The cause is **not** established here. Three candidates remain open, and this PR's only claim about them is that the next failure will name which.
- A verdict on `aa8077e3` was given before commit 2 existed and does not carry to this head.
