### PR TITLE
feat(pi): add Pi as a bundled agent type with in-process delivery

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -13,7 +13,7 @@
 
 ## バグ報告と機能要望
 
-[`fujibee/agmsg`](https://github.com/fujibee/agmsg/issues) に issue を立てる。agmsg のバージョン、ホストエージェント(Claude Code / Codex / Gemini CLI / Antigravity)、可能なら最小の再現手順を含めること。
+[`fujibee/agmsg`](https://github.com/fujibee/agmsg/issues) に issue を立てる。agmsg のバージョン、ホストエージェント(Claude Code / Codex / Gemini CLI / Antigravity / Pi)、可能なら最小の再現手順を含めること。
 
 ## プルリクエスト
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thanks for considering a contribution! agmsg is a small project; this guide is i
 
 ## Reporting bugs and requesting features
 
-Open an issue on [`fujibee/agmsg`](https://github.com/fujibee/agmsg/issues). Include the agmsg version, the host agent (Claude Code / Codex / Gemini CLI / Antigravity), and a minimal reproduction if possible.
+Open an issue on [`fujibee/agmsg`](https://github.com/fujibee/agmsg/issues). Include the agmsg version, the host agent (Claude Code / Codex / Gemini CLI / Antigravity / Pi), and a minimal reproduction if possible.
 
 ## Pull requests
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@ CLI AI エージェント間のクロスエージェントメッセージング�
 # 1. インストール — npxが最速の道、クローン不要
 npx agmsg
 
-# 2. Claude Code / Codex / Gemini CLI / Antigravity / OpenCode を再起動して新しいスキルを反映
+# 2. Claude Code / Codex / Gemini CLI / Antigravity / OpenCode / Pi を再起動して新しいスキルを反映
 
 # 3. コマンドを実行 — 初回はチーム名とエージェント名を尋ねられる
 #    Claude Code:  /agmsg
@@ -121,7 +121,7 @@ cd agmsg
 
 `--cmd` と `--agent-type` は直接スクリプト経路でのみ利用可能。`npm` とプラグインの経路は常に `agmsg` としてインストールされ、ホストのエージェントタイプを自動検出する。
 
-インストール後、**エージェントを再起動**して（Claude Code / Codex / Gemini CLI / Copilot CLI / Antigravity / OpenCode）新しいスキルを反映させる。
+インストール後、**エージェントを再起動**して（Claude Code / Codex / Gemini CLI / Copilot CLI / Antigravity / OpenCode / Pi）新しいスキルを反映させる。
 
 ### Windows: Git Bash と Codex
 
@@ -210,7 +210,7 @@ codex:
   --dangerously-skip-permissions: false  # `false`の値はフラグ自体を出力しない
 ```
 
-9種類のエージェントタイプのうち8つがspawn可能 — `claude-code`、`codex`、`grok-build`、`cursor`、`gemini`、`antigravity`、`copilot`、`opencode`。`hermes` は不可 — そのCLIには初期プロンプトを事前に仕込んだインタラクティブセッションを開始するモードがない（#279）。macOSが主なターゲットで、LinuxとWindowsはベストエフォート（ターミナルが未対応の場合はissueまたはPRを歓迎）。ヘッドレス環境 — tmuxもなく使えるターミナルもない — はエージェントCLIがインタラクティブなターミナルを必要とするためエラーになる。
+10種類のエージェントタイプのうち9つがspawn可能 — `claude-code`、`codex`、`grok-build`、`cursor`、`gemini`、`antigravity`、`copilot`、`opencode`、`pi`。`hermes` は不可 — そのCLIには初期プロンプトを事前に仕込んだインタラクティブセッションを開始するモードがない（#279）。macOSが主なターゲットで、LinuxとWindowsはベストエフォート（ターミナルが未対応の場合はissueまたはPRを歓迎）。ヘッドレス環境 — tmuxもなく使えるターミナルもない — はエージェントCLIがインタラクティブなターミナルを必要とするためエラーになる。
 
 ### spawnしたエージェントを終了する（`despawn`）
 
@@ -313,6 +313,16 @@ $agmsg
 これによりOpenCodeは、Ollamaのようなローカルプロバイダーを使う構成を含め、ローカルのコーディングエージェントとして役立つ。
 
 完全なセットアップ手順は [docs/opencode.md](docs/opencode.md) を参照。
+
+### Pi
+
+```
+/agmsg
+```
+
+`./install.sh` でインストールする（`~/.pi/` が存在する場合、Pi向けスキルが `~/.pi/agent/skills/agmsg/SKILL.md` に、デフォルトのCodex向け共有スキルと並んで自動的に配置される）。`--agent-type pi` はCodexがインストールされていないPi専用環境でのみ使う。Piは `mode turn`（エージェントがsettleしたときにinboxを確認）、`mode monitor`（プロセス内15秒ポーリング — Piのセッションストアにはwriter leaseがあるため外部ウォッチャーでは注入できない）、`mode off` に対応。`spawn pi` は利用可能。`both` は非対応。
+
+完全なセットアップ手順は [docs/pi.md](docs/pi.md) を参照。
 
 ### シェル（任意のエージェント）
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In real use it looks like this — Claude Code asking Codex for a code review an
 # 1. Install — npx is the fastest path, no clone needed
 npx agmsg
 
-# 2. Restart Claude Code / Codex / Gemini CLI / Antigravity / OpenCode to pick up the new skill
+# 2. Restart Claude Code / Codex / Gemini CLI / Antigravity / OpenCode / Pi to pick up the new skill
 
 # 3. Run the command — it will prompt for team and agent name on first use
 #    Claude Code:  /agmsg
@@ -121,7 +121,7 @@ The **command name** determines:
 
 `--cmd` and `--agent-type` are only available via the direct-script path; the `npm` and plugin paths always install as `agmsg` and auto-detect the host agent type.
 
-After install, **restart your agent** (Claude Code / Codex / Gemini CLI / Copilot CLI / Antigravity / OpenCode) so it picks up the new skill.
+After install, **restart your agent** (Claude Code / Codex / Gemini CLI / Copilot CLI / Antigravity / OpenCode / Pi) so it picks up the new skill.
 
 ### Windows: Git Bash & Codex
 
@@ -211,7 +211,7 @@ codex:
   --dangerously-skip-permissions: false  # a `false` value suppresses the flag entirely
 ```
 
-Eight of the nine agent types are spawnable — `claude-code`, `codex`, `grok-build`, `cursor`, `gemini`, `antigravity`, `copilot`, `opencode`. `hermes` is not: its CLI has no mode that starts an interactive session pre-seeded with an initial prompt (#279). macOS is the primary target; Linux and Windows are best-effort (please open an issue/PR if your terminal isn't handled). Headless environments — no tmux **and** no usable terminal — error out, since the agent CLIs need an interactive terminal.
+Nine of the ten agent types are spawnable — `claude-code`, `codex`, `grok-build`, `cursor`, `gemini`, `antigravity`, `copilot`, `opencode`, `pi`. `hermes` is not: its CLI has no mode that starts an interactive session pre-seeded with an initial prompt (#279). macOS is the primary target; Linux and Windows are best-effort (please open an issue/PR if your terminal isn't handled). Headless environments — no tmux **and** no usable terminal — error out, since the agent CLIs need an interactive terminal.
 
 ### Tear down a spawned agent (`despawn`)
 
@@ -327,6 +327,16 @@ Install with `./install.sh` (when `~/.config/opencode/` exists, the OpenCode-typ
 This makes OpenCode useful as a local coding agent, including configurations backed by local providers such as Ollama.
 
 See [docs/opencode.md](docs/opencode.md) for full setup instructions.
+
+### Pi
+
+```
+/agmsg
+```
+
+Install with `./install.sh` (when `~/.pi/` exists, the Pi-typed skill is placed at `~/.pi/agent/skills/agmsg/SKILL.md` alongside the default Codex-typed shared skill). Use `--agent-type pi` only for Pi-only environments where Codex is not installed. Pi supports `mode turn` (inbox check when the agent settles), `mode monitor` (in-process 15s poll — Pi's session store has a writer lease, so an external watcher cannot inject), and `mode off`. `spawn pi` is available. `both` is not supported.
+
+See [docs/pi.md](docs/pi.md) for full setup instructions.
 
 ### Shell (any agent)
 

--- a/docs/agent-types.md
+++ b/docs/agent-types.md
@@ -1,7 +1,7 @@
 # Agent types
 
 agmsg supports several agent runtimes — claude-code, codex, gemini, antigravity,
-copilot, opencode, hermes, cursor — and each is described by a small **manifest** so that the rest
+copilot, opencode, hermes, cursor, grok-build, pi — and each is described by a small **manifest** so that the rest
 of agmsg (detection, the join whitelist, spawn, and delivery routing) discovers it
 from data instead of hardcoded `case` arms.
 

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -1,0 +1,78 @@
+# agmsg for Pi
+
+Pi ([earendil-works/pi](https://github.com/earendil-works/pi)) supports **turn, monitor, and off** delivery through a project-local extension. `both` is not supported. `spawn pi` launches the `pi` CLI.
+
+Pi's session store takes a SQLite writer lease, so an external process cannot inject into the live TUI (`pi --print` from a watcher would contend for that lease). Incoming messages are delivered **in-process**: `delivery.sh` writes `.pi/extensions/agmsg.ts`, which either checks the inbox when the agent settles (`turn`) or polls unread messages on a ~15s timer (`monitor`) and injects them with `pi.sendMessage({ triggerTurn: true, deliverAs: "steer" })`.
+
+## Install
+
+**Alongside Codex (typical setup):**
+
+```bash
+bash <(curl -fsSL https://agmsg.cc/install.sh)
+```
+
+When `~/.pi/` already exists, the installer automatically places a Pi-typed
+`SKILL.md` at `~/.pi/agent/skills/agmsg/SKILL.md` without touching the shared
+`~/.agents/skills/agmsg/SKILL.md` (which stays Codex-typed). This is the
+recommended approach for mixed Codex + Pi teams.
+
+**Pi-only (no Codex):**
+
+```bash
+bash <(curl -fsSL https://agmsg.cc/install.sh) --agent-type pi
+```
+
+`--agent-type pi` overwrites the shared `~/.agents/skills/agmsg/SKILL.md` with
+the Pi template. Use this only when Codex is **not** installed; it will break
+Codex identification if both agents share the same `~/.agents/` path.
+
+From a local clone, substitute `bash <(curl ...)` with `./install.sh`.
+
+Pi skill search order (later locations win on name collision):
+
+1. `.pi/skills/` — project-local
+2. `~/.pi/agent/skills/<name>/SKILL.md` — global Pi skills ← installed here
+3. `~/.agents/skills/<name>/SKILL.md` — agent-compatible fallback (Codex-typed)
+
+## Join a team
+
+From Pi, run:
+
+```
+/agmsg
+```
+
+On first run it prompts for a team name and agent name, then joins you to the
+team. Choose delivery mode `turn`, `monitor`, or `off` when prompted. Then
+`/reload` (or restart Pi) so the project extension is picked up.
+
+Or join directly from the shell:
+
+```bash
+~/.agents/skills/agmsg/scripts/join.sh <team> <agent_name> pi "$(pwd)"
+~/.agents/skills/agmsg/scripts/delivery.sh set turn pi "$(pwd)"
+```
+
+## Delivery modes
+
+| mode | mechanism |
+|---|---|
+| **`turn`** (default) | Extension runs `inbox.sh` on `agent_settled` |
+| **`monitor`** | Extension polls unread messages every 15s and injects them into the session |
+| **`off`** | The extension file is removed; manual `/agmsg` only |
+
+`delivery.sh set` writes or removes `<project>/.pi/extensions/agmsg.ts`. Project-local Pi extensions load only after the project is trusted.
+
+Do **not** start `watch.sh` for Pi. That path is for runtimes with a Monitor tool; Pi injects from inside the session instead.
+
+The extension also registers `agmsg_send` and `agmsg_inbox` tools so the model can send and check mail without going through the skill command.
+
+## Common actions
+
+```
+/agmsg                          — check inbox
+/agmsg send <agent> <message>   — send a message
+/agmsg team                     — list team members
+/agmsg mode turn|monitor|off    — switch delivery mode (then /reload)
+```

--- a/install.sh
+++ b/install.sh
@@ -103,7 +103,7 @@ AGENT_TYPE=""  # claude-code, codex, gemini, antigravity — passed via --agent-
 # cursor) that had already drifted from the other two -- re-detecting one of
 # those three types as "codex" and then, via the template pick, overwriting
 # the SKILL.md the installer itself had written with the wrong flavor.
-AGMSG_SHARED_SKILL_TPL_TYPES="gemini antigravity opencode hermes cursor grok-build"
+AGMSG_SHARED_SKILL_TPL_TYPES="gemini antigravity opencode hermes cursor grok-build pi"
 
 # Put <src> at <dest>, then remove any leftover <src>. The arm is chosen by
 # <dest>, so the fix's scope matches the defect's (#747):
@@ -239,7 +239,7 @@ while [[ $# -gt 0 ]]; do
       echo "Options:"
       echo "  --cmd <name>      Command & skill folder name (default: agmsg)"
       echo "                    Claude Code: /<cmd>, Codex/Gemini/Antigravity: \$<cmd>"
-      echo "  --agent-type <t>  Agent type: claude-code, codex, gemini, antigravity, opencode, hermes, cursor, grok-build"
+      echo "  --agent-type <t>  Agent type: claude-code, codex, gemini, antigravity, opencode, hermes, cursor, grok-build, pi"
       echo "                    Selects which template becomes SKILL.md (matches the"
       echo "                    <type> arg passed to join.sh / whoami.sh)"
       echo "  --update          Update skill scripts only (preserve DB and teams)"
@@ -404,6 +404,14 @@ if [ "$UPDATE_ONLY" = true ]; then
   if [ -d "$HOME/.grok" ]; then
     mkdir -p "$GROK_SKILL_DIR"
     sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$(agmsg_type_template_path grok-build)" > "$GROK_SKILL_DIR/SKILL.md"
+  fi
+  # Refresh / install the Pi skill. Pi auto-discovers ~/.pi/agent/skills and
+  # ~/.agents/skills; the shared SKILL.md is Codex-typed, so keep a Pi-typed
+  # copy in Pi's own skills dir (later locations win on name collision).
+  PI_SKILL_DIR="$HOME/.pi/agent/skills/$SKILL_NAME"
+  if [ -d "$HOME/.pi" ]; then
+    mkdir -p "$PI_SKILL_DIR"
+    sed "s/__SKILL_NAME__/$SKILL_NAME/g" "$(agmsg_type_template_path pi)" > "$PI_SKILL_DIR/SKILL.md"
   fi
   cp "$SCRIPT_DIR/openai.yaml" "$SKILL_DIR/agents/openai.yaml" 2>/dev/null || true
   # A team config written by an older release can be group- or world-writable,
@@ -698,6 +706,18 @@ if [ -d "$HOME/.grok" ]; then
   echo "  + installed /$CMD_NAME skill to ~/.grok/skills/"
 fi
 
+# --- Install Pi skill ---
+# Pi auto-discovers ~/.pi/agent/skills/<name>/SKILL.md (and ~/.agents/skills as
+# a fallback). The shared ~/.agents/skills/<name>/SKILL.md is Codex-typed and
+# would mis-identify a Pi session — keep the Pi copy separate. Delivery writes
+# a project-local extension at <project>/.pi/extensions/agmsg.ts.
+PI_SKILL_DIR="$HOME/.pi/agent/skills/$CMD_NAME"
+if [ -d "$HOME/.pi" ]; then
+  mkdir -p "$PI_SKILL_DIR"
+  sed "s/__SKILL_NAME__/$CMD_NAME/g" "$(agmsg_type_template_path pi)" > "$PI_SKILL_DIR/SKILL.md"
+  echo "  + installed /$CMD_NAME skill to ~/.pi/agent/skills/"
+fi
+
 # Codex sandbox writable_roots are configured by configure_codex_sandbox() at
 # the "Done" step below — the single source of truth for db/, teams/, and run/.
 # (A legacy inline copy used to run here too, which double-mutated the array and
@@ -709,7 +729,7 @@ echo ""
 echo "  ✓ Installed to ~/.agents/skills/$CMD_NAME/ (version $INSTALLED_VERSION)"
 echo ""
 echo "  Next steps:"
-echo "    1. Restart your agent (Claude Code / Codex / Gemini CLI / Antigravity / OpenCode) to pick up the new skill"
+echo "    1. Restart your agent (Claude Code / Codex / Gemini CLI / Antigravity / OpenCode / Pi) to pick up the new skill"
 echo "    2. Run the command to join a team:"
 echo "       Claude Code:  /$CMD_NAME"
 echo "       Codex:        \$$CMD_NAME"
@@ -717,6 +737,7 @@ echo "       Gemini CLI:   \$$CMD_NAME"
 echo "       Antigravity:  \$$CMD_NAME"
 echo "       Copilot CLI:  /$CMD_NAME"
 echo "       OpenCode:     \$$CMD_NAME"
+echo "       Pi:           /$CMD_NAME"
 echo "       It will prompt for team name and agent name on first run."
 echo ""
 echo "  Docs: https://agmsg.cc/"

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # agmsg
 
-> Cross-agent messaging for CLI AI agents. Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, Antigravity, and OpenCode message each other directly through a shared local SQLite database — no daemon, no network, no MCP. Just `bash` + `sqlite3`.
+> Cross-agent messaging for CLI AI agents. Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, Antigravity, OpenCode, and Pi message each other directly through a shared local SQLite database — no daemon, no network, no MCP. Just `bash` + `sqlite3`.
 
 ## Quick Start
 
@@ -58,6 +58,7 @@ plugin marketplace (`/plugin marketplace add fujibee/agmsg`). All paths land at
 - [docs/spec/driver-interface.md](docs/spec/driver-interface.md): the formal driver contract.
 - [docs/adr/](docs/adr/): architecture decision records (the "why").
 - [docs/opencode.md](docs/opencode.md): OpenCode-specific integration.
+- [docs/pi.md](docs/pi.md): Pi-specific integration.
 - [CONTRIBUTING.md](CONTRIBUTING.md): how to propose changes.
 
 ## Key source files

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agmsg",
   "version": "1.2.3",
-  "description": "Cross-agent messaging via SQLite for CLI AI agents (Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, Antigravity, OpenCode). The npm package is a thin bootstrapper that fetches and runs the canonical bash installer at https://github.com/fujibee/agmsg.",
+  "description": "Cross-agent messaging via SQLite for CLI AI agents (Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, Antigravity, OpenCode, Pi). The npm package is a thin bootstrapper that fetches and runs the canonical bash installer at https://github.com/fujibee/agmsg.",
   "bin": {
     "agmsg": "bin/agmsg.js"
   },
@@ -25,6 +25,7 @@
     "copilot-cli",
     "antigravity",
     "opencode",
+    "pi",
     "messaging",
     "multi-agent",
     "agent-to-agent",

--- a/scripts/drivers/types/pi/_delivery.sh
+++ b/scripts/drivers/types/pi/_delivery.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# pi delivery plug — project-local Pi extension (.pi/extensions/agmsg.ts).
+#
+# Pi's session store takes a writer lease, so an external `pi --print` / watch.sh
+# cannot inject into the live TUI. Delivery is in-process:
+#   turn    — the extension checks inbox.sh on agent_settled
+#   monitor — the same extension polls unread messages on a timer
+#   off     — the extension file is removed
+#
+# delivery_modes=monitor turn off, so mode=both never reaches this function
+# (rejected by delivery.sh's central gate). Uses resolve_hooks_file + SKILL_DIR
+# from delivery.sh's sourced context.
+#
+# on_disable is a no-op besides apply's file removal: do NOT fall through to
+# the default teardown (which stops this project's watch.sh). Another agent
+# type on the same project may hold a live watcher.
+
+_agmsg_pi_json_string() {
+  local s=$1
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  printf '"%s"' "$s"
+}
+
+_agmsg_pi_write_extension() {
+  local dest="$1" mode="$2"
+  local src="$SKILL_DIR/scripts/drivers/types/pi/extension.ts"
+  local tmp skill_json poll_ms
+  [ -f "$src" ] || { echo "pi delivery: missing extension template $src" >&2; return 1; }
+
+  mkdir -p "$(dirname "$dest")"
+  skill_json="$(_agmsg_pi_json_string "$SKILL_DIR")"
+  if [ "$mode" = "monitor" ]; then
+    poll_ms=15000
+  else
+    poll_ms=0
+  fi
+
+  tmp="${dest}.tmp.$$"
+  # The shipped extension.ts is a template: mode/skill-dir/poll-ms are filled
+  # here so the running copy is pinned to this install and this delivery mode.
+  # Bash replacement (not sed) so a skill path cannot be read as a delimiter.
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=${line//__AGMSG_DELIVERY_MODE__/${mode}}
+    line=${line//__AGMSG_SKILL_DIR_JSON__/${skill_json}}
+    line=${line//__AGMSG_POLL_MS__/${poll_ms}}
+    printf '%s\n' "$line"
+  done < "$src" > "$tmp"
+  mv "$tmp" "$dest"
+}
+
+agmsg_delivery_apply() {
+  local type="$1"
+  local project="$2"
+  local mode="$3"
+  local ext_file
+  ext_file=$(resolve_hooks_file "$type" "$project")
+
+  rm -f "$ext_file"
+
+  case "$mode" in
+    turn|monitor)
+      _agmsg_pi_write_extension "$ext_file" "$mode"
+      ;;
+    off)
+      : # extension already removed
+      ;;
+  esac
+}
+
+agmsg_delivery_status() {
+  local type="$1" project="$2"
+  local ext_file
+  ext_file="$(resolve_hooks_file "$type" "$project")"
+  if [ ! -f "$ext_file" ]; then
+    echo "mode: off"
+  elif grep -q "agmsg-delivery-mode: monitor" "$ext_file" 2>/dev/null; then
+    echo "mode: monitor"
+  else
+    echo "mode: turn"
+  fi
+}
+
+agmsg_delivery_on_enable() {
+  local mode="$1"
+  case "$mode" in
+    turn|monitor)
+      echo "Pi loads the project extension from .pi/extensions/agmsg.ts. Run /reload (or restart Pi) so this session picks it up."
+      ;;
+  esac
+}
+
+agmsg_delivery_on_disable() {
+  echo "Removed the Pi agmsg extension for this project. Other agent types' watchers are left running."
+}

--- a/scripts/drivers/types/pi/extension.ts
+++ b/scripts/drivers/types/pi/extension.ts
@@ -1,0 +1,142 @@
+import { execFileSync } from "node:child_process";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+
+// agmsg-delivery-mode: __AGMSG_DELIVERY_MODE__
+const AGMSG_DELIVERY_MODE = "__AGMSG_DELIVERY_MODE__";
+const AGMSG_SKILL_DIR = __AGMSG_SKILL_DIR_JSON__;
+const AGMSG_POLL_MS = __AGMSG_POLL_MS__;
+
+function runScript(script: string, args: string[]): string {
+  return execFileSync(
+    "bash",
+    [`${AGMSG_SKILL_DIR}/scripts/${script}`, ...args],
+    { encoding: "utf-8", timeout: 15000 },
+  );
+}
+
+function parseWhoami(output: string): { agent: string; teams: string[] } | null {
+  const agent = /(?:^|\n)agent=(\S+)/.exec(output)?.[1];
+  const teams = /(?:^|\n)teams=(\S+)/.exec(output)?.[1];
+  if (!agent || !teams) return null;
+  return { agent, teams: teams.split(",").filter(Boolean) };
+}
+
+function resolveIdentity(cwd: string): { agent: string; teams: string[] } | null {
+  let whoami: string;
+  try {
+    whoami = runScript("whoami.sh", [cwd, "pi"]);
+  } catch {
+    return null;
+  }
+  if (whoami.includes("not_joined=true") || whoami.includes("multiple=true")) {
+    return null;
+  }
+  return parseWhoami(whoami);
+}
+
+function collectUnread(cwd: string): string {
+  const id = resolveIdentity(cwd);
+  if (!id) return "";
+  const chunks: string[] = [];
+  for (const team of id.teams) {
+    try {
+      const out = runScript("inbox.sh", [team, id.agent, "--quiet"]).trim();
+      if (out) chunks.push(out);
+    } catch {
+      // Keep polling even if one team store is missing or busy.
+    }
+  }
+  return chunks.join("\n\n");
+}
+
+async function deliverUnread(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
+  const body = collectUnread(ctx.cwd);
+  if (!body) return;
+  if (ctx.hasUI) {
+    ctx.ui.notify("New agmsg message received", "info");
+  }
+  await pi.sendMessage(
+    {
+      customType: "agmsg-delivery",
+      content: `[New agmsg message]:\n${body}`,
+      display: true,
+    },
+    { triggerTurn: true, deliverAs: "steer" },
+  );
+}
+
+export default function (pi: ExtensionAPI) {
+  let pollingInterval: ReturnType<typeof setInterval> | undefined;
+
+  pi.on("session_start", async (_event, ctx) => {
+    if (pollingInterval) {
+      clearInterval(pollingInterval);
+      pollingInterval = undefined;
+    }
+    if (AGMSG_DELIVERY_MODE === "monitor") {
+      pollingInterval = setInterval(() => {
+        void deliverUnread(pi, ctx);
+      }, AGMSG_POLL_MS);
+      void deliverUnread(pi, ctx);
+    }
+  });
+
+  pi.on("agent_settled", async (_event, ctx) => {
+    if (AGMSG_DELIVERY_MODE === "turn") {
+      void deliverUnread(pi, ctx);
+    }
+  });
+
+  pi.on("session_shutdown", () => {
+    if (pollingInterval) {
+      clearInterval(pollingInterval);
+      pollingInterval = undefined;
+    }
+  });
+
+  pi.registerTool({
+    name: "agmsg_send",
+    description: "Send an agmsg message to another agent on this machine",
+    parameters: Type.Object({
+      recipient: Type.String({ description: "Recipient agent name" }),
+      message: Type.String({ description: "Message body" }),
+    }),
+    execute: async (_toolCallId, { recipient, message }, _signal, _onUpdate, ctx) => {
+      const id = resolveIdentity(ctx.cwd);
+      if (!id) {
+        throw new Error("agmsg: this project is not joined as a single pi identity; run /agmsg to join.");
+      }
+      const team = id.teams[0];
+      if (!team) {
+        throw new Error("agmsg: no team is registered for this identity.");
+      }
+      const output = runScript("send.sh", [team, id.agent, recipient, message]);
+      return {
+        content: [{ type: "text", text: output.trim() || "Message sent." }],
+        details: {},
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "agmsg_inbox",
+    description: "Check this agent's agmsg inbox and mark unread messages as read",
+    parameters: Type.Object({}),
+    execute: async (_toolCallId, _params, _signal, _onUpdate, ctx) => {
+      const id = resolveIdentity(ctx.cwd);
+      if (!id) {
+        throw new Error("agmsg: this project is not joined as a single pi identity; run /agmsg to join.");
+      }
+      const chunks: string[] = [];
+      for (const team of id.teams) {
+        const output = runScript("inbox.sh", [team, id.agent]).trim();
+        if (output) chunks.push(output);
+      }
+      return {
+        content: [{ type: "text", text: chunks.join("\n\n") || "No new messages." }],
+        details: {},
+      };
+    },
+  });
+}

--- a/scripts/drivers/types/pi/template.md
+++ b/scripts/drivers/types/pi/template.md
@@ -1,0 +1,251 @@
+---
+name: __SKILL_NAME__
+description: Cross-agent messaging via SQLite. Send messages between Claude Code, Codex, Gemini CLI, Pi, and other agents. No daemon, no network, no dependencies beyond bash and sqlite3.
+---
+
+Agent messaging command. **IMPORTANT: Always use the provided scripts. NEVER directly read or edit config files, DB, or team data. There is NO register.sh — use join.sh to join a team.**
+
+**Shell requirement:** All agmsg scripts are Bash scripts. Always execute them via `bash`, never via PowerShell or cmd directly. If your default shell is not Bash (e.g. PowerShell on Windows), wrap every command with `bash -lc '...'`. Example: `bash -lc '~/.agents/skills/__SKILL_NAME__/scripts/send.sh myteam alice bob "hello"'`. Do NOT construct DB paths manually — the scripts handle path resolution internally. If you need to redirect storage, use `AGMSG_STORAGE_PATH` (the supported override).
+
+## Identity
+
+If you already know your AGENT and TEAMS from a previous `/__SKILL_NAME__` call in this session, skip to **Execute** below.
+
+Otherwise, run: `~/.agents/skills/__SKILL_NAME__/scripts/whoami.sh "$(pwd)" pi`
+
+Four possible outputs:
+
+**A) Single identity:**
+`agent=<name> teams=<t1,t2,...> type=pi project=<path>`
+→ Remember AGENT and TEAMS, then go to **Execute**.
+
+**B) Multiple identities:**
+`multiple=true agents=<n1,n2,...> teams=<t1,t2,...> type=pi project=<path>`
+→ Ask the user which agent name to use for this session, then go to **Execute**.
+
+**C) Not in a team:**
+`not_joined=true available_teams=<t1,t2,...>` (or `available_teams=none`)
+→ Show the user the available teams from the output, then:
+
+  Before first-time setup, inspect the user's request. If they ask to join, import, or bring in a team that already exists on a server, do not call `join.sh`. Go directly to `remote pull` under Execute. First run `~/.agents/skills/__SKILL_NAME__/scripts/team-list.sh --json --scope all`; if a same-named local team has `binding_state` `none` or `disconnected`, stop and ask the user how to proceed. After pull succeeds, return to Identity setup so the user can register a new local agent in the pulled team.
+
+  > **First-time setup required.**
+  > Joining a team so this agent can send and receive messages.
+  > - **Team name**: a group of agents that can message each other (available: <list from output>)
+  > - **Agent name**: this agent's identity within the team
+
+  1. Ask: "Enter a team name (joins existing or creates new)"
+  2. If the team name given already appears in `available_teams`, run `~/.agents/skills/__SKILL_NAME__/scripts/team.sh <team>` to see the current roster (name, type, project) and note the names already in use. Look for a naming convention already in play (e.g. a shared base name with role and number suffixes (`<base>-<role><n>`), or names derived from the team name) and, when one exists, propose 2-3 unused names that extend it; otherwise propose 2-3 short, distinctive identity names (not a bare tool-type label like `codex`/`cc`). Either way, names must not collide with the roster. Then ask: "Enter a name for this agent (suggestions: <name1>, <name2>, <name3> — or type your own)". For a brand-new team, skip the roster check and just ask: "Enter a name for this agent".
+  3. **You MUST use join.sh** — run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> pi "$(pwd)"`
+  4. Show the result and explain:
+
+  > **Joined!** You can now use `/__SKILL_NAME__` to check and send messages.
+  > - `/__SKILL_NAME__` — check inbox
+  > - `/__SKILL_NAME__ send <agent> <message>` — send a message
+  > - `/__SKILL_NAME__ team` — list team members
+  > - `/__SKILL_NAME__ history` — message history
+
+  5. **REQUIRED — Do NOT skip this step.** Ask the user to pick a delivery mode using exactly this prompt:
+
+     ```
+     Choose delivery mode for incoming messages:
+
+       1) turn    — Check inbox after each assistant turn
+                     A project Pi extension (.pi/extensions/agmsg.ts) polls
+                     inbox.sh when the agent settles. Zero extra setup.
+
+       2) monitor — In-process polling (~15s)
+                     The same extension polls unread messages on a timer and
+                     injects them into this session (Pi's session store has a
+                     writer lease, so an external watcher cannot inject).
+
+       3) off     — No automatic delivery
+                     Manual /__SKILL_NAME__ only.
+
+     [1]:
+     ```
+
+     - **Wait for the user's answer before proceeding.** Empty input means `1` (turn).
+     - Map the chosen number to a mode (`1`→`turn`, `2`→`monitor`, `3`→`off`) and run:
+       `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> pi "$(pwd)"`
+     - Tell the user to `/reload` (or restart Pi) so the project extension is picked up. `both` is not supported. Do NOT launch `watch.sh`.
+
+  6. Then check inbox for the newly joined team.
+
+**D) Suggestions for reuse:**
+`suggest=true agents=<n1,n2,...> teams=<t1,t2,...> type=pi project=<path> available_teams=<t1,t2,...>`
+→ No exact registration exists for this project, but there are same-type agent names registered elsewhere.
+
+  1. Show the suggested agent names to the user.
+  2. Ask whether to reuse one of those names or choose a new one.
+  3. Ask for the team name to join (existing or new).
+  4. Run: `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <agent_name> pi "$(pwd)"`
+  5. Then continue with the normal post-join flow above.
+
+## Execute
+
+**Only use scripts in `~/.agents/skills/__SKILL_NAME__/scripts/` — do not read or modify files under `teams/` or `db/` directly.**
+
+Incoming messages in `turn`/`monitor` are delivered by the project Pi extension at `.pi/extensions/agmsg.ts` (written by `delivery.sh`). Do **not** start `watch.sh` or any background watcher — Pi's session store rejects concurrent writers, so injection has to happen in-process. If delivery was just enabled and the extension is not loaded yet, ask the user to `/reload`. In `off` mode there is no extension; skip this.
+
+**If no arguments provided (DEFAULT action — always do this when the command is invoked without arguments):**
+1. **IMMEDIATELY** run inbox check for each TEAM: `~/.agents/skills/__SKILL_NAME__/scripts/inbox.sh $TEAM $AGENT`
+2. Do NOT ask the user what to do — just run the inbox check.
+3. If there are messages, read and respond appropriately. To reply:
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+
+If argument is "history":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/history.sh $TEAM $AGENT`
+
+If argument starts with "team list" (e.g. "team list", "team list --json", "team list --scope project"):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/team-list.sh <the rest of the args after "team list", unchanged>`
+2. This is a distinct command from bare "team" below — check for "team list" FIRST so "list" is never mistaken for a team name.
+
+If argument is "team":
+1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM`
+
+If argument starts with "send" (e.g. "send misaki check the server"):
+1. Parse target agent and message from the arguments
+2. Determine which team the target agent belongs to, then run:
+   `~/.agents/skills/__SKILL_NAME__/scripts/send.sh $TEAM $AGENT <to_agent> "<message>"`
+
+If argument is "config":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh show`
+2. Show the output to the user.
+
+If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
+1. Parse key and value from the arguments.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
+
+
+If argument starts with "actas" followed by an agent name (e.g. "actas alice"):
+1. Parse the new role name. If none was given (e.g. bare "actas", or the user asks you to suggest one), run `~/.agents/skills/__SKILL_NAME__/scripts/team.sh <team>` for each TEAM to see the current roster. Look for a naming convention already in play (e.g. a shared base name with role and number suffixes (`<base>-<role><n>`), or names derived from the team name) and, when one exists, propose 2-3 unused names that extend it; otherwise propose 2-3 short, distinctive identity names (not a bare tool-type label). Either way, names must not collide with the roster. Ask the user to pick one or type their own before continuing.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" pi` to see whether the role is already registered for this (project, type).
+3. If the name does not appear in the output, join under the existing team. For a single team, run `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> pi "$(pwd)"`. For multiple teams, ask the user which team to join the new role into.
+4. Set the session's active FROM to `<name>` for every `send.sh` call until another `actas`. The Pi extension re-resolves identity on each poll, so there is no watcher to switch.
+5. Tell the user: "Now acting as `<name>`. Sends use `<name>` as from."
+
+If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
+1. Parse the role name.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" pi <name>` to remove that role's registration.
+3. If the session's active FROM was `<name>`, clear that state.
+4. Tell the user: "Dropped role `<name>` from this project."
+
+If argument is "mode" (no further args):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh status pi "$(pwd)"`
+2. Show the output to the user.
+
+If argument starts with "mode" followed by a mode name (e.g. "mode turn"):
+1. Parse the mode. Pi supports `turn`, `monitor`, and `off` — reject `both` with: "Pi does not support `both`; use `turn`, `monitor`, or `off`."
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> pi "$(pwd)"`
+3. Tell the user to `/reload` (or restart Pi) so the project extension matches the new mode. Do not start or stop `watch.sh`.
+
+If argument is "hook on" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set turn pi "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'turn' (legacy hook on behavior)."
+
+If argument is "hook off" (legacy alias):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set off pi "$(pwd)"`
+2. Tell the user: "Delivery mode set to 'off'."
+
+If argument is "reset":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/reset.sh "$(pwd)" pi`
+2. Tell the user the result.
+
+If argument starts with "rename" but not "rename-team":
+1. Accept only an explicit user request. Parse either `<team> <old_name> <new_name>`, or `<old_name> <new_name>` only when this agent belongs to exactly one team.
+2. Never invent either name. Before execution, repeat the resolved team, old name, and new name and ask the user to confirm. Wait for confirmation.
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/rename.sh <team> <old_name> <new_name>`
+4. Show the result. For a connected team, the `member_renamed` journal event propagates the rename to other machines.
+
+If argument starts with "rename-team":
+1. Accept only an explicit user request. Parse `<old_team> <new_team>`.
+2. Never invent either team name. Before execution, repeat the old and new team names and ask the user to confirm. Wait for confirmation.
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/rename-team.sh <old_team> <new_team>`
+4. Show the result.
+
+If argument starts with "remote connect":
+1. Parse the required `--endpoint <url>` and `<team>`, plus optional `--e2ee`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh connect --endpoint <url> [--e2ee] <team>`
+3. Show the output to the user. Plain sync is the default; pass `--e2ee` only when the user explicitly requests end-to-end encryption. The choice is fixed by the first connect.
+4. End by showing this copy-paste command for the other machine, with the actual endpoint and team substituted: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <actual-url> <actual-team>`
+
+If argument starts with "remote pull":
+1. When the user asks to join or bring in a team that already exists on a server, NEVER use `join.sh`, create a team, or create a same-named local team. Always use remote pull.
+2. Before pulling, check for a same-named local team. If one already exists without an active remote connection, stop and ask the user how to proceed; do not overwrite, merge, connect, or rename it on your own.
+3. Parse the required `--endpoint <url>` and `<team>`, plus optional `--team-id <uuid>`.
+4. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh pull --endpoint <url> [--team-id <uuid>] <team>`
+5. Show the output to the user.
+
+Machine B needs its own install, not just its own environment variables.
+Only `remote.sh`, `remote-sync.sh`, `key.sh` and the two internal helpers read
+`AGMSG_SYNC_CONNECTION_DIR`; `send.sh`, `history.sh`, `team.sh` and `inbox.sh`
+resolve the team config from the install directory. So a pull driven by
+environment variables alone succeeds, and the send that is supposed to confirm
+it then reports the team as missing — the failure lands one step after the
+cause. See "Use a separate install for testing" in `docs/remote-setup.md`.
+
+**What e2ee changes, and what it doesn't.** The local store stays plaintext either way — `history`, `inbox`, and `send` read and write exactly the same regardless of a team's encryption setting. Only the SERVER side differs: an e2ee team's server rows carry `cipher: age-v1` and hold sealed ciphertext, so `from`, `to`, and `body` are not readable there; a plain team's rows are not sealed. Keys never pass through the server — moving one to another machine means carrying a handoff bundle by hand (`key handoff` above).
+
+**Readable local history is therefore not evidence that a team is unencrypted.** To state whether a given team is e2ee, ask the program — `remote status <team>` below — never infer it from what you can read locally.
+
+If argument starts with "remote unlock":
+1. Parse `<team>`, `--bundle <file>`, and `--confirm-digest <sha256>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh unlock <team> --bundle <file> --confirm-digest <sha256>`
+3. The snapshot digest must be compared over a separate live channel. Never infer or auto-confirm it. The bundle is permanent secret key material; tell the user to transfer and handle it only through their own trusted channel, never by pasting it into agent chat.
+4. Show the complete result, including the imported-envelope count and engine PID.
+5. The advanced form with repeatable `--snapshot` plus `--identity` or `--identity-stdin` remains available when explicitly requested.
+
+If argument starts with "remote status":
+1. Parse an optional `<team>` and `--json`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh status [<team>] [--json]`
+3. Show the output to the user.
+
+If argument starts with "remote sync start":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh sync start <team>`
+3. Show the output to the user.
+
+If argument starts with "remote disconnect":
+1. Parse the required `<team>`.
+2. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh disconnect <team>`
+3. Show the output to the user.
+
+If argument starts with "remote forget":
+1. Parse the required `<team>`. This permanently deletes that team's local roster, history, keys, trust, and sync state, but never changes the server.
+2. Do not add `--yes` yourself. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/remote.sh forget <team>`
+3. The command requires the user to confirm in their terminal. If this agent has no interactive terminal, show the deletion summary and tell the user to rerun the displayed command directly; never bypass confirmation for them.
+
+If argument starts with "key generate" followed by an optional team name:
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh generate [<team>]`
+2. Show the full output to the user, including the mandatory key-backup notice — do not summarize it away.
+
+If argument starts with "key show":
+1. Parse an optional team name and `--reveal-secret`.
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/key.sh show [<team>] [--reveal-secret]`
+3. `--reveal-secret` requires a real interactive terminal and is refused in agent mode — if the user wants to reveal a secret, tell them to run it themselves directly in their own terminal rather than through you.
+4. Show the output to the user.
+
+If argument starts with "key handoff" followed by a team name:
+1. Parse optional `--out <file>` and run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/key.sh handoff <team> [--out <file>]`
+2. The output bundle contains every epoch identity and is itself permanent secret key material. Never read it into agent chat or display its contents.
+3. Show the bundle path, latest snapshot digest, and full secrecy warning.
+
+If argument starts with "key import" followed by a team name:
+1. **Do not ask the user to paste the private identity into this chat, and do not run this command yourself.** This identity is a permanent secret. Tell the user to run this directly in their own terminal:
+   ```
+   read -rsp 'Identity: ' IDENTITY; echo
+   printf '%s' "$IDENTITY" | ~/.agents/skills/__SKILL_NAME__/scripts/key.sh import <team> --identity-stdin
+   unset IDENTITY
+   ```
+2. Ask them to paste back only the command's output (never the identity itself) once it's done.
+3. **No advanced/automation env-var path is offered for key import** — not even a pre-existing, before-session variable. An identity file is a permanent secret; always use the human-in-own-terminal flow above.
+
+If argument starts with "key rotate" followed by a team name:
+1. Rotation mints a replacement epoch for a team that already has a key and announces it on the roster journal. It requires an existing current key, an identity journal (connect or migrate the team first), and `age`; it refuses with a message naming whichever is missing.
+2. Confirm with the user before running it. It changes the team's key state, and every other machine has to receive the new identity out of band.
+3. Run: `bash ~/.agents/skills/__SKILL_NAME__/scripts/key.sh rotate <team>`
+4. Show the output: epoch, key_id, and recipient fingerprint. The private key is never written to the journal. Revealing it needs `key show <team> --key-id <id> --reveal-secret`, which is refused in agent mode — tell the user to run that in their own terminal.
+5. Messages before the acknowledged rotation boundary remain readable with the old key.
+
+Device pairing (`key request` / `key approve`) is not implemented — they are not `key.sh` subcommands, so a call prints usage and exits 1. If the user asks for one, tell them so instead of attempting to run it.

--- a/scripts/drivers/types/pi/type.conf
+++ b/scripts/drivers/types/pi/type.conf
@@ -1,0 +1,12 @@
+# agmsg agent-type manifest — read-only key=value DATA. NEVER sourced.
+name=pi
+template=template.md
+cli=pi
+spawnable=yes
+detect_proc=pi pi-*
+hooks_file=.pi/extensions/agmsg.ts
+# monitor=no: Pi has no Monitor-tool equivalent. Incoming messages are injected
+# in-process by a project extension (see _delivery.sh); spawn must not wait for
+# a watch.sh pidfile that this type never writes.
+monitor=no
+delivery_modes=monitor turn off

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -2882,27 +2882,25 @@ JSON
 @test "delivery set turn (pi): writes .pi/extensions/agmsg.ts with turn marker" {
   run bash "$SCRIPTS/delivery.sh" set turn pi "$TEST_PROJECT"
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "Delivery mode set to 'turn'" ]]
+  printf '%s\n' "$output" | grep -q "Delivery mode set to 'turn'"
   local ext_file="$TEST_PROJECT/.pi/extensions/agmsg.ts"
   [ -f "$ext_file" ]
-  run cat "$ext_file"
-  [[ "$output" == *"agmsg-delivery-mode: turn"* ]]
-  [[ "$output" == *"agent_settled"* ]]
-  [[ "$output" == *"$TEST_SKILL_DIR"* ]]
-  [[ "$output" != *"agmsg-delivery-mode: monitor"* ]]
+  grep -q "agmsg-delivery-mode: turn" "$ext_file"
+  grep -q "agent_settled" "$ext_file"
+  grep -F -q "$TEST_SKILL_DIR" "$ext_file"
+  refute grep -q "agmsg-delivery-mode: monitor" "$ext_file"
 }
 
 @test "delivery set monitor (pi): writes the extension with a 15s poll" {
   run bash "$SCRIPTS/delivery.sh" set monitor pi "$TEST_PROJECT"
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "Delivery mode set to 'monitor'" ]]
+  printf '%s\n' "$output" | grep -q "Delivery mode set to 'monitor'"
   local ext_file="$TEST_PROJECT/.pi/extensions/agmsg.ts"
   [ -f "$ext_file" ]
-  run cat "$ext_file"
-  [[ "$output" == *"agmsg-delivery-mode: monitor"* ]]
-  [[ "$output" == *"15000"* ]]
-  [[ "$output" == *"$TEST_SKILL_DIR"* ]]
-  [[ "$output" != *"watch.sh"* ]]
+  grep -q "agmsg-delivery-mode: monitor" "$ext_file"
+  grep -q "15000" "$ext_file"
+  grep -F -q "$TEST_SKILL_DIR" "$ext_file"
+  refute grep -q "watch.sh" "$ext_file"
 }
 
 @test "delivery set off (pi): removes the extension" {
@@ -2915,15 +2913,15 @@ JSON
 
 @test "delivery status (pi): derives mode from the extension marker" {
   run bash "$SCRIPTS/delivery.sh" status pi "$TEST_PROJECT"
-  [[ "$output" =~ "mode: off" ]]
+  printf '%s\n' "$output" | grep -q "mode: off"
 
   bash "$SCRIPTS/delivery.sh" set turn pi "$TEST_PROJECT" >/dev/null
   run bash "$SCRIPTS/delivery.sh" status pi "$TEST_PROJECT"
-  [[ "$output" =~ "mode: turn" ]]
+  printf '%s\n' "$output" | grep -q "mode: turn"
 
   bash "$SCRIPTS/delivery.sh" set monitor pi "$TEST_PROJECT" >/dev/null
   run bash "$SCRIPTS/delivery.sh" status pi "$TEST_PROJECT"
-  [[ "$output" =~ "mode: monitor" ]]
+  printf '%s\n' "$output" | grep -q "mode: monitor"
 }
 
 @test "delivery set both (pi): rejected; does NOT delete an existing turn extension" {

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -2874,6 +2874,84 @@ JSON
   [[ "$output" =~ "mode: turn" ]]
 }
 
+# --- pi (in-process extension at .pi/extensions/agmsg.ts) ---
+# Pi's session store takes a writer lease, so delivery is a project-local
+# extension rather than watch.sh / JSON hooks. turn|monitor write the file;
+# off removes it. both is rejected by the central gate.
+
+@test "delivery set turn (pi): writes .pi/extensions/agmsg.ts with turn marker" {
+  run bash "$SCRIPTS/delivery.sh" set turn pi "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Delivery mode set to 'turn'" ]]
+  local ext_file="$TEST_PROJECT/.pi/extensions/agmsg.ts"
+  [ -f "$ext_file" ]
+  run cat "$ext_file"
+  [[ "$output" == *"agmsg-delivery-mode: turn"* ]]
+  [[ "$output" == *"agent_settled"* ]]
+  [[ "$output" == *"$TEST_SKILL_DIR"* ]]
+  [[ "$output" != *"agmsg-delivery-mode: monitor"* ]]
+}
+
+@test "delivery set monitor (pi): writes the extension with a 15s poll" {
+  run bash "$SCRIPTS/delivery.sh" set monitor pi "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Delivery mode set to 'monitor'" ]]
+  local ext_file="$TEST_PROJECT/.pi/extensions/agmsg.ts"
+  [ -f "$ext_file" ]
+  run cat "$ext_file"
+  [[ "$output" == *"agmsg-delivery-mode: monitor"* ]]
+  [[ "$output" == *"15000"* ]]
+  [[ "$output" == *"$TEST_SKILL_DIR"* ]]
+  [[ "$output" != *"watch.sh"* ]]
+}
+
+@test "delivery set off (pi): removes the extension" {
+  bash "$SCRIPTS/delivery.sh" set turn pi "$TEST_PROJECT"
+  [ -f "$TEST_PROJECT/.pi/extensions/agmsg.ts" ]
+  run bash "$SCRIPTS/delivery.sh" set off pi "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_PROJECT/.pi/extensions/agmsg.ts" ]
+}
+
+@test "delivery status (pi): derives mode from the extension marker" {
+  run bash "$SCRIPTS/delivery.sh" status pi "$TEST_PROJECT"
+  [[ "$output" =~ "mode: off" ]]
+
+  bash "$SCRIPTS/delivery.sh" set turn pi "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status pi "$TEST_PROJECT"
+  [[ "$output" =~ "mode: turn" ]]
+
+  bash "$SCRIPTS/delivery.sh" set monitor pi "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" status pi "$TEST_PROJECT"
+  [[ "$output" =~ "mode: monitor" ]]
+}
+
+@test "delivery set both (pi): rejected; does NOT delete an existing turn extension" {
+  bash "$SCRIPTS/delivery.sh" set turn pi "$TEST_PROJECT" >/dev/null
+  run bash "$SCRIPTS/delivery.sh" set both pi "$TEST_PROJECT"
+  [ "$status" -ne 0 ]
+  [ -f "$TEST_PROJECT/.pi/extensions/agmsg.ts" ]
+}
+
+@test "delivery set off (pi): does not stop Claude Code watchers for the same project" {
+  mkdir -p "$TEST_SKILL_DIR/teams/myteam"
+  cat > "$TEST_SKILL_DIR/teams/myteam/config.json" <<JSON
+{"name":"myteam","agents":{"alice":{"registrations":[{"type":"claude-code","project":"$TEST_PROJECT"}]}}}
+JSON
+  AGMSG_WATCH_INTERVAL=10 bash "$SCRIPTS/watch.sh" pi-preserve-test "$TEST_PROJECT" claude-code 3>&- &
+  local watch_pid=$!
+  sleep 1
+  [ -f "$TEST_SKILL_DIR/run/watch.pi-preserve-test.pid" ]
+
+  run bash "$SCRIPTS/delivery.sh" set off pi "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  run kill -0 "$watch_pid"
+  [ "$status" -eq 0 ]
+
+  kill "$watch_pid" 2>/dev/null || true
+  wait 2>/dev/null || true
+}
+
 @test "delivery status (codex): a recorded seat makes \"not running\" mean the process (#579)" {
   bash "$SCRIPTS/join.sh" team alice codex "$TEST_PROJECT" >/dev/null
   bash "$SCRIPTS/delivery.sh" set monitor codex "$TEST_PROJECT" >/dev/null

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -955,6 +955,39 @@ EOF
   ! grep -q "whoami.sh \"\$(pwd)\" codex" "$SK/SKILL.md"
 }
 
