### PR TITLE
fix(check-inbox): consume the rows after the payload is written, not before (#677)

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -38,10 +38,16 @@ POSTTOOL_OUTPUT="$(agmsg_type_get "$TYPE" posttooluse_output 2>/dev/null || true
 # SILENT: codex 0.149.1 treats malformed post-tool-use JSON as a failure, and an
 # empty additionalContext on every tool call would be pure noise — so a no-op
 # turn emits no bytes, which every runtime reads as "hook did nothing".
+# Status of the write that hands a payload over. Declared before the first emit
+# (the cooldown one) so EVERY emit in this file reports through the same
+# variable: "each emit says whether it worked" is checkable, while "the emits
+# that can carry a message are guarded" needs the next reader to work out which
+# ones those are -- and that is how one of three ends up unguarded.
+EMIT_RC=0
 emit_status_json() {
   [ "$EVENT" = "PostToolUse" ] && return 0
   [ "$STOP_OUTPUT" = "json" ] || return 0
-  printf '{\n  "continue": true,\n  "systemMessage": "%s"\n}\n' "$1"
+  printf '{\n  "continue": true,\n  "systemMessage": "%s"\n}\n' "$1" || EMIT_RC=$?
 }
 
 # Hook runtimes that pass JSON do so on stdin. Interactive invocations such as
@@ -217,6 +223,9 @@ agmsg_storage_load
 # poll was partial; only when there is nothing to deliver does the status carry
 # the failure.
 OUTPUT=""
+# Ids that have been FORMATTED but not yet written out: one "team<TAB>id id id"
+# entry per team. They become read only after the payload leaves this process.
+PENDING_MARKS=()
 LOOP_RC=0
 LOOP_FAILED_TEAM=""
 for team in "${TEAM_LIST[@]}"; do
@@ -333,8 +342,10 @@ for team in "${TEAM_LIST[@]}"; do
   # ADDITIVE: it may show a message earlier, but Stop still fetches, shows, and
   # consumes it as before. A duplicate display is harmless; an invisible loss is
   # not.
+  # DEFERRED, not skipped: what was formatted is remembered here and consumed
+  # after the payload has actually left this process. See the emit below (#677).
   if [ "$EVENT" != "PostToolUse" ] && [ "${#IDS[@]}" -gt 0 ]; then
-    storage_mark_read_batch "$team" "$AGENT" "${IDS[@]}" >/dev/null 2>&1 || true
+    PENDING_MARKS+=("$team"$'\t'"${IDS[*]}")
   fi
 done
 
@@ -375,17 +386,69 @@ if [ -n "$OUTPUT" ]; then
     # unverified part (see PR): this is the shape the 0.149.1 parser accepts.
     case "$POSTTOOL_OUTPUT" in
       hookSpecificOutput)
-        printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"%s"}}\n' "$ESCAPED"
+        printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"%s"}}\n' "$ESCAPED" || EMIT_RC=$?
         ;;
-      *) : ;;
+      # Emitted nothing (no known shape for this event), which is not the same
+      # fact as "emitted and it worked". EMIT_RC is left at 0 because there is
+      # nothing to protect: this branch reaches the consume loop with an empty
+      # PENDING_MARKS, exactly as the line above it does.
+      *) EMIT_RC=0 ;;
     esac
   else
-    cat <<ENDJSON
+    cat <<ENDJSON || EMIT_RC=$?
 {
   "decision": "block",
   "reason": "$ESCAPED"
 }
 ENDJSON
