### PR TITLE
feat(rename): a seat renames its own CLI session name by typing /rename (#1081)

### DIFF
--- a/scripts/drivers/types/claude-code/type.conf
+++ b/scripts/drivers/types/claude-code/type.conf
@@ -9,6 +9,23 @@ model_arg=--model
 # the /resume picker, and the marker the resurrect hook keys on. Types without
 # name_arg simply skip naming.
 name_arg=-n
+# Interactive command that renames the CURRENT session, typed into the pane the
+# way a person would (#1081). Distinct from name_arg: name_arg names a session at
+# LAUNCH; rename_cmd fixes one that is already running -- a hand-started seat that
+# got no -n, or a type whose only route to a session name is the keyboard. A type
+# without rename_cmd cannot be renamed after launch and its cli_session cell stays
+# skipped, naming this manifest key rather than the type. The seat pokes
+# "<rename_cmd> <team>-<agent>" into its own pane once; see self-rename.sh.
+rename_cmd=/rename
+# How this type's session name is OBSERVED from outside, so a rename can be
+# verified and the cli_session cell judged (#1081). `title` = the name rides the
+# terminal title (agmsg_cli_session_from_title reads it); a live claude-code seat
+# shows "<glyph> <team>-<agent>" there. Another form is `screen:<prefix>`, read by
+# peeking the pane and taking only the line beginning with <prefix>. A type
+# without session_name_source has no observable name, so its cell stays
+# n/a:no_session_name and a rename cannot be verified (never called failed on
+# that account -- unobservable is unknown, not failure).
+session_name_source=title
 # Flag that resumes a session by id (#339): when a role has a recorded session
 # whose transcript still exists, spawn passes `--resume <uuid>` so the role comes
 # back into its prior context instead of booting fresh. Types without resume_arg

--- a/scripts/drivers/types/codex/type.conf
+++ b/scripts/drivers/types/codex/type.conf
@@ -65,6 +65,21 @@ spawn_unset_env=CODEX_THREAD_ID AGMSG_REAL_CODEX AGMSG_CODEX_*
 # sessions are not named <team>-<agent> (spawn/despawn resume still works via the
 # recorded thread id; tmux-resurrect title matching does not apply to codex).
 resume_arg=resume
+# codex has no name_arg (above), but it CAN be renamed after launch by typing
+# `/rename <name>` into its TUI, exactly as a person would (#1081). So a seat can
+# still reach a <team>-<agent> session name -- through the keyboard, not a flag.
+rename_cmd=/rename
+# ...but codex's session/thread name is NOT on the terminal title (that shows the
+# working directory), so it cannot be read the way claude-code's is. The only
+# external view is the TUI's own header line "Thread name: <name>", which codex
+# prints at the START of a session and scrolls away as the conversation grows.
+# So `screen:Thread name:` = peek the pane and take only the line beginning with
+# that prefix. Because it is visible only early and can vanish, verification is
+# best-effort: when the line is not readable the observation is unknown, never a
+# failure -- a changed TUI layout must read as "could not confirm", not "rename
+# failed" (#1081). The seat checks the line is readable BEFORE it pokes, and the
+# window where it can verify is the same early window where it should rename.
+session_name_source=screen:Thread name:
 # codex invokes a skill with "$", not Claude Code's "/" (see spawn.sh, #283).
 cmd_prefix=$
 model_arg=-m

--- a/scripts/history.sh
+++ b/scripts/history.sh
@@ -24,6 +24,10 @@ if [ -n "$AGENT" ]; then
   # shellcheck disable=SC1091
   source "$SCRIPT_DIR/lib/self-name.sh"
   agmsg_self_name_on_action "$TEAM" "$AGENT"
+  # Fix its own CLI session name once, early (self-rename.sh, #1081). Best-effort.
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/lib/self-rename.sh"
+  agmsg_self_rename_on_action "$TEAM" "$AGENT"
 fi
 
 # A history read must not create a store, so a team that has never been written

--- a/scripts/inbox.sh
+++ b/scripts/inbox.sh
@@ -21,6 +21,10 @@ agmsg_storage_load
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/self-name.sh"
 agmsg_self_name_on_action "$TEAM" "$AGENT"
+# Fix its own CLI session name once, early (self-rename.sh, #1081). Best-effort.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/self-rename.sh"
+agmsg_self_rename_on_action "$TEAM" "$AGENT"
 
 # An inbox check must not create the store, so a team that has never been
 # written to has no file yet. Since the stores split per team that is the

--- a/scripts/lib/role-session.sh
+++ b/scripts/lib/role-session.sh
@@ -236,6 +236,58 @@ agmsg_role_session_named() {
   printf '%s\t%s\n' "$ref" "$epoch"
 }
 
+# The self-RENAME mark (#1081), separate from the naming mark above because it
+# records a different cell (the CLI session name) and, unlike naming, it MUST fire
+# at most once per (seat, pane, server generation): typing `/rename` into a live
+# session is invasive, so the mark is what stops a second attempt -- on the next
+# action AND in the next process, since it is persisted here. <result> is the
+# outcome the seat reached: attempted | ok | poked_unverified | failed |
+# skipped:<why>. <ref>/<epoch> key it to the pane+generation, so a reused pane or
+# a restarted server is a NEW attempt, exactly as the naming mark is.
+#   agmsg_role_session_mark_renamed <team> <agent> <ref> <epoch> <result> [project] [type]
+agmsg_role_session_mark_renamed() {
+  local team="$1" agent="$2" ref="$3" epoch="${4:-}" result="${5:-}" project="${6:-}" type="${7:-}"
+  [ -n "$team" ] && [ -n "$agent" ] && [ -n "$ref" ] || return 0
+  local path dir tmp ts line
+  _agmsg_role_session_path_into "$team" "$agent"
+  path="$_AGMSG_ROLE_SESSION_PATH"
+  dir="$(_actas_lock_dir)"
+  mkdir -p "$dir" 2>/dev/null || true
+  tmp="$(mktemp "$dir/.role-session.XXXXXX" 2>/dev/null)" || return 0
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+  {
+    if [ -f "$path" ]; then
+      while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in renamed_ref=*|renamed_epoch=*|rename_result=*|renamed_at=*) ;; *) printf '%s\n' "$line" ;; esac
+      done < "$path"
+    else
+      printf 'name=%s-%s\n' "$team" "$agent"
+      printf 'team=%s\n' "$team"
+      printf 'agent=%s\n' "$agent"
+      printf 'type=%s\n' "$type"
+      printf 'project=%s\n' "$project"
+      printf 'updated_at=%s\n' "$ts"
+    fi
+    printf 'renamed_ref=%s\n' "$ref"
+    printf 'renamed_epoch=%s\n' "$epoch"
+    printf 'rename_result=%s\n' "$result"
+    printf 'renamed_at=%s\n' "$ts"
+  } > "$tmp" 2>/dev/null || { rm -f "$tmp" 2>/dev/null; return 0; }
+  mv -f "$tmp" "$path" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+  return 0
+}
+
+# The rename mark as "<ref>\t<epoch>\t<result>", or empty when there is none.
+agmsg_role_session_renamed() {
+  local team="$1" agent="$2" ref epoch result
+  _agmsg_role_session_path_into "$team" "$agent"
+  ref="$(_agmsg_role_session_field "$_AGMSG_ROLE_SESSION_PATH" renamed_ref)"
+  [ -n "$ref" ] || return 0
+  epoch="$(_agmsg_role_session_field "$_AGMSG_ROLE_SESSION_PATH" renamed_epoch)"
+  result="$(_agmsg_role_session_field "$_AGMSG_ROLE_SESSION_PATH" rename_result)"
+  printf '%s\t%s\t%s\n' "$ref" "$epoch" "$result"
+}
+
 # Read a single field from a role's record by (team, agent). Empty if absent.
 # Convenience getter used by consumers that need one field (e.g. the resurrect
 # hook reading `type`); mirrors agmsg_role_session_uuid's read of `session`.

