### PR TITLE
fix(remote): keep curl's stderr when the request fails (#850)

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -441,10 +441,35 @@ _remote_curl_path() {
 # config file is 0600 and removed immediately after the call.
 _remote_http_post_json() {
   local url="$1" body_file="$2" out_file="$3" header_file="$4" cfg http_code \
-    fifo_dir header_fifo copier_pid curl_output curl_status=0
-  cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
-  fifo_dir="$(mktemp -d "${TMPDIR:-/tmp}/agmsg-header-pipe.XXXXXX")"
-  header_fifo="$fifo_dir/header"
+    work_dir header_fifo copier_pid curl_output curl_status=0 curl_err
+  # ONE ALLOCATION BEFORE THE TRAP, AND EVERYTHING ELSE INSIDE IT.
+  #
+  # Two things go wrong with the ordering this replaces, and this shape is the
+  # smallest one that closes both.
+  #
+  # A trap cannot expand what it cannot see. An EXIT trap set inside a function
+  # runs after that function's frame is gone, so a single-quoted body expands
+  # `$cfg` in the CALLER's scope, where no local of that name exists. It removes
+  # "" and returns 0, so the cleanup reads as working. Measured on bash 3.2.57
+  # and 5.3.15: a local is EMPTY inside an EXIT trap fired by errexit from
+  # within the function. `printf %q` fixes the value at set time and survives a
+  # TMPDIR containing spaces.
+  #
+  # And anything created BEFORE the trap is armed is unprotected. Making the
+  # config, then a directory, then arming the trap leaves a window where the
+  # second allocation fails and the first is stranded -- including a 0600 config
+  # naming the request body. Reordering cannot close it, because there is always
+  # a first allocation. So there is exactly one, and everything else is made
+  # inside a directory that is already condemned.
+  #
+  # It also removes a hazard rather than guarding it: the caller's header file
+  # lives OUTSIDE this directory, so `rm -rf` cannot reach it even on the marker
+  # path below, where `header_fifo` IS `header_file`.
+  work_dir="$(mktemp -d "${TMPDIR:-/tmp}/agmsg-curl.XXXXXX")"
+  trap "rm -rf $(printf '%q' "$work_dir")" EXIT INT TERM
+  cfg="$work_dir/config"
+  curl_err="$work_dir/stderr"
+  : > "$cfg"
   chmod 600 "$cfg"
   # The headers go through a fifo so a hostile or broken server cannot make us
   # buffer an unbounded response — bounded-copy.py enforces the ceiling while
@@ -473,10 +498,9 @@ _remote_http_post_json() {
     header_fifo="$header_file"
     : > "$header_fifo"
     copier_pid=""
-    trap 'rm -f "$cfg"; rmdir "$fifo_dir" 2>/dev/null || true' EXIT INT TERM
   else
+    header_fifo="$work_dir/header"
     mkfifo "$header_fifo"
-    trap 'rm -f "$cfg" "$header_fifo"; rmdir "$fifo_dir" 2>/dev/null || true' EXIT INT TERM
     # Reaped on both normal paths below (waited on success, killed and waited on
     # failure), so this is short-lived by construction -- but the EXIT trap only
     # removes files, it does not kill the copier. A signal arriving before curl
@@ -497,11 +521,21 @@ _remote_http_post_json() {
     printf 'max-filesize = "2097152"\n'
     printf 'data = "@%s"\n' "$(_remote_curl_path "$body_file")"
   } > "$cfg"
-  if curl_output=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>/dev/null); then
+  # Do not discard curl's stderr. On failure it is the only record of WHY, and
+  # the caller only ever sees the HTTP code -- which this function reports as
+  # "000" for every kind of failure alike. A Windows run spent a long time on a
+  # bare 000 whose cause (curl could not open a path embedded in the config)
+  # was sitting in the stderr this line was throwing away.
+  #
+  # Captured rather than passed through, and shown only when curl actually
+  # failed: on the success path curl -sS is already silent, and a stray write
+  # to stderr here would land in the middle of a caller's output.
+  if curl_output=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>"$curl_err"); then
     :
   else
     curl_status=$?
   fi
+  [ "$curl_status" -ne 0 ] && [ -s "$curl_err" ] && cat "$curl_err" >&2
   if [ "$curl_status" -ne 0 ]; then
     [ -n "$copier_pid" ] && { kill "$copier_pid" 2>/dev/null || true; wait "$copier_pid" 2>/dev/null || true; }
     http_code="000"
@@ -510,14 +544,11 @@ _remote_http_post_json() {
   else
     http_code="000"
   fi
-  # Only remove the fifo, never the caller's header file. On the cygpath path
-  # `header_fifo` IS `header_file`, so an unconditional `rm -f "$header_fifo"`
-  # here deletes the headers this function was asked to produce — before the
-  # caller has read them. The fifo exists only when a copier was started, so
-  # that is the condition to key on.
-  rm -f "$cfg"
-  [ -n "$copier_pid" ] && rm -f "$header_fifo"
-  rmdir "$fifo_dir" 2>/dev/null || true
+  # One directory holds the config, the error file and the fifo, so the normal
+  # path removes exactly what the trap would have. The caller's header file is
+  # not in it and was never at risk from this line -- which is the point of the
+  # layout rather than a condition to remember.
+  rm -rf "$work_dir"
   trap - EXIT INT TERM
   printf '%s' "$http_code"
 }

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -535,7 +535,16 @@ _remote_http_post_json() {
   else
     curl_status=$?
   fi
-  [ "$curl_status" -ne 0 ] && [ -s "$curl_err" ] && cat "$curl_err" >&2
+  # THE DIAGNOSIS COMES AFTER THE OUTCOME IS SETTLED, AND CANNOT CHANGE IT.
+  #
+  # This used to be one `&& && cat` line placed before the branch below. Under
+  # `set -e` a failing `cat` -- a closed stderr, a reader that went away, a full
+  # disk -- ends the function on the spot: the copier is never reaped, the
+  # work_dir is never removed, and the caller gets no code at all instead of the
+  # "000" this helper promises for every failure. Being unable to explain a
+  # failure must not turn it into a different failure.
+  #
+  # So: reap and decide first, then write the diagnosis best-effort.
   if [ "$curl_status" -ne 0 ]; then
     [ -n "$copier_pid" ] && { kill "$copier_pid" 2>/dev/null || true; wait "$copier_pid" 2>/dev/null || true; }
     http_code="000"
@@ -543,6 +552,9 @@ _remote_http_post_json() {
     http_code="$curl_output"
   else
     http_code="000"
+  fi
+  if [ "$curl_status" -ne 0 ] && [ -s "$curl_err" ]; then
+    cat "$curl_err" >&2 || true
   fi
   # One directory holds the config, the error file and the fifo, so the normal
   # path removes exactly what the trap would have. The caller's header file is

--- a/tests/test_remote_curl_config_paths.bats
+++ b/tests/test_remote_curl_config_paths.bats
@@ -147,15 +147,30 @@ sandbox_path() {
 # Runs the real helper under a sandbox PATH, and prints the http code. The
 # consumer the curl stub plays is named by the caller, so a test cannot
 # accidentally get a curl that accepts whatever the config happens to say.
+# STDERR GOES TO A FILE, NOT INTO $output.
+#
+# bats merges the two streams, and this helper's stderr is not reliably empty.
+# On a loaded macOS CI runner, bash reported
+#
+#   remote.sh: line NNN: .../agmsg-header-pipe.JVbrl7/header: Interrupted system call
+#
+# while opening the header fifo, and $output became that line followed by the
+# http code. Every exact comparison against "200" or "000" then fails on a code
+# that was in fact correct. Observed twice in one run, on a head that was green
+# on the author's machine: the difference is load, not platform.
+#
+# The http code is the only thing on stdout, so separating the streams is what
+# makes an exact comparison mean what it says.
 post_under() {
   local bin="$1" consumer="$2" body_file="$3" extra="${4:-}"
+  ERR_FILE="$BATS_TEST_TMPDIR/helper-stderr"
   run env PATH="$bin" STUB_CURL_CONSUMER="$consumer" CFG_CAPTURE="$CFG_CAPTURE" \
     FAKE_ROOT="$FAKE_ROOT" bash -c '
     set -uo pipefail
     . '"$SCRIPTS"'/remote.sh 2>/dev/null
     '"$extra"'
     _remote_http_post_json "https://example.invalid/v1/x" "'"$body_file"'" \
-      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$BATS_TEST_TMPDIR"'/out-header"
+      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$BATS_TEST_TMPDIR"'/out-header" 2>"'"$ERR_FILE"'"
   '
 }
 

--- a/tests/test_remote_curl_stderr.bats
+++ b/tests/test_remote_curl_stderr.bats
@@ -61,53 +61,6 @@ fi
 printf '200'
 STUB
   chmod +x "$STUB_SRC/curl"
-
-  # A python3 that records its own pid before becoming the real thing, so a
-  # copier left running is observable rather than assumed absent. `exec` keeps
-  # the pid, so the number in the log is the process the helper must reap.
-  COPIER_PIDS="$BATS_TEST_TMPDIR/copier-pids"
-  export COPIER_PIDS
-  : > "$COPIER_PIDS"
-  REAL_PYTHON3="$(command -v python3)"; export REAL_PYTHON3
-  cat > "$STUB_SRC/python3" <<'STUB'
-#!/usr/bin/env bash
-case "$*" in
-  *bounded-copy.py*) printf '%s\n' "$$" >> "$COPIER_PIDS" ;;
-esac
-exec "$REAL_PYTHON3" "$@"
-STUB
-  chmod +x "$STUB_SRC/python3"
-}
-
-# Nothing this file starts may outlive it. A test that leaves a copier blocked
-# on a fifo holds whatever descriptors it inherited, which is how three probes
-# in this series hung -- so the fixture reaps its own strays even when a case
-# fails, and says so rather than cleaning up silently.
-teardown() {
-  if [ -f "${COPIER_PIDS:-/nonexistent}" ]; then
-    while read -r pid; do
-      [ -n "$pid" ] || continue
-      if kill -0 "$pid" 2>/dev/null; then
-        echo "teardown: reaping copier $pid that the helper left running" >&2
-        kill "$pid" 2>/dev/null || true
-        wait "$pid" 2>/dev/null || true
-      fi
-    done < "$COPIER_PIDS"
-  fi
-  teardown_test_env
-}
-
-# Fails the test when any recorded copier is still alive.
-refute_orphan_copier() {
-  local pid alive=""
-  while read -r pid; do
-    [ -n "$pid" ] || continue
-    kill -0 "$pid" 2>/dev/null && alive="$alive $pid"
-  done < "$COPIER_PIDS"
-  if [ -n "$alive" ]; then
-    echo "copier still running:$alive" >&2
-    return 1
-  fi
 }
 
 sandbox_path() {
@@ -118,7 +71,6 @@ sandbox_path() {
     ln -s "$src" "$dir/$tool"
   done
   ln -s "$STUB_SRC/curl" "$dir/curl"
-  ln -sf "$STUB_SRC/python3" "$dir/python3"
   printf '%s' "$dir"
 }
 
@@ -134,7 +86,6 @@ post_with_curl() {
   printf '{"t":"secret"}' > "$body"
 
   run env PATH="$bin" TMPDIR="$RUN_TMPDIR" STUB_CURL_MODE="$mode" \
-    COPIER_PIDS="$COPIER_PIDS" REAL_PYTHON3="$REAL_PYTHON3" \
     STUB_CURL_STDERR="$stderr_text" bash -c '
     set -uo pipefail
     . '"$SCRIPTS"'/remote.sh 2>/dev/null
@@ -220,7 +171,6 @@ post_with_curl() {
   chmod +x "$bin/cat"
 
   run env PATH="$bin" TMPDIR="$RUN_TMPDIR" STUB_CURL_MODE=fail \
-    COPIER_PIDS="$COPIER_PIDS" REAL_PYTHON3="$REAL_PYTHON3" \
     STUB_CURL_STDERR="curl: (26) Failed to open/read local data" bash -c '
     set -euo pipefail
     . '"$SCRIPTS"'/remote.sh 2>/dev/null
@@ -232,11 +182,32 @@ post_with_curl() {
   [ "$status" -eq 0 ]
   [ "$output" = "000" ]
 
-  # 2. Nothing is left running. The recorded pid is the copier's own, because
-  #    the wrapper execs and keeps it.
-  refute_orphan_copier
+  # 2. NOT ASSERTED HERE: that no copier survives. I tried four instruments and
+  #    each failed its own positive control on this machine, so the check would
+  #    have been a green that measured nothing:
+  #
+  #      a pid the copier records itself   the failure path kills it before the
+  #                                        forked shell runs its first line, so
+  #                                        the log comes back EMPTY
+  #      pgrep -f <full script path>       no match while the process is alive
+  #      pgrep -f bounded-copy.py          matched an unrelated shell whose argv
+  #                                        merely contained the string -- an
+  #                                        instrument that would kill the wrong
+  #                                        process
+  #      lsof +D <work dir>                nothing: a copier blocked in open()
+  #                                        holds no fd on it yet
+  #
+  #    The reason all four miss is one fact, measured: a copier waiting on the
+  #    fifo is still a forked BASH wearing its parent's command line -- `comm`
+  #    reads `bash`, and python3 is not exec'd until curl opens the pipe. It is
+  #    identifiable as "a child of that shell" and by nothing else, and once the
+  #    shell is gone so is that relation.
+  #
+  #    The reaping itself is in the production path above (kill then wait before
+  #    the code is returned). What is unproven is the absence of a survivor, and
+  #    that behaviour has its own issue: #864.
 
-  # 3. And nothing is left on disk.
+  # 3. Nothing is left on disk.
   refute ls -d "$RUN_TMPDIR"/agmsg-curl.* 2>/dev/null
 }
 

--- a/tests/test_remote_curl_stderr.bats
+++ b/tests/test_remote_curl_stderr.bats
@@ -174,6 +174,15 @@ post_with_curl() {
     STUB_CURL_STDERR="curl: (26) Failed to open/read local data" bash -c '
     set -euo pipefail
     . '"$SCRIPTS"'/remote.sh 2>/dev/null
+    REAP_LOG="'"$RUN_TMPDIR"'/reap.log"
+    kill() { printf "kill %s\n" "$*" >> "$REAP_LOG"; builtin kill "$@"; }
+    wait() {
+      printf "wait %s\n" "$*" >> "$REAP_LOG"
+      builtin wait "$@"
+      local rc=$?
+      printf "wait-rc %s %s\n" "$*" "$rc" >> "$REAP_LOG"
+      return $rc
+    }
     _remote_http_post_json "https://example.invalid/v1/x" "'"$body"'" \
       "'"$RUN_TMPDIR"'/out-body" "'"$RUN_TMPDIR"'/out-header"
   '
@@ -182,30 +191,32 @@ post_with_curl() {
   [ "$status" -eq 0 ]
   [ "$output" = "000" ]
 
-  # 2. NOT ASSERTED HERE: that no copier survives. I tried four instruments and
-  #    each failed its own positive control on this machine, so the check would
-  #    have been a green that measured nothing:
+  # 2. THE COPIER WAS REAPED, and the identity is the shell's own child table
+  #    rather than anything found in the process table afterwards.
   #
-  #      a pid the copier records itself   the failure path kills it before the
-  #                                        forked shell runs its first line, so
-  #                                        the log comes back EMPTY
-  #      pgrep -f <full script path>       no match while the process is alive
-  #      pgrep -f bounded-copy.py          matched an unrelated shell whose argv
-  #                                        merely contained the string -- an
-  #                                        instrument that would kill the wrong
-  #                                        process
-  #      lsof +D <work dir>                nothing: a copier blocked in open()
-  #                                        holds no fd on it yet
+  #    Four post-hoc instruments failed their positive controls before this one
+  #    (a pid the copier writes about itself, two pgrep forms, lsof on the work
+  #    dir), all for the same reason: a copier waiting on the fifo is still a
+  #    forked BASH wearing its parent's command line -- `comm` reads `bash` --
+  #    because python3 is not exec'd until curl opens the pipe. Nothing outside
+  #    can name it. But the shell that forked it can: `wait` is a builtin over
+  #    that shell's OWN waitable children, so a successful wait IS the
+  #    observation, and it needs no identity of its own.
   #
-  #    The reason all four miss is one fact, measured: a copier waiting on the
-  #    fifo is still a forked BASH wearing its parent's command line -- `comm`
-  #    reads `bash`, and python3 is not exec'd until curl opens the pipe. It is
-  #    identifiable as "a child of that shell" and by nothing else, and once the
-  #    shell is gone so is that relation.
-  #
-  #    The reaping itself is in the production path above (kill then wait before
-  #    the code is returned). What is unproven is the absence of a survivor, and
-  #    that behaviour has its own issue: #864.
+  #    `kill` and `wait` are shadowed in the driven shell and delegate to the
+  #    builtins, so production runs unchanged and only the seam is recorded.
+  reap="$RUN_TMPDIR/reap.log"
+  [ -s "$reap" ]
+  killed="$(sed -n 's/^kill //p' "$reap" | head -1)"
+  waited="$(sed -n 's/^wait //p' "$reap" | head -1)"
+  [ -n "$killed" ]
+  [ "$killed" = "$waited" ]
+
+  #    And the wait really collected that child: 127 is bash's "not a child of
+  #    this shell", which is what a stale or foreign pid returns.
+  rc="$(sed -n "s/^wait-rc $waited //p" "$reap" | head -1)"
+  [ -n "$rc" ]
+  [ "$rc" != "127" ]
 
   # 3. Nothing is left on disk.
   refute ls -d "$RUN_TMPDIR"/agmsg-curl.* 2>/dev/null

--- a/tests/test_remote_curl_stderr.bats
+++ b/tests/test_remote_curl_stderr.bats
@@ -1,0 +1,255 @@
+#!/usr/bin/env bats
+# WHEN THE ONLY THING A CALLER SEES IS "000", THROWING AWAY curl's STDERR IS
+# THROWING AWAY THE DIAGNOSIS (#850).
+#
+# `_remote_http_post_json` reports `000` for every kind of failure alike: a
+# refused connection, a timeout, a path curl could not open. The reason existed
+# each time -- curl wrote it to stderr -- and `2>/dev/null` discarded it. A
+# Windows run spent an afternoon on a bare `000` whose cause was in that stream.
+#
+# WHAT HAS TO HOLD, and each is its own case here:
+#
+#   on failure   the diagnosis reaches the caller's stderr
+#   on success   nothing does, even if curl wrote something -- the show is
+#                gated on curl having FAILED, not on the stream being empty
+#   either way   the http code is exactly what it was before
+#   either way   no scratch file is left behind
+#
+# The stderr of the helper is captured to a FILE rather than read from bats's
+# `$output`, which merges the two streams: a test that cannot tell stdout from
+# stderr cannot check that a message went to the right one, and "the message
+# appears somewhere" is what this fix is not about.
+
+load test_helper
+
+SANDBOX_TOOLS=(bash dirname mktemp mkfifo chmod rm rmdir sed cp cat grep python3 uname)
+
+setup() {
+  setup_test_env
+
+  STUB_SRC="$BATS_TEST_TMPDIR/stubs"
+  mkdir -p "$STUB_SRC"
+
+  # A curl whose behaviour the test dictates: STUB_CURL_MODE says whether it
+  # succeeds, and STUB_CURL_STDERR is written to stderr either way. Writing on
+  # the success path too is the point of one of the cases below -- it is how
+  # "shown only when curl failed" is told apart from "the stream was empty".
+  cat > "$STUB_SRC/curl" <<'STUB'
+#!/usr/bin/env bash
+set -u
+cfg=""; out=""; prev=""
+for arg in "$@"; do
+  case "$prev" in
+    -K) cfg="$arg" ;;
+    -o) out="$arg" ;;
+  esac
+  prev="$arg"
+done
+[ -z "${STUB_CURL_STDERR:-}" ] || printf '%s\n' "$STUB_CURL_STDERR" >&2
+hdr="$(sed -n 's/^dump-header = "\(.*\)"$/\1/p' "$cfg")"
+if [ "${STUB_CURL_MODE:-ok}" = "fail" ]; then
+  # A failure AFTER the headers were written -- curl exceeding max-filesize on
+  # the body, say. The headers matter here: leaving the fifo without a writer
+  # strands the bounded copier on open(), and everything downstream of that
+  # waits on a process that will never finish. That is a real property of the
+  # failure path, and driving it is a different experiment from this one.
+  [ -z "$hdr" ] || printf 'HTTP/1.1 200 OK\r\n\r\n' > "$hdr"
+  exit 63
+fi
+[ -z "$hdr" ] || printf 'HTTP/1.1 200 OK\r\n\r\n' > "$hdr"
+[ -z "$out" ] || printf '{"ok":true}' > "$out"
+printf '200'
+STUB
+  chmod +x "$STUB_SRC/curl"
+}
+
+teardown() { teardown_test_env; }
+
+sandbox_path() {
+  local dir tool src
+  dir="$(mktemp -d "$BATS_TEST_TMPDIR/sandbox.XXXXXX")"
+  for tool in "${SANDBOX_TOOLS[@]}"; do
+    src="$(command -v "$tool")" || { echo "host lacks $tool" >&2; return 1; }
+    ln -s "$src" "$dir/$tool"
+  done
+  ln -s "$STUB_SRC/curl" "$dir/curl"
+  printf '%s' "$dir"
+}
+
+# Runs the helper with its own TMPDIR, so "what scratch files remain" is a
+# question about this call and not about everything else on the machine.
+# stdout (the http code) lands in $output; stderr lands in $ERR_FILE.
+post_with_curl() {
+  local mode="$1" stderr_text="$2"
+  RUN_TMPDIR="$(mktemp -d "$BATS_TEST_TMPDIR/run.XXXXXX")"
+  ERR_FILE="$BATS_TEST_TMPDIR/helper-stderr"
+  local bin; bin="$(sandbox_path)"
+  local body="$RUN_TMPDIR/body.json"
+  printf '{"t":"secret"}' > "$body"
+
+  run env PATH="$bin" TMPDIR="$RUN_TMPDIR" STUB_CURL_MODE="$mode" \
+    STUB_CURL_STDERR="$stderr_text" bash -c '
+    set -uo pipefail
+    . '"$SCRIPTS"'/remote.sh 2>/dev/null
+    _remote_http_post_json "https://example.invalid/v1/x" "'"$body"'" \
+      "'"$RUN_TMPDIR"'/out-body" "'"$RUN_TMPDIR"'/out-header" 2>"'"$ERR_FILE"'"
+  '
+}
+
+@test "a failing curl's diagnosis reaches the caller's stderr (#850)" {
+  # The whole point. Without this the operator has "000" and nothing else, and
+  # the reason they need is written down and then deleted.
+  post_with_curl fail "curl: (26) Failed to open/read local data from file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "000" ]
+
+  grep -q 'Failed to open/read local data' "$ERR_FILE"
+}
+
+@test "a successful curl's stderr is NOT shown, even when it wrote something (#850)" {
+  # Distinguishes "shown only when curl failed" from "the stream happened to be
+  # empty". curl -sS is quiet on success, so a test that let it stay quiet here
+  # would pass against a version that dumped stderr unconditionally -- and that
+  # version would drop noise into the middle of a caller's output.
+  post_with_curl ok "a progress line nobody asked for"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  [ ! -s "$ERR_FILE" ]
+}
+
+@test "the http code is unchanged on both paths (#850)" {
+  # The contract this must not have altered while adding the diagnosis.
+  post_with_curl ok ""
+  [ "$output" = "200" ]
+
+  post_with_curl fail "curl: (7) Failed to connect"
+  [ "$output" = "000" ]
+}
+
+@test "no scratch file is left behind, on either path (#850)" {
+  # The config, the error file and the fifo now live in one directory the helper
+  # mints, so this is one glob rather than three.
+  #
+  # THE NAME MATTERS AND ALMOST GOT THIS WRONG. An earlier version of this test
+  # globbed agmsg-curl-cfg.* and agmsg-curl-err.*, which the new layout never
+  # creates -- the check would have passed on any behaviour whatsoever, and gone
+  # on passing if the directory leaked. An absence assertion aimed at a name
+  # nothing uses is indistinguishable from a clean run.
+  post_with_curl ok ""
+  [ "$output" = "200" ]
+  refute ls -d "$RUN_TMPDIR"/agmsg-curl.* 2>/dev/null
+
+  post_with_curl fail "curl: (7) Failed to connect"
+  [ "$output" = "000" ]
+  refute ls -d "$RUN_TMPDIR"/agmsg-curl.* 2>/dev/null
+}
+
+@test "an early exit between the mktemp and the cleanup still sweeps the file (#850)" {
+  # The hole the explicit cleanup cannot cover: it only runs if the function
+  # GETS there. A signal is the obvious way out early and it is also the one I
+  # could not drive -- the probe hung, because the bounded copier keeps the run
+  # alive while curl is being waited on. A review pointed out that the signal is
+  # not the only exit, and errexit is a bounded one.
+  #
+  # `cat` is the last command of the `&& &&` chain that shows the diagnosis, so
+  # under `set -e` a failing cat leaves the function immediately -- after the
+  # mktemp, before the rm. Everything that survives that has to come from the
+  # trap, which is exactly the property under test.
+  RUN_TMPDIR="$(mktemp -d "$BATS_TEST_TMPDIR/run.XXXXXX")"
+  local bin; bin="$(sandbox_path)"
+  local body="$RUN_TMPDIR/body.json"
+  printf '{"t":"secret"}' > "$body"
+
+  # A `cat` that always fails, shadowing the real one for this run only. The
+  # symlink is REMOVED first: `>` through a symlink writes to its target, which
+  # here is the system's own /bin/cat. The first attempt did exactly that and
+  # was refused by the OS -- on a machine where it was not refused, this test
+  # would have replaced a system binary.
+  rm -f "$bin/cat"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$bin/cat"
+  chmod +x "$bin/cat"
+
+  # Output goes to FILES, not to bats's capture pipe. On this path the bounded
+  # copier is never reaped -- the trap removes files and does not kill it -- so
+  # it outlives the shell still holding the inherited stdout and stderr. Those
+  # being a pipe is what makes `run` wait forever; those being files is what
+  # makes this test finish. The orphan is a real property of the early-exit
+  # path and is reported alongside this test rather than papered over.
+  run env PATH="$bin" TMPDIR="$RUN_TMPDIR" STUB_CURL_MODE=fail \
+    STUB_CURL_STDERR="curl: (26) Failed to open/read local data" bash -c '
+    set -euo pipefail
+    . '"$SCRIPTS"'/remote.sh 2>/dev/null
+    _remote_http_post_json "https://example.invalid/v1/x" "'"$body"'" \
+      "'"$RUN_TMPDIR"'/out-body" "'"$RUN_TMPDIR"'/out-header"
+  ' >"$RUN_TMPDIR/driver-stdout" 2>"$RUN_TMPDIR/driver-stderr"
+  # It leaves early: the function never reaches its `printf` of the code.
+  [ "$status" -ne 0 ]
+  [ ! -s "$RUN_TMPDIR/driver-stdout" ]
+
+  # And nothing is stranded. This is the trap's work, not the tail's -- and all
+  # three are asserted, because measuring this path is what showed the trap had
+  # never swept ANY of them. It expanded function locals after the frame was
+  # gone, removed empty strings, and returned 0.
+  refute ls "$RUN_TMPDIR"/agmsg-curl-err.* 2>/dev/null
+  refute ls "$RUN_TMPDIR"/agmsg-curl-cfg.* 2>/dev/null
+  refute ls -d "$RUN_TMPDIR"/agmsg-curl.* 2>/dev/null
+}
+
+@test "a failure while setting up leaves nothing behind either (#850)" {
+  # The window the previous shape could not close: anything created BEFORE the
+  # trap is armed is unprotected, and there is always a first allocation. The
+  # answer is that there is now only ONE allocation before the trap, and
+  # everything else is made inside it.
+  #
+  # Driven by making `mkfifo` fail, which happens after the directory exists and
+  # after the config has been written into it. Under `set -e` that leaves the
+  # function immediately -- before curl, before any cleanup the tail would do.
+  RUN_TMPDIR="$(mktemp -d "$BATS_TEST_TMPDIR/run.XXXXXX")"
+  local bin; bin="$(sandbox_path)"
+  local body="$RUN_TMPDIR/body.json"
+  printf '{"t":"secret"}' > "$body"
+
+  rm -f "$bin/mkfifo"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$bin/mkfifo"
+  chmod +x "$bin/mkfifo"
+
+  run env PATH="$bin" TMPDIR="$RUN_TMPDIR" bash -c '
+    set -euo pipefail
+    . '"$SCRIPTS"'/remote.sh 2>/dev/null
+    _remote_http_post_json "https://example.invalid/v1/x" "'"$body"'" \
+      "'"$RUN_TMPDIR"'/out-body" "'"$RUN_TMPDIR"'/out-header"
+  '
+  [ "$status" -ne 0 ]
+
+  # Nothing survives: not the directory, and so not the config inside it. The
+  # config is the file that matters -- it is what this helper exists to keep
+  # out of curl's argv, and a stranded copy names the request body.
+  refute ls -d "$RUN_TMPDIR"/agmsg-curl.* 2>/dev/null
+}
+
+@test "an EXIT trap cannot read the locals of the function that set it (#850)" {
+  # The premise the trap's shape rests on, measured here rather than asserted
+  # in a comment. If a future bash made locals visible to an EXIT trap, the
+  # `printf %q` baking would look like pointless ceremony and someone would
+  # simplify it back into a single-quoted body -- reopening the leak. This test
+  # is what tells them the ceremony is load-bearing.
+  run bash -c '
+    f() { local v="hello"; trap '"'"'printf "TRAP_SEES=[%s]\n" "${v:-EMPTY}"'"'"' EXIT; false; }
+    set -e
+    f
+  '
+  [ "$output" = "TRAP_SEES=[EMPTY]" ]
+}
+
+@test "the leftover check can see a leftover when there is one (#850)" {
+  # Control on the assertion above, which is an absence: a glob that matches
+  # nothing looks exactly like a glob pointed at the wrong directory. Plant one
+  # and confirm the same check fires.
+  # Planted under the name the helper really uses, so this controls the glob
+  # that the absence assertions actually run.
+  post_with_curl ok ""
+  mkdir -p "$RUN_TMPDIR/agmsg-curl.planted"
+  run ls -d "$RUN_TMPDIR"/agmsg-curl.*
+  [ "$status" -eq 0 ]
+}

--- a/tests/test_remote_curl_stderr.bats
+++ b/tests/test_remote_curl_stderr.bats
@@ -61,9 +61,54 @@ fi
 printf '200'
 STUB
   chmod +x "$STUB_SRC/curl"
+
+  # A python3 that records its own pid before becoming the real thing, so a
+  # copier left running is observable rather than assumed absent. `exec` keeps
+  # the pid, so the number in the log is the process the helper must reap.
+  COPIER_PIDS="$BATS_TEST_TMPDIR/copier-pids"
+  export COPIER_PIDS
+  : > "$COPIER_PIDS"
+  REAL_PYTHON3="$(command -v python3)"; export REAL_PYTHON3
+  cat > "$STUB_SRC/python3" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *bounded-copy.py*) printf '%s\n' "$$" >> "$COPIER_PIDS" ;;
+esac
+exec "$REAL_PYTHON3" "$@"
+STUB
+  chmod +x "$STUB_SRC/python3"
 }
 
-teardown() { teardown_test_env; }
+# Nothing this file starts may outlive it. A test that leaves a copier blocked
+# on a fifo holds whatever descriptors it inherited, which is how three probes
+# in this series hung -- so the fixture reaps its own strays even when a case
+# fails, and says so rather than cleaning up silently.
+teardown() {
+  if [ -f "${COPIER_PIDS:-/nonexistent}" ]; then
+    while read -r pid; do
+      [ -n "$pid" ] || continue
+      if kill -0 "$pid" 2>/dev/null; then
+        echo "teardown: reaping copier $pid that the helper left running" >&2
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+      fi
+    done < "$COPIER_PIDS"
+  fi
+  teardown_test_env
+}
+
+# Fails the test when any recorded copier is still alive.
+refute_orphan_copier() {
+  local pid alive=""
+  while read -r pid; do
+    [ -n "$pid" ] || continue
+    kill -0 "$pid" 2>/dev/null && alive="$alive $pid"
+  done < "$COPIER_PIDS"
+  if [ -n "$alive" ]; then
+    echo "copier still running:$alive" >&2
+    return 1
+  fi
+}
 
 sandbox_path() {
   local dir tool src
@@ -73,6 +118,7 @@ sandbox_path() {
     ln -s "$src" "$dir/$tool"
   done
   ln -s "$STUB_SRC/curl" "$dir/curl"
+  ln -sf "$STUB_SRC/python3" "$dir/python3"
   printf '%s' "$dir"
 }
 
@@ -88,6 +134,7 @@ post_with_curl() {
   printf '{"t":"secret"}' > "$body"
 
   run env PATH="$bin" TMPDIR="$RUN_TMPDIR" STUB_CURL_MODE="$mode" \
+    COPIER_PIDS="$COPIER_PIDS" REAL_PYTHON3="$REAL_PYTHON3" \
     STUB_CURL_STDERR="$stderr_text" bash -c '
     set -uo pipefail
     . '"$SCRIPTS"'/remote.sh 2>/dev/null
@@ -145,17 +192,19 @@ post_with_curl() {
   refute ls -d "$RUN_TMPDIR"/agmsg-curl.* 2>/dev/null
 }
 
-@test "an early exit between the mktemp and the cleanup still sweeps the file (#850)" {
-  # The hole the explicit cleanup cannot cover: it only runs if the function
-  # GETS there. A signal is the obvious way out early and it is also the one I
-  # could not drive -- the probe hung, because the bounded copier keeps the run
-  # alive while curl is being waited on. A review pointed out that the signal is
-  # not the only exit, and errexit is a bounded one.
+@test "a diagnosis that cannot be written does not change the outcome (#850)" {
+  # THIS CASE ASSERTED THE OPPOSITE UNTIL REVIEW TURNED IT AROUND.
   #
-  # `cat` is the last command of the `&& &&` chain that shows the diagnosis, so
-  # under `set -e` a failing cat leaves the function immediately -- after the
-  # mktemp, before the rm. Everything that survives that has to come from the
-  # trap, which is exactly the property under test.
+  # The diagnosis used to be `[ ... ] && [ ... ] && cat "$curl_err" >&2` sitting
+  # before the failure arm. Under `set -e` a failing `cat` -- closed stderr, a
+  # reader that went away, a full disk -- ended the function there: no reap, no
+  # cleanup, and no http code at all where the contract promises "000".
+  #
+  # I wrote a test that drove exactly that and asserted it: nonzero status,
+  # empty stdout, and a comment noting the copier was left orphaned. It was
+  # measuring the defect and calling it the property. Being unable to EXPLAIN a
+  # failure must not turn it into a DIFFERENT failure, so all three of these are
+  # now the other way round.
   RUN_TMPDIR="$(mktemp -d "$BATS_TEST_TMPDIR/run.XXXXXX")"
   local bin; bin="$(sandbox_path)"
   local body="$RUN_TMPDIR/body.json"
@@ -163,36 +212,31 @@ post_with_curl() {
 
   # A `cat` that always fails, shadowing the real one for this run only. The
   # symlink is REMOVED first: `>` through a symlink writes to its target, which
-  # here is the system's own /bin/cat. The first attempt did exactly that and
+  # here is the system's own /bin/cat. An earlier version did exactly that and
   # was refused by the OS -- on a machine where it was not refused, this test
   # would have replaced a system binary.
   rm -f "$bin/cat"
   printf '#!/usr/bin/env bash\nexit 1\n' > "$bin/cat"
   chmod +x "$bin/cat"
 
-  # Output goes to FILES, not to bats's capture pipe. On this path the bounded
-  # copier is never reaped -- the trap removes files and does not kill it -- so
-  # it outlives the shell still holding the inherited stdout and stderr. Those
-  # being a pipe is what makes `run` wait forever; those being files is what
-  # makes this test finish. The orphan is a real property of the early-exit
-  # path and is reported alongside this test rather than papered over.
   run env PATH="$bin" TMPDIR="$RUN_TMPDIR" STUB_CURL_MODE=fail \
+    COPIER_PIDS="$COPIER_PIDS" REAL_PYTHON3="$REAL_PYTHON3" \
     STUB_CURL_STDERR="curl: (26) Failed to open/read local data" bash -c '
     set -euo pipefail
     . '"$SCRIPTS"'/remote.sh 2>/dev/null
     _remote_http_post_json "https://example.invalid/v1/x" "'"$body"'" \
       "'"$RUN_TMPDIR"'/out-body" "'"$RUN_TMPDIR"'/out-header"
-  ' >"$RUN_TMPDIR/driver-stdout" 2>"$RUN_TMPDIR/driver-stderr"
-  # It leaves early: the function never reaches its `printf` of the code.
-  [ "$status" -ne 0 ]
-  [ ! -s "$RUN_TMPDIR/driver-stdout" ]
+  '
 
-  # And nothing is stranded. This is the trap's work, not the tail's -- and all
-  # three are asserted, because measuring this path is what showed the trap had
-  # never swept ANY of them. It expanded function locals after the frame was
-  # gone, removed empty strings, and returned 0.
-  refute ls "$RUN_TMPDIR"/agmsg-curl-err.* 2>/dev/null
-  refute ls "$RUN_TMPDIR"/agmsg-curl-cfg.* 2>/dev/null
+  # 1. The request still reports what it always reported.
+  [ "$status" -eq 0 ]
+  [ "$output" = "000" ]
+
+  # 2. Nothing is left running. The recorded pid is the copier's own, because
+  #    the wrapper execs and keeps it.
+  refute_orphan_copier
+
+  # 3. And nothing is left on disk.
   refute ls -d "$RUN_TMPDIR"/agmsg-curl.* 2>/dev/null
 }
 

--- a/tests/test_remote_header_sink.bats
+++ b/tests/test_remote_header_sink.bats
@@ -126,14 +126,29 @@ sandbox_path() {
   printf '%s' "$dir"
 }
 
+# STDERR GOES TO A FILE, NOT INTO $output.
+#
+# bats merges the two streams, and this helper's stderr is not reliably empty.
+# On a loaded macOS CI runner, bash reported
+#
+#   remote.sh: line NNN: .../agmsg-header-pipe.JVbrl7/header: Interrupted system call
+#
+# while opening the header fifo, and $output became that line followed by the
+# http code. Every exact comparison against "200" or "000" then fails on a code
+# that was in fact correct. Observed twice in one run, on a head that was green
+# on the author's machine: the difference is load, not platform.
+#
+# The http code is the only thing on stdout, so separating the streams is what
+# makes an exact comparison mean what it says.
 post_under() {
   local bin="$1" body_file="$2" header_out="$3"
+  ERR_FILE="$BATS_TEST_TMPDIR/helper-stderr"
   run env PATH="$bin" CALL_LOG="$CALL_LOG" REAL_MKFIFO="$REAL_MKFIFO" \
     REAL_PYTHON3="$REAL_PYTHON3" bash -c '
     set -uo pipefail
     . '"$SCRIPTS"'/remote.sh 2>/dev/null
     _remote_http_post_json "https://example.invalid/v1/x" "'"$body_file"'" \
-      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$header_out"'"
+      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$header_out"'" 2>"'"$ERR_FILE"'"
   '
 }
 


### PR DESCRIPTION
Part 3 of 3 splitting the Windows connect fix. All three together are on `win-connect-fix-850`, which is the branch to install for a real walk.

**This is the one that made the other two findable.** Landing it separately is the point: without it the next failure in this family is another opaque `000`.

## What is wrong

`_remote_http_post_json` sent curl's stderr to `/dev/null` and reported `000` for every kind of failure alike. The caller sees only that code, so when a request failed there was nothing anywhere saying why.

That cost the Windows run a long time: `connect` returned a bare `000`, and the reason — curl could not open a path embedded in its own config file — was in the stderr this line was discarding.

Captured to a file rather than passed straight through, and shown only when curl actually failed: on the success path `curl -sS` is already silent, and an unconditional pass-through would put curl's output in the middle of a caller's.

## Scope, stated because it is narrower than the reasoning

This fixes the **POST** helper only, which is what the verified Windows commit changed.

`_remote_http_get_json` still carries `2>/dev/null`, and the same argument applies to it — `pull` goes through the GET path, so a failure there is still an opaque `000` with the reason discarded. It embeds no paths in its config, so PR-A's defect does not reach it, but the diagnosability one does.

Left out deliberately rather than folded in: this PR carries what was measured on the Windows machine, and extending it here would mix verified work with unverified. Worth a follow-up.

## What was verified on Windows 11 / Git Bash

Quoted rather than summarised:

> Verified on Windows 11 / Git Bash: connect <team> now returns a real HTTP response, writes remote_binding, remote status reports connected, and the sync engine round-trips (push.ack seq 1 stored -> pull.applied). Existing-store team migration is NOT yet exercised.

## What was verified on macOS, and what that is worth

`tests/test_remote.bats` — 122 ok / 0 not ok, on this branch alone.

**Green was not evidence anything was diagnosed.** When this was written, no test in the suite asserted on curl's stderr — that is no longer true, and the tests added since are described at the end of this body. What green establishes is that capturing it, and emitting it only on failure, leaves every existing caller's behaviour and every reported HTTP code unchanged.

## Not measured

**A team with an existing store has not been migrated on Windows.** The verified run was a fresh team.


---

## Tests, added at `adbf2b34d74f`

`tests/test_remote_curl_stderr.bats` — **5 ok / 0 not ok**, driving the production `_remote_http_post_json`. Production is untouched; the diff since the reviewed head is this one file.

The helper's stderr is captured to a **file** rather than read from bats's `$output`, which merges the streams. The http code goes to stdout and the diagnosis has to go to stderr — a test that cannot tell them apart cannot check that.

| case | |
|---|---|
| failing curl | the diagnosis reaches the caller's stderr |
| succeeding curl | nothing does — **and the stub wrote to stderr anyway** |
| both | the http code is unchanged, 200 and 000 |
| both | no scratch file left in the run's own TMPDIR |
| control | the leftover check fires on a planted leftover |

The second row is the one that needs explaining. Real `curl -sS` is quiet on success, so a stub that also stayed quiet would pass against a version that dumped stderr unconditionally — and that version drops noise into the middle of a caller's output. Making the stub noisy on success is what separates *"shown only when curl failed"* from *"the stream happened to be empty"*.

The last row is the control on an absence: a glob that matches nothing looks exactly like a glob aimed at the wrong directory.

| mutation | red |
|---|---|
| M0 no mutation | **0** |
| M1 `2>/dev/null` restored | the diagnosis reaches stderr |
| M2 stderr shown on success too | success stays quiet |
| M3 the error file never removed | no scratch left behind |
| M4 failure reports curl's exit code | the code contract, and the two cases that read it |

## Not covered

**The signal path.** The scratch file is removed on both normal paths, and the trap set earlier in the function does not name it — its list is the config and the fifo. That is a reading of the trap's text, **not a measurement**: I tried to drive a signal through it and the probe hung on this host, because the bounded copier keeps the run alive while curl is being waited on.

Adding `curl_err` to that trap is one line, but it changes the fix rather than testing it, so it is the author's call rather than mine.

**Windows** is unverified by me, here as elsewhere in this series.


---

## Tests and one further production change, at `d59284c11e38`

Review asked for one line — put `curl_err` in the existing trap so an early exit cannot strand it. **I wrote that line, added a test for it, and the test failed.** What the measurement then said is why this head carries more than tests.

### An EXIT trap set inside a function cannot read that function's locals

It runs after the frame is gone, so a single-quoted body expands `$cfg` in the **caller's** scope, where no local of that name exists. It removes the empty string, returns 0, and reads as a cleanup that worked.

```
bash 3.2.57   TRAP SEES: [EMPTY]
bash 5.3.15   TRAP SEES: [EMPTY]
```

So this was never about `curl_err`. **The pre-existing trap has never swept anything on an early exit.** Driven with a stub curl that fails after writing its headers and a `cat` that fails, so errexit leaves the function between the mktemp and the tail cleanup, a real run left all three behind:

```
agmsg-curl-cfg.cn24V2        a 0600 config naming the request body
agmsg-curl-err.cJJHwm
agmsg-header-pipe.2u0Xbp
```

The config is the one that matters — it is the file this helper exists to keep out of curl's argv.

**The fix:** bake the paths into the trap with `printf %q` at set time instead of expanding them when it fires, and create `curl_err` with the other temporaries so it exists before the trap that must remove it. Same run afterwards leaves nothing. This is more than the one line asked for, and the reason is that the one line does not work; the tests bind the behaviour, not the mechanism, so a different shape is open to the author.

### `tests/test_remote_curl_stderr.bats` — 7 ok / 0 not ok

| case | |
|---|---|
| failing curl | the diagnosis reaches the caller's stderr |
| succeeding curl | nothing does — and the stub wrote to stderr anyway |
| both | the http code is unchanged, 200 and 000 |
| both | no scratch file left in the run's own TMPDIR |
| early exit | errexit out of the middle sweeps **all three** files |
| premise | an EXIT trap cannot read the locals of the function that set it — measured, so the `printf %q` baking is not mistaken for ceremony and simplified back |
| control | the leftover check fires on a planted leftover |

| mutation | red |
|---|---|
| M0 no mutation | **0** |
| M1 `2>/dev/null` restored | the diagnosis reaches stderr |
| M2 stderr shown on success too | success stays quiet |
| M3 the error file never removed | no scratch left behind |
| M4 failure reports curl's exit code | the code contract, and the two cases that read it |

Existing suite unchanged on this head: `tests/test_remote.bats` — 122 ok / 0 not ok.

### The early-exit case took three attempts, and each failure is worth naming

1. **A signal.** The probe hung: on that path the bounded copier is never reaped, so it outlives the shell holding the inherited stdout and bats's capture waits on it. Review suggested errexit instead, which is bounded.
2. **Writing the fake `cat` through the sandbox symlink.** `>` follows a symlink, so it wrote to the system's own `/bin/cat` — refused by the OS here. On a machine where it was not refused, the test would have replaced a system binary. The symlink is removed first now.
3. **A failure stub that exited without writing the headers**, which strands the copier on `open()` and hangs for the same reason as (1). The stub now writes headers and then fails, which is what a real curl does when it dies on the body.

**Windows** is unverified by me.


---

## Update at `a38d6f8e1430` — one directory, armed before anything else exists

Review's remaining point: **whatever is created before the trap is armed is unprotected**, and the previous shape kept that window — it made three things and then armed a trap over all three. A failure at the second or third strands the first, including a 0600 config naming the request body.

Reordering cannot close it, because there is always a first allocation. So there is now exactly one:

```sh
work_dir="$(mktemp -d ...)"
trap "rm -rf <baked work_dir>" EXIT INT TERM
cfg="$work_dir/config"; curl_err="$work_dir/stderr"; header_fifo="$work_dir/header"
```

Everything else is made inside a directory that is already condemned; the normal path removes the same directory. The `printf %q` baking stays, for the measured reason above.

**New case:** make `mkfifo` fail — after the directory exists and after the config is inside it — and assert nothing survives.

### And four of my absence assertions were aimed at names that no longer exist

The leftover checks globbed `agmsg-curl-cfg.*` and `agmsg-curl-err.*`. This layout never creates those. They would have passed on **any** behaviour, and gone on passing while the new directory leaked. Both they and their planted-leftover control now use the name the helper really mints.

An absence assertion pointed at a name nothing uses is indistinguishable from a clean run — and I wrote four of them without noticing the rename I had just made underneath.

```
tests/test_remote_curl_stderr.bats   8 ok / 0 not ok
tests/test_remote.bats             122 ok / 0 not ok   (unchanged)
```

### Filed separately, not folded in

On the failure path the bounded copier is **not reaped** when the function leaves early, and it holds the caller's inherited stdout — which is what hung three of my probes. It predates the stderr work, so it is **#864** rather than a change here.


---

> **Everything below this line up to the next heading is history.** It describes `edcebc5`, whose contract for the failing-diagnosis case was the opposite of the current one.

# Rebuilt on current main at `edcebc597e39bd7959ddfe77f516050517810477`

**The earlier verdicts on this PR are void.** Everything above describes heads that predate #868, which landed the header-sink work and gave this helper two arms. Drift against today's `main` was **NON-EMPTY — 213 insertions in `scripts/remote.sh`**, the one file this changes, so the branch was rebuilt rather than rebased.

**Base is now `fix/curl-tests-read-merged-stream` (#886), and that is a real dependency, not tidiness** — measured in both directions below.

## What this adds to main

Curl's stderr is kept and shown when curl actually failed. The caller only ever sees the HTTP code, and this helper reports `000` for every kind of failure alike — refused connection, timeout, a path curl could not open. Shown only on failure: `curl -sS` is silent on success, so an unconditional dump would land in the middle of a caller's output.

## What it simplifies

All temporaries move into one directory, minted before the trap is armed:

```sh
work_dir="$(mktemp -d ...)"
trap "rm -rf <baked work_dir>" EXIT INT TERM
cfg="$work_dir/config"; curl_err="$work_dir/stderr"; header_fifo="$work_dir/header"
```

Two reasons, both measured earlier in this series:

- **An EXIT trap cannot expand the locals of the function that set it.** It runs after the frame is gone, so a single-quoted `$cfg` expands in the caller's scope and removes `""`. `bash 3.2.57` and `5.3.15` both report EMPTY. `printf %q` fixes the value at set time.
- **Anything created before the trap is armed is unprotected**, and reordering cannot fix that because there is always a first allocation.

It also **removes a hazard instead of guarding it.** main carries a comment warning that on the marker path `header_fifo` IS `header_file`, so an unconditional `rm -f "$header_fifo"` would delete the headers the caller asked for. The caller's file is outside `work_dir`, so `rm -rf` cannot reach it — the guard becomes a property of the layout. Two traps become one and `fifo_dir` disappears.

## The dependency on #886, measured both ways

```
main's harness + this change   ->  not ok 21  an untranslated POSIX path ... is the reported 000
#886's harness + this change   ->  ok
```

`tests/test_remote_curl_config_paths.bats` compares bats's `$output` — stdout and stderr **merged** — against `"000"`. Showing curl's diagnosis puts a line in front of the code. That test is *already* intermittently red on main for the same reason under CI load; this change turns intermittent into certain. **#886 is a prerequisite.**

## Tests

`tests/test_remote_curl_stderr.bats` — **8 ok / 0 not ok**

| case | |
|---|---|
| failing curl | the diagnosis reaches the caller's stderr |
| succeeding curl | nothing does — and the stub wrote to stderr anyway |
| both | the http code is unchanged, 200 and 000 |
| both | no scratch left in the run's own TMPDIR |
| early exit | errexit out of the middle sweeps everything |
| setup failure | `mkfifo` fails after the directory exists — nothing survives |
| premise | an EXIT trap cannot read the locals of the function that set it, measured |
| control | the leftover check fires on a planted leftover |

**22 ok / 0 not ok** across this file and the two already covering this helper (`test_remote_header_sink.bats`, `test_remote_curl_config_paths.bats`).

**Windows** is unverified by me. Related: the header copier is not reaped on an early exit (#864).



---

> **History from here to the next heading.** `f94c333` concluded that the survivor question could not be measured; the head below measures it.

# Current head: `f94c333f28c7731c2b35d1e8d56b224c37c9685c`

Two review rounds since `edcebc5`. Both changed what this PR claims, so the section above is history and this one is the state.

## The diagnosis line was itself an exit

```sh
[ "$curl_status" -ne 0 ] && [ -s "$curl_err" ] && cat "$curl_err" >&2
```

Under `set -e` a failing `cat` — closed stderr, a reader that went away, a full disk — ends the function there. The copier is never reaped, the `work_dir` is never removed, and the caller gets **nothing** where this helper promises `000` for every failure. Being unable to *explain* a failure turned it into a *different* failure.

**And the test I shipped asserted that.** It drove a failing `cat`, asserted nonzero status and empty stdout, and its own comment noted the copier was left orphaned. It measured the defect and called it the property; the reviewer read the test as the specification, which is what a test is.

Now: reap and decide first, then write the diagnosis best-effort. Same case, contract the other way round.

| mutation | red |
|---|---|
| M0 no mutation | **0** |
| M1 diagnosis back before the branch, fatal | the new case |
| M2 same position, `\|\| true` removed | the new case |
| M3 diagnosis removed entirely | *the diagnosis reaches stderr* |
| M4 diagnosis shown on success too | *success stays quiet* |

M1 and M2 redden separately, so **position** and **best-effort** are bound apart.

## What this case does NOT assert, and why

The second round questioned the copier check I added: it passed vacuously on an empty record, and its teardown killed by remembered PID — a number the kernel may reuse, so the fixture could have signalled an unrelated process on the runner.

Fixing it properly produced a finding. **Four instruments, each failing its own positive control:**

| instrument | what it did |
|---|---|
| a pid the copier records itself | the failure path kills it before the forked shell runs its first line — log **empty** |
| `pgrep -f <full script path>` | no match while the process is alive |
| `pgrep -f bounded-copy.py` | matched an unrelated shell whose argv merely contained the string — would have killed the wrong process |
| `lsof +D <work dir>` | nothing: a copier blocked in `open()` holds no fd on it yet |

One fact explains all four: **a copier waiting on the fifo is still a forked `bash` wearing its parent's command line** — measured, `comm` reads `bash` — because python3 is not exec'd until curl opens the pipe. It is identifiable as *a child of that shell* and by nothing else, and after the shell exits, not even that.

A fifth attempt — running the driven shell in its own process group, so the group could be the identity — **hung the harness**, the same way three earlier probes in this series died: the orphan holds the capture pipe.

So the assertion is **removed rather than left as a green that measures nothing**, and the case carries all of the above where the next person will be tempted to add it back. The reaping is in production (kill, then wait, before the code is returned); what is unproven is the *absence* of a survivor, and that behaviour is already filed as **#864**.

## Still asserted

```
status 0 and "000" on stdout   the contract, unchanged by a failed write
no work_dir left               cleanup still runs
```

`tests/test_remote_curl_stderr.bats` — **8 ok / 0 not ok**. Base remains #886, for the reason measured above.



---

# Current head: `597d345525efb1b5401b167ac38fdffd973b90fe`

**The section above says the absence of a survivor cannot be measured. That was wrong**, and the reviewer named the identity I had not used: the helper's own child table.

Every instrument I tried looked for the copier in the process table *after* the fact. All four failed for one reason — a copier waiting on the fifo is still a forked `bash` wearing its parent's command line, because python3 is not exec'd until curl opens the pipe. **Nothing outside can name it.**

But `wait` is a builtin over the shell's **own** waitable children. A successful wait *is* the observation, and it needs no identity of its own.

So the driven shell shadows `kill` and `wait`, records the pid each was given, and delegates to the builtins. Production runs unchanged; only the seam is recorded.

```
the pid killed is the pid waited on
the wait collected that child -- rc is not 127, bash's "not a child of this shell"
```

## It earns its place

| mutation | red |
|---|---|
| M0 no mutation | **0** |
| M1 diagnosis before the branch, fatal | the failing-diagnosis case |
| M2 same position, `\|\| true` removed | the failing-diagnosis case |
| M3 diagnosis removed entirely | *the diagnosis reaches stderr* |
| M4 diagnosis shown on success too | *success stays quiet* |
| **M5 failure arm no longer reaps** | **the failing-diagnosis case** |

**M5 is the one that matters.** Status stays `0`, stdout stays `"000"`, the `work_dir` is still gone — every assertion this case had before would be green on a build that never reaps. The seam is what tells them apart.

M1 and M2 redden through the same case for the opposite reason: a fatal `cat` exits before the seam is reached, so nothing is recorded.

## The boundary, narrowed

**#864** still holds the *other* early-exit routes — signals in particular, where the trap removes files and does not kill a process. That **this PR's failing-diagnosis route reaches `kill` and `wait`** is measured here rather than deferred.

`tests/test_remote_curl_stderr.bats` — **8 ok / 0 not ok**; **22 ok / 0 not ok** across the three files covering this helper. Base remains #886.
