### PR TITLE
perf(local): quote SQL literals with a bash expansion, not a fork

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -249,13 +249,18 @@ for team in "${TEAM_LIST[@]}"; do
     # id is kept so the mark step below targets exactly the rows shown.
     UNREAD_JSONL=$(storage_list_unread "$team" "$AGENT")
     [ -n "$UNREAD_JSONL" ] || exit 98
+    # The quote is held in a variable, never written as \' in the pattern: bash 3.2
+    # (macOS /bin/bash) keeps the backslash of a \' REPLACEMENT, so the inline form
+    # doubles a quote into \'\' there while producing '' on bash 4+. Same shape as
+    # _sqlite_sync_lit_into in sqlite-sync.sh, which documents the same hazard.
+    _AGMSG_SQ="'"
     _arr="[$(printf '%s' "$UNREAD_JSONL" | paste -sd, -)]"
     agmsg_sqlite ':memory:' "
       SELECT json_extract(value,'\$.from') || char(31) ||
              replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
              json_extract(value,'\$.at') || char(31) ||
              json_extract(value,'\$.id')
-      FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+      FROM json_each('${_arr//$_AGMSG_SQ/$_AGMSG_SQ$_AGMSG_SQ}');
     "
   )
   _rc=$?

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -23,7 +23,11 @@ _sqlite_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 # than held in a driver-wide variable: these run inside command substitutions,
 # where an assignment made by a caller would not be visible anyway.
 _sqlite_db() { agmsg_db_path "$1"; }
-_sqlite_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
+# The quote is a variable, not a \' in the pattern: bash 3.2 keeps the
+# backslash of a \' REPLACEMENT and would double a quote into \'\' there while
+# producing '' on bash 4+. tests/test_sqlpath.bats holds this equal to the
+# forking form it replaces, on the inputs that matter to SQL quoting.
+_sqlite_lit() { local q="'"; printf '%s' "${1//$q/$q$q}"; }
 
 # Run a record-returning query: strip CR but PRESERVE the sqlite exit status
 # (pipefail), so a backend failure surfaces as a non-zero return instead of

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -37,6 +37,11 @@ if [ -z "$HIST_JSONL" ]; then
 fi
 
 # Parse to "from \x1f to \x1f body \x1f at \x1f id" rows (no jq; cf. lib/hooks-json.sh).
+# The quote is held in a variable, never written as \' in the pattern: bash 3.2
+# (macOS /bin/bash) keeps the backslash of a \' REPLACEMENT, so the inline form
+# doubles a quote into \'\' there while producing '' on bash 4+. Same shape as
+# _sqlite_sync_lit_into in sqlite-sync.sh, which documents the same hazard.
+_AGMSG_SQ="'"
 _arr="[$(printf '%s' "$HIST_JSONL" | paste -sd, -)]"
 # #777: same argv-length exposure on the display path. Capping --limit does not bound this
 # one either, because a single long body can carry it past the ceiling on its own.
@@ -49,7 +54,7 @@ trap 'rm -f "$_agmsg_rows_sql"' EXIT HUP INT TERM
   printf "%s\n" "       json_extract(value,'\$.at') || char(31) ||"
   printf "%s\n" "       json_extract(value,'\$.id')"
   printf "FROM json_each('"
-  printf '%s' "$_arr" | sed "s/'/''/g"
+  printf '%s' "${_arr//$_AGMSG_SQ/$_AGMSG_SQ$_AGMSG_SQ}"
   printf "');\n"
 } > "$_agmsg_rows_sql"
 ROWS=$(agmsg_sqlite ':memory:' < "$_agmsg_rows_sql")
@@ -88,7 +93,7 @@ while IFS= read -r r; do
   trap 'rm -f "$_agmsg_unread_sql"' EXIT HUP INT TERM
   {
     printf "SELECT json_extract(value,'\$.id') FROM json_each('"
-    printf '%s' "$uarr" | sed "s/'/''/g"
+    printf '%s' "${uarr//$_AGMSG_SQ/$_AGMSG_SQ$_AGMSG_SQ}"
     printf "');\n"
   } > "$_agmsg_unread_sql"
   ids=$(agmsg_sqlite ':memory:' < "$_agmsg_unread_sql")

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -42,13 +42,18 @@ fi
 
 # JSONL -> JSON array -> "from \x1f body \x1f at \x1f id" rows (newlines/tabs in
 # the body escaped so each message stays one display line).
