### PR TITLE
fix(terminals): ask the terminal whether the pane closed, and only then delete the record (#1051)

### DIFF
--- a/scripts/despawn.sh
+++ b/scripts/despawn.sh
@@ -184,6 +184,18 @@ _pane_state="$(recorded_pane_state)"
 case "$_pane_state" in
   no-record|gone)
     rm -f "$SPAWN_REC" 2>/dev/null || true
+    # Asking whether the record MAY go and checking that it WENT are two
+    # different questions, and this branch used to answer only the first. A
+    # record left behind (a read-only run dir, a permission failure) outlives
+    # the pane it names, and the next `--force` reads it as a live placement and
+    # tries to tear down a pane that is already gone — the same "reported
+    # success, left the caller a wrong authority" shape this whole change is
+    # about. So assert the STATE, not `rm`'s exit code.
+    if [ -e "$SPAWN_REC" ]; then
+      echo "despawn: '$NAME' was torn down, but its placement record at $SPAWN_REC could not be removed. The record now names a pane that is gone, and --force would act on it; delete it by hand." >&2
+      echo "status=error name=$NAME team=$TEAM note=record-not-removed after=${waited}s"
+      exit 1
+    fi
     echo "status=ok name=$NAME team=$TEAM after=${waited}s"
     ;;
   present)

--- a/scripts/despawn.sh
+++ b/scripts/despawn.sh
@@ -66,6 +66,37 @@ SPAWN_REC="$(agmsg_spawn_path "$TEAM" "$NAME")"
 # possibility for tmux and herdr) means the pane may STILL be alive, and the caller
 # must keep the record rather than delete the one retry authority. Returns 0 on a
 # confirmed teardown, non-zero otherwise (no side effects here beyond the kill call).
+# What does the terminal say about the recorded pane, RIGHT NOW? Read only —
+# nothing is closed here.
+#
+# Prints one of: no-record / gone / present / unknown.
+#
+# It resolves the record the same way kill_recorded_placement does, and stops
+# short of the kill. `terminal_despawn` cannot be used for this: measured on a
+# throwaway tmux server, `kill-pane` returns non-zero both for a pane that is
+# already gone and for one it could not close, and the driver maps both to 13.
+# Asking with it would make a graceful teardown that WORKED report needs-force.
+recorded_pane_state() {
+  [ -f "$SPAWN_REC" ] || { printf 'no-record'; return 0; }
+  local id _proj _type _term _bare _out _rc=0
+  IFS=$'\t' read -r id _proj _type < "$SPAWN_REC"
+  [ -n "$id" ] || { printf 'unknown'; return 0; }
+  _term="$(agmsg_terminal_ref_terminal "$id")" || { printf 'unknown'; return 0; }
+  _bare="$(agmsg_terminal_ref_id "$id")"       || { printf 'unknown'; return 0; }
+  agmsg_terminal_load "$_term" 2>/dev/null     || { printf 'unknown'; return 0; }
+  declare -F terminal_pane_state >/dev/null 2>&1 || { printf 'unknown'; return 0; }
+  _out="$(terminal_pane_state "$_bare" 2>/dev/null)" || _rc=$?
+  # The token is the answer and the code says whether it is a settled one. A
+  # non-zero (13 unsupported, 10 unreachable) is NOT an answer about the pane,
+  # whatever was printed.
+  [ "$_rc" -eq 0 ] || { printf 'unknown'; return 0; }
+  case "$_out" in
+    gone|present) printf '%s' "$_out" ;;
+    *)            printf 'unknown' ;;
+  esac
+  return 0
+}
+
 kill_recorded_placement() {
   [ -f "$SPAWN_REC" ] || return 1
   local id _proj _type _term _bare
@@ -140,5 +171,31 @@ while true; do
   waited=$((waited + 1))
 done
 
-rm -f "$SPAWN_REC" 2>/dev/null || true
-echo "status=ok name=$NAME team=$TEAM after=${waited}s"
+# The lock going free means the watcher let go of it. It does NOT mean the pane
+# was closed: the watcher releases the lock (via reset.sh) BEFORE it tries to
+# close anything, and a lock whose owner has died reads as free too. Deleting the
+# record on that signal is what made #1051 unrecoverable — the record is the only
+# thing `--force` can work from, and it was gone before anyone knew the pane was
+# still open.
+#
+# So ask the terminal. The record is deleted, and success reported, only when the
+# answer is a settled `gone`.
+_pane_state="$(recorded_pane_state)"
+case "$_pane_state" in
+  no-record|gone)
+    rm -f "$SPAWN_REC" 2>/dev/null || true
+    echo "status=ok name=$NAME team=$TEAM after=${waited}s"
+    ;;
+  present)
+    echo "despawn: '$NAME' released its lock but the recorded pane is STILL OPEN — the teardown did not fold the window. The placement record is kept; retry with --force to tear it down through it." >&2
+    echo "status=needs-force name=$NAME team=$TEAM note=pane-still-open after=${waited}s"
+    exit 1
+    ;;
+  *)
+    # Deliberately a different sentence from `present`: the operator's next move
+    # differs. "Still open" says close it; "could not check" says look.
+    echo "despawn: '$NAME' released its lock, but this terminal could not be asked whether the pane closed, so the teardown is unconfirmed. The placement record is kept; check the window, and use --force if it is still there." >&2
+    echo "status=needs-force name=$NAME team=$TEAM note=teardown-unverified after=${waited}s"
+    exit 1
+    ;;
+esac

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -439,23 +439,64 @@ terminal_pane_state() {
   [ "$vrc" -eq 0 ] || { echo unknown; return 10; }
   [ "$valid" = 1 ] || { echo unknown; return 10; }
 
-  local iesc q jtype jtrc hit hrc
+  # `gone` is the ONLY answer that deletes a placement record, so it has to be
+  # earned the same way `_herdr_pane_for_session` earns "not among": the claim is
+  # about the WHOLE set, so it is honest only when EVERY entry's membership is
+  # DECIDABLE. An array whose entries were never inspected proves nothing — a
+  # target hiding in an entry this driver cannot read is exactly the case that
+  # must not come back as `gone`.
+  #
+  # DECIDABLE here, for a pane_id question (narrower than the session question,
+  # which also has to recognize a session-less pane by structure): the entry is an
+  # object, carries a pane_id in the MEASURED grammar, and carries the fixed
+  # identity anchor that positively marks it a real herdr pane. Both known kinds —
+  # a session entry and a bare pane — satisfy this, because both carry a pane_id;
+  # anything else (a non-object entry, a missing/ungrammatical pane_id, an
+  # unanchored shape) is drift, and drift is `unknown`, never `gone`.
+  #
+  # `hit` is deliberately LOOSER than `det`: an exact pane_id match is evidence the
+  # pane exists whatever else the entry looks like, and `present` keeps the record.
+  # The asymmetry is the point — the cheap answer is permissive, the destructive
+  # one is not.
+  local iesc q jtype jtrc out orc alen det hit
   iesc="$(printf '%s' "$id" | sed "s/'/''/g")"
   for q in '$.result.agents' '$' '$.agents' '$.result'; do
     jtrc=0
     jtype="$(sqlite3 :memory: "SELECT json_type('$jesc', '$q')" 2>/dev/null)" || jtrc=$?
     [ "$jtrc" -eq 0 ] || { echo unknown; return 10; }
     [ "$jtype" = array ] || continue
-    hrc=0
-    hit="$(sqlite3 :memory: "
-      SELECT EXISTS(
-        SELECT 1 FROM json_each('$jesc', '$q')
-         WHERE json_extract(value, '\$.pane_id') = '$iesc'
-      );" 2>/dev/null)" || hrc=$?
-    [ "$hrc" -eq 0 ] || { echo unknown; return 10; }
-    if [ "$hit" = 1 ]; then echo present; return 0; fi
-    echo gone
-    return 0
+    orc=0
+    out="$(sqlite3 :memory: "
+      WITH entries(value) AS (SELECT value FROM json_each('$jesc', '$q')),
+           -- ALIASED (e) so the correlated json_each in the anchor test binds
+           -- e.value per row; a bare json_each(value) does not correlate.
+           tagged(pane_ok, anchor_ok, pid) AS (
+             SELECT
+               CASE WHEN json_type(e.value,'\$.pane_id') = 'text'
+                 AND json_extract(e.value,'\$.pane_id') GLOB 'w[0-9A-Za-z]*:p[0-9A-Za-z]*'
+                 AND NOT (json_extract(e.value,'\$.pane_id') GLOB '*:*:*')
+                 AND NOT (json_extract(e.value,'\$.pane_id') GLOB '*[^0-9A-Za-z:]*')
+               THEN 1 ELSE 0 END,
+               CASE WHEN json_type(e.value,'\$.agent') IS NOT NULL
+                 AND json_type(e.value,'\$.terminal_id') IS NOT NULL
+                 AND json_type(e.value,'\$.tab_id') IS NOT NULL
+                 AND json_type(e.value,'\$.workspace_id') IS NOT NULL
+               THEN 1 ELSE 0 END,
+               json_extract(e.value,'\$.pane_id')
+             FROM entries e WHERE json_type(e.value) = 'object'),
+           det(x) AS (SELECT 1 FROM tagged WHERE pane_ok = 1 AND anchor_ok = 1),
+           hit(x) AS (SELECT 1 FROM tagged WHERE pid = '$iesc' LIMIT 1)
+      SELECT (SELECT count(*) FROM entries),
+             (SELECT count(*) FROM det),
+             (SELECT count(*) FROM hit)" 2>/dev/null)" || orc=$?
+    [ "$orc" -eq 0 ] || { echo unknown; return 10; }
+    IFS='|' read -r alen det hit <<< "$out"
+    if [ "${hit:-0}" -gt 0 ]; then echo present; return 0; fi
+    # No match. Not-present is honest only if every entry was decidable.
+    # Empty array: det == alen == 0 -> gone, which is correct (no panes at all).
+    if [ "${det:-0}" -eq "${alen:-0}" ]; then echo gone; return 0; fi
+    echo unknown
+    return 10
   done
   # No array at any candidate path: the list was readable JSON but not a shape
   # this driver knows, which is "could not answer", not "not in it".

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -407,6 +407,62 @@ terminal_spawn() {
 }
 
 # control op: close the herdr pane named by the bare id.
+# Is the recorded pane still there? READ ONLY — `agent list` and nothing else.
+#
+# Same reason as the tmux driver's: `terminal_despawn` collapses "already closed"
+# and "could not close" into 13, so it cannot tell a caller whether a graceful
+# teardown worked.
+#
+#   present / 0    the id appears in the list
+#   gone    / 0    the list answered, validly, and the id is not in it
+#   unknown / 10   herdr could not be reached, or answered something unreadable
+#
+# `gone` is a claim about the WHOLE list, so it is only made after the list has
+# been PROVEN readable — exit-0 bytes are not proof. Anything short of that is
+# `unknown`, because the caller deletes the placement record on `gone` alone.
+#
+# The read-and-validate preamble is deliberately the same shape as
+# `_herdr_pane_for_session` above and is NOT yet factored out of it: that
+# function is under review for a release block. Two copies of a preamble is a
+# thing to fix, not to leave unnamed — noted here so the next reader knows it is
+# known rather than accidental.
+terminal_pane_state() {
+  local id="$1" json rc=0
+  command -v herdr >/dev/null 2>&1 || { echo unknown; return 10; }
+  json="$(herdr agent list 2>/dev/null)" || rc=$?
+  [ "$rc" -eq 0 ] || { echo unknown; return 10; }
+  [ -n "$json" ] || { echo unknown; return 10; }
+
+  local jesc valid vrc=0
+  jesc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  valid="$(sqlite3 :memory: "SELECT json_valid('$jesc')" 2>/dev/null)" || vrc=$?
+  [ "$vrc" -eq 0 ] || { echo unknown; return 10; }
+  [ "$valid" = 1 ] || { echo unknown; return 10; }
+
+  local iesc q jtype jtrc hit hrc
+  iesc="$(printf '%s' "$id" | sed "s/'/''/g")"
+  for q in '$.result.agents' '$' '$.agents' '$.result'; do
+    jtrc=0
+    jtype="$(sqlite3 :memory: "SELECT json_type('$jesc', '$q')" 2>/dev/null)" || jtrc=$?
+    [ "$jtrc" -eq 0 ] || { echo unknown; return 10; }
+    [ "$jtype" = array ] || continue
+    hrc=0
+    hit="$(sqlite3 :memory: "
+      SELECT EXISTS(
+        SELECT 1 FROM json_each('$jesc', '$q')
+         WHERE json_extract(value, '\$.pane_id') = '$iesc'
+      );" 2>/dev/null)" || hrc=$?
+    [ "$hrc" -eq 0 ] || { echo unknown; return 10; }
+    if [ "$hit" = 1 ]; then echo present; return 0; fi
+    echo gone
+    return 0
+  done
+  # No array at any candidate path: the list was readable JSON but not a shape
+  # this driver knows, which is "could not answer", not "not in it".
+  echo unknown
+  return 10
+}
+
 terminal_despawn() {
   local id="$1"
   herdr pane close "$id" >/dev/null 2>&1 || { echo runtime_error; return 13; }

--- a/scripts/drivers/terminals/plain/ops.sh
+++ b/scripts/drivers/terminals/plain/ops.sh
@@ -111,6 +111,11 @@ terminal_spawn() {
 # is '-'), so there is nothing to kill from here — it closes when its process
 # exits, exactly as before the axis (OS-terminal members were never force-
 # killable). Report ok (nothing to tear down) rather than a spurious error.
+# plain has no addressable pane, so it cannot be asked whether one is still
+# there. 13 is that answer, and it is a real answer rather than a failure — the
+# caller must not read it as "closed".
+terminal_pane_state() { echo unknown; return 13; }
+
 terminal_despawn() { echo ok; return 0; }
 
 _plain_unsupported() {

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -95,11 +95,40 @@ terminal_arrange() {
 terminal_detect() {
   [ -n "${TMUX:-}" ] || return 1
   if [ -n "${TMUX_PANE:-}" ]; then
-    printf '%s\n' "$TMUX_PANE"
+    # `<socket>:<pane>`, so whatever records this can later ask the RIGHT server.
+    # $TMUX is "<socket-path>,<pid>,<session>"; the first field is the socket.
+    printf '%s:%s\n' "${TMUX%%,*}" "$TMUX_PANE"
   else
     echo "tmux: \$TMUX_PANE is unset — cannot identify this pane" >&2
   fi
   return 0
+}
+
+# A tmux id may carry the SERVER it belongs to: `<socket-path>:%1`, or a bare
+# `%1` for a record written before this existed.
+#
+# It has to, because a pane id is not unique across servers — measured: two
+# throwaway servers both had `%0`, and each answered "yes, I know %0" about the
+# other's pane. Without the socket, "is this pane still there?" cannot be asked
+# of the right authority, and a wrong answer deletes the placement record (#1051).
+#
+# The socket must be SPLIT OFF before the id reaches `-t`, never passed through:
+# measured, `tmux kill-pane -t '<socket>:%0'` is read as session:window, prints
+# "can't find window: %0" and closes NOTHING. Silent no-op, not a wrong kill —
+# but a teardown that did nothing while looking like it ran is exactly this
+# issue's shape.
+#
+# Split on the LAST colon: a socket path may contain one.
+_tmux_sock_of() { case "$1" in *:*) printf '%s' "${1%:*}" ;; *) printf '' ;; esac; }
+_tmux_bare_of() { printf '%s' "${1##*:}"; }
+
+# Run tmux against the server that owns <id>. With no socket in the id this is
+# plain `tmux`, which is what a legacy record gets and what the ambient
+# environment decides — the honest behaviour for a ref that does not say.
+_tmux_do() {   # <id> <tmux args...>
+  local id="$1"; shift
+  local sock; sock="$(_tmux_sock_of "$id")"
+  if [ -n "$sock" ]; then tmux -S "$sock" "$@"; else tmux "$@"; fi
 }
 
 # Positive proof that a captured id is a tmux id of the expected KIND: a pane is
@@ -149,16 +178,83 @@ terminal_spawn() {
       ;;
     *) printf 'unsupported: unknown target: %s (window|pane-h|pane-v)\n' "$target" >&2; return 13 ;;
   esac
-  printf '%s\n' "$id"
+  # Socket-qualified, the same shape terminal_detect emits: whoever records this
+  # id must be able to ask the server that owns it, not whichever one they can
+  # reach. A spawn always happens from inside a tmux server, so $TMUX is set.
+  if [ -n "${TMUX:-}" ]; then
+    printf '%s:%s\n' "${TMUX%%,*}" "$id"
+  else
+    printf '%s\n' "$id"
+  fi
   return 0
 }
 
 # control op: kill the pane (%N) or window (@N) named by the bare id.
+# Is the recorded pane still there? READ ONLY — this never closes anything.
+#
+# It exists because `terminal_despawn` cannot answer the question. Measured on a
+# throwaway server: `kill-pane` returns 0 for a live pane and non-zero for one
+# that is already gone, and the driver maps both non-zeros to 13 — so "already
+# closed" and "could not close" arrive as the same value, and a graceful teardown
+# that succeeded would have to report needs-force.
+#
+# Prints a token and returns a code, like the other ops:
+#   present / 0    the id is in the terminal's own list
+#   gone    / 0    the list answered and the id is not in it
+#   unknown / 10   the terminal could not be reached to ask
+#   unknown / 13   the id is not one this terminal can be asked about
+#
+# "Could not ask" must never come back as 0: the caller deletes the placement
+# record — the only thing `--force` can work from — on `gone` alone.
+terminal_pane_state() {
+  local id="$1" out
+  command -v tmux >/dev/null 2>&1 \
+    || { echo unknown; return 10; }
+  # No socket in the id: a record written before refs carried one. The pane id
+  # alone cannot name an authority — two servers can both hold `%0` — so this
+  # cannot be answered, and saying `gone` here is what deletes a live member's
+  # record. An honest `unknown` sends the caller to --force instead (#1051).
+  local sock bare
+  sock="$(_tmux_sock_of "$id")"
+  bare="$(_tmux_bare_of "$id")"
+  [ -n "$sock" ] || { echo unknown; return 10; }
+
+  # The server that owned this pane is gone, so the pane is too — a pane does not
+  # outlive its server. This matters because it is the ORDINARY case: measured,
+  # killing a server's last pane ends the server, which is what folding a member
+  # that had its own window does, and without this the answer was `unknown`
+  # exactly when the teardown had worked.
+  #
+  # The discriminator is tmux SAYING SO, not the socket file: measured, the socket
+  # survives the server's exit, so its presence proves nothing. `no server running
+  # on <path>` is tmux telling us the server is not there, and only that sentence
+  # is taken as proof — every other failure stays `unknown`, because `gone` is
+  # what deletes the placement record and it must be earned.
+  local err="" out="" _rc=0
+  case "$bare" in
+    %*) out="$(_tmux_do "$id" list-panes  -a -F '#{pane_id}'   2>/tmp/.agmsg-tmux-err.$$)" || _rc=$? ;;
+    @*) out="$(_tmux_do "$id" list-windows -a -F '#{window_id}' 2>/tmp/.agmsg-tmux-err.$$)" || _rc=$? ;;
+    *)  rm -f "/tmp/.agmsg-tmux-err.$$" 2>/dev/null; echo unknown; return 13 ;;
+  esac
+  err="$(cat "/tmp/.agmsg-tmux-err.$$" 2>/dev/null)"
+  rm -f "/tmp/.agmsg-tmux-err.$$" 2>/dev/null
+  if [ "$_rc" -ne 0 ]; then
+    case "$err" in
+      *"no server running"*) echo gone; return 0 ;;
+      *)                     echo unknown; return 10 ;;
+    esac
+  fi
+  if printf '%s\n' "$out" | grep -qx -- "$bare"; then echo present; return 0; fi
+  echo gone
+  return 0
+}
+
 terminal_despawn() {
   local id="$1"
-  case "$id" in
-    %*) tmux kill-pane   -t "$id" >/dev/null 2>&1 || { echo runtime_error; return 13; } ;;
-    @*) tmux kill-window -t "$id" >/dev/null 2>&1 || { echo runtime_error; return 13; } ;;
+  # The KIND is in the bare id; a socket-qualified id starts with the socket path.
+  case "$(_tmux_bare_of "$id")" in
+    %*) _tmux_do "$id" kill-pane   -t "$(_tmux_bare_of "$id")" >/dev/null 2>&1 || { echo runtime_error; return 13; } ;;
+    @*) _tmux_do "$id" kill-window -t "$(_tmux_bare_of "$id")" >/dev/null 2>&1 || { echo runtime_error; return 13; } ;;
     *)  printf 'unsupported: not a tmux pane/window id: %s\n' "$id" >&2; return 13 ;;
   esac
   echo ok
