### PR TITLE
feat(arrange): accept a pane reference as anchor, and add swap

### DIFF
--- a/scripts/arrange.sh
+++ b/scripts/arrange.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Declaratively place one member's pane relative to another member's pane.
+# Arrange one member's pane relative to an anchor pane. place_below and
+# place_right are idempotent; swap is not — calling swap twice swaps back.
 # Identity/placement resolution belongs here; terminal drivers receive ids only.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -15,34 +16,56 @@ die() { echo "arrange: $*" >&2; exit 1; }
 
 TEAM="${1:-}"; SOURCE="${2:-}"; INTENT="${3:-}"; TARGET="${4:-}"
 [ -n "$TEAM" ] && [ -n "$SOURCE" ] && [ -n "$INTENT" ] && [ -n "$TARGET" ] \
-  || die "Usage: arrange.sh <team> <agent> <place_below|place_right> <anchor-agent>"
-[ "$SOURCE" != "$TARGET" ] || die "source and anchor must be different members"
-case "$INTENT" in place_below|place_right) : ;; *) die "unknown intent '$INTENT' (expected place_below or place_right)" ;; esac
+  || die "Usage: arrange.sh <team> <agent> <place_below|place_right|swap> <anchor-ref>"
+case "$INTENT" in
+  place_below|place_right|swap) : ;;
+  *) die "unknown intent '$INTENT' (expected place_below, place_right, or swap)" ;;
+esac
 
 _placement() {
-  local agent="$1" rec ref terminal id
+  local agent="$1" rec ref terminal id project type
   rec="$(agmsg_spawn_path "$TEAM" "$agent")"
   [ -f "$rec" ] || { echo "arrange: no placement record for '$TEAM/$agent'" >&2; return 1; }
-  IFS=$'\t' read -r ref _ _ < "$rec" || true
+  IFS=$'\t' read -r ref project type < "$rec" || true
   terminal="$(agmsg_terminal_ref_terminal "$ref" 2>/dev/null)" || terminal=""
   id="$(agmsg_terminal_ref_id "$ref" 2>/dev/null)" || id=""
   [ -n "$terminal" ] && [ -n "$id" ] \
     || { echo "arrange: placement record for '$TEAM/$agent' is unreadable" >&2; return 1; }
   PLACEMENT_TERMINAL="$terminal"
   PLACEMENT_ID="$id"
+  PLACEMENT_PROJECT="$project"
+  PLACEMENT_TYPE="$type"
 }
 
-PLACEMENT_TERMINAL=""; PLACEMENT_ID=""
+PLACEMENT_TERMINAL=""; PLACEMENT_ID=""; PLACEMENT_PROJECT=""; PLACEMENT_TYPE=""
 _placement "$SOURCE" || exit $?
 SOURCE_TERMINAL="$PLACEMENT_TERMINAL"; SOURCE_ID="$PLACEMENT_ID"
-_placement "$TARGET" || exit $?
-TARGET_TERMINAL="$PLACEMENT_TERMINAL"; TARGET_ID="$PLACEMENT_ID"
-[ "$SOURCE_TERMINAL" = "$TARGET_TERMINAL" ] \
-  || die "members are in different terminals ('$SOURCE_TERMINAL' and '$TARGET_TERMINAL')"
+SOURCE_PROJECT="$PLACEMENT_PROJECT"; SOURCE_TYPE="$PLACEMENT_TYPE"
+
+# The source remains a roster member: its placement record is an address, not
+# proof that the registration still exists. The anchor is deliberately not
+# looked up in the roster; a terminal pane may belong to another team or to a
+# plain shell. Its reference is validated by the shared terminal-ref parser.
+[ -n "$SOURCE_PROJECT" ] && [ -n "$SOURCE_TYPE" ] \
+  || die "placement record for '$TEAM/$SOURCE' is missing project or type"
+if ! "$SCRIPT_DIR/identities.sh" "$SOURCE_PROJECT" "$SOURCE_TYPE" \
+    | awk -F '\t' -v team="$TEAM" -v agent="$SOURCE" \
+        '$1 == team && $2 == agent { found=1 } END { exit found ? 0 : 1 }'; then
+  die "source '$TEAM/$SOURCE' is not a registered member"
+fi
+
+ANCHOR_TERMINAL=""; ANCHOR_ID=""
+ANCHOR_TERMINAL="$(agmsg_terminal_ref_terminal "$TARGET" 2>/dev/null)" || ANCHOR_TERMINAL=""
+ANCHOR_ID="$(agmsg_terminal_ref_id "$TARGET" 2>/dev/null)" || ANCHOR_ID=""
+[ -n "$ANCHOR_TERMINAL" ] && [ -n "$ANCHOR_ID" ] \
+  || die "anchor reference '$TARGET' did not resolve to a terminal and pane id"
+
+[ "$SOURCE_TERMINAL" = "$ANCHOR_TERMINAL" ] \
+  || die "source and anchor are in different terminals ('$SOURCE_TERMINAL' and '$ANCHOR_TERMINAL')"
 agmsg_terminal_has "$SOURCE_TERMINAL" capabilities arrange \
   || die "terminal '$SOURCE_TERMINAL' cannot arrange panes"
 agmsg_terminal_load "$SOURCE_TERMINAL" \
   || die "cannot load terminal driver '$SOURCE_TERMINAL'"
 
 # Last command: preserve the driver's moved/unchanged/error token and exit code.