--- a/scripts/lib/self-rename.sh
+++ b/scripts/lib/self-rename.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# self-rename.sh — a seat fixes its own CLI SESSION NAME by typing the type's
+# rename command into its own pane, once, early (#1081).
+#
+# The third identity cell is the CLI session name. No launch flag sets it after
+# start (claude-code's -n is a launch-only flag; codex has none), and a
+# hand-started or resumed seat never got one -- yet a person can always fix it by
+# typing `/rename <name>`. This hook does that from the inside: a seat knows its
+# team, its name, and (from the environment) the pane it is in, so it pokes the
+# rename into its own pane.
+#
+# It is deliberately NOT modelled on self-name.sh's every-action naming, because
+# typing into a live session is INVASIVE and its verification WINDOW is narrow:
+#   - Invasive: `poke` seizes the keyboard. Doing that to oneself on a loop is how
+#     a conversation gets wrecked. So this fires AT MOST ONCE per (seat, pane,
+#     server generation); the persisted mark is what stops a second attempt, on
+#     the next action AND in the next process.
+#   - Narrow window: a name that can only be READ early (codex prints "Thread
+#     name:" at the top of the TUI and it scrolls away) can only be VERIFIED
+#     early. The window to verify and the window to rename are the same one, which
+#     is also why it must run early -- before the /resume picker, before a person
+#     grows used to a name. Two reasons, one design.
+#
+# Two-phase, because the keystroke is QUEUED and lands after the current turn:
+#   action 1  observe my name. Correct already -> record ok, type nothing.
+#             Unreadable (window gone) -> record why, type nothing (never rename
+#             what cannot be verified). Wrong and readable -> poke once, mark
+#             "attempted".
+#   action 2  the mark says "attempted": the rename has had a turn to land, so
+#             re-observe. Took -> ok. Could not read it (scrolled off, load) ->
+#             the THIRD word poked_unverified -- typed, could not confirm, NEVER
+#             "failed" on a screen we could not read. A title name still wrong ->
+#             failed. Either way, no second poke.
+#
+# Two-tier opt-out, and it is VISIBLE on the mark, never silent: AGMSG_SELF_NAME=
+# off stops the whole self-naming family; AGMSG_SELF_RENAME=off stops only the
+# keystroke (more invasive than writing a label -- a person may accept the label
+# and refuse the auto-typing).
+#
+# Never fails the caller: renaming is a side effect of the action. Every path
+# returns 0.
+#
+#   agmsg_self_rename_on_action <team> <agent> [<type>]
+
+[ -n "${_AGMSG_SELF_RENAME_SH:-}" ] && return 0
+_AGMSG_SELF_RENAME_SH=1
+
+_agmsg_self_rename_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${SKILL_DIR:=$(cd "$_agmsg_self_rename_dir/../.." && pwd)}"
+export SKILL_DIR
+
+# Record the outcome on the mark, keyed to this pane+generation, and stop.
+_agmsg_self_rename_record() {   # <team> <agent> <ref> <epoch> <result> <type>
+  agmsg_role_session_mark_renamed "$1" "$2" "$3" "$4" "$5" "" "$6" 2>/dev/null || true
+}
+
+agmsg_self_rename_on_action() {
+  local team="${1:-}" agent="${2:-}" type="${3:-}"
+  [ -n "$team" ] && [ -n "$agent" ] || return 0
+
+  # shellcheck disable=SC1091
+  . "$SKILL_DIR/scripts/lib/type-registry.sh" 2>/dev/null || return 0
+  # shellcheck disable=SC1091
+  . "$SKILL_DIR/scripts/lib/terminal-registry.sh" 2>/dev/null || return 0
+  # shellcheck disable=SC1091
+  . "$SKILL_DIR/scripts/lib/role-session.sh" 2>/dev/null || return 0
+  # shellcheck disable=SC1091
+  . "$SKILL_DIR/scripts/lib/team-status.sh" 2>/dev/null || return 0
+
+  # The acting commands (send/inbox/history) do not carry the seat's CLI type, so
+  # resolve it from the role-session record the join/actas flow already wrote. No
+  # record, no type -> we cannot know the rename command, so do nothing.
+  [ -n "$type" ] || type="$(agmsg_role_session_get "$team" "$agent" type 2>/dev/null || true)"
+  [ -n "$type" ] || return 0
+
+  # Only a type that declares how it renames itself does anything (#1081). The
+  # datum, not the type name: a type gains this by adding rename_cmd.
+  local rename_cmd
+  rename_cmd="$(agmsg_type_get "$type" rename_cmd 2>/dev/null || true)"
+  [ -n "$rename_cmd" ] || return 0
+
+  # Where am I -- environment only, no terminal call yet.
+  local here terminal id epoch ref
+  here="$(agmsg_terminal_self_env)"
+  [ -n "$here" ] || return 0                 # plain, or no terminal: no pane
+  terminal="${here%%	*}"; here="${here#*	}"
+  id="${here%%	*}"; epoch="${here#*	}"
+  ref="$(agmsg_terminal_ref "$terminal" "$id")"
+
+  # The mark: what did this seat already do at THIS pane+generation?
+  local have hr he hres phase=first
+  have="$(agmsg_role_session_renamed "$team" "$agent")"
+  if [ -n "$have" ]; then
+    hr="${have%%	*}"; have="${have#*	}"; he="${have%%	*}"; hres="${have#*	}"
+    if [ "$hr" = "$ref" ] && [ "$he" = "$epoch" ]; then
+      case "$hres" in
+        attempted) phase=confirm ;;   # poked last time; confirm now, do not re-poke
+        *) return 0 ;;                # ok / failed / poked_unverified / skipped: done
+      esac
+    fi
+    # a mark for a DIFFERENT pane/generation is stale: treat as first, below.
+  fi
+
+  # Opt-out, recorded VISIBLY (only relevant when we would otherwise act now).
+  if [ "$phase" = first ] \
+     && { [ "${AGMSG_SELF_NAME:-on}" = off ] || [ "${AGMSG_SELF_RENAME:-on}" = off ]; }; then
+    _agmsg_self_rename_record "$team" "$agent" "$ref" "$epoch" "skipped:self_rename_off" "$type"
+    return 0
+  fi
+
+  # Observe my own session name. Loading the driver + one observation is the cost;
+  # it happens at most twice ever (the two phases), then the mark ends it.
+  agmsg_terminal_load "$terminal" 2>/dev/null || return 0
+  local expected="$team-$agent" raw title observed
+  raw="$(agmsg_team_observe_loaded "$id" 2>/dev/null)"
+  title="$(printf '%s' "$raw" | awk -F '\t' 'NR==1{print $4}')"
+  observed="$(agmsg_cli_session_observed "$type" "$title" "$id" 2>/dev/null)"
+
+  if [ "$phase" = confirm ]; then
+    # The rename has had a turn to land. Judge, but never call a screen we could
+    # not read a failure.
+    case "$observed" in
+      "$expected") _agmsg_self_rename_record "$team" "$agent" "$ref" "$epoch" ok "$type" ;;
+      unknown:*|n/a:*) _agmsg_self_rename_record "$team" "$agent" "$ref" "$epoch" poked_unverified "$type" ;;
+      *)
+        case "$(agmsg_type_get "$type" session_name_source 2>/dev/null || true)" in
+          screen:*) _agmsg_self_rename_record "$team" "$agent" "$ref" "$epoch" poked_unverified "$type" ;;
+          *)        _agmsg_self_rename_record "$team" "$agent" "$ref" "$epoch" failed "$type" ;;
+        esac
+        ;;
+    esac
+    return 0
+  fi
+
+  # phase=first
+  case "$observed" in
+    "$expected")
+      # Already correct (e.g. claude-code born with -n). Nothing to type.
+      _agmsg_self_rename_record "$team" "$agent" "$ref" "$epoch" ok "$type" ;;
+    unknown:*|n/a:*)
+      # Cannot read the name now, so cannot verify a rename: do NOT type blindly.
+      _agmsg_self_rename_record "$team" "$agent" "$ref" "$epoch" "skipped:${observed}" "$type" ;;
+    *)
+      # Readable and wrong: type the rename ONCE, and mark "attempted" so the next
+      # action confirms instead of poking again.
+      if terminal_poke "$id" "$rename_cmd $expected" >/dev/null 2>&1; then
+        _agmsg_self_rename_record "$team" "$agent" "$ref" "$epoch" attempted "$type"
+      else
+        _agmsg_self_rename_record "$team" "$agent" "$ref" "$epoch" "failed:poke" "$type"
+      fi
+      ;;
+  esac
+  return 0
+}

