### PR TITLE
fix(compat): compare a command line and a path in one alphabet

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -664,20 +664,18 @@ kill_all_watchers() {
         # our watch.sh. Defends against pid recycling — a stale pidfile
         # could point at an unrelated process that reused the pid.
         cmd=$(compat_get_cmdline "$pid" 2>/dev/null || true)
-        case "$cmd" in
-          *"$SKILL_DIR/scripts/watch.sh"*)
-            # When scoped, skip (and preserve the pidfile of) watchers that don't
-            # match this (project, type) — i.e. other projects, and other types
-            # in the same project.
-            if [ -n "$needle" ]; then
-              case " $cmd " in
-                *"$needle"*) ;;
-                *) continue ;;
-              esac
-            fi
-            kill "$pid" 2>/dev/null && killed=$((killed + 1)) ;;
-          *) ;;  # not our watcher; leave it
-        esac
+        if agmsg_cmdline_names_path "$cmd" "$SKILL_DIR/scripts/watch.sh"; then
+          # When scoped, skip (and preserve the pidfile of) watchers that don't
+          # match this (project, type) — i.e. other projects, and other types
+          # in the same project.
+          if [ -n "$needle" ]; then
+            case " $cmd " in
+              *"$needle"*) ;;
+              *) continue ;;
+            esac
+          fi
+          kill "$pid" 2>/dev/null && killed=$((killed + 1))
+        fi   # otherwise it is not our watcher; leave it
       fi
       rm -f "$f"
     done

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -58,6 +58,46 @@ _compat_cim_cmdline() {
 }
 
 # Get full command line of a process.  Replaces: ps -o args= -p <pid>
+# Does <cmdline> name <path>?
+#
+# It has to be asked as a function because the two sides are written in
+# different alphabets and only one of them is ours. `compat_get_cmdline` returns
+# what the OS says a process was started with; the path we compare it against
+# came out of this shell. Under Git Bash those disagree for the same file:
+# `$SKILL_DIR` is `/c/Users/...`, and a native binary launched from it reports
+# `C:/Users/...`. A `case` on one against the other never fires -- so every
+# check built that way answers "not ours" about a process that IS ours, and
+# does it silently, because a non-match is the ordinary answer.
+#
+# Measured on the reporting machine (#652): the sync engine was alive, its
+# `/proc/<pid>/cmdline` read
+#   "C:\Program Files\nodejs\node.exe" C:/Users/.../internal/remote-sync.mjs run --team ossb
+# while the comparison held /c/Users/.../internal/remote-sync.mjs. Forcing the
+# CIM source instead of /proc returned the same `C:/` form, so this is not about
+# where the cmdline is read from -- both sources speak Windows.
+#
+# Five call sites compared a shell path against an OS cmdline this way. Four of
+# them decide whether to kill a stale watcher, so on Windows they answered "not
+# ours" and left it running.
+#
+# `cygpath -m` is the mixed form -- `C:/Users/...`, forward slashes -- which is
+# what MSYS hands a native binary, and therefore what the process reports.
+# Off Windows there is no cygpath and this is the plain match and nothing else,
+# the same escape `agmsg_sql_readfile_path` takes.
+agmsg_cmdline_names_path() {
+  local cmdline="$1" path="$2" native
+  [ -n "$cmdline" ] && [ -n "$path" ] || return 1
+  case "$cmdline" in *"$path"*) return 0 ;; esac
+  command -v cygpath >/dev/null 2>&1 || return 1
+  native="$(cygpath -m "$path" 2>/dev/null || true)"
+  [ -n "$native" ] || return 1
+  # Identical forms would make this second look a copy of the first, not a
+  # second chance at it.
+  [ "$native" != "$path" ] || return 1
+  case "$cmdline" in *"$native"*) return 0 ;; esac
+  return 1
+}
+
 compat_get_cmdline() {
   local pid="$1"
   [ -z "$pid" ] && return 1

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -1726,11 +1726,17 @@ _remote_sync_engine_status() {
     return
   fi
   command="$(compat_get_cmdline "$pid" 2>/dev/null || true)"
-  expected="$SCRIPT_DIR/internal/remote-sync.mjs run --team $team"
-  case "$command" in
-    *"$expected") printf 'running\t%s\n' "$pid" ;;
-    *) printf 'stale\t%s\n' "$pid" ;;
-  esac
+  # Two conditions where there was one suffix match, and neither one is written
+  # in a path alphabet: the cmdline has to NAME the engine script -- asked
+  # through the comparator, which knows the OS may spell that path its own way
+  # (#652) -- and it has to END with this team's arguments, which is what kept
+  # another team's engine from answering for this one.
+  if agmsg_cmdline_names_path "$command" "$SCRIPT_DIR/internal/remote-sync.mjs" &&
+     case "$command" in *" run --team $team") true ;; *) false ;; esac; then
+    printf 'running\t%s\n' "$pid"
+  else
+    printf 'stale\t%s\n' "$pid"
+  fi
 }
 
 _remote_sync_engine_reap_owned() {

--- a/scripts/session-end.sh
+++ b/scripts/session-end.sh
@@ -62,10 +62,9 @@ if [ -f "$PIDFILE" ]; then
     # watch.sh. Pids can be recycled — a stale pidfile could point at an
     # unrelated process that took the same pid.
     cmd=$(compat_get_cmdline "$pid" 2>/dev/null || true)
-    case "$cmd" in
-      *"$SKILL_DIR/scripts/watch.sh"*) kill "$pid" 2>/dev/null || true ;;
-      *) ;;
-    esac
+    if agmsg_cmdline_names_path "$cmd" "$SKILL_DIR/scripts/watch.sh"; then
+      kill "$pid" 2>/dev/null || true
+    fi
   fi
   rm -f "$PIDFILE"
 fi

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -173,10 +173,9 @@ for f in "$RUN_DIR"/cc-instance.*; do
         # our watch.sh. Defends against pid recycling — a stale pidfile
         # could point at an unrelated process that took the same pid.
         cmd=$(compat_get_cmdline "$orphan_pid" 2>/dev/null || true)