-terminal_arrange "$SOURCE_ID" "$INTENT" "$TARGET_ID"
+terminal_arrange "$SOURCE_ID" "$INTENT" "$ANCHOR_ID"

--- a/scripts/arrange.sh
+++ b/scripts/arrange.sh
@@ -62,6 +62,12 @@ ANCHOR_ID="$(agmsg_terminal_ref_id "$TARGET" 2>/dev/null)" || ANCHOR_ID=""
 
 [ "$SOURCE_TERMINAL" = "$ANCHOR_TERMINAL" ] \
   || die "source and anchor are in different terminals ('$SOURCE_TERMINAL' and '$ANCHOR_TERMINAL')"
+case "$INTENT" in
+  place_below|place_right)
+    [ "$SOURCE_ID" != "$ANCHOR_ID" ] \
+      || die "source and anchor must be different panes"
+    ;;
+esac
 agmsg_terminal_has "$SOURCE_TERMINAL" capabilities arrange \
   || die "terminal '$SOURCE_TERMINAL' cannot arrange panes"
 agmsg_terminal_load "$SOURCE_TERMINAL" \

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -49,7 +49,12 @@ terminal_describe() {
   printf 'skill_help=herdr --skill\n'
   printf 'intent.place_below=herdr pane move SOURCE --new-tab; herdr pane move SOURCE --tab CONTAINER --split down --target-pane TARGET\n'
   printf 'intent.place_right=herdr pane move SOURCE --new-tab; herdr pane move SOURCE --tab CONTAINER --split right --target-pane TARGET\n'
+  printf 'intent.swap=herdr pane swap --source-pane SOURCE --target-pane TARGET\n'
 }
+
+# place_below/place_right are idempotent; swap is not — two swaps restore the
+# original occupants. The caller must therefore report a native swap as moved
+# unless the driver explicitly reports changed=false.
 
 # Extract the pane id whose agent_session == <sid> from `herdr agent list` JSON.
 # Uses sqlite3 JSON1 (the codebase's no-jq convention). ASSERTED field names
@@ -599,11 +604,45 @@ _herdr_layout_has_pane() {
   [ "$count" = 1 ]
 }
 
