### PR TITLE
fix(spawn): the pre-join must not name the caller's pane (#1096)

### DIFF
--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -374,7 +374,13 @@ _herdr_pane_input_ready() {
 # placement (tab create / pane split, then rename + run).
 terminal_spawn() {
   local name="$1" project="$2" target="$3"; shift 3
-  local boot="$*" json pane dir
+  local boot="$*" json pane dir label
+  # The label the pane is created with. The driver's spawn signature carries no
+  # team; the caller hands it in AGMSG_SPAWN_TEAM (spawn.sh sets it from the
+  # resolved team). With it the label is the one vocabulary `_herdr_label`
+  # defines -- the same string terminal_name writes -- without it the bare name.
+  label="$name"
+  [ -z "${AGMSG_SPAWN_TEAM:-}" ] || label="$(_herdr_label "$AGMSG_SPAWN_TEAM" "$name")"
   # Validate target explicitly — a typo must fail, not silently pick a default.
   case "$target" in
     window|pane-h|pane-v) : ;;
@@ -385,13 +391,20 @@ terminal_spawn() {
     # silently splitting a pane the caller did not ask for.
     [ -n "${HERDR_WORKSPACE_ID:-}" ] || {
       printf 'unsupported: window target needs HERDR_WORKSPACE_ID\n' >&2; return 13; }
-    json="$(herdr tab create --workspace "$HERDR_WORKSPACE_ID" --label "$name" --cwd "$project" 2>/dev/null)" || return 13
+    json="$(herdr tab create --workspace "$HERDR_WORKSPACE_ID" --label "$label" --cwd "$project" 2>/dev/null)" || return 13
   else
     case "$target" in pane-h) dir=right ;; *) dir=down ;; esac
     json="$(herdr pane split "${HERDR_PANE_ID:-}" --direction "$dir" --no-focus --cwd "$project" 2>/dev/null)" || return 13
   fi
   pane="$(_herdr_new_pane_id "$json")" || return 13
-  herdr pane rename "$pane" "$name" >/dev/null 2>&1 || true
+  # The creation-time label is already the FINAL one (the same string
+  # terminal_name writes), not a bare name overwritten later. The bare name was
+  # the state a pane stayed in whenever the later naming failed (#1096: the key
+  # cannot be set until herdr has detected the agent, so the label write behind
+  # it never ran) -- there is no reason to create a state that only exists to
+  # be replaced. `pane rename` needs no agent detection; it works on a pane that
+  # is seconds old.
+  herdr pane rename "$pane" "$label" >/dev/null 2>&1 || true
   # requirement 1: wait (bounded) for the shell to reach its prompt, then act on the
   # THREE outcomes distinctly. Only NOT-READY(1) is retried — READY(0) and UNKNOWN(2)
   # are terminal. Every iteration uses the SAME classifier; UNKNOWN is never folded into
