### PR TITLE
docs(skill): preserve terminal driver guidance after rendering

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -115,6 +115,10 @@ If argument starts with "config set" (e.g. "config set hook.check_interval 30"):
 1. Parse key and value from the arguments.
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/config.sh set <key> <value>`
 
+If argument is "version":
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/version.sh`
+2. Show the output — the installed version (git-describe provenance recorded at install time).
+
 
 <!-- agmsg:slot actas -->
 If argument starts with "actas" followed by an agent name:
@@ -130,6 +134,21 @@ If argument starts with "drop" followed by an agent name:
 2. Clear the active role when it matches `<name>` and report the result.
 <!-- /agmsg:slot drop -->
 <!-- agmsg:slot spawn -->
+If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex reviewer --window"):
+1. Parse `<type>` (a spawnable agent type), `<name>`, and any options (`--boot-prompt <text>`, `--project <path>`, `--team <team>`, `--window`, `--split h|v`, `--terminal <template>`, `--no-wait`, `--ready-timeout <secs>`, `--model <id>`, `--fresh`).
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
+   - `spawn.sh` pre-joins `<name>`, then opens a tmux pane/window or a new OS terminal and launches the target CLI with `__CMD_PREFIX____SKILL_NAME__ actas <name>` as its initial prompt. `--boot-prompt` appends a first task to that prompt.
+   - By default it waits for a target watcher to attach and report `status=ready`; `--no-wait` returns immediately. Codex has no Monitor, so a Codex spawn skips that readiness wait.
+   - It refuses early when `<name>` is already held, the target CLI is missing, the project path is invalid, or no tmux/usable terminal is available.
+3. Show the script's output.
+
+If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --force"):
+1. Parse `<name>` and any options (`--force`, `--timeout <secs>`).
+2. Determine which team `<name>` belongs to, then run:
+   `~/.agents/skills/__SKILL_NAME__/scripts/despawn.sh <team> $AGENT <name> [--force] [--timeout <secs>]`
+   - The default graceful path sends a `ctrl:despawn` message so the member's watcher drops its role and closes its spawned pane, then waits for the lock to release.
+   - If the member has no watcher, or graceful teardown times out, use `--force` to tear down the recorded placement and drop the registration directly.
+3. Show the script's output.
 <!-- /agmsg:slot spawn -->
 <!-- shared actas/drop guidance is supplied by the type overlay -->
 

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -63,7 +63,21 @@ If argument starts with "drop" followed by an agent name:
 <!-- /agmsg:slot drop -->
 
 <!-- agmsg:slot spawn -->
-If argument starts with "spawn": run `spawn.sh <type> <name> --project "$(pwd)" [options]`; it opens a pane and waits for a Claude Code watcher to attach. `despawn` sends `ctrl:despawn` and closes the spawned pane, or accepts `--force`.
+If argument starts with "spawn" (e.g. "spawn codex reviewer", "spawn claude-code alice --window"):
+1. Parse `<type>` (a spawnable agent type), `<name>`, and any options (`--boot-prompt <text>`, `--project <path>`, `--team <team>`, `--window`, `--split h|v`, `--terminal <template>`, `--no-wait`, `--ready-timeout <secs>`, `--model <id>`, `--fresh`).
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
+   - `spawn.sh` pre-joins `<name>`, then opens a tmux pane/window or a new OS terminal and launches the target CLI with `/__SKILL_NAME__ actas <name>` as its initial prompt. `--boot-prompt` appends a first task to that prompt.
+   - By default it blocks until a spawned Claude Code agent's watcher attaches and prints `status=ready`; `--no-wait` returns immediately. A spawned Codex agent has no Monitor and skips the readiness wait.
+   - It refuses early when `<name>` is already held by another live session, the target CLI is missing, the project path is invalid, or no tmux/usable terminal is available.
+3. Show the script's output. Do not TaskStop or relaunch this session's own Monitor; spawn affects a separate agent.
+
+If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --force"):
+1. Parse `<name>` and any options (`--force`, `--timeout <secs>`). `despawn` tears down a member previously spawned by this session.
+2. Determine which team `<name>` belongs to, then run:
+   `~/.agents/skills/__SKILL_NAME__/scripts/despawn.sh <team> $AGENT <name> [--force] [--timeout <secs>]`
+   - The default graceful path sends a `ctrl:despawn` message; the member's watcher drops its role and closes its spawned pane, then `despawn` waits for the lock to release.
+   - If the member is Codex and has no watcher, or graceful teardown times out, use `--force` to tear down the recorded pane/window and drop the registration directly.
+3. Show the script's output. Do not TaskStop or relaunch this session's own Monitor.
 <!-- /agmsg:slot spawn -->
 
 <!-- agmsg:slot mode -->

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -27,7 +27,21 @@ If argument starts with "drop", run `reset.sh "$(pwd)" __AGENT_TYPE__ <name>` an
 <!-- /agmsg:slot drop -->
 
 <!-- agmsg:slot spawn -->
