### PR TITLE
fix(sync): count roster mutations as held so the read frontier can advance (#968)

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -1399,7 +1399,10 @@ storage_sync_prepare_read_state() {
       ((.local_agents|unique|length)==(.local_agents|length)) and all(.local_agents[];
         (type=="string") and length>0) and
       (.members|length)<=1000 and all(.members[];
-        ((.member_id|type)=="string") and ((.name|type)=="string") and (.name|length)>0)) | "ok"' \
+        ((.member_id|type)=="string") and ((.name|type)=="string") and (.name|length)>0) and
+      ((.roster_seqs|type)=="null" or ((.roster_seqs|type)=="array" and
+        (.roster_seqs|length)<=1000000 and all(.roster_seqs[];
+          (type=="string") and test("^(0|[1-9][0-9]{0,18})$"))))) | "ok"' \
       2>/dev/null)" = ok ] || { _sqlite_sync_why; return 13; }
   floor=$(printf '%s\n' "$context" | jq -r '.min_available_seq')
   current=$(printf '%s\n' "$context" | jq -r '.current_seq')
@@ -1429,6 +1432,22 @@ EOF
   if [ "$count" -gt 0 ]; then
     insert_members="INSERT INTO incoming_read_members VALUES $values;"
   fi
+  # Sequences the engine knows to be roster mutations (#968). They occupy
+  # server sequence numbers but are, by design, not messages: the engine routes
+  # them to the roster driver, so they never gain a sync_messages mapping and
+  # (on the engine pull path) never enter sync_quarantine at all. Without this
+  # list the contiguity check below reads every one of them as a hole and pins
+  # the frontier at the first -- which is seq 1, the founding member_joined, on
+  # every team ever created. Validated above as decimal strings, so they are
+  # emitted as integers here without further quoting. Absent list => empty
+  # table => today's behavior (a frontier that cannot advance), never a
+  # frontier advanced on evidence that was not supplied.
+  local insert_roster_seqs="" roster_values
+  roster_values=$(printf '%s\n' "$context" |
+    jq -r '[.roster_seqs // [] | .[] | "(" + . + ")"] | join(",")')
+  if [ -n "$roster_values" ]; then
+    insert_roster_seqs="INSERT OR IGNORE INTO roster_read_seqs VALUES $roster_values;"
+  fi
   if [ -n "$local_values" ]; then
     insert_local_agents="INSERT INTO local_read_agents VALUES $local_values;"
   fi
@@ -1438,8 +1457,10 @@ EOF
   _sqlite_exec_stdin "$db" "BEGIN IMMEDIATE;
     CREATE TEMP TABLE incoming_read_members(member_id TEXT UNIQUE,agent TEXT UNIQUE);
     CREATE TEMP TABLE local_read_agents(agent TEXT PRIMARY KEY);
+    CREATE TEMP TABLE roster_read_seqs(server_seq INTEGER PRIMARY KEY);
     $insert_members
     $insert_local_agents
+    $insert_roster_seqs
     UPDATE sync_read_members SET active=0 WHERE local_team='$tl'
       AND server_instance_id='$server' AND remote_team_id='$remote'
       AND protocol_version=$protocol AND driver_generation='$generation';
@@ -1485,32 +1506,57 @@ EOF
     INSERT INTO sync_read_prepared
       (local_team,server_instance_id,remote_team_id,protocol_version,
        driver_generation,member_id,server_seq)
