### PR TITLE
fix(roster): bound the wait on the local child without spawning anything to do it (#821)

### DIFF
--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -29,7 +29,7 @@ agmsg_roster_ensure "$team_dir" "$config"
 
 node_bin="${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
 
-# THE CRITICAL SECTION IS BOUNDED IN TIME, NOT ONLY IN SCOPE (#817).
+# THE CRITICAL SECTION IS BOUNDED IN TIME, NOT ONLY IN SCOPE (#821).
 #
 # The scope is right and stays: `roster-sync.mjs` is the read-modify-write of
 # the journal and state this lock exists to serialise. It does no network —
@@ -48,8 +48,25 @@ node_bin="${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
 # So the wait has a ceiling, and passing it is a failure with a name rather
 # than a hang. The traps stay as the backup they always were.
 ROSTER_SYNC_BUDGET_S="${AGMSG_ROSTER_SYNC_TIMEOUT_S:-120}"
+# A BOUND THAT CANNOT BE READ IS NOT A BOUND. `read -t` rejects a zero, a
+# negative or a non-numeric budget by failing immediately, and its failure is
+# indistinguishable here from "the writer is gone" — so a mistyped setting
+# would turn the ceiling off and leave the wait unbounded, silently, which is
+# the defect this file is closing (raised in review). Checked before anything
+# is started, and refused by name.
+case "$ROSTER_SYNC_BUDGET_S" in
+  ''|*[!0-9]*)
+    agmsg_lock_release
+    echo "agmsg: roster sync $operation failed for team '$team': AGMSG_ROSTER_SYNC_TIMEOUT_S must be a positive whole number of seconds, got '${AGMSG_ROSTER_SYNC_TIMEOUT_S:-}'" >&2
+    exit 15 ;;
+esac
+if [ "$ROSTER_SYNC_BUDGET_S" -le 0 ]; then
+  agmsg_lock_release
+  echo "agmsg: roster sync $operation failed for team '$team': AGMSG_ROSTER_SYNC_TIMEOUT_S must be greater than zero, got '$ROSTER_SYNC_BUDGET_S'" >&2
+  exit 15
+fi
 
-# THE BOUND COSTS NO EXTRA PROCESS, and on this machine that is the point.
+# THE BOUND ADDS NO PROCESS THAT OUTLIVES THE CALL (#821).
 #
 # The first version put a watchdog beside the child: one more process per
 # roster operation. The leading explanation for the field failure is process
@@ -61,7 +78,16 @@ ROSTER_SYNC_BUDGET_S="${AGMSG_ROSTER_SYNC_TIMEOUT_S:-120}"
 # one end of a FIFO it never writes to; when it exits, that end closes and the
 # read here returns end-of-file. `read -t` distinguishes the two outcomes by
 # status: >128 means the budget expired, and anything else means the writer is
-# gone. One process runs — node — exactly as before this change.
+# gone.
+#
+# What this does NOT claim is "no extra process at all": `mktemp`, `mkfifo` and
+# `rm` are external commands and each is a spawn (raised in review; an earlier
+# version of this comment said "one process runs, exactly as before", which is
+# false). They are short-lived and sequential, where a watchdog is concurrent
+# and lives as long as the operation — and on a machine that is refusing
+# spawns, a process held open beside every roster call is the shape that
+# matters. Each of the three is checked: a failure to make the temp path or the
+# FIFO falls back to the unbounded path and says so on stderr.
 # A path to make the FIFO at, and nothing written to it: the child never sends
 # anything, and what this waits for is the moment its end closes.
 _roster_fifo="$(mktemp -u 2>/dev/null)" || _roster_fifo=""
@@ -77,8 +103,15 @@ if [ "$_roster_bounded" = "1" ]; then
   # fd 0. Measured, as every operation failing with "input is invalid".
   exec 9<&0
   "$node_bin" "$SCRIPT_DIR/roster-sync.mjs" "$operation" "$config" \
-    "$server" "$remote" "$protocol" "$@" <&9 3>&- 4>&- 8> "$_roster_fifo" &
+    "$server" "$remote" "$protocol" "$@" <&9 9<&- 3>&- 4>&- 8> "$_roster_fifo" &
   _roster_child=$!
+  # BOTH COPIES GO. `<&9` duplicates the caller's stdin onto fd 0 and leaves
+  # fd 9 open beside it, so node would hold that stream twice and this shell
+  # would hold it until its own exit — the same "a child keeps the caller's
+  # streams" class fixed twice tonight, reintroduced by the descriptor used to
+  # fix it (raised in review). The child closes its saved copy in the
+  # redirection above; this closes ours the moment it is no longer needed.
+  exec 9<&-
   exec 8< "$_roster_fifo"
   rm -f "$_roster_fifo"
 

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -105,16 +105,44 @@ _roster_inner_state() {
     printf 'unknown\n'
     return
   fi
+  # "UNUSABLE" AND "DEAD" ARE NOT THE SAME ANSWER (raised in review).
+  #
+  # `_agmsg_pid_alive_local` starts by rejecting a pid outside the POSIX
+  # ceiling and returns 1 for it — the same 1 it returns for "no such
+  # process". A digits-only value can be unusable: `2147483648` passes the
+  # crude filter at the call site and is refused here, and reading that
+  # refusal as `gone` releases the lock on a question that could not be asked.
+  # So the validator is consulted FIRST, and its refusal is `unknown`.
+  if ! _agmsg_pid_valid "$_roster_inner" 2147483647; then
+    printf 'unknown\n'
+    return
+  fi
   if ! _agmsg_pid_alive_local "$_roster_inner"; then
     printf 'gone\n'
     return
   fi
   local cmd
   cmd="$(compat_get_cmdline "$_roster_inner" 2>/dev/null || true)"
-  case "$cmd" in
-    *"$SCRIPT_DIR/roster-sync.mjs $operation $config"*) printf 'ours\n' ;;
-    *) printf 'unknown\n' ;;
-  esac
+  # PLATFORM-AWARE, because a raw `case` compares two different alphabets.
+  #
+  # Under Git Bash the shell's path is `/c/Users/...` while a native process
+  # reports `C:/Users/...`, so a raw match answers "not ours" about a process
+  # that IS ours — silently, because a non-match is the ordinary answer.
+  # `agmsg_cmdline_names_path` exists for exactly this and takes the `cygpath
+  # -m` second look; `_remote_sync_engine_status` already uses it. Reaching for
+  # a bare `case` here would have made Windows keep the lock on every timeout,
+  # on its own healthy child (raised in review).
+  #
+  # BOTH paths, and the operation between them, because either alone is too
+  # loose: the script path is shared by every team, and a config path with a
+  # different operation is a different run.
+  if agmsg_cmdline_names_path "$cmd" "$SCRIPT_DIR/roster-sync.mjs" \
+    && agmsg_cmdline_names_path "$cmd" "$config"; then
+    case "$cmd" in
+      *" $operation "*) printf 'ours\n'; return ;;
+    esac
+  fi
+  printf 'unknown\n'
 }
 
 # Signalling has exactly one safe answer, so it gets its own name rather than

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -157,13 +157,24 @@ _roster_inner_state() {
     script_win="$(cygpath -m "$script_sh" 2>/dev/null || true)"
     config_win="$(cygpath -m "$config" 2>/dev/null || true)"
   fi
+  # AND THE NEEDLE NEEDS ARGV BOUNDARIES (raised in review). An ordered
+  # substring is still a substring: with the config `/teams/demo/config.json`,
+  # the pattern matched a command line whose config was
+  # `/teams/demo/config.json.bak` — and, on the other side, a script at
+  # `/x/opt/agmsg/.../roster-sync.mjs` contains our absolute path as a tail.
+  # Both are different runs reading as ours.
+  #
+  # Padding the haystack with one space at each end lets a single pattern
+  # require a boundary on both sides without a separate end-of-string case:
+  # an argument at either extreme now has the space the pattern asks for.
+  local padded=" $cmd "
   local s c
   for s in "$script_sh" "$script_win"; do
     [ -n "$s" ] || continue
     for c in "$config" "$config_win"; do
       [ -n "$c" ] || continue
-      case "$cmd" in
-        *"$s $operation $c"*) printf 'ours\n'; return ;;
+      case "$padded" in
+        *" $s $operation $c "*) printf 'ours\n'; return ;;
       esac
     done
   done

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -133,15 +133,40 @@ _roster_inner_state() {
   # a bare `case` here would have made Windows keep the lock on every timeout,
   # on its own healthy child (raised in review).
   #
-  # BOTH paths, and the operation between them, because either alone is too
-  # loose: the script path is shared by every team, and a config path with a
-  # different operation is a different run.
-  if agmsg_cmdline_names_path "$cmd" "$SCRIPT_DIR/roster-sync.mjs" \
-    && agmsg_cmdline_names_path "$cmd" "$config"; then
-    case "$cmd" in
-      *" $operation "*) printf 'ours\n'; return ;;
-    esac
+  # THE ORDERED TRIPLE, NOT THREE INDEPENDENT SIGHTINGS (raised in review).
+  #
+  # Asking "does the cmdline contain the script path" AND "does it contain
+  # this config" AND "does it contain this operation somewhere" is three
+  # questions, and three questions do not add up to "this operation, on this
+  # config". A command line carrying a different operation and a different
+  # config can satisfy all three at once — the operation from one place, the
+  # config from another. Two existence checks are not a relation.
+  #
+  # So the needle is the sequence the driver actually spawns:
+  #     <script> <operation> <config>
+  # and it has to appear as one run of text.
+  #
+  # BOTH ALPHABETS, because the shell's `/c/Users/...` and a native process's
+  # `C:/Users/...` are the same path written differently. `cygpath -m` is the
+  # conversion `agmsg_cmdline_names_path` uses for exactly this; it is called
+  # here rather than that function because the needle must be composed from
+  # converted PARTS — handing a whole sentence to a path converter would not
+  # do what it says.
+  local script_sh="$SCRIPT_DIR/roster-sync.mjs" script_win="" config_win=""
+  if command -v cygpath >/dev/null 2>&1; then
+    script_win="$(cygpath -m "$script_sh" 2>/dev/null || true)"
+    config_win="$(cygpath -m "$config" 2>/dev/null || true)"
   fi
+  local s c
+  for s in "$script_sh" "$script_win"; do
+    [ -n "$s" ] || continue
+    for c in "$config" "$config_win"; do
+      [ -n "$c" ] || continue
+      case "$cmd" in
+        *"$s $operation $c"*) printf 'ours\n'; return ;;
+      esac
+    done
+  done
   printf 'unknown\n'
 }
 

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -12,6 +12,10 @@ source "$SKILL_DIR/scripts/lib/roster-journal.sh"
 # that file exists to give -- and a repo-wide check refuses one, correctly.
 # shellcheck disable=SC1091
 source "$SKILL_DIR/scripts/lib/instance-id.sh"
+# For `compat_get_cmdline`, which is how `scripts/remote.sh` already answers
+# "is this pid still the process I started?" on every platform this ships to.
+# shellcheck disable=SC1091
+source "$SKILL_DIR/scripts/lib/compat.sh"
 
 operation="${1:?Missing operation}"; team="${2:?Missing team}"
 server="${3:?Missing server id}"; remote="${4:?Missing remote team id}"
@@ -59,6 +63,34 @@ trap 'agmsg_lock_release; exit 129' HUP
 agmsg_roster_ensure "$team_dir" "$config"
 
 node_bin="${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
+
+# "Is the recorded pid still the process this operation started?" — asked in
+# ONE place, so the signalling path and the release decision cannot come to
+# different answers. Two questions with one wording is how a gate ends up
+# guarding something narrower than the thing it authorises.
+#
+# A NUMBER IN A FILE IS NOT AN IDENTITY (raised as BLOCKING, and the answer
+# was already in this repo). A pid is recycled the moment its process is
+# reaped, so between the wrapper writing that number and the timeout path
+# reading it, it can belong to something else entirely.
+# `_remote_sync_engine_status` in `scripts/remote.sh` had already been here:
+# "A live PID is not enough: PID reuse can make an unrelated process pass
+# kill -0, so running requires the exact engine script/team suffix in argv."
+#
+# Both halves are required. Liveness alone reads a recycled number as our
+# child; argv alone would accept a match on a pid that is already gone. The
+# suffix is specific rather than convenient: `$config` is per-team, so a
+# roster sync for a DIFFERENT team cannot satisfy it.
+_roster_inner_still_ours() {
+  [ -n "${_roster_inner:-}" ] || return 1
+  _agmsg_pid_alive_local "$_roster_inner" || return 1
+  local cmd
+  cmd="$(compat_get_cmdline "$_roster_inner" 2>/dev/null || true)"
+  case "$cmd" in
+    *"$SCRIPT_DIR/roster-sync.mjs $operation $config"*) return 0 ;;
+  esac
+  return 1
+}
 
 # THE CRITICAL SECTION IS BOUNDED IN TIME, NOT ONLY IN SCOPE (#821).
 #
@@ -323,21 +355,53 @@ if [ "$_roster_wait" != "none" ]; then
     # that was writing under it may still be running, because letting the next
     # caller in beside a live writer is worse than the leak being fixed.
     _roster_inner="$(cat "$_roster_pidfile" 2>/dev/null || true)"
-    if [ -n "$_roster_inner" ]; then
+    # A leading zero, a negative, a word, or an empty file all mean the same
+    # thing here: there is no pid to work with. Cleared once, so the predicate
+    # refuses it in one place rather than every caller guessing.
+    case "$_roster_inner" in
+      ''|*[!0-9]*|0*) _roster_inner="" ;;
+    esac
+    # Signalled ONLY when it is still the process we started. Anything else is
+    # left alone: the cost of not signalling our own child is a lock we keep
+    # and report; the cost of signalling someone else's is a process we had no
+    # business touching.
+    if _roster_inner_still_ours; then
       kill -TERM "$_roster_inner" 2>/dev/null || true
     fi
+    # The wrapper needs no such check — it is this shell's own child, held in
+    # `$!` and not reaped until below, so its number cannot have been recycled
+    # while we still hold it.
     kill -TERM "$_roster_child" 2>/dev/null || true
     # `|| true`: a failed spawn here would exit before the KILL and the reap,
     # leaving the EXIT trap to release the lock beside a child that ignored
     # TERM — the precise case this grace period exists for.
     sleep 2 || true
-    if [ -n "$_roster_inner" ]; then
+    # Re-asked, not remembered: the grace period is exactly the window in
+    # which our child can exit and its number be handed to someone else. A
+    # KILL aimed at an answer obtained two seconds ago is the same defect as
+    # the TERM above, one branch later.
+    if _roster_inner_still_ours; then
       kill -KILL "$_roster_inner" 2>/dev/null || true
     fi
     kill -KILL "$_roster_child" 2>/dev/null || true
     wait "$_roster_child" 2>/dev/null || true
     # Read once more AFTER the reap: a wrapper that was finishing while this
     # side gave up would otherwise be reported as a timeout it never had.
+    #
+    # THE SENTINEL DOES NOT SHORT-CIRCUIT THE GATE (raised in review). It is
+    # written by the wrapper only after `wait` on node returned, so it *should*
+    # imply the inner process is gone — but that is an argument about the
+    # wrapper's code, not an observation of this machine, and the branch it
+    # guards is the one that releases the lock. So the same question is asked
+    # here too. It costs nothing when the inner really has exited: the
+    # predicate fails on its first call and this reads exactly as it did
+    # before.
+    if [ -s "$_roster_sentinel" ] && _roster_inner_still_ours; then
+      AGMSG_HELD_LOCKS=""
+      rm -f "$_roster_sentinel" "$_roster_pidfile" || true
+      echo "agmsg: roster sync $operation failed for team '$team': the wrapper recorded an exit status, but process $_roster_inner is still running this operation's roster-sync. The team lock is being KEPT rather than released. Stop that process, then remove $team_dir/.config.lock" >&2
+      exit 17
+    fi
     if [ -s "$_roster_sentinel" ]; then
       _roster_status="$(cat "$_roster_sentinel" 2>/dev/null || printf '13')"
       rm -f "$_roster_sentinel" "$_roster_pidfile" || true
@@ -361,23 +425,29 @@ if [ "$_roster_wait" != "none" ]; then
       # cross-checks with `ps` so a sandbox that refuses to signal cannot be
       # mistaken for a process that is not there.
       #
-      # WHICH WAY IT FAILS MATTERS MORE THAN WHETHER IT CAN. A pid can be
-      # reused, so this can be wrong in two directions:
+      # AND IT ASKS THE SAME QUESTION THE SIGNALS DID, not a weaker one. An
+      # earlier version gated on liveness alone, which reads a recycled number
+      # as "our child is still running" (raised in review). The predicate is
+      # the pair — alive AND still carrying this operation's argv — so the two
+      # cannot drift apart.
       #
-      #   wrong "alive"  the number was recycled by an unrelated process. The
-      #                  lock is then held when it need not be — visible,
-      #                  named, and fixable by hand.
-      #   wrong "dead"   the lock comes off beside a live writer. Silent, and
-      #                  it corrupts.
+      # WHICH WAY IT FAILS MATTERS MORE THAN WHETHER IT CAN:
       #
-      # The instrument is built to err toward "alive", and that is the
-      # direction this path needs. The conservative answer is the one that
-      # costs an operator a message rather than the journal.
+      #   wrong "still ours"  the lock is held when it need not be — visible,
+      #                       named, and fixable by hand.
+      #   wrong "gone"        the lock comes off beside a live writer. Silent,
+      #                       and it corrupts.
+      #
+      # `_agmsg_pid_alive_local` errs toward "alive"; the argv match errs
+      # toward "not ours". Their conjunction therefore errs toward "gone" —
+      # the WRONG direction — so a pid that is alive but unrecognisable is
+      # reported as UNKNOWN below rather than folded into either answer.
       _roster_gone=1
+      _roster_unknown=0
       if [ -n "$_roster_inner" ]; then
         _roster_confirm_deadline=$((SECONDS + 5))
         while [ "$SECONDS" -lt "$_roster_confirm_deadline" ]; do
-          if _agmsg_pid_alive_local "$_roster_inner"; then
+          if _roster_inner_still_ours; then
             # `|| true` for the third time, and for the same contract: exiting
             # here would release the lock through the trap without ever
             # reaching the decision below.
@@ -386,9 +456,28 @@ if [ "$_roster_wait" != "none" ]; then
             break
           fi
         done
-        if _agmsg_pid_alive_local "$_roster_inner"; then
+        if _roster_inner_still_ours; then
           _roster_gone=0
+        elif _agmsg_pid_alive_local "$_roster_inner"; then
+          # ALIVE, BUT NO LONGER RECOGNISABLE. Two readings, and this cannot
+          # tell them apart: our child exited and something else took the
+          # number, or our child is there and its argv could not be read (a
+          # platform where `compat_get_cmdline` answers nothing, a sandbox).
+          #
+          # Reported as its own state rather than folded into either. Calling
+          # it "gone" would release the lock on the strength of an answer that
+          # was never obtained, which is the class this whole review round has
+          # been about.
+          _roster_gone=0
+          _roster_unknown=1
         fi
+      fi
+
+      if [ "$_roster_gone" = "0" ] && [ "$_roster_unknown" = "1" ]; then
+        AGMSG_HELD_LOCKS=""
+        rm -f "$_roster_sentinel" "$_roster_pidfile" || true
+        echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s, and process $_roster_inner is alive but no longer identifiable as this operation's child — it was NOT signalled, because the number may since have been reused by an unrelated process. Whether our own child is still running could not be determined, so the team lock is being KEPT. Check that process, then remove $team_dir/.config.lock" >&2
+        exit 18
       fi
 
       if [ "$_roster_gone" = "0" ]; then

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -29,9 +29,15 @@ ROSTER_SYNC_BUDGET_S="${AGMSG_ROSTER_SYNC_TIMEOUT_S:-120}"
 # is started — and before the lock is taken, because refusing after the lock
 # and after `agmsg_roster_ensure` would mean a setting error had already moved
 # the team's state and taken the critical section (raised in review).
+# The length is checked with the digits, because a value can be all digits and
+# still be unusable: `[ "$x" -le 0 ]` on a thirty-digit number is beyond what
+# the shell's integers hold, and it errors — under `set -e` that ends this
+# script with the shell's own status and none of the sentence below, which is
+# the silent refusal this guard exists to remove (raised in review). Nine
+# digits is over thirty years in seconds; nothing legitimate reaches it.
 case "$ROSTER_SYNC_BUDGET_S" in
-  ''|*[!0-9]*)
-    echo "agmsg: roster sync $operation failed for team '$team': AGMSG_ROSTER_SYNC_TIMEOUT_S must be a positive whole number of seconds, got '${AGMSG_ROSTER_SYNC_TIMEOUT_S:-}'" >&2
+  ''|*[!0-9]*|??????????*)
+    echo "agmsg: roster sync $operation failed for team '$team': AGMSG_ROSTER_SYNC_TIMEOUT_S must be a positive whole number of seconds, at most nine digits, got '${AGMSG_ROSTER_SYNC_TIMEOUT_S:-}'" >&2
     exit 15 ;;
 esac
 if [ "$ROSTER_SYNC_BUDGET_S" -le 0 ]; then

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -418,12 +418,25 @@ if [ "$_roster_wait" != "none" ]; then
     case "$_roster_inner" in
       ''|*[!0-9]*|0*) _roster_inner="" ;;
     esac
+    # WHAT WAS ACTUALLY SENT IS RECORDED, because the state can change under
+    # us between one signal and the next (raised in review, and it stood for
+    # three rounds before I read it properly).
+    #
+    # The predicate is re-asked before TERM and again before KILL, which is
+    # right — but it means a pid that was `ours` at the first can be `unknown`
+    # at the second, through recycling or an argv that stopped being readable.
+    # The diagnostic then said "nothing was signalled on that number", which
+    # would be FALSE: TERM had already gone out. An operator reading that
+    # would go looking for a process nobody had touched.
+    _roster_sent_term=0
+    _roster_sent_kill=0
     # Signalled ONLY when it is still the process we started. Anything else is
     # left alone: the cost of not signalling our own child is a lock we keep
     # and report; the cost of signalling someone else's is a process we had no
     # business touching.
     if _roster_inner_still_ours; then
       kill -TERM "$_roster_inner" 2>/dev/null || true
+      _roster_sent_term=1
     fi
     # The wrapper needs no such check — it is this shell's own child, held in
     # `$!` and not reaped until below, so its number cannot have been recycled
@@ -439,6 +452,7 @@ if [ "$_roster_wait" != "none" ]; then
     # the TERM above, one branch later.
     if _roster_inner_still_ours; then
       kill -KILL "$_roster_inner" 2>/dev/null || true
+      _roster_sent_kill=1
     fi
     kill -KILL "$_roster_child" 2>/dev/null || true
     wait "$_roster_child" 2>/dev/null || true
@@ -520,9 +534,18 @@ if [ "$_roster_wait" != "none" ]; then
       _roster_state="$(_roster_inner_state)"
 
       if [ "$_roster_state" = "unknown" ]; then
+        # THE DIAGNOSTIC REPORTS WHAT HAPPENED, not what the usual case would
+        # have been. Two ways to arrive here, and they leave the machine in
+        # different states, so they get different sentences.
+        _roster_signal_note="Nothing was signalled on that number: it was never identifiable as this operation's child"
+        if [ "$_roster_sent_term" = "1" ] && [ "$_roster_sent_kill" = "1" ]; then
+          _roster_signal_note="TERM and KILL were both sent to that number while it still carried this operation's argv; it stopped being identifiable afterwards"
+        elif [ "$_roster_sent_term" = "1" ]; then
+          _roster_signal_note="TERM WAS SENT to that number while it still carried this operation's argv, and KILL was then WITHHELD because it no longer did — so a process may have been signalled once and not stopped"
+        fi
         AGMSG_HELD_LOCKS=""
         rm -f "$_roster_sentinel" "$_roster_pidfile" || true
-        echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s, and its fate could not be established — the recorded pid was '$_roster_inner', which is either absent or alive without this operation's argv. Nothing was signalled on that number, because it may since have been reused by an unrelated process. The team lock is being KEPT rather than released, since releasing it beside a writer that may still be running can corrupt the roster journal. Check that process, then remove $team_dir/.config.lock" >&2
+        echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s, and its fate could not be established — the recorded pid was '$_roster_inner', which is either absent or alive without this operation's argv. $_roster_signal_note. The team lock is being KEPT rather than released, since releasing it beside a writer that may still be running can corrupt the roster journal. Check that process, then remove $team_dir/.config.lock" >&2
         exit 18
       fi
 

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -137,6 +137,21 @@ if [ "$_roster_bounded" = "1" ]; then
     "$node_bin" "$SCRIPT_DIR/roster-sync.mjs" "$operation" "$config" \
       "$server" "$remote" "$protocol" "$@" <&9 9<&- &
     _rs_node=$!
+    # THE WRAPPER'S OWN COPY, AND IT IS A THIRD ONE. Introducing this shell to
+    # carry the pid put a process between the driver and node that inherits
+    # fd 9 and was closing it nowhere — so the caller's stdin was held for the
+    # whole operation by something neither the child's `9<&-` nor the parent's
+    # `exec 9<&-` reaches. The same class as the two closes around it, made
+    # reachable again by the shell added to fix a different one.
+    #
+    # CI found this, and the case that found it is the behavioural half whose
+    # comment said `$PPID` is the driver. It stopped being the driver when this
+    # brace group appeared; the assertion then read THIS shell's table and
+    # reported fd 9 open, which was the truth.
+    #
+    # Closed here rather than in the group's redirection list, because node
+    # above still needs it: `<&9` is read when that command starts.
+    exec 9<&-
     printf '%s\n' "$_rs_node" > "$_roster_pidfile"
     _rs_rc=0
     wait "$_rs_node" || _rs_rc=$?

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -7,6 +7,11 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SKILL_DIR/scripts/lib/registry-lock.sh"
 # shellcheck disable=SC1091
 source "$SKILL_DIR/scripts/lib/roster-journal.sh"
+# For `_agmsg_pid_alive_local`, which is where liveness is OWNED. A bare
+# `kill -0` here would be a second answer to "is it running?" beside the one
+# that file exists to give -- and a repo-wide check refuses one, correctly.
+# shellcheck disable=SC1091
+source "$SKILL_DIR/scripts/lib/instance-id.sh"
 
 operation="${1:?Missing operation}"; team="${2:?Missing team}"
 server="${3:?Missing server id}"; remote="${4:?Missing remote team id}"
@@ -83,9 +88,13 @@ node_bin="${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
 #
 # So the wait is bounded by a READ, not by a second process. The child is given
 # one end of a FIFO it never writes to; when it exits, that end closes and the
-# read here returns end-of-file. `read -t` distinguishes the two outcomes by
-# status: >128 means the budget expired, and anything else means the writer is
-# gone.
+# read here returns end-of-file.
+#
+# This USED TO SAY that `read -t` then distinguishes the two outcomes by
+# status — above 128 for the budget, anything else for a departed writer — AND
+# THAT WAS WRONG WHERE IT RUNS. The correction and its measurement are below;
+# the sentence is kept in the past tense so this file does not appear to state
+# two contracts at once.
 #
 # What this does NOT claim is "no extra process at all": `mktemp`, `mkfifo` and
 # `rm` are external commands and each is a spawn (raised in review; an earlier
@@ -93,8 +102,10 @@ node_bin="${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
 # false). They are short-lived and sequential, where a watchdog is concurrent
 # and lives as long as the operation — and on a machine that is refusing
 # spawns, a process held open beside every roster call is the shape that
-# matters. Each of the three is checked: a failure to make the temp path or the
-# FIFO falls back to the unbounded path and says so on stderr.
+# matters. What happens when one of them fails is NOT "fall back to the
+# unbounded path" — that is what this used to do, and it is the defect. See
+# the mode table below: no FIFO still bounds by polling, and no temp file at
+# all refuses.
 # A FIFO to notice the child's exit by, and a SENTINEL to say what happened.
 #
 # Two files, because one of them cannot answer both questions on the shell
@@ -145,6 +156,25 @@ if [ -n "$_roster_sentinel" ] && [ -n "$_roster_pidfile" ]; then
     _roster_fifo=""
     _roster_wait=poll
   fi
+fi
+
+# A PARTIAL SETUP LEAVES PART OF ITSELF BEHIND, AND `none` IS WHERE IT SHOWS
+# (raised in review).
+#
+# The three `mktemp` calls above run independently, so "could not build a
+# bound" is not one state: the sentinel can exist while the pidfile failed, or
+# the other way round. Both routes out of `none` — the override and the
+# refusal — used to walk past whatever had already been created, and the
+# failure that sends a run down here is *a temp directory that is full*. A
+# feature that responds to a full filesystem by adding a file to it is the
+# wrong shape, and it is the same self-defeating loop `sync-autostart.sh`
+# already carries a comment about.
+#
+# Swept once, here, before either route is taken. `rm -f` on an empty name is
+# a no-op, so the three cases (none created, one, two) need no branching, and
+# `|| true` because nothing below may hang on a failed unlink.
+if [ "$_roster_wait" = "none" ]; then
+  rm -f "$_roster_sentinel" "$_roster_pidfile" 2>/dev/null || true
 fi
 
 # THE WAY OUT, because a refusal with no override is a wall. An operator who
