### PR TITLE
fix(codex): discover a ws:// app-server in the SessionStart plug

### DIFF
--- a/scripts/drivers/types/codex/_session-start.sh
+++ b/scripts/drivers/types/codex/_session-start.sh
@@ -137,6 +137,17 @@ agmsg_session_start() {
       app_server="unix://$socket_path"
     fi
   fi
+  if [ -z "$app_server" ]; then
+    # A ws:// (TCP) app-server has no socket file to find, and codex-monitor.sh
+    # passes the URL to `codex --remote`, not as a `unix://` token this script can
+    # scrape — so none of the three probes above can see it. The port file does
+    # carry the URL; reuse the helper codex-record-session.sh already uses for it.
+    if ! command -v _agmsg_codex_app_server_url >/dev/null 2>&1; then
+      # shellcheck disable=SC1091
+      . "$SKILL_DIR/scripts/drivers/types/codex/_app-server.sh"
+    fi
+    app_server="$(_agmsg_codex_app_server_url "$PROJECT")"
+  fi
   [ -n "$app_server" ] || exit 0
 
   if [ "${AGMSG_CODEX_BRIDGE_LAUNCHER:-}" = "1" ]; then


### PR DESCRIPTION
Fixes the first half of #1056.

`_session-start.sh` looks for the app-server in three places — the `AGMSG_CODEX_BRIDGE_APP_SERVER` variable, a `unix://` token in the agent cmdline, and a `.sock` file — and then gives up:

```sh
[ -n "$app_server" ] || exit 0
```

A `ws://` app-server matches none of them. `codex-monitor.sh` hands the URL to `codex --remote` (so there is no `unix://` token to scrape) and records the port in `run/codex-app-server.<hash>.port` (so there is no socket file). The plug therefore exits before writing `codex-bridge-request.<hash>`, the launcher keeps using whatever that file last held, and every relaunch is pinned to a dead port with no self-recovery. #1056 has the full symptom and log evidence.

The port file does carry the URL, and `_app-server.sh:32` already exports `_agmsg_codex_app_server_url()` to build it — `codex-record-session.sh:115` calls it for the same reason. This change just adds it as the last resort in the plug.

`SKILL_DIR` and `agmsg_sha1` are both available in this context (the plug is sourced by `session-start.sh`, see the header comment), and the helper returns empty rather than failing when it cannot resolve a port, so the existing `exit 0` still handles the genuine "no app-server" case.

The second half of #1056 — the launcher trusting the request file without checking whether the endpoint is reachable — is a design judgment, so I left it out of this PR and described it in the issue instead.

**Tests**: `bats` was not installed locally, so I ran it via `npx bats`. `tests/test_delivery.bats`, `tests/test_resume_seat_guard.bats`, `tests/test_close_fds.bats` → 200 passed, 0 failed. `tests/test_codex_*.bats` (bridge, bridge_launcher, monitor, resume, shim) → 142 passed, 0 failed. I did not run the whole suite locally.