-        case "$cmd" in
-          *"$SKILL_DIR/scripts/watch.sh"*) kill "$orphan_pid" 2>/dev/null || true ;;
-          *) ;;  # not our watcher anymore; leave it alone
-        esac
+        if agmsg_cmdline_names_path "$cmd" "$SKILL_DIR/scripts/watch.sh"; then
+          kill "$orphan_pid" 2>/dev/null || true
+        fi   # otherwise it is not our watcher anymore; leave it alone
       fi
       rm -f "$orphan_pidfile"
     fi

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -227,9 +227,9 @@ if [ -f "$PIDFILE" ]; then
   if [ -n "$prev_pid" ] && [ "$prev_pid" != "$$" ] && _agmsg_pid_alive_local "$prev_pid"; then
     prev_cmd=$(compat_get_cmdline "$prev_pid" 2>/dev/null || true)
     if [ -n "$prev_cmd" ]; then
-      case "$prev_cmd" in
-        *"$SKILL_DIR/scripts/watch.sh"*) PREV_PID_TO_DISPLACE="$prev_pid" ;;
-      esac
+      if agmsg_cmdline_names_path "$prev_cmd" "$SKILL_DIR/scripts/watch.sh"; then
+        PREV_PID_TO_DISPLACE="$prev_pid"
+      fi
     else
       # ps unavailable (sandboxed) — skip cmdline validation, rely on kill -0
       PREV_PID_TO_DISPLACE="$prev_pid"

