### PR TITLE
fix(team): print the usage block instead of passing it to ${1:?}

### DIFF
--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -12,7 +12,14 @@ USAGE='Usage: team.sh <team> [--json] [--fix | --fix-pane-names | --rename-sessi
                      into a session
   --rename-sessions  repair the CLI session name only; TYPES the rename
                      command into each session that is at a prompt'
-TEAM="${1:?$USAGE}"
+# Printed, not passed to ${1:?...}: the shell prefixes that form with its own
+# "line N: 1:" and renders the whole multi-line text as a single mangled line,
+# which is exactly the help for the options #1110 added.
+if [ $# -eq 0 ]; then
+  printf '%s\n' "$USAGE" >&2
+  exit 2
+fi
+TEAM="$1"
 shift
 OUTPUT_MODE=human
 # Two separable repairs (#1110): the pane names are written through the

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -1069,3 +1069,20 @@ STUB
   printf '%s\n' "$output" | grep -q -- '--rename-sessions'
   printf '%s\n' "$output" | grep -qi 'typ'
 }
+
+# The multi-line usage #1110 added must reach the user AS the block it is. Passing
+# it through `${1:?...}` makes the shell prefix it with its own "line N: 1:" and
+# collapse the block into one line, which is unreadable exactly where the reader
+# is trying to learn which option types into a pane. Asserted on the SHAPE (a
+# later line still starting its own line), not on one word: a check for the word
+# "--fix" alone passes on the mangled single line too.
+@test "team.sh with no argument prints the option block as separate lines" {
+  run bash "$SCRIPTS/team.sh"
+  [ "$status" -eq 2 ]
+  # The shell's own diagnostic prefix must not be there.
+  ! grep -q 'line [0-9]*: 1:' <<<"$output"
+  # Each option is on a line of its own, anchored at line start.
+  grep -qE '^Usage: team\.sh ' <<<"$output"
+  grep -qE '^  --fix-pane-names ' <<<"$output"
+  grep -qE '^  --rename-sessions ' <<<"$output"
+}

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -1079,8 +1079,10 @@ STUB
 @test "team.sh with no argument prints the option block as separate lines" {
   run bash "$SCRIPTS/team.sh"
   [ "$status" -eq 2 ]
-  # The shell's own diagnostic prefix must not be there.
-  ! grep -q 'line [0-9]*: 1:' <<<"$output"
+  # The shell's own diagnostic prefix must not be there. `refute`, not `! cmd`:
+  # a negated command cannot fail a bats test anywhere (#670), so `! grep -q`
+  # here would have asserted nothing at all.
+  refute grep -q 'line [0-9]*: 1:' <<<"$output"
   # Each option is on a line of its own, anchored at line start.
   grep -qE '^Usage: team\.sh ' <<<"$output"
   grep -qE '^  --fix-pane-names ' <<<"$output"


### PR DESCRIPTION
The option help added in #1110 is a multi-line block. Passed as the message of
`${1:?...}`, the shell prefixes it with its own `line N: 1:` and renders the whole
block as one line:

```
team.sh: line 15: 1: Usage: team.sh <team> [--json] [--fix | --fix-pane-names | --rename-sessions]   --fix repair every identity cell: the pane names AND the CLI session name -- the latter by TYPING a rename command into the session   --fix-pane-names repair ...
```

That is unreadable exactly where the reader is trying to learn which option types
into a pane, which is the distinction the three options exist to draw.

Print it and exit 2 — the status this script already uses for its other usage
error (an unrecognized option). The `${1:?}` form exited 1.

## Test

Asserted on the **shape**: a later option line still starting its own line, and
the absence of the shell's diagnostic prefix. A check for the word `--fix`
alone passes on the mangled single line too, so it would not have caught this.

Each assertion was confirmed to redden independently against the previous
version, measured on its actual output rather than inferred from bats stopping
at the first failure:

| assertion | previous version |
|---|---|
| exit status 2 | 1 |
| no `line N: 1:` prefix | 1 such line |
| `^  --fix-pane-names ` | 0 such lines |