### PR TITLE
ci(windows): a feed outage must not be reported as this change's red (#824)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ env:
   # binary, not whatever the feed is serving today (#824). Bumping this is one
   # cache miss and one trip to chocolatey, which is the only time the community
   # feed is asked at all.
-  WINDOWS_SQLITE_VERSION: '0.0.0-probe-824'   # PROBE 2: reverted in the next commit
+  WINDOWS_SQLITE_VERSION: '0.0.0-probe-824b'  # PROBE 2b: reverted in the next commit
 
 jobs:
   # Cheap gate: is this PR's diff entirely documentation? Pushes to main always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ env:
   # binary, not whatever the feed is serving today (#824). Bumping this is one
   # cache miss and one trip to chocolatey, which is the only time the community
   # feed is asked at all.
-  WINDOWS_SQLITE_VERSION: '0.0.0-probe-824'   # PROBE: reverted in the next commit
+  WINDOWS_SQLITE_VERSION: '3.53.4'
 
 jobs:
   # Cheap gate: is this PR's diff entirely documentation? Pushes to main always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ env:
   # binary, not whatever the feed is serving today (#824). Bumping this is one
   # cache miss and one trip to chocolatey, which is the only time the community
   # feed is asked at all.
-  WINDOWS_SQLITE_VERSION: '3.53.4'
+  WINDOWS_SQLITE_VERSION: '0.0.0-probe-824'   # PROBE: reverted in the next commit
 
 jobs:
   # Cheap gate: is this PR's diff entirely documentation? Pushes to main always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,11 @@ env:
   # Number of parallel bats shards per OS. The matrix and the shard helper must
   # stay in lockstep; the stable summary job below verifies that they do.
   SHARD_TOTAL: 4
+  # Pinned so the Windows sqlite cache key means something: a hit is the same
+  # binary, not whatever the feed is serving today (#824). Bumping this is one
+  # cache miss and one trip to chocolatey, which is the only time the community
+  # feed is asked at all.
+  WINDOWS_SQLITE_VERSION: '3.53.4'
 
 jobs:
   # Cheap gate: is this PR's diff entirely documentation? Pushes to main always
@@ -214,7 +219,23 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         run: |
           bash --version | head -1
-          sqlite3 --version
+          # Two changes here, and they pull in opposite directions (#824).
+          #
+          # The `|| sqlite3.exe --version || echo "sqlite3 not found on PATH"`
+          # fallback is gone: it turned a missing binary into a success line, so
+          # nothing between a failed install and `Run tests` said anything was
+          # wrong. Absence is now decided by the presence check above, which is
+          # allowed to be red about it.
+          #
+          # But without the fallback this line would fail on a leg that never
+          # installs sqlite3 — `driver input (#817)` carries `sqlite: false`
+          # precisely so a package feed cannot stop a leg that drives a mock
+          # bash driver. Reporting a version it was never meant to have would
+          # re-create, one step lower, the coupling #822 removed. `matrix.sqlite`
+          # is a fixed value from the matrix above, not external input.
+          if [ "${{ matrix.sqlite }}" = "true" ]; then
+            sqlite3 --version
+          fi
           bats --version
 
       # Diagnostics for the shards that report every test ok and then sit
@@ -575,14 +596,70 @@ jobs:
         if: needs.changes.outputs.docs_only == 'true'
         run: echo "Diff is documentation-only; skipping the Windows bats legs."
 
-      - name: Install sqlite3
+      # A THIRD PARTY'S BAD MINUTE MUST NOT BE REPORTED AS THIS CHANGE'S RED
+      # (#824). `choco install sqlite -y --no-progress` was one call with no
+      # retry, no cache and — the part that did the damage — no check. On a 503
+      # from the community feed it printed "Chocolatey installed 0/0 packages"
+      # and EXITED ZERO, so the step went green, the version step's
+      # `|| echo "not found"` turned a missing binary into a success line, and
+      # the red landed three steps later on `Run tests`. Measured on
+      # run 31869238895: steps 4, 5, 6 and 7 all `success`, step 8 `failure`,
+      # with `sqlite3: command not found` in step 7's own log.
+      #
+      # Reading that check list, the failure belongs to the change under test.
+      # It did not. The feed's flakiness is not ours to fix; which step goes red
+      # is.
+      #
+      # EVERY STEP HERE IS GATED ON `matrix.sqlite`, which #822 added. A leg that
+      # never opens a store must not be stopped by a package feed either — that
+      # is the contract #822 built, and hardening the install would have
+      # cancelled it by making `driver input (#817)` depend on chocolatey again.
+      #
+      # The restore is tried first so most runs never ask the feed at all: the
+      # key is the pinned version, so a hit is the same binary and a miss is the
+      # only thing that needs the network.
+      - name: Restore sqlite3 (cache)
         if: needs.changes.outputs.docs_only != 'true' && matrix.sqlite