@@ -263,9 +293,22 @@ if [ "$_roster_wait" != "none" ]; then
     # trade against no bound at all.
     #
     # `SECONDS` is the shell's own counter, so the deadline needs no `date`.
+    #
+    # `|| true` ON THE SLEEP, for the same reason the `rm` above has one, and
+    # it is sharper here (raised in review). `sleep` is an external command
+    # under `set -e`; a refused spawn would end this shell HERE — with the
+    # wrapper and node already started and none of the terminate/KILL/reap
+    # below reached — and the EXIT trap would drop the lock beside a live
+    # writer. That is the contract this path is written to keep, broken by the
+    # one command it uses to wait. And this mode is *chosen* on machines that
+    # could not make a FIFO, which is the same population that refuses spawns.
+    #
+    # What a failing `sleep` costs instead: this loop spins on `SECONDS` until
+    # the deadline. Hot, and bounded, and it still terminates — the right
+    # trade against exiting mid-critical-section.
     _roster_deadline=$((SECONDS + ROSTER_SYNC_BUDGET_S))
     while [ ! -s "$_roster_sentinel" ] && [ "$SECONDS" -lt "$_roster_deadline" ]; do
-      sleep 1
+      sleep 1 || true
     done
   fi
 
@@ -284,7 +327,10 @@ if [ "$_roster_wait" != "none" ]; then
       kill -TERM "$_roster_inner" 2>/dev/null || true
     fi
     kill -TERM "$_roster_child" 2>/dev/null || true
-    sleep 2
+    # `|| true`: a failed spawn here would exit before the KILL and the reap,
+    # leaving the EXIT trap to release the lock beside a child that ignored
+    # TERM — the precise case this grace period exists for.
+    sleep 2 || true
     if [ -n "$_roster_inner" ]; then
       kill -KILL "$_roster_inner" 2>/dev/null || true
     fi
@@ -297,13 +343,80 @@ if [ "$_roster_wait" != "none" ]; then
       rm -f "$_roster_sentinel" "$_roster_pidfile" || true
       [ "$_roster_status" = "0" ] || exit "$_roster_status"
     else
+      # "I SENT A SIGNAL" IS NOT "THE PROCESS IS GONE" (raised as BLOCKING).
+      #
+      # Everything above discards its result: `kill -TERM ... || true`, then
+      # `kill -KILL ... || true`. Neither says whether anything died. The inner
+      # process is a GRANDCHILD, so `wait` cannot speak for it either — only
+      # the wrapper is this shell's child. So the release below used to rest on
+      # nothing at all: a signal refused by a sandbox, or a process wedged in an
+      # uninterruptible state, and the lock came off anyway with the writer
+      # still running. That is the one outcome this whole path exists to avoid,
+      # and the comment two branches up says so in as many words.
+      #
+      # So the question is ASKED, with the repo's own instrument.
+      # `_agmsg_pid_alive_local` is the right one of the two: this pid was
+      # minted by `$!` in one of these shells and read back from a pidfile one
+      # of them wrote. It reads EPERM as alive, treats a zombie as gone, and
+      # cross-checks with `ps` so a sandbox that refuses to signal cannot be
+      # mistaken for a process that is not there.
+      #
+      # WHICH WAY IT FAILS MATTERS MORE THAN WHETHER IT CAN. A pid can be
+      # reused, so this can be wrong in two directions:
+      #
+      #   wrong "alive"  the number was recycled by an unrelated process. The
+      #                  lock is then held when it need not be — visible,
+      #                  named, and fixable by hand.
+      #   wrong "dead"   the lock comes off beside a live writer. Silent, and
+      #                  it corrupts.
+      #
+      # The instrument is built to err toward "alive", and that is the
+      # direction this path needs. The conservative answer is the one that
+      # costs an operator a message rather than the journal.
+      _roster_gone=1
+      if [ -n "$_roster_inner" ]; then
+        _roster_confirm_deadline=$((SECONDS + 5))
+        while [ "$SECONDS" -lt "$_roster_confirm_deadline" ]; do
+          if _agmsg_pid_alive_local "$_roster_inner"; then
+            # `|| true` for the third time, and for the same contract: exiting
+            # here would release the lock through the trap without ever
+            # reaching the decision below.
+            sleep 1 || true
+          else
+            break
+          fi
+        done
+        if _agmsg_pid_alive_local "$_roster_inner"; then
+          _roster_gone=0
+        fi
+      fi
+
+      if [ "$_roster_gone" = "0" ]; then
+        # THE LOCK IS KEPT, ON PURPOSE, AND THE OPERATOR IS TOLD.
+        #
+        # Emptying `AGMSG_HELD_LOCKS` is how the lock survives: the EXIT trap
+        # calls `agmsg_lock_release`, which walks that list and does nothing
+        # when it is empty. The directory stays where it is. Reaching for the
+        # trap itself would fight the library that installed it; this uses the
+        # library's own state.
+        #
+        # This does not reopen #821. That property is "a child that hangs must
+        # not hold the critical section INDEFINITELY, silently" — and this
+        # shell exits, now, with the pid and the path to remove. What it
+        # refuses to do is claim a process was stopped when it was not.
+        AGMSG_HELD_LOCKS=""
+        rm -f "$_roster_sentinel" "$_roster_pidfile" || true
+        echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s, and process $_roster_inner is STILL RUNNING after TERM and KILL. The team lock is being KEPT rather than released, because releasing it beside a live writer can corrupt the roster journal. Stop that process, then remove $team_dir/.config.lock" >&2
+        exit 17
+      fi
+
       rm -f "$_roster_sentinel" "$_roster_pidfile" || true
       # Released here rather than left to the EXIT trap. The trap is the
       # mechanism that is not reached when a child never returns, and a fix
       # that leans on it on the one path it exists for is not a fix. It still
       # runs afterwards and finds nothing to do.
       agmsg_lock_release
-      echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s; it was stopped and the team lock released" >&2
+      echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s; it was stopped, confirmed gone, and the team lock released" >&2
       # Stopping between the journal write and the state write leaves the two
       # out of step. Each is written by rename, so neither is torn — but that
       # the next run converges from every such point is NOT established, and is

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -419,9 +419,11 @@ if [ "$_roster_wait" != "none" ]; then
     case "$_roster_inner" in
       ''|*[!0-9]*|0*) _roster_inner="" ;;
     esac
-    # WHAT WAS ACTUALLY SENT IS RECORDED, because the state can change under
-    # us between one signal and the next (raised in review, and it stood for
-    # three rounds before I read it properly).
+    # WHAT WAS ACTUALLY ATTEMPTED IS RECORDED, because the state can change
+    # under us between one signal and the next (raised in review, and it stood
+    # for three rounds before I read it properly). "Attempted" is the whole
+    # claim — see the note below, and do not widen this heading back to
+    # "sent": the block would then state two different contracts.
     #
     # The predicate is re-asked before TERM and again before KILL, which is
     # right — but it means a pid that was `ours` at the first can be `unknown`

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -81,15 +81,46 @@ node_bin="${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
 # child; argv alone would accept a match on a pid that is already gone. The
 # suffix is specific rather than convenient: `$config` is per-team, so a
 # roster sync for a DIFFERENT team cannot satisfy it.
-_roster_inner_still_ours() {
-  [ -n "${_roster_inner:-}" ] || return 1
-  _agmsg_pid_alive_local "$_roster_inner" || return 1
+# THREE ANSWERS, AND A BOOLEAN CANNOT CARRY THEM (raised in review, twice).
+#
+# The first version of this returned true/false, so every caller had to read
+# "false" as "gone" — and false covered two very different things: the process
+# really has exited, and the process is alive but we could not establish that
+# it is ours. Releasing the lock is only safe for the first. Collapsing them
+# put the unsafe reading on the default path, which is the same shape as every
+# other defect in this PR.
+#
+# So it prints one of three words:
+#
+#   ours     alive, and still carrying this operation's argv
+#   gone     not alive — the only answer that authorises a release
+#   unknown  everything else, and it is NOT a residual category:
+#              * no pid recorded at all (the wrapper never got that far, so
+#                whether node started is not known — this used to read as
+#                "gone" and release)
+#              * alive, argv does not match — a recycled number, OR our child
+#                with an argv this platform would not hand over
+_roster_inner_state() {
+  if [ -z "${_roster_inner:-}" ]; then
+    printf 'unknown\n'
+    return
+  fi
+  if ! _agmsg_pid_alive_local "$_roster_inner"; then
+    printf 'gone\n'
+    return
+  fi
   local cmd
   cmd="$(compat_get_cmdline "$_roster_inner" 2>/dev/null || true)"
   case "$cmd" in
-    *"$SCRIPT_DIR/roster-sync.mjs $operation $config"*) return 0 ;;
+    *"$SCRIPT_DIR/roster-sync.mjs $operation $config"*) printf 'ours\n' ;;
+    *) printf 'unknown\n' ;;
   esac
-  return 1
+}
+
+# Signalling has exactly one safe answer, so it gets its own name rather than
+# every call site re-deriving it from the word.
+_roster_inner_still_ours() {
+  [ "$(_roster_inner_state)" = "ours" ]
 }
 
 # THE CRITICAL SECTION IS BOUNDED IN TIME, NOT ONLY IN SCOPE (#821).
@@ -396,10 +427,14 @@ if [ "$_roster_wait" != "none" ]; then
     # here too. It costs nothing when the inner really has exited: the
     # predicate fails on its first call and this reads exactly as it did
     # before.
-    if [ -s "$_roster_sentinel" ] && _roster_inner_still_ours; then
+    # AND IT ASKS FOR THE WORD, NOT FOR A YES/NO. Gating this on
+    # `_roster_inner_still_ours` was the same collapse one layer up: "not
+    # ours" released the lock, and "not ours" includes "alive, unidentifiable"
+    # (raised in review). Only `gone` may pass.
+    if [ -s "$_roster_sentinel" ] && [ "$(_roster_inner_state)" != "gone" ]; then
       AGMSG_HELD_LOCKS=""
       rm -f "$_roster_sentinel" "$_roster_pidfile" || true
-      echo "agmsg: roster sync $operation failed for team '$team': the wrapper recorded an exit status, but process $_roster_inner is still running this operation's roster-sync. The team lock is being KEPT rather than released. Stop that process, then remove $team_dir/.config.lock" >&2
+      echo "agmsg: roster sync $operation failed for team '$team': the wrapper recorded an exit status, but process '$_roster_inner' could not be confirmed to have exited (state: $(_roster_inner_state)). The team lock is being KEPT rather than released. Check that process, then remove $team_dir/.config.lock" >&2
       exit 17
     fi
     if [ -s "$_roster_sentinel" ]; then
@@ -442,45 +477,30 @@ if [ "$_roster_wait" != "none" ]; then
       # toward "not ours". Their conjunction therefore errs toward "gone" —
       # the WRONG direction — so a pid that is alive but unrecognisable is
       # reported as UNKNOWN below rather than folded into either answer.
-      _roster_gone=1
-      _roster_unknown=0
-      if [ -n "$_roster_inner" ]; then
-        _roster_confirm_deadline=$((SECONDS + 5))
-        while [ "$SECONDS" -lt "$_roster_confirm_deadline" ]; do
-          if _roster_inner_still_ours; then
-            # `|| true` for the third time, and for the same contract: exiting
-            # here would release the lock through the trap without ever
-            # reaching the decision below.
-            sleep 1 || true
-          else
-            break
-          fi
-        done
-        if _roster_inner_still_ours; then
-          _roster_gone=0
-        elif _agmsg_pid_alive_local "$_roster_inner"; then
-          # ALIVE, BUT NO LONGER RECOGNISABLE. Two readings, and this cannot
-          # tell them apart: our child exited and something else took the
-          # number, or our child is there and its argv could not be read (a
-          # platform where `compat_get_cmdline` answers nothing, a sandbox).
-          #
-          # Reported as its own state rather than folded into either. Calling
-          # it "gone" would release the lock on the strength of an answer that
-          # was never obtained, which is the class this whole review round has
-          # been about.
-          _roster_gone=0
-          _roster_unknown=1
-        fi
-      fi
+      # Waited on only while the answer is `ours` — the one state in which the
+      # process may still be finishing. `gone` and `unknown` are both terminal
+      # here: nothing about waiting turns an unreadable argv into a readable
+      # one.
+      _roster_confirm_deadline=$((SECONDS + 5))
+      while [ "$(_roster_inner_state)" = "ours" ] && [ "$SECONDS" -lt "$_roster_confirm_deadline" ]; do
+        # `|| true` for the third time, and for the same contract: exiting
+        # here would release the lock through the trap without ever reaching
+        # the decision below.
+        sleep 1 || true
+      done
 
-      if [ "$_roster_gone" = "0" ] && [ "$_roster_unknown" = "1" ]; then
+      # ONE READ OF THE WORD, THEN THREE ARMS. Taken once rather than per
+      # branch so the arms cannot disagree about what was observed.
+      _roster_state="$(_roster_inner_state)"
+
+      if [ "$_roster_state" = "unknown" ]; then
         AGMSG_HELD_LOCKS=""
         rm -f "$_roster_sentinel" "$_roster_pidfile" || true
-        echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s, and process $_roster_inner is alive but no longer identifiable as this operation's child — it was NOT signalled, because the number may since have been reused by an unrelated process. Whether our own child is still running could not be determined, so the team lock is being KEPT. Check that process, then remove $team_dir/.config.lock" >&2
+        echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s, and its fate could not be established — the recorded pid was '$_roster_inner', which is either absent or alive without this operation's argv. Nothing was signalled on that number, because it may since have been reused by an unrelated process. The team lock is being KEPT rather than released, since releasing it beside a writer that may still be running can corrupt the roster journal. Check that process, then remove $team_dir/.config.lock" >&2
         exit 18
       fi
 
-      if [ "$_roster_gone" = "0" ]; then
+      if [ "$_roster_state" = "ours" ]; then
         # THE LOCK IS KEPT, ON PURPOSE, AND THE OPERATOR IS TOLD.
         #
         # Emptying `AGMSG_HELD_LOCKS` is how the lock survives: the EXIT trap
@@ -499,6 +519,16 @@ if [ "$_roster_wait" != "none" ]; then
         exit 17
       fi
 
+      # ONLY `gone` REACHES HERE, AND IT IS SAID RATHER THAN LEFT IMPLIED.
+      # The two arms above return, so falling through means the word was
+      # `gone` — but a fourth state added later would fall through too, and
+      # inherit a release nobody meant to give it. This refuses instead.
+      if [ "$_roster_state" != "gone" ]; then
+        AGMSG_HELD_LOCKS=""
+        rm -f "$_roster_sentinel" "$_roster_pidfile" || true
+        echo "agmsg: roster sync $operation failed for team '$team': internal error — the roster child's state was reported as '$_roster_state', which this code does not know how to act on. The team lock is being KEPT rather than released. Remove $team_dir/.config.lock once you are satisfied nothing is writing to the team" >&2
+        exit 19
+      fi
       rm -f "$_roster_sentinel" "$_roster_pidfile" || true
       # Released here rather than left to the EXIT trap. The trap is the
       # mechanism that is not reached when a child never returns, and a fix

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -28,8 +28,103 @@ trap 'agmsg_lock_release; exit 129' HUP
 agmsg_roster_ensure "$team_dir" "$config"
 
 node_bin="${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
-"$node_bin" "$SCRIPT_DIR/roster-sync.mjs" "$operation" "$config" \
-  "$server" "$remote" "$protocol" "$@"
+
+# THE CRITICAL SECTION IS BOUNDED IN TIME, NOT ONLY IN SCOPE (#817).
+#
+# The scope is right and stays: `roster-sync.mjs` is the read-modify-write of
+# the journal and state this lock exists to serialise. It does no network —
+# measured, with a positive control on the search — and its whole input is
+# handed over in one write before it starts, so nothing in here waits on a
+# remote. Moving it out of the lock would move the very thing being protected.
+#
+# What was missing is a bound. Release was the EXIT trap alone, which is sound
+# when this shell reaches its own exit: a child that fails to start, or exits
+# non-zero, still gets there under `set -e`. It is not sound when the child
+# neither runs nor returns — the shell waits, the trap never runs, and the lock
+# is held by a live process that will never finish. The next start then fails
+# on `.config.lock: File exists`, and the team is unusable until someone finds
+# a directory they have no reason to know about.
+#
+# So the wait has a ceiling, and passing it is a failure with a name rather
+# than a hang. The traps stay as the backup they always were.
+ROSTER_SYNC_BUDGET_S="${AGMSG_ROSTER_SYNC_TIMEOUT_S:-120}"
+
+# THE BOUND COSTS NO EXTRA PROCESS, and on this machine that is the point.
+#
+# The first version put a watchdog beside the child: one more process per
+# roster operation. The leading explanation for the field failure is process
+# pressure — a spawn refused with a Windows DLL-initialisation status — so a
+# guard against hanging that raises the number of spawns can make the thing it
+# guards against more likely. Raised in review, and it is the right objection.
+#
+# So the wait is bounded by a READ, not by a second process. The child is given
+# one end of a FIFO it never writes to; when it exits, that end closes and the
+# read here returns end-of-file. `read -t` distinguishes the two outcomes by
+# status: >128 means the budget expired, and anything else means the writer is
+# gone. One process runs — node — exactly as before this change.
+# A path to make the FIFO at, and nothing written to it: the child never sends
+# anything, and what this waits for is the moment its end closes.
+_roster_fifo="$(mktemp -u 2>/dev/null)" || _roster_fifo=""
+_roster_bounded=0
+if [ -n "$_roster_fifo" ] && mkfifo "$_roster_fifo" 2>/dev/null; then
+  _roster_bounded=1
+fi
+
+if [ "$_roster_bounded" = "1" ]; then
+  # fd 9 is this shell's stdin, kept for the child: a shell with job control
+  # off gives an asynchronous command /dev/null for stdin, and backgrounding
+  # the child silently took away the records the engine had already written to
+  # fd 0. Measured, as every operation failing with "input is invalid".
+  exec 9<&0
+  "$node_bin" "$SCRIPT_DIR/roster-sync.mjs" "$operation" "$config" \
+    "$server" "$remote" "$protocol" "$@" <&9 3>&- 4>&- 8> "$_roster_fifo" &
+  _roster_child=$!
+  exec 8< "$_roster_fifo"
+  rm -f "$_roster_fifo"
+
+  _roster_read_status=0
+  read -r -t "$ROSTER_SYNC_BUDGET_S" _roster_ignored <&8 || _roster_read_status=$?
+  exec 8<&-
+
+  if [ "$_roster_read_status" -gt 128 ]; then
+    # The budget expired with the child still holding its end. Stop it, give it
+    # a moment, insist, and REAP it — the lock is not released while the process
+    # that was writing under it may still be running, because letting the next
+    # caller in beside a live writer is worse than the leak being fixed.
+    kill -TERM "$_roster_child" 2>/dev/null || true
+    sleep 2
+    kill -KILL "$_roster_child" 2>/dev/null || true
+    wait "$_roster_child" 2>/dev/null || true
+    # Released here rather than left to the EXIT trap. The trap is the mechanism
+    # that is not reached when a child never returns, and a fix that leans on it
+    # on the one path it exists for is not a fix. It still runs afterwards and
+    # finds nothing to do.
+    agmsg_lock_release
+    echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s; it was stopped and the team lock released" >&2
+    # Stopping between the journal write and the state write leaves the two out
+    # of step. Each is written by rename, so neither is torn — but that the next
+    # run converges from every such point is NOT established, and is recorded on
+    # the issue rather than claimed here.
+    exit 14
+  fi
+
+  # End of file: the child is gone, and `wait` gives its status directly.
+  # `|| _roster_status=$?` because this file runs under `set -e` and `wait`
+  # returns the child's code — without it a node exiting 13 would kill this
+  # shell here, before anything below could report why.
+  _roster_status=0
+  wait "$_roster_child" || _roster_status=$?
+  [ "$_roster_status" = "0" ] || exit "$_roster_status"
+else
+  # No FIFO — an exotic filesystem, or a temp directory that does not support
+  # one. The previous behaviour is what remains: run it in the foreground and
+  # wait as long as it takes. Stated rather than silently degraded, because a
+  # bound that is sometimes absent is worse documentation than none.
+  echo "agmsg: roster sync $operation for team '$team': cannot create a FIFO in the temp directory; running without a time bound" >&2
+  "$node_bin" "$SCRIPT_DIR/roster-sync.mjs" "$operation" "$config" \
+    "$server" "$remote" "$protocol" "$@"
+fi
+
 case "$operation" in
   reconcile|apply) agmsg_roster_project_config "$team_dir" "$config" ;;
 esac

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -429,15 +429,22 @@ if [ "$_roster_wait" != "none" ]; then
     # The diagnostic then said "nothing was signalled on that number", which
     # would be FALSE: TERM had already gone out. An operator reading that
     # would go looking for a process nobody had touched.
-    _roster_sent_term=0
-    _roster_sent_kill=0
+    # ATTEMPTED, and the name is the claim. `kill ... || true` discards its
+    # status, so what this shell can honestly record is that it CALLED kill —
+    # not that a signal was accepted, and certainly not that one was
+    # delivered. An earlier version set these beside the call and then the
+    # diagnostic said "TERM WAS SENT", which under EPERM or ESRCH is false:
+    # the same "discarded the result of kill" boundary this path exists to
+    # respect, crossed again in the reporting (raised in review).
+    _roster_term_attempted=0
+    _roster_kill_attempted=0
     # Signalled ONLY when it is still the process we started. Anything else is
     # left alone: the cost of not signalling our own child is a lock we keep
     # and report; the cost of signalling someone else's is a process we had no
     # business touching.
     if _roster_inner_still_ours; then
       kill -TERM "$_roster_inner" 2>/dev/null || true
-      _roster_sent_term=1
+      _roster_term_attempted=1
     fi
     # The wrapper needs no such check — it is this shell's own child, held in
     # `$!` and not reaped until below, so its number cannot have been recycled
@@ -451,9 +458,20 @@ if [ "$_roster_wait" != "none" ]; then
     # which our child can exit and its number be handed to someone else. A
     # KILL aimed at an answer obtained two seconds ago is the same defect as
     # the TERM above, one branch later.
-    if _roster_inner_still_ours; then
+    # ESCALATION IS MONOTONE, and this is a safety rule rather than a tidiness
+    # one (raised in review). The predicate is re-asked, so the other
+    # direction of the transition is possible too: `unknown` before TERM, then
+    # `ours` before KILL, through recycling or an instrument that failed once
+    # and recovered. The old code would then send KILL to a number it had just
+    # refused to send TERM to — escalating against something it never
+    # established a claim on.
+    #
+    # So KILL requires BOTH: that we were entitled to TERM this number, and
+    # that it is still ours now. A number once judged unidentifiable is not
+    # re-adopted later in the same timeout.
+    if [ "$_roster_term_attempted" = "1" ] && _roster_inner_still_ours; then
       kill -KILL "$_roster_inner" 2>/dev/null || true
-      _roster_sent_kill=1
+      _roster_kill_attempted=1
     fi
     kill -KILL "$_roster_child" 2>/dev/null || true
     wait "$_roster_child" 2>/dev/null || true
@@ -534,16 +552,19 @@ if [ "$_roster_wait" != "none" ]; then
       # branch so the arms cannot disagree about what was observed.
       _roster_state="$(_roster_inner_state)"
 
+      # THE DIAGNOSTIC REPORTS WHAT WAS ATTEMPTED, once, for both exits below.
+      # Computed here rather than in each branch so the two cannot describe
+      # the same run differently — and worded as ATTEMPTS, because `kill`'s
+      # status was discarded and delivery is not observable from this side at
+      # all.
+      _roster_signal_note="No signal was attempted on that number: it was never identifiable as this operation's child"
+      if [ "$_roster_term_attempted" = "1" ] && [ "$_roster_kill_attempted" = "1" ]; then
+        _roster_signal_note="TERM and then KILL were both ATTEMPTED on that number while it carried this operation's argv; whether either was accepted or delivered is not known here"
+      elif [ "$_roster_term_attempted" = "1" ]; then
+        _roster_signal_note="TERM was ATTEMPTED on that number while it carried this operation's argv, and KILL was then WITHHELD because it no longer did — so a process may have been signalled once and not stopped"
+      fi
+
       if [ "$_roster_state" = "unknown" ]; then
-        # THE DIAGNOSTIC REPORTS WHAT HAPPENED, not what the usual case would
-        # have been. Two ways to arrive here, and they leave the machine in
-        # different states, so they get different sentences.
-        _roster_signal_note="Nothing was signalled on that number: it was never identifiable as this operation's child"
-        if [ "$_roster_sent_term" = "1" ] && [ "$_roster_sent_kill" = "1" ]; then
-          _roster_signal_note="TERM and KILL were both sent to that number while it still carried this operation's argv; it stopped being identifiable afterwards"
-        elif [ "$_roster_sent_term" = "1" ]; then
-          _roster_signal_note="TERM WAS SENT to that number while it still carried this operation's argv, and KILL was then WITHHELD because it no longer did — so a process may have been signalled once and not stopped"
-        fi
         AGMSG_HELD_LOCKS=""
         rm -f "$_roster_sentinel" "$_roster_pidfile" || true
         echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s, and its fate could not be established — the recorded pid was '$_roster_inner', which is either absent or alive without this operation's argv. $_roster_signal_note. The team lock is being KEPT rather than released, since releasing it beside a writer that may still be running can corrupt the roster journal. Check that process, then remove $team_dir/.config.lock" >&2
@@ -565,7 +586,7 @@ if [ "$_roster_wait" != "none" ]; then
         # refuses to do is claim a process was stopped when it was not.
         AGMSG_HELD_LOCKS=""
         rm -f "$_roster_sentinel" "$_roster_pidfile" || true
