### PR TITLE
fix(team): tell a key that is absent from a key that could not be read

### DIFF
--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -706,7 +706,21 @@ terminal_team_observe() {
   activity="$(sqlite3 :memory: "SELECT COALESCE(json_extract('$pesc','\$.result.pane.agent_status'),'unknown:activity_missing')" 2>/dev/null)" || return 10
   label="$(sqlite3 :memory: "SELECT COALESCE(json_extract('$pesc','\$.result.pane.label'),'unknown:pane_label_missing')" 2>/dev/null)" || return 10
   title="$(sqlite3 :memory: "SELECT COALESCE(json_extract('$pesc','\$.result.pane.terminal_title'),'unknown:terminal_title_missing')" 2>/dev/null)" || return 10
-  key="$(sqlite3 :memory: "SELECT COALESCE((SELECT json_extract(value,'\$.name') FROM json_each('$aesc','\$.result.agents') WHERE json_extract(value,'\$.pane_id')='$(printf '%s' "$id" | sed "s/'/''/g")' LIMIT 1),'unknown:agent_key_missing')" 2>/dev/null)" || return 10
+  # Two different facts were collapsed into one value here, and the one this
+  # exists to repair travelled the ambiguous half. The agent list was already
+  # fetched successfully above (`|| return 10`), so reaching this point means the
+  # list was READ — what remains undecided is only which case produced no name:
+  #
+  #   no entry for this pane_id   -> the pane could not be located in the list.
+  #                                  Undecided: `unknown:` (team --fix skips it).
+  #   entry present, no `.name`   -> the list answered ABOUT this pane and it
+  #                                  carries no key. Decided: `absent:`, which
+  #                                  reaches team --fix as a mismatch. This is
+  #                                  the measured codex case.
+  #
+  # The nesting does the split: the inner COALESCE fires only when a row matched,
+  # the outer one only when none did.
+  key="$(sqlite3 :memory: "SELECT COALESCE((SELECT COALESCE(json_extract(value,'\$.name'),'absent:agent_key_unset') FROM json_each('$aesc','\$.result.agents') WHERE json_extract(value,'\$.pane_id')='$(printf '%s' "$id" | sed "s/'/''/g")' LIMIT 1),'unknown:pane_not_in_agent_list')" 2>/dev/null)" || return 10
   case "$activity$label$key$title" in *$'\t'*|*$'\n'*|*$'\r'*) return 10 ;; esac
   printf '%s\t%s\t%s\t%s\n' "$activity" "$label" "$key" "$title"
 }

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -718,9 +718,17 @@ terminal_team_observe() {
   #                                  reaches team --fix as a mismatch. This is
   #                                  the measured codex case.
   #
+  # NULLIF is load-bearing, not defensive: `json_extract` returns SQL NULL for a
+  # missing key and for JSON null, but the EMPTY STRING for `"name":""` (measured).
+  # An empty key is decidedly not a key, yet without NULLIF it slipped past the
+  # COALESCE as a value -- and an empty field makes the wrapper call the whole
+  # observation `unknown:observe_malformed`, which --fix skips. So the one case
+  # this exists to repair would have been skipped again, taking the other three
+  # fields' observations down with it.
+  #
   # The nesting does the split: the inner COALESCE fires only when a row matched,
   # the outer one only when none did.
-  key="$(sqlite3 :memory: "SELECT COALESCE((SELECT COALESCE(json_extract(value,'\$.name'),'absent:agent_key_unset') FROM json_each('$aesc','\$.result.agents') WHERE json_extract(value,'\$.pane_id')='$(printf '%s' "$id" | sed "s/'/''/g")' LIMIT 1),'unknown:pane_not_in_agent_list')" 2>/dev/null)" || return 10
+  key="$(sqlite3 :memory: "SELECT COALESCE((SELECT COALESCE(NULLIF(json_extract(value,'\$.name'),''),'absent:agent_key_unset') FROM json_each('$aesc','\$.result.agents') WHERE json_extract(value,'\$.pane_id')='$(printf '%s' "$id" | sed "s/'/''/g")' LIMIT 1),'unknown:pane_not_in_agent_list')" 2>/dev/null)" || return 10
   case "$activity$label$key$title" in *$'\t'*|*$'\n'*|*$'\r'*) return 10 ;; esac
   printf '%s\t%s\t%s\t%s\n' "$activity" "$label" "$key" "$title"
 }

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -313,7 +313,7 @@ terminal_peek() {
 # tmux has no pane-label field independent of the CLI-owned terminal title.
 # The resolvable key is the pane-local @agmsg_agent user option.
 terminal_team_observe() {
-  local id="$1" key title bare
+  local id="$1" key title bare facts seen_id
   command -v tmux >/dev/null 2>&1 || return 10
   # Two separate things, and doing only one of them is worse than doing neither:
   # STRIP the socket so the kind test and `-t` see a bare id, and USE that socket
@@ -323,8 +323,28 @@ terminal_team_observe() {
   bare="$(_tmux_bare_of "$id")"
   case "$bare" in @*|%*) : ;; *) return 13 ;; esac
   key="$(_tmux_do "$id" show-options -p -v -t "$bare" @agmsg_agent 2>/dev/null)" || key=""
-  title="$(_tmux_do "$id" display-message -p -t "$bare" '#{pane_title}' 2>/dev/null)" || return 10
-  [ -n "$key" ] || key=unknown:agent_key_missing
+  # Co-observe the pane id we asked about, in the SAME query as the title. An
+  # empty `@agmsg_agent` only means "unset" if the pane was actually reached, and
+  # nothing here proved that: MEASURED on tmux 3.5, `display-message -p -t %999`
+  # exits 0 with EMPTY output for a pane that does not exist, so the `|| return`
+  # guard below never fires for it. Without the co-observation, a missing pane
+  # and an unset option produced the identical answer — and that answer decides
+  # whether `team --fix` overwrites the key.
+  #
+  # `#{pane_id}` is the canary: its value is known before the call (it is the
+  # target), so it separates "the server answered about THIS pane" from "the
+  # server answered about nothing". Same move as `terminal_pane_state` (#1051).
+  facts="$(_tmux_do "$id" display-message -p -t "$bare" '#{pane_id}|#{pane_title}' 2>/dev/null)" || return 10
+  seen_id="${facts%%|*}"
+  title="${facts#*|}"
+  # Not the pane we asked about (or no pane at all) -> the observation did not
+  # happen. 10 is "could not be reached", the same answer a dead server gets:
+  # `unknown` on a field would be a claim about the pane, and we have none.
+  [ "$seen_id" = "$bare" ] || return 10
+  # The pane IS proven reachable now, so an empty key is a decided fact, not a
+  # failed read. It is NOT `unknown:` — that prefix is the marker `team --fix`
+  # skips on, and skipping is what left every codex seat unnamed.
+  [ -n "$key" ] || key=absent:agent_key_unset
   [ -n "$title" ] || title=unknown:terminal_title_missing
   case "$key$title" in *$'\t'*|*$'\n'*|*$'\r'*) return 10 ;; esac
   printf 'n/a:unsupported\tn/a:no_independent_field\t%s\t%s\n' "$key" "$title"

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -310,10 +310,26 @@ terminal_peek() {
   return 0
 }
 
+# A tmux ref names one of two KINDS, and each kind has its own identity field.
+# The pair is the rule, not two branches: asking `#{pane_id}` about a window `@N`
+# returns the window's active PANE (measured: target @1 -> %1), so a pane-shaped
+# identity used on a window can never match and every window placement reads as
+# unobservable. Keeping the mapping in one place is what stops a third kind from
+# silently inheriting whichever field was written first — an unknown kind gets no
+# identity field and fails closed here rather than being compared against a
+# borrowed one.
+_tmux_identity_field() {   # <bare-id> -> the #{…} that reports THIS kind's own id
+  case "$1" in
+    %*) printf '#{pane_id}' ;;
+    @*) printf '#{window_id}' ;;
+    *)  return 1 ;;
+  esac
+}
+
 # tmux has no pane-label field independent of the CLI-owned terminal title.
 # The resolvable key is the pane-local @agmsg_agent user option.
 terminal_team_observe() {
-  local id="$1" key title bare facts seen_id
+  local id="$1" key title bare facts seen_id idfield
   command -v tmux >/dev/null 2>&1 || return 10
   # Two separate things, and doing only one of them is worse than doing neither:
   # STRIP the socket so the kind test and `-t` see a bare id, and USE that socket
@@ -331,10 +347,13 @@ terminal_team_observe() {
   # and an unset option produced the identical answer — and that answer decides
   # whether `team --fix` overwrites the key.
   #
-  # `#{pane_id}` is the canary: its value is known before the call (it is the
-  # target), so it separates "the server answered about THIS pane" from "the
-  # server answered about nothing". Same move as `terminal_pane_state` (#1051).
-  facts="$(_tmux_do "$id" display-message -p -t "$bare" '#{pane_id}|#{pane_title}' 2>/dev/null)" || return 10
+  # The identity field is the canary: its value is known before the call (it is
+  # the target), so it separates "the server answered about THIS ref" from "the
+  # server answered about nothing". Which field carries that identity depends on
+  # the ref KIND — see _tmux_identity_field. Same move as `terminal_pane_state`
+  # (#1051).
+  idfield="$(_tmux_identity_field "$bare")" || return 13
+  facts="$(_tmux_do "$id" display-message -p -t "$bare" "$idfield|#{pane_title}" 2>/dev/null)" || return 10
   seen_id="${facts%%|*}"
   title="${facts#*|}"
   # Not the pane we asked about (or no pane at all) -> the observation did not

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -137,6 +137,40 @@ agmsg_terminal_has() {
 _AGMSG_TERMINAL_REQUIRED="terminal_check terminal_describe terminal_detect terminal_spawn terminal_despawn terminal_pane_state terminal_peek terminal_poke terminal_where terminal_arrange terminal_name"
 _AGMSG_TERMINAL_OPTIONAL="terminal_team_observe terminal_team_input_ready"
 
+# A driver's observation fields carry EITHER an observed value or one of these
+# prefixes, which say why there is no value. They are listed here, once, because
+# two sides need the same list and neither owns it: the drivers emit them, and
+# anything judging an observation ("is this a key I can trust?") has to recognise
+# every one. A judge that enumerates them by hand goes stale the moment a driver
+# gains a case — which is exactly what happened between the spawn-side read-back
+# and this file's `absent:` (the judge tested a BARE `absent`, so a prefixed value
+# read as a usable key and a nameless pane was reported as named).
+#
+# The prefix form is load-bearing: a value is disqualified by its PREFIX, never by
+# equality with a whole token, so a driver may make a reason more specific without
+# any judge changing. Do not mix bare sentinels into this set.
+#
+#   unknown:  the observation could not be made           (nothing was learned)
+#   n/a:      this terminal has no such thing to observe  (nothing to learn)
+#   absent:   it was observed, and there is nothing there (a decided fact)
+#
+# The three are NOT interchangeable further up: `agmsg_identity_cell` passes
+# `unknown:`/`n/a:` through as skip markers and turns `absent:` into a mismatch a
+# repair can act on. They are alike only in the one respect this set is for —
+# none of them is an observed value.
+_AGMSG_OBSERVATION_NON_VALUE_PREFIXES="unknown: n/a: absent:"
+
+# 0 when the field carries a real observed value, 1 when it carries a reason (or
+# nothing). The single question a read-back judge should be asking.
+agmsg_observation_has_value() {   # <field>
+  local v="$1" p
+  [ -n "$v" ] || return 1
+  for p in $_AGMSG_OBSERVATION_NON_VALUE_PREFIXES; do
+    case "$v" in "$p"*) return 1 ;; esac
+  done
+  return 0
+}
+
 # Wipe every terminal_* ABI function from the current shell. Called before each
 # source so a driver that is switched to cannot inherit the previous driver's ops
 # — the clobber flagged in review: "no function" fails loudly (command not found), but a

--- a/tests/test_team_status.bats
+++ b/tests/test_team_status.bats
@@ -18,9 +18,19 @@ install_team_fake_tmux() {
 printf 'tmux' >> "$TEAM_TMUX_LOG"
 for arg in "$@"; do printf ' [%s]' "$arg" >> "$TEAM_TMUX_LOG"; done
 printf '\n' >> "$TEAM_TMUX_LOG"
+# Faithful to the MEASURED tmux 3.5 behaviour these tests depend on:
+#   - `display-message` for a pane that does NOT exist exits 0 with EMPTY output;
+#     it does not fail. That is why the driver co-observes #{pane_id}.
+#   - `show-options` for an UNSET option prints nothing.
+# Knobs: TEAM_TMUX_PANE_MISSING=1 (the pane is gone), TEAM_TMUX_KEY_UNSET=1.
+target=""; prev=""
+for arg in "$@"; do [ "$prev" = -t ] && target="$arg"; prev="$arg"; done
 case "$*" in
   *pane_in_mode*) printf '0|64066|/dev/ttys066\n' ;;
-  *show-options*) printf 'team:alice\n' ;;
+  *show-options*) [ -n "${TEAM_TMUX_KEY_UNSET:-}" ] || printf 'team:alice\n' ;;
+  *pane_id*pane_title*)
+    [ -n "${TEAM_TMUX_PANE_MISSING:-}" ] && { printf '|\n'; exit 0; }
+    printf '%s|✳ team-alice\n' "$target" ;;
   *pane_title*) printf '✳ team-alice\n' ;;
 esac
 EOF
