### PR TITLE
fix(watch,inbox): deliver a backlog past the argv limit, and never fail silently (#1045/#777)

### DIFF
--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -48,13 +48,25 @@ fi
 # _sqlite_sync_lit_into in sqlite-sync.sh, which documents the same hazard.
 _AGMSG_SQ="'"
 _arr="[$(printf '%s' "$UNREAD_JSONL" | paste -sd, -)]"
-ROWS=$(agmsg_sqlite ':memory:' "
-  SELECT json_extract(value,'\$.from') || char(31) ||
-         replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||
-         json_extract(value,'\$.at') || char(31) ||
-         json_extract(value,'\$.id')
-  FROM json_each('${_arr//$_AGMSG_SQ/$_AGMSG_SQ$_AGMSG_SQ}');
-")
+# #777/#1045: build the statement into a temp file and pass it on STDIN, the way
+# history.sh (#899) already does. Interpolating a large unread backlog into the SQL
+# and handing the whole string to sqlite3 as one argv element exceeds the per-argument
+# length ceiling; the call then fails — and an unread backlog past the limit can never
+# clear itself. A single long body can carry it past the ceiling on its own.
+_agmsg_rows_sql=$(mktemp "${TMPDIR:-/tmp}/agmsg-inbox-rows.XXXXXX") || exit 13
+trap 'rm -f "$_agmsg_rows_sql"' EXIT HUP INT TERM
+{
+  printf "%s\n" "SELECT json_extract(value,'\$.from') || char(31) ||"
+  printf "%s\n" "       replace(replace(json_extract(value,'\$.body'), char(10), '\n'), char(9), '\t') || char(31) ||"
+  printf "%s\n" "       json_extract(value,'\$.at') || char(31) ||"
+  printf "%s\n" "       json_extract(value,'\$.id')"
+  printf "FROM json_each('"
+  printf '%s' "${_arr//$_AGMSG_SQ/$_AGMSG_SQ$_AGMSG_SQ}"
+  printf "');\n"
+} > "$_agmsg_rows_sql"
+ROWS=$(agmsg_sqlite ':memory:' < "$_agmsg_rows_sql")
+rm -f "$_agmsg_rows_sql"
+trap - EXIT HUP INT TERM
 
 COUNT=$(printf '%s\n' "$ROWS" | wc -l | tr -d ' ')
 echo "$COUNT new message(s):"

--- a/scripts/lib/watch-stuck-map.sh
+++ b/scripts/lib/watch-stuck-map.sh
@@ -52,3 +52,34 @@ _stuck_set() {
   _stuck_drop "$1"
   STUCK_MAP="${STUCK_MAP:+$STUCK_MAP$_AGMSG_NL}$(printf '%s\x1f%s\x1f%s' "$1" "$2" "$3")"
 }
+
+# Decide whether the watcher should serve (team=$1, agent=$2) this cycle, given
+# its actas-lock state=$3 ("other:<sid>", "free", "ours", ...). Sets PAIR_VERDICT
+# to one of:
+#   serve       -- free/ours and the team's store exists: deliver this cycle
+#   held:<sid>  -- another session holds it (broad watcher): SKIP
+#   nostore     -- the team's store does not exist yet: SKIP
+# and returns 0. On EITHER skip verdict it has already dropped the pair's stuck
+# tracker via _stuck_drop, because a cycle this watcher does not observe is not a
+# consecutive stall -- a resumed pair must start a fresh count or a healthy
+# watcher would trip the guard on the first cycle back.
+#
+# The drop lives HERE, inside the skip decision, on purpose: the two are one
+# operation. Earlier the drop was a separate statement at each `continue`, so a
+# refactor could delete it and every test stayed green -- the property was at the
+# call sites, not in a tested contract. Now removing the drop reddens this
+# function's unit test, and removing the call reddens the held/no-store behavior
+# tests. It must NOT run in a `$(...)`: _stuck_drop mutates the STUCK_MAP global,
+# which a command-substitution subshell would discard -- hence the verdict is
+# returned in PAIR_VERDICT, not on stdout. The caller handles the actas-fatal
+# case (a dedicated watcher that lost its only role EXITS) before calling this,
+# and does the once-per-transition logging keyed on the verdict.
+_pair_gate() {
+  case "$3" in
+    other:*) _stuck_drop "$1:$2"; PAIR_VERDICT="held:${3#other:}"; return 0 ;;
+  esac
+  if ! storage_store_exists "$1"; then
+    _stuck_drop "$1:$2"; PAIR_VERDICT="nostore"; return 0
+  fi
+  PAIR_VERDICT="serve"
+}

--- a/scripts/lib/watch-stuck-map.sh
+++ b/scripts/lib/watch-stuck-map.sh
@@ -1,0 +1,54 @@
+# watch-stuck-map.sh -- per-pair "stuck cursor" tracker for the delivery watcher
+# (#1045 fix 2). Kept in its own file so the map operations can be unit-tested
+# directly: watch.sh runs on source, so its inline helpers could only ever be
+# exercised through a timing-dependent end-to-end test, and on a shared host a
+# poll-cycle count cannot be hit deterministically (see #1045 review notes).
+#
+# Data structure: one record per tracked pair, records separated by NEWLINE,
+# fields within a record separated by US (\x1f): "<pair><US><cursor><US><count>".
+# The record separator must be a byte that cannot occur inside a field. A newline
+# is one we already rely on -- the watcher reads its subscription set one
+# tab-separated pair per LINE, so a team or agent name cannot contain a newline;
+# US is a control byte names never carry. An earlier version joined records with
+# a SPACE and scanned them with `for e in $STUCK_MAP`, which word-splits a name
+# like "team a" across two words so its record never matches -- the count then
+# resets every cycle and the guard this exists to provide NEVER fires. Records
+# are therefore read a whole line at a time and fields split on US only, never by
+# shell word splitting. The functions operate on the caller's STUCK_MAP global in
+# place (no subshell) so they add no fork to the watcher's poll loop.
+
+_AGMSG_NL='
+'
+
+# "<cursor><US><count>" for PAIR, or empty when PAIR is not tracked.
+_stuck_get() {
+  [ -n "$STUCK_MAP" ] || return 0
+  while IFS= read -r _sm_rec; do
+    [ -n "$_sm_rec" ] || continue
+    IFS=$'\x1f' read -r _sm_p _sm_c _sm_n <<< "$_sm_rec"
+    if [ "$_sm_p" = "$1" ]; then printf '%s\x1f%s' "$_sm_c" "$_sm_n"; return 0; fi
+  done <<< "$STUCK_MAP"
+  return 0
+}
+
+# Remove PAIR's record from STUCK_MAP (a no-op if it has none). Called on every
+# branch that STOPS observing a pair -- held by another session, or no store yet
+# -- so a resumed pair starts a fresh count instead of inheriting a stale one and
+# tripping the guard on a healthy watcher.
+_stuck_drop() {
+  [ -n "$STUCK_MAP" ] || return 0
+  _sm_out=""
+  while IFS= read -r _sm_rec; do
+    [ -n "$_sm_rec" ] || continue
+    IFS=$'\x1f' read -r _sm_p _sm_rest <<< "$_sm_rec"
+    [ "$_sm_p" = "$1" ] && continue
+    _sm_out="${_sm_out:+$_sm_out$_AGMSG_NL}$_sm_rec"
+  done <<< "$STUCK_MAP"
+  STUCK_MAP="$_sm_out"
+}
+
+# Set PAIR's record to cursor $2, count $3 (replacing any existing record).
+_stuck_set() {
+  _stuck_drop "$1"
+  STUCK_MAP="${STUCK_MAP:+$STUCK_MAP$_AGMSG_NL}$(printf '%s\x1f%s\x1f%s' "$1" "$2" "$3")"
+}

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -716,6 +716,17 @@ _held_elsewhere_without() {
 # crash (#983). The threshold is FIXED, not an env knob -- an empty/0/non-numeric knob
 # would silently disable the very guard against silence.
 STUCK_THRESHOLD=3
+# Exit status for a watcher that STOPS because delivery is unhealthy -- the store
+# read failed, or a cursor is wedged behind a pending batch. These print a reason
+# and exit, but the exit must not read as success: a supervisor or launcher that
+# only sees the process end would otherwise treat an unhealthy watcher as a clean
+# shutdown, indistinguishable from the intentional exits (install-changed,
+# session-ended, role-moved) that DO mean "done, nothing wrong". A defined
+# non-zero keeps "visible failure" visible at the process contract too. Distinct
+# from the startup exit 1 (usage / DB path / DB-open, #197) so "started, then
+# delivery broke" can be told from "never started"; the value matters only that
+# it is non-zero and stable, which the tests pin.
+_AGMSG_EXIT_DELIVERY_UNHEALTHY=75
 # Per-pair tracker state and its map operations (_stuck_get/_stuck_set/
 # _stuck_drop). Kept in a sourced lib so the record framing -- which broke for
 # names with spaces once and must not again -- can be unit-tested away from this
@@ -856,7 +867,7 @@ while true; do
       printf 'agmsg watch: cannot read delivery state for %s — the store read failed, so whether messages are waiting is unknown. Treating "unknown" as "no messages" would leave this watcher alive and silent, so it is exiting instead; restart this session (or run /%s actas <name>) to resume delivery (#1045/#777).\n' \
         "$pair_team:$pair_agent" "$(basename "$SKILL_DIR")"
       cleanup
-      exit 0
+      exit "$_AGMSG_EXIT_DELIVERY_UNHEALTHY"
     fi
     # fix 2 (#1045): update this pair's stuck-cursor tracker (see the block comment
     # before the loop). "Pending" here means real undelivered MESSAGE rows -- not a
@@ -887,7 +898,7 @@ while true; do
           printf 'agmsg watch: delivery for %s is STUCK — its read cursor (%s) has not advanced for %s poll cycles while %s bytes of messages wait behind it, so nothing is being delivered and nothing is being marked read. This watcher is exiting rather than looping in silence; restart this session (or run /%s actas <name>) to resume delivery. If it recurs, the pending batch may be hitting a system limit (#1045/#777).\n' \
             "$_agmsg_pair_key" "$READ_CURSOR" "$_agmsg_n" "$_agmsg_bytes" "$(basename "$SKILL_DIR")"
           cleanup
-          exit 0
+          exit "$_AGMSG_EXIT_DELIVERY_UNHEALTHY"
         fi
         _stuck_set "$_agmsg_pair_key" "$READ_CURSOR" "$_agmsg_n"
         ;;

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -716,7 +716,12 @@ _held_elsewhere_without() {
 # crash (#983). The threshold is FIXED, not an env knob -- an empty/0/non-numeric knob
 # would silently disable the very guard against silence.
 STUCK_THRESHOLD=3
-STUCK_MAP=""   # space-separated entries "<pair><US><cursor><US><count>" (US = \x1f)
+# Per-pair tracker state and its map operations (_stuck_get/_stuck_set/
+# _stuck_drop). Kept in a sourced lib so the record framing -- which broke for
+# names with spaces once and must not again -- can be unit-tested away from this
+# script's poll loop; see lib/watch-stuck-map.sh for the data-structure contract.
+STUCK_MAP=""
+source "$SCRIPT_DIR/lib/watch-stuck-map.sh"
 
 while true; do
   # The installation changed under us (#684). Say it on STDOUT, not stderr:
@@ -798,6 +803,9 @@ while true; do
 }${pair_team}/${pair_agent}"
           echo "agmsg watch: ${pair_team}/${pair_agent} was claimed by session ${pair_state#other:}; not serving it while they hold it." >&2
         fi
+        # Stopped observing this pair -- the holder advances the cursor now, not
+        # us -- so forget any stuck count; a gap is not consecutive stalling.
+        _stuck_drop "$pair_team:$pair_agent"
         continue
         ;;
       *)
@@ -824,45 +832,51 @@ while true; do
         *) NO_STORE_REPORTED="$NO_STORE_REPORTED $pair_team:$pair_agent"
            watch_log "${pair_team}/${pair_agent}: no store yet; skipping this pair until one exists." ;;
       esac
