### PR TITLE
fix(remote): keep curl's stderr on the GET path too (#850)

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -570,10 +570,19 @@ _remote_http_post_json() {
 # Nothing else is sent, because there is nothing else to send: this protocol
 # carries no credential at all (see cmd_connect).
 _remote_http_get_json() {
-  local url="$1" team_id="$2" out_file="$3" cfg curl_output curl_status=0
-  cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
+  local url="$1" team_id="$2" out_file="$3" cfg curl_output curl_status=0 \
+    curl_err work_dir
+  # One allocation, then the trap, then everything else inside it -- the same
+  # shape as the POST helper and for the same two reasons. A trap set inside a
+  # function cannot expand that function's locals when it fires, so the path is
+  # baked in with printf %q; and anything created before the trap is armed is
+  # unprotected, so only one thing is.
+  work_dir="$(mktemp -d "${TMPDIR:-/tmp}/agmsg-curl.XXXXXX")"
+  trap "rm -rf $(printf '%q' "$work_dir")" EXIT INT TERM
+  cfg="$work_dir/config"
+  curl_err="$work_dir/stderr"
+  : > "$cfg"
   chmod 600 "$cfg"
-  trap 'rm -f "$cfg"' EXIT INT TERM
   {
     printf 'url = "%s"\n' "$url"
     printf 'request = "GET"\n'
@@ -583,13 +592,26 @@ _remote_http_get_json() {
     printf 'max-time = "15"\n'
     printf 'max-filesize = "2097152"\n'
   } > "$cfg"
-  if curl_output=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>/dev/null); then
+  # Same reason as the POST helper: discarding stderr leaves "000" as the only
+  # thing anyone sees, and "000" is what this reports for every failure alike.
+  # `pull` goes through here, so a failure on this path was as undiagnosable as
+  # the connect one that cost a Windows run its afternoon.
+  if curl_output=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>"$curl_err"); then
     :
   else
     curl_status=$?
   fi
+  # The outcome is settled BEFORE the diagnosis is written, and the write is
+  # best-effort. As one fatal `&&` chain this line ended the function whenever
+  # `cat` failed -- a closed stderr, a reader that went away -- so being unable
+  # to explain a failure returned no code at all instead of the "000" this
+  # helper promises. Reviewed and reversed on the POST side; the same shape
+  # would have been wrong here.
   [ "$curl_status" -eq 0 ] || curl_output="000"
-  rm -f "$cfg"
+  if [ "$curl_status" -ne 0 ] && [ -s "$curl_err" ]; then
+    cat "$curl_err" >&2 || true
+  fi
+  rm -rf "$work_dir"
   trap - EXIT INT TERM
   printf '%s' "$curl_output"
 }