@@ -868,6 +881,12 @@ terminal_poke() {
 # 'a' + 24 hex = 25 chars, leading letter, all within the regex. Uses the store's
 # canonical agmsg_sha256 (lib/hash.sh); sourced context may not have it, so load it
 # relative to this driver file. Prints the key, or non-zero if no SHA-256 tool.
+# The visible label, in ONE place: terminal_name writes it, terminal_spawn
+# creates the pane with it (#1096), and a test that pins the string pins both.
+_herdr_label() {   # <team> <agent>
+  printf '%s:%s\n' "$1" "$2"
+}
+
 _herdr_internal_key() {
   local team="$1" agent="$2" hex
   if ! command -v agmsg_sha256 >/dev/null 2>&1; then
@@ -901,7 +920,7 @@ _herdr_internal_key() {
 # and a key that cannot be set is an error there, because nothing else happened.
 terminal_name() {
   local id="$1" team="$2" name="$3" mode="${4:-}" label key
-  label="$team:$name"
+  label="$(_herdr_label "$team" "$name")"
 
   # THE KEY FIRST, and its failure is fatal.
   #

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -566,6 +566,17 @@ agmsg_terminal_name_self() {
     echo "agmsg: terminal_name_self needs <team> and <agent>" >&2; return 1
   }
 
+  # AGMSG_SELF_NAME=off: this process must NOT name its pane, whatever pair it
+  # is handed. Checked HERE, in the one function every self-naming path ends in
+  # (join at boot, actas, the action hook), not only in the action hook -- a
+  # switch honoured by one path out of several is not a switch. The case that
+  # needs it (#1096): spawn runs join.sh in the CALLER's process on behalf of
+  # the new member; "self" below resolves through the caller's environment
+  # (HERDR_PANE_ID, $TMUX/$TMUX_PANE), so without this the caller's pane is
+  # renamed to the new member's label and key. spawn sets it on that one
+  # subprocess; a seat joining by hand keeps naming itself.
+  [ "${AGMSG_SELF_NAME:-on}" != off ] || return 0
+
   # The BARE sid, whatever the caller had. A terminal knows the id the CLI
   # published; the composite "<sid>.<pid>" exists only inside agmsg, and handing
   # it over asks a question no terminal can answer -- the answer comes back as

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -414,7 +414,18 @@ esac
 # PROJECT here is the explicit spawn target (--project / $PWD), which may not be
 # registered yet. Opt out of #92 pwd-resolution so join.sh registers exactly
 # this path rather than rewriting it to the spawning session's own project.
-AGMSG_RESOLVE_PROJECT=0 "$SCRIPT_DIR/join.sh" "$TEAM" "$NAME" "$AGENT_TYPE" "$PROJECT" >/dev/null
+# AGMSG_SELF_NAME=off: this join runs in THIS process on behalf of the member
+# being spawned, and join's boot-time self-naming resolves "self" through the
+# environment it runs in -- the caller's pane (#1096: the caller's pane was
+# renamed to the new member's label and key, and the new pane got neither).
+# The new member names its own pane from its own process (actas, the action
+# hook); the caller's pane is not this member's to name.
+AGMSG_SELF_NAME=off AGMSG_RESOLVE_PROJECT=0 "$SCRIPT_DIR/join.sh" "$TEAM" "$NAME" "$AGENT_TYPE" "$PROJECT" >/dev/null
+# The team the terminal driver labels the new pane with at creation (herdr
+# `terminal_spawn`, #1096). A shell variable, not exported: the driver runs in
+# this process, and the spawned CLI's environment must not carry it.
+# shellcheck disable=SC2034  # read by the driver function, sourced into this process
+AGMSG_SPAWN_TEAM="$TEAM"
 
 # --- Build the boot script the new agent will run ---
 # Rather than embed a multiply-escaped command string into each platform's

--- a/tests/test_dispatch.bats
+++ b/tests/test_dispatch.bats
@@ -194,3 +194,41 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"Team: demo"* ]]
 }
+
+# #1096 seam: spawn turns self-naming off for the pre-join it runs on behalf of
+# the NEW member (join.sh in the caller's process). The dispatcher's two join.sh
+# calls -- `join`, and the `actas` fallback -- join the seat ITSELF, from its own
+# pane, and must keep naming it. A stray AGMSG_SELF_NAME=off on either path turns
+# the matching half of this test red; the fake herdr logs every argv.
+@test "dispatch: join and the actas fallback name the seat's OWN pane (#1096)" {
+  local proj="$BATS_TEST_TMPDIR/project-naming" log="$BATS_TEST_TMPDIR/herdr.log"
+  local bin="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$proj" "$bin"
+  cat > "$bin/herdr" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$log"
+case "\$1/\$2" in
+  agent/list) echo '{"result":{"agents":[]}}' ;;
+  *) echo '{"result":{"type":"ok"}}' ;;
+esac
+STUB
+  chmod +x "$bin/herdr"
+  export PATH="$bin:$PATH"
+  : > "$log"
+  # Under herdr: presence is HERDR_ENV=1, the pane is HERDR_PANE_ID.
+  export HERDR_ENV=1 HERDR_PANE_ID=wD:pSelf
+  unset AGMSG_TERMINAL
+
+  # join: the seat names its own pane with the key and the prefixed label.
+  run bash "$SCRIPTS/windows/dispatch.sh" --type claude-code --project "$proj" -- join demo carol
+  [ "$status" -eq 0 ]
+  grep -q '^agent rename wD:pSelf ' "$log"
+  grep -q '^pane rename wD:pSelf demo:carol$' "$log"
+
+  # actas fallback (name not registered yet -> join.sh): the same.
+  : > "$log"
+  run env CLAUDE_CODE_SESSION_ID=test-session bash "$SCRIPTS/windows/dispatch.sh" --type claude-code --project "$proj" -- actas dave
+  [ "$status" -eq 0 ]
+  grep -q '^agent rename wD:pSelf ' "$log"
+  grep -q '^pane rename wD:pSelf demo:dave$' "$log"
+}

