### PR TITLE
ci: a docs-only skip and a passing suite are no longer the same green (#798)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,7 +204,14 @@ jobs:
           echo "contracts_needed=$contracts_needed" >> "$GITHUB_OUTPUT"
 
   bats-shard:
-    name: bats (${{ matrix.os }} ${{ matrix.shard }}/4)
+    # The docs-only skip below reports this check green without running the
+    # suite -- correctly, so the required aggregate can be satisfied -- but a
+    # green that measured nothing must not read like one that ran 24 files
+    # (#798). The name says which it was. Only the shard checks change name;
+    # the required contexts are `bats` (the aggregate) and the Windows install
+    # leg, and neither is renamed, so branch protection sees exactly what it
+    # saw. `needs` is one of the contexts a job name may read.
+    name: bats (${{ matrix.os }} ${{ matrix.shard }}/4)${{ needs.changes.outputs.docs_only == 'true' && ' — docs-only, suite skipped' || '' }}
     needs: changes
     # Run even if `changes` somehow failed/was skipped — fail open to the full
     # suite rather than leaving this REQUIRED check unreported (which would
@@ -244,7 +251,9 @@ jobs:
 
       - name: Docs-only change — skipping suite
         if: needs.changes.outputs.docs_only == 'true'
-        run: echo "Diff is documentation-only; skipping the bats suite and reporting green to satisfy the required check."
+        run: |
+          echo "Diff is documentation-only; skipping the bats suite and reporting green to satisfy the required check."
+          echo "::notice title=bats shard skipped::docs-only diff — this shard ran 0 test files; its green satisfies the required check and measures nothing (#798)"
 
       - name: Compute this shard's test files
         if: needs.changes.outputs.docs_only != 'true'
@@ -421,7 +430,15 @@ jobs:
 
       - name: Docs-only change — no shard manifests to verify
         if: needs.changes.outputs.docs_only == 'true'
-        run: echo "Diff is documentation-only; shard manifests are not expected."
+        # Same conclusion as a full pass -- this is the required context and a
+        # docs-only PR must stay mergeable -- but the run says which green it
+        # is, where a person reads it: the checks tab (annotation) and the run
+        # summary. `gh pr checks` still prints `bats pass`; the shard lines
+        # beside it now carry "docs-only, suite skipped" (#798).
+        run: |
+          echo "Diff is documentation-only; shard manifests are not expected."
+          echo "::notice title=bats::docs-only diff — the bats suite did not run on any shard; this green satisfies the required check and measures nothing (#798)"
+          printf '%s\n' "## bats: docs-only, suite skipped" "" "The diff was documentation-only, so no shard ran the bats suite. This green satisfies the required check; it is not evidence that the suite passes (#798)." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Download shard manifests
         if: needs.changes.outputs.docs_only != 'true'
@@ -443,6 +460,10 @@ jobs:
               status=1
             fi
           done
+          # The other green, named the same way (#798): how many files the
+          # shards ran, so a full pass and a skip never read alike.
+          count="$(printf '%s\n' "$expected" | grep -c .)"
+          printf '%s\n' "## bats: suite ran" "" "The shards ran $count test files on ubuntu-latest and macos-latest and every shard passed." >> "$GITHUB_STEP_SUMMARY"
           exit "$status"
 
   # The age-v1 vectors are shared normative fixtures. Exercise them with the

--- a/tests/test_ci_workflow.bats
+++ b/tests/test_ci_workflow.bats
@@ -40,3 +40,37 @@
   run grep -F 'no age-gated test files found' "$workflow"
   [ "$status" -eq 0 ]
 }
