### PR TITLE
fix(state): write the team binding with a mode, not with the umask's leftovers

### DIFF
--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -413,59 +413,68 @@ agmsg_write_atomic() {
   # 0600 applies to every caller of this helper -- team configs, roster
   # journals, the codex port file, migrations. That is deliberate: it is how
   # this product already treats its own state (`key.sh`, the handoff bundle).
-  local attempts=0
+  # THE TEMP LIVES IN A DIRECTORY THIS CALL MADE, and that is the whole point.
+  #
+  # Two earlier shapes were refused by review, and the second one is why this is
+  # a directory:
+  #
+  #   - creating the temp empty under `set -C` and then opening `$tmp` AGAIN to
+  #     write it. The second open resolves the name a second time, so what the
+  #     exclusive creation established could be replaced in between. An
+  #     exclusive create whose result is reached BY NAME is not exclusive.
+  #
+  #   - merging those into one `>` and testing `[ -e ]` first. That test is a
+  #     filter and not a guarantee -- which the comment said -- and then the
+  #     failure branch removed `$tmp` on the reading that this process must have
+  #     made it. When the loser of a real race takes that branch, the file it
+  #     removes belongs to the WINNER. `$$` does not rescue the reasoning: a
+  #     subshell shares its parent's pid, so two concurrent calls in one process
+  #     tree draw from the same `$$.$RANDOM` space. The removal was the defect,
+  #     not the detection.
+  #
+  # `mkdir` answers both. It is atomic, it fails rather than joining an existing
+  # directory, and its SUCCESS is the proof of ownership that `[ -e ]` could
+  # never be: everything inside belongs to this call, so the payload is written
+  # into a name nothing else can be holding, and removing that name cannot
+  # remove anyone else's. It is the same primitive this file already trusts for
+  # the registry lock, for the same reason.
+  #
+  # `mkdir` and `rmdir` are both on the PATH `join` is required to work under --
+  # checked, because that list is what ruled out `mktemp` and `chmod`.
+  local attempts=0 tmpdir
   while :; do
-    tmp="$dest.tmp.$$.$RANDOM"
-    # A NAME ALREADY IN USE IS RETRIED, and this test is a FILTER, not the
-    # guarantee. `set -C` below is what makes the creation exclusive against a
-    # writer that arrives between these two lines. This exists so a leftover is
-    # answered by drawing another name, rather than by the branch underneath,
-    # which reports a write that ran out of room and removes what it wrote.
-    if [ -e "$tmp" ]; then
-      attempts=$((attempts + 1))
-      if [ "$attempts" -ge 32 ]; then
-        printf 'agmsg: could not create a private temporary file beside %s\n' "$dest" >&2
-        return 1
-      fi
-      continue
-    fi
-    # CREATED AND FILLED BY ONE REDIRECTION, so the name is resolved once.
-    #
-    # This used to create the temp empty under `set -C` and then open `$tmp`
-    # AGAIN to write the content. The second open resolves the name a second
-    # time, so whatever the exclusive creation established could be replaced in
-    # between and the payload would follow the replacement -- through a file
-    # this call never created. Review named it as a stop condition and it was
-    # right: an exclusive create whose result is used BY NAME is not exclusive.
-    #
-    # One `>` both creates the file and receives the bytes. `umask 077` still
-    # applies at creation and `set -C` still refuses an existing file rather
-    # than truncating it, so neither property is traded away for the merge.
-    if ( umask 077; set -C; printf '%s\n' "$content" > "$tmp" ) 2>/dev/null; then
+    tmpdir="$dest.tmp.$$.$RANDOM.d"
+    if ( umask 077; mkdir "$tmpdir" ) 2>/dev/null; then
       break
     fi
-    # The name was free on the line above and nothing is publishable, so the
-    # WRITE is what failed -- a full disk, a quota, an I/O error. Not retried:
-    # 32 attempts at a full disk leave 32 partial files behind, and the
-    # destination is what this function protects, which it has done by not
-    # reaching the `mv`.
-    #
-    # The temp is discarded on the reading that this process made it: the name
-    # carries THIS shell's pid, so another writer producing the same one is not
-    # a case this defends against. That reading is written down because it is
-    # what makes the removal safe rather than obvious.
+    # Taken, by anyone, for any reason: draw another name. Nothing is removed
+    # here, because nothing here was created.
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 32 ]; then
+      printf 'agmsg: could not create a private temporary directory beside %s\n' "$dest" >&2
+      return 1
+    fi
+  done
+  tmp="$tmpdir/new"
+
+  # 0700 on the directory and 0600 on the file. The content is written once,
+  # into a fresh name inside a directory only this call can enter.
+  if ! ( umask 077; printf '%s\n' "$content" > "$tmp" ) 2>/dev/null; then
     _agmsg_discard_temp "$tmp"
+    rmdir "$tmpdir" 2>/dev/null
     printf 'agmsg: could not write the new contents for %s\n' "$dest" >&2
     return 1
-  done
+  fi
 
   # The `mv` is what makes a reader see the whole new file or the whole old one.
-  # The loop above is what makes the CONTENT whole: a `printf` that wrote half
+  # The gate above is what makes the CONTENT whole: a `printf` that wrote half
   # the payload and then failed would otherwise be published, indivisibly, as
   # the truncated destination.
   if ! mv "$tmp" "$dest"; then
     _agmsg_discard_temp "$tmp"
+    rmdir "$tmpdir" 2>/dev/null
     printf 'agmsg: could not move the new contents into place at %s\n' "$dest" >&2
     return 1
   fi
