### PR TITLE
fix(whoami): validate the type the caller asked for, and stop dispatch guessing one (#783)

### DIFF
--- a/scripts/lib/detect-cli-type.sh
+++ b/scripts/lib/detect-cli-type.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Which CLI is this? Detection lives here, not in whoami.sh, because whoami.sh
+# is not the only caller that needs the answer (#783/#801): windows/dispatch.sh
+# hands the type to join.sh, reset.sh, delivery.sh and identities.sh, and a
+# default guessed there registers a real agent under a type nobody chose.
+#
+# Sourcing this requires lib/type-registry.sh and lib/compat.sh to be sourced
+# first; it reads agmsg_known_types / agmsg_type_get / compat_get_comm /
+# compat_get_ppid and deliberately does not source them itself, so a caller
+# cannot end up with two copies of the registry's state.
+
+# Auto-detect CLI type from environment variables and the process tree, driven by
+# the per-type manifests' `detect=` (env-var names) and `detect_proc=` (process
+# name globs) keys — no hardcoded type list lives here.
+agmsg_detect_cli_type() {
+  # `detect=` / `detect_proc=` tokens are split with `read -ra` (IFS word-split,
+  # NO pathname expansion) rather than an unquoted `for x in $list` — a file in
+  # the caller's cwd matching a pattern like `claude-*` must not glob-eat the
+  # pattern. (Plain `set -f` can't be used here: agmsg_known_types discovers types
+  # via a `*/` glob that must keep working.)
+
+  # 1. Environment variables. Sorted registry order preserves the historical
+  # precedence: a runtime's own session vars (CLAUDE_CODE_SESSION_ID, CODEX_*) are
+  # checked before the GEMINI_* family, which users also set for the SDK without
+  # the CLI. `detect=explicit` (and types with no detect=) are never auto-detected.
+  local _t _v _detect _toks
+  while IFS= read -r _t; do
+    [ -n "$_t" ] || continue
+    _detect="$(agmsg_type_get "$_t" detect)"
+    if [ -z "$_detect" ] || [ "$_detect" = "explicit" ]; then
+      continue
+    fi
+    read -ra _toks <<<"$_detect"
+    for _v in "${_toks[@]}"; do
+      if [ -n "${!_v:-}" ]; then
+        echo "$_t"
+        return 0
+      fi
+    done
+  done <<EOF
+$(agmsg_known_types | sort -u)
+EOF
+
+  # 2. Process-tree detection via each type's `detect_proc=` name globs. Walk up
+  # from this process; at each ancestor the first type whose glob matches wins
+  # (the globs are disjoint, so order within a level is irrelevant).
+  local pid=$$ max_depth=10 depth=0 proc_name _pats _pat
+  while [ $depth -lt $max_depth ] && [ "$pid" != "1" ] && [ -n "$pid" ]; do
+    proc_name=$(compat_get_comm "$pid" 2>/dev/null || true)
+    if [ -n "$proc_name" ]; then
+      while IFS= read -r _t; do
+        [ -n "$_t" ] || continue
+        _pats="$(agmsg_type_get "$_t" detect_proc)"
+        [ -n "$_pats" ] || continue
+        read -ra _toks <<<"$_pats"
+        for _pat in "${_toks[@]}"; do
+          # $_pat is intentionally an UNQUOTED glob pattern matched against the
+          # process name; read -ra already kept it out of pathname expansion.
+          # shellcheck disable=SC2254
+          case "$proc_name" in
+            $_pat) echo "$_t"; return 0 ;;
+          esac
+        done
+      done <<EOF
+$(agmsg_known_types | sort -u)
+EOF
+    fi
+
+    # Move to parent process
+    pid=$(compat_get_ppid "$pid" 2>/dev/null || true)
+    depth=$((depth + 1))
+  done
+
+  # Default fallback. A LITERAL, and the one name here that no registry lookup
+  # stands behind — which is why whoami.sh validates only a type the caller
+  # asked for, and why nothing may treat this function's output as a member of
+  # agmsg_known_types.
+  echo "claude-code"
+}

