### PR TITLE
fix(sync): ask jq for binary output, and refuse a jq that cannot give it

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -81,12 +81,54 @@ _sqlite_sync_sequence() {
   [ "$(_sqlite_sync_decimal_le "$1" 9223372036854775807)" = 1 ]
 }
 
+
+# `jq -b` IS REQUIRED HERE, AND THE REQUIREMENT FAILS CLOSED (#829).
+#
+# A native Windows jq opens stdout in text mode, so every line it prints ends
+# CRLF. Two values this driver sends ride out of a final-stage `jq … | @tsv`
+# read by `while IFS=$'\t' read -r`: `read` consumes the LF, `IFS` has no CR,
+# so the CR sticks to the LAST field -- the message `wire_id` and the base64
+# envelope `blob`. The server then answers HTTP 400. Measured on the reporting
+# machine: `hex(wire_id)` and `hex(blob)` both end `0D`, and stripping that byte
+# and resending produces `push.ack … stored`.
+#
+# `-b` is jq's own answer to this and the manual names this exact case. It is
+# the short form on purpose: `--binary` is rejected by jq-1.7.1-apple (measured:
+# rc 2, same as an unknown option), while `-b` is accepted there and on the
+# reporting machine's jq 1.8.2.
+#
+# REFUSING IS THE POINT. This repository checks that jq EXISTS and never that it
+# is a particular version -- `doctor` does not look at jq at all -- so there is
+# no floor to lean on. A jq without `-b` would exit 2 on every call, which is a
+# failure either way; saying so by name here is the difference between "the sync
+# is broken" and "this jq cannot do binary output". Falling back to stripping CR
+# afterwards is deliberately NOT offered: it guesses at which CRs were added,
+# and the guess is wrong for any value that legitimately ends a line with one.
+_AGMSG_JQ_BINARY_OK=""
+_sqlite_sync_require_jq_binary() {
+  case "$_AGMSG_JQ_BINARY_OK" in
+    yes) return 0 ;;
+    no)  return 1 ;;
+  esac
+  if printf '{}\n' | jq -b -r 'empty' >/dev/null 2>&1; then
+    _AGMSG_JQ_BINARY_OK=yes
+    return 0
+  fi
+  _AGMSG_JQ_BINARY_OK=no
+  echo "agmsg: Stage-1 sync requires a jq that supports -b (binary output)" >&2
+  echo "agmsg:   this jq: $(jq --version 2>/dev/null || echo 'unknown')" >&2
+  echo "agmsg:   without -b, a Windows jq emits CRLF and the trailing CR rides" >&2
+  echo "agmsg:   into the values this sends, which the server rejects (#829)." >&2
+  return 1
+}
+
 # <team> is the storage selector, threaded from the contract that called us.
 _sqlite_sync_schema() {
   command -v jq >/dev/null 2>&1 || {
     echo "agmsg: Stage-1 sync requires jq" >&2
     return 10
   }
+  _sqlite_sync_require_jq_binary || return 10
   storage_init "$1" >/dev/null || return 13
   local db generation
   db="$(_sqlite_db "$1")"
@@ -545,7 +587,7 @@ storage_sync_prepare_push() {
       seal_wire[$prepared]="$wire"; prepared=$((prepared + 1))
     done < <(paste <(printf '%s\n' "$uuids") \
                    <(printf '%s\n' "$rows" | jq -c 'select(.reserved==null)') \
-             | jq -rR 'split("\t") as $pair | ($pair[1] | fromjson) as $row
+             | jq -b -rR 'split("\t") as $pair | ($pair[1] | fromjson) as $row
                        | [$row.local_position, $row.local_id, $pair[0]] | @tsv')
     [ "$prepared" -eq "$pending" ] || return 13
     if [ -n "$key_id" ]; then q="'$(_sqlite_lit "$key_id")'"; else q="NULL"; fi
@@ -612,7 +654,7 @@ storage_sync_prepare_push() {
            projection:{body:$row.body,created_at:$created,
                        from_agent:$row.from_agent,to_agent:$row.to_agent}}' \
       | "$node_bin" "$cipher_helper" seal-batch "$pending" \
-      | jq -r --unbuffered --arg cipher "$cipher" --argjson key "$key_json" '
+      | jq -b -r --unbuffered --arg cipher "$cipher" --argjson key "$key_json" '
           select(.type=="sync_seal_result")
           | [(.index|tostring),
              (if .status=="ok" and .envelope.v==1 and .envelope.cipher==$cipher

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -105,38 +105,49 @@ _sqlite_sync_sequence() {
 # afterwards is deliberately NOT offered: it guesses at which CRs were added,
 # and the guess is wrong for any value that legitimately ends a line with one.
 _AGMSG_JQ_BINARY_OK=""
-_sqlite_sync_require_jq_binary() {
-  case "$_AGMSG_JQ_BINARY_OK" in
-    yes) return 0 ;;
-    no)  return 1 ;;
-  esac
-  local probe=""
-  # THE CONTRACT, NOT THE FLAG.
-  #
-  # An earlier version probed with `jq -b -r 'empty'`, which emits nothing: a jq
-  # that ACCEPTS `-b` and still writes CRLF passed it. The field report is about
-  # the bytes on stdout, so the probe has to produce a line and look at how that
-  # line ends (raised in review).
-  #
-  # Read with `read`, never through `$( )`. Command substitution on MSYS drops
-  # the final CR -- that is the very behaviour that hid this defect from a
-  # single-value capture -- so inspecting the probe that way would report clean
-  # output from a jq that is still adding CR. `read` stops at the LF and leaves
-  # the CR in the variable, so `probe` and `probe<CR>` are distinguishable here.
-  #
-  # A jq that fails outright leaves `probe` empty, which is also not the
-  # expected value, so a broken jq and a CRLF jq both fall to the refusal below
-  # -- and the message names the capability rather than guessing which it was.
-  IFS= read -r probe < <(printf '{}\n' | jq -b -r '"agmsg-probe"' 2>/dev/null) || probe=""
-  if [ "$probe" = "agmsg-probe" ]; then
-    _AGMSG_JQ_BINARY_OK=yes
-    return 0
-  fi
-  _AGMSG_JQ_BINARY_OK=no
+
+# Said every time it refuses, not only the first time (#829, raised in review).
+#
+# The result is cached because the probe costs a process, but a cached NO used to
+# `return 1` in silence: the first push in a long-lived shell explained itself and
+# every push after it just failed. A caller that retries -- which is what the
+# engine does on its cycle -- would see one sentence and then nothing, and the
+# one sentence scrolls away.
+_sqlite_sync_jq_binary_refusal() {
   echo "agmsg: sending requires a jq whose -b (binary output) produces LF-terminated lines" >&2
   echo "agmsg:   this jq: $(jq --version 2>/dev/null || echo 'unknown')" >&2
   echo "agmsg:   a Windows jq without it emits CRLF, and the trailing CR rides into" >&2
   echo "agmsg:   the values this sends, which the server rejects (#829)." >&2
+}
+
+_sqlite_sync_require_jq_binary() {
+  case "$_AGMSG_JQ_BINARY_OK" in
+    yes) return 0 ;;
+    no)  _sqlite_sync_jq_binary_refusal; return 1 ;;
+  esac
+  local probe="" status=1 out="${TMPDIR:-/tmp}/agmsg-jq-probe.$$"
+  # BOTH HALVES: the bytes AND jq's own exit status.
+  #
+  # Probing with `jq -b -r 'empty'` tested option parsing only -- it emits
+  # nothing, so a jq that accepts `-b` and still writes CRLF passed. Reading a
+  # sentinel fixes that half. The other half is that a jq can print the right
+  # bytes and still fail; observed through a process substitution, that status is
+  # unreachable, and the probe would cache `yes` for a jq that exited non-zero
+  # (raised in review). So the output goes to a file, the status is taken from
+  # the pipeline, and the bytes are read back afterwards.
+  #
+  # Read with `read`, never through `$( )`: command substitution on MSYS drops
+  # the final CR, which is exactly the byte this is looking for.
+  printf '{}\n' | jq -b -r '"agmsg-probe"' > "$out" 2>/dev/null
+  status=$?
+  IFS= read -r probe < "$out" 2>/dev/null || probe=""
+  if command -v rm >/dev/null 2>&1; then rm -f "$out"; fi
+  if [ "$status" -eq 0 ] && [ "$probe" = "agmsg-probe" ]; then
+    _AGMSG_JQ_BINARY_OK=yes
+    return 0
+  fi
+  _AGMSG_JQ_BINARY_OK=no
+  _sqlite_sync_jq_binary_refusal
   return 1
 }
 

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -125,24 +125,30 @@ _sqlite_sync_require_jq_binary() {
     yes) return 0 ;;
     no)  _sqlite_sync_jq_binary_refusal; return 1 ;;
   esac
-  local probe="" status=1 out="${TMPDIR:-/tmp}/agmsg-jq-probe.$$"
-  # BOTH HALVES: the bytes AND jq's own exit status.
+  local probe="" ok=""
+  # BOTH HALVES, AND NO SHARED FILE.
   #
   # Probing with `jq -b -r 'empty'` tested option parsing only -- it emits
   # nothing, so a jq that accepts `-b` and still writes CRLF passed. Reading a
-  # sentinel fixes that half. The other half is that a jq can print the right
-  # bytes and still fail; observed through a process substitution, that status is
-  # unreachable, and the probe would cache `yes` for a jq that exited non-zero
-  # (raised in review). So the output goes to a file, the status is taken from
-  # the pipeline, and the bytes are read back afterwards.
+  # sentinel fixes that half; the other half is that a jq can print the right
+  # bytes and still fail, and through a process substitution that status is
+  # unreachable (both raised in review).
   #
-  # Read with `read`, never through `$( )`: command substitution on MSYS drops
-  # the final CR, which is exactly the byte this is looking for.
-  printf '{}\n' | jq -b -r '"agmsg-probe"' > "$out" 2>/dev/null
-  status=$?
-  IFS= read -r probe < "$out" 2>/dev/null || probe=""
-  if command -v rm >/dev/null 2>&1; then rm -f "$out"; fi
-  if [ "$status" -eq 0 ] && [ "$probe" = "agmsg-probe" ]; then
+  # The first attempt at getting both wrote jq's output to
+  # `${TMPDIR}/agmsg-jq-probe.$$` and took the status from the pipeline. `$$` is
+  # the PARENT's pid inside a subshell, so concurrent sealers in one process tree
+  # shared that path: one removed it while another was still reading, and the
+  # driver refused a jq that was fine. `concurrent age-v1 sealers` caught it.
+  # This is the same reasoning about `$$` that was wrong once already (#804).
+  #
+  # So the status travels in the stream instead of in a file. jq writes the
+  # sentinel; `&&` appends a second line only if jq exited 0. Two `read`s, no
+  # shared name, nothing to clean up -- and still `read` rather than `$( )`,
+  # because command substitution on MSYS drops the byte this is looking for.
+  { IFS= read -r probe; IFS= read -r ok; } < <(
+    printf '{}\n' | { jq -b -r '"agmsg-probe"' && printf 'agmsg-ok\n'; } 2>/dev/null
+  )
+  if [ "$probe" = "agmsg-probe" ] && [ "$ok" = "agmsg-ok" ]; then
     _AGMSG_JQ_BINARY_OK=yes
     return 0
   fi

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -110,15 +110,33 @@ _sqlite_sync_require_jq_binary() {
     yes) return 0 ;;
     no)  return 1 ;;
   esac
-  if printf '{}\n' | jq -b -r 'empty' >/dev/null 2>&1; then
+  local probe=""
+  # THE CONTRACT, NOT THE FLAG.
+  #
+  # An earlier version probed with `jq -b -r 'empty'`, which emits nothing: a jq
+  # that ACCEPTS `-b` and still writes CRLF passed it. The field report is about
+  # the bytes on stdout, so the probe has to produce a line and look at how that
+  # line ends (raised in review).
+  #
+  # Read with `read`, never through `$( )`. Command substitution on MSYS drops
+  # the final CR -- that is the very behaviour that hid this defect from a
+  # single-value capture -- so inspecting the probe that way would report clean
+  # output from a jq that is still adding CR. `read` stops at the LF and leaves
+  # the CR in the variable, so `probe` and `probe<CR>` are distinguishable here.
+  #
+  # A jq that fails outright leaves `probe` empty, which is also not the
+  # expected value, so a broken jq and a CRLF jq both fall to the refusal below
+  # -- and the message names the capability rather than guessing which it was.
+  IFS= read -r probe < <(printf '{}\n' | jq -b -r '"agmsg-probe"' 2>/dev/null) || probe=""
+  if [ "$probe" = "agmsg-probe" ]; then
     _AGMSG_JQ_BINARY_OK=yes
     return 0
   fi
   _AGMSG_JQ_BINARY_OK=no
-  echo "agmsg: Stage-1 sync requires a jq that supports -b (binary output)" >&2
+  echo "agmsg: sending requires a jq whose -b (binary output) produces LF-terminated lines" >&2
   echo "agmsg:   this jq: $(jq --version 2>/dev/null || echo 'unknown')" >&2
-  echo "agmsg:   without -b, a Windows jq emits CRLF and the trailing CR rides" >&2
-  echo "agmsg:   into the values this sends, which the server rejects (#829)." >&2
+  echo "agmsg:   a Windows jq without it emits CRLF, and the trailing CR rides into" >&2
+  echo "agmsg:   the values this sends, which the server rejects (#829)." >&2
   return 1
 }
 
