### PR TITLE
feat(terminals): arrange panes by declarative intent

### DIFF
--- a/scripts/arrange.sh
+++ b/scripts/arrange.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Declaratively place one member's pane relative to another member's pane.
+# Identity/placement resolution belongs here; terminal drivers receive ids only.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/terminal-registry.sh"
+
+die() { echo "arrange: $*" >&2; exit 1; }
+
+TEAM="${1:-}"; SOURCE="${2:-}"; INTENT="${3:-}"; TARGET="${4:-}"
+[ -n "$TEAM" ] && [ -n "$SOURCE" ] && [ -n "$INTENT" ] && [ -n "$TARGET" ] \
+  || die "Usage: arrange.sh <team> <agent> <place_below|place_right> <anchor-agent>"
+[ "$SOURCE" != "$TARGET" ] || die "source and anchor must be different members"
+case "$INTENT" in place_below|place_right) : ;; *) die "unknown intent '$INTENT' (expected place_below or place_right)" ;; esac
+
+_placement() {
+  local agent="$1" rec ref terminal id
+  rec="$(agmsg_spawn_path "$TEAM" "$agent")"
+  [ -f "$rec" ] || { echo "arrange: no placement record for '$TEAM/$agent'" >&2; return 1; }
+  IFS=$'\t' read -r ref _ _ < "$rec" || true
+  terminal="$(agmsg_terminal_ref_terminal "$ref" 2>/dev/null)" || terminal=""
+  id="$(agmsg_terminal_ref_id "$ref" 2>/dev/null)" || id=""
+  [ -n "$terminal" ] && [ -n "$id" ] \
+    || { echo "arrange: placement record for '$TEAM/$agent' is unreadable" >&2; return 1; }
+  PLACEMENT_TERMINAL="$terminal"
+  PLACEMENT_ID="$id"
+}
+
+PLACEMENT_TERMINAL=""; PLACEMENT_ID=""
+_placement "$SOURCE" || exit $?
+SOURCE_TERMINAL="$PLACEMENT_TERMINAL"; SOURCE_ID="$PLACEMENT_ID"
+_placement "$TARGET" || exit $?
+TARGET_TERMINAL="$PLACEMENT_TERMINAL"; TARGET_ID="$PLACEMENT_ID"
+[ "$SOURCE_TERMINAL" = "$TARGET_TERMINAL" ] \
+  || die "members are in different terminals ('$SOURCE_TERMINAL' and '$TARGET_TERMINAL')"
+agmsg_terminal_has "$SOURCE_TERMINAL" capabilities arrange \
+  || die "terminal '$SOURCE_TERMINAL' cannot arrange panes"
+agmsg_terminal_load "$SOURCE_TERMINAL" \
+  || die "cannot load terminal driver '$SOURCE_TERMINAL'"
+
+# Last command: preserve the driver's moved/unchanged/error token and exit code.
+terminal_arrange "$SOURCE_ID" "$INTENT" "$TARGET_ID"

--- a/scripts/despawn.sh
+++ b/scripts/despawn.sh
@@ -66,6 +66,37 @@ SPAWN_REC="$(agmsg_spawn_path "$TEAM" "$NAME")"
 # possibility for tmux and herdr) means the pane may STILL be alive, and the caller
 # must keep the record rather than delete the one retry authority. Returns 0 on a
 # confirmed teardown, non-zero otherwise (no side effects here beyond the kill call).
+# What does the terminal say about the recorded pane, RIGHT NOW? Read only —
+# nothing is closed here.
+#
+# Prints one of: no-record / gone / present / unknown.
+#
+# It resolves the record the same way kill_recorded_placement does, and stops
+# short of the kill. `terminal_despawn` cannot be used for this: measured on a
+# throwaway tmux server, `kill-pane` returns non-zero both for a pane that is
+# already gone and for one it could not close, and the driver maps both to 13.
+# Asking with it would make a graceful teardown that WORKED report needs-force.
+recorded_pane_state() {
+  [ -f "$SPAWN_REC" ] || { printf 'no-record'; return 0; }
+  local id _proj _type _term _bare _out _rc=0
+  IFS=$'\t' read -r id _proj _type < "$SPAWN_REC"
+  [ -n "$id" ] || { printf 'unknown'; return 0; }
+  _term="$(agmsg_terminal_ref_terminal "$id")" || { printf 'unknown'; return 0; }
+  _bare="$(agmsg_terminal_ref_id "$id")"       || { printf 'unknown'; return 0; }
+  agmsg_terminal_load "$_term" 2>/dev/null     || { printf 'unknown'; return 0; }
+  declare -F terminal_pane_state >/dev/null 2>&1 || { printf 'unknown'; return 0; }
+  _out="$(terminal_pane_state "$_bare" 2>/dev/null)" || _rc=$?
+  # The token is the answer and the code says whether it is a settled one. A
+  # non-zero (13 unsupported, 10 unreachable) is NOT an answer about the pane,
+  # whatever was printed.
+  [ "$_rc" -eq 0 ] || { printf 'unknown'; return 0; }
+  case "$_out" in
+    gone|present) printf '%s' "$_out" ;;
+    *)            printf 'unknown' ;;
+  esac
+  return 0
+}
+
 kill_recorded_placement() {
   [ -f "$SPAWN_REC" ] || return 1
   local id _proj _type _term _bare
@@ -140,5 +171,31 @@ while true; do
   waited=$((waited + 1))
 done
 
-rm -f "$SPAWN_REC" 2>/dev/null || true
-echo "status=ok name=$NAME team=$TEAM after=${waited}s"
+# The lock going free means the watcher let go of it. It does NOT mean the pane
+# was closed: the watcher releases the lock (via reset.sh) BEFORE it tries to
+# close anything, and a lock whose owner has died reads as free too. Deleting the
+# record on that signal is what made #1051 unrecoverable — the record is the only
+# thing `--force` can work from, and it was gone before anyone knew the pane was
+# still open.
+#
+# So ask the terminal. The record is deleted, and success reported, only when the
+# answer is a settled `gone`.
+_pane_state="$(recorded_pane_state)"
+case "$_pane_state" in
+  no-record|gone)
+    rm -f "$SPAWN_REC" 2>/dev/null || true
+    echo "status=ok name=$NAME team=$TEAM after=${waited}s"
+    ;;
+  present)
+    echo "despawn: '$NAME' released its lock but the recorded pane is STILL OPEN — the teardown did not fold the window. The placement record is kept; retry with --force to tear it down through it." >&2
+    echo "status=needs-force name=$NAME team=$TEAM note=pane-still-open after=${waited}s"
+    exit 1
+    ;;
+  *)
+    # Deliberately a different sentence from `present`: the operator's next move
+    # differs. "Still open" says close it; "could not check" says look.
+    echo "despawn: '$NAME' released its lock, but this terminal could not be asked whether the pane closed, so the teardown is unconfirmed. The placement record is kept; check the window, and use --force if it is still there." >&2
+    echo "status=needs-force name=$NAME team=$TEAM note=teardown-unverified after=${waited}s"
+    exit 1
+    ;;
+esac

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -44,7 +44,11 @@ terminal_check() {
 terminal_describe() {
   printf 'name=herdr\n'
   printf 'backend=herdr pane\n'
-  printf 'capabilities=spawn despawn peek poke name\n'
+  printf 'capabilities=spawn despawn peek poke where arrange name\n'
+  printf 'syntax_help=herdr --help\n'
+  printf 'skill_help=herdr --skill\n'
+  printf 'intent.place_below=herdr pane move SOURCE --new-tab; herdr pane move SOURCE --tab CONTAINER --split down --target-pane TARGET\n'
+  printf 'intent.place_right=herdr pane move SOURCE --new-tab; herdr pane move SOURCE --tab CONTAINER --split right --target-pane TARGET\n'
 }
 
 # Extract the pane id whose agent_session == <sid> from `herdr agent list` JSON.
@@ -463,6 +467,145 @@ terminal_despawn() {
   local id="$1"
   herdr pane close "$id" >/dev/null 2>&1 || { echo runtime_error; return 13; }
   echo ok
+  return 0
+}
+
+# Ask herdr where a pane is. Existence is deliberately outside this op:
+# terminal_pane_state is the only function allowed to say `gone`. A successful
+# layout query that no longer contains the pane is the present-then-missing race,
+# so it is unknown/10 with its own reason.
+terminal_where() {
+  local id="$1" json rc=0 esc container present
+  command -v herdr >/dev/null 2>&1 || { echo unknown; return 10; }
+  _herdr_pane_id_ok "$id" || { echo unsupported; return 13; }
+  json="$(herdr pane layout --pane "$id" 2>/dev/null)" || rc=$?
+  [ "$rc" -eq 0 ] && [ -n "$json" ] || { echo unknown; return 10; }
+  esc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  present="$(sqlite3 :memory: "SELECT count(*) FROM json_each('$esc','\$.result.layout.panes') WHERE json_extract(value,'\$.pane_id') = '$(printf '%s' "$id" | sed "s/'/''/g")'" 2>/dev/null)" \
+    || { echo unknown; return 10; }
+  container="$(sqlite3 :memory: "SELECT json_extract('$esc','\$.result.layout.tab_id')" 2>/dev/null)" \
+    || { echo unknown; return 10; }
+  if [ "$present" != 1 ] || [ -z "$container" ]; then
+    echo unknown
+    echo "herdr: pane '$id' was present immediately before location lookup, but its tab could not be resolved" >&2
+    return 10
+  fi
+  printf '%s\n' "$container"
+  return 0
+}
+
+# Classify the requested terminal relationship from one pane-layout response.
+# Output: unchanged, different, ambiguous_layout, or runtime_error.
+_herdr_arrange_state() {
+  local json="$1" source="$2" intent="$3" target="$4" esc sesc tesc dir result rc=0
+  esc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  sesc="$(printf '%s' "$source" | sed "s/'/''/g")"
+  tesc="$(printf '%s' "$target" | sed "s/'/''/g")"
+  case "$intent" in place_below) dir=down ;; place_right) dir=right ;; *) echo runtime_error; return 13 ;; esac
+  # A candidate split must contain both panes, have the requested direction,
+  # and agree with their rectangle order. Among those, the smallest area is the
+  # LCA equivalent. Equal-area candidates really occur in degenerate layouts
+  # (measured with a zero-height child); if more than one remains, fail closed.
+  result="$(sqlite3 :memory: "
+    WITH p AS (
+      SELECT json_extract(value,'\$.pane_id') id,
+             json_extract(value,'\$.rect.x') x, json_extract(value,'\$.rect.y') y,
+             json_extract(value,'\$.rect.width') w, json_extract(value,'\$.rect.height') h
+      FROM json_each('$esc','\$.result.layout.panes')
+    ), src AS (SELECT * FROM p WHERE id='$sesc'), tgt AS (SELECT * FROM p WHERE id='$tesc'),
+    candidates AS (
+      SELECT json_extract(s.value,'\$.rect.width') * json_extract(s.value,'\$.rect.height') area
+      FROM json_each('$esc','\$.result.layout.splits') s, src, tgt
+      WHERE json_extract(s.value,'\$.direction')='$dir'
+        AND src.x >= json_extract(s.value,'\$.rect.x')
+        AND src.y >= json_extract(s.value,'\$.rect.y')
+        AND src.x + src.w <= json_extract(s.value,'\$.rect.x') + json_extract(s.value,'\$.rect.width')
+        AND src.y + src.h <= json_extract(s.value,'\$.rect.y') + json_extract(s.value,'\$.rect.height')
+        AND tgt.x >= json_extract(s.value,'\$.rect.x')
+        AND tgt.y >= json_extract(s.value,'\$.rect.y')
+        AND tgt.x + tgt.w <= json_extract(s.value,'\$.rect.x') + json_extract(s.value,'\$.rect.width')
+        AND tgt.y + tgt.h <= json_extract(s.value,'\$.rect.y') + json_extract(s.value,'\$.rect.height')
+        AND (('$dir'='down' AND src.y = tgt.y + tgt.h AND src.x = tgt.x AND src.w = tgt.w)
+          OR ('$dir'='right' AND src.x = tgt.x + tgt.w AND src.y = tgt.y AND src.h = tgt.h))
+    ), m AS (SELECT min(area) area FROM candidates)
+    SELECT CASE
+      WHEN (SELECT count(*) FROM tgt) != 1 OR (SELECT count(*) FROM src) > 1 THEN 'unknown'
+      WHEN (SELECT count(*) FROM src) = 0 THEN 'source_missing'
+      WHEN (SELECT count(*) FROM candidates c,m WHERE c.area=m.area) > 1 THEN 'ambiguous_layout'
+      WHEN (SELECT count(*) FROM candidates) > 0 THEN 'unchanged'
+      ELSE 'different' END;" 2>/dev/null)" || rc=$?
+  [ "$rc" -eq 0 ] && [ -n "$result" ] || { echo runtime_error; return 10; }
+  printf '%s\n' "$result"
+}
+
+_herdr_move_changed() {
+  local json="$1" esc
+  esc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  [ "$(sqlite3 :memory: "SELECT json_extract('$esc','\$.result.move_result.changed')" 2>/dev/null)" = 1 ]
+}
+
+_herdr_move_created_tab() {
+  local json="$1" esc
+  esc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  sqlite3 :memory: "SELECT json_extract('$esc','\$.result.move_result.created_tab.tab_id')" 2>/dev/null
+}
+
+_herdr_layout_has_pane() {
+  local json="$1" id="$2" esc iesc count
+  esc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  iesc="$(printf '%s' "$id" | sed "s/'/''/g")"
+  count="$(sqlite3 :memory: "SELECT count(*) FROM json_each('$esc','\$.result.layout.panes') WHERE json_extract(value,'\$.pane_id')='$iesc'" 2>/dev/null)" \
+    || return 1
+  [ "$count" = 1 ]
+}
+
+terminal_arrange() {
+  local source="$1" intent="$2" target="$3" layout source_layout state rc=0 tab first second temporary_tab
+  command -v herdr >/dev/null 2>&1 || { echo runtime_error; return 10; }
+  _herdr_pane_id_ok "$source" && _herdr_pane_id_ok "$target" || { echo unsupported; return 13; }
+  case "$intent" in place_below|place_right) : ;; *) echo unsupported; return 13 ;; esac
+  layout="$(herdr pane layout --pane "$target" 2>/dev/null)" || rc=$?
+  [ "$rc" -eq 0 ] && [ -n "$layout" ] || { echo runtime_error; return 10; }
+  rc=0
+  state="$(_herdr_arrange_state "$layout" "$source" "$intent" "$target")" || rc=$?
+  case "$state" in
+    unchanged) echo unchanged; return 0 ;;
+    ambiguous_layout) echo ambiguous_layout; return 12 ;;
+    different) : ;;
+    source_missing)
+      # `pane layout --pane TARGET` only describes TARGET's tab. A source in a
+      # different tab is therefore absent from that response, but is still a
+      # valid move candidate. Ask the source itself before treating absence as
+      # "different"; an unanswered or malformed lookup remains unknown.
+      rc=0
+      source_layout="$(herdr pane layout --pane "$source" 2>/dev/null)" || rc=$?
+      [ "$rc" -eq 0 ] && [ -n "$source_layout" ] && _herdr_layout_has_pane "$source_layout" "$source" \
+        || { echo unknown; return 10; }
+      ;;
+    unknown) echo unknown; return 10 ;;
+    *) echo runtime_error; [ "$rc" -ne 0 ] && return "$rc"; return 10 ;;
+  esac
+  tab="$(sqlite3 :memory: "SELECT json_extract('$(printf '%s' "$layout" | sed "s/'/''/g")','\$.result.layout.tab_id')" 2>/dev/null)" \
+    || { echo runtime_error; return 10; }
+  [ -n "$tab" ] || { echo runtime_error; return 10; }
+  first="$(herdr pane move "$source" --new-tab --no-focus 2>/dev/null)" || { echo runtime_error; echo "herdr: failed before moving '$source' to a temporary tab" >&2; return 12; }
+  _herdr_move_changed "$first" || { echo runtime_error; echo "herdr: the temporary-tab move for '$source' did not report changed=true" >&2; return 12; }
+  temporary_tab="$(_herdr_move_created_tab "$first")" || temporary_tab=""
+  [ -n "$temporary_tab" ] || temporary_tab='<new tab id unavailable>'
+  case "$intent" in
+    place_below) second="$(herdr pane move "$source" --tab "$tab" --split down --target-pane "$target" --no-focus 2>/dev/null)" ;;
+    place_right) second="$(herdr pane move "$source" --tab "$tab" --split right --target-pane "$target" --no-focus 2>/dev/null)" ;;
+  esac || {
+    echo runtime_error
+    echo "herdr: '$source' is left in temporary tab '$temporary_tab': placing it back in tab '$tab' relative to '$target' failed" >&2
+    return 12
+  }
+  _herdr_move_changed "$second" || {
+    echo runtime_error
+    echo "herdr: '$source' may be left in temporary tab '$temporary_tab': the move back to tab '$tab' did not report changed=true" >&2
+    return 12
+  }
+  echo moved
   return 0
 }
 

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -403,6 +403,62 @@ terminal_spawn() {
 }
 
 # control op: close the herdr pane named by the bare id.
