### PR TITLE
perf(sync): find the first gap once, not once per candidate

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -837,17 +837,31 @@ storage_sync_reconcile_push() {
      WHERE x.local_team='$tl' AND x.server_instance_id='$server'
        AND x.remote_team_id='$remote' AND x.protocol_version=$protocol
        AND x.driver_generation='$generation';
+    -- The cursor advances to the end of the CONTIGUOUS acknowledged run, which
+    -- is what it always did. What changed is how the run's end is found.
+    --
+    -- It used to ask, for each candidate e, whether any gap existed in
+    -- (push_cursor, e.seq]. That inner test named e.seq, so it was correlated:
+    -- one scan of the gap set per candidate, and the work grew with the SQUARE
+    -- of the number of candidates. On a first connect, where every message is a
+    -- candidate, that is the whole history squared (#912).
+    --
+    -- The gap set does not depend on e. Ask it once: the FIRST gap after the
+    -- cursor bounds every contiguous run that starts there, so the answer is
+    -- the largest candidate below it. Same answer, because a candidate below
+    -- the first gap has no gap beneath it by definition, and one at or above it
+    -- has that gap. Two independent aggregates instead of one correlated pair.
     UPDATE sync_bindings AS b SET push_cursor=COALESCE((
       SELECT MAX(e.seq) FROM events e
       WHERE e.type='message_sent' AND e.team='$tl' AND e.seq>b.push_cursor
-        AND NOT EXISTS (
-          SELECT 1 FROM events gap LEFT JOIN sync_messages gm
+        AND e.seq < COALESCE((
+          SELECT MIN(gap.seq) FROM events gap LEFT JOIN sync_messages gm
             ON gm.local_team='$tl' AND gm.server_instance_id='$server'
            AND gm.remote_team_id='$remote' AND gm.protocol_version=$protocol
            AND gm.driver_generation='$generation' AND gm.local_position=gap.seq
           WHERE gap.type='message_sent' AND gap.team='$tl'
-            AND gap.seq>b.push_cursor AND gap.seq<=e.seq AND gm.server_seq IS NULL
-        )),b.push_cursor)
+            AND gap.seq>b.push_cursor AND gm.server_seq IS NULL
+        ),9223372036854775807)),b.push_cursor)
     WHERE b.local_team='$tl' AND b.server_instance_id='$server'
       AND b.remote_team_id='$remote' AND b.protocol_version=$protocol
       AND b.driver_generation='$generation';

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -846,22 +846,39 @@ storage_sync_reconcile_push() {
     -- of the number of candidates. On a first connect, where every message is a
     -- candidate, that is the whole history squared (#912).
     --
-    -- The gap set does not depend on e. Ask it once: the FIRST gap after the
-    -- cursor bounds every contiguous run that starts there, so the answer is
-    -- the largest candidate below it. Same answer, because a candidate below
-    -- the first gap has no gap beneath it by definition, and one at or above it
-    -- has that gap. Two independent aggregates instead of one correlated pair.
+    -- The gap set does not depend on e. The FIRST gap after the cursor bounds
+    -- every contiguous run that starts there, so the answer is the largest
+    -- candidate below it. Same answer: a candidate below the first gap has no
+    -- gap beneath it, and one at or above it has that gap.
+    --
+    -- A TEMP TABLE rather than a subquery, for two reasons that both had to be
+    -- measured rather than assumed. Written inline as a derived table, SQLite
+    -- re-evaluated it per candidate and the quadratic came straight back (3.3 s
+    -- against 27 ms at 2,000 rows). Written twice as an uncorrelated scalar
+    -- subquery it is fast, but then the gap query exists in two places that can
+    -- drift apart. A temp table is built once because of how it is built, not
+    -- because a planner chose to.
+    --
+    -- No sentinel. An earlier revision bounded with 9223372036854775807 as
+    -- though it were infinity; it is the largest value events.seq can hold, so
+    -- a candidate sitting exactly there was accepted by the old query and
+    -- refused by the new one. `IS NULL OR <` says what was meant and has no
+    -- boundary to collide with.
+    CREATE TEMP TABLE sync_first_gap AS
+      SELECT MIN(gap.seq) AS seq FROM events gap LEFT JOIN sync_messages gm
+        ON gm.local_team='$tl' AND gm.server_instance_id='$server'
+       AND gm.remote_team_id='$remote' AND gm.protocol_version=$protocol
+       AND gm.driver_generation='$generation' AND gm.local_position=gap.seq
+      WHERE gap.type='message_sent' AND gap.team='$tl' AND gm.server_seq IS NULL
+        AND gap.seq>(SELECT push_cursor FROM sync_bindings
+                      WHERE local_team='$tl' AND server_instance_id='$server'
+                        AND remote_team_id='$remote' AND protocol_version=$protocol
+                        AND driver_generation='$generation');
     UPDATE sync_bindings AS b SET push_cursor=COALESCE((
       SELECT MAX(e.seq) FROM events e
       WHERE e.type='message_sent' AND e.team='$tl' AND e.seq>b.push_cursor
-        AND e.seq < COALESCE((
-          SELECT MIN(gap.seq) FROM events gap LEFT JOIN sync_messages gm
-            ON gm.local_team='$tl' AND gm.server_instance_id='$server'
-           AND gm.remote_team_id='$remote' AND gm.protocol_version=$protocol
-           AND gm.driver_generation='$generation' AND gm.local_position=gap.seq
-          WHERE gap.type='message_sent' AND gap.team='$tl'
-            AND gap.seq>b.push_cursor AND gm.server_seq IS NULL
-        ),9223372036854775807)),b.push_cursor)
+        AND ((SELECT seq FROM sync_first_gap) IS NULL
+             OR e.seq<(SELECT seq FROM sync_first_gap))),b.push_cursor)
     WHERE b.local_team='$tl' AND b.server_instance_id='$server'
       AND b.remote_team_id='$remote' AND b.protocol_version=$protocol
       AND b.driver_generation='$generation';

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -104,6 +104,32 @@ prepare_push() {
   [ "$(printf '%s\n' "$result" | jq -r '.push_cursor')" = 3 ]
 }
 
