### PR TITLE
Naming is an invariant every entry point re-asserts, and the roster can see it (#1044)

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -222,6 +222,42 @@ agmsg_storage_load
 # When there are messages to hand over the status is 0 and the text says the
 # poll was partial; only when there is nothing to deliver does the status carry
 # the failure.
+# Re-assert this pane's name (#1044), once per invocation, before any delivery.
+#
+# This entry point is the only one some types ever reach: `grok-build` has no
+# SessionStart hook and `monitor=yes` holds on two of the nine, so for the rest
+# the per-turn hook is where a hand-started pane first gets named. Idempotent by
+# construction — the driver sets the same two names again — and quiet when there
+# is no session id to resolve with, exactly as `join` is.
+#
+# Cost, stated rather than waved away: this adds one terminal resolution plus
+# the driver's rename calls per turn, per team. It is not cached, because the
+# only cheap thing to cache on is the session id, and a pane can be rearranged
+# under a session id that has not changed.
+#
+# No record is written: the seat's placement is `actas`'s claim, and a delivery
+# hook is not a claim of anything.
+#
+# The source carries the errexit lift: on bash 3.2 a failure inside a sourced
+# file fires THIS script's `set -e`, and nothing here may fail a delivery.
+_agmsg_tr_rc=0; _agmsg_tr_e=0
+case $- in *e*) _agmsg_tr_e=1 ;; esac
+set +e
+# shellcheck disable=SC1091
+[ -r "$SCRIPT_DIR/lib/terminal-registry.sh" ] && . "$SCRIPT_DIR/lib/terminal-registry.sh"
+_agmsg_tr_rc=$?
+[ "$_agmsg_tr_e" = 1 ] && set -e
+if [ "$_agmsg_tr_rc" -eq 0 ] && declare -F agmsg_terminal_name_self_safe >/dev/null 2>&1; then
+  # Guarded expansion, the form this file already uses above: bash 3.2 treats
+  # "${TEAM_LIST[@]}" on an empty array as unbound under `set -u` (measured). An
+  # early exit above makes the list non-empty here today, and this does not
+  # depend on that staying true.
+  for _nteam in ${TEAM_LIST[@]+"${TEAM_LIST[@]}"}; do
+    [ -n "$_nteam" ] || continue
+    agmsg_terminal_name_self_safe "${SESSION_ID:-}" "$_nteam" "$AGENT" "$PROJECT" "$TYPE" || true
+  done
+fi
+
 OUTPUT=""
 # Ids that have been FORMATTED but not yet written out: one "team<TAB>id id id"
 # entry per team. They become read only after the payload leaves this process.

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -523,12 +523,29 @@ _herdr_internal_key() {
 #               failed agent rename (a live-name collision, or no SHA-256 tool to
 #               derive the key) is non-fatal — the pane id in the record still
 #               resolves.
+# <mode> is `key` or absent. Absent means both names; `key` means the resolvable
+# one only, and the caller has already decided that (the registry reads the env
+# var, so the policy lives in one place and this only carries it out).
+#
+# Which of the two is which matters: `pane rename` is the label a person reads,
+# `agent rename` is what `peek`/`poke` resolve the member through. So under
+# `key` the addressing is still established and only the decoration is skipped —
+# and a key that cannot be set is an error there, because nothing else happened.
 terminal_name() {
-  local id="$1" team="$2" name="$3" label key
+  local id="$1" team="$2" name="$3" mode="${4:-}" label key
   label="$team:$name"
-  herdr pane rename "$id" "$label" >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  if [ "$mode" != key ]; then
+    herdr pane rename "$id" "$label" >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  fi
   if key="$(_herdr_internal_key "$team" "$name")"; then
-    herdr agent rename "$id" "$key" >/dev/null 2>&1 || true
+    if ! herdr agent rename "$id" "$key" >/dev/null 2>&1; then
+      if [ "$mode" = key ]; then echo runtime_error; return 13; fi
+    fi
+  elif [ "$mode" = key ]; then
+    # Nothing was attempted at all: reporting ok would say the member is
+    # addressable when no key was set.
+    echo runtime_error
+    return 13
   fi
   echo ok
   return 0

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -537,16 +537,19 @@ terminal_name() {
   if [ "$mode" != key ]; then
     herdr pane rename "$id" "$label" >/dev/null 2>&1 || { echo runtime_error; return 13; }
   fi
-  if key="$(_herdr_internal_key "$team" "$name")"; then
-    if ! herdr agent rename "$id" "$key" >/dev/null 2>&1; then
-      if [ "$mode" = key ]; then echo runtime_error; return 13; fi
-    fi
-  elif [ "$mode" = key ]; then
-    # Nothing was attempted at all: reporting ok would say the member is
-    # addressable when no key was set.
-    echo runtime_error
-    return 13
-  fi
+  # The key is not optional, in either mode. It is what peek/poke resolve the
+  # member through, so failing to set it IS the member becoming unreachable —
+  # the defect this issue is about. This used to be `|| true`, which made the
+  # severities exactly backwards: the decoration was fatal and the addressing was
+  # swallowed, so the "a name is never absent" requirement held strictly in the
+  # reduced mode and not in the default one everybody uses.
+  #
+  # A key that cannot be DERIVED is treated the same way, and that is a change on
+  # a real condition: `_herdr_internal_key` returns non-zero when no SHA-256 tool
+  # is available. Reporting ok there would say the member is addressable when no
+  # key was set — the same lie by a different route.
+  key="$(_herdr_internal_key "$team" "$name")" || { echo runtime_error; return 13; }
+  herdr agent rename "$id" "$key" >/dev/null 2>&1 || { echo runtime_error; return 13; }
   echo ok
   return 0
 }

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -528,18 +528,28 @@ _herdr_internal_key() {
 # var, so the policy lives in one place and this only carries it out).
 #
 # Which of the two is which matters: `pane rename` is the label a person reads,
-# `agent rename` is what `peek`/`poke` resolve the member through. So under
-# `key` the addressing is still established and only the decoration is skipped —
+# `agent rename` is the name herdr itself addresses the agent by, in its own
+# namespace — NOT what this repo's `peek`/`poke` resolve through, which is the
+# placement record's pane id. So under `key` that name is still established and
+# only the decoration is skipped —
 # and a key that cannot be set is an error there, because nothing else happened.
 terminal_name() {
   local id="$1" team="$2" name="$3" mode="${4:-}" label key
   label="$team:$name"
 
-  # THE KEY FIRST, and its failure is fatal. It is what `peek` and `poke` resolve
-  # the member through; the label is what a person reads. Ordering the label
-  # first meant a failed decoration returned 13 before the key was ever
-  # attempted, so the requirement this driver is here to serve — a member's pane
-  # is never without a name — broke through the other door. tmux has always had
+  # THE KEY FIRST, and its failure is fatal.
+  #
+  # The reason is NOT that peek/poke resolve through the key — an earlier
+  # revision of this comment said so and it is false in this tree: those commands
+  # resolve through the placement record's pane id, and `_herdr_internal_key` is
+  # read nowhere outside this driver. The key is the name herdr knows the agent
+  # by, on its side.
+  #
+  # The reason that survives is the one below: the caller writes the placement
+  # record only when this returns 0. Ordering the label first meant a failed
+  # DECORATION returned 13 before the key was attempted and before the record was
+  # written, so a member ended up with neither name and no record — the
+  # requirement this driver serves broke through that door. tmux has always had
   # this order; herdr was the one driver that put the ornament in front.
   key="$(_herdr_internal_key "$team" "$name")" || { echo runtime_error; return 13; }
   herdr agent rename "$id" "$key" >/dev/null 2>&1 || { echo runtime_error; return 13; }

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -534,22 +534,24 @@ _herdr_internal_key() {
 terminal_name() {
   local id="$1" team="$2" name="$3" mode="${4:-}" label key
   label="$team:$name"
-  if [ "$mode" != key ]; then
-    herdr pane rename "$id" "$label" >/dev/null 2>&1 || { echo runtime_error; return 13; }
-  fi
-  # The key is not optional, in either mode. It is what peek/poke resolve the
-  # member through, so failing to set it IS the member becoming unreachable —
-  # the defect this issue is about. This used to be `|| true`, which made the
-  # severities exactly backwards: the decoration was fatal and the addressing was
-  # swallowed, so the "a name is never absent" requirement held strictly in the
-  # reduced mode and not in the default one everybody uses.
-  #
-  # A key that cannot be DERIVED is treated the same way, and that is a change on
-  # a real condition: `_herdr_internal_key` returns non-zero when no SHA-256 tool
-  # is available. Reporting ok there would say the member is addressable when no
-  # key was set — the same lie by a different route.
+
+  # THE KEY FIRST, and its failure is fatal. It is what `peek` and `poke` resolve
+  # the member through; the label is what a person reads. Ordering the label
+  # first meant a failed decoration returned 13 before the key was ever
+  # attempted, so the requirement this driver is here to serve — a member's pane
+  # is never without a name — broke through the other door. tmux has always had
+  # this order; herdr was the one driver that put the ornament in front.
   key="$(_herdr_internal_key "$team" "$name")" || { echo runtime_error; return 13; }
   herdr agent rename "$id" "$key" >/dev/null 2>&1 || { echo runtime_error; return 13; }
+
+  # The label, and its failure is deliberately NOT fatal — the same shape tmux
+  # has. Not merely for symmetry: the caller writes the placement record only
+  # when this returns 0, and that record is the other half of addressing. A
+  # non-zero here would therefore throw away the very thing the reordering above
+  # exists to protect, for a decoration.
+  if [ "$mode" != key ]; then
+    herdr pane rename "$id" "$label" >/dev/null 2>&1 || true
+  fi
   echo ok
   return 0
 }

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -160,10 +160,14 @@ terminal_poke() {
 # select-pane -T sets the human-visible title as a copy. Canonical separator is
 # ':' (both team and agent commonly contain '-'). Idempotent (safe to re-apply on
 # SessionStart).
+# <mode> is `key` or absent — see the herdr driver for the split. Here the
+# `@agmsg_agent` pane option is the resolvable one and the window name / pane
+# title is the decoration, so `key` sets the option and stops.
 terminal_name() {
-  local id="$1" team="$2" name="$3" label
+  local id="$1" team="$2" name="$3" mode="${4:-}" label
   label="$team:$name"
   tmux set-option -p -t "$id" @agmsg_agent "$label" >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  if [ "$mode" = key ]; then echo ok; return 0; fi
   case "$id" in
     @*) tmux rename-window -t "$id" "$label" >/dev/null 2>&1 || true ;;
     *)  tmux select-pane  -t "$id" -T "$label" >/dev/null 2>&1 || true ;;

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -30,8 +30,11 @@
 #   terminal_name <id> <team> <name> [mode]
 #                                       control op: set the pane's names; idempotent.
 #                                       Two names, not one: the label a person
-#                                       reads and the key peek/poke resolve
-#                                       through. `mode=key` sets only the key
+#                                       reads and the key the TERMINAL addresses
+#                                       the agent by in its own namespace. This
+#                                       repo's peek/poke resolve through the
+#                                       placement record, not the key.
+#                                       `mode=key` sets only the key
 #                                       (AGMSG_TERMINAL_NAMING=off); absent sets
 #                                       both. A driver that has only one name
 #                                       treats it as the key.
@@ -484,10 +487,16 @@ agmsg_terminal_name_self() {
   agmsg_terminal_load "$terminal" || return 1
 
   # AGMSG_TERMINAL_NAMING=off suppresses the VISIBLE label and nothing else. The
-  # key stays, always, because it is addressing rather than decoration: dropping
-  # it makes the member unreachable to peek and poke, which is the defect #1044
-  # is about, re-created on request. A caller that genuinely wants no terminal
-  # writes at all is describing the `plain` terminal.
+  # key stays, always, because it is addressing rather than decoration — the name
+  # the TERMINAL knows the agent by, in its own namespace.
+  #
+  # Narrower than an earlier revision of this comment claimed, and the difference
+  # matters: `peek`, `poke` and `despawn` in THIS repo resolve through the
+  # placement record's pane id, and `_herdr_internal_key` is read nowhere outside
+  # its own driver (counted). So dropping the key does not make a member
+  # unreachable to agmsg. Saying it did pointed at the wrong thing to protect.
+  # A caller that genuinely wants no terminal writes at all is describing the
+  # `plain` terminal.
   #
   # The env var is read HERE and handed to the driver as a mode, so the policy
   # has one home and each driver only carries it out. Read at call time, not

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -427,6 +427,19 @@ agmsg_terminal_name_self() {
     echo "agmsg: terminal_name_self needs <team> and <agent>" >&2; return 1
   }
 
+  # The BARE sid, whatever the caller had. A terminal knows the id the CLI
+  # published; the composite "<sid>.<pid>" exists only inside agmsg, and handing
+  # it over asks a question no terminal can answer -- the answer comes back as
+  # "this session cannot identify its own pane", which reads as a resolution
+  # problem and is an identifier mismatch. That was a real defect at the actas
+  # call site, and watch.sh had it before that. Normalising HERE instead of at
+  # each caller is what stops the next entry point from repeating it: the
+  # conversion is idempotent (bare -> bare, composite -> bare, empty -> empty),
+  # so a caller cannot get it wrong by passing either form.
+  if [ -n "$sid" ] && declare -F agmsg_instance_bare_sid >/dev/null 2>&1; then
+    sid="$(agmsg_instance_bare_sid "$sid")"
+  fi
+
   # No bare `x=$(cmd)` past this point. Under `set -e` a non-zero inside a command
   # substitution ends the CALLER before the status can be read -- the shape review
   # caught four times in this branch -- so every capture carries `|| rc=$?`.

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -27,7 +27,14 @@
 #   terminal_peek <id> [--lines N]      RECORD op: print visible pane text verbatim (NOT
 #                                       parsed). unsupported -> exit 13, reason on stderr.
 #   terminal_poke <id> <text>           control op: send text and submit. unsupported -> 13.
-#   terminal_name <id> <team> <name>    control op: set the human pane name; idempotent
+#   terminal_name <id> <team> <name> [mode]
+#                                       control op: set the pane's names; idempotent.
+#                                       Two names, not one: the label a person
+#                                       reads and the key peek/poke resolve
+#                                       through. `mode=key` sets only the key
+#                                       (AGMSG_TERMINAL_NAMING=off); absent sets
+#                                       both. A driver that has only one name
+#                                       treats it as the key.
 #                                       (safe to re-apply on SessionStart).
 #
 # Detection is a driver FUNCTION (not a manifest datum like the types axis's
@@ -476,9 +483,23 @@ agmsg_terminal_name_self() {
 
   agmsg_terminal_load "$terminal" || return 1
 
+  # AGMSG_TERMINAL_NAMING=off suppresses the VISIBLE label and nothing else. The
+  # key stays, always, because it is addressing rather than decoration: dropping
+  # it makes the member unreachable to peek and poke, which is the defect #1044
+  # is about, re-created on request. A caller that genuinely wants no terminal
+  # writes at all is describing the `plain` terminal.
+  #
+  # The env var is read HERE and handed to the driver as a mode, so the policy
+  # has one home and each driver only carries it out. Read at call time, not
+  # cached: a value cached at source time is a value nobody can change.
+  local name_mode=""
+  case "${AGMSG_TERMINAL_NAMING:-}" in
+    off) name_mode=key ;;
+  esac
+
   local out=""
   rc=0
-  out="$(terminal_name "$id" "$team" "$agent")" || rc=$?
+  out="$(terminal_name "$id" "$team" "$agent" "$name_mode")" || rc=$?
   if [ "$rc" -ne 0 ]; then
     echo "agmsg: could not name this $terminal pane for $team:$agent${out:+ ($out)}" >&2
     return "$rc"

--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -20,6 +20,53 @@ if [ ! -f "$CONFIG" ]; then
   exit 1
 fi
 
+# Where each member's pane is, when we know. A pane with no name is invisible
+# from inside agmsg -- the #1044 dogfood found one by reading the terminal's own
+# JSON, because nothing here reported it -- and that is also why there was no way
+# to assert the naming requirement. This column is what makes it checkable.
+#
+# What is printed is the PLACEMENT RECORD, which is a recorded fact: the terminal
+# and the pane id that peek/poke resolve a member through. The visible label is
+# NOT printed, because reading it back means asking the terminal and no read op
+# for it exists; inferring it from the record would report a claim as an
+# observation, and under AGMSG_TERMINAL_NAMING=off it would be wrong.
+#
+# The source carries the errexit lift: a failure inside a sourced file fires this
+# script's `set -e` on bash 3.2, and a roster must still list its members on a
+# machine where the terminal layer is unavailable.
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+_agmsg_pl_rc=0; _agmsg_pl_e=0
+case $- in *e*) _agmsg_pl_e=1 ;; esac
+set +e
+# shellcheck disable=SC1091
+[ -r "$SCRIPT_DIR/lib/actas-lock.sh" ] && . "$SCRIPT_DIR/lib/actas-lock.sh" \
+  && [ -r "$SCRIPT_DIR/lib/terminal-registry.sh" ] && . "$SCRIPT_DIR/lib/terminal-registry.sh"
+_agmsg_pl_rc=$?
+[ "$_agmsg_pl_e" = 1 ] && set -e
+
+# "<terminal> <pane>" for <team>/<agent>, or a reason nobody has to guess at.
+_member_placement() {
+  local team="$1" agent="$2" rec ref t id
+  if [ "$_agmsg_pl_rc" -ne 0 ] || ! declare -F agmsg_spawn_path >/dev/null 2>&1; then
+    printf 'placement unavailable — terminal support not loaded'; return 0
+  fi
+  rec="$(agmsg_spawn_path "$team" "$agent" 2>/dev/null)" || rec=""
+  if [ -z "$rec" ] || [ ! -f "$rec" ]; then
+    printf 'no pane recorded — not named yet'; return 0
+  fi
+  IFS="$(printf '\t')" read -r ref _ _ < "$rec" || true
+  if [ -z "$ref" ]; then
+    printf 'placement record is empty'; return 0
+  fi
+  t=""; id=""
+  t="$(agmsg_terminal_ref_terminal "$ref" 2>/dev/null)" || t=""
+  id="$(agmsg_terminal_ref_id "$ref" 2>/dev/null)" || id=""
+  if [ -z "$t" ] || [ -z "$id" ]; then
+    printf 'placement record unreadable (%s)' "$ref"; return 0
+  fi
+  printf '%s %s' "$t" "$id"
+}
+
 echo "Team: $TEAM"
 echo ""
 
@@ -40,9 +87,9 @@ while IFS='	' read -r name types project registrations; do
     # empty type and a "?" project, which reads as damage.
     echo "  $name (remote — no local registration)"
   elif [ "$registrations" -gt 1 ]; then
-    echo "  $name ($types) — $project (+$((registrations - 1)) more)"
+    echo "  $name ($types) — $project (+$((registrations - 1)) more)   [$(_member_placement "$TEAM" "$name")]"
   else
-    echo "  $name ($types) — $project"
+    echo "  $name ($types) — $project   [$(_member_placement "$TEAM" "$name")]"
   fi
   COUNT=$((COUNT + 1))
 # tr -d '\r': sqlite3.exe on Windows emits CRLF rows; the trailing CR would make

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -664,6 +664,28 @@ if [ -n "$ACTIVE_NAME" ]; then
   done <<< "$PAIRS"
 fi
 
+# Re-assert this pane's name (#1044). Naming is an invariant, not an assignment
+# made once at a chosen place: measured across the nine agent types, no single
+# entry point covers them all — `actas` is reached by every type but does not
+# always know the session id yet, SessionStart fires at launch on claude-code
+# and on the first turn on codex and not at all on grok, the watcher exists only
+# where `monitor=yes`, and the per-turn hook is absent on hermes. So every entry
+# point that knows the session id asserts it, idempotently, and whichever
+# arrives first wins. This is the watcher's turn.
+#
+# Outside the `ACTIVE_NAME` block above on purpose: a broad watcher knows the
+# session id and its pairs just as well, and the requirement is about the pane
+# having a name, not about which mode the watcher is in.
+#
+# No record is written: holding the seat is `actas`'s claim to make, and a
+# watcher can be running for a seat it did not claim.
+if declare -F agmsg_terminal_name_self_safe >/dev/null 2>&1; then
+  while IFS=$'\t' read -r _nt _na; do
+    [ -z "$_nt" ] && continue
+    agmsg_terminal_name_self_safe "$SESSION_ID" "$_nt" "$_na" "$PROJECT_PATH" "$AGENT_TYPE" || true
+  done <<< "$PAIRS"
+fi
+
 # Pairs another session currently holds, so each departure and each return is
 # announced once instead of every cycle. Membership is not a decision -- the
 # lock is -- it only records what has already been said (#683).

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -3609,3 +3609,77 @@ JSON
   run bash "$SCRIPTS/inbox.sh" testteam alice
   printf '%s' "$output" | grep -Fq "mid-turn, still unread"
 }
+
+# A `herdr` that logs its argv and answers `agent list` with a roster holding one
+# session, so a lookup BY that session id succeeds. Deliberately not the registry
+# suite's fixture: that one pins the measured JSON shape, which is a different
+# job from the one here.
+_fake_herdr_with_session() {
+  local sid="$1"
+  cat > "$FAKEBIN/herdr" <<EOF
+#!/usr/bin/env bash
+{ printf 'herdr'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = agent ] && [ "\$2" = list ]; then
+  printf '{"id":"1","result":{"type":"list","agents":[{"agent":"claude","agent_session":{"agent":"claude","kind":"id","source":"herdr:claude","value":"%s"},"pane_id":"wC:p4","display_agent":"x","name":"k"}]}}\n' "$sid"
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/herdr"
+  export PATH="$FAKEBIN:$PATH"
+}
+
+# --- the per-turn hook re-asserts the pane's name (#1044) ---------------------
+#
+# For several agent types this is the ONLY entry point that ever knows the
+# session id: grok-build has no SessionStart hook, and `monitor=yes` holds on two
+# of the nine, so a hand-started pane on the rest is first named from here.
+# Naming is an invariant re-asserted at every entry point, not an assignment made
+# once somewhere — measured across the nine types, no single place covers them.
+@test "check-inbox: names this pane on the way through (#1044)" {
+  export FAKEBIN="$TEST_SKILL_DIR/fakebin" ARGV_LOG="$TEST_SKILL_DIR/argv.log"
+  mkdir -p "$FAKEBIN"; : > "$ARGV_LOG"
+  agmsg_install_fake_tmux
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+
+  bash "$SCRIPTS/join.sh" nameteam alice claude-code "$TEST_PROJECT"
+  bash "$SCRIPTS/config.sh" set delivery.turn.check_interval 0 >/dev/null
+  : > "$ARGV_LOG"   # drop whatever join itself did; this test is about the hook
+
+  run bash -c "echo '{}' | bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT'"
+  [ "$status" -eq 0 ]
+
+  grep -Fq '[@agmsg_agent] [nameteam:alice]' "$ARGV_LOG"
+}
+
+# The other half of the same rule, and the half that is easy to lose: no session
+# id is "there was nothing to resolve with", not "resolution failed". It stays
+# quiet, and it must not go naming panes it cannot identify.
+#
+# A differential pair, because the two halves differ in exactly one input. The
+# first attempt asserted `herdr agent list` as a positive control for the no-sid
+# run and it failed — measured: with no session id the resolver does not ask
+# herdr anything at all, because there is nothing to ask BY. So the control is
+# the same invocation carrying a session id, which does reach herdr and does
+# rename; the silence of the other half means something only next to it.
+@test "check-inbox: no session id names nothing; the same call with one does (#1044)" {
+  export FAKEBIN="$TEST_SKILL_DIR/fakebin" ARGV_LOG="$TEST_SKILL_DIR/argv.log"
+  mkdir -p "$FAKEBIN"; : > "$ARGV_LOG"
+  _fake_herdr_with_session "sess-x"
+  export HERDR_ENV=1
+  unset TMUX TMUX_PANE
+
+  bash "$SCRIPTS/join.sh" nameteam alice claude-code "$TEST_PROJECT"
+  bash "$SCRIPTS/config.sh" set delivery.turn.check_interval 0 >/dev/null
+
+  # No session id on stdin.
+  : > "$ARGV_LOG"
+  run bash -c "echo '{}' | bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT'"
+  [ "$status" -eq 0 ]
+  refute grep -Fq 'herdr [pane] [rename]' "$ARGV_LOG"
+
+  # The same call, one input different.
+  : > "$ARGV_LOG"
+  run bash -c "printf '%s' '{\"session_id\":\"sess-x\"}' | bash '$SCRIPTS/check-inbox.sh' claude-code '$TEST_PROJECT'"
+  [ "$status" -eq 0 ]
+  grep -Fq 'herdr [pane] [rename] [wC:p4] [nameteam:alice]' "$ARGV_LOG"
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -38,6 +38,27 @@ teardown_test_env() {
   rm -rf "$TEST_SKILL_DIR"
 }
 
+# A fake `tmux` that logs its argv and produces the ids/text real tmux would.
+#
+# Shared because three suites drive the terminal layer now — the registry's own
+# tests, the watcher, and per-turn delivery (#1044 gave the last two a naming
+# call). Callers set FAKEBIN and ARGV_LOG first; nothing here reads them at
+# source time, so a suite that does not want a fake terminal is unaffected.
+agmsg_install_fake_tmux() {
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+case "\$1" in
+  new-window)   echo '@7' ;;
+  split-window) echo '%9' ;;
+  capture-pane) printf 'line one\nline two\n' ;;
+esac
+exit 0
+EOF
+  chmod +x "$FAKEBIN/tmux"
+  export PATH="$FAKEBIN:$PATH"
+}
+
 # Skip a test on native Windows / Git Bash (MSYS/MINGW/Cygwin). Use ONLY for
 # behaviour that depends on POSIX process semantics agmsg does not yet support
 # there — watcher discovery/kill via ps/pgrep, and session liveness via kill -0

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -51,6 +51,8 @@ elif [ "\$1" = tab ] && [ "\$2" = create ]; then
   echo '{"result":{"root_pane":{"pane_id":"wD:p1"}}}'
 elif [ "\$1" = pane ] && [ "\$2" = read ]; then
   printf 'herdr visible text\n'
+elif [ "\$1" = pane ] && [ "\$2" = rename ]; then
+  exit "\${HERDR_PANE_RENAME_RC:-0}"
 elif [ "\$1" = agent ] && [ "\$2" = rename ]; then
   # The key rename. Failable per test (HERDR_AGENT_RENAME_RC), because "does it
   # fire when it should" and "does it answer ok when it failed" are different
@@ -1350,8 +1352,9 @@ M
   [ "$status" -ne 0 ]
 
   # It really did get as far as trying, rather than failing earlier for some
-  # other reason: the label was set first, and the key was attempted.
-  grep -Fq 'herdr [pane] [rename] [wC:p4] [keyteam:alice]' "$ARGV_LOG"
+  # other reason. The evidence used to be "the label was set first" — that was an
+  # artefact of the old order, and the key now goes first precisely so a failed
+  # label cannot take addressing down with it.
   grep -Fq 'herdr [agent] [rename]' "$ARGV_LOG"
 }
 
@@ -1376,4 +1379,58 @@ M
 
   run agmsg_terminal_name_self "sess-k" keyteam alice /proj/A claude-code
   [ "$status" -eq 0 ]
+}
+
+# --- the label is decoration: its failure must not cost the addressing (#1044) -
+#
+# Reported by a reviewer against the previous revision: with the label renamed
+# first and its failure fatal, a failed decoration returned 13 before the key was
+# ever attempted. The requirement — a member's pane is never without a name —
+# broke through a second door, and the fix for the first door (the key's failure
+# no longer swallowed) did not touch it.
+@test "a failed LABEL rename still leaves the member addressable (#1044)" {
+  _install_fake_herdr "sess-l"
+  export HERDR_ENV=1
+  export HERDR_PANE_RENAME_RC=1     # the decoration fails
+  export HERDR_AGENT_RENAME_RC=0    # the key would succeed, if it is reached
+  unset AGMSG_TERMINAL_NAMING
+
+  run agmsg_terminal_name_self "sess-l" labelteam alice /proj/A claude-code
+  # Not fatal: the caller writes the placement record only on 0, and that record
+  # is the other half of addressing — so failing here would throw away exactly
+  # what this test is about.
+  [ "$status" -eq 0 ]
+
+  # The key was set. This is the assertion the previous revision could not pass.
+  grep -Fq 'herdr [agent] [rename]' "$ARGV_LOG"
+  # ...and the label really was attempted and really did fail, or the line above
+  # proves nothing about this scenario.
+  grep -Fq 'herdr [pane] [rename]' "$ARGV_LOG"
+}
+
+# --- a key that cannot be DERIVED is a failure, not an ok (#1044) -------------
+#
+# The commit that made the key fatal claimed this branch in a comment and left it
+# unguarded: a reviewer's mutation that returned ok for an underivable key failed
+# no test. A comment is not a check.
+#
+# `_herdr_internal_key` can fail three ways — the lib directory not resolving,
+# `hash.sh` missing, and the hash itself failing. This drives the third: a
+# `agmsg_sha256` that is present and returns non-zero. The other two are the same
+# `return 1` one line apart and are not separately exercised.
+@test "a key that cannot be derived fails the naming (#1044)" {
+  _install_fake_herdr "sess-h"
+  export HERDR_ENV=1
+  unset AGMSG_TERMINAL_NAMING
+
+  # Present, so the `command -v` guard passes, and failing, so the hash does not.
+  agmsg_sha256() { return 1; }
+  export -f agmsg_sha256 2>/dev/null || true
+
+  run agmsg_terminal_name_self "sess-h" hashteam alice /proj/A claude-code
+  [ "$status" -ne 0 ]
+
+  # Nothing was renamed: no key could be built, so the member is not addressable
+  # and saying `ok` would have claimed that it was.
+  refute grep -Fq 'herdr [agent] [rename]' "$ARGV_LOG"
 }

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -1271,10 +1271,11 @@ M
 
 # --- AGMSG_TERMINAL_NAMING=off drops the label and keeps the key (#1044) ------
 #
