### PR TITLE
feat(terminal): a seat names its own pane when it acts, from its environment

### DIFF
--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -223,9 +223,19 @@ _herdr_pane_for_session() {
   return 2   # no candidate array path (unknown schema) -> could not answer
 }
 
-# record op: we are under herdr iff HERDR_ENV=1 and herdr is on PATH. Resolve
-# THIS session's pane from the session id via agent list (NOT inherited
-# HERDR_PANE_ID). Non-zero if not under herdr or the pane cannot be resolved.
+# record op: we are under herdr iff HERDR_ENV=1. Resolve THIS pane from the
+# environment first: herdr sets HERDR_PANE_ID in every pane's process tree, and
+# it is the pane the process is actually in -- MEASURED 2026-09-08 on the live
+# workstation (herdr 0.8.0): of every process carrying both HERDR_PANE_ID and
+# a CLI session id, 176 sat in exactly the pane `agent list` reported for that
+# session and 0 did not. An earlier note here said the inherited value was not
+# trusted; that was a caution written without a measurement, and the cost of
+# it was one `agent list` round trip per self-identification plus a hard
+# requirement for a session id, which a seat that acts (send, inbox) does not
+# have at hand -- so every codex seat stayed nameless. The session-id lookup
+# remains as the fallback for a caller with a session id and no pane in its
+# environment. Non-zero if not under herdr; empty stdout if the pane cannot
+# be resolved.
 terminal_detect() {
   local sid="${1:-}"
   # PRESENCE (exit code) is HERDR_ENV=1 ALONE: whether herdr is on PATH is a
@@ -237,8 +247,15 @@ terminal_detect() {
   # answered but we are not in it) goes to stderr for resolve-for-name's error;
   # resolve-for-placement uses only the exit code and needs no id.
   [ "${HERDR_ENV:-}" = 1 ] || return 1
+  # The pane we are in, from the environment: no round trip, no session id.
+  # Only a value of the measured pane-id grammar is taken; anything else
+  # falls through to the lookup rather than naming a pane that cannot exist.
+  if [ -n "${HERDR_PANE_ID:-}" ] && _herdr_pane_id_ok "${HERDR_PANE_ID}"; then
+    printf '%s\n' "${HERDR_PANE_ID}"
+    return 0
+  fi
   if [ -z "$sid" ]; then
-    echo "herdr: no session id to resolve this pane by" >&2
+    echo "herdr: no HERDR_PANE_ID in the environment and no session id to resolve this pane by" >&2
     return 0
   fi
   local pane hrc=0

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -17,6 +17,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 agmsg_storage_load
 
+# A seat that reads history as itself names its own pane if it is not named
+# (self-name.sh); see send.sh. Only when an agent is given: without one this
+# is a team-wide read by nobody in particular.
+if [ -n "$AGENT" ]; then
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/lib/self-name.sh"
+  agmsg_self_name_on_action "$TEAM" "$AGENT"
+fi
+
 # A history read must not create a store, so a team that has never been written
 # to has no file yet. Since the stores split per team that is the ordinary state
 # of a freshly joined team rather than a broken install, and it reads out the

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -16,6 +16,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"
 agmsg_storage_load
 
+# A seat that reads its inbox names its own pane if it is not named
+# (self-name.sh); see send.sh. Best-effort, never fails the read.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/self-name.sh"
+agmsg_self_name_on_action "$TEAM" "$AGENT"
+
 # An inbox check must not create the store, so a team that has never been
 # written to has no file yet. Since the stores split per team that is the
 # ORDINARY state of a freshly joined team, not a broken install — before the

--- a/scripts/lib/role-session.sh
+++ b/scripts/lib/role-session.sh
@@ -141,9 +141,16 @@ agmsg_role_session_load() {
 agmsg_role_session_record() {
   local team="$1" agent="$2" bare_sid="$3" project="${4:-}" type="${5:-}"
   [ -n "$team" ] && [ -n "$agent" ] && [ -n "$bare_sid" ] || return 0
-  local path dir tmp ts
+  local path dir tmp ts named_ref="" named_epoch="" named_at=""
   _agmsg_role_session_path_into "$team" "$agent"
   path="$_AGMSG_ROLE_SESSION_PATH"
+  # The naming mark (named_ref / named_at, see agmsg_role_session_mark_named)
+  # survives a re-record: this function rewrites the session fields, and the
+  # mark is a fact about the PANE, not about the session. Dropping it here
+  # would cost one terminal round trip on the seat's next action for nothing.
+  named_ref="$(_agmsg_role_session_field "$path" named_ref)"
+  named_epoch="$(_agmsg_role_session_field "$path" named_epoch)"
+  named_at="$(_agmsg_role_session_field "$path" named_at)"
   dir="$(_actas_lock_dir)"
   mkdir -p "$dir" 2>/dev/null || true
   tmp="$(mktemp "$dir/.role-session.XXXXXX" 2>/dev/null)" || return 0
@@ -156,9 +163,77 @@ agmsg_role_session_record() {
     printf 'type=%s\n' "$type"
     printf 'project=%s\n' "$project"
     printf 'updated_at=%s\n' "$ts"
+    [ -z "$named_ref" ] || printf 'named_ref=%s\n' "$named_ref"
+    [ -z "$named_ref" ] || printf 'named_epoch=%s\n' "$named_epoch"
+    [ -z "$named_at" ] || printf 'named_at=%s\n' "$named_at"
   } > "$tmp" 2>/dev/null || { rm -f "$tmp" 2>/dev/null; return 0; }
   mv -f "$tmp" "$path" 2>/dev/null || rm -f "$tmp" 2>/dev/null
   return 0
+}
+
+# The naming mark: "agmsg named the pane <ref> for this (team, agent)". It is a
+# record of what agmsg DID, not a guarantee of what the terminal shows now --
+# a pane can be closed and reused by another seat, and a terminal can restart
+# and forget the name while the mark survives. So a reader compares named_ref
+# with the pane it is in NOW (see agmsg_self_name_on_action) and treats any
+# difference as "not named"; a reference that carries the terminal server's
+# identity (tmux: $TMUX, with the server pid inside) invalidates itself on a
+# restart, one that does not (herdr: the pane id alone) cannot, and that case
+# is named as a blind spot where the hook is documented.
+#
+# Every other field of the record is preserved; a record that does not exist
+# yet (a seat that never went through actas/session-start, e.g. one started by
+# hand) is created with the identity fields and no session line -- every
+# reader of this file is fail-open on a missing field.
+#
+#   agmsg_role_session_mark_named <team> <agent> <ref> <epoch> [<project>] [<type>]
+#
+# <epoch> is the terminal server's generation as the environment shows it
+# (tmux: the server pid inside $TMUX; herdr: inode and ctime of the socket at
+# $HERDR_SOCKET_PATH, which the server recreates when it starts). A restarted
+# server changes it, so a mark made against the old server no longer matches
+# even when the pane reference is reused unchanged.
+agmsg_role_session_mark_named() {
+  local team="$1" agent="$2" ref="$3" epoch="${4:-}" project="${5:-}" type="${6:-}"
+  [ -n "$team" ] && [ -n "$agent" ] && [ -n "$ref" ] || return 0
+  local path dir tmp ts line
+  _agmsg_role_session_path_into "$team" "$agent"
+  path="$_AGMSG_ROLE_SESSION_PATH"
+  dir="$(_actas_lock_dir)"
+  mkdir -p "$dir" 2>/dev/null || true
+  tmp="$(mktemp "$dir/.role-session.XXXXXX" 2>/dev/null)" || return 0
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+  {
+    if [ -f "$path" ]; then
+      while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in named_ref=*|named_epoch=*|named_at=*) ;; *) printf '%s\n' "$line" ;; esac
+      done < "$path"
+    else
+      printf 'name=%s-%s\n' "$team" "$agent"
+      printf 'team=%s\n' "$team"
+      printf 'agent=%s\n' "$agent"
+      printf 'type=%s\n' "$type"
+      printf 'project=%s\n' "$project"
+      printf 'updated_at=%s\n' "$ts"
+    fi
+    printf 'named_ref=%s\n' "$ref"
+    printf 'named_epoch=%s\n' "$epoch"
+    printf 'named_at=%s\n' "$ts"
+  } > "$tmp" 2>/dev/null || { rm -f "$tmp" 2>/dev/null; return 0; }
+  mv -f "$tmp" "$path" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+  return 0
+}
+
+# The mark as "<ref>\t<epoch>", or empty when there is none. One file read;
+# this is the common-case cost of "am I named?" (measured 0.22 ms), which is
+# what lets a seat ask on every action.
+agmsg_role_session_named() {
+  local team="$1" agent="$2" ref epoch
+  _agmsg_role_session_path_into "$team" "$agent"
+  ref="$(_agmsg_role_session_field "$_AGMSG_ROLE_SESSION_PATH" named_ref)"
+  [ -n "$ref" ] || return 0
+  epoch="$(_agmsg_role_session_field "$_AGMSG_ROLE_SESSION_PATH" named_epoch)"
+  printf '%s\t%s\n' "$ref" "$epoch"
 }
 
 # Read a single field from a role's record by (team, agent). Empty if absent.

--- a/scripts/lib/role-session.sh
+++ b/scripts/lib/role-session.sh
@@ -224,9 +224,9 @@ agmsg_role_session_mark_named() {
   return 0
 }
 
-# The mark as "<ref>\t<epoch>", or empty when there is none. One file read;
-# this is the common-case cost of "am I named?" (measured 0.22 ms), which is
-# what lets a seat ask on every action.
+# The mark as "<ref>\t<epoch>", or empty when there is none. Two reads of one
+# small file, no process; this is the common-case cost of "am I named?"
+# (measured 0.22 ms), which is what lets a seat ask on every action.
 agmsg_role_session_named() {
   local team="$1" agent="$2" ref epoch
   _agmsg_role_session_path_into "$team" "$agent"

--- a/scripts/lib/self-name.sh
+++ b/scripts/lib/self-name.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# self-name.sh — a seat names its own pane when it ACTS, if it is not named.
+#
+# The problem (1.3.0 requirement): every live seat's terminal id/name must be
+# right in any state. Identifying a seat from the outside cannot reach every
+# state -- a seat started by hand has no placement record, a resumed seat's
+# record points at a pane it no longer sits in -- so `team --fix` skips
+# exactly the seats that need it. Inverting the direction removes the
+# question: the seat itself knows its team, its name and (from its environment)
+# the pane it is in, so when it does anything through agmsg it can make sure
+# its pane carries its name. The moment such a seat sends or reads, it is
+# correct, whatever the records say.
+#
+# The self-naming primitive already existed (agmsg_terminal_name_self), but
+# every one of its five callers was a Claude Code path (SessionStart,
+# actas-claim, join, watch, check-inbox), so a codex seat never passed
+# through it. This hook is tied to the ACTION instead, and is called from the
+# commands a seat of any type runs: send, inbox, history. The five paths stay;
+# they and this hook call the same primitive and leave the same mark, so
+# whichever runs first, the state is the same.
+#
+# COST is the condition (measured 2026-09-08 on the shared workstation):
+#   history.sh 0.8-1.1 s, inbox.sh 0.2-0.3 s   the commands this rides on
+#   mark check (one file read + compare)         0.22 ms
+#   naming (one terminal round trip)            10-30 ms, tmux or herdr
+# So the common case costs nothing anyone can see, and the terminal is called
+# once per (seat, pane, server generation).
+#
+# THE MARK LIES in two ways, and this is what is done about each:
+#   - the pane was closed and another seat now sits in it: that seat has no
+#     mark for this pane (its own record names another pane, or nothing), so
+#     it names the pane for itself on its first action, overwriting the stale
+#     name. The old seat, if it acts again from elsewhere, finds its mark
+#     naming a pane it is not in, and names the new one.
+#   - the terminal server restarted and forgot the name: the mark carries the
+#     server generation as the environment shows it (tmux: the pid in $TMUX;
+#     herdr: the socket file's inode+ctime, recreated at server start), so a
+#     restart makes the mark not match and the seat names itself again.
+#   BLIND SPOT, stated rather than papered over: a name removed while the
+#   server generation and the pane are unchanged (someone renamed the pane by
+#   hand, or a terminal that clears names without restarting) is not seen
+#   here -- the mark says named, nothing in the environment says otherwise,
+#   and no terminal call is made. `team --fix` (which observes the terminal)
+#   or `rename` repairs that case; this hook does not claim to.
+#
+# Never fails the caller: naming is a side effect of the action, the action is
+# the thing. Every failure path returns 0 after one line on stderr.
+#
+#   agmsg_self_name_on_action <team> <agent> [<project>] [<type>]
+
+[ -n "${_AGMSG_SELF_NAME_SH:-}" ] && return 0
+_AGMSG_SELF_NAME_SH=1
+
+_agmsg_self_name_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${SKILL_DIR:=$(cd "$_agmsg_self_name_dir/../.." && pwd)}"
+export SKILL_DIR
+
+agmsg_self_name_on_action() {
+  local team="${1:-}" agent="${2:-}" project="${3:-}" type="${4:-}"
+  [ -n "$team" ] && [ -n "$agent" ] || return 0
+  # Opt-out for a caller that must not touch a terminal at all (tests that run
+  # under a real tmux, batch tooling). Same switch as the existing naming paths
+  # use for the visible label; here it turns the whole hook off.
+  [ "${AGMSG_SELF_NAME:-on}" != off ] || return 0
+
+  # shellcheck disable=SC1091
+  . "$SKILL_DIR/scripts/lib/terminal-registry.sh" 2>/dev/null || return 0
+  # shellcheck disable=SC1091
+  . "$SKILL_DIR/scripts/lib/role-session.sh" 2>/dev/null || return 0
+
+  # Fast half: where am I (environment only), and does my mark say so?
+  local here terminal id epoch have ref
+  here="$(agmsg_terminal_self_env)"
+  [ -n "$here" ] || return 0                 # no pane to name (plain, or no terminal)
+  terminal="${here%%	*}"; here="${here#*	}"
+  id="${here%%	*}"; epoch="${here#*	}"
+  ref="$(agmsg_terminal_ref "$terminal" "$id")"
+  have="$(agmsg_role_session_named "$team" "$agent")"
+  if [ -n "$have" ] && [ "${have%%	*}" = "$ref" ] && [ "${have#*	}" = "$epoch" ]; then
+    return 0                                 # named, by a mark that matches where I am
+  fi
+
+  # Slow half, once: name the pane through the same primitive every other
+  # path uses; it leaves the mark on success. An empty session id is right
+  # here: both drivers identify the pane from the environment now, and the
+  # acting commands have no session id at hand.
+  agmsg_terminal_name_self_safe "" "$team" "$agent" "$project" "$type" || true
+  return 0
+}

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -381,6 +381,55 @@ agmsg_terminal_ref() {
   printf '%s:%s\n' "$1" "$2"
 }
 
+# The terminal server's generation, as the ENVIRONMENT shows it -- no call to
+# the terminal. This is what lets a naming mark (role-session named_epoch)
+# notice that the server it was made against has been restarted, the case in
+# which the pane reference can survive unchanged while the name it carried is
+# gone. Empty when the terminal offers nothing of the kind.
+#
+#   tmux   the server pid, the middle field of $TMUX ("socket,pid,index")
+#   herdr  inode and ctime of the socket at $HERDR_SOCKET_PATH: the server
+#          creates that file when it starts (measured: its ctime is the last
+#          server start), so a restart recreates it. stat's flags differ
+#          between BSD and GNU; both are tried, and no stat at all is "".
+#   plain  nothing to observe
+agmsg_terminal_epoch() {   # <terminal>
+  case "$1" in
+    tmux)
+      [ -n "${TMUX:-}" ] || return 0
+      local rest="${TMUX#*,}"
+      printf 'pid=%s\n' "${rest%%,*}" ;;
+    herdr)
+      [ -n "${HERDR_SOCKET_PATH:-}" ] || return 0
+      local s=""
+      s="$(stat -f '%i:%c' "$HERDR_SOCKET_PATH" 2>/dev/null)" \
+        || s="$(stat -c '%i:%Z' "$HERDR_SOCKET_PATH" 2>/dev/null)" \
+        || s=""
+      [ -z "$s" ] || printf 'sock=%s\n' "$s" ;;
+  esac
+  return 0
+}
+
+# The pane this process is in, from the ENVIRONMENT alone: no driver loaded, no
+# terminal called. Prints "<terminal>\t<id>\t<epoch>" or nothing. This is the
+# fast half of self-naming on action: a seat that finds its mark equal to this
+# never touches the terminal (measured 0.22 ms for the file read). It answers
+# the same question as agmsg_terminal_resolve_name("") for tmux and herdr --
+# tmux from $TMUX/$TMUX_PANE (the driver's terminal_detect reads exactly those),
+# herdr from HERDR_PANE_ID (the driver's terminal_detect now prefers it too).
+# Under neither, nothing: plain has no pane to name.
+agmsg_terminal_self_env() {
+  if [ -n "${TMUX:-}" ] && [ -n "${TMUX_PANE:-}" ]; then
+    printf 'tmux\t%s:%s\t%s\n' "${TMUX%%,*}" "$TMUX_PANE" "$(agmsg_terminal_epoch tmux)"
+    return 0
+  fi
+  if [ "${HERDR_ENV:-}" = 1 ] && [ -n "${HERDR_PANE_ID:-}" ]; then
+    printf 'herdr\t%s\t%s\n' "$HERDR_PANE_ID" "$(agmsg_terminal_epoch herdr)"
+    return 0
+  fi
+  return 0
+}
+
 # Print the terminal name of a record ref (stdout). Handles legacy bare ids.
 # Is <id> a well-formed id for <terminal>? The SINGLE authority for the per-terminal
 # bare-id grammar, shared by agmsg_terminal_ref_terminal (below) and the herdr
