### PR TITLE
feat(terminals): arrange panes by declarative intent

### DIFF
--- a/scripts/arrange.sh
+++ b/scripts/arrange.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Declaratively place one member's pane relative to another member's pane.
+# Identity/placement resolution belongs here; terminal drivers receive ids only.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/terminal-registry.sh"
+
+die() { echo "arrange: $*" >&2; exit 1; }
+
+TEAM="${1:-}"; SOURCE="${2:-}"; INTENT="${3:-}"; TARGET="${4:-}"
+[ -n "$TEAM" ] && [ -n "$SOURCE" ] && [ -n "$INTENT" ] && [ -n "$TARGET" ] \
+  || die "Usage: arrange.sh <team> <agent> <place_below|place_right> <anchor-agent>"
+[ "$SOURCE" != "$TARGET" ] || die "source and anchor must be different members"
+case "$INTENT" in place_below|place_right) : ;; *) die "unknown intent '$INTENT' (expected place_below or place_right)" ;; esac
+
+_placement() {
+  local agent="$1" rec ref terminal id
+  rec="$(agmsg_spawn_path "$TEAM" "$agent")"
+  [ -f "$rec" ] || { echo "arrange: no placement record for '$TEAM/$agent'" >&2; return 1; }
+  IFS=$'\t' read -r ref _ _ < "$rec" || true
+  terminal="$(agmsg_terminal_ref_terminal "$ref" 2>/dev/null)" || terminal=""
+  id="$(agmsg_terminal_ref_id "$ref" 2>/dev/null)" || id=""
+  [ -n "$terminal" ] && [ -n "$id" ] \
+    || { echo "arrange: placement record for '$TEAM/$agent' is unreadable" >&2; return 1; }
+  PLACEMENT_TERMINAL="$terminal"
+  PLACEMENT_ID="$id"
+}
+
+PLACEMENT_TERMINAL=""; PLACEMENT_ID=""
+_placement "$SOURCE" || exit $?
+SOURCE_TERMINAL="$PLACEMENT_TERMINAL"; SOURCE_ID="$PLACEMENT_ID"
+_placement "$TARGET" || exit $?
+TARGET_TERMINAL="$PLACEMENT_TERMINAL"; TARGET_ID="$PLACEMENT_ID"
+[ "$SOURCE_TERMINAL" = "$TARGET_TERMINAL" ] \
+  || die "members are in different terminals ('$SOURCE_TERMINAL' and '$TARGET_TERMINAL')"
+agmsg_terminal_has "$SOURCE_TERMINAL" capabilities arrange \
+  || die "terminal '$SOURCE_TERMINAL' cannot arrange panes"
+agmsg_terminal_load "$SOURCE_TERMINAL" \
+  || die "cannot load terminal driver '$SOURCE_TERMINAL'"
+
+# Last command: preserve the driver's moved/unchanged/error token and exit code.
+terminal_arrange "$SOURCE_ID" "$INTENT" "$TARGET_ID"

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -44,7 +44,11 @@ terminal_check() {
 terminal_describe() {
   printf 'name=herdr\n'
   printf 'backend=herdr pane\n'
-  printf 'capabilities=spawn despawn peek poke name\n'
+  printf 'capabilities=spawn despawn peek poke where arrange name\n'
+  printf 'syntax_help=herdr --help\n'
+  printf 'skill_help=herdr --skill\n'
+  printf 'intent.place_below=herdr pane move SOURCE --new-tab; herdr pane move SOURCE --tab CONTAINER --split down --target-pane TARGET\n'
+  printf 'intent.place_right=herdr pane move SOURCE --new-tab; herdr pane move SOURCE --tab CONTAINER --split right --target-pane TARGET\n'
 }
 
 # Extract the pane id whose agent_session == <sid> from `herdr agent list` JSON.
@@ -407,6 +411,144 @@ terminal_despawn() {
   local id="$1"
   herdr pane close "$id" >/dev/null 2>&1 || { echo runtime_error; return 13; }
   echo ok
+  return 0
+}
+
+# Ask herdr where a pane is. Existence is deliberately outside this op: a layout
+# query that does not contain the pane is an unanswered location query, so it is
+# unknown/10 rather than a claim that the pane is gone.
+terminal_where() {
+  local id="$1" json rc=0 esc container present
+  command -v herdr >/dev/null 2>&1 || { echo unknown; return 10; }
+  _herdr_pane_id_ok "$id" || { echo unsupported; return 13; }
+  json="$(herdr pane layout --pane "$id" 2>/dev/null)" || rc=$?
+  [ "$rc" -eq 0 ] && [ -n "$json" ] || { echo unknown; return 10; }
+  esc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  present="$(sqlite3 :memory: "SELECT count(*) FROM json_each('$esc','\$.result.layout.panes') WHERE json_extract(value,'\$.pane_id') = '$(printf '%s' "$id" | sed "s/'/''/g")'" 2>/dev/null)" \
+    || { echo unknown; return 10; }
+  container="$(sqlite3 :memory: "SELECT json_extract('$esc','\$.result.layout.tab_id')" 2>/dev/null)" \
+    || { echo unknown; return 10; }
+  if [ "$present" != 1 ] || [ -z "$container" ]; then
+    echo unknown
+    echo "herdr: pane '$id' was present immediately before location lookup, but its tab could not be resolved" >&2
+    return 10
+  fi
+  printf '%s\n' "$container"
+  return 0
+}
+
+# Classify the requested terminal relationship from one pane-layout response.
+# Output: unchanged, different, ambiguous_layout, or runtime_error.
+_herdr_arrange_state() {
+  local json="$1" source="$2" intent="$3" target="$4" esc sesc tesc dir result rc=0
+  esc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  sesc="$(printf '%s' "$source" | sed "s/'/''/g")"
+  tesc="$(printf '%s' "$target" | sed "s/'/''/g")"
+  case "$intent" in place_below) dir=down ;; place_right) dir=right ;; *) echo runtime_error; return 13 ;; esac
+  # A candidate split must contain both panes, have the requested direction,
+  # and agree with their rectangle order. Among those, the smallest area is the
+  # LCA equivalent. Equal-area candidates really occur in degenerate layouts
+  # (measured with a zero-height child); if more than one remains, fail closed.
+  result="$(sqlite3 :memory: "
+    WITH p AS (
+      SELECT json_extract(value,'\$.pane_id') id,
+             json_extract(value,'\$.rect.x') x, json_extract(value,'\$.rect.y') y,
+             json_extract(value,'\$.rect.width') w, json_extract(value,'\$.rect.height') h
+      FROM json_each('$esc','\$.result.layout.panes')
+    ), src AS (SELECT * FROM p WHERE id='$sesc'), tgt AS (SELECT * FROM p WHERE id='$tesc'),
+    candidates AS (
+      SELECT json_extract(s.value,'\$.rect.width') * json_extract(s.value,'\$.rect.height') area
+      FROM json_each('$esc','\$.result.layout.splits') s, src, tgt
+      WHERE json_extract(s.value,'\$.direction')='$dir'
+        AND src.x >= json_extract(s.value,'\$.rect.x')
+        AND src.y >= json_extract(s.value,'\$.rect.y')
+        AND src.x + src.w <= json_extract(s.value,'\$.rect.x') + json_extract(s.value,'\$.rect.width')
+        AND src.y + src.h <= json_extract(s.value,'\$.rect.y') + json_extract(s.value,'\$.rect.height')
+        AND tgt.x >= json_extract(s.value,'\$.rect.x')
+        AND tgt.y >= json_extract(s.value,'\$.rect.y')
+        AND tgt.x + tgt.w <= json_extract(s.value,'\$.rect.x') + json_extract(s.value,'\$.rect.width')
+        AND tgt.y + tgt.h <= json_extract(s.value,'\$.rect.y') + json_extract(s.value,'\$.rect.height')
+        AND (('$dir'='down' AND src.y = tgt.y + tgt.h AND src.x = tgt.x AND src.w = tgt.w)
+          OR ('$dir'='right' AND src.x = tgt.x + tgt.w AND src.y = tgt.y AND src.h = tgt.h))
+    ), m AS (SELECT min(area) area FROM candidates)
+    SELECT CASE
+      WHEN (SELECT count(*) FROM tgt) != 1 OR (SELECT count(*) FROM src) > 1 THEN 'unknown'
+      WHEN (SELECT count(*) FROM src) = 0 THEN 'source_missing'
+      WHEN (SELECT count(*) FROM candidates c,m WHERE c.area=m.area) > 1 THEN 'ambiguous_layout'
+      WHEN (SELECT count(*) FROM candidates) > 0 THEN 'unchanged'
+      ELSE 'different' END;" 2>/dev/null)" || rc=$?
+  [ "$rc" -eq 0 ] && [ -n "$result" ] || { echo runtime_error; return 10; }
+  printf '%s\n' "$result"
+}
+
+_herdr_move_changed() {
+  local json="$1" esc
+  esc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  [ "$(sqlite3 :memory: "SELECT json_extract('$esc','\$.result.move_result.changed')" 2>/dev/null)" = 1 ]
+}
+
+_herdr_move_created_tab() {
+  local json="$1" esc
+  esc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  sqlite3 :memory: "SELECT json_extract('$esc','\$.result.move_result.created_tab.tab_id')" 2>/dev/null
+}
+
+_herdr_layout_has_pane() {
+  local json="$1" id="$2" esc iesc count
+  esc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  iesc="$(printf '%s' "$id" | sed "s/'/''/g")"
+  count="$(sqlite3 :memory: "SELECT count(*) FROM json_each('$esc','\$.result.layout.panes') WHERE json_extract(value,'\$.pane_id')='$iesc'" 2>/dev/null)" \
+    || return 1
+  [ "$count" = 1 ]
+}
+
+terminal_arrange() {
+  local source="$1" intent="$2" target="$3" layout source_layout state rc=0 tab first second temporary_tab
+  command -v herdr >/dev/null 2>&1 || { echo runtime_error; return 10; }
+  _herdr_pane_id_ok "$source" && _herdr_pane_id_ok "$target" || { echo unsupported; return 13; }
+  case "$intent" in place_below|place_right) : ;; *) echo unsupported; return 13 ;; esac
+  layout="$(herdr pane layout --pane "$target" 2>/dev/null)" || rc=$?
+  [ "$rc" -eq 0 ] && [ -n "$layout" ] || { echo runtime_error; return 10; }
+  rc=0
+  state="$(_herdr_arrange_state "$layout" "$source" "$intent" "$target")" || rc=$?
+  case "$state" in
+    unchanged) echo unchanged; return 0 ;;
+    ambiguous_layout) echo ambiguous_layout; return 12 ;;
+    different) : ;;
+    source_missing)
+      # `pane layout --pane TARGET` only describes TARGET's tab. A source in a
+      # different tab is therefore absent from that response, but is still a
+      # valid move candidate. Ask the source itself before treating absence as
+      # "different"; an unanswered or malformed lookup remains unknown.
+      rc=0
+      source_layout="$(herdr pane layout --pane "$source" 2>/dev/null)" || rc=$?
+      [ "$rc" -eq 0 ] && [ -n "$source_layout" ] && _herdr_layout_has_pane "$source_layout" "$source" \
+        || { echo unknown; return 10; }
+      ;;
+    unknown) echo unknown; return 10 ;;
+    *) echo runtime_error; [ "$rc" -ne 0 ] && return "$rc"; return 10 ;;
+  esac
+  tab="$(sqlite3 :memory: "SELECT json_extract('$(printf '%s' "$layout" | sed "s/'/''/g")','\$.result.layout.tab_id')" 2>/dev/null)" \
+    || { echo runtime_error; return 10; }
+  [ -n "$tab" ] || { echo runtime_error; return 10; }
+  first="$(herdr pane move "$source" --new-tab --no-focus 2>/dev/null)" || { echo runtime_error; echo "herdr: failed before moving '$source' to a temporary tab" >&2; return 12; }
+  _herdr_move_changed "$first" || { echo runtime_error; echo "herdr: the temporary-tab move for '$source' did not report changed=true" >&2; return 12; }
+  temporary_tab="$(_herdr_move_created_tab "$first")" || temporary_tab=""
+  [ -n "$temporary_tab" ] || temporary_tab='<new tab id unavailable>'
+  case "$intent" in
+    place_below) second="$(herdr pane move "$source" --tab "$tab" --split down --target-pane "$target" --no-focus 2>/dev/null)" ;;
+    place_right) second="$(herdr pane move "$source" --tab "$tab" --split right --target-pane "$target" --no-focus 2>/dev/null)" ;;
+  esac || {
+    echo runtime_error
+    echo "herdr: '$source' is left in temporary tab '$temporary_tab': placing it back in tab '$tab' relative to '$target' failed" >&2
+    return 12
+  }
+  _herdr_move_changed "$second" || {
+    echo runtime_error
+    echo "herdr: '$source' may be left in temporary tab '$temporary_tab': the move back to tab '$tab' did not report changed=true" >&2
+    return 12
+  }
+  echo moved
   return 0
 }
 

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -430,7 +430,7 @@ terminal_where() {
     || { echo unknown; return 10; }
   if [ "$present" != 1 ] || [ -z "$container" ]; then
     echo unknown
-    echo "herdr: pane '$id' was present immediately before location lookup, but its tab could not be resolved" >&2
+    echo "herdr: the layout answered but did not contain '$id'; pane existence must be checked separately" >&2
     return 10
   fi
   printf '%s\n' "$container"
@@ -444,7 +444,7 @@ _herdr_arrange_state() {
   esc="$(printf '%s' "$json" | sed "s/'/''/g")"
   sesc="$(printf '%s' "$source" | sed "s/'/''/g")"
   tesc="$(printf '%s' "$target" | sed "s/'/''/g")"
-  case "$intent" in place_below) dir=down ;; place_right) dir=right ;; *) echo runtime_error; return 13 ;; esac
+  case "$intent" in place_below) dir=down ;; place_right) dir=right ;; *) echo unsupported; return 13 ;; esac
   # A candidate split must contain both panes, have the requested direction,
   # and agree with their rectangle order. Among those, the smallest area is the
   # LCA equivalent. Equal-area candidates really occur in degenerate layouts

