### PR TITLE
ci: say what the offender listing is, and how to find the new one

### DIFF
--- a/.github/scripts/check-enforced-assertions.sh
+++ b/.github/scripts/check-enforced-assertions.sh
@@ -104,7 +104,32 @@ case "$baseline" in
 esac
 
 if [ "$found" -gt "$baseline" ]; then
-  echo "check-enforced-assertions: $found unenforceable assertions, baseline is $baseline." >&2
+  over=$((found - baseline))
+  echo "check-enforced-assertions: $found unenforceable assertions, baseline is $baseline (+$over)." >&2
+  echo >&2
+  # Say what the list is before printing it. It is every offender in the tree,
+  # and on a typical red that is hundreds of lines around a `+1`. Four people
+  # read this output on one red and each drew a different wrong conclusion --
+  # the first file in the list taken as the cause, a hundred-line diff between
+  # two heads read as a hundred new offenders (line numbers shift below any
+  # insertion), and from that a guess that the listing must be truncated. It is
+  # not truncated; it is complete, unordered by novelty, and unlabelled.
+  #
+  # No state is added here on purpose. Storing the previous offender set beside
+  # the count would let this name the new entries directly, but it introduces a
+  # second thing to keep in sync with the first, and a listing that disagrees
+  # with the count is the same confusion wearing different clothes. The count
+  # stays the only authority; what changes is that the output stops implying
+  # otherwise. See #892.
+  if [ "$over" -eq 1 ]; then
+    echo "One assertion pushed this over. The list below is EVERY unenforceable" >&2
+  else
+    echo "$over assertions pushed this over. The list below is EVERY unenforceable" >&2
+  fi
+  echo "assertion in the tree, not the new one(s) -- nothing here marks which." >&2
+  echo "To find them: run this checker at the previous commit and compare the" >&2
+  echo "counts, bisecting until the count changes. Comparing the listings does" >&2
+  echo "not work; a line added anywhere shifts every line number below it." >&2
   echo >&2
   printf '%s\n' "$listing" | sed 's/^/  /' >&2
   echo >&2


### PR DESCRIPTION
CI only. One file, `.github/scripts/check-enforced-assertions.sh`. No product change, and no change to what passes or fails.

## Why

Four people read this checker's output on one red tonight, and each drew a different wrong conclusion:

- the first file in the listing taken as the cause;
- a hundred-line difference between two heads read as a hundred new offenders;
- from that, a conclusion that the listing must be truncated;
- and one reader who had the answer in a file list produced for another purpose and did not recognise it.

Everyone eventually arrived by the same route — run the checker at each commit and watch where the count changes — and nothing in the output suggests it.

## What was measured

The listing is **not** truncated. With the baseline forced low:

```
reported   638 unenforceable assertions
printed    638 lines
```

It is complete, unordered by novelty, and unlabelled. On a `+1` that is 639 lines with nothing marking the one that matters. The hundred-line diff was line numbers shifting below an insertion, not new entries.

## The change

```
check-enforced-assertions: 639 unenforceable assertions, baseline is 637 (+2).

2 assertions pushed this over. The list below is EVERY unenforceable
assertion in the tree, not the new one(s) -- nothing here marks which.
To find them: run this checker at the previous commit and compare the
counts, bisecting until the count changes. Comparing the listings does
not work; a line added anywhere shifts every line number below it.
```

## Deliberately no new state

Storing the previous offender set beside the count would let this name the new entries outright. It also introduces a second artifact to keep in sync with the first, and a listing that disagrees with its own count is the same confusion wearing different clothes — on a checker four people just misread. The count stays the only authority; what changes is that the output stops implying otherwise.

If the stored-set version is wanted later, #892 has the argument for it.

## Verified

At `+1`, `+2`, `+9`, at the baseline, and below it. The pass and below-baseline paths are untouched and still read as before.