### PR TITLE
fix(codex-bridge): give the identity lease a start token on Windows

### DIFF
--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -407,9 +407,50 @@ _REAP_WAIT_TICKS=50
 #            recycled pid is always distinguishable from the one we leased.
 #   else  -> `ps -o lstart=` (second precision). Echoes "<src><TAB><token>";
 #            returns non-zero (indeterminable) so the caller fails closed.
+#   win32 -> Process.StartTime.Ticks via PowerShell -- the SAME single source
+#            codex-bridge.js startToken() writes, so both sides always agree.
+#            WMIC's CreationDate is cheaper but deprecated (already gone from some
+#            Windows 11 installs); a "WMIC, else PowerShell" order on each side
+#            independently would let the two resolve DIFFERENT sources for the
+#            same process whenever only one of them can reach wmic.exe, and their
+#            differently-FORMATTED tokens would make the reaper read a live
+#            bridge's lease as another process's. powershell.exe and pwsh return
+#            identical Ticks (measured), so falling back between those two
+#            binaries introduces no such divergence.
+#
+# ★The Windows branch is taken INSTEAD of the /proc branch, not merely before it.
+# MSYS/Cygwin do expose a working /proc (field 22 and all), but it is keyed by the
+# emulation layer's OWN pid space, while a lease records the Windows pid that
+# codex-bridge.js sees as process.pid -- the two are unrelated numbers for the
+# same process (measured on MINGW64: MSYS pid 3065729 vs winpid 1456). Letting
+# /proc win here would silently return the start time of whatever UNRELATED MSYS
+# process happens to sit at that number, and the reaper would then compare a
+# well-formed token against the wrong process: exactly the recycled-pid confusion
+# the token exists to prevent, only harder to notice because nothing errors.
+_agmsg_is_windows() {
+  case "${_AGMSG_UNAME_S:=$(uname -s 2>/dev/null || echo unknown)}" in
+    MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 _start_token() {
-  local pid="$1" s r tok
+  local pid="$1" s r tok bin
   local -a a
+  if _agmsg_is_windows; then
+    for bin in powershell.exe pwsh; do
+      # `tr -d '\r'` because PowerShell writes CRLF and Node's .trim() on the
+      # writer side strips it there, so both end up with the bare digits.
+      tok="$("$bin" -NoProfile -NonInteractive -Command \
+        "(Get-Process -Id $pid).StartTime.Ticks" 2>/dev/null | tr -d '\r' | head -n 1)"
+      tok="${tok#"${tok%%[![:space:]]*}"}"
+      tok="${tok%"${tok##*[![:space:]]}"}"
+      case "$tok" in ''|*[!0-9]*) continue ;; esac
+      printf 'pwsh\t%s' "$tok"
+      return 0
+    done
+    return 1
+  fi
   if [ -r "/proc/$pid/stat" ]; then
     s="$(cat "/proc/$pid/stat" 2>/dev/null)" || return 1
     r="${s##*)}"
@@ -433,7 +474,7 @@ _start_token() {
 # Parse a lease under an EXACT v=1 schema and fail closed on anything else. Sets
 # lproj/lpairs/lhost/lpid/lstart/lstartsrc and returns 0 only when the file is
 # precisely the seven expected keys, each once, no unknown or duplicate or extra
-# line, hashes 40-hex, pid numeric, startsrc proc|ps. A malformed, truncated, or
+# line, hashes 40-hex, pid numeric, startsrc proc|ps|pwsh. A malformed, truncated, or
 # tampered lease returns non-zero, so the reaper never kills on a doubtful one.
 _read_lease() {
   local file="$1" line k v nlines=0 lv=""
@@ -460,10 +501,16 @@ _read_lease() {
   case "$lproj" in *[!0-9a-f]*|"") return 1 ;; esac; [ "${#lproj}" -eq 40 ] || return 1
   case "$lpairs" in *[!0-9a-f]*|"") return 1 ;; esac; [ "${#lpairs}" -eq 40 ] || return 1
   case "$lpid" in *[!0-9]*|"") return 1 ;; esac
-  case "$lstartsrc" in proc|ps) ;; *) return 1 ;; esac
+  case "$lstartsrc" in proc|ps|pwsh) ;; *) return 1 ;; esac
   [ -n "$lhost" ] || return 1
   [ -n "$lstart" ] || return 1