+# --- pi skill (~/.pi/agent/skills/<name>/SKILL.md) ---
+
+@test "install: drops a Pi SKILL.md when ~/.pi exists" {
+  mkdir -p "$FAKE_HOME/.pi"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  local pi_skill="$FAKE_HOME/.pi/agent/skills/agmsg/SKILL.md"
+  [ -f "$pi_skill" ]
+  grep -q "whoami.sh \"\$(pwd)\" pi" "$pi_skill"
+  refute grep -q "whoami.sh \"\$(pwd)\" codex" "$pi_skill"
+  grep -q "^name: agmsg" "$pi_skill"
+}
+
+@test "install: skips Pi skill when ~/.pi is absent" {
+  rm -rf "$FAKE_HOME/.pi"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  [ ! -d "$FAKE_HOME/.pi" ]
+}
+
+@test "install --update: installs Pi skill for upgraders without prior skill" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
+  [ ! -d "$FAKE_HOME/.pi/agent/skills/agmsg" ]
+  mkdir -p "$FAKE_HOME/.pi"
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --update
+  [ -f "$FAKE_HOME/.pi/agent/skills/agmsg/SKILL.md" ]
+  grep -q "whoami.sh \"\$(pwd)\" pi" "$FAKE_HOME/.pi/agent/skills/agmsg/SKILL.md"
+}
+
+@test "install: --agent-type pi makes shared SKILL.md Pi-typed" {
+  HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg --agent-type pi
+  grep -q "whoami.sh \"\$(pwd)\" pi" "$SK/SKILL.md"
+  ! grep -q "whoami.sh \"\$(pwd)\" codex" "$SK/SKILL.md"
+}
+
 # Positive control for #846 (A), covering every type the installer can render a
 # shared SKILL.md for: install fresh with that type, then run bare --update
 # (no --agent-type, forcing the on-disk re-detection path) and confirm the