@@ -234,6 +244,91 @@ EOF
   [ ! -e "$BATS_TEST_TMPDIR/poke" ]
 }
 
+# --- herdr observation: "not in the list" is not "has no key" -------------------
+#
+# The measured codex case. `agent list` is fetched successfully before this point,
+# so what stayed undecided was only WHICH no-name case applied — and both landed
+# on the same `unknown:` value, which `team --fix` skips. The nesting splits them:
+# an entry that matched but carries no `.name` is a DECIDED absence.
+_herdr_observe_stub() {   # <entries-json>
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/drivers/terminals/herdr/ops.sh"
+  _herdr_pane_id_ok() { return 0; }
+  eval "herdr() {
+    case \"\$1 \$2\" in
+      'pane get')   printf '%s\n' '{\"result\":{\"pane\":{\"agent_status\":\"idle\",\"label\":\"team:alice\",\"terminal_title\":\"x\"}}}' ;;
+      'agent list') printf '%s\n' '{\"result\":{\"agents\":$1}}' ;;
+    esac
+  }"
+}
+
+@test "herdr observation: an entry with no name is a DECIDED absence" {
+  _herdr_observe_stub '[{"pane_id":"w2:p3","agent":"codex"}]'
+  run terminal_team_observe 'w2:p3'
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | cut -f3)" = 'absent:agent_key_unset' ]
+}
+
+@test "herdr observation: a pane absent from the list stays UNDECIDED" {
+  # Differential partner: same call, same shape, only the pane_id differs, so the
+  # difference in the answer can only come from membership. Without the split
+  # this returned the same value as the test above and --fix skipped both.
+  _herdr_observe_stub '[{"pane_id":"w9:p9","agent":"codex","name":"team:bob"}]'
+  run terminal_team_observe 'w2:p3'
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | cut -f3)" = 'unknown:pane_not_in_agent_list' ]
+}
+
+@test "herdr observation: a named entry still reads its key (no regression)" {
+  _herdr_observe_stub '[{"pane_id":"w2:p3","agent":"codex","name":"team:alice"}]'
+  run terminal_team_observe 'w2:p3'
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | cut -f3)" = 'team:alice' ]
+}
+
+# --- the decided absence must reach --fix, and the undecided one must not -------
+
+@test "a decided absence becomes a mismatch cell, an undecided one does not" {
+  # This is the whole point of the vocabulary: agmsg_identity_cell passes
+  # `unknown:`/`n/a:` through untouched (the marker --fix skips on) and turns
+  # anything else into a mismatch. So the split in the drivers is what makes the
+  # key repairable, with no change to any reader.
+  [ "$(agmsg_identity_cell 'team:alice' 'absent:agent_key_unset')" \
+    = 'mismatch(expected=team:alice,actual=absent:agent_key_unset)' ]
+  [ "$(agmsg_identity_cell 'team:alice' 'unknown:pane_not_in_agent_list')" \
+    = 'unknown:pane_not_in_agent_list' ]
+}
+
+@test "identity fix repairs a key that was decidedly absent, and verifies it" {
+  # The behaviour tl asked for: --fix must actually set the key on a seat that
+  # never had one, and must only say `changed` after reading it back.
+  agmsg_type_get() { printf '\n'; }
+  _herdr_internal_key() { printf 'a123\n'; }
+  terminal_name() { printf '%s\n' "$4" >> "$BATS_TEST_TMPDIR/names"; }
+  terminal_team_observe() { printf 'idle\tteam:alice\ta123\tx\n'; }   # read-back: now present
+  run agmsg_team_fix_identity_loaded team alice codex herdr w2:p3 \
+    'ok(actual=team:alice)' \
+    'mismatch(expected=a123,actual=absent:agent_key_unset)' \
+    'n/a:no_session_name'
+  [ "$status" -eq 0 ]
+  [ "${lines[1]}" = $'agent_key\tchanged\trenamed_and_verified' ]
+  grep -qx 'key' "$BATS_TEST_TMPDIR/names"
+}
+
+@test "identity fix still skips a key it could not read" {
+  # The half that stops this from becoming "overwrite everything": an undecided
+  # observation must remain skipped, and must not be reported as changed.
+  agmsg_type_get() { printf '\n'; }
+  terminal_name() { printf 'called\n' > "$BATS_TEST_TMPDIR/names"; }
+  run agmsg_team_fix_identity_loaded team alice codex herdr w2:p3 \
+    'ok(actual=team:alice)' \
+    'unknown:pane_not_in_agent_list' \
+    'n/a:no_session_name'
+  [ "$status" -eq 0 ]
+  [ "${lines[1]}" = $'agent_key\tskipped\tpane_not_in_agent_list' ]
+  [ ! -e "$BATS_TEST_TMPDIR/names" ]
+}
+
 @test "herdr readiness positively identifies the expected live agent" {
   # shellcheck disable=SC1090
   source "$SCRIPTS/drivers/terminals/herdr/ops.sh"
@@ -329,5 +424,35 @@ EOF
   [ "$status" -eq 0 ]
   [ "$output" = $'n/a:unsupported\tn/a:no_independent_field\tteam:alice\t✳ team-alice' ]
   grep -qF 'tmux [show-options] [-p] [-v] [-t] [%3] [@agmsg_agent]' "$TEAM_TMUX_LOG"
-  grep -qF 'tmux [display-message] [-p] [-t] [%3] [#{pane_title}]' "$TEAM_TMUX_LOG"
+  # The title query now carries its own canary: #{pane_id} is asked for in the
+  # SAME call, so the answer can be tied to the pane it was asked about.
+  grep -qF 'tmux [display-message] [-p] [-t] [%3] [#{pane_id}|#{pane_title}]' "$TEAM_TMUX_LOG"
+}
+
+@test "tmux observation: the pane is reachable and the key is UNSET -> decided absence" {
+  # The case every codex seat is in. `unknown:` here is what made `team --fix`
+  # skip it forever, so the value must NOT carry that prefix.
+  install_team_fake_tmux
+  export TEAM_TMUX_KEY_UNSET=1
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/drivers/terminals/tmux/ops.sh"
+  run terminal_team_observe '%3'
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | cut -f3)" = 'absent:agent_key_unset' ]
+  # The title still reads, so this is a statement ABOUT a pane we reached.
+  [ "$(printf '%s' "$output" | cut -f4)" = '✳ team-alice' ]
+}
+
+@test "tmux observation: a pane that does not exist is NOT a decided absence" {
+  # The differential partner of the test above: MEASURED, display-message exits 0
+  # with empty output for a missing pane, so without the co-observed #{pane_id}
+  # this case returned the exact same answer as an unset option — and `--fix`
+  # would then overwrite a key on a pane nobody could find.
+  install_team_fake_tmux
+  export TEAM_TMUX_KEY_UNSET=1 TEAM_TMUX_PANE_MISSING=1
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/drivers/terminals/tmux/ops.sh"
+  run terminal_team_observe '%3'
+  [ "$status" -eq 10 ]
+  refute grep -q 'absent:' <<<"$output"
 }