@@ -589,7 +638,26 @@ agmsg_terminal_name_self() {
     return "$rc"
   fi
 
-  # Named. Whether that ALSO makes this pane the seat's recorded placement is the
+  # Named. Leave the mark that says so -- "agmsg named pane <ref> of server
+  # generation <epoch> for this seat" -- in the seat's role-session record, so
+  # the next action reads one file instead of calling the terminal (see
+  # agmsg_self_name_on_action). Every path that names writes the same mark
+  # here, which is what makes "whichever path runs first" produce the same
+  # state. Best-effort: a mark that cannot be written costs one round trip on
+  # the next action, nothing else, and must never turn a successful naming
+  # into a failure.
+  if ! declare -F agmsg_role_session_mark_named >/dev/null 2>&1 \
+     && [ -n "${SKILL_DIR:-}" ] && [ -r "$SKILL_DIR/scripts/lib/role-session.sh" ]; then
+    # shellcheck disable=SC1091
+    . "$SKILL_DIR/scripts/lib/role-session.sh" 2>/dev/null || true
+  fi
+  if declare -F agmsg_role_session_mark_named >/dev/null 2>&1; then
+    agmsg_role_session_mark_named "$team" "$agent" \
+      "$(agmsg_terminal_ref "$terminal" "$id")" "$(agmsg_terminal_epoch "$terminal")" \
+      "$project" "$type" || true
+  fi
+
+  # Whether that ALSO makes this pane the seat's recorded placement is the
   # caller's claim to make, not this function's.
   [ "$write_record" = record ] || return 0
 

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -392,6 +392,11 @@ agmsg_terminal_ref() {
 #          creates that file when it starts (measured: its ctime is the last
 #          server start), so a restart recreates it. stat's flags differ
 #          between BSD and GNU; both are tried, and no stat at all is "".
+#          Resolution is one second, and a filesystem may hand the freed
+#          inode straight back (ext4 does; measured on a Linux runner), so a
+#          recreation inside the same second is not visible -- a real restart
+#          takes longer than that, and the case falls into the stated blind
+#          spot rather than into a false detection.
 #   plain  nothing to observe
 agmsg_terminal_epoch() {   # <terminal>
   case "$1" in

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -23,6 +23,14 @@ source "$SCRIPT_DIR/lib/validate.sh"
 # never bypass team-name path safety.
 agmsg_validate_team_name "$TEAM" || exit 1
 
+# A seat that sends names its own pane if it is not named (self-name.sh): the
+# 1.3.0 rule that every live seat's terminal id/name is right in any state,
+# tied to the action rather than to a CLI's boot path. Best-effort, never fails
+# the send; the common case is one file read.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/self-name.sh"
+agmsg_self_name_on_action "$TEAM" "$FROM"
+
 agmsg_storage_load
 DB="$(agmsg_db_path "$TEAM")"
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -2,6 +2,15 @@
 # Each test gets an isolated skill directory with its own DB and teams.
 
 setup_test_env() {
+  # A test never inherits the developer's terminal. The terminal drivers
+  # identify "this pane" from the environment (tmux: $TMUX/$TMUX_PANE; herdr:
+  # HERDR_PANE_ID, measured 2026-09-08), and join/send/inbox/history name the
+  # caller's pane through it -- so a suite run from inside a real tmux or herdr
+  # pane would otherwise write the fixture's team:agent onto the developer's
+  # own pane. Tests that want a terminal set these AFTER this call, against a
+  # fake on PATH. CI runners carry none of these, so nothing changes there.
+  unset TMUX TMUX_PANE
+  unset HERDR_ENV HERDR_PANE_ID HERDR_SOCKET_PATH HERDR_WORKSPACE_ID HERDR_TAB_ID HERDR_SESSION
   export TEST_SKILL_DIR="$(mktemp -d)"
   mkdir -p "$TEST_SKILL_DIR"/{scripts,db,teams}
 

--- a/tests/test_self_name.bats
+++ b/tests/test_self_name.bats
@@ -197,10 +197,43 @@ _mark() {   # <team> <agent> -> "ref<TAB>epoch" or empty
   : > "$ARGV_LOG"
   agmsg_self_name_on_action team alice
   [ "$(_terminal_calls)" -eq 0 ]
-  # A restarted server recreates its socket: a new inode.
-  rm -f "$HERDR_SOCKET_PATH"; : > "$HERDR_SOCKET_PATH"
+  # A restarted server recreates its socket. The fingerprint is inode:ctime
+  # with ctime in whole seconds, and ext4 hands a just-freed inode straight
+  # back (measured on the ubuntu runner: recreate within the same second and
+  # the fingerprint did not move), so a recreation is only visible across a
+  # second boundary -- which a real server restart always crosses. Cross it.
+  rm -f "$HERDR_SOCKET_PATH"; sleep 1; : > "$HERDR_SOCKET_PATH"
   agmsg_self_name_on_action team alice
   [ "$(_name_calls)" -eq 1 ]
+}
+
+@test "herdr: a seat moved to another herdr session (a different socket path) is named again" {
+  # Not a restart: a different server altogether, whose socket is another
+  # file. The inode differs regardless of timing, so this holds on every
+  # filesystem; the restart case above is the one that needs the second.
+  _install_fake_herdr; _under_herdr w1:pB "$BATS_TEST_TMPDIR/herdr-a.sock"
+  agmsg_self_name_on_action team alice
+  : > "$ARGV_LOG"
+  _under_herdr w1:pB "$BATS_TEST_TMPDIR/herdr-b.sock"
+  agmsg_self_name_on_action team alice
+  [ "$(_name_calls)" -eq 1 ]
+}
+
+@test "setup_test_env strips the developer's terminal from the environment (regression guard)" {
+  # The tests in this file unset these themselves, so without this guard the
+  # helper's unset could be removed and nothing here would go red -- while a
+  # suite run from inside a real pane would name the developer's pane again.
+  run bash -c '
+    cd "$1" && load() { source "./test_helper.bash"; }; load
+    export TMUX="/tmp/s,1,0" TMUX_PANE="%1" HERDR_ENV=1 HERDR_PANE_ID="w1:p1" HERDR_SOCKET_PATH=/tmp/x
+    setup_test_env
+    rc=0
+    for v in TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID HERDR_SOCKET_PATH; do
+      [ -z "$(eval "printf %s \"\${$v:-}\"")" ] || { echo "still set: $v"; rc=1; }
+    done
+    teardown_test_env; exit $rc
+  ' _ "$BATS_TEST_DIRNAME"
+  [ "$status" -eq 0 ] || { echo "$output"; return 1; }
 }
 
 @test "herdr driver: terminal_detect answers from HERDR_PANE_ID, falls back to the session lookup without it, and rejects a malformed value" {

--- a/tests/test_self_name.bats
+++ b/tests/test_self_name.bats
@@ -1,0 +1,291 @@
+#!/usr/bin/env bats
+#
+# Self-naming on action (scripts/lib/self-name.sh): a seat that sends or reads
+# names its own pane if it is not named, from its environment, at the cost of
+# one file read in the common case. Pinned here, each with a control the other
+# way, and every terminal call counted through a fake that logs its argv:
+#
+#   - mark present and matching       -> the terminal is not called at all
+#   - mark present, pane differs       -> named again, mark rewritten
+#   - mark present, server restarted   -> named again (the epoch changed)
+#   - mark present, name gone, nothing else changed -> NOT seen (blind spot,
+#                                         pinned as such)
+#   - no mark                          -> named once, mark written
+#   - another seat in the same pane    -> names it for itself
+#   - order independence: a boot path first, then the action; the action
+#     first, then a boot path -- same key, one terminal call in total
+#   - herdr identifies its pane from HERDR_PANE_ID with no session id
+#   - the action commands (send / inbox / history) run the hook, and a failure
+#     to name never fails the command
+
+setup() {
+  load 'test_helper'
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  export RUN_DIR="$SKILL_DIR/run"
+  mkdir -p "$RUN_DIR"
+  export AGMSG_AGENT_PID=""
+  FAKEBIN="$BATS_TEST_TMPDIR/bin"; mkdir -p "$FAKEBIN"
+  ARGV_LOG="$BATS_TEST_TMPDIR/argv.log"; : > "$ARGV_LOG"
+  export FAKEBIN ARGV_LOG
+  # No terminal by default: each test sets the environment it wants.
+  unset TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID HERDR_SOCKET_PATH
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/self-name.sh"
+}
+teardown() { teardown_test_env; }
+
+_install_fake_tmux() {
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+exit 0
+EOF
+  chmod +x "$FAKEBIN/tmux"
+  export PATH="$FAKEBIN:$PATH"
+}
+
+_install_fake_herdr() {
+  cat > "$FAKEBIN/herdr" <<EOF
+#!/usr/bin/env bash
+{ printf 'herdr'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = agent ] && [ "\$2" = list ]; then
+  printf '{"id":"1","result":{"type":"list","agents":[]}}\n'
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/herdr"
+  export PATH="$FAKEBIN:$PATH"
+}
+
+_under_tmux() {   # <socket> <pid> <pane>
+  export TMUX="$1,$2,0" TMUX_PANE="$3"
+}
+
+_under_herdr() {  # <pane> [<socket file>]
+  local sock="${2:-$BATS_TEST_TMPDIR/herdr.sock}"
+  [ -e "$sock" ] || : > "$sock"
+  export HERDR_ENV=1 HERDR_PANE_ID="$1" HERDR_SOCKET_PATH="$sock"
+}
+
+_terminal_calls() { grep -c . "$ARGV_LOG"; }
+# The tmux driver addresses the pane's server first (`tmux -S <socket> ...`),
+# so the naming call is not at the start of the line.
+_name_calls() { grep -cE '\[set-option\] \[-p\]|^herdr \[agent\] \[rename\]' "$ARGV_LOG"; }
+# join the fixture seats with NO terminal in the environment, so the join
+# path (which names too) leaves no mark and the action under test is the
+# first thing that names.
+_join_unnamed() {   # <team> <agent>
+  env -u TMUX -u TMUX_PANE -u HERDR_ENV -u HERDR_PANE_ID -u HERDR_SOCKET_PATH \
+    bash "$SKILL_DIR/scripts/join.sh" "$1" "$2" claude-code /tmp/p >/dev/null
+}
+
+_mark() {   # <team> <agent> -> "ref<TAB>epoch" or empty
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/role-session.sh"
+  agmsg_role_session_named "$1" "$2"
+}
+
+# --- the three directions, tmux -----------------------------------------------------
+
+@test "no mark: the first action names the pane once and leaves a mark with the pane and the server pid" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  agmsg_self_name_on_action team alice
+  [ "$(_name_calls)" -eq 1 ]
+  # Addressed to the pane's OWN server (the socket from $TMUX), not to whatever
+  # `tmux` would pick by default.
+  grep -q 'tmux \[-S\] \[/tmp/s\] \[set-option\] \[-p\] \[-t\] \[%3\] \[@agmsg_agent\] \[team:alice\]' "$ARGV_LOG"
+  [ "$(_mark team alice)" = $'tmux:/tmp/s:%3\tpid=4242' ]
+}
+
+@test "mark present and matching: the action does not call the terminal at all" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  agmsg_self_name_on_action team alice
+  : > "$ARGV_LOG"
+  agmsg_self_name_on_action team alice
+  agmsg_self_name_on_action team alice
+  [ "$(_terminal_calls)" -eq 0 ]
+}
+
+@test "mark present, but I am in another pane: named again, and the mark follows" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  agmsg_self_name_on_action team alice
+  : > "$ARGV_LOG"
+  _under_tmux /tmp/s 4242 %7
+  agmsg_self_name_on_action team alice
+  [ "$(_name_calls)" -eq 1 ]
+  grep -q '\[-t\] \[%7\]' "$ARGV_LOG"
+  [ "$(_mark team alice)" = $'tmux:/tmp/s:%7\tpid=4242' ]
+}
+
+@test "mark present, same pane, but the tmux server restarted: named again (the pid in \$TMUX changed)" {
+  # The case where the pane reference survives unchanged and the name did not.
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  agmsg_self_name_on_action team alice
+  : > "$ARGV_LOG"
+  _under_tmux /tmp/s 5151 %3
+  agmsg_self_name_on_action team alice
+  [ "$(_name_calls)" -eq 1 ]
+  [ "$(_mark team alice)" = $'tmux:/tmp/s:%3\tpid=5151' ]
+}
+
+@test "blind spot, pinned: the name removed while pane and server are unchanged is not seen" {
+  # Nothing in the environment changes when a name is cleared by hand, so the
+  # hook cannot know; it is documented as the case team --fix / rename repair.
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  agmsg_self_name_on_action team alice
+  : > "$ARGV_LOG"
+  # (the fake tmux has no state to clear; the point is that the hook makes no call)
+  agmsg_self_name_on_action team alice
+  [ "$(_terminal_calls)" -eq 0 ]
+  grep -q 'BLIND SPOT' "$SKILL_DIR/scripts/lib/self-name.sh"
+}
+
+@test "another seat in the same pane names it for itself: its own record has no mark for that pane" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  agmsg_self_name_on_action team alice
+  : > "$ARGV_LOG"
+  agmsg_self_name_on_action team bob
+  [ "$(_name_calls)" -eq 1 ]
+  grep -q '\[@agmsg_agent\] \[team:bob\]' "$ARGV_LOG"
+  [ "$(_mark team bob)" = $'tmux:/tmp/s:%3\tpid=4242' ]
+  # alice's mark still names %3; when alice acts from elsewhere she is renamed there.
+  [ "$(_mark team alice)" = $'tmux:/tmp/s:%3\tpid=4242' ]
+}
+
+# --- order independence with the existing paths -------------------------------------
+
+@test "a boot path names first, then the action: same key, and the action makes no second call" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/terminal-registry.sh"
+  agmsg_terminal_name_self_safe "sid-1" team alice /tmp/p claude-code
+  [ "$(_name_calls)" -eq 1 ]
+  [ "$(_mark team alice)" = $'tmux:/tmp/s:%3\tpid=4242' ]
+  : > "$ARGV_LOG"
+  agmsg_self_name_on_action team alice
+  [ "$(_terminal_calls)" -eq 0 ]
+}
+
+@test "the action names first, then a boot path: same key both times" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  agmsg_self_name_on_action team alice
+  first="$(grep 'set-option' "$ARGV_LOG")"
+  : > "$ARGV_LOG"
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/terminal-registry.sh"
+  agmsg_terminal_name_self_safe "sid-1" team alice /tmp/p claude-code
+  [ "$(grep 'set-option' "$ARGV_LOG")" = "$first" ]
+}
+
+# --- herdr ---------------------------------------------------------------------------
+
+@test "herdr: the pane comes from HERDR_PANE_ID with no session id, and the mark carries the socket generation" {
+  _install_fake_herdr; _under_herdr w1:pB
+  agmsg_self_name_on_action team alice
+  [ "$(_name_calls)" -eq 1 ]
+  grep -q '^herdr \[agent\] \[rename\] \[w1:pB\] ' "$ARGV_LOG"
+  refute grep -q '\[agent\] \[list\]' "$ARGV_LOG"
+  local m; m="$(_mark team alice)"
+  [ "${m%%	*}" = 'herdr:w1:pB' ]
+  case "${m#*	}" in sock=*:*) ;; *) echo "epoch not a socket fingerprint: $m"; return 1 ;; esac
+}
+
+@test "herdr: mark matching -> no call; socket recreated (server restart) -> named again" {
+  _install_fake_herdr; _under_herdr w1:pB
+  agmsg_self_name_on_action team alice
+  : > "$ARGV_LOG"
+  agmsg_self_name_on_action team alice
+  [ "$(_terminal_calls)" -eq 0 ]
+  # A restarted server recreates its socket: a new inode.
+  rm -f "$HERDR_SOCKET_PATH"; : > "$HERDR_SOCKET_PATH"
+  agmsg_self_name_on_action team alice
+  [ "$(_name_calls)" -eq 1 ]
+}
+
+@test "herdr driver: terminal_detect answers from HERDR_PANE_ID, falls back to the session lookup without it, and rejects a malformed value" {
+  _install_fake_herdr
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/terminal-registry.sh"
+  export HERDR_ENV=1 HERDR_PANE_ID=w1:pB
+  run agmsg_terminal_resolve_name ""
+  [ "$status" -eq 0 ]
+  [ "$output" = $'herdr\tw1:pB' ]
+  refute grep -q '\[agent\] \[list\]' "$ARGV_LOG"
+  unset HERDR_PANE_ID
+  run agmsg_terminal_resolve_name ""
+  [ "$status" -eq 1 ]
+  export HERDR_PANE_ID='not a pane'
+  run agmsg_terminal_resolve_name ""
+  [ "$status" -eq 1 ]
+}
+
+# --- the commands ----------------------------------------------------------------------
+
+@test "send.sh names the sender's pane, and a naming failure does not fail the send" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  _join_unnamed team alice
+  _join_unnamed team bob
+  [ -z "$(_mark team alice)" ]
+  : > "$ARGV_LOG"
+  run bash "$SKILL_DIR/scripts/send.sh" team alice bob 'hello'
+  [ "$status" -eq 0 ]
+  grep -q '\[@agmsg_agent\] \[team:alice\]' "$ARGV_LOG"
+  [ "$(_mark team alice)" = $'tmux:/tmp/s:%3\tpid=4242' ]
+  # Order independence end to end: a boot path (join, kept as it was: it
+  # names unconditionally) writes the SAME key, and the send after it finds
+  # the mark and makes no call of its own.
+  : > "$ARGV_LOG"
+  bash "$SKILL_DIR/scripts/join.sh" team alice claude-code /tmp/p >/dev/null
+  [ "$(_name_calls)" -eq 1 ]
+  grep -q '\[-t\] \[%3\] \[@agmsg_agent\] \[team:alice\]' "$ARGV_LOG"
+  : > "$ARGV_LOG"
+  run bash "$SKILL_DIR/scripts/send.sh" team alice bob 'hello twice'
+  [ "$status" -eq 0 ]
+  [ "$(_name_calls)" -eq 0 ]
+  # A tmux that fails the option write: the send still succeeds.
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$FAKEBIN/tmux"
+  _under_tmux /tmp/s 4242 %9
+  run bash "$SKILL_DIR/scripts/send.sh" team alice bob 'hello again'
+  [ "$status" -eq 0 ]
+}
+
+@test "inbox.sh and history.sh (with an agent) name the reader's pane; history without an agent does not" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  _join_unnamed team alice
+  : > "$ARGV_LOG"
+  bash "$SKILL_DIR/scripts/inbox.sh" team alice >/dev/null 2>&1 || true
+  [ "$(_name_calls)" -eq 1 ]
+  grep -q '\[@agmsg_agent\] \[team:alice\]' "$ARGV_LOG"
+  : > "$ARGV_LOG"
+  _under_tmux /tmp/s 4242 %4
+  bash "$SKILL_DIR/scripts/history.sh" team alice 5 >/dev/null 2>&1 || true
+  grep -q '\[-t\] \[%4\] \[@agmsg_agent\] \[team:alice\]' "$ARGV_LOG"
+  : > "$ARGV_LOG"
+  bash "$SKILL_DIR/scripts/history.sh" team >/dev/null 2>&1 || true
+  [ "$(_terminal_calls)" -eq 0 ]
+}
+
+@test "AGMSG_SELF_NAME=off turns the hook off, and no terminal means no call" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  AGMSG_SELF_NAME=off agmsg_self_name_on_action team alice
+  [ "$(_terminal_calls)" -eq 0 ]
+  unset TMUX TMUX_PANE
+  agmsg_self_name_on_action team alice
+  [ "$(_terminal_calls)" -eq 0 ]
+}
+
+@test "the record writer keeps the mark, and the mark writer keeps the record" {
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/role-session.sh"
+  agmsg_role_session_record team alice sid-1 /tmp/p claude-code
+  agmsg_role_session_mark_named team alice tmux:/tmp/s:%3 pid=4242
+  agmsg_role_session_record team alice sid-2 /tmp/p claude-code
+  [ "$(agmsg_role_session_uuid team alice)" = sid-2 ]
+  [ "$(agmsg_role_session_named team alice)" = $'tmux:/tmp/s:%3\tpid=4242' ]
+  # A seat with no record yet (started by hand) gets a minimal one from the mark.
+  agmsg_role_session_mark_named team carol herdr:w1:pC sock=1:2 /tmp/p codex
+  [ "$(agmsg_role_session_named team carol)" = $'herdr:w1:pC\tsock=1:2' ]
+  [ "$(agmsg_role_session_get team carol type)" = codex ]
+  [ -z "$(agmsg_role_session_uuid team carol)" ]
+}