-# Two names, and only one of them is optional. The key is what peek/poke resolve
-# a member through, so turning it off would make the member unreachable — which
-# is the defect #1044 is about, re-created on request. A caller that wants no
-# terminal writes at all is describing `plain`.
+# Two names, and only one of them is optional. The key is the name the TERMINAL
+# addresses the agent by in its own namespace; the label is what a person reads.
+# (peek/poke/despawn in this repo resolve through the placement record's pane id
+# — an earlier version of this comment said the key, and that is false here.) A
+# caller that wants no terminal writes at all is describing `plain`.
 #
 # Both drivers are exercised because the split is not the same shape in each:
 # herdr has two commands (`pane rename` / `agent rename`), tmux has a pane option

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -1273,3 +1273,66 @@ M
   grep -q '%HELD' "$rec"
   grep -q '/proj/OLD' "$rec"
 }
+
+# --- AGMSG_TERMINAL_NAMING=off drops the label and keeps the key (#1044) ------
+#
+# Two names, and only one of them is optional. The key is what peek/poke resolve
+# a member through, so turning it off would make the member unreachable — which
+# is the defect #1044 is about, re-created on request. A caller that wants no
+# terminal writes at all is describing `plain`.
+#
+# Both drivers are exercised because the split is not the same shape in each:
+# herdr has two commands (`pane rename` / `agent rename`), tmux has a pane option
+# and a title. "Same idea, so same result" is not a measurement.
+@test "naming off (tmux): the pane option is set and the title is not (#1044)" {
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  export AGMSG_TERMINAL_NAMING=off
+
+  run agmsg_terminal_name_self "" offteam alice /proj/A claude-code
+  [ "$status" -eq 0 ]
+
+  # The key: still set, because it is addressing.
+  grep -Fq 'tmux [set-option] [-p] [-t] [%1] [@agmsg_agent] [offteam:alice]' "$ARGV_LOG"
+  # The decoration: not set.
+  refute grep -Fq 'select-pane' "$ARGV_LOG"
+  refute grep -Fq 'rename-window' "$ARGV_LOG"
+}
+
+@test "naming ON by default (tmux): both the option and the title (#1044)" {
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  unset AGMSG_TERMINAL_NAMING
+
+  run agmsg_terminal_name_self "" onteam alice /proj/A claude-code
+  [ "$status" -eq 0 ]
+  grep -Fq '[@agmsg_agent] [onteam:alice]' "$ARGV_LOG"
+  grep -Fq 'select-pane' "$ARGV_LOG"
+}
+
+@test "naming off (herdr): agent rename happens, pane rename does not (#1044)" {
+  _install_fake_herdr "sess-off"
+  export HERDR_ENV=1
+  export AGMSG_TERMINAL_NAMING=off
+
+  run agmsg_terminal_name_self "sess-off" offteam alice /proj/A claude-code
+  [ "$status" -eq 0 ]
+
+  # The key: still set.
+  grep -Fq 'herdr [agent] [rename]' "$ARGV_LOG"
+  # The visible label: not set.
+  refute grep -Fq 'herdr [pane] [rename]' "$ARGV_LOG"
+}
+
+@test "naming ON by default (herdr): both renames (#1044)" {
+  _install_fake_herdr "sess-on"
+  export HERDR_ENV=1
+  unset AGMSG_TERMINAL_NAMING
+
+  run agmsg_terminal_name_self "sess-on" onteam alice /proj/A claude-code
+  [ "$status" -eq 0 ]
+  grep -Fq 'herdr [pane] [rename] [wC:p4] [onteam:alice]' "$ARGV_LOG"
+  grep -Fq 'herdr [agent] [rename]' "$ARGV_LOG"
+}

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -51,6 +51,11 @@ elif [ "\$1" = tab ] && [ "\$2" = create ]; then
   echo '{"result":{"root_pane":{"pane_id":"wD:p1"}}}'
 elif [ "\$1" = pane ] && [ "\$2" = read ]; then
   printf 'herdr visible text\n'
