### PR TITLE
fix(sync): report a busy store as busy, not as a failed check, and wait for it

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -48,10 +48,21 @@ _SQLITE_SYNC_COMMIT_BYTES=131072
 # up to max_blob_bytes, which is already larger than ARG_MAX once base64 and SQL
 # quoting are applied — so an argv statement could not hold even one such row,
 # and no group bound would have saved it.
+#
+# -bail on EVERY transaction this file feeds sqlite3 on stdin (here, reconcile,
+# read-prepare, read-apply; the page apply already had it). On stdin the CLI
+# runs on past a failed statement, so a BEGIN IMMEDIATE that loses the busy
+# timeout to another writer is followed by the body executing anyway — each
+# statement waiting its own timeout, and the ones that land after the other
+# writer lets go commit on their own, outside any transaction. A lock that frees
+# mid-script would apply the tail without the head. Statements handed over as an
+# argv string do not have this problem: there the CLI stops at the first error.
+# -bail makes the stdin form stop too, which is what lets the engine retry a busy
+# call: nothing of a transaction that never began has been written.
 _sqlite_sync_commit_chunk() {
   local db="$1" sql="$2"
   [ -n "$sql" ] || return 0
-  printf 'BEGIN IMMEDIATE;\n%s\nCOMMIT;\n' "$sql" | agmsg_sqlite "$db" >/dev/null 2>&1
+  printf 'BEGIN IMMEDIATE;\n%s\nCOMMIT;\n' "$sql" | agmsg_sqlite -bail "$db" >/dev/null 2>&1
 }
 
 # Builtin single-quote escaping, assigned into _SQLITE_SYNC_LIT in the CALLER's
@@ -834,7 +845,7 @@ storage_sync_reconcile_push() {
     WHERE b.local_team='$tl' AND b.server_instance_id='$server'
       AND b.remote_team_id='$remote' AND b.protocol_version=$protocol
       AND b.driver_generation='$generation';
-    COMMIT;" | agmsg_sqlite -batch "$db" >/dev/null 2>&1 || return 12
+    COMMIT;" | agmsg_sqlite -bail -batch "$db" >/dev/null 2>&1 || return 12
 
   _sqlite_data "$team" "SELECT json_object('type','sync_reconcile_result','push_cursor',
     CAST(push_cursor AS TEXT)) FROM sync_bindings WHERE local_team='$tl'
@@ -1353,7 +1364,7 @@ EOF
        AND rm.remote_team_id='$remote' AND rm.protocol_version=$protocol
        AND rm.driver_generation='$generation' AND rm.active=1
        AND rm.name_mismatch=0;
-    COMMIT;" | agmsg_sqlite -batch "$db" >/dev/null || { _sqlite_sync_why; return 13; }
+    COMMIT;" | agmsg_sqlite -bail -batch "$db" >/dev/null || { _sqlite_sync_why; return 13; }
 
   _sqlite_data "$team" "SELECT json_object('type','sync_read_frontier','member_id',f.member_id,
       'server_seq',f.server_seq) FROM sync_read_prepared f JOIN sync_read_members rm
@@ -1576,7 +1587,7 @@ storage_sync_apply_read_state() {
           AND rm.driver_generation=x.driver_generation AND rm.agent=x.agent
           AND CAST(x.server_seq AS INTEGER)<=CAST(rm.remote_server_seq AS INTEGER));
     COMMIT;" >> "$sql_file"
-  if ! agmsg_sqlite "$db" < "$sql_file" >/dev/null 2>&1; then
+  if ! agmsg_sqlite -bail "$db" < "$sql_file" >/dev/null 2>&1; then
     rm -f "$sql_file"; trap - EXIT INT TERM HUP; _sqlite_sync_why; return 13
   fi
   rm -f "$sql_file"; trap - EXIT INT TERM HUP; _AGMSG_READ_SYNC_SQL_FILE=""

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2008,35 +2008,25 @@ export const STORAGE_BUSY_EXIT = 11;
 // to outlast a real writer, not a polite one: the first prepare on a pulled
 // store held the lock for 63 s on the machine that filed #910 (155 s on a copy
 // of the same data), and that is the writer that killed the reprocess this
-// exists for. AGMSG_SYNC_BUSY_RETRY_MS overrides the budget, for tests and for
-// an operator who knows their store.
+// exists for. 5 minutes is that with margin for a slower disk.
+//
+// Constants, not an environment knob. The only reason to vary the budget was
+// that the right value is not settled -- #919 removes that first-prepare lock,
+// and the budget can come down then, here, in one place. A knob that accepts
+// an arbitrary string is a surface that has to be validated (not a number, not
+// finite, not safe) and each of those was a way back to "retry forever", the
+// one outcome a budget exists to rule out; the tests inject the sleep and do
+// not need a shorter budget. If an operator ever needs to tune this, that is
+// the moment to add the surface, with the reason.
 const STORAGE_BUSY_WAIT_CAP_MS = 30000;
 const STORAGE_BUSY_RETRY_BUDGET_MS = 300000;
