### PR TITLE
fix(codex-bridge-launcher): reap a same-(project,role) orphan before spawning (#906 link 2)

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -679,11 +679,10 @@ EOF
 
   # The role-session record is the sole thread authority (#150 phase 2/#350).
 
-  # Reset each tick: a mismatched-live bridge sets these to the pid it must kill
-  # AND that pid's start token at the moment we chose it, so the deferred kill can
-  # prove the pid is still that same process (below). Killed only once we commit to
-  # spawning the replacement.
-  need_kill=""; need_kill_token=""
+  # Reset each tick: a mismatched-live bridge (bound to a stale thread/app-server)
+  # sets this to its pid, purely as a flag that we must NOT spawn beside it. We do
+  # not kill it from here -- see the guard before the spawn below.
+  need_kill=""
   if [ -f "$pidfile" ]; then
     bridge_pid=""
     IFS= read -r bridge_pid < "$pidfile" 2>/dev/null || true
@@ -711,9 +710,8 @@ EOF
       # the gates below would let a throttled or proof-less tick leave the binding
       # wiped and un-rewritten, so a later launcher has nothing to rebind from
       # (#350). Defer every teardown to the point we are actually committed to
-      # spawning the replacement.
+      # replacement -- and we do not kill it directly at all (below).
       need_kill="$bridge_pid"
-      need_kill_token="$(_start_token "$bridge_pid" 2>/dev/null || true)"
     fi
   fi
 
@@ -734,19 +732,22 @@ EOF
     continue
   fi
 
-  # Committed to spawning now: retire the old bridge (if any) and its stale
-  # records, immediately before writing the new ones, so the wipe and the rewrite
-  # are not separated by a gate that can bail out between them. The kill needs the
-  # same proof of IDENTITY as the reaper: the gates above may have taken seconds,
-  # in which the old pid could have exited and been reused, so kill ONLY when the
-  # pid's start token still reads and matches the one we stored when we chose it --
-  # unreadable or changed means a different (or gone) process, so do nothing.
-  if [ -n "$need_kill" ] && [ -n "$need_kill_token" ]; then
-    _nk_now="$(_start_token "$need_kill" 2>/dev/null || true)"
-    if [ -n "$_nk_now" ] && [ "$_nk_now" = "$need_kill_token" ]; then
-      kill "$need_kill" 2>/dev/null || true
-    fi
+  # A mismatched-live bridge must be gone before we spawn its replacement, or we
+  # double-start a writer (#935). We do NOT kill it here: the pidfile holds a bare
+  # pid with no identity token, so a direct kill could land on a reused pid. The
+  # lease-based reaper above is the ONLY reuse-safe path that may signal it, and it
+  # kills same-identity leased bridges (and, when it cannot prove they exited,
+  # returns non-zero so we already bailed). If the pid is somehow STILL alive here
+  # -- the reaper spared a legacy bridge with no lease, or it is mid-shutdown --
+  # do nothing this tick: leave the binding intact and retry, rather than spawn
+  # beside it. A lease-less bridge that never dies simply lingers (orphan survival
+  # is acceptable; a wrong-kill or a double-start is not).
+  if [ -n "$need_kill" ] && _agmsg_pid_alive "$need_kill"; then
+    poll_sleep
+    continue
   fi
+  # Committed to spawning now: clear the stale records immediately before writing
+  # the new ones, so no gate can bail out between the wipe and the rewrite.
   rm -f "$pidfile" "$appserver_file" "$thread_file"
 
   nohup "${bridge_run[@]}" \

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -506,20 +506,24 @@ _reap_orphan_bridges() {
   # positive proof, and on any observation failure we do NOTHING -- the timeout
   # bounds the wait, a failed read is never re-read as state:
   #   kill  only with proof of IDENTITY  -- the start token READ and MATCHED (above)
-  #   spawn only with proof of EXIT      -- the pid proven ABSENT, or its token read
-  #                                         and now naming a DIFFERENT process (below)
-  # Wait for each killed pid to exit. Proof of exit is EITHER _agmsg_pid_alive_local
-  # returning absent (the sanctioned helper -- EPERM-aware, ps-cross-checked, erring
-  # to "alive" on any ambiguity, so a false return is real absence not a transient
-  # miss; it is also the one liveness path allowed to touch kill -0) OR a start token
-  # that reads and DIFFERS (a replacement). A token we merely could not read proves
-  # nothing -- keep waiting. No proof of exit within the budget: return 1 and do NOT
-  # spawn, so a bridge still holding the thread as writer is never double-started (#935).
+  #   spawn only with proof of EXIT      -- the killed pid's token READ and now names
+  #                                         a DIFFERENT process (a replacement, below)
+  # Wait for each killed pid to exit. The ONLY positive proof of exit we can trust
+  # here is a start token that reads and DIFFERS: the pid now hosts another process,
+  # so the one we killed is gone. Everything else keeps waiting -- a token that reads
+  # UNCHANGED (still alive), and, deliberately, a token we could NOT read (which
+  # proves nothing: /proc or ps can fail transiently). We do NOT consult
+  # _agmsg_pid_alive_local: its false is not a trustworthy absence proof -- a
+  # transient ps failure there returns "gone" (missing pipefail, #954), the exact
+  # observation-as-state trap this loop exists to avoid. So a normal exit falls
+  # through to the timeout and returns 1: we do NOT spawn this pass, so a bridge
+  # still holding the thread as writer is never double-started (#935). The cost is
+  # not a stall but one cycle -- the next pass no longer sees the exited pid in
+  # pgrep and spawns then.
   while IFS="$TAB" read -r pid lstartsrc lstart; do
     [ -n "$pid" ] || continue
     waited=0
     while :; do
-      _agmsg_pid_alive_local "$pid" || break
       cur="$(_start_token "$pid")"
       if [ -n "$cur" ] && [ "$cur" != "$lstartsrc	$lstart" ]; then break; fi
       if [ "$waited" -ge "$_REAP_WAIT_TICKS" ]; then return 1; fi

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -679,6 +679,9 @@ EOF
 
   # The role-session record is the sole thread authority (#150 phase 2/#350).
 
+  # Reset each tick: a mismatched-live bridge sets this to the pid it must kill,
+  # but only once we commit to spawning its replacement (see below).
+  need_kill=""
   if [ -f "$pidfile" ]; then
     bridge_pid=""
     IFS= read -r bridge_pid < "$pidfile" 2>/dev/null || true
@@ -701,10 +704,13 @@ EOF
         poll_sleep
         continue
       fi
-      kill "$bridge_pid" 2>/dev/null || true
-      rm -f "$pidfile" "$appserver_file" "$thread_file"
-    else
-      rm -f "$pidfile" "$appserver_file" "$thread_file"
+      # A mismatched live bridge must be retired and rebound -- but NOT here.
+      # Tearing down (kill + wiping the recorded pidfile/app-server/thread) before
+      # the gates below would let a throttled or proof-less tick leave the binding
+      # wiped and un-rewritten, so a later launcher has nothing to rebind from
+      # (#350). Defer every teardown to the point we are actually committed to
+      # spawning the replacement.
+      need_kill="$bridge_pid"
     fi
   fi
 
@@ -714,6 +720,8 @@ EOF
   # In a set +e subshell: these two do a lot of probing whose non-zero results
   # (no such process, an empty match, a lock already held) are normal, and the
   # launcher runs under set -euo pipefail where a bare non-zero would exit it.
+  # Either returning non-zero means "not this tick" -- and because no teardown has
+  # run yet, the existing binding is left intact for the next tick / a rebind.
   if ! ( set +e; _spawn_rate_ok ); then
     poll_sleep
     continue
@@ -722,6 +730,12 @@ EOF
     poll_sleep
     continue
   fi
+
+  # Committed to spawning now: retire the old bridge (if any) and its stale
+  # records, immediately before writing the new ones, so the wipe and the rewrite
+  # are not separated by a gate that can bail out between them.
+  if [ -n "$need_kill" ]; then kill "$need_kill" 2>/dev/null || true; fi
+  rm -f "$pidfile" "$appserver_file" "$thread_file"
 
   nohup "${bridge_run[@]}" \
     --project "$PROJECT" \

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -374,11 +374,19 @@ while IFS="$TAB" read -r candidate_team candidate_name; do
   bridge_pair_values+=("$candidate_team"$'\t'"$candidate_name")
 done <<< "$ids"
 # This launcher's identity, hashed the same way the bridge hashes its lease
-# (scripts/drivers/types/codex/codex-bridge.js writeLease): SHA-1 of the sorted
-# "team<TAB>name" set joined by newlines. PROJECT_HASH (above) is the project
-# half. Comparing hashes -- never raw values -- is what keeps a separator inside
-# a path or role from being misread as identity (#943).
-BRIDGE_PAIRS_HASH="$(printf '%s' "$(printf '%s\n' "${bridge_pair_values[@]}" | LC_ALL=C sort)" | agmsg_sha1)"
+# (scripts/drivers/types/codex/codex-bridge.js writeLease): SHA-1 of the ASCII-
+# sorted per-pair SHA-1 hashes, joined by newlines. Hashing each pair FIRST means
+# the set order is decided by sorting hex (pure ASCII), so a byte sort here and a
+# code-unit sort in JS agree even for non-ASCII team/name -- the locale/Unicode
+# sort-order gap a raw-value sort would leave. PROJECT_HASH (above) is the project
+# half. Comparing hashes -- never raw values -- is what keeps a separator inside a
+# path or role from being misread as identity (#943).
+_pair_hashes=""
+for _pv in "${bridge_pair_values[@]}"; do
+  _pair_hashes="$_pair_hashes$(printf '%s' "$_pv" | agmsg_sha1)
+"
+done
+BRIDGE_PAIRS_HASH="$(printf '%s' "$(printf '%s' "$_pair_hashes" | LC_ALL=C sort | sed '/^$/d')" | agmsg_sha1)"
 
 
 # This launcher's full identity as one key: sha1 of the project hash and the
@@ -511,44 +519,56 @@ EOF
 # A ceiling on bridge spawns for this identity: at most _SPAWN_MAX in _SPAWN_WINDOW
 # seconds. The reap converges duplicates to one, but a bridge that cannot stay up
 # (a launcher dying before it records the pidfile) would reap-and-respawn every
-# tick; this bounds that churn. The read-modify-write is under a per-identity
-# mkdir lock (project + pair-set, not role alone) so concurrent launchers cannot
-# each read the same count and overshoot.
+# tick; this bounds that churn. The read-modify-write runs under a per-identity
+# lock (project + pair-set, not role alone) so concurrent launchers cannot each
+# read the same count and overshoot.
 _SPAWN_WINDOW=30
 _SPAWN_MAX=5
-# A lock a crashed launcher left behind is reclaimed only once it is this old. The
-# critical section is a sub-second read-modify-write, so a much older lock is dead;
-# the window is wide enough that a live holder is never reclaimed out from under.
-_SPAWN_LOCK_STALE=30
 _spawn_rate_ok() {
   local stamps="$RUN_DIR/codex-bridge-rate.$IDENTITY_HASH.spawns"
   local lock="$stamps.lock"
-  local now cutoff kept="" t n tries=0 age m
-  # mkdir is atomic: exactly one launcher holds the lock. If we cannot take it,
-  # another launcher for THIS identity is reserving right now -- the concurrent
-  # spawn we exist to bound -- so we THROTTLE (return 1, do not spawn) rather than
-  # proceed lock-free and let both overshoot. The only exception is a lock left by
-  # a crash, reclaimed once provably stale.
-  while ! mkdir "$lock" 2>/dev/null; do
+  local myhost mytok owner ownhost ownpid ownrest tmp acquired=0 tries=0
+  local now cutoff kept="" t n
+  myhost="$(hostname 2>/dev/null)"
+  [ -n "$myhost" ] || return 1
+  # Our own identity as the lock owner: host, pid, and lossless-where-possible
+  # start token. $$ is the launcher (subshells do not change it), the process a
+  # reclaimer must prove is gone. If we cannot even name ourselves, fail closed.
+  mytok="$(_start_token "$$")" || return 1
+  tmp="$stamps.mine.$$"
+  printf '%s	%s	%s
+' "$myhost" "$$" "$mytok" > "$tmp" || { rm -f "$tmp" 2>/dev/null || true; return 1; }
+  # ln() is an atomic exclusive create: it fails if $lock already exists, and the
+  # inode already holds the owner line, so a reader never sees an empty lock (the
+  # gap an mkdir-then-write leaves). Exactly one launcher links it.
+  while :; do
+    if ln "$tmp" "$lock" 2>/dev/null; then acquired=1; break; fi
     tries=$((tries + 1))
     if [ "$tries" -ge 50 ]; then
-      # GNU (-c) first: on BSD/macOS `stat -c` exits non-zero and falls through
-      # to `-f`; ordered the other way, Linux `stat -f %m` can exit 0 with garbage
-      # and the real mtime is never read, so a crashed lock is never reclaimed.
-      m="$(stat -c %Y "$lock" 2>/dev/null || stat -f %m "$lock" 2>/dev/null)"
-      now="$(date +%s)"
-      case "$m" in ''|*[!0-9]*) return 1 ;; esac
-      age=$((now - m))
-      if [ "$age" -ge "$_SPAWN_LOCK_STALE" ]; then
-        rmdir "$lock" 2>/dev/null || true
-        tries=0
-        continue
+      # Reclaim ONLY a lock whose owner we can prove is gone, and only on our own
+      # host. Read host<TAB>pid<TAB>src<TAB>token; a foreign host, a malformed or
+      # empty owner, or an owner still alive with the SAME start token (a mere
+      # stall -- SIGSTOP, scheduler, NFS -- is not death) all THROTTLE. A pid that
+      # is gone, or recycled (start token changed), is reclaimable.
+      owner="$(cat "$lock" 2>/dev/null)"
+      [ -n "$owner" ] || { rm -f "$tmp" 2>/dev/null || true; return 1; }
+      IFS="$TAB" read -r ownhost ownpid ownrest <<EOF
+$owner
+EOF
+      [ "$ownhost" = "$myhost" ] || { rm -f "$tmp" 2>/dev/null || true; return 1; }
+      case "$ownpid" in ''|*[!0-9]*) rm -f "$tmp" 2>/dev/null || true; return 1 ;; esac
+      if kill -0 "$ownpid" 2>/dev/null && [ "$(_start_token "$ownpid" 2>/dev/null)" = "$ownrest" ]; then
+        rm -f "$tmp" 2>/dev/null || true; return 1
       fi
-      return 1
+      rm -f "$lock" 2>/dev/null || true
+      tries=0
+      continue
     fi
     sleep 0.02
   done
-  # --- critical section (we own the lock; only we mutate stamps and rmdir) ---
+  rm -f "$tmp" 2>/dev/null || true
+  [ "$acquired" = 1 ] || return 1
+  # --- critical section: we hold $lock; only we mutate $stamps and release it ---
   now="$(date +%s)"
   cutoff=$((now - _SPAWN_WINDOW))
   if [ -f "$stamps" ]; then
@@ -561,11 +581,24 @@ _spawn_rate_ok() {
   n=0
   if [ -n "$kept" ]; then n=$(printf '%s' "$kept" | grep -c .); fi
   if [ "$n" -ge "$_SPAWN_MAX" ]; then
-    rmdir "$lock" 2>/dev/null || true
+    rm -f "$lock" 2>/dev/null || true
     return 1
   fi
-  printf '%s%s\n' "$kept" "$now" > "$stamps"
-  rmdir "$lock" 2>/dev/null || true
+  # Reserve atomically: write the new stamp set to a temp and rename it over the
+  # file. A partial/failed write must NOT count as a reservation, so on any write
+  # or rename failure we release the lock and fail closed (return 1) instead of
+  # spawning unreserved; rename also keeps a crash mid-write from truncating the
+  # existing stamps to nothing.
+  if ! printf '%s%s
+' "$kept" "$now" > "$stamps.tmp.$$"; then
+    rm -f "$stamps.tmp.$$" "$lock" 2>/dev/null || true
+    return 1
+  fi
+  if ! mv "$stamps.tmp.$$" "$stamps"; then
+    rm -f "$stamps.tmp.$$" "$lock" 2>/dev/null || true
+    return 1
+  fi
+  rm -f "$lock" 2>/dev/null || true
   return 0
 }
 pidfile="$RUN_DIR/codex-bridge.$bridge_key.pid"

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -519,86 +519,45 @@ EOF
 # A ceiling on bridge spawns for this identity: at most _SPAWN_MAX in _SPAWN_WINDOW
 # seconds. The reap converges duplicates to one, but a bridge that cannot stay up
 # (a launcher dying before it records the pidfile) would reap-and-respawn every
-# tick; this bounds that churn. The read-modify-write runs under a per-identity
-# lock (project + pair-set, not role alone) so concurrent launchers cannot each
-# read the same count and overshoot.
+# tick; this bounds that churn.
+#
+# Reservations are self-expiring marker FILES, not a shared lock. A lock has to be
+# reclaimed when its holder dies, and every read->decide->reclaim scheme races
+# (an owner check cannot be made atomic with the unlink -- ABA). So instead each
+# spawn creates its own uniquely named marker carrying its timestamp IN THE NAME;
+# the count is just how many unexpired markers exist. Nothing is ever reclaimed:
+# a crashed launcher's marker simply ages out of the window and any later pass
+# prunes it. Reserve-then-count means a concurrent pair both count each other and
+# both back off, so the cap is never exceeded (it may briefly under-count, which
+# for a coarse throttle is the safe direction).
 _SPAWN_WINDOW=30
 _SPAWN_MAX=5
 _spawn_rate_ok() {
-  local stamps="$RUN_DIR/codex-bridge-rate.$IDENTITY_HASH.spawns"
-  local lock="$stamps.lock"
-  local myhost mytok owner ownhost ownpid ownrest tmp acquired=0 tries=0
-  local now cutoff kept="" t n
-  myhost="$(hostname 2>/dev/null)"
-  [ -n "$myhost" ] || return 1
-  # Our own identity as the lock owner: host, pid, and lossless-where-possible
-  # start token. $$ is the launcher (subshells do not change it), the process a
-  # reclaimer must prove is gone. If we cannot even name ourselves, fail closed.
-  mytok="$(_start_token "$$")" || return 1
-  tmp="$stamps.mine.$$"
-  printf '%s	%s	%s
-' "$myhost" "$$" "$mytok" > "$tmp" || { rm -f "$tmp" 2>/dev/null || true; return 1; }
-  # ln() is an atomic exclusive create: it fails if $lock already exists, and the
-  # inode already holds the owner line, so a reader never sees an empty lock (the
-  # gap an mkdir-then-write leaves). Exactly one launcher links it.
-  while :; do
-    if ln "$tmp" "$lock" 2>/dev/null; then acquired=1; break; fi
-    tries=$((tries + 1))
-    if [ "$tries" -ge 50 ]; then
-      # Reclaim ONLY a lock whose owner we can prove is gone, and only on our own
-      # host. Read host<TAB>pid<TAB>src<TAB>token; a foreign host, a malformed or
-      # empty owner, or an owner still alive with the SAME start token (a mere
-      # stall -- SIGSTOP, scheduler, NFS -- is not death) all THROTTLE. A pid that
-      # is gone, or recycled (start token changed), is reclaimable.
-      owner="$(cat "$lock" 2>/dev/null)"
-      [ -n "$owner" ] || { rm -f "$tmp" 2>/dev/null || true; return 1; }
-      IFS="$TAB" read -r ownhost ownpid ownrest <<EOF
-$owner
-EOF
-      [ "$ownhost" = "$myhost" ] || { rm -f "$tmp" 2>/dev/null || true; return 1; }
-      case "$ownpid" in ''|*[!0-9]*) rm -f "$tmp" 2>/dev/null || true; return 1 ;; esac
-      if kill -0 "$ownpid" 2>/dev/null && [ "$(_start_token "$ownpid" 2>/dev/null)" = "$ownrest" ]; then
-        rm -f "$tmp" 2>/dev/null || true; return 1
-      fi
-      rm -f "$lock" 2>/dev/null || true
-      tries=0
-      continue
-    fi
-    sleep 0.02
-  done
-  rm -f "$tmp" 2>/dev/null || true
-  [ "$acquired" = 1 ] || return 1
-  # --- critical section: we hold $lock; only we mutate $stamps and release it ---
+  local prefix="codex-bridge-rate.$IDENTITY_HASH."
+  local now cutoff mine f base ts n=0
   now="$(date +%s)"
+  case "$now" in ''|*[!0-9]*) return 1 ;; esac
   cutoff=$((now - _SPAWN_WINDOW))
