### PR TITLE
fix(history): pass the history and unread-marker SQL on stdin (#777)

### DIFF
--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -71,10 +71,19 @@ while IFS= read -r r; do
   [ -n "$u" ] || continue
   uarr="[$(printf '%s' "$u" | paste -sd, -)]"
   # #777: a recipient's unread backlog grows independently of the display limit, so
-  # interpolating it into one argv element eventually exceeds ARG_MAX (measured on Linux:
-  # 2,097,152 was not enough for a 2,079-message team). Pass the statement on stdin
-  # instead, mirroring drivers/storage/sqlite-sync.sh:1082. printf is a bash builtin, so
-  # feeding it a large value does not exec and cannot hit ARG_MAX.
+  # interpolating it into one argv element eventually exceeds the ceiling on a SINGLE
+  # argument -- on Linux `MAX_ARG_STRLEN`, 131,072 bytes. Measured: the failing
+  # statement for a 2,079-message team was 125,945 bytes, which is nowhere near
+  # `ARG_MAX` (2,097,152 here) because ARG_MAX bounds argv plus environment in total,
+  # not any one element of it. The distinction decides the repair: splitting one long
+  # statement into several shorter arguments satisfies MAX_ARG_STRLEN and leaves
+  # ARG_MAX untouched, and a reader who has the wrong limit in mind reaches for the
+  # wrong fix. Note also that MAX_ARG_STRLEN is a kernel constant with no getconf key,
+  # so the limit that bites is the one the tools cannot show you.
+  #
+  # Pass the statement on stdin instead, mirroring drivers/storage/sqlite-sync.sh:1082.
+  # printf is a bash builtin, so feeding it a large value does not exec at all and can
+  # hit neither ceiling.
   _agmsg_unread_sql=$(mktemp "${TMPDIR:-/tmp}/agmsg-history-unread.XXXXXX") || continue
   trap 'rm -f "$_agmsg_unread_sql"' EXIT HUP INT TERM
   {

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -38,14 +38,23 @@ fi
 
 # Parse to "from \x1f to \x1f body \x1f at \x1f id" rows (no jq; cf. lib/hooks-json.sh).
 _arr="[$(printf '%s' "$HIST_JSONL" | paste -sd, -)]"
-ROWS=$(agmsg_sqlite ':memory:' "
-  SELECT json_extract(value,'\$.from') || char(31) ||
-         json_extract(value,'\$.to') || char(31) ||
-         replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
-         json_extract(value,'\$.at') || char(31) ||
-         json_extract(value,'\$.id')
-  FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
-")
+# #777: same argv-length exposure on the display path. Capping --limit does not bound this
+# one either, because a single long body can carry it past the ceiling on its own.
+_agmsg_rows_sql=$(mktemp "${TMPDIR:-/tmp}/agmsg-history-rows.XXXXXX") || exit 13
+trap 'rm -f "$_agmsg_rows_sql"' EXIT HUP INT TERM
+{
+  printf "%s\n" "SELECT json_extract(value,'\$.from') || char(31) ||"
+  printf "%s\n" "       json_extract(value,'\$.to') || char(31) ||"
+  printf "%s\n" "       replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||"
+  printf "%s\n" "       json_extract(value,'\$.at') || char(31) ||"
+  printf "%s\n" "       json_extract(value,'\$.id')"
+  printf "FROM json_each('"
+  printf '%s' "$_arr" | sed "s/'/''/g"
+  printf "');\n"
+} > "$_agmsg_rows_sql"
+ROWS=$(agmsg_sqlite ':memory:' < "$_agmsg_rows_sql")
+rm -f "$_agmsg_rows_sql"
+trap - EXIT HUP INT TERM
 
 # Read-state for the ●(unread)/○(read) marker (G2(c)): read-state is
 # recipient-scoped and not carried on a history record, so derive it by unioning
@@ -61,9 +70,21 @@ while IFS= read -r r; do
   u=$(storage_list_unread "$TEAM" "$r") || continue
   [ -n "$u" ] || continue
   uarr="[$(printf '%s' "$u" | paste -sd, -)]"
-  ids=$(agmsg_sqlite ':memory:' "
-    SELECT json_extract(value,'\$.id') FROM json_each('$(printf '%s' "$uarr" | sed "s/'/''/g")');
-  ")
+  # #777: a recipient's unread backlog grows independently of the display limit, so
+  # interpolating it into one argv element eventually exceeds ARG_MAX (measured on Linux:
+  # 2,097,152 was not enough for a 2,079-message team). Pass the statement on stdin
+  # instead, mirroring drivers/storage/sqlite-sync.sh:1082. printf is a bash builtin, so
+  # feeding it a large value does not exec and cannot hit ARG_MAX.
+  _agmsg_unread_sql=$(mktemp "${TMPDIR:-/tmp}/agmsg-history-unread.XXXXXX") || continue
+  trap 'rm -f "$_agmsg_unread_sql"' EXIT HUP INT TERM
+  {
+    printf "SELECT json_extract(value,'\$.id') FROM json_each('"
+    printf '%s' "$uarr" | sed "s/'/''/g"
+    printf "');\n"
+  } > "$_agmsg_unread_sql"
+  ids=$(agmsg_sqlite ':memory:' < "$_agmsg_unread_sql")
+  rm -f "$_agmsg_unread_sql"
+  trap - EXIT HUP INT TERM
   UNREAD_IDS+="$ids"$'\n'
 done <<< "$RECIPIENTS"
 


### PR DESCRIPTION
Fixes the two `history.sh` call sites listed in #777 (`history.sh:47` and `history.sh:65` in
the issue's numbering) by passing the SQL on stdin instead of as one argv element.

## Why these two first

They are the pair that makes `history` unusable rather than merely slow, and one of them is
not bounded by anything the operator can control:

- **`:64-65` (unread marker)** — builds `json_each('<the recipient's entire unread
  backlog>')`. This set is independent of the display limit, so `history.sh <team> "" 3`
  fails exactly like `history.sh <team>`. From the operator's side, asking for fewer messages
  does not help at any value.
- **`:41` (display slice)** — same construction over the displayed rows. Bounded by the
  limit, but a single long body can carry it past the ceiling on its own, so it is fixed in
  the same commit.

## Measured on Linux, not only Windows

This issue is scoped in its title to Windows/Git Bash. It reproduces on Linux, and the
headroom there is much smaller than `getconf ARG_MAX` suggests — the limit that fails is the
**per-argument** one:

| limit | value here | exceeded | how established |
|---|---|---|---|
| `ARG_MAX` (argv+envp total) | 2,097,152 | no | `getconf ARG_MAX` |
| **`MAX_ARG_STRLEN` (one argument)** | **131,072** (`32 * PAGE_SIZE`) | **yes** | measured (below) |

Boundary, measured with a plain external binary:

```console
$ for n in 131071 131072; do
    arg=$(head -c $n /dev/zero | tr '\0' 'a')
    /bin/echo "$arg" >/dev/null 2>&1 && echo "$n OK" || echo "$n E2BIG"
  done
131071 OK
131072 E2BIG
```

On a live team (2,079+ messages, ~31 MB store) the unread statement measures **125,945
bytes — 96% of that ceiling**, i.e. about 5 KB of headroom remains. One sufficiently large
message, or a handful of ordinary ones, takes it over, and `history` then stops working
entirely. So on Linux this is reached at roughly 128 KB of
accumulated unread payload for one recipient, which is a normal team where a participant has
not read for a while — not an unusually large one.

Before/after in the same installation, same team:

```
unpatched   exit 126   lib/storage.sh: line 237: sqlite3: Argument list too long
patched     exit 0     prints the requested rows
```

## Approach

Mirrors what `drivers/storage/sqlite-sync.sh:1082` already does for the sync-apply batch:
write the statement to a temp file, feed it to `sqlite3` on stdin. `printf` is a bash
builtin, so passing the large value through it does not exec and cannot hit the limit.
Temp files are removed via `trap ... EXIT HUP INT TERM`, following the idiom already used
in `export.sh:90`, so a failing `sqlite3` does not leave one behind.

No behaviour change otherwise — same SQL, same output, same escaping (`sed "s/'/''/g"` is
kept and applied identically).

## Tests

Existing suites, unmodified, on Linux with bats 1.13.0:

```
tests/test_messaging.bats
tests/test_storage.bats
tests/test_storage_contract.bats
tests/test_bin_agmsg.bats
tests/test_binding_mode.bats
tests/test_migrate_team_store.bats
tests/test_legacy_mirror.bats
-> 133 tests, 0 failures
```

Those are the suites that exercise `history.sh` (`grep -l history.sh tests/*.bats`).

## Which numbers are measured, which are not

- **measured**: the 131,071/131,072 boundary; the 125,945-byte statement on a live team;
  the unpatched-vs-patched exit codes; the bats results.
- **arithmetic, not measured**: nothing in this PR body. (An estimated ~420-message
  threshold appears in the issue thread for the *pull* path; it is not used here.)
- **untested**: the `--limit ~200` idea floated in the issue thread for `remote pull` is a
  candidate to test, not a recommendation, and is not part of this change.

Note on the commit message: an earlier revision of this branch attributed the failure to
`ARG_MAX`. That was wrong and is corrected both in the current commit message and in
[the issue thread](https://github.com/fujibee/agmsg/issues/777).

## Not covered here

The other five call sites named in #777 (`check-inbox.sh:241`, `inbox.sh:51`,
`remote.sh:786`, `watch.sh:704`, `drivers/types/codex/watch-once.sh:131`) and the pull-apply
site reported separately in the issue thread (`sqlite-sync.sh:1094-1112`) are untouched. Happy
to extend this PR to any of them if you would rather land them together — I kept the scope to
the two that were blocking day-to-day `history` use here.

## Disclosure

Investigated and drafted by Claude via Claude Code, prepared with the user's authorization,
following the same convention as the rest of #777.