-        echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s, and process $_roster_inner is STILL RUNNING after TERM and KILL. The team lock is being KEPT rather than released, because releasing it beside a live writer can corrupt the roster journal. Stop that process, then remove $team_dir/.config.lock" >&2
+        echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s, and process $_roster_inner is STILL RUNNING and still carrying this operation's argv. $_roster_signal_note. The team lock is being KEPT rather than released, because releasing it beside a live writer can corrupt the roster journal. Stop that process, then remove $team_dir/.config.lock" >&2
         exit 17
       fi
 

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -192,8 +192,15 @@ if [ "$_roster_wait" != "none" ]; then
   # here: measured, as a three-second budget that had not returned after
   # seventeen minutes.
   {
+    # `3>&- 4>&-` HERE AS WELL AS ON THE GROUP, and the repetition is the point.
+    # The enclosing group already closes both, so node's descriptors were never
+    # actually at risk — but `tests/test_spawn_fd_guard.bats` reads the spawn
+    # LINE, deliberately: an exemption keyed on "something upstream closes them"
+    # accepts an `exec` inside a branch that never runs, or after the spawn it
+    # was supposed to cover. Redundancy is the cheaper mistake, and the same
+    # belt-and-braces pattern is already in `scripts/lib/sync-autostart.sh`.
     "$node_bin" "$SCRIPT_DIR/roster-sync.mjs" "$operation" "$config" \
-      "$server" "$remote" "$protocol" "$@" <&9 9<&- &
+      "$server" "$remote" "$protocol" "$@" <&9 9<&- 3>&- 4>&- &
     _rs_node=$!
     # THE WRAPPER'S OWN COPY, AND IT IS A THIRD ONE. Introducing this shell to
     # carry the pid put a process between the driver and node that inherits

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -113,7 +113,14 @@ if [ "$_roster_bounded" = "1" ]; then
   # redirection above; this closes ours the moment it is no longer needed.
   exec 9<&-
   exec 8< "$_roster_fifo"
-  rm -f "$_roster_fifo"
+  # `|| true` because this file runs under `set -e` and `rm` is an external
+  # command: a spawn refused, or a filesystem that will not unlink, would end
+  # this shell HERE — while the child is still running — and the EXIT trap
+  # would release the lock beside a live writer. That is worse than the leak
+  # being fixed, and it is the one place this fix could create it (raised in
+  # review). The FIFO is already open on fd 8; unlinking it is tidiness, and
+  # tidiness may not decide whether the lock is held.
+  rm -f "$_roster_fifo" || true
 
   _roster_read_status=0
   read -r -t "$ROSTER_SYNC_BUDGET_S" _roster_ignored <&8 || _roster_read_status=$?

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -123,61 +123,23 @@ _roster_inner_state() {
   fi
   local cmd
   cmd="$(compat_get_cmdline "$_roster_inner" 2>/dev/null || true)"
-  # PLATFORM-AWARE, because a raw `case` compares two different alphabets.
+  # THE WHOLE QUESTION LIVES IN `agmsg_roster_argv_is_ours`, and it lives in
+  # `scripts/lib/roster-journal.sh` rather than here so that its cases can
+  # drive IT rather than a copy of it. Inline, the only way to reach it was to
+  # run the driver, so the tests re-implemented the comparison and then
+  # asserted on this file with `grep` -- which measures a duplicate and a
+  # spelling, never the thing production calls (raised in review).
   #
-  # Under Git Bash the shell's path is `/c/Users/...` while a native process
-  # reports `C:/Users/...`, so a raw match answers "not ours" about a process
-  # that IS ours — silently, because a non-match is the ordinary answer.
-  # `agmsg_cmdline_names_path` exists for exactly this and takes the `cygpath
-  # -m` second look; `_remote_sync_engine_status` already uses it. Reaching for
-  # a bare `case` here would have made Windows keep the lock on every timeout,
-  # on its own healthy child (raised in review).
-  #
-  # THE ORDERED TRIPLE, NOT THREE INDEPENDENT SIGHTINGS (raised in review).
-  #
-  # Asking "does the cmdline contain the script path" AND "does it contain
-  # this config" AND "does it contain this operation somewhere" is three
-  # questions, and three questions do not add up to "this operation, on this
-  # config". A command line carrying a different operation and a different
-  # config can satisfy all three at once — the operation from one place, the
-  # config from another. Two existence checks are not a relation.
-  #
-  # So the needle is the sequence the driver actually spawns:
-  #     <script> <operation> <config>
-  # and it has to appear as one run of text.
-  #
-  # BOTH ALPHABETS, because the shell's `/c/Users/...` and a native process's
-  # `C:/Users/...` are the same path written differently. `cygpath -m` is the
-  # conversion `agmsg_cmdline_names_path` uses for exactly this; it is called
-  # here rather than that function because the needle must be composed from
-  # converted PARTS — handing a whole sentence to a path converter would not
-  # do what it says.
-  local script_sh="$SCRIPT_DIR/roster-sync.mjs" script_win="" config_win=""
-  if command -v cygpath >/dev/null 2>&1; then
-    script_win="$(cygpath -m "$script_sh" 2>/dev/null || true)"
-    config_win="$(cygpath -m "$config" 2>/dev/null || true)"
+  # What it holds, and why, is documented beside it: quotes stripped first
+  # because a native Windows command line quotes any argument containing a
+  # space; both path alphabets, because `/c/Users/...` and `C:/Users/...` are
+  # the same path; the ordered triple with argument boundaries, because three
+  # separate `contains` checks are three questions and an ordered substring is
+  # still a substring.
+  if agmsg_roster_argv_is_ours "$cmd" "$SCRIPT_DIR/roster-sync.mjs" "$operation" "$config"; then
+    printf 'ours\n'
+    return
   fi
-  # AND THE NEEDLE NEEDS ARGV BOUNDARIES (raised in review). An ordered
-  # substring is still a substring: with the config `/teams/demo/config.json`,
-  # the pattern matched a command line whose config was
-  # `/teams/demo/config.json.bak` — and, on the other side, a script at
-  # `/x/opt/agmsg/.../roster-sync.mjs` contains our absolute path as a tail.
-  # Both are different runs reading as ours.
-  #
-  # Padding the haystack with one space at each end lets a single pattern
-  # require a boundary on both sides without a separate end-of-string case:
-  # an argument at either extreme now has the space the pattern asks for.
-  local padded=" $cmd "
-  local s c
-  for s in "$script_sh" "$script_win"; do
-    [ -n "$s" ] || continue
-    for c in "$config" "$config_win"; do
-      [ -n "$c" ] || continue
-      case "$padded" in
-        *" $s $operation $c "*) printf 'ours\n'; return ;;
-      esac
-    done
-  done
   printf 'unknown\n'
 }
 

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -130,12 +130,13 @@ _roster_inner_state() {
   # asserted on this file with `grep` -- which measures a duplicate and a
   # spelling, never the thing production calls (raised in review).
   #
-  # What it holds, and why, is documented beside it: quotes stripped first
-  # because a native Windows command line quotes any argument containing a
-  # space; both path alphabets, because `/c/Users/...` and `C:/Users/...` are
-  # the same path; the ordered triple with argument boundaries, because three
-  # separate `contains` checks are three questions and an ordered substring is
-  # still a substring.
+  # What it holds, and why, is documented beside it: the quoted forms are
+  # enumerated rather than the quotes removed, because a quote is an argument
+  # boundary and deleting it lets a quoted DATA argument that merely contains
+  # the triple pass as an invocation; both path alphabets, because
+  # `/c/Users/...` and `C:/Users/...` are the same path; the ordered triple
+  # with argument boundaries, because three separate `contains` checks are
+  # three questions and an ordered substring is still a substring.
   if agmsg_roster_argv_is_ours "$cmd" "$SCRIPT_DIR/roster-sync.mjs" "$operation" "$config"; then
     printf 'ours\n'
     return

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -95,11 +95,27 @@ node_bin="${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
 # spawns, a process held open beside every roster call is the shape that
 # matters. Each of the three is checked: a failure to make the temp path or the
 # FIFO falls back to the unbounded path and says so on stderr.
-# A path to make the FIFO at, and nothing written to it: the child never sends
-# anything, and what this waits for is the moment its end closes.
+# A FIFO to notice the child's exit by, and a SENTINEL to say what happened.
+#
+# Two files, because one of them cannot answer both questions on the shell
+# this actually runs under. `read -t` returns 1 for a timeout AND 1 for
+# end-of-file on Bash 3.2 — measured on 3.2.57, which is what the macOS
+# runners use — so a bound written as `status > 128` is simply never taken
+# there. That is what happened: a two-second budget waited twenty-five
+# minutes, on the one platform whose bash cannot tell the two apart, while
+# every Linux leg stayed green because Bash 5 does distinguish them.
+#
+# So the ANSWER IS NOT THE RETURN CODE. The wrapper writes its child's exit
+# status to a sentinel as its last act; this side reads the sentinel. Present
+# means the wrapper finished — including when the command could not be exec'd
+# at all, because a failed exec sets `$?` in the wrapper and the wrapper still
+# reaches the write. Absent after the wait means the wrapper is still there,
+# which is the only case a bound is for.
 _roster_fifo="$(mktemp -u 2>/dev/null)" || _roster_fifo=""
+_roster_sentinel="$(mktemp 2>/dev/null)" || _roster_sentinel=""
+_roster_pidfile="$(mktemp 2>/dev/null)" || _roster_pidfile=""
 _roster_bounded=0
-if [ -n "$_roster_fifo" ] && mkfifo "$_roster_fifo" 2>/dev/null; then
+if [ -n "$_roster_fifo" ] && [ -n "$_roster_sentinel" ] && [ -n "$_roster_pidfile" ] && mkfifo "$_roster_fifo" 2>/dev/null; then
   _roster_bounded=1
 fi
 
@@ -109,8 +125,23 @@ if [ "$_roster_bounded" = "1" ]; then
   # the child silently took away the records the engine had already written to
   # fd 0. Measured, as every operation failing with "input is invalid".
   exec 9<&0
-  "$node_bin" "$SCRIPT_DIR/roster-sync.mjs" "$operation" "$config" \
-    "$server" "$remote" "$protocol" "$@" <&9 9<&- 3>&- 4>&- 8> "$_roster_fifo" &
+  # The wrapper records the READ CHILD'S pid before waiting on it, because the
+  # thing that has to be stopped on a timeout is the command, not the shell
+  # around it. Signalling the wrapper alone leaves the command orphaned, still
+  # holding this shell's stdout — and a caller that captures output then waits
+  # for an end-of-file that never comes. That is the same "an abandoned child
+  # keeps the caller's streams" defect fixed twice tonight, and it reappeared
+  # here: measured, as a three-second budget that had not returned after
+  # seventeen minutes.
+  {
+    "$node_bin" "$SCRIPT_DIR/roster-sync.mjs" "$operation" "$config" \
+      "$server" "$remote" "$protocol" "$@" <&9 9<&- &
+    _rs_node=$!
+    printf '%s\n' "$_rs_node" > "$_roster_pidfile"
+    _rs_rc=0
+    wait "$_rs_node" || _rs_rc=$?
+    printf '%s\n' "$_rs_rc" > "$_roster_sentinel"
+  } 3>&- 4>&- 8> "$_roster_fifo" &
   _roster_child=$!
   # BOTH COPIES GO. `<&9` duplicates the caller's stdin onto fd 0 and leaves
   # fd 9 open beside it, so node would hold that stream twice and this shell
@@ -119,6 +150,8 @@ if [ "$_roster_bounded" = "1" ]; then
   # fix it (raised in review). The child closes its saved copy in the
   # redirection above; this closes ours the moment it is no longer needed.
   exec 9<&-
+  # The two opens rendezvous: a writer's `8>` does not complete until a reader
+  # arrives, so this cannot be left waiting for a writer that has already gone.
   exec 8< "$_roster_fifo"
   # `|| true` because this file runs under `set -e` and `rm` is an external
   # command: a spawn refused, or a filesystem that will not unlink, would end
@@ -129,39 +162,54 @@ if [ "$_roster_bounded" = "1" ]; then
   # tidiness may not decide whether the lock is held.
   rm -f "$_roster_fifo" || true
 
-  _roster_read_status=0
-  read -r -t "$ROSTER_SYNC_BUDGET_S" _roster_ignored <&8 || _roster_read_status=$?
+  # The read's own status is DELIBERATELY DISCARDED. It cannot be trusted to
+  # separate "the budget expired" from "the writer is gone" on Bash 3.2, and
+  # trusting it there is the defect this replaces.
+  read -r -t "$ROSTER_SYNC_BUDGET_S" _roster_ignored <&8 || true
   exec 8<&-
 
-  if [ "$_roster_read_status" -gt 128 ]; then
-    # The budget expired with the child still holding its end. Stop it, give it
-    # a moment, insist, and REAP it — the lock is not released while the process
+  if [ -s "$_roster_sentinel" ]; then
+    _roster_status="$(cat "$_roster_sentinel" 2>/dev/null || printf '13')"
+    wait "$_roster_child" 2>/dev/null || true
+    rm -f "$_roster_sentinel" "$_roster_pidfile" || true
+    [ "$_roster_status" = "0" ] || exit "$_roster_status"
+  else
+    # No sentinel: the wrapper has not reached its last act. Stop it, give it a
+    # moment, insist, and REAP it — the lock is not released while the process
     # that was writing under it may still be running, because letting the next
     # caller in beside a live writer is worse than the leak being fixed.
+    _roster_inner="$(cat "$_roster_pidfile" 2>/dev/null || true)"
+    if [ -n "$_roster_inner" ]; then
+      kill -TERM "$_roster_inner" 2>/dev/null || true
+    fi
     kill -TERM "$_roster_child" 2>/dev/null || true
     sleep 2
+    if [ -n "$_roster_inner" ]; then
+      kill -KILL "$_roster_inner" 2>/dev/null || true
+    fi
     kill -KILL "$_roster_child" 2>/dev/null || true
     wait "$_roster_child" 2>/dev/null || true
-    # Released here rather than left to the EXIT trap. The trap is the mechanism
-    # that is not reached when a child never returns, and a fix that leans on it
-    # on the one path it exists for is not a fix. It still runs afterwards and
-    # finds nothing to do.
-    agmsg_lock_release
-    echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s; it was stopped and the team lock released" >&2
-    # Stopping between the journal write and the state write leaves the two out
-    # of step. Each is written by rename, so neither is torn — but that the next
-    # run converges from every such point is NOT established, and is recorded on
-    # the issue rather than claimed here.
-    exit 14
+    # Read once more AFTER the reap: a wrapper that was finishing while this
+    # side gave up would otherwise be reported as a timeout it never had.
+    if [ -s "$_roster_sentinel" ]; then
+      _roster_status="$(cat "$_roster_sentinel" 2>/dev/null || printf '13')"
+      rm -f "$_roster_sentinel" "$_roster_pidfile" || true
+      [ "$_roster_status" = "0" ] || exit "$_roster_status"
+    else
+      rm -f "$_roster_sentinel" "$_roster_pidfile" || true
+      # Released here rather than left to the EXIT trap. The trap is the
+      # mechanism that is not reached when a child never returns, and a fix
+      # that leans on it on the one path it exists for is not a fix. It still
+      # runs afterwards and finds nothing to do.
+      agmsg_lock_release
+      echo "agmsg: roster sync $operation failed for team '$team': the local roster child did not finish within ${ROSTER_SYNC_BUDGET_S}s; it was stopped and the team lock released" >&2
+      # Stopping between the journal write and the state write leaves the two
+      # out of step. Each is written by rename, so neither is torn — but that
+      # the next run converges from every such point is NOT established, and is
+      # recorded on the issue rather than claimed here.
+      exit 14
+    fi
   fi
-
-  # End of file: the child is gone, and `wait` gives its status directly.
-  # `|| _roster_status=$?` because this file runs under `set -e` and `wait`
-  # returns the child's code — without it a node exiting 13 would kill this
-  # shell here, before anything below could report why.
-  _roster_status=0
-  wait "$_roster_child" || _roster_status=$?
-  [ "$_roster_status" = "0" ] || exit "$_roster_status"
 else
   # No FIFO — an exotic filesystem, or a temp directory that does not support
   # one. The previous behaviour is what remains: run it in the foreground and

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -20,6 +20,26 @@ protocol="${5:?Missing protocol version}"; shift 5
 config="${AGMSG_SYNC_LOCAL_ROSTER_FILE:-$SKILL_DIR/teams/$team/config.json}"
 team_dir="$(cd "$(dirname "$config")" && pwd)"
 
+ROSTER_SYNC_BUDGET_S="${AGMSG_ROSTER_SYNC_TIMEOUT_S:-120}"
+# A BOUND THAT CANNOT BE READ IS NOT A BOUND. `read -t` rejects a zero, a
+# negative or a non-numeric budget by failing immediately, and its failure is
+# indistinguishable here from "the writer is gone" — so a mistyped setting
+# would turn the ceiling off and leave the wait unbounded, silently, which is
+# the defect this file is closing (raised in review). Checked before anything
+# is started — and before the lock is taken, because refusing after the lock
+# and after `agmsg_roster_ensure` would mean a setting error had already moved
+# the team's state and taken the critical section (raised in review).
+case "$ROSTER_SYNC_BUDGET_S" in
+  ''|*[!0-9]*)
+    echo "agmsg: roster sync $operation failed for team '$team': AGMSG_ROSTER_SYNC_TIMEOUT_S must be a positive whole number of seconds, got '${AGMSG_ROSTER_SYNC_TIMEOUT_S:-}'" >&2
+    exit 15 ;;
+esac
+if [ "$ROSTER_SYNC_BUDGET_S" -le 0 ]; then
+  echo "agmsg: roster sync $operation failed for team '$team': AGMSG_ROSTER_SYNC_TIMEOUT_S must be greater than zero, got '$ROSTER_SYNC_BUDGET_S'" >&2
+  exit 15
+fi
+
+
 agmsg_lock_acquire "$team_dir"
 # agmsg_lock_acquire already installs EXIT cleanup and exit-on-INT/TERM traps.
 # Keep those handlers: replacing them with release-only handlers would let a
@@ -47,25 +67,6 @@ node_bin="${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
 #
 # So the wait has a ceiling, and passing it is a failure with a name rather
 # than a hang. The traps stay as the backup they always were.
-ROSTER_SYNC_BUDGET_S="${AGMSG_ROSTER_SYNC_TIMEOUT_S:-120}"
-# A BOUND THAT CANNOT BE READ IS NOT A BOUND. `read -t` rejects a zero, a
-# negative or a non-numeric budget by failing immediately, and its failure is
-# indistinguishable here from "the writer is gone" — so a mistyped setting
-# would turn the ceiling off and leave the wait unbounded, silently, which is
-# the defect this file is closing (raised in review). Checked before anything
-# is started, and refused by name.
-case "$ROSTER_SYNC_BUDGET_S" in
-  ''|*[!0-9]*)
-    agmsg_lock_release
-    echo "agmsg: roster sync $operation failed for team '$team': AGMSG_ROSTER_SYNC_TIMEOUT_S must be a positive whole number of seconds, got '${AGMSG_ROSTER_SYNC_TIMEOUT_S:-}'" >&2
-    exit 15 ;;
-esac
-if [ "$ROSTER_SYNC_BUDGET_S" -le 0 ]; then
-  agmsg_lock_release
-  echo "agmsg: roster sync $operation failed for team '$team': AGMSG_ROSTER_SYNC_TIMEOUT_S must be greater than zero, got '$ROSTER_SYNC_BUDGET_S'" >&2
-  exit 15
-fi
-
 # THE BOUND ADDS NO PROCESS THAT OUTLIVES THE CALL (#821).
 #
 # The first version put a watchdog beside the child: one more process per

--- a/scripts/internal/roster-sync-driver.sh
+++ b/scripts/internal/roster-sync-driver.sh
@@ -114,12 +114,70 @@ node_bin="${AGMSG_SYNC_NODE_BIN:-${AGMSG_NODE:-node}}"
 _roster_fifo="$(mktemp -u 2>/dev/null)" || _roster_fifo=""
 _roster_sentinel="$(mktemp 2>/dev/null)" || _roster_sentinel=""
 _roster_pidfile="$(mktemp 2>/dev/null)" || _roster_pidfile=""
-_roster_bounded=0
-if [ -n "$_roster_fifo" ] && [ -n "$_roster_sentinel" ] && [ -n "$_roster_pidfile" ] && mkfifo "$_roster_fifo" 2>/dev/null; then
-  _roster_bounded=1
+
+# FAILING TO BUILD THE BOUND MUST NOT RUN WITHOUT ONE (raised by three
+# reviewers, and they are right).
+#
+# This used to fall back to the foreground, unbounded call — the exact state
+# #821 forbids — and printed `running without a time bound` while doing it.
+# That is not a fallback. "The instrument could not be built, so the property
+# is dropped" reproduces the defect on precisely the machines least able to
+# afford it: a temp directory that is full or unwritable is the same condition
+# that makes a child hang, so the two arrive together.
+#
+# There are two ways to wait with a ceiling, and only the faster one needs a
+# FIFO:
+#
+#   fifo  a blocking read on a descriptor the wrapper holds. No polling, so no
+#         spawn while waiting — which is why it is preferred on a machine that
+#         is refusing spawns.
+#   poll  the sentinel is looked for on a timer. Costs one `sleep` per second
+#         of waiting, and needs nothing but the two temp files.
+#
+# Both bound the wait. Only when even `mktemp` fails is there no bound to be
+# had, and then this REFUSES: releases the lock and says why, rather than
+# taking the critical section for an unlimited time.
+_roster_wait=none
+if [ -n "$_roster_sentinel" ] && [ -n "$_roster_pidfile" ]; then
+  if [ -n "$_roster_fifo" ] && mkfifo "$_roster_fifo" 2>/dev/null; then
+    _roster_wait=fifo
+  else
+    _roster_fifo=""
+    _roster_wait=poll
+  fi
 fi
 
-if [ "$_roster_bounded" = "1" ]; then
+# THE WAY OUT, because a refusal with no override is a wall. An operator who
+# knows their filesystem cannot hold a temp file, and would rather risk the
+# lock than not sync at all, can say so — deliberately, by name, in the
+# environment. What is removed is the SILENT return to the old behaviour.
+if [ "$_roster_wait" = "none" ] && [ "${AGMSG_ROSTER_SYNC_UNBOUNDED:-0}" = "1" ]; then
+  echo "agmsg: roster sync $operation for team '$team': AGMSG_ROSTER_SYNC_UNBOUNDED=1 — running the local roster child with NO time bound; if it hangs it holds the team lock until this process is killed" >&2
+  "$node_bin" "$SCRIPT_DIR/roster-sync.mjs" "$operation" "$config" \
+    "$server" "$remote" "$protocol" "$@"
+  case "$operation" in
+    reconcile|apply) agmsg_roster_project_config "$team_dir" "$config" ;;
+  esac
+  exit 0
+fi
+
+if [ "$_roster_wait" = "none" ]; then
+  agmsg_lock_release
+  echo "agmsg: roster sync $operation failed for team '$team': cannot create the temporary files needed to bound the local roster child (is TMPDIR set to a path that exists and is writable, and is the filesystem full?); refusing rather than holding the team lock for an unlimited time. To run it anyway, set AGMSG_ROSTER_SYNC_UNBOUNDED=1." >&2
+  exit 16
+fi
+
+# One spawn, whichever wait follows: when there is no FIFO the wrapper's fd 8
+# goes to /dev/null, so the line that starts the child is the same in both
+# modes and its descriptor closing cannot drift between them.
+_roster_write_target="/dev/null"
+if [ "$_roster_wait" = "fifo" ]; then
+  _roster_write_target="$_roster_fifo"
+fi
+
+# Both remaining modes are bounded; `none` has already left, one way or the
+# other. The block is kept so the two waits sit inside one spawn/teardown.
+if [ "$_roster_wait" != "none" ]; then
   # fd 9 is this shell's stdin, kept for the child: a shell with job control
   # off gives an asynchronous command /dev/null for stdin, and backgrounding
   # the child silently took away the records the engine had already written to
@@ -156,7 +214,7 @@ if [ "$_roster_bounded" = "1" ]; then
     _rs_rc=0
     wait "$_rs_node" || _rs_rc=$?
     printf '%s\n' "$_rs_rc" > "$_roster_sentinel"
-  } 3>&- 4>&- 8> "$_roster_fifo" &
+  } 3>&- 4>&- 8> "$_roster_write_target" &
   _roster_child=$!
   # BOTH COPIES GO. `<&9` duplicates the caller's stdin onto fd 0 and leaves
   # fd 9 open beside it, so node would hold that stream twice and this shell
@@ -165,23 +223,44 @@ if [ "$_roster_bounded" = "1" ]; then
   # fix it (raised in review). The child closes its saved copy in the
   # redirection above; this closes ours the moment it is no longer needed.
   exec 9<&-
-  # The two opens rendezvous: a writer's `8>` does not complete until a reader
-  # arrives, so this cannot be left waiting for a writer that has already gone.
-  exec 8< "$_roster_fifo"
-  # `|| true` because this file runs under `set -e` and `rm` is an external
-  # command: a spawn refused, or a filesystem that will not unlink, would end
-  # this shell HERE — while the child is still running — and the EXIT trap
-  # would release the lock beside a live writer. That is worse than the leak
-  # being fixed, and it is the one place this fix could create it (raised in
-  # review). The FIFO is already open on fd 8; unlinking it is tidiness, and
-  # tidiness may not decide whether the lock is held.
-  rm -f "$_roster_fifo" || true
+  if [ "$_roster_wait" = "fifo" ]; then
+    # The two opens rendezvous: a writer's `8>` does not complete until a reader
+    # arrives, so this cannot be left waiting for a writer that has already gone.
+    exec 8< "$_roster_fifo"
+    # `|| true` because this file runs under `set -e` and `rm` is an external
+    # command: a spawn refused, or a filesystem that will not unlink, would end
+    # this shell HERE — while the child is still running — and the EXIT trap
+    # would release the lock beside a live writer. That is worse than the leak
+    # being fixed, and it is the one place this fix could create it (raised in
+    # review). The FIFO is already open on fd 8; unlinking it is tidiness, and
+    # tidiness may not decide whether the lock is held.
+    rm -f "$_roster_fifo" || true
 
-  # The read's own status is DELIBERATELY DISCARDED. It cannot be trusted to
-  # separate "the budget expired" from "the writer is gone" on Bash 3.2, and
-  # trusting it there is the defect this replaces.
-  read -r -t "$ROSTER_SYNC_BUDGET_S" _roster_ignored <&8 || true
-  exec 8<&-
+    # The read's own status is DELIBERATELY DISCARDED. It cannot be trusted to
+    # separate "the budget expired" from "the writer is gone" on Bash 3.2, and
+    # trusting it there is the defect this replaces.
+    read -r -t "$ROSTER_SYNC_BUDGET_S" _roster_ignored <&8 || true
+    exec 8<&-
+  else
+    # NO FIFO, AND STILL BOUNDED. The wrapper's fd 8 went to /dev/null, so
+    # there is nothing to read; what is watched instead is the sentinel the
+    # wrapper writes as its last act — the same fact, asked on a timer rather
+    # than by blocking.
+    #
+    # `-s` and not `-e`: the file was created empty by `mktemp`, so its mere
+    # existence says nothing. It is non-empty exactly once the status is in it.
+    #
+    # The cost is one `sleep` per second of waiting, and that is why this is
+    # the second choice rather than the only one — on a machine refusing
+    # spawns, a wait that spawns is the wrong shape. It is still the right
+    # trade against no bound at all.
+    #
+    # `SECONDS` is the shell's own counter, so the deadline needs no `date`.
+    _roster_deadline=$((SECONDS + ROSTER_SYNC_BUDGET_S))
+    while [ ! -s "$_roster_sentinel" ] && [ "$SECONDS" -lt "$_roster_deadline" ]; do
+      sleep 1
+    done
+  fi
 
   if [ -s "$_roster_sentinel" ]; then
     _roster_status="$(cat "$_roster_sentinel" 2>/dev/null || printf '13')"
@@ -225,14 +304,6 @@ if [ "$_roster_bounded" = "1" ]; then
       exit 14
     fi
   fi
-else
-  # No FIFO — an exotic filesystem, or a temp directory that does not support
-  # one. The previous behaviour is what remains: run it in the foreground and
-  # wait as long as it takes. Stated rather than silently degraded, because a
-  # bound that is sometimes absent is worse documentation than none.
-  echo "agmsg: roster sync $operation for team '$team': cannot create a FIFO in the temp directory; running without a time bound" >&2
-  "$node_bin" "$SCRIPT_DIR/roster-sync.mjs" "$operation" "$config" \
-    "$server" "$remote" "$protocol" "$@"
 fi
 
 case "$operation" in

--- a/scripts/lib/roster-journal.sh
+++ b/scripts/lib/roster-journal.sh
@@ -406,20 +406,25 @@ agmsg_roster_argv_is_ours() {
   local cmdline="$1" script="$2" operation="$3" config="$4"
   [ -n "$cmdline" ] && [ -n "$script" ] && [ -n "$operation" ] && [ -n "$config" ] || return 1
 
-  # QUOTES COME OFF FIRST. A native Windows command line quotes any argument
-  # containing a space, so `compat_get_cmdline` can return
-  #   "C:/Users/First Last/.../roster-sync.mjs" reconcile "C:/Users/.../config.json"
-  # and an unquoted needle never matches it — the real child then reads as
-  # unknown and its lock is kept (raised in review). Removing the quote
-  # characters cannot merge two arguments: the space that separated them is
-  # still there.
-  local haystack=" ${cmdline//\"/} "
-
-  # BOTH ALPHABETS. The shell's `/c/Users/...` and a native process's
-  # `C:/Users/...` are the same path written differently, and `cygpath -m` is
-  # the conversion `agmsg_cmdline_names_path` uses for it. It is applied to
-  # the PARTS, because the needle is composed from them — handing a whole
-  # sentence to a path converter would not do what it says.
+  # QUOTES ARE A BOUNDARY, NOT DECORATION — AND DELETING THEM DESTROYS ONE
+  # (raised in review, after an earlier version of this did exactly that).
+  #
+  # A native Windows command line quotes any argument containing a space, so
+  # `compat_get_cmdline` can return
+  #   "C:/Users/First Last/.../roster-sync.mjs" reconcile "C:/.../config.json"
+  # and an unquoted needle never matches it. The first fix stripped every `"`
+  # from the haystack. That is worse than it looks: it is true that the space
+  # between two arguments survives, but a quote also carries "the spaces INSIDE
+  # me are not argument separators". Strip it and
+  #   node other.js --note "<script> reconcile <config>"
+  # — one quoted data argument that merely CONTAINS the triple — becomes
+  # indistinguishable from a real invocation, and a stranger picked up through
+  # pid reuse would be signalled.
+  #
+  # So the quotes stay, and the FORMS the shell can legitimately produce are
+  # enumerated instead: either path may or may not be quoted, and the quote
+  # then sits outside the argument, where the boundary space still has to be.
+  local haystack=" $cmdline "
   local script_win="" config_win=""
   if command -v cygpath >/dev/null 2>&1; then
     script_win="$(cygpath -m "$script" 2>/dev/null || true)"
@@ -434,6 +439,11 @@ agmsg_roster_argv_is_ours() {
   # absolute script path is a tail of `/x/opt/.../roster-sync.mjs`. Padding
   # the haystack lets one pattern require both boundaries, including for an
   # argument at either end of the line.
+  #
+  # FOUR ACCEPTED FORMS PER PAIR, because either path may arrive quoted and
+  # they are quoted independently — a path with a space in it is quoted, one
+  # without it is not, and the two paths need not agree. The quote goes where
+  # the shell puts it: around the argument, INSIDE the boundary spaces.
   local s c
   for s in "$script" "$script_win"; do
     [ -n "$s" ] || continue
@@ -441,6 +451,9 @@ agmsg_roster_argv_is_ours() {
       [ -n "$c" ] || continue
       case "$haystack" in
         *" $s $operation $c "*) return 0 ;;
+        *" \"$s\" $operation \"$c\" "*) return 0 ;;
+        *" \"$s\" $operation $c "*) return 0 ;;
+        *" $s $operation \"$c\" "*) return 0 ;;
       esac
     done
   done