-  if [ -f "$stamps" ]; then
-    while IFS= read -r t; do
-      case "$t" in ''|*[!0-9]*) continue ;; esac
-      if [ "$t" -ge "$cutoff" ]; then kept="$kept$t
-"; fi
-    done < "$stamps"
-  fi
-  n=0
-  if [ -n "$kept" ]; then n=$(printf '%s' "$kept" | grep -c .); fi
-  if [ "$n" -ge "$_SPAWN_MAX" ]; then
-    rm -f "$lock" 2>/dev/null || true
+  # Reserve: create MY marker with an exclusive (noclobber) create so two
+  # launchers never share one name. The timestamp lives in the name, so the file
+  # is empty and there is no create-then-write window for a counter to misread.
+  mine="$RUN_DIR/${prefix}${now}.$$.${RANDOM}${RANDOM}"
+  ( set -o noclobber; : > "$mine" ) 2>/dev/null || return 1
+  # Count unexpired markers (mine included), pruning ones that have aged out. The
+  # timestamp is read from the NAME, never the contents.
+  for f in "$RUN_DIR/$prefix"*; do
+    [ -e "$f" ] || continue
+    base="${f##*/}"
+    ts="${base#"$prefix"}"; ts="${ts%%.*}"
+    case "$ts" in ''|*[!0-9]*) continue ;; esac
+    if [ "$ts" -lt "$cutoff" ]; then rm -f "$f" 2>/dev/null || true; continue; fi
+    n=$((n + 1))
+  done
+  # Over the cap: roll back my reservation and throttle.
+  if [ "$n" -gt "$_SPAWN_MAX" ]; then
+    rm -f "$mine" 2>/dev/null || true
     return 1
   fi