+elif [ "\$1" = agent ] && [ "\$2" = rename ]; then
+  # The key rename. Failable per test (HERDR_AGENT_RENAME_RC), because "does it
+  # fire when it should" and "does it answer ok when it failed" are different
+  # questions and only the first one had a control.
+  exit "\${HERDR_AGENT_RENAME_RC:-0}"
 elif [ "\$1" = pane ] && [ "\$2" = process-info ]; then
   # requirement 1 gate: a READY pane (foreground pgid == shell pid) so terminal_spawn
   # proceeds to type. Overridable per test via HERDR_PROCESS_INFO_RESPONSE.
@@ -1323,4 +1328,52 @@ M
   [ "$status" -eq 0 ]
   grep -Fq 'herdr [pane] [rename] [wC:p4] [onteam:alice]' "$ARGV_LOG"
   grep -Fq 'herdr [agent] [rename]' "$ARGV_LOG"
+}
+
+# --- a failed KEY is a failure, in the mode everybody uses (#1044) ------------
+#
+# The severities were backwards: the label's failure was fatal and the key's was
+# swallowed with `|| true`, so "a member's name is never absent" held strictly in
+# the reduced mode and not in the default one. Measured by a reviewer, not
+# reasoned about: with the key rename failing, default mode returned rc=0 and
+# printed `ok`.
+#
+# Both modes are asserted, because "it goes red under `off`" is not evidence
+# about the default — that split is exactly what hid this.
+@test "a failed key rename fails the naming, in DEFAULT mode (#1044)" {
+  _install_fake_herdr "sess-k"
+  export HERDR_ENV=1
+  export HERDR_AGENT_RENAME_RC=1
+  unset AGMSG_TERMINAL_NAMING
+
+  run agmsg_terminal_name_self "sess-k" keyteam alice /proj/A claude-code
+  [ "$status" -ne 0 ]
+
+  # It really did get as far as trying, rather than failing earlier for some
+  # other reason: the label was set first, and the key was attempted.
+  grep -Fq 'herdr [pane] [rename] [wC:p4] [keyteam:alice]' "$ARGV_LOG"
+  grep -Fq 'herdr [agent] [rename]' "$ARGV_LOG"
+}
+
+@test "a failed key rename fails the naming, in KEY-ONLY mode too (#1044)" {
+  _install_fake_herdr "sess-k"
+  export HERDR_ENV=1
+  export HERDR_AGENT_RENAME_RC=1
+  export AGMSG_TERMINAL_NAMING=off
+
+  run agmsg_terminal_name_self "sess-k" keyteam alice /proj/A claude-code
+  [ "$status" -ne 0 ]
+  grep -Fq 'herdr [agent] [rename]' "$ARGV_LOG"
+}
+
+# And the paired positive: the same setup with the rename succeeding must pass,
+# or the two tests above are satisfied by naming being broken outright.
+@test "the same setup with the key rename succeeding is green (#1044)" {
+  _install_fake_herdr "sess-k"
+  export HERDR_ENV=1
+  export HERDR_AGENT_RENAME_RC=0
+  unset AGMSG_TERMINAL_NAMING
+
+  run agmsg_terminal_name_self "sess-k" keyteam alice /proj/A claude-code
+  [ "$status" -eq 0 ]
 }

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -28,21 +28,9 @@ setup() {
 
 teardown() { teardown_test_env; }
 
-# A fake `tmux` that logs argv and produces the ids/text real tmux would.
-_install_fake_tmux() {
-  cat > "$FAKEBIN/tmux" <<EOF
-#!/usr/bin/env bash
-{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
-case "\$1" in
-  new-window)   echo '@7' ;;
-  split-window) echo '%9' ;;
-  capture-pane) printf 'line one\nline two\n' ;;
-esac
-exit 0
-EOF
-  chmod +x "$FAKEBIN/tmux"
-  export PATH="$FAKEBIN:$PATH"
-}
+# One definition, in test_helper.bash: the watcher and delivery suites drive the
+# terminal layer too now (#1044).
+_install_fake_tmux() { agmsg_install_fake_tmux; }
 
 # A fake `herdr` that logs argv and returns canned JSON/text for session <sid>.
 _install_fake_herdr() {

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -1197,6 +1197,7 @@ STUB
   [ "$st" -eq 75 ]
   # Non-delivery-shaped diagnostic (a plain "agmsg watch:" line, not "ts | team | from → to | body").
   grep -q "agmsg watch: cannot read delivery state for team:alice" "$out"
+}
 
 # --- the watcher re-asserts this pane's name (#1044) --------------------------
 #

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -1225,7 +1225,8 @@ STUB
   _stop_watcher "$pid"
 
   [ "$found" -eq 0 ]
