### PR TITLE
fix(remote): let go of the registry lock before waiting for readiness

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2450,6 +2450,30 @@ cmd_sync_start() {
   # in the same process would read a stale yes and skip its own locking.
   _REMOTE_ENGINE_CALLER_HOLDS_LOCK=0
   started_pid="$(cat "$(_remote_sync_engine_pidfile "$team")")"
+
+  # RELEASED HERE, BEFORE THE WAIT, AND THAT IS THE WHOLE FIX (#817).
+  #
+  # The lock exists to serialise "is one running, and if not, start one". Both
+  # halves are over by this line: the pidfile names a live engine, so a second
+  # `sync start` that takes this lock now reads `running` from
+  # `_remote_sync_engine_status` -- which asks the pidfile, the pid's liveness
+  # and its cmdline, and never asks about readiness -- and returns
+  # "already running" without starting anything. Nothing below needs exclusion:
+  # the loop only reads status and tails a log.
+  #
+  # Holding it across the wait is what put the lock in the field report. The
+  # engine's own first cycle emits the capabilities marker this loop waits for
+  # and THEN asks for this same lock, for `roster prepare`. On a host where
+  # noticing the marker is cheap the release lands first and nothing collides.
+  # On Windows each turn of the loop spawns a process substitution, a `tail`,
+  # an `awk` and a `sleep`, so the engine reaches its lock request first, waits
+  # its whole budget, and dies -- after which the marker can never be satisfied
+  # (`_remote_sync_engine_status` stops saying `running`) and this loop runs its
+  # full 1600 turns holding the lock the rest of the machine needs.
+  #
+  # It is a race, not a deadlock: nothing here waits on anything the engine
+  # holds. What the platform changes is only who gets there first.
+  agmsg_lock_release
   while [ "$i" -lt 1600 ]; do
     IFS=$'\t' read -r engine_state ready_pid < <(_remote_sync_engine_status "$team")
     if [ "$engine_state" = "running" ] && [ "$ready_pid" = "$started_pid" ] &&
@@ -2468,8 +2492,7 @@ cmd_sync_start() {
     if _remote_sync_engine_reap_owned "$team" "$started_pid"; then
       rm -f "$(_remote_sync_engine_pidfile "$team")"
       rm -f "$(_remote_sync_engine_cycle_stamp "$team")"   # same reason as in _remote_sync_engine_stop
-      agmsg_lock_release
-      echo "agmsg: sync engine for '$team' did not become ready" >&2
+            echo "agmsg: sync engine for '$team' did not become ready" >&2
       return 1
     fi
     # The reap did not stop it, and the engine is still running.
@@ -2499,8 +2522,7 @@ cmd_sync_start() {
     # on a backoff forever -- and since the pidfile only ever names the most
     # recent one, a second attempt leaves the first with nothing pointing at
     # it. Measured: one after the first failed attempt, two after the second.
-    agmsg_lock_release
-    {
+        {
       echo "agmsg: sync engine for '$team' did not become ready, and this command did not stop it."
       echo "  pid $started_pid is still running. It cannot reach the server -- that is why"
       echo "  it never became ready -- and it will keep retrying on a backoff."
@@ -2517,8 +2539,7 @@ cmd_sync_start() {
     } >&2
     return 1
   fi
-  agmsg_lock_release
-  echo "Sync engine started for '$team' (pid $started_pid)."
+    echo "Sync engine started for '$team' (pid $started_pid)."
 }
 
 cmd_sync() {

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2461,18 +2461,28 @@ cmd_sync_start() {
   # "already running" without starting anything. Nothing below needs exclusion:
   # the loop only reads status and tails a log.
   #
-  # Holding it across the wait is what put the lock in the field report. The
-  # engine's own first cycle emits the capabilities marker this loop waits for
-  # and THEN asks for this same lock, for `roster prepare`. On a host where
-  # noticing the marker is cheap the release lands first and nothing collides.
-  # On Windows each turn of the loop spawns a process substitution, a `tail`,
-  # an `awk` and a `sleep`, so the engine reaches its lock request first, waits
-  # its whole budget, and dies -- after which the marker can never be satisfied
-  # (`_remote_sync_engine_status` stops saying `running`) and this loop runs its
-  # full 1600 turns holding the lock the rest of the machine needs.
+  # WHAT THE FIELD REPORT ACTUALLY WAS, in the order it happened.
   #
-  # It is a race, not a deadlock: nothing here waits on anything the engine
-  # holds. What the platform changes is only who gets there first.
+  # The engine emits the capabilities marker BEFORE it asks for this lock, so the
+  # ordinary sequence is: marker, this loop sees it, release, then `roster
+  # prepare` takes the lock. That order was never the problem, and an earlier
+  # version of this comment said it was.
+  #
+  # On the reporting machine the loop never reached the marker check at all.
+  # `_remote_sync_engine_status` answered `stale` for a pid this shell had just
+  # started -- the non-local probe cannot see it on Windows (#652) -- so
+  # `engine_state = running` was false and the condition short-circuited before
+  # the marker was ever read. The loop then ran to its ceiling, which is counted
+  # in ITERATIONS and not in time (#779), and on that host 1600 turns of four
+  # spawned processes each is not sixteen seconds. The lock was held for all of
+  # it, and every other operation for that team waited on a directory that was
+  # not going to be removed.
+  #
+  # #812 removed the direct cause: the status probe is local now. This release is
+  # not a second fix for that. It is a separate contract -- the lock covers
+  # deciding whether to start and starting, and nothing after -- so that a marker
+  # that is late or missing for ANY reason costs this caller its own wait and
+  # not the rest of the machine.
   agmsg_lock_release
   while [ "$i" -lt 1600 ]; do
     IFS=$'\t' read -r engine_state ready_pid < <(_remote_sync_engine_status "$team")

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2489,12 +2489,45 @@ cmd_sync_start() {
     sleep 0.01
   done
   if [ "$ready" -ne 1 ]; then
+    # TAKEN BACK FOR THE CLEANUP, because the cleanup WRITES SHARED STATE.
+    #
+    # The pidfile and the cycle stamp are per team, not per caller. Releasing
+    # before the wait -- which is the point of this change -- means another
+    # `sync start` may have taken the lock, decided this engine was gone and
+    # started its own by the time we get here. Removing those two files without
+    # the lock would then delete the state of an engine this call never
+    # started, and the pidfile is the only thing that names it (raised in
+    # review). Reaping is guarded by `_remote_sync_engine_reap_owned`, which
+    # refuses a pid it cannot prove is ours; the file removal had no such guard.
+    #
+    # A lock that cannot be retaken must not swallow the diagnostic below, so
+    # the failure is reported and the files are left rather than removed blind:
+    # a stale pidfile is what `status` already knows how to describe.
+    local relocked=1
+    agmsg_lock_acquire "$TEAMS_DIR/$team" || relocked=0
     if _remote_sync_engine_reap_owned "$team" "$started_pid"; then
-      rm -f "$(_remote_sync_engine_pidfile "$team")"
-      rm -f "$(_remote_sync_engine_cycle_stamp "$team")"   # same reason as in _remote_sync_engine_stop
-            echo "agmsg: sync engine for '$team' did not become ready" >&2
+      if [ "$relocked" -eq 1 ]; then
+        # AND ONLY IF IT IS STILL OURS. Retaking the lock stops the file from
+        # changing under the removal; it does not make the file this call's to
+        # remove. Between the release and here another `sync start` may have
+        # completed and written its own pid, and that pidfile is the only thing
+        # naming its engine -- removing it would leave a live engine nothing
+        # points at, which is the shape `set-endpoint` already warns about.
+        local recorded
+        recorded="$(cat "$(_remote_sync_engine_pidfile "$team")" 2>/dev/null || true)"
+        if [ "$recorded" = "$started_pid" ]; then
+          rm -f "$(_remote_sync_engine_pidfile "$team")"
+          rm -f "$(_remote_sync_engine_cycle_stamp "$team")"   # same reason as in _remote_sync_engine_stop
+        fi
+        agmsg_lock_release
+      else
+        echo "agmsg: could not retake the registry lock to clear the engine's records for '$team'" >&2
+        echo "  the engine is stopped; its pidfile is left, and 'remote.sh status' reads it as stale." >&2
+      fi
+      echo "agmsg: sync engine for '$team' did not become ready" >&2
       return 1
     fi
+    [ "$relocked" -eq 1 ] && agmsg_lock_release
     # The reap did not stop it, and the engine is still running.
     #
     # _remote_sync_engine_reap_owned returns non-zero for two different

--- a/tests/test_remote_engine_start_refusal.bats
+++ b/tests/test_remote_engine_start_refusal.bats
@@ -295,21 +295,29 @@ skip_if_root() {
   #
   # The pidfile and the cycle stamp are per team, not per caller. While this
   # starter polls, another `sync start` may complete and record its own engine --
-  # and that pidfile is the only thing naming it. Retaking the lock stops the
-  # file changing under the removal; it does not make the file this call's to
-  # remove. Both are needed, and this drives the second.
+  # and that pidfile is the only thing naming it.
   #
-  # The other starter is simulated rather than run: what matters to the code
-  # under test is a pidfile naming a pid that is not the one it started, which
-  # is exactly what a completed second start leaves. Running a real one would
-  # need the blind probe, and with it a second 1600-turn wait.
+  # ORDER MATTERS HERE, and the first version got it wrong. It wrote the foreign
+  # pid while this starter's own engine was still alive, so
+  # `_remote_sync_engine_reap_owned` saw a record it could not prove was ours and
+  # returned non-zero -- the branch holding the removal was never entered, and
+  # the case passed with the guard removed too. Ending our own engine FIRST makes
+  # the reap succeed on its "already gone" path, which is the only way into the
+  # removal (raised in review).
   local pidfile="$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
-  local starter foreign i=0
+  local starter engine foreign i=0
 
   bash "$SCRIPTS/remote.sh" sync start testteam >/dev/null 2>&1 &
   starter=$!
   while [ ! -f "$pidfile" ] && [ "$i" -lt 400 ]; do i=$((i + 1)); sleep 0.05; done
   [ -f "$pidfile" ]
+  engine="$(cat "$pidfile")"
+
+  # Our own engine ends first, so the reap reaches its success path.
+  kill "$engine" 2>/dev/null || true
+  i=0
+  while kill -0 "$engine" 2>/dev/null && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
+  refute kill -0 "$engine" 2>/dev/null
 
   # Somebody else's engine, recorded while this starter is still polling.
   sleep 300 &

--- a/tests/test_remote_engine_start_refusal.bats
+++ b/tests/test_remote_engine_start_refusal.bats
@@ -171,13 +171,20 @@ skip_if_root() {
   # THE FIELD DEFECT, OBSERVED FROM OUTSIDE THE COMMAND.
   #
   # `cmd_sync_start` took the team's registry lock, started the engine, and then
-  # polled for a readiness marker while still holding it. The engine's own first
-  # cycle emits that marker and THEN asks for the same lock, for `roster
-  # prepare`. Where noticing the marker is cheap the release lands first; where
-  # it is not -- Windows spawns a process substitution, a `tail`, an `awk` and a
-  # `sleep` every 10ms of that loop -- the engine asks first, waits its whole
-  # budget, and dies. Measured on the reporting machine: the lock was held from
-  # 23:05 with the starter still sitting in the loop hours later.
+  # polled for a readiness marker while still holding it.
+  #
+  # The engine emits that marker BEFORE it asks for the same lock, so the order
+  # was never the problem -- an earlier version of this comment said it was. On
+  # the reporting machine the loop never reached the marker check:
+  # `_remote_sync_engine_status` answered `stale` for a pid this shell had just
+  # started (#652), so the condition short-circuited, and the ceiling it then ran
+  # to is counted in iterations rather than time (#779). The lock was held for
+  # all of it.
+  #
+  # #812 removed that direct cause. What this case pins is the contract, not the
+  # cure: the lock covers deciding whether to start and starting, and nothing
+  # after -- so a marker that is late or missing for any reason costs this caller
+  # its own wait and not the rest of the machine.
   #
   # So this asserts the property from outside: while the starter is STILL
   # polling, the lock must not be held. Nothing here inspects the loop.
@@ -332,4 +339,43 @@ skip_if_root() {
 
   kill "$foreign" 2>/dev/null || true
   wait "$foreign" 2>/dev/null || true
+}
+
+@test "sync start: a cleanup that cannot retake the lock says so and keeps the record (#817)" {
+  # THE RETAKE, OBSERVED WHERE IT DIFFERS FROM NOT RETAKING.
+  #
+  # After the early release the timeout cleanup writes shared state, so it takes
+  # the lock back first. That is only distinguishable from not taking it when
+  # somebody else is holding it -- so a helper holds this team's lock for the
+  # whole window, and the starter has to arrive at its cleanup and find it taken.
+  #
+  # Our own engine is ended first for the same reason as the case above: it is
+  # the only way `_remote_sync_engine_reap_owned` reaches its success path, and
+  # therefore the only way the cleanup gets as far as the records.
+  local pidfile="$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+  local lock="$TEST_SKILL_DIR/teams/testteam/.config.lock"
+  local starter engine i=0 err="$TEST_SKILL_DIR/retake.err"
+
+  bash "$SCRIPTS/remote.sh" sync start testteam >"$err" 2>&1 &
+  starter=$!
+  while [ ! -f "$pidfile" ] && [ "$i" -lt 400 ]; do i=$((i + 1)); sleep 0.05; done
+  [ -f "$pidfile" ]
+  engine="$(cat "$pidfile")"
+
+  # Somebody else takes the lock and keeps it. Held with mkdir directly, the way
+  # the library takes it, so no helper of ours has to survive the wait.
+  mkdir "$lock"
+
+  kill "$engine" 2>/dev/null || true
+  i=0
+  while kill -0 "$engine" 2>/dev/null && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
+
+  wait "$starter" 2>/dev/null || true
+
+  # 1. it said it could not retake, rather than clearing the records blind
+  grep -q 'could not retake the registry lock' "$err"
+  # 2. and the record is still there
+  [ -f "$pidfile" ]
+
+  rmdir "$lock" 2>/dev/null || true
 }

--- a/tests/test_remote_engine_start_refusal.bats
+++ b/tests/test_remote_engine_start_refusal.bats
@@ -219,60 +219,109 @@ skip_if_root() {
   # platform that breaks it. Review caught that. So it is driven here rather than
   # argued: `MSYSTEM` plus a `tasklist` that answers nothing is the condition
   # #652 reproduces, and it runs on any host.
-  # FROM A KNOWN STATE, because this test COUNTS.
   #
-  # Earlier cases in this file start real engines for this same team, and the
-  # count below would include them -- so the first draft passed alone and failed
-  # in the full file. Worse than flaky: a surviving engine makes the second
-  # `sync start` read `running` from the PIDFILE and return, which hides exactly
-  # the defect this exists to catch. The fixture stood inside its own instrument.
-  pkill -f "remote-sync.mjs run --team testteam" 2>/dev/null || true
-  rm -f "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
-  local settle=0
-  while [ "$settle" -lt 100 ]; do
-    [ -z "$(pgrep -f "remote-sync.mjs run --team testteam")" ] && break
-    settle=$((settle + 1)); sleep 0.05
-  done
-  [ -z "$(pgrep -f "remote-sync.mjs run --team testteam")" ]
+  # A TEAM NAME NOBODY ELSE USES, because this test counts processes.
+  #
+  # It first counted with `pgrep -f "... --team testteam"`, which is machine-wide
+  # and names a team half this suite also uses: it counted -- and KILLED --
+  # engines belonging to other cases, other files and other shards. Scoping by
+  # `$TEST_SKILL_DIR` would not help either, since the store is passed in the
+  # environment and never appears in argv. The team name IS in argv, so making it
+  # unique makes every match this test's own (raised in review).
+  local team="lockrace817"
+  bash "$SCRIPTS/join.sh" "$team" alice claude-code /tmp/project-lockrace >/dev/null
+
+  local cfg="$TEST_SKILL_DIR/teams/$team/config.json" escaped updated
+  escaped="$(sed "s/'/''/g" "$cfg")"
+  updated="$(sqlite_mem "
+    SELECT json_set('$escaped', '\$.remote_binding', json_object(
+      'endpoint', 'https://remote.example',
+      'server_instance_id', '018f0000-0000-7000-8000-000000000001',
+      'remote_team_id', '018f0000-0000-7000-8000-000000000002',
+      'protocol_version', 1,
+      'capabilities', json_object('write_allowed_ciphers', json_array('none')),
+      'connected_at', '2026-07-30T00:00:00Z',
+      'disconnected_at', null
+    ));")"
+  printf '%s\n' "$updated" > "$cfg"
+
+  local pattern="remote-sync.mjs run --team $team"
+  # Nothing of this name may exist yet; if it does, the isolation is not real
+  # and every count below would be meaningless.
+  [ -z "$(pgrep -f "$pattern")" ]
 
   local blind="$TEST_SKILL_DIR/blind-probe"
   mkdir -p "$blind"
   printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$blind/tasklist"
   chmod +x "$blind/tasklist"
 
-  local pidfile="$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
-  local one two
+  local pidfile="$TEST_SKILL_DIR/run/remote-sync.$team.pid"
+  local one two i=0 k=0 running=0
 
-  env PATH="$blind:$PATH" MSYSTEM=MINGW64 bash "$SCRIPTS/remote.sh" sync start testteam >/dev/null 2>&1 &
+  env PATH="$blind:$PATH" MSYSTEM=MINGW64 bash "$SCRIPTS/remote.sh" sync start "$team" >/dev/null 2>&1 &
   one=$!
-  # The second starts once the first has an engine -- which is exactly the
-  # window the early release opens, and the window this has to be safe in.
-  local i=0
   while [ ! -f "$pidfile" ] && [ "$i" -lt 400 ]; do i=$((i + 1)); sleep 0.05; done
   [ -f "$pidfile" ]
-  env PATH="$blind:$PATH" MSYSTEM=MINGW64 bash "$SCRIPTS/remote.sh" sync start testteam >/dev/null 2>&1 &
+  env PATH="$blind:$PATH" MSYSTEM=MINGW64 bash "$SCRIPTS/remote.sh" sync start "$team" >/dev/null 2>&1 &
   two=$!
 
   # NOT waiting for either starter to return, deliberately. With the blind probe
-  # in place the readiness marker can never be satisfied, so each starter runs
-  # its whole 1600-turn loop -- minutes here, and the thing being measured is
-  # over long before that. A second engine, if it is going to exist, exists as
-  # soon as the second caller has decided; that decision is what this watches.
-  local k=0 running=0
+  # the readiness marker can never be satisfied, so each starter runs its whole
+  # 1600-turn loop -- minutes here, and the thing being measured is over long
+  # before that. A second engine, if it is going to exist, exists as soon as the
+  # second caller has decided; that decision is what this watches.
   while [ "$k" -lt 60 ]; do
-    running="$(pgrep -f "remote-sync.mjs run --team testteam" | wc -l | tr -d ' ')"
+    running="$(pgrep -f "$pattern" | wc -l | tr -d ' ')"
     [ "$running" -gt 1 ] && break        # fail fast: the defect has happened
     kill -0 "$two" 2>/dev/null || break  # the second caller is done deciding
     k=$((k + 1)); sleep 0.05
   done
-  running="$(pgrep -f "remote-sync.mjs run --team testteam" | wc -l | tr -d ' ')"
+  running="$(pgrep -f "$pattern" | wc -l | tr -d ' ')"
 
   # Counted by what is actually running rather than by what the pidfile says --
   # the pidfile only ever names the most recent, which is how a second engine
-  # hides from anyone who asks the file.
-  pkill -f "remote-sync.mjs run --team testteam" 2>/dev/null || true
+  # hides from anyone who asks the file. Everything torn down here carries this
+  # test's own team name, so nothing else on the machine is touched.
+  pkill -f "$pattern" 2>/dev/null || true
   kill "$one" "$two" 2>/dev/null || true
   wait "$one" "$two" 2>/dev/null || true
 
   [ "$running" -le 1 ]
+}
+
+@test "sync start: a timed-out starter does not clear another engine's records (#817)" {
+  # THE CLEANUP AFTER THE WAIT WRITES SHARED STATE, and the early release means
+  # it can arrive to find that state belonging to somebody else.
+  #
+  # The pidfile and the cycle stamp are per team, not per caller. While this
+  # starter polls, another `sync start` may complete and record its own engine --
+  # and that pidfile is the only thing naming it. Retaking the lock stops the
+  # file changing under the removal; it does not make the file this call's to
+  # remove. Both are needed, and this drives the second.
+  #
+  # The other starter is simulated rather than run: what matters to the code
+  # under test is a pidfile naming a pid that is not the one it started, which
+  # is exactly what a completed second start leaves. Running a real one would
+  # need the blind probe, and with it a second 1600-turn wait.
+  local pidfile="$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+  local starter foreign i=0
+
+  bash "$SCRIPTS/remote.sh" sync start testteam >/dev/null 2>&1 &
+  starter=$!
+  while [ ! -f "$pidfile" ] && [ "$i" -lt 400 ]; do i=$((i + 1)); sleep 0.05; done
+  [ -f "$pidfile" ]
+
+  # Somebody else's engine, recorded while this starter is still polling.
+  sleep 300 &
+  foreign=$!
+  printf '%s\n' "$foreign" > "$pidfile"
+
+  wait "$starter" 2>/dev/null || true
+
+  # The record survives, and still names the other engine.
+  [ -f "$pidfile" ]
+  [ "$(cat "$pidfile")" = "$foreign" ]
+
+  kill "$foreign" 2>/dev/null || true
+  wait "$foreign" 2>/dev/null || true
 }

--- a/tests/test_remote_engine_start_refusal.bats
+++ b/tests/test_remote_engine_start_refusal.bats
@@ -166,3 +166,41 @@ skip_if_root() {
   refute grep -qF "Nothing is syncing for this team" <<<"$output"
   refute grep -qF "could not start the sync engine" <<<"$output"
 }
+
+@test "sync start: the registry lock is free while readiness is still polled (#817)" {
+  # THE FIELD DEFECT, OBSERVED FROM OUTSIDE THE COMMAND.
+  #
+  # `cmd_sync_start` took the team's registry lock, started the engine, and then
+  # polled for a readiness marker while still holding it. The engine's own first
+  # cycle emits that marker and THEN asks for the same lock, for `roster
+  # prepare`. Where noticing the marker is cheap the release lands first; where
+  # it is not -- Windows spawns a process substitution, a `tail`, an `awk` and a
+  # `sleep` every 10ms of that loop -- the engine asks first, waits its whole
+  # budget, and dies. Measured on the reporting machine: the lock was held from
+  # 23:05 with the starter still sitting in the loop hours later.
+  #
+  # So this asserts the property from outside: while the starter is STILL
+  # polling, the lock must not be held. Nothing here inspects the loop.
+  local lock="$TEST_SKILL_DIR/teams/testteam/.config.lock"
+  local pidfile="$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+  local starter i=0 j=0 freed=0
+
+  bash "$SCRIPTS/remote.sh" sync start testteam >/dev/null 2>&1 &
+  starter=$!
+
+  # The engine existing is what says the START is over and the WAIT has begun.
+  while [ ! -f "$pidfile" ] && [ "$i" -lt 400 ]; do i=$((i + 1)); sleep 0.05; done
+  [ -f "$pidfile" ]
+
+  # Both halves in one condition, deliberately: a free lock AFTER the starter
+  # has returned proves nothing -- that is the old behaviour too. What has to
+  # hold is free WHILE it is still in there.
+  while [ "$j" -lt 60 ]; do
+    if [ ! -d "$lock" ] && kill -0 "$starter" 2>/dev/null; then freed=1; break; fi
+    j=$((j + 1)); sleep 0.05
+  done
+  [ "$freed" -eq 1 ]
+
+  kill "$(cat "$pidfile" 2>/dev/null)" 2>/dev/null || true
+  wait "$starter" 2>/dev/null || true
+}

--- a/tests/test_remote_engine_start_refusal.bats
+++ b/tests/test_remote_engine_start_refusal.bats
@@ -204,3 +204,75 @@ skip_if_root() {
   kill "$(cat "$pidfile" 2>/dev/null)" 2>/dev/null || true
   wait "$starter" 2>/dev/null || true
 }
+
+@test "sync start: two at once leave exactly one engine, on the blind probe (#817, #652)" {
+  # THE INVARIANT THE EARLY RELEASE RESTS ON, DRIVEN ON THE PLATFORM THAT BREAKS IT.
+  #
+  # Letting go of the lock before the readiness wait is only safe because a
+  # second `sync start` reads `running` from `_remote_sync_engine_status` and
+  # returns without starting anything. That reading asks whether the pid is
+  # alive -- and on Windows the non-local probe cannot see a pid this shell
+  # minted (#652), so it answers `stale`, the second caller does NOT stop, and
+  # two engines end up running for one team.
+  #
+  # I asserted that invariant from reading the code and did not measure it on the
+  # platform that breaks it. Review caught that. So it is driven here rather than
+  # argued: `MSYSTEM` plus a `tasklist` that answers nothing is the condition
+  # #652 reproduces, and it runs on any host.
+  # FROM A KNOWN STATE, because this test COUNTS.
+  #
+  # Earlier cases in this file start real engines for this same team, and the
+  # count below would include them -- so the first draft passed alone and failed
+  # in the full file. Worse than flaky: a surviving engine makes the second
+  # `sync start` read `running` from the PIDFILE and return, which hides exactly
+  # the defect this exists to catch. The fixture stood inside its own instrument.
+  pkill -f "remote-sync.mjs run --team testteam" 2>/dev/null || true
+  rm -f "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+  local settle=0
+  while [ "$settle" -lt 100 ]; do
+    [ -z "$(pgrep -f "remote-sync.mjs run --team testteam")" ] && break
+    settle=$((settle + 1)); sleep 0.05
+  done
+  [ -z "$(pgrep -f "remote-sync.mjs run --team testteam")" ]
+
+  local blind="$TEST_SKILL_DIR/blind-probe"
+  mkdir -p "$blind"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$blind/tasklist"
+  chmod +x "$blind/tasklist"
+
+  local pidfile="$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+  local one two
+
+  env PATH="$blind:$PATH" MSYSTEM=MINGW64 bash "$SCRIPTS/remote.sh" sync start testteam >/dev/null 2>&1 &
+  one=$!
+  # The second starts once the first has an engine -- which is exactly the
+  # window the early release opens, and the window this has to be safe in.
+  local i=0
+  while [ ! -f "$pidfile" ] && [ "$i" -lt 400 ]; do i=$((i + 1)); sleep 0.05; done
+  [ -f "$pidfile" ]
+  env PATH="$blind:$PATH" MSYSTEM=MINGW64 bash "$SCRIPTS/remote.sh" sync start testteam >/dev/null 2>&1 &
+  two=$!
+
+  # NOT waiting for either starter to return, deliberately. With the blind probe
+  # in place the readiness marker can never be satisfied, so each starter runs
+  # its whole 1600-turn loop -- minutes here, and the thing being measured is
+  # over long before that. A second engine, if it is going to exist, exists as
+  # soon as the second caller has decided; that decision is what this watches.
+  local k=0 running=0
+  while [ "$k" -lt 60 ]; do
+    running="$(pgrep -f "remote-sync.mjs run --team testteam" | wc -l | tr -d ' ')"
+    [ "$running" -gt 1 ] && break        # fail fast: the defect has happened
+    kill -0 "$two" 2>/dev/null || break  # the second caller is done deciding
+    k=$((k + 1)); sleep 0.05
+  done
+  running="$(pgrep -f "remote-sync.mjs run --team testteam" | wc -l | tr -d ' ')"
+
+  # Counted by what is actually running rather than by what the pidfile says --
+  # the pidfile only ever names the most recent, which is how a second engine
+  # hides from anyone who asks the file.
+  pkill -f "remote-sync.mjs run --team testteam" 2>/dev/null || true
+  kill "$one" "$two" 2>/dev/null || true
+  wait "$one" "$two" 2>/dev/null || true
+
+  [ "$running" -le 1 ]
+}

--- a/tests/test_remote_engine_start_refusal.bats
+++ b/tests/test_remote_engine_start_refusal.bats
@@ -312,6 +312,7 @@ skip_if_root() {
   # the reap succeed on its "already gone" path, which is the only way into the
   # removal (raised in review).
   local pidfile="$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+  local cycles="$TEST_SKILL_DIR/run/remote-sync.testteam.cycles.json"
   local starter engine foreign i=0
 
   bash "$SCRIPTS/remote.sh" sync start testteam >/dev/null 2>&1 &
@@ -326,16 +327,22 @@ skip_if_root() {
   while kill -0 "$engine" 2>/dev/null && [ "$i" -lt 200 ]; do i=$((i + 1)); sleep 0.05; done
   refute kill -0 "$engine" 2>/dev/null
 
-  # Somebody else's engine, recorded while this starter is still polling.
+  # Somebody else's engine, recorded while this starter is still polling. BOTH
+  # files, because the cleanup removes them on two separate lines and a control
+  # that watches one does not protect the other (raised in review).
   sleep 300 &
   foreign=$!
   printf '%s\n' "$foreign" > "$pidfile"
+  printf '%s\n' "REPLACEMENT-CYCLE-STATE" > "$cycles"
 
   wait "$starter" 2>/dev/null || true
 
   # The record survives, and still names the other engine.
   [ -f "$pidfile" ]
   [ "$(cat "$pidfile")" = "$foreign" ]
+  # And so does the other half of it, byte for byte.
+  [ -f "$cycles" ]
+  [ "$(cat "$cycles")" = "REPLACEMENT-CYCLE-STATE" ]
 
   kill "$foreign" 2>/dev/null || true
   wait "$foreign" 2>/dev/null || true
@@ -354,6 +361,7 @@ skip_if_root() {
   # therefore the only way the cleanup gets as far as the records.
   local pidfile="$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
   local lock="$TEST_SKILL_DIR/teams/testteam/.config.lock"
+  local cycles="$TEST_SKILL_DIR/run/remote-sync.testteam.cycles.json"
   local starter engine i=0 err="$TEST_SKILL_DIR/retake.err"
 
   bash "$SCRIPTS/remote.sh" sync start testteam >"$err" 2>&1 &
@@ -365,6 +373,7 @@ skip_if_root() {
   # Somebody else takes the lock and keeps it. Held with mkdir directly, the way
   # the library takes it, so no helper of ours has to survive the wait.
   mkdir "$lock"
+  printf '%s\n' "KEPT-CYCLE-STATE" > "$cycles"
 
   kill "$engine" 2>/dev/null || true
   i=0
@@ -374,8 +383,11 @@ skip_if_root() {
 
   # 1. it said it could not retake, rather than clearing the records blind
   grep -q 'could not retake the registry lock' "$err"
-  # 2. and the record is still there
+  # 2. and BOTH records are still there. Two separate removals, two assertions:
+  # watching only the pidfile leaves the cycle line unguarded (raised in review).
   [ -f "$pidfile" ]
+  [ -f "$cycles" ]
+  [ "$(cat "$cycles")" = "KEPT-CYCLE-STATE" ]
 
   rmdir "$lock" 2>/dev/null || true
 }


### PR DESCRIPTION
Declared reviewers: 1

Refs #817.

`cmd_sync_start` takes the team's registry lock, starts the engine, and then
polls for a readiness marker **while still holding it**. This releases the lock
once the start is over, before the wait.

**This description is for head `5f51ccf78a5f534ab889e18390b655503a1cfaa9`.** If that is not the head of this branch,
nothing below has been re-measured.

## Why the lock is not needed after the start

It exists to serialise *is one running, and if not, start one*. Both halves are
over by that line: the pidfile names a live engine, so a second `sync start`
that takes the lock reads `running` from `_remote_sync_engine_status` — which
asks the pidfile, the pid's liveness and its cmdline, and **never asks about
readiness** — and returns "already running" without starting anything. The loop
below only reads status and tails a log.

## What holding it across the wait did

The engine emits the capabilities marker **before** it asks for this lock, so the
ordinary order — marker, release, `roster prepare` — was never the problem. An
earlier version of this description said it was; that was wrong and is corrected
here.

On the reporting machine the loop never reached the marker check.
`_remote_sync_engine_status` answered `stale` for a pid the shell had just
started — the non-local probe cannot see it on Windows (#652) — so
`engine_state = running` was false and the condition short-circuited before the
marker was read. The loop then ran to a ceiling counted in **iterations, not
time** (#779), which on that host is not sixteen seconds. The lock was held for
all of it.

Measured there: holder `remote.sh` pid 117357, lock taken 23:05, the starter
still in the loop hours later, six `roster sync prepare failed` in the engine log
and **not one line from the holder** — a foreground `remote.sh` writes to the
terminal, and only the engine's own `nohup … run` is redirected into
`run/remote-sync.<team>.log`.

**#812 removed that direct cause.** This change is not a second fix for it. It is
a separate contract: the lock covers deciding whether to start and starting, and
nothing after — so a marker that is late or missing **for any reason** costs the
caller its own wait and not the rest of the machine.

## The control, and its mutation

It observes the property from **outside** the command: while the starter is
*still polling* — both halves in one condition, since a free lock after it
returns is the old behaviour too — the lock must not be held.

| mutation | result |
|---|---|
| put the release back after the loop | that case red, on `[ "$freed" -eq 1 ]`, and nothing else |

```
tests/test_remote_engine_start_refusal.bats                     9/9
+ test_remote_status_liveness, test_remote_refusal,
  test_registry_lock                                   58 ok / 0 not ok
```

The three `agmsg_lock_release` calls after the loop are **removed** rather than
left as no-ops: a reader who found one there would take it to mean the lock is
still held at that point, which is the belief this change corrects.


## The invariant, driven rather than argued

The safety argument above — a second `sync start` reads `running` and returns —
was asserted from reading the code and **not measured on the platform that breaks
it**. Review blocked the previous head on exactly that, and it was right: on
Windows the non-local probe cannot see a pid this shell minted (#652), so
`_remote_sync_engine_status` answers `stale`, the second caller does not stop, and
one team ends up with two engines.

This branch is **rebased onto the destination that carries #812**, and the
invariant now has a control that runs anywhere: `MSYSTEM` plus a `tasklist` that
answers nothing is the condition #652 reproduces.

| mutation | result |
|---|---|
| put the release back after the loop | *the lock is free while readiness is still polled* red, and only that |
| revert the local probe to the old one | *two at once leave exactly one engine* red, and only that |

Each control binds its own property; neither mutation touches the other's case.

The counting control got two things wrong first, and both are written into it: it
counted engines left by earlier cases in the same file (passing alone, failing in
the full file — and a surviving engine would have hidden the very defect it exists
to catch), and it waited for both starters to return when the decision it measures
is over in milliseconds.


## The cleanup after the wait

Releasing early has a consequence the first version missed: the timeout cleanup
writes **shared** state. `_remote_sync_engine_reap_owned` refuses a pid it cannot
prove is ours, but the two removals after it had no such guard, and by then
another `sync start` may have taken the lock and recorded its own engine.

So the lock is **retaken** for the cleanup, and a failure to retake is reported
rather than swallowed. Retaking alone is not enough: it stops the file changing
under the removal, it does not make the file this call's to remove. The removal
is now also guarded on the pidfile **still naming the pid this call started**,
because that file is the only thing naming a live engine.

| mutation | result |
|---|---|
| put the release back after the loop | *the lock is free…* red, and only that |
| revert the local probe to the old one | *two at once…* red, and only that |
| remove the ownership guard | *a timed-out starter does not clear another engine's records* red, on `[ -f "$pidfile" ]` |
| remove the lock retake | *a cleanup that cannot retake the lock says so and keeps the record* red, on the missing diagnostic |
| move the cycle removal outside the ownership guard | *does not clear another engine's records* red, on the **cycle** assertion |
| delete the cycle stamp after a failed retake | *cannot retake the lock…* red, on the **cycle** assertion |

The ownership guard is bound now. The case that was meant to bind it did not,
because it wrote the foreign pid while this starter's own engine was still alive:
`_remote_sync_engine_status` then read the record as `stale`,
`_remote_sync_engine_reap_owned` returned non-zero, and **the branch containing
the removal was never entered** — green with the guard and green without it, for
a reason unrelated to the guard. Ending our own engine first makes the reap
succeed on its "already gone" path, which is the only way in.

Both cleanup controls originally asserted the pidfile and nothing else, while
the cleanup removes the pidfile **and** the cycle stamp on two separate lines —
so a mutation touching only the cycle line stayed green. A guard on one line is
not a guard on the line under it. Both cases carry a cycle-stamp sentinel now.

**The lock retake is bound too.** Retaking is only distinguishable from not
retaking while somebody else holds the lock, so the case takes this team's lock
from outside and keeps it, ends our own engine so the reap reaches its success
path, and then requires the cleanup both to SAY it could not retake and to leave
the record behind.

The concurrency control also named its target by a string this suite shares, so
it counted and terminated engines belonging to other cases and other shards. It
creates its own team now, and refuses to start if one of that name already
exists — a broken isolation fails loudly instead of quietly counting somebody
else's process.

## Deliberately not in this change

- The loop is budgeted in **iterations, not time** — the defect #779 already
  fixed inside `agmsg_lock_acquire`, and a sweep finds it in three more places
  (`remote.sh:1734`, `remote.sh:1324`, `lib/actas-lock.sh:145`).
- The loop keeps turning after the engine it waits for has died.

Either would also shorten the window. Neither is needed to close it.