-If argument starts with "spawn", run `spawn.sh <type> <name> --project "$(pwd)" [options]`. Codex spawn uses the bundled shim and bridge; `despawn --force` is required when a Codex member has no watcher.
+If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex reviewer --window"):
+1. Parse `<type>` (a spawnable agent type), `<name>`, and any options (`--boot-prompt <text>`, `--project <path>`, `--team <team>`, `--window`, `--split h|v`, `--terminal <template>`, `--no-wait`, `--ready-timeout <secs>`, `--model <id>`, `--fresh`).
+2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
+   - `spawn.sh` pre-joins `<name>`, then opens a tmux pane/window or a new OS terminal and launches the target CLI with `$__SKILL_NAME__ actas <name>` as its initial prompt. `--boot-prompt` appends a first task to that prompt. Codex spawn uses the bundled shim and bridge.
+   - By default it blocks until a spawned Claude Code agent's watcher attaches and prints `status=ready`; `--no-wait` returns immediately. A spawned Codex agent has no Monitor and skips the readiness wait.
+   - It refuses early when `<name>` is already held by another live session, the target CLI is missing, the project path is invalid, or no tmux/usable terminal is available.
+3. Show the script's output.
+
+If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --force"):
+1. Parse `<name>` and any options (`--force`, `--timeout <secs>`). `despawn` tears down a member previously spawned by this session.
+2. Determine which team `<name>` belongs to, then run:
+   `~/.agents/skills/__SKILL_NAME__/scripts/despawn.sh <team> $AGENT <name> [--force] [--timeout <secs>]`
+   - The default graceful path sends a `ctrl:despawn` message so a Claude Code member's watcher drops its role and closes its spawned pane, then waits for the lock to release.
+   - A Codex member has no watcher, so use `--force` for it. `--force` skips the message, tears down the recorded pane/window, and drops the registration directly.
+3. Show the script's output.
 <!-- /agmsg:slot spawn -->
 
 <!-- agmsg:slot mode -->

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -388,14 +388,32 @@ PS1
 }
 
 @test "skill renderer keeps terminal-driver guidance in every rendered artifact" {
-  local type rendered
+  local type rendered required
   while IFS= read -r type; do
     rendered="$FAKE_HOME/$type-terminal-driver.md"
     run bash -c 'source "$1/scripts/lib/type-registry.sh"; source "$1/scripts/lib/skill-render.sh"; SCRIPT_DIR="$1" agmsg_render_skill "$2" agmsg "$3"' _ "$REPO_ROOT" "$type" "$rendered"
     [ "$status" -eq 0 ]
-    grep -Fq 'If argument is "version":' "$rendered"
-    grep -Fq 'If argument starts with "spawn"' "$rendered"
-    grep -Fq 'If argument starts with "despawn"' "$rendered"
+    for required in \
+      'If argument is "version":' \
+      'version.sh' \
+      'If argument starts with "spawn"' \
+      'spawn.sh <type> <name>' \
+      '--ready-timeout' \
+      'status=ready' \
+      '--no-wait' \
+      'already held' \
+      'target CLI is missing' \
+      'If argument starts with "despawn"' \
+      'despawn.sh <team> $AGENT <name>' \
+      'ctrl:despawn' \
+      'no watcher' \
+      '--force' \
+      '--timeout'; do
+      grep -Fq -- "$required" "$rendered" || {
+        echo "rendered $type is missing terminal-driver fact: $required" >&2
+        return 1
+      }
+    done
   done < <(agmsg_renderable_types "$REPO_ROOT")
 }
 

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -387,6 +387,18 @@ PS1
   ! grep -q "__SKILL_NAME__\|__AGENT_TYPE__\|__CMD_PREFIX__" "$rendered"
 }
 
+@test "skill renderer keeps terminal-driver guidance in every rendered artifact" {
+  local type rendered
+  while IFS= read -r type; do
+    rendered="$FAKE_HOME/$type-terminal-driver.md"
+    run bash -c 'source "$1/scripts/lib/type-registry.sh"; source "$1/scripts/lib/skill-render.sh"; SCRIPT_DIR="$1" agmsg_render_skill "$2" agmsg "$3"' _ "$REPO_ROOT" "$type" "$rendered"
+    [ "$status" -eq 0 ]
+    grep -Fq 'If argument is "version":' "$rendered"
+    grep -Fq 'If argument starts with "spawn"' "$rendered"
+    grep -Fq 'If argument starts with "despawn"' "$rendered"
+  done < <(agmsg_renderable_types "$REPO_ROOT")
+}
+
 @test "install: watch.sh self-cleans a prior watcher on re-invocation for the same sid" {
   HOME="$FAKE_HOME" bash "$REPO_ROOT/install.sh" --cmd agmsg
   bash "$SK/scripts/join.sh" demo alice claude-code /tmp/install-projA


### PR DESCRIPTION
Folding the ten type templates into a shared root and thin overlays took some guidance with it. This restores what was lost and adds the check that would have caught it.

Measured on the artifact a user actually reads — the rendered skill installed at `v1.2.3-49-g21e813e` — against the claude-code template as it stood before the fold:

| | before | after the fold |
|---|---|---|
| `version` | 3 mentions | **0** |
| `spawn` | 14 | 2 |
| `despawn` | 6 | 1 |
| `watch` | 10 | 5 |

`version` vanished entirely: it went into neither the shared root nor any overlay. The others survived as a single compressed line, which reads as a reminder to someone who already knows the command and not as instructions to someone who does not. The old text carried the arguments and options, what the ready-wait means, which failures are permanent, and how a graceful `despawn` differs from `--force`. The one-liner carries none of that.

Deduplication was the point of the fold and remains right — the same paragraph did not need to exist in ten files. Writing it once in the shared root is the design working as intended; writing it once and much shorter was a separate decision that went too far for the commands this release exists to add.

## The check

`tests/test_install.bats` now renders every renderable type and asserts the terminal-driver guidance is present in the **output**. Not in a template, not in a slot — in the file that gets installed.

That distinction is the whole reason this regression survived review. The fold was checked by reading templates and by comparing a root against an overlay; the rendered result was never compared against what it replaced. A check on the rendered artifact fails when guidance is dropped again, whichever layer drops it.