--- a/scripts/lib/team-status.sh
+++ b/scripts/lib/team-status.sh
@@ -369,6 +369,13 @@ agmsg_cli_session_observed() {   # <type> <title> <pane>
       while [ "${name# }" != "$name" ]; do name="${name# }"; done      # lead ws
       while [ "${name% }" != "$name" ]; do name="${name% }"; done      # trail ws
       [ -n "$name" ] || { printf 'unknown:name_not_visible\n'; return 0; }
+      # The header line is real, but everything after the prefix is still screen
+      # text (#1102 review). A session name is short and has no control bytes;
+      # anything else is not a name we can trust to compare or mark, so it reads
+      # malformed rather than being passed through. A TAB especially would corrupt
+      # the TAB-separated records this feeds.
+      case "$name" in *[[:cntrl:]]*) printf 'unknown:name_malformed\n'; return 0 ;; esac
+      [ "${#name}" -le 128 ] || { printf 'unknown:name_malformed\n'; return 0; }
       printf '%s\n' "$name"
       ;;
     *) printf 'unknown:session_name_source_unrecognized\n' ;;

--- a/scripts/lib/team-status.sh
+++ b/scripts/lib/team-status.sh
@@ -153,10 +153,15 @@ agmsg_team_fix_identity_loaded() {
 
   case "$session_cell" in
     mismatch\(*)
-      if [ "$type" != claude-code ]; then
-        _agmsg_team_fix_result cli_session skipped rename_unsupported
+      # The ability to rename is a manifest datum, not a type name (#1081): a type
+      # that declares rename_cmd can be renamed, one that does not is skipped with
+      # the reason naming the datum -- so a new renamable type needs no edit here.
+      rename_cmd="$(agmsg_type_get "$type" rename_cmd 2>/dev/null || true)"
+      if [ -z "$rename_cmd" ]; then
+        _agmsg_team_fix_result cli_session skipped no_rename_cmd
         return 0
       fi
+      session_src="$(_agmsg_cli_session_source "$type")"
       readiness="$(agmsg_team_input_ready_loaded "$type" "$pane")"
       IFS="$(printf '\t')" read -r state reason <<EOF
 $readiness
@@ -166,7 +171,7 @@ EOF
         return 0
       fi
       rc=0
-      terminal_poke "$pane" "/rename $expected_session" >/dev/null 2>&1 || rc=$?
+      terminal_poke "$pane" "$rename_cmd $expected_session" >/dev/null 2>&1 || rc=$?
       if [ "$rc" -ne 0 ]; then
         _agmsg_team_fix_result cli_session failed "terminal_poke_rc_$rc"
         return 0
@@ -177,15 +182,19 @@ EOF
         IFS="$(printf '\t')" read -r _ _ _ title <<EOF
 $observed
 EOF
-        case "$title" in
-          n/a:*|unknown:*) : ;;
-          *) [ "$(agmsg_cli_session_from_title "$title")" = "$expected_session" ] \
-               && { _agmsg_team_fix_result cli_session changed renamed_and_verified; return 0; } ;;
-        esac
+        [ "$(agmsg_cli_session_observed "$type" "$title" "$pane")" = "$expected_session" ] \
+          && { _agmsg_team_fix_result cli_session changed renamed_and_verified; return 0; }
         sleep 0.1 2>/dev/null || true
         tries=$((tries + 1))
       done