--- a/scripts/lib/roster-journal.sh
+++ b/scripts/lib/roster-journal.sh
@@ -386,3 +386,63 @@ agmsg_roster_project_config() {
   fi
   agmsg_write_atomic "$config" "$updated"
 }
+
+# agmsg_roster_argv_is_ours <cmdline> <script-path> <operation> <config-path>
+#
+# "Is this command line the roster-sync run I started?" — the whole question,
+# in one place, callable.
+#
+# IT LIVES HERE SO IT CAN BE DRIVEN DIRECTLY. It began inside
+# `roster-sync-driver.sh`, where the only way to reach it was to run the
+# driver — so its cases ended up re-implementing the comparison in the test
+# file and asserting on the driver with `grep`. That measures a copy and the
+# spelling of the original, never the original itself (raised in review).
+#
+# The answer must be conservative in ONE direction. A false "yes" sends TERM
+# and KILL to a process that is not ours; a false "no" leaves a lock held and
+# reported. So every widening below is deliberate and bounded, and anything
+# unrecognised is "no".
+agmsg_roster_argv_is_ours() {
+  local cmdline="$1" script="$2" operation="$3" config="$4"
+  [ -n "$cmdline" ] && [ -n "$script" ] && [ -n "$operation" ] && [ -n "$config" ] || return 1
+
+  # QUOTES COME OFF FIRST. A native Windows command line quotes any argument
+  # containing a space, so `compat_get_cmdline` can return
+  #   "C:/Users/First Last/.../roster-sync.mjs" reconcile "C:/Users/.../config.json"
+  # and an unquoted needle never matches it — the real child then reads as
+  # unknown and its lock is kept (raised in review). Removing the quote
+  # characters cannot merge two arguments: the space that separated them is
+  # still there.
+  local haystack=" ${cmdline//\"/} "
+
+  # BOTH ALPHABETS. The shell's `/c/Users/...` and a native process's
+  # `C:/Users/...` are the same path written differently, and `cygpath -m` is
+  # the conversion `agmsg_cmdline_names_path` uses for it. It is applied to
+  # the PARTS, because the needle is composed from them — handing a whole
+  # sentence to a path converter would not do what it says.
+  local script_win="" config_win=""
+  if command -v cygpath >/dev/null 2>&1; then
+    script_win="$(cygpath -m "$script" 2>/dev/null || true)"
+    config_win="$(cygpath -m "$config" 2>/dev/null || true)"
+  fi
+
+  # THE ORDERED TRIPLE, WITH ARGUMENT BOUNDARIES. Three separate `contains`
+  # checks are three questions, and a command line carrying a different
+  # operation and a different config satisfies all three at once. And an
+  # ordered substring is still a substring: without the surrounding spaces,
+  # `/teams/demo/config.json` matches a run using `config.json.bak`, and our
+  # absolute script path is a tail of `/x/opt/.../roster-sync.mjs`. Padding
+  # the haystack lets one pattern require both boundaries, including for an
+  # argument at either end of the line.
+  local s c
+  for s in "$script" "$script_win"; do
+    [ -n "$s" ] || continue
+    for c in "$config" "$config_win"; do
+      [ -n "$c" ] || continue
+      case "$haystack" in
+        *" $s $operation $c "*) return 0 ;;
+      esac
+    done
+  done
+  return 1
+}

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -438,7 +438,10 @@ _roster_state_digest() {
 
   local before; before="$(_roster_state_digest "$team_dir")"
   local bad
-  for bad in 0 -1 abc 1.5; do
+  # The last is all digits and still unusable: `[ "$x" -le 0 ]` on it is beyond
+  # the shell's integers and errors, which under `set -e` would end the script
+  # with no sentence at all — a silent refusal, which is the thing being fixed.
+  for bad in 0 -1 abc 1.5 999999999999999999999999999999; do
     rm -f "$ran"
     run env AGMSG_TEST_RAN="$ran" AGMSG_SYNC_NODE_BIN="$fake" \
       AGMSG_ROSTER_SYNC_TIMEOUT_S="$bad" \
@@ -559,4 +562,44 @@ _roster_state_digest() {
   [ -n "$check_at" ]
   [ -n "$lock_at" ]
   [ "$check_at" -lt "$lock_at" ]
+}
+
+@test "an unusable timeout is refused without waiting for the lock (#821)" {
+  # THE ORDER, MEASURED — not read.
+  #
+  # A held lock is what makes the two orders observably different: validating
+  # first refuses at once, validating after `agmsg_lock_acquire` spends the
+  # whole lock budget and then reports a lock timeout instead. Without a holder
+  # both orders look identical from outside, which is why the first attempt at
+  # this control could not discriminate and the property was asserted
+  # structurally.
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo" ran="$TEST_SKILL_DIR/child-ran2"
+  local fake="$TEST_SKILL_DIR/fake-node-records2"
+  printf '%s\n' '#!/usr/bin/env bash' ': > "$AGMSG_TEST_RAN"' 'exit 0' > "$fake"
+  chmod +x "$fake"
+
+  # Somebody else holds it. Made by hand rather than by another driver: what
+  # matters is that the directory is there, which is exactly what the lock is.
+  mkdir -p "$team_dir/.config.lock"
+
+  local began=$SECONDS
+  run env AGMSG_TEST_RAN="$ran" AGMSG_SYNC_NODE_BIN="$fake" \
+    AGMSG_LOCK_SECONDS=10 AGMSG_ROSTER_SYNC_TIMEOUT_S=0 \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+  local took=$((SECONDS - began))
+
+  [ "$status" -ne 0 ]
+  # The SETTING is what it complains about, not the lock: reaching the lock at
+  # all means the check ran too late.
+  printf '%s' "$output" | grep -q 'AGMSG_ROSTER_SYNC_TIMEOUT_S'
+  refute grep -q 'timed out acquiring registry lock' <<<"$output"
+  # And it did not spend the lock budget getting there.
+  [ "$took" -lt 5 ]
+  [ ! -e "$ran" ]
+  # Someone else's lock is still theirs.
+  [ -d "$team_dir/.config.lock" ]
+  rmdir "$team_dir/.config.lock"
 }

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -918,7 +918,7 @@ EOF
 
   [ "$driver_status" -eq 18 ]
   # It says TERM WENT OUT...
-  printf '%s' "$driver_out" | grep -q 'TERM WAS SENT'
+  printf '%s' "$driver_out" | grep -q 'TERM was ATTEMPTED'
   # ...and that KILL was withheld once the number stopped being identifiable.
   printf '%s' "$driver_out" | grep -q 'WITHHELD'
   # ...and it does NOT claim nothing was signalled, which is the false
@@ -929,7 +929,7 @@ EOF
   # assertion incapable of failing -- exactly the class this PR is about.
   # `.github/scripts/check-enforced-assertions.sh` caught it; the baseline
   # went 638 -> 639 and named the line.
-  run bash -c 'printf "%s" "$1" | grep -q "Nothing was signalled"' _ "$driver_out"
+  run bash -c 'printf "%s" "$1" | grep -q "No signal was attempted"' _ "$driver_out"
   [ "$status" -ne 0 ]
   [ -d "$team_dir/.config.lock" ]
 
@@ -937,6 +937,102 @@ EOF
   # message: the child is still alive. It ignores nothing -- it has no KILL
   # handler and could not have one -- so its survival is the evidence.
   kill -0 "$(pgrep -f "$fake" | head -1)" 2>/dev/null
+
+  local leftover
+  leftover="$(pgrep -f "$fake" || true)"
+  if [ -n "$leftover" ]; then
+    kill $leftover 2>/dev/null || true
+    sleep 1
+    kill -9 $leftover 2>/dev/null || true
+  fi
+  rmdir "$team_dir/.config.lock" 2>/dev/null || true
+}
+
+@test "a number once judged not ours is not re-adopted for KILL (#821)" {
+  skip_on_windows "POSIX signal semantics are not supported by this test"
+  # THE OTHER DIRECTION OF THE TRANSITION, and it is a safety hole rather
+  # than a reporting one (raised in review).
+  #
+  # The predicate is re-asked before TERM and again before KILL, so a number
+  # can read `unknown` at the first and `ours` at the second -- recycling, or
+  # an instrument that failed once and recovered. The old code then sent KILL
+  # to a number it had just refused to send TERM to: escalating against
+  # something it had never established a claim on. Escalation is monotone now.
+  #
+  # Driven by CALL COUNT rather than by a timer, so there is no race: the
+  # `ps -o args=` stub answers with a decoy on its first call and truthfully
+  # after. The first call is the one before TERM.
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  local config="$team_dir/config.json"
+  local member_id fake shimdir made calls
+  member_id="$(config_field "$config" '$.agents.alice.member_id')"
+  source "$SCRIPTS/lib/roster-journal.sh"
+  agmsg_roster_append_left "$team_dir" "$member_id" alice "2026-01-01T00:00:00Z"
+
+  made="$TEST_SKILL_DIR/mktemp-made-readopt"
+  calls="$TEST_SKILL_DIR/ps-args-calls"
+  shimdir="$TEST_SKILL_DIR/shim-readopt"
+  mkdir -p "$shimdir"
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'out=$(/usr/bin/mktemp "$@") || exit 1'
+    printf '%s\n' '[ -e "$out" ] && printf "%s\\n" "$out" >> "$AGMSG_TEST_MKTEMP_MADE"'
+    printf '%s\n' 'printf "%s\\n" "$out"'
+  } > "$shimdir/mktemp"
+  chmod +x "$shimdir/mktemp"
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'if [ "$1" = "-o" ] && [ "$2" = "args=" ]; then'
+    printf '%s\n' '  n=$(cat "$AGMSG_TEST_PS_CALLS" 2>/dev/null || echo 0)'
+    printf '%s\n' '  n=$((n + 1)); printf %s "$n" > "$AGMSG_TEST_PS_CALLS"'
+    printf '%s\n' '  if [ "$n" -eq 1 ]; then'
+    printf '%s\n' '    printf "%s\\n" "some-unrelated-process --before-recycle"'
+    printf '%s\n' '    exit 0'
+    printf '%s\n' '  fi'
+    printf '%s\n' 'fi'
+    printf '%s\n' 'exec /bin/ps "$@"'
+  } > "$shimdir/ps"
+  chmod +x "$shimdir/ps"
+
+  fake="$TEST_SKILL_DIR/fake-node-readopt"
+  cat > "$fake" <<'EOF'
+#!/usr/bin/env bash
+exec >/dev/null 2>&1
+trap '' TERM
+while :; do sleep 1; done
+EOF
+  chmod +x "$fake"
+
+  run env PATH="$shimdir:$PATH" AGMSG_SYNC_NODE_BIN="$fake" \
+    AGMSG_TEST_MKTEMP_MADE="$made" AGMSG_TEST_PS_CALLS="$calls" \
+    AGMSG_ROSTER_SYNC_TIMEOUT_S=3 \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+
+  local driver_status="$status" driver_out="$output"
+
+  # POSITIVE CONTROL ON THE INSTRUMENT: the stub was consulted more than once,
+  # so the run really did ask before TERM and again afterwards. With a single
+  # call this would be an ordinary never-identifiable timeout and would prove
+  # nothing about re-adoption.
+  [ "$(cat "$calls" 2>/dev/null || echo 0)" -ge 2 ]
+
+  # THE CHILD IS STILL ALIVE. It ignores TERM, but nothing can ignore KILL --
+  # so its survival is the measurement that no KILL was sent to it. This is
+  # the assertion the finding is about.
+  local alive
+  alive="$(pgrep -f "$fake" | head -1 || true)"
+  [ -n "$alive" ]
+  kill -0 "$alive" 2>/dev/null
+
+  # And the diagnostic does not claim a signal it never attempted.
+  printf '%s' "$driver_out" | grep -q 'No signal was attempted'
+  [ -d "$team_dir/.config.lock" ]
+  # 17: alive and identifiable by the time the decision is taken. Not 14,
+  # which would mean the lock came off beside it.
+  [ "$driver_status" -eq 17 ]
 
   local leftover
   leftover="$(pgrep -f "$fake" || true)"

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -765,20 +765,62 @@ EOF
     "source '$SCRIPTS/lib/compat.sh'; agmsg_cmdline_names_path '$native_cmd' '$other'"
   [ "$status" -ne 0 ]
 
-  # AND THE DRIVER MUST ACTUALLY USE IT. Everything above measures the
-  # comparator; none of it would notice the driver going back to a raw
-  # comparison, and that is precisely the regression to guard -- measured, by
-  # reverting the driver to `case` and watching every assertion above stay
-  # green. There is no Windows here to catch it behaviourally, so the driver's
-  # side is asserted where it lives.
+  # AND THE DRIVER MUST ACTUALLY USE THE CONVERSION. Everything above measures
+  # the comparator; none of it would notice the driver going back to a raw
+  # comparison -- measured, by reverting the driver and watching every
+  # assertion above stay green. There is no Windows here to catch that
+  # behaviourally, so the driver's side is asserted where it lives.
   local sh="$SCRIPTS/internal/roster-sync-driver.sh"
-  # It calls the comparator for both paths...
-  grep -q 'agmsg_cmdline_names_path "\$cmd" "\$SCRIPT_DIR/roster-sync.mjs"' "$sh"
-  grep -q 'agmsg_cmdline_names_path "\$cmd" "\$config"' "$sh"
-  # ...and nowhere matches a shell-side path against the cmdline directly,
-  # which is the shape that is blind on Windows.
+  grep -q 'cygpath -m' "$sh"
+  # THE ORDERED TRIPLE, not three separate sightings. `<script> <operation>
+  # <config>` has to appear as one run of text, because a cmdline carrying a
+  # different operation and a different config can satisfy three independent
+  # `contains` checks at once.
+  grep -q '\*"\$s \$operation \$c"\*' "$sh"
+  # And no shell-side path is matched against the cmdline directly.
   run grep -nE 'case "\$cmd" in.*\$(SCRIPT_DIR|config)' "$sh"
   [ "$status" -ne 0 ]
+}
+
+@test "the argv match is a sequence, not three sightings (#821)" {
+  # TWO EXISTENCE CHECKS ARE NOT A RELATION (raised in review).
+  #
+  # The predicate used to ask three separate questions: does the cmdline
+  # contain the script path, does it contain this config, does it contain this
+  # operation anywhere. A command line can satisfy all three while being a
+  # DIFFERENT run -- the operation supplied by one part of it and the config by
+  # another. This drives exactly that shape.
+  #
+  # The driver's own predicate is not reachable from here without running it,
+  # so the composition is measured on the same text the driver builds: the
+  # ordered needle must reject this cmdline, and the three loose checks must
+  # each accept it. That contrast is the whole finding.
+  local script="/opt/agmsg/scripts/internal/roster-sync.mjs"
+  local conf="/opt/agmsg/teams/demo/config.json"
+  local other="/opt/agmsg/teams/other/config.json"
+  local operation="reconcile"
+
+  # A real command line for a DIFFERENT run: `apply` on another team's config,
+  # with the word `reconcile` present for an unrelated reason.
+  local decoy="node $script apply $other --note reconcile "
+
+  # The three loose checks all say yes -- this is the premise, and without it
+  # the assertion below would prove nothing.
+  case "$decoy" in *"$script"*) : ;; *) return 1 ;; esac
+  case "$decoy" in *"$other"*) : ;; *) return 1 ;; esac
+  case "$decoy" in *" $operation "*) : ;; *) return 1 ;; esac
+
+  # The ordered needle says no, for this team's config...
+  run bash -c "case \"$decoy\" in *\"$script $operation $conf\"*) exit 0 ;; esac; exit 1"
+  [ "$status" -ne 0 ]
+  # ...and for the other team's too, because the OPERATION does not line up.
+  run bash -c "case \"$decoy\" in *\"$script $operation $other\"*) exit 0 ;; esac; exit 1"
+  [ "$status" -ne 0 ]
+
+  # Positive control: the needle does match the run it describes.
+  local real="node $script $operation $conf"
+  run bash -c "case \"$real\" in *\"$script $operation $conf\"*) exit 0 ;; esac; exit 1"
+  [ "$status" -eq 0 ]
 }
 
 @test "a recycled pid is neither signalled nor read as gone (#821)" {

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -557,6 +557,86 @@ EOF
   refute pgrep -f "$fake"
 }
 
+@test "an unusable pidfile is not read as a child that exited (#821)" {
+  skip_on_windows "POSIX signal semantics are not supported by this test"
+  # THE OTHER HALF OF "UNKNOWN", and it was the one the code got wrong for
+  # longest. With no usable pid there is nothing to ask about -- which is
+  # exactly why it must not be read as "the child exited". The wrapper writes
+  # that number before it waits, so an empty or garbled pidfile means the
+  # wrapper did not get that far, and whether node is running is unknown.
+  #
+  # The earlier versions cleared the variable and let the predicate return
+  # false, which every caller read as "gone" and released on. Mutating
+  # `unknown` back to `gone` for this branch left every other case green --
+  # measured -- which is what this case is here for.
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  local config="$team_dir/config.json"
+  local member_id fake shimdir made substituted
+  member_id="$(config_field "$config" '$.agents.alice.member_id')"
+  source "$SCRIPTS/lib/roster-journal.sh"
+  agmsg_roster_append_left "$team_dir" "$member_id" alice "2026-01-01T00:00:00Z"
+
+  made="$TEST_SKILL_DIR/mktemp-made-garbled"
+  substituted="$TEST_SKILL_DIR/pidfile-garbled"
+  shimdir="$TEST_SKILL_DIR/shim-garbled"
+  mkdir -p "$shimdir"
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'out=$(/usr/bin/mktemp "$@") || exit 1'
+    printf '%s\n' '[ -e "$out" ] && printf "%s\\n" "$out" >> "$AGMSG_TEST_MKTEMP_MADE"'
+    printf '%s\n' 'printf "%s\\n" "$out"'
+  } > "$shimdir/mktemp"
+  chmod +x "$shimdir/mktemp"
+
+  # Not empty but UNPARSEABLE, so the file still passes `-s` and the refusal
+  # has to come from reading the contents rather than from the file's size.
+  fake="$TEST_SKILL_DIR/fake-node-garbles-pidfile"
+  cat > "$fake" <<'EOF'
+#!/usr/bin/env bash
+exec >/dev/null 2>&1
+trap '' TERM
+( i=0
+  while [ "$i" -lt 25 ]; do
+    pidfile="$(sed -n '2p' "$AGMSG_TEST_MKTEMP_MADE" 2>/dev/null)"
+    if [ -n "$pidfile" ] && [ -s "$pidfile" ]; then
+      printf 'not-a-pid\n' > "$pidfile"
+      printf 'garbled\n' > "$AGMSG_TEST_SUBSTITUTED"
+    fi
+    i=$((i + 1))
+    sleep 0.1
+  done
+) &
+while :; do sleep 1; done
+EOF
+  chmod +x "$fake"
+
+  run env PATH="$shimdir:$PATH" AGMSG_SYNC_NODE_BIN="$fake" \
+    AGMSG_TEST_MKTEMP_MADE="$made" AGMSG_TEST_SUBSTITUTED="$substituted" \
+    AGMSG_ROSTER_SYNC_TIMEOUT_S=4 \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+
+  local driver_status="$status" driver_out="$output"
+  # POSITIVE CONTROL: the garbling must have happened, or this is measuring an
+  # ordinary timeout that reached the same branch for a different reason.
+  [ "$(cat "$substituted" 2>/dev/null || true)" = "garbled" ]
+
+  [ "$driver_status" -eq 18 ]
+  printf '%s' "$driver_out" | grep -q 'could not be established'
+  [ -d "$team_dir/.config.lock" ]
+
+  local leftover
+  leftover="$(pgrep -f "$fake" || true)"
+  if [ -n "$leftover" ]; then
+    kill $leftover 2>/dev/null || true
+    sleep 1
+    kill -9 $leftover 2>/dev/null || true
+  fi
+  rmdir "$team_dir/.config.lock" 2>/dev/null || true
+}
+
 @test "a recycled pid is neither signalled nor read as gone (#821)" {
   skip_on_windows "POSIX signal semantics are not supported by this test"
   # "I SENT A SIGNAL" IS NOT "THE PROCESS IS GONE" (raised as BLOCKING).

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -540,3 +540,23 @@ _roster_state_digest() {
   [ -n "$close_at" ]
   [ "$close_at" -gt "$spawn_at" ]
 }
+
+@test "the timeout setting is validated before the lock is taken (#821)" {
+  # WHY THIS IS STRUCTURAL, having tried the other way: moving the validation
+  # back after `agmsg_lock_acquire` and `agmsg_roster_ensure` leaves every
+  # behavioural assertion green. The refusal still releases the lock, and
+  # `agmsg_roster_ensure` is idempotent, so "the team's state is unchanged"
+  # cannot tell the two orders apart. Measured — that mutation was run and
+  # stayed green.
+  #
+  # What the order buys is that a setting error never takes the critical
+  # section at all, which matters on a machine where taking it is the risky
+  # part. So the order is asserted where it lives, with both anchors required
+  # to exist so this cannot pass by finding nothing.
+  local sh="$SCRIPTS/internal/roster-sync-driver.sh" check_at lock_at
+  check_at="$(grep -n 'AGMSG_ROSTER_SYNC_TIMEOUT_S must be a positive' "$sh" | head -1 | cut -d: -f1)"
+  lock_at="$(grep -n '^agmsg_lock_acquire "\$team_dir"$' "$sh" | head -1 | cut -d: -f1)"
+  [ -n "$check_at" ]
+  [ -n "$lock_at" ]
+  [ "$check_at" -lt "$lock_at" ]
+}

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -365,3 +365,47 @@ EOS
   # And the roster is exactly as it was.
   [ "$(config_field "$config" '$.agents.alice.member_id')" = "$before" ]
 }
+
+@test "roster sync bounds a local child that never finishes, and releases the lock (#817)" {
+  skip_on_windows "POSIX signal delivery is not supported by this test"
+  # THE CASE THE FIELD REPORT DESCRIBES, made deterministic: a child that
+  # neither runs to completion nor lets the shell exit. Release used to be the
+  # EXIT trap alone, which is sound when this shell reaches its own exit — a
+  # child that fails to launch or exits non-zero still gets there — and not
+  # sound here. The shell waits, the trap never runs, and `.config.lock` is
+  # held by a live process that will never finish. The next start then fails on
+  # `File exists`, and the team is unusable.
+  #
+  # The fake IGNORES TERM, so the grace period and the KILL are exercised too;
+  # a fake that exits on TERM would leave the harder half of the path untested.
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  local config="$team_dir/config.json"
+  local member_id fake status=0
+  member_id="$(config_field "$config" '$.agents.alice.member_id')"
+  source "$SCRIPTS/lib/roster-journal.sh"
+  agmsg_roster_append_left "$team_dir" "$member_id" alice "2026-01-01T00:00:00Z"
+
+  fake="$TEST_SKILL_DIR/fake-node-unkillable"
+  cat > "$fake" <<'EOF'
+#!/usr/bin/env bash
+trap '' TERM
+while :; do sleep 1; done
+EOF
+  chmod +x "$fake"
+
+  run env AGMSG_SYNC_NODE_BIN="$fake" AGMSG_ROSTER_SYNC_TIMEOUT_S=2 \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+
+  # A bounded FAILURE, not a hang and not a success.
+  [ "$status" -ne 0 ]
+  printf '%s' "$output" | grep -q 'did not finish within'
+  # And the lock is gone, which is the whole point: the next start must not
+  # meet `.config.lock: File exists` left by a process that is no longer there.
+  [ ! -d "$team_dir/.config.lock" ]
+  # The child is gone as well — released after the reap, never beside a live
+  # writer.
+  refute pgrep -f "$fake"
+}

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -557,7 +557,7 @@ EOF
   refute pgrep -f "$fake"
 }
 