--- a/scripts/drivers/terminals/herdr/terminal.conf
+++ b/scripts/drivers/terminals/herdr/terminal.conf
@@ -5,4 +5,4 @@
 # (the inherited HERDR_PANE_ID is NOT trusted — measured 2026-08-29).
 name=herdr
 backend=herdr pane
-capabilities=spawn despawn peek poke name
+capabilities=spawn despawn peek poke where arrange name

--- a/scripts/drivers/terminals/plain/ops.sh
+++ b/scripts/drivers/terminals/plain/ops.sh
@@ -19,6 +19,18 @@ terminal_describe() {
   printf 'capabilities=spawn despawn\n'
 }
 
+terminal_where() {
+  echo unsupported
+  echo "plain: no addressable pane has a container" >&2
+  return 13
+}
+
+terminal_arrange() {
+  echo unsupported
+  echo "plain: no addressable panes can be arranged" >&2
+  return 13
+}
+
 # record op: the fallback always "matches" but has no addressable pane, so the
 # self id is '-'. Detection order puts plain last.
 terminal_detect() { printf '%s\n' '-'; return 0; }

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -16,7 +16,72 @@ terminal_check() {
 terminal_describe() {
   printf 'name=tmux\n'
   printf 'backend=tmux pane/window\n'
-  printf 'capabilities=spawn despawn peek poke name\n'
+  printf 'capabilities=spawn despawn peek poke where arrange name\n'
+  printf 'syntax_help=tmux list-commands\n'
+  printf 'intent.place_below=tmux move-pane -s SOURCE -t TARGET -v\n'
+  printf 'intent.place_right=tmux move-pane -s SOURCE -t TARGET -h\n'
+}
+
+# READ op: print the window containing <id>. This answers WHERE only and never
+# treats an unresolved location as proof that the pane is gone.
+terminal_where() {
+  local id="$1" out container
+  command -v tmux >/dev/null 2>&1 || { echo unknown; return 10; }
+  # A window placement (@N) is its own container.
+  case "$id" in @*) printf '%s\n' "$id"; return 0 ;; %*) : ;; *) echo unsupported; return 13 ;; esac
+  out="$(tmux list-panes -a -F '#{pane_id}|#{window_id}' 2>/dev/null)" \
+    || { echo unknown; return 10; }
+  container="$(printf '%s\n' "$out" | awk -F '|' -v id="$id" '$1 == id { print $2; exit }')"
+  if [ -z "$container" ]; then
+    echo unknown
+    echo "tmux: pane '$id' was present immediately before location lookup, but its window could not be resolved" >&2
+    return 10
+  fi
+  printf '%s\n' "$container"
+  return 0
+}
+
+# True iff source already occupies the exact split that the native move would
+# create. tmux exposes geometry, not a split tree, so this is intentionally a
+# visible-rectangle predicate. The +1 is tmux's separator cell.
+_tmux_arranged() {
+  local intent="$1" st="$2" sl="$3" sw="$4" sh="$5" tt="$6" tl="$7" tw="$8" th="$9"
+  case "$intent" in
+    place_below) [ "$sl" -eq "$tl" ] && [ "$sw" -eq "$tw" ] && [ "$st" -eq $((tt + th + 1)) ] ;;
+    place_right) [ "$st" -eq "$tt" ] && [ "$sh" -eq "$th" ] && [ "$sl" -eq $((tl + tw + 1)) ] ;;
+    *) return 2 ;;
+  esac
+}
+
+_tmux_layout_numbers_ok() {
+  local value
+  for value in "$@"; do case "$value" in ''|*[!0-9]*) return 1 ;; esac; done
+  return 0
+}
+
+terminal_arrange() {
+  local source="$1" intent="$2" target="$3" out srow trow
+  local sid swin st sl sw sh tid twin tt tl tw th
+  command -v tmux >/dev/null 2>&1 || { echo runtime_error; return 10; }
+  case "$source:$target" in %*:%*) : ;; *) echo unsupported; return 13 ;; esac
+  case "$intent" in place_below|place_right) : ;; *) echo unsupported; return 13 ;; esac
+  out="$(tmux list-panes -a -F '#{pane_id}|#{window_id}|#{pane_top}|#{pane_left}|#{pane_width}|#{pane_height}' 2>/dev/null)" \
+    || { echo runtime_error; return 10; }
+  srow="$(printf '%s\n' "$out" | awk -F '|' -v id="$source" '$1 == id { print; exit }')"
+  trow="$(printf '%s\n' "$out" | awk -F '|' -v id="$target" '$1 == id { print; exit }')"
+  [ -n "$srow" ] && [ -n "$trow" ] || { echo unknown; return 10; }
+  IFS='|' read -r sid swin st sl sw sh <<< "$srow"
+  IFS='|' read -r tid twin tt tl tw th <<< "$trow"
+  _tmux_layout_numbers_ok "$st" "$sl" "$sw" "$sh" "$tt" "$tl" "$tw" "$th" \
+    || { echo runtime_error; return 10; }
+  [ "$swin" = "$twin" ] && _tmux_arranged "$intent" "$st" "$sl" "$sw" "$sh" "$tt" "$tl" "$tw" "$th" \
+    && { echo unchanged; return 0; }
+  case "$intent" in
+    place_below) tmux move-pane -s "$source" -t "$target" -v >/dev/null 2>&1 ;;
+    place_right) tmux move-pane -s "$source" -t "$target" -h >/dev/null 2>&1 ;;
+  esac || { echo runtime_error; return 12; }
+  echo moved
+  return 0
 }
 
 # record op: report TWO facts and decide nothing (tl 2026-08-31). PRESENCE — are

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -34,7 +34,7 @@ terminal_where() {
   container="$(printf '%s\n' "$out" | awk -F '|' -v id="$id" '$1 == id { print $2; exit }')"
   if [ -z "$container" ]; then
     echo unknown
-    echo "tmux: pane '$id' was present immediately before location lookup, but its window could not be resolved" >&2
+    echo "tmux: the pane listing answered but did not contain '$id'; pane existence must be checked separately" >&2
     return 10
   fi
   printf '%s\n' "$container"

--- a/scripts/drivers/terminals/tmux/terminal.conf
+++ b/scripts/drivers/terminals/tmux/terminal.conf
@@ -4,4 +4,4 @@
 # pane. Detection is env-only ($TMUX / $TMUX_PANE).
 name=tmux
 backend=tmux pane/window
-capabilities=spawn despawn peek poke name
+capabilities=spawn despawn peek poke where arrange name

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -137,6 +137,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -229,6 +229,11 @@ If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --for
    - `--force`: skips the message and tears the member down from the placement recorded at spawn time — kills its tmux pane/window and drops its registration. Use when the member's watcher can't respond.
 3. Show the script's output. Do NOT TaskStop or relaunch this session's own Monitor — despawn affects the spawned member, not this session's subscription.
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -166,6 +166,11 @@ If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --for
    - `--force`: skips the message and tears the member down from the placement recorded at spawn time — kills its tmux pane/window and drops its registration.
 3. Show the script's output.
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -137,6 +137,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -136,6 +136,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -137,6 +137,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -167,6 +167,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
    - persistent: true
 5. Tell the user: "Dropped role `<name>` from this project."
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -125,6 +125,11 @@ If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex re
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
 3. Show the script's output.
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -160,6 +160,11 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
    - description: `agmsg inbox stream`
 5. Tell the user: "Dropped role `<name>` from this project."
 
+If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
+1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).
 2. Determine which team `<name>` belongs to (as with `send`), then run:

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -27,6 +27,14 @@
 #   terminal_peek <id> [--lines N]      RECORD op: print visible pane text verbatim (NOT
 #                                       parsed). unsupported -> exit 13, reason on stderr.
 #   terminal_poke <id> <text>           control op: send text and submit. unsupported -> 13.