-      _agmsg_team_fix_result cli_session failed rename_not_observed
+      # Poked, never observed to take. A `title` name is authoritative -- still
+      # wrong after the rename is a real failure. A `screen` name that scrolls off
+      # is not observable, so there this is the third word: poked, could not
+      # confirm -- never "failed" on a screen we could not read (#1081).
+      case "$session_src" in
+        screen:*) _agmsg_team_fix_result cli_session poked_unverified rename_not_observed ;;
+        *)        _agmsg_team_fix_result cli_session failed rename_not_observed ;;
+      esac
       ;;
     ok\(*) _agmsg_team_fix_result cli_session skipped already_matches ;;
     n/a:*) _agmsg_team_fix_result cli_session skipped "${session_cell#n/a:}" ;;
@@ -207,7 +216,7 @@ agmsg_identity_cell() {
 agmsg_team_identity_loaded() {
   local team="$1" agent="$2" type="$3" terminal="$4" pane="$5"
   local raw activity actual_label actual_key title expected_label expected_key
-  local actual_session expected_session pane_cell key_cell session_cell consistency name_arg
+  local actual_session expected_session pane_cell key_cell session_cell consistency session_src
   raw="$(agmsg_team_observe_loaded "$pane")"
   IFS="$(printf '\t')" read -r activity actual_label actual_key title <<EOF
 $raw
@@ -236,19 +245,23 @@ EOF
     n/a:*|unknown:*) key_cell="$expected_key" ;;
     *) key_cell="$(agmsg_identity_cell "$expected_key" "$actual_key")" ;;
   esac
-  name_arg="$(agmsg_type_get "$type" name_arg 2>/dev/null || true)"
-  if [ -z "$name_arg" ]; then
+  # The session name is judged only when the type says how it can be OBSERVED
+  # (session_name_source), not by whether it has a launch flag (#1081): codex has
+  # no name_arg yet its name is readable early from the TUI header, so it must be
+  # judged too. A type with no source has no observable name (n/a). A source that
+  # cannot be read right now (TUI header scrolled off, screen unreadable) yields
+  # unknown, NOT mismatch -- unobservable is never "wrong".
+  session_src="$(_agmsg_cli_session_source "$type")"
+  if [ -z "$session_src" ]; then
     expected_session=n/a:no_session_name
     actual_session=n/a:no_session_name
     session_cell=n/a:no_session_name
   else
     expected_session="$team-$agent"
