### PR TITLE
test(remote): two tests on main can fail on a correct code — they read a merged stream

### DIFF
--- a/tests/test_remote_curl_config_paths.bats
+++ b/tests/test_remote_curl_config_paths.bats
@@ -125,6 +125,23 @@ case "$mode" in
 esac
 STUB
   chmod +x "$STUB_SRC/cygpath"
+
+  # A python3 that writes one line to stderr before becoming the real thing.
+  # The copier is started with its stderr INHERITED, so that line arrives on the
+  # helper's stderr -- which is what the redirect under test has to keep out of
+  # bats's $output. Without something that actually writes there, adding or
+  # removing the redirect changes nothing and the harness fix is unbound.
+  REAL_PYTHON3="$(command -v python3)"; export REAL_PYTHON3
+  NOISE="stderr-noise-from-the-copier"
+  export NOISE
+  cat > "$STUB_SRC/python3" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *bounded-copy.py*) printf '%s\n' "$NOISE" >&2 ;;
+esac
+exec "$REAL_PYTHON3" "$@"
+STUB
+  chmod +x "$STUB_SRC/python3"
 }
 
 teardown() { teardown_test_env; }
@@ -140,6 +157,7 @@ sandbox_path() {
     ln -s "$src" "$dir/$tool"
   done
   ln -s "$STUB_SRC/curl" "$dir/curl"
+  ln -sf "$STUB_SRC/python3" "$dir/python3"
   [ "$want_cygpath" = "yes" ] && ln -s "$STUB_SRC/cygpath" "$dir/cygpath"
   printf '%s' "$dir"
 }