-    WITH ordered AS (
+    WITH held AS (
+      -- The sequence space this client is expected to hold (#968): every
+      -- message in quarantine, plus every sequence the roster driver applied
+      -- as a roster mutation. A roster sequence that also has a quarantine row
+      -- (the bootstrap path quarantines them) is one row here, flagged roster.
+      SELECT q.local_team,q.server_instance_id,q.remote_team_id,q.protocol_version,
+             q.driver_generation,CAST(q.server_seq AS INTEGER) AS seq,q.status,q.wire_id,
+             EXISTS(SELECT 1 FROM roster_read_seqs r
+                     WHERE r.server_seq=CAST(q.server_seq AS INTEGER)) AS roster
+        FROM sync_quarantine q
+       WHERE q.local_team='$tl' AND q.server_instance_id='$server'
+         AND q.remote_team_id='$remote' AND q.protocol_version=$protocol
+         AND q.driver_generation='$generation'
+      UNION ALL
+      SELECT '$tl','$server','$remote',$protocol,'$generation',r.server_seq,'imported',NULL,1
+        FROM roster_read_seqs r
+       WHERE NOT EXISTS(SELECT 1 FROM sync_quarantine q
+                         WHERE q.local_team='$tl' AND q.server_instance_id='$server'
+                           AND q.remote_team_id='$remote' AND q.protocol_version=$protocol
+                           AND q.driver_generation='$generation'
+                           AND CAST(q.server_seq AS INTEGER)=r.server_seq)
+    ), ordered AS (
       SELECT rm.member_id,rm.agent,CAST(rm.remote_server_seq AS INTEGER) AS base,
              CAST(b.transport_cursor AS INTEGER) AS tip,
-             CAST(q.server_seq AS INTEGER) AS seq,q.status,m.local_position,e.to_agent,
-             ROW_NUMBER() OVER(PARTITION BY rm.member_id ORDER BY CAST(q.server_seq AS INTEGER)) AS rn
+             h.seq,h.status,h.roster,m.local_position,e.to_agent,
+             ROW_NUMBER() OVER(PARTITION BY rm.member_id ORDER BY h.seq) AS rn
         FROM sync_read_members rm JOIN sync_bindings b
           ON b.local_team=rm.local_team AND b.server_instance_id=rm.server_instance_id
          AND b.remote_team_id=rm.remote_team_id AND b.protocol_version=rm.protocol_version
          AND b.driver_generation=rm.driver_generation
-        LEFT JOIN sync_quarantine q ON q.local_team=rm.local_team
-         AND q.server_instance_id=rm.server_instance_id AND q.remote_team_id=rm.remote_team_id
-         AND q.protocol_version=rm.protocol_version AND q.driver_generation=rm.driver_generation
-         AND CAST(q.server_seq AS INTEGER)>CAST(rm.remote_server_seq AS INTEGER)
-         AND CAST(q.server_seq AS INTEGER)<=MIN(CAST(b.transport_cursor AS INTEGER),$current)
+        LEFT JOIN held h ON h.local_team=rm.local_team
+         AND h.server_instance_id=rm.server_instance_id AND h.remote_team_id=rm.remote_team_id
+         AND h.protocol_version=rm.protocol_version AND h.driver_generation=rm.driver_generation
+         AND h.seq>CAST(rm.remote_server_seq AS INTEGER)
+         AND h.seq<=MIN(CAST(b.transport_cursor AS INTEGER),$current)
         LEFT JOIN sync_messages m ON m.server_instance_id=rm.server_instance_id
          AND m.remote_team_id=rm.remote_team_id AND m.protocol_version=rm.protocol_version
-         AND m.wire_id=q.wire_id
+         AND m.wire_id=h.wire_id
         LEFT JOIN events e ON e.seq=m.local_position
        WHERE rm.local_team='$tl' AND rm.server_instance_id='$server'
          AND rm.remote_team_id='$remote' AND rm.protocol_version=$protocol
          AND rm.driver_generation='$generation' AND rm.active=1
          AND rm.name_mismatch=0
     ), bad AS (
+      -- A roster sequence is accounted for by being a roster sequence: it has
+      -- no message mapping and never will. Everything else keeps the strict
+      -- reading -- a message sequence with no mapping, or missing from the
+      -- space entirely, is still a hole, so a lost message still pins.
       SELECT member_id,MIN(base+rn) AS seq FROM ordered
        WHERE seq IS NULL OR seq<>base+rn OR status NOT IN ('imported','reconciled')
-          OR local_position IS NULL
+          OR (local_position IS NULL AND roster=0)
           OR (to_agent=agent AND local_position>COALESCE((SELECT local_position
                 FROM read_cursors c WHERE c.team='$tl' AND c.agent=ordered.agent),0)
               AND NOT EXISTS(SELECT 1 FROM events r WHERE r.type='message_read'

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -1409,17 +1409,33 @@ storage_sync_prepare_read_state() {
   # past it has had ten thousand joins, leaves or renames, which is a signal
   # to look at the design, not a size to wave through. Over the bound is
   # refused (13), which leaves the frontier where it was -- the safe side.
-  # Shape and size in jq; the DOMAIN through _sqlite_sync_sequence, the same
-  # bound this function already holds current_seq to a hundred lines above.
-  # Shape alone let 9223372036854775808..9999999999999999999 through (review
-  # finding), and an INTEGER PRIMARY KEY temp table then fails the whole
-  # read-prepare transaction with a datatype mismatch -- no 13, no reason.
+  # Shape and size in jq, then the DOMAIN per entry through
+  # _sqlite_sync_sequence -- the same bound (9223372036854775807) this
+  # function already holds current_seq to, a hundred lines above. Two review
+  # findings shaped this:
+  #   - Shape alone let 9223372036854775808..9999999999999999999 through. The
+  #     temp table's INTEGER PRIMARY KEY (a rowid alias) refuses such a value
+  #     outright, so the whole read-prepare transaction died with a datatype
+  #     mismatch -- neither a 13 nor "no evidence", a way of failing the
+  #     contract does not name. Hence the domain check.
+  #   - The shape test is anchored \A..\z, not ^..$: in jq's regex engine $
+  #     also matches before one trailing newline, so "1\n" passed as a
+  #     sequence; the per-entry loop below then read "1", skipped the empty
+  #     line, and the SQL got (1\n), which SQLite accepts as 1 -- a malformed
+  #     entry exempting a real sequence, the one direction this must never
+  #     take. With absolute anchors no accepted entry can carry a newline, so
+  #     the line-framed loop sees exactly the entries jq accepted.
   # Pure bash per entry, no fork; at most 10,000 entries.
-  [ "$(printf '%s\n' "$context" | jq -r '
-    select((.roster_seqs|type)=="null" or ((.roster_seqs|type)=="array" and
-      (.roster_seqs|length)<=10000 and all(.roster_seqs[]; type=="string"))) | "ok"' \
-      2>/dev/null)" = ok ] || {
-    echo "agmsg: sqlite-sync: roster_seqs is not a list of at most 10000 strings (#968)" >&2
+  # The jq program lives in a variable: bash 3.2 misparses the backslashes of
+  # \A and \z when they sit in a quoted string inside $( ), and the check
+  # then fails closed for every list (macOS CI, and the same 3.2 divergence
+  # #928 met with a quote). The same reason _SQLITE_SYNC_WIRE_RE is a variable.
+  local roster_seqs_jq
+  roster_seqs_jq='select((.roster_seqs|type)=="null" or ((.roster_seqs|type)=="array" and
+      (.roster_seqs|length)<=10000 and all(.roster_seqs[];
+        (type=="string") and test("\\A(0|[1-9][0-9]{0,18})\\z")))) | "ok"'
+  [ "$(printf '%s\n' "$context" | jq -r "$roster_seqs_jq" 2>/dev/null)" = ok ] || {
+    echo "agmsg: sqlite-sync: roster_seqs is not a list of at most 10000 canonical sequences (#968)" >&2
     _sqlite_sync_why; return 13
   }
   local roster_seq

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -1399,11 +1399,39 @@ storage_sync_prepare_read_state() {
       ((.local_agents|unique|length)==(.local_agents|length)) and all(.local_agents[];
         (type=="string") and length>0) and
       (.members|length)<=1000 and all(.members[];
-        ((.member_id|type)=="string") and ((.name|type)=="string") and (.name|length)>0) and
-      ((.roster_seqs|type)=="null" or ((.roster_seqs|type)=="array" and
-        (.roster_seqs|length)<=1000000 and all(.roster_seqs[];
-          (type=="string") and test("^(0|[1-9][0-9]{0,18})$"))))) | "ok"' \
+        ((.member_id|type)=="string") and ((.name|type)=="string") and (.name|length)>0)) | "ok"' \
       2>/dev/null)" = ok ] || { _sqlite_sync_why; return 13; }
+  # ...and the roster list on its own line, so a refusal here is told apart
+  # from the eight context checks above by the line number _sqlite_sync_why
+  # prints (#911) -- and says what it is in words as well. The bound is the
+  # size the contract test actually passes through this path (10,000): the
+  # list is one entry per roster mutation the team ever applied, so a team
+  # past it has had ten thousand joins, leaves or renames, which is a signal
+  # to look at the design, not a size to wave through. Over the bound is
+  # refused (13), which leaves the frontier where it was -- the safe side.
+  # Shape and size in jq; the DOMAIN through _sqlite_sync_sequence, the same
+  # bound this function already holds current_seq to a hundred lines above.
+  # Shape alone let 9223372036854775808..9999999999999999999 through (review
+  # finding), and an INTEGER PRIMARY KEY temp table then fails the whole
+  # read-prepare transaction with a datatype mismatch -- no 13, no reason.
+  # Pure bash per entry, no fork; at most 10,000 entries.
+  [ "$(printf '%s\n' "$context" | jq -r '
+    select((.roster_seqs|type)=="null" or ((.roster_seqs|type)=="array" and
+      (.roster_seqs|length)<=10000 and all(.roster_seqs[]; type=="string"))) | "ok"' \
+      2>/dev/null)" = ok ] || {
+    echo "agmsg: sqlite-sync: roster_seqs is not a list of at most 10000 strings (#968)" >&2
+    _sqlite_sync_why; return 13
+  }
+  local roster_seq
+  while IFS= read -r roster_seq; do
+    [ -n "$roster_seq" ] || continue
+    _sqlite_sync_sequence "$roster_seq" || {
+      echo "agmsg: sqlite-sync: roster_seqs carries '$roster_seq', which is not a canonical sequence (#968)" >&2
+      _sqlite_sync_why; return 13
+    }
+  done <<EOF
+$(printf '%s\n' "$context" | jq -r '.roster_seqs // [] | .[]')
+EOF
   floor=$(printf '%s\n' "$context" | jq -r '.min_available_seq')
   current=$(printf '%s\n' "$context" | jq -r '.current_seq')
   case "$floor:$current" in *[!0-9:]*) _sqlite_sync_why; return 13 ;; esac

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2820,11 +2820,46 @@ export async function configure(args) {
     remote_team_id: config.remote_team_id });
 }
 
+// The server sequences this client holds as ROSTER mutations rather than as
+// messages (#968). The roster driver journals one `roster_synced` record per
+// applied mutation -- on the engine pull path and on the bootstrap path alike,
+// and since the same commit that put roster mutations on the transport -- so
+// the journal is the complete list of sequences that will never have a
+// message mapping. The read-state frontier check needs that list: without it
+// every roster sequence reads as a hole, and the first hole is seq 1 (the
+// founding member_joined) on every team.
+//
+// Failure direction: a journal that cannot be read, or a line that cannot be
+// parsed, yields NO sequences, which leaves the frontier check exactly as it
+// was -- pinned. A frontier is never advanced on evidence that was not read.
+export async function rosterSequencesFor(config, dependencies = {}) {
+  const readFileCall = dependencies.readFileCall ?? readFile;
+  const rosterFile = dependencies.rosterFile ?? rosterFileFor(config.local_team);
+  if (!rosterFile) return [];
+  let text;
+  try { text = await readFileCall(join(dirname(rosterFile), "roster.jsonl"), "utf8"); }
+  catch { return []; }
+  const sequences = new Set();
+  for (const line of text.split(/\r?\n/u)) {
+    if (!line) continue;
+    let record;
+    try { record = JSON.parse(line); } catch { return []; } // a torn journal is no evidence
+    if (record?.type === "roster_synced" &&
+        record.server_instance_id === config.server_instance_id &&
+        record.remote_team_id === config.remote_team_id &&
+        typeof record.server_seq === "string" && /^(0|[1-9][0-9]{0,18})$/u.test(record.server_seq)) {
+      sequences.add(record.server_seq);
+    }
+  }
+  return [...sequences].sort((a, b) => BigInt(a) < BigInt(b) ? -1 : 1);
+}
+
 export async function readStateCycle(config, limit, dependencies = {}) {
   const driverCall = dependencies.driverCall ?? driver;
   const requestCall = dependencies.requestCall ?? request;
   const eventCall = dependencies.eventCall ?? event;
   const localAgentsCall = dependencies.localAgentsCall ?? localAgentRoster;
+  const rosterSequencesCall = dependencies.rosterSequencesCall ?? rosterSequencesFor;
   const driverCapabilities = await driverCall("capabilities", config, []);
   if (!stage2ReadStateSupported(driverCapabilities)) {
     await eventCall("read-state.skipped", { reason: "driver-capability-not-advertised" });
@@ -2865,9 +2900,10 @@ export async function readStateCycle(config, limit, dependencies = {}) {
       missing: unmaterialised,
     });
   }
+  const rosterSeqs = await rosterSequencesCall(config, dependencies);
   const prepared = await driverCall("read-prepare", config, [{ type: "sync_read_context",
     min_available_seq: capabilities.min_available_seq, current_seq: capabilities.current_seq,
-    members, local_agents: localAgents }]);
+    members, local_agents: localAgents, roster_seqs: rosterSeqs }]);
   const batches = readStateUpdateBatches(members, prepared);
   const pageLimit = Math.min(limit, 1000);
   let page;

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2879,10 +2879,12 @@ export async function rosterSequencesFor(config, dependencies = {}) {
         record.server_instance_id !== config.server_instance_id ||
         record.remote_team_id !== config.remote_team_id) continue;
     // The sequence DOMAIN, through the one validator the rest of this file
