### PR TITLE
fix(actas-lock): keep a lock whose owner is unreadable, don't reclaim it (#1071)

### DIFF
--- a/scripts/lib/actas-lock.sh
+++ b/scripts/lib/actas-lock.sh
@@ -100,6 +100,28 @@ actas_lock_sid_alive() {
   agmsg_instance_alive "$1"
 }
 
+# Is <owner> a lock we are ALLOWED to reclaim/steal? Only when the owner reads back as a
+# real, non-empty token that is not alive. An EMPTY owner is the #1071 trigger: a
+# transient read failure (head -1 on a busy FS, a torn write) yields "", which the old
+# `[ -z "$owner" ] || ! alive` folded into "stale" and then DELETED — removing a LIVE
+# seat's lock so another session claimed the same role. An owner we cannot even read is
+# NOT evidence the seat is gone; keep it, exactly as actas_lock_release_all skips a file
+# whose owner it cannot read. So require the owner to be present before trusting the
+# liveness verdict. #1071.
+#
+# SCOPE: this closes the empty-owner half — the destructive one #1071 observed. The other
+# half ("liveness cannot be DETERMINED" for a present owner: actas_lock_sid_alive returns
+# "not alive" for a dead owner AND for an unreadable cc-instance) needs a 3-valued
+# liveness that distinguishes dead from indeterminate. That lives in agmsg_instance_alive
+# and is being made 3-valued on the integration branch (#996-era); wiring these sites to
+# it is a post-1.3.0 follow-up once it reaches main. Doing it here would duplicate that
+# work and break the bare-<sid> reclamation the existing tests depend on.
+_actas_owner_reclaimable() {   # <owner-token>
+  local owner="$1"
+  [ -n "$owner" ] || return 1
+  ! actas_lock_sid_alive "$owner"
+}
+
 # Internal: attempt one atomic claim. Echoes "ok" on success, "held:<sid>"
 # when another sid currently owns it, or "stale" when the existing lock's
 # owner is dead (caller should retry after removing).
