### PR TITLE
test(compat): make the space-in-path premise able to fail (unblocks main)

### DIFF
--- a/tests/test_compat_posix.bats
+++ b/tests/test_compat_posix.bats
@@ -109,7 +109,11 @@ _stub_ps_printing() {
   esac
 
   # The real ps hands us a path with a space -- the premise of the stub above.
-  [[ "$raw" == *"Application Support"* ]]
+  # grep, not `[[ ]]`: a non-last `[[ ]]` cannot fail a test on bash 3.2 (#670),
+  # and a premise that cannot fail is worse than no premise -- the assertions
+  # below would still run, against a `raw` that never had the shape they are
+  # about.
+  grep -qF -- 'Application Support' <<<"$raw"
 
   run compat_get_comm "$_PROC_PID"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
**`main` is red on a required check right now, so this blocks landing for every branch.**

```
check-enforced-assertions: 639 unenforceable assertions, baseline is 638.
```

## Where the extra one came from

Bisected across the commits since `v1.2.1`, running the checker at each:

```
v1.2.1    638     67a1252   638     626a625   638
df4c597   638     fa826b7   639  <- here      2910722   639
```

`fa826b7` (#771) added `tests/test_compat_posix.bats`, and with it:

```sh
  # The real ps hands us a path with a space -- the premise of the stub above.
  [[ "$raw" == *"Application Support"* ]]
```

## Why the ratchet is right and the baseline should not move

A non-last `[[ ]]` cannot fail a test on bash 3.2 (#670). This one is the case's
**premise** — it exists to establish that the real `ps` on this platform hands
back a path containing a space, which is the whole situation the assertions below
it are about.

Because it cannot fail, it passes for any `raw` whatsoever. On a platform whose
`ps` returned something else entirely, the case would sail past its own premise
and then assert against a value that never had the shape in question. The `case`
statement above it already skips the platforms where the path is unreachable, so
the surviving failure mode is the quiet one: a premise that reads as checked and
is not.

That is the class the ratchet exists to catch, so the fix is the assertion, not
the number.

## The change

`grep -qF`, the idiom the other #850-era cases in this tree settled on:

```sh
  grep -qF -- 'Application Support' <<<"$raw"
```

## Verified

```
check-enforced-assertions: 638 unenforceable assertions, at the baseline (638).   exit 0
bats tests/test_compat_posix.bats -> all cases pass
```

The mutation is the point of the change, so it is worth stating plainly: with the
old line, replacing `Application Support` with a string the path never contains
leaves the case green. With the new line it goes red.