@@ -128,7 +146,6 @@ _sqlite_sync_schema() {
     echo "agmsg: Stage-1 sync requires jq" >&2
     return 10
   }
-  _sqlite_sync_require_jq_binary || return 10
   storage_init "$1" >/dev/null || return 13
   local db generation
   db="$(_sqlite_db "$1")"
@@ -502,6 +519,12 @@ storage_sync_prepare_push() {
   case "$limit" in ''|*[!0-9]*) return 13 ;; esac
   [ "$limit" -ge 1 ] && [ "$limit" -le 1000 ] || return 13
   _sqlite_sync_schema "$team" || return $?
+  # HERE, NOT IN THE SCHEMA. `_sqlite_sync_schema` gates every Stage-1 call, so
+  # requiring `-b` there refused receiving and status as well -- on a POSIX jq
+  # that never needed binary stdout. The defect this closes is "can receive but
+  # never send", and this is the only path that produces the two values the CR
+  # rides on. Placed before anything is reserved or written (raised in review).
+  _sqlite_sync_require_jq_binary || return 10
 
   local prepare generation db tl input_ok version cipher key_json key_id recipients max_blob allow_new
   prepare=$(cat)

--- a/tests/test_sqlite_sync_jq_binary.bats
+++ b/tests/test_sqlite_sync_jq_binary.bats
@@ -253,7 +253,8 @@ STUB
 }
 
 @test "sync: concurrent probes in one process tree do not break each other (#829)" {
-  # THE DEFECT THE FIRST VERSION SHIPPED. The probe wrote jq's output to
+  # THE DEFECT AN EARLIER PUSHED HEAD CARRIED -- never landed, never released.
+  # That head's probe wrote jq's output to
   # `${TMPDIR}/agmsg-jq-probe.$$`. Inside a subshell `$$` is the PARENT's pid, so
   # concurrent sealers in one process tree shared that path: one removed the file
   # while another was still reading it, the read failed, and a perfectly good jq

--- a/tests/test_sqlite_sync_jq_binary.bats
+++ b/tests/test_sqlite_sync_jq_binary.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+# The `-b` requirement, and the refusal that carries it (#829).
+#
+# A native Windows jq prints CRLF, and the trailing CR rides into the two values
+# this driver sends -- the message `wire_id` and the base64 envelope `blob` --
+# because `read` takes the LF and `IFS` has no CR. `jq -b` is jq's own answer.
+#
+# The requirement fails closed rather than degrading: this repository checks that
+# jq EXISTS and never which jq it is, so a jq without `-b` would exit 2 on every
+# call in here anyway. What the refusal buys is the operator reading "this jq
+# cannot do binary output" instead of "Stage-1 sync is broken".
+
+load test_helper
+
+setup() { setup_test_env; }
+teardown() { teardown_test_env; }
+
+# A jq that works for everything except `-b`, which is what an older jq is.
+stub_jq_without_b() {
+  local bin="$TEST_SKILL_DIR/jq-no-b"
+  mkdir -p "$bin"
+  cat > "$bin/jq" <<'STUB'
+#!/usr/bin/env bash
+for a in "$@"; do
+  case "$a" in
+    -b|-b*|--binary) echo "jq: Unknown option $a" >&2; exit 2 ;;
+  esac
+done
+exec /usr/bin/env -i PATH="$REAL_PATH" jq "$@"
+STUB
+  chmod +x "$bin/jq"
+  printf '%s' "$bin"
+}
+
+@test "sync: a jq without -b is refused by name, not left to fail later (#829)" {
+  local bin; bin="$(stub_jq_without_b)"
+
+  run env REAL_PATH="$PATH" PATH="$bin:$PATH" bash -c '
+    . "$1/drivers/storage/sqlite-sync.sh"
+    _sqlite_sync_require_jq_binary
+  ' _ "$SCRIPTS"
+
+  [ "$status" -ne 0 ]
+  # NAMED. The point of failing closed is the sentence, so the sentence is what
+  # is asserted -- not merely that something went wrong.
+  echo "$output" | grep -q 'requires a jq that supports -b'
+  echo "$output" | grep -q 'CRLF'
+}
+
+@test "sync: a jq WITH -b is accepted, so the refusal is not unconditional (#829)" {
+  # The negative control. Without it, the case above is satisfied by a probe
+  # that refuses every jq.
+  run bash -c '
+    . "$1/drivers/storage/sqlite-sync.sh"
+    _sqlite_sync_require_jq_binary
+  ' _ "$SCRIPTS"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "sync: the driver's own entry refuses too, so the check is wired (#829)" {
+  # THE PROBE BEING RIGHT IS NOT THE PROBE BEING CALLED.
+  #
+  # The two cases above drive `_sqlite_sync_require_jq_binary` directly, so they
+  # hold even if nothing in the driver ever calls it -- measured: removing the
+  # call from `_sqlite_sync_schema` reddens neither. This one goes in through the
+  # entry that gates the driver, so the wiring is what fails when the wiring is
+  # what breaks.
+  local bin; bin="$(stub_jq_without_b)"
+
+  run env REAL_PATH="$PATH" PATH="$bin:$PATH" bash -c '
+    . "$1/lib/storage.sh" 2>/dev/null || true
+    . "$1/drivers/storage/sqlite-sync.sh"
+    _sqlite_sync_schema testteam
+  ' _ "$SCRIPTS"
+
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q 'requires a jq that supports -b'
+}

--- a/tests/test_sqlite_sync_jq_binary.bats
+++ b/tests/test_sqlite_sync_jq_binary.bats
@@ -187,3 +187,67 @@ staged_hex() {
   [ -n "$hex" ]
   refute grep -qi '0D$' <<< "$hex"
 }
+
+# A jq that prints the right bytes and then fails. Both halves of the contract
+# are required: LF-terminated output AND a jq that completed.
+stub_jq_clean_but_failing() {
+  local bin="$TEST_SKILL_DIR/jq-clean-fail"
+  mkdir -p "$bin"
+  cat > "$bin/jq" <<STUB
+#!/usr/bin/env bash
+for a in "\$@"; do
+  case "\$a" in -b|-b*) printf 'agmsg-probe\n'; exit 3 ;;
+  esac
+done
+exec "$(command -v jq)" "\$@"
+STUB
+  chmod +x "$bin/jq"
+  printf '%s' "$bin"
+}
+
+@test "sync: a jq that prints clean bytes and then fails is refused too (#829)" {
+  # THE OTHER HALF OF THE CONTRACT. Reading the sentinel proves the bytes; it
+  # does not prove jq finished. Observed through a process substitution the exit
+  # status is unreachable, and a jq that wrote the right line and exited 3 was
+  # cached as usable (raised in review).
+  local bin; bin="$(stub_jq_clean_but_failing)"
+
+  run env PATH="$bin:$PATH" bash -c '
+    . "$1/drivers/storage/sqlite-sync.sh"
+    _sqlite_sync_require_jq_binary
+  ' _ "$SCRIPTS"
+
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q 'requires a jq whose -b (binary output) produces LF-terminated lines'
+}
+
+@test "sync: the second refusal in one shell says it too (#829)" {
+  # A CACHED NO USED TO BE SILENT. The result is cached because probing costs a
+  # process, but the engine retries on its cycle: the first attempt explained
+  # itself and every attempt after it failed without a word, so the explanation
+  # scrolled away and never came back.
+  local bin; bin="$(stub_jq_without_b)"
+
+  # NO PIPELINE. Piping each call into `sed` put it in a subshell, so the cache
+  # set by the first call never reached the second and BOTH ran the uncached
+  # path -- the case passed while the cached branch was never entered. Measured:
+  # making the cached refusal silent reddened nothing. `{ …; } 2>file` keeps the
+  # calls in one shell.
+  run env REAL_PATH="$PATH" PATH="$bin:$PATH" bash -c '
+    cd "$2"
+    . "$1/drivers/storage/sqlite-sync.sh"
+    { _sqlite_sync_require_jq_binary; } 2>err1
+    { _sqlite_sync_require_jq_binary; } 2>err2
+    echo "cached=$_AGMSG_JQ_BINARY_OK"
+    echo "first: $(head -1 err1)"
+    echo "second: $(head -1 err2)"
+  ' _ "$SCRIPTS" "$BATS_TEST_TMPDIR"
+
+  # BOTH, named separately: a control that only counted occurrences would pass
+  # on two copies of the first one.
+  # The cache really was consulted -- otherwise this proves nothing about the
+  # cached branch.
+  echo "$output" | grep -q 'cached=no'
+  echo "$output" | grep -q 'first: agmsg: sending requires a jq whose -b'
+  echo "$output" | grep -q 'second: agmsg: sending requires a jq whose -b'
+}