+      # No store to read this cycle -- not an observation of a stalled cursor, so
+      # drop any prior count; the backlog (if any) starts a fresh one on return.
+      _stuck_drop "$pair_team:$pair_agent"
       continue
     fi
     READ_CURSOR="$(storage_read_cursor_get "$pair_team" "$pair_agent" 2>/dev/null || true)"
     [ -n "$READ_CURSOR" ] || READ_CURSOR=0
     OUT="$(storage_watch_after "$READ_CURSOR" "$pair_team:$pair_agent" 2>/dev/null || true)"
     # fix 2 (#1045): update this pair's stuck-cursor tracker (see the block comment
-    # before the loop). When OUT is non-empty the pair has pending rows; if READ_CURSOR
-    # is UNCHANGED from the previous cycle, delivery did not advance it -- count that.
-    # At the threshold, say why on stdout and exit. When OUT is empty the pair is caught
-    # up, so drop its tracker and a future backlog starts a fresh count.
+    # before the loop). "Pending" here means real undelivered MESSAGE rows -- not a
+    # non-empty OUT. storage_watch_after also emits a trailing "cursor" high-water
+    # line, and that line is present for a CAUGHT-UP pair too, because the team's
+    # sequence advances whenever ANY pair in the team receives a message. Keying the
+    # tracker on [ -n "$OUT" ] would therefore treat every idle pair as perpetually
+    # pending, and on any cycle its cursor could not advance (e.g. a delivery stall
+    # that is not this pair's fault) the count would climb and fire the guard on a
+    # perfectly healthy watcher. So track a pair only while a message_sent row is
+    # actually waiting for it; a glob avoids forking grep in the poll loop. When
+    # READ_CURSOR is UNCHANGED from the previous cycle delivery did not advance it --
+    # count that; at the threshold say why on stdout and exit. With no message row
+    # waiting the pair is caught up, so drop its tracker and a future backlog starts
+    # a fresh count.
     _agmsg_pair_key="$pair_team:$pair_agent"
-    if [ -n "$OUT" ]; then
-      _agmsg_prev_c=""; _agmsg_prev_n=0; _agmsg_rest=""
-      for _agmsg_e in $STUCK_MAP; do
-        case "$_agmsg_e" in
-          "$_agmsg_pair_key"$'\x1f'*) IFS=$'\x1f' read -r _ _agmsg_prev_c _agmsg_prev_n <<< "$_agmsg_e" ;;
-          *) _agmsg_rest="${_agmsg_rest:+$_agmsg_rest }$_agmsg_e" ;;
-        esac
-      done
-      if [ "$_agmsg_prev_c" = "$READ_CURSOR" ]; then
-        _agmsg_n=$((_agmsg_prev_n + 1))
-      else
-        _agmsg_n=1
-      fi
-      if [ "$_agmsg_n" -ge "$STUCK_THRESHOLD" ]; then
-        _agmsg_bytes="$(printf '%s' "$OUT" | wc -c | tr -d ' ')"
-        printf 'agmsg watch: delivery for %s is STUCK — its read cursor (%s) has not advanced for %s poll cycles while %s bytes of messages wait behind it, so nothing is being delivered and nothing is being marked read. This watcher is exiting rather than looping in silence; restart this session (or run /%s actas <name>) to resume delivery. If it recurs, the pending batch may be hitting a system limit (#1045/#777).\n' \
-          "$_agmsg_pair_key" "$READ_CURSOR" "$_agmsg_n" "$_agmsg_bytes" "$(basename "$SKILL_DIR")"
-        cleanup
-        exit 0
-      fi
-      STUCK_MAP="${_agmsg_rest:+$_agmsg_rest }$(printf '%s\x1f%s\x1f%s' "$_agmsg_pair_key" "$READ_CURSOR" "$_agmsg_n")"
-    else
-      _agmsg_rest=""
-      for _agmsg_e in $STUCK_MAP; do
-        case "$_agmsg_e" in "$_agmsg_pair_key"$'\x1f'*) ;; *) _agmsg_rest="${_agmsg_rest:+$_agmsg_rest }$_agmsg_e" ;; esac
-      done
-      STUCK_MAP="$_agmsg_rest"
-    fi
+    case "$OUT" in
+      *'"type":"message_sent"'*)
+        IFS=$'\x1f' read -r _agmsg_prev_c _agmsg_prev_n <<< "$(_stuck_get "$_agmsg_pair_key")"
+        [ -n "$_agmsg_prev_n" ] || _agmsg_prev_n=0
+        if [ "$_agmsg_prev_c" = "$READ_CURSOR" ]; then
+          _agmsg_n=$((_agmsg_prev_n + 1))
+        else
+          _agmsg_n=1
+        fi
+        if [ "$_agmsg_n" -ge "$STUCK_THRESHOLD" ]; then
+          _agmsg_bytes="$(printf '%s' "$OUT" | wc -c | tr -d ' ')"
+          printf 'agmsg watch: delivery for %s is STUCK — its read cursor (%s) has not advanced for %s poll cycles while %s bytes of messages wait behind it, so nothing is being delivered and nothing is being marked read. This watcher is exiting rather than looping in silence; restart this session (or run /%s actas <name>) to resume delivery. If it recurs, the pending batch may be hitting a system limit (#1045/#777).\n' \
+            "$_agmsg_pair_key" "$READ_CURSOR" "$_agmsg_n" "$_agmsg_bytes" "$(basename "$SKILL_DIR")"
+          cleanup
+          exit 0
+        fi
+        _stuck_set "$_agmsg_pair_key" "$READ_CURSOR" "$_agmsg_n"
+        ;;
+      *)
+        _stuck_drop "$_agmsg_pair_key"
+        ;;
+    esac
     if [ -n "$OUT" ]; then
     # The quote is held in a variable, never written as \' in the pattern: bash 3.2
     # (macOS /bin/bash) keeps the backslash of a \' REPLACEMENT, so the inline form

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -699,6 +699,25 @@ _held_elsewhere_without() {
   printf '%s' "$out"
 }
 
