### PR TITLE
feat(codex): deliver the inbox mid-turn via a PostToolUse hook, not only at Stop (#1003)

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -158,7 +158,19 @@ fi
 # lives in the skill's run dir — independent of AGMSG_STORAGE_PATH. Keeping it
 # out of the store means an overridden/sandboxed store still gets delivery even
 # when the default db dir doesn't exist.
-MARKER="$SKILL_DIR/run/.lastcheck-$AGENT"
+#
+# PostToolUse (#1003) uses a SEPARATE marker so the two events' cooldowns do not
+# bind. This event is the UNVERIFIED path (model receipt of its output is not
+# observed), and it must not be able to suppress the verified Stop path: if they
+# shared one marker, a PostToolUse poll would record the cooldown and the very
+# next Stop would exit at the gate without delivering. Its own marker bounds the
+# per-tool-call cost to one read/minute without touching Stop's. (This one value
+# was answering two questions — the same shape reviews keep flagging.)
+if [ "$EVENT" = "PostToolUse" ]; then
+  MARKER="$SKILL_DIR/run/.lastcheck-$AGENT.posttooluse"
+else
+  MARKER="$SKILL_DIR/run/.lastcheck-$AGENT"
+fi
 
 if [ -f "$MARKER" ]; then
   last=$(compat_file_mtime "$MARKER")
@@ -312,7 +324,16 @@ for team in "${TEAM_LIST[@]}"; do
   # legacy row (§2.4). Only the ids collected from the rows actually displayed
   # above — never a blanket match — so a message that arrives after the SELECT
   # can never be marked read unseen.
-  if [ "${#IDS[@]}" -gt 0 ]; then
+  #
+  # PostToolUse (#1003) does NOT mark read: read state is consumed only by a path
+  # whose delivery is verified, and this event's model receipt is not observed.
+  # "displayed" here means "formatted", not "received" — so consuming here would
+  # be exactly "consumed and never shown", which this file already names below as
+  # worse than the failure the status reports. Mid-turn delivery is therefore
+  # ADDITIVE: it may show a message earlier, but Stop still fetches, shows, and
+  # consumes it as before. A duplicate display is harmless; an invisible loss is
+  # not.
+  if [ "$EVENT" != "PostToolUse" ] && [ "${#IDS[@]}" -gt 0 ]; then
     storage_mark_read_batch "$team" "$AGENT" "${IDS[@]}" >/dev/null 2>&1 || true
   fi
 done

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -19,11 +19,27 @@ source "$SCRIPT_DIR/lib/resolve-project.sh"  # agmsg_agent_pid, for instance-id 
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/type-registry.sh"
 
+# Which hook event fired. The Stop entry runs `check-inbox.sh <type> <project>`
+# (EVENT defaults to Stop); the mid-turn PostToolUse entry (#1003) appends the
+# event as a 3rd arg so this script emits the shape that event's runtime accepts,
+# without branching on the type name.
+EVENT="${3:-Stop}"
+
 # Some Stop-hook runtimes (codex, copilot) want an explicit JSON status object
 # even when there is nothing to deliver; others (claude-code) stay silent. This
 # is the type's manifest `stop_output=` (data), not a hardcoded type list.
 STOP_OUTPUT="$(agmsg_type_get "$TYPE" stop_output 2>/dev/null || true)"
+# The wire shape for a PostToolUse payload, from the type manifest (#1003) — the
+# same data-driven approach as stop_output. Measured on codex-cli 0.149.1:
+# hookSpecificOutput. An unknown/unset value emits nothing rather than a guess.
+POSTTOOL_OUTPUT="$(agmsg_type_get "$TYPE" posttooluse_output 2>/dev/null || true)"
+
+# Status (nothing-to-deliver / cooldown) output. For PostToolUse this stays
+# SILENT: codex 0.149.1 treats malformed post-tool-use JSON as a failure, and an
+# empty additionalContext on every tool call would be pure noise — so a no-op
+# turn emits no bytes, which every runtime reads as "hook did nothing".
 emit_status_json() {
+  [ "$EVENT" = "PostToolUse" ] && return 0
   [ "$STOP_OUTPUT" = "json" ] || return 0
   printf '{\n  "continue": true,\n  "systemMessage": "%s"\n}\n' "$1"
 }
@@ -329,12 +345,27 @@ if [ -n "$OUTPUT" ]; then
   fi
   # Escape for JSON: backslash, double-quote, newlines, tabs (macOS/Linux compatible)
   ESCAPED=$(printf '%s' "$OUTPUT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g' | awk '{if(NR>1) printf "\\n"; printf "%s",$0}')
-  cat <<ENDJSON
+  if [ "$EVENT" = "PostToolUse" ]; then
+    # Mid-turn delivery (#1003). The shape is data, from the manifest — not a
+    # type-name branch. codex-cli 0.149.1 requires a hookSpecificOutput object
+    # (hookEventName=PostToolUse, body in additionalContext) and rejects anything
+    # else as "invalid post-tool-use JSON output"; an unknown/unset shape emits
+    # nothing rather than a malformed guess. Reaching the model with this is the
+    # unverified part (see PR): this is the shape the 0.149.1 parser accepts.
+    case "$POSTTOOL_OUTPUT" in
+      hookSpecificOutput)
+        printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"%s"}}\n' "$ESCAPED"
+        ;;
+      *) : ;;
+    esac
+  else
+    cat <<ENDJSON
 {
   "decision": "block",
   "reason": "$ESCAPED"
 }
 ENDJSON
