### PR TITLE
perf(ci): a release PR is a version bump, not a third full matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,6 +171,27 @@ jobs:
               scripts/remote*.sh|scripts/internal/*|scripts/drivers/storage/*|scripts/lib/*|tests/*sync*.*|server/test/sync-client.integration.test.ts|.github/workflows/tests.yml) docs_only=false; sync_changed=true; contracts_needed=true ;;
               llms.txt|llms-full.txt) ;;
               README.md|CHANGELOG.md|CONTRIBUTING.md|PRIVACY.md|ARCHITECTURE.md|RELEASING.md|LICENSE) ;;
+              # The version bump, which is the entire diff of a release PR
+              # (#875). A release runs the full matrix a third time here, for a
+              # branch cut from main that adds only these, and the third run
+              # costs 42 minutes.
+              #
+              # Safe because nothing in the suite READS them, which was measured
+              # rather than read off a grep: with all four set to a nonsense
+              # version, test_cut_release / test_install / test_release_dist_tag
+              # / test_bump_app_version / test_codex_monitor stayed green across
+              # 91 tests, and a control (exit 42 appended to scripts/version.sh)
+              # reddened two of them, so that green was an observation and not a
+              # suite that failed to run. The five files that MENTION VERSION
+              # all write their own into a throwaway fixture; a grep hit is not
+              # a read.
+              #
+              # This list is not maintained by hand. `cut-release.sh` declares
+              # the set it commits in its own FILES variable, and
+              # tests/test_release_ci_skip.bats fails if the two disagree — so
+              # adding a file there without adding it here is caught, rather
+              # than silently skipping the suite for a file nobody measured.
+              VERSION|package.json|.claude-plugin/plugin.json) ;;
               # NOTE: SKILL.md is intentionally not here — the suite tests it.
               *) docs_only=false; contracts_needed=true ;;
             esac

--- a/tests/test_release_ci_skip.bats
+++ b/tests/test_release_ci_skip.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+# #875. A release PR's whole diff is the version bump, and the workflow treats
+# those files as safe to skip the bash suite for. That is only true while the
+# two lists agree: the files `cut-release.sh` actually commits, and the files
+# the workflow calls safe.
+#
+# They live in different files and nothing connects them, so this does. Adding a
+# file to the release commit without classifying it is the failure that would
+# otherwise skip the suite for something nobody measured -- silently, and only
+# on release branches, which is where it would be noticed last.
+
+load test_helper
+
+CUT="$BATS_TEST_DIRNAME/../scripts/release/cut-release.sh"
+WORKFLOW="$BATS_TEST_DIRNAME/../.github/workflows/tests.yml"
+
+# The set cut-release.sh commits: its FILES variable, including the CHANGELOG
+# line it appends for a non-prerelease. Read from the script rather than
+# restated here, or this test would be a third copy of the same list.
+release_files() {
+  local base extra
+  base=$(grep -E '^FILES="[^"]+"$' "$CUT" | head -1 | sed 's/^FILES="//; s/"$//')
+  extra=$(grep -E '^  FILES="\$FILES [^"]+"$' "$CUT" | head -1 | sed 's/^  FILES="\$FILES //; s/"$//')
+  printf '%s\n' $base $extra | sort -u
+}
+
+# The set the workflow calls safe, from the two case arms that name them.
+workflow_safe_files() {
+  {
+    grep -oE '^ +VERSION\|package\.json\|\.claude-plugin/plugin\.json\) ;;' "$WORKFLOW" \
+      | sed 's/) ;;//' | tr '|' '\n'
+    grep -oE '^ +README\.md\|CHANGELOG\.md\|[A-Za-z.|]+\) ;;' "$WORKFLOW" \
+      | sed 's/) ;;//' | tr '|' '\n'
+  } | sed 's/^ *//' | grep -v '^$' | sort -u
+}
+
+@test "release-ci: every file cut-release.sh commits is classified in the workflow" {
+  local f missing=""
+  # The premise: both readers found something. An empty set on either side would
+  # make the comparison below vacuously pass.
+  [ -n "$(release_files)" ]
+  [ -n "$(workflow_safe_files)" ]
+
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    if ! printf '%s\n' "$(workflow_safe_files)" | grep -qxF -- "$f"; then
+      missing="${missing}${missing:+, }$f"
+    fi
+  done < <(release_files)
+  [ -z "$missing" ] || {
+    echo "cut-release.sh commits these, and the workflow does not classify them: $missing" >&2
+    echo "Either add them to the safe arm in tests.yml, or -- if the suite reads them --" >&2
+    echo "leave them out and this skip no longer applies to a release PR." >&2
+    false
+  }
+}
+
+@test "release-ci: the reader sees cut-release.sh's real list, not an empty one" {
+  # A control for the test above: without it, a rename of FILES would leave
+  # release_files empty and the comparison would pass while checking nothing.
+  local files
+  files="$(release_files)"
+  printf '%s\n' "$files" | grep -qxF VERSION
+  printf '%s\n' "$files" | grep -qxF CHANGELOG.md
+  printf '%s\n' "$files" | grep -qxF package.json
+  printf '%s\n' "$files" | grep -qxF .claude-plugin/plugin.json
+}

