### PR TITLE
[observation] #798: a real docs-only run — close without merging

### DIFF
--- a/docs/actas.md
+++ b/docs/actas.md
@@ -68,3 +68,5 @@ On Codex, `$agmsg actas <name>` is **send-side only** for this session. Codex sl
 The receive side isn't actually narrowed either: `check-inbox.sh` resolves identity through `whoami.sh` (which picks the first registered agent) and has no view of the agent's in-session actas role, so Codex keeps polling whichever pair it would have without actas. The check-inbox lock filter only skips pairs *another* session owns.
 
 Treat Codex actas as a from-line override until a Codex session-id story exists. Claude Code's `/agmsg actas` does claim the lock symmetrically and is the path that exercises the full exclusivity model.
+
+<!-- Observation draft for #798: a docs-only diff, opened to read the shard check names on a real docs-only run. Close without merging. -->


### PR DESCRIPTION
Throwaway draft for the post-landing observation promised on #1005: a docs-only diff, so the shard checks should now read `bats (<os> <n>/4) — docs-only, suite skipped` while the required `bats` aggregate stays green. The resulting `gh pr checks` output and checks-tab shapes will be pasted into #798, then this PR is closed unmerged and the branch deleted.