+#   terminal_where <id>                 READ op: print the id's container (tmux window /
+#                                       herdr tab). Existence is not answered here;
+#                                       a missing id is unknown/10, never `gone`.
+#   terminal_arrange <source-id> <intent> <target-id>
+#                                       control op: declaratively place source below/right
+#                                       of target. Prints moved / unchanged. It reads layout
+#                                       before mutating because the native moves are not
+#                                       idempotent. Ambiguous layout -> token + non-zero.
 #   terminal_name <id> <team> <name> [mode]
 #                                       control op: set the pane's names; idempotent.
 #                                       Two names, not one: the label a person
@@ -116,7 +124,7 @@ agmsg_terminal_has() {
 # verifies it. Naming the set here (not relying on each driver being complete) is
 # what makes a missing op FAIL rather than silently borrow the previously loaded
 # driver's same-named function.
-_AGMSG_TERMINAL_REQUIRED="terminal_check terminal_describe terminal_detect terminal_spawn terminal_despawn terminal_peek terminal_poke terminal_name"
+_AGMSG_TERMINAL_REQUIRED="terminal_check terminal_describe terminal_detect terminal_spawn terminal_despawn terminal_peek terminal_poke terminal_where terminal_arrange terminal_name"
 
 # Wipe every terminal_* ABI function from the current shell. Called before each
 # source so a driver that is switched to cannot inherit the previous driver's ops

--- a/tests/test_peek_poke.bats
+++ b/tests/test_peek_poke.bats
@@ -44,6 +44,13 @@ _write_record() {
   printf '%s\t/tmp/project-a\tclaude-code' "$ref" > "$path"
 }
 
+_write_named_record() {
+  local name="$1" ref="$2" path
+  path="$(bash -c '. "'"$SKILL_DIR"'/scripts/lib/actas-lock.sh"; agmsg_spawn_path testteam "$1"' _ "$name")"
+  [ -n "$path" ]
+  printf '%s\t/tmp/project-a\tclaude-code' "$ref" > "$path"
+}
+
 _install_fake_tmux() {
   cat > "$FAKEBIN/tmux" <<EOF
 #!/usr/bin/env bash
@@ -464,4 +471,46 @@ EOF
   run env HERDR_ENV=1 bash "$SCRIPTS/poke.sh" testteam alice "hi"
   [ "$status" -eq 12 ]
   _out_has "could not poke 'testteam/alice'"
+}
+
+# --- arrange ---------------------------------------------------------------
+
+_install_fake_tmux_arrange() {
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = list-panes ]; then printf '%s\n' "\$TMUX_LAYOUT"; fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/tmux"; export PATH="$FAKEBIN:$PATH"
+}
+
+@test "arrange: a missing source record remains the final reason" {
+  _write_named_record bob 'tmux:%2'
+  run bash "$SCRIPTS/arrange.sh" testteam alice place_below bob
+  [ "$status" -ne 0 ]
+  [ "$output" = "arrange: no placement record for 'testteam/alice'" ]
+  refute _out_has "terminal '' cannot arrange"
+}
+
+@test "arrange: public identity join rejects different recorded terminals" {
+  _write_named_record alice 'tmux:%1'
+  _write_named_record bob 'herdr:wA:p2'
+  run bash "$SCRIPTS/arrange.sh" testteam alice place_below bob
+  [ "$status" -ne 0 ]
+  _out_has "members are in different terminals"
+}
+
+@test "arrange: public entry preserves unchanged and moved from the driver" {
+  _install_fake_tmux_arrange
+  _write_named_record alice 'tmux:%1'
+  _write_named_record bob 'tmux:%2'
+  export TMUX_LAYOUT=$'%1|@7|11|0|80|10\n%2|@7|0|0|80|10'
+  run bash "$SCRIPTS/arrange.sh" testteam alice place_below bob
+  [ "$status" -eq 0 ]
+  [ "$output" = unchanged ]
+  export TMUX_LAYOUT=$'%1|@7|0|0|40|10\n%2|@7|12|0|40|10'
+  run bash "$SCRIPTS/arrange.sh" testteam alice place_below bob
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
 }

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -263,11 +263,40 @@ _fake_herdr_list_scalar_session() {
 # --- conf reader ------------------------------------------------------------
 
 @test "conf: get reads a key, has tests membership, absent key returns default" {
-  [ "$(agmsg_terminal_get tmux capabilities)" = "spawn despawn peek poke name" ]
+  [ "$(agmsg_terminal_get tmux capabilities)" = "spawn despawn peek poke where arrange name" ]
   agmsg_terminal_has tmux capabilities peek
   refute agmsg_terminal_has tmux capabilities nonesuch
   [ "$(agmsg_terminal_get plain capabilities)" = "spawn despawn" ]
   [ "$(agmsg_terminal_get plain nonesuch DEFLT)" = "DEFLT" ]
+}
+
+@test "tmux hint syntax_help: executes tmux list-commands" {
+  _install_fake_tmux
+  agmsg_terminal_load tmux
+  run terminal_describe
+  grep -q '^syntax_help=tmux list-commands$' <<<"$output"
+  grep -q '^intent.place_below=' <<<"$output"
+  grep -q '^intent.place_right=' <<<"$output"
+  tmux list-commands >/dev/null
+  grep -q '^tmux \[list-commands\]$' "$ARGV_LOG"
+}
+
+@test "herdr hint syntax_help: executes herdr --help" {
+  _install_fake_herdr 'sess-help'
+  agmsg_terminal_load herdr
+  run terminal_describe
+  grep -q '^syntax_help=herdr --help$' <<<"$output"
+  herdr --help >/dev/null
+  grep -q '^herdr \[--help\]$' "$ARGV_LOG"
+}
+
+@test "herdr hint skill_help: executes herdr --skill" {
+  _install_fake_herdr 'sess-help'
+  agmsg_terminal_load herdr
+  run terminal_describe
+  grep -q '^skill_help=herdr --skill$' <<<"$output"
+  herdr --skill >/dev/null
+  grep -q '^herdr \[--skill\]$' "$ARGV_LOG"
 }
 
 # --- plain driver -----------------------------------------------------------
@@ -421,6 +450,74 @@ EOF
   grep -q '\[rename-window\] \[-t\] \[@7\] \[teamx:alice\]' "$ARGV_LOG"
 }
 
