### PR TITLE
fix(team): report a missing placement record as that, not "not named yet"

### DIFF
--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -52,7 +52,12 @@ _member_placement() {
   fi
   rec="$(agmsg_spawn_path "$team" "$agent" 2>/dev/null)" || rec=""
   if [ -z "$rec" ] || [ ! -f "$rec" ]; then
-    printf 'no pane recorded — not named yet'; return 0
+    # This reads the PLACEMENT RECORD (agmsg_spawn_path), which only spawn writes
+    # -- not the pane's name. A member started by hand has no record, but its pane
+    # label (<team>:<name>) is still set automatically (#1047). Reporting the
+    # record's absence as "not named yet" conflated the two: koit read it as
+    # "naming is broken" while the label td-dogfood:alice was in fact present.
+    printf 'no placement record (not spawned through agmsg)'; return 0
   fi
   IFS="$(printf '\t')" read -r ref _ _ < "$rec" || true
   if [ -z "$ref" ]; then


### PR DESCRIPTION
From the /agmsgtd check bundle (tl), the independently-fixable wording item.

`team.sh`s placement column reads the **placement record** (`agmsg_spawn_path`, written only by `spawn`), but printed its absence as `no pane recorded — not named yet`. A member started by hand has no placement record while its pane label `<team>:<name>` is still set automatically (#1047), so the message claimed something about the **name** the code never observed — koit read it as "naming is broken" while the label `td-dogfood:alice` was in fact present.

Now reports the record’s absence as what it is: `no placement record (not spawned through agmsg)`.

No test asserts the old string (the column prints the record, deliberately not the label — see the block comment). The rename-tip (template.md) and README "three names" items in the same bundle wait for the `check` implementation, per tl, so they are not in this PR.

Base `integration/terminal-driver-v1`.