### PR TITLE
fix(sync): a pulled field that is an array must not become shell words

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -911,27 +911,50 @@ storage_sync_apply_pull() {
     # refused the embedded newline. Raised in review, and it was a real
     # regression -- the reason has to be explicit now that it is no longer a
     # side effect of how the fields were read.
+    # `tostring` before `@sh` on EVERY field, not only the ones that needed a
+    # string form. `@sh` emits one quoted word per element of an ARRAY, and a
+    # line carrying several words is not an assignment to the shell -- it is an
+    # assignment PREFIXED TO A COMMAND. Three things follow at once, and the
+    # third is the reason this is not a cosmetic fix:
+    #
+    #   the field is not assigned, so the variable keeps the PREVIOUS line's
+    #   value -- and several of these are interpolated into SQL below;
+    #
+    #   `jq_ok` is on a later line and is still reached, so the line is
+    #   ACCEPTED rather than refused;
+    #
+    #   the shell resolves and runs a word taken from the input.
+    #
+    # This input arrives from the sync server, so all three are server-chosen.
+    # `tostring` makes an array or object arrive as a single quoted value
+    # carrying its JSON text, which every whitelist below refuses, and leaves
+    # strings, numbers and booleans exactly as `jq -r` produced them -- so the
+    # set of inputs this accepts does not change.
+    #
+    # Four fields already had it. The other fourteen are the defect: it was
+    # applied where a non-string value was expected, rather than everywhere the
+    # result reaches `eval`.
     jq_ok=0
     eval "$(printf '%s\n' "$line" | jq -r -s '
       if length != 1 then error("one JSON value per line") else .[0] end
-      | "type=\(.type // "" | @sh)",
-      "line_next_after=\(.next_after // "" | @sh)",
-      "seq=\(.server_seq // "" | @sh)",
-      "wire=\(.id // "" | @sh)",
-      "received=\(.server_received_at // "" | @sh)",
+      | "type=\(.type // "" | tostring | @sh)",
+      "line_next_after=\(.next_after // "" | tostring | @sh)",
+      "seq=\(.server_seq // "" | tostring | @sh)",
+      "wire=\(.id // "" | tostring | @sh)",
+      "received=\(.server_received_at // "" | tostring | @sh)",
       "v=\(.envelope.v | tostring | @sh)",
       "cipher=\(.envelope.cipher | tostring | @sh)",
-      "key_id=\(.envelope.key_id // "" | @sh)",
+      "key_id=\(.envelope.key_id // "" | tostring | @sh)",
       "blob=\(.envelope.blob | tostring | @sh)",
       "status=\(.status | tostring | @sh)",
-      "policy=\(.policy_revision // "" | @sh)",
-      "local_rev=\(.local_security_revision // "" | @sh)",
-      "reason=\(.reason // "" | @sh)",
-      "kind=\(.projection.kind // "" | @sh)",
-      "from=\(.projection.from_agent // "" | @sh)",
-      "to=\(.projection.to_agent // "" | @sh)",
-      "body=\(.projection.body // "" | @sh)",
-      "at=\(.projection.created_at // "" | @sh)",
+      "policy=\(.policy_revision // "" | tostring | @sh)",
+      "local_rev=\(.local_security_revision // "" | tostring | @sh)",
+      "reason=\(.reason // "" | tostring | @sh)",
+      "kind=\(.projection.kind // "" | tostring | @sh)",
+      "from=\(.projection.from_agent // "" | tostring | @sh)",
+      "to=\(.projection.to_agent // "" | tostring | @sh)",
+      "body=\(.projection.body // "" | tostring | @sh)",
+      "at=\(.projection.created_at // "" | tostring | @sh)",
       "jq_ok=1"' 2>/dev/null)"
     [ "$jq_ok" = 1 ] || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
     if [ "$type" = sync_pull_cursor ]; then

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -911,8 +911,21 @@ storage_sync_apply_pull() {
     # refused the embedded newline. Raised in review, and it was a real
     # regression -- the reason has to be explicit now that it is no longer a
     # side effect of how the fields were read.
-    # `tostring` before `@sh` on EVERY field, not only the ones that needed a
-    # string form. `@sh` emits one quoted word per element of an ARRAY, and a
+    # INVARIANT: every field passes through `tostring` before `@sh`. No
+    # exceptions, and the reason is not that these values are untidy.
+    #
+    # "This field is a string, so it does not need it" is the judgement that
+    # produced this defect, and it does not hold: THE SENDER CHOOSES THE TYPE.
+    # What arrives here is JSON off the wire from the sync server, so the type
+    # of any field is whatever that server put there -- our expectation of it is
+    # not a constraint on it. `tostring` is applied for what the value reaches,
+    # not for what it is: it is the last thing between a server-chosen value and
+    # `eval`, and every field reaches `eval`.
+    #
+    # Adding a field to this filter without `tostring` reopens the hole below,
+    # however plainly its name says "string".
+    #
+    # `@sh` emits one quoted word per element of an ARRAY, and a
     # line carrying several words is not an assignment to the shell -- it is an
     # assignment PREFIXED TO A COMMAND. Three things follow at once, and the
     # third is the reason this is not a cosmetic fix:
@@ -931,9 +944,9 @@ storage_sync_apply_pull() {
     # strings, numbers and booleans exactly as `jq -r` produced them -- so the
     # set of inputs this accepts does not change.
     #
-    # Four fields already had it. The other fourteen are the defect: it was
-    # applied where a non-string value was expected, rather than everywhere the
-    # result reaches `eval`.
+    # Four fields already had it -- chosen because a non-string value was
+    # EXPECTED there. That is the wrong axis, and the other fourteen are what it
+    # cost.
     jq_ok=0
     eval "$(printf '%s\n' "$line" | jq -r -s '
       if length != 1 then error("one JSON value per line") else .[0] end

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -791,6 +791,48 @@ second line	after a tab"
 # want of a cursor, so the bug is invisible. After it, the stale fields say
 # "sync_pull_cursor", the loop skips the line as if it had been one, and the
 # page COMMITS — an unparseable line accepted as a page terminator.
+# Every field of a pulled line reaches `eval` through `@sh`, and `@sh` emits one
+# quoted word per element of an ARRAY. A line of several words is an assignment
+# prefixed to a COMMAND, so an array-valued field both fails to assign -- leaving
+# the previous value in place -- and gets a word from the input resolved and run.
+# This input comes from the sync server.
+#
+# Two claims, asserted separately because they fail separately, and the more
+# severe one first: nothing from the line ran, and the page was refused.
+@test "sync contract: an array-valued pull field is refused and does not execute" {
+  local marker shim rc=0 bad
+  marker="$BATS_TEST_TMPDIR/executed"
+  shim="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$shim"
+  printf '#!/bin/sh\ntouch %s\n' "$marker" > "$shim/agmsg-exec-probe"
+  chmod +x "$shim/agmsg-exec-probe"
+
+  # The probe has to be runnable, or "it did not run" would hold because it was
+  # unreachable and this test would pass against any implementation.
+  PATH="$shim:$PATH" agmsg-exec-probe
+  [ -f "$marker" ]
+  rm -f "$marker"
+
+  bad=$(jq -nc '
+    {type:["sync_pull_message","agmsg-exec-probe"],server_seq:"4",
+     id:"550e8400-e29b-41d4-a716-4466554400d9",
+     server_received_at:"2026-07-20T13:00:04.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"array field",created_at:"2026-07-20T13:00:04.000000Z",
+        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"array field",created_at:"2026-07-20T13:00:04.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
+  # Exported, not prefixed: a prefix assignment would scope PATH to the left of
+  # the pipe, while the `eval` that could run the probe is on the right.
+  export PATH="$shim:$PATH"
+  printf '%s\n' "$bad" \
+    | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null 2>&1 || rc=$?
+
+  refute test -f "$marker"
+  [ "$rc" -ne 0 ]
+}
+
 @test "sync contract: an unparseable line fails the page, wherever it sits" {
   local remote db rc=0
   db=$(agmsg_db_path demo)


### PR DESCRIPTION
Every field of a pulled line reaches `eval` through `@sh`.

`@sh` emits **one quoted word per element of an array**, and a line carrying several words is not an assignment to the shell — it is an assignment **prefixed to a command**. Three things follow at once:

- the field is **not assigned**, so the variable keeps the **previous line's** value — and several of these are interpolated into SQL;
- `jq_ok` sits on a later line and is still reached, so the line is **accepted** rather than refused;
- the shell resolves and runs a word taken from the input.

This input arrives from the sync server, so all three are server-chosen.

## The fix

`tostring` before `@sh` on **every** field. An array or object then arrives as a single quoted value carrying its JSON text, which the whitelists refuse, and strings, numbers and booleans are exactly what `jq -r` produced — so **the set of inputs this accepts does not change**.

Four of the eighteen fields already had it. The other fourteen are the defect: it had been applied where a *non-string value was expected*, rather than *everywhere the result reaches `eval`*.

Derived rather than enumerated, so the claim is checkable in one command:

```
fields without tostring, before   14
fields with    tostring, before    4
rewritten                         14
fields without tostring, after     0
```

All eighteen are in `storage_sync_apply_pull`; nothing else in the file matched.

## Test

Two claims, asserted separately because they fail separately, and the more severe one first: **nothing from the line ran**, and the page was refused.

Three things had to be right for that to mean anything:

- the probe is checked to be **runnable** before its absence is relied on — otherwise "it did not run" holds because it was unreachable, and the test passes against any implementation;
- `PATH` is **exported** rather than prefixed, which would scope it to the left of the pipe while the `eval` runs on the right;
- the non-execution assertion sits **before** the exit-status one, or a failure stops the test before the severe claim is ever evaluated.

Mutation: remove `tostring` from `.type` alone → the **non-execution** assertion reddens, which is also what shows the behaviour is real rather than argued.

`tests/test_remote_sync.bats` — 35/35. Not run locally: the full matrix. CI's job.

## Scope

- Branched on top of #925, which had already landed; the rebase stays with one author.
- The same shape was caught in review on #927 for the acknowledgement read and fixed there. This is the other half, in the path that was already on `main`.
- Deliberately omitted: a working reproduction. The mechanism above is what a reader needs to check the fix.
