### PR TITLE
Stop telling every agent that key rotate is unavailable

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -303,8 +303,24 @@ If argument starts with "key import" followed by a team name:
 3. Do not offer an environment-variable path. An identity file is a permanent
    secret; always use the human-in-own-terminal flow above.
 
-`key rotate` and device-pairing `key request`/`key approve` are not available
-yet. If the user asks for one, tell them so instead of attempting to run it.
+If argument starts with "key rotate" followed by a team name:
+1. Rotation mints a replacement epoch for a team that already has a key and
+   announces it on the roster journal. It requires an existing current key, an
+   identity journal (connect or migrate the team first), and `age`; it refuses
+   with a message naming whichever is missing.
+2. Confirm with the user before running it. It changes the team's key state,
+   and every other machine has to receive the new identity out of band.
+3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+4. Show the output: epoch, key_id, and recipient fingerprint. The private key
+   is never written to the journal. Revealing it needs
+   `key show <team> --key-id <id> --reveal-secret`, which is refused in agent
+   mode — tell the user to run that in their own terminal.
+5. Messages before the acknowledged rotation boundary remain readable with the
+   old key.
+
+Device pairing (`key request` / `key approve`) is not implemented — they are
+not `key.sh` subcommands, so a call prints usage and exits 1. If the user asks
+for one, tell them so instead of attempting to run it.
 
 ## Permission prompts (Claude Code)
 

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -232,4 +232,11 @@ If argument starts with "key import" followed by a team name:
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
-`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.
+If argument starts with "key rotate" followed by a team name:
+1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
+2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
+3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
+5. Messages before the acknowledged rotation boundary remain readable with the old key.
+
+Device pairing (`key request` / `key approve`) is not implemented — they are not `key.sh` subcommands, so a call prints usage and exits 1. If the user asks for one, tell them so instead of attempting to run it.

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -235,7 +235,7 @@ If argument starts with "key import" followed by a team name:
 If argument starts with "key rotate" followed by a team name:
 1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
 2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
-3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/key.sh rotate <team>`
 4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
 5. Messages before the acknowledged rotation boundary remain readable with the old key.
 

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -340,7 +340,7 @@ If argument starts with "key import" followed by a team name:
 If argument starts with "key rotate" followed by a team name:
 1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
 2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
-3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/key.sh rotate <team>`
 4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
 5. Messages before the acknowledged rotation boundary remain readable with the old key.
 

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -337,4 +337,11 @@ If argument starts with "key import" followed by a team name:
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
-`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.
+If argument starts with "key rotate" followed by a team name:
+1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
+2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
+3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
+5. Messages before the acknowledged rotation boundary remain readable with the old key.
+
+Device pairing (`key request` / `key approve`) is not implemented — they are not `key.sh` subcommands, so a call prints usage and exits 1. If the user asks for one, tell them so instead of attempting to run it.

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -266,4 +266,11 @@ If argument starts with "key import" followed by a team name:
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
-`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.
+If argument starts with "key rotate" followed by a team name:
+1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
+2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
+3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
+5. Messages before the acknowledged rotation boundary remain readable with the old key.
+
+Device pairing (`key request` / `key approve`) is not implemented — they are not `key.sh` subcommands, so a call prints usage and exits 1. If the user asks for one, tell them so instead of attempting to run it.

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -269,7 +269,7 @@ If argument starts with "key import" followed by a team name:
 If argument starts with "key rotate" followed by a team name:
 1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
 2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
-3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/key.sh rotate <team>`
 4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
 5. Messages before the acknowledged rotation boundary remain readable with the old key.
 

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -232,4 +232,11 @@ If argument starts with "key import" followed by a team name:
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
-`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.
+If argument starts with "key rotate" followed by a team name:
+1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
+2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
+3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
+5. Messages before the acknowledged rotation boundary remain readable with the old key.
+
+Device pairing (`key request` / `key approve`) is not implemented — they are not `key.sh` subcommands, so a call prints usage and exits 1. If the user asks for one, tell them so instead of attempting to run it.

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -235,7 +235,7 @@ If argument starts with "key import" followed by a team name:
 If argument starts with "key rotate" followed by a team name:
 1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
 2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
-3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/key.sh rotate <team>`
 4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
 5. Messages before the acknowledged rotation boundary remain readable with the old key.
 

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -238,7 +238,7 @@ If argument starts with "key import" followed by a team name:
 If argument starts with "key rotate" followed by a team name:
 1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
 2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