--- a/tests/test_cmdline_path_match.bats
+++ b/tests/test_cmdline_path_match.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+
+# Does a command line name a path we hold? (#652)
+#
+# The two sides are written in different alphabets and only one of them is ours.
+# `compat_get_cmdline` returns what the OS says; the path it is compared against
+# came out of this shell. Under Git Bash the same file is `/c/Users/...` on our
+# side and `C:/Users/...` on the OS's, so a plain match never fires -- silently,
+# because "no match" is the ordinary answer for someone else's process.
+#
+# These run EVERYWHERE, not only on MSYS. That is deliberate and it is why the
+# comparator was written to route the conversion through `cygpath`: a stub on
+# PATH reproduces the Windows spelling on any host, so the branch that only
+# Windows takes is still exercised by every run of this suite. The alternative
+# -- gating on `uname` like tests/test_compat.bats does -- would mean this fix
+# is verified on the one platform nobody develops on.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  STUB_DIR="$BATS_TEST_TMPDIR/stub"
+  mkdir -p "$STUB_DIR"
+  # Mimics `cygpath -m`: the mixed form, forward slashes, which is what MSYS
+  # hands a native binary and therefore what that process reports.
+  cat > "$STUB_DIR/cygpath" <<'STUB'
+#!/bin/sh
+case "$2" in
+  /c/*) printf %s "C:${2#/c}" ;;
+  *) printf %s "$2" ;;
+esac
+STUB
+  chmod +x "$STUB_DIR/cygpath"
+
+  ENGINE_PATH="/c/Users/u/.agents/skills/agmsg/scripts/internal/remote-sync.mjs"
+  WINDOWS_CMDLINE="\"C:\\Program Files\\nodejs\\node.exe\" C:/Users/u/.agents/skills/agmsg/scripts/internal/remote-sync.mjs run --team ossb"
+  POSIX_CMDLINE="/usr/bin/node $ENGINE_PATH run --team ossb"
+}
+
+teardown() { teardown_test_env; }
+
+@test "cmdline-path: a Windows-spelled command line names a path we hold in POSIX form (#652)" {
+  PATH="$STUB_DIR:$PATH"
+  . "$SCRIPTS/lib/compat.sh"
+  # The whole defect in one line: this is the comparison that answered "not
+  # ours" about a live engine on the reporting machine.
+  run agmsg_cmdline_names_path "$WINDOWS_CMDLINE" "$ENGINE_PATH"
+  [ "$status" -eq 0 ]
+}
+
+@test "cmdline-path: a POSIX-spelled command line still matches, with or without cygpath (#652)" {
+  # The control, and the regression guard. If the fix only worked through the
+  # conversion, every non-Windows host would stop recognising its own
+  # processes -- which is a worse failure than the one being fixed, and it
+  # would not show up on a Windows-gated test.
+  . "$SCRIPTS/lib/compat.sh"
+  run agmsg_cmdline_names_path "$POSIX_CMDLINE" "$ENGINE_PATH"
+  [ "$status" -eq 0 ]
+
+  PATH="$STUB_DIR:$PATH"
+  run agmsg_cmdline_names_path "$POSIX_CMDLINE" "$ENGINE_PATH"
+  [ "$status" -eq 0 ]
+}
+
+@test "cmdline-path: a different path is not matched, in either spelling (#652)" {
+  # What the comparison is FOR. The pid came out of our own pidfile, so this
+  # only has to catch a pid that has been reused by something else -- and a
+  # conversion that made everything match would remove that check entirely
+  # while looking like a fix.
+  PATH="$STUB_DIR:$PATH"
+  . "$SCRIPTS/lib/compat.sh"
+
+  run agmsg_cmdline_names_path "$WINDOWS_CMDLINE" "/c/Users/u/.agents/skills/agmsg/scripts/internal/other.mjs"
+  [ "$status" -ne 0 ]
+
+  run agmsg_cmdline_names_path "$POSIX_CMDLINE" "/c/Users/u/.agents/skills/agmsg/scripts/internal/other.mjs"
+  [ "$status" -ne 0 ]
+}
+
+@test "cmdline-path: an empty command line is not a match (#652)" {
+  # `compat_get_cmdline` returns empty when it cannot read the process at all
+  # -- a sandbox, or a pid that is gone. Callers treat empty as "cannot tell",
+  # and a comparator that answered "yes" to it would turn every unreadable
+  # process into one of ours.
+  PATH="$STUB_DIR:$PATH"
+  . "$SCRIPTS/lib/compat.sh"
+  run agmsg_cmdline_names_path "" "$ENGINE_PATH"
+  [ "$status" -ne 0 ]
+}

--- a/tests/test_cmdline_path_match.bats
+++ b/tests/test_cmdline_path_match.bats
@@ -87,3 +87,34 @@ teardown() { teardown_test_env; }
   run agmsg_cmdline_names_path "" "$ENGINE_PATH"
   [ "$status" -ne 0 ]
 }
+
+@test "cmdline-path: no caller compares a shell path against a command line directly (#652)" {
+  # The structural control, and the reason it is structural: the four watcher
+  # sites decide whether to KILL something, and a per-site regression test would
+  # have to stand up a fake watcher four times to say what one grep says once.
+  #
+  # This is the criterion the sweep used, not a list of the five files found by
+  # it -- a sixth site added tomorrow fails this without anyone editing it.
+  #
+  # The shape being banned: a `case`/`[[` arm whose pattern interpolates a
+  # shell-derived path and whose subject came from `compat_get_cmdline`.
+  local offenders
+  offenders="$(grep -rnE '\*"\$(SKILL_DIR|SCRIPT_DIR)[^"]*"\*?\)' "$SCRIPTS"/*.sh "$SCRIPTS"/drivers/types/codex/*.sh 2>/dev/null || true)"
+  [ -z "$offenders" ] || {
+    printf 'a path is being matched against a command line directly:\n%s\n' "$offenders" >&3
+    false
+  }
+}
+
+@test "cmdline-path: every file that reads a command line for a path uses the comparator (#652)" {
+  # The other half. The ban above is satisfied by deleting a check entirely;
+  # this says the five that need the comparison still make it.
+  local f
+  for f in remote.sh watch.sh session-end.sh session-start.sh delivery.sh; do
+    grep -q 'agmsg_cmdline_names_path' "$SCRIPTS/$f" || {
+      printf '%s no longer asks the comparator\n' "$f" >&3
+      false
+      return
+    }
+  done
+}

--- a/tests/test_remote_status_liveness.bats
+++ b/tests/test_remote_status_liveness.bats
@@ -132,6 +132,66 @@ remember_engine_pid() {
   ENGINE_PIDS="${ENGINE_PIDS:+$ENGINE_PIDS }$ENGINE_PID"
 }
 
+# The Windows spelling, through the production entry. (#652)
+#
+# `write_matching_ps_fixture` answers with the POSIX path, which is the case
+# that never broke. These two answer with what the reporting machine actually
+# showed -- a drive-letter path -- and put a `cygpath` stub on PATH so the
+# conversion the comparator relies on exists.
+#
+# The point is the WIRING, not the comparator: `tests/test_cmdline_path_match.bats`
+# drives `agmsg_cmdline_names_path` alone, and every one of its cases stays green
+# if `remote.sh` goes back to the old suffix match. These two go red.
+write_windows_spelling_fixtures() {
+  local fake_bin="$TEST_SKILL_DIR/fake-win-bin" engine_win="C:/w/scripts/internal/remote-sync.mjs"
+  mkdir -p "$fake_bin"
+  # ps: this pid's argv, spelled the way a native binary reports it.
+  printf '%s\n' '#!/usr/bin/env bash' \
+    "if [[ \" \$* \" == *\" -p $ENGINE_PID \"* && \" \$* \" == *\" -o args= \"* ]]; then" \
+    "  printf '%s\\n' '\"C:\\Program Files\\nodejs\\node.exe\" $engine_win run --team testteam'" \
+    '  exit 0' \
+    'fi' \
+    'exec /bin/ps "$@"' > "$fake_bin/ps"
+  # cygpath: only the one path this test is about. A stub that rewrote
+  # everything would hide a comparator that converts the wrong operand.
+  printf '%s\n' '#!/usr/bin/env bash' \
+    "if [ \"\$2\" = \"$SCRIPTS/internal/remote-sync.mjs\" ]; then" \
+    "  printf '%s' '$engine_win'" \
+    '  exit 0' \
+    'fi' \
+    'printf %s "$2"' > "$fake_bin/cygpath"
+  chmod +x "$fake_bin/ps" "$fake_bin/cygpath"
+  printf '%s\n' "$fake_bin"
+}
+
+@test "status: a Windows-spelled argv still names this team's engine (#652)" {
+  start_matching_engine
+  local fake_bin; fake_bin="$(write_windows_spelling_fixtures)"
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" status testteam
+  [ "$status" -eq 0 ]
+  # `stale` is what the reporting machine got while the engine was running.
+  refute grep -qi 'stale' <<<"$output"
+  grep -qiE 'running|active' <<<"$output"
+}
+
+@test "disconnect: a Windows-spelled argv gets the engine stopped, not just forgotten (#652)" {
+  # The third contract, and it is not reached by a `sync stop` -- there is no
+  # such command. `_remote_sync_engine_stop` is what `unlock`, `disconnect`,
+  # `forget` and `set-endpoint` all call, and it reaps ONLY when the state is
+  # `running` while removing the pidfile either way. So a comparison that reads
+  # `stale` makes `disconnect` erase the engine's whereabouts and leave it
+  # polling a team whose binding was just torn off.
+  start_matching_engine
+  local fake_bin; fake_bin="$(write_windows_spelling_fixtures)"
+  run env PATH="$fake_bin:$PATH" bash "$SCRIPTS/remote.sh" disconnect testteam
+  [ "$status" -eq 0 ]
+  refute test -f "$TEST_SKILL_DIR/run/remote-sync.testteam.pid"
+  # The engine itself -- the half that "forgotten" leaves behind, and the whole
+  # reason the pidfile assertion above is not enough on its own.
+  sleep 1
+  refute kill -0 "$ENGINE_PID" 2>/dev/null
+}
+
 @test "status: a running engine that has never completed a cycle says so (#756)" {
   # `engine running` reports that a process is alive, which is true and is not
   # the question an operator has. In #744's report an engine failed every cycle


### PR DESCRIPTION
Declared reviewers: 1

## What was actually broken

Not what the issue says. Counted on `integration/remote` before touching
anything:

| the issue's scope | measured |
|---|---|
| "eight call sites in `scripts/remote.sh` use the non-local helper" | **0.** #812 converted all eight |
| "`scripts/watch.sh` still has one" | **not a call site** — `watch.sh:599`, inside a comment |

So "convert the eight call sites" is a job that no longer exists. The defect
that remains is one layer down, past the liveness check that #812 fixed.

`_remote_sync_engine_status` asks two things of a pid: is it alive, and is it
still the engine. The second compares an OS-provided command line against a
path this shell derived — and under Git Bash those are written in different
alphabets for the same file.

Measured on the reporting machine, one snapshot, engine alive:

```
_agmsg_pid_alive_local(963997)  TRUE        <- #812 works
expected  /c/Users/.../internal/remote-sync.mjs run --team ossb
cmdline   "C:\Program Files\nodejs\node.exe" C:/Users/.../internal/remote-sync.mjs run --team ossb
case *"$expected"  ->  no match  ->  stale
```

Forcing the CIM source instead of `/proc` returns the same `C:/` form, so this
is **not** about where the command line is read from. Both sources speak
Windows. The difference is `/c/` versus `C:/`, and nothing else.

## Swept by criterion, not by the issue's list

The criterion: *a comparison whose one side is an OS-provided command line and
whose other side is a shell-derived path.*

```
$ grep -rnE 'compat_get_cmdline|/proc/[^/]*/cmdline|ps -o args' scripts/ --include='*.sh'
```

Eleven captures; the ones that compare against a **path** are the class. The
rest match a fixed program name (`*codex*app-server*`, `*"daemon run"*`) and
have no path form to disagree about.

| file | the question it was getting wrong on Windows |
|---|---|
| `scripts/remote.sh` | is this pid still the sync engine — **the reported symptom** |
| `scripts/watch.sh` | is the previous pid still a watcher, to displace it |
| `scripts/session-end.sh` | is this pid a watcher, to kill it |
| `scripts/session-start.sh` | is this orphan a watcher, to kill it |
| `scripts/delivery.sh` | is this pid a watcher, to kill it |

**Five, and the issue named one.** Four of them decide whether to kill a stale
watcher, so on Windows they have been answering "not ours" and leaving it
running — which is the same shape as the orphaned engines, one layer over.

After: `grep -rn 'SKILL_DIR/scripts/watch.sh"\*' scripts/` counts **0**.

## The fix

One comparator, beside `compat_get_cmdline` so the producer and the reader
cannot drift apart. It tries the path as written, then — only where `cygpath`
exists — as `cygpath -m` spells it: the mixed form, forward slashes, which is
what MSYS hands a native binary and therefore what the process reports. Off
Windows there is no cygpath and it is the plain match and nothing else, the
same escape `agmsg_sql_readfile_path` takes.

`_remote_sync_engine_status` becomes **two** conditions where it was one suffix
match: the command line must NAME the engine script, and it must END with this
team's arguments. That second half is what kept another team's engine from
answering for this one, and collapsing everything into a single normalised
match would have quietly dropped it.

## One comparison, three answers

`status` is where it was found. The same answer is read in two more places, and
one of them I got wrong in an earlier version of this description.

- **`sync status`** reports `stale` for an engine that is running.
- **`sync start`** cannot confirm readiness, waits out its budget, prints a
  failure and reaps — the reported symptom.
- **not `sync stop`.** There is no such command. Writing the test is how that
  was found, after this body had already named it. `_remote_sync_engine_stop`
  is reached from **`unlock`, `disconnect`, `forget` and `set-endpoint`**, and
  it reaps only when the state is `running` while removing the pidfile either
  way:

```sh
  IFS=$'\t' read -r state pid < <(_remote_sync_engine_status "$team")
  if [ "$state" = "running" ]; then
    ... reap ...
  fi
  rm -f "$pidfile"          # unconditional