+_herdr_swap_changed() {
+  local json="$1" esc changed
+  esc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  changed="$(sqlite3 :memory: "SELECT json_extract('$esc','\$.result.swap_result.changed')" 2>/dev/null)" \
+    || return 2
+  case "$changed" in
+    1|true) return 0 ;;
+    0|false) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
 terminal_arrange() {
-  local source="$1" intent="$2" target="$3" layout source_layout state rc=0 tab first second temporary_tab
+  local source="$1" intent="$2" target="$3" layout source_layout state rc=0 tab first second temporary_tab swap_result
   command -v herdr >/dev/null 2>&1 || { echo runtime_error; return 10; }
   _herdr_pane_id_ok "$source" && _herdr_pane_id_ok "$target" || { echo unsupported; return 13; }
-  case "$intent" in place_below|place_right) : ;; *) echo unsupported; return 13 ;; esac
+  case "$intent" in place_below|place_right|swap) : ;; *) echo unsupported; return 13 ;; esac
+  if [ "$intent" = swap ]; then
+    [ "$source" != "$target" ] || { echo unsupported; return 13; }
+    # Swap keeps both panes occupied, but the native command still needs a
+    # positive existence observation for each id. A layout response for one
+    # pane cannot establish the other when they live in different tabs.
+    layout="$(herdr pane layout --pane "$target" 2>/dev/null)" || { echo runtime_error; return 10; }
+    [ -n "$layout" ] && _herdr_layout_has_pane "$layout" "$target" \
+      || { echo unknown; return 10; }
+    source_layout="$(herdr pane layout --pane "$source" 2>/dev/null)" || { echo runtime_error; return 10; }
+    [ -n "$source_layout" ] && _herdr_layout_has_pane "$source_layout" "$source" \
+      || { echo unknown; return 10; }
+    swap_result="$(herdr pane swap --source-pane "$source" --target-pane "$target" 2>/dev/null)" \
+      || { echo runtime_error; return 12; }
+    [ -n "$swap_result" ] || { echo runtime_error; return 12; }
+    rc=0
+    _herdr_swap_changed "$swap_result" || rc=$?
+    case "$rc" in
+      0) echo moved; return 0 ;;
+      1) echo unchanged; return 0 ;;
+      *) echo runtime_error; return 12 ;;
+    esac
+  fi
   layout="$(herdr pane layout --pane "$target" 2>/dev/null)" || rc=$?
   [ "$rc" -eq 0 ] && [ -n "$layout" ] || { echo runtime_error; return 10; }
   rc=0

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -20,7 +20,12 @@ terminal_describe() {
   printf 'syntax_help=tmux list-commands\n'
   printf 'intent.place_below=tmux move-pane -s SOURCE -t TARGET -v\n'
   printf 'intent.place_right=tmux move-pane -s SOURCE -t TARGET -h\n'
+  printf 'intent.swap=tmux swap-pane -s SOURCE -t TARGET\n'
 }
+
+# place_below/place_right are idempotent; swap is not — two swaps restore the
+# original occupants. The caller must therefore report a native swap as moved
+# unless the driver explicitly reports changed=false.
 
 # READ op: print the window containing <id>. This answers WHERE only and never
 # treats an unresolved location as proof that the pane is gone.
@@ -82,7 +87,7 @@ terminal_arrange() {
   # same reason: a bare id names no server, so "same server" is not a fact — and
   # unlike a read, this op MUTATES, so the unestablished case must not proceed.
   [ "$ssock" = "$tsock" ] || { echo unsupported; return 13 ;}
-  case "$intent" in place_below|place_right) : ;; *) echo unsupported; return 13 ;; esac
+  case "$intent" in place_below|place_right|swap) : ;; *) echo unsupported; return 13 ;; esac
   out="$(_tmux_do "$source" list-panes -a -F '#{pane_id}|#{window_id}|#{pane_top}|#{pane_left}|#{pane_width}|#{pane_height}' 2>/dev/null)" \
     || { echo runtime_error; return 10; }
   srow="$(printf '%s\n' "$out" | awk -F '|' -v id="$sbare" '$1 == id { print; exit }')"
@@ -92,6 +97,13 @@ terminal_arrange() {
   IFS='|' read -r tid twin tt tl tw th <<< "$trow"
   _tmux_layout_numbers_ok "$st" "$sl" "$sw" "$sh" "$tt" "$tl" "$tw" "$th" \
     || { echo runtime_error; return 10; }
+  if [ "$intent" = swap ]; then
+    [ "$sbare" != "$tbare" ] || { echo unsupported; return 13; }
+    _tmux_do "$source" swap-pane -s "$sbare" -t "$tbare" >/dev/null 2>&1 \
+      || { echo runtime_error; return 12; }
+    echo moved
+    return 0
+  fi
   [ "$swin" = "$twin" ] && _tmux_arranged "$intent" "$st" "$sl" "$sw" "$sh" "$tt" "$tl" "$tw" "$th" \
     && { echo unchanged; return 0; }
   case "$intent" in

--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -137,10 +137,10 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
-If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
-1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
-3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+If argument starts with "arrange" (e.g. "arrange alice place_below tmux:%2"):
+1. Parse `<agent> <place_below|place_right|swap> <anchor-ref>` and determine the source agent's team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-ref>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `place_below` and `place_right` are idempotent, but `swap` is not: calling `swap` twice swaps the panes back, so a native swap normally reports `moved`; `unchanged` is only possible when the driver explicitly reports `changed=false`. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
 
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -229,10 +229,10 @@ If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --for
    - `--force`: skips the message and tears the member down from the placement recorded at spawn time — kills its tmux pane/window and drops its registration. Use when the member's watcher can't respond.
 3. Show the script's output. Do NOT TaskStop or relaunch this session's own Monitor — despawn affects the spawned member, not this session's subscription.
 
-If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
-1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
-3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+If argument starts with "arrange" (e.g. "arrange alice place_below tmux:%2"):
+1. Parse `<agent> <place_below|place_right|swap> <anchor-ref>` and determine the source agent's team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-ref>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `place_below` and `place_right` are idempotent, but `swap` is not: calling `swap` twice swaps the panes back, so a native swap normally reports `moved`; `unchanged` is only possible when the driver explicitly reports `changed=false`. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
 
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -166,10 +166,10 @@ If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --for
    - `--force`: skips the message and tears the member down from the placement recorded at spawn time — kills its tmux pane/window and drops its registration.
 3. Show the script's output.
 
-If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
-1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
-3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+If argument starts with "arrange" (e.g. "arrange alice place_below tmux:%2"):
+1. Parse `<agent> <place_below|place_right|swap> <anchor-ref>` and determine the source agent's team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-ref>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `place_below` and `place_right` are idempotent, but `swap` is not: calling `swap` twice swaps the panes back, so a native swap normally reports `moved`; `unchanged` is only possible when the driver explicitly reports `changed=false`. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
 
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).