-3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/key.sh rotate <team>`
 4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
 5. Messages before the acknowledged rotation boundary remain readable with the old key.
 

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -235,4 +235,11 @@ If argument starts with "key import" followed by a team name:
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
-`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.
+If argument starts with "key rotate" followed by a team name:
+1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
+2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
+3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
+5. Messages before the acknowledged rotation boundary remain readable with the old key.
+
+Device pairing (`key request` / `key approve`) is not implemented — they are not `key.sh` subcommands, so a call prints usage and exits 1. If the user asks for one, tell them so instead of attempting to run it.

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -232,4 +232,11 @@ If argument starts with "key import" followed by a team name:
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
-`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.
+If argument starts with "key rotate" followed by a team name:
+1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
+2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
+3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
+5. Messages before the acknowledged rotation boundary remain readable with the old key.
+
+Device pairing (`key request` / `key approve`) is not implemented — they are not `key.sh` subcommands, so a call prints usage and exits 1. If the user asks for one, tell them so instead of attempting to run it.

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -235,7 +235,7 @@ If argument starts with "key import" followed by a team name:
 If argument starts with "key rotate" followed by a team name:
 1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
 2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
-3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/key.sh rotate <team>`
 4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
 5. Messages before the acknowledged rotation boundary remain readable with the old key.
 

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -263,4 +263,11 @@ If argument starts with "key import" followed by a team name:
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
-`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.
+If argument starts with "key rotate" followed by a team name:
+1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
+2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
+3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
+5. Messages before the acknowledged rotation boundary remain readable with the old key.
+
+Device pairing (`key request` / `key approve`) is not implemented — they are not `key.sh` subcommands, so a call prints usage and exits 1. If the user asks for one, tell them so instead of attempting to run it.

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -266,7 +266,7 @@ If argument starts with "key import" followed by a team name:
 If argument starts with "key rotate" followed by a team name:
 1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
 2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
-3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/key.sh rotate <team>`
 4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
 5. Messages before the acknowledged rotation boundary remain readable with the old key.
 

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -223,7 +223,7 @@ If argument starts with "key import" followed by a team name:
 If argument starts with "key rotate" followed by a team name:
 1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
 2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
-3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/key.sh rotate <team>`
 4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
 5. Messages before the acknowledged rotation boundary remain readable with the old key.
 

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -220,4 +220,11 @@ If argument starts with "key import" followed by a team name:
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
-`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.
+If argument starts with "key rotate" followed by a team name:
+1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
+2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
+3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
+5. Messages before the acknowledged rotation boundary remain readable with the old key.
+
+Device pairing (`key request` / `key approve`) is not implemented — they are not `key.sh` subcommands, so a call prints usage and exits 1. If the user asks for one, tell them so instead of attempting to run it.

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -260,4 +260,11 @@ If argument starts with "key import" followed by a team name:
 2. Ask them to paste back only the command's output (never the identity itself) once it's done.
 3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
 
