### PR TITLE
test(compat): make the space-in-path premise able to fail (main is over its assertion baseline)

### DIFF
--- a/tests/test_compat_posix.bats
+++ b/tests/test_compat_posix.bats
@@ -109,7 +109,9 @@ _stub_ps_printing() {
   esac
 
   # The real ps hands us a path with a space -- the premise of the stub above.
-  [[ "$raw" == *"Application Support"* ]]
+  # A plain command, not `[[ ]]`: a non-last `[[ ]]` cannot fail a bats test on
+  # bash 3.2, so as a conditional this premise check asserted nothing (#670).
+  grep -qF -- "Application Support" <<<"$raw"
 
   run compat_get_comm "$_PROC_PID"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Declared reviewers: 1

**Change class: CI only.** No product code, no shipped behaviour.

## main is red, and this is why

`check-enforced-assertions` reports **639 against a baseline of 638**, on `main`
itself — so every branch taken from it inherits the failure, in three checks
(the standalone job and the bats cases on ubuntu and macos).

Located by comparing the checker's own enumeration at the commit that set the
baseline against `origin/main`, **per file rather than per line** — the line
numbers move everywhere and a line diff cannot separate "moved" from "added":

```
ba773a6 (baseline set, 638)  vs  origin/main (639)
  +1  tests/test_compat_posix.bats     (0 -> 1)
  everything else unchanged
```

The one entry:

```
tests/test_compat_posix.bats:112: [[ "$raw" == *"Application Support"* ]]
```

## The fix

A non-last `[[ ]]` cannot fail a bats test on bash 3.2 (#670), so as written
this premise check asserted nothing. It is a premise worth keeping — the case
below it only means something if `ps` really did report a path with a space —
so it becomes a plain command rather than being deleted.

## Measured

```
before:  check-enforced-assertions: 639 ... baseline is 638      (red)
after:   check-enforced-assertions: 638 ... at the baseline (638)
tests/test_compat_posix.bats                                      5/5
```

And that the line can now do its job, which the old form could not:

```
premise pointed at a string ps never reports  ->  case 5 RED
the same substitution under the old `[[ ]]`   ->  green
```

The baseline number is left at 638 rather than raised: the tree meets it again.