-  # The key, specifically — the thing peek/poke resolve through, not just any
-  # tmux call.
+  # The key specifically — the name the terminal addresses the agent by — rather
+  # than just any tmux call. (peek/poke resolve through the placement record, not
+  # through this; the assertion is about which of the two names was set.)
   grep -Fq '[@agmsg_agent] [team:alice]' "$ARGV_LOG"
 }

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -1197,4 +1197,35 @@ STUB
   [ "$st" -eq 75 ]
   # Non-delivery-shaped diagnostic (a plain "agmsg watch:" line, not "ts | team | from → to | body").
   grep -q "agmsg watch: cannot read delivery state for team:alice" "$out"
+
+# --- the watcher re-asserts this pane's name (#1044) --------------------------
+#
+# Naming is an invariant re-asserted wherever the session id is known, not an
+# assignment made once at a chosen place: measured across the nine agent types,
+# no single entry point covers them all. The watcher is one of those places, and
+# it is the one that runs for the whole life of a monitor-mode session.
+#
+# Waits for the rename to appear rather than sleeping: a fixed sleep would encode
+# "the watcher is usually done by now", which is a claim about the machine — the
+# reason the helpers above exist.
+@test "watch: the watcher names this session's pane (#1044)" {
+  export FAKEBIN="$TEST_SKILL_DIR/fakebin" ARGV_LOG="$TEST_SKILL_DIR/argv.log"
+  mkdir -p "$FAKEBIN"
+  : > "$ARGV_LOG"
+  agmsg_install_fake_tmux
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+
+  local sid out found
+  sid="$(_iid sid-naming)"
+  out="$BATS_TEST_TMPDIR/watch.out"
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" "$sid" "$PROJ" claude-code >"$out" 2>/dev/null 3>&- 4>&- &
+  local pid=$!
+  _wait_for_file_contains "$ARGV_LOG" 'team:alice' "$pid"
+  found=$?
+  _stop_watcher "$pid"
+
+  [ "$found" -eq 0 ]
+  # The key, specifically — the thing peek/poke resolve through, not just any
+  # tmux call.
+  grep -Fq '[@agmsg_agent] [team:alice]' "$ARGV_LOG"
 }