--- a/scripts/whoami.sh
+++ b/scripts/whoami.sh
@@ -16,75 +16,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/type-registry.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/compat.sh"
-
-# Auto-detect CLI type from environment variables and the process tree, driven by
-# the per-type manifests' `detect=` (env-var names) and `detect_proc=` (process
-# name globs) keys — no hardcoded type list lives here.
-detect_cli_type() {
-  # `detect=` / `detect_proc=` tokens are split with `read -ra` (IFS word-split,
-  # NO pathname expansion) rather than an unquoted `for x in $list` — a file in
-  # the caller's cwd matching a pattern like `claude-*` must not glob-eat the
-  # pattern. (Plain `set -f` can't be used here: agmsg_known_types discovers types
-  # via a `*/` glob that must keep working.)
-
-  # 1. Environment variables. Sorted registry order preserves the historical
-  # precedence: a runtime's own session vars (CLAUDE_CODE_SESSION_ID, CODEX_*) are
-  # checked before the GEMINI_* family, which users also set for the SDK without
-  # the CLI. `detect=explicit` (and types with no detect=) are never auto-detected.
-  local _t _v _detect _toks
-  while IFS= read -r _t; do
-    [ -n "$_t" ] || continue
-    _detect="$(agmsg_type_get "$_t" detect)"
-    if [ -z "$_detect" ] || [ "$_detect" = "explicit" ]; then
-      continue
-    fi
-    read -ra _toks <<<"$_detect"
-    for _v in "${_toks[@]}"; do
-      if [ -n "${!_v:-}" ]; then
-        echo "$_t"
-        return 0
-      fi
-    done
-  done <<EOF
-$(agmsg_known_types | sort -u)
-EOF
-
-  # 2. Process-tree detection via each type's `detect_proc=` name globs. Walk up
-  # from this process; at each ancestor the first type whose glob matches wins
-  # (the globs are disjoint, so order within a level is irrelevant).
-  local pid=$$ max_depth=10 depth=0 proc_name _pats _pat
-  while [ $depth -lt $max_depth ] && [ "$pid" != "1" ] && [ -n "$pid" ]; do
-    proc_name=$(compat_get_comm "$pid" 2>/dev/null || true)
-    if [ -n "$proc_name" ]; then
-      while IFS= read -r _t; do
-        [ -n "$_t" ] || continue
-        _pats="$(agmsg_type_get "$_t" detect_proc)"
-        [ -n "$_pats" ] || continue
-        read -ra _toks <<<"$_pats"
-        for _pat in "${_toks[@]}"; do
-          # $_pat is intentionally an UNQUOTED glob pattern matched against the
-          # process name; read -ra already kept it out of pathname expansion.
-          # shellcheck disable=SC2254
-          case "$proc_name" in
-            $_pat) echo "$_t"; return 0 ;;
-          esac
-        done
-      done <<EOF
-$(agmsg_known_types | sort -u)
-EOF
-    fi
-
-    # Move to parent process
-    pid=$(compat_get_ppid "$pid" 2>/dev/null || true)
-    depth=$((depth + 1))
-  done
-
-  # Default fallback
-  echo "claude-code"
-}
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/detect-cli-type.sh"
 
 PROJECT_PATH="${1:?Usage: whoami.sh <project_path> [type]}"
-AGENT_TYPE="${2:-$(detect_cli_type)}"
+AGENT_TYPE="${2:-$(agmsg_detect_cli_type)}"
 
 # Reject an unknown type the caller ASKED for, the same check join.sh makes
 # (#783). Without it a wrong or misspelled $2 reads all the way through to
@@ -93,10 +29,11 @@ AGENT_TYPE="${2:-$(detect_cli_type)}"
 # rather than an error, so nobody doubts it and they go and join again.
 #
 # GUARDED ON $2 BEING PRESENT, following doctor.sh's --type check, and that is
-# not tidiness. detect_cli_type's own value is NOT guaranteed to be a member of
+# not tidiness. agmsg_detect_cli_type's value is NOT guaranteed to be a member of
 # the registry: two of its three exits echo a name read out of
-# agmsg_known_types, but the third is the literal `claude-code` fallback above,
-# which no registry lookup stands behind. Validating the RESOLVED value ties
+# agmsg_known_types, but the third is the literal `claude-code` fallback at the
+# end of lib/detect-cli-type.sh, which no registry lookup stands behind.
+# Validating the RESOLVED value ties
 # the no-argument path to that literal still being discoverable — so a broken
 # install, or a trust decision that drops the built-in base, would stop
 # everyone rather than only the person who mistyped a type. Measured: with