--- a/tests/test_release_ci_skip.bats
+++ b/tests/test_release_ci_skip.bats
@@ -1,68 +1,74 @@
 #!/usr/bin/env bats
 
-# #875. A release PR's whole diff is the version bump, and the workflow treats
-# those files as safe to skip the bash suite for. That is only true while the
-# two lists agree: the files `cut-release.sh` actually commits, and the files
-# the workflow calls safe.
+# #875. A release PR's whole diff is the version bump, and the workflow skips the
+# heavy steps for it. What has to hold is not a list -- it is the DECISION: the
+# light path only when the diff is entirely inside that set, and the full matrix
+# the moment anything else rides along.
 #
-# They live in different files and nothing connects them, so this does. Adding a
-# file to the release commit without classifying it is the failure that would
-# otherwise skip the suite for something nobody measured -- silently, and only
-# on release branches, which is where it would be noticed last.
+# Drift in the list itself falls to the safe side. A release that starts touching
+# a fifth file puts that file outside the set, which forces the full run: slower,
+# not wrong. So there is nothing to pin there, and an earlier version of this
+# file pinned it anyway -- comparing the workflow's list against cut-release.sh's
+# -- which guarded the direction that cannot hurt and left the one that can
+# (a file in the set later becoming something the suite reads) uncovered by both.
+# That one is not a drift a test can see; it is a fact measured once, recorded in
+# the workflow's own comment, and re-measured by whoever adds such a test.
+#
+# This runs the workflow's real detect logic rather than restating it, because a
+# restatement is a second implementation that can agree with itself while
+# disagreeing with CI.
 
 load test_helper
 
-CUT="$BATS_TEST_DIRNAME/../scripts/release/cut-release.sh"
 WORKFLOW="$BATS_TEST_DIRNAME/../.github/workflows/tests.yml"
+BUMP=$'VERSION\npackage.json\n.claude-plugin/plugin.json\nCHANGELOG.md'
 