+        id: sqlite-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            C:\ProgramData\chocolatey\lib\SQLite
+            C:\ProgramData\chocolatey\bin\sqlite3.exe
+          key: sqlite3-${{ runner.os }}-choco-${{ env.WINDOWS_SQLITE_VERSION }}
+
+      - name: Install sqlite3
+        if: needs.changes.outputs.docs_only != 'true' && matrix.sqlite && steps.sqlite-cache.outputs.cache-hit != 'true'
         shell: pwsh
-        run: choco install sqlite -y --no-progress
+        run: |
+          # Three attempts with a widening pause. The observed failures are 503
+          # and 504 from `community.chocolatey.org`, and they are per-request
+          # rather than an outage: on run 31869238895 the two Windows legs ran
+          # concurrently and one of them installed fine.
+          for ($attempt = 1; $attempt -le 3; $attempt++) {
+            choco install sqlite --version=$env:WINDOWS_SQLITE_VERSION -y --no-progress
+            if (Test-Path 'C:\ProgramData\chocolatey\bin\sqlite3.exe') { exit 0 }
+            Write-Host "::warning::sqlite3 not installed on attempt $attempt; the chocolatey feed is answering errors"
+            Start-Sleep -Seconds (10 * $attempt)
+          }
+          exit 0   # the hard check is its own step, so a retry loop cannot decide the colour
 
       - name: Put chocolatey shims on PATH (Git Bash form)
         if: needs.changes.outputs.docs_only != 'true' && matrix.sqlite
         run: echo "/c/ProgramData/chocolatey/bin" >> "$GITHUB_PATH"
+
+      # THE STEP THAT IS ALLOWED TO BE RED ABOUT THIS. Separate from the install
+      # on purpose: whether the dependency is present is a different question
+      # from whether one `choco` invocation worked, and only this one may decide
+      # the job's colour. Named so the check list says what is wrong — a reader
+      # seeing this red does not go looking through the diff.
+      - name: sqlite3 must be present, or this leg is about chocolatey
+        if: needs.changes.outputs.docs_only != 'true' && matrix.sqlite
+        run: |
+          if ! sqlite3 --version; then
+            echo "::error::sqlite3 is missing. The chocolatey community feed did not serve it (503/504 seen on 2026-08-15). This leg reports on that, NOT on the change under test — see #824."
+            exit 1
+          fi
 
       - name: Install bats
         if: needs.changes.outputs.docs_only != 'true'
@@ -595,7 +672,11 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         run: |
           bash --version | head -1
-          sqlite3 --version || sqlite3.exe --version || echo "sqlite3 not found on PATH"
+          # No `|| echo` fallback (#824): it turned a missing binary into a
+          # success line, so nothing between the failed install and `Run tests`
+          # said anything was wrong. Absence is decided by the step above, which
+          # is allowed to be red about it; this one only reports.
+          sqlite3 --version
           bats --version
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ env:
   # binary, not whatever the feed is serving today (#824). Bumping this is one
   # cache miss and one trip to chocolatey, which is the only time the community
   # feed is asked at all.
-  WINDOWS_SQLITE_VERSION: '3.53.4'
+  WINDOWS_SQLITE_VERSION: '0.0.0-probe-824'   # PROBE 2: reverted in the next commit
 
 jobs:
   # Cheap gate: is this PR's diff entirely documentation? Pushes to main always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ env:
   # binary, not whatever the feed is serving today (#824). Bumping this is one
   # cache miss and one trip to chocolatey, which is the only time the community
   # feed is asked at all.
-  WINDOWS_SQLITE_VERSION: '0.0.0-probe-824b'  # PROBE 2b: reverted in the next commit
+  WINDOWS_SQLITE_VERSION: '3.53.4'
 
 jobs:
   # Cheap gate: is this PR's diff entirely documentation? Pushes to main always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -219,23 +219,7 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         run: |
           bash --version | head -1