@@ -187,10 +283,10 @@ terminal_peek() {
   command -v tmux >/dev/null 2>&1 \
     || { echo "tmux: not on PATH — cannot reach the terminal to peek pane '$id'" >&2; return 10; }
   if [ -n "$lines" ]; then
-    tmux capture-pane -p -t "$id" -S "-$lines" \
+    _tmux_do "$id" capture-pane -p -t "$(_tmux_bare_of "$id")" -S "-$lines" \
       || { echo "tmux: could not capture pane '$id' (it may no longer exist)" >&2; return 12; }
   else
-    tmux capture-pane -p -t "$id" \
+    _tmux_do "$id" capture-pane -p -t "$(_tmux_bare_of "$id")" \
       || { echo "tmux: could not capture pane '$id' (it may no longer exist)" >&2; return 12; }
   fi
   return 0
@@ -252,10 +348,10 @@ terminal_poke() {
   # poke path at all (plain) — a tmux pane's transient loss must not borrow it.
   command -v tmux >/dev/null 2>&1 \
     || { echo runtime_error; echo "tmux: not on PATH — cannot reach the terminal to poke pane '$id'" >&2; return 10; }
-  tmux send-keys -l -t "$id" -- "$text" \
+  _tmux_do "$id" send-keys -l -t "$(_tmux_bare_of "$id")" -- "$text" \
     || { echo runtime_error; echo "tmux: could not send to pane '$id' (it may no longer exist)" >&2; return 12; }
   sleep 0.3 2>/dev/null || true
-  tmux send-keys -t "$id" Right Enter \
+  _tmux_do "$id" send-keys -t "$(_tmux_bare_of "$id")" Right Enter \
     || { echo runtime_error; echo "tmux: could not send Enter to pane '$id' (it may no longer exist)" >&2; return 12; }
   echo ok
   return 0
@@ -273,11 +369,11 @@ terminal_poke() {
 terminal_name() {
   local id="$1" team="$2" name="$3" mode="${4:-}" label
   label="$team:$name"
-  tmux set-option -p -t "$id" @agmsg_agent "$label" >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  _tmux_do "$id" set-option -p -t "$(_tmux_bare_of "$id")" @agmsg_agent "$label" >/dev/null 2>&1 || { echo runtime_error; return 13; }
   if [ "$mode" = key ]; then echo ok; return 0; fi
-  case "$id" in
-    @*) tmux rename-window -t "$id" "$label" >/dev/null 2>&1 || true ;;
-    *)  tmux select-pane  -t "$id" -T "$label" >/dev/null 2>&1 || true ;;
+  case "$(_tmux_bare_of "$id")" in
+    @*) _tmux_do "$id" rename-window -t "$(_tmux_bare_of "$id")" "$label" >/dev/null 2>&1 || true ;;
+    *)  _tmux_do "$id" select-pane  -t "$(_tmux_bare_of "$id")" -T "$label" >/dev/null 2>&1 || true ;;
   esac
   echo ok
   return 0

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -25,19 +25,28 @@ terminal_describe() {
 # READ op: print the window containing <id>. This answers WHERE only and never
 # treats an unresolved location as proof that the pane is gone.
 terminal_where() {
-  local id="$1" out container
+  local id="$1" out container sock bare
   command -v tmux >/dev/null 2>&1 || { echo unknown; return 10; }
+  # Split the server off first: a ref now carries the socket that owns the pane,
+  # and both the kind test below and the listing have to see the bare id or a
+  # socket-qualified ref is read as an unknown kind (unsupported/13) while the
+  # listing goes to whichever server happens to be ambient.
+  sock="$(_tmux_sock_of "$id")"; bare="$(_tmux_bare_of "$id")"
   # A window placement (@N) is its own container.
-  case "$id" in @*) printf '%s\n' "$id"; return 0 ;; %*) : ;; *) echo unsupported; return 13 ;; esac
-  out="$(tmux list-panes -a -F '#{pane_id}|#{window_id}' 2>/dev/null)" \
+  case "$bare" in @*) printf '%s\n' "$id"; return 0 ;; %*) : ;; *) echo unsupported; return 13 ;; esac
+  out="$(_tmux_do "$id" list-panes -a -F '#{pane_id}|#{window_id}' 2>/dev/null)" \
     || { echo unknown; return 10; }
