### PR TITLE
fix(self-name): the placement guard sits before the rename and knows its own seat (#1114)

### DIFF
--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -566,11 +566,14 @@ agmsg_terminal_ref_id() {
 # STOP-GAP (#1114, guarding the regression #1111 exposed). Delete this and its
 # caller when #1112 lands.
 #
-# "Other seat" means another AGENT NAME, in any team. run/ is flat and one seat
-# registered in two teams has two records (spawn.<team1>__<x>, spawn.<team2>__<x>)
-# for the same pane; the second must not be blocked by the first, or a seat that
-# acts in its second team can never be recorded there (measured on this host,
-# where every seat is in two teams).
+# "Other seat" means a record that is not THIS agent's in any existing team.
+# run/ is flat and one seat registered in two teams has two records
+# (spawn.<team1>__<x>, spawn.<team2>__<x>) for the same pane; the second must not
+# be blocked by the first, or a seat that acts in its second team can never be
+# recorded there (measured on this host, where every seat is in two teams).
+# "This agent's" is decided by building the record path for each team on disk
+# with the same encoder and comparing whole file names -- "__" is legal inside
+# a name, so the file name cannot be cut at a separator.
 #
 # Since #1111 a seat records its own placement when it acts, resolving the pane
 # from its OWN environment. For codex that environment is not its own: those
@@ -621,23 +624,48 @@ _agmsg_placement_split() {   # <ref>
   return 0
 }
 
-_agmsg_placement_claimed_by() {   # <ref> <this-seat's-record-path>
-  local ref="$1" mine="$2" dir f first
-  [ -n "$ref" ] || return 0
+# <ref> <team> <agent>
+#   Prints the claimant as its record file spells it ("<team>__<agent>", encoded)
+#   when ANOTHER seat's record claims this pane; prints nothing when the pane is
+#   unclaimed. Returns 1 when this seat's OWN ref cannot be parsed: ownership is
+#   then undecidable and the caller must not name or record (fail-closed).
+_agmsg_placement_claimed_by() {
+  local ref="$1" team="$2" agent="$3" dir f first mine enc_agent t is_mine
+  local want_term want_id want_sock
+  _agmsg_placement_split "$ref" || return 1          # undecidable, not "unclaimed"
+  want_term="$_AGMSG_PS_TERM"; want_id="$_AGMSG_PS_ID"; want_sock="$_AGMSG_PS_SOCK"
+  mine="$(agmsg_spawn_path "$team" "$agent")" || return 1
   dir="$(dirname "$mine")"
   [ -d "$dir" ] || return 0
-  local want_term want_id want_sock
-  _agmsg_placement_split "$ref" || return 0
-  want_term="$_AGMSG_PS_TERM"; want_id="$_AGMSG_PS_ID"; want_sock="$_AGMSG_PS_SOCK"
+  enc_agent="$(_actas_lock_encode "$agent")"
   for f in "$dir"/spawn.*; do
     [ -f "$f" ] || continue
-    # This seat's own records -- its own file, and the same seat under another
-    # team: the agent part of the file name is the seat, the team part is which
-    # roster it acted in. Neither is a rival claim. One rule, so one seam.
-    [ "${f##*__}" = "${mine##*__}" ] && continue
-    IFS="$(printf '\t')" read -r first _ < "$f" 2>/dev/null || continue
-    [ -n "$first" ] || continue
-    _agmsg_placement_split "$first" || continue
+    [ "$f" = "$mine" ] && continue
+    # This seat under another team is not a rival. "This seat" is decided
+    # EXACTLY: the file equals this agent's record path for a team that exists
+    # on disk, spelled by the same encoder -- never by cutting the file name at
+    # a separator, because "__" is legal inside a name and cutting there made a
+    # peer called "foo__bar" look like "bar". The suffix test is only a cheap
+    # pre-filter before the exact comparison.
+    is_mine=0
+    case "$f" in
+      *"__$enc_agent")
+        for t in "$(dirname "$dir")"/teams/*/; do
+          [ -d "$t" ] || continue
+          t="${t%/}"; t="${t##*/}"
+          [ "$f" = "$(agmsg_spawn_path "$t" "$agent")" ] && { is_mine=1; break; }
+        done ;;
+    esac
+    [ "$is_mine" -eq 1 ] && continue
+    IFS="$(printf '\t')" read -r first _ < "$f" 2>/dev/null || first=""
+    # A record whose ref cannot be read as a pane -- empty, unreadable, or an
+    # unknown spelling -- cannot be ruled out as THIS pane, so it claims. Naming
+    # it lets a person drop it; waving it through is the fail-open this guard
+    # exists to close.
+    if [ -z "$first" ] || ! _agmsg_placement_split "$first"; then
+      printf '%s' "${f##*/spawn.}"
+      return 0
+    fi
     [ "$_AGMSG_PS_TERM" = "$want_term" ] || continue
     [ "$_AGMSG_PS_ID" = "$want_id" ] || continue
     # Same terminal, same pane id. The sockets decide whether that is the same
@@ -756,15 +784,18 @@ agmsg_terminal_name_self() {
     . "$SKILL_DIR/scripts/lib/actas-lock.sh" 2>/dev/null || true
   fi
   if declare -F agmsg_spawn_path >/dev/null 2>&1; then
-    local _claim_rec="" _claim_ref="" _claimed_by=""
-    _claim_rec="$(agmsg_spawn_path "$team" "$agent" 2>/dev/null)" || _claim_rec=""
+    local _claim_ref="" _claimed_by="" _claim_rc=0
     _claim_ref="$(agmsg_terminal_ref "$terminal" "$id" 2>/dev/null)" || _claim_ref=""
-    if [ -n "$_claim_rec" ] && [ -n "$_claim_ref" ]; then
-      _claimed_by="$(_agmsg_placement_claimed_by "$_claim_ref" "$_claim_rec")"
-      if [ -n "$_claimed_by" ]; then
-        echo "agmsg: did not name or record this pane: this seat resolved $_claim_ref, and that pane is already recorded as $_claimed_by's. Keeping that seat's name and record. If that seat is gone, drop or despawn it and act again. (#1114 stop-gap for the shared-environment resolution #1112 fixes.)" >&2
-        return 0
-      fi
+    # Undecidable (this seat's own ref cannot be parsed, or its record path
+    # cannot be built) is not "unclaimed": neither name nor record then.
+    _claimed_by="$(_agmsg_placement_claimed_by "$_claim_ref" "$team" "$agent")" || _claim_rc=$?
+    if [ "$_claim_rc" -ne 0 ]; then
+      echo "agmsg: did not name or record this pane: this seat's own reference ('$_claim_ref') cannot be read as a pane, so whether another seat holds it cannot be decided. (#1114 stop-gap for the shared-environment resolution #1112 fixes.)" >&2
+      return 0
+    fi
+    if [ -n "$_claimed_by" ]; then
+      echo "agmsg: did not name or record this pane: this seat resolved $_claim_ref, and that pane is already recorded as $_claimed_by's. Keeping that seat's name and record. If that seat is gone, drop or despawn it and act again. (#1114 stop-gap for the shared-environment resolution #1112 fixes.)" >&2
+      return 0
     fi
   fi
 

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -586,11 +586,49 @@ agmsg_terminal_ref_id() {
 # a stale record from a dead seat will squat a pane that a live seat has taken
 # over. That is why it is a stop-gap and not the fix: #1112 makes the resolution
 # correct, and then nothing needs to arbitrate.
+# Split a placement ref into terminal / pane id / socket, so two refs can be
+# compared as PANES rather than as strings. Sets _AGMSG_PS_TERM, _AGMSG_PS_ID and
+# _AGMSG_PS_SOCK (empty when the ref carries no socket); non-zero for a ref it
+# cannot parse.
+#
+# String equality is not enough: the record format still accepts the legacy
+# socket-less tmux forms (`%N`, `@N`) alongside `tmux:<socket>:%N` (see the
+# scheme comment above and agmsg_terminal_ref_terminal), so a peer record holding
+# `%1` never matches a freshly composed `tmux:/tmp/x:%1` -- and the guard waves
+# the write through for exactly the records most likely to be OLD, which are the
+# ones most likely to belong to somebody else.
+#
+# The scheme table below mirrors agmsg_terminal_ref_terminal / agmsg_terminal_ref_id
+# (inline, so the scan forks nothing per record); a test pins that the two agree
+# on every form the record format accepts.
+_agmsg_placement_split() {   # <ref>
+  local ref="$1" term id
+  _AGMSG_PS_TERM=""; _AGMSG_PS_ID=""; _AGMSG_PS_SOCK=""
+  case "$ref" in
+    tmux:*)  term=tmux;  id="${ref#tmux:}" ;;
+    herdr:*) term=herdr; id="${ref#herdr:}" ;;
+    plain:*) term=plain; id="${ref#plain:}" ;;
+    %*|@*)   term=tmux;  id="$ref" ;;        # legacy pre-axis bare tmux id
+    *)       return 1 ;;
+  esac
+  if [ "$term" = tmux ]; then
+    case "$id" in
+      *:*) _AGMSG_PS_SOCK="${id%:*}"; id="${id##*:}" ;;   # split on the LAST colon
+    esac
+  fi
+  [ -n "$id" ] || return 1
+  _AGMSG_PS_TERM="$term"; _AGMSG_PS_ID="$id"
+  return 0
+}
+
 _agmsg_placement_claimed_by() {   # <ref> <this-seat's-record-path>
   local ref="$1" mine="$2" dir f first
   [ -n "$ref" ] || return 0
   dir="$(dirname "$mine")"
   [ -d "$dir" ] || return 0
+  local want_term want_id want_sock
+  _agmsg_placement_split "$ref" || return 0
+  want_term="$_AGMSG_PS_TERM"; want_id="$_AGMSG_PS_ID"; want_sock="$_AGMSG_PS_SOCK"
   for f in "$dir"/spawn.*; do
     [ -f "$f" ] || continue
     # This seat's own records -- its own file, and the same seat under another
@@ -598,10 +636,22 @@ _agmsg_placement_claimed_by() {   # <ref> <this-seat's-record-path>
     # roster it acted in. Neither is a rival claim. One rule, so one seam.
     [ "${f##*__}" = "${mine##*__}" ] && continue
     IFS="$(printf '\t')" read -r first _ < "$f" 2>/dev/null || continue
-    if [ "$first" = "$ref" ]; then
-      printf '%s' "${f##*/spawn.}"
-      return 0
+    [ -n "$first" ] || continue
+    _agmsg_placement_split "$first" || continue
+    [ "$_AGMSG_PS_TERM" = "$want_term" ] || continue
+    [ "$_AGMSG_PS_ID" = "$want_id" ] || continue
+    # Same terminal, same pane id. The sockets decide whether that is the same
+    # PANE: a pane id is not unique across tmux servers (#1051). A record may be
+    # the legacy socket-less form, and an unknown server cannot be shown to be a
+    # DIFFERENT one -- so an unknown socket on either side counts as a claim.
+    # Refusing there costs one action; taking a pane that turns out to be
+    # someone's is the damage this guard exists to prevent.
+    if [ -n "$_AGMSG_PS_SOCK" ] && [ -n "$want_sock" ] \
+       && [ "$_AGMSG_PS_SOCK" != "$want_sock" ]; then
+      continue                                # different servers, different panes
     fi
+    printf '%s' "${f##*/spawn.}"
+    return 0
   done
   return 0
 }

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -573,7 +573,11 @@ agmsg_terminal_ref_id() {
 # recorded there (measured on this host, where every seat is in two teams).
 # "This agent's" is decided by building the record path for each team on disk
 # with the same encoder and comparing whole file names -- "__" is legal inside
-# a name, so the file name cannot be cut at a separator.
+# a name, so the file name cannot be cut at a separator. The one state this
+# cannot resolve: this agent's own record under a team that has since vanished
+# from teams/ -- no path can be built for it, so it reads as a rival and blocks
+# this seat (fail-closed). The refusal message says so and names the file to
+# remove; a team that is dropped with its run/ records left behind is that state.
 #
 # Since #1111 a seat records its own placement when it acts, resolving the pane
 # from its OWN environment. For codex that environment is not its own: those
@@ -751,21 +755,6 @@ agmsg_terminal_name_self() {
 
   agmsg_terminal_load "$terminal" || return 1
 
-  # AGMSG_TERMINAL_NAMING=off suppresses the VISIBLE label and nothing else. The
-  # key stays, always, because it is addressing rather than decoration — the name
-  # the TERMINAL knows the agent by, in its own namespace.
-  #
-  # Narrower than an earlier revision of this comment claimed, and the difference
-  # matters: `peek`, `poke` and `despawn` in THIS repo resolve through the
-  # placement record's pane id, and `_herdr_internal_key` is read nowhere outside
-  # its own driver (counted). So dropping the key does not make a member
-  # unreachable to agmsg. Saying it did pointed at the wrong thing to protect.
-  # A caller that genuinely wants no terminal writes at all is describing the
-  # `plain` terminal.
-  #
-  # The env var is read HERE and handed to the driver as a mode, so the policy
-  # has one home and each driver only carries it out. Read at call time, not
-  # cached: a value cached at source time is a value nobody can change.
   # STOP-GAP (#1114, remove with #1112): a pane another seat's record already
   # claims is not this seat's to NAME, MARK, or RECORD. The check sits here,
   # BEFORE the rename, because the rename is the act it exists to prevent: with
@@ -794,11 +783,34 @@ agmsg_terminal_name_self() {
       return 0
     fi
     if [ -n "$_claimed_by" ]; then
-      echo "agmsg: did not name or record this pane: this seat resolved $_claim_ref, and that pane is already recorded as $_claimed_by's. Keeping that seat's name and record. If that seat is gone, drop or despawn it and act again. (#1114 stop-gap for the shared-environment resolution #1112 fixes.)" >&2
+      # A claimant whose name ends in THIS seat's name may be this seat under a
+      # team no longer on disk (the exact rule cannot tell, and stays closed);
+      # the way out is then the file, not a seat.
+      local _self_hint=""
+      case "$_claimed_by" in
+        *"__$(_actas_lock_encode "$agent")")
+          _self_hint=" If '$_claimed_by' is this seat under a team that no longer exists, remove run/spawn.$_claimed_by." ;;
+      esac
+      echo "agmsg: did not name or record this pane: this seat resolved $_claim_ref, and that pane is already recorded as $_claimed_by's. Keeping that seat's name and record. If that seat is gone, drop or despawn it and act again.$_self_hint (#1114 stop-gap for the shared-environment resolution #1112 fixes.)" >&2
       return 0
     fi
   fi
 
+  # AGMSG_TERMINAL_NAMING=off suppresses the VISIBLE label and nothing else. The
+  # key stays, always, because it is addressing rather than decoration — the name
+  # the TERMINAL knows the agent by, in its own namespace.
+  #
+  # Narrower than an earlier revision of this comment claimed, and the difference
+  # matters: `peek`, `poke` and `despawn` in THIS repo resolve through the
+  # placement record's pane id, and `_herdr_internal_key` is read nowhere outside
+  # its own driver (counted). So dropping the key does not make a member
+  # unreachable to agmsg. Saying it did pointed at the wrong thing to protect.
+  # A caller that genuinely wants no terminal writes at all is describing the
+  # `plain` terminal.
+  #
+  # The env var is read HERE and handed to the driver as a mode, so the policy
+  # has one home and each driver only carries it out. Read at call time, not
+  # cached: a value cached at source time is a value nobody can change.
   local name_mode=""
   case "${AGMSG_TERMINAL_NAMING:-}" in
     off) name_mode=key ;;

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -563,7 +563,14 @@ agmsg_terminal_ref_id() {
 # Prints "<team>__<agent>" as the record file spells it (percent-encoded, the form
 # on disk) and nothing when the pane is unclaimed.
 #
-# STOP-GAP (#1113). Delete this and its caller when #1112 lands.
+# STOP-GAP (#1114, guarding the regression #1111 exposed). Delete this and its
+# caller when #1112 lands.
+#
+# "Other seat" means another AGENT NAME, in any team. run/ is flat and one seat
+# registered in two teams has two records (spawn.<team1>__<x>, spawn.<team2>__<x>)
+# for the same pane; the second must not be blocked by the first, or a seat that
+# acts in its second team can never be recorded there (measured on this host,
+# where every seat is in two teams).
 #
 # Since #1111 a seat records its own placement when it acts, resolving the pane
 # from its OWN environment. For codex that environment is not its own: those
@@ -586,7 +593,10 @@ _agmsg_placement_claimed_by() {   # <ref> <this-seat's-record-path>
   [ -d "$dir" ] || return 0
   for f in "$dir"/spawn.*; do
     [ -f "$f" ] || continue
-    [ "$f" = "$mine" ] && continue
+    # This seat's own records -- its own file, and the same seat under another
+    # team: the agent part of the file name is the seat, the team part is which
+    # roster it acted in. Neither is a rival claim. One rule, so one seam.
+    [ "${f##*__}" = "${mine##*__}" ] && continue
     IFS="$(printf '\t')" read -r first _ < "$f" 2>/dev/null || continue
     if [ "$first" = "$ref" ]; then
       printf '%s' "${f##*/spawn.}"
@@ -678,6 +688,36 @@ agmsg_terminal_name_self() {
   # The env var is read HERE and handed to the driver as a mode, so the policy
   # has one home and each driver only carries it out. Read at call time, not
   # cached: a value cached at source time is a value nobody can change.
+  # STOP-GAP (#1114, remove with #1112): a pane another seat's record already
+  # claims is not this seat's to NAME, MARK, or RECORD. The check sits here,
+  # BEFORE the rename, because the rename is the act it exists to prevent: with
+  # the shared-daemon environment #1112 describes, three codex seats resolve one
+  # pane, and a check placed after the rename let each of them relabel and rekey
+  # that pane (another seat's) and mark itself as named there, sparing only the
+  # record. The resolved reference is known now, so the decision is made now.
+  #
+  # The claim scan needs agmsg_spawn_path (actas-lock.sh). When it cannot be
+  # loaded the scan is skipped -- a caller that asked for `record` fails on that
+  # below, with its own message; a caller that did not is not blocked by a
+  # library it never needed.
+  if ! declare -F agmsg_spawn_path >/dev/null 2>&1 \
+     && [ -n "${SKILL_DIR:-}" ] && [ -r "$SKILL_DIR/scripts/lib/actas-lock.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$SKILL_DIR/scripts/lib/actas-lock.sh" 2>/dev/null || true
+  fi
+  if declare -F agmsg_spawn_path >/dev/null 2>&1; then
+    local _claim_rec="" _claim_ref="" _claimed_by=""
+    _claim_rec="$(agmsg_spawn_path "$team" "$agent" 2>/dev/null)" || _claim_rec=""
+    _claim_ref="$(agmsg_terminal_ref "$terminal" "$id" 2>/dev/null)" || _claim_ref=""
+    if [ -n "$_claim_rec" ] && [ -n "$_claim_ref" ]; then
+      _claimed_by="$(_agmsg_placement_claimed_by "$_claim_ref" "$_claim_rec")"
+      if [ -n "$_claimed_by" ]; then
+        echo "agmsg: did not name or record this pane: this seat resolved $_claim_ref, and that pane is already recorded as $_claimed_by's. Keeping that seat's name and record. If that seat is gone, drop or despawn it and act again. (#1114 stop-gap for the shared-environment resolution #1112 fixes.)" >&2
+        return 0
+      fi
+    fi
+  fi
+
   local name_mode=""
   case "${AGMSG_TERMINAL_NAMING:-}" in
     off) name_mode=key ;;
@@ -742,18 +782,8 @@ agmsg_terminal_name_self() {
   [ "$rc" -eq 0 ] && [ -n "$rec" ] && [ -n "$ref" ] || {
     echo "agmsg: named the pane but could not build its record path" >&2; return 1
   }
-  # STOP-GAP (#1113, remove with #1112): do not take a pane another seat's record
-  # already claims. Naming SUCCEEDED -- the pane carries this seat's label -- so
-  # this returns 0; what is declined is the placement CLAIM, and the reason is
-  # said out loud rather than the write silently not happening. Without this, the
-  # first codex seat to act overwrites its own correct record with the shared
-  # daemon's pane, and the next one overwrites that.
-  local _claimed_by=""
-  _claimed_by="$(_agmsg_placement_claimed_by "$ref" "$rec")"
-  if [ -n "$_claimed_by" ]; then
-    echo "agmsg: named the pane but did NOT record it: this seat resolved $ref, and that pane is already recorded as $_claimed_by's. Keeping the existing record. (#1113 stop-gap for the shared-environment resolution #1112 fixes.)" >&2
-    return 0
-  fi
+  # The claim check that used to sit here now sits BEFORE the rename (above):
+  # a claimed pane is neither named nor marked nor recorded.
 
   mkdir -p "$(dirname "$rec")" 2>/dev/null || true
   # Atomic (temp + rename): a failed write must not truncate a correct existing

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -563,8 +563,14 @@ agmsg_terminal_ref_id() {
 # Prints "<team>__<agent>" as the record file spells it (percent-encoded, the form
 # on disk) and nothing when the pane is unclaimed.
 #
-# STOP-GAP (#1114, guarding the regression #1111 exposed). Delete this and its
-# caller when #1112 lands.
+# PLACEMENT GUARD (#1114, guarding the regression #1111 exposed). Written as a
+# stop-gap for #1112; #1112 has landed and this stays as the SECOND line: label-
+# first resolution makes a wrong answer less likely, not impossible (a label can
+# be duplicated, cleared, or stale, and the environment fallback is still the
+# shared daemon's for codex), so a pane another seat's record already claims is
+# still refused here. Removing it is a separate decision, taken only when label
+# resolution is made authoritative; the seam tests pin the two mechanisms
+# together until then.
 #
 # "Other seat" means a record that is not THIS agent's in any existing team.
 # run/ is flat and one seat registered in two teams has two records
@@ -591,8 +597,10 @@ agmsg_terminal_ref_id() {
 # So until the environment is fixed, a seat does not take a pane another seat's
 # record already claims. This is first-writer-wins, which is NOT always right --
 # a stale record from a dead seat will squat a pane that a live seat has taken
-# over. That is why it is a stop-gap and not the fix: #1112 makes the resolution
-# correct, and then nothing needs to arbitrate.
+# over. #1112 (label-first resolution) is the fix for the shared environment,
+# and this guard is not replaced by it: a label makes a wrong answer less likely,
+# not impossible, so the arbitration stays. The cost of the squat is one action
+# and a message naming the file; the cost of no guard is another seat's pane.
 # Split a placement ref into terminal / pane id / socket, so two refs can be
 # compared as PANES rather than as strings. Sets _AGMSG_PS_TERM, _AGMSG_PS_ID and
 # _AGMSG_PS_SOCK (empty when the ref carries no socket); non-zero for a ref it
@@ -861,8 +869,9 @@ agmsg_terminal_name_self() {
 
   agmsg_terminal_load "$terminal" || return 1
 
-  # STOP-GAP (#1114, remove with #1112): a pane another seat's record already
-  # claims is not this seat's to NAME, MARK, or RECORD. The check sits here,
+  # PLACEMENT GUARD (#1114, kept alongside #1112's label-first resolution): a
+  # pane another seat's record already claims is not this seat's to NAME, MARK,
+  # or RECORD, whichever path resolved it. The check sits here,
   # BEFORE the rename, because the rename is the act it exists to prevent: with
   # the shared-daemon environment #1112 describes, three codex seats resolve one
   # pane, and a check placed after the rename let each of them relabel and rekey
@@ -885,7 +894,7 @@ agmsg_terminal_name_self() {
     # cannot be built) is not "unclaimed": neither name nor record then.
     _claimed_by="$(_agmsg_placement_claimed_by "$_claim_ref" "$team" "$agent")" || _claim_rc=$?
     if [ "$_claim_rc" -ne 0 ]; then
-      echo "agmsg: did not name or record this pane: this seat's own reference ('$_claim_ref') cannot be read as a pane, so whether another seat holds it cannot be decided. (#1114 stop-gap for the shared-environment resolution #1112 fixes.)" >&2
+      echo "agmsg: did not name or record this pane: this seat's own reference ('$_claim_ref') cannot be read as a pane, so whether another seat holds it cannot be decided. (#1114 placement guard, kept alongside #1112's label-first resolution.)" >&2
       return 0
     fi
     if [ -n "$_claimed_by" ]; then
@@ -897,7 +906,7 @@ agmsg_terminal_name_self() {
         *"__$(_actas_lock_encode "$agent")")
           _self_hint=" If '$_claimed_by' is this seat under a team that no longer exists, remove run/spawn.$_claimed_by." ;;
       esac
-      echo "agmsg: did not name or record this pane: this seat resolved $_claim_ref, and that pane is already recorded as $_claimed_by's. Keeping that seat's name and record. If that seat is gone, drop or despawn it and act again.$_self_hint (#1114 stop-gap for the shared-environment resolution #1112 fixes.)" >&2
+      echo "agmsg: did not name or record this pane: this seat resolved $_claim_ref, and that pane is already recorded as $_claimed_by's. Keeping that seat's name and record. If that seat is gone, drop or despawn it and act again.$_self_hint (#1114 placement guard, kept alongside #1112's label-first resolution.)" >&2
       return 0
     fi
   fi

--- a/tests/test_self_name.bats
+++ b/tests/test_self_name.bats
@@ -11,7 +11,9 @@
 #   - mark present, name gone, nothing else changed -> NOT seen (blind spot,
 #                                         pinned as such)
 #   - no mark                          -> named once, mark written
-#   - another seat in the same pane    -> names it for itself
+#   - another seat in the same pane    -> NOT taken while the first seat's record
+#                                         claims it (#1114 stop-gap; was "names it
+#                                         for itself" and returns to that with #1112)
 #   - order independence: a boot path first, then the action; the action
 #     first, then a boot path -- same key, one terminal call in total
 #   - herdr identifies its pane from HERDR_PANE_ID with no session id
@@ -153,16 +155,29 @@ _placement() {   # <team> <agent> -> "<terminal>:<id>" or empty
   grep -q 'BLIND SPOT' "$SKILL_DIR/scripts/lib/self-name.sh"
 }
 
-@test "another seat in the same pane names it for itself: its own record has no mark for that pane" {
+@test "another seat in the same pane does NOT take it while the first seat's record claims it (#1114 stop-gap)" {
+  # Before the #1114 stop-gap this test read "names it for itself": the second
+  # seat relabeled the pane and marked itself there. Under the stop-gap a pane
+  # another seat's record claims is neither named, marked, nor recorded -- that
+  # is the shape that stops co-located codex seats taking each other's pane, and
+  # a second role acting from the SAME pane is indistinguishable from it. The
+  # message says who holds the pane and how to release it (drop or despawn).
+  # Delete this test with the guard when #1112 lands and restore the old one.
   _install_fake_tmux; _under_tmux /tmp/s 4242 %3
   agmsg_self_name_on_action team alice
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
   : > "$ARGV_LOG"
-  agmsg_self_name_on_action team bob
-  [ "$(_name_calls)" -eq 1 ]
-  grep -q '\[@agmsg_agent\] \[team:bob\]' "$ARGV_LOG"
-  [ "$(_mark team bob)" = $'tmux:/tmp/s:%3\tpid=4242' ]
-  # alice's mark still names %3; when alice acts from elsewhere she is renamed there.
+  run agmsg_self_name_on_action team bob
+  [ "$status" -eq 0 ]
+  [ "$(_name_calls)" -eq 0 ]
+  refute grep -q '\[team:bob\]' "$ARGV_LOG"
+  [ -z "$(_mark team bob)" ]
+  [ -z "$(_placement team bob)" ]
+  grep -q 'already recorded as team__alice' <<<"$output"
+  grep -q 'drop or despawn' <<<"$output"
+  # alice keeps everything.
   [ "$(_mark team alice)" = $'tmux:/tmp/s:%3\tpid=4242' ]
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
 }
 
 # --- order independence with the existing paths -------------------------------------

--- a/tests/test_self_name.bats
+++ b/tests/test_self_name.bats
@@ -12,8 +12,9 @@
 #                                         pinned as such)
 #   - no mark                          -> named once, mark written
 #   - another seat in the same pane    -> NOT taken while the first seat's record
-#                                         claims it (#1114 stop-gap; was "names it
-#                                         for itself" and returns to that with #1112)
+#                                         claims it (#1114 placement guard, kept
+#                                         alongside #1112; was "names it for itself"
+#                                         and returns to that only if the guard goes)
 #   - order independence: a boot path first, then the action; the action
 #     first, then a boot path -- same key, one terminal call in total
 #   - herdr identifies its pane from HERDR_PANE_ID with no session id
@@ -155,14 +156,15 @@ _placement() {   # <team> <agent> -> "<terminal>:<id>" or empty
   grep -q 'BLIND SPOT' "$SKILL_DIR/scripts/lib/self-name.sh"
 }
 
-@test "another seat in the same pane does NOT take it while the first seat's record claims it (#1114 stop-gap)" {
-  # Before the #1114 stop-gap this test read "names it for itself": the second
-  # seat relabeled the pane and marked itself there. Under the stop-gap a pane
+@test "another seat in the same pane does NOT take it while the first seat's record claims it (#1114 placement guard)" {
+  # Before the #1114 guard this test read "names it for itself": the second
+  # seat relabeled the pane and marked itself there. Under the guard a pane
   # another seat's record claims is neither named, marked, nor recorded -- that
   # is the shape that stops co-located codex seats taking each other's pane, and
   # a second role acting from the SAME pane is indistinguishable from it. The
   # message says who holds the pane and how to release it (drop or despawn).
-  # Delete this test with the guard when #1112 lands and restore the old one.
+  # The guard is kept alongside #1112's label-first resolution; this test goes
+  # only if the guard does, as a separate decision, and the old one returns.
   _install_fake_tmux; _under_tmux /tmp/s 4242 %3
   agmsg_self_name_on_action team alice
   [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2378,3 +2378,37 @@ _tmux_op_args() {
   refute grep -qE '\[set-option\]|\[select-pane\]' "$ARGV_LOG"
   refute test -e "$mine"
 }
+
+@test "placement guard: this seat's record under a VANISHED team blocks it (closed) and the message names the file to remove (#1114 review)" {
+  # The exact rule builds this agent's record path for each team on disk. A team
+  # dropped with its run/ record left behind has no path to build, so that
+  # record reads as a rival: fail-closed, and the refusal must say the way out
+  # is the file, since "drop or despawn" points at this seat itself.
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  mkdir -p "$SKILL_DIR/teams/seatteam"          # the live team exists; "gone" does not
+
+  local stale; stale="$(agmsg_spawn_path gone alice)"
+  mkdir -p "$(dirname "$stale")"
+  printf 'tmux:/tmp/fake:%%1\t/proj/OLD\tclaude-code\n' > "$stale"
+
+  local mine; mine="$(agmsg_spawn_path seatteam alice)"
+  : > "$ARGV_LOG"
+  run agmsg_terminal_name_self "" seatteam alice /proj/MINE claude-code record
+  [ "$status" -eq 0 ]
+  grep -q 'did not name or record' <<<"$output"
+  grep -q "recorded as gone__alice's" <<<"$output"
+  grep -q 'remove run/spawn.gone__alice' <<<"$output"
+  refute grep -qE '\[set-option\]|\[select-pane\]' "$ARGV_LOG"
+  refute test -e "$mine"
+
+  # Control: a genuine other seat gets no such hint.
+  rm -f "$stale"
+  local rival; rival="$(agmsg_spawn_path seatteam bob)"
+  printf 'tmux:/tmp/fake:%%1\t/proj/PEER\tclaude-code\n' > "$rival"
+  run agmsg_terminal_name_self "" seatteam alice /proj/MINE claude-code record
+  grep -q "recorded as seatteam__bob's" <<<"$output"
+  refute grep -q 'remove run/spawn' <<<"$output"
+}

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2074,13 +2074,15 @@ _tmux_op_args() {
   done
 }
 
-# --- #1114 stop-gap: a seat does not take a pane another seat already records ---
+# --- #1114 placement guard: a seat does not take a pane another seat already records ---
 #
 # Four directions, because the guard is only worth anything if it also gets out
 # of the way: another seat holds it -> neither named nor marked nor recorded;
 # nobody holds it -> named and recorded; this seat's own record holds it ->
-# rewritten; this SEAT under another TEAM holds it -> recorded. Delete these
-# with the guard when #1112 lands.
+# rewritten; this SEAT under another TEAM holds it -> recorded. The guard is
+# kept alongside #1112's label-first resolution (a label makes a wrong answer
+# less likely, not impossible); these go only if the guard does, as a separate
+# decision. The "seam" tests further down pin the two mechanisms together.
 
 @test "terminal_name_self record: a pane ANOTHER seat's record claims is neither named, marked, nor recorded (#1114)" {
   _install_fake_tmux

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2213,3 +2213,74 @@ _tmux_op_args() {
   grep -q 'did not name or record' <<<"$output"
   refute test -e "$rival"
 }
+
+# --- #1114 follow-up: refs are compared as PANES, not as strings --------------------
+
+@test "placement guard: a LEGACY socket-less peer record still claims the pane (#1114 follow-up)" {
+  # The record format accepts `%N` / `@N` from before refs carried the server
+  # (#1051), and those are the oldest records -- the ones most likely to belong
+  # to somebody else. Compared as strings, `%1` never matches `tmux:<sock>:%1`,
+  # so the guard waves the write through exactly there. Compared as panes, it
+  # claims.
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+
+  local peer; peer="$(agmsg_spawn_path seatteam legacypeer)"
+  mkdir -p "$(dirname "$peer")"
+  printf '%%1\t/proj/PEER\tclaude-code\n' > "$peer"
+
+  local mine; mine="$(agmsg_spawn_path seatteam newcomer)"
+  : > "$ARGV_LOG"
+  run agmsg_terminal_name_self "" seatteam newcomer /proj/MINE claude-code record
+  [ "$status" -eq 0 ]
+  grep -q 'did not name or record' <<<"$output"
+  grep -q 'seatteam__legacypeer' <<<"$output"
+  refute grep -qE '\[set-option\]|\[select-pane\]' "$ARGV_LOG"
+  refute test -e "$mine"
+}
+
+@test "placement guard: a peer on a DIFFERENT tmux server is not a claim (#1114 follow-up)" {
+  # The partner, and the reason the rule is scoped rather than "same pane id
+  # wins": a pane id is not unique across tmux servers (#1051). When BOTH refs
+  # name a server and the servers differ, they are different panes and the write
+  # proceeds. Only an UNKNOWN server counts as a claim.
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+
+  local peer; peer="$(agmsg_spawn_path seatteam otherserver)"
+  mkdir -p "$(dirname "$peer")"
+  printf 'tmux:/tmp/OTHERSOCK:%%1\t/proj/PEER\tclaude-code\n' > "$peer"
+
+  local mine; mine="$(agmsg_spawn_path seatteam sameid)"
+  run agmsg_terminal_name_self "" seatteam sameid /proj/MINE claude-code record
+  [ "$status" -eq 0 ]
+  refute grep -q 'did not name or record' <<<"$output"
+  grep -q '^tmux:/tmp/fake:%1	/proj/MINE	claude-code$' "$mine"
+}
+
+@test "placement guard: the pane splitter agrees with the registry's own ref parsers on every accepted form (#1114 follow-up)" {
+  # The splitter mirrors agmsg_terminal_ref_terminal / agmsg_terminal_ref_id
+  # inline (no fork per scanned record). Two grammars for one format drift; this
+  # pins them together on the bare legacy id, the scheme without a socket, the
+  # full tmux form, and herdr (whose ids contain a colon that is NOT a socket).
+  local ref term id sock
+  for ref in '%7' '@3' 'tmux:%7' 'tmux:/tmp/s:%7' 'tmux:/tmp/with:colon:%7' 'herdr:w1:pB' 'plain:-'; do
+    _agmsg_placement_split "$ref" || { echo "FAIL: split refused $ref"; return 1; }
+    term="$(agmsg_terminal_ref_terminal "$ref")" || { echo "FAIL: registry refused $ref"; return 1; }
+    id="$(agmsg_terminal_ref_id "$ref")"
+    [ "$_AGMSG_PS_TERM" = "$term" ] || { echo "FAIL: $ref term $_AGMSG_PS_TERM vs $term"; return 1; }
+    case "$term" in
+      tmux) sock="${id%:*}"; [ "$sock" = "$id" ] && sock=""; id="${id##*:}"
+            [ "$_AGMSG_PS_SOCK" = "$sock" ] || { echo "FAIL: $ref sock $_AGMSG_PS_SOCK vs $sock"; return 1; } ;;
+      *)    [ -z "$_AGMSG_PS_SOCK" ] || { echo "FAIL: $ref has a socket on $term"; return 1; } ;;
+    esac
+    [ "$_AGMSG_PS_ID" = "$id" ] || { echo "FAIL: $ref id $_AGMSG_PS_ID vs $id"; return 1; }
+  done
+  # And an unknown scheme is refused by both.
+  refute _agmsg_placement_split 'bogus:thing'
+  refute agmsg_terminal_ref_terminal 'bogus:thing'
+}

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2195,6 +2195,10 @@ _tmux_op_args() {
   export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
   source "$SKILL_DIR/scripts/lib/actas-lock.sh"
 
+  # Both teams exist on disk: "this seat under another team" is decided by
+  # rebuilding this agent's record path for each existing team, never by
+  # cutting the file name.
+  mkdir -p "$SKILL_DIR/teams/otherteam" "$SKILL_DIR/teams/seatteam"
   local other_team; other_team="$(agmsg_spawn_path otherteam twice)"
   mkdir -p "$(dirname "$other_team")"
   printf 'tmux:/tmp/fake:%%1\t/proj/MINE\tclaude-code\n' > "$other_team"
@@ -2283,4 +2287,94 @@ _tmux_op_args() {
   # And an unknown scheme is refused by both.
   refute _agmsg_placement_split 'bogus:thing'
   refute agmsg_terminal_ref_terminal 'bogus:thing'
+}
+
+# --- #1114 follow-up (review): "this seat" is exact, and unreadable is a claim ------
+
+@test "placement guard: a peer whose name ENDS in this seat's name is another seat (#1114 review)" {
+  # "__" is legal inside an agent name (validate allows it). Cutting the record
+  # file name at the last "__" made peer foo__bar look like bar, and bar took
+  # foo__bar's pane. The comparison is on whole record paths built by the
+  # encoder for each existing team, so the peer is a rival here.
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  mkdir -p "$SKILL_DIR/teams/seatteam"
+
+  local peer; peer="$(agmsg_spawn_path seatteam foo__bar)"
+  mkdir -p "$(dirname "$peer")"
+  printf 'tmux:/tmp/fake:%%1\t/proj/PEER\tclaude-code\n' > "$peer"
+
+  local mine; mine="$(agmsg_spawn_path seatteam bar)"
+  : > "$ARGV_LOG"
+  run agmsg_terminal_name_self "" seatteam bar /proj/MINE claude-code record
+  [ "$status" -eq 0 ]
+  grep -q 'did not name or record' <<<"$output"
+  grep -q 'seatteam__foo__bar' <<<"$output"
+  refute grep -qE '\[set-option\]|\[select-pane\]' "$ARGV_LOG"
+  refute test -e "$mine"
+
+  # And the mirror: this seat is foo__bar, the peer is bar -- still a rival.
+  rm -f "$peer"
+  peer="$(agmsg_spawn_path seatteam bar)"
+  printf 'tmux:/tmp/fake:%%1\t/proj/PEER\tclaude-code\n' > "$peer"
+  mine="$(agmsg_spawn_path seatteam foo__bar)"
+  run agmsg_terminal_name_self "" seatteam foo__bar /proj/MINE claude-code record
+  [ "$status" -eq 0 ]
+  grep -q 'seatteam__bar' <<<"$output"
+  refute test -e "$mine"
+}
+
+@test "placement guard: a peer record whose ref cannot be read as a pane is a CLAIM, not a pass (#1114 review)" {
+  # unknown spelling, and an empty record: neither can be ruled out as this
+  # pane, so both claim and are named, so a person can drop them.
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+
+  local peer; peer="$(agmsg_spawn_path seatteam garbled)"
+  mkdir -p "$(dirname "$peer")"
+  printf 'unknown:ref\t/proj/PEER\tclaude-code\n' > "$peer"
+  local mine; mine="$(agmsg_spawn_path seatteam careful)"
+  : > "$ARGV_LOG"
+  run agmsg_terminal_name_self "" seatteam careful /proj/MINE claude-code record
+  [ "$status" -eq 0 ]
+  grep -q 'did not name or record' <<<"$output"
+  grep -q 'seatteam__garbled' <<<"$output"
+  refute grep -qE '\[set-option\]|\[select-pane\]' "$ARGV_LOG"
+  refute test -e "$mine"
+
+  rm -f "$peer"
+  peer="$(agmsg_spawn_path seatteam blank)"
+  : > "$peer"
+  run agmsg_terminal_name_self "" seatteam careful /proj/MINE claude-code record
+  [ "$status" -eq 0 ]
+  grep -q 'seatteam__blank' <<<"$output"
+  refute test -e "$mine"
+}
+
+@test "placement guard: this seat's OWN ref unreadable as a pane is undecidable -> neither named nor recorded (#1114 review)" {
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  mkdir -p "$SKILL_DIR/run"
+
+  # The helper itself: rc 1, prints nothing.
+  run _agmsg_placement_claimed_by 'bogus:thing' seatteam who
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+
+  # Through the naming function, with the ref composer handing back a spelling
+  # the guard cannot read: the seat says so, types nothing, records nothing.
+  agmsg_terminal_ref() { printf 'bogus:thing\n'; }
+  local mine; mine="$(agmsg_spawn_path seatteam who)"
+  : > "$ARGV_LOG"
+  run agmsg_terminal_name_self "" seatteam who /proj/MINE claude-code record
+  [ "$status" -eq 0 ]
+  grep -q 'cannot be read as a pane' <<<"$output"
+  refute grep -qE '\[set-option\]|\[select-pane\]' "$ARGV_LOG"
+  refute test -e "$mine"
 }

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2744,3 +2744,79 @@ EOF
   run _agmsg_terminal_resolve_by_label team alice
   [ "$status" -ne 0 ]
 }
+
+# --- seam: #1112's label-first resolution feeds #1117's placement guard ---------------
+#
+# Both touch "which pane is mine": #1112 decides it (label first, environment
+# second) and #1117 refuses to take it when another seat's record claims it.
+# Each is tested alone above; this pins the JOIN -- whichever path resolved the
+# pane, the guard judges THAT pane, and only that pane.
+
+@test "seam: a seat resolved by its LABEL is refused when a peer's record claims the label's pane (#1112 x #1114)" {
+  # The environment points at the shared daemon pane; the label says this seat
+  # is at w1:pMINE. A peer record already claims w1:pMINE.
+  _fake_herdr_labels "w1:pDAEMON=agmsg:other" "w1:pMINE=team:alice"
+  export HERDR_ENV=1 HERDR_PANE_ID="w1:pDAEMON"
+  unset TMUX TMUX_PANE
+  export AGMSG_TERMINAL_DRIVER=herdr
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  local peer; peer="$(agmsg_spawn_path team peer)"
+  mkdir -p "$(dirname "$peer")"
+  printf 'herdr:w1:pMINE\t/proj/PEER\tclaude-code\n' > "$peer"
+  local mine; mine="$(agmsg_spawn_path team alice)"
+  : > "$ARGV_LOG"
+
+  run agmsg_terminal_name_self "" team alice /proj/A claude-code record
+  [ "$status" -eq 0 ]
+  grep -q 'did not name or record' <<<"$output"
+  grep -q 'herdr:w1:pMINE' <<<"$output"
+  grep -q "team__peer" <<<"$output"
+  # The guard judged the LABEL's pane (w1:pMINE), and nothing was renamed.
+  refute grep -qE '\[rename\]' "$ARGV_LOG"
+  refute test -e "$mine"
+
+  # Control 1: the same peer claiming the ENVIRONMENT's pane instead does not
+  # block a seat the label placed elsewhere -- the guard judges the resolved
+  # pane, not the inherited one.
+  printf 'herdr:w1:pDAEMON\t/proj/PEER\tclaude-code\n' > "$peer"
+  : > "$ARGV_LOG"
+  run agmsg_terminal_name_self "" team alice /proj/A claude-code record
+  [ "$status" -eq 0 ]
+  refute grep -q 'did not name or record' <<<"$output"
+  grep -q 'w1:pMINE' "$ARGV_LOG"
+  refute grep -q 'w1:pDAEMON' "$ARGV_LOG"
+  grep -q '^herdr:w1:pMINE	/proj/A	claude-code$' "$mine"
+}
+
+@test "seam: a seat that fell through to its ENVIRONMENT is refused when a peer's record claims that pane (#1112 x #1114)" {
+  # No label matches, so resolution falls back to the environment (w1:pDAEMON);
+  # a peer record claims exactly that pane -- the co-located codex shape.
+  _fake_herdr_labels "w1:pDAEMON=agmsg:other" "w1:pX=null"
+  export HERDR_ENV=1 HERDR_PANE_ID="w1:pDAEMON"
+  unset TMUX TMUX_PANE
+  export AGMSG_TERMINAL_DRIVER=herdr
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  local peer; peer="$(agmsg_spawn_path team other)"
+  mkdir -p "$(dirname "$peer")"
+  printf 'herdr:w1:pDAEMON\t/proj/PEER\tcodex\n' > "$peer"
+  local mine; mine="$(agmsg_spawn_path team alice)"
+  : > "$ARGV_LOG"
+
+  run agmsg_terminal_name_self "" team alice /proj/A codex record
+  [ "$status" -eq 0 ]
+  grep -q 'did not name or record' <<<"$output"
+  grep -q 'herdr:w1:pDAEMON' <<<"$output"
+  grep -q "team__other" <<<"$output"
+  refute grep -qE '\[rename\]' "$ARGV_LOG"
+  refute test -e "$mine"
+
+  # Control 2: with no claim on the environment's pane, the fallback names and
+  # records it -- the guard got out of the way on this path too.
+  rm -f "$peer"
+  : > "$ARGV_LOG"
+  run agmsg_terminal_name_self "" team alice /proj/A codex record
+  [ "$status" -eq 0 ]
+  refute grep -q 'did not name or record' <<<"$output"
+  grep -q 'w1:pDAEMON' "$ARGV_LOG"
+  grep -q '^herdr:w1:pDAEMON	/proj/A	codex$' "$mine"
+}

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2070,20 +2070,26 @@ _tmux_op_args() {
   done
 }
 
-# --- #1113 stop-gap: a seat does not take a pane another seat already records ---
+# --- #1114 stop-gap: a seat does not take a pane another seat already records ---
 #
-# Both directions, because the guard is only worth anything if it also gets out
-# of the way. Delete these two with the guard when #1112 lands.
+# Four directions, because the guard is only worth anything if it also gets out
+# of the way: another seat holds it -> neither named nor marked nor recorded;
+# nobody holds it -> named and recorded; this seat's own record holds it ->
+# rewritten; this SEAT under another TEAM holds it -> recorded. Delete these
+# with the guard when #1112 lands.
 
-@test "terminal_name_self record: refuses a pane ANOTHER seat's record already claims (#1113)" {
+@test "terminal_name_self record: a pane ANOTHER seat's record claims is neither named, marked, nor recorded (#1114)" {
   _install_fake_tmux
   export PATH="$FAKEBIN:$PATH"
   export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
   source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  source "$SKILL_DIR/scripts/lib/role-session.sh"
 
   # A peer already records the very pane this seat is about to resolve. That is
   # the codex shape: three seats inherit one daemon's environment, so all three
-  # resolve the same pane and each overwrite would take it from the last.
+  # resolve the same pane. The check has to sit BEFORE the rename: a guard that
+  # spared only the record still let each seat relabel and rekey the daemon's
+  # pane (another seat's) and mark itself as named there.
   local peer; peer="$(agmsg_spawn_path seatteam peer)"
   mkdir -p "$(dirname "$peer")"
   # The ref carries the socket (#1051), so the fixture has to spell it the way
@@ -2096,25 +2102,28 @@ _tmux_op_args() {
 
   local mine; mine="$(agmsg_spawn_path seatteam taker)"
   refute test -e "$mine"
+  : > "$ARGV_LOG"
 
   run agmsg_terminal_name_self "" seatteam taker /proj/MINE claude-code record
-  # Naming succeeded; only the placement CLAIM was declined, so this is 0.
+  # Declined, not failed: the seat is fine, the pane is somebody else's.
   [ "$status" -eq 0 ]
 
-  # Positive control: the pane really was named, so the assertions below are not
-  # green because the call did nothing.
-  grep -q '\[select-pane\]' "$ARGV_LOG" || grep -q '\[set-option\]' "$ARGV_LOG"
-
-  # The reason is said, not swallowed -- and it names both sides.
-  grep -q 'did NOT record it' <<<"$output"
+  # The reason is said, not swallowed -- it names both sides and the way out.
+  grep -q 'did not name or record' <<<"$output"
   grep -q 'tmux:/tmp/fake:%1' <<<"$output"
+  grep -q "peer" <<<"$output"
+  grep -q 'drop or despawn' <<<"$output"
 
-  # Nothing was taken and nothing was invented.
+  # NOT named: no write reached the terminal (the resolve-time reads may).
+  refute grep -qE '\[set-option\]|\[select-pane\]' "$ARGV_LOG"
+  # NOT marked: this seat does not believe it is named on that pane.
+  [ -z "$(agmsg_role_session_named seatteam taker 2>/dev/null)" ]
+  # NOT recorded, and the peer's record is byte-identical.
   cmp -s "$peer" "$peer_snapshot"
   refute test -e "$mine"
 }
 
-@test "terminal_name_self record: still records when no other seat claims the pane (#1113)" {
+@test "terminal_name_self record: still names and records when no other seat claims the pane (#1114)" {
   # The partner. Without it, a guard that refused every write would pass the test
   # above, and #1111 -- the reason placement is recorded at all -- would be dead.
   _install_fake_tmux
@@ -2135,9 +2144,11 @@ _tmux_op_args() {
   grep -q '^tmux:/tmp/fake:%1	/proj/MINE	claude-code$' "$mine"
 }
 
-@test "terminal_name_self record: re-recording its OWN pane is not a conflict (#1113)" {
+@test "terminal_name_self record: re-recording its OWN pane is not a conflict (#1114)" {
   # The seat's own record names the same pane. The scan must skip the seat's own
   # file, or every seat would refuse to refresh itself after the first write.
+  # The seed and the expectation differ in the project field, so a refresh that
+  # did not happen is visible.
   _install_fake_tmux
   export PATH="$FAKEBIN:$PATH"
   export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
@@ -2149,6 +2160,56 @@ _tmux_op_args() {
 
   run agmsg_terminal_name_self "" seatteam again /proj/NEW claude-code record
   [ "$status" -eq 0 ]
-  refute grep -q 'did NOT record it' <<<"$output"
+  refute grep -q 'did not name or record' <<<"$output"
   grep -q '^tmux:/tmp/fake:%1	/proj/NEW	claude-code$' "$mine"
+}
+
+@test "terminal_name_self record: a seat's own record is rewritten from an OLD pane to the one it is in (#1114)" {
+  # The seat moved (or its record was stale): its own row holds a different
+  # pane. Its own row never blocks it, and the row ends up saying where it is.
+  # Seed and expectation differ in the REF, so "left as it was" is red.
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+
+  local mine; mine="$(agmsg_spawn_path seatteam mover)"
+  mkdir -p "$(dirname "$mine")"
+  printf 'tmux:/tmp/fake:%%OLD\t/proj/MINE\tclaude-code\n' > "$mine"
+
+  run agmsg_terminal_name_self "" seatteam mover /proj/MINE claude-code record
+  [ "$status" -eq 0 ]
+  refute grep -q 'did not name or record' <<<"$output"
+  grep -q '\[set-option\]' "$ARGV_LOG"
+  grep -q '^tmux:/tmp/fake:%1	/proj/MINE	claude-code$' "$mine"
+  refute grep -q '%OLD' "$mine"
+}
+
+@test "terminal_name_self record: the same SEAT under another TEAM is not a rival claim (#1114)" {
+  # run/ is flat: one seat in two teams has two records for the same pane. The
+  # first version of the guard scanned every team and blocked a seat with its
+  # own other-team record, so a seat acting in its second team was never
+  # recorded there (measured on a host where every seat is in two teams).
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+
+  local other_team; other_team="$(agmsg_spawn_path otherteam twice)"
+  mkdir -p "$(dirname "$other_team")"
+  printf 'tmux:/tmp/fake:%%1\t/proj/MINE\tclaude-code\n' > "$other_team"
+
+  local mine; mine="$(agmsg_spawn_path seatteam twice)"
+  refute test -e "$mine"
+
+  run agmsg_terminal_name_self "" seatteam twice /proj/MINE claude-code record
+  [ "$status" -eq 0 ]
+  refute grep -q 'did not name or record' <<<"$output"
+  grep -q '^tmux:/tmp/fake:%1	/proj/MINE	claude-code$' "$mine"
+  # A different seat on the same pane is still refused (the same scan).
+  local rival; rival="$(agmsg_spawn_path seatteam rival)"
+  run agmsg_terminal_name_self "" seatteam rival /proj/MINE claude-code record
+  [ "$status" -eq 0 ]
+  grep -q 'did not name or record' <<<"$output"
+  refute test -e "$rival"
 }


### PR DESCRIPTION
Refs #1114, #1112. Follow-up to the placement guard #1114 landed on integration.

Two defects in the landed guard, both confirmed on the landed library, and one wrong reference.

## A. A seat in two teams was blocked by its own record

`_agmsg_placement_claimed_by` scanned every `spawn.*` record and excluded only this seat's own **file**. `run/` is flat, so a seat registered in two teams has `spawn.<team1>__<x>` and `spawn.<team2>__<x>` for the same pane, and the second was refused by the first. Measured: with `spawn.agmsg__seatX` holding a pane, the claim for `spawn.agmsg-work__seatX` on that pane returned `agmsg__seatX`. A seat acting in its second team could never be recorded there, and every seat on the host this was measured on is in two teams.

Fix: the same agent under another team is the same seat, not a rival. "The same agent" is decided exactly: the peer file equals this agent's record path for a team that exists on disk, built by the same encoder. It is never decided by cutting the file name at `__`, because `__` is legal inside a name and cutting there made a peer called `foo__bar` look like `bar` (found in review). A different name on the same pane is still refused.

Reviewed and closed in the same round: any record whose reference cannot be read as a pane, an unknown spelling or an empty file, counts as a claim and is named, so a person can drop it; and if this seat's own reference cannot be read as a pane the guard reports undecidable and the seat neither names nor records. Both were fail-open before.

One state the exact rule cannot resolve, found in review: this seat's own record under a team that has since vanished from `teams/` has no path to rebuild, so it reads as a rival and blocks this seat. That is the closed direction, and it is left closed; what changed is the diagnosis: when the claimant's name ends in this seat's own name, the message says it may be this seat under a vanished team and names the `run/spawn.<X>` file to remove, since "drop or despawn" would point at the seat itself. The helper's comment records the state.

## B. The guard sat after the rename it exists to prevent

The check ran after `terminal_name` and after the seat's mark was written, sparing only the record. With the shared-daemon environment #1112 describes, three codex seats resolve one pane; each of them still relabeled and rekeyed that pane (another seat's) and marked itself as named there. The landed comment said so ("naming SUCCEEDED").

Fix: the check now sits before the rename. A pane another seat's record claims is neither named, marked, nor recorded; the message names the other seat, the pane, and the way out (drop or despawn a seat that is gone). The late check is deleted, so there is one guard with one seam. Cost: a seat in that state re-resolves on every action until #1112 lands, tens of milliseconds.

### Behaviour change to know about

A second role acting from the **same** pane as a role whose record claims it (a person who did `actas alice` and then `actas bob` in one pane) is indistinguishable from the co-located codex case, so under the stop-gap the second role is not named, marked, or recorded until the first role is dropped or despawned. Before this change it was named but not recorded. The message says so and names the way out. The self-name test that pinned "another seat in the same pane names it for itself" now pins the stop-gap shape and says which test to restore when #1112 lands.

## D. Legacy socket-less records never matched, so the guard passed them through

The claim scan compared references as strings. The record format still accepts the legacy tmux forms `%N` / `@N` and `tmux:%N` alongside `tmux:<socket>:%N`, so a peer record holding `%1` never equalled a freshly composed `tmux:/tmp/x:%1` and the write went through, for exactly the records most likely to be old, which are the ones most likely to be somebody else's. (Found in review of the landed guard.)

Fix: references are split into terminal, pane id and socket and compared as panes. Same terminal and pane id is a claim unless both sides name a server and the servers differ (a pane id is not unique across tmux servers, #1051); an unknown server on either side counts as a claim, fail-closed. The splitter mirrors the registry's own reference parsers inline so the scan forks nothing per record, and a test pins the two grammars together on every accepted form.

## C. The guard cited the wrong number

Comments and test names said `#1113`, which is the `team --fix` split. They now cite #1114 (this guard) and #1112 (label-first resolution, which the guard is kept alongside; see below).

## Merge with #1112 and the seam

#1112 (label-first self resolution) landed on integration while this was in review. Integration is merged into this branch as a merge commit so the history shows what happened; the only conflict was both sides appending tests to the end of `tests/test_terminal_registry.bats`, resolved by keeping both. The two changes touch the same question, "which pane is mine": #1112 decides it, this guard refuses it when another seat's record claims it.

**Lifetime, restated after the merge (review finding):** the guard was written as a stop-gap "until #1112 lands". #1112 has landed and the guard stays as the second line: a label makes a wrong answer less likely, not impossible (a label can be duplicated, cleared, or stale, and the environment fallback is still the shared daemon's for codex), so a pane another seat's record claims is still refused, whichever path resolved it. Removing the guard is a separate decision, taken only when label resolution is made authoritative. Every comment, message and test note that said "delete with #1112" now says this instead. Two seam tests pin the join: a seat resolved by its label is refused when a peer claims the label's pane and is not blocked by a peer on the environment's pane; a seat that fell through to its environment is refused when a peer claims that pane, and names and records it when nobody does. Neutralising the guard reddens both.

## Tests (`tests/test_terminal_registry.bats`)

Four directions plus a rewrite, each a control for the others:

- another seat holds the pane → not named (no `set-option`/`select-pane` in the fake tmux's argv), not marked (`agmsg_role_session_named` empty), not recorded, the peer's record byte-identical, the message names the peer and says drop/despawn;
- nobody holds it → named and recorded;
- this seat's own record holds it → rewritten (project field differs between seed and expectation);
- **new:** this seat's own record holds an OLD pane → rewritten to the pane it is in (the ref differs between seed and expectation, so "left as it was" is red);
- **new:** the same seat under another team holds it → recorded; a different seat on the same pane is still refused in the same test.

For D:

- a legacy `%1` peer record claims the pane → not named, not recorded, the message names the peer;
- a peer on a different tmux server with the same pane id is not a claim → named and recorded;
- the pane splitter agrees with `agmsg_terminal_ref_terminal` / `agmsg_terminal_ref_id` on the bare legacy id, the scheme without a socket, the full tmux form, a socket path containing a colon, herdr, and plain; both refuse an unknown scheme.

From review:

- a peer named `foo__bar` claims the pane and this seat is `bar` → refused, the message names `foo__bar`; and the mirror (this seat `foo__bar`, peer `bar`) → refused;
- a peer record spelled `unknown:ref`, and an empty peer record → both refused and named;
- this seat's own reference unreadable as a pane → the helper returns 1 and prints nothing; through the naming function the seat says so, types nothing, records nothing;
- this seat's own record under a vanished team → blocked (closed), the message names `gone__alice` and says to remove `run/spawn.gone__alice`; a genuine other seat gets no such hint (control in the same test).

Mutations, each restored from the index: dropping the same-seat rule (now the only exclusion) reddens the own-pane and two-team tests; neutralising the early check reddens the three refusal tests; reverting the pane comparison to string equality reddens the legacy test and leaves the other-server test green; accepting any file ending in `__<agent>` as this seat's reddens the `foo__bar` test; skipping an unreadable peer reddens the unreadable-peer test; treating an unreadable own reference as unclaimed reddens the undecidable test; never adding the vanished-team hint reddens the vanished-team test.
