### PR TITLE
fix(watch): fold sentinel '-' into the empty session-id path

### DIFF
--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -36,6 +36,7 @@ source "$(cd "$(dirname "$0")" && pwd)/lib/compat.sh"
 # in — notably Grok Build's `monitor` tool, where "$GROK_SESSION_ID" expands to
 # empty — still starts the watcher. project_path and agent_type are required.
 SESSION_ID="${1:-}"
+[ "$SESSION_ID" = "-" ] && SESSION_ID="" # #477: caller sentinel for empty session id
 PROJECT_PATH="${2:?Missing project_path}"
 AGENT_TYPE="${3:?Missing agent_type}"
 ACTIVE_NAME="${4:-}"

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -845,3 +845,24 @@ _record_handover_events() {
   [ "$started" -eq 1 ]
   ! grep -q "Usage: watch.sh" "$out"
 }
+
+# Callers pass "${GROK_SESSION_ID:--}" (and the same pattern for other hosts)
+# so a launcher that drops a quoted-empty first arg cannot shift project/type.
+# watch.sh must fold "-" into the same generated-fallback path as "" (#236).
+@test "watch: sentinel '-' session_id resolves like an empty one (#855)" {
+  local out="$BATS_TEST_TMPDIR/dash-sid.out"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" - "$PROJ" claude-code alice >"$out" 2>&1 3>&- &
+  local pid=$!
+  # Folded to empty => a generated fallback id, so a watch.agmsg-*.pid appears.
+  local i started=0
+  for i in $(seq 1 25); do
+    if ls "$TEST_SKILL_DIR/run"/watch.agmsg-*.pid >/dev/null 2>&1; then started=1; break; fi
+    sleep 0.2
+  done
+  kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
+  [ "$started" -eq 1 ]
+  # No literal "-" session id leaked into the run dir key space.
+  ! ls "$TEST_SKILL_DIR/run"/watch.-*.pid >/dev/null 2>&1
+  ! grep -q "Usage: watch.sh" "$out"
+  ! grep -q "ERROR: unknown agent type" "$out"
+}

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -849,7 +849,7 @@ _record_handover_events() {
 # Callers pass "${GROK_SESSION_ID:--}" (and the same pattern for other hosts)
 # so a launcher that drops a quoted-empty first arg cannot shift project/type.
 # watch.sh must fold "-" into the same generated-fallback path as "" (#236).
-@test "watch: sentinel '-' session_id resolves like an empty one (#855)" {
+@test "watch: sentinel '-' session_id resolves like an empty one (#477)" {
   local out="$BATS_TEST_TMPDIR/dash-sid.out"
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" - "$PROJ" claude-code alice >"$out" 2>&1 3>&- &
   local pid=$!

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -862,7 +862,7 @@ _record_handover_events() {
   kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
   [ "$started" -eq 1 ]
   # No literal "-" session id leaked into the run dir key space.
-  ! ls "$TEST_SKILL_DIR/run"/watch.-*.pid >/dev/null 2>&1
-  ! grep -q "Usage: watch.sh" "$out"
-  ! grep -q "ERROR: unknown agent type" "$out"
+  refute ls "$TEST_SKILL_DIR/run"/watch.-*.pid >/dev/null 2>&1
+  refute grep -q "Usage: watch.sh" "$out"
+  refute grep -q "ERROR: unknown agent type" "$out"
 }


### PR DESCRIPTION
Fixes #855.

Restores the #477 one-line fold of sentinel `-` in `watch.sh`, and the bats case that locked it. Callers that pass `"${GROK_SESSION_ID:--}"` are unchanged. Problem, repro, and why this is not a caller fix are on the issue.

Independently mergeable. #858 no longer contains these commits (unstacked). Cursor monitor still needs this fold at runtime (`"${CURSOR_CONVERSATION_ID:--}"`), so please land this before #858. #858 stays a draft until then.

## Test plan

- [x] `bats tests/test_watch.bats --filter "sentinel '-' session_id"`
- [x] `.github/scripts/check-enforced-assertions.sh` at baseline
- [ ] CI green