### PR TITLE
perf(sync): quote each pulled message's fields once, not at 42 fork sites (#908)

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -68,7 +68,13 @@ _sqlite_sync_commit_chunk() {
 # Builtin single-quote escaping, assigned into _SQLITE_SYNC_LIT in the CALLER's
 # shell. _sqlite_lit forks printf|sed per call, which the bulk loop calls three
 # times per message; a `$( )` wrapper here would fork just as surely.
-_sqlite_sync_lit_into() { _SQLITE_SYNC_LIT="${1//\'/\'\'}"; }
+#
+# The quote is held in a variable rather than written as \' in the pattern:
+# bash 3.2 (macOS /bin/bash) keeps the backslash of a \' REPLACEMENT, so
+# `${1//\'/\'\'}` turns it's into it\'\'s there and into it''s on bash 4+. A
+# variable is read the same way by every bash, and the contract test in
+# tests/test_remote_sync.bats holds this equal to _sqlite_lit byte for byte.
+_sqlite_sync_lit_into() { local q="'"; _SQLITE_SYNC_LIT="${1//$q/$q$q}"; }
 
 # Bulk form of _sqlite_sync_uuid4: one /dev/urandom read and builtin-only
 # formatting for `count` ids. A 1000-message catch-up page costs one fork here

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -862,6 +862,8 @@ storage_sync_apply_pull() {
   local generation db tl sql_file line type final_cursor="" corrupt=0 outcome_ids=""
   local seq wire received v cipher key_id blob status policy local_rev reason kind
   local from to body at local_id q line_next_after jq_ok
+  local cipher_q blob_q key_id_q received_q policy_q local_rev_q reason_q
+  local from_q to_q body_q at_q
   generation=$(_sqlite_sync_generation "$team"); db="$(_sqlite_db "$team")"; tl="$(_sqlite_lit "$team")"
   _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || { _sqlite_sync_why; return 13; }
   sql_file=$(mktemp "${TMPDIR:-/tmp}/agmsg-sync-sql.XXXXXX") || { _sqlite_sync_why; return 13; }
@@ -941,14 +943,33 @@ storage_sync_apply_pull() {
     outcome_ids="${outcome_ids}${outcome_ids:+,}'$wire'"
     case "$seq:$v" in *[!0-9:]*) rm -f "$sql_file"; _sqlite_sync_why; return 13 ;; esac
     case "$status" in importable|unsupported_cipher|pending_key|authentication_failed|malformed|policy_violation) ;; *) rm -f "$sql_file"; _sqlite_sync_why; return 13 ;; esac
-    q="'$(_sqlite_lit "$key_id")'"; [ -n "$key_id" ] || q=NULL
+    # Quoted ONCE PER MESSAGE, here, in the shell: each of these fields used
+    # to go through `$(_sqlite_lit ...)` -- a printf|sed fork -- at every use
+    # site in the SQL below, 32 forks per message and most of the 34 processes
+    # a pulled message cost (#908). _sqlite_sync_lit_into is the builtin form
+    # the bulk seal loop already uses; the escaping rule lives there, not here.
+    # Inside the per-message loop on purpose: every one of these changes with
+    # the message, and hoisting them to the page would carry the previous
+    # message's values into this one's rows.
+    _sqlite_sync_lit_into "$cipher"; cipher_q="$_SQLITE_SYNC_LIT"
+    _sqlite_sync_lit_into "$blob"; blob_q="$_SQLITE_SYNC_LIT"
+    _sqlite_sync_lit_into "$key_id"; key_id_q="$_SQLITE_SYNC_LIT"
+    _sqlite_sync_lit_into "$received"; received_q="$_SQLITE_SYNC_LIT"
+    _sqlite_sync_lit_into "$policy"; policy_q="$_SQLITE_SYNC_LIT"
+    _sqlite_sync_lit_into "$local_rev"; local_rev_q="$_SQLITE_SYNC_LIT"
+    _sqlite_sync_lit_into "$reason"; reason_q="$_SQLITE_SYNC_LIT"
+    _sqlite_sync_lit_into "$from"; from_q="$_SQLITE_SYNC_LIT"
+    _sqlite_sync_lit_into "$to"; to_q="$_SQLITE_SYNC_LIT"
+    _sqlite_sync_lit_into "$body"; body_q="$_SQLITE_SYNC_LIT"
+    _sqlite_sync_lit_into "$at"; at_q="$_SQLITE_SYNC_LIT"
+    q="'$key_id_q'"; [ -n "$key_id" ] || q=NULL
     printf "%s\n" "
       INSERT OR IGNORE INTO sync_conflicts
         (local_team,server_instance_id,remote_team_id,protocol_version,
          driver_generation,server_seq,wire_id,envelope_v,cipher,key_id,blob,
          reason,observed_at)
       SELECT '$tl','$server','$remote',$protocol,'$generation','$seq','$wire',$v,