-    // uses -- shape alone let 9223372036854775808..9999999999999999999
-    // through (review finding), and SQLite stores those as REAL rather than
-    // refusing them. A record outside the domain is corrupt evidence, treated
-    // like a torn line: named, and the whole list withheld.
+    // uses. Shape alone let 9223372036854775808..9999999999999999999 through
+    // (review finding); on the driver side the temp table's INTEGER PRIMARY
+    // KEY refuses such a value outright, so the whole read-prepare
+    // transaction died with a datatype mismatch -- neither a 13 nor "no
+    // evidence" (measured in review). A record outside the domain is corrupt
+    // evidence, treated like a torn line: named, and the whole list withheld.
     try { sequence(record.server_seq, "roster journal server_seq"); }
     catch (error) {
       try {

--- a/scripts/internal/remote-sync.mjs
+++ b/scripts/internal/remote-sync.mjs
@@ -2832,24 +2832,66 @@ export async function configure(args) {
 // Failure direction: a journal that cannot be read, or a line that cannot be
 // parsed, yields NO sequences, which leaves the frontier check exactly as it
 // was -- pinned. A frontier is never advanced on evidence that was not read.
+// And it SAYS so: a pinned frontier is also what #968 looked like before this
+// change, so a silent fallback here would be indistinguishable from the bug it
+// fixes. The event names the file and, for a torn journal, the line. A journal
+// that does not exist yet is not an anomaly (a team has no roster before its
+// first pull) and is the one case that stays quiet.
+//
+// The whole journal is read on every read-state cycle. It holds one record
+// per roster mutation the team ever applied (30 on a 21,505-message team),
+// so it grows with membership events, not with traffic; the storage driver
+// bounds the list it will accept at 10,000 and refuses beyond that. Cutting
+// it at the members' read floor would need that floor here, and it lives in
+// storage (sync_read_members.remote_server_seq) -- a new driver op, if the
+// list ever grows enough to matter.
 export async function rosterSequencesFor(config, dependencies = {}) {
   const readFileCall = dependencies.readFileCall ?? readFile;
+  const eventCall = dependencies.eventCall ?? event;
   const rosterFile = dependencies.rosterFile ?? rosterFileFor(config.local_team);
   if (!rosterFile) return [];
+  const journalPath = join(dirname(rosterFile), "roster.jsonl");
   let text;
-  try { text = await readFileCall(join(dirname(rosterFile), "roster.jsonl"), "utf8"); }
-  catch { return []; }
+  try { text = await readFileCall(journalPath, "utf8"); }
+  catch (error) {
+    if (error?.code !== "ENOENT") {
+      try {
+        await eventCall("read-state.roster-journal-unreadable", { path: journalPath,
+          reason: error?.code ?? error?.message ?? String(error) });
+      } catch { /* logging is best-effort */ }
+    }
+    return [];
+  }
   const sequences = new Set();
-  for (const line of text.split(/\r?\n/u)) {
+  const lines = text.split(/\r?\n/u);
+  for (const [index, line] of lines.entries()) {
     if (!line) continue;
     let record;
-    try { record = JSON.parse(line); } catch { return []; } // a torn journal is no evidence
-    if (record?.type === "roster_synced" &&
-        record.server_instance_id === config.server_instance_id &&
-        record.remote_team_id === config.remote_team_id &&
-        typeof record.server_seq === "string" && /^(0|[1-9][0-9]{0,18})$/u.test(record.server_seq)) {
-      sequences.add(record.server_seq);
+    try { record = JSON.parse(line); }
+    catch (error) { // a torn journal is no evidence -- and is named, with its line
+      try {
+        await eventCall("read-state.roster-journal-unreadable", { path: journalPath,
+          line: index + 1, reason: error?.message ?? String(error) });
+      } catch { /* logging is best-effort */ }
+      return [];
     }
+    if (record?.type !== "roster_synced" ||
+        record.server_instance_id !== config.server_instance_id ||
+        record.remote_team_id !== config.remote_team_id) continue;
+    // The sequence DOMAIN, through the one validator the rest of this file
+    // uses -- shape alone let 9223372036854775808..9999999999999999999
+    // through (review finding), and SQLite stores those as REAL rather than
+    // refusing them. A record outside the domain is corrupt evidence, treated
+    // like a torn line: named, and the whole list withheld.
+    try { sequence(record.server_seq, "roster journal server_seq"); }
+    catch (error) {
+      try {
+        await eventCall("read-state.roster-journal-unreadable", { path: journalPath,
+          line: index + 1, reason: error?.message ?? String(error) });
+      } catch { /* logging is best-effort */ }
+      return [];
+    }
+    sequences.add(record.server_seq);
   }
   return [...sequences].sort((a, b) => BigInt(a) < BigInt(b) ? -1 : 1);
 }

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -1403,20 +1403,64 @@ test("roster sequences: the journal's roster_synced records for this binding, an
       // another binding's record is not this binding's evidence
       JSON.stringify({ type: "roster_synced", mutation_id: "mx", server_seq: "7", wire_id: "wx",
         server_instance_id: other, remote_team_id: config.remote_team_id }),
-      // a non-canonical sequence is not evidence either
-      JSON.stringify({ type: "roster_synced", mutation_id: "my", server_seq: "007", wire_id: "wy",
-        server_instance_id: config.server_instance_id, remote_team_id: config.remote_team_id }),
       // duplicate of seq 2 collapses
       JSON.stringify({ type: "roster_synced", mutation_id: "m1b", server_seq: "2", wire_id: "w1b",
         server_instance_id: config.server_instance_id, remote_team_id: config.remote_team_id }),
     ].join("\n"));
     assert.deepEqual(await rosterSequencesFor(config, { rosterFile }), ["1", "2"]);
     // A torn journal (a line that is not JSON) yields nothing: a frontier is
-    // never advanced on evidence that could not be read whole.
+    // never advanced on evidence that could not be read whole. And it is
+    // NAMED, with the line, because a pinned frontier is also what #968
+    // looked like -- a silent fallback would be indistinguishable from the bug.
+    const events = [];
+    const eventCall = async (name, fields) => { events.push({ name, ...fields }); };
     await writeFile(join(root, "teams", "demo", "roster.jsonl"),
       '{"type":"roster_synced","mutation_id":"m1","server_seq":"2","wire_id":"w1",' +
       `"server_instance_id":"${config.server_instance_id}","remote_team_id":"${config.remote_team_id}"}\n{"type":"roster_syn`);
-    assert.deepEqual(await rosterSequencesFor(config, { rosterFile }), []);
+    assert.deepEqual(await rosterSequencesFor(config, { rosterFile, eventCall }), []);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].name, "read-state.roster-journal-unreadable");
+    assert.equal(events[0].line, 2);
+    assert.match(events[0].path, /roster\.jsonl$/u);
+    // A non-canonical sequence ("007") is corrupt evidence: the whole list is
+    // withheld and the line named, not the one record skipped -- a journal
+    // with one bad record is not a journal to take sequences from.
+    events.length = 0;
+    await writeFile(join(root, "teams", "demo", "roster.jsonl"), [
+      JSON.stringify({ type: "roster_synced", mutation_id: "m0", server_seq: "1", wire_id: "w0",
+        server_instance_id: config.server_instance_id, remote_team_id: config.remote_team_id }),
+      JSON.stringify({ type: "roster_synced", mutation_id: "my", server_seq: "007", wire_id: "wy",
+        server_instance_id: config.server_instance_id, remote_team_id: config.remote_team_id }),
+    ].join("\n"));
+    assert.deepEqual(await rosterSequencesFor(config, { rosterFile, eventCall }), []);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].line, 2);
+    // A sequence outside the domain is corrupt evidence, treated the same way
+    // (review finding: shape alone let 2^63..10^19-1 through).
+    events.length = 0;
+    await writeFile(join(root, "teams", "demo", "roster.jsonl"),
+      JSON.stringify({ type: "roster_synced", mutation_id: "m1", server_seq: "9223372036854775808", wire_id: "w1",
+        server_instance_id: config.server_instance_id, remote_team_id: config.remote_team_id }));
+    assert.deepEqual(await rosterSequencesFor(config, { rosterFile, eventCall }), []);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].line, 1);
+    assert.match(events[0].reason, /not a canonical sequence/u);
+    // MAX itself is a legal sequence.
+    events.length = 0;
+    await writeFile(join(root, "teams", "demo", "roster.jsonl"),
+      JSON.stringify({ type: "roster_synced", mutation_id: "m1", server_seq: "9223372036854775807", wire_id: "w1",
+        server_instance_id: config.server_instance_id, remote_team_id: config.remote_team_id }));
+    assert.deepEqual(await rosterSequencesFor(config, { rosterFile, eventCall }), ["9223372036854775807"]);
+    assert.equal(events.length, 0);
+    // No journal at all is not an anomaly (no roster before the first pull): quiet.
+    await rm(join(root, "teams", "demo", "roster.jsonl"));
+    assert.deepEqual(await rosterSequencesFor(config, { rosterFile, eventCall }), []);
+    assert.equal(events.length, 0);
+    // An unreadable journal (a directory in its place) IS named.
+    await mkdir(join(root, "teams", "demo", "roster.jsonl"));
+    assert.deepEqual(await rosterSequencesFor(config, { rosterFile, eventCall }), []);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].reason, "EISDIR");
   } finally {
     await rm(root, { recursive: true });
   }