--- a/tests/test_self_name.bats
+++ b/tests/test_self_name.bats
@@ -322,3 +322,18 @@ _mark() {   # <team> <agent> -> "ref<TAB>epoch" or empty
   [ "$(agmsg_role_session_get team carol type)" = codex ]
   [ -z "$(agmsg_role_session_uuid team carol)" ]
 }
+
+@test "AGMSG_SELF_NAME=off turns the boot path off too, not only the hook (#1096)" {
+  # spawn runs join.sh in the caller's process for the new member; join's boot
+  # path calls agmsg_terminal_name_self directly, so the switch has to be
+  # honoured THERE, or the caller's pane is named after the new member.
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/terminal-registry.sh"
+  AGMSG_SELF_NAME=off agmsg_terminal_name_self_safe "sid-1" team alice /tmp/p claude-code
+  [ "$(_name_calls)" -eq 0 ]
+  [ -z "$(_mark team alice)" ]
+  # Control: the same call with the switch at its default names once.
+  agmsg_terminal_name_self_safe "sid-1" team alice /tmp/p claude-code
+  [ "$(_name_calls)" -eq 1 ]
+}

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -1023,6 +1023,10 @@ _setup_fake_herdr() {
   # realistic herdr tests exercise the SUCCESSFUL naming path (not the fallback).
   export HERDR_AGENT_DB="$TEST_SKILL_DIR/herdr-agents.db"
   : > "$HERDR_AGENT_DB"
+  # Same shape for labels: `pane rename` records (pane_id -> label), `pane get`
+  # replays the last one -- the caller pane's label is observable state (#1096).
+  export HERDR_LABEL_DB="$TEST_SKILL_DIR/herdr-labels.db"
+  : > "$HERDR_LABEL_DB"
   cat > "$herdr_stub" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$HERDR_CALL_LOG"
@@ -1035,7 +1039,14 @@ case "$1/$2" in
   pane/split)
     printf '%s\n' "${HERDR_SPLIT_RESPONSE:-$DEFAULT_SPLIT}"
     ;;
-  pane/rename|pane/run|pane/close)
+  pane/rename)
+    # `pane rename <pane_id> <label>` -- record the mapping so `pane get` can
+    # replay it (#1096: the caller pane's label must be observable before and
+    # after a spawn, not just the argv). $3=pane id, $4=label.
+    printf '%s\t%s\n' "$3" "$4" >> "$HERDR_LABEL_DB"
+    echo '{"id":"cli:pane:rename","result":{"type":"ok"}}'
+    ;;
+  pane/run|pane/close)
     echo '{"id":"cli:pane:'"$2"'","result":{"type":"ok"}}'
     ;;
   pane/process-info)
@@ -1076,9 +1087,12 @@ case "$1/$2" in
     printf ']}}\n'
     ;;
   pane/get)
-    # Minimal valid pane document; the read-back only needs the agent key (from
-    # agent list), so label/status/title just need to parse. $3=pane id.
-    printf '{"result":{"pane":{"pane_id":"%s","label":"pane","agent_status":"idle","terminal_title":"t"}}}\n' "$3"
+    # Minimal valid pane document. The label is the LAST one `pane rename`
+    # recorded for this pane (so a test can read a pane's label back the way a
+    # person would), "pane" when none was. $3=pane id.
+    _label="$(awk -F'\t' -v id="$3" '$1==id{l=$2} END{print (l==""?"pane":l)}' "$HERDR_LABEL_DB" 2>/dev/null)"
+    [ -n "$_label" ] || _label=pane
+    printf '{"result":{"pane":{"pane_id":"%s","label":"%s","agent_status":"idle","terminal_title":"t"}}}\n' "$3" "$_label"
     ;;
   *)
     echo '{"error":"unknown stub call: '"$*"'}' >&2
@@ -1105,7 +1119,10 @@ STUB
 
   # herdr was called: pane split, pane rename, pane run.
   grep -q "pane split wT:pSelf --direction right --no-focus" "$HERDR_CALL_LOG"
