### PR TITLE
fix(sync): refuse a non-string envelope.blob/cipher instead of storing "null" (#1042)

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -1004,16 +1004,36 @@ storage_sync_apply_pull() {
                  "status","policy_revision","local_security_revision","reason",
                  "projection.kind","projection.from_agent","projection.to_agent",
                  "projection.body","projection.created_at"];
-    def pick($r; $name):
+    # envelope.blob and envelope.cipher have NO `// ""` default, unlike the twelve
+    # fields that do, and the value is `tostring`-ed below -- so on a message a
+    # JSON null, an absent key, or a number was silently stored as the plausible-
+    # looking text "null"/"12345", rc=0 (#1042). A `// ""` default (like the other
+    # twelve) would only trade "null" for "" -- still a silent non-ciphertext -- so
+    # instead REJECT a non-string, the way the two other unguarded fields already
+    # are: status against a whitelist, envelope.v against a numeric gate, both
+    # rc=13. A sentinel value was the alternative but it would add a thing four
+    # places (read/store/projection/migration) must recognise. The type is only
+    # known HERE, before `tostring` erases it (a real ciphertext and a former null
+    # both read as strings downstream), so the guard has to live in the pick. Only
+    # a sync_pull_message carries an envelope; a sync_pull_cursor legitimately has
+    # none, so the check is scoped to messages (a cursor reads blob/cipher but never
+    # uses them). An empty string is a present string and stays out of scope here.
+    def pick($n; $r; $name):
       (if   $name == "type"                    then $r.type // ""
        elif $name == "next_after"              then $r.next_after // ""
        elif $name == "server_seq"              then $r.server_seq // ""
        elif $name == "id"                      then $r.id // ""
        elif $name == "server_received_at"      then $r.server_received_at // ""
        elif $name == "envelope.v"              then $r.envelope.v
-       elif $name == "envelope.cipher"         then $r.envelope.cipher
+       elif $name == "envelope.cipher"         then
+             (if $r.type == "sync_pull_message"
+              then ($r.envelope.cipher | if type == "string" then . else error("record \($n): envelope.cipher is \(type), not a string") end)
+              else $r.envelope.cipher end)
        elif $name == "envelope.key_id"         then $r.envelope.key_id // ""
-       elif $name == "envelope.blob"           then $r.envelope.blob
+       elif $name == "envelope.blob"           then
+             (if $r.type == "sync_pull_message"
+              then ($r.envelope.blob | if type == "string" then . else error("record \($n): envelope.blob is \(type), not a string") end)
+              else $r.envelope.blob end)
        elif $name == "status"                  then $r.status
        elif $name == "policy_revision"         then $r.policy_revision // ""
        elif $name == "local_security_revision" then $r.local_security_revision // ""
@@ -1030,7 +1050,7 @@ storage_sync_apply_pull() {
         | (.key + 1) as $n
         | (try (.value | fromjson) catch error("record \($n): not one JSON value on its line")) as $r
         | fields[] as $name
-        | pick($r; $name) as $v
+        | pick($n; $r; $name) as $v
         | (if ($v | contains("\u0000"))
            then error("record \($n): field \($name) contains U+0000")
            else $v end) + "\u0000" )

--- a/tests/test_remote_sync_reject_envelope.bats
+++ b/tests/test_remote_sync_reject_envelope.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+# #1042: on a sync_pull_message the apply path `tostring`-ed envelope.blob and
+# envelope.cipher with no type guard, so a JSON null, an absent key, or a number
+# was stored as the plausible-looking text "null"/"12345" and reported rc=0 -- a
+# malformed envelope reading as content on a byte-exact feature. The two other
+# fields that lacked `// ""` were already guarded elsewhere (status by a
+# whitelist, envelope.v by a numeric gate, both rc=13); blob and cipher are now
+# refused the same way. These pin all three layers:
+#   read     the input shapes the jq pick turns into "null"/"12345" (null / absent
+#            key / number) are the cases exercised below
+#   return   a refused message stores NO row (sync_messages, sync_quarantine, or
+#            the projected messages table)
+#   process  the call returns rc=13 -- NOT rc=0 with no row, which a caller would
+#            read as success. Allowing a non-string again (the mutation) makes
+#            each reject case fail on the rc assertion.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store"
+  export AGMSG_STORAGE_DRIVER=sqlite
+  source "$SCRIPTS/lib/storage.sh"
+  agmsg_storage_load
+  storage_init demo >/dev/null
+  SERVER_ID=018f3f7e-0000-7000-8000-000000000000
+  TEAM_ID=018f3f7e-0000-7000-8000-000000000001
+}
+teardown() { teardown_test_env; }
+
+# A one-message page with the message transformed by the jq expression in $1.
+page() {
+  jq -nc '{type:"sync_pull_message",server_seq:"1",
+    id:"550e8400-e29b-41d4-a716-446655440001",
+    server_received_at:"2026-07-20T13:00:00.000000Z",
+    envelope:{v:1,cipher:"age-v1",key_id:"epoch-1",blob:"ciphertext-abc"},
+    status:"importable",policy_revision:"0",local_security_revision:"0",
+    projection:{body:"body-1",from_agent:"alice",to_agent:"bob",
+      created_at:"2026-07-20T13:00:00.000000Z"}} | '"$1"
+  printf '%s\n' '{"type":"sync_pull_cursor","next_after":"1"}'
+}
+
+# Total rows this message could have left behind, across every table it reaches.
+stored_rows() {
+  local db; db=$(agmsg_db_path demo)
+  agmsg_sqlite "$db" "SELECT
+    (SELECT count(*) FROM sync_messages)
+  + (SELECT count(*) FROM sync_quarantine)
+  + (SELECT count(*) FROM messages);" | tr -d '\r'
+}
+
+@test "sync apply: a clean message still imports (rc 0), so the reject is specific (#1042)" {
+  run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$(page '.')"
+  [ "$status" -eq 0 ]
+  [ "$(agmsg_sqlite "$(agmsg_db_path demo)" "SELECT blob FROM sync_messages WHERE server_seq='1';" | tr -d '\r')" = ciphertext-abc ]
+}
+
+@test "sync apply: a null / absent / numeric envelope.blob is refused with rc 13 and no row (#1042)" {
+  local mut
+  for mut in '.envelope.blob=null' 'del(.envelope.blob)' '.envelope.blob=12345'; do
+    export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store-blob-${mut//[^a-z]/}"
+    storage_init demo >/dev/null
+    run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$(page "$mut")"
+    [ "$status" -eq 13 ]          # process: failure, not a silent rc 0
+    [ "$(stored_rows)" -eq 0 ]    # return: nothing stored anywhere
+  done
+}
+
+@test "sync apply: a null / absent / numeric envelope.cipher is refused with rc 13 and no row (#1042)" {
+  local mut
+  for mut in '.envelope.cipher=null' 'del(.envelope.cipher)' '.envelope.cipher=12345'; do
+    export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store-cipher-${mut//[^a-z]/}"
+    storage_init demo >/dev/null
+    run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$(page "$mut")"
+    [ "$status" -eq 13 ]
+    [ "$(stored_rows)" -eq 0 ]
+  done
+}
+
+@test "sync apply: an empty-string blob is a present string and stays in scope of the seal side, not refused here (#1042)" {
+  # Documents the boundary: the #1042 guard rejects a NON-string. An empty string
+  # is a string, so it is not this guard's business (the seal side owns "is this a
+  # real ciphertext"); flip this if the contract later refuses empty too.
+  run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$(page '.envelope.blob=""')"
+  [ "$status" -eq 0 ]
+}

--- a/tests/test_remote_sync_reject_envelope.bats
+++ b/tests/test_remote_sync_reject_envelope.bats
@@ -4,16 +4,23 @@
 # envelope.cipher with no type guard, so a JSON null, an absent key, or a number
 # was stored as the plausible-looking text "null"/"12345" and reported rc=0 -- a
 # malformed envelope reading as content on a byte-exact feature. The two other
-# fields that lacked `// ""` were already guarded elsewhere (status by a
+# fields that lacked `// ""` were already refused elsewhere (status by a
 # whitelist, envelope.v by a numeric gate, both rc=13); blob and cipher are now
 # refused the same way. These pin all three layers:
-#   read     the input shapes the jq pick turns into "null"/"12345" (null / absent
-#            key / number) are the cases exercised below
+#   read     the input shapes the jq pick turns into "null"/"12345" -- a null, an
+#            absent key (jq reads both as null), and a number -- are exercised
 #   return   a refused message stores NO row (sync_messages, sync_quarantine, or
-#            the projected messages table)
-#   process  the call returns rc=13 -- NOT rc=0 with no row, which a caller would
-#            read as success. Allowing a non-string again (the mutation) makes
-#            each reject case fail on the rc assertion.
+#            the projected messages table); the page is rejected atomically
+#   process  the call returns rc=13, NOT rc=0-with-no-row (a caller reads rc=0 as
+#            success), AND says WHAT was rejected -- the diagnostic naming the
+#            record, the field, the observed JSON type, and "not a string". That
+#            diagnostic is the requested property, so it is asserted, not just its
+#            side effects; a diagnostic that is present but generic must fail too.
+#
+# Exercised through the PRODUCTION adapter (internal/storage-sync-driver.sh, the
+# `apply` entry the Node engine calls), so the test also establishes that the
+# adapter passes the driver's stderr and its rc=13 through unchanged, rather than
+# only the driver function in isolation.
 
 load test_helper
 
@@ -42,6 +49,9 @@ page() {
   printf '%s\n' '{"type":"sync_pull_cursor","next_after":"1"}'
 }
 
+# Apply a page through the production adapter; $output holds stdout AND stderr.
+apply() { run bash "$SCRIPTS/internal/storage-sync-driver.sh" apply demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$(page "$1")"; }
+
 # Total rows this message could have left behind, across every table it reaches.
 stored_rows() {
   local db; db=$(agmsg_db_path demo)
@@ -52,37 +62,46 @@ stored_rows() {
 }
 
 @test "sync apply: a clean message still imports (rc 0), so the reject is specific (#1042)" {
-  run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$(page '.')"
+  apply '.'
   [ "$status" -eq 0 ]
   [ "$(agmsg_sqlite "$(agmsg_db_path demo)" "SELECT blob FROM sync_messages WHERE server_seq='1';" | tr -d '\r')" = ciphertext-abc ]
 }
 
-@test "sync apply: a null / absent / numeric envelope.blob is refused with rc 13 and no row (#1042)" {
-  local mut
-  for mut in '.envelope.blob=null' 'del(.envelope.blob)' '.envelope.blob=12345'; do
-    export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store-blob-${mut//[^a-z]/}"
-    storage_init demo >/dev/null
-    run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$(page "$mut")"
-    [ "$status" -eq 13 ]          # process: failure, not a silent rc 0
-    [ "$(stored_rows)" -eq 0 ]    # return: nothing stored anywhere
+@test "sync apply: a null / absent / numeric envelope.blob is refused, rc 13, no row, named diagnostic (#1042)" {
+  local spec mut ty
+  # jq reads a null and an absent key identically (null), so both take the "null"
+  # arm; a number takes the "number" arm. Each store is fresh so no prior row can
+  # mask the "nothing stored" check.
+  for spec in '.envelope.blob=null|null' 'del(.envelope.blob)|null' '.envelope.blob=12345|number'; do
+    mut="${spec%|*}"; ty="${spec##*|}"
+    export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store-blob-$ty-${mut//[^a-z]/}"; storage_init demo >/dev/null
+    apply "$mut"
+    [ "$status" -eq 13 ]                                                    # process: failure, not rc 0
+    [ "$(stored_rows)" -eq 0 ]                                              # return: nothing stored
+    # process: the diagnostic names WHAT was rejected -- record, field, observed
+    # type, and "not a string". Asserting the observed type is the positive
+    # control that it reached THIS type check and not some other failure, and it
+    # reddens a diagnostic that is present but generic, not only one removed.
+    grep -q "record 1: envelope.blob is $ty, not a string" <<<"$output"
   done
 }
 
-@test "sync apply: a null / absent / numeric envelope.cipher is refused with rc 13 and no row (#1042)" {
-  local mut
-  for mut in '.envelope.cipher=null' 'del(.envelope.cipher)' '.envelope.cipher=12345'; do
-    export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store-cipher-${mut//[^a-z]/}"
-    storage_init demo >/dev/null
-    run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$(page "$mut")"
+@test "sync apply: a null / absent / numeric envelope.cipher is refused, rc 13, no row, named diagnostic (#1042)" {
+  local spec mut ty
+  for spec in '.envelope.cipher=null|null' 'del(.envelope.cipher)|null' '.envelope.cipher=12345|number'; do
+    mut="${spec%|*}"; ty="${spec##*|}"
+    export AGMSG_STORAGE_PATH="$BATS_TEST_TMPDIR/store-cipher-$ty-${mut//[^a-z]/}"; storage_init demo >/dev/null
+    apply "$mut"
     [ "$status" -eq 13 ]
     [ "$(stored_rows)" -eq 0 ]
+    grep -q "record 1: envelope.cipher is $ty, not a string" <<<"$output"
   done
 }
 
-@test "sync apply: an empty-string blob is a present string and stays in scope of the seal side, not refused here (#1042)" {
-  # Documents the boundary: the #1042 guard rejects a NON-string. An empty string
-  # is a string, so it is not this guard's business (the seal side owns "is this a
-  # real ciphertext"); flip this if the contract later refuses empty too.
-  run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$(page '.envelope.blob=""')"
+@test "sync apply: an empty-string blob is a present string and is not this guard's business (#1042)" {
+  # The #1042 guard rejects a NON-string. An empty string is a string, so the seal
+  # side owns "is this a real ciphertext", not this apply-time type check. Flip
+  # this if the contract later refuses empty too.
+  apply '.envelope.blob=""'
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Fixes #1042.

`storage_sync_apply_pull` `tostring`-ed `envelope.blob` and `envelope.cipher` with no type guard, so on a `sync_pull_message` a JSON `null`, an absent key, or a number was stored as the literal text `"null"` / `"12345"` with `rc=0` — a malformed envelope reading as plausible content on a byte-exact feature.

The two other fields that lacked a `// ""` default were already refused elsewhere (`status` by a whitelist, `envelope.v` by a numeric gate, both `rc=13`). `blob` and `cipher` now join them: a non-string ends the jq stream and the page apply returns `rc=13`, storing nothing. Design call (refuse vs sentinel) was to refuse, matching the two existing guards rather than introducing a sentinel value four places would have to recognise.

**Why the whole page is refused and nothing is quarantined:** `sync_quarantine` durably holds *evaluated envelope outcomes* (`pending_key`, authentication failure, a malformed canonical message, …) — envelopes that arrived as unchanged bytes and were then judged. A `null` / number / absent field is not an unchanged byte envelope at all, and cannot be stored in the TEXT schema without losing its type. So refusing the page atomically — no `sync_messages` row, no `sync_quarantine` row, and no cursor advance — is the coherent outcome, not a choice.

Notes:
- The guard lives in the jq `pick` because `tostring` erases the type a shell-level check would need, and is scoped to `sync_pull_message` (a `sync_pull_cursor` legitimately has no envelope).
- An empty string is a present string and stays out of scope (the seal/engine side owns "is this a real ciphertext").

Measured at `main` `e58dbaf` (and its parent `0444bae`, identical): `blob`/`cipher` `null|absent|number` were `rc=0` with the literal stored; `status`/`envelope.v` were already `rc=13`. The test, run through the production adapter (`internal/storage-sync-driver.sh apply`), pins all three input shapes → `rc=13`, no row in any table, and the diagnostic naming the record, field, observed type and "not a string"; a mutation that keeps `rc=13`/no rows but genericises that diagnostic turns the test red.