### PR TITLE
perf(storage): index the two lookups that made import scale with the store

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -250,6 +250,16 @@ _sqlite_sync_schema() {
                   protocol_version,driver_generation,local_position),
       UNIQUE(server_instance_id,remote_team_id,protocol_version,wire_id)
     );
+    -- The one lookup on this table that the UNIQUE above cannot serve: the
+    -- apply conflict guard asks whether a server_seq is already mapped to a
+    -- DIFFERENT wire id, so it comes in by (binding, server_seq). Without
+    -- this index that guard walked every row of the binding and fetched each
+    -- one (rows carry the wire blob), once per imported message: 68.6 ms per
+    -- message on a 21,471-row store, 73 percent of the import batch, and the
+    -- reason import time grew with the store (#910). sync_quarantine already
+    -- has the equivalent path as its second UNIQUE constraint.
+    CREATE INDEX IF NOT EXISTS sync_messages_server_seq
+      ON sync_messages(server_instance_id,remote_team_id,protocol_version,server_seq);
     CREATE TABLE IF NOT EXISTS sync_quarantine (
       local_team TEXT NOT NULL,
       server_instance_id TEXT NOT NULL,

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -143,6 +143,15 @@ storage_init() {
     -- The ALTER above runs first on purpose, so an older store has the column
     -- before this asks for the index on it.
     CREATE INDEX IF NOT EXISTS events_legacy ON events(legacy_id);
+    -- id is the value every cross-reference to an event carries, but the
+    -- table's key is seq, so a lookup by id is otherwise a full scan of a
+    -- table that holds every message body. The sync import pays that scan
+    -- once per imported message (the sync_messages projection selects
+    -- FROM events WHERE id=...), which made the import batch grow with the
+    -- store: 24.6 ms per message on a 21,471-event store, against ~0 with
+    -- this index (#910's remaining reprocess drift, measured statement by
+    -- statement on a captured import batch).
+    CREATE INDEX IF NOT EXISTS events_id ON events(id);
     CREATE TABLE IF NOT EXISTS read_cursors (
       team TEXT NOT NULL,
       agent TEXT NOT NULL,

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -1244,3 +1244,24 @@ _longest_argv() {
   [ "$status" -eq 13 ]
   grep -q 'failed at sqlite-sync\.sh:[0-9]' <<<"$stderr"
 }
+
+@test "sync schema: the conflict guard's server_seq lookup on sync_messages is a search, not a scan (#910)" {
+  # The apply conflict guard asks whether a server_seq already maps to a
+  # different wire id. sync_messages' UNIQUE serves wire_id lookups only, so
+  # this came in by server_seq as a walk of every row of the binding, once
+  # per imported message -- 68.6 ms per message on a 21,471-row store, and
+  # the reason import time grew with the store. Schema setup now carries the
+  # index, on new stores and on any store the next sync call touches.
+  prepare_push >/dev/null
+  local db
+  db=$(agmsg_db_path demo)
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name='sync_messages' AND name='sync_messages_server_seq';" | tr -d '\r')" -eq 1 ]
+  sqlite3 "$db" "EXPLAIN QUERY PLAN SELECT 1 FROM sync_messages mx
+    WHERE mx.server_instance_id='s' AND mx.remote_team_id='r'
+      AND mx.protocol_version=1 AND mx.server_seq='7' AND mx.wire_id<>'w';" |
+    grep -q 'USING INDEX sync_messages_server_seq\|USING COVERING INDEX sync_messages_server_seq'
+  # A store whose sync schema predates the index picks it up on the next call.
+  sqlite3 "$db" "DROP INDEX sync_messages_server_seq;"
+  prepare_push >/dev/null
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='sync_messages_server_seq';" | tr -d '\r')" -eq 1 ]
+}

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -380,3 +380,21 @@ _use_per_team() {
   [ "$(sqlite3 "$AGMSG_STORAGE_PATH/messages.db" "PRAGMA table_info(events);" | grep -c legacy_id)" -eq 1 ]
   [ "$(sqlite3 "$AGMSG_STORAGE_PATH/messages.db" "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='events_legacy';" | tr -d '\r')" -eq 1 ]
 }
+
+@test "storage: events.id is indexed, on a new store and on one that predates the index (#910)" {
+  source "$SCRIPTS/lib/storage.sh"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=sqlite
+  agmsg_storage_load
+  storage_init demo >/dev/null
+  local db
+  db=$(agmsg_db_path demo)
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name='events' AND name='events_id';" | tr -d '\r')" -eq 1 ]
+  # The lookup the sync import makes per imported message (FROM events
+  # WHERE id=...) is a search now -- not a scan of every message body.
+  sqlite3 "$db" "EXPLAIN QUERY PLAN SELECT seq FROM events WHERE id = 'x';" | grep -q 'USING COVERING INDEX events_id\|USING INDEX events_id'
+  # A store from before this index existed picks it up on the next init.
+  sqlite3 "$db" "DROP INDEX events_id;"
+  storage_init demo >/dev/null
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='events_id';" | tr -d '\r')" -eq 1 ]
+}


