### PR TITLE
fix(install): --update re-detects opencode/hermes/cursor instead of falling back to codex

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -93,6 +93,18 @@ UPDATE_ONLY=false
 INTERACTIVE=true
 AGENT_TYPE=""  # claude-code, codex, gemini, antigravity — passed via --agent-type, or empty for auto/default
 
+# Types the installer renders their OWN shared SKILL.md for (their template.md
+# differs from codex's). Everything else -- codex itself, plus claude-code and
+# copilot, which keep separate dedicated copies elsewhere -- gets the codex-
+# typed shared SKILL.md. One list, read by three call sites below (fresh
+# install's template pick, --update's template pick, and --update's type
+# re-detection from the SKILL.md already on disk): before #846, the third site
+# hardcoded its own, narrower copy of this same set (missing opencode/hermes/
+# cursor) that had already drifted from the other two -- re-detecting one of
+# those three types as "codex" and then, via the template pick, overwriting
+# the SKILL.md the installer itself had written with the wrong flavor.
+AGMSG_SHARED_SKILL_TPL_TYPES="gemini antigravity opencode hermes cursor grok-build"
+
 configure_codex_sandbox() {
   # --- Configure Codex sandbox (if Codex is installed) ---
   # The Codex bridge writes pidfiles/sockets/request files under the
@@ -278,22 +290,28 @@ if [ "$UPDATE_ONLY" = true ]; then
   CMD_NAME="$SKILL_NAME"
   echo "  Updating $SKILL_NAME..."
   if [ -z "$AGENT_TYPE" ]; then
-    if grep -q "whoami.sh.*antigravity" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
-      AGENT_TYPE="antigravity"
-    elif grep -q "whoami.sh.*gemini" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
-      AGENT_TYPE="gemini"
-    elif grep -q "whoami.sh.*grok-build" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
-      AGENT_TYPE="grok-build"
-    else
-      AGENT_TYPE="codex"
-    fi
+    # Re-detect the type this install's shared SKILL.md was last rendered for,
+    # from the whoami.sh line its own template prints (#846) -- every
+    # renderable type's line is unambiguous against every other's; see the
+    # cross-grep this list is built from, noted alongside
+    # AGMSG_SHARED_SKILL_TPL_TYPES above. codex is not grepped for: it is the
+    # default a match against this list falls back to.
+    AGENT_TYPE="codex"
+    for _agmsg_t in $AGMSG_SHARED_SKILL_TPL_TYPES; do
+      if grep -q "whoami.sh.*$_agmsg_t" "$SKILL_DIR/SKILL.md" 2>/dev/null; then
+        AGENT_TYPE="$_agmsg_t"
+        break
+      fi
+    done
+    unset _agmsg_t
   fi
-  # The shared SKILL.md uses the codex template by default; gemini/antigravity/
-  # opencode get their own. (claude-code and copilot reuse the codex-typed
-  # shared SKILL.md; their dedicated copies are dropped separately below.)
+  # The shared SKILL.md uses the codex template by default; the types in
+  # AGMSG_SHARED_SKILL_TPL_TYPES get their own. (claude-code and copilot reuse
+  # the codex-typed shared SKILL.md; their dedicated copies are dropped
+  # separately below.)
   TPL_TYPE="codex"
-  case "$AGENT_TYPE" in
-    gemini|antigravity|opencode|hermes|cursor|grok-build) TPL_TYPE="$AGENT_TYPE" ;;
+  case " $AGMSG_SHARED_SKILL_TPL_TYPES " in
+    *" $AGENT_TYPE "*) TPL_TYPE="$AGENT_TYPE" ;;
   esac
   sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$(agmsg_type_template_path "$TPL_TYPE")" > "$SKILL_DIR/SKILL.md"
   # Recursive copy so nested helper dirs (scripts/lib/, scripts/drivers/types/)
@@ -429,10 +447,10 @@ mkdir -p "$SKILL_DIR"/{scripts,types,db,agents}
 
 # SKILL.md is generated from the agent-specific command template, resolved from
 # the type manifest (scripts/drivers/types/<type>/template.md). The shared SKILL.md uses the
-# codex template by default; gemini/antigravity/opencode get their own.
+# codex template by default; the types in AGMSG_SHARED_SKILL_TPL_TYPES get their own.
 TPL_TYPE="codex"