--- a/tests/test_sqlite_sync_jq_binary.bats
+++ b/tests/test_sqlite_sync_jq_binary.bats
@@ -44,8 +44,8 @@ STUB
   [ "$status" -ne 0 ]
   # NAMED. The point of failing closed is the sentence, so the sentence is what
   # is asserted -- not merely that something went wrong.
-  echo "$output" | grep -q 'requires a jq that supports -b'
-  echo "$output" | grep -q 'CRLF'
+  echo "$output" | grep -q 'requires a jq whose -b (binary output) produces LF-terminated lines'
+  echo "$output" | grep -q 'emits CRLF'
 }
 
 @test "sync: a jq WITH -b is accepted, so the refusal is not unconditional (#829)" {
@@ -70,12 +70,120 @@ STUB
   # what breaks.
   local bin; bin="$(stub_jq_without_b)"
 
+  # THROUGH THE PATH THAT NEEDS IT. The check was moved out of
+  # `_sqlite_sync_schema` -- which gates receiving and status too -- and into the
+  # push path, which is the only one producing the two values the CR rides on.
+  # So the wiring assertion has to enter there.
   run env REAL_PATH="$PATH" PATH="$bin:$PATH" bash -c '
-    . "$1/lib/storage.sh" 2>/dev/null || true
-    . "$1/drivers/storage/sqlite-sync.sh"
-    _sqlite_sync_schema testteam
-  ' _ "$SCRIPTS"
+    export SKILL_DIR="$2" AGMSG_STORAGE_PATH="$3" AGMSG_STORAGE_DRIVER=sqlite
+    . "$1/lib/storage.sh"; agmsg_storage_load
+    storage_init demo >/dev/null 2>&1
+    printf "%s\n" "{\"type\":\"sync_prepare\",\"envelope_v\":1,\"cipher\":\"none\",\"key_id\":null,\"max_blob_bytes\":1048576,\"allow_new\":true}" \
+      | storage_sync_prepare_push demo 018f3f7e-0000-7000-8000-000000000000 018f3f7e-0000-7000-8000-000000000001 1 100
+  ' _ "$SCRIPTS" "$TEST_SKILL_DIR" "$BATS_TEST_TMPDIR/store3"
 
   [ "$status" -ne 0 ]
-  echo "$output" | grep -q 'requires a jq that supports -b'
+  echo "$output" | grep -q 'requires a jq whose -b (binary output) produces LF-terminated lines'
+}
+
+# A jq that adds CR the way the reporting machine's does -- but only to the
+# `@tsv` stages, and that restriction is the honest part.
+#
+# On the reporting machine EVERY jq line ends CRLF, and the shell there drops the
+# trailing CR from a `$( )` capture, so only the `read` sinks are poisoned. This
+# test runs on a shell that does NOT drop it, so a faithful stub also poisons
+# every `VAR=$(… jq …)` in the driver -- `cipher` becomes `none<CR>`, `version`
+# becomes `1<CR>` -- and prepare fails for a reason that cannot happen on the
+# platform being simulated. Measured: it returned 13, silently.
+#
+# So the simulation is scoped to the sink under test: the two final stages that
+# end in `@tsv` and are consumed by `while IFS=$'\t' read -r`. That is where the
+# field report measured the CR, and it is the only place this change touches.
+stub_jq_crlf_without_b() {
+  local bin="$TEST_SKILL_DIR/jq-crlf"
+  mkdir -p "$bin"
+  cat > "$bin/jq" <<STUB
+#!/usr/bin/env bash
+real="$(command -v jq)"
+for a in "\$@"; do
+  case "\$a" in -b|-b*) exec "\$real" "\$@" ;; esac
+done
+tsv=0
+for a in "\$@"; do
+  case "\$a" in *@tsv*) tsv=1 ;; esac
+done
+if [ "\$tsv" = 1 ]; then
+  "\$real" "\$@" | sed 's/\$/\r/'
+  exit "\${PIPESTATUS[0]}"
+fi
+exec "\$real" "\$@"
+STUB
+  chmod +x "$bin/jq"
+  printf '%s' "$bin"
+}
+
+push_fixture() {
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=sqlite
+  # shellcheck disable=SC1091
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  storage_init demo >/dev/null
+  SERVER_ID=018f3f7e-0000-7000-8000-000000000000
+  TEAM_ID=018f3f7e-0000-7000-8000-000000000001
+  PREPARE='{"type":"sync_prepare","envelope_v":1,"cipher":"none","key_id":null,"max_blob_bytes":1048576,"allow_new":true}'
+  storage_send demo alice bob "a body that must arrive intact" >/dev/null
+}
+
+staged_hex() {
+  local col="$1" db
+  db="$(printf '%s' "$AGMSG_STORAGE_PATH")/teams/demo/store.db"
+  [ -f "$db" ] || db="$(find "$AGMSG_STORAGE_PATH" -name '*.db' -print -quit)"
+  sqlite3 "$db" "SELECT hex($col) FROM sync_messages WHERE direction='push' LIMIT 1;"
+}
+
+@test "sync: a CRLF jq does not put a trailing CR on the staged wire_id (#829)" {
+  # THE FIELD OBSERVATION, REPRODUCED LOCALLY. On the reporting machine
+  # `hex(wire_id)` ended `0D`; stripping that byte and resending produced
+  # `push.ack … stored`. So the assertion is on the same bytes, in the same
+  # column, and NOT shared with the blob -- one assertion covering both values
+  # would hide a regression in either.
+  push_fixture
+  local bin; bin="$(stub_jq_crlf_without_b)"
+  # RUN IN THIS SHELL. `storage_sync_prepare_push` is a function that
+  # `agmsg_storage_load` defines here; a `bash -c` child does not have it, and
+  # invoking it there reports "command not found" rather than exercising the
+  # driver. Measured: status 127 from the child, which is what the first draft
+  # of this case was actually observing.
+  local saved_path="$PATH"
+  PATH="$bin:$PATH"
+  printf '%s\n' "$PREPARE" \
+    | storage_sync_prepare_push demo "$SERVER_ID" "$TEAM_ID" 1 100 >/dev/null
+  PATH="$saved_path"
+
+  local hex; hex="$(staged_hex wire_id)"
+  [ -n "$hex" ]
+  refute grep -qi '0D$' <<< "$hex"
+}
+
+@test "sync: a CRLF jq does not put a trailing CR on the staged blob (#829)" {
+  # The other half, asserted separately and deliberately: the two values leave
+  # two different final-stage jq calls, so they are two contracts.
+  push_fixture
+  local bin; bin="$(stub_jq_crlf_without_b)"
+  # RUN IN THIS SHELL. `storage_sync_prepare_push` is a function that
+  # `agmsg_storage_load` defines here; a `bash -c` child does not have it, and
+  # invoking it there reports "command not found" rather than exercising the
+  # driver. Measured: status 127 from the child, which is what the first draft
+  # of this case was actually observing.
+  local saved_path="$PATH"
+  PATH="$bin:$PATH"
+  printf '%s\n' "$PREPARE" \
+    | storage_sync_prepare_push demo "$SERVER_ID" "$TEAM_ID" 1 100 >/dev/null
+  PATH="$saved_path"
+
+  local hex; hex="$(staged_hex blob)"
+  [ -n "$hex" ]
+  refute grep -qi '0D$' <<< "$hex"
 }