-  container="$(printf '%s\n' "$out" | awk -F '|' -v id="$id" '$1 == id { print $2; exit }')"
+  container="$(printf '%s\n' "$out" | awk -F '|' -v id="$bare" '$1 == id { print $2; exit }')"
   if [ -z "$container" ]; then
     echo unknown
     echo "tmux: the pane listing answered but did not contain '$id'; pane existence must be checked separately" >&2
     return 10
   fi
-  printf '%s\n' "$container"
+  # The answer is exactly as server-qualified as the question: a window id is no
+  # more unique across servers than a pane id, so a container derived from a
+  # socket-qualified ref keeps the socket, and one derived from a legacy bare id
+  # stays bare rather than gaining a precision it does not have.
+  if [ -n "$sock" ]; then printf '%s:%s\n' "$sock" "$container"; else printf '%s\n' "$container"; fi
   return 0
 }
 
@@ -61,14 +70,23 @@ _tmux_layout_numbers_ok() {
 
 terminal_arrange() {
   local source="$1" intent="$2" target="$3" out srow trow
+  local ssock sbare tsock tbare
   local sid swin st sl sw sh tid twin tt tl tw th
   command -v tmux >/dev/null 2>&1 || { echo runtime_error; return 10; }
-  case "$source:$target" in %*:%*) : ;; *) echo unsupported; return 13 ;; esac
+  ssock="$(_tmux_sock_of "$source")"; sbare="$(_tmux_bare_of "$source")"
+  tsock="$(_tmux_sock_of "$target")"; tbare="$(_tmux_bare_of "$target")"
+  case "$sbare:$tbare" in %*:%*) : ;; *) echo unsupported; return 13 ;; esac
+  # Both panes must live on the SAME server, and it must be established rather
+  # than assumed. A pane cannot be moved between servers, and one server's
+  # listing cannot decide another's layout. Mixed precision is refused for the
+  # same reason: a bare id names no server, so "same server" is not a fact — and
+  # unlike a read, this op MUTATES, so the unestablished case must not proceed.
+  [ "$ssock" = "$tsock" ] || { echo unsupported; return 13 ;}
   case "$intent" in place_below|place_right) : ;; *) echo unsupported; return 13 ;; esac
-  out="$(tmux list-panes -a -F '#{pane_id}|#{window_id}|#{pane_top}|#{pane_left}|#{pane_width}|#{pane_height}' 2>/dev/null)" \
+  out="$(_tmux_do "$source" list-panes -a -F '#{pane_id}|#{window_id}|#{pane_top}|#{pane_left}|#{pane_width}|#{pane_height}' 2>/dev/null)" \
     || { echo runtime_error; return 10; }
-  srow="$(printf '%s\n' "$out" | awk -F '|' -v id="$source" '$1 == id { print; exit }')"
-  trow="$(printf '%s\n' "$out" | awk -F '|' -v id="$target" '$1 == id { print; exit }')"
+  srow="$(printf '%s\n' "$out" | awk -F '|' -v id="$sbare" '$1 == id { print; exit }')"
+  trow="$(printf '%s\n' "$out" | awk -F '|' -v id="$tbare" '$1 == id { print; exit }')"
   [ -n "$srow" ] && [ -n "$trow" ] || { echo unknown; return 10; }
   IFS='|' read -r sid swin st sl sw sh <<< "$srow"
   IFS='|' read -r tid twin tt tl tw th <<< "$trow"
@@ -77,8 +95,8 @@ terminal_arrange() {
   [ "$swin" = "$twin" ] && _tmux_arranged "$intent" "$st" "$sl" "$sw" "$sh" "$tt" "$tl" "$tw" "$th" \
     && { echo unchanged; return 0; }
   case "$intent" in
-    place_below) tmux move-pane -s "$source" -t "$target" -v >/dev/null 2>&1 ;;
-    place_right) tmux move-pane -s "$source" -t "$target" -h >/dev/null 2>&1 ;;
+    place_below) _tmux_do "$source" move-pane -s "$sbare" -t "$tbare" -v >/dev/null 2>&1 ;;
+    place_right) _tmux_do "$source" move-pane -s "$sbare" -t "$tbare" -h >/dev/null 2>&1 ;;
   esac || { echo runtime_error; return 12; }
   echo moved
   return 0
@@ -295,11 +313,17 @@ terminal_peek() {
 # tmux has no pane-label field independent of the CLI-owned terminal title.
 # The resolvable key is the pane-local @agmsg_agent user option.
 terminal_team_observe() {
-  local id="$1" key title
+  local id="$1" key title bare
   command -v tmux >/dev/null 2>&1 || return 10
-  case "$id" in @*|%*) : ;; *) return 13 ;; esac
-  key="$(tmux show-options -p -v -t "$id" @agmsg_agent 2>/dev/null)" || key=""
-  title="$(tmux display-message -p -t "$id" '#{pane_title}' 2>/dev/null)" || return 10
+  # Two separate things, and doing only one of them is worse than doing neither:
+  # STRIP the socket so the kind test and `-t` see a bare id, and USE that socket
+  # so the query goes to the server that owns the pane. A ref stripped but not
+  # routed lands on whatever server is ambient, where the same pane id is a
+  # DIFFERENT pane — which is where #1051 started.
+  bare="$(_tmux_bare_of "$id")"
+  case "$bare" in @*|%*) : ;; *) return 13 ;; esac
+  key="$(_tmux_do "$id" show-options -p -v -t "$bare" @agmsg_agent 2>/dev/null)" || key=""
+  title="$(_tmux_do "$id" display-message -p -t "$bare" '#{pane_title}' 2>/dev/null)" || return 10
   [ -n "$key" ] || key=unknown:agent_key_missing
   [ -n "$title" ] || title=unknown:terminal_title_missing
   case "$key$title" in *$'\t'*|*$'\n'*|*$'\r'*) return 10 ;; esac
@@ -311,10 +335,15 @@ terminal_team_observe() {
 # process-group leader from the pane tty and compare its argv with the expected
 # CLI executable.
 terminal_team_input_ready() {
-  local id="$1" expected="$2" facts in_mode pane_pid pane_tty tpgid command first
+  local id="$1" expected="$2" facts in_mode pane_pid pane_tty tpgid command first bare
   command -v tmux >/dev/null 2>&1 || { printf 'unknown:terminal_unreachable\n'; return 2; }
-  case "$id" in @*|%*) : ;; *) printf 'unknown:invalid_pane_id\n'; return 2 ;; esac
-  facts="$(tmux display-message -p -t "$id" '#{pane_in_mode}|#{pane_pid}|#{pane_tty}' 2>/dev/null)" \
+  # Strip the socket for the kind test and `-t`, and route the query to the
+  # server the ref names — see terminal_team_observe. Here the stakes are the
+  # pane's pid and tty: reading them off another server's same-numbered pane
+  # would produce a confident readiness answer about the wrong process.
+  bare="$(_tmux_bare_of "$id")"
+  case "$bare" in @*|%*) : ;; *) printf 'unknown:invalid_pane_id\n'; return 2 ;; esac
+  facts="$(_tmux_do "$id" display-message -p -t "$bare" '#{pane_in_mode}|#{pane_pid}|#{pane_tty}' 2>/dev/null)" \
     || { printf 'unknown:pane_query_failed\n'; return 2; }
   IFS='|' read -r in_mode pane_pid pane_tty <<EOF
 $facts

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -372,8 +372,13 @@ _agmsg_terminal_id_ok() {   # <terminal> <id>
       case "$id" in
         *:*) _sock="${id%:*}"; id="${id##*:}"
              [ -n "$_sock" ] || return 1
-             # No whitespace or control bytes in the path we would hand to `-S`.
-             case "$_sock" in *[[:space:]]*) return 1 ;; esac ;;
+             # What breaks a record is a TAB or a newline — it is one TAB-separated
+             # line — not an ordinary space, and socket paths under a home
+             # directory containing a space are perfectly normal. So reject the
+             # CONTROL bytes (TAB 0x09, LF, CR and the rest) and let 0x20 through:
+             # [[:cntrl:]] is exactly that split, where [[:space:]] also swallows
+             # the space and would refuse a legitimate path.
+             case "$_sock" in *[[:cntrl:]]*) return 1 ;; esac ;;
       esac
       case "$id" in %*|@*) : ;; *) return 1 ;; esac
       rest="${id#?}"

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -27,6 +27,16 @@
 #   terminal_peek <id> [--lines N]      RECORD op: print visible pane text verbatim (NOT
 #                                       parsed). unsupported -> exit 13, reason on stderr.
 #   terminal_poke <id> <text>           control op: send text and submit. unsupported -> 13.
+#   terminal_pane_state <id>            READ ONLY: is that pane still there?
+#                                       Prints gone / present / unknown and
+#                                       returns 0 for a settled answer, 13 when
+#                                       this terminal has no addressable pane to
+#                                       ask about, 10 when it could not be
+#                                       reached. "Could not ask" never returns 0:
+#                                       a caller deletes the placement record on
+#                                       `gone` alone, and `terminal_despawn`
+#                                       cannot answer this (it collapses "already
+#                                       closed" and "could not close" into 13).
 #   terminal_where <id>                 READ op: print the id's container (tmux window /
 #                                       herdr tab). Existence is not answered here;
 #                                       a missing id is unknown/10, never `gone`.