@@ -966,7 +999,7 @@ EOF
 # grepped for and was never broken -- it IS the fallback).
 @test "install: bare --update preserves every renderable type's SKILL.md flavor (#846)" {
   local t
-  for t in codex gemini antigravity opencode hermes cursor grok-build; do
+  for t in codex gemini antigravity opencode hermes cursor grok-build pi; do
     local cmd="agmsg-$t"
     HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd "$cmd" --agent-type "$t"
     local skill_md="$FAKE_HOME/.agents/skills/$cmd/SKILL.md"

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -10,7 +10,7 @@ setup() {
   # a terminal. PATH is prepended so the stubs win.
   export STUB_BIN="$TEST_SKILL_DIR/stub-bin"
   mkdir -p "$STUB_BIN"
-  for bin in claude codex grok hermes cursor-agent gemini agy copilot opencode; do
+  for bin in claude codex grok hermes cursor-agent gemini agy copilot opencode pi; do
     printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB_BIN/$bin"
     chmod +x "$STUB_BIN/$bin"
   done

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -29,11 +29,11 @@ write_node_launcher_fixtures() {
   printf '// stub node launcher fixture\n' > "$nd/nodetype-launcher.mjs"
 }
 
-@test "type-registry: known_types lists the ten built-ins" {
+@test "type-registry: known_types lists the eleven built-ins" {
   run env -i PATH="$PATH" bash -c \
     "source '$SCRIPTS/lib/type-registry.sh'; agmsg_known_types | sort -u | paste -sd, -"
   [ "$status" -eq 0 ]
-  [ "$output" = "agmsg-app,antigravity,claude-code,codex,copilot,cursor,gemini,grok-build,hermes,opencode" ]
+  [ "$output" = "agmsg-app,antigravity,claude-code,codex,copilot,cursor,gemini,grok-build,hermes,opencode,pi" ]
 }
 
 @test "type-registry: is_known_type accepts a built-in and rejects a bogus type" {
@@ -92,9 +92,9 @@ write_node_launcher_fixtures() {
 }
 
 @test "agent templates all explain that readable local history is not evidence a team is unencrypted (#682)" {
-  # scripts/drivers/types/*/template.md is nine independent copies with no
+  # scripts/drivers/types/*/template.md is ten independent copies with no
   # shared fragment (#676's exact shape) -- a loop with `[ -f ] || continue`
-  # alone would silently pass if the glob matched fewer than nine files (a
+  # alone would silently pass if the glob matched fewer than ten files (a
   # renamed/missing template), so the count is asserted explicitly rather
   # than just "every file found had it."
   local template count=0
@@ -105,9 +105,9 @@ write_node_launcher_fixtures() {
       || { echo "missing the e2ee-verification paragraph: $template" >&2; return 1; }
   done
   # agmsg-app has no template.md (spawnable=no -- it's the desktop app's own
-  # identity, not a CLI type), so nine is the whole set, not a lower bound a
+  # identity, not a CLI type), so ten is the whole set, not a lower bound a
   # silently-skipped file could still satisfy.
-  [ "$count" -eq 9 ]
+  [ "$count" -eq 10 ]
 }
 
 @test "the e2ee-verification explanation also appears in both remote-setup docs (#682)" {
@@ -156,8 +156,8 @@ write_node_launcher_fixtures() {
     ! grep -qiE 'rotat(e|ion)[^.]*not available' "$surface" \
       || { echo "still calls rotation unavailable: $surface" >&2; return 1; }
   done
-  # nine templates (agmsg-app has none) plus SKILL.md.
-  [ "$count" -eq 10 ]
+  # ten templates (agmsg-app has none) plus SKILL.md.
+  [ "$count" -eq 11 ]
 
   # Bind the claim to the code. If `rotate` ever stops being a subcommand the
   # surfaces above become wrong again, and this is the line that says so.
@@ -170,7 +170,7 @@ write_node_launcher_fixtures() {
   grep -Fq 'To mint a replacement epoch instead:' "$BATS_TEST_DIRNAME/../scripts/key.sh"
 }
 
-@test "type-registry: spawnable set is exactly eight of the ten built-ins (#277, #279)" {
+@test "type-registry: spawnable set is exactly nine of the eleven built-ins (#277, #279)" {
   # hermes deliberately stays out (#279): no known CLI mode starts it
   # interactive with a seeded initial prompt. agmsg-app also stays out: it's
   # the desktop app itself (spawnable=no), not a spawnable agent type.
@@ -181,7 +181,7 @@ write_node_launcher_fixtures() {
        [ \"\$(agmsg_type_get \"\$t\" spawnable)\" = yes ] && echo \"\$t\"
      done <<< \"\$(agmsg_known_types | sort -u)\" | paste -sd, -"
   [ "$status" -eq 0 ]
-  [ "$output" = "antigravity,claude-code,codex,copilot,cursor,gemini,grok-build,opencode" ]
+  [ "$output" = "antigravity,claude-code,codex,copilot,cursor,gemini,grok-build,opencode,pi" ]
 }
 
 @test "type-registry: detection manifests carry the expected env / proc keys" {
@@ -192,6 +192,7 @@ write_node_launcher_fixtures() {
   [ "$(g antigravity detect)" = "explicit" ]
   [ "$(g copilot detect)" = "explicit" ]
   [ "$(g opencode detect_proc)" = "opencode opencode-*" ]
+  [ "$(g pi detect_proc)" = "pi pi-*" ]
 }
 
 @test "type-registry: whoami detects codex end-to-end from CODEX_THREAD_ID" {


### PR DESCRIPTION
## Summary

Adds [Pi](https://github.com/earendil-works/pi) as a bundled agent type. Closes #727.

Pi's session store takes a SQLite writer lease, so an external `watch.sh` / `pi --print` cannot inject into the live TUI. Delivery is in-process:

- `turn` — project extension (`.pi/extensions/agmsg.ts`) checks `inbox.sh` on `agent_settled`
- `monitor` — the same extension polls unread messages every 15s and injects with `pi.sendMessage({ triggerTurn: true, deliverAs: "steer" })`
- `off` — the extension file is removed
- `both` is rejected

The extension is generated from `scripts/drivers/types/pi/extension.ts` and pinned to this install's `SKILL_DIR`. It also registers `agmsg_send` / `agmsg_inbox` tools. Send/inbox go through the skill scripts (`inbox.sh` / `send.sh`), not the npm `agmsg` bootstrapper.

When `~/.pi/` exists, `install.sh` drops a Pi-typed `SKILL.md` at `~/.pi/agent/skills/agmsg/` so Pi does not pick up the Codex-typed shared skill.

`spawn pi` is enabled (`cli=pi`, `monitor=no` so spawn does not wait for a watch.sh pidfile this type never writes).

## Test plan

- [x] `bats tests/test_type_registry.bats`
- [x] `bats tests/test_delivery.bats --filter pi`
- [x] `bats tests/test_install.bats --filter 'Pi|pi makes|every renderable'`
- [ ] Live Pi session: install, `/agmsg` join, `/reload`, send from another agent, confirm toast + steer injection
- [ ] `spawn pi <name>` from another agent in the same team