### PR TITLE
Remove internal handles from the published tree, and teach the checker their identifier contexts

### DIFF
--- a/.github/scripts/check-errexit-status-reads.sh
+++ b/.github/scripts/check-errexit-status-reads.sh
@@ -200,7 +200,7 @@ def split_statements(text):
         # `#` opens a comment when it STARTS A WORD -- at the beginning of a
         # statement or after whitespace. Requiring the statement to be empty
         # was not merely incomplete, it was actively dangerous: a TRAILING
-        # comment stayed in the text, and the apostrophe in one (`co1's`) read
+        # comment stayed in the text, and the apostrophe in one (`review's`) read
         # as an opening single quote and swallowed everything to the next one.
         # That silently disabled the sql_bare control several functions later,
         # so the file reported three findings instead of four and still looked
@@ -374,7 +374,7 @@ sql_guarded_case() {     # the false positive that cost a workaround — must NO
     LIMIT 1;" 2>/dev/null)" || rc=$?
   [ "$rc" -eq 0 ] || return 2
 }
-source_continued_case() { # co1's second hole — a source split across a
+source_continued_case() { # the review's second hole — a source split across a
                           # backslash-newline. MUST be reported: this is a
                           # single-line source with a line break in it, and a
                           # splitter that breaks there reports nothing while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -491,10 +491,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve symlinks before trampoline compare; doctor checks node
 - Detect the macOS CLT python3 trampoline, not just PATH presence
 - Close the python3 dependency-tiering gap on the remote path
-- Close the integer-overflow bypass in AGMSG_TEAM_LIST_MAX_TEAMS validation (co1 delta review round 2)
-- Validate AGMSG_TEAM_LIST_MAX_TEAMS as a positive integer (co1 delta review)
+- Close the integer-overflow bypass in AGMSG_TEAM_LIST_MAX_TEAMS validation (delta review round 2)
+- Validate AGMSG_TEAM_LIST_MAX_TEAMS as a positive integer (delta review)
 - Fail closed on incompleteness; shrink v1 schema
-- Wire 'agmsg team list' into actual dispatch entry points (co1 P1)
+- Wire 'agmsg team list' into actual dispatch entry points (review P1)
 - Stop binding config JSON via .param set (#87-class tokenizer bug)
 - Hide imported identity at TTY
 - Separate token input from E2EE prompts
@@ -529,15 +529,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Read messages from the event log too, not just the legacy table
 - Assert against the event log, not the legacy messages table
 - Escape interpolated names in rename/rename-team SQL (#223, #87)
-- Jsonl compact keys reads by tuple, not a space-join (co1 #221)
+- Jsonl compact keys reads by tuple, not a space-join (#221 review)
 - Make the jsonl driver parse under macOS bash 3.2 (#207, #221 CI)
-- Jsonl mark aborts on a failed existing-reads scan (co1 #207 residual)
-- Jsonl driver must not swallow failures as ok (co1 #207 review)
+- Jsonl mark aborts on a failed existing-reads scan (#207 residual)
+- Jsonl driver must not swallow failures as ok (#207 review)
 - Watch-once stale-wake token = unread-set digest, not a max id (#207)
-- Document --limit semantics + make storage_history agent truly optional (co1 #206 review)
-- Export skips unknown event types; pin high-water with a tail-duplicate test (co1 #205 review)
-- Describe is a metadata op; surface backend errors; chronological reads (co1 re-review, #204)
-- Legacy read, pipefail framing, §1.4 control ops (co1 review, #204)
+- Document --limit semantics + make storage_history agent truly optional (#206 review)
+- Export skips unknown event types; pin high-water with a tail-duplicate test (#205 review)
+- Describe is a metadata op; surface backend errors; chronological reads (re-review, #204)
+- Legacy read, pipefail framing, §1.4 control ops (review, #204)
 
 ### Performance
 - Seal a bulk push page in parallel (#502)
@@ -565,8 +565,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Close Stage 2 frontier edge cases
 - Define Stage 2 read-state synchronization
 - Note rename.sh/rename-team.sh/api.sh as sqlite-coupled known gaps
-- Correct the ctrl:despawn cursor-advance comment (co1 step-3 review)
-- Clarify stdout framing, cursor token, watch tip (co1 review, #203)
+- Correct the ctrl:despawn cursor-advance comment (step-3 review)
+- Clarify stdout framing, cursor token, watch tip (review, #203)
 - Storage contract §2 — messages-only, opaque cursor, recipient-scoped read (#203)
 - Draft ADR 0003 — storage axis driver ABI, contract, scope (proposed)
 
@@ -794,7 +794,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 - Add supported-agents logo strip
-- List hermes in the --agent-type help (co1 nit)
+- List hermes in the --agent-type help (review nit)
 - Add docs/plugins.md + README section + plugins/ drop-in dir
 - Refresh manifest table + paths for the 1.1.0 layout
 - Lead Quick Start with npx, the zero-clone install path

--- a/install.sh
+++ b/install.sh
@@ -297,7 +297,7 @@ if [ "$UPDATE_ONLY" = true ]; then
   # reserved-name validation, so any pattern that would catch a real backup
   # (e.g. "agmsg.bak-20260731") can equally match a legitimately chosen
   # install name (e.g. "agmsg.bak-tool") -- there is no substring that is
-  # guaranteed to mean "not a real install" (co2 review, #659). A leftover
+  # guaranteed to mean "not a real install" (review of #659). A leftover
   # backup directory that still carries the .agmsg marker is therefore just
   # another candidate: it makes the set ambiguous, and ambiguous is exactly
   # what this fix already refuses to guess through, below.

--- a/scripts/despawn.sh
+++ b/scripts/despawn.sh
@@ -59,7 +59,7 @@ case "$TIMEOUT" in ''|*[!0-9]*) die "--timeout must be a whole number of seconds
 SPAWN_REC="$(agmsg_spawn_path "$TEAM" "$NAME")"
 
 # Tear down the recorded placement through the terminal-driver registry, and PROVE
-# it (co1, full-head review). The record ref is <terminal>:<id> or a legacy bare
+# it (full-head review). The record ref is <terminal>:<id> or a legacy bare
 # %N/@N; an unknown/corrupt ref does NOT resolve (agmsg_terminal_ref_terminal fails
 # closed). The teardown counts as confirmed only if the ref resolved, the driver
 # loaded, AND terminal_despawn exited 0 — a driver reporting runtime_error/13 (a real

--- a/scripts/drivers/storage/jsonl-unread.duckdb.sql
+++ b/scripts/drivers/storage/jsonl-unread.duckdb.sql
@@ -2,7 +2,7 @@
 -- Read as DATA by the jsonl driver (scripts/drivers/storage/jsonl.sh) and never
 -- parsed by bash, so its apostrophes and "double-quoted" identifiers can't trip
 -- the macOS system bash 3.2 parser. The driver fills the placeholders by literal
--- bash substitution: __LG__ = events.jsonl path, __TL__ = team, __AL__ = agent
+-- bash substitution: __LG__ = events.jsonl path, __TEAM__ = team, __AL__ = agent
 -- (all already SQL-escaped — apostrophes doubled — before substitution).
 -- Columns are read as explicit VARCHAR, never read_json_auto, whose type
 -- inference would parse `at` as a TIMESTAMP and drop the canonical ISO-8601 T/Z.
@@ -16,8 +16,8 @@ WITH log AS (
 SELECT to_json(struct_pack(type := 'message_sent', id := s.id, team := s.team,
          "from" := s."from", "to" := s."to", body := s.body, at := s.at))
 FROM sent s
-WHERE s.position > __CUR__ AND s.team='__TL__' AND s."to"='__AL__'
+WHERE s.position > __CUR__ AND s.team='__TEAM__' AND s."to"='__AL__'
 AND s.id NOT IN (
   SELECT msg_id FROM log
-  WHERE type='message_read' AND team='__TL__' AND agent='__AL__')
+  WHERE type='message_read' AND team='__TEAM__' AND agent='__AL__')
 ORDER BY s.position;

--- a/scripts/drivers/storage/jsonl.sh
+++ b/scripts/drivers/storage/jsonl.sh
@@ -279,7 +279,7 @@ _jsonl_unread_duckdb() {
   [ -f "$tpl" ] || return 1
   sql="$(cat "$tpl")"
   sql="${sql//__LG__/$lg}"
-  sql="${sql//__TL__/$tl}"
+  sql="${sql//__TEAM__/$tl}"
   sql="${sql//__AL__/$al}"
   sql="${sql//__CUR__/$cursor}"
   printf '%s\n' "$sql" | duckdb -noheader -list 2>/dev/null

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -5,7 +5,7 @@
 # no set -e/-u.
 #
 # FACT BOUNDARY — what is measured vs still asserted (keep this honest):
-#   MEASURED on the real machine (seat 0, 2026-08-29; and live by utildev on
+#   MEASURED on the real machine (2026-08-29; and live on
 #   a real workstation, herdr 0.8.0, 2026-09-02/03 — the resolver run against the real
 #   `agent list`, with positive controls):
 #     - `herdr agent list` is JSON; agent_session in the list is an OBJECT and the
@@ -22,7 +22,7 @@
 #       display_agent was a string in one 2026-09-04 agent list; a NAMED bare pane was not
 #       observed by 2026-09-04 (its control is defensive).
 #     - the pane-id grammar (w1:p4, w1:pB, w5:p3, w1:pC).
-#     - `pane read --source <visible|recent|...>` (seat 0 measured the --source values).
+#     - `pane read --source <visible|recent|...>` (the --source values were measured live).
 #     - the internal agent-name key is a collision-resistant SHA-256 derivation of
 #       (team, agent) — see _herdr_internal_key for why concatenation/folding has a
 #       structural collision.
@@ -56,7 +56,7 @@ terminal_describe() {
 # (agent_session, pane_id) — verified by the live matrix. Prints the pane id, or
 # nothing (empty) if no entry matches.
 # Resolve <sid> to a pane via `agent list`, distinguishing THREE outcomes so the
-# caller can give an honest reason (co1/tl 2026-08-31):
+# caller can give an honest reason (2026-08-31):
 #   return 2         — could not ANSWER (herdr absent, or `agent list` errored/empty)
 #   return 0, pane   — answered, this session's pane is <pane>
 #   return 0, empty  — answered, but this session is not among the live agents
@@ -80,8 +80,8 @@ _herdr_pane_for_session() {
   local q pane sesc jtype jtrc alen det badhit out orc
   sesc="$(printf '%s' "$sid" | sed "s/'/''/g")"
   # The claim "not among" is a claim about the WHOLE set, so it is only honest when
-  # every entry's membership is DECIDABLE. The trap (co1/tl over several rounds, then
-  # utildev's live measurement) is grabbing a proxy for "decidable":
+  # every entry's membership is DECIDABLE. The trap (over several review rounds, then
+  # the live measurement) is grabbing a proxy for "decidable":
   #   1 query succeeded  2 container is an array  3 an entry of the expected shape
   #   exists  4 >=1 well-formed  5 same predicate twice  6 the '|' delimiter is in
   #   the value  7 the pane-id "shape" is just a skeleton
@@ -126,12 +126,12 @@ _herdr_pane_for_session() {
     orc=0
     out="$(sqlite3 :memory: "
       WITH entries(value) AS (SELECT value FROM json_each('$jesc', '$q')),
-           -- Tag every object entry ONCE (co1: one predicate, no drift). The entries
+           -- Tag every object entry ONCE (one predicate, no drift). The entries
            -- table is ALIASED (e) so the correlated json_each below binds e.value per
            -- row -- without the alias a bare json_each(value) does NOT correlate and
            -- returns the same answer for every row (measured).
            tagged(value, pane_ok, as_type, anchor_ok, struct_free) AS (
-             -- pane_ok is normalized to a definite 0/1 (co1): a boolean expression
+             -- pane_ok is normalized to a definite 0/1: a boolean expression
              -- would be NULL when pane_id is ABSENT, and then a target session with
              -- no pane_id lands in NEITHER hit (AND pane_ok -> NULL) nor badhit
              -- (AND NOT pane_ok -> NULL), so present-but-unaddressable would read as
@@ -146,7 +146,7 @@ _herdr_pane_for_session() {
                json_type(e.value,'\$.agent_session'),
                -- (c) the fixed bare-pane ANCHOR: the herdr-pane identity keys every
                --     agent-list entry carries (measured always-present, 0 variance over
-               --     11 panes, utildev 2026-09-04). This is the POSITIVE proof the entry
+               --     11 panes, live 2026-09-04). This is the POSITIVE proof the entry
                --     is a real herdr pane, so a minimal or unknown shape that merely has
                --     a pane_id-looking field is NOT taken for one.
                CASE WHEN json_type(e.value,'\$.agent') IS NOT NULL
@@ -164,12 +164,12 @@ _herdr_pane_for_session() {
            -- drift while the pane lives (agent_status changes state; name/display_agent
            -- appear and vanish when the agent is named or ends), so pinning to either
            -- makes the predicate intermittently green and reopens the round-8 regression.
-           -- The four conditions (co1/tl 2026-09-04):
+           -- The four conditions (2026-09-04):
            --   (a) the agent_session KEY is ABSENT (as_type IS NULL);
            --   (b) a valid pane_id (grammar above);
            --   (c) the fixed identity anchor is present (anchor_ok);
            --   (d‴) no field is object- or array-valued (struct_free).
-           -- SCOPE of (d‴), stated exactly (co1): it catches a session moved to a
+           -- SCOPE of (d‴), stated exactly: it catches a session moved to a
            -- renamed OBJECT or ARRAY key -- future_session:{…}, future_sessions:[…],
            -- session_ids:[…], inner shape irrelevant -- because the MEASURED agent_session
            -- is an object, so a structured value where none belongs fails struct_free and
@@ -186,7 +186,7 @@ _herdr_pane_for_session() {
            -- A scalar extension (name, display_agent -- measured as a string once in the
            -- 2026-09-04 agent list) passes, so a NAMED bare pane still reaches not-among.
            -- NOTE: a named bare pane (name present, agent_session absent) was NOT
-           -- observed as of 2026-09-04 (utildev); its control is DEFENSIVE.
+           -- observed as of 2026-09-04 (live measurement); its control is DEFENSIVE.
            det(value) AS (
              SELECT value FROM tagged
              WHERE ( as_type = 'object' AND json_type(value,'\$.agent_session.value') = 'text' )
@@ -230,7 +230,7 @@ terminal_detect() {
   local sid="${1:-}"
   # PRESENCE (exit code) is HERDR_ENV=1 ALONE: whether herdr is on PATH is a
   # terminal_check question ("can I operate it"), NOT "which terminal am I in"
-  # (co1/tl 2026-08-31). Conflating them would make a herdr session with no herdr
+  # (2026-08-31). Conflating them would make a herdr session with no herdr
   # on PATH place/name as tmux or plain. SELF-ID (stdout) is the pane from agent
   # list, which may be EMPTY — the third value "could not resolve", NOT "not
   # herdr". The reason (no session id / list did not answer, incl. herdr absent /
@@ -259,7 +259,7 @@ terminal_detect() {
 }
 
 # Read the new pane id from a herdr JSON result at one of the known paths.
-# The measured herdr pane-id grammar as ONE shell authority (co1: the resolver and
+# The measured herdr pane-id grammar as ONE shell authority (the resolver and
 # the spawn side must not implement the predicate twice and drift). w + >=1 alnum,
 # exactly one ':', then p + >=1 alnum, alnum+':' only. A test cross-checks that this
 # agrees with the resolver's SQL GLOB form on the boundary values. (bash negated
@@ -267,7 +267,7 @@ terminal_detect() {
 _herdr_pane_id_ok() {
   # Delegate to the registry's single per-terminal id authority so the spawn-side
   # extraction, the resolver's cross-check, and agmsg_terminal_ref_terminal all use
-  # ONE herdr pane grammar (co1: do not implement the predicate twice). The herdr
+  # ONE herdr pane grammar (do not implement the predicate twice). The herdr
   # driver is always loaded through the registry, so the helper is in scope; a bare
   # source without it falls back to the inline grammar rather than accepting anything.
   if declare -F _agmsg_terminal_id_ok >/dev/null 2>&1; then
@@ -299,7 +299,7 @@ _herdr_new_pane_id() {
 # requirement 1 (herdr pre-input readiness). Before typing the boot into the pane's
 # shell, confirm the shell is AT ITS PROMPT — nothing else in the foreground — so a
 # startup program (e.g. an oh-my-zsh update prompt) cannot eat the first keystroke.
-# The signal is STRUCTURAL and environment-independent (co1/tl 2026-09-04): herdr's
+# The signal is STRUCTURAL and environment-independent (2026-09-04): herdr's
 # pane process-info reports shell_pid and foreground_process_group_id, and the shell is
 # at its prompt IFF the foreground process group IS the shell itself. No prompt string
 # is matched (zsh/bash/Windows alike) and no point-in-time value is baked in.
@@ -311,14 +311,14 @@ _herdr_new_pane_id() {
 #     agent list (30 panes vs 11 agent-list entries), so it cannot see a bare shell.
 #   - agent list has no shell-readiness field; process-info is the one that does.
 #
-# NECESSARY, NOT SUFFICIENT (utildev, kept honest): this proves "no OTHER command is
+# NECESSARY, NOT SUFFICIENT (kept honest): this proves "no OTHER command is
 # running". It does NOT prove the keystroke survives — if the SHELL ITSELF is reading
 # (an oh-my-zsh "[Y/n]" has no child process), process-info returns equal and this
 # reports READY. That case was UNMEASURED as of 2026-09-04. So a first keystroke can
 # still be lost; that residual is caught AFTER typing by the readiness handshake /
 # launched-unconfirmed, never here. Do not read this gate as a guarantee.
 #
-# THREE outcomes, kept distinct (co1's positive-validation contract):
+# THREE outcomes, kept distinct (the positive-validation contract):
 #   0 READY      — command ok, BOTH ids present and canonical positive integers, EQUAL.
 #   1 NOT READY  — both ids validated the SAME way, and UNEQUAL (a foreground process).
 #   2 UNKNOWN    — the command failed, a field is missing, or a value is not a canonical
@@ -333,7 +333,7 @@ _herdr_pane_input_ready() {
   jesc="$(printf '%s' "$info" | sed "s/'/''/g")"
   # Require the JSON TYPE to be integer, in the SAME payload, BEFORE reading the value:
   # a JSON string "123" extracts as 123 and would pass a digit check, but a pid that
-  # arrives as a string is not a validated pid (co1). The CASE yields the value only when
+  # arrives as a string is not a validated pid. The CASE yields the value only when
   # json_type is 'integer', else empty -> the digit/positive guard below rejects it.
   sp="$(sqlite3 :memory: "SELECT CASE WHEN json_type('$jesc','\$.result.process_info.shell_pid')='integer' THEN json_extract('$jesc','\$.result.process_info.shell_pid') ELSE '' END" 2>/dev/null)" || return 2
   fg="$(sqlite3 :memory: "SELECT CASE WHEN json_type('$jesc','\$.result.process_info.foreground_process_group_id')='integer' THEN json_extract('$jesc','\$.result.process_info.foreground_process_group_id') ELSE '' END" 2>/dev/null)" || return 2
@@ -378,11 +378,11 @@ terminal_spawn() {
   #
   # The bound is FIXED, not an env surface: a knob read from the environment could arrive
   # empty / 0 / non-numeric and silently skip the observation (loop never runs -> UNKNOWN
-  # -> boot), which is the very thing this gate exists to prevent (co1). ~5s (50 * 0.1s)
+  # -> boot), which is the very thing this gate exists to prevent. ~5s (50 * 0.1s)
   # covers a slow interactive-shell startup without a knob to misconfigure.
   # `ready_rc=0; classifier || ready_rc=$?`, NOT `classifier; ready_rc=$?`: the classifier
   # returns non-zero for NOT-READY(1)/UNKNOWN(2), and a bare command whose status is read
-  # on the next line takes a `set -e` caller down BEFORE the branch classifies it (co1).
+  # on the next line takes a `set -e` caller down BEFORE the branch classifies it.
   local ready_rc=2 tries=0
   while [ "$tries" -lt 50 ]; do
     ready_rc=0; _herdr_pane_input_ready "$pane" || ready_rc=$?
@@ -567,7 +567,7 @@ terminal_peek() {
   # peek is a READ op: only the pane CONTENT may reach stdout. herdr writes an error
   # JSON to STDOUT on failure (e.g. {"error":{"code":"pane_not_found",...}}), which the
   # caller would otherwise read as the pane's content — "read" and "could-not-read"
-  # returning in the same shape (tl/co1, the third instance of one channel carrying two
+  # returning in the same shape (the third instance of one channel carrying two
   # meanings). ISOLATE it (capture; the error body goes to stderr, never stdout), and
   # SPLIT the single 13 so the caller can tell the three cases apart:
   #   plain has no peek path        -> 13 (unchanged; documented, and the templates say so)
@@ -578,7 +578,7 @@ terminal_peek() {
   # READ contract: stdout must be the pane's visible text VERBATIM. A command
   # substitution strips EVERY trailing newline; a following printf '%s\n' then invents
   # exactly one back, so empty content becomes a lone newline and content ending in
-  # 0 or 2+ newlines is silently rewritten (co1). Capture to a temp file instead,
+  # 0 or 2+ newlines is silently rewritten. Capture to a temp file instead,
   # decide on rc, then cat the bytes unmodified. herdr writes its error JSON to
   # STDOUT on failure, so on the failure path that body is a diagnostic -> stderr,
   # never the caller's content.
@@ -650,7 +650,7 @@ terminal_team_input_ready() {
 # a tmux send-keys concern, not herdr's. ASSERTED argv (agent prompt <id> <text>).
 terminal_poke() {
   local id="$1" text="$2"
-  # Same exit taxonomy as peek (tl/co1): a terminal that is UNREACHABLE (herdr not on
+  # Same exit taxonomy as peek: a terminal that is UNREACHABLE (herdr not on
   # PATH) is 10; a pane that cannot RECEIVE — gone, or with no live agent to accept the
   # prompt — is 12. 13 stays reserved for a driver with no poke path at all (plain's
   # permanent "no addressable pane"); a herdr pane whose agent has EXITED must not
@@ -676,7 +676,7 @@ terminal_poke() {
 # chars and a leading '-', so ':', '-' and '_' are all legal in team AND agent
 # names):
 #     ("a-b","c") and ("a","b-c")   both fold to  a-b-c
-#     ("a:b","c") and ("a","b:c")   both join to  a:b:c   (tl's `<team>:<agent>` too)
+#     ("a:b","c") and ("a","b:c")   both join to  a:b:c   (the `<team>:<agent>` form too)
 # We DERIVE instead: 'a' + the first 24 hex (96 bits) of SHA-256 of the pair. The
 # pair is joined with a NEWLINE, a control char FORBIDDEN in both names
 # (scripts/lib/validate.sh rejects [[:cntrl:]]), so the PREIMAGE encoding is

--- a/scripts/drivers/terminals/plain/ops.sh
+++ b/scripts/drivers/terminals/plain/ops.sh
@@ -53,7 +53,7 @@ terminal_spawn() {
   # can write to stdout — a custom template especially — and that would be captured
   # by the caller as the placement id. So each backend's STDOUT is redirected to
   # stderr (kept as a diagnostic, not swallowed), leaving only the '-' this function
-  # prints on stdout (co1).
+  # prints on stdout.
   if [ -n "$tmpl" ] && _plain_has_template "$tmpl"; then
     local q_boot; q_boot="$(printf '%q' "$boot")"
     local cmd="${tmpl//\{cmd\}/$q_boot}"

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -84,7 +84,7 @@ terminal_arrange() {
   return 0
 }
 
-# record op: report TWO facts and decide nothing (tl 2026-08-31). PRESENCE — are
+# record op: report TWO facts and decide nothing (2026-08-31). PRESENCE — are
 # we under tmux — is the exit code: 0 iff $TMUX is set (we ARE in tmux, whether or
 # not we can name our own pane). SELF-ID is stdout: $TMUX_PANE, which may be EMPTY
 # — that is the third value "could not resolve", NOT "not tmux"; the reason goes
@@ -139,7 +139,7 @@ terminal_spawn() {
       # $TMUX_PANE is the caller's pane (tmux sets it in every pane; the tmux
       # equivalent of herdr's $HERDR_PANE_ID). Require it and target it EXPLICITLY —
       # not observing the caller's pane is NOT evidence the ambient target is the
-      # caller, so fail closed rather than guess (positive-proof; co1). A window
+      # caller, so fail closed rather than guess (positive-proof). A window
       # target does not need it and is handled above.
       [ -n "${TMUX_PANE:-}" ] \
         || { printf 'unsupported: a tmux split needs $TMUX_PANE to target the caller pane (#990)\n' >&2; return 13; }
@@ -178,7 +178,7 @@ terminal_peek() {
   done
   case "$lines" in ''|*[!0-9]*) lines="" ;; esac
   # peek exit taxonomy, SHARED with herdr so the template reads one meaning across
-  # every peek-capable driver (co1): the terminal being UNREACHABLE (tmux not on
+  # every peek-capable driver: the terminal being UNREACHABLE (tmux not on
   # PATH — no server to talk to) is 10; an answered-but-no-content failure (the pane
   # is gone / capture failed) is 12. 13 is reserved for a driver with no peek path at
   # all (plain's permanent "no addressable pane") — a different message to the user,
@@ -247,7 +247,7 @@ EOF
 # — no env seam.
 terminal_poke() {
   local id="$1" text="$2"
-  # Same exit taxonomy as peek (tl/co1): tmux not on PATH (unreachable) is 10; a
+  # Same exit taxonomy as peek: tmux not on PATH (unreachable) is 10; a
   # send-keys failure (the pane is gone) is 12. 13 stays reserved for a driver with no
   # poke path at all (plain) — a tmux pane's transient loss must not borrow it.
   command -v tmux >/dev/null 2>&1 \

--- a/scripts/drivers/types/codex/type.conf
+++ b/scripts/drivers/types/codex/type.conf
@@ -24,7 +24,7 @@ stop_output=json
 # Measured on codex-cli 0.149.1: PostToolUse requires a hookSpecificOutput object
 # (hookEventName=PostToolUse, body in additionalContext); plain stdout is rejected
 # ("hook returned invalid post-tool-use JSON output"). Reaching the model with it
-# is not yet observed end-to-end (co1's sandbox blocked the loopback probe).
+# is not yet observed end-to-end (a sandboxed reviewer could not run the loopback probe).
 posttooluse_output=hookSpecificOutput
 # Floor for INSTALLING the PostToolUse entry: the exact codex CLI version the
 # event was measured on (0.149.1), compared full-numerically (patch included), so

--- a/scripts/internal/private-names.mjs
+++ b/scripts/internal/private-names.mjs
@@ -89,9 +89,16 @@ const NAME_AFTER = "(?![A-Za-z0-9])";
  */
 const NOT_IN_DATA_URI = "(?<!base64,[^\"'\\s]*)";
 const NOT_VARIABLE_REF = "(?<!\\$\\{?)";
-const NOT_IN_ARITHMETIC = "(?<!\\(\\([^)]*)";
+const NOT_IN_ARITHMETIC = "(?<!\\(\\([^)\\r\\n]*)";
+// Closed within ONE line on purpose: the pattern has no `m` flag, so `^` is the
+// start of whatever string it is run on, and `\s` / `[^#]` would both walk
+// across a newline. scan() feeds it one line at a time, but the pattern is
+// exported and must not depend on that: a declaration on line 1 could otherwise
+// hide an attribution on line 2 (measured with the pattern applied to a
+// two-line string). Space and tab only, and the run before the name stops at a
+// `#` OR a line break.
 const NOT_DECLARED =
-  "(?<!^\\s*(?:[A-Za-z_][A-Za-z0-9_]*=\\S*\\s+)*(?:local|declare|typeset|export|readonly|unset|read)\\s[^#]*)";
+  "(?<!^[ \\t]*(?:[A-Za-z_][A-Za-z0-9_]*=[^ \\t\\r\\n]*[ \\t]+)*(?:local|declare|typeset|export|readonly|unset|read)[ \\t][^#\\r\\n]*)";
 const NOT_ASSIGNED = "(?!=)";
 
 /**

--- a/scripts/internal/private-names.mjs
+++ b/scripts/internal/private-names.mjs
@@ -24,8 +24,8 @@
  * reasons, one of them load-bearing today:
  *
  * 1. `-` must NOT be a boundary here. These two are the SHAPE's boundaries, and
- *    a shape is built out of hyphens: with `\b`, `<a>-<b>-cc1` could match from
- *    the middle and report `<b>-cc1`, naming a seat that does not exist while
+ *    a shape is built out of hyphens: with `\b`, `<a>-<b>-cc<n>` could match from
+ *    the middle and report `<b>-cc<n>`, naming a seat that does not exist while
  *    the real one goes unreported. Excluding `-` forces the match to start at
  *    the beginning of the name. (The bare-name boundaries are separate, and
  *    deliberately looser — see below.)
@@ -50,7 +50,7 @@ const AFTER = "(?![A-Za-z0-9_-])";
  *
  *   refusing `-` on the LEFT   missed `<team>-<name>`, 17 real occurrences
  *   refusing `-` on the RIGHT  missed `<name>-approved`, found in review
- *   suppressing when a role follows missed `<hyphenated-base>-cc1` entirely,
+ *   suppressing when a role follows missed `<hyphenated-base>-cc<n>` entirely,
  *     because the shape does not match it either
  *
  * Every hole came from the same wish. A duplicate report costs a reader one
@@ -63,8 +63,40 @@ const NAME_BEFORE = "(?<![A-Za-z0-9])";
 const NAME_AFTER = "(?![A-Za-z0-9])";
 
 /**
+ * A listed name used as a shell IDENTIFIER is code, not attribution, and is not
+ * reported. Measured on the tree (2026-09-06): one two-letter handle is also
+ * the name storage drivers give to a local variable, in 102 lines of `$name` /
+ * `${name}` / `name=` and 19 declaration lines (`local … name …`,
+ * `read -r … name …`), plus one arithmetic use `$(( name + … ))`. Listing the
+ * handle without these guards reports 262 lines for 106 real ones, which is how
+ * a check gets switched off.
+ *
+ * Each guard names ONE syntactic context and nothing wider:
+ *   $name, ${name}      a variable reference
+ *   name=               an assignment (prose puts a space before `=`)
+ *   (( … name … ))      shell arithmetic, until the closing paren
+ *   local … name …      a declaration line: the first word (after any
+ *                       `VAR=value` prefixes) is a declaring builtin, and the
+ *                       name sits before any `#`. A comment on the same line is
+ *                       still scanned.
+ *   data:…;base64,…     the payload of a data URI is opaque bytes; a two-letter
+ *                       name lands in one by chance (measured: one SVG's
+ *                       embedded PNG). The guard ends at the closing quote or
+ *                       whitespace, so text after the URI is scanned again.
+ * Nothing here refuses punctuation prose actually uses — `name.`, `name,`,
+ * `(name)`, `name's`, `name/other` all still report — so the guards cannot
+ * hide a sentence. They are tested one by one in tests/private_names.test.mjs.
+ */
+const NOT_IN_DATA_URI = "(?<!base64,[^\"'\\s]*)";
+const NOT_VARIABLE_REF = "(?<!\\$\\{?)";
+const NOT_IN_ARITHMETIC = "(?<!\\(\\([^)]*)";
+const NOT_DECLARED =
+  "(?<!^\\s*(?:[A-Za-z_][A-Za-z0-9_]*=\\S*\\s+)*(?:local|declare|typeset|export|readonly|unset|read)\\s[^#]*)";
+const NOT_ASSIGNED = "(?!=)";
+
+/**
  * A seat name: a base, then a role, then an optional index. The base may
- * itself contain hyphens -- `<a>-<b>-cc1` is a seat, and a base of
+ * itself contain hyphens -- `<a>-<b>-cc<n>` is a seat, and a base of
  * `[a-z][a-z0-9]*` alone matched neither from `<a>` (where `-<b>` is not a
  * role) nor from `<b>` (where the preceding hyphen is refused).
  *
@@ -104,7 +136,11 @@ export function injectedPattern(names) {
   // attribution as the lowercase form. No capitalised variant exists on the
   // current tree, so this costs nothing today; it is for the one that will be
   // written, which a fixed sample cannot rule out.
-  return new RegExp(`${NAME_BEFORE}(?:${alternation})${NAME_AFTER}`, "gi");
+  return new RegExp(
+    `${NAME_BEFORE}${NOT_VARIABLE_REF}${NOT_IN_ARITHMETIC}${NOT_DECLARED}${NOT_IN_DATA_URI}` +
+    `(?:${alternation})${NAME_AFTER}${NOT_ASSIGNED}`,
+    "gi",
+  );
 }
 
 /** Read injected names from the environment: a literal list, or a file of them. */

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -129,7 +129,7 @@ _AGMSG_TERMINAL_OPTIONAL="terminal_team_observe terminal_team_input_ready"
 
 # Wipe every terminal_* ABI function from the current shell. Called before each
 # source so a driver that is switched to cannot inherit the previous driver's ops
-# — the clobber co1 flagged: "no function" fails loudly (command not found), but a
+# — the clobber flagged in review: "no function" fails loudly (command not found), but a
 # LEFTOVER function of a different driver succeeds and runs the wrong backend.
 _agmsg_terminal_unset_ops() {
   local fn
@@ -210,7 +210,7 @@ _agmsg_terminal_detect_one() {
   )
 }
 
-# Detection has TWO callers with different needs (tl 2026-08-31); detect itself
+# Detection has TWO callers with different needs (2026-08-31); detect itself
 # decides nothing — these do.
 #
 # Precedence for both: an explicit override (AGMSG_TERMINAL_DRIVER, or arg 2) wins
@@ -221,7 +221,7 @@ _agmsg_terminal_detect_one() {
 # member (despawn/peek/poke) read the terminal from the placement record, never
 # the env. The override env is AGMSG_TERMINAL_DRIVER (flag --terminal-driver,
 # wired in spawn's arg parsing) — a NEW name, because --terminal / AGMSG_TERMINAL
-# are the OS-terminal command template and stay unchanged (tl 2026-08-31).
+# are the OS-terminal command template and stay unchanged (2026-08-31).
 
 # resolve-for-PLACEMENT (spawn): which terminal are we under? Prints the terminal
 # NAME, exit 0. Uses PRESENCE only — it does NOT need the caller's own pane id
@@ -249,7 +249,7 @@ agmsg_terminal_resolve_placement() {
 }
 
 # resolve-for-NAME (terminal_name / SessionStart): prints "<terminal>\t<self-id>"
-# and exit 0. ORDER (tl 2026-09-01, from cc1's nested measurement): prefer a
+# and exit 0. ORDER (2026-09-01, from the nested-herdr measurement): prefer a
 # candidate that PRODUCED A PANE ID over one that only claimed PRESENCE; the
 # declaration order (herdr > tmux > plain) is the tiebreak AMONG id-producers.
 #
@@ -378,7 +378,7 @@ agmsg_terminal_ref_terminal() {
   # A KNOWN scheme is not enough: the id after it is still handed to the terminal as a
   # TARGET, so a corrupt id (tmux:%9;kill, tmux:alice, herdr:<newline>, plain:any)
   # must not fall through. Validate it against the terminal's grammar; fail closed
-  # otherwise (co1: the container is not the contents).
+  # otherwise (the container is not the contents).
   _agmsg_terminal_id_ok "$term" "$id" || return 1
   printf '%s\n' "$term"
 }

--- a/scripts/poke.sh
+++ b/scripts/poke.sh
@@ -96,7 +96,7 @@ if [ "$RC" -ne 0 ]; then
   # 13 is the driver's "unsupported" — it has already printed a precise reason to
   # stderr AND, for poke, a pointer to the type's native channel ("not a dead end").
   # A generic "could not poke" added AFTER it is the last line the operator reads and
-  # would CANCEL that guidance (tl). So on 13, let the driver's reason stand as the
+  # would CANCEL that guidance. So on 13, let the driver's reason stand as the
   # final word; only a reachability/delivery failure (10/12) or an unexpected code —
   # a genuine "it should have worked" — gets the entry's summary line.
   if [ "$RC" -ne 13 ]; then

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -178,7 +178,7 @@ done
 case "$SPLIT" in h|v) ;; *) die "--split must be 'h' or 'v'" ;; esac
 case "$READY_TIMEOUT" in ''|*[!0-9]*) die "--ready-timeout must be a whole number of seconds" ;; esac
 
-# Validate the terminal-driver override HERE, before any state change (co1): it is a
+# Validate the terminal-driver override HERE, before any state change: it is a
 # deterministic argument typo, so it must fail like --split does — before the role is
 # registered and a boot file is written (place_and_launch runs after both), and
 # before an unrelated "no team" error can mask it. The accepted set is EXACTLY the
@@ -516,7 +516,7 @@ chmod +x "$BOOT"
 # Write the placement record, and REPORT if the write itself failed. The record is
 # the ONLY authority peek / poke / despawn --force have over a spawned member, so a
 # live pane with no record (disk full, permission) is a distinct, worse state than a
-# clean spawn — not a success (co1/tl, full-head review). We cannot un-spawn the pane
+# clean spawn — not a success (full-head review). We cannot un-spawn the pane
 # that already exists, so we do not roll back; we set a flag the main flow turns into
 # `status=spawned-but-unrecorded` (a DIFFERENT word from `spawned`) with the pane id,
 # and a non-zero exit, so the operator knows a window exists it cannot address.
@@ -630,7 +630,7 @@ launch_in_herdr() {
 }
 
 _launch_os_terminal() {
-  # Place THROUGH the plain terminal driver (tl 2026-09-02: the driver claims
+  # Place THROUGH the plain terminal driver (2026-09-02: the driver claims
   # capabilities=spawn despawn, so production must actually go through it, not a
   # duplicate). plain's terminal_spawn does the OS-terminal launch — a {cmd} template
   # on any OS, else the current macOS terminal (`open -g -a`) / a Linux emulator /
@@ -646,12 +646,12 @@ _launch_os_terminal() {
     || die "could not open an OS terminal (see the reason above); run inside tmux/herdr or set a {cmd} AGMSG_TERMINAL"
   [ "$_plain_id" = '-' ] \
     || die "the plain terminal driver returned an unexpected placement id ('${_plain_id}') — expected '-' (an OS terminal has no addressable pane)"
-  # "launched", NOT "spawned" (tl): every placement line below states only that the
+  # "launched", NOT "spawned": every placement line below states only that the
   # pane was created and the boot typed into it — a PLACEMENT fact. It is deliberately
   # not the word "spawned", because whether the agent actually STARTED is answered
   # later and separately by the status= line (status=ready = a positive observation
   # that its watcher attached; status=launched-unconfirmed = a type with no handshake,
-  # so startup cannot be confirmed here). tl hit "spawned" printed while the agent had
+  # so startup cannot be confirmed here). Observed live: "spawned" printed while the agent had
   # not started (a shell prompt ate the first keystroke of the boot command).
   # The message keeps the two shapes the tests and users know: a custom template vs a
   # plain new window.
@@ -664,8 +664,8 @@ _launch_os_terminal() {
 
 place_and_launch() {
   # --terminal-driver / AGMSG_TERMINAL_DRIVER forces WHICH axis places the member,
-  # bypassing detection. It is a spawn/name PREFERENCE on a NEW surface (tl
-  # 2026-08-31); tmux/herdr each still require their own environment (a forced tmux
+  # bypassing detection. It is a spawn/name PREFERENCE on a NEW surface
+  # (2026-08-31); tmux/herdr each still require their own environment (a forced tmux
   # split needs to be inside tmux, a forced herdr split needs HERDR_PANE_ID), so an
   # impossible force fails in the launcher with that launcher's own error.
   if [ -n "$TERMINAL_DRIVER" ]; then
@@ -681,7 +681,7 @@ place_and_launch() {
   fi
 
   # No override: PRESERVE the detection order — $TMUX (tmux-inside-herdr backward
-  # compat) → herdr → OS terminal. tl deferred the nested spawn-placement decision to
+  # compat) → herdr → OS terminal. The nested spawn-placement decision is deferred to
   # the live matrix, so this does NOT switch to the registry's herdr-first resolver.
   if [ -n "${TMUX:-}" ]; then
     launch_in_tmux
@@ -725,7 +725,7 @@ place_and_launch
 # requirement 1 arm 3 (herdr): the boot was typed, but the pane's pre-input readiness
 # could not be verified. Say so with the BEFORE-typing reason — deliberately worded
 # apart from the AFTER-typing "launched-unconfirmed" below, so an operator can tell
-# which check was blind (utildev). Per co1's priority this is only a WARNING: the final
+# which check was blind (live measurement). By design this is only a WARNING: the final
 # startup verdict is still the post-input one — a watcher that then attaches makes the
 # status ready, and a monitor=no type still reports launched-unconfirmed on its own.
 if [ "$SPAWN_READINESS_UNVERIFIED" = "1" ]; then
@@ -734,7 +734,7 @@ fi
 
 # The pane was placed. If its placement record could not be written, the member is
 # running but unaddressable by peek/poke/despawn --force — report that distinctly and
-# fail, rather than let a normal `status=ready` imply everything is fine (co1/tl).
+# fail, rather than let a normal `status=ready` imply everything is fine.
 if [ "$SPAWN_UNRECORDED" = "1" ]; then
   echo "status=spawned-but-unrecorded name=${NAME} team=${TEAM} ref=${SPAWN_UNREC_REF}"
   echo "spawn: '${NAME}' launched, but its placement record could not be written (disk full or a permission error) — peek/poke/despawn --force cannot reach it. The pane is ${SPAWN_UNREC_REF}; close it manually if needed." >&2
@@ -759,13 +759,13 @@ elif [ "$SKIPPED_READINESS_BY_TYPE" = "1" ]; then
   # "spawned in <terminal>" placement log stand as success: a boot that never ran
   # (measured — a shell that prompts at startup eats the FIRST keystroke of the boot
   # command, so `/var/…/boot` becomes `var/…/boot: no such file or directory`) would
-  # otherwise read as a clean spawn. Report startup as UNCONFIRMED, distinctly (tl).
+  # otherwise read as a clean spawn. Report startup as UNCONFIRMED, distinctly.
   echo "status=launched-unconfirmed name=${NAME} team=${TEAM} note=no-readiness-handshake"
   echo "spawn: '${NAME}' was launched, but this type has no readiness handshake so its STARTUP IS UNCONFIRMED. If it does not appear, read its pane — a shell that prompts at startup (e.g. an update prompt) can eat the first keystroke of the boot command, and the failure then looks like a slow start." >&2
 else
   # Explicit --no-wait (WAIT_READY cleared by the flag, not by a monitor=no type): the
   # caller opted OUT of the readiness handshake, so — exactly like monitor=no — startup
-  # is not confirmed here, only that the boot was placed/typed. co1: both no-confirmation
+  # is not confirmed here, only that the boot was placed/typed. Both no-confirmation
   # paths report launched-unconfirmed, so this arm must exist too; a distinct note keeps
   # the two reasons legible. Silence (a bare `launched …` at rc 0) would imply success.
   echo "status=launched-unconfirmed name=${NAME} team=${TEAM} note=no-wait"

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -253,7 +253,7 @@ close_own_placement() {
   # assignment would leave rec_term/rec_id empty and fall through to the "belongs to
   # someone else" branch with an empty recorded side — a misleading message, and
   # under a caller's `set -e` it would take the watcher down with no log at all.
-  # Give the unresolvable ref its OWN contract, in the sibling guards' shape (co1).
+  # Give the unresolvable ref its OWN contract, in the sibling guards' shape.
   rec_term=""; rec_id=""
   rec_term="$(agmsg_terminal_ref_terminal "$ref")" || rec_term=""
   rec_id="$(agmsg_terminal_ref_id "$ref")" || rec_id=""

--- a/tests/private_names.test.mjs
+++ b/tests/private_names.test.mjs
@@ -90,16 +90,32 @@ test("a name used as a shell variable is code, and each context is refused on it
   // variable. Each line below is one syntactic context; a guard that covered
   // "anything near a dollar sign" would also have to explain why it did not
   // cover the next one, so they are pinned separately.
+  // Each case is scanned ALONE. Joined into one text, a declaration on the
+  // first line would be the only guard ever exercised if the others were
+  // broken (found in review); separate scans make each guard load-bearing.
   const T = ["t", "l"].join("");
-  const code = [
-    `  local db ${T} generation table_count`,           // declaration
-    `  IFS='|' read -r tid twin tt ${T} tw th <<< "$row"`, // declaration after a VAR= prefix
-    `  ${T}="$(_sqlite_lit "$team")"`,                     // assignment
-    `  sqlite3 "$db" "SELECT * FROM t WHERE team=$${T}"`, // reference
-    `  printf '%s' "\${${T}}"`,                            // braced reference
-    `  [ "$sl" -eq $((${T} + tw + 1)) ]`,                  // arithmetic
-  ].join("\n");
-  assert.deepEqual(scan(code, "scripts/x.sh", named(T)), []);
+  const cases = {
+    declaration: `  local db ${T} generation table_count`,
+    "declaration after a VAR= prefix": `  IFS='|' read -r tid twin tt ${T} tw th <<< "$row"`,
+    assignment: `  ${T}="$(_sqlite_lit "$team")"`,
+    reference: `  sqlite3 "$db" "SELECT * FROM t WHERE team=$${T}"`,
+    "braced reference": `  printf '%s' "\${${T}}"`,
+    arithmetic: `  [ "$sl" -eq $((${T} + tw + 1)) ]`,
+  };
+  for (const [context, line] of Object.entries(cases)) {
+    assert.deepEqual(scan(line, "scripts/x.sh", named(T)), [], context);
+  }
+});
+
+test("a declaration on one line cannot hide an attribution on the next", () => {
+  // The pattern is exported without the `m` flag, so `^`, `\s` and `[^#]`
+  // would all walk across a newline if the declaration guard let them. Run the
+  // raw pattern on a two-line string — NOT through scan(), which splits lines
+  // and would pass regardless.
+  const T = ["t", "l"].join("");
+  const text = `local x\nprintf 'review by ${T}'`;
+  const pattern = injectedPattern([T]);
+  assert.deepEqual([...text.matchAll(pattern)].map((m) => m[0]), [T]);
 });
 
 test("the identifier guards do not reach the prose forms attribution takes", () => {

--- a/tests/private_names.test.mjs
+++ b/tests/private_names.test.mjs
@@ -52,7 +52,7 @@ test("an injected name is found where it abuts CJK", () => {
 
 test("a hyphenated base is a seat, and neither detector may drop it", () => {
   // The hole that ended the no-double-report idea. A base can contain hyphens,
-  // and with a base of `[a-z][a-z0-9]*` the shape matched `<a>-<b>-cc1` from
+  // and with a base of `[a-z][a-z0-9]*` the shape matched `<a>-<b>-cc<n>` from
   // neither end -- not from `<a>` (`-<b>` is not a role) and not from `<b>` (the
   // preceding hyphen is refused). The bare-name detector then suppressed itself
   // too, on the theory that the shape had it. Nothing reported it.
@@ -83,6 +83,52 @@ test("a name hyphenated to an ordinary word is still the name", () => {
   // against the real tree.
   const found = scan(`# ${A}-approved interface, see ${A}-code`, "scripts/x.sh", named(A));
   assert.deepEqual(found.map((f) => f.name), [A, A]);
+});
+
+test("a name used as a shell variable is code, and each context is refused on its own", () => {
+  // Measured on the tree: a two-letter handle is also a storage driver's local
+  // variable. Each line below is one syntactic context; a guard that covered
+  // "anything near a dollar sign" would also have to explain why it did not
+  // cover the next one, so they are pinned separately.
+  const T = ["t", "l"].join("");
+  const code = [
+    `  local db ${T} generation table_count`,           // declaration
+    `  IFS='|' read -r tid twin tt ${T} tw th <<< "$row"`, // declaration after a VAR= prefix
+    `  ${T}="$(_sqlite_lit "$team")"`,                     // assignment
+    `  sqlite3 "$db" "SELECT * FROM t WHERE team=$${T}"`, // reference
+    `  printf '%s' "\${${T}}"`,                            // braced reference
+    `  [ "$sl" -eq $((${T} + tw + 1)) ]`,                  // arithmetic
+  ].join("\n");
+  assert.deepEqual(scan(code, "scripts/x.sh", named(T)), []);
+});
+
+test("the identifier guards do not reach the prose forms attribution takes", () => {
+  const T = ["t", "l"].join("");
+  const prose = [
+    `# report TWO facts and decide nothing (${T} 2026-08-31). PRESENCE`,
+    `# would CANCEL that guidance (${T}). So on 13, let the driver's reason stand`,
+    `# ${T}'s load-bearing case: real herdr with the lookup broken`,
+    `# ORDER (${T} 2026-09-01, from someone's nested measurement)`,
+    `@test "the single 13 is split (${T}/reviewer)" {`,
+    `  local x  # ${T} asked for this`,   // a comment on a declaration line is still prose
+    `# ${T}: assert with the measured value.`,
+  ].join("\n");
+  const found = scan(prose, "scripts/x.sh", named(T));
+  assert.equal(found.length, 7, found.map((f) => f.text).join("\n"));
+});
+
+test("a data URI's base64 payload is opaque, and the text after it is not", () => {
+  // Measured: an SVG embedding a PNG happened to contain a two-letter handle
+  // between two base64 punctuation characters. The guard stops at the quote
+  // that ends the URI, so a name written after it is still found.
+  // The payload copy is capitalised differently from the prose copy, so the
+  // reported name says which one was found: the match is case-insensitive and
+  // a failed guard would report the payload's spelling.
+  const T = ["t", "l"].join("");
+  const inPayload = ["t", "L"].join("");
+  const line = `<image href="data:image/png;base64,iVBORw0K+${inPayload}/AAA=" /><!-- ask ${T} -->`;
+  const found = scan(line, "docs/x.svg", named(T));
+  assert.deepEqual(found.map((f) => f.name), [T]);
 });
 
 test("a supplied name cannot widen itself through regex metacharacters", () => {

--- a/tests/test_inbox.bats
+++ b/tests/test_inbox.bats
@@ -339,7 +339,7 @@ delivered_to_operator() {
 
 # --- #1003: codex mid-turn delivery via PostToolUse emits the shape 0.149.1 wants ---
 #
-# These guard the "broken but green" tl named: a test that only checks a
+# These guard the "broken but green" case: a test that only checks a
 # PostToolUse hook entry EXISTS stays green even if check-inbox emits the wrong
 # shape. So they assert the SHAPE check-inbox actually emits, per event. (Whether
 # the model then receives it is unobserved — see the PR; measured here is only the

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -90,7 +90,7 @@ teardown() {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg-second
   # Distinct per-install sentinels, not just each install's VERSION (which is
   # the same source-derived string for both and would not distinguish "one of
-  # them got silently updated" from "neither did" -- co2 review, #659).
+  # them got silently updated" from "neither did" -- review of #659).
   echo "agmsg sentinel" > "$FAKE_HOME/.agents/skills/agmsg/SKILL.md"
   echo "agmsg-second sentinel" > "$FAKE_HOME/.agents/skills/agmsg-second/SKILL.md"
 
@@ -111,7 +111,7 @@ teardown() {
   # exclude nothing on a real machine, while remaining broad enough to
   # collide with a legitimately chosen --cmd name (--cmd has no reserved-name
   # validation: "agmsg.bak-tool" installs today with no error). Two rounds of
-  # narrowing hit that same collision from co2 review on #659; the fix is to
+  # narrowing hit that same collision from the #659 review; the fix is to
   # not special-case names at all. A directory that still carries the .agmsg
   # marker is just another candidate, and more than one candidate is exactly
   # the ambiguity this fix already refuses to guess through.

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -48,7 +48,7 @@ stored_types() {
 #
 # The values here come from send.sh, so this is a statement about the
 # product's own write path, not about a literal this test inserted. That
-# distinction is the whole point (tl ruling): a typeof() check on a value the
+# distinction is the whole point: a typeof() check on a value the
 # test wrote proves the test can write an integer.
 #
 # read_cursors is NOT here. A text AFFINITY on that column turns the 1005/999

--- a/tests/test_peek_poke.bats
+++ b/tests/test_peek_poke.bats
@@ -227,7 +227,7 @@ EOF
 }
 
 # --- peek exit taxonomy: UNREACHABLE (10) vs pane-gone (12) vs unsupported (13) ---
-# co1: 13 must mean ONE thing to the template — a driver with no peek path at all
+# The value 13 must mean ONE thing to the template — a driver with no peek path at all
 # (plain). A terminal that is momentarily unreachable (its CLI not on PATH) is 10;
 # an answered-but-no-content failure (the pane is gone) is 12. Both peek-capable
 # backends (tmux, herdr) must answer with the SAME taxonomy, so the two failures
@@ -312,7 +312,7 @@ EOF
   grep -q "could not read pane 'w1:p4'" "$errf"
 }
 
-# --- peek READ contract: content reaches stdout VERBATIM (co1) --------------
+# --- peek READ contract: content reaches stdout VERBATIM --------------
 # herdr's content is captured to a temp file and cat'd, NOT round-tripped through a
 # command substitution (which strips every trailing newline) + printf '%s\n' (which
 # invents exactly one back). Assert the BYTES, since `run`/$output would itself hide
@@ -388,7 +388,7 @@ EOF
 
 # --- poke exit taxonomy: UNREACHABLE (10) vs no-live-agent / pane-gone (12) vs
 #     unsupported (13) --------------------------------------------------------
-# tl found the same 13-conflation co1 caught in peek, still in poke: a herdr pane
+# The same 13-conflation caught in peek was still in poke: a herdr pane
 # whose agent has EXITED returned 13, which the template reads as plain's permanent
 # "no addressable pane". poke now uses the SAME taxonomy as peek across both backends.
 # This also makes the peek/poke asymmetry concrete: peek reads a pane with no live
@@ -451,7 +451,7 @@ EOF
 }
 
 # --- poke entry: on `unsupported` (13) the driver's guidance is the LAST line ----
-# tl: for plain, the driver says "not a dead end — the type template says which native
+# For plain, the driver says "not a dead end — the type template says which native
 # channel"; poke.sh must not cover that with a generic "could not poke", which would be
 # the last line the operator reads. Only 13 (unsupported) suppresses the entry line;
 # a real delivery failure (12) still gets it.

--- a/tests/test_resume_seat_guard.bats
+++ b/tests/test_resume_seat_guard.bats
@@ -149,7 +149,7 @@ _run_session_start() {
 }
 
 @test "resume, narrowed to bob: the emitted watcher consumes bob's mail only, not alice's" {
-  # The strongest guard (tl's ask): run the directive AS EMITTED and check which
+  # The strongest guard: run the directive AS EMITTED and check which
   # pairs it actually consumes. A watcher that ignored its 4th arg — or a
   # regression that emitted the generic one — would advance alice's cursor too.
   _mark_sid_alive "sid-bob"

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -817,7 +817,7 @@ EOF
 }
 
 @test "spawn: --no-wait on a monitor=YES type still reports launched-unconfirmed (no post-input confirmation)" {
-  # co1 full-head: --no-wait skips the readiness handshake by request, so startup is
+  # Full-head review: --no-wait skips the readiness handshake by request, so startup is
   # NOT confirmed — exactly like monitor=no. Both no-confirmation paths must report
   # status=launched-unconfirmed (a distinct note keeps the reasons apart). A monitor=YES
   # type (claude-code) with --no-wait is the arm that was silently falling through both
@@ -853,7 +853,7 @@ EOF
 }
 
 @test "spawn: a no-handshake type (monitor=no) reports startup UNCONFIRMED, not a bare success" {
-  # tl hit "spawned" printed while the agent had not started (a startup shell prompt
+  # Observed live: "spawned" printed while the agent had not started (a startup shell prompt
   # ate the first keystroke of the boot command). A type with no readiness handshake
   # cannot confirm startup, so spawn must say so DISTINCTLY — status=launched-unconfirmed
   # with an explanation — instead of letting the placement line stand as success.
@@ -872,7 +872,7 @@ EOF
 @test "spawn: --no-wait says 'launched' (never 'spawned'), and its unconfirmed NOTE differs from monitor=no's" {
   # The placement word is 'launched', never 'spawned', on the --no-wait path too; and
   # the two no-confirmation reasons read apart — --no-wait carries note=no-wait, a
-  # monitor=no type carries note=no-readiness-handshake (utildev: distinct wording).
+  # monitor=no type carries note=no-readiness-handshake (distinct wording).
   bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
   run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
   [ "$status" -eq 0 ]
@@ -1251,7 +1251,7 @@ _spawn_recorded_id() {
 }
 
 @test "spawn req1: a numeric-STRING pid is UNKNOWN on BOTH arms and either field (json_type must be integer)" {
-  # co1/tl (3): json_extract turns a JSON string "5" into 5, which would pass a digit
+  # json_extract turns a JSON string "5" into 5, which would pass a digit
   # check; the classifier requires json_type=integer on BOTH fields. Each case below
   # must be UNKNOWN -> type + BEFORE-typing warning, NOT the NOT-READY 5s-wait/fail and
   # NOT a silent ready. The cases pin the drift a one-sided control would miss:
@@ -1295,7 +1295,7 @@ _spawn_recorded_id() {
 }
 
 @test "spawn req1: arm-3 (pre-input) and launched-unconfirmed (post-input) are DISTINCT messages" {
-  # utildev: the two 'unconfirmed' reasons must read apart. A monitor=no type spawned
+  # The two 'unconfirmed' reasons must read apart. A monitor=no type spawned
   # through herdr with UNKNOWN readiness shows BOTH, worded differently.
   bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
   _setup_fake_herdr
@@ -1331,7 +1331,7 @@ _spawn_recorded_id() {
 }
 
 @test "spawn: --terminal-driver validates EARLY — before team resolution or any state change" {
-  # co1: an unknown driver is a deterministic arg typo, so it must fail before spawn
+  # An unknown driver is a deterministic arg typo, so it must fail before spawn
   # registers a role or writes a boot file, and before an unrelated 'no team' can mask
   # it. With NO team registered for the project, a bogus driver must STILL error with
   # 'unknown terminal driver' (not 'no team') — proving the check runs at parse time.

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -125,7 +125,7 @@ _fake_herdr_list_numeric_pane() {
 # must be not-among — NOT did-not-answer.
 _fake_herdr_list_bare_pane() {
   local sid="${1:-sess-OTHER}"
-  # The MEASURED session-less pane (utildev, live herdr, raw JSON): the agent_session
+  # The MEASURED session-less pane (live herdr, raw JSON): the agent_session
   # KEY is ABSENT entirely. B recognizes it by STRUCTURE, not by agent_status's value:
   # the pane carries the herdr-pane identity anchor (agent, terminal_id, tab_id,
   # workspace_id — measured always-present) and every field is a SCALAR. agent_status
@@ -236,7 +236,7 @@ _fake_herdr_list_scalar_session() {
   [ "$(agmsg_terminal_ref_id '%3')" = "%3" ]
 }
 
-@test "record: an unknown or CORRUPT ref FAILS CLOSED — validates the ID, not just the scheme (co1)" {
+@test "record: an unknown or CORRUPT ref FAILS CLOSED — validates the ID, not just the scheme" {
   # A ref is handed to a terminal as a TARGET (peek/poke/despawn). A KNOWN scheme is
   # not enough — the id after it must be a well-formed id for that terminal, or a
   # corrupt id (tmux:%9;kill, tmux:alice -> a real session, herdr:junk, plain:any)
@@ -347,7 +347,7 @@ _fake_herdr_list_scalar_session() {
 
 @test "tmux: spawn --split FAILS CLOSED when \$TMUX_PANE is unset (no ambient guess, #990)" {
   # Not observing the caller's pane is not evidence the ambient target is the caller
-  # (co1). A pane split must fail closed (13) rather than let tmux pick the attached
+  # A pane split must fail closed (13) rather than let tmux pick the attached
   # client's active window — and it must not call split-window at all.
   _install_fake_tmux
   agmsg_terminal_load tmux
@@ -543,7 +543,7 @@ EOF
 }
 
 @test "herdr: terminal_spawn reaches the readiness arms under a NON-conditional set -e caller" {
-  # co1 (1): the readiness classifier returns non-zero for NOT-READY/UNKNOWN; a bare
+  # The readiness classifier returns non-zero for NOT-READY/UNKNOWN; a bare
   # `classifier; ready_rc=$?` takes a set -e caller down BEFORE the arms classify. The
   # spawn.sh tests call terminal_spawn inside `$(...)`, where errexit is masked — so
   # prove the fix from a NON-conditional set -e caller (terminal_spawn called directly).
@@ -582,7 +582,7 @@ EOF
 }
 
 @test "herdr: the pane-id grammar shell authority agrees with the resolver on boundary values" {
-  # co1: the resolver (SQL GLOB) and the spawn side (_herdr_pane_id_ok, bash) express
+  # The resolver (SQL GLOB) and the spawn side (_herdr_pane_id_ok, bash) express
   # the SAME grammar; a drift between them would let one accept what the other rejects.
   # Cross-check both on the boundary set: the shell authority and a resolver lookup
   # (via a one-entry list whose pane_id is the value) must agree on accept/reject.
@@ -781,7 +781,7 @@ EOF
   grep -q '\[pane\] \[move\]' "$ARGV_LOG"
 }
 
-@test "herdr peek: an error body is NOT returned as content, and the single 13 is split (tl/co1)" {
+@test "herdr peek: an error body is NOT returned as content, and the single 13 is split" {
   agmsg_terminal_load herdr
   # (1) herdr answers but the pane is GONE: it exits non-zero AND writes an error JSON
   # to STDOUT. peek must NOT hand that back as the pane content (stdout empty), and it
@@ -805,9 +805,9 @@ _last_agent_rename_key() {
 }
 
 @test "herdr naming: the internal key avoids the known fold/join collisions ('-' and ':')" {
-  # tl/cc1/co1 2026-09-01: the old fold (':' and non-regex chars -> '-') and ANY
+  # 2026-09-01: the old fold (':' and non-regex chars -> '-') and ANY
   # literal separator have a STRUCTURAL (deterministic, reachable) collision, because
-  # the separator is legal inside a name. cc1's example:
+  # the separator is legal inside a name. Example:
   #     ("a-b","c") and ("a","b-c")   both fold to  a-b-c
   # and the same holds for the ':' the spec proposed as the join char:
   #     ("a:b","c") and ("a","b:c")   both join to  a:b:c
@@ -831,10 +831,10 @@ _last_agent_rename_key() {
   [ "$k3" != "$k4" ]
 }
 
-# --- ABI completeness + structural clobber-proofing (co1 #1014 review) -------
+# --- ABI completeness + structural clobber-proofing (#1014 review) -------
 
 @test "abi: every driver defines every required terminal_* function" {
-  # The declaration/implementation match co1 flagged: an ops.sh missing a verb
+  # The declaration/implementation match flagged in review: an ops.sh missing a verb
   # would, after a prior load, silently run the previous driver's same-named
   # function. agmsg_terminal_load verifies the full set; loading each driver must
   # therefore succeed (a missing verb fails the load loudly).
@@ -897,7 +897,7 @@ OPS
   refute declare -F terminal_poke
 }
 
-# --- fail-closed resolution (co1 #1014 review) ------------------------------
+# --- fail-closed resolution (#1014 review) ------------------------------
 
 @test "detect: tmux with an empty \$TMUX_PANE still PLACES in tmux (presence)" {
   # For placement, being in tmux is enough — spawn records the pane it CREATES,
@@ -911,7 +911,7 @@ OPS
 
 @test "detect: tmux with an empty \$TMUX_PANE is FATAL for naming, with a reason" {
   # For naming, we must identify the pane. Present-but-no-id is fatal: say why,
-  # non-zero — better than naming nothing (co1's fail-closed lives on this side).
+  # non-zero — better than naming nothing (the fail-closed rule lives on this side).
   export TMUX="/tmp/sock,1,0"
   unset TMUX_PANE
   run agmsg_terminal_resolve_name "sess-x"
@@ -961,7 +961,7 @@ OPS
   [ "$output" = "ok" ]
 }
 
-@test "plain: spawn ISOLATES backend stdout — the record-op result is exactly '-' (co1)" {
+@test "plain: spawn ISOLATES backend stdout — the record-op result is exactly '-'" {
   # spawn is a record op: its stdout must be the id ('-') and nothing else. A backend
   # (here a {cmd} template) that writes to stdout must not pollute the captured result
   # — otherwise the caller reads '<noise>\n-' as the placement id. Capture stdout
@@ -977,7 +977,7 @@ OPS
   [ "$out" = "-" ]                       # exactly '-', the backend noise did not leak
 }
 
-# --- load failure cleanup: source failure, like missing-function, leaves nothing (co1 rd2) ---
+# --- load failure cleanup: source failure, like missing-function, leaves nothing (review round 2) ---
 
 @test "load: a driver whose ops.sh fails to source leaves no partial functions behind" {
   local pdir="$TEST_SKILL_DIR/plugins/terminals/halfsource"
@@ -1006,7 +1006,7 @@ OPS
   [ -z "$_AGMSG_TERMINAL_LOADED" ]
 }
 
-# --- herdr spawn target validation (co1 rd2) --------------------------------
+# --- herdr spawn target validation (review round 2) --------------------------------
 
 @test "herdr: spawn rejects an unknown target instead of defaulting" {
   _install_fake_herdr "s"
@@ -1030,7 +1030,7 @@ OPS
   refute grep -q '\[pane\] \[split\]' "$ARGV_LOG"
 }
 
-# --- co1 round-5: presence vs binary availability; errexit-safe reason read ---
+# --- Review round 5: presence vs binary availability; errexit-safe reason read ---
 
 @test "herdr: HERDR_ENV=1 with NO herdr binary still PLACES in herdr (presence != binary)" {
   # Restrict PATH so `herdr` is genuinely absent (this machine has a real one),
@@ -1046,7 +1046,7 @@ OPS
 
 @test "herdr naming: 'agent list' cannot answer -> fatal, reason 'did not answer'" {
   # herdr present (HERDR_ENV=1) but its list errors: resolve-for-name is fatal and
-  # the driver's reason reaches the error (co1: the reason reaches A). A real herdr
+  # The driver's reason reaches the error (the reason reaches A). A real herdr
   # is on PATH here, so shadow it with a failing fake.
   _fake_herdr_list_fails
   export HERDR_ENV=1
@@ -1069,7 +1069,7 @@ OPS
   # POSITIVE PROOF the json_valid gate discriminates: a herdr that exits 0 with
   # non-JSON bytes must be "could not answer" (return 2), not silently downgraded to
   # "answered, this session is not among the agents". The two reasons are the two
-  # sides co1 named: garbage -> did-not-answer; empty valid array -> not-among.
+  # sides named in review: garbage -> did-not-answer; empty valid array -> not-among.
   _fake_herdr_list_garbage
   export HERDR_ENV=1
   run agmsg_terminal_resolve_name "sess-x"
@@ -1079,7 +1079,7 @@ OPS
 }
 
 @test "resolve_name: no set -e leak; a BARE call still reaches and PRINTS the verdict line" {
-  # co1 round-6: the old control wrapped the call in `|| rc=$?`, which disables set -e
+  # Review round 6: the old control wrapped the call in `|| rc=$?`, which disables set -e
   # for the ENTIRE function body — so an internal errexit leak could not be observed.
   # This is a BARE call under `set -e`: two leak-prone sites run before the verdict —
   #   (1) the loop's `id="$(_detect_one herdr ...)"` returns non-zero (HERDR_ENV unset)
@@ -1100,7 +1100,7 @@ M
 }
 
 @test "herdr naming: valid JSON, UNKNOWN schema ({}) -> did-not-answer, NOT 'no match'" {
-  # co1/tl 2026-09-01: a SUCCESSFUL json_each is not proof of a recognized list.
+  # 2026-09-01: a SUCCESSFUL json_each is not proof of a recognized list.
   # json_each on {} returns 0 rows and succeeds, which without the json_type gate
   # would misclassify an unknown schema as "answered, session not present". Only a
   # real ARRAY at a candidate path counts as answered. This is the OTHER side of the
@@ -1126,7 +1126,7 @@ M
 }
 
 @test "herdr naming: entry-shape drift (SCALAR agent_session) is did-not-answer, NOT not-among" {
-  # co1/tl 2026-09-01 (3rd instance of the shape): the answer depends on the session
+  # 2026-09-01 (3rd instance of the shape): the answer depends on the session
   # id being COMPARED against a real entry, so schema drift is NOT a positive proof
   # of absence. A non-empty array whose entries are the OLD scalar-agent_session
   # shape has 0 expected-shape entries -> did-not-answer (return 2), not "answered,
@@ -1154,7 +1154,7 @@ M
 }
 
 @test "herdr naming: a BARE PANE (no agent_session) is decidable — absent target is not-among" {
-  # utildev live-measured: the real machine has a session-less pane among the agents.
+  # Live-measured: the real machine has a session-less pane among the agents.
   # A bare pane definitely is not the target, so it does NOT block a not-among answer
   # (the earlier well==alen rule treated it as unreadable, making not-among
   # unreachable — every absent session wrongly returned did-not-answer).
@@ -1175,7 +1175,7 @@ M
 }
 
 @test "herdr naming: the bare-pane arm is POSITIVE by STRUCTURE — an unresolvable entry is did-not-answer" {
-  # B recognizes a session-less pane by structure (co1/tl 2026-09-04), not by a value
+  # B recognizes a session-less pane by structure (2026-09-04), not by a value
   # or a key-name set — both drift while a pane lives. An entry is did-not-answer, never
   # a silent not-among, unless it is provably a bare pane: agent_session key absent, a
   # valid pane_id, the fixed identity anchor present, and NO field object/array-valued.
@@ -1213,7 +1213,7 @@ M
   #   - working / idle / done: the live-changing value must NOT gate the answer.
   #   - an unknown SCALAR extension key: herdr adding a scalar field must not break it.
   #   - name + display_agent (a NAMED bare pane): DEFENSIVE — this state (name present,
-  #     agent_session absent) was NOT observed as of 2026-09-04 (utildev); display_agent
+  #     agent_session absent) was NOT observed as of 2026-09-04 (live measurement); display_agent
   #     was a string in one 2026-09-04 agent list. Kept so naming (this driver's own job)
   #     cannot silently make a member unresolvable.
   export HERDR_ENV=1
@@ -1233,7 +1233,7 @@ M
 }
 
 @test "herdr naming: target session with a MISSING/null pane_id -> did-not-answer (unaddressable)" {
-  # co1 round 10: pane_ok must be a definite 0/1, not a boolean that goes NULL when
+  # Review round 10: pane_ok must be a definite 0/1, not a boolean that goes NULL when
   # pane_id is absent — else a target session with no pane_id falls into neither hit
   # (AND pane_ok) nor badhit (AND NOT pane_ok) and, if it is the only decidable
   # entry, reads as not-among though the target is present-but-unaddressable. Both a
@@ -1251,7 +1251,7 @@ M
 }
 
 @test "herdr naming: MIXED array, target ABSENT -> did-not-answer (cannot rule out the malformed entry)" {
-  # co1/tl one layer further: >=1 well-formed entry proves some entries are readable,
+  # One layer further: >=1 well-formed entry proves some entries are readable,
   # NOT that the target is not hiding in a malformed sibling. Here alen=2 (a
   # well-formed other-session entry + a malformed one) and well=1; the searched
   # session is in neither well-formed slot. Absence is NOT provable — the target
@@ -1275,7 +1275,7 @@ M
 }
 
 @test "herdr naming: a pane_id containing '|' is NOT well-formed -> did-not-answer (framing-safe)" {
-  # co1/tl: json text can contain the '|' this function frames on. 'w1:p|4' passes
+  # JSON text can contain the '|' this function frames on. 'w1:p|4' passes
   # the skeleton but the '|' is caught by the safety class, so it exercises that
   # guard (not just the skeleton). Its entry is not well-formed -> the sole entry is
   # ill-formed -> did-not-answer, and no truncated/garbled pane is resolved.
@@ -1298,7 +1298,7 @@ M
 }
 
 @test "herdr naming: the MEASURED real pane-id form (w1:p4) still RESOLVES (not over-narrowed)" {
-  # tl: assert with the measured value that narrowing did not reject the real form.
+  # Assert with the measured value that narrowing did not reject the real form.
   # Real herdr 0.8.0 on this machine emits w<n>:p<x> (w1:p4, w1:pB, w5:p3).
   _fake_herdr_list_one_pane "sess-mine" 'w1:p4'
   export HERDR_ENV=1
@@ -1308,7 +1308,7 @@ M
 }
 
 @test "herdr naming: the SEARCH predicate == the well-formed predicate (no numeric pane_id find)" {
-  # co1: the search must not be weaker than the count. A malformed entry that carries
+  # The search must not be weaker than the count. A malformed entry that carries
   # the target agent_session.value but a NUMERIC pane_id is NOT well-formed; the
   # search must skip it (not return pane 123), and with a well-formed sibling present
   # the set is not fully comparable -> did-not-answer. A search predicate of only
@@ -1323,7 +1323,7 @@ M
 }
 
 @test "resolve order: NESTED herdr-in-tmux — tmux (produces %0) wins over herdr (present, no id)" {
-  # tl 2026-09-01: a nested herdr-in-tmux inherits HERDR_* into a tmux server it
+  # 2026-09-01: a nested herdr-in-tmux inherits HERDR_* into a tmux server it
   # spawned. herdr says 'present' but resolves no pane; tmux CAN produce %0. The
   # id-producer must win (record tmux:%0 — the pane really is a tmux pane), not the
   # first-present. herdr is tried first in declaration order, so this proves the
@@ -1337,7 +1337,7 @@ M
 }
 
 @test "resolve order: herdr broken AND no tmux pane -> FATAL with BOTH reasons, not silent plain" {
-  # tl's load-bearing case: real herdr with the lookup broken, and $TMUX_PANE empty.
+  # The load-bearing case: real herdr with the lookup broken, and $TMUX_PANE empty.
   # No candidate produces a nameable id. This must fail LOUDLY with EVERY present
   # candidate's reason (not one), rather than fall through to plain's '-' and succeed
   # silently. 'noisy wrong' beats 'silent wrong'.
@@ -1413,7 +1413,7 @@ M
 }
 
 @test "terminal_name_self: a failed record re-write leaves the EXISTING correct record intact (atomic)" {
-  # co1: SessionStart / actas re-name a pane that ALREADY has a correct record. A raw
+  # SessionStart / actas re-name a pane that ALREADY has a correct record. A raw
   # `>` truncates it at open, so a write that then fails (ENOSPC / permission) has
   # destroyed the authority peek/poke/despawn depend on BEFORE it can report the
   # failure. agmsg_write_atomic writes a temp beside the record and renames, so a

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -995,7 +995,7 @@ _record_handover_events() {
 }
 
 # --- close_own_placement: an unresolvable pane ref gets its OWN logged branch ---
-# co1 (3): the ref parser fails CLOSED (non-zero) on a corrupt/unknown-scheme ref.
+# The ref parser fails CLOSED (non-zero) on a corrupt/unknown-scheme ref.
 # A bare `rec_term="$(...)"` left rec_term/rec_id empty and fell through to the
 # "belongs to someone else" branch with an EMPTY recorded side (a misleading log),
 # and under a caller's set -e it would take the watcher down with no log at all.


### PR DESCRIPTION
## Summary

- The private-name checker's injected half now refuses shell identifier contexts — `$name`, `${name}`, `name=`, `(( … name … ))`, and the bare words of a `local`/`read`/… declaration line — plus the base64 payload of a data URI. Each context has its own unit test, and one test pins that the prose forms (`(name 2026-…)`, `name's`, `name/other`, `name:`) are still reported. Without this, a listed two-letter handle that is also a variable name in the storage drivers reported 262 lines for 106 real ones.
- The checker's own comments illustrate the seat shape with `cc<n>` instead of a concrete index; the jsonl SQL template's team-substitution marker is renamed `__TEAM__` (its old two-letter spelling collided with a listed handle under case-insensitive matching, and the new name says what it holds).
- 113 lines in 20 files that carried a reviewer's or coordinator's handle as the reason for a rule now state the fact instead: dates and measurements stay, review rounds are numbered without a name, and sentences that lost their subject were rewritten (CHANGELOG entries, driver comments, test comments and test names).

## Order of work

The private list (kept outside this repository, as the checker's own comment requires) gained the unshaped handles first, so the checker reported all 113 lines **before** any rewrite; the rewrite was then driven by that report until it reached 0 with the list still injected.

## Verification

- `AGMSG_PRIVATE_NAMES_FILE=<private list> node scripts/check-private-names.mjs` → clean, 457 files scanned (list injected).
- Positive control: the same list plus one name that does occur in the tree → red on 44 files. No list at all → exit 2 (misconfigured), not a pass.
- `AGMSG_PRIVATE_NAMES=none node scripts/check-private-names.mjs` (the CI form) → clean.
- `node --test tests/private_names.test.mjs` → 17 pass.
- `.github/scripts/check-enforced-assertions.sh` at baseline (628); `.github/scripts/check-errexit-status-reads.sh` at baseline (0).
- `bats`: test_terminal_registry 96/96, test_peek_poke 30/30, test_spawn 89/89, test_storage_contract 34/34, test_jsonl_remote_sync 25/25; the remaining touched suites (comment-only edits) are reported in the review thread.

One two-letter token was deliberately not added to the list: it also appears inside a package name in the site lockfile (3 lines, permanently), so its single real occurrence was rewritten instead and the reason is recorded next to the list.