### PR DESCRIPTION
Part of #910's remaining reprocess cost. Two one-line indexes, each covering a lookup the import path makes once per message against a table that grows by one row per import — which is exactly why import time grew with the store.

## Where the time was going

Event-file instrumentation of a full 21,501-message unlock reprocess (real store, 216 pages of 100) put 84.6% of the wall in the apply driver call, and apply was the only bucket that grew: 5.4 s/page in the first third, 11.6 s/page in the last, while candidate SELECT, decrypt, and page-boundary costs stayed flat. Statement-level timing of a captured apply batch (the driver's own generated SQL for the store's last 100 messages, replayed with .timer against a copy reset to un-imported) split the batch like this:

(1) The conflict guard's EXISTS comes into sync_messages by server_seq. The table's UNIQUE serves wire_id lookups only, so the planner walks every index entry of the binding and fetches each row (rows carry the wire blob): 68.6 ms/message, 6.86 s of a 9.4 s batch, 73%. sync_quarantine already has the equivalent path as its second UNIQUE constraint; sync_messages did not.

(2) The sync_messages projection selects FROM events WHERE id='...', and events has no index on id (its key is seq, and #926's index is on the neighbouring legacy_id column): 24.6 ms/message, 26%. The other two WHERE id= statements in the batch pair id with legacy_id IS NULL and are already served by events_legacy — EXPLAIN confirms only this one scans.

The remaining twelve statement shapes in the batch total ~0.1 s. Both walks lengthen linearly as imports add rows; averaged over the run they account for the observed per-message drift.

## Effect, measured on the real store

Method: copy the full store, reset its last 100 messages to un-imported (delete their events/messages/sync_messages rows, quarantine status back to pending_key), run the same reprocess with the same instrumentation. Same machine, same store, same page.

| store copy | apply, last page |
|---|---|
| stock | 13.5 / 15.7 s (two runs) |
| + events(id) only | 11.4 s |
| + sync_messages server_seq only | 6.5 s |
| + both | 5.9 s |

5.9 s is what a page cost when the store was near-empty, i.e. the growth term is gone; EXPLAIN QUERY PLAN confirms both lookups become index searches. These numbers are from the production-sized real store — a synthetic store with small bodies understates the absolute times.

## Write-side cost

Both tables are on the write hot path, so the price of two more b-trees was measured rather than assumed, on a copy of the same 21,501-message store: send.sh end to end, 50 sends each, median 156.7 ms stock vs 149.4 ms with both indexes (inside the noise, stdev ~18 ms); single INSERT INTO events + COMMIT on a warm connection, 500 each, median 0.097 ms vs 0.099 ms. The sync_messages index is not touched by a local send at all (only the sync import and ack paths write that table).

## Migration

Both are CREATE INDEX IF NOT EXISTS inside schema blocks that already run on every call (storage_init for events, the sync schema function for sync_messages), so existing stores pick the indexes up on their next write or sync call — the same route events_legacy shipped through in #926. Tests assert the index exists on a new store, that the query plan uses it, and that a store missing it gains it on the next call. Both suites (test_storage.bats, test_remote_sync.bats) are green under bash 5 and /bin/bash 3.2.
