### PR TITLE
perf(sync): read a pulled message with one jq, not eighteen (#780)

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -741,7 +741,7 @@ storage_sync_apply_pull() {
   _sqlite_sync_schema "$team" || return $?
   local generation db tl sql_file line type final_cursor="" corrupt=0 outcome_ids=""
   local seq wire received v cipher key_id blob status policy local_rev reason kind
-  local from to body at local_id q
+  local from to body at local_id q line_next_after jq_ok
   generation=$(_sqlite_sync_generation "$team"); db="$(_sqlite_db "$team")"; tl="$(_sqlite_lit "$team")"
   _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || return 13
   sql_file=$(mktemp "${TMPDIR:-/tmp}/agmsg-sync-sql.XXXXXX") || return 13
@@ -751,29 +751,62 @@ storage_sync_apply_pull() {
 
   while IFS= read -r line; do
     [ -n "$line" ] || continue
-    type=$(printf '%s\n' "$line" | jq -r '.type // empty')
+    # One `jq` per message, not one per field (#780). This read cost 18
+    # processes, and process creation -- not parsing -- is what a pull spends
+    # its time on; it is the whole cost on Windows, where a spawn is dear.
+    #
+    # `@sh` is jq's shell-quoting filter, so every value arrives verbatim,
+    # tabs and newlines and quotes included, with no delimiter convention for
+    # this side to get wrong. `jq_ok` is emitted last: a line jq cannot parse
+    # produces no output at all, and the eval then leaves it 0 rather than
+    # letting the previous message's fields stand in for this one's.
+    #
+    # `tostring` where the old code had no `// empty`: those fields print
+    # "null" when absent, and the arity and status checks below reject that.
+    # `// ""` would turn a missing envelope.v into an empty string, which
+    # passes the digits check.
+    #
+    # No test can tell those two apart, and that is not an oversight. An empty
+    # envelope_v reaches SQLite as `,,` and the batch dies of a syntax error,
+    # so the page is refused either way and the suite sees one exit status for
+    # two different rejections. The check is kept because a message refused by
+    # the check names what was wrong with it, and a message refused by a
+    # syntax error names a comma.
+    jq_ok=0
+    eval "$(printf '%s\n' "$line" | jq -r '
+      "type=\(.type // "" | @sh)",
+      "line_next_after=\(.next_after // "" | @sh)",
+      "seq=\(.server_seq // "" | @sh)",
+      "wire=\(.id // "" | @sh)",
+      "received=\(.server_received_at // "" | @sh)",
+      "v=\(.envelope.v | tostring | @sh)",
+      "cipher=\(.envelope.cipher | tostring | @sh)",
+      "key_id=\(.envelope.key_id // "" | @sh)",
+      "blob=\(.envelope.blob | tostring | @sh)",
+      "status=\(.status | tostring | @sh)",
+      "policy=\(.policy_revision // "" | @sh)",
+      "local_rev=\(.local_security_revision // "" | @sh)",
+      "reason=\(.reason // "" | @sh)",
+      "kind=\(.projection.kind // "" | @sh)",
+      "from=\(.projection.from_agent // "" | @sh)",
+      "to=\(.projection.to_agent // "" | @sh)",
+      "body=\(.projection.body // "" | @sh)",
+      "at=\(.projection.created_at // "" | @sh)",
+      "jq_ok=1"' 2>/dev/null)"
+    [ "$jq_ok" = 1 ] || { rm -f "$sql_file"; return 13; }
     if [ "$type" = sync_pull_cursor ]; then
-      final_cursor=$(printf '%s\n' "$line" | jq -r '.next_after // empty')
+      # Held in its own variable and copied only here. Every line now carries
+      # a next_after, so assigning the cursor directly would let a message
+      # line after the cursor line blank it.
+      final_cursor="$line_next_after"
       case "$final_cursor" in ''|*[!0-9]*) rm -f "$sql_file"; return 13 ;; esac
       continue
     fi
     [ "$type" = sync_pull_message ] || { rm -f "$sql_file"; return 13; }
-    seq=$(printf '%s\n' "$line" | jq -r '.server_seq // empty')
-    wire=$(printf '%s\n' "$line" | jq -r '.id // empty')
     printf '%s\n' "$wire" | grep -Eq \
       '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' \
       || { rm -f "$sql_file"; trap - EXIT INT TERM HUP; return 13; }
     outcome_ids="${outcome_ids}${outcome_ids:+,}'$wire'"
-    received=$(printf '%s\n' "$line" | jq -r '.server_received_at // empty')
-    v=$(printf '%s\n' "$line" | jq -r '.envelope.v')
-    cipher=$(printf '%s\n' "$line" | jq -r '.envelope.cipher')
-    key_id=$(printf '%s\n' "$line" | jq -r '.envelope.key_id // empty')
-    blob=$(printf '%s\n' "$line" | jq -r '.envelope.blob')
-    status=$(printf '%s\n' "$line" | jq -r '.status')
-    policy=$(printf '%s\n' "$line" | jq -r '.policy_revision // empty')
-    local_rev=$(printf '%s\n' "$line" | jq -r '.local_security_revision // empty')
-    reason=$(printf '%s\n' "$line" | jq -r '.reason // empty')
-    kind=$(printf '%s\n' "$line" | jq -r '.projection.kind // empty')
     case "$seq:$v" in *[!0-9:]*) rm -f "$sql_file"; return 13 ;; esac
     case "$status" in importable|unsupported_cipher|pending_key|authentication_failed|malformed|policy_violation) ;; *) rm -f "$sql_file"; return 13 ;; esac
     q="'$(_sqlite_lit "$key_id")'"; [ -n "$key_id" ] || q=NULL