+# fix 2 (#1045): a pair whose read cursor never advances while it still has pending
+# rows is STUCK -- delivery is failing every cycle and the failure is INVISIBLE: ps
+# shows a healthy process, the cursor is frozen, and stdout is silent. The symptom this
+# fixes is not "not delivered" but "not knowing it is not delivered". So count, per pair,
+# the number of CONSECUTIVE poll cycles the cursor stayed at the same value while a
+# pending batch waited -- an EVENT count, not elapsed time, which fires the same on a
+# slow and a fast machine (time would misfire on one and never fire on the other). At
+# the threshold, print WHY and exit. The report goes to STDOUT deliberately: the
+# watcher's stderr is /dev/null in every launcher we ship (#691) and the Monitor tool
+# surfaces only stdout as an event, so a reason on stderr would share the fate of the
+# delivery it reports on -- exactly the invisibility being fixed. It is a plain
+# "agmsg watch:" line, NOT the "ts | team | from -> to | body" delivery shape, so a
+# reader does not mistake it for a message. Exiting (rather than looping) makes "the
+# monitor stopped" visible; a watcher that ends without a reason cannot be told from a
+# crash (#983). The threshold is FIXED, not an env knob -- an empty/0/non-numeric knob
+# would silently disable the very guard against silence.
+STUCK_THRESHOLD=3
+STUCK_MAP=""   # space-separated entries "<pair><US><cursor><US><count>" (US = \x1f)
+
 while true; do
   # The installation changed under us (#684). Say it on STDOUT, not stderr:
   # stdout is the delivery channel the session is reading, and this watcher's
@@ -810,6 +829,40 @@ while true; do
     READ_CURSOR="$(storage_read_cursor_get "$pair_team" "$pair_agent" 2>/dev/null || true)"
     [ -n "$READ_CURSOR" ] || READ_CURSOR=0
     OUT="$(storage_watch_after "$READ_CURSOR" "$pair_team:$pair_agent" 2>/dev/null || true)"
+    # fix 2 (#1045): update this pair's stuck-cursor tracker (see the block comment
+    # before the loop). When OUT is non-empty the pair has pending rows; if READ_CURSOR
+    # is UNCHANGED from the previous cycle, delivery did not advance it -- count that.
+    # At the threshold, say why on stdout and exit. When OUT is empty the pair is caught
+    # up, so drop its tracker and a future backlog starts a fresh count.
+    _agmsg_pair_key="$pair_team:$pair_agent"
+    if [ -n "$OUT" ]; then
+      _agmsg_prev_c=""; _agmsg_prev_n=0; _agmsg_rest=""
+      for _agmsg_e in $STUCK_MAP; do
+        case "$_agmsg_e" in
+          "$_agmsg_pair_key"$'\x1f'*) IFS=$'\x1f' read -r _ _agmsg_prev_c _agmsg_prev_n <<< "$_agmsg_e" ;;
+          *) _agmsg_rest="${_agmsg_rest:+$_agmsg_rest }$_agmsg_e" ;;
+        esac
+      done
+      if [ "$_agmsg_prev_c" = "$READ_CURSOR" ]; then
+        _agmsg_n=$((_agmsg_prev_n + 1))
+      else
+        _agmsg_n=1
+      fi
+      if [ "$_agmsg_n" -ge "$STUCK_THRESHOLD" ]; then
+        _agmsg_bytes="$(printf '%s' "$OUT" | wc -c | tr -d ' ')"
+        printf 'agmsg watch: delivery for %s is STUCK — its read cursor (%s) has not advanced for %s poll cycles while %s bytes of messages wait behind it, so nothing is being delivered and nothing is being marked read. This watcher is exiting rather than looping in silence; restart this session (or run /%s actas <name>) to resume delivery. If it recurs, the pending batch may be hitting a system limit (#1045/#777).\n' \
+          "$_agmsg_pair_key" "$READ_CURSOR" "$_agmsg_n" "$_agmsg_bytes" "$(basename "$SKILL_DIR")"
+        cleanup
+        exit 0
+      fi
+      STUCK_MAP="${_agmsg_rest:+$_agmsg_rest }$(printf '%s\x1f%s\x1f%s' "$_agmsg_pair_key" "$READ_CURSOR" "$_agmsg_n")"
+    else
+      _agmsg_rest=""
+      for _agmsg_e in $STUCK_MAP; do
+        case "$_agmsg_e" in "$_agmsg_pair_key"$'\x1f'*) ;; *) _agmsg_rest="${_agmsg_rest:+$_agmsg_rest }$_agmsg_e" ;; esac
+      done
+      STUCK_MAP="$_agmsg_rest"
+    fi
     if [ -n "$OUT" ]; then
     # The quote is held in a variable, never written as \' in the pattern: bash 3.2
     # (macOS /bin/bash) keeps the backslash of a \' REPLACEMENT, so the inline form
@@ -817,17 +870,34 @@ while true; do
     # _sqlite_sync_lit_into in sqlite-sync.sh, which documents the same hazard.
     _AGMSG_SQ="'"
     _arr="[$(printf '%s' "$OUT" | paste -sd, -)]"