+# Is the recorded pane still there? READ ONLY — `agent list` and nothing else.
+#
+# Same reason as the tmux driver's: `terminal_despawn` collapses "already closed"
+# and "could not close" into 13, so it cannot tell a caller whether a graceful
+# teardown worked.
+#
+#   present / 0    the id appears in the list
+#   gone    / 0    the list answered, validly, and the id is not in it
+#   unknown / 10   herdr could not be reached, or answered something unreadable
+#
+# `gone` is a claim about the WHOLE list, so it is only made after the list has
+# been PROVEN readable — exit-0 bytes are not proof. Anything short of that is
+# `unknown`, because the caller deletes the placement record on `gone` alone.
+#
+# The read-and-validate preamble is deliberately the same shape as
+# `_herdr_pane_for_session` above and is NOT yet factored out of it: that
+# function is under review for a release block. Two copies of a preamble is a
+# thing to fix, not to leave unnamed — noted here so the next reader knows it is
+# known rather than accidental.
+terminal_pane_state() {
+  local id="$1" json rc=0
+  command -v herdr >/dev/null 2>&1 || { echo unknown; return 10; }
+  json="$(herdr agent list 2>/dev/null)" || rc=$?
+  [ "$rc" -eq 0 ] || { echo unknown; return 10; }
+  [ -n "$json" ] || { echo unknown; return 10; }
+
+  local jesc valid vrc=0
+  jesc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  valid="$(sqlite3 :memory: "SELECT json_valid('$jesc')" 2>/dev/null)" || vrc=$?
+  [ "$vrc" -eq 0 ] || { echo unknown; return 10; }
+  [ "$valid" = 1 ] || { echo unknown; return 10; }
+
+  local iesc q jtype jtrc hit hrc
+  iesc="$(printf '%s' "$id" | sed "s/'/''/g")"
+  for q in '$.result.agents' '$' '$.agents' '$.result'; do
+    jtrc=0
+    jtype="$(sqlite3 :memory: "SELECT json_type('$jesc', '$q')" 2>/dev/null)" || jtrc=$?
+    [ "$jtrc" -eq 0 ] || { echo unknown; return 10; }
+    [ "$jtype" = array ] || continue
+    hrc=0
+    hit="$(sqlite3 :memory: "
+      SELECT EXISTS(
+        SELECT 1 FROM json_each('$jesc', '$q')
+         WHERE json_extract(value, '\$.pane_id') = '$iesc'
+      );" 2>/dev/null)" || hrc=$?
+    [ "$hrc" -eq 0 ] || { echo unknown; return 10; }
+    if [ "$hit" = 1 ]; then echo present; return 0; fi
+    echo gone
+    return 0
+  done
+  # No array at any candidate path: the list was readable JSON but not a shape
+  # this driver knows, which is "could not answer", not "not in it".
+  echo unknown
+  return 10
+}
+
 terminal_despawn() {
   local id="$1"
   herdr pane close "$id" >/dev/null 2>&1 || { echo runtime_error; return 13; }

--- a/scripts/drivers/terminals/herdr/terminal.conf
+++ b/scripts/drivers/terminals/herdr/terminal.conf
@@ -5,4 +5,4 @@
 # (the inherited HERDR_PANE_ID is NOT trusted — measured 2026-08-29).
 name=herdr
 backend=herdr pane
-capabilities=spawn despawn peek poke name
+capabilities=spawn despawn peek poke where arrange name

--- a/scripts/drivers/terminals/plain/ops.sh
+++ b/scripts/drivers/terminals/plain/ops.sh
@@ -99,6 +99,11 @@ terminal_spawn() {
 # is '-'), so there is nothing to kill from here — it closes when its process
 # exits, exactly as before the axis (OS-terminal members were never force-
 # killable). Report ok (nothing to tear down) rather than a spurious error.
+# plain has no addressable pane, so it cannot be asked whether one is still
+# there. 13 is that answer, and it is a real answer rather than a failure — the
+# caller must not read it as "closed".
+terminal_pane_state() { echo unknown; return 13; }
+
 terminal_despawn() { echo ok; return 0; }
 
 _plain_unsupported() {

--- a/scripts/drivers/terminals/plain/ops.sh
+++ b/scripts/drivers/terminals/plain/ops.sh
@@ -19,6 +19,18 @@ terminal_describe() {
   printf 'capabilities=spawn despawn\n'
 }
 
+terminal_where() {
+  echo unsupported
+  echo "plain: no addressable pane has a container" >&2
+  return 13
+}
+
+terminal_arrange() {
+  echo unsupported
+  echo "plain: no addressable panes can be arranged" >&2
+  return 13
+}
+
 # record op: the fallback always "matches" but has no addressable pane, so the
 # self id is '-'. Detection order puts plain last.
 terminal_detect() { printf '%s\n' '-'; return 0; }

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -16,7 +16,82 @@ terminal_check() {
 terminal_describe() {
   printf 'name=tmux\n'
   printf 'backend=tmux pane/window\n'
-  printf 'capabilities=spawn despawn peek poke name\n'
+  printf 'capabilities=spawn despawn peek poke where arrange name\n'
+  printf 'syntax_help=tmux list-commands\n'
+  printf 'intent.place_below=tmux move-pane -s SOURCE -t TARGET -v\n'
+  printf 'intent.place_right=tmux move-pane -s SOURCE -t TARGET -h\n'
+}
+
+# READ op: print the window containing <id>. This answers WHERE only. In
+# particular it must never print `gone`: terminal_pane_state is the sole
+# authority for existence, and a pane that vanishes after that positive check is
+# an unanswered location query, not a second proof of absence.
+terminal_where() {
+  local id="$1" bare out container
+  command -v tmux >/dev/null 2>&1 || { echo unknown; return 10; }
+  bare="$(_tmux_bare_of "$id")"
+  # A window placement (@N) is its own container. Public where has already
+  # established presence through terminal_pane_state before asking this op.
+  case "$bare" in @*) printf '%s\n' "$bare"; return 0 ;; %*) : ;; *) echo unsupported; return 13 ;; esac
+  out="$(_tmux_do "$id" list-panes -a -F '#{pane_id}|#{window_id}' 2>/dev/null)" \
+    || { echo unknown; return 10; }
+  container="$(printf '%s\n' "$out" | awk -F '|' -v id="$bare" '$1 == id { print $2; exit }')"
+  if [ -z "$container" ]; then
+    echo unknown
+    echo "tmux: pane '$id' was present immediately before location lookup, but its window could not be resolved" >&2
+    return 10
+  fi
+  printf '%s\n' "$container"
+  return 0
+}
+
+# True iff source already occupies the exact split that the native move would
+# create. tmux exposes geometry, not a split tree, so this is intentionally a
+# visible-rectangle predicate. The +1 is tmux's separator cell.
+_tmux_arranged() {
+  local intent="$1" st="$2" sl="$3" sw="$4" sh="$5" tt="$6" tl="$7" tw="$8" th="$9"
+  case "$intent" in
+    place_below) [ "$sl" -eq "$tl" ] && [ "$sw" -eq "$tw" ] && [ "$st" -eq $((tt + th + 1)) ] ;;
+    place_right) [ "$st" -eq "$tt" ] && [ "$sh" -eq "$th" ] && [ "$sl" -eq $((tl + tw + 1)) ] ;;
+    *) return 2 ;;
+  esac
+}
+
+_tmux_layout_numbers_ok() {
+  local value
+  for value in "$@"; do case "$value" in ''|*[!0-9]*) return 1 ;; esac; done
+  return 0
+}
+
+terminal_arrange() {
+  local source="$1" intent="$2" target="$3" out srow trow
+  local source_sock target_sock source_bare target_bare
+  local sid swin st sl sw sh tid twin tt tl tw th
+  command -v tmux >/dev/null 2>&1 || { echo runtime_error; return 10; }
+  source_sock="$(_tmux_sock_of "$source")"
+  target_sock="$(_tmux_sock_of "$target")"
+  source_bare="$(_tmux_bare_of "$source")"
+  target_bare="$(_tmux_bare_of "$target")"
+  [ "$source_sock" = "$target_sock" ] || { echo unsupported; return 13; }
+  case "$source_bare:$target_bare" in %*:%*) : ;; *) echo unsupported; return 13 ;; esac
+  case "$intent" in place_below|place_right) : ;; *) echo unsupported; return 13 ;; esac
+  out="$(_tmux_do "$source" list-panes -a -F '#{pane_id}|#{window_id}|#{pane_top}|#{pane_left}|#{pane_width}|#{pane_height}' 2>/dev/null)" \
+    || { echo runtime_error; return 10; }
+  srow="$(printf '%s\n' "$out" | awk -F '|' -v id="$source_bare" '$1 == id { print; exit }')"
+  trow="$(printf '%s\n' "$out" | awk -F '|' -v id="$target_bare" '$1 == id { print; exit }')"
+  [ -n "$srow" ] && [ -n "$trow" ] || { echo unknown; return 10; }
+  IFS='|' read -r sid swin st sl sw sh <<< "$srow"
+  IFS='|' read -r tid twin tt tl tw th <<< "$trow"
+  _tmux_layout_numbers_ok "$st" "$sl" "$sw" "$sh" "$tt" "$tl" "$tw" "$th" \
+    || { echo runtime_error; return 10; }
+  [ "$swin" = "$twin" ] && _tmux_arranged "$intent" "$st" "$sl" "$sw" "$sh" "$tt" "$tl" "$tw" "$th" \
+    && { echo unchanged; return 0; }
+  case "$intent" in
+    place_below) _tmux_do "$source" move-pane -s "$source_bare" -t "$target_bare" -v >/dev/null 2>&1 ;;
+    place_right) _tmux_do "$source" move-pane -s "$source_bare" -t "$target_bare" -h >/dev/null 2>&1 ;;
+  esac || { echo runtime_error; return 12; }
+  echo moved
+  return 0
 }
 
 # record op: report TWO facts and decide nothing (tl 2026-08-31). PRESENCE — are

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -30,11 +30,40 @@ terminal_describe() {
 terminal_detect() {
   [ -n "${TMUX:-}" ] || return 1
   if [ -n "${TMUX_PANE:-}" ]; then
-    printf '%s\n' "$TMUX_PANE"
+    # `<socket>:<pane>`, so whatever records this can later ask the RIGHT server.
+    # $TMUX is "<socket-path>,<pid>,<session>"; the first field is the socket.
+    printf '%s:%s\n' "${TMUX%%,*}" "$TMUX_PANE"
   else
     echo "tmux: \$TMUX_PANE is unset — cannot identify this pane" >&2
   fi
   return 0
+}
+
+# A tmux id may carry the SERVER it belongs to: `<socket-path>:%1`, or a bare
+# `%1` for a record written before this existed.
+#
+# It has to, because a pane id is not unique across servers — measured: two
+# throwaway servers both had `%0`, and each answered "yes, I know %0" about the
+# other's pane. Without the socket, "is this pane still there?" cannot be asked
+# of the right authority, and a wrong answer deletes the placement record (#1051).
+#
+# The socket must be SPLIT OFF before the id reaches `-t`, never passed through:
+# measured, `tmux kill-pane -t '<socket>:%0'` is read as session:window, prints
+# "can't find window: %0" and closes NOTHING. Silent no-op, not a wrong kill —
+# but a teardown that did nothing while looking like it ran is exactly this
+# issue's shape.
+#
+# Split on the LAST colon: a socket path may contain one.
+_tmux_sock_of() { case "$1" in *:*) printf '%s' "${1%:*}" ;; *) printf '' ;; esac; }
+_tmux_bare_of() { printf '%s' "${1##*:}"; }
+
+# Run tmux against the server that owns <id>. With no socket in the id this is
+# plain `tmux`, which is what a legacy record gets and what the ambient
+# environment decides — the honest behaviour for a ref that does not say.
+_tmux_do() {   # <id> <tmux args...>
+  local id="$1"; shift
+  local sock; sock="$(_tmux_sock_of "$id")"
+  if [ -n "$sock" ]; then tmux -S "$sock" "$@"; else tmux "$@"; fi
 }
 
 # Positive proof that a captured id is a tmux id of the expected KIND: a pane is
