### PR TITLE
fix(#804): correct a binding an older release left writable, and say what to run if you do not upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -344,6 +344,42 @@ if [ "$UPDATE_ONLY" = true ]; then
     sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$(agmsg_type_template_path grok-build)" > "$GROK_SKILL_DIR/SKILL.md"
   fi
   cp "$SCRIPT_DIR/openai.yaml" "$SKILL_DIR/agents/openai.yaml" 2>/dev/null || true
+  # A team config written by an older release can be group- or world-writable,
+  # and the sync engine refuses to read one that is (#804). Upgrading does not
+  # rewrite files that already exist, so without this the release we are asking
+  # people to install is the release that stops them: joined on v1.2.0-rc.5,
+  # upgraded as told, and now the binding they already had is rejected.
+  #
+  # Narrow on purpose. Only `teams/*/config.json`, only the group and other
+  # WRITE bits, and only files that actually carry them — the same condition
+  # the engine checks, so this cannot correct a file into a state the engine
+  # still refuses, and cannot touch one it would have accepted.
+  #
+  # `go-w` rather than a numeric mode: the owner's bits and any read access the
+  # operator deliberately granted are theirs, not ours to normalise.
+  #
+  # Said out loud, per file. A permission change the operator cannot see is
+  # indistinguishable from one that did not happen, and this one runs without
+  # being asked for.
+  agmsg_fixed_bindings=0
+  for agmsg_binding in "$SKILL_DIR"/teams/*/config.json; do
+    [ -f "$agmsg_binding" ] || continue
+    # `find -perm` rather than parsing `stat`, whose format flags differ between
+    # BSD and GNU — the portability trap this file has hit before. `-maxdepth`
+    # goes before the test: GNU find warns when it trails one. Two tests, not a
+    # combined `-go+w`, because `-perm -MODE` means ALL of the named bits, so
+    # the combined form would silently skip a file writable by only one of them.
+    if [ -n "$(find "$agmsg_binding" -maxdepth 0 -perm -g+w 2>/dev/null)" ] ||
+       [ -n "$(find "$agmsg_binding" -maxdepth 0 -perm -o+w 2>/dev/null)" ]; then
+      if chmod go-w "$agmsg_binding" 2>/dev/null; then
+        echo "  + tightened $agmsg_binding (was group- or world-writable; the sync engine refuses those)"
+        agmsg_fixed_bindings=$((agmsg_fixed_bindings + 1))
+      else
+        echo "  ! could not tighten $agmsg_binding — run: chmod go-w $agmsg_binding" >&2
+      fi
+    fi
+  done
+  unset agmsg_binding agmsg_fixed_bindings
   chmod +x "$SKILL_DIR/scripts/"*.sh
   chmod +x "$SKILL_DIR/scripts/drivers/types/codex/"*.sh 2>/dev/null || true
   # Refresh the Codex monitor shim (~/.agents/bin/codex) if it's ours. --update

--- a/install.sh
+++ b/install.sh
@@ -350,36 +350,60 @@ if [ "$UPDATE_ONLY" = true ]; then
   # people to install is the release that stops them: joined on v1.2.0-rc.5,
   # upgraded as told, and now the binding they already had is rejected.
   #
-  # Narrow on purpose. Only `teams/*/config.json`, only the group and other
-  # WRITE bits, and only files that actually carry them — the same condition
-  # the engine checks, so this cannot correct a file into a state the engine
-  # still refuses, and cannot touch one it would have accepted.
+  # Narrow on purpose -- the set is meant to be exactly the set the engine
+  # refuses ON MODE, so this cannot correct a file into a state the engine still
+  # refuses, and cannot touch one it would have accepted:
+  #
+  #   -type f      a symlink is refused by the engine BEFORE mode is consulted
+  #                ("must not be a symbolic link"), so chmod-ing one would
+  #                change a file OUTSIDE the store and announce a repair that
+  #                repaired nothing. `[ -f ]` follows symlinks; this does not.
+  #   -perm -g+w   two tests, not one `-go+w`: `-perm -MODE` means ALL of the
+  #   -perm -o+w   named bits, so the combined form skips a file writable by
+  #                only one of them.
+  #   find, glob   `teams/*/config.json` silently drops a team whose name
+  #                begins with a dot, and lib/validate.sh allows those -- it
+  #                rejects `.` and `..` but not `.anything`. find descends
+  #                regardless of the leading character.
+  #   one traversal, not two `find` starts per binding.
   #
   # `go-w` rather than a numeric mode: the owner's bits and any read access the
   # operator deliberately granted are theirs, not ours to normalise.
   #
+  # Skipped on Windows, where the engine skips the mode check itself
+  # (`process.platform !== "win32"` guards it, and it is the LAST thing it
+  # consults). MSYS reports modes the filesystem does not really carry, so
+  # without this the walk would announce that the sync engine refuses a file the
+  # sync engine is perfectly happy with -- on every update, on the one platform
+  # where the sentence cannot be true.
+  #
   # Said out loud, per file. A permission change the operator cannot see is
   # indistinguishable from one that did not happen, and this one runs without
   # being asked for.
-  agmsg_fixed_bindings=0
-  for agmsg_binding in "$SKILL_DIR"/teams/*/config.json; do
-    [ -f "$agmsg_binding" ] || continue
-    # `find -perm` rather than parsing `stat`, whose format flags differ between
-    # BSD and GNU — the portability trap this file has hit before. `-maxdepth`
-    # goes before the test: GNU find warns when it trails one. Two tests, not a
-    # combined `-go+w`, because `-perm -MODE` means ALL of the named bits, so
-    # the combined form would silently skip a file writable by only one of them.
-    if [ -n "$(find "$agmsg_binding" -maxdepth 0 -perm -g+w 2>/dev/null)" ] ||
-       [ -n "$(find "$agmsg_binding" -maxdepth 0 -perm -o+w 2>/dev/null)" ]; then
-      if chmod go-w "$agmsg_binding" 2>/dev/null; then
-        echo "  + tightened $agmsg_binding (was group- or world-writable; the sync engine refuses those)"
-        agmsg_fixed_bindings=$((agmsg_fixed_bindings + 1))
-      else
-        echo "  ! could not tighten $agmsg_binding — run: chmod go-w $agmsg_binding" >&2
-      fi
-    fi
-  done
-  unset agmsg_binding agmsg_fixed_bindings
+  if ! is_windows_host; then
+    # Same scheme as lib/shquote.sh, inline rather than sourced: the installer
+    # must not depend on the tree it is in the middle of writing. A team name
+    # may contain a space or a single quote -- lib/validate.sh rejects only
+    # empty / `.` / `..` / `/` / `\` / a leading `-` / control characters -- so
+    # a path printed for someone to paste has to survive both.
+    agmsg_shq() {
+      printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+    }
+    # -print0 and `read -d ''` because the path is arbitrary UTF-8. A newline
+    # cannot appear in a team name (validate.sh rejects control characters), but
+    # nothing here needs to rely on that.
+    find "$SKILL_DIR/teams" -mindepth 2 -maxdepth 2 -name config.json -type f \
+      \( -perm -g+w -o -perm -o+w \) -print0 2>/dev/null |
+      while IFS= read -r -d '' agmsg_binding; do
+        if chmod go-w "$agmsg_binding" 2>/dev/null; then
+          echo "  + tightened $agmsg_binding (an older release left it group- or world-writable; the sync engine refuses those)"
+        else
+          printf '  ! could not tighten %s -- run: chmod go-w %s\n' \
+            "$agmsg_binding" "$(agmsg_shq "$agmsg_binding")" >&2
+        fi
+      done || true
+    unset -f agmsg_shq
+  fi
   chmod +x "$SKILL_DIR/scripts/"*.sh
   chmod +x "$SKILL_DIR/scripts/drivers/types/codex/"*.sh 2>/dev/null || true
   # Refresh the Codex monitor shim (~/.agents/bin/codex) if it's ours. --update

--- a/install.sh
+++ b/install.sh
@@ -350,9 +350,19 @@ if [ "$UPDATE_ONLY" = true ]; then
   # people to install is the release that stops them: joined on v1.2.0-rc.5,
   # upgraded as told, and now the binding they already had is rejected.
   #
-  # Narrow on purpose -- the set is meant to be exactly the set the engine
-  # refuses ON MODE, so this cannot correct a file into a state the engine still
-  # refuses, and cannot touch one it would have accepted:
+  # This is a HISTORICAL correction, not a sweep of every authority file. The
+  # set an older release's write path could have left wrong is exactly
+  # `teams/<team>/config.json`, because it is the only one written by shell
+  # under the caller's umask; `<storage>/remote-sync/<team>.json` and the
+  # retained age checkpoint are written by Node with an explicit 0600 on a
+  # fresh `wx` file, and that code is byte-identical at v1.2.0-rc.5. Those two
+  # are still authority files the engine refuses on mode -- a mode changed by
+  # hand is outside this walk, and the pasteable remedy in the refusal is what
+  # covers that case.
+  #
+  # Within what it does walk, the selection is meant to be exactly the files
+  # the engine refuses ON MODE, so this cannot correct a file into a state the
+  # engine still refuses, and cannot touch one it would have accepted:
   #
   #   -type f      a symlink is refused by the engine BEFORE mode is consulted
   #                ("must not be a symbolic link"), so chmod-ing one would

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -594,11 +594,37 @@ export function authorityFileFault(stats, { maxBytes, privateFile }) {
   // there -- and because it is the LAST thing consulted, no message above can
   // be about it. That ordering is the fix, not a detail of it.
   if (process.platform !== "win32" && (stats.mode & (privateFile ? 0o077 : 0o022)) !== 0) {
+    // The mode it HAS, not only the mode it may not have. An operator reading
+    // "must not be writable by group or others" cannot tell whether they are
+    // looking at 0664 or 0666 or a directory bit, and the two remedies differ.
+    // Printed the way `chmod` and `ls` speak, four digits, so it can be
+    // compared with what `stat` prints without arithmetic.
+    const mode = `0${(stats.mode & 0o7777).toString(8).padStart(3, "0")}`;
     return privateFile
-      ? "must not be readable or writable by group or others"
-      : "must not be writable by group or others";
+      ? `must not be readable or writable by group or others (it is ${mode})`
+      : `must not be writable by group or others (it is ${mode})`;
   }
   return null;
+}
+
+// The command that clears the fault above, or null when there is nothing to
+// type. Same conditions, same function pair, deliberately: the sentence and
+// the condition drifted apart once already (#781), and a remedy derived by
+// re-reading the SENTENCE would drift the same way the moment the wording
+// changes. This re-asks the stats.
+//
+// Only the permission fault has one. A symlink, a directory or an oversized
+// file are not fixed by a mode change, and offering `chmod` for them would send
+// someone to do the wrong thing confidently.
+//
+// `go-w` and `go-rwx` rather than `644` and `600`: the check is about the group
+// and other bits, so the remedy touches those and leaves the owner's alone. A
+// numeric mode would also silently strip a read bit the operator meant to keep.
+export function authorityFileRemedy(stats, { privateFile }) {
+  if (process.platform === "win32") return null;
+  if (stats.isSymbolicLink() || !stats.isFile()) return null;
+  if ((stats.mode & (privateFile ? 0o077 : 0o022)) === 0) return null;
+  return privateFile ? "chmod go-rwx" : "chmod go-w";
 }
 
 async function readBoundedAuthorityFile(path, maxBytes, privateFile) {
@@ -607,8 +633,13 @@ async function readBoundedAuthorityFile(path, maxBytes, privateFile) {
   if (fault) {
     // The path too: the previous message named a property without naming what
     // had it, on a machine that may hold several.
+    // The remedy last, so the sentence still reads as a diagnosis first. An
+    // operator who already knows what to do stops at the path; one who does not
+    // gets the line to paste, on the file that is actually wrong.
+    const remedy = authorityFileRemedy(before, { privateFile });
     throw new Error(
-      `${privateFile ? "remote credential" : "connected team binding"} ${fault}: ${path}`);
+      `${privateFile ? "remote credential" : "connected team binding"} ${fault}: ${path}` +
+      (remedy ? ` — fix it with: ${remedy} ${path}` : ""));
   }
   const handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
   try {
@@ -1268,7 +1299,11 @@ function compareRetainedCheckpoint(config, retained) {
 async function readRetainedCheckpointFile(path) {
   const metadata = await lstat(path);
   const fault = authorityFileFault(metadata, { privateFile: true });
-  if (fault) throw new Error(`retained age checkpoint ${fault}: ${path}`);
+  if (fault) {
+    const remedy = authorityFileRemedy(metadata, { privateFile: true });
+    throw new Error(`retained age checkpoint ${fault}: ${path}` +
+      (remedy ? ` — fix it with: ${remedy} ${path}` : ""));
+  }
   const records = parseStrictJsonl(await readFile(path, "utf8"));
   if (records.length < 1 || records.length > 4096) {
     throw new Error("retained age checkpoint history is invalid");

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -599,7 +599,7 @@ export function authorityFileFault(stats, { maxBytes, privateFile }) {
     // looking at 0664 or 0666 or a directory bit, and the two remedies differ.
     // Printed the way `chmod` and `ls` speak, four digits, so it can be
     // compared with what `stat` prints without arithmetic.
-    const mode = `0${(stats.mode & 0o7777).toString(8).padStart(3, "0")}`;
+    const mode = (stats.mode & 0o7777).toString(8).padStart(4, "0");
     return privateFile
       ? `must not be readable or writable by group or others (it is ${mode})`
       : `must not be writable by group or others (it is ${mode})`;

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -641,6 +641,29 @@ export function authorityFileRemedy(stats, { privateFile }) {
   if ((stats.mode & (privateFile ? 0o077 : 0o022)) === 0) return null;
   return privateFile ? "chmod go-rwx" : "chmod go-w";
 }
+// One sentence, built in one place. `authorityFileFault` exists as a single
+// function because the wording and the condition drifted apart once (#781);
+// two call sites assembling the sentence around it is the same hazard one level
+// out. Measured: unquoting the path at only the checkpoint site left the whole
+// suite green, because nothing drove that site -- so the pin has to be on the
+// construction, not on each caller.
+//
+// The remedy goes last, so the sentence still reads as a diagnosis first. An
+// operator who already knows what to do stops at the path; one who does not
+// gets a line to paste, quoted, about the file that is actually wrong.
+export function authorityFileError(subject, path, stats, { maxBytes, privateFile }) {
+  // `maxBytes` is forwarded, not dropped. Omitting it made this return null for
+  // an oversized file whose caller had already decided there WAS a fault, and
+  // the caller then threw that null. The suite caught it; the lesson is that a
+  // wrapper around a predicate has to take every argument the predicate reads.
+  const fault = authorityFileFault(stats, { maxBytes, privateFile });
+  if (!fault) return null;
+  const remedy = authorityFileRemedy(stats, { privateFile });
+  return new Error(
+    `${subject} ${fault}: ${path}` +
+    (remedy ? ` — fix it with: ${remedy} ${shellQuote(path)}` : ""));
+}
+
 
 async function readBoundedAuthorityFile(path, maxBytes, privateFile) {
   const before = await lstat(path);
@@ -648,13 +671,9 @@ async function readBoundedAuthorityFile(path, maxBytes, privateFile) {
   if (fault) {
     // The path too: the previous message named a property without naming what
     // had it, on a machine that may hold several.
-    // The remedy last, so the sentence still reads as a diagnosis first. An
-    // operator who already knows what to do stops at the path; one who does not
-    // gets the line to paste, on the file that is actually wrong.
-    const remedy = authorityFileRemedy(before, { privateFile });
-    throw new Error(
-      `${privateFile ? "remote credential" : "connected team binding"} ${fault}: ${path}` +
-      (remedy ? ` — fix it with: ${remedy} ${shellQuote(path)}` : ""));
+    throw authorityFileError(
+      privateFile ? "remote credential" : "connected team binding",
+      path, before, { maxBytes, privateFile });
   }
   const handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
   try {
@@ -1313,12 +1332,9 @@ function compareRetainedCheckpoint(config, retained) {
 
 async function readRetainedCheckpointFile(path) {
   const metadata = await lstat(path);
-  const fault = authorityFileFault(metadata, { privateFile: true });
-  if (fault) {
-    const remedy = authorityFileRemedy(metadata, { privateFile: true });
-    throw new Error(`retained age checkpoint ${fault}: ${path}` +
-      (remedy ? ` — fix it with: ${remedy} ${shellQuote(path)}` : ""));
-  }
+  const checkpointFault = authorityFileError(
+    "retained age checkpoint", path, metadata, { privateFile: true });
+  if (checkpointFault) throw checkpointFault;
   const records = parseStrictJsonl(await readFile(path, "utf8"));
   if (records.length < 1 || records.length > 4096) {
     throw new Error("retained age checkpoint history is invalid");

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -620,6 +620,21 @@ export function authorityFileFault(stats, { maxBytes, privateFile }) {
 // `go-w` and `go-rwx` rather than `644` and `600`: the check is about the group
 // and other bits, so the remedy touches those and leaves the owner's alone. A
 // numeric mode would also silently strip a read bit the operator meant to keep.
+// A path as ONE shell argument, for a command someone is expected to paste and
+// run. Same scheme as scripts/lib/shquote.sh: wrap in single quotes and replace
+// each embedded ' with '\'' -- close the quote, emit an escaped literal quote,
+// reopen it.
+//
+// Not cosmetic. A team name is validated only against empty / `.` / `..` / `/`
+// / `\` / a leading `-` / control characters (lib/validate.sh), so a space and
+// a single quote are both legal in one, and the store lives under $HOME, which
+// is outside our control entirely. An unquoted path turns the remedy we printed
+// into a command that operates on a DIFFERENT file, or on several -- the worst
+// possible outcome for a line whose whole job is "run this and you are fixed".
+export function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
 export function authorityFileRemedy(stats, { privateFile }) {
   if (process.platform === "win32") return null;
   if (stats.isSymbolicLink() || !stats.isFile()) return null;
@@ -639,7 +654,7 @@ async function readBoundedAuthorityFile(path, maxBytes, privateFile) {
     const remedy = authorityFileRemedy(before, { privateFile });
     throw new Error(
       `${privateFile ? "remote credential" : "connected team binding"} ${fault}: ${path}` +
-      (remedy ? ` — fix it with: ${remedy} ${path}` : ""));
+      (remedy ? ` — fix it with: ${remedy} ${shellQuote(path)}` : ""));
   }
   const handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
   try {
@@ -1302,7 +1317,7 @@ async function readRetainedCheckpointFile(path) {
   if (fault) {
     const remedy = authorityFileRemedy(metadata, { privateFile: true });
     throw new Error(`retained age checkpoint ${fault}: ${path}` +
-      (remedy ? ` — fix it with: ${remedy} ${path}` : ""));
+      (remedy ? ` — fix it with: ${remedy} ${shellQuote(path)}` : ""));
   }
   const records = parseStrictJsonl(await readFile(path, "utf8"));
   if (records.length < 1 || records.length > 4096) {

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -564,44 +564,62 @@ test("the permission fault carries the command that clears it, and nothing else 
 test("the remedy we print is a command that runs, on a path that fights back", async () => {
   if (process.platform === "win32") return;
 
+  // THE PRODUCTION ENTRY, not the pieces beside it. An earlier version of this
+  // test built the command itself out of `authorityFileRemedy` and
+  // `shellQuote` -- which proves those two work and says nothing about whether
+  // the sentence production emits uses either. Deleting the `shellQuote` call
+  // from both throw sites left it green. This drives `loadConfig`, takes the
+  // message it actually throws, and cuts the command out of that.
+  //
   // A team name may contain a space and a single quote -- lib/validate.sh
   // rejects only empty, `.`, `..`, `/`, `\\`, a leading `-`, and control
-  // characters -- and $HOME is outside our control entirely. So the assertion
-  // is not "the string looks quoted". It is: take the line we printed, hand it
-  // to a real shell, and see the right file change and nothing else.
+  // characters -- and the store sits under $HOME, which is outside our control
+  // entirely.
   const root = await mkdtemp(join(tmpdir(), "agmsg-remedy-"));
+  const previousConnection = process.env.AGMSG_SYNC_CONNECTION_DIR;
+  const previousSkill = process.env.SKILL_DIR;
   try {
-    const dir = join(root, "a b", "it's", "teams", "x");
+    const team = "a b's team";
+    const dir = join(root, "teams", team);
     await mkdir(dir, { recursive: true });
     const target = join(dir, "config.json");
     const bystander = join(root, "bystander");
-    await writeFile(target, "{}\n");
+    await writeFile(target, JSON.stringify({ local_team: team }));
     await writeFile(bystander, "{}\n");
     await chmod(target, 0o664);
     await chmod(bystander, 0o664);
 
-    const before = await stat(target);
-    const fault = authorityFileFault(before, { maxBytes: 100, privateFile: false });
-    const remedy = authorityFileRemedy(before, { privateFile: false });
-    // The premise: this file is one the engine actually refuses. Without it the
-    // chmod below could be "fixing" something that was never wrong.
-    assert.ok(fault, "0664 must be a fault, or this test proves nothing");
-    assert.ok(remedy, "a fault with a mode remedy must offer one");
+    process.env.AGMSG_SYNC_CONNECTION_DIR = root;
+    delete process.env.SKILL_DIR;
 
-    const command = `${remedy} ${shellQuote(target)}`;
+    // The premise: production refuses this file, and says so with a command.
+    // Without asserting it, a message that stopped offering one would leave the
+    // rest of this test skipping quietly.
+    let message = null;
+    await assert.rejects(() => loadConfig(team), (error) => {
+      message = error.message;
+      return true;
+    });
+    assert.match(message, /must not be writable by group or others \(it is 0664\)/u);
+    assert.ok(message.includes(" — fix it with: "), `no remedy offered: ${message}`);
+
+    const command = message.split(" — fix it with: ")[1];
     const ran = spawnSync("sh", ["-c", command], { encoding: "utf8" });
-    assert.equal(ran.status, 0, `printed command failed: ${ran.stderr}`);
+    assert.equal(ran.status, 0, `printed command failed: ${command}\n${ran.stderr}`);
 
     const after = await stat(target);
-    // It changed...
-    assert.notEqual(after.mode & 0o7777, before.mode & 0o7777);
-    // ...into a mode the engine accepts, stated the way the engine states it.
+    // It changed, into a mode the engine accepts, stated the way it states it.
+    assert.notEqual(after.mode & 0o7777, 0o664);
     assert.equal(after.mode & 0o022, 0);
     assert.equal(authorityFileFault(after, { maxBytes: 100, privateFile: false }), null);
-    // ...and only it. An unquoted path would have split at the space and made
-    // this a command about several files, or a different one.
+    // And only it. Unquoted, the command would have split at the space and been
+    // about a different file, or about several.
     assert.equal((await stat(bystander)).mode & 0o7777, 0o664);
   } finally {
+    if (previousConnection === undefined) delete process.env.AGMSG_SYNC_CONNECTION_DIR;
+    else process.env.AGMSG_SYNC_CONNECTION_DIR = previousConnection;
+    if (previousSkill === undefined) delete process.env.SKILL_DIR;
+    else process.env.SKILL_DIR = previousSkill;
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -14,6 +14,7 @@ import {
   activateKeyRotations,
   authorityFileFault,
   authorityFileRemedy,
+  shellQuote,
   describeChildExit,
   canonicalJson,
   consistentReadStateContext,
@@ -557,6 +558,71 @@ test("the permission fault carries the command that clears it, and nothing else 
         remedy !== null, fault !== null,
         `mode 0${mode.toString(8)} privateFile=${privateFile}: fault=${fault} remedy=${remedy}`);
     }
+  }
+});
+
+test("the remedy we print is a command that runs, on a path that fights back", async () => {
+  if (process.platform === "win32") return;
+
+  // A team name may contain a space and a single quote -- lib/validate.sh
+  // rejects only empty, `.`, `..`, `/`, `\\`, a leading `-`, and control
+  // characters -- and $HOME is outside our control entirely. So the assertion
+  // is not "the string looks quoted". It is: take the line we printed, hand it
+  // to a real shell, and see the right file change and nothing else.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-remedy-"));
+  try {
+    const dir = join(root, "a b", "it's", "teams", "x");
+    await mkdir(dir, { recursive: true });
+    const target = join(dir, "config.json");
+    const bystander = join(root, "bystander");
+    await writeFile(target, "{}\n");
+    await writeFile(bystander, "{}\n");
+    await chmod(target, 0o664);
+    await chmod(bystander, 0o664);
+
+    const before = await stat(target);
+    const fault = authorityFileFault(before, { maxBytes: 100, privateFile: false });
+    const remedy = authorityFileRemedy(before, { privateFile: false });
+    // The premise: this file is one the engine actually refuses. Without it the
+    // chmod below could be "fixing" something that was never wrong.
+    assert.ok(fault, "0664 must be a fault, or this test proves nothing");
+    assert.ok(remedy, "a fault with a mode remedy must offer one");
+
+    const command = `${remedy} ${shellQuote(target)}`;
+    const ran = spawnSync("sh", ["-c", command], { encoding: "utf8" });
+    assert.equal(ran.status, 0, `printed command failed: ${ran.stderr}`);
+
+    const after = await stat(target);
+    // It changed...
+    assert.notEqual(after.mode & 0o7777, before.mode & 0o7777);
+    // ...into a mode the engine accepts, stated the way the engine states it.
+    assert.equal(after.mode & 0o022, 0);
+    assert.equal(authorityFileFault(after, { maxBytes: 100, privateFile: false }), null);
+    // ...and only it. An unquoted path would have split at the space and made
+    // this a command about several files, or a different one.
+    assert.equal((await stat(bystander)).mode & 0o7777, 0o664);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("shellQuote survives what the validator lets through", () => {
+  if (process.platform === "win32") return;
+
+  // Round-trip through a real shell rather than comparing to an expected
+  // string: the question is what the pasting shell does with it, and an
+  // expected-string assertion would only re-state the implementation.
+  for (const value of [
+    "/plain/path",
+    "/with a space/config.json",
+    "/with'a'quote/config.json",
+    "/both it's here/config.json",
+    "/$(touch pwned)/config.json",
+    "/back\\slash/config.json",
+  ]) {
+    const out = spawnSync("sh", ["-c", `printf %s ${shellQuote(value)}`], { encoding: "utf8" });
+    assert.equal(out.status, 0, `shell rejected ${shellQuote(value)}`);
+    assert.equal(out.stdout, value, `did not round-trip: ${value}`);
   }
 });
 

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -13,6 +13,7 @@ import {
   ageSnapshotDigest,
   activateKeyRotations,
   authorityFileFault,
+  authorityFileRemedy,
   describeChildExit,
   canonicalJson,
   consistentReadStateContext,
@@ -508,6 +509,54 @@ test("a file fault names the condition that failed, and permissions last", () =>
     assert.match(
       authorityFileFault(stats({ mode: 0o666 }), { maxBytes: 100 }),
       /must not be writable by group or others/u);
+
+    // The mode it HAS. #804: a machine that joined on an older version carries
+    // a 0664 config, upgrading does not rewrite it, and the operator was told
+    // which bits are forbidden without being told which ones are set.
+    assert.match(
+      authorityFileFault(stats({ mode: 0o664 }), { maxBytes: 100 }), /\(it is 0664\)/u);
+    assert.match(
+      authorityFileFault(stats({ mode: 0o666 }), { maxBytes: 100, privateFile: true }),
+      /\(it is 0666\)/u);
+    // Four digits, so it can be compared with `stat` output without arithmetic
+    // -- and so a setuid bit shows up rather than being masked away.
+    assert.match(
+      authorityFileFault(stats({ mode: 0o4664 }), { maxBytes: 100 }), /\(it is 4664\)/u);
+  }
+});
+
+test("the permission fault carries the command that clears it, and nothing else does", () => {
+  const stats = (over = {}) => ({
+    isSymbolicLink: () => false, isFile: () => true, size: 10, mode: 0o600, ...over,
+  });
+  if (process.platform === "win32") return;
+
+  // The two faults a mode change fixes, and the two different remedies. `go-w`
+  // for the binding and `go-rwx` for the credential: the checks differ, so the
+  // commands do.
+  assert.equal(authorityFileRemedy(stats({ mode: 0o664 }), {}), "chmod go-w");
+  assert.equal(
+    authorityFileRemedy(stats({ mode: 0o640 }), { privateFile: true }), "chmod go-rwx");
+
+  // Nothing to type. Offering `chmod` for these would send someone to do the
+  // wrong thing confidently, which is worse than saying less.
+  assert.equal(authorityFileRemedy(stats({ isSymbolicLink: () => true, mode: 0o666 }), {}), null);
+  assert.equal(authorityFileRemedy(stats({ isFile: () => false, mode: 0o666 }), {}), null);
+  // Already correct: no fault, so no remedy.
+  assert.equal(authorityFileRemedy(stats({ mode: 0o644 }), {}), null);
+  assert.equal(authorityFileRemedy(stats({ mode: 0o600 }), { privateFile: true }), null);
+
+  // The pair must agree. A remedy offered where there is no fault, or withheld
+  // where there is one, is the drift this function pair exists to prevent --
+  // the same drift #781 fixed between the sentence and the condition.
+  for (const mode of [0o600, 0o640, 0o644, 0o660, 0o664, 0o666, 0o700, 0o777]) {
+    for (const privateFile of [false, true]) {
+      const fault = authorityFileFault(stats({ mode }), { maxBytes: 100, privateFile });
+      const remedy = authorityFileRemedy(stats({ mode }), { privateFile });
+      assert.equal(
+        remedy !== null, fault !== null,
+        `mode 0${mode.toString(8)} privateFile=${privateFile}: fault=${fault} remedy=${remedy}`);
+    }
   }
 });
 

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1038,3 +1038,83 @@ CYG
   [ "$(( 8#$after & 8#0022 ))" -eq 0 ]
   grep -Fq "$cfg" <<<"$output"
 }
+
+# The engine refuses a symlink BEFORE it looks at the mode ("must not be a
+# symbolic link"), so a symlinked binding is not in the set this walk is for.
+# `[ -f ]` follows symlinks and so does `chmod`: the old shape would have
+# changed a file OUTSIDE the store and announced a repair that repaired nothing,
+# because the binding stays refused either way.
+@test "install --update: does not follow a symlinked binding to something outside the store (#804)" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  bash "$SK/scripts/join.sh" lnk alice claude-code /tmp/install-804-d
+
+  local cfg outside before after
+  cfg="$SK/teams/lnk/config.json"
+  outside="$FAKE_HOME/outside.json"
+
+  cp "$cfg" "$outside"
+  chmod 0664 "$outside"
+  rm -f "$cfg"
+  ln -s "$outside" "$cfg"
+
+  before="$(file_mode "$outside")"
+  [ "$before" = "664" ]
+
+  run env HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  [ "$status" -eq 0 ]
+
+  after="$(file_mode "$outside")"
+  # The file the symlink pointed at is untouched...
+  [ "$after" = "664" ]
+  # ...and nothing was claimed about it.
+  refute grep -Fq "$cfg" <<<"$output"
+  refute grep -Fq "$outside" <<<"$output"
+}
+
+# lib/validate.sh rejects `.` and `..` and allows `.anything`, so a team whose
+# name starts with a dot is a legal team with a real binding. A `teams/*/` glob
+# does not match it -- silently, which is the whole failure mode of this issue
+# repeated one level up.
+@test "install --update: corrects a binding under a dot-leading team name (#804)" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  bash "$SK/scripts/join.sh" .dotteam alice claude-code /tmp/install-804-e
+
+  local cfg before after
+  cfg="$SK/teams/.dotteam/config.json"
+  [ -f "$cfg" ]
+
+  chmod 0664 "$cfg"
+  before="$(file_mode "$cfg")"
+  [ "$before" = "664" ]
+
+  run env HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  [ "$status" -eq 0 ]
+
+  after="$(file_mode "$cfg")"
+  [ "$after" != "$before" ]
+  [ "$(( 8#$after & 8#0022 ))" -eq 0 ]
+}
+
+# The engine guards its mode check with `process.platform !== "win32"` and it is
+# the LAST thing it consults, so on Windows no binding is ever refused for its
+# mode. MSYS also reports modes the filesystem does not carry. Correcting there
+# would announce that the sync engine refuses a file the sync engine is happy
+# with -- on every update, on the one platform where that sentence cannot be
+# true.
+@test "install --update: does not touch or announce bindings on Windows (#804)" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  bash "$SK/scripts/join.sh" win alice claude-code /tmp/install-804-f
+
+  local cfg before after
+  cfg="$SK/teams/win/config.json"
+  chmod 0664 "$cfg"
+  before="$(file_mode "$cfg")"
+  [ "$before" = "664" ]
+
+  run env HOME="$FAKE_HOME" AGMSG_FORCE_WINDOWS=1 bash "$REPO_ROOT/install.sh" --update
+  [ "$status" -eq 0 ]
+
+  after="$(file_mode "$cfg")"
+  [ "$after" = "664" ]
+  refute grep -Fq "tightened" <<<"$output"
+}

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1139,7 +1139,14 @@ CYG
   # the guard itself is measured on POSIX, where AGMSG_FORCE_WINDOWS drives
   # exactly the same branch with a mode that is real.
   if [ "$(( 8#$before & 8#0022 ))" -eq 0 ]; then
-    skip "modes are synthetic here (chmod 0664 left it $before); the guard is measured on POSIX"
+    # `return 0`, not `skip`. A skip after passing assertions still reports the
+    # row as skipped, so the two checks above -- which DID run and DID have to
+    # pass to get here -- are counted as unmeasured by every reader and tally.
+    # This ends the test normally and records the boundary in the output.
+    echo "boundary: modes are synthetic here (chmod 0664 left it $before);" \
+      "the 0664 premise is fixed on POSIX, where AGMSG_FORCE_WINDOWS drives" \
+      "the same branch with a real mode"
+    return 0
   fi
   [ "$before" = "664" ]
 }

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -951,3 +951,65 @@ CYG
   run cat "$SK/VERSION"
   [ "$output" = "$expected" ]
 }
+
+# #804, the upgrade half. test_binding_mode.bats covers the write side: join.sh
+# now writes 0600, so bindings created from here on are fine. These cover the
+# bindings that already exist. A machine that joined on v1.2.0-rc.5 has a 0664
+# binding on disk, and --update does not rewrite a file that is already there,
+# so without the store walk the upgrade we tell people to run leaves them exactly
+# as stuck as before -- having done what we asked.
+@test "install --update: clears group-write on a binding an older release left 0664 (#804)" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  bash "$SK/scripts/join.sh" upg alice claude-code /tmp/install-804-a
+
+  local cfg before after
+  cfg="$SK/teams/upg/config.json"
+  [ -f "$cfg" ]
+
+  # Put the file into the state the older release left, and prove it took --
+  # otherwise a chmod that silently did nothing would make the assertion below
+  # pass on a file that was never wrong.
+  chmod 0664 "$cfg"
+  before="$(file_mode "$cfg")"
+  [ "$before" = "664" ]
+
+  run env HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  [ "$status" -eq 0 ]
+
+  after="$(file_mode "$cfg")"
+  # It changed at all...
+  [ "$after" != "$before" ]
+  # ...and it changed into a mode the readers accept, stated the way they state
+  # it. Both halves: "something happened" is not "the right thing happened".
+  [ "$(( 8#$after & 8#0022 ))" -eq 0 ]
+
+  # And it said so. A permission change nobody can see is indistinguishable from
+  # one that did not happen, and this one runs without being asked for.
+  # `grep`, not `[[ ]]`: a non-last `[[ ]]` cannot fail under errexit on bash
+  # 3.2, so this one works only for as long as it stays the last line.
+  grep -Fq "$cfg" <<<"$output"
+}
+
+@test "install --update: leaves a binding the readers already accept alone (#804)" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  bash "$SK/scripts/join.sh" keep alice claude-code /tmp/install-804-b
+
+  local cfg before after
+  cfg="$SK/teams/keep/config.json"
+  [ -f "$cfg" ]
+
+  # 0600 is what join.sh writes. The point is not that 0600 survives but that
+  # the walk is a correction and not a normalisation: a blanket `chmod 0644`
+  # would pass the test above and quietly widen every binding on the machine.
+  chmod 0600 "$cfg"
+  before="$(file_mode "$cfg")"
+  [ "$before" = "600" ]
+
+  run env HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  [ "$status" -eq 0 ]
+
+  after="$(file_mode "$cfg")"
+  [ "$after" = "600" ]
+  # Nothing was announced about it either.
+  refute grep -Fq "$cfg" <<<"$output"
+}

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1121,14 +1121,25 @@ CYG
 
   local cfg before after
   cfg="$SK/teams/win/config.json"
-  chmod 0664 "$cfg"
+  chmod 0664 "$cfg" 2>/dev/null || true
   before="$(file_mode "$cfg")"
-  [ "$before" = "664" ]
 
   run env HOME="$FAKE_HOME" AGMSG_FORCE_WINDOWS=1 bash "$REPO_ROOT/install.sh" --update
   [ "$status" -eq 0 ]
 
-  after="$(file_mode "$cfg")"
-  [ "$after" = "664" ]
+  # Nothing announced, and nothing changed. Both hold on every platform.
   refute grep -Fq "tightened" <<<"$output"
+  after="$(file_mode "$cfg")"
+  [ "$after" = "$before" ]
+
+  # The rest only says something if the file was group- or other-writable to
+  # begin with, and on MSYS it cannot be: modes there are synthetic and
+  # `chmod 0664` does not take, which is how this row first went red on the
+  # Windows leg. Say where the boundary is instead of asserting through it --
+  # the guard itself is measured on POSIX, where AGMSG_FORCE_WINDOWS drives
+  # exactly the same branch with a mode that is real.
+  if [ "$(( 8#$before & 8#0022 ))" -eq 0 ]; then
+    skip "modes are synthetic here (chmod 0664 left it $before); the guard is measured on POSIX"
+  fi
+  [ "$before" = "664" ]
 }

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1057,6 +1057,20 @@ CYG
   rm -f "$cfg"
   ln -s "$outside" "$cfg"
 
+  # A symlink's OWN mode decides whether a walk missing `-type f` would even
+  # select it, and that mode is not the same everywhere: Linux creates them
+  # 0777, macOS 0755. Without this the test passes on macOS for a reason that
+  # has nothing to do with the code -- the link is simply never selected -- and
+  # the platform where it does not hold is the platform CI mostly runs on.
+  # `chmod -h` sets the link itself on BSD; GNU chmod has no such flag and does
+  # not need one.
+  chmod -h go+w "$cfg" 2>/dev/null || true
+  local linkmode
+  linkmode="$(file_mode "$cfg")"
+  if [ "$(( 8#$linkmode & 8#0022 ))" -eq 0 ]; then
+    skip "symlinks here are $linkmode; a walk without -type f could not select one anyway"
+  fi
+
   before="$(file_mode "$outside")"
   [ "$before" = "664" ]
 

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -1013,3 +1013,28 @@ CYG
   # Nothing was announced about it either.
   refute grep -Fq "$cfg" <<<"$output"
 }
+
+# The condition is two tests, not one: `find -perm -MODE` means ALL of the named
+# bits, so a single `-go+w` would skip a file writable by only one of them. Each
+# half needs its own row, or deleting either one stays green. 0664 is the
+# reported shape; this is the other.
+@test "install --update: clears other-write on a binding left 0646 (#804)" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  bash "$SK/scripts/join.sh" oth alice claude-code /tmp/install-804-c
+
+  local cfg before after
+  cfg="$SK/teams/oth/config.json"
+  [ -f "$cfg" ]
+
+  chmod 0646 "$cfg"
+  before="$(file_mode "$cfg")"
+  [ "$before" = "646" ]
+
+  run env HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  [ "$status" -eq 0 ]
+
+  after="$(file_mode "$cfg")"
+  [ "$after" != "$before" ]
+  [ "$(( 8#$after & 8#0022 ))" -eq 0 ]
+  grep -Fq "$cfg" <<<"$output"
+}


### PR DESCRIPTION
Closes #804.

## What this changes for users

Someone who joined a team on v1.2.0-rc.5 has a `teams/<team>/config.json` on
disk at 0664. Every reader of a binding refuses `mode & 0o022`, so their sync is
dead. Upgrading does not rewrite a file that already exists, so today the
release we tell them to install is the release that leaves them stuck — having
done exactly what we asked.

Two halves, because they reach different people:

1. **`--update` walks the store and clears the group and other write bits** on
   any binding that carries them. This is the fix for anyone who upgrades.
2. **The refusal now names the mode the file has and the command that clears
   it.** This is for anyone who does not upgrade, or who hits it again some
   other way. Before: `must not be writable by group or others: <path>`. After:
   `must not be writable by group or others (it is 0664): <path> — fix it with:
   chmod go-w '<path>'`.

The write side is already fixed and already tested — `join.sh` writes 0600, per
`tests/test_binding_mode.bats`. This PR is about the files that already exist
and the message that reaches whoever does not run the installer.

**Classification:** this affects existing users — it changes what runs on their
machine during an upgrade, and it changes a user-visible error string.

## The walked set is exactly the set an older release could have left wrong

Two narrowings, both from review. The first version claimed the walk matched
"the same condition the engine checks" and had four gaps in it; all four are
fixed here, each with its own test row. The second narrowing is the sentence
itself — see the derivation below. The walk is a **historical correction**, not
the set of every file the engine can refuse on mode.

- **`-type f`.** The engine refuses a symlink *before* it consults the mode
  ("must not be a symbolic link"), so a symlinked binding stays refused whatever
  its target's mode is. `[ -f ]` follows symlinks and so does `chmod`, so the
  walk changed a file **outside the store** and announced a repair that repaired
  nothing.
- **`find`, not a glob.** `teams/*/config.json` does not match `teams/.x/`, and
  `lib/validate.sh` allows dot-leading names — it rejects `.` and `..`, not
  `.anything`. Measured: `join.sh .dotteam alice` succeeds and the glob matches
  nothing. A whole team silently skipped.
- **Skipped on Windows.** The engine guards the mode check with
  `process.platform !== "win32"` and consults it last, so no binding is ever
  refused there for its mode; MSYS also reports modes the filesystem does not
  carry. The walk would have announced that the sync engine refuses a file the
  sync engine is happy with, on every update. `install.sh` already had
  `is_windows_host`, so "a platform branch could be wrong" was not a reason to
  avoid one.
- **Two `-perm` tests, not one `-go+w`.** `-perm -MODE` means **all** of the
  named bits, so the combined form silently skips a file writable by only one of
  them.

`chmod go-w`, not a numeric mode: the owner's bits, and any read access the
operator granted on purpose, are theirs and not ours to normalise.

The path printed in the "could not tighten" line is shell-quoted, with the same
scheme as `lib/shquote.sh`, inlined rather than sourced as `lib/registry-lock.sh`
already does — the installer must not depend on the tree it is in the middle of
writing. Checked to produce byte-identical output to `agmsg_shq` on a value
containing both a space and a single quote.

## Cost

**Corrected from the first version of this body, which said "N stat calls".**
That was wrong: it was two external `find` processes per binding, because each
file started `find` twice. It is now **one traversal for the whole store**, with
the two `-perm` tests as a single `-o` expression, and zero writes when every
binding is already acceptable.

## Measured

Not "chmod, then it passes". A store built by the real `join.sh`, put into the
state the older release left, then the real `install.sh --update` over it:

| binding | before | after | corrected? |
|---|---|---|---|
| group-writable | 0664, engine refuses | 0644, engine accepts | yes |
| other-writable | 0646, engine refuses | 0644, engine accepts | yes |
| both | 0666, engine refuses | 0644, engine accepts | yes |
| already correct | 0644, engine accepts | 0644 | untouched |
| owner-only | 0600, engine accepts | 0600 | untouched, **not** normalised |

The third column is the engine's own verdict, called directly. The refusals in
the second column are what make it a measurement rather than a restatement.

For the message half: a store under `a b's team`, driven through `loadConfig`,
the command cut out of the message it actually threw and handed to `sh`. The
target went 0664 → 0644 and a 0664 bystander beside it was untouched.

## Mutations

`bats -f "#804" tests/test_install.bats` (6) and
`node --test tests/remote_sync_engine.test.mjs` (97). Each mutation reverted
before the next.

| # | mutation | red |
|---|---|---|
| A | remove the store walk entirely | t1 |
| B | replace it with a blanket `chmod 0644` | t2 |
| C | delete the `-o+w` test, keep `-g+w` | t3 |
| D | collapse both into one `-go+w` | t1, t3 |
| E | drop `-type f` (follow symlinks again) | t4 |
| F | go back to the `teams/*/` glob | t5 |
| G | remove the `is_windows_host` guard | t6 |
| H | drop `shellQuote` from the message | remedy test |

The diagonal is the point: no row restates another. B is worth naming — a
blanket `chmod 0644` passes A's test while quietly widening every binding on the
machine.

## Two mutations came back green, and both were my instrument

Reporting these because they are the reason to trust the rest of the table.

- **E was green at first.** A symlink's own mode decides whether a walk missing
  `-type f` selects it, and that mode is not the same everywhere: Linux makes
  them 0777, macOS 0755. The row was passing on macOS with or without the fix.
  It now makes the link group-writable (`chmod -h`, a BSD flag GNU does not
  need) and **asserts that premise**, skipping with a reason where it cannot be
  established.
- **H was green at first.** The test built the command itself out of
  `authorityFileRemedy` and `shellQuote` — which proves those two work and says
  nothing about whether the thrown sentence uses either. It now drives
  `loadConfig` and cuts the command out of the message production emits.

Following H: unquoting the path at **only** the checkpoint throw site left the
whole suite green, because nothing drove that site. Rather than add a second
test, the two sites now share one `authorityFileError`, the way
`authorityFileFault` is already one function for exactly this reason (#781).
That refactor introduced a bug — the wrapper dropped `maxBytes`, so an oversized
file produced `throw null` — which an existing test caught immediately.

## Ran

- `bats -f "#804" tests/test_install.bats` — 6/6
- `node --test tests/remote_sync_engine.test.mjs` — 97/97
- `bats tests/test_enforced_assertions.bats` — including "the real tree sits at
  its baseline": these tests add **zero** new unenforced assertions.

Not run locally: the full suite. CI runs it.

## Which files could an older release have left wrong? — derived, and the first derivation was short

Listed as an open doubt in the first version of this body. It is now closed, and
the first pass had missed half the readers.

`readBoundedAuthorityFile` has **four** call sites, not the two I derived from.
They resolve through **two** path functions:

| path function | resolves to | written by |
|---|---|---|
| `teamConfigPath` (×3) | `<connection root>/teams/<team>/config.json` | `join.sh`, in shell, under the caller's umask |
| `configPath` (×1) | `<storage>/remote-sync/<team>.json` | `writeConfig`, in Node |

Only the first can carry a bad mode from an older release. `writeConfig` creates
a fresh temp file with an explicit `{ mode: 0o600, flag: "wx" }` and renames it,
so the mode does not come from the umask — and that function is **byte-identical
at `v1.2.0-rc.5`**, so that write path never produced a wrong one.

Measured, rather than read off the code, with the control beside it:

```
writeConfig's shape under umask 002:  0600
a plain write under umask 002:        0664   <- the control
```

The control is the point: umask 002 really does widen an ordinary write here, so
the 0600 is the explicit mode holding, not a friendly umask.

The `privateFile: true` reader is the retained age checkpoint, reached via
`ageTrustPath(config)` — outside `teams/`, and also written by Node.

**What that establishes, and what it does not.** It establishes that the set an
older release's *write path* could have left wrong is exactly
`teams/<team>/config.json` — which is what a one-time upgrade correction is for.
It does **not** establish that the walk covers every file the engine can refuse
on mode. `<storage>/remote-sync/<team>.json` and the retained age checkpoint are
both authority files, and both are refused on mode if their mode is wrong today;
they are simply not files any shipped write path made wrong. A mode changed by
hand, or by something we have not shipped yet, is outside the walk.

That boundary is where the two halves meet: whatever the correction does not
reach, the refusal now hands the operator a quoted command that does.

## Still worth a second opinion

- **The walk runs on every `--update`, for everyone.** One `find` traversal of
  `teams/` at depth 2. I have not measured it on a store with hundreds of teams.