@@ -124,7 +134,7 @@ agmsg_terminal_has() {
 # verifies it. Naming the set here (not relying on each driver being complete) is
 # what makes a missing op FAIL rather than silently borrow the previously loaded
 # driver's same-named function.
-_AGMSG_TERMINAL_REQUIRED="terminal_check terminal_describe terminal_detect terminal_spawn terminal_despawn terminal_peek terminal_poke terminal_where terminal_arrange terminal_name"
+_AGMSG_TERMINAL_REQUIRED="terminal_check terminal_describe terminal_detect terminal_spawn terminal_despawn terminal_pane_state terminal_peek terminal_poke terminal_where terminal_arrange terminal_name"
 _AGMSG_TERMINAL_OPTIONAL="terminal_team_observe terminal_team_input_ready"
 
 # Wipe every terminal_* ABI function from the current shell. Called before each
@@ -350,6 +360,21 @@ _agmsg_terminal_id_ok() {   # <terminal> <id>
   local id="$2" rest
   case "$1" in
     tmux)
+      # Two accepted forms, and the older one is accepted on purpose:
+      #   <socket-path>:%N / <socket-path>:@N   written since refs carry the server
+      #   %N / @N                               a record written before they did
+      # A pane id is not unique across tmux servers (measured: two servers both
+      # holding %0), so the socket is what makes a ref answerable. The legacy form
+      # still resolves — it just cannot be asked "is it still there?" (#1051).
+      #
+      # Split on the LAST colon: a socket path may contain one.
+      local _sock=""
+      case "$id" in
+        *:*) _sock="${id%:*}"; id="${id##*:}"
+             [ -n "$_sock" ] || return 1
+             # No whitespace or control bytes in the path we would hand to `-S`.
+             case "$_sock" in *[[:space:]]*) return 1 ;; esac ;;
+      esac
       case "$id" in %*|@*) : ;; *) return 1 ;; esac
       rest="${id#?}"
       case "$rest" in ''|*[!0-9]*) return 1 ;; esac

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -161,9 +161,26 @@ esac
 # Pairs already reported as storeless, so the notice is once per process.
 NO_STORE_REPORTED=""
 
