### PR TITLE
fix(remote): check a pid we minted with the probe that can see it

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -61,8 +61,9 @@ source "$SCRIPT_DIR/lib/shquote.sh"
 source "$SCRIPT_DIR/lib/require-python3.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/node.sh"
-# For _agmsg_pid_alive — the one piece of watch.sh's daemon plumbing that is
-# already a shared, reusable helper. The rest of the sync engine's lifecycle
+# For _agmsg_pid_alive_local — the one piece of watch.sh's daemon plumbing that
+# is already a shared, reusable helper. The LOCAL probe, because every pid this
+# file checks is one it minted itself (#652); see the lifecycle note below. The rest of the sync engine's lifecycle
 # (below) is written here rather than shared, because watch.sh's is inline and
 # keyed on watcher-only concepts (session/actas) this engine does not have.
 # shellcheck disable=SC1091
@@ -1322,7 +1323,7 @@ EOF
   _remote_sync_engine_start "$team" || true
   local pid="${REMOTE_SYNC_ENGINE_PID:-}" ready=0 attempts=0
   while [ "$attempts" -lt 50 ]; do
-    if [ -z "$pid" ] || ! _agmsg_pid_alive "$pid"; then
+    if [ -z "$pid" ] || ! _agmsg_pid_alive_local "$pid"; then
       break
     fi
     if tail -c "+$log_offset" "$engine_log" 2>/dev/null |
@@ -1336,7 +1337,7 @@ EOF
   local pidfile="$(_remote_sync_engine_pidfile "$team")" recorded_pid=""
   [ -f "$pidfile" ] && recorded_pid="$(cat "$pidfile" 2>/dev/null || true)"
   if [ "$ready" -ne 1 ] || [ "$recorded_pid" != "$pid" ] ||
-      ! _agmsg_pid_alive "$pid"; then
+      ! _agmsg_pid_alive_local "$pid"; then
     _remote_sync_engine_stop "$team"
     echo "agmsg: encrypted sync was configured, but the sync engine did not become ready" >&2
     exit 1
@@ -1351,7 +1352,16 @@ EOF
 # polling to push new local messages and pull remote ones. Its lifecycle mirrors
 # watch.sh's FORM without sharing its code (see the instance-id.sh source note):
 # one pidfile per unit under the connection's run dir, SIGTERM to stop, and
-# _agmsg_pid_alive to tell a live engine from a stale pidfile. This leaves the
+# _agmsg_pid_alive_local to tell a live engine from a stale pidfile.
+#
+# LOCAL, and that is not a detail. Every pid checked in this file came from `$!`
+# in this shell, or was read back from the pidfile this shell wrote it to — and
+# a pidfile does not move a number into another pid space. Under Git Bash those
+# are MSYS pids, which `tasklist` has no record of, so the non-local probe
+# answers "dead" for an engine that is running: the field report in #652, where
+# `ps -W` found the process, the pidfile held the same number, and status still
+# said stale. The rule is in instance-id.sh and it is about WHERE THE PID WAS
+# MINTED, not about whether it arrived through a file. This leaves the
 # pidfile lifecycle in two places (here and watch.sh); factoring it into a shared
 # lib is intentionally deferred, not overlooked.
 _remote_sync_engine_pidfile() { printf '%s' "$CONNECTION_ROOT/run/remote-sync.$1.pid"; }