### PR DESCRIPTION
Refs #1044, and deliberately not `Fixes`: the issue lists three items in order
and this is the first two. The third — the placement record gaining the key, so
that addressing survives panes being rearranged — is not here, so the issue's
claim is wider than this change and closing it on merge would be wrong.

Against `integration/terminal-driver-v1`, which is where the terminal layer lives
— `main` has no `terminal-registry.sh` yet.

## The requirement, and why it is not a patch to `join`

> Every member's pane carries its name, on every agent type, whether it was
> spawned or started by hand. A delay is acceptable; an absence is not.

No single entry point can deliver that, which is the whole reason this is shaped
as an invariant rather than an assignment:

| anchor | covers |
|---|---|
| `actas` | every type reaches it, but the session id is not always known there yet (codex) |
| SessionStart | claude-code at launch; codex on the first user turn; grok has none |
| the watcher | `monitor=yes` on two of the nine |
| per-turn delivery hook | everything except hermes, which is `delivery_modes=off` |

So naming becomes a property that **every entry point re-asserts, idempotently**,
and the first one to know the session id wins. No session id still skips in
silence — that skip was always right; what was missing is anything that names the
pane afterwards.

## What changed

**The helper normalises the session id itself.** Callers had to hand it the bare
sid, and getting it wrong is silent: the composite `<sid>.<pid>` exists only
inside agmsg, so a terminal answers "this session cannot identify its own pane",
which reads as a resolution failure and is an identifier mismatch. `watch.sh` had
that defect, then `actas-claim.sh` had it. This PR adds two more callers, so the
conversion moves to where no caller can get it wrong. Idempotent — checked by
reading it and by running it: bare → bare, composite → bare, empty → empty.