-          # Two changes here, and they pull in opposite directions (#824).
-          #
-          # The `|| sqlite3.exe --version || echo "sqlite3 not found on PATH"`
-          # fallback is gone: it turned a missing binary into a success line, so
-          # nothing between a failed install and `Run tests` said anything was
-          # wrong. Absence is now decided by the presence check above, which is
-          # allowed to be red about it.
-          #
-          # But without the fallback this line would fail on a leg that never
-          # installs sqlite3 — `driver input (#817)` carries `sqlite: false`
-          # precisely so a package feed cannot stop a leg that drives a mock
-          # bash driver. Reporting a version it was never meant to have would
-          # re-create, one step lower, the coupling #822 removed. `matrix.sqlite`
-          # is a fixed value from the matrix above, not external input.
-          if [ "${{ matrix.sqlite }}" = "true" ]; then
-            sqlite3 --version
-          fi
+          sqlite3 --version
           bats --version
 
       # Diagnostics for the shards that report every test ok and then sit
@@ -672,11 +656,23 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         run: |
           bash --version | head -1
-          # No `|| echo` fallback (#824): it turned a missing binary into a
-          # success line, so nothing between the failed install and `Run tests`
-          # said anything was wrong. Absence is decided by the step above, which
-          # is allowed to be red about it; this one only reports.
-          sqlite3 --version
+          # Two changes here, pulling in opposite directions (#824).
+          #
+          # The `|| sqlite3.exe --version || echo "sqlite3 not found on PATH"`
+          # fallback is gone: it turned a missing binary into a success line, so
+          # nothing between a failed install and `Run tests` said anything was
+          # wrong. Absence is decided by the presence check above, which is
+          # allowed to be red about it.
+          #
+          # Without the fallback this line would fail on a leg that never
+          # installs sqlite3 — `driver input (#817)` carries `sqlite: false`
+          # precisely so a package feed cannot stop a leg driving a mock bash
+          # driver. Reporting a version it was never meant to have would
+          # re-create, one step lower, the coupling #822 removed.
+          # `matrix.sqlite` is a fixed value from the matrix above.
+          if [ "${{ matrix.sqlite }}" = "true" ]; then
+            sqlite3 --version
+          fi
           bats --version
 
       - name: Run tests


### PR DESCRIPTION
Declared reviewers: 1

Refs #824 — **not `Closes`**, and the issue's own words are why.

Its Directions rank three options and put this one last: *"Or keep chocolatey and add a retry with a fallback source, **which is the cheapest change and the least durable** — a second feed is a second thing that can be down."* That is what this is. It fixes the harm that was reported — a feed failure being indistinguishable from the change's own red — and it does **not** remove the single point of failure the title names. On a cold cache with the feed down, the leg is still red; it now says chocolatey rather than pointing at the diff.

The durable directions are still open: fetch the tools zip from `sqlite.org`, or vendor a pinned binary with a hash. Either would let #824 close.


**Base moved to `main`** — `integration/remote` has been retired. That changes two things about this PR and neither is cosmetic: `main` carries branch protection, so every required check must be green rather than merely reported, and a closing keyword now fires.

That second half is why the line at the top of this body changed. When the base moved, this said *"`Closes` is correct here: this PR is the whole of #824."* **It is not**, and reading the issue's own Directions is what settled it — the option taken here is the one it ranks last. The keyword was replaced and this sentence was left behind for a while, which is its own small lesson: changing the header is not the same as removing the claim.

Measured before the switch: `git diff origin/main origin/integration/remote -- .github/workflows/tests.yml` is **empty**, so the two bases are identical for the only file this touches, and drift against the new base is **EMPTY, AND MEASURED** across 21 commits.

`choco install sqlite -y --no-progress` was one call with no retry, no cache and — the part that did the damage — **no check**.

## What the check list said, and what had happened

Measured on run `31869238895`, leg `install helpers`:

```
4  success   Install sqlite3          <- "Chocolatey installed 0/0 packages" after a 503
5  success   Put chocolatey shims on PATH
6  success   Install bats
7  success   Show tool versions       <- its own log: "sqlite3: command not found"
8  failure   Run tests
```

`choco` **exits zero** when it resolves the package version and then fails to fetch it, and `sqlite3 --version || sqlite3.exe --version || echo "sqlite3 not found on PATH"` turns a missing binary into a success line. So nothing between the failed install and the tests said anything was wrong, and the red landed on `Run tests` — which reads as *the change under test broke something*.

## It is worse than intermittent: the same cause picks a different step

Run `31870847862`, a different branch, same feed problem:

```
4  failure   Install sqlite3          <- 499 on the IsLatestVersion query
5  skipped   …
8  skipped   Run tests
```

Chocolatey resolves in two phases — *which version is latest*, then *fetch that version*:

| where it fails | chocolatey's accounting | exit | which step goes red |
|---|---|---|---|
| phase 1 (`…IsLatestVersion`) | `installed 0/1 packages. 1 packages failed` | non-zero | **Install sqlite3** |
| phase 2 (`Packages(Id='SQLite',Version='3.53.4')`) | `installed 0/0 packages` | **zero** | **Run tests** |