@@ -84,16 +113,83 @@ terminal_spawn() {
       ;;
     *) printf 'unsupported: unknown target: %s (window|pane-h|pane-v)\n' "$target" >&2; return 13 ;;
   esac
-  printf '%s\n' "$id"
+  # Socket-qualified, the same shape terminal_detect emits: whoever records this
+  # id must be able to ask the server that owns it, not whichever one they can
+  # reach. A spawn always happens from inside a tmux server, so $TMUX is set.
+  if [ -n "${TMUX:-}" ]; then
+    printf '%s:%s\n' "${TMUX%%,*}" "$id"
+  else
+    printf '%s\n' "$id"
+  fi
   return 0
 }
 
 # control op: kill the pane (%N) or window (@N) named by the bare id.
+# Is the recorded pane still there? READ ONLY — this never closes anything.
+#
+# It exists because `terminal_despawn` cannot answer the question. Measured on a
+# throwaway server: `kill-pane` returns 0 for a live pane and non-zero for one
+# that is already gone, and the driver maps both non-zeros to 13 — so "already
+# closed" and "could not close" arrive as the same value, and a graceful teardown
+# that succeeded would have to report needs-force.
+#
+# Prints a token and returns a code, like the other ops:
+#   present / 0    the id is in the terminal's own list
+#   gone    / 0    the list answered and the id is not in it
+#   unknown / 10   the terminal could not be reached to ask
+#   unknown / 13   the id is not one this terminal can be asked about
+#
+# "Could not ask" must never come back as 0: the caller deletes the placement
+# record — the only thing `--force` can work from — on `gone` alone.
+terminal_pane_state() {
+  local id="$1" out
+  command -v tmux >/dev/null 2>&1 \
+    || { echo unknown; return 10; }
+  # No socket in the id: a record written before refs carried one. The pane id
+  # alone cannot name an authority — two servers can both hold `%0` — so this
+  # cannot be answered, and saying `gone` here is what deletes a live member's
+  # record. An honest `unknown` sends the caller to --force instead (#1051).
+  local sock bare
+  sock="$(_tmux_sock_of "$id")"
+  bare="$(_tmux_bare_of "$id")"
+  [ -n "$sock" ] || { echo unknown; return 10; }
+
+  # The server that owned this pane is gone, so the pane is too — a pane does not
+  # outlive its server. This matters because it is the ORDINARY case: measured,
+  # killing a server's last pane ends the server, which is what folding a member
+  # that had its own window does, and without this the answer was `unknown`
+  # exactly when the teardown had worked.
+  #
+  # The discriminator is tmux SAYING SO, not the socket file: measured, the socket
+  # survives the server's exit, so its presence proves nothing. `no server running
+  # on <path>` is tmux telling us the server is not there, and only that sentence
+  # is taken as proof — every other failure stays `unknown`, because `gone` is
+  # what deletes the placement record and it must be earned.
+  local err="" out="" _rc=0
+  case "$bare" in
+    %*) out="$(_tmux_do "$id" list-panes  -a -F '#{pane_id}'   2>/tmp/.agmsg-tmux-err.$$)" || _rc=$? ;;
+    @*) out="$(_tmux_do "$id" list-windows -a -F '#{window_id}' 2>/tmp/.agmsg-tmux-err.$$)" || _rc=$? ;;
+    *)  rm -f "/tmp/.agmsg-tmux-err.$$" 2>/dev/null; echo unknown; return 13 ;;
+  esac
+  err="$(cat "/tmp/.agmsg-tmux-err.$$" 2>/dev/null)"
+  rm -f "/tmp/.agmsg-tmux-err.$$" 2>/dev/null
+  if [ "$_rc" -ne 0 ]; then
+    case "$err" in
+      *"no server running"*) echo gone; return 0 ;;
+      *)                     echo unknown; return 10 ;;
+    esac
+  fi
+  if printf '%s\n' "$out" | grep -qx -- "$bare"; then echo present; return 0; fi
+  echo gone
+  return 0
+}
+
 terminal_despawn() {
   local id="$1"
-  case "$id" in
-    %*) tmux kill-pane   -t "$id" >/dev/null 2>&1 || { echo runtime_error; return 13; } ;;
-    @*) tmux kill-window -t "$id" >/dev/null 2>&1 || { echo runtime_error; return 13; } ;;
+  # The KIND is in the bare id; a socket-qualified id starts with the socket path.
+  case "$(_tmux_bare_of "$id")" in
+    %*) _tmux_do "$id" kill-pane   -t "$(_tmux_bare_of "$id")" >/dev/null 2>&1 || { echo runtime_error; return 13; } ;;
+    @*) _tmux_do "$id" kill-window -t "$(_tmux_bare_of "$id")" >/dev/null 2>&1 || { echo runtime_error; return 13; } ;;
     *)  printf 'unsupported: not a tmux pane/window id: %s\n' "$id" >&2; return 13 ;;
   esac
   echo ok
@@ -122,10 +218,10 @@ terminal_peek() {
   command -v tmux >/dev/null 2>&1 \
     || { echo "tmux: not on PATH — cannot reach the terminal to peek pane '$id'" >&2; return 10; }
   if [ -n "$lines" ]; then
-    tmux capture-pane -p -t "$id" -S "-$lines" \
+    _tmux_do "$id" capture-pane -p -t "$(_tmux_bare_of "$id")" -S "-$lines" \
       || { echo "tmux: could not capture pane '$id' (it may no longer exist)" >&2; return 12; }
   else
-    tmux capture-pane -p -t "$id" \
+    _tmux_do "$id" capture-pane -p -t "$(_tmux_bare_of "$id")" \
       || { echo "tmux: could not capture pane '$id' (it may no longer exist)" >&2; return 12; }
   fi
   return 0
@@ -145,10 +241,10 @@ terminal_poke() {
   # poke path at all (plain) — a tmux pane's transient loss must not borrow it.
   command -v tmux >/dev/null 2>&1 \
     || { echo runtime_error; echo "tmux: not on PATH — cannot reach the terminal to poke pane '$id'" >&2; return 10; }
-  tmux send-keys -l -t "$id" -- "$text" \
+  _tmux_do "$id" send-keys -l -t "$(_tmux_bare_of "$id")" -- "$text" \
     || { echo runtime_error; echo "tmux: could not send to pane '$id' (it may no longer exist)" >&2; return 12; }
   sleep 0.3 2>/dev/null || true
-  tmux send-keys -t "$id" Right Enter \
+  _tmux_do "$id" send-keys -t "$(_tmux_bare_of "$id")" Right Enter \
     || { echo runtime_error; echo "tmux: could not send Enter to pane '$id' (it may no longer exist)" >&2; return 12; }
   echo ok
   return 0
@@ -166,11 +262,11 @@ terminal_poke() {
 terminal_name() {
   local id="$1" team="$2" name="$3" mode="${4:-}" label
   label="$team:$name"
-  tmux set-option -p -t "$id" @agmsg_agent "$label" >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  _tmux_do "$id" set-option -p -t "$(_tmux_bare_of "$id")" @agmsg_agent "$label" >/dev/null 2>&1 || { echo runtime_error; return 13; }
   if [ "$mode" = key ]; then echo ok; return 0; fi
-  case "$id" in
-    @*) tmux rename-window -t "$id" "$label" >/dev/null 2>&1 || true ;;
-    *)  tmux select-pane  -t "$id" -T "$label" >/dev/null 2>&1 || true ;;
+  case "$(_tmux_bare_of "$id")" in
+    @*) _tmux_do "$id" rename-window -t "$(_tmux_bare_of "$id")" "$label" >/dev/null 2>&1 || true ;;
+    *)  _tmux_do "$id" select-pane  -t "$(_tmux_bare_of "$id")" -T "$label" >/dev/null 2>&1 || true ;;
   esac
   echo ok
   return 0

