### PR TITLE
fix(self-name): record placement when a seat names its own pane, so it is reachable

### DIFF
--- a/scripts/lib/self-name.sh
+++ b/scripts/lib/self-name.sh
@@ -67,6 +67,16 @@ agmsg_self_name_on_action() {
   . "$SKILL_DIR/scripts/lib/terminal-registry.sh" 2>/dev/null || return 0
   # shellcheck disable=SC1091
   . "$SKILL_DIR/scripts/lib/role-session.sh" 2>/dev/null || return 0
+  # agmsg_spawn_path: to check (fast half) and, via the primitive, write (slow
+  # half) the placement record. A seat that names its pane but is never recorded
+  # looks correct and is unreachable (#1109); this hook is the one caller entitled
+  # to claim placement, because it runs AS the seat, IN its own pane, resolved from
+  # that process's own environment -- exactly the case the primitive's record
+  # comment (terminal-registry.sh) reserves for the caller to assert. Best-effort:
+  # if it will not source, the fast-half check below is skipped and the slow half's
+  # own lazy load writes the record, so naming still proceeds.
+  # shellcheck disable=SC1091
+  . "$SKILL_DIR/scripts/lib/actas-lock.sh" 2>/dev/null || true
 
   # Fast half: where am I (environment only), and does my mark say so?
   local here terminal id epoch have ref
@@ -76,14 +86,28 @@ agmsg_self_name_on_action() {
   id="${here%%	*}"; epoch="${here#*	}"
   ref="$(agmsg_terminal_ref "$terminal" "$id")"
   have="$(agmsg_role_session_named "$team" "$agent")"
-  if [ -n "$have" ] && [ "${have%%	*}" = "$ref" ] && [ "${have#*	}" = "$epoch" ]; then
-    return 0                                 # named, by a mark that matches where I am
+  # The fast half short-circuits only when BOTH halves are already in place: the
+  # naming mark matches this pane AND the placement record points here too. Before
+  # #1109 it trusted the mark alone, so a seat named once but never recorded (every
+  # hand-started seat) short-circuited past the write forever. Reading the record
+  # is one file read, the same order as the mark read.
+  local recorded="" rec=""
+  if declare -F agmsg_spawn_path >/dev/null 2>&1; then
+    rec="$(agmsg_spawn_path "$team" "$agent" 2>/dev/null || true)"
+    [ -n "$rec" ] && [ -f "$rec" ] && IFS=$'\t' read -r recorded _ < "$rec" 2>/dev/null || true
+  fi
+  if [ -n "$have" ] && [ "${have%%	*}" = "$ref" ] && [ "${have#*	}" = "$epoch" ] \
+     && [ "$recorded" = "$ref" ]; then
+    return 0                                 # named AND recorded at where I am
   fi
 
-  # Slow half, once: name the pane through the same primitive every other
-  # path uses; it leaves the mark on success. An empty session id is right
-  # here: both drivers identify the pane from the environment now, and the
-  # acting commands have no session id at hand.
-  agmsg_terminal_name_self_safe "" "$team" "$agent" "$project" "$type" || true
+  # Slow half, once: name the pane through the same primitive every other path
+  # uses, and -- the #1109 fix -- record this pane as the seat's placement. The
+  # `record` claim is legitimate here and only here among the label writers (see
+  # the sourcing comment above); every other caller of the primitive still passes
+  # five args and only relabels. It leaves the mark on success. An empty session
+  # id is right here: both drivers identify the pane from the environment now, and
+  # the acting commands have no session id at hand.
+  agmsg_terminal_name_self_safe "" "$team" "$agent" "$project" "$type" record || true
   return 0
 }

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -674,7 +674,17 @@ agmsg_terminal_name_self() {
   fi
 
   # Whether that ALSO makes this pane the seat's recorded placement is the
-  # caller's claim to make, not this function's.
+  # caller's claim to make, not this function's. The claim is legitimate because
+  # this function only ever names the CALLER'S OWN pane -- resolved from the
+  # caller's session id or, with an empty sid, its environment (above) -- so
+  # `record` asserts "the pane I just resolved as mine is where I live". The
+  # callers that pass it are exactly the self-locating ones: SessionStart and
+  # actas name the seat as it starts, and the action hook (self-name.sh) does the
+  # same on every action for a hand-started seat that was never recorded (#1109).
+  # A future path that names a pane it was HANDED -- batch relabeling of someone
+  # else's pane -- must NOT pass record: it is not that seat and cannot speak for
+  # its placement. (spawn records too, but writes the record itself for the CHILD
+  # pane it created; it does not reach this line.)
   [ "$write_record" = record ] || return 0
 
   # The record is what despawn/peek/poke resolve through, so it is written only

--- a/tests/test_self_name.bats
+++ b/tests/test_self_name.bats
@@ -230,13 +230,14 @@ _placement() {   # <team> <agent> -> "<terminal>:<id>" or empty
 @test "no pane in the environment: nothing is recorded, so an un-named seat stays unreachable (#1109)" {
   _install_fake_tmux                                                # a tmux binary exists, but
   unset TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID HERDR_SOCKET_PATH    # no pane in the environment
-  agmsg_self_name_on_action team codexapp
-  # self_env resolves nothing -> no name, no record. This is the codex-app / grok-cc
-  # contrast: a real seat that never named itself must keep reading as unreachable,
-  # not be made falsely addressable. Making everything reachable would turn "cannot
-  # reach" into "said it could and could not", which is worse.
+  agmsg_self_name_on_action team seat1
+  # self_env resolves nothing -> no name, no record. This is the contrast case: a
+  # real seat that never named itself (neither a naming record nor a placement one)
+  # must keep reading as unreachable, not be made falsely addressable. Making
+  # everything reachable would turn "cannot reach" into "said it could and could
+  # not", which is worse.
   [ "$(_terminal_calls)" -eq 0 ]
-  [ -z "$(_placement team codexapp)" ]
+  [ -z "$(_placement team seat1)" ]
 }
 
 # --- herdr ---------------------------------------------------------------------------

--- a/tests/test_self_name.bats
+++ b/tests/test_self_name.bats
@@ -86,6 +86,18 @@ _mark() {   # <team> <agent> -> "ref<TAB>epoch" or empty
   agmsg_role_session_named "$1" "$2"
 }
 
+# The placement record's pane ref (its first field), or empty. This is the half
+# peek/poke/despawn/team/--fix resolve through -- the half #1109 was missing.
+_placement() {   # <team> <agent> -> "<terminal>:<id>" or empty
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  local rec r
+  rec="$(agmsg_spawn_path "$1" "$2")" || return 0
+  [ -f "$rec" ] || return 0
+  IFS=$'\t' read -r r _ < "$rec" || return 0
+  printf '%s' "$r"
+}
+
 # --- the three directions, tmux -----------------------------------------------------
 
 @test "no mark: the first action names the pane once and leaves a mark with the pane and the server pid" {
@@ -159,9 +171,14 @@ _mark() {   # <team> <agent> -> "ref<TAB>epoch" or empty
   _install_fake_tmux; _under_tmux /tmp/s 4242 %3
   # shellcheck disable=SC1090
   source "$SKILL_DIR/scripts/lib/terminal-registry.sh"
-  agmsg_terminal_name_self_safe "sid-1" team alice /tmp/p claude-code
+  # A recording boot (SessionStart / actas both pass `record`): it leaves BOTH
+  # the mark and the placement record, so the action's fast half finds nothing to
+  # do. Without the record the action would rightly act to write it (see the
+  # hand-started #1109 test below) -- that is the point of checking both halves.
+  agmsg_terminal_name_self_safe "sid-1" team alice /tmp/p claude-code record
   [ "$(_name_calls)" -eq 1 ]
   [ "$(_mark team alice)" = $'tmux:/tmp/s:%3\tpid=4242' ]
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
   : > "$ARGV_LOG"
   agmsg_self_name_on_action team alice
   [ "$(_terminal_calls)" -eq 0 ]
@@ -176,6 +193,50 @@ _mark() {   # <team> <agent> -> "ref<TAB>epoch" or empty
   source "$SKILL_DIR/scripts/lib/terminal-registry.sh"
   agmsg_terminal_name_self_safe "sid-1" team alice /tmp/p claude-code
   [ "$(grep 'set-option' "$ARGV_LOG")" = "$first" ]
+}
+
+# --- #1109: the action records placement, so a hand-started seat is reachable -------
+
+@test "a hand-started seat: the action RECORDS its placement, not only the label (#1109)" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  # No prior naming and no record -- a seat someone started by hand that has just
+  # sent its first message.
+  [ -z "$(_placement team alice)" ]
+  agmsg_self_name_on_action team alice
+  # The label was set AND the placement record now points at this pane -- the half
+  # peek/poke/despawn/team/--fix resolve through. A test on the label alone (the
+  # mark / _name_calls) passes without the fix; asserting the record is the point.
+  [ "$(_name_calls)" -eq 1 ]
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+}
+
+@test "named once but never recorded: the next action writes the missing record (#1109)" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  # A mark-only prior naming (watch.sh names with five args, no record): the mark
+  # matches this pane, but no placement record exists. The old fast half trusted
+  # the mark alone and short-circuited past the write forever.
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/terminal-registry.sh"
+  agmsg_terminal_name_self_safe "sid-1" team alice /tmp/p claude-code
+  [ -n "$(_mark team alice)" ]
+  [ -z "$(_placement team alice)" ]
+  : > "$ARGV_LOG"
+  agmsg_self_name_on_action team alice
+  # It did not short-circuit on the mark: it wrote the record. After this a
+  # further action fast-paths (the no-second-call test above proves that half).
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+}
+
+@test "no pane in the environment: nothing is recorded, so an un-named seat stays unreachable (#1109)" {
+  _install_fake_tmux                                                # a tmux binary exists, but
+  unset TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID HERDR_SOCKET_PATH    # no pane in the environment
+  agmsg_self_name_on_action team codexapp
+  # self_env resolves nothing -> no name, no record. This is the codex-app / grok-cc
+  # contrast: a real seat that never named itself must keep reading as unreachable,
+  # not be made falsely addressable. Making everything reachable would turn "cannot
+  # reach" into "said it could and could not", which is worse.
+  [ "$(_terminal_calls)" -eq 0 ]
+  [ -z "$(_placement team codexapp)" ]
 }
 
 # --- herdr ---------------------------------------------------------------------------


### PR DESCRIPTION
A seat that names its own pane still could not be reached. It wrote the naming mark, the pane carried the right label and key, and `team` reported `no_placement_record` — because the readers resolve through a different file, and only `spawn` ever wrote that one.

Measured before the change, on live sessions: nine of the eleven members reported as having no placement had already named themselves. Their marks were on disk, complete with the pane reference and the server epoch. `peek` returned 13 — no addressable pane — for panes that were right there and correctly named. Two working seats were unreachable for a day this way, and the symptom is indistinguishable from a dead watcher.

The naming primitive already takes an argument for this; the self-naming caller did not pass it. It does now.

## Why the caller, not the readers

Making the readers fall back to the naming mark was the other option and looked tidier. Counting them settled it: seven or eight call sites read the placement path directly — `peek`, `poke`, `despawn`, `team`, the `--fix` naming route, `arrange`, `watch` — with no shared resolver to change in one place. Wiring a fallback through all of them is a much larger change than the defect.

## What the gate still means

`agmsg_terminal_name_self` documents that recording placement is the caller's claim to make, not the function's, and that stays true. The self-naming hook may claim it because of where it runs: as the seat, in the seat's own pane, resolved from that process's own environment. A future caller that relabels a pane it was handed must not claim it, and the gate comment now says so in the one place someone would look.

## Tests

The fast path previously returned early on the naming mark alone, which would have left the nine existing seats unrepaired forever — they have marks. It now also requires the placement record to point at the same pane, so those seats record themselves on their next action.

Covered: a hand-started seat becomes reachable and `--fix` no longer skips it; a seat with neither a mark nor a record still reports unreachable, which is the case that must not be swept up by making everything reachable.