-  # Reserve atomically: write the new stamp set to a temp and rename it over the
-  # file. A partial/failed write must NOT count as a reservation, so on any write
-  # or rename failure we release the lock and fail closed (return 1) instead of
-  # spawning unreserved; rename also keeps a crash mid-write from truncating the
-  # existing stamps to nothing.
-  if ! printf '%s%s
-' "$kept" "$now" > "$stamps.tmp.$$"; then
-    rm -f "$stamps.tmp.$$" "$lock" 2>/dev/null || true
-    return 1
-  fi
-  if ! mv "$stamps.tmp.$$" "$stamps"; then
-    rm -f "$stamps.tmp.$$" "$lock" 2>/dev/null || true
-    return 1
-  fi
-  rm -f "$lock" 2>/dev/null || true
   return 0
 }
 pidfile="$RUN_DIR/codex-bridge.$bridge_key.pid"

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -501,17 +501,27 @@ _reap_orphan_bridges() {
 "
   done
   [ -n "$killed" ] || return 0
-  # Wait for each to exit, using the start token AS the liveness check -- never a
-  # bare kill -0. A dead pid yields no start token (no /proc entry, no ps row), so
-  # `_start_token` succeeding IS proof the pid is still live, and its value being
-  # unchanged IS proof it is still the SAME process: liveness and identity from one
-  # observation, with no window between them for a recycled pid to slip through
-  # (and no kill -0 EPERM blind spot). A token that stops reading, or changes, ends
-  # the wait -- the process we killed is gone (or already replaced).
+  # THE RULE for every check here (add a new one? read this first): a failed
+  # observation is proof of NOTHING. Killing and spawning each need their OWN
+  # positive proof, and on any observation failure we do NOTHING -- the timeout
+  # bounds the wait, a failed read is never re-read as state:
+  #   kill  only with proof of IDENTITY  -- the start token READ and MATCHED (above)
+  #   spawn only with proof of EXIT      -- the pid proven ABSENT, or its token read
+  #                                         and now naming a DIFFERENT process (below)
+  # Wait for each killed pid to exit. Proof of exit is EITHER _agmsg_pid_alive_local
+  # returning absent (the sanctioned helper -- EPERM-aware, ps-cross-checked, erring
+  # to "alive" on any ambiguity, so a false return is real absence not a transient
+  # miss; it is also the one liveness path allowed to touch kill -0) OR a start token
+  # that reads and DIFFERS (a replacement). A token we merely could not read proves
+  # nothing -- keep waiting. No proof of exit within the budget: return 1 and do NOT
+  # spawn, so a bridge still holding the thread as writer is never double-started (#935).
   while IFS="$TAB" read -r pid lstartsrc lstart; do
     [ -n "$pid" ] || continue
     waited=0
-    while cur="$(_start_token "$pid")" && [ "$cur" = "$lstartsrc	$lstart" ]; do
+    while :; do
+      _agmsg_pid_alive_local "$pid" || break
+      cur="$(_start_token "$pid")"
+      if [ -n "$cur" ] && [ "$cur" != "$lstartsrc	$lstart" ]; then break; fi
       if [ "$waited" -ge "$_REAP_WAIT_TICKS" ]; then return 1; fi
       sleep 0.1; waited=$((waited + 1))
     done

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -380,60 +380,125 @@ done <<< "$ids"
 # a path or role from being misread as identity (#943).
 BRIDGE_PAIRS_HASH="$(printf '%s' "$(printf '%s\n' "${bridge_pair_values[@]}" | LC_ALL=C sort)" | agmsg_sha1)"
 
+
+# This launcher's full identity as one key: sha1 of the project hash and the
+# pair-set hash together. Everywhere identity is used -- the reap match AND the
+# spawn-rate reservation below -- keys on BOTH halves, so nothing is scoped by
+# role alone (project-blind keying is the bug class that produced #721 and the
+# earlier .meta collision).
+IDENTITY_HASH="$(printf '%s\n%s' "$PROJECT_HASH" "$BRIDGE_PAIRS_HASH" | agmsg_sha1)"
+
 # How long to wait for a reaped bridge to exit before treating it as stuck. The
 # real bridge shuts down async on SIGTERM and holds its thread as writer until it
 # does, so this outlasts an ordinary shutdown.
 _REAP_WAIT_TICKS=50
 
+# A process's start token, at the best precision the platform offers and by the
+# SAME method codex-bridge.js writeLease() records for itself, so the two agree:
+#   Linux -> /proc/<pid>/stat field 22 (starttime in clock ticks): lossless, so a
+#            recycled pid is always distinguishable from the one we leased.
+#   else  -> `ps -o lstart=` (second precision). Echoes "<src><TAB><token>";
+#            returns non-zero (indeterminable) so the caller fails closed.
+_start_token() {
+  local pid="$1" s r tok
+  local -a a
+  if [ -r "/proc/$pid/stat" ]; then
+    s="$(cat "/proc/$pid/stat" 2>/dev/null)" || return 1
+    r="${s##*)}"
+    read -ra a <<< "$r"
+    tok="${a[19]:-}"
+    case "$tok" in ''|*[!0-9]*) return 1 ;; esac
+    printf 'proc\t%s' "$tok"
+    return 0
+  fi
+  tok="$(ps -o lstart= -p "$pid" 2>/dev/null)"
+  # Trim leading/trailing whitespace only (ps pads); Node's .trim() on the writer
+  # side does the same, and both leave the internal single/double spaces intact,
+  # so the two strings compare equal.
+  tok="${tok#"${tok%%[![:space:]]*}"}"
+  tok="${tok%"${tok##*[![:space:]]}"}"
+  [ -n "$tok" ] || return 1
+  printf 'ps\t%s' "$tok"
+  return 0
+}
+
+# Parse a lease under an EXACT v=1 schema and fail closed on anything else. Sets
+# lproj/lpairs/lhost/lpid/lstart/lstartsrc and returns 0 only when the file is
+# precisely the seven expected keys, each once, no unknown or duplicate or extra
+# line, hashes 40-hex, pid numeric, startsrc proc|ps. A malformed, truncated, or
+# tampered lease returns non-zero, so the reaper never kills on a doubtful one.
+_read_lease() {
+  local file="$1" line k v nlines=0 lv=""
+  local sv=0 sproj=0 spairs=0 shost=0 spid=0 sstart=0 ssrc=0
+  lproj=""; lpairs=""; lhost=""; lpid=""; lstart=""; lstartsrc=""
+  while IFS= read -r line || [ -n "$line" ]; do
+    nlines=$((nlines + 1))
+    case "$line" in *=*) ;; *) return 1 ;; esac
+    k="${line%%=*}"; v="${line#*=}"
+    case "$k" in
+      v)        sv=$((sv + 1)); lv="$v" ;;
+      project)  sproj=$((sproj + 1)); lproj="$v" ;;
+      pairs)    spairs=$((spairs + 1)); lpairs="$v" ;;
+      host)     shost=$((shost + 1)); lhost="$v" ;;
+      pid)      spid=$((spid + 1)); lpid="$v" ;;
+      start)    sstart=$((sstart + 1)); lstart="$v" ;;
+      startsrc) ssrc=$((ssrc + 1)); lstartsrc="$v" ;;
+      *) return 1 ;;
+    esac
+  done < "$file"
+  [ "$nlines" -eq 7 ] || return 1
+  [ "$sv$sproj$spairs$shost$spid$sstart$ssrc" = "1111111" ] || return 1
+  [ "$lv" = "1" ] || return 1
+  case "$lproj" in *[!0-9a-f]*|"") return 1 ;; esac; [ "${#lproj}" -eq 40 ] || return 1
+  case "$lpairs" in *[!0-9a-f]*|"") return 1 ;; esac; [ "${#lpairs}" -eq 40 ] || return 1
+  case "$lpid" in *[!0-9]*|"") return 1 ;; esac
+  case "$lstartsrc" in proc|ps) ;; *) return 1 ;; esac
+  [ -n "$lhost" ] || return 1
+  [ -n "$lstart" ] || return 1
+  if [ "$lstartsrc" = proc ]; then case "$lstart" in *[!0-9]*|"") return 1 ;; esac; fi
+  return 0
+}
+
 # Reap every live bridge that is EXACTLY this (project, pair-set), identified by
 # the per-PID lease it published (codex-bridge-lease.<pid>) -- not by
 # reconstructing argv from ps, which is a lossy representation that misread