+# Two front doors onto one log.
+#
+# `watch_log` announces on stderr, which is right for a diagnostic nobody has to
+# act on. `watch_report` announces on STDOUT, for the ones an operator must see:
+# the shipped launcher runs the watcher with fd2 on /dev/null (#691, measured
+# while fixing #1045), so a teardown that failed and said so on stderr said so
+# nowhere. Same log file either way — the difference is only which channel the
+# person watching gets it on.
+watch_report() {
+  printf 'agmsg watch: %s\n' "$*"
+  _watch_log_file "$*"
+}
+
 watch_log() {
+  printf 'agmsg watch: %s\n' "$*" >&2
+  _watch_log_file "$*"
+}
+
+_watch_log_file() {
   local msg="$*" record size=0 bytes
-  printf 'agmsg watch: %s\n' "$msg" >&2
   mkdir -p "$RUN_DIR" 2>/dev/null || return 0
   # Built first, so the rotation decision can weigh what is actually going to
   # be appended rather than only what is already there.
@@ -225,6 +242,23 @@ watch_log() {
 # Silence is never the answer here: a pane that should have closed and did not
 # is exactly the state an operator cannot see. Every path that declines says
 # why, on stderr and in the watcher log.
+# Fold this session's own pane, and SAY WHICH of three things happened:
+#
+#   0  closed            the driver confirmed the pane is folded
+#   1  could-not-close   a pane was placed for this seat and this call did not
+#                        fold it — it may still be open
+#   2  nothing-to-close  nothing of ours was ever placed here (no record, or the
+#                        record names another session's pane)
+#
+# The channel follows the same split, and that is the rule rather than a habit:
+# 1 goes to STDOUT (`watch_report`) because an operator has a window to deal
+# with and the shipped launcher discards stderr (#691); 2 goes to stderr, because
+# there is nothing for anyone to do.
+#
+# Every branch used to `return 0`, including the one where the driver refused —
+# so the caller could not tell a folded pane from an open one, and reported
+# success either way (#1051). The failures also announced themselves only on
+# stderr, which the shipped launcher discards (#691), so they reached nobody.
 close_own_placement() {
   local team="$1" name="$2"
   local rec ref rec_term rec_id mine my_term my_id
@@ -236,17 +270,17 @@ close_own_placement() {
     # nothing here to close. Say so rather than exiting quietly, because the
     # same silence would also cover "the record was lost".
     watch_log "despawned '$name' (role dropped); no placement record for '$team/$name', so there is no pane to close from here — if a window remains it was not placed by agmsg; close it directly"
-    return 0
+    return 2
   fi
   IFS=$'\t' read -r ref _ _ < "$rec"
   if [ -z "$ref" ]; then
-    watch_log "despawned '$name' (role dropped); the placement record at $rec is empty, so the pane cannot be identified — close this window manually"
-    return 0
+    watch_report "despawned '$name' (role dropped); the placement record at $rec is empty, so the pane cannot be identified — close this window manually"
+    return 1
   fi
 
   if ! declare -F agmsg_terminal_ref_terminal >/dev/null 2>&1; then
-    watch_log "despawned '$name' (role dropped); the terminal registry is not available in this install, so the recorded pane cannot be closed — close this window manually"
-    return 0
+    watch_report "despawned '$name' (role dropped); the terminal registry is not available in this install, so the recorded pane cannot be closed — close this window manually"
+    return 1
   fi
 
   # The ref parser fails CLOSED (non-zero) on a corrupt/unknown-scheme ref. A bare
@@ -258,8 +292,8 @@ close_own_placement() {
   rec_term="$(agmsg_terminal_ref_terminal "$ref")" || rec_term=""
   rec_id="$(agmsg_terminal_ref_id "$ref")" || rec_id=""
   if [ -z "$rec_term" ] || [ -z "$rec_id" ]; then
-    watch_log "despawned '$name' (role dropped); the placement record's pane ref ($ref) did not resolve to a terminal and pane id, so the pane cannot be identified — close this window manually"
-    return 0
+    watch_report "despawned '$name' (role dropped); the placement record's pane ref ($ref) did not resolve to a terminal and pane id, so the pane cannot be identified — close this window manually"
+    return 1
   fi
 
   # Which pane is THIS process in, right now. resolve-for-name is the strict
@@ -285,26 +319,44 @@ close_own_placement() {
     mine="$(agmsg_terminal_resolve_name "$bare_sid" 2>/dev/null || true)"
   fi
   if [ -z "$mine" ]; then
-    watch_log "despawned '$name' (role dropped); this session cannot identify its own pane, so the recorded placement ($ref) is not provably ours and was left alone — close this window manually"
-    return 0
+    watch_report "despawned '$name' (role dropped); this session cannot identify its own pane, so the recorded placement ($ref) is not provably ours and was left alone — close this window manually"
+    return 1
   fi
   my_term="${mine%%	*}"
   my_id="${mine#*	}"
 
-  if [ "$my_term" != "$rec_term" ] || [ "$my_id" != "$rec_id" ]; then
+  # Compare at the precision BOTH sides have. A record written before refs
+  # carried the tmux socket says `%9`; this session now resolves itself as
+  # `<socket>:%9`, and a literal comparison calls its own pane someone else's —
+  # measured: the member stopped being able to fold itself. So when either side
+  # is missing the socket, compare the bare ids.
+  #
+  # That is the legacy ambiguity, not a new one: a bare `%9` cannot name a server
+  # (two servers can both hold it), and this is the same assumption the record
+  # has always carried. New records carry the socket and compare at full
+  # precision.
+  local _my_cmp="$my_id" _rec_cmp="$rec_id"
+  case "$my_id:$rec_id" in
+    *:*)
+      if [ "${my_id#*:}" = "$my_id" ] || [ "${rec_id#*:}" = "$rec_id" ]; then
+        _my_cmp="${my_id##*:}"; _rec_cmp="${rec_id##*:}"
+      fi ;;
+  esac
+  if [ "$my_term" != "$rec_term" ] || [ "$_my_cmp" != "$_rec_cmp" ]; then
     watch_log "despawned '$name' (role dropped); the placement record names $rec_term:$rec_id but this session is in $my_term:$my_id, so that pane belongs to someone else and was left alone — close this window manually"
-    return 0
+    return 2
   fi
 
   if ! agmsg_terminal_load "$rec_term" 2>/dev/null; then
-    watch_log "despawned '$name' (role dropped); the '$rec_term' terminal driver would not load, so the pane could not be closed — close this window manually"
-    return 0
+    watch_report "despawned '$name' (role dropped); the '$rec_term' terminal driver would not load, so the pane could not be closed — close this window manually"
+    return 1
   fi
   if ! terminal_despawn "$rec_id" >/dev/null 2>&1; then
     # 13 is the drivers' "unsupported" — plain has no addressable pane, so there
     # is genuinely nothing to close and the member must be told, not left with a
     # window it thinks was folded.
-    watch_log "despawned '$name' (role dropped); the '$rec_term' terminal did not close pane $rec_id — close this window manually"
+    watch_report "despawned '$name' (role dropped); the '$rec_term' terminal did not close pane $rec_id — close this window manually"
+    return 1
   fi
   return 0
 }
@@ -749,6 +801,11 @@ STUCK_THRESHOLD=3
 # delivery broke" can be told from "never started"; the value matters only that
 # it is non-zero and stable, which the tests pin.
 _AGMSG_EXIT_DELIVERY_UNHEALTHY=75
+# The watcher was told to fold itself, released its role, and the pane is STILL
+# THERE. Distinct from 75 (delivery is unhealthy) because the operator's next
+# move is different: the placement record is deliberately left in place and
+# `despawn --force` works from it.
+_AGMSG_EXIT_TEARDOWN_INCOMPLETE=76
 # Per-pair tracker state and its map operations (_stuck_get/_stuck_set/
 # _stuck_drop). Kept in a sourced lib so the record framing -- which broke for
 # names with spaces once and must not again -- can be unit-tested away from this
@@ -1017,7 +1074,14 @@ while true; do
     fi
     if [ -n "$DESPAWN_TARGET" ]; then
       "$SCRIPT_DIR/reset.sh" "$PROJECT_PATH" "$AGENT_TYPE" "$DESPAWN_TARGET" "$SESSION_ID" >/dev/null 2>&1 || true
-      close_own_placement "$pair_team" "$DESPAWN_TARGET"
+      # The status is used, not discarded: 1 means a pane of ours is still open.
+      # Nothing here deletes the placement record — that is what `--force` works
+      # from, and the caller now reads its presence rather than assuming.
+      _close_rc=0
+      close_own_placement "$pair_team" "$DESPAWN_TARGET" || _close_rc=$?
+      if [ "$_close_rc" -eq 1 ]; then
+        exit "$_AGMSG_EXIT_TEARDOWN_INCOMPLETE"
+      fi
       exit 0
     fi
     fi

--- a/tests/test_despawn.bats
+++ b/tests/test_despawn.bats
@@ -325,7 +325,12 @@ _despawn_member_with_env() {   # <bindir> <env assignments...>
   # this it asks whatever tmux happens to be on the machine — which answered
   # `gone` about a pane id it had never heard of, and the record was deleted on
   # that. Measured here before it was noticed anywhere else.
-  PATH="$bindir:$PATH" bash "$SCRIPTS/despawn.sh" team leader alice --timeout 10 >/dev/null 2>&1 || true
+  # DESPAWN_BIN (optional) is prepended for the CALLER only, never for the
+  # watcher: a stub that has to break one of despawn's own syscalls must not also
+  # break the watcher's unrelated cleanup, or the test measures two things.
+  DESPAWN_RC=0
+  PATH="${DESPAWN_BIN:+$DESPAWN_BIN:}$bindir:$PATH" bash "$SCRIPTS/despawn.sh" \
+    team leader alice --timeout 10 >"$RUN/despawn.out" 2>"$RUN/despawn.err" || DESPAWN_RC=$?
   for i in 1 2 3 4 5 6 7 8 9 10; do kill -0 "$WPID" 2>/dev/null || break; sleep 0.5; done
   kill "$WPID" 2>/dev/null || true; wait "$WPID" 2>/dev/null || true
 }
@@ -452,6 +457,39 @@ EOF
 # that confirmed nothing), and the test above is the one that covers the new
 # code. Saying so because a name that implies the other branch is how a test gets
 # counted as coverage it does not provide.
+@test "despawn: a settled 'gone' that could not delete the record is NOT ok (#1051)" {
+  # Whether the record MAY go and whether it WENT are different questions, and
+  # this branch answered only the first: `rm -f ... || true`, then status=ok. A
+  # record that outlives the pane it names is exactly what --force then acts on,
+  # so reporting success here hands the next caller a wrong authority — the same
+  # shape as the bug this whole change is about, one layer further out.
+  local bin="$BATS_TEST_TMPDIR/bin"
+  _stub_tmux "$bin"                       # list-panes prints nothing -> settled `gone`
+  local rec; rec="$(_spawn_rec_path team alice)"
+  mkdir -p "$(dirname "$rec")"
+  printf 'tmux:/tmp/fake-tmux-socket:%%9\t%s\tclaude-code\n' "$PROJ" > "$rec"
+
+  # Break the deletion itself, for the caller only. The fix asserts the STATE of
+  # the record rather than rm's exit code, so a stub that exits non-zero AND one
+  # that lies with exit 0 are both caught — this one does both at once.
+  local dbin="$BATS_TEST_TMPDIR/dbin"; mkdir -p "$dbin"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$dbin/rm"      # succeeds, removes nothing
+  chmod +x "$dbin/rm"
+
+  DESPAWN_BIN="$dbin" _despawn_member_with_env "$bin" \
+    TMUX=/tmp/fake-tmux-socket,0,0 TMUX_PANE=%9
+
+  # Positive control: the terminal really was asked, so `gone` is the settled
+  # answer and this test is exercising the delete branch, not an earlier refusal.
+  grep -Fq 'list-panes' "$bin/tmux.log"
+  # The record did survive — the premise of the assertions below.
+  [ -f "$rec" ]
+
+  refute grep -q 'status=ok' "$RUN/despawn.out"
+  grep -q 'note=record-not-removed' "$RUN/despawn.out"
+  [ "$DESPAWN_RC" -ne 0 ]
+}
+
 @test "despawn: a free lock with a record still reports needs-force (#1051, pre-existing branch)" {
   local bin="$BATS_TEST_TMPDIR/bin"
   _stub_tmux_close_fails "$bin"

--- a/tests/test_despawn.bats
+++ b/tests/test_despawn.bats
@@ -314,13 +314,18 @@ _despawn_member_with_env() {   # <bindir> <env assignments...>
 
   AGMSG_WATCH_INTERVAL=1 PATH="$bindir:$PATH" env "$@" \
     bash "$SCRIPTS/watch.sh" sess-m "$PROJ" claude-code alice \
-    >/dev/null 2>"$RUN/watch.err" 3>&- &
+    >"$RUN/watch.out" 2>"$RUN/watch.err" 3>&- &
   WPID=$!
   local i
   for i in 1 2 3 4 5 6 7 8 9 10; do [ -e "$RUN/ready.team__alice" ] && break; sleep 0.5; done
   [ -e "$RUN/ready.team__alice" ]
 
-  bash "$SCRIPTS/despawn.sh" team leader alice --timeout 10 >/dev/null 2>&1 || true
+  # The stub is the terminal for the CALLER too, not only for the watcher. The
+  # caller asks the terminal whether the pane is still there (#1051), and without
+  # this it asks whatever tmux happens to be on the machine — which answered
+  # `gone` about a pane id it had never heard of, and the record was deleted on
+  # that. Measured here before it was noticed anywhere else.
+  PATH="$bindir:$PATH" bash "$SCRIPTS/despawn.sh" team leader alice --timeout 10 >/dev/null 2>&1 || true
   for i in 1 2 3 4 5 6 7 8 9 10; do kill -0 "$WPID" 2>/dev/null || break; sleep 0.5; done
   kill "$WPID" 2>/dev/null || true; wait "$WPID" 2>/dev/null || true
 }
@@ -385,4 +390,81 @@ _despawn_member_with_env() {   # <bindir> <env assignments...>
     refute grep -Fq 'kill-pane -t %9' "$bin/tmux.log"
   fi
   grep -Fq 'belongs to someone else' "$RUN/watch.err"
+}
+
+# --- #1051: a teardown that did not fold the pane does not report success -----
+#
+# The dogfood that produced #1051: graceful despawn said `status=ok`, the pane
+# stayed open with the agent running, and `--force` then refused because the
+# graceful path had already deleted the record it works from. Three things had to
+# line up, and each gets a control here.
+#
+# The one that made it unrecoverable is the caller's: it treated "the actas lock
+# went free" as proof the pane was folded. The lock goes free when the watcher
+# lets go of it — before it tries to close anything, and also when its owner
+# simply died. Proof of one event was read as proof of another.
+
+# A `tmux` stub whose pane LIST still contains the pane after a kill: the shape
+# of "the close did not take". The kill is recorded so the test can prove it was
+# attempted, and the list is what `terminal_pane_state` reads.
+_stub_tmux_close_fails() {
+  local bin="$1"; mkdir -p "$bin"
+  cat > "$bin/tmux" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$bin/tmux.log"
+case "\$1" in
+  list-panes)   echo '%1' ;;   # still there, whatever we were asked to close
+  kill-pane)    exit 1 ;;
+  capture-pane) echo 'x' ;;
+esac
+exit 0
+EOF
+  chmod +x "$bin/tmux"
+}
+
+@test "despawn: graceful does not report ok when the pane is still open (#1051)" {
+  local bin="$BATS_TEST_TMPDIR/bin"
+  _stub_tmux_close_fails "$bin"
+  local rec; rec="$(_spawn_rec_path team alice)"
+  mkdir -p "$(dirname "$rec")"
+  printf 'tmux:%%1\t%s\tclaude-code\n' "$PROJ" > "$rec"
+
+  _despawn_member_with_env "$bin" TMUX=/tmp/fake-tmux-socket,0,0 TMUX_PANE=%1
+
+  # Positive control: the teardown really did try to close it. Without this the
+  # assertions below also pass for a run that never got that far.
+  grep -Fq 'kill-pane' "$bin/tmux.log"
+
+  # 1. The record — the only thing --force can work from — is KEPT.
+  [ -f "$rec" ]
+
+  # 2. The failure reached the channel an operator actually has. watch_log writes
+  #    to stderr and the shipped launcher runs the watcher with fd2 on /dev/null
+  #    (#691), so stderr alone is nowhere.
+  grep -Fq 'did not close pane' "$RUN/watch.out"
+}
+
+# NOTE ON WHICH BRANCH THIS COVERS. With no watcher the lock is free from the
+# start, so this exits through the PRE-EXISTING "no live actas lock, but a record
+# remains" branch and never reaches the post-teardown check added by #1051 —
+# measured: forcing that check to answer `gone` leaves this test green. It is a
+# control for the branch it does reach (the record survives a graceful attempt
+# that confirmed nothing), and the test above is the one that covers the new
+# code. Saying so because a name that implies the other branch is how a test gets
+# counted as coverage it does not provide.
+@test "despawn: a free lock with a record still reports needs-force (#1051, pre-existing branch)" {
+  local bin="$BATS_TEST_TMPDIR/bin"
+  _stub_tmux_close_fails "$bin"
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/join.sh" team leader claude-code "$PROJ" >/dev/null
+  local rec; rec="$(_spawn_rec_path team alice)"
+  mkdir -p "$(dirname "$rec")"
+  printf 'tmux:%%1\t%s\tclaude-code\n' "$PROJ" > "$rec"
+
+  # No watcher at all: the lock is free from the start, which is exactly the
+  # state the caller used to read as "torn down". The pane, per the stub, is not.
+  run env PATH="$bin:$PATH" bash "$SCRIPTS/despawn.sh" team leader alice --timeout 2
+  [ "$status" -ne 0 ]
+  printf '%s' "$output" | grep -Fq 'needs-force'
+  [ -f "$rec" ]
 }

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -1364,7 +1364,10 @@ T
   chmod 700 "$TEST_SKILL_DIR/run"                       # restore so teardown can clean up
   [ "$status" -ne 0 ]
   grep -q "status=spawned-but-unrecorded" <<<"$output"
-  grep -q "tmux:%9" <<<"$output"
+  # The ref names the server that owns the pane (#1051): $TMUX is "/tmp/fake,1,0",
+  # so the socket is /tmp/fake. A bare 'tmux:%9' would not identify which tmux
+  # server to ask, and %9 is not unique across servers.
+  grep -q "tmux:/tmp/fake:%9" <<<"$output"
 }
 
 @test "spawn: the plain driver's '-' protocol value never leaks to spawn stdout" {

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -170,12 +170,17 @@ _fake_herdr_list_scalar_session() {
   [ "$output" = "$(printf 'plain\t-')" ]
 }
 
-@test "resolve: picks tmux from \$TMUX and returns \$TMUX_PANE as the self id" {
+# The self id carries the SERVER, not just the pane: `<socket>:%N`. A pane id is
+# not unique across tmux servers (measured — two servers both holding %0), so an
+# id without its socket cannot be asked "are you still there?" of the right
+# authority, and a wrong answer deletes a live member's placement record (#1051).
+# $TMUX is "<socket-path>,<pid>,<session>"; the first field is the socket.
+@test "resolve: picks tmux from \$TMUX and returns socket-qualified \$TMUX_PANE (#1051)" {
   _install_fake_tmux
   export TMUX="/tmp/sock,1,0" TMUX_PANE="%4"
   run agmsg_terminal_resolve_name "sess-x"
   [ "$status" -eq 0 ]
-  [ "$output" = "$(printf 'tmux\t%%4')" ]
+  [ "$output" = "$(printf 'tmux\t/tmp/sock:%%4')" ]
 }
 
 @test "resolve: picks herdr from HERDR_ENV and resolves the pane from the session id" {
@@ -1333,7 +1338,7 @@ M
   export TMUX="/tmp/s,1,0" TMUX_PANE="%0"      # tmux present, has a pane
   run agmsg_terminal_resolve_name "sess-x"
   [ "$status" -eq 0 ]
-  [ "$output" = "$(printf 'tmux\t%%0')" ]
+  [ "$output" = "$(printf 'tmux\t/tmp/s:%%0')" ]
 }
 
 @test "resolve order: herdr broken AND no tmux pane -> FATAL with BOTH reasons, not silent plain" {
@@ -1390,7 +1395,7 @@ M
 
   # Positive control first: the pane WAS named, so a green result below cannot be
   # "the call did nothing".
-  grep -q 'tmux \[select-pane\]' "$ARGV_LOG" || grep -q 'tmux \[set-option\]' "$ARGV_LOG"
+  grep -q '\[select-pane\]' "$ARGV_LOG" || grep -q '\[set-option\]' "$ARGV_LOG"
 
   # `cmp`, not a captured string: command substitution strips trailing newlines,
   # so the string form cannot see a rewrite that changes only that. The sibling
@@ -1409,7 +1414,7 @@ M
   run agmsg_terminal_name_self "" seatteam bob /proj/B claude-code record
   [ "$status" -eq 0 ]
   [ -f "$rec" ]
-  grep -q 'tmux:%1' "$rec"
+  grep -q 'tmux:/tmp/fake:%1' "$rec"
 }
 
 @test "terminal_name_self: a failed record re-write leaves the EXISTING correct record intact (atomic)" {
@@ -1508,7 +1513,7 @@ M
   # Positive control FIRST: join reached the naming step and the pane really was
   # named. Without it a join that skipped naming altogether also leaves the record
   # alone, and this test would read that as the property holding.
-  grep -q 'tmux \[select-pane\]' "$ARGV_LOG" || grep -q 'tmux \[set-option\]' "$ARGV_LOG"
+  grep -q '\[select-pane\]' "$ARGV_LOG" || grep -q '\[set-option\]' "$ARGV_LOG"
 
   # The seat's placement is not join's to take. `cmp`, not `[ "$(cat …)" = … ]`:
   # command substitution strips every trailing newline, so the string form is
@@ -1542,7 +1547,12 @@ M
   [ "$status" -eq 0 ]
 
   # The key: still set, because it is addressing.
-  grep -Fq 'tmux [set-option] [-p] [-t] [%1] [@agmsg_agent] [offteam:alice]' "$ARGV_LOG"
+  # The op and its arguments. The line now leads with `[-S] [<socket>]` — every
+  # call is aimed at the server that owns the pane (#1051) — so anchoring on
+  # `tmux [set-option]` would be asserting the absence of that fix.
+  grep -Fq '[set-option] [-p] [-t] [%1] [@agmsg_agent] [offteam:alice]' "$ARGV_LOG"
+  # And the aim itself, which is the new behaviour worth pinning.
+  grep -Fq '[-S] [/tmp/fake]' "$ARGV_LOG"
   # The decoration: not set.
   refute grep -Fq 'select-pane' "$ARGV_LOG"
   refute grep -Fq 'rename-window' "$ARGV_LOG"
@@ -1686,4 +1696,131 @@ M
   # Nothing was renamed: no key could be built, so the member is not addressable
   # and saying `ok` would have claimed that it was.
   refute grep -Fq 'herdr [agent] [rename]' "$ARGV_LOG"
+}
+
+# --- a driver that is missing a required op does not load (#1051) -------------
+#
+# The registry has always refused a driver missing an ABI function; what it did
+# not have is anything that NOTICES when the required set grows. #1051 adds
+# `terminal_pane_state`, and the failure mode named when it was approved is
+# "someone adds an op and forgets to add it to `_AGMSG_TERMINAL_REQUIRED`" — a
+# hole that leaves the op optional in practice while the contract says otherwise.
+#
+# So this asserts the coupling in both directions:
+#   a driver missing the NEW op is refused  — the required set really includes it
+#   the refusal names the missing function  — an operator can act on it
+#   the shipped drivers all satisfy it      — the requirement is not vacuous
+@test "a driver missing terminal_pane_state is refused, by name (#1051)" {
+  local d="$TEST_SKILL_DIR/scripts/drivers/terminals/stubby"
+  mkdir -p "$d"
+  printf 'name=stubby\ncapabilities=\n' > "$d/terminal.conf"
+  # Every required op except the new one.
+  {
+    for fn in terminal_check terminal_describe terminal_detect terminal_spawn \
+              terminal_despawn terminal_peek terminal_poke terminal_name; do
+      printf '%s() { return 0; }\n' "$fn"
+    done
+  } > "$d/ops.sh"
+
+  run agmsg_terminal_load stubby
+  [ "$status" -ne 0 ]
+  printf '%s' "$output" | grep -Fq 'terminal_pane_state'
+
+  # Positive control: the same driver WITH the op loads. Without it, this test
+  # also passes when `agmsg_terminal_load` is broken for every input.
+  printf 'terminal_pane_state() { echo unknown; return 13; }\n' >> "$d/ops.sh"
+  run agmsg_terminal_load stubby
+  [ "$status" -eq 0 ]
+}
+
+@test "every shipped driver implements the required set (#1051)" {
+  local drv
+  for drv in tmux herdr plain; do
+    run agmsg_terminal_load "$drv"
+    [ "$status" -eq 0 ] || { echo "driver $drv failed to load: $output"; return 1; }
+  done
+}
+
+# --- terminal_pane_state: the three answers, and what earns each one (#1051) --
+#
+# `terminal_despawn` cannot answer "is that pane still there?": measured on a
+# throwaway server, `kill-pane` returns non-zero both for a pane already gone and
+# for one it could not close, and the driver maps both to 13. So a graceful
+# teardown that WORKED would have had to report needs-force.
+#
+# The answers are not symmetric in cost. `present` and `unknown` keep the
+# placement record; `gone` DELETES it, and that is the only irreversible one — so
+# `gone` has to be earned, and every uncertainty resolves to `unknown`.
+_fake_tmux_server() {   # <mode: alive|empty|noserver|broken>
+  local mode="$1"
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+# Skip the server selector the driver puts first, the way real tmux does.
+if [ "\$1" = -S ]; then shift 2; fi
+case "$mode" in
+  alive)    [ "\$1" = list-panes ] && echo '%1'; exit 0 ;;
+  empty)    [ "\$1" = list-panes ] && exit 0; exit 0 ;;
+  noserver) echo "no server running on /tmp/fake-sock" >&2; exit 1 ;;
+  broken)   echo "some other tmux failure" >&2; exit 1 ;;
+esac
+EOF
+  chmod +x "$FAKEBIN/tmux"
+  export PATH="$FAKEBIN:$PATH"
+}
+
+@test "pane_state: the pane is in its server's list -> present (#1051)" {
+  _fake_tmux_server alive
+  agmsg_terminal_load tmux
+  run terminal_pane_state "/tmp/fake-sock:%1"
+  [ "$status" -eq 0 ]
+  [ "$output" = present ]
+  # Asked the server the ref names, not whichever one was reachable.
+  grep -Fq '[-S] [/tmp/fake-sock]' "$ARGV_LOG"
+}
+
+@test "pane_state: the server answers and the pane is not in it -> gone (#1051)" {
+  _fake_tmux_server empty
+  agmsg_terminal_load tmux
+  run terminal_pane_state "/tmp/fake-sock:%1"
+  [ "$status" -eq 0 ]
+  [ "$output" = gone ]
+}
+
+@test "pane_state: the server is no longer running -> gone (#1051)" {
+  # The ordinary case for a member that had its own window: closing the last pane
+  # ends the server. Measured — without this the answer was `unknown` exactly
+  # when the teardown had worked. The discriminator is tmux SAYING so; the socket
+  # file survives the server's exit and proves nothing.
+  _fake_tmux_server noserver
+  agmsg_terminal_load tmux
+  run terminal_pane_state "/tmp/fake-sock:%1"
+  [ "$status" -eq 0 ]
+  [ "$output" = gone ]
+}
+
+@test "pane_state: any OTHER failure is unknown, not gone (#1051)" {
+  _fake_tmux_server broken
+  agmsg_terminal_load tmux
+  run terminal_pane_state "/tmp/fake-sock:%1"
+  [ "$status" -eq 10 ]
+  [ "$output" = unknown ]
+}
+
+@test "pane_state: an id with no socket cannot name an authority -> unknown (#1051)" {
+  # A record written before refs carried the server. Two servers can both hold
+  # `%1`, so there is no one to ask — and answering `gone` here is what deletes a
+  # live member's record.
+  _fake_tmux_server alive
+  agmsg_terminal_load tmux
+  run terminal_pane_state "%1"
+  [ "$status" -eq 10 ]
+  [ "$output" = unknown ]
+}
+
+@test "pane_state: plain says it cannot be asked, and that is not 'gone' (#1051)" {
+  agmsg_terminal_load plain
+  run terminal_pane_state "-"
+  [ "$status" -eq 13 ]
+  [ "$output" = unknown ]
 }

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -1853,6 +1853,112 @@ _fake_herdr_list_anchored_plus() {
   chmod +x "$FAKEBIN/herdr"; export PATH="$FAKEBIN:$PATH"
 }
 