+  fi
   # Exit 0 even when the poll failed part-way: this is the delivering path, and
   # a non-zero status here throws the delivery away.
   exit 0

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -160,11 +160,14 @@ agmsg_delivery_apply_default() {
   #
   # What this gate does and does NOT do (#1003 review): it narrows the POPULATION
   # of projects that get the entry WRITTEN to those where a supporting CLI was
-  # seen at install time. It does NOT establish that an older CLI ignores the
-  # entry harmlessly — hooks.json persists after this exits, and a later
-  # downgrade, a different codex binary, or another environment can read the same
-  # file without the gate running again. The harmless-ignore invariant is still
-  # unmeasured; this only shrinks who is exposed to it, it does not remove it.
+  # seen at install time. It does NOT by itself govern how an OLDER CLI handles a
+  # persisted entry later — hooks.json outlives this call, and a downgrade or a
+  # different codex binary can read the same file without the gate running again.
+  # That handling was measured separately: codex 0.116.0 (pre-PostToolUse) reads a
+  # PostToolUse-carrying hooks.json and silently ignores the unknown key, no
+  # startup/parse error, positive-control confirmed — the Hooks Review screen was
+  # not directly reached (inferred harmless). So the gate is defense-in-depth on
+  # top of that measurement, not the sole protection against an unknown.
   local pt_output pt_min pt_cli pt_install=0
   pt_output=$(agmsg_type_get "$type" posttooluse_output 2>/dev/null || true)
   if [ -n "$pt_output" ]; then

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -74,6 +74,33 @@ RUN_DIR="$SKILL_DIR/run"
 . "$SCRIPT_DIR/lib/shquote.sh"
 _agmsg_shq() { agmsg_shq "$1"; }
 
+# True (0) iff <cli>'s reported version is >= <min> (both compared as MAJOR.MINOR).
+# FAIL-CLOSED: returns non-zero when the cli is not on PATH, `--version` fails, or
+# neither the output nor <min> yields a MAJOR.MINOR — an unknown version must not
+# pass, because the caller installs a hook only for a version confirmed to accept
+# it (#1003). `AGMSG_<CLI>_VERSION` (e.g. AGMSG_CODEX_VERSION) overrides the probe
+# — a gate needs a way to be exercised in tests and overridden by an operator,
+# the same shape lib/node.sh's AGMSG_NODE already sets. Patch is ignored on
+# purpose: the floor is a MAJOR.MINOR the event is confirmed to exist at.
+_agmsg_cli_version_ge() {
+  local cli="$1" min="$2" raw ovkey maj mn tmaj tmn
+  [ -n "$cli" ] && [ -n "$min" ] || return 1
+  ovkey="AGMSG_$(printf '%s' "$cli" | tr 'a-z-' 'A-Z_')_VERSION"
+  eval "raw=\${$ovkey:-}"
+  if [ -z "$raw" ]; then
+    command -v "$cli" >/dev/null 2>&1 || return 1
+    raw="$("$cli" --version 2>/dev/null || true)"
+  fi
+  raw="$(printf '%s' "$raw" | grep -oE '[0-9]+\.[0-9]+' | head -1)"
+  [ -n "$raw" ] || return 1
+  maj="${raw%%.*}"; mn="${raw#*.}"; mn="${mn%%.*}"
+  tmaj="${min%%.*}"; tmn="${min#*.}"; tmn="${tmn%%.*}"
+  case "$maj.$mn.$tmaj.$tmn" in *[!0-9.]*) return 1 ;; esac
+  [ "$maj" -gt "$tmaj" ] && return 0
+  [ "$maj" -eq "$tmaj" ] && [ "$mn" -ge "$tmn" ] && return 0
+  return 1
+}
+
 # The per-project delivery hooks file is the type's manifest `hooks_file=`
 # (project-relative), not a hardcoded per-type case. The hook FORMAT written into
 # it is still type-specific (apply_settings_* below).