-# identity five different ways. ps is used only to enumerate live pids and to
-# read each one's start time. Every doubt fails CLOSED (no kill): a missing lease
+# identity five different ways. ps is used ONLY to enumerate live pids and to
+# read each one's start token. Every doubt fails CLOSED (no kill): a missing lease
 # (a legacy bridge), a malformed or partial one, a different or absent host, a
-# start time that no longer matches. Non-Windows only (the pid is only killable
-# in this shell's pid namespace; Windows is the #458 mismatch) and a no-op with
-# no process lister.
+# hash that is not ours, a start token that no longer matches. Non-Windows only
+# (the pid is only killable in this shell's pid namespace; Windows is the #458
+# mismatch) and a no-op with no process lister.
 _reap_orphan_bridges() {
   case "${MSYSTEM:-}" in MINGW*|MSYS*|CLANGARM*) return 0 ;; esac
   command -v pgrep >/dev/null 2>&1 || return 0
-  local myhost pid lease k v lv lproj lpairs lhost lpid lstart st killed="" waited
+  local myhost pid lease cur killed="" waited
+  local lproj lpairs lhost lpid lstart lstartsrc
   myhost="$(hostname 2>/dev/null)"
   [ -n "$myhost" ] || return 0
   for pid in $(pgrep -f 'codex-bridge\.js' 2>/dev/null); do
     lease="$RUN_DIR/codex-bridge-lease.$pid"
-    echo "PID $pid lease=$lease exists=$([ -f "$lease" ] && echo Y || echo N) myproj=$PROJECT_HASH mypairs=$BRIDGE_PAIRS_HASH" >> /tmp/lease.log
     [ -f "$lease" ] || continue
-    lv=""; lproj=""; lpairs=""; lhost=""; lpid=""; lstart=""
-    while IFS='=' read -r k v; do
-      case "$k" in
-        v) lv="$v" ;; project) lproj="$v" ;; pairs) lpairs="$v" ;;
-        host) lhost="$v" ;; pid) lpid="$v" ;; start) lstart="$v" ;;
-      esac
-    done < "$lease"
-    [ "$lv" = 1 ] || continue
-    [ -n "$lproj" ] && [ -n "$lpairs" ] && [ -n "$lhost" ] && [ -n "$lpid" ] && [ -n "$lstart" ] || continue
+    _read_lease "$lease" || continue
     [ "$lpid" = "$pid" ] || continue
     [ "$lhost" = "$myhost" ] || continue
     [ "$lproj" = "$PROJECT_HASH" ] || continue
-    echo "  read lv=$lv lproj=$lproj lpairs=$lpairs lhost=$lhost lpid=$lpid mismatch=proj$([ "$lproj" = "$PROJECT_HASH" ]&&echo =||echo X)pairs$([ "$lpairs" = "$BRIDGE_PAIRS_HASH" ]&&echo =||echo X)host$([ "$lhost" = "$myhost" ]&&echo =||echo X)" >> /tmp/lease.log
     [ "$lpairs" = "$BRIDGE_PAIRS_HASH" ] || continue
-    # Reuse guard: the LIVE pid's actual start time must still equal the lease's.
-    # A recycled pid (a new, unrelated process on the old number) has a different
-    # start time, so it is spared.
-    st="$(ps -o lstart= -p "$pid" 2>/dev/null)"
-    [ "$st" = "$lstart" ] || continue
+    # Reuse guard: the LIVE pid's actual start token (same source) must still equal
+    # the lease's. A recycled pid has a different token (lossless on Linux), so it
+    # is spared.
+    cur="$(_start_token "$pid")" || continue
+    [ "$cur" = "$lstartsrc	$lstart" ] || continue
     kill "$pid" 2>/dev/null || true
-    killed="$killed$pid	$lstart
+    killed="$killed$pid	$lstartsrc	$lstart
 "
   done
   [ -n "$killed" ] || return 0
-  # Wait for each to exit. A pid whose start time changed is a DIFFERENT process
+  # Wait for each to exit. A pid whose start token changed is a DIFFERENT process
   # -- the one we killed is already gone -- so it is not waited on.
-  while IFS="$TAB" read -r pid lstart; do
+  while IFS="$TAB" read -r pid lstartsrc lstart; do
     [ -n "$pid" ] || continue
     waited=0
-    while kill -0 "$pid" 2>/dev/null && [ "$(ps -o lstart= -p "$pid" 2>/dev/null)" = "$lstart" ]; do
+    while kill -0 "$pid" 2>/dev/null && [ "$(_start_token "$pid")" = "$lstartsrc	$lstart" ]; do
       if [ "$waited" -ge "$_REAP_WAIT_TICKS" ]; then return 1; fi
       sleep 0.1; waited=$((waited + 1))
     done
@@ -443,26 +508,47 @@ EOF
   return 0
 }
 
-# A ceiling on bridge spawns for this role: at most _SPAWN_MAX in _SPAWN_WINDOW
+# A ceiling on bridge spawns for this identity: at most _SPAWN_MAX in _SPAWN_WINDOW
 # seconds. The reap converges duplicates to one, but a bridge that cannot stay up
 # (a launcher dying before it records the pidfile) would reap-and-respawn every
-# tick; this bounds that churn. The read-modify-write is under an mkdir-atomic
-# lock so concurrent launchers cannot each read the same count and overshoot.
+# tick; this bounds that churn. The read-modify-write is under a per-identity
+# mkdir lock (project + pair-set, not role alone) so concurrent launchers cannot
+# each read the same count and overshoot.
 _SPAWN_WINDOW=30
 _SPAWN_MAX=5
+# A lock a crashed launcher left behind is reclaimed only once it is this old. The
+# critical section is a sub-second read-modify-write, so a much older lock is dead;
+# the window is wide enough that a live holder is never reclaimed out from under.
+_SPAWN_LOCK_STALE=30
 _spawn_rate_ok() {
-  local stamps="$RUN_DIR/codex-bridge.$bridge_key.spawns"
+  local stamps="$RUN_DIR/codex-bridge-rate.$IDENTITY_HASH.spawns"
   local lock="$stamps.lock"
-  local now cutoff kept="" t n rc=0 tries=0
-  # Per-key lock: a same-key launcher must not read-modify-write the stamp file
-  # in the same instant. mkdir is atomic, so exactly one creator wins the lock;
-  # a stuck holder is bounded by the 50-try (~1s) ceiling, after which we throttle
-  # by proceeding lock-free rather than blocking a spawn forever.
+  local now cutoff kept="" t n tries=0 age m
+  # mkdir is atomic: exactly one launcher holds the lock. If we cannot take it,
+  # another launcher for THIS identity is reserving right now -- the concurrent
+  # spawn we exist to bound -- so we THROTTLE (return 1, do not spawn) rather than
+  # proceed lock-free and let both overshoot. The only exception is a lock left by
+  # a crash, reclaimed once provably stale.
   while ! mkdir "$lock" 2>/dev/null; do
     tries=$((tries + 1))
-    if [ "$tries" -ge 50 ]; then break; fi
+    if [ "$tries" -ge 50 ]; then
+      # GNU (-c) first: on BSD/macOS `stat -c` exits non-zero and falls through
+      # to `-f`; ordered the other way, Linux `stat -f %m` can exit 0 with garbage
+      # and the real mtime is never read, so a crashed lock is never reclaimed.
+      m="$(stat -c %Y "$lock" 2>/dev/null || stat -f %m "$lock" 2>/dev/null)"
+      now="$(date +%s)"
+      case "$m" in ''|*[!0-9]*) return 1 ;; esac
+      age=$((now - m))
+      if [ "$age" -ge "$_SPAWN_LOCK_STALE" ]; then
+        rmdir "$lock" 2>/dev/null || true
+        tries=0
+        continue
+      fi
+      return 1
+    fi
     sleep 0.02
   done
+  # --- critical section (we own the lock; only we mutate stamps and rmdir) ---
   now="$(date +%s)"
   cutoff=$((now - _SPAWN_WINDOW))
   if [ -f "$stamps" ]; then
@@ -475,12 +561,12 @@ _spawn_rate_ok() {
   n=0
   if [ -n "$kept" ]; then n=$(printf '%s' "$kept" | grep -c .); fi
   if [ "$n" -ge "$_SPAWN_MAX" ]; then
-    rc=1
-  else
-    printf '%s%s\n' "$kept" "$now" > "$stamps"
+    rmdir "$lock" 2>/dev/null || true
+    return 1
   fi
+  printf '%s%s\n' "$kept" "$now" > "$stamps"
   rmdir "$lock" 2>/dev/null || true
-  return "$rc"
+  return 0
 }
 pidfile="$RUN_DIR/codex-bridge.$bridge_key.pid"
 log="$RUN_DIR/codex-bridge.$bridge_key.log"

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -368,9 +368,120 @@ else
   bridge_key="$(printf '%s' "$ids" | agmsg_sha1)"
 fi
 bridge_pairs=()
+bridge_pair_values=()
 while IFS="$TAB" read -r candidate_team candidate_name; do
   bridge_pairs+=(--pair "$candidate_team"$'\t'"$candidate_name")
+  bridge_pair_values+=("$candidate_team"$'\t'"$candidate_name")
 done <<< "$ids"