### PR DESCRIPTION
Against `integration/terminal-driver-v1` (61bcd66). This fills the 1.3.0
requirement as it was actually stated -- every live seat's terminal id/name is
right in any state -- rather than the narrower reading that shipped: "what
spawn failed to name, `team --fix` repairs".

## Why the outside-in approach cannot reach every state

`team --fix` identifies a seat from its placement record and repairs the pane
that record names. A seat started by hand has no record, so all three cells
are skipped. A seat whose record is stale points at a pane it no longer sits
in. Measured on the live workstation while writing this: one codex seat's
placement said `w1:pJ`, herdr listed no pane named for it, and its processes
sat in `w1:p2` and `wG:p1`; a lead reported it dead on that basis, and was
wrong. From the outside there is always a state that cannot be identified.

## Inverting the direction

The seat knows its team, its name and -- from its environment -- the pane it
is in. So when it does anything through agmsg, it makes sure its pane carries
its name. The moment a seat sends or reads, it is correct, whatever the
records say.

The primitive existed (`agmsg_terminal_name_self`), but all five of its callers
were Claude Code paths (SessionStart, actas-claim, join, watch, check-inbox),
so a codex seat never passed through it. This change ties naming to the
ACTION: `send.sh`, `inbox.sh` and `history.sh` (with an agent) call
`agmsg_self_name_on_action <team> <agent>`. The five paths stay; they and the
hook use the same primitive and leave the same mark, so whichever runs first
the state is the same (pinned both ways).

