### PR TITLE
ci: run tests and version checks on every integration branch, not a named list

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,10 @@ name: tests
 # names because a list goes quiet exactly when a new integration branch
 # appears: a PR onto an unlisted base has no required checks, so GitHub reports
 # `mergeStateStatus: CLEAN` -- "nothing to check", not "everything checked" --
-# and that reads as green in every summary view (measured 2026-08-31). The suite is
+# and the PR's summary status alone cannot tell those apart (measured
+# 2026-08-31). The detail views can: `gh pr checks`, `gh run list` and the
+# Checks tab all show zero runs. That is why the merge gate reads a run whose
+# headSha matches the head being merged, and never the PR's status. The suite is
 # fast (~2 min) and this repo is public, so GitHub-hosted runners are free —
 # running everything every time is simpler and safer than selectively running
 # "only the changed tests", which would miss regressions in shared libs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,11 @@
 name: tests
 
-# Run the full Bats suite on PRs targeting main or integration/remote and on
-# pushes to main. The suite is
+# Run the full Bats suite on PRs targeting main or any `integration/**` branch,
+# and on pushes to main. The filter is a pattern rather than a list of branch
+# names because a list goes quiet exactly when a new integration branch
+# appears: a PR onto an unlisted base has no required checks, so GitHub reports
+# `mergeStateStatus: CLEAN` -- "nothing to check", not "everything checked" --
+# and that reads as green in every summary view (measured 2026-08-31). The suite is
 # fast (~2 min) and this repo is public, so GitHub-hosted runners are free —
 # running everything every time is simpler and safer than selectively running
 # "only the changed tests", which would miss regressions in shared libs
@@ -49,7 +53,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, integration/remote]
+    branches: [main, 'integration/**']
 
 permissions:
   contents: read

--- a/.github/workflows/verify-versions.yml
+++ b/.github/workflows/verify-versions.yml
@@ -6,18 +6,25 @@
 
 name: verify-versions
 
-# `integration/remote` is here because releases are cut from it. Every
-# prerelease so far -- 1.2.0-rc.1 through rc.3 -- was cut from that branch, so
-# its release PR targeted `integration/remote` and this check never ran on any
-# of them. `release.yml` runs the same `--check` at tag time and would have
-# stopped a bad tag, so nothing shipped out of sync; the cost was that the
-# failure would have surfaced at publish instead of at review, on a branch
-# nobody could see it coming from (#679).
+# Integration branches are here because releases are cut from them. Every
+# prerelease through 1.2.0-rc.3 was cut from `integration/remote`, so its
+# release PR targeted that branch and this check never ran on any of them.
+# `release.yml` runs the same `--check` at tag time and would have stopped a
+# bad tag, so nothing shipped out of sync; the cost was that the failure would
+# have surfaced at publish instead of at review, on a branch nobody could see
+# it coming from (#679).
+#
+# The filter is `integration/**`, not one branch name, because naming them one
+# at a time is a gate that goes quiet exactly when a new one appears: a PR onto
+# an unlisted base reports `mergeStateStatus: CLEAN`, which means "nothing to
+# check", not "everything checked" -- indistinguishable from a green run in
+# every summary view (measured 2026-08-31 on a PR retargeted onto a fresh
+# integration branch).
 on:
   push:
-    branches: [main, integration/remote]
+    branches: [main, 'integration/**']
   pull_request:
-    branches: [main, integration/remote]
+    branches: [main, 'integration/**']
 
 jobs:
   check:

--- a/.github/workflows/verify-versions.yml
+++ b/.github/workflows/verify-versions.yml
@@ -17,9 +17,10 @@ name: verify-versions
 # The filter is `integration/**`, not one branch name, because naming them one
 # at a time is a gate that goes quiet exactly when a new one appears: a PR onto
 # an unlisted base reports `mergeStateStatus: CLEAN`, which means "nothing to
-# check", not "everything checked" -- indistinguishable from a green run in
-# every summary view (measured 2026-08-31 on a PR retargeted onto a fresh
-# integration branch).
+# check", not "everything checked". The PR's summary status alone does not
+# separate those two (measured 2026-08-31 on a PR retargeted onto a fresh
+# integration branch); the detail views do, which is the reason a merge is
+# gated on a run whose headSha matches the head rather than on that status.
 on:
   push:
     branches: [main, 'integration/**']


### PR DESCRIPTION
`tests.yml` and `verify-versions.yml` both filtered pull requests by an explicit list of base branches:

```yaml
pull_request:
  branches: [main, integration/remote]
```

A PR whose base is not on that list matches no workflow, so no job runs and no required check is ever reported. GitHub then answers `mergeStateStatus: CLEAN` for that PR, because there is nothing outstanding.

**`CLEAN` there means "nothing to check", not "everything checked", and the PR's summary status alone does not separate the two.** Observed while retargeting an open PR onto a newly cut integration branch: the PR had a red suite on its previous base (two macOS shards failing), and after the retarget reported `MERGEABLE / CLEAN` without a single job having run. Nothing about the diff had changed.

The detail views do separate them — `gh pr checks`, `gh run list` and the Checks tab all show zero runs — which is why a merge is gated on a run whose `headSha` equals the head being merged rather than on the PR's status. That is the accurate shape of the problem: the summary status is not a safeguard here, so the trigger has to be right in the first place.

Naming integration branches one at a time makes that the default behaviour every time a new one is cut — the gate goes quiet exactly when a branch is new enough that nobody has looked at it yet. `verify-versions.yml`'s own header already records a previous instance: every prerelease through 1.2.0-rc.3 was cut from `integration/remote` before that branch was added to the filter, so the check never ran on any of their release PRs (#679).

## Change

Both workflows match `integration/**` instead of a list. GitHub's branch glob `**` spans slashes, so multi-segment integration names are covered too. `verify-versions.yml`'s `push:` filter is widened the same way, for the reason its own comment gives — releases are cut from these branches.

Both headers now record why the filter is a pattern, so the next person adding an integration branch does not have to rediscover that a list has a silent failure mode.

No job definitions change and no publish surface is added; this only widens which events reach the existing jobs.
