### PR TITLE
perf(sync): one jq per acknowledgement, not six forks

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -774,15 +774,36 @@ storage_sync_reconcile_push() {
   local team="$1" server="$2" remote="$3" protocol="$4"
   _sqlite_sync_valid_binding "$server" "$remote" "$protocol" || { _sqlite_sync_why; return 13; }
   _sqlite_sync_schema "$team" || return $?
-  local generation db tl line values="" pos wire seq disposition count=0
+  local generation db tl line values="" type pos wire seq disposition jq_ok count=0
   generation=$(_sqlite_sync_generation "$team"); db="$(_sqlite_db "$team")"; tl="$(_sqlite_lit "$team")"
   while IFS= read -r line; do
     [ -n "$line" ] || continue
-    [ "$(printf '%s\n' "$line" | jq -r '.type // empty')" = sync_push_ack ] || { _sqlite_sync_why; return 13; }
-    pos=$(printf '%s\n' "$line" | jq -r '.local_position // empty')
-    wire=$(printf '%s\n' "$line" | jq -r '.id // empty')
-    seq=$(printf '%s\n' "$line" | jq -r '.server_seq // empty')
-    disposition=$(printf '%s\n' "$line" | jq -r '.disposition // empty')
+    # One `jq` per line, not one per field -- the same read `storage_sync_apply_pull`
+    # already does (#780), for the same reason. Five field reads plus a `grep` cost
+    # six forks per acknowledgement, and a fork is 6.3 ms on the machine this was
+    # measured on, which is nearly all of the 37.8 ms an acknowledgement took.
+    #
+    # `-s` with a length check, because one LINE is not one JSON value to jq: two
+    # values on a line would otherwise each emit a full set of assignments and the
+    # second would overwrite the first, `jq_ok` included, so a page could hide
+    # anything in the tail of a line (#780).
+    #
+    # `@sh` is jq's shell-quoting filter, so every value arrives verbatim through
+    # `eval` with nothing for this side to get wrong. `jq_ok` is emitted LAST: a
+    # line jq cannot parse produces no assignments at all, so the sentinel stays 0
+    # and this fails closed rather than proceeding on stale values from the
+    # previous iteration.
+    jq_ok=0
+    eval "$(printf '%s\n' "$line" | jq -r -s '
+      if length != 1 then error("one JSON value per line") else .[0] end
+      | "type=\(.type // "" | @sh)",
+      "pos=\(.local_position // "" | @sh)",
+      "wire=\(.id // "" | @sh)",
+      "seq=\(.server_seq // "" | @sh)",
+      "disposition=\(.disposition // "" | @sh)",
+      "jq_ok=1"' 2>/dev/null)"
+    [ "$jq_ok" = 1 ] || { _sqlite_sync_why; return 13; }
+    [ "$type" = sync_push_ack ] || { _sqlite_sync_why; return 13; }
     # $pos and $seq are interpolated into SQL below, so these stay whitelists.
     # A local position may be negative (projected legacy history sits under the
     # live space); a server sequence is assigned by the server and never is.
@@ -797,7 +818,13 @@ storage_sync_reconcile_push() {
       '' | *[!0-9]*) _sqlite_sync_why; return 13 ;;
     esac
     case "$disposition" in stored|duplicate) ;; *) _sqlite_sync_why; return 13 ;; esac