## Cost, measured first (shared workstation, load 19-27 on 16 cores)

    history.sh 0.80 / 0.95 / 1.07 s   inbox.sh 0.22-0.34 s      what the hook rides on
    mark check: one file read+compare  0.22 ms                  the common case
    naming: one terminal round trip    tmux 14-28 ms (median 20), herdr 10-30 ms

The terminal is called once per (seat, pane, server generation); every other
action reads one file.

## Where am I, without asking the terminal

    tmux    $TMUX_PANE and $TMUX ("socket,pid,index") are in every pane process's
            environment (measured on a private server); the driver already
            derived socket:pane from exactly these
    herdr   HERDR_PANE_ID is in every pane process's environment, codex seats and
            spawned seats included (ps -E on the live processes). The driver's
            header said the inherited value was "NOT trusted"; measured against
            `herdr agent list` for every live process carrying both the variable
            and a CLI session id: 176 agree, 0 disagree. The caution was written
            without a measurement. terminal_detect now takes HERDR_PANE_ID first
            (grammar-checked) and keeps the session-id lookup as the fallback --
            which also makes join's session-less call name a herdr pane at all.
    plain   no pane; nothing to do

## The mark, and the two ways it lies

The mark lives in the seat's `run/role-session.<team>__<agent>` (the file that
already holds its session): `named_ref=<terminal>:<id>`, `named_epoch`,
`named_at`. It is written inside `agmsg_terminal_name_self` after the driver
names the pane, so every path that names also marks; the record writer
preserves it; a seat with no record (started by hand) gets a minimal one.