-    case "$title" in
-      n/a:*|unknown:*) actual_session="$title"; session_cell="$title" ;;
-      *)
-        actual_session="$(agmsg_cli_session_from_title "$title")"
-        session_cell="$(agmsg_identity_cell "$expected_session" "$actual_session")"
-        ;;
+    actual_session="$(agmsg_cli_session_observed "$type" "$title" "$pane")"
+    case "$actual_session" in
+      n/a:*|unknown:*) session_cell="$actual_session" ;;
+      *) session_cell="$(agmsg_identity_cell "$expected_session" "$actual_session")" ;;
     esac
   fi
   consistency="$(agmsg_identity_consistency "$pane_cell" "$key_cell" "$session_cell")"
@@ -299,6 +312,64 @@ agmsg_cli_session_from_title() {
       ;;
   esac
   printf '%s\n' "$title"
+}
+
+# Observe a type's CLI session name from OUTSIDE, per its `session_name_source`
+# manifest datum (#1081). One shared reader for both the cli_session cell and the
+# rename readback, so the two cannot disagree about what the name is.
+#   <title> the terminal title already observed for this pane (used by `title`)
+#   <pane>  the bare pane id (used by `screen:` to peek)
+# Prints the observed name, or a namespaced `unknown:<why>` / `n/a:<why>`.
+#
+# UNOBSERVABLE IS UNKNOWN, NEVER FAILURE. A type whose name lives only in a TUI
+# header that has scrolled off cannot be judged wrong, and a changed TUI layout
+# must read as "could not confirm", not "rename failed". Only a name we actually
+# read and that differs is a mismatch; anything we could not read is unknown.
+#   title           -> agmsg_cli_session_from_title of the terminal title
+#   screen:<prefix> -> peek the pane, take ONLY the line beginning with <prefix>,
+#                      and only its text after the prefix. The rest of the screen
+#                      is another process's output: reported, never trusted (the
+#                      peek posture SKILL.md states), so nothing else is read.
+#   (absent)        -> n/a:no_session_name (no observable name; not renamable)
+# The observation source for a type, resolved once: its session_name_source, or
+# `title` when it has a launch name flag (name_arg) but no explicit source -- a
+# name_arg type has always been read from the terminal title, so that stays true
+# without every such manifest having to also spell out session_name_source.
+_agmsg_cli_session_source() {   # <type>
+  local s; s="$(agmsg_type_get "$1" session_name_source 2>/dev/null || true)"
+  if [ -z "$s" ] && [ -n "$(agmsg_type_get "$1" name_arg 2>/dev/null || true)" ]; then
+    s=title
+  fi
+  printf '%s\n' "$s"
+}
+
+agmsg_cli_session_observed() {   # <type> <title> <pane>
+  local type="$1" title="$2" pane="$3" src prefix screen line name rc=0
+  src="$(_agmsg_cli_session_source "$type")"
+  case "$src" in
+    "") printf 'n/a:no_session_name\n' ;;
+    title)
+      case "$title" in
+        n/a:*|unknown:*) printf '%s\n' "$title" ;;
+        *) agmsg_cli_session_from_title "$title" ;;
+      esac
+      ;;
+    screen:*)
+      prefix="${src#screen:}"
+      screen="$(terminal_peek "$pane" 2>/dev/null)" || rc=$?
+      [ "$rc" -eq 0 ] || { printf 'unknown:screen_unreadable\n'; return 0; }
+      # Only the FIRST line carrying the prefix; the rest of the screen is not
+      # judged. head -1 keeps a single line even if the phrase recurs later.
+      line="$(printf '%s\n' "$screen" | grep -F "$prefix" | head -1)"
+      [ -n "$line" ] || { printf 'unknown:name_not_visible\n'; return 0; }
+      name="${line#*"$prefix"}"
+      while [ "${name# }" != "$name" ]; do name="${name# }"; done      # lead ws
+      while [ "${name% }" != "$name" ]; do name="${name% }"; done      # trail ws
+      [ -n "$name" ] || { printf 'unknown:name_not_visible\n'; return 0; }
+      printf '%s\n' "$name"
+      ;;
+    *) printf 'unknown:session_name_source_unrecognized\n' ;;
+  esac
 }
 
 _agmsg_team_identity_detail() {

--- a/scripts/lib/team-status.sh
+++ b/scripts/lib/team-status.sh
@@ -358,11 +358,14 @@ agmsg_cli_session_observed() {   # <type> <title> <pane>
       prefix="${src#screen:}"
       screen="$(terminal_peek "$pane" 2>/dev/null)" || rc=$?
       [ "$rc" -eq 0 ] || { printf 'unknown:screen_unreadable\n'; return 0; }
-      # Only the FIRST line carrying the prefix; the rest of the screen is not
-      # judged. head -1 keeps a single line even if the phrase recurs later.
-      line="$(printf '%s\n' "$screen" | grep -F "$prefix" | head -1)"
+      # ONLY a line that BEGINS with the prefix -- the header, not a phrase that
+      # merely appears somewhere in the conversation. `index($0,p)==1` is a
+      # literal, line-start match (grep -F would accept "... Thread name: x" and
+      # read the rest of an unrelated line as the name, #1102 review). First such
+      # line wins; the rest of the screen is not judged.
+      line="$(printf '%s\n' "$screen" | awk -v p="$prefix" 'index($0,p)==1 { print; exit }')"
       [ -n "$line" ] || { printf 'unknown:name_not_visible\n'; return 0; }
-      name="${line#*"$prefix"}"
+      name="${line#"$prefix"}"
       while [ "${name# }" != "$name" ]; do name="${name# }"; done      # lead ws
       while [ "${name% }" != "$name" ]; do name="${name% }"; done      # trail ws
       [ -n "$name" ] || { printf 'unknown:name_not_visible\n'; return 0; }

--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -30,6 +30,12 @@ agmsg_validate_team_name "$TEAM" || exit 1
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/self-name.sh"
 agmsg_self_name_on_action "$TEAM" "$FROM"
+# And, once and early, fix its own CLI session name by typing /rename into its own
+# pane (self-rename.sh, #1081). Best-effort, never fails the send; opt out with
+# AGMSG_SELF_RENAME=off (or the whole family with AGMSG_SELF_NAME=off).
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/self-rename.sh"
+agmsg_self_rename_on_action "$TEAM" "$FROM"
 
 agmsg_storage_load
 DB="$(agmsg_db_path "$TEAM")"

--- a/tests/test_self_rename.bats
+++ b/tests/test_self_rename.bats
@@ -113,6 +113,24 @@ _poked_panes() { grep -oE '\[send-keys\].*\[-t\] \[[^]]+\]' "$ARGV_LOG" | grep -
   [ "$(_mark team alice | cut -f3)" = failed ]
 }
 
+@test "one attempt ACROSS PROCESSES: a fresh process reads the persisted mark, does not re-poke (#1081)" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  export FAKE_TITLE='wrong-name'
+  agmsg_self_rename_on_action team alice claude-code      # phase 1: pokes, PERSISTS attempted
+  [ "$(grep -c '\[send-keys\] \[-l\]' "$ARGV_LOG")" -eq 1 ]
+  : > "$ARGV_LOG"
+  # A brand-new shell shares NO memory with the first call; only the on-disk
+  # role-session mark can carry "attempted" across. If the mark were held in a
+  # variable rather than persisted, this fresh process would poke a second time.
+  # (The stopping guarantee for an invasive auto-keystroke lives in the mark.)
+  FAKE_TITLE='wrong-name' bash -c '
+    source "$SKILL_DIR/scripts/lib/self-rename.sh"
+    agmsg_self_rename_on_action team alice claude-code
+  '
+  refute grep -q '\[send-keys\] \[-l\]' "$ARGV_LOG"
+  [ "$(_mark team alice | cut -f3)" = failed ]            # confirmed in the 2nd process
+}
+
 @test "the verify window: after a poke, the name took -> ok, still no second poke" {
   _install_fake_tmux; _under_tmux /tmp/s 4242 %3
   export FAKE_TITLE='wrong-name'

--- a/tests/test_self_rename.bats
+++ b/tests/test_self_rename.bats
@@ -151,3 +151,21 @@ _poked_panes() { grep -oE '\[send-keys\].*\[-t\] \[[^]]+\]' "$ARGV_LOG" | grep -
   terminal_peek() { return 1; }
   [ "$(agmsg_cli_session_observed codex '' wA:p1)" = 'unknown:screen_unreadable' ]
 }
+
+# The header line begins with the prefix, but the rest of it is still screen text
+# (#1102 review, tl follow-up). A real session name is short and has no control
+# bytes; a value carrying a TAB would corrupt the TAB-separated records this feeds,
+# so a control byte reads malformed rather than being passed through as the name.
+@test "codex screen parse: a value with a control byte is malformed, not a name (#1102)" {
+  source "$SKILL_DIR/scripts/lib/team-status.sh"
+  terminal_peek() { printf 'Thread name: bad\tname\nmore\n'; }
+  [ "$(agmsg_cli_session_observed codex '' wA:p1)" = 'unknown:name_malformed' ]
+}
+
+# A screen line far longer than any session name is not a name we can trust.
+@test "codex screen parse: an over-long value is malformed, not a name (#1102)" {
+  source "$SKILL_DIR/scripts/lib/team-status.sh"
+  local long; printf -v long 'x%.0s' {1..200}
+  terminal_peek() { printf 'Thread name: %s\n' "$long"; }
+  [ "$(agmsg_cli_session_observed codex '' wA:p1)" = 'unknown:name_malformed' ]
+}

--- a/tests/test_self_rename.bats
+++ b/tests/test_self_rename.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+#
+# Self-rename on action (scripts/lib/self-rename.sh, #1081): a seat types the
+# type's rename command into ITS OWN pane, once, early, and only when it can
+# verify. The guard that matters most (and the one #1096 was missing): the
+# keystroke reaches the seat's own pane and NO OTHER pane. A test that only
+# checks "my name changed" passes even when every pane is typed into.
+
+setup() {
+  load 'test_helper'
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  export RUN_DIR="$SKILL_DIR/run"; mkdir -p "$RUN_DIR"
+  export AGMSG_AGENT_PID=""
+  FAKEBIN="$BATS_TEST_TMPDIR/bin"; mkdir -p "$FAKEBIN"
+  ARGV_LOG="$BATS_TEST_TMPDIR/argv.log"; : > "$ARGV_LOG"
+  export FAKEBIN ARGV_LOG
+  unset TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID HERDR_SOCKET_PATH
+  unset AGMSG_SELF_NAME AGMSG_SELF_RENAME
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/self-rename.sh"
+}
+teardown() { teardown_test_env; }
+
+# A fake tmux that logs argv, answers the title query with $FAKE_TITLE, and takes
+# send-keys (the poke) as a logged no-op.
+_install_fake_tmux() {
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+# real tmux takes an optional leading -S <socket>, so the subcommand is NOT
+# always \$1: scan the args for it and for the pane after -t.
+prev=""; pane=""; is_dm=0
+for a in "\$@"; do
+  [ "\$prev" = "-t" ] && pane="\$a"
+  [ "\$a" = display-message ] && is_dm=1
+  prev="\$a"
+done
+# display-message answers "<pane_id>|<title>"; terminal_team_observe co-observes
+# the id, so it must echo the queried pane back verbatim.
+[ "\$is_dm" = 1 ] && printf '%s|%s\n' "\$pane" "\${FAKE_TITLE:-unknown}"
+exit 0
+EOF
+  chmod +x "$FAKEBIN/tmux"; export PATH="$FAKEBIN:$PATH"
+}
+
+_under_tmux() { export TMUX="$1,$2,0" TMUX_PANE="$3"; }   # <socket> <pid> <pane>
+_mark() { agmsg_role_session_renamed "$1" "$2"; }         # -> ref<TAB>epoch<TAB>result
+# every send-keys target pane in the log, deduped
+_poked_panes() { grep -oE '\[send-keys\].*\[-t\] \[[^]]+\]' "$ARGV_LOG" | grep -oE '\[-t\] \[[^]]+\]' | sed -E 's/.*\[(.*)\]/\1/' | sort -u; }
+
+@test "the rename is typed into the seat's OWN pane, and no other pane is touched (#1096)" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  export FAKE_TITLE='wrong-name'   # not team-alice -> must rename
+  agmsg_self_rename_on_action team alice claude-code
+  # (a) the seat's pane got the /rename
+  grep -q '\[send-keys\] \[-l\] \[-t\] \[%3\] \[--\] \[/rename team-alice\]' "$ARGV_LOG"
+  # (b) THE POINT: every send-keys went to %3 and to nothing else
+  [ "$(_poked_panes)" = '%3' ]
+  # and it recorded the attempt (so it will not poke again)
+  [ "$(_mark team alice | cut -f3)" = attempted ]
+}
+
+@test "already correctly named: nothing is typed at all" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  export FAKE_TITLE='team-alice'
+  agmsg_self_rename_on_action team alice claude-code
+  refute grep -q '\[send-keys\]' "$ARGV_LOG"
+  [ "$(_mark team alice | cut -f3)" = ok ]
+}
+
+@test "a type with no rename_cmd types nothing (the datum, not the type)" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  export FAKE_TITLE='wrong-name'
+  agmsg_self_rename_on_action team alice gemini   # gemini has no rename_cmd
+  refute grep -q '\[send-keys\]' "$ARGV_LOG"
+  [ -z "$(_mark team alice)" ]   # no attempt recorded at all
+}
+
+@test "AGMSG_SELF_RENAME=off types nothing, and the stop is VISIBLE on the mark" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  export FAKE_TITLE='wrong-name' AGMSG_SELF_RENAME=off
+  agmsg_self_rename_on_action team alice claude-code
+  refute grep -q '\[send-keys\]' "$ARGV_LOG"
+  [ "$(_mark team alice | cut -f3)" = skipped:self_rename_off ]
+}
+
+@test "AGMSG_SELF_NAME=off also stops the keystroke, visibly" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  export FAKE_TITLE='wrong-name' AGMSG_SELF_NAME=off
+  agmsg_self_rename_on_action team alice claude-code
+  refute grep -q '\[send-keys\]' "$ARGV_LOG"
+  [ "$(_mark team alice | cut -f3)" = skipped:self_rename_off ]
+}
+
+@test "one attempt only: after it has poked, a second action does not poke again" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  export FAKE_TITLE='wrong-name'
+  agmsg_self_rename_on_action team alice claude-code      # phase 1: pokes, marks attempted
+  [ "$(grep -c '\[send-keys\] \[-l\]' "$ARGV_LOG")" -eq 1 ]
+  : > "$ARGV_LOG"
+  # phase 2: the mark says attempted; it confirms, it does NOT poke again. The
+  # title is still wrong -> a title name is authoritative -> failed, no re-poke.
+  agmsg_self_rename_on_action team alice claude-code
+  refute grep -q '\[send-keys\] \[-l\]' "$ARGV_LOG"
+  [ "$(_mark team alice | cut -f3)" = failed ]
+}
+
+@test "the verify window: after a poke, the name took -> ok, still no second poke" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  export FAKE_TITLE='wrong-name'
+  agmsg_self_rename_on_action team alice claude-code      # pokes, marks attempted
+  : > "$ARGV_LOG"
+  export FAKE_TITLE='team-alice'                          # the rename landed
+  agmsg_self_rename_on_action team alice claude-code      # confirm
+  refute grep -q '\[send-keys\] \[-l\]' "$ARGV_LOG"
+  [ "$(_mark team alice | cut -f3)" = ok ]
+}