--- a/tests/test_remote_curl_stderr_get.bats
+++ b/tests/test_remote_curl_stderr_get.bats
@@ -1,0 +1,200 @@
+#!/usr/bin/env bats
+# THE SAME LOSS, ON THE OTHER HELPER (#850).
+#
+# `_remote_http_get_json` discarded curl's stderr exactly as the POST helper
+# did, and reports the same `000` for every failure alike. `pull` goes through
+# here, so a failure on this path was as undiagnosable as the connect one.
+#
+# SEPARATE TESTS, NOT A SHARED ONE. This is a different function with a
+# different shape -- no fifo, no copier, its own trap and its own cleanup --
+# and the two were fixed in two pull requests so that a mutation in one cannot
+# be covered by the other's tests. A parameterised file over both helpers would
+# put that back: reverting the GET change would redden a case whose name says
+# POST, and the attribution is the thing being bought.
+#
+# Stderr is captured to a FILE rather than read from bats's `$output`, which
+# merges the streams. The http code goes to stdout and the diagnosis has to go
+# to stderr; a test that cannot tell them apart cannot say that.
+
+load test_helper
+
+SANDBOX_TOOLS=(bash dirname mktemp mkfifo chmod rm rmdir sed cp cat grep python3 uname)
+
+setup() {
+  setup_test_env
+
+  STUB_SRC="$BATS_TEST_TMPDIR/stubs"
+  mkdir -p "$STUB_SRC"
+
+  cat > "$STUB_SRC/curl" <<'STUB'
+#!/usr/bin/env bash
+set -u
+cfg=""; out=""; prev=""
+for arg in "$@"; do
+  case "$prev" in
+    -K) cfg="$arg" ;;
+    -o) out="$arg" ;;
+  esac
+  prev="$arg"
+done
+[ -z "${STUB_CURL_STDERR:-}" ] || printf '%s\n' "$STUB_CURL_STDERR" >&2
+if [ "${STUB_CURL_MODE:-ok}" = "fail" ]; then
+  exit 7
+fi
+# The GET helper sends the team in a header and expects a body back; nothing
+# here dumps headers, which is one of the shape differences from the POST side.
+grep -q '^header = "Agmsg-Team-ID: ' "$cfg" || { echo "STUB_CURL: no team header" >&2; exit 2; }
+[ -z "$out" ] || printf '{"teams":[]}' > "$out"
+printf '200'
+STUB
+  chmod +x "$STUB_SRC/curl"
+}
+
+teardown() { teardown_test_env; }
+
+sandbox_path() {
+  local dir tool src
+  dir="$(mktemp -d "$BATS_TEST_TMPDIR/sandbox.XXXXXX")"
+  for tool in "${SANDBOX_TOOLS[@]}"; do
+    src="$(command -v "$tool")" || { echo "host lacks $tool" >&2; return 1; }
+    ln -s "$src" "$dir/$tool"
+  done
+  ln -s "$STUB_SRC/curl" "$dir/curl"
+  printf '%s' "$dir"
+}
+
+get_with_curl() {
+  local mode="$1" stderr_text="$2"
+  RUN_TMPDIR="$(mktemp -d "$BATS_TEST_TMPDIR/run.XXXXXX")"
+  ERR_FILE="$BATS_TEST_TMPDIR/helper-stderr"
+  local bin; bin="$(sandbox_path)"
+
+  run env PATH="$bin" TMPDIR="$RUN_TMPDIR" STUB_CURL_MODE="$mode" \
+    STUB_CURL_STDERR="$stderr_text" bash -c '
+    set -uo pipefail
+    . '"$SCRIPTS"'/remote.sh 2>/dev/null
+    _remote_http_get_json "https://example.invalid/v1/teams" "team-abc" \
+      "'"$RUN_TMPDIR"'/out-body" 2>"'"$ERR_FILE"'"
+  '
+}
+
+@test "GET: a failing curl's diagnosis reaches the caller's stderr (#850)" {
+  # `pull` is the command a person runs here, and before this it could only say
+  # 000 -- the same 000 as a refused connection, a timeout, or an unopenable
+  # path.
+  get_with_curl fail "curl: (7) Failed to connect to example.invalid port 443"
+  [ "$status" -eq 0 ]
+  [ "$output" = "000" ]
+
+  grep -q 'Failed to connect' "$ERR_FILE"
+}
+
+@test "GET: a successful curl's stderr is NOT shown, even when it wrote something (#850)" {
+  # Tells "shown only when curl failed" apart from "the stream was empty". The
+  # stub deliberately writes on the success path; real curl -sS would not, and
+  # a quiet stub would pass against an unconditional dump.
+  get_with_curl ok "a progress line nobody asked for"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  [ ! -s "$ERR_FILE" ]
+}
+
+@test "GET: the http code is unchanged on both paths (#850)" {
+  get_with_curl ok ""
+  [ "$output" = "200" ]
+
+  get_with_curl fail "curl: (28) Operation timed out"
+  [ "$output" = "000" ]
+}
+
+@test "GET: no scratch file is left behind, on either path (#850)" {
+  # This helper writes a config and now an error file, and removes both. Each
+  # run gets a private TMPDIR so the question is about this call only.
+  # THE NAME MATTERS. An earlier version globbed agmsg-curl-cfg.* and
+  # agmsg-curl-err.*, which this layout never creates -- the check would pass on
+  # any behaviour at all, including a leaked directory. An absence assertion
+  # aimed at a name nothing uses is indistinguishable from a clean run.
+  get_with_curl ok ""
+  [ "$output" = "200" ]
+  refute ls -d "$RUN_TMPDIR"/agmsg-curl.* 2>/dev/null
+
+  get_with_curl fail "curl: (28) Operation timed out"
+  [ "$output" = "000" ]
+  refute ls -d "$RUN_TMPDIR"/agmsg-curl.* 2>/dev/null
+}
+
+@test "GET: a diagnosis that cannot be written does not change the outcome (#850)" {
+  # The POST side shipped this case asserting the OPPOSITE, and review turned it
+  # around: the diagnosis was one fatal `&& && cat`, so a failing `cat` ended the
+  # function before the cleanup and before the code was printed. Being unable to
+  # EXPLAIN a failure must not turn it into a DIFFERENT failure.
+  #
+  # This helper has no fifo and no copier, so there is nothing to reap -- the
+  # two things that must survive a failed write are the code and the cleanup.
+  RUN_TMPDIR="$(mktemp -d "$BATS_TEST_TMPDIR/run.XXXXXX")"
+  local bin; bin="$(sandbox_path)"
+
+  # The symlink is removed before writing: `>` follows a symlink to its target,
+  # which here would be the system's own /bin/cat.
+  rm -f "$bin/cat"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$bin/cat"
+  chmod +x "$bin/cat"
+
+  run env PATH="$bin" TMPDIR="$RUN_TMPDIR" STUB_CURL_MODE=fail \
+    STUB_CURL_STDERR="curl: (7) Failed to connect" bash -c '
+    set -euo pipefail
+    . '"$SCRIPTS"'/remote.sh 2>/dev/null
+    _remote_http_get_json "https://example.invalid/v1/teams" "team-abc" \
+      "'"$RUN_TMPDIR"'/out-body"
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" = "000" ]
+
+  refute ls -d "$RUN_TMPDIR"/agmsg-curl.* 2>/dev/null
+}
+
+@test "GET: a failure while setting up leaves nothing behind either (#850)" {
+  # The window review found: whatever exists before the trap is armed is
+  # unprotected, and there is always a first allocation. There is now exactly
+  # one, and everything else is made inside it.
+  #
+  # Driven by making `chmod` fail, which happens after the directory exists and
+  # after the config has been created inside it.
+  RUN_TMPDIR="$(mktemp -d "$BATS_TEST_TMPDIR/run.XXXXXX")"
+  local bin; bin="$(sandbox_path)"
+
+  rm -f "$bin/chmod"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$bin/chmod"
+  chmod +x "$bin/chmod"
+
+  run env PATH="$bin" TMPDIR="$RUN_TMPDIR" bash -c '
+    set -euo pipefail
+    . '"$SCRIPTS"'/remote.sh 2>/dev/null
+    _remote_http_get_json "https://example.invalid/v1/teams" "team-abc" \
+      "'"$RUN_TMPDIR"'/out-body"
+  '
+  [ "$status" -ne 0 ]
+
+  refute ls -d "$RUN_TMPDIR"/agmsg-curl.* 2>/dev/null
+}
+
+@test "GET: the leftover check can see a leftover when there is one (#850)" {
+  # Control on the absence above: a glob matching nothing looks the same as a
+  # glob aimed at the wrong directory.
+  # Planted under the name the helper really mints, so this controls the glob
+  # the absence assertions actually run.
+  get_with_curl ok ""
+  mkdir -p "$RUN_TMPDIR/agmsg-curl.planted"
+  run ls -d "$RUN_TMPDIR"/agmsg-curl.*
+  [ "$status" -eq 0 ]
+}
+
+@test "GET: the request still carries the team header (#850)" {
+  # The contract the stub leans on, asserted rather than assumed. Without this
+  # the stub's own guard could be satisfied by a config that changed shape, and
+  # every case above would be reporting on something other than a GET.
+  get_with_curl ok ""
+  [ "$output" = "200" ]
+  [ -s "$RUN_TMPDIR/out-body" ]
+}