-
-// The knob, read like one. Anything that is not a whole number of milliseconds
-// is refused here, on the first driver call, rather than read as NaN: NaN
-// compares false against everything, and `waited + wait > NaN` would have
-// turned the budget into "retry forever" -- the opposite of what a budget is
-// for, and exactly the unbounded wait this code exists to avoid.
-function storageBusyRetryBudgetMs() {
-  const raw = process.env.AGMSG_SYNC_BUSY_RETRY_MS;
-  if (raw === undefined || raw === "") return STORAGE_BUSY_RETRY_BUDGET_MS;
-  // The shape AND the magnitude: a string of digits long enough reads as
-  // Infinity, which compares exactly like NaN does here -- never exceeded.
-  const value = Number(raw);
-  if (!/^(0|[1-9][0-9]*)$/u.test(raw) || !Number.isSafeInteger(value)) {
-    throw new Error(
-      `AGMSG_SYNC_BUSY_RETRY_MS must be a whole number of milliseconds, not ${JSON.stringify(raw)}`);
-  }
-  return value;
-}
 
 export async function driver(operation, config, input, extra = [], dependencies = {}) {
   const script = process.env.AGMSG_SYNC_DRIVER;
   if (!script) throw new Error("AGMSG_SYNC_DRIVER is not set");
   const sleepCall = dependencies.sleepCall ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
   const eventCall = dependencies.eventCall ?? event;
-  const budgetMs = storageBusyRetryBudgetMs();
+  const budgetMs = STORAGE_BUSY_RETRY_BUDGET_MS;
   const run = () => runDriver({
     args: [script, operation, config.local_team, config.server_instance_id,
       config.remote_team_id, String(config.protocol_version), ...extra],
@@ -2064,9 +2054,9 @@ export async function driver(operation, config, input, extra = [], dependencies 
       if (waitedMs + waitMs > budgetMs) {
         // The driver's own sentence stays in front; what is added is how long
         // this waited, so the operator can tell "held for minutes" from
-        // "held forever" and knows which knob this was.
+        // "held forever".
         error.message += ` -- waited ${Math.round(waitedMs / 1000)} s for the store to come free ` +
-          `(AGMSG_SYNC_BUSY_RETRY_MS=${budgetMs}) and it did not`;
+          `(the ${budgetMs / 1000} s budget) and it did not`;
         error.code = "storage-busy";
         error.retryable = true;
         throw error;

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2013,12 +2013,27 @@ export const STORAGE_BUSY_EXIT = 11;
 const STORAGE_BUSY_WAIT_CAP_MS = 30000;
 const STORAGE_BUSY_RETRY_BUDGET_MS = 300000;
 
+// The knob, read like one. Anything that is not a whole number of milliseconds
+// is refused here, on the first driver call, rather than read as NaN: NaN
+// compares false against everything, and `waited + wait > NaN` would have
+// turned the budget into "retry forever" -- the opposite of what a budget is
+// for, and exactly the unbounded wait this code exists to avoid.
+function storageBusyRetryBudgetMs() {
+  const raw = process.env.AGMSG_SYNC_BUSY_RETRY_MS;
+  if (raw === undefined || raw === "") return STORAGE_BUSY_RETRY_BUDGET_MS;
+  if (!/^(0|[1-9][0-9]*)$/u.test(raw)) {
+    throw new Error(
+      `AGMSG_SYNC_BUSY_RETRY_MS must be a whole number of milliseconds, not ${JSON.stringify(raw)}`);
+  }
+  return Number(raw);
+}
+
 export async function driver(operation, config, input, extra = [], dependencies = {}) {
   const script = process.env.AGMSG_SYNC_DRIVER;
   if (!script) throw new Error("AGMSG_SYNC_DRIVER is not set");
   const sleepCall = dependencies.sleepCall ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
   const eventCall = dependencies.eventCall ?? event;
-  const budgetMs = Number(process.env.AGMSG_SYNC_BUSY_RETRY_MS ?? STORAGE_BUSY_RETRY_BUDGET_MS);
+  const budgetMs = storageBusyRetryBudgetMs();
   const run = () => runDriver({
     args: [script, operation, config.local_team, config.server_instance_id,
       config.remote_team_id, String(config.protocol_version), ...extra],

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2021,11 +2021,14 @@ const STORAGE_BUSY_RETRY_BUDGET_MS = 300000;
 function storageBusyRetryBudgetMs() {
   const raw = process.env.AGMSG_SYNC_BUSY_RETRY_MS;
   if (raw === undefined || raw === "") return STORAGE_BUSY_RETRY_BUDGET_MS;
-  if (!/^(0|[1-9][0-9]*)$/u.test(raw)) {
+  // The shape AND the magnitude: a string of digits long enough reads as
+  // Infinity, which compares exactly like NaN does here -- never exceeded.
+  const value = Number(raw);
+  if (!/^(0|[1-9][0-9]*)$/u.test(raw) || !Number.isSafeInteger(value)) {
     throw new Error(
       `AGMSG_SYNC_BUSY_RETRY_MS must be a whole number of milliseconds, not ${JSON.stringify(raw)}`);
   }
-  return Number(raw);
+  return value;
 }
 
 export async function driver(operation, config, input, extra = [], dependencies = {}) {

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1973,8 +1973,13 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
       const diagnostic = stderr.trim() ||
         "driver returned a non-zero exit without diagnostics; inspect that team's storage" +
           bindingNote(bindingPath);
-      fail(new Error(
-        `${label} ${operation} failed${subject} (${describeChildExit(code, signal)}): ${diagnostic}`));
+      const error = new Error(
+        `${label} ${operation} failed${subject} (${describeChildExit(code, signal)}): ${diagnostic}`);
+      // The raw status, for the one caller that acts on a specific value -- the
+      // storage adapter's "busy" exit, see `driver` -- without parsing its own
+      // sentence back out of the message.
+      error.driverExitCode = code;
+      fail(error);
     });
     child.on("close", () => {
       if (failure) { settle(failure, null); return; }
@@ -1992,10 +1997,29 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
   });
 }
 
-export async function driver(operation, config, input, extra = []) {
+// The storage adapter's exit status for "the store was busy" -- another writer
+// held it past the busy timeout (storage-sync-driver.sh says why it is 11). It
+// is the one driver failure that is about the moment rather than the input:
+// the same call succeeds once that writer is done. Every other non-zero exit
+// is a decision (a failed check, an unsupported operation) and asking again
+// does not change it, so nothing else is retried here.
+export const STORAGE_BUSY_EXIT = 11;
+// One wait is never longer than this; the budget is the total. The budget has
+// to outlast a real writer, not a polite one: the first prepare on a pulled
+// store held the lock for 63 s on the machine that filed #910 (155 s on a copy
+// of the same data), and that is the writer that killed the reprocess this
+// exists for. AGMSG_SYNC_BUSY_RETRY_MS overrides the budget, for tests and for
+// an operator who knows their store.
+const STORAGE_BUSY_WAIT_CAP_MS = 30000;
+const STORAGE_BUSY_RETRY_BUDGET_MS = 300000;
+
+export async function driver(operation, config, input, extra = [], dependencies = {}) {
   const script = process.env.AGMSG_SYNC_DRIVER;
   if (!script) throw new Error("AGMSG_SYNC_DRIVER is not set");
-  return runDriver({
+  const sleepCall = dependencies.sleepCall ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const eventCall = dependencies.eventCall ?? event;
+  const budgetMs = Number(process.env.AGMSG_SYNC_BUSY_RETRY_MS ?? STORAGE_BUSY_RETRY_BUDGET_MS);
+  const run = () => runDriver({
     args: [script, operation, config.local_team, config.server_instance_id,
       config.remote_team_id, String(config.protocol_version), ...extra],
     label: "storage sync",
@@ -2006,6 +2030,34 @@ export async function driver(operation, config, input, extra = []) {
       parseStrictJsonl(stdout) : parseJsonl(stdout)),
     input,
   });
+  // Retrying is safe ONLY because a busy call wrote nothing: every operation
+  // that writes does so in one BEGIN IMMEDIATE transaction fed with -bail (or
+  // as an argv statement, where the CLI stops at the first error), so a lock
+  // lost at BEGIN leaves the store as it was, and the prepare's chunked
+  // reservations are re-entrant by contract. The adapter exits 11 only when the
+  // last statement was the busy one -- the operation returned at that point.
+  let waitedMs = 0;
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await run();
+    } catch (error) {
+      if (error?.driverExitCode !== STORAGE_BUSY_EXIT) throw error;
+      const waitMs = Math.min(STORAGE_BUSY_WAIT_CAP_MS, 1000 * 2 ** (attempt - 1));
+      if (waitedMs + waitMs > budgetMs) {
+        // The driver's own sentence stays in front; what is added is how long
+        // this waited, so the operator can tell "held for minutes" from
+        // "held forever" and knows which knob this was.
+        error.message += ` -- waited ${Math.round(waitedMs / 1000)} s for the store to come free ` +
+          `(AGMSG_SYNC_BUSY_RETRY_MS=${budgetMs}) and it did not`;
+        error.code = "storage-busy";
+        error.retryable = true;
+        throw error;
+      }
+      await eventCall("driver.busy", { operation, attempt, wait_ms: waitMs, waited_ms: waitedMs });
+      await sleepCall(waitMs);
+      waitedMs += waitMs;
+    }
+  }
 }
 
 // The roster file to hand the driver, when this process can work it out.

--- a/scripts/internal/storage-sync-driver.sh
+++ b/scripts/internal/storage-sync-driver.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 # Private adapter between the Node polling engine and sourced storage drivers.
+#
+# Exit statuses this adapter itself can end with (the driver's own pass through):
+#    2  usage
+#   11  the store was BUSY: another writer held it past the busy timeout
+#       (sqlite3 "database is locked"). Not a failed check -- the same call with
+#       the same input succeeds once that writer is gone -- so the engine waits
+#       and retries it (remote-sync.mjs `driver`) instead of giving up. 11 because
+#       it is the hole in the storage driver's own 10-14 block (10 jq missing,
+#       12 reconcile transaction failed, 13 a check failed, 14 operation
+#       unsupported); 15-19 are the roster driver's, and 75 is the test-only
+#       abort-after-seal injection -- 75 was the first candidate and would have
+#       made that test's assertion mean two things.
+#   14  the loaded storage driver has no such operation
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -9,7 +22,22 @@ export SKILL_DIR
 . "$SKILL_DIR/scripts/lib/storage.sh"
 agmsg_storage_load
 
+# Every sqlite3 call the driver makes below records how it ended in this file
+# (storage.sh `_agmsg_sqlite_recording`), so a non-zero exit can be told apart
+# by its cause AFTER the fact. The driver functions return 13 for every failed
+# check and discard the statement's stderr where they call it, which is where
+# SQLITE_BUSY -- a condition of the moment, not of the input -- was being
+# reported as a permanent refusal. That is how #910 lost 4,100 messages for
+# five days: an unlock's reprocess was on page 133 of 173 when an engine's first
+# prepare took the store for 63 s, the next page's `storage_init` waited out the
+# 5 s busy timeout, and the 13 it returned read as "this page cannot be
+# processed" rather than "not now".
+AGMSG_SQLITE_OUTCOME_FILE="$(mktemp)" || exit 1
+export AGMSG_SQLITE_OUTCOME_FILE
+trap 'rm -f "$AGMSG_SQLITE_OUTCOME_FILE"' EXIT
+
 op="${1:-}"; shift || true
+rc=0
 case "$op" in
   capabilities) command -v storage_describe >/dev/null 2>&1 || exit 14
                 capabilities=$(storage_describe | sed -n 's/^capabilities=//p')
@@ -36,4 +64,14 @@ case "$op" in
   read-unblock) command -v storage_sync_unblock_read_state >/dev/null 2>&1 || exit 14
                 storage_sync_unblock_read_state "$@" ;;
   *) echo "usage: storage-sync-driver.sh capabilities|prepare|reconcile|apply|reprocess|resync-status|resync|read-prepare|read-apply|read-block|read-unblock ..." >&2; exit 2 ;;
-esac
+esac || rc=$?
+
+# The operation failed and its last statement was the one that ran out of busy
+# timeout: say so, on top of whatever the driver already said about the site,
+# and exit 11 so the caller can tell this from a check that failed.
+if [ "$rc" -ne 0 ] && [ "$(cat "$AGMSG_SQLITE_OUTCOME_FILE" 2>/dev/null)" = busy ]; then
+  printf 'agmsg: sqlite-sync: %s: the store is busy -- another writer held it past the %sms busy timeout (SQLITE_BUSY); this is not a failed check, the same call succeeds once that writer is done\n' \
+    "$op" "${AGMSG_BUSY_TIMEOUT:-5000}" >&2
+  exit 11
+fi
+exit "$rc"

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -233,8 +233,52 @@ agmsg_sqlite() {
   # shell. Note it is once per SHELL, not once per machine: a call made from
   # inside a command substitution still probes in that subshell.
   [ -n "$_AGMSG_ESCAPE_PROBED" ] || _agmsg_escape_flag >/dev/null
+  if [ -n "${AGMSG_SQLITE_OUTCOME_FILE:-}" ]; then
+    _agmsg_sqlite_recording "$@"
+    return
+  fi
   # shellcheck disable=SC2086  # intentional split: "-escape off" → two args, or none
   sqlite3 $_AGMSG_ESCAPE_FLAG -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@"
+}
+
+# The same call, recording how it ended. With AGMSG_SQLITE_OUTCOME_FILE set,
+# every call overwrites that file with one word: `ok`; `busy` when the busy
+# timeout above ran out (sqlite3 said "database is locked"); `failed` for
+# anything else.
+#
+# Only the sync driver adapter sets it (scripts/internal/storage-sync-driver.sh),
+# and this is what it is for: the driver's functions return 13 for every failed
+# check with the statement's stderr discarded at the call site, so their caller
+# could not tell "the input was refused" from "another writer held the store past
+# the timeout". The second is the one failure that is a fact about the moment
+# rather than about the input -- the same call succeeds once that writer is done
+# -- and the adapter reports it as its own exit status so the engine can wait
+# and retry instead of giving up (#910). The word is the LAST call's outcome on
+# purpose: a check-failing function returns right after the statement that
+# failed, so "the operation failed and the last statement was busy" names it.
+#
+# stderr is captured to classify it and re-emitted unchanged, so a caller that
+# reads or silences it sees what it saw before; stdout is the data stream and
+# is not touched; the exit status is passed through. Written as an `if` so a
+# caller running under `set -e` is not exited by the assignment itself.
+_agmsg_sqlite_recording() {
+  local err rc
+  # shellcheck disable=SC2086  # same intentional split as above
+  if { err=$(sqlite3 $_AGMSG_ESCAPE_FLAG -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@" 2>&1 >&3 3>&-); } 3>&1; then
+    rc=0
+  else
+    rc=$?
+  fi
+  [ -z "$err" ] || printf '%s\n' "$err" >&2
+  if [ "$rc" -eq 0 ]; then
+    printf 'ok\n' > "$AGMSG_SQLITE_OUTCOME_FILE"
+  else
+    case "$err" in
+      *"database is locked"*) printf 'busy\n' > "$AGMSG_SQLITE_OUTCOME_FILE" ;;
+      *) printf 'failed\n' > "$AGMSG_SQLITE_OUTCOME_FILE" ;;
+    esac
+  fi
+  return "$rc"
 }
 
 # Runtime ownership seam. This is the first run/-state-in-storage primitive for

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -4409,6 +4409,27 @@ test("driver() waits out a busy store and retries; anything else is asked once",
     /waited 3 s for the store to come free \(AGMSG_SYNC_BUSY_RETRY_MS=3500\) and it did not/u.test(error.message));
   assert.deepEqual(waits, [1000, 2000]);
   assert.equal(await readFile(counter, "utf8"), "3");
+
+  // A budget that is not a number is refused on the first call, before the
+  // driver is even started. Read as NaN it would compare false against every
+  // sum and retry forever -- the unbounded wait this whole thing exists to end.
+  for (const bad of ["oops", "-1", "1.5", "1e3", " 5"]) {
+    process.env.AGMSG_SYNC_BUSY_RETRY_MS = bad;
+    await writeFile(counter, "0");
+    waits.length = 0;
+    await assert.rejects(() => driver("prepare", config, [], [], dependencies), (error) =>
+      error.message === `AGMSG_SYNC_BUSY_RETRY_MS must be a whole number of milliseconds, not ${JSON.stringify(bad)}` &&
+      !isRetryable(error));
+    assert.equal(await readFile(counter, "utf8"), "0", `driver ran under ${JSON.stringify(bad)}`);
+    assert.deepEqual(waits, []);
+  }
+  // Zero is a budget too: the first busy is the last.
+  process.env.AGMSG_SYNC_BUSY_RETRY_MS = "0";
+  await writeFile(counter, "0");
+  await assert.rejects(() => driver("prepare", config, [], [], dependencies), (error) =>
+    error.code === "storage-busy" && /waited 0 s .*\(AGMSG_SYNC_BUSY_RETRY_MS=0\)/u.test(error.message));
+  assert.equal(await readFile(counter, "utf8"), "1");
+  assert.deepEqual(waits, []);
   delete process.env.AGMSG_SYNC_BUSY_RETRY_MS;
 
   // A failed check (13) is a decision: asked once, not retried, not retryable.

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -22,6 +22,7 @@ import {
   cycle,
   discardInputDirectory,
   driver,
+  STORAGE_BUSY_EXIT,
   exportAgeHandoff,
   exportAgeSnapshot,
   isRetryable,
@@ -4339,4 +4340,82 @@ test("pull bootstrap prints a server cursor only when it is a canonical sequence
   const good = await run("41");
   assert.match(good, /fetching messages after 41 /);
   assert.ok(!good.includes("an unreadable cursor"), "a real sequence is not replaced");
+});
+
+test("driver() waits out a busy store and retries; anything else is asked once", async (t) => {
+  // #910: the storage adapter exits STORAGE_BUSY_EXIT when another writer held
+  // the store past the busy timeout. That is a fact about the moment, so the
+  // call is repeated with a growing wait, within a budget; every other non-zero
+  // exit is a decision and is not asked again.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-busy-"));
+  const previousDriver = process.env.AGMSG_SYNC_DRIVER;
+  const previousBudget = process.env.AGMSG_SYNC_BUSY_RETRY_MS;
+  t.after(async () => {
+    if (previousDriver === undefined) delete process.env.AGMSG_SYNC_DRIVER;
+    else process.env.AGMSG_SYNC_DRIVER = previousDriver;
+    if (previousBudget === undefined) delete process.env.AGMSG_SYNC_BUSY_RETRY_MS;
+    else process.env.AGMSG_SYNC_BUSY_RETRY_MS = previousBudget;
+    if (!root.startsWith(tmpdir())) throw new Error("unsafe test root");
+    await rm(root, { recursive: true, force: true });
+  });
+  const config = {
+    local_team: "t", server_instance_id: "018f3f7e-0000-7000-8000-000000000001",
+    remote_team_id: "018f3f7e-0000-7000-8000-000000000002", protocol_version: 1,
+  };
+  const counter = join(root, "calls");
+  // A driver that is busy for its first `busyFor` calls and answers after that.
+  const useDriver = async (name, busyFor, exitWith = STORAGE_BUSY_EXIT) => {
+    const script = join(root, name);
+    await writeFile(script, [
+      "#!/usr/bin/env bash",
+      "cat > /dev/null",
+      `n=$(( $(cat ${shellQuote(counter)} 2>/dev/null || echo 0) + 1 ))`,
+      `printf %s "$n" > ${shellQuote(counter)}`,
+      `if [ "$n" -le ${busyFor} ]; then`,
+      "  echo 'agmsg: sqlite-sync: prepare: the store is busy -- another writer held it' >&2",
+      `  exit ${exitWith}`,
+      "fi",
+      "printf '%s\\n' '{\"type\":\"sync_state\",\"transport_cursor\":\"0\"}'",
+      "",
+    ].join("\n"), { mode: 0o755 });
+    await writeFile(counter, "0");
+    process.env.AGMSG_SYNC_DRIVER = script;
+  };
+  const waits = [];
+  const events = [];
+  const dependencies = {
+    sleepCall: async (ms) => { waits.push(ms); },
+    eventCall: async (name, fields) => { events.push({ name, ...fields }); },
+  };
+
+  // Busy twice, then answered: two waits, doubling, and the answer comes back.
+  await useDriver("busy-twice.sh", 2);
+  const result = await driver("prepare", config, [], [], dependencies);
+  assert.deepEqual(result, [{ type: "sync_state", transport_cursor: "0" }]);
+  assert.equal(await readFile(counter, "utf8"), "3");
+  assert.deepEqual(waits, [1000, 2000]);
+  assert.deepEqual(events.map((e) => [e.name, e.operation, e.attempt, e.wait_ms, e.waited_ms]),
+    [["driver.busy", "prepare", 1, 1000, 0], ["driver.busy", "prepare", 2, 2000, 1000]]);
+
+  // Busy past the budget: the driver's own sentence comes back, marked
+  // retryable and named, with how long this waited and under which knob.
+  await useDriver("busy-always.sh", 1000);
+  process.env.AGMSG_SYNC_BUSY_RETRY_MS = "3500"; // 1 s + 2 s fit; the 4 s wait does not
+  waits.length = 0;
+  await assert.rejects(() => driver("prepare", config, [], [], dependencies), (error) =>
+    error.code === "storage-busy" && isRetryable(error) &&
+    error.driverExitCode === STORAGE_BUSY_EXIT &&
+    /storage sync prepare failed for team 't' \(exit 11\): agmsg: sqlite-sync: prepare: the store is busy/u.test(error.message) &&
+    /waited 3 s for the store to come free \(AGMSG_SYNC_BUSY_RETRY_MS=3500\) and it did not/u.test(error.message));
+  assert.deepEqual(waits, [1000, 2000]);
+  assert.equal(await readFile(counter, "utf8"), "3");
+  delete process.env.AGMSG_SYNC_BUSY_RETRY_MS;
+
+  // A failed check (13) is a decision: asked once, not retried, not retryable.
+  await useDriver("refuses.sh", 1000, 13);
+  waits.length = 0;
+  await assert.rejects(() => driver("prepare", config, [], [], dependencies), (error) =>
+    error.driverExitCode === 13 && !isRetryable(error) && error.code === undefined);
+  assert.equal(await readFile(counter, "utf8"), "1");
+  assert.deepEqual(waits, []);
 });

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -4349,12 +4349,9 @@ test("driver() waits out a busy store and retries; anything else is asked once",
   // exit is a decision and is not asked again.
   const root = await mkdtemp(join(tmpdir(), "agmsg-busy-"));
   const previousDriver = process.env.AGMSG_SYNC_DRIVER;
-  const previousBudget = process.env.AGMSG_SYNC_BUSY_RETRY_MS;
   t.after(async () => {
     if (previousDriver === undefined) delete process.env.AGMSG_SYNC_DRIVER;
     else process.env.AGMSG_SYNC_DRIVER = previousDriver;
-    if (previousBudget === undefined) delete process.env.AGMSG_SYNC_BUSY_RETRY_MS;
-    else process.env.AGMSG_SYNC_BUSY_RETRY_MS = previousBudget;
     if (!root.startsWith(tmpdir())) throw new Error("unsafe test root");
     await rm(root, { recursive: true, force: true });
   });
@@ -4398,41 +4395,19 @@ test("driver() waits out a busy store and retries; anything else is asked once",
     [["driver.busy", "prepare", 1, 1000, 0], ["driver.busy", "prepare", 2, 2000, 1000]]);
 
   // Busy past the budget: the driver's own sentence comes back, marked
-  // retryable and named, with how long this waited and under which knob.
+  // retryable and named, with how long this waited. The budget is a constant
+  // (5 min) and the sleep is injected, so the whole ladder runs in no time:
+  // 1+2+4+8+16 s, then 30 s steps, and the 14th attempt would need 301 s.
   await useDriver("busy-always.sh", 1000);
-  process.env.AGMSG_SYNC_BUSY_RETRY_MS = "3500"; // 1 s + 2 s fit; the 4 s wait does not
   waits.length = 0;
   await assert.rejects(() => driver("prepare", config, [], [], dependencies), (error) =>
     error.code === "storage-busy" && isRetryable(error) &&
     error.driverExitCode === STORAGE_BUSY_EXIT &&
     /storage sync prepare failed for team 't' \(exit 11\): agmsg: sqlite-sync: prepare: the store is busy/u.test(error.message) &&
-    /waited 3 s for the store to come free \(AGMSG_SYNC_BUSY_RETRY_MS=3500\) and it did not/u.test(error.message));
-  assert.deepEqual(waits, [1000, 2000]);
-  assert.equal(await readFile(counter, "utf8"), "3");
-
-  // A budget that is not a number is refused on the first call, before the
-  // driver is even started. Read as NaN it would compare false against every
-  // sum and retry forever -- the unbounded wait this whole thing exists to end.
-  // The 400-digit one reads as Infinity, which no sum ever exceeds either; the
-  // 16-digit one is the first integer past Number.MAX_SAFE_INTEGER.
-  for (const bad of ["oops", "-1", "1.5", "1e3", " 5", "9".repeat(400), "9007199254740992"]) {
-    process.env.AGMSG_SYNC_BUSY_RETRY_MS = bad;
-    await writeFile(counter, "0");
-    waits.length = 0;
-    await assert.rejects(() => driver("prepare", config, [], [], dependencies), (error) =>
-      error.message === `AGMSG_SYNC_BUSY_RETRY_MS must be a whole number of milliseconds, not ${JSON.stringify(bad)}` &&
-      !isRetryable(error));
-    assert.equal(await readFile(counter, "utf8"), "0", `driver ran under ${JSON.stringify(bad)}`);
-    assert.deepEqual(waits, []);
-  }
-  // Zero is a budget too: the first busy is the last.
-  process.env.AGMSG_SYNC_BUSY_RETRY_MS = "0";
-  await writeFile(counter, "0");
-  await assert.rejects(() => driver("prepare", config, [], [], dependencies), (error) =>
-    error.code === "storage-busy" && /waited 0 s .*\(AGMSG_SYNC_BUSY_RETRY_MS=0\)/u.test(error.message));
-  assert.equal(await readFile(counter, "utf8"), "1");
-  assert.deepEqual(waits, []);
-  delete process.env.AGMSG_SYNC_BUSY_RETRY_MS;
+    /waited 271 s for the store to come free \(the 300 s budget\) and it did not/u.test(error.message));
+  assert.deepEqual(waits, [1000, 2000, 4000, 8000, 16000, ...Array(8).fill(30000)]);
+  assert.equal(await readFile(counter, "utf8"), "14");
+  assert.equal(waits.reduce((sum, ms) => sum + ms, 0), 271000);
 
   // A failed check (13) is a decision: asked once, not retried, not retryable.
   await useDriver("refuses.sh", 1000, 13);

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -4413,7 +4413,9 @@ test("driver() waits out a busy store and retries; anything else is asked once",
   // A budget that is not a number is refused on the first call, before the
   // driver is even started. Read as NaN it would compare false against every
   // sum and retry forever -- the unbounded wait this whole thing exists to end.
-  for (const bad of ["oops", "-1", "1.5", "1e3", " 5"]) {
+  // The 400-digit one reads as Infinity, which no sum ever exceeds either; the
+  // 16-digit one is the first integer past Number.MAX_SAFE_INTEGER.
+  for (const bad of ["oops", "-1", "1.5", "1e3", " 5", "9".repeat(400), "9007199254740992"]) {
     process.env.AGMSG_SYNC_BUSY_RETRY_MS = bad;
     await writeFile(counter, "0");
     waits.length = 0;

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -940,3 +940,35 @@ _longest_argv() {
   # cursor or a count moving by a few characters is not that.
   [ "$long" -lt "$((short + 200))" ]
 }
+
+@test "sync contract: a store another writer holds is busy (11), not a failed check (13)" {
+  # #910: an unlock's reprocess died on the page where an engine's first prepare
+  # held the store past the busy timeout, and the 13 it got read as "this page
+  # cannot be processed". The adapter tells the two apart -- and only the
+  # adapter: the driver function still returns 13 and still names the site, the
+  # adapter reads the last statement's outcome and exits 11 with its own line.
+  prepare_push >/dev/null
+  local db adapter holder
+  db=$(agmsg_db_path demo)
+  adapter="$SCRIPTS/internal/storage-sync-driver.sh"
+  # Another process holds the write lock for longer than the busy timeout.
+  ( printf 'BEGIN IMMEDIATE;\nSELECT 1;\n'; sleep 3; printf 'COMMIT;\n' ) | sqlite3 "$db" >/dev/null &
+  holder=$!
+  sleep 0.5
+  export AGMSG_BUSY_TIMEOUT=200
+  run --separate-stderr bash "$adapter" reprocess demo "$SERVER_ID" "$TEAM_ID" 1 10
+  unset AGMSG_BUSY_TIMEOUT
+  wait "$holder"
+  [ "$status" -eq 11 ]
+  [ -z "$output" ]
+  grep -q 'failed at sqlite-sync\.sh:[0-9]' <<<"$stderr"
+  grep -q 'reprocess: the store is busy' <<<"$stderr"
+  # The same call once the writer is gone: the input was never the problem.
+  run --separate-stderr bash "$adapter" reprocess demo "$SERVER_ID" "$TEAM_ID" 1 10
+  [ "$status" -eq 0 ]
+  grep -q '"type":"sync_reprocess_page"' <<<"$output"
+  # A refused input still exits 13: the two are told apart, not merged.
+  run --separate-stderr bash "$adapter" reprocess demo "$SERVER_ID" "$TEAM_ID" 1 0
+  [ "$status" -eq 13 ]
+  grep -q 'failed at sqlite-sync\.sh:[0-9]' <<<"$stderr"
+}


### PR DESCRIPTION
Part of #910. Follows #911 (which is what made this diagnosable in one line) and sits next to #909 (who started the engine) and #919 (why the first prepare holds the lock for minutes) -- both are separate defects and are not changed here.

## What happened

On the machine that filed #910, the unlock's reprocess had imported 13,200 of 17,300 quarantined messages -- exactly 132 pages of 100 -- when it died with `storage sync reprocess failed (exit 13)` and no further text (1.2.2), leaving 4,100 rows as `unsupported_cipher` with the stale reason `age-v1 is not configured` from the bootstrap pull. Nothing was wrong with the cipher: the rows carry the same `key_id` as their imported neighbours, the driver's `reprocess` op returns that page normally on a copy of the store (exit 0, 100 candidates), and three of the stuck envelopes decrypt with the key the machine holds.

What was wrong was the moment. At 07:50:46Z a session registered on the machine, at 07:50:47Z its sync-autostart started the engine, and the engine's first cycle ran the store's first-ever `prepare`, whose one-time legacy projection held the SQLite write lock for the whole 63 s that `capabilities -> push.prepared` took (every later cycle: under 1 s). On a copy of the same store that projection takes 155.6 s and holds the lock for 154.6 s while inserting nothing (#919). The reprocess's next driver call -- every operation starts with `_sqlite_sync_schema` -> `storage_init`, which issues writes -- waited out the 5 s busy timeout, got SQLITE_BUSY, and returned 13. Reproduced on the copy with a held lock: exit 13 after 5.2 s, and with #911's line it reads `_sqlite_sync_schema failed at sqlite-sync.sh:191`.

So the defect is not that the store was busy. It is that a condition of the moment was returned with the same number as a refused input, and the engine treated it as a decision: the run ended, and nothing came back to retry it.

## What this changes

(1) `scripts/lib/storage.sh`: `agmsg_sqlite` gains a recording mode, active only when `AGMSG_SQLITE_OUTCOME_FILE` is set. Each call overwrites that file with `ok`, `busy` (sqlite3 said `database is locked`, i.e. the busy timeout ran out) or `failed`. stderr is captured to classify and re-emitted unchanged; stdout and the exit status pass through. Nothing outside the adapter sets the variable, so every other caller of `agmsg_sqlite` runs the same line it ran before.

(2) `scripts/internal/storage-sync-driver.sh`: sets that file for the duration of one operation, and when the operation failed and the last statement was the busy one, prints its own sentence on stderr (after the driver's site line, which is unchanged) and exits 11. The driver functions themselves are untouched on this point: they still return 13 and still name the site. 11 is documented in the adapter header with the reason: it is the hole in the storage driver's own 10-14 block (10 jq missing, 12 reconcile transaction failed, 13 check failed, 14 operation unsupported); 15-19 belong to the roster driver; 75 was the first candidate and is the test-only abort-after-seal injection -- reusing it would have made that test's assertion mean two things, which is the shape this PR is removing.

(3) `scripts/internal/remote-sync.mjs`: `runDriver` puts the raw exit status on the error (`driverExitCode`); `driver()` retries exactly `STORAGE_BUSY_EXIT` (11) with a doubling wait capped at 30 s, within a 5-minute budget, logging `driver.busy` per attempt. Past the budget it throws the driver's own sentence with `-- waited N s for the store to come free (the 300 s budget) and it did not` appended, `code: "storage-busy"`, `retryable: true` (so the run loop backs off as for any retryable failure). Every other non-zero exit is thrown on the first attempt, as before. Why 5 minutes: the budget has to outlast the writer that actually killed the reprocess, and that writer is the first `prepare` on a pulled store -- 63 s on the real machine, 155 s on a copy of the same data (#919). 5 minutes is that with margin for a slower disk, and deliberately on the safe side. Why a constant and not an environment knob: the only reason to vary it was that the right value is not settled -- once #919 removes that projection's lock the longest ordinary writer is a 1000-message page apply and the budget can come down, in one place. A knob that accepts an arbitrary string is a surface that has to be validated (not a number, not finite, not a safe integer), each of those was a way back to "retry forever" (two review rounds found two), and the tests inject the sleep so they never needed a shorter budget. If an operator ever needs to tune this, that is the moment to add the surface, with the reason.

(4) `scripts/drivers/storage/sqlite-sync.sh`: `-bail` on the four transactions fed to sqlite3 on stdin that did not have it (reservation chunks, reconcile, read-prepare, read-apply; the page apply already had it). This is the only change to that file, and it is its own defect, not a decoration for (3) -- see the next section.

## The stdin form commits half a transaction on its own (#921)

Measured with sqlite3 3.51 while checking whether a retry would be safe: the same `BEGIN IMMEDIATE; ...; COMMIT;` behaves differently depending on how it is handed to the CLI. Passed as an argv string, the CLI stops at the first error, so a BEGIN that loses the busy timeout to another writer ends the script with nothing done. Fed on stdin (the form this file uses for anything that grows with the data, #882), the CLI runs on past the failed BEGIN: every following statement is executed on its own, each waiting its own busy timeout, and the ones that land after the other writer lets go commit in autocommit mode, outside any transaction. A lock that frees mid-script applies the tail without the head, and what the caller sees is one non-zero exit and the error lines of the statements that lost -- nothing says that the rest went in. This can happen with or without any retry; it needs only a concurrent writer, which is exactly the situation #910 was in. `-bail` makes the stdin form stop at the failed BEGIN like the argv form does. Whether these four are all of them is #921's question, derived there rather than asserted here; these four are the ones the retry in (3) depends on.

## Retry safety, per operation

A retry is only added to calls that wrote nothing when they were busy. Checked by reading each operation in `sqlite-sync.sh`:

| op | writes | shape when busy |
|---|---|---|
| capabilities | none | no store access |
| prepare | `storage_init` (idempotent: IF NOT EXISTS / INSERT OR IGNORE / ON CONFLICT), `_sqlite_sync_project_legacy` (argv; two statements, NOT EXISTS guards and a marker -- re-runnable), `_sqlite_sync_ensure_binding` (INSERT OR IGNORE), `_sqlite_sync_rewind_to_legacy` (one UPDATE), reservation chunks (`BEGIN IMMEDIATE ... COMMIT`, now `-bail`; re-entrant by contract, "prepare is re-entrant and byte-stable" in the suite) | each piece is idempotent or a whole transaction; a busy BEGIN leaves nothing |
| reconcile | one `BEGIN IMMEDIATE ... COMMIT` on stdin (now `-bail`) | all or nothing |
| apply | one `BEGIN IMMEDIATE ... COMMIT` on stdin with `-bail` (already) | all or nothing; a retry re-sends the same records to a store that has none of them |
| reprocess | SELECT only (plus the prelude above) | nothing to undo |
| resync-status | read only | -- |
| resync | one argv `BEGIN IMMEDIATE ... COMMIT` | argv stops at the first error |
| read-prepare | ensure_binding, then one `BEGIN IMMEDIATE ... COMMIT` on stdin (now `-bail`) | all or nothing |
| read-apply | one `BEGIN IMMEDIATE ... COMMIT` on stdin (now `-bail`) | all or nothing |
| read-block / read-unblock | one argv `BEGIN IMMEDIATE ... COMMIT` each | argv stops at the first error |

The prelude (`storage_init`) runs first in every operation and takes the first write lock, so a writer that is already there is met there, before anything else has been attempted; that is also where the reproduction failed. A writer arriving between the prelude and a later write is met by that later transaction's BEGIN, and with `-bail` that too writes nothing.

One edge, named rather than hidden: the outcome word is the last statement's. A busy that a function tolerates (`|| true`) followed immediately by a check that fails without touching sqlite would be reported as busy and retried once more than necessary; the retry then fails the same check and is thrown as 13. No operation has that sequence today.

## Not in this PR

Why the first prepare holds the lock for minutes (#919), who starts an engine while an unlock is running (#909), and the reprocess step's own cost (#922: 934 ms per message on the real run, 4.5x the pull; measured from the timeline, not yet explained). `remote.sh` is untouched: whether `unlock` should stop an engine before reprocessing is a question for after this lands, since with this in place the reprocess waits instead of dying.

## Verification

- `tests/test_remote_sync.bats` +1: another process holds the write lock past a 200 ms busy timeout; the adapter's `reprocess` exits 11, stdout empty, stderr carries both the site line and the busy line; the same call with the store free exits 0; a refused input (`limit 0`) still exits 13. 33/33 locally.
- `tests/remote_sync_engine.test.mjs` +1: a driver that is busy twice then answers is called three times with waits [1000, 2000] and two `driver.busy` events; busy for good walks the whole ladder (1+2+4+8+16 s, then 30 s steps) against the injected sleep and rejects on the 14th call with `storage-busy`, retryable, `driverExitCode 11`, and `waited 271 s ... (the 300 s budget)`; a driver that exits 13 is called once and is not retryable. 100/100 locally.
- `test_storage.bats` 24/24, `test_storage_contract.bats` 34/34, `test_sqlite_sync_jq_binary.bats` 8/8, `test_jsonl_remote_sync.bats` 25/25 locally (the suites that reach the `-bail`'d paths and `agmsg_sqlite`).
- On a `.backup` copy of the real store with the new adapter: held lock -> exit 11 with both lines; store free -> exit 0 with the page after 13,200.

The `BW02` warning bats prints for `run --separate-stderr` is pre-existing (the #911 test) and is a warning, not a failure.