@@ -889,10 +922,6 @@ storage_sync_apply_pull() {
              AND server_seq='$seq' AND status='importable';" >> "$sql_file"
         continue
       fi
-      from=$(printf '%s\n' "$line" | jq -r '.projection.from_agent // empty')
-      to=$(printf '%s\n' "$line" | jq -r '.projection.to_agent // empty')
-      body=$(printf '%s\n' "$line" | jq -r '.projection.body // empty')
-      at=$(printf '%s\n' "$line" | jq -r '.projection.created_at // empty')
       [ -n "$from" ] && [ -n "$to" ] && [ -n "$body" ] && [ -n "$at" ] || {
         echo "agmsg: storage sync apply received an importable message without its projection" >&2
         rm -f "$sql_file"; trap - EXIT INT TERM HUP; return 13;

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -772,9 +772,21 @@ storage_sync_apply_pull() {
     # two different rejections. The check is kept because a message refused by
     # the check names what was wrong with it, and a message refused by a
     # syntax error names a comma.
+    # `-s` with a length check, because one line is not one JSON value to jq.
+    # Given `{...} {...}` on a single line it parses BOTH and emits the whole
+    # assignment list twice; the eval runs both and the second silently
+    # overwrites the first, `jq_ok` included. A page could then hide anything
+    # it liked in front of a well-formed message.
+    #
+    # The per-field reads this replaced rejected that by accident: each
+    # substitution came back holding two lines, and the type and arity checks
+    # refused the embedded newline. Raised in review, and it was a real
+    # regression -- the reason has to be explicit now that it is no longer a
+    # side effect of how the fields were read.
     jq_ok=0
-    eval "$(printf '%s\n' "$line" | jq -r '
-      "type=\(.type // "" | @sh)",
+    eval "$(printf '%s\n' "$line" | jq -r -s '
+      if length != 1 then error("one JSON value per line") else .[0] end
+      | "type=\(.type // "" | @sh)",
       "line_next_after=\(.next_after // "" | @sh)",
       "seq=\(.server_seq // "" | @sh)",
       "wire=\(.id // "" | @sh)",

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -813,3 +813,51 @@ second line	after a tab"
   [ "$(sqlite3 "$db" "SELECT count(*) FROM events WHERE body='no envelope';" | tr -d '\r')" -eq 0 ]
   [ "$(sqlite3 "$db" "SELECT count(*) FROM sync_quarantine WHERE wire_id='550e8400-e29b-41d4-a716-4466554400d4';" | tr -d '\r')" -eq 0 ]
 }
+
+# One line is not one JSON value to jq. Given two concatenated objects it parses
+# both, and a filter that emits assignments emits the whole list twice — the
+# eval runs both and the second overwrites the first, `jq_ok` included. A page
+# could put anything it liked in front of a well-formed message and have it
+# vanish.
+#
+# The per-field reads this replaced refused it by accident: each substitution
+# came back holding two lines, and the type and arity checks rejected the
+# embedded newline. Raised in review of the single-read change.
+#
+# The leading object here is a VALID message with its own wire id, not garbage,
+# so the assertion cannot pass merely because the line failed to parse — and the
+# ids are checked separately, because "the page was refused" and "the right one
+# was refused" are different claims.
+@test "sync contract: two JSON values on one line are refused, not resolved to the last" {
+  local first second db rc=0
+  db=$(agmsg_db_path demo)
+  first=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"6",
+     id:"550e8400-e29b-41d4-a716-4466554400e1",
+     server_received_at:"2026-07-20T13:00:06.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"hidden in front",created_at:"2026-07-20T13:00:06.000000Z",
+        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"hidden in front",created_at:"2026-07-20T13:00:06.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
+  second=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"7",
+     id:"550e8400-e29b-41d4-a716-4466554400e2",
+     server_received_at:"2026-07-20T13:00:07.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"the visible one",created_at:"2026-07-20T13:00:07.000000Z",
+        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"the visible one",created_at:"2026-07-20T13:00:07.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
+
+  printf '%s %s\n%s\n' "$first" "$second" '{"type":"sync_pull_cursor","next_after":"7"}' \
+    | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ]
+
+  # Neither of them, and neither wire id. The dangerous outcome is the SECOND
+  # one landing while the first disappears without trace, so both are named.
+  [ "$(sqlite3 "$db" "SELECT count(*) FROM events WHERE body IN ('hidden in front','the visible one');" | tr -d '\r')" -eq 0 ]
+  [ "$(sqlite3 "$db" "SELECT count(*) FROM sync_quarantine WHERE wire_id IN ('550e8400-e29b-41d4-a716-4466554400e1','550e8400-e29b-41d4-a716-4466554400e2');" | tr -d '\r')" -eq 0 ]
+}

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -678,3 +678,138 @@ _reconcile_one_ack() {
   [ "$(storage_history demo | jq -s '[.[]|select(.body=="older than the event log")]|length')" -eq 1 ]
   [ "$(storage_list_unread demo bob | jq -s '[.[]|select(.body=="older than the event log")]|length')" -eq 1 ]
 }
+
+# The single read is only possible because the shell `eval`s what jq emits, so
+# the safety of that eval is this change's load-bearing claim. `@sh` is jq's
+# shell-quoting filter and exists for exactly this — but a claim about a
+# quoting filter is worth what its adversarial case is worth, and there was no
+# adversarial case here before.
+#
+# The body carries every character class a shell acts on: command substitution
+# in both spellings, a quote, a semicolon with a destructive command behind it,
+# a backslash. Plus the tab and the newline, which is the other half — a reader
+# that joined the fields with a delimiter would split this body into pieces.
+#
+# Asserted from both ends: nothing executed, and the value arrived unchanged.
+# Either one alone passes for an implementation that is wrong in the other
+# direction — a mangled body proves no injection, and a safe eval says nothing
+# about whether the tab survived.
+@test "sync contract: a projection body reaches the store verbatim, whatever it contains" {
+  local canary body remote db got
+  canary="$BATS_TEST_TMPDIR/should-not-exist"
+  body="it's \$(touch $canary) \`touch $canary\`; rm -rf . \\ end
+second line	after a tab"
+
+  remote=$(jq -nc --arg b "$body" '
+    {type:"sync_pull_message",server_seq:"1",
+     id:"550e8400-e29b-41d4-a716-4466554400d1",
+     server_received_at:"2026-07-20T13:00:01.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:$b,created_at:"2026-07-20T13:00:01.000000Z",
+        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:$b,created_at:"2026-07-20T13:00:01.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
+  printf '%s\n%s\n' "$remote" '{"type":"sync_pull_cursor","next_after":"1"}' \
+    | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+
+  [ ! -e "$canary" ]
+
+  db=$(agmsg_db_path demo)
+  # Reached through the wire mapping rather than by matching on the body, which
+  # is the value under test and cannot also be the key that finds it.
+  got=$(sqlite3 "$db" "SELECT e.body FROM events e JOIN sync_messages m
+          ON m.local_id=e.id
+        WHERE m.wire_id='550e8400-e29b-41d4-a716-4466554400d1';" | tr -d '\r')
+  [ "$got" = "$body" ]
+}
+
+# Every line of a page now carries a next_after, not just the cursor line,
+# because all the fields are read in one pass. So the cursor has to be taken
+# from the line whose TYPE says it is the cursor — assigning it from whatever
+# the last read produced lets a message line arriving afterwards blank it, and
+# the apply then either fails with no cursor or rewinds the transport.
+#
+# Position is not significant in the format, and this is the assertion that
+# says so.
+@test "sync contract: a message line after the cursor line does not blank the cursor" {
+  local remote db
+  db=$(agmsg_db_path demo)
+  remote=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"9",
+     id:"550e8400-e29b-41d4-a716-4466554400d2",
+     server_received_at:"2026-07-20T13:00:09.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"after the cursor",created_at:"2026-07-20T13:00:09.000000Z",
+        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"after the cursor",created_at:"2026-07-20T13:00:09.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
+  printf '%s\n%s\n' '{"type":"sync_pull_cursor","next_after":"9"}' "$remote" \
+    | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+
+  [ "$(sqlite3 "$db" "SELECT transport_cursor FROM sync_bindings WHERE local_team='demo';" | tr -d '\r')" = 9 ]
+}
+
+# A line jq cannot parse produces NO output, and an eval of nothing is not an
+# error — it leaves every field holding the previous line's value. So the read
+# has to say whether it happened, and the last thing jq emits is that flag.
+#
+# The garbage line is placed AFTER the cursor line on purpose. Before it, the
+# stale fields still say "sync_pull_message" and the page fails at the end for
+# want of a cursor, so the bug is invisible. After it, the stale fields say
+# "sync_pull_cursor", the loop skips the line as if it had been one, and the
+# page COMMITS — an unparseable line accepted as a page terminator.
+@test "sync contract: an unparseable line fails the page, wherever it sits" {
+  local remote db rc=0
+  db=$(agmsg_db_path demo)
+  remote=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"4",
+     id:"550e8400-e29b-41d4-a716-4466554400d3",
+     server_received_at:"2026-07-20T13:00:04.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"before the garbage",created_at:"2026-07-20T13:00:04.000000Z",
+        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"before the garbage",created_at:"2026-07-20T13:00:04.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
+  printf '%s\n%s\n%s\n' "$remote" '{"type":"sync_pull_cursor","next_after":"4"}' \
+    'this is not json' \
+    | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ]
+  # And nothing from the page reached the store, including the message that
+  # came before the bad line. Asserting only the exit status passes for an
+  # implementation that committed and then reported the failure.
+  [ "$(sqlite3 "$db" "SELECT count(*) FROM events WHERE body='before the garbage';" | tr -d '\r')" -eq 0 ]
+}
+
+# `.envelope.v` leaves jq with no default on purpose: absent, it reads "null",
+# and the arity check rejects that. An empty-string default would let
+# "$seq:$v" hold nothing but digits and a colon and walk straight past it.
+#
+# This test does NOT bind that choice, and saying so is the point of the
+# paragraph. Run it against the empty-string default and it still passes —
+# because an empty `envelope_v` interpolates into the batch as `,,`, which is a
+# SQLite syntax error, so the page is refused a second time further down. Two
+# rejections, one exit status, and the suite cannot see which one fired.
+#
+# What it does pin is the outcome for an input that has no envelope at all:
+# refused, and nothing left behind in either table. The reason for preferring
+# the check over the syntax error is in the driver, where a reader deciding
+# whether the `tostring` matters will be standing.
+@test "sync contract: a message with no envelope is refused, not defaulted" {
+  local remote db rc=0
+  db=$(agmsg_db_path demo)
+  remote=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"5",
+     id:"550e8400-e29b-41d4-a716-4466554400d4",
+     server_received_at:"2026-07-20T13:00:05.000000Z",
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"no envelope",created_at:"2026-07-20T13:00:05.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
+  printf '%s\n%s\n' "$remote" '{"type":"sync_pull_cursor","next_after":"5"}' \
+    | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ]
+  [ "$(sqlite3 "$db" "SELECT count(*) FROM events WHERE body='no envelope';" | tr -d '\r')" -eq 0 ]
+  [ "$(sqlite3 "$db" "SELECT count(*) FROM sync_quarantine WHERE wire_id='550e8400-e29b-41d4-a716-4466554400d4';" | tr -d '\r')" -eq 0 ]
+}


### PR DESCRIPTION
Declared reviewers: 1

Closes nothing automatically — `integration/remote` is not the default branch, so #780 is closed by hand after this lands.

## The measurement, before the fix

`storage_sync_apply_pull` ran one `jq` per field. Counted independently rather than taken from the issue:

    jq invocations inside storage_sync_apply_pull    18
    of those, on the ordinary message path           14

Same input, same machine, both directions, at two different machine loads:

| | 18 calls/message | 1 call/message | ratio |
|---|---|---|---|
| run 1 | 163 ms | 6.0 ms | 27x |
| run 2 | 86.5 ms | 5.2 ms | 16.7x |
| run 3 | 117.3 ms | 8.9 ms | 13.1x |

Runs 1 and 2 were taken on the filter **before** the cardinality guard below was added, so they measure a program this branch no longer ships. Run 3 is the shipped filter, extracted from the driver rather than retyped.

Two things went wrong getting run 3, both worth naming:

- The first extraction was a greedy regex and swallowed 340 lines of the file. `jq` failed to compile and exited immediately, and the harness happily reported **5.5 ms per call** — a measurement of a compile error. It was caught by positive-controlling the extracted filter (feed it one object, check it emits assignments and ends with `jq_ok=1`) rather than by the number looking wrong. It did not look wrong.
- A sequential A/B put the cardinality guard at **+2.97 ms**. Interleaving the two variants so drift hits both equally puts it at **−0.03 ms** (medians, n=60 each). The guard is free; the first figure was the machine, not the code.

**The ratio is not the number to quote** — it moves with load. The one that does not move is that a message costs **seventeen fewer processes**.

That is also the explanation for the ratio moving:

    jq --version spawn     8.0 ms
    /usr/bin/true spawn    5.1 ms

A `jq` that parses nothing costs within 3 ms of a program that does nothing. The parse was never the expense; process creation was.

**Does this only matter on Windows?** No — the numbers above are macOS. It matters *most* on Windows, where a spawn is dearest, but 17 spawns per message is not free anywhere.

## How the fields come back

`@sh` is jq's shell-quoting filter. The driver evals a list of assignments and each value arrives verbatim — quotes, tabs, newlines, backslashes — with no delimiter convention for this side to unescape.

`@tsv` with a separator was the first attempt and is worse than it looks: **tab is IFS whitespace**, so `read` collapses runs of it, and every empty field in the middle shifts the ones after it. Most of these fields are routinely empty.

Three consequences of reading in one pass, each of which is a way to get this wrong:

- **`jq_ok` is emitted last.** A line jq cannot parse produces *no output*, and an eval of nothing is not an error — every field keeps the previous line's value. Without the flag, an unparseable line arriving after the cursor line inherits type `sync_pull_cursor`, is skipped as if it were one, and **the page commits.**
- **The cursor is copied only in the branch whose type says cursor.** Every line now carries a `next_after`, so assigning it directly lets a message line after the cursor line blank it.
- **`tostring`, not `// ""`,** where the old code had no default. Absent, those fields read `null` and the arity check rejects them; an empty string is digits-and-a-colon and walks past.

## Mutations

| mutation | red |
|---|---|
| `@sh` dropped on `body` | **7** |
| cursor assigned from every line | **1** (the new ordering test) |
| `jq_ok` guard removed | **1** (the new garbage-line test) |
| `tostring` → `// ""` on `envelope.v` | **0** |

**The last one is reported, not fixed, and it cannot be fixed by a test.** An empty `envelope_v` reaches SQLite as `,,` and the batch dies of a syntax error, so the page is refused twice and the suite sees one exit status for two different rejections. Verified directly:

    sqlite3 :memory: "INSERT INTO t VALUES('x',,'z');"
    Error: in prepare, near ",": syntax error

`tostring` is kept anyway — a message refused by the check names what was wrong with it, and a message refused by a syntax error names a comma. Both the driver and the test say this where a reader would ask.

## Tests

Four added. The first is the one this change owes: `eval` is now on the path, so the adversarial body carries command substitution in both spellings, a quote, a semicolon with `rm -rf` behind it, a backslash, a tab and a newline. Asserted from **both** ends — nothing executed, and the value arrived byte-identical. Either assertion alone passes for an implementation that is wrong in the other direction.

    tests/test_remote_sync.bats        30/30
    tests/test_jsonl_remote_sync.bats  25/25

## A validation regression the single read introduced, and its fix

Raised in review. One line is not one JSON value to jq: given `{...} {...}` it parses both, the filter emits its whole assignment list twice, and the eval's second pass overwrites everything the first set — `jq_ok` included. The read reported success while describing the **last** object on the line, so a page could hide anything in front of a well-formed message.

Measured on the filter as it stood:

```
printf '%s\n' '{"type":"garbage"} {"type":"sync_pull_message",...}' \
  | jq -r '"type=\(.type // "" | @sh)","jq_ok=1"'

type='garbage'
jq_ok=1
type='sync_pull_message'
jq_ok=1
```

**The old code refused this by accident**, which is the part worth recording: each per-field substitution came back holding two lines, and the type and arity checks rejected the embedded newline. Nothing intended it. Reading the fields once removes that side effect, so the property is now asserted — `-s` with a length check, making more than one value an error instead of last-one-wins.

| mutation | red |
|---|---|
| length check removed, `.[0]` kept | 1 (the new test) |
| `-s` removed entirely (the reviewed form) | 1 (the new test, at `rc -ne 0`) |

The test's leading object is a **valid** message with its own wire id, not garbage, so it cannot pass merely because the line failed to parse. Both wire ids are asserted absent: "the page was refused" and "the right one was refused" are different claims, and the dangerous outcome is the second message landing while the first vanishes.

`tests/test_remote_sync.bats` is now 31/31.

## What I would look at first

The `eval`. It is the load-bearing claim here, and "`@sh` is safe" is an appeal to a filter's contract. The adversarial test is the evidence I have for it; if that body is missing a character class, the test is worth less than it looks.

Second: I ran the field-extraction replacement with a file-wide regex on the first attempt and it deleted `jq` calls out of `storage_sync_resync` and `storage_sync_reconcile_push` as well. That was reverted and redone inside the function's line range; the diff is confined to `storage_sync_apply_pull` and the `jq` count outside it is unchanged at 44. Worth a glance at the hunk headers regardless.

---

exact head: `c0b7c660ff5e643dad764abbcb0cf1f5620b2cf8`
