### PR TITLE
docs: state the reason a comment gives, not who gave it

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -464,7 +464,8 @@ _doctor_scan_pair() {
       # about us. The reader that fed this line answered "" for both, so doctor
       # printed "no lock" for a lock it could not read — which is exactly the
       # output an operator uses to conclude there is nothing here to clean up.
-      # (co1.) tl's instance today: he read a record he could not open, reported
+      # (Review.) A real instance the same day: someone read a record they could
+      # not open, reported
       # a seat as dead, and it was alive. A diagnostic that says `none` when it
       # means `could not look` makes people repeat that. Three reads, three
       # words. (#983)

--- a/scripts/lib/actas-lock.sh
+++ b/scripts/lib/actas-lock.sh
@@ -100,7 +100,7 @@ agmsg_spawn_path() {
 # claim / rm / consume. Guarding at each call site is not the fix, because the
 # next call site starts from the same empty string. The fold is removed HERE,
 # and no owner-only form is left in the tree to fall back into.
-# (#983, tl's ruling; the same shape as terminal_team_observe in #1066.)
+# (#983, review ruling; the same shape as terminal_team_observe in #1066.)
 #
 # Prints "<read>\t<owner>":
 #
@@ -111,7 +111,7 @@ agmsg_spawn_path() {
 #   unreadable\t   the lock is there and could not be read, OR its directory
 #                  cannot be searched, in which case absence is not knowable.
 #                  `[ -e ]` is false for BOTH "no such file" and "cannot look
-#                  inside the parent", so the directory is asked first (co3).
+#                  inside the parent", so the directory is asked first (review).
 _actas_lock_read_path() {   # <lock-path>
   local lock="$1" owner _dir
   if owner="$(head -1 "$lock" 2>/dev/null)"; then
@@ -151,10 +151,10 @@ actas_lock_sid_alive() {
 
 # The verdict for one lock, shared by every producer.
 #
-# co1 found the SAME empty lock answered `free` by actas_lock_observe and
+# Review found the SAME empty lock answered `free` by actas_lock_observe and
 # `unknown:owner_empty` by _actas_lock_try_claim. Both had been made three-valued
 # -- separately -- so two producers disagreed about one file and nothing in the
-# code said which was right. tl's axis 5: it is not enough that a path returns
+# code said which was right. Review axis 5: it is not enough that a path returns
 # unknown; every path must return the SAME unknown for the same state. So the
 # decision lives in one function and the producers translate its answer into
 # their own vocabulary instead of deciding again.
@@ -171,7 +171,7 @@ actas_lock_sid_alive() {
 #                                 a tmp file BEFORE linking it into place, and
 #                                 release unlinks), so an empty lock is a torn or
 #                                 truncated write -- a reason to wait, not to take
-#                                 the role. (cc3's #1071 trigger.)
+#                                 the role. (#1071's trigger.)
 #   unknown:liveness_undecidable  the owner is known, its liveness is not
 _actas_lock_verdict() {   # <sid> <read> <owner>
   local sid="$1" rd="$2" owner="$3" arc=0
@@ -220,8 +220,7 @@ _actas_lock_try_claim() {
   # here, unclaimable there. So the write is checked, and then what actually
   # landed is READ BACK before it is linked into place -- printf's status alone
   # does not prove the bytes are on disk. Failing here returns 1, which
-  # actas_lock_claim already reports as unknown:claim_failed. (co3, co1; tl's
-  # axis 6.)
+  # actas_lock_claim already reports as unknown:claim_failed. (Review, axis 6.)
   if ! printf '%s\n' "$sid" > "$tmp" 2>/dev/null; then
     rm -f "$tmp"
     return 1
@@ -271,7 +270,7 @@ _actas_lock_try_claim() {
 # call sites branch on the OUTPUT, so all of those read as "not held: and not
 # unknown:" = "we got it", and a pair nobody had claimed went into the subscribed
 # set. A verdict on every path is what lets a caller require an explicit success
-# instead of inferring one from silence. (#983, co3/co1)
+# instead of inferring one from silence. (#983, review)
 actas_lock_claim() {
   local team="$1" agent="$2" sid="$3"
   local attempts=0 result lock_path reclaim_dir _r _owner _alive_rc
@@ -418,13 +417,13 @@ actas_lock_gc_stale() {
 # Prints "<state>\t<owner>"; the owner is empty when there is none to report.
 # The states are _actas_lock_verdict's, documented there -- this function is the
 # read plus that verdict, and nothing else, so that `observe` and `try_claim`
-# cannot drift apart again (they did: tl's axis 5).
+# cannot drift apart again (they did: review axis 5).
 #
 # Returning the owner alongside the state matters as much as the values: callers
 # that need a baseline to compare against later were reading the state and then
 # reading the owner in a SECOND call, and a claim landing between the two
 # produced a stale state paired with a fresh owner. One read, both facts, no
-# window. (#983, found by co3.)
+# window. (#983, found in review.)
 actas_lock_observe() {
   local _r
   _r="$(actas_lock_read "$1" "$2")"

--- a/scripts/lib/instance-id.sh
+++ b/scripts/lib/instance-id.sh
@@ -420,7 +420,7 @@ EOF
 # bare answered 2 where composite answered DEAD (an empty marker). Each fix moved
 # the disagreement rather than removing it. So the read is here, once, and each
 # branch only decides what its own answer means. Same shape, and the same reason,
-# as _actas_lock_read_path. (co1, co3; tl's axis 5.)
+# as _actas_lock_read_path. (Review, axis 5.)
 _agmsg_marker_read() {   # <path>
   local f="$1" content _dir
   if content="$(cat "$f" 2>/dev/null)"; then
@@ -465,7 +465,7 @@ agmsg_instance_alive() {
       # Absent is alive-by-default and that is deliberate: the pid IS alive and
       # nothing contradicts it. Inaccessible is not absent -- `[ -e ]` is false
       # for both, and this arm used to answer ALIVE for the second one, which
-      # blocks a legitimate reclaim forever (co1).
+      # blocks a legitimate reclaim forever (review).
       absent)     return 0 ;;
       unreadable) return 2 ;;
     esac
@@ -475,7 +475,7 @@ agmsg_instance_alive() {
     # live pid is not you" makes a live seat's lock reclaimable. Not `return 0`
     # by analogy with absent above: absent means the marker was never written,
     # and the pid is then the evidence; a half-written file says a writer WAS
-    # here and we do not know what it meant to say. (co1, co3.)
+    # here and we do not know what it meant to say. (Review.)
     [ -n "$s" ] || return 2
     [ "$s" = "$token" ] && return 0
     return 1
@@ -491,7 +491,7 @@ agmsg_instance_alive() {
   # cc-instance.* path and then every `[ -f "$f" ]` is false, so the loop skipped
   # all of them and fell through to `return 1` -- a confident DEAD, produced by a
   # scan that read nothing. The composite branch above already asked for both,
-  # which is the giveaway: one function, two paths, two answers. (co1)
+  # which is the giveaway: one function, two paths, two answers. (Review.)
   { [ -d "$run" ] && [ -r "$run" ] && [ -x "$run" ]; } || return 2
   local _m
   for f in "$run"/cc-instance.*; do

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -205,7 +205,7 @@ for TEAM_CONFIG in "$TEAMS_DIR"/*/config.json; do
   # stale seat record (session uuid, name, team, type, project) per member ever
   # spawned, which internal/resurrect-panes.sh reads.
   #
-  # Two conditions the first cut got wrong (#1052 review, measured by utildev):
+  # Two conditions the first cut got wrong (#1052 review, measured):
   #  - ONLY when REMAINING is 0. The record is keyed on (team, agent) ALONE --
   #    project is a field inside it -- so a peer still registered under a DIFFERENT
   #    project shares this one file. Deleting it whenever any registration is

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -869,7 +869,7 @@ fi
 # could not be set/confirmed. The member is still fully reachable — peek/poke/despawn
 # --force resolve it through the placement record, not this key — so this is NOT a
 # failed spawn (unlike the unrecorded case above, which loses the member). But it is
-# NOT ready/launched-confirmed either (koit: do not report ready when the name did not
+# NOT ready/launched-confirmed either (the rule: do not report ready when the name did not
 # take). Reported by the helper below, and — crucially — only AFTER readiness is
 # settled: naming and readiness are INDEPENDENT facts (a seat can be receiving yet
 # unnamed), so bailing out before the wait would hide whether the watcher attached.

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -285,12 +285,12 @@ _pair_unchanged_since_read() {   # <team> <agent> <owner-as-read-this-turn>
   # wrong, and the second is the subtler one:
   #
   #   `|| echo free`        turned an unreadable lock into "free", which COMPARED
-  #                         EQUAL to a pair read as free (co3, round 1).
+  #                         EQUAL to a pair read as free (review, round 1).
   #   probe then re-derive  checked the status of one read and then used a second
   #                         one's answer: actas_lock_state does its own read and
   #                         collapses ITS failure to free/rc0, so for a broad
   #                         watcher (pair_state=free) the unknown was laundered
-  #                         back into unchanged (co3, round 2).
+  #                         back into unchanged (review, round 2).
   #
   # Deriving `free`/`mine`/`other:` also drags in liveness, and
   # actas_lock_sid_alive -> agmsg_instance_alive is a boolean with no "cannot
@@ -304,13 +304,13 @@ _pair_unchanged_since_read() {   # <team> <agent> <owner-as-read-this-turn>
   # empty against a non-empty capture and is `changed`, which refuses; that is the
   # conservative direction and costs one cycle.
   #
-  # The reader is the three-valued one (#983, tl): `absent` and `unreadable` are
+  # The reader is the three-valued one (#983): `absent` and `unreadable` are
   # NOT the same answer here. Absent means there is no owner, which compares
   # equal to an empty baseline and is correctly `unchanged` -- that is the
   # ordinary case for a broad watcher on a free pair. Unreadable means we cannot
   # say, and cannot say is refused. `actas_lock_owner` returned "" and rc 0 for
   # both, so a run directory that became unsearchable mid-turn matched the free
-  # baseline exactly and the guard waved the act through (co3/co1).
+  # baseline exactly and the guard waved the act through (review).
   local _r _rd _now
   _r="$(actas_lock_read "$1" "$2")" || return 2
   _rd="${_r%%$'\t'*}"
@@ -742,7 +742,7 @@ if [ -n "$PAIRS" ]; then
       # anything (mktemp, an uncreatable lock dir, three contended reclaim
       # rounds) printed nothing and was read as "we got it". Naming the success
       # instead of the failures is what makes an unanticipated answer safe.
-      # (#983, co3/co1)
+      # (#983, review)
       case "$result" in
         ok) : ;;
         held:*)
@@ -985,7 +985,7 @@ while true; do
     # between the two calls: a claim landing there produced a stale `free` state
     # (so the gate chose serve) paired with a FRESH owner baseline (so the guard
     # compared new-to-new and said unchanged), and the pair was served for a role
-    # someone else held. Found by co3; the fix belongs in the library, so every
+    # someone else held. Found in review; the fix belongs in the library, so every
     # caller that needs both gets them from one observation. (#983)
     IFS="$(printf '\t')" read -r pair_state pair_owner <<EOF
 $(actas_lock_observe "$pair_team" "$pair_agent" "$SESSION_ID")

--- a/tests/test_actas_lock.bats
+++ b/tests/test_actas_lock.bats
@@ -292,7 +292,7 @@ live_pid() { echo "$$"; }
   # `[ -e "$lock" ]` is false when the parent lacks search permission, so an
   # inaccessible directory answered "absent" -> `free` -> callers act. The
   # file-level chmod control does not reach this: there the directory is fine.
-  # (co3)
+  # (Review.)
   [ "$(id -u)" -eq 0 ] && skip "chmod 000 is ineffective as root"
   actas_lock_claim T alice sid-me
   local lock dir; lock="$(actas_lock_path T alice)"; dir="${lock%/*}"
@@ -368,7 +368,7 @@ live_pid() { echo "$$"; }
   # A third case, distinct from "unreadable" and from "undecidable": the file is
   # there and readable, and its contents are empty. That is not "nobody holds
   # it" — it is a lock written by someone whose write we may be seeing halfway,
-  # or truncated. try_claim's `[ -z "$existing" ]` handed it over. (cc3)
+  # or truncated. try_claim's `[ -z "$existing" ]` handed it over. (#1071)
   actas_lock_claim T alice sid-me
   : > "$(actas_lock_path T alice)"          # empty, still present
   # Assert the VERDICT, not only the outcome. Measured before the fix: the steal
@@ -423,7 +423,7 @@ _owner_only() {   # <team> <agent>
   [ "$(id -u)" -eq 0 ] && skip "chmod 000 is ineffective as root"
   local tab; tab="$(printf '\t')"
   # `[ -e ]` is false for both, so asking it alone reports "absent" for a
-  # directory we cannot look inside — the answer that makes callers act (co3).
+  # directory we cannot look inside — the answer that makes callers act (review).
   echo sid-x > "$(actas_lock_path T alice)"
   chmod 000 "$(_actas_lock_dir)"
   local r; r="$(actas_lock_read T alice)"
@@ -438,11 +438,11 @@ _owner_only() {   # <team> <agent>
 }
 
 @test "one state one answer: an empty lock is unknown:owner_empty on EVERY path" {
-  # co1 found the same file answered `free` by observe and `unknown:owner_empty`
+  # Review found the same file answered `free` by observe and `unknown:owner_empty`
   # by try_claim. Both had been made three-valued — separately — so the tree held
   # two answers for one state and nothing marked either wrong. The verdict now
   # lives in one function and each producer translates it, which is what makes
-  # this assertion writable at all. (tl's axis 5.)
+  # this assertion writable at all. (Review axis 5.)
   : > "$(actas_lock_path T alice)"
   [ "$(actas_lock_state T alice sid-me)" = 'unknown:owner_empty' ]
   [ "$(_actas_lock_try_claim T alice sid-me)" = 'unknown:owner_empty' ]

--- a/tests/test_doctor.bats
+++ b/tests/test_doctor.bats
@@ -528,22 +528,22 @@ configured_off() {
 @test "doctor: --redacted also redacts the embedded delivery-status block, not just its own formatting" {
   local home_proj="$HOME/embedded-leak-check"
   mkdir -p "$home_proj"
-  bash "$SCRIPTS/join.sh" agmsg advisor codex "$home_proj" >/dev/null
-  # A live codex bridge for agmsg/advisor, minimal enough for
+  bash "$SCRIPTS/join.sh" agmsg helper codex "$home_proj" >/dev/null
+  # A live codex bridge for agmsg/helper, minimal enough for
   # _delivery.sh's agmsg_delivery_runtime_status to report it "alive": a
   # pidfile naming a real (this test's own) pid, and a matching metafile.
   mkdir -p "$TEST_SKILL_DIR/run"
-  printf '%s\n' "$$" > "$TEST_SKILL_DIR/run/codex-bridge.agmsg.advisor.pid"
+  printf '%s\n' "$$" > "$TEST_SKILL_DIR/run/codex-bridge.agmsg.helper.pid"
   {
     echo "pid=$$"
     echo "project=$home_proj"
     echo "type=codex"
-  } > "$TEST_SKILL_DIR/run/codex-bridge.agmsg.advisor.meta"
+  } > "$TEST_SKILL_DIR/run/codex-bridge.agmsg.helper.meta"
 
   run bash "$SCRIPTS/doctor.sh" --project "$home_proj" --type codex --redacted
   [ "$status" -eq 0 ]
   [[ "$output" == *"Codex bridge: team1/agent1 alive"* ]]
-  [[ "$output" != *"agmsg/advisor"* ]]
+  [[ "$output" != *"agmsg/helper"* ]]
   [[ "$output" != *"$HOME"* ]]
 }
 

--- a/tests/test_doctor.bats
+++ b/tests/test_doctor.bats
@@ -555,9 +555,9 @@ configured_off() {
   run bash "$SCRIPTS/doctor.sh" --project "$PROJ" --type claude-code
   chmod 644 "$TEST_SKILL_DIR/run/actas.team__alice.session"
   # `lock=none` is a claim about the world; this is a claim about us. An
-  # operator reads `none` as "nothing here to clean up" and acts on it. tl did
+  # operator reads `none` as "nothing here to clean up" and acts on it. Someone did
   # exactly this today with a record he could not open: reported a seat dead,
-  # it was alive. (co1)
+  # it was alive. (Review.)
   grep -q 'lock=unreadable' <<<"$output"
   refute grep -q 'lock=none' <<<"$output"
 }

--- a/tests/test_doctor.bats
+++ b/tests/test_doctor.bats
@@ -150,7 +150,7 @@ teardown() {
 #     status emits scans the WHOLE run/ directory -- an installation-wide
 #     fact, not a (project, type) fact. Printing it inside every group that
 #     uses default runtime status repeats the identical line once per group;
-#     tl2 flagged this as duplication on the same real-installation run. ---
+#     review flagged this as duplication on the same real-installation run. ---
 
 @test "doctor: the install-wide 'watch processes' line appears once, not once per group" {
   # The line only appears when run/ exists (default runtime status guards

--- a/tests/test_instance_id.bats
+++ b/tests/test_instance_id.bats
@@ -635,7 +635,7 @@ require_eperm_pid() {
 }
 
 @test "instance alive: an unstattable cc-instance is UNDECIDABLE for a composite token too" {
-  # The other direction of the same break (co1): `[ -f ]` is false for "absent"
+  # The other direction of the same break (review): `[ -f ]` is false for "absent"
   # AND for "cannot stat", and that arm answers ALIVE — so an unreadable run/
   # made every composite token look alive and blocked legitimate reclaim. The
   # bare-token branch already returned 2 for the same condition, so one fact
@@ -663,7 +663,7 @@ require_eperm_pid() {
   # mode 0400: -r is true, -x is false. The glob still enumerates every
   # cc-instance.* path, and then nothing can stat them. The old guard asked only
   # for -r, so the loop ran, matched nothing, and returned a confident DEAD from
-  # a scan that had read no file at all. (co1)
+  # a scan that had read no file at all. (Review.)
   [ "$(id -u)" -eq 0 ] && skip "directory permissions are ineffective as root"
   local run="$SKILL_DIR/run"
   mkdir -p "$run"
@@ -688,7 +688,7 @@ require_eperm_pid() {
 @test "instance alive: an EMPTY cc-instance marker for a live pid is undecidable" {
   # A half-written marker is not "this process is someone else". Read as a plain
   # mismatch, a scan of torn markers reports a live owner as DEAD, and dead is
-  # what licences a reclaim. Same fact as an empty lock file. (co3)
+  # what licences a reclaim. Same fact as an empty lock file. (Review.)
   local run="$SKILL_DIR/run"
   mkdir -p "$run"
   : > "$run/cc-instance.$$"          # live pid, marker not yet written
@@ -709,7 +709,7 @@ require_eperm_pid() {
 @test "instance alive: an EMPTY cc-instance marker is undecidable for a COMPOSITE token too" {
   # Composite is the ordinary owner token, so this is the path that matters most
   # -- and it is the one I left behind when fixing the bare branch. A torn marker
-  # read as a mismatch makes a live seat's lock reclaimable. (co1, co3)
+  # read as a mismatch makes a live seat's lock reclaimable. (Review.)
   local run="$SKILL_DIR/run"
   mkdir -p "$run"
   : > "$run/cc-instance.$$"                 # live pid, marker not yet written

--- a/tests/test_migrate_team_store.bats
+++ b/tests/test_migrate_team_store.bats
@@ -193,7 +193,7 @@ stored_types() {
   [ -z "$called" ] || { echo "$called"; false; }
 }
 
-# The loss pm's advisory describes: a run interrupted after the config flipped
+# The loss the advisory describes: a run interrupted after the config flipped
 # leaves rows in BOTH stores, and re-running with the destination gone deletes
 # the shared copy on the strength of the flag alone.
 #

--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -2138,7 +2138,7 @@ PY_BIND
   [ "$status" -ne 0 ]
 }
 
-# unlock, with a start refusal injected (#730). advisor ruled this had to be
+# unlock, with a start refusal injected (#730). Review ruled this had to be
 # pinned rather than described: unlock is the only caller that discards the
 # helper's status with `|| true` and converts it, through
 # REMOTE_SYNC_ENGINE_PID and the readiness loop, into its own failure. A

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -1818,7 +1818,7 @@ OPS
 }
 
 @test "spawn-side naming: a naming that does not read back reports spawned-but-unnamed, NOT ready/launched" {
-  # The read-back is the point (koit: only say named after reading back ok, like
+  # The read-back is the point (the rule: only say named after reading back ok, like
   # team --fix). terminal_name SUCCEEDS here (rc 0) but the key reads back as a
   # missing sentinel — so ONLY the read-back catches it. Dropping the read-back
   # and trusting the write's exit would turn this control green (mutation guard).

--- a/tests/test_team_status.bats
+++ b/tests/test_team_status.bats
@@ -379,7 +379,7 @@ _herdr_observe_stub() {   # <entries-json>
 }
 
 @test "identity fix repairs a key that was decidedly absent, and verifies it" {
-  # The behaviour tl asked for: --fix must actually set the key on a seat that
+  # The behaviour asked for in review: --fix must actually set the key on a seat that
   # never had one, and must only say `changed` after reading it back.
   agmsg_type_get() { printf '\n'; }
   _herdr_internal_key() { printf 'a123\n'; }

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -1898,7 +1898,7 @@ _fake_herdr_list_anchored_plus() {
   chmod +x "$FAKEBIN/herdr"; export PATH="$FAKEBIN:$PATH"
 }
 
-# --- every id-taking tmux op honours BOTH ref forms (#1051, co2/tl) ----------
+# --- every id-taking tmux op honours BOTH ref forms (#1051, review) ----------
 #
 # Putting the socket in the ref made the WRITERS emit `<socket>:%N`; the READERS
 # were not counted at the same time, and four of them pattern-matched a bare

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -1480,7 +1480,7 @@ _claim_in_window() {   # <team> <agent> <new-sid> — steal the pair mid-turn
 }
 
 @test "watch: a lock that cannot be READ stops the act, it does not read as free (#983)" {
-  # The guard's own fail-open, found by co3. Two layers turn "could not read the
+  # The guard's own fail-open, found in review. Two layers turn "could not read the
   # lock" into "the lock is free" — actas_lock_owner answers empty for both a
   # missing file and a failed read, and actas_lock_state maps an empty owner to
   # `free` at rc 0. With a `|| echo free` on top, an UNREADABLE lock compared
@@ -1516,7 +1516,7 @@ _claim_in_window() {   # <team> <agent> <new-sid> — steal the pair mid-turn
 }
 
 @test "watch: an unreadable lock also stops the ctrl:despawn teardown (#983)" {
-  # co3's control (2): the same fail-closed rule on the act that cannot be undone
+  # Review's control (2): the same fail-closed rule on the act that cannot be undone
   # at all. Refusing costs one poll cycle; dropping the role and closing the pane
   # under an unknown lock state does not come back.
   skip_on_windows "watcher background launch under Git Bash (#182)"
@@ -1549,7 +1549,7 @@ _claim_in_window() {   # <team> <agent> <new-sid> — steal the pair mid-turn
 }
 
 @test "watch: a BROAD watcher refuses too when the lock stops being readable (#983)" {
-  # co3's exact scenario, and the one the actas-watcher tests above cannot reach.
+  # Review's exact scenario, and the one the actas-watcher tests above cannot reach.
   # A broad watcher claims nothing, so its baseline owner is the EMPTY STRING —
   # and a reader that folds "could not read" into "" compares equal to that
   # baseline and calls the pair unchanged. Every unreadable-lock test we had used
@@ -1594,7 +1594,7 @@ _claim_in_window() {   # <team> <agent> <new-sid> — steal the pair mid-turn
 }
 
 @test "watch: the re-verify makes exactly ONE lock read, and derives nothing (#983)" {
-  # co3's round-2 finding was not a wrong value, it was a wrong SHAPE: the helper
+  # The round-2 finding was not a wrong value, it was a wrong SHAPE: the helper
   # checked the status of one read and then used a second read's answer, and the
   # second one (inside actas_lock_state) collapses its own failure to free/rc0. No
   # behavioural test can express "the second read failed but the first did not" —
@@ -1614,7 +1614,7 @@ _claim_in_window() {   # <team> <agent> <new-sid> — steal the pair mid-turn
   # And the folding reader may not come back anywhere in the tree. It answered
   # "" and rc 0 for missing, unreadable and empty alike; keeping the guard here
   # while leaving the function callable just moves the next defect one call site
-  # over. (tl: fix the fold, do not guard the caller.) Comment lines are dropped
+  # over. (Review: fix the fold, do not guard the caller.) Comment lines are dropped
   # first -- several comments name it to say what it used to do, and a check that
   # forbids naming a removed function is a check nobody can keep green.
   local named live


### PR DESCRIPTION
Comment lines across the tree named the person who found the thing the comment
explains. On a public repository those are private names, and none of them is
information: "found in review, round 2" carries everything "found by `<name>`,
round 2" carried. Every line is rewritten to state the reason. One case was not
a sentence but a **test fixture identity**, and is renamed rather than reworded.

Most are mine, from #1070. The rest are older (#1052, #1051, and three tests).

## Three passes, because I kept enumerating the set instead of deriving it

| pass | how I got the name list | what it missed |
|---|---|---|
| 1 | the seat names I remembered | a user handle, two role words |
| 2 | the list review handed me | a numbered variant of a role word |
| 3 | **derived from the team roster** — registered names, their prefix-stripped short forms, the human handle (42 names) | — |

Each pass lost by exactly what the previous list forgot. The third one is the
only method that does not depend on my memory, and it is what a pre-push run
should use.

## The checker was already in the tree and I did not run it

`scripts/check-private-names.mjs` reports every one of these lines when it is
given the real names. CI cannot: the `internal names` job runs it as
`AGMSG_PRIVATE_NAMES=none`, which checks name **shapes**, and these names have
no shape — most are two- and three-character words. The tool says so itself, in
the sentence a passing run prints:

> A pass here means "no seat-shaped name", NOT "clean".

A green CI on that job was never evidence about these lines, and I read it as if
it were.

## Measured, at head `041f163`

With the derived 42-name list:

| | findings | lines | files |
|---|---|---|---|
| before (base `b65f27e`) | 63 | 51 | 16 |
| after | 41 | 40 | 11 |

In CI's shapes-only mode: clean before and after — which is the demonstration
that the CI job could not have caught any of it.

**Every one of the 41 remaining findings is a false positive, checked by reading
each reported line rather than by trusting the count:**

- `codex-app-server.*` — 37 lines in 11 files. `codex-app` is a registered name;
  `codex-app-server` is this codebase's own run-file prefix for the Codex
  app-server, in `delivery.sh`, four codex driver scripts and five test files.
  Renaming a real filename to satisfy a substring match would be the tail
  wagging the dog.
- `which-pm-runs` — 4 lines in `site/package-lock.json`. A real npm package; the
  registry URL is on the same line.

They are recorded here rather than silenced, because the tool deliberately
offers no way to silence a finding.

## Scope

Documentation and one test fixture. No product behaviour changes. The fixture
rename is `test_doctor.bats`'s codex identity and the two run-file names derived
from it; `test_doctor` 39/39 green after.

Refs #1070