**Two entry points join the three that existed.** The watcher (outside its
`ACTIVE_NAME` block: a broad watcher knows the session id just as well) and
`check-inbox`, which for a type with no SessionStart and no watcher is the only
place naming can ever happen. Neither writes the placement record — holding the
seat is `actas`'s claim, and a delivery hook is not a claim of anything.

**`AGMSG_TERMINAL_NAMING=off` drops the label and never the key.**

```
the label a person reads              herdr pane rename   / tmux pane title
the key the TERMINAL addresses by     herdr agent rename  / tmux @agmsg_agent
```

The env var is read in the registry and passed to the driver as a mode, so the
policy has one home; `terminal_name` gains an optional fourth argument, absent
meaning both.

**A correction, because the first revisions of this PR said otherwise in six
places.** The key is *not* what `peek`, `poke` and `despawn` resolve a member
through in this repo — counted: all three go through the placement record's pane
id, and `_herdr_internal_key` is read nowhere outside its own driver. The key is
the name the terminal knows the agent by, on its side. The wrong version pointed
at the wrong thing to protect, which is the dangerous direction: someone setting
out to defend addressing would have defended the key and left the record.

**The roster carries the pane.** A pane with no name was invisible from inside
agmsg — the dogfood found one by reading the terminal's own JSON — and that is
also why the requirement had nothing to assert against.

