### PR TITLE
ci: test the merged shape, not only each PR against the base it was opened on

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: tests
 
 # Run the full Bats suite on PRs targeting main or any `integration/**` branch,
+# and on pushes to either. The push leg on integration branches is what tests
+# the MERGED shape: a PR is only ever tested as "my head against the base I was
+# opened on", so with several PRs collecting on one integration branch, the
+# state that is actually dogfooded -- all of them together at the tip -- is a
+# tree no PR run ever saw.
 # and on pushes to main. The filter is a pattern rather than a list of branch
 # names because a list goes quiet exactly when a new integration branch
 # appears: a PR onto an unlisted base has no required checks, so GitHub reports
@@ -54,7 +59,7 @@ name: tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'integration/**']
   pull_request:
     branches: [main, 'integration/**']
 
@@ -70,8 +75,29 @@ permissions:
 # cancelled: its group is its own run id, and that run is what a release reads
 # (#848).
 concurrency:
-  group: tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Three cases, and they want different things.
+  #
+  #   pull_request        -- group by PR. A head that has moved makes the run
+  #                          worthless, so cancel the one before it.
+  #   push to main        -- group by run id, i.e. never cancel. A release reads
+  #                          the run for the commit it ships (#848); a main run
+  #                          that another main run cancelled would leave that
+  #                          commit with no verdict at all.
+  #   push to integration -- group by ref, and cancel. An integration branch
+  #                          collects several PRs one after another, and it is
+  #                          only ever dogfooded at its tip. Without this the
+  #                          five merges of one release queue five full suites
+  #                          that all compete for the same five macOS slots
+  #                          (the header above measured 0-50 min queue waits at
+  #                          that contention), and four of the five verdicts are
+  #                          about a tip that no longer exists by the time they
+  #                          land.
+  group: >-
+    tests-${{ github.event_name == 'pull_request'
+    && format('pr-{0}', github.event.pull_request.number)
+    || (github.ref == 'refs/heads/main' && github.run_id
+    || format('push-{0}', github.ref)) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
 
 env:
   # Number of parallel bats shards per OS. The matrix and the shard helper must

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,8 @@ name: tests
 # opened on", so with several PRs collecting on one integration branch, the
 # state that is actually dogfooded -- all of them together at the tip -- is a
 # tree no PR run ever saw.
-# and on pushes to main. The filter is a pattern rather than a list of branch
+#
+# The filter is a pattern rather than a list of branch
 # names because a list goes quiet exactly when a new integration branch
 # appears: a PR onto an unlisted base has no required checks, so GitHub reports
 # `mergeStateStatus: CLEAN` -- "nothing to check", not "everything checked" --
@@ -71,9 +72,10 @@ permissions:
 # and the account runs at most five macOS jobs at once (measured 2026-08-21:
 # 35 runs that day, 140 macOS jobs, queue waits of 0-50 min, one PR's shard
 # waiting 50 min behind runs whose heads had already been replaced). So a new
-# run for the same PR cancels the one before it. A push to main is never
-# cancelled: its group is its own run id, and that run is what a release reads
-# (#848).
+# run for the same PR cancels the one before it. The same reasoning applies to
+# an integration branch, which is only ever dogfooded at its tip. A push to main
+# is the one case that is never cancelled: its group is its own run id, and that
+# run is what a release reads (#848). The block below spells out all three.
 concurrency:
   # Three cases, and they want different things.
   #
@@ -120,8 +122,11 @@ env:
   WINDOWS_SQLITE_SHA256: 'f46ee2475de4cbe287e6e5f7d43c838796b14e7379cd216bdbb28d391429f9fc'
 
 jobs:
-  # Cheap gate: is this PR's diff entirely documentation? Pushes to main always
-  # run the full suite (docs_only=false) — main must stay fully verified.
+  # Cheap gate: is this PR's diff entirely documentation? The gate is scoped to
+  # pull_request by event name, so EVERY push runs the full suite
+  # (docs_only=false) — main because it must stay fully verified, an integration
+  # branch because its tip is what gets dogfooded and a docs-only merge still
+  # changes that tip.
   changes:
     name: detect docs-only
     runs-on: ubuntu-latest
@@ -825,7 +830,8 @@ jobs:
   # cargo check + tsc --noEmit is a few minutes, not the full-bundle cost.
   # Same always-report pattern as bats: the job always completes, and only
   # the heavy steps are gated, so it can be promoted to a required check
-  # without ever leaving a PR stuck pending. Pushes to main always run it.
+  # without ever leaving a PR stuck pending. Every push runs it (the gate is
+  # scoped to pull_request by event name), main and integration alike.
   # Fail-open mirrors bats too: steps skip only on an EXPLICIT
   # app_changed=false — if the changes job breaks and its output is empty,
   # the typecheck runs rather than green-washing a possibly-app diff.

--- a/tests/test_ci_workflow.bats
+++ b/tests/test_ci_workflow.bats
@@ -74,3 +74,39 @@
   # ...and the name pin no longer matches it.
   if grep -Fq "name: bats (\${{ matrix.os }} \${{ matrix.shard }}/4)\${{ needs.changes.outputs.docs_only == 'true' && ' — docs-only, suite skipped' || '' }}" "$mutant"; then false; fi
 }
+
+# The suite has to run on the shape that actually gets dogfooded. A PR is only
+# ever tested as "this head against the base it was opened on", so when several
+# PRs collect on one integration branch, the tip -- all of them together -- is a
+# tree no PR run has seen. The push leg on `integration/**` is what covers it.
+@test "tests run on integration branches, on both legs" {
+  local workflow="$BATS_TEST_DIRNAME/../.github/workflows/tests.yml"
+
+  # Two occurrences: one under push:, one under pull_request:. Asserting the
+  # count (not merely "present somewhere") is what makes this fail if only one
+  # leg is widened -- the failure mode that leaves the merged shape untested
+  # while every summary view still reads green.
+  run bash -c "grep -c \"branches: \[main, 'integration/\*\*'\]\" '$workflow'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "2" ]
+}
+
+# Guards the OTHER direction. A group expression alone cannot fail this: swap
+# cancel-in-progress to a bare `true` and the group still reads correctly while
+# main runs begin cancelling each other -- and a cancelled main run leaves the
+# commit a release ships with no verdict at all (#848). So the main arm is
+# asserted by name, not inferred from the group.
+@test "only main is exempt from cancellation" {
+  local workflow="$BATS_TEST_DIRNAME/../.github/workflows/tests.yml"
+
+  run grep -F "cancel-in-progress: \${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}" "$workflow"
+  [ "$status" -eq 0 ]
+
+  # main pushes group by run id, so nothing can ever supersede them.
+  run grep -F "github.ref == 'refs/heads/main' && github.run_id" "$workflow"
+  [ "$status" -eq 0 ]
+
+  # Every other push groups by ref, so a later merge supersedes an earlier one.
+  run grep -F "format('push-{0}', github.ref)" "$workflow"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
A `pull_request` run tests "this head against the base it was opened on". When
several PRs collect on one integration branch before a single merge to `main`,
the state that is actually dogfooded — all of them together at the tip — is a
tree no PR run has ever seen. #1020 made PRs *targeting* an integration branch
run; this adds the push leg, so the tip itself is tested after each merge into it.

Adding the push leg alone would have made things worse under load. Push runs
group by run id and so never cancel each other: five merges collecting one
release would queue five full suites competing for the same five macOS slots
(the comment above the concurrency block measured 0–50 min queue waits at that
contention), and four of the five verdicts would describe a tip that no longer
exists by the time they land. So the grouping now separates three cases:

| event | group | cancels |
|---|---|---|
| `pull_request` | by PR number | yes — a moved head makes the run useless |
| push to `main` | by run id | **no** — a release reads the run for the commit it ships (#848); a main run cancelled by another main run leaves that commit with no verdict |
| push to `integration/**` | by ref | yes — only the tip is ever dogfooded |

The group expression is a folded scalar whose continuation lines sit at the same
indentation as the first, so it folds to a single line. More-indented lines in a
YAML folded block keep their newlines; that is the failure this avoids, and the
folded value was read back from a parser rather than assumed.

## Tests

Two, and each was mutation-checked to fail on the break it is about and only on
that one:

- **branches** — counts *two* occurrences, so widening one leg and not the other
  fails, rather than passing on "present somewhere".
- **cancellation** — names the `main` arm explicitly. A test that only reads the
  group expression stays green while `cancel-in-progress` is swapped to a bare
  `true`, which is the direction that starts cancelling `main` runs.

Reverting the push filter fails only the first; forcing `cancel-in-progress: true`
fails only the second.
