### PR TITLE
fix(lock): break a registry lock whose recorded holder is gone (#865)

### DIFF
--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -90,22 +90,38 @@ _agmsg_lock_holder_gone() {
 
 # Break a lock whose recorded holder is gone.
 #
-# CLAIMED BEFORE IT IS BROKEN, and the claim is the holder file itself. Two
-# processes can reach the same verdict in the same instant; `mv` of a given file
-# succeeds for exactly one of them, so exactly one goes on to remove the
-# directory. The loser's `mv` fails and it re-evaluates — by which time the
-# winner has either taken the lock or left the path free.
+# CLAIM FIRST, JUDGE SECOND, and the order is the whole correctness argument.
 #
-# The claim also binds the removal to the holder that was JUDGED. If the lock
-# changed hands between the verdict and here, the file this renames is not the
-# file that was read, the rename fails, and no `rmdir` lands on a lock somebody
-# else has since taken.
+# The first version read the holder, decided it was dead, and then renamed
+# whatever was at that path. Review took it apart: between the two, a different
+# breaker can claim the old holder and remove the directory, a new owner can
+# take the same path and write a LIVE holder — and the rename then succeeds
+# against the new file, because the path is the same. The `rmdir` after it
+# removes the new owner's lock. "If the lock changed hands the rename fails" was
+# not true of a path.
+#
+# Renaming first makes the claim the thing that is judged. Two processes cannot
+# both claim: `mv` of a given file succeeds for exactly one of them. And once
+# the holder is claimed, nobody else can legitimately break this lock (the file
+# they would have to claim is gone) and no new owner can appear (the directory
+# is still there, so `mkdir` still fails) — so the directory removed below is
+# necessarily the one the claimed holder belonged to.
+#
+# A claim that turns out to be alive is put back. That costs a rename on a live
+# lock, which is why the caller checks `_agmsg_lock_holder_gone` first: the
+# cheap read filters the common case, and this is the judgement that counts.
 _agmsg_lock_break_dead() {
-  local lock="$1" claimed="$lock.dead.$$.${RANDOM:-0}"
+  local lock="$1" claimed="$lock.dead.$$.${RANDOM:-0}" pid
   mv "$lock.holder" "$claimed" 2>/dev/null || return 1
+  pid="$(sed -n 's/^pid //p' "$claimed" 2>/dev/null | head -1)"
+  if [ -z "$pid" ] || _agmsg_pid_alive_local "$pid"; then
+    # Alive, or nothing here can say otherwise. Put it back — the next reader
+    # must still find out who the lock says is holding it.
+    mv "$claimed" "$lock.holder" 2>/dev/null || true
+    return 1
+  fi
   if ! rmdir "$lock" 2>/dev/null; then
-    # Not taking it after all, so the next reader must still find out who the
-    # lock says is holding it.
+    # Not taking it after all, so the record goes back where it was.
     mv "$claimed" "$lock.holder" 2>/dev/null || true
     return 1
   fi
@@ -184,7 +200,20 @@ agmsg_lock_acquire() {
       # that sent the last three diagnoses after processes that were not there.
       if [ -f "$lock.holder" ]; then
         echo "agmsg: the lock records: $(tr '\n' ' ' < "$lock.holder" 2>/dev/null)" >&2
-        echo "agmsg: that process answered as alive, so this was contention." >&2
+        # ALIVE AND UNCHECKABLE ARE NOT THE SAME ANSWER. A holder file with no
+        # `pid` line, an empty one, or a value `_agmsg_pid_valid` rejects all
+        # leave `_agmsg_lock_holder_gone` false — which is "this could not be
+        # asked", not "it answered yes". Saying the second puts the operator
+        # back where the old message put them: hunting a process on the strength
+        # of a sentence that never checked (raised in review).
+        _agmsg_timeout_pid="$(sed -n 's/^pid //p' "$lock.holder" 2>/dev/null | head -1)"
+        if [ -z "$_agmsg_timeout_pid" ]; then
+          echo "agmsg: that record names no pid, so nothing here could ask whether it is held." >&2
+        elif _agmsg_pid_alive_local "$_agmsg_timeout_pid"; then
+          echo "agmsg: that process answered as alive, so this was contention." >&2
+        else
+          echo "agmsg: that process is not running — the lock was being broken as this wait ended." >&2
+        fi
       else
         echo "agmsg: the lock records no holder, so nothing here could ask whether it is held." >&2
         echo "agmsg: a lock with no holder record is not broken automatically — see #865." >&2

--- a/scripts/lib/registry-lock.sh
+++ b/scripts/lib/registry-lock.sh
@@ -53,6 +53,70 @@ _agmsg_lock_describe_dir() {
   echo "agmsg:   running as: $(id 2>/dev/null || echo 'unknown')" >&2
 }
 
+# LIVENESS, from the library that already answers this question (#865).
+#
+# `kill -0` on its own reads EPERM as dead, which in a sandbox turns "cannot
+# signal" into "not running" — and here that would break a lock somebody is
+# holding. `_agmsg_pid_alive_local` treats EPERM as alive, a zombie as gone, and
+# cross-checks with `ps`. Sourced rather than reimplemented; guarded, so a
+# caller that already has it pays nothing.
+if ! declare -f _agmsg_pid_alive_local >/dev/null 2>&1; then
+  # shellcheck source=instance-id.sh
+  source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/instance-id.sh"
+fi
+
+# Is this lock's recorded holder gone?
+#
+# TRUE ONLY WHEN THERE IS SOMETHING TO ASK ABOUT. No holder file, or one with no
+# pid in it, answers "no" — not because such a lock is healthy, but because
+# nothing here can tell a lock written by an older version of this file from one
+# created microseconds ago whose owner has not written its record yet. Breaking
+# on "I cannot tell" would take a live lock away, which is worse than the leak.
+# That case is #865's remaining half and is left for the change that makes an
+# empty lock impossible in the first place.
+#
+# A recycled pid reads as ALIVE here, and that is the safe direction: this
+# process waits and reports contention instead of breaking a lock whose number
+# now belongs to a stranger. Fencing the number with a start time is the third
+# piece of #865 and is not in this change.
+_agmsg_lock_holder_gone() {
+  local lock="$1" pid
+  [ -f "$lock.holder" ] || return 1
+  pid="$(sed -n 's/^pid //p' "$lock.holder" 2>/dev/null | head -1)"
+  [ -n "$pid" ] || return 1
+  _agmsg_pid_alive_local "$pid" && return 1
+  return 0
+}
+
+# Break a lock whose recorded holder is gone.
+#
+# CLAIMED BEFORE IT IS BROKEN, and the claim is the holder file itself. Two
+# processes can reach the same verdict in the same instant; `mv` of a given file
+# succeeds for exactly one of them, so exactly one goes on to remove the
+# directory. The loser's `mv` fails and it re-evaluates — by which time the
+# winner has either taken the lock or left the path free.
+#
+# The claim also binds the removal to the holder that was JUDGED. If the lock
+# changed hands between the verdict and here, the file this renames is not the
+# file that was read, the rename fails, and no `rmdir` lands on a lock somebody
+# else has since taken.
+_agmsg_lock_break_dead() {
+  local lock="$1" claimed="$lock.dead.$$.${RANDOM:-0}"
+  mv "$lock.holder" "$claimed" 2>/dev/null || return 1
+  if ! rmdir "$lock" 2>/dev/null; then
+    # Not taking it after all, so the next reader must still find out who the
+    # lock says is holding it.
+    mv "$claimed" "$lock.holder" 2>/dev/null || true
+    return 1
+  fi
+  # `rm` is not on every allow-listed PATH that takes this lock — the same
+  # reason the holder lives beside the directory rather than inside it.
+  if command -v rm >/dev/null 2>&1; then
+    rm -f "$claimed" 2>/dev/null || true
+  fi
+  return 0
+}
+
 agmsg_lock_acquire() {
   local team_dir="$1" lock i=0 max="${AGMSG_LOCK_TRIES:-1000}" err=""
   local budget="${AGMSG_LOCK_SECONDS:-10}" started elapsed
@@ -85,6 +149,18 @@ agmsg_lock_acquire() {
       _agmsg_lock_describe_dir "$team_dir"
       return 1
     fi
+    # IS ANYBODY THERE? Until #865 this loop never asked. A lock whose holder
+    # had been killed was indistinguishable from one held by a live process
+    # doing slow work, so it waited out its budget and failed — every time,
+    # forever, and the team stayed wedged until somebody removed a directory by
+    # hand. The observed case is `roster-sync-driver.sh`, which acquires and
+    # then runs node in the foreground: the lock is held for as long as that
+    # runs, so one `kill -9`, one OOM kill or one force-quit in that span leaves
+    # a lock with a holder record and no holder.
+    if _agmsg_lock_holder_gone "$lock" && _agmsg_lock_break_dead "$lock"; then
+      echo "agmsg: broke a registry lock in $team_dir whose recorded holder is gone" >&2
+      continue
+    fi
     i=$((i + 1))
     elapsed=$(( $(date +%s) - started ))
     # Whichever bound arrives first, and the message says which — "1000 tries"
@@ -99,6 +175,19 @@ agmsg_lock_acquire() {
         echo "agmsg: timed out acquiring registry lock for $team_dir after ${elapsed}s" >&2
       else
         echo "agmsg: timed out acquiring registry lock for $team_dir after $i attempts (${elapsed}s)" >&2
+      fi
+      # WHAT WAS HOLDING IT, in the same breath. Since #865 a timeout means one
+      # of exactly two things — a holder that answered as alive, or a lock this
+      # process could not account for and would not break — and which one
+      # decides where the operator looks next. Without this the message says
+      # "contention" for a lock that has no holder at all, which is the sentence
+      # that sent the last three diagnoses after processes that were not there.
+      if [ -f "$lock.holder" ]; then
+        echo "agmsg: the lock records: $(tr '\n' ' ' < "$lock.holder" 2>/dev/null)" >&2
+        echo "agmsg: that process answered as alive, so this was contention." >&2
+      else
+        echo "agmsg: the lock records no holder, so nothing here could ask whether it is held." >&2
+        echo "agmsg: a lock with no holder record is not broken automatically — see #865." >&2
       fi
       # The reason travels with the timeout too. If the wait was hopeless for
       # a cause this function did not anticipate, the errno is the only thing
@@ -161,8 +250,15 @@ agmsg_lock_acquire() {
   } > "$lock.holder" 2>/dev/null || true
   AGMSG_HELD_LOCKS="${AGMSG_HELD_LOCKS:+$AGMSG_HELD_LOCKS
 }$lock"
-  # Idempotent: re-arming the same handlers each acquire is harmless. They release
-  # every held lock, so a crash with one or two locks held leaves no stale lock.
+  # Idempotent: re-arming the same handlers each acquire is harmless.
+  #
+  # WHAT THEY COVER, AND WHAT THEY DO NOT. These release every lock this process
+  # holds, so an ordinary exit or a Ctrl-C leaves nothing behind. `SIGKILL`, an
+  # OOM kill and the machine going down run no trap at all, and the lock stays.
+  # This sentence used to end at "a crash leaves no stale lock", with no
+  # qualifier, so the next reader believed crashes were covered — and the crash
+  # that is not covered is the one #865 was reported from. What covers it is the
+  # staleness check in the loop above, not this.
   # EXIT releases only. INT/TERM release AND exit, so a signal arriving between
   # commands in a critical section can't release the lock and then let the script
   # continue into an unprotected config move/write (matters for 2-lock

--- a/tests/test_registry_lock.bats
+++ b/tests/test_registry_lock.bats
@@ -468,3 +468,37 @@ write_holder() {  # write_holder <pid>
   # judged.
   [[ "$output" == *"first=0 second=1"* ]]
 }
+
+@test "lock: a breaker arriving after the lock changed hands leaves the new owner alone (#865)" {
+  # THE INTERLEAVING THE FIRST VERSION GOT WRONG, raised in review. Judging the
+  # holder and then renaming "whatever is at that path" are not the same thing:
+  # between them the lock can be broken by somebody else and re-taken by a new
+  # owner, and the rename then succeeds against the NEW holder — after which the
+  # rmdir removes a lock that is being used.
+  #
+  # Driven as the handoff, not as a repeat: the second breaker faces a live
+  # holder at the same path, which is precisely the state that used to be
+  # indistinguishable.
+  mkdir "$TEAM_DIR/.config.lock"
+  local gone; gone="$(dead_pid)"
+  write_holder "$gone"
+  start_live_holder
+  run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" LIVE="$LIVE_PID" bash -c '
+    . "$LOCKLIB"
+    lock="$TEAM_DIR/.config.lock"
+    _agmsg_lock_break_dead "$lock" || { echo "first-refused"; exit 1; }
+    # A new owner takes the freed path and records itself, alive.
+    mkdir "$lock"
+    printf "token t\npid %s\ncommand join.sh\nhost h\n" "$LIVE" > "$lock.holder"
+    # The late breaker, still carrying the verdict it formed on the OLD holder.
+    if _agmsg_lock_break_dead "$lock"; then echo "late-broke-it"; else echo "late-refused"; fi
+    [ -d "$lock" ] && echo "lock-survived"
+    sed -n "s/^pid //p" "$lock.holder" | head -1
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"late-refused"* ]]
+  [[ "$output" == *"lock-survived"* ]]
+  # The new owner's record is intact — put back byte for byte, not consumed.
+  [[ "$output" == *"$LIVE_PID"* ]]
+  kill "$LIVE_PID" 2>/dev/null || true
+}

--- a/tests/test_registry_lock.bats
+++ b/tests/test_registry_lock.bats
@@ -339,3 +339,132 @@ acquire() {  # runs the acquire in its own shell, with a short spin budget
   run diff "$BATS_TEST_TMPDIR/holder.before" "$TEAM_DIR/.config.lock.holder"
   [ "$status" -eq 0 ]
 }
+
+# --- a holder that is gone, and one that is not (#865) ----------------------
+#
+# The lock was permanent because acquire never asked whether the recorded holder
+# was still running. Both halves are here, and the second is the one that has to
+# hold: breaking a lock somebody IS using is worse than the leak this fixes.
+
+# A process that is alive for as long as the test needs it, and whose pid is
+# real. `sleep` rather than a made-up number: a pid that happens to be free
+# would make the "live" case pass for the wrong reason.
+start_live_holder() {
+  sleep 30 &
+  LIVE_PID=$!
+}
+
+# A pid that is genuinely not running: spawn, wait for it, then reuse the number.
+# `wait` is what makes this a measurement rather than a guess — the process has
+# been reaped before its number is written into the holder.
+dead_pid() {
+  local p
+  sleep 0 &
+  p=$!
+  wait "$p" 2>/dev/null || true
+  printf '%s' "$p"
+}
+
+write_holder() {  # write_holder <pid>
+  printf 'token %s\npid %s\ncommand %s\nhost %s\n' \
+    "test.token.$1" "$1" "join.sh" "testhost" > "$TEAM_DIR/.config.lock.holder"
+}
+
+@test "lock: a lock whose holder is gone is broken, and the acquire succeeds (#865)" {
+  mkdir "$TEAM_DIR/.config.lock"
+  local gone; gone="$(dead_pid)"
+  # CONTROL FIRST: the pid really is not running. Without this the case passes
+  # whenever the number happens to be free, which is not what it claims.
+  run env PID="$gone" LOCKLIB="$LOCKLIB" bash -c '. "$LOCKLIB"; _agmsg_pid_alive_local "$PID"'
+  [ "$status" -ne 0 ]
+
+  write_holder "$gone"
+  acquire
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"broke a registry lock"* ]]
+  [[ "$output" == *"holder is gone"* ]]
+  # HELD, not merely removed — and asserted INSIDE the acquiring shell, because
+  # its EXIT trap releases the lock the moment it returns. Checking afterwards
+  # would find no directory and prove nothing either way.
+  mkdir -p "$TEAM_DIR/.config.lock"
+  write_holder "$gone"
+  run env AGMSG_LOCK_TRIES=5 LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+    . "$LOCKLIB"
+    agmsg_lock_acquire "$TEAM_DIR" 2>/dev/null
+    [ -d "$TEAM_DIR/.config.lock" ] && echo HELD
+    sed -n "s/^pid //p" "$TEAM_DIR/.config.lock.holder" | head -1
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"HELD"* ]]
+  # The record is the new holder's, not the dead one's.
+  [[ "$output" != *"$gone"* ]]
+}
+
+@test "lock: a lock whose holder is ALIVE is never broken (#865)" {
+  mkdir "$TEAM_DIR/.config.lock"
+  start_live_holder
+  # CONTROL: the holder is alive AT THE MOMENT the acquire runs, asserted here
+  # rather than assumed from having spawned it — a `sleep` that failed to start
+  # would make this case pass by breaking a lock, which is the outcome it
+  # exists to forbid.
+  run env PID="$LIVE_PID" LOCKLIB="$LOCKLIB" bash -c '. "$LOCKLIB"; _agmsg_pid_alive_local "$PID"'
+  [ "$status" -eq 0 ]
+
+  write_holder "$LIVE_PID"
+  acquire
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"timed out acquiring registry lock"* ]]
+  [[ "$output" != *"broke a registry lock"* ]]
+  # And the holder record is untouched — the lock is still theirs.
+  run grep -c "^pid $LIVE_PID\$" "$TEAM_DIR/.config.lock.holder"
+  [ "$output" = "1" ]
+  kill "$LIVE_PID" 2>/dev/null || true
+}
+
+@test "lock: a lock with NO holder record is left alone, and the timeout says so (#865)" {
+  # The half this change does not take on: nothing here can tell a lock written
+  # by an older version from one created microseconds ago whose owner has not
+  # recorded itself yet, so it does not guess. Pinned so that changing it has to
+  # be a decision.
+  mkdir "$TEAM_DIR/.config.lock"
+  acquire
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"broke a registry lock"* ]]
+  [[ "$output" == *"records no holder"* ]]
+  [ -d "$TEAM_DIR/.config.lock" ]
+}
+
+@test "lock: the timeout on a live holder prints what the lock records (#865)" {
+  mkdir "$TEAM_DIR/.config.lock"
+  start_live_holder
+  write_holder "$LIVE_PID"
+  acquire
+  [ "$status" -ne 0 ]
+  # The pid is the part an operator acts on; asserting the whole line would
+  # pin the format instead.
+  [[ "$output" == *"the lock records:"* ]]
+  [[ "$output" == *"pid $LIVE_PID"* ]]
+  kill "$LIVE_PID" 2>/dev/null || true
+}
+
+@test "lock: two racing breakers, and only one of them removes the lock (#865)" {
+  # The claim-then-remove is what makes this safe: `mv` of one holder file
+  # succeeds for exactly one caller. Without it both would rmdir, and the second
+  # could take the directory away from a lock the first had already re-taken.
+  mkdir "$TEAM_DIR/.config.lock"
+  local gone; gone="$(dead_pid)"
+  write_holder "$gone"
+  run env LOCKLIB="$LOCKLIB" TEAM_DIR="$TEAM_DIR" bash -c '
+    . "$LOCKLIB"
+    a=1; b=1
+    _agmsg_lock_break_dead "$TEAM_DIR/.config.lock" && a=0
+    mkdir -p "$TEAM_DIR/.config.lock"
+    _agmsg_lock_break_dead "$TEAM_DIR/.config.lock" && b=0
+    echo "first=$a second=$b"
+  '
+  [ "$status" -eq 0 ]
+  # The second call faces a lock whose holder file it already consumed: it must
+  # refuse, because it cannot show that the directory now there is the one it
+  # judged.
+  [[ "$output" == *"first=0 second=1"* ]]
+}


