### PR TITLE
perf(codex): batch the rollout mtime scan (#1035)

### DIFF
--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -25,7 +25,17 @@
 # portable compat_file_mtime, since `find -printf` is GNU-only (no
 # `-printf` on macOS/BSD find, which this repo also has to support). See #416.
 agmsg_newest_rollout_files() {
-  local dir="$1" limit="$2" f mtime
+  local dir="$1" limit="$2"
+  # Batch the mtime lookup (compat_files_mtime_0) instead of running
+  # `mtime=$(compat_file_mtime "$f")` in a per-file loop: that substitution
+  # forks a subshell + uname + stat for EVERY rollout, and on Windows/MSYS2
+  # -- where process creation is orders of magnitude costlier than a Linux
+  # fork -- the scan measured ~12 minutes against 2582 accumulated rollouts.
+  # This function runs inside the synchronous SessionStart hook, and
+  # agmsg_resolve_codex_thread calls it up to 3 times, so the per-file form
+  # blocks Codex startup for tens of minutes once a machine has real rollout
+  # history. One stat per argv batch resolves the same list in seconds.
+  #
   # `head -n "$limit"` here would close its read end after $limit lines while
   # `sort` may still be writing -- under this caller's `set -euo pipefail`,
   # that SIGPIPEs `sort` (status 141) and pipefail surfaces it as the whole
@@ -36,18 +46,15 @@ agmsg_newest_rollout_files() {
   # different mechanism. awk reads its input through to EOF regardless of
   # `n` (only *printing* stops early), so `sort` is always fully drained and
   # never SIGPIPEd.
-  # `|| true` on the mtime lookup: under set -e, a plain `var=$(cmd)`
-  # assignment DOES abort on cmd's failure (unlike a substitution used inside
-  # a test/conditional). A rollout that `find` listed but that Codex deletes
-  # or rotates before `stat` runs on it (a real possibility across the ~1-2s
-  # this loop can take with hundreds of files) would otherwise abort this
-  # whole while-loop subshell -- another way to reintroduce the "no
-  # candidate found" failure the ${mtime:-0} fallback below already exists to
-  # avoid.
-  find "$dir" -type f -name 'rollout-*.jsonl' 2>/dev/null | while IFS= read -r f; do
-    mtime=$(compat_file_mtime "$f" || true)
-    printf '%s\t%s\n' "${mtime:-0}" "$f"
-  done | sort -t "$(printf '\t')" -k1,1rn | awk -F'\t' -v n="$limit" 'NR<=n { sub(/^[^\t]*\t/, ""); print }'
+  #
+  # A rollout that `find` listed but that Codex deletes or rotates before
+  # the stat batch reaches it no longer needs special handling here:
+  # compat_files_mtime_0 suppresses the per-file error and still prints
+  # every surviving file, so a dead file can't starve the caller of the
+  # whole candidate list.
+  find "$dir" -type f -name 'rollout-*.jsonl' -print0 2>/dev/null \
+    | compat_files_mtime_0 \
+    | sort -t "$(printf '\t')" -k1,1rn | awk -F'\t' -v n="$limit" 'NR<=n { sub(/^[^\t]*\t/, ""); print }'
 }
 
 # Resolve the current Codex thread id. CODEX_THREAD_ID is only exported on the

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -219,3 +219,32 @@ compat_file_mtime() {
     *)      stat -c %Y "$file" 2>/dev/null ;;
   esac
 }
+
+# Batch variant of compat_file_mtime: read NUL-separated paths on stdin
+# (find -print0) and emit one "<mtime><TAB><path>" line per file, spawning
+# one stat per argv batch instead of one process chain per file.
+#
+# Why a batch form exists at all: `mtime=$(compat_file_mtime "$f")` in a
+# per-file loop pays a command-substitution subshell + uname + stat for
+# every file (the subshell also discards the platform memo each time). On
+# Windows/MSYS2, where process creation is orders of magnitude costlier
+# than a Linux fork, that turns a scan of a few thousand files into
+# minutes of wall clock. xargs keeps each stat invocation under the argv
+# limit (cf. the E2BIG failures in #882), so arbitrarily long lists stay
+# safe.
+#
+# A path that vanishes between the listing and the stat batch (a real race
+# against a live writer) makes stat report an error for that file and exit
+# nonzero, but every surviving file is still printed -- so the error is
+# suppressed and the status discarded rather than letting one dead file
+# starve the caller of the whole list. Empty input is likewise quiet: stat
+# with no operands fails, which the same suppression covers.
+compat_files_mtime_0() {
+  _agmsg_detect_platform
+  local tab
+  tab=$(printf '\t')
+  case "$_agmsg_platform" in
+    macos)  xargs -0 stat -f "%m${tab}%N" 2>/dev/null ;;
+    *)      xargs -0 stat -c "%Y${tab}%n" 2>/dev/null ;;
+  esac || true
+}


### PR DESCRIPTION
Fixes #1035.

## Summary

- Replace the per-file `mtime=$(compat_file_mtime "$f")` loop in `agmsg_newest_rollout_files()` with a single `find -print0 | compat_files_mtime_0` pipeline
- Add `compat_files_mtime_0()` to `compat.sh` — reads NUL-separated paths and emits `<mtime>\t<path>` via one `xargs -0 stat` invocation per argv batch

## Why

The per-file form forks a command-substitution subshell + `uname -s` + `stat` for every rollout file. The subshell discards the `_agmsg_platform` memo, so `uname` re-runs on every iteration. On Windows/MSYS2, where process creation is orders of magnitude costlier than a Linux fork, this turns accumulated rollout history into minutes of synchronous blocking inside the SessionStart hook.

On spawn paths (app-server / `codex exec`), `CODEX_THREAD_ID` is not exported (documented behavior), so `agmsg_resolve_codex_thread` always falls through to the rollout scan — every spawned seat pays the full cost.

## Measurements (Windows 11 / MINGW64_NT / MSYS2 Git Bash)

| Rollout files | Per-file (before) | Batched (after) | Speedup |
|---------------|-------------------|-----------------|---------|
| 200 | 35.5 s | 0.15 s | ~240× |
| 2675 (real history) | ~12 min | 1.33 s | ~540× |

## Test results (Windows/MSYS2)

`bats --filter rollout tests/test_delivery.bats`: **2 pass + 1 skip** (#182 Windows-expected). The #416 mtime-ordering test passes.

Full `test_delivery.bats` (190 tests): **161 pass / 10 fail / 18 skip**. All 10 failures are in watcher/lifecycle areas (signal handling, pidfile management, delivery stop) — none in rollout or mtime code paths.

## macOS note

The `stat -f "%m\t%N"` (macOS/BSD) path is included but **not tested on macOS**. BSD `xargs -0` with empty input prints a usage error to stderr; `2>/dev/null` in the function suppresses it. Deferring to CI for macOS validation.

## Not a duplicate of

- **#449** — explicitly scoped SessionStart out
- **#423** — the PR that introduced the per-file pattern (no perf discussion)
- **#583** — moved seat assignment to app-server threads but kept rollout scan as fallback