-  if [ "$lstartsrc" = proc ]; then case "$lstart" in *[!0-9]*|"") return 1 ;; esac; fi
+  # proc's starttime ticks and .NET's StartTime.Ticks are both bare integers, so
+  # a lease carrying anything else under either label fails closed here. ps stays
+  # exempt: its lstart is a human date string whose punctuation varies by
+  # platform, and writer and reader only ever compare it byte for byte.
+  case "$lstartsrc" in
+    proc|pwsh) case "$lstart" in *[!0-9]*|"") return 1 ;; esac ;;
+  esac
   return 0
 }
 

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -407,26 +407,20 @@ _REAP_WAIT_TICKS=50
 #            recycled pid is always distinguishable from the one we leased.
 #   else  -> `ps -o lstart=` (second precision). Echoes "<src><TAB><token>";
 #            returns non-zero (indeterminable) so the caller fails closed.
-#   win32 -> Process.StartTime.Ticks via PowerShell -- the SAME single source
+#   win32 -> Process.StartTime.Ticks via PowerShell -- the same single source
 #            codex-bridge.js startToken() writes, so both sides always agree.
-#            WMIC's CreationDate is cheaper but deprecated (already gone from some
-#            Windows 11 installs); a "WMIC, else PowerShell" order on each side
-#            independently would let the two resolve DIFFERENT sources for the
-#            same process whenever only one of them can reach wmic.exe, and their
-#            differently-FORMATTED tokens would make the reaper read a live
-#            bridge's lease as another process's. powershell.exe and pwsh return
-#            identical Ticks (measured), so falling back between those two
+#            WMIC is deprecated and already absent from some Windows 11 installs;
+#            a per-side "WMIC, else PowerShell" order would let the two record
+#            differently-FORMATTED tokens for the same process. powershell.exe
+#            and pwsh return identical Ticks, so falling back between those two
 #            binaries introduces no such divergence.
 #
-# ★The Windows branch is taken INSTEAD of the /proc branch, not merely before it.
-# MSYS/Cygwin do expose a working /proc (field 22 and all), but it is keyed by the
-# emulation layer's OWN pid space, while a lease records the Windows pid that
-# codex-bridge.js sees as process.pid -- the two are unrelated numbers for the
-# same process (measured on MINGW64: MSYS pid 3065729 vs winpid 1456). Letting
-# /proc win here would silently return the start time of whatever UNRELATED MSYS
-# process happens to sit at that number, and the reaper would then compare a
-# well-formed token against the wrong process: exactly the recycled-pid confusion
-# the token exists to prevent, only harder to notice because nothing errors.
+# The Windows branch is taken INSTEAD of the /proc branch, not merely before it:
+# MSYS/Cygwin do expose a working /proc, but it is keyed by the emulation layer's
+# own pid space while a lease records the Windows pid codex-bridge.js sees as
+# process.pid. Letting /proc win would return the start time of whatever
+# unrelated MSYS process sits at that number -- the recycled-pid confusion this
+# token exists to prevent, with nothing to signal it.
 _agmsg_is_windows() {
   case "${_AGMSG_UNAME_S:=$(uname -s 2>/dev/null || echo unknown)}" in
     MINGW*|MSYS*|CYGWIN*) return 0 ;;