-  grep -q "pane rename wT:pN alice" "$HERDR_CALL_LOG"
+  # The creation-time label is the final, team-prefixed one (#1096) -- the same
+  # string terminal_name writes -- never the bare name.
+  grep -q "^pane rename wT:pN myteam:alice$" "$HERDR_CALL_LOG"
+  refute grep -q "^pane rename wT:pN alice$" "$HERDR_CALL_LOG"
   grep -q "pane run wT:pN" "$HERDR_CALL_LOG"
 
   # Placement record uses herdr: scheme tag.
@@ -1129,7 +1146,8 @@ STUB
   bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
   run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait --window
   [ "$status" -eq 0 ]
-  grep -q "tab create --workspace wT --label alice" "$HERDR_CALL_LOG"
+  # The window is created with the final, team-prefixed label too (#1096).
+  grep -q "tab create --workspace wT --label myteam:alice" "$HERDR_CALL_LOG"
   grep -q "pane run wT:pR" "$HERDR_CALL_LOG"
 
   local rec="$TEST_SKILL_DIR/run/spawn.myteam__alice"
@@ -1912,4 +1930,58 @@ OPS
   [ "$status" -eq 0 ]
   grep -qF "status=ready" <<<"$output"
   refute grep -qF "status=spawned-but-unnamed" <<<"$output"