--- a/scripts/drivers/terminals/tmux/terminal.conf
+++ b/scripts/drivers/terminals/tmux/terminal.conf
@@ -4,4 +4,4 @@
 # pane. Detection is env-only ($TMUX / $TMUX_PANE).
 name=tmux
 backend=tmux pane/window
-capabilities=spawn despawn peek poke name
+capabilities=spawn despawn peek poke where arrange name

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -137,6 +137,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -229,6 +229,11 @@ If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --for
    - `--force`: skips the message and tears the member down from the placement recorded at spawn time — kills its tmux pane/window and drops its registration. Use when the member's watcher can't respond.
 3. Show the script's output. Do NOT TaskStop or relaunch this session's own Monitor — despawn affects the spawned member, not this session's subscription.
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -166,6 +166,11 @@ If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --for
    - `--force`: skips the message and tears the member down from the placement recorded at spawn time — kills its tmux pane/window and drops its registration.
 3. Show the script's output.
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -137,6 +137,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -136,6 +136,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -137,6 +137,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -167,6 +167,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
    - persistent: true
 5. Tell the user: "Dropped role `<name>` from this project."
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -125,6 +125,11 @@ If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex re
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
 3. Show the script's output.
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -160,6 +160,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
    - description: `agmsg inbox stream`
 5. Tell the user: "Dropped role `<name>` from this project."
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -37,6 +37,15 @@
 #                                       `gone` alone, and `terminal_despawn`
 #                                       cannot answer this (it collapses "already
 #                                       closed" and "could not close" into 13).
+#   terminal_where <id>                 READ op: print the id's container (tmux window /
+#                                       herdr tab). Existence is NOT answered here:
+#                                       terminal_pane_state is the only op allowed to say
+#                                       `gone`; a present-then-missing race is unknown/10.
+#   terminal_arrange <source-id> <intent> <target-id>
+#                                       control op: declaratively place source below/right
+#                                       of target. Prints moved / unchanged. It reads layout
+#                                       before mutating because the native moves are not
+#                                       idempotent. Ambiguous layout -> token + non-zero.
 #   terminal_name <id> <team> <name> [mode]
 #                                       control op: set the pane's names; idempotent.
 #                                       Two names, not one: the label a person
@@ -126,7 +135,7 @@ agmsg_terminal_has() {
 # verifies it. Naming the set here (not relying on each driver being complete) is
 # what makes a missing op FAIL rather than silently borrow the previously loaded
 # driver's same-named function.
-_AGMSG_TERMINAL_REQUIRED="terminal_check terminal_describe terminal_detect terminal_spawn terminal_despawn terminal_pane_state terminal_peek terminal_poke terminal_name"
+_AGMSG_TERMINAL_REQUIRED="terminal_check terminal_describe terminal_detect terminal_spawn terminal_despawn terminal_pane_state terminal_peek terminal_poke terminal_where terminal_arrange terminal_name"
 
 # Wipe every terminal_* ABI function from the current shell. Called before each
 # source so a driver that is switched to cannot inherit the previous driver's ops
@@ -185,6 +194,41 @@ agmsg_terminal_load() {
     return 1
   fi
   _AGMSG_TERMINAL_LOADED="$name"
+}
+
+# Join the two terminal observations needed by team.sh after a driver is loaded.
+# Prints exactly two TAB-separated fields: <container> <live>. Neither is ever
+# empty. Existence has ONE authority: terminal_pane_state. terminal_where only
+# runs after present/0 and can make the container unknown, but can never revise
+# live to `gone`.
+agmsg_terminal_location_loaded() {
+  local id="$1" state="" container="" rc=0 reason
+  declare -F terminal_pane_state >/dev/null 2>&1 \
+    || { printf 'unknown:pane_state_unavailable\tunknown:pane_state_unavailable\n'; return 0; }
+  declare -F terminal_where >/dev/null 2>&1 \
+    || { printf 'unknown:where_unavailable\tunknown:where_unavailable\n'; return 0; }
+  state="$(terminal_pane_state "$id" 2>/dev/null)" || rc=$?
+  if [ "$rc" -ne 0 ] || [ "$state" = unknown ]; then
+    reason="pane_state_rc_${rc}"
+    printf 'unknown:%s\tunknown:%s\n' "$reason" "$reason"
+    return 0
+  fi
+  if [ "$state" = gone ]; then
+    printf 'n/a:pane_gone\tgone\n'
+    return 0
+  fi
+  if [ "$state" != present ]; then
+    printf 'unknown:unexpected_pane_state\tunknown:unexpected_pane_state\n'
+    return 0
+  fi
+  rc=0
+  container="$(terminal_where "$id" 2>/dev/null)" || rc=$?
+  if [ "$rc" -ne 0 ] || [ -z "$container" ] || [ "$container" = unknown ]; then
+    printf 'unknown:present_then_location_rc_%s\tpresent\n' "$rc"
+    return 0
+  fi
+  printf '%s\tpresent\n' "$container"
+  return 0
 }
 
 # Run <name>'s terminal_detect for <session_id> in a SUBSHELL so its terminal_*

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -27,6 +27,16 @@
 #   terminal_peek <id> [--lines N]      RECORD op: print visible pane text verbatim (NOT
 #                                       parsed). unsupported -> exit 13, reason on stderr.
 #   terminal_poke <id> <text>           control op: send text and submit. unsupported -> 13.
+#   terminal_pane_state <id>            READ ONLY: is that pane still there?
+#                                       Prints gone / present / unknown and
+#                                       returns 0 for a settled answer, 13 when
+#                                       this terminal has no addressable pane to
+#                                       ask about, 10 when it could not be
+#                                       reached. "Could not ask" never returns 0:
+#                                       a caller deletes the placement record on
+#                                       `gone` alone, and `terminal_despawn`
+#                                       cannot answer this (it collapses "already
+#                                       closed" and "could not close" into 13).
 #   terminal_name <id> <team> <name> [mode]
 #                                       control op: set the pane's names; idempotent.
 #                                       Two names, not one: the label a person
@@ -116,7 +126,7 @@ agmsg_terminal_has() {
 # verifies it. Naming the set here (not relying on each driver being complete) is
 # what makes a missing op FAIL rather than silently borrow the previously loaded
 # driver's same-named function.
-_AGMSG_TERMINAL_REQUIRED="terminal_check terminal_describe terminal_detect terminal_spawn terminal_despawn terminal_peek terminal_poke terminal_name"
+_AGMSG_TERMINAL_REQUIRED="terminal_check terminal_describe terminal_detect terminal_spawn terminal_despawn terminal_pane_state terminal_peek terminal_poke terminal_name"
 
 # Wipe every terminal_* ABI function from the current shell. Called before each
 # source so a driver that is switched to cannot inherit the previous driver's ops
@@ -339,6 +349,21 @@ _agmsg_terminal_id_ok() {   # <terminal> <id>
   local id="$2" rest
   case "$1" in
     tmux)
+      # Two accepted forms, and the older one is accepted on purpose:
+      #   <socket-path>:%N / <socket-path>:@N   written since refs carry the server
+      #   %N / @N                               a record written before they did
+      # A pane id is not unique across tmux servers (measured: two servers both
+      # holding %0), so the socket is what makes a ref answerable. The legacy form
+      # still resolves — it just cannot be asked "is it still there?" (#1051).
+      #
+      # Split on the LAST colon: a socket path may contain one.
+      local _sock=""
+      case "$id" in
+        *:*) _sock="${id%:*}"; id="${id##*:}"
+             [ -n "$_sock" ] || return 1
+             # No whitespace or control bytes in the path we would hand to `-S`.
+             case "$_sock" in *[[:space:]]*) return 1 ;; esac ;;
+      esac
       case "$id" in %*|@*) : ;; *) return 1 ;; esac
       rest="${id#?}"
       case "$rest" in ''|*[!0-9]*) return 1 ;; esac

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -161,9 +161,26 @@ esac
 # Pairs already reported as storeless, so the notice is once per process.
 NO_STORE_REPORTED=""
 