-    ROWS="$(agmsg_sqlite ':memory:' "
-      SELECT COALESCE(json_extract(value,'\$.type'),'') || char(31) ||
-             COALESCE(json_extract(value,'\$.id'),'') || char(31) ||
-             COALESCE(json_extract(value,'\$.at'),'') || char(31) ||
-             COALESCE(json_extract(value,'\$.team'),'') || char(31) ||
-             COALESCE(json_extract(value,'\$.from'),'') || char(31) ||
-             COALESCE(json_extract(value,'\$.to'),'') || char(31) ||
-             replace(replace(replace(COALESCE(json_extract(value,'\$.body'),''), char(13), ''), char(10), '\\n'), char(9), '\t') || char(31) ||
-             COALESCE(json_extract(value,'\$.cursor'),'')
-      FROM json_each('${_arr//$_AGMSG_SQ/$_AGMSG_SQ$_AGMSG_SQ}');
-    " 2>/dev/null || true)"
+    # #777/#1045: build the statement into a temp file and pass it on STDIN, the way
+    # history.sh (#899) already does. Interpolating the pending batch into the SQL and
+    # handing the whole string to sqlite3 as ONE argv element exceeds the per-argument
+    # length ceiling once a backlog (or a single long body) grows past it; the call then
+    # fails, and because the failure was swallowed here the cursor never advanced and the
+    # SAME oversized batch came back every cycle -- a silent, self-locking outage. The
+    # temp file is removed inline (no EXIT trap, which would displace the watcher's own
+    # cleanup trap); the stuck-cursor guard below is the backstop for any OTHER cause.
+    _agmsg_watch_sql="$(mktemp "${TMPDIR:-/tmp}/agmsg-watch-rows.XXXXXX" 2>/dev/null || true)"
+    if [ -n "$_agmsg_watch_sql" ]; then
+      {
+        printf "%s\n" "SELECT COALESCE(json_extract(value,'\$.type'),'') || char(31) ||"
+        printf "%s\n" "       COALESCE(json_extract(value,'\$.id'),'') || char(31) ||"
+        printf "%s\n" "       COALESCE(json_extract(value,'\$.at'),'') || char(31) ||"
+        printf "%s\n" "       COALESCE(json_extract(value,'\$.team'),'') || char(31) ||"
+        printf "%s\n" "       COALESCE(json_extract(value,'\$.from'),'') || char(31) ||"
+        printf "%s\n" "       COALESCE(json_extract(value,'\$.to'),'') || char(31) ||"
+        printf "%s\n" "       replace(replace(replace(COALESCE(json_extract(value,'\$.body'),''), char(13), ''), char(10), '\\n'), char(9), '\t') || char(31) ||"
+        printf "%s\n" "       COALESCE(json_extract(value,'\$.cursor'),'')"
+        printf "FROM json_each('"
+        printf '%s' "${_arr//$_AGMSG_SQ/$_AGMSG_SQ$_AGMSG_SQ}"
+        printf "');\n"
+      } > "$_agmsg_watch_sql"
+      ROWS="$(agmsg_sqlite ':memory:' < "$_agmsg_watch_sql" 2>/dev/null || true)"
+      rm -f "$_agmsg_watch_sql"
+    else
+      ROWS=""
+    fi
 
     FINAL_CURSOR=""
     DELIVERED_IDS=()

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -772,74 +772,92 @@ while true; do
     # pair is the half a running process can detect for the price of a file
     # read. Gaining one is the caller's job, at the point it creates the team.
     pair_state="$(actas_lock_state "$pair_team" "$pair_agent" "$SESSION_ID" 2>/dev/null || echo free)"
-    case "$pair_state" in
-      other:*)
-        if [ -n "$ACTIVE_NAME" ]; then
-          # This watcher exists to serve exactly this role and no longer owns
-          # it. Stop -- and say so: stderr is the only place a reason survives,
-          # and a watcher that ends without one is indistinguishable from one
-          # that crashed.
+    # actas-fatal: a watcher that exists to serve exactly this one role, and no
+    # longer owns it, stops -- and says so on stderr (the only place a reason
+    # survives; a watcher that ends without one is indistinguishable from a
+    # crash). This is decided here, before the gate, because it EXITS rather than
+    # skips; the gate only decides serve-vs-skip for a watcher that keeps running.
+    if [ -n "$ACTIVE_NAME" ]; then
+      case "$pair_state" in
+        other:*)
           watch_log "${pair_team}/${pair_agent} is now held by session ${pair_state#other:}."
           watch_log "this watcher no longer owns that role and is stopping."
           watch_log "messages for it stay unread and reach the session that claimed it."
           exit 0
-        fi
+          ;;
+      esac
+    fi
+    # Serve-or-skip, with the stuck-tracker drop tied to the skip (see _pair_gate
+    # in lib/watch-stuck-map.sh). held/nostore -> skip and the count is already
+    # forgotten; serve -> proceed. The transition logging stays here, keyed on the
+    # verdict, so it is announced once per transition, not once per cycle.
+    _pair_gate "$pair_team" "$pair_agent" "$pair_state"
+    case "$PAIR_VERDICT" in
+      held:*)
         # Broad subscription: this watcher serves other roles too, so skip the
         # pair rather than ending the process -- exiting here would take down a
         # whole session's delivery because one of its roles moved elsewhere.
-        #
-        # Skipped FOR AS LONG AS someone else holds it, not permanently. When
-        # the holder goes away the lock reads free again and this watcher takes
-        # the pair back, which is the same rule the startup filter uses (a
-        # stale lock is free). Dropping it for good would be worse: the role is
-        # still registered to this project, so nobody would deliver for it
-        # until the session restarted.
-        #
-        # Announced on each transition, not each cycle -- a per-cycle message
-        # would bury the log, and announcing only the first time would make a
-        # second departure invisible.
+        # Skipped FOR AS LONG AS someone else holds it: when the holder goes away
+        # the lock reads free again and this watcher takes the pair back (a stale
+        # lock is free, the startup filter's rule). Announced on each transition,
+        # not each cycle, and not only the first time (a second departure must
+        # still be visible).
         if ! _held_elsewhere_has "${pair_team}/${pair_agent}"; then
           HELD_ELSEWHERE="${HELD_ELSEWHERE:+$HELD_ELSEWHERE
 }${pair_team}/${pair_agent}"
-          echo "agmsg watch: ${pair_team}/${pair_agent} was claimed by session ${pair_state#other:}; not serving it while they hold it." >&2
+          echo "agmsg watch: ${pair_team}/${pair_agent} was claimed by session ${PAIR_VERDICT#held:}; not serving it while they hold it." >&2
         fi
-        # Stopped observing this pair -- the holder advances the cursor now, not
-        # us -- so forget any stuck count; a gap is not consecutive stalling.
-        _stuck_drop "$pair_team:$pair_agent"
         continue
         ;;
-      *)
-        # Free or ours. If we had stepped aside for it, say that we are taking
-        # it back -- otherwise the log shows a role leaving and never returning,
-        # which reads as a permanent drop.
-        if _held_elsewhere_has "${pair_team}/${pair_agent}"; then
-          HELD_ELSEWHERE="$(_held_elsewhere_without "${pair_team}/${pair_agent}")"
-          echo "agmsg watch: ${pair_team}/${pair_agent} is unheld again; serving it here." >&2
-        fi
+      nostore)
+        # Per team: with a store per team, "one team has no store yet" is a
+        # normal state, and a single check outside this loop would silence
+        # delivery for every OTHER team as well. Said once per pair per process
+        # (#692) -- a line every poll interval would bury the log it exists to
+        # make readable.
+        case " $NO_STORE_REPORTED " in
+          *" $pair_team:$pair_agent "*) ;;
+          *) NO_STORE_REPORTED="$NO_STORE_REPORTED $pair_team:$pair_agent"
+             watch_log "${pair_team}/${pair_agent}: no store yet; skipping this pair until one exists." ;;
+        esac
+        continue
         ;;
     esac
-    # Per team: with a store per team, "one team has no store yet" is a
-    # normal state, and a single check outside this loop would silence
-    # delivery for every OTHER team as well.
-    # Skipped, and said once. The same "stop quietly" shape as the guard above
-    # (#692): a team with no store yet is a normal state, but a team that
-    # silently stops being delivered every cycle is not distinguishable from
-    # one that is fine. Once per pair per process -- a line every poll interval
-    # would bury the log this exists to make readable.
-    if ! storage_store_exists "$pair_team"; then
-      case " $NO_STORE_REPORTED " in
-        *" $pair_team:$pair_agent "*) ;;
-        *) NO_STORE_REPORTED="$NO_STORE_REPORTED $pair_team:$pair_agent"
-           watch_log "${pair_team}/${pair_agent}: no store yet; skipping this pair until one exists." ;;
-      esac
-      # No store to read this cycle -- not an observation of a stalled cursor, so
-      # drop any prior count; the backlog (if any) starts a fresh one on return.
-      _stuck_drop "$pair_team:$pair_agent"
-      continue
+    # serve: free or ours, store present. If we had stepped aside for it, say we
+    # are taking it back -- otherwise the log shows a role leaving and never
+    # returning, which reads as a permanent drop.
+    if _held_elsewhere_has "${pair_team}/${pair_agent}"; then
+      HELD_ELSEWHERE="$(_held_elsewhere_without "${pair_team}/${pair_agent}")"
+      echo "agmsg watch: ${pair_team}/${pair_agent} is unheld again; serving it here." >&2
     fi