+  rmdir "$tmpdir" 2>/dev/null
 }

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -379,28 +379,27 @@ EOF
 # never a truncated one.
 agmsg_write_atomic() {
   local dest="$1" content="$2" tmp
-  tmp="$dest.tmp.$$"
-  # The mode is set as the bytes are created, not afterwards: a file that exists
-  # readable-by-others for even one syscall has already been readable.
+  # The temp is CREATED, never adopted.
   #
-  # It is set AT ALL because leaving it to the caller's umask made the product
-  # refuse its own output (#804). Every reader of a team binding rejects
-  # `mode & 0o022`, and `umask 002` -- an ordinary setting on a group-shared
-  # machine -- produces 0664. `pull` wrote the file and the `unlock` after it
-  # would not accept it.
+  # `> "$dest.tmp.$$"` onto a file a killed run left behind only truncates it:
+  # the redirect does not touch the mode, and `umask` applies to creation, so
+  # the content would exist at whatever that leftover was set to before any
+  # `chmod` could run. For a binding that is a disclosure, not a tidiness
+  # problem -- `remote_binding.endpoint` is the credential on a hosted
+  # deployment (#804, review).
   #
-  # 0600 rather than 0644, because `remote_binding.endpoint` holds whatever
-  # address the caller connected to, and on a hosted deployment that address IS
-  # the credential (the secret is a path segment). The rest of this product
-  # already treats its own state that way: key.sh chmods to 600 in three places
-  # and the handoff bundle is written under `umask 077`. The binding was the one
-  # authority file left out.
+  # `mktemp` is the primitive that cannot do that: it creates exclusively, and
+  # it creates at 0600. A leftover `.tmp.<pid>` is now simply another file this
+  # function does not open.
   #
-  # A `chmod` follows the write because `>` on a PRE-EXISTING temp keeps that
-  # file's old mode, and a stale `.tmp.<pid>` from a killed run is reachable.
-  # It is not silenced: this is a file this function just created, so a refusal
-  # here is a real fault and not a condition to swallow (#802).
-  ( umask 077; printf '%s\n' "$content" > "$tmp" )
-  chmod 600 "$tmp"
+  # 0600 is deliberate and applies to every caller of this helper -- team
+  # configs, roster journals, the codex port file, migrations. It is a policy
+  # for this product's own state, matching `key.sh` (chmod 600 in three places)
+  # and the handoff bundle (`umask 077`), not a change made for bindings alone.
+  tmp="$(mktemp "$dest.tmp.XXXXXX")" || {
+    printf 'agmsg: could not create a temporary file beside %s\n' "$dest" >&2
+    return 1
+  }
+  printf '%s\n' "$content" > "$tmp"
   mv "$tmp" "$dest"
 }

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -416,25 +416,53 @@ agmsg_write_atomic() {
   local attempts=0
   while :; do
     tmp="$dest.tmp.$$.$RANDOM"
-    if ( umask 077; set -C; : > "$tmp" ) 2>/dev/null; then
+    # A NAME ALREADY IN USE IS RETRIED, and this test is a FILTER, not the
+    # guarantee. `set -C` below is what makes the creation exclusive against a
+    # writer that arrives between these two lines. This exists so a leftover is
+    # answered by drawing another name, rather than by the branch underneath,
+    # which reports a write that ran out of room and removes what it wrote.
+    if [ -e "$tmp" ]; then
+      attempts=$((attempts + 1))
+      if [ "$attempts" -ge 32 ]; then
+        printf 'agmsg: could not create a private temporary file beside %s\n' "$dest" >&2
+        return 1
+      fi
+      continue
+    fi
+    # CREATED AND FILLED BY ONE REDIRECTION, so the name is resolved once.
+    #
+    # This used to create the temp empty under `set -C` and then open `$tmp`
+    # AGAIN to write the content. The second open resolves the name a second
+    # time, so whatever the exclusive creation established could be replaced in
+    # between and the payload would follow the replacement -- through a file
+    # this call never created. Review named it as a stop condition and it was
+    # right: an exclusive create whose result is used BY NAME is not exclusive.
+    #
+    # One `>` both creates the file and receives the bytes. `umask 077` still
+    # applies at creation and `set -C` still refuses an existing file rather
+    # than truncating it, so neither property is traded away for the merge.
+    if ( umask 077; set -C; printf '%s\n' "$content" > "$tmp" ) 2>/dev/null; then
       break
     fi
-    attempts=$((attempts + 1))
-    if [ "$attempts" -ge 32 ]; then
-      printf 'agmsg: could not create a private temporary file beside %s\n' "$dest" >&2
-      return 1
-    fi
-  done
-
-  # The `mv` is what makes a reader see the whole new file or the whole old one.
-  # It does NOT make the CONTENT whole: a `printf` that writes half the payload
-  # and then fails -- a full disk, a quota, an I/O error -- would otherwise be
-  # published, indivisibly, as the truncated destination.
-  if ! printf '%s\n' "$content" > "$tmp"; then
+    # The name was free on the line above and nothing is publishable, so the
+    # WRITE is what failed -- a full disk, a quota, an I/O error. Not retried:
+    # 32 attempts at a full disk leave 32 partial files behind, and the
+    # destination is what this function protects, which it has done by not
+    # reaching the `mv`.
+    #
+    # The temp is discarded on the reading that this process made it: the name
+    # carries THIS shell's pid, so another writer producing the same one is not
+    # a case this defends against. That reading is written down because it is
+    # what makes the removal safe rather than obvious.
     _agmsg_discard_temp "$tmp"
     printf 'agmsg: could not write the new contents for %s\n' "$dest" >&2
     return 1
-  fi
+  done
+
+  # The `mv` is what makes a reader see the whole new file or the whole old one.
+  # The loop above is what makes the CONTENT whole: a `printf` that wrote half
+  # the payload and then failed would otherwise be published, indivisibly, as
+  # the truncated destination.
   if ! mv "$tmp" "$dest"; then
     _agmsg_discard_temp "$tmp"
     printf 'agmsg: could not move the new contents into place at %s\n' "$dest" >&2

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -400,6 +400,21 @@ agmsg_write_atomic() {
     printf 'agmsg: could not create a temporary file beside %s\n' "$dest" >&2
     return 1
   }
-  printf '%s\n' "$content" > "$tmp"
-  mv "$tmp" "$dest"
+  # The `mv` is what makes a reader see the whole new file or the whole old one.
+  # It does NOT make the CONTENT whole: a `printf` that writes half the payload
+  # and then fails -- a full disk, a quota, an I/O error -- would otherwise be
+  # published, indivisibly, as the truncated destination (review).
+  #
+  # So the move is gated on the write finishing, and a failed write leaves the
+  # old destination exactly where it was.
+  if ! printf '%s\n' "$content" > "$tmp"; then
+    rm -f "$tmp"
+    printf 'agmsg: could not write the new contents for %s\n' "$dest" >&2
+    return 1
+  fi
+  if ! mv "$tmp" "$dest"; then
+    rm -f "$tmp"
+    printf 'agmsg: could not move the new contents into place at %s\n' "$dest" >&2
+    return 1
+  fi
 }

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -389,6 +389,30 @@ _agmsg_discard_temp() {
   fi
 }
 