-             '$(_sqlite_lit "$cipher")',$q,'$(_sqlite_lit "$blob")',
+             '$cipher_q',$q,'$blob_q',
              'server sequence maps to another wire id',
              strftime('%Y-%m-%dT%H:%M:%fZ','now')
       WHERE EXISTS(SELECT 1 FROM sync_quarantine qx
@@ -964,48 +985,48 @@ storage_sync_apply_pull() {
          driver_generation,server_seq,wire_id,envelope_v,cipher,key_id,blob,
          reason,observed_at)
       SELECT '$tl','$server','$remote',$protocol,'$generation','$seq','$wire',$v,
-             '$(_sqlite_lit "$cipher")',$q,'$(_sqlite_lit "$blob")',
+             '$cipher_q',$q,'$blob_q',
              'wire id maps to another sequence or envelope',
              strftime('%Y-%m-%dT%H:%M:%fZ','now')
       WHERE EXISTS(SELECT 1 FROM sync_quarantine qx
         WHERE qx.server_instance_id='$server' AND qx.remote_team_id='$remote'
           AND qx.protocol_version=$protocol AND qx.wire_id='$wire'
           AND (qx.server_seq<>'$seq' OR qx.envelope_v<>$v
-            OR qx.cipher<>'$(_sqlite_lit "$cipher")'
-            OR COALESCE(qx.key_id,'')<>'$(_sqlite_lit "$key_id")'
-            OR qx.blob<>'$(_sqlite_lit "$blob")'))
+            OR qx.cipher<>'$cipher_q'
+            OR COALESCE(qx.key_id,'')<>'$key_id_q'
+            OR qx.blob<>'$blob_q'))
          OR EXISTS(SELECT 1 FROM sync_messages mx
         WHERE mx.server_instance_id='$server' AND mx.remote_team_id='$remote'
           AND mx.protocol_version=$protocol AND mx.wire_id='$wire'
           AND (mx.server_seq IS NOT NULL AND mx.server_seq<>'$seq'
-            OR mx.envelope_v<>$v OR mx.cipher<>'$(_sqlite_lit "$cipher")'
-            OR COALESCE(mx.key_id,'')<>'$(_sqlite_lit "$key_id")'
-            OR mx.blob<>'$(_sqlite_lit "$blob")'));
+            OR mx.envelope_v<>$v OR mx.cipher<>'$cipher_q'
+            OR COALESCE(mx.key_id,'')<>'$key_id_q'
+            OR mx.blob<>'$blob_q'));
       INSERT OR IGNORE INTO sync_quarantine
         (local_team,server_instance_id,remote_team_id,protocol_version,
          driver_generation,server_seq,wire_id,server_received_at,envelope_v,
          cipher,key_id,blob,status,policy_revision,local_security_revision,reason)
       VALUES('$tl','$server','$remote',$protocol,'$generation','$seq','$wire',
-        '$(_sqlite_lit "$received")',$v,'$(_sqlite_lit "$cipher")',$q,
-        '$(_sqlite_lit "$blob")','$status','$(_sqlite_lit "$policy")',
-        '$(_sqlite_lit "$local_rev")','$(_sqlite_lit "$reason")');
+        '$received_q',$v,'$cipher_q',$q,
+        '$blob_q','$status','$policy_q',
+        '$local_rev_q','$reason_q');
       UPDATE sync_quarantine SET status='$status',
-          policy_revision='$(_sqlite_lit "$policy")',
-          local_security_revision='$(_sqlite_lit "$local_rev")',
-          reason='$(_sqlite_lit "$reason")'
+          policy_revision='$policy_q',
+          local_security_revision='$local_rev_q',
+          reason='$reason_q'
        WHERE server_instance_id='$server' AND remote_team_id='$remote'
          AND protocol_version=$protocol AND wire_id='$wire'
          AND server_seq='$seq' AND envelope_v=$v
-         AND cipher='$(_sqlite_lit "$cipher")'
-         AND COALESCE(key_id,'')='$(_sqlite_lit "$key_id")'
-         AND blob='$(_sqlite_lit "$blob")'
+         AND cipher='$cipher_q'
+         AND COALESCE(key_id,'')='$key_id_q'
+         AND blob='$blob_q'
          AND status NOT IN ('corrupt_state','imported','reconciled');
       UPDATE sync_quarantine SET status='corrupt_state',reason='wire envelope mismatch'
        WHERE server_instance_id='$server' AND remote_team_id='$remote'
          AND protocol_version=$protocol AND wire_id='$wire'
