### PR TITLE
docs(changelog): carry the three prefix-less squash subjects into the notes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -75,6 +75,9 @@ commit_parsers = [
   { message = "^Isolate Codex monitor bridges by role", group = "<!-- 0 -->Added" },
   { message = "^Allow launcher-reserved bridge PID", group = "<!-- 1 -->Fixed" },
   { message = "^Stop telling every agent that key rotate", group = "<!-- 1 -->Fixed" },
+{ message = "^Naming is an invariant every entry point re-asserts", group = "<!-- 0 -->Added" },
+{ message = "^spawn: launch codex through the bundled monitor shim", group = "<!-- 1 -->Fixed" },
+{ message = "^Remove internal handles from the published tree", group = "<!-- 3 -->Changed" },
   # Everything else (merges, initial commit, misc) is intentionally dropped.
   { message = ".*", skip = true },
 ]


### PR DESCRIPTION
Three squash subjects on this branch carry no Conventional prefix. The catch-all parser at the end of `commit_parsers` drops anything it does not recognize, so those three vanish from the generated notes entirely — not misfiled, absent.

Measured with git-cliff 2.13.1 over `v1.2.3..HEAD`:

| | entries | the three |
|---|---|---|
| without these parsers | 28 | absent |
| with them | 31 | one occurrence each |

The three are the spawn shim that stops a bare codex fallback, the removal of internal handles from the published tree, and the naming invariant re-asserted at every entry point. All three are user-visible, and two of them are the kind of change a reader would go looking for.

This is the same class that cost the 1.1.7 notes their headline feature, which is why `commit_parsers` already carries a block of literal-subject rules from earlier releases. These three join it.

A checker that would catch this before a release rather than during one is a separate, already-open piece of work; it is not part of this change.