-@test "the lock is KEPT when the inner child cannot be confirmed gone (#821)" {
+@test "a recycled pid is neither signalled nor read as gone (#821)" {
   skip_on_windows "POSIX signal semantics are not supported by this test"
   # "I SENT A SIGNAL" IS NOT "THE PROCESS IS GONE" (raised as BLOCKING).
   #
@@ -566,13 +566,20 @@ EOF
   # rested on nothing: a refused signal, and the lock came off beside a live
   # writer.
   #
-  # DRIVING IT NEEDED A PROCESS THE DRIVER CANNOT KILL, and SIGKILL cannot be
-  # ignored -- it is refused only under EPERM or an uninterruptible wait. So
-  # the case uses EPERM, which is the realistic half anyway (a sandbox that
-  # will not let us signal, #505): it makes the recorded pid **1**, which no
-  # ordinary user may signal. `kill -0 1` answers `Operation not permitted`,
-  # and `_agmsg_pid_alive_local` reads every non-ESRCH failure as alive --
-  # which is the conservative direction this gate needs.
+  # AND A NUMBER IN A FILE IS NOT AN IDENTITY. A pid is recycled the moment
+  # its process is reaped, so the number the wrapper wrote can belong to
+  # something else by the time the timeout path reads it. The earlier version
+  # sent TERM and then KILL to whatever it said.
+  #
+  # So the case makes the recorded pid **1** -- alive, certainly not ours, and
+  # not signallable by an ordinary user. That is one substitution standing in
+  # for both hazards: a recycled number, and (through EPERM) a process this
+  # process may not touch.
+  #
+  # What it must produce is the UNKNOWN outcome: pid 1 not signalled, our own
+  # child's fate undetermined, and therefore the lock kept. Reading it as
+  # "gone" would release on an answer never obtained; reading it as "still
+  # ours" would mean the driver had adopted a stranger.
   #
   # Nothing in the driver is stubbed. The pidfile is a real file whose path
   # the `mktemp` shim already reports, and the fake node overwrites it the way
@@ -613,17 +620,29 @@ EOF
 # measures the lock and nothing else.
 exec >/dev/null 2>&1
 trap '' TERM
-( sleep 1
-  pidfile="$(sed -n '2p' "$AGMSG_TEST_MKTEMP_MADE" 2>/dev/null)"
-  if [ -n "$pidfile" ] && [ -e "$pidfile" ]; then
-    printf '1\n' > "$pidfile"
-    # Recorded HERE, not read back from the pidfile afterwards: the driver
-    # deletes that file on its way out, so a check made after the run finds
-    # an empty string whether or not the substitution happened. Measured --
-    # the first version of this control failed for exactly that reason, on a
-    # run whose status was already the 17 this case is about.
-    printf 'substituted\n' > "$AGMSG_TEST_SUBSTITUTED"
-  fi
+# SUBSTITUTED REPEATEDLY, NOT ONCE, because once is a race this suite loses.
+#
+# The wrapper writes the real pid AFTER spawning this process, so a single
+# write timed off a `sleep 1` can land first and simply be overwritten. Alone
+# the case passed; in the full file, under the load of twenty-odd other cases,
+# it did not -- measured, as a status of 14 where 18 was expected. Rewriting
+# until just before the driver's budget expires removes the timing question
+# from the case entirely.
+( i=0
+  while [ "$i" -lt 25 ]; do
+    pidfile="$(sed -n '2p' "$AGMSG_TEST_MKTEMP_MADE" 2>/dev/null)"
+    if [ -n "$pidfile" ] && [ -e "$pidfile" ] && [ -s "$pidfile" ]; then
+      printf '1\n' > "$pidfile"
+      # Recorded HERE, not read back from the pidfile afterwards: the driver
+      # deletes that file on its way out, so a check made after the run finds
+      # an empty string whether or not the substitution happened. Measured --
+      # the first version of this control failed for exactly that reason, on a
+      # run that had already reached the branch it was checking for.
+      printf 'substituted\n' > "$AGMSG_TEST_SUBSTITUTED"
+    fi
+    i=$((i + 1))
+    sleep 0.1
+  done
 ) &
 while :; do sleep 1; done
 EOF
@@ -643,10 +662,15 @@ EOF
   [ -s "$made" ]
   [ "$(cat "$substituted" 2>/dev/null || true)" = "substituted" ]
 
-  # A distinct, named refusal -- not 14, which is the "stopped and released"
-  # outcome and would mean the gate did not fire.
-  [ "$status" -eq 17 ]
-  printf '%s' "$output" | grep -q 'STILL RUNNING'
+  # 18, the UNKNOWN outcome -- not 14 ("stopped and confirmed gone", which
+  # would mean the gate did not fire) and not 17 ("still ours and running",
+  # which would mean the driver had decided pid 1 was its own child).
+  [ "$status" -eq 18 ]
+  printf '%s' "$output" | grep -q 'no longer identifiable'
+  # AND IT SAYS IT DID NOT SIGNAL. This is the half that matters most: the
+  # earlier version sent TERM and KILL to whatever the file said, so a
+  # recycled number meant signalling a stranger.
+  printf '%s' "$output" | grep -q 'NOT signalled'
   # THE LOCK IS STILL THERE. This is the assertion the whole finding is about:
   # a release here would be a release beside a writer we could not stop.
   [ -d "$team_dir/.config.lock" ]

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -9,6 +9,30 @@ setup() {
 }
 
 teardown() {
+  # NOTHING THIS FILE STARTS MAY OUTLIVE IT.
+  #
+  # Several cases here are driven by a fake node that ignores TERM, and one is
+  # deliberately a process the driver must NOT be able to stop. When such a
+  # case fails -- or when someone runs a mutation against it -- the fixture is
+  # left running. That is the shape `scripts/lib/close-fds.sh` and
+  # `tests/test_spawn_fd_guard.bats` exist for: a leaked process can hold a
+  # shard open long after every case has reported. Five were found alive on
+  # this machine at once while this file was being written.
+  #
+  # Matched on TEST_SKILL_DIR, which `mktemp -d` makes fresh for every single
+  # case, so this can only ever name processes this case started -- never
+  # another suite's, and never another worktree's.
+  if [ -n "${TEST_SKILL_DIR:-}" ]; then
+    local stragglers
+    stragglers="$(pgrep -f "$TEST_SKILL_DIR" 2>/dev/null || true)"
+    if [ -n "$stragglers" ]; then
+      # shellcheck disable=SC2086
+      kill $stragglers 2>/dev/null || true
+      sleep 1
+      # shellcheck disable=SC2086
+      kill -9 $stragglers 2>/dev/null || true
+    fi
+  fi
   teardown_test_env
 }
 
@@ -533,40 +557,112 @@ EOF
   refute pgrep -f "$fake"
 }
 
-@test "the lock is not released until the inner child is confirmed gone (#821)" {
-  # A STRUCTURAL CHECK, AND THE REASON IS A LIMIT I COULD NOT GET AROUND.
+@test "the lock is KEPT when the inner child cannot be confirmed gone (#821)" {
+  skip_on_windows "POSIX signal semantics are not supported by this test"
+  # "I SENT A SIGNAL" IS NOT "THE PROCESS IS GONE" (raised as BLOCKING).
   #
-  # The property: "I sent a signal" is not "the process is gone". The inner
-  # process is a GRANDCHILD, so `wait` cannot speak for it, and every `kill`
-  # above discards its result. The release must therefore be gated on ASKING.
+  # The inner process is a GRANDCHILD, so `wait` cannot speak for it, and
+  # every `kill` on that path discards its result. Without asking, the release
+  # rested on nothing: a refused signal, and the lock came off beside a live
+  # writer.
   #
-  # The behavioural case would need a process that survives SIGKILL, and on a
-  # machine where this suite can run, there is none: KILL is only refused
-  # under EPERM (a sandbox) or an uninterruptible wait, and neither can be
-  # produced here. I tried and could not, and I would rather say that than
-  # ship a case that passes for a reason unrelated to the property.
+  # DRIVING IT NEEDED A PROCESS THE DRIVER CANNOT KILL, and SIGKILL cannot be
+  # ignored -- it is refused only under EPERM or an uninterruptible wait. So
+  # the case uses EPERM, which is the realistic half anyway (a sandbox that
+  # will not let us signal, #505): it makes the recorded pid **1**, which no
+  # ordinary user may signal. `kill -0 1` answers `Operation not permitted`,
+  # and `_agmsg_pid_alive_local` reads every non-ESRCH failure as alive --
+  # which is the conservative direction this gate needs.
   #
-  # So the gate is asserted where it lives, with both anchors required to
-  # exist so this cannot pass by finding nothing -- the same guard that caught
-  # the spawn anchor going stale on the previous head.
-  local sh="$SCRIPTS/internal/roster-sync-driver.sh" ask_at release_at keep_at
-  # The question is asked with the repo's own instrument, not a bare kill -0.
-  ask_at="$(grep -n '_agmsg_pid_alive_local "\$_roster_inner"' "$sh" | tail -1 | cut -d: -f1)"
-  # The lock is deliberately kept by emptying the library's own list.
-  keep_at="$(grep -n '^        AGMSG_HELD_LOCKS=""$' "$sh" | head -1 | cut -d: -f1)"
-  # The timeout path's release, which must come after the question.
-  release_at="$(grep -n '^      agmsg_lock_release$' "$sh" | head -1 | cut -d: -f1)"
+  # Nothing in the driver is stubbed. The pidfile is a real file whose path
+  # the `mktemp` shim already reports, and the fake node overwrites it the way
+  # a pid recycled under the driver's feet would.
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  local config="$team_dir/config.json"
+  local member_id fake shimdir made
+  member_id="$(config_field "$config" '$.agents.alice.member_id')"
+  source "$SCRIPTS/lib/roster-journal.sh"
+  agmsg_roster_append_left "$team_dir" "$member_id" alice "2026-01-01T00:00:00Z"
 
-  [ -n "$ask_at" ]
-  [ -n "$keep_at" ]
-  [ -n "$release_at" ]
-  [ "$release_at" -gt "$ask_at" ]
-  [ "$keep_at" -gt "$ask_at" ]
-  [ "$keep_at" -lt "$release_at" ]
-  # And the instrument is the sourced one, so this cannot be satisfied by a
-  # bare `kill -0` reintroduced beside it -- which a repo-wide check also
-  # refuses, from the other direction.
-  grep -q 'source "\$SKILL_DIR/scripts/lib/instance-id.sh"' "$sh"
+  made="$TEST_SKILL_DIR/mktemp-made-keep"
+  shimdir="$TEST_SKILL_DIR/shim-keep"
+  mkdir -p "$shimdir"
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'out=$(/usr/bin/mktemp "$@") || exit 1'
+    printf '%s\n' '[ -e "$out" ] && printf "%s\\n" "$out" >> "$AGMSG_TEST_MKTEMP_MADE"'
+    printf '%s\n' 'printf "%s\\n" "$out"'
+  } > "$shimdir/mktemp"
+  chmod +x "$shimdir/mktemp"
+
+  # The second real file the driver makes is the pidfile (the first is the
+  # sentinel; the FIFO's `mktemp -u` creates nothing and is not logged). The
+  # fake waits for the wrapper to have written it, then replaces the number.
+  fake="$TEST_SKILL_DIR/fake-node-unkillable-pid"
+  cat > "$fake" <<'EOF'
+#!/usr/bin/env bash
+# STDOUT IS LET GO HERE, IN THE FIXTURE, AND THAT IS ITS OWN FINDING.
+#
+# Without this the case hangs -- and not because of the property under test.
+# This fake is deliberately one the driver CANNOT kill, so it outlives the
+# run; while it holds the caller's stdout, `run` waits for an end-of-file
+# that never comes. That is inherent to "a child we may not signal", not
+# something the lock gate could fix, and it is reported to the reviewers as
+# an observation rather than fixed inside this PR. Released here so the case
+# measures the lock and nothing else.
+exec >/dev/null 2>&1
+trap '' TERM
+( sleep 1
+  pidfile="$(sed -n '2p' "$AGMSG_TEST_MKTEMP_MADE" 2>/dev/null)"
+  if [ -n "$pidfile" ] && [ -e "$pidfile" ]; then
+    printf '1\n' > "$pidfile"
+    # Recorded HERE, not read back from the pidfile afterwards: the driver
+    # deletes that file on its way out, so a check made after the run finds
+    # an empty string whether or not the substitution happened. Measured --
+    # the first version of this control failed for exactly that reason, on a
+    # run whose status was already the 17 this case is about.
+    printf 'substituted\n' > "$AGMSG_TEST_SUBSTITUTED"
+  fi
+) &
+while :; do sleep 1; done
+EOF
+  chmod +x "$fake"
+
+  local substituted="$TEST_SKILL_DIR/pid-substituted"
+  run env PATH="$shimdir:$PATH" AGMSG_SYNC_NODE_BIN="$fake" \
+    AGMSG_TEST_MKTEMP_MADE="$made" AGMSG_TEST_SUBSTITUTED="$substituted" \
+    AGMSG_ROSTER_SYNC_TIMEOUT_S=4 \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+
+  # POSITIVE CONTROL ON THE SETUP: the substitution must actually have
+  # happened, or this case is measuring an ordinary timeout that would have
+  # reached the same branch for a different reason.
+  [ -s "$made" ]
+  [ "$(cat "$substituted" 2>/dev/null || true)" = "substituted" ]
+
+  # A distinct, named refusal -- not 14, which is the "stopped and released"
+  # outcome and would mean the gate did not fire.
+  [ "$status" -eq 17 ]
+  printf '%s' "$output" | grep -q 'STILL RUNNING'
+  # THE LOCK IS STILL THERE. This is the assertion the whole finding is about:
+  # a release here would be a release beside a writer we could not stop.
+  [ -d "$team_dir/.config.lock" ]
+  # And the operator is told where it is, since nothing will clean it up.
+  printf '%s' "$output" | grep -q "$team_dir/.config.lock"
+
+  # The real fake node is still running -- it is not pid 1 and this test owns
+  # it, so it is stopped here by the pid the shell knows.
+  local leftover
+  leftover="$(pgrep -f "$fake" || true)"
+  if [ -n "$leftover" ]; then
+    kill $leftover 2>/dev/null || true
+    sleep 1
+    kill -9 $leftover 2>/dev/null || true
+  fi
+  rmdir "$team_dir/.config.lock" 2>/dev/null || true
 }
 
 @test "a partial temp setup leaves nothing behind (#821)" {
@@ -579,9 +675,14 @@ EOF
   # full. A feature answering a full filesystem by adding a file to it is the
   # wrong shape.
   #
-  # The stub fails only from the SECOND call on, so the first `mktemp -u`
-  # succeeds and the sentinel's does not. The previous cases all failed every
-  # call, which never produced this shape.
+  # THE STUB FAILS FROM THE THIRD CALL ON, and the number is the whole point.
+  #
+  # The first call is `mktemp -u`, which only generates a NAME — it creates
+  # nothing. So failing from the second call leaves no file either, and the
+  # case then passes whether or not anything sweeps up. Measured: with the
+  # sweep deleted the case stayed GREEN, which is what sent this comment here.
+  # Failing from the third leaves exactly one real file — the sentinel — with
+  # the pidfile refused, which is the partial state.
   bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
   local team_dir="$TEST_SKILL_DIR/teams/demo"
   local shimdir counter before after fake
@@ -590,40 +691,57 @@ EOF
   chmod +x "$fake"
 
   counter="$TEST_SKILL_DIR/mktemp-calls"
+  local made="$TEST_SKILL_DIR/mktemp-made"
   shimdir="$TEST_SKILL_DIR/shim-partial-mktemp"
   mkdir -p "$shimdir"
+  # THE SHIM RECORDS WHAT IT ACTUALLY CREATED, and that is not decoration.
+  #
+  # The first version of this case counted files in `$TMPDIR` before and
+  # after. It could not have failed: on macOS `mktemp` with no template
+  # IGNORES `TMPDIR` and writes to the per-user directory under /var/folders,
+  # so the count was taken of a directory the driver never touched. Measured
+  # -- with the sweep deleted the case stayed green, twice.
+  #
+  # So the paths are logged as they are handed out, and only when the file is
+  # really there (`-u` generates a name and creates nothing). The assertion is
+  # then about those exact paths, wherever the platform decided to put them.
   {
     printf '%s\n' '#!/bin/sh'
     printf '%s\n' 'n=$(cat "$AGMSG_TEST_MKTEMP_COUNTER" 2>/dev/null || echo 0)'
     printf '%s\n' 'n=$((n + 1)); printf %s "$n" > "$AGMSG_TEST_MKTEMP_COUNTER"'
-    printf '%s\n' '[ "$n" -ge 2 ] && exit 1'
-    printf '%s\n' 'exec /usr/bin/mktemp "$@"'
+    printf '%s\n' '[ "$n" -ge 3 ] && exit 1'
+    printf '%s\n' 'out=$(/usr/bin/mktemp "$@") || exit 1'
+    printf '%s\n' '[ -e "$out" ] && printf "%s\\n" "$out" >> "$AGMSG_TEST_MKTEMP_MADE"'
+    printf '%s\n' 'printf "%s\\n" "$out"'
   } > "$shimdir/mktemp"
   chmod +x "$shimdir/mktemp"
 
-  # Every temp path this driver could have created lives in TMPDIR, so the
-  # question is asked of the directory itself: what is in it before, and what
-  # is in it after. Counting entries rather than naming them, because the
-  # names are generated and the assertion is about residue, not identity.
-  export TMPDIR="$TEST_SKILL_DIR/tmp-partial"
-  mkdir -p "$TMPDIR"
-  before="$(find "$TMPDIR" -type f | wc -l | tr -d ' ')"
-
   run env PATH="$shimdir:$PATH" AGMSG_SYNC_NODE_BIN="$fake" \
-    AGMSG_TEST_MKTEMP_COUNTER="$counter" TMPDIR="$TMPDIR" \
+    AGMSG_TEST_MKTEMP_COUNTER="$counter" AGMSG_TEST_MKTEMP_MADE="$made" \
     bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
       018f3f7e-0000-7000-8000-000000000001 \
       018f3f7e-0000-7000-8000-000000000002 1 </dev/null
 
   # It took the refusal, which is what a partial setup must do.
   [ "$status" -eq 16 ]
-  # POSITIVE CONTROL ON THE STUB: without this, a stub that never ran would
-  # leave the case asserting "no residue" about a run that had no temps to
-  # leave. Two calls means the first succeeded and the second was refused --
-  # exactly the partial shape.
-  [ "$(cat "$counter")" -ge 2 ]
-  after="$(find "$TMPDIR" -type f | wc -l | tr -d ' ')"
-  [ "$after" -eq "$before" ]
+  # POSITIVE CONTROL ON THE STUB: three calls means the sentinel's `mktemp`
+  # really ran and the pidfile's was refused -- the partial shape, rather than
+  # the "nothing was ever made" one the other cases already cover.
+  [ "$(cat "$counter")" -ge 3 ]
+  # AND A POSITIVE CONTROL ON THE INSTRUMENT: at least one file really
+  # existed, so "none of them is left" is not a sentence about an empty list.
+  [ -s "$made" ]
+  before="$(wc -l < "$made" | tr -d ' ')"
+  [ "$before" -ge 1 ]
+  after=0
+  while IFS= read -r leftover; do
+    [ -n "$leftover" ] || continue
+    if [ -e "$leftover" ]; then
+      after=$((after + 1))
+      echo "left behind: $leftover" >&2
+    fi
+  done < "$made"
+  [ "$after" -eq 0 ]
   [ ! -d "$team_dir/.config.lock" ]
 }
 

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -459,3 +459,35 @@ EOF
   [ "$status" -eq 0 ]
   [ -e "$ran" ]
 }
+
+@test "the roster child does not inherit the descriptor used to hand it stdin (#821)" {
+  # `<&9` duplicates the caller's stdin onto the child's fd 0 and leaves fd 9
+  # open beside it unless the redirection closes it. The child then holds the
+  # caller's stream twice — the class that hung a shard twice tonight, arriving
+  # through the descriptor added to fix it.
+  #
+  # Asserted from INSIDE the child, because that is the only place the answer
+  # exists: a reader of the source can be told `9<&-` is there, and reading is
+  # what let this back in.
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  local seen="$TEST_SKILL_DIR/child-fd9" fake="$TEST_SKILL_DIR/fake-node-fd"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'if : <&9 2>/dev/null; then printf open > "$AGMSG_TEST_FD_SEEN"'
+    printf '%s\n' 'else printf closed > "$AGMSG_TEST_FD_SEEN"; fi'
+    printf '%s\n' 'exit 0'
+  } > "$fake"
+  chmod +x "$fake"
+
+  run env AGMSG_TEST_FD_SEEN="$seen" AGMSG_SYNC_NODE_BIN="$fake" \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+  [ "$status" -eq 0 ]
+  # The child ran at all — without this the assertion below passes on a file
+  # that was never written.
+  [ -e "$seen" ]
+  [ "$(cat "$seen")" = "closed" ]
+  [ ! -d "$team_dir/.config.lock" ]
+}

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -494,11 +494,15 @@ EOF
   # And it must NOT have announced that it was running unbounded — the old
   # sentence is the marker of the path this case exists to remove.
   #
-  # `!` and not `refute`: `refute` takes a command, and a pipe binds tighter,
-  # so `refute printf ... | grep` hands `refute` only the `printf` and asserts
-  # something else entirely. Measured — it failed against output that does not
-  # contain the string.
-  ! printf '%s' "$output" | grep -q 'without a time bound'
+  # `run` AND A STATUS, and neither of the two shapes that come to mind first.
+  # `refute` takes a command and a pipe binds tighter, so
+  # `refute printf ... | grep` hands `refute` only the `printf` — measured, it
+  # failed against output that does not contain the string. And `! cmd` is
+  # what `.github/scripts/check-enforced-assertions.sh` refuses: it cannot
+  # fail a bats test unless it is the very last line, which makes the
+  # assertion's strength depend on where it happens to sit.
+  run bash -c 'printf "%s" "$1" | grep -q "without a time bound"' _ "$output"
+  [ "$status" -ne 0 ]
 }
 
 @test "a failing sleep does not drop the lock beside a live child (#821)" {
@@ -919,7 +923,14 @@ EOF
   printf '%s' "$driver_out" | grep -q 'WITHHELD'
   # ...and it does NOT claim nothing was signalled, which is the false
   # sentence this case exists to remove.
-  ! printf '%s' "$driver_out" | grep -q 'Nothing was signalled'
+  #
+  # `run` and a status, NOT `! cmd`: a non-last `! cmd` cannot fail a bats
+  # test anywhere, so writing the negation that way would have shipped an
+  # assertion incapable of failing -- exactly the class this PR is about.
+  # `.github/scripts/check-enforced-assertions.sh` caught it; the baseline
+  # went 638 -> 639 and named the line.
+  run bash -c 'printf "%s" "$1" | grep -q "Nothing was signalled"' _ "$driver_out"
+  [ "$status" -ne 0 ]
   [ -d "$team_dir/.config.lock" ]
 
   # KILL WAS WITHHELD, observed on the process rather than read from the

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -713,146 +713,100 @@ EOF
   rmdir "$team_dir/.config.lock" 2>/dev/null || true
 }
 
-@test "the argv match survives the Windows path alphabet (#821)" {
-  # THE COMPARISON RUNS ON TWO ALPHABETS, AND THIS MACHINE ONLY HAS ONE.
+@test "the production argv matcher: alphabet, quoting, order and boundaries (#821)" {
+  # DRIVEN THROUGH THE FUNCTION PRODUCTION CALLS, not a copy of it.
   #
-  # Under Git Bash the shell's own path is `/c/Users/...` while a native
-  # process reports `C:/Users/...`, so a raw `case` answers "not ours" about a
-  # process that IS ours -- and silently, since a non-match is the ordinary
-  # answer. `scripts/lib/compat.sh` documents it, measured on a reporting
-  # machine, and `agmsg_cmdline_names_path` exists to take the `cygpath -m`
-  # second look.
-  #
-  # There is no Windows here, so the DIFFERENCE is driven instead: a `cygpath`
-  # stub maps this suite's real paths into the `C:/` form, and the comparator
-  # is handed a cmdline written in that form. If the driver ever goes back to
-  # a raw `case`, this is what reddens -- on the alphabet difference alone,
-  # with everything else identical.
-  source "$SCRIPTS/lib/compat.sh"
+  # The earlier versions of these cases re-implemented the comparison with
+  # `bash -c case` and then asserted on the driver with `grep`. That measures
+  # a duplicate and a spelling; it cannot notice production diverging from
+  # either (raised in review). `agmsg_roster_argv_is_ours` now lives in
+  # `scripts/lib/roster-journal.sh` for exactly this reason, and every row
+  # below goes through it.
+  source "$SCRIPTS/lib/roster-journal.sh"
 
-  local shimdir="$TEST_SKILL_DIR/shim-cygpath"
-  mkdir -p "$shimdir"
-  # `-m` is the mixed form. The stub answers only for it, so a call with any
-  # other flag cannot accidentally satisfy the assertions below.
-  # `/c/Users/x` becomes `C:/Users/x` -- the drive letter REPLACES the leading
-  # `/c`, it is not prepended to it. Prepending leaves the original substring
-  # intact, so a raw match still fires and the case measures nothing; the
-  # premise control below caught exactly that on the first attempt.
-  {
-    printf '%s\n' '#!/bin/sh'
-    printf '%s\n' '[ "$1" = "-m" ] || exit 1'
-    printf '%s\n' 'printf "C:%s\\n" "${2#/c}"'
-  } > "$shimdir/cygpath"
-  chmod +x "$shimdir/cygpath"
-
-  local script="/c/Users/agent/.agents/skills/agmsg/scripts/internal/roster-sync.mjs"
-  local conf="/c/Users/agent/.agents/skills/agmsg/teams/demo/config.json"
-  local native_cmd="node.exe C:${script#/c} reconcile C:${conf#/c}"
-
-  # POSITIVE CONTROL ON THE PREMISE: the raw comparison really does fail on
-  # this input. Without it, the assertions below could pass because the two
-  # forms happened to match, and the case would be measuring nothing.
-  run bash -c "case \"$native_cmd\" in *\"$script\"*) exit 0 ;; esac; exit 1"
-  [ "$status" -ne 0 ]
-
-  # With cygpath present, the same input is recognised.
-  PATH="$shimdir:$PATH" agmsg_cmdline_names_path "$native_cmd" "$script"
-  PATH="$shimdir:$PATH" agmsg_cmdline_names_path "$native_cmd" "$conf"
-
-  # And it is not a rubber stamp: another team's config is still refused.
-  local other="/c/Users/agent/.agents/skills/agmsg/teams/other/config.json"
-  run env PATH="$shimdir:$PATH" bash -c \
-    "source '$SCRIPTS/lib/compat.sh'; agmsg_cmdline_names_path '$native_cmd' '$other'"
-  [ "$status" -ne 0 ]
-
-  # AND THE DRIVER MUST ACTUALLY USE THE CONVERSION. Everything above measures
-  # the comparator; none of it would notice the driver going back to a raw
-  # comparison -- measured, by reverting the driver and watching every
-  # assertion above stay green. There is no Windows here to catch that
-  # behaviourally, so the driver's side is asserted where it lives.
-  local sh="$SCRIPTS/internal/roster-sync-driver.sh"
-  grep -q 'cygpath -m' "$sh"
-  # THE ORDERED TRIPLE, not three separate sightings. `<script> <operation>
-  # <config>` has to appear as one run of text, because a cmdline carrying a
-  # different operation and a different config can satisfy three independent
-  # `contains` checks at once.
-  grep -q '\*" \$s \$operation \$c "\*' "$sh"
-  # And no shell-side path is matched against the cmdline directly.
-  run grep -nE 'case "\$cmd" in.*\$(SCRIPT_DIR|config)' "$sh"
-  [ "$status" -ne 0 ]
-}
-
-@test "the argv match is a sequence, not three sightings (#821)" {
-  # TWO EXISTENCE CHECKS ARE NOT A RELATION (raised in review).
-  #
-  # The predicate used to ask three separate questions: does the cmdline
-  # contain the script path, does it contain this config, does it contain this
-  # operation anywhere. A command line can satisfy all three while being a
-  # DIFFERENT run -- the operation supplied by one part of it and the config by
-  # another. This drives exactly that shape.
-  #
-  # The driver's own predicate is not reachable from here without running it,
-  # so the composition is measured on the same text the driver builds: the
-  # ordered needle must reject this cmdline, and the three loose checks must
-  # each accept it. That contrast is the whole finding.
   local script="/opt/agmsg/scripts/internal/roster-sync.mjs"
   local conf="/opt/agmsg/teams/demo/config.json"
   local other="/opt/agmsg/teams/other/config.json"
-  local operation="reconcile"
+  local op="reconcile"
 
+  # --- the run it describes ------------------------------------------------
+  agmsg_roster_argv_is_ours "node $script $op $conf 018f 018f 1" "$script" "$op" "$conf"
+  # config as the last argument on the line: the padding is what makes this
+  # work without a separate end-of-string branch.
+  agmsg_roster_argv_is_ours "node $script $op $conf" "$script" "$op" "$conf"
+
+  # --- QUOTED NATIVE ARGV --------------------------------------------------
+  # A native Windows command line quotes any argument containing a space. An
+  # unquoted needle never matches it, so the real child read as unknown and
+  # its lock was kept. This is the shape `compat_get_cmdline` returns from CIM.
+  local qs='C:/Users/First Last/.agents/skills/agmsg/scripts/internal/roster-sync.mjs'
+  local qc='C:/Users/First Last/.agents/skills/agmsg/teams/demo/config.json'
+  agmsg_roster_argv_is_ours "\"C:/Program Files/nodejs/node.exe\" \"$qs\" $op \"$qc\" 018f" \
+    "$qs" "$op" "$qc"
+  # ...and it is not a rubber stamp once the quotes are gone: another team's
+  # config, quoted the same way, is still refused.
+  local qo='C:/Users/First Last/.agents/skills/agmsg/teams/other/config.json'
+  run agmsg_roster_argv_is_ours "\"node.exe\" \"$qs\" $op \"$qo\" 018f" "$qs" "$op" "$qc"
+  [ "$status" -ne 0 ]
+  # ...nor is a different operation.
+  run agmsg_roster_argv_is_ours "\"node.exe\" \"$qs\" apply \"$qc\" 018f" "$qs" "$op" "$qc"
+  [ "$status" -ne 0 ]
+
+  # --- THREE SIGHTINGS ARE NOT A RELATION ----------------------------------
   # A real command line for a DIFFERENT run: `apply` on another team's config,
-  # with the word `reconcile` present for an unrelated reason.
-  local decoy="node $script apply $other --note reconcile "
-
-  # The three loose checks all say yes -- this is the premise, and without it
-  # the assertion below would prove nothing.
-  case "$decoy" in *"$script"*) : ;; *) return 1 ;; esac
-  case "$decoy" in *"$other"*) : ;; *) return 1 ;; esac
-  case "$decoy" in *" $operation "*) : ;; *) return 1 ;; esac
-
-  # The ordered needle says no, for this team's config...
-  run bash -c "case \"$decoy\" in *\"$script $operation $conf\"*) exit 0 ;; esac; exit 1"
+  # with the word `reconcile` present for an unrelated reason. It satisfies
+  # "contains the script", "contains a config" and "contains this operation"
+  # all at once.
+  local decoy="node $script apply $other --note $op "
+  run agmsg_roster_argv_is_ours "$decoy" "$script" "$op" "$conf"
   [ "$status" -ne 0 ]
-  # ...and for the other team's too, because the OPERATION does not line up.
-  run bash -c "case \"$decoy\" in *\"$script $operation $other\"*) exit 0 ;; esac; exit 1"
+  run agmsg_roster_argv_is_ours "$decoy" "$script" "$op" "$other"
   [ "$status" -ne 0 ]
 
-  # Positive control: the needle does match the run it describes.
-  local real="node $script $operation $conf"
-  run bash -c "case \"$real\" in *\"$script $operation $conf\"*) exit 0 ;; esac; exit 1"
-  [ "$status" -eq 0 ]
-
-  # AND AN ORDERED SUBSTRING IS STILL A SUBSTRING (raised in review). Without
-  # boundaries the needle for `/teams/demo/config.json` matches a run whose
-  # config is `/teams/demo/config.json.bak`, and a script at
-  # `/x/opt/agmsg/.../roster-sync.mjs` contains our absolute path as a tail.
-  # Both are different runs that would read as ours.
-  local suffixed="node $script $operation $conf.bak 018f 018f 1"
-  local prefixed="node /x$script $operation $conf 018f 018f 1"
-
-  # The premise: the UNBOUNDED needle accepts both. This is what was shipped.
-  run bash -c "case \"$suffixed\" in *\"$script $operation $conf\"*) exit 0 ;; esac; exit 1"
-  [ "$status" -eq 0 ]
-  run bash -c "case \"$prefixed\" in *\"$script $operation $conf\"*) exit 0 ;; esac; exit 1"
-  [ "$status" -eq 0 ]
-
-  # The padded, boundary-requiring form refuses both...
-  run bash -c "case \" $suffixed \" in *\" $script $operation $conf \"*) exit 0 ;; esac; exit 1"
+  # --- AN ORDERED SUBSTRING IS STILL A SUBSTRING ---------------------------
+  run agmsg_roster_argv_is_ours "node $script $op $conf.bak 018f" "$script" "$op" "$conf"
   [ "$status" -ne 0 ]
-  run bash -c "case \" $prefixed \" in *\" $script $operation $conf \"*) exit 0 ;; esac; exit 1"
+  run agmsg_roster_argv_is_ours "node /x$script $op $conf 018f" "$script" "$op" "$conf"
   [ "$status" -ne 0 ]
-  # ...and still accepts the real run, including when the config is the last
-  # argument on the line, which is what the padding is for.
-  run bash -c "case \" node $script $operation $conf 018f 1 \" in *\" $script $operation $conf \"*) exit 0 ;; esac; exit 1"
-  [ "$status" -eq 0 ]
-  run bash -c "case \" node $script $operation $conf \" in *\" $script $operation $conf \"*) exit 0 ;; esac; exit 1"
-  [ "$status" -eq 0 ]
 
