### PR TITLE
fix(self-name): do not take a placement another seat already recorded

### DIFF
--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -705,6 +705,28 @@ agmsg_terminal_name_self() {
   [ "$rc" -eq 0 ] && [ -n "$rec" ] && [ -n "$ref" ] || {
     echo "agmsg: named the pane but could not build its record path" >&2; return 1
   }
+  # INTERIM (#1112). A process that resolved this pane from its own environment
+  # is not always in it: a codex session inherits its environment from a shared
+  # app-server daemon, so every seat under that daemon resolves the SAME pane --
+  # the one the daemon was started from. Measured: three seats in three panes,
+  # all three marks reading the same reference.
+  #
+  # Until that is fixed at the source, refuse to take a reference another seat's
+  # record already holds. This keeps a correct record (written by spawn, which
+  # knew the real pane) from being replaced by an inherited one. It is first-writer-
+  # wins, which is NOT always right -- a stale record can squat -- so this is a
+  # stop-gap and should be removed when #1112 makes the resolution trustworthy.
+  local _owner_rec _owner_ref _other
+  for _owner_rec in "$(dirname "$rec")"/spawn."${team}"__*; do
+    [ -f "$_owner_rec" ] || continue
+    [ "$_owner_rec" = "$rec" ] && continue
+    _owner_ref="$(head -1 "$_owner_rec" 2>/dev/null | cut -f1)" || continue
+    [ "$_owner_ref" = "$ref" ] || continue
+    _other="$(basename "$_owner_rec")"; _other="${_other#spawn."${team}"__}"
+    echo "agmsg: named the pane but did not record it: $ref is already recorded for '$_other' (#1112 -- an inherited environment can name a pane this process is not in)" >&2
+    return 0
+  done
+
   mkdir -p "$(dirname "$rec")" 2>/dev/null || true
   # Atomic (temp + rename): a failed write must not truncate a correct existing
   # record. agmsg_write_atomic adds the trailing newline, so pass the row without.

--- a/tests/test_self_name.bats
+++ b/tests/test_self_name.bats
@@ -91,6 +91,8 @@ _mark() {   # <team> <agent> -> "ref<TAB>epoch" or empty
 _placement() {   # <team> <agent> -> "<terminal>:<id>" or empty
   # shellcheck disable=SC1090
   source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/terminal-registry.sh"
   local rec r
   rec="$(agmsg_spawn_path "$1" "$2")" || return 0
   [ -f "$rec" ] || return 0
@@ -398,4 +400,52 @@ _placement() {   # <team> <agent> -> "<terminal>:<id>" or empty
   # Control: the same call with the switch at its default names once.
   agmsg_terminal_name_self_safe "sid-1" team alice /tmp/p claude-code
   [ "$(_name_calls)" -eq 1 ]
+}
+
+# INTERIM guard for #1112. A codex session inherits its environment from a shared
+# app-server daemon, so it resolves the pane that daemon was started from -- and
+# every seat under it resolves the SAME one. Measured: three seats in three panes,
+# all three marks reading one reference. Recording that replaces a correct
+# placement (written by spawn, which knew the real pane) with an inherited one.
+#
+# Three directions. Two of them pass on a guard that is always on or always off;
+# the third is the one that breaks a working seat, so it is not optional.
+
+@test "a seat does not take a placement another seat's record already holds (#1112)" {
+  _install_fake_herdr; _under_herdr w1:p2
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  local other; other="$(agmsg_spawn_path team seatA)"
+  mkdir -p "$(dirname "$other")"
+  printf 'herdr:w1:p2\t/proj\tcodex\n' > "$other"
+
+  agmsg_self_name_on_action team seatB /proj codex
+
+  [ ! -f "$(agmsg_spawn_path team seatB)" ]
+}
+
+@test "a seat does take a placement no other seat holds (#1112)" {
+  _install_fake_herdr; _under_herdr w1:pZ
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  local other; other="$(agmsg_spawn_path team seatA)"
+  mkdir -p "$(dirname "$other")"
+  printf 'herdr:w1:p2\t/proj\tcodex\n' > "$other"
+
+  agmsg_self_name_on_action team seatB /proj codex
+
+  grep -q 'herdr:w1:pZ' "$(agmsg_spawn_path team seatB)"
+}
+
+@test "a seat rewriting its own placement is not blocked by its own row (#1112)" {
+  _install_fake_herdr; _under_herdr w1:pQ
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  local mine; mine="$(agmsg_spawn_path team seatB)"
+  mkdir -p "$(dirname "$mine")"
+  printf 'herdr:w1:pQ\t/proj\tclaude-code\n' > "$mine"
+
+  agmsg_self_name_on_action team seatB /proj claude-code
+
+  grep -q 'herdr:w1:pQ' "$mine"
 }


### PR DESCRIPTION
Since #1111 a seat records its placement when it acts. That is right for a process whose environment describes the pane it is in, and wrong for one that inherited it — and a codex session inherits from a shared app-server daemon, so every seat under that daemon resolves the pane the daemon was started from.

Measured on three live seats:

```
seat        naming mark        actually in
agdev-co1   herdr:w1:p2        w1:p2
agdev-co2   herdr:w1:p2        w1:pN
agdev-co3   herdr:w1:p2        w1:pP
```

One answer, three panes. `agdev-co2` had no reference at all, was asked to run a single `send.sh`, and wrote `herdr:w1:p2` — a pane belonging to a different seat. The wrong value is produced on demand.

Those seats' placement records are currently *correct*, because `spawn` wrote them at launch from outside, knowing the real pane. The next action each one takes would replace a correct record with the inherited one. So this is not a latent problem: it consumes correct state as the seats work.

## What this does

Refuses to write a placement reference that another seat's record already holds, and says whose it is rather than declining quietly.

It is first-writer-wins. That is **not** always the right rule — a stale record can squat on a pane its seat has left, and this makes that squat permanent for as long as it stands. It is a stop-gap for #1112, where the resolution itself gets fixed, and the comment in the code says so with the issue number.

## Tests

Three, in three directions, because two of them pass on a guard that is always on or always off:

- another seat holds the reference → not recorded
- nobody holds it → recorded
- **the seat holds it itself** → recorded

The third is the one that breaks a working seat, and a guard that omits it blocks every seat from ever updating its own row. Removing the guard reddens only the first; the other two stay green, which is what makes them a control rather than decoration.

24/24 green on `tests/test_self_name.bats` locally.