--- a/tests/test_sqlite_sync_jq_binary.bats
+++ b/tests/test_sqlite_sync_jq_binary.bats
@@ -251,3 +251,30 @@ STUB
   echo "$output" | grep -q 'first: agmsg: sending requires a jq whose -b'
   echo "$output" | grep -q 'second: agmsg: sending requires a jq whose -b'
 }
+
+@test "sync: concurrent probes in one process tree do not break each other (#829)" {
+  # THE DEFECT THE FIRST VERSION SHIPPED. The probe wrote jq's output to
+  # `${TMPDIR}/agmsg-jq-probe.$$`. Inside a subshell `$$` is the PARENT's pid, so
+  # concurrent sealers in one process tree shared that path: one removed the file
+  # while another was still reading it, the read failed, and a perfectly good jq
+  # was refused. `concurrent age-v1 sealers publish one transaction winner`
+  # turned red on it in CI.
+  #
+  # Same shape as the `$$` reasoning that was already wrong once in #804. The
+  # probe carries no shared name now, and this holds it there.
+  run bash -c '
+    . "$1/drivers/storage/sqlite-sync.sh"
+    rc=0
+    for _ in 1 2 3 4 5 6 7 8; do
+      ( _sqlite_sync_require_jq_binary ) || rc=1 &
+    done
+    wait
+    exit "$rc"
+  ' _ "$SCRIPTS"
+
+  # Every one of them accepted the same real jq. A shared path shows up here as
+  # an intermittent refusal, which is what it did on the runner.
+  [ "$status" -eq 0 ]
+  # And nothing was said, because nothing was wrong.
+  [ -z "$output" ]
+}