+}
+
+# --- #1096: the caller's pane is not the new member's to name ------------------------
+#
+# spawn pre-joins the new member by running join.sh in the CALLER's process, and
+# join's boot-time self-naming resolves "self" through that environment -- the
+# caller's pane. Before the fix the caller's pane took the new member's label and
+# key, and the tests below only ever looked at the NEW pane, so they stayed green.
+# The caller assertion is the one that goes red on that tree.
+
+@test "spawn: herdr -- the caller's pane keeps its label and key byte-for-byte across a spawn (#1096)" {
+  _setup_fake_herdr
+  bash "$SCRIPTS/join.sh" myteam existing claude-code "$PROJ"
+  # The caller's pane as a person sees it before the spawn: a label and a key,
+  # written through the same fake so `pane get` / the agent DB replay them.
+  "$STUB_BIN/herdr" pane rename wT:pSelf 'myteam:existing' >/dev/null
+  "$STUB_BIN/herdr" agent rename wT:pSelf a1111111111111111111111111 >/dev/null
+  local before_label before_key after_label after_key
+  before_label="$("$STUB_BIN/herdr" pane get wT:pSelf | sed -n 's/.*"label":"\([^"]*\)".*/\1/p')"
+  before_key="$(awk -F'\t' '$1=="wT:pSelf"{k=$2} END{print k}' "$HERDR_AGENT_DB")"
+  [ "$before_label" = 'myteam:existing' ]
+  [ "$before_key" = a1111111111111111111111111 ]
+  : > "$HERDR_CALL_LOG"
+
+  run bash "$SCRIPTS/spawn.sh" claude-code alice --project "$PROJ" --no-wait
+  [ "$status" -eq 0 ]
+
+  # After: the same two values, read back the same way, and no rename argv ever
+  # targeted the caller's pane.
+  after_label="$("$STUB_BIN/herdr" pane get wT:pSelf | sed -n 's/.*"label":"\([^"]*\)".*/\1/p')"
+  after_key="$(awk -F'\t' '$1=="wT:pSelf"{k=$2} END{print k}' "$HERDR_AGENT_DB")"
+  [ "$after_label" = "$before_label" ]
+  [ "$after_key" = "$before_key" ]
+  refute grep -qE '^(pane|agent) rename wT:pSelf ' "$HERDR_CALL_LOG"
+
+  # The NEW pane is the one named: prefixed label at creation, then the key.
+  grep -q '^pane rename wT:pN myteam:alice$' "$HERDR_CALL_LOG"
+  refute grep -q '^pane rename wT:pN alice$' "$HERDR_CALL_LOG"
+  grep -q '^agent rename wT:pN ' "$HERDR_CALL_LOG"
+  refute grep -qF 'status=spawned-but-unnamed' <<<"$output"
+}
+
+@test "join: names its own pane at boot (control), and not under AGMSG_SELF_NAME=off (#1096)" {
+  _setup_fake_herdr
+  # Control: a seat joining from its own pane names it -- key and prefixed label.
+  bash "$SCRIPTS/join.sh" myteam bob claude-code "$PROJ"
+  grep -q '^agent rename wT:pSelf ' "$HERDR_CALL_LOG"
+  grep -q '^pane rename wT:pSelf myteam:bob$' "$HERDR_CALL_LOG"
+  : > "$HERDR_CALL_LOG"
+  # The switch spawn sets on its pre-join: the same join, no naming call at all.
+  AGMSG_SELF_NAME=off bash "$SCRIPTS/join.sh" myteam carol claude-code "$PROJ"
+  refute grep -q ' rename ' "$HERDR_CALL_LOG"
+  # ...and the join itself still happened: carol is registered for the project.
+  bash "$SCRIPTS/identities.sh" "$PROJ" claude-code | grep -q 'carol'
 }


### PR DESCRIPTION
Fixes #1096.

## What broke

`spawn` pre-joins the new member by running `join.sh` in the **caller's** process (`scripts/spawn.sh`, the pre-join line). `join.sh`'s boot-time self-naming calls `agmsg_terminal_name_self_safe "" <team> <new-member>` — a sid-less call. Since #1080 the herdr driver's `terminal_detect` resolves the pane from `HERDR_PANE_ID`, which in that process is the **caller's** pane. So the caller's pane received the new member's label and key. Before #1080 the sid-less call was skipped on herdr, which is why this is a 1.3.0 regression and not an old defect.

Confirmed by one observation, not by reading: the exact `join.sh` call with a probe pair, run in a process holding my own pane's `HERDR_PANE_ID`, rewrote my pane's label to `<team>:<probe>` and its key to the probe's computed key (restored byte-for-byte afterwards).

The new pane being keyless is a separate fact: `herdr agent rename` on a pane herdr has not yet detected as an agent returns `agent_not_found`, so `terminal_name` returns 13 before its label write and spawn reports `status=spawned-but-unnamed` — an honest report. The member's own first action names it (#1080). The timing question (should spawn wait for detection?) is filed separately.

## The fix

- **`scripts/lib/terminal-registry.sh`** — `AGMSG_SELF_NAME=off` is honoured at the top of `agmsg_terminal_name_self`, the one function every self-naming path (join at boot, actas, the action hook) ends in. Previously only the action hook looked at it; a switch honoured by one path out of several is not a switch.
- **`scripts/spawn.sh`** — the pre-join runs with `AGMSG_SELF_NAME=off`. Only that subprocess: a seat joining by hand keeps naming its own pane, and the other in-process `join.sh` callers (`scripts/windows/dispatch.sh`, twice) join their **own** seat and are correct as they are. All three callers were counted before deciding where the switch goes.
- **`scripts/drivers/terminals/herdr/ops.sh`** — the label vocabulary lives in one helper (`_herdr_label`), used by `terminal_name` and by `terminal_spawn`, so the pane (or tab) is **created** with the final `<team>:<name>` label. The bare-name label was a state that existed only to be overwritten, and was the state a pane stayed in whenever the later key write failed. The team reaches the driver through `AGMSG_SPAWN_TEAM`, a shell variable spawn.sh sets and does not export.

## Tests

The existing herdr spawn tests only ever looked at the new pane, so they were green on the broken tree. Added:

- `tests/test_spawn.bats` — the fake herdr now records `pane rename` labels and replays them from `pane get`, so a pane's label is observable state. New test: the **caller's** pane label and key are byte-identical before and after a spawn, read back the same way both times, and no `pane rename` / `agent rename` argv ever targets the caller's pane; the new pane gets the prefixed label at creation and the key. Red on the base tip (mutation: dropping the env on the pre-join), green here.
- `tests/test_spawn.bats` — `join.sh` control/off differential: a seat joining from its own pane names it (key + prefixed label); under `AGMSG_SELF_NAME=off` the same join makes no naming call and still registers.
- `tests/test_self_name.bats` — `AGMSG_SELF_NAME=off` stops the boot path (`agmsg_terminal_name_self_safe`) too, with the default-on control naming once.
- Two existing assertions updated from the bare creation-time label to the prefixed one (split and window paths).

Checkers: `check-enforced-assertions` 627 at baseline 627, `check-errexit-status-reads` 0 at baseline 0, shellcheck 0.10.0 on the three touched scripts 22 findings before and after (no new ones).