+# This launcher's identity, hashed the same way the bridge hashes its lease
+# (scripts/drivers/types/codex/codex-bridge.js writeLease): SHA-1 of the sorted
+# "team<TAB>name" set joined by newlines. PROJECT_HASH (above) is the project
+# half. Comparing hashes -- never raw values -- is what keeps a separator inside
+# a path or role from being misread as identity (#943).
+BRIDGE_PAIRS_HASH="$(printf '%s' "$(printf '%s\n' "${bridge_pair_values[@]}" | LC_ALL=C sort)" | agmsg_sha1)"
+
+# How long to wait for a reaped bridge to exit before treating it as stuck. The
+# real bridge shuts down async on SIGTERM and holds its thread as writer until it
+# does, so this outlasts an ordinary shutdown.
+_REAP_WAIT_TICKS=50
+
+# Reap every live bridge that is EXACTLY this (project, pair-set), identified by
+# the per-PID lease it published (codex-bridge-lease.<pid>) -- not by
+# reconstructing argv from ps, which is a lossy representation that misread
+# identity five different ways. ps is used only to enumerate live pids and to
+# read each one's start time. Every doubt fails CLOSED (no kill): a missing lease
+# (a legacy bridge), a malformed or partial one, a different or absent host, a
+# start time that no longer matches. Non-Windows only (the pid is only killable
+# in this shell's pid namespace; Windows is the #458 mismatch) and a no-op with
+# no process lister.
+_reap_orphan_bridges() {
+  case "${MSYSTEM:-}" in MINGW*|MSYS*|CLANGARM*) return 0 ;; esac
+  command -v pgrep >/dev/null 2>&1 || return 0
+  local myhost pid lease k v lv lproj lpairs lhost lpid lstart st killed="" waited
+  myhost="$(hostname 2>/dev/null)"
+  [ -n "$myhost" ] || return 0
+  for pid in $(pgrep -f 'codex-bridge\.js' 2>/dev/null); do
+    lease="$RUN_DIR/codex-bridge-lease.$pid"
+    echo "PID $pid lease=$lease exists=$([ -f "$lease" ] && echo Y || echo N) myproj=$PROJECT_HASH mypairs=$BRIDGE_PAIRS_HASH" >> /tmp/lease.log
+    [ -f "$lease" ] || continue
+    lv=""; lproj=""; lpairs=""; lhost=""; lpid=""; lstart=""
+    while IFS='=' read -r k v; do
+      case "$k" in
+        v) lv="$v" ;; project) lproj="$v" ;; pairs) lpairs="$v" ;;
+        host) lhost="$v" ;; pid) lpid="$v" ;; start) lstart="$v" ;;
+      esac
+    done < "$lease"
+    [ "$lv" = 1 ] || continue
+    [ -n "$lproj" ] && [ -n "$lpairs" ] && [ -n "$lhost" ] && [ -n "$lpid" ] && [ -n "$lstart" ] || continue
+    [ "$lpid" = "$pid" ] || continue
+    [ "$lhost" = "$myhost" ] || continue
+    [ "$lproj" = "$PROJECT_HASH" ] || continue
+    echo "  read lv=$lv lproj=$lproj lpairs=$lpairs lhost=$lhost lpid=$lpid mismatch=proj$([ "$lproj" = "$PROJECT_HASH" ]&&echo =||echo X)pairs$([ "$lpairs" = "$BRIDGE_PAIRS_HASH" ]&&echo =||echo X)host$([ "$lhost" = "$myhost" ]&&echo =||echo X)" >> /tmp/lease.log
+    [ "$lpairs" = "$BRIDGE_PAIRS_HASH" ] || continue
+    # Reuse guard: the LIVE pid's actual start time must still equal the lease's.
+    # A recycled pid (a new, unrelated process on the old number) has a different
+    # start time, so it is spared.
+    st="$(ps -o lstart= -p "$pid" 2>/dev/null)"
+    [ "$st" = "$lstart" ] || continue
+    kill "$pid" 2>/dev/null || true
+    killed="$killed$pid	$lstart
+"
+  done
+  [ -n "$killed" ] || return 0
+  # Wait for each to exit. A pid whose start time changed is a DIFFERENT process
+  # -- the one we killed is already gone -- so it is not waited on.
+  while IFS="$TAB" read -r pid lstart; do
+    [ -n "$pid" ] || continue
+    waited=0
+    while kill -0 "$pid" 2>/dev/null && [ "$(ps -o lstart= -p "$pid" 2>/dev/null)" = "$lstart" ]; do
+      if [ "$waited" -ge "$_REAP_WAIT_TICKS" ]; then return 1; fi
+      sleep 0.1; waited=$((waited + 1))
+    done
+  done <<EOF
+$killed
+EOF
+  return 0
+}
+
+# A ceiling on bridge spawns for this role: at most _SPAWN_MAX in _SPAWN_WINDOW
+# seconds. The reap converges duplicates to one, but a bridge that cannot stay up
+# (a launcher dying before it records the pidfile) would reap-and-respawn every
+# tick; this bounds that churn. The read-modify-write is under an mkdir-atomic
+# lock so concurrent launchers cannot each read the same count and overshoot.
+_SPAWN_WINDOW=30
+_SPAWN_MAX=5
+_spawn_rate_ok() {
+  local stamps="$RUN_DIR/codex-bridge.$bridge_key.spawns"
+  local lock="$stamps.lock"
+  local now cutoff kept="" t n rc=0 tries=0
+  # Per-key lock: a same-key launcher must not read-modify-write the stamp file
+  # in the same instant. mkdir is atomic, so exactly one creator wins the lock;
+  # a stuck holder is bounded by the 50-try (~1s) ceiling, after which we throttle
+  # by proceeding lock-free rather than blocking a spawn forever.
+  while ! mkdir "$lock" 2>/dev/null; do
+    tries=$((tries + 1))
+    if [ "$tries" -ge 50 ]; then break; fi
+    sleep 0.02
+  done
+  now="$(date +%s)"
+  cutoff=$((now - _SPAWN_WINDOW))
+  if [ -f "$stamps" ]; then
+    while IFS= read -r t; do
+      case "$t" in ''|*[!0-9]*) continue ;; esac
+      if [ "$t" -ge "$cutoff" ]; then kept="$kept$t
+"; fi
+    done < "$stamps"
+  fi
+  n=0
+  if [ -n "$kept" ]; then n=$(printf '%s' "$kept" | grep -c .); fi
+  if [ "$n" -ge "$_SPAWN_MAX" ]; then
+    rc=1
+  else
+    printf '%s%s\n' "$kept" "$now" > "$stamps"
+  fi
+  rmdir "$lock" 2>/dev/null || true
+  return "$rc"
+}
 pidfile="$RUN_DIR/codex-bridge.$bridge_key.pid"
 log="$RUN_DIR/codex-bridge.$bridge_key.log"
 # Records the app-server URL the live bridge was launched against, so a later
@@ -498,6 +609,21 @@ EOF
     else
       rm -f "$pidfile" "$appserver_file" "$thread_file"
     fi
+  fi
+
+  # Bound the spawn rate first (a rate-limited tick changes nothing), then reap
+  # any orphan for this exact (project, role) so exactly one bridge remains. If a
+  # reaped bridge will not exit, do not spawn beside it this tick.
+  # In a set +e subshell: these two do a lot of probing whose non-zero results
+  # (no such process, an empty match, a lock already held) are normal, and the
+  # launcher runs under set -euo pipefail where a bare non-zero would exit it.
+  if ! ( set +e; _spawn_rate_ok ); then
+    poll_sleep
+    continue
+  fi
+  if ! ( set +e; _reap_orphan_bridges ); then
+    poll_sleep
+    continue
   fi
 
   nohup "${bridge_run[@]}" \

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -680,9 +680,9 @@ EOF
   # The role-session record is the sole thread authority (#150 phase 2/#350).
 
   # Reset each tick: a mismatched-live bridge (bound to a stale thread/app-server)
-  # sets this to its pid, purely as a flag that we must NOT spawn beside it. We do
-  # not kill it from here -- see the guard before the spawn below.
-  need_kill=""
+  # sets these to its pid and the start token it had at that moment. We never kill
+  # it from here; the token is how the guard before the spawn proves it is gone.
+  need_kill=""; need_kill_token=""
   if [ -f "$pidfile" ]; then
     bridge_pid=""
     IFS= read -r bridge_pid < "$pidfile" 2>/dev/null || true
@@ -712,6 +712,7 @@ EOF
       # (#350). Defer every teardown to the point we are actually committed to
       # replacement -- and we do not kill it directly at all (below).
       need_kill="$bridge_pid"
+      need_kill_token="$(_start_token "$bridge_pid" 2>/dev/null || true)"
     fi
   fi
 
@@ -732,19 +733,25 @@ EOF
     continue
   fi
 
-  # A mismatched-live bridge must be gone before we spawn its replacement, or we
-  # double-start a writer (#935). We do NOT kill it here: the pidfile holds a bare
-  # pid with no identity token, so a direct kill could land on a reused pid. The
-  # lease-based reaper above is the ONLY reuse-safe path that may signal it, and it
-  # kills same-identity leased bridges (and, when it cannot prove they exited,
-  # returns non-zero so we already bailed). If the pid is somehow STILL alive here
-  # -- the reaper spared a legacy bridge with no lease, or it is mid-shutdown --
-  # do nothing this tick: leave the binding intact and retry, rather than spawn
-  # beside it. A lease-less bridge that never dies simply lingers (orphan survival
-  # is acceptable; a wrong-kill or a double-start is not).
-  if [ -n "$need_kill" ] && _agmsg_pid_alive "$need_kill"; then
-    poll_sleep
-    continue
+  # A mismatched-live bridge must be proven GONE before we spawn its replacement,
+  # or we double-start a writer that still holds the thread through async shutdown
+  # (#935). We do NOT kill it from here (the pidfile is a bare pid with no identity,
+  # so any direct kill could hit a reused pid; the lease-based reaper above is the
+  # only reuse-safe path that may signal it). And we do NOT ask _agmsg_pid_alive to
+  # "confirm" it is gone: a false from that helper can be a transient ps failure
+  # (#954), and a failed observation is not proof (see THE RULE above). The one
+  # positive proof we accept is the start token we stashed at detection now reading
+  # a DIFFERENT process -- the old pid has been reused, so the old writer is gone.
+  # A token that still matches (alive), or cannot be read (unproven), keeps the
+  # binding and retries; a normal exit is picked up next tick by the dead-pid path
+  # at the top of the loop. A lease-less bridge that never dies simply lingers
+  # (orphan survival is acceptable; a wrong-kill or a double-start is not).
+  if [ -n "$need_kill" ]; then
+    _nk_now="$(_start_token "$need_kill" 2>/dev/null || true)"
+    if [ -z "$need_kill_token" ] || [ -z "$_nk_now" ] || [ "$_nk_now" = "$need_kill_token" ]; then
+      poll_sleep
+      continue
+    fi
   fi
   # Committed to spawning now: clear the stale records immediately before writing
   # the new ones, so no gate can bail out between the wipe and the rewrite.

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -679,9 +679,11 @@ EOF
 
   # The role-session record is the sole thread authority (#150 phase 2/#350).
 
-  # Reset each tick: a mismatched-live bridge sets this to the pid it must kill,
-  # but only once we commit to spawning its replacement (see below).
-  need_kill=""
+  # Reset each tick: a mismatched-live bridge sets these to the pid it must kill
+  # AND that pid's start token at the moment we chose it, so the deferred kill can
+  # prove the pid is still that same process (below). Killed only once we commit to
+  # spawning the replacement.
+  need_kill=""; need_kill_token=""
   if [ -f "$pidfile" ]; then
     bridge_pid=""
     IFS= read -r bridge_pid < "$pidfile" 2>/dev/null || true
