### PR TITLE
fix(resolve): map grok-build to grok in the pid walk

### DIFF
--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -236,6 +236,7 @@ _agmsg_agent_binaries() {
     antigravity) echo "antigravity" ;;
     copilot)     echo "copilot" ;;
     opencode)    echo "opencode" ;;
+    grok-build)  echo "grok" ;;
     *)           echo "claude codex gemini" ;;
   esac
 }

--- a/scripts/lib/resolve-project.sh
+++ b/scripts/lib/resolve-project.sh
@@ -228,6 +228,9 @@ agmsg_find_registered_project_variant() {
 }
 
 # Map an agent type to the binary basename(s) its process may carry.
+# Names must be type-distinctive. Do not list `agent`: Homebrew grok-build
+# and the Cursor CLI installer both use that basename (#856). Matching it
+# would attach the wrong pid (#93). The alias is an intentional miss.
 _agmsg_agent_binaries() {
   case "$1" in
     claude-code) echo "claude" ;;

--- a/tests/test_resolve_project.bats
+++ b/tests/test_resolve_project.bats
@@ -435,3 +435,8 @@ setup_git_repo() {
   [ "$result" = "$base/parent" ]
   rm -rf "$base"
 }
+
+@test "agent-binaries: grok-build maps to grok (#859)" {
+  [ "$(_agmsg_agent_binaries grok-build)" = "grok" ]
+  [ "$(_agmsg_agent_binaries claude-code)" = "claude" ]
+}


### PR DESCRIPTION
Fixes #859.

`_agmsg_agent_binaries` has no `grok-build` arm, so the type falls through to `claude codex gemini` and grok-build watchers are not liveness-gated.

Independently mergeable. Split out of #856 because cursor monitor only needs the `cursor-agent` arm. Reading `detect_proc` from the manifest stays #631.

Do not list `agent` (Homebrew grok-build and the Cursor CLI installer share that basename). The policy is on #856; this PR comments the omission.

#858 stays a draft until this and #857 have landed.

## Test plan

- [x] `bats tests/test_resolve_project.bats --filter agent-binaries`
- [x] `bats tests/test_resolve_project.bats`
- [ ] CI green