### PR TITLE
docs(watch): correct the three (#683) source comments (#988)

### DIFF
--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -276,7 +276,7 @@ if [ -n "$PREV_PID_TO_DISPLACE" ]; then
   kill "$PREV_PID_TO_DISPLACE" 2>/dev/null || true
 fi
 
-# --- Say when this watcher is sharing an inbox with another (#683). ---
+# --- Say when this watcher is sharing an inbox with another. ---
 #
 # A watcher started WITHOUT an active name subscribes to every (team, agent)
 # registered for this project that nobody else has claimed. The read cursor is
@@ -547,7 +547,7 @@ fi
 
 # Pairs another session currently holds, so each departure and each return is
 # announced once instead of every cycle. Membership is not a decision -- the
-# lock is -- it only records what has already been said (#683).
+# lock is -- it only records what has already been said.
 #
 # Held as newline-separated entries and compared as EXACT strings, never as
 # patterns. A team name is arbitrary UTF-8 minus a path deny-list and an agent
@@ -623,7 +623,7 @@ while true; do
     # whoever polls first TAKES the row and the other sees nothing. When the
     # one that takes it is this stale process, its printf succeeds -- stdout is
     # still an open pipe to a live session -- so the id is marked read and the
-    # message is gone, delivered to a stream nobody is reading (#683).
+    # message is gone, delivered to a stream nobody is reading (#983).
     #
     # Only the lock file is read here, not the whole subscription set: losing a
     # pair is the half a running process can detect for the price of a file


### PR DESCRIPTION
Fixes #988. Follow-up to #987, which corrected the `(#683)` tags in `tests/`. The same miscitation survived in three `scripts/watch.sh` comments — and a source comment is read by the person about to change that code, so a wrong pointer there costs more than a wrong test name.

`#683` is "Per-team migration copies a global read cursor without preserving its sequence floor" — read-cursor migration. Each comment was checked **one at a time** against that subject; **keeping the tag was an allowed outcome** (the goal is that every remaining `#683` be correct, not that there be none). None of the three is about cursor migration:

| line | comment subject | verdict |
|---|---|---|
| 279 | the sharing *warning* for two unfiltered watchers on unclaimed pairs | not migration, not the claim-race, no matching issue → **tag removed** |
| 550 | the held-pair set that de-duplicates departure/return announcements (*"said" = announced, not read*) | bookkeeping, not migration, no matching issue → **tag removed** |
| 626 | a *stale* process consuming a message for a pair *another session claimed* | the **#983 hazard** — this comment sits on the FIRST `actas_lock_state` check, and #983 is the still-open window BETWEEN that check and the later fetch. It **names** the hazard; it does not close it → **retagged (#983)** |

**Comments only — no code changes.** `bash -n` clean, enforced-assertions at baseline. (#983 remains open; nothing here fixes it.)

## Why one wrong number is worth this much care

The genealogy of this single miscitation — traced by `git log -S` to the introducing commits — is the whole argument:

```
one wrong (#683) on watcher-series commit subjects
  e3844c2 (subject did not even cite it; the tag was added to the body later)
  e4db061  "step aside while a pair is held … (#683)"      → CHANGELOG L275
  be48ecf  "release a pair another session has claimed (#683)" → CHANGELOG L276
```

lands in three kinds of place:

| fixable | not fixable |
|---|---|
| `tests/` tags — done (#987, landed) | git history: `(#683)` is in the squash-merge commit subjects, immutable |
| `scripts/` comments — this PR | published `CHANGELOG.md` L274–276, regenerated by git-cliff *from* those subjects (a hand edit reverts next release) |
| | published release notes / distributed tarballs |

Three people reached "L550 is not #683" by independent routes (the code de-dups *announcements*, not reads; no independent evidence it was ever judged #683; its tag descends straight from a miscited subject). The point of the asymmetry: a single wrong issue number is cheap to write and, once it rides a squash merge and a release, impossible to take back.