### PR TITLE
fix(remote): connect --e2ee actually bypasses the plaintext-address check

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -2190,7 +2190,14 @@ cmd_connect() {
     esac
   done
   : "${endpoint:?Usage: remote.sh connect --endpoint <url> [--e2ee] <team>}"
-  _remote_validate_endpoint "$endpoint" || exit 1
+  # The plaintext-address rule protects message bodies that would otherwise
+  # cross the network unencrypted. Under --e2ee those bodies are sealed before
+  # they ever reach this check, so the rule has nothing left to protect here --
+  # skip it, exactly as the refusal text itself promises ("connect with --e2ee
+  # so the contents are sealed before they leave this machine").
+  if [ "$e2ee" -eq 0 ]; then
+    _remote_validate_endpoint "$endpoint" || exit 1
+  fi
   endpoint="${endpoint%/}"
   team="${positional[0]:-}"
   [ -n "$team" ] || { echo "agmsg: connect requires a team: remote.sh connect --endpoint <url> [--e2ee] <team>" >&2; exit 1; }

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -150,6 +150,30 @@ skip_if_no_age() {
   [ "$status" -eq 0 ]
 }
 
+@test "connect: without --e2ee, an address outside the allowlist is still refused (control)" {
+  # 0.0.0.0 is not in the private-range allowlist (10/8, 172.16/12, 192.168/16,
+  # 169.254/16, 127/8) and nothing listens on port 1 there, so this fails fast
+  # either way. The control for the next test: plain sync must still refuse it.
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "http://0.0.0.0:1" testteam
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be https://"* ]]
+}
+
+@test "connect --e2ee: an address the plaintext check would refuse is accepted, since e2ee seals the body before it leaves" {
+  skip_if_no_age
+  # Same address as the control above. Without --e2ee this fails validation
+  # before ever reaching the network. The promise in the refusal text itself
+  # ("connect with --e2ee so the contents are sealed before they leave this
+  # machine") is that --e2ee is an independent way to satisfy this, not
+  # something layered on top of an address that already passed -- so under
+  # --e2ee this must get past the check and fail at the network instead, for
+  # an unrelated reason (nothing listens on 0.0.0.0:1), never for the address.
+  run bash "$SCRIPTS/remote.sh" connect --endpoint "http://0.0.0.0:1" --e2ee testteam
+  [ "$status" -ne 0 ]
+  refute grep -qF 'must be https://' <<<"$output"
+  grep -qF 'agmsg: connect failed' <<<"$output"
+}
+
 # --- #143: a connect that already registered must not dead-end -------------
 #
 # Registration commits on the server in one transaction, and the binding is


### PR DESCRIPTION
Fixes #1018.

## What

`remote.sh connect --e2ee` promised to permit an endpoint outside the plaintext HTTP allowlist because age-v1 seals message bodies before they leave the machine, but two unconditional checks contradicted that promise:

1. `cmd_connect` rejected the endpoint before consulting `--e2ee`.
2. After registration, `connectedBinding()` re-applied the same plaintext-address rule while building the initial snapshot and on every later sync cycle.

The first failure was immediate. The second was worse: registration had already recorded the binding before the sync engine failed.

## Fix

- In `cmd_connect`, run `_remote_validate_endpoint` only for plaintext connections.
- In `connectedBinding()`, use the binding's recorded `cipher_profile` as the source of truth:
  - `age-v1`: the message body is sealed, so the plaintext-address rule does not apply.
  - every other profile: keep requiring HTTPS or private-address HTTP.

This keeps all six `connectedBinding()` call sites consistent without threading a caller-supplied flag through them.

## Tests

Added three regression cases to `tests/test_remote.bats`:

- plaintext connect still refuses an address outside the allowlist;
- `connect --e2ee` gets past that refusal;
- `connect --e2ee` against `http://0.0.0.0:$MOCK_PORT` completes registration and one full engine cycle, proven by the emitted `sync_cycle_stamp`.

Verification against the PR merged onto current `main` (`ac00fbe`):

- `bats tests/test_remote.bats tests/test_endpoint_scheme.bats tests/test_endpoint_table_node.bats`: 158/158 passed
- `bats tests/test_enforced_assertions.bats`: 9/9 passed
- assertion, errexit-status, unguarded-env, internal-name-shape, and CLI-routing static checks passed
- GitHub Actions: 27/27 checks passed

## Environment

Found while connecting two machines over Tailscale. Its CGNAT range (`100.64.0.0/10`) is outside the hardcoded private-range list, so a Tailscale-only pair had no usable plaintext path and `--e2ee`, the documented alternative, did not work end to end.