+# Two front doors onto one log.
+#
+# `watch_log` announces on stderr, which is right for a diagnostic nobody has to
+# act on. `watch_report` announces on STDOUT, for the ones an operator must see:
+# the shipped launcher runs the watcher with fd2 on /dev/null (#691, measured
+# while fixing #1045), so a teardown that failed and said so on stderr said so
+# nowhere. Same log file either way — the difference is only which channel the
+# person watching gets it on.
+watch_report() {
+  printf 'agmsg watch: %s\n' "$*"
+  _watch_log_file "$*"
+}
+
 watch_log() {
+  printf 'agmsg watch: %s\n' "$*" >&2
+  _watch_log_file "$*"
+}
+
+_watch_log_file() {
   local msg="$*" record size=0 bytes
-  printf 'agmsg watch: %s\n' "$msg" >&2
   mkdir -p "$RUN_DIR" 2>/dev/null || return 0
   # Built first, so the rotation decision can weigh what is actually going to
   # be appended rather than only what is already there.
@@ -225,6 +242,23 @@ watch_log() {
 # Silence is never the answer here: a pane that should have closed and did not
 # is exactly the state an operator cannot see. Every path that declines says
 # why, on stderr and in the watcher log.
+# Fold this session's own pane, and SAY WHICH of three things happened:
+#
+#   0  closed            the driver confirmed the pane is folded
+#   1  could-not-close   a pane was placed for this seat and this call did not
+#                        fold it — it may still be open
+#   2  nothing-to-close  nothing of ours was ever placed here (no record, or the
+#                        record names another session's pane)
+#
+# The channel follows the same split, and that is the rule rather than a habit:
+# 1 goes to STDOUT (`watch_report`) because an operator has a window to deal
+# with and the shipped launcher discards stderr (#691); 2 goes to stderr, because
+# there is nothing for anyone to do.
+#
+# Every branch used to `return 0`, including the one where the driver refused —
+# so the caller could not tell a folded pane from an open one, and reported
+# success either way (#1051). The failures also announced themselves only on
+# stderr, which the shipped launcher discards (#691), so they reached nobody.
 close_own_placement() {
   local team="$1" name="$2"
   local rec ref rec_term rec_id mine my_term my_id
@@ -236,17 +270,17 @@ close_own_placement() {
     # nothing here to close. Say so rather than exiting quietly, because the
     # same silence would also cover "the record was lost".
     watch_log "despawned '$name' (role dropped); no placement record for '$team/$name', so there is no pane to close from here — if a window remains it was not placed by agmsg; close it directly"
-    return 0
+    return 2
   fi
   IFS=$'\t' read -r ref _ _ < "$rec"
   if [ -z "$ref" ]; then
-    watch_log "despawned '$name' (role dropped); the placement record at $rec is empty, so the pane cannot be identified — close this window manually"
-    return 0
+    watch_report "despawned '$name' (role dropped); the placement record at $rec is empty, so the pane cannot be identified — close this window manually"
+    return 1
   fi
 
   if ! declare -F agmsg_terminal_ref_terminal >/dev/null 2>&1; then
-    watch_log "despawned '$name' (role dropped); the terminal registry is not available in this install, so the recorded pane cannot be closed — close this window manually"
-    return 0
+    watch_report "despawned '$name' (role dropped); the terminal registry is not available in this install, so the recorded pane cannot be closed — close this window manually"
+    return 1
   fi
 
   # The ref parser fails CLOSED (non-zero) on a corrupt/unknown-scheme ref. A bare
@@ -258,8 +292,8 @@ close_own_placement() {
   rec_term="$(agmsg_terminal_ref_terminal "$ref")" || rec_term=""
   rec_id="$(agmsg_terminal_ref_id "$ref")" || rec_id=""
   if [ -z "$rec_term" ] || [ -z "$rec_id" ]; then
-    watch_log "despawned '$name' (role dropped); the placement record's pane ref ($ref) did not resolve to a terminal and pane id, so the pane cannot be identified — close this window manually"
-    return 0
+    watch_report "despawned '$name' (role dropped); the placement record's pane ref ($ref) did not resolve to a terminal and pane id, so the pane cannot be identified — close this window manually"
+    return 1
   fi
 
   # Which pane is THIS process in, right now. resolve-for-name is the strict
@@ -285,26 +319,44 @@ close_own_placement() {
     mine="$(agmsg_terminal_resolve_name "$bare_sid" 2>/dev/null || true)"
   fi
   if [ -z "$mine" ]; then
-    watch_log "despawned '$name' (role dropped); this session cannot identify its own pane, so the recorded placement ($ref) is not provably ours and was left alone — close this window manually"
-    return 0
+    watch_report "despawned '$name' (role dropped); this session cannot identify its own pane, so the recorded placement ($ref) is not provably ours and was left alone — close this window manually"
+    return 1
   fi
   my_term="${mine%%	*}"
   my_id="${mine#*	}"
 
-  if [ "$my_term" != "$rec_term" ] || [ "$my_id" != "$rec_id" ]; then
+  # Compare at the precision BOTH sides have. A record written before refs
+  # carried the tmux socket says `%9`; this session now resolves itself as
+  # `<socket>:%9`, and a literal comparison calls its own pane someone else's —
+  # measured: the member stopped being able to fold itself. So when either side
+  # is missing the socket, compare the bare ids.
+  #
+  # That is the legacy ambiguity, not a new one: a bare `%9` cannot name a server
+  # (two servers can both hold it), and this is the same assumption the record
+  # has always carried. New records carry the socket and compare at full
+  # precision.
+  local _my_cmp="$my_id" _rec_cmp="$rec_id"
+  case "$my_id:$rec_id" in
+    *:*)
+      if [ "${my_id#*:}" = "$my_id" ] || [ "${rec_id#*:}" = "$rec_id" ]; then
+        _my_cmp="${my_id##*:}"; _rec_cmp="${rec_id##*:}"
+      fi ;;
+  esac
+  if [ "$my_term" != "$rec_term" ] || [ "$_my_cmp" != "$_rec_cmp" ]; then
     watch_log "despawned '$name' (role dropped); the placement record names $rec_term:$rec_id but this session is in $my_term:$my_id, so that pane belongs to someone else and was left alone — close this window manually"
-    return 0
+    return 2
   fi
 
   if ! agmsg_terminal_load "$rec_term" 2>/dev/null; then
-    watch_log "despawned '$name' (role dropped); the '$rec_term' terminal driver would not load, so the pane could not be closed — close this window manually"
-    return 0
+    watch_report "despawned '$name' (role dropped); the '$rec_term' terminal driver would not load, so the pane could not be closed — close this window manually"
+    return 1
   fi
   if ! terminal_despawn "$rec_id" >/dev/null 2>&1; then
     # 13 is the drivers' "unsupported" — plain has no addressable pane, so there
     # is genuinely nothing to close and the member must be told, not left with a
     # window it thinks was folded.
-    watch_log "despawned '$name' (role dropped); the '$rec_term' terminal did not close pane $rec_id — close this window manually"
+    watch_report "despawned '$name' (role dropped); the '$rec_term' terminal did not close pane $rec_id — close this window manually"
+    return 1
   fi
   return 0
 }
@@ -749,6 +801,11 @@ STUCK_THRESHOLD=3
 # delivery broke" can be told from "never started"; the value matters only that
 # it is non-zero and stable, which the tests pin.
 _AGMSG_EXIT_DELIVERY_UNHEALTHY=75
+# The watcher was told to fold itself, released its role, and the pane is STILL
+# THERE. Distinct from 75 (delivery is unhealthy) because the operator's next
+# move is different: the placement record is deliberately left in place and
+# `despawn --force` works from it.
+_AGMSG_EXIT_TEARDOWN_INCOMPLETE=76
 # Per-pair tracker state and its map operations (_stuck_get/_stuck_set/
 # _stuck_drop). Kept in a sourced lib so the record framing -- which broke for
 # names with spaces once and must not again -- can be unit-tested away from this
@@ -1017,7 +1074,14 @@ while true; do
     fi
     if [ -n "$DESPAWN_TARGET" ]; then
       "$SCRIPT_DIR/reset.sh" "$PROJECT_PATH" "$AGENT_TYPE" "$DESPAWN_TARGET" "$SESSION_ID" >/dev/null 2>&1 || true
-      close_own_placement "$pair_team" "$DESPAWN_TARGET"
+      # The status is used, not discarded: 1 means a pane of ours is still open.
+      # Nothing here deletes the placement record — that is what `--force` works
+      # from, and the caller now reads its presence rather than assuming.
+      _close_rc=0
+      close_own_placement "$pair_team" "$DESPAWN_TARGET" || _close_rc=$?
+      if [ "$_close_rc" -eq 1 ]; then
+        exit "$_AGMSG_EXIT_TEARDOWN_INCOMPLETE"
+      fi
       exit 0
     fi
     fi

--- a/tests/test_despawn.bats
+++ b/tests/test_despawn.bats
@@ -314,13 +314,18 @@ _despawn_member_with_env() {   # <bindir> <env assignments...>
 
   AGMSG_WATCH_INTERVAL=1 PATH="$bindir:$PATH" env "$@" \
     bash "$SCRIPTS/watch.sh" sess-m "$PROJ" claude-code alice \
-    >/dev/null 2>"$RUN/watch.err" 3>&- &
+    >"$RUN/watch.out" 2>"$RUN/watch.err" 3>&- &
   WPID=$!
   local i
   for i in 1 2 3 4 5 6 7 8 9 10; do [ -e "$RUN/ready.team__alice" ] && break; sleep 0.5; done
   [ -e "$RUN/ready.team__alice" ]
 
-  bash "$SCRIPTS/despawn.sh" team leader alice --timeout 10 >/dev/null 2>&1 || true
+  # The stub is the terminal for the CALLER too, not only for the watcher. The
+  # caller asks the terminal whether the pane is still there (#1051), and without
+  # this it asks whatever tmux happens to be on the machine — which answered
+  # `gone` about a pane id it had never heard of, and the record was deleted on
+  # that. Measured here before it was noticed anywhere else.
+  PATH="$bindir:$PATH" bash "$SCRIPTS/despawn.sh" team leader alice --timeout 10 >/dev/null 2>&1 || true
   for i in 1 2 3 4 5 6 7 8 9 10; do kill -0 "$WPID" 2>/dev/null || break; sleep 0.5; done
   kill "$WPID" 2>/dev/null || true; wait "$WPID" 2>/dev/null || true
 }
@@ -385,4 +390,81 @@ _despawn_member_with_env() {   # <bindir> <env assignments...>
     refute grep -Fq 'kill-pane -t %9' "$bin/tmux.log"
   fi
   grep -Fq 'belongs to someone else' "$RUN/watch.err"
+}
+
+# --- #1051: a teardown that did not fold the pane does not report success -----
+#
+# The dogfood that produced #1051: graceful despawn said `status=ok`, the pane
+# stayed open with the agent running, and `--force` then refused because the
+# graceful path had already deleted the record it works from. Three things had to
+# line up, and each gets a control here.
+#
+# The one that made it unrecoverable is the caller's: it treated "the actas lock
+# went free" as proof the pane was folded. The lock goes free when the watcher
+# lets go of it — before it tries to close anything, and also when its owner
+# simply died. Proof of one event was read as proof of another.
+
+# A `tmux` stub whose pane LIST still contains the pane after a kill: the shape
+# of "the close did not take". The kill is recorded so the test can prove it was
+# attempted, and the list is what `terminal_pane_state` reads.
+_stub_tmux_close_fails() {
+  local bin="$1"; mkdir -p "$bin"
+  cat > "$bin/tmux" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$bin/tmux.log"
+case "\$1" in
+  list-panes)   echo '%1' ;;   # still there, whatever we were asked to close
+  kill-pane)    exit 1 ;;
+  capture-pane) echo 'x' ;;
+esac
+exit 0
+EOF
+  chmod +x "$bin/tmux"
+}
+
+@test "despawn: graceful does not report ok when the pane is still open (#1051)" {
+  local bin="$BATS_TEST_TMPDIR/bin"
+  _stub_tmux_close_fails "$bin"
+  local rec; rec="$(_spawn_rec_path team alice)"
+  mkdir -p "$(dirname "$rec")"
+  printf 'tmux:%%1\t%s\tclaude-code\n' "$PROJ" > "$rec"
+
+  _despawn_member_with_env "$bin" TMUX=/tmp/fake-tmux-socket,0,0 TMUX_PANE=%1
+
+  # Positive control: the teardown really did try to close it. Without this the
+  # assertions below also pass for a run that never got that far.
+  grep -Fq 'kill-pane' "$bin/tmux.log"
+
+  # 1. The record — the only thing --force can work from — is KEPT.
+  [ -f "$rec" ]
+
+  # 2. The failure reached the channel an operator actually has. watch_log writes
+  #    to stderr and the shipped launcher runs the watcher with fd2 on /dev/null
+  #    (#691), so stderr alone is nowhere.
+  grep -Fq 'did not close pane' "$RUN/watch.out"
+}
+
+# NOTE ON WHICH BRANCH THIS COVERS. With no watcher the lock is free from the
+# start, so this exits through the PRE-EXISTING "no live actas lock, but a record
+# remains" branch and never reaches the post-teardown check added by #1051 —
+# measured: forcing that check to answer `gone` leaves this test green. It is a
+# control for the branch it does reach (the record survives a graceful attempt
+# that confirmed nothing), and the test above is the one that covers the new
+# code. Saying so because a name that implies the other branch is how a test gets
+# counted as coverage it does not provide.
+@test "despawn: a free lock with a record still reports needs-force (#1051, pre-existing branch)" {
+  local bin="$BATS_TEST_TMPDIR/bin"
+  _stub_tmux_close_fails "$bin"
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null
+  bash "$SCRIPTS/join.sh" team leader claude-code "$PROJ" >/dev/null
+  local rec; rec="$(_spawn_rec_path team alice)"
+  mkdir -p "$(dirname "$rec")"
+  printf 'tmux:%%1\t%s\tclaude-code\n' "$PROJ" > "$rec"
+
+  # No watcher at all: the lock is free from the start, which is exactly the
+  # state the caller used to read as "torn down". The pane, per the stub, is not.
+  run env PATH="$bin:$PATH" bash "$SCRIPTS/despawn.sh" team leader alice --timeout 2
+  [ "$status" -ne 0 ]
+  printf '%s' "$output" | grep -Fq 'needs-force'
+  [ -f "$rec" ]
 }

--- a/tests/test_peek_poke.bats
+++ b/tests/test_peek_poke.bats
@@ -44,6 +44,13 @@ _write_record() {
   printf '%s\t/tmp/project-a\tclaude-code' "$ref" > "$path"
 }
 
+_write_named_record() {
+  local name="$1" ref="$2" path
+  path="$(bash -c '. "'"$SKILL_DIR"'/scripts/lib/actas-lock.sh"; agmsg_spawn_path testteam "$1"' _ "$name")"
+  [ -n "$path" ]
+  printf '%s\t/tmp/project-a\tclaude-code' "$ref" > "$path"
+}
+
 _install_fake_tmux() {
   cat > "$FAKEBIN/tmux" <<EOF
 #!/usr/bin/env bash
@@ -464,4 +471,46 @@ EOF
   run env HERDR_ENV=1 bash "$SCRIPTS/poke.sh" testteam alice "hi"
   [ "$status" -eq 12 ]
   _out_has "could not poke 'testteam/alice'"
+}
+
+# --- arrange ---------------------------------------------------------------
+
+_install_fake_tmux_arrange() {
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = list-panes ]; then printf '%s\n' "\$TMUX_LAYOUT"; fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/tmux"; export PATH="$FAKEBIN:$PATH"
+}
+
+@test "arrange: a missing source record remains the final reason" {
+  _write_named_record bob 'tmux:%2'
+  run bash "$SCRIPTS/arrange.sh" testteam alice place_below bob
+  [ "$status" -ne 0 ]
+  [ "$output" = "arrange: no placement record for 'testteam/alice'" ]
+  refute _out_has "terminal '' cannot arrange"
+}
+
+@test "arrange: public identity join rejects different recorded terminals" {
+  _write_named_record alice 'tmux:%1'
+  _write_named_record bob 'herdr:wA:p2'
+  run bash "$SCRIPTS/arrange.sh" testteam alice place_below bob
+  [ "$status" -ne 0 ]
+  _out_has "members are in different terminals"
+}
+
+@test "arrange: public entry preserves unchanged and moved from the driver" {
+  _install_fake_tmux_arrange
+  _write_named_record alice 'tmux:%1'
+  _write_named_record bob 'tmux:%2'
+  export TMUX_LAYOUT=$'%1|@7|11|0|80|10\n%2|@7|0|0|80|10'
+  run bash "$SCRIPTS/arrange.sh" testteam alice place_below bob
+  [ "$status" -eq 0 ]
+  [ "$output" = unchanged ]
+  export TMUX_LAYOUT=$'%1|@7|0|0|40|10\n%2|@7|12|0|40|10'
+  run bash "$SCRIPTS/arrange.sh" testteam alice place_below bob
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
 }

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -1364,7 +1364,10 @@ T
   chmod 700 "$TEST_SKILL_DIR/run"                       # restore so teardown can clean up
   [ "$status" -ne 0 ]
   grep -q "status=spawned-but-unrecorded" <<<"$output"
