### PR TITLE
fix(sync): an error page is not a protocol mismatch (#814)

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1522,6 +1522,25 @@ async function health(serverUrl, teamId) {
     throw error;
   }
   if (response.headers.get("agmsg-protocol-version") !== PROTOCOL) {
+    // AN ERROR PAGE IS NOT A PROTOCOL MISMATCH.
+    //
+    // A gateway that is down answers 502/503/504 with its own body and none of
+    // our headers, so the version check fails for a reason that has nothing to
+    // do with versions. `request()` already draws this line and names it
+    // "intermediary failure"; this function did not, and this is the one the
+    // engine's loop calls every cycle — so a 90-second outage ended both
+    // engines permanently and silently, and the remote recovering did not
+    // bring them back (#814).
+    //
+    // The distinction is what makes this safe: a 200 whose header says a
+    // different version IS a real mismatch and must still be fatal. Only an
+    // unsuccessful 502/503/504 is treated as weather.
+    if (!response.ok && [502, 503, 504].includes(response.status)) {
+      const error = new Error(`HTTP ${response.status} intermediary failure`);
+      error.status = response.status;
+      error.retryable = true;
+      throw error;
+    }
     throw new Error("health protocol version mismatch");
   }
   const body = await response.json();

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2441,6 +2441,64 @@ test("age configure extends a stored chain and activates its announced epoch", a
   });
 });
 
+test("health treats a 503 error page as weather, not a protocol mismatch (#814)", async () => {
+  // A gateway that is down answers 502/503/504 with its own body and none of
+  // our headers, so the version check fails for a reason that has nothing to do
+  // with versions. `request()` already drew this line; `health()` did not — and
+  // `health()` is what the engine's loop calls every cycle, so a 90-second
+  // outage ended both engines on a live two-machine setup, permanently and
+  // silently. The remote recovered; they did not.
+  const previousFetch = globalThis.fetch;
+  await withConnectedCredential(async (root) => {
+    await writeConnectedTeam(root, { capabilities: { write_allowed_ciphers: ["none"] } });
+    globalThis.fetch = async () =>
+      new Response("<html>503 Service Unavailable</html>",
+        { status: 503, headers: { "Content-Type": "text/html" } });
+    try {
+      await assert.rejects(
+        configure({ team: "demo", server: "https://sync.example",
+          "team-id": config.remote_team_id, "minimum-security": "plaintext-allowed" }),
+        (error) => {
+          // Retryable is the whole point: the loop keeps the engine alive and
+          // the machine comes back on its own when the remote does.
+          assert.equal(error.retryable, true, "a 503 error page must be retryable");
+          assert.equal(error.status, 503);
+          return true;
+        });
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+});
+
+test("health still refuses a 200 that names a different protocol version (#814)", async () => {
+  // The other half, and the reason the fix is a narrowed guard rather than
+  // "retry everything": a successful response whose header says another version
+  // IS a real mismatch. Making the first case retryable must not make this one
+  // retryable too — one condition covering both cases is what the defect was.
+  const previousFetch = globalThis.fetch;
+  await withConnectedCredential(async (root) => {
+    await writeConnectedTeam(root, { capabilities: { write_allowed_ciphers: ["none"] } });
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ status: "ok", database: "ok",
+        server_instance_id: config.server_instance_id,
+        team_id: config.remote_team_id }),
+        { status: 200, headers: { "Agmsg-Protocol-Version": "999" } });
+    try {
+      await assert.rejects(
+        configure({ team: "demo", server: "https://sync.example",
+          "team-id": config.remote_team_id, "minimum-security": "plaintext-allowed" }),
+        (error) => {
+          assert.notEqual(error.retryable, true,
+            "a 200 with a different protocol version must NOT be retryable");
+          return /protocol version mismatch/u.test(error.message);
+        });
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+});
+
 test("configured native identity must belong to its epoch recipient manifest", async () => {
   const root = await mkdtemp(join(tmpdir(), "agmsg-age-identity-"));
   const identity = join(root, "identity");


### PR DESCRIPTION
Declared reviewers: 1

References #814. No closing keyword — `integration/remote` is not the default
branch, so one would not fire.

## What happened in the field

A remote was unavailable for about 90 seconds during a two-machine walk. **Both
engines exited permanently and silently.** The remote recovered on its own; the
engines did not, and nothing surfaced it until someone ran `remote.sh status`.

## Why

`health()` compared the `agmsg-protocol-version` response header against
`PROTOCOL` and threw a fatal error whenever they differed. A gateway that is down
answers 502/503/504 with its own body and none of our headers — so the version
check failed for a reason that has nothing to do with versions, and `health()`
is the function the engine's loop calls every cycle.

`request()` in the same file already draws this line, and even names the
condition:

```js
if (protocol !== PROTOCOL) {
  if (!response.ok && [502, 503, 504].includes(response.status)) {
    const error = new Error(`HTTP ${response.status} intermediary failure`);
    error.status = response.status; error.retryable = true;
    throw error;
  }
  throw new Error("response protocol version mismatch");
}
```

This copies it into `health()`.

## Two assertions, because the defect was one condition covering two cases

```
503 with no protocol header     retryable — the loop survives, the machine
                                comes back when the remote does
200 with a different version    NOT retryable — a real mismatch, still fatal
```

A single test would leave the same hole the fix is closing. The second case is
also why this is a narrowed guard rather than "retry everything": a successful
response claiming another protocol version means what it says.

## Mutations

```
remove the guard (the pre-fix state)   the 503 test reds
make every mismatch retryable          the 200 test reds
```

Both run. The suite is green with the guard in place.

## Found while measuring, not fixed here

The same unguarded comparison exists a third time in this file, in
`publicGet()`. It is **not** on the engine's loop — `configure` and `connect`
reach it — so a transient 5xx there fails one command instead of ending a
long-running process. Different blast radius, and #814 does not ask for it.
Worth its own issue rather than a silent widening of this one.

## The other side

`JugemuAI/agmsg-cloud#481` is the gateway crash that produced the outage. This
change is the half that means a future outage does not need the other half to be
fixed first: engines ride it out and return by themselves.