--- a/scripts/drivers/types/copilot/template.md
+++ b/scripts/drivers/types/copilot/template.md
@@ -137,10 +137,10 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
-If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
-1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
-3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+If argument starts with "arrange" (e.g. "arrange alice place_below tmux:%2"):
+1. Parse `<agent> <place_below|place_right|swap> <anchor-ref>` and determine the source agent's team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-ref>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `place_below` and `place_right` are idempotent, but `swap` is not: calling `swap` twice swaps the panes back, so a native swap normally reports `moved`; `unchanged` is only possible when the driver explicitly reports `changed=false`. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
 
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).

--- a/scripts/drivers/types/cursor/template.md
+++ b/scripts/drivers/types/cursor/template.md
@@ -136,10 +136,10 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
-If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
-1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
-3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+If argument starts with "arrange" (e.g. "arrange alice place_below tmux:%2"):
+1. Parse `<agent> <place_below|place_right|swap> <anchor-ref>` and determine the source agent's team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-ref>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `place_below` and `place_right` are idempotent, but `swap` is not: calling `swap` twice swaps the panes back, so a native swap normally reports `moved`; `unchanged` is only possible when the driver explicitly reports `changed=false`. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
 
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).

--- a/scripts/drivers/types/gemini/template.md
+++ b/scripts/drivers/types/gemini/template.md
@@ -137,10 +137,10 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
 3. If the session's active FROM was `<name>`, clear that state.
 4. Tell the user: "Dropped role `<name>` from this project."
 
-If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
-1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
-3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+If argument starts with "arrange" (e.g. "arrange alice place_below tmux:%2"):
+1. Parse `<agent> <place_below|place_right|swap> <anchor-ref>` and determine the source agent's team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-ref>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `place_below` and `place_right` are idempotent, but `swap` is not: calling `swap` twice swaps the panes back, so a native swap normally reports `moved`; `unchanged` is only possible when the driver explicitly reports `changed=false`. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
 
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).

--- a/scripts/drivers/types/grok-build/template.md
+++ b/scripts/drivers/types/grok-build/template.md
@@ -167,10 +167,10 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
    - persistent: true
 5. Tell the user: "Dropped role `<name>` from this project."
 
-If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
-1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
-3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+If argument starts with "arrange" (e.g. "arrange alice place_below tmux:%2"):
+1. Parse `<agent> <place_below|place_right|swap> <anchor-ref>` and determine the source agent's team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-ref>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `place_below` and `place_right` are idempotent, but `swap` is not: calling `swap` twice swaps the panes back, so a native swap normally reports `moved`; `unchanged` is only possible when the driver explicitly reports `changed=false`. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
 
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).

--- a/scripts/drivers/types/hermes/template.md
+++ b/scripts/drivers/types/hermes/template.md
@@ -125,10 +125,10 @@ If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex re
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
 3. Show the script's output.
 