--- a/tests/test_team_status.bats
+++ b/tests/test_team_status.bats
@@ -28,8 +28,16 @@ for arg in "$@"; do [ "$prev" = -t ] && target="$arg"; prev="$arg"; done
 case "$*" in
   *pane_in_mode*) printf '0|64066|/dev/ttys066\n' ;;
   *show-options*) [ -n "${TEAM_TMUX_KEY_UNSET:-}" ] || printf 'team:alice\n' ;;
-  *pane_id*pane_title*)
+  *window_id*pane_title*|*pane_id*pane_title*)
+    # tmux answers with the id of the thing it FOUND. A missing target yields an
+    # empty identity; a present one echoes back the id that was asked about --
+    # which is only true when the field matches the target's KIND, and that is
+    # exactly what these tests are here to pin.
     [ -n "${TEAM_TMUX_PANE_MISSING:-}" ] && { printf '|\n'; exit 0; }
+    case "$* " in
+      *'#{window_id}'*) [ "${target#@}" != "$target" ] || { printf '|\n'; exit 0; } ;;
+      *'#{pane_id}'*)   [ "${target#%}" != "$target" ] || { printf '|\n'; exit 0; } ;;
+    esac
     printf '%s|✳ team-alice\n' "$target" ;;
   *pane_title*) printf '✳ team-alice\n' ;;
 esac