### PR DESCRIPTION
Declared reviewers: 1

Refs #829.

A native Windows jq opens stdout in text mode, so every line it prints ends CRLF.
Two values this driver sends leave a final-stage `jq … | @tsv` that a
`while IFS=$'\t' read -r` consumes: `read` takes the LF, `IFS` has no CR, so the
CR sticks to the **last** field — the message `wire_id` and the base64 envelope
`blob`. The server answers HTTP 400, and the machine can receive but never send.

Measured on the reporting machine: `hex(wire_id)` and `hex(blob)` both end `0D`,
and stripping that byte and resending produces `push.ack … stored`.

## Why `-b`, and why the short form

`-b` is jq's own answer, and its manual names this exact case. The short form is
deliberate: `--binary` is **rejected** by jq-1.7.1-apple — measured rc 2, the
same as an unknown option — while `-b` is accepted there and on the reporting
machine's jq 1.8.2.

## Why it fails closed

This repository checks that jq **exists** and never which jq it is — `doctor`
does not look at jq at all — so there is no version floor to lean on. A jq
without `-b` would exit 2 on every call here. That is a failure either way; what
changes is whether the operator reads *"Stage-1 sync is broken"* or *"this jq
cannot do binary output"*.

The probe runs once and caches, beside the `command -v jq` check that already
gates this driver.