-If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
-1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
-3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+If argument starts with "arrange" (e.g. "arrange alice place_below tmux:%2"):
+1. Parse `<agent> <place_below|place_right|swap> <anchor-ref>` and determine the source agent's team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-ref>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `place_below` and `place_right` are idempotent, but `swap` is not: calling `swap` twice swaps the panes back, so a native swap normally reports `moved`; `unchanged` is only possible when the driver explicitly reports `changed=false`. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
 
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).

--- a/scripts/drivers/types/opencode/template.md
+++ b/scripts/drivers/types/opencode/template.md
@@ -160,10 +160,10 @@ If argument starts with "drop" followed by an agent name (e.g. "drop alice"):
    - description: `agmsg inbox stream`
 5. Tell the user: "Dropped role `<name>` from this project."
 
-If argument starts with "arrange" (e.g. "arrange alice place_below bob"):
-1. Parse `<agent> <place_below|place_right> <anchor-agent>` and determine their shared team.
-2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-agent>`.
-3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+If argument starts with "arrange" (e.g. "arrange alice place_below tmux:%2"):
+1. Parse `<agent> <place_below|place_right|swap> <anchor-ref>` and determine the source agent's team.
+2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-ref>`.
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `place_below` and `place_right` are idempotent, but `swap` is not: calling `swap` twice swaps the panes back, so a native swap normally reports `moved`; `unchanged` is only possible when the driver explicitly reports `changed=false`. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
 
 If argument starts with "peek" (e.g. "peek reviewer", "peek alice --lines 80"):
 1. Parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return).

--- a/tests/test_peek_poke.bats
+++ b/tests/test_peek_poke.bats
@@ -494,23 +494,59 @@ EOF
 }
 
 @test "arrange: public identity join rejects different recorded terminals" {
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a >/dev/null
   _write_named_record alice 'tmux:%1'
-  _write_named_record bob 'herdr:wA:p2'
-  run bash "$SCRIPTS/arrange.sh" testteam alice place_below bob
+  run bash "$SCRIPTS/arrange.sh" testteam alice place_below herdr:wA:p2
   [ "$status" -ne 0 ]
-  _out_has "members are in different terminals"
+  _out_has "source and anchor are in different terminals"
 }
 
 @test "arrange: public entry preserves unchanged and moved from the driver" {
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a >/dev/null
   _install_fake_tmux_arrange
   _write_named_record alice 'tmux:%1'
-  _write_named_record bob 'tmux:%2'
   export TMUX_LAYOUT=$'%1|@7|11|0|80|10\n%2|@7|0|0|80|10'
-  run bash "$SCRIPTS/arrange.sh" testteam alice place_below bob
+  run bash "$SCRIPTS/arrange.sh" testteam alice place_below tmux:%2
   [ "$status" -eq 0 ]
   [ "$output" = unchanged ]
   export TMUX_LAYOUT=$'%1|@7|0|0|40|10\n%2|@7|12|0|40|10'
-  run bash "$SCRIPTS/arrange.sh" testteam alice place_below bob
+  run bash "$SCRIPTS/arrange.sh" testteam alice place_below tmux:%2
   [ "$status" -eq 0 ]
   [ "$output" = moved ]
+}
+
+@test "arrange: source must still be a roster member, anchor need not be one" {
+  _install_fake_tmux_arrange
+  _write_named_record alice 'tmux:%1'
+  export TMUX_LAYOUT=$'%1|@7|0|0|40|10\n%2|@7|12|0|40|10'
+  run bash "$SCRIPTS/arrange.sh" testteam alice swap tmux:%2
+  [ "$status" -ne 0 ]
+  [ "$output" = "arrange: source 'testteam/alice' is not a registered member" ]
+}
+
+@test "arrange: an invalid anchor reference is distinct from terminal and layout failures" {
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a >/dev/null
+  _write_named_record alice 'tmux:%1'
+  run bash "$SCRIPTS/arrange.sh" testteam alice swap tmux:not-a-pane
+  [ "$status" -ne 0 ]
+  [ "$output" = "arrange: anchor reference 'tmux:not-a-pane' did not resolve to a terminal and pane id" ]
+}
+
+@test "arrange: a terminal without arrange capability stays distinct from bad references" {
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a >/dev/null
+  _write_named_record alice 'plain:-'
+  run bash "$SCRIPTS/arrange.sh" testteam alice swap plain:-
+  [ "$status" -ne 0 ]
+  [ "$output" = "arrange: terminal 'plain' cannot arrange panes" ]
+}
+
+@test "arrange: swap accepts a non-member pane reference" {
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a >/dev/null
+  _install_fake_tmux_arrange
+  _write_named_record alice 'tmux:%1'
+  export TMUX_LAYOUT=$'%1|@7|0|0|40|10\n%2|@7|0|41|40|10'
+  run bash "$SCRIPTS/arrange.sh" testteam alice swap tmux:%2
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  grep -q '^tmux \[swap-pane\] \[-s\] \[%1\] \[-t\] \[%2\]$' "$ARGV_LOG"
 }