@@ -441,6 +449,45 @@ _herdr_observe_stub() {   # <entries-json>
   [ "$(printf '%s' "$output" | cut -f3)" = 'absent:agent_key_unset' ]
   # The title still reads, so this is a statement ABOUT a pane we reached.
   [ "$(printf '%s' "$output" | cut -f4)" = '✳ team-alice' ]
+}
+
+@test "tmux observation: a WINDOW placement is observed with the WINDOW's identity" {
+  # `spawn --window` records @N (new-window -P -F '#{window_id}'), and asking
+  # `#{pane_id}` about a window answers with its ACTIVE PANE — measured, target @1
+  # answers %1. A pane-shaped canary on a window can therefore never match, and
+  # every window-placed seat read as unobservable. The identity field is paired to
+  # the ref KIND, so this must observe exactly like the pane case.
+  install_team_fake_tmux
+  export TEAM_TMUX_KEY_UNSET=1
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/drivers/terminals/tmux/ops.sh"
+  run terminal_team_observe '@3'
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | cut -f3)" = 'absent:agent_key_unset' ]
+  grep -qF 'tmux [display-message] [-p] [-t] [@3] [#{window_id}|#{pane_title}]' "$TEAM_TMUX_LOG"
+}
+
+@test "tmux observation: a window that does not exist is NOT a decided absence" {
+  # The @-kind partner of the %-kind control: both kinds must fail closed, or the
+  # one that was never exercised is the one that ships broken.
+  install_team_fake_tmux
+  export TEAM_TMUX_KEY_UNSET=1 TEAM_TMUX_PANE_MISSING=1
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/drivers/terminals/tmux/ops.sh"
+  run terminal_team_observe '@3'
+  [ "$status" -eq 10 ]
+  refute grep -q 'absent:' <<<"$output"
+}
+
+@test "tmux observation: a PANE placement still asks for the pane identity" {
+  # The other half of the pairing, pinned by argv so the two kinds cannot both be
+  # served by whichever field was written first.
+  install_team_fake_tmux
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/drivers/terminals/tmux/ops.sh"
+  run terminal_team_observe '%3'
+  [ "$status" -eq 0 ]
+  grep -qF 'tmux [display-message] [-p] [-t] [%3] [#{pane_id}|#{pane_title}]' "$TEAM_TMUX_LOG"
 }
 
 @test "tmux observation: a pane that does not exist is NOT a decided absence" {

--- a/tests/test_team_status.bats
+++ b/tests/test_team_status.bats
@@ -277,6 +277,21 @@ _herdr_observe_stub() {   # <entries-json>
   [ "$(printf '%s' "$output" | cut -f3)" = 'absent:agent_key_unset' ]
 }
 
+@test "herdr observation: an EMPTY name is a decided absence, not a value" {
+  # `json_extract` answers SQL NULL for a missing key and for JSON null, but the
+  # EMPTY STRING for `"name":""` (measured) — so without NULLIF it slips past the
+  # COALESCE as if it were a key. It is not one, and an empty field makes the
+  # wrapper report `unknown:observe_malformed` for ALL FOUR fields, which --fix
+  # skips: the case this exists to repair, skipped again, taking the other three
+  # observations with it.
+  _herdr_observe_stub '[{"pane_id":"w2:p3","agent":"codex","name":""}]'
+  run terminal_team_observe 'w2:p3'
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | cut -f3)" = 'absent:agent_key_unset' ]
+  # ...and the observation stays whole: the other fields are still readable.
+  [ "$(printf '%s' "$output" | cut -f1)" = 'idle' ]
+}
+
 @test "herdr observation: a pane absent from the list stays UNDECIDED" {
   # Differential partner: same call, same shape, only the pane_id differs, so the
   # difference in the answer can only come from membership. Without the split

--- a/tests/test_team_status.bats
+++ b/tests/test_team_status.bats
@@ -270,6 +270,62 @@ _herdr_observe_stub() {   # <entries-json>
   }"
 }
 