@@ -115,10 +142,26 @@ agmsg_delivery_apply_default() {
 
   # Mid-turn delivery (#1003): a type whose manifest carries a posttooluse_output
   # datum also gets a PostToolUse hook running check-inbox between tool calls, not
-  # only at Stop. The datum's PRESENCE is the gate (kept type-agnostic here — no
-  # `if type = codex`); its value is the wire shape check-inbox emits, read there.
-  local pt_output
+  # only at Stop. The datum's PRESENCE opts the type in (kept type-agnostic here —
+  # no `if type = codex`); its value is the wire shape check-inbox emits.
+  #
+  # But opt-in is not enough to INSTALL: whether a CLI that predates the
+  # PostToolUse event ignores the entry harmlessly is unmeasured, and an entry a
+  # startup/hooks-review parser rejects would break turn delivery before
+  # check-inbox runs. So a second datum, posttooluse_min_cli, gates on the
+  # detected CLI version, FAIL-CLOSED: the entry is installed only when the CLI is
+  # confirmed at or above it. Older, or a version we cannot read, gets Stop only.
+  local pt_output pt_min pt_cli pt_install=0
   pt_output=$(agmsg_type_get "$type" posttooluse_output 2>/dev/null || true)
+  if [ -n "$pt_output" ]; then
+    pt_min=$(agmsg_type_get "$type" posttooluse_min_cli 2>/dev/null || true)
+    pt_cli=$(agmsg_type_get "$type" cli 2>/dev/null || true)
+    if [ -z "$pt_min" ]; then
+      pt_install=1                              # opted in with no version floor
+    elif _agmsg_cli_version_ge "$pt_cli" "$pt_min"; then
+      pt_install=1                              # CLI confirmed new enough
+    fi
+  fi
 
   # Work on a temp copy so a partially-modified file never replaces the
   # original until the whole chain succeeds.
@@ -162,7 +205,7 @@ agmsg_delivery_apply_default() {
       # Same inbox check, fired after every tool call (#1003). The trailing event
       # arg tells check-inbox.sh which wire shape to emit; matcher is empty (all
       # tools) via add_event_entry_file. The 60s cooldown bounds the cost.
-      if [ -n "$pt_output" ]; then
+      if [ "$pt_install" = 1 ]; then
         add_event_entry_file "$tmp_state" "PostToolUse" "$cmd $(_agmsg_shq "PostToolUse")" "$ww"
       fi
       ;;
@@ -173,7 +216,7 @@ agmsg_delivery_apply_default() {
       add_event_entry_file "$tmp_state" "SessionStart" "$ss" "$ww"
       add_event_entry_file "$tmp_state" "SessionEnd"   "$se" "$ww"
       add_event_entry_file "$tmp_state" "Stop"         "$st" "$ww"
-      if [ -n "$pt_output" ]; then
+      if [ "$pt_install" = 1 ]; then
         add_event_entry_file "$tmp_state" "PostToolUse" "$st $(_agmsg_shq "PostToolUse")" "$ww"
       fi
       ;;
@@ -186,6 +229,18 @@ agmsg_delivery_apply_default() {
       return 1
       ;;
   esac
+
+  # Say when mid-turn delivery was WANTED here but not installed, so a silent
+  # absence is not mistaken for "it's on" (#1003; same "silent = can't tell
+  # waiting from broken" hazard #1001 names). Only meaningful for turn/both, and
+  # only when the type opted in (pt_output) but the version gate said no.
+  if [ -n "$pt_output" ] && [ "$pt_install" != 1 ]; then
+    case "$mode" in
+      turn|both)
+        echo "  ~ mid-turn delivery (PostToolUse) not installed: could not confirm the '$pt_cli' CLI is at or above ${pt_min:-?} (set AGMSG_$(printf '%s' "$pt_cli" | tr 'a-z-' 'A-Z_')_VERSION to override). Stop-hook delivery is still active."
+        ;;
+    esac
+  fi
 
   prune_empty_hooks_file "$tmp_state"
 

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -151,12 +151,14 @@ agmsg_delivery_apply_default() {
   # only at Stop. The datum's PRESENCE opts the type in (kept type-agnostic here —
   # no `if type = codex`); its value is the wire shape check-inbox emits.
   #
-  # But opt-in is not enough to INSTALL: whether a CLI that predates the
-  # PostToolUse event ignores the entry harmlessly is unmeasured, and an entry a
-  # startup/hooks-review parser rejects would break turn delivery before
-  # check-inbox runs. So a second datum, posttooluse_min_cli, gates on the
-  # detected CLI version, FAIL-CLOSED: the entry is installed only when the CLI is
-  # confirmed at or above it. Older, or a version we cannot read, gets Stop only.
+  # But opt-in is not enough to INSTALL: the entry is meaningless to a CLI that
+  # cannot execute PostToolUse, and — the concern that first motivated the gate —
+  # an older parser that rejected it at startup/hooks-review would break turn
+  # delivery before check-inbox runs. So a second datum, posttooluse_min_cli,
+  # gates on the detected CLI version, FAIL-CLOSED: the entry is installed only
+  # when the CLI is confirmed at or above it. Older, or a version we cannot read,
+  # gets Stop only. (That older-parser concern was later measured — see the next
+  # paragraph — so this stays as defense-in-depth, not the sole protection.)
   #
   # What this gate does and does NOT do (#1003 review): it narrows the POPULATION
   # of projects that get the entry WRITTEN to those where a supporting CLI was

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -74,31 +74,37 @@ RUN_DIR="$SKILL_DIR/run"
 . "$SCRIPT_DIR/lib/shquote.sh"
 _agmsg_shq() { agmsg_shq "$1"; }
 
-# True (0) iff <cli>'s reported version is >= <min> (both compared as MAJOR.MINOR).
+# True (0) iff <cli>'s reported version is >= <min>, compared as MAJOR.MINOR.PATCH.
 # FAIL-CLOSED: returns non-zero when the cli is not on PATH, `--version` fails, or
-# neither the output nor <min> yields a MAJOR.MINOR — an unknown version must not
-# pass, because the caller installs a hook only for a version confirmed to accept
-# it (#1003). `AGMSG_<CLI>_VERSION` (e.g. AGMSG_CODEX_VERSION) overrides the probe
-# — a gate needs a way to be exercised in tests and overridden by an operator,
-# the same shape lib/node.sh's AGMSG_NODE already sets. Patch is ignored on
-# purpose: the floor is a MAJOR.MINOR the event is confirmed to exist at.
+# neither the output nor <min> yields a dotted-numeric version — an unknown
+# version must not pass, because the caller installs a hook only for a version
+# confirmed to accept it (#1003). No env override: a version is READ from the CLI,
+# never asserted; tests place a fake `codex` on PATH (both the pass and the fail
+# cases), so no operator seam to claim an unmeasured capability is added.
 _agmsg_cli_version_ge() {
-  local cli="$1" min="$2" raw ovkey maj mn tmaj tmn
+  local cli="$1" min="$2" raw ver
   [ -n "$cli" ] && [ -n "$min" ] || return 1
-  ovkey="AGMSG_$(printf '%s' "$cli" | tr 'a-z-' 'A-Z_')_VERSION"
-  eval "raw=\${$ovkey:-}"
-  if [ -z "$raw" ]; then
-    command -v "$cli" >/dev/null 2>&1 || return 1
-    raw="$("$cli" --version 2>/dev/null || true)"
-  fi
-  raw="$(printf '%s' "$raw" | grep -oE '[0-9]+\.[0-9]+' | head -1)"
-  [ -n "$raw" ] || return 1
-  maj="${raw%%.*}"; mn="${raw#*.}"; mn="${mn%%.*}"
-  tmaj="${min%%.*}"; tmn="${min#*.}"; tmn="${tmn%%.*}"
-  case "$maj.$mn.$tmaj.$tmn" in *[!0-9.]*) return 1 ;; esac
-  [ "$maj" -gt "$tmaj" ] && return 0
-  [ "$maj" -eq "$tmaj" ] && [ "$mn" -ge "$tmn" ] && return 0
-  return 1
+  command -v "$cli" >/dev/null 2>&1 || return 1
+  raw="$("$cli" --version 2>/dev/null || true)"
+  ver="$(printf '%s' "$raw" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+|[0-9]+\.[0-9]+' | head -1)"
+  [ -n "$ver" ] || return 1
+  _agmsg_ver_ge "$ver" "$min"
+}
+
+# True (0) iff dotted-numeric $1 >= $2, compared component by component (a missing
+# component reads as 0). Patch is significant: the floor is the exact measured
+# version, so a same-minor build BELOW it (0.149.0 vs a 0.149.1 floor) is refused.
+_agmsg_ver_ge() {
+  local a="$1" b="$2" i av bv
+  for i in 1 2 3; do
+    av=$(printf '%s.0.0.0' "$a" | cut -d. -f"$i")
+    bv=$(printf '%s.0.0.0' "$b" | cut -d. -f"$i")
+    case "$av" in ''|*[!0-9]*) av=0 ;; esac
+    case "$bv" in ''|*[!0-9]*) bv=0 ;; esac
+    [ "$av" -gt "$bv" ] && return 0
+    [ "$av" -lt "$bv" ] && return 1
+  done
+  return 0
 }
 
 # The per-project delivery hooks file is the type's manifest `hooks_file=`
@@ -151,6 +157,14 @@ agmsg_delivery_apply_default() {
   # check-inbox runs. So a second datum, posttooluse_min_cli, gates on the
   # detected CLI version, FAIL-CLOSED: the entry is installed only when the CLI is
   # confirmed at or above it. Older, or a version we cannot read, gets Stop only.
+  #
+  # What this gate does and does NOT do (#1003 review): it narrows the POPULATION
+  # of projects that get the entry WRITTEN to those where a supporting CLI was
+  # seen at install time. It does NOT establish that an older CLI ignores the
+  # entry harmlessly — hooks.json persists after this exits, and a later
+  # downgrade, a different codex binary, or another environment can read the same
+  # file without the gate running again. The harmless-ignore invariant is still
+  # unmeasured; this only shrinks who is exposed to it, it does not remove it.
   local pt_output pt_min pt_cli pt_install=0
   pt_output=$(agmsg_type_get "$type" posttooluse_output 2>/dev/null || true)
   if [ -n "$pt_output" ]; then
@@ -237,7 +251,7 @@ agmsg_delivery_apply_default() {
   if [ -n "$pt_output" ] && [ "$pt_install" != 1 ]; then
     case "$mode" in
       turn|both)
-        echo "  ~ mid-turn delivery (PostToolUse) not installed: could not confirm the '$pt_cli' CLI is at or above ${pt_min:-?} (set AGMSG_$(printf '%s' "$pt_cli" | tr 'a-z-' 'A-Z_')_VERSION to override). Stop-hook delivery is still active."
+        echo "  ~ mid-turn delivery (PostToolUse) not installed: could not confirm the '$pt_cli' CLI is at or above ${pt_min:-?}. Stop-hook delivery is still active."
         ;;
     esac
   fi

--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -113,6 +113,13 @@ agmsg_delivery_apply_default() {
   local ww
   ww=$(agmsg_type_get "$type" hook_windows_wrap 2>/dev/null || true)
 
+  # Mid-turn delivery (#1003): a type whose manifest carries a posttooluse_output
+  # datum also gets a PostToolUse hook running check-inbox between tool calls, not
+  # only at Stop. The datum's PRESENCE is the gate (kept type-agnostic here — no
+  # `if type = codex`); its value is the wire shape check-inbox emits, read there.
+  local pt_output
+  pt_output=$(agmsg_type_get "$type" posttooluse_output 2>/dev/null || true)
+
   # Work on a temp copy so a partially-modified file never replaces the
   # original until the whole chain succeeds.
   local tmp_state
@@ -127,6 +134,10 @@ agmsg_delivery_apply_default() {
   strip_agmsg_event_file "$tmp_state" "SessionStart"
   strip_agmsg_event_file "$tmp_state" "SessionEnd"
   strip_agmsg_event_file "$tmp_state" "Stop"
+  # Always strip PostToolUse too (#1003), so `off`/`monitor`/a mode change removes
+  # the mid-turn entry alongside Stop. Unconditional: a type that never installed
+  # one has nothing to remove.
+  strip_agmsg_event_file "$tmp_state" "PostToolUse"
 
   # 2) Re-add what this mode wants.
   #
@@ -148,6 +159,12 @@ agmsg_delivery_apply_default() {
     turn)
       local cmd="$(_agmsg_shq "$SKILL_DIR/scripts/check-inbox.sh") $(_agmsg_shq "$type") $(_agmsg_shq "$project")"
       add_event_entry_file "$tmp_state" "Stop" "$cmd" "$ww"
+      # Same inbox check, fired after every tool call (#1003). The trailing event
+      # arg tells check-inbox.sh which wire shape to emit; matcher is empty (all
+      # tools) via add_event_entry_file. The 60s cooldown bounds the cost.
+      if [ -n "$pt_output" ]; then
+        add_event_entry_file "$tmp_state" "PostToolUse" "$cmd $(_agmsg_shq "PostToolUse")" "$ww"
+      fi
       ;;
     both)
       local ss="$(_agmsg_shq "$SKILL_DIR/scripts/session-start.sh") $(_agmsg_shq "$type") $(_agmsg_shq "$project")"
@@ -156,6 +173,9 @@ agmsg_delivery_apply_default() {
       add_event_entry_file "$tmp_state" "SessionStart" "$ss" "$ww"
       add_event_entry_file "$tmp_state" "SessionEnd"   "$se" "$ww"
       add_event_entry_file "$tmp_state" "Stop"         "$st" "$ww"
+      if [ -n "$pt_output" ]; then
+        add_event_entry_file "$tmp_state" "PostToolUse" "$st $(_agmsg_shq "PostToolUse")" "$ww"
+      fi
       ;;
     off)
       : # already stripped
@@ -287,6 +307,11 @@ agmsg_delivery_status_default() {
     count=$(agmsg_sqlite_mem "SELECT json_array_length(json_extract(readfile('$sql_hf'), '\$.hooks.Stop'));" 2>/dev/null || echo 0)
     case "$count" in ''|*[!0-9]*) count=0 ;; esac
     echo "  Stop entries:         $count"
+    # The mid-turn PostToolUse entry (#1003) sits next to Stop in turn/both for
+    # types whose manifest opts in; show its count so an operator can see it.
+    count=$(agmsg_sqlite_mem "SELECT json_array_length(json_extract(readfile('$sql_hf'), '\$.hooks.PostToolUse'));" 2>/dev/null || echo 0)
+    case "$count" in ''|*[!0-9]*) count=0 ;; esac
+    echo "  PostToolUse entries:  $count"
   fi
 }
 agmsg_delivery_status() { agmsg_delivery_status_default "$@"; }

--- a/scripts/drivers/types/codex/type.conf
+++ b/scripts/drivers/types/codex/type.conf
@@ -26,13 +26,15 @@ stop_output=json
 # ("hook returned invalid post-tool-use JSON output"). Reaching the model with it
 # is not yet observed end-to-end (co1's sandbox blocked the loopback probe).
 posttooluse_output=hookSpecificOutput
-# Minimum codex CLI version confirmed to carry the PostToolUse hook event
-# (measured: 0.149.1). The entry is installed ONLY when the CLI is detected at or
-# above this; an older or undetectable CLI gets Stop-only, unchanged — because
-# whether a pre-PostToolUse codex ignores the entry harmlessly is NOT yet
-# measured, and an install that a startup/hooks-review parser rejects would break
-# turn delivery before check-inbox even runs. Override the detected version with
-# AGMSG_CODEX_VERSION. Fail-closed: unknown version => not installed.
-posttooluse_min_cli=0.149
+# Floor for INSTALLING the PostToolUse entry: the exact codex CLI version the
+# event was measured on (0.149.1), compared full-numerically (patch included), so
+# a same-minor build below it (0.149.0) — which was never measured — does not
+# pass. The entry is written ONLY when the detected CLI is at or above this;
+# older / undetectable / unparseable gets Stop-only. Fail-closed: unknown => not
+# installed. NOTE this gate narrows the POPULATION that gets the entry written; it
+# does NOT establish that an older CLI ignores the entry harmlessly — hooks.json
+# persists and a later downgrade or a different codex binary can read it without
+# the gate running again. That invariant is still unmeasured.
+posttooluse_min_cli=0.149.1
 hook_windows_wrap=yes
 delivery_modes=monitor turn off

--- a/scripts/drivers/types/codex/type.conf
+++ b/scripts/drivers/types/codex/type.conf
@@ -18,5 +18,13 @@ detect_proc=codex codex-*
 hooks_file=.codex/hooks.json
 monitor=no
 stop_output=json
+# PostToolUse mid-turn delivery (#1003). Its PRESENCE gates the PostToolUse hook
+# entry in turn/both delivery (type-agnostically — a type without this datum gets
+# no such entry); its VALUE is the wire shape check-inbox.sh emits for that event.
+# Measured on codex-cli 0.149.1: PostToolUse requires a hookSpecificOutput object
+# (hookEventName=PostToolUse, body in additionalContext); plain stdout is rejected
+# ("hook returned invalid post-tool-use JSON output"). Reaching the model with it
+# is not yet observed end-to-end (co1's sandbox blocked the loopback probe).
+posttooluse_output=hookSpecificOutput
 hook_windows_wrap=yes
 delivery_modes=monitor turn off

--- a/scripts/drivers/types/codex/type.conf
+++ b/scripts/drivers/types/codex/type.conf
@@ -31,10 +31,16 @@ posttooluse_output=hookSpecificOutput
 # a same-minor build below it (0.149.0) — which was never measured — does not
 # pass. The entry is written ONLY when the detected CLI is at or above this;
 # older / undetectable / unparseable gets Stop-only. Fail-closed: unknown => not
-# installed. NOTE this gate narrows the POPULATION that gets the entry written; it
-# does NOT establish that an older CLI ignores the entry harmlessly — hooks.json
-# persists and a later downgrade or a different codex binary can read it without
-# the gate running again. That invariant is still unmeasured.
+# installed. The gate narrows the POPULATION that gets the entry written; it does
+# not by itself establish how a persisted entry is handled by an OLDER CLI later
+# (hooks.json outlives this call). That handling was measured separately (#1003
+# review): codex 0.116.0 (pre-PostToolUse, confirmed by `strings`) reads a
+# hooks.json carrying a valid PostToolUse entry and SILENTLY IGNORES it — no
+# startup or config-parse error — with a positive control (malformed known data
+# warns) proving it read the file. Not observed: the Hooks Review screen (the
+# isolated env had no auth to reach it); "not blocked there" is inference from the
+# parser dropping the unknown key, not a direct observation. So the gate is now
+# defense-in-depth, not the only protection.
 posttooluse_min_cli=0.149.1
 hook_windows_wrap=yes
 delivery_modes=monitor turn off

--- a/scripts/drivers/types/codex/type.conf
+++ b/scripts/drivers/types/codex/type.conf
@@ -26,5 +26,13 @@ stop_output=json
 # ("hook returned invalid post-tool-use JSON output"). Reaching the model with it
 # is not yet observed end-to-end (co1's sandbox blocked the loopback probe).
 posttooluse_output=hookSpecificOutput
+# Minimum codex CLI version confirmed to carry the PostToolUse hook event
+# (measured: 0.149.1). The entry is installed ONLY when the CLI is detected at or
+# above this; an older or undetectable CLI gets Stop-only, unchanged — because
+# whether a pre-PostToolUse codex ignores the entry harmlessly is NOT yet
+# measured, and an install that a startup/hooks-review parser rejects would break
+# turn delivery before check-inbox even runs. Override the detected version with
+# AGMSG_CODEX_VERSION. Fail-closed: unknown version => not installed.
+posttooluse_min_cli=0.149
 hook_windows_wrap=yes
 delivery_modes=monitor turn off

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1751,6 +1751,76 @@ JSON
   [ -z "$cw" ]
 }
 
