### PR TITLE
Windows can use the hosted service: connect reaches the server, the fingerprint is real, and doctor names a wedged lock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,11 +58,21 @@ env:
   # Number of parallel bats shards per OS. The matrix and the shard helper must
   # stay in lockstep; the stable summary job below verifies that they do.
   SHARD_TOTAL: 4
-  # Pinned so the Windows sqlite cache key means something: a hit is the same
-  # binary, not whatever the feed is serving today (#824). Bumping this is one
-  # cache miss and one trip to chocolatey, which is the only time the community
-  # feed is asked at all.
+  # The Windows legs' sqlite3, pinned three ways (#824).
+  #
+  # This comment used to end "one trip to chocolatey, which is the only time
+  # the community feed is asked at all". There is no feed any more: the binary
+  # comes from one sqlite.org URL, and the hash is what makes the pin mean
+  # something rather than the version string alone.
+  #
+  # Bumping a release means changing all four together — YEAR and BUILD form
+  # the URL, VERSION is what `sqlite3 --version` will report, and SHA256 is the
+  # measured digest of that exact zip. A stale SHA256 fails the download step
+  # loudly, which is the intended way to find out one of them was missed.
   WINDOWS_SQLITE_VERSION: '3.53.4'
+  WINDOWS_SQLITE_YEAR: '2026'
+  WINDOWS_SQLITE_BUILD: '3530400'
+  WINDOWS_SQLITE_SHA256: 'f46ee2475de4cbe287e6e5f7d43c838796b14e7379cd216bdbb28d391429f9fc'
 
 jobs:
   # Cheap gate: is this PR's diff entirely documentation? Pushes to main always
@@ -580,68 +590,83 @@ jobs:
         if: needs.changes.outputs.docs_only == 'true'
         run: echo "Diff is documentation-only; skipping the Windows bats legs."
 
-      # A THIRD PARTY'S BAD MINUTE MUST NOT BE REPORTED AS THIS CHANGE'S RED
-      # (#824). `choco install sqlite -y --no-progress` was one call with no
-      # retry, no cache and — the part that did the damage — no check. On a 503
-      # from the community feed it printed "Chocolatey installed 0/0 packages"
-      # and EXITED ZERO, so the step went green, the version step's
-      # `|| echo "not found"` turned a missing binary into a success line, and
-      # the red landed three steps later on `Run tests`. Measured on
-      # run 31869238895: steps 4, 5, 6 and 7 all `success`, step 8 `failure`,
-      # with `sqlite3: command not found` in step 7's own log.
+      # NO PACKAGE FEED ON THESE LEGS AT ALL (#824).
       #
-      # Reading that check list, the failure belongs to the change under test.
-      # It did not. The feed's flakiness is not ours to fix; which step goes red
-      # is.
+      # This used to be `choco install sqlite`. On 2026-08-15 the chocolatey
+      # community feed answered 503/504 for hours and every Windows leg went
+      # red for a reason that had nothing to do with the change under test —
+      # and worse, WHICH step went red depended on which phase of chocolatey's
+      # two-phase resolution happened to fail, so the same outage was not
+      # reproducible in place. Measured: `installed 0/1` exits non-zero and
+      # reddens the install; `installed 0/0` exits ZERO and the red lands three
+      # steps later on `Run tests`, reading as the diff's fault.
       #
-      # EVERY STEP HERE IS GATED ON `matrix.sqlite`, which #822 added. A leg that
-      # never opens a store must not be stopped by a package feed either — that
-      # is the contract #822 built, and hardening the install would have
-      # cancelled it by making `driver input (#817)` depend on chocolatey again.
+      # #827 made that legible — retry, cache, and a presence check that is the
+      # only step allowed to be red about it. This removes the cause instead.
+      # The issue's own Directions ranked the retry last, "the cheapest change
+      # and the least durable", and it was right: on a cache miss the leg still
+      # needed the feed. `bats` is a required check on `main` with
+      # enforce_admins, so a red Windows leg now blocks every landing.
       #
-      # The restore is tried first so most runs never ask the feed at all: the
-      # key is the pinned version, so a hit is the same binary and a miss is the
-      # only thing that needs the network.
+      # What is gone is the FEED, not the third party: sqlite.org is still
+      # somebody else's host. What it is not is a package index — no resolver,
+      # no two-phase lookup, no per-request 503 that serves one concurrent job
+      # and refuses another. One pinned URL, and a hash that says the bytes are
+      # the ones this pin was measured against.
+      #
+      # Not measured: whether the GitHub Windows image already ships sqlite3.
+      # It does not appear in the Windows 2022 or 2025 image manifests, which
+      # is the published list rather than a `where sqlite3` on a live runner.
       - name: Restore sqlite3 (cache)
         if: needs.changes.outputs.docs_only != 'true' && matrix.sqlite
         id: sqlite-cache
         uses: actions/cache@v4
         with:
-          path: |
-            C:\ProgramData\chocolatey\lib\SQLite
-            C:\ProgramData\chocolatey\bin\sqlite3.exe
-          key: sqlite3-${{ runner.os }}-choco-${{ env.WINDOWS_SQLITE_VERSION }}
+          path: C:\sqlite-tools
+          key: sqlite3-${{ runner.os }}-sqliteorg-${{ env.WINDOWS_SQLITE_VERSION }}
 
-      - name: Install sqlite3
+      - name: Fetch sqlite3 from sqlite.org
         if: needs.changes.outputs.docs_only != 'true' && matrix.sqlite && steps.sqlite-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          # Three attempts with a widening pause. The observed failures are 503
-          # and 504 from `community.chocolatey.org`, and they are per-request
-          # rather than an outage: on run 31869238895 the two Windows legs ran
-          # concurrently and one of them installed fine.
+          $ErrorActionPreference = 'Stop'
+          $url = "https://sqlite.org/$env:WINDOWS_SQLITE_YEAR/sqlite-tools-win-x64-$env:WINDOWS_SQLITE_BUILD.zip"
+          $zip = Join-Path $env:RUNNER_TEMP 'sqlite-tools.zip'
+          # Three attempts: one host having a bad second is still possible, it
+          # is just no longer a package index having a bad phase.
           for ($attempt = 1; $attempt -le 3; $attempt++) {
-            choco install sqlite --version=$env:WINDOWS_SQLITE_VERSION -y --no-progress
-            if (Test-Path 'C:\ProgramData\chocolatey\bin\sqlite3.exe') { exit 0 }
-            Write-Host "::warning::sqlite3 not installed on attempt $attempt; the chocolatey feed is answering errors"
-            Start-Sleep -Seconds (10 * $attempt)
+            try {
+              Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+              break
+            } catch {
+              Write-Host "::warning::sqlite.org fetch failed on attempt $attempt"
+              Start-Sleep -Seconds (10 * $attempt)
+            }
           }
-          exit 0   # the hard check is its own step, so a retry loop cannot decide the colour
+          if (-not (Test-Path $zip)) { exit 0 }   # the presence check below decides the colour
+          # THE HASH IS THE POINT. Without it this trades a feed that answers
+          # errors for a host that could answer anything, and the tests would
+          # run against whatever arrived.
+          $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLower()
+          if ($actual -ne $env:WINDOWS_SQLITE_SHA256) {
+            Write-Host "::error::sqlite-tools zip hash mismatch. expected $env:WINDOWS_SQLITE_SHA256, got $actual"
+            exit 1
+          }
+          Expand-Archive -Path $zip -DestinationPath 'C:\sqlite-tools' -Force
 
-      - name: Put chocolatey shims on PATH (Git Bash form)
+      - name: Put sqlite3 on PATH (Git Bash form)
         if: needs.changes.outputs.docs_only != 'true' && matrix.sqlite
-        run: echo "/c/ProgramData/chocolatey/bin" >> "$GITHUB_PATH"
+        run: echo "/c/sqlite-tools" >> "$GITHUB_PATH"
 
-      # THE STEP THAT IS ALLOWED TO BE RED ABOUT THIS. Separate from the install
-      # on purpose: whether the dependency is present is a different question
-      # from whether one `choco` invocation worked, and only this one may decide
-      # the job's colour. Named so the check list says what is wrong — a reader
-      # seeing this red does not go looking through the diff.
-      - name: sqlite3 must be present, or this leg is about chocolatey
+      # THE STEP THAT IS ALLOWED TO BE RED ABOUT THIS, kept from #827 and still
+      # the load-bearing part: whatever supplies sqlite3, the step that decides
+      # the leg's colour must be the one that says the dependency is missing,
+      # not the one that runs the tests.
+      - name: sqlite3 must be present, or this leg is about its download
         if: needs.changes.outputs.docs_only != 'true' && matrix.sqlite
         run: |
           if ! sqlite3 --version; then