-  # And the driver uses the padded form rather than the bare one.
-  local sh="$SCRIPTS/internal/roster-sync-driver.sh"
-  grep -q 'local padded=" \$cmd "' "$sh"
-  grep -q '\*" \$s \$operation \$c "\*' "$sh"
+  # --- THE WINDOWS ALPHABET, driven with a cygpath stub --------------------
+  # There is no Windows here, so the DIFFERENCE is driven instead. `/c/x`
+  # becomes `C:/x` -- the drive letter REPLACES the leading `/c` rather than
+  # being prepended to it; prepending leaves the original substring intact and
+  # a raw match still fires, which is what the premise control below caught on
+  # the first attempt.
+  local shimdir="$TEST_SKILL_DIR/shim-cygpath"
+  mkdir -p "$shimdir"
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' '[ "$1" = "-m" ] || exit 1'
+    printf '%s\n' 'printf "C:%s\n" "${2#/c}"'
+  } > "$shimdir/cygpath"
+  chmod +x "$shimdir/cygpath"
+
+  local wsh="/c/Users/agent/.agents/skills/agmsg/scripts/internal/roster-sync.mjs"
+  local wconf="/c/Users/agent/.agents/skills/agmsg/teams/demo/config.json"
+  local native="node.exe C:${wsh#/c} $op C:${wconf#/c} 018f"
+
+  # PREMISE CONTROL: without cygpath the two alphabets do not match, so the
+  # row below is measuring the conversion and not a coincidence.
+  run agmsg_roster_argv_is_ours "$native" "$wsh" "$op" "$wconf"
+  [ "$status" -ne 0 ]
+  # With it, the same input is recognised.
+  PATH="$shimdir:$PATH" agmsg_roster_argv_is_ours "$native" "$wsh" "$op" "$wconf"
+  # And still refused for another team, converted the same way.
+  local wother="/c/Users/agent/.agents/skills/agmsg/teams/other/config.json"
+  run env PATH="$shimdir:$PATH" bash -c \
+    "source '$SCRIPTS/lib/roster-journal.sh'; agmsg_roster_argv_is_ours '$native' '$wsh' '$op' '$wother'"
+  [ "$status" -ne 0 ]
+
+  # --- and the driver calls it ---------------------------------------------
+  # The only structural assertion left, and it is about WIRING rather than
+  # about the comparison: everything above measures the real function, but
+  # nothing above would notice the driver ceasing to call it.
+  grep -q 'agmsg_roster_argv_is_ours "\$cmd"' "$SCRIPTS/internal/roster-sync-driver.sh"
 }
+
 
 @test "a recycled pid is neither signalled nor read as gone (#821)" {
   skip_on_windows "POSIX signal semantics are not supported by this test"

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -776,7 +776,7 @@ EOF
   # <config>` has to appear as one run of text, because a cmdline carrying a
   # different operation and a different config can satisfy three independent
   # `contains` checks at once.
-  grep -q '\*"\$s \$operation \$c"\*' "$sh"
+  grep -q '\*" \$s \$operation \$c "\*' "$sh"
   # And no shell-side path is matched against the cmdline directly.
   run grep -nE 'case "\$cmd" in.*\$(SCRIPT_DIR|config)' "$sh"
   [ "$status" -ne 0 ]
@@ -821,6 +821,37 @@ EOF
   local real="node $script $operation $conf"
   run bash -c "case \"$real\" in *\"$script $operation $conf\"*) exit 0 ;; esac; exit 1"
   [ "$status" -eq 0 ]
+
+  # AND AN ORDERED SUBSTRING IS STILL A SUBSTRING (raised in review). Without
+  # boundaries the needle for `/teams/demo/config.json` matches a run whose
+  # config is `/teams/demo/config.json.bak`, and a script at
+  # `/x/opt/agmsg/.../roster-sync.mjs` contains our absolute path as a tail.
+  # Both are different runs that would read as ours.
+  local suffixed="node $script $operation $conf.bak 018f 018f 1"
+  local prefixed="node /x$script $operation $conf 018f 018f 1"
+
+  # The premise: the UNBOUNDED needle accepts both. This is what was shipped.
+  run bash -c "case \"$suffixed\" in *\"$script $operation $conf\"*) exit 0 ;; esac; exit 1"
+  [ "$status" -eq 0 ]
+  run bash -c "case \"$prefixed\" in *\"$script $operation $conf\"*) exit 0 ;; esac; exit 1"
+  [ "$status" -eq 0 ]
+
+  # The padded, boundary-requiring form refuses both...
+  run bash -c "case \" $suffixed \" in *\" $script $operation $conf \"*) exit 0 ;; esac; exit 1"
+  [ "$status" -ne 0 ]
+  run bash -c "case \" $prefixed \" in *\" $script $operation $conf \"*) exit 0 ;; esac; exit 1"
+  [ "$status" -ne 0 ]
+  # ...and still accepts the real run, including when the config is the last
+  # argument on the line, which is what the padding is for.
+  run bash -c "case \" node $script $operation $conf 018f 1 \" in *\" $script $operation $conf \"*) exit 0 ;; esac; exit 1"
+  [ "$status" -eq 0 ]
+  run bash -c "case \" node $script $operation $conf \" in *\" $script $operation $conf \"*) exit 0 ;; esac; exit 1"
+  [ "$status" -eq 0 ]
+
+  # And the driver uses the padded form rather than the bare one.
+  local sh="$SCRIPTS/internal/roster-sync-driver.sh"
+  grep -q 'local padded=" \$cmd "' "$sh"
+  grep -q '\*" \$s \$operation \$c "\*' "$sh"
 }
 
 @test "a recycled pid is neither signalled nor read as gone (#821)" {

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -672,7 +672,7 @@ _roster_state_digest() {
   local node_at wrapper_close_at group_at parent_close_at
 
   # 1. node is handed the descriptor and drops its saved copy in one redirection.
-  node_at="$(grep -n '"\$@" <&9 9<&- &$' "$sh" | head -1 | cut -d: -f1)"
+  node_at="$(grep -n '"\$@" <&9 9<&- 3>&- 4>&- &$' "$sh" | head -1 | cut -d: -f1)"
   # 2. the wrapper closes its own copy — indented inside the brace group.
   wrapper_close_at="$(grep -n '^    exec 9<&-$' "$sh" | head -1 | cut -d: -f1)"
   # 3. the brace group is backgrounded.

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -764,6 +764,21 @@ EOF
   run env PATH="$shimdir:$PATH" bash -c \
     "source '$SCRIPTS/lib/compat.sh'; agmsg_cmdline_names_path '$native_cmd' '$other'"
   [ "$status" -ne 0 ]
+
+  # AND THE DRIVER MUST ACTUALLY USE IT. Everything above measures the
+  # comparator; none of it would notice the driver going back to a raw
+  # comparison, and that is precisely the regression to guard -- measured, by
+  # reverting the driver to `case` and watching every assertion above stay
+  # green. There is no Windows here to catch it behaviourally, so the driver's
+  # side is asserted where it lives.
+  local sh="$SCRIPTS/internal/roster-sync-driver.sh"
+  # It calls the comparator for both paths...
+  grep -q 'agmsg_cmdline_names_path "\$cmd" "\$SCRIPT_DIR/roster-sync.mjs"' "$sh"
+  grep -q 'agmsg_cmdline_names_path "\$cmd" "\$config"' "$sh"
+  # ...and nowhere matches a shell-side path against the cmdline directly,
+  # which is the shape that is blind on Windows.
+  run grep -nE 'case "\$cmd" in.*\$(SCRIPT_DIR|config)' "$sh"
+  [ "$status" -ne 0 ]
 }
 
 @test "a recycled pid is neither signalled nor read as gone (#821)" {

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -571,19 +571,28 @@ EOF
   # something else by the time the timeout path reads it. The earlier version
   # sent TERM and then KILL to whatever it said.
   #
-  # So the case makes the recorded pid **1** -- alive, certainly not ours, and
-  # not signallable by an ordinary user. That is one substitution standing in
-  # for both hazards: a recycled number, and (through EPERM) a process this
-  # process may not touch.
+  # THE STAND-IN IS A PROCESS THIS CASE OWNS, NOT PID 1. An earlier version
+  # substituted 1: alive, certainly not ours, and unsignallable -- which made
+  # the driver aim TERM and KILL at init on every run of this suite, and
+  # proved nothing about restraint either, because a signal to pid 1 leaves no
+  # trace an ordinary user can read (raised in review, and right).
   #
-  # What it must produce is the UNKNOWN outcome: pid 1 not signalled, our own
-  # child's fate undetermined, and therefore the lock kept. Reading it as
-  # "gone" would release on an answer never obtained; reading it as "still
-  # ours" would mean the driver had adopted a stranger.
+  # A `sleep` this case starts answers both. Its argv does not match, so it
+  # models a recycled number; and because the case owns it, "no signal was
+  # delivered" is DIRECTLY OBSERVABLE -- if TERM had been sent, it would be
+  # gone. It is still alive at the end, or this case fails.
+  #
+  # What the run must produce is the UNKNOWN outcome: nothing signalled, our
+  # own child's fate undetermined, and therefore the lock kept. Reading it as
+  # "gone" would release on an answer never obtained; reading it as "ours"
+  # would mean the driver had adopted a stranger.
   #
   # Nothing in the driver is stubbed. The pidfile is a real file whose path
   # the `mktemp` shim already reports, and the fake node overwrites it the way
   # a pid recycled under the driver's feet would.
+  local stranger
+  sleep 120 &
+  stranger=$!
   bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
   local team_dir="$TEST_SKILL_DIR/teams/demo"
   local config="$team_dir/config.json"
@@ -632,7 +641,7 @@ trap '' TERM
   while [ "$i" -lt 25 ]; do
     pidfile="$(sed -n '2p' "$AGMSG_TEST_MKTEMP_MADE" 2>/dev/null)"
     if [ -n "$pidfile" ] && [ -e "$pidfile" ] && [ -s "$pidfile" ]; then
-      printf '1\n' > "$pidfile"
+      printf '%s\n' "$AGMSG_TEST_STRANGER_PID" > "$pidfile"
       # Recorded HERE, not read back from the pidfile afterwards: the driver
       # deletes that file on its way out, so a check made after the run finds
       # an empty string whether or not the substitution happened. Measured --
@@ -651,7 +660,7 @@ EOF
   local substituted="$TEST_SKILL_DIR/pid-substituted"
   run env PATH="$shimdir:$PATH" AGMSG_SYNC_NODE_BIN="$fake" \
     AGMSG_TEST_MKTEMP_MADE="$made" AGMSG_TEST_SUBSTITUTED="$substituted" \
-    AGMSG_ROSTER_SYNC_TIMEOUT_S=4 \
+    AGMSG_TEST_STRANGER_PID="$stranger" AGMSG_ROSTER_SYNC_TIMEOUT_S=4 \
     bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
       018f3f7e-0000-7000-8000-000000000001 \
       018f3f7e-0000-7000-8000-000000000002 1 </dev/null
@@ -662,23 +671,38 @@ EOF
   [ -s "$made" ]
   [ "$(cat "$substituted" 2>/dev/null || true)" = "substituted" ]
 
+  # KEPT BEFORE ANY OTHER `run`, because `run` overwrites `$output` -- the
+  # positive control below is itself a `run`, and with the assertions in the
+  # other order it silently began grepping the control's output instead of the
+  # driver's. Measured, as an assertion that failed on text that was there.
+  local driver_status="$status" driver_out="$output"
+
   # 18, the UNKNOWN outcome -- not 14 ("stopped and confirmed gone", which
-  # would mean the gate did not fire) and not 17 ("still ours and running",
-  # which would mean the driver had decided pid 1 was its own child).
-  [ "$status" -eq 18 ]
-  printf '%s' "$output" | grep -q 'no longer identifiable'
-  # AND IT SAYS IT DID NOT SIGNAL. This is the half that matters most: the
-  # earlier version sent TERM and KILL to whatever the file said, so a
-  # recycled number meant signalling a stranger.
-  printf '%s' "$output" | grep -q 'NOT signalled'
+  # would mean the gate did not fire) and not 17 ("ours and still running",
+  # which would mean the driver had adopted a stranger.)
+  [ "$driver_status" -eq 18 ]
+  printf '%s' "$driver_out" | grep -q 'could not be established'
   # THE LOCK IS STILL THERE. This is the assertion the whole finding is about:
   # a release here would be a release beside a writer we could not stop.
   [ -d "$team_dir/.config.lock" ]
   # And the operator is told where it is, since nothing will clean it up.
-  printf '%s' "$output" | grep -q "$team_dir/.config.lock"
+  printf '%s' "$driver_out" | grep -q "$team_dir/.config.lock"
 
-  # The real fake node is still running -- it is not pid 1 and this test owns
-  # it, so it is stopped here by the pid the shell knows.
+  # THE OBSERVATION THAT MATTERS, and it is a measurement rather than a
+  # reading of the driver's own prose: the process whose number was in the
+  # pidfile is STILL ALIVE. TERM would have ended it. This is what "a
+  # recycled pid is not signalled" means, checked on the process itself.
+  kill -0 "$stranger" 2>/dev/null
+  # Positive control on that check: the same assertion must be able to fail.
+  # A pid this case never started is not alive, and if `kill -0` could not
+  # tell the difference the line above would prove nothing.
+  run kill -0 999999
+  [ "$status" -ne 0 ]
+
+  kill "$stranger" 2>/dev/null || true
+  # The real fake node outlives the driver by design, so it is stopped here by
+  # the pid the shell knows. The teardown catches it too; this keeps the
+  # window short.
   local leftover
   leftover="$(pgrep -f "$fake" || true)"
   if [ -n "$leftover" ]; then

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -366,10 +366,17 @@ EOS
   [ "$(config_field "$config" '$.agents.alice.member_id')" = "$before" ]
 }
 
-@test "roster sync bounds a local child that never finishes, and releases the lock (#817)" {
+@test "roster sync bounds a local child that never finishes, and releases the lock (#821)" {
   skip_on_windows "POSIX signal delivery is not supported by this test"
-  # THE CASE THE FIELD REPORT DESCRIBES, made deterministic: a child that
-  # neither runs to completion nor lets the shell exit. Release used to be the
+  # A child that neither runs to completion nor lets the shell exit.
+  #
+  # NOT the Windows failure reported on #817: that one is explained by a
+  # holder-metadata write whose failure is swallowed, and by the parent
+  # SIGKILLing this driver after a stdin error — neither of which is this, and
+  # neither of which has been reproduced. What is deterministic here is the
+  # property #821 states, and nothing beyond it.
+  #
+  # Release used to be the
   # EXIT trap alone, which is sound when this shell reaches its own exit — a
   # child that fails to launch or exits non-zero still gets there — and not
   # sound here. The shell waits, the trap never runs, and `.config.lock` is
@@ -408,4 +415,47 @@ EOF
   # The child is gone as well — released after the reap, never beside a live
   # writer.
   refute pgrep -f "$fake"
+}
+
+@test "roster sync refuses a timeout setting it cannot honour, and does not start the child (#821)" {
+  # `read -t` rejects a zero, a negative or a non-numeric budget by failing
+  # immediately, and that failure is indistinguishable from "the writer is
+  # gone" — so a mistyped setting used to turn the ceiling off and leave the
+  # wait unbounded. A bound that a typo removes is not a bound.
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo" ran="$TEST_SKILL_DIR/child-ran"
+  local fake="$TEST_SKILL_DIR/fake-node-records"
+  printf '%s\n' '#!/usr/bin/env bash' ': > "$AGMSG_TEST_RAN"' 'exit 0' > "$fake"
+  chmod +x "$fake"
+
+  local bad
+  for bad in 0 -1 abc 1.5; do
+    rm -f "$ran"
+    run env AGMSG_TEST_RAN="$ran" AGMSG_SYNC_NODE_BIN="$fake" \
+      AGMSG_ROSTER_SYNC_TIMEOUT_S="$bad" \
+      bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+        018f3f7e-0000-7000-8000-000000000001 \
+        018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+    # Named, not silent, and not a bare non-zero.
+    [ "$status" -ne 0 ]
+    printf '%s' "$output" | grep -q 'AGMSG_ROSTER_SYNC_TIMEOUT_S'
+    # The child is never started: refusing after the work has begun would
+    # leave the state half-written for a setting error.
+    [ ! -e "$ran" ]
+    # And the lock does not survive the refusal.
+    [ ! -d "$team_dir/.config.lock" ]
+  done
+
+  # EMPTY IS NOT INVALID — it is unset, and unset takes the default. Asserting
+  # a refusal here would pin the opposite of what `${VAR:-120}` does, and the
+  # first version of this case did exactly that: it read the default path as a
+  # missing guard. Measured, as this test failing against correct code.
+  rm -f "$ran"
+  run env AGMSG_TEST_RAN="$ran" AGMSG_SYNC_NODE_BIN="$fake" \
+    AGMSG_ROSTER_SYNC_TIMEOUT_S="" \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+  [ "$status" -eq 0 ]
+  [ -e "$ran" ]
 }

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -637,6 +637,135 @@ EOF
   rmdir "$team_dir/.config.lock" 2>/dev/null || true
 }
 
+@test "a numeric but unusable pid is not read as a child that exited (#821)" {
+  skip_on_windows "POSIX signal semantics are not supported by this test"
+  # A THIRD WAY INTO "GONE", AND THE OTHER TWO CASES DO NOT REACH IT.
+  #
+  # `_agmsg_pid_alive_local` refuses a pid above the POSIX ceiling and returns
+  # 1 for it -- the same 1 it returns for "no such process". So a value that
+  # is all digits but out of range, like 2147483648, passed the crude filter
+  # at the call site, was refused by the validator, and that refusal read as
+  # `gone` and released the lock. "Could not ask" became "it is dead".
+  #
+  # `not-a-pid` does not exercise this: it is cleared to empty at the call
+  # site and never reaches the validator. This value does.
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  local config="$team_dir/config.json"
+  local member_id fake shimdir made substituted
+  member_id="$(config_field "$config" '$.agents.alice.member_id')"
+  source "$SCRIPTS/lib/roster-journal.sh"
+  agmsg_roster_append_left "$team_dir" "$member_id" alice "2026-01-01T00:00:00Z"
+
+  made="$TEST_SKILL_DIR/mktemp-made-oob"
+  substituted="$TEST_SKILL_DIR/pidfile-oob"
+  shimdir="$TEST_SKILL_DIR/shim-oob"
+  mkdir -p "$shimdir"
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'out=$(/usr/bin/mktemp "$@") || exit 1'
+    printf '%s\n' '[ -e "$out" ] && printf "%s\\n" "$out" >> "$AGMSG_TEST_MKTEMP_MADE"'
+    printf '%s\n' 'printf "%s\\n" "$out"'
+  } > "$shimdir/mktemp"
+  chmod +x "$shimdir/mktemp"
+
+  fake="$TEST_SKILL_DIR/fake-node-oob-pid"
+  cat > "$fake" <<'EOF'
+#!/usr/bin/env bash
+exec >/dev/null 2>&1
+trap '' TERM
+( i=0
+  while [ "$i" -lt 25 ]; do
+    pidfile="$(sed -n '2p' "$AGMSG_TEST_MKTEMP_MADE" 2>/dev/null)"
+    if [ -n "$pidfile" ] && [ -s "$pidfile" ]; then
+      # INT32_MAX + 1: every character is a digit, and no process can have it.
+      printf '2147483648\n' > "$pidfile"
+      printf 'oob\n' > "$AGMSG_TEST_SUBSTITUTED"
+    fi
+    i=$((i + 1))
+    sleep 0.1
+  done
+) &
+while :; do sleep 1; done
+EOF
+  chmod +x "$fake"
+
+  run env PATH="$shimdir:$PATH" AGMSG_SYNC_NODE_BIN="$fake" \
+    AGMSG_TEST_MKTEMP_MADE="$made" AGMSG_TEST_SUBSTITUTED="$substituted" \
+    AGMSG_ROSTER_SYNC_TIMEOUT_S=4 \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+
+  local driver_status="$status" driver_out="$output"
+  [ "$(cat "$substituted" 2>/dev/null || true)" = "oob" ]
+  [ "$driver_status" -eq 18 ]
+  printf '%s' "$driver_out" | grep -q 'could not be established'
+  [ -d "$team_dir/.config.lock" ]
+
+  local leftover
+  leftover="$(pgrep -f "$fake" || true)"
+  if [ -n "$leftover" ]; then
+    kill $leftover 2>/dev/null || true
+    sleep 1
+    kill -9 $leftover 2>/dev/null || true
+  fi
+  rmdir "$team_dir/.config.lock" 2>/dev/null || true
+}
+
+@test "the argv match survives the Windows path alphabet (#821)" {
+  # THE COMPARISON RUNS ON TWO ALPHABETS, AND THIS MACHINE ONLY HAS ONE.
+  #
+  # Under Git Bash the shell's own path is `/c/Users/...` while a native
+  # process reports `C:/Users/...`, so a raw `case` answers "not ours" about a
+  # process that IS ours -- and silently, since a non-match is the ordinary
+  # answer. `scripts/lib/compat.sh` documents it, measured on a reporting
+  # machine, and `agmsg_cmdline_names_path` exists to take the `cygpath -m`
+  # second look.
+  #
+  # There is no Windows here, so the DIFFERENCE is driven instead: a `cygpath`
+  # stub maps this suite's real paths into the `C:/` form, and the comparator
+  # is handed a cmdline written in that form. If the driver ever goes back to
+  # a raw `case`, this is what reddens -- on the alphabet difference alone,
+  # with everything else identical.
+  source "$SCRIPTS/lib/compat.sh"
+
+  local shimdir="$TEST_SKILL_DIR/shim-cygpath"
+  mkdir -p "$shimdir"
+  # `-m` is the mixed form. The stub answers only for it, so a call with any
+  # other flag cannot accidentally satisfy the assertions below.
+  # `/c/Users/x` becomes `C:/Users/x` -- the drive letter REPLACES the leading
+  # `/c`, it is not prepended to it. Prepending leaves the original substring
+  # intact, so a raw match still fires and the case measures nothing; the
+  # premise control below caught exactly that on the first attempt.
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' '[ "$1" = "-m" ] || exit 1'
+    printf '%s\n' 'printf "C:%s\\n" "${2#/c}"'
+  } > "$shimdir/cygpath"
+  chmod +x "$shimdir/cygpath"
+
+  local script="/c/Users/agent/.agents/skills/agmsg/scripts/internal/roster-sync.mjs"
+  local conf="/c/Users/agent/.agents/skills/agmsg/teams/demo/config.json"
+  local native_cmd="node.exe C:${script#/c} reconcile C:${conf#/c}"
+
+  # POSITIVE CONTROL ON THE PREMISE: the raw comparison really does fail on
+  # this input. Without it, the assertions below could pass because the two
+  # forms happened to match, and the case would be measuring nothing.
+  run bash -c "case \"$native_cmd\" in *\"$script\"*) exit 0 ;; esac; exit 1"
+  [ "$status" -ne 0 ]
+
+  # With cygpath present, the same input is recognised.
+  PATH="$shimdir:$PATH" agmsg_cmdline_names_path "$native_cmd" "$script"
+  PATH="$shimdir:$PATH" agmsg_cmdline_names_path "$native_cmd" "$conf"
+
+  # And it is not a rubber stamp: another team's config is still refused.
+  local other="/c/Users/agent/.agents/skills/agmsg/teams/other/config.json"
+  run env PATH="$shimdir:$PATH" bash -c \
+    "source '$SCRIPTS/lib/compat.sh'; agmsg_cmdline_names_path '$native_cmd' '$other'"
+  [ "$status" -ne 0 ]
+}
+
 @test "a recycled pid is neither signalled nor read as gone (#821)" {
   skip_on_windows "POSIX signal semantics are not supported by this test"
   # "I SENT A SIGNAL" IS NOT "THE PROCESS IS GONE" (raised as BLOCKING).

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -417,6 +417,14 @@ EOF
   refute pgrep -f "$fake"
 }
 
