### PR TITLE
perf: replace sed subprocess with bash-native SQL literal escaping (local send/inbox/history/watch path)

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -238,7 +238,7 @@ for team in "${TEAM_LIST[@]}"; do
              replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
              json_extract(value,'\$.at') || char(31) ||
              json_extract(value,'\$.id')
-      FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+      FROM json_each('${_arr//\'/\'\'}');
     "
   )
   _rc=$?

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -23,7 +23,7 @@ _sqlite_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 # than held in a driver-wide variable: these run inside command substitutions,
 # where an assignment made by a caller would not be visible anyway.
 _sqlite_db() { agmsg_db_path "$1"; }
-_sqlite_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
+_sqlite_lit() { local s="$1" q="'"; printf '%s' "${s//$q/$q$q}"; }
 
 # Run a record-returning query: strip CR but PRESERVE the sqlite exit status
 # (pipefail), so a backend failure surfaces as a non-zero return instead of

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -44,7 +44,7 @@ ROWS=$(agmsg_sqlite ':memory:' "
          replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
          json_extract(value,'\$.at') || char(31) ||
          json_extract(value,'\$.id')
-  FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+  FROM json_each('${_arr//\'/\'\'}');
 ")
 
 # Read-state for the ●(unread)/○(read) marker (G2(c)): read-state is
@@ -62,7 +62,7 @@ while IFS= read -r r; do
   [ -n "$u" ] || continue
   uarr="[$(printf '%s' "$u" | paste -sd, -)]"
   ids=$(agmsg_sqlite ':memory:' "
-    SELECT json_extract(value,'\$.id') FROM json_each('$(printf '%s' "$uarr" | sed "s/'/''/g")');
+    SELECT json_extract(value,'\$.id') FROM json_each('${uarr//\'/\'\'}');
   ")
   UNREAD_IDS+="$ids"$'\n'
 done <<< "$RECIPIENTS"

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -48,7 +48,7 @@ ROWS=$(agmsg_sqlite ':memory:' "
          replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
          json_extract(value,'\$.at') || char(31) ||
          json_extract(value,'\$.id')
-  FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+  FROM json_each('${_arr//\'/\'\'}');
 ")
 
 COUNT=$(printf '%s\n' "$ROWS" | wc -l | tr -d ' ')

--- a/scripts/lib/sqlpath.sh
+++ b/scripts/lib/sqlpath.sh
@@ -29,7 +29,7 @@ agmsg_sql_readfile_path() {
   if command -v cygpath >/dev/null 2>&1; then
     path=$(cygpath -w "$path" 2>/dev/null || printf '%s' "$path")
   fi
-  printf '%s' "$path" | sed "s/'/''/g"
+  printf '%s' "${path//\'/\'\'}"
 }
 
 # True when sqlite can actually open <path>.

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -47,7 +47,7 @@ if [ "$FORCE" -ne 1 ]; then
     fi
     local cfg_sql name_sql found roster
     cfg_sql=$(agmsg_sql_readfile_path "$TEAM_CONFIG")
-    name_sql=$(printf '%s' "$name" | sed "s/'/''/g")
+    name_sql="${name//\'/\'\'}"
     found=$(agmsg_sqlite_mem "
       WITH raw(json) AS (SELECT CAST(readfile('$cfg_sql') AS TEXT)),
       cfg(json) AS (SELECT CASE WHEN json_valid(json) THEN json END FROM raw)

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -702,7 +702,7 @@ while true; do
              COALESCE(json_extract(value,'\$.to'),'') || char(31) ||
              replace(replace(replace(COALESCE(json_extract(value,'\$.body'),''), char(13), ''), char(10), '\\n'), char(9), '\t') || char(31) ||
              COALESCE(json_extract(value,'\$.cursor'),'')
-      FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+      FROM json_each('${_arr//\'/\'\'}');
     " 2>/dev/null || true)"
 
     FINAL_CURSOR=""


### PR DESCRIPTION
Fixes #896.

## What changed

`sed "s/'/''/g"` doubles a single quote for SQL literal embedding — a
transform simple enough that bash's own `${var//pattern/replacement}` does it
without spawning a process. This swaps the 8 call sites on the ordinary local
send/inbox/history/watch path (the sqlite driver used day-to-day, not the
remote-sync path #780/#799 already fixed) from a `sed` subprocess to pure bash
parameter expansion:

```bash
# before
_sqlite_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
# after
_sqlite_lit() { local s="$1" q="'"; printf '%s' "${s//$q/$q$q}"; }
```

Same technique in `send.sh`'s roster-check escape, `inbox.sh`/`history.sh`
(x2)/`watch.sh`/`check-inbox.sh`'s JSONL-array escape, and
`lib/sqlpath.sh`'s `agmsg_sql_readfile_path` (the `cygpath` call there stays —
only the trailing `sed` is replaced).

## Why (measured on Windows 11 / Git Bash, the environment #896 was filed from)

| | `sed` | bash-native | ratio |
|---|---|---|---|
| single call, 20-run average | 221 ms | 12 ms | ~18x |

`storage_send` alone calls `_sqlite_lit` 6 times (team/from/to/body/id/at)
per message, so this one function accounts for roughly 1.3s of the ~10s a
single `send.sh` call cost before this change.

End-to-end, same machine, same team, before/after this patch (installed
locally and exercised against a real two-agent team, not synthetic):

| operation | before | after |
|---|---|---|
| `send.sh <team> a b "<msg>"` | 10.5-11.8 s | 6.4-7.6 s |
| full send-to-ack round trip (separate process, real second agent) | 35-123 s | ~20 s |

## What this does not fix

`history.sh` (and `check-inbox.sh`) separately recompute
`storage_list_unread` once per distinct recipient in the displayed slice, to
derive the unread ●/○ marker — an N+1 query pattern, unrelated to the
`sed`→bash swap here, and out of scope for this PR. `history.sh` on a
159-row store took ~31s both before and after this patch, unaffected by it.
Happy to file that separately if useful; flagging here so it is not read as
"still slow, so this didn't work."

## Correctness

Before touching any live file, `${s//$q/$q$q}` was checked byte-for-byte
against `sed "s/'/''/g"` across 19 cases (empty string, leading/trailing/
consecutive quotes, Thai text, unicode, embedded newline/tab, a SQL-injection
attempt, a 2000-char string) — all identical. Live-verified after patching by
sending a real message containing both an apostrophe and Thai text between
two real agents on a live team; it round-tripped byte-identical on both ends
(sender's `history.sh` and the recipient's own read).

## Testing

Tried running the storage/messaging bats suite locally (`npm install -g
bats`, Windows 11 / Git Bash) before opening this — it did not finish in a
reasonable time and produced no output beyond the version banner, which is
consistent with the same per-process spawn cost this PR is about (bats
itself forks a lot per test). Not reporting a pass/fail I did not actually
observe. What I do have is the byte-for-byte equivalence check (19 cases,
above) and the live production round-trip on a real two-agent team, both
before this PR existed. Leaning on CI here rather than guessing at a local
result.