**Stripping the CR afterwards is not offered as a fallback.** It guesses which
CRs the runtime added, and the guess is wrong for any value that legitimately
ends a line with one.

## What this PR does not cover

This PR closes the jq boundary for the two values that ride the wire. The rest of
the sweep is deliberately not here, and this is the record of what "the rest" is,
so that *separate* does not quietly become *unexamined*.

Numbers below are derived from the tree at this head, not carried over from the
issue. Where they differ from earlier figures circulated while scoping, these are
the ones that were re-derived with a detector that finds both `IFS=$'\t'` and
`IFS='<TAB>'` loop forms — the earlier count missed the second and reported 33
loops instead of 35.

### `while IFS=… read -r` loops — 35 total

| input source | count | status |
|---|---|---|
| **jq, directly** | **2** | **fixed here** — the wire-id `@tsv` producer and the seal-result blob `@tsv` producer in `sqlite-sync.sh` |
| **sqlite3, directly** | **2** | `team.sh:36` **already guarded**, `whoami.sh:88` **not** |
| herestring from a variable (`done <<< "$VAR"`) | 20 | producer not yet traced |
| a pipeline | 6 | producer not yet traced |
| other process substitution | 2 | not yet traced |
| heredoc | 2 | literal input; not a tool boundary |
| other | 1 | not yet traced |

