### PR TITLE
docs(skill): route agent-to-agent messages through agmsg, not the host CLI's own

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -7,6 +7,20 @@ description: Cross-agent messaging via SQLite. Send messages between Claude Code
 
 **IMPORTANT: Always use the provided scripts. NEVER directly read or edit config files, DB, or team data. There is NO register.sh — use join.sh to join a team.**
 
+**Use agmsg, not the host agent's own inter-session messaging.** Several agent
+CLIs ship a native way for one session to message another on the same machine
+(in Claude Code, the `SendMessage` / `ListAgents` tools over its peer-session
+list). While a project is on agmsg, route agent-to-agent messages through agmsg
+instead. A message sent natively does not exist as far as agmsg is concerned:
+it is absent from `history.sh` and the team's export, it never reaches a member
+on another machine through remote sync, it does not mark read or advance any
+cursor, and it cannot address a member whose CLI is a different type. Half the
+conversation living somewhere unrecorded is worse than either channel alone,
+and the gap is invisible until someone reads the history and finds a decision
+with no message behind it. The native channel stays fine for anything outside
+the team — a subagent you spawned for your own task, or a session that has not
+joined.
+
 **Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/agmsg/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
 
 ## How to use


### PR DESCRIPTION
Several agent CLIs ship a native way for one session to message another on the same machine. Claude Code has `SendMessage` / `ListAgents` over its peer-session list; other CLIs have their own.

Nothing today tells an agent which channel to prefer, and the two are easy to mix without noticing, because the native one is right there in the tool list and needs no team, no join, and no arguments.

A message sent natively does not exist as far as agmsg is concerned:

- it is absent from `history.sh` and from a team export
- it never reaches a member on another machine through remote sync
- it marks nothing read and advances no cursor
- it cannot address a member whose CLI is a different type

**The failure is quiet.** Nothing errors and no message is lost from the sender's point of view — the history simply ends up with a decision in it and no message behind it, which is only noticed much later by whoever reads it back.

This states the precedence in SKILL.md, next to the other two rules an agent reads before doing anything, and says where the native channel is still fine: anything outside the team — a subagent spawned for one's own task, or a session that has not joined.

Documentation only; no script changes.