+# --- the observation vocabulary is one list, and it is DERIVED, not retyped -----
+
+@test "agmsg_observation_has_value accepts a value and rejects every reason prefix" {
+  # The single question a read-back judge asks. Driven from the SET, so a prefix
+  # added there is exercised here without editing this test.
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/terminal-registry.sh"
+  local p n=0
+  for p in $_AGMSG_OBSERVATION_NON_VALUE_PREFIXES; do
+    n=$((n + 1))
+    refute agmsg_observation_has_value "${p}whatever" \
+      || { echo "$p was accepted as a value"; return 1; }
+  done
+  [ "$n" -ge 3 ] || { echo "the prefix set is suspiciously small: $n"; return 1; }
+  refute agmsg_observation_has_value ''
+  agmsg_observation_has_value 'team:alice'
+}
+
+@test "the prefix set covers every reason the shipped drivers actually emit" {
+  # DERIVED both ways: the set is one side, and the other is scraped out of the
+  # drivers rather than retyped here. A driver that gains a new reason prefix
+  # fails this until the set names it — the failure the spawn-side judge hit by
+  # hand-listing a bare `absent` while the driver emitted `absent:`.
+  #
+  # Scoped to the terminal_team_observe BODY on purpose: `not_ready:` belongs to
+  # terminal_team_input_ready, a different question with its own vocabulary, and
+  # pane-id globs elsewhere in the file contain colons that are not prefixes at
+  # all. A wider scrape reported seven "missing" prefixes, none of them real.
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/terminal-registry.sh"
+  local d emitted="" missing="" p
+  for d in "$SCRIPTS"/drivers/terminals/*/ops.sh; do
+    # Comment lines are dropped first: prose contains colons ("canary:", "split:")
+    # and a scrape that reads them reports seven prefixes that no driver emits.
+    # The reason word after the colon is required for the same reason.
+    emitted="$emitted $(awk '/^terminal_team_observe\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$d" \
+      | grep -v '^[[:space:]]*#' \
+      | sed 's/\\t/ /g' \
+      | grep -oE "[a-z][a-z_]*(\/[a-z])?:[a-z_]+" \
+      | sed 's/:.*/:/' | sort -u | tr '\n' ' ')"
+  done
+  emitted="$(printf '%s\n' $emitted | sort -u)"
+  # Canary: the scrape must find what we know is there, or "nothing missing"
+  # would only mean "nothing was scraped".
+  printf '%s\n' "$emitted" | grep -qx 'unknown:' || { echo "scrape found no unknown: — the search is broken"; return 1; }
+  printf '%s\n' "$emitted" | grep -qx 'absent:'  || { echo "scrape found no absent: — the search is broken"; return 1; }
+  printf '%s\n' "$emitted" | grep -qx 'n/a:'     || { echo "scrape found no n/a: — the search is broken"; return 1; }
+  for p in $emitted; do
+    case " $_AGMSG_OBSERVATION_NON_VALUE_PREFIXES " in
+      *" $p "*) : ;;
+      *) missing="$missing $p" ;;
+    esac
+  done
+  [ -z "$missing" ] || { echo "drivers emit prefixes the set does not name:$missing"; return 1; }
+}
+
 @test "herdr observation: an entry with no name is a DECIDED absence" {
   _herdr_observe_stub '[{"pane_id":"w2:p3","agent":"codex"}]'
   run terminal_team_observe 'w2:p3'


### PR DESCRIPTION
Refs the codex agent-key gap (koit: "spawn した側がつけるべき / 機会が無い場合は check --fix").
This is the `--fix` half. The spawn half is PR #1065 (cc3) and the two do not share a file.

Against `integration/terminal-driver-v1` @ 7930c62. Reviewer: co3.

---

Every codex seat is unnamed, and `team` reports identity=mismatch for all of
them. `team --fix` can already write the key — it just never tries, because the
observation it acts on says `unknown:agent_key_missing`, and `unknown:` is the
marker `--fix` skips on. Skipping an unreadable value is correct; the defect is
that a value which was decisively READ as absent was wearing that marker.

Both drivers collapsed two different facts into it, in two different ways.

## tmux: an empty option is only "unset" if the pane was reached

    key="$(… show-options -p -v -t "$bare" @agmsg_agent)" || key=""
    title="$(… display-message -p -t "$bare" '#{pane_title}')" || return 10
    [ -n "$key" ] || key=unknown:agent_key_missing

The title query looks like a guard that filters out an unreachable pane before
the key is classified. Measured on tmux 3.5, against a throwaway server, running
the FUNCTION rather than the command:

    A  pane ok, option UNSET   rc=0   agent_key=unknown:agent_key_missing
    B  option SET              rc=0   agent_key=team:alice
    C  pane does NOT exist     rc=0   agent_key=unknown:agent_key_missing
    D  server gone             rc=10  (exits early)

The guard fires for D and not for C: `display-message -p -t %999` exits **0 with
empty output** for a pane that does not exist. So A and C produced the identical
answer, and whether `--fix` may overwrite a key was resting on a value that could
not tell "this pane has no key" from "there is no such pane".

`#{pane_id}` is now asked for in the SAME call as the title. Its value is known
before the call — it is the target — so it separates "the server answered about
THIS pane" from "the server answered about nothing". A mismatch there returns 10,
the same answer a dead server gets, because `unknown` on a field would still be a
claim about a pane we never reached. Once the pane IS proven, an empty option is
a decided fact: `absent:agent_key_unset`.

Same move as `terminal_pane_state` (#1051): co-observe something whose answer you
already know, in the observation whose success you are trying to establish.

## herdr: "not in the list" is not "has no key"

    COALESCE((SELECT json_extract(value,'$.name') FROM json_each(agents)
              WHERE json_extract(value,'$.pane_id')='<id>' LIMIT 1),
             'unknown:agent_key_missing')

The agent list was already fetched successfully above, so the read is not in
question — but one COALESCE served two cases: no matching entry (the pane could
not be located) and a matching entry with no `.name` (a decided absence). The
measured codex seats are the second, so the case this exists to repair travelled
the undecidable half. Nesting the COALESCEs splits them: the inner one fires only
when a row matched, the outer only when none did.

## No reader changed, and that is the reason for the vocabulary

`agmsg_identity_cell` passes `n/a:` and `unknown:` through untouched and turns
anything else into `mismatch(expected=…,actual=…)`. So a third prefix needs no
new branch anywhere: `absent:` flows into the EXISTING mismatch path, and the
cell renderer, the `--json` output, `agmsg_identity_consistency` and the `--fix`
arm all work unchanged. Verified by deriving the readers first, on three axes:

    1  names the function terminal_team_observe
    2  reads its value vocabulary
    3  consumes the row POSITIONALLY, naming neither          <- found team.sh,
                                                                 which 1 and 2 miss

Axis 3 is the one that mattered: `team.sh:177-185` destructures the identity row
and renders `agent_key` without ever mentioning the function or its vocabulary.
`lib/terminal-registry.sh` looked like a reader to a grep and is not one — the
name appears only in `_AGMSG_TERMINAL_OPTIONAL`. Both were settled by opening
them, not by counting hits.

## Controls

Differential pairs, so the answer can only come from the one thing that differs:

    tmux    same stub, one knob      unset -> absent  /  missing pane -> rc 10
    herdr   same JSON, one pane_id   entry without name -> absent
                                     pane not in the list -> unknown
    cell    absent: -> mismatch(…)   unknown: -> passed through
    --fix   repairs a decided absence and only says `changed` after reading it
            back; still skips an undecided one and writes nothing

Calibrated, each mutation confirmed applied before its result was read, each
reddening exactly one control:

    tmux drops the co-observed pane_id          -> the missing-pane control
    herdr collapses the two cases again         -> the decided-absence control
    herdr calls an unfound pane absent too      -> the undecided control
    the classifier skips absent: like unknown:  -> the cell control

test_team_status 37/0, test_terminal_registry 113/0, test_team 82/0,
test_peek_poke 30/0; both repo checkers at baseline.