--- a/tests/test_self_rename.bats
+++ b/tests/test_self_rename.bats
@@ -17,6 +17,13 @@ setup() {
   export FAKEBIN ARGV_LOG
   unset TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID HERDR_SOCKET_PATH
   unset AGMSG_SELF_NAME AGMSG_SELF_RENAME
+  # self-rename.sh sources its deps lazily inside the hook, so make the registry
+  # and observation helpers available up front for the tests that call them
+  # directly (the codex screen-parse ones).
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/type-registry.sh"
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/team-status.sh"
   # shellcheck disable=SC1090
   source "$SKILL_DIR/scripts/lib/self-rename.sh"
 }
@@ -115,4 +122,32 @@ _poked_panes() { grep -oE '\[send-keys\].*\[-t\] \[[^]]+\]' "$ARGV_LOG" | grep -
   agmsg_self_rename_on_action team alice claude-code      # confirm
   refute grep -q '\[send-keys\] \[-l\]' "$ARGV_LOG"
   [ "$(_mark team alice | cut -f3)" = ok ]
+}
+
+# --- codex screen parse: only a line BEGINNING with "Thread name:" (#1102 review)
+# grep -F accepted the phrase anywhere on a line and read the rest of an unrelated
+# line as the name; the header is a line that STARTS with the prefix.
+
+@test "codex screen parse: a leading Thread name line yields the name" {
+  source "$SKILL_DIR/scripts/lib/team-status.sh"
+  terminal_peek() { printf 'some banner\nThread name: team-alice\ntrailing output\n'; }
+  [ "$(agmsg_cli_session_observed codex '' wA:p1)" = 'team-alice' ]
+}
+
+@test "codex screen parse: the phrase appearing mid-line is NOT the name -> unknown (#1102)" {
+  source "$SKILL_DIR/scripts/lib/team-status.sh"
+  terminal_peek() { printf 'ordinary output Thread name: team-alice\nmore\n'; }
+  [ "$(agmsg_cli_session_observed codex '' wA:p1)" = 'unknown:name_not_visible' ]
+}
+
+@test "codex screen parse: no header at all -> unknown" {
+  source "$SKILL_DIR/scripts/lib/team-status.sh"
+  terminal_peek() { printf 'just some conversation\nno header here\n'; }
+  [ "$(agmsg_cli_session_observed codex '' wA:p1)" = 'unknown:name_not_visible' ]
+}
+
+@test "codex screen parse: an unreadable screen -> unknown, not a name" {
+  source "$SKILL_DIR/scripts/lib/team-status.sh"
+  terminal_peek() { return 1; }
+  [ "$(agmsg_cli_session_observed codex '' wA:p1)" = 'unknown:screen_unreadable' ]
 }