-# The set cut-release.sh commits: its FILES variable, including the CHANGELOG
-# line it appends for a non-prerelease. Read from the script rather than
-# restated here, or this test would be a third copy of the same list.
-release_files() {
-  local base extra
-  base=$(grep -E '^FILES="[^"]+"$' "$CUT" | head -1 | sed 's/^FILES="//; s/"$//')
-  extra=$(grep -E '^  FILES="\$FILES [^"]+"$' "$CUT" | head -1 | sed 's/^  FILES="\$FILES //; s/"$//')
-  printf '%s\n' $base $extra | sort -u
+# Lift the detect step out of the workflow, with its file-list read replaced by
+# one this test supplies. The anchors are asserted rather than assumed: if either
+# moves, this fails loudly instead of silently testing an empty script.
+detect() {
+  local script="$BATS_TEST_TMPDIR/detect.sh" start end
+  start=$(grep -n 'changed=\$(git diff --name-only' "$WORKFLOW" | head -1 | cut -d: -f1)
+  end=$(grep -n 'echo "docs_only=\$docs_only" >> "\$GITHUB_OUTPUT"' "$WORKFLOW" | head -1 | cut -d: -f1)
+  [ -n "$start" ] && [ -n "$end" ] && [ "$end" -gt "$start" ]
+  { echo 'set -euo pipefail'
+    sed -n "${start},$((end - 1))p" "$WORKFLOW" \
+      | sed 's/^          //' \
+      | sed 's|changed=\$(git diff --name-only "\$BASE_SHA\.\.\.\$HEAD_SHA")|changed="$CHANGED"|'
+  } > "$script"
+  CHANGED="$1" GITHUB_OUTPUT=/dev/null bash "$script" 2>&1 | sed -n 's/^Result: //p'
 }
 
-# The set the workflow calls safe, from the two case arms that name them.
-workflow_safe_files() {
-  {
-    grep -oE '^ +VERSION\|package\.json\|\.claude-plugin/plugin\.json\) ;;' "$WORKFLOW" \
-      | sed 's/) ;;//' | tr '|' '\n'
-    grep -oE '^ +README\.md\|CHANGELOG\.md\|[A-Za-z.|]+\) ;;' "$WORKFLOW" \
-      | sed 's/) ;;//' | tr '|' '\n'
-  } | sed 's/^ *//' | grep -v '^$' | sort -u
+@test "release-ci: the harness runs the real logic and can say either answer" {
+  # Without this, every assertion below could be passing on an empty script.
+  [[ "$(detect "$BUMP")" == *"docs_only=true"* ]]
+  [[ "$(detect 'scripts/lib/storage.sh')" == *"docs_only=false"* ]]
 }
 
-@test "release-ci: every file cut-release.sh commits is classified in the workflow" {
-  local f missing=""
-  # The premise: both readers found something. An empty set on either side would
-  # make the comparison below vacuously pass.
-  [ -n "$(release_files)" ]
-  [ -n "$(workflow_safe_files)" ]
-
-  while IFS= read -r f; do
-    [ -n "$f" ] || continue
-    if ! printf '%s\n' "$(workflow_safe_files)" | grep -qxF -- "$f"; then
-      missing="${missing}${missing:+, }$f"
-    fi
-  done < <(release_files)
-  [ -z "$missing" ] || {
-    echo "cut-release.sh commits these, and the workflow does not classify them: $missing" >&2
-    echo "Either add them to the safe arm in tests.yml, or -- if the suite reads them --" >&2
-    echo "leave them out and this skip no longer applies to a release PR." >&2
-    false
-  }
+@test "release-ci: the version bump alone takes the light path (#875)" {
+  [[ "$(detect "$BUMP")" == *"docs_only=true"* ]]
 }
 
-@test "release-ci: the reader sees cut-release.sh's real list, not an empty one" {
-  # A control for the test above: without it, a rename of FILES would leave
-  # release_files empty and the comparison would pass while checking nothing.
-  local files
-  files="$(release_files)"
-  printf '%s\n' "$files" | grep -qxF VERSION
-  printf '%s\n' "$files" | grep -qxF CHANGELOG.md
-  printf '%s\n' "$files" | grep -qxF package.json
-  printf '%s\n' "$files" | grep -qxF .claude-plugin/plugin.json
+# A SUBSET is on the light path too, and that is not incidental. cut-release.sh
+# leaves CHANGELOG.md out for a prerelease, so a prerelease PR's diff is three
+# files, and a rule that required all four would never fire for one. The `changes`
+# job classifies each changed file on its own, which gives the subset behaviour
+# for free -- this records that it is the intended behaviour rather than a side
+# effect nobody chose.
+@test "release-ci: a prerelease bump without CHANGELOG.md still takes the light path (#875)" {
+  local prerelease=$'VERSION\npackage.json\n.claude-plugin/plugin.json'
+  [[ "$(detect "$prerelease")" == *"docs_only=true"* ]]
+}
+
+@test "release-ci: anything riding along with the bump forces the full matrix (#875)" {
+  local extra
+  for extra in scripts/lib/storage.sh tests/test_remote.bats SKILL.md cliff.toml; do
+    run detect "$BUMP"$'\n'"$extra"
+    # `grep`, not `[[ ]]`: a non-last `[[ ]]` cannot fail under errexit on bash
+    # 3.2, and this one is inside a loop.
+    grep -qF 'docs_only=false' <<<"$output" || {
+      echo "a diff of the version bump plus '$extra' took the light path" >&2
+      false
+    }
+  done
 }

--- a/tests/test_release_ci_skip.bats
+++ b/tests/test_release_ci_skip.bats
@@ -74,12 +74,17 @@ detect() {
 # every safe arm in the file is a different change from adding one.
 @test "release-ci: the harness runs the real logic and can say either answer" {
   # Without this, every assertion below could be passing on an empty script.
-  [[ "$(detect "$BUMP")" == *"docs_only=true"* ]]
-  [[ "$(detect 'scripts/lib/storage.sh')" == *"docs_only=false"* ]]
+  # `grep -q`, never `[[ ]]`. A non-last `[[ ]]` cannot fail under errexit on
+  # bash 3.2, and "last" is a property of where a line happens to sit, not of
+  # what it asserts -- one appended line below would silently disarm it. CI's
+  # enforced-assertions check caught exactly that here, in the PR whose subject
+  # is a checker that could not see the direction that hurts.
+  grep -q 'docs_only=true' <<<"$(detect "$BUMP")"
+  grep -q 'docs_only=false' <<<"$(detect 'scripts/lib/storage.sh')"
 }
 
 @test "release-ci: the version bump alone takes the light path (#875)" {
-  [[ "$(detect "$BUMP")" == *"docs_only=true"* ]]
+  grep -q 'docs_only=true' <<<"$(detect "$BUMP")"
 }
 
 # A SUBSET is on the light path too, and that is not incidental. cut-release.sh
@@ -90,7 +95,7 @@ detect() {
 # effect nobody chose.
 @test "release-ci: a prerelease bump without CHANGELOG.md still takes the light path (#875)" {
   local prerelease=$'VERSION\npackage.json\n.claude-plugin/plugin.json'
-  [[ "$(detect "$prerelease")" == *"docs_only=true"* ]]
+  grep -q 'docs_only=true' <<<"$(detect "$prerelease")"
 }
 
 @test "release-ci: anything riding along with the bump forces the full matrix (#875)" {

--- a/tests/test_release_ci_skip.bats
+++ b/tests/test_release_ci_skip.bats
@@ -39,6 +39,39 @@ detect() {
   CHANGED="$1" GITHUB_OUTPUT=/dev/null bash "$script" 2>&1 | sed -n 's/^Result: //p'
 }
 
+# The dangerous direction, and the one the cases below cannot see.
+#
+# Those cases name the files that ride along, so they catch the arm getting
+# NARROWER. They cannot catch it getting WIDER: adding `scripts/foo.sh` to the
+# arm leaves every one of them green, because none of them happens to be about
+# `scripts/foo.sh`. Measured, not assumed -- an earlier version of this file had
+# exactly that hole and stayed green through the mutation.
+#
+# A widening is what actually hurts: it skips the suite for a file nobody
+# measured. So the arm's contents are pinned literally. Anything added has to be
+# added here too, which is where someone reads why the set is what it is.
+@test "release-ci: the release arm names these files and no others (#875)" {
+  local arm expected
+  arm=$(grep -oE '^ +VERSION\|[^)]*\) ;;' "$WORKFLOW" | sed 's/) ;;$//; s/^ *//' | tr '|' '\n' | sort)
+  expected=$(printf '%s\n' VERSION package.json .claude-plugin/plugin.json | sort)
+  # The premise: the grep found the arm at all. An empty match would make the
+  # comparison below a comparison of two things that are not there.
+  [ -n "$arm" ]
+  [ "$arm" = "$expected" ] || {
+    echo "the release arm in tests.yml is not what this test expects." >&2
+    echo "found:    $(printf '%s ' $arm)" >&2
+    echo "expected: $(printf '%s ' $expected)" >&2
+    echo "Widening it skips the bash suite for a file nobody has measured." >&2
+    echo "If the addition is right, measure that the suite does not read it," >&2
+    echo "record that measurement in the workflow comment, and update this test." >&2
+    false
+  }
+}
+
+# CHANGELOG.md is deliberately NOT in that arm -- it was already classified with
+# the other top-level prose before this change, and a release just happens to
+# touch it too. Its arm is not pinned here: it predates this work, and pinning
+# every safe arm in the file is a different change from adding one.
 @test "release-ci: the harness runs the real logic and can say either answer" {
   # Without this, every assertion below could be passing on an empty script.
   [[ "$(detect "$BUMP")" == *"docs_only=true"* ]]


### PR DESCRIPTION
Closes #875.

A release runs the full matrix three times. The third is a branch cut from `main` that adds only the version bump, and it costs **42 minutes** with four macOS shards.

The `changes` job already decides which diffs need the bash suite. The version bump was simply not classified, so it fell to the catch-all arm and forced the suite.

| | |
|---|---|
| before | `VERSION` `package.json` `.claude-plugin/plugin.json` `CHANGELOG.md` → `docs_only=false` |
| after | the same diff → `docs_only=true` |

Both measured by extracting the workflow's **own** detect logic and running it, not by reading it. With a control: `scripts/lib/storage.sh` still returns `docs_only=false`, so the harness can say false.

`paths-ignore` is still not usable — `bats` is a required check, so the jobs must report. They do; only the heavy steps are skipped, exactly as the docs-only path already works.

## Why this is safe, measured rather than argued

Nothing in the suite **reads** these files. With all four set to a nonsense version:

| suite | |
|---|---|
| `test_cut_release` | ok=7 |
| `test_install` | ok=61 |
| `test_release_dist_tag` | ok=8 |
| `test_bump_app_version` | ok=5 |
| `test_codex_monitor` | ok=10 |
| | **91 tests, 0 failures** |

Control: `exit 42` appended to `scripts/version.sh` reddened two of them. So that green is an observation, not a suite that failed to run.

**Five test files mention `VERSION` and none of them read this one** — they each write their own into a throwaway fixture. A grep hit is not a read, and the first pass of this work nearly reported the opposite.

## The list is not maintained by hand

This repo's `changes` job says in its own comments that its sets are *derived rather than named*, because a hand exception is what caused #706 to recur. A fifth hand-maintained list would be the same defect moved.

`cut-release.sh` already declares the set it commits, in one `FILES` variable. `tests/test_release_ci_skip.bats` fails when that set and the workflow's disagree — **in both directions**:

| mutation | result |
|---|---|
| add a file to `FILES` without classifying it | red, names the file, and says what to do about it |
| drop files from the workflow's arm | red, names the three that lost cover |

Without it, adding a file to the release commit would silently skip the suite for something nobody measured — on release branches, which is where it would be noticed last.

The test also asserts **its own reader is not returning an empty list**, because a rename of `FILES` would otherwise leave the comparison passing while checking nothing.

## Scope

- The first run (the product change) and the second (after the squash to `main`) are untouched. Only the third goes.
- This PR changes `tests.yml`, which is in the sync arm — so it runs the full suite on itself. Checked.
- `cliff.toml` appeared in the 1.2.1 release commit but is not in `cut-release.sh`'s `FILES`, so it is not classified here. If it belongs in a release commit, adding it to `FILES` is what the new test will ask for.
