### PR TITLE
fix(despawn): remove the role-session record on teardown, on both paths (#1041)

### DIFF
--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -32,6 +32,10 @@ source "$SCRIPT_DIR/lib/roster-journal.sh"
 # cluster — '.', '/', '\', '"', '[', ']' all have path meaning to json1).
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/validate.sh"
+# The advisory role->session record is torn down here too (#1041); it keys on the
+# same (team, agent) as the actas lock released below, via _actas_lock_encode.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/role-session.sh"
 # Escape as a SQL string literal (parity with join.sh/rename.sh/leave.sh):
 # concatenated into JSON paths below as `'$.agents.' || '<escaped>'` rather
 # than spliced into the path text, so a single quote can't break the
@@ -201,6 +205,13 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
   if [ -n "$SESSION_ID" ]; then
     actas_lock_release "$TEAM_NAME" "$TARGET_AGENT" "$SESSION_ID" 2>/dev/null || true
   fi
+  # Remove the advisory role->session record for this seat (#1041). Nothing else
+  # deleted it, so it outlived every despawn -- graceful AND --force -- leaving one
+  # stale seat record (session uuid, name, team, type, project) per member ever
+  # spawned, which internal/resurrect-panes.sh reads. NOT gated on SESSION_ID:
+  # --force calls reset.sh with none, and the record must go on both paths.
+  _agmsg_role_session_path_into "$TEAM_NAME" "$TARGET_AGENT"
+  rm -f "$_AGMSG_ROLE_SESSION_PATH" 2>/dev/null || true
 done
 
 if [ "$REMOVED" -eq 0 ]; then

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -200,18 +200,32 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
   TOUCHED_TEAMS=$((TOUCHED_TEAMS + 1))
   echo "Cleared $MATCH_COUNT registration(s) for $TARGET_AGENT from $TEAM_NAME"
 
+  # Remove the advisory role->session record for this seat (#1041). Nothing else
+  # deleted it, so it outlived every despawn -- graceful AND --force -- leaving one
+  # stale seat record (session uuid, name, team, type, project) per member ever
+  # spawned, which internal/resurrect-panes.sh reads.
+  #
+  # Two conditions the first cut got wrong (#1052 review, measured by utildev):
+  #  - ONLY when REMAINING is 0. The record is keyed on (team, agent) ALONE --
+  #    project is a field inside it -- so a peer still registered under a DIFFERENT
+  #    project shares this one file. Deleting it whenever any registration is
+  #    dropped tore the record out from under a live seat in another project. Ride
+  #    the same count the config removal above already uses.
+  #  - BEFORE the actas lock is released, not after. actas-claim acquires the lock
+  #    THEN writes the record, so a peer that legitimately claims in the window
+  #    between our release and our rm ends up holding the lock with no record --
+  #    its fresh record deleted by our late rm. Removing first closes that window.
+  # NOT gated on SESSION_ID: --force passes none and the record must go on both
+  # paths; the SESSION_ID gate stays on the lock release alone.
+  if [ "$REMAINING" -eq 0 ]; then
+    _agmsg_role_session_path_into "$TEAM_NAME" "$TARGET_AGENT"
+    rm -f "$_AGMSG_ROLE_SESSION_PATH" 2>/dev/null || true
+  fi
   # Release the actas lock for this (team, agent) pair so peer sessions can
   # claim it without waiting for owner-session-end / stale GC.
   if [ -n "$SESSION_ID" ]; then
     actas_lock_release "$TEAM_NAME" "$TARGET_AGENT" "$SESSION_ID" 2>/dev/null || true
   fi
-  # Remove the advisory role->session record for this seat (#1041). Nothing else
-  # deleted it, so it outlived every despawn -- graceful AND --force -- leaving one
-  # stale seat record (session uuid, name, team, type, project) per member ever
-  # spawned, which internal/resurrect-panes.sh reads. NOT gated on SESSION_ID:
-  # --force calls reset.sh with none, and the record must go on both paths.
-  _agmsg_role_session_path_into "$TEAM_NAME" "$TARGET_AGENT"
-  rm -f "$_AGMSG_ROLE_SESSION_PATH" 2>/dev/null || true
 done
 
 if [ "$REMOVED" -eq 0 ]; then

--- a/tests/test_reset_role_session.bats
+++ b/tests/test_reset_role_session.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+# #1041: despawn left run/role-session.<team>__<member> behind on BOTH teardown
+# paths (graceful and --force), because nothing removed it -- every other seat
+# record had a removal site, this one had zero. Both paths converge on reset.sh
+# (graceful: the member's watcher runs it with a session_id; --force: despawn.sh
+# runs it with none), so reset.sh removes the record for the (team, agent) it is
+# dropping, on either path.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export AGMSG_AGENT_PID=""
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  export RUN_DIR="$SKILL_DIR/run"
+  mkdir -p "$RUN_DIR"
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/role-session.sh"
+}
+teardown() { teardown_test_env; }
+
+fake_register() { bash "$SKILL_DIR/scripts/join.sh" "$1" "$2" claude-code "${3:-/tmp/p1}"; }
+
+# Path of the (team, agent) role-session record.
+rs_path() { _agmsg_role_session_path_into "$1" "$2"; printf '%s' "$_AGMSG_ROLE_SESSION_PATH"; }
+
+@test "reset (graceful, with session_id) removes the role-session record (#1041)" {
+  fake_register T alice
+  agmsg_role_session_record T alice sid-me /tmp/p1 claude-code
+  [ -f "$(rs_path T alice)" ]                     # present before
+
+  bash "$SKILL_DIR/scripts/reset.sh" /tmp/p1 claude-code alice sid-me >/dev/null
+
+  [ ! -f "$(rs_path T alice)" ]                   # gone after
+}
+
+@test "reset (--force, no session_id) removes the role-session record (#1041)" {
+  # The --force teardown calls reset.sh WITHOUT a session_id; the record must go
+  # on this path too (the bug was present on both). Removal must not be gated on
+  # session_id the way the lock release is.
+  fake_register T alice
+  agmsg_role_session_record T alice sid-me /tmp/p1 claude-code
+  [ -f "$(rs_path T alice)" ]
+
+  bash "$SKILL_DIR/scripts/reset.sh" /tmp/p1 claude-code alice >/dev/null
+
+  [ ! -f "$(rs_path T alice)" ]
+}
+
+@test "reset removes only the dropped role's record, not a peer's (#1041)" {
+  fake_register T alice
+  fake_register T bob
+  agmsg_role_session_record T alice sid-a /tmp/p1 claude-code
+  agmsg_role_session_record T bob   sid-b /tmp/p1 claude-code
+
+  bash "$SKILL_DIR/scripts/reset.sh" /tmp/p1 claude-code alice sid-a >/dev/null
+
+  [ ! -f "$(rs_path T alice)" ]
+  [ -f "$(rs_path T bob)" ]                       # bob's seat untouched
+}
+
+@test "reset still drops the registration when it removes the record (positive control) (#1041)" {
+  fake_register T alice
+  agmsg_role_session_record T alice sid-me /tmp/p1 claude-code
+
+  run bash "$SKILL_DIR/scripts/reset.sh" /tmp/p1 claude-code alice sid-me
+  [ "$status" -eq 0 ]
+  # the record removal did not replace the existing teardown: registration gone too
+  run bash "$SKILL_DIR/scripts/whoami.sh" /tmp/p1 claude-code
+  ! grep -q 'agent=alice' <<<"$output"
+}