-    READ_CURSOR="$(storage_read_cursor_get "$pair_team" "$pair_agent" 2>/dev/null || true)"
-    [ -n "$READ_CURSOR" ] || READ_CURSOR=0
-    OUT="$(storage_watch_after "$READ_CURSOR" "$pair_team:$pair_agent" 2>/dev/null || true)"
+    # Read this pair's delivery state -- its read frontier, then the messages
+    # past it -- and KEEP THE STATUS separate from the output. A failed read must
+    # not collapse to "" and fall into the caught-up arm below: that arm drops the
+    # tracker and continues in silence, which is the exact outage #1045 exists to
+    # catch, one level earlier. The stuck guard cannot see this one -- a failed
+    # scan returns no message_sent row to count, so the pair looks caught up
+    # forever. So on a failed observation, say why on stdout (a plain
+    # "agmsg watch:" line, not the delivery shape) and exit: a bounded, visible
+    # stop, never silent continuation. This is the same failure-is-not-empty
+    # collapse the cursor-only fix above closed, at the read itself.
+    #
+    # The two OTHER reads in this cycle that also fall back to empty are the
+    # DIFFERENT case the stuck guard already covers, so they are left as-is: the
+    # mktemp and the ':memory:' delivery query (below) can fail to "", but OUT
+    # still holds the message_sent rows, so a frozen cursor climbs to the
+    # threshold and fires. actas_lock_state's fall back to "free" (above) is a
+    # deliberate fail-open (a stale/unreadable lock is free, #595), not this
+    # class. Reverting either read here to `|| true` reopens the silent hole --
+    # a mutation test asserts it.
+    if READ_CURSOR="$(storage_read_cursor_get "$pair_team" "$pair_agent" 2>/dev/null)" \
+       && OUT="$(storage_watch_after "$READ_CURSOR" "$pair_team:$pair_agent" 2>/dev/null)"; then
+      [ -n "$READ_CURSOR" ] || READ_CURSOR=0
+    else
+      printf 'agmsg watch: cannot read delivery state for %s — the store read failed, so whether messages are waiting is unknown. Treating "unknown" as "no messages" would leave this watcher alive and silent, so it is exiting instead; restart this session (or run /%s actas <name>) to resume delivery (#1045/#777).\n' \
+        "$pair_team:$pair_agent" "$(basename "$SKILL_DIR")"
+      cleanup
+      exit 0
+    fi
     # fix 2 (#1045): update this pair's stuck-cursor tracker (see the block comment
     # before the loop). "Pending" here means real undelivered MESSAGE rows -- not a
     # non-empty OUT. storage_watch_after also emits a trailing "cursor" high-water

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -409,3 +409,20 @@ _codex_proj() {
   grep -q 'additive' <<<"$output"
   [ "$(pair_unread_count ctm alice)" -eq 0 ]
 }
+
+@test "inbox: an unread backlog past the argv ceiling still delivers (#1045/#777, stdin)" {
+  # The old inline-SQL path handed the whole backlog to sqlite3 as ONE argv element;
+  # once it exceeded ARG_MAX the call failed and the backlog could never clear itself.
+  # Building the statement into a temp file and passing it on stdin removes the ceiling.
+  local big i
+  big="$(head -c 200000 /dev/zero | tr '\0' x)"      # 200 KB body
+  for i in 1 2 3 4 5 6; do
+    bash "$SCRIPTS/send.sh" testteam bob alice "MSG${i}-${big}-END${i}" >/dev/null
+  done                                                # ~1.2 MB backlog, past ARG_MAX (1 MB)
+  run bash "$SCRIPTS/inbox.sh" testteam alice
+  [ "$status" -eq 0 ]
+  grep -q "6 new message(s):" <<<"$output"
+  # the first and last actually came through -- not a truncated or empty head
+  grep -q "MSG1-" <<<"$output"
+  grep -q "END6" <<<"$output"
+}

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -411,18 +411,34 @@ _codex_proj() {
 }
 
 @test "inbox: an unread backlog past the argv ceiling still delivers (#1045/#777, stdin)" {
-  # The old inline-SQL path handed the whole backlog to sqlite3 as ONE argv element;
-  # once it exceeded ARG_MAX the call failed and the backlog could never clear itself.
-  # Building the statement into a temp file and passing it on stdin removes the ceiling.
-  local big i
-  big="$(head -c 200000 /dev/zero | tr '\0' x)"      # 200 KB body
-  for i in 1 2 3 4 5 6; do
-    bash "$SCRIPTS/send.sh" testteam bob alice "MSG${i}-${big}-END${i}" >/dev/null
-  done                                                # ~1.2 MB backlog, past ARG_MAX (1 MB)
+  # The old inline-SQL path handed the whole backlog to sqlite3 as ONE argv
+  # element; once that exceeded the OS argument limit the call failed and the
+  # backlog could never clear itself. Building the statement into a temp file and
+  # passing it on stdin removes the ceiling.
+  #
+  # The backlog is built from many NORMAL-sized messages -- the real shape of the
+  # bug -- so the fixture itself never puts an oversized argument on argv. Linux
+  # caps a single argv element at 128 KB (MAX_ARG_STRLEN), which macOS does not;
+  # the earlier 200 KB single body passed on macOS and failed on the ubuntu
+  # runner with "Argument list too long". The COUNT is derived from the measured
+  # ARG_MAX so the delivered batch is guaranteed to exceed it ON THIS host -- a
+  # fixed size can sit under the limit where ARG_MAX is larger and pass green
+  # without exercising the ceiling at all.
+  local arg_max body count total i last filler
+  arg_max="$(getconf ARG_MAX)"
+  body=90000                                    # one message body, < 128 KB per-arg cap
+  count=$(( arg_max / body + 3 ))               # total payload > ARG_MAX, with margin
+  total=$(( count * body ))
+  [ "$total" -gt "$arg_max" ]                   # guarantee the ceiling is actually exceeded
+  filler="$(head -c "$body" /dev/zero | tr '\0' x)"
+  for i in $(seq 1 "$count"); do
+    bash "$SCRIPTS/send.sh" testteam bob alice "MSG${i}-${filler}-END${i}" >/dev/null
+  done
+  last="$count"
   run bash "$SCRIPTS/inbox.sh" testteam alice
   [ "$status" -eq 0 ]
-  grep -q "6 new message(s):" <<<"$output"
+  grep -q "${count} new message(s):" <<<"$output"
   # the first and last actually came through -- not a truncated or empty head
   grep -q "MSG1-" <<<"$output"
-  grep -q "END6" <<<"$output"
+  grep -q "END${last}" <<<"$output"
 }

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -1073,8 +1073,12 @@ STUB
   # (2) ...and the watcher must EXIT on its own, not keep looping.
   local i alive=1
   for i in $(seq 1 60); do kill -0 "$w" 2>/dev/null || { alive=0; break; }; sleep 0.1; done
-  kill "$w" 2>/dev/null || true; wait "$w" 2>/dev/null || true
-  [ "$alive" -eq 0 ]
+  if [ "$alive" -ne 0 ]; then kill "$w" 2>/dev/null || true; false; fi
+  # (3) ...and it must report FAILURE at the process contract (the defined
+  # unhealthy code, 75), not exit 0 -- a supervisor must not read a wedged
+  # watcher as a clean shutdown. Reverting the arm to `exit 0` turns this red.
+  local st=0; wait "$w" || st=$?
+  [ "$st" -eq 75 ]
   # the report is a plain "agmsg watch:" line, never mistaken for a "team | from → to" message
   grep -q "agmsg watch: delivery for team:alice is STUCK" "$out"
 }
@@ -1185,8 +1189,12 @@ STUB
   # `|| true` makes the message never appear and the watcher never exit -> red.)
   local i alive=1
   for i in $(seq 1 60); do kill -0 "$w" 2>/dev/null || { alive=0; break; }; sleep 0.1; done
