### PR TITLE
feat(inbox): report a mark-read that lost to a concurrent writer (#1011)

### DIFF
--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -84,7 +84,12 @@ fi
 # without mutating the legacy row (§2.4). Only the ids collected from the
 # rows actually displayed above — never a blanket match — so a message that
 # arrives after the SELECT above can never be marked read unseen. Non-fatal —
-# may fail in sandboxed environments.
+# may fail in sandboxed environments or lose to a concurrent writer — but a
+# failure is reported on stderr, because the messages above were displayed and
+# will now be shown again as unread (#1011). The exit status stays 0: the
+# inbox did deliver, and the rows are still there.
 if [ "${#IDS[@]}" -gt 0 ]; then
-  storage_mark_read_batch "$TEAM" "$AGENT" "${IDS[@]}" >/dev/null 2>&1 || true
+  if ! storage_mark_read_batch "$TEAM" "$AGENT" "${IDS[@]}" >/dev/null 2>&1; then
+    echo "agmsg: failed to mark ${#IDS[@]} displayed message(s) read; they remain unread and will be shown again (#1011)" >&2
+  fi
 fi

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -85,11 +85,13 @@ fi
 # rows actually displayed above — never a blanket match — so a message that
 # arrives after the SELECT above can never be marked read unseen. Non-fatal —
 # may fail in sandboxed environments or lose to a concurrent writer — but a
-# failure is reported on stderr, because the messages above were displayed and
-# will now be shown again as unread (#1011). The exit status stays 0: the
-# inbox did deliver, and the rows are still there.
+# failure is reported on stderr, because the messages above were displayed
+# and their read state is now unknown (#1011). "Some or all", not "they":
+# only the sqlite driver marks in one transaction; the jsonl driver can have
+# recorded part of the batch before the failing step. The exit status stays
+# 0: the inbox did deliver.
 if [ "${#IDS[@]}" -gt 0 ]; then
   if ! storage_mark_read_batch "$TEAM" "$AGENT" "${IDS[@]}" >/dev/null 2>&1; then
-    echo "agmsg: failed to mark ${#IDS[@]} displayed message(s) read; they remain unread and will be shown again (#1011)" >&2
+    echo "agmsg: failed to record read state for ${#IDS[@]} displayed message(s); some or all may be shown again (#1011)" >&2
   fi
 fi

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -101,25 +101,36 @@ await_barrier_reached() {
     | sqlite3 "$db" >/dev/null &
   holder=$!
   # Proceed only once a real write attempt has failed — the backgrounded holder
-  # existing is not the lock being held.
+  # existing is not the lock being held. No assertion may run while the holder
+  # is still parked on the fifo: a failed assert would abort the test body
+  # before the release, leaving a lock-holding process behind instead of a
+  # clean red. So this path, like the main one, releases before it judges.
   local held=0
   for _ in $(seq 1 100); do
     if ! sqlite3 -cmd '.timeout 20' "$db" 'BEGIN IMMEDIATE; COMMIT;' >/dev/null 2>&1; then held=1; break; fi
     sleep 0.05
   done
-  [ "$held" -eq 1 ]
+  if [ "$held" -ne 1 ]; then
+    : > "$TEST_SKILL_DIR/hold.release"
+    wait "$holder"
+    false
+  fi
 
   local st=0
   AGMSG_BUSY_TIMEOUT=200 bash "$SCRIPTS/inbox.sh" testteam alice \
     > "$TEST_SKILL_DIR/held.out" 2> "$TEST_SKILL_DIR/held.err" || st=$?
+  # The run under contention is over; let the holder go BEFORE any assertion.
+  : > "$TEST_SKILL_DIR/hold.release"
+  wait "$holder"
+
   # Delivered, exit 0 — and the failed mark is now SAID, not swallowed.
   [ "$st" -eq 0 ]
   grep -q 'trapped' "$TEST_SKILL_DIR/held.out"
-  grep -q 'failed to mark 1 displayed message(s) read' "$TEST_SKILL_DIR/held.err"
+  grep -q 'failed to record read state for 1 displayed message(s)' "$TEST_SKILL_DIR/held.err"
   grep -q '#1011' "$TEST_SKILL_DIR/held.err"
-
-  : > "$TEST_SKILL_DIR/hold.release"
-  wait "$holder"
+  # All-unread is a fact about THIS driver (sqlite marks in one transaction);
+  # the jsonl driver can legitimately leave a partial batch, which is why the
+  # diagnostic says "some or all".
   [ "$(unread_count alice)" -eq 1 ]
 
   # The same inbox once the writer is gone: shown again, marked, and silent.

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -85,6 +85,54 @@ await_barrier_reached() {
   [ "$(unread_count alice)" -eq 0 ]
 }
 
+@test "inbox: a mark-read that loses to a concurrent writer is reported, and the message reappears (#1011)" {
+  # Before #1011 the mark's failure was fully swallowed: the message printed,
+  # the row stayed unread, the exit code was 0, and nothing said so. The
+  # display SELECT reads beside a writer (WAL); only the mark write loses.
+  bash "$SCRIPTS/send.sh" testteam bob alice "trapped"
+  local db
+  db="$(cd "$TEST_SKILL_DIR" && bash -c '. scripts/lib/storage.sh; agmsg_storage_load; agmsg_db_path testteam' 2>/dev/null)"
+  [ -n "$db" ] && [ -f "$db" ]
+
+  # Hold the write lock until told to let go (a fifo, not a sleep, so the hold
+  # cannot expire mid-test however slowly the inbox runs).
+  mkfifo "$TEST_SKILL_DIR/hold.release"
+  ( printf 'BEGIN IMMEDIATE;\nSELECT 1;\n'; cat "$TEST_SKILL_DIR/hold.release"; printf 'COMMIT;\n' ) \
+    | sqlite3 "$db" >/dev/null &
+  holder=$!
+  # Proceed only once a real write attempt has failed — the backgrounded holder
+  # existing is not the lock being held.
+  local held=0
+  for _ in $(seq 1 100); do
+    if ! sqlite3 -cmd '.timeout 20' "$db" 'BEGIN IMMEDIATE; COMMIT;' >/dev/null 2>&1; then held=1; break; fi
+    sleep 0.05
+  done
+  [ "$held" -eq 1 ]
+
+  local st=0
+  AGMSG_BUSY_TIMEOUT=200 bash "$SCRIPTS/inbox.sh" testteam alice \
+    > "$TEST_SKILL_DIR/held.out" 2> "$TEST_SKILL_DIR/held.err" || st=$?
+  # Delivered, exit 0 — and the failed mark is now SAID, not swallowed.
+  [ "$st" -eq 0 ]
+  grep -q 'trapped' "$TEST_SKILL_DIR/held.out"
+  grep -q 'failed to mark 1 displayed message(s) read' "$TEST_SKILL_DIR/held.err"
+  grep -q '#1011' "$TEST_SKILL_DIR/held.err"
+
+  : > "$TEST_SKILL_DIR/hold.release"
+  wait "$holder"
+  [ "$(unread_count alice)" -eq 1 ]
+
+  # The same inbox once the writer is gone: shown again, marked, and silent.
+  st=0
+  bash "$SCRIPTS/inbox.sh" testteam alice \
+    > "$TEST_SKILL_DIR/free.out" 2> "$TEST_SKILL_DIR/free.err" || st=$?
+  [ "$st" -eq 0 ]
+  grep -q 'trapped' "$TEST_SKILL_DIR/free.out"
+  # Not `! grep -q`: a negated non-last command cannot fail a bats test (#670).
+  [ "$(grep -c '#1011' "$TEST_SKILL_DIR/free.err" || true)" -eq 0 ]
+  [ "$(unread_count alice)" -eq 0 ]
+}
+
 
 # Make ONE team's store unreadable without touching any other team's.
 #


### PR DESCRIPTION
Observation half of #1011, `inbox.sh` site only.

## What changes

`inbox.sh` marked its displayed messages read with the result swallowed whole
(`>/dev/null 2>&1 || true`): under a concurrent writer the mark can lose, and
then the message was **displayed, stayed unread, exit 0, nothing written
anywhere** — the operator's only symptom was the same message reappearing
later, unexplained. The call now reports the failure on stderr:

```
agmsg: failed to mark N displayed message(s) read; they remain unread and will be shown again (#1011)
```

The exit status stays 0 — the inbox did deliver, the rows are still there —
so this is observation only, no behavior change. Applying the #114 retry is a
separate decision, for after this has (or has not) been seen firing outside a
harness.

## What does not change

- `check-inbox.sh:300` has the same swallow but overlaps #677, which owns that
  seam; it is deliberately untouched here.
- `watch.sh` needs nothing: it consumes only IDs it successfully output, so a
  failed consume means redelivery, which is its at-least-once contract (see
  the corrected #1011 body).

## Test

Forces the loss deterministically rather than by timing: a fifo-released
holder keeps `BEGIN IMMEDIATE` until told to let go (a hold that cannot
expire mid-test however slowly the run goes), and the inbox runs only after a
probe write has actually failed — the backgrounded holder existing is not the
lock being held. Asserts all three faces: while held, delivered + reported +
still unread; once released, redelivered + marked + silent. The negative
assertion uses a `grep -c` comparison, not a non-final `! grep -q`, which
cannot fail a bats test (#670).

Suites: test_inbox + test_enforced_assertions, 23/23 on bash 5.3 and 3.2.

Related: #1011 (the observation gap), #1001 (how it was found), #677 (the
opposite direction of the same seam), #114 (where a retry would come from).