The mark says "agmsg named this", not "the terminal shows this now":

- **the pane was closed and another seat sits in it** -- that seat's own record
  has no mark for this pane, so it names the pane for itself on its first
  action (measured in the tests: one call, its own key). The old seat, acting
  from elsewhere, finds its mark naming a pane it is not in and names the new
  one.
- **the terminal server restarted and forgot the name** -- `named_epoch` is the
  server generation as the environment shows it: tmux, the pid inside `$TMUX`;
  herdr, inode and ctime of the socket at `$HERDR_SOCKET_PATH`, which the server
  recreates when it starts (its ctime on the live machine is the last server
  start). A restart changes it, the mark no longer matches, the seat names
  itself again. tmux: shown with a changed pid. herdr: shown with a recreated
  socket file; the shared server was not restarted to prove the recreation.
  The fingerprint resolves to one second, and ext4 hands a freed inode
  straight back (measured in an ubuntu container: recreate within the same
  second and `inode:ctime` does not move; across a second it does; APFS
  allocates a fresh inode either way, which is why the first version of the
  restart test passed here and failed on the ubuntu shard). A real restart
  crosses a second, so the detection holds on both; a recreation inside one
  second is not visible and falls into the blind spot below. A seat moved to
  another herdr session (another socket path) is named again regardless.