-  kill "$w" 2>/dev/null || true; wait "$w" 2>/dev/null || true
-  [ "$alive" -eq 0 ]
+  if [ "$alive" -ne 0 ]; then kill "$w" 2>/dev/null || true; false; fi
+  # ...with the defined unhealthy exit code (75), not exit 0: a failed store read
+  # is unhealthy, and the process contract must say so. Reverting the arm to
+  # `exit 0` turns this red.
+  local st=0; wait "$w" || st=$?
+  [ "$st" -eq 75 ]
   # Non-delivery-shaped diagnostic (a plain "agmsg watch:" line, not "ts | team | from → to | body").
   grep -q "agmsg watch: cannot read delivery state for team:alice" "$out"
 }

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -1028,16 +1028,23 @@ _record_handover_events() {
 
 @test "watch: a backlog past the argv ceiling still delivers (#1045/#777, stdin)" {
   skip_on_windows "watcher background launch under Git Bash (#182)"
-  # Same exposure as inbox: the pending batch interpolated into one argv element
-  # exceeds ARG_MAX and the delivery call fails; on stdin it does not. Send past 1 MB.
-  local big i
-  big="$(head -c 200000 /dev/zero | tr '\0' x)"       # 200 KB body
-  for i in 1 2 3 4 5 6; do
-    bash "$SCRIPTS/send.sh" team bob alice "WMSG${i}-${big}-WEND${i}" >/dev/null
-  done                                                 # ~1.2 MB backlog, past ARG_MAX
-  run_watcher_until "sess-wbig" "$TEST_SKILL_DIR/wbig.log" "WEND6"
+  # Same exposure as the inbox argv-ceiling test (see it for why the backlog is
+  # many normal messages sized from the measured ARG_MAX, not one oversized body:
+  # a single >128 KB argv element fails on the ubuntu runner though it fits on
+  # macOS, and a fixed size can pass green without exceeding a larger ARG_MAX).
+  local arg_max body count i last filler
+  arg_max="$(getconf ARG_MAX)"
+  body=90000                                    # one message body, < 128 KB per-arg cap
+  count=$(( arg_max / body + 3 ))               # total payload > ARG_MAX, with margin
+  [ $(( count * body )) -gt "$arg_max" ]        # guarantee the ceiling is actually exceeded
+  filler="$(head -c "$body" /dev/zero | tr '\0' x)"
+  for i in $(seq 1 "$count"); do
+    bash "$SCRIPTS/send.sh" team bob alice "WMSG${i}-${filler}-WEND${i}" >/dev/null
+  done
+  last="$count"
+  run_watcher_until "sess-wbig" "$TEST_SKILL_DIR/wbig.log" "WEND${last}"
   grep -q "WMSG1-" "$TEST_SKILL_DIR/wbig.log"
-  grep -q "WEND6" "$TEST_SKILL_DIR/wbig.log"
+  grep -q "WEND${last}" "$TEST_SKILL_DIR/wbig.log"
 }
 
 @test "watch: a cursor stuck N cycles with pending rows reports on stdout and exits (#1045)" {
@@ -1144,4 +1151,42 @@ STUB
   kill -0 "$w" 2>/dev/null
   kill "$w" 2>/dev/null || true; wait "$w" 2>/dev/null || true
   ! grep -q "is STUCK" "$out"
+}
+
+@test "watch: a failed pending-scan is surfaced and exits, not collapsed to caught-up (#1045)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  # The loop reads whether messages are waiting with storage_watch_after. If that
+  # READ fails and the failure collapses to "" (the old `|| true`), the caught-up
+  # arm drops the tracker and the watcher continues in silence forever -- the very
+  # outage #1045 exists to catch, and one the stuck guard cannot see (a failed
+  # scan returns no message_sent row to count). So a failed read must be surfaced
+  # and exit, not treated as "no messages".
+  #
+  # Fail ONLY the pending scan: its SQL is the one passed on argv that contains
+  # "message_sent" (the startup "SELECT 1;" and the cursor read do not; the
+  # delivery query goes over stdin with ':memory:'). The startup DB healthcheck
+  # therefore still passes, so this exercises a RUNTIME read failure, not startup.
+  bash "$SCRIPTS/send.sh" team bob alice "SEED" >/dev/null   # create the store
+  local realsqlite; realsqlite="$(command -v sqlite3)"
+  local stub="$TEST_SKILL_DIR/sqstub4"; mkdir -p "$stub"
+  cat > "$stub/sqlite3" <<STUB
+#!/usr/bin/env bash
+for _a in "\$@"; do case "\$_a" in *message_sent*) exit 1 ;; esac; done
+exec "$realsqlite" "\$@"
+STUB
+  chmod +x "$stub/sqlite3"
+  local out="$TEST_SKILL_DIR/pollfail.log"
+  AGMSG_WATCH_INTERVAL=1 env PATH="$stub:$PATH" bash "$SCRIPTS/watch.sh" \
+    sess-pollfail "$PROJ" claude-code alice >"$out" 2>/dev/null 3>&- 4>&- &
+  local w=$!
+  # The failed read must be surfaced...
+  if ! _wait_for_file_contains "$out" "cannot read delivery state"; then kill "$w" 2>/dev/null || true; false; fi
+  # ...and the watcher must EXIT, not loop in silence. (Reverting the read to
+  # `|| true` makes the message never appear and the watcher never exit -> red.)
+  local i alive=1
+  for i in $(seq 1 60); do kill -0 "$w" 2>/dev/null || { alive=0; break; }; sleep 0.1; done
+  kill "$w" 2>/dev/null || true; wait "$w" 2>/dev/null || true
+  [ "$alive" -eq 0 ]
+  # Non-delivery-shaped diagnostic (a plain "agmsg watch:" line, not "ts | team | from → to | body").
+  grep -q "agmsg watch: cannot read delivery state for team:alice" "$out"
 }

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -1011,3 +1011,49 @@ _record_handover_events() {
   # must NOT reach the "belongs to someone else" fallthrough with an empty recorded side
   refute grep -q "belongs to someone else" "$WLOG"
 }
+
+@test "watch: a backlog past the argv ceiling still delivers (#1045/#777, stdin)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  # Same exposure as inbox: the pending batch interpolated into one argv element
+  # exceeds ARG_MAX and the delivery call fails; on stdin it does not. Send past 1 MB.
+  local big i
+  big="$(head -c 200000 /dev/zero | tr '\0' x)"       # 200 KB body
+  for i in 1 2 3 4 5 6; do
+    bash "$SCRIPTS/send.sh" team bob alice "WMSG${i}-${big}-WEND${i}" >/dev/null
+  done                                                 # ~1.2 MB backlog, past ARG_MAX
+  run_watcher_until "sess-wbig" "$TEST_SKILL_DIR/wbig.log" "WEND6"
+  grep -q "WMSG1-" "$TEST_SKILL_DIR/wbig.log"
+  grep -q "WEND6" "$TEST_SKILL_DIR/wbig.log"
+}
+
+@test "watch: a cursor stuck N cycles with pending rows reports on stdout and exits (#1045)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  # Force the delivery query -- the ONLY sqlite call in the loop whose last arg is
+  # ':memory:' (SQL on stdin) -- to return nothing, while the store queries (a real DB
+  # file as the last arg) keep working. So OUT stays non-empty, ROWS is empty, the
+  # cursor never advances, and the SAME batch returns every cycle: the exact silent
+  # self-lock. The stuck guard must notice after STUCK_THRESHOLD cycles, say why on
+  # STDOUT (stderr is /dev/null here), and EXIT rather than loop in silence.
+  local realsqlite; realsqlite="$(command -v sqlite3)"
+  local stub="$TEST_SKILL_DIR/sqstub"; mkdir -p "$stub"
+  cat > "$stub/sqlite3" <<STUB
+#!/usr/bin/env bash
+if [ "\${@: -1}" = ":memory:" ]; then cat >/dev/null 2>&1; exit 0; fi
+exec "$realsqlite" "\$@"
+STUB
+  chmod +x "$stub/sqlite3"
+  bash "$SCRIPTS/send.sh" team bob alice "STUCKMSG" >/dev/null   # pending; delivery will fail
+  local out="$TEST_SKILL_DIR/stuck.log"
+  AGMSG_WATCH_INTERVAL=1 env PATH="$stub:$PATH" bash "$SCRIPTS/watch.sh" \
+    sess-stuck "$PROJ" claude-code >"$out" 2>/dev/null 3>&- 4>&- &
+  local w=$!
+  # (1) the report must appear...
+  if ! _wait_for_file_contains "$out" "is STUCK"; then kill "$w" 2>/dev/null || true; false; fi
+  # (2) ...and the watcher must EXIT on its own, not keep looping.
+  local i alive=1
+  for i in $(seq 1 60); do kill -0 "$w" 2>/dev/null || { alive=0; break; }; sleep 0.1; done
+  kill "$w" 2>/dev/null || true; wait "$w" 2>/dev/null || true
+  [ "$alive" -eq 0 ]
+  # the report is a plain "agmsg watch:" line, never mistaken for a "team | from → to" message
+  grep -q "agmsg watch: delivery for team:alice is STUCK" "$out"
+}

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -293,10 +293,24 @@ _wait_for_file_contains() {
   wait "$sesspid" 2>/dev/null || true
   bash "$SCRIPTS/send.sh" team bob alice "M2-undelivered" >/dev/null
   _wait_for_missing "$pf" || { kill "$w" 2>/dev/null || true; false; }
+  # The pidfile is removed on the exit path; the process itself dies a beat
+  # later, and on a loaded host that beat is long enough to lose a race against
+  # an instant kill -0. The contract is that the watcher EXITS within ~1 interval
+  # of the session dying, not that it is already reaped the microsecond its
+  # pidfile vanishes -- so wait a bounded moment for the process to be gone. A
+  # watcher that never exits (a real liveness bug) still fails: the loop exhausts
+  # and kill -0 keeps succeeding.
+  local _i; for _i in $(seq 1 50); do kill -0 "$w" 2>/dev/null || break; sleep 0.1; done
   run kill -0 "$w"; [ "$status" -ne 0 ]
   [ "$(_read_cursor team alice)" = "$first_cursor" ]
   refute grep -q "M2-undelivered" "$out"
-  run_watcher_for "after-liveness" "$TEST_SKILL_DIR/liveness-redelivery.log" 2
+  # Wait for the redelivery instead of sleeping a fixed 2s: a fresh watcher must
+  # deliver the row the dead one left unconsumed, but WHEN it lands depends on
+  # host load, not on the contract (see the run_watcher_for/until note above --
+  # a fixed sleep is a claim about the machine). run_watcher_until blocks until
+  # M2 is delivered and the cursor advances, or fails if it never does, so a real
+  # non-redelivery still fails while load-induced slowness no longer does.
+  run_watcher_until "after-liveness" "$TEST_SKILL_DIR/liveness-redelivery.log" "M2-undelivered"
   grep -q "M2-undelivered" "$TEST_SKILL_DIR/liveness-redelivery.log"
 }
 
