### PR TITLE
ci: name the shard that stopped, and say what cancelled means

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -372,19 +372,54 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Beyond the workflow's `contents: read`, so the failure path can ask which
+    # shard stopped. Without it that call is a 403 the step swallows, and the
+    # listing below would be a feature that reads as present and never runs.
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v4
 
+      # `result` is the matrix's roll-up: one word for twelve jobs, and the word
+      # it uses for a shard that ran out of `timeout-minutes` is `cancelled`.
+      # That cost an outside contributor a day. Two of their pull requests went
+      # red with every ubuntu shard, every Windows leg and three of four macOS
+      # shards green; the fourth had been stopped at exactly 25 minutes, and
+      # the only thing this job said was `result: cancelled`. Nothing on the
+      # page connected that to a runner limit, so it read as the repository
+      # rejecting their change.
+      #
+      # So name the jobs. The roll-up decides the exit code, as before; the
+      # listing is what makes the exit code actionable.
       - name: Check shard results
         env:
           RESULT: ${{ needs.bats-shard.result }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          case "$RESULT" in
-            success) ;;
-            skipped) echo "::error::the bats shards did not run"; exit 1 ;;
-            *) echo "::error::the bats shards did not all pass (result: $RESULT)"; exit 1 ;;
-          esac
+          if [ "$RESULT" = "success" ]; then exit 0; fi
+          if [ "$RESULT" = "skipped" ]; then echo "::error::the bats shards did not run"; exit 1; fi
+
+          # Best-effort: the diagnosis must never decide the outcome. A failure
+          # to list the jobs leaves the roll-up's own message standing rather
+          # than turning a red into a green or into a different red.
+          if gh api --paginate \
+               "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+               --jq '.jobs[] | select(.name | startswith("bats (")) | select(.conclusion != "success") | "\(.conclusion)\t\(.name)"' \
+               > /tmp/bad-shards.txt 2>/dev/null && [ -s /tmp/bad-shards.txt ]; then
+            echo "Shards that did not pass:"
+            sed 's/^/  /' /tmp/bad-shards.txt
+            if grep -q '^cancelled' /tmp/bad-shards.txt; then
+              echo
+              echo "A shard reported as 'cancelled' usually means it hit this workflow's"
+              echo "timeout-minutes rather than failing a test. Its log ends mid-suite and"
+              echo "names no failing case. That is a limit in this repository's CI, not a"
+              echo "defect in the change under test."
+            fi
+          fi
+          echo "::error::the bats shards did not all pass (result: $RESULT)"
+          exit 1
 
       - name: Docs-only change — no shard manifests to verify
         if: needs.changes.outputs.docs_only == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -411,11 +411,30 @@ jobs:
 
           # Inside `if`, so a failed call cannot end the step: the roll-up below
           # stays the only thing that decides this job's status.
+          # The exact matrix shape, not the `bats (` prefix. Three Windows legs
+          # share that prefix and are gated separately -- they are NOT part of
+          # `needs.bats-shard.result`, so listing them here would let the
+          # diagnosis name an unrelated Windows failure as if it explained the
+          # roll-up. The prefix matched 11 jobs where the roll-up covers 8.
+          # 2 = the matrix's `os:` list (ubuntu-latest, macos-latest). If a third
+          # is added, `seen` stops matching and the listing goes quiet with a
+          # warning rather than describing the wrong set -- the failure mode
+          # this count exists to prevent, announcing itself.
+          expected=$(( SHARD_TOTAL * 2 ))
           if gh api --paginate \
                "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
-               --jq '.jobs[] | select(.name | startswith("bats (")) | "\(.conclusion)\t\(.name)"' \
+               --jq '.jobs[] | select(.name | test("^bats \\((ubuntu|macos)-latest [0-9]+/[0-9]+\\)$")) | "\(.conclusion)\t\(.name)"' \
                > "$listing" 2>/dev/null && [ -s "$listing" ]; then
-            echo "Matrix jobs seen: $(wc -l < "$listing" | tr -d ' ')"
+            seen=$(wc -l < "$listing" | tr -d ' ')
+            echo "Matrix jobs seen: $seen (expected $expected)"
+            # The control is the comparison, not the listing. A count that does
+            # not match means this query is no longer selecting the set the
+            # roll-up summarises, and the lines below would describe some other
+            # set of jobs.
+            [ "$seen" = "$expected" ] || {
+              echo "::warning::listed $seen matrix jobs, expected $expected — not reporting shard names from a set that does not match the roll-up"
+              : > "$listing"
+            }
           else
             echo "::warning::could not list the shard jobs (the diagnosis below will be missing)"
             : > "$listing"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -386,36 +386,57 @@ jobs:
       # That cost an outside contributor a day. Two of their pull requests went
       # red with every ubuntu shard, every Windows leg and three of four macOS
       # shards green; the fourth had been stopped at exactly 25 minutes, and
-      # the only thing this job said was `result: cancelled`. Nothing on the
-      # page connected that to a runner limit, so it read as the repository
-      # rejecting their change.
+      # the only thing this job said was `result: cancelled`, which names no
+      # shard. From the outside it read as the repository rejecting the change.
       #
-      # So name the jobs. The roll-up decides the exit code, as before; the
-      # listing is what makes the exit code actionable.
+      # So name the job. Naming is all this does: `conclusion` plus a job name
+      # is the whole of what the query observes, and the text below says only
+      # that. An earlier draft went on to assert the cap had been hit, that the
+      # log ended mid-suite, and that the change under test was innocent -- none
+      # of which this code establishes, and the last of which is false whenever
+      # the change is itself what hangs. Give the reader the discriminator and
+      # let them apply it.
+      #
+      # The listing also runs on success, where it must find matrix jobs and
+      # finds no failures. That is its positive control: a permissions or API
+      # problem shows up on a green run as "could not list", instead of waiting
+      # for a red to discover the diagnosis was never able to speak.
       - name: Check shard results
         env:
           RESULT: ${{ needs.bats-shard.result }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          listing="$RUNNER_TEMP/shard-jobs.txt"
+
+          # Inside `if`, so a failed call cannot end the step: the roll-up below
+          # stays the only thing that decides this job's status.
+          if gh api --paginate \
+               "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+               --jq '.jobs[] | select(.name | startswith("bats (")) | "\(.conclusion)\t\(.name)"' \
+               > "$listing" 2>/dev/null && [ -s "$listing" ]; then
+            echo "Matrix jobs seen: $(wc -l < "$listing" | tr -d ' ')"
+          else
+            echo "::warning::could not list the shard jobs (the diagnosis below will be missing)"
+            : > "$listing"
+          fi
+
           if [ "$RESULT" = "success" ]; then exit 0; fi
           if [ "$RESULT" = "skipped" ]; then echo "::error::the bats shards did not run"; exit 1; fi
 
-          # Best-effort: the diagnosis must never decide the outcome. A failure
-          # to list the jobs leaves the roll-up's own message standing rather
-          # than turning a red into a green or into a different red.
-          if gh api --paginate \
-               "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
-               --jq '.jobs[] | select(.name | startswith("bats (")) | select(.conclusion != "success") | "\(.conclusion)\t\(.name)"' \
-               > /tmp/bad-shards.txt 2>/dev/null && [ -s /tmp/bad-shards.txt ]; then
+          if grep -v '^success' "$listing" > "$RUNNER_TEMP/bad.txt" 2>/dev/null \
+             && [ -s "$RUNNER_TEMP/bad.txt" ]; then
             echo "Shards that did not pass:"
-            sed 's/^/  /' /tmp/bad-shards.txt
-            if grep -q '^cancelled' /tmp/bad-shards.txt; then
+            sed 's/^/  /' "$RUNNER_TEMP/bad.txt"
+            if grep -q '^cancelled' "$RUNNER_TEMP/bad.txt"; then
               echo
-              echo "A shard reported as 'cancelled' usually means it hit this workflow's"
-              echo "timeout-minutes rather than failing a test. Its log ends mid-suite and"
-              echo "names no failing case. That is a limit in this repository's CI, not a"
-              echo "defect in the change under test."
+              echo "A shard whose conclusion is 'cancelled' was stopped rather than"
+              echo "failing a case, and this job cannot tell you why: reaching the"
+              echo "25-minute job cap and being cancelled from outside the run look"
+              echo "identical from here. Open the job named above. If it ran for about"
+              echo "25 minutes and its log ends mid-suite naming no failing case, it"
+              echo "reached the cap -- which a change that hangs can also cause, so the"
+              echo "cap being reached does not by itself say whose fault it is."
             fi
           fi
           echo "::error::the bats shards did not all pass (result: $RESULT)"


### PR DESCRIPTION
CI only. One file, `.github/workflows/tests.yml`. Nothing a user installs or runs changes.

## What happened

Two pull requests from an outside contributor sat red for a day. Their results:

```
ubuntu, all four shards      success
Windows, all three legs      success
macOS 2/4, 3/4, 4/4          success
macOS 1/4                    cancelled
bats  (the required check)   failure
```

The cancelled shard had run for exactly 25 minutes on both — this workflow's
`timeout-minutes`. GitHub records a job that exceeds it as `cancelled`, not as
`timed out`, and the matrix roll-up collapses twelve jobs into that one word.

What the required check said, in full:

```
::error::the bats shards did not all pass (result: cancelled)
```

It names no shard. It does not say that `cancelled` here means a runner limit.
From outside the project, that reads as the repository rejecting the change —
and there is nothing on the page to suggest otherwise, or to suggest a re-run
would help.

## The change

The roll-up still decides the exit code. What is added is the job name, and a
sentence that hands the reader the discriminator rather than a conclusion:

```
Shards that did not pass:
  cancelled	bats (macos-latest 1/4)

A shard whose conclusion is 'cancelled' was stopped rather than failing a
case, and this job cannot tell you why: reaching the 25-minute job cap and
being cancelled from outside the run look identical from here. Open the job
named above. If it ran for about 25 minutes and its log ends mid-suite naming
no failing case, it reached the cap -- which a change that hangs can also
cause, so the cap being reached does not by itself say whose fault it is.
```

An earlier revision of this PR said more than that: it asserted the cap *had*
been hit, that the log ended mid-suite, and that the change under test was
innocent. The query observes a conclusion and a job name. It establishes none of
those three, and the last is false precisely when a change hangs and drives its
own shard into the cap — the case where a wrong answer costs the most. Caught in
review.

**Best-effort by construction.** The listing sits inside an `if`, so a failed API
call leaves the roll-up's message standing. A diagnosis must never be able to
turn a red into a green, or into a different red.

**It needs `actions: read`**, granted at the job. The workflow's `contents: read`
does not cover the jobs endpoint; without the grant the call is a 403 the step
swallows.

## The listing proves it can see, on every run

It runs whatever the outcome and prints how many matrix jobs it found. On a green
run that is the positive control: a permissions or API problem shows up
immediately as `could not list the shard jobs`, instead of lying dormant until a
red arrives and the diagnosis turns out to have never been able to speak.

An earlier revision of this body claimed the path could not be exercised without
a failing shard. That was wrong, and the control costs one line.

## What this does not do

It does not stop the timeout being hit. That is the eight slowest tests, seven of
them `sync start`, at 30% of the suite's runtime — #876. And it does not reduce
the queueing that makes a slow shard slower — #877.

This is the third of the three, and the only one about what a person sees when it
goes wrong.