+# --- #1003: codex mid-turn PostToolUse hook install/strip/status wiring ---
+
+@test "delivery set turn (codex): installs a PostToolUse entry alongside Stop, carrying the event arg (#1003)" {
+  run bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  local hf="$TEST_PROJECT/.codex/hooks.json"
+  [ -f "$hf" ]
+  local n
+  n=$(sqlite_mem "SELECT json_array_length(json_extract(readfile('$(rf "$hf")'), '\$.hooks.PostToolUse'));")
+  [ "$n" = "1" ]
+  # The command runs check-inbox with the PostToolUse event as a 3rd arg, so the
+  # script emits that event's shape — not a copy that would silently use Stop's.
+  local cmd
+  cmd=$(sqlite_mem "SELECT json_extract(readfile('$(rf "$hf")'), '\$.hooks.PostToolUse[0].hooks[0].command');")
+  grep -q 'check-inbox.sh' <<<"$cmd"
+  grep -q 'PostToolUse' <<<"$cmd"
+  # matcher empty = all tools.
+  local m
+  m=$(sqlite_mem "SELECT json_extract(readfile('$(rf "$hf")'), '\$.hooks.PostToolUse[0].matcher');")
+  [ -z "$m" ]
+  # Stop is still installed alongside it.
+  local s
+  s=$(sqlite_mem "SELECT json_array_length(json_extract(readfile('$(rf "$hf")'), '\$.hooks.Stop'));")
+  [ "$s" = "1" ]
+}
+
+@test "delivery set turn (codex): the PostToolUse entry carries commandWindows too (#1003)" {
+  skip_on_windows "commandWindows not written on native Windows (#182)"
+  run bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  local cw
+  cw=$(sqlite_mem "SELECT json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse[0].hooks[0].commandWindows');")
+  [ -n "$cw" ]
+  grep -q 'check-inbox.sh' <<<"$cw"
+  grep -q 'PostToolUse' <<<"$cw"
+}
+
+@test "delivery set off (codex): strips the PostToolUse entry with Stop (#1003)" {
+  bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" set off codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  local n
+  n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
+  [ "${n:-0}" = "0" ]
+}
+
+@test "delivery set monitor (codex): installs NO PostToolUse entry (#1003)" {
+  run bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  local n
+  n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
+  [ "${n:-0}" = "0" ]
+}
+
+@test "delivery set turn (claude-code): installs NO PostToolUse entry — no manifest datum (#1003)" {
+  run bash "$SCRIPTS/delivery.sh" set turn claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  local n
+  n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.claude/settings.local.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
+  [ "${n:-0}" = "0" ]
+}
+
+@test "delivery status (codex turn): reports the PostToolUse entry count next to Stop (#1003)" {
+  bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  grep -q 'Stop entries:' <<<"$output"
+  grep -q 'PostToolUse entries:  1' <<<"$output"
+}
+
 # --- Hook JSON escaping: build entries via json_object, not by hand (#134) ---
 #
 # The pre-fix code hand-assembled the entry JSON and only escaped the codex

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1752,9 +1752,15 @@ JSON
 }
 
 # --- #1003: codex mid-turn PostToolUse hook install/strip/status wiring ---