--- a/tests/test_team_status.bats
+++ b/tests/test_team_status.bats
@@ -223,7 +223,7 @@ EOF
 }
 
 @test "identity fix repairs names and verifies the CLI rename" {
-  agmsg_type_get() { [ "$2" = cli ] && printf 'claude\n'; }
+  agmsg_type_get() { case "$2" in cli) printf 'claude\n';; rename_cmd) printf '/rename\n';; session_name_source) printf 'title\n';; esac; }
   _herdr_internal_key() { printf 'a123\n'; }
   terminal_name() { printf '%s\n' "$4" >> "$BATS_TEST_TMPDIR/names"; }
   terminal_team_input_ready() { printf 'ready\n'; }
@@ -241,7 +241,7 @@ EOF
 }
 
 @test "identity fix never pokes a CLI without positive readiness" {
-  agmsg_type_get() { [ "$2" = cli ] && printf 'claude\n'; }
+  agmsg_type_get() { case "$2" in cli) printf 'claude\n';; rename_cmd) printf '/rename\n';; session_name_source) printf 'title\n';; esac; }
   terminal_team_input_ready() { printf 'not_ready:agent_not_found\n'; return 1; }
   terminal_poke() { printf 'called\n' > "$BATS_TEST_TMPDIR/poke"; }
   run agmsg_team_fix_identity_loaded team alice claude-code herdr w2:p3 \