+  fi
+  # A test-only observation point, and the reason it has to be HERE rather than
+  # in the test: the failure this ordering exists for makes stdout unwritable, so
+  # the run that matters cannot report on itself through the payload. Running the
+  # hook a second time with a writable stdout shows that OTHER process reached
+  # the write; it says nothing about this one. The exit status goes in with it,
+  # so a test can tell "reached the emit and it failed" from "reached the emit
+  # and it worked" -- otherwise a control here would be satisfied by the happy
+  # path it is meant to exclude.
+  if [ -n "${AGMSG_TEST_MARK_BARRIER:-}" ]; then
+    printf '%s\n' "$EMIT_RC" > "$AGMSG_TEST_MARK_BARRIER.emitted"
+  fi
+  # THE PAYLOAD HAS NOW LEFT THIS PROCESS. Only here do the rows it carried stop
+  # being unread (#677).
+  #
+  # Both emits above set EMIT_RC, including the PostToolUse one that has nothing
+  # to consume today -- `PENDING_MARKS` is only filled when EVENT is not
+  # PostToolUse. Guarding only the branch that currently matters would make the
+  # invariant "the one emit that counts happens to be the guarded one" instead of
+  # "every emit reports whether it worked", and the day PostToolUse starts
+  # consuming, the guard would not cover it and nothing would say so.
+  #
+  # Before this, the mark happened while the messages were still sitting in a
+  # shell variable: "displayed" meant "formatted", not "written". watch.sh has had
+  # the right shape all along -- it consumes only the ids whose `printf`
+  # succeeded -- and this brings the third path to it.
+  #
+  # WHAT THIS PROVES, EXACTLY: that the write to this process's stdout returned
+  # success. It does NOT prove the hook runtime parsed the payload, or that the
+  # model received it. A runtime that rejects what it was handed leaves the write
+  # successful and the rows consumed, exactly as before -- which is why #1015
+  # (a Windows login shell prepending profile output, so the JSON is rejected) is
+  # NOT fixed by this ordering. Claiming otherwise would be claiming more than the
+  # exit status can carry.
+  #
+  # The reverse risk is accepted deliberately. If the write succeeds and the mark
+  # fails, the message is offered twice; if the mark precedes a failed write, it
+  # is offered never. The two are not equal -- a duplicate is visible and a
+  # silence is not -- so the failure is placed on the side the user can see.
+  if [ "${EMIT_RC:-0}" -eq 0 ]; then
+    for _pending in ${PENDING_MARKS[@]+"${PENDING_MARKS[@]}"}; do
+      _p_team="${_pending%%$'\t'*}"
+      _p_ids="${_pending#*$'\t'}"
+      [ -n "$_p_team" ] && [ -n "$_p_ids" ] || continue
+      # word-split on purpose: $_p_ids is the space-joined id list for this team
+      # shellcheck disable=SC2086
+      storage_mark_read_batch "$_p_team" "$AGENT" $_p_ids >/dev/null 2>&1 || true
+    done
   fi
   # Exit 0 even when the poll failed part-way: this is the delivering path, and
   # a non-zero status here throws the delivery away.

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -3306,3 +3306,109 @@ JSON
   run bash -c "printf '%s\n' \"\$1\" | grep -q 'taken by the watcher'" _ "$output"
   [ "$status" -ne 0 ] || { echo "the hook re-offered a consumed message" >&2; return 1; }
 }