@@ -711,6 +713,7 @@ EOF
       # (#350). Defer every teardown to the point we are actually committed to
       # spawning the replacement.
       need_kill="$bridge_pid"
+      need_kill_token="$(_start_token "$bridge_pid" 2>/dev/null || true)"
     fi
   fi
 
@@ -733,8 +736,17 @@ EOF
 
   # Committed to spawning now: retire the old bridge (if any) and its stale
   # records, immediately before writing the new ones, so the wipe and the rewrite
-  # are not separated by a gate that can bail out between them.
-  if [ -n "$need_kill" ]; then kill "$need_kill" 2>/dev/null || true; fi
+  # are not separated by a gate that can bail out between them. The kill needs the
+  # same proof of IDENTITY as the reaper: the gates above may have taken seconds,
+  # in which the old pid could have exited and been reused, so kill ONLY when the
+  # pid's start token still reads and matches the one we stored when we chose it --
+  # unreadable or changed means a different (or gone) process, so do nothing.
+  if [ -n "$need_kill" ] && [ -n "$need_kill_token" ]; then
+    _nk_now="$(_start_token "$need_kill" 2>/dev/null || true)"
+    if [ -n "$_nk_now" ] && [ "$_nk_now" = "$need_kill_token" ]; then
+      kill "$need_kill" 2>/dev/null || true
+    fi
+  fi
   rm -f "$pidfile" "$appserver_file" "$thread_file"
 
   nohup "${bridge_run[@]}" \

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -501,12 +501,17 @@ _reap_orphan_bridges() {
 "
   done
   [ -n "$killed" ] || return 0
-  # Wait for each to exit. A pid whose start token changed is a DIFFERENT process
-  # -- the one we killed is already gone -- so it is not waited on.
+  # Wait for each to exit, using the start token AS the liveness check -- never a
+  # bare kill -0. A dead pid yields no start token (no /proc entry, no ps row), so
+  # `_start_token` succeeding IS proof the pid is still live, and its value being
+  # unchanged IS proof it is still the SAME process: liveness and identity from one
+  # observation, with no window between them for a recycled pid to slip through
+  # (and no kill -0 EPERM blind spot). A token that stops reading, or changes, ends
+  # the wait -- the process we killed is gone (or already replaced).
   while IFS="$TAB" read -r pid lstartsrc lstart; do
     [ -n "$pid" ] || continue
     waited=0
-    while kill -0 "$pid" 2>/dev/null && [ "$(_start_token "$pid")" = "$lstartsrc	$lstart" ]; do
+    while cur="$(_start_token "$pid")" && [ "$cur" = "$lstartsrc	$lstart" ]; do
       if [ "$waited" -ge "$_REAP_WAIT_TICKS" ]; then return 1; fi
       sleep 0.1; waited=$((waited + 1))
     done

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -5,6 +5,7 @@ const { spawn, spawnSync } = require("child_process");
 const crypto = require("crypto");
 const fs = require("fs");
 const net = require("net");
+const os = require("os");
 const path = require("path");
 const readline = require("readline");
 
@@ -953,6 +954,12 @@ class CodexBridge {
       : crypto.createHash("sha1").update(identities.map((p) => `${p.team}\t${p.name}`).join("\n")).digest("hex");
     this.pidfile = path.join(RUN_DIR, `codex-bridge.${key}.pid`);
     this.metafile = path.join(RUN_DIR, `codex-bridge.${key}.meta`);
+    // A per-PID identity lease the launcher reaper reads to tell an orphan of THIS
+    // (project, role) from any other bridge, without reconstructing argv from ps
+    // (#943). Keyed by pid so duplicates are each enumerable; content is hashes,
+    // so no raw project/role value with a separator can be misread.
+    this.leasefile = path.join(RUN_DIR, `codex-bridge-lease.${process.pid}`);
+    this.leaseStart = "";
   }
 
   async run() {
@@ -1057,6 +1064,54 @@ class CodexBridge {
         `type=${this.opts.type}`,
       ].join("\n") + "\n",
     );
+    this.writeLease();
+  }
+
+  // The reaper's authority. It is published atomically (temp + rename) so a
+  // reader never sees a half-written file, and BEFORE any thread/network work,
+  // so a bridge is reapable the instant it exists. project and pairs are stored
+  // as SHA-1 hashes -- the launcher hashes its own PROJECT and sorted pair set
+  // the same way and compares hex, so no separator inside a project path or role
+  // can make one identity read as another (the whole class of bugs argv parsing
+  // hit). host and the process start time are what let the reaper reject a
+  // recycled pid or another machine before it kills anything.
+  writeLease() {
+    const start = spawnSync("ps", ["-o", "lstart=", "-p", String(process.pid)], { encoding: "utf8" });
+    this.leaseStart = (start.stdout || "").trim();
+    const projectHash = crypto.createHash("sha1").update(this.opts.project).digest("hex");
+    const pairsHash = crypto.createHash("sha1")
+      .update(this.identities.map((pair) => `${pair.team}\t${pair.name}`).sort().join("\n"))
+      .digest("hex");
+    const body = [
+      "v=1",
+      `project=${projectHash}`,
+      `pairs=${pairsHash}`,
+      `host=${os.hostname()}`,
+      `pid=${process.pid}`,
+      `start=${this.leaseStart}`,
+    ].join("\n") + "\n";
+    const tmp = `${this.leasefile}.tmp`;
+    try {
+      fs.writeFileSync(tmp, body, { mode: 0o600 });
+      fs.renameSync(tmp, this.leasefile);
+    } catch (error) {
+      console.error(`codex-bridge: could not publish identity lease: ${error.message}`);
+    }
+  }
+
+  // Remove only OUR lease: read it back and unlink only when both the pid and the
+  // start token still name this process, so a lease a recycled pid's new owner
+  // may have written to the same path is never deleted from under it.
+  cleanupLease() {
+    try {
+      if (!fs.existsSync(this.leasefile)) return;
+      const text = fs.readFileSync(this.leasefile, "utf8");
+      const pid = (text.match(/^pid=(.*)$/mu) || [])[1];
+      const start = (text.match(/^start=(.*)$/mu) || [])[1];
+      if (pid === String(process.pid) && start === this.leaseStart) {
+        fs.unlinkSync(this.leasefile);
+      }
+    } catch (_) { /* best effort */ }
   }
 
   installSignals() {
@@ -1068,6 +1123,7 @@ class CodexBridge {
     process.on("exit", () => {
       this.client.stop();
       this.cleanupMeta();
+      this.cleanupLease();
     });
   }
 

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -1110,8 +1110,17 @@ class CodexBridge {
     const host = os.hostname();
     if (!host) throw new Error("cannot determine hostname for identity lease");
     const projectHash = crypto.createHash("sha1").update(this.opts.project).digest("hex");
+    // Canonicalize the pair SET before hashing: hash each "team\tname" pair, then
+    // sort the hex hashes (pure ASCII, so a byte sort in the launcher and a JS
+    // code-unit sort here agree even for non-ASCII names) and hash the joined
+    // list. codex-bridge-launcher.sh computes BRIDGE_PAIRS_HASH identically.
     const pairsHash = crypto.createHash("sha1")
-      .update(this.identities.map((pair) => `${pair.team}\t${pair.name}`).sort().join("\n"))
+      .update(
+        this.identities
+          .map((pair) => crypto.createHash("sha1").update(`${pair.team}\t${pair.name}`).digest("hex"))
+          .sort()
+          .join("\n"),
+      )
       .digest("hex");
     this.leaseStart = token;
     this.leaseStartSrc = src;

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -960,6 +960,7 @@ class CodexBridge {
     // so no raw project/role value with a separator can be misread.
     this.leasefile = path.join(RUN_DIR, `codex-bridge-lease.${process.pid}`);
     this.leaseStart = "";
+    this.leaseStartSrc = "";
   }
 
   async run() {
@@ -1075,28 +1076,59 @@ class CodexBridge {
   // can make one identity read as another (the whole class of bugs argv parsing
   // hit). host and the process start time are what let the reaper reject a
   // recycled pid or another machine before it kills anything.
+  // This process's start token, at the best precision the platform offers and by
+  // the SAME method _reap_orphan_bridges (codex-bridge-launcher.sh) recomputes it
+  // for a live pid, so the two agree:
+  //   Linux -> /proc/<pid>/stat field 22 (starttime in clock ticks): lossless, so
+  //            a recycled pid is always distinguishable from the one we leased.
+  //   else  -> `ps -o lstart=` (second precision): a pid reused within the SAME
+  //            second is the documented residual on such platforms; no external
+  //            observer can do better there (etime/mtime are second-grained too),
+  //            and the only victim would be a same-(project,pair) bridge in the
+  //            sub-ms window before it overwrites this pid's lease, self-corrected
+  //            by the launcher respawning it.
+  startToken() {
+    try {
+      const stat = fs.readFileSync(`/proc/${process.pid}/stat`, "utf8");
+      const after = stat.slice(stat.lastIndexOf(")") + 1).trim().split(/\s+/);
+      const ticks = after[19];
+      if (/^\d+$/.test(ticks || "")) return { src: "proc", token: ticks };
+    } catch (_) { /* no /proc (macOS/BSD) or unreadable */ }
+    const ps = spawnSync("ps", ["-o", "lstart=", "-p", String(process.pid)], { encoding: "utf8" });
+    const token = (ps.status === 0 ? (ps.stdout || "") : "").trim();
+    return { src: "ps", token };
+  }
+
   writeLease() {
-    const start = spawnSync("ps", ["-o", "lstart=", "-p", String(process.pid)], { encoding: "utf8" });
-    this.leaseStart = (start.stdout || "").trim();
+    const { src, token } = this.startToken();
+    // Fail CLOSED at the source. A bridge that cannot publish a well-formed,
+    // enumerable lease must not go on to arm its network/thread -- that is exactly
+    // the authority-less orphan #906 is about. Each failure below throws, and run()
+    // publishes the lease before client.start(), so the throw aborts startup rather
+    // than leaving a live-but-unreapable bridge.
+    if (!token) throw new Error("cannot determine process start token for identity lease");
+    const host = os.hostname();
+    if (!host) throw new Error("cannot determine hostname for identity lease");
     const projectHash = crypto.createHash("sha1").update(this.opts.project).digest("hex");
     const pairsHash = crypto.createHash("sha1")
       .update(this.identities.map((pair) => `${pair.team}\t${pair.name}`).sort().join("\n"))
       .digest("hex");
+    this.leaseStart = token;
+    this.leaseStartSrc = src;
     const body = [
       "v=1",
       `project=${projectHash}`,
       `pairs=${pairsHash}`,
-      `host=${os.hostname()}`,
+      `host=${host}`,
       `pid=${process.pid}`,
-      `start=${this.leaseStart}`,
+      `start=${token}`,
+      `startsrc=${src}`,
     ].join("\n") + "\n";
     const tmp = `${this.leasefile}.tmp`;
-    try {
-      fs.writeFileSync(tmp, body, { mode: 0o600 });
-      fs.renameSync(tmp, this.leasefile);
-    } catch (error) {
-      console.error(`codex-bridge: could not publish identity lease: ${error.message}`);
-    }
+    // writeFileSync / renameSync throw on failure -> fatal, by design (see above).
+    // rename is atomic, so a reader never sees a half-written lease.
+    fs.writeFileSync(tmp, body, { mode: 0o600 });
+    fs.renameSync(tmp, this.leasefile);
   }
 
   // Remove only OUR lease: read it back and unlink only when both the pid and the

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -511,7 +511,10 @@ wait_for_child_count() {
 # --- #937: reap a same-(project,role) orphan via its per-PID identity lease ---
 
 _count_role_bridges() { # <project> <name>
-  ps -Ao pid=,args= 2>/dev/null | grep -F "codex-bridge.js" | grep -F -- "--project $1 " | grep -F "$2" | grep -c . | tr -d ' '
+  # Match the role name at a word boundary, not as a substring: "alice" must not
+  # also count "alice2" (the survive tests turn on exactly that distinction), so a
+  # trailing digit/letter excludes it. Names here are plain [a-z0-9] test tokens.
+  ps -Ao pid=,args= 2>/dev/null | grep -F "codex-bridge.js" | grep -F -- "--project $1 " | grep -E "$2([^0-9A-Za-z]|\$)" | grep -c . | tr -d ' '
 }
 # Poll until this project's role-bridge count settles at <want>, then echo it --
 # a fixed sleep before a point-in-time count races the reap-and-respawn.

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -40,10 +40,28 @@ setup() {
   # Node binary codex-bridge-launcher.sh resolves this file through; pointing
   # it at bash makes bash the interpreter for this file regardless of its .js
   # name, so the launcher's default (no-custom-wrapper) path runs unmodified.
-  cat > "$SCRIPTS/drivers/types/codex/codex-bridge.js" <<EOF
+  # Mock bridge: records argv AND publishes the same per-PID identity lease the
+  # real bridge does (so the reaper, which reads leases, can find/spare it). All
+  # of $CAPTURE / $SCRIPTS / $RUN_DIR come from the environment it inherits.
+  cat > "$SCRIPTS/drivers/types/codex/codex-bridge.js" <<'EOF'
 #!/usr/bin/env bash
-printf '%s\n' "\$*" >> "$CAPTURE"
-[ -z "\${MOCK_BRIDGE_SLEEP:-}" ] || sleep "\$MOCK_BRIDGE_SLEEP"
+printf '%s\n' "$*" >> "$CAPTURE"
+source "$SCRIPTS/lib/hash.sh" 2>/dev/null || true
+_proj=""; _parr=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --project) _proj="$2"; shift 2 ;;
+    --pair) _parr+=("$2"); shift 2 ;;
+    *) shift ;;
+  esac
+done
+_lease="$RUN_DIR/codex-bridge-lease.$$"
+{ printf 'v=1\nproject=%s\npairs=%s\nhost=%s\npid=%s\nstart=%s\n' \
+    "$(printf '%s' "$_proj" | agmsg_sha1)" \
+    "$(printf '%s' "$(printf '%s\n' "${_parr[@]}" | LC_ALL=C sort)" | agmsg_sha1)" \
+    "$(hostname)" "$$" "$(ps -o lstart= -p $$)" ; } > "$_lease.tmp" && mv "$_lease.tmp" "$_lease"
+trap 'rm -f "$_lease"' EXIT
+[ -z "${MOCK_BRIDGE_SLEEP:-}" ] || sleep "$MOCK_BRIDGE_SLEEP"
 exit 0
 EOF
   chmod +x "$SCRIPTS/drivers/types/codex/codex-bridge.js"
@@ -474,4 +492,115 @@ wait_for_child_count() {
 
   [ -f "$CAPTURE" ] || { echo "no bridge was started on native Windows"; false; }
   grep -q -- '--thread thread-win' "$CAPTURE"
+}
+
+# --- #937: reap a same-(project,role) orphan via its per-PID identity lease ---
+
+_count_role_bridges() { # <project> <name>
+  ps -Ao pid=,args= 2>/dev/null | grep -F "codex-bridge.js" | grep -F -- "--project $1 " | grep -F "$2" | grep -c . | tr -d ' '
+}
+# Poll until this project's role-bridge count settles at <want>, then echo it --
+# a fixed sleep before a point-in-time count races the reap-and-respawn.
+_wait_role_count() { # <project> <name> <want>
+  local i
+  for i in {1..100}; do
+    [ "$(_count_role_bridges "$1" "$2")" -eq "$3" ] && break
+    sleep 0.1
+  done
+  _count_role_bridges "$1" "$2"
+}
+# Run the mock bridge directly for a given (project, pairs) so it publishes a
+# lease of that identity and stays alive. Sets FAKE_PID (NOT via $(...) -- a
+# background job in command substitution is killed when that subshell exits).
+_spawn_fake() { # <project> <pair...>
+  local proj="$1"; shift
+  local args=(--project "$proj") pv
+  for pv in "$@"; do args+=(--pair "$pv"); done
+  MOCK_BRIDGE_SLEEP=25 bash "$SCRIPTS/drivers/types/codex/codex-bridge.js" "${args[@]}" 3>&- &
+  FAKE_PID=$!
+}
+
+@test "launcher: reaps a same-(project,role) orphan the pidfile lost, converging to one (#937)" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=25
+  sleep 22 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
+  local i; for i in {1..80}; do [ "$(_count_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  [ "$(_count_role_bridges "$PROJ" alice)" -eq 1 ]
+  rm -f "$RUN_DIR"/codex-bridge.*.pid
+  [ "$(_wait_role_count "$PROJ" alice 1)" -eq 1 ]
+  kill "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true
+}
+
+@test "launcher: a reap for one role leaves a same-project OTHER role alive (#937)" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=25
+  local tab; tab=$(printf '\t')
+  _spawn_fake "$PROJ" "team${tab}bob"; local bob=$FAKE_PID
+  sleep 22 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
+  local i; for i in {1..80}; do [ "$(_count_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  rm -f "$RUN_DIR"/codex-bridge.*.pid
+  [ "$(_wait_role_count "$PROJ" alice 1)" -eq 1 ]
+  kill -0 "$bob"
+  kill "$bob" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$bob" 2>/dev/null || true
+}
+
+@test "launcher: a reap for one project leaves the SAME role in another project alive (#937)" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=25
+  local tab; tab=$(printf '\t')
+  _spawn_fake "$TEST_SKILL_DIR/other-proj" "team${tab}alice"; local other=$FAKE_PID
+  sleep 22 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
+  local i; for i in {1..80}; do [ "$(_count_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  rm -f "$RUN_DIR"/codex-bridge.*.pid
+  [ "$(_wait_role_count "$PROJ" alice 1)" -eq 1 ]
+  kill -0 "$other"
+  kill "$other" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$other" 2>/dev/null || true
+}
+
+@test "launcher: a reap for role 'alice' does not sweep the prefix-colliding 'alice2' (#937)" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=25
+  local tab; tab=$(printf '\t')
+  _spawn_fake "$PROJ" "team${tab}alice2"; local alice2=$FAKE_PID
+  sleep 22 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
+  local i; for i in {1..80}; do [ "$(_count_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  rm -f "$RUN_DIR"/codex-bridge.*.pid
+  [ "$(_wait_role_count "$PROJ" alice 1)" -eq 1 ]
+  kill -0 "$alice2"
+  kill "$alice2" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$alice2" 2>/dev/null || true
+}
+
+@test "launcher: an alice reaper does not kill a bridge that also serves bob (pair superset) (#937)" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=25
+  local tab; tab=$(printf '\t')
+  _spawn_fake "$PROJ" "team${tab}alice" "team${tab}bob"; local both=$FAKE_PID
+  sleep 22 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
+  local i; for i in {1..80}; do [ "$(_count_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  rm -f "$RUN_DIR"/codex-bridge.*.pid
+  [ "$(_wait_role_count "$PROJ" alice 1)" -eq 1 ]
+  # Its pair set is {alice,bob}, not {alice}: set inequality spares it.
+  kill -0 "$both"
+  kill "$both" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$both" 2>/dev/null || true
+}
+
+@test "launcher: a live bridge with no lease (legacy) is left alone, not killed (#937)" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=25
+  local tab; tab=$(printf '\t')
+  # A same-(project,role) process that never published a lease -- an older bridge
+  # build. Fail-open: no lease, no kill. Spawn it, then remove its lease.
+  _spawn_fake "$PROJ" "team${tab}alice"; local legacy=$FAKE_PID
+  local j; for j in {1..50}; do [ -f "$RUN_DIR/codex-bridge-lease.$legacy" ] && break; sleep 0.1; done
+  rm -f "$RUN_DIR/codex-bridge-lease.$legacy"
+  sleep 22 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
+  sleep 3
+  kill -0 "$legacy"
+  kill "$legacy" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$legacy" 2>/dev/null || true
 }

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -676,3 +676,21 @@ _fake_alice_lease() { # sets FAKE_PID once its lease file exists
   kill -0 "$victim"
   kill "$victim" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$victim" 2>/dev/null || true
 }
+
+@test "launcher: a lease whose start token no longer matches the live pid is not killed (#937)" {
+  # The reuse guard: if the process now at that pid started at a different time
+  # than the lease records (a recycled pid, an unrelated bridge), killing it would
+  # be a wrong-kill. The token must PROVE the live process is the leased one, or
+  # nothing happens. Same identity as the launcher, so only the token spares it.
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=25
+  _fake_alice_lease; local victim=$FAKE_PID lease="$RUN_DIR/codex-bridge-lease.$FAKE_PID"
+  # Rewrite start= to a value that cannot equal the live process's actual token
+  # (its src stays valid so the lease still parses; only the token is wrong).
+  awk '{ if ($0 ~ /^start=/) print "start=1"; else print }' "$lease" > "$lease.x"; mv "$lease.x" "$lease"
+  sleep 22 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
+  sleep 3
+  kill -0 "$victim"
+  kill "$victim" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$victim" 2>/dev/null || true
+}

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -66,9 +66,13 @@ else
   _start="${_start#"${_start%%[![:space:]]*}"}"; _start="${_start%"${_start##*[![:space:]]}"}"
   _ssrc=ps
 fi
+_ph=""
+for _pv in "${_parr[@]}"; do _ph="$_ph$(printf '%s' "$_pv" | agmsg_sha1)
+"; done
+_pairs_hash="$(printf '%s' "$(printf '%s' "$_ph" | LC_ALL=C sort | sed '/^$/d')" | agmsg_sha1)"
 { printf 'v=1\nproject=%s\npairs=%s\nhost=%s\npid=%s\nstart=%s\nstartsrc=%s\n' \
     "$(printf '%s' "$_proj" | agmsg_sha1)" \
-    "$(printf '%s' "$(printf '%s\n' "${_parr[@]}" | LC_ALL=C sort)" | agmsg_sha1)" \
+    "$_pairs_hash" \
     "$(hostname)" "$$" "$_start" "$_ssrc" ; } > "$_lease.tmp" && mv "$_lease.tmp" "$_lease"
 trap 'rm -f "$_lease"' EXIT
 [ -z "${MOCK_BRIDGE_SLEEP:-}" ] || sleep "$MOCK_BRIDGE_SLEEP"

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -56,10 +56,20 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 _lease="$RUN_DIR/codex-bridge-lease.$$"
-{ printf 'v=1\nproject=%s\npairs=%s\nhost=%s\npid=%s\nstart=%s\n' \
+# Start token exactly as codex-bridge-launcher.sh _start_token computes it: /proc
+# field 22 where available, else a trimmed `ps -o lstart=`.
+if [ -r "/proc/$$/stat" ]; then
+  _s="$(cat "/proc/$$/stat")"; _r="${_s##*)}"; read -ra _a <<< "$_r"
+  _start="${_a[19]}"; _ssrc=proc
+else
+  _start="$(ps -o lstart= -p $$)"
+  _start="${_start#"${_start%%[![:space:]]*}"}"; _start="${_start%"${_start##*[![:space:]]}"}"
+  _ssrc=ps
+fi
+{ printf 'v=1\nproject=%s\npairs=%s\nhost=%s\npid=%s\nstart=%s\nstartsrc=%s\n' \
     "$(printf '%s' "$_proj" | agmsg_sha1)" \
     "$(printf '%s' "$(printf '%s\n' "${_parr[@]}" | LC_ALL=C sort)" | agmsg_sha1)" \
-    "$(hostname)" "$$" "$(ps -o lstart= -p $$)" ; } > "$_lease.tmp" && mv "$_lease.tmp" "$_lease"
+    "$(hostname)" "$$" "$_start" "$_ssrc" ; } > "$_lease.tmp" && mv "$_lease.tmp" "$_lease"
 trap 'rm -f "$_lease"' EXIT
 [ -z "${MOCK_BRIDGE_SLEEP:-}" ] || sleep "$MOCK_BRIDGE_SLEEP"
 exit 0
@@ -603,4 +613,62 @@ _spawn_fake() { # <project> <pair...>
   sleep 3
   kill -0 "$legacy"
   kill "$legacy" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$legacy" 2>/dev/null || true
+}
+
+# --- #937 finding (4): the lease is the reaper's authority, so a broken one is a
+# new failure surface. Every malformed/partial/foreign lease must fail CLOSED
+# (no kill), asserted by a same-(project,alice) fake surviving the reaper. Each
+# starts from the valid lease the mock published, then corrupts that one file. ---
+_fake_alice_lease() { # sets FAKE_PID once its lease file exists
+  local tab; tab=$(printf '\t')
+  _spawn_fake "$PROJ" "team${tab}alice"
+  local j; for j in {1..50}; do [ -f "$RUN_DIR/codex-bridge-lease.$FAKE_PID" ] && break; sleep 0.1; done
+}
+
+@test "launcher: a truncated lease (missing fields) is not killed, fail-closed (#937)" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=25
+  _fake_alice_lease; local victim=$FAKE_PID lease="$RUN_DIR/codex-bridge-lease.$FAKE_PID"
+  head -3 "$lease" > "$lease.x"; mv "$lease.x" "$lease"
+  sleep 22 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
+  sleep 3
+  kill -0 "$victim"
+  kill "$victim" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$victim" 2>/dev/null || true
+}
+
+@test "launcher: a lease with a foreign host is not killed, fail-closed (#937)" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=25
+  _fake_alice_lease; local victim=$FAKE_PID lease="$RUN_DIR/codex-bridge-lease.$FAKE_PID"
+  awk '{ if ($0 ~ /^host=/) print "host=some-other-host.invalid"; else print }' "$lease" > "$lease.x"; mv "$lease.x" "$lease"
+  sleep 22 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
+  sleep 3
+  kill -0 "$victim"
+  kill "$victim" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$victim" 2>/dev/null || true
+}
+
+@test "launcher: a lease with an unknown extra key is not killed, fail-closed (#937)" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=25
+  _fake_alice_lease; local victim=$FAKE_PID lease="$RUN_DIR/codex-bridge-lease.$FAKE_PID"
+  { cat "$lease"; printf 'rogue=1\n'; } > "$lease.x"; mv "$lease.x" "$lease"
+  sleep 22 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
+  sleep 3
+  kill -0 "$victim"
+  kill "$victim" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$victim" 2>/dev/null || true
+}
+
+@test "launcher: a lease with a duplicated key is not killed, fail-closed (#937)" {
+  put_record team alice thread-alice "$PROJ" codex
+  export MOCK_BRIDGE_SLEEP=25
+  _fake_alice_lease; local victim=$FAKE_PID lease="$RUN_DIR/codex-bridge-lease.$FAKE_PID"
+  { cat "$lease"; printf 'pid=99999\n'; } > "$lease.x"; mv "$lease.x" "$lease"
+  sleep 22 3>&- & local parent=$!
+  bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
+  sleep 3
+  kill -0 "$victim"
+  kill "$victim" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$victim" 2>/dev/null || true
 }


### PR DESCRIPTION
Part of #906 (link 2). On `main`.

## The leak

`codex-bridge-launcher.sh`'s reuse check trusts only the pidfile PID: if the recorded PID is alive and bound to the current app-server/thread it reuses that bridge, otherwise it removes the pidfile and spawns a new one. What it never does is look for a LIVE bridge for this same (project, role) that the pidfile does not name — and that bridge exists whenever the pidfile was removed while the process stayed alive:

- a kill that failed (`kill … || true`) on a mismatch, e.g. a cross-host PID over an NFS-shared `$HOME` (#906, #938), or a race;
- a launcher killed (SIGKILL/OOM) between the spawn and the pidfile write.

The launcher then spawns a duplicate beside the orphan. On a host with a per-user pid limit those accumulate until the slice saturates (#906, two incidents in one day).

Reproduced against the real launcher (the mock bridge in `tests/test_codex_bridge_launcher.bats`): launch a bridge, remove its pidfile while it stays alive, and the polling child spawns a second — two live bridges for one role.

## The change

Before the spawn, reap any live codex-bridge for THIS exact (project, role), then bound how often we spawn.

**Kill only, never adopt.** Whether a found bridge is bound to the current app-server/thread cannot be told from the launcher (the files it would have written may be this launcher's, or gone), so a "still good" guess would keep alive exactly the stray this removes. Killing a good one costs one restart; adopting a bad one is the bug.

**Exact match on BOTH `--project` and each `--pair team\tname`.** The pidfile/run-file key is role-only (`team.name`), not project-scoped, so a same-role bridge in another project shares the key — matching must scope by project too, or it would kill an unrelated project's bridge. Matching reads the process argv: Linux `/proc/PID/cmdline` (NUL-separated, so `grep -Fxq` matches a whole argv element and a prefix cannot sneak in); elsewhere `ps -o args=`, normalising the pair's TAB (macOS/BSD `ps` prints it as `\011`) and bounding each token with spaces so `dev` does not match `dev2`. Exact where `/proc` exists; best-effort for a project/role value that itself contains a space, which `ps` cannot disambiguate.

**Non-Windows only.** Matching yields a PID that is only killable in this shell's own PID namespace, which on Windows (MSYS vs native) is the #458 mismatch, unsolved until that lands; there the scan does nothing rather than kill a PID it cannot address. **If no process lister (`pgrep`) is available** (a minimal container), it also does nothing and the spawn proceeds — no worse than before.

**A spawn-rate ceiling** (`_SPAWN_MAX` in `_SPAWN_WINDOW` s, 5 in 30) bounds the remaining churn: a bridge that cannot stay up (the launcher dying before it records the pidfile) would reap-and-respawn every poll tick. A rate-limited tick changes nothing (it does not even reap), so a genuinely-stuck role backs off instead of spinning. Not a fix for the crash, a cap on its cost.

## Verification

`tests/test_codex_bridge_launcher.bats` +4, all driving the real launcher:

- reaps a same-(project,role) orphan the pidfile lost, converging to one (the repro, now green);
- a reap for one role leaves a same-project OTHER role (`bob`) alive;
- a reap for one project leaves the SAME role (`alice`) in another project alive;
- a reap for role `alice` does not sweep the prefix-colliding `alice2`.

The last three assert SURVIVAL — that the kill is scoped, not just that the orphan dies — because a too-broad kill passes an "it died" test but is the worst outcome here. Full `test_codex_bridge_launcher.bats` green locally; no existing test regressed (the #485 dedup tests still pass).

Not done here: the cross-host PID collision itself (#938 — a PID is only meaningful with a host attached) and the Windows PID-namespace mismatch (#458).