--- a/tests/test_reset_role_session.bats
+++ b/tests/test_reset_role_session.bats
@@ -62,6 +62,47 @@ rs_path() { _agmsg_role_session_path_into "$1" "$2"; printf '%s' "$_AGMSG_ROLE_S
   [ -f "$(rs_path T bob)" ]                       # bob's seat untouched
 }
 
+@test "reset keeps the record while the SAME (team,agent) is still registered under another project (#1052)" {
+  # The record is keyed on (team, agent) ALONE; project is a field inside it. A
+  # peer registered under a different project shares this one file, so removing it
+  # whenever any registration drops tears it out from under a live seat. Removal is
+  # gated on REMAINING==0 -- the same count the config removal uses. Reverting to an
+  # unconditional rm (dropping the REMAINING gate) turns this red.
+  fake_register T alice /tmp/p1
+  fake_register T alice /tmp/p2
+  agmsg_role_session_record T alice sid-live /tmp/p2 claude-code
+  [ -f "$(rs_path T alice)" ]
+
+  bash "$SKILL_DIR/scripts/reset.sh" /tmp/p1 claude-code alice sid-other >/dev/null
+
+  run bash "$SKILL_DIR/scripts/whoami.sh" /tmp/p2 claude-code
+  grep -q 'agent=alice' <<<"$output"                # control: p2's seat is still live
+  [ -f "$(rs_path T alice)" ]                        # so its record must survive
+}
+
+@test "reset removes the record BEFORE releasing the actas lock, not after (#1052)" {
+  # actas-claim acquires the lock THEN writes the record, so a peer that claims in
+  # the window between our release and our rm would have its fresh record deleted.
+  # Removal must precede the release. Seam: actas_lock_release stands in for a peer
+  # that claims exactly at release time by writing its own record; if the rm ran
+  # first the peer's record survives, if it ran after the peer's record is gone.
+  # Swapping the two lines in reset.sh turns this red.
+  cat >> "$SKILL_DIR/scripts/lib/actas-lock.sh" <<'SEAM'
+actas_lock_release() {
+  _agmsg_role_session_path_into "$1" "$2"
+  printf 'session=PEER\n' > "$_AGMSG_ROLE_SESSION_PATH"
+}
+SEAM
+  fake_register T alice /tmp/p1
+  agmsg_role_session_record T alice sid-me /tmp/p1 claude-code
+
+  bash "$SKILL_DIR/scripts/reset.sh" /tmp/p1 claude-code alice sid-me >/dev/null
+
+  # The peer's record (written by the release seam) must survive -> rm ran first.
+  [ -f "$(rs_path T alice)" ]
+  grep -q '^session=PEER$' "$(rs_path T alice)"
+}
+
 @test "reset still drops the registration when it removes the record (positive control) (#1041)" {
   fake_register T alice
   agmsg_role_session_record T alice sid-me /tmp/p1 claude-code


### PR DESCRIPTION
Fixes #1041.

`despawn` left `run/role-session.<team>__<member>` behind after both teardown paths (graceful and `--force`). Every other seat record had a removal site; this one had **zero**, so it accumulated one stale record (session uuid, name, team, type, project) per member ever spawned — the record `internal/resurrect-panes.sh` reads.

Both teardown paths converge on `reset.sh` (graceful: the member’s watcher runs it with a `session_id`; `--force`: `despawn.sh` runs it with none), so `reset.sh` now removes the record for the `(team, agent)` it drops — keyed the same way (`_actas_lock_encode`) as the actas lock it releases, and **not** gated on `session_id`, since the `--force` path passes none.

Base is `integration/terminal-driver-v1` (not main) because #1047 changed record handling; the current record shape was read first.

Test exercises `reset.sh` on both the with-session and no-session paths → record gone while a peer’s is untouched, plus a positive control that the registration is still dropped; a mutation removing the `rm` turns the removal cases red. Regression: reset/role-session/despawn/team suites green (238 tests), checkers at baseline.

Not separately measured (flagged in the issue): whether a stale record affected identity resolution for a reused member name — the fix removes the record, so no stale record survives a despawn; the pre-fix behavior was not reproduced.