+# Remove what a failed attempt left, and NEVER let the removal speak for the
+# attempt.
+#
+# Both commands are neutralised with `|| :`. Many of this repository's scripts
+# run under `set -e`, where a `rmdir` that fails on a directory it could not
+# empty aborts the shell BEFORE the caller's diagnostic is printed and before
+# its `return 1` -- turning a named failure into a silent exit. Cleanup is
+# allowed to fail here. It is not allowed to decide (#804, raised in review).
+_agmsg_cleanup_attempt() {
+  _agmsg_discard_temp "$1" || :
+  rmdir "$2" 2>/dev/null || :
+}
+
+# SAID, NOT SWALLOWED (#802). On the PATH `join` is required to work under there
+# is no `rm`, so a failed write cannot be removed and the directory holding it
+# cannot be removed either. What survives is 0700 with a 0600 file inside --
+# privacy intact, tidiness not -- and the operator is told WHERE in the same
+# breath as the failure rather than finding it later.
+_agmsg_say_residue() {
+  if [ -d "$1" ]; then
+    printf 'agmsg: a private copy of the failed attempt is left in %s\n' "$1" >&2
+  fi
+}
+
 agmsg_write_atomic() {
   local dest="$1" content="$2" tmp
   # The temp is CREATED, never adopted, using only shell builtins.
@@ -406,9 +430,13 @@ agmsg_write_atomic() {
   # either; the version before this one called it and only survived because its
   # failure was ignored.
   #
-  # So: `umask` and `noclobber`, both builtins. `set -C` makes `>` REFUSE an
-  # existing file rather than truncate it, so a leftover is never opened, and
-  # the name carries $RANDOM so a leftover does not block the write forever.
+  # So: `umask`, plus `mkdir` and `rmdir`, which that list does carry. An
+  # earlier revision of this fix used `noclobber` (`set -C`) to refuse an
+  # existing file; that is gone, and the paragraph describing it went with it,
+  # because a comment that explains a primitive the code no longer uses is read
+  # as enforcement by whoever arrives next. What replaced it is below: the temp
+  # lives inside a directory this call created, and the name carries $RANDOM so
+  # a leftover does not block the write forever.
   #
   # 0600 applies to every caller of this helper -- team configs, roster
   # journals, the codex port file, migrations. That is deliberate: it is how
@@ -460,9 +488,9 @@ agmsg_write_atomic() {
   # 0700 on the directory and 0600 on the file. The content is written once,
   # into a fresh name inside a directory only this call can enter.
   if ! ( umask 077; printf '%s\n' "$content" > "$tmp" ) 2>/dev/null; then
-    _agmsg_discard_temp "$tmp"
-    rmdir "$tmpdir" 2>/dev/null
+    _agmsg_cleanup_attempt "$tmp" "$tmpdir"
     printf 'agmsg: could not write the new contents for %s\n' "$dest" >&2
+    _agmsg_say_residue "$tmpdir"
     return 1
   fi
 
@@ -471,10 +499,28 @@ agmsg_write_atomic() {
   # the payload and then failed would otherwise be published, indivisibly, as
   # the truncated destination.
   if ! mv "$tmp" "$dest"; then
-    _agmsg_discard_temp "$tmp"
-    rmdir "$tmpdir" 2>/dev/null
+    _agmsg_cleanup_attempt "$tmp" "$tmpdir"
     printf 'agmsg: could not move the new contents into place at %s\n' "$dest" >&2
+    _agmsg_say_residue "$tmpdir"
     return 1
   fi
-  rmdir "$tmpdir" 2>/dev/null
+
+  # PUBLISHED. EVERYTHING BELOW IS TIDYING, AND TIDYING DOES NOT GET A VOTE.
+  #
+  # This function used to end on a bare `rmdir`, so the status of the tidy-up
+  # became the status of the write: a `rmdir` that failed after a `mv` that
+  # succeeded returned non-zero, and the caller treated a committed write as a
+  # failure. That needs no `set -e` to happen -- the last command's status is
+  # the function's -- and under `set -e` it is worse, because the caller aborts
+  # on a write that in fact landed. Review named it (#804).
+  #
+  # So the removal is checked, its failure is SAID rather than swallowed (#802),
+  # and the return is explicit and unconditional. After a successful `mv` the
+  # directory is empty and 0700, so a failure here is close to impossible; if it
+  # happens, what leaks is an empty private directory, and the operator is told
+  # which one rather than left to find it.
+  if ! rmdir "$tmpdir" 2>/dev/null; then
+    printf 'agmsg: wrote %s, but could not remove the temporary directory %s\n' "$dest" "$tmpdir" >&2
+  fi
+  return 0
 }

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -377,43 +377,66 @@ EOF
 # temp file in the same directory, then rename(2) it over <dest>. The rename is
 # atomic, so a concurrent unlocked reader sees either the old or the new file,
 # never a truncated one.
+# Best effort, and said out loud rather than assumed: `rm` is NOT on the PATH
+# that `join` is required to work under, so on that path a failed write leaves
+# its temp behind. The temp is 0600 and holds no more than the destination
+# would have, so what is lost is tidiness, not privacy -- and this is the one
+# place in here allowed to shrug, because it runs only after a failure that has
+# already been reported.
+_agmsg_discard_temp() {
+  if command -v rm >/dev/null 2>&1; then
+    rm -f "$1"
+  fi
+}
+
 agmsg_write_atomic() {
   local dest="$1" content="$2" tmp
-  # The temp is CREATED, never adopted.
+  # The temp is CREATED, never adopted, using only shell builtins.
   #
   # `> "$dest.tmp.$$"` onto a file a killed run left behind only truncates it:
   # the redirect does not touch the mode, and `umask` applies to creation, so
-  # the content would exist at whatever that leftover was set to before any
-  # `chmod` could run. For a binding that is a disclosure, not a tidiness
-  # problem -- `remote_binding.endpoint` is the credential on a hosted
-  # deployment (#804, review).
+  # the content would exist at whatever that leftover was set to. For a binding
+  # that is a disclosure -- `remote_binding.endpoint` is the credential on a
+  # hosted deployment (#804).
   #
-  # `mktemp` is the primitive that cannot do that: it creates exclusively, and
-  # it creates at 0600. A leftover `.tmp.<pid>` is now simply another file this
-  # function does not open.
+  # `mktemp` would solve it and CANNOT BE USED HERE. `join` is required to work
+  # on a PATH that carries only bash, dirname, sqlite3, sed, date, mkdir, rmdir,
+  # cat, mv, head, od, tr, sort, basename and paste -- there is a test for it,
+  # and it caught the first attempt at this fix. `chmod` is not on that list
+  # either; the version before this one called it and only survived because its
+  # failure was ignored.
   #
-  # 0600 is deliberate and applies to every caller of this helper -- team
-  # configs, roster journals, the codex port file, migrations. It is a policy
-  # for this product's own state, matching `key.sh` (chmod 600 in three places)
-  # and the handoff bundle (`umask 077`), not a change made for bindings alone.
-  tmp="$(mktemp "$dest.tmp.XXXXXX")" || {
-    printf 'agmsg: could not create a temporary file beside %s\n' "$dest" >&2
-    return 1
-  }
+  # So: `umask` and `noclobber`, both builtins. `set -C` makes `>` REFUSE an
+  # existing file rather than truncate it, so a leftover is never opened, and
+  # the name carries $RANDOM so a leftover does not block the write forever.
+  #
+  # 0600 applies to every caller of this helper -- team configs, roster
+  # journals, the codex port file, migrations. That is deliberate: it is how
+  # this product already treats its own state (`key.sh`, the handoff bundle).
+  local attempts=0
+  while :; do
+    tmp="$dest.tmp.$$.$RANDOM"
+    if ( umask 077; set -C; : > "$tmp" ) 2>/dev/null; then
+      break
+    fi
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 32 ]; then
+      printf 'agmsg: could not create a private temporary file beside %s\n' "$dest" >&2
+      return 1
+    fi
+  done
+
   # The `mv` is what makes a reader see the whole new file or the whole old one.
   # It does NOT make the CONTENT whole: a `printf` that writes half the payload
   # and then fails -- a full disk, a quota, an I/O error -- would otherwise be
-  # published, indivisibly, as the truncated destination (review).
-  #
-  # So the move is gated on the write finishing, and a failed write leaves the
-  # old destination exactly where it was.
+  # published, indivisibly, as the truncated destination.
   if ! printf '%s\n' "$content" > "$tmp"; then
-    rm -f "$tmp"
+    _agmsg_discard_temp "$tmp"
     printf 'agmsg: could not write the new contents for %s\n' "$dest" >&2
     return 1
   fi
   if ! mv "$tmp" "$dest"; then
-    rm -f "$tmp"
+    _agmsg_discard_temp "$tmp"
     printf 'agmsg: could not move the new contents into place at %s\n' "$dest" >&2
     return 1
   fi

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -380,6 +380,27 @@ EOF
 agmsg_write_atomic() {
   local dest="$1" content="$2" tmp
   tmp="$dest.tmp.$$"
-  printf '%s\n' "$content" > "$tmp"
+  # The mode is set as the bytes are created, not afterwards: a file that exists
+  # readable-by-others for even one syscall has already been readable.
+  #
+  # It is set AT ALL because leaving it to the caller's umask made the product
+  # refuse its own output (#804). Every reader of a team binding rejects
+  # `mode & 0o022`, and `umask 002` -- an ordinary setting on a group-shared
+  # machine -- produces 0664. `pull` wrote the file and the `unlock` after it
+  # would not accept it.
+  #
+  # 0600 rather than 0644, because `remote_binding.endpoint` holds whatever
+  # address the caller connected to, and on a hosted deployment that address IS
+  # the credential (the secret is a path segment). The rest of this product
+  # already treats its own state that way: key.sh chmods to 600 in three places
+  # and the handoff bundle is written under `umask 077`. The binding was the one
+  # authority file left out.
+  #
+  # A `chmod` follows the write because `>` on a PRE-EXISTING temp keeps that
+  # file's old mode, and a stale `.tmp.<pid>` from a killed run is reachable.
+  # It is not silenced: this is a file this function just created, so a refusal
+  # here is a real fault and not a condition to swallow (#802).
+  ( umask 077; printf '%s\n' "$content" > "$tmp" )
+  chmod 600 "$tmp"
   mv "$tmp" "$dest"
 }

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -415,7 +415,12 @@ _agmsg_say_residue() {
 
 agmsg_write_atomic() {
   local dest="$1" content="$2" tmp
-  # The temp is CREATED, never adopted, using only shell builtins.
+  # The temp is CREATED, never adopted, using only what the minimal PATH
+  # guarantees: `umask` and `printf` from the shell, and `mkdir`, `mv` and
+  # `rmdir`, which are on that list. It said "only shell builtins" while calling
+  # three external commands -- true of a revision that used `noclobber`, and
+  # contradicted twelve lines further down by the paragraph explaining why
+  # `mkdir` and `rmdir` are safe to depend on.
   #
   # `> "$dest.tmp.$$"` onto a file a killed run left behind only truncates it:
   # the redirect does not touch the mode, and `umask` applies to creation, so

--- a/tests/test_binding_mode.bats
+++ b/tests/test_binding_mode.bats
@@ -54,14 +54,34 @@ file_mode() {
   # proved nothing, which is the same defect it exists to catch.
   #
   # Calling the helper in this shell makes `$$` the one it would use.
+  #
+  # AND `$$` ALONE WAS NOT ENOUGH, WHICH THIS TEST USED TO GET WRONG.
+  #
+  # The candidate name is `<dest>.tmp.$$.$RANDOM`. This planted its decoy at
+  # `<dest>.tmp.$$` — a name the helper never draws — so the helper walked past
+  # it and every assertion below passed for the wrong reason. Measured, not
+  # supposed: with the decoy at that name, REMOVING `set -C` from the creation
+  # left all five cases in this file green. The guard had no control at all,
+  # which is the second time this same test proved nothing (see the paragraph
+  # above for the first).
+  #
+  # `RANDOM` is seeded so the helper's FIRST draw is known here, and the decoy
+  # is planted at exactly that name. Assigning to `RANDOM` reseeds bash's
+  # generator, so drawing the name and then reseeding puts the helper back at
+  # the same first value. The call has to be direct rather than under `run`:
+  # `run` forks, and bash reseeds the generator in a subshell.
   local probe decoy
   probe="$TEST_SKILL_DIR/stale.json"
-  decoy="$probe.tmp.$$"
-  printf 'SENTINEL-NOT-TOUCHED\n' > "$decoy"
-  chmod 666 "$decoy"
 
   # shellcheck disable=SC1091
   source "$SCRIPTS/lib/registry-lock.sh"
+
+  RANDOM=20804
+  decoy="$probe.tmp.$$.$RANDOM"
+  printf 'SENTINEL-NOT-TOUCHED\n' > "$decoy"
+  chmod 666 "$decoy"
+
+  RANDOM=20804
   agmsg_write_atomic "$probe" '{"endpoint":"https://host/t/THE-SECRET/"}'
 
   # 1. the leftover is still THERE. This is the assertion that discriminates:
@@ -135,4 +155,59 @@ file_mode() {
   [ "$(cat "$dest")" = "$before" ]
   # 3. and nothing private was left lying beside it
   [ -z "$(find "$TEST_SKILL_DIR" -maxdepth 1 -name 'partial.json.tmp.*' -print -quit)" ]
+}
+
+@test "when every candidate name is taken the write gives up and says so (#804)" {
+  # THE GIVE-UP PATH, driven deterministically rather than by luck.
+  #
+  # The loop draws `<dest>.tmp.$$.$RANDOM` and stops after 32 candidates. Seeding
+  # `RANDOM` makes that sequence reproducible, so this plants exactly the 32
+  # names the helper is about to draw and nothing else. No permissions are
+  # changed and no filesystem is filled, which is what makes it run the same way
+  # on every platform in the matrix.
+  #
+  # The alternative was an unwritable directory. That drives the same branch
+  # through a different cause and answers differently where chmod is advisory,
+  # so it would have been a control on the runner rather than on this loop.
+  local probe taken i
+  probe="$TEST_SKILL_DIR/exhaust.json"
+  printf 'ORIGINAL\n' > "$probe"
+
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/registry-lock.sh"
+
+  RANDOM=7104
+  taken=()
+  for ((i = 0; i < 32; i++)); do
+    taken+=("$probe.tmp.$$.$RANDOM")
+  done
+  for name in "${taken[@]}"; do
+    printf 'SOMEONE-ELSES\n' > "$name"
+  done
+
+  # Direct, not under `run`: bash reseeds the generator in a subshell, so a
+  # forked call would draw a different sequence and collide with none of these.
+  # STDERR GOES TO A FILE, not through `$( )`. A command substitution forks, and
+  # a forked bash reseeds `RANDOM` -- the helper would then draw 32 names none of
+  # which are planted here, allocate on the first try and return 0. That is
+  # exactly what it did on the first run of this test: the assertion below caught
+  # it, and the cause was the capture, not the loop.
+  RANDOM=7104
+  local rc=0 errfile="$TEST_SKILL_DIR/exhaust.err"
+  agmsg_write_atomic "$probe" '{"endpoint":"https://host/t/THE-SECRET/"}' 2>"$errfile" || rc=$?
+
+  # 1. it FAILED, rather than returning 0 with nothing written
+  [ "$rc" -ne 0 ]
+  # 2. and said which of the two failures this was
+  grep -q 'could not create a private temporary file' "$errfile"
+  # 3. the destination is untouched — the caller's old file is still the file
+  [ "$(cat "$probe")" = "ORIGINAL" ]
+  # 4. and not one of the 32 was opened, emptied or carried off
+  for name in "${taken[@]}"; do
+    [ -f "$name" ]
+    [ "$(cat "$name")" = "SOMEONE-ELSES" ]
+  done
+  refute grep -rq 'THE-SECRET' "$TEST_SKILL_DIR"
+
+  rm -f "${taken[@]}"
 }

--- a/tests/test_binding_mode.bats
+++ b/tests/test_binding_mode.bats
@@ -88,3 +88,36 @@ file_mode() {
   # No temp survives beside it.
   [ -z "$(find "$TEST_SKILL_DIR" -maxdepth 1 -name 'probe.json.tmp.*' -print -quit)" ]
 }
+
+@test "a write that fails part-way leaves the old file exactly as it was (#804)" {
+  # `mv` makes a reader see the whole new file or the whole old one. It does not
+  # make the CONTENT whole: a printf that writes half the payload and then fails
+  # would be published, indivisibly, as a truncated destination (review).
+  #
+  # The failure is forced with `ulimit -f`, and SIGXFSZ is ignored so the write
+  # RETURNS the error instead of killing the shell -- which is what makes the
+  # helper's own handling observable rather than the kernel's.
+  local dest original
+  dest="$TEST_SKILL_DIR/partial.json"
+  original='{"keep":"this exact byte string"}'
+  printf '%s\n' "$original" > "$dest"
+  chmod 600 "$dest"
+  local before
+  before="$(cat "$dest")"
+
+  local status=0
+  (
+    trap '' XFSZ
+    ulimit -f 1          # 512-byte blocks: a 200 KB payload cannot land
+    # shellcheck disable=SC1091
+    source "$SCRIPTS/lib/registry-lock.sh"
+    agmsg_write_atomic "$dest" "$(head -c 200000 /dev/zero | tr '\0' 'x')"
+  ) 2>/dev/null || status=$?
+
+  # 1. it did not claim success
+  [ "$status" -ne 0 ]
+  # 2. the old destination is byte-for-byte what it was
+  [ "$(cat "$dest")" = "$before" ]
+  # 3. and nothing private was left lying beside it
+  [ -z "$(find "$TEST_SKILL_DIR" -maxdepth 1 -name 'partial.json.tmp.*' -print -quit)" ]
+}

--- a/tests/test_binding_mode.bats
+++ b/tests/test_binding_mode.bats
@@ -44,14 +44,47 @@ file_mode() {
   [ "$mode" = "600" ]
 }
 
-@test "a rewrite of an existing binding does not widen it back (#804)" {
-  # The second write goes through the same helper; a temp file left by a killed
-  # run would otherwise carry its old mode through `>`.
-  ( umask 002; bash "$SCRIPTS/join.sh" rewriteteam alice claude-code /tmp/p-804c >/dev/null )
-  local cfg
-  cfg="$TEST_SKILL_DIR/teams/rewriteteam/config.json"
-  printf 'stale\n' > "$cfg.tmp.$$"
-  chmod 666 "$cfg.tmp.$$"
-  ( umask 002; bash "$SCRIPTS/join.sh" rewriteteam bob claude-code /tmp/p-804d >/dev/null )
-  [ "$(( 8#$(file_mode "$cfg") & 8#0022 ))" -eq 0 ]
+@test "a leftover permissive temp is never opened, so no content passes through it (#804)" {
+  # THE STALE-TEMP CASE, and it has to be driven through the helper directly.
+  #
+  # An earlier version of this test spawned `join.sh` and planted a decoy named
+  # `<dest>.tmp.$$` — but `$$` there was the TEST's pid, and the script writing
+  # the file has its own. The decoy never had the name the old implementation
+  # would have opened, so the control passed against both implementations. It
+  # proved nothing, which is the same defect it exists to catch.
+  #
+  # Calling the helper in this shell makes `$$` the one it would use.
+  local probe decoy
+  probe="$TEST_SKILL_DIR/stale.json"
+  decoy="$probe.tmp.$$"
+  printf 'SENTINEL-NOT-TOUCHED\n' > "$decoy"
+  chmod 666 "$decoy"
+
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/registry-lock.sh"
+  agmsg_write_atomic "$probe" '{"endpoint":"https://host/t/THE-SECRET/"}'
+
+  # 1. the leftover still holds its own bytes: nothing was written through it
+  [ "$(cat "$decoy")" = "SENTINEL-NOT-TOUCHED" ]
+  # 2. and the secret is not in it, at any mode
+  ! grep -q 'THE-SECRET' "$decoy"
+  # 3. the real write happened, privately
+  grep -q 'THE-SECRET' "$probe"
+  [ "$(file_mode "$probe")" = "600" ]
+  rm -f "$decoy"
+}
+
+@test "the temp the helper creates is private before any content is written (#804)" {
+  # Asserted on the primitive rather than on a race: `mktemp` creates at 0600,
+  # so there is no moment at which the file exists more permissively. If the
+  # helper is changed to create-then-narrow, this stops holding.
+  local probe
+  probe="$TEST_SKILL_DIR/probe.json"
+  ( umask 002
+    source "$SCRIPTS/lib/registry-lock.sh"
+    # A content large enough that the write is not one atomic-looking blip.
+    agmsg_write_atomic "$probe" "$(head -c 200000 /dev/zero | tr '\0' 'x')" )
+  [ "$(file_mode "$probe")" = "600" ]
+  # No temp survives beside it.
+  [ -z "$(find "$TEST_SKILL_DIR" -maxdepth 1 -name 'probe.json.tmp.*' -print -quit)" ]
 }

--- a/tests/test_binding_mode.bats
+++ b/tests/test_binding_mode.bats
@@ -117,9 +117,14 @@ file_mode() {
 }
 
 @test "the temp the helper creates is private before any content is written (#804)" {
-  # Asserted on the primitive rather than on a race: `mktemp` creates at 0600,
-  # so there is no moment at which the file exists more permissively. If the
+  # Asserted on the primitive rather than on a race: `umask 077` applies at
+  # CREATION -- to the directory the call makes and to the file it opens inside
+  # it -- so there is no moment at which either exists more permissively. If the
   # helper is changed to create-then-narrow, this stops holding.
+  #
+  # It used to say `mktemp` creates at 0600. `mktemp` was removed from this
+  # helper long before this line was, and a comment naming a primitive the code
+  # does not use is read as enforcement by whoever arrives next.
   local probe
   probe="$TEST_SKILL_DIR/probe.json"
   ( umask 002
@@ -218,4 +223,97 @@ file_mode() {
   refute grep -rq 'THE-SECRET' "$TEST_SKILL_DIR"
 
   rm -rf "${taken[@]}"
+}
+
+@test "a cleanup that fails after the write landed does not report a failure (#804)" {
+  # THE WRITE IS COMMITTED AT THE `mv`. Everything after it is tidying, and this
+  # function used to end on a bare `rmdir` -- so the tidy-up's status became the
+  # function's, and a caller was told a committed write had failed. No `set -e`
+  # is needed for that; the last command's status is the function's.
+  #
+  # `rmdir` is shadowed by one that always fails, which is the same failure a
+  # non-empty or vanished directory would produce, without needing to arrange
+  # either.
+  local dest bindir errfile rc=0
+  dest="$TEST_SKILL_DIR/committed.json"
+  bindir="$TEST_SKILL_DIR/failing-rmdir"
+  errfile="$TEST_SKILL_DIR/committed.err"
+  mkdir -p "$bindir"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$bindir/rmdir"
+  chmod +x "$bindir/rmdir"
+
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/registry-lock.sh"
+  PATH="$bindir:$PATH" agmsg_write_atomic "$dest" '{"endpoint":"https://host/t/KEPT/"}' 2>"$errfile" || rc=$?
+
+  # 1. the write is reported as what it is: done
+  [ "$rc" -eq 0 ]
+  # 2. and it really is done, at the right mode
+  grep -q 'KEPT' "$dest"
+  [ "$(file_mode "$dest")" = "600" ]
+  # 3. the leak is SAID rather than swallowed, and says which directory
+  grep -q 'could not remove the temporary directory' "$errfile"
+  # 4. and it is not dressed up as a failure of the write
+  refute grep -q 'could not write the new contents' "$errfile"
+}
+
+@test "a failed write with no rm says so, and says what it left (#804)" {
+  # THE MINIMAL PATH IS THE POINT. `join` must work on a PATH without `rm`, so
+  # a write that fails there cannot remove its own attempt, and the directory
+  # holding it cannot be removed either. Two things must survive that: the
+  # caller's diagnostic and its non-zero return, neither of which may be
+  # replaced by the cleanup's own failure under `set -e`.
+  local dest bindir errfile before rc=0
+  dest="$TEST_SKILL_DIR/norm.json"
+  bindir="$TEST_SKILL_DIR/no-rm-bin"
+  errfile="$TEST_SKILL_DIR/norm.err"
+  printf '%s\n' '{"keep":"this exact byte string"}' > "$dest"
+  chmod 600 "$dest"
+  before="$(cat "$dest")"
+
+  mkdir -p "$bindir"
+  # Everything the helper needs, and deliberately NOT `rm`.
+  for tool in mkdir rmdir mv; do
+    ln -sf "$(command -v "$tool")" "$bindir/$tool"
+  done
+
+  # BUILT BEFORE THE PATH IS NARROWED. `head` and `tr` are not in that bin dir --
+  # they do not need to be, the helper never calls them -- so composing the
+  # payload inside the subshell produced an EMPTY string, a write small enough to
+  # land, and a pass with rc=0. The assertion below caught it.
+  local payload
+  payload="$(head -c 200000 /dev/zero | tr '\0' 'x')"
+
+  # RUN IN A CHILD SHELL, and that is not a style choice.
+  #
+  # The first version wrapped the scenario in `( set -e; ... ) || rc=$?`. A
+  # compound command on the left of `||` has errexit DISABLED inside it, so the
+  # `set -e` never applied and the mutation that removes the `|| :` from the
+  # cleanup changed nothing -- the control could not see the thing it exists to
+  # bind. Measured: with that harness, removing the guard reddened no case.
+  #
+  # A separate process carries its own errexit, which no condition in this test
+  # can suppress. `run` then records the status without putting the child on the
+  # left of anything.
+  local script="$TEST_SKILL_DIR/no-rm-write.sh"
+  cat > "$script" <<SCRIPT
+set -e
+trap '' XFSZ
+ulimit -f 1
+PATH="$bindir"
+. "$SCRIPTS/lib/registry-lock.sh"
+agmsg_write_atomic "$dest" "\$1"
+SCRIPT
+
+  run bash "$script" "$payload"
+  rc="$status"
+  printf '%s' "$output" > "$errfile"
+
+  # 1. it failed, and said so as a WRITE failure
+  [ "$rc" -ne 0 ]
+  grep -q 'could not write the new contents' "$errfile"
+  # 2. the residue is named rather than left to be discovered
+  grep -q 'a private copy of the failed attempt is left in' "$errfile"
+  # 3. the destination is byte-for-byte what it was
+  [ "$(cat "$dest")" = "$before" ]
 }

--- a/tests/test_binding_mode.bats
+++ b/tests/test_binding_mode.bats
@@ -277,24 +277,28 @@ file_mode() {
     ln -sf "$(command -v "$tool")" "$bindir/$tool"
   done
 
-  # BUILT BEFORE THE PATH IS NARROWED. `head` and `tr` are not in that bin dir --
-  # they do not need to be, the helper never calls them -- so composing the
-  # payload inside the subshell produced an EMPTY string, a write small enough to
-  # land, and a pass with rc=0. The assertion below caught it.
-  local payload
-  payload="$(head -c 200000 /dev/zero | tr '\0' 'x')"
-
-  # RUN IN A CHILD SHELL, and that is not a style choice.
+  # THE PAYLOAD IS BUILT INSIDE THE SCRIPT, BY A BUILTIN, AND NOT PASSED IN.
   #
-  # The first version wrapped the scenario in `( set -e; ... ) || rc=$?`. A
-  # compound command on the left of `||` has errexit DISABLED inside it, so the
-  # `set -e` never applied and the mutation that removes the `|| :` from the
-  # cleanup changed nothing -- the control could not see the thing it exists to
-  # bind. Measured: with that harness, removing the guard reddened no case.
+  # Two ways of getting it in have already failed here, and both are recorded
+  # because each looked correct:
   #
+  #   composed inside the narrowed PATH -> `head` and `tr` are not in that bin
+  #     dir, so it wrote an EMPTY string, the write succeeded, and the case
+  #     passed with rc=0.
+  #   passed as `run bash "$script" "$payload"` -> a 200 KB argv entry is over
+  #     ARG_MAX on Linux. It ran on the machine that wrote it and died on CI
+  #     with `/usr/bin/bash: Argument list too long` -- the same shape as #820,
+  #     which I had filed against `history.sh` an hour earlier.
+  #
+  # Doubling a string is a builtin loop: no argv, no external command, and it
+  # works after PATH has been narrowed to the bin dir below.
+  #
+  # RUN IN A CHILD SHELL, and that is not a style choice. The first version
+  # wrapped the scenario in `( set -e; ... ) || rc=$?`. A compound command on the
+  # left of `||` has errexit DISABLED inside it, so the `set -e` never applied
+  # and the mutation that removes the `|| :` from the cleanup changed nothing.
   # A separate process carries its own errexit, which no condition in this test
-  # can suppress. `run` then records the status without putting the child on the
-  # left of anything.
+  # can suppress.
   local script="$TEST_SKILL_DIR/no-rm-write.sh"
   cat > "$script" <<SCRIPT
 set -e
@@ -302,10 +306,12 @@ trap '' XFSZ
 ulimit -f 1
 PATH="$bindir"
 . "$SCRIPTS/lib/registry-lock.sh"
-agmsg_write_atomic "$dest" "\$1"
+payload=x
+while [ \${#payload} -lt 200000 ]; do payload="\$payload\$payload"; done
+agmsg_write_atomic "$dest" "\$payload"
 SCRIPT
 
-  run bash "$script" "$payload"
+  run bash "$script"
   rc="$status"
   printf '%s' "$output" > "$errfile"
 

--- a/tests/test_binding_mode.bats
+++ b/tests/test_binding_mode.bats
@@ -64,11 +64,26 @@ file_mode() {
   source "$SCRIPTS/lib/registry-lock.sh"
   agmsg_write_atomic "$probe" '{"endpoint":"https://host/t/THE-SECRET/"}'
 
-  # 1. the leftover still holds its own bytes: nothing was written through it
+  # 1. the leftover is still THERE. This is the assertion that discriminates:
+  # the old implementation opened this exact path and then `mv`'d it into place,
+  # so under that code the decoy does not survive at all -- it becomes the
+  # destination. Its disappearance is the observable, and it has to be asserted
+  # before its contents, because `cat` on a missing file is a different failure
+  # with a different message.
+  [ -f "$decoy" ]
+  # 2. and it still holds its own bytes
   [ "$(cat "$decoy")" = "SENTINEL-NOT-TOUCHED" ]
-  # 2. and the secret is not in it, at any mode
-  ! grep -q 'THE-SECRET' "$decoy"
-  # 3. the real write happened, privately
+  # 3. and the secret is not in it, at any mode. This one cannot be the reason
+  # the test reddens -- adoption removes the file rather than leaving it with
+  # the secret inside -- so it is a guard against a future implementation that
+  # writes through the leftover WITHOUT consuming it, not the discriminator.
+  #
+  # `refute`, not `! grep`: a command under `!` is exempt from errexit, so the
+  # negated form returns non-zero and the test carries on regardless -- it could
+  # not fail. The repository has a checker for exactly this, and it was right to
+  # stop this file. #715 is the same mechanism, found the same way.
+  refute grep -q 'THE-SECRET' "$decoy"
+  # 4. the real write happened, privately
   grep -q 'THE-SECRET' "$probe"
   [ "$(file_mode "$probe")" = "600" ]
   rm -f "$decoy"

--- a/tests/test_binding_mode.bats
+++ b/tests/test_binding_mode.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+# #804. `pull` wrote the team binding at whatever the caller's umask produced,
+# and the `unlock` after it refused that file: every reader of a binding rejects
+# `mode & 0o022`, and `umask 002` -- ordinary on a group-shared machine --
+# produces 0664. The product refused its own output, on the happy path, every
+# time, for anyone with that umask.
+#
+# The mode is asserted rather than the message, because the message is downstream
+# of it: fix the mode and no reader has anything to refuse.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+}
+teardown() { teardown_test_env; }
+
+# `stat` is one of the flags this suite exists to keep honest across userlands.
+file_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+@test "a binding written under umask 002 is not group-writable (#804)" {
+  ( umask 002; bash "$SCRIPTS/join.sh" umaskteam alice claude-code /tmp/p-804 >/dev/null )
+  local cfg mode
+  cfg="$TEST_SKILL_DIR/teams/umaskteam/config.json"
+  [ -f "$cfg" ]
+  mode="$(file_mode "$cfg")"
+  # The property the readers enforce, stated the way they state it.
+  [ "$(( 8#$mode & 8#0022 ))" -eq 0 ]
+  # And the mode this product gives its own authority files.
+  [ "$mode" = "600" ]
+}
+
+@test "the same holds under umask 000, where nothing is masked (#804)" {
+  # 002 is the reported case; 000 is the one that proves the write sets the mode
+  # rather than merely surviving a friendly umask.
+  ( umask 000; bash "$SCRIPTS/join.sh" openteam alice claude-code /tmp/p-804b >/dev/null )
+  local mode
+  mode="$(file_mode "$TEST_SKILL_DIR/teams/openteam/config.json")"
+  [ "$(( 8#$mode & 8#0022 ))" -eq 0 ]
+  [ "$mode" = "600" ]
+}
+
+@test "a rewrite of an existing binding does not widen it back (#804)" {
+  # The second write goes through the same helper; a temp file left by a killed
+  # run would otherwise carry its old mode through `>`.
+  ( umask 002; bash "$SCRIPTS/join.sh" rewriteteam alice claude-code /tmp/p-804c >/dev/null )
+  local cfg
+  cfg="$TEST_SKILL_DIR/teams/rewriteteam/config.json"
+  printf 'stale\n' > "$cfg.tmp.$$"
+  chmod 666 "$cfg.tmp.$$"
+  ( umask 002; bash "$SCRIPTS/join.sh" rewriteteam bob claude-code /tmp/p-804d >/dev/null )
+  [ "$(( 8#$(file_mode "$cfg") & 8#0022 ))" -eq 0 ]
+}

--- a/tests/test_binding_mode.bats
+++ b/tests/test_binding_mode.bats
@@ -55,21 +55,25 @@ file_mode() {
   #
   # Calling the helper in this shell makes `$$` the one it would use.
   #
-  # AND `$$` ALONE WAS NOT ENOUGH, WHICH THIS TEST USED TO GET WRONG.
+  # AND `$$` ALONE WAS NOT ENOUGH, WHICH THIS TEST USED TO GET WRONG. TWICE.
   #
-  # The candidate name is `<dest>.tmp.$$.$RANDOM`. This planted its decoy at
-  # `<dest>.tmp.$$` — a name the helper never draws — so the helper walked past
-  # it and every assertion below passed for the wrong reason. Measured, not
-  # supposed: with the decoy at that name, REMOVING `set -C` from the creation
-  # left all five cases in this file green. The guard had no control at all,
-  # which is the second time this same test proved nothing (see the paragraph
-  # above for the first).
+  # The candidate name has changed twice under this case, and both times the
+  # decoy was left on the OLD one, so the helper walked past it and every
+  # assertion below passed for the wrong reason:
   #
-  # `RANDOM` is seeded so the helper's FIRST draw is known here, and the decoy
-  # is planted at exactly that name. Assigning to `RANDOM` reseeds bash's
-  # generator, so drawing the name and then reseeding puts the helper back at
-  # the same first value. The call has to be direct rather than under `run`:
-  # `run` forks, and bash reseeds the generator in a subshell.
+  #   decoy at `<dest>.tmp.$$`          candidate was `<dest>.tmp.$$.$RANDOM`
+  #   decoy at `<dest>.tmp.$$.$RANDOM`  candidate is  `<dest>.tmp.$$.$RANDOM.d`
+  #
+  # Measured, not supposed: at the first of those, removing `set -C` from the
+  # creation altogether left all five cases in this file green.
+  #
+  # The decoy is now a DIRECTORY on the seeded first candidate, holding a file
+  # at the name the helper writes into. That is the stronger statement: it fails
+  # if the helper adopts a directory it did not create, not merely if it
+  # truncates a file.
+  #
+  # `RANDOM` is seeded so the first candidate is known here. The call is direct
+  # rather than under `run`, because bash reseeds the generator in a subshell.
   local probe decoy
   probe="$TEST_SKILL_DIR/stale.json"
 
@@ -77,9 +81,11 @@ file_mode() {
   source "$SCRIPTS/lib/registry-lock.sh"
 
   RANDOM=20804
-  decoy="$probe.tmp.$$.$RANDOM"
-  printf 'SENTINEL-NOT-TOUCHED\n' > "$decoy"
-  chmod 666 "$decoy"
+  decoy="$probe.tmp.$$.$RANDOM.d"
+  mkdir "$decoy"
+  printf 'SENTINEL-NOT-TOUCHED\n' > "$decoy/new"
+  chmod 777 "$decoy"
+  chmod 666 "$decoy/new"
 
   RANDOM=20804
   agmsg_write_atomic "$probe" '{"endpoint":"https://host/t/THE-SECRET/"}'
@@ -90,9 +96,10 @@ file_mode() {
   # destination. Its disappearance is the observable, and it has to be asserted
   # before its contents, because `cat` on a missing file is a different failure
   # with a different message.
-  [ -f "$decoy" ]
+  [ -d "$decoy" ]
+  [ -f "$decoy/new" ]
   # 2. and it still holds its own bytes
-  [ "$(cat "$decoy")" = "SENTINEL-NOT-TOUCHED" ]
+  [ "$(cat "$decoy/new")" = "SENTINEL-NOT-TOUCHED" ]
   # 3. and the secret is not in it, at any mode. This one cannot be the reason
   # the test reddens -- adoption removes the file rather than leaving it with
   # the secret inside -- so it is a guard against a future implementation that
@@ -102,11 +109,11 @@ file_mode() {
   # negated form returns non-zero and the test carries on regardless -- it could
   # not fail. The repository has a checker for exactly this, and it was right to
   # stop this file. #715 is the same mechanism, found the same way.
-  refute grep -q 'THE-SECRET' "$decoy"
+  refute grep -q 'THE-SECRET' "$decoy/new"
   # 4. the real write happened, privately
   grep -q 'THE-SECRET' "$probe"
   [ "$(file_mode "$probe")" = "600" ]
-  rm -f "$decoy"
+  rm -rf "$decoy"
 }
 
 @test "the temp the helper creates is private before any content is written (#804)" {
@@ -179,10 +186,11 @@ file_mode() {
   RANDOM=7104
   taken=()
   for ((i = 0; i < 32; i++)); do
-    taken+=("$probe.tmp.$$.$RANDOM")
+    taken+=("$probe.tmp.$$.$RANDOM.d")
   done
   for name in "${taken[@]}"; do
-    printf 'SOMEONE-ELSES\n' > "$name"
+    mkdir "$name"
+    printf 'SOMEONE-ELSES\n' > "$name/new"
   done
 
   # Direct, not under `run`: bash reseeds the generator in a subshell, so a
@@ -199,15 +207,15 @@ file_mode() {
   # 1. it FAILED, rather than returning 0 with nothing written
   [ "$rc" -ne 0 ]
   # 2. and said which of the two failures this was
-  grep -q 'could not create a private temporary file' "$errfile"
+  grep -q 'could not create a private temporary directory' "$errfile"
   # 3. the destination is untouched — the caller's old file is still the file
   [ "$(cat "$probe")" = "ORIGINAL" ]
   # 4. and not one of the 32 was opened, emptied or carried off
   for name in "${taken[@]}"; do
-    [ -f "$name" ]
-    [ "$(cat "$name")" = "SOMEONE-ELSES" ]
+    [ -d "$name" ]
+    [ "$(cat "$name/new")" = "SOMEONE-ELSES" ]
   done
   refute grep -rq 'THE-SECRET' "$TEST_SKILL_DIR"
 
-  rm -f "${taken[@]}"
+  rm -rf "${taken[@]}"
 }


### PR DESCRIPTION
Declared reviewers: 1

Refs #804.

`pull` wrote the team binding at whatever the caller's umask produced, and the
`unlock` after it refused that file: every reader of a binding rejects
`mode & 0o022`, and `umask 002` — ordinary on a group-shared machine — produces
0664. The product refused its own output, on the happy path, every time, for
anyone with that umask.

**This description is for head `f355bd2341b941ef895724528d9b7b3fa14ec804`.** If
that is not the head of this branch, nothing below has been re-measured.

## The write

`agmsg_write_atomic` is the shared writer — team configs, roster journals, the
codex port file, migrations — so the mode is set where the file comes into
existence rather than after it:

```bash
tmpdir="$dest.tmp.$$.$RANDOM.d"
( umask 077; mkdir "$tmpdir" )          # retried on collision, 32 then give up
( umask 077; printf '%s\n' "$content" > "$tmpdir/new" )
mv "$tmpdir/new" "$dest"
```

`mktemp` cannot be used: `join` must work on a PATH carrying only bash, dirname,
sqlite3, sed, date, mkdir, rmdir, cat, mv, head, od, tr, sort, basename and
paste. There is a test for that and it caught the first attempt at this fix.
`chmod` is not on that list either — the version before it called `chmod` and
survived only because the failure was ignored. `mkdir` and `rmdir` are on it.

**Why a directory.** Two earlier shapes were refused in review:

1. Create the temp empty under `set -C`, then open `$tmp` *again* for the
   content. The second open resolves the name a second time, so what the
   exclusive creation established could be replaced in between. An exclusive
   create whose result is reached by name is not exclusive.
2. Merge those into one `>` and test `[ -e ]` first. That test is a filter, not
   a guarantee, and the failure branch then removed `$tmp` on the reading that
   this process must have made it. **The loser of a real race would remove the
   winner's file.** `$$` does not carry that reasoning: a subshell shares its
   parent's pid, so two concurrent calls in one process tree draw from the same
   `$$.$RANDOM` space.

An existence test cannot answer *did I make this*. `mkdir` can: it is atomic, it
refuses an existing directory rather than joining it, and everything inside one
it just made belongs to this call. It is the primitive this file already trusts
for the registry lock.

## Cleanup does not get to speak for the write

The function used to end on a bare `rmdir`, so the status of removing an empty
directory became the status of the write — a committed write reported as a
failure. The failure paths had the mirror: with no `rm` on the minimal PATH, the
attempt cannot be removed, `rmdir` cannot succeed, and under `set -e` that
non-zero ended the shell *before* the diagnostic and the `return 1`.

Cleanup now carries `|| :`, the publish path checks its own `rmdir` and returns 0
explicitly, and a residue left on a PATH without `rm` is named on stderr rather
than swallowed (#802).

## Controls

| mutation | result |
|---|---|
| `mkdir` → `mkdir -p` (adopt an existing directory) | cases 3 and 6 red |
| give-up returns 0 instead of failing | case 6 red |
| drop the umask on the content write | cases 1, 2, 3, 4 red |
| end on a bare `rmdir` again | case 7 red, on the return status |
| drop the residue line | case 8 red, on the residue message |
| drop `\|\| :` from cleanup | case 8 red, on the **write** diagnostic |
| **drop the umask on the directory** | **nothing red** |

The last row is uncontrolled and is not described as covered. The directory
exists only inside the call and is removed before it returns, so a case cannot
read its mode without racing the thing it measures. What bounds the consequence
is the file's own 0600, which a row above does bind: a permissive directory would
expose the temp's *name*, not its contents.

Two of these controls had to be repaired before they could discriminate, and both
repairs are recorded in the tests:

- the stale-temp case planted its decoy on a name the helper no longer draws —
  twice, once per change to the candidate name — so it passed for the wrong
  reason. Measured: at the first of those, removing `set -C` entirely left every
  case green.
- the no-`rm` case wrapped its scenario in `( set -e; … ) || rc=$?`. A compound
  command on the left of `||` has errexit disabled inside it, so the `set -e`
  never applied. It runs in a child shell now.

## Measured on this head

```
tests/test_binding_mode.bats                            8/8
+ test_local_team_ids, test_team, test_registry_lock    108 ok / 0 not ok
```

## Rebase

Rebased onto `integration/remote` earlier: #794 landed 239 lines into this same
file, so destination drift was non-empty. Both sides survive and they touch
different functions.

#804 stays open after this lands: whether existing 0664 files should be repaired
rather than refused, and the refusal not printing `chmod 600 <path>`, are
undecided.
