### PR TITLE
fix(remote): dump headers to a file where a real fifo cannot exist (#850)

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -312,8 +312,13 @@ _remote_http_post_json() {
   # hidden, because it is a real difference between the platforms and not a
   # detail of how the file is named.
   #
-  # Gated on `command -v cygpath`, not on an OS name: what decides is whether a
-  # real fifo can be made, and that is what the probe asks.
+  # Gated on `command -v cygpath`, not on an OS name. Say what that probe
+  # actually asks, because it is narrower than the thing we care about: it is a
+  # CAPABILITY MARKER for an environment where MSYS fifos and a native curl
+  # coexist -- it does not test whether a real fifo can be made, and nothing
+  # here does. An earlier version of this comment claimed it did, which would
+  # have told the next reader that a machine passing the probe had been checked
+  # for the property that matters.
   if command -v cygpath >/dev/null 2>&1; then
     header_fifo="$header_file"
     : > "$header_fifo"

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -295,17 +295,42 @@ _remote_http_post_json() {
   cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
   fifo_dir="$(mktemp -d "${TMPDIR:-/tmp}/agmsg-header-pipe.XXXXXX")"
   header_fifo="$fifo_dir/header"
-  mkfifo "$header_fifo"
   chmod 600 "$cfg"
-  trap 'rm -f "$cfg" "$header_fifo"; rmdir "$fifo_dir" 2>/dev/null || true' EXIT INT TERM
-  # Reaped on both normal paths below (waited on success, killed and waited on
-  # failure), so this is short-lived by construction -- but the EXIT trap only
-  # removes files, it does not kill the copier. A signal arriving before curl
-  # opens the fifo therefore leaves it blocked on open() with no writer ever
-  # coming, and an inherited fd 3 would then hold a bats test file open to the
-  # timeout. Closing the fds costs nothing and removes that one path.
-  python3 "$SCRIPT_DIR/internal/bounded-copy.py" 65536 < "$header_fifo" > "$header_file" 3>&- 4>&- &
-  copier_pid=$!
+  # The headers go through a fifo so a hostile or broken server cannot make us
+  # buffer an unbounded response — bounded-copy.py enforces the ceiling while
+  # the transfer is still running. That mechanism needs a real named pipe.
+  #
+  # On Windows/Git Bash there is no real named pipe to have: MSYS emulates
+  # mkfifo with a .lnk file that only MSYS-aware programs understand, and curl
+  # there is a NATIVE binary. It cannot open what mkfifo made, so it fails and
+  # the caller sees the "000" it reports for every failure alike.
+  #
+  # Where cygpath exists, dump straight to the destination file and skip both
+  # the fifo and the copier. That gives up streaming enforcement of the size
+  # ceiling on that platform — curl's own `max-filesize` still applies to the
+  # BODY, and the header dump is what becomes unbounded. Stated rather than
+  # hidden, because it is a real difference between the platforms and not a
+  # detail of how the file is named.
+  #
+  # Gated on `command -v cygpath`, not on an OS name: what decides is whether a
+  # real fifo can be made, and that is what the probe asks.
+  if command -v cygpath >/dev/null 2>&1; then
+    header_fifo="$header_file"
+    : > "$header_fifo"
+    copier_pid=""
+    trap 'rm -f "$cfg"; rmdir "$fifo_dir" 2>/dev/null || true' EXIT INT TERM
+  else
+    mkfifo "$header_fifo"
+    trap 'rm -f "$cfg" "$header_fifo"; rmdir "$fifo_dir" 2>/dev/null || true' EXIT INT TERM
+    # Reaped on both normal paths below (waited on success, killed and waited on
+    # failure), so this is short-lived by construction -- but the EXIT trap only
+    # removes files, it does not kill the copier. A signal arriving before curl
+    # opens the fifo therefore leaves it blocked on open() with no writer ever
+    # coming, and an inherited fd 3 would then hold a bats test file open to the
+    # timeout. Closing the fds costs nothing and removes that one path.
+    python3 "$SCRIPT_DIR/internal/bounded-copy.py" 65536 < "$header_fifo" > "$header_file" 3>&- 4>&- &
+    copier_pid=$!
+  fi
   {
     printf 'url = "%s"\n' "$url"
     printf 'request = "POST"\n'
@@ -323,15 +348,20 @@ _remote_http_post_json() {
     curl_status=$?
   fi
   if [ "$curl_status" -ne 0 ]; then
-    kill "$copier_pid" 2>/dev/null || true
-    wait "$copier_pid" 2>/dev/null || true
+    [ -n "$copier_pid" ] && { kill "$copier_pid" 2>/dev/null || true; wait "$copier_pid" 2>/dev/null || true; }
     http_code="000"
-  elif wait "$copier_pid"; then
+  elif [ -z "$copier_pid" ] || wait "$copier_pid"; then
     http_code="$curl_output"
   else
     http_code="000"
   fi
-  rm -f "$cfg" "$header_fifo"
+  # Only remove the fifo, never the caller's header file. On the cygpath path
+  # `header_fifo` IS `header_file`, so an unconditional `rm -f "$header_fifo"`
+  # here deletes the headers this function was asked to produce — before the
+  # caller has read them. The fifo exists only when a copier was started, so
+  # that is the condition to key on.
+  rm -f "$cfg"
+  [ -n "$copier_pid" ] && rm -f "$header_fifo"
   rmdir "$fifo_dir" 2>/dev/null || true
   trap - EXIT INT TERM
   printf '%s' "$http_code"

--- a/tests/test_remote_header_sink.bats
+++ b/tests/test_remote_header_sink.bats
@@ -1,0 +1,238 @@
+#!/usr/bin/env bats
+# WHERE A REAL NAMED PIPE CANNOT EXIST, DO NOT BUILD ONE (#850).
+#
+# `_remote_http_post_json` streams curl's headers through a fifo so
+# `bounded-copy.py` can enforce a size ceiling while the transfer is still
+# running. That needs a real named pipe. On Windows/Git Bash there is none to
+# have: MSYS emulates `mkfifo` with a `.lnk` file that only MSYS-aware programs
+# understand, and curl there is a NATIVE binary. It cannot open what mkfifo
+# made, so it fails and the caller reports the same `000` it reports for
+# everything.
+#
+# The fix takes a different sink on that platform: dump straight to the
+# caller's header file, no fifo and no copier. Two things then have to hold,
+# and they are the two this file drives:
+#
+#   the fifo machinery is NOT built when the marker says it cannot work
+#   the caller's header file SURVIVES -- on that path `header_fifo` IS
+#     `header_file`, so the cleanup that removes the fifo would delete the
+#     headers the function was asked to produce
+#
+# HOW THE ABSENCE OF A CALL IS OBSERVED. `mkfifo` and `python3` are replaced by
+# recording wrappers that then exec the real thing, so a test can assert on
+# what was invoked without changing what happens. An assertion that something
+# did NOT run is only worth its opposite: every case here also names a case
+# where the same wrapper DOES record, so "no line in the log" cannot pass
+# because the log was never wired up.
+#
+# WHAT THIS FILE DOES NOT CLAIM. The sibling defect (#851, embedded config
+# paths) is not on this branch, so paths stay POSIX here and the curl stub is a
+# POSIX consumer. On a real Windows machine this fix alone is not enough --
+# both are needed, and they compose only on the combined branch.
+#
+# Self-contained rather than sharing a harness with the #851 file: these are
+# separate pull requests that must land in either order, and a helper moved
+# into test_helper.bash by one of them is a conflict for the other.
+
+load test_helper
+
+# Externals `remote.sh` needs to source, plus those the helper and the stubs
+# call. Allowlist rather than subtraction: on Git Bash `cygpath` sits in the
+# same directory as `mktemp`, so nothing can be removed by dropping a path.
+SANDBOX_TOOLS=(bash dirname mktemp mkfifo chmod rm rmdir sed cp cat grep python3 uname)
+
+setup() {
+  setup_test_env
+
+  CALL_LOG="$BATS_TEST_TMPDIR/calls.log"
+  export CALL_LOG
+  : > "$CALL_LOG"
+
+  STUB_SRC="$BATS_TEST_TMPDIR/stubs"
+  mkdir -p "$STUB_SRC"
+
+  # curl: writes the headers where the config says, the way the real one does.
+  cat > "$STUB_SRC/curl" <<'STUB'
+#!/usr/bin/env bash
+set -u
+cfg=""; out=""; prev=""
+for arg in "$@"; do
+  case "$prev" in
+    -K) cfg="$arg" ;;
+    -o) out="$arg" ;;
+  esac
+  prev="$arg"
+done
+[ -n "$cfg" ] || { echo "STUB_CURL: no -K config" >&2; exit 2; }
+hdr="$(sed -n 's/^dump-header = "\(.*\)"$/\1/p' "$cfg")"
+if [ -n "$hdr" ]; then
+  printf 'HTTP/1.1 200 OK\r\nX-Marker: from-curl\r\n\r\n' > "$hdr" || {
+    echo "STUB_CURL: cannot write dump-header: $hdr" >&2; exit 23; }
+fi
+[ -z "$out" ] || printf '{"ok":true}' > "$out"
+printf '200'
+STUB
+  chmod +x "$STUB_SRC/curl"
+
+  # cygpath: only ever probed with `command -v` by the code under test, but it
+  # has to be a working binary -- a marker that errors would be a different
+  # experiment from a marker that exists.
+  cat > "$STUB_SRC/cygpath" <<'STUB'
+#!/usr/bin/env bash
+printf '%s' "${2-}"
+STUB
+  chmod +x "$STUB_SRC/cygpath"
+
+  # Recording wrappers. They record and then do the real thing, so the run is
+  # unchanged and only observability is added.
+  cat > "$STUB_SRC/mkfifo" <<'STUB'
+#!/usr/bin/env bash
+printf 'mkfifo %s\n' "$*" >> "$CALL_LOG"
+exec "$REAL_MKFIFO" "$@"
+STUB
+  chmod +x "$STUB_SRC/mkfifo"
+
+  cat > "$STUB_SRC/python3" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *bounded-copy.py*) printf 'bounded-copy %s\n' "$*" >> "$CALL_LOG" ;;
+  *) printf 'python3 %s\n' "$*" >> "$CALL_LOG" ;;
+esac
+exec "$REAL_PYTHON3" "$@"
+STUB
+  chmod +x "$STUB_SRC/python3"
+
+  REAL_MKFIFO="$(command -v mkfifo)"; export REAL_MKFIFO
+  REAL_PYTHON3="$(command -v python3)"; export REAL_PYTHON3
+}
+
+teardown() { teardown_test_env; }
+
+# A PATH holding the allowlist plus the stubs, with cygpath present only when
+# asked. Fails loudly if the host lacks a tool: a short sandbox would make the
+# helper fail for reasons unrelated to the fix.
+sandbox_path() {
+  local want_cygpath="$1" dir tool src
+  dir="$(mktemp -d "$BATS_TEST_TMPDIR/sandbox.XXXXXX")"
+  for tool in "${SANDBOX_TOOLS[@]}"; do
+    src="$(command -v "$tool")" || { echo "host lacks $tool" >&2; return 1; }
+    ln -s "$src" "$dir/$tool"
+  done
+  # The recording wrappers shadow the real tools of the same name.
+  ln -sf "$STUB_SRC/mkfifo" "$dir/mkfifo"
+  ln -sf "$STUB_SRC/python3" "$dir/python3"
+  ln -s "$STUB_SRC/curl" "$dir/curl"
+  [ "$want_cygpath" = "yes" ] && ln -s "$STUB_SRC/cygpath" "$dir/cygpath"
+  printf '%s' "$dir"
+}
+
+post_under() {
+  local bin="$1" body_file="$2" header_out="$3"
+  run env PATH="$bin" CALL_LOG="$CALL_LOG" REAL_MKFIFO="$REAL_MKFIFO" \
+    REAL_PYTHON3="$REAL_PYTHON3" bash -c '
+    set -uo pipefail
+    . '"$SCRIPTS"'/remote.sh 2>/dev/null
+    _remote_http_post_json "https://example.invalid/v1/x" "'"$body_file"'" \
+      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$header_out"'"
+  '
+}
+
+@test "the sandbox decides whether the marker exists — both directions (#850)" {
+  # The control on the instrument, and on the recording wrappers. Everything
+  # below reads a log, and a log that is never written looks exactly like a
+  # call that never happened.
+  local without with
+  without="$(sandbox_path no)"
+  with="$(sandbox_path yes)"
+
+  run env PATH="$without" bash -c 'command -v cygpath >/dev/null 2>&1 && echo PRESENT || echo ABSENT'
+  [ "$output" = "ABSENT" ]
+
+  run env PATH="$with" bash -c 'command -v cygpath >/dev/null 2>&1 && echo PRESENT || echo ABSENT'
+  [ "$output" = "PRESENT" ]
+
+  # And the wrappers really do record, so an empty log later means something.
+  run env PATH="$without" CALL_LOG="$CALL_LOG" REAL_MKFIFO="$REAL_MKFIFO" \
+    bash -c 'mkfifo "$BATS_TEST_TMPDIR/control-fifo"'
+  grep -q '^mkfifo ' "$CALL_LOG"
+}
+
+@test "with the marker present, no fifo is made (#850)" {
+  # Two absences, two tests. They are separate pieces of machinery and can be
+  # left behind separately -- keeping the fifo while dropping the copier gives
+  # a pipe nobody drains, dropping the fifo while keeping the copier gives a
+  # reader blocked on a file that never fills. One test asserting both says
+  # "some of it is still there" and names neither.
+  local bin; bin="$(sandbox_path yes)"
+  body="$BATS_TEST_TMPDIR/body.json"; printf '{"t":"secret"}' > "$body"
+  hdr="$BATS_TEST_TMPDIR/headers.txt"
+
+  post_under "$bin" "$body" "$hdr"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  refute grep -q '^mkfifo ' "$CALL_LOG"
+}
+
+@test "with the marker present, no bounded copier is started (#850)" {
+  local bin; bin="$(sandbox_path yes)"
+  body="$BATS_TEST_TMPDIR/body.json"; printf '{"t":"secret"}' > "$body"
+  hdr="$BATS_TEST_TMPDIR/headers.txt"
+
+  post_under "$bin" "$body" "$hdr"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  refute grep -q '^bounded-copy ' "$CALL_LOG"
+}
+
+@test "with the marker present, the caller's header file survives the call (#850)" {
+  # The trap this fix had to avoid: on that path `header_fifo` IS `header_file`,
+  # so a cleanup that removes the fifo deletes the headers the caller asked for
+  # — after a successful request, which makes it look like the server sent none.
+  local bin; bin="$(sandbox_path yes)"
+  body="$BATS_TEST_TMPDIR/body.json"; printf '{"t":"secret"}' > "$body"
+  hdr="$BATS_TEST_TMPDIR/headers.txt"
+
+  post_under "$bin" "$body" "$hdr"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  [ -f "$hdr" ]
+  grep -q 'X-Marker: from-curl' "$hdr"
+}
+
+@test "without the marker, the fifo and the bounded copier are still used (#850)" {
+  # The platforms that are supposed to be unchanged, asserted rather than
+  # assumed. This is also the positive control for the two absences above.
+  local bin; bin="$(sandbox_path no)"
+  body="$BATS_TEST_TMPDIR/body.json"; printf '{"t":"secret"}' > "$body"
+  hdr="$BATS_TEST_TMPDIR/headers.txt"
+
+  post_under "$bin" "$body" "$hdr"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  grep -q '^mkfifo ' "$CALL_LOG"
+  grep -q '^bounded-copy ' "$CALL_LOG"
+
+  # And the headers still arrive, by the longer route.
+  grep -q 'X-Marker: from-curl' "$hdr"
+}
+
+@test "without the marker, the fifo is cleaned up and the header file is not (#850)" {
+  # Both halves of the cleanup on the POSIX path: the temporary pipe goes, the
+  # caller's file stays. Reading the fifo path out of the call log is what makes
+  # the first half checkable — it is a name the helper chose, not one we passed.
+  local bin; bin="$(sandbox_path no)"
+  body="$BATS_TEST_TMPDIR/body.json"; printf '{"t":"secret"}' > "$body"
+  hdr="$BATS_TEST_TMPDIR/headers.txt"
+
+  post_under "$bin" "$body" "$hdr"
+  [ "$status" -eq 0 ]
+
+  fifo="$(sed -n 's/^mkfifo //p' "$CALL_LOG" | head -1)"
+  [ -n "$fifo" ]
+  refute test -e "$fifo"
+  [ -f "$hdr" ]
+}


### PR DESCRIPTION
Part 2 of 3 splitting the Windows connect fix. All three together are on `win-connect-fix-850`, which is the branch to install for a real walk.

**Classification: affects existing users — a road that could not be walked becomes walkable.**

## What is wrong

The headers go through a fifo so a broken or hostile server cannot make us buffer an unbounded response: `bounded-copy.py` enforces the ceiling while the transfer is still running. That mechanism needs a real named pipe.

On Windows/Git Bash there is no real named pipe to have. MSYS emulates `mkfifo` with a `.lnk` file that only MSYS-aware programs understand, and curl there is a **native** binary — it cannot open what mkfifo made. curl fails, and the caller sees the `000` reported for every failure alike.

## What this gives up, and where

Where cygpath exists, headers are dumped straight to the destination file and both the fifo and the copier are skipped. **That gives up streaming enforcement of the header size ceiling on that platform.** curl's own `max-filesize` still bounds the body; the header dump is what becomes unbounded.

Stated here rather than left implicit, because it is a real difference between the platforms and not a detail of how a file is named.

Gated on `command -v cygpath` rather than an OS name — **and that probe is a marker, not a measurement.** It does not ask whether a real fifo can be made; nothing here does. What it identifies is an environment where MSYS fifos and a native curl coexist. *(This sentence previously claimed the probe asked the fifo question directly. It does not, and the source comment has been corrected to match.)*

## A second defect the branch form makes dangerous

The cleanup ran `rm -f "$cfg" "$header_fifo"` unconditionally — and on the cygpath path `header_fifo` **is** `header_file`, so it deleted the headers this function was asked to produce, before the caller read them. The fifo only exists when a copier was started, so that is what the removal is keyed on now.

Found while splitting the change into reviewable pieces. It is present in the verified Windows commit as well, and it is fixed there too (`win-connect-fix-850`).

## What was verified on Windows 11 / Git Bash

Quoted rather than summarised:

> Verified on Windows 11 / Git Bash: connect <team> now returns a real HTTP response, writes remote_binding, remote status reports connected, and the sync engine round-trips (push.ack seq 1 stored -> pull.applied). Existing-store team migration is NOT yet exercised.

## What was verified on macOS, and what that is worth

`tests/test_remote.bats` — 122 ok / 0 not ok, on this branch alone.

**Green here is not evidence the Windows defect is fixed.** This machine has no cygpath, so the suite takes the fifo path throughout and never enters the branch this PR adds. What green establishes is that the fifo path — the one every non-Windows user is on — still behaves exactly as before, including the copier reaping and the fd-closing the surrounding comment describes.

## Not measured

**A team with an existing store has not been migrated on Windows.** The verified run was a fresh team.


---

## Tests, added at `841048cb8e43` — and what this branch alone does not fix

**This branch does not carry #851.** That PR is the one that renders the paths embedded in the curl config, and without it those paths stay POSIX. On a real Windows machine **this fix alone does not make the request work**: the header sink is fixed here, and the config still names paths native curl cannot open. The two compose only on the combined branch. Nothing below should be read as "Windows works now".

Accordingly the curl stub in these tests is a **POSIX consumer** — the right one for the code on this branch, and the reason the tests pass here says nothing about Windows.

**The Windows 11 / Git Bash quotation above was measured on `acf7f0f2`, not on this head.** The change since then is comments only, shown rather than asserted:

```
git diff acf7f0f HEAD -- scripts/
  changed lines that are NOT comments   0
  changed lines that are comments       9
```

So the executable code that run exercised is the executable code here. **Nothing has been re-run on Windows at this head**, and stub tests do not substitute for that.

`tests/test_remote_header_sink.bats` — 6 ok / 0 not ok, driving the production `_remote_http_post_json`.

The subject is an **absence** — no fifo, no copier — and an absence is only observable if the instrument can record a presence. `mkfifo` and `python3` are replaced by wrappers that log and then exec the real thing, so the run is unchanged and only observability is added; the first test proves the wrappers record at all. A log that was never wired up looks exactly like a call that never happened.

| mutation | red |
|---|---|
| M0 no mutation | **0** |
| M1 marker ignored, always fifo + copier | no fifo, no copier |
| M2 cleanup removes `header_fifo` unconditionally | the caller's header file survives |
| M3 marker branch builds a fifo anyway | no fifo |
| M4 marker branch starts a copier anyway | no copier |

M3 and M4 are why the two absences are two tests: they are separate machinery, left behind separately — a pipe nobody drains, or a reader blocked on a file that never fills. M2 is the trap this fix had to avoid, since on the marker path `header_fifo` **is** `header_file`.

**Still not measured:** an existing-store team on Windows, as the section above already says. And the size-ceiling downgrade on the marker path is a real difference between platforms, stated in the source rather than hidden.