+
+# --- #677: the rows are consumed only after the payload is written ------------
+#
+# The hook formatted its messages into a variable, marked them read, and only
+# then wrote them out. Anything that went wrong in between consumed the rows and
+# showed the user nothing — the message still in `history.sh`, gone from
+# `inbox.sh`, looking exactly like a delivery failure.
+#
+# The pair below is the whole claim: identical setup, the only difference being
+# whether the write can succeed.
+@test "check-inbox: a message whose payload was written is consumed (#677)" {
+  bash "$SCRIPTS/join.sh" testteam alice codex "$TEST_PROJECT"
+  bash "$SCRIPTS/join.sh" testteam bob   codex "$TEST_PROJECT"
+  bash "$SCRIPTS/config.sh" set delivery.turn.check_interval 0 >/dev/null
+  bash "$SCRIPTS/send.sh" testteam bob alice "written and consumed"
+
+  run bash -c "echo '{}' | bash '$SCRIPTS/check-inbox.sh' codex '$TEST_PROJECT'"
+  [ "$status" -eq 0 ]
+  # `grep -Fq`, not `[[ =~ ]]`: a non-final [[ ]] cannot fail a test on bash 3.2
+  # (#670), and this is the assertion that watches the whole change -- a payload
+  # that lost its message body while the mark still succeeded would otherwise sit
+  # green next to the "No new messages" below.
+  printf '%s' "$output" | grep -Fq "written and consumed"
+
+  # Consumed: a second look offers nothing.
+  run bash "$SCRIPTS/inbox.sh" testteam alice
+  printf '%s' "$output" | grep -Fq "No new messages"
+}
+
+@test "check-inbox: a message whose payload could not be written stays unread (#677)" {
+  bash "$SCRIPTS/join.sh" testteam alice codex "$TEST_PROJECT"
+  bash "$SCRIPTS/join.sh" testteam bob   codex "$TEST_PROJECT"
+  bash "$SCRIPTS/config.sh" set delivery.turn.check_interval 0 >/dev/null
+  bash "$SCRIPTS/send.sh" testteam bob alice "must survive an unwritable stdout"
+
+  # stdout CLOSED, so the write of the payload fails. Everything else is the same
+  # as the test above — which is what makes this a comparison and not a smoke
+  # test.
+  #
+  # The barrier variable names a prefix, not a wait: `.release` is created first
+  # so the run never blocks on it. What it buys is two markers the run leaves
+  # behind — `.reached` when the rows are formatted and `.emitted` when the emit
+  # has been attempted — because a run whose stdout is closed cannot tell the
+  # test anything through the payload, and "the message is unread" is equally
+  # true of a run that did nothing at all.
+  local barrier="$BATS_TEST_TMPDIR/mark-barrier"
+  : > "$barrier.release"
+  AGMSG_TEST_MARK_BARRIER="$barrier" \
+    run bash -c "echo '{}' | bash '$SCRIPTS/check-inbox.sh' codex '$TEST_PROJECT' >&-"
+
+  # THE control, and it is taken inside the run that failed: `.emitted` is
+  # written immediately after the emit, so its existence says THIS run reached
+  # the write, and the status it carries says the write is what failed.
+  #
+  # Two weaker forms were tried and both are recorded here because each looks
+  # sufficient. A barrier before the mark proves only that the rows were
+  # FORMATTED. Re-running the hook with a writable stdout proves that a
+  # DIFFERENT process reached the write — a separate run succeeding is not
+  # evidence about this one. Neither excludes the case this test exists to
+  # exclude: an early exit that leaves the message unread for a reason that has
+  # nothing to do with the write.
+  [ -e "$barrier.emitted" ]
+  # Not just "it got there" — it got there and FAILED. Without this the happy
+  # path satisfies the line above.
+  [ "$(cat "$barrier.emitted")" != "0" ]
+
+  # Implied by `.emitted` (the emit sits inside `if [ -n "$OUTPUT" ]`), kept
+  # because it fails nearer the cause when the run stops before formatting.
+  [ -e "$barrier.reached" ]
+
+  # And the row itself survived intact — still deliverable, with its body. This
+  # is a claim about the ROW, not about the failed run. Asserted BEFORE any
+  # `inbox.sh`: inbox displays AND consumes, so reading it first would take the
+  # row away and leave this measuring its own side effect. (Measured — that is
+  # exactly what the first draft of this test did.)
+  run bash -c "echo '{}' | bash '$SCRIPTS/check-inbox.sh' codex '$TEST_PROJECT'"
+  [ "$status" -eq 0 ]
+  printf '%s' "$output" | grep -Fq "must survive an unwritable stdout"
+
+  # ...and now it is consumed, by the run that could write it.
+  run bash "$SCRIPTS/inbox.sh" testteam alice
+  printf '%s' "$output" | grep -Fq "No new messages"
+}
+
+# The fact the emit guards lean on: mid-turn delivery shows a message but does
+# not consume it, so the PostToolUse branch reaches the consume loop with nothing
+# pending. Unpinned, that stops being true the moment someone makes PostToolUse
+# mark read — and the guard comments would then be describing a tree that no
+# longer exists (#1003/#677).
+@test "check-inbox (PostToolUse): shows a message without consuming it (#1003)" {
+  bash "$SCRIPTS/join.sh" testteam alice codex "$TEST_PROJECT"
+  bash "$SCRIPTS/join.sh" testteam bob   codex "$TEST_PROJECT"
+  bash "$SCRIPTS/config.sh" set delivery.turn.check_interval 0 >/dev/null
+  bash "$SCRIPTS/send.sh" testteam bob alice "mid-turn, still unread"
+
+  run bash -c "echo '{}' | bash '$SCRIPTS/check-inbox.sh' codex '$TEST_PROJECT' PostToolUse"
+  [ "$status" -eq 0 ]
+  # Positive control: it really did deliver. Without this, the assertion below
+  # also passes when the hook did nothing at all.
+  printf '%s' "$output" | grep -Fq "mid-turn, still unread"
+  printf '%s' "$output" | grep -Fq "hookSpecificOutput"
+
+  # ...and the row is still there for Stop to deliver and consume.
+  run bash "$SCRIPTS/inbox.sh" testteam alice
+  printf '%s' "$output" | grep -Fq "mid-turn, still unread"
+}