## Two things stated rather than smoothed over

**The visible label is not printed by `team.sh`.** Reading it back means asking
the terminal and no read op exists; deriving it from the record would report a
claim as an observation, and under `AGMSG_TERMINAL_NAMING=off` the derivation is
wrong. The terminal and pane — recorded facts — are printed, and they are what
makes the requirement checkable.

**The per-turn naming is not cached.** It costs one terminal resolution plus the
driver's renames per turn, per team. The only cheap thing to cache on is the
session id, and a pane can be rearranged under a session id that has not changed
— which is a direction this design already anticipates.

## Calibration

Every mutation was confirmed present in the file before its result was read; a
mutation that does not mutate reads exactly like a passing check.

| mutation | goes red |
|---|---|
| the registry ignores the env var | the two `off` tests |
| `off` read as "no naming at all", so the key is dropped too | the herdr `off` test |
| the default suppresses the label | the tmux default test |
| the key's failure swallowed again (default mode) | the default-mode key test — **and not the key-only one**, which is the finding |
| the old order back: the label first and fatal | the label test |
| an underivable key passes as `ok` | the derivation test |
| `check-inbox` stops naming | both of its tests |
| the watcher stops naming | the watcher test |

**One of my own controls was wrong and is worth recording.** The no-session-id
test first asserted `herdr agent list` as a positive control, and it failed —
measured: with no session id the resolver never asks herdr anything, because
there is nothing to ask BY. It is now a differential pair: the same invocation,
with and without a session id, so the silent half means something.