--- a/scripts/whoami.sh
+++ b/scripts/whoami.sh
@@ -86,6 +86,28 @@ EOF
 PROJECT_PATH="${1:?Usage: whoami.sh <project_path> [type]}"
 AGENT_TYPE="${2:-$(detect_cli_type)}"
 
+# Reject an unknown type the caller ASKED for, the same check join.sh makes
+# (#783). Without it a wrong or misspelled $2 reads all the way through to
+# `not_joined=true` — a true answer to a different question ("are you
+# registered under this exact, wrong type?"), which looks like ordinary output
+# rather than an error, so nobody doubts it and they go and join again.
+#
+# GUARDED ON $2 BEING PRESENT, following doctor.sh's --type check, and that is
+# not tidiness. detect_cli_type's own value is NOT guaranteed to be a member of
+# the registry: two of its three exits echo a name read out of
+# agmsg_known_types, but the third is the literal `claude-code` fallback above,
+# which no registry lookup stands behind. Validating the RESOLVED value ties
+# the no-argument path to that literal still being discoverable — so a broken
+# install, or a trust decision that drops the built-in base, would stop
+# everyone rather than only the person who mistyped a type. Measured: with
+# `claude-code` renamed out of scripts/drivers/types/, validating the resolved
+# value turns a plain `whoami.sh <project>` into exit 1, while the same tree
+# without the check still answers.
+if [ -n "${2:-}" ] && ! agmsg_is_known_type "$AGENT_TYPE"; then
+  echo "Unknown agent type: '$AGENT_TYPE' (supported: $(agmsg_known_types | sort -u | paste -sd, - | sed 's/,/, /g'))" >&2
+  exit 1
+fi
+
 # SCRIPT_DIR is already resolved above (before sourcing the type registry).
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEAMS_DIR="$SCRIPT_DIR/../teams"

--- a/scripts/windows/dispatch.sh
+++ b/scripts/windows/dispatch.sh
@@ -12,6 +12,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 AGENT_TYPE="${AGMSG_AGENT_TYPE:-codex}"
+# Whether the type above was CHOSEN or merely defaulted (#783). The commands
+# below all require a type, so the `codex` fallback has to stay — but whoami.sh
+# is the one caller that can work it out for itself, and handing it this default
+# replaces its detection with a guess. A Claude Code user on Windows who never
+# set AGMSG_AGENT_TYPE was asking "am I joined AS CODEX?", getting the truthful
+# `not_joined=true`, and reading it as "I am not joined."
+AGENT_TYPE_EXPLICIT="${AGMSG_AGENT_TYPE:+1}"
 PROJECT="$PWD"
 TEAM="${AGMSG_TEAM:-}"
 AGENT="${AGMSG_AGENT:-}"
@@ -38,7 +45,7 @@ EOF
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --type)    AGENT_TYPE="${2:?--type needs a value}"; shift 2 ;;
+    --type)    AGENT_TYPE="${2:?--type needs a value}"; AGENT_TYPE_EXPLICIT=1; shift 2 ;;
     --project) PROJECT="${2:?--project needs a path}"; shift 2 ;;
     --team)    TEAM="${2:?--team needs a value}"; shift 2 ;;
     --agent)   AGENT="${2:?--agent needs a value}"; shift 2 ;;
