### PR TITLE
fix(self-name): a seat does not take a pane another seat's record already claims

### DIFF
--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -559,6 +559,43 @@ agmsg_terminal_ref_id() {
 # placement over.
 #
 #   agmsg_terminal_name_self <session_id> <team> <agent> <project> <type> [record]
+# Which OTHER seat's placement record already claims this pane reference, if any.
+# Prints "<team>__<agent>" as the record file spells it (percent-encoded, the form
+# on disk) and nothing when the pane is unclaimed.
+#
+# STOP-GAP (#1113). Delete this and its caller when #1112 lands.
+#
+# Since #1111 a seat records its own placement when it acts, resolving the pane
+# from its OWN environment. For codex that environment is not its own: those
+# seats arrive through one shared app-server daemon, so every seat under it
+# inherits the daemon's pane (measured: three codex seats all resolve
+# herdr:w1:p2, while they actually sit at w1:p2, w1:pN and w1:pP). Their records
+# are correct today only because spawn wrote them from outside; the next action
+# each one takes overwrites its own record with the daemon's pane, one seat at a
+# time.
+#
+# So until the environment is fixed, a seat does not take a pane another seat's
+# record already claims. This is first-writer-wins, which is NOT always right --
+# a stale record from a dead seat will squat a pane that a live seat has taken
+# over. That is why it is a stop-gap and not the fix: #1112 makes the resolution
+# correct, and then nothing needs to arbitrate.
+_agmsg_placement_claimed_by() {   # <ref> <this-seat's-record-path>
+  local ref="$1" mine="$2" dir f first
+  [ -n "$ref" ] || return 0
+  dir="$(dirname "$mine")"
+  [ -d "$dir" ] || return 0
+  for f in "$dir"/spawn.*; do
+    [ -f "$f" ] || continue
+    [ "$f" = "$mine" ] && continue
+    IFS="$(printf '\t')" read -r first _ < "$f" 2>/dev/null || continue
+    if [ "$first" = "$ref" ]; then
+      printf '%s' "${f##*/spawn.}"
+      return 0
+    fi
+  done
+  return 0
+}
+
 agmsg_terminal_name_self() {
   local sid="${1:-}" team="${2:-}" agent="${3:-}" project="${4:-}" type="${5:-}"
   local write_record="${6:-}"
@@ -705,6 +742,19 @@ agmsg_terminal_name_self() {
   [ "$rc" -eq 0 ] && [ -n "$rec" ] && [ -n "$ref" ] || {
     echo "agmsg: named the pane but could not build its record path" >&2; return 1
   }
+  # STOP-GAP (#1113, remove with #1112): do not take a pane another seat's record
+  # already claims. Naming SUCCEEDED -- the pane carries this seat's label -- so
+  # this returns 0; what is declined is the placement CLAIM, and the reason is
+  # said out loud rather than the write silently not happening. Without this, the
+  # first codex seat to act overwrites its own correct record with the shared
+  # daemon's pane, and the next one overwrites that.
+  local _claimed_by=""
+  _claimed_by="$(_agmsg_placement_claimed_by "$ref" "$rec")"
+  if [ -n "$_claimed_by" ]; then
+    echo "agmsg: named the pane but did NOT record it: this seat resolved $ref, and that pane is already recorded as $_claimed_by's. Keeping the existing record. (#1113 stop-gap for the shared-environment resolution #1112 fixes.)" >&2
+    return 0
+  fi
+
   mkdir -p "$(dirname "$rec")" 2>/dev/null || true
   # Atomic (temp + rename): a failed write must not truncate a correct existing
   # record. agmsg_write_atomic adds the trailing newline, so pass the row without.

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2069,3 +2069,86 @@ _tmux_op_args() {
     [ -z "$output" ]    || { echo "FAIL: printed '$output'"; return 1; }
   done
 }
+
+# --- #1113 stop-gap: a seat does not take a pane another seat already records ---
+#
+# Both directions, because the guard is only worth anything if it also gets out
+# of the way. Delete these two with the guard when #1112 lands.
+
+@test "terminal_name_self record: refuses a pane ANOTHER seat's record already claims (#1113)" {
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+
+  # A peer already records the very pane this seat is about to resolve. That is
+  # the codex shape: three seats inherit one daemon's environment, so all three
+  # resolve the same pane and each overwrite would take it from the last.
+  local peer; peer="$(agmsg_spawn_path seatteam peer)"
+  mkdir -p "$(dirname "$peer")"
+  # The ref carries the socket (#1051), so the fixture has to spell it the way
+  # resolution does -- `tmux:%1` claims a DIFFERENT pane and the guard would
+  # correctly not fire. (Measured: the first version of this test wrote the
+  # short form and passed for the wrong reason.)
+  printf 'tmux:/tmp/fake:%%1\t/proj/PEER\tclaude-code\n' > "$peer"
+  local peer_snapshot="$BATS_TEST_TMPDIR/peer.snapshot"
+  cp "$peer" "$peer_snapshot"
+
+  local mine; mine="$(agmsg_spawn_path seatteam taker)"
+  refute test -e "$mine"
+
+  run agmsg_terminal_name_self "" seatteam taker /proj/MINE claude-code record
+  # Naming succeeded; only the placement CLAIM was declined, so this is 0.
+  [ "$status" -eq 0 ]
+
+  # Positive control: the pane really was named, so the assertions below are not
+  # green because the call did nothing.
+  grep -q '\[select-pane\]' "$ARGV_LOG" || grep -q '\[set-option\]' "$ARGV_LOG"
+
+  # The reason is said, not swallowed -- and it names both sides.
+  grep -q 'did NOT record it' <<<"$output"
+  grep -q 'tmux:/tmp/fake:%1' <<<"$output"
+
+  # Nothing was taken and nothing was invented.
+  cmp -s "$peer" "$peer_snapshot"
+  refute test -e "$mine"
+}
+
+@test "terminal_name_self record: still records when no other seat claims the pane (#1113)" {
+  # The partner. Without it, a guard that refused every write would pass the test
+  # above, and #1111 -- the reason placement is recorded at all -- would be dead.
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+
+  # A peer exists, but on a DIFFERENT pane: the directory is not empty, so this
+  # also shows the scan distinguishes panes rather than merely finding files.
+  local peer; peer="$(agmsg_spawn_path seatteam elsewhere)"
+  mkdir -p "$(dirname "$peer")"
+  printf 'tmux:/tmp/fake:%%OTHER\t/proj/PEER\tclaude-code\n' > "$peer"
+
+  local mine; mine="$(agmsg_spawn_path seatteam writer)"
+  run agmsg_terminal_name_self "" seatteam writer /proj/MINE claude-code record
+  [ "$status" -eq 0 ]
+  refute grep -q 'did NOT record it' <<<"$output"
+  grep -q '^tmux:/tmp/fake:%1	/proj/MINE	claude-code$' "$mine"
+}
+
+@test "terminal_name_self record: re-recording its OWN pane is not a conflict (#1113)" {
+  # The seat's own record names the same pane. The scan must skip the seat's own
+  # file, or every seat would refuse to refresh itself after the first write.
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+
+  local mine; mine="$(agmsg_spawn_path seatteam again)"
+  mkdir -p "$(dirname "$mine")"
+  printf 'tmux:/tmp/fake:%%1\t/proj/OLD\tclaude-code\n' > "$mine"
+
+  run agmsg_terminal_name_self "" seatteam again /proj/NEW claude-code record
+  [ "$status" -eq 0 ]
+  refute grep -q 'did NOT record it' <<<"$output"
+  grep -q '^tmux:/tmp/fake:%1	/proj/NEW	claude-code$' "$mine"
+}


### PR DESCRIPTION
**STOP-GAP.** #1112 is the fix; this stops correct records being destroyed while
it is written, and goes away with it.

## What is happening now

Since #1111 a seat records its own placement when it acts, resolving the pane
from its own environment. For codex seats that environment is not their own:
they arrive through one shared app-server daemon, so each inherits the daemon's
pane.

Measured on the live team — three codex seats all resolve `herdr:w1:p2` while
they actually sit at `w1:p2`, `w1:pN` and `w1:pP`, and one of them wrote
`w1:p2` into its own record within a second of its first send. Their records are
correct right now only because spawn wrote them from outside; **the next action
each seat takes replaces its own correct record with the daemon's pane, one seat
at a time.**

## What this does

The placement write refuses a pane reference that another seat's record already
claims, and says which seat:

```
agmsg: named the pane but did NOT record it: this seat resolved <ref>, and
that pane is already recorded as <seat>'s. Keeping the existing record.
```

Three things it deliberately does **not** do:

- **It does not fail.** Naming succeeded — the pane carries this seat's label —
  and only the placement *claim* is declined, so the call still returns 0.
- **It does not go quiet.** A write that silently does not happen is the shape
  this repository spent the day removing.
- **It does not touch the seat's own record.** The scan skips it, or every seat
  would refuse to refresh itself after its first write.

## Why it is a stop-gap and not the fix

It is first-writer-wins, which is not always right: a stale record left by a
dead seat will squat a pane a live seat has since taken over. #1112 makes the
resolution correct, and then nothing has to arbitrate. The comment on the helper
says so, so whoever lands #1112 knows this comes out with it.

## Tests

Both directions, plus the case that would freeze a seat solid:

| test | what it pins |
|---|---|
| refuses a pane another seat claims | the guard fires, and the reason names both sides |
| still records when nobody claims it | the guard gets out of the way — with a peer present on a **different** pane, so a guard that merely noticed a non-empty directory would fail here |
| re-recording its own pane is not a conflict | a seat can still refresh itself |

Mutations, each reddening the control that names it: removing the guard (1),
making it fire for every pane (1), dropping the skip of the seat's own record
(1), returning without saying why (1).

Measured: `test_terminal_registry` 118/0, `test_peek_poke` 36/0, `test_despawn`
18/0, `test_spawn` 108/0, `test_key` 38/0, both bats checkers at baseline.

One note on the tests: the first version of the conflict fixture wrote
`tmux:%1`, but a resolved ref carries the socket (`tmux:/tmp/fake:%1`, #1051),
so the peer was claiming a different pane, the guard correctly did not fire, and
the test looked like the guard was broken. The fixtures now spell the ref the
way resolution does.

Refs #1112