@@ -1056,4 +1070,78 @@ STUB
   [ "$alive" -eq 0 ]
   # the report is a plain "agmsg watch:" line, never mistaken for a "team | from → to" message
   grep -q "agmsg watch: delivery for team:alice is STUCK" "$out"
+}
+
+@test "watch: the stuck guard fires for a pair whose agent name has a space (#1045)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  # End-to-end companion to test_watch_stuck_map.bats: the tracker keys on the
+  # "<team>:<agent>" pair, and identities.sh emits a spaced agent as one
+  # tab-separated field, so the key carries the space. The first cut framed the
+  # tracker with spaces and scanned it with `for e in $MAP`, splitting "sp aced"
+  # across words: its record never matched, the count reset every cycle, and the
+  # guard NEVER fired for that pair -- the silence-catcher silent. Restoring word
+  # splitting turns this red (the report never appears -> the wait times out).
+  local sproj="/tmp/agmsg-watch-spaced-proj"
+  bash "$SCRIPTS/join.sh" team 'sp aced' claude-code "$sproj" >/dev/null
+  bash "$SCRIPTS/join.sh" team bob claude-code "$sproj" >/dev/null
+  local realsqlite; realsqlite="$(command -v sqlite3)"
+  local stub="$TEST_SKILL_DIR/sqstub2"; mkdir -p "$stub"
+  cat > "$stub/sqlite3" <<STUB
+#!/usr/bin/env bash
+if [ "\${@: -1}" = ":memory:" ]; then cat >/dev/null 2>&1; exit 0; fi
+exec "$realsqlite" "\$@"
+STUB
+  chmod +x "$stub/sqlite3"
+  bash "$SCRIPTS/send.sh" team bob 'sp aced' "SPACEDMSG" >/dev/null  # pending; delivery will fail
+  local out="$TEST_SKILL_DIR/stuck-spaced.log"
+  AGMSG_WATCH_INTERVAL=1 env PATH="$stub:$PATH" bash "$SCRIPTS/watch.sh" \
+    sess-stuck-sp "$sproj" claude-code >"$out" 2>/dev/null 3>&- 4>&- &
+  local w=$!
+  if ! _wait_for_file_contains "$out" "is STUCK"; then kill "$w" 2>/dev/null || true; false; fi
+  local i alive=1
+  for i in $(seq 1 60); do kill -0 "$w" 2>/dev/null || { alive=0; break; }; sleep 0.1; done
+  kill "$w" 2>/dev/null || true; wait "$w" 2>/dev/null || true
+  [ "$alive" -eq 0 ]
+  grep -q "agmsg watch: delivery for team:sp aced is STUCK" "$out"
+}
+
+@test "watch: an idle pair seeing only a cursor high-water is not treated as stuck (#1045)" {
+  skip_on_windows "watcher background launch under Git Bash (#182)"
+  # storage_watch_after appends a trailing "cursor" high-water line even for a
+  # CAUGHT-UP pair, because the team's sequence advances whenever ANY pair in the
+  # team gets a message. So OUT is non-empty for an idle pair with zero messages
+  # of its own. The stuck tracker must key on real message_sent rows, not on
+  # [ -n "$OUT" ]; otherwise a healthy idle watcher whose cursor cannot advance
+  # (here: the delivery query is stubbed to fail, freezing every cursor) would
+  # climb to the threshold and EXIT. 'idle' has no messages; the bob->alice send
+  # only bumps the team high-water, so 'idle' sees a cursor-only OUT. The guard
+  # must NOT fire. Reverting the tracker to [ -n "$OUT" ] turns this red.
+  bash "$SCRIPTS/join.sh" team idle claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/send.sh" team bob alice "BUMP" >/dev/null   # bumps team high-water, not for idle
+  local realsqlite; realsqlite="$(command -v sqlite3)"
+  local stub="$TEST_SKILL_DIR/sqstub3"; mkdir -p "$stub"
+  cat > "$stub/sqlite3" <<STUB
+#!/usr/bin/env bash
+if [ "\${@: -1}" = ":memory:" ]; then cat >/dev/null 2>&1; exit 0; fi
+exec "$realsqlite" "\$@"
+STUB
+  chmod +x "$stub/sqlite3"
+  local out="$TEST_SKILL_DIR/idle.log"
+  # actas 'idle' narrows this watcher to the idle pair only, so no other pair's
+  # real backlog can fire and mask the property under test.
+  AGMSG_WATCH_INTERVAL=1 env PATH="$stub:$PATH" bash "$SCRIPTS/watch.sh" \
+    sess-idle "$PROJ" claude-code idle >"$out" 2>/dev/null 3>&- 4>&- &
+  local w=$!
+  # Watch across well more than STUCK_THRESHOLD cycles: if "is STUCK" ever
+  # appears the guard fired on a healthy idle pair -- fail fast.
+  local i
+  for i in $(seq 1 70); do
+    if grep -q "is STUCK" "$out" 2>/dev/null; then kill "$w" 2>/dev/null || true; false; fi
+    kill -0 "$w" 2>/dev/null || break
+    sleep 0.1
+  done
+  # It must still be alive (it neither fired nor exited for any other reason).
+  kill -0 "$w" 2>/dev/null
+  kill "$w" 2>/dev/null || true; wait "$w" 2>/dev/null || true
+  ! grep -q "is STUCK" "$out"
 }

--- a/tests/test_watch_stuck_map.bats
+++ b/tests/test_watch_stuck_map.bats
@@ -101,3 +101,43 @@ _get() {
   _stuck_drop "team:nobody"    # full map, pair absent
   _get "team:bob"; [ "$GN" = "1" ]
 }
