### PR TITLE
fix(install): record provenance when git answers in another path space (#830)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ AGENTS_DIR="$HOME/.agents"
 # uncommitted changes. Non-git (tarball via setup.sh/npx, no .git): fall back to
 # the canonical VERSION file. See #117.
 agmsg_source_version() {
-  local v top
+  local v top native
   # Only describe when SCRIPT_DIR is ITS OWN git checkout. `git describe`
   # searches ancestors for a .git, so a non-git copy unpacked under some other
   # git repo would otherwise record that PARENT repo's describe instead of

--- a/install.sh
+++ b/install.sh
@@ -61,8 +61,17 @@ agmsg_source_version() {
   # `agmsg_cmdline_names_path` takes in compat.sh, where the identical mismatch
   # made four watcher-ownership checks answer "not ours" on Windows.
   #
-  # Off Windows there is no cygpath, `native` stays empty, and this is the plain
-  # comparison and nothing else.
+  # The condition below is a CAPABILITY, not an operating system: where cygpath
+  # is not on PATH, `native` stays empty and this is the plain comparison and
+  # nothing else. Saying "off Windows" instead would be wider than the code —
+  # this file's own test drives the second branch on macOS and Linux by putting
+  # a cygpath stub on PATH.
+  #
+  # Where cygpath is absent, fails, returns nothing, or returns a path unequal
+  # to git's toplevel, the recorded value is the fallback, exactly as before.
+  # A wrong answer that happened to equal the toplevel would still take the
+  # describe branch, so this is a set of conditions and not a guarantee that
+  # the worst case is the old behaviour.
   native=""
   if command -v cygpath >/dev/null 2>&1; then
     native="$(cygpath -m "$SCRIPT_DIR" 2>/dev/null || true)"

--- a/install.sh
+++ b/install.sh
@@ -49,7 +49,25 @@ agmsg_source_version() {
   # app's own version comparison (agmsg_core_version_status in agmsg.rs)
   # can't parse as semver, which it then treats as "outdated" unconditionally.
   top="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
-  if [ -n "$top" ] && [ "$top" = "$SCRIPT_DIR" ] \
+  # THE TWO SIDES ARE IN DIFFERENT PATH SPACES ON WINDOWS, so the equality was
+  # always false there and every Git Bash install recorded the VERSION file
+  # instead of the describe string (#830):
+  #
+  #   $SCRIPT_DIR            /tmp/tmp.XXXX/agmsg        MSYS form, from bash
+  #   git --show-toplevel    C:/Users/.../tmp.XXXX/agmsg  native form, from git
+  #
+  # `cygpath -m` is the mixed form git reports — the same second chance this
+  # file already takes for the writable paths below, and the same one
+  # `agmsg_cmdline_names_path` takes in compat.sh, where the identical mismatch
+  # made four watcher-ownership checks answer "not ours" on Windows.
+  #
+  # Off Windows there is no cygpath, `native` stays empty, and this is the plain
+  # comparison and nothing else.
+  native=""
+  if command -v cygpath >/dev/null 2>&1; then
+    native="$(cygpath -m "$SCRIPT_DIR" 2>/dev/null || true)"
+  fi
+  if [ -n "$top" ] && { [ "$top" = "$SCRIPT_DIR" ] || { [ -n "$native" ] && [ "$top" = "$native" ]; }; } \
       && v="$(git -C "$SCRIPT_DIR" describe --tags --always --dirty --abbrev=7 --match 'v[0-9]*' 2>/dev/null)" \
       && [ -n "$v" ]; then
     printf '%s' "$v"

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -904,10 +904,19 @@ SHIM
   # two forms are reconciled. Stubbing only the disagreement made the first
   # version of this test unable to exercise the fix at all: it fell back, and
   # the fix looked broken when it was the model that was incomplete.
+  # THE FLAG IS THE CLAIM, so this stub refuses to answer anything else. Real
+  # cygpath picks the output path space from the option: `-m` is the mixed form
+  # git reports, while the default and `-u` are the Unix form the comparison
+  # already holds — calling either of those would leave #830 exactly where it
+  # was. An earlier version printed `C:<last arg>` whatever it was handed, so
+  # dropping the flag or passing `-u` in production kept this test green
+  # (raised in review). Refusing is what makes the flag observable.
   cat >"$shim_dir/cygpath" <<'CYG'
 #!/usr/bin/env bash
-# -m is the mixed form; the only flag the code under test passes.
-printf 'C:%s\n' "${@: -1}"
+[ "$#" -eq 2 ] || { echo "cygpath stub: want 2 args, got $#: $*" >&2; exit 64; }
+[ "$1" = "-m" ] || { echo "cygpath stub: want -m, got '$1'" >&2; exit 64; }
+[ -f "$2/install.sh" ] || { echo "cygpath stub: not the source dir: '$2'" >&2; exit 64; }
+printf 'C:%s\n' "$2"
 CYG
   chmod +x "$shim_dir/cygpath"
 

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -868,3 +868,71 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *alice* ]]
 }
+
+# --- provenance across path spaces (#830) --------------------------------
+#     The test above passes on any POSIX host because `$SCRIPT_DIR` and
+#     `git rev-parse --show-toplevel` agree there. On Windows they do not:
+#     bash hands out `/tmp/tmp.XXXX/agmsg` and git answers
+#     `C:/Users/.../tmp.XXXX/agmsg`, so the equality guarding the describe
+#     branch was always false and every Git Bash install silently recorded the
+#     fallback instead. This reproduces that mismatch on this host.
+
+@test "install: records provenance even when git reports the toplevel in another path space (#830)" {
+  # A git that answers `rev-parse --show-toplevel` in native Windows form and
+  # passes everything else — including `describe` — through to the real one.
+  # Rewriting only that one answer is what makes this a model of the platform
+  # rather than a broken git.
+  local shim_dir="$FAKE_HOME/shim-git"
+  mkdir -p "$shim_dir"
+  cat >"$shim_dir/git" <<'SHIM'
+#!/usr/bin/env bash
+real="$(PATH="${PATH#*:}" command -v git)"
+for a in "$@"; do
+  if [ "$a" = "--show-toplevel" ]; then
+    top="$("$real" "$@")" || exit $?
+    # `/tmp/x` -> `C:/tmp/x`: a different space, same directory.
+    printf 'C:%s\n' "$top"
+    exit 0
+  fi
+done
+exec "$real" "$@"
+SHIM
+  chmod +x "$shim_dir/git"
+
+  # BOTH HALVES OF THE PLATFORM, or the model is one-sided. Windows does not
+  # merely disagree about the path — it also ships `cygpath`, which is how the
+  # two forms are reconciled. Stubbing only the disagreement made the first
+  # version of this test unable to exercise the fix at all: it fell back, and
+  # the fix looked broken when it was the model that was incomplete.
+  cat >"$shim_dir/cygpath" <<'CYG'
+#!/usr/bin/env bash
+# -m is the mixed form; the only flag the code under test passes.
+printf 'C:%s\n' "${@: -1}"
+CYG
+  chmod +x "$shim_dir/cygpath"
+
+  # The premise, checked rather than assumed: the shim really does answer in
+  # the other form, so a green result below cannot come from the shim being
+  # bypassed.
+  run env PATH="$shim_dir:$PATH" git -C "$REPO_ROOT" rev-parse --show-toplevel
+  [ "$status" -eq 0 ]
+  [[ "$output" == C:* ]]
+
+  # What the describe branch WOULD record, taken from the real git.
+  local expected
+  expected="$(git -C "$REPO_ROOT" describe --tags --always --dirty --abbrev=7 --match 'v[0-9]*')"
+  [ -n "$expected" ]
+  # And what the fallback would record, so the assertion below is known to
+  # tell them apart. Without this the test passes on the fallback: the VERSION
+  # file holds a plausible version string too, which is how the first version
+  # of this test stayed green with the fix reverted.
+  local fallback=""
+  [ -f "$REPO_ROOT/VERSION" ] && fallback="$(tr -d '[:space:]' < "$REPO_ROOT/VERSION")"
+  [ "$expected" != "$fallback" ]
+
+  run env PATH="$shim_dir:$PATH" env HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  [ "$status" -eq 0 ]
+  [ -f "$SK/VERSION" ]
+  run cat "$SK/VERSION"
+  [ "$output" = "$expected" ]
+}

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -923,9 +923,15 @@ CYG
   # The premise, checked rather than assumed: the shim really does answer in
   # the other form, so a green result below cannot come from the shim being
   # bypassed.
+  #
+  # `[ "${output#C:}" != "$output" ]` rather than a `[[ ]]` prefix match: a
+  # non-last `[[ ]]` cannot fail the test on macOS bash 3.2 (#670), and this
+  # line exists to keep an unnoticed pass from happening. It would have been a
+  # blind check guarding against blind checks — which is the whole subject of
+  # this test.
   run env PATH="$shim_dir:$PATH" git -C "$REPO_ROOT" rev-parse --show-toplevel
   [ "$status" -eq 0 ]
-  [[ "$output" == C:* ]]
+  [ "${output#C:}" != "$output" ]
 
   # What the describe branch WOULD record, taken from the real git.
   local expected


### PR DESCRIPTION
Refs #830.

## What was wrong

On Windows the `git describe` branch of `install.sh` was never taken, so every
Git Bash install recorded the `VERSION` file instead. The guard compared two
paths written in different alphabets:

```
$SCRIPT_DIR           /tmp/tmp.XXXX/agmsg            MSYS form, from bash
git --show-toplevel   C:/Users/.../tmp.XXXX/agmsg    native form, from git
```

The equality was always false there, and a false equality is the ordinary
answer — nothing reported anything.

## The sixth site of the same family

`agmsg_cmdline_names_path` in `scripts/lib/compat.sh` already records five
places that compared a shell path against a native one. Four of them decide
whether to kill a stale watcher, so on Windows they answered "not ours" and
left it running. This is the sixth. The fix is the same second chance:
`cygpath -m`, the mixed form git reports — an idiom this file already uses for
its writable paths.

The condition is a CAPABILITY, not an operating system: where `cygpath` is not
on PATH, `native` stays empty and this is the plain comparison and nothing
else. The exact boundary is stated under **Existing-user impact** below.

## Every finding on this PR was the test apparatus, not the code

The production comparison has not been challenged once. Four separate ways the
control failed to control, in order:

**1. It was inert.** It asserted the recorded value merely looked like a
version — but the fallback writes `1.2.0-rc.6`, which passes that. Reverting
the fix left it green. It now compares against the actual `git describe`
output, and asserts up front that the describe string and the fallback string
DIFFER, so the assertion is known to be able to tell the two outcomes apart.

**2. It modelled one half of the platform.** A `git` stub answering
`--show-toplevel` in native form reproduces the disagreement — but Windows also
ships `cygpath`, which is how the two forms are reconciled, and this host has
none. The fix could not fire, and looked broken when what was incomplete was
the model.

**3. The flag was unasserted** (raised in review). The `cygpath` stub returned
`C:<last arg>` whatever it was handed, while its own comment claimed `-m` was
the only flag passed — written, not asserted. Real cygpath picks the output
path space from the option: `-m` is the mixed form git reports, the default and
`-u` are the Unix form the comparison already holds. So production could drop
the flag or pass `-u`, reintroducing #830 exactly, and this test stayed green.
The stub is now fail-closed on all three of arg count, `-m`, and the source-dir
operand.

**4. Its own premise check could not fail** (caught by CI's `enforceable
assertions`, red here and green on main). The line asserting the git shim
really does answer in the native form — the one stopping a green result from
coming out of a bypassed shim — was a non-last `[[ ]]`, which cannot fail on
macOS bash 3.2 (#670). A blind check guarding against blind checks. Now
`[ "${output#C:}" != "$output" ]`.

## Measured

`bats tests/test_install.bats` — 54/54 on this head.

Mutation matrix, every row run:

| mutation | result |
| --- | --- |
| baseline (unmutated) | GREEN |
| comparison → single-space form | RED |
| `cygpath -m` → `cygpath` (no flag) | RED |
| `cygpath -m` → `cygpath -u` | RED |
| git shim stops prefixing `C:` | RED, at the premise line |

Rows 3 and 4 go red by the stub exiting non-zero, `native` staying empty, the
comparison failing, and the recorded value falling back to `VERSION`.

Row 5 is the premise check being mutated rather than the code: with the shim no
longer disagreeing, the final assertion alone still passes, so nothing but the
premise line could catch it — and it does, at line 934.

`check-enforced-assertions`: 638, at the baseline. This branch adds no
exemption.

## Existing-user impact: YES — this needs the explicit go

Updating or reinstalling from a Git checkout on Windows changes the recorded
provenance from the `VERSION` fallback to the `git describe` string. That value
is not display-only: `agmsg_core_version_status`
(`app/src-tauri/src/agmsg.rs:711-717`) reads the installed `VERSION` and parses
it as semver to decide whether the core is outdated.

What the code actually guarantees — stated as conditions, not as an absolute:

- **Where `cygpath` is not on PATH, nothing changes.** Production tests the
  capability, not the operating system: it is `command -v cygpath`. So the
  boundary is the tool being present, not "off Windows". This PR's own test is
  the proof — it runs on macOS and Linux and drives the new branch by putting a
  `cygpath` stub on PATH.
- **Where `cygpath` is absent, fails, returns empty output, or returns a path
  unequal to git's toplevel, the existing fallback is what gets recorded.**
  Those four are the conditions the code guarantees. A wrong answer that
  happened to equal git's toplevel WOULD enter the describe branch, so this is
  not an absolute "the worst case is today's behaviour".
- **On supported Windows Git Bash, a matching mixed-form path adds the
  previously missing route to `git describe`.**

And the value it moves to is the shape every macOS and Linux source install
already records, so it reaches `parse_semver` by a path those platforms have
been on all along.

## What is NOT verified here

Nobody has run this on Windows. The evidence is a stubbed model of the two path
spaces, not the platform. The field confirmation this waits on is the same one
#652 / #784 are held open for.

## Base

Opened against `main` per the switch away from `integration/remote`.
