### PR TITLE
perf(sync): check a pulled wire id without a process (#908)

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -76,6 +76,13 @@ _sqlite_sync_commit_chunk() {
 # tests/test_remote_sync.bats holds this equal to _sqlite_lit byte for byte.
 _sqlite_sync_lit_into() { local q="'"; _SQLITE_SYNC_LIT="${1//$q/$q$q}"; }
 
+# The UUIDv4 wire-id shape, for [[ =~ ]]: held in a variable because that is
+# the one form every bash reads the same way -- an inline pattern with braces
+# is at the mercy of each version's quoting rules. Kept byte-identical to the
+# grep -E pattern it replaces on the per-message path (#908): checking a wire
+# id used to cost a printf and a grep per pulled message.
+_SQLITE_SYNC_WIRE_RE='^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+
 # Bulk form of _sqlite_sync_uuid4: one /dev/urandom read and builtin-only
 # formatting for `count` ids. A 1000-message catch-up page costs one fork here
 # instead of one per message.
@@ -1050,8 +1057,7 @@ storage_sync_apply_pull() {
       continue
     fi
     [ "$type" = sync_pull_message ] || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
-    printf '%s\n' "$wire" | grep -Eq \
-      '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' \
+    [[ "$wire" =~ $_SQLITE_SYNC_WIRE_RE ]] \
       || { rm -f "$sql_file"; trap - EXIT INT TERM HUP; _sqlite_sync_why; return 13; }
     outcome_ids="${outcome_ids}${outcome_ids:+,}'$wire'"
     case "$seq:$v" in *[!0-9:]*) rm -f "$sql_file"; _sqlite_sync_why; return 13 ;; esac

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -48,6 +48,28 @@ prepare_push() {
   [ "$_SQLITE_SYNC_LIT" = "a''b''''c" ]
 }
 
+@test "sync contract: apply refuses a wire id that is not a canonical UUIDv4 (#908)" {
+  # The shape check moved from `printf | grep -Eq` to `[[ =~ ]]` with the
+  # pattern in a variable; the acceptance set must not move with it. One
+  # accepted id and the near-misses: wrong version nibble, wrong variant
+  # nibble, uppercase, too short, and empty.
+  local good='{"type":"sync_pull_message","server_seq":"1","id":"550e8400-e29b-41d4-a716-446655440000","server_received_at":"2026-07-20T13:00:00.000000Z","envelope":{"v":1,"cipher":"none","key_id":null,"blob":"e30="},"status":"malformed","policy_revision":"0","local_security_revision":"0","reason":"fixture"}'
+  local page cursor='{"type":"sync_pull_cursor","next_after":"1"}'
+  page=$(printf '%s\n%s\n' "$good" "$cursor")
+  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  local bad
+  for bad in \
+    "550e8400-e29b-51d4-a716-446655440000" \
+    "550e8400-e29b-41d4-c716-446655440000" \
+    "550E8400-E29B-41D4-A716-446655440000" \
+    "550e8400-e29b-41d4-a716-44665544000" \
+    ""; do
+    page=$(printf '%s\n%s\n' "${good/550e8400-e29b-41d4-a716-446655440000/$bad}" "$cursor")
+    run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$page"
+    [ "$status" -eq 13 ]
+  done
+}
+
 @test "sync contract: prepare is re-entrant and byte-stable before reconcile" {
   storage_send demo alice bob "preserve these exact bytes" >/dev/null
   local first second


### PR DESCRIPTION
Part of #908, item (2): after #925 removed the 32 quoting forks, each pulled message still pays one `printf | grep -Eq` to check its wire id's UUIDv4 shape. That is two processes per message on the per-message path of `storage_sync_apply_pull`.

## What changes

The check becomes `[[ "$wire" =~ $_SQLITE_SYNC_WIRE_RE ]]`, with the pattern held in a variable — the one form of `=~` that every bash reads the same way (an inline pattern with braces is at the mercy of each version's quoting rules; the day #925 landed, a bash-3.2 expansion difference was exactly what CI caught, so this PR does not repeat that shape). The pattern is byte-identical to the `grep -E` pattern it replaces. Rejection now happens without a process; the accept/reject set does not move.

A new case in `tests/test_remote_sync.bats` pins that set: one canonical UUIDv4 is accepted, and the near-misses — wrong version nibble, wrong variant nibble, uppercase, one digit short, empty — are each refused with exit 13. The suite is green under bash 5 and under `/bin/bash` 3.2.

The other `grep -Eq` shape checks in the file are per call, per page, or per roster member (the same classification as #908's remaining `_sqlite_lit` sites, measured there); they are not on the per-message path and are left alone.

## Before and after, same machine, same method

`tests/perf/join-harness.sh --messages 400` (the harness on `main`), `bootstrap.apply`, two runs each:

| | ms/msg |
|---|---|
| main (`50c503f`) | 29.1 / 28.6 |
| this change | 23.6 / 23.7 |

About −5 ms per message — the `printf` and the `grep` — on top of #925's 280 → ~27. For a 17,300-message pull that is ~1.4 min off an ~8-minute bootstrap. What remains per message is the one `jq` (#908 item (3), separate change) and the SQL itself.
