### PR TITLE
test: count a role's bridges by pair set, and return the value that was waited for (#984)

### DIFF
--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -560,6 +560,27 @@ _wait_exact_role_count() { # <project> <name> <want>
   printf '%s' "$seen"
 }
 
+# The gate the five reap tests open before they make an orphan: the launcher
+# must actually have ONE bridge for exactly {<name>} first.
+#
+# It has to be load-bearing, and a `for ... && break` loop is not. Exhausting
+# such a loop and breaking out of it are indistinguishable from the next line,
+# so a test whose launcher never spawned would go on to `rm -f` pidfiles that do
+# not exist, wait, and then be satisfied by a bridge the launcher started DURING
+# that wait -- green, having created no orphan and reaped none. The test would
+# pass without exercising #937 at all, and nothing would say so (#984).
+#
+# Same rule as the team-lock gate in test_remote_engine_start_refusal.bats: when
+# a precondition cannot be established, say which count was actually reached and
+# fail, rather than continuing into an assertion that no longer means what it
+# says.
+_require_launcher_bridge() { # <project> <name>
+  local seen; seen="$(_wait_exact_role_count "$1" "$2" 1)"
+  [ "$seen" = 1 ] && return 0
+  echo "the launcher never reached one {$2} bridge (saw $seen), so this test could not create the orphan it is about" >&2
+  return 1
+}
+
 # Run the mock bridge directly for a given (project, pairs) so it publishes a
 # lease of that identity and stays alive. Sets FAKE_PID (NOT via $(...) -- a
 # background job in command substitution is killed when that subshell exits).
@@ -601,13 +622,32 @@ _spawn_fake() { # <project> <pair...>
   wait "$other" 2>/dev/null || true; wait "$solo" 2>/dev/null || true
 }
 