```

  So on Windows `disconnect` and `forget` erase an engine's whereabouts and
  leave it polling a team whose binding was just torn off. The code names that
  outcome itself, a few lines up, describing a different route into it: *"the
  orphan state: invisible to status, and `_remote_sync_engine_stop` returns 0
  without looking for it."*

  That is now a test — `disconnect` driven with the Windows spelling, asserting
  the engine is gone as well as the pidfile — so it is no longer only a
  derivation. It has still not been exercised on Windows itself.

## Tests, and why they are not `uname`-gated

`tests/test_compat.bats` skips itself off MSYS. A fix for Windows verified only
on Windows is verified by nobody here — so these route the conversion through
`cygpath` and put a **stub on PATH**, which reproduces the Windows spelling on
any host. The branch only Windows takes runs on every CI leg.

Mutations, both directions:

| mutation | result |
|---|---|
| the conversion branch removed (the pre-fix behaviour) | the Windows-spelling case **fails**; the other three pass |
| the comparator made to match everything | the wrong-path and empty-command-line cases **fail** |
| **`remote.sh` put back to the old suffix match** | **both production-entry cases fail — and all four helper-only cases stay green** |
| one watcher site put back to the old shape | **both structural cases fail** |

The second matters as much as the first: a "fix" that normalises until
everything matches would pass the first test and destroy the check. The third
is the one a reviewer asked for and it is the point — the first version of
these tests drove the comparator alone, so the likeliest regression, *the
comparator is right and a caller stops asking it*, was invisible. The fourth is
a positive control on a grep, which otherwise cannot be told from one that
cannot see.

Suites over the changed files: **404 tests, 0 failures**
(`test_delivery` 179, `test_remote` 122, `test_remote_status_liveness` 31,
`test_role_session` 24, `test_watch` 21, `test_watch_once` 10, `test_compat` 8,
`test_cmdline_path_match` 6, `test_watch_install_changed` 3).

## Measured on Windows, and what still is not

The reporting machine ran **the predecessor head, `1146dce9`**, before landing —
not the head this body is written at. Reported back:

| condition | result |
|---|---|
| `status` for a running engine | **`running`** — it was `stale` at the same instant on the previous head |
| `sync start` | **rc 0 in about 2 seconds** — it used to wait out its budget and fail |
| the pidfile after start | **survives** |
| starting twice | **no second engine** |

**Why that carries to this head, measured rather than asserted:**

```
$ git diff --name-only 1146dce9 bbd6e0b
tests/test_cmdline_path_match.bats
tests/test_remote_status_liveness.bats
$ git diff --name-only 1146dce9 bbd6e0b | grep -cv '^tests/'
0
```

The six production files are byte-identical between the two heads, so the run
above is evidence about this head's behaviour. It is **not** a run of this head,
and this section says which it is because those are different claims.

An earlier version of this section said the engine reading as `running` was
"not measured". That was written before those results came back and is
corrected here rather than left to age.

**Still not measured on Windows:** the `disconnect` / `forget` path. It has a
test now, and that test runs on every CI leg through a stub — but the machine
that reports this bug has not been asked to disconnect. The claim about it
rests on reading `remote.sh` plus a stubbed reproduction, and it is listed
separately for that reason.

Refs #652

Same class as #833 — a POSIX contract assumed to hold on Windows. Four of
these surfaced on the same day; this is one of them.