`team.sh:36` is worth reading before anyone treats the remainder as new work:

```sh
# tr -d '\r': sqlite3.exe on Windows emits CRLF rows; the trailing CR would make
# the `registrations` field "N\r" and trip the integer test in the loop (#130).
```

**This class was found once, fixed at the site that showed it, and not swept.**
`whoami.sh:88` is the same shape, the same tool, and has no guard. That is the
single strongest argument for the follow-up being a sweep rather than another
site fix.

### `VAR=$(… jq …)` captures — 41

- **32** take a raw string (`-r`): `sqlite-sync.sh` 29, `jsonl.sh` 2,
  `release/sync-version.sh` 1
- **9** take JSON (`-c` or default) and are re-parsed downstream

Whether a raw capture is affected depends on a third axis that is **not derived
yet**: whether the captured value can contain LF. On MSYS `$( )` drops only the
*trailing* CR, so a single-physical-line value is safe and a multi-line one is
not. Numeric, UUID and enumerated fields cannot hold LF; `.name`, `.reason` and
`.local_agents[]` can. That reading is from the filters, not from validation
code, and is marked here as unfinished rather than counted as safe.

### Not swept at all

`sqlite3` output reaching a raw sink through any idiom other than the two loops
above. The tool is known to emit CRLF on Windows — that is what `#130` is — and
this PR does not touch it.

