### PR TITLE
feat(sync): emit push.posted at POST completion, and read it in the perf harness (#913)

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -3142,6 +3142,15 @@ export async function cycle(config, { pushLimit, pullLimit }, dependencies = {})
       }
       throw error;
     }
+    // The POST is over and every ack is in hand; the durable write has not
+    // started. This is the one boundary a reader of the log could not see:
+    // push.ack and push.reconciled are both emitted after recordAcks, so
+    // between push.prepared and push.ack sat the POST AND the reconcile with
+    // nothing to tell them apart (#913). Through note(), never bare: this event
+    // sits between the acks and the write that makes them durable, and a log
+    // that cannot be written must not cost that write -- the same reason the
+    // failing path above reports through note().
+    await note(eventCall, "push.posted", { count: posted.acks.length });
     await reportAcks(eventCall, await recordAcks(posted.acks));
   }
   // A full push page (and eligible) means at least a full page was available,

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -25,12 +25,13 @@ Every run prints a per-stage table and writes `summary.json`; with more than one
 | `bootstrap.fetch` | stderr `fetching messages after N` → `applying N messages` | `GET /v1/teams/<id>/messages`, one page |
 | `bootstrap.apply` | stderr `applying N messages` → `pull.bootstrap.applied` | evaluate (JS) + roster driver apply + storage driver apply |
 | `engine.prepare` / `once.prepare` | `capabilities` → `push.prepared` | storage driver prepare (roster prepare in parallel) |