--- a/tests/test_peek_poke.bats
+++ b/tests/test_peek_poke.bats
@@ -532,6 +532,21 @@ EOF
   [ "$output" = "arrange: anchor reference 'tmux:not-a-pane' did not resolve to a terminal and pane id" ]
 }
 
+@test "arrange: place intents reject the source pane as anchor before driver mutation" {
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a >/dev/null
+  _install_fake_tmux_arrange
+  _write_named_record alice 'tmux:%1'
+  export TMUX_LAYOUT='%1|@7|0|0|40|10'
+  local intent
+  for intent in place_below place_right; do
+    : > "$ARGV_LOG"
+    run bash "$SCRIPTS/arrange.sh" testteam alice "$intent" tmux:%1
+    [ "$status" -ne 0 ]
+    [ "$output" = "arrange: source and anchor must be different panes" ]
+    [ ! -s "$ARGV_LOG" ]
+  done
+}
+
 @test "arrange: a terminal without arrange capability stays distinct from bad references" {
   bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a >/dev/null
   _write_named_record alice 'plain:-'

--- a/tests/test_peek_poke.bats
+++ b/tests/test_peek_poke.bats
@@ -565,3 +565,14 @@ EOF
   [ "$output" = moved ]
   grep -q '^tmux \[swap-pane\] \[-s\] \[%1\] \[-t\] \[%2\]$' "$ARGV_LOG"
 }
+
+@test "arrange: legacy bare tmux anchor references remain accepted" {
+  bash "$SCRIPTS/join.sh" testteam alice claude-code /tmp/project-a >/dev/null
+  _install_fake_tmux_arrange
+  _write_named_record alice 'tmux:%1'
+  export TMUX_LAYOUT=$'%1|@7|0|0|40|10\n%2|@7|0|41|40|10'
+  run bash "$SCRIPTS/arrange.sh" testteam alice swap %2
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  grep -q '^tmux \[swap-pane\] \[-s\] \[%1\] \[-t\] \[%2\]$' "$ARGV_LOG"
+}

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -513,6 +513,22 @@ EOF
   grep -q '\[move-pane\] \[-s\] \[%1\] \[-t\] \[%2\] \[-h\]' "$ARGV_LOG"
 }
 
+@test "tmux hint swap: two calls both move occupied panes" {
+  _install_fake_tmux_layout
+  agmsg_terminal_load tmux
+  terminal_describe | grep -q '^intent.swap=tmux swap-pane -s SOURCE -t TARGET$'
+  export TMUX_LAYOUT=$'%1|@7|0|0|40|10\n%2|@7|0|41|40|10'
+  run terminal_arrange '%1' swap '%2'
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  grep -q '\[swap-pane\] \[-s\] \[%1\] \[-t\] \[%2\]' "$ARGV_LOG"
+  : > "$ARGV_LOG"
+  run terminal_arrange '%1' swap '%2'
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  grep -q '\[swap-pane\] \[-s\] \[%1\] \[-t\] \[%2\]' "$ARGV_LOG"
+}
+
 @test "tmux: arrange cannot locate a listed pane -> unknown/10, not runtime_error" {
   _install_fake_tmux_layout
   agmsg_terminal_load tmux
@@ -649,6 +665,12 @@ elif [ "\$1 \$2" = 'pane move' ]; then
       ;;
     *) printf '%s\n' '{"result":{"move_result":{"changed":true}}}' ;;
   esac
+elif [ "\$1 \$2" = 'pane swap' ]; then
+  if [ "\${HERDR_SWAP_CHANGED:-true}" = true ]; then
+    printf '%s\n' '{"result":{"swap_result":{"changed":true}}}'
+  else
+    printf '%s\n' '{"result":{"swap_result":{"changed":false}}}'
+  fi
 fi
 exit 0
 EOF