-case "$AGENT_TYPE" in
-  gemini|antigravity|opencode|hermes|cursor|grok-build) TPL_TYPE="$AGENT_TYPE" ;;
+case " $AGMSG_SHARED_SKILL_TPL_TYPES " in
+  *" $AGENT_TYPE "*) TPL_TYPE="$AGENT_TYPE" ;;
 esac
 sed "s/__SKILL_NAME__/$CMD_NAME/g" "$(agmsg_type_template_path "$TPL_TYPE")" > "$SKILL_DIR/SKILL.md"
 # Recursive copy so nested helper dirs (scripts/lib/, scripts/drivers/types/) ship

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -848,6 +848,28 @@ EOF
   ! grep -q "whoami.sh \"\$(pwd)\" codex" "$SK/SKILL.md"
 }
 
+# Positive control for #846 (A), covering every type the installer can render a
+# shared SKILL.md for: install fresh with that type, then run bare --update
+# (no --agent-type, forcing the on-disk re-detection path) and confirm the
+# type survives. Before the fix, only antigravity/gemini/grok-build were
+# grepped for at re-detection time -- opencode/hermes/cursor silently fell
+# through to the codex default and got their SKILL.md overwritten with the
+# codex template, i.e. the installer clobbering what it had itself just
+# written. codex itself is included as the baseline case (it was never
+# grepped for and was never broken -- it IS the fallback).
+@test "install: bare --update preserves every renderable type's SKILL.md flavor (#846)" {
+  local t
+  for t in codex gemini antigravity opencode hermes cursor grok-build; do
+    local cmd="agmsg-$t"
+    HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd "$cmd" --agent-type "$t"
+    local skill_md="$FAKE_HOME/.agents/skills/$cmd/SKILL.md"
+    grep -q "whoami.sh \"\$(pwd)\" $t" "$skill_md"
+
+    HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update --cmd "$cmd"
+    grep -q "whoami.sh \"\$(pwd)\" $t" "$skill_md"
+  done
+}
+
 # The Windows leg of the bats matrix selects by test NAME (filter "[Ww]indows"),
 # and until this test existed it ran only the two install-helper checks above --
 # so join.sh, which is the first thing any Windows user runs, executed in no


### PR DESCRIPTION
## Summary

Part of #846 — specifically the `--update` re-render regression noted at the bottom of that issue, not the broader "make the shared SKILL.md provider-agnostic" redesign (still under discussion there).

`install.sh --update` re-detects an existing install's type by grepping its shared `SKILL.md` for the whoami.sh line the type's own template renders. That detection only checked for `antigravity`, `gemini`, and `grok-build` — a narrower, separately-hardcoded copy of the list the template-selection `case` (used both at fresh install and at `--update`) actually supports (`gemini antigravity opencode hermes cursor grok-build`).

Effect: an `opencode`, `hermes`, or `cursor` install fell through the incomplete detection to the `codex` default, and the very next `--update` overwrote its `SKILL.md` with the codex-typed template — the installer clobbering what it had itself written on the previous install/update.

## Fix

Replaced the three independent copies of this type list (fresh-install template pick, `--update` template pick, `--update` re-detection) with one `AGMSG_SHARED_SKILL_TPL_TYPES` variable read by all three. The list itself is unchanged in content — this fix is only about there being one of it instead of three, since the bug was exactly two of those three drifting apart.

`codex` itself was never in the previous re-detection list either, but is unaffected: it's the fallback all three call sites use when a type isn't found in the list.

Out of scope (left untouched, per the rest of #846): making the shared SKILL.md itself provider-agnostic, and `claude-code`'s handling of it.

## Positive control

Verified the failure first, against the pre-fix code: rendered a fresh shared `SKILL.md` for every type the installer can render one for (`codex gemini antigravity opencode hermes cursor grok-build`), ran `--update` against each, and checked the type survived. `opencode`/`hermes`/`cursor` failed as expected; `codex`/`gemini`/`antigravity`/`grok-build` passed. Applying the fix turns all 7 green.

## Tests

Added `install: bare --update preserves every renderable type's SKILL.md flavor (#846)` to `tests/test_install.bats`, covering exactly that 7-type round trip. Ran `tests/test_install.bats` in isolation: 55/55 passing. Also re-ran `.github/scripts/check-enforced-assertions.sh`: unchanged at baseline (638).

Not run locally: the full suite (left to CI, per team convention).