### PR DESCRIPTION
Refs #677 — deliberately not `Fixes`. This narrows the window the report
describes; it does not establish that the window is what the reporter hit, and
#1015 (below) is untouched. Closing #677 is a judgement to make after reading
**What this does not fix**, not something a merge should do on its own.

## The defect

`check-inbox.sh` built its message text into a shell variable, marked the rows
read, and only then wrote them out. At the mark, nothing had left the process, so a
write that then failed consumed the rows and displayed nothing.

From a user's seat that is a delivery failure with no error: the message sits in
`history.sh` and is gone from `inbox.sh`. That is exactly what #677 reports, on a
single session, with no other consumer running.

The two other paths that advance read state never had this shape:

| | order |
|---|---|
| `inbox.sh` | read → print → mark |
| `watch.sh` | read → print, and consume **only the ids whose `printf` succeeded** |
| `check-inbox.sh` | read → **mark** → print |

`watch.sh` is the model, and this brings the third path to the same contract.

## The change

Ids collected while formatting go into `PENDING_MARKS`; they are consumed after
the payload is emitted, and only if the emit succeeded.

A comment above the old mark said the ids were "collected from the rows actually
displayed". True of *which* ids, false about *when* — "displayed" meant
"formatted". That sentence is why the ordering read as deliberate, so it has been
corrected rather than left standing.

## What this proves — and what it does not

The new order establishes exactly one thing: **the write to this process's stdout
returned success.** It says nothing about whether the hook runtime parsed the
payload, or whether the model received it. A runtime that rejects what it was
handed leaves the write successful and the rows consumed, just as before.

So this narrows the window between formatting and handing over. It does not make
delivery verified, and the PR should not be read as claiming that.

## The direction of the remaining risk, chosen deliberately

If the write succeeds and the mark fails, the message is offered twice. Under the
old order, a failed write meant it was offered never. These are not symmetric:

- **twice** — visible; the user sees a duplicate and the failure is reportable
- **never** — indistinguishable from a lost message

The failure now lands on the side a user can see and act on.

## Tests

Two, differing in exactly one thing — whether stdout can be written:

- payload written → the message appears **and** is consumed
- stdout closed → the message is **still offered**, asserted on its text (a
  version that emptied the store would pass a mere "something is unread")

The second one needs a positive control, and the control has to be an observation
**of the run that failed**. That run's stdout is gone, so it cannot report on
itself through the payload — which is why the observation point sits in the
script, immediately after the emit, and records the emit's status along with the
fact that it was reached (`<prefix>.emitted`, written only when the test-only
`AGMSG_TEST_MARK_BARRIER` is set; the file already carried a `.reached` marker
before this change).

Two weaker controls were written first, and each looked sufficient on its own.
They are named here because the failure they share is easy to repeat:

| control | what it actually proves |
|---|---|
| a marker placed before the mark | the rows were **formatted** |
| re-running the hook with a writable stdout | a **different process** reached the write |

Neither excludes what the test exists to exclude — an early exit, which leaves
the message unread for a reason that has nothing to do with the write. An earlier
revision of this description credited the second one with proving the failing run
reached the emit; it does not, and that claim was wider than the control.

Calibrated with three mutations, each red in a different place, and the
payload-written test green through all three:

| mutation | where it goes red |
|---|---|
| the emit guard removed (consume whatever the emit did) | the message is gone |
| `exit` before the emit | `.emitted` is absent |
| the seam reporting success regardless of the emit | the recorded status is `0` |

A third test pins the premise the emit guards rely on: a PostToolUse poll
delivers a message and leaves it unread.

All assertions use `grep -Fq` or `[ ]`, not `[[ =~ ]]`: a non-final `[[ ]]` cannot
fail a test on bash 3.2 (#670), and the assertion watching this change was one of
them. `check-enforced-assertions` reports 635, exactly the baseline.

`test_delivery` 193 passed / 0 failed. `test_inbox`, `test_messaging` unchanged
and green.

## What this does not fix

#1015 — on Windows the hook is launched through a login shell, so profile output
is prepended to this same payload and the runtime rejects the whole thing.

**This change does not help that path at all.** The shell's write still succeeds,
so the rows are still consumed and still never displayed. An earlier draft of
this description said those rows would survive; that was wrong, and it was
claiming more than an exit status can carry. #1015 is a different failure and
needs a different fix.

Nor does it establish that this ordering is what #677's reporter hit. The
mechanism is fixed because it is wrong on every platform, not because it was
measured firing there.

