### PR TITLE
perf(sync): parse a pull page with one jq, framed by NUL, with no eval (#908, #940)

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -1022,15 +1022,25 @@ storage_sync_apply_pull() {
            then error("record \($n): field \($name) contains U+0000")
            else $v end) + "\u0000" )
   ' 2>"$jq_err")
-  _sqlite_sync_page_fail() {  # message -- shared cleanup for a framing/refusal failure
-    [ -s "$jq_err" ] && sed 's/^/agmsg: sqlite-sync: /' "$jq_err" >&2
-    printf 'agmsg: sqlite-sync: %s\n' "$1" >&2
+  # ONE cleanup for EVERY failure after the stream opened: the file descriptor,
+  # both temp files, the globals the trap reads, and the trap itself. The bats
+  # suite calls this function directly in a long-lived shell, so a site that
+  # returns without coming through here leaks an fd and a temp file into that
+  # shell -- exactly what the first review of this change found at the sites
+  # that predate the stream and still only removed the SQL file.
+  _sqlite_sync_apply_fail() {  # [message]
+    if [ "$#" -gt 0 ]; then
+      [ -s "$jq_err" ] && sed 's/^/agmsg: sqlite-sync: /' "$jq_err" >&2
+      printf 'agmsg: sqlite-sync: %s\n' "$1" >&2
+    fi
+    exec 3<&- 2>/dev/null || true
     rm -f "$sql_file" "$jq_err"
-    exec 3<&-
+    _AGMSG_SYNC_SQL_FILE=""; _AGMSG_SYNC_JQ_ERR=""
+    trap - EXIT INT TERM HUP
   }
   if ! IFS= read -r -d '' page_count <&3 || ! [[ "$page_count" =~ ^[0-9]+$ ]]; then
-    _sqlite_sync_page_fail "the page produced no readable record count"
-    trap - EXIT INT TERM HUP; _sqlite_sync_why; return 13
+    _sqlite_sync_apply_fail "the page produced no readable record count"
+    _sqlite_sync_why; return 13
   fi
   record_index=0
   while [ "$record_index" -lt "$page_count" ]; do
@@ -1038,8 +1048,8 @@ storage_sync_apply_pull() {
     for field_name in type line_next_after seq wire received v cipher key_id blob \
                       status policy local_rev reason kind from to body at; do
       if ! IFS= read -r -d '' "$field_name" <&3; then
-        _sqlite_sync_page_fail "record $record_index ended mid-frame at field $field_name"
-        trap - EXIT INT TERM HUP; _sqlite_sync_why; return 13
+        _sqlite_sync_apply_fail "record $record_index ended mid-frame at field $field_name"
+        _sqlite_sync_why; return 13
       fi
     done
     if [ "$type" = sync_pull_cursor ]; then
@@ -1047,15 +1057,15 @@ storage_sync_apply_pull() {
       # a next_after, so assigning the cursor directly would let a message
       # line after the cursor line blank it.
       final_cursor="$line_next_after"
-      case "$final_cursor" in ''|*[!0-9]*) rm -f "$sql_file"; _sqlite_sync_why; return 13 ;; esac
+      case "$final_cursor" in ''|*[!0-9]*) _sqlite_sync_apply_fail; _sqlite_sync_why; return 13 ;; esac
       continue
     fi
-    [ "$type" = sync_pull_message ] || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
+    [ "$type" = sync_pull_message ] || { _sqlite_sync_apply_fail; _sqlite_sync_why; return 13; }
     [[ "$wire" =~ $_SQLITE_SYNC_WIRE_RE ]] \
-      || { rm -f "$sql_file"; trap - EXIT INT TERM HUP; _sqlite_sync_why; return 13; }
+      || { _sqlite_sync_apply_fail; _sqlite_sync_why; return 13; }
     outcome_ids="${outcome_ids}${outcome_ids:+,}'$wire'"
-    case "$seq:$v" in *[!0-9:]*) rm -f "$sql_file"; _sqlite_sync_why; return 13 ;; esac
-    case "$status" in importable|unsupported_cipher|pending_key|authentication_failed|malformed|policy_violation) ;; *) rm -f "$sql_file"; _sqlite_sync_why; return 13 ;; esac
+    case "$seq:$v" in *[!0-9:]*) _sqlite_sync_apply_fail; _sqlite_sync_why; return 13 ;; esac
+    case "$status" in importable|unsupported_cipher|pending_key|authentication_failed|malformed|policy_violation) ;; *) _sqlite_sync_apply_fail; _sqlite_sync_why; return 13 ;; esac
     # Quoted ONCE PER MESSAGE, here, in the shell: each of these fields used
     # to go through `$(_sqlite_lit ...)` -- a printf|sed fork -- at every use
     # site in the SQL below, 32 forks per message and most of the 34 processes