## Which of the two names may fail, and in which order

Both halves of this were found by review, and they are the same requirement
breaking through two different doors:

| | before | now |
|---|---|---|
| the key's failure | swallowed with `\|\| true` in the default mode | fatal, in every mode |
| the order | the label first, and fatal | the key first; the label after, and not fatal |

The first let a member become unreachable while naming reported `ok`. The second
let a failed *decoration* return before the key was attempted at all. Fixing one
and claiming "a name is never absent" would have been wrong both times.

The label's failure is deliberately not fatal, and this is the reason the
reordering survives at all: the caller writes the placement record **only when
this returns 0**, and the record is what addressing actually rests on. With the
label first and fatal, a failed ornament returned before the key was attempted
*and* before the record was written — the member ended up with neither name and
no placement. A non-zero for a failed ornament would throw that away again.

## The per-turn entry point is an instruction on seven of the nine types

Worth stating plainly, because it is a property of the design and not something
a test can close. On `claude-code` and the other types with a real hook file, the
per-turn call is code that runs. On the remaining seven the per-turn delivery
step is **a line of markdown in the agent's own template** — the agent is asked
to run `check-inbox` and generally does, but nothing enforces it and no test can
pin it.

So for those types the naming happens if and when the agent follows its
instructions, and "there is a test for the per-turn path" must not be read as
"the per-turn path is guaranteed". The entry points that ARE code — `join`,
`actas`, SessionStart where it exists, and the watcher where `monitor=yes` — are
what the invariant actually rests on for them.

## Types

Exercised against fakes for **tmux** and **herdr**, both modes, and end-to-end
through `join`, `actas`, the watcher and `check-inbox` as **claude-code**.

**Not exercised per type, and on review that is the right axis.** Inside
`agmsg_terminal_name_self` the agent type appears exactly once — in the row
written to the placement record — and is never used in a decision. The naming
behaviour depends on the TERMINAL, not the type, and both terminals are covered
in both modes. What the type decides is only *which entry point fires*, and that
is a count (`monitor=yes` on two; no SessionStart on grok-build) rather than a
behaviour.

The roster column still exists so that "spawn one per type and check the pane
column" can become a real check; that check is not in this PR.

```
test_terminal_registry  74     test_delivery  198
test_watch              24     test_team       79
check-enforced-assertions 628 (baseline)   check-errexit-status-reads 0 (baseline)
```