-| `engine.post+reconcile` / `once.post+reconcile` | `push.prepared` → `push.ack` | `POST /v1/messages` until the acks are back, **and** the storage driver reconcile of those acks — one stage, because the engine writes the acks through `reconcile` before it emits `push.ack` (`push.reconciled` follows in the same call). Splitting POST from reconcile needs an event at POST completion that the engine does not emit today. |
+| `engine.post` / `once.post` | `push.prepared` → `push.posted` | `POST /v1/messages` until the acks are back |
+| `engine.reconcile` / `once.reconcile` | `push.posted` → `push.ack` | storage driver reconcile of the acks (the engine writes them through `reconcile` before it emits `push.ack`; `push.posted` is the event at POST completion that makes the boundary visible, #913) |
 | `engine.fetch+evaluate` / `once.fetch+evaluate` | previous event → `pull.received` | `GET /v1/messages` + evaluate (JS) |
 | `engine.apply` / `once.apply` | `pull.received` → `pull.applied` | storage driver apply |
 | `reprocess.total` | phase marker → `reprocess.complete` | driver reprocess pages + evaluate + apply (and two HTTP reads) |
 
-#913 asked for `push.prepared` / POST complete / reconcile complete to split the 359 seconds of a push. This harness gives the first and the last; the middle one does not exist as an event, so POST and reconcile are reported together until it does.
+`push.prepared` → `push.posted` → `push.ack` are the three timings #913 asked for to split the 359 seconds of a push. A cycle whose `push.ack` arrives without a `push.posted` is reported as missing, not as a zero-length POST.
 
 **A missing event fails the run; it is never a zero.** `report.py` declares the events each phase must contain (`EXPECTED`) and exits 2 naming any that did not arrive. A stage whose input was empty (nothing to push, no quarantined rows) is reported as `[not exercised]`, and the comparison says `NOT EXERCISED` rather than `fast`.
 
@@ -41,7 +42,7 @@ Every run prints a per-stage table and writes `summary.json`; with more than one
 | scenario | exercises | measured stages | does NOT exercise |
 |---|---|---|---|
 | `join` (default) | `remote.sh pull` of a team whose history lives on the server: bootstrap pages through the storage driver, then one explicit engine cycle and one explicit reprocess | `bootstrap.fetch`, `bootstrap.apply`; `once.*` (empty: fixed costs only); `reprocess.total` with 0 candidates | push, reconcile, reprocess of quarantined rows |
-| `push` | a local team seeded with N messages, `remote.sh connect`, the engine's catch-up cycles until a cycle prepares nothing: prepare → POST → reconcile, and the pull side bringing every pushed message straight back (the echo-back #908 observed) | `engine.prepare`, `engine.post+reconcile`, `engine.fetch+evaluate`, `engine.apply` per cycle; then `once.*`, `reprocess.total` (0 candidates) | reprocess of quarantined rows; POST separately from reconcile |
+| `push` | a local team seeded with N messages, `remote.sh connect`, the engine's catch-up cycles until a cycle prepares nothing: prepare → POST → reconcile, and the pull side bringing every pushed message straight back (the echo-back #908 observed) | `engine.prepare`, `engine.post`, `engine.reconcile`, `engine.fetch+evaluate`, `engine.apply` per cycle; then `once.*`, `reprocess.total` (0 candidates) | reprocess of quarantined rows |
 
 **Not covered: the encrypted path (#916).** #910's 4,100 `unsupported_cipher` rows and the reprocess that should have cleared them — quarantine → `unlock` → `reprocess` on `age-v1` envelopes — is not exercised by either scenario. Both run with `cipher: none`, so `reprocess.total` always reports 0 candidates and is marked not exercised. A run of this harness therefore reproduces the history-proportional apply and push costs of #910 (and the reconcile shape of #912), not the unreadable-after-four-hours end state. Adding an `age-v1` history needs the `age` binary and a sealing step (`scripts/internal/sync-cipher.mjs seal-batch`); that is #916.
 

--- a/tests/perf/report.py
+++ b/tests/perf/report.py
@@ -66,7 +66,7 @@ EXPECTED = {
     },
     "push": {
         "seed": ["harness.seed"],
-        "engine": ["capabilities", "push.prepared", "push.ack", "push.reconciled",
+        "engine": ["capabilities", "push.prepared", "push.posted", "push.ack", "push.reconciled",
                    "pull.received", "pull.applied"],
         "once": ["capabilities", "push.prepared", "pull.received", "pull.applied"],
         "reprocess": ["reprocess.complete"],
@@ -182,17 +182,19 @@ def measure_cycle(cycle, stages, missing, label):
             missing.append(f"{label}: push.ack (push.prepared count={pushed})")
         if not reconciled:
             missing.append(f"{label}: push.reconciled (push.prepared count={pushed})")
-        if acks and reconciled:
-            # ONE stage, not two. In cycle() the acks are written through the
-            # reconcile driver (recordAcks) BEFORE push.ack is emitted, and
-            # push.reconciled follows it within the same reportAcks call
-            # (remote-sync.mjs, the `posted`/`recordAcks`/`reportAcks` block).
-            # So push.prepared -> push.ack spans the POST *and* the reconcile,
-            # and push.ack -> push.reconciled is two consecutive writes to the
-            # log. Splitting them here would report the log's write latency as
-            # "reconcile" and call the sum "post". Splitting them for real needs
-            # an event at POST completion, which the engine does not emit.
-            stages["post+reconcile"].add(acks[0]["_t"] - prepared["_t"], len(acks[0].get("acks", [])))
+        posted = by.get("push.posted", [])
+        if acks and not posted:
+            # push.ack is emitted only after the reconcile driver has run, and
+            # push.reconciled follows it in the same call -- so without the
+            # POST-completion event the two stages cannot be told apart, and
+            # pretending otherwise would report the log's write latency as
+            # "reconcile". The engine emits push.posted at that boundary; a
+            # cycle that acked without it is unreported, not fast.
+            missing.append(f"{label}: push.posted (push.ack arrived without the POST-completion event)")
+        if acks and reconciled and posted:
+            count = len(acks[0].get("acks", []))
+            stages["post"].add(posted[0]["_t"] - prepared["_t"], count)
+            stages["reconcile"].add(acks[0]["_t"] - posted[0]["_t"], count)
             last = reconciled[0]
     received = by.get("pull.received", [])
     applied = by.get("pull.applied", [])
@@ -284,7 +286,7 @@ def summarize(args):
         for name in ("connect", "engine"):
             window.extend(phases.get(name, []))
         window.sort(key=lambda e: e["_t"])
-        for name in ("prepare", "post+reconcile", "fetch+evaluate", "apply"):
+        for name in ("prepare", "post", "reconcile", "fetch+evaluate", "apply"):
             stages["engine." + name] = Stage("engine." + name, "msg")
         engine_stages = {k[len("engine."):]: v for k, v in stages.items() if k.startswith("engine.")}
         cycles = cycles_of(window)
@@ -319,14 +321,14 @@ def summarize(args):
         if seed:
             summary["seed"] = {"messages": seed[0].get("count"), "seconds": seed[0].get("seconds")}
         engine_stages["prepare"].note = "driver prepare (+ roster prepare in parallel), per cycle"
-        engine_stages["post+reconcile"].note = ("POST /v1/messages AND the driver reconcile of its acks, "
-                                                "per cycle (one stage: push.ack is emitted after both)")
+        engine_stages["post"].note = "POST /v1/messages until the acks are back (push.prepared -> push.posted), per cycle"
+        engine_stages["reconcile"].note = "driver reconcile of the acks (push.posted -> push.ack), per cycle"
         engine_stages["fetch+evaluate"].note = "GET /v1/messages + evaluate (JS); echo-back of own pushes"
         engine_stages["apply"].note = "driver apply of the echo-back page"
 
     # --- one explicit cycle -----------------------------------------------
     if "once" in phases:
-        for name in ("prepare", "post+reconcile", "fetch+evaluate", "apply"):
+        for name in ("prepare", "post", "reconcile", "fetch+evaluate", "apply"):
             stages["once." + name] = Stage("once." + name, "msg")
         once_stages = {k[len("once."):]: v for k, v in stages.items() if k.startswith("once.")}
         cycles = cycles_of(phases["once"])
@@ -334,9 +336,10 @@ def summarize(args):
             missing.append(f"once: expected exactly 1 capabilities event, saw {len(cycles)}")
         for cycle in cycles[:1]:
             measure_cycle(cycle, once_stages, missing, "once")
-        if once_stages["post+reconcile"].calls == 0:
-            once_stages["post+reconcile"].exercised = False
-            once_stages["post+reconcile"].note = "nothing to push in this cycle: stage not exercised"
+        for name in ("post", "reconcile"):
+            if once_stages[name].calls == 0:
+                once_stages[name].exercised = False
+                once_stages[name].note = "nothing to push in this cycle: stage not exercised"
 
     # --- reprocess ----------------------------------------------------------
     if "reprocess" in phases:

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -3852,6 +3852,69 @@ function ackAllFrom(counter) {
   });
 }
 
+test("push.posted marks the end of the POST, before the acks are written", async () => {
+  // push.ack and push.reconciled are both emitted after recordAcks, so a
+  // reader of the log saw the POST and the reconcile as one span between
+  // push.prepared and push.ack (#913). push.posted is the boundary: it carries
+  // the ack count, and it arrives after the last POST answered and before the
+  // reconcile driver is asked to write anything.
+  const candidates = Array.from({ length: 3 }, (_unused, index) =>
+    bulkyCandidate(index, 100));
+  const ack = ackAllFrom({ value: 0 });
+  const sequence = [];
+  const harness = pushHarness(candidates, (messages) => {
+    sequence.push(`POST ${messages.length}`);
+    return ack(messages);
+  });
+  await cycle(config, { pushLimit: 100, pullLimit: 1000 }, {
+    ...harness,
+    eventCall: async (name, payload) => {
+      if (name.startsWith("push.")) sequence.push(`${name} ${payload?.count ?? payload?.acks?.length ?? ""}`.trim());
+    },
+    driverCall: async (operation, driverConfig, input) => {
+      if (operation === "reconcile") {
+        sequence.push(`reconcile ${input.length}`);
+        return [{ type: "sync_reconcile_result", count: input.length }];
+      }
+      return harness.driverCall(operation, driverConfig, input);
+    },
+  });
+  assert.deepEqual(sequence, [
+    "push.prepared 3",
+    "POST 3",
+    "push.posted 3",
+    "reconcile 3",
+    "push.ack 3",
+    "push.reconciled",
+  ]);
+});
+
+test("push.posted cannot cost the durable write: an unwritable log still reconciles", async () => {
+  // The event sits between the acks and recordAcks. Emitted bare, a log
+  // failure there would throw before the write and the acks would be lost to
+  // this cycle; the next one would resend what the server already holds. So
+  // it goes through note(): the write happens, and the failure is the log's.
+  const candidates = Array.from({ length: 2 }, (_unused, index) =>
+    bulkyCandidate(index, 100));
+  const ack = ackAllFrom({ value: 0 });
+  const reconciled = [];
+  const harness = pushHarness(candidates, (messages) => ack(messages));
+  await cycle(config, { pushLimit: 100, pullLimit: 1000 }, {
+    ...harness,
+    eventCall: async (name) => {
+      if (name === "push.posted") throw new Error("event log is unwritable");
+    },
+    driverCall: async (operation, driverConfig, input) => {
+      if (operation === "reconcile") {
+        reconciled.push(...input.map((record) => record.id));
+        return [{ type: "sync_reconcile_result", count: input.length }];
+      }
+      return harness.driverCall(operation, driverConfig, input);
+    },
+  });
+  assert.deepEqual(reconciled, candidates.map((candidate) => candidate.id));
+});
+
 test("push splits a page by BYTES, not by message count", async () => {
   // The count limit was 1000, so a thousand small messages and a thousand large
   // ones were the same batch and only the second kind was ever refused. Twelve

--- a/tests/test_perf_harness.bats
+++ b/tests/test_perf_harness.bats
@@ -122,6 +122,7 @@ EOF
 {"at":"2026-08-21T00:00:02.000Z","event":"harness.phase","phase":"engine"}
 {"at":"2026-08-21T00:00:02.100Z","event":"capabilities"}
 {"at":"2026-08-21T00:00:02.200Z","event":"push.prepared","count":2}
+{"at":"2026-08-21T00:00:02.250Z","event":"push.posted","count":2}
 {"at":"2026-08-21T00:00:02.300Z","event":"push.ack","acks":[{"id":"a","server_seq":"1","disposition":"stored"},{"id":"b","server_seq":"2","disposition":"stored"}]}
 {"at":"2026-08-21T00:00:02.301Z","event":"push.reconciled"}
 {"at":"2026-08-21T00:00:02.400Z","event":"pull.received","messages":[{"id":"a","server_seq":"1"},{"id":"b","server_seq":"2"}]}
@@ -141,10 +142,45 @@ EOF
     --messages 2 --roster 1 --page 1000 --out "$work/summary.json"
   [ "$status" -eq 2 ]
   printf '%s\n' "$output" | grep -q 'engine cycle 2: pull.received'
-  # And the stage the first cycle DID report is one stage, not a split whose
-  # second half is the log's own write latency.
-  [ "$(jq -r '.stages["engine.post+reconcile"].calls' "$work/summary.json")" -eq 1 ]
-  [ "$(jq -r '.stages | has("engine.reconcile")' "$work/summary.json")" = "false" ]
+  # And the first cycle's push is split at the POST boundary the engine reports:
+  # post = push.prepared -> push.posted, reconcile = push.posted -> push.ack.
+  [ "$(jq -r '.stages["engine.post"].calls' "$work/summary.json")" -eq 1 ]
+  [ "$(jq -r '.stages["engine.post"].seconds' "$work/summary.json")" = "0.05" ]
+  [ "$(jq -r '.stages["engine.reconcile"].seconds' "$work/summary.json")" = "0.05" ]
+}
+
+@test "report: an ack without the POST-completion event is unreported, not a zero-length POST" {
+  local work="$TEST_SKILL_DIR/work"
+  mkdir -p "$work"
+  cat > "$work/events.jsonl" <<'EOF'
+{"at":"2026-08-21T00:00:00.000Z","event":"harness.phase","phase":"seed"}
+{"at":"2026-08-21T00:00:00.100Z","event":"harness.seed","count":1,"seconds":0.01}
+{"at":"2026-08-21T00:00:01.000Z","event":"harness.phase","phase":"connect"}
+{"at":"2026-08-21T00:00:02.000Z","event":"harness.phase","phase":"engine"}
+{"at":"2026-08-21T00:00:02.100Z","event":"capabilities"}
+{"at":"2026-08-21T00:00:02.200Z","event":"push.prepared","count":1}
+{"at":"2026-08-21T00:00:02.300Z","event":"push.ack","acks":[{"id":"a","server_seq":"1","disposition":"stored"}]}
+{"at":"2026-08-21T00:00:02.301Z","event":"push.reconciled"}
+{"at":"2026-08-21T00:00:02.400Z","event":"pull.received","messages":[{"id":"a","server_seq":"1"}]}
+{"at":"2026-08-21T00:00:02.900Z","event":"pull.applied"}
+{"at":"2026-08-21T00:00:08.000Z","event":"capabilities"}
+{"at":"2026-08-21T00:00:08.100Z","event":"push.prepared","count":0}
+{"at":"2026-08-21T00:00:08.200Z","event":"pull.received","messages":[]}
+{"at":"2026-08-21T00:00:08.300Z","event":"pull.applied"}
+{"at":"2026-08-21T00:00:09.000Z","event":"harness.phase","phase":"once"}
+{"at":"2026-08-21T00:00:09.100Z","event":"capabilities"}
+{"at":"2026-08-21T00:00:09.200Z","event":"push.prepared","count":0}
+{"at":"2026-08-21T00:00:09.300Z","event":"pull.received","messages":[]}
+{"at":"2026-08-21T00:00:09.400Z","event":"pull.applied"}
+{"at":"2026-08-21T00:00:10.000Z","event":"harness.phase","phase":"reprocess"}
+{"at":"2026-08-21T00:00:10.500Z","event":"reprocess.complete","count":0}
+{"at":"2026-08-21T00:00:11.000Z","event":"harness.phase","phase":"done"}
+EOF
+  run python3 "$PERF/report.py" summarize --work "$work" --scenario push \
+    --messages 1 --roster 1 --page 1000 --out "$work/summary.json"
+  [ "$status" -eq 2 ]
+  printf '%s\n' "$output" | grep -q 'engine cycle 1: push.posted'
+  [ "$(jq -r '.stages["engine.post"].calls' "$work/summary.json")" -eq 0 ]
 }
 
 @test "harness: join of a small history measures every stage on the shipped path" {
@@ -164,7 +200,8 @@ EOF
   [ "$(jq -r '.state.roster_agents' "$summary")" -eq 2 ]
   # Not-exercised stages say so instead of reporting a time.
   [ "$(jq -r '.stages["reprocess.total"].exercised' "$summary")" = "false" ]
-  [ "$(jq -r '.stages["once.post+reconcile"].exercised' "$summary")" = "false" ]
+  [ "$(jq -r '.stages["once.post"].exercised' "$summary")" = "false" ]
+  [ "$(jq -r '.stages["once.reconcile"].exercised' "$summary")" = "false" ]
   # Nothing was written into this test's own skill dir by the run: the harness
   # copied scripts/ under $out and pointed every path there.
   [ ! -d "$TEST_SKILL_DIR/teams/pulled-team" ]


### PR DESCRIPTION
Closes the event gap in #913. #917 has landed (`2ac27f2f`); this branch is rebased onto `main` and is the one commit on top.

## The gap

`push.ack` and `push.reconciled` are both emitted after `recordAcks` has run the reconcile driver (`cycle()` in `scripts/internal/remote-sync.mjs`, the `posted` / `recordAcks` / `reportAcks` block). So a reader of the event log saw the POST and the reconcile as one span, `push.prepared -> push.ack`, and `push.ack -> push.reconciled` was two consecutive log writes. #913 asks for three timings to split a 359-second push — prepared, POST complete, reconcile complete — and the middle one did not exist. #917's harness therefore reports `post+reconcile` as a single stage and says why.

## The change: one event, with a reader

`push.posted` (`{ count }`) is emitted once `postCandidates` has returned and before `recordAcks` starts. It goes through `note()`, never bare: it is the one event that sits between the acks being in hand and the write that makes them durable, and a log that cannot be written must not cost that write — the failing path a few lines up reports through `note()` for the same reason. Two engine tests pin this: the order `push.prepared, POST, push.posted, reconcile driver, push.ack, push.reconciled` on a successful push, and that an `eventCall` that throws on `push.posted` still reconciles every ack.

The reader is in the same change, so the event is not a diagnostic nobody consumes: `tests/perf/report.py` now reports `post` (`push.prepared -> push.posted`) and `reconcile` (`push.posted -> push.ack`) as two stages, requires `push.posted` in the engine phase, and reports a cycle whose `push.ack` arrives without it as **missing** rather than as a zero-length POST. `tests/test_perf_harness.bats` pins the split (two 50 ms halves from a synthetic log) and the refusal. README updated.

## What the split shows on the first run

`tests/perf/join-harness.sh --scenario push --messages 30` on this machine, loopback mock server:

```
engine.post          0.006 s    32 msgs    0.19 ms/msg   POST /v1/messages until the acks are back
engine.reconcile     1.515 s    32 msgs   47.34 ms/msg   driver reconcile of the acks
```

The ~37-49 ms/msg that #917 could only call `post+reconcile` is, against a loopback server, almost entirely the reconcile driver — the POST itself is milliseconds. Against a real server the POST will carry the link, but the reconcile cost is there regardless of the link, and this is the first number that says so. Whether it scales the way #912 predicts is what `--scenario push --messages 17300` is for.

## Behaviour otherwise unchanged

One added event on the success path of a push; nothing else in the cycle moves. The existing engine test that drives an event sink which throws on `push.partial` / `push.ack` / `push.reconciled` still sees exactly those three in order (`push.posted` is not reached on that failing path). `node --test tests/remote_sync_engine.test.mjs`: 101/101 locally.