--- a/scripts/drivers/types/codex/codex-bridge-launcher.sh
+++ b/scripts/drivers/types/codex/codex-bridge-launcher.sh
@@ -423,7 +423,7 @@ _REAP_WAIT_TICKS=50
 # token exists to prevent, with nothing to signal it.
 _agmsg_is_windows() {
   case "${_AGMSG_UNAME_S:=$(uname -s 2>/dev/null || echo unknown)}" in
-    MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    MINGW*|MSYS*|CYGWIN*|CLANGARM*) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -1087,7 +1087,45 @@ class CodexBridge {
   //            and the only victim would be a same-(project,pair) bridge in the
   //            sub-ms window before it overwrites this pid's lease, self-corrected
   //            by the launcher respawning it.
+  //   win32 -> Process.StartTime.Ticks, read through PowerShell. Windows has NO
+  //            /proc, and the only `ps` likely to be on PATH there is MSYS's,
+  //            which rejects -o outright ("ps: unknown option -- o") rather than
+  //            degrading -- so BOTH POSIX sources above yield an empty token and
+  //            writeLease() throws, which is why the bridge could never start on
+  //            Windows at all.
+  //            ★ONE source, deliberately, not a preference list. WMIC's
+  //            CreationDate is ~2x cheaper and was the obvious first pick, but it
+  //            is deprecated and already absent from Windows 11 installs that
+  //            have dropped the Feature-on-Demand. A per-side "WMIC, else
+  //            PowerShell" order would then let THIS writer and _start_token
+  //            (codex-bridge-launcher.sh) resolve DIFFERENT sources for the SAME
+  //            process whenever only one of the two can reach wmic.exe -- their
+  //            tokens differ by FORMAT, so the reaper would read a live bridge's
+  //            lease as some other process's and never collect the orphan it
+  //            exists to collect. Ticks is the one value both sides can always
+  //            agree on, so the speed is not worth the divergence.
+  //            Falling back from powershell.exe to pwsh is safe for the same
+  //            reason it is safe here and nowhere else: both return the SAME
+  //            Ticks for a given pid (measured), so the src label names the
+  //            format, not the executable that produced it.
   startToken() {
+    if (process.platform === "win32") {
+      for (const bin of ["powershell.exe", "pwsh"]) {
+        const r = spawnSync(
+          bin,
+          [
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            `(Get-Process -Id ${process.pid}).StartTime.Ticks`,
+          ],
+          { encoding: "utf8" },
+        );
+        const ticks = (r.status === 0 ? (r.stdout || "") : "").trim();
+        if (/^\d+$/.test(ticks)) return { src: "pwsh", token: ticks };
+      }
+      return { src: "pwsh", token: "" };
+    }
     try {
       const stat = fs.readFileSync(`/proc/${process.pid}/stat`, "utf8");
       const after = stat.slice(stat.lastIndexOf(")") + 1).trim().split(/\s+/);

--- a/scripts/drivers/types/codex/codex-bridge.js
+++ b/scripts/drivers/types/codex/codex-bridge.js
@@ -1087,27 +1087,16 @@ class CodexBridge {
   //            and the only victim would be a same-(project,pair) bridge in the
   //            sub-ms window before it overwrites this pid's lease, self-corrected
   //            by the launcher respawning it.
-  //   win32 -> Process.StartTime.Ticks, read through PowerShell. Windows has NO
-  //            /proc, and the only `ps` likely to be on PATH there is MSYS's,
-  //            which rejects -o outright ("ps: unknown option -- o") rather than
-  //            degrading -- so BOTH POSIX sources above yield an empty token and
-  //            writeLease() throws, which is why the bridge could never start on
-  //            Windows at all.
-  //            ★ONE source, deliberately, not a preference list. WMIC's
-  //            CreationDate is ~2x cheaper and was the obvious first pick, but it
-  //            is deprecated and already absent from Windows 11 installs that
-  //            have dropped the Feature-on-Demand. A per-side "WMIC, else
-  //            PowerShell" order would then let THIS writer and _start_token
-  //            (codex-bridge-launcher.sh) resolve DIFFERENT sources for the SAME
-  //            process whenever only one of the two can reach wmic.exe -- their
-  //            tokens differ by FORMAT, so the reaper would read a live bridge's
-  //            lease as some other process's and never collect the orphan it
-  //            exists to collect. Ticks is the one value both sides can always
-  //            agree on, so the speed is not worth the divergence.
-  //            Falling back from powershell.exe to pwsh is safe for the same
-  //            reason it is safe here and nowhere else: both return the SAME
-  //            Ticks for a given pid (measured), so the src label names the
-  //            format, not the executable that produced it.
+  //   win32 -> Process.StartTime.Ticks, read through PowerShell. Windows has no
+  //            /proc, and MSYS's `ps` rejects -o outright, so both POSIX sources
+  //            yield an empty token and no lease can be published at all.
+  //            ONE source, not a preference list: WMIC is deprecated and already
+  //            absent from some Windows 11 installs, and letting each side choose
+  //            between WMIC and PowerShell independently would let this writer and
+  //            _start_token (codex-bridge-launcher.sh) record differently-
+  //            FORMATTED tokens for the same process. powershell.exe and pwsh
+  //            return identical Ticks, so falling back between those two binaries
+  //            is safe: the src label names the format, not the executable.
   startToken() {
     if (process.platform === "win32") {
       for (const bin of ["powershell.exe", "pwsh"]) {

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -697,3 +697,86 @@ _fake_alice_lease() { # sets FAKE_PID once its lease file exists
   kill -0 "$victim"
   kill "$victim" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$victim" 2>/dev/null || true
 }
+
+# --- Windows start token: the lease schema must admit the source
+# codex-bridge.js writeLease() records on Windows, where /proc does not exist and
+# the only `ps` likely to be on PATH (MSYS's) rejects -o outright, so both POSIX
+# sources yield an empty token and the bridge can never publish a lease at all.
+#
+# _read_lease is the reaper's ONLY gate on a lease, so its accept/reject set is
+# the contract. These exercise it directly -- the pattern test_remote.bats uses
+# for _remote_endpoint_display -- rather than through the reaper: the reaper
+# needs a spawnable bridge and a live pid, which is exactly what does not work on
+# Git Bash (#567), and the schema question has nothing to do with either. Kept
+# out of the `windows-native` filter deliberately: nothing here runs PowerShell,
+# so these belong on every leg, not only the Windows one. ---
+_lease_verdict() { # <startsrc> <start> -> prints accept|reject
+  local h40=0123456789abcdef0123456789abcdef01234567
+  printf 'v=1\nproject=%s\npairs=%s\nhost=h\npid=123\nstart=%s\nstartsrc=%s\n' \
+    "$h40" "$h40" "$2" "$1" > "$TEST_SKILL_DIR/lease-under-test"
+  bash -c '
+    eval "$(sed -n "/^_read_lease() {/,/^}/p" "$1")"
+    _read_lease "$2" && echo accept || echo reject
+  ' _ "$LAUNCHER" "$TEST_SKILL_DIR/lease-under-test" 2>/dev/null
+}
+
+@test "launcher: the lease schema admits a pwsh start token" {
+  [ "$(_lease_verdict pwsh 639231441791462826)" = accept ]
+}
+
+@test "launcher: a pwsh lease whose token is not an integer is rejected, fail-closed" {
+  # .NET Ticks is a bare integer. Anything else under that label is a lease this
+  # side did not write, and a doubtful lease must never authorise a kill.
+  [ "$(_lease_verdict pwsh 6392314.5)" = reject ]
+  [ "$(_lease_verdict pwsh '')" = reject ]
+}
+
+@test "launcher: an unrecognised startsrc is rejected, fail-closed" {
+  # wmic is here on purpose, not as an arbitrary bad value: WMIC's CreationDate
+  # was the faster candidate and was deliberately NOT adopted, because a per-side
+  # "WMIC, else PowerShell" order lets the writer and the reaper resolve different
+  # sources for the same process whenever only one of them can reach wmic.exe.
+  # Rejecting the label pins that decision, so reintroducing it fails loudly.
+  [ "$(_lease_verdict wmic 20260824041348.411807+540)" = reject ]
+  [ "$(_lease_verdict bogus 123)" = reject ]
+}
+
+@test "launcher: proc and ps leases still parse (start-token regression)" {
+  [ "$(_lease_verdict proc 396341883)" = accept ]
+  [ "$(_lease_verdict ps 'Sun Aug 24 04:00:00 2026')" = accept ]
+  # ps stays exempt from the integer check (its token is a human date string
+  # whose punctuation varies by platform); proc does not.
+  [ "$(_lease_verdict proc abc)" = reject ]
+}
+
+_run_start_token() { # <pid> -> runs _start_token in a subshell
+  run bash -c '
+    eval "$(sed -n "/^_agmsg_is_windows() {/,/^}/p;/^_start_token() {/,/^}/p" "$1")"
+    _start_token "$2"
+  ' _ "$LAUNCHER" "$1"
+}
+
+@test "launcher: a live pid yields a proc or ps start token on POSIX" {
+  skip_on_windows "Windows has its own source; see the windows-native case"
+  _run_start_token $$
+  [ "$status" -eq 0 ]
+  local tab; tab=$(printf '\t')
+  case "${output%%"$tab"*}" in proc|ps) ;; *) false ;; esac
+  [ -n "${output#*"$tab"}" ]
+}
+
+@test "launcher: windows-native a live pid yields an integer pwsh start token" {
+  skip_unless_windows "PowerShell and the Windows pid space are the point"
+  # The pid must be the WINDOWS one. MSYS/Cygwin number processes in their own
+  # space -- the same shell is MSYS pid 3994449 and winpid 19568 on our runner --
+  # and Get-Process only knows the latter, which is also the pid
+  # codex-bridge.js records as process.pid.
+  local winpid; winpid="$(cat /proc/$$/winpid)"
+  [ -n "$winpid" ]
+  _run_start_token "$winpid"
+  [ "$status" -eq 0 ]
+  local tab; tab=$(printf '\t')
+  [ "${output%%"$tab"*}" = pwsh ]
+  local tok="${output#*"$tab"}"
+  case "$tok" in ''|*[!0-9]*) false ;; esac
+}

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -715,7 +715,8 @@ _lease_verdict() { # <startsrc> <start> -> prints accept|reject
   printf 'v=1\nproject=%s\npairs=%s\nhost=h\npid=123\nstart=%s\nstartsrc=%s\n' \
     "$h40" "$h40" "$2" "$1" > "$TEST_SKILL_DIR/lease-under-test"
   bash -c '
-    eval "$(sed -n "/^_read_lease() {/,/^}/p" "$1")"
+    pattern="/^_read_lease() {/,/^}/p"
+    eval "$(sed -n "$pattern" "$1")"
     _read_lease "$2" && echo accept || echo reject
   ' _ "$LAUNCHER" "$TEST_SKILL_DIR/lease-under-test" 2>/dev/null
 }
@@ -751,7 +752,8 @@ _lease_verdict() { # <startsrc> <start> -> prints accept|reject
 
 _run_start_token() { # <pid> -> runs _start_token in a subshell
   run bash -c '
-    eval "$(sed -n "/^_agmsg_is_windows() {/,/^}/p;/^_start_token() {/,/^}/p" "$1")"
+    pattern="/^_agmsg_is_windows() {/,/^}/p;/^_start_token() {/,/^}/p"
+    eval "$(sed -n "$pattern" "$1")"
     _start_token "$2"
   ' _ "$LAUNCHER" "$1"
 }
@@ -763,6 +765,18 @@ _run_start_token() { # <pid> -> runs _start_token in a subshell
   local tab; tab=$(printf '\t')
   case "${output%%"$tab"*}" in proc|ps) ;; *) false ;; esac
   [ -n "${output#*"$tab"}" ]
+}
+
+@test "launcher: CLANGARM uname selects the Windows start token path" {
+  local stubdir="$TEST_SKILL_DIR/clangarm-bin"
+  mkdir -p "$stubdir"
+  printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" CLANGARM64_NT-10.0' > "$stubdir/uname"
+  printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" 639231441791462826' > "$stubdir/powershell.exe"
+  chmod +x "$stubdir/uname" "$stubdir/powershell.exe"
+
+  PATH="$stubdir:$PATH" _run_start_token 123
+  [ "$status" -eq 0 ]
+  [ "$output" = $'pwsh\t639231441791462826' ]
 }
 
 @test "launcher: windows-native a live pid yields an integer pwsh start token" {


### PR DESCRIPTION
Fixes #977.

The codex bridge could not start on Windows at all: `startToken()` had two
sources and Windows satisfies neither, so `writeLease()` failed closed on an
empty token every time and the launcher respawned it into the same wall.

```
/proc/<pid>/stat   ENOENT
ps -o lstart=      ps: unknown option -- o
```

The fail-closed is correct (#906) — the missing Windows source is what this adds:
`Process.StartTime.Ticks` through PowerShell, in both `codex-bridge.js`
`startToken()` and `codex-bridge-launcher.sh` `_start_token`, with `pwsh` admitted
to the lease schema.

**One source, not a preference list**

WMIC's `CreationDate` is ~2x cheaper (0.36 s vs 0.83 s measured) and was the
first implementation. It is dropped, and not because WMIC may be missing: a
per-side "WMIC, else PowerShell" order lets the writer and the reaper resolve
different sources for the same process whenever only one of them can reach
`wmic.exe`, and their tokens differ by format — so the reaper reads a live
bridge's lease as another process's. Reproduced with `wmic` shadowed on one side:

```
node: src=wmic token=20260824045224.102163+540
bash: src=pwsh token=639231439441021632
```

`powershell.exe` → `pwsh` fallback is safe where WMIC was not: both return
identical Ticks for a pid, so the `src` label names the format, not the binary.

**The Windows branch replaces the `/proc` branch rather than preceding it**

MSYS/Cygwin expose a working `/proc`, but it is keyed by their own pid space
while the lease records the Windows `process.pid`, so preferring it would return
an unrelated process's start time with nothing to signal it. Measurements in #977.

**Tests**

Six cases against `_read_lease` — the reaper's only gate on a lease, so its
accept/reject set is the contract that widening `proc|ps` to `proc|ps|pwsh`
changes. Exercised directly, the way `tests/test_remote.bats` already does for
`_remote_endpoint_display`, rather than through the reaper: that path needs a
spawnable bridge and a live pid, which is what does not work under Git Bash
(#567) and has nothing to do with the schema.

Two detect the change; four are guards. Stated as a table rather than a pass
count so a reviewer checking it finds the same thing:

| case | with the change | without it |
|---|---|---|
| a `pwsh` lease parses | ok | **fails** |
| `windows-native`: a live pid yields an integer `pwsh` token | ok | **fails** |
| a `pwsh` token that is not an integer is rejected | ok | ok |
| an unrecognised `startsrc` is rejected (`wmic` included) | ok | ok |
| `proc`/`ps` still parse; `proc` non-numeric still rejected | ok | ok |
| POSIX: a live pid yields a `proc` or `ps` token | ok | ok |

`wmic` is in the rejection case deliberately, not as an arbitrary bad value: it
pins the decision above, so reintroducing WMIC fails loudly.

Only the case that runs PowerShell carries `windows-native` in its name, so it
lands on that leg; the rest carry no marker and run everywhere. The two
platform-specific cases complement each other — on either leg one runs and the
other skips.

**Verification**

- Windows 11 26200 / MINGW64 / node 22 (win32) / codex-cli 0.149.0: the six cases
  pass; re-run against the parent commit's `codex/` tree, the two
  change-detecting cases fail as tabled
- Linux (Bats 1.14.0 from a clone): the five non-`windows-native` cases pass and
  the mutation check reproduces. Run independently on a separate machine by a
  second person, not a re-run of the Windows box
- End to end on Windows: the bridge starts, publishes
  `start=639231452158110466 startsrc=pwsh`, and a message sent to the role drives
  a turn and gets an answer. Before this change the same sequence produced only
  the token error

**Not verified**

- `bats tests/` green on Windows. That is not achievable and is not new: the
  workflow shards the suite over `[ubuntu-latest, macos-latest]` only, and the
  Windows leg runs `filter: "windows-native"`. The full file has never been
  expected to pass under Git Bash
- `launcher: windows-native starts the bridge (#567)` fails on our Windows
  machine with and without this change. It asserts the half of #567 that is not
  fixed: the parent-liveness probe asks `tasklist` about an MSYS pid, and the two
  pid spaces are disjoint (`tasklist` finds winpid 19568 only; `kill -0` finds
  MSYS pid 3994449 only). The workflow already lists `windows runtime (#567)`
  among its known intermittent reds
- macOS is not covered by our own runs; the POSIX branches are untouched, but
  that is an argument, not a measurement

**Unrelated flake, for context**

`tests/test_codex_bridge_launcher.bats` flakes under full-suite load on Linux
independently of this change: baseline produced the same `not ok 17` on one of
three full runs, and the failing test moves between runs, while single-test runs
were green 3/3 on both. We are not claiming equal rates — the run count is far
too small — only that the same failure occurs without this change.
