### PR TITLE
fix(sync): hand the driver its input as a file, not down a pipe

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -545,6 +545,16 @@ jobs:
           - leg: windows runtime (#567)
             filter: "windows-native"
             target: tests/test_codex_monitor.bats tests/test_codex_bridge_launcher.bats
+          # The roster driver's staged input (#817). Same reasoning as the leg
+          # above, one layer down: the fix is for Windows, and two of the things
+          # it rests on -- an ordinary file descriptor arriving as Git Bash's
+          # stdin, and a temp file that cannot be unlinked while open -- behave
+          # differently there than on the hosts that were measured. The engine's
+          # own bats leg is ubuntu and macos only, so this selects the two tests
+          # that would notice and runs them on the platform in question.
+          - leg: driver input (#817)
+            filter: "driver-input"
+            target: tests/test_remote_sync_driver_input.bats
     defaults:
       run:
         # bats is bash; on Windows runners `shell: bash` is Git Bash, the same

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -530,6 +530,7 @@ jobs:
           - leg: install helpers
             filter: "[Ww]indows"
             target: tests/test_install.bats
+            sqlite: true
           # The Windows runtime path, which nothing here covered until #567: a
           # change to how liveness is decided on Windows shipped through a CI
           # that never decided liveness on Windows. Everything else about that
@@ -545,6 +546,7 @@ jobs:
           - leg: windows runtime (#567)
             filter: "windows-native"
             target: tests/test_codex_monitor.bats tests/test_codex_bridge_launcher.bats
+            sqlite: true
           # The roster driver's staged input (#817). Same reasoning as the leg
           # above, one layer down: the fix is for Windows, and two of the things
           # it rests on -- an ordinary file descriptor arriving as Git Bash's
@@ -555,6 +557,12 @@ jobs:
           - leg: driver input (#817)
             filter: "driver-input"
             target: tests/test_remote_sync_driver_input.bats
+            # No sqlite3: these two drive a mock bash driver and never open a
+            # store. Installing it anyway made this leg red for an outage in a
+            # third-party package feed, on a run where its own tests never
+            # started -- a leg that fails for something it does not use reports
+            # on that thing, not on the code.
+            sqlite: false
     defaults:
       run:
         # bats is bash; on Windows runners `shell: bash` is Git Bash, the same
@@ -568,12 +576,12 @@ jobs:
         run: echo "Diff is documentation-only; skipping the Windows bats legs."
 
       - name: Install sqlite3
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && matrix.sqlite
         shell: pwsh
         run: choco install sqlite -y --no-progress
 
       - name: Put chocolatey shims on PATH (Git Bash form)
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && matrix.sqlite
         run: echo "/c/ProgramData/chocolatey/bin" >> "$GITHUB_PATH"
 
       - name: Install bats

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1746,7 +1746,7 @@ function stageInput(input, staging) {
 // is message content, and a swallowed failure leaves it on disk with nobody
 // told. So the failure is downgraded to a warning that names the directory,
 // which is the one thing an operator needs to remove it.
-function discardInputDirectory(directory, reason) {
+export function discardInputDirectory(directory, reason) {
   try {
     rmSync(directory, { recursive: true, force: true });
   } catch (error) {

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1701,17 +1701,37 @@ function bindingNote(binding) {
 // held. A file cannot fail that way. It is complete before the child exists --
 // therefore before the lock exists -- and the child still reads its stdin
 // exactly as before, so no driver changes.
+//
+// ONLY the driver that holds the lock is handed its input this way, and the
+// caller says which one that is. The storage driver has no registry lock, so
+// nothing about it needs this, and giving it the same treatment would cost it
+// two things for nothing: its input -- which after evaluatePull() is decrypted
+// message content, on E2EE teams as much as plain ones -- would go to rest on
+// disk where only a pipe carried it, and it would lose the bounded failure it
+// has today, since a driver that stops reading a pipe fails at once while a
+// driver handed a file is waited for. This is a fix for one caller and it is
+// scoped to that caller.
 function handOverInput(input) {
   // 0700 by mkdtemp and 0600 on the file. These records are message content,
   // and putting them in a file puts them at rest on disk, which a pipe did not.
   const directory = mkdtempSync(join(tmpdir(), "agmsg-driver-input-"));
   const path = join(directory, "input.jsonl");
-  writeFileSync(path, input.map((record) => `${JSON.stringify(record)}\n`).join(""),
-    { mode: 0o600 });
-  // A fresh read-only descriptor. Passing on the one the write used would hand
-  // over a descriptor sitting at EOF, and the driver would read an empty input
-  // and report a successful sync of nothing.
-  const fd = openSync(path, "r");
+  let fd;
+  try {
+    writeFileSync(path, input.map((record) => `${JSON.stringify(record)}\n`).join(""),
+      { mode: 0o600 });
+    // A fresh read-only descriptor. Passing on the one the write used would
+    // hand over a descriptor sitting at EOF, and the driver would read an empty
+    // input and report a successful sync of nothing.
+    fd = openSync(path, "r");
+  } catch (error) {
+    // The content is already written by the time `openSync` can fail, and there
+    // is no descriptor yet for anything downstream to clean up from. Failing
+    // out of here without this leaves message content in a temp directory that
+    // nothing else knows the name of.
+    discardInputDirectory(directory, "staging the driver's input failed");
+    throw error;
+  }
   // Then take the name away immediately, while the descriptor stays open: the
   // spawn duplicates it into the child, so both sides keep reading a file that
   // nothing can any longer open by name, and a parent that dies leaves no
@@ -1726,7 +1746,24 @@ function handOverInput(input) {
   return { directory: unlinked ? null : directory, fd };
 }
 
-function runDriver({ args, label, operation, parse, input, rosterFile, team, bindingPath }) {
+// Removing a temp directory must not fail the call around it -- refusing a sync
+// that completed, over a file the caller cannot act on, trades a real result
+// for a cleanup detail. But it must not be SILENT either: what is left behind
+// is message content, and a swallowed failure leaves it on disk with nobody
+// told. So the failure is downgraded to a warning that names the directory,
+// which is the one thing an operator needs to remove it.
+function discardInputDirectory(directory, reason) {
+  try {
+    rmSync(directory, { recursive: true, force: true });
+  } catch (error) {
+    process.emitWarning(
+      `${reason}: driver input left at ${directory} (${error.message})`,
+      "AgmsgDriverInputResidue");
+  }
+}
+
+function runDriver({ args, label, operation, parse, input, rosterFile, team, bindingPath,
+  holdsRegistryLock = false }) {
   return new Promise((resolve, reject) => {
     const childEnvironment = { ...process.env };
     delete childEnvironment.AGMSG_SYNC_TOKEN;
@@ -1744,24 +1781,25 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
     // comment rather than in the function. Naming the single variable keeps the
     // guarantee where it can be checked.
     if (rosterFile) childEnvironment.AGMSG_SYNC_LOCAL_ROSTER_FILE = rosterFile;
-    // Before the spawn, so before the lock: a failure to stage the input is a
-    // failure with no child and no lock to leak.
+    // Staged before the spawn, so before the lock: a failure to stage the input
+    // is a failure with no child and no lock to leak. Only for the caller that
+    // holds the lock -- everyone else keeps the pipe, and with it the bounded
+    // failure a pipe gives and an input that never reaches disk.
     let handover = null;
-    try {
-      handover = handOverInput(input);
-    } catch (error) {
-      reject(error);
-      return;
+    if (holdsRegistryLock) {
+      try {
+        handover = handOverInput(input);
+      } catch (error) {
+        reject(error);
+        return;
+      }
     }
-    // The fd is opened read-only and fresh, never the one the write used --
-    // that one sits at EOF, which the driver would read as an empty input and
-    // report as a successful sync of nothing.
-    const child = spawn("bash", args,
-      { stdio: [handover.fd, "pipe", "pipe"], env: childEnvironment });
-    let stdout = ""; let stderr = ""; let settled = false; let failure = null;
 
     // Ours to close: a descriptor handed to `stdio` is duplicated for the child,
-    // and the parent's copy stays open until the parent closes it.
+    // and the parent's copy stays open until the parent closes it. Declared
+    // before the spawn because the spawn itself can throw, and a throw between
+    // the handover and the settle path would otherwise strand both the
+    // descriptor and, on Windows, a named file of message content.
     const releaseInput = () => {
       if (!handover) return;
       const { directory, fd } = handover;
@@ -1769,13 +1807,29 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
       try { closeSync(fd); } catch { /* already closed */ }
       // Null when the directory was already taken away at handover, which is
       // the ordinary case everywhere the file could be unlinked while open.
-      // Best effort, and deliberately not a failure: refusing the whole call
-      // because a temp directory outlived it would turn a completed sync into
-      // an error over something the caller cannot act on.
       if (directory !== null) {
-        try { rmSync(directory, { recursive: true, force: true }); } catch { /* ignore */ }
+        discardInputDirectory(directory, "the driver call ended");
       }
     };
+
+    // Read once, here. `handover` is nulled when the input is released, so it
+    // cannot be asked later whether there was ever a pipe to write to.
+    const staged = handover !== null;
+    let child;
+    try {
+      // The fd is opened read-only and fresh, never the one the write used --
+      // that one sits at EOF, which the driver would read as an empty input and
+      // report as a successful sync of nothing.
+      child = spawn("bash", args,
+        { stdio: [staged ? handover.fd : "pipe", "pipe", "pipe"], env: childEnvironment });
+    } catch (error) {
+      // A synchronous spawn failure never reaches 'error', so nothing else here
+      // would run. There is no child, so there is nothing else to undo.
+      releaseInput();
+      reject(error);
+      return;
+    }
+    let stdout = ""; let stderr = ""; let settled = false; let failure = null;
 
     const settle = (error, value) => {
       if (settled) return;
@@ -1796,12 +1850,12 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
       }
       if (running) {
         try {
-          // Reachable only with a child that is already gone -- see the note on
-          // handOverInput. Every route into fail() is either 'error' (the spawn
-          // itself failed, so there is no process) or the 'exit' handler (the
-          // child has exited, so `running` is false). This stays as the backstop
-          // it was written to be, and it is deliberately still SIGKILL: making
-          // it SIGTERM would only look like lock-safety without being it.
+          // Unchanged, and it still matters: on the pipe path a write that
+          // loses its reader arrives here with the driver alive, and leaving it
+          // running would trade "the process dies" for "the process cannot
+          // exit". What changed is only who can be on that path -- a driver
+          // holding the registry lock is handed a file instead, so it is never
+          // the one being killed. See the note on handOverInput.
           child.kill("SIGKILL");
           return;
         } catch { /* already gone; fall through and settle now */ }
@@ -1820,12 +1874,19 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
       process.stderr.write(chunk);
     });
     child.on("error", fail);
-    // There is no stdin 'error' handler any more, and no stdin stream to put
-    // one on. The `driverFailurePhase = "stdin-write"` marker went with it: it
-    // existed because a write whose reader is gone is EPIPE on Linux and either
-    // ENOTCONN or EPIPE on macOS, so the failure could not be recognised by
-    // errno downstream. Handing the input over as a file removes the write, and
-    // with it the failure it was labelling.
+    // Only on the pipe path -- a staged input has no stdin stream to put this
+    // on, and no write that could fail.
+    child.stdin?.on("error", (error) => {
+      // Where the failure came from, recorded at the boundary because the OS
+      // code cannot be asked for it: a write whose reader is gone is EPIPE on
+      // Linux, and on macOS -- socketpairs -- either ENOTCONN or EPIPE
+      // depending on how far the write got. That set is not closed, so nothing
+      // downstream can recognise this failure by errno without going stale on
+      // the next platform. The error is otherwise passed through untouched, so
+      // its code and message survive for diagnostics.
+      error.driverFailurePhase = "stdin-write";
+      fail(error);
+    });
     // Every failure ends here, at 'exit'. A driver that merely exits non-zero is
     // the ordinary case and it needs this as much as a stream error does: it too
     // can leave a grandchild holding the inherited pipes, and waiting for 'close'
@@ -1855,7 +1916,11 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
         settle(error, null);
       }
     });
-    // Nothing is written here. The input was complete on disk before the spawn.
+    // Nothing to write when the input was staged: it was complete on disk
+    // before the spawn, and the child is already reading it.
+    if (!staged) {
+      child.stdin.end(input.map((record) => `${JSON.stringify(record)}\n`).join(""));
+    }
   });
 }
 
@@ -1901,6 +1966,11 @@ export async function rosterDriver(operation, config, input, extra = []) {
     bindingPath: bindingPathOrReason(config.local_team),
     parse: parseJsonl,
     input,
+    // This is the driver that takes the team's registry lock, as its first act,
+    // and releases it only from a trap. It is the reason the input is staged in
+    // a file: nothing here may ever be in a position to kill it. The storage
+    // driver takes no such lock and is deliberately not given this.
+    holdsRegistryLock: true,
     // The roster file, resolved here and handed over as one path — not the
     // directory it sits in. A directory would put the driver back in the
     // business of deriving locations, which is what AGMSG_SYNC_CONNECTION_DIR

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1711,39 +1711,33 @@ function bindingNote(binding) {
 // has today, since a driver that stops reading a pipe fails at once while a
 // driver handed a file is waited for. This is a fix for one caller and it is
 // scoped to that caller.
-function handOverInput(input) {
+function stageInput(input, staging) {
+  // Filled IN PLACE, so that one cleanup path can undo whatever part of it got
+  // made. The first version cleaned up inside here as well as at settle, which
+  // is two routes doing the same job -- and the one in here could not be
+  // reached by any test, so it was a guarantee nothing was holding up. There is
+  // one route now, and the caller owns it.
+  //
   // 0700 by mkdtemp and 0600 on the file. These records are message content,
   // and putting them in a file puts them at rest on disk, which a pipe did not.
-  const directory = mkdtempSync(join(tmpdir(), "agmsg-driver-input-"));
-  const path = join(directory, "input.jsonl");
-  let fd;
-  try {
-    writeFileSync(path, input.map((record) => `${JSON.stringify(record)}\n`).join(""),
-      { mode: 0o600 });
-    // A fresh read-only descriptor. Passing on the one the write used would
-    // hand over a descriptor sitting at EOF, and the driver would read an empty
-    // input and report a successful sync of nothing.
-    fd = openSync(path, "r");
-  } catch (error) {
-    // The content is already written by the time `openSync` can fail, and there
-    // is no descriptor yet for anything downstream to clean up from. Failing
-    // out of here without this leaves message content in a temp directory that
-    // nothing else knows the name of.
-    discardInputDirectory(directory, "staging the driver's input failed");
-    throw error;
-  }
+  staging.directory = mkdtempSync(join(tmpdir(), "agmsg-driver-input-"));
+  const path = join(staging.directory, "input.jsonl");
+  writeFileSync(path, input.map((record) => `${JSON.stringify(record)}\n`).join(""),
+    { mode: 0o600 });
+  // A fresh read-only descriptor. Passing on the one the write used would hand
+  // over a descriptor sitting at EOF, and the driver would read an empty input
+  // and report a successful sync of nothing.
+  staging.fd = openSync(path, "r");
   // Then take the name away immediately, while the descriptor stays open: the
   // spawn duplicates it into the child, so both sides keep reading a file that
   // nothing can any longer open by name, and a parent that dies leaves no
   // message content behind. Windows cannot unlink an open file, so there it
   // stays until the call settles -- which is why the directory is still tracked
   // and removed there rather than only here.
-  let unlinked = false;
   try {
-    rmSync(directory, { recursive: true, force: true });
-    unlinked = true;
+    rmSync(staging.directory, { recursive: true, force: true });
+    staging.directory = null;
   } catch { /* Windows, or a tmpdir that will not allow it; settle cleans up */ }
-  return { directory: unlinked ? null : directory, fd };
 }
 
 // Removing a temp directory must not fail the call around it -- refusing a sync
@@ -1781,54 +1775,48 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
     // comment rather than in the function. Naming the single variable keeps the
     // guarantee where it can be checked.
     if (rosterFile) childEnvironment.AGMSG_SYNC_LOCAL_ROSTER_FILE = rosterFile;
-    // Staged before the spawn, so before the lock: a failure to stage the input
-    // is a failure with no child and no lock to leak. Only for the caller that
-    // holds the lock -- everyone else keeps the pipe, and with it the bounded
-    // failure a pipe gives and an input that never reaches disk.
-    let handover = null;
-    if (holdsRegistryLock) {
-      try {
-        handover = handOverInput(input);
-      } catch (error) {
-        reject(error);
-        return;
-      }
-    }
-
-    // Ours to close: a descriptor handed to `stdio` is duplicated for the child,
-    // and the parent's copy stays open until the parent closes it. Declared
-    // before the spawn because the spawn itself can throw, and a throw between
-    // the handover and the settle path would otherwise strand both the
-    // descriptor and, on Windows, a named file of message content.
+    // The staged input, and the ONE place that undoes it. Whatever part of the
+    // staging exists when something goes wrong -- a directory and no descriptor,
+    // both, or neither -- this is what puts it back, and it is the only thing
+    // that does. That matters more than it looks: the routes into it that a
+    // test cannot reach are undone by the same lines as the route a test can,
+    // so binding one binds them all.
+    const staging = { directory: null, fd: null };
     const releaseInput = () => {
-      if (!handover) return;
-      const { directory, fd } = handover;
-      handover = null;
-      try { closeSync(fd); } catch { /* already closed */ }
-      // Null when the directory was already taken away at handover, which is
-      // the ordinary case everywhere the file could be unlinked while open.
-      if (directory !== null) {
-        discardInputDirectory(directory, "the driver call ended");
+      if (staging.fd !== null) {
+        try { closeSync(staging.fd); } catch { /* already closed */ }
+        staging.fd = null;
+      }
+      // Already null whenever the file could be unlinked while still open,
+      // which is everywhere except Windows.
+      if (staging.directory !== null) {
+        discardInputDirectory(staging.directory, "the driver call ended");
+        staging.directory = null;
       }
     };
 
-    // Read once, here. `handover` is nulled when the input is released, so it
-    // cannot be asked later whether there was ever a pipe to write to.
-    const staged = handover !== null;
     let child;
     try {
-      // The fd is opened read-only and fresh, never the one the write used --
-      // that one sits at EOF, which the driver would read as an empty input and
-      // report as a successful sync of nothing.
-      child = spawn("bash", args,
-        { stdio: [staged ? handover.fd : "pipe", "pipe", "pipe"], env: childEnvironment });
+      // Staged before the spawn, so before the lock: a failure to stage is a
+      // failure with no child and no lock to leak. Only for the caller that
+      // holds the lock -- everyone else keeps the pipe, and with it the bounded
+      // failure a pipe gives and an input that never reaches disk.
+      if (holdsRegistryLock) stageInput(input, staging);
+      child = spawn("bash", args, {
+        stdio: [staging.fd === null ? "pipe" : staging.fd, "pipe", "pipe"],
+        env: childEnvironment,
+      });
     } catch (error) {
-      // A synchronous spawn failure never reaches 'error', so nothing else here
-      // would run. There is no child, so there is nothing else to undo.
+      // Reached by a staging failure and by a synchronous spawn failure alike.
+      // Neither leaves a child, and a synchronous spawn failure never reaches
+      // 'error', so nothing else here would run for it.
       releaseInput();
       reject(error);
       return;
     }
+    // Read once, here: `staging.fd` is nulled on release, so it cannot be asked
+    // later whether there was ever a pipe to write to.
+    const staged = staging.fd !== null;
     let stdout = ""; let stderr = ""; let settled = false; let failure = null;
 
     const settle = (error, value) => {
@@ -1855,7 +1843,7 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
           // running would trade "the process dies" for "the process cannot
           // exit". What changed is only who can be on that path -- a driver
           // holding the registry lock is handed a file instead, so it is never
-          // the one being killed. See the note on handOverInput.
+          // the one being killed. See the note on stageInput.
           child.kill("SIGKILL");
           return;
         } catch { /* already gone; fall through and settle now */ }

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -5,7 +5,8 @@ import { spawn } from "node:child_process";
 import { appendFile, lstat, mkdir, open, readFile, rename, rm, rmdir, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import process from "node:process";
-import { realpathSync } from "node:fs";
+import { closeSync, mkdtempSync, openSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { ageExecutableVersion, CipherStateError, openEnvelope,
   readNativeAgeIdentity } from "./sync-cipher.mjs";
@@ -1678,6 +1679,53 @@ function bindingNote(binding) {
   return " and its binding";
 }
 
+// Hands the driver its input as a FILE rather than down a pipe.
+//
+// The driver takes that team's registry lock as its first act and holds it for
+// the whole call, and every release route it has is a trap. So the parent must
+// never end up in a position where it has to kill the driver: SIGKILL runs no
+// trap and leaves `.config.lock` with no owner, and every later run for that
+// team then waits on a directory nobody will remove. Measured, on one script
+// with an EXIT/TERM trap: SIGTERM leaves no lock, SIGKILL leaves it.
+//
+// Sending SIGTERM instead is NOT the fix, and was measured not to be one.
+// Bash defers a trap while it waits on a foreground child, so the driver --
+// which is sitting in `node` -- does not run its release until that child ends;
+// signalling the process group does work here, but on Windows Node's kill()
+// ignores the signal and terminates forcefully whatever it is asked for, which
+// is the platform the field report came from.
+//
+// So the kill is removed instead of being softened. Writing to a pipe was the
+// one failure route that reached a LIVE driver: a write whose reader is gone
+// raises on the stdin stream, and that arrived at fail() while the lock was
+// held. A file cannot fail that way. It is complete before the child exists --
+// therefore before the lock exists -- and the child still reads its stdin
+// exactly as before, so no driver changes.
+function handOverInput(input) {
+  // 0700 by mkdtemp and 0600 on the file. These records are message content,
+  // and putting them in a file puts them at rest on disk, which a pipe did not.
+  const directory = mkdtempSync(join(tmpdir(), "agmsg-driver-input-"));
+  const path = join(directory, "input.jsonl");
+  writeFileSync(path, input.map((record) => `${JSON.stringify(record)}\n`).join(""),
+    { mode: 0o600 });
+  // A fresh read-only descriptor. Passing on the one the write used would hand
+  // over a descriptor sitting at EOF, and the driver would read an empty input
+  // and report a successful sync of nothing.
+  const fd = openSync(path, "r");
+  // Then take the name away immediately, while the descriptor stays open: the
+  // spawn duplicates it into the child, so both sides keep reading a file that
+  // nothing can any longer open by name, and a parent that dies leaves no
+  // message content behind. Windows cannot unlink an open file, so there it
+  // stays until the call settles -- which is why the directory is still tracked
+  // and removed there rather than only here.
+  let unlinked = false;
+  try {
+    rmSync(directory, { recursive: true, force: true });
+    unlinked = true;
+  } catch { /* Windows, or a tmpdir that will not allow it; settle cleans up */ }
+  return { directory: unlinked ? null : directory, fd };
+}
+
 function runDriver({ args, label, operation, parse, input, rosterFile, team, bindingPath }) {
   return new Promise((resolve, reject) => {
     const childEnvironment = { ...process.env };
@@ -1696,12 +1744,43 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
     // comment rather than in the function. Naming the single variable keeps the
     // guarantee where it can be checked.
     if (rosterFile) childEnvironment.AGMSG_SYNC_LOCAL_ROSTER_FILE = rosterFile;
-    const child = spawn("bash", args, { stdio: ["pipe", "pipe", "pipe"], env: childEnvironment });
+    // Before the spawn, so before the lock: a failure to stage the input is a
+    // failure with no child and no lock to leak.
+    let handover = null;
+    try {
+      handover = handOverInput(input);
+    } catch (error) {
+      reject(error);
+      return;
+    }
+    // The fd is opened read-only and fresh, never the one the write used --
+    // that one sits at EOF, which the driver would read as an empty input and
+    // report as a successful sync of nothing.
+    const child = spawn("bash", args,
+      { stdio: [handover.fd, "pipe", "pipe"], env: childEnvironment });
     let stdout = ""; let stderr = ""; let settled = false; let failure = null;
+
+    // Ours to close: a descriptor handed to `stdio` is duplicated for the child,
+    // and the parent's copy stays open until the parent closes it.
+    const releaseInput = () => {
+      if (!handover) return;
+      const { directory, fd } = handover;
+      handover = null;
+      try { closeSync(fd); } catch { /* already closed */ }
+      // Null when the directory was already taken away at handover, which is
+      // the ordinary case everywhere the file could be unlinked while open.
+      // Best effort, and deliberately not a failure: refusing the whole call
+      // because a temp directory outlived it would turn a completed sync into
+      // an error over something the caller cannot act on.
+      if (directory !== null) {
+        try { rmSync(directory, { recursive: true, force: true }); } catch { /* ignore */ }
+      }
+    };
 
     const settle = (error, value) => {
       if (settled) return;
       settled = true;
+      releaseInput();
       if (error) reject(error); else resolve(value);
     };
     // Records the failure, stops the child, and lets go of our pipe ends; 'exit'
@@ -1717,6 +1796,12 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
       }
       if (running) {
         try {
+          // Reachable only with a child that is already gone -- see the note on
+          // handOverInput. Every route into fail() is either 'error' (the spawn
+          // itself failed, so there is no process) or the 'exit' handler (the
+          // child has exited, so `running` is false). This stays as the backstop
+          // it was written to be, and it is deliberately still SIGKILL: making
+          // it SIGTERM would only look like lock-safety without being it.
           child.kill("SIGKILL");
           return;
         } catch { /* already gone; fall through and settle now */ }
@@ -1735,17 +1820,12 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
       process.stderr.write(chunk);
     });
     child.on("error", fail);
-    child.stdin.on("error", (error) => {
-      // Where the failure came from, recorded at the boundary because the OS
-      // code cannot be asked for it: a write whose reader is gone is EPIPE on
-      // Linux, and on macOS -- socketpairs -- either ENOTCONN or EPIPE
-      // depending on how far the write got. That set is not closed, so nothing
-      // downstream can recognise this failure by errno without going stale on
-      // the next platform. The error is otherwise passed through untouched, so
-      // its code and message survive for diagnostics.
-      error.driverFailurePhase = "stdin-write";
-      fail(error);
-    });
+    // There is no stdin 'error' handler any more, and no stdin stream to put
+    // one on. The `driverFailurePhase = "stdin-write"` marker went with it: it
+    // existed because a write whose reader is gone is EPIPE on Linux and either
+    // ENOTCONN or EPIPE on macOS, so the failure could not be recognised by
+    // errno downstream. Handing the input over as a file removes the write, and
+    // with it the failure it was labelling.
     // Every failure ends here, at 'exit'. A driver that merely exits non-zero is
     // the ordinary case and it needs this as much as a stream error does: it too
     // can leave a grandchild holding the inherited pipes, and waiting for 'close'
@@ -1775,7 +1855,7 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
         settle(error, null);
       }
     });
-    child.stdin.end(input.map((record) => `${JSON.stringify(record)}\n`).join(""));
+    // Nothing is written here. The input was complete on disk before the spawn.
   });
 }
 

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, symlink, unlink,
   writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -1889,30 +1890,44 @@ async function driverLifecycleFixture(t, { script, calls, root }) {
   return { started, gone };
 }
 
-test("a driver that stops reading its input fails the call and is not left running",
+test("a driver that stops reading its input is left to release its own lock",
   { timeout: 30_000 }, async (t) => {
-  // The write loses its reader and takes EPIPE, which arrives on the stdin
-  // stream rather than on the child -- and an unhandled stream 'error' is
-  // thrown, not returned. So the failure escaped the promise and killed the
-  // process, surfacing as an uncaughtException inside whichever unrelated test
-  // was running when it fired, which is how it read as a flake.
+  // This was a test about EPIPE. The parent wrote the input down a pipe, a
+  // driver that had stopped reading took the write's error, and the call
+  // answered by SIGKILLing that driver -- which is the one thing it must not do.
+  // roster-sync-driver.sh takes the team's registry lock as its first act and
+  // holds it for the whole call, and its only release routes are traps. SIGKILL
+  // runs none of them, so the fast failure was bought by leaving `.config.lock`
+  // behind with no owner, and every later run for that team then waits on a
+  // directory nobody is going to remove.
   //
-  // Rejecting is only half of it: a rejected call that leaves the driver running
-  // trades "the process dies" for "the process cannot exit". So the fixture
-  // records its pid, and leaves a background descendant holding the inherited
-  // pipes -- what a real driver that starts a helper does, and the thing that
-  // keeps 'close' from ever arriving -- then replaces itself with a sleep longer
-  // than this test may run, so nothing here can pass by waiting.
+  // So the fixture now takes a lock the way the driver does -- a directory,
+  // released from an EXIT trap -- and stops reading its input while still
+  // holding it. It keeps the background descendant that holds the inherited
+  // pipes, which is what a real driver starting a helper leaves and the reason
+  // 'close' never arrives, but it ends itself rather than sleeping past the
+  // test: nothing here may pass by waiting, and nothing may hang.
   //
   // The payload is past any platform's pipe buffer (64 KiB on Linux, less on
-  // macOS), so the write cannot complete unread.
-  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-epipe-"));
+  // macOS): under the old code the write could not complete unread, which is
+  // what made it fail there.
+  //
+  // Measured against the previous implementation this test fails -- the driver
+  // is killed about 20ms in and the trap never runs. What it costs is the fast
+  // failure: the call now waits for the driver to end instead of ending it.
+  // That trade is deliberate, and bounding a driver that HANGS is separate work
+  // that is not done here.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-lock-"));
+  const lockFor = (pidFile) => `${pidFile}.lock`;
   const script = (pidFile, helperFile) => `#!/usr/bin/env bash
 echo $$ > ${JSON.stringify(pidFile)}
 sleep 300 &
 echo $! > ${JSON.stringify(helperFile)}
+mkdir ${JSON.stringify(lockFor(pidFile))} || exit 1
+trap 'rmdir ${JSON.stringify(lockFor(pidFile))} 2>/dev/null' EXIT
 exec 0<&-
-exec sleep 300
+sleep 2
+exit 7
 `;
   const wide = "x".repeat(4096);
   const input = Array.from({ length: 512 }, (_, index) => ({ type: "probe", index, wide }));
@@ -1922,21 +1937,58 @@ exec sleep 300
       () => rosterDriver("apply", config, input),
     ]);
 
-  for (const { promise, childPid } of started) {
-    // On the marker the stdin handler sets, not on the errno. This asserted
-    // EPIPE first and so passed or failed by platform -- macOS answers ENOTCONN
-    // or EPIPE from the same event -- and enumerating the codes seen so far only
-    // moves the problem to whichever spelling appears next. The set of errnos is
-    // not closed; the set of places that set this marker is.
-    //
-    // It stays load-bearing for the same reason it is stable: only that handler
-    // sets it, so a rejection arriving from 'close' cannot satisfy this, and
-    // removing the handler fails the test.
+  for (const [index, { promise, childPid }] of started.entries()) {
+    // The call still fails, but through the ordinary route -- the driver's own
+    // exit status -- rather than through a write whose reader went away. Both
+    // halves are asserted: a rejection carrying the stdin-write marker would
+    // mean the pipe write came back, and that marker is set in exactly one
+    // place, so it cannot be satisfied by accident.
     await assert.rejects(() => promise,
-      (error) => error.driverFailurePhase === "stdin-write");
+      (error) => error.driverFailurePhase === undefined &&
+        /exit/iu.test(String(error.message)));
     // No poll and no grace period. The call settles only after the driver has
     // exited, so by this line it is already gone.
     assert.ok(gone(childPid), "the failed driver was left running");
+    // The property this test exists for.
+    assert.ok(!existsSync(lockFor(join(root, `child-${index}.pid`))),
+      "the driver was killed before its trap could release the lock");
+  }
+});
+
+test("a driver is handed its whole input, from the start of it",
+  { timeout: 30_000 }, async (t) => {
+  // The input is staged in a file and that file's descriptor is handed over as
+  // the child's stdin. Two ways that goes silently wrong, and neither one
+  // announces itself -- the driver reads a short input or an empty one and
+  // reports a perfectly successful sync of nothing:
+  //
+  //   - the descriptor the write used is passed on, and it sits at EOF
+  //   - the file is still being written when the child starts reading
+  //
+  // So the driver counts what it actually received and the count is asserted
+  // against what was sent. A payload well past any pipe buffer, because a small
+  // one is delivered correctly by almost any mistake.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-input-"));
+  const script = (pidFile, helperFile) => `#!/usr/bin/env bash
+echo $$ > ${JSON.stringify(pidFile)}
+echo $$ > ${JSON.stringify(helperFile)}
+lines=$(wc -l)
+printf '{"lines":%d}\\n' "$lines"
+`;
+  const wide = "x".repeat(4096);
+  const RECORDS = 512;
+  const input = Array.from({ length: RECORDS },
+    (_, index) => ({ type: "probe", index, wide }));
+  const { started } = await withDriverEnvironment(t, root, script,
+    (mock, config) => [
+      () => driver("prepare", config, input, ["1"]),
+      () => rosterDriver("apply", config, input),
+    ]);
+
+  for (const { promise } of started) {
+    const result = await promise;
+    assert.equal(result[0]?.lines, RECORDS,
+      "the driver did not receive every record that was sent");
   }
 });
 

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2070,11 +2070,29 @@ printf '{"ok":true}\\n'
   const descriptors = () => {
     try { return readdirSync("/dev/fd").length; } catch { return null; }
   };
+  // Sequential, and driven directly rather than through the pid fixture. That
+  // fixture waits for every driver to record a pid before it returns, and 24
+  // bash processes at once is a lot to ask of a Windows runner -- a timeout
+  // there would fail this test for the runner's speed rather than for a leak,
+  // which is the wrong thing for it to be sensitive to.
+  const okDriver = join(root, "ok-driver.sh");
+  await writeFile(okDriver,
+    "#!/usr/bin/env bash\ncat > /dev/null\nprintf '{\"ok\":true}\\n'\n",
+    { mode: 0o700 });
+  const previousRosterDriver = process.env.AGMSG_SYNC_ROSTER_DRIVER;
+  process.env.AGMSG_SYNC_ROSTER_DRIVER = okDriver;
+  t.after(() => {
+    if (previousRosterDriver === undefined) delete process.env.AGMSG_SYNC_ROSTER_DRIVER;
+    else process.env.AGMSG_SYNC_ROSTER_DRIVER = previousRosterDriver;
+  });
+  const config = {
+    local_team: "residue", server_instance_id: "018f0000-0000-7000-8000-000000000001",
+    remote_team_id: "018f0000-0000-7000-8000-000000000002", protocol_version: 1,
+  };
   const openBefore = descriptors();
-  const { started: fine } = await withDriverEnvironment(t, root, ok,
-    (mock, config) => Array.from({ length: 24 },
-      () => () => rosterDriver("apply", config, input)));
-  for (const { promise } of fine) await promise;
+  for (let attempt = 0; attempt < 24; attempt += 1) {
+    await rosterDriver("apply", config, input);
+  }
   assert.equal(await residue(), before, "a successful call left its input behind");
   if (openBefore !== null) {
     // A bound, not equality: this process has descriptors of its own. Twenty-

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -18,6 +18,7 @@ import {
   consistentReadStateContext,
   configure,
   cycle,
+  discardInputDirectory,
   driver,
   exportAgeHandoff,
   exportAgeSnapshot,
@@ -2197,6 +2198,54 @@ printf '{"ok":true}\\n'
     "the staged input still had a name while the driver was reading it");
   for (const { promise } of started) await promise;
   assert.equal(await residue(), before, "and none after it settled");
+});
+
+test("a cleanup that cannot remove the staged input says so, and does not fail the call",
+  { timeout: 30_000 }, async (t) => {
+  // The staged file is message content. When its removal fails there are two
+  // wrong answers and this takes neither: failing the call would trade a sync
+  // that completed for a cleanup detail the caller cannot act on, and staying
+  // silent would leave that content on disk with nobody told.
+  //
+  // Driven directly rather than through a driver call, because the state it
+  // needs -- a directory that refuses removal -- cannot be arranged from
+  // outside `runDriver` without reaching into the timing of its own staging,
+  // and a test that depends on that timing breaks on the next refactor for
+  // reasons unrelated to what it checks.
+  if (process.platform === "win32") {
+    t.skip("chmod is the mechanism here and Windows does not honour it that way");
+    return;
+  }
+  if (process.getuid?.() === 0) {
+    t.skip("root ignores the permissions this arranges, so the failure never happens");
+    return;
+  }
+  const parent = await mkdtemp(join(tmpdir(), "agmsg-sync-stuck-"));
+  const directory = join(parent, "agmsg-driver-input-stuck");
+  await mkdir(directory);
+  await writeFile(join(directory, "input.jsonl"), "{\"a\":1}\n");
+  // Not writable, so the file inside it cannot be unlinked and the recursive
+  // removal has to fail.
+  await chmod(directory, 0o500);
+  t.after(async () => {
+    await chmod(directory, 0o700).catch(() => {});
+  });
+
+  const warnings = [];
+  const collect = (warning) => warnings.push(warning);
+  process.on("warning", collect);
+  // Must not throw. That is half the contract and it is asserted by being here
+  // at all -- a throw fails this test on the line above the assertions.
+  discardInputDirectory(directory, "the driver call ended");
+  // emitWarning is delivered on the next tick.
+  await new Promise((resolve) => setImmediate(resolve));
+  process.off("warning", collect);
+
+  // The directory itself, because that is the one thing an operator needs in
+  // order to go and remove it. A warning that says "cleanup failed" and not
+  // where is a warning that cannot be acted on.
+  assert.ok(warnings.some((warning) => warning.message.includes(directory)),
+    `no warning named the directory left behind: ${warnings.map((w) => w.message)}`);
 });
 
 test("a driver that fails after starting a helper fails the call, and says how",

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, symlink, unlink,
   writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -2077,6 +2077,49 @@ exit 9
     (mock, config) => [() => rosterDriver("apply", config, input)]);
   for (const { promise } of broken) await assert.rejects(() => promise);
   assert.equal(await residue(), before, "a failed call left its input behind");
+
+  // The third route, and the one nothing else here reaches: the spawn itself
+  // fails. It is staged by then -- the input is written before the spawn, on
+  // purpose -- so this is the window where the descriptor and, on Windows, a
+  // named file of message content have no owner at all. A synchronous spawn
+  // failure never reaches 'error', so the settle path that cleans up after
+  // every other route is not on this one.
+  //
+  // Forced through the arguments rather than through the environment: a NUL in
+  // an argument is rejected by spawn() before it does anything, which is a
+  // synchronous throw and not an ENOENT the runner would answer later.
+  // Called directly, without the driver fixture: nothing is started, so there
+  // is no pid for that helper to wait on, and the driver script is never read
+  // because the spawn does not get that far.
+  // On this platform the directory count cannot see this route at all, and
+  // saying so is the point: the name is taken away at handover, so what a
+  // spawn failure strands here is the DESCRIPTOR, not a directory. Windows,
+  // where the file cannot be unlinked while open, is the other way round --
+  // there the directory assertion above is the one that catches it, which is
+  // why this test runs in the focused Windows leg too.
+  //
+  // So the descriptor is counted, and the route is run enough times that one
+  // leaked per call is unmistakable rather than lost in noise.
+  const descriptors = () => {
+    try { return readdirSync("/dev/fd").length; } catch { return null; }
+  };
+  const openBefore = descriptors();
+  for (let attempt = 0; attempt < 24; attempt += 1) {
+    await assert.rejects(() => rosterDriver("apply", {
+      local_team: "team\u0000name",
+      server_instance_id: "018f0000-0000-7000-8000-000000000001",
+      remote_team_id: "018f0000-0000-7000-8000-000000000002",
+      protocol_version: 1,
+    }, input));
+  }
+  assert.equal(await residue(), before, "a failed spawn left its input behind");
+  if (openBefore !== null) {
+    // Not exact equality: this process is doing other things, and a count that
+    // has to be identical would fail on something unrelated. Twenty-four leaked
+    // descriptors is not a margin, it is the defect.
+    assert.ok(descriptors() < openBefore + 12,
+      `a failed spawn leaked its descriptor: ${openBefore} -> ${descriptors()}`);
+  }
 });
 
 test("a driver that fails after starting a helper fails the call, and says how",

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2061,10 +2061,27 @@ echo $$ > ${JSON.stringify(helperFile)}
 cat > /dev/null
 printf '{"ok":true}\\n'
 `;
+  // Repeated, and counted on descriptors as well as directories, because the
+  // ORDINARY path is the one that matters most here: this runs every sync
+  // cycle for the life of the engine. On this platform the file is already
+  // unlinked by settle time, so a settle that forgot to release would leave no
+  // directory at all and leak one descriptor per cycle -- invisible to a
+  // directory count, and fatal over a long run.
+  const descriptors = () => {
+    try { return readdirSync("/dev/fd").length; } catch { return null; }
+  };
+  const openBefore = descriptors();
   const { started: fine } = await withDriverEnvironment(t, root, ok,
-    (mock, config) => [() => rosterDriver("apply", config, input)]);
+    (mock, config) => Array.from({ length: 24 },
+      () => () => rosterDriver("apply", config, input)));
   for (const { promise } of fine) await promise;
   assert.equal(await residue(), before, "a successful call left its input behind");
+  if (openBefore !== null) {
+    // A bound, not equality: this process has descriptors of its own. Twenty-
+    // four is not a margin.
+    assert.ok(descriptors() < openBefore + 12,
+      `successful calls leaked descriptors: ${openBefore} -> ${descriptors()}`);
+  }
 
   const bad = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-residue-"));
   const fails = (pidFile, helperFile) => `#!/usr/bin/env bash
@@ -2100,10 +2117,7 @@ exit 9
   //
   // So the descriptor is counted, and the route is run enough times that one
   // leaked per call is unmistakable rather than lost in noise.
-  const descriptors = () => {
-    try { return readdirSync("/dev/fd").length; } catch { return null; }
-  };
-  const openBefore = descriptors();
+  const spawnOpenBefore = descriptors();
   for (let attempt = 0; attempt < 24; attempt += 1) {
     await assert.rejects(() => rosterDriver("apply", {
       local_team: "team\u0000name",
@@ -2113,13 +2127,58 @@ exit 9
     }, input));
   }
   assert.equal(await residue(), before, "a failed spawn left its input behind");
-  if (openBefore !== null) {
+  if (spawnOpenBefore !== null) {
     // Not exact equality: this process is doing other things, and a count that
     // has to be identical would fail on something unrelated. Twenty-four leaked
     // descriptors is not a margin, it is the defect.
-    assert.ok(descriptors() < openBefore + 12,
-      `a failed spawn leaked its descriptor: ${openBefore} -> ${descriptors()}`);
+    assert.ok(descriptors() < spawnOpenBefore + 12,
+      `a failed spawn leaked its descriptor: ${spawnOpenBefore} -> ${descriptors()}`);
   }
+});
+
+test("the staged input has no name for as long as the driver is reading it",
+  { timeout: 30_000 }, async (t) => {
+  // The claim this binds is the security one, and until now nothing tested it:
+  // the file is unlinked as soon as its read-only descriptor is open, so for
+  // the whole life of the call there is a file being read that nothing can
+  // open by name -- which is what makes "a parent that dies leaves no message
+  // content behind" true rather than hopeful.
+  //
+  // Every other test here looks AFTER the call, and by then the settle path has
+  // cleaned up whether the handover unlinked or not. So this one looks WHILE
+  // the driver is alive and still reading, which is the only window where the
+  // two differ.
+  //
+  // POSIX only, and not skipped quietly on Windows for a bad reason: there a
+  // file cannot be unlinked while open, so the directory is SUPPOSED to survive
+  // until settle, and the residue test is what covers it.
+  if (process.platform === "win32") {
+    t.skip("Windows cannot unlink an open file; settle-time removal covers it there");
+    return;
+  }
+  const residue = async () => (await readdir(tmpdir()))
+    .filter((entry) => entry.startsWith("agmsg-driver-input-")).length;
+  const before = await residue();
+
+  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-unnamed-"));
+  // Writes its pid, then stays alive without having read its input yet -- the
+  // fixture helper returns once that pid is on disk, so the check below lands
+  // inside the call rather than after it.
+  const script = (pidFile, helperFile) => `#!/usr/bin/env bash
+echo $$ > ${JSON.stringify(pidFile)}
+echo $$ > ${JSON.stringify(helperFile)}
+sleep 2
+cat > /dev/null
+printf '{"ok":true}\\n'
+`;
+  const input = Array.from({ length: 2000 }, (_, index) => ({ type: "probe", index }));
+  const { started } = await withDriverEnvironment(t, root, script,
+    (mock, config) => [() => rosterDriver("apply", config, input)]);
+
+  assert.equal(await residue(), before,
+    "the staged input still had a name while the driver was reading it");
+  for (const { promise } of started) await promise;
+  assert.equal(await residue(), before, "and none after it settled");
 });
 
 test("a driver that fails after starting a helper fails the call, and says how",

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2221,14 +2221,23 @@ test("a cleanup that cannot remove the staged input says so, and does not fail t
     return;
   }
   const parent = await mkdtemp(join(tmpdir(), "agmsg-sync-stuck-"));
-  const directory = join(parent, "agmsg-driver-input-stuck");
+  // NOT named `agmsg-driver-input-*`. That prefix is what the residue test
+  // counts, and a fixture standing in the middle of another test's instrument
+  // is a fixture that can fail it -- or, worse, hide a real leak inside its own
+  // noise. What is under test here is the helper, which takes any path.
+  const directory = join(parent, "refuses-removal");
   await mkdir(directory);
-  await writeFile(join(directory, "input.jsonl"), "{\"a\":1}\n");
+  const staged = join(directory, "input.jsonl");
+  await writeFile(staged, "{\"a\":1}\n");
   // Not writable, so the file inside it cannot be unlinked and the recursive
   // removal has to fail.
   await chmod(directory, 0o500);
+  // And put it back afterwards, all of it. This test's whole subject is content
+  // left on disk when a removal fails; leaving that content on disk would be an
+  // odd way to make the point, and the run after this one inherits it.
   t.after(async () => {
     await chmod(directory, 0o700).catch(() => {});
+    await rm(parent, { recursive: true, force: true }).catch(() => {});
   });
 
   const warnings = [];

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1890,7 +1890,7 @@ async function driverLifecycleFixture(t, { script, calls, root }) {
   return { started, gone };
 }
 
-test("a driver that stops reading its input is left to release its own lock",
+test("the roster driver that stops reading its input is left to release its own lock",
   { timeout: 30_000 }, async (t) => {
   // This was a test about EPIPE. The parent wrote the input down a pipe, a
   // driver that had stopped reading took the write's error, and the call
@@ -1931,9 +1931,11 @@ exit 7
 `;
   const wide = "x".repeat(4096);
   const input = Array.from({ length: 512 }, (_, index) => ({ type: "probe", index, wide }));
+  // The ROSTER driver only. It is the one that holds the lock, and it is the
+  // only one handed a staged file; the storage driver keeps its pipe and is
+  // covered by the test below, with the expectations it always had.
   const { started, gone } = await withDriverEnvironment(t, root, script,
     (mock, config) => [
-      () => driver("prepare", config, input, ["1"]),
       () => rosterDriver("apply", config, input),
     ]);
 
@@ -1952,6 +1954,48 @@ exit 7
     // The property this test exists for.
     assert.ok(!existsSync(lockFor(join(root, `child-${index}.pid`))),
       "the driver was killed before its trap could release the lock");
+  }
+});
+
+test("the storage driver that stops reading its input fails the call and is not left running",
+  { timeout: 30_000 }, async (t) => {
+  // Unchanged behaviour, kept under its own test so that it stays unchanged.
+  //
+  // The storage driver takes no registry lock, so nothing about it needs the
+  // staged file the roster driver gets, and giving it one would cost it both an
+  // input that never touches disk -- after evaluatePull() these records are
+  // decrypted message content, on E2EE teams as much as plain ones -- and the
+  // bounded failure it has here. A driver handed a file is waited for; a driver
+  // that stops reading a pipe fails at once.
+  //
+  // So this is the original EPIPE test, scoped to the caller it was always
+  // about: the write loses its reader, the failure arrives on the stdin stream,
+  // and the driver does not survive the call. Flip `holdsRegistryLock` on for
+  // the storage driver and this test says so.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-epipe-"));
+  const script = (pidFile, helperFile) => `#!/usr/bin/env bash
+echo $$ > ${JSON.stringify(pidFile)}
+sleep 300 &
+echo $! > ${JSON.stringify(helperFile)}
+exec 0<&-
+exec sleep 300
+`;
+  const wide = "x".repeat(4096);
+  const input = Array.from({ length: 512 }, (_, index) => ({ type: "probe", index, wide }));
+  const { started, gone } = await withDriverEnvironment(t, root, script,
+    (mock, config) => [
+      () => driver("prepare", config, input, ["1"]),
+    ]);
+
+  for (const { promise, childPid } of started) {
+    // On the marker the stdin handler sets, not on the errno: macOS answers
+    // ENOTCONN or EPIPE from the same event, and the set of spellings is not
+    // closed. The set of places that set this marker is -- there is one.
+    await assert.rejects(() => promise,
+      (error) => error.driverFailurePhase === "stdin-write");
+    // No poll and no grace period. The call settles only after the driver has
+    // exited, so by this line it is already gone.
+    assert.ok(gone(childPid), "the failed driver was left running");
   }
 });
 
@@ -1990,6 +2034,49 @@ printf '{"lines":%d}\\n' "$lines"
     assert.equal(result[0]?.lines, RECORDS,
       "the driver did not receive every record that was sent");
   }
+});
+
+test("a staged input leaves nothing behind, whether the call succeeds or fails",
+  { timeout: 30_000 }, async (t) => {
+  // What is staged is message content, so the temp directory is not a tidiness
+  // matter. Two routes have to be checked and neither is the interesting one:
+  // it is the DULL paths that leak, because the failure path is the one people
+  // write cleanup for.
+  //
+  // Counted by name in the system temp directory rather than by watching the
+  // implementation, so a future change of mechanism is still measured. The
+  // baseline is taken first: this is a shared directory and something else may
+  // already have left one, and asserting zero would be asserting about the
+  // machine rather than about this call.
+  const residue = async () => (await readdir(tmpdir()))
+    .filter((entry) => entry.startsWith("agmsg-driver-input-")).length;
+  const before = await residue();
+
+  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-residue-"));
+  const input = Array.from({ length: 8 }, (_, index) => ({ type: "probe", index }));
+
+  const ok = (pidFile, helperFile) => `#!/usr/bin/env bash
+echo $$ > ${JSON.stringify(pidFile)}
+echo $$ > ${JSON.stringify(helperFile)}
+cat > /dev/null
+printf '{"ok":true}\\n'
+`;
+  const { started: fine } = await withDriverEnvironment(t, root, ok,
+    (mock, config) => [() => rosterDriver("apply", config, input)]);
+  for (const { promise } of fine) await promise;
+  assert.equal(await residue(), before, "a successful call left its input behind");
+
+  const bad = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-residue-"));
+  const fails = (pidFile, helperFile) => `#!/usr/bin/env bash
+echo $$ > ${JSON.stringify(pidFile)}
+echo $$ > ${JSON.stringify(helperFile)}
+echo "refused" >&2
+exit 9
+`;
+  const { started: broken } = await withDriverEnvironment(t, bad, fails,
+    (mock, config) => [() => rosterDriver("apply", config, input)]);
+  for (const { promise } of broken) await assert.rejects(() => promise);
+  assert.equal(await residue(), before, "a failed call left its input behind");
 });
 
 test("a driver that fails after starting a helper fails the call, and says how",

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2226,8 +2226,14 @@ test("a cleanup that cannot remove the staged input says so, and does not fail t
   // the half-built cases -- the ones a failure actually produces -- are the
   // ones that leak.
   t.after(async () => {
+    // The chmod is best effort on purpose: it runs before the directory below
+    // necessarily exists, and its only job is to make the removal possible.
     await chmod(join(parent, "refuses-removal"), 0o700).catch(() => {});
-    await rm(parent, { recursive: true, force: true }).catch(() => {});
+    // The removal is NOT. `force: true` already treats a path that is not there
+    // as success, so a catch here could only ever hide a real failure -- and
+    // what it would hide is this fixture's content staying on disk while the
+    // test reports green, which is the exact shape this test is about.
+    await rm(parent, { recursive: true, force: true });
   });
   // NOT named `agmsg-driver-input-*`. That prefix is what the residue test
   // counts, and a fixture standing in the middle of another test's instrument

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2221,6 +2221,14 @@ test("a cleanup that cannot remove the staged input says so, and does not fail t
     return;
   }
   const parent = await mkdtemp(join(tmpdir(), "agmsg-sync-stuck-"));
+  // Registered against the parent the moment it exists, before anything below
+  // can throw. Hooking cleanup up only once the fixture is fully built means
+  // the half-built cases -- the ones a failure actually produces -- are the
+  // ones that leak.
+  t.after(async () => {
+    await chmod(join(parent, "refuses-removal"), 0o700).catch(() => {});
+    await rm(parent, { recursive: true, force: true }).catch(() => {});
+  });
   // NOT named `agmsg-driver-input-*`. That prefix is what the residue test
   // counts, and a fixture standing in the middle of another test's instrument
   // is a fixture that can fail it -- or, worse, hide a real leak inside its own
@@ -2232,23 +2240,28 @@ test("a cleanup that cannot remove the staged input says so, and does not fail t
   // Not writable, so the file inside it cannot be unlinked and the recursive
   // removal has to fail.
   await chmod(directory, 0o500);
-  // And put it back afterwards, all of it. This test's whole subject is content
-  // left on disk when a removal fails; leaving that content on disk would be an
-  // odd way to make the point, and the run after this one inherits it.
-  t.after(async () => {
-    await chmod(directory, 0o700).catch(() => {});
-    await rm(parent, { recursive: true, force: true }).catch(() => {});
-  });
+  // Everything comes back afterwards -- see the hook above, registered before
+  // this could throw. This test's whole subject is content left on disk when a
+  // removal fails; leaving that content on disk would be an odd way to make
+  // the point, and the run after this one inherits it.
 
   const warnings = [];
   const collect = (warning) => warnings.push(warning);
   process.on("warning", collect);
-  // Must not throw. That is half the contract and it is asserted by being here
-  // at all -- a throw fails this test on the line above the assertions.
-  discardInputDirectory(directory, "the driver call ended");
-  // emitWarning is delivered on the next tick.
-  await new Promise((resolve) => setImmediate(resolve));
-  process.off("warning", collect);
+  try {
+    // Must not throw. That is half the contract, and it is asserted by this
+    // call standing here: a throw propagates out of the finally and fails the
+    // test before it can reach the assertion below.
+    discardInputDirectory(directory, "the driver call ended");
+    // emitWarning is delivered on the next tick.
+    await new Promise((resolve) => setImmediate(resolve));
+  } finally {
+    // In a finally, not on the straight line. A regression that makes the
+    // helper throw would otherwise leave this listener attached for the rest
+    // of the file -- so the first failure would be followed by a second,
+    // unrelated one, in whichever test happens to warn next.
+    process.off("warning", collect);
+  }
 
   // The directory itself, because that is the one thing an operator needs in
   // order to go and remove it. A warning that says "cleanup failed" and not

--- a/tests/test_remote_sync_driver_input.bats
+++ b/tests/test_remote_sync_driver_input.bats
@@ -19,6 +19,13 @@
   run node --test \
     --test-name-pattern 'whole input, from the start|leaves nothing behind' \
     "$BATS_TEST_DIRNAME/remote_sync_engine.test.mjs"
+  # The whole captured output on failure, to fd 3, because bats truncates its
+  # own "Last output" and the first failure of this leg was unreadable for
+  # exactly that reason -- a Windows-only failure with its assertion cut off is
+  # a leg that tells you it broke and not what broke.
+  if [ "$status" -ne 0 ]; then
+    printf '%s\n' "$output" >&3
+  fi
   [ "$status" -eq 0 ]
   # A pattern that selects nothing exits 0 with nothing run, which is precisely
   # the shape of a leg that looks green because it never happened. So the count

--- a/tests/test_remote_sync_driver_input.bats
+++ b/tests/test_remote_sync_driver_input.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+# The staged-input path, run where it actually matters (#817).
+#
+# The change these cover exists FOR Windows: the roster driver is handed its
+# input as an open file descriptor instead of a pipe, so that nothing is ever in
+# a position to SIGKILL a driver that holds the registry lock. Two of the things
+# it rests on behave differently on Windows than anywhere else -- Node hands an
+# ordinary descriptor to Git Bash as stdin, and Windows cannot unlink a file
+# that is still open, so the temp directory is removed on a different route.
+#
+# `tests/test_remote_sync_engine.bats` runs on ubuntu and macos only. Without
+# this file the Windows half of a Windows fix would be argued rather than run.
+#
+# The name carries `driver-input` because the Windows matrix leg selects by
+# `bats --filter`.
+
+@test "driver-input: the staged input arrives whole and leaves nothing behind" {
+  run node --test \
+    --test-name-pattern 'whole input, from the start|leaves nothing behind' \
+    "$BATS_TEST_DIRNAME/remote_sync_engine.test.mjs"
+  [ "$status" -eq 0 ]
+  # A pattern that selects nothing exits 0 with nothing run, which is precisely
+  # the shape of a leg that looks green because it never happened. So the count
+  # is asserted, not just the status: two tests, both of them passing.
+  echo "$output" | grep -qE '(^|[^0-9])tests 2([^0-9]|$)'
+  echo "$output" | grep -qE '(^|[^0-9])pass 2([^0-9]|$)'
+  echo "$output" | grep -qE '(^|[^0-9])fail 0([^0-9]|$)'
+}

--- a/tests/test_remote_sync_driver_input.bats
+++ b/tests/test_remote_sync_driver_input.bats
@@ -22,8 +22,14 @@
   [ "$status" -eq 0 ]
   # A pattern that selects nothing exits 0 with nothing run, which is precisely
   # the shape of a leg that looks green because it never happened. So the count
-  # is asserted, not just the status: two tests, both of them passing.
-  echo "$output" | grep -qE '(^|[^0-9])tests 2([^0-9]|$)'
+  # is asserted, not just the status.
+  #
+  # On `pass` and `fail`, deliberately not on `tests`. How the runner totals
+  # `tests` under a name filter is a version-dependent detail -- whether the
+  # unselected ones are excluded or counted as skipped -- and pinning it would
+  # make this leg fail on a Node upgrade for a reason that has nothing to do
+  # with the code. `pass 2` carries the whole guard on its own: nothing selected
+  # means nothing passed.
   echo "$output" | grep -qE '(^|[^0-9])pass 2([^0-9]|$)'
   echo "$output" | grep -qE '(^|[^0-9])fail 0([^0-9]|$)'
 }


### PR DESCRIPTION
Declared reviewers: 1

Head this body was written at: `30f16b2`

## What this changes

`runDriver()` wrote the driver's input down a pipe. That was the one failure
route that reached a **live** driver: a write whose reader has gone raises on
the stdin stream, arrives at `fail()`, and `fail()` answered with `SIGKILL`.

`roster-sync-driver.sh` takes that team's registry lock as its first act —
`agmsg_lock_acquire` runs before it starts `node` — and holds it for the whole
call. Every release route it has is a trap. **`SIGKILL` runs no trap**, so the
fast failure was bought by leaving `.config.lock` behind with no owner, and
every later run for that team then waits on a directory nobody is going to
remove.

So **that one caller** now has its input staged in a file before the spawn —
therefore before the lock exists — and that file's descriptor is handed over as
the child's stdin. The child reads its stdin exactly as before, so **no driver
changes**.

**Only that caller.** `rosterDriver()` passes `holdsRegistryLock`; nothing else
does. The storage driver takes no registry lock, so it keeps the pipe, the
`stdin-write` marker and the live-child cleanup unchanged — giving it the file
would put its input, which after `evaluatePull()` is decrypted message content
on E2EE teams as much as plain ones, at rest on disk, and would cost it the
bounded failure it has today for no reason. The `SIGKILL` backstop is unchanged
and still reachable on the pipe path; what changed is only that the driver
holding the lock can no longer be the one it reaches.

## What this does NOT claim

It does not fix the field report, and the evidence for that got stronger while
this PR was in review rather than weaker. The reporting machine was measured
live and **the lock was held by `sync start` itself** — holder file present,
its pid alive in `ps`. That is the measurement. The mechanism behind it is
still being narrowed and is disputed between the people looking at it, so no
mechanism is named here: naming a contested one would put a second wrong
sentence exactly where the first one was.

What that measurement does settle is the negative. The `stdin-write → SIGKILL`
ordering was never observed in the field, and the holder the field actually has
is a live process rather than an abandoned lock. So read this as what it is: a
defect in the code, and its removal. Bounding a driver that **hangs** is
separate work and is not done here either.

## Measurements

Same probe, driving the real `driver()` through `AGMSG_SYNC_DRIVER`, against a
fixture that takes a lock directory with an EXIT trap and then stops reading
its input while still holding it:

| variant | outcome | lock |
|---|---|---|
| before | rejects in 21ms | **left behind** |
| after | rejects in 10055ms, when the driver ends | released |

The trap/signal behaviour on its own, one script, EXIT+TERM trap:

| signal | lock |
|---|---|
| SIGTERM | released |
| SIGKILL | **left behind** |

**A SIGTERM-then-escalate version of this change was written first and measured
not to work**: it left the lock behind exactly as before and only took the
grace period to do it (2023ms vs 22ms). Bash defers a trap while it waits on a
foreground child, so a driver sitting in `node` does not release until that
child ends; the signal reaches only `bash`. Signalling the process **group**
does release it — but on Windows Node's `kill()` ignores the signal and
terminates forcefully whatever it is asked for, so no signal substitution is
portable, and the reported failure is a Windows one. That is why the kill is
removed rather than softened.

Input delivery, sent vs. what the driver counted on stdin — with the pipe as
the control, so the number is known to be read from something real:

| variant | sent | received |
|---|---|---|
| pipe (control) | 20000 | 20000 |
| staged file fd | 20000 | 20000 |

**Platform boundary, stated rather than glossed:** every row above was measured
on macOS. "Windows `kill()` ignores the signal" is Node's documented behaviour,
not something measured here.

## Mutations

Run on this head, one file reverted at a time, each restored and the restore
verified by reading the line back before the next:

| mutation | result |
|---|---|
| `holdsRegistryLock` removed from `rosterDriver()` — the roster driver goes back to the pipe | the roster lock test **fails** |
| `openSync(path, "r")` → `openSync(path, "a")`, the descriptor at EOF | the delivery test **fails** |
| `holdsRegistryLock: true` added to the **storage** caller | the storage test **fails** — as a 30s timeout rather than an assertion, because its fixture outlives the run by design |
| the focused leg's name pattern changed to one that selects nothing | the Windows leg **fails** on its count assertion |
| `releaseInput()` removed from the spawn catch | the residue test **fails** on its descriptor count — 13 → 37, one per call |
| `releaseInput()` removed from `settle()` | the residue test **fails** on its descriptor count over the ordinary path — 13 → 37, one per cycle |
| the warning removed from `discardInputDirectory` | the refused-cleanup test **fails** with no warnings collected |
| the unlink at handover removed | the name-lifetime test **fails**: the directory is still there while the driver reads |

The first two are the same properties a reviewer independently mutated on the
previous head; these rows are re-run here because that head is superseded and
the scoping changed underneath them.

## The cleanup routes a test could not reach, removed rather than disclosed

An earlier revision of this description named two guarantees no mutation
reddened — the cleanup when staging fails, and the warning when a removal
fails — on the principle that a boundary should be stated rather than left for
a reader to find. Reviewers pushed back, correctly: disclosing an unheld
guarantee does not make it safe.

The answer was not another test. It was that the second route should not exist.
Staging used to clean up after itself, and the call cleaned up again at settle
— one job in two places, and only one of them reachable. `stageInput` now fills
a record in place and undoes nothing; whatever part of it exists is undone by
the single `releaseInput` the call owns, and a staging failure and a
synchronous spawn failure arrive at the same catch. **The route a test can
reach and the route it cannot are now the same lines.**

The warning's reachability is stated where it lives instead of in general.
`discardInputDirectory` runs only when the directory is still present at
release, and it is taken away at staging anywhere a file can be unlinked while
open — so here it covers a temp directory that refused removal, and on Windows
it is the ordinary path. "It warns rather than staying silent" read as a claim
about every platform, and it was not one.

And it is now controlled rather than described. `discardInputDirectory` is
exported and driven directly against a directory made unwritable, so the file
inside cannot be unlinked and the removal has to fail. Both halves are
asserted: that it does not throw, by the call standing in the test body; and
that it is not silent, on the warning containing the **directory**, since a
warning that says cleanup failed without saying where cannot be acted on.
Driving it through a driver call instead would need the test to know
`runDriver`'s internal staging timing, which is a test that breaks on the next
refactor for reasons unrelated to what it checks.

Its fixture does not stand in another test's instrument. It first named its
directory `agmsg-driver-input-stuck` — the prefix the residue test counts — and
never removed it, which can fail that test outright and, worse, can hide a real
leak inside its own noise. It is `refuses-removal` under its own parent now,
and the parent goes away afterwards. Measured from a clean temp directory after
a full run: nothing of either prefix left behind. Its own housekeeping is on the
path a failure takes, not the straight line: the warning listener comes off in
a `finally`, and the directory cleanup is registered the moment the parent
exists rather than once the fixture is fully built. Measured by making the
helper rethrow instead of warning — 93 pass, 1 fail, nothing downstream of it. The final removal does not swallow its own failure either: `force: true`
already treats an absent path as success, so a catch there could only hide a
real one — controlled by removing the chmod restore, which turns the test red.

`tests/remote_sync_engine.test.mjs`: 94 pass, 0 fail.

## The claim that no live child with a lock is killed, derived rather than listed

The argument rests on "every route into `fail()` that can reach a live child is
one the lock-holding driver is not on". That is a claim about a **set**, so the
set is derived from the file rather than recalled:

```
$ S=$(grep -n '^function runDriver' scripts/internal/remote-sync.mjs | cut -d: -f1)
$ E=$(awk -v s="$S" 'NR>s && /^}/{print NR; exit}' scripts/internal/remote-sync.mjs)
$ awk -v s="$S" -v e="$E" 'NR>=s&&NR<=e' scripts/internal/remote-sync.mjs | grep -n '\bfail\b'
```

Four entries besides the definition: `child.on("error", fail)`, the
`child.stdin?.on("error", …)` handler, and two inside the `'exit'` handler.

- The two in `'exit'` run after the child has exited, so `running` is false.
- `'error'` is raised when the process could not be spawned, could not be
  killed, or could not be sent a message. The second needs a `kill` that only
  `fail()` issues and `settled` blocks the re-entry; the third needs an IPC
  channel this spawn does not have.
- The **stdin handler is the one that reaches a live child** — and it is
  attached with `child.stdin?.`, which is null exactly when the input was
  staged. So the lock-holding driver is not on it.

## Temp lifecycle

The staged file is message content, so its removal is not a tidiness matter.

- `mkdtemp` gives 0700, the file is 0600, and the name is taken away as soon as
  the read-only descriptor is open — the spawn duplicates that descriptor, so
  both sides read a file nothing can open by name and a parent that dies leaves
  nothing behind. Windows cannot unlink an open file, so there the directory
  survives until the call settles and is removed there.
- A failure between writing the file and opening it removes the directory
  rather than leaving content under a name nothing else knows.
- `spawn()` is inside the try: a synchronous spawn failure never reaches
  `'error'`, and would otherwise strand the descriptor and the named file.
- A removal that fails at settle is **not** swallowed. It does not fail the
  call — refusing a sync that completed, over a file the caller cannot act on,
  trades a real result for a cleanup detail — but it emits a warning naming the
  directory.

## Tests

- The EPIPE test is **split, not deleted**. The storage half keeps it verbatim
  with the expectations it always had; the roster half takes a lock the way the
  driver does and asserts it is released. Splitting them is the point: one test
  covering both callers would pin the wider scope as correct.
- A delivery test counts what the driver actually received. A descriptor left
  at EOF, or a file still being written when the child starts reading, delivers
  an empty input and reports a perfectly successful sync of nothing.
- A residue test asserts nothing survives a successful call, a failing one, or
  a **failed spawn**, counted by name in the system temp directory so a change
  of mechanism is still measured, and against a baseline rather than zero
  because that directory is shared.
- The spawn-failure route needs **two** controls, and the reason is worth
  stating: here the staged file is unlinked at handover, so a failed spawn
  strands the *descriptor* and not a directory, and a directory count cannot
  see it. On Windows the file cannot be unlinked while open, so there the
  directory count is the one that catches it. Neither covers both, so the route
  asserts on both — and this test is in the focused Windows leg, where the half
  that is blind here is the half that sees.

- A name-lifetime test looks **during** the call, while the driver is alive and
  still reading. Every other test looks after it, by which time the settle path
  has cleaned up whether the handover unlinked or not — so "a parent that dies
  leaves no message content behind" was prose until this. POSIX only, and
  skipped on Windows for the stated reason that a file cannot be unlinked there
  while open, which is what the residue assertions cover instead.



## Windows is now run, not argued

`tests/test_remote_sync_engine.bats` is ubuntu and macos only, so a fix whose
whole reason is Windows had no Windows evidence. `tests/test_remote_sync_driver_input.bats`
selects the two tests that would notice — delivery and residue — and a new
`bats (windows-latest, driver input (#817))` leg runs them there.

It asserts the **count** it reached, not just the exit status: a name pattern
that selects nothing exits 0 with nothing run, which is the shape of a leg that
looks green because it never happened. Controlled — pointing the pattern at a
name that does not exist turns the leg red.

Its first run was red **without reaching one of its tests**: the job installs
sqlite3 from a third-party package feed, the feed could not serve it, and the
step before the tests failed the job. These two drive a mock bash driver and
never open a store, so the matrix now says which legs need sqlite3 and this one
does not get the step. A leg that fails for something it does not use reports
on that thing, not on the code. If they ever do need a store they will fail on
a missing binary, which says so plainly.

**It is green on Windows, and it ran.** `ok 1` in the job log, and the bats test
asserts `pass 2` / `fail 0` inside it, so both node tests executed on
windows-latest rather than being selected away.

It took two goes to get there, and the first red is worth keeping in the record
because it is the reason this leg exists. It went red on the residue test — and
could not say why, because bats truncates its own "Last output". A Windows-only
failure with its assertion cut off is a check that reports it broke and not
what broke, so the leg now prints the whole captured output on failure. The
cause was the descriptor control running its 24 calls through the pid fixture,
which waits for every driver to record a pid: 24 concurrent bash spawns on that
runner is a fixture timeout, so the test was sensitive to the runner's speed
rather than to a leak. Sequential and fixture-free now.

Three other legs are red on this head and none of them is this PR's. They are
red for **three different reasons**, which took two corrections to get right —
an earlier version of this paragraph said all of them were the same, and it was
mine.

**`bats (windows-latest, install helpers)` — a dependency that did not install.**
Its suite ran: 4 bats result lines, all `not ok`, failing on a missing
`sqlite3`. The chocolatey step reports success even when the package does not
install, so the job carried on. Measured in this head's log:
`Response status code does not indicate success: 504 (Gateway Timeout)`. Other
codes have been reported on other runs; they are not repeated here because they
were not measured here. This diff writes neither `install.sh` nor any test that
leg runs, and the log shows the `choco install` attempt, so the `matrix.sqlite`
condition added here is not what starved it.

**`bats (windows-latest, windows runtime (#567))` — not that at all.** sqlite3
installed fine in that job (`ShimGen has successfully created a shim for
sqlite3.exe`), and there is no chocolatey failure in its log. One of its two
tests failed, and it failed in **teardown**:
`rm: cannot remove '/tmp/tmp.…': Directory not empty`. Two heads of this branch
that contain this change — `84967e3` and `e5a5d1f` — pass this leg, so the
change is not sufficient to produce it, and the only match for "driver" in
`test_codex_monitor.bats` is an unrelated path
(`drivers/types/codex/codex-monitor.sh`).

**`bats (ubuntu-latest 3/4)` — `test_actas_integration.bats`.** A role-handover
test built on `sleep 4` and a 1s poll. This diff writes nothing it names, and
the shard it runs in is composed identically with and without this change:
adding a bats file could have moved it, so that was measured rather than
assumed — `test_actas_integration.bats` is in shard 3 either way, and shard 3's
file list diffs empty against the destination.

None of these three is offered as a same-mode non-inclusion control for the
others. They break in different places, and saying otherwise is what the two
corrections above were about.

CI on this head: 18 success, 4 non-success. Named rather than counted, because
a count hides which ones: `bats (windows-latest, install helpers)`,
`bats (windows-latest, windows runtime (#567))`, `bats (ubuntu-latest 3/4)`,
and the `bats` rollup that reports whichever shard failed. The first three are
the ones described immediately above; the rollup carries no failure of its own. All four macOS shards and both jsonl storage-contract
legs are green, so this change is measured on macOS as well as on Windows.

Refs #817