+_install_fake_tmux_layout() {
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = list-panes ]; then printf '%s\n' "\${TMUX_LAYOUT:-}"; fi
+exit "\${TMUX_RC:-0}"
+EOF
+  chmod +x "$FAKEBIN/tmux"; export PATH="$FAKEBIN:$PATH"
+}
+
+@test "tmux: where answers the window only; a missing-after-present id is unknown, never gone" {
+  _install_fake_tmux_layout
+  export TMUX_LAYOUT='%1|@7|0|0|80|10'
+  agmsg_terminal_load tmux
+  run terminal_where '%1'
+  [ "$status" -eq 0 ]
+  [ "$output" = '@7' ]
+  run terminal_where '@7'
+  [ "$status" -eq 0 ]
+  [ "$output" = '@7' ]
+  run terminal_where '%9'
+  [ "$status" -eq 10 ]
+  printf '%s\n' "$output" | grep -q '^unknown'
+  refute grep -q '^gone$' <<<"$output"
+}
+
+@test "tmux hint place_below: gates the non-idempotent move, then executes move-pane -v" {
+  _install_fake_tmux_layout
+  agmsg_terminal_load tmux
+  terminal_describe | grep -q '^intent.place_below=tmux move-pane -s SOURCE -t TARGET -v$'
+  export TMUX_LAYOUT=$'%1|@7|11|0|80|10\n%2|@7|0|0|80|10'
+  run terminal_arrange '%1' place_below '%2'
+  [ "$status" -eq 0 ]
+  [ "$output" = unchanged ]
+  refute grep -q '\[move-pane\]' "$ARGV_LOG"
+  : > "$ARGV_LOG"
+  export TMUX_LAYOUT=$'%1|@7|0|0|40|10\n%2|@7|12|0|40|10'
+  run terminal_arrange '%1' place_below '%2'
+  [ "$output" = moved ]
+  grep -q '\[move-pane\] \[-s\] \[%1\] \[-t\] \[%2\] \[-v\]' "$ARGV_LOG"
+}
+
+@test "tmux hint place_right: gates the non-idempotent move, then executes move-pane -h" {
+  _install_fake_tmux_layout
+  agmsg_terminal_load tmux
+  terminal_describe | grep -q '^intent.place_right=tmux move-pane -s SOURCE -t TARGET -h$'
+  export TMUX_LAYOUT=$'%1|@7|0|41|39|23\n%2|@7|0|0|40|23'
+  run terminal_arrange '%1' place_right '%2'
+  [ "$status" -eq 0 ]
+  [ "$output" = unchanged ]
+  refute grep -q '\[move-pane\]' "$ARGV_LOG"
+  : > "$ARGV_LOG"
+  export TMUX_LAYOUT=$'%1|@7|12|0|40|10\n%2|@7|0|0|40|10'
+  run terminal_arrange '%1' place_right '%2'
+  [ "$output" = moved ]
+  grep -q '\[move-pane\] \[-s\] \[%1\] \[-t\] \[%2\] \[-h\]' "$ARGV_LOG"
+}
+
+@test "tmux: arrange cannot locate a listed pane -> unknown/10, not runtime_error" {
+  _install_fake_tmux_layout
+  agmsg_terminal_load tmux
+  export TMUX_LAYOUT='%2|@7|0|0|80|10'
+  run terminal_arrange '%1' place_below '%2'
+  [ "$status" -eq 10 ]
+  [ "$output" = unknown ]
+  refute grep -q '\[move-pane\]' "$ARGV_LOG"
+}
+
 # --- herdr driver ops (fake herdr argv; live-verified argv flagged) ---------
 
 @test "herdr: detect resolves the pane for the session id via agent list" {
@@ -527,6 +624,145 @@ EOF
   # herdr's [a-z][a-z0-9_-]{0,31} regex. (Exact value is asserted for distinctness
   # in the injectivity test below, not pinned here.)
   grep -qE '\[agent\] \[rename\] \[wC:p9\] \[a[0-9a-f]{24}\]' "$ARGV_LOG"
+}
+
+_install_fake_herdr_layout() {
+  cat > "$FAKEBIN/herdr" <<EOF
+#!/usr/bin/env bash
+{ printf 'herdr'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1 \$2" = 'pane layout' ]; then
+  if [ -n "\${HERDR_SOURCE_LAYOUT:-}" ] && [ "\${4:-}" = 'wA:p1' ]; then printf '%s\n' "\$HERDR_SOURCE_LAYOUT"
+  else printf '%s\n' "\$HERDR_LAYOUT"
+  fi
+elif [ "\$1 \$2" = 'pane move' ]; then
+  case " \$* " in *' --tab '*) [ "\${HERDR_SECOND_RC:-0}" -eq 0 ] || exit "\$HERDR_SECOND_RC" ;; esac
+  case " \$* " in
+    *' --new-tab '*) printf '%s\n' '{"result":{"move_result":{"changed":true,"created_tab":{"tab_id":"wA:t9"}}}}' ;;
+    *) printf '%s\n' '{"result":{"move_result":{"changed":true}}}' ;;
+  esac
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/herdr"; export PATH="$FAKEBIN:$PATH"
+}
+
+@test "herdr: where answers the tab only and never becomes a second gone authority" {
+  _install_fake_herdr_layout
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t2","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":0,"width":10,"height":10}}],"splits":[]}}}'
+  agmsg_terminal_load herdr
+  run terminal_where 'wA:p1'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'wA:t2' ]
+  run terminal_where 'wA:p9'
+  [ "$status" -eq 10 ]
+  printf '%s\n' "$output" | grep -q '^unknown'
+  refute grep -q '^gone$' <<<"$output"
+}
+
+@test "herdr hint place_below: gates the move, then executes new-tab and split down" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  terminal_describe | grep -q '^intent.place_below=herdr pane move SOURCE --new-tab; herdr pane move SOURCE --tab CONTAINER --split down --target-pane TARGET$'
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":10,"width":20,"height":10}},{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":20,"height":10}}],"splits":[{"id":"opaque","direction":"down","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":20}}]}}}'
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = unchanged ]
+  refute grep -q '\[pane\] \[move\]' "$ARGV_LOG"
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":0,"width":10,"height":20}},{"pane_id":"wA:p2","rect":{"x":10,"y":0,"width":10,"height":20}}],"splits":[{"id":"opaque","direction":"right","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":20}}]}}}'
+  : > "$ARGV_LOG"
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$output" = moved ]
+  grep -q '\[pane\] \[move\] \[wA:p1\] \[--new-tab\] \[--no-focus\]' "$ARGV_LOG"
+  grep -q '\[--tab\] \[wA:t1\] \[--split\] \[down\] \[--target-pane\] \[wA:p2\]' "$ARGV_LOG"
+}
+
+@test "herdr hint place_right: gates the move, then executes new-tab and split right" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  terminal_describe | grep -q '^intent.place_right=herdr pane move SOURCE --new-tab; herdr pane move SOURCE --tab CONTAINER --split right --target-pane TARGET$'
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":10,"y":0,"width":10,"height":20}},{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":10,"height":20}}],"splits":[{"id":"opaque","direction":"right","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":20}}]}}}'
+  run terminal_arrange 'wA:p1' place_right 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = unchanged ]
+  refute grep -q '\[pane\] \[move\]' "$ARGV_LOG"
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":0,"width":20,"height":10}},{"pane_id":"wA:p2","rect":{"x":0,"y":10,"width":20,"height":10}}],"splits":[{"id":"opaque","direction":"down","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":20}}]}}}'
+  : > "$ARGV_LOG"
+  run terminal_arrange 'wA:p1' place_right 'wA:p2'
+  [ "$output" = moved ]
+  grep -q '\[pane\] \[move\] \[wA:p1\] \[--new-tab\] \[--no-focus\]' "$ARGV_LOG"
+  grep -q '\[--split\] \[right\]' "$ARGV_LOG"
+}
+
+@test "herdr: equal-area direction-compatible split candidates fail closed" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":1,"width":10,"height":1}},{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":10,"height":1}}],"splits":[{"id":"opaque-a","direction":"down","ratio":0.5,"rect":{"x":0,"y":0,"width":10,"height":2}},{"id":"opaque-b","direction":"down","ratio":0.5,"rect":{"x":0,"y":0,"width":10,"height":2}}]}}}'
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 12 ]
+  [ "$output" = ambiguous_layout ]
+  refute grep -q '\[pane\] \[move\]' "$ARGV_LOG"
+}
+
+@test "herdr: a pane below an intervening pane is different, not directly place_below" {
+  agmsg_terminal_load herdr
+  local layout='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":20,"width":20,"height":10}},{"pane_id":"wA:pX","rect":{"x":0,"y":10,"width":20,"height":10}},{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":20,"height":10}}],"splits":[{"id":"outer","direction":"down","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":30}},{"id":"inner","direction":"down","ratio":0.5,"rect":{"x":0,"y":10,"width":20,"height":20}}]}}}'
+  run _herdr_arrange_state "$layout" 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = different ]
+}
+
+@test "herdr: second arrange step failure says the source may be stranded in a temporary tab" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  export HERDR_SECOND_RC=1
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":0,"width":10,"height":20}},{"pane_id":"wA:p2","rect":{"x":10,"y":0,"width":10,"height":20}}],"splits":[{"id":"opaque","direction":"right","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":20}}]}}}'
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 12 ]
+  printf '%s\n' "$output" | grep -q '^runtime_error'
+  printf '%s\n' "$output" | grep -q "left in temporary tab 'wA:t9'"
+  printf '%s\n' "$output" | grep -q "placing it back in tab 'wA:t1'"
+}
+
+@test "herdr: arrange cannot locate a layout pane -> unknown/10, not runtime_error" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":20,"height":20}}],"splits":[]}}}'
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 10 ]
+  [ "$output" = unknown ]
+  refute grep -q '\[pane\] \[move\]' "$ARGV_LOG"
+}
+
+@test "herdr: arrange moves a source proven present in a different tab" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":20,"height":20}}],"splits":[]}}}'
+  export HERDR_SOURCE_LAYOUT='{"result":{"layout":{"tab_id":"wA:t2","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":0,"width":20,"height":20}}],"splits":[]}}}'
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  [ "$(grep -c '\[pane\] \[layout\]' "$ARGV_LOG")" -eq 2 ]
+  grep -q '\[pane\] \[move\] \[wA:p1\] \[--new-tab\]' "$ARGV_LOG"
+  grep -q '\[--tab\] \[wA:t1\] \[--split\] \[down\] \[--target-pane\] \[wA:p2\]' "$ARGV_LOG"
+}
+
+@test "arrange meaning: both tmux and herdr move when another pane separates source from target" {
+  _install_fake_tmux_layout
+  agmsg_terminal_load tmux
+  export TMUX_LAYOUT=$'%1|@7|22|0|80|10\n%X|@7|11|0|80|10\n%2|@7|0|0|80|10'
+  run terminal_arrange '%1' place_below '%2'
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  grep -q '\[move-pane\]' "$ARGV_LOG"
+
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":20,"width":20,"height":10}},{"pane_id":"wA:pX","rect":{"x":0,"y":10,"width":20,"height":10}},{"pane_id":"wA:p2","rect":{"x":0,"y":0,"width":20,"height":10}}],"splits":[{"id":"outer","direction":"down","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":30}},{"id":"inner","direction":"down","ratio":0.5,"rect":{"x":0,"y":10,"width":20,"height":20}}]}}}'
+  : > "$ARGV_LOG"
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  grep -q '\[pane\] \[move\]' "$ARGV_LOG"
 }
 
 @test "herdr peek: an error body is NOT returned as content, and the single 13 is split (tl/co1)" {

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -637,7 +637,11 @@ if [ "\$1 \$2" = 'pane layout' ]; then
 elif [ "\$1 \$2" = 'pane move' ]; then
   case " \$* " in *' --tab '*) [ "\${HERDR_SECOND_RC:-0}" -eq 0 ] || exit "\$HERDR_SECOND_RC" ;; esac
   case " \$* " in
