### PR TITLE
test(teardown): report pid and process state when cleanup fails, without naming the holder (#1036)

### DIFF
--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -72,9 +72,11 @@ teardown() {
     kill "$pid" 2>/dev/null || true
     wait_for_pid_exit "$pid" || true
     # Hand the pid to the shared teardown's reporter (#1036). What matters when
-    # the removal then fails is the set this teardown ACTED on, which is not
-    # recoverable from disk afterwards: the recursive delete can unlink these
-    # very files before it fails.
+    # the removal then fails is the set this teardown called kill and wait on,
+    # which is not recoverable from disk afterwards: the recursive delete can
+    # unlink these very files before it fails. Both statuses above are
+    # discarded, so this records the attempt, not a confirmed exit — the
+    # reporter labels it that way.
     AGMSG_TEARDOWN_WAITED_PIDS="${AGMSG_TEARDOWN_WAITED_PIDS:-} $pid"
   done
   export AGMSG_TEARDOWN_WAITED_PIDS

--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -56,6 +56,21 @@ PY
 esac
 EOF
   chmod +x "$FAKE_CODEX"
+
+  # Stub the bridge launcher (#1049 CI race). codex-monitor.sh spawns
+  # codex-bridge-launcher.sh DETACHED, and it "outlives this script" -- it
+  # resolves its own SKILL_DIR from its script path, which under test is
+  # TEST_SKILL_DIR, so it writes into TEST_SKILL_DIR/run (temp files, a bridge
+  # pidfile, and mkdir -p run/ that RECREATES the dir). teardown kills only the
+  # codex-app-server.*.pid set, never this launcher, so under load it is still
+  # writing run/ when teardown_test_env removes the tree -> "rm: Directory not
+  # empty". None of these tests exercise the bridge (they assert on app-server
+  # pid handling and the codex handoff in CALL_LOG), so a no-op launcher removes
+  # the racer without changing what is tested.
+  local noop="$TEST_PROJECT/noop-bridge-launcher"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$noop"
+  chmod +x "$noop"
+  export AGMSG_CODEX_BRIDGE_LAUNCHER_CMD="$noop"
 }
 
 teardown() {

--- a/tests/test_codex_monitor.bats
+++ b/tests/test_codex_monitor.bats
@@ -71,7 +71,13 @@ teardown() {
     [ -n "$pid" ] || continue
     kill "$pid" 2>/dev/null || true
     wait_for_pid_exit "$pid" || true
+    # Hand the pid to the shared teardown's reporter (#1036). What matters when
+    # the removal then fails is the set this teardown ACTED on, which is not
+    # recoverable from disk afterwards: the recursive delete can unlink these
+    # very files before it fails.
+    AGMSG_TEARDOWN_WAITED_PIDS="${AGMSG_TEARDOWN_WAITED_PIDS:-} $pid"
   done
+  export AGMSG_TEARDOWN_WAITED_PIDS
   rm -rf "$TEST_PROJECT"
   teardown_test_env
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -48,12 +48,16 @@ setup_test_env() {
 #
 # TWO SETS, KEPT APART, because they are not the same claim:
 #
-#   acted   pids a file-level teardown actually signalled and waited for, handed
-#           over before the removal ran. This is the set the question is about.
-#   seen    pid FILES that merely existed before the removal. Nobody may have
-#           waited on these. Printing them under the first heading would say
-#           something untrue about them — the same label-without-content defect
-#           that an earlier draft of this had, one layer along.
+#   acted   pids a file-level teardown CALLED `kill` and a wait on, handed over
+#           before the removal ran. Not "killed": the producer discards both
+#           statuses (`kill … || true`, `wait_for_pid_exit … || true`), so a pid
+#           that was already gone, and one whose wait timed out, are both in
+#           here. Read as intent, not as outcome — the STILL ALIVE marker
+#           beside each pid is the outcome, and it is measured here.
+#   seen    pid FILES that merely existed before the removal. Nothing here
+#           signalled them. Printing them in the first column would say
+#           something untrue about them — the same label-wider-than-its-content
+#           defect that an earlier draft of this had, one layer along.
 #
 # Both are captured BEFORE the removal: a recursive delete can unlink part of
 # the tree before it fails, so a reporter that scanned afterwards would print
@@ -71,8 +75,8 @@ _teardown_forensics() {
     echo "##### teardown could not remove $dir (#1036)"
     echo "##### what is still there:"
     ls -laR "$dir" 2>/dev/null
-    _teardown_report_pids "pids a teardown SIGNALLED and WAITED FOR (captured before the rm)" "$acted"
-    _teardown_report_pids "pid FILES present before the rm — NOT known to have been waited on" "$seen"
+    _teardown_report_pids "pids a teardown CALLED kill AND wait ON (captured before the rm)" "$acted"
+    _teardown_report_pids "pid FILES present before the rm — NOT known to have been signalled" "$seen"
     echo "##### process inventory at that same moment (correlation only —"
     echo "##### this does NOT say which of these holds the directory):"
     ps -ef 2>/dev/null || ps 2>/dev/null

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -34,60 +34,77 @@ setup_test_env() {
   mkdir -p "$HOME"
 }
 
-# When the removal fails, say WHO is still holding the directory (#1036).
+# When the removal fails, report what is known about it (#1036).
 #
-# Three windows-latest failures reported nothing but `rm: cannot remove
-# '/tmp/tmp.XXXXXXXXXX': Directory not empty`, on a job whose every test passed.
-# That message names the directory and not the holder, so each red cost a rerun
-# and taught nobody anything. POSIX unlinks a directory whose files are open, so
-# this only ever fires on Windows -- which is also the only place the answer is
-# needed.
+# Three windows-latest jobs failed with `rm: cannot remove …: Directory not
+# empty` on runs where every test passed. That message names the directory and
+# not the holder, so each red cost a rerun and taught the next one nothing.
 #
-# The probe reports and does NOT repair: the removal's own status is returned
-# unchanged, so a failure stays a failure. Every probe is allowed to fail and
-# none of them can turn a green teardown red -- a dump is worth nothing if it
-# becomes a second thing to debug. `head` is avoided in the pipelines for the
-# reason the workflow's forensics step gives: it closes the pipe early and
-# SIGPIPEs whatever was writing.
+# WHAT THIS ESTABLISHES, and what it does not. It records the pids this teardown
+# actually killed and waited for, and whether each is still alive at the moment
+# the removal failed, alongside a process inventory taken at that same moment.
+# It does NOT identify the holder: nothing here binds an open handle to the
+# remaining path, and neither `ps` nor `tasklist` can. The pids and the
+# inventory are correlation material for whoever reads the next red — the
+# holder's identity stays unproven until something can name it.
 #
-# What it prints is chosen to answer ONE question, the one nobody could answer
-# from three reds: is the pid teardown killed and waited for the same pid that
-# is still holding the directory? The pid files record the wrapper that
-# codex-monitor backgrounded; the handle may belong to a CHILD of that wrapper,
-# which no wait on the parent covers.
+# The pid set is captured BEFORE the removal, not scanned after it. A recursive
+# delete can unlink some of the tree before it fails, so the pid files may be
+# gone by the time the report runs; a reporter that re-scanned them would then
+# print nothing at exactly the moment its output was wanted.
+#
+# Reports, never repairs: the removal's own status is returned unchanged, so a
+# failure stays a failure. The probe body runs in a SUBSHELL so its `set +e`
+# cannot leak into the caller — a report-only probe must not alter the state the
+# framework runs in afterwards. `head` is avoided in the pipelines, as the
+# workflow's forensics step does, because it SIGPIPEs whatever was writing.
 _teardown_forensics() {
-  local dir="$1" pf pid
-  set +e
-  {
+  local dir="$1" waited="$2"
+  (
+    set +e
+    set +o pipefail 2>/dev/null || true
     echo "##### teardown could not remove $dir (#1036)"
     echo "##### what is still there:"
     ls -laR "$dir" 2>/dev/null
-    echo "##### pids teardown knew about, and whether they are still alive:"
-    for pf in "$dir"/run/*.pid; do
-      [ -f "$pf" ] || continue
-      pid="$(cat "$pf" 2>/dev/null)"
-      [ -n "$pid" ] || continue
-      if kill -0 "$pid" 2>/dev/null; then
-        echo "  $pf -> $pid STILL ALIVE (teardown waited for this one)"
-      else
-        echo "  $pf -> $pid exited"
-      fi
-    done
-    echo "##### every process this runner can see (the holder is in here):"
+    echo "##### pids this teardown killed and waited for, captured BEFORE the rm:"
+    if [ -z "$waited" ]; then
+      echo "  (none — no pid file existed when the removal started)"
+    else
+      local pid
+      for pid in $waited; do
+        if kill -0 "$pid" 2>/dev/null; then
+          echo "  $pid STILL ALIVE at the moment the removal failed"
+        else
+          echo "  $pid exited"
+        fi
+      done
+    fi
+    echo "##### process inventory at that same moment (correlation only —"
+    echo "##### this does NOT say which of these holds the directory):"
     ps -ef 2>/dev/null || ps 2>/dev/null
-    # Native Windows processes do not appear in the MSYS ps at all, and the
-    # holder is exactly the kind that would not: a node started by a wrapper.
+    # A native Windows process is absent from the MSYS ps entirely, and the
+    # suspected holder — a node started by a wrapper — is exactly that kind.
     command -v tasklist >/dev/null 2>&1 && tasklist 2>/dev/null
-  } >&2
+  ) >&2
   return 0
 }
 
 teardown_test_env() {
-  local rc=0
+  local rc=0 waited="" pf pid
+  # Snapshot BEFORE the removal (see above). AGMSG_TEARDOWN_WAITED_PIDS lets a
+  # file-level teardown hand over the pids it actually signalled, which is
+  # stronger than anything inferable from the files still on disk.
+  for pf in "$TEST_SKILL_DIR"/run/*.pid; do
+    [ -f "$pf" ] || continue
+    pid="$(cat "$pf" 2>/dev/null)"
+    [ -n "$pid" ] && waited="$waited $pid"
+  done
+  waited="${AGMSG_TEARDOWN_WAITED_PIDS:-}$waited"
   rm -rf "$TEST_SKILL_DIR" || rc=$?
-  [ "$rc" -eq 0 ] || _teardown_forensics "$TEST_SKILL_DIR"
+  [ "$rc" -eq 0 ] || _teardown_forensics "$TEST_SKILL_DIR" "$waited"
   return "$rc"
 }
+
 
 # Skip a test on native Windows / Git Bash (MSYS/MINGW/Cygwin). Use ONLY for
 # behaviour that depends on POSIX process semantics agmsg does not yet support

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -34,8 +34,59 @@ setup_test_env() {
   mkdir -p "$HOME"
 }
 
+# When the removal fails, say WHO is still holding the directory (#1036).
+#
+# Three windows-latest failures reported nothing but `rm: cannot remove
+# '/tmp/tmp.XXXXXXXXXX': Directory not empty`, on a job whose every test passed.
+# That message names the directory and not the holder, so each red cost a rerun
+# and taught nobody anything. POSIX unlinks a directory whose files are open, so
+# this only ever fires on Windows -- which is also the only place the answer is
+# needed.
+#
+# The probe reports and does NOT repair: the removal's own status is returned
+# unchanged, so a failure stays a failure. Every probe is allowed to fail and
+# none of them can turn a green teardown red -- a dump is worth nothing if it
+# becomes a second thing to debug. `head` is avoided in the pipelines for the
+# reason the workflow's forensics step gives: it closes the pipe early and
+# SIGPIPEs whatever was writing.
+#
+# What it prints is chosen to answer ONE question, the one nobody could answer
+# from three reds: is the pid teardown killed and waited for the same pid that
+# is still holding the directory? The pid files record the wrapper that
+# codex-monitor backgrounded; the handle may belong to a CHILD of that wrapper,
+# which no wait on the parent covers.
+_teardown_forensics() {
+  local dir="$1" pf pid
+  set +e
+  {
+    echo "##### teardown could not remove $dir (#1036)"
+    echo "##### what is still there:"
+    ls -laR "$dir" 2>/dev/null
+    echo "##### pids teardown knew about, and whether they are still alive:"
+    for pf in "$dir"/run/*.pid; do
+      [ -f "$pf" ] || continue
+      pid="$(cat "$pf" 2>/dev/null)"
+      [ -n "$pid" ] || continue
+      if kill -0 "$pid" 2>/dev/null; then
+        echo "  $pf -> $pid STILL ALIVE (teardown waited for this one)"
+      else
+        echo "  $pf -> $pid exited"
+      fi
+    done
+    echo "##### every process this runner can see (the holder is in here):"
+    ps -ef 2>/dev/null || ps 2>/dev/null
+    # Native Windows processes do not appear in the MSYS ps at all, and the
+    # holder is exactly the kind that would not: a node started by a wrapper.
+    command -v tasklist >/dev/null 2>&1 && tasklist 2>/dev/null
+  } >&2
+  return 0
+}
+
 teardown_test_env() {
-  rm -rf "$TEST_SKILL_DIR"
+  local rc=0
+  rm -rf "$TEST_SKILL_DIR" || rc=$?
+  [ "$rc" -eq 0 ] || _teardown_forensics "$TEST_SKILL_DIR"
+  return "$rc"
 }
 
 # Skip a test on native Windows / Git Bash (MSYS/MINGW/Cygwin). Use ONLY for

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -40,45 +40,39 @@ setup_test_env() {
 # empty` on runs where every test passed. That message names the directory and
 # not the holder, so each red cost a rerun and taught the next one nothing.
 #
-# WHAT THIS ESTABLISHES, and what it does not. It records the pids this teardown
-# actually killed and waited for, and whether each is still alive at the moment
-# the removal failed, alongside a process inventory taken at that same moment.
-# It does NOT identify the holder: nothing here binds an open handle to the
-# remaining path, and neither `ps` nor `tasklist` can. The pids and the
-# inventory are correlation material for whoever reads the next red — the
-# holder's identity stays unproven until something can name it.
+# WHAT THIS ESTABLISHES, and what it does not. It records pids and their
+# liveness at the moment the removal failed, alongside a process inventory taken
+# at that same moment. It does NOT identify the holder: nothing here binds an
+# open handle to the remaining path, and neither `ps` nor `tasklist` can. All of
+# it is correlation material for whoever reads the next red.
 #
-# The pid set is captured BEFORE the removal, not scanned after it. A recursive
-# delete can unlink some of the tree before it fails, so the pid files may be
-# gone by the time the report runs; a reporter that re-scanned them would then
-# print nothing at exactly the moment its output was wanted.
+# TWO SETS, KEPT APART, because they are not the same claim:
 #
-# Reports, never repairs: the removal's own status is returned unchanged, so a
-# failure stays a failure. The probe body runs in a SUBSHELL so its `set +e`
-# cannot leak into the caller — a report-only probe must not alter the state the
+#   acted   pids a file-level teardown actually signalled and waited for, handed
+#           over before the removal ran. This is the set the question is about.
+#   seen    pid FILES that merely existed before the removal. Nobody may have
+#           waited on these. Printing them under the first heading would say
+#           something untrue about them — the same label-without-content defect
+#           that an earlier draft of this had, one layer along.
+#
+# Both are captured BEFORE the removal: a recursive delete can unlink part of
+# the tree before it fails, so a reporter that scanned afterwards would print
+# nothing at exactly the moment its output was wanted.
+#
+# Reports, never repairs: the removal's own status is returned unchanged. The
+# probe body is a SUBSHELL so its `set +e` cannot leak into the state the
 # framework runs in afterwards. `head` is avoided in the pipelines, as the
 # workflow's forensics step does, because it SIGPIPEs whatever was writing.
 _teardown_forensics() {
-  local dir="$1" waited="$2"
+  local dir="$1" acted="$2" seen="$3"
   (
     set +e
     set +o pipefail 2>/dev/null || true
     echo "##### teardown could not remove $dir (#1036)"
     echo "##### what is still there:"
     ls -laR "$dir" 2>/dev/null
-    echo "##### pids this teardown killed and waited for, captured BEFORE the rm:"
-    if [ -z "$waited" ]; then
-      echo "  (none — no pid file existed when the removal started)"
-    else
-      local pid
-      for pid in $waited; do
-        if kill -0 "$pid" 2>/dev/null; then
-          echo "  $pid STILL ALIVE at the moment the removal failed"
-        else
-          echo "  $pid exited"
-        fi
-      done
-    fi
+    _teardown_report_pids "pids a teardown SIGNALLED and WAITED FOR (captured before the rm)" "$acted"
+    _teardown_report_pids "pid FILES present before the rm — NOT known to have been waited on" "$seen"
     echo "##### process inventory at that same moment (correlation only —"
     echo "##### this does NOT say which of these holds the directory):"
     ps -ef 2>/dev/null || ps 2>/dev/null
@@ -89,19 +83,43 @@ _teardown_forensics() {
   return 0
 }
 
+_teardown_report_pids() {
+  local heading="$1" pids="$2" pid
+  echo "##### $heading:"
+  if [ -z "${pids// /}" ]; then
+    echo "  (none)"
+    return 0
+  fi
+  for pid in $pids; do
+    if kill -0 "$pid" 2>/dev/null; then
+      echo "  $pid STILL ALIVE at the moment the removal failed"
+    else
+      echo "  $pid exited"
+    fi
+  done
+}
+
+# Deduplicate a whitespace-separated pid list, order preserved.
+_teardown_uniq_pids() {
+  local seen=" " out="" p
+  for p in $1; do
+    case "$seen" in *" $p "*) continue ;; esac
+    seen="$seen$p "; out="$out $p"
+  done
+  printf '%s' "${out# }"
+}
+
 teardown_test_env() {
-  local rc=0 waited="" pf pid
-  # Snapshot BEFORE the removal (see above). AGMSG_TEARDOWN_WAITED_PIDS lets a
-  # file-level teardown hand over the pids it actually signalled, which is
-  # stronger than anything inferable from the files still on disk.
+  local rc=0 acted seen="" pf pid
+  acted="$(_teardown_uniq_pids "${AGMSG_TEARDOWN_WAITED_PIDS:-}")"
   for pf in "$TEST_SKILL_DIR"/run/*.pid; do
     [ -f "$pf" ] || continue
     pid="$(cat "$pf" 2>/dev/null)"
-    [ -n "$pid" ] && waited="$waited $pid"
+    [ -n "$pid" ] && case " $acted " in *" $pid "*) : ;; *) seen="$seen $pid" ;; esac
   done
-  waited="${AGMSG_TEARDOWN_WAITED_PIDS:-}$waited"
+  seen="$(_teardown_uniq_pids "$seen")"
   rm -rf "$TEST_SKILL_DIR" || rc=$?
-  [ "$rc" -eq 0 ] || _teardown_forensics "$TEST_SKILL_DIR" "$waited"
+  [ "$rc" -eq 0 ] || _teardown_forensics "$TEST_SKILL_DIR" "$acted" "$seen"
   return "$rc"
 }
 

--- a/tests/test_teardown_forensics.bats
+++ b/tests/test_teardown_forensics.bats
@@ -4,9 +4,14 @@
 #
 # The reporter only ever runs on a red that appears roughly once a day on one
 # platform, so nothing else in the suite would notice it rotting. These pin the
-# properties that make it worth having at all — including the arm that an
-# earlier draft got wrong, where the removal deletes the pid file BEFORE it
-# fails and a reporter that scanned afterwards had nothing left to say.
+# properties that make it worth having at all — including the arm an earlier
+# draft got wrong, where the removal deletes the pid file BEFORE it fails and a
+# reporter that scanned afterwards had nothing left to say.
+#
+# Every claim here is a plain command or a `[ ]`, never a non-last `[[ ]]`: on
+# bash 3.2, which is what CI's macOS leg runs, a non-last `[[ ]]` reports `ok`
+# with a false claim inside it (#670). A first draft of this file had three of
+# them, and check-enforced-assertions.sh is what named them.
 
 load test_helper
 
@@ -17,19 +22,36 @@ setup() {
 
 teardown() {
   [ -n "${LIVE_PID:-}" ] && kill "$LIVE_PID" 2>/dev/null
-  [ -d "${PROBE_DIR:-}/zlocked" ] && chmod 700 "$PROBE_DIR/zlocked" 2>/dev/null
-  [ -n "${PROBE_DIR:-}" ] && rm -rf "$PROBE_DIR" 2>/dev/null
+  # `command`, because a test may have replaced `rm` with the seam below.
+  [ -n "${PROBE_DIR:-}" ] && command rm -rf "$PROBE_DIR" 2>/dev/null
   return 0
 }
 
-# Build a directory whose `rm -rf` removes run/ (and the pid file in it) and
-# THEN fails on an unwritable subdirectory. `zlocked` sorts after `run`, which is
-# what puts the deletion first — the partial-delete arm.
-_unremovable_with_pidfile() {   # <pid to record>
-  mkdir -p "$PROBE_DIR/run" "$PROBE_DIR/zlocked"
+# Says so, so a red names which claim fired rather than a bare line number.
+_says() {          # <haystack> <needle>
+  case "$1" in *"$2"*) return 0 ;; esac
+  echo "expected the report to contain: $2" >&2
+  return 1
+}
+
+# The removal fails, and the pid file is already gone when it does.
+#
+# A seam, not a filesystem trick. An earlier draft built an unwritable
+# subdirectory sorting after `run/` and leaned on `rm` walking it in name order
+# and on chmod 500 refusing the delete — two assumptions about the platform,
+# neither of which is what this file is asking about. The question is what the
+# reporter can still say after a partial delete, so the partial delete is
+# stated outright.
+_arm_partial_delete() {   # <pid to write into the pid file>
+  mkdir -p "$PROBE_DIR/run"
   printf '%s\n' "$1" > "$PROBE_DIR/run/server.pid"
-  : > "$PROBE_DIR/zlocked/inner"
-  chmod 500 "$PROBE_DIR/zlocked"
+  rm() {
+    if [ "${1:-}" = "-rf" ] && [ "${2:-}" = "$PROBE_DIR" ]; then
+      command rm -f "$PROBE_DIR/run/server.pid"
+      return 1
+    fi
+    command rm "$@"
+  }
 }
 
 @test "teardown forensics: a successful removal says nothing at all (#1036)" {
@@ -46,35 +68,35 @@ _unremovable_with_pidfile() {   # <pid to record>
   sleep 30 & LIVE_PID=$!
   export TEST_SKILL_DIR="$PROBE_DIR"
   export AGMSG_TEARDOWN_WAITED_PIDS="$LIVE_PID"
-  _unremovable_with_pidfile "$LIVE_PID"
+  _arm_partial_delete "$LIVE_PID"
 
   run teardown_test_env
-  [ "$status" -ne 0 ]                              # the failure is not swallowed
-  [ ! -f "$PROBE_DIR/run/server.pid" ]             # the arm under test: it is gone
-  [[ "$output" == *"$LIVE_PID STILL ALIVE"* ]]     # …and the pid survived anyway
-  [[ "$output" == *"SIGNALLED and WAITED FOR"* ]]
+  [ "$status" -ne 0 ]                          # the failure is not swallowed
+  [ ! -f "$PROBE_DIR/run/server.pid" ]         # the arm under test: it is gone
+  _says "$output" "$LIVE_PID STILL ALIVE"      # …and the pid survived anyway
+  _says "$output" "CALLED kill AND wait ON"
 }
 
-@test "teardown forensics: a pid file nobody waited on is NOT reported as waited (#1036)" {
-  # Provenance: the generic pre-rm scan finds pid FILES. Reporting those under
-  # the "signalled and waited for" heading would say something untrue about
+@test "teardown forensics: a pid file nobody signalled is NOT reported as signalled (#1036)" {
+  # Provenance: the generic pre-rm scan finds pid FILES. Reporting those in the
+  # column for pids the teardown acted on would say something untrue about
   # them, which is the defect this file exists to keep out.
   export TEST_SKILL_DIR="$PROBE_DIR"
-  _unremovable_with_pidfile 999001                 # written, never signalled
+  _arm_partial_delete 999001                   # written, never signalled
 
   run teardown_test_env
   [ "$status" -ne 0 ]
-  local waited_block="${output#*SIGNALLED and WAITED FOR}"
-  waited_block="${waited_block%%#####*}"
-  [[ "$waited_block" != *999001* ]]
-  [[ "$output" == *"NOT known to have been waited on"* ]]
-  [[ "$output" == *999001* ]]
+  local acted_block="${output#*CALLED kill AND wait ON}"
+  acted_block="${acted_block%%#####*}"
+  refute _says "$acted_block" 999001
+  _says "$output" "NOT known to have been signalled"
+  _says "$output" 999001
 }
 
 @test "teardown forensics: a pid is not reported twice when both sources carry it (#1036)" {
   export TEST_SKILL_DIR="$PROBE_DIR"
   export AGMSG_TEARDOWN_WAITED_PIDS="999002 999002"
-  _unremovable_with_pidfile 999002
+  _arm_partial_delete 999002
 
   run teardown_test_env
   [ "$status" -ne 0 ]
@@ -83,17 +105,20 @@ _unremovable_with_pidfile() {   # <pid to record>
 
 @test "teardown forensics: the probe does not change the caller's shell options (#1036)" {
   # Asked of a plain bash, not of this test body: bats manages `set -e` around
-  # every command it runs, so a leak inside a @test is invisible — checked, and
-  # the mutation that removes the subshell passes in here while leaking for real
-  # outside. The property belongs to whatever sources the helper, so that is
-  # what gets asked.
-  _unremovable_with_pidfile 999003
+  # every command it runs, so a leak inside a @test is invisible — measured,
+  # and the mutation that removes the subshell passed in here while leaking for
+  # real outside. The property belongs to whatever sources the helper, so that
+  # is what gets asked.
+  mkdir -p "$PROBE_DIR/run"
+  printf '999003\n' > "$PROBE_DIR/run/server.pid"
   run bash -c '
     . "$1/test_helper.bash"
     export TEST_SKILL_DIR="$2"
+    rm() { if [ "${1:-}" = "-rf" ]; then return 1; fi; command rm "$@"; }
     set -e
     teardown_test_env >/dev/null 2>&1 || true
     case "$-" in *e*) echo OPTIONS_INTACT ;; *) echo OPTIONS_LEAKED ;; esac
   ' _ "$BATS_TEST_DIRNAME" "$PROBE_DIR"
-  [[ "$output" == *OPTIONS_INTACT* ]]
+  [ "$status" -eq 0 ]
+  _says "$output" OPTIONS_INTACT
 }

--- a/tests/test_teardown_forensics.bats
+++ b/tests/test_teardown_forensics.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+#
+# Controls for the teardown's failure reporter (#1036).
+#
+# The reporter only ever runs on a red that appears roughly once a day on one
+# platform, so nothing else in the suite would notice it rotting. These pin the
+# properties that make it worth having at all — including the arm that an
+# earlier draft got wrong, where the removal deletes the pid file BEFORE it
+# fails and a reporter that scanned afterwards had nothing left to say.
+
+load test_helper
+
+setup() {
+  PROBE_DIR="$(mktemp -d)"
+  unset AGMSG_TEARDOWN_WAITED_PIDS
+}
+
+teardown() {
+  [ -n "${LIVE_PID:-}" ] && kill "$LIVE_PID" 2>/dev/null
+  [ -d "${PROBE_DIR:-}/zlocked" ] && chmod 700 "$PROBE_DIR/zlocked" 2>/dev/null
+  [ -n "${PROBE_DIR:-}" ] && rm -rf "$PROBE_DIR" 2>/dev/null
+  return 0
+}
+
+# Build a directory whose `rm -rf` removes run/ (and the pid file in it) and
+# THEN fails on an unwritable subdirectory. `zlocked` sorts after `run`, which is
+# what puts the deletion first — the partial-delete arm.
+_unremovable_with_pidfile() {   # <pid to record>
+  mkdir -p "$PROBE_DIR/run" "$PROBE_DIR/zlocked"
+  printf '%s\n' "$1" > "$PROBE_DIR/run/server.pid"
+  : > "$PROBE_DIR/zlocked/inner"
+  chmod 500 "$PROBE_DIR/zlocked"
+}
+
+@test "teardown forensics: a successful removal says nothing at all (#1036)" {
+  export TEST_SKILL_DIR="$PROBE_DIR"
+  mkdir -p "$TEST_SKILL_DIR/run"
+  run teardown_test_env
+  [ "$status" -eq 0 ]
+  # Not "few bytes" — none. A probe that chatters on green trains people to
+  # ignore it on red.
+  [ -z "$output" ]
+}
+
+@test "teardown forensics: the rm deletes the pid file first, and the report still names it (#1036)" {
+  sleep 30 & LIVE_PID=$!
+  export TEST_SKILL_DIR="$PROBE_DIR"
+  export AGMSG_TEARDOWN_WAITED_PIDS="$LIVE_PID"
+  _unremovable_with_pidfile "$LIVE_PID"
+
+  run teardown_test_env
+  [ "$status" -ne 0 ]                              # the failure is not swallowed
+  [ ! -f "$PROBE_DIR/run/server.pid" ]             # the arm under test: it is gone
+  [[ "$output" == *"$LIVE_PID STILL ALIVE"* ]]     # …and the pid survived anyway
+  [[ "$output" == *"SIGNALLED and WAITED FOR"* ]]
+}
+
+@test "teardown forensics: a pid file nobody waited on is NOT reported as waited (#1036)" {
+  # Provenance: the generic pre-rm scan finds pid FILES. Reporting those under
+  # the "signalled and waited for" heading would say something untrue about
+  # them, which is the defect this file exists to keep out.
+  export TEST_SKILL_DIR="$PROBE_DIR"
+  _unremovable_with_pidfile 999001                 # written, never signalled
+
+  run teardown_test_env
+  [ "$status" -ne 0 ]
+  local waited_block="${output#*SIGNALLED and WAITED FOR}"
+  waited_block="${waited_block%%#####*}"
+  [[ "$waited_block" != *999001* ]]
+  [[ "$output" == *"NOT known to have been waited on"* ]]
+  [[ "$output" == *999001* ]]
+}
+
+@test "teardown forensics: a pid is not reported twice when both sources carry it (#1036)" {
+  export TEST_SKILL_DIR="$PROBE_DIR"
+  export AGMSG_TEARDOWN_WAITED_PIDS="999002 999002"
+  _unremovable_with_pidfile 999002
+
+  run teardown_test_env
+  [ "$status" -ne 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c '^  999002 ')" -eq 1 ]
+}
+
+@test "teardown forensics: the probe does not change the caller's shell options (#1036)" {
+  # Asked of a plain bash, not of this test body: bats manages `set -e` around
+  # every command it runs, so a leak inside a @test is invisible — checked, and
+  # the mutation that removes the subshell passes in here while leaking for real
+  # outside. The property belongs to whatever sources the helper, so that is
+  # what gets asked.
+  _unremovable_with_pidfile 999003
+  run bash -c '
+    . "$1/test_helper.bash"
+    export TEST_SKILL_DIR="$2"
+    set -e
+    teardown_test_env >/dev/null 2>&1 || true
+    case "$-" in *e*) echo OPTIONS_INTACT ;; *) echo OPTIONS_LEAKED ;; esac
+  ' _ "$BATS_TEST_DIRNAME" "$PROBE_DIR"
+  [[ "$output" == *OPTIONS_INTACT* ]]
+}


### PR DESCRIPTION
Three `windows-latest` jobs failed with

```
rm: cannot remove '/tmp/tmp.XXXXXXXXXX': Directory not empty
```

on runs where **every test passed**. The message names the directory and not the
holder, so each red cost a rerun and left the next one no better informed.

### What this establishes — and what it does not

It records **the pids this teardown called `kill` and a wait on** — not the
pids it killed. The producer discards both statuses (`kill … || true`,
`wait_for_pid_exit … || true`), so a pid that was already gone and one whose
wait timed out are both in that column; it is an intent, and the STILL ALIVE
marker printed beside each pid is the outcome. It also records a process
inventory taken at the moment the removal failed.

It does **not** identify the holder. Nothing here binds an open handle to the
remaining path, and neither `ps` nor `tasklist` can. The pids and the inventory
are correlation material for whoever reads the next red; the holder's identity
stays unproven until something can name it.

That boundary is deliberate. An earlier draft of this PR said the next failure
would answer the question outright, which was more than the dump can support.

### The pid set is captured before the removal

A recursive delete can unlink part of the tree before it fails. On the arm where
the pid files go first and the directory survives, a reporter that re-scanned
them afterwards would print nothing — while its heading still said "the pids
teardown knew about". A label with no content reads as an answer.

The file-level teardown also hands over the pids it called `kill` on, which is
more than is inferable from what remains on disk — and the two sets are printed
in separate columns, the second marked "NOT known to have been signalled",
because a pid FILE that merely existed is not a pid anything acted on.

### Why the teardown and not a workflow step

The suspected holder exits on its own 60-second timer. By the time a post-job
step runs, the photograph is of an empty room. The failing cleanup is the only
moment it is still there.

### Reports, never repairs

* `rm`'s status is returned unchanged — a failure stays a failure
* the probe body is a **subshell**, so its `set +e` cannot leak into the state
  the framework runs in afterwards
* every probe may fail without consequence
* no `head` in the pipelines — it SIGPIPEs the writer, the same reason the
  workflow's forensics step avoids it
* `tasklist` is included because a native Windows process is absent from the
  MSYS `ps` entirely

### Verified with controls

| case | result |
|---|---|
| normal teardown | returns 0, prints **zero bytes** |
| unremovable dir whose pid file the `rm` already deleted | returns non-zero, **still names that pid and reports it alive** |
| `errexit` set by the caller | still set after the probe returns |

Only Windows can confirm the diagnosis this enables; POSIX unlinks a directory
whose files are open, which is why this has never reproduced locally.

### What was wrong before, recorded so nobody retraces it

Two earlier diagnoses of mine were wrong: I read a comment present on one of two
identical fakes as evidence of a mechanism absent from the other, and I proposed
adding a pid-file teardown loop that was already there.


### The controls are enforceable, and each was broken to prove it

`tests/test_teardown_forensics.bats` pins the properties above. A first draft of
it made three of its central claims with a non-last `[[ ]]`, which on bash 3.2 —
what CI's macOS leg runs — reports `ok` with a false claim inside it (#670).
`check-enforced-assertions.sh` names them: it read 638 against a baseline of 635
and exited 1. Every claim is now a plain command or a `[ ]`, and the checker is
back at the baseline.

The partial-delete arm no longer depends on `rm` walking the tree in name order
or on `chmod 500` refusing a delete — two assumptions about the platform, and
neither is what the file is asking about. A seam replaces `rm` for that one
call: it unlinks the pid file, then returns non-zero.

Six mutations, one per property, each red:

| mutation | result |
|---|---|
| scan the pid files after the `rm` instead of before | 1 failing |
| merge both sets into the acted column | 1 failing |
| drop the dedupe | 1 failing |
| let the probe leak `set +e` | 1 failing |
| report on a successful removal too | 1 failing |
| drop the STILL ALIVE liveness marker | 1 failing |


---

## Root cause of the CI red (codex-monitor 357/359), and the fix at `b5aedd5`

The `Directory not empty` red on `codex-monitor: never kills a non-codex process recorded under a reused pid` / `reuses a live app-server when tasklist cannot see it (#567)` is a teardown race whose writer is now named:

- `codex-monitor.sh:240` spawns `codex-bridge-launcher.sh` **detached** (`… &`, comment: "the launcher is detached on purpose and outlives this script").
- The launcher resolves its own `SKILL_DIR` from its script path (`codex-bridge-launcher.sh:31`), which under test is **`TEST_SKILL_DIR`**, so it writes into **`TEST_SKILL_DIR/run`** — including `mkdir -p "$RUN_DIR"` (recreates the dir), an atomic-rename temp `${prefix}${now}.$$.$RANDOM`, a bridge pidfile, and an identity-cache marker.
- The test teardown kills **only** the `codex-app-server.*.pid` set — never this launcher — so it outlives the test and, under shard load, is still writing `run/` when `teardown_test_env` removes the tree → `rm: … Directory not empty`. Its temp is gone by the time the #1036 forensic reporter runs, which is why the report shows an **empty** `run/`.
- Confirmed the launcher fires: stubbing it to a probe showed **3 invocations** in 357/359 (`codex <proj> ws://127.0.0.1:PORT <ppid>`).

**Why #1049 and not `main`:** #1049 adds ~3k lines across 39 test files; the shard split (weighted by @test count) rebalances and the codex-monitor shard gets heavier, so the launcher is slower under that load and overlaps the rm. **No single line of #1049 introduces the race — it exposes a pre-existing latent race in the codex-monitor teardown via shard load.**

**Fix (`b5aedd5`):** stub `AGMSG_CODEX_BRIDGE_LAUNCHER_CMD` to a no-op in `test_codex_monitor.bats` setup, so the detached launcher never spawns. These tests assert app-server pid handling and the codex handoff in `CALL_LOG`, not the bridge, so coverage is unchanged. Verified: 10/10 green, no bridge process lingers.

### Reproduction status (honest)

The **natural timing race did not reproduce locally** — isolation (2/2), 4× CPU load (3/3), and `bats --jobs 4` (4/4) were all clean. A fast machine finishes the launcher before teardown. "Did not reproduce" is a result, not proof of absence; the mechanism is established by the code path plus the confirmed launcher spawn.

### Deterministic reproduction the next person can add (seam, not sleep)

Rather than chase the timing, pin the timepoint with a barrier seam like `inbox.sh:82`'s `AGMSG_TEST_MARK_BARRIER` (`.reached` / `.release`, no-op when unset; siblings in `check-inbox.sh`, `remote.sh`). Concretely: point `AGMSG_CODEX_BRIDGE_LAUNCHER_CMD` at a stub that (given the run dir via env) writes a `run/` file, touches `<barrier>.reached`, and blocks on `<barrier>.release`; have the test wait for `.reached`, then run the teardown rm **while the launcher's file is present** — a deterministic `Directory not empty`. The `b5aedd5` fix (no-op launcher) then turns it green. That converts this from a load-flake into a controlled regression test.

**Priority note:** base is `main`, not on the 1.3.0 path; left at `b5aedd5` with the above so the next person need not redo the investigation.