-  grep -q "tmux:%9" <<<"$output"
+  # The ref names the server that owns the pane (#1051): $TMUX is "/tmp/fake,1,0",
+  # so the socket is /tmp/fake. A bare 'tmux:%9' would not identify which tmux
+  # server to ask, and %9 is not unique across servers.
+  grep -q "tmux:/tmp/fake:%9" <<<"$output"
 }
 
 @test "spawn: the plain driver's '-' protocol value never leaks to spawn stdout" {

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -170,12 +170,17 @@ _fake_herdr_list_scalar_session() {
   [ "$output" = "$(printf 'plain\t-')" ]
 }
 
-@test "resolve: picks tmux from \$TMUX and returns \$TMUX_PANE as the self id" {
+# The self id carries the SERVER, not just the pane: `<socket>:%N`. A pane id is
+# not unique across tmux servers (measured — two servers both holding %0), so an
+# id without its socket cannot be asked "are you still there?" of the right
+# authority, and a wrong answer deletes a live member's placement record (#1051).
+# $TMUX is "<socket-path>,<pid>,<session>"; the first field is the socket.
+@test "resolve: picks tmux from \$TMUX and returns socket-qualified \$TMUX_PANE (#1051)" {
   _install_fake_tmux
   export TMUX="/tmp/sock,1,0" TMUX_PANE="%4"
   run agmsg_terminal_resolve_name "sess-x"
   [ "$status" -eq 0 ]
-  [ "$output" = "$(printf 'tmux\t%%4')" ]
+  [ "$output" = "$(printf 'tmux\t/tmp/sock:%%4')" ]
 }
 
 @test "resolve: picks herdr from HERDR_ENV and resolves the pane from the session id" {
@@ -1081,7 +1086,7 @@ M
   export TMUX="/tmp/s,1,0" TMUX_PANE="%0"      # tmux present, has a pane
   run agmsg_terminal_resolve_name "sess-x"
   [ "$status" -eq 0 ]
-  [ "$output" = "$(printf 'tmux\t%%0')" ]
+  [ "$output" = "$(printf 'tmux\t/tmp/s:%%0')" ]
 }
 
 @test "resolve order: herdr broken AND no tmux pane -> FATAL with BOTH reasons, not silent plain" {
@@ -1138,7 +1143,7 @@ M
 
   # Positive control first: the pane WAS named, so a green result below cannot be
   # "the call did nothing".
-  grep -q 'tmux \[select-pane\]' "$ARGV_LOG" || grep -q 'tmux \[set-option\]' "$ARGV_LOG"
+  grep -q '\[select-pane\]' "$ARGV_LOG" || grep -q '\[set-option\]' "$ARGV_LOG"
 
   # `cmp`, not a captured string: command substitution strips trailing newlines,
   # so the string form cannot see a rewrite that changes only that. The sibling
@@ -1157,7 +1162,7 @@ M
   run agmsg_terminal_name_self "" seatteam bob /proj/B claude-code record
   [ "$status" -eq 0 ]
   [ -f "$rec" ]
-  grep -q 'tmux:%1' "$rec"
+  grep -q 'tmux:/tmp/fake:%1' "$rec"
 }
 
 @test "terminal_name_self: a failed record re-write leaves the EXISTING correct record intact (atomic)" {
@@ -1256,7 +1261,7 @@ M
   # Positive control FIRST: join reached the naming step and the pane really was
   # named. Without it a join that skipped naming altogether also leaves the record
   # alone, and this test would read that as the property holding.
-  grep -q 'tmux \[select-pane\]' "$ARGV_LOG" || grep -q 'tmux \[set-option\]' "$ARGV_LOG"
+  grep -q '\[select-pane\]' "$ARGV_LOG" || grep -q '\[set-option\]' "$ARGV_LOG"
 
   # The seat's placement is not join's to take. `cmp`, not `[ "$(cat …)" = … ]`:
   # command substitution strips every trailing newline, so the string form is
@@ -1290,7 +1295,12 @@ M
   [ "$status" -eq 0 ]
 
   # The key: still set, because it is addressing.
-  grep -Fq 'tmux [set-option] [-p] [-t] [%1] [@agmsg_agent] [offteam:alice]' "$ARGV_LOG"
+  # The op and its arguments. The line now leads with `[-S] [<socket>]` — every
+  # call is aimed at the server that owns the pane (#1051) — so anchoring on
+  # `tmux [set-option]` would be asserting the absence of that fix.
+  grep -Fq '[set-option] [-p] [-t] [%1] [@agmsg_agent] [offteam:alice]' "$ARGV_LOG"
+  # And the aim itself, which is the new behaviour worth pinning.
+  grep -Fq '[-S] [/tmp/fake]' "$ARGV_LOG"
   # The decoration: not set.
   refute grep -Fq 'select-pane' "$ARGV_LOG"
   refute grep -Fq 'rename-window' "$ARGV_LOG"
@@ -1434,4 +1444,131 @@ M
   # Nothing was renamed: no key could be built, so the member is not addressable
   # and saying `ok` would have claimed that it was.
   refute grep -Fq 'herdr [agent] [rename]' "$ARGV_LOG"
+}
+
+# --- a driver that is missing a required op does not load (#1051) -------------
+#
+# The registry has always refused a driver missing an ABI function; what it did
+# not have is anything that NOTICES when the required set grows. #1051 adds
+# `terminal_pane_state`, and the failure mode named when it was approved is
+# "someone adds an op and forgets to add it to `_AGMSG_TERMINAL_REQUIRED`" — a
+# hole that leaves the op optional in practice while the contract says otherwise.
+#
+# So this asserts the coupling in both directions:
+#   a driver missing the NEW op is refused  — the required set really includes it
+#   the refusal names the missing function  — an operator can act on it
+#   the shipped drivers all satisfy it      — the requirement is not vacuous
+@test "a driver missing terminal_pane_state is refused, by name (#1051)" {
+  local d="$TEST_SKILL_DIR/scripts/drivers/terminals/stubby"
+  mkdir -p "$d"
+  printf 'name=stubby\ncapabilities=\n' > "$d/terminal.conf"
+  # Every required op except the new one.
+  {
+    for fn in terminal_check terminal_describe terminal_detect terminal_spawn \
+              terminal_despawn terminal_peek terminal_poke terminal_name; do
+      printf '%s() { return 0; }\n' "$fn"
+    done
+  } > "$d/ops.sh"
+
+  run agmsg_terminal_load stubby
+  [ "$status" -ne 0 ]
+  printf '%s' "$output" | grep -Fq 'terminal_pane_state'
+
+  # Positive control: the same driver WITH the op loads. Without it, this test
+  # also passes when `agmsg_terminal_load` is broken for every input.
+  printf 'terminal_pane_state() { echo unknown; return 13; }\n' >> "$d/ops.sh"
+  run agmsg_terminal_load stubby
+  [ "$status" -eq 0 ]
+}
+
+@test "every shipped driver implements the required set (#1051)" {
+  local drv
+  for drv in tmux herdr plain; do
+    run agmsg_terminal_load "$drv"
+    [ "$status" -eq 0 ] || { echo "driver $drv failed to load: $output"; return 1; }
+  done
+}
+
+# --- terminal_pane_state: the three answers, and what earns each one (#1051) --
+#
+# `terminal_despawn` cannot answer "is that pane still there?": measured on a
+# throwaway server, `kill-pane` returns non-zero both for a pane already gone and
+# for one it could not close, and the driver maps both to 13. So a graceful
+# teardown that WORKED would have had to report needs-force.
+#
+# The answers are not symmetric in cost. `present` and `unknown` keep the
+# placement record; `gone` DELETES it, and that is the only irreversible one — so
+# `gone` has to be earned, and every uncertainty resolves to `unknown`.
+_fake_tmux_server() {   # <mode: alive|empty|noserver|broken>
+  local mode="$1"
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+# Skip the server selector the driver puts first, the way real tmux does.
+if [ "\$1" = -S ]; then shift 2; fi
+case "$mode" in
+  alive)    [ "\$1" = list-panes ] && echo '%1'; exit 0 ;;
+  empty)    [ "\$1" = list-panes ] && exit 0; exit 0 ;;
+  noserver) echo "no server running on /tmp/fake-sock" >&2; exit 1 ;;
+  broken)   echo "some other tmux failure" >&2; exit 1 ;;
+esac
+EOF
+  chmod +x "$FAKEBIN/tmux"
+  export PATH="$FAKEBIN:$PATH"
+}
+
+@test "pane_state: the pane is in its server's list -> present (#1051)" {
+  _fake_tmux_server alive
+  agmsg_terminal_load tmux
+  run terminal_pane_state "/tmp/fake-sock:%1"
+  [ "$status" -eq 0 ]
+  [ "$output" = present ]
+  # Asked the server the ref names, not whichever one was reachable.
+  grep -Fq '[-S] [/tmp/fake-sock]' "$ARGV_LOG"
+}
+
+@test "pane_state: the server answers and the pane is not in it -> gone (#1051)" {
+  _fake_tmux_server empty
+  agmsg_terminal_load tmux
+  run terminal_pane_state "/tmp/fake-sock:%1"
+  [ "$status" -eq 0 ]
+  [ "$output" = gone ]
+}
+
+@test "pane_state: the server is no longer running -> gone (#1051)" {
+  # The ordinary case for a member that had its own window: closing the last pane
+  # ends the server. Measured — without this the answer was `unknown` exactly
+  # when the teardown had worked. The discriminator is tmux SAYING so; the socket
+  # file survives the server's exit and proves nothing.
+  _fake_tmux_server noserver
+  agmsg_terminal_load tmux
+  run terminal_pane_state "/tmp/fake-sock:%1"
+  [ "$status" -eq 0 ]
+  [ "$output" = gone ]
+}
+
+@test "pane_state: any OTHER failure is unknown, not gone (#1051)" {
+  _fake_tmux_server broken
+  agmsg_terminal_load tmux
+  run terminal_pane_state "/tmp/fake-sock:%1"
+  [ "$status" -eq 10 ]
+  [ "$output" = unknown ]
+}
+
+@test "pane_state: an id with no socket cannot name an authority -> unknown (#1051)" {
+  # A record written before refs carried the server. Two servers can both hold
+  # `%1`, so there is no one to ask — and answering `gone` here is what deletes a
+  # live member's record.
+  _fake_tmux_server alive
+  agmsg_terminal_load tmux
+  run terminal_pane_state "%1"
+  [ "$status" -eq 10 ]
+  [ "$output" = unknown ]
+}
+
+@test "pane_state: plain says it cannot be asked, and that is not 'gone' (#1051)" {
+  agmsg_terminal_load plain
+  run terminal_pane_state "-"
+  [ "$status" -eq 13 ]
+  [ "$output" = unknown ]
 }

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -268,11 +268,87 @@ _fake_herdr_list_scalar_session() {
 # --- conf reader ------------------------------------------------------------
 
 @test "conf: get reads a key, has tests membership, absent key returns default" {
-  [ "$(agmsg_terminal_get tmux capabilities)" = "spawn despawn peek poke name" ]
+  [ "$(agmsg_terminal_get tmux capabilities)" = "spawn despawn peek poke where arrange name" ]
   agmsg_terminal_has tmux capabilities peek
   refute agmsg_terminal_has tmux capabilities nonesuch
   [ "$(agmsg_terminal_get plain capabilities)" = "spawn despawn" ]
   [ "$(agmsg_terminal_get plain nonesuch DEFLT)" = "DEFLT" ]
+}
+
+# terminal_pane_state is supplied by #1051. These contract stubs deliberately
+# isolate team/location branching from that implementation: only the promised
+# token + status pairs matter here.
+@test "location join: present/0 asks where and preserves the container" {
+  terminal_pane_state() { echo present; return 0; }
+  terminal_where() { case "$1" in '%1') echo '@7'; return 0 ;; *) return 1 ;; esac; }
+  run agmsg_terminal_location_loaded '%1'
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf '@7\tpresent')" ]
+}
+
+@test "location join: gone/0 is authoritative and never asks where" {
+  terminal_pane_state() { echo gone; return 0; }
+  terminal_where() { echo CALLED; return 0; }
+  run agmsg_terminal_location_loaded '%1'
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'n/a:pane_gone\tgone')" ]
+  refute grep -q CALLED <<<"$output"
+}
+
+@test "location join: unknown/10 stays unknown and never becomes gone" {
+  terminal_pane_state() { echo unknown; return 10; }
+  terminal_where() { echo CALLED; return 0; }
+  run agmsg_terminal_location_loaded '%1'
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'unknown:pane_state_rc_10\tunknown:pane_state_rc_10')" ]
+  refute grep -q gone <<<"$output"
+  refute grep -q CALLED <<<"$output"
+}
+
+@test "location join: unsupported/13 stays unknown, not absent" {
+  terminal_pane_state() { echo unknown; return 13; }
+  terminal_where() { echo CALLED; return 0; }
+  run agmsg_terminal_location_loaded '-'
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'unknown:pane_state_rc_13\tunknown:pane_state_rc_13')" ]
+}
+
+@test "location join: present then missing keeps live=present and only location unknown" {
+  terminal_pane_state() { echo present; return 0; }
+  terminal_where() { echo unknown; return 10; }
+  run agmsg_terminal_location_loaded '%1'
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'unknown:present_then_location_rc_10\tpresent')" ]
+  refute grep -q gone <<<"$output"
+}
+
+@test "tmux hint syntax_help: executes tmux list-commands" {
+  _install_fake_tmux
+  agmsg_terminal_load tmux
+  run terminal_describe
+  grep -q '^syntax_help=tmux list-commands$' <<<"$output"
+  grep -q '^intent.place_below=' <<<"$output"
+  grep -q '^intent.place_right=' <<<"$output"
+  tmux list-commands >/dev/null
+  grep -q '^tmux \[list-commands\]$' "$ARGV_LOG"
+}
+
+@test "herdr hint syntax_help: executes herdr --help" {
+  _install_fake_herdr 'sess-help'
+  agmsg_terminal_load herdr
+  run terminal_describe
+  grep -q '^syntax_help=herdr --help$' <<<"$output"
+  herdr --help >/dev/null
+  grep -q '^herdr \[--help\]$' "$ARGV_LOG"
+}
+
+@test "herdr hint skill_help: executes herdr --skill" {
+  _install_fake_herdr 'sess-help'
+  agmsg_terminal_load herdr
+  run terminal_describe
+  grep -q '^skill_help=herdr --skill$' <<<"$output"
+  herdr --skill >/dev/null
+  grep -q '^herdr \[--skill\]$' "$ARGV_LOG"
 }
 
 # --- plain driver -----------------------------------------------------------
