### PR TITLE
test: correct the (#683) tag on eight tests, and audit the rest (#985)

### DIFF
--- a/tests/test_actas_integration.bats
+++ b/tests/test_actas_integration.bats
@@ -187,7 +187,7 @@ fake_session() {
   wait "$wpid" 2>/dev/null || true
 }
 
-# --- watch.sh releasing a pair it no longer owns (#683) ---
+# --- watch.sh releasing a pair it no longer owns (#983) ---
 
 # The subscription set and the lock check both happen once, before the polling
 # loop (watch.sh 159-211 vs the loop at 274). So a watcher that is already
@@ -200,7 +200,7 @@ fake_session() {
 # stdout is still an open pipe to a live session -- so the id is appended to
 # DELIVERED_IDS and the message is marked read. Nothing surfaces it. That is the
 # reported symptom: consumed, marked read, and never delivered.
-@test "watch: a pair claimed by another session is released, not consumed (#683)" {
+@test "watch: a pair claimed by another session is released, not consumed (#983)" {
   skip_on_windows "actas watcher process mgmt under Git Bash (#182)"
   fake_register T alice
   fake_register T bob
@@ -262,7 +262,7 @@ fake_session() {
 # must cost it that role and nothing else. Exiting here would take down a whole
 # session's delivery because one member ran `actas` somewhere -- a worse failure
 # than the one being fixed.
-@test "watch: a broad watcher drops only the claimed pair and keeps serving the rest (#683)" {
+@test "watch: a broad watcher drops only the claimed pair and keeps serving the rest (#983)" {
   skip_on_windows "actas watcher process mgmt under Git Bash (#182)"
   fake_register T alice
   fake_register T bob
@@ -304,7 +304,7 @@ fake_session() {
 # reads free again. Permanence would be the worse behaviour -- the role is still
 # registered to this project, so nobody would deliver for it until the session
 # restarted -- so this pins the return rather than the drop.
-@test "watch: a broad watcher takes a pair back once nobody holds it (#683)" {
+@test "watch: a broad watcher takes a pair back once nobody holds it (#983)" {
   skip_on_windows "actas watcher process mgmt under Git Bash (#182)"
   fake_register T alice
   fake_register T carol
@@ -367,7 +367,7 @@ fake_session() {
 # still-held one is announced a second time. The lock, not this list, decides
 # delivery -- so the assertion is on the log, which is the only thing the
 # bookkeeping controls.
-@test "watch: releasing one held pair does not forget another whose name it matches (#683)" {
+@test "watch: releasing one held pair does not forget another whose name it matches (#983)" {
   skip_on_windows "actas watcher process mgmt under Git Bash (#182)"
   fake_register 't.m' alice
   fake_register 'txm' alice

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -167,7 +167,7 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
   sqlite_mem "SELECT coalesce(json_extract(CAST(readfile('$escaped') AS TEXT), '\$.remote_binding.$2'), '');"
 }
 
-@test "connect: a POST that committed but lost its response recovers on retry (#143)" {
+@test "connect: a POST that committed but lost its response recovers on retry" {
   # Arm the cut: the next /v1/connect registers the team and answers nothing.
   run curl -sS "$ENDPOINT/_test/drop-next-connect"
   [ "$status" -eq 0 ]
@@ -187,7 +187,7 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
   [ "$(_binding_field testteam remote_team_name)" = "testteam" ]
 }
 
-@test "connect: refuses to re-anchor a binding to a different server instance (#143)" {
+@test "connect: refuses to re-anchor a binding to a different server instance" {
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
   [ "$status" -eq 0 ]
   local anchored
@@ -219,7 +219,7 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
   [ "$(_binding_field testteam server_instance_id)" != "$anchored" ]
 }
 
-@test "connect: a repeat run cannot restate the registered cipher profile (#143)" {
+@test "connect: a repeat run cannot restate the registered cipher profile" {
   # Declaring age-v1 means minting a key, so this one needs age. The refusal
   # itself does not -- the quoting it prints is covered without age in
   # test_shquote.bats, at the function that owns it.
@@ -496,7 +496,7 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
   [ "$(_binding_field testteam endpoint)" = "$ENDPOINT" ]
 }
 
-@test "connect: the printed recovery command is shell-safe for a hostile team name (#143)" {
+@test "connect: the printed recovery command is shell-safe for a hostile team name" {
   # This asserts the CALL SITE, not the helper. tests/test_shquote.bats pins
   # what agmsg_shq does; nothing there stops remote.sh from going back to a
   # bare '$team', and the case that would catch it needs age and so never runs
@@ -570,14 +570,14 @@ _capability_endpoint() {
   printf '%s' "$ENDPOINT/t/$CAPABILITY_SECRET"
 }
 
-@test "redaction: adoption success does not print the capability (#143)" {
+@test "redaction: adoption success does not print the capability" {
   local cap; cap="$(_capability_endpoint)"
   bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
   assert_no_capability "adopting that registration" \
     bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
 }
 
-@test "redaction: an unreadable capabilities response does not print it (#143)" {
+@test "redaction: an unreadable capabilities response does not print it" {
   local cap; cap="$(_capability_endpoint)"
   bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
   curl -sS "$ENDPOINT/_test/fail-next?route=capabilities" >/dev/null
@@ -585,7 +585,7 @@ _capability_endpoint() {
     bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
 }
 
-@test "redaction: an unreadable roster response does not print it (#143)" {
+@test "redaction: an unreadable roster response does not print it" {
   local cap; cap="$(_capability_endpoint)"
   bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
   curl -sS "$ENDPOINT/_test/fail-next?route=members" >/dev/null
@@ -593,7 +593,7 @@ _capability_endpoint() {
     bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
 }
 
-@test "redaction: a server-instance mismatch does not print it (#143)" {
+@test "redaction: a server-instance mismatch does not print it" {
   local cap; cap="$(_capability_endpoint)"
   bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
   curl -sS "$ENDPOINT/_test/rotate-server-id" >/dev/null
@@ -601,7 +601,7 @@ _capability_endpoint() {
     bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
 }
 
-@test "redaction: a team-name mismatch does not print it (#143)" {
+@test "redaction: a team-name mismatch does not print it" {
   local cap; cap="$(_capability_endpoint)"
   bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
   curl -sS --get --data-urlencode "from=testteam" --data-urlencode "to=someone-elses" \
@@ -610,7 +610,7 @@ _capability_endpoint() {
     bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
 }
 
-@test "redaction: a roster mismatch does not print it (#143)" {
+@test "redaction: a roster mismatch does not print it" {
   local cap; cap="$(_capability_endpoint)"
   bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
   local cfg="$TEST_SKILL_DIR/teams/testteam/config.json" updated
@@ -620,7 +620,7 @@ _capability_endpoint() {
     bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
 }
 
-@test "redaction: a cipher-profile mismatch does not print it (#143)" {
+@test "redaction: a cipher-profile mismatch does not print it" {
   local cap; cap="$(_capability_endpoint)"
   bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
   curl -sS --get --data-urlencode "team_name=testteam" --data-urlencode "profile=age-v1" \
@@ -629,7 +629,7 @@ _capability_endpoint() {
     bash "$SCRIPTS/remote.sh" connect --endpoint "$cap" testteam
 }
 
-@test "redaction: the helper drops path, query, fragment and userinfo (#143)" {
+@test "redaction: the helper drops path, query, fragment and userinfo" {
   # The one source-level claim kept: it is about the helper's own behaviour,
   # not about who remembers to call it.
   eval "$(sed -n '/^_remote_endpoint_display() {/,/^}/p' "$SCRIPTS/remote.sh")"
@@ -640,7 +640,7 @@ _capability_endpoint() {
   [ "$(_remote_endpoint_display 'https://host/a@b/c')" = "https://host" ]
 }
 
-@test "connect: refuses to adopt a registration whose roster is not this team's (#143)" {
+@test "connect: refuses to adopt a registration whose roster is not this team's" {
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
   [ "$status" -eq 0 ]
 
@@ -1712,7 +1712,7 @@ _deny_engine_pidfile() {
   [[ "$output" == *"already has history"* ]]
 }
 
-@test "remote pull: refuses a team whose history is in the LEGACY table (#147)" {
+@test "remote pull: refuses a team whose history is in the LEGACY table" {
   # The shape the old guard could not see. It counted the event log only, so a
   # store whose history lives in the legacy `messages` table read as empty --
   # and this is the one case the guard exists to refuse. Asking the driver
@@ -1954,7 +1954,7 @@ PY_BIND
   [ "$(sqlite_mem "SELECT json_extract(CAST(readfile('$(rf "$cfg")') AS TEXT), '\$.remote_binding.cipher_profile');")" = "age-v1" ]
 }
 
-@test "remote pull: a declared-sealed EMPTY team without the key does not start its engine (#147)" {
+@test "remote pull: a declared-sealed EMPTY team without the key does not start its engine" {
   # The hole the envelope count left. Zero sealed envelopes arrive, so a
   # count-based gate never asks about the key at all and starts the engine --
   # on a machine that cannot read a word of what this team is about to
@@ -1972,7 +1972,7 @@ PY_BIND
   [ ! -f "$TEST_SKILL_DIR/run/remote-sync.encrypted.pid" ]
 }
 
-@test "remote pull: a declared-sealed EMPTY team WITH the key starts its engine (#147)" {
+@test "remote pull: a declared-sealed EMPTY team WITH the key starts its engine" {
   skip_if_no_age
   # The other side of the same gate: same declaration, same zero envelopes,
   # and the key present. Without this case a version that simply never starts
@@ -2008,7 +2008,7 @@ PY_BIND
   [[ "$output" != *"local but locked"* ]]
 }
 
-@test "remote pull: an unreadable local history stops the pull, loudly (#147)" {
+@test "remote pull: an unreadable local history stops the pull, loudly" {
   # An unknown history is not an empty one. Rounding it down is how the
   # non-fast-forward guard stops guarding -- the single case it exists to
   # refuse would sail through it. And the old code did worse than round: the
@@ -2092,7 +2092,7 @@ PY_BIND
   [ "$after" = "$before" ]
 }
 
-@test "pull decision: the engine follows the key, not the ciphertext (#147)" {
+@test "pull decision: the engine follows the key, not the ciphertext" {
   skip_if_no_age
   # The predicate on its own. The pull fixture cannot produce a team that is
   # both freshly pulled AND already keyed -- that state is created by a caller
@@ -2756,7 +2756,7 @@ assert_lookup_rejected() {
   assert_lookup_rejected root_name
 }
 
-@test "remote pull: the unlock line it prints can actually be run (#147)" {
+@test "remote pull: the unlock line it prints can actually be run" {
   # Typed, not read. A remedy line is only worth printing if a shell can run
   # it: this takes the line out of the output, fills the placeholders, and
   # requires the failure to be about the BUNDLE -- never "command not found"

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -639,7 +639,7 @@ _record_handover_events() {
   refute grep -n 'kill "\$prev_pid"' "$watch_sh"
 }
 
-@test "watch: a second unfiltered watcher says it is sharing, and a lone one does not (#683)" {
+@test "watch: a second unfiltered watcher says it is sharing, and a lone one does not" {
   # Two watchers with no active name subscribe to the same unclaimed pairs. The
   # read cursor is one per (team, agent), so whoever polls first takes the row
   # and the other never sees it — and `inbox.sh` then truthfully says "no new
@@ -707,7 +707,7 @@ _record_handover_events() {
   _stop_watcher "$first_pid"
 }
 
-@test "watch: a filtered watcher is never mistaken for unfiltered while starting (#683)" {
+@test "watch: a filtered watcher is never mistaken for unfiltered while starting" {
   # A reader that finds a live pid with no filter file SKIPS it: it cannot tell
   # the role or the project. If the pidfile were published first, every filtered
   # watcher would sit in exactly that state for the length of its startup
@@ -738,7 +738,7 @@ _record_handover_events() {
   _stop_watcher "$named_pid"
 }
 
-@test "watch: a watcher does not delete filter metadata it did not write (#683)" {
+@test "watch: a watcher does not delete filter metadata it did not write" {
   # The replacement path signals the previous watcher for this session id and
   # does not wait for it, so a successor writes its filter file while the
   # pidfile still names the predecessor. Deciding the filter's fate by the


### PR DESCRIPTION
Fixes #985.

The problem is not "eight #683 tags" — it is **tests/ tags that point at an issue whose stated subject is not what the test asserts**. A wrong tag is worse than no tag: it spends the reader's trust before they verify it, and one already misdirected an investigation (a repro posted to the closed #683, then retracted). This PR corrects the known cases and reports an audit of the rest.

## Corrected tags

Each was checked against the issue's actual subject with `gh issue view` — and, where the number was wrong, also against the introducing commit and an issue search, before deciding retag-vs-remove.

**27 tag lines change in all: 8 for #683 (5 retagged `(#983)`, 3 removed), 13 for #143 (removed), 6 for #147 (removed).** (The #143/#147 count is 19, not the 16 first estimated before the tags were actually counted.)

**#683** (read-cursor migration) — 8 tags, none describing the tagged test:
- 5 actas tests (`test_actas_integration.bats`: the section comment + "a pair claimed by another session is released, not consumed" and three siblings) → retagged **(#983)**, whose reproduction is literally `bats -f "claimed by another session"` against this file.
- 3 watch.bats tests (sharing-warning, filtered-vs-unfiltered startup, filter-metadata ownership) → tag **removed**. #66 describes the duplicate-watcher *leak*, not this behaviour; two came from review with no issue; the first's introducing commit (e3844c2) is where #683 was first miscited.

**#143** ("delivery.sh set turn malformed JSON on Windows") — 13 `test_remote.bats` tests actually about remote **connect** (idempotent recovery, binding re-anchor, cipher profile, redaction). Introduced by a56a6e8 / 8c2bd4b, neither citing #143. Tag **removed** (no issue states the group's behaviour).

**#147** ("validate team names to prevent teams/ path traversal") — 6 `test_remote.bats` tests actually about remote **pull** of sealed/encrypted/legacy teams. Introduced by d44cf9d / b6fc258, neither citing #147. Tag **removed**.

**Test names and comments only — no test behaviour changes.** Per-file `bats --count` is unchanged (actas 14, watch 22, remote 148).

## Audit of the remaining tags — and its limits

All **146 distinct `(#NNN)` tags** in `tests/` were checked **by issue title only** (comparing the issue's stated subject to what the tagged tests assert). Reading 146 bodies was out of scope; title-only is the range. Three boxes, so ambiguous cases are not silently counted as matches:

| box | count |
|---|---|
| match | ~138 |
| mismatch (wrong subsystem — fixed above) | 2 (#143, #147) |
| can't-judge | 6 |

**The 6 can't-judge are NOT fixed by this PR** (title too abstract, or the tagged tests span more than one subject, and all stay within the tag's own subsystem — none is the wrong-subsystem shape): **#245, #442, #477, #728, #730, #850**. They are left exactly as they are; a follow-up could confirm them against issue bodies.

**Bare `#NNN` references in comments were NOT audited** — only `(#NNN)` tags on test names and section headers were. A bare in-comment mention points nowhere a reader would trust as "this test is about issue N", so it is out of this audit's scope.