+#
+# The install is version-gated (#1003 review): the entry goes in only when the
+# codex CLI is confirmed >= posttooluse_min_cli, fail-closed otherwise, so
+# whether a pre-PostToolUse CLI mishandles the entry never has to be known. These
+# pin AGMSG_CODEX_VERSION so the outcome does not depend on whether a codex binary
+# happens to be on the runner's PATH (CI has none).
 
 @test "delivery set turn (codex): installs a PostToolUse entry alongside Stop, carrying the event arg (#1003)" {
-  run bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+  run env AGMSG_CODEX_VERSION=0.149.1 bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   local hf="$TEST_PROJECT/.codex/hooks.json"
   [ -f "$hf" ]
@@ -1779,7 +1785,7 @@ JSON
 
 @test "delivery set turn (codex): the PostToolUse entry carries commandWindows too (#1003)" {
   skip_on_windows "commandWindows not written on native Windows (#182)"
-  run bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+  run env AGMSG_CODEX_VERSION=0.149.1 bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   local cw
   cw=$(sqlite_mem "SELECT json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse[0].hooks[0].commandWindows');")
@@ -1789,7 +1795,7 @@ JSON
 }
 
 @test "delivery set off (codex): strips the PostToolUse entry with Stop (#1003)" {
-  bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT" >/dev/null
+  env AGMSG_CODEX_VERSION=0.149.1 bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT" >/dev/null
   run bash "$SCRIPTS/delivery.sh" set off codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   local n
@@ -1797,8 +1803,48 @@ JSON
   [ "${n:-0}" = "0" ]
 }
 
+# --- version gate, fail-closed (#1003 review): install ONLY for a confirmed CLI ---
+
+@test "delivery set turn (codex): a CLI below the floor gets NO PostToolUse, and says why (#1003)" {
+  run env AGMSG_CODEX_VERSION=0.148.0 bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  local n
+  n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
+  [ "${n:-0}" = "0" ]
+  # Not silent: the operator is told mid-turn delivery was not installed (#1001 shape).
+  grep -q 'mid-turn delivery (PostToolUse) not installed' <<<"$output"
+  # Stop is still installed — the safe existing path is unaffected.
+  local s
+  s=$(sqlite_mem "SELECT json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.Stop'));")
+  [ "$s" = "1" ]
+}
+
+@test "delivery set turn (codex): an unparseable CLI version gets NO PostToolUse, fail-closed (#1003)" {
+  run env AGMSG_CODEX_VERSION="banana" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  local n
+  n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
+  [ "${n:-0}" = "0" ]
+  grep -q 'mid-turn delivery (PostToolUse) not installed' <<<"$output"
+}
+
+@test "delivery set turn (codex): a CLI whose --version fails gets NO PostToolUse, fail-closed (#1003)" {
+  # No override; a fake codex on PATH that fails --version stands in for both an
+  # unreadable version and an absent CLI (command -v / probe failure).
+  local fake="$TEST_SKILL_DIR/fakebin"
+  mkdir -p "$fake"
+  printf '#!/bin/sh\nexit 1\n' > "$fake/codex"
+  chmod +x "$fake/codex"
+  run env -u AGMSG_CODEX_VERSION PATH="$fake:$PATH" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  local n
+  n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
+  [ "${n:-0}" = "0" ]
+  grep -q 'mid-turn delivery (PostToolUse) not installed' <<<"$output"
+}
+
 @test "delivery set monitor (codex): installs NO PostToolUse entry (#1003)" {
-  run bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT"
+  run env AGMSG_CODEX_VERSION=0.149.1 bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   local n
   n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
@@ -1814,7 +1860,7 @@ JSON
 }
 
 @test "delivery status (codex turn): reports the PostToolUse entry count next to Stop (#1003)" {
-  bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT" >/dev/null
+  env AGMSG_CODEX_VERSION=0.149.1 bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT" >/dev/null
   run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   grep -q 'Stop entries:' <<<"$output"

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -1754,13 +1754,28 @@ JSON
 # --- #1003: codex mid-turn PostToolUse hook install/strip/status wiring ---
 #
 # The install is version-gated (#1003 review): the entry goes in only when the
-# codex CLI is confirmed >= posttooluse_min_cli, fail-closed otherwise, so
-# whether a pre-PostToolUse CLI mishandles the entry never has to be known. These
-# pin AGMSG_CODEX_VERSION so the outcome does not depend on whether a codex binary
-# happens to be on the runner's PATH (CI has none).
+# codex CLI is confirmed at or above posttooluse_min_cli, fail-closed otherwise.
+# The version is READ from the CLI, never asserted, so these place a fake `codex`
+# on PATH (both the pass and the fail cases) rather than depending on whether a
+# real codex is installed (CI has none). The gate narrows WHO gets the entry
+# written; it does not establish that an older CLI ignores a persisted entry.
+
+# A fake `codex` whose `--version` prints $1 (empty $1 => it exits non-zero).
+# Echoes a dir to PREPEND to PATH.
+_fake_codex_path() {
+  local dir="$TEST_SKILL_DIR/fakebin"
+  mkdir -p "$dir"
+  if [ -z "${1:-}" ]; then
+    printf '#!/bin/sh\nexit 1\n' > "$dir/codex"
+  else
+    printf '#!/bin/sh\necho "%s"\n' "$1" > "$dir/codex"
+  fi
+  chmod +x "$dir/codex"
+  printf '%s' "$dir"
+}
 
 @test "delivery set turn (codex): installs a PostToolUse entry alongside Stop, carrying the event arg (#1003)" {
-  run env AGMSG_CODEX_VERSION=0.149.1 bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+  run env PATH="$(_fake_codex_path 'codex-cli 0.149.1'):$PATH" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   local hf="$TEST_PROJECT/.codex/hooks.json"
   [ -f "$hf" ]
@@ -1773,11 +1788,9 @@ JSON
   cmd=$(sqlite_mem "SELECT json_extract(readfile('$(rf "$hf")'), '\$.hooks.PostToolUse[0].hooks[0].command');")
   grep -q 'check-inbox.sh' <<<"$cmd"
   grep -q 'PostToolUse' <<<"$cmd"
-  # matcher empty = all tools.
   local m
   m=$(sqlite_mem "SELECT json_extract(readfile('$(rf "$hf")'), '\$.hooks.PostToolUse[0].matcher');")
   [ -z "$m" ]
-  # Stop is still installed alongside it.
   local s
   s=$(sqlite_mem "SELECT json_array_length(json_extract(readfile('$(rf "$hf")'), '\$.hooks.Stop'));")
   [ "$s" = "1" ]
@@ -1785,7 +1798,7 @@ JSON
 
 @test "delivery set turn (codex): the PostToolUse entry carries commandWindows too (#1003)" {
   skip_on_windows "commandWindows not written on native Windows (#182)"
-  run env AGMSG_CODEX_VERSION=0.149.1 bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+  run env PATH="$(_fake_codex_path '0.149.1'):$PATH" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   local cw
   cw=$(sqlite_mem "SELECT json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse[0].hooks[0].commandWindows');")
@@ -1795,7 +1808,7 @@ JSON
 }
 
 @test "delivery set off (codex): strips the PostToolUse entry with Stop (#1003)" {
-  env AGMSG_CODEX_VERSION=0.149.1 bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT" >/dev/null
+  env PATH="$(_fake_codex_path '0.149.1'):$PATH" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT" >/dev/null
   run bash "$SCRIPTS/delivery.sh" set off codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   local n
@@ -1803,24 +1816,39 @@ JSON
   [ "${n:-0}" = "0" ]
 }
 
-# --- version gate, fail-closed (#1003 review): install ONLY for a confirmed CLI ---
+# --- version gate: install only at/above the EXACT measured floor, fail-closed ---
+# Boundary controls on both sides: exact floor, floor-minus-one, and a MAX.
 
-@test "delivery set turn (codex): a CLI below the floor gets NO PostToolUse, and says why (#1003)" {
-  run env AGMSG_CODEX_VERSION=0.148.0 bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+@test "delivery set turn (codex): the exact measured floor 0.149.1 installs (#1003)" {
+  run env PATH="$(_fake_codex_path '0.149.1'):$PATH" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  local n
+  n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
+  [ "${n:-0}" = "1" ]
+}
+
+@test "delivery set turn (codex): floor-minus-one 0.149.0 does NOT install — patch is significant (#1003)" {
+  run env PATH="$(_fake_codex_path '0.149.0'):$PATH" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   local n
   n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
   [ "${n:-0}" = "0" ]
-  # Not silent: the operator is told mid-turn delivery was not installed (#1001 shape).
   grep -q 'mid-turn delivery (PostToolUse) not installed' <<<"$output"
-  # Stop is still installed — the safe existing path is unaffected.
   local s
   s=$(sqlite_mem "SELECT json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.Stop'));")
   [ "$s" = "1" ]
 }
 
-@test "delivery set turn (codex): an unparseable CLI version gets NO PostToolUse, fail-closed (#1003)" {
-  run env AGMSG_CODEX_VERSION="banana" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+@test "delivery set turn (codex): a far-newer version installs (MAX side) (#1003)" {
+  run env PATH="$(_fake_codex_path '9.9.9'):$PATH" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  local n
+  n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
+  [ "${n:-0}" = "1" ]
+}
+
+@test "delivery set turn (codex): an unparseable CLI version does NOT install, fail-closed (#1003)" {
+  run env PATH="$(_fake_codex_path 'banana'):$PATH" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   local n
   n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
@@ -1828,14 +1856,8 @@ JSON
   grep -q 'mid-turn delivery (PostToolUse) not installed' <<<"$output"
 }
 
-@test "delivery set turn (codex): a CLI whose --version fails gets NO PostToolUse, fail-closed (#1003)" {
-  # No override; a fake codex on PATH that fails --version stands in for both an
-  # unreadable version and an absent CLI (command -v / probe failure).
-  local fake="$TEST_SKILL_DIR/fakebin"
-  mkdir -p "$fake"
-  printf '#!/bin/sh\nexit 1\n' > "$fake/codex"
-  chmod +x "$fake/codex"
-  run env -u AGMSG_CODEX_VERSION PATH="$fake:$PATH" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
+@test "delivery set turn (codex): a CLI whose --version fails does NOT install, fail-closed (#1003)" {
+  run env PATH="$(_fake_codex_path ''):$PATH" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   local n
   n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
@@ -1844,7 +1866,7 @@ JSON
 }
 
 @test "delivery set monitor (codex): installs NO PostToolUse entry (#1003)" {
-  run env AGMSG_CODEX_VERSION=0.149.1 bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT"
+  run env PATH="$(_fake_codex_path '0.149.1'):$PATH" bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   local n
   n=$(sqlite_mem "SELECT coalesce(json_array_length(json_extract(readfile('$(rf "$TEST_PROJECT/.codex/hooks.json")'), '\$.hooks.PostToolUse')), 0);" 2>/dev/null || echo 0)
@@ -1860,7 +1882,7 @@ JSON
 }
 
 @test "delivery status (codex turn): reports the PostToolUse entry count next to Stop (#1003)" {
-  env AGMSG_CODEX_VERSION=0.149.1 bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT" >/dev/null
+  env PATH="$(_fake_codex_path '0.149.1'):$PATH" bash "$SCRIPTS/delivery.sh" set turn codex "$TEST_PROJECT" >/dev/null
   run bash "$SCRIPTS/delivery.sh" status codex "$TEST_PROJECT"
   [ "$status" -eq 0 ]
   grep -q 'Stop entries:' <<<"$output"

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -326,3 +326,27 @@ _codex_proj() {
   grep -q 'at stop' <<<"$output"
   refute grep -q 'hookSpecificOutput' <<<"$output"
 }
+
+@test "check-inbox codex PostToolUse is additive: displays without consuming, and does not gate Stop (#1003)" {
+  # The #677/#1004 intersection control. PostToolUse is the UNVERIFIED path
+  # (model receipt unobserved); it must neither consume read state nor suppress
+  # the verified Stop path via the shared cooldown marker.
+  local p; p=$(_codex_proj)
+  bash "$SCRIPTS/send.sh" ctm bob alice "additive"
+  [ "$(pair_unread_count ctm alice)" -eq 1 ]
+
+  # PostToolUse displays it ...
+  run bash -c 'printf "{}" | "$1" codex "$2" PostToolUse' _ "$SCRIPTS/check-inbox.sh" "$p"
+  [ "$status" -eq 0 ]
+  grep -q 'additive' <<<"$output"
+  # ... but does NOT consume it: an unverified path must not mark read.
+  [ "$(pair_unread_count ctm alice)" -eq 1 ]
+
+  # Stop, immediately and with no time advance, must STILL deliver and consume it.
+  # If PostToolUse shared Stop's cooldown marker, this Stop would exit at the gate
+  # and deliver nothing — the unverified path silencing the verified one.
+  run bash -c 'printf "{}" | "$1" codex "$2"' _ "$SCRIPTS/check-inbox.sh" "$p"
+  [ "$status" -eq 0 ]
+  grep -q 'additive' <<<"$output"
+  [ "$(pair_unread_count ctm alice)" -eq 0 ]
+}

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -277,3 +277,52 @@ delivered_to_operator() {
   # The late message was not silently marked read by the first run
   [ "$(unread_count alice)" -eq 1 ]
 }
+
+# --- #1003: codex mid-turn delivery via PostToolUse emits the shape 0.149.1 wants ---
+#
+# These guard the "broken but green" tl named: a test that only checks a
+# PostToolUse hook entry EXISTS stays green even if check-inbox emits the wrong
+# shape. So they assert the SHAPE check-inbox actually emits, per event. (Whether
+# the model then receives it is unobserved — see the PR; measured here is only the
+# wire shape codex-cli 0.149.1's parser accepts vs rejects.)
+
+_codex_proj() {
+  local p="$TEST_SKILL_DIR/codexproj"
+  mkdir -p "$p"
+  bash "$SCRIPTS/join.sh" ctm alice codex "$p" >/dev/null
+  bash "$SCRIPTS/join.sh" ctm bob   codex "$p" >/dev/null
+  printf '%s' "$p"
+}
+
+@test "check-inbox codex PostToolUse: a pending message emits a hookSpecificOutput object (#1003)" {
+  local p; p=$(_codex_proj)
+  bash "$SCRIPTS/send.sh" ctm bob alice "mid-turn ping"
+  run bash -c 'printf "{}" | "$1" codex "$2" PostToolUse' _ "$SCRIPTS/check-inbox.sh" "$p"
+  [ "$status" -eq 0 ]
+  grep -q '"hookSpecificOutput"' <<<"$output"
+  grep -q '"hookEventName":"PostToolUse"' <<<"$output"
+  grep -q '"additionalContext"' <<<"$output"
+  grep -q 'mid-turn ping' <<<"$output"
+  # Must NOT emit the Stop-event shapes for a PostToolUse event.
+  refute grep -q '"decision"' <<<"$output"
+  refute grep -q '"systemMessage"' <<<"$output"
+}
+
+@test "check-inbox codex PostToolUse: nothing to deliver emits no bytes (#1003)" {
+  local p; p=$(_codex_proj)
+  # No message sent. A malformed/empty JSON body is a failure to codex 0.149.1,
+  # so a no-op turn must emit nothing at all (not an empty additionalContext).
+  run bash -c 'printf "{}" | "$1" codex "$2" PostToolUse' _ "$SCRIPTS/check-inbox.sh" "$p"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "check-inbox codex Stop (default event) shape is unchanged by #1003" {
+  local p; p=$(_codex_proj)
+  bash "$SCRIPTS/send.sh" ctm bob alice "at stop"
+  run bash -c 'printf "{}" | "$1" codex "$2"' _ "$SCRIPTS/check-inbox.sh" "$p"
+  [ "$status" -eq 0 ]
+  grep -q '"decision": "block"' <<<"$output"
+  grep -q 'at stop' <<<"$output"
+  refute grep -q 'hookSpecificOutput' <<<"$output"
+}


### PR DESCRIPTION
Refs #1003 — **does not close it** (see "What is NOT proven" below).

## Why

A Codex session in a long loop (`/goal`, a multi-step task) can run many minutes without reaching `Stop`, so turn-mode delivery only pulled the inbox after the whole response. `PostToolUse` fires after every tool call, so the same inbox check attached there can deliver mid-turn — **additively**, without touching the verified Stop path.

## What (type-agnostic — no `if type = codex`)

**Wiring.** A manifest datum `posttooluse_output` opts a type in; `delivery.sh` installs a `PostToolUse` entry alongside `Stop` in `turn`/`both` (matcher empty = all tools, `commandWindows` mirrored), strips it with `Stop` on `off`/`monitor`/`strip`, and `status` reports its count. The entry runs the same `check-inbox.sh` with the event name as a 3rd arg. codex's `delivery_modes` is `monitor turn off`, so `turn` is the reachable path; the `both` arm is generic.

**Output shape.** For `PostToolUse`, `check-inbox` emits `{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":…}}` — the shape codex-cli 0.149.1's parser requires (plain stdout is rejected as `invalid post-tool-use JSON output`). A no-op turn (nothing unread, or the cooldown) emits **no bytes** rather than an empty/partial object.

**Version-gated install, fail-closed — defense in depth.** `posttooluse_min_cli=0.149.1` (the exact measured version, compared full-numerically so an unmeasured `0.149.0` does not pass) gates the install on the CLI version read from `codex --version`; older / unreadable / unparseable / absent → **Stop only**, said out loud (a silent skip would be the `#1001` "can't tell waiting from broken" shape). The gate narrows the **population** that gets the entry *written*; it does not by itself govern how an older CLI handles a persisted entry later (`hooks.json` outlives `delivery.sh`). That handling was measured separately — see below — so the gate now stands as defense-in-depth, not the only protection.

**Additive — the unverified path never consumes or gates the verified one.** `check-inbox` marks read *before* it emits; a `PostToolUse` whose model receipt is unobserved would then "consume and never show" (the exact loss this file's own comment names, amplified to once per tool call — the #677 / #1004 intersection). So for `PostToolUse`, `check-inbox` does **not** mark read and uses its **own** cooldown marker. If mid-turn works the user sees a message earlier; if it does not, `Stop` still fetches, shows, and consumes it as before. Duplicate display is harmless; invisible loss is not.

## Old-CLI compatibility — measured, with the boundary drawn

Issue #1003 item 5 required that an older Codex (one without `PostToolUse`) handle the entry harmlessly: no startup error, and the Hooks Review screen not blocked. Measured by co1 on a real old binary:

- **Measured harmless:** codex-cli **0.116.0** (a pre-PostToolUse build, confirmed by `strings` carrying no PostToolUse event name) **reads** a `hooks.json` that carries a valid `PostToolUse` entry and **silently ignores the unknown key** — no hooks-config error, session initialization proceeds to the network request. A **positive control on the same file** (malformed known `SessionStart` data → `warning: failed to parse hooks config …: invalid type … expected a sequence`) proves the binary actually read the file, so the no-error result is "read and dropped", not "never read".
- **Not directly observed:** the **Hooks Review screen** not being blocked. The isolated `CODEX_HOME` had no auth to reach that screen, so "not blocked there" is **inference** from the parser dropping the unknown event, not a direct observation.

So one half of item 5 is measured with a positive control; the other half is inference from the measured parser behavior.

## What is NOT proven (do not read past this)

- **Model receipt is unobserved.** The output shape is measured against codex-cli 0.149.1's **parser/schema** (co1); the end-to-end "the model saw it" was blocked by the sandbox. This ships the parser-accepted shape; it does **not** prove mid-turn delivery reaches the model. #1003 stays **open** for that acceptance evidence.
- **The Hooks Review screen is inferred, not observed** (see above) — the one remaining part of item 5 not directly measured.

## The "broken but green" this guards

A test that only checks a `PostToolUse` entry *exists* stays green even if the shape is wrong. So the tests assert the **shape** `check-inbox` emits per event, the **additive** property (displays but does not consume; does not gate Stop), and the **version gate** with boundary controls (exact floor installs; floor-minus-one `0.149.0` does not; a MAX installs; unparseable / `--version`-fails do not). Every version case places a fake `codex` on `PATH` (pass and fail alike) — the version is read, never asserted. Mutation-verified: emitting Stop's shape, sharing the Stop cooldown marker, marking read, discarding patch in the comparison, or making the gate always-install each reddens its own test. What is **not** covered is model receipt (unobservable here).

Full local `test_inbox.bats` / `test_delivery.bats` pass; enforced-assertions at baseline.