### PR TITLE
test(actas): the watcher-handover test waited four seconds instead of for the watcher (#828)

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -1043,7 +1043,7 @@ storage_sync_apply_pull() {
       [ -s "$jq_err" ] && sed 's/^/agmsg: sqlite-sync: /' "$jq_err" >&2
       printf 'agmsg: sqlite-sync: %s\n' "$1" >&2
     fi
-    exec 3<&- 2>/dev/null || true
+    { exec 3<&-; } 2>/dev/null || true
     rm -f "$sql_file" "$jq_err"
     _AGMSG_SYNC_SQL_FILE=""; _AGMSG_SYNC_JQ_ERR=""
     trap - EXIT INT TERM HUP

--- a/tests/test_actas_integration.bats
+++ b/tests/test_actas_integration.bats
@@ -224,8 +224,24 @@ fake_session() {
 
   bash "$SKILL_DIR/scripts/send.sh" T bob alice "after the handover" >/dev/null
 
-  # Several poll cycles at the 1s interval set above.
-  sleep 4
+  # Wait for the watcher to SAY it noticed, not for a duration to pass (#828).
+  # `sleep 4` here assumed four poll cycles at the 1s interval; under load the
+  # watcher can complete none of them in four seconds, and the assertions below
+  # then read a watcher that has not looked yet as one that consumed nothing.
+  # The stderr line is the same observable the last assertion in this test
+  # already relies on, so waiting for it costs nothing and cannot pass early.
+  for i in $(seq 1 200); do
+    grep -q "sid-new" "$BATS_TEST_TMPDIR/old.err" 2>/dev/null && break
+    sleep 0.1
+  done
+  grep -q "sid-new" "$BATS_TEST_TMPDIR/old.err"
+
+  # And for it to be gone, rather than assuming saying so was the same as
+  # having exited.
+  for i in $(seq 1 200); do
+    kill -0 "$old" 2>/dev/null || break
+    sleep 0.1
+  done
   kill "$newpid" 2>/dev/null || true
 
   # It must not have taken a message addressed to a role it no longer owns.

--- a/tests/test_apply_fail_stderr.bats
+++ b/tests/test_apply_fail_stderr.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# `_sqlite_sync_apply_fail` must not take the shell's stderr with it.
+#
+# It closes fd 3 and discards whatever closing an already-closed fd would say.
+# Written as `exec 3<&- 2>/dev/null`, with no command word, the redirection is
+# not scoped to anything -- bash applies it to the shell itself, permanently.
+# Every later `>&2` in that process goes to /dev/null.
+#
+# The path this sits on is the failure path, so the diagnostics it silences are
+# the ones a failing apply is about to print. The first casualty is the message
+# #911 added, naming which check returned 13. Reported by @JoelMitz.
+
+setup() {
+  SCRIPTS="${BATS_TEST_DIRNAME}/../scripts"
+}
+
+@test "apply-fail: closing fd 3 does not redirect the shell's stderr (#911)" {
+  # Runs the driver's OWN definition, not a copy of it: the function is nested
+  # inside storage_sync_apply_pull and cannot be sourced, so its body is lifted
+  # out of the file by line range and defined here. A copy would keep passing
+  # while the driver regressed, which is the whole failure this test is about.
+  local first last body
+  first="$(grep -n '_sqlite_sync_apply_fail() {' "${SCRIPTS}/drivers/storage/sqlite-sync.sh" | head -1 | cut -d: -f1)"
+  [ -n "$first" ]
+  last="$(awk -v s="$first" 'NR>s && /^  \}$/ { print NR; exit }' "${SCRIPTS}/drivers/storage/sqlite-sync.sh")"
+  [ -n "$last" ]
+  body="$(sed -n "${first},${last}p" "${SCRIPTS}/drivers/storage/sqlite-sync.sh")"
+
+  run bash -c "
+    jq_err=/dev/null; sql_file=/dev/null
+    $body
+    _sqlite_sync_apply_fail
+    echo 'stderr-after-close' >&2
+  "
+  [ "$status" -eq 0 ]
+  grep -q "stderr-after-close" <<<"$output"
+}
+
+@test "apply-fail: the driver closes fd 3 in a scoped block, not bare exec" {
+  # The regression is one character of syntax, so the guard is on the syntax.
+  # A bare `exec <redirect>` with no command word anywhere in this file would
+  # take the shell's stderr the same way.
+  run grep -nE '^\s*exec [0-9]*[<>][&-]* +[0-9]*>' "${SCRIPTS}/drivers/storage/sqlite-sync.sh"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Closes the first of the two tests named in #828. Eight first-attempt failures across forty runs, all on branches that cannot reach the code it exercises.

## What it waited for

```
bash send.sh T bob alice "after the handover"

# Several poll cycles at the 1s interval set above.
sleep 4
```

Four seconds stood in for four poll cycles. On a loaded runner the watcher can complete none of them in that time, and every assertion after the sleep then reads a watcher that *has not looked yet* as one that behaved correctly:

```
[[ "$output" != *"after the handover"* ]]     # it consumed nothing — or it has not polled
refute kill -0 "$old"                         # it exited — or it is still starting
```

Both are the point of the test, and both pass for the wrong reason when the wait is short.

## What it waits for now

The watcher writes to stderr when it finds the pair claimed by another session. That line is not new to this change — the last assertion in this test already requires it:

```
[[ "$output" == *"sid-new"* ]]
```

So waiting for it introduces no assumption the test did not already carry, and unlike elapsed time it cannot be satisfied early. After that, it waits for the process to be gone rather than treating *having said so* as *having exited* — the two are a poll cycle apart.

Both waits are bounded (200 × 0.1 s) and assert after the loop, so a watcher that never says anything fails rather than hangs.

## Scope

The sibling test #828 names, `test_watch.bats:208`, already waits on an observable (`_wait_for_missing`) rather than on a duration. Left alone.

Three more `sleep`-then-assert sites remain in this file at lines 351, 401 and 405, of the same shape. Not touched here: fixing one test whose failure rate is measured, and leaving the others until theirs is, keeps it possible to tell which change moved the number. Line 299's `sleep` is the opposite case and is correct — it asserts the watcher is *still running*, which a longer wait can only strengthen.
