### PR TITLE
fix(storage): a store at the current schema revision skips init's write batch (#1001)

### DIFF
--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -108,9 +108,31 @@ storage_describe() {
 # "no messages yet" without lazily initializing a store in a storeless project.)
 storage_store_exists() { [ -f "$(_sqlite_db "$1")" ]; }
 
+# Bumped whenever the init batch below changes shape: it is what lets a store
+# that already carries revision N skip the batch entirely (#1001). The number
+# is stamped INSIDE the same transaction as the schema statements, so a store
+# can never hold the new number over an old schema.
+_AGMSG_STORAGE_SCHEMA_REV=1
+
 storage_init() {
   local db; db="$(_sqlite_db "$1")"
   mkdir -p "$(dirname "$db")" 2>/dev/null || true
+  # Fast path (#1001): a store already at the current schema revision needs
+  # nothing from this function -- and the check is a READ, which WAL serves
+  # even while another process holds the write lock. Without this, every
+  # storage call re-ran the write batch below, and under a busy sync engine
+  # each of those waited the full busy timeout and then failed with
+  # SQLITE_BUSY, silently: 21 sqlite3 calls per inbox.sh, measured 106 s of
+  # nothing but this. A failed read falls through to the full init -- an
+  # observation failure must not skip the schema.
+  if [ -f "$db" ]; then
+    local schema_rev
+    schema_rev="$(agmsg_sqlite "$db" "PRAGMA user_version;" 2>/dev/null | tr -d '[:space:]')" || schema_rev=""
+    if [ "$schema_rev" = "$_AGMSG_STORAGE_SCHEMA_REV" ]; then
+      echo ok
+      return 0
+    fi
+  fi
   # CREATE TABLE IF NOT EXISTS does nothing to a store that already has the
   # table, so an existing events table never gains legacy_id from the schema
   # below. SQLite has no ADD COLUMN IF NOT EXISTS, and a failing statement
@@ -120,8 +142,16 @@ storage_init() {
     agmsg_sqlite "$db" "ALTER TABLE events ADD COLUMN legacy_id INTEGER;" \
       >/dev/null 2>&1 || true
   fi
-  agmsg_sqlite "$db" "
-    PRAGMA journal_mode=WAL;
+  # journal_mode cannot run inside a transaction, so it stays outside the
+  # one below; its failure surfaces through the transaction that follows.
+  agmsg_sqlite "$db" "PRAGMA journal_mode=WAL;" >/dev/null 2>&1 || true
+  # One transaction, stopped at the first error (-bail), with the revision
+  # stamp as its LAST statement: either every schema statement landed and the
+  # store says so, or none of it is visible and the store still says the old
+  # revision. A crash or failure in the middle cannot leave a new stamp over
+  # an old schema, which is the one way the fast path above could lie.
+  agmsg_sqlite -bail "$db" "
+    BEGIN IMMEDIATE;
     CREATE TABLE IF NOT EXISTS events (
       seq        INTEGER PRIMARY KEY AUTOINCREMENT,
       type       TEXT NOT NULL,
@@ -218,6 +248,8 @@ storage_init() {
         read_cursors.local_position,excluded.local_position);
     INSERT OR IGNORE INTO storage_metadata(key,value)
       VALUES('read_cursor_v1','1');
+    PRAGMA user_version=${_AGMSG_STORAGE_SCHEMA_REV};
+    COMMIT;
   " >/dev/null 2>&1 || { echo runtime_error; return 13; }
   echo ok
 }

--- a/scripts/drivers/storage/sqlite.sh
+++ b/scripts/drivers/storage/sqlite.sh
@@ -142,9 +142,21 @@ storage_init() {
     agmsg_sqlite "$db" "ALTER TABLE events ADD COLUMN legacy_id INTEGER;" \
       >/dev/null 2>&1 || true
   fi
-  # journal_mode cannot run inside a transaction, so it stays outside the
-  # one below; its failure surfaces through the transaction that follows.
-  agmsg_sqlite "$db" "PRAGMA journal_mode=WAL;" >/dev/null 2>&1 || true
+  # journal_mode cannot run inside a transaction, so it stays outside the one
+  # below -- and its RESULT is checked, not assumed. The pragma answers with
+  # the mode now in effect; anything but "wal" (a transient writer making it
+  # BUSY, a filesystem refusing the side files) must stop here, because the
+  # stamp below would otherwise record a non-WAL store as current and the
+  # fast path would never retry the switch -- reads would queue behind
+  # writers for the full busy timeout again, with a stamp saying all is well
+  # (review finding). Only a store that is actually in WAL proceeds to the
+  # schema transaction and can be stamped.
+  local journal_mode
+  journal_mode="$(agmsg_sqlite "$db" "PRAGMA journal_mode=WAL;" 2>/dev/null | tr -d '[:space:]')" || journal_mode=""
+  if [ "$journal_mode" != wal ]; then
+    echo runtime_error
+    return 13
+  fi
   # One transaction, stopped at the first error (-bail), with the revision
   # stamp as its LAST statement: either every schema statement landed and the
   # store says so, or none of it is visible and the store still says the old

--- a/scripts/lib/storage.sh
+++ b/scripts/lib/storage.sh
@@ -254,7 +254,18 @@ agmsg_sqlite() {
     return
   fi
   # shellcheck disable=SC2086  # intentional split: "-escape off" → two args, or none
-  sqlite3 $_AGMSG_ESCAPE_FLAG -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@"
+  local _agmsg_sqlite_rc=0
+  sqlite3 $_AGMSG_ESCAPE_FLAG -cmd ".timeout ${AGMSG_BUSY_TIMEOUT:-5000}" "$@" || _agmsg_sqlite_rc=$?
+  # SQLITE_BUSY after the full timeout used to pass in silence: the caller saw
+  # a non-zero it often swallowed, and the operator saw a command that hung
+  # for the timeout and said nothing (#1001 -- two people diagnosed two
+  # different commands as broken). One line on stderr turns "hung" into
+  # "waited and gave up", names the likely writer, and costs nothing when
+  # there is no contention.
+  if [ "$_agmsg_sqlite_rc" -eq 5 ]; then
+    echo "agmsg: the message store is busy: this call waited ${AGMSG_BUSY_TIMEOUT:-5000}ms behind another writer (a sync engine cycle may be running) and gave up (#1001)" >&2
+  fi
+  return "$_agmsg_sqlite_rc"
 }
 
 # The same call, recording how it ended. With AGMSG_SQLITE_OUTCOME_FILE set,

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -591,7 +591,12 @@ prepare_push() {
 # failure mode is silent (zero candidates, no error), so it is pinned here.
 _seed_legacy_history() {
   local db; db=$(agmsg_db_path demo)
+  # An old store also predates the schema-revision stamp (#1001): reset it,
+  # or the simulated pre-cursor store would fast-path around the adoption
+  # this seeder exists to exercise. No product path deletes the marker; only
+  # this simulation does.
   agmsg_sqlite "$db" "
+    PRAGMA user_version=0;
     DELETE FROM storage_metadata WHERE key='read_cursor_v1';
     INSERT INTO messages(team,from_agent,to_agent,body,created_at) VALUES
       ('demo','alice','bob','legacy one','2026-01-01T00:00:00Z'),

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -393,8 +393,111 @@ _use_per_team() {
   # The lookup the sync import makes per imported message (FROM events
   # WHERE id=...) is a search now -- not a scan of every message body.
   sqlite3 "$db" "EXPLAIN QUERY PLAN SELECT seq FROM events WHERE id = 'x';" | grep -q 'USING COVERING INDEX events_id\|USING INDEX events_id'
-  # A store from before this index existed picks it up on the next init.
-  sqlite3 "$db" "DROP INDEX events_id;"
+  # A store from before this index existed picks it up on the next init. Such
+  # a store also predates the schema-revision stamp (#1001), so the
+  # simulation regresses both together -- a current stamp over a missing
+  # index is a state no product path produces, and the fast path would
+  # (correctly, per its contract) not heal it.
+  sqlite3 "$db" "DROP INDEX events_id; PRAGMA user_version=0;"
   storage_init demo >/dev/null
   [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='events_id';" | tr -d '\r')" -eq 1 ]
+}
+
+# ---- #1001: storage_init fast path and the busy note ----
+
+@test "storage: a store at the current schema revision skips init's write batch -- even while a writer holds the store (#1001)" {
+  source "$SCRIPTS/lib/storage.sh"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=sqlite
+  agmsg_storage_load
+  storage_init demo >/dev/null
+  local db; db=$(agmsg_db_path demo)
+  # The stamp landed.
+  [ "$(sqlite3 "$db" "PRAGMA user_version;" | tr -d ' \r')" = 1 ]
+  # Under a held write lock, the old init re-ran its write batch, waited the
+  # full busy timeout and failed; the fast path READS the revision (WAL serves
+  # reads beside a writer) and returns ok without touching the lock.
+  ( printf 'BEGIN IMMEDIATE;\nSELECT 1;\n'; sleep 3; printf 'COMMIT;\n' ) | sqlite3 "$db" >/dev/null &
+  local holder=$!
+  sleep 0.5
+  export AGMSG_BUSY_TIMEOUT=200
+  run storage_init demo
+  unset AGMSG_BUSY_TIMEOUT
+  wait "$holder"
+  [ "$status" -eq 0 ]
+  [ "$output" = ok ]
+}
+
+@test "storage: a revision mismatch runs the real init, and the stamp follows the schema (#1001)" {
+  # The gate must swing BOTH ways: matching skips (above), and NOT matching
+  # actually initializes -- the danger of a fast path is an old schema waved
+  # through as new.
+  source "$SCRIPTS/lib/storage.sh"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=sqlite
+  agmsg_storage_load
+  storage_init demo >/dev/null
+  local db; db=$(agmsg_db_path demo)
+  # Regress the store: drop a piece of schema and the stamp together.
+  sqlite3 "$db" "DROP INDEX events_id; PRAGMA user_version=0;"
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM sqlite_master WHERE name='events_id';" | tr -d ' \r')" = 0 ]
+  run storage_init demo
+  [ "$status" -eq 0 ]
+  # The batch really ran: the schema piece is back, and so is the stamp.
+  [ "$(sqlite3 "$db" "SELECT COUNT(*) FROM sqlite_master WHERE name='events_id';" | tr -d ' \r')" = 1 ]
+  [ "$(sqlite3 "$db" "PRAGMA user_version;" | tr -d ' \r')" = 1 ]
+}
+
+@test "storage: a failing init batch leaves the OLD revision, never a new stamp over a broken schema (#1001)" {
+  # The stamp is the last statement of the same -bail transaction as the
+  # schema. If anything before it fails, the transaction rolls back and the
+  # store still says the old revision -- the fast path can then never treat
+  # the broken store as current. Forced here with a trigger that aborts the
+  # read-cursor adoption insert.
+  source "$SCRIPTS/lib/storage.sh"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=sqlite
+  agmsg_storage_load
+  mkdir -p "$AGMSG_STORAGE_PATH"
+  local db; db=$(agmsg_db_path demo)
+  sqlite3 "$db" "
+    CREATE TABLE events (seq INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL,
+      id TEXT NOT NULL, team TEXT, from_agent TEXT, to_agent TEXT, body TEXT,
+      msg_id TEXT, agent TEXT, at TEXT NOT NULL, legacy_id INTEGER);
+    CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL,
+      from_agent TEXT NOT NULL, to_agent TEXT NOT NULL, body TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')), read_at TEXT);
+    INSERT INTO messages(team,from_agent,to_agent,body) VALUES('demo','a','b','legacy row');
+    CREATE TRIGGER boom BEFORE INSERT ON events WHEN NEW.type='message_read'
+      BEGIN SELECT RAISE(ABORT,'forced mid-batch failure'); END;"
+  run storage_init demo
+  [ "$status" -eq 13 ]
+  [ "$output" = runtime_error ]
+  # No stamp: the store still says revision 0, so the next init tries again.
+  [ "$(sqlite3 "$db" "PRAGMA user_version;" | tr -d ' \r')" = 0 ]
+}
+
+@test "storage: a call that gives up after the busy timeout says so on stderr, and a quiet store says nothing (#1001)" {
+  source "$SCRIPTS/lib/storage.sh"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=sqlite
+  agmsg_storage_load
+  storage_init demo >/dev/null
+  local db; db=$(agmsg_db_path demo)
+  # Quiet store: a write emits nothing.
+  run --separate-stderr agmsg_sqlite "$db" "INSERT INTO storage_metadata(key,value) VALUES('t1','1');"
+  [ "$status" -eq 0 ]
+  [ -z "$stderr" ]
+  # Contended store: the write waits the timeout, fails with SQLITE_BUSY, and
+  # SAYS so -- "hung" becomes "waited and gave up".
+  ( printf 'BEGIN IMMEDIATE;\nSELECT 1;\n'; sleep 3; printf 'COMMIT;\n' ) | sqlite3 "$db" >/dev/null &
+  local holder=$!
+  sleep 0.5
+  export AGMSG_BUSY_TIMEOUT=200
+  run --separate-stderr agmsg_sqlite "$db" "INSERT INTO storage_metadata(key,value) VALUES('t2','1');"
+  unset AGMSG_BUSY_TIMEOUT
+  wait "$holder"
+  [ "$status" -eq 5 ]
+  grep -Fq "the message store is busy" <<<"$stderr"
+  grep -Fq "waited 200ms" <<<"$stderr"
 }

--- a/tests/test_storage.bats
+++ b/tests/test_storage.bats
@@ -501,3 +501,41 @@ _use_per_team() {
   grep -Fq "the message store is busy" <<<"$stderr"
   grep -Fq "waited 200ms" <<<"$stderr"
 }
+
+@test "storage: init stamps only a store that is really in WAL -- a busy journal switch stops before the stamp (#1001)" {
+  # The fast path's whole premise is WAL serving reads beside a writer. If
+  # the journal-mode switch alone lost to a transient writer while the schema
+  # transaction then succeeded, a rollback-journal store would be stamped
+  # current and the fast path would never retry the switch -- minute-long
+  # waits would return with a stamp saying all is well (review finding). So
+  # init checks what the pragma ANSWERS and refuses to proceed on anything
+  # but "wal".
+  source "$SCRIPTS/lib/storage.sh"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=sqlite
+  agmsg_storage_load
+  mkdir -p "$AGMSG_STORAGE_PATH"
+  local db; db=$(agmsg_db_path demo)
+  # A rollback-journal store, not yet initialized.
+  sqlite3 "$db" "PRAGMA journal_mode=DELETE; CREATE TABLE seedmark(x);" >/dev/null
+  [ "$(sqlite3 "$db" "PRAGMA user_version;" | tr -d ' \r')" = 0 ]
+  # A writer holds the store: the journal switch comes back busy, and init
+  # must stop THERE -- old stamp, old journal mode, an error worth seeing.
+  ( printf 'BEGIN IMMEDIATE;\nSELECT 1;\n'; sleep 3; printf 'COMMIT;\n' ) | sqlite3 "$db" >/dev/null &
+  local holder=$!
+  sleep 0.5
+  export AGMSG_BUSY_TIMEOUT=200
+  run storage_init demo
+  unset AGMSG_BUSY_TIMEOUT
+  [ "$status" -eq 13 ]
+  [ "$output" = runtime_error ]
+  wait "$holder"
+  [ "$(sqlite3 "$db" "PRAGMA user_version;" | tr -d ' \r')" = 0 ]
+  [ "$(sqlite3 "$db" "PRAGMA journal_mode;" | tr -d ' \r')" = delete ]
+  # The writer gone, the same init switches to WAL, initializes, and stamps.
+  run storage_init demo
+  [ "$status" -eq 0 ]
+  [ "$output" = ok ]
+  [ "$(sqlite3 "$db" "PRAGMA journal_mode;" | tr -d ' \r')" = wal ]
+  [ "$(sqlite3 "$db" "PRAGMA user_version;" | tr -d ' \r')" = 1 ]
+}

--- a/tests/test_storage_contract.bats
+++ b/tests/test_storage_contract.bats
@@ -121,7 +121,10 @@ _cursor_of() { printf '%s\n' "$1" | sed -n 's/.*"type":"cursor","cursor":"\([^"]
     local store_dir; store_dir="$(dirname "$(agmsg_db_path agsuite)")"
     rm -f "$store_dir/.read-cursor-v1" "$store_dir/read-cursors.tsv"
   else
+    # A pre-cursor-era store also predates the schema-revision stamp (#1001);
+    # without resetting it the next init would fast-path past the adoption.
     agmsg_sqlite "$(agmsg_db_path agsuite)" "
+      PRAGMA user_version=0;
       DELETE FROM storage_metadata WHERE key='read_cursor_v1';
       DELETE FROM read_cursors;" >/dev/null
   fi


### PR DESCRIPTION
Closes #1001. The waiting had a single owner, and it was not the per-statement timeout.

## Measured

Isolated store, a counting `sqlite3` shim, and a writer holding `BEGIN IMMEDIATE` for 30 s:

- `inbox.sh` starts **21 sqlite3 processes** (`history.sh` 15) — the reported 106 s matches 21 × 5 s.
- Under the writer it waited 15 s, returned 0, and printed only its normal result — the reported silence, reproduced.
- Per-call logging split the 15 s exactly: **three runs of `storage_init`'s schema batch (`PRAGMA journal_mode=WAL; CREATE TABLE IF NOT EXISTS …`), 5.0 s each, every one failing with SQLITE_BUSY and being swallowed.** The read-only work itself never waited. The rc=1 crowd is the known idempotent ALTER.

So suggestion 3 of the issue was the cause, not a refinement: read commands pay init's *write* path on every storage call. The send path had already learned this lesson — `sqlite.sh`'s INSERT-first fallback (#114 pattern) exists precisely to avoid running init per call.

## The fix

`storage_init` stamps `PRAGMA user_version` with a schema revision (`_AGMSG_STORAGE_SCHEMA_REV`, bumped whenever the batch changes) as the **last statement of one `-bail BEGIN IMMEDIATE … COMMIT` transaction** — `journal_mode` cannot sit inside a transaction and stays outside it. On entry it reads the stamp — a read, which WAL serves beside an active writer — and returns `ok` on a match. Either every schema statement landed and the store says the new revision, or the transaction rolled back and the store still says the old one: a crash or mid-batch failure can never leave a new stamp over an old schema, which is the one way this fast path could lie. A failed read of the stamp falls through to the full init. Old stores carry no stamp and take the slow path exactly once.

Measured after, same setup: the contended `inbox.sh` drops from 15 s of init waits to only the time its one real write — the read-mark — spends behind the writer; zero busy failures from init.

And that one real write now speaks when it loses: `agmsg_sqlite` prints a single stderr line when a call comes back SQLITE_BUSY after its full timeout — how long it waited and that a sync cycle is the likely writer. "Hung" becomes "waited and gave up", which is what both reports in the issue needed to see. Suggestion 2 (a command-wide bound) is not taken: with the cause removed there is nothing left for it to bound but real writes, which the note now names.

## Follow-up, stated not hidden

Under a busy engine, `inbox.sh`'s read-mark write can still wait its 5 s and fail; the message is shown but stays unread, so it is delivered again later. That loss predates this change and is now announced by the note; whether that write should retry (the #114 treatment) is a separate decision.

## Tests

Both directions of the revision gate: a matching store skips the batch **while a writer holds the store** (`AGMSG_BUSY_TIMEOUT=200`, deterministic — the old code failed here); a regressed store (index dropped, stamp reset) really re-initializes and re-stamps. The transactional stamp: a trigger-forced mid-batch failure returns 13 and leaves the old revision. The busy note: present on contention with the waited duration, absent on a quiet store. Three existing old-store simulations (the legacy-history seeder, the cursor-migration case, the pre-#910-index case) now regress the stamp together with what they remove — a genuinely old store presents with an old stamp, and no product path deletes the marker or an index while keeping the stamp current.

Suites: the five storage-touching files (`test_storage`, `test_storage_contract`, `test_migrate_team_store`, `test_inbox`, `test_remote_sync`) 149/149 under bash 5 and `/bin/bash` 3.2; enforceable-assertions at baseline; `git diff --check` clean. No new flag, subcommand, or setting — `user_version` is SQLite's own header field.