-    printf '%s' "$wire" | grep -Eq '^[0-9a-f-]{36}$' || { _sqlite_sync_why; return 13; }
+    # The sixth fork, removed. `case` is a builtin and these two patterns are
+    # exactly `^[0-9a-f-]{36}$`: a length of 36, and not one character outside
+    # the class. Kept as a whitelist because `$wire` is interpolated into SQL.
+    # (`storage_sync_apply_pull` still greps, but its pattern is the strict
+    # UUIDv4 shape, which does not reduce to a glob this cleanly.)
+    case "${#wire}" in 36) ;; *) _sqlite_sync_why; return 13 ;; esac
+    case "$wire" in *[!0-9a-f-]*) _sqlite_sync_why; return 13 ;; esac
     values="${values}${values:+,}($pos,'$wire','$seq')"; count=$((count + 1))
   done
   [ "$count" -gt 0 ] || { _sqlite_sync_why; return 13; }

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -788,16 +788,18 @@ storage_sync_reconcile_push() {
     # second would overwrite the first, `jq_ok` included, so a page could hide
     # anything in the tail of a line (#780).
     #
-    # `tostring` before `@sh` on every field, which is not decoration. `@sh` turns
-    # an ARRAY into a list of shell words, so `"local_position": ["1","reboot"]`
-    # expands to `pos='1' 'reboot'` -- a command-prefix assignment that runs
-    # `reboot`, leaves `pos` holding the PREVIOUS line's value, and still reaches
-    # `jq_ok=1` on the next line, so the line is accepted. Demonstrated, not
-    # reasoned about. `tostring` makes the same input `pos='["1","reboot"]'`,
-    # which the whitelist below refuses, and it leaves strings and numbers
-    # exactly as they were. `storage_sync_apply_pull` already does this on the
-    # fields it does not otherwise constrain; this read simply has to do it on
-    # all of them.
+    # `tostring` before `@sh` on every field, which is not decoration. `@sh`
+    # emits one quoted word per element of an ARRAY, and a line carrying several
+    # words is not an assignment to the shell -- it is an assignment PREFIXED TO
+    # A COMMAND. Three things follow at once: the field is not assigned, so the
+    # variable keeps the PREVIOUS line's value, and `$pos` is interpolated into
+    # SQL below; `jq_ok` is on a later line and is still reached, so the line is
+    # ACCEPTED; and the shell resolves and runs a word taken from the input.
+    # This input arrives from the sync server, so all three are server-chosen.
+    #
+    # `tostring` makes an array or object arrive as a single quoted value
+    # carrying its JSON text, which the whitelist below refuses, and leaves
+    # strings and numbers exactly as they were.
     #
     # `@sh` is jq's shell-quoting filter, so every value arrives verbatim through
     # `eval` with nothing for this side to get wrong. `jq_ok` is emitted LAST: a

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -788,6 +788,17 @@ storage_sync_reconcile_push() {
     # second would overwrite the first, `jq_ok` included, so a page could hide
     # anything in the tail of a line (#780).
     #
+    # `tostring` before `@sh` on every field, which is not decoration. `@sh` turns
+    # an ARRAY into a list of shell words, so `"local_position": ["1","reboot"]`
+    # expands to `pos='1' 'reboot'` -- a command-prefix assignment that runs
+    # `reboot`, leaves `pos` holding the PREVIOUS line's value, and still reaches
+    # `jq_ok=1` on the next line, so the line is accepted. Demonstrated, not
+    # reasoned about. `tostring` makes the same input `pos='["1","reboot"]'`,
+    # which the whitelist below refuses, and it leaves strings and numbers
+    # exactly as they were. `storage_sync_apply_pull` already does this on the
+    # fields it does not otherwise constrain; this read simply has to do it on
+    # all of them.
+    #
     # `@sh` is jq's shell-quoting filter, so every value arrives verbatim through
     # `eval` with nothing for this side to get wrong. `jq_ok` is emitted LAST: a
     # line jq cannot parse produces no assignments at all, so the sentinel stays 0
@@ -796,11 +807,11 @@ storage_sync_reconcile_push() {
     jq_ok=0
     eval "$(printf '%s\n' "$line" | jq -r -s '
       if length != 1 then error("one JSON value per line") else .[0] end
-      | "type=\(.type // "" | @sh)",
-      "pos=\(.local_position // "" | @sh)",
-      "wire=\(.id // "" | @sh)",
-      "seq=\(.server_seq // "" | @sh)",
-      "disposition=\(.disposition // "" | @sh)",
+      | "type=\(.type // "" | tostring | @sh)",
+      "pos=\(.local_position // "" | tostring | @sh)",
+      "wire=\(.id // "" | tostring | @sh)",
+      "seq=\(.server_seq // "" | tostring | @sh)",
+      "disposition=\(.disposition // "" | tostring | @sh)",
       "jq_ok=1"' 2>/dev/null)"
     [ "$jq_ok" = 1 ] || { _sqlite_sync_why; return 13; }
     [ "$type" = sync_push_ack ] || { _sqlite_sync_why; return 13; }

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -564,6 +564,46 @@ printf_two_acks_through_reconcile() {
   printf '%s %s\n' "$1" "$2" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1
 }
 
+# `@sh` turns an ARRAY into a list of shell WORDS, so an array-typed field does
+# not merely slip past the whitelist -- it changes what `eval` is handed.
+# `"local_position": ["1","<name>"]` expands to `pos='1' '<name>'`, which is a
+# command-prefix assignment: it RUNS `<name>`, leaves `pos` holding the previous
+# line's value, and still reaches `jq_ok=1`, so the line is accepted.
+#
+# Two assertions, because "refused" and "did not execute" are different claims
+# and only one of them is about the exit status.
+@test "sync contract: an array-typed ack field is refused and does not execute (#780)" {
+  _seed_legacy_history
+  prepare_push >/dev/null
+  local marker shim good
+  marker="$BATS_TEST_TMPDIR/executed"
+  shim="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$shim"
+  printf '#!/bin/sh\ntouch %s\n' "$marker" > "$shim/agmsg-exec-probe"
+  chmod +x "$shim/agmsg-exec-probe"
+
+  # The probe must be runnable, or "it did not run" proves nothing.
+  PATH="$shim:$PATH" agmsg-exec-probe
+  [ -f "$marker" ]
+  rm -f "$marker"
+
+  good='{"type":"sync_push_ack","local_position":"1","id":"00000000-0000-4000-8000-000000000000","server_seq":"1","disposition":"stored"}'
+  run _reconcile_array_position "$good"
+  [ "$status" -eq 13 ]
+  refute test -f "$marker"
+}
+
+_reconcile_array_position() {
+  local bad
+  bad='{"type":"sync_push_ack","local_position":["1","agmsg-exec-probe"],"id":"00000000-0000-4000-8000-000000000001","server_seq":"2","disposition":"stored"}'
+  # PATH is exported for the WHOLE function, not prefixed to `printf`. A prefix
+  # assignment would scope it to the left side of the pipe, while the `eval` that
+  # could run the probe is on the right -- so the "did not execute" assertion
+  # would hold because the probe was unreachable, not because nothing ran it.
+  export PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+  printf '%s\n%s\n' "$1" "$bad" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1
+}
+
 # The sentinel, driven the only way that can fail. A single unparseable line is
 # caught anyway -- with no assignments the fields are empty and the position
 # whitelist refuses "" -- so the shape that separates a working sentinel from a

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -564,6 +564,25 @@ printf_two_acks_through_reconcile() {
   printf '%s %s\n' "$1" "$2" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1
 }
 
+# The sentinel, driven the only way that can fail. A single unparseable line is
+# caught anyway -- with no assignments the fields are empty and the position
+# whitelist refuses "" -- so the shape that separates a working sentinel from a
+# broken one is a GOOD line followed by a BAD one: without it the bad line
+# silently re-uses the good line's position, wire id and sequence, and is
+# counted a second time.
+@test "sync contract: an unparseable ack line does not inherit the previous line (#780)" {
+  _seed_legacy_history
+  prepare_push >/dev/null
+  local good
+  good='{"type":"sync_push_ack","local_position":"1","id":"00000000-0000-4000-8000-000000000000","server_seq":"1","disposition":"stored"}'
+  run _reconcile_good_then_garbage "$good"
+  [ "$status" -eq 13 ]
+}
+
+_reconcile_good_then_garbage() {
+  printf '%s\n{not json\n' "$1" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1
+}
+
 # The wire-id check stopped being a `grep -Eq '^[0-9a-f-]{36}$'` and became two
 # builtin `case` patterns. Same whitelist or not is the question, and `$wire`
 # goes straight into SQL, so it is asked with the shapes that separate the two:

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -589,8 +589,10 @@ printf_two_acks_through_reconcile() {
 
   good='{"type":"sync_push_ack","local_position":"1","id":"00000000-0000-4000-8000-000000000000","server_seq":"1","disposition":"stored"}'
   run _reconcile_array_position "$good"
-  [ "$status" -eq 13 ]
+  # Execution first: it is the more severe of the two claims, and asserting the
+  # exit status ahead of it would stop the test before this ever ran.
   refute test -f "$marker"
+  [ "$status" -eq 13 ]
 }
 
 _reconcile_array_position() {

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -543,6 +543,54 @@ _reconcile_one_ack() {
     | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1
 }
 
+# The #780 guard, on the ACK path. The existing "two JSON values on one line"
+# test drives `sync_pull_message`, so the same guard on reconcile was carried by
+# nothing: a second value on the line would emit a second full set of
+# assignments, `jq_ok` included, and the last one would win.
+@test "sync contract: reconcile refuses two JSON values on one ack line (#780)" {
+  _seed_legacy_history
+  prepare_push >/dev/null
+  local one two
+  one='{"type":"sync_push_ack","local_position":"1","id":"00000000-0000-4000-8000-000000000000","server_seq":"1","disposition":"stored"}'
+  # Second value hides a different position on the same line.
+  two='{"type":"sync_push_ack","local_position":"2","id":"00000000-0000-4000-8000-000000000001","server_seq":"2","disposition":"stored"}'
+  # Drive it in THIS shell, for the reason _reconcile_one_ack documents: a 127
+  # from an undefined function would look like the rejection being asserted.
+  run printf_two_acks_through_reconcile "$one" "$two"
+  [ "$status" -eq 13 ]
+}
+
+printf_two_acks_through_reconcile() {
+  printf '%s %s\n' "$1" "$2" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1
+}
+
+# The wire-id check stopped being a `grep -Eq '^[0-9a-f-]{36}$'` and became two
+# builtin `case` patterns. Same whitelist or not is the question, and `$wire`
+# goes straight into SQL, so it is asked with the shapes that separate the two:
+# right length wrong charset, right charset wrong length, and an injection that
+# is neither.
+@test "sync contract: an ack wire id stays a whitelist after the grep was removed" {
+  _seed_legacy_history
+  prepare_push >/dev/null
+  local bad
+  for bad in \
+    "00000000-0000-4000-8000-00000000000" \
+    "00000000-0000-4000-8000-0000000000000" \
+    "00000000-0000-4000-8000-00000000000g" \
+    "00000000-0000-4000-8000-00000000000'" \
+    "'; DROP TABLE sync_messages; --" \
+    "" \
+    "00000000-0000-4000-8000-0000000000 0"; do
+    run _reconcile_one_ack_wire "$bad"
+    [ "$status" -eq 13 ]
+  done
+}
+
+_reconcile_one_ack_wire() {
+  printf '{"type":"sync_push_ack","local_position":"1","id":"%s","server_seq":"1","disposition":"stored"}\n' \
+    "$1" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1
+}
+
 @test "sync contract: an ack position stays a whitelist after allowing negatives" {
   # local_position is interpolated straight into SQL, so widening it to accept
   # projected (negative) positions must not widen it to anything else.


### PR DESCRIPTION
Refs #913.

## What was slow

Reconciling a push read five fields with five `jq` invocations and checked the wire id with a `grep`. **Six forks per acknowledged message**, in a sequential `while` loop.

A fork costs **6.3 ms** on the machine this was measured on, so nearly all of an acknowledgement's cost was process creation rather than work.

## The fix is a read this file already contains

`storage_sync_apply_pull` solved exactly this for the pull side under #780: one `jq -r -s` per line emitting `@sh`-quoted assignments, `eval`ed, with a `jq_ok=1` sentinel emitted last. Its own comment says *"One `jq` per message, not one per field (#780). This read cost 18…"*.

This PR moves that read to the ack side. Not a new idea — the same idea, in the second place it was needed.

| piece | why it is there |
|---|---|
| `-s` with a length check | one **line** is not one JSON value to jq. Two values on a line would each emit a full set of assignments and the second would win, sentinel included, so a page could hide anything in the tail of a line. |
| `tostring` then `@sh` | `@sh` alone turns an **array** into a list of shell **words**. See below — this one is not decoration. |
| `@sh` | every value arrives verbatim through `eval`, with nothing for this side to get wrong. |
| `jq_ok` emitted last | a line jq cannot parse produces no assignments at all, so this fails closed instead of proceeding on the previous iteration's values. |

The sixth fork was `grep -Eq '^[0-9a-f-]{36}$'`, now two builtin `case` patterns — a length of 36, and not one character outside the class. Still a whitelist, because `$wire` is interpolated into SQL. `storage_sync_apply_pull` keeps its `grep`: its pattern is the strict UUIDv4 shape, which does not reduce to a glob this cleanly.

## Measured

Same harness for both sides, 200 lines per run, three runs each. Only the extraction differs between the two arms.

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| before | 25.87 | 24.97 | 29.37 | **25.87** ms/line |
| after | 4.84 | 4.99 | 5.86 | **4.99** ms/line |

**5.2×.** The remaining 4.99 ms is the one surviving `jq` fork; see *What this does not do*.

**How the numbers were taken, and what they are not.** The harness reproduces the loop's field-reading step — the same five `jq` calls and `grep` before, the same single `jq` and `case` patterns after — rather than calling `storage_sync_reconcile_push` itself, so the sqlite work either arm would also do is excluded from both. That makes this a measurement of the change, not of the function: the real per-ack cost is **higher than both numbers**, never lower, and the ratio is the claim.

## Review found a hole in the first revision, and measuring it found a bigger one

The first revision passed each field straight to `@sh`. Review caught that `@sh` turns an **array** into a list of shell **words**, so `"local_position": ["1"]` became `pos='1'` and passed the numeric whitelist that the old `jq -r` read had refused.

Measuring it found that a multi-element array is not a widened whitelist at all. `@sh` emits one quoted word per element, and a line of several words is not an assignment to the shell — it is an **assignment prefixed to a command**. The consequences are all three of:

- the field is **not** assigned, so the variable keeps the **previous line's** value — and that value is interpolated into SQL;
- the sentinel is on a later line and is still reached, so the line is **accepted**;
- the shell resolves and runs something it took from the stream.

This was confirmed by observation rather than reasoning, with a harmless marker. The acknowledgement stream comes from the sync server, so the last point is server-controlled. Details are deliberately omitted here: the same shape exists elsewhere and is being fixed separately.

It never reached `main` — this PR is where it was caught.

**Fix:** `tostring` before `@sh` on every field. An array or object then arrives as a single quoted value carrying its JSON text, which the whitelist refuses; strings and numbers are untouched, so the five-`jq` read's behaviour is restored exactly. This is not a new idea either — `storage_sync_apply_pull` already applies `tostring` to the fields it does not otherwise constrain. The defect was carrying its read over without carrying that part of it.

## Behaviour

Unchanged **as of this revision**, and four mutations say so rather than my reading of the diff.

| # | mutation | red |
|---|---|---|
| A | drop the `-s` length guard (the #780 protection) | "reconcile refuses two JSON values on one ack line" |
| B | drop the charset half of the wire-id whitelist, keep the length half | "an ack wire id stays a whitelist after the grep was removed" |
| C | pre-set the sentinel to `1`, so an unparseable line proceeds on stale values | "an unparseable ack line does not inherit the previous line" |
| D | drop `tostring` from `local_position` | "an array-typed ack field is refused and does not execute" |

Each reddens only its own row.

**C is the one worth reading.** It came back **green** the first time: the suite had nothing that could tell a working sentinel from a broken one. A single unparseable line is caught anyway — with no assignments the fields are empty and the position whitelist refuses `""` — so the shape that separates them is a **good line followed by a bad one**, where the bad line silently inherits the good line's position, wire id and sequence and is counted a second time. That test now exists, and C reddens it.

**D is worth reading too, for the test rather than the code.** The test makes two claims — the line is refused, and the probe did not run — and they can fail separately. Three things had to be right for it to mean anything: the probe is checked to be runnable first, or "it did not run" would hold because it was unreachable; `PATH` is exported for the whole helper rather than prefixed to `printf`, which would scope it to the left of the pipe while the `eval` runs on the right; and the non-execution assertion sits **before** the exit-status one, because with the order reversed the mutation failed the status check and bats stopped, leaving the more severe claim never evaluated. All three were wrong in my first draft of it.

A and B are also new tests: the existing "two JSON values on one line" test drives `sync_pull_message`, so the same guard on the ack path was carried by nothing, and the wire-id whitelist changed shape in this PR from a regex to two globs.

## Ran

`tests/test_remote_sync.bats` — 33/33 before these tests, 37/37 with them. Not run locally: the full matrix. CI's job.

## What this does not do

- **The surviving fork.** 4.99 ms/line is one `jq` per line. Parsing the whole stream in a single `jq` would remove it, but the per-line read is what carries the #780 refusal and the fail-closed sentinel, and both are deliberate. That is a separate change with a different risk profile, not a tidy-up of this one.
- **#912.** The correlated subquery at the end of the same function is the other half of what makes this function slow, and it is a much larger number. Separate PR, same author, so the rebase stays in one place.
- **age.** Sealing is 88% fork per message, but it is parallelised across cores while this loop is sequential, so its contribution to wall clock is small by comparison. Deprioritised deliberately — see the note on #913.