@@ -426,6 +502,99 @@ EOF
   grep -q '\[rename-window\] \[-t\] \[@7\] \[teamx:alice\]' "$ARGV_LOG"
 }
 
+_install_fake_tmux_layout() {
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = -S ]; then shift 2; fi
+if [ "\$1" = list-panes ]; then printf '%s\n' "\${TMUX_LAYOUT:-}"; fi
+exit "\${TMUX_RC:-0}"
+EOF
+  chmod +x "$FAKEBIN/tmux"; export PATH="$FAKEBIN:$PATH"
+}
+
+@test "tmux: where answers the window only; a missing-after-present id is unknown, never gone" {
+  _install_fake_tmux_layout
+  export TMUX_LAYOUT='%1|@7|0|0|80|10'
+  agmsg_terminal_load tmux
+  run terminal_where '%1'
+  [ "$status" -eq 0 ]
+  [ "$output" = '@7' ]
+  run terminal_where '@7'
+  [ "$status" -eq 0 ]
+  [ "$output" = '@7' ]
+  run terminal_where '%9'
+  [ "$status" -eq 10 ]
+  printf '%s\n' "$output" | grep -q '^unknown'
+  refute grep -q '^gone$' <<<"$output"
+}
+
+@test "tmux hint place_below: gates the non-idempotent move, then executes move-pane -v" {
+  _install_fake_tmux_layout
+  agmsg_terminal_load tmux
+  terminal_describe | grep -q '^intent.place_below=tmux move-pane -s SOURCE -t TARGET -v$'
+  export TMUX_LAYOUT=$'%1|@7|11|0|80|10\n%2|@7|0|0|80|10'
+  run terminal_arrange '%1' place_below '%2'
+  [ "$status" -eq 0 ]
+  [ "$output" = unchanged ]
+  refute grep -q '\[move-pane\]' "$ARGV_LOG"
+  : > "$ARGV_LOG"
+  export TMUX_LAYOUT=$'%1|@7|0|0|40|10\n%2|@7|12|0|40|10'
+  run terminal_arrange '%1' place_below '%2'
+  [ "$output" = moved ]
+  grep -q '\[move-pane\] \[-s\] \[%1\] \[-t\] \[%2\] \[-v\]' "$ARGV_LOG"
+}
+
+@test "tmux hint place_right: gates the non-idempotent move, then executes move-pane -h" {
+  _install_fake_tmux_layout
+  agmsg_terminal_load tmux
+  terminal_describe | grep -q '^intent.place_right=tmux move-pane -s SOURCE -t TARGET -h$'
+  export TMUX_LAYOUT=$'%1|@7|0|41|39|23\n%2|@7|0|0|40|23'
+  run terminal_arrange '%1' place_right '%2'
+  [ "$status" -eq 0 ]
+  [ "$output" = unchanged ]
+  refute grep -q '\[move-pane\]' "$ARGV_LOG"
+  : > "$ARGV_LOG"
+  export TMUX_LAYOUT=$'%1|@7|12|0|40|10\n%2|@7|0|0|40|10'
+  run terminal_arrange '%1' place_right '%2'
+  [ "$output" = moved ]
+  grep -q '\[move-pane\] \[-s\] \[%1\] \[-t\] \[%2\] \[-h\]' "$ARGV_LOG"
+}
+
+@test "tmux: arrange cannot locate a listed pane -> unknown/10, not runtime_error" {
+  _install_fake_tmux_layout
+  agmsg_terminal_load tmux
+  export TMUX_LAYOUT='%2|@7|0|0|80|10'
+  run terminal_arrange '%1' place_below '%2'
+  [ "$status" -eq 10 ]
+  [ "$output" = unknown ]
+  refute grep -q '\[move-pane\]' "$ARGV_LOG"
+}
+
+@test "tmux: where and arrange query the socket recorded with the pane" {
+  _install_fake_tmux_layout
+  agmsg_terminal_load tmux
+  export TMUX_LAYOUT=$'%1|@7|0|0|40|10\n%2|@7|12|0|40|10'
+  run terminal_where '/tmp/agmsg.sock:%1'
+  [ "$status" -eq 0 ]
+  [ "$output" = '@7' ]
+  grep -q '^tmux \[-S\] \[/tmp/agmsg.sock\] \[list-panes\]' "$ARGV_LOG"
+  : > "$ARGV_LOG"
+  run terminal_arrange '/tmp/agmsg.sock:%1' place_below '/tmp/agmsg.sock:%2'
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  grep -q '^tmux \[-S\] \[/tmp/agmsg.sock\] \[move-pane\] \[-s\] \[%1\] \[-t\] \[%2\] \[-v\]' "$ARGV_LOG"
+}
+
+@test "tmux: arrange refuses panes from different servers without querying either" {
+  _install_fake_tmux_layout
+  agmsg_terminal_load tmux
+  run terminal_arrange '/tmp/one.sock:%1' place_below '/tmp/two.sock:%2'
+  [ "$status" -eq 13 ]
+  [ "$output" = unsupported ]
+  [ ! -s "$ARGV_LOG" ]
+}
+
 # --- herdr driver ops (fake herdr argv; live-verified argv flagged) ---------
 
 @test "herdr: detect resolves the pane for the session id via agent list" {
@@ -532,6 +701,145 @@ EOF
   # herdr's [a-z][a-z0-9_-]{0,31} regex. (Exact value is asserted for distinctness
   # in the injectivity test below, not pinned here.)
   grep -qE '\[agent\] \[rename\] \[wC:p9\] \[a[0-9a-f]{24}\]' "$ARGV_LOG"
+}
+
+_install_fake_herdr_layout() {
+  cat > "$FAKEBIN/herdr" <<EOF
+#!/usr/bin/env bash
+{ printf 'herdr'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1 \$2" = 'pane layout' ]; then
+  if [ -n "\${HERDR_SOURCE_LAYOUT:-}" ] && [ "\${4:-}" = 'wA:p1' ]; then printf '%s\n' "\$HERDR_SOURCE_LAYOUT"
+  else printf '%s\n' "\$HERDR_LAYOUT"
+  fi
+elif [ "\$1 \$2" = 'pane move' ]; then
+  case " \$* " in *' --tab '*) [ "\${HERDR_SECOND_RC:-0}" -eq 0 ] || exit "\$HERDR_SECOND_RC" ;; esac
+  case " \$* " in
+    *' --new-tab '*) printf '%s\n' '{"result":{"move_result":{"changed":true,"created_tab":{"tab_id":"wA:t9"}}}}' ;;
+    *) printf '%s\n' '{"result":{"move_result":{"changed":true}}}' ;;
+  esac
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/herdr"; export PATH="$FAKEBIN:$PATH"
+}
+
+@test "herdr: where answers the tab only and never becomes a second gone authority" {
+  _install_fake_herdr_layout
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t2","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":0,"width":10,"height":10}}],"splits":[]}}}'
+  agmsg_terminal_load herdr
+  run terminal_where 'wA:p1'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'wA:t2' ]
+  run terminal_where 'wA:p9'
+  [ "$status" -eq 10 ]
+  printf '%s\n' "$output" | grep -q '^unknown'
+  refute grep -q '^gone$' <<<"$output"
+}
+
+@test "herdr hint place_below: gates the move, then executes new-tab and split down" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  terminal_describe | grep -q '^intent.place_below=herdr pane move SOURCE --new-tab; herdr pane move SOURCE --tab CONTAINER --split down --target-pane TARGET$'
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":10,"width":20,"height":10}},{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":20,"height":10}}],"splits":[{"id":"opaque","direction":"down","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":20}}]}}}'
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = unchanged ]
+  refute grep -q '\[pane\] \[move\]' "$ARGV_LOG"
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":0,"width":10,"height":20}},{"pane_id":"wA:p2","rect":{"x":10,"y":0,"width":10,"height":20}}],"splits":[{"id":"opaque","direction":"right","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":20}}]}}}'
+  : > "$ARGV_LOG"
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$output" = moved ]
+  grep -q '\[pane\] \[move\] \[wA:p1\] \[--new-tab\] \[--no-focus\]' "$ARGV_LOG"
+  grep -q '\[--tab\] \[wA:t1\] \[--split\] \[down\] \[--target-pane\] \[wA:p2\]' "$ARGV_LOG"
+}
+
+@test "herdr hint place_right: gates the move, then executes new-tab and split right" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  terminal_describe | grep -q '^intent.place_right=herdr pane move SOURCE --new-tab; herdr pane move SOURCE --tab CONTAINER --split right --target-pane TARGET$'
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":10,"y":0,"width":10,"height":20}},{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":10,"height":20}}],"splits":[{"id":"opaque","direction":"right","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":20}}]}}}'
+  run terminal_arrange 'wA:p1' place_right 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = unchanged ]
+  refute grep -q '\[pane\] \[move\]' "$ARGV_LOG"
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":0,"width":20,"height":10}},{"pane_id":"wA:p2","rect":{"x":0,"y":10,"width":20,"height":10}}],"splits":[{"id":"opaque","direction":"down","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":20}}]}}}'
+  : > "$ARGV_LOG"
+  run terminal_arrange 'wA:p1' place_right 'wA:p2'
+  [ "$output" = moved ]
+  grep -q '\[pane\] \[move\] \[wA:p1\] \[--new-tab\] \[--no-focus\]' "$ARGV_LOG"
+  grep -q '\[--split\] \[right\]' "$ARGV_LOG"
+}
+
+@test "herdr: equal-area direction-compatible split candidates fail closed" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":1,"width":10,"height":1}},{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":10,"height":1}}],"splits":[{"id":"opaque-a","direction":"down","ratio":0.5,"rect":{"x":0,"y":0,"width":10,"height":2}},{"id":"opaque-b","direction":"down","ratio":0.5,"rect":{"x":0,"y":0,"width":10,"height":2}}]}}}'
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 12 ]
+  [ "$output" = ambiguous_layout ]
+  refute grep -q '\[pane\] \[move\]' "$ARGV_LOG"
+}
+
+@test "herdr: a pane below an intervening pane is different, not directly place_below" {
+  agmsg_terminal_load herdr
+  local layout='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":20,"width":20,"height":10}},{"pane_id":"wA:pX","rect":{"x":0,"y":10,"width":20,"height":10}},{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":20,"height":10}}],"splits":[{"id":"outer","direction":"down","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":30}},{"id":"inner","direction":"down","ratio":0.5,"rect":{"x":0,"y":10,"width":20,"height":20}}]}}}'
+  run _herdr_arrange_state "$layout" 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = different ]
+}
+
+@test "herdr: second arrange step failure says the source may be stranded in a temporary tab" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  export HERDR_SECOND_RC=1
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":0,"width":10,"height":20}},{"pane_id":"wA:p2","rect":{"x":10,"y":0,"width":10,"height":20}}],"splits":[{"id":"opaque","direction":"right","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":20}}]}}}'
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 12 ]
+  printf '%s\n' "$output" | grep -q '^runtime_error'
+  printf '%s\n' "$output" | grep -q "left in temporary tab 'wA:t9'"
+  printf '%s\n' "$output" | grep -q "placing it back in tab 'wA:t1'"
+}
+
+@test "herdr: arrange cannot locate a layout pane -> unknown/10, not runtime_error" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":20,"height":20}}],"splits":[]}}}'
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 10 ]
+  [ "$output" = unknown ]
+  refute grep -q '\[pane\] \[move\]' "$ARGV_LOG"
+}
+
+@test "herdr: arrange moves a source proven present in a different tab" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":20,"height":20}}],"splits":[]}}}'
+  export HERDR_SOURCE_LAYOUT='{"result":{"layout":{"tab_id":"wA:t2","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":0,"width":20,"height":20}}],"splits":[]}}}'
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  [ "$(grep -c '\[pane\] \[layout\]' "$ARGV_LOG")" -eq 2 ]
+  grep -q '\[pane\] \[move\] \[wA:p1\] \[--new-tab\]' "$ARGV_LOG"
+  grep -q '\[--tab\] \[wA:t1\] \[--split\] \[down\] \[--target-pane\] \[wA:p2\]' "$ARGV_LOG"
+}
+
+@test "arrange meaning: both tmux and herdr move when another pane separates source from target" {
+  _install_fake_tmux_layout
+  agmsg_terminal_load tmux
+  export TMUX_LAYOUT=$'%1|@7|22|0|80|10\n%X|@7|11|0|80|10\n%2|@7|0|0|80|10'
+  run terminal_arrange '%1' place_below '%2'
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  grep -q '\[move-pane\]' "$ARGV_LOG"
+
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":20,"width":20,"height":10}},{"pane_id":"wA:pX","rect":{"x":0,"y":10,"width":20,"height":10}},{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":20,"height":10}}],"splits":[{"id":"outer","direction":"down","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":30}},{"id":"inner","direction":"down","ratio":0.5,"rect":{"x":0,"y":10,"width":20,"height":20}}]}}}'
+  : > "$ARGV_LOG"
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  grep -q '\[pane\] \[move\]' "$ARGV_LOG"
 }
 
 @test "herdr peek: an error body is NOT returned as content, and the single 13 is split (tl/co1)" {
@@ -1465,7 +1773,8 @@ M
   # Every required op except the new one.
   {
     for fn in terminal_check terminal_describe terminal_detect terminal_spawn \
-              terminal_despawn terminal_peek terminal_poke terminal_name; do
+              terminal_despawn terminal_peek terminal_poke terminal_where \
+              terminal_arrange terminal_name; do
       printf '%s() { return 0; }\n' "$fn"
     done
   } > "$d/ops.sh"

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -170,6 +170,15 @@ write_node_launcher_fixtures() {
   grep -Fq 'To mint a replacement epoch instead:' "$BATS_TEST_DIRNAME/../scripts/key.sh"
 }
 
+@test "every agent template exposes declarative arrange without adding a public where verb" {
+  local template
+  for template in "$SCRIPTS"/drivers/types/*/template.md; do
+    grep -q 'scripts/arrange\.sh <team> <agent> <intent> <anchor-agent>' "$template"
+    grep -q '`moved` as a performed move and `unchanged`' "$template"
+    [ "$(grep -c 'If argument starts with "where"' "$template" || true)" -eq 0 ]
+  done
+}
+
 @test "type-registry: spawnable set is exactly eight of the ten built-ins (#277, #279)" {
   # hermes deliberately stays out (#279): no known CLI mode starts it
   # interactive with a seeded initial prompt. agmsg-app also stays out: it's

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -1007,6 +1007,7 @@ _record_handover_events() {
   {
     printf '%s\n' 'set -u'
     printf '%s\n' 'watch_log() { printf "%s\n" "$*" >> "$WLOG"; }'
+    printf '%s\n' 'watch_report() { printf "%s\n" "$*" >> "$WREPORT"; }'
     printf '%s\n' '. "$SCRIPTS/lib/actas-lock.sh"'
     printf '%s\n' '. "$SCRIPTS/lib/terminal-registry.sh"'
     awk '/^close_own_placement\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$SCRIPTS/watch.sh"
@@ -1019,11 +1020,19 @@ _record_handover_events() {
   printf 'bogus:xyz\t/tmp/p\tclaude-code' > "$rec"
 
   export WLOG="$TEST_SKILL_DIR/wlog"; : > "$WLOG"
+  export WREPORT="$TEST_SKILL_DIR/wreport"; : > "$WREPORT"
   # SESSION_ID is referenced only past the ref guard; the guard returns before it.
-  SESSION_ID=irrelevant bash -c '. "'"$shim"'"; close_own_placement wt carol'
-  grep -q "did not resolve to a terminal and pane id" "$WLOG"
+  run env SESSION_ID=irrelevant bash -c '. "'"$shim"'"; close_own_placement wt carol'
+  # A pane that may still be open is the operator's problem, so it is a REPORT
+  # (stdout), not a log (stderr): the shipped launcher runs the watcher with fd2
+  # on /dev/null (#691), so this text on stderr would be text nobody ever sees.
+  # 1 = "a placed pane may still be open", distinct from 2 = "nothing of ours".
+  [ "$status" -eq 1 ]
+  grep -q "did not resolve to a terminal and pane id" "$WREPORT"
+  refute grep -q "did not resolve to a terminal and pane id" "$WLOG"
   # must NOT reach the "belongs to someone else" fallthrough with an empty recorded side
   refute grep -q "belongs to someone else" "$WLOG"
+  refute grep -q "belongs to someone else" "$WREPORT"
 }
 
 @test "watch: a backlog past the argv ceiling still delivers (#1045/#777, stdin)" {


### PR DESCRIPTION
## Summary

- add declarative `place_below` and `place_right` terminal intents with idempotent layout gates
- add a public `arrange.sh` entry point that joins member placement records before dispatching to the terminal driver
- add internal terminal location observation for team status while keeping `terminal_pane_state` as the only authority allowed to report `gone`
- point terminal descriptions at native syntax/help and cover every advertised recipe with an argv test

## Driver behavior

| Driver | `place_below` | `place_right` |
| --- | --- | --- |
| tmux | one `move-pane -v` call | one `move-pane -h` call |
| herdr | move to a temporary tab, then split `down` into the original tab | move to a temporary tab, then split `right` into the original tab |
| plain | unsupported | unsupported |

Both mutating drivers inspect the current layout first and return `unchanged` without invoking the native move when the requested direct adjacency already exists.

## Dependency

This branch includes PR #1058 as its first commit because location observation depends on `terminal_pane_state` and socket-qualified tmux placement references. After #1058 lands in the integration branch, that commit can be dropped by rebasing.

## Verification

- `bats tests/test_terminal_registry.bats tests/test_peek_poke.bats tests/test_type_registry.bats tests/test_claude_template.bats tests/test_despawn.bats tests/test_spawn.bats tests/test_watch.bats` (299 tests)
- `bash .github/scripts/check-enforced-assertions.sh`
- `bash -n scripts/arrange.sh scripts/lib/terminal-registry.sh scripts/drivers/terminals/tmux/ops.sh scripts/drivers/terminals/herdr/ops.sh scripts/drivers/terminals/plain/ops.sh`