### PR TITLE
test(compat): make the space-containing-path premise able to fail

### DIFF
--- a/tests/test_compat_posix.bats
+++ b/tests/test_compat_posix.bats
@@ -109,7 +109,13 @@ _stub_ps_printing() {
   esac
 
   # The real ps hands us a path with a space -- the premise of the stub above.
-  [[ "$raw" == *"Application Support"* ]]
+  # A non-last `[[ ]]` cannot fail the test on bash 3.2, so this states the
+  # premise the way the skip guard above already does.
+  case "$raw" in
+    *"Application Support"*) ;;
+    *) echo "ps reported [$raw], which does not carry the space-containing path" >&2
+       return 1 ;;
+  esac
 
   run compat_get_comm "$_PROC_PID"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
`main` is one over its enforced-assertions baseline right now, so the `enforceable assertions` check fails on every branch cut from it. Two open PRs hit this before it was traced, and neither had added the line.

## What happened

`tests/test_compat_posix.bats:112` states the premise of its last test with a non-last `[[ ]]`:

```sh
[[ "$raw" == *"Application Support"* ]]
```

On bash 3.2 a non-last `[[ ]]` cannot fail the test, so the line read as a check without being one. That is exactly what the baseline counts, and it took the count from 638 to 639.

It reached `main` because the branch that introduced it predated the `enforceable assertions` job: 15 checks ran on that head, and this was not among them. CI runs the workflow as it exists on the branch, so an old enough branch is not measured by a check `main` requires.

## The change

The premise now uses the same `case`/`esac` shape as the skip guard directly above it, and prints what `ps` actually reported on failure.

## Positive control

Replacing the pattern with one `$raw` cannot match turns test 5 red and leaves the other four green:

```
not ok 5 compat_get_comm matches the real ps for a binary under a space-containing path
#   `return 1 ;;' failed
# ps reported [/var/folders/.../Application Support/bin/claude], which does not carry the space-containing path
```

`check-enforced-assertions.sh`: 639 before, 638 after — at the baseline. `bats tests/test_compat_posix.bats`: 5/5.