### PR DESCRIPTION
**Describes head `304de04e6f0233824f2ff7f94c4acfc3082db0d6`, based on `main` at `b1e3e05`.**

#903 has landed, so this now targets `main` directly and carries **one commit** — the GET-side change. Everything the POST side contributed is in `main`.

**Rebased, because drift said so.** Measured at the base swap, before touching anything:

```
merge-base = c7f9010 (#903's pre-merge head)
NON-EMPTY: scripts/remote.sh 73 +/-, tests/test_remote_curl_stderr.bats 281 +
```

That drift was my own landed work arriving from the other side — which is exactly the case the rule exists for, since a verdict guarantees the state *after* the change lands, not the lines in it. After the rebase:

```
head    304de04e6f0233824f2ff7f94c4acfc3082db0d6
base    main (b1e3e05)
drift   STRUCTURAL, NOT MEASURED — merge-base == origin/main
tests   16 ok / 0 not ok
```

**The content is unchanged from what was cleared**, measured rather than asserted:

```
$ git range-diff c7f9010..8f1ef78  b1e3e05..304de04
1:  8f1ef78 = 1:  304de04   fix(remote): keep curl's stderr on the GET path …
```

`=` means the commit is identical. The SHA moved, so the verdict naming `8f1ef78` does not cover this head and needs re-issuing; nothing in the change does.