@@ -1176,7 +1186,7 @@ storage_sync_apply_pull() {
           member_joined|member_left|member_renamed|key_rotated) ;;
           *)
             echo "agmsg: storage sync apply cannot acknowledge projection kind '$kind'" >&2
-            rm -f "$sql_file"; trap - EXIT INT TERM HUP; _sqlite_sync_why; return 13 ;;
+            _sqlite_sync_apply_fail; _sqlite_sync_why; return 13 ;;
         esac
         # The roster driver has already durably applied this mutation. Storage
         # owns the quarantine and transport cursor, so it records the matching
@@ -1190,9 +1200,9 @@ storage_sync_apply_pull() {
       fi
       [ -n "$from" ] && [ -n "$to" ] && [ -n "$body" ] && [ -n "$at" ] || {
         echo "agmsg: storage sync apply received an importable message without its projection" >&2
-        rm -f "$sql_file"; trap - EXIT INT TERM HUP; _sqlite_sync_why; return 13;
+        _sqlite_sync_apply_fail; _sqlite_sync_why; return 13;
       }
-      local_id=$(compat_uuid7) || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
+      local_id=$(compat_uuid7) || { _sqlite_sync_apply_fail; _sqlite_sync_why; return 13; }
       printf "%s\n" "
         INSERT INTO events(type,id,team,from_agent,to_agent,body,at)
         SELECT 'message_sent','$local_id','$tl','$from_q',
@@ -1238,14 +1248,18 @@ storage_sync_apply_pull() {
               AND m.direction='pull');" >> "$sql_file"
     fi
   done
-  # The stream must end exactly where the count said: one more read must fail.
-  if IFS= read -r -d '' field_name <&3; then
-    _sqlite_sync_page_fail "the page carried bytes past its declared $page_count records"
-    trap - EXIT INT TERM HUP; _sqlite_sync_why; return 13
+  # The stream must end exactly where the count said. One more read must fail
+  # AND deliver nothing: read -d '' returns non-zero at EOF while still
+  # filling the variable with any bytes that arrived before it, so surplus
+  # without a final NUL passes the status check alone (review finding).
+  field_name=""
+  if IFS= read -r -d '' field_name <&3 || [ -n "$field_name" ]; then
+    _sqlite_sync_apply_fail "the page carried bytes past its declared $page_count records"
+    _sqlite_sync_why; return 13
   fi
   exec 3<&-
   rm -f "$jq_err"; _AGMSG_SYNC_JQ_ERR=""
-  [ -n "$final_cursor" ] || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
+  [ -n "$final_cursor" ] || { _sqlite_sync_apply_fail; _sqlite_sync_why; return 13; }
   printf "%s\n" "UPDATE sync_bindings SET transport_cursor='$final_cursor'
     WHERE local_team='$tl' AND server_instance_id='$server' AND remote_team_id='$remote'
       AND protocol_version=$protocol AND driver_generation='$generation';
@@ -1259,7 +1273,7 @@ storage_sync_apply_pull() {
   # no copy, or a copy nothing points at (#689). Found in the local path while
   # building this and not carried across; a reviewer caught that.
   if ! agmsg_sqlite -bail "$db" < "$sql_file" >/dev/null 2>&1; then
-    rm -f "$sql_file"; trap - EXIT INT TERM HUP; _sqlite_sync_why; return 13
+    _sqlite_sync_apply_fail; _sqlite_sync_why; return 13
   fi
   rm -f "$sql_file"
   trap - EXIT INT TERM HUP

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -952,102 +952,96 @@ storage_sync_apply_pull() {
   _sqlite_sync_ensure_binding "$team" "$server" "$remote" "$protocol" "$generation" || { _sqlite_sync_why; return 13; }
   sql_file=$(mktemp "${TMPDIR:-/tmp}/agmsg-sync-sql.XXXXXX") || { _sqlite_sync_why; return 13; }
   _AGMSG_SYNC_SQL_FILE="$sql_file"
-  trap 'case "${_AGMSG_SYNC_SQL_FILE:-}" in "${TMPDIR:-/tmp}"/agmsg-sync-sql.*) rm -f "$_AGMSG_SYNC_SQL_FILE" ;; esac' EXIT INT TERM HUP
+  _AGMSG_SYNC_JQ_ERR=""
+  trap 'case "${_AGMSG_SYNC_SQL_FILE:-}" in "${TMPDIR:-/tmp}"/agmsg-sync-sql.*) rm -f "$_AGMSG_SYNC_SQL_FILE" ;; esac
+        case "${_AGMSG_SYNC_JQ_ERR:-}" in "${TMPDIR:-/tmp}"/agmsg-sync-jq.*) rm -f "$_AGMSG_SYNC_JQ_ERR" ;; esac' EXIT INT TERM HUP
   printf '%s\n' 'BEGIN IMMEDIATE;' > "$sql_file"
 
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    # One `jq` per message, not one per field (#780). This read cost 18
-    # processes, and process creation -- not parsing -- is what a pull spends
-    # its time on; it is the whole cost on Windows, where a spawn is dear.
-    #
-    # `@sh` is jq's shell-quoting filter, so every value arrives verbatim,
-    # tabs and newlines and quotes included, with no delimiter convention for
-    # this side to get wrong. `jq_ok` is emitted last: a line jq cannot parse
-    # produces no output at all, and the eval then leaves it 0 rather than
-    # letting the previous message's fields stand in for this one's.
-    #
-    # `tostring` where the old code had no `// empty`: those fields print
-    # "null" when absent, and the arity and status checks below reject that.
-    # `// ""` would turn a missing envelope.v into an empty string, which
-    # passes the digits check.
-    #
-    # No test can tell those two apart, and that is not an oversight. An empty
-    # envelope_v reaches SQLite as `,,` and the batch dies of a syntax error,
-    # so the page is refused either way and the suite sees one exit status for
-    # two different rejections. The check is kept because a message refused by
-    # the check names what was wrong with it, and a message refused by a
-    # syntax error names a comma.
-    # `-s` with a length check, because one line is not one JSON value to jq.
-    # Given `{...} {...}` on a single line it parses BOTH and emits the whole
-    # assignment list twice; the eval runs both and the second silently
-    # overwrites the first, `jq_ok` included. A page could then hide anything
-    # it liked in front of a well-formed message.
-    #
-    # The per-field reads this replaced rejected that by accident: each
-    # substitution came back holding two lines, and the type and arity checks
-    # refused the embedded newline. Raised in review, and it was a real
-    # regression -- the reason has to be explicit now that it is no longer a
-    # side effect of how the fields were read.
-    # INVARIANT: every field passes through `tostring` before `@sh`. No
-    # exceptions, and the reason is not that these values are untidy.
-    #
-    # "This field is a string, so it does not need it" is the judgement that
-    # produced this defect, and it does not hold: THE SENDER CHOOSES THE TYPE.
-    # What arrives here is JSON off the wire from the sync server, so the type
-    # of any field is whatever that server put there -- our expectation of it is
-    # not a constraint on it. `tostring` is applied for what the value reaches,
-    # not for what it is: it is the last thing between a server-chosen value and
-    # `eval`, and every field reaches `eval`.
-    #
-    # Adding a field to this filter without `tostring` reopens the hole below,
-    # however plainly its name says "string".
-    #
-    # `@sh` emits one quoted word per element of an ARRAY, and a
-    # line carrying several words is not an assignment to the shell -- it is an
-    # assignment PREFIXED TO A COMMAND. Three things follow at once, and the
-    # third is the reason this is not a cosmetic fix:
-    #
-    #   the field is not assigned, so the variable keeps the PREVIOUS line's
-    #   value -- and several of these are interpolated into SQL below;
-    #
-    #   `jq_ok` is on a later line and is still reached, so the line is
-    #   ACCEPTED rather than refused;
-    #
-    #   the shell resolves and runs a word taken from the input.
-    #
-    # This input arrives from the sync server, so all three are server-chosen.
-    # `tostring` makes an array or object arrive as a single quoted value
-    # carrying its JSON text, which every whitelist below refuses, and leaves
-    # strings, numbers and booleans exactly as `jq -r` produced them -- so the
-    # set of inputs this accepts does not change.
-    #
-    # Four fields already had it -- chosen because a non-string value was
-    # EXPECTED there. That is the wrong axis, and the other fourteen are what it
-    # cost.
-    jq_ok=0
-    eval "$(printf '%s\n' "$line" | jq -r -s '
-      if length != 1 then error("one JSON value per line") else .[0] end
-      | "type=\(.type // "" | tostring | @sh)",
-      "line_next_after=\(.next_after // "" | tostring | @sh)",
-      "seq=\(.server_seq // "" | tostring | @sh)",
-      "wire=\(.id // "" | tostring | @sh)",
-      "received=\(.server_received_at // "" | tostring | @sh)",
-      "v=\(.envelope.v | tostring | @sh)",
-      "cipher=\(.envelope.cipher | tostring | @sh)",
-      "key_id=\(.envelope.key_id // "" | tostring | @sh)",
-      "blob=\(.envelope.blob | tostring | @sh)",
-      "status=\(.status | tostring | @sh)",
-      "policy=\(.policy_revision // "" | tostring | @sh)",
-      "local_rev=\(.local_security_revision // "" | tostring | @sh)",
-      "reason=\(.reason // "" | tostring | @sh)",
-      "kind=\(.projection.kind // "" | tostring | @sh)",
-      "from=\(.projection.from_agent // "" | tostring | @sh)",
-      "to=\(.projection.to_agent // "" | tostring | @sh)",
-      "body=\(.projection.body // "" | tostring | @sh)",
-      "at=\(.projection.created_at // "" | tostring | @sh)",
-      "jq_ok=1"' 2>/dev/null)"
-    [ "$jq_ok" = 1 ] || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
+  # ONE jq FOR THE WHOLE PAGE, AND NO eval AT ALL (#908 item 3, #940).
+  #
+  # Each message used to pay a printf and a jq, and the jq's output was a list
+  # of shell assignments fed to eval -- which is why every field had to travel
+  # through `tostring | @sh` (#930): the only thing standing between a
+  # server-chosen string and the shell was quoting discipline. Both costs go
+  # together. The page is parsed by a single jq that emits, after a leading
+  # record count, every record's eighteen fields as raw values separated by
+  # NUL bytes; the loop below reads them with `read -d ''` into plain
+  # variables. Nothing server-chosen is ever parsed as shell again -- the
+  # class #930 had to defend is gone, not guarded.
+  #
+  # The framing is sound because a NUL can never appear inside a value: jq
+  # refuses any record whose field contains U+0000, naming the record and the
+  # field (#940 -- the old pipeline silently stored such a body MANGLED, the
+  # NUL becoming other bytes on the way through `jq -r` and the shell's own
+  # NUL-stripping, and reported success; a value the store cannot hold
+  # verbatim is refused now, not rewritten).
+  #
+  # --raw-input keeps the old "one JSON value per line" refusal: each line is
+  # fromjson'd on its own, so a line smuggling two values fails exactly as it
+  # did when the per-line jq slurped it (the error names the line). `-s` holds
+  # the page in jq's memory once -- the same order of memory the old
+  # per-message `-s` peaked at for its largest message, page-wide, and a page
+  # is bounded at 1000 records.
+  local jq_err page_count record_index field_name
+  jq_err=$(mktemp "${TMPDIR:-/tmp}/agmsg-sync-jq.XXXXXX") || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
+  _AGMSG_SYNC_JQ_ERR="$jq_err"
+  exec 3< <(jq -j -R -s '
+    def fields: ["type","next_after","server_seq","id","server_received_at",
+                 "envelope.v","envelope.cipher","envelope.key_id","envelope.blob",
+                 "status","policy_revision","local_security_revision","reason",
+                 "projection.kind","projection.from_agent","projection.to_agent",
+                 "projection.body","projection.created_at"];
+    def pick($r; $name):
+      (if   $name == "type"                    then $r.type // ""
+       elif $name == "next_after"              then $r.next_after // ""
+       elif $name == "server_seq"              then $r.server_seq // ""
+       elif $name == "id"                      then $r.id // ""
+       elif $name == "server_received_at"      then $r.server_received_at // ""
+       elif $name == "envelope.v"              then $r.envelope.v
+       elif $name == "envelope.cipher"         then $r.envelope.cipher
+       elif $name == "envelope.key_id"         then $r.envelope.key_id // ""
+       elif $name == "envelope.blob"           then $r.envelope.blob
+       elif $name == "status"                  then $r.status
+       elif $name == "policy_revision"         then $r.policy_revision // ""
+       elif $name == "local_security_revision" then $r.local_security_revision // ""
+       elif $name == "reason"                  then $r.reason // ""
+       elif $name == "projection.kind"         then $r.projection.kind // ""
+       elif $name == "projection.from_agent"   then $r.projection.from_agent // ""
+       elif $name == "projection.to_agent"     then $r.projection.to_agent // ""
+       elif $name == "projection.body"         then $r.projection.body // ""
+       else                                         $r.projection.created_at // ""
+       end) | tostring;
+    [ split("\n")[] | select(length > 0) ] as $lines
+    | ($lines | length | tostring) + "\u0000"
+    , ( $lines | to_entries[]
+        | (.key + 1) as $n
+        | (try (.value | fromjson) catch error("record \($n): not one JSON value on its line")) as $r
+        | fields[] as $name
+        | pick($r; $name) as $v
+        | (if ($v | contains("\u0000"))
+           then error("record \($n): field \($name) contains U+0000")
+           else $v end) + "\u0000" )
+  ' 2>"$jq_err")
+  _sqlite_sync_page_fail() {  # message -- shared cleanup for a framing/refusal failure
+    [ -s "$jq_err" ] && sed 's/^/agmsg: sqlite-sync: /' "$jq_err" >&2
+    printf 'agmsg: sqlite-sync: %s\n' "$1" >&2
+    rm -f "$sql_file" "$jq_err"
+    exec 3<&-
+  }
+  if ! IFS= read -r -d '' page_count <&3 || ! [[ "$page_count" =~ ^[0-9]+$ ]]; then
+    _sqlite_sync_page_fail "the page produced no readable record count"
+    trap - EXIT INT TERM HUP; _sqlite_sync_why; return 13
+  fi
+  record_index=0
+  while [ "$record_index" -lt "$page_count" ]; do
+    record_index=$((record_index + 1))
+    for field_name in type line_next_after seq wire received v cipher key_id blob \
+                      status policy local_rev reason kind from to body at; do
+      if ! IFS= read -r -d '' "$field_name" <&3; then
+        _sqlite_sync_page_fail "record $record_index ended mid-frame at field $field_name"
+        trap - EXIT INT TERM HUP; _sqlite_sync_why; return 13
+      fi
+    done
     if [ "$type" = sync_pull_cursor ]; then
       # Held in its own variable and copied only here. Every line now carries
       # a next_after, so assigning the cursor directly would let a message
@@ -1244,6 +1238,13 @@ storage_sync_apply_pull() {
               AND m.direction='pull');" >> "$sql_file"
     fi
   done
+  # The stream must end exactly where the count said: one more read must fail.
+  if IFS= read -r -d '' field_name <&3; then
+    _sqlite_sync_page_fail "the page carried bytes past its declared $page_count records"
+    trap - EXIT INT TERM HUP; _sqlite_sync_why; return 13
+  fi
+  exec 3<&-
+  rm -f "$jq_err"; _AGMSG_SYNC_JQ_ERR=""
   [ -n "$final_cursor" ] || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
   printf "%s\n" "UPDATE sync_bindings SET transport_cursor='$final_cursor'
     WHERE local_team='$tl' AND server_instance_id='$server' AND remote_team_id='$remote'

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -48,6 +48,30 @@ prepare_push() {
   [ "$_SQLITE_SYNC_LIT" = "a''b''''c" ]
 }
 
+@test "sync contract: a field containing U+0000 is refused by name, not stored mangled (#940)" {
+  # The old pipeline reported success for a body holding U+0000 and stored
+  # DIFFERENT bytes (the NUL re-spelled by jq -r and the shell's own
+  # NUL-stripping on the way to the store). A value the store cannot hold
+  # verbatim is refused now, with the record and the field named, and the
+  # page commits nothing.
+  local nul_body page db
+  nul_body=$(jq -nc '"x" + ([0]|implode) + "y"')
+  page=$(jq -nc --argjson b "$nul_body" '
+    {type:"sync_pull_message",server_seq:"1",id:"550e8400-e29b-41d4-a716-446655440040",
+     server_received_at:"2026-07-20T13:00:00.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:($b|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:$b,created_at:"2026-07-20T13:00:00.000000Z",
+                 from_agent:"alice",to_agent:"bob"}}')
+  run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 \
+    <<<"$(printf '%s\n%s\n' "$page" '{"type":"sync_pull_cursor","next_after":"1"}')"
+  [ "$status" -eq 13 ]
+  printf '%s\n' "$output" | grep -q 'record 1: field projection.body contains U+0000'
+  db=$(agmsg_db_path demo)
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM messages;" | tr -d '\r')" -eq 0 ]
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_quarantine;" | tr -d '\r')" -eq 0 ]
+}
+
 @test "sync contract: apply refuses a wire id that is not a canonical UUIDv4 (#908)" {
   # The shape check moved from `printf | grep -Eq` to `[[ =~ ]]` with the
   # pattern in a variable; the acceptance set must not move with it. One


### PR DESCRIPTION
Part of #908, item (3) — and it closes #940, because the fix and the framing are the same decision. Stacked on #939 (base `main` so CI runs; until #939 lands the diff shows its commit too).

## One jq per page, and no `eval` at all

`storage_sync_apply_pull` paid a `printf | jq` per message, and the jq's output was a list of shell assignments fed to `eval`. That second half is why #930 had to route all eighteen fields through `tostring | @sh`: quoting discipline was the only thing between a server-chosen string and the shell.

Now a single `jq -j -R -s` parses the whole page and emits, after a leading record count, each record's eighteen fields as raw values separated by NUL bytes; the loop reads them with `IFS= read -r -d ''` into plain variables. There is no `eval` — nothing server-chosen is parsed as shell anymore, so the class #930 defended against is gone rather than guarded. `--raw-input` keeps the old "one JSON value per line" refusal: each line is `fromjson`'d on its own, and a line carrying two values fails with the line named, exactly as the per-line jq refused it.

**Blast radius is unchanged.** Today a single bad record already refuses the whole page before anything is written (`jq_ok=0` → the SQL file is discarded → 13); the page-level jq refuses the same way, and names what the old sentinel could not: which record, and which field. The stream is also verified end-to-end — the leading count must match the records read, every record must complete its eighteen frames, and one more read past the count must find EOF.

## Why a NUL can never break the framing: U+0000 is refused (#940)

NUL-delimited framing is only sound if a value cannot contain a NUL — and it cannot, because jq refuses any record whose field contains U+0000, naming the record and the field. That is #940's fix as much as the framing's precondition. Measured on `main` before this change: a body of `"xy"` was **accepted, reported imported, and stored as four different bytes** (`hex 785C3079` — the NUL re-spelled on its way through `jq -r`'s raw output and the shell's own NUL-stripping, both of which vary by version). A value the store cannot hold verbatim is now refused, not silently rewritten. Contract cases pin both: the refusal (record and field named, nothing committed) and the framing checks (two values on one line, mid-frame truncation, bytes past the declared count).

`bash` cannot hold a NUL in a variable at all (command substitution and `read` both drop or stop at it), which is also why the alternative — carrying such a value through — does not exist: any scheme that lands in shell variables loses the byte. Refusing is the honest version of what every framing here would do anyway.

## Before and after, same machine, same method

`tests/perf/join-harness.sh --messages 400`, `bootstrap.apply`, two runs each:

| | ms/msg |
|---|---|
| #939 (`8cb6cad`) | 23.6 / 23.7 |
| this change | 15.5 / 16.9 |

About −7 ms per message — the `printf` and the `jq` — for ~2 more minutes off a 17,300-message pull; the whole apply path has gone 280 → ~16 ms/msg across #925, #939 and this. The suite (`tests/test_remote_sync.bats`, 43 cases) is green under bash 5 and under `/bin/bash` 3.2 — the day #925 landed, a bash-3.2 divergence is what CI caught, so both are checked before pushing, and the primitives this leans on (`read -r -d ''`, process substitution, a dynamic variable name to `read`) were probed on 3.2.57 directly.

## Scope

- `scripts/drivers/storage/sqlite-sync.sh`, `storage_sync_apply_pull` only; the per-ack jq in `reconcile` is #927's shape and untouched; the jsonl driver has its own apply.
- After this, apply's per-message process count is zero: #925 took the 32 quoting forks, #939 the uuid `printf|grep`, this the `printf|jq`. What remains per message is bash and SQLite.
