### PR TITLE
fix(sync): retry a busy apply that races EPIPE, keeping the hung-driver bound

### DIFF
--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1836,6 +1836,26 @@ export function discardInputDirectory(directory, reason) {
   }
 }
 
+// How long to wait for a driver that has stopped reading its stdin to exit on
+// its own before the pipe path's bound (the SIGKILL in runDriver's `fail`) is
+// applied. Derived from the storage busy timeout, since the only exit worth
+// waiting for is a busy child's, which comes that timeout after it starts
+// waiting; a few seconds of teardown slack past it.
+//
+// Bounded on BOTH ends. Below: a value that is not a sane non-negative integer
+// -- NaN, negative, or a huge one -- falls to the 5 s default. Above: the busy
+// timeout is capped at an hour before the slack is added, so the result can
+// never approach setTimeout's 32-bit millisecond limit. Past that limit Node
+// clamps a delay to 1 ms and would kill a busy child almost at once -- the
+// opposite of a grace -- so `Number.isSafeInteger` alone (which admits values
+// far past the timer limit) is not enough; the cap is what closes that.
+export function storageDriverExitGraceMs(busyTimeoutEnv = process.env.AGMSG_BUSY_TIMEOUT) {
+  const busyTimeoutMs = Number(busyTimeoutEnv);
+  const usable = Number.isSafeInteger(busyTimeoutMs) &&
+    busyTimeoutMs >= 0 && busyTimeoutMs <= 3_600_000 ? busyTimeoutMs : 5000;
+  return usable + 5000;
+}
+
 function runDriver({ args, label, operation, parse, input, rosterFile, team, bindingPath,
   holdsRegistryLock = false }) {
   return new Promise((resolve, reject) => {
@@ -1973,21 +1993,22 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
     // process cannot exit". Deferring to 'exit' must not drop that bound, so a
     // timer keeps it: if no exit arrives, `fail` runs and kills, as before.
     //
-    // Its length is not a tuning knob and not a wait the fast path ever feels.
-    // The only child worth waiting for is a busy one, and it exits the storage
-    // busy timeout (AGMSG_BUSY_TIMEOUT, default 5 s) after it starts waiting --
-    // so any bound past that timeout catches every exit that is coming, and all
-    // it delays is an already-broken child's failure. Timeout plus a few seconds
-    // of teardown slack, with a safe default when the env value is unusable.
+    // Its length (storageDriverExitGraceMs) is not a tuning knob and not a wait
+    // the fast path ever feels: the only child worth waiting for is a busy one,
+    // which exits the busy timeout after it starts waiting, so any bound past
+    // that timeout catches every exit that is coming and delays only an
+    // already-broken child's failure.
+    //
+    // `settled` first, so nothing here runs after the call has ended -- a stdin
+    // error can arrive after 'exit' has already settled a non-zero exit, and
+    // without this it would arm a fresh timer past the cleared one.
     child.stdin?.on("error", (error) => {
+      if (settled) return;
       error.driverFailurePhase = "stdin-write";
       lastStdinError = error;
       child.stdin.destroy();
       if (stdinExitTimer === null) {
-        const busyTimeoutMs = Number(process.env.AGMSG_BUSY_TIMEOUT);
-        const graceMs = (Number.isSafeInteger(busyTimeoutMs) && busyTimeoutMs >= 0
-          ? busyTimeoutMs : 5000) + 5000;
-        stdinExitTimer = setTimeout(() => fail(error), graceMs);
+        stdinExitTimer = setTimeout(() => fail(error), storageDriverExitGraceMs());
         stdinExitTimer.unref?.();
       }
     });
@@ -2023,6 +2044,13 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
     });
     child.on("close", () => {
       if (failure) { settle(failure, null); return; }
+      // Order-independent with the exit above: whichever of them ran, a stdin
+      // write that lost its reader means the child cannot have received the
+      // whole page, so 'close' must not settle success on a truncated input --
+      // it fails closed on the recorded write error instead. The exit handler
+      // catches this when the exit is seen first; this catches the case where
+      // the write error was recorded only after a clean exit had returned.
+      if (lastStdinError) { settle(lastStdinError, null); return; }
       try {
         settle(null, parse(stdout));
       } catch (error) {

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1898,10 +1898,17 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
     // later whether there was ever a pipe to write to.
     const staged = staging.fd !== null;
     let stdout = ""; let stderr = ""; let settled = false; let failure = null;
+    // The last stdin-write error, kept only so a child that exits 0 despite a
+    // broken write is not reported as a silent success. See the stdin handler.
+    let lastStdinError = null;
+    // Armed when a stdin write loses its reader, cleared when the call settles.
+    // See the stdin handler for what it bounds and why its length is what it is.
+    let stdinExitTimer = null;
 
     const settle = (error, value) => {
       if (settled) return;
       settled = true;
+      if (stdinExitTimer !== null) { clearTimeout(stdinExitTimer); stdinExitTimer = null; }
       releaseInput();
       if (error) reject(error); else resolve(value);
     };
@@ -1944,16 +1951,45 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
     child.on("error", fail);
     // Only on the pipe path -- a staged input has no stdin stream to put this
     // on, and no write that could fail.
+    //
+    // A write to stdin that loses its reader is a SYMPTOM, not the verdict: the
+    // child exited before the whole input was sent and closing its read end
+    // turned the next write into EPIPE (on macOS -- socketpairs -- ENOTCONN or
+    // EPIPE depending on how far the write got; the errno set is not closed).
+    // The reason it exited is its exit code, and a busy `apply` exits 11 exactly
+    // here -- its page is larger than the pipe buffer, so it waits out the busy
+    // timeout and exits while the parent is still writing. Concluding
+    // "stdin-write failed" on the errno, ahead of the exit, is what masked that
+    // retryable 11 as an unrecoverable EPIPE and ended #910's reprocess.
+    //
+    // So stop writing and let 'exit' rule on the code. Keep the marker for
+    // diagnostics, but do not settle on it here: `failure` stays unset, so
+    // 'exit' reports the child's own answer.
+    //
+    // Not forever, though. This path keeps its pipe (the roster path stages, so
+    // it never has a lost-reader write), and the pipe path's bound against a
+    // child that stops reading AND does not exit is the SIGKILL in `fail` --
+    // written for exactly this, so "the process dies" is not traded for "the
+    // process cannot exit". Deferring to 'exit' must not drop that bound, so a
+    // timer keeps it: if no exit arrives, `fail` runs and kills, as before.
+    //
+    // Its length is not a tuning knob and not a wait the fast path ever feels.
+    // The only child worth waiting for is a busy one, and it exits the storage
+    // busy timeout (AGMSG_BUSY_TIMEOUT, default 5 s) after it starts waiting --
+    // so any bound past that timeout catches every exit that is coming, and all
+    // it delays is an already-broken child's failure. Timeout plus a few seconds
+    // of teardown slack, with a safe default when the env value is unusable.
     child.stdin?.on("error", (error) => {
-      // Where the failure came from, recorded at the boundary because the OS
-      // code cannot be asked for it: a write whose reader is gone is EPIPE on
-      // Linux, and on macOS -- socketpairs -- either ENOTCONN or EPIPE
-      // depending on how far the write got. That set is not closed, so nothing
-      // downstream can recognise this failure by errno without going stale on
-      // the next platform. The error is otherwise passed through untouched, so
-      // its code and message survive for diagnostics.
       error.driverFailurePhase = "stdin-write";
-      fail(error);
+      lastStdinError = error;
+      child.stdin.destroy();
+      if (stdinExitTimer === null) {
+        const busyTimeoutMs = Number(process.env.AGMSG_BUSY_TIMEOUT);
+        const graceMs = (Number.isSafeInteger(busyTimeoutMs) && busyTimeoutMs >= 0
+          ? busyTimeoutMs : 5000) + 5000;
+        stdinExitTimer = setTimeout(() => fail(error), graceMs);
+        stdinExitTimer.unref?.();
+      }
     });
     // Every failure ends here, at 'exit'. A driver that merely exits non-zero is
     // the ordinary case and it needs this as much as a stream error does: it too
@@ -1962,6 +1998,10 @@ function runDriver({ args, label, operation, parse, input, rosterFile, team, bin
     // goes on to 'close', because only success has to parse all of stdout.
     child.on("exit", (code, signal) => {
       if (failure) { fail(failure); return; }
+      // A clean exit after a broken write is not a clean sync: the child cannot
+      // have read input the parent never finished sending, so a "success" here
+      // would be a sync of a truncated page. Report the write failure instead.
+      if (code === 0 && !signal && lastStdinError) { fail(lastStdinError); return; }
       if (code === 0 && !signal) return;
       // The team and the binding path, because the previous fallback said
       // "inspect its team storage and binding" and named neither -- on a

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -1850,7 +1850,15 @@ export function discardInputDirectory(directory, reason) {
 // opposite of a grace -- so `Number.isSafeInteger` alone (which admits values
 // far past the timer limit) is not enough; the cap is what closes that.
 export function storageDriverExitGraceMs(busyTimeoutEnv = process.env.AGMSG_BUSY_TIMEOUT) {
-  const busyTimeoutMs = Number(busyTimeoutEnv);
+  // Empty is the 5 s default, exactly as the child reads it: storage.sh and the
+  // adapter use `${AGMSG_BUSY_TIMEOUT:-5000}`, where unset AND empty both mean
+  // 5000. Number("") is 0, not that default -- so an empty value taken literally
+  // would make the grace 5 s, equal to the child's busy timeout, and the SIGKILL
+  // would fire at the same moment a busy child exits 11, dropping it again. So
+  // normalise empty to the default before parsing, and keep this in step with
+  // the child's own default if that ever changes.
+  const raw = busyTimeoutEnv === undefined || busyTimeoutEnv === "" ? "5000" : busyTimeoutEnv;
+  const busyTimeoutMs = Number(raw);
   const usable = Number.isSafeInteger(busyTimeoutMs) &&
     busyTimeoutMs >= 0 && busyTimeoutMs <= 3_600_000 ? busyTimeoutMs : 5000;
   return usable + 5000;

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -23,6 +23,7 @@ import {
   discardInputDirectory,
   driver,
   STORAGE_BUSY_EXIT,
+  storageDriverExitGraceMs,
   exportAgeHandoff,
   exportAgeSnapshot,
   isRetryable,
@@ -2140,6 +2141,55 @@ exit 7
     // already gone -- and it was NOT killed to get there.
     assert.ok(gone(childPid), "the failed driver was left running");
   }
+});
+
+test("a clean exit after a broken write is not a truncated success", { timeout: 30_000 }, async (t) => {
+  // The order-independent half of the fix. A driver that reads a little of a
+  // large page and then exits 0 leaves the parent's write without a reader --
+  // EPIPE -- while the child's status is a success. The call must NOT report
+  // that as a synced page: the child never received the rest. Whichever of
+  // 'exit' (code 0) and the stdin error is seen first, the write error is what
+  // settles it. Without the close-handler's fail-closed check this rejects only
+  // when the exit is seen after the error, and passes as an empty success when
+  // the clean exit is seen first -- so this pins the case that used to slip.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-trunc-"));
+  const script = (pidFile, helperFile) => `#!/usr/bin/env bash
+echo $$ > ${JSON.stringify(pidFile)}
+sleep 300 &
+echo $! > ${JSON.stringify(helperFile)}
+head -c 50 >/dev/null
+exit 0
+`;
+  const wide = "x".repeat(4096);
+  const input = Array.from({ length: 512 }, (_, index) => ({ type: "probe", index, wide }));
+  const { started } = await withDriverEnvironment(t, root, script,
+    (mock, config) => [
+      () => driver("prepare", config, input, ["1"]),
+    ]);
+  for (const { promise } of started) {
+    await assert.rejects(() => promise,
+      (error) => error.driverFailurePhase === "stdin-write");
+  }
+});
+
+test("the storage driver exit grace is bounded above so a huge busy timeout cannot overflow the timer", () => {
+  // setTimeout clamps a delay past its 32-bit millisecond limit to 1 ms, which
+  // would kill a busy child almost at once -- so a safe integer past that limit
+  // must not pass through. The env carries the storage busy timeout; the grace
+  // is it plus slack, or the default when it is unusable.
+  const TIMER_MAX = 2 ** 31 - 1;
+  assert.equal(storageDriverExitGraceMs(undefined), 10000);           // default 5 s + slack
+  assert.equal(storageDriverExitGraceMs("500"), 5500);                // the test value used below
+  assert.equal(storageDriverExitGraceMs("5000"), 10000);              // default busy timeout
+  for (const unusable of ["oops", "-1", "1.5", "9007199254740991", String(TIMER_MAX)]) {
+    const grace = storageDriverExitGraceMs(unusable);
+    assert.equal(grace, 10000, `${unusable} did not fall back to the default`);
+    assert.ok(grace < TIMER_MAX, "grace must stay under the timer limit");
+  }
+  // The largest accepted busy timeout (one hour) is still well under the limit.
+  assert.equal(storageDriverExitGraceMs("3600000"), 3605000);
+  assert.ok(storageDriverExitGraceMs("3600000") < TIMER_MAX);
+  assert.equal(storageDriverExitGraceMs("3600001"), 10000);           // over the cap -> default
 });
 
 test("the storage driver that stops reading AND never exits is still bounded and killed",

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2092,28 +2092,34 @@ exit 7
   }
 });
 
-test("the storage driver that stops reading its input fails the call and is not left running",
+test("the storage driver that stops reading its input fails through its exit code, not the broken write",
   { timeout: 30_000 }, async (t) => {
-  // Unchanged behaviour, kept under its own test so that it stays unchanged.
+  // The storage driver keeps its pipe: after evaluatePull() its input is
+  // decrypted message content, on E2EE teams as much as plain ones, and a pipe
+  // is what keeps that off disk. So a large page can lose its reader when the
+  // driver exits before the whole page is written -- a busy `apply` waits out
+  // its timeout and exits 11 while the parent is still writing -- and the write
+  // comes back EPIPE (macOS: ENOTCONN or EPIPE, the errno set is not closed).
   //
-  // The storage driver takes no registry lock, so nothing about it needs the
-  // staged file the roster driver gets, and giving it one would cost it both an
-  // input that never touches disk -- after evaluatePull() these records are
-  // decrypted message content, on E2EE teams as much as plain ones -- and the
-  // bounded failure it has here. A driver handed a file is waited for; a driver
-  // that stops reading a pipe fails at once.
+  // That EPIPE is a symptom of the exit, not a verdict on the call. Concluding
+  // "stdin-write failed" on it, ahead of the exit, is what masked a retryable
+  // busy 11 as an unrecoverable error and ended #910's reprocess. So the call
+  // must report the CHILD'S EXIT CODE: here a plain non-zero (7), asserted to
+  // arrive as `driverExitCode` with no `driverFailurePhase` verdict in front of
+  // it -- which is exactly what lets `driver` see an 11 and retry it. The busy
+  // 11 -> retry path itself is covered by "driver() waits out a busy store".
   //
-  // So this is the original EPIPE test, scoped to the caller it was always
-  // about: the write loses its reader, the failure arrives on the stdin stream,
-  // and the driver does not survive the call. Flip `holdsRegistryLock` on for
-  // the storage driver and this test says so.
+  // The trade this makes explicit: a driver that stops reading AND never exits
+  // is no longer failed at once -- the call waits for its exit, the same trade
+  // the roster (staged) path already makes above. Bounding a driver that hangs
+  // without exiting is separate work, not done here; this driver exits.
   const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-epipe-"));
   const script = (pidFile, helperFile) => `#!/usr/bin/env bash
 echo $$ > ${JSON.stringify(pidFile)}
 sleep 300 &
 echo $! > ${JSON.stringify(helperFile)}
 exec 0<&-
-exec sleep 300
+exit 7
 `;
   const wide = "x".repeat(4096);
   const input = Array.from({ length: 512 }, (_, index) => ({ type: "probe", index, wide }));
@@ -2123,14 +2129,58 @@ exec sleep 300
     ]);
 
   for (const { promise, childPid } of started) {
-    // On the marker the stdin handler sets, not on the errno: macOS answers
-    // ENOTCONN or EPIPE from the same event, and the set of spellings is not
-    // closed. The set of places that set this marker is -- there is one.
+    // The exit code won, and the EPIPE marker did not get in front of it. Both
+    // are asserted: a rejection still carrying `stdin-write` would mean the old
+    // premature verdict came back, and that marker is set in exactly one place,
+    // so it cannot be satisfied by accident.
+    await assert.rejects(() => promise,
+      (error) => error.driverFailurePhase === undefined &&
+        error.driverExitCode === 7 && /exit 7/u.test(String(error.message)));
+    // The call settles only after the driver has exited, so by this line it is
+    // already gone -- and it was NOT killed to get there.
+    assert.ok(gone(childPid), "the failed driver was left running");
+  }
+});
+
+test("the storage driver that stops reading AND never exits is still bounded and killed",
+  { timeout: 30_000 }, async (t) => {
+  // The other side of deferring to the exit code: a driver that loses the write
+  // AND does not exit must not hang the call forever. The pipe path keeps its
+  // SIGKILL bound for exactly this -- a timer past the busy timeout gives a real
+  // (busy) child every chance to exit on its own, and only a child that takes
+  // neither route is killed. Its failure carries the stdin-write marker, since
+  // that is the only thing this child ever told us.
+  //
+  // AGMSG_BUSY_TIMEOUT is set low so the grace (timeout + slack) is a few
+  // seconds, not the default ten: this is the one child the timer is allowed to
+  // wait for, and there is no reason to make the suite wait the whole default.
+  const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-hang-"));
+  const script = (pidFile, helperFile) => `#!/usr/bin/env bash
+echo $$ > ${JSON.stringify(pidFile)}
+sleep 300 &
+echo $! > ${JSON.stringify(helperFile)}
+exec 0<&-
+exec sleep 300
+`;
+  const wide = "x".repeat(4096);
+  const input = Array.from({ length: 512 }, (_, index) => ({ type: "probe", index, wide }));
+  const previousBusy = process.env.AGMSG_BUSY_TIMEOUT;
+  process.env.AGMSG_BUSY_TIMEOUT = "500";
+  t.after(() => {
+    if (previousBusy === undefined) delete process.env.AGMSG_BUSY_TIMEOUT;
+    else process.env.AGMSG_BUSY_TIMEOUT = previousBusy;
+  });
+  const { started, gone } = await withDriverEnvironment(t, root, script,
+    (mock, config) => [
+      () => driver("prepare", config, input, ["1"]),
+    ]);
+
+  for (const { promise, childPid } of started) {
+    // The bound fired: the marker is the child's only signal, and the driver was
+    // killed rather than waited for without end.
     await assert.rejects(() => promise,
       (error) => error.driverFailurePhase === "stdin-write");
-    // No poll and no grace period. The call settles only after the driver has
-    // exited, so by this line it is already gone.
-    assert.ok(gone(childPid), "the failed driver was left running");
+    assert.ok(gone(childPid), "the hung driver was left running past the bound");
   }
 });
 

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2179,6 +2179,10 @@ test("the storage driver exit grace is bounded above so a huge busy timeout cann
   // is it plus slack, or the default when it is unusable.
   const TIMER_MAX = 2 ** 31 - 1;
   assert.equal(storageDriverExitGraceMs(undefined), 10000);           // default 5 s + slack
+  // Empty means the same 5 s default the child reads from ${...:-5000}, NOT
+  // Number("") === 0 -- otherwise the grace would equal the child's busy timeout
+  // and the kill would race a busy exit 11.
+  assert.equal(storageDriverExitGraceMs(""), 10000);
   assert.equal(storageDriverExitGraceMs("500"), 5500);                // the test value used below
   assert.equal(storageDriverExitGraceMs("5000"), 10000);              // default busy timeout
   for (const unusable of ["oops", "-1", "1.5", "9007199254740991", String(TIMER_MAX)]) {


### PR DESCRIPTION
Part of #910; follows #920. On `main`.

## What #920 left on the apply path

#920 made a busy store's exit 11 retryable in `driver()`. It works wherever the driver's exit reaches `driver()` **as** exit 11 -- `reprocess`, `prepare`, and an `apply` whose lock clears within a retry. It does not on a sustained lock, and #910's reprocess is exactly that: one machine's engine held the store while another's `apply` was mid-page.

An `apply` page is ~100 messages with age blobs -- larger than the pipe buffer. So the parent is still writing the page to the driver's stdin when the busy driver, having waited out the busy timeout, exits 11. The child's exit closes its read end; the parent's next write fails EPIPE (on macOS -- socketpairs -- ENOTCONN or EPIPE, depending how far it got). The stdin-error handler concluded `driverFailurePhase: "stdin-write"` -- an error with no `driverExitCode` -- and `driver()`, seeing no exit 11, did not retry. The reprocess ended.

Measured, on a `.backup` copy of #910's store (17,369 messages, 4,100 quarantined) under a synthetic writer holding the store 12 s each minute plus one 155 s hold:

```
before this PR   fatal: write EPIPE at 3,500 of 4,100 remaining (reprocess died)
```

## The change (`remote-sync.mjs`, storage driver keeps its pipe)

The EPIPE is a symptom of the child's exit, not a verdict on the call. The stdin-error handler now stops writing and **defers to the child's exit code**: a busy 11 is retried by `driver()`, a real failure (7, 13, ...) is reported as before, and the `driverFailurePhase` marker is kept only for diagnostics -- it no longer settles the call ahead of the exit.

What that must not drop is the pipe path's existing bound: a child that stops reading **and never exits** is SIGKILLed by `fail`, written for exactly that so "the process dies" is not traded for "the process cannot exit". Deferring to the exit keeps it via a timer -- if no exit arrives within the storage busy timeout (`AGMSG_BUSY_TIMEOUT`, default 5 s) plus a few seconds of teardown slack, `fail` runs and kills as it always did. The length is derived from the one number that decides when a busy child exits, not a tuning knob; a healthy call never feels it, and all it ever delays is an already-broken child's failure.

Staging the storage input to a file (as the roster driver does, which is why the roster path has no lost-reader write) was considered and **rejected**: after `evaluatePull()` these records are decrypted message content, on E2EE teams as much as plain ones, and the pipe is what keeps that off disk.

## Verification

- `tests/remote_sync_engine.test.mjs`: a storage driver that stops reading then **exits 7** fails via its exit code, `driverFailurePhase` undefined, and is **not** killed; one that stops reading and **never exits** is killed after the bound (measured ~5.5 s with `AGMSG_BUSY_TIMEOUT=500`); the #920 busy-retry and the roster lock-release cases are unchanged. 101/101 local.
- End to end, same store copy and synthetic contention as above, with this fix: all 4,100 recover -- `reprocess.complete` reports `imported_count: 4100, blocking_remaining: false`, the store goes from 4,100 `unsupported_cipher` to 0, and `fatal` events stay 0. It weathered the 155 s hold and ~35 twelve-second holds, firing 19 `driver.busy` retries, in 2102 s (rc 0). The pre-fix run on the same input died at 3,500 remaining with `fatal: write EPIPE`.

Not in this PR: why the first prepare holds the lock (#919, separate PR), and the reprocess step's per-message cost (#922).