@@ -129,7 +136,13 @@ resolve_identity() {
   local whoami_output
   local whoami_code
   set +e
-  whoami_output="$(run_script whoami.sh "$PROJECT" "$AGENT_TYPE" 2>&1)"
+  # Pass the type only when the caller chose it; otherwise let whoami.sh detect.
+  # See AGENT_TYPE_EXPLICIT above (#783).
+  if [ -n "$AGENT_TYPE_EXPLICIT" ]; then
+    whoami_output="$(run_script whoami.sh "$PROJECT" "$AGENT_TYPE" 2>&1)"
+  else
+    whoami_output="$(run_script whoami.sh "$PROJECT" 2>&1)"
+  fi
   whoami_code=$?
   set -e
   if [ "$whoami_code" -ne 0 ]; then

--- a/scripts/windows/dispatch.sh
+++ b/scripts/windows/dispatch.sh
@@ -12,12 +12,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 AGENT_TYPE="${AGMSG_AGENT_TYPE:-codex}"
-# Whether the type above was CHOSEN or merely defaulted (#783). The commands
-# below all require a type, so the `codex` fallback has to stay — but whoami.sh
-# is the one caller that can work it out for itself, and handing it this default
-# replaces its detection with a guess. A Claude Code user on Windows who never
-# set AGMSG_AGENT_TYPE was asking "am I joined AS CODEX?", getting the truthful
-# `not_joined=true`, and reading it as "I am not joined."
+# Whether the type above was CHOSEN or merely defaulted (#783/#801). Resolved
+# into a detected type below, once the flags have been read.
 AGENT_TYPE_EXPLICIT="${AGMSG_AGENT_TYPE:+1}"
 PROJECT="$PWD"
 TEAM="${AGMSG_TEAM:-}"
@@ -55,6 +51,28 @@ while [ $# -gt 0 ]; do
     *) break ;;
   esac
 done
+
+# THE TYPE IS DETECTED, NOT GUESSED, WHENEVER NOBODY CHOSE ONE (#801).
+#
+# Every command below hands $AGENT_TYPE to a script that acts on it —
+# join.sh and reset.sh WRITE registrations with it, identities.sh and
+# delivery.sh read by it. Leaving the `codex` literal in place made those
+# writes real: a Claude Code user on Windows who never set AGMSG_AGENT_TYPE
+# would run `agmsg actas <name>`, have their identity resolved correctly from
+# the claude-code registration, and then be joined a SECOND time as codex —
+# one person, two identities. That is a broken state, not a misread message,
+# which is why detecting inside whoami.sh alone was not enough.
+#
+# An explicit --type or AGMSG_AGENT_TYPE is never overridden.
+if [ -z "$AGENT_TYPE_EXPLICIT" ]; then
+  # shellcheck disable=SC1091
+  . "$SCRIPT_DIR/../lib/type-registry.sh"
+  # shellcheck disable=SC1091
+  . "$SCRIPT_DIR/../lib/compat.sh"
+  # shellcheck disable=SC1091
+  . "$SCRIPT_DIR/../lib/detect-cli-type.sh"
+  AGENT_TYPE="$(agmsg_detect_cli_type)"
+fi
 
 if [ -n "$ARGV_FILE" ]; then
   if ! command -v base64 >/dev/null 2>&1; then
@@ -136,8 +154,12 @@ resolve_identity() {
   local whoami_output
   local whoami_code
   set +e
-  # Pass the type only when the caller chose it; otherwise let whoami.sh detect.
-  # See AGENT_TYPE_EXPLICIT above (#783).
+  # Still not passed when nobody chose it, even though $AGENT_TYPE now holds
+  # the same detected value: whoami.sh validates the type it is GIVEN, so
+  # passing it would put the fail-closed case back — a registry that cannot
+  # offer detect's literal fallback would stop every Windows caller instead of
+  # only one who mistyped. Letting whoami detect for itself costs a second
+  # process-tree walk and keeps that guard meaningful.
   if [ -n "$AGENT_TYPE_EXPLICIT" ]; then
     whoami_output="$(run_script whoami.sh "$PROJECT" "$AGENT_TYPE" 2>&1)"
   else

--- a/tests/test_dispatch.bats
+++ b/tests/test_dispatch.bats
@@ -76,6 +76,25 @@ teardown() {
   [[ ! "$output" =~ "agent=dave" ]]
 }
 
+# "Explicit" is TWO entrances, and a control that drives one of them measures
+# half of the property. `--type` is covered above; this is the environment
+# side. Without it, flattening AGENT_TYPE_EXPLICIT's env-derived value to empty
+# leaves every declared control green, so the claim "both are honoured" would
+# rest on reading the source rather than on anything the tree enforces.
+@test "dispatch: AGMSG_AGENT_TYPE is honoured over detection, exactly as --type is (#801)" {
+  local proj="$BATS_TEST_TMPDIR/project-envtype"
+  mkdir -p "$proj"
+  bash "$SCRIPTS/join.sh" demo gina claude-code "$proj"
+
+  # Detection would answer claude-code here — CLAUDE_CODE_SESSION_ID is set and
+  # gina is registered under it. The env var says codex, and the env var wins,
+  # so gina must not be the identity that comes back.
+  run env CLAUDE_CODE_SESSION_ID=test-session AGMSG_AGENT_TYPE=codex \
+    bash "$SCRIPTS/windows/dispatch.sh" --project "$proj" -- inbox
+  [ "$status" -eq 2 ]
+  refute grep -qF "agent=gina" <<<"$output"
+}
+
 # WHAT THIS BINDS IS THE BREAKAGE, NOT THE REPAIR. Detecting the type inside
 # whoami.sh fixed the message a user reads; it did not fix what dispatch then
 # WRITES. `actas` resolves the identity from the claude-code registration and

--- a/tests/test_dispatch.bats
+++ b/tests/test_dispatch.bats
@@ -51,7 +51,9 @@ teardown() {
   # with dispatch, and this line says so instead of staying quiet.
   run env CLAUDE_CODE_SESSION_ID=test-session bash "$SCRIPTS/whoami.sh" "$proj"
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "type=claude-code" ]]
+  # A plain command: a non-last `[[ ]]` cannot fail the test on bash 3.2 (#670),
+  # and a control that cannot fail is not a control.
+  grep -qF "type=claude-code" <<<"$output"
 
   run env CLAUDE_CODE_SESSION_ID=test-session bash "$SCRIPTS/windows/dispatch.sh" --project "$proj" -- inbox
   [ "$status" -eq 0 ]
@@ -72,6 +74,33 @@ teardown() {
   run env CLAUDE_CODE_SESSION_ID=test-session bash "$SCRIPTS/windows/dispatch.sh" --type codex --project "$proj" -- inbox
   [ "$status" -eq 2 ]
   [[ ! "$output" =~ "agent=dave" ]]
+}
+
+# WHAT THIS BINDS IS THE BREAKAGE, NOT THE REPAIR. Detecting the type inside
+# whoami.sh fixed the message a user reads; it did not fix what dispatch then
+# WRITES. `actas` resolves the identity from the claude-code registration and
+# immediately calls identities.sh and join.sh — with the type dispatch is
+# holding. Left at the `codex` literal, an already-joined claude-code user gets
+# a SECOND registration under codex: one person, two identities.
+#
+# So the assertion is that the wrong record does not appear. Asserting "the
+# claude-code one is used" would pass while an extra codex row was created
+# beside it.
+@test "dispatch: actas with no type chosen does not register the user again under codex (#801)" {
+  local proj="$BATS_TEST_TMPDIR/project-actas"
+  mkdir -p "$proj"
+  bash "$SCRIPTS/join.sh" demo erin claude-code "$proj"
+
+  # Control: nothing is registered as codex in this project yet, so a codex
+  # row found afterwards can only have been created by the run below.
+  run bash "$SCRIPTS/identities.sh" "$proj" codex
+  [ -z "$output" ]
+
+  run env CLAUDE_CODE_SESSION_ID=test-session bash "$SCRIPTS/windows/dispatch.sh" --project "$proj" -- actas frank
+  [ "$status" -eq 0 ]
+
+  run bash "$SCRIPTS/identities.sh" "$proj" codex
+  [ -z "$output" ]
 }
 
 @test "dispatch: multiple identity stops without choosing" {

--- a/tests/test_dispatch.bats
+++ b/tests/test_dispatch.bats
@@ -34,6 +34,46 @@ teardown() {
   [[ "$output" =~ "No new messages." ]]
 }
 
+# Every other test here passes `--type codex`, so none of them exercises the
+# default — which is where #783 actually bit. dispatch.sh must resolve a type
+# for the commands that require one, but whoami.sh is the caller that can work
+# it out itself, and handing it the `codex` default replaced detection with a
+# guess: a Claude Code user on Windows who never set AGMSG_AGENT_TYPE asked "am
+# I joined AS CODEX?", got the truthful `not_joined=true`, and read it as "I am
+# not joined". Reverting either half of the dispatch change turns this red.
+@test "dispatch: with no type chosen, identity comes from detection, not the codex default (#783)" {
+  local proj="$BATS_TEST_TMPDIR/project-claude"
+  mkdir -p "$proj"
+  bash "$SCRIPTS/join.sh" demo carol claude-code "$proj"
+
+  # Control first. If detection does not land on claude-code here, the
+  # assertion below would pass or fail for a reason that has nothing to do
+  # with dispatch, and this line says so instead of staying quiet.
+  run env CLAUDE_CODE_SESSION_ID=test-session bash "$SCRIPTS/whoami.sh" "$proj"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "type=claude-code" ]]
+
+  run env CLAUDE_CODE_SESSION_ID=test-session bash "$SCRIPTS/windows/dispatch.sh" --project "$proj" -- inbox
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "No new messages." ]]
+}
+
+# The other direction: a type the caller DID choose must still be honoured, so
+# the fix above cannot be "ignore the type argument".
+@test "dispatch: an explicitly chosen type is still what identity is resolved as (#783)" {
+  local proj="$BATS_TEST_TMPDIR/project-both"
+  mkdir -p "$proj"
+  bash "$SCRIPTS/join.sh" demo dave claude-code "$proj"
+
+  # Asked as codex, dave is not there — dispatch must stop rather than quietly
+  # resolve him. (The output is `suggest=true`, not `not_joined=true`: setup()
+  # registers codex agents in other projects, so the scan has something to
+  # suggest. What matters is that dave is not the answer.)
+  run env CLAUDE_CODE_SESSION_ID=test-session bash "$SCRIPTS/windows/dispatch.sh" --type codex --project "$proj" -- inbox
+  [ "$status" -eq 2 ]
+  [[ ! "$output" =~ "agent=dave" ]]
+}
+
 @test "dispatch: multiple identity stops without choosing" {
   bash "$SCRIPTS/join.sh" many first codex "$PROJECT_MULTI"
   bash "$SCRIPTS/join.sh" many second codex "$PROJECT_MULTI"

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -339,6 +339,49 @@ EOF
   [[ "$output" =~ "type=claude-code" ]]
 }
 