+# The existing contiguous-prefix test has exactly ONE gap, and with one gap the
+# first gap and the last gap are the same row -- so it cannot tell "stop at the
+# first gap" from "stop at the last one". Two gaps separate them, and that is
+# the whole correctness question for how the run's end is found.
+@test "sync contract: reconcile stops at the FIRST gap, not the last (#912)" {
+  local i candidates acks result
+  for i in one two three four five; do storage_send demo alice bob "$i" >/dev/null; done
+  candidates=$(prepare_push 5)
+
+  # Acknowledge 2 and 4. Gaps at 1, 3 and 5.
+  acks=$(printf '%s\n' "$candidates" | jq -c '
+    select(.type=="sync_push_candidate" and ((.local_position|tonumber)==2 or (.local_position|tonumber)==4))
+    | {type:"sync_push_ack",local_position,id,server_seq:.local_position,disposition:"stored"}')
+  result=$(printf '%s\n' "$acks" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1)
+  # Nothing contiguous from the cursor: the first gap is position 1.
+  [ "$(printf '%s\n' "$result" | jq -r '.push_cursor')" = 0 ]
+
+  # Fill position 1. The run is now 1..2 and stops at the gap at 3 -- bounding by
+  # the LAST gap instead would carry the cursor to 4, straight over that gap.
+  acks=$(printf '%s\n' "$candidates" | jq -c '
+    select(.type=="sync_push_candidate" and (.local_position|tonumber)==1)
+    | {type:"sync_push_ack",local_position,id,server_seq:"1",disposition:"stored"}')
+  result=$(printf '%s\n' "$acks" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r '.push_cursor')" = 2 ]
+}
+
 @test "sync contract: pull reconciles echoes, imports wire IDs once, and keeps read state separate" {
   storage_send demo alice bob "outgoing" >/dev/null
   local prepared candidate ack envelope echo remote page result

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -108,6 +108,29 @@ prepare_push() {
 # first gap and the last gap are the same row -- so it cannot tell "stop at the
 # first gap" from "stop at the last one". Two gaps separate them, and that is
 # the whole correctness question for how the run's end is found.
+# An earlier revision bounded the candidate scan with 9223372036854775807 as
+# though it were infinity. It is the largest value `events.seq` can hold, so a
+# message sitting exactly there was accepted before and refused after -- a
+# changed acceptance set at one value, which a differential run over ordinary
+# fixtures never visits. The bound is now `IS NULL OR <`, which has no such
+# value; this pins that it stays that way.
+@test "sync contract: a message at the maximum seq still advances the cursor (#912)" {
+  local db candidates acks result max=9223372036854775807
+  storage_send demo alice bob one >/dev/null
+  db=$(agmsg_db_path demo)
+  # Move the second message to the top of the seq space. AUTOINCREMENT permits
+  # an explicit value, and this is the only one the old sentinel collided with.
+  storage_send demo alice bob two >/dev/null
+  sqlite3 "$db" "UPDATE events SET seq=$max WHERE body='two';"
+
+  candidates=$(prepare_push 5)
+  acks=$(printf '%s\n' "$candidates" | jq -c '
+    select(.type=="sync_push_candidate")
+    | {type:"sync_push_ack",local_position,id,server_seq:.local_position,disposition:"stored"}')
+  result=$(printf '%s\n' "$acks" | storage_sync_reconcile_push demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(printf '%s\n' "$result" | jq -r '.push_cursor')" = "$max" ]
+}
+
 @test "sync contract: reconcile stops at the FIRST gap, not the last (#912)" {
   local i candidates acks result
   for i in one two three four five; do storage_send demo alice bob "$i" >/dev/null; done


### PR DESCRIPTION
Closes #912.

## What was slow

The push cursor advances to the end of the **contiguous** acknowledged run. Finding that end asked, for each candidate `e`, whether any gap existed in `(push_cursor, e.seq]`.

That inner test named `e.seq`, so it was **correlated**: one scan of the gap set per candidate, and the work grew with the **square** of the number of candidates. On a first connect every message is a candidate, so that is the whole history squared.

## The fix

The gap set does not depend on `e`. Ask it once.

The **first** gap after the cursor bounds every contiguous run that starts there, so the answer is the largest candidate below it — two independent aggregates instead of one correlated pair.

Same answer by definition rather than by coincidence: a candidate below the first gap has no gap beneath it, and a candidate at or above it has that one.

## Measured

16,640 acknowledged messages, no gap — the old query's **worst case**, because with nothing to stop it early it must scan to the end.

| | |
|---|---|
| before | **153,560.6 ms** |
| after | **70.0 ms** |
| result | identical cursor from both |

The ratio is not the interesting part. The scaling is:

| N | old | new |
|---|---|---|
| 500 | 115.3 ms | 27 ms |
| 2,000 | 1,829.4 ms | 27 ms |
| 16,640 | 153,560.6 ms | 70 ms |

Quadratic against flat over this range. A store twice as large costs the old query four times as much.

## Review found the bound had a value it could collide with

`9223372036854775807` is not infinity — it is the largest value `events.seq` can hold. A message sitting exactly there was **accepted** by the old query (no gap beneath it, so the cursor advanced to it) and **refused** by the first revision of this one. The acceptance set changed at one value:

| | cursor |
|---|---|
| old | `9223372036854775807` |
| first revision | `1` |

The bound is now `IS NULL OR <`, which says what was meant and has no value to collide with.

That form needs the gap query's result twice, and both obvious ways of supplying it had to be **measured rather than assumed**:

| shape | result |
|---|---|
| derived table, inline | SQLite re-evaluated it per candidate — **the quadratic came straight back**, 3,268 ms against 27 ms at 2,000 rows |
| the scalar subquery written twice | fast, but the gap query then exists in two places that can drift apart |

So: a **temp table**, built once because of how it is built rather than because a planner chose to, in a statement that already creates two of them.

A differential run over ordinary fixtures never visits `seq = 2^63 - 1`, which is why 24 agreeing pairs did not catch this. The boundary now has its own test, and reverting to the sentinel reddens that test and nothing else.

## Equivalence was checked before the speed

Both queries run over the same fixtures, across gap shapes — none, first, middle, last, and several spread through the run — at two sizes and two cursor positions, plus both cursor positions at the maximum seq. **26 pairs, no disagreement**, re-run against the final form.

Then the harness was shown to be **able** to disagree: weakening the new query's bound from `<` to `<=` was caught in 4 of 4 cases. A comparison that has never reported a difference is indistinguishable from one that cannot.

## Mutations

| # | mutation | red |
|---|---|---|
| A | weaken the bound from `<` to `<=`, so the cursor steps onto the gap | "reconcile advances only the acknowledged contiguous prefix" |
| B | `MIN` → `MAX` in the gap bound, so it stops at the **last** gap | "reconcile stops at the FIRST gap, not the last" |
| C | remove the gap bound entirely | both |

**B came back green the first time.** The existing contiguous-prefix test has exactly one gap, and with one gap the first and the last are the same row — so the mutation was inert on that fixture rather than survivable in the code. The failure it hides is the serious one: bounding by the last gap carries the cursor **over** an unacknowledged message, which is what the cursor exists to prevent. A two-gap test now separates them, and B reddens it.

## Ran

`tests/test_remote_sync.bats` — 34/34 before the new tests, 36/36 with them. Not run locally: the full matrix. CI's job.

## Scope

- Only the cursor-advance statement in `storage_sync_reconcile_push`. The acknowledgement read in the same function is #927; the two touch different statements and the rebase stays with one author.
- No index was added. The rewrite removes the quadratic term; whether the remaining two aggregates want an index is a separate question with its own measurement.