@@ -700,6 +722,29 @@ EOF
   [ "$output" = moved ]
   grep -q '\[pane\] \[move\] \[wA:p1\] \[--new-tab\] \[--no-focus\]' "$ARGV_LOG"
   grep -q '\[--split\] \[right\]' "$ARGV_LOG"
+}
+
+@test "herdr hint swap: two calls move, explicit changed=false is unchanged" {
+  _install_fake_herdr_layout
+  agmsg_terminal_load herdr
+  terminal_describe | grep -q '^intent.swap=herdr pane swap --source-pane SOURCE --target-pane TARGET$'
+  export HERDR_LAYOUT='{"result":{"layout":{"tab_id":"wA:t1","panes":[{"pane_id":"wA:p1","rect":{"x":0,"y":0,"width":10,"height":20}},{"pane_id":"wA:p2","rect":{"x":10,"y":0,"width":10,"height":20}}],"splits":[]}}}'
+  run terminal_arrange 'wA:p1' swap 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  [ "$(grep -c '\[pane\] \[layout\]' "$ARGV_LOG")" -eq 2 ]
+  [ "$(grep -c '\[pane\] \[swap\]' "$ARGV_LOG")" -eq 1 ]
+  : > "$ARGV_LOG"
+  run terminal_arrange 'wA:p1' swap 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = moved ]
+  [ "$(grep -c '\[pane\] \[swap\]' "$ARGV_LOG")" -eq 1 ]
+  : > "$ARGV_LOG"
+  export HERDR_SWAP_CHANGED=false
+  run terminal_arrange 'wA:p1' swap 'wA:p2'
+  [ "$status" -eq 0 ]
+  [ "$output" = unchanged ]
+  grep -q '\[pane\] \[swap\] \[--source-pane\] \[wA:p1\] \[--target-pane\] \[wA:p2\]' "$ARGV_LOG"
 }
 
 @test "herdr: equal-area direction-compatible split candidates fail closed" {

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -173,8 +173,9 @@ write_node_launcher_fixtures() {
 @test "every agent template exposes declarative arrange without adding a public where verb" {
   local template
   for template in "$SCRIPTS"/drivers/types/*/template.md; do
-    grep -q 'scripts/arrange\.sh <team> <agent> <intent> <anchor-agent>' "$template"
+    grep -q 'scripts/arrange\.sh <team> <agent> <intent> <anchor-ref>' "$template"
     grep -q '`moved` as a performed move and `unchanged`' "$template"
+    grep -q '`swap` is not' "$template"
     [ "$(grep -c 'If argument starts with "where"' "$template" || true)" -eq 0 ]
   done
 }


### PR DESCRIPTION
Closes #1077.

`arrange` could only name another member of the same team as its anchor, and could only place — never exchange. A seat that needed to move a pane to the bottom-right of a workspace found neither expressible and called `herdr pane swap` directly, which is the report behind the issue.

Two changes, both narrow.

**An anchor may now be a terminal pane reference.** An anchor is a position, not a participant, so it does not have to be an agent: a member of another team, a bare shell, an editor pane all work now, in the same `<terminal>:<id>` form `peek` and `poke` already report. Legacy bare tmux ids (`%N`, `@N`) resolve through the same path. A reference that names nothing is a reference error and is *not* retried as a roster lookup — falling back would turn a typo into a silent lookup of a member who happens to share the string. The source still has to be a member; that is what the placement record is keyed on, and the check is now explicit rather than implied.

**`swap` joins `place_below` and `place_right`.** It is the least ambiguous of the three: both positions exist, both stay occupied, and nothing has to be inferred about the layout.

**`swap` is not idempotent, and the other two are.** `place_below` run twice reports `unchanged` the second time because there is a target state to already be in. `swap` run twice puts both panes back where they started, so there is no equivalent `unchanged` to report — inventing one would be a lie. It reports `moved` both times, and a test asserts exactly that, so a later reader who thinks the second call "should" be `unchanged` finds the intent recorded rather than having to re-derive it. The only `unchanged` `swap` can honestly report is a self-swap, which tmux refuses. All nine type templates carry the same note, since that is what an agent reads.

Absolute positions ("bottom right") are deliberately not added. They mean different things under different layouts, and the existing `ambiguous_layout` reasoning is built on relative intent. With a pane reference as anchor and a swap intent, "put this at the bottom right" is expressible as "swap it with whatever is there", which is unambiguous.

The three refusal reasons stay distinct: a terminal that cannot arrange, a layout that cannot be resolved, and a reference that names nothing are three different answers.