--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -5,7 +5,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, symlink, unlink,
   utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { readNativeAgeIdentity } from "../scripts/internal/sync-cipher.mjs";
@@ -38,6 +38,7 @@ import {
   pullBootstrap,
   parseStrictJsonl,
   readStateCycle,
+  rosterSequencesFor,
   readStateUpdateBatches,
   reprocessCycle,
   request,
@@ -1383,6 +1384,60 @@ test("Stage-1-only driver skips the optional Stage-2 network path", async () => 
   assert.deepEqual(events, [["read-state.skipped", {
     reason: "driver-capability-not-advertised",
   }]]);
+});
+
+test("roster sequences: the journal's roster_synced records for this binding, and nothing on a missing or torn journal (#968)", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agmsg-968-journal-"));
+  try {
+    const rosterFile = join(root, "teams", "demo", "config.json");
+    await mkdir(dirname(rosterFile), { recursive: true });
+    // No journal yet: no evidence, no sequences.
+    assert.deepEqual(await rosterSequencesFor(config, { rosterFile }), []);
+    const other = "018f3f7e-0000-7000-8000-00000000ffff";
+    await writeFile(join(root, "teams", "demo", "roster.jsonl"), [
+      JSON.stringify({ type: "member_joined", id: "m1", name: "alice" }),
+      JSON.stringify({ type: "roster_synced", mutation_id: "m1", server_seq: "2", wire_id: "w1",
+        server_instance_id: config.server_instance_id, remote_team_id: config.remote_team_id }),
+      JSON.stringify({ type: "roster_synced", mutation_id: "m0", server_seq: "1", wire_id: "w0",
+        server_instance_id: config.server_instance_id, remote_team_id: config.remote_team_id }),
+      // another binding's record is not this binding's evidence
+      JSON.stringify({ type: "roster_synced", mutation_id: "mx", server_seq: "7", wire_id: "wx",
+        server_instance_id: other, remote_team_id: config.remote_team_id }),
+      // a non-canonical sequence is not evidence either
+      JSON.stringify({ type: "roster_synced", mutation_id: "my", server_seq: "007", wire_id: "wy",
+        server_instance_id: config.server_instance_id, remote_team_id: config.remote_team_id }),
+      // duplicate of seq 2 collapses
+      JSON.stringify({ type: "roster_synced", mutation_id: "m1b", server_seq: "2", wire_id: "w1b",
+        server_instance_id: config.server_instance_id, remote_team_id: config.remote_team_id }),
+    ].join("\n"));
+    assert.deepEqual(await rosterSequencesFor(config, { rosterFile }), ["1", "2"]);
+    // A torn journal (a line that is not JSON) yields nothing: a frontier is
+    // never advanced on evidence that could not be read whole.
+    await writeFile(join(root, "teams", "demo", "roster.jsonl"),
+      '{"type":"roster_synced","mutation_id":"m1","server_seq":"2","wire_id":"w1",' +
+      `"server_instance_id":"${config.server_instance_id}","remote_team_id":"${config.remote_team_id}"}\n{"type":"roster_syn`);
+    assert.deepEqual(await rosterSequencesFor(config, { rosterFile }), []);
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("Stage-2 read-prepare carries the roster sequences into the context (#968)", async () => {
+  const events = [];
+  const harness = readStateHarness(threeMembers, ["masa-claude"], events);
+  let contextSeen = null;
+  const innerDriver = harness.driverCall;
+  await readStateCycle(config, 100, {
+    ...harness,
+    driverCall: async (operation, cfg, input) => {
+      if (operation === "read-prepare") contextSeen = input[0];
+      return innerDriver(operation, cfg, input);
+    },
+    rosterSequencesCall: async () => ["1", "2"],
+  });
+  assert.ok(contextSeen, "read-prepare was called");
+  assert.equal(contextSeen.type, "sync_read_context");
+  assert.deepEqual(contextSeen.roster_seqs, ["1", "2"]);
 });
 
 test("Stage-2 isolates a limit offender and continues read-only synchronization", async () => {

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -1452,3 +1452,38 @@ _968_exact_count() { printf '%s\n' "$1" | jq -r 'select(.type=="sync_read_exact"
   run _968_prepare 2 '"1"'
   [ "$status" -eq 13 ]
 }
+
+@test "read-state: the roster list bound is swept on both sides -- 10,000 pass and advance the frontier, 10,001 are refused and it does not move (#968)" {
+  # Messages sit past ten thousand roster sequences; all are read.
+  _968_apply_messages 10001 10002 10003 10004
+  local ten_k prepared db
+  ten_k=$(jq -nc '[range(1;10001) | tostring]')
+  prepared=$(_968_prepare 10004 "$ten_k")
+  # Passing is not the claim -- the frontier landing on the right value is.
+  [ "$(_968_frontier "$prepared")" = 10004 ]
+  [ "$(_968_exact_count "$prepared")" -eq 0 ]
+  # One past the bound: refused, and told apart from every other context
+  # refusal by its own message (the #911 line number would differ as well).
+  run _968_prepare 10004 "$(jq -nc '[range(1;10002) | tostring]')"
+  [ "$status" -eq 13 ]
+  [[ "$output" == *"roster_seqs is not a list of at most 10000"* ]]
+  # And nothing moved: the frontier recorded by the accepted call is still
+  # the one on disk, not a partially trusted one.
+  db=$(agmsg_db_path demo)
+  [ "$(agmsg_sqlite "$db" "SELECT server_seq FROM sync_read_prepared;" | tr -d '\r')" = 10004 ]
+}
+
+@test "read-state: a roster sequence is validated against the sequence DOMAIN, not just its shape (#968)" {
+  # 9223372036854775808 through 9999999999999999999 are canonical-looking
+  # 19-digit decimals past MAX_SEQUENCE; SQLite stores them as REAL instead of
+  # refusing (review finding). MAX itself is a legal sequence.
+  _968_apply_messages 1 2
+  local prepared
+  prepared=$(_968_prepare 2 '["9223372036854775807"]')
+  [ "$(_968_frontier "$prepared")" = 2 ]
+  run _968_prepare 2 '["9223372036854775808"]'
+  [ "$status" -eq 13 ]
+  [[ "$output" == *"not a canonical sequence"* ]]
+  run _968_prepare 2 '["9999999999999999999"]'
+  [ "$status" -eq 13 ]
+}

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -1341,3 +1341,114 @@ _462_piped_sites_under() {
   # And ONLY that site: the mutant differs from the tree in one place.
   [ "$(printf '%s\n' "$unwarmed" | grep -c .)" -eq 1 ]
 }
+
+# ---- #968: roster sequences and the read frontier ----
+
+_968_apply_messages() {
+  # Apply messages to bob at the given server sequences and mark them all read.
+  local page="" i=0 seq last
+  for seq in "$@"; do
+    i=$((i+1))
+    page="${page}$(jq -nc --arg s "$seq" --arg n "$i" '
+      {type:"sync_pull_message",server_seq:$s,
+       id:("550e8400-e29b-41d4-a716-4466554409"+(if ($n|length)==1 then "0"+$n else $n end)),
+       server_received_at:"2026-07-21T06:00:00.000000Z",
+       envelope:{v:1,cipher:"none",key_id:null,blob:"e30="},status:"importable",
+       policy_revision:"0",local_security_revision:"0",
+       projection:{body:("msg "+$n),created_at:"2026-07-21T06:00:00.000000Z",
+                   from_agent:"alice",to_agent:"bob"}}')
+"
+  done
+  last="${!#}"
+  page="${page}{\"type\":\"sync_pull_cursor\",\"next_after\":\"$last\"}"
+  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  local id
+  for id in $(storage_history demo | jq -r 'select(.to=="bob")|.id'); do
+    storage_read_cursor_consume demo bob "$(storage_watch_tip demo:bob)" "$id" >/dev/null
+  done
+}
+
+_968_prepare() {
+  # $1 = current_seq, $2 = roster_seqs as a JSON array, or the word none.
+  local roster="$2" context
+  context=$(jq -nc --arg cur "$1" --arg roster "$roster" '
+    {type:"sync_read_context",min_available_seq:"0",current_seq:$cur,local_agents:["bob"],
+     members:[{member_id:"018f3f7e-0000-7000-8000-000000000010",name:"bob"}]}
+    + (if $roster=="none" then {} else {roster_seqs:($roster|fromjson)} end)')
+  printf '%s\n' "$context" | storage_sync_prepare_read_state demo "$SERVER_ID" "$TEAM_ID" 1
+}
+
+_968_frontier() { printf '%s\n' "$1" | jq -r 'select(.type=="sync_read_frontier")|.server_seq'; }
+_968_exact_count() { printf '%s\n' "$1" | jq -r 'select(.type=="sync_read_exact")|.wire_id' | grep -c . || true; }
+
+@test "read-state: a frontier advances across roster sequences the engine names, and stays pinned when it does not (#968)" {
+  # The reported shape: seq 1 and 2 were member_joined (never messages), the
+  # messages start at 3. Everything is imported and read.
+  _968_apply_messages 3 4 5 6
+  local prepared
+  prepared=$(_968_prepare 6 '["1","2"]')
+  [ "$(_968_frontier "$prepared")" = 6 ]
+  [ "$(_968_exact_count "$prepared")" -eq 0 ]
+  # Without the roster list the check has no evidence for seq 1 and 2, and a
+  # frontier is never advanced on evidence that was not supplied: this is the
+  # pre-#968 behavior, pinned at 0 with every read message shipped as an
+  # exception. Kept as the documented fail-safe direction.
+  prepared=$(_968_prepare 6 none)
+  [ "$(_968_frontier "$prepared")" = 0 ]
+  [ "$(_968_exact_count "$prepared")" -eq 4 ]
+}
+
+@test "read-state: a lost MESSAGE still pins the frontier; the roster list exempts only its own sequences (#968)" {
+  # Seq 4 is a message that never arrived. The roster list says 1 and 2 only.
+  _968_apply_messages 3 5 6
+  local prepared
+  prepared=$(_968_prepare 6 '["1","2"]')
+  [ "$(_968_frontier "$prepared")" = 3 ]
+  # The two read messages past the hole travel as exact exceptions, as before.
+  [ "$(_968_exact_count "$prepared")" -eq 2 ]
+  # The one way this check goes green while something is wrong, named: a
+  # roster list that claims a sequence which was really a message. The journal
+  # is written from the same records the server labelled as roster mutations,
+  # so this needs the label to be wrong first; it is recorded here as the
+  # residual, not hidden.
+  prepared=$(_968_prepare 6 '["1","2","4"]')
+  [ "$(_968_frontier "$prepared")" = 6 ]
+}
+
+@test "read-state: a roster row that IS in quarantine (bootstrap path) is exempt only when the roster list names it (#968)" {
+  # The bootstrap path quarantines roster records and marks them imported
+  # without a message mapping. Imported-and-unmapped is NOT by itself the
+  # exemption: only the roster list is, so a message row that somehow lost its
+  # mapping still reads as a hole.
+  local wire=550e8400-e29b-41d4-a716-446655440921 roster
+  roster=$(jq -nc --arg id "$wire" '
+    {type:"sync_pull_message",server_seq:"1",id:$id,
+     server_received_at:"2026-07-21T05:59:00.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:"e30="},status:"importable",
+     policy_revision:"0",local_security_revision:"0",
+     projection:{kind:"member_joined",mutation_id:"019fb4bb-7948-7520-8c16-ab64753e2012",
+       member_id:"019fb4bb-7948-7ce9-8e4f-61229dc726cf",name:"dana",occurred_at:"2026-07-21T05:59:00.000000Z"}}')
+  printf '%s\n%s\n' "$roster" '{"type":"sync_pull_cursor","next_after":"1"}' |
+    storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  local db
+  db=$(agmsg_db_path demo)
+  [ "$(agmsg_sqlite "$db" "SELECT status FROM sync_quarantine WHERE wire_id='$wire';" | tr -d '\r')" = imported ]
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_messages WHERE wire_id='$wire';" | tr -d '\r')" -eq 0 ]
+  _968_apply_messages 2 3
+  local prepared
+  prepared=$(_968_prepare 3 '["1"]')
+  [ "$(_968_frontier "$prepared")" = 3 ]
+  [ "$(_968_exact_count "$prepared")" -eq 0 ]
+  prepared=$(_968_prepare 3 '[]')
+  [ "$(_968_frontier "$prepared")" = 0 ]
+}
+
+@test "read-state: a malformed roster list is refused, not partially trusted (#968)" {
+  _968_apply_messages 1 2
+  run _968_prepare 2 '["1","x"]'
+  [ "$status" -eq 13 ]
+  run _968_prepare 2 '[1]'
+  [ "$status" -eq 13 ]
+  run _968_prepare 2 '"1"'
+  [ "$status" -eq 13 ]
+}

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -1466,7 +1466,7 @@ _968_exact_count() { printf '%s\n' "$1" | jq -r 'select(.type=="sync_read_exact"
   # refusal by its own message (the #911 line number would differ as well).
   run _968_prepare 10004 "$(jq -nc '[range(1;10002) | tostring]')"
   [ "$status" -eq 13 ]
-  [[ "$output" == *"roster_seqs is not a list of at most 10000"* ]]
+  printf '%s\n' "$output" | grep -Fq "roster_seqs is not a list of at most 10000"
   # And nothing moved: the frontier recorded by the accepted call is still
   # the one on disk, not a partially trusted one.
   db=$(agmsg_db_path demo)
@@ -1475,15 +1475,41 @@ _968_exact_count() { printf '%s\n' "$1" | jq -r 'select(.type=="sync_read_exact"
 
 @test "read-state: a roster sequence is validated against the sequence DOMAIN, not just its shape (#968)" {
   # 9223372036854775808 through 9999999999999999999 are canonical-looking
-  # 19-digit decimals past MAX_SEQUENCE; SQLite stores them as REAL instead of
-  # refusing (review finding). MAX itself is a legal sequence.
+  # 19-digit decimals past MAX_SEQUENCE. Handed to the INTEGER PRIMARY KEY
+  # temp table they are refused with a datatype mismatch that takes the whole
+  # read-prepare transaction down -- no 13, no reason (measured in review).
+  # MAX itself is a legal sequence.
   _968_apply_messages 1 2
   local prepared
   prepared=$(_968_prepare 2 '["9223372036854775807"]')
   [ "$(_968_frontier "$prepared")" = 2 ]
   run _968_prepare 2 '["9223372036854775808"]'
   [ "$status" -eq 13 ]
-  [[ "$output" == *"not a canonical sequence"* ]]
+  printf '%s\n' "$output" | grep -Fq "not a canonical sequence"
   run _968_prepare 2 '["9999999999999999999"]'
   [ "$status" -eq 13 ]
+}
+
+@test "read-state: a roster entry with a trailing newline is refused at the shape check, and the frontier does not move (#968)" {
+  # jq's regex engine lets $ match before one trailing newline, so an entry
+  # of "1\n" passed a ^..$ shape test; the line-framed per-entry loop then
+  # validated "1" and the SQL received (1\n), which SQLite accepts as 1 -- a
+  # malformed entry exempting a real sequence (review finding, measured).
+  # The shape test is anchored \A..\z now. Each control proves the frontier
+  # did not move, because the danger here is advancing, not failing.
+  _968_apply_messages 3 4
+  local prepared db
+  prepared=$(_968_prepare 4 '["1","2"]')
+  [ "$(_968_frontier "$prepared")" = 4 ]
+  db=$(agmsg_db_path demo)
+  run _968_prepare 4 "$(jq -nc '["1\n","2"]')"
+  [ "$status" -eq 13 ]
+  printf '%s\n' "$output" | grep -Fq "canonical sequences"
+  [ "$(agmsg_sqlite "$db" "SELECT server_seq FROM sync_read_prepared;" | tr -d '\r')" = 4 ]
+  run _968_prepare 4 "$(jq -nc '["1\n2"]')"
+  [ "$status" -eq 13 ]
+  [ "$(agmsg_sqlite "$db" "SELECT server_seq FROM sync_read_prepared;" | tr -d '\r')" = 4 ]
+  run _968_prepare 4 '[""]'
+  [ "$status" -eq 13 ]
+  [ "$(agmsg_sqlite "$db" "SELECT server_seq FROM sync_read_prepared;" | tr -d '\r')" = 4 ]
 }


### PR DESCRIPTION
Closes #968. Also the root of #971: the read-state slowness that grows while the engine runs is these exceptions accumulating, not an index.

## What was wrong

`storage_sync_prepare_read_state()` judged a member's read frontier by contiguity of the sequences held locally, checked against `sync_quarantine` — which holds messages only. Roster mutations consume server sequence numbers but are routed to the roster driver by design, so they never get a message mapping and, on the engine pull path, never enter quarantine at all. Every one of them reads as a hole, the first hole is seq 1 (the founding `member_joined`), and so the frontier is pinned at 0 on every team from the moment it is created. Every read message then ships as an individual `sync_read_exact` on every cycle, forever, growing with history.

Reproduced at the driver level with two stores that differ only in where numbering starts: messages at seqs 3–6, all read, with seqs 1–2 having been roster → frontier 0 and all four reads shipped as exceptions; messages at 1–4, all read → frontier 4 and none. The reporter's exact shape.

There is a second shape of the same disease, found on our own production team while verifying: a store filled by pull-bootstrap does quarantine the roster records (status `imported`) but they have no `sync_messages` mapping, so the check's `local_position IS NULL` branch fires instead of the contiguity branch. Same outcome — all 30 members pinned at 0, 15,299 read aliases re-sent as exceptions every cycle, 13 pages / 13,000 read-state items on the last cycle before this change.

## What this does

The roster driver already journals one `roster_synced` record, carrying the server sequence, for every mutation it applies — on both ingestion paths, and since the same commit (9e41edd, v1.2.0) that put roster mutations on the transport, so no store predates the journal. The engine now reads that journal at each read-state cycle and passes the sequences as `roster_seqs` in `sync_read_context`. The storage driver folds them into the held sequence space — the union of quarantine rows and roster sequences, one row per sequence — and exempts exactly those sequences from the mapping requirement. No ingestion path changes, no new persistent table, and both shapes heal on the first prepare after landing: the frontier is recomputed from scratch each time, so nothing needs cleaning up.

## The failure direction, and the one way it stays green while wrong

- No `roster_seqs` in the context (an older engine), a missing or torn journal, or a journal line that will not parse → no sequences → today's behavior, a frontier that cannot advance — and the engine says so (`read-state.roster-journal-unreadable`, with path and line), because a pinned frontier is also what this bug looked like. A frontier is never advanced on evidence that was not read. A malformed list is refused with 13 on its own line and with its own message, so it is told apart from the other context refusals. The list is held to the sequence domain on both sides independently — `sequence()`/`MAX_SEQUENCE` in the engine, `_sqlite_sync_sequence` in the driver, the same bound this function already holds `current_seq` to — with an absolutely anchored shape test (`\A..\z`, since jq's `$` also matches before a trailing newline). Bound at 10,000 entries, the size the contract test passes through both ways: 10,000 accepted and the frontier landing on the right value, 10,001 refused and the recorded frontier unmoved. The list is one entry per roster mutation the team ever applied (30 on our 21,505-message team), so it grows with membership events, not traffic.
- Imported-and-unmapped is deliberately NOT an exemption on its own, even though today only roster rows look like that. If the message import batch's atomicity ever broke and a message row lost its mapping, that sequence is absent from the journal and still pins. A genuinely lost message still pins (tested: seq 4 missing → frontier 3).
- The named residual: a journal that claims a sequence which was really a message would let the frontier pass a real hole. The journal is written from the same records the server labelled as roster mutations, so this needs the label to be wrong first. It is pinned in a test as the documented residual rather than hidden.

## Measured on both paths, not read

- Engine pull path: the real `cycle()` with the real storage and roster drivers against an isolated store, pulling a `member_joined` at seq 1 and a message at seq 2. The journal gained `roster_synced` with `server_seq "1"`; read-state reported frontier 1 before the member read seq 2, and 2 after (both from the request body the engine sent and from `sync_read_prepared`).
- Bootstrap path: our production team's journal holds exactly 30 `roster_synced` records, sequences 1–30, matching one-to-one the 30 imported-and-unmapped quarantine rows.

## After landing — how to tell it worked

On our production team, observation only, before and after the first cycle on this code:

| | before (last cycle, 2026-08-25 06:00Z) | after |
|---|---|---|
| `sync_read_members.remote_server_seq`, all 30 members | 0 | expected: advances once the server echoes the uploaded frontier |
| `sync_read_prepared.server_seq` | 0 | expected: at or near `current_seq` (21,5xx) |
| read-state items per cycle (`read-state.applied` in the engine log) | 13 pages / 13,000 | expected: ~30 (one frontier per member, ~0 exact) |

Both numbers will be recorded on this PR after the first post-landing cycle. The one thing this cannot verify before landing, which the reporter also named: whether the server accepts a frontier that steps over roster sequences. The mock-server tests fix the client's shape; the first real answer is that after-column. If it stays at 0, the server rejected the frontier and this needs a server-side look.

## Tests

- `tests/test_remote_sync.bats` (+4, suite 48/48 green): the reporter's shape heals with the list and stays pinned without it; a lost message still pins and the wrongly-listed residual is named; the bootstrap shape is exempt only via the list; a malformed list is refused.
- `tests/remote_sync_engine.test.mjs` (+2, suite 113/113 green): the journal reader filters by binding, ignores non-canonical sequences, dedupes, sorts, and returns nothing on a missing or torn journal; the read-prepare context carries the sequences.

Scope: `scripts/drivers/storage/sqlite-sync.sh` (`storage_sync_prepare_read_state` only) and `scripts/internal/remote-sync.mjs` (one reader + one context field). No overlap with #969.