-            echo "::error::sqlite3 is missing. The chocolatey community feed did not serve it (503/504 seen on 2026-08-15). This leg reports on that, NOT on the change under test — see #824."
+            echo "::error::sqlite3 is missing — the pinned sqlite.org download did not arrive. This leg reports on that, NOT on the change under test — see #824."
             exit 1
           fi
 

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -95,6 +95,14 @@ _key_read_config_field() {
 # callers, which now take the value into a variable of its own before printing
 # it. An empty fingerprint is the worst possible output here -- both people see
 # the same blank and agree.
+#
+# THAT REFUSAL RIDES ON `set -o pipefail`, LINE 2. `agmsg_sha256` is in the
+# middle of this pipeline, and `cut` and `sed` are perfectly happy with the
+# empty input a failed digest leaves them: without pipefail the pipeline exits 0
+# with an empty string, the caller's assignment succeeds, and the label prints
+# with nothing after it. Dropping `pipefail` reddens both "no blank
+# fingerprint" cases in tests/test_key.bats, which is the control for this
+# paragraph -- if you are here because you want to simplify line 2, run them.
 _key_fingerprint() {
   printf '%s' "$1" | agmsg_sha256 | cut -c1-16 | sed 's/\(....\)/\1-/g;s/-$//'
 }

--- a/scripts/key.sh
+++ b/scripts/key.sh
@@ -35,6 +35,10 @@ source "$SCRIPT_DIR/lib/operator-guidance.sh"
 source "$SCRIPT_DIR/lib/shquote.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/roster-journal.sh"
+# agmsg_sha256 -- `shasum` is absent in Git for Windows' Git Bash, and every
+# digest below is either a fingerprint a human compares or an E2EE checkpoint.
+# shellcheck source=lib/hash.sh
+source "$SCRIPT_DIR/lib/hash.sh"
 
 TEAMS_DIR="$CONNECTION_ROOT/teams"
 CRED_ROOT="$CONNECTION_ROOT/run/remote-credentials"
@@ -86,12 +90,17 @@ _key_read_config_field() {
 # Short, human-comparable digest of a recipient string (SSH-key-fingerprint
 # style grouping) — for the H7 fingerprint-verification step:
 # two people compare this same short string over a separate channel.
+#
+# Fails rather than returning a short string it could not compute: see the
+# callers, which now take the value into a variable of its own before printing
+# it. An empty fingerprint is the worst possible output here -- both people see
+# the same blank and agree.
 _key_fingerprint() {
-  printf '%s' "$1" | shasum -a 256 | cut -c1-16 | sed 's/\(....\)/\1-/g;s/-$//'
+  printf '%s' "$1" | agmsg_sha256 | cut -c1-16 | sed 's/\(....\)/\1-/g;s/-$//'
 }
 
 _key_fingerprint_sha256() {
-  printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  printf '%s' "$1" | agmsg_sha256
 }
 
 # A timestamp alone collides when two epochs are minted within the same
@@ -321,8 +330,17 @@ cmd_generate() {
   _key_write_epoch_locked "$cfg" "$(_key_epoch_json "$key_id" 0 0 "$recipient" null "$created_at")"
   agmsg_lock_release
 
+  # Computed into a variable of its own, NOT inline in the echo. A command
+  # substitution that fails inside a simple command's arguments leaves that
+  # command's own status untouched, so `echo` succeeded and printed the label
+  # with nothing after it. A bare assignment's status IS the substitution's, so
+  # `set -e` stops here instead. (Same reasoning as remote.sh's `existing=` note;
+  # `local fp_short="$(...)"` would put the status back on the declaration and
+  # undo it.)
+  local fp_short
+  fp_short="$(_key_fingerprint "$recipient")"
   echo "Generated a new key for team '$team'."
-  echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+  echo "Recipient fingerprint: $fp_short"
   echo
   # What the key IS, always: true whoever ran this, so it is never held back.
   #
@@ -415,8 +433,10 @@ cmd_show() {
   fi
 
   if [ "$reveal" -eq 0 ]; then
+    local fp_short
+    fp_short="$(_key_fingerprint "$recipient")"
     echo "Team: $team"
-    echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+    echo "Recipient fingerprint: $fp_short"
     echo "Public recipient: $recipient"
     return
   fi
@@ -578,8 +598,10 @@ cmd_import() {
       _key_write_identity_atomic "$cred_dir/$staged_key_id.key" "$identity"
       agmsg_lock_release
       unset identity
+      local fp_short
+      fp_short="$(_key_fingerprint "$recipient")"
       echo "Imported replacement key for team '$team' (key_id=$staged_key_id)."
-      echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+      echo "Recipient fingerprint: $fp_short"
       return
     fi
     # Matches the existing epoch: just store this device's copy of the
@@ -598,8 +620,10 @@ cmd_import() {
   fi
   unset identity
 
+  local fp_short
+  fp_short="$(_key_fingerprint "$recipient")"
   echo "Imported key for team '$team'."
-  echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+  echo "Recipient fingerprint: $fp_short"
 }
 
 cmd_rotate() {
@@ -762,7 +786,7 @@ EOF
     echo "agmsg: could not read the current authority-confirmed epoch snapshot." >&2
     exit 1
   fi
-  previous_snapshot_sha="$(shasum -a 256 "$previous_snapshot" | awk '{print $1}')"
+  previous_snapshot_sha="$(agmsg_sha256 < "$previous_snapshot")"
   rm -f "$previous_snapshot"
   writer_generation="$(agmsg_sqlite_mem \
     "SELECT CAST('$(_agmsg_sqlesc "$(_key_read_config_field "$cfg" '$.remote_key.current.writer_generation')")' AS INTEGER) + 1;")"
@@ -783,8 +807,10 @@ EOF
   fi
   agmsg_lock_release
 
+  local fp_short
+  fp_short="$(_key_fingerprint "$recipient")"
   echo "Generated replacement key for team '$team' (epoch=$next_epoch, key_id=$key_id)."
-  echo "Recipient fingerprint: $(_key_fingerprint "$recipient")"
+  echo "Recipient fingerprint: $fp_short"
   echo "The private key was not written to the journal; distribute it out of band."
   echo "On an interactive terminal, run:"
   echo "  bash $(agmsg_shq "$SKILL_DIR/scripts/key.sh") show $(agmsg_shq "$team") --key-id $(agmsg_shq "$key_id") --reveal-secret"

--- a/scripts/lib/hash.sh
+++ b/scripts/lib/hash.sh
@@ -124,13 +124,21 @@ _agmsg_sha256_selected() {
 # anywhere near `connect`'s preflight. A list like that is exactly what was
 # already missed once.
 #
-# Memoised, so a command that takes several digests pays for one extra. That is
-# the limit of what this claims: the tool answered correctly when first asked in
-# this process, not that it will keep doing so.
+# RUN BEFORE EVERY DIGEST, AND NOT MEMOISED. It was, on one head, keyed on a
+# shell variable -- which review took apart twice over. The flag was read
+# straight from the environment, so `_AGMSG_SHA256_VERIFIED=1` in a preseeded
+# environment meant "already checked" and skipped the check outright: an
+# undocumented env override that turned a fail-closed contract off. And it did
+# not even work: every production call is `printf | agmsg_sha256` or
+# `x="$(agmsg_sha256 …)"`, both subshells, so the flag never reached the parent
+# and the self-test ran again anyway. The saving was imaginary and the hole was
+# not.
+#
+# So the cost is stated instead of avoided: one extra digest of a 5-byte input
+# per digest taken. The commands that take one take at most three (`key rotate`:
+# fingerprint, journal fingerprint, previous snapshot), and each is already
+# doing file and network work that dwarfs it.
 _agmsg_sha256_selftest() {
-  if [ "${_AGMSG_SHA256_VERIFIED:-0}" = 1 ]; then
-    return 0
-  fi
   local probe
   probe="$(printf '%s' probe | _agmsg_sha256_selected)" || return 1
   if [ "$probe" != 'ba9c736f19e7f60b7f6764adb0b7908c0a2b394e09b6c09863528c7f2bc86095' ]; then
@@ -138,7 +146,6 @@ _agmsg_sha256_selftest() {
     echo "Its answers cannot be used for key fingerprints or encryption checkpoints." >&2
     return 1
   fi
-  _AGMSG_SHA256_VERIFIED=1
 }
 
 agmsg_sha256() {

--- a/scripts/lib/hash.sh
+++ b/scripts/lib/hash.sh
@@ -27,3 +27,73 @@ agmsg_sha1() {
     cksum | awk '{print $1}'
   fi
 }
+
+# Portable SHA-256 of stdin, emitting the bare hex digest.
+#
+# Same absence as above -- `shasum` is not in Git for Windows' Git Bash -- and
+# the same fixed order, so a given machine always answers with one tool:
+#   shasum -a 256 (macOS/Linux) -> sha256sum (Git Bash/Linux) -> openssl.
+#
+# THE LAST RESORT IS DIFFERENT ON PURPOSE, and it is the point of this helper.
+# agmsg_sha1 ends in `cksum` because its callers name a socket after the digest
+# and need only that the same input give the same name on the same machine.
+# These callers need the opposite property. The digest is
+#
+#   * the fingerprint two people read to each other over a separate channel to
+#     confirm they are talking to the key they think they are, and
+#   * the age-v1 checkpoint that says an epoch snapshot is the snapshot it
+#     claims to be.
+#
+# A non-cryptographic stand-in does not weaken those, it makes them say
+# something untrue. So when no tool here can compute SHA-256 this FAILS, and
+# every caller is expected to stop rather than carry an empty or substitute
+# value forward.
+#
+# Do not add a `cksum` arm to "make this consistent with agmsg_sha1". The
+# inconsistency is the decision.
+agmsg_sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 | awk '{print $NF}'
+  else
+    echo "agmsg: no SHA-256 tool found on PATH (looked for shasum, sha256sum, openssl)." >&2
+    echo "One of these is required for key fingerprints and end-to-end-encryption checkpoints." >&2
+    return 1
+  fi
+}
+
+# True when agmsg_sha256 has something to run. Separated so a caller can ASK
+# before it starts, rather than discover it at the digest.
+#
+# The order matters more than it looks: the first SHA-256 in a `connect --e2ee`
+# comes AFTER the team has been registered with the server, so without this the
+# operator's first news of a missing tool is a half-finished connect. Same
+# category as the `age` check next to it -- a prerequisite of end-to-end
+# encryption, not of agmsg -- and asked at the same moment.
+# Probed by RUNNING it, not by `command -v`. The question is whether this
+# machine can produce a SHA-256, and presence on PATH is only a proxy for that:
+# a tool that is installed and fails answers "yes" to the proxy and "no" to the
+# question, which is the direction that hurts -- the preflight passes and the
+# digest fails later, which is the shape of #861 all over again. Costs one
+# subprocess, once, on a command that is about to make a network round trip.
+agmsg_sha256_usable() {
+  local probe
+  probe="$(printf '%s' probe | agmsg_sha256 2>/dev/null)" || return 1
+  [ -n "$probe" ]
+}
+
+# Refuse to proceed without one, with the same install guidance shape the age
+# preflight uses.
+agmsg_require_sha256() {
+  if ! agmsg_sha256_usable; then
+    echo "agmsg: end-to-end encryption needs a SHA-256 tool, and none was found on this device." >&2
+    echo "agmsg looks for 'shasum', then 'sha256sum', then 'openssl'. Install one, then retry:" >&2
+    echo "  macOS (Homebrew):      brew install openssl" >&2
+    echo "  Debian/Ubuntu:         sudo apt install coreutils" >&2
+    echo "  Windows (Git Bash):    ships with Git for Windows; reinstall it if 'sha256sum' is missing" >&2
+    return 1
+  fi
+}

--- a/scripts/lib/hash.sh
+++ b/scripts/lib/hash.sh
@@ -51,18 +51,61 @@ agmsg_sha1() {
 #
 # Do not add a `cksum` arm to "make this consistent with agmsg_sha1". The
 # inconsistency is the decision.
+#
+# THE FAILURE IS THE HELPER'S OWN, not the caller's shell options. Written as
+# `shasum -a 256 | awk …` this function's status was the status of `awk`, which
+# is delighted by the empty input a failed digest hands it — so "this FAILS"
+# held only because `key.sh` and `remote.sh` happen to `set -o pipefail` on
+# their second line. A caller without it got an empty success and carried it
+# into a fingerprint. Each tool is now run as its own command substitution with
+# its status checked here, so the refusal travels with the function.
+#
+# WHICH ARM RUNS IS DECIDED BY PRESENCE, AND A CHOSEN ARM THAT FAILS IS THE END.
+# The fallback exists for a tool that is ABSENT, not for one that is broken:
+# there is no second attempt after `shasum` is found and then fails. That is
+# deliberate — a machine whose `shasum` is broken has something wrong with it
+# that a quiet substitution would hide — and it is asserted below, so changing
+# it has to be a decision rather than a drift.
+#
+# The answer is then checked for being 64 lowercase hex. A tool that exits 0 and
+# prints a warning, a path, or an empty line has not failed as far as `$?` is
+# concerned, and this value is not a label: it is what two people read to each
+# other to confirm a key, and what the age-v1 checkpoint pins a snapshot with.
+# Lowercase specifically, because all three arms emit lowercase and a fourth
+# that did not would leave two machines disagreeing about a fingerprint that is
+# "the same".
+#
+# The two checks overlap on purpose and are not redundant: a tool that exits
+# non-zero while still printing a well-formed digest is caught only by the
+# status, and one that exits zero while printing anything else only by the
+# shape. There is a case for each below.
 agmsg_sha256() {
+  local raw
   if command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 | awk '{print $1}'
+    raw="$(shasum -a 256)" || return 1
+    raw="${raw%% *}"
   elif command -v sha256sum >/dev/null 2>&1; then
-    sha256sum | awk '{print $1}'
+    raw="$(sha256sum)" || return 1
+    raw="${raw%% *}"
   elif command -v openssl >/dev/null 2>&1; then
-    openssl dgst -sha256 | awk '{print $NF}'
+    raw="$(openssl dgst -sha256)" || return 1
+    raw="${raw##* }"
   else
     echo "agmsg: no SHA-256 tool found on PATH (looked for shasum, sha256sum, openssl)." >&2
     echo "One of these is required for key fingerprints and end-to-end-encryption checkpoints." >&2
     return 1
   fi
+  case "$raw" in
+    *[!0-9a-f]*|'')
+      echo "agmsg: the SHA-256 tool on PATH answered with something that is not a digest." >&2
+      return 1
+      ;;
+  esac
+  [ "${#raw}" -eq 64 ] || {
+    echo "agmsg: the SHA-256 tool on PATH answered with ${#raw} characters, not a 64-hex digest." >&2
+    return 1
+  }
+  printf '%s\n' "$raw"
 }
 
 # True when agmsg_sha256 has something to run. Separated so a caller can ASK
@@ -79,10 +122,17 @@ agmsg_sha256() {
 # question, which is the direction that hurts -- the preflight passes and the
 # digest fails later, which is the shape of #861 all over again. Costs one
 # subprocess, once, on a command that is about to make a network round trip.
+#
+# Checked against a KNOWN digest, not against "something came back". A tool can
+# exit 0 and print sixty-four characters that are not the SHA-256 of the input,
+# and this probe is what stands between that and a fingerprint two people
+# believe they compared. `agmsg_sha256` refuses anything that is not 64
+# lowercase hex; this adds the only remaining question — whether it is the
+# right hex.
 agmsg_sha256_usable() {
   local probe
   probe="$(printf '%s' probe | agmsg_sha256 2>/dev/null)" || return 1
-  [ -n "$probe" ]
+  [ "$probe" = 'ba9c736f19e7f60b7f6764adb0b7908c0a2b394e09b6c09863528c7f2bc86095' ]
 }
 
 # Refuse to proceed without one, with the same install guidance shape the age

--- a/scripts/lib/hash.sh
+++ b/scripts/lib/hash.sh
@@ -110,7 +110,7 @@ _agmsg_sha256_selected() {
   printf '%s\n' "$raw"
 }
 
-# ASK THE SELECTED TOOL A QUESTION WE KNOW THE ANSWER TO, ONCE PER PROCESS.
+# ASK THE SELECTED TOOL A QUESTION WE KNOW THE ANSWER TO, BEFORE EVERY DIGEST.
 #
 # `_agmsg_sha256_selected` accepts any 64 lowercase hex, which is the shape of
 # a digest and not the proof of one: a tool that exits 0 and prints a plausible
@@ -135,9 +135,11 @@ _agmsg_sha256_selected() {
 # not.
 #
 # So the cost is stated instead of avoided: one extra digest of a 5-byte input
-# per digest taken. The commands that take one take at most three (`key rotate`:
-# fingerprint, journal fingerprint, previous snapshot), and each is already
-# doing file and network work that dwarfs it.
+# per digest taken. The command that takes the most is `key rotate` with an
+# accepted rotation to check -- the accepted recipient's fingerprint, the new
+# recipient's journal fingerprint, the previous snapshot, and the short
+# fingerprint printed at the end: FOUR digests, so eight runs of the tool. Every
+# one of them sits beside file and lock work that dwarfs it.
 _agmsg_sha256_selftest() {
   local probe
   probe="$(printf '%s' probe | _agmsg_sha256_selected)" || return 1
@@ -165,8 +167,9 @@ agmsg_sha256() {
 # machine can produce a SHA-256, and presence on PATH is only a proxy for that:
 # a tool that is installed and fails answers "yes" to the proxy and "no" to the
 # question, which is the direction that hurts -- the preflight passes and the
-# digest fails later, which is the shape of #861 all over again. Costs one
-# subprocess, once, on a command that is about to make a network round trip.
+# digest fails later, which is the shape of #861 all over again. Costs two runs
+# of the tool -- `agmsg_sha256`'s self-test and this probe's own digest -- on a
+# command that is about to make a network round trip.
 #
 # Nothing more than "can this machine produce one", because the correctness
 # question moved into `agmsg_sha256` itself -- a preflight that knows something

--- a/scripts/lib/hash.sh
+++ b/scripts/lib/hash.sh
@@ -79,7 +79,9 @@ agmsg_sha1() {
 # non-zero while still printing a well-formed digest is caught only by the
 # status, and one that exits zero while printing anything else only by the
 # shape. There is a case for each below.
-agmsg_sha256() {
+# The arms and the shape check, without the self-test below -- so the self-test
+# can call it without calling itself.
+_agmsg_sha256_selected() {
   local raw
   if command -v shasum >/dev/null 2>&1; then
     raw="$(shasum -a 256)" || return 1
@@ -108,6 +110,42 @@ agmsg_sha256() {
   printf '%s\n' "$raw"
 }
 
+# ASK THE SELECTED TOOL A QUESTION WE KNOW THE ANSWER TO, ONCE PER PROCESS.
+#
+# `_agmsg_sha256_selected` accepts any 64 lowercase hex, which is the shape of
+# a digest and not the proof of one: a tool that exits 0 and prints a plausible
+# but wrong value is accepted, and that value then becomes a fingerprint two
+# people read to each other, or the checkpoint that says a snapshot is the
+# snapshot it claims to be.
+#
+# The check lives HERE rather than at the callers because the alternative is a
+# list of entry points that must be kept complete -- `key.sh` is its own CLI and
+# `generate`, `show`, `import` and `rotate` all reach a digest without going
+# anywhere near `connect`'s preflight. A list like that is exactly what was
+# already missed once.
+#
+# Memoised, so a command that takes several digests pays for one extra. That is
+# the limit of what this claims: the tool answered correctly when first asked in
+# this process, not that it will keep doing so.
+_agmsg_sha256_selftest() {
+  if [ "${_AGMSG_SHA256_VERIFIED:-0}" = 1 ]; then
+    return 0
+  fi
+  local probe
+  probe="$(printf '%s' probe | _agmsg_sha256_selected)" || return 1
+  if [ "$probe" != 'ba9c736f19e7f60b7f6764adb0b7908c0a2b394e09b6c09863528c7f2bc86095' ]; then
+    echo "agmsg: the SHA-256 tool on PATH returned the wrong digest for a known input." >&2
+    echo "Its answers cannot be used for key fingerprints or encryption checkpoints." >&2
+    return 1
+  fi
+  _AGMSG_SHA256_VERIFIED=1
+}
+
+agmsg_sha256() {
+  _agmsg_sha256_selftest || return 1
+  _agmsg_sha256_selected
+}
+
 # True when agmsg_sha256 has something to run. Separated so a caller can ASK
 # before it starts, rather than discover it at the digest.
 #
@@ -123,24 +161,23 @@ agmsg_sha256() {
 # digest fails later, which is the shape of #861 all over again. Costs one
 # subprocess, once, on a command that is about to make a network round trip.
 #
-# Checked against a KNOWN digest, not against "something came back". A tool can
-# exit 0 and print sixty-four characters that are not the SHA-256 of the input,
-# and this probe is what stands between that and a fingerprint two people
-# believe they compared. `agmsg_sha256` refuses anything that is not 64
-# lowercase hex; this adds the only remaining question — whether it is the
-# right hex.
+# Nothing more than "can this machine produce one", because the correctness
+# question moved into `agmsg_sha256` itself -- a preflight that knows something
+# the digest path does not is the shape of #861, and for one head this function
+# was the only thing checking the answer while `key.sh` reached a digest by four
+# routes that never call it.
 agmsg_sha256_usable() {
-  local probe
-  probe="$(printf '%s' probe | agmsg_sha256 2>/dev/null)" || return 1
-  [ "$probe" = 'ba9c736f19e7f60b7f6764adb0b7908c0a2b394e09b6c09863528c7f2bc86095' ]
+  printf '%s' probe | agmsg_sha256 >/dev/null 2>&1
 }
 
 # Refuse to proceed without one, with the same install guidance shape the age
 # preflight uses.
 agmsg_require_sha256() {
   if ! agmsg_sha256_usable; then
-    echo "agmsg: end-to-end encryption needs a SHA-256 tool, and none was found on this device." >&2
-    echo "agmsg looks for 'shasum', then 'sha256sum', then 'openssl'. Install one, then retry:" >&2
+    echo "agmsg: end-to-end encryption needs a working SHA-256 tool, and this device has none." >&2
+    echo "One may be installed: a tool that is present but fails, or answers a known input" >&2
+    echo "wrongly, is reported here the same way as one that is absent -- neither can be used." >&2
+    echo "agmsg looks for 'shasum', then 'sha256sum', then 'openssl'. Install or repair one:" >&2
     echo "  macOS (Homebrew):      brew install openssl" >&2
     echo "  Debian/Ubuntu:         sudo apt install coreutils" >&2
     echo "  Windows (Git Bash):    ships with Git for Windows; reinstall it if 'sha256sum' is missing" >&2

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -68,6 +68,10 @@ source "$SCRIPT_DIR/lib/node.sh"
 # keyed on watcher-only concepts (session/actas) this engine does not have.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/instance-id.sh"
+# agmsg_sha256 -- the age-v1 checkpoint below is a SHA-256 of the snapshot, and
+# `shasum` is absent in Git for Windows' Git Bash.
+# shellcheck source=lib/hash.sh
+source "$SCRIPT_DIR/lib/hash.sh"
 
 TEAMS_DIR="$CONNECTION_ROOT/teams"
 CRED_ROOT="$CONNECTION_ROOT/run/remote-credentials"
@@ -247,6 +251,23 @@ cmd_doctor() {
     echo "  Debian/Ubuntu:         sudo apt install age"
     echo "  Windows (winget):      winget install FiloSottile.age"
     echo "See https://github.com/FiloSottile/age for other install methods."
+  fi
+  echo
+  # Reported with age, and optional for the same reason: only end-to-end
+  # encryption needs it. Not failed=1 -- a machine syncing with cipher "none"
+  # is fully functional without it. Listed at all because when it IS missing
+  # the symptom lands after the team is registered, which reads like a server
+  # problem rather than a missing tool.
+  if agmsg_sha256_usable; then
+    echo "  [x] SHA-256 tool on PATH  (optional)"
+  else
+    echo "  [ ] SHA-256 tool on PATH  (optional)"
+    echo
+    echo "End-to-end encryption needs one of 'shasum', 'sha256sum' or 'openssl' for key"
+    echo "fingerprints and the age-v1 checkpoint. Remote sync without --e2ee does not use it:"
+    echo "  macOS (Homebrew):      brew install openssl"
+    echo "  Debian/Ubuntu:         sudo apt install coreutils"
+    echo "  Windows (Git Bash):    ships with Git for Windows; reinstall it if 'sha256sum' is missing"
   fi
   echo
   if agmsg_python3_usable; then
@@ -1821,7 +1842,7 @@ _remote_configure_keyed_team() {
     echo "agmsg: could not export the initial age-v1 snapshot for team '$team'; sync was not started." >&2
     return 1
   fi
-  snapshot_sha="$(shasum -a 256 "$snapshot_file" | awk '{print $1}')"
+  snapshot_sha="$(agmsg_sha256 < "$snapshot_file")"
   if ! bash "$SCRIPT_DIR/remote-sync.sh" configure \
       --team "$team" \
       --server "$endpoint" \
@@ -1875,6 +1896,16 @@ cmd_connect() {
       ;;
   esac
   key_id="$(_remote_read_config_field "$cfg" '$.remote_key.current.key_id')"
+  # Asked HERE: before the key is minted and before the registration POST.
+  # Every SHA-256 in the e2ee path -- the fingerprint printed by `key.sh
+  # generate`, and the age-v1 checkpoint that starts the sync engine -- happens
+  # at or after those, so a device without one used to register the team and
+  # only then fail, reporting "binding recorded, sync engine not started" for
+  # what is a missing command-line tool. Same category as the `age` preflight:
+  # a prerequisite of end-to-end encryption, so it is only asked under --e2ee.
+  if [ "$e2ee" -eq 1 ]; then
+    agmsg_require_sha256 || exit 1
+  fi
   if [ "$e2ee" -eq 1 ] && { [ -z "$key_id" ] || [ "$key_id" = "null" ]; }; then
     bash "$SCRIPT_DIR/key.sh" generate "$team" || exit 1
     key_id="$(_remote_read_config_field "$cfg" '$.remote_key.current.key_id')"

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -239,53 +239,81 @@ _remote_prompt_read() {
 # Not a check, so no `[x]`/`[ ]` and no effect on the exit code: a lock that
 # exists is not a failed prerequisite, and a doctor that exits non-zero because
 # a team is busy would be wrong every time somebody is joining.
+# One lock, reported. Split out so the two ways of finding them — a named team,
+# or a sweep — share this body and neither has to feed a loop from a string.
+# Joining the paths into one variable and reading it back would mean either an
+# unquoted heredoc, which runs command substitution on a team name, or unquoted
+# word splitting, which globs one.
+_remote_doctor_one_lock() {
+  local lock="$1" team holder pid state q
+  [ -d "$lock" ] || return 0
+  team="${lock%/.config.lock}"
+  team="${team##*/}"
+  if [ "$shown" -eq 0 ]; then
+    echo "Registry locks:"
+    shown=1
+  fi
+  holder="$lock.holder"
+  pid=""
+  [ -f "$holder" ] && pid="$(sed -n 's/^pid //p' "$holder" 2>/dev/null | head -1)"
+  # THREE ANSWERS, NOT TWO. "held" and "the holder is gone" are what the
+  # operator acts on; "cannot tell" is neither — a lock this could not ask
+  # about, and saying it is gone would be a guess. The guess that costs is the
+  # one that calls a live lock dead and then prints the command to remove it.
+  #
+  # WHICH IS WHY THE NUMBER IS VALIDATED BEFORE IT IS ASKED ABOUT.
+  # `_agmsg_pid_alive_local` returns false for a value it never put to the
+  # process table at all — non-numeric, leading zero, past the POSIX ceiling —
+  # and folding that into "not running" turned `pid not-a-pid` into a stale
+  # verdict with a removal beside it (raised in review). The same ceiling the
+  # helper uses, for the same reason it uses it.
+  if [ -z "$pid" ]; then
+    state="cannot tell — no holder recorded"
+  elif ! _agmsg_pid_valid "$pid" 2147483647; then
+    state="cannot tell — the holder record's pid is not a usable number"
+  elif _agmsg_pid_alive_local "$pid"; then
+    state="held — pid $pid is running"
+  else
+    state="stale — pid $pid is not running"
+  fi
+  echo "  $team: $state"
+  if [ -f "$holder" ]; then
+    echo "    records: $(tr '\n' ' ' < "$holder" 2>/dev/null)"
+  fi
+  echo "    created: $(ls -ld "$lock" 2>/dev/null || printf '%s (cannot stat)' "$lock")"
+  # QUOTED, because this is meant to be pasted. The store root and the team
+  # name can both contain a space, and an unquoted path becomes several
+  # arguments to `rm -r`. Same scheme as lib/shquote.sh.
+  q="$(printf "'%s'" "$(printf '%s' "$lock" | sed "s/'/'\\\\''/g")")"
+  if [ "$state" = "held — pid $pid is running" ]; then
+    echo "    a command is using this team. Nothing to do."
+  else
+    echo "    if no agmsg command is running for this team, remove it:"
+    echo "      rm -r $q"
+    [ -f "$holder" ] && echo "      rm -f $q.holder"
+    echo "    nothing but the lock lives in there — it holds no team data."
+  fi
+}
+
 _remote_doctor_locks() {
-  local only_team="${1:-}" lock team holder pid state shown=0 q
-  # Every team, or the one named. `for` over a glob rather than `find`, which is
-  # not on every PATH this tree is required to run under.
-  for lock in "$TEAMS_DIR"/*/.config.lock; do
-    [ -d "$lock" ] || continue
-    team="${lock%/.config.lock}"
-    team="${team##*/}"
-    [ -z "$only_team" ] || [ "$team" = "$only_team" ] || continue
-    if [ "$shown" -eq 0 ]; then
-      echo "Registry locks:"
-      shown=1
-    fi
-    holder="$lock.holder"
-    pid=""
-    [ -f "$holder" ] && pid="$(sed -n 's/^pid //p' "$holder" 2>/dev/null | head -1)"
-    # THREE ANSWERS, NOT TWO. "held" and "the holder is gone" are what the
-    # operator acts on; "no holder recorded" is neither — it is a lock this
-    # cannot ask about, written either by a version of the library that recorded
-    # nothing or by a process that was killed between creating the lock and
-    # writing its record. Reporting it as gone would be a guess, and the guess
-    # that costs is the one that says a live lock is dead.
-    if [ -z "$pid" ]; then
-      state="cannot tell — no holder recorded"
-    elif _agmsg_pid_alive_local "$pid"; then
-      state="held — pid $pid is running"
-    else
-      state="stale — pid $pid is not running"
-    fi
-    echo "  $team: $state"
-    if [ -f "$holder" ]; then
-      echo "    records: $(tr '\n' ' ' < "$holder" 2>/dev/null)"
-    fi
-    echo "    created: $(ls -ld "$lock" 2>/dev/null || printf '%s (cannot stat)' "$lock")"
-    # QUOTED, because this is meant to be pasted. The store root and the team
-    # name can both contain a space, and an unquoted path becomes several
-    # arguments to `rm -r`. Same scheme as lib/shquote.sh.
-    q="$(printf "'%s'" "$(printf '%s' "$lock" | sed "s/'/'\\\\''/g")")"
-    if [ "$state" = "held — pid $pid is running" ]; then
-      echo "    a command is using this team. Nothing to do."
-    else
-      echo "    if no agmsg command is running for this team, remove it:"
-      echo "      rm -r $q"
-      [ -f "$holder" ] && echo "      rm -f $q.holder"
-      echo "    nothing but the lock lives in there — it holds no team data."
-    fi
-  done
+  local only_team="${1:-}" lock shown=0
+  # A NAMED TEAM IS LOOKED AT DIRECTLY, and the sweep does not stop at `*`.
+  #
+  # Team names may begin with a dot — the validator rejects empty, `.`, `..`, a
+  # leading `-`, `/`, `\` and control characters, and nothing else — and `*`
+  # does not match a leading dot, so `.foo` was invisible to the sweep (raised
+  # in review). The two extra patterns cover `.foo` and `..foo`; `.` and `..`
+  # themselves cannot be team names.
+  #
+  # Globs rather than `find`, which is not on every PATH this tree is required
+  # to run under. Quoted, so a team name containing a space stays one path.
+  if [ -n "$only_team" ]; then
+    _remote_doctor_one_lock "$TEAMS_DIR/$only_team/.config.lock"
+  else
+    for lock in "$TEAMS_DIR"/*/.config.lock "$TEAMS_DIR"/.[!.]*/.config.lock "$TEAMS_DIR"/..?*/.config.lock; do
+      _remote_doctor_one_lock "$lock"
+    done
+  fi
   [ "$shown" -eq 0 ] || echo
 }
 
@@ -345,7 +373,11 @@ cmd_doctor() {
   echo
   _remote_doctor_locks "$team"
   if [ "$failed" -eq 0 ]; then
-    echo "All checks passed."
+    # NARROWED, because a lock report can sit above this line. "All checks
+    # passed." after "stale — pid 4711 is not running" and a `rm -r` reads as
+    # cancelling it, and the exit code deliberately does not move: a locked team
+    # is not a failed prerequisite (raised in review).
+    echo "All prerequisite checks passed."
   else
     echo "Some checks failed. See above."
     exit 1

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -285,6 +285,17 @@ cmd_doctor() {
 
 # --- shared HTTP helpers (B1: never put secrets in curl's own argv/ps) ---
 
+# _remote_curl_path <path> — render <path> for embedding INSIDE a curl -K config
+# file. On Windows/Git Bash, MSYS translates POSIX paths to Windows form only for
+# a native binary's argv, NOT for paths read from a config file's contents, so an
+# embedded /tmp or /c/.. path is unopenable by native curl (→ curl fails → the
+# caller's HTTP 000). cygpath -m yields a Windows drive path with FORWARD slashes;
+# -w is wrong here because curl's config parser treats backslashes as escapes.
+# Capability-gated on cygpath so macOS/Linux (no cygpath) are unchanged.
+_remote_curl_path() {
+  if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s' "$1"; fi
+}
+
 # _remote_http_post_json <url> <body_file> <out_body_file> <out_header_file> -> prints http_code
 # Posts <body_file> as the request body via a curl -K config file, so the
 # body (which holds the token) never appears in curl's own argv/ps. The
@@ -311,11 +322,11 @@ _remote_http_post_json() {
     printf 'request = "POST"\n'
     printf 'header = "Content-Type: application/json"\n'
     printf 'header = "Agmsg-Protocol-Version: 1"\n'
-    printf 'dump-header = "%s"\n' "$header_fifo"
+    printf 'dump-header = "%s"\n' "$(_remote_curl_path "$header_fifo")"
     printf 'connect-timeout = "10"\n'
     printf 'max-time = "15"\n'
     printf 'max-filesize = "2097152"\n'
-    printf 'data = "@%s"\n' "$body_file"
+    printf 'data = "@%s"\n' "$(_remote_curl_path "$body_file")"
   } > "$cfg"
   if curl_output=$(curl -sS -o "$out_file" -w '%{http_code}' -K "$cfg" 2>/dev/null); then
     :

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -312,8 +312,13 @@ _remote_http_post_json() {
   # hidden, because it is a real difference between the platforms and not a
   # detail of how the file is named.
   #
-  # Gated on `command -v cygpath`, not on an OS name: what decides is whether a
-  # real fifo can be made, and that is what the probe asks.
+  # Gated on `command -v cygpath`, not on an OS name. Say what that probe
+  # actually asks, because it is narrower than the thing we care about: it is a
+  # CAPABILITY MARKER for an environment where MSYS fifos and a native curl
+  # coexist -- it does not test whether a real fifo can be made, and nothing
+  # here does. An earlier version of this comment claimed it did, which would
+  # have told the next reader that a machine passing the probe had been checked
+  # for the property that matters.
   if command -v cygpath >/dev/null 2>&1; then
     header_fifo="$header_file"
     : > "$header_fifo"

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -308,6 +308,17 @@ _remote_doctor_locks() {
   # Globs rather than `find`, which is not on every PATH this tree is required
   # to run under. Quoted, so a team name containing a space stays one path.
   if [ -n "$only_team" ]; then
+    # VALIDATED BEFORE IT BECOMES A PATH. `cmd_doctor` takes its argument and,
+    # until this line, only ever put it in a header sentence — so nothing had
+    # ever checked it. Building `$TEAMS_DIR/$only_team/.config.lock` from it
+    # turned `doctor ../outside` into a read of a directory outside the store,
+    # reported with its records and a `rm -r` to paste (raised in review). The
+    # sweep it replaced never reached one only because no team was named that.
+    #
+    # The same validator every other team-taking path uses: it rejects empty,
+    # `.`, `..`, `/`, `\`, a leading `-` and control characters, and allows a
+    # leading dot and a space, which this reports on and must keep.
+    agmsg_validate_team_name "$only_team" || return 1
     _remote_doctor_one_lock "$TEAMS_DIR/$only_team/.config.lock"
   else
     for lock in "$TEAMS_DIR"/*/.config.lock "$TEAMS_DIR"/.[!.]*/.config.lock "$TEAMS_DIR"/..?*/.config.lock; do
@@ -371,7 +382,10 @@ cmd_doctor() {
     failed=1
   fi
   echo
-  _remote_doctor_locks "$team"
+  # A REJECTED TEAM NAME ENDS THE COMMAND. The validator prints why; carrying on
+  # to "All prerequisite checks passed." after refusing to look at what was
+  # asked about would report success for a question nobody answered.
+  _remote_doctor_locks "$team" || exit 1
   if [ "$failed" -eq 0 ]; then
     # NARROWED, because a lock report can sit above this line. "All checks
     # passed." after "stale — pid 4711 is not running" and a `rm -r` reads as

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -258,10 +258,13 @@ cmd_doctor() {
   # is fully functional without it. Listed at all because when it IS missing
   # the symptom lands after the team is registered, which reads like a server
   # problem rather than a missing tool.
+  # "usable", not "on PATH": presence and usability are different questions and
+  # this line answers the second one -- a tool that is installed and fails, or
+  # that returns the wrong digest for a known input, reports unusable here.
   if agmsg_sha256_usable; then
-    echo "  [x] SHA-256 tool on PATH  (optional)"
+    echo "  [x] usable SHA-256 tool  (optional)"
   else
-    echo "  [ ] SHA-256 tool on PATH  (optional)"
+    echo "  [ ] usable SHA-256 tool  (optional)"
     echo
     echo "End-to-end encryption needs one of 'shasum', 'sha256sum' or 'openssl' for key"
     echo "fingerprints and the age-v1 checkpoint. Remote sync without --e2ee does not use it:"

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -221,6 +221,74 @@ _remote_prompt_read() {
 # token, no state change, safe whether or not the team is already connected.
 # Currently just the age-binary-presence check (§8) — the natural home for
 # any future preflight check added later.
+# WHICH DIRECTORY TO REMOVE — the thing that was missing (#865).
+#
+# A registry lock left behind by a killed process is never broken by anything:
+# nothing expires, nothing sweeps, and acquire waits out its budget and fails
+# with `timed out acquiring registry lock`, which describes contention. The
+# operator's next move is to look for the process holding it; there is no
+# process, and no message anywhere names the directory to remove. A machine in
+# that state cannot get itself out.
+#
+# This REPORTS and removes nothing. The report alone ends "cannot recover":
+# it says which team, what the lock records, whether that process is running,
+# and prints the removal as a line to paste. Sweeping automatically is a
+# separate decision with a worse failure mode — a wrong verdict takes a lock
+# away from a process that is using it — and it is not made here.
+#
+# Not a check, so no `[x]`/`[ ]` and no effect on the exit code: a lock that
+# exists is not a failed prerequisite, and a doctor that exits non-zero because
+# a team is busy would be wrong every time somebody is joining.
+_remote_doctor_locks() {
+  local only_team="${1:-}" lock team holder pid state shown=0 q
+  # Every team, or the one named. `for` over a glob rather than `find`, which is
+  # not on every PATH this tree is required to run under.
+  for lock in "$TEAMS_DIR"/*/.config.lock; do
+    [ -d "$lock" ] || continue
+    team="${lock%/.config.lock}"
+    team="${team##*/}"
+    [ -z "$only_team" ] || [ "$team" = "$only_team" ] || continue
+    if [ "$shown" -eq 0 ]; then
+      echo "Registry locks:"
+      shown=1
+    fi
+    holder="$lock.holder"
+    pid=""
+    [ -f "$holder" ] && pid="$(sed -n 's/^pid //p' "$holder" 2>/dev/null | head -1)"
+    # THREE ANSWERS, NOT TWO. "held" and "the holder is gone" are what the
+    # operator acts on; "no holder recorded" is neither — it is a lock this
+    # cannot ask about, written either by a version of the library that recorded
+    # nothing or by a process that was killed between creating the lock and
+    # writing its record. Reporting it as gone would be a guess, and the guess
+    # that costs is the one that says a live lock is dead.
+    if [ -z "$pid" ]; then
+      state="cannot tell — no holder recorded"
+    elif _agmsg_pid_alive_local "$pid"; then
+      state="held — pid $pid is running"
+    else
+      state="stale — pid $pid is not running"
+    fi
+    echo "  $team: $state"
+    if [ -f "$holder" ]; then
+      echo "    records: $(tr '\n' ' ' < "$holder" 2>/dev/null)"
+    fi
+    echo "    created: $(ls -ld "$lock" 2>/dev/null || printf '%s (cannot stat)' "$lock")"
+    # QUOTED, because this is meant to be pasted. The store root and the team
+    # name can both contain a space, and an unquoted path becomes several
+    # arguments to `rm -r`. Same scheme as lib/shquote.sh.
+    q="$(printf "'%s'" "$(printf '%s' "$lock" | sed "s/'/'\\\\''/g")")"
+    if [ "$state" = "held — pid $pid is running" ]; then
+      echo "    a command is using this team. Nothing to do."
+    else
+      echo "    if no agmsg command is running for this team, remove it:"
+      echo "      rm -r $q"
+      [ -f "$holder" ] && echo "      rm -f $q.holder"
+      echo "    nothing but the lock lives in there — it holds no team data."
+    fi
+  done
+  [ "$shown" -eq 0 ] || echo
+}
+
 cmd_doctor() {
   local team="${1:-}"
   echo "Checking prerequisites${team:+ for team '$team'}..."
@@ -275,6 +343,7 @@ cmd_doctor() {
     failed=1
   fi
   echo
+  _remote_doctor_locks "$team"
   if [ "$failed" -eq 0 ]; then
     echo "All checks passed."
   else

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -295,17 +295,42 @@ _remote_http_post_json() {
   cfg="$(mktemp "${TMPDIR:-/tmp}/agmsg-curl-cfg.XXXXXX")"
   fifo_dir="$(mktemp -d "${TMPDIR:-/tmp}/agmsg-header-pipe.XXXXXX")"
   header_fifo="$fifo_dir/header"
-  mkfifo "$header_fifo"
   chmod 600 "$cfg"
-  trap 'rm -f "$cfg" "$header_fifo"; rmdir "$fifo_dir" 2>/dev/null || true' EXIT INT TERM
-  # Reaped on both normal paths below (waited on success, killed and waited on
-  # failure), so this is short-lived by construction -- but the EXIT trap only
-  # removes files, it does not kill the copier. A signal arriving before curl
-  # opens the fifo therefore leaves it blocked on open() with no writer ever
-  # coming, and an inherited fd 3 would then hold a bats test file open to the
-  # timeout. Closing the fds costs nothing and removes that one path.
-  python3 "$SCRIPT_DIR/internal/bounded-copy.py" 65536 < "$header_fifo" > "$header_file" 3>&- 4>&- &
-  copier_pid=$!
+  # The headers go through a fifo so a hostile or broken server cannot make us
+  # buffer an unbounded response — bounded-copy.py enforces the ceiling while
+  # the transfer is still running. That mechanism needs a real named pipe.
+  #
+  # On Windows/Git Bash there is no real named pipe to have: MSYS emulates
+  # mkfifo with a .lnk file that only MSYS-aware programs understand, and curl
+  # there is a NATIVE binary. It cannot open what mkfifo made, so it fails and
+  # the caller sees the "000" it reports for every failure alike.
+  #
+  # Where cygpath exists, dump straight to the destination file and skip both
+  # the fifo and the copier. That gives up streaming enforcement of the size
+  # ceiling on that platform — curl's own `max-filesize` still applies to the
+  # BODY, and the header dump is what becomes unbounded. Stated rather than
+  # hidden, because it is a real difference between the platforms and not a
+  # detail of how the file is named.
+  #
+  # Gated on `command -v cygpath`, not on an OS name: what decides is whether a
+  # real fifo can be made, and that is what the probe asks.
+  if command -v cygpath >/dev/null 2>&1; then
+    header_fifo="$header_file"
+    : > "$header_fifo"
+    copier_pid=""
+    trap 'rm -f "$cfg"; rmdir "$fifo_dir" 2>/dev/null || true' EXIT INT TERM
+  else
+    mkfifo "$header_fifo"
+    trap 'rm -f "$cfg" "$header_fifo"; rmdir "$fifo_dir" 2>/dev/null || true' EXIT INT TERM
+    # Reaped on both normal paths below (waited on success, killed and waited on
+    # failure), so this is short-lived by construction -- but the EXIT trap only
+    # removes files, it does not kill the copier. A signal arriving before curl
+    # opens the fifo therefore leaves it blocked on open() with no writer ever
+    # coming, and an inherited fd 3 would then hold a bats test file open to the
+    # timeout. Closing the fds costs nothing and removes that one path.
+    python3 "$SCRIPT_DIR/internal/bounded-copy.py" 65536 < "$header_fifo" > "$header_file" 3>&- 4>&- &
+    copier_pid=$!
+  fi
   {
     printf 'url = "%s"\n' "$url"
     printf 'request = "POST"\n'
@@ -323,15 +348,20 @@ _remote_http_post_json() {
     curl_status=$?
   fi
   if [ "$curl_status" -ne 0 ]; then
-    kill "$copier_pid" 2>/dev/null || true
-    wait "$copier_pid" 2>/dev/null || true
+    [ -n "$copier_pid" ] && { kill "$copier_pid" 2>/dev/null || true; wait "$copier_pid" 2>/dev/null || true; }
     http_code="000"
-  elif wait "$copier_pid"; then
+  elif [ -z "$copier_pid" ] || wait "$copier_pid"; then
     http_code="$curl_output"
   else
     http_code="000"
   fi
-  rm -f "$cfg" "$header_fifo"
+  # Only remove the fifo, never the caller's header file. On the cygpath path
+  # `header_fifo` IS `header_file`, so an unconditional `rm -f "$header_fifo"`
+  # here deletes the headers this function was asked to produce — before the
+  # caller has read them. The fifo exists only when a copier was started, so
+  # that is the condition to key on.
+  rm -f "$cfg"
+  [ -n "$copier_pid" ] && rm -f "$header_fifo"
   rmdir "$fifo_dir" 2>/dev/null || true
   trap - EXIT INT TERM
   printf '%s' "$http_code"

--- a/tests/test_hash.bats
+++ b/tests/test_hash.bats
@@ -177,6 +177,141 @@ sha256_under() {
   [[ "$output" == *install* ]]
 }
 
+# THE REFUSAL WITHOUT THE CALLER'S HELP. Every case above runs under
+# `set -euo pipefail`, so none of them can tell "the helper failed" from "the
+# caller's pipefail noticed that the last stage got nothing". This one turns
+# pipefail OFF, which is the shell any caller that has not opted in provides.
+#
+# A PRESENT-BUT-BROKEN TOOL, NOT AN ABSENT ONE. The first version of this case
+# used an empty pathbox and could not fail: with no tool at all the helper takes
+# its `else` branch and returns 1 outright, which never depended on pipefail.
+# It measured nothing, and the mutation that should have reddened it did not.
+# A tool that is FOUND and then fails is the only path where the status of the
+# tool has to survive on its own.
+@test "hash: a broken tool is refused even when the caller has no pipefail" {
+  local shim="$TEST_SKILL_DIR/nopipefail"
+  mkdir -p "$shim"
+  printf '#!/bin/sh\nexit 1\n' > "$shim/shasum"
+  chmod +x "$shim/shasum"
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '
+    set +o pipefail
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+# THE HALF THE SHAPE CHECK CANNOT SEE. A tool that exits non-zero while still
+# printing a well-formed digest passes every check on the answer and is caught
+# only by the status of the tool itself. Without this case, reverting the arms
+# to their piped form changes no result, because the 64-hex check happens to
+# catch every other broken-tool shape.
+@test "hash: a tool that fails while printing a plausible digest is refused" {
+  local shim="$TEST_SKILL_DIR/failsloud"
+  mkdir -p "$shim"
+  printf '#!/bin/sh\ncat >/dev/null\necho "%s  -"\nexit 1\n' "$AGMSG_SHA256" > "$shim/shasum"
+  chmod +x "$shim/shasum"
+  # Control: the digest it prints is the RIGHT one, so nothing about the answer
+  # is what makes this fail.
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c 'printf x | shasum -a 256 | cut -d" " -f1'
+  [ "$output" = "$AGMSG_SHA256" ]
+
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '
+    set +o pipefail
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "hash: and it still answers correctly with no pipefail when a tool is there" {
+  # The other half, so the case above cannot pass by refusing everything.
+  run env PATH="$PATH" "$BASH_BIN" -c '
+    set +o pipefail
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256
+  ' _ "$SCRIPTS"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$AGMSG_SHA256" ]
+}
+
+# EXIT 0 IS NOT A DIGEST. The broken-tool case above uses `exit 1`, which any
+# status check catches. This is the one that gets through a status check: a
+# tool that succeeds and prints something else -- a warning, a path, an empty
+# line -- and whose output would be carried into a fingerprint.
+@test "hash: a tool that exits 0 and prints a non-digest is refused" {
+  local shim="$TEST_SKILL_DIR/liar"
+  mkdir -p "$shim"
+  local tool
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\ncat >/dev/null\necho "warning: cannot read the input"\nexit 0\n' > "$shim/$tool"
+    chmod +x "$shim/$tool"
+  done
+  # Control: it really does exit 0, so a status check alone would pass it.
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c 'printf x | shasum -a 256 >/dev/null'
+  [ "$status" -eq 0 ]
+
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+}
+
+# 64 hex characters that are the WRONG 64. Nothing about the shape of the answer
+# says it is the digest of the input, and this value is the one two people read
+# to each other. The refusal here lives in the probe, not in agmsg_sha256 --
+# which is why the probe checks against a known digest rather than for content.
+@test "hash: a tool returning a well-formed but wrong digest is not usable" {
+  local shim="$TEST_SKILL_DIR/plausible"
+  mkdir -p "$shim"
+  local tool
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\ncat >/dev/null\necho "%s  -"\n' \
+      0000000000000000000000000000000000000000000000000000000000000000 > "$shim/$tool"
+    chmod +x "$shim/$tool"
+  done
+  # Control: agmsg_sha256 itself accepts it, because it IS 64 lowercase hex.
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256
+  ' _ "$SCRIPTS"
+  [ "$status" -eq 0 ]
+  [ "$output" = 0000000000000000000000000000000000000000000000000000000000000000 ]
+
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+}
+
+# THE FALLBACK IS FOR AN ABSENT TOOL, NOT A BROKEN ONE. Presence picks the arm;
+# a chosen arm that fails ends it, and the working tool behind it is not tried.
+# Asserted because it is a decision, and an undocumented decision becomes an
+# accident the first time someone "fixes" it.
+@test "hash: a broken first arm is not rescued by a working later one" {
+  local shim="$TEST_SKILL_DIR/firstbroken"
+  mkdir -p "$shim"
+  printf '#!/bin/sh\nexit 1\n' > "$shim/shasum"
+  chmod +x "$shim/shasum"
+  local box; box="$(pathbox firstbroken-real awk openssl)" || skip "openssl not installed"
+  # Control: openssl alone, in that box, does answer.
+  run sha256_under "$box"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$AGMSG_SHA256" ]
+
+  run env PATH="$shim:$box" "$BASH_BIN" -c '
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
 # agmsg_sha1 is deliberately NOT changed by this work. Asserted here so that
 # "make the two consistent" has to break a test rather than pass review.
 @test "hash: agmsg_sha1 still answers with no digest tool at all (cksum arm)" {

--- a/tests/test_hash.bats
+++ b/tests/test_hash.bats
@@ -264,11 +264,16 @@ sha256_under() {
   [ "$status" -ne 0 ]
 }
 
-# 64 hex characters that are the WRONG 64. Nothing about the shape of the answer
+# 64 hex characters that are the WRONG 64. Nothing about the shape of an answer
 # says it is the digest of the input, and this value is the one two people read
-# to each other. The refusal here lives in the probe, not in agmsg_sha256 --
-# which is why the probe checks against a known digest rather than for content.
-@test "hash: a tool returning a well-formed but wrong digest is not usable" {
+# to each other.
+#
+# THE REFUSAL IS agmsg_sha256'S OWN, not the preflight's. It was the preflight's
+# for one head, which left `key.sh` — its own CLI, four subcommands, none of
+# them going through `connect` — accepting the wrong value. Raised in review.
+# The case now pins both halves: the shape layer accepts it, and the function
+# every caller actually uses does not.
+@test "hash: a tool returning a well-formed but wrong digest is refused" {
   local shim="$TEST_SKILL_DIR/plausible"
   mkdir -p "$shim"
   local tool
@@ -277,13 +282,21 @@ sha256_under() {
       0000000000000000000000000000000000000000000000000000000000000000 > "$shim/$tool"
     chmod +x "$shim/$tool"
   done
-  # Control: agmsg_sha256 itself accepts it, because it IS 64 lowercase hex.
+  # Control: the shape layer accepts it, because it IS 64 lowercase hex. So the
+  # refusal below is the self-test and not something about the answer's form.
   run env PATH="$shim:$PATH" "$BASH_BIN" -c '
     . "$1/lib/hash.sh"
-    printf "%s" agmsg | agmsg_sha256
+    printf "%s" agmsg | _agmsg_sha256_selected
   ' _ "$SCRIPTS"
   [ "$status" -eq 0 ]
   [ "$output" = 0000000000000000000000000000000000000000000000000000000000000000 ]
+
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
 
   run env PATH="$shim:$PATH" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
   [ "$status" -ne 0 ]

--- a/tests/test_hash.bats
+++ b/tests/test_hash.bats
@@ -1,0 +1,183 @@
+#!/usr/bin/env bats
+#
+# agmsg_sha256's fallback chain, exercised by taking the tools away.
+#
+# This suite is unusual for a portability fix and worth saying why: the bug it
+# covers (#861) is `shasum` missing from Git for Windows' Git Bash, and yet
+# NOTHING here needs Windows. The behaviour that broke is selected by
+# `command -v`, so a PATH holding only the tools we choose reproduces each
+# platform's choice exactly, on any platform. Where a capability branch is
+# probed rather than switched on an OS name, the probe is the thing to drive.
+#
+# Every case asserts the same LITERAL digest rather than "the arms agree with
+# each other". Three arms that agree could agree on a wrong answer; the literal
+# says each one computes SHA-256.
+
+load test_helper
+
+# printf '%s' agmsg | sha256sum
+readonly AGMSG_SHA256=5d2d1e5ffb2742e3830c7b49e324852dbcc6c16056d9cc0a900247a403ae60f2
+
+setup() {
+  setup_test_env
+  # Absolute, because the tests below run commands under a PATH that
+  # deliberately does not contain a shell.
+  BASH_BIN="$(command -v bash)"
+  PATHBOX="$TEST_SKILL_DIR/pathbox"
+}
+
+teardown() {
+  teardown_test_env
+}
+
+# pathbox <name> <tool>... -> prints a directory containing ONLY those tools.
+#
+# Symlinks to the real binaries, not copies: a copy that arrives without its
+# executable bit fails every case for a reason that has nothing to do with what
+# is under test, and looks exactly like the fallback working.
+#
+# Returns 1 (and the caller skips) when a tool this machine does not have is
+# asked for -- macOS runners have no `sha256sum`, and a silently-skipped arm
+# that reports success is the failure mode this file exists to avoid.
+pathbox() {
+  local dir="$PATHBOX/$1"; shift
+  mkdir -p "$dir"
+  local tool src
+  for tool in "$@"; do
+    src="$(command -v "$tool")" || return 1
+    ln -sf "$src" "$dir/$tool"
+  done
+  printf '%s' "$dir"
+}
+
+# Run `printf '%s' agmsg | agmsg_sha256` with PATH set to $1 and nothing else.
+sha256_under() {
+  local box="$1"
+  PATH="$box" "$BASH_BIN" -c '
+    set -euo pipefail
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256
+  ' _ "$SCRIPTS"
+}
+
+@test "hash: agmsg_sha256 on the unrestricted PATH returns the real digest" {
+  run sha256_under "$PATH"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$AGMSG_SHA256" ]
+}
+
+# The negative control for every case below it. If a pathbox did NOT hide the
+# tool it claims to hide, the fallback tests would pass without ever leaving
+# the first arm -- green, and measuring nothing.
+@test "hash: a pathbox really does hide the tools it leaves out" {
+  local box; box="$(pathbox control awk)" || skip "awk not found"
+  run env PATH="$box" "$BASH_BIN" -c 'command -v shasum || echo ABSENT'
+  [ "$status" -eq 0 ]
+  [ "$output" = "ABSENT" ]
+  # ...and the positive half: a tool that IS in the box is found.
+  run env PATH="$box" "$BASH_BIN" -c 'command -v awk >/dev/null && echo PRESENT'
+  [ "$output" = "PRESENT" ]
+}
+
+@test "hash: the shasum arm computes SHA-256" {
+  local box; box="$(pathbox shasum awk shasum)" || skip "shasum not installed"
+  run sha256_under "$box"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$AGMSG_SHA256" ]
+}
+
+@test "hash: without shasum it falls through to sha256sum, same value" {
+  local box; box="$(pathbox sha256sum awk sha256sum)" || skip "sha256sum not installed"
+  run sha256_under "$box"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$AGMSG_SHA256" ]
+}
+
+@test "hash: without shasum or sha256sum it falls through to openssl, same value" {
+  local box; box="$(pathbox openssl awk openssl)" || skip "openssl not installed"
+  run sha256_under "$box"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$AGMSG_SHA256" ]
+}
+
+# The whole point of the different last resort. agmsg_sha1 ends in `cksum` and
+# always answers; this one must refuse.
+@test "hash: with no SHA-256 tool at all it FAILS instead of answering" {
+  local box; box="$(pathbox none awk)" || skip "awk not found"
+  # stderr discarded INSIDE: bats' `run` merges the two streams, so the
+  # diagnostic would land in $output and the "nothing was printed" assertion
+  # below would be measuring the error message.
+  run env PATH="$box" "$BASH_BIN" -c '
+    set -euo pipefail
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  # And nothing on stdout: an empty success is the outcome that would be
+  # carried forward as a fingerprint or a checkpoint.
+  [ -z "$output" ]
+}
+
+@test "hash: the failure says which tools were looked for" {
+  local box; box="$(pathbox nonemsg awk)" || skip "awk not found"
+  run env PATH="$box" "$BASH_BIN" -c '
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha256 2>&1 >/dev/null
+  ' _ "$SCRIPTS"
+  [[ "$output" == *shasum* ]]
+  [[ "$output" == *sha256sum* ]]
+  [[ "$output" == *openssl* ]]
+}
+
+@test "hash: agmsg_sha256_usable reports what agmsg_sha256 can actually do" {
+  local box; box="$(pathbox usable-no awk)" || skip "awk not found"
+  run env PATH="$box" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+
+  box="$(pathbox usable-yes awk openssl)" || skip "openssl not installed"
+  run env PATH="$box" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
+  [ "$status" -eq 0 ]
+}
+
+# The reason the probe runs the tool instead of asking `command -v`. A digest
+# tool that is installed and broken is exactly the case where a presence check
+# says yes and the digest says no -- and the whole value of a preflight is that
+# it disagrees with nothing later.
+@test "hash: agmsg_sha256_usable says no when the tools are present but broken" {
+  local shim="$TEST_SKILL_DIR/broken"
+  mkdir -p "$shim"
+  local tool
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\nexit 1\n' > "$shim/$tool"
+    chmod +x "$shim/$tool"
+  done
+  # Control first: they ARE on PATH, so a `command -v` probe would say yes.
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c 'command -v shasum >/dev/null && echo PRESENT'
+  [ "$output" = "PRESENT" ]
+
+  run env PATH="$shim:$PATH" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+}
+
+@test "hash: agmsg_require_sha256 names a way to install one" {
+  local box; box="$(pathbox require awk)" || skip "awk not found"
+  run env PATH="$box" "$BASH_BIN" -c '
+    . "$1/lib/hash.sh"
+    agmsg_require_sha256 2>&1 >/dev/null
+  ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *install* ]]
+}
+
+# agmsg_sha1 is deliberately NOT changed by this work. Asserted here so that
+# "make the two consistent" has to break a test rather than pass review.
+@test "hash: agmsg_sha1 still answers with no digest tool at all (cksum arm)" {
+  local box; box="$(pathbox sha1 awk cksum)" || skip "cksum not found"
+  run env PATH="$box" "$BASH_BIN" -c '
+    set -euo pipefail
+    . "$1/lib/hash.sh"
+    printf "%s" agmsg | agmsg_sha1
+  ' _ "$SCRIPTS"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}

--- a/tests/test_hash.bats
+++ b/tests/test_hash.bats
@@ -130,9 +130,11 @@ sha256_under() {
     . "$1/lib/hash.sh"
     printf "%s" agmsg | agmsg_sha256 2>&1 >/dev/null
   ' _ "$SCRIPTS"
-  [[ "$output" == *shasum* ]]
-  [[ "$output" == *sha256sum* ]]
-  [[ "$output" == *openssl* ]]
+  # grep, not `[[ ]]`: a non-last `[[ ]]` cannot fail a test on bash 3.2, so the
+  # first two of three would have been decoration (#670).
+  grep -qF -- shasum <<<"$output"
+  grep -qF -- sha256sum <<<"$output"
+  grep -qF -- openssl <<<"$output"
 }
 
 @test "hash: agmsg_sha256_usable reports what agmsg_sha256 can actually do" {

--- a/tests/test_hash.bats
+++ b/tests/test_hash.bats
@@ -102,8 +102,14 @@ sha256_under() {
 
 # The whole point of the different last resort. agmsg_sha1 ends in `cksum` and
 # always answers; this one must refuse.
+#
+# `cksum` IS in the box on purpose. Without it this test passed a mutation that
+# added the cksum arm -- not because the refusal survived, but because the
+# sandbox had no cksum for the fallback to reach. It was measuring the box, not
+# the decision. On any real machine cksum is present, so that is the shape the
+# test has to run in.
 @test "hash: with no SHA-256 tool at all it FAILS instead of answering" {
-  local box; box="$(pathbox none awk)" || skip "awk not found"
+  local box; box="$(pathbox none awk cksum)" || skip "awk/cksum not found"
   # stderr discarded INSIDE: bats' `run` merges the two streams, so the
   # diagnostic would land in $output and the "nothing was printed" assertion
   # below would be measuring the error message.
@@ -119,7 +125,7 @@ sha256_under() {
 }
 
 @test "hash: the failure says which tools were looked for" {
-  local box; box="$(pathbox nonemsg awk)" || skip "awk not found"
+  local box; box="$(pathbox nonemsg awk cksum)" || skip "awk/cksum not found"
   run env PATH="$box" "$BASH_BIN" -c '
     . "$1/lib/hash.sh"
     printf "%s" agmsg | agmsg_sha256 2>&1 >/dev/null
@@ -130,7 +136,7 @@ sha256_under() {
 }
 
 @test "hash: agmsg_sha256_usable reports what agmsg_sha256 can actually do" {
-  local box; box="$(pathbox usable-no awk)" || skip "awk not found"
+  local box; box="$(pathbox usable-no awk cksum)" || skip "awk/cksum not found"
   run env PATH="$box" "$BASH_BIN" -c '. "$1/lib/hash.sh"; agmsg_sha256_usable' _ "$SCRIPTS"
   [ "$status" -ne 0 ]
 
@@ -160,7 +166,7 @@ sha256_under() {
 }
 
 @test "hash: agmsg_require_sha256 names a way to install one" {
-  local box; box="$(pathbox require awk)" || skip "awk not found"
+  local box; box="$(pathbox require awk cksum)" || skip "awk/cksum not found"
   run env PATH="$box" "$BASH_BIN" -c '
     . "$1/lib/hash.sh"
     agmsg_require_sha256 2>&1 >/dev/null

--- a/tests/test_hash.bats
+++ b/tests/test_hash.bats
@@ -302,6 +302,33 @@ sha256_under() {
   [ "$status" -ne 0 ]
 }
 
+# NOTHING IN THE ENVIRONMENT CAN SAY "ALREADY CHECKED". The self-test was
+# memoised on one head, keyed on a plain shell variable that was read from the
+# environment — so exporting it turned the check off, which is an undocumented
+# override of a fail-closed contract. The memo is gone; this case is what stops
+# it coming back in a form that can be preseeded.
+#
+# Every plausible name is tried, because guessing the private name of a future
+# memo is not the point: the property is that NO inherited variable skips it.
+@test "hash: a preseeded environment cannot skip the self-test" {
+  local shim="$TEST_SKILL_DIR/preseeded"
+  mkdir -p "$shim"
+  local tool
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\ncat >/dev/null\necho "%s  -"\n' \
+      2222222222222222222222222222222222222222222222222222222222222222 > "$shim/$tool"
+    chmod +x "$shim/$tool"
+  done
+  run env PATH="$shim:$PATH" \
+    _AGMSG_SHA256_VERIFIED=1 AGMSG_SHA256_VERIFIED=1 _AGMSG_SHA256_OK=1 \
+    "$BASH_BIN" -c '
+      . "$1/lib/hash.sh"
+      printf "%s" agmsg | agmsg_sha256 2>/dev/null
+    ' _ "$SCRIPTS"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
 # THE FALLBACK IS FOR AN ABSENT TOOL, NOT A BROKEN ONE. Presence picks the arm;
 # a chosen arm that fails ends it, and the working tool behind it is not tried.
 # Asserted because it is a decision, and an undocumented decision becomes an

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -695,8 +695,38 @@ break_the_digest() {
   refute grep -qE 'Recipient fingerprint: *$' <<<"$output"
 }
 
-# The control for the two above: with the digest working, the same commands
-# print a fingerprint that is actually there. Without this, both tests would
+# A TOOL THAT SUCCEEDS AND LIES. The shim above exits 1, which any status check
+# catches. This one exits 0 and prints a well-formed digest that is not the
+# digest of the input — and `key.sh` is its own CLI: `generate`, `show`,
+# `import` and `rotate` all reach a digest without passing `connect`'s
+# preflight, so for one head the preflight was the only thing asking whether the
+# answer was right and none of these four asked it. Raised in review.
+#
+# Driven from `key.sh` deliberately, not from the helper: the claim is about
+# what this command does, and a helper-level case cannot fail if a caller stops
+# using the helper.
+@test "key generate: a tool that returns the wrong digest stops the command" {
+  skip_if_no_age
+  local shim="$TEST_SKILL_DIR/lying-digest"
+  mkdir -p "$shim"
+  local tool
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\ncat >/dev/null\necho "%s  -"\n' \
+      1111111111111111111111111111111111111111111111111111111111111111 > "$shim/$tool"
+    chmod +x "$shim/$tool"
+  done
+  # Control: it exits 0 and its answer has the shape of a digest, so nothing
+  # short of asking a question with a known answer distinguishes it.
+  run env PATH="$shim:$PATH" bash -c 'printf x | shasum -a 256'
+  [ "$status" -eq 0 ]
+
+  run env PATH="$shim:$PATH" bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -ne 0 ]
+  refute grep -qE '1111111111111111' <<<"$output"
+}
+
+# The control for the three above: with the digest working, the same commands
+# print a fingerprint that is actually there. Without this, they would all
 # still pass if key.sh had simply stopped working entirely.
 @test "key generate: the working case still prints a non-empty fingerprint" {
   skip_if_no_age

--- a/tests/test_key.bats
+++ b/tests/test_key.bats
@@ -651,6 +651,60 @@ PY_BIND
   [[ "$output" == *"no current key"* ]]
 }
 
+# --- fingerprint: never print one that was not computed (#861) -------------
+
+# A recipient fingerprint exists so two people can read the same short string
+# to each other over a separate channel and agree they hold the same key. If
+# the digest cannot be computed, BOTH of them see an empty string and both say
+# it matches. That is worse than no fingerprint at all, so a digest that fails
+# has to stop the command rather than print a label with nothing after it.
+#
+# Driven by making the first digest arm fail rather than by emptying PATH:
+# key.sh needs a dozen other tools to reach this line, and a PATH restricted
+# far enough to hide `shasum` would stop it long before the fingerprint for
+# reasons that have nothing to do with #861.
+break_the_digest() {
+  local shim="$TEST_SKILL_DIR/broken-digest"
+  mkdir -p "$shim"
+  # All three arms, so this does not quietly become "the second arm answered".
+  local tool
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\nexit 1\n' > "$shim/$tool"
+    chmod +x "$shim/$tool"
+  done
+  printf '%s' "$shim"
+}
+
+@test "key generate: a digest that fails stops the command, no blank fingerprint" {
+  skip_if_no_age
+  local shim; shim="$(break_the_digest)"
+  run env PATH="$shim:$PATH" bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -ne 0 ]
+  # The label must not appear with an empty value after it. Matching the label
+  # plus end-of-line is the whole point: `*"Recipient fingerprint:"*` would be
+  # satisfied by exactly the broken output this test exists to reject.
+  refute grep -qE 'Recipient fingerprint: *$' <<<"$output"
+}
+
+@test "key show: a digest that fails stops the command, no blank fingerprint" {
+  skip_if_no_age
+  bash "$SCRIPTS/key.sh" generate testteam
+  local shim; shim="$(break_the_digest)"
+  run env PATH="$shim:$PATH" bash "$SCRIPTS/key.sh" show testteam
+  [ "$status" -ne 0 ]
+  refute grep -qE 'Recipient fingerprint: *$' <<<"$output"
+}
+
+# The control for the two above: with the digest working, the same commands
+# print a fingerprint that is actually there. Without this, both tests would
+# still pass if key.sh had simply stopped working entirely.
+@test "key generate: the working case still prints a non-empty fingerprint" {
+  skip_if_no_age
+  run bash "$SCRIPTS/key.sh" generate testteam
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qE 'Recipient fingerprint: [0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}$'
+}
+
 # --- dispatch --------------------------------------------------------------
 
 @test "key.sh: unknown subcommand prints usage and exits non-zero" {

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2597,6 +2597,61 @@ PY
   [[ "$output" == *"Some checks failed"* ]]
 }
 
+# --- SHA-256 availability (#861) -------------------------------------------
+
+# All three arms present but failing. Shadowing rather than emptying PATH:
+# connect needs most of the toolchain to reach the point under test, and a
+# PATH stripped far enough to hide these would stop it much earlier for
+# reasons that have nothing to do with #861.
+broken_digest_path() {
+  local dir tool
+  dir="$(mktemp -d)"
+  for tool in shasum sha256sum openssl; do
+    printf '#!/bin/sh\nexit 1\n' > "$dir/$tool"
+    chmod +x "$dir/$tool"
+  done
+  printf '%s' "$dir"
+}
+
+@test "remote doctor: reports a SHA-256 tool, and its absence does not fail the run" {
+  local broken; broken="$(broken_digest_path)"
+  run env PATH="$broken:$PATH" bash "$SCRIPTS/remote.sh" doctor
+  # Optional, exactly like age: a team on cipher "none" never computes one.
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[ ] SHA-256 tool on PATH"* ]]
+  [[ "$output" == *"All checks passed"* ]]
+}
+
+@test "remote doctor: reports the SHA-256 tool as present when one works" {
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[x] SHA-256 tool on PATH"* ]]
+}
+
+# The bug this preflight exists for: the first SHA-256 in a `connect --e2ee`
+# happens after the team is registered with the server, so the operator's news
+# of a missing tool arrived as a half-finished connect.
+@test "remote connect --e2ee: refuses BEFORE registering when no SHA-256 works" {
+  local broken; broken="$(broken_digest_path)"
+  run env PATH="$broken:$PATH" bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SHA-256"* ]]
+  # And the team is still unregistered. This is the half that makes it a
+  # PREflight: asserting only the message would pass just as well if the
+  # check ran after the POST.
+  run python3 -c "import json;print(json.load(open('$SCRIPTS/../teams/testteam/config.json')).get('remote_binding'))"
+  [ "$output" = "None" ]
+}
+
+# Plain sync never computes a SHA-256, so the same broken machine must still
+# be able to connect. Without this the preflight could be moved ahead of the
+# --e2ee test and nothing would notice.
+@test "remote connect without --e2ee: a broken SHA-256 tool does not block it" {
+  local broken; broken="$(broken_digest_path)"
+  run env PATH="$broken:$PATH" bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  [ "$status" -eq 0 ]
+}
+
 @test "remote pull: a name is enough — no UUID is carried by hand" {
   # The team_id requirement existed to stand in for authentication, and this
   # server has none to stand in for. The second machine should never need a

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -115,7 +115,7 @@ skip_if_no_age() {
   run bash "$SCRIPTS/remote.sh" doctor
   [ "$status" -eq 0 ]
   [[ "$output" == *"age / age-keygen on PATH"* ]]
-  [[ "$output" == *"All checks passed."* ]]
+  [[ "$output" == *"All prerequisite checks passed."* ]]
 }
 
 @test "remote doctor: is read-only (no token required, no state touched)" {
@@ -1550,7 +1550,7 @@ VALUES ('remote-pending.$key', $owner_pid, strftime('%Y-%m-%dT%H:%M:%SZ','now'))
     || skip "all doctor prerequisites are not installed"
   run bash "$SCRIPTS/remote.sh" doctor
   [ "$status" -eq 0 ]
-  [[ "$output" == *"All checks passed."* ]]
+  [[ "$output" == *"All prerequisite checks passed."* ]]
 }
 
 PULL_TEAM_ID=018f3f7e-2222-7000-8000-000000000002
@@ -2582,7 +2582,7 @@ PY
   local no_age; no_age="$(path_without_age)"
   run env PATH="$no_age" bash "$SCRIPTS/remote.sh" doctor
   [ "$status" -eq 0 ]
-  [[ "$output" == *"All checks passed"* ]]
+  [[ "$output" == *"All prerequisite checks passed"* ]]
   [[ "$output" == *"optional"* ]]
   [[ "$output" != *"is required for end-to-end encryption"* ]]
 }
@@ -2799,7 +2799,7 @@ make_lock() {  # make_lock <team> [pid]
   make_lock wedged "$gone"
   run bash "$SCRIPTS/remote.sh" doctor
   [ "$status" -eq 0 ]
-  grep -qF -- "All checks passed." <<<"$output"
+  grep -qF -- "All prerequisite checks passed." <<<"$output"
 }
 
 @test "remote doctor <team>: reports that team's lock and not another's (#865)" {
@@ -2810,4 +2810,58 @@ make_lock() {  # make_lock <team> [pid]
   [ "$status" -eq 0 ]
   grep -qF -- "mine: stale" <<<"$output"
   refute grep -qF -- "theirs: stale" <<<"$output"
+}
+
+@test "remote doctor: a pid that was never asked about is not called stale (#865)" {
+  # THE VERDICT AND THE REMOVAL RIDE TOGETHER, so "false" from the liveness
+  # helper is not enough on its own: it is also false for a value the helper
+  # refused to put to the process table at all. `pid not-a-pid` and a number
+  # past the POSIX ceiling were being reported as stale, with `rm -r` beside
+  # them (raised in review).
+  make_lock badpid
+  printf 'token t\npid not-a-pid\ncommand join.sh\nhost h\n' \
+    > "$TEST_SKILL_DIR/teams/badpid/.config.lock.holder"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "badpid: cannot tell" <<<"$output"
+  refute grep -qF -- "badpid: stale" <<<"$output"
+
+  # CONTROL: the helper does answer false for it, so this case is measuring the
+  # validation and not some other difference.
+  run bash -c ". \"$SCRIPTS/lib/instance-id.sh\"; _agmsg_pid_alive_local not-a-pid"
+  [ "$status" -ne 0 ]
+}
+
+@test "remote doctor: a pid past the POSIX ceiling is not called stale (#865)" {
+  make_lock hugepid
+  printf 'token t\npid 2147483648\ncommand join.sh\nhost h\n' \
+    > "$TEST_SKILL_DIR/teams/hugepid/.config.lock.holder"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "hugepid: cannot tell" <<<"$output"
+  refute grep -qF -- "hugepid: stale" <<<"$output"
+}
+
+@test "remote doctor: a team whose name begins with a dot is swept too (#865)" {
+  # `*` does not match a leading dot, and the team validator allows one — so the
+  # sweep walked past `.hidden` entirely (raised in review). The validator
+  # rejects empty, `.`, `..`, a leading `-`, `/`, `\` and control characters,
+  # and nothing else.
+  local gone; gone="$(doctor_lock_dead_pid)"
+  make_lock .hidden "$gone"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- ".hidden: stale" <<<"$output"
+}
+
+@test "remote doctor: the summary does not cancel a lock finding (#865)" {
+  # "All checks passed." above a stale lock and a removal command reads as
+  # withdrawing them. The exit code deliberately stays 0 — a locked team is not
+  # a failed prerequisite — so the wording is what has to carry the distinction.
+  local gone; gone="$(doctor_lock_dead_pid)"
+  make_lock wedged "$gone"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "All prerequisite checks passed." <<<"$output"
+  refute grep -qE '^All checks passed\.$' <<<"$output"
 }

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2618,7 +2618,7 @@ broken_digest_path() {
   run env PATH="$broken:$PATH" bash "$SCRIPTS/remote.sh" doctor
   # Optional, exactly like age: a team on cipher "none" never computes one.
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[ ] SHA-256 tool on PATH"* ]]
+  grep -qF -- '[ ] SHA-256 tool on PATH' <<<"$output"
   [[ "$output" == *"All checks passed"* ]]
 }
 
@@ -2635,7 +2635,7 @@ broken_digest_path() {
   local broken; broken="$(broken_digest_path)"
   run env PATH="$broken:$PATH" bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" --e2ee testteam
   [ "$status" -ne 0 ]
-  [[ "$output" == *"SHA-256"* ]]
+  grep -qF -- 'SHA-256' <<<"$output"
   # And the team is still unregistered. This is the half that makes it a
   # PREflight: asserting only the message would pass just as well if the
   # check ran after the POST.

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2618,14 +2618,17 @@ broken_digest_path() {
   run env PATH="$broken:$PATH" bash "$SCRIPTS/remote.sh" doctor
   # Optional, exactly like age: a team on cipher "none" never computes one.
   [ "$status" -eq 0 ]
-  grep -qF -- '[ ] SHA-256 tool on PATH' <<<"$output"
-  [[ "$output" == *"All checks passed"* ]]
+  # "usable", not "on PATH": this shim IS on PATH and fails when run, which is
+  # the distinction the line was reworded to keep -- see hash.sh.
+  grep -qF -- '[ ] usable SHA-256 tool' <<<"$output"
+  # grep, not `[[ ]]`: a non-last `[[ ]]` cannot fail a test on bash 3.2 (#670).
+  grep -qF -- 'All checks passed' <<<"$output"
 }
 
-@test "remote doctor: reports the SHA-256 tool as present when one works" {
+@test "remote doctor: reports the SHA-256 tool as usable when one works" {
   run bash "$SCRIPTS/remote.sh" doctor
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[x] SHA-256 tool on PATH"* ]]
+  grep -qF -- '[x] usable SHA-256 tool' <<<"$output"
 }
 
 # The bug this preflight exists for: the first SHA-256 in a `connect --e2ee`

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2714,3 +2714,100 @@ assert_lookup_rejected() {
   [[ "$output" != *"No such file or directory"*"remote.sh"* ]]
   [[ "$output" != *"Usage: remote.sh unlock"* ]]
 }
+
+# --- doctor names the wedged lock, and removes nothing (#865) ---------------
+#
+# A registry lock left by a killed process is never broken: acquire waits out
+# its budget and says "timed out acquiring registry lock", which describes
+# contention, and no message anywhere names the directory to remove. `doctor` is
+# where that becomes findable.
+
+doctor_lock_dead_pid() {  # a pid that is genuinely not running
+  local p
+  sleep 0 &
+  p=$!
+  wait "$p" 2>/dev/null || true
+  printf '%s' "$p"
+}
+
+make_lock() {  # make_lock <team> [pid]
+  mkdir -p "$TEST_SKILL_DIR/teams/$1"
+  mkdir -p "$TEST_SKILL_DIR/teams/$1/.config.lock"
+  if [ -n "${2:-}" ]; then
+    printf 'token t\npid %s\ncommand join.sh\nhost h\n' "$2" \
+      > "$TEST_SKILL_DIR/teams/$1/.config.lock.holder"
+  fi
+}
+
+@test "remote doctor: a lock whose holder is gone is named, with the way out (#865)" {
+  local gone; gone="$(doctor_lock_dead_pid)"
+  # CONTROL: the pid really is not running, asserted before it is written into
+  # the holder — a number that merely happened to be free would make this pass
+  # for a reason that has nothing to do with the report.
+  run bash -c ". \"$SCRIPTS/lib/instance-id.sh\"; _agmsg_pid_alive_local $gone"
+  [ "$status" -ne 0 ]
+
+  make_lock wedged "$gone"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "wedged: stale — pid $gone is not running" <<<"$output"
+  grep -qF -- "rm -r " <<<"$output"
+  # REPORTS ONLY. The whole point of doing this before an automatic sweep is
+  # that a wrong verdict must not cost anything.
+  [ -d "$TEST_SKILL_DIR/teams/wedged/.config.lock" ]
+}
+
+@test "remote doctor: a lock whose holder is alive is not called stale (#865)" {
+  sleep 30 &
+  local live=$!
+  # CONTROL: alive at the moment doctor runs, not merely spawned.
+  run bash -c ". \"$SCRIPTS/lib/instance-id.sh\"; _agmsg_pid_alive_local $live"
+  [ "$status" -eq 0 ]
+
+  make_lock busy "$live"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "busy: held — pid $live is running" <<<"$output"
+  # And it must NOT offer to remove a lock somebody is using.
+  refute grep -qF -- "if no agmsg command is running for this team" <<<"$output"
+  kill "$live" 2>/dev/null || true
+}
+
+@test "remote doctor: a lock with no holder record says it cannot tell (#865)" {
+  # Neither "held" nor "gone": written by a version that recorded nothing, or by
+  # a process killed between creating the lock and writing its record. Guessing
+  # here is what would cost a live lock.
+  make_lock unknown
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "unknown: cannot tell — no holder recorded" <<<"$output"
+  grep -qF -- "rm -r " <<<"$output"
+}
+
+@test "remote doctor: says nothing about locks when there are none (#865)" {
+  # The negative control for the three above: the section is absent on a healthy
+  # install, so "Registry locks:" appearing at all is a finding.
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  refute grep -qF -- "Registry locks:" <<<"$output"
+}
+
+@test "remote doctor: a lock does not fail the run (#865)" {
+  # A team being locked is not a failed prerequisite. If it set the exit code,
+  # doctor would fail every time somebody is joining.
+  local gone; gone="$(doctor_lock_dead_pid)"
+  make_lock wedged "$gone"
+  run bash "$SCRIPTS/remote.sh" doctor
+  [ "$status" -eq 0 ]
+  grep -qF -- "All checks passed." <<<"$output"
+}
+
+@test "remote doctor <team>: reports that team's lock and not another's (#865)" {
+  local gone; gone="$(doctor_lock_dead_pid)"
+  make_lock mine "$gone"
+  make_lock theirs "$gone"
+  run bash "$SCRIPTS/remote.sh" doctor mine
+  [ "$status" -eq 0 ]
+  grep -qF -- "mine: stale" <<<"$output"
+  refute grep -qF -- "theirs: stale" <<<"$output"
+}

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2865,3 +2865,45 @@ make_lock() {  # make_lock <team> [pid]
   grep -qF -- "All prerequisite checks passed." <<<"$output"
   refute grep -qE '^All checks passed\.$' <<<"$output"
 }
+
+@test "remote doctor <team>: a traversal argument is refused and reads nothing (#865)" {
+  # The named-team lookup builds a path from the argument, and until this was
+  # added nothing had ever validated it — `cmd_doctor` only ever put the value
+  # in a header sentence. A sentinel outside the store proves the refusal is
+  # about reach and not about the string.
+  local outside="$BATS_TEST_TMPDIR/outside"
+  mkdir -p "$outside/.config.lock"
+  printf 'token t\npid 1\ncommand join.sh\nhost h\n' > "$outside/.config.lock.holder"
+  # CONTROL: the sentinel is real and would be reported if it were reached —
+  # the same shape, under a team name, IS reported (the case above).
+  [ -d "$outside/.config.lock" ]
+
+  run bash "$SCRIPTS/remote.sh" doctor "../../$(basename "$BATS_TEST_TMPDIR")/outside"
+  [ "$status" -ne 0 ]
+  refute grep -qF -- "Registry locks:" <<<"$output"
+  refute grep -qF -- "rm -r " <<<"$output"
+  grep -qF -- "invalid team name" <<<"$output"
+  # And it must not claim the prerequisites verdict for a question it refused.
+  refute grep -qF -- "All prerequisite checks passed." <<<"$output"
+}
+
+@test "remote doctor <team>: a slash in the name is refused (#865)" {
+  run bash "$SCRIPTS/remote.sh" doctor "a/b"
+  [ "$status" -ne 0 ]
+  grep -qF -- "invalid team name" <<<"$output"
+}
+
+@test "remote doctor <team>: an ordinary and a dot-leading name still resolve (#865)" {
+  # The validator allows both, and the direct lookup has to keep working for
+  # them — a refusal that took the legitimate names with it would be the
+  # cheapest way to pass the two cases above.
+  local gone; gone="$(doctor_lock_dead_pid)"
+  make_lock plain "$gone"
+  make_lock .dotted "$gone"
+  run bash "$SCRIPTS/remote.sh" doctor plain
+  [ "$status" -eq 0 ]
+  grep -qF -- "plain: stale" <<<"$output"
+  run bash "$SCRIPTS/remote.sh" doctor .dotted
+  [ "$status" -eq 0 ]
+  grep -qF -- ".dotted: stale" <<<"$output"
+}

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2622,7 +2622,10 @@ broken_digest_path() {
   # the distinction the line was reworded to keep -- see hash.sh.
   grep -qF -- '[ ] usable SHA-256 tool' <<<"$output"
   # grep, not `[[ ]]`: a non-last `[[ ]]` cannot fail a test on bash 3.2 (#670).
-  grep -qF -- 'All checks passed' <<<"$output"
+  # The summary was narrowed to "prerequisite" when doctor gained the lock
+  # report (#865): an unqualified "All checks passed." sitting above a stale
+  # lock and a removal command reads as cancelling the diagnosis.
+  grep -qF -- 'All prerequisite checks passed' <<<"$output"
 }
 
 @test "remote doctor: reports the SHA-256 tool as usable when one works" {

--- a/tests/test_remote_curl_config_paths.bats
+++ b/tests/test_remote_curl_config_paths.bats
@@ -291,5 +291,11 @@ post_under() {
 
   post_under "$bin" posix "$body" '_remote_curl_path() { printf "%s%s" "$FAKE_ROOT" "$1"; }'
   [ "$status" -eq 0 ]
-  [ "$output" = "000" ]
+  # The status line, not the whole stream. This consumer takes the fifo branch,
+  # and a curl that refuses the config never opens the header fifo -- so the
+  # copier stays blocked in open() until the failure path kills it, and bash on
+  # macOS reports that interrupted open on stderr. The noise rides on a request
+  # that was already failing; what this case is about is the code that comes
+  # back, so assert a line that IS 000 rather than a stream that equals it.
+  grep -qFx -- '000' <<<"$output"
 }

--- a/tests/test_remote_curl_config_paths.bats
+++ b/tests/test_remote_curl_config_paths.bats
@@ -9,43 +9,60 @@
 # curl as the literal string `/tmp/x`, which it cannot open. curl fails, and the
 # caller reports HTTP 000 -- a network-shaped symptom for a path-shaped fault.
 #
-# WHAT THIS FILE DRIVES. The production `_remote_http_post_json`, sourced from
-# `remote.sh`, with two stubs on PATH:
+# THE SAME BYTES, TWO CONSUMERS. That is what makes this hard to test honestly:
+# `/tmp/x` is openable by a POSIX curl and not by a native Windows one, so a
+# path string is only right or wrong RELATIVE TO WHO READS IT. The stubs here
+# are therefore capability-paired, and each test states which pairing it runs:
 #
-#   cygpath   present or absent, which is the capability the fix gates on
-#   curl      captures the config it was given, and OPENS WHAT IT NAMES
+#   PATH        an allowlist sandbox -- cygpath is ABSENT because this file did
+#               not link it, not because the host happens to lack one. Each arm
+#               asserts the capability it relies on before relying on it.
+#   curl        told which consumer it is playing. As `native-windows` it
+#               refuses a POSIX path the way real curl.exe would; as `posix` it
+#               refuses a Windows path. Neither accepts both.
+#   cygpath     -m yields forward slashes, -w yields backslashes -- really both,
+#               because telling them apart is the whole reason the fix names -m.
 #
-# The second half of that stub is the point. A stub that only records the
-# config would pass whatever the config said, including a path no curl could
-# open -- which is the defect. This one resolves the path the way MSYS would,
-# writes the headers, and FAILS if it cannot, so a wrong rendering shows up as
-# the same 000 the user got rather than as a passing assertion about a string.
+# An earlier version of this file got the second point wrong: its stub accepted
+# any absolute POSIX path whatever the platform, so it could not have failed on
+# the untranslated path that broke the user, and the file's own header claimed
+# otherwise. Review caught it. What follows is written so that the claim and the
+# stub say the same thing.
 
 load test_helper
+
+# Externals `remote.sh` needs to source, plus those `_remote_http_post_json`
+# and the curl stub call. Derived by sourcing under an empty PATH and adding
+# what it asked for, then reading the function for the rest: mktemp, mkfifo,
+# chmod, python3 (the bounded-copy reader), rm, rmdir.
+#
+# An allowlist rather than a subtraction, matching `path_without_python3` in
+# test_helper. A subtraction cannot express "cygpath is absent" on a machine
+# where cygpath lives in the same directory as mktemp, which is every Git Bash.
+SANDBOX_TOOLS=(bash dirname mktemp mkfifo chmod rm rmdir sed cp cat grep python3 uname)
 
 setup() {
   setup_test_env
 
-  STUB_BIN="$BATS_TEST_TMPDIR/bin"
-  mkdir -p "$STUB_BIN"
   CFG_CAPTURE="$BATS_TEST_TMPDIR/captured-config"
   export CFG_CAPTURE
 
   # The Windows drive prefix the fake cygpath maps onto. Any string works; what
-  # matters is that the two stubs agree, so the curl stub can undo it exactly
-  # the way a native binary on Windows resolves a real Windows path back to the
-  # same file.
+  # matters is that the stubs agree, so the curl stub can undo it exactly the
+  # way a native binary resolves a Windows path back to the same file.
   FAKE_ROOT="C:/msys64"
   export FAKE_ROOT
 
-  cat > "$STUB_BIN/curl" <<'STUB'
+  STUB_SRC="$BATS_TEST_TMPDIR/stubs"
+  mkdir -p "$STUB_SRC"
+
+  cat > "$STUB_SRC/curl" <<'STUB'
 #!/usr/bin/env bash
-# A stand-in for native curl on Windows: it reads the config, and it can only
-# open paths that a native binary could open.
+# Stands in for whichever curl the config is destined for. STUB_CURL_CONSUMER
+# decides which one, and the two do NOT accept the same strings -- that
+# asymmetry is the defect being tested, so a stub without it proves nothing.
 set -u
-cfg=""
-out=""
-prev=""
+cfg=""; out=""; prev=""
 for arg in "$@"; do
   case "$prev" in
     -K) cfg="$arg" ;;
@@ -56,37 +73,38 @@ done
 [ -n "$cfg" ] || { echo "STUB_CURL: no -K config" >&2; exit 2; }
 cp "$cfg" "$CFG_CAPTURE"
 
-# Undo the fake cygpath mapping, which is what the real MSYS/Windows pair does:
-# a Windows path names the same file the POSIX path did. A path in neither form
-# is one this stub cannot open -- and neither could curl.
+# Resolve an embedded path to something this consumer can open, or fail.
+#
+#   native-windows  only a Windows path opens. A POSIX path is a literal
+#                   filename with no such directory -- the reported bug.
+#   posix           only a POSIX path opens. A Windows path is a filename
+#                   containing a colon, which is not a path here.
 resolve() {
-  case "$1" in
-    "$FAKE_ROOT"/*) printf '%s' "/${1#"$FAKE_ROOT"/}" ;;
-    /*) printf '%s' "$1" ;;
+  case "$STUB_CURL_CONSUMER:$1" in
+    "native-windows:$FAKE_ROOT"/*) printf '%s' "/${1#"$FAKE_ROOT"/}" ;;
+    native-windows:*) return 1 ;;
+    posix:/*) printf '%s' "$1" ;;
+    posix:*) return 1 ;;
     *) return 1 ;;
   esac
 }
 
-# `data = "@<path>"` must name a readable file, or curl has nothing to post.
 data_field="$(sed -n 's/^data = "@\(.*\)"$/\1/p' "$cfg")"
 if [ -n "$data_field" ]; then
   if ! body="$(resolve "$data_field")" || [ ! -r "$body" ]; then
-    echo "STUB_CURL: cannot open data path: $data_field" >&2
+    echo "STUB_CURL($STUB_CURL_CONSUMER): cannot open data path: $data_field" >&2
     exit 26
   fi
 fi
 
-# `dump-header = "<path>"` must be openable for writing. On the real thing this
-# is the fifo the caller is already reading; failing to open it is exactly the
-# fault this fix exists for.
 hdr_field="$(sed -n 's/^dump-header = "\(.*\)"$/\1/p' "$cfg")"
 if [ -n "$hdr_field" ]; then
   if ! hdr="$(resolve "$hdr_field")"; then
-    echo "STUB_CURL: cannot open dump-header path: $hdr_field" >&2
+    echo "STUB_CURL($STUB_CURL_CONSUMER): cannot open dump-header path: $hdr_field" >&2
     exit 23
   fi
   printf 'HTTP/1.1 200 OK\r\n\r\n' > "$hdr" || {
-    echo "STUB_CURL: dump-header not writable: $hdr_field" >&2
+    echo "STUB_CURL($STUB_CURL_CONSUMER): dump-header not writable: $hdr_field" >&2
     exit 23
   }
 fi
@@ -94,14 +112,10 @@ fi
 [ -z "$out" ] || printf '{"ok":true}' > "$out"
 printf '200'
 STUB
-  chmod +x "$STUB_BIN/curl"
+  chmod +x "$STUB_SRC/curl"
 
-  cat > "$STUB_BIN/cygpath" <<'STUB'
+  cat > "$STUB_SRC/cygpath" <<'STUB'
 #!/usr/bin/env bash
-# Mixed (-m) gives forward slashes; Windows (-w) gives backslashes. The
-# difference is the whole reason the fix names one of them, so the stub must
-# actually produce both -- returning the same string for either would make the
-# test unable to tell the two apart.
 set -u
 mode="$1"; path="$2"
 case "$mode" in
@@ -110,40 +124,70 @@ case "$mode" in
   *) echo "stub cygpath: unexpected mode $mode" >&2; exit 64 ;;
 esac
 STUB
-  chmod +x "$STUB_BIN/cygpath"
+  chmod +x "$STUB_SRC/cygpath"
 }
 
 teardown() { teardown_test_env; }
 
-# Runs the real helper with PATH arranged by the caller, and prints the http
-# code it returned. `cygpath` is present only when asked for.
-post_with() {
-  local with_cygpath="$1" body_file="$2"
-  local bin="$STUB_BIN"
-  if [ "$with_cygpath" = "no" ]; then
-    bin="$BATS_TEST_TMPDIR/bin-nocygpath"
-    mkdir -p "$bin"
-    ln -sf "$STUB_BIN/curl" "$bin/curl"
-  fi
-  run env PATH="$bin:$PATH" bash -c '
+# A PATH holding the allowlist, the curl stub, and cygpath only when asked.
+# Fails the test if the host is missing a tool: a silently short sandbox would
+# make the helper fail for a reason that has nothing to do with the fix.
+sandbox_path() {
+  local want_cygpath="$1" dir tool src
+  dir="$(mktemp -d "$BATS_TEST_TMPDIR/sandbox.XXXXXX")"
+  for tool in "${SANDBOX_TOOLS[@]}"; do
+    src="$(command -v "$tool")" || { echo "host lacks $tool" >&2; return 1; }
+    ln -s "$src" "$dir/$tool"
+  done
+  ln -s "$STUB_SRC/curl" "$dir/curl"
+  [ "$want_cygpath" = "yes" ] && ln -s "$STUB_SRC/cygpath" "$dir/cygpath"
+  printf '%s' "$dir"
+}
+
+# Runs the real helper under a sandbox PATH, and prints the http code. The
+# consumer the curl stub plays is named by the caller, so a test cannot
+# accidentally get a curl that accepts whatever the config happens to say.
+post_under() {
+  local bin="$1" consumer="$2" body_file="$3" extra="${4:-}"
+  run env PATH="$bin" STUB_CURL_CONSUMER="$consumer" CFG_CAPTURE="$CFG_CAPTURE" \
+    FAKE_ROOT="$FAKE_ROOT" bash -c '
     set -uo pipefail
     . '"$SCRIPTS"'/remote.sh 2>/dev/null
+    '"$extra"'
     _remote_http_post_json "https://example.invalid/v1/x" "'"$body_file"'" \
       "'"$BATS_TEST_TMPDIR"'/out-body" "'"$BATS_TEST_TMPDIR"'/out-header"
   '
 }
 
+@test "the sandbox decides whether cygpath exists — both directions (#850)" {
+  # The control on the instrument. Every arm below rests on the capability
+  # being what this file says it is, and on the host that is true by accident:
+  # macOS has no cygpath at all. If the sandbox were not really removing it,
+  # the negative arm would pass on any machine and fail on a Windows runner --
+  # which is the one machine this fix is for.
+  local without with
+  without="$(sandbox_path no)"
+  with="$(sandbox_path yes)"
+
+  run env PATH="$without" bash -c 'command -v cygpath >/dev/null 2>&1 && echo PRESENT || echo ABSENT'
+  [ "$output" = "ABSENT" ]
+
+  run env PATH="$with" bash -c 'command -v cygpath >/dev/null 2>&1 && echo PRESENT || echo ABSENT'
+  [ "$output" = "PRESENT" ]
+}
+
 @test "without cygpath the embedded paths are passed through byte for byte (#850)" {
-  # macOS and Linux have no cygpath, and this is the assertion that says the fix
-  # costs them nothing: the config must hold the exact strings the caller built.
+  # macOS and Linux, and the assertion that says the fix costs them nothing:
+  # the config must hold the exact strings the caller built.
+  local bin; bin="$(sandbox_path no)"
   body="$BATS_TEST_TMPDIR/body.json"
   printf '{"t":"secret"}' > "$body"
 
-  post_with no "$body"
+  post_under "$bin" posix "$body"
   [ "$status" -eq 0 ]
   [ "$output" = "200" ]
 
-  # The data path is one the test chose, so it can be compared exactly.
+  # The data path is one this test chose, so it can be compared exactly.
   grep -q -F -- "data = \"@$body\"" "$CFG_CAPTURE"
 
   # The header path is generated inside the helper, so what is asserted is its
@@ -157,15 +201,19 @@ post_with() {
 @test "with cygpath the DATA path is rendered in mixed Windows form (#850)" {
   # Two fields, two tests, because they are two effects of one line and can
   # regress apart. Asserting both in one test says "something is untranslated"
-  # -- which is true of either, and points at neither. Reverting the header
-  # field alone must not be able to fail this one.
+  # -- true of either, pointing at neither.
+  local bin; bin="$(sandbox_path yes)"
   body="$BATS_TEST_TMPDIR/body.json"
   printf '{"t":"secret"}' > "$body"
 
-  post_with yes "$body"
+  post_under "$bin" native-windows "$body"
   [ "$status" -eq 0 ]
-  [ "$output" = "200" ]
 
+  # Deliberately NOT asserting the 200 here. The stub refuses to open either
+  # field's path when it is untranslated, so a request fails whichever half is
+  # wrong -- and asserting the outcome in both field tests made them both go
+  # red for either mutation, which is the attribution this split exists to get.
+  # The outcome has its own test below.
   grep -q -F -- "data = \"@$FAKE_ROOT$body\"" "$CFG_CAPTURE"
 }
 
@@ -174,51 +222,74 @@ post_with() {
   # thinks of as "the file", and the header sink is generated inside the helper.
   # Translate one and not the other and curl opens the body, fails on the
   # header, and the caller reports 000 -- which reads as a header problem.
+  local bin; bin="$(sandbox_path yes)"
   body="$BATS_TEST_TMPDIR/body.json"
   printf '{"t":"secret"}' > "$body"
 
-  post_with yes "$body"
+  post_under "$bin" native-windows "$body"
   [ "$status" -eq 0 ]
-  [ "$output" = "200" ]
 
+  # Config bytes only, for the reason given in the DATA case above.
   hdr="$(sed -n 's/^dump-header = "\(.*\)"$/\1/p' "$CFG_CAPTURE")"
   case "$hdr" in "$FAKE_ROOT"/*) : ;; *) echo "header path not translated: $hdr"; return 1 ;; esac
+}
+
+@test "with both fields rendered, the request actually completes (#850)" {
+  # The outcome the two field tests deliberately leave alone. A native curl has
+  # to be able to open BOTH paths for the call to return a code at all, so this
+  # is the one assertion that fails for either field -- and that is its job:
+  # whatever regresses, the user's request stops working.
+  local bin; bin="$(sandbox_path yes)"
+  body="$BATS_TEST_TMPDIR/body.json"
+  printf '{"t":"secret"}' > "$body"
+
+  post_under "$bin" native-windows "$body"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
 }
 
 @test "the rendered paths carry forward slashes, never backslashes (#850)" {
   # `cygpath -w` also produces a valid Windows path, and it is the wrong one:
   # curl's config parser reads a backslash as an escape, so the path arrives
-  # corrupted. This is the assertion that separates -m from -w, and it is
-  # written against the config text rather than against the flag, because what
-  # breaks a user is the bytes curl parses.
+  # corrupted. Written against the config text rather than against the flag,
+  # because what breaks a user is the bytes curl parses.
+  local bin; bin="$(sandbox_path yes)"
   body="$BATS_TEST_TMPDIR/body.json"
   printf '{"t":"secret"}' > "$body"
 
-  post_with yes "$body"
+  post_under "$bin" native-windows "$body"
   [ "$status" -eq 0 ]
 
-  # No backslash anywhere in either embedded path.
-  ! grep -q '\\' "$CFG_CAPTURE"
+  refute grep -q '\\' "$CFG_CAPTURE"
 }
 
-@test "a path curl cannot open surfaces as HTTP 000, the way the user saw it (#850)" {
-  # The negative control for the stub itself. If the stub accepted any string as
-  # a path, every assertion above would pass on a broken rendering -- so make
-  # the rendering broken on purpose and confirm the stub notices.
+@test "an untranslated POSIX path reaching native curl is the reported 000 (#850)" {
+  # The defect itself, and the control on the stub. `_remote_curl_path` is
+  # replaced AFTER sourcing, so the production helper is still the one under
+  # test -- only its renderer is reduced to the passthrough it was before the
+  # fix. The consumer is the native Windows one, which cannot open /tmp/...
   #
-  # `_remote_curl_path` is replaced AFTER sourcing, so the production helper is
-  # still the one under test; only its path renderer is made to produce
-  # something no curl could open.
+  # Without this case the assertions above could all be passing on a config no
+  # curl would accept, which is exactly how the previous version of this file
+  # was wrong.
+  local bin; bin="$(sandbox_path yes)"
   body="$BATS_TEST_TMPDIR/body.json"
   printf '{"t":"secret"}' > "$body"
 
-  run env PATH="$STUB_BIN:$PATH" bash -c '
-    set -uo pipefail
-    . '"$SCRIPTS"'/remote.sh 2>/dev/null
-    _remote_curl_path() { printf "Z:\\\\nowhere\\\\%s" "$1"; }
-    _remote_http_post_json "https://example.invalid/v1/x" "'"$body"'" \
-      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$BATS_TEST_TMPDIR"'/out-header"
-  '
+  post_under "$bin" native-windows "$body" '_remote_curl_path() { printf "%s" "$1"; }'
+  [ "$status" -eq 0 ]
+  [ "$output" = "000" ]
+}
+
+@test "a Windows path reaching a POSIX curl is equally a 000 (#850)" {
+  # The mirror, so "native-windows refuses POSIX paths" is not read as "this
+  # stub refuses whatever the test needs it to". Each consumer refuses the
+  # other's form, and the fix is what puts the right form in front of each.
+  local bin; bin="$(sandbox_path no)"
+  body="$BATS_TEST_TMPDIR/body.json"
+  printf '{"t":"secret"}' > "$body"
+
+  post_under "$bin" posix "$body" '_remote_curl_path() { printf "%s%s" "$FAKE_ROOT" "$1"; }'
   [ "$status" -eq 0 ]
   [ "$output" = "000" ]
 }

--- a/tests/test_remote_curl_config_paths.bats
+++ b/tests/test_remote_curl_config_paths.bats
@@ -1,0 +1,224 @@
+#!/usr/bin/env bats
+# PATHS EMBEDDED IN A CURL CONFIG FILE ARE NOT TRANSLATED FOR YOU (#850).
+#
+# `_remote_http_post_json` hands curl its arguments in a `-K` config file so the
+# request body -- which carries the token -- never appears in curl's argv. On
+# Windows that has a consequence the POSIX side never sees: MSYS rewrites POSIX
+# paths into Windows form for a native binary's ARGV, and does not touch the
+# CONTENTS of a file that binary reads. So `data = "@/tmp/x"` reaches native
+# curl as the literal string `/tmp/x`, which it cannot open. curl fails, and the
+# caller reports HTTP 000 -- a network-shaped symptom for a path-shaped fault.
+#
+# WHAT THIS FILE DRIVES. The production `_remote_http_post_json`, sourced from
+# `remote.sh`, with two stubs on PATH:
+#
+#   cygpath   present or absent, which is the capability the fix gates on
+#   curl      captures the config it was given, and OPENS WHAT IT NAMES
+#
+# The second half of that stub is the point. A stub that only records the
+# config would pass whatever the config said, including a path no curl could
+# open -- which is the defect. This one resolves the path the way MSYS would,
+# writes the headers, and FAILS if it cannot, so a wrong rendering shows up as
+# the same 000 the user got rather than as a passing assertion about a string.
+
+load test_helper
+
+setup() {
+  setup_test_env
+
+  STUB_BIN="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB_BIN"
+  CFG_CAPTURE="$BATS_TEST_TMPDIR/captured-config"
+  export CFG_CAPTURE
+
+  # The Windows drive prefix the fake cygpath maps onto. Any string works; what
+  # matters is that the two stubs agree, so the curl stub can undo it exactly
+  # the way a native binary on Windows resolves a real Windows path back to the
+  # same file.
+  FAKE_ROOT="C:/msys64"
+  export FAKE_ROOT
+
+  cat > "$STUB_BIN/curl" <<'STUB'
+#!/usr/bin/env bash
+# A stand-in for native curl on Windows: it reads the config, and it can only
+# open paths that a native binary could open.
+set -u
+cfg=""
+out=""
+prev=""
+for arg in "$@"; do
+  case "$prev" in
+    -K) cfg="$arg" ;;
+    -o) out="$arg" ;;
+  esac
+  prev="$arg"
+done
+[ -n "$cfg" ] || { echo "STUB_CURL: no -K config" >&2; exit 2; }
+cp "$cfg" "$CFG_CAPTURE"
+
+# Undo the fake cygpath mapping, which is what the real MSYS/Windows pair does:
+# a Windows path names the same file the POSIX path did. A path in neither form
+# is one this stub cannot open -- and neither could curl.
+resolve() {
+  case "$1" in
+    "$FAKE_ROOT"/*) printf '%s' "/${1#"$FAKE_ROOT"/}" ;;
+    /*) printf '%s' "$1" ;;
+    *) return 1 ;;
+  esac
+}
+
+# `data = "@<path>"` must name a readable file, or curl has nothing to post.
+data_field="$(sed -n 's/^data = "@\(.*\)"$/\1/p' "$cfg")"
+if [ -n "$data_field" ]; then
+  if ! body="$(resolve "$data_field")" || [ ! -r "$body" ]; then
+    echo "STUB_CURL: cannot open data path: $data_field" >&2
+    exit 26
+  fi
+fi
+
+# `dump-header = "<path>"` must be openable for writing. On the real thing this
+# is the fifo the caller is already reading; failing to open it is exactly the
+# fault this fix exists for.
+hdr_field="$(sed -n 's/^dump-header = "\(.*\)"$/\1/p' "$cfg")"
+if [ -n "$hdr_field" ]; then
+  if ! hdr="$(resolve "$hdr_field")"; then
+    echo "STUB_CURL: cannot open dump-header path: $hdr_field" >&2
+    exit 23
+  fi
+  printf 'HTTP/1.1 200 OK\r\n\r\n' > "$hdr" || {
+    echo "STUB_CURL: dump-header not writable: $hdr_field" >&2
+    exit 23
+  }
+fi
+
+[ -z "$out" ] || printf '{"ok":true}' > "$out"
+printf '200'
+STUB
+  chmod +x "$STUB_BIN/curl"
+
+  cat > "$STUB_BIN/cygpath" <<'STUB'
+#!/usr/bin/env bash
+# Mixed (-m) gives forward slashes; Windows (-w) gives backslashes. The
+# difference is the whole reason the fix names one of them, so the stub must
+# actually produce both -- returning the same string for either would make the
+# test unable to tell the two apart.
+set -u
+mode="$1"; path="$2"
+case "$mode" in
+  -m) printf '%s%s' "$FAKE_ROOT" "$path" ;;
+  -w) printf '%s%s' "${FAKE_ROOT//\//\\}" "${path//\//\\}" ;;
+  *) echo "stub cygpath: unexpected mode $mode" >&2; exit 64 ;;
+esac
+STUB
+  chmod +x "$STUB_BIN/cygpath"
+}
+
+teardown() { teardown_test_env; }
+
+# Runs the real helper with PATH arranged by the caller, and prints the http
+# code it returned. `cygpath` is present only when asked for.
+post_with() {
+  local with_cygpath="$1" body_file="$2"
+  local bin="$STUB_BIN"
+  if [ "$with_cygpath" = "no" ]; then
+    bin="$BATS_TEST_TMPDIR/bin-nocygpath"
+    mkdir -p "$bin"
+    ln -sf "$STUB_BIN/curl" "$bin/curl"
+  fi
+  run env PATH="$bin:$PATH" bash -c '
+    set -uo pipefail
+    . '"$SCRIPTS"'/remote.sh 2>/dev/null
+    _remote_http_post_json "https://example.invalid/v1/x" "'"$body_file"'" \
+      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$BATS_TEST_TMPDIR"'/out-header"
+  '
+}
+
+@test "without cygpath the embedded paths are passed through byte for byte (#850)" {
+  # macOS and Linux have no cygpath, and this is the assertion that says the fix
+  # costs them nothing: the config must hold the exact strings the caller built.
+  body="$BATS_TEST_TMPDIR/body.json"
+  printf '{"t":"secret"}' > "$body"
+
+  post_with no "$body"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  # The data path is one the test chose, so it can be compared exactly.
+  grep -q -F -- "data = \"@$body\"" "$CFG_CAPTURE"
+
+  # The header path is generated inside the helper, so what is asserted is its
+  # shape: still POSIX, and untouched by any translation.
+  hdr="$(sed -n 's/^dump-header = "\(.*\)"$/\1/p' "$CFG_CAPTURE")"
+  [ -n "$hdr" ]
+  case "$hdr" in /*) : ;; *) echo "not a POSIX path: $hdr"; return 1 ;; esac
+  case "$hdr" in *"$FAKE_ROOT"*) echo "translated with no cygpath present: $hdr"; return 1 ;; esac
+}
+
+@test "with cygpath the DATA path is rendered in mixed Windows form (#850)" {
+  # Two fields, two tests, because they are two effects of one line and can
+  # regress apart. Asserting both in one test says "something is untranslated"
+  # -- which is true of either, and points at neither. Reverting the header
+  # field alone must not be able to fail this one.
+  body="$BATS_TEST_TMPDIR/body.json"
+  printf '{"t":"secret"}' > "$body"
+
+  post_with yes "$body"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  grep -q -F -- "data = \"@$FAKE_ROOT$body\"" "$CFG_CAPTURE"
+}
+
+@test "with cygpath the DUMP-HEADER path is rendered in mixed Windows form (#850)" {
+  # The half that is easy to leave behind: the body path is the one a reader
+  # thinks of as "the file", and the header sink is generated inside the helper.
+  # Translate one and not the other and curl opens the body, fails on the
+  # header, and the caller reports 000 -- which reads as a header problem.
+  body="$BATS_TEST_TMPDIR/body.json"
+  printf '{"t":"secret"}' > "$body"
+
+  post_with yes "$body"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  hdr="$(sed -n 's/^dump-header = "\(.*\)"$/\1/p' "$CFG_CAPTURE")"
+  case "$hdr" in "$FAKE_ROOT"/*) : ;; *) echo "header path not translated: $hdr"; return 1 ;; esac
+}
+
+@test "the rendered paths carry forward slashes, never backslashes (#850)" {
+  # `cygpath -w` also produces a valid Windows path, and it is the wrong one:
+  # curl's config parser reads a backslash as an escape, so the path arrives
+  # corrupted. This is the assertion that separates -m from -w, and it is
+  # written against the config text rather than against the flag, because what
+  # breaks a user is the bytes curl parses.
+  body="$BATS_TEST_TMPDIR/body.json"
+  printf '{"t":"secret"}' > "$body"
+
+  post_with yes "$body"
+  [ "$status" -eq 0 ]
+
+  # No backslash anywhere in either embedded path.
+  ! grep -q '\\' "$CFG_CAPTURE"
+}
+
+@test "a path curl cannot open surfaces as HTTP 000, the way the user saw it (#850)" {
+  # The negative control for the stub itself. If the stub accepted any string as
+  # a path, every assertion above would pass on a broken rendering -- so make
+  # the rendering broken on purpose and confirm the stub notices.
+  #
+  # `_remote_curl_path` is replaced AFTER sourcing, so the production helper is
+  # still the one under test; only its path renderer is made to produce
+  # something no curl could open.
+  body="$BATS_TEST_TMPDIR/body.json"
+  printf '{"t":"secret"}' > "$body"
+
+  run env PATH="$STUB_BIN:$PATH" bash -c '
+    set -uo pipefail
+    . '"$SCRIPTS"'/remote.sh 2>/dev/null
+    _remote_curl_path() { printf "Z:\\\\nowhere\\\\%s" "$1"; }
+    _remote_http_post_json "https://example.invalid/v1/x" "'"$body"'" \
+      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$BATS_TEST_TMPDIR"'/out-header"
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" = "000" ]
+}

--- a/tests/test_remote_curl_config_paths.bats
+++ b/tests/test_remote_curl_config_paths.bats
@@ -294,8 +294,8 @@ post_under() {
   # The status line, not the whole stream. This consumer takes the fifo branch,
   # and a curl that refuses the config never opens the header fifo -- so the
   # copier stays blocked in open() until the failure path kills it, and bash on
-  # macOS reports that interrupted open on stderr. The noise rides on a request
-  # that was already failing; what this case is about is the code that comes
-  # back, so assert a line that IS 000 rather than a stream that equals it.
+  # macOS reports that interrupted open on stderr (#869). The noise rides on a
+  # request that was already failing; what this case is about is the code that
+  # comes back, so assert a line that IS 000 rather than a stream equal to it.
   grep -qFx -- '000' <<<"$output"
 }

--- a/tests/test_remote_header_sink.bats
+++ b/tests/test_remote_header_sink.bats
@@ -1,0 +1,238 @@
+#!/usr/bin/env bats
+# WHERE A REAL NAMED PIPE CANNOT EXIST, DO NOT BUILD ONE (#850).
+#
+# `_remote_http_post_json` streams curl's headers through a fifo so
+# `bounded-copy.py` can enforce a size ceiling while the transfer is still
+# running. That needs a real named pipe. On Windows/Git Bash there is none to
+# have: MSYS emulates `mkfifo` with a `.lnk` file that only MSYS-aware programs
+# understand, and curl there is a NATIVE binary. It cannot open what mkfifo
+# made, so it fails and the caller reports the same `000` it reports for
+# everything.
+#
+# The fix takes a different sink on that platform: dump straight to the
+# caller's header file, no fifo and no copier. Two things then have to hold,
+# and they are the two this file drives:
+#
+#   the fifo machinery is NOT built when the marker says it cannot work
+#   the caller's header file SURVIVES -- on that path `header_fifo` IS
+#     `header_file`, so the cleanup that removes the fifo would delete the
+#     headers the function was asked to produce
+#
+# HOW THE ABSENCE OF A CALL IS OBSERVED. `mkfifo` and `python3` are replaced by
+# recording wrappers that then exec the real thing, so a test can assert on
+# what was invoked without changing what happens. An assertion that something
+# did NOT run is only worth its opposite: every case here also names a case
+# where the same wrapper DOES record, so "no line in the log" cannot pass
+# because the log was never wired up.
+#
+# WHAT THIS FILE DOES NOT CLAIM. The sibling defect (#851, embedded config
+# paths) is not on this branch, so paths stay POSIX here and the curl stub is a
+# POSIX consumer. On a real Windows machine this fix alone is not enough --
+# both are needed, and they compose only on the combined branch.
+#
+# Self-contained rather than sharing a harness with the #851 file: these are
+# separate pull requests that must land in either order, and a helper moved
+# into test_helper.bash by one of them is a conflict for the other.
+
+load test_helper
+
+# Externals `remote.sh` needs to source, plus those the helper and the stubs
+# call. Allowlist rather than subtraction: on Git Bash `cygpath` sits in the
+# same directory as `mktemp`, so nothing can be removed by dropping a path.
+SANDBOX_TOOLS=(bash dirname mktemp mkfifo chmod rm rmdir sed cp cat grep python3 uname)
+
+setup() {
+  setup_test_env
+
+  CALL_LOG="$BATS_TEST_TMPDIR/calls.log"
+  export CALL_LOG
+  : > "$CALL_LOG"
+
+  STUB_SRC="$BATS_TEST_TMPDIR/stubs"
+  mkdir -p "$STUB_SRC"
+
+  # curl: writes the headers where the config says, the way the real one does.
+  cat > "$STUB_SRC/curl" <<'STUB'
+#!/usr/bin/env bash
+set -u
+cfg=""; out=""; prev=""
+for arg in "$@"; do
+  case "$prev" in
+    -K) cfg="$arg" ;;
+    -o) out="$arg" ;;
+  esac
+  prev="$arg"
+done
+[ -n "$cfg" ] || { echo "STUB_CURL: no -K config" >&2; exit 2; }
+hdr="$(sed -n 's/^dump-header = "\(.*\)"$/\1/p' "$cfg")"
+if [ -n "$hdr" ]; then
+  printf 'HTTP/1.1 200 OK\r\nX-Marker: from-curl\r\n\r\n' > "$hdr" || {
+    echo "STUB_CURL: cannot write dump-header: $hdr" >&2; exit 23; }
+fi
+[ -z "$out" ] || printf '{"ok":true}' > "$out"
+printf '200'
+STUB
+  chmod +x "$STUB_SRC/curl"
+
+  # cygpath: only ever probed with `command -v` by the code under test, but it
+  # has to be a working binary -- a marker that errors would be a different
+  # experiment from a marker that exists.
+  cat > "$STUB_SRC/cygpath" <<'STUB'
+#!/usr/bin/env bash
+printf '%s' "${2-}"
+STUB
+  chmod +x "$STUB_SRC/cygpath"
+
+  # Recording wrappers. They record and then do the real thing, so the run is
+  # unchanged and only observability is added.
+  cat > "$STUB_SRC/mkfifo" <<'STUB'
+#!/usr/bin/env bash
+printf 'mkfifo %s\n' "$*" >> "$CALL_LOG"
+exec "$REAL_MKFIFO" "$@"
+STUB
+  chmod +x "$STUB_SRC/mkfifo"
+
+  cat > "$STUB_SRC/python3" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *bounded-copy.py*) printf 'bounded-copy %s\n' "$*" >> "$CALL_LOG" ;;
+  *) printf 'python3 %s\n' "$*" >> "$CALL_LOG" ;;
+esac
+exec "$REAL_PYTHON3" "$@"
+STUB
+  chmod +x "$STUB_SRC/python3"
+
+  REAL_MKFIFO="$(command -v mkfifo)"; export REAL_MKFIFO
+  REAL_PYTHON3="$(command -v python3)"; export REAL_PYTHON3
+}
+
+teardown() { teardown_test_env; }
+
+# A PATH holding the allowlist plus the stubs, with cygpath present only when
+# asked. Fails loudly if the host lacks a tool: a short sandbox would make the
+# helper fail for reasons unrelated to the fix.
+sandbox_path() {
+  local want_cygpath="$1" dir tool src
+  dir="$(mktemp -d "$BATS_TEST_TMPDIR/sandbox.XXXXXX")"
+  for tool in "${SANDBOX_TOOLS[@]}"; do
+    src="$(command -v "$tool")" || { echo "host lacks $tool" >&2; return 1; }
+    ln -s "$src" "$dir/$tool"
+  done
+  # The recording wrappers shadow the real tools of the same name.
+  ln -sf "$STUB_SRC/mkfifo" "$dir/mkfifo"
+  ln -sf "$STUB_SRC/python3" "$dir/python3"
+  ln -s "$STUB_SRC/curl" "$dir/curl"
+  [ "$want_cygpath" = "yes" ] && ln -s "$STUB_SRC/cygpath" "$dir/cygpath"
+  printf '%s' "$dir"
+}
+
+post_under() {
+  local bin="$1" body_file="$2" header_out="$3"
+  run env PATH="$bin" CALL_LOG="$CALL_LOG" REAL_MKFIFO="$REAL_MKFIFO" \
+    REAL_PYTHON3="$REAL_PYTHON3" bash -c '
+    set -uo pipefail
+    . '"$SCRIPTS"'/remote.sh 2>/dev/null
+    _remote_http_post_json "https://example.invalid/v1/x" "'"$body_file"'" \
+      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$header_out"'"
+  '
+}
+
+@test "the sandbox decides whether the marker exists — both directions (#850)" {
+  # The control on the instrument, and on the recording wrappers. Everything
+  # below reads a log, and a log that is never written looks exactly like a
+  # call that never happened.
+  local without with
+  without="$(sandbox_path no)"
+  with="$(sandbox_path yes)"
+
+  run env PATH="$without" bash -c 'command -v cygpath >/dev/null 2>&1 && echo PRESENT || echo ABSENT'
+  [ "$output" = "ABSENT" ]
+
+  run env PATH="$with" bash -c 'command -v cygpath >/dev/null 2>&1 && echo PRESENT || echo ABSENT'
+  [ "$output" = "PRESENT" ]
+
+  # And the wrappers really do record, so an empty log later means something.
+  run env PATH="$without" CALL_LOG="$CALL_LOG" REAL_MKFIFO="$REAL_MKFIFO" \
+    bash -c 'mkfifo "$BATS_TEST_TMPDIR/control-fifo"'
+  grep -q '^mkfifo ' "$CALL_LOG"
+}
+
+@test "with the marker present, no fifo is made (#850)" {
+  # Two absences, two tests. They are separate pieces of machinery and can be
+  # left behind separately -- keeping the fifo while dropping the copier gives
+  # a pipe nobody drains, dropping the fifo while keeping the copier gives a
+  # reader blocked on a file that never fills. One test asserting both says
+  # "some of it is still there" and names neither.
+  local bin; bin="$(sandbox_path yes)"
+  body="$BATS_TEST_TMPDIR/body.json"; printf '{"t":"secret"}' > "$body"
+  hdr="$BATS_TEST_TMPDIR/headers.txt"
+
+  post_under "$bin" "$body" "$hdr"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  refute grep -q '^mkfifo ' "$CALL_LOG"
+}
+
+@test "with the marker present, no bounded copier is started (#850)" {
+  local bin; bin="$(sandbox_path yes)"
+  body="$BATS_TEST_TMPDIR/body.json"; printf '{"t":"secret"}' > "$body"
+  hdr="$BATS_TEST_TMPDIR/headers.txt"
+
+  post_under "$bin" "$body" "$hdr"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  refute grep -q '^bounded-copy ' "$CALL_LOG"
+}
+
+@test "with the marker present, the caller's header file survives the call (#850)" {
+  # The trap this fix had to avoid: on that path `header_fifo` IS `header_file`,
+  # so a cleanup that removes the fifo deletes the headers the caller asked for
+  # — after a successful request, which makes it look like the server sent none.
+  local bin; bin="$(sandbox_path yes)"
+  body="$BATS_TEST_TMPDIR/body.json"; printf '{"t":"secret"}' > "$body"
+  hdr="$BATS_TEST_TMPDIR/headers.txt"
+
+  post_under "$bin" "$body" "$hdr"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  [ -f "$hdr" ]
+  grep -q 'X-Marker: from-curl' "$hdr"
+}
+
+@test "without the marker, the fifo and the bounded copier are still used (#850)" {
+  # The platforms that are supposed to be unchanged, asserted rather than
+  # assumed. This is also the positive control for the two absences above.
+  local bin; bin="$(sandbox_path no)"
+  body="$BATS_TEST_TMPDIR/body.json"; printf '{"t":"secret"}' > "$body"
+  hdr="$BATS_TEST_TMPDIR/headers.txt"
+
+  post_under "$bin" "$body" "$hdr"
+  [ "$status" -eq 0 ]
+  [ "$output" = "200" ]
+
+  grep -q '^mkfifo ' "$CALL_LOG"
+  grep -q '^bounded-copy ' "$CALL_LOG"
+
+  # And the headers still arrive, by the longer route.
+  grep -q 'X-Marker: from-curl' "$hdr"
+}
+
+@test "without the marker, the fifo is cleaned up and the header file is not (#850)" {
+  # Both halves of the cleanup on the POSIX path: the temporary pipe goes, the
+  # caller's file stays. Reading the fifo path out of the call log is what makes
+  # the first half checkable — it is a name the helper chose, not one we passed.
+  local bin; bin="$(sandbox_path no)"
+  body="$BATS_TEST_TMPDIR/body.json"; printf '{"t":"secret"}' > "$body"
+  hdr="$BATS_TEST_TMPDIR/headers.txt"
+
+  post_under "$bin" "$body" "$hdr"
+  [ "$status" -eq 0 ]
+
+  fifo="$(sed -n 's/^mkfifo //p' "$CALL_LOG" | head -1)"
+  [ -n "$fifo" ]
+  refute test -e "$fifo"
+  [ -f "$hdr" ]
+}


### PR DESCRIPTION
Windows could not use the hosted service at all. Four defects sat behind one another, each
hidden by the one in front of it, and none of them had ever been reached because **nobody had
run `connect` on Windows** — the machines that had teams got them from `pull`, which takes a
different path.

This branch carries the four fixes and the diagnostic command that would have named the fifth.

## What a Windows user could not do, and now can

**`connect` never sent its request.** The paths embedded in curl's config file stayed in POSIX
form — MSYS rewrites a native binary's argv, not the contents of a file it reads — so curl
could not open them and the operator saw `HTTP 000`, which reads as a network failure on a
machine whose network is fine.

**The header sink could not be written.** Native curl cannot write into an MSYS named pipe.
Fixing the paths alone got the request out and then died one line later.

**The key fingerprint came out empty.** `shasum` is a Perl script that ships on macOS and most
Linux and **not** in Git for Windows. `lib/hash.sh` already knew this and had a fallback chain
— for SHA-1 only. The cryptographic paths called `shasum -a 256` directly, printed
`Recipient fingerprint:` with nothing after it, and carried on. Two people comparing that
value out of band would have been comparing two blanks.

**And when something wedges, nothing said what.** `doctor` now names the registry locks it
finds: which team, when it was taken, what the holder record says, whether that process is
still alive, and the exact directory to remove. Previously the only signal was
`timed out acquiring registry lock`, which describes contention and sends the reader looking
for a process that is not there.

## Verified on a real Windows machine

Not by injected platform flags — on Windows 11 / Git Bash, against the real remote:

```
connect            completes; no HTTP 000; Snapshot SHA-256 computed
remote status      connected (age-v1, key present)
Recipient fingerprint   b265-…   and 3a04-778b-3e47-8abc with shasum hidden,
                        so the fallback arm is exercised, not just the first one
doctor             runs; reports the SHA-256 tool
```

The machine has no `shasum`, has `sha256sum`, `openssl` and `cygpath` — so all three
capability branches are the ones actually taken there, rather than the untaken side.

## What is not in here

**`#853` / `#854` — keeping curl's stderr on failure.** Both are CLEARED and both conflict
with the header-sink change in the same function. They are diagnostics: without them the next
Windows failure reports `000` with no reason again, which is how this investigation started.
They go in the next release rather than holding this one.

**`#866` — breaking a stale lock automatically.** Its first round produced a P0 in which a
live lock could be removed, and the repaired version cannot be shown correct by mutation
because the interleaving it guards happens inside one function. `doctor` reports; it does not
delete. That split was deliberate.

## Boundary

The end-to-end walk covered connect, status, the fingerprint and `doctor`. **The sync
round-trip was not measured**: the engine was started over ssh, the session ended, the engine
died with it — and that left a registry lock nothing can break, which is the defect `doctor`
now reports and a later change will repair. The wedged team is still on that machine, kept as
a live case rather than a fixture.