+
+# --- _pair_gate: the drop is TIED to the skip decision (finding 2, round 3) ---
+# These pin the property AT the two skip entries, which a helper-only reset test
+# could not: the earlier code dropped the tracker in a separate statement at each
+# `continue`, so deleting it left every test green. Now the drop is inside the
+# gate's skip verdict, and these seed a count at threshold-1, fire each skip
+# transition, and assert the production state was removed -- no wall clock.
+
+@test "pair-gate: held-by-another drops the pair's stuck count and says skip" {
+  storage_store_exists() { return 0; }        # not consulted on the held path
+  _stuck_set "team:alice" 42 2                 # seed threshold-1
+  _pair_gate team alice "other:sess9"
+  [ "$PAIR_VERDICT" = "held:sess9" ]
+  _get "team:alice"; [ -z "$GN" ]              # the count was forgotten
+}
+
+@test "pair-gate: no-store drops the pair's stuck count and says skip" {
+  storage_store_exists() { return 1; }         # store absent
+  _stuck_set "team:alice" 42 2                 # seed threshold-1
+  _pair_gate team alice "free"
+  [ "$PAIR_VERDICT" = "nostore" ]
+  _get "team:alice"; [ -z "$GN" ]              # the count was forgotten
+}
+
+@test "pair-gate: a servable pair keeps its count (a success is not a skip)" {
+  storage_store_exists() { return 0; }         # store present
+  _stuck_set "team:alice" 42 2                 # seed threshold-1
+  _pair_gate team alice "free"
+  [ "$PAIR_VERDICT" = "serve" ]
+  _get "team:alice"; [ "$GC" = "42" ] && [ "$GN" = "2" ]   # untouched -> guard can still fire
+}
+
+@test "pair-gate: skip drops only the gated pair, not another tracked pair" {
+  storage_store_exists() { return 1; }
+  _stuck_set "team:alice" 42 2
+  _stuck_set "team:bob" 99 2
+  _pair_gate team alice "free"                  # no-store skip for alice
+  _get "team:alice"; [ -z "$GN" ]
+  _get "team:bob"; [ "$GC" = "99" ] && [ "$GN" = "2" ]
+}

--- a/tests/test_watch_stuck_map.bats
+++ b/tests/test_watch_stuck_map.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+# Unit tests for the watcher's stuck-cursor tracker (lib/watch-stuck-map.sh,
+# #1045 fix 2). These exercise the two failure modes a full-watcher test cannot
+# pin down deterministically on a shared host, where a poll-cycle count drifts
+# with load (see [[this machine cannot measure time]]):
+#
+#   1. A team or agent NAME WITH A SPACE must still be tracked. The first cut
+#      framed records with a space and scanned them with `for e in $MAP`, so a
+#      spaced name split across two words and its record never matched -- the
+#      guard then never fired for that pair. Restoring word splitting turns the
+#      "spaced name round-trips" tests below RED.
+#   2. The count must RESET when the watcher stops observing a pair (held by
+#      another session, or no store yet). Those branches call _stuck_drop; if
+#      they did not, a resumed pair would inherit its old count and a healthy
+#      watcher would exit early. "a drop makes a resumed pair start fresh" is
+#      that reset, isolated from timing.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  source "$SCRIPTS/lib/watch-stuck-map.sh"
+  STUCK_MAP=""
+}
+
+# Read _stuck_get "$1" into globals GC (cursor) and GN (count); empty when absent.
+_get() {
+  local raw; raw="$(_stuck_get "$1")"
+  IFS=$'\x1f' read -r GC GN <<< "$raw"
+}
+
+@test "stuck-map: a pair with spaces in both team and agent round-trips" {
+  local P="team a:agent x"
+  _stuck_set "$P" 100 1
+  _get "$P"
+  [ "$GC" = "100" ]
+  [ "$GN" = "1" ]
+}
+
+@test "stuck-map: a spaced pair reaches a bumped count (the guard can fire for it)" {
+  local P="team a:agent x"
+  _stuck_set "$P" 100 1
+  _stuck_set "$P" 100 2
+  _stuck_set "$P" 100 3
+  _get "$P"
+  [ "$GC" = "100" ]
+  [ "$GN" = "3" ]
+}
+
+@test "stuck-map: setting a pair replaces its record, it is never duplicated" {
+  local P="team a:agent x"
+  _stuck_set "$P" 100 1
+  _stuck_set "$P" 100 2
+  # Exactly one record for the pair -> exactly one line in the map.
+  [ "$(printf '%s\n' "$STUCK_MAP" | grep -c .)" -eq 1 ]
+  _get "$P"
+  [ "$GN" = "2" ]
+}
+
+@test "stuck-map: two pairs are independent; dropping one keeps the other" {
+  local P="team a:agent x" Q="team:bob"
+  _stuck_set "$P" 100 2
+  _stuck_set "$Q" 200 1
+  _stuck_drop "$P"
+  _get "$P"
+  [ -z "$GC" ] && [ -z "$GN" ]
+  _get "$Q"
+  [ "$GC" = "200" ]
+  [ "$GN" = "1" ]
+}
+
+@test "stuck-map: a drop makes a resumed pair start fresh, not inherit its count" {
+  # Model the held/no-store gap: a pair builds a count, the watcher stops
+  # observing it (drop), then serves it again. On resume _stuck_get returns
+  # empty, so the caller starts the count at 1 -- not at old+1, which for a
+  # count already at threshold-1 would exit a healthy watcher on the first
+  # cycle back. Without the drop on those branches this is old+1.
+  local P="team a:agent x"
+  _stuck_set "$P" 100 2        # two consecutive stuck cycles observed
+  _stuck_drop "$P"             # held elsewhere / store gone for a cycle
+  _get "$P"                    # resumed: nothing remembered
+  [ -z "$GN" ]
+}
+
+@test "stuck-map: one pair is not matched by another that shares a prefix" {
+  local A="team:al" B="team:alice"
+  _stuck_set "$A" 100 1
+  _stuck_set "$B" 200 2
+  _get "$A"; [ "$GC" = "100" ] && [ "$GN" = "1" ]
+  _get "$B"; [ "$GC" = "200" ] && [ "$GN" = "2" ]
+  _stuck_drop "$A"
+  _get "$A"; [ -z "$GN" ]
+  _get "$B"; [ "$GN" = "2" ]   # dropping "team:al" must not touch "team:alice"
+}
+
+@test "stuck-map: dropping an untracked pair is a no-op on an empty and a full map" {
+  _stuck_drop "team:nobody"    # empty map
+  [ -z "$STUCK_MAP" ]
+  _stuck_set "team:bob" 200 1
+  _stuck_drop "team:nobody"    # full map, pair absent
+  _get "team:bob"; [ "$GN" = "1" ]
+}


### PR DESCRIPTION
Two fixes for the argv-length outage in watch.sh / inbox.sh (#1045, the remaining sites of #777; history.sh was already done in #899). Symptom measured in production: ~1000 undelivered messages / 2.46 MB — no delivery, a frozen read cursor, and a process that `ps` reports healthy. Silent.

## 1. STDIN, not argv

`watch.sh` and `inbox.sh` interpolated the whole pending batch into the SQL and handed the string to `sqlite3` as one argv element. Past `ARG_MAX` the call fails; on the watcher path the failure was swallowed, so the cursor never advanced and the same oversized batch came back every cycle — a self-locking, silent outage that a backlog past the limit can never escape. Both paths now build the statement into a temp file and pass it on **stdin**, exactly as `history.sh` does. (watch.sh removes the temp file inline rather than with an `EXIT` trap, which would displace the watcher's own cleanup trap.)

## 2. Never fail silently

Fix 1 removes *this* trigger. The real defect is that the outage was invisible — "not delivered" is survivable; "not knowing it is not delivered" is not. So, per pair, the watcher counts **consecutive poll cycles whose read cursor did not advance while a batch waited** — an **event** count, not elapsed time, so it fires the same on a slow and a fast machine. At a fixed threshold it prints why and exits.

**Report channel — measured, not preference.** The watcher's stderr is `/dev/null` in every launcher we ship (#691, and the #684 install-changed notice already uses stdout for exactly this reason), and the Monitor tool surfaces only stdout as an event. A reason written to stderr would share the fate of the delivery it is reporting on — the very invisibility being fixed. So the report goes to **stdout**, as a plain `agmsg watch:` line — never the `ts | team | from → to | body` delivery shape, so it is not mistaken for a message. Exiting (not looping) makes "the monitor stopped" visible; a watcher that ends without a reason cannot be told from a crash (#983). The threshold is fixed, not an env knob that could arrive empty and disable the guard.

## Tests

A backlog past `ARG_MAX` delivers through both paths, each **mutation-verified** against the inline-argv form. The stuck guard reports and exits after the threshold, **mutation-verified three ways**: clean → green, remove the report → red, remove the exit → red. Reverting fix 1 additionally shows fix 2 catching the residual — it reports the 1.2 MB frozen backlog instead of looping in silence. Enforced-assertions and errexit-status-reads at baseline.

Targets `integration/terminal-driver-v1` (1.3.0), where #1026 (mark-read-after-display) — the same class of defect — also lands.
