### PR TITLE
fix(hash): SHA-256 without shasum, and no fingerprint it could not compute (#861)

### DIFF
--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -95,6 +95,14 @@ _key_read_config_field() {
 # callers, which now take the value into a variable of its own before printing
 # it. An empty fingerprint is the worst possible output here -- both people see
 # the same blank and agree.
+#
+# THAT REFUSAL RIDES ON `set -o pipefail`, LINE 2. `agmsg_sha256` is in the
+# middle of this pipeline, and `cut` and `sed` are perfectly happy with the
+# empty input a failed digest leaves them: without pipefail the pipeline exits 0
+# with an empty string, the caller's assignment succeeds, and the label prints
+# with nothing after it. Dropping `pipefail` reddens both "no blank
+# fingerprint" cases in tests/test_key.bats, which is the control for this
+# paragraph -- if you are here because you want to simplify line 2, run them.
 _key_fingerprint() {
   printf '%s' "$1" | agmsg_sha256 | cut -c1-16 | sed 's/\(....\)/\1-/g;s/-$//'
 }

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -35,6 +35,10 @@ source "$SCRIPT_DIR/lib/operator-guidance.sh"
 source "$SCRIPT_DIR/lib/shquote.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/roster-journal.sh"
+# agmsg_sha256 -- `shasum` is absent in Git for Windows' Git Bash, and every
+# digest below is either a fingerprint a human compares or an E2EE checkpoint.
+# shellcheck source=lib/hash.sh
+source "$SCRIPT_DIR/lib/hash.sh"
 
 TEAMS_DIR="$CONNECTION_ROOT/teams"
 CRED_ROOT="$CONNECTION_ROOT/run/remote-credentials"
@@ -86,12 +90,17 @@ _key_read_config_field() {
 # Short, human-comparable digest of a recipient string (SSH-key-fingerprint
 # style grouping) — for the H7 fingerprint-verification step:
 # two people compare this same short string over a separate channel.
+#
+# Fails rather than returning a short string it could not compute: see the
+# callers, which now take the value into a variable of its own before printing
+# it. An empty fingerprint is the worst possible output here -- both people see
+# the same blank and agree.
 _key_fingerprint() {
-  printf '%s' "$1" | shasum -a 256 | cut -c1-16 | sed 's/\(....\)/\1-/g;s/-$//'
+  printf '%s' "$1" | agmsg_sha256 | cut -c1-16 | sed 's/\(....\)/\1-/g;s/-$//'
 }
 
 _key_fingerprint_sha256() {
-  printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  printf '%s' "$1" | agmsg_sha256
 }
 
 # A timestamp alone collides when two epochs are minted within the same
@@ -321,8 +330,17 @@ cmd_generate() {
   _key_write_epoch_locked "$cfg" "$(_key_epoch_json "$key_id" 0 0 "$recipient" null "$created_at")"
   agmsg_lock_release
 
+  # Computed into a variable of its own, NOT inline in the echo. A command
+  # substitution that fails inside a simple command's arguments leaves that
+  # command's own status untouched, so `echo` succeeded and printed the label
+  # with nothing after it. A bare assignment's status IS the substitution's, so
+  # `set -e` stops here instead. (Same reasoning as remote.sh's `existing=` note;
+  # `local fp_short="$(...)"` would put the status back on the declaration and
+  # undo it.)
+  local fp_short
+  fp_short="$(_key_fingerprint "$recipient")"
   echo "Generated a new key for team '$team'."
-  echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+  echo "Recipient fingerprint: $fp_short"
   echo
   # What the key IS, always: true whoever ran this, so it is never held back.
   #
@@ -415,8 +433,10 @@ cmd_show() {
   fi
 
   if [ "$reveal" -eq 0 ]; then
+    local fp_short
+    fp_short="$(_key_fingerprint "$recipient")"
     echo "Team: $team"
-    echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+    echo "Recipient fingerprint: $fp_short"
     echo "Public recipient: $recipient"
     return
   fi
@@ -578,8 +598,10 @@ cmd_import() {
       _key_write_identity_atomic "$cred_dir/$staged_key_id.key" "$identity"
       agmsg_lock_release
       unset identity
+      local fp_short
+      fp_short="$(_key_fingerprint "$recipient")"
       echo "Imported replacement key for team '$team' (key_id=$staged_key_id)."
-      echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+      echo "Recipient fingerprint: $fp_short"
       return
     fi
     # Matches the existing epoch: just store this device's copy of the
@@ -598,8 +620,10 @@ cmd_import() {
   fi
   unset identity
 
+  local fp_short
+  fp_short="$(_key_fingerprint "$recipient")"
   echo "Imported key for team '$team'."
-  echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+  echo "Recipient fingerprint: $fp_short"
 }
 
 cmd_rotate() {
@@ -762,7 +786,7 @@ EOF
     echo "agmsg: could not read the current authority-confirmed epoch snapshot." >&2
     exit 1
   fi
-  previous_snapshot_sha="$(shasum -a 256 "$previous_snapshot" | awk '{print $1}')"
+  previous_snapshot_sha="$(agmsg_sha256 < "$previous_snapshot")"
   rm -f "$previous_snapshot"
   writer_generation="$(agmsg_sqlite_mem \
     "SELECT CAST('$(_agmsg_sqlesc "$(_key_read_config_field "$cfg" '$.remote_key.current.writer_generation')")' AS INTEGER) + 1;")"
@@ -783,8 +807,10 @@ EOF
   fi
   agmsg_lock_release
 
+  local fp_short
+  fp_short="$(_key_fingerprint "$recipient")"
   echo "Generated replacement key for team '$team' (epoch=$next_epoch, key_id=$key_id)."
-  echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+  echo "Recipient fingerprint: $fp_short"
   echo "The private key was not written to the journal; distribute it out of band."
   echo "On an interactive terminal, run:"
   echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/key.sh") show $(agmsg_shq "$team") --key-id $(agmsg_shq "$key_id") --reveal-secret"

--- a/scripts/lib/hash.sh
+++ b/scripts/lib/hash.sh
@@ -124,13 +124,21 @@ _agmsg_sha256_selected() {
 # anywhere near `connect`'s preflight. A list like that is exactly what was
 # already missed once.
 #
-# Memoised, so a command that takes several digests pays for one extra. That is
-# the limit of what this claims: the tool answered correctly when first asked in
-# this process, not that it will keep doing so.
+# RUN BEFORE EVERY DIGEST, AND NOT MEMOISED. It was, on one head, keyed on a
+# shell variable -- which review took apart twice over. The flag was read
+# straight from the environment, so `_AGMSG_SHA256_VERIFIED=1` in a preseeded
+# environment meant "already checked" and skipped the check outright: an
+# undocumented env override that turned a fail-closed contract off. And it did
+# not even work: every production call is `printf | agmsg_sha256` or
+# `x="$(agmsg_sha256 …)"`, both subshells, so the flag never reached the parent
+# and the self-test ran again anyway. The saving was imaginary and the hole was
+# not.
+#
+# So the cost is stated instead of avoided: one extra digest of a 5-byte input
+# per digest taken. The commands that take one take at most three (`key rotate`:
+# fingerprint, journal fingerprint, previous snapshot), and each is already
+# doing file and network work that dwarfs it.
 _agmsg_sha256_selftest() {
-  if [ "${_AGMSG_SHA256_VERIFIED:-0}" = 1 ]; then
-    return 0
-  fi
   local probe
   probe="$(printf '%s' probe | _agmsg_sha256_selected)" || return 1
   if [ "$probe" != 'ba9c736f19e7f60b7f6764adb0b7908c0a2b394e09b6c09863528c7f2bc86095' ]; then
@@ -138,7 +146,6 @@ _agmsg_sha256_selftest() {
     echo "Its answers cannot be used for key fingerprints or encryption checkpoints." >&2
     return 1
   fi
-  _AGMSG_SHA256_VERIFIED=1
 }
 
 agmsg_sha256() {

--- a/scripts/lib/hash.sh
+++ b/scripts/lib/hash.sh
@@ -27,3 +27,73 @@ agmsg_sha1() {
     cksum | awk '{print $1}'
   fi
 }
+
+# Portable SHA-256 of stdin, emitting the bare hex digest.
+#
+# Same absence as above -- `shasum` is not in Git for Windows' Git Bash -- and
+# the same fixed order, so a given machine always answers with one tool:
+#   shasum -a 256 (macOS/Linux) -> sha256sum (Git Bash/Linux) -> openssl.
+#
+# THE LAST RESORT IS DIFFERENT ON PURPOSE, and it is the point of this helper.
+# agmsg_sha1 ends in `cksum` because its callers name a socket after the digest
+# and need only that the same input give the same name on the same machine.
+# These callers need the opposite property. The digest is
+#
+#   * the fingerprint two people read to each other over a separate channel to
+#     confirm they are talking to the key they think they are, and
+#   * the age-v1 checkpoint that says an epoch snapshot is the snapshot it
+#     claims to be.
+#
+# A non-cryptographic stand-in does not weaken those, it makes them say
+# something untrue. So when no tool here can compute SHA-256 this FAILS, and
+# every caller is expected to stop rather than carry an empty or substitute
+# value forward.
+#
+# Do not add a `cksum` arm to "make this consistent with agmsg_sha1". The
+# inconsistency is the decision.
+agmsg_sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 | awk '{print $NF}'
+  else
+    echo "agmsg: no SHA-256 tool found on PATH (looked for shasum, sha256sum, openssl)." >&2
+    echo "One of these is required for key fingerprints and end-to-end-encryption checkpoints." >&2
+    return 1
+  fi
+}
+
+# True when agmsg_sha256 has something to run. Separated so a caller can ASK
+# before it starts, rather than discover it at the digest.
+#
+# The order matters more than it looks: the first SHA-256 in a `connect --e2ee`
+# comes AFTER the team has been registered with the server, so without this the
+# operator's first news of a missing tool is a half-finished connect. Same
+# category as the `age` check next to it -- a prerequisite of end-to-end
+# encryption, not of agmsg -- and asked at the same moment.
+# Probed by RUNNING it, not by `command -v`. The question is whether this
+# machine can produce a SHA-256, and presence on PATH is only a proxy for that:
+# a tool that is installed and fails answers "yes" to the proxy and "no" to the
+# question, which is the direction that hurts -- the preflight passes and the
+# digest fails later, which is the shape of #861 all over again. Costs one
+# subprocess, once, on a command that is about to make a network round trip.
+agmsg_sha256_usable() {
+  local probe
+  probe="$(printf '%s' probe | agmsg_sha256 2>/dev/null)" || return 1
+  [ -n "$probe" ]
+}
+
+# Refuse to proceed without one, with the same install guidance shape the age
+# preflight uses.
+agmsg_require_sha256() {
+  if ! agmsg_sha256_usable; then
+    echo "agmsg: end-to-end encryption needs a SHA-256 tool, and none was found on this device." >&2
+    echo "agmsg looks for 'shasum', then 'sha256sum', then 'openssl'. Install one, then retry:" >&2
+    echo "  macOS (Homebrew):      brew install openssl" >&2
+    echo "  Debian/Ubuntu:         sudo apt install coreutils" >&2
+    echo "  Windows (Git Bash):    ships with Git for Windows; reinstall it if 'sha256sum' is missing" >&2
+    return 1
+  fi
+}

--- a/scripts/lib/hash.sh
+++ b/scripts/lib/hash.sh
@@ -51,18 +51,61 @@ agmsg_sha1() {
 #
 # Do not add a `cksum` arm to "make this consistent with agmsg_sha1". The
 # inconsistency is the decision.
+#
+# THE FAILURE IS THE HELPER'S OWN, not the caller's shell options. Written as
+# `shasum -a 256 | awk …` this function's status was the status of `awk`, which
+# is delighted by the empty input a failed digest hands it — so "this FAILS"
+# held only because `key.sh` and `remote.sh` happen to `set -o pipefail` on
+# their second line. A caller without it got an empty success and carried it
+# into a fingerprint. Each tool is now run as its own command substitution with
+# its status checked here, so the refusal travels with the function.
+#
+# WHICH ARM RUNS IS DECIDED BY PRESENCE, AND A CHOSEN ARM THAT FAILS IS THE END.
+# The fallback exists for a tool that is ABSENT, not for one that is broken:
+# there is no second attempt after `shasum` is found and then fails. That is
+# deliberate — a machine whose `shasum` is broken has something wrong with it
+# that a quiet substitution would hide — and it is asserted below, so changing
+# it has to be a decision rather than a drift.
+#
+# The answer is then checked for being 64 lowercase hex. A tool that exits 0 and
+# prints a warning, a path, or an empty line has not failed as far as `$?` is
+# concerned, and this value is not a label: it is what two people read to each
+# other to confirm a key, and what the age-v1 checkpoint pins a snapshot with.
+# Lowercase specifically, because all three arms emit lowercase and a fourth
+# that did not would leave two machines disagreeing about a fingerprint that is
+# "the same".
+#
+# The two checks overlap on purpose and are not redundant: a tool that exits
+# non-zero while still printing a well-formed digest is caught only by the
+# status, and one that exits zero while printing anything else only by the
+# shape. There is a case for each below.
 agmsg_sha256() {
+  local raw
   if command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 | awk '{print $1}'
+    raw="$(shasum -a 256)" || return 1
+    raw="${raw%% *}"
   elif command -v sha256sum >/dev/null 2>&1; then
-    sha256sum | awk '{print $1}'
+    raw="$(sha256sum)" || return 1
+    raw="${raw%% *}"
   elif command -v openssl >/dev/null 2>&1; then
-    openssl dgst -sha256 | awk '{print $NF}'
+    raw="$(openssl dgst -sha256)" || return 1
+    raw="${raw##* }"
   else
     echo "agmsg: no SHA-256 tool found on PATH (looked for shasum, sha256sum, openssl)." >&2
     echo "One of these is required for key fingerprints and end-to-end-encryption checkpoints." >&2
     return 1
   fi
+  case "$raw" in
+    *[!0-9a-f]*|'')
+      echo "agmsg: the SHA-256 tool on PATH answered with something that is not a digest." >&2
+      return 1
+      ;;
+  esac
+  [ "${#raw}" -eq 64 ] || {
+    echo "agmsg: the SHA-256 tool on PATH answered with ${#raw} characters, not a 64-hex digest." >&2
+    return 1
+  }
+  printf '%s\n' "$raw"
 }
 
 # True when agmsg_sha256 has something to run. Separated so a caller can ASK
@@ -79,10 +122,17 @@ agmsg_sha256() {
 # question, which is the direction that hurts -- the preflight passes and the
 # digest fails later, which is the shape of #861 all over again. Costs one
 # subprocess, once, on a command that is about to make a network round trip.
+#
+# Checked against a KNOWN digest, not against "something came back". A tool can
+# exit 0 and print sixty-four characters that are not the SHA-256 of the input,
+# and this probe is what stands between that and a fingerprint two people
+# believe they compared. `agmsg_sha256` refuses anything that is not 64
+# lowercase hex; this adds the only remaining question — whether it is the
+# right hex.
 agmsg_sha256_usable() {
   local probe
   probe="$(printf '%s' probe | agmsg_sha256 2>/dev/null)" || return 1
-  [ -n "$probe" ]
+  [ "$probe" = 'ba9c736f19e7f60b7f6764adb0b7908c0a2b394e09b6c09863528c7f2bc86095' ]
 }
 
 # Refuse to proceed without one, with the same install guidance shape the age

--- a/scripts/lib/hash.sh
+++ b/scripts/lib/hash.sh
@@ -110,7 +110,7 @@ _agmsg_sha256_selected() {
   printf '%s\n' "$raw"
 }
 
-# ASK THE SELECTED TOOL A QUESTION WE KNOW THE ANSWER TO, ONCE PER PROCESS.
+# ASK THE SELECTED TOOL A QUESTION WE KNOW THE ANSWER TO, BEFORE EVERY DIGEST.
 #
 # `_agmsg_sha256_selected` accepts any 64 lowercase hex, which is the shape of
 # a digest and not the proof of one: a tool that exits 0 and prints a plausible
@@ -135,9 +135,11 @@ _agmsg_sha256_selected() {
 # not.
 #
 # So the cost is stated instead of avoided: one extra digest of a 5-byte input
-# per digest taken. The commands that take one take at most three (`key rotate`:
-# fingerprint, journal fingerprint, previous snapshot), and each is already
-# doing file and network work that dwarfs it.
+# per digest taken. The command that takes the most is `key rotate` with an
+# accepted rotation to check -- the accepted recipient's fingerprint, the new
+# recipient's journal fingerprint, the previous snapshot, and the short
+# fingerprint printed at the end: FOUR digests, so eight runs of the tool. Every
+# one of them sits beside file and lock work that dwarfs it.
 _agmsg_sha256_selftest() {
   local probe
   probe="$(printf '%s' probe | _agmsg_sha256_selected)" || return 1
@@ -165,8 +167,9 @@ agmsg_sha256() {
 # machine can produce a SHA-256, and presence on PATH is only a proxy for that:
 # a tool that is installed and fails answers "yes" to the proxy and "no" to the
 # question, which is the direction that hurts -- the preflight passes and the
-# digest fails later, which is the shape of #861 all over again. Costs one
-# subprocess, once, on a command that is about to make a network round trip.
+# digest fails later, which is the shape of #861 all over again. Costs two runs
+# of the tool -- `agmsg_sha256`'s self-test and this probe's own digest -- on a
+# command that is about to make a network round trip.
 #
 # Nothing more than "can this machine produce one", because the correctness
 # question moved into `agmsg_sha256` itself -- a preflight that knows something

--- a/scripts/lib/hash.sh
+++ b/scripts/lib/hash.sh
@@ -79,7 +79,9 @@ agmsg_sha1() {
 # non-zero while still printing a well-formed digest is caught only by the
 # status, and one that exits zero while printing anything else only by the
 # shape. There is a case for each below.
-agmsg_sha256() {
+# The arms and the shape check, without the self-test below -- so the self-test
+# can call it without calling itself.
+_agmsg_sha256_selected() {
   local raw
   if command -v shasum >/dev/null 2>&1; then
     raw="$(shasum -a 256)" || return 1
@@ -108,6 +110,42 @@ agmsg_sha256() {
   printf '%s\n' "$raw"
 }
 
+# ASK THE SELECTED TOOL A QUESTION WE KNOW THE ANSWER TO, ONCE PER PROCESS.
+#
+# `_agmsg_sha256_selected` accepts any 64 lowercase hex, which is the shape of
+# a digest and not the proof of one: a tool that exits 0 and prints a plausible
+# but wrong value is accepted, and that value then becomes a fingerprint two
+# people read to each other, or the checkpoint that says a snapshot is the
+# snapshot it claims to be.
+#
+# The check lives HERE rather than at the callers because the alternative is a
+# list of entry points that must be kept complete -- `key.sh` is its own CLI and
+# `generate`, `show`, `import` and `rotate` all reach a digest without going
+# anywhere near `connect`'s preflight. A list like that is exactly what was
+# already missed once.
+#
+# Memoised, so a command that takes several digests pays for one extra. That is
+# the limit of what this claims: the tool answered correctly when first asked in
+# this process, not that it will keep doing so.
+_agmsg_sha256_selftest() {
+  if [ "${_AGMSG_SHA256_VERIFIED:-0}" = 1 ]; then
+    return 0
+  fi
+  local probe
+  probe="$(printf '%s' probe | _agmsg_sha256_selected)" || return 1
+  if [ "$probe" != 'ba9c736f19e7f60b7f6764adb0b7908c0a2b394e09b6c09863528c7f2bc86095' ]; then
+    echo "agmsg: the SHA-256 tool on PATH returned the wrong digest for a known input." >&2
+    echo "Its answers cannot be used for key fingerprints or encryption checkpoints." >&2
+    return 1
+  fi
+  _AGMSG_SHA256_VERIFIED=1
+}
+
+agmsg_sha256() {
+  _agmsg_sha256_selftest || return 1
+  _agmsg_sha256_selected
+}
+
 # True when agmsg_sha256 has something to run. Separated so a caller can ASK
 # before it starts, rather than discover it at the digest.
 #
@@ -123,24 +161,23 @@ agmsg_sha256() {
 # digest fails later, which is the shape of #861 all over again. Costs one
 # subprocess, once, on a command that is about to make a network round trip.
 #
-# Checked against a KNOWN digest, not against "something came back". A tool can
-# exit 0 and print sixty-four characters that are not the SHA-256 of the input,
-# and this probe is what stands between that and a fingerprint two people
-# believe they compared. `agmsg_sha256` refuses anything that is not 64
-# lowercase hex; this adds the only remaining question — whether it is the
-# right hex.
+# Nothing more than "can this machine produce one", because the correctness
+# question moved into `agmsg_sha256` itself -- a preflight that knows something
+# the digest path does not is the shape of #861, and for one head this function
+# was the only thing checking the answer while `key.sh` reached a digest by four
+# routes that never call it.
 agmsg_sha256_usable() {
-  local probe
-  probe="$(printf '%s' probe | agmsg_sha256 2>/dev/null)" || return 1
-  [ "$probe" = 'ba9c736f19e7f60b7f6764adb0b7908c0a2b394e09b6c09863528c7f2bc86095' ]
+  printf '%s' probe | agmsg_sha256 >/dev/null 2>&1
 }
 
 # Refuse to proceed without one, with the same install guidance shape the age
 # preflight uses.
 agmsg_require_sha256() {
   if ! agmsg_sha256_usable; then
-    echo "agmsg: end-to-end encryption needs a SHA-256 tool, and none was found on this device." >&2
-    echo "agmsg looks for 'shasum', then 'sha256sum', then 'openssl'. Install one, then retry:" >&2
+    echo "agmsg: end-to-end encryption needs a working SHA-256 tool, and this device has none." >&2
+    echo "One may be installed: a tool that is present but fails, or answers a known input" >&2
+    echo "wrongly, is reported here the same way as one that is absent -- neither can be used." >&2
+    echo "agmsg looks for 'shasum', then 'sha256sum', then 'openssl'. Install or repair one:" >&2
     echo "  macOS (Homebrew):      brew install openssl" >&2
     echo "  Debian/Ubuntu:         sudo apt install coreutils" >&2
     echo "  Windows (Git Bash):    ships with Git for Windows; reinstall it if 'sha256sum' is missing" >&2

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -68,6 +68,10 @@ source "$SCRIPT_DIR/lib/node.sh"
 # keyed on watcher-only concepts (session/actas) this engine does not have.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/instance-id.sh"
+# agmsg_sha256 -- the age-v1 checkpoint below is a SHA-256 of the snapshot, and
+# `shasum` is absent in Git for Windows' Git Bash.
+# shellcheck source=lib/hash.sh
+source "$SCRIPT_DIR/lib/hash.sh"
 
 TEAMS_DIR="$CONNECTION_ROOT/teams"
 CRED_ROOT="$CONNECTION_ROOT/run/remote-credentials"
@@ -247,6 +251,23 @@ cmd_doctor() {
     echo "  Debian/Ubuntu:         sudo apt install age"
     echo "  Windows (winget):      winget install FiloSottile.age"
     echo "See https://github.com/FiloSottile/age for other install methods."
+  fi
+  echo
+  # Reported with age, and optional for the same reason: only end-to-end
+  # encryption needs it. Not failed=1 -- a machine syncing with cipher "none"
+  # is fully functional without it. Listed at all because when it IS missing
+  # the symptom lands after the team is registered, which reads like a server
+  # problem rather than a missing tool.
+  if agmsg_sha256_usable; then
+    echo "  [x] SHA-256 tool on PATH  (optional)"
+  else
+    echo "  [ ] SHA-256 tool on PATH  (optional)"
+    echo
+    echo "End-to-end encryption needs one of 'shasum', 'sha256sum' or 'openssl' for key"
+    echo "fingerprints and the age-v1 checkpoint. Remote sync without --e2ee does not use it:"
+    echo "  macOS (Homebrew):      brew install openssl"
+    echo "  Debian/Ubuntu:         sudo apt install coreutils"
+    echo "  Windows (Git Bash):    ships with Git for Windows; reinstall it if 'sha256sum' is missing"
   fi
   echo
   if agmsg_python3_usable; then
@@ -1821,7 +1842,7 @@ _remote_configure_keyed_team() {
     echo "agmsg: could not export the initial age-v1 snapshot for team '$team'; sync was not started." >&2
     return 1
   fi
-  snapshot_sha="$(shasum -a 256 "$snapshot_file" | awk '{print $1}')"
+  snapshot_sha="$(agmsg_sha256 < "$snapshot_file")"
   if ! bash "$SCRIPT_DIR/remote-sync.sh" configure \
       --team "$team" \
       --server "$endpoint" \
@@ -1875,6 +1896,16 @@ cmd_connect() {
       ;;
   esac
   key_id="$(_remote_read_config_field "$cfg" '$.remote_key.current.key_id')"
+  # Asked HERE: before the key is minted and before the registration POST.
+  # Every SHA-256 in the e2ee path -- the fingerprint printed by `key.sh
+  # generate`, and the age-v1 checkpoint that starts the sync engine -- happens
+  # at or after those, so a device without one used to register the team and
+  # only then fail, reporting "binding recorded, sync engine not started" for
+  # what is a missing command-line tool. Same category as the `age` preflight:
+  # a prerequisite of end-to-end encryption, so it is only asked under --e2ee.
+  if [ "$e2ee" -eq 1 ]; then
+    agmsg_require_sha256 || exit 1
+  fi
   if [ "$e2ee" -eq 1 ] && { [ -z "$key_id" ] || [ "$key_id" = "null" ]; }; then
     bash "$SCRIPT_DIR/key.sh" generate "$team" || exit 1
     key_id="$(_remote_read_config_field "$cfg" '$.remote_key.current.key_id')"

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -258,10 +258,13 @@ cmd_doctor() {
   # is fully functional without it. Listed at all because when it IS missing
   # the symptom lands after the team is registered, which reads like a server
   # problem rather than a missing tool.
+  # "usable", not "on PATH": presence and usability are different questions and
+  # this line answers the second one -- a tool that is installed and fails, or
+  # that returns the wrong digest for a known input, reports unusable here.
   if agmsg_sha256_usable; then
-    echo "  [x] SHA-256 tool on PATH  (optional)"
+    echo "  [x] usable SHA-256 tool  (optional)"
   else
-    echo "  [ ] SHA-256 tool on PATH  (optional)"
+    echo "  [ ] usable SHA-256 tool  (optional)"
     echo
     echo "End-to-end encryption needs one of 'shasum', 'sha256sum' or 'openssl' for key"
     echo "fingerprints and the age-v1 checkpoint. Remote sync without --e2ee does not use it:"

--- a/tests/test_hash.bats
+++ b/tests/test_hash.bats
@@ -177,6 +177,141 @@ sha256_under() {
   [[ "$output" == *install* ]]
 }
 
+# THE REFUSAL WITHOUT THE CALLER'S HELP. Every case above runs under
+# `set -euo pipefail`, so none of them can tell "the helper failed" from "the
+# caller's pipefail noticed that the last stage got nothing". This one turns
+# pipefail OFF, which is the shell any caller that has not opted in provides.
+#
+# A PRESENT-BUT-BROKEN TOOL, NOT AN ABSENT ONE. The first version of this case
+# used an empty pathbox and could not fail: with no tool at all the helper takes
+# its `else` branch and returns 1 outright, which never depended on pipefail.
+# It measured nothing, and the mutation that should have reddened it did not.
+# A tool that is FOUND and then fails is the only path where the status of the
+# tool has to survive on its own.
+@test "hash: a broken tool is refused even when the caller has no pipefail" {
+  local shim="$TEST_SKILL_DIR/nopipefail"
+  mkdir -p "$shim"
+  printf '#!/bin/sh\nexit 1\n' > "$shim/shasum"
+  chmod +x "$shim/shasum"
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '
+    set +o pipefail
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+# THE HALF THE SHAPE CHECK CANNOT SEE. A tool that exits non-zero while still
+# printing a well-formed digest passes every check on the answer and is caught
+# only by the status of the tool itself. Without this case, reverting the arms
+# to their piped form changes no result, because the 64-hex check happens to
+# catch every other broken-tool shape.
+@test "hash: a tool that fails while printing a plausible digest is refused" {
+  local shim="$TEST_SKILL_DIR/failsloud"
+  mkdir -p "$shim"
+  printf '#!/bin/sh\ncat >/dev/null\necho "%s  -"\nexit 1\n' "$AGMSG_SHA256" > "$shim/shasum"
+  chmod +x "$shim/shasum"
+  # Control: the digest it prints is the RIGHT one, so nothing about the answer
+  # is what makes this fail.
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c 'printf x | shasum -a 256 | cut -d" " -f1'
+  [ "$output" = "$AGMSG_SHA256" ]
+
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '
+    set +o pipefail
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "hash: and it still answers correctly with no pipefail when a tool is there" {
+  # The other half, so the case above cannot pass by refusing everything.
+  run env PATH="$PATH" "$BASH_BIN" -c '
+    set +o pipefail
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256
+  ' _ "$SCRIPTS"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$AGMSG_SHA256" ]
+}
+
+# EXIT 0 IS NOT A DIGEST. The broken-tool case above uses `exit 1`, which any
+# status check catches. This is the one that gets through a status check: a
+# tool that succeeds and prints something else -- a warning, a path, an empty
+# line -- and whose output would be carried into a fingerprint.
+@test "hash: a tool that exits 0 and prints a non-digest is refused" {
+  local shim="$TEST_SKILL_DIR/liar"
+  mkdir -p "$shim"
+  local tool
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\ncat >/dev/null\necho "warning: cannot read the input"\nexit 0\n' > "$shim/$tool"
+    chmod +x "$shim/$tool"
+  done
+  # Control: it really does exit 0, so a status check alone would pass it.
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c 'printf x | shasum -a 256 >/dev/null'
+  [ "$status" -eq 0 ]
+
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+}
+
+# 64 hex characters that are the WRONG 64. Nothing about the shape of the answer
+# says it is the digest of the input, and this value is the one two people read
+# to each other. The refusal here lives in the probe, not in agmsg_sha256 --
+# which is why the probe checks against a known digest rather than for content.
+@test "hash: a tool returning a well-formed but wrong digest is not usable" {
+  local shim="$TEST_SKILL_DIR/plausible"
+  mkdir -p "$shim"
+  local tool
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\ncat >/dev/null\necho "%s  -"\n' \
+      0000000000000000000000000000000000000000000000000000000000000000 > "$shim/$tool"
+    chmod +x "$shim/$tool"
+  done
+  # Control: agmsg_sha256 itself accepts it, because it IS 64 lowercase hex.
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256
+  ' _ "$SCRIPTS"
+  [ "$status" -eq 0 ]
+  [ "$output" = 0000000000000000000000000000000000000000000000000000000000000000 ]
+
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+}
+
+# THE FALLBACK IS FOR AN ABSENT TOOL, NOT A BROKEN ONE. Presence picks the arm;
+# a chosen arm that fails ends it, and the working tool behind it is not tried.
+# Asserted because it is a decision, and an undocumented decision becomes an
+# accident the first time someone "fixes" it.
+@test "hash: a broken first arm is not rescued by a working later one" {
+  local shim="$TEST_SKILL_DIR/firstbroken"
+  mkdir -p "$shim"
+  printf '#!/bin/sh\nexit 1\n' > "$shim/shasum"
+  chmod +x "$shim/shasum"
+  local box; box="$(pathbox firstbroken-real awk openssl)" || skip "openssl not installed"
+  # Control: openssl alone, in that box, does answer.
+  run sha256_under "$box"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$AGMSG_SHA256" ]
+
+  run env PATH="$shim:$box" "$BASH_BIN" -c '
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
 # agmsg_sha1 is deliberately NOT changed by this work. Asserted here so that
 # "make the two consistent" has to break a test rather than pass review.
 @test "hash: agmsg_sha1 still answers with no digest tool at all (cksum arm)" {

--- a/tests/test_hash.bats
+++ b/tests/test_hash.bats
@@ -264,11 +264,16 @@ sha256_under() {
   [ "$status" -ne 0 ]
 }
 
-# 64 hex characters that are the WRONG 64. Nothing about the shape of the answer
+# 64 hex characters that are the WRONG 64. Nothing about the shape of an answer
 # says it is the digest of the input, and this value is the one two people read
-# to each other. The refusal here lives in the probe, not in agmsg_sha256 --
-# which is why the probe checks against a known digest rather than for content.
-@test "hash: a tool returning a well-formed but wrong digest is not usable" {
+# to each other.
+#
+# THE REFUSAL IS agmsg_sha256'S OWN, not the preflight's. It was the preflight's
+# for one head, which left `key.sh` — its own CLI, four subcommands, none of
+# them going through `connect` — accepting the wrong value. Raised in review.
+# The case now pins both halves: the shape layer accepts it, and the function
+# every caller actually uses does not.
+@test "hash: a tool returning a well-formed but wrong digest is refused" {
   local shim="$TEST_SKILL_DIR/plausible"
   mkdir -p "$shim"
   local tool
@@ -277,13 +282,21 @@ sha256_under() {
       0000000000000000000000000000000000000000000000000000000000000000 > "$shim/$tool"
     chmod +x "$shim/$tool"
   done
-  # Control: agmsg_sha256 itself accepts it, because it IS 64 lowercase hex.
+  # Control: the shape layer accepts it, because it IS 64 lowercase hex. So the
+  # refusal below is the self-test and not something about the answer's form.
   run env PATH="$shim:$PATH" "$BASH_BIN" -c '
     . "$1/lib/hash.sh"
-    printf "%s" agmsg | agmsg_sha256
+    printf "%s" agmsg | _agmsg_sha256_selected
   ' _ "$SCRIPTS"
   [ "$status" -eq 0 ]
   [ "$output" = 0000000000000000000000000000000000000000000000000000000000000000 ]
+
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
 
   run env PATH="$shim:$PATH" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
   [ "$status" -ne 0 ]

--- a/tests/test_hash.bats
+++ b/tests/test_hash.bats
@@ -1,0 +1,183 @@
+#!/usr/bin/env bats
+#
+# agmsg_sha256's fallback chain, exercised by taking the tools away.
+#
+# This suite is unusual for a portability fix and worth saying why: the bug it
+# covers (#861) is `shasum` missing from Git for Windows' Git Bash, and yet
+# NOTHING here needs Windows. The behaviour that broke is selected by
+# `command -v`, so a PATH holding only the tools we choose reproduces each
+# platform's choice exactly, on any platform. Where a capability branch is
+# probed rather than switched on an OS name, the probe is the thing to drive.
+#
+# Every case asserts the same LITERAL digest rather than "the arms agree with
+# each other". Three arms that agree could agree on a wrong answer; the literal
+# says each one computes SHA-256.
+
+load test_helper
+
+# printf '%s' agmsg | sha256sum
+readonly AGMSG_SHA256=5d2d1e5ffb2742e3830c7b49e324852dbcc6c16056d9cc0a900247a403ae60f2
+
+setup() {
+  setup_test_env
+  # Absolute, because the tests below run commands under a PATH that
+  # deliberately does not contain a shell.
+  BASH_BIN="$(command -v bash)"
+  PATHBOX="$TEST_SKILL_DIR/pathbox"
+}
+
+teardown() {
+  teardown_test_env
+}
+
+# pathbox <name> <tool>... -> prints a directory containing ONLY those tools.
+#
+# Symlinks to the real binaries, not copies: a copy that arrives without its
+# executable bit fails every case for a reason that has nothing to do with what
+# is under test, and looks exactly like the fallback working.
+#
+# Returns 1 (and the caller skips) when a tool this machine does not have is
+# asked for -- macOS runners have no `sha256sum`, and a silently-skipped arm
+# that reports success is the failure mode this file exists to avoid.
+pathbox() {
+  local dir="$PATHBOX/$1"; shift
+  mkdir -p "$dir"
+  local tool src
+  for tool in "$@"; do
+    src="$(command -v "$tool")" || return 1
+    ln -sf "$src" "$dir/$tool"
+  done
+  printf '%s' "$dir"
+}
+
+# Run `printf '%s' agmsg | agmsg_sha256` with PATH set to $1 and nothing else.
+sha256_under() {
+  local box="$1"
+  PATH="$box" "$BASH_BIN" -c '
+    set -euo pipefail
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256
+  ' _ "$SCRIPTS"
+}
+
+@test "hash: agmsg_sha256 on the unrestricted PATH returns the real digest" {
+  run sha256_under "$PATH"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$AGMSG_SHA256" ]
+}
+
+# The negative control for every case below it. If a pathbox did NOT hide the
+# tool it claims to hide, the fallback tests would pass without ever leaving
+# the first arm -- green, and measuring nothing.
+@test "hash: a pathbox really does hide the tools it leaves out" {
+  local box; box="$(pathbox control awk)" || skip "awk not found"
+  run env PATH="$box" "$BASH_BIN" -c 'command -v shasum || echo ABSENT'
+  [ "$status" -eq 0 ]
+  [ "$output" = "ABSENT" ]
+  # ...and the positive half: a tool that IS in the box is found.
+  run env PATH="$box" "$BASH_BIN" -c 'command -v awk >/dev/null && echo PRESENT'
+  [ "$output" = "PRESENT" ]
+}
+
+@test "hash: the shasum arm computes SHA-256" {
+  local box; box="$(pathbox shasum awk shasum)" || skip "shasum not installed"
+  run sha256_under "$box"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$AGMSG_SHA256" ]
+}
+
+@test "hash: without shasum it falls through to sha256sum, same value" {
+  local box; box="$(pathbox sha256sum awk sha256sum)" || skip "sha256sum not installed"
+  run sha256_under "$box"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$AGMSG_SHA256" ]
+}
+
+@test "hash: without shasum or sha256sum it falls through to openssl, same value" {
+  local box; box="$(pathbox openssl awk openssl)" || skip "openssl not installed"
+  run sha256_under "$box"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$AGMSG_SHA256" ]
+}
+
+# The whole point of the different last resort. agmsg_sha1 ends in `cksum` and
+# always answers; this one must refuse.
+@test "hash: with no SHA-256 tool at all it FAILS instead of answering" {
+  local box; box="$(pathbox none awk)" || skip "awk not found"
+  # stderr discarded INSIDE: bats' `run` merges the two streams, so the
+  # diagnostic would land in $output and the "nothing was printed" assertion
+  # below would be measuring the error message.
+  run env PATH="$box" "$BASH_BIN" -c '
+    set -euo pipefail
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  # And nothing on stdout: an empty success is the outcome that would be
+  # carried forward as a fingerprint or a checkpoint.
+  [ -z "$output" ]
+}
+
+@test "hash: the failure says which tools were looked for" {
+  local box; box="$(pathbox nonemsg awk)" || skip "awk not found"
+  run env PATH="$box" "$BASH_BIN" -c '
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>&1 >/dev/null
+  ' _ "$SCRIPTS"
+  [[ "$output" == *shasum* ]]
+  [[ "$output" == *sha256sum* ]]
+  [[ "$output" == *openssl* ]]
+}
+
+@test "hash: agmsg_sha256_usable reports what agmsg_sha256 can actually do" {
+  local box; box="$(pathbox usable-no awk)" || skip "awk not found"
+  run env PATH="$box" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+
+  box="$(pathbox usable-yes awk openssl)" || skip "openssl not installed"
+  run env PATH="$box" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
+  [ "$status" -eq 0 ]
+}
+
+# The reason the probe runs the tool instead of asking `command -v`. A digest
+# tool that is installed and broken is exactly the case where a presence check
+# says yes and the digest says no -- and the whole value of a preflight is that
+# it disagrees with nothing later.
+@test "hash: agmsg_sha256_usable says no when the tools are present but broken" {
+  local shim="$TEST_SKILL_DIR/broken"
+  mkdir -p "$shim"
+  local tool
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\nexit 1\n' > "$shim/$tool"
+    chmod +x "$shim/$tool"
+  done
+  # Control first: they ARE on PATH, so a `command -v` probe would say yes.
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c 'command -v shasum >/dev/null && echo PRESENT'
+  [ "$output" = "PRESENT" ]
+
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+}
+
+@test "hash: agmsg_require_sha256 names a way to install one" {
+  local box; box="$(pathbox require awk)" || skip "awk not found"
+  run env PATH="$box" "$BASH_BIN" -c '
+    . "$1/lib/hash.sh"
+    agmsg_require_sha256 2>&1 >/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *install* ]]
+}
+
+# agmsg_sha1 is deliberately NOT changed by this work. Asserted here so that
+# "make the two consistent" has to break a test rather than pass review.
+@test "hash: agmsg_sha1 still answers with no digest tool at all (cksum arm)" {
+  local box; box="$(pathbox sha1 awk cksum)" || skip "cksum not found"
+  run env PATH="$box" "$BASH_BIN" -c '
+    set -euo pipefail
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha1
+  ' _ "$SCRIPTS"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}

--- a/tests/test_hash.bats
+++ b/tests/test_hash.bats
@@ -130,9 +130,11 @@ sha256_under() {
     . "$1/lib/hash.sh"
     printf "%s" agmsg | agmsg_sha256 2>&1 >/dev/null
   ' _ "$SCRIPTS"
-  [[ "$output" == *shasum* ]]
-  [[ "$output" == *sha256sum* ]]
-  [[ "$output" == *openssl* ]]
+  # grep, not `[[ ]]`: a non-last `[[ ]]` cannot fail a test on bash 3.2, so the
+  # first two of three would have been decoration (#670).
+  grep -qF -- shasum <<<"$output"
+  grep -qF -- sha256sum <<<"$output"
+  grep -qF -- openssl <<<"$output"
 }
 
 @test "hash: agmsg_sha256_usable reports what agmsg_sha256 can actually do" {

--- a/tests/test_hash.bats
+++ b/tests/test_hash.bats
@@ -102,8 +102,14 @@ sha256_under() {
 
 # The whole point of the different last resort. agmsg_sha1 ends in `cksum` and
 # always answers; this one must refuse.
+#
+# `cksum` IS in the box on purpose. Without it this test passed a mutation that
+# added the cksum arm -- not because the refusal survived, but because the
+# sandbox had no cksum for the fallback to reach. It was measuring the box, not
+# the decision. On any real machine cksum is present, so that is the shape the
+# test has to run in.
 @test "hash: with no SHA-256 tool at all it FAILS instead of answering" {
-  local box; box="$(pathbox none awk)" || skip "awk not found"
+  local box; box="$(pathbox none awk cksum)" || skip "awk/cksum not found"
   # stderr discarded INSIDE: bats' `run` merges the two streams, so the
   # diagnostic would land in $output and the "nothing was printed" assertion
   # below would be measuring the error message.
@@ -119,7 +125,7 @@ sha256_under() {
 }
 
 @test "hash: the failure says which tools were looked for" {
-  local box; box="$(pathbox nonemsg awk)" || skip "awk not found"
+  local box; box="$(pathbox nonemsg awk cksum)" || skip "awk/cksum not found"
   run env PATH="$box" "$BASH_BIN" -c '
     . "$1/lib/hash.sh"
     printf "%s" agmsg | agmsg_sha256 2>&1 >/dev/null
@@ -130,7 +136,7 @@ sha256_under() {
 }
 
 @test "hash: agmsg_sha256_usable reports what agmsg_sha256 can actually do" {
-  local box; box="$(pathbox usable-no awk)" || skip "awk not found"
+  local box; box="$(pathbox usable-no awk cksum)" || skip "awk/cksum not found"
   run env PATH="$box" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
   [ "$status" -ne 0 ]
 
@@ -160,7 +166,7 @@ sha256_under() {
 }
 
 @test "hash: agmsg_require_sha256 names a way to install one" {
-  local box; box="$(pathbox require awk)" || skip "awk not found"
+  local box; box="$(pathbox require awk cksum)" || skip "awk/cksum not found"
   run env PATH="$box" "$BASH_BIN" -c '
     . "$1/lib/hash.sh"
     agmsg_require_sha256 2>&1 >/dev/null

--- a/tests/test_hash.bats
+++ b/tests/test_hash.bats
@@ -302,6 +302,33 @@ sha256_under() {
   [ "$status" -ne 0 ]
 }
 
+# NOTHING IN THE ENVIRONMENT CAN SAY "ALREADY CHECKED". The self-test was
+# memoised on one head, keyed on a plain shell variable that was read from the
+# environment — so exporting it turned the check off, which is an undocumented
+# override of a fail-closed contract. The memo is gone; this case is what stops
+# it coming back in a form that can be preseeded.
+#
+# Every plausible name is tried, because guessing the private name of a future
+# memo is not the point: the property is that NO inherited variable skips it.
+@test "hash: a preseeded environment cannot skip the self-test" {
+  local shim="$TEST_SKILL_DIR/preseeded"
+  mkdir -p "$shim"
+  local tool
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\ncat >/dev/null\necho "%s  -"\n' \
+      2222222222222222222222222222222222222222222222222222222222222222 > "$shim/$tool"
+    chmod +x "$shim/$tool"
+  done
+  run env PATH="$shim:$PATH" \
+    _AGMSG_SHA256_VERIFIED=1 AGMSG_SHA256_VERIFIED=1 _AGMSG_SHA256_OK=1 \
+    "$BASH_BIN" -c '
+      . "$1/lib/hash.sh"
+      printf "%s" agmsg | agmsg_sha256 2>/dev/null
+    ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
 # THE FALLBACK IS FOR AN ABSENT TOOL, NOT A BROKEN ONE. Presence picks the arm;
 # a chosen arm that fails ends it, and the working tool behind it is not tried.
 # Asserted because it is a decision, and an undocumented decision becomes an

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -695,8 +695,38 @@ break_the_digest() {
   refute grep -qE 'Recipient fingerprint: *$' <<<"$output"
 }
 
-# The control for the two above: with the digest working, the same commands
-# print a fingerprint that is actually there. Without this, both tests would
+# A TOOL THAT SUCCEEDS AND LIES. The shim above exits 1, which any status check
+# catches. This one exits 0 and prints a well-formed digest that is not the
+# digest of the input — and `key.sh` is its own CLI: `generate`, `show`,
+# `import` and `rotate` all reach a digest without passing `connect`'s
+# preflight, so for one head the preflight was the only thing asking whether the
+# answer was right and none of these four asked it. Raised in review.
+#
+# Driven from `key.sh` deliberately, not from the helper: the claim is about
+# what this command does, and a helper-level case cannot fail if a caller stops
+# using the helper.
+@test "key generate: a tool that returns the wrong digest stops the command" {
+  skip_if_no_age
+  local shim="$TEST_SKILL_DIR/lying-digest"
+  mkdir -p "$shim"
+  local tool
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\ncat >/dev/null\necho "%s  -"\n' \
+      1111111111111111111111111111111111111111111111111111111111111111 > "$shim/$tool"
+    chmod +x "$shim/$tool"
+  done
+  # Control: it exits 0 and its answer has the shape of a digest, so nothing
+  # short of asking a question with a known answer distinguishes it.
+  run env PATH="$shim:$PATH" bash -c 'printf x | shasum -a 256'
+  [ "$status" -eq 0 ]
+
+  run env PATH="$shim:$PATH" bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -ne 0 ]
+  refute grep -qE '1111111111111111' <<<"$output"
+}
+
+# The control for the three above: with the digest working, the same commands
+# print a fingerprint that is actually there. Without this, they would all
 # still pass if key.sh had simply stopped working entirely.
 @test "key generate: the working case still prints a non-empty fingerprint" {
   skip_if_no_age

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -651,6 +651,60 @@ PY_BIND
   [[ "$output" == *"no current key"* ]]
 }
 
+# --- fingerprint: never print one that was not computed (#861) -------------
+
+# A recipient fingerprint exists so two people can read the same short string
+# to each other over a separate channel and agree they hold the same key. If
+# the digest cannot be computed, BOTH of them see an empty string and both say
+# it matches. That is worse than no fingerprint at all, so a digest that fails
+# has to stop the command rather than print a label with nothing after it.
+#
+# Driven by making the first digest arm fail rather than by emptying PATH:
+# key.sh needs a dozen other tools to reach this line, and a PATH restricted
+# far enough to hide `shasum` would stop it long before the fingerprint for
+# reasons that have nothing to do with #861.
+break_the_digest() {
+  local shim="$TEST_SKILL_DIR/broken-digest"
+  mkdir -p "$shim"
+  # All three arms, so this does not quietly become "the second arm answered".
+  local tool
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\nexit 1\n' > "$shim/$tool"
+    chmod +x "$shim/$tool"
+  done
+  printf '%s' "$shim"
+}
+
+@test "key generate: a digest that fails stops the command, no blank fingerprint" {
+  skip_if_no_age
+  local shim; shim="$(break_the_digest)"
+  run env PATH="$shim:$PATH" bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -ne 0 ]
+  # The label must not appear with an empty value after it. Matching the label
+  # plus end-of-line is the whole point: `*"Recipient fingerprint:"*` would be
+  # satisfied by exactly the broken output this test exists to reject.
+  refute grep -qE 'Recipient fingerprint: *$' <<<"$output"
+}
+
+@test "key show: a digest that fails stops the command, no blank fingerprint" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  local shim; shim="$(break_the_digest)"
+  run env PATH="$shim:$PATH" bash "$SCRIPTS/key.sh" show testteam
+  [ "$status" -ne 0 ]
+  refute grep -qE 'Recipient fingerprint: *$' <<<"$output"
+}
+
+# The control for the two above: with the digest working, the same commands
+# print a fingerprint that is actually there. Without this, both tests would
+# still pass if key.sh had simply stopped working entirely.
+@test "key generate: the working case still prints a non-empty fingerprint" {
+  skip_if_no_age
+  run bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qE 'Recipient fingerprint: [0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}$'
+}
+
 # --- dispatch --------------------------------------------------------------
 
 @test "key.sh: unknown subcommand prints usage and exits non-zero" {

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2597,6 +2597,61 @@ PY
   [[ "$output" == *"Some checks failed"* ]]
 }
 
+# --- SHA-256 availability (#861) -------------------------------------------
+
+# All three arms present but failing. Shadowing rather than emptying PATH:
+# connect needs most of the toolchain to reach the point under test, and a
+# PATH stripped far enough to hide these would stop it much earlier for
+# reasons that have nothing to do with #861.
+broken_digest_path() {
+  local dir tool
+  dir="$(mktemp -d)"
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\nexit 1\n' > "$dir/$tool"
+    chmod +x "$dir/$tool"
+  done
+  printf '%s' "$dir"
+}
+
+@test "remote doctor: reports a SHA-256 tool, and its absence does not fail the run" {
+  local broken; broken="$(broken_digest_path)"
+  run env PATH="$broken:$PATH" bash "$SCRIPTS/remote.sh" doctor
+  # Optional, exactly like age: a team on cipher "none" never computes one.
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[ ] SHA-256 tool on PATH"* ]]
+  [[ "$output" == *"All checks passed"* ]]
+}
+
+@test "remote doctor: reports the SHA-256 tool as present when one works" {
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[x] SHA-256 tool on PATH"* ]]
+}
+
+# The bug this preflight exists for: the first SHA-256 in a `connect --e2ee`
+# happens after the team is registered with the server, so the operator's news
+# of a missing tool arrived as a half-finished connect.
+@test "remote connect --e2ee: refuses BEFORE registering when no SHA-256 works" {
+  local broken; broken="$(broken_digest_path)"
+  run env PATH="$broken:$PATH" bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SHA-256"* ]]
+  # And the team is still unregistered. This is the half that makes it a
+  # PREflight: asserting only the message would pass just as well if the
+  # check ran after the POST.
+  run python3 -c "import json;print(json.load(open('$SCRIPTS/../teams/testteam/config.json')).get('remote_binding'))"
+  [ "$output" = "None" ]
+}
+
+# Plain sync never computes a SHA-256, so the same broken machine must still
+# be able to connect. Without this the preflight could be moved ahead of the
+# --e2ee test and nothing would notice.
+@test "remote connect without --e2ee: a broken SHA-256 tool does not block it" {
+  local broken; broken="$(broken_digest_path)"
+  run env PATH="$broken:$PATH" bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  [ "$status" -eq 0 ]
+}
+
 @test "remote pull: a name is enough — no UUID is carried by hand" {
   # The team_id requirement existed to stand in for authentication, and this
   # server has none to stand in for. The second machine should never need a

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2618,7 +2618,7 @@ broken_digest_path() {
   run env PATH="$broken:$PATH" bash "$SCRIPTS/remote.sh" doctor
   # Optional, exactly like age: a team on cipher "none" never computes one.
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[ ] SHA-256 tool on PATH"* ]]
+  grep -qF -- '[ ] SHA-256 tool on PATH' <<<"$output"
   [[ "$output" == *"All checks passed"* ]]
 }
 
@@ -2635,7 +2635,7 @@ broken_digest_path() {
   local broken; broken="$(broken_digest_path)"
   run env PATH="$broken:$PATH" bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam
   [ "$status" -ne 0 ]
-  [[ "$output" == *"SHA-256"* ]]
+  grep -qF -- 'SHA-256' <<<"$output"
   # And the team is still unregistered. This is the half that makes it a
   # PREflight: asserting only the message would pass just as well if the
   # check ran after the POST.

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2618,14 +2618,17 @@ broken_digest_path() {
   run env PATH="$broken:$PATH" bash "$SCRIPTS/remote.sh" doctor
   # Optional, exactly like age: a team on cipher "none" never computes one.
   [ "$status" -eq 0 ]
-  grep -qF -- '[ ] SHA-256 tool on PATH' <<<"$output"
-  [[ "$output" == *"All checks passed"* ]]
+  # "usable", not "on PATH": this shim IS on PATH and fails when run, which is
+  # the distinction the line was reworded to keep -- see hash.sh.
+  grep -qF -- '[ ] usable SHA-256 tool' <<<"$output"
+  # grep, not `[[ ]]`: a non-last `[[ ]]` cannot fail a test on bash 3.2 (#670).
+  grep -qF -- 'All checks passed' <<<"$output"
 }
 
-@test "remote doctor: reports the SHA-256 tool as present when one works" {
+@test "remote doctor: reports the SHA-256 tool as usable when one works" {
   run bash "$SCRIPTS/remote.sh" doctor
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[x] SHA-256 tool on PATH"* ]]
+  grep -qF -- '[x] usable SHA-256 tool' <<<"$output"
 }
 
 # The bug this preflight exists for: the first SHA-256 in a `connect --e2ee`


### PR DESCRIPTION
Fixes #861.

`connect --e2ee` on Git for Windows registered the team with the server and then died on the way to the sync engine. One absent command explains it: `shasum` is a Perl script that ships on macOS and most Linux and is not in Git for Windows' Git Bash.

## Change classification

**Behaviour changes for existing users.** A path that could not be walked on Windows now can be. Nothing changes on macOS or Linux: `shasum` is still the first arm and returns the same digests it always did.

## The repository already knew

`scripts/lib/hash.sh` exists for exactly this reason, and its comment describes the output seen this week — *"NOT in Git for Windows Git Bash, where it fails with `shasum: command not found`, leaving the hash empty"*. It was written for SHA-1 only. The SHA-256 sites never got the same treatment.

## What was changed, derived rather than taken on report

`git grep shasum -- scripts/` gives six invocations across five files. Four are SHA-256 in production and all four now go through a new `agmsg_sha256`:

| site | what the digest is |
|---|---|
| `key.sh` `_key_fingerprint` | the short string two people compare over a separate channel |
| `key.sh` `_key_fingerprint_sha256` | the fingerprint recorded in the roster journal |
| `key.sh` rotate | the previous-snapshot digest that anchors a new epoch |
| `remote.sh` | the age-v1 checkpoint that starts the sync engine |

The fifth is `hash.sh`'s own SHA-1 arm, unchanged. The sixth is `scripts/release/update-cask.sh`, which downloads a `.dmg` and pushes a Homebrew tap — it cannot run on the platform this is about, so it is deliberately left alone rather than converted for symmetry.

## The last resort is different from the SHA-1 helper, on purpose

`agmsg_sha1` falls through to `cksum` because its callers name a socket after the digest and need only that the same input give the same name on the same machine. These callers need the opposite property: one value is a fingerprint two people read to each other to confirm they hold the same key, the other decides whether an epoch snapshot is the one it claims to be. A non-cryptographic stand-in there does not weaken the check — it makes it assert something untrue.

So `agmsg_sha256` ends by failing, and says so in a comment, because the obvious next edit is to make the two helpers consistent.

## A fingerprint that could not be computed is worse than none

The five print sites read `echo "Recipient fingerprint: $(_key_fingerprint ...)"`. A command substitution that fails inside a simple command's arguments leaves that command's own status alone — so `echo` succeeded and printed the label with nothing after it. The entire purpose of that string is that two people compare it, and both would have seen the same blank and agreed.

Making the helper fail is not enough to fix this; the call site has to be able to notice. Each one now takes the value into a variable of its own first, where a bare assignment's status **is** the substitution's and `set -e` stops. Not `local x="$(...)"`, which puts the status back on the declaration and undoes it.

## Preflighted before registration, not only in `doctor`

Every SHA-256 in the e2ee path happens at or after key generation, which is after the team is registered — which is why the symptom read as a server problem rather than a missing tool. The check is now asked before both. `doctor` also reports it, as optional and next to `age`, for the same reason: a team on cipher `none` never computes one.

The probe runs the digest rather than asking `command -v`. A tool that is installed and broken answers yes to a presence check and no to the question, and that is the direction that hurts — the preflight passes and the digest fails later, which is the shape of this bug again.

## Left alone deliberately

`remote.sh`'s fail-closed structure. An empty digest made the checkpoint invalid, setup refused, and connect reported "binding recorded, sync engine not started" without ever falling back to plaintext. That behaviour was correct. It was the digest that was wrong, and with a digest it can compute, this path now simply completes.

## Unlike the sibling Windows fix, this one is verified here

The behaviour is selected by `command -v`, not by an OS name, so a PATH holding only the tools we choose reproduces each platform's choice on any platform. **What that buys is bounded, and the boundary is worth stating: the arms, the refusal and the shape of each answer are host-independent and are measured here. Whether Git for Windows' `sha256sum` is on a given operator's PATH is not, and no run here says anything about it.**

Each arm is asserted against a literal digest rather than against the other arms — three arms that agree can agree on a wrong answer. The suite carries its own negative control (that a restricted PATH really does hide what it claims to hide) and covers the case that motivated the run-it probe: tools present and failing.

## Mutation results

Green means nothing on its own, so each part of the change was reverted in turn to see whether anything noticed. Every row turned red, and each mutation hits its own case:

| reverted | went red |
|---|---|
| drop the `sha256sum` arm | falls through to sha256sum |
| drop the `openssl` arm | falls through to openssl (+ the usable probe) |
| fall back to `cksum` instead of failing | fails instead of answering, the message, the usable probe, the preflight |
| `shasum` without `-a 256` | both literal-digest cases, and an existing key-rotate test |
| probe by presence, not by running it | present-but-broken, and both connect/doctor cases |
| fingerprint back inline in `echo` (generate) | generate: no blank fingerprint |
| fingerprint back inline in `echo` (show) | show: no blank fingerprint |
| remove the connect preflight | refuses before registering |
| `doctor` always claims a tool | doctor reports its absence |
| **drop `set -o pipefail` from `key.sh`** | **both no-blank-fingerprint cases, and nothing else** |
| **arms back to `tool \| awk`** | a tool that fails while printing a plausible digest |
| **drop the 64-lowercase-hex check** | a tool that exits 0 and prints a warning |
| **`usable` back to "something came back"** | a tool returning a well-formed but wrong digest |
| **a broken first arm falls through to a later one** | all three broken-first-arm cases |
| **drop the known-answer self-test from the helper** | `key generate` with a lying tool, and the helper's own case |
| **memoise the self-test on a shell variable** | a preseeded environment cannot skip it |

**Three rows were re-measured after the instrument changed.** Four assertions were rewritten to `grep -qF` for the enforceable-assertions check, which means the earlier table was taken with a different instrument than the one now in the tree. The three rows those assertions could touch were run again on `542c2ff`: `cksum` instead of failing (4 cases red — the refusal, the message, the usable probe, the install guidance), removing the connect preflight (its case, and only its case), and `doctor` always claiming a tool (its case, and only its case). The other six rows stand as taken.

**The last row is the mechanism, and it was not obvious.** `_key_fingerprint` is `printf | agmsg_sha256 | cut | sed`, and `cut` and `sed` are perfectly content with the empty input a failed digest leaves them — so the pipeline's own status is `sed`'s, which is 0. Taking the value into a variable of its own is necessary but not sufficient; what makes the assignment fail is `pipefail`, on line 2, three hundred lines away from the code it protects. Replacing `set -euo pipefail` with `set -eu` reddens exactly the two cases that exist to forbid a blank fingerprint. `key.sh` now says so where the pipeline is.

**One mutation run was thrown away.** The first attempt at the `cksum` row dropped a closing quote, `bash -n` failed, and nine of eleven cases went red — a red from a script that does not parse, which says nothing about any assertion. The harness now runs `bash -n` over all three scripts before it will report a result.

The `cksum` row is worth naming: the first time it ran, it changed nothing. The sandbox PATH held only `awk`, so the mutant's `cksum` was not found either and the assertion passed for a reason unrelated to the decision under test — it was measuring the box, not the behaviour. `cksum` is present on every machine this runs on, so the sandbox now holds it too, and that row is the one it should be.

## The helper's refusal was the caller's, and its answer was unchecked

Static review found the shape this PR describes in `key.sh` sitting one level below it, in the helper itself. `shasum -a 256 | awk '{print $1}'` makes the function's status `awk`'s, and `awk` is content with the empty input a failed digest hands it — so "no tool, or a broken one, and this FAILS" held only because both callers happen to `set -o pipefail` on line 2. Each tool now runs as its own command substitution with its status checked, and the refusal travels with the function.

Nothing looked at the answer either. A tool that exits 0 while printing a warning has not failed as far as `$?` is concerned, and this value is the one two people read to each other. The helper now requires 64 lowercase hex, and `agmsg_sha256_usable` compares against the known digest of its own probe input rather than asking whether anything came back — sixty-four characters that are the wrong sixty-four is the case a fingerprint cannot survive.

The two checks overlap and are not redundant: a tool that exits non-zero while printing a well-formed digest is caught only by the status, one that exits zero while printing anything else only by the shape. There is a mutation row for each.

**One of the new cases was rewritten because it could not fail.** The first "refuses without pipefail" case used an empty PATH — where the helper takes its `else` branch and returns 1 outright, so pipefail was never in the picture. Reverting the arms changed no result, which is how it was caught. A present-but-broken tool is the only path that isolates the status.

**And the correctness check was wired to the wrong thing.** For one head it lived in `agmsg_sha256_usable`, whose only production callers are `remote.sh`'s `doctor` and the `connect` preflight — so `key.sh`, which is its own CLI and reaches a digest through `generate`, `show`, `import` and `rotate` without going near `connect`, accepted a tool that exits 0 with a well-formed but wrong digest. The suite pinned that as expected behaviour. Raised in review.

`agmsg_sha256` now asks the selected tool a question whose answer is known, **before every digest**, and returns nothing until it has. **Keyed on the helper and not on the callers, because the alternative is a list of entry points kept complete by hand — which is precisely what was missed.** A `key.sh` case drives it with a lying shim, because a helper-level case cannot fail if a caller stops calling the helper. What it claims is bounded: the tool answered correctly the last time it was asked, which is immediately before the digest being taken.

**The self-test was memoised, and the memo was worse than useless.** Its flag was read from the environment, so `_AGMSG_SHA256_VERIFIED=1` in an inherited environment read as "already checked" and skipped the check — an undocumented override of a fail-closed contract, sitting on the hole closed one commit earlier. It also saved nothing: every production call is `printf | agmsg_sha256` or `x="$(agmsg_sha256 …)"`, both subshells, so the flag never reached the parent and the next digest self-tested anyway. Both halves raised in review.

It is removed rather than made private — a memo whose saving is imaginary is only a surface. **The cost is stated instead: one extra digest of a five-byte input per digest taken.** The worst path is `key rotate` with an accepted rotation to verify — the accepted recipient's fingerprint, the new recipient's journal fingerprint, the previous snapshot, and the short fingerprint printed at the end: **four digests, so eight runs of the tool**, each already alongside file and lock work. (Three, and one run each, was what this section said until review counted the accepted-rotation branch.) The case that pins it tries several variable names, because the property is about the environment rather than about one spelling.

**`require` and `doctor` said "none was found" and "tool on PATH" for a tool that is present and broken.** Presence and usability are different questions and both lines answer the second one; reworded, with the cases following.

**The fallback is for an ABSENT tool, not a broken one.** Presence picks the arm and a chosen arm that fails ends it; the working tool behind it is not tried. That was undocumented, is now stated in the helper, and has a case.

## What is not measured

No part of this ran on Windows. What is claimed is that the fallback chain and the refusal behave as described when the tools are absent or broken, which is measured directly. Whether Git for Windows' `sha256sum` is on the operator's PATH at the moment they run `connect` is a property of their install, not of this change.

## Suites

`tests/test_hash.bats` (new, 18 cases), and a `key.sh` case driving the same question through the CLI, `tests/test_key.bats`, `tests/test_remote.bats`.