-         AND (server_seq<>'$seq' OR envelope_v<>$v OR cipher<>'$(_sqlite_lit "$cipher")'
-              OR COALESCE(key_id,'')<>'$(_sqlite_lit "$key_id")'
-              OR blob<>'$(_sqlite_lit "$blob")');
+         AND (server_seq<>'$seq' OR envelope_v<>$v OR cipher<>'$cipher_q'
+              OR COALESCE(key_id,'')<>'$key_id_q'
+              OR blob<>'$blob_q');
       UPDATE sync_quarantine SET status='corrupt_state',reason='binding sequence conflict'
        WHERE server_instance_id='$server' AND remote_team_id='$remote'
          AND protocol_version=$protocol AND wire_id='$wire'
@@ -1017,15 +1038,15 @@ storage_sync_apply_pull() {
          AND protocol_version=$protocol AND wire_id='$wire' AND EXISTS(
            SELECT 1 FROM sync_messages m WHERE m.server_instance_id='$server'
              AND m.remote_team_id='$remote' AND m.protocol_version=$protocol
-             AND m.wire_id='$wire' AND (m.envelope_v<>$v OR m.cipher<>'$(_sqlite_lit "$cipher")'
-               OR COALESCE(m.key_id,'')<>'$(_sqlite_lit "$key_id")'
-               OR m.blob<>'$(_sqlite_lit "$blob")'
+             AND m.wire_id='$wire' AND (m.envelope_v<>$v OR m.cipher<>'$cipher_q'
+               OR COALESCE(m.key_id,'')<>'$key_id_q'
+               OR m.blob<>'$blob_q'
                OR (m.server_seq IS NOT NULL AND m.server_seq<>'$seq')));
       UPDATE sync_messages SET server_seq='$seq' WHERE server_instance_id='$server'
         AND remote_team_id='$remote' AND protocol_version=$protocol AND wire_id='$wire'
-        AND envelope_v=$v AND cipher='$(_sqlite_lit "$cipher")'
-        AND COALESCE(key_id,'')='$(_sqlite_lit "$key_id")'
-        AND blob='$(_sqlite_lit "$blob")' AND (server_seq IS NULL OR server_seq='$seq')
+        AND envelope_v=$v AND cipher='$cipher_q'
+        AND COALESCE(key_id,'')='$key_id_q'
+        AND blob='$blob_q' AND (server_seq IS NULL OR server_seq='$seq')
         AND EXISTS(SELECT 1 FROM sync_quarantine qx
           WHERE qx.server_instance_id='$server' AND qx.remote_team_id='$remote'
             AND qx.protocol_version=$protocol AND qx.wire_id='$wire'
@@ -1061,8 +1082,8 @@ storage_sync_apply_pull() {
       local_id=$(compat_uuid7) || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
       printf "%s\n" "
         INSERT INTO events(type,id,team,from_agent,to_agent,body,at)
-        SELECT 'message_sent','$local_id','$tl','$(_sqlite_lit "$from")',
-               '$(_sqlite_lit "$to")','$(_sqlite_lit "$body")','$(_sqlite_lit "$at")'
+        SELECT 'message_sent','$local_id','$tl','$from_q',
+               '$to_q','$body_q','$at_q'
         WHERE NOT EXISTS(SELECT 1 FROM sync_messages m
           WHERE m.server_instance_id='$server' AND m.remote_team_id='$remote'
             AND m.protocol_version=$protocol AND m.wire_id='$wire')
@@ -1083,8 +1104,8 @@ storage_sync_apply_pull() {
         -- skipped there is no row with this id, so neither statement fires and
         -- last_insert_rowid() is never read.
         INSERT INTO messages(team,from_agent,to_agent,body,created_at)
-        SELECT '$tl','$(_sqlite_lit "$from")','$(_sqlite_lit "$to")',
-               '$(_sqlite_lit "$body")','$(_sqlite_lit "$at")'
+        SELECT '$tl','$from_q','$to_q',
+               '$body_q','$at_q'
          WHERE EXISTS(SELECT 1 FROM events e
                        WHERE e.id='$local_id' AND e.legacy_id IS NULL);
         UPDATE events SET legacy_id=last_insert_rowid()
@@ -1094,7 +1115,7 @@ storage_sync_apply_pull() {
            driver_generation,local_position,local_id,wire_id,envelope_v,cipher,
            key_id,blob,server_seq,direction)
         SELECT '$tl','$server','$remote',$protocol,'$generation',seq,id,'$wire',$v,
-               '$(_sqlite_lit "$cipher")',$q,'$(_sqlite_lit "$blob")','$seq','pull'
+               '$cipher_q',$q,'$blob_q','$seq','pull'
           FROM events WHERE id='$local_id';
         UPDATE sync_quarantine SET status='imported' WHERE server_instance_id='$server'
           AND remote_team_id='$remote' AND protocol_version=$protocol AND wire_id='$wire'

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -22,6 +22,32 @@ prepare_push() {
   printf '%s\n' "$PREPARE" | storage_sync_prepare_push demo "$SERVER_ID" "$TEAM_ID" 1 "${1:-100}"
 }
 
+@test "sync contract: the builtin quote and the forking quote agree on adversarial input (#908)" {
+  # storage_sync_apply_pull quotes its eleven per-message fields through
+  # _sqlite_sync_lit_into (a bash expansion) where it used to fork
+  # _sqlite_lit (printf|sed) at every use site. A speed change that alters
+  # one quoted byte corrupts rows, so the two are held equal here on the
+  # inputs that matter to SQL quoting: a quote alone, doubled, leading,
+  # trailing; a newline; a backslash, and one next to a quote; empty;
+  # sed's and printf's own metacharacters.
+  local input expected actual
+  while IFS= read -r -d '' input; do
+    expected="$(_sqlite_lit "$input")"
+    _sqlite_sync_lit_into "$input"
+    actual="$_SQLITE_SYNC_LIT"
+    [ "$actual" = "$expected" ] || {
+      printf 'quote mismatch for %q: builtin %q, helper %q\n' "$input" "$actual" "$expected" >&2
+      return 1
+    }
+  done < <(printf '%s\0' \
+    "plain" "it's" "two''quotes" "'leading" "trailing'" "'" "''" "" \
+    $'line one\nline two' $'tab\there' 'back\slash' "back\\'slash quote" \
+    '100% $HOME' 'and & ampersand' 'a/b' 'dots...')
+  # And the shape SQL needs: every single quote doubled, nothing else touched.
+  _sqlite_sync_lit_into "a'b''c"
+  [ "$_SQLITE_SYNC_LIT" = "a''b''''c" ]
+}
+
 @test "sync contract: prepare is re-entrant and byte-stable before reconcile" {
   storage_send demo alice bob "preserve these exact bytes" >/dev/null
   local first second


### PR DESCRIPTION
Part of #908 (the 32 of the 34 processes per pulled message). Also fixes #928, because it has to — see the section on bash 3.2. Two things, in two commits: (1) `apply` quotes through the builtin helper instead of forking (speed, the claim of this PR); (2) that helper was wrong on bash 3.2 and is now portable (a pre-existing bug, #928, which this PR could not land on macOS without).

## What changes

`storage_sync_apply_pull` in `scripts/drivers/storage/sqlite-sync.sh` quoted its per-message fields with `$(_sqlite_lit "$x")` — a `printf | sed` fork — at every use site inside the SQL it builds. Counted one way: 43 occurrences of `_sqlite_lit` on 33 lines of the function (several lines hold two or three), of which 42 are per message over 11 fields (`cipher` and `blob` eleven times each, `key_id` eight, the rest one to three) and one is the team name, quoted once per call. Per plain importable message that is 32 forks (the conflict/quarantine statements add more for a quarantined one), on top of the one `jq` and the one `grep`. #908 measured that helper at 127 s for 32 x 1,000 calls against 0.131 s for the equivalent bash expansion.

Now each field is quoted **once per message**, at the top of the per-message body of the `while read` loop (right after the `jq` extraction and the cursor-line `continue`, where the old code already built `$q` for `key_id`), through `_sqlite_sync_lit_into` — the builtin-expansion form of the same escaping that the bulk seal loop in `storage_sync_prepare_push` already uses — into `cipher_q`, `blob_q`, `key_id_q`, `received_q`, `policy_q`, `local_rev_q`, `reason_q`, `from_q`, `to_q`, `body_q`, `at_q`. The 42 per-message use sites become `'$x_q'`. No SQL statement changes shape; the bytes that reach SQLite are the same bytes. It is deliberately inside the per-message loop and not hoisted to the page: every one of those fields changes with the message, and a page-level hoist would carry the previous message's values into the next row's SQL.

`_sqlite_lit` itself is untouched, as are its other 23 call sites (`storage_sync_resync` 5, `storage_sync_prepare_push` 3, `storage_sync_prepare_read_state` 3, `storage_sync_resync_status` 2, three other functions 3 — per page or per call, not per message). The same shape remains there; this PR takes the 42 that sit in the per-message loop of the path a pull pays for every message.

## What the tests say, and what they do not

**No regression:** `tests/test_remote_sync.bats` (the sync contract suite, 34 cases) is green against this change locally. A new case in it runs `_sqlite_lit` and `_sqlite_sync_lit_into` over the inputs that matter to SQL quoting — a quote alone, doubled, leading, trailing; an empty string; a newline; a tab; a backslash and a backslash beside a quote; `%` and `$`; `&`; `/` — and fails on the first byte of difference, then checks the shape SQL needs (`a'b''c` → `a''b''''c`). A speed change that altered one quoted byte would corrupt rows; this is the check that it does not.

Neither of those says the change is faster, and they cannot: the two quoting forms produce the same bytes, so no behavioural test distinguishes before from after (the equivalence case is green on both). The claim of this PR is the measurement below, and only that.

## Second commit: the helper was wrong on bash 3.2 (#928, pre-existing)

The first head (`ee83348`) failed the macOS shard on the new equivalence case and on "a projection body reaches the store verbatim": `_sqlite_sync_lit_into` was `${1//\'/\'\'}`, and **bash 3.2 keeps the backslash of a `\'` replacement** — `it's` became `it\'\'s` there (bash 4+ gives `it''s`). macOS `/bin/bash` is 3.2 and that is what `macos-latest` runs `bats` with; locally Homebrew's bash 5 hid it. The helper was already in `main`, used by the bulk seal loop in `storage_sync_prepare_push`, whose only callers need `age` — skipped on macOS CI — so nothing had ever run it under 3.2 until this change made `apply` use it. The second commit holds the quote in a variable (`local q="'"; ${1//$q/$q$q}`), which every bash expands the same way; checked on 3.2.57 and 5.3 directly and by running `tests/test_remote_sync.bats` under `/bin/bash` 3.2 (34/34) as well as under bash 5. That closes the latent bug in the bulk seal path too. The equivalence case is the check that found it, which is what it was added for.

## Before and after, same machine, same method

Measured with the harness from #917 (`tests/perf/join-harness.sh --sizes 50,400`, `bootstrap.apply` = `applying N messages` → `pull.bootstrap.applied`, the shipped `remote.sh pull` path, no driver wrapped), the harness files placed untracked in this worktree for the measurement and not part of this PR:

| | `bootstrap.apply` @50 | @400 | shape | join wall @400 | 17,300 at the @400 rate |
|---|---|---|---|---|---|
| before (`3376bfe`) | 280.5 ms/msg | 286.7 ms/msg | linear (x8 -> x8) | 2.0 min | 1.38 h |
| after | 29.6 ms/msg | 26.0 ms/msg | linear (x8 -> x7) | 16 s | 7.5 min |

Both runs `verdict: OK`, 53 and 403 rows imported, end state identical in shape (`messages_in_store` 50 / 400, every quarantine row `imported`). The 32 forks were about 90% of the per-message apply cost on this machine; what remains per message is the `jq`, the `grep`, and the SQL itself.

### The same function is the reprocess's import step

`storage_sync_reprocess` only returns candidates; each page of a reprocess ends in `storage_sync_apply_pull` too. So the `unlock` scenario from #923 (pull an `age-v1` team with no key — every row quarantined — then `unlock`, whose reprocess re-evaluates and imports every row) was run before and after as well, same machine, same method:

| | `bootstrap.apply` (quarantining) @50 / @400 | `unlock.reprocess` @50 / @400 | 17,300 candidates at the @400 rate |
|---|---|---|---|
| before | 171.2 / 156.1 ms/msg | 224.4 / 196.5 ms/candidate | 57 min |
| after | 25.7 / 15.6 ms/msg | 52.9 / 44.2 ms/candidate | 12.8 min |

Both after-runs `verdict: OK`, 50/50 and 400/400 quarantined rows imported. What is left per candidate in the reprocess (~44 ms) is the reprocess driver's own page SELECT, the `age-v1` open in JS, the per-message `jq`/`grep` of the apply, and the SQL.

## Out of scope, on purpose

- The `grep -Eq` uuid check (1 process per message) and the per-message `jq` (1 per message) from #908 (2) and (3): separate PRs, after this number is in.
- The 23 remaining `_sqlite_lit` call sites outside the per-message loop.