+
+@test "CI: a docs-only skip and a passing suite are not the same green (#798)" {
+  # The docs-only path reports the bats checks green without running the
+  # suite, which is right for the required context and wrong for a reader:
+  # #776's green was once put forward as evidence that the base was fine, and
+  # that shard had run nothing. What this pins is that the run SAYS which green
+  # it is, in three places, and that the required context is not renamed.
+  local workflow="$BATS_TEST_DIRNAME/../.github/workflows/tests.yml"
+  # 1. The shard job's name carries the marker, keyed on the docs_only output.
+  #    Shard checks are not required contexts, so the name may vary.
+  grep -Fq "name: bats (\${{ matrix.os }} \${{ matrix.shard }}/4)\${{ needs.changes.outputs.docs_only == 'true' && ' — docs-only, suite skipped' || '' }}" "$workflow"
+  # 2. The aggregate -- the required context -- keeps its exact name, once,
+  #    unconditionally.
+  [ "$(grep -c '^    name: bats$' "$workflow")" -eq 1 ]
+  # 3. Both greens are named on the aggregate's own output: the skip as an
+  #    annotation and a summary heading, the full pass as a summary heading
+  #    that carries the file count.
+  grep -Fq '::notice title=bats::docs-only diff — the bats suite did not run on any shard' "$workflow"
+  grep -Fq '"## bats: docs-only, suite skipped"' "$workflow"
+  grep -Fq '"## bats: suite ran"' "$workflow"
+  grep -Fq 'The shards ran $count test files' "$workflow"
+  # 4. And on the shard itself, so the checks tab shows it per job.
+  grep -Fq '::notice title=bats shard skipped::docs-only diff — this shard ran 0 test files' "$workflow"
+}
+
+@test "CI: the #798 pins go red when the marker is taken back out (mutation control)" {
+  # A pin that stays green when the thing it pins is removed is not a pin.
+  local workflow="$BATS_TEST_DIRNAME/../.github/workflows/tests.yml" mutant="$BATS_TEST_TMPDIR/tests.yml"
+  sed "s/ && ' — docs-only, suite skipped' || ''//" "$workflow" > "$mutant"
+  # The mutation took: the marker is gone from the copy.
+  if grep -Fq "docs-only, suite skipped' || ''" "$mutant"; then false; fi
+  # ...and the name pin no longer matches it.
+  if grep -Fq "name: bats (\${{ matrix.os }} \${{ matrix.shard }}/4)\${{ needs.changes.outputs.docs_only == 'true' && ' — docs-only, suite skipped' || '' }}" "$mutant"; then false; fi
+}


### PR DESCRIPTION
Closes #798. A docs-only diff skips the bats suite and reports the required check green — correctly, and this keeps that — but the run now says which green it is, in the places a person actually reads.

## What was indistinguishable

`bats (ubuntu-latest 4/4)` was `success` both when the suite ran and when the docs-only step skipped it; only opening the job and reading step 9 told them apart. #776's green was once offered as evidence that the base was fine while that shard had run nothing.

## What this does, without touching the required contexts

Branch protection on `main` requires exactly two contexts: `bats` (the aggregate) and `bats (windows-latest, install helpers)`. Neither is renamed and neither changes conclusion. The distinction goes into three places that are not gated:

1. **The shard checks' names.** `bats (<os> <n>/4)` becomes `bats (<os> <n>/4) — docs-only, suite skipped` when `needs.changes.outputs.docs_only == 'true'`, via a conditional in the job name (`needs` is one of the contexts a job name may read). This is what `gh pr checks` and the checks list show, beside the unchanged `bats pass`. The shard checks are not required contexts, so branch protection is untouched.
2. **Annotations.** The skipped shard and the aggregate each emit a `::notice` naming the skip ("this shard ran 0 test files; its green satisfies the required check and measures nothing"), so the checks tab carries it per job.
3. **The run summary.** The aggregate writes `## bats: docs-only, suite skipped` on the skip path and `## bats: suite ran` with the file count on the full path, so the two greens never read alike on the run page either.

No new workflow, no new check, no new input or setting. Issue's suggestion 1 minus its stated cost (renaming the required check), plus suggestion 2; suggestion 3 (a `skipped` aggregate) was not taken because the aggregate is the required context and a docs-only PR has to stay mergeable.

## Tests

Two cases in `tests/test_ci_workflow.bats`: the three places are pinned (the shard name expression, the exact single unconditional `name: bats`, both summary headings, both annotations), and a mutation control strips the name marker from a copy and shows the pin no longer matches. 4/4 under bash 5 and `/bin/bash` 3.2; enforceable-assertions check at baseline; YAML parses.

## The one way this stays green while wrong, named

The pins are greps over the workflow text. They cannot prove that GitHub renders the `needs` expression inside a job name on a real docs-only run — and this PR cannot exercise that path itself, because a diff that touches `.github/workflows/tests.yml` sets `docs_only=false` by construction. So the verification is an observation after landing: open a throwaway docs-only draft PR, read `gh pr checks` and the checks tab, and paste both shapes (the docs-only shard lines and a full run's) into #798. If the shard names come back without the marker, the expression is not rendered there and the annotation/summary halves still stand while the name half goes back to the drawing board.