+# --- every id-taking tmux op honours BOTH ref forms (#1051, co2/tl) ----------
+#
+# Putting the socket in the ref made the WRITERS emit `<socket>:%N`; the READERS
+# were not counted at the same time, and four of them pattern-matched a bare
+# `%`/`@` and called an ambient `tmux`. Those are TWO defects per site, not one:
+# a ref stripped but not routed reaches whatever server is ambient, where the
+# same pane id is a DIFFERENT pane — which is where #1051 started.
+#
+# The op list is DERIVED, not typed: the ABI minus the ops that take no pane id.
+# A new id-taking op therefore fails this test until it is covered, instead of
+# quietly inheriting the old assumption (the fixture-enumeration mistake, again).
+_TMUX_NO_ID_OPS="terminal_check terminal_describe terminal_detect terminal_spawn"
+
+# op -> the argument list to call it with, using SOCKID/BAREID as the id slot.
+_tmux_op_args() {
+  case "$1" in
+    terminal_arrange) printf '%s place_below %s' "$2" "$2" ;;
+    terminal_poke)    printf '%s hello' "$2" ;;
+    terminal_name)    printf '%s k label' "$2" ;;
+    terminal_team_input_ready) printf '%s claude' "$2" ;;
+    *)                printf '%s' "$2" ;;
+  esac
+}
+
+@test "every id-taking tmux op derives from the ABI and is covered here (#1051)" {
+  # The guard for the table above: if the ABI grows an id-taking op, this fails
+  # until _tmux_op_args and the two tests below have seen it. Without this the
+  # coverage claim is only as current as the day it was typed.
+  local op uncovered=""
+  for op in $_AGMSG_TERMINAL_REQUIRED $_AGMSG_TERMINAL_OPTIONAL; do
+    case " $_TMUX_NO_ID_OPS " in *" $op "*) continue ;; esac
+    grep -q "^${op}() {" scripts/drivers/terminals/tmux/ops.sh || uncovered="$uncovered $op(missing)"
+  done
+  [ -z "$uncovered" ] || { echo "not implemented by the tmux driver:$uncovered"; return 1; }
+  # And the exclusion list is not a place to hide an op: every name in it must be
+  # a real ABI op, or a typo silently drops a reader from the sweep.
+  for op in $_TMUX_NO_ID_OPS; do
+    case " $_AGMSG_TERMINAL_REQUIRED $_AGMSG_TERMINAL_OPTIONAL " in
+      *" $op "*) : ;;
+      *) echo "exclusion names a non-op: $op"; return 1 ;;
+    esac
+  done
+}
+
+@test "a socket-qualified ref reaches the OWNING server, with a bare -t (#1051)" {
+  _fake_tmux_server alive
+  agmsg_terminal_load tmux
+  local op args n=0 want=0
+  for op in $_AGMSG_TERMINAL_REQUIRED $_AGMSG_TERMINAL_OPTIONAL; do
+    case " $_TMUX_NO_ID_OPS " in *" $op "*) continue ;; esac
+    want=$((want + 1))
+    : > "$ARGV_LOG"
+    # shellcheck disable=SC2046
+    run $op $(_tmux_op_args "$op" '/tmp/fake-sock:%1')
+    # Not asserting success: some ops legitimately answer unsupported/unknown
+    # against a stub. What must hold is HOW they asked.
+    if [ -s "$ARGV_LOG" ]; then
+      n=$((n + 1))
+      grep -Fq '[-S] [/tmp/fake-sock]' "$ARGV_LOG" \
+        || { echo "$op: did not select the owning server"; cat "$ARGV_LOG"; return 1; }
+      refute grep -Fq '[/tmp/fake-sock:%1]' "$ARGV_LOG" \
+        || { echo "$op: passed the socket-qualified id through as a target"; cat "$ARGV_LOG"; return 1; }
+    fi
+  done
+  # Positive control. Every assertion above is inside `if [ -s ... ]`, so an op
+  # that stops invoking tmux is checked by nothing and the sweep shrinks in
+  # silence — "0 findings" and "never ran" would look identical. Measured: all
+  # of them invoke tmux today, so anything less is a real change to explain.
+  [ "$n" -eq "$want" ] || { echo "only $n of $want id-taking ops reached tmux"; return 1; }
+}
+
+@test "a LEGACY bare ref still works and selects no server (#1051)" {
+  # Without this half, making every op REQUIRE a socket would pass the test
+  # above. Legacy bare refs are real input: agmsg_terminal_ref_terminal accepts
+  # a schemeless bare tmux id on purpose, and records written before the socket
+  # axis carry exactly that.
+  _fake_tmux_server alive
+  agmsg_terminal_load tmux
+  local op silent=""
+  for op in $_AGMSG_TERMINAL_REQUIRED $_AGMSG_TERMINAL_OPTIONAL; do
+    case " $_TMUX_NO_ID_OPS " in *" $op "*) continue ;; esac
+    : > "$ARGV_LOG"
+    # shellcheck disable=SC2046
+    run $op $(_tmux_op_args "$op" '%1')
+    if [ -s "$ARGV_LOG" ]; then
+      refute grep -Fq '[-S]' "$ARGV_LOG" \
+        || { echo "$op: selected a server for a ref that names none"; cat "$ARGV_LOG"; return 1; }
+      continue
+    fi
+    silent="$silent $op"
+    # An op that invoked nothing asserted nothing, so name why it is allowed to.
+    # `pane_state` is the ONE deliberate abstainer: a bare id names no server, so
+    # there is nobody to ask, and `gone` here would delete a live member's
+    # record. It must say so — unknown/10 — rather than merely doing nothing.
+    [ "$op" = terminal_pane_state ] \
+      || { echo "$op invoked no tmux for a legacy bare ref (silently refused?)"; return 1; }
+    [ "$status" -eq 10 ] && [ "$output" = unknown ] \
+      || { echo "pane_state abstained without saying unknown/10: status=$status out=$output"; return 1; }
+  done
+  # The abstainer list is pinned, not counted: a second op going quiet would keep
+  # any >=N count green while its half of the sweep asserted nothing, and
+  # "everything now requires a socket" would read as a pass.
+  [ "$silent" = " terminal_pane_state" ] \
+    || { echo "unexpected set of ops invoking nothing:$silent"; return 1; }
+}
+
 @test "pane_state (herdr): the pane is in the list -> present (#1051)" {
   _fake_herdr_list_anchored_plus ""
   agmsg_terminal_load herdr

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -1714,13 +1714,21 @@ M
   local d="$TEST_SKILL_DIR/scripts/drivers/terminals/stubby"
   mkdir -p "$d"
   printf 'name=stubby\ncapabilities=\n' > "$d/terminal.conf"
-  # Every required op except the new one.
-  {
-    for fn in terminal_check terminal_describe terminal_detect terminal_spawn \
-              terminal_despawn terminal_peek terminal_poke terminal_name; do
-      printf '%s() { return 0; }\n' "$fn"
-    done
-  } > "$d/ops.sh"
+  # DERIVE the set from the registry, minus the one op under test. An enumerated
+  # list here silently falls behind the moment another op joins the required set:
+  # the stub is then missing two ops, the loader names whichever it finds first,
+  # and the positive control below cannot load at all. (Measured — terminal_where
+  # and terminal_arrange landed on the base and did exactly that.)
+  local fn
+  : > "$d/ops.sh"
+  for fn in $_AGMSG_TERMINAL_REQUIRED; do
+    [ "$fn" = terminal_pane_state ] && continue
+    printf '%s() { return 0; }\n' "$fn" >> "$d/ops.sh"
+  done
+  # The derivation is only meaningful if it actually left the op out, and only
+  # honest if it wrote the others.
+  refute grep -q 'terminal_pane_state' "$d/ops.sh"
+  [ "$(grep -c '() { return 0; }' "$d/ops.sh")" -ge 8 ]
 
   run agmsg_terminal_load stubby
   [ "$status" -ne 0 ]

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -1824,3 +1824,89 @@ EOF
   [ "$status" -eq 13 ]
   [ "$output" = unknown ]
 }
