### PR TITLE
perf(storage): index events.legacy_id (155 s first-prepare lock to 0.5 s)

### DIFF
--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -128,6 +128,17 @@ storage_init() {
     );
     CREATE INDEX IF NOT EXISTS events_sent ON events(type, team, to_agent, seq);
     CREATE INDEX IF NOT EXISTS events_read ON events(type, team, agent, msg_id);
+    -- legacy_id is looked up by value from the other side: every reader that
+    -- unions the two tables asks NOT EXISTS(events.legacy_id = messages.id)
+    -- per legacy row, and the one-time push projection asks the same question
+    -- for every message in the team. Without this index each of those is a
+    -- full scan of events, so the cost is messages x events: on a 17,369-message
+    -- store with 28,568 events the projection ran 155 s inside one write
+    -- transaction (#919) -- holding the store's write lock for the whole of it,
+    -- which is what killed the unlock reprocess in #910 -- to insert nothing.
+    -- The ALTER above runs first on purpose, so an older store has the column
+    -- before this asks for the index on it.
+    CREATE INDEX IF NOT EXISTS events_legacy ON events(legacy_id);
     CREATE TABLE IF NOT EXISTS read_cursors (
       team TEXT NOT NULL,
       agent TEXT NOT NULL,

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -358,3 +358,25 @@ _use_per_team() {
     scripts bin server 2>/dev/null | grep -v ':[0-9]*: *#' | grep -v 'storage_init()' || true)"
   [ -z "$offenders" ] || { echo "$offenders"; false; }
 }
+
+@test "storage: events.legacy_id is indexed, on a new store and on one that predates the column (#919)" {
+  source "$SCRIPTS/lib/storage.sh"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=sqlite
+  agmsg_storage_load
+  storage_init demo >/dev/null
+  local db
+  db=$(agmsg_db_path demo)
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name='events' AND name='events_legacy';" | tr -d '\r')" -eq 1 ]
+  # The lookup every reader makes per legacy row, and the projection makes per
+  # message, is a search now -- not a scan of events.
+  sqlite3 "$db" "EXPLAIN QUERY PLAN SELECT 1 FROM events e2 WHERE e2.legacy_id = 5;" | grep -q 'USING COVERING INDEX events_legacy\|USING INDEX events_legacy'
+  # A store created before legacy_id existed: init adds the column first (the
+  # ALTER that already ran for #689), then the index on it.
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/old"
+  mkdir -p "$AGMSG_STORAGE_PATH"
+  sqlite3 "$AGMSG_STORAGE_PATH/messages.db" "CREATE TABLE events (seq INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, id TEXT NOT NULL, team TEXT, from_agent TEXT, to_agent TEXT, body TEXT, msg_id TEXT, agent TEXT, at TEXT NOT NULL);"
+  storage_init demo >/dev/null
+  [ "$(sqlite3 "$AGMSG_STORAGE_PATH/messages.db" "PRAGMA table_info(events);" | grep -c legacy_id)" -eq 1 ]
+  [ "$(sqlite3 "$AGMSG_STORAGE_PATH/messages.db" "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='events_legacy';" | tr -d '\r')" -eq 1 ]
+}


### PR DESCRIPTION
Closes #919. On `main` (includes #920).

## What was slow

The two tables that hold a message are joined on `events.legacy_id = messages.id`. `legacy_id` had no index, so every lookup by its value was a full scan of `events`:

- the inbox and history readers (`storage_read_*` in `sqlite.sh`) ask `NOT EXISTS (SELECT 1 FROM events e2 WHERE e2.legacy_id = messages.id ...)` once per legacy row they list;
- the one-time push projection `_sqlite_sync_project_legacy` asks the same question for every message in the team, inside a single `INSERT ... SELECT`, inside one write transaction.

Cost is messages x events. Measured on a `.backup` copy of the store from #910 (17,369 messages, 28,568 events), first `prepare` on that store, lock probed every 0.5 s:

```
before (no index)   prepare 147 s, write lock held 145 s, 0 rows inserted
                    (the inbox NOT EXISTS predicate alone: 120 s)
after (this PR)     prepare 0.5 s, lock held below the probe's resolution
                    (the index build is included in that 0.5 s)
```

That 145 s write lock is the writer that killed the unlock reprocess in #910: its first cycle's `prepare` held the store while the reprocess's next page waited out the busy timeout.

## The change

One line in `storage_init` (`sqlite.sh`), next to the two indexes already there:

```sql
CREATE INDEX IF NOT EXISTS events_legacy ON events(legacy_id);
```

It sits after the `ALTER TABLE events ADD COLUMN legacy_id` that #689 already runs first, so a store predating the column gets the column and then the index. `EXPLAIN QUERY PLAN` for the projection's second `NOT EXISTS` goes from `SCAN e2` to `SEARCH e2 USING COVERING INDEX events_legacy`.

This is the same shape as #908's fix: the fast form already existed (an index), it just was not applied to this column.

## Verification

- `tests/test_storage.bats` +1: `events_legacy` exists after `storage_init` on a fresh store; `EXPLAIN QUERY PLAN` uses it; and a store created before `legacy_id` existed gets both the column and the index on init. 25/25 local.
- `tests/test_storage_contract.bats` 34/34 local.
- Before/after numbers above are from the real store copy; the read side (120 s -> 0.04 s for the inbox predicate) and the write side (147 s -> 0.5 s) both move.

Not in this PR: the reconcile gap subquery (#912) and apply fork cost (#908/#925) are different functions.
