### PR TITLE
fix(install): write Codex writable_roots through a symlinked config.toml instead of replacing the link (#747)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -105,14 +105,24 @@ AGENT_TYPE=""  # claude-code, codex, gemini, antigravity — passed via --agent-
 # the SKILL.md the installer itself had written with the wrong flavor.
 AGMSG_SHARED_SKILL_TPL_TYPES="gemini antigravity opencode hermes cursor grok-build"
 
-# Overwrite <dest> with the contents of <src>, then remove <src>. Unlike `mv`,
-# a redirect follows <dest> when it is a symlink and writes the link's target,
-# so a `~/.codex/config.toml` managed as a symlink (stow/chezmoi/manual dotfiles)
-# keeps its link and receives the edit — `mv` would replace the link with a plain
-# file and drop the edit on a detached copy (#747). Not atomic, which is fine for
-# a few-KB config written once at install time.
-write_through_symlink() {
-  cat "$1" > "$2" && rm -f "$1"
+# Put <src> at <dest>, then remove any leftover <src>. The arm is chosen by
+# <dest>, so the fix's scope matches the defect's (#747):
+#   - regular <dest>: `mv` — an atomic rename, so an interrupted install leaves
+#     either the whole old config or the whole new one, never a torn file. This
+#     is the common path and must stay atomic.
+#   - symlinked <dest>: write THROUGH the link (a redirect follows it) so a
+#     config.toml managed as a symlink (stow/chezmoi/manual dotfiles) keeps its
+#     link and its target receives the edit. `mv` would replace the link with a
+#     plain file and strand the edit on a detached copy — the actual #747 bug.
+#     This arm is non-atomic (there is no atomic write-through-a-link with plain
+#     POSIX tools), but the exposure is confined to symlink users, whose target
+#     is typically a version-controlled dotfile.
+move_into_place() {
+  if [ -L "$2" ]; then
+    cat "$1" > "$2" && rm -f "$1"
+  else
+    mv "$1" "$2"
+  fi
 }
 
 configure_codex_sandbox() {
@@ -168,13 +178,13 @@ configure_codex_sandbox() {
         done=1
       }
       { print }
-    ' "$code_config" > "$code_config.tmp" && write_through_symlink "$code_config.tmp" "$code_config"
+    ' "$code_config" > "$code_config.tmp" && move_into_place "$code_config.tmp" "$code_config"
   elif grep -q '^\[sandbox_workspace_write\]' "$code_config" 2>/dev/null; then
     # Section exists but no writable_roots
     awk -v entries="$entries" '
       { print }
       /^\[sandbox_workspace_write\]/ { print "writable_roots = [" entries "]" }
-    ' "$code_config" > "$code_config.tmp" && write_through_symlink "$code_config.tmp" "$code_config"
+    ' "$code_config" > "$code_config.tmp" && move_into_place "$code_config.tmp" "$code_config"
   else
     # No section at all
     printf '\n[sandbox_workspace_write]\nwritable_roots = [%s]\n' "$entries" >> "$code_config"

--- a/install.sh
+++ b/install.sh
@@ -105,6 +105,16 @@ AGENT_TYPE=""  # claude-code, codex, gemini, antigravity — passed via --agent-
 # the SKILL.md the installer itself had written with the wrong flavor.
 AGMSG_SHARED_SKILL_TPL_TYPES="gemini antigravity opencode hermes cursor grok-build"
 
+# Overwrite <dest> with the contents of <src>, then remove <src>. Unlike `mv`,
+# a redirect follows <dest> when it is a symlink and writes the link's target,
+# so a `~/.codex/config.toml` managed as a symlink (stow/chezmoi/manual dotfiles)
+# keeps its link and receives the edit — `mv` would replace the link with a plain
+# file and drop the edit on a detached copy (#747). Not atomic, which is fine for
+# a few-KB config written once at install time.
+write_through_symlink() {
+  cat "$1" > "$2" && rm -f "$1"
+}
+
 configure_codex_sandbox() {
   # --- Configure Codex sandbox (if Codex is installed) ---
   # The Codex bridge writes pidfiles/sockets/request files under the
@@ -158,13 +168,13 @@ configure_codex_sandbox() {
         done=1
       }
       { print }
-    ' "$code_config" > "$code_config.tmp" && mv "$code_config.tmp" "$code_config"
+    ' "$code_config" > "$code_config.tmp" && write_through_symlink "$code_config.tmp" "$code_config"
   elif grep -q '^\[sandbox_workspace_write\]' "$code_config" 2>/dev/null; then
     # Section exists but no writable_roots
     awk -v entries="$entries" '
       { print }
       /^\[sandbox_workspace_write\]/ { print "writable_roots = [" entries "]" }
-    ' "$code_config" > "$code_config.tmp" && mv "$code_config.tmp" "$code_config"
+    ' "$code_config" > "$code_config.tmp" && write_through_symlink "$code_config.tmp" "$code_config"
   else
     # No section at all
     printf '\n[sandbox_workspace_write]\nwritable_roots = [%s]\n' "$entries" >> "$code_config"

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -563,6 +563,45 @@ PY
   fi
 }
 
+@test "install: a symlinked Codex config.toml keeps its link and the edit lands on the target (#747, writable_roots exists)" {
+  mkdir -p "$FAKE_HOME/.codex" "$FAKE_HOME/dotfiles"
+  # The reporter's exact shape: writable_roots already present with an entry, and
+  # config.toml is a symlink into a dotfiles repo (stow/chezmoi/manual).
+  cat > "$FAKE_HOME/dotfiles/config.toml" <<'EOF'
+[sandbox_workspace_write]
+writable_roots = ["/some/existing/path"]
+EOF
+  ln -s "$FAKE_HOME/dotfiles/config.toml" "$FAKE_HOME/.codex/config.toml"
+  [ -L "$FAKE_HOME/.codex/config.toml" ] || skip "filesystem did not create a real symlink here"
+
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+
+  # The link survives: `mv` would have replaced it with a plain file (#747).
+  [ -L "$FAKE_HOME/.codex/config.toml" ]
+  # The edit reached the link's target, not a detached copy at the link path.
+  grep -q "$SK/db" "$FAKE_HOME/dotfiles/config.toml"
+  grep -q "$SK/teams" "$FAKE_HOME/dotfiles/config.toml"
+  grep -q "$SK/run" "$FAKE_HOME/dotfiles/config.toml"
+  # The pre-existing entry is kept.
+  grep -q "/some/existing/path" "$FAKE_HOME/dotfiles/config.toml"
+}
+
+@test "install: a symlinked Codex config.toml keeps its link when only the section exists (#747, second branch)" {
+  mkdir -p "$FAKE_HOME/.codex" "$FAKE_HOME/dotfiles"
+  # Section present, no writable_roots — the other mv-based branch.
+  cat > "$FAKE_HOME/dotfiles/config.toml" <<'EOF'
+[sandbox_workspace_write]
+EOF
+  ln -s "$FAKE_HOME/dotfiles/config.toml" "$FAKE_HOME/.codex/config.toml"
+  [ -L "$FAKE_HOME/.codex/config.toml" ] || skip "filesystem did not create a real symlink here"
+
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+
+  [ -L "$FAKE_HOME/.codex/config.toml" ]
+  grep -q "$SK/db" "$FAKE_HOME/dotfiles/config.toml"
+  grep -q "$SK/run" "$FAKE_HOME/dotfiles/config.toml"
+}
+
 
 # --- hermes Agent skill (~/.hermes/skills/<name>/SKILL.md) ---
 

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -602,6 +602,28 @@ EOF
   grep -q "$SK/run" "$FAKE_HOME/dotfiles/config.toml"
 }
 
+@test "install: an ordinary Codex config.toml is replaced atomically, not truncated in place (#747 control)" {
+  mkdir -p "$FAKE_HOME/.codex"
+  cat > "$FAKE_HOME/.codex/config.toml" <<'EOF'
+[sandbox_workspace_write]
+writable_roots = ["/some/existing/path"]
+EOF
+  # The reverse of the symlink tests, guarding the ordinary-file arm so the atomic
+  # mv cannot be dropped again unseen (#747). An atomic `mv` gives the destination
+  # a NEW inode (the temp file's); a truncate-then-write (`cat >`, the symlink arm)
+  # keeps the old inode. So an unchanged inode here would mean the ordinary path
+  # silently became non-atomic.
+  local ino_before; ino_before="$(ls -i "$FAKE_HOME/.codex/config.toml" | awk '{print $1}')"
+
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+
+  [ ! -L "$FAKE_HOME/.codex/config.toml" ]
+  grep -q "$SK/db" "$FAKE_HOME/.codex/config.toml"
+  grep -q "/some/existing/path" "$FAKE_HOME/.codex/config.toml"
+  local ino_after; ino_after="$(ls -i "$FAKE_HOME/.codex/config.toml" | awk '{print $1}')"
+  [ "$ino_after" != "$ino_before" ]
+}
+
 
 # --- hermes Agent skill (~/.hermes/skills/<name>/SKILL.md) ---
 


### PR DESCRIPTION
Fixes #747.

## Problem

`configure_codex_sandbox()` edited `~/.codex/config.toml` with `awk ... > tmp && mv tmp config`. `mv` replaces a **symlink** with the plain temp file, so on a `config.toml` managed as a symlink (stow / chezmoi / manual dotfiles) the install **detached the link** and wrote agmsg's paths to a fresh file at the link path — the dotfiles target kept its old contents, and the edit was effectively lost. The install printed success, so nothing flagged it.

Deterministic whenever `writable_roots` or `[sandbox_workspace_write]` already exists and agmsg's paths are not yet listed. The no-section branch already appended with `>>` (which follows the link), so it was unaffected.

## Change

Both `mv`-based branches now write through a small helper:

```sh
write_through_symlink() { cat "$1" > "$2" && rm -f "$1"; }
```

A redirect follows the link and updates its target, preserving the link. Not atomic — acceptable for a few-KB config written once at install time (option **A** in the issue). The third (`>>`) branch is left as-is.

## Reproduction (isolated, fake HOME)

Before: `~/.codex/config.toml` is a symlink into a dotfiles dir. After `install.sh`: with the fix the link is preserved and the target gains agmsg's `db`/`teams`/`run` paths; before the fix the link became a plain file and the target was untouched.

## Tests

`tests/test_install.bats` — two tests covering both `mv` branches (writable_roots present; section-only). Each runs the real installer against a symlinked `config.toml` and asserts the link survives and the edit lands on the **target**. Reverting the helper to `mv` fails both. Enforced-assertions checker at baseline (638); existing Codex writable_roots tests stay green.