### PR DESCRIPTION
Fixes #1081. The third identity cell — the CLI session name — has no programmatic setter after launch: claude-code's `-n` is launch-only, codex has none, and a hand-started or resumed seat never gets one. But a person can always type `/rename`, and a seat knows its team, its name, and (from its environment) its own pane. So it renames itself from the inside, exactly as `team --fix` already does from the outside.

## What it adds
- **Manifest data, no type-specific code:** `rename_cmd` (the interactive rename command) and `session_name_source` (`title`, or `screen:<prefix>` read by peeking the pane and taking only that line). A type without `rename_cmd` does nothing; the skipped reason names the manifest, not the type.
- **`self-rename.sh`, hooked on send/inbox/history:** a seat pokes `<rename_cmd> <team>-<agent>` into its OWN pane, once, early — before the /resume picker, and (for codex, whose "Thread name:" header scrolls away) inside the only window where it can still be verified. Two-phase, because the keystroke is queued and lands after the turn: poke and mark on the first action, confirm on the next.
- **A third result word, `poked_unverified`:** typed, could not confirm. A screen name we cannot read is `unknown`, never `failed` — a changed TUI layout must not read as "rename failed".
- **Two-tier opt-out, visible not silent:** `AGMSG_SELF_NAME=off` stops the whole family; `AGMSG_SELF_RENAME=off` stops only the (more invasive) keystroke. Either is recorded on the mark.
- **One attempt per (seat, pane, server generation),** via a persisted mark — no retry on the next action or the next process.
- **Generalizes `team --fix`** from claude-code-only to any type with `rename_cmd`; codex is now observable and renamable from the outside too. The self path and the `--fix` path stay separate: `--fix` is explicit and human-triggered; self-rename is automatic and carries the stopping rules.

## Tests
- `test_self_rename.bats`: the keystroke reaches the seat's own pane and **no other pane is touched** — the guard a same-shaped bug survived because the only test checked "my name changed", which passes even when every pane is typed into. Also: already-correct types nothing; no `rename_cmd` types nothing; both opt-outs type nothing and are visible; one attempt only; the verify window.
- Regression: `test_team_status`, `test_team`, `test_type_registry` green; enforced-assertions at baseline.

Independent of the in-flight terminal work; base is integration.