@@ -165,6 +183,7 @@ post_under() {
   local bin="$1" consumer="$2" body_file="$3" extra="${4:-}"
   ERR_FILE="$BATS_TEST_TMPDIR/helper-stderr"
   run env PATH="$bin" STUB_CURL_CONSUMER="$consumer" CFG_CAPTURE="$CFG_CAPTURE" \
+    NOISE="$NOISE" REAL_PYTHON3="$REAL_PYTHON3" \
     FAKE_ROOT="$FAKE_ROOT" bash -c '
     set -uo pipefail
     . '"$SCRIPTS"'/remote.sh 2>/dev/null
@@ -172,6 +191,29 @@ post_under() {
     _remote_http_post_json "https://example.invalid/v1/x" "'"$body_file"'" \
       "'"$BATS_TEST_TMPDIR"'/out-body" "'"$BATS_TEST_TMPDIR"'/out-header" 2>"'"$ERR_FILE"'"
   '
+}
+
+@test "the helper's stderr stays out of the code, and there IS stderr to keep out (#850)" {
+  # THE CONTROL FOR THE REDIRECT ITSELF. Every other case here compares $output
+  # against an exact code; that comparison only means something because stdout
+  # and stderr are separated, and separation only means something when the
+  # stream is non-empty. On a quiet run, adding or removing `2> "$ERR_FILE"`
+  # changes nothing -- which is how the redirect went in unbound.
+  #
+  # The copier inherits the helper's stderr, so a python3 that writes one line
+  # before exec'ing puts a real line there. What CI produced was bash reporting
+  # an interrupted fifo open; this is a different writer to the same stream, and
+  # it is deterministic.
+  local bin; bin="$(sandbox_path no)"
+  body="$BATS_TEST_TMPDIR/body.json"
+  printf '{"t":"secret"}' > "$body"
+
+  post_under "$bin" posix "$body"
+  [ "$status" -eq 0 ]
+
+  # The code alone, and the noise really happened.
+  [ "$output" = "200" ]
+  grep -q -F -- "$NOISE" "$ERR_FILE"
 }
 
 @test "the sandbox decides whether cygpath exists — both directions (#850)" {

--- a/tests/test_remote_curl_config_paths.bats
+++ b/tests/test_remote_curl_config_paths.bats
@@ -147,15 +147,30 @@ sandbox_path() {
 # Runs the real helper under a sandbox PATH, and prints the http code. The
 # consumer the curl stub plays is named by the caller, so a test cannot
 # accidentally get a curl that accepts whatever the config happens to say.
+# STDERR GOES TO A FILE, NOT INTO $output.
+#
+# bats merges the two streams, and this helper's stderr is not reliably empty.
+# On a loaded macOS CI runner, bash reported
+#
+#   remote.sh: line NNN: .../agmsg-header-pipe.JVbrl7/header: Interrupted system call
+#
+# while opening the header fifo, and $output became that line followed by the
+# http code. Every exact comparison against "200" or "000" then fails on a code
+# that was in fact correct. Observed twice in one run, on a head that was green
+# on the author's machine: the difference is load, not platform.
+#
+# The http code is the only thing on stdout, so separating the streams is what
+# makes an exact comparison mean what it says.
 post_under() {
   local bin="$1" consumer="$2" body_file="$3" extra="${4:-}"
+  ERR_FILE="$BATS_TEST_TMPDIR/helper-stderr"
   run env PATH="$bin" STUB_CURL_CONSUMER="$consumer" CFG_CAPTURE="$CFG_CAPTURE" \
     FAKE_ROOT="$FAKE_ROOT" bash -c '
     set -uo pipefail
     . '"$SCRIPTS"'/remote.sh 2>/dev/null
     '"$extra"'
     _remote_http_post_json "https://example.invalid/v1/x" "'"$body_file"'" \
-      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$BATS_TEST_TMPDIR"'/out-header"
+      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$BATS_TEST_TMPDIR"'/out-header" 2>"'"$ERR_FILE"'"
   '
 }
 

--- a/tests/test_remote_curl_config_paths.bats
+++ b/tests/test_remote_curl_config_paths.bats
@@ -175,7 +175,9 @@ sandbox_path() {
 # while opening the header fifo, and $output became that line followed by the
 # http code. Every exact comparison against "200" or "000" then fails on a code
 # that was in fact correct. Observed twice in one run, on a head that was green
-# on the author's machine: the difference is load, not platform.
+# on the author's machine. That is the boundary of what was observed -- a
+# loaded macOS CI runner produced it and no local run has. Load is the
+# candidate, not something any control here varied.
 #
 # The http code is the only thing on stdout, so separating the streams is what
 # makes an exact comparison mean what it says.

--- a/tests/test_remote_header_sink.bats
+++ b/tests/test_remote_header_sink.bats
@@ -92,10 +92,19 @@ exec "$REAL_MKFIFO" "$@"
 STUB
   chmod +x "$STUB_SRC/mkfifo"
 
+  # It also writes one line to stderr. The copier inherits the helper's stderr,
+  # so that line lands where the redirect under test has to keep it out of
+  # bats's $output. Without a writer there, adding or removing `2> "$ERR_FILE"`
+  # changes nothing and the harness fix is unbound -- which is how it went in.
+  NOISE="stderr-noise-from-the-copier"
+  export NOISE
   cat > "$STUB_SRC/python3" <<'STUB'
 #!/usr/bin/env bash
 case "$*" in
-  *bounded-copy.py*) printf 'bounded-copy %s\n' "$*" >> "$CALL_LOG" ;;
+  *bounded-copy.py*)
+    printf 'bounded-copy %s\n' "$*" >> "$CALL_LOG"
+    printf '%s\n' "$NOISE" >&2
+    ;;
   *) printf 'python3 %s\n' "$*" >> "$CALL_LOG" ;;
 esac
 exec "$REAL_PYTHON3" "$@"
@@ -144,7 +153,7 @@ post_under() {
   local bin="$1" body_file="$2" header_out="$3"
   ERR_FILE="$BATS_TEST_TMPDIR/helper-stderr"
   run env PATH="$bin" CALL_LOG="$CALL_LOG" REAL_MKFIFO="$REAL_MKFIFO" \
-    REAL_PYTHON3="$REAL_PYTHON3" bash -c '
+    REAL_PYTHON3="$REAL_PYTHON3" NOISE="$NOISE" bash -c '
     set -uo pipefail
     . '"$SCRIPTS"'/remote.sh 2>/dev/null
     _remote_http_post_json "https://example.invalid/v1/x" "'"$body_file"'" \
@@ -170,6 +179,22 @@ post_under() {
   run env PATH="$without" CALL_LOG="$CALL_LOG" REAL_MKFIFO="$REAL_MKFIFO" \
     bash -c 'mkfifo "$BATS_TEST_TMPDIR/control-fifo"'
   grep -q '^mkfifo ' "$CALL_LOG"
+}
+
+@test "the helper's stderr stays out of the code, and there IS stderr to keep out (#850)" {
+  # The control for the redirect itself, on the arm that starts a copier. Every
+  # other case compares $output against an exact code, and that comparison only
+  # means something because the streams are separated -- which in turn only
+  # means something when the stream is non-empty.
+  local bin; bin="$(sandbox_path no)"
+  body="$BATS_TEST_TMPDIR/body.json"; printf '{"t":"secret"}' > "$body"
+  hdr="$BATS_TEST_TMPDIR/headers.txt"
+
+  post_under "$bin" "$body" "$hdr"
+  [ "$status" -eq 0 ]
+
+  [ "$output" = "200" ]
+  grep -q -F -- "$NOISE" "$ERR_FILE"
 }
 
 @test "with the marker present, no fifo is made (#850)" {

--- a/tests/test_remote_header_sink.bats
+++ b/tests/test_remote_header_sink.bats
@@ -126,14 +126,29 @@ sandbox_path() {
   printf '%s' "$dir"
 }
 
+# STDERR GOES TO A FILE, NOT INTO $output.
+#
+# bats merges the two streams, and this helper's stderr is not reliably empty.
+# On a loaded macOS CI runner, bash reported
+#
+#   remote.sh: line NNN: .../agmsg-header-pipe.JVbrl7/header: Interrupted system call
+#
+# while opening the header fifo, and $output became that line followed by the
+# http code. Every exact comparison against "200" or "000" then fails on a code
+# that was in fact correct. Observed twice in one run, on a head that was green
+# on the author's machine: the difference is load, not platform.
+#
+# The http code is the only thing on stdout, so separating the streams is what
+# makes an exact comparison mean what it says.
 post_under() {
   local bin="$1" body_file="$2" header_out="$3"
+  ERR_FILE="$BATS_TEST_TMPDIR/helper-stderr"
   run env PATH="$bin" CALL_LOG="$CALL_LOG" REAL_MKFIFO="$REAL_MKFIFO" \
     REAL_PYTHON3="$REAL_PYTHON3" bash -c '
     set -uo pipefail
     . '"$SCRIPTS"'/remote.sh 2>/dev/null
     _remote_http_post_json "https://example.invalid/v1/x" "'"$body_file"'" \
-      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$header_out"'"
+      "'"$BATS_TEST_TMPDIR"'/out-body" "'"$header_out"'" 2>"'"$ERR_FILE"'"
   '
 }
 

--- a/tests/test_remote_header_sink.bats
+++ b/tests/test_remote_header_sink.bats
@@ -145,7 +145,9 @@ sandbox_path() {
 # while opening the header fifo, and $output became that line followed by the
 # http code. Every exact comparison against "200" or "000" then fails on a code
 # that was in fact correct. Observed twice in one run, on a head that was green
-# on the author's machine: the difference is load, not platform.
+# on the author's machine. That is the boundary of what was observed -- a
+# loaded macOS CI runner produced it and no local run has. Load is the
+# candidate, not something any control here varied.
 #
 # The http code is the only thing on stdout, so separating the streams is what
 # makes an exact comparison mean what it says.


### PR DESCRIPTION
**Describes head `7544efc859ac740203ab1fdee2a38749558c6cdc`** (base `d077a87adfa4214d6ebdf972cef7ccb892aa8296`).

> Sections below marked *(history)* describe earlier heads and are kept for the record. Where they and the current section disagree, the current section is the head.

**A flake in a required check, on `main` right now.** Two tests can fail on a correct result, so this blocks landing for every branch, not only the one that hit it.

## What happens

`tests/test_remote_curl_config_paths.bats` and `tests/test_remote_header_sink.bats` compare bats's `$output` against `"200"` or `"000"`. **`$output` is stdout and stderr merged**, and the helper's stderr is not reliably empty. On a loaded macOS runner:

```
remote.sh: line 318: .../agmsg-header-pipe.JVbrl7/header: Interrupted system call
000
```

The fifo open was interrupted and bash reported it. The http code was right; the comparison was against a two-line string.

**Observed, not reasoned about** — two cases in one CI run, at a head that was green on the author's machine:

```
not ok 351 an untranslated POSIX path reaching native curl is the reported 000 (#850)
not ok 352 a Windows path reaching a POSIX curl is equally a 000 (#850)
```

Same OS, same code. **That is the boundary of the observation**: it happened on a loaded macOS CI runner and has not reproduced locally. Load is the candidate — nothing measured here varied load alone.

## Scope

The window is the fifo open, so **every case that drives the non-marker arm is exposed** — including four in the header-sink file that have not failed yet. Fixing only the two that were seen would leave the same defect waiting in the other file.

Derived from **this tree**, not from a branch: `tests/` at this head contains exactly two `#850` test files, and both are changed here.

```
tests/test_remote_curl_config_paths.bats
tests/test_remote_header_sink.bats
```

Two sibling files (`test_remote_curl_stderr*.bats`) exist only on `refs/heads/fix/850-c-curl-stderr` and `fix/850-d-get-stderr`, which are not merged. They already separate the streams, and their remaining unseparated `run` sites assert `$status` only — stated here because those branches stack on this one, not as evidence about this head.

## The change

Both harnesses send the helper's stderr to a file; the http code is alone on stdout. No production change.

*(history: at that head this was "same cases, same assertions" — true then. The current head adds one case per file, counted below.)*

```
tests/test_remote_curl_config_paths.bats + tests/test_remote_header_sink.bats
  14 ok / 0 not ok        (history: at the first head, before the controls below)
```

## Boundary

This makes an exact comparison mean what it says. It does **not** stop the interruption itself — the fifo open can still be interrupted, and if that ever matters to behaviour rather than to a test's string comparison, it is a separate question. Related: the header copier is not reaped on an early exit (#864).

Declared reviewers: 1



---

## Update at `d1bf17c06fa0` — the redirect now has a control

**Nothing drove the two redirects.** Remove either one and the suite stayed green: on a quiet run, separating the streams changes nothing, so the fix was unbound. Review caught it, and it is the same shape as several findings tonight — a mechanism added without measuring the place where it matters.

The copier is started with its **stderr inherited**, so a `python3` wrapper that writes one line before exec'ing puts a real line on the helper's stderr. What CI produced was bash reporting an interrupted fifo open; this is a different writer to the same stream, and it is deterministic.

Each file gets the same case: the code is exactly `"200"` **and** the noise is in the stderr file. Both halves matter — the second is what makes the first mean *separated* rather than *nothing was written*.

| mutation | red |
|---|---|
| M0 no mutation | **0** |
| M1 config-path redirect removed | 2, both in that file |
| M2 header-sink redirect removed | 2, both in that file |

Per-file, so *"the name is there but the separation is not"* does not pass either.

**16 ok / 0 not ok** across the two files — measured, not carried over:

```
$ grep -c '^@test' tests/test_remote_curl_config_paths.bats tests/test_remote_header_sink.bats
tests/test_remote_curl_config_paths.bats:9
tests/test_remote_header_sink.bats:7

$ bats tests/test_remote_curl_config_paths.bats tests/test_remote_header_sink.bats
1..16   ok 16   not ok 0
```

**The `21` this said before was wrong** — a figure carried from a run that was not this pair of files at this head. 9 + 7 = 16, and the plan line says 16.

### A claim narrowed

The body and the source comments said the difference "was timing, not platform". What was **observed** is that two cases reddened on a loaded macOS CI runner and have not reproduced locally. Load is the candidate; nothing here varied load alone. Both comments now say that instead.

### CI on the previous head

`daf58fa` came back with one real failure, in a test this PR does not touch:

```
not ok 303 watch: a pair claimed by another session is released, not consumed
```

That is **#828** — two `watch:` tests that decide "has the watcher stopped?" by sleeping. (The test's own name cites `#683`, which is a closed and unrelated issue; #828 is the flake.)



---

## Update at `7544efc859ac` — the same claim, in the two places I missed

Each file carried the wide sentence **twice**: once in the file header, once in the `post_under` comment — and the second is where a reader looking at the redirect actually lands. I narrowed one copy per file and reported it done.

Both are now the observed boundary: a loaded macOS CI runner produced it, no local run has reproduced it, load is the candidate, and no control here varied load alone.

```
$ grep -rn 'load, not platform\|timing, not platform' tests/*.bats | wc -l
0
```

Test count and contents are unchanged by this commit: **16 ok / 0 not ok**.