+@test "whoami: rejects an explicit unknown type instead of answering not_joined (#783)" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj
+  clear_autodetect_env
+  mock_no_agent_ps
+  run bash "$SCRIPTS/whoami.sh" /tmp/proj not-a-real-type
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "Unknown agent type: 'not-a-real-type'" ]]
+  # The whole point: the old behaviour was a truthful answer to a question the
+  # caller did not mean to ask, and it is that answer which must not appear.
+  [[ ! "$output" =~ "not_joined=true" ]]
+}
+
+@test "whoami: the unknown-type error lists the registry, like join.sh's does (#783)" {
+  clear_autodetect_env
+  mock_no_agent_ps
+  run bash "$SCRIPTS/whoami.sh" /tmp/proj bogus-type
+  [ "$status" -eq 1 ]
+  # Derived from the registry rather than compared against a written-out list,
+  # so adding a type cannot leave this assertion behind.
+  local expected
+  expected="$(cd "$SCRIPTS" && bash -c 'source lib/type-registry.sh; agmsg_known_types | sort -u | paste -sd, - | sed "s/,/, /g"')"
+  [[ "$output" =~ "supported: $expected" ]]
+}
+
+# THE CHECK IS GUARDED ON $2, AND THIS IS THE TEST THAT SAYS SO. Validating the
+# RESOLVED type instead would pass every other test in this file and fail only
+# here: detect_cli_type's last exit is a hardcoded `claude-code` that no
+# registry lookup stands behind, so tying the no-argument path to it makes a
+# registry that cannot offer that name stop everyone, not just a caller who
+# mistyped. Removing the `[ -n "${2:-}" ]` guard turns this red.
+@test "whoami: no type argument still answers when the fallback name is not in the registry (#783)" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj
+  clear_autodetect_env
+  mock_no_agent_ps
+  # Move it aside rather than delete it: what is under test is the registry no
+  # longer offering the name detect_cli_type falls back to.
+  mv "$TYPES/claude-code" "$TYPES/.claude-code-hidden"
+  run bash "$SCRIPTS/whoami.sh" /tmp/proj
+  mv "$TYPES/.claude-code-hidden" "$TYPES/claude-code"
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ "Unknown agent type" ]]
+}
+
 # --- reset.sh ---
 
 @test "reset: removes only current project registration" {

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -345,10 +345,13 @@ EOF
   mock_no_agent_ps
   run bash "$SCRIPTS/whoami.sh" /tmp/proj not-a-real-type
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "Unknown agent type: 'not-a-real-type'" ]]
-  # The whole point: the old behaviour was a truthful answer to a question the
-  # caller did not mean to ask, and it is that answer which must not appear.
-  [[ ! "$output" =~ "not_joined=true" ]]
+  # Plain commands, not `[[ ]]`: a non-last `[[ ]]` cannot fail the test on
+  # bash 3.2 (#670), and the absence check below is the one that carries the
+  # point of this fix.
+  grep -qF "Unknown agent type: 'not-a-real-type'" <<<"$output"
+  # The old behaviour was a truthful answer to a question the caller did not
+  # mean to ask, and it is that answer which must not appear.
+  refute grep -qF "not_joined=true" <<<"$output"
 }
 
 @test "whoami: the unknown-type error lists the registry, like join.sh's does (#783)" {


### PR DESCRIPTION
Declared reviewers: 1

Refs #783. Head as this body was written: `b017ed97d3beb01563496fee380cbe0084dfe95e`.

**`Refs`, not `Closes`, and #783 must be closed by hand after this lands.** A closing keyword only fires on a merge into the default branch, and this PR's base is `integration/remote` — so `Closes` would have been a promise the artifact cannot keep. It said `Closes #783` until a reviewer caught it.

**This PR fixes two different defects, and one does not imply the other.** Naming them apart matters, because "a type check was added" reads as though the second were handled:

- **Validation** (#783) — `whoami.sh` accepted any string as a type and answered `not_joined=true`. Nothing is written; a person misreads a true answer.
- **Propagation** (#801, found in review) — `windows/dispatch.sh` passed its own `codex` default to the scripts that **write** registrations. An already-joined Claude Code user could end up registered a second time as codex. **State breaks.**

The measurement that separates them: removing the validation leaves the propagation test **green**, and reverting the propagation leaves the validation tests **green**. Validation does not stop the state-breaking defect.

## Validation — the check is guarded on `$2`, and that is load-bearing

`whoami.sh` answered `not_joined=true` for a wrong or misspelled type. That answer is true about the question it was asked — "are you registered under this exact type?" — and it looks like ordinary output rather than an error, so it gets read as "you are not joined" and the user goes and joins again. `join.sh` already rejects unknown types; `whoami.sh` did not.

`doctor.sh:99` already has the right shape (`[ -n "$FILTER_TYPE" ] && ! agmsg_is_known_type …`), and this follows it. Validating the **resolved** type instead ties the no-argument path to something the registry does not stand behind. `agmsg_detect_cli_type` has three exits: two echo a name read out of `agmsg_known_types`, so they are members by construction, and the third is a hardcoded `claude-code` fallback that no registry lookup backs.

```
agmsg_detect_cli_type's possible outputs = agmsg_known_types() ∪ { "claude-code" }
```

`agmsg_known_types` is disk discovery (`scripts/drivers/types/*/type.conf`, external drivers behind trust), not a fixed enum. Measured, with `claude-code` renamed out of `scripts/drivers/types/` and no type argument:

| | registry intact | `claude-code` moved aside |
|---|---|---|
| validating the resolved type | `not_joined=true`, exit 0 | **`Unknown agent type: 'claude-code'`, exit 1** |
| no check at all | `not_joined=true`, exit 0 | `not_joined=true`, exit 0 |

A broken install, or a trust decision that drops the built-in base, would stop everyone rather than only the caller who mistyped.

## Propagation — the type is resolved once, for every consumer

`dispatch.sh:14` defaulted to the literal `codex`, and every command hands `$AGENT_TYPE` to a script that acts on it: `join.sh` and `reset.sh` **write** registrations with it, `identities.sh` and `delivery.sh` read by it. `actas` reaches the inconsistency directly — it resolves the identity from the claude-code registration and then joins the user again as codex.

Fixing this inside `resolve_identity` would have been too narrow: **`mode`, `join`, `reset` and `drop` never call it**, so they would have kept the literal — and `agmsg join` is the first command a new user runs. So the type is detected once, after flag parsing, whenever nobody chose one. `detect_cli_type` moves to `scripts/lib/detect-cli-type.sh` so `dispatch.sh` can call it without a copy, the same reason `agmsg_is_known_type` is shared.

`whoami.sh` is still called **without** a type when nobody chose one, even though `$AGENT_TYPE` now holds the same value: it validates the type it is given, so passing it would restore exactly the fail-closed case above. The cost is a second process-tree walk on that path.

## Which entry points take this value, derived rather than enumerated

Scope of the search, so the result says what it covers: `git grep -n 'AGENT_TYPE=' -- scripts/` on this branch's merge-base. **Nine assignments.** Vendored trees and `app/` were not searched.

Seven are `${n:?…}` — required, always explicit. The two that could be non-explicit are the two this PR touches:

```
whoami.sh:87             ${2:-$(detect_cli_type)}     -> falls back to the literal `claude-code`
windows/dispatch.sh:14   ${AGMSG_AGENT_TYPE:-codex}   -> falls back to the literal `codex`
```

`spawn.sh` takes `${1:-}` but dies on empty before validating, and `doctor.sh` guards on non-empty; both reach `agmsg_is_known_type` with an explicit value.

## Review stop conditions

Answered under the reviewer's own headings, so an unanswered one would be visibly empty.

**(1) `resolve_identity` carries the detected type to later consumers when none was explicit.** Done, and deliberately **wider than asked**: the resolution happens once after flag parsing rather than inside `resolve_identity`, because `mode`, `join`, `reset` and `drop` never call `resolve_identity` and would have kept the `codex` literal. Same property, applied to every consumer instead of one.

**(2) A control driving production `actas` with no type against an existing claude-code join, asserting no codex registration appears.** `tests/test_dispatch.bats` — *"actas with no type chosen does not register the user again under codex (#801)"*. It asserts the **absence** of the codex row, not the presence of the claude-code one, because the wrong record can be created beside the right one. A control first proves the project has no codex registration before the run, so a row found afterwards can only have come from it.

**(3) A mutation removing the propagation turns that control red.** Measured — see the table below.

**(4) An explicit `--type` / `AGMSG_AGENT_TYPE` still wins.** `AGENT_TYPE_EXPLICIT` is set by both, and the detection block is skipped when it is set. **Both entrances are now driven, and only one was before**: the original control ran `--type codex` and the string `AGMSG_AGENT_TYPE` appeared nowhere in the suite, so flattening its half of the flag to empty left every declared control green — the claim rested on reading the source. *"AGMSG_AGENT_TYPE is honoured over detection, exactly as --type is"* closes that half, and the mutation table below shows it reddening alone.

**(5) The body's "not passed to whoami only" wording, which the current contract contradicts.** That sentence is gone. It used to read *"the default stays, because delivery/join/reset/identities all require a type; whoami is the one caller that can work it out, and it is no longer told"* — **and that was wrong**: it treated needing a value as though it made the value correct. The contract now is that the detected type reaches every consumer, and the only thing withheld from `whoami.sh` is the argument, so its guard keeps working.

## Mutations

Each reverts one thing, so the controls cannot mix. **Named, not numbered** — inserting a test renumbers every one after it, and a table of stale numbers reads exactly like a table of fresh ones. Every row was re-measured on this head, which is how the last row got corrected: reverting the whole file reddens **two** tests, not the one first written here.

| mutation | what reddens | what stays green |
|---|---|---|
| remove only the `[ -n "${2:-}" ]` guard | *no type argument still answers when the fallback name is not in the registry* | the two unknown-type tests |
| remove the whole whoami check | *rejects an explicit unknown type…* and *the unknown-type error lists the registry…* | the fallback test, **and every `test_dispatch.bats` test including the actas one** |
| revert the dispatch propagation | *actas with no type chosen does not register the user again under codex* | the other three dispatch tests |
| `AGENT_TYPE_EXPLICIT=""` in place of `${AGMSG_AGENT_TYPE:+1}` | *AGMSG_AGENT_TYPE is honoured over detection, exactly as --type is* | the other three dispatch tests |
| revert `windows/dispatch.sh` entirely | *with no type chosen, identity comes from detection…* **and** *actas … does not register the user again under codex* | *AGMSG_AGENT_TYPE is honoured…*; `test_team.bats`, 0 failures |

**Rows 2 and 3 are the point.** Removing the validation leaves the actas control green; reverting the propagation reddens it and nothing else. The two defects have separate controls and neither fix covers the other — which is why the summary at the top names them apart.

`.github/scripts/check-enforced-assertions.sh` caught two assertions of mine that could not fail — a non-last `[[ ]]` is a no-op on bash 3.2 (#670), and one of them was the absence check carrying the whole point of the whoami fix. Both are plain commands now (`grep -qF`, `refute grep -qF`); the count is back at the 638 baseline.

## Not measured

- **A real Windows host.** `dispatch.sh` is bash and was exercised on macOS; MSYS, Git Bash and WSL2 were not. The extra process-tree walk this adds is on the platform where that walk is most expensive (#779), and it has not been timed there.
- **Lint.** `shellcheck` is not in any workflow under `.github/workflows/`, and is not installed here. `bash -n` passes on all three scripts; that is all.
- **Whether the reports that prompted #783 went through `dispatch.sh`.** They may not have. This does not claim to close anything else.