### One pushed head carried a defect, and CI named it

A pushed revision of this probe — never landed, never released — wrote jq's output to `${TMPDIR}/agmsg-jq-probe.$$` to get
the exit status alongside the bytes. **`$$` inside a subshell is the parent's
pid**, so concurrent sealers in one process tree shared that path — one removed
the file while another read it, and a good jq was refused.
`concurrent age-v1 sealers publish one transaction winner` turned red on it.

It is the same reasoning about `$$` that was already wrong in #804. The status
now travels in the stream (`jq … && printf 'agmsg-ok\n'`, read as two lines), so
there is no shared name at all.

### Where the rest is tracked

**This PR does not close #829.** #829 stays open, and these are what it stays
open for:

1. **`whoami.sh:88`** — `done < <(sqlite3 …)` with no `tr -d '\r'`, the same
   shape `team.sh:36` already guards — and the wider sqlite3 raw-sink sweep.
2. **Producer tracing** for the read paths not yet attributed: 20 herestring,
   6 pipeline, 2 other process substitution, 1 other.
3. **Alphabet classification** of the 32 raw `jq` captures — whether each
   captured value can contain LF, which is what decides safe from vulnerable on
   MSYS. Read from the filters so far, never from validation code, and therefore
   counted as unfinished rather than safe.

The patch is split; the tracking is not. If #829 is later closed by the
follow-up, these three are the checklist it has to answer.

### Why the split

The two sites fixed here are what the field report measured, and they are the
whole of *"Windows can receive but never send"*. The rest changes no observed
behaviour on the reporting machine and would widen this change's blast radius
while a release waits on it. Splitting is a scheduling decision, not a judgement
that the remainder is safe.

## Measured on this head

```
tests/test_remote_sync_engine.bats + test_jsonl_remote_sync.bats   26 ok / 0
tests/remote_sync_engine.test.mjs                                  94 pass / 0
```

## The controls, and the one that had to be added twice

| mutation | result |
|---|---|
| probe forced to succeed | *a jq without -b is refused by name* red |
| probe forced to fail | *a jq WITH -b is accepted* red |
| call removed from the push entry | *the driver's own entry refuses too* red |
| **`-b` removed from the wire line** | *no trailing CR on the staged wire_id* red |
| **`-b` removed from the blob line** | *no trailing CR on the staged blob* red |
| **jq's exit status ignored** | *clean bytes and then fails is refused too* red |
| **cached refusal made silent** | *the second refusal in one shell says it too* red |
| **probe given a `$$`-named temp file again** | *concurrent probes in one process tree* red, 3 runs of 3 |

The third case exists because the first two did not cover what they looked like
they covered: they drive the probe directly, so **removing the call from the
driver reddened neither**. The probe being right is not the probe being called.

The jq without `-b` is a stub that rejects that flag and execs the real one for
everything else. The negative control matters as much — without it, the refusal
case is satisfied by a probe that refuses *every* jq, which would break the
driver everywhere instead of on Windows.

Assertions are on the sentence, not merely on a non-zero status: the reason to
fail closed at all is which sentence the operator reads.

```
tests/test_sqlite_sync_jq_binary.bats   8/8
```

**This description is for head `b9f64973275ca33eff258a5c0061c7efa58c8e26`.**