+
+# --- herdr pane_state: `gone` is a claim about the WHOLE list (#1051) ---------
+#
+# The first version asked only "is the container an array?" and then read "no
+# entry matched" as absence. An array whose entries were never inspected proves
+# nothing: a target sitting in an entry this driver cannot read came back as
+# `gone`, and `gone` is the answer that deletes the record. Aligned with
+# `_herdr_pane_for_session`, which only says not-among when EVERY entry is
+# decidable.
+#
+# A herdr `agent list` carrying the two MEASURED decidable entries plus one raw
+# caller-supplied entry, so a test can add exactly one undecidable entry and
+# nothing else. The two fixed entries both carry a grammatical pane_id and the
+# identity anchor (agent/terminal_id/tab_id/workspace_id), so on their own the
+# list is fully decidable.
+_fake_herdr_list_anchored_plus() {
+  local raw="$1"
+  printf '#!/usr/bin/env bash\n[ "$1" = agent ] && [ "$2" = list ] && { echo '"'"'{"id":"1","result":{"type":"list","agents":[{"agent":"claude","agent_session":{"agent":"claude","kind":"id","source":"herdr:claude","value":"sess-OTHER"},"pane_id":"w1:p4","terminal_id":"tm0","tab_id":"t0","workspace_id":"w0"},{"agent":"codex","agent_status":"working","tab_id":"t1","terminal_id":"tm1","workspace_id":"w1","pane_id":"w5:p3"}%s]}}'"'"'; exit 0; }\nexit 0\n' "$raw" > "$FAKEBIN/herdr"
+  chmod +x "$FAKEBIN/herdr"; export PATH="$FAKEBIN:$PATH"
+}
+
+@test "pane_state (herdr): the pane is in the list -> present (#1051)" {
+  _fake_herdr_list_anchored_plus ""
+  agmsg_terminal_load herdr
+  run terminal_pane_state "w5:p3"
+  [ "$status" -eq 0 ]
+  [ "$output" = present ]
+}
+
+@test "pane_state (herdr): every entry decidable and no match -> gone (#1051)" {
+  # The positive control for the one below: with the SAME two entries and nothing
+  # added, an absent pane is honestly gone. Without this, the `unknown` test
+  # cannot tell "the extra entry made it undecidable" from "this driver can never
+  # say gone".
+  _fake_herdr_list_anchored_plus ""
+  agmsg_terminal_load herdr
+  run terminal_pane_state "w9:p9"
+  [ "$status" -eq 0 ]
+  [ "$output" = gone ]
+}
+
+@test "pane_state (herdr): ONE undecidable entry and no match -> unknown, not gone (#1051)" {
+  # Differs from the control above by exactly one array element: an object with a
+  # grammatical pane_id but no identity anchor, so this driver cannot say it is a
+  # herdr pane at all. The target could be that entry under a shape we do not
+  # read, so absence is not established — and `gone` here would delete a live
+  # member's record.
+  _fake_herdr_list_anchored_plus ',{"pane_id":"w2:p2"}'
+  agmsg_terminal_load herdr
+  run terminal_pane_state "w9:p9"
+  [ "$status" -eq 10 ]
+  [ "$output" = unknown ]
+}
+
+@test "pane_state (herdr): an undecidable entry does not hide a MATCH (#1051)" {
+  # `hit` is deliberately looser than the decidability test: an exact pane_id
+  # match is evidence the pane exists whatever else the list looks like, and
+  # `present` keeps the record. Being permissive toward the cheap answer is not
+  # the same mistake as being permissive toward the destructive one.
+  _fake_herdr_list_anchored_plus ',{"pane_id":"w2:p2"}'
+  agmsg_terminal_load herdr
+  run terminal_pane_state "w2:p2"
+  [ "$status" -eq 0 ]
+  [ "$output" = present ]
+}
+
+# --- a socket path may contain a space (#1051) --------------------------------
+#
+# The record is one TAB-separated line, so what breaks it is a TAB or a newline.
+# An ordinary space does not, and a socket under a home directory with a space in
+# it is perfectly normal — refusing 0x20 would reject a legitimate ref.
+@test "ref grammar: a tmux socket path containing a SPACE is accepted (#1051)" {
+  [ "$(agmsg_terminal_ref_terminal 'tmux:/Users/A B/tmp/s:%3')" = 'tmux' ]
+  [ "$(agmsg_terminal_ref_id 'tmux:/Users/A B/tmp/s:%3')" = '/Users/A B/tmp/s:%3' ]
+}
+
+@test "ref grammar: a tmux socket path containing a TAB or newline is refused (#1051)" {
+  # These are the bytes that actually corrupt the record's framing — it is one
+  # TAB-separated line — and they are the only ones that need refusing.
+  local bad
+  for bad in "$(printf 'tmux:/tmp/a\tb:%%3')" "$(printf 'tmux:/tmp/a\nb:%%3')"; do
+    run agmsg_terminal_ref_terminal "$bad"
+    [ "$status" -ne 0 ] || { echo "FAIL: control byte accepted in '$bad'"; return 1; }
+    [ -z "$output" ]    || { echo "FAIL: printed '$output'"; return 1; }
+  done
+}

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -1007,6 +1007,7 @@ _record_handover_events() {
   {
     printf '%s\n' 'set -u'
     printf '%s\n' 'watch_log() { printf "%s\n" "$*" >> "$WLOG"; }'
+    printf '%s\n' 'watch_report() { printf "%s\n" "$*" >> "$WREPORT"; }'
     printf '%s\n' '. "$SCRIPTS/lib/actas-lock.sh"'
     printf '%s\n' '. "$SCRIPTS/lib/terminal-registry.sh"'
     awk '/^close_own_placement\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$SCRIPTS/watch.sh"
@@ -1019,11 +1020,19 @@ _record_handover_events() {
   printf 'bogus:xyz\t/tmp/p\tclaude-code' > "$rec"
 
   export WLOG="$TEST_SKILL_DIR/wlog"; : > "$WLOG"
+  export WREPORT="$TEST_SKILL_DIR/wreport"; : > "$WREPORT"
   # SESSION_ID is referenced only past the ref guard; the guard returns before it.
-  SESSION_ID=irrelevant bash -c '. "'"$shim"'"; close_own_placement wt carol'
-  grep -q "did not resolve to a terminal and pane id" "$WLOG"
+  run env SESSION_ID=irrelevant bash -c '. "'"$shim"'"; close_own_placement wt carol'
+  # A pane that may still be open is the operator's problem, so it is a REPORT
+  # (stdout), not a log (stderr): the shipped launcher runs the watcher with fd2
+  # on /dev/null (#691), so this text on stderr would be text nobody ever sees.
+  # 1 = "a placed pane may still be open", distinct from 2 = "nothing of ours".
+  [ "$status" -eq 1 ]
+  grep -q "did not resolve to a terminal and pane id" "$WREPORT"
+  refute grep -q "did not resolve to a terminal and pane id" "$WLOG"
   # must NOT reach the "belongs to someone else" fallthrough with an empty recorded side
   refute grep -q "belongs to someone else" "$WLOG"
+  refute grep -q "belongs to someone else" "$WREPORT"
 }
 
 @test "watch: a backlog past the argv ceiling still delivers (#1045/#777, stdin)" {


### PR DESCRIPTION
Fixes #1051. Refs #1055 (the tmux half of it; herdr is deliberately untouched).

Against `integration/terminal-driver-v1` — the release candidate. This is what
blocks 1.3.0.

## What happened

A `grok-build` member was despawned gracefully during the dogfood. `despawn` said
`status=ok`, the pane stayed open with the agent running, and `--force` then
refused because the graceful path had already deleted the record it works from.
The only way out was `herdr pane close`, outside agmsg.

The comparison that makes it clear is in the issue: a `codex` member in the same
session **failed honestly** — `needs-force`, record kept — and `--force`
recovered it. **The type that reported success is the one that could not be
recovered.**

## The diagnosis in the issue named the wrong actor, and it matters

The issue said `reset.sh` removes the record before the pane is closed. It does
not — grepped, and `reset.sh` touches only the registration and the actas lock.
The deletion is the CALLER's:

```
despawn.sh:130-141   wait until the actas lock is free
despawn.sh:143       rm -f "$SPAWN_REC"
despawn.sh:144       status=ok
```

**The lock going free is not the pane closing.** The watcher releases it (via
`reset.sh`) *before* it attempts the close, and a lock whose owner has died reads
as free as well. Fixing the watcher's ordering alone would have left the caller
deleting the record anyway.

## The fix

**The caller asks the terminal, and deletes the record only on a settled `gone`.**

`terminal_despawn` cannot answer that question — measured on a throwaway tmux
server, `kill-pane` returns non-zero both for a pane already gone and for one it
could not close, and the driver maps both to 13. A graceful teardown that WORKED
would have had to report needs-force. So the drivers gain a read-only op:

```
terminal_pane_state <id>    prints  gone / present / unknown
                            returns 0 settled · 13 cannot be asked · 10 unreachable
```

The three answers are not symmetric in cost. `present` and `unknown` keep the
record; **`gone` deletes it**, and that is the only irreversible one — so "could
not ask" never returns 0, and every uncertainty resolves to `unknown`.

`close_own_placement` now distinguishes **closed / could-not-close /
nothing-to-close**, where every branch used to `return 0`. The channel follows
the same split rather than a habit: could-not-close goes to **stdout**, because
the shipped launcher runs the watcher with fd2 on `/dev/null` (#691) and a
failure announced on stderr was announced nowhere.

## A pane id does not name a server

Found while testing this, and it had to be fixed here or the fix above rests on
a guess:

```
server A holds %0     server B holds %0
asking B about A's %0        -> "yes, I know it"
enumerating every socket     -> both know it
```

My own test hit it: the real tmux on this machine had never heard of the recorded
pane, that read as `gone`, and the record went. So tmux refs now carry the server
— `tmux:<socket>:%1` — which fits inside the tmux driver and the id grammar and
changes no other terminal. The socket is split off before the id reaches `-t`:
measured, `kill-pane -t '<socket>:%0'` is read as session:window and closes
**nothing**, which is this issue's shape all over again.

**Old refs still resolve and still work.** What they cannot do is answer
`pane_state`, which returns `unknown` for them — a member placed before this
reports needs-force rather than a guess. New records can be confirmed; old ones
say honestly that they cannot be.

## Two corrections the measurements forced, and one regression I made

- Closing a server's **last** pane ends the server — the ordinary case for a
  member in its own window. Without handling it, the answer was `unknown`
  precisely when the teardown had worked.
- The socket **file survives** the server's exit, so "no socket file" is not the
  discriminator. My first implementation rested on that. The discriminator is
  tmux saying `no server running on <path>`; every other failure stays `unknown`.
- With the self id socket-qualified, a **legacy record stopped matching it**, so a
  member with an older record could not fold itself — the ownership check called
  its own pane someone else's. Ownership now compares at the precision both sides
  have. That inherits the ambiguity a bare id always had; it adds none.

## Controls

| | |
|---|---|
| the caller does not report ok with the pane still open | record kept, failure on stdout |
| a free lock with a record still reports needs-force | names the pre-existing branch it covers |
| `pane_state`: present / gone / vanished-server / other-failure / no-socket / plain | six |
| a driver missing the op is refused, by name | with a positive control that the same driver loads once it has it |
| every shipped driver satisfies the required set | so the requirement is not vacuous |
| the corrupt-ref refusal lands on the report channel, not the log | `test_watch` #23, rewritten — it asserted the text, not the channel, and the channel is the fix |

Calibrated on **both axes** — remove the action, and make it lie — each mutation
confirmed present in the file before its result was read:

| mutation | goes red |
|---|---|
| a socket-less id answers `gone` | the no-socket control |
| any other failure answers `gone` | the other-failure control |
| the vanished server reads as `unknown` | the vanished-server control |
| the caller deletes without asking | the caller control |
| `close_own_placement` swallows the refusal again | the caller control |
| `terminal_spawn` emits the id without its server | `test_spawn` #88 |
| the corrupt-ref refusal goes back to `watch_log` | `test_watch` #23 |
| that refusal returns 2 ("nothing of ours") instead of 1 | `test_watch` #23 |

## Two existing tests changed, and why that is not weakening them

Both were reddened by this change and both are now stricter, not looser.

- **`test_spawn` #88** expected `tmux:%9`; the ref is now `tmux:/tmp/fake:%9`.
  The assertion pins the socket-qualified form, so dropping the socket from
  `terminal_spawn` reddens it (verified).
- **`test_watch` #23** extracts `close_own_placement` into a shim and stubbed only
  `watch_log`. Adding `watch_report` broke the shim — `command not found` — which
  is the useful part: the test asserted the *text* of the refusal and said nothing
  about the *channel*, and the channel is what #691 makes load-bearing. It now
  stubs both, asserts the refusal reaches the report channel and **not** the log,
  and pins `return 1` (a placed pane may still be open) against `2` (nothing of
  ours). Both mutations verified red.

## One commit, not two

The socket change and the `pane_state` change are separate stories and are
written up separately above, but neither stands alone: tmux's `pane_state` needs
the socket to have somebody to ask, and the socket-qualified grammar is what the
new controls assert against. A split would have produced an intermediate commit
that is wrong in one direction or the other, so it is one commit with both
stories in the message.

## Not here

- **herdr.** Whether `herdr:w1:p6` has the same server-identity problem is not
  established; #1055 stays open for it, and the tmux conclusion is not
  generalised to it.
- **Migrating old records.** They keep working and answer `unknown`.
- **The role-session write-back** agreed with the #1052 seat: on this base
  nothing deletes that record (the deletion arrives with #1052), so the guard
  would be dead code and its control could not be written honestly. It belongs
  in whichever change lands second.

---

## Review round 2 — three findings, all the same shape

Each was a claim wider than what had been checked, which is the shape this PR
exists to fix. All three are fixed with a control apiece.

**1. herdr's `gone` was not fail-closed.** `terminal_pane_state` asked only "is the
container an array?" and read "no entry matched" as absence. An array whose
ENTRIES were never inspected proves nothing, and `gone` is the answer that deletes
the record. Now aligned with `_herdr_pane_for_session` in the same file: not-present
only when EVERY entry is decidable. For a pane_id question decidable means an
object with a pane_id in the measured grammar plus the fixed identity anchor —
both known kinds qualify, since both carry a pane_id; anything else is drift.

`hit` is deliberately looser than `det`: an exact pane_id match is evidence the
pane exists whatever the rest of the entry looks like, and `present` keeps the
record. Permissive toward the cheap answer is not the same mistake as permissive
toward the destructive one.

**2. a socket path may contain a space.** `[[:space:]]` swallows 0x20 too, so a
socket under a home directory with a space in it was refused. What corrupts the
record is a TAB or a newline — it is one TAB-separated line — so the class is
`[[:cntrl:]]`, which is exactly that split.

**3. a delete that failed still reported ok.** `rm -f "$SPAWN_REC" || true`, then
`status=ok`. Whether the record MAY go and whether it WENT are different questions
and only the first was asked; a record outliving the pane it names is what the next
`--force` acts on. The check is on the record's STATE, not `rm`'s exit code, so a
delete that fails loudly and one that lies with exit 0 are both caught →
`status=error note=record-not-removed`, non-zero.

Six more calibrations, each mutation confirmed present in the file before its
result was read:

| mutation | goes red |
|---|---|
| `det` without the anchor requirement | herdr: one undecidable entry → unknown |
| the `det == alen` gate removed | same |
| `[[:cntrl:]]` back to `[[:space:]]` | socket path with a space |
| the control-byte check removed | socket path with a TAB / newline |
| the post-delete state check removed | record-not-removed |
| `terminal_pane_state` dropped from the required set | the missing-op control |

The herdr controls are a **differential pair**: the same two decidable entries
answer `gone`, and adding exactly ONE undecidable element makes it `unknown`.
Without the pair, "the added entry made it undecidable" and "this driver can never
say gone" are indistinguishable.

## Rebased onto the integration tip

Two conflicts, both in `terminal-registry.sh`, both resolved as **unions**: the ABI
doc block, and `_AGMSG_TERMINAL_REQUIRED`. The second is load-bearing — taking
either side alone lets a driver borrow the previously loaded driver's same-named
function, the failure that file's own comment warns about.

Verified by name rather than by "no conflicts": all 11 ops present in all 3 shipped
drivers, every marker of this branch at its pre-rebase count, and no test lost from
either side (229 → 246, nothing removed).

The rebase also broke the missing-op fixture, which had **enumerated** the required
ops by hand: with `terminal_where` and `terminal_arrange` newly required, the stub
was missing three ops instead of one and the positive control could not load. The
fixture now DERIVES the set from `$_AGMSG_TERMINAL_REQUIRED` minus the op under
test, with two assertions keeping the derivation honest (the op really is absent,
the others really were written).

## Regression

`test_terminal_registry` 110/0 · `test_despawn` 18/0 · `test_peek_poke` 30/0 ·
`test_spawn` 89/0 · `test_watch` 28/1 · `test_team` 82/0 · `test_delivery` 198/0.
Both repo checkers at baseline (628 / 0).

The one red is `test_watch` #197, and it is **not this branch**: measured by
alternating runs against this branch and its unmodified base, it fails at the same
rate on BOTH (2 of 3 pass on each side). The test's fixed `sleep 2` does not
reliably span a poll interval on a loaded shared host. Not investigated further;
green in CI.