---

---

*(Everything below is historical: it was written when this PR sat on #853 at `1abc96e`. Head references there are not current — the current coordinates are the ones above.)*

Follow-up to #853, and **based on it** rather than on `main`: both touch the same shape in the same file, so stacking keeps the diff honest instead of producing a conflict for whoever lands second.

## What is wrong

#853 stopped the POST helper discarding curl's stderr. `_remote_http_get_json` still did, and the argument is identical — it reports `000` for every kind of failure alike, so without stderr there is nothing anywhere saying why.

**`pull` goes through this path.** A failure there was as undiagnosable as the `connect` one that cost a Windows run its afternoon. The Windows fix did not reach it, because that work was scoped to the helper the failure happened to land in.

## What does NOT apply here, said explicitly

Unlike the POST helper, this one **embeds no paths in its curl config**. The output file arrives via `-o`, which is curl's own argv, and MSYS does translate argv for a native binary. So #851's defect never reached this function — only the diagnosability one did.

Worth stating because "the Windows fix missed a spot" would be the wrong reading. Two different problems shared one helper; only one of them was in both.

## Scope

With this, **no curl call in the file discards its stderr** — verified by grep, not by eye:

```
curl calls still discarding stderr: 0
```

## What was verified

`tests/test_remote.bats` — 122 ok / 0 not ok, on this branch.

**Green was not evidence anything was diagnosed.** When this was written, no test asserted on curl's stderr — that is no longer true, and the tests added since are described at the end of this body. What green establishes is that capturing it, and emitting it only on failure, leaves every existing caller's behaviour and every reported HTTP code unchanged.

This one is not gated on a platform: it changes the same way everywhere, which is also why the suite is a more meaningful check here than on #851 or #852.

## Not measured

**A team with an existing store has not been migrated on Windows**, on this path or any other. The verified Windows run was a fresh team.


---

## Tests, added at `c7ddd16d7d4b`

`tests/test_remote_curl_stderr_get.bats` — **6 ok / 0 not ok**, driving the production `_remote_http_get_json`. Production untouched; the diff is this one file.

**A separate file from #853's, not a parameterised one over both helpers.** These are two functions with two shapes — the GET side has no fifo, no copier, its own trap and its own cleanup — and they were split into two pull requests precisely so a mutation in one cannot be covered by the other's tests. Sharing a file puts that back: reverting the GET change would redden a case whose name says POST.

| case | |
|---|---|
| failing curl | the diagnosis reaches the caller's stderr |
| succeeding curl | nothing does — and the stub wrote to stderr anyway |
| both | the http code is unchanged, 200 and 000 |
| both | no scratch file left in the run's own TMPDIR |
| control | the leftover check fires on a planted leftover |
| shape | the request still carries the team header, so the rows above are reporting on a GET |

| mutation | red |
|---|---|
| M0 no mutation | **0** |
| M1 `2>/dev/null` restored | the diagnosis reaches stderr |
| M2 stderr shown on success too | success stays quiet |
| M3 the error file never removed | no scratch left behind |
| M4 failure reports curl's exit code | the code contract, and the two cases that read it |

**Every mutation is confined to the GET function's line range**, re-derived from the file each round. On this branch the POST helper carries the same lines verbatim, so a file-wide substitution would have mutated #853's fix and reported the result here.

### The first run of that matrix was wrong

Worth recording rather than quietly re-running. The perl replacements contained `$curl_err` and `$curl_status` unescaped, so perl expanded them as its own variables — to nothing. M2 became *"test an empty string"* and M4 *"assign an empty code"*, neither of which is the mutation the label names.

Both still produced red, and the red looked plausible. What gave it away was M2 reddening the **failure** case instead of the success case. A mutation that does something other than what its label says is a false row in the table, not a stricter one.

## Not covered

**The signal path**, exactly as in #853: the scratch file is removed on both normal paths, the trap does not name it, and what I have is a reading of the trap's text rather than a measurement — the probe hung on this host. Adding `curl_err` to the trap is one line and it changes the fix, so it is the author's call.

**Windows** is unverified by me.


---

## Rebased, tested, and given the same trap fix — at `fa3ccdfa8060`

**New coordinates**, since this PR is stacked:

```
base   d59284c11e38c244615b9324347bed955f4c8236   (#853's head: the POST fix + its tests)
head   fa3ccdfa80606d9a01d71309503697b6d29cdff8
```

Two commits were replayed onto that base. The old base `1c833bb` is still the second commit of this branch — what moved is where it sits, not what it says.

### The GET helper's trap had the same hole, and the same cause

Review asked for one line: add `curl_err` to the existing trap. That line does not work. An EXIT trap set inside a function runs after the frame is gone, so a single-quoted body expands `$cfg` in the caller's scope, where no local of that name exists — it removes the empty string and returns 0.

```
bash 3.2.57   TRAP SEES: [EMPTY]
bash 5.3.15   TRAP SEES: [EMPTY]
```

This helper's trap held only `$cfg`, and **it has never removed it on an early exit either**. Both the config and the error file are now baked in with `printf %q` at set time, and `curl_err` is created beside the config so it exists before the trap that must sweep it. The measured run behind this is in #853, where all three of that helper's files survived.

### `tests/test_remote_curl_stderr_get.bats` — 7 ok / 0 not ok

| case | |
|---|---|
| failing curl | the diagnosis reaches the caller's stderr |
| succeeding curl | nothing does — and the stub wrote to stderr anyway |
| both | the http code is unchanged, 200 and 000 |
| both | no scratch file left in the run's own TMPDIR |
| early exit | errexit out of the middle sweeps **both** files |
| control | the leftover check fires on a planted leftover |
| shape | the request still carries the team header, so the rows above are reporting on a GET |

The early-exit case is cheaper here than on the POST side: this helper has no fifo and no copier, so nothing can be stranded on `open()` and the run cannot hang. Same property, fewer moving parts.

| mutation | red |
|---|---|
| M0 no mutation | **0** |
| M1 `2>/dev/null` restored | the diagnosis reaches stderr |
| M2 stderr shown on success too | success stays quiet |
| M3 the error file never removed | no scratch left behind |
| M4 failure reports curl's exit code | the code contract, and the two cases that read it |

**Every mutation is confined to the GET function's line range**, re-derived each round: the POST helper on this branch carries the same lines verbatim, so a file-wide substitution would have mutated #853's fix and reported the result here.

**The first run of that matrix was wrong.** The perl replacements had `$curl_err` and `$curl_status` unescaped, so perl expanded them as its own variables — to nothing. M2 became "test an empty string" and M4 "assign an empty code". Both still went red, plausibly; what gave it away was M2 reddening the *failure* case instead of the success case. A mutation that does something other than what its label says is a false row, not a stricter one.

On this head, the POST tests and the existing remote suite run together: **129 ok / 0 not ok**.

**Windows** is unverified by me.


---

> **History from here to the next top-level heading.** It describes `9acc615`, whose base has since been rewritten twice and whose failing-diagnosis contract was the opposite of the current one.

## Update at `9acc615a4839` — one directory here too

**New coordinates**, since this PR is stacked:

```
base   a38d6f8e1430325f1bbf5537348fbd9edeffb6d3   (#853's head)
head   9acc615a4839f9b8c0b5a2a247afcd0c7d652779
```

The window review found applies to this helper as well: it made the config, then the error file, and only then armed the trap, so a failure at the second allocation or at the `chmod` stranded the first. Same shape as the POST side now — acquire one directory, arm the trap on it, make everything inside.

**New case:** make `chmod` fail, after the directory exists and after the config is inside it, and assert nothing survives. Cheaper than the POST side's control, because this helper has no fifo and no copier to strand.

### The absence assertions were aimed at names this layout never creates

They globbed `agmsg-curl-cfg.*` and `agmsg-curl-err.*`; both files now live inside `agmsg-curl.XXXXXX`. Those checks would have passed on any behaviour at all, including a leaked directory. They and their planted-leftover control now use the name the helper really mints.

```
tests/test_remote_curl_stderr_get.bats     8 ok / 0 not ok
POST tests + tests/test_remote.bats      130 ok / 0 not ok   (on this head)
```

The orphaned-copier behaviour on the POST side is filed as **#864** rather than folded into either PR.



---

# Current head: `1abc96eaa60125e888f68cd0459ac9a78a8694e4`

**Rebuilt, not rebased.** The old branch sat on a base that has been rewritten twice since, so both its diff and its verdict were against ground that moved. Everything above is history.

```
base   597d345525efb1b5401b167ac38fdffd973b90fe   (#853's current head)
head   1abc96eaa60125e888f68cd0459ac9a78a8694e4
```

## Everything the POST side learned under review, applied at once

Three review rounds happened on #853. Rather than repeat them here, this head arrives with all three:

- **one directory**, minted before the trap, with the config and the error file inside it
- **the trap's path baked in with `printf %q`**, because an EXIT trap runs after the function's frame is gone and cannot expand its locals (measured on bash 3.2.57 and 5.3.15)
- **the outcome settled BEFORE the diagnosis, and the diagnosis best-effort**

The last one is the finding that mattered. As a single fatal `&&` chain, a failing `cat` — closed stderr, a reader that went away — ends the function: no cleanup, no code. **Being unable to *explain* a failure returned nothing where the contract promises `000`.**

This helper has **no fifo and no copier**, so there is nothing to reap and no `kill`/`wait` seam to instrument. What must survive a failed write is the code and the cleanup, and both are asserted.

## Tests

`tests/test_remote_curl_stderr_get.bats` — **8 ok / 0 not ok**

| case | |
|---|---|
| failing curl | the diagnosis reaches the caller's stderr |
| succeeding curl | nothing does — and the stub wrote to stderr anyway |
| both | the http code is unchanged, 200 and 000 |
| both | no scratch left in the run's own TMPDIR |
| failed write | status 0, `"000"`, and the cleanup still ran |
| setup failure | `chmod` fails after the directory exists — nothing survives |
| control | the leftover check fires on a planted leftover |
| shape | the request still carries the team header |

**The leftover globs name `agmsg-curl.*` now.** They named `agmsg-curl-cfg.*` and `agmsg-curl-err.*`, which this layout never creates — checks that would have passed on any behaviour at all, including a leaked directory. The same mistake the POST side made when the same rename happened under it.

## Where this sits

```
#887  →  main green  →  #886  →  #853  →  this
```

The stack is real: #853 needs #886's harness fix or it is deterministically red, measured both ways. Once main is green and #886 lands, the plan is to repoint all of these at `main` — the head SHAs do not change, so verdicts survive, but **drift has to be re-measured against the new destination** at that moment.

**Windows** is unverified by me.