- **BLIND SPOT, stated:** a name cleared while pane and server generation are
  unchanged (a rename by hand, a terminal that drops names without restarting)
  is not seen -- nothing in the environment changes, and no call is made.
  `team --fix` (which observes the terminal) and `rename` repair that case;
  this hook does not claim to. Pinned by a test that asserts the hook makes
  no call there.

## Controls (tests/test_self_name.bats, 17; every terminal call counted through a logging fake)

- no mark: one naming call, addressed to the pane's own server, mark written
  with pane and server pid; mark matching: zero terminal calls across repeated
  actions; another pane: named again, mark follows; server restarted: named
  again; the blind spot: no call, and the text that states it exists
- another seat in the same pane names it for itself; the first seat's mark is
  left as it was
- order independence: a boot path first then the action (same key, no second
  call); the action first then a boot path (same key)
- herdr: the pane from HERDR_PANE_ID with no session id and no `agent list`
  call; mark carries the socket fingerprint; recreated socket (across a
  second, as a restart is) -> named again; another socket path -> named again;
  the driver falls back to the session lookup without the variable and
  rejects a malformed value
- the commands: send names the sender and a tmux failure does not fail the
  send; join under a terminal then send: the same key and no second call;
  inbox and history (with an agent) name the reader; history without an agent
  makes no call; `AGMSG_SELF_NAME=off` and no terminal make no call