@@ -125,7 +147,7 @@ _actas_lock_try_claim() {
     echo "ok"
     return 0
   fi
-  if [ -z "$existing" ] || ! actas_lock_sid_alive "$existing"; then
+  if _actas_owner_reclaimable "$existing"; then
     echo "stale"
     return 0
   fi
@@ -161,7 +183,7 @@ actas_lock_claim() {
         # leave it — the next try_claim observes it as held.
         if mkdir "$reclaim_dir" 2>/dev/null; then
           _owner="$(actas_lock_owner "$team" "$agent")"
-          if [ -z "$_owner" ] || ! actas_lock_sid_alive "$_owner"; then
+          if _actas_owner_reclaimable "$_owner"; then
             rm -f "$lock_path"
           fi
           rmdir "$reclaim_dir" 2>/dev/null
@@ -217,7 +239,7 @@ actas_lock_gc_stale() {
   for f in "$dir"/actas.*.session; do
     [ -f "$f" ] || continue
     owner="$(head -1 "$f" 2>/dev/null || true)"
-    if [ -z "$owner" ] || ! actas_lock_sid_alive "$owner"; then
+    if _actas_owner_reclaimable "$owner"; then
       rm -f "$f"
       count=$((count + 1))
     fi

--- a/tests/test_actas_lock.bats
+++ b/tests/test_actas_lock.bats
@@ -244,3 +244,37 @@ live_pid() { echo "$$"; }
   run actas_lock_state "T" "alice" "sid-me"
   [ "$output" = "free" ]
 }
+
+# --- #1071: an unreadable (empty) owner must NOT be treated as stale/dead ---
+# A transient read failure (head -1 on a busy FS, a torn write) yields an empty owner.
+# The old `[ -z "$owner" ] || ! actas_lock_sid_alive` folded that into the stale branch
+# and DELETED / stole the lock — removing a possibly-LIVE seat's lock so another session
+# claimed the same role. Each control co-observes a genuinely dead-owner lock that IS
+# still reclaimed, so it proves the empty-owner guard, not a broken predicate.
+# Mutation: flip `_actas_owner_reclaimable`'s `[ -n "$owner" ] || return 1` to `return 0`
+# (empty → reclaimable) and both go red.
+
+@test "gc_stale: KEEPS a lock whose owner is empty/unreadable, still GCs a dead one (#1071)" {
+  skip_on_windows "actas live-session liveness under Git Bash (#182)"
+  printf '' > "$(actas_lock_path "T-empty" "alice")"      # empty owner (transient read)
+  echo "sid-dead" > "$(actas_lock_path "T-dead" "bob")"   # non-empty, no live cc-instance
+  run actas_lock_gc_stale
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]                                     # only the dead one was counted
+  [ -f "$(actas_lock_path "T-empty" "alice")" ]           # empty owner KEPT — the fix
+  [ ! -f "$(actas_lock_path "T-dead" "bob")" ]            # dead owner still reclaimed
+}
+
+@test "claim: does NOT steal a lock whose owner is empty/unreadable, but still reclaims a dead one (#1071)" {
+  skip_on_windows "actas live-session liveness under Git Bash (#182)"
+  # empty owner -> held, not stolen
+  printf '' > "$(actas_lock_path "T" "alice")"
+  run actas_lock_claim "T" "alice" "sid-mine"
+  [ "$status" -ne 0 ]
+  [ "$(actas_lock_owner "T" "alice")" != "sid-mine" ]    # not overwritten with our sid
+  # a genuinely dead owner is still reclaimable (existing behaviour preserved)
+  echo "sid-dead" > "$(actas_lock_path "T2" "bob")"
+  run actas_lock_claim "T2" "bob" "sid-mine2"
+  [ "$status" -eq 0 ]
+  [ "$(actas_lock_owner "T2" "bob")" = "sid-mine2" ]
+}


### PR DESCRIPTION
## What

`actas_lock_gc_stale` and the claim/reclaim path decided a lock was stale with
`[ -z "$owner" ] || ! actas_lock_sid_alive "$owner"`, folding an **unreadable** owner in
with a genuinely dead one. A transient read failure (`head -1` on a busy FS, a torn
write) yields an empty owner → `-z` branch → the lock, a possibly-**live** seat's, is
**deleted** (gc_stale) or **stolen** (claim) → another session claims the same role and
two sessions collide on one identity. (`actas_lock_release_all` in the same file is
already safe: it compares `[ "$owner" = "$sid" ]`, so an empty owner never matches.)

The three destructive sites (try-claim's stale decision, the under-mutex reclaim `rm`,
and gc_stale's `rm`) now go through `_actas_owner_reclaimable`, which requires the owner
to read back **non-empty** before trusting the liveness verdict.

## Scope (coordinated with cc1's #1070)

Closes the **empty-owner half** — the destructive trigger #1071 observed. The other half
(liveness that cannot be *determined* for a present owner) needs a 3-valued liveness
distinguishing dead from indeterminate; that is being added to `agmsg_instance_alive` on
the integration branch, and wiring these sites to it is a **post-1.3.0 follow-up**. Doing
it here would duplicate that work and break the bare-`<sid>` reclamation the existing
tests exercise. cc1 dropped gc_stale/claim from #1070 so these are non-overlapping; #1071
lands first (base main), #1070 rebases after.

## Tests

An empty-owner lock is KEPT by gc_stale and not stolen by claim, each co-observing a
genuinely dead-owner lock that IS still reclaimed (proving the guard, not a broken
predicate). All 24 actas-lock tests pass (existing reclamation behaviour preserved).
Mutation-verified: making the empty owner reclaimable reds both new controls.

Base: `main` (merge-ready; lands after 1.3.0 per the standing rule).