+@test "launcher: an unreachable gate fails the test instead of continuing (#984)" {
+  # No launcher is started here at all, so the gate's condition can never be
+  # reached. It has to END the test.
+  #
+  # This is the control for the five reap tests: each calls the gate bare, so an
+  # unreachable precondition fails them -- but ONLY if the gate returns non-zero
+  # on exhaustion. The `for ... && break` gate it replaces returned nothing at
+  # all: reaching the count and running out of tries left the same state behind,
+  # and the test carried on to delete pidfiles that did not exist and assert
+  # against a bridge started during the wait. Green, with #937 never exercised.
+  #
+  # Costs the waiter's full sweep by design -- an exhausted gate is what is
+  # being measured, so it cannot be short-circuited.
+  run _require_launcher_bridge "$PROJ" alice
+  [ "$status" -ne 0 ]
+  # And it must say WHICH count it reached: an exhausted gate that fails with a
+  # bare non-zero tells the next reader nothing about why.
+  printf '%s' "$output" | grep -q 'never reached one {alice} bridge (saw 0)'
+}
+
 @test "launcher: reaps a same-(project,role) orphan the pidfile lost, converging to one (#937)" {
   put_record team alice thread-alice "$PROJ" codex
   export MOCK_BRIDGE_SLEEP=25
   sleep 22 3>&- & local parent=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
-  local i; for i in {1..80}; do [ "$(_count_exact_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
-  [ "$(_count_exact_role_bridges "$PROJ" alice)" -eq 1 ]
+  _require_launcher_bridge "$PROJ" alice
   rm -f "$RUN_DIR"/codex-bridge.*.pid
   [ "$(_wait_exact_role_count "$PROJ" alice 1)" -eq 1 ]
   kill "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true
@@ -620,7 +660,7 @@ _spawn_fake() { # <project> <pair...>
   _spawn_fake "$PROJ" "team${tab}bob"; local bob=$FAKE_PID
   sleep 22 3>&- & local parent=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
-  local i; for i in {1..80}; do [ "$(_count_exact_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  _require_launcher_bridge "$PROJ" alice
   rm -f "$RUN_DIR"/codex-bridge.*.pid
   [ "$(_wait_exact_role_count "$PROJ" alice 1)" -eq 1 ]
   kill -0 "$bob"
@@ -634,7 +674,7 @@ _spawn_fake() { # <project> <pair...>
   _spawn_fake "$TEST_SKILL_DIR/other-proj" "team${tab}alice"; local other=$FAKE_PID
   sleep 22 3>&- & local parent=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
-  local i; for i in {1..80}; do [ "$(_count_exact_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  _require_launcher_bridge "$PROJ" alice
   rm -f "$RUN_DIR"/codex-bridge.*.pid
   [ "$(_wait_exact_role_count "$PROJ" alice 1)" -eq 1 ]
   kill -0 "$other"
@@ -648,7 +688,7 @@ _spawn_fake() { # <project> <pair...>
   _spawn_fake "$PROJ" "team${tab}alice2"; local alice2=$FAKE_PID
   sleep 22 3>&- & local parent=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
-  local i; for i in {1..80}; do [ "$(_count_exact_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  _require_launcher_bridge "$PROJ" alice
   rm -f "$RUN_DIR"/codex-bridge.*.pid
   [ "$(_wait_exact_role_count "$PROJ" alice 1)" -eq 1 ]
   kill -0 "$alice2"
@@ -666,7 +706,7 @@ _spawn_fake() { # <project> <pair...>
   # before the launcher has spawned anything: this is the one site where the
   # gate opened on the test's own fixture. The exact counter requires a pair set
   # of {alice}, the same set inequality the `kill -0 "$both"` below relies on.
-  local i; for i in {1..80}; do [ "$(_count_exact_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  _require_launcher_bridge "$PROJ" alice
   rm -f "$RUN_DIR"/codex-bridge.*.pid
   # ONE exact-{alice} bridge: the launcher's. `both` is not counted here -- the
   # `kill -0` below is what says it survived. The two assertions carry different

--- a/tests/test_codex_bridge_launcher.bats
+++ b/tests/test_codex_bridge_launcher.bats
@@ -510,22 +510,56 @@ wait_for_child_count() {
 
 # --- #937: reap a same-(project,role) orphan via its per-PID identity lease ---
 
-_count_role_bridges() { # <project> <name>
-  # Match the role name at a word boundary, not as a substring: "alice" must not
-  # also count "alice2" (the survive tests turn on exactly that distinction), so a
-  # trailing digit/letter excludes it. Names here are plain [a-z0-9] test tokens.
-  ps -Ao pid=,args= 2>/dev/null | grep -F "codex-bridge.js" | grep -F -- "--project $1 " | grep -E "$2([^0-9A-Za-z]|\$)" | grep -c . | tr -d ' '
+# Bridges whose pair set is EXACTLY {<name>}: one `--pair`, and that pair naming
+# <name>. Distinct from a plain argv match on <name> -- the form these tests used
+# until #984 -- which counts any process with <name> anywhere in its argv,
+# including a bridge that serves <name> alongside others.
+#
+# That distinction is the one this file's superset test already turns on: a
+# bridge for {alice,bob} is not a bridge for {alice}. An argv match cannot see
+# it, so it cannot be used to wait for "the launcher has spawned its alice" in a
+# test that has itself just spawned an {alice,bob} bridge -- the gate opens on
+# the test's own fixture, before the launcher has done anything (#937).
+#
+# Counted with `grep`, not by splitting fields: a pair value is `team<TAB>name`,
+# and awk splits on tabs as well as spaces whatever `-F` says about the input,
+# so `$(i+1)` after `--pair` is only `team`. Measured that way first and it
+# counted 0 for a bridge that plainly had one alice pair.
+_count_exact_role_bridges() { # <project> <name>
+  ps -Ao pid=,args= 2>/dev/null \
+    | grep -F "codex-bridge.js" \
+    | grep -F -- "--project $1 " \
+    | while IFS= read -r line; do
+        # Exactly one --pair, and its value's NAME half is <name>. A pair is
+        # `team<TAB>name`, and the separator has two renderings to allow for:
+        # `ps` writes the tab as the four characters \011 -- three of them
+        # digits, so a single-character [^0-9A-Za-z] separator class matches
+        # nothing at all and the counter answers 0 to everything (#984).
+        [ "$(printf '%s' "$line" | grep -o -- '--pair' | grep -c .)" -eq 1 ] || continue
+        printf '%s' "$line" | grep -Eq -- "--pair [^ ]*(\\\\011|[^0-9A-Za-z])$2([^0-9A-Za-z]|\$)" || continue
+        printf '.\n'
+      done | grep -c . | tr -d ' '
 }
-# Poll until this project's role-bridge count settles at <want>, then echo it --
-# a fixed sleep before a point-in-time count races the reap-and-respawn.
-_wait_role_count() { # <project> <name> <want>
-  local i
+
+# Poll until the exact-{<name>} count settles at <want>, then echo THE VALUE THAT
+# SATISFIED THE WAIT.
+#
+# The form these tests used until #984 re-counted after its loop, so what it
+# returned was a second, later observation. Between the two, the reaper kills the
+# orphan and the launcher respawns, and the count passes through 2 and through 0
+# -- so the caller was handed a number that nothing had ever waited for. That is
+# the half of #984 needing no superset fixture, and it is why all five call sites
+# could fail, not only the superset one.
+_wait_exact_role_count() { # <project> <name> <want>
+  local i seen
   for i in {1..100}; do
-    [ "$(_count_role_bridges "$1" "$2")" -eq "$3" ] && break
+    seen="$(_count_exact_role_bridges "$1" "$2")"
+    [ "$seen" = "$3" ] && { printf '%s' "$seen"; return 0; }
     sleep 0.1
   done
-  _count_role_bridges "$1" "$2"
+  printf '%s' "$seen"
 }
+
 # Run the mock bridge directly for a given (project, pairs) so it publishes a
 # lease of that identity and stays alive. Sets FAKE_PID (NOT via $(...) -- a
 # background job in command substitution is killed when that subshell exits).
@@ -537,15 +571,45 @@ _spawn_fake() { # <project> <pair...>
   FAKE_PID=$!
 }
 
+@test "launcher: the exact-role counter reads a pair set, not an argv substring (#984)" {
+  export MOCK_BRIDGE_SLEEP=25
+  local tab; tab=$(printf '\t')
+  _spawn_fake "$PROJ" "team${tab}alice" "team${tab}bob";      local both=$FAKE_PID
+  _spawn_fake "$PROJ" "team${tab}alice2";                     local two=$FAKE_PID
+  _spawn_fake "$TEST_SKILL_DIR/other-proj" "team${tab}alice"; local other=$FAKE_PID
+  # Positive control FIRST. Without it, the zeroes below are also what a counter
+  # that answers 0 to everything produces -- including one whose pattern never
+  # matches the separator `ps` renders between a pair's team and its name (it is
+  # a tab, and `ps` writes it as the four characters \011, three of them digits).
+  [ "$(_wait_exact_role_count "$PROJ" alice2 1)" -eq 1 ]
+  # None of the three is a bridge whose pair set is {alice} in THIS project:
+  # {alice,bob} is a superset, {alice2} collides only by prefix, and the third
+  # is another project's.
+  [ "$(_count_exact_role_bridges "$PROJ" alice)" -eq 0 ]
+  # ... and {alice,bob} is not {bob} either -- the rule is set equality, not
+  # "serves this role". Asked through the waiter, with a `want` of 1 it will
+  # never reach: this is the one assertion here that goes red if the waiter is
+  # ever rewritten to return its `want` instead of what it saw. Every other
+  # check in this file passes under that rewrite, which is the shape of the
+  # defect being fixed (#984). It costs the waiter's full 10s by design.
+  [ "$(_wait_exact_role_count "$PROJ" bob 1)" -eq 0 ]
+  # One that IS {alice} counts, with the other three still running.
+  _spawn_fake "$PROJ" "team${tab}alice"; local solo=$FAKE_PID
+  [ "$(_wait_exact_role_count "$PROJ" alice 1)" -eq 1 ]
+  kill "$both" "$two" "$other" "$solo" 2>/dev/null || true
+  wait "$both" 2>/dev/null || true; wait "$two" 2>/dev/null || true
+  wait "$other" 2>/dev/null || true; wait "$solo" 2>/dev/null || true
+}
+
 @test "launcher: reaps a same-(project,role) orphan the pidfile lost, converging to one (#937)" {
   put_record team alice thread-alice "$PROJ" codex
   export MOCK_BRIDGE_SLEEP=25
   sleep 22 3>&- & local parent=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
-  local i; for i in {1..80}; do [ "$(_count_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
-  [ "$(_count_role_bridges "$PROJ" alice)" -eq 1 ]
+  local i; for i in {1..80}; do [ "$(_count_exact_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  [ "$(_count_exact_role_bridges "$PROJ" alice)" -eq 1 ]
   rm -f "$RUN_DIR"/codex-bridge.*.pid
-  [ "$(_wait_role_count "$PROJ" alice 1)" -eq 1 ]
+  [ "$(_wait_exact_role_count "$PROJ" alice 1)" -eq 1 ]
   kill "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true
 }
 
@@ -556,9 +620,9 @@ _spawn_fake() { # <project> <pair...>
   _spawn_fake "$PROJ" "team${tab}bob"; local bob=$FAKE_PID
   sleep 22 3>&- & local parent=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
-  local i; for i in {1..80}; do [ "$(_count_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  local i; for i in {1..80}; do [ "$(_count_exact_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
   rm -f "$RUN_DIR"/codex-bridge.*.pid
-  [ "$(_wait_role_count "$PROJ" alice 1)" -eq 1 ]
+  [ "$(_wait_exact_role_count "$PROJ" alice 1)" -eq 1 ]
   kill -0 "$bob"
   kill "$bob" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$bob" 2>/dev/null || true
 }
@@ -570,9 +634,9 @@ _spawn_fake() { # <project> <pair...>
   _spawn_fake "$TEST_SKILL_DIR/other-proj" "team${tab}alice"; local other=$FAKE_PID
   sleep 22 3>&- & local parent=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
-  local i; for i in {1..80}; do [ "$(_count_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  local i; for i in {1..80}; do [ "$(_count_exact_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
   rm -f "$RUN_DIR"/codex-bridge.*.pid
-  [ "$(_wait_role_count "$PROJ" alice 1)" -eq 1 ]
+  [ "$(_wait_exact_role_count "$PROJ" alice 1)" -eq 1 ]
   kill -0 "$other"
   kill "$other" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$other" 2>/dev/null || true
 }
@@ -584,9 +648,9 @@ _spawn_fake() { # <project> <pair...>
   _spawn_fake "$PROJ" "team${tab}alice2"; local alice2=$FAKE_PID
   sleep 22 3>&- & local parent=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
-  local i; for i in {1..80}; do [ "$(_count_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  local i; for i in {1..80}; do [ "$(_count_exact_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
   rm -f "$RUN_DIR"/codex-bridge.*.pid
-  [ "$(_wait_role_count "$PROJ" alice 1)" -eq 1 ]
+  [ "$(_wait_exact_role_count "$PROJ" alice 1)" -eq 1 ]
   kill -0 "$alice2"
   kill "$alice2" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$alice2" 2>/dev/null || true
 }
@@ -598,9 +662,16 @@ _spawn_fake() { # <project> <pair...>
   _spawn_fake "$PROJ" "team${tab}alice" "team${tab}bob"; local both=$FAKE_PID
   sleep 22 3>&- & local parent=$!
   bash "$LAUNCHER" codex "$PROJ" "ws://127.0.0.1:1" "$parent" >/dev/null 2>&1 3>&- & local disp=$!
-  local i; for i in {1..80}; do [ "$(_count_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
+  # `both` carries `--pair team<TAB>alice`, so an argv match answers 1 for it
+  # before the launcher has spawned anything: this is the one site where the
+  # gate opened on the test's own fixture. The exact counter requires a pair set
+  # of {alice}, the same set inequality the `kill -0 "$both"` below relies on.
+  local i; for i in {1..80}; do [ "$(_count_exact_role_bridges "$PROJ" alice)" -ge 1 ] && break; sleep 0.1; done
   rm -f "$RUN_DIR"/codex-bridge.*.pid
-  [ "$(_wait_role_count "$PROJ" alice 1)" -eq 1 ]
+  # ONE exact-{alice} bridge: the launcher's. `both` is not counted here -- the
+  # `kill -0` below is what says it survived. The two assertions carry different
+  # halves of this test's claim.
+  [ "$(_wait_exact_role_count "$PROJ" alice 1)" -eq 1 ]
   # Its pair set is {alice,bob}, not {alice}: set inequality spares it.
   kill -0 "$both"
   kill "$both" "$disp" "$parent" 2>/dev/null || true; wait "$disp" 2>/dev/null || true; wait "$both" 2>/dev/null || true


### PR DESCRIPTION
Refs #984 — deliberately not `Fixes`. See **What is not measured** at the bottom.

## Two defects, and they do not reach the same tests

The five `#937` reap tests share one assertion line. Two separate things are
wrong with it, and only one of them needs the superset fixture:

| | 596 / 609 / 623 / 637 | 665 (pair superset) |
|---|---|---|
| **A — the set counted.** The counter matched the role name anywhere in a process's argv, so a bridge serving `{alice,bob}` counted as a bridge for `alice`. | does not reach: the fixtures are `bob`, another project's `alice`, and `alice2`, none of which an argv match counts | **reaches.** The `-ge 1` gate opened on the test's own `{alice,bob}` fixture, before the launcher had spawned anything |
| **B — waited on one observation, asserted on another.** The waiter polled until the count matched, then counted *again* and returned that second reading. | **reaches all four** | reaches |

B is why all five can fail while only one has a superset fixture. Between the
two observations the reaper kills the orphan and the launcher respawns, so the
count passes through 2 and through 0: the caller was handed a number nothing had
ever waited for. Measured in isolation, with a 60 ms observation, the old form
returns **2** and fails where the single-observation form returns **1** and
passes.

`#984` records two failing tests on `main` — `not ok 244` (reaps a
same-(project,role) orphan) and `not ok 248` (pair superset). 244 is the
**A-does-not-reach** column. A fix that only converted the superset site would
have left the other recorded failure untouched.

## The change

Both halves are replaced together, at all five sites:

- `_count_exact_role_bridges` — requires a pair set of exactly `{name}`. This is
  the same set inequality the superset test's `kill -0 "$both"` already relies
  on; the gate now applies the rule the outcome was already using.
- `_wait_exact_role_count` — returns the value that satisfied the wait.

The argv-match pair had **no other users in the tree** (derived, not
enumerated: one `grep` across every `.bats`/`.sh`, and every hit was in these
five tests). It is removed rather than left standing beside the new one — a
leftover second form is exactly how four of the five sites came to be missed on
the first pass. With it gone, a missed site is a `grep` for a name that no
longer exists.

## Why the expected value is still 1

It is unchanged, but it now holds for the stated reason rather than by
accident. After `rm -f "$RUN_DIR"/codex-bridge.*.pid`, the launcher's own child
is a pidfile-less orphan; the reaper kills it and the launcher respawns one
bridge for the role. So exactly one bridge whose pair set is `{alice}` exists
once it settles. In the superset test the `{alice,bob}` fixture is not one of
them — that it survived is asserted separately, on the next line, by `kill -0`.

Under the old gate this test could not distinguish that: it opened on the
fixture, so the assertion ran against whatever the launcher happened to have
finished by then. **The gate and the expected value are one decision**, which is
why they move in the same commit.

## The new test, and what would leave it green

`the exact-role counter reads a pair set, not an argv substring (#984)` pins the
counter itself. Two things in it are deliberate:

- **The positive control comes first.** Three zeroes are also what a counter
  that answers 0 to everything produces — and that is what the first version of
  this predicate did. `ps` renders a pair's tab separator as the four characters
  `\011`, three of them digits, so a single-character `[^0-9A-Za-z]` separator
  class matched nothing at all. Every reap test went red; the counter, not the
  tests, was wrong. The control was written before the fix and observed red on
  the broken predicate, then green after.
- **It asks the waiter for a count it will never reach.** This is the only
  assertion in the file that goes red if the waiter is ever rewritten to return
  its `want` instead of what it saw. Every other check here — and every one of
  the five reap tests — passes under that rewrite, which is the very defect
  being fixed. Calibrated: mutating the waiter to `printf '%s' "$3"` turns this
  line red, and only this line. It costs the waiter's full 10 s by design.

## How it was run

- `tests/test_codex_bridge_launcher.bats` in full: **28 passed, 0 failed**
  (1 skipped — the Windows-native case, which needs a real `tasklist`).
- Both calibrations above run and observed red, then reverted and observed
  green.

## What is not measured

**Whether this is what fires in CI.** The failure does not reproduce on this
machine — three full rounds of the shard before the change, zero failures — so
the mechanism is measured but the firing is not. If the shard is green after
this lands, that is a green shard, not a cause. #984 stays open for that reason,
and closing it needs the same denominator run on the other side.