@@ -1711,7 +1721,7 @@ _remote_sync_engine_status() {
     printf 'stale\t\n'
     return
   fi
-  if ! _agmsg_pid_alive "$pid"; then
+  if ! _agmsg_pid_alive_local "$pid"; then
     printf 'stale\t%s\n' "$pid"
     return
   fi
@@ -1727,17 +1737,17 @@ _remote_sync_engine_reap_owned() {
   local team="$1" owned_pid="$2" state pid signal attempts
   for signal in TERM KILL; do
     IFS=$'\t' read -r state pid < <(_remote_sync_engine_status "$team")
-    if ! _agmsg_pid_alive "$owned_pid"; then return 0; fi
+    if ! _agmsg_pid_alive_local "$owned_pid"; then return 0; fi
     [ "$state" = "running" ] && [ "$pid" = "$owned_pid" ] || return 1
     kill "-$signal" "$owned_pid" 2>/dev/null || true
     attempts=0
     while [ "$attempts" -lt 100 ]; do
-      _agmsg_pid_alive "$owned_pid" || return 0
+      _agmsg_pid_alive_local "$owned_pid" || return 0
       attempts=$((attempts + 1))
       sleep 0.01
     done
   done
-  ! _agmsg_pid_alive "$owned_pid"
+  ! _agmsg_pid_alive_local "$owned_pid"
 }
 
 # Upgrade a team that predates local ids: mint a team_id AND a member_id for

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -741,3 +741,57 @@ write_unownable_ps_fixture() {
   kill -9 "$child_pid" 2>/dev/null || true
   wait "$child_pid" 2>/dev/null || true
 }
+
+# --- the probe a minted pid is checked with (#652) -----------------------
+#     Field report, koit's Windows dogfood: `ps -W` found node 33872, the
+#     pidfile held 33872, and status still said "engine stale — pidfile 33872
+#     points at a dead or foreign process". The pid was right; the thing asking
+#     whether it was alive could not see it.
+#
+#     `remote.sh` mints every pid it checks — `$!` in this shell, or read back
+#     from the pidfile this shell wrote it to — and a pidfile does not move a
+#     number into another pid space. Under Git Bash those are MSYS pids, which
+#     `tasklist` has no record of.
+
+@test "the non-local probe cannot see a pid this shell minted, and the local one can (#652)" {
+  # Windows modelled on this host: MSYSTEM set, and a `tasklist` that answers
+  # nothing — which is exactly what the real one does when asked about an MSYS
+  # pid. This reproduces the mechanism; it is not a Windows run.
+  local fake_bin="$TEST_SKILL_DIR/fake-tasklist-blind"
+  mkdir -p "$fake_bin"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$fake_bin/tasklist"
+  chmod +x "$fake_bin/tasklist"
+
+  sleep 30 &
+  local minted=$!
+
+  # The premise, checked rather than assumed: the process really is alive.
+  run kill -0 "$minted"
+  [ "$status" -eq 0 ]
+
+  run env PATH="$fake_bin:$PATH" MSYSTEM=MINGW64 bash -c \
+    'source "$1/lib/instance-id.sh"; _agmsg_pid_alive "$2" && echo ALIVE || echo DEAD' \
+    _ "$SCRIPTS" "$minted"
+  [ "$output" = "DEAD" ]   # the defect, reproduced
+
+  run env PATH="$fake_bin:$PATH" MSYSTEM=MINGW64 bash -c \
+    'source "$1/lib/instance-id.sh"; _agmsg_pid_alive_local "$2" && echo ALIVE || echo DEAD' \
+    _ "$SCRIPTS" "$minted"
+  [ "$output" = "ALIVE" ]  # the probe the minted pid is entitled to
+
+  kill "$minted" 2>/dev/null || true
+  wait "$minted" 2>/dev/null || true
+}
+
+@test "remote.sh checks every pid it minted with the local probe (#652)" {
+  # The test above pins the DIFFERENCE between the probes; it says nothing
+  # about which one `remote.sh` calls. This says that, and it is a count
+  # because the failure it guards against is a new call site appearing rather
+  # than an existing one changing.
+  #
+  # Comment lines are stripped first: this file names the non-local probe in
+  # prose to explain why it is not used, and counting those would make the
+  # check measure its own commentary.
+  run bash -c "grep -v '^[[:space:]]*#' \"\$1\" | grep -c '_agmsg_pid_alive \"'" _ "$SCRIPTS/remote.sh"
+  [ "$output" = "0" ]
+}

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -743,8 +743,8 @@ write_unownable_ps_fixture() {
 }
 
 # --- the probe a minted pid is checked with (#652) -----------------------
-#     Field report, koit's Windows dogfood: `ps -W` found node 33872, the
-#     pidfile held 33872, and status still said "engine stale — pidfile 33872
+#     Field report from the owner's Windows dogfood: `ps -W` found node 33872,
+#     the pidfile held 33872, and status still said "engine stale — pidfile
 #     points at a dead or foreign process". The pid was right; the thing asking
 #     whether it was alive could not see it.
 #
@@ -789,9 +789,15 @@ write_unownable_ps_fixture() {
   # because the failure it guards against is a new call site appearing rather
   # than an existing one changing.
   #
-  # Comment lines are stripped first: this file names the non-local probe in
-  # prose to explain why it is not used, and counting those would make the
-  # check measure its own commentary.
-  run bash -c "grep -v '^[[:space:]]*#' \"\$1\" | grep -c '_agmsg_pid_alive \"'" _ "$SCRIPTS/remote.sh"
+  # NOT `grep '_agmsg_pid_alive "'`. That pattern pins the CALL SITE'S SPELLING,
+  # not the call: two spaces, a tab, an unquoted `$pid`, or a line continuation
+  # after the name all slip past it, so a reverted call site could sit here
+  # green (raised in review).
+  #
+  # Instead: strip whole-line comments, delete every `_agmsg_pid_alive_local`
+  # token, and count what is left of the name. Nothing about the argument or
+  # the spacing is assumed, because nothing after the name is looked at. The
+  # helper is defined in instance-id.sh, so no definition is counted here.
+  run bash -c "grep -v '^[[:space:]]*#' \"\$1\" | sed 's/_agmsg_pid_alive_local//g' | grep -c '_agmsg_pid_alive'" _ "$SCRIPTS/remote.sh"
   [ "$output" = "0" ]
 }


### PR DESCRIPTION
Declared reviewers: 1

**Refs #652** — no closing keyword: this lands on `integration/remote`, where GitHub does not act on one.

## The field report

The owner's first Windows dogfood: `ps -W` showed node 33872 alive, the pidfile held 33872, and status said **"engine stale — pidfile 33872 points at a dead or foreign process"**. The pid was right; the thing asking whether it was alive could not see it. The agent on the machine restarted the engine twice before reading the log and finding it had been running all along.

`_agmsg_pid_alive` queries `tasklist` under MSYSTEM, and `tasklist` has no record of a pid this shell minted. Round-tripping the number through a pidfile does not move it into the Windows pid space.

## Derived, not swapped

Every non-local call site in `remote.sh` was traced to where its pid came from **before** changing it — a blanket replacement would be wrong if any of them checked a foreign pid:

| site | pid | provenance |
|---|---|---|
| 1325, 1339 | `$REMOTE_SYNC_ENGINE_PID` | set from `$!` |
| 1714 | `cat "$pidfile"` | the file this shell wrote `$!` into |
| 1730–1740 | `owned_pid` | from `_remote_sync_engine_status` (that pidfile), or `started_pid`, also read from it |

**All six are pids this codebase minted; none checks a pid from outside these shells.** That is the rule `instance-id.sh` states in its own comments: which probe applies is decided by **where the pid was minted**, not by whether it arrived through a file.

## The issue's numbers have moved

It says `_agmsg_pid_alive_local` has "32 occurrences on `main` and 0 on this branch", and that `watch.sh` still has a non-local site. Measured now:

- **32 on both** — the `main` → `integration/remote` merge brought the helper in
- **`watch.sh` already uses the local probe**
- **six** call sites in `remote.sh`, not eight

The issue predicted exactly this: *"The merge will bring in `_agmsg_pid_alive_local` and leave every one of these call sites pointed at the old helper."* It did. Two comments describing the old wiring are corrected rather than left to be believed.

## The same false "dead" reads twice, and the second one breaks state

**Established statically — by reading `remote.sh`, not by running it.** Line numbers are this branch's.

The probe is consulted at two stages of one `sync start`, and the defect turns both:

1. **Readiness.** `agmsg_lock_acquire` at 2414 is held for the whole loop. The loop's condition asks `engine_state = "running"` **first** (2454), and that comes from `_remote_sync_engine_status`, which uses the probe. Under the defect it answers `stale`, so the `&&` chain never evaluates the capabilities marker — the loop spins its full `1600 × 0.01s` **holding the team lock**.

2. **Recovery.** After the timeout, `_remote_sync_engine_reap_owned` (2468) opens with `if ! _agmsg_pid_alive "$owned_pid"; then return 0` (1730). The same false "dead" makes it return success **having sent no signal at all**. The caller reads that as reaped, removes the pidfile, and releases the lock.

**So a live engine is left running with its pidfile deleted** — untracked. `_remote_sync_engine_status` then reports `stopped`, and the next `sync start` is free to launch a second one.

That is why the fix is six call sites rather than the one in the status path: the readiness short-circuit and the no-op reap are the same defect read at two stages.

**Not observed in the field.** The field report is the stale status message and two restarts. Whether the lock contention and the orphaned engine actually occurred on that machine is **not** established here — this section is a code path, and a code path that is reachable is not a run that happened.

## Tested — the mechanism reproduced, not described

`MSYSTEM` set and a `tasklist` that answers nothing (which is what the real one does when asked about an MSYS pid): `_agmsg_pid_alive` reports a live shell-minted pid **dead**, `_agmsg_pid_alive_local` reports it **alive**. The premise is checked first with `kill -0`, so the test cannot pass against a process that had already exited.

This is a reproduction of the mechanism on a POSIX host. **It is not a Windows run**, and the field symptom itself has not been reproduced here.

A second test counts non-local call sites in `remote.sh` and requires zero.

**The two are not interchangeable.** The first pins the difference between the probes and says nothing about which one this file calls; the second pins the wiring and says nothing about behaviour. Reverting one call site turns **only the second** red — which is how that is known rather than assumed.

## Suites

`test_remote_status_liveness.bats` **29 pass**.

`test_remote.bats` **121 pass, 1 fail** — `remote doctor: age is optional — its absence does not fail the run`. That fails **identically on `origin/integration/remote` at `6b29693` with this change absent**: same test, same `[ "$status" -eq 0 ]` at line 2584. A base red, not this branch's.

CI counts go in a comment rather than here, so editing this body does not change the number it states.