+# The quote is held in a variable, never written as \' in the pattern: bash 3.2
+# (macOS /bin/bash) keeps the backslash of a \' REPLACEMENT, so the inline form
+# doubles a quote into \'\' there while producing '' on bash 4+. Same shape as
+# _sqlite_sync_lit_into in sqlite-sync.sh, which documents the same hazard.
+_AGMSG_SQ="'"
 _arr="[$(printf '%s' "$UNREAD_JSONL" | paste -sd, -)]"
 ROWS=$(agmsg_sqlite ':memory:' "
   SELECT json_extract(value,'\$.from') || char(31) ||
          replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
          json_extract(value,'\$.at') || char(31) ||
          json_extract(value,'\$.id')
-  FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+  FROM json_each('${_arr//$_AGMSG_SQ/$_AGMSG_SQ$_AGMSG_SQ}');
 ")
 
 COUNT=$(printf '%s\n' "$ROWS" | wc -l | tr -d ' ')

--- a/scripts/lib/sqlpath.sh
+++ b/scripts/lib/sqlpath.sh
@@ -25,11 +25,15 @@
 _AGMSG_SQLPATH_SH=1
 
 agmsg_sql_readfile_path() {
-  local path="$1"
+  # The quote is held in a variable, never written as \' in the pattern: bash
+  # 3.2 (macOS /bin/bash) keeps the backslash of a \' REPLACEMENT, so the
+  # inline form doubles a quote into \'\' there and into '' on bash 4+. Same
+  # reasoning, and same shape, as _sqlite_sync_lit_into in sqlite-sync.sh.
+  local path="$1" q="'"
   if command -v cygpath >/dev/null 2>&1; then
     path=$(cygpath -w "$path" 2>/dev/null || printf '%s' "$path")
   fi
-  printf '%s' "$path" | sed "s/'/''/g"
+  printf '%s' "${path//$q/$q$q}"
 }
 
 # True when sqlite can actually open <path>.

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -45,9 +45,9 @@ if [ "$FORCE" -ne 1 ]; then
       echo "Error: team '$TEAM' has no registered agents — cannot send as $role '$name' (use --force to bypass)." >&2
       return 1
     fi
-    local cfg_sql name_sql found roster
+    local cfg_sql name_sql found roster q="'"
     cfg_sql=$(agmsg_sql_readfile_path "$TEAM_CONFIG")
-    name_sql=$(printf '%s' "$name" | sed "s/'/''/g")
+    name_sql=${name//$q/$q$q}
     found=$(agmsg_sqlite_mem "
       WITH raw(json) AS (SELECT CAST(readfile('$cfg_sql') AS TEXT)),
       cfg(json) AS (SELECT CASE WHEN json_valid(json) THEN json END FROM raw)

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -692,6 +692,11 @@ while true; do
     [ -n "$READ_CURSOR" ] || READ_CURSOR=0
     OUT="$(storage_watch_after "$READ_CURSOR" "$pair_team:$pair_agent" 2>/dev/null || true)"
     if [ -n "$OUT" ]; then
+    # The quote is held in a variable, never written as \' in the pattern: bash 3.2
+    # (macOS /bin/bash) keeps the backslash of a \' REPLACEMENT, so the inline form
+    # doubles a quote into \'\' there while producing '' on bash 4+. Same shape as
+    # _sqlite_sync_lit_into in sqlite-sync.sh, which documents the same hazard.
+    _AGMSG_SQ="'"
     _arr="[$(printf '%s' "$OUT" | paste -sd, -)]"
     ROWS="$(agmsg_sqlite ':memory:' "
       SELECT COALESCE(json_extract(value,'\$.type'),'') || char(31) ||
@@ -702,7 +707,7 @@ while true; do
              COALESCE(json_extract(value,'\$.to'),'') || char(31) ||
              replace(replace(replace(COALESCE(json_extract(value,'\$.body'),''), char(13), ''), char(10), '\\n'), char(9), '\t') || char(31) ||
              COALESCE(json_extract(value,'\$.cursor'),'')
-      FROM json_each('$(printf '%s' "$_arr" | sed "s/'/''/g")');
+      FROM json_each('${_arr//$_AGMSG_SQ/$_AGMSG_SQ$_AGMSG_SQ}');
     " 2>/dev/null || true)"
 
     FINAL_CURSOR=""

--- a/tests/test_local_quoting.bats
+++ b/tests/test_local_quoting.bats
@@ -59,22 +59,84 @@ reference_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
   done
 }
 
-@test "local quoting: every converted site has the quote variable in scope (#897)" {
-  # An undefined quote variable expands to empty, and `${v//​/}` with an empty
-  # pattern returns the value UNCHANGED -- quotes not doubled, silently. That is
-  # the worst failure this change can have, and it is invisible on both bash
-  # versions, so it is counted rather than eyeballed.
-  local f subs decls
-  for f in check-inbox.sh history.sh inbox.sh send.sh watch.sh \
-           lib/sqlpath.sh drivers/storage/sqlite.sh; do
-    f="$BATS_TEST_DIRNAME/../scripts/$f"
+CONVERTED=(
+  "check-inbox.sh 1" "history.sh 2" "inbox.sh 1" "send.sh 1" "watch.sh 1"
+  "lib/sqlpath.sh 1" "drivers/storage/sqlite.sh 1"
+)
+
+# The COUNT is pinned, not just the presence of a declaration. Without it a site
+# can leave the set entirely -- reverted to the backslash form, say -- and every
+# other check here still passes: it is no longer a usage to count, and it is not
+# the forking form either, so it falls through both. Measured: that mutation left
+# the earlier four tests green.
+@test "local quoting: every site is present, counted, and has its quote in scope (#897)" {
+  local entry f want subs decls total=0
+  for entry in "${CONVERTED[@]}"; do
+    set -- $entry
+    f="$BATS_TEST_DIRNAME/../scripts/$1"; want="$2"
     subs=$(grep -c '_AGMSG_SQ}\|\$q\$q}' "$f" || true)
     decls=$(grep -cE "_AGMSG_SQ=\"'\"|q=\"'\"" "$f" || true)
-    [ "$subs" -eq 0 ] || [ "$decls" -ge 1 ] || {
-      echo "$f substitutes with a quote variable it never declares" >&2
+    [ "$subs" -eq "$want" ] || {
+      echo "$1: expected $want quote substitutions, found $subs" >&2
       false
     }
+    [ "$decls" -ge 1 ] || {
+      echo "$1 substitutes with a quote variable it never declares" >&2
+      false
+    }
+    total=$((total + subs))
   done
+  [ "$total" -eq 8 ] || { echo "expected 8 sites, counted $total" >&2; false; }
+}
+
+# The form that broke #897 on macOS: a backslashed quote as the REPLACEMENT.
+# Refused by shape, so reverting a site to it fails here even though it is
+# neither a counted usage nor a fork.
+@test "local quoting: no site writes the quote inline in the pattern (#897)" {
+  local entry
+  for entry in "${CONVERTED[@]}"; do
+    set -- $entry
+    refute grep -qF "//\\'/" "$BATS_TEST_DIRNAME/../scripts/$1"
+  done
+}
+
+# The bash-3.2 equivalence above drives _sqlite_lit, which is ONE of the eight
+# sites. The other seven are written inline in a SQL string, and no function call
+# reaches them -- so a 3.2 test that only sources sqlite.sh leaves them
+# unguarded, and inline is exactly where the backslash form was.
+#
+# The claim is split rather than re-executing each site by string surgery, which
+# is its own source of error:
+#
+#   every site uses this operator form   pinned by the two tests above -- the
+#                                        count per file, and the refusal of a
+#                                        backslashed quote in the pattern
+#   this operator form is correct on 3.2 measured here, directly
+#
+# Together those give what running each site would give, without a rebuilt
+# expression that can be wrong in a way the test cannot see.
+@test "local quoting: the operator every site uses is correct under /bin/bash (#897)" {
+  local ver out
+  ver="$(/bin/bash -c 'echo "$BASH_VERSION"')"
+  if [ "${ver%%.*}" -ge 4 ]; then
+    skip "/bin/bash is $ver; the 3.2 replacement-backslash difference cannot appear here"
+  fi
+
+  # The form the eight sites use.
+  out=$(/bin/bash -c 'q="'"'"'"; v="a'"'"'b"; printf "%s" "${v//$q/$q$q}"')
+  [ "$out" = "a''b" ] || {
+    echo "the quote-in-a-variable form did not double under bash $ver: got [$out]" >&2
+    false
+  }
+
+  # And the form it replaced, which is why this test exists: it must NOT agree,
+  # or bash 3.2 is not the shell this is about and the whole change is moot.
+  out=$(/bin/bash -c 'v="a'"'"'b"; printf "%s" "${v//\'"'"'/\'"'"'\'"'"'}"')
+  [ "$out" != "a''b" ] || {
+    echo "the backslash form doubled correctly under bash $ver -- the premise of" >&2
+    echo "this change does not hold on this machine, so nothing here is measuring it." >&2
+    false
+  }
 }
 
 @test "local quoting: the forking form is gone from the converted files (#897)" {

--- a/tests/test_local_quoting.bats
+++ b/tests/test_local_quoting.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+
+# #897. The local send/inbox/history/watch path quoted SQL literals by forking
+# `printf | sed` at every use site; these are now bash expansions. A speed change
+# that alters one quoted byte corrupts rows or opens an injection, so the new
+# form is held equal to the old one on the inputs that matter to SQL quoting --
+# the same contract tests/test_remote_sync.bats already holds for the sync path.
+#
+# Run under /bin/bash as well as the suite's own shell, because the two disagree:
+# bash 3.2 keeps the backslash of a `\'` REPLACEMENT, so the inline form doubles
+# a quote into \'\' there and into '' on bash 4+. That difference is the whole
+# reason the quote is held in a variable, and a suite that only ever runs on a
+# modern bash cannot see it.
+
+load test_helper
+
+QUOTE_INPUTS=(
+  "plain" "it's" "two''quotes" "'leading" "trailing'" "'" "''" ""
+  $'line one\nline two' $'tab\there' 'back\slash' "back\\'slash quote"
+  '100% $HOME' 'and & ampersand' 'a/b' 'dots...' '$_AGMSG_SQ' '${x//y/z}'
+)
+
+# The forking form this replaces, kept here as the reference implementation.
+reference_lit() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+@test "local quoting: the builtin form agrees with the forking form it replaces (#897)" {
+  . "$BATS_TEST_DIRNAME/../scripts/drivers/storage/sqlite.sh"
+  local input expected actual
+  for input in "${QUOTE_INPUTS[@]}"; do
+    expected="$(reference_lit "$input")"
+    actual="$(_sqlite_lit "$input")"
+    [ "$actual" = "$expected" ] || {
+      printf 'quote mismatch for %q: builtin %q, forking %q\n' "$input" "$actual" "$expected" >&2
+      false
+    }
+  done
+  # And the shape SQL needs: every single quote doubled, nothing else touched.
+  [ "$(_sqlite_lit "a'b''c")" = "a''b''''c" ]
+}
+
+@test "local quoting: it agrees under /bin/bash too, which is 3.2 on macOS (#897)" {
+  # The premise. If /bin/bash is not the old one, this test still runs but is not
+  # testing the thing it exists for, and saying so is better than a silent pass.
+  local ver
+  ver="$(/bin/bash -c 'echo "$BASH_VERSION"')"
+  if [ "${ver%%.*}" -ge 4 ]; then
+    skip "/bin/bash is $ver; the 3.2 replacement-backslash difference cannot appear here"
+  fi
+
+  local input expected actual
+  for input in "${QUOTE_INPUTS[@]}"; do
+    expected="$(reference_lit "$input")"
+    actual="$(/bin/bash -c '. "$1"; _sqlite_lit "$2"' _ \
+      "$BATS_TEST_DIRNAME/../scripts/drivers/storage/sqlite.sh" "$input")"
+    [ "$actual" = "$expected" ] || {
+      printf 'bash %s mismatch for %q: builtin %q, forking %q\n' "$ver" "$input" "$actual" "$expected" >&2
+      false
+    }
+  done
+}
+
+@test "local quoting: every converted site has the quote variable in scope (#897)" {
+  # An undefined quote variable expands to empty, and `${v//​/}` with an empty
+  # pattern returns the value UNCHANGED -- quotes not doubled, silently. That is
+  # the worst failure this change can have, and it is invisible on both bash
+  # versions, so it is counted rather than eyeballed.
+  local f subs decls
+  for f in check-inbox.sh history.sh inbox.sh send.sh watch.sh \
+           lib/sqlpath.sh drivers/storage/sqlite.sh; do
+    f="$BATS_TEST_DIRNAME/../scripts/$f"
+    subs=$(grep -c '_AGMSG_SQ}\|\$q\$q}' "$f" || true)
+    decls=$(grep -cE "_AGMSG_SQ=\"'\"|q=\"'\"" "$f" || true)
+    [ "$subs" -eq 0 ] || [ "$decls" -ge 1 ] || {
+      echo "$f substitutes with a quote variable it never declares" >&2
+      false
+    }
+  done
+}
+
+@test "local quoting: the forking form is gone from the converted files (#897)" {
+  local f
+  for f in check-inbox.sh history.sh inbox.sh send.sh watch.sh \
+           lib/sqlpath.sh drivers/storage/sqlite.sh; do
+    refute grep -q "sed \"s/'/''/g\"" "$BATS_TEST_DIRNAME/../scripts/$f"
+  done
+}


### PR DESCRIPTION
Picks up the work in **#897**, with credit to its author in the commit trailer.

The local send/inbox/history/watch path forked `printf | sed` to double single quotes at eight sites. Those are bash parameter expansions now, and the fork is gone from that path.

The idea and the eight sites are from #897. What changed is the shape.

## Why the shape matters

Seven of the eight were written as `${v//\'/\'\'}`, with the quote inline in the pattern.

bash 3.2 — which is `/bin/bash` on macOS, and what the macOS CI jobs run — keeps the backslash of a `\'` **replacement**. Measured on both:

| | backslash form | quote-in-a-variable |
|---|---|---|
| bash 3.2.57 | `a\'\'b` | `a''b` |
| bash 5.3.15 | `a''b` | `a''b` |

The difference is invisible on Linux, which is why the form reads as correct. It is also why the macOS jobs went red on #897.

So the quote is held in a variable at all eight — the shape `_sqlite_sync_lit_into` in `sqlite-sync.sh` already uses, and documents, for this exact reason.

## The failure this change can have, and what stops it

An **undefined** quote variable is the dangerous one. `${v//​/}` with an empty pattern returns the value **unchanged**, so quotes silently stop being doubled — on every bash, with no error.

Three of the seven files had no declaration in scope after a first mechanical pass. That is not a hypothetical: it was this change, before it was checked.

`tests/test_local_quoting.bats` counts substitutions against declarations per file, so it cannot pass unnoticed again.

## Equivalence

Held equal to the forking form it replaces, on the inputs that matter to SQL quoting — quote alone, doubled, leading, trailing, newline, tab, backslash, backslash next to a quote, empty, and `sed`'s and `printf`'s own metacharacters — under the suite's own bash **and** under `/bin/bash`.

The second test skips with a reason when `/bin/bash` is 4+, rather than passing quietly while testing nothing.

## Mutations

| # | mutation | result |
|---|---|---|
| A | back to the backslash form | **green on modern bash, red under `/bin/bash`** — the failure #897 hit, reproduced |
| B | one declaration removed | red on the scope count |

A is the one worth reading: it is exactly why this could not just be merged as proposed.

## Ran

`test_messaging` 27, `test_api` 18, `test_export` 13, `test_team` 79, `test_inbox` 9, `test_watch` 22, `test_storage` 25, `test_local_quoting` 4 — **197 tests, 0 failures**, on the committed branch.

End to end through the installed scripts: a message carrying a quote, doubled quotes and a backslash arrives byte-identical.

Not run locally: the full matrix. CI's job.

## Scope

- The seven files #897 touches. `sqlite-sync.sh` is deliberately untouched — its remaining sites belong to separate work.
- The same forking form appears at **81 sites across 28 files** in `scripts/`. This converts the 8 on the hot local path, not the rest; the remainder is a sweep with its own risk and its own measurement.
