### PR TITLE
fix(sync): the apply failure path silenced the shell's stderr, starting with #911's diagnostic

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -1043,7 +1043,7 @@ storage_sync_apply_pull() {
       [ -s "$jq_err" ] && sed 's/^/agmsg: sqlite-sync: /' "$jq_err" >&2
       printf 'agmsg: sqlite-sync: %s\n' "$1" >&2
     fi
-    exec 3<&- 2>/dev/null || true
+    { exec 3<&-; } 2>/dev/null || true
     rm -f "$sql_file" "$jq_err"
     _AGMSG_SYNC_SQL_FILE=""; _AGMSG_SYNC_JQ_ERR=""
     trap - EXIT INT TERM HUP

--- a/tests/test_apply_fail_stderr.bats
+++ b/tests/test_apply_fail_stderr.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# `_sqlite_sync_apply_fail` must not take the shell's stderr with it.
+#
+# It closes fd 3 and discards whatever closing an already-closed fd would say.
+# Written as `exec 3<&- 2>/dev/null`, with no command word, the redirection is
+# not scoped to anything -- bash applies it to the shell itself, permanently.
+# Every later `>&2` in that process goes to /dev/null.
+#
+# The path this sits on is the failure path, so the diagnostics it silences are
+# the ones a failing apply is about to print. The first casualty is the message
+# #911 added, naming which check returned 13. Reported by @JoelMitz.
+
+setup() {
+  SCRIPTS="${BATS_TEST_DIRNAME}/../scripts"
+}
+
+@test "apply-fail: closing fd 3 does not redirect the shell's stderr (#911)" {
+  # Runs the driver's OWN definition, not a copy of it: the function is nested
+  # inside storage_sync_apply_pull and cannot be sourced, so its body is lifted
+  # out of the file by line range and defined here. A copy would keep passing
+  # while the driver regressed, which is the whole failure this test is about.
+  local first last body
+  first="$(grep -n '_sqlite_sync_apply_fail() {' "${SCRIPTS}/drivers/storage/sqlite-sync.sh" | head -1 | cut -d: -f1)"
+  [ -n "$first" ]
+  last="$(awk -v s="$first" 'NR>s && /^  \}$/ { print NR; exit }' "${SCRIPTS}/drivers/storage/sqlite-sync.sh")"
+  [ -n "$last" ]
+  body="$(sed -n "${first},${last}p" "${SCRIPTS}/drivers/storage/sqlite-sync.sh")"
+
+  run bash -c "
+    jq_err=/dev/null; sql_file=/dev/null
+    $body
+    _sqlite_sync_apply_fail
+    echo 'stderr-after-close' >&2
+  "
+  [ "$status" -eq 0 ]
+  grep -q "stderr-after-close" <<<"$output"
+}
+
+@test "apply-fail: the driver closes fd 3 in a scoped block, not bare exec" {
+  # The regression is one character of syntax, so the guard is on the syntax.
+  # A bare `exec <redirect>` with no command word anywhere in this file would
+  # take the shell's stderr the same way.
+  run grep -nE '^\s*exec [0-9]*[<>][&-]* +[0-9]*>' "${SCRIPTS}/drivers/storage/sqlite-sync.sh"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Reported by @JoelMitz on 2026-08-22, reproduced here.

```
scripts/drivers/storage/sqlite-sync.sh:1046   in _sqlite_sync_apply_fail

  exec 3<&- 2>/dev/null || true
```

`exec` with no command word does not run anything — it applies its redirections to the current shell, and they stay. The intent is "close fd 3, and say nothing if closing an already-closed fd complains". The effect is that the shell's stderr is pointed at /dev/null for the rest of the process.

```
$ f() { exec 3<&- 2>/dev/null || true; }
$ echo before >&2 ; f ; echo after >&2
before
$                       # "after" is gone
```

## What it costs

`_sqlite_sync_apply_fail` is the failure path. It runs when an apply has already gone wrong, which is exactly when the messages that follow it matter. Everything written to stderr after the first failure — in that process — is discarded.

The first thing lost is the message #911 added this morning, naming which check returned 13. That diagnostic is what made the rest of today's work possible: the incident in #910 presented as `exit 13` with nothing else, and #911 existed so that would not happen again. It was disabled a few hundred lines away in the same file, on the path where it is needed.

@JoelMitz named that consequence in the report, which is the part that makes this worth fixing today rather than filing.

## The fix

```
{ exec 3<&-; } 2>/dev/null || true
```

The redirection now belongs to the block.

## Tests

Two, because either one alone passes while the other's regression ships:

- **The behaviour.** Lifts `_sqlite_sync_apply_fail`'s body out of the driver by line range and calls it, then writes to stderr and asserts the write is visible. The function is nested inside `storage_sync_apply_pull` and cannot be sourced; writing a copy of the shape into the test would keep passing while the driver regressed, which is the failure this test exists to catch.
- **The shape.** Greps the file for a bare `exec` carrying a redirection. Catches the same mistake written a different way, anywhere in the file.

Both were confirmed to go red against the old line and green against the new one.

The other two `exec` sites in the tree are fine: `codex-bridge-launcher.sh:13` carries no redirection, and `codex-monitor.sh:128` is inside a subshell, which scopes it.