-`key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.
+If argument starts with "key rotate" followed by a team name:
+1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
+2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
+3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
+5. Messages before the acknowledged rotation boundary remain readable with the old key.
+
+Device pairing (`key request` / `key approve`) is not implemented — they are not `key.sh` subcommands, so a call prints usage and exits 1. If the user asks for one, tell them so instead of attempting to run it.

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -263,7 +263,7 @@ If argument starts with "key import" followed by a team name:
 If argument starts with "key rotate" followed by a team name:
 1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
 2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
-3. Run: `bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>`
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/key.sh rotate <team>`
 4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
 5. Messages before the acknowledged rotation boundary remain readable with the old key.
 

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -295,8 +295,10 @@ cmd_generate() {
   existing="$(_key_read_config_field "$cfg" '$.remote_key.current.key_id')"
   if [ -n "$existing" ] && [ "$existing" != "null" ]; then
     agmsg_lock_release
-    echo "agmsg: team '$team' already has a key (key_id=$existing); rotation is not available in this release. To view it:" >&2
+    echo "agmsg: team '$team' already has a key (key_id=$existing). To view it:" >&2
     echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/key.sh") show $(agmsg_shq "$team")" >&2
+    echo "To mint a replacement epoch instead:" >&2
+    echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/key.sh") rotate $(agmsg_shq "$team")" >&2
     exit 1
   fi
 

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -115,6 +115,42 @@ write_node_launcher_fixtures() {
   grep -q "ローカルのメッセージ履歴が読めることは" "$BATS_TEST_DIRNAME/../docs/remote-setup.ja.md"
 }
 
+@test "every agent-readable surface routes key rotate, and none of them calls it unavailable" {
+  # The claim being guarded is not a wording preference: `key rotate` shipped
+  # on 2026-07-22 and seven days later ten surfaces began telling every agent
+  # it was "not available yet (they refuse unconditionally and change no
+  # state)". An agent reads one of these at startup, so the lie was answered
+  # to users far more often than any doc under docs/ is read.
+  #
+  # The negative half alone would pass on a file that says nothing at all, so
+  # both halves are asserted, and the count is explicit for the same reason as
+  # the #682 test above.
+  local surface count=0
+  for surface in "$BATS_TEST_DIRNAME"/../scripts/drivers/types/*/template.md \
+                 "$BATS_TEST_DIRNAME"/../SKILL.md; do
+    [ -f "$surface" ] || continue
+    count=$((count + 1))
+    grep -Fq 'key.sh rotate <team>' "$surface" \
+      || { echo "does not route key rotate: $surface" >&2; return 1; }
+    grep -Fq 'Device pairing (`key request` / `key approve`) is not implemented' "$surface" \
+      || { echo "does not state the pairing commands are absent: $surface" >&2; return 1; }
+    ! grep -qiE 'rotat(e|ion)[^.]*not available' "$surface" \
+      || { echo "still calls rotation unavailable: $surface" >&2; return 1; }
+  done
+  # nine templates (agmsg-app has none) plus SKILL.md.
+  [ "$count" -eq 10 ]
+
+  # Bind the claim to the code. If `rotate` ever stops being a subcommand the
+  # surfaces above become wrong again, and this is the line that says so.
+  grep -qE '^[[:space:]]*rotate\)' "$BATS_TEST_DIRNAME/../scripts/key.sh"
+  grep -qE '^cmd_rotate\(\)' "$BATS_TEST_DIRNAME/../scripts/key.sh"
+
+  # The same false sentence also stood in key.sh itself, where `generate`
+  # refuses an existing key: it named rotation unavailable and sent the user
+  # to `show`. Assert the working route is offered there too.
+  grep -Fq 'To mint a replacement epoch instead:' "$BATS_TEST_DIRNAME/../scripts/key.sh"
+}
+
 @test "type-registry: spawnable set is exactly eight of the ten built-ins (#277, #279)" {
   # hermes deliberately stays out (#279): no known CLI mode starts it
   # interactive with a seeded initial prompt. agmsg-app also stays out: it's

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -125,13 +125,32 @@ write_node_launcher_fixtures() {
   # The negative half alone would pass on a file that says nothing at all, so
   # both halves are asserted, and the count is explicit for the same reason as
   # the #682 test above.
+  # A template is an installer INPUT: install.sh renders it with
+  # `sed s/__SKILL_NAME__/$CMD_NAME/g`, so a route written with a literal
+  # `agmsg` sends an agent installed as `--cmd m` at somebody else's install
+  # — and rotation changes key state, so that is not a cosmetic slip. The
+  # path is therefore asserted per surface kind, not as one shared substring:
+  # matching only `key.sh rotate <team>` is green for both spellings and
+  # would have let this through.
   local surface count=0
   for surface in "$BATS_TEST_DIRNAME"/../scripts/drivers/types/*/template.md \
                  "$BATS_TEST_DIRNAME"/../SKILL.md; do
     [ -f "$surface" ] || continue
     count=$((count + 1))
-    grep -Fq 'key.sh rotate <team>' "$surface" \
-      || { echo "does not route key rotate: $surface" >&2; return 1; }
+    case "$surface" in
+      */SKILL.md)
+        # The top-level skill doc is a rendered artifact, not an input: it
+        # carries no placeholder at all, so here the literal is correct.
+        grep -Fq 'bash ~/.agents/skills/agmsg/scripts/key.sh rotate <team>' "$surface" \
+          || { echo "SKILL.md does not route rotate through the literal install path: $surface" >&2; return 1; }
+        ;;
+      *)
+        grep -Fq 'bash ~/.agents/skills/__SKILL_NAME__/scripts/key.sh rotate <team>' "$surface" \
+          || { echo "template does not route rotate through __SKILL_NAME__: $surface" >&2; return 1; }
+        ! grep -Fq '~/.agents/skills/agmsg/' "$surface" \
+          || { echo "template hardcodes the default install name: $surface" >&2; return 1; }
+        ;;
+    esac
     grep -Fq 'Device pairing (`key request` / `key approve`) is not implemented' "$surface" \
       || { echo "does not state the pairing commands are absent: $surface" >&2; return 1; }
     ! grep -qiE 'rotat(e|ion)[^.]*not available' "$surface" \