-    *' --new-tab '*) printf '%s\n' '{"result":{"move_result":{"changed":true,"created_tab":{"tab_id":"wA:t9"}}}}' ;;
+    *' --new-tab '*)
+      if [ "\${HERDR_FIRST_CHANGED:-true}" = true ]; then printf '%s\n' '{"result":{"move_result":{"changed":true,"created_tab":{"tab_id":"wA:t9"}}}}'
+      else printf '%s\n' '{"result":{"move_result":{"changed":false}}}'
+      fi
+      ;;
     *) printf '%s\n' '{"result":{"move_result":{"changed":true}}}' ;;
   esac
 fi
@@ -721,6 +725,18 @@ EOF
   printf '%s\n' "$output" | grep -q '^runtime_error'
   printf '%s\n' "$output" | grep -q "left in temporary tab 'wA:t9'"
   printf '%s\n' "$output" | grep -q "placing it back in tab 'wA:t1'"
+}
+
+@test "herdr: an unchanged temporary-tab move fails before the second step" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  export HERDR_FIRST_CHANGED=false
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":0,"width":10,"height":20}},{"pane_id":"wA:p2","rect":{"x":10,"y":0,"width":10,"height":20}}],"splits":[{"id":"opaque","direction":"right","ratio":0.5,"rect":{"x":0,"y":0,"width":20,"height":20}}]}}}'
+  run terminal_arrange 'wA:p1' place_below 'wA:p2'
+  [ "$status" -eq 12 ]
+  printf '%s\n' "$output" | grep -q '^runtime_error'
+  printf '%s\n' "$output" | grep -q 'did not report changed=true'
+  [ "$(grep -c '\[pane\] \[move\]' "$ARGV_LOG")" -eq 1 ]
 }
 
 @test "herdr: arrange cannot locate a layout pane -> unknown/10, not runtime_error" {

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -170,6 +170,15 @@ write_node_launcher_fixtures() {
   grep -Fq 'To mint a replacement epoch instead:' "$BATS_TEST_DIRNAME/../scripts/key.sh"
 }
 
+@test "every agent template exposes declarative arrange without adding a public where verb" {
+  local template
+  for template in "$SCRIPTS"/drivers/types/*/template.md; do
+    grep -q 'scripts/arrange\.sh <team> <agent> <intent> <anchor-agent>' "$template"
+    grep -q '`moved` as a performed move and `unchanged`' "$template"
+    [ "$(grep -c 'If argument starts with "where"' "$template" || true)" -eq 0 ]
+  done
+}
+
 @test "type-registry: spawnable set is exactly eight of the ten built-ins (#277, #279)" {
   # hermes deliberately stays out (#279): no known CLI mode starts it
   # interactive with a seeded initial prompt. agmsg-app also stays out: it's


### PR DESCRIPTION
## Summary

- add declarative `place_below` and `place_right` terminal intents with idempotent layout gates
- add a public `arrange.sh` entry point that joins member placement records before dispatching to the terminal driver
- add terminal location lookup as a driver operation without making it a public verb
- point terminal descriptions at native syntax/help and cover every advertised recipe with an argv test

## Driver behavior

| Driver | `place_below` | `place_right` |
| --- | --- | --- |
| tmux | one `move-pane -v` call | one `move-pane -h` call |
| herdr | move to a temporary tab, then split `down` into the original tab | move to a temporary tab, then split `right` into the original tab |
| plain | unsupported | unsupported |

Both mutating drivers inspect the current layout first and return `unchanged` without invoking the native move when the requested direct adjacency already exists. A herdr source in another tab is moved only after its own layout positively confirms that pane.

## Deferred follow-up

Joining location with pane liveness is intentionally deferred until #1058 lands. This change can report the container recorded by the terminal, but does not call `terminal_pane_state` or expose a `live` field. A separate follow-up will add the existence gate so `gone` has exactly one authority.

## Verification

- `bats tests/test_terminal_registry.bats tests/test_peek_poke.bats tests/test_type_registry.bats tests/test_claude_template.bats` (151 tests)
- `bash .github/scripts/check-enforced-assertions.sh`
- `bash .github/scripts/check-errexit-status-reads.sh`
- `bash -n scripts/arrange.sh scripts/lib/terminal-registry.sh scripts/drivers/terminals/tmux/ops.sh scripts/drivers/terminals/herdr/ops.sh scripts/drivers/terminals/plain/ops.sh`