+# Everything under the team directory that a roster operation would move, as
+# one string: names, sizes and contents. Used to say "unchanged" about state
+# that already exists, which is what a refusal before the lock has to leave.
+_roster_state_digest() {
+  local dir="$1"
+  ( cd "$dir" 2>/dev/null && ls -la . && cat ./*.json ./*.jsonl 2>/dev/null ) | shasum | cut -d' ' -f1
+}
+
 @test "roster sync refuses a timeout setting it cannot honour, and does not start the child (#821)" {
   # `read -t` rejects a zero, a negative or a non-numeric budget by failing
   # immediately, and that failure is indistinguishable from "the writer is
@@ -428,6 +436,7 @@ EOF
   printf '%s\n' '#!/usr/bin/env bash' ': > "$AGMSG_TEST_RAN"' 'exit 0' > "$fake"
   chmod +x "$fake"
 
+  local before; before="$(_roster_state_digest "$team_dir")"
   local bad
   for bad in 0 -1 abc 1.5; do
     rm -f "$ran"
@@ -442,6 +451,11 @@ EOF
     # The child is never started: refusing after the work has begun would
     # leave the state half-written for a setting error.
     [ ! -e "$ran" ]
+    # And the team's state is UNCHANGED: the refusal happens before the lock
+    # and before `agmsg_roster_ensure`, so a mistyped setting moves nothing.
+    # Compared against what was there, because the journal is created by join
+    # and "it does not exist" would be asserting the wrong thing.
+    [ "$(_roster_state_digest "$team_dir")" = "$before" ]
     # And the lock does not survive the refusal.
     [ ! -d "$team_dir/.config.lock" ]
   done
@@ -476,18 +490,53 @@ EOF
     printf '%s\n' '#!/usr/bin/env bash'
     printf '%s\n' 'if : <&9 2>/dev/null; then printf open > "$AGMSG_TEST_FD_SEEN"'
     printf '%s\n' 'else printf closed > "$AGMSG_TEST_FD_SEEN"; fi'
+    # THE PARENT'S COPY, asked of the parent. With the FIFO design this child is
+    # spawned by the driver shell itself, so $PPID is the driver and its
+    # descriptor table answers directly where one is readable. Where it is not
+    # -- macOS has no /proc -- this records that it could not look, rather than
+    # reporting "closed" from an instrument that cannot see.
+    printf '%s\n' 'if [ -d "/proc/$PPID/fd" ]; then'
+    printf '%s\n' '  if [ -e "/proc/$PPID/fd/9" ]; then printf parent-open > "$AGMSG_TEST_FD_PARENT"'
+    printf '%s\n' '  else printf parent-closed > "$AGMSG_TEST_FD_PARENT"; fi'
+    printf '%s\n' 'else printf parent-unreadable > "$AGMSG_TEST_FD_PARENT"; fi'
     printf '%s\n' 'exit 0'
   } > "$fake"
   chmod +x "$fake"
 
-  run env AGMSG_TEST_FD_SEEN="$seen" AGMSG_SYNC_NODE_BIN="$fake" \
+  local parent_seen="$TEST_SKILL_DIR/parent-fd9"
+  run env AGMSG_TEST_FD_SEEN="$seen" AGMSG_TEST_FD_PARENT="$parent_seen" \
+    AGMSG_SYNC_NODE_BIN="$fake" \
     bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
       018f3f7e-0000-7000-8000-000000000001 \
       018f3f7e-0000-7000-8000-000000000002 1 </dev/null
   [ "$status" -eq 0 ]
-  # The child ran at all — without this the assertion below passes on a file
-  # that was never written.
+  # The child ran at all — without this the assertions below pass on files
+  # that were never written.
   [ -e "$seen" ]
+  [ -e "$parent_seen" ]
   [ "$(cat "$seen")" = "closed" ]
+  # Where the descriptor table is readable, the parent's copy is gone too.
+  # Where it is not, the case says so instead of asserting an answer it did
+  # not get: an instrument that cannot look must not report "closed".
+  case "$(cat "$parent_seen")" in
+    parent-unreadable) : ;;
+    *) [ "$(cat "$parent_seen")" = "parent-closed" ] ;;
+  esac
   [ ! -d "$team_dir/.config.lock" ]
+}
+
+@test "the driver's own copy of that descriptor is closed after the spawn (#821)" {
+  # A STRUCTURAL CHECK, and it is here because the behavioural one above cannot
+  # run everywhere: reading another live process's descriptors needs /proc, and
+  # macOS has none. Reverting the parent's close would then be green on half
+  # the matrix — which is how a leak survives.
+  #
+  # So the order is asserted where it lives: the spawn, then `exec 9<&-`, with
+  # both anchors required to exist so this cannot pass by finding nothing.
+  local sh="$SCRIPTS/internal/roster-sync-driver.sh" spawn_at close_at
+  spawn_at="$(grep -n '<&9 9<&- 3>&- 4>&- 8> "\$_roster_fifo" &' "$sh" | head -1 | cut -d: -f1)"
+  close_at="$(grep -n '^  exec 9<&-$' "$sh" | head -1 | cut -d: -f1)"
+  [ -n "$spawn_at" ]
+  [ -n "$close_at" ]
+  [ "$close_at" -gt "$spawn_at" ]
 }

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -752,6 +752,28 @@ EOF
   run agmsg_roster_argv_is_ours "\"node.exe\" \"$qs\" apply \"$qc\" 018f" "$qs" "$op" "$qc"
   [ "$status" -ne 0 ]
 
+  # --- A QUOTED DATA ARGUMENT IS NOT AN INVOCATION -------------------------
+  # The first quote fix deleted every `"` from the haystack. It is true that
+  # the space between two arguments survives that -- but a quote also carries
+  # "the spaces INSIDE me are not argument separators". Strip it, and one
+  # quoted argument that merely CONTAINS the triple becomes indistinguishable
+  # from a real invocation, and a stranger picked up through pid reuse would
+  # be signalled (raised in review).
+  run agmsg_roster_argv_is_ours "node other.js --note \"$script $op $conf\" x" \
+    "$script" "$op" "$conf"
+  [ "$status" -ne 0 ]
+  # Same shape with the native paths, since that is where quoting actually
+  # arises.
+  run agmsg_roster_argv_is_ours "node.exe other.js --note \"$qs $op $qc\" x" \
+    "$qs" "$op" "$qc"
+  [ "$status" -ne 0 ]
+  # And the four legitimate quotings are all accepted -- the two paths are
+  # quoted independently, because a path with a space in it is quoted and one
+  # without it is not.
+  agmsg_roster_argv_is_ours "node \"$script\" $op \"$conf\" x" "$script" "$op" "$conf"
+  agmsg_roster_argv_is_ours "node \"$script\" $op $conf x"     "$script" "$op" "$conf"
+  agmsg_roster_argv_is_ours "node $script $op \"$conf\" x"     "$script" "$op" "$conf"
+
   # --- THREE SIGHTINGS ARE NOT A RELATION ----------------------------------
   # A real command line for a DIFFERENT run: `apply` on another team's config,
   # with the word `reconcile` present for an unrelated reason. It satisfies
@@ -807,6 +829,113 @@ EOF
   grep -q 'agmsg_roster_argv_is_ours "\$cmd"' "$SCRIPTS/internal/roster-sync-driver.sh"
 }
 
+
+@test "a TERM already sent is reported, not denied (#821)" {
+  skip_on_windows "POSIX signal semantics are not supported by this test"
+  # THE STATE CAN CHANGE BETWEEN ONE SIGNAL AND THE NEXT, and the diagnostic
+  # used to deny it (raised in review, and it stood for three rounds because I
+  # kept answering the other reviewer's items and not this one).
+  #
+  # The predicate is re-asked before TERM and again before KILL -- which is
+  # right, and means a pid that was `ours` at the first can be `unknown` at
+  # the second, through recycling or an argv that stopped being readable. The
+  # message then said "nothing was signalled on that number", which is FALSE:
+  # TERM had already gone out. An operator would go looking for a process
+  # nobody had touched.
+  #
+  # WHAT HAD TO CHANGE IS THE ARGV OF A LIVE PID, not the pidfile. The driver
+  # reads the pidfile ONCE, so swapping its contents does nothing -- the first
+  # version of this case did that and measured an ordinary timeout (status 14,
+  # "confirmed gone"). The real scenario is pid REUSE: the number stays, the
+  # process behind it changes, and the argv stops matching.
+  #
+  # A pid cannot be recycled on demand, so the OBSERVATION is driven instead:
+  # `compat_get_cmdline` reads `ps -o args= -p` off Windows, and a `ps` stub
+  # answers truthfully until a marker appears and with a decoy afterwards. The
+  # fake node traps TERM and drops that marker from inside the handler, so the
+  # transition lands exactly between TERM and KILL. It does not exit from the
+  # handler, so it survives to be observed.
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  local config="$team_dir/config.json"
+  local member_id fake shimdir made termed
+  member_id="$(config_field "$config" '$.agents.alice.member_id')"
+  source "$SCRIPTS/lib/roster-journal.sh"
+  agmsg_roster_append_left "$team_dir" "$member_id" alice "2026-01-01T00:00:00Z"
+
+  made="$TEST_SKILL_DIR/mktemp-made-term"
+  termed="$TEST_SKILL_DIR/term-received"
+  shimdir="$TEST_SKILL_DIR/shim-term"
+  mkdir -p "$shimdir"
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'out=$(/usr/bin/mktemp "$@") || exit 1'
+    printf '%s\n' '[ -e "$out" ] && printf "%s\\n" "$out" >> "$AGMSG_TEST_MKTEMP_MADE"'
+    printf '%s\n' 'printf "%s\\n" "$out"'
+  } > "$shimdir/mktemp"
+  chmod +x "$shimdir/mktemp"
+
+  # The seam: truthful until the marker exists, a decoy afterwards. Only the
+  # `-o args=` form is intercepted, so nothing else that shells out to `ps` --
+  # `_agmsg_pid_alive_local`'s own cross-check among them -- is affected.
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'if [ "$1" = "-o" ] && [ "$2" = "args=" ] && [ -e "$AGMSG_TEST_TERMED" ]; then'
+    printf '%s\n' '  printf "%s\\n" "some-unrelated-process --after-recycle"'
+    printf '%s\n' '  exit 0'
+    printf '%s\n' 'fi'
+    printf '%s\n' 'exec /bin/ps "$@"'
+  } > "$shimdir/ps"
+  chmod +x "$shimdir/ps"
+
+  fake="$TEST_SKILL_DIR/fake-node-swaps-on-term"
+  cat > "$fake" <<'EOF'
+#!/usr/bin/env bash
+exec >/dev/null 2>&1
+_on_term() { printf 'termed\n' > "$AGMSG_TEST_TERMED"; }
+trap _on_term TERM
+while :; do sleep 1; done
+EOF
+  chmod +x "$fake"
+
+  run env PATH="$shimdir:$PATH" AGMSG_SYNC_NODE_BIN="$fake" \
+    AGMSG_TEST_MKTEMP_MADE="$made" AGMSG_TEST_TERMED="$termed" \
+    AGMSG_ROSTER_SYNC_TIMEOUT_S=3 \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+
+  local driver_status="$status" driver_out="$output"
+
+  # POSITIVE CONTROL: TERM really reached the child, so the run really did
+  # traverse `ours` -> signal -> `unknown`. Without this the case could pass
+  # on an ordinary never-identifiable timeout.
+  [ "$(cat "$termed" 2>/dev/null || true)" = "termed" ]
+
+  [ "$driver_status" -eq 18 ]
+  # It says TERM WENT OUT...
+  printf '%s' "$driver_out" | grep -q 'TERM WAS SENT'
+  # ...and that KILL was withheld once the number stopped being identifiable.
+  printf '%s' "$driver_out" | grep -q 'WITHHELD'
+  # ...and it does NOT claim nothing was signalled, which is the false
+  # sentence this case exists to remove.
+  ! printf '%s' "$driver_out" | grep -q 'Nothing was signalled'
+  [ -d "$team_dir/.config.lock" ]
+
+  # KILL WAS WITHHELD, observed on the process rather than read from the
+  # message: the child is still alive. It ignores nothing -- it has no KILL
+  # handler and could not have one -- so its survival is the evidence.
+  kill -0 "$(pgrep -f "$fake" | head -1)" 2>/dev/null
+
+  local leftover
+  leftover="$(pgrep -f "$fake" || true)"
+  if [ -n "$leftover" ]; then
+    kill $leftover 2>/dev/null || true
+    sleep 1
+    kill -9 $leftover 2>/dev/null || true
+  fi
+  rmdir "$team_dir/.config.lock" 2>/dev/null || true
+}
 
 @test "a recycled pid is neither signalled nor read as gone (#821)" {
   skip_on_windows "POSIX signal semantics are not supported by this test"

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -477,6 +477,156 @@ EOF
   ! printf '%s' "$output" | grep -q 'without a time bound'
 }
 
+@test "a failing sleep does not drop the lock beside a live child (#821)" {
+  skip_on_windows "POSIX signal delivery is not supported by this test"
+  # THE WAIT'S OWN COMMAND CAN BE THE THING THAT FAILS (raised in review).
+  #
+  # `sleep` is external. Under `set -e` an unguarded one ends this shell where
+  # it stands — with the wrapper and node already started, and none of the
+  # terminate/KILL/reap reached — and the EXIT trap then releases the lock
+  # beside a live writer. That is the contract the timeout path is written to
+  # keep, broken by the command it waits with.
+  #
+  # Driven in POLL mode on purpose: poll is chosen on machines that could not
+  # make a FIFO, which is the same population that refuses spawns, so this is
+  # where the two failures actually meet. The grace `sleep` on the FIFO path
+  # is the same contract and is covered by the same stub — this run reaches
+  # both, since a poll-mode timeout still runs the TERM/grace/KILL sequence.
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  local config="$team_dir/config.json"
+  local member_id fake shimdir
+  member_id="$(config_field "$config" '$.agents.alice.member_id')"
+  source "$SCRIPTS/lib/roster-journal.sh"
+  agmsg_roster_append_left "$team_dir" "$member_id" alice "2026-01-01T00:00:00Z"
+
+  fake="$TEST_SKILL_DIR/fake-node-unkillable-nosleep"
+  cat > "$fake" <<'EOF'
+#!/usr/bin/env bash
+trap '' TERM
+while :; do read -r _ 2>/dev/null || :; done
+EOF
+  chmod +x "$fake"
+
+  # Both stubs in one directory: no FIFO (so poll is chosen) and no sleep (so
+  # every wait in the driver has to survive its own tool being broken). The
+  # fake node deliberately does NOT call sleep, so the stub cannot stop it.
+  shimdir="$TEST_SKILL_DIR/shim-nofifo-nosleep"
+  mkdir -p "$shimdir"
+  printf '%s\n' '#!/bin/sh' 'exit 1' > "$shimdir/mkfifo"
+  printf '%s\n' '#!/bin/sh' 'exit 1' > "$shimdir/sleep"
+  chmod +x "$shimdir/mkfifo" "$shimdir/sleep"
+
+  run env PATH="$shimdir:$PATH" AGMSG_SYNC_NODE_BIN="$fake" \
+    AGMSG_ROSTER_SYNC_TIMEOUT_S=2 \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+
+  # A NAMED failure — not the shell's own death from a failed sleep, which
+  # would arrive as an unexplained non-zero with no sentence at all.
+  [ "$status" -ne 0 ]
+  printf '%s' "$output" | grep -q 'did not finish within'
+  # The lock is gone BECAUSE the child was dealt with, not because a trap ran
+  # on the way out.
+  [ ! -d "$team_dir/.config.lock" ]
+  refute pgrep -f "$fake"
+}
+
+@test "the lock is not released until the inner child is confirmed gone (#821)" {
+  # A STRUCTURAL CHECK, AND THE REASON IS A LIMIT I COULD NOT GET AROUND.
+  #
+  # The property: "I sent a signal" is not "the process is gone". The inner
+  # process is a GRANDCHILD, so `wait` cannot speak for it, and every `kill`
+  # above discards its result. The release must therefore be gated on ASKING.
+  #
+  # The behavioural case would need a process that survives SIGKILL, and on a
+  # machine where this suite can run, there is none: KILL is only refused
+  # under EPERM (a sandbox) or an uninterruptible wait, and neither can be
+  # produced here. I tried and could not, and I would rather say that than
+  # ship a case that passes for a reason unrelated to the property.
+  #
+  # So the gate is asserted where it lives, with both anchors required to
+  # exist so this cannot pass by finding nothing -- the same guard that caught
+  # the spawn anchor going stale on the previous head.
+  local sh="$SCRIPTS/internal/roster-sync-driver.sh" ask_at release_at keep_at
+  # The question is asked with the repo's own instrument, not a bare kill -0.
+  ask_at="$(grep -n '_agmsg_pid_alive_local "\$_roster_inner"' "$sh" | tail -1 | cut -d: -f1)"
+  # The lock is deliberately kept by emptying the library's own list.
+  keep_at="$(grep -n '^        AGMSG_HELD_LOCKS=""$' "$sh" | head -1 | cut -d: -f1)"
+  # The timeout path's release, which must come after the question.
+  release_at="$(grep -n '^      agmsg_lock_release$' "$sh" | head -1 | cut -d: -f1)"
+
+  [ -n "$ask_at" ]
+  [ -n "$keep_at" ]
+  [ -n "$release_at" ]
+  [ "$release_at" -gt "$ask_at" ]
+  [ "$keep_at" -gt "$ask_at" ]
+  [ "$keep_at" -lt "$release_at" ]
+  # And the instrument is the sourced one, so this cannot be satisfied by a
+  # bare `kill -0` reintroduced beside it -- which a repo-wide check also
+  # refuses, from the other direction.
+  grep -q 'source "\$SKILL_DIR/scripts/lib/instance-id.sh"' "$sh"
+}
+
+@test "a partial temp setup leaves nothing behind (#821)" {
+  # `mktemp` IS CALLED THREE TIMES, INDEPENDENTLY (raised in review), so
+  # "could not build a bound" is not one state: the sentinel can exist while
+  # the pidfile failed. Both ways out of that state used to walk past whatever
+  # had already been made.
+  #
+  # It matters because of WHY this path is reached: a temp directory that is
+  # full. A feature answering a full filesystem by adding a file to it is the
+  # wrong shape.
+  #
+  # The stub fails only from the SECOND call on, so the first `mktemp -u`
+  # succeeds and the sentinel's does not. The previous cases all failed every
+  # call, which never produced this shape.
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  local shimdir counter before after fake
+  fake="$TEST_SKILL_DIR/fake-node-partial"
+  printf '%s\n' '#!/bin/sh' 'exit 0' > "$fake"
+  chmod +x "$fake"
+
+  counter="$TEST_SKILL_DIR/mktemp-calls"
+  shimdir="$TEST_SKILL_DIR/shim-partial-mktemp"
+  mkdir -p "$shimdir"
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'n=$(cat "$AGMSG_TEST_MKTEMP_COUNTER" 2>/dev/null || echo 0)'
+    printf '%s\n' 'n=$((n + 1)); printf %s "$n" > "$AGMSG_TEST_MKTEMP_COUNTER"'
+    printf '%s\n' '[ "$n" -ge 2 ] && exit 1'
+    printf '%s\n' 'exec /usr/bin/mktemp "$@"'
+  } > "$shimdir/mktemp"
+  chmod +x "$shimdir/mktemp"
+
+  # Every temp path this driver could have created lives in TMPDIR, so the
+  # question is asked of the directory itself: what is in it before, and what
+  # is in it after. Counting entries rather than naming them, because the
+  # names are generated and the assertion is about residue, not identity.
+  export TMPDIR="$TEST_SKILL_DIR/tmp-partial"
+  mkdir -p "$TMPDIR"
+  before="$(find "$TMPDIR" -type f | wc -l | tr -d ' ')"
+
+  run env PATH="$shimdir:$PATH" AGMSG_SYNC_NODE_BIN="$fake" \
+    AGMSG_TEST_MKTEMP_COUNTER="$counter" TMPDIR="$TMPDIR" \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+
+  # It took the refusal, which is what a partial setup must do.
+  [ "$status" -eq 16 ]
+  # POSITIVE CONTROL ON THE STUB: without this, a stub that never ran would
+  # leave the case asserting "no residue" about a run that had no temps to
+  # leave. Two calls means the first succeeded and the second was refused --
+  # exactly the partial shape.
+  [ "$(cat "$counter")" -ge 2 ]
+  after="$(find "$TMPDIR" -type f | wc -l | tr -d ' ')"
+  [ "$after" -eq "$before" ]
+  [ ! -d "$team_dir/.config.lock" ]
+}
+
 @test "roster sync refuses, rather than waiting unbounded, when it cannot build a bound (#821)" {
   # `mkfifo` failing has a second way to wait. `mktemp` failing has none: with
   # no sentinel there is nothing to watch, so the choice is between refusing

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -493,11 +493,14 @@ _roster_state_digest() {
     printf '%s\n' '#!/usr/bin/env bash'
     printf '%s\n' 'if : <&9 2>/dev/null; then printf open > "$AGMSG_TEST_FD_SEEN"'
     printf '%s\n' 'else printf closed > "$AGMSG_TEST_FD_SEEN"; fi'
-    # THE PARENT'S COPY, asked of the parent. With the FIFO design this child is
-    # spawned by the driver shell itself, so $PPID is the driver and its
-    # descriptor table answers directly where one is readable. Where it is not
-    # -- macOS has no /proc -- this records that it could not look, rather than
-    # reporting "closed" from an instrument that cannot see.
+    # THE PARENT'S COPY, asked of the parent. $PPID here is the WRAPPER shell
+    # that carries node's pid, not the driver -- an earlier version of this
+    # comment said it was the driver, and that stopped being true when the
+    # wrapper was introduced. The assertion did not need changing: whoever the
+    # parent is, it must not be holding the caller's stdin, and this is the
+    # instrument that caught the wrapper doing exactly that. Where the table
+    # cannot be read -- macOS has no /proc -- this records that it could not
+    # look, rather than reporting "closed" from an instrument that cannot see.
     printf '%s\n' 'if [ -d "/proc/$PPID/fd" ]; then'
     printf '%s\n' '  if [ -e "/proc/$PPID/fd/9" ]; then printf parent-open > "$AGMSG_TEST_FD_PARENT"'
     printf '%s\n' '  else printf parent-closed > "$AGMSG_TEST_FD_PARENT"; fi'
@@ -534,14 +537,39 @@ _roster_state_digest() {
   # macOS has none. Reverting the parent's close would then be green on half
   # the matrix — which is how a leak survives.
   #
-  # So the order is asserted where it lives: the spawn, then `exec 9<&-`, with
-  # both anchors required to exist so this cannot pass by finding nothing.
-  local sh="$SCRIPTS/internal/roster-sync-driver.sh" spawn_at close_at
-  spawn_at="$(grep -n '<&9 9<&- 3>&- 4>&- 8> "\$_roster_fifo" &' "$sh" | head -1 | cut -d: -f1)"
-  close_at="$(grep -n '^  exec 9<&-$' "$sh" | head -1 | cut -d: -f1)"
-  [ -n "$spawn_at" ]
-  [ -n "$close_at" ]
-  [ "$close_at" -gt "$spawn_at" ]
+  # So the order is asserted where it lives, with every anchor required to
+  # exist so this cannot pass by finding nothing.
+  #
+  # THERE ARE THREE COPIES OF fd 9, NOT TWO, AND THAT IS WHY THIS CASE CHANGED.
+  # The wrapper that carries node's pid is a shell of its own, and it inherits
+  # fd 9 like anything else. Its earlier version closed it nowhere, so the
+  # caller's stdin was held for the whole operation by a process that neither
+  # the child's close nor the driver's reaches. CI caught it on the /proc half.
+  # Each close is anchored separately below, after the spawn it belongs to.
+  local sh="$SCRIPTS/internal/roster-sync-driver.sh"
+  local node_at wrapper_close_at group_at parent_close_at
+
+  # 1. node is handed the descriptor and drops its saved copy in one redirection.
+  node_at="$(grep -n '"\$@" <&9 9<&- &$' "$sh" | head -1 | cut -d: -f1)"
+  # 2. the wrapper closes its own copy — indented inside the brace group.
+  wrapper_close_at="$(grep -n '^    exec 9<&-$' "$sh" | head -1 | cut -d: -f1)"
+  # 3. the brace group is backgrounded.
+  group_at="$(grep -n '^  } 3>&- 4>&- 8> "\$_roster_fifo" &$' "$sh" | head -1 | cut -d: -f1)"
+  # 4. the driver closes its copy — at the driver's own indent, which is why
+  #    the two `exec 9<&-` anchors cannot be confused for one another.
+  parent_close_at="$(grep -n '^  exec 9<&-$' "$sh" | head -1 | cut -d: -f1)"
+
+  [ -n "$node_at" ]
+  [ -n "$wrapper_close_at" ]
+  [ -n "$group_at" ]
+  [ -n "$parent_close_at" ]
+
+  # The wrapper's close is after node has the descriptor, and before the group
+  # ends — remove it and this is the assertion that goes red.
+  [ "$wrapper_close_at" -gt "$node_at" ]
+  [ "$wrapper_close_at" -lt "$group_at" ]
+  # The driver's close is after the group is spawned.
+  [ "$parent_close_at" -gt "$group_at" ]
 }
 
 @test "the timeout setting is validated before the lock is taken (#821)" {

--- a/tests/test_roster_journal.bats
+++ b/tests/test_roster_journal.bats
@@ -417,6 +417,128 @@ EOF
   refute pgrep -f "$fake"
 }
 
+# A directory that shadows one command with a failing stub, for the two cases
+# below. Only the named command is replaced; everything else still resolves
+# normally, so the driver is exercised rather than a crippled shell.
+_shim_failing() {
+  local name="$1" dir="$TEST_SKILL_DIR/shim-$name"
+  mkdir -p "$dir"
+  printf '%s\n' '#!/bin/sh' 'exit 1' > "$dir/$name"
+  chmod +x "$dir/$name"
+  printf '%s' "$dir"
+}
+
+@test "roster sync is still bounded when no FIFO can be made (#821)" {
+  skip_on_windows "POSIX signal delivery is not supported by this test"
+  # THE PATH THAT USED TO DROP THE PROPERTY. When `mkfifo` failed, this fell
+  # back to a foreground call with no ceiling and said `running without a time
+  # bound` — which is the state #821 exists to forbid, reached by the code
+  # meant to hold it. Three reviewers raised it independently.
+  #
+  # A FIFO is only the cheaper way to wait. Without one the sentinel is polled,
+  # and the ceiling is the same. This case is the difference between the two
+  # readings of "the instrument could not be built".
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  local config="$team_dir/config.json"
+  local member_id fake shim
+  member_id="$(config_field "$config" '$.agents.alice.member_id')"
+  source "$SCRIPTS/lib/roster-journal.sh"
+  agmsg_roster_append_left "$team_dir" "$member_id" alice "2026-01-01T00:00:00Z"
+
+  fake="$TEST_SKILL_DIR/fake-node-unkillable-nofifo"
+  cat > "$fake" <<'EOF'
+#!/usr/bin/env bash
+trap '' TERM
+while :; do sleep 1; done
+EOF
+  chmod +x "$fake"
+  shim="$(_shim_failing mkfifo)"
+
+  run env PATH="$shim:$PATH" AGMSG_SYNC_NODE_BIN="$fake" \
+    AGMSG_ROSTER_SYNC_TIMEOUT_S=2 \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+
+  # Bounded, exactly as with a FIFO: a failure that names itself, no lock, no
+  # child. Same three assertions as the FIFO case, deliberately.
+  [ "$status" -ne 0 ]
+  printf '%s' "$output" | grep -q 'did not finish within'
+  [ ! -d "$team_dir/.config.lock" ]
+  refute pgrep -f "$fake"
+  # And it must NOT have announced that it was running unbounded — the old
+  # sentence is the marker of the path this case exists to remove.
+  #
+  # `!` and not `refute`: `refute` takes a command, and a pipe binds tighter,
+  # so `refute printf ... | grep` hands `refute` only the `printf` and asserts
+  # something else entirely. Measured — it failed against output that does not
+  # contain the string.
+  ! printf '%s' "$output" | grep -q 'without a time bound'
+}
+
+@test "roster sync refuses, rather than waiting unbounded, when it cannot build a bound (#821)" {
+  # `mkfifo` failing has a second way to wait. `mktemp` failing has none: with
+  # no sentinel there is nothing to watch, so the choice is between refusing
+  # and holding the team lock for an unlimited time. It refuses, and says how
+  # to override that on purpose.
+  #
+  # The child must not be started at all — running it and then complaining is
+  # the same unbounded wait with a better message.
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  local ran="$TEST_SKILL_DIR/refuse-child-ran" fake shim
+  fake="$TEST_SKILL_DIR/fake-node-marks"
+  printf '%s\n' '#!/bin/sh' 'printf ran > "$AGMSG_TEST_RAN"' 'exit 0' > "$fake"
+  chmod +x "$fake"
+  shim="$(_shim_failing mktemp)"
+
+  run env PATH="$shim:$PATH" AGMSG_SYNC_NODE_BIN="$fake" \
+    AGMSG_TEST_RAN="$ran" \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+
+  [ "$status" -eq 16 ]
+  # The reason AND the way out, because a refusal with neither is a wall.
+  printf '%s' "$output" | grep -q 'cannot create the temporary files'
+  printf '%s' "$output" | grep -q 'AGMSG_ROSTER_SYNC_UNBOUNDED=1'
+  # The lock is released by the refusal itself.
+  [ ! -d "$team_dir/.config.lock" ]
+  # Nothing was run.
+  [ ! -e "$ran" ]
+}
+
+@test "the unbounded path is still reachable, but only by asking for it (#821)" {
+  # FAIL-CLOSED NEEDS A WAY OUT. An operator whose filesystem cannot hold a
+  # temp file may still prefer syncing to refusing, and can say so by name.
+  # What was removed is the SILENT return to that behaviour, not the behaviour.
+  #
+  # Driven by a child that exits immediately: this case is about the route
+  # being open and announced, and a hanging child here would hang the suite —
+  # which is the honest shape of "no bound".
+  bash "$SCRIPTS/join.sh" demo alice claude-code /tmp/a
+  local team_dir="$TEST_SKILL_DIR/teams/demo"
+  local ran="$TEST_SKILL_DIR/unbounded-child-ran" fake shim
+  fake="$TEST_SKILL_DIR/fake-node-quick"
+  printf '%s\n' '#!/bin/sh' 'printf ran > "$AGMSG_TEST_RAN"' 'exit 0' > "$fake"
+  chmod +x "$fake"
+  shim="$(_shim_failing mktemp)"
+
+  run env PATH="$shim:$PATH" AGMSG_SYNC_NODE_BIN="$fake" \
+    AGMSG_TEST_RAN="$ran" AGMSG_ROSTER_SYNC_UNBOUNDED=1 \
+    bash "$SCRIPTS/internal/roster-sync-driver.sh" reconcile demo \
+      018f3f7e-0000-7000-8000-000000000001 \
+      018f3f7e-0000-7000-8000-000000000002 1 </dev/null
+
+  [ "$status" -eq 0 ]
+  # It ran, and it warned — an unbounded wait taken deliberately still has to
+  # be visible in the output of the run that took it.
+  [ -e "$ran" ]
+  printf '%s' "$output" | grep -q 'NO time bound'
+  [ ! -d "$team_dir/.config.lock" ]
+}
+
 # Everything under the team directory that a roster operation would move, as
 # one string: names, sizes and contents. Used to say "unchanged" about state
 # that already exists, which is what a refusal before the lock has to leave.
@@ -554,7 +676,7 @@ _roster_state_digest() {
   # 2. the wrapper closes its own copy — indented inside the brace group.
   wrapper_close_at="$(grep -n '^    exec 9<&-$' "$sh" | head -1 | cut -d: -f1)"
   # 3. the brace group is backgrounded.
-  group_at="$(grep -n '^  } 3>&- 4>&- 8> "\$_roster_fifo" &$' "$sh" | head -1 | cut -d: -f1)"
+  group_at="$(grep -n '^  } 3>&- 4>&- 8> "\$_roster_write_target" &$' "$sh" | head -1 | cut -d: -f1)"
   # 4. the driver closes its copy — at the driver's own indent, which is why
   #    the two `exec 9<&-` anchors cannot be confused for one another.
   parent_close_at="$(grep -n '^  exec 9<&-$' "$sh" | head -1 | cut -d: -f1)"


### PR DESCRIPTION
Declared reviewers: 2

**Existing-user impact: YES — this needs koit's explicit GO before it lands.**

Not a CI-only change. It alters what an existing install does when a roster sync stops responding, in three ways a user can meet:

- a hang that used to wait forever now **fails at a ceiling** (default 120s, `AGMSG_ROSTER_SYNC_TIMEOUT_S`), with a named error instead of silence;
- on the paths where the child cannot be confirmed stopped, the team lock is **deliberately kept**, and clearing it is a manual step the message spells out — previously the lock came off unconditionally, which is the defect, but "a directory you must remove by hand" is still a new thing for a user to meet;
- new exit codes (14 / 16 / 17 / 18 / 19) and a new opt-out (`AGMSG_ROSTER_SYNC_UNBOUNDED=1`) for the case where no bound can be built at all.

I am not pressing this. Classification is mine to state, not to decide on.

Closes #821. Refs #817.

Landing on `main`. Head `87d91e1a208b3d3c3a7725b6693b857bef104345`.

> Base moved from `integration/remote` to `main`. On the default branch `Closes #821` **does** fire, so #821 closes on merge and needs no hand-closing. An earlier version of this body said the opposite, which was true only of the old base.

> **Three `probe:` commits have been dropped from this branch's history.** They were an ablation from the shard investigation — one of them says *not to be landed* in its own subject line — and they sat mid-branch, so a merge commit would have carried them onto `main` (raised in review). Removed with `git rebase --onto`; the resulting tree is **byte-identical** to the branch before the surgery, checked by `git diff` and by comparing the blob ids of both changed files.

## What this does not do

**It leaves #817 open, and it does not unblock the Windows walk.** That investigation is live and its mechanism is not settled — several accounts have been put forward and withdrawn on the machine's own evidence, and this PR quotes none of them, because a body that names a cause the investigation has already moved past is worse than one that names none. What is settled enough to say: it is in the start path, in a different file, and it needs a different change. Earlier guesses that this driver's spawn or its holder metadata explained it were measured and dropped.

What this holds is one property, split out of that issue and filed as #821:

> A local child that hangs must not hold the per-team critical section indefinitely.

## Why the property is worth holding on its own

`roster-sync-driver.sh` takes the per-team lock and waits on node with no ceiling. Under `set -e` a child that fails to launch, or exits non-zero, still reaches this shell's own exit, so the EXIT trap releases the lock. A child that **hangs** has no answer: the shell waits, the trap never runs, and the next start meets `.config.lock: File exists` left by a process that is alive and will never finish.

The lock's *scope* is right and does not change. `roster-sync.mjs` is the read-modify-write being serialised; it does no network (measured, with a positive control on the search), and its whole input is written to fd 0 before it starts. #817's original direction — move the "network call" out of the lock — would have moved the thing the lock protects.

## The bound adds no process that outlives the call

The first version put a watchdog beside the child. That is one more spawn per roster operation, and the leading explanation for the field failure is process pressure — a spawn refused with a Windows DLL-initialisation status. **A guard against hanging that raises the number of spawns can make the thing it guards against more likely** (raised in review, and correct).

So the wait is bounded by a **read**, not by a process. The child is given one end of a FIFO it never writes to; when it exits, that end closes and the read returns end-of-file.

**How the two outcomes are told apart is not the read's status, and that is a correction to an earlier version of this body.** It said `read -t` separates them by status, above 128 meaning the budget expired. That is true of Bash 4 and later. It is **false on `/bin/bash` 3.2.57, which is what the macOS runners execute** — measured directly there, and both outcomes return 1:

```
timeout  → rc=1
EOF      → rc=1
```

So a bound written as `status > 128` is never taken on half the matrix. The symptom was not subtle: a 2-second budget survived 25 minutes. What replaces it is a **sentinel**. A wrapper around node writes node's exit status to a file as its last act; this side reads the file. Present means the child finished and the file carries its status; absent means it did not, and the budget has expired. `read -t`'s status is now deliberately discarded — `|| true` — because on 3.2 it cannot answer the question.

**No process is added that outlives the call.** What is *not* claimed is "no extra process at all": before the child runs there are **four** — `mktemp` three times (the FIFO path, the sentinel, the pidfile) and `mkfifo` once — plus `rm` on the way out. That count went up by two when the sentinel replaced the status test, and saying so is the point of writing it down; an earlier version of this body said "three spawns, two contracts", and before that "one process runs, exactly as before", which was false. They are short-lived and sequential, where a watchdog is concurrent and lives as long as the operation; on a machine refusing spawns, a process held open beside every roster call is the shape that matters. The four are **checked**, and what happens when one fails is **not** "fall back to the unbounded path" — that is what this used to do, and it is the defect; see the mode table in the next section. `rm` and `sleep` are deliberately **unchecked** — their results are made irrelevant with `|| true`, because they run while the child is alive and a failed unlink or a refused spawn must not end this shell and let the EXIT trap drop the lock beside a live writer.

## Failing to build the bound must not run without one

**This is the largest change since the first review, and three reviewers raised it independently.** Where a FIFO could not be created, this used to fall back to the foreground call with no ceiling, and print `running without a time bound` while doing it. That is not a fallback — it is the state #821 forbids, reached by the code written to hold it. Worse, it is reached on exactly the machines least able to afford it: a temp directory that is full or unwritable is the same condition that makes a child hang, so the two arrive together.

A FIFO is only the **cheaper** way to wait, not the only one:

| mode | how it waits | needs |
|---|---|---|
| `fifo` | blocking read on a descriptor the wrapper holds — **spawns nothing while waiting**, which is why it is preferred on a machine refusing spawns | two temp files and a FIFO |
| `poll` | the sentinel is looked for on a timer — one `sleep` per second of waiting | two temp files |
| `none` | there is no bound to be had | — |

`none` now **refuses**: it releases the lock and says why, naming the likely causes and the override. The old behaviour stays reachable through `AGMSG_ROSTER_SYNC_UNBOUNDED=1`, because fail-closed with no way out is a wall — what is removed is the *silent* return to it, and a run that takes that route still says so on stderr.

The three `mktemp` calls are independent, so `none` is not one state — the sentinel can exist while the pidfile failed. Whatever was made is swept once, before either route out is taken: the condition that sends a run down here is *a full temp filesystem*, and answering that by leaving a file on it is the wrong shape.

## Releasing the lock is gated on asking, not on having signalled

The second thing three reviewers converged on, and the sharper of the two.

The timeout path sends TERM, waits, sends KILL — and **discarded every result**. The inner process is a *grandchild*, so `wait` cannot speak for it either; only the wrapper is this shell's child. So the release rested on nothing at all: a signal refused by a sandbox, or a process wedged in an uninterruptible wait, and the lock came off with the writer still running. That is the one outcome the whole path exists to avoid, and the code's own comment said so two branches above.

It is now gated on `_agmsg_pid_alive_local` — the repo's own instrument, which reads EPERM as alive, treats a zombie as gone, and cross-checks with `ps` so a sandbox refusing to signal cannot be mistaken for an absent process. When the answer is "still there", **the lock is kept**: `AGMSG_HELD_LOCKS` is emptied so the EXIT trap finds nothing to drop, and the message names the pid and the path to remove. Exit 17, distinct from the 14 that means "stopped and confirmed gone".

### A number in a file is not an identity

The first version of that gate asked only whether the pid was **alive**, and the signals above it went to whatever the pidfile said. A pid is recycled the moment its process is reaped, so between the wrapper writing that number and this side reading it, it can belong to something else — and TERM, then KILL, went to a stranger. The machine this budget exists for is one under process pressure, which is also a machine turning pids over quickly.

**The answer was already in this repo**, and a reviewer pointed at it. `_remote_sync_engine_status` in `scripts/remote.sh`:

> A live PID is not enough: PID reuse can make an unrelated process pass `kill -0`, so running requires the exact engine script/team suffix in argv.

The same shape is used here, through `compat_get_cmdline` — the function that path already uses on every platform this ships to. The suffix carries `$config`, which is per-team, so a roster sync for a *different* team cannot satisfy it.

It is **one predicate**, `_roster_inner_still_ours`, used by the TERM, by the KILL and by the release decision, so the signalling path and the gate cannot answer differently. It is **re-asked before the KILL** rather than remembered: the grace period is exactly the window in which the number can change hands.

**This produces a third state, and the reason is which way each half fails:**

| answer | what it costs |
|---|---|
| wrong "still ours" | the lock is held when it need not be — visible, named, fixable by hand |
| wrong "gone" | the lock comes off beside a live writer — silent, and it corrupts |

`_agmsg_pid_alive_local` errs toward *alive*; the argv match errs toward *not ours*. Their conjunction therefore errs toward **"gone"** — the wrong direction. So the predicate prints a word rather than answering yes or no:

| word | meaning |
|---|---|
| `ours` | alive, and still carrying this operation's argv |
| `gone` | not alive — **the only answer that authorises a release** |
| `unknown` | no usable pid recorded, **or** a pid the repo's validator refuses, **or** alive with an argv that does not match |

**Two more things reached `gone`, and both were found in review after the three-state split.**

A pid can be **all digits and still unusable**. `_agmsg_pid_alive_local` refuses anything above the POSIX ceiling and returns 1 — the same 1 it returns for "no such process" — so `2147483648` passed the crude filter at the call site, was refused by the validator, and that refusal read as `gone`. *Could not ask* became *it is dead*. The validator is consulted first now, and its refusal is `unknown`.

And **the argv comparison ran on two alphabets.** Under Git Bash the shell's path is `/c/Users/…` while a native process reports `C:/Users/…`, so a raw `case` answers "not ours" about a process that **is** ours — silently, since a non-match is the ordinary answer. `scripts/lib/compat.sh` documents this, measured on a reporting machine, and `agmsg_cmdline_names_path` exists to take the `cygpath -m` second look; `_remote_sync_engine_status` already used it. As first written, Windows would have kept the lock on **every** timeout, on its own healthy child. The whole question now lives in **`agmsg_roster_argv_is_ours`**, in `scripts/lib/roster-journal.sh`, and it took four rounds of review to get right. Each round found something the previous needle let through:

| what it let through | the fix |
|---|---|
| a shell-side path never matches a native one — Windows would keep the lock on **every** timeout, on its own healthy child | `cygpath -m` on each path part, the conversion `agmsg_cmdline_names_path` uses |
| "contains the script" + "contains a config" + "contains this operation" — three questions that a *different* run satisfies at once | the ordered sequence `<script> <operation> <config>`, as one run of text |
| an ordered substring is still a substring: `config.json` matched `config.json.bak`, and our absolute script path is a tail of `/x/opt/…/roster-sync.mjs` | the haystack padded with a space at each end, so one pattern requires both argument boundaries |
| a native command line **quotes** any argument containing a space, so `"C:/Users/First Last/…"` never matched | the four legitimate quotings enumerated — each path is quoted independently, and the quote sits inside the boundary space |
| …and the first fix for that, **deleting every quote**, opened a false *positive*: `node other.js --note "<script> reconcile <config>"` — one quoted **data** argument that merely contains the triple — became indistinguishable from a real invocation, so a stranger found through pid reuse would have been signalled | the quotes stay. A quote is not decoration: it carries *"the spaces inside me are not argument separators"* |

**And it lives in a library because of how it was being tested.** Inline in the driver, the only way to reach it was to run the driver — so its cases re-implemented the comparison with `bash -c case` and then asserted on the driver with `grep`. That measures a duplicate and a spelling, and would not notice production diverging from either (raised in review). Every row above now goes through the real function; the one structural assertion left is about **wiring** — that the driver still calls it.

That function is on `main` and not on this branch's original merge-base, so **the branch is rebased onto `main`** — `git range-diff` reports `=` for all 19 commits carried across.

**`unknown` is not a residual category, and all of its inputs were once read as "gone".** An unusable pidfile means the wrapper never got as far as writing the number, so whether node started is not known — that used to release the lock. A live pid with a different argv is either a recycled number or our own child on a platform that would not hand the argv over — that used to release it too. Either way: exit 18, the lock kept, and the message saying nothing was signalled on that number.

Returning a boolean was the shape of the bug, twice: every caller had to read "false" as "gone", so the unsafe reading sat on the default path. The word is taken **once** and dispatched to three arms, and a word this code does not recognise **keeps the lock** (exit 19) rather than falling through to the release — because a fourth state added later would otherwise inherit an authorisation nobody meant to give it.

**The post-timeout sentinel no longer short-circuits the gate**, and it asks for the *word*, not for a yes/no. It is written only after the wrapper's `wait` on node returned, so it *should* imply the inner process is gone — but that is an argument about the wrapper's code, not an observation of the machine, and the branch it guards is the one that releases the lock.

**Only that branch.** The *normal-completion* sentinel — the one reached when the wait ends inside the budget — still releases without asking, and an earlier version of this paragraph claimed the gate covered every sentinel branch, which the code does not support (raised in review). The distinction is deliberate: on the normal path nothing has been signalled and the wrapper reached its last act unhindered, so the argument above is all there is. On the post-timeout path we have just tried to kill things, which is exactly when "it should be gone" stops being good enough.

**This does not reopen #821.** That property is "a hanging child must not hold the critical section *indefinitely*, silently". This shell exits, now, with instructions. What it refuses to do is claim a process was stopped when it was not.

### And it reports what it actually attempted

The predicate is re-asked before TERM and again before KILL — which is right, and means a pid that was `ours` at the first can be `unknown` at the second. The diagnostic then said **"nothing was signalled on that number"**, which in that case is *false*: a TERM had already been attempted, and an operator reading it would go looking for a process nobody had touched. Raised by a reviewer, and it stood for three rounds because I kept answering the other reviewer's items and not this one.

What was attempted is recorded, and the message distinguishes three outcomes: nothing attempted, **TERM attempted and KILL withheld** once the number stopped being identifiable, and both attempted.

**ATTEMPTED, not sent — and the distinction was itself a review finding.** `kill … || true` discards its status, so what this shell can honestly record is that it *called* `kill`. Under EPERM or ESRCH the earlier wording, "TERM WAS SENT", was false — the same discarded-result boundary this whole path exists to respect, crossed again in the reporting. Delivery is not claimed at all: a zero from `kill` would not prove it either.

**And the transition runs both ways, which was a safety hole rather than a reporting one.** A number can read `unknown` before TERM and `ours` before KILL — recycling, or an instrument that failed once and recovered. The old code then sent **KILL to a number it had just refused to send TERM to**, escalating against something it had never established a claim on. Escalation is monotone now: KILL requires both that we were entitled to TERM this number *and* that it is still ours. A number once judged unidentifiable is not re-adopted later in the same timeout.

Its case drives that direction by **call count** rather than by a timer, so there is no race: the `ps` stub answers with a decoy on its first call and truthfully after. That no KILL was sent is measured **on the child** — it ignores TERM, but nothing ignores KILL, so its survival is the evidence. Removing the monotone gate kills it.

Driving that took two attempts, and the first was measuring the wrong thing. It swapped the *pidfile* — which does nothing, because the driver reads that file once — and produced an ordinary timeout at status 14. The scenario is pid **reuse**: the number stays and the process behind it changes. So the *observation* is driven instead, with a `ps -o args=` stub that answers truthfully until the child's TERM handler drops a marker. That KILL was withheld is then checked **on the child**, which survives.

## The wait's own tools can be the thing that fails

`sleep` is an external command, and there were three unguarded ones under `set -euo pipefail`. A refused spawn ended the shell where it stood — with the wrapper and node already started, and the terminate/KILL/reap never reached — leaving the EXIT trap to release the lock beside a live writer. The `rm` beside them already carried `|| true` for exactly this reason; the sleeps did not.

It is not a hypothetical placement: **poll mode is chosen on machines that could not make a FIFO, which is the same population that refuses spawns.** The two failures meet there by construction.

Guarded. A failing `sleep` now costs a hot but bounded spin against `SECONDS` instead of a released lock.

Both waits sit inside one spawn and one teardown: when there is no FIFO the wrapper's fd 8 goes to `/dev/null`, so the line that starts the child is identical in both modes and its descriptor closing cannot drift between them.

## Fourteen defects of my own, each caught by a measurement or a reviewer

Worth reading, because all fourteen are the shape this work is about. Nine of
them are mine from the original build; the last five arrived *after* review
started — two from CI on this PR, two from reviewers, and one from mutating my
own tests and finding they could not fail:

1. **The first version's `$!` was the subshell, not node.** Signalling it left node orphaned, still holding this shell's stdout, so a caller capturing output waited for an EOF that never came. *A fix for a hang that hung* — measured as a test that did not finish.
2. **`wait` under `set -e` killed the wrapper before it could record the status.** A child exiting 13 in milliseconds was reported as a timeout after 135 seconds. Measured: two node suites failing.
3. **A failed `rm` would have released the lock beside a live writer.** Unlinking the FIFO after the spawn is an external command under `set -e`: a refused spawn, or a filesystem that will not unlink, ends this shell while the child is still running, and the EXIT trap then drops the lock with the writer still going — the fix creating the very thing it closes (raised in review). Guarded; the FIFO is already open on fd 8, so unlinking it is tidiness, and tidiness may not decide whether the lock is held.
4. **The descriptor that fixed the stdin problem leaked in turn.** `<&9` duplicates the caller's stdin onto fd 0 and leaves fd 9 open beside it, so node held the stream twice and this shell held it until its own exit — the same "a child keeps the caller's streams" class, reintroduced by the fix for it (raised in review). Closed in the child's redirection and in the parent immediately after the spawn.
5. **A backgrounded child gets `/dev/null` for stdin.** The records the engine had already written to fd 0 were still there and nothing was reading them — every operation failed with `roster prepare input is invalid`. The descriptor is duplicated and handed back explicitly now.
6. **The bound was written against a `read -t` contract that does not hold where it runs.** See above: `>128` on Bash 3.2 is never true, so the ceiling existed in the source and not in the behaviour. Found by measuring `/bin/bash` itself, not by reading it — the documented contract and the installed one disagreed.
7. **Item 1's class came back in the replacement design.** With the sentinel, killing the *wrapper* rather than the inner node left node orphaned holding the caller's stdout again: a 3-second budget had not returned after 17 minutes. The inner pid is recorded in a pidfile and signalled first now, then the wrapper, then both are reaped.
8. **The node spawn line did not literally close fd 3 and fd 4.** The enclosing group closes both, so nothing was at risk — but the repo-wide guard reads the *line*, deliberately, because an exemption keyed on "something upstream closes them" accepts a close inside a branch that never runs. Red in CI on the previous head, in a different shard from the two below. **I reported that head as failing two cases; it failed three.** I had opened one shard's log and read the other's *name* — the same "a claim wider than what was measured" this PR is otherwise about.
9. **The wrapper introduced by item 7 held the caller's stdin.** There are **three** copies of fd 9, not two: the driver's, node's, and the wrapper shell's — and the wrapper closed its own nowhere, so the caller's stdin was held for the whole operation by a process neither existing close reaches. **CI found this**, on the half of the matrix that can read `/proc`: the behavioural case asked `$PPID` for fd 9 and got `open`, which was the truth. The case's own comment asserted `$PPID` was the driver; that stopped being so the moment the wrapper appeared, and the comment is corrected beside the fix. The structural case failed at the same time for the opposite reason — it anchored on a spawn line the sentinel design had already split in two, so it **found nothing**, which is exactly what its "both anchors must exist" guard exists to catch. It is re-anchored on all four points now, each close ordered against the spawn it belongs to.
10. **The bound was allowed to disappear when it could not be built.** See "Failing to build the bound must not run without one" above. Raised as BLOCKING by three reviewers independently, and the correct call: "the instrument could not be made, so drop the property" is the defect wearing a fallback's clothes.
11. **The lock was released on the strength of having sent a signal, and the signals went to a bare number.** Every `kill` on the timeout path discarded its result, and the inner process is a grandchild `wait` cannot speak for — so the release rested on nothing. Then the gate that fixed it asked only about liveness, which reads a recycled pid as our own child. Both halves raised in review; both above.
12. **Three `sleep`s were unguarded under `set -e`.** The command the wait is made of could end the shell mid-critical-section and leave the trap to drop the lock. The `rm` beside them had carried `|| true` for that exact reason since an earlier round; the sleeps were added later and did not inherit the lesson.
13. **A partial `mktemp` setup left its own residue** on a path reached because the temp filesystem is full.
14. **Three of my own tests were green for the wrong reason** — a structural gate that survived its mutation, a residue check pointed at a directory the code never writes to, and a control that read a file the code deletes. All three found by mutating rather than by reading. Detailed under "Test" above, because a test that cannot fail is the same defect class as a claim wider than its measurement, and this PR is otherwise about that.

## Test

`tests/test_roster_journal.bats`, seventeen cases — named, so the count cannot drift from the contents:

```
roster sync bounds a local child that never finishes, and releases the lock
roster sync is still bounded when no FIFO can be made
a failing sleep does not drop the lock beside a live child
an unusable pidfile is not read as a child that exited
a numeric but unusable pid is not read as a child that exited
the production argv matcher: alphabet, quoting, order and boundaries
a TERM already sent is reported, not denied
a number once judged not ours is not re-adopted for KILL
a recycled pid is neither signalled nor read as gone
a partial temp setup leaves nothing behind
roster sync refuses, rather than waiting unbounded, when it cannot build a bound
the unbounded path is still reachable, but only by asking for it
roster sync refuses a timeout setting it cannot honour, and does not start the child
the roster child does not inherit the descriptor used to hand it stdin
the driver's own copy of that descriptor is closed after the spawn
the timeout setting is validated before the lock is taken
an unusable timeout is refused without waiting for the lock
```

"Still bounded when no FIFO can be made" makes **the same three assertions as the first case** — a named failure, no lock left, no child left — deliberately, because "still bounded" has to mean the same thing in both modes. "Refuses… when it cannot build a bound" asserts the child was **never started**: running it and then complaining is the same unbounded wait with a better message. "The unbounded path is still reachable" is driven by a child that exits immediately, since a hanging child there would hang the suite — which is the honest shape of "no bound".

### Three of these cases needed their instruments rebuilt, and that is worth reading

Each was green for a reason unrelated to its property, and each was caught by mutating the code rather than by reading the test:

1. **The lock-keeping gate was structural, on a claim I had not tested** — and its first two replacements were wrong in turn. I wrote that a process surviving SIGKILL could not be produced here; SIGKILL is also refused under **EPERM**, so the case substituted **pid 1** into the pidfile. That worked, and it was still wrong: it made every run of this suite aim TERM and KILL at init, and it proved nothing about restraint either, because a signal to pid 1 leaves no trace an ordinary user can read (raised in review). The stand-in is now **a `sleep` the case starts itself**: its argv does not match, so it still models a recycled number, and because the case owns it, "nothing was signalled" is observed **on the process** — it is still alive at the end, with a positive control showing the same check can fail.
   Its substitution also had to be **repeated** rather than timed off one `sleep`: alone the case passed, and in the full file under load it did not — measured, as a 14 where 18 was expected. A fixture that races the thing it is setting up is a test that reports on the weather.
2. **The partial-`mktemp` case counted files in `$TMPDIR`.** macOS `mktemp` with no template **ignores `TMPDIR`** and writes under `/var/folders`, so the count was taken of a directory the driver never touched — it stayed green with the sweep deleted, twice. The shim now logs the paths it really created and the case asserts those exact paths are gone, with the log's non-emptiness as the control.
3. **The substitution control read the pidfile back after the run.** The driver deletes it on that path, so the control failed on a run whose status was already the 17 it was checking for. Recorded by the fixture at the moment it acts instead.

**And one of the new negations could not have failed.** `! cmd` does not fail a bats test unless it is the very last line, so "the message does not claim nothing was signalled" would have reported pass whatever happened — the same class this PR is about, in a case written *for* that class. `.github/scripts/check-enforced-assertions.sh` caught it (638 → 639, with the line named); I did not. Both negations in this file are `run` plus an explicit status now — not `refute`, which takes a command and loses to a pipe binding tighter, measured earlier on this branch.

A `teardown` now stops anything still running out of the case's own `TEST_SKILL_DIR`. Several cases are driven by a fake that ignores TERM, and one by a fake the driver must **not** be able to stop; a failed case leaves them alive, and a leaked process can hold a shard open long after every test has reported. Five were alive at once on this machine while this was being written.

The first is driven by a child that **ignores TERM**, so the grace and the KILL are exercised and not just the polite path: it asserts a bounded **failure** — not a hang, not a success — a message that names what happened, that the lock directory is gone, and that the child is gone.

The rest hold what a reader cannot check by reading. The child **answers for its own descriptors**, because a source comment saying `9<&-` is present is exactly what let that leak back in. An unusable budget is refused **by name**, before the lock and before any state work, and the last case measures that ordering against a lock somebody else is already holding.

| mutation | result |
|---|---|
| the refusal restored to the unbounded fallback | **red — and only "refuses… when it cannot build a bound" reddens**, the rest stay green |
| no-FIFO routed out of the bounded path (`poll` → `none`) | **red — and only "still bounded when no FIFO can be made" reddens** |
| the liveness gate bypassed (`if false`) | **red — the recycled-pid case falls to status 14** |
| the argv identity check removed (liveness alone, as an earlier pushed head carried) | **red — the stranger is adopted as our own child: status 17 instead of 18** |
| the absent-pid branch returned to `gone` | **red — "an unusable pidfile…"**, and it was green before that case existed |
| the quoted forms removed from the matcher | **red — the quoted native argv row** |
| the signal record ignored, as the diagnostic first read it | **red — "a TERM already sent…" no longer reports the attempt** |
| the monotone gate removed from KILL | **red — the re-adoption case's child is killed**, which is the defect itself |
| the argument boundaries removed from the needle | **red — the `config.json.bak` decoy is accepted** |
| the `cygpath -m` conversion never run | **red — the alphabet row, against its own premise control** |

All three run against `agmsg_roster_argv_is_ours` itself, not against a copy of it in the test file.
| the partial-setup sweep deleted | **red — and it names the file left behind** |
| the poll loop's `sleep 1 \|\| true` unguarded again | **red as a run that does not end** — the driver dies mid-path, the child is left alive holding the pipe, and the case never reports. The defect and its symptom in one |
| the ceiling removed (`read` without `-t`) | **red — as a run that does not end**, which is the defect itself |
| the sentinel test replaced by `[ "$rc" -gt 128 ]` | **red on macOS — the 3.2 case: the budget expires and the run does not end** |
| the child's `9<&-` removed | red — the child reports fd 9 **open** |
| the **wrapper's** `exec 9<&-` removed | red — the behavioural case reports `parent-open` where `/proc` is readable, and the structural case loses an anchor |
| the parent's `exec 9<&-` removed | red — the case that pins the order of spawn and close |
| the budget validated after the lock instead of before | red — it complains about the **lock** instead of the setting |

### One of them is structural, and that is measured rather than preferred

The parent's `exec 9<&-` cannot be told apart by behaviour on every machine this runs on: reading another live process's descriptor table needs `/proc`, and macOS has none. A behavioural-only control would be green on half the matrix, which is how a leak survives — so the order of the spawn and the close is asserted where it lives, with both anchors required to exist so it cannot pass by finding nothing. The behavioural half is still there where it can run: with `/proc`, the child reports its parent's fd 9 as closed, and where it cannot look it records **that** rather than an answer it did not get.

The validation order started out structural for the same reason and **is not any more**. Moving the check back after the lock leaves every behavioural assertion green *as long as nobody holds the lock* — the refusal still releases it, and `agmsg_roster_ensure` is idempotent, so "the team's state is unchanged" cannot discriminate. That mutation was run and stayed green, which is what sent it to a structural assertion in the first place.

**A held lock is what makes the two orders observably different.** With the directory already there, validating first refuses in under a second and names the setting; validating after spends the whole lock budget and complains about the lock. That case is on this branch, and it is what the table's last row reddens. The structural assertion is kept beside it, because the order is changed by a reader and a reader is who it has to stop.

## Measurements

```
tests/test_roster_journal.bats                 29 tests, 0 failures
tests/roster_sync.test.mjs                      2 tests, 2 pass, 0 fail
tests/test_spawn_fd_guard.bats                  4 tests, 0 failures
.github/scripts/check-enforced-assertions.sh  638, at the baseline (638)
/bin/bash --version (macOS)                   3.2.57 — read -t: timeout rc=1, EOF rc=1
```

**The suite going green on macOS does not establish defect 8's fix, and it is worth saying why.** The behavioural case reads `/proc`, so on macOS it records `parent-unreadable` and passes either way — a local green there is silent on exactly the property CI reddened. So the wrapper was measured directly, with `lsof`, which needs no `/proc`. The same probe, the same machine, one line different:

```
without the wrapper's `exec 9<&-`   wrapper fd 9: bash 98894 … 9r REG /private/etc/hosts   ← the caller's stdin, held
with it                             wrapper fd 9: NOT HELD
```

The first line is the negative control: the defect reproduces on macOS, so the instrument is not merely failing to look.

## Drift

**Empty, and it is empty for a reason that is not a measurement.** The branch was just rebased onto `main`, so:

```
merge-base    4c448cb195aafd7991b373847797154403419fae
origin/main   4c448cb195aafd7991b373847797154403419fae
```

They are **the same commit**. A diff of a commit against itself is empty whatever the state of the world, so this says only "the destination has not moved since the rebase" — it is **structural, not measured**, and should not be counted as a drift check.

The measurement that does mean something was taken before the rebase, against the previous merge-base:

```
git diff --stat 887cb110 4c448cb1 -- scripts/internal/roster-sync-driver.sh tests/test_roster_journal.bats
  → empty
git diff --stat 887cb110 4c448cb1                      # positive control, no pathspec
  → 19 files changed, 2098 insertions(+), 84 deletions(-)
```

`main` had moved by nineteen files and neither of this PR's two was among them. **Whoever presses must measure again immediately before landing**, against `origin/main` as it stands at that moment — this section will be structurally empty until the destination moves, and that is exactly when it stops being informative.

## Boundaries

- The Windows `0xC0000142` report is **not reproduced**, and this is not claimed to fit it.
- Stopping the child can land between the journal write and the state write. Each is written by `rename`, so neither is torn, but that the next run converges from every such point is **not** established — recorded on #821 rather than claimed.
- The `read -t` measurement above is of the **local** `/bin/bash` 3.2.57. That the macOS runners execute the same build is inferred from the image, not measured on a runner.
- **A child we may not signal keeps whatever streams it holds, and this PR does not fix that.** Found while building the lock-keeping case: the fixture had to release stdout or the run hung, because a process the driver cannot kill outlives it still holding the caller's pipe. That is inherent to "cannot signal" rather than something the lock gate could close, and it is recorded here rather than folded in.
- The mode table's `poll` costs one `sleep` per second of waiting. That it is the right trade on a spawn-refusing machine is a **judgement**, not a measurement — the alternative measured against it is no bound at all.
