### PR TITLE
feat(team): split --fix into --fix-pane-names and --rename-sessions (#1110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,14 +334,14 @@ See [docs/opencode.md](docs/opencode.md) for full setup instructions.
 ~/.agents/skills/<cmd>/scripts/send.sh <team> <from> <to> "<message>" [--force]
 ~/.agents/skills/<cmd>/scripts/inbox.sh <team> <agent_id>
 ~/.agents/skills/<cmd>/scripts/history.sh <team> [agent_id] [limit]
-~/.agents/skills/<cmd>/scripts/team.sh <team> [--json | --fix]
+~/.agents/skills/<cmd>/scripts/team.sh <team> [--json | --fix | --fix-pane-names | --rename-sessions]
 ~/.agents/skills/<cmd>/scripts/whoami.sh <project_path> <type>
 ~/.agents/skills/<cmd>/scripts/delivery.sh set <mode> <type> <project_path>
 ~/.agents/skills/<cmd>/scripts/delivery.sh status [<type> <project_path>]
 ~/.agents/skills/<cmd>/scripts/reset.sh <project_path> <type> [agent_id]
 ```
 
-`team.sh` combines the roster with terminal placement, activity, delivery mode, and identity consistency. Verified identity is collapsed to `identity=ok`; mismatches and values that could not be observed are expanded with their evidence. `--json` emits every field for every registration. `--fix` repairs writable naming mismatches and reports each action as `changed`, `skipped`, or `failed`; it sends `/rename` only after positively identifying a ready Claude Code process in the recorded pane. Pane liveness will join this view when the pane-state contract lands; until then the unavailable column is omitted rather than filled with `unknown`.
+`team.sh` combines the roster with terminal placement, activity, delivery mode, and identity consistency. Verified identity is collapsed to `identity=ok`; mismatches and values that could not be observed are expanded with their evidence. `--json` emits every field for every registration. The repair flags report each action per identity cell as `changed`, `skipped`, `failed`, or (for a session name that could not be read back) `poked_unverified`. They are two different kinds of act: `--fix-pane-names` repairs the pane label and agent key through the terminal's own API and never types into a session; `--rename-sessions` repairs the CLI session name by typing the type's rename command (`/rename <team>-<agent>` for Claude Code, whatever the type's manifest declares otherwise) into the pane, and only after positively identifying a ready process there. `--fix` does both, unconditionally, including the keystroke. Pane liveness will join this view when the pane-state contract lands; until then the unavailable column is omitted rather than filled with `unknown`.
 
 Terminal identity has a different number of observable names on each backend. Herdr exposes three independent values: the visible pane label, its internal agent key, and the CLI session name. tmux exposes two: the `@agmsg_agent` pane option is the internal key, while the CLI owns `pane_title`, so there is no independent pane-label field after the CLI starts. `team.sh` reports that tmux field as `n/a` rather than treating an unavailable concept as a mismatch.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -99,8 +99,11 @@ If argument starts with "team list" (e.g. "team list", "team list --json", "team
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/team-list.sh <the rest of the args after "team list", unchanged>`
 2. This is a distinct command from bare "team" below — check for "team list" FIRST so "list" is never mistaken for a team name.
 
-If argument is "team", "team --json", or "team --fix":
-1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM [--json|--fix]`, preserving the option when present. `--json` returns every observed field; `--fix` repairs writable identity mismatches and reports changed, skipped, and failed actions.
+If argument is "team", "team --json", "team --fix", "team --fix-pane-names", or "team --rename-sessions":
+1. For each TEAM, run: `~/.agents/skills/__SKILL_NAME__/scripts/team.sh $TEAM [--json|--fix|--fix-pane-names|--rename-sessions]`, preserving the option when present. `--json` returns every observed field. The repair flags report changed, skipped, and failed actions per identity cell:
+   - `--fix-pane-names` repairs the pane label and agent key through the terminal's own API. It never types into a session.
+   - `--rename-sessions` repairs the CLI session name by **typing** the type's rename command (e.g. `/rename <team>-<agent>`) into each session whose name mismatches, is renamable, and is at a prompt; reported as `changed`, `poked_unverified`, `skipped`, or `failed`.
+   - `--fix` does both, unconditionally, including the keystroke.
 
 If argument starts with "send" (e.g. "send misaki check the server"):
 1. Parse target agent and message from the arguments

--- a/scripts/lib/team-status.sh
+++ b/scripts/lib/team-status.sh
@@ -109,10 +109,21 @@ EOF
 # Each field gets an explicit changed/skipped/failed action; no write is
 # attempted unless its observed cell is a mismatch, and CLI input additionally
 # requires a positive readiness proof.
-agmsg_team_fix_identity_loaded() {
+#
+# Two halves, because they are two kinds of act (#1110): the pane names (label
+# and key) are attributes written through the terminal's own API; the CLI
+# session name is repaired by TYPING a rename command into the pane. The halves
+# are separable work and a caller may want only one -- so each is its own
+# function, and `agmsg_team_fix_identity_loaded` is their union. The pane-names
+# half never calls terminal_poke; that is its contract, not an accident of the
+# cells it is handed.
+
+# <team> <agent> <type> <terminal> <pane> <pane_cell> <key_cell>
+#   -> pane_label and agent_key actions. Never types into the pane.
+agmsg_team_fix_pane_names_loaded() {
   local team="$1" agent="$2" type="$3" terminal="$4" pane="$5"
-  local pane_cell="$6" key_cell="$7" session_cell="$8"
-  local expected_session="$team-$agent" readiness state reason rc=0 observed title tries
+  local pane_cell="$6" key_cell="$7"
+  local reason rc=0
 
   case "$pane_cell" in
     mismatch\(*)
@@ -150,6 +161,19 @@ agmsg_team_fix_identity_loaded() {
     n/a:*) _agmsg_team_fix_result agent_key skipped "${key_cell#n/a:}" ;;
     *) _agmsg_team_fix_result agent_key skipped "${key_cell#unknown:}" ;;
   esac
+}
+
+# <team> <agent> <type> <terminal> <pane> <session_cell>
+#   -> the cli_session action. This is the half that TYPES into the pane
+#   (`<rename_cmd> <team>-<agent>`), behind three gates: the cell is a mismatch,
+#   the type declares a rename command, and the pane reports ready.
+agmsg_team_rename_session_loaded() {
+  # $4 (terminal) is accepted for a signature parallel to the pane-names half;
+  # the rename goes through the loaded driver's terminal_poke and needs no name.
+  local team="$1" agent="$2" type="$3" pane="$5"
+  local session_cell="$6"
+  local expected_session="$team-$agent" readiness state reason rc=0 observed title tries
+  local rename_cmd session_src
 
   case "$session_cell" in
     mismatch\(*)
@@ -200,6 +224,13 @@ EOF
     n/a:*) _agmsg_team_fix_result cli_session skipped "${session_cell#n/a:}" ;;
     *) _agmsg_team_fix_result cli_session skipped "${session_cell#unknown:}" ;;
   esac
+}
+
+# <team> <agent> <type> <terminal> <pane> <pane_cell> <key_cell> <session_cell>
+#   -> all three actions: the pane names, then the session rename (`team --fix`).
+agmsg_team_fix_identity_loaded() {
+  agmsg_team_fix_pane_names_loaded "$1" "$2" "$3" "$4" "$5" "$6" "$7"
+  agmsg_team_rename_session_loaded "$1" "$2" "$3" "$4" "$5" "$8"
 }
 
 agmsg_identity_cell() {

--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -4,20 +4,36 @@ set -euo pipefail
 # Usage: team.sh <team>
 # Shows team members.
 
-TEAM="${1:?Usage: team.sh <team> [--json] [--fix]}"
+USAGE='Usage: team.sh <team> [--json] [--fix | --fix-pane-names | --rename-sessions]
+  --fix              repair every identity cell: the pane names AND the CLI
+                     session name -- the latter by TYPING a rename command
+                     into the session
+  --fix-pane-names   repair the pane label and agent key only; never types
+                     into a session
+  --rename-sessions  repair the CLI session name only; TYPES the rename
+                     command into each session that is at a prompt'
+TEAM="${1:?$USAGE}"
 shift
 OUTPUT_MODE=human
-FIX=0
+# Two separable repairs (#1110): the pane names are written through the
+# terminal's API; the session name is typed into the session. --fix is the
+# unconditional umbrella and does both; the specific flags pick one half.
+FIX_PANE_NAMES=0
+FIX_SESSIONS=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --json) OUTPUT_MODE=json ;;
-    --fix) FIX=1 ;;
-    *) echo "Usage: team.sh <team> [--json] [--fix]" >&2; exit 2 ;;
+    --fix) FIX_PANE_NAMES=1; FIX_SESSIONS=1 ;;
+    --fix-pane-names) FIX_PANE_NAMES=1 ;;
+    --rename-sessions) FIX_SESSIONS=1 ;;
+    *) echo "$USAGE" >&2; exit 2 ;;
   esac
   shift
 done
+FIX=0
+if [ "$FIX_PANE_NAMES" -eq 1 ] || [ "$FIX_SESSIONS" -eq 1 ]; then FIX=1; fi
 if [ "$FIX" -eq 1 ] && [ "$OUTPUT_MODE" = json ]; then
-  echo "Usage: team.sh <team> [--json] [--fix] (--json and --fix cannot be combined)" >&2
+  echo "Usage: team.sh <team> [--json] [--fix | --fix-pane-names | --rename-sessions] (--json and a repair flag cannot be combined)" >&2
   exit 2
 fi
 
@@ -114,10 +130,16 @@ $actions
 EOF
 }
 
+# The skipped lines for a member no repair can reach -- only the cells the
+# requested flags cover, so the report never mentions a cell it was not asked
+# to touch.
 _emit_unfixable_actions() {
-  local reason="$1"
+  local reason="$1" actions=""
   [ "$FIX" -eq 1 ] || return 0
-  _emit_fix_actions "$(printf 'pane_label\tskipped\t%s\nagent_key\tskipped\t%s\ncli_session\tskipped\t%s\n' "$reason" "$reason" "$reason")"
+  [ "$FIX_PANE_NAMES" -eq 1 ] && actions="$(printf 'pane_label\tskipped\t%s\nagent_key\tskipped\t%s\n' "$reason" "$reason")"
+  [ "$FIX_SESSIONS" -eq 1 ] && actions="${actions:+$actions
+}$(printf 'cli_session\tskipped\t%s\n' "$reason")"
+  _emit_fix_actions "$actions"
 }
 
 _member_status() {
@@ -179,8 +201,17 @@ EOF
 $identity
 EOF
     if [ "$FIX" -eq 1 ]; then
-      fix_actions="$(agmsg_team_fix_identity_loaded "$team" "$agent" "$type" "$terminal" "$pane" \
-        "$pane_label" "$agent_key" "$cli_session")"
+      # Each half only when its flag asked for it. The pane-names half never
+      # types into the pane; the session half is the one that does (#1110).
+      fix_actions=""
+      if [ "$FIX_PANE_NAMES" -eq 1 ]; then
+        fix_actions="$(agmsg_team_fix_pane_names_loaded "$team" "$agent" "$type" "$terminal" "$pane" \
+          "$pane_label" "$agent_key")"
+      fi
+      if [ "$FIX_SESSIONS" -eq 1 ]; then
+        fix_actions="${fix_actions:+$fix_actions
+}$(agmsg_team_rename_session_loaded "$team" "$agent" "$type" "$terminal" "$pane" "$cli_session")"
+      fi
       identity="$(agmsg_team_identity_loaded "$team" "$agent" "$type" "$terminal" "$pane")"
       IFS="$(printf '\t')" read -r activity _actual_label _expected_label _actual_key _expected_key _actual_session _expected_session pane_label agent_key cli_session consistency <<EOF
 $identity

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -965,3 +965,107 @@ JSON
   [[ "$output" == *"1 member(s)"* ]]
   [[ "$output" != *"no local registration"* ]]
 }
+
+# --- #1110: team --fix / --fix-pane-names / --rename-sessions -----------------------
+#
+# Two members on herdr, every identity cell mismatching, both panes ready. A fake
+# herdr on PATH logs EVERY call, so "nothing was typed into any pane" is a fact
+# about the log (no `agent prompt` line for any pane id), not about a label.
+
+_install_team_fix_fixture() {   # two claude-code members placed on herdr panes
+  export TEAM_HERDR_LOG="$BATS_TEST_TMPDIR/herdr.log"; : > "$TEAM_HERDR_LOG"
+  local bin="$BATS_TEST_TMPDIR/bin"; mkdir -p "$bin"
+  cat > "$bin/herdr" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$TEAM_HERDR_LOG"
+case "\$1/\$2" in
+  pane/get)   printf '{"result":{"pane":{"pane_id":"%s","label":"wrong","agent_status":"idle","terminal_title":"✳ wrong"}}}\n' "\$3" ;;
+  agent/list) echo '{"result":{"agents":[{"pane_id":"w1:p1","name":"old"},{"pane_id":"w1:p2","name":"old"}]}}' ;;
+  agent/get)  echo '{"result":{"agent":{"agent":"claude","agent_status":"idle"}}}' ;;
+  *)          echo '{"result":{"type":"ok"}}' ;;
+esac
+STUB
+  chmod +x "$bin/herdr"
+  export PATH="$bin:$PATH"
+  bash "$SCRIPTS/join.sh" fixteam alice claude-code /tmp/proj >/dev/null
+  bash "$SCRIPTS/join.sh" fixteam bob claude-code /tmp/proj >/dev/null
+  local rec
+  rec="$(SKILL_DIR="$TEST_SKILL_DIR" bash -c 'cd "$1" && . lib/actas-lock.sh && . lib/terminal-registry.sh && agmsg_spawn_path fixteam alice' _ "$SCRIPTS")"
+  mkdir -p "$(dirname "$rec")"
+  printf 'herdr:w1:p1\t-\t-\n' > "$rec"
+  rec="$(SKILL_DIR="$TEST_SKILL_DIR" bash -c 'cd "$1" && . lib/actas-lock.sh && . lib/terminal-registry.sh && agmsg_spawn_path fixteam bob' _ "$SCRIPTS")"
+  printf 'herdr:w1:p2\t-\t-\n' > "$rec"
+}
+
+@test "team --fix-pane-names types into no pane, and writes both names on both panes (#1110)" {
+  _install_team_fix_fixture
+  run bash "$SCRIPTS/team.sh" fixteam --fix-pane-names
+  [ "$status" -eq 0 ]
+  # The fake saw the observation calls (the log is live) ...
+  grep -q '^pane get w1:p1$' "$TEAM_HERDR_LOG"
+  grep -q '^pane get w1:p2$' "$TEAM_HERDR_LOG"
+  # ... the name writes for both panes ...
+  grep -q '^agent rename w1:p1 ' "$TEAM_HERDR_LOG"
+  grep -q '^agent rename w1:p2 ' "$TEAM_HERDR_LOG"
+  grep -q '^pane rename w1:p1 fixteam:alice$' "$TEAM_HERDR_LOG"
+  grep -q '^pane rename w1:p2 fixteam:bob$' "$TEAM_HERDR_LOG"
+  # ... and NOT ONE keystroke, into any pane.
+  refute grep -q '^agent prompt ' "$TEAM_HERDR_LOG"
+  # The report names only the cells this flag covers.
+  printf '%s\n' "$output" | grep -q 'fix.pane_label='
+  printf '%s\n' "$output" | grep -q 'fix.agent_key='
+  refute grep -q 'fix.cli_session=' <<<"$output"
+}
+
+@test "team --rename-sessions types the rename into each ready pane and writes no name (#1110)" {
+  _install_team_fix_fixture
+  run bash "$SCRIPTS/team.sh" fixteam --rename-sessions
+  [ "$status" -eq 0 ]
+  grep -q '^agent prompt w1:p1 /rename fixteam-alice$' "$TEAM_HERDR_LOG"
+  grep -q '^agent prompt w1:p2 /rename fixteam-bob$' "$TEAM_HERDR_LOG"
+  refute grep -qE '^(agent|pane) rename ' "$TEAM_HERDR_LOG"
+  printf '%s\n' "$output" | grep -q 'fix.cli_session='
+  refute grep -qE 'fix.(pane_label|agent_key)=' <<<"$output"
+}
+
+@test "team --fix does both, and the report says which cell each result belongs to (#1110)" {
+  _install_team_fix_fixture
+  run bash "$SCRIPTS/team.sh" fixteam --fix
+  [ "$status" -eq 0 ]
+  grep -q '^agent rename w1:p1 ' "$TEAM_HERDR_LOG"
+  grep -q '^pane rename w1:p2 fixteam:bob$' "$TEAM_HERDR_LOG"
+  grep -q '^agent prompt w1:p1 /rename fixteam-alice$' "$TEAM_HERDR_LOG"
+  grep -q '^agent prompt w1:p2 /rename fixteam-bob$' "$TEAM_HERDR_LOG"
+  # One line per cell per member, each naming its cell.
+  [ "$(grep -c 'fix.pane_label=' <<<"$output")" -eq 2 ]
+  [ "$(grep -c 'fix.agent_key=' <<<"$output")" -eq 2 ]
+  [ "$(grep -c 'fix.cli_session=' <<<"$output")" -eq 2 ]
+}
+
+@test "team: the skipped report covers only the requested cells (#1110)" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj
+  run bash "$SCRIPTS/team.sh" myteam --fix-pane-names
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qF 'fix.pane_label=skipped(reason=no_placement_record)'
+  printf '%s\n' "$output" | grep -qF 'fix.agent_key=skipped(reason=no_placement_record)'
+  refute grep -qF 'fix.cli_session=' <<<"$output"
+  run bash "$SCRIPTS/team.sh" myteam --rename-sessions
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qF 'fix.cli_session=skipped(reason=no_placement_record)'
+  refute grep -qE 'fix.(pane_label|agent_key)=' <<<"$output"
+}
+
+@test "team: --json refuses every repair flag, and the usage says which one types (#1110)" {
+  bash "$SCRIPTS/join.sh" myteam alice claude-code /tmp/proj
+  run bash "$SCRIPTS/team.sh" myteam --json --fix-pane-names
+  [ "$status" -eq 2 ]
+  printf '%s\n' "$output" | grep -qF 'cannot be combined'
+  run bash "$SCRIPTS/team.sh" myteam --json --rename-sessions
+  [ "$status" -eq 2 ]
+  printf '%s\n' "$output" | grep -qF 'cannot be combined'
+  run bash "$SCRIPTS/team.sh" myteam --bogus
+  [ "$status" -eq 2 ]
+  printf '%s\n' "$output" | grep -q -- '--fix-pane-names'
+  printf '%s\n' "$output" | grep -q -- '--rename-sessions'
+  printf '%s\n' "$output" | grep -qi 'typ'
+}

--- a/tests/test_team_status.bats
+++ b/tests/test_team_status.bats
@@ -574,3 +574,45 @@ _herdr_observe_stub() {   # <entries-json>
   [ "$status" -eq 10 ]
   refute grep -q 'absent:' <<<"$output"
 }
+
+# --- #1110: the two halves of the repair are two kinds of act -----------------------
+#
+# The pane names are written through the terminal's API; the session name is
+# TYPED into the pane. Each half is its own function, and the pane-names half
+# must never call terminal_poke -- asserted on the poke fake, not on the cells.
+
+@test "pane-names repair never pokes, even with every cell mismatching and the pane ready" {
+  agmsg_type_get() { case "$2" in cli) printf 'claude\n';; rename_cmd) printf '/rename\n';; session_name_source) printf 'title\n';; esac; }
+  _herdr_internal_key() { printf 'a123\n'; }
+  terminal_name() { printf '%s\n' "$4" >> "$BATS_TEST_TMPDIR/names"; }
+  terminal_team_input_ready() { printf 'ready\n'; }
+  terminal_poke() { printf 'called %s\n' "$*" >> "$BATS_TEST_TMPDIR/poke"; }
+  terminal_team_observe() { printf 'idle\tteam:alice\ta123\t✳ team-alice\n'; }
+  run agmsg_team_fix_pane_names_loaded team alice claude-code herdr w2:p3 \
+    'mismatch(expected=team:alice,actual=alice)' \
+    'mismatch(expected=a123,actual=old)'
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = $'pane_label\tchanged\trenamed_and_verified' ]
+  [ "${lines[1]}" = $'agent_key\tchanged\trenamed_and_verified' ]
+  # The names were written (two terminal_name calls: the label call logs an
+  # empty mode, the key call logs "key") and nothing was typed.
+  [ "$(wc -l < "$BATS_TEST_TMPDIR/names")" -eq 2 ]
+  grep -qx key "$BATS_TEST_TMPDIR/names"
+  [ ! -e "$BATS_TEST_TMPDIR/poke" ]
+}
+
+@test "session rename does only the session: one poke, no name write" {
+  agmsg_type_get() { case "$2" in cli) printf 'claude\n';; rename_cmd) printf '/rename\n';; session_name_source) printf 'title\n';; esac; }
+  terminal_name() { printf 'called\n' >> "$BATS_TEST_TMPDIR/names"; }
+  terminal_team_input_ready() { printf 'ready\n'; }
+  terminal_poke() { printf '%s\n' "$2" > "$BATS_TEST_TMPDIR/poke"; }
+  terminal_team_observe() { printf 'idle\tteam:alice\ta123\t✳ team-alice\n'; }
+  run agmsg_team_rename_session_loaded team alice claude-code herdr w2:p3 \
+    'mismatch(expected=team-alice,actual=alice)'
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = $'cli_session\tchanged\trenamed_and_verified' ]
+  [ "$(< "$BATS_TEST_TMPDIR/poke")" = '/rename team-alice' ]
+  [ ! -e "$BATS_TEST_TMPDIR/names" ]
+}

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -240,8 +240,12 @@ EOF
   grep -qxF 'claude-code' <<<"$renderable_types"
   while IFS= read -r type; do
     template="$(render_type "$type")"
-    grep -Fq '"team --json", or "team --fix"' "$template"
-    grep -Fq 'team.sh $TEAM [--json|--fix]' "$template"
+    grep -Fq '"team --json", "team --fix", "team --fix-pane-names", or "team --rename-sessions"' "$template"
+    grep -Fq 'team.sh $TEAM [--json|--fix|--fix-pane-names|--rename-sessions]' "$template"
+    # The flag list itself says which repair types into a session (#1110).
+    grep -Fq -- '--fix-pane-names' "$template"
+    grep -Fq -- '--rename-sessions' "$template"
+    grep -Fiq 'types' "$template"
   done <<<"$renderable_types"
 }
 


### PR DESCRIPTION
Fixes #1110.

## Shape

```
team --fix                everything, unconditionally -- including the keystroke
team --fix-pane-names     the pane naming only -- never types into a session
team --rename-sessions    the session name -- types the rename command into the pane
```

`--fix` stays the umbrella. The two specific flags exist because the halves are separable work and sometimes only one is wanted, and so the report can say which of the two happened. Names as decided on the issue: not `--fix-agent-id` (the separate key exists on herdr only), not `--fix-pane-id` (the one thing this never changes); `--fix-pane-names` is true on both drivers.

## Change

- **`scripts/lib/team-status.sh`** — the repair is two functions. `agmsg_team_fix_pane_names_loaded` handles the pane label and agent key and never calls `terminal_poke`; that is its contract. `agmsg_team_rename_session_loaded` handles the CLI session name and is the half that types, behind the three gates that were already there (the cell is a mismatch, the type declares a rename command, the pane reports ready). `agmsg_team_fix_identity_loaded` is now their union, so every existing caller and test keeps its eight-argument contract.
- **`scripts/team.sh`** — parses the three flags; `--fix` sets both halves, the specific flags one each, and `--fix-pane-names --rename-sessions` equals `--fix`. Each half runs only when asked for. The per-member report prints only the cells the flags cover, including the `skipped` lines for members no repair can reach. `--json` still refuses any repair flag. The usage text says which flag types into a session.
- **`SKILL.md`, `README.md`** — the flag list says the same, so a reader does not have to open the source to learn that one of these types.

## Tests

- `tests/test_team.bats` — a fake herdr on PATH logs every call. Two members on herdr panes with every identity cell mismatching and both panes ready:
  - `--fix-pane-names`: `agent rename` and `pane rename` for both panes, and **no `agent prompt` line for any pane** — the assertion is on the call log, not on a label. The report has `pane_label` and `agent_key` lines and no `cli_session` line.
  - `--rename-sessions`: `agent prompt <pane> /rename <team>-<member>` for both, no name write, only `cli_session` lines.
  - `--fix`: both, and exactly one line per cell per member.
  - The skipped report covers only the requested cells; `--json` refuses each flag; an unknown flag prints a usage that names both new flags and the word "types".
  - Mutation: routing `--fix-pane-names` through the union turns the "no pane typed" test red (an `agent prompt` line appears) and the `--fix` line count red.
- `tests/test_team_status.bats` — the pane-names half with every cell mismatching and a ready pane makes two name writes and no poke; the session half makes one poke and no name write. The existing three-cell test of the union is unchanged.
- `tests/test_type_registry.bats` — every rendered agent template carries the three flags and says one types.

Checkers: `check-enforced-assertions` 626 at baseline 626, `check-errexit-status-reads` 0 at baseline 0, shellcheck 0.10.0 on the two touched scripts 1 finding before and after (pre-existing).

Touched files ran green: `test_team.bats` 87, `test_team_status.bats` 45, `test_type_registry.bats` 29.