### PR DESCRIPTION
Refs #865 — **not `Closes`**: this is one of the three fixes the issue describes, and merging it must not close the other two.

**Draft, and third in line.** The order was changed after this was opened: `doctor` reports the locks first (#867, no removal at all), `doctor --fix` sweeps second, and this — acquire breaking a stale lock on its own — comes last, because a wrong verdict here takes a lock away from a live process. Its own review history is the argument: the first version bound the removal to a *path* rather than to the holder it had judged, so a lock that changed hands between the verdict and the rename could be taken from somebody using it.

**Describes head `15d2e1bc4d6be98a9eb1cc05fd5a13ddfbe081b2`.**

**Affects existing users.** A team that is wedged today becomes usable again on the next command, without anyone removing a directory by hand. Nothing changes for a lock that is genuinely held.

## What was wrong

The acquire loop never asked whether the recorded holder was still running. A lock left behind by a killed process was indistinguishable, to that loop, from one held by a live process doing slow work — so it waited out its budget and failed. Every time. Forever. The message said `timed out acquiring registry lock`, which describes contention, so the operator went looking for a process that was not there.

Observed on a machine eight minutes after boot under load average 8: two lock directories six seconds apart, both still present nearly three hours later.

## Scope: one of the three pieces

The issue names three fixes. This is the one it calls second — asking whether the holder is alive — and it is scheduled last, for the reason above.

| | |
|---|---|
| #867 | `doctor` names every lock and which directory to remove — **removes nothing** |
| next | `doctor --fix` sweeps |
| **this PR** | **acquire asks whether the holder is alive and breaks the lock itself — last, and riskiest** |
| later | make an empty lock impossible — build the holder first, put the lock in place atomically |
| later | fence the pid with a start time, so a recycled number is not read as the same process |

**The scope was chosen from how these locks are actually made**, and there are two ways with very different windows:

- **killed between `mkdir` and the holder write** — leaves an *empty* lock. A narrow window; it takes load and simultaneity. The two observed locks are these.
- **killed while the lock is held** — leaves a lock *with* a holder record. The window is however long the work takes, and `roster-sync-driver.sh` acquires and then runs node in the foreground, so it is the whole of that run. One `kill -9`, one OOM kill or one force-quit is enough.

The second is far likelier and it has a holder record to ask about. So asking is the change that closes the most for the least.

## What it does not do, and why that is a decision

**A lock with no holder record is left alone.** Nothing here can tell a lock written by an older version of this file from one created microseconds ago whose owner has not written its record yet, and breaking on "I cannot tell" takes a live lock away — which is worse than the leak. There is a case pinning that, so changing it has to be a decision rather than a drift. The piece that makes empty locks impossible removes the question instead of answering it.

**A recycled pid reads as alive.** Without a start-time fence, `pid 1598 is alive` cannot be told from `the pid 1598 that took this lock is alive`, so this waits and reports contention rather than breaking a stranger's lock. That is the safe direction, and it is the third piece.

## How it is done

Liveness is `_agmsg_pid_alive_local`, which already exists for this: it reads `EPERM` as alive, a zombie as gone, and cross-checks with `ps`. A bare `kill -0` reads `EPERM` as dead, which in a sandbox turns "cannot signal" into "not running" — and here that would break a lock somebody is holding.

**The break claims the holder before it judges or removes anything, and the order is the correctness argument.** The first version read the holder, decided it was dead, and then renamed whatever was at that path — between those two steps another breaker can claim the old holder and free the directory, a new owner can take the same path and write a *live* holder, and the rename then succeeds against the new file. Raised in review, and fixed by renaming first: two processes cannot both claim, and once the holder is claimed no new owner can appear, because the directory is still there.

**That fix has no mutation row, and saying so is the point.** The interleaving happens between two statements inside one function, so nothing outside it can drive the sequence; a fixture that forces the state anyway reddens the *correct* code, because with claim-first that state is unreachable. It rests on the structure, not on a measurement.

**And one residual it does not close:** an operator removing the lock directory by hand — which this code's own message tells them to do — while a breaker is mid-judgement. No ordering inside the helper reaches outside the primitive.

**The earlier claim-before-remove reasoning** Two processes can reach the same verdict in the same instant; `mv` of a given file succeeds for exactly one of them, so exactly one goes on to `rmdir`. It also binds the removal to the holder that was *judged*: if the lock changed hands in between, the file being renamed is not the file that was read, the rename fails, and no `rmdir` lands on a lock somebody else has since taken.

The timeout message now says which of the two situations it is — a holder that answered as alive, or a lock with no holder record — because that is what decides where the operator looks next.

And the comment above the traps, which read *"a crash with one or two locks held leaves no stale lock"*: true of `EXIT`/`INT`/`TERM`, **not** of `SIGKILL`, an OOM kill, or the machine going down. That is the crash this issue was reported from, and the sentence had no qualifier.

## Mutations

Each reverted alone, and each reddens its own case:

| reverted | went red |
|---|---|
| the break never fires | a gone holder's lock is broken |
| stop asking whether the holder is alive (treat every holder as gone) | **a live holder's lock is never broken**, and the timeout that names it |
| remove the lock without claiming the holder first | two racing breakers, only one removes |

The live-holder row is the one that matters: breaking a lock somebody is using is worse than the leak this fixes.

**Both liveness controls are asserted, not assumed.** The "gone" case spawns a process, `wait`s for it, and then checks `_agmsg_pid_alive_local` says gone before writing that number into the holder — a pid that merely happened to be free would pass for the wrong reason. The "alive" case checks the holder is alive at the moment the acquire runs, because a `sleep` that failed to start would make it pass by breaking a lock.

## Suites

`tests/test_registry_lock.bats` **21/21** (5 new), `tests/test_team.bats` **79/79**, `tests/test_local_team_ids.bats` **5/5** — the last one because this sources `instance-id.sh`, and that suite is the one that runs the core join under an allow-listed PATH.

Not the full suite locally; CI is the gate.

