### PR TITLE
docs(instance-id): record that the directory guard is redundant, and why it stays

### DIFF
--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -492,6 +492,14 @@ agmsg_instance_alive() {
   # all of them and fell through to `return 1` -- a confident DEAD, produced by a
   # scan that read nothing. The composite branch above already asked for both,
   # which is the giveaway: one function, two paths, two answers. (co1)
+  #
+  # Measured after the shared reader landed, so the next reader is not misled
+  # about which line is load-bearing: this guard is now REDUNDANT. Deleting the
+  # -x from it produces no reds, because _agmsg_marker_read answers `unreadable`
+  # for every entry in an unsearchable directory and the loop then reports 2 on
+  # its own. It stays as the cheap early answer -- and because "we cannot search
+  # this directory" is the fact the branch rests on, which is not something to
+  # infer from what the per-entry reads happened to return.
   { [ -d "$run" ] && [ -r "$run" ] && [ -x "$run" ]; } || return 2
   local _m
   for f in "$run"/cc-instance.*; do


### PR DESCRIPTION
A guard whose deletion produces no reds is one a later reader will delete. This writes down the measurement instead: the `-x` check in the bare branch is redundant now that the shared marker reader answers `unreadable` for every entry in an unsearchable directory, and the loop reports 2 on its own.

It stays anyway, and the comment says why — `"we cannot search this directory"` is the fact the branch rests on, and inferring it from what the per-entry reads happened to return is the coupling that produced a confident DEAD from a scan that had read nothing.

Comment only; no behavior changes. Written while re-measuring the landed #983 work and nearly lost, since it was added after that PR had already been squashed onto this branch.