Both runs are the same outage. **Which step is red is decided by timing, not by cause** — so the failure is not reproducible in place, and half the time it is attributed to the diff.

This also settles an attribution question raised while triaging: the two branches' `tests.yml` differ only in adding `sqlite: true|false` to the matrix and `&& matrix.sqlite` to two `if:`s — five `+`/`-` lines, none of which touch the `choco` invocation. Both Windows legs carry `sqlite: true`, so that condition is vacuously true for them. **The differing step colours are phase-of-failure, not diff.**

## Which legs actually need it, derived

| leg target | `sqlite3` hits | store paths |
|---|---|---|
| `tests/test_codex_monitor.bats` | 0 | 0 |
| `tests/test_codex_bridge_launcher.bats` | 1 | 5 |
| `tests/test_install.bats` | 8 | 14 |

`windows runtime (#567)` runs the first two and the second opens a store; `install helpers` needs one outright. **Both genuinely require sqlite3**, so `sqlite: false` — the existing mechanism, and the right one for `driver input (#817)` — is not available to them. That is why this is about the *install*, not about skipping.

## Three changes, one per problem

**Cache**, keyed on a pinned version. Most runs never ask the feed; a miss is the only thing that needs the network, and a hit is the same binary rather than whatever is being served today.

**Retry**, three attempts with a widening pause. The failures are per-request rather than an outage — on `31869238895` the two Windows legs ran concurrently and one of them installed fine.

**A dedicated presence check**, and it is the only step allowed to be red about this. Whether one `choco` invocation worked is a different question from whether the dependency is present; the install step exits 0 after its retries precisely so that a retry loop cannot decide the job's colour. The step is named so the check list says chocolatey — a reader seeing it red does not go looking through the diff.

Also drops the `|| echo` from `Show tool versions`: absence is now decided by a step that may fail, and that one only reports.

## The control, on both legs, from one run

The feed recovered before this was written, so the condition was produced rather than waited for: **one line pointing the pin at a version the feed cannot serve**, which busts the cache key *and* fails the install — the path a 503 takes.

Run on `b0b5a1a`, the two legs that matter, same commit:

```
install helpers  (sqlite: true)
  Restore sqlite3 (cache)                     success    miss, nothing restored
  Install sqlite3                             success    exits 0 after its retries
  sqlite3 must be present, ...                FAILURE    the only red
  Install bats / Show tool versions           skipped
  Run tests                                   skipped    never runs

driver input (#817)  (sqlite: false)
  Restore / Install / PATH / presence check   skipped    all four
  Install bats                                success
  Show tool versions                          success
  Run tests                                   SUCCESS
```

The first column is what this PR is for: **the red names chocolatey, and `Run tests` does not execute**, so it cannot be read as the change's failure. The second is **#822's contract, intact**: a leg that never opens a store is not stopped by a package feed.

**The probe is reverted.** `grep -c 'probe-824'` over the workflow is **0**, the pin reads `3.53.4`, and `git diff b0b5a1a HEAD --stat` is one line — the pin and nothing else.

## Two things this got wrong on the way, both caught by reading the job

**The guard went onto the wrong job's step.** There are three `Show tool versions` steps in this file. The edit was anchored on a nearby comment about the hang sampler, which belongs to `bats-shard` — so `bats-windows` stayed unguarded and `driver input` went red on `sqlite3: command not found`, re-creating one step lower exactly the coupling #822 removed. Worse, `bats-shard` has no `matrix.sqlite` at all, so the interpolation was empty and `sqlite3 --version` would never have run again on Linux or macOS: a diagnostic disabled for nothing. The shard step is restored to the destination's exact text (diffed, identical), and the guard is placed by walking job headers rather than line numbers.

**The first explanation for that red was wrong.** It was attributed to a stale `refs/pull/827/merge`. The second probe carried a new pin value, the job's log printed that value, and the old step text was still there — so the tree was current and the edit was simply in the wrong place. Named here because the wrong explanation was the comfortable one.

## Not measured

- **Whether a cache hit produces a working `sqlite3`.** Every run so far has been a miss: a new key, then two probes busting it, then the revert restoring a key never written under. The first genuine hit is the next run.
- **Whether the feed's failure modes are only 499/503/504.** Those are what the four job logs showed.
- **Whether retrying recovers anything.** The probe fails all three attempts by construction, so what is shown is that the loop terminates and the presence check decides the colour — not that a retry helps against a real transient.