### PR DESCRIPTION
**Affects existing users — needs an explicit go.** This changes `SKILL.md` and the nine `scripts/drivers/types/*/template.md` that a reinstall renders onto a user's machine, plus one message printed by `scripts/key.sh generate`. No code path changes.

It is both kinds of change, and the second is the one worth a decision:

- *Something broken is repaired*: agents stop answering that an implemented command does not exist.
- *Behaviour changes*: agents will now route `key rotate`, a state-changing operation on team key material that they previously declined outright. The new block asks the agent to confirm with the user first, and keeps the reveal step human-in-own-terminal, but the net effect is that rotation becomes reachable through the agent surface where it was not before.

---

## What was wrong

`scripts/key.sh` has had a `rotate` subcommand since d6acda2 (2026-07-22). Seven days later, f239c7b (2026-07-29, #555 — a change whose own purpose was purging an obsolete token flow from agent-readable surfaces) added this sentence:

> `key rotate` and device-pairing `key request`/`key approve` are not available yet (they refuse unconditionally and change no state) — if the user asks for either, tell them so rather than attempting to run them.

It shipped in ten places: `SKILL.md` and all nine `scripts/drivers/types/*/template.md`. Those are what an agent reads when the user invokes the skill, so the effect was that a user asking to rotate a team key was told the feature does not exist.

The sentence bundles two claims and only one of them was true:

| claim | measured |
| --- | --- |
| `key rotate` is not available, refuses unconditionally, changes no state | **false** — `cmd_rotate` (`scripts/key.sh:603`) acquires the team lock, promotes the confirmed epoch, requires an identity journal, mints a replacement epoch and appends `key_rotated` to the roster journal. `tests/test_key.bats` covers four of its paths. |
| `key request` / `key approve` are not available | true — they are not subcommands, so they fall to the default case, print usage and exit 1 (`tests/test_key.bats` asserts this) |

The same false claim also stood inside `scripts/key.sh` itself. When `generate` refuses because the team already has a key, it said *"rotation is not available in this release"* and pointed the user at `show` — so the one place a user meets the question was also the place that misdirected them away from the working command.

## What this changes

- All ten surfaces now route `key rotate <team>`, describing what it requires (a current key, an identity journal, `age`), that it needs user confirmation because it changes team key state, and that revealing the new secret is a human-in-own-terminal step. The true half about `key request` / `key approve` is kept and stated separately.
- `key.sh generate` still shows `key show`, and now also offers `key rotate` as the way to mint a replacement epoch.
- No behaviour change to `key.sh` beyond that guidance line.

### The two surface kinds are not spelled the same way

A `scripts/drivers/types/*/template.md` is an installer **input**: `install.sh` renders it with `sed "s/__SKILL_NAME__/$CMD_NAME/g"` (eight call sites), so every path inside a template is written `~/.agents/skills/__SKILL_NAME__/...`. `SKILL.md` is a rendered artifact and carries no placeholder at all — `grep -c __SKILL_NAME__` is 76 in the claude-code template and 0 in `SKILL.md`.

The first version of this change wrote the literal default name in all ten. On an install made with `--cmd m`, that route would have sent the agent at a *different* install's `key.sh` — and rotation changes key state, so it would have rotated the wrong team's key rather than merely failing. The four routes already beside it in the same files (`generate`, `show`, `handoff`, `import`) all used the placeholder; only the added line did not.

Templates now use the placeholder and `SKILL.md` keeps the literal.

## The guard

`tests/test_type_registry.bats` gets one test, next to the existing `#682` cross-template test it borrows its shape from. Four things made this defect class survive, and the test is built against all four:

1. **Ten independent copies.** The templates share no fragment, so fixing one and leaving nine is the natural failure. The test iterates every surface and asserts `count -eq 10` explicitly, rather than trusting a glob that would silently pass on a renamed or missing file.
2. **A negative-only check would pass on silence.** Deleting the sentence is not the same as saying rotation works, so both halves are asserted: the surface must route `key rotate <team>` *and* must not call rotation unavailable.
3. **One substring across two surface kinds does not discriminate.** The first version of this guard matched `key.sh rotate <team>` everywhere, which is green for the placeholder spelling and green for the literal one — it would have passed the defect above. The test now branches on surface kind: templates must carry the exact `__SKILL_NAME__` route and must contain no literal `~/.agents/skills/agmsg/` path at all; `SKILL.md` must carry the exact rendered literal.
4. **The docs were never bound to the code.** The test also asserts the `rotate)` dispatch case and `cmd_rotate` exist in `scripts/key.sh`, so if rotation is ever removed the failure names the documents that just became wrong instead of leaving them to drift again.

## Verification

Mutation matrix — each row reverts or plants one thing and the test must go red. Control is the unmutated tree.

| # | mutation | result |
| --- | --- | --- |
| 1 | revert one of the nine templates (`hermes`) to base | RED, naming that file |
| 2 | revert `SKILL.md` to base | RED, naming that file |
| 3 | revert `scripts/key.sh` to base | RED on the generate-guidance assertion |
| 4 | delete the `rotate)` dispatch case | RED on the binding assertion |
| 5 | plant the old sentence into a file that already has the new text | RED on the negative assertion |
| 6 | rewrite one template's route (`gemini`) to the literal `agmsg` path | RED on the placeholder assertion |
| 7 | plant `__SKILL_NAME__` into `SKILL.md`'s route (the reverse direction) | RED on the literal assertion |
| — | control: unmutated | green |

Rows 6 and 7 are the pair that the earlier shared-substring guard could not tell apart; they fire on separate assertions, in opposite directions.

Row 1 was not hypothetical. While restoring after a mutation, `git checkout --` reverted the codex template's fix along with the planted line, and the working tree went to eleven fixed files instead of twelve; the count assertion is what surfaced it.

Post-fix measurements on this head: templates carrying the exact placeholder route = 9; templates containing any literal `~/.agents/skills/agmsg/` = 0; `SKILL.md` carrying the exact literal route = 1; `__SKILL_NAME__` occurrences in `SKILL.md` = 0.

Suites run locally on this head, macOS:

- `tests/test_type_registry.bats tests/test_claude_template.bats tests/test_printed_command_paths.bats` in **one** `bats` invocation — 31 ok, 0 not ok.
- `tests/test_install.bats` — 53 tests, 0 not ok. This is the suite that actually renders a template through `install.sh`.
- `tests/test_key.bats` — 34 ok (run against the first commit of this branch; `scripts/key.sh` is unchanged since).

Neither form is CI's: CI runs `xargs bats --print-output-on-failure < shard-files.txt` over a shard, on ubuntu and macOS runners.

The first commit of this branch (6a098fa) had one CI failure, `bats (ubuntu-latest 4/4)`: `watch: a pair claimed by another session is released, not consumed (#683)`, which #828 names verbatim as a sleep-based flake. Re-running that job on the identical SHA came back 22/22 green. Unrelated to this change; the current head's run is its own gate.

## Scope

Only the false claim and its guard. `key rotate` has no reference documentation of its own beyond the new block, and device pairing remains unimplemented; neither is addressed here.