- the record writer keeps the mark; the mark writer keeps the record and
  creates a minimal one for a seat that has none

## A hazard this exposed, fixed here

bats inherits the developer's terminal environment. With environment-based
pane identification, a suite run from inside a real herdr or tmux pane would
have named the DEVELOPER's own pane with the fixture's `team:alice` the first
time a test joined or sent. `setup_test_env` now unsets `TMUX`, `TMUX_PANE`
and the `HERDR_*` variables; tests that want a terminal set them afterwards
against a fake on PATH. CI runners carry none of these, so CI is unchanged.
A regression guard pins the helper's unset: the tests in this file strip the
variables themselves, so without it the helper's line could be removed and
nothing here would go red.

## Not in this PR

`team --fix` still identifies seats from placement records; a seat with none
still shows `unknown:no_placement_record` there until it acts. Making `team`
discover seats from the panes themselves is a separate change.

Local: the suites the change touches, run one at a time with the terminal
environment stripped (this shell sits in a real herdr pane): test_self_name
17/17 on macOS and 17/17 on Linux (ubuntu 24.04 container, bash 5.2, bats
1.14 -- run there because the first restart test passed on APFS and failed on
ext4, and "green here" is one OS), test_role_session 24/0, test_reset_role_session 6/0,
test_terminal_registry 113/0. Then the full suite, because the hook sits on
send/inbox/history and join's herdr path changed: 2014 ok / 1 red / 16 skip
(started with 0 concurrent suites at load 21; another seat's suite ran
alongside for most of the two hours, load 24-74). The one red is
`the engine start restores all three traps the acquire takes (#762)` in
test_remote_status_liveness, a file this change does not touch. Isolated per
the #1067 procedure: run alone it is red at this head AND at the base 61bcd66
(2-3 s each, one other suite running, load 25), and the base's own CI run
(34099403907, success) shows it as `ok 23` on both ubuntu and macos. A host
red at the base, not this diff. `check-enforced-assertions`
at its baseline; shellcheck 0.10.0 finds nothing new in the touched scripts
(self-name.sh 0; the others unchanged from the base).
