### PR TITLE
feat(doctor): name the registry locks, and which directory to remove (#865)

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -239,53 +239,81 @@ _remote_prompt_read() {
 # Not a check, so no `[x]`/`[ ]` and no effect on the exit code: a lock that
 # exists is not a failed prerequisite, and a doctor that exits non-zero because
 # a team is busy would be wrong every time somebody is joining.
+# One lock, reported. Split out so the two ways of finding them — a named team,
+# or a sweep — share this body and neither has to feed a loop from a string.
+# Joining the paths into one variable and reading it back would mean either an
+# unquoted heredoc, which runs command substitution on a team name, or unquoted
+# word splitting, which globs one.
+_remote_doctor_one_lock() {
+  local lock="$1" team holder pid state q
+  [ -d "$lock" ] || return 0
+  team="${lock%/.config.lock}"
+  team="${team##*/}"
+  if [ "$shown" -eq 0 ]; then
+    echo "Registry locks:"
+    shown=1
+  fi
+  holder="$lock.holder"
+  pid=""
+  [ -f "$holder" ] && pid="$(sed -n 's/^pid //p' "$holder" 2>/dev/null | head -1)"
+  # THREE ANSWERS, NOT TWO. "held" and "the holder is gone" are what the
+  # operator acts on; "cannot tell" is neither — a lock this could not ask
+  # about, and saying it is gone would be a guess. The guess that costs is the
+  # one that calls a live lock dead and then prints the command to remove it.
+  #
+  # WHICH IS WHY THE NUMBER IS VALIDATED BEFORE IT IS ASKED ABOUT.
+  # `_agmsg_pid_alive_local` returns false for a value it never put to the
+  # process table at all — non-numeric, leading zero, past the POSIX ceiling —
+  # and folding that into "not running" turned `pid not-a-pid` into a stale
+  # verdict with a removal beside it (raised in review). The same ceiling the
+  # helper uses, for the same reason it uses it.
+  if [ -z "$pid" ]; then
+    state="cannot tell — no holder recorded"
+  elif ! _agmsg_pid_valid "$pid" 2147483647; then
+    state="cannot tell — the holder record's pid is not a usable number"
+  elif _agmsg_pid_alive_local "$pid"; then
+    state="held — pid $pid is running"
+  else
+    state="stale — pid $pid is not running"
+  fi
+  echo "  $team: $state"
+  if [ -f "$holder" ]; then
+    echo "    records: $(tr '\n' ' ' < "$holder" 2>/dev/null)"
+  fi
+  echo "    created: $(ls -ld "$lock" 2>/dev/null || printf '%s (cannot stat)' "$lock")"
+  # QUOTED, because this is meant to be pasted. The store root and the team
+  # name can both contain a space, and an unquoted path becomes several
+  # arguments to `rm -r`. Same scheme as lib/shquote.sh.
+  q="$(printf "'%s'" "$(printf '%s' "$lock" | sed "s/'/'\\\\''/g")")"
+  if [ "$state" = "held — pid $pid is running" ]; then
+    echo "    a command is using this team. Nothing to do."
+  else
+    echo "    if no agmsg command is running for this team, remove it:"
+    echo "      rm -r $q"
+    [ -f "$holder" ] && echo "      rm -f $q.holder"
+    echo "    nothing but the lock lives in there — it holds no team data."
+  fi
+}
+
 _remote_doctor_locks() {
-  local only_team="${1:-}" lock team holder pid state shown=0 q
-  # Every team, or the one named. `for` over a glob rather than `find`, which is
-  # not on every PATH this tree is required to run under.
-  for lock in "$TEAMS_DIR"/*/.config.lock; do
-    [ -d "$lock" ] || continue
-    team="${lock%/.config.lock}"
-    team="${team##*/}"
-    [ -z "$only_team" ] || [ "$team" = "$only_team" ] || continue
-    if [ "$shown" -eq 0 ]; then
-      echo "Registry locks:"
-      shown=1
-    fi
-    holder="$lock.holder"
-    pid=""
-    [ -f "$holder" ] && pid="$(sed -n 's/^pid //p' "$holder" 2>/dev/null | head -1)"
-    # THREE ANSWERS, NOT TWO. "held" and "the holder is gone" are what the
-    # operator acts on; "no holder recorded" is neither — it is a lock this
-    # cannot ask about, written either by a version of the library that recorded
-    # nothing or by a process that was killed between creating the lock and
-    # writing its record. Reporting it as gone would be a guess, and the guess
-    # that costs is the one that says a live lock is dead.
-    if [ -z "$pid" ]; then
-      state="cannot tell — no holder recorded"
-    elif _agmsg_pid_alive_local "$pid"; then
-      state="held — pid $pid is running"
-    else
-      state="stale — pid $pid is not running"
-    fi
-    echo "  $team: $state"
-    if [ -f "$holder" ]; then
-      echo "    records: $(tr '\n' ' ' < "$holder" 2>/dev/null)"
-    fi
-    echo "    created: $(ls -ld "$lock" 2>/dev/null || printf '%s (cannot stat)' "$lock")"
-    # QUOTED, because this is meant to be pasted. The store root and the team
-    # name can both contain a space, and an unquoted path becomes several
-    # arguments to `rm -r`. Same scheme as lib/shquote.sh.
-    q="$(printf "'%s'" "$(printf '%s' "$lock" | sed "s/'/'\\\\''/g")")"
-    if [ "$state" = "held — pid $pid is running" ]; then
-      echo "    a command is using this team. Nothing to do."
-    else
-      echo "    if no agmsg command is running for this team, remove it:"
-      echo "      rm -r $q"
-      [ -f "$holder" ] && echo "      rm -f $q.holder"
-      echo "    nothing but the lock lives in there — it holds no team data."
-    fi
-  done
+  local only_team="${1:-}" lock shown=0
+  # A NAMED TEAM IS LOOKED AT DIRECTLY, and the sweep does not stop at `*`.
+  #
+  # Team names may begin with a dot — the validator rejects empty, `.`, `..`, a
+  # leading `-`, `/`, `\` and control characters, and nothing else — and `*`
+  # does not match a leading dot, so `.foo` was invisible to the sweep (raised
+  # in review). The two extra patterns cover `.foo` and `..foo`; `.` and `..`
+  # themselves cannot be team names.
+  #
+  # Globs rather than `find`, which is not on every PATH this tree is required
+  # to run under. Quoted, so a team name containing a space stays one path.
+  if [ -n "$only_team" ]; then
+    _remote_doctor_one_lock "$TEAMS_DIR/$only_team/.config.lock"
+  else
+    for lock in "$TEAMS_DIR"/*/.config.lock "$TEAMS_DIR"/.[!.]*/.config.lock "$TEAMS_DIR"/..?*/.config.lock; do
+      _remote_doctor_one_lock "$lock"
+    done
+  fi
   [ "$shown" -eq 0 ] || echo
 }
 
@@ -345,7 +373,11 @@ cmd_doctor() {
   echo
   _remote_doctor_locks "$team"
   if [ "$failed" -eq 0 ]; then
-    echo "All checks passed."
+    # NARROWED, because a lock report can sit above this line. "All checks
+    # passed." after "stale — pid 4711 is not running" and a `rm -r` reads as
+    # cancelling it, and the exit code deliberately does not move: a locked team
+    # is not a failed prerequisite (raised in review).
+    echo "All prerequisite checks passed."
   else
     echo "Some checks failed. See above."
     exit 1

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -308,6 +308,17 @@ _remote_doctor_locks() {
   # Globs rather than `find`, which is not on every PATH this tree is required
   # to run under. Quoted, so a team name containing a space stays one path.
   if [ -n "$only_team" ]; then
+    # VALIDATED BEFORE IT BECOMES A PATH. `cmd_doctor` takes its argument and,
+    # until this line, only ever put it in a header sentence — so nothing had
+    # ever checked it. Building `$TEAMS_DIR/$only_team/.config.lock` from it
+    # turned `doctor ../outside` into a read of a directory outside the store,
+    # reported with its records and a `rm -r` to paste (raised in review). The
+    # sweep it replaced never reached one only because no team was named that.
+    #
+    # The same validator every other team-taking path uses: it rejects empty,
+    # `.`, `..`, `/`, `\`, a leading `-` and control characters, and allows a
+    # leading dot and a space, which this reports on and must keep.
+    agmsg_validate_team_name "$only_team" || return 1
     _remote_doctor_one_lock "$TEAMS_DIR/$only_team/.config.lock"
   else
     for lock in "$TEAMS_DIR"/*/.config.lock "$TEAMS_DIR"/.[!.]*/.config.lock "$TEAMS_DIR"/..?*/.config.lock; do
@@ -371,7 +382,10 @@ cmd_doctor() {
     failed=1
   fi
   echo
-  _remote_doctor_locks "$team"
+  # A REJECTED TEAM NAME ENDS THE COMMAND. The validator prints why; carrying on
+  # to "All prerequisite checks passed." after refusing to look at what was
+  # asked about would report success for a question nobody answered.
+  _remote_doctor_locks "$team" || exit 1
   if [ "$failed" -eq 0 ]; then
     # NARROWED, because a lock report can sit above this line. "All checks
     # passed." after "stale — pid 4711 is not running" and a `rm -r` reads as

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -221,6 +221,74 @@ _remote_prompt_read() {
 # token, no state change, safe whether or not the team is already connected.
 # Currently just the age-binary-presence check (§8) — the natural home for
 # any future preflight check added later.
+# WHICH DIRECTORY TO REMOVE — the thing that was missing (#865).
+#
+# A registry lock left behind by a killed process is never broken by anything:
+# nothing expires, nothing sweeps, and acquire waits out its budget and fails
+# with `timed out acquiring registry lock`, which describes contention. The
+# operator's next move is to look for the process holding it; there is no
+# process, and no message anywhere names the directory to remove. A machine in
+# that state cannot get itself out.
+#
+# This REPORTS and removes nothing. The report alone ends "cannot recover":
+# it says which team, what the lock records, whether that process is running,
+# and prints the removal as a line to paste. Sweeping automatically is a
+# separate decision with a worse failure mode — a wrong verdict takes a lock
+# away from a process that is using it — and it is not made here.
+#
+# Not a check, so no `[x]`/`[ ]` and no effect on the exit code: a lock that
+# exists is not a failed prerequisite, and a doctor that exits non-zero because
+# a team is busy would be wrong every time somebody is joining.
+_remote_doctor_locks() {
+  local only_team="${1:-}" lock team holder pid state shown=0 q
+  # Every team, or the one named. `for` over a glob rather than `find`, which is
+  # not on every PATH this tree is required to run under.
+  for lock in "$TEAMS_DIR"/*/.config.lock; do
+    [ -d "$lock" ] || continue
+    team="${lock%/.config.lock}"
+    team="${team##*/}"
+    [ -z "$only_team" ] || [ "$team" = "$only_team" ] || continue
+    if [ "$shown" -eq 0 ]; then
+      echo "Registry locks:"
+      shown=1
+    fi
+    holder="$lock.holder"
+    pid=""
+    [ -f "$holder" ] && pid="$(sed -n 's/^pid //p' "$holder" 2>/dev/null | head -1)"
+    # THREE ANSWERS, NOT TWO. "held" and "the holder is gone" are what the
+    # operator acts on; "no holder recorded" is neither — it is a lock this
+    # cannot ask about, written either by a version of the library that recorded
+    # nothing or by a process that was killed between creating the lock and
+    # writing its record. Reporting it as gone would be a guess, and the guess
+    # that costs is the one that says a live lock is dead.
+    if [ -z "$pid" ]; then
+      state="cannot tell — no holder recorded"
+    elif _agmsg_pid_alive_local "$pid"; then
+      state="held — pid $pid is running"
+    else
+      state="stale — pid $pid is not running"
+    fi
+    echo "  $team: $state"
+    if [ -f "$holder" ]; then
+      echo "    records: $(tr '\n' ' ' < "$holder" 2>/dev/null)"
+    fi
+    echo "    created: $(ls -ld "$lock" 2>/dev/null || printf '%s (cannot stat)' "$lock")"
+    # QUOTED, because this is meant to be pasted. The store root and the team
+    # name can both contain a space, and an unquoted path becomes several
+    # arguments to `rm -r`. Same scheme as lib/shquote.sh.
+    q="$(printf "'%s'" "$(printf '%s' "$lock" | sed "s/'/'\\\\''/g")")"
+    if [ "$state" = "held — pid $pid is running" ]; then
+      echo "    a command is using this team. Nothing to do."
+    else
+      echo "    if no agmsg command is running for this team, remove it:"
+      echo "      rm -r $q"
+      [ -f "$holder" ] && echo "      rm -f $q.holder"
+      echo "    nothing but the lock lives in there — it holds no team data."
+    fi
+  done
+  [ "$shown" -eq 0 ] || echo
+}
+
 cmd_doctor() {
   local team="${1:-}"
   echo "Checking prerequisites${team:+ for team '$team'}..."
@@ -275,6 +343,7 @@ cmd_doctor() {
     failed=1
   fi
   echo
+  _remote_doctor_locks "$team"
   if [ "$failed" -eq 0 ]; then
     echo "All checks passed."
   else

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -115,7 +115,7 @@ skip_if_no_age() {
   run bash "$SCRIPTS/remote.sh" doctor
   [ "$status" -eq 0 ]
   [[ "$output" == *"age / age-keygen on PATH"* ]]
-  [[ "$output" == *"All checks passed."* ]]
+  [[ "$output" == *"All prerequisite checks passed."* ]]
 }
 
 @test "remote doctor: is read-only (no token required, no state touched)" {
@@ -1550,7 +1550,7 @@ VALUES ('remote-pending.$key', $owner_pid, strftime('%Y-%m-%dT%H:%M:%SZ','now'))
     || skip "all doctor prerequisites are not installed"
   run bash "$SCRIPTS/remote.sh" doctor
   [ "$status" -eq 0 ]
-  [[ "$output" == *"All checks passed."* ]]
+  [[ "$output" == *"All prerequisite checks passed."* ]]
 }
 
 PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
@@ -2582,7 +2582,7 @@ PY
   local no_age; no_age="$(path_without_age)"
   run env PATH="$no_age" bash "$SCRIPTS/remote.sh" doctor
   [ "$status" -eq 0 ]
-  [[ "$output" == *"All checks passed"* ]]
+  [[ "$output" == *"All prerequisite checks passed"* ]]
   [[ "$output" == *"optional"* ]]
   [[ "$output" != *"is required for end-to-end encryption"* ]]
 }
@@ -2799,7 +2799,7 @@ make_lock() {  # make_lock <team> [pid]
   make_lock wedged "$gone"
   run bash "$SCRIPTS/remote.sh" doctor
   [ "$status" -eq 0 ]
-  grep -qF -- "All checks passed." <<<"$output"
+  grep -qF -- "All prerequisite checks passed." <<<"$output"
 }
 
 @test "remote doctor <team>: reports that team's lock and not another's (#865)" {
@@ -2810,4 +2810,58 @@ make_lock() {  # make_lock <team> [pid]
   [ "$status" -eq 0 ]
   grep -qF -- "mine: stale" <<<"$output"
   refute grep -qF -- "theirs: stale" <<<"$output"
+}
+
+@test "remote doctor: a pid that was never asked about is not called stale (#865)" {
+  # THE VERDICT AND THE REMOVAL RIDE TOGETHER, so "false" from the liveness
+  # helper is not enough on its own: it is also false for a value the helper
+  # refused to put to the process table at all. `pid not-a-pid` and a number
+  # past the POSIX ceiling were being reported as stale, with `rm -r` beside
+  # them (raised in review).
+  make_lock badpid
+  printf 'token t\npid not-a-pid\ncommand join.sh\nhost h\n' \
+    > "$TEST_SKILL_DIR/teams/badpid/.config.lock.holder"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "badpid: cannot tell" <<<"$output"
+  refute grep -qF -- "badpid: stale" <<<"$output"
+
+  # CONTROL: the helper does answer false for it, so this case is measuring the
+  # validation and not some other difference.
+  run bash -c ". \"$SCRIPTS/lib/instance-id.sh\"; _agmsg_pid_alive_local not-a-pid"
+  [ "$status" -ne 0 ]
+}
+
+@test "remote doctor: a pid past the POSIX ceiling is not called stale (#865)" {
+  make_lock hugepid
+  printf 'token t\npid 2147483648\ncommand join.sh\nhost h\n' \
+    > "$TEST_SKILL_DIR/teams/hugepid/.config.lock.holder"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "hugepid: cannot tell" <<<"$output"
+  refute grep -qF -- "hugepid: stale" <<<"$output"
+}
+
+@test "remote doctor: a team whose name begins with a dot is swept too (#865)" {
+  # `*` does not match a leading dot, and the team validator allows one — so the
+  # sweep walked past `.hidden` entirely (raised in review). The validator
+  # rejects empty, `.`, `..`, a leading `-`, `/`, `\` and control characters,
+  # and nothing else.
+  local gone; gone="$(doctor_lock_dead_pid)"
+  make_lock .hidden "$gone"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- ".hidden: stale" <<<"$output"
+}
+
+@test "remote doctor: the summary does not cancel a lock finding (#865)" {
+  # "All checks passed." above a stale lock and a removal command reads as
+  # withdrawing them. The exit code deliberately stays 0 — a locked team is not
+  # a failed prerequisite — so the wording is what has to carry the distinction.
+  local gone; gone="$(doctor_lock_dead_pid)"
+  make_lock wedged "$gone"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "All prerequisite checks passed." <<<"$output"
+  refute grep -qE '^All checks passed\.$' <<<"$output"
 }

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2714,3 +2714,100 @@ assert_lookup_rejected() {
   [[ "$output" != *"No such file or directory"*"remote.sh"* ]]
   [[ "$output" != *"Usage: remote.sh unlock"* ]]
 }
+
+# --- doctor names the wedged lock, and removes nothing (#865) ---------------
+#
+# A registry lock left by a killed process is never broken: acquire waits out
+# its budget and says "timed out acquiring registry lock", which describes
+# contention, and no message anywhere names the directory to remove. `doctor` is
+# where that becomes findable.
+
+doctor_lock_dead_pid() {  # a pid that is genuinely not running
+  local p
+  sleep 0 &
+  p=$!
+  wait "$p" 2>/dev/null || true
+  printf '%s' "$p"
+}
+
+make_lock() {  # make_lock <team> [pid]
+  mkdir -p "$TEST_SKILL_DIR/teams/$1"
+  mkdir -p "$TEST_SKILL_DIR/teams/$1/.config.lock"
+  if [ -n "${2:-}" ]; then
+    printf 'token t\npid %s\ncommand join.sh\nhost h\n' "$2" \
+      > "$TEST_SKILL_DIR/teams/$1/.config.lock.holder"
+  fi
+}
+
+@test "remote doctor: a lock whose holder is gone is named, with the way out (#865)" {
+  local gone; gone="$(doctor_lock_dead_pid)"
+  # CONTROL: the pid really is not running, asserted before it is written into
+  # the holder — a number that merely happened to be free would make this pass
+  # for a reason that has nothing to do with the report.
+  run bash -c ". \"$SCRIPTS/lib/instance-id.sh\"; _agmsg_pid_alive_local $gone"
+  [ "$status" -ne 0 ]
+
+  make_lock wedged "$gone"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "wedged: stale — pid $gone is not running" <<<"$output"
+  grep -qF -- "rm -r " <<<"$output"
+  # REPORTS ONLY. The whole point of doing this before an automatic sweep is
+  # that a wrong verdict must not cost anything.
+  [ -d "$TEST_SKILL_DIR/teams/wedged/.config.lock" ]
+}
+
+@test "remote doctor: a lock whose holder is alive is not called stale (#865)" {
+  sleep 30 &
+  local live=$!
+  # CONTROL: alive at the moment doctor runs, not merely spawned.
+  run bash -c ". \"$SCRIPTS/lib/instance-id.sh\"; _agmsg_pid_alive_local $live"
+  [ "$status" -eq 0 ]
+
+  make_lock busy "$live"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "busy: held — pid $live is running" <<<"$output"
+  # And it must NOT offer to remove a lock somebody is using.
+  refute grep -qF -- "if no agmsg command is running for this team" <<<"$output"
+  kill "$live" 2>/dev/null || true
+}
+
+@test "remote doctor: a lock with no holder record says it cannot tell (#865)" {
+  # Neither "held" nor "gone": written by a version that recorded nothing, or by
+  # a process killed between creating the lock and writing its record. Guessing
+  # here is what would cost a live lock.
+  make_lock unknown
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "unknown: cannot tell — no holder recorded" <<<"$output"
+  grep -qF -- "rm -r " <<<"$output"
+}
+
+@test "remote doctor: says nothing about locks when there are none (#865)" {
+  # The negative control for the three above: the section is absent on a healthy
+  # install, so "Registry locks:" appearing at all is a finding.
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  refute grep -qF -- "Registry locks:" <<<"$output"
+}
+
+@test "remote doctor: a lock does not fail the run (#865)" {
+  # A team being locked is not a failed prerequisite. If it set the exit code,
+  # doctor would fail every time somebody is joining.
+  local gone; gone="$(doctor_lock_dead_pid)"
+  make_lock wedged "$gone"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "All checks passed." <<<"$output"
+}
+
+@test "remote doctor <team>: reports that team's lock and not another's (#865)" {
+  local gone; gone="$(doctor_lock_dead_pid)"
+  make_lock mine "$gone"
+  make_lock theirs "$gone"
+  run bash "$SCRIPTS/remote.sh" doctor mine
+  [ "$status" -eq 0 ]
+  grep -qF -- "mine: stale" <<<"$output"
+  refute grep -qF -- "theirs: stale" <<<"$output"
+}

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2865,3 +2865,45 @@ make_lock() {  # make_lock <team> [pid]
   grep -qF -- "All prerequisite checks passed." <<<"$output"
   refute grep -qE '^All checks passed\.$' <<<"$output"
 }
+
+@test "remote doctor <team>: a traversal argument is refused and reads nothing (#865)" {
+  # The named-team lookup builds a path from the argument, and until this was
+  # added nothing had ever validated it — `cmd_doctor` only ever put the value
+  # in a header sentence. A sentinel outside the store proves the refusal is
+  # about reach and not about the string.
+  local outside="$BATS_TEST_TMPDIR/outside"
+  mkdir -p "$outside/.config.lock"
+  printf 'token t\npid 1\ncommand join.sh\nhost h\n' > "$outside/.config.lock.holder"
+  # CONTROL: the sentinel is real and would be reported if it were reached —
+  # the same shape, under a team name, IS reported (the case above).
+  [ -d "$outside/.config.lock" ]
+
+  run bash "$SCRIPTS/remote.sh" doctor "../../$(basename "$BATS_TEST_TMPDIR")/outside"
+  [ "$status" -ne 0 ]
+  refute grep -qF -- "Registry locks:" <<<"$output"
+  refute grep -qF -- "rm -r " <<<"$output"
+  grep -qF -- "invalid team name" <<<"$output"
+  # And it must not claim the prerequisites verdict for a question it refused.
+  refute grep -qF -- "All prerequisite checks passed." <<<"$output"
+}
+
+@test "remote doctor <team>: a slash in the name is refused (#865)" {
+  run bash "$SCRIPTS/remote.sh" doctor "a/b"
+  [ "$status" -ne 0 ]
+  grep -qF -- "invalid team name" <<<"$output"
+}
+
+@test "remote doctor <team>: an ordinary and a dot-leading name still resolve (#865)" {
+  # The validator allows both, and the direct lookup has to keep working for
+  # them — a refusal that took the legitimate names with it would be the
+  # cheapest way to pass the two cases above.
+  local gone; gone="$(doctor_lock_dead_pid)"
+  make_lock plain "$gone"
+  make_lock .dotted "$gone"
+  run bash "$SCRIPTS/remote.sh" doctor plain
+  [ "$status" -eq 0 ]
+  grep -qF -- "plain: stale" <<<"$output"
+  run bash "$SCRIPTS/remote.sh" doctor .dotted
+  [ "$status" -eq 0 ]
+  grep -qF -- ".dotted: stale" <<<"$output"
+}


### PR DESCRIPTION
Refs #865 — the first of the three pieces it describes, and the one that removes nothing.

**Describes head `3d3b0b784d49cbc1926bf07c617bc05049fa1318`.**

**Affects existing users**, and only by printing more: `doctor` gains a section. No behaviour changes, no exit code changes, nothing is deleted.

## What is missing today

A registry lock left behind by a killed process is never broken. Nothing expires, nothing sweeps, and `agmsg_lock_release` is only ever reached from a trap — which `SIGKILL`, an OOM kill and the machine going down do not run. Acquire then waits out its budget and says:

```
agmsg: timed out acquiring registry lock for <dir> after 10s
```

That describes contention, so the operator goes looking for the process holding it. There is no process. **And no message anywhere names the directory to remove**, so a machine in this state cannot get itself out. Observed: two locks, six seconds apart, still there nearly three hours later.

## What this adds

```
Registry locks:
  wedged: stale — pid 4711 is not running
    records: token t pid 4711 command join.sh host h
    created: drwx------  2 me  staff  64 18 Aug 05:12 …/teams/wedged/.config.lock
    if no agmsg command is running for this team, remove it:
      rm -r '…/teams/wedged/.config.lock'
      rm -f '…/teams/wedged/.config.lock.holder'
    nothing but the lock lives in there — it holds no team data.
```

**Three answers, not two.** `held` and `the holder is gone` are what an operator acts on. `cannot tell` is neither: it names what could not be established rather than asserting the lock is dead.

**What the three states change is the sentence, not whether a removal is offered.** `stale` and `cannot tell` both print the removal, because the operator on a wedged machine needs it in exactly those two cases — a legacy lock with no holder record is the one koit's machine is sitting on. What carries the safety is that the line is conditional (`if no agmsg command is running for this team`) and that the state above it does not claim more than was measured. Only `held` withholds it, and says so. Calling `cannot tell` stale would put a measurement's weight behind a guess.

**Two things reach `cannot tell`, and the second was a defect found in review.** A lock with no holder record at all — written either by a library version that recorded nothing or by a process killed between creating the lock and writing its record. And **a holder whose pid was never put to the process table**: `_agmsg_pid_alive_local` returns false for a non-numeric value, a leading zero, or a number past the POSIX ceiling, and folding that into "not running" turned `pid not-a-pid` into a stale verdict with a `rm -r` beside it. The number is validated with the same ceiling the helper uses before it is asked about.

**It removes nothing, and it does not touch the exit code.** A team being locked is not a failed prerequisite — reporting it as one would fail `doctor` every time somebody is joining. Sweeping automatically is a separate decision with a worse failure mode, and it is not made here.

**The named team is validated before it becomes a path.** `cmd_doctor` takes an optional team and, until the direct lookup landed, only ever put it in a header sentence — so nothing had ever checked it, and `doctor ../outside` read a directory outside the store and offered to remove it. Raised in review. It goes through `agmsg_validate_team_name` now, the same one every other team-taking path uses, and a rejection ends the command rather than falling through to a prerequisites verdict for a question nobody answered.

**Reporting one lock is its own function**, shared by both callers, so neither has to join paths into a string and read them back — which would mean either an unquoted heredoc (running command substitution on a team name) or unquoted word splitting (globbing one). The first attempt did build such a string, and fed it to a `while read` loop with no redirection at all: it read stdin and reported nothing. Caught by reading the structure back, not by a test — the cases were written against the behaviour, and a loop that reports nothing fails them, but the run that would have said so was still going when the code was re-read.

**A named team is looked at directly, and the sweep does not stop at `*`.** Team names may begin with a dot — the validator rejects empty, `.`, `..`, a leading `-`, `/`, `\` and control characters, and nothing else — and `*` does not match a leading dot, so `.foo` was invisible to it. Raised in review.

**The summary line is narrowed to `All prerequisite checks passed.`** `All checks passed.` printed under a stale lock and its removal command reads as withdrawing them, and the exit code deliberately does not move.

Liveness is `_agmsg_pid_alive_local`, already sourced by `remote.sh`: it reads `EPERM` as alive, a zombie as gone, and cross-checks with `ps`. A bare `kill -0` reads `EPERM` as dead, which in a sandbox would report a live lock as stale.

The removal line is quoted (`lib/shquote.sh`'s scheme), because the store root and a team name can both contain a space and an unquoted path becomes several arguments to `rm -r`.

## Order, and why this piece is first

The issue names three fixes. This is the one with no way to make things worse:

| | |
|---|---|
| **this PR** | **`doctor` finds them and says which directory to remove** |
| next | `doctor --fix` sweeps |
| later | acquire breaks a stale lock on its own — **the riskiest, deliberately last** |

That third one exists as a draft (#866) and has already earned the caution: its first version bound the removal to a *path* rather than to the holder it had judged, so a lock that changed hands between the verdict and the rename could be taken from a live process. Review caught it. A wrong verdict there costs a lock somebody is using; a wrong verdict here costs a line of output.

## Mutations

Each reverted alone, and each reddens its own case:

| reverted | went red |
|---|---|
| never call a holder alive | a live holder's lock is not called stale |
| report an unaskable lock as stale | a lock with no holder says it cannot tell |
| ignore the team argument | `doctor <team>` reports that team and not another |
| report even when no lock exists | a healthy install says nothing about locks |
| fold an unusable pid into "not running" | `pid not-a-pid` and a pid past the ceiling say `cannot tell` |
| sweep with `*` alone | a team whose name begins with a dot |
| the old `All checks passed.` | the summary does not cancel a lock finding |
| skip the team-name validation | a traversal argument reads nothing; a slash is refused |

**Both liveness controls are asserted, not assumed.** The stale case spawns a process, `wait`s for it, and checks `_agmsg_pid_alive_local` says gone *before* writing that number into the holder — a pid that merely happened to be free would pass for the wrong reason. The live case checks the holder is alive at the moment `doctor` runs.

## Before this lands: one rebase step, written down here so it is not re-derived

This branch renames the summary line, and **#862 — already on the 1.2.1 integration branch — adds and edits assertions on the old wording.** Landing order is #862 first, so when this rebases onto `main` after 1.2.1 the following will be present and must move to `All prerequisite checks passed.` (measured on #862's head `15d0067e`, four assertions in `tests/test_remote.bats`):

- `remote doctor: passes when age is installed`
- `remote doctor: passes with the full toolchain installed`
- `remote doctor: age is optional — its absence does not fail the run`
- `remote doctor: reports a SHA-256 tool, and its absence does not fail the run` — **this one is #862's own edit**, and the reason the collision exists at all

The five on this branch are already updated. The check after rebasing is `grep -c 'All checks passed' tests/test_remote.bats` returning 0 for assertions (one comment mentions the phrase and is not one).

## Suites

`tests/test_remote.bats -f 865` **13/13**, `-f doctor` **22/22** (13 new). Not the full suite locally; CI is the gate.
