### PR TITLE
fix(rename): --fix / --rename-sessions rename a codex seat (verify a new confirmation line)

### DIFF
--- a/scripts/drivers/types/codex/type.conf
+++ b/scripts/drivers/types/codex/type.conf
@@ -80,6 +80,22 @@ rename_cmd=/rename
 # failed" (#1081). The seat checks the line is readable BEFORE it pokes, and the
 # window where it can verify is the same early window where it should rename.
 session_name_source=screen:Thread name:
+# READ and WRITE are separate capabilities here, and #1109/#1113's fix turned on
+# the distinction that the header above only hinted at. Reading the CURRENT name
+# (session_name_source) is unreliable -- the "Thread name:" header scrolls off, so
+# an established session reads as unknown. That is "cannot read the name", NOT
+# "cannot be renamed": the WRITE works and announces itself. Typing `/rename
+# <name>` prints a confirmation line on the pane (measured, codex-cli, three
+# seats): "Session renamed to <name>. To resume this session run codex resume ...".
+# So `team --fix` / `--rename-sessions` do NOT pre-check a codex seat (there is
+# nothing dependable to pre-read) -- they type UNCONDITIONALLY and verify by
+# peeking for that confirmation line. Because the line is emitted right after the
+# keystroke (unlike the header, which may already be gone), its ABSENCE is a real
+# failure (rename_not_observed), not the "could not confirm" that an unreadable
+# header is. claude-code, whose name rides the title, keeps pre-checking; this
+# datum is what tells the two paths apart, so the difference lives in the manifest
+# rather than in a type-name branch.
+rename_confirm=Session renamed to
 # codex invokes a skill with "$", not Claude Code's "/" (see spawn.sh, #283).
 cmd_prefix=$
 model_arg=-m

--- a/scripts/lib/team-status.sh
+++ b/scripts/lib/team-status.sh
@@ -163,17 +163,80 @@ agmsg_team_fix_pane_names_loaded() {
   esac
 }
 
+# Count the confirmation lines "<confirm_prefix> <expected>." currently visible in
+# a pane's scrollback. Used only by a rename_confirm type (codex): the line
+# PERSISTS after a rename and `--fix` runs repeatedly (and a person may have typed
+# /rename by hand), so a later run must not read an EARLIER line as its own. The
+# caller counts before and after its keystroke and requires an INCREASE; the
+# expected name is the same every run, so newness -- not the name -- is the only
+# thing that separates this rename from a prior one. Unreadable pane -> 0.
+_agmsg_rename_confirm_count() {   # <pane> <confirm_prefix> <expected>
+  local screen
+  screen="$(terminal_peek "$1" --lines 400 2>/dev/null)" || { printf '0\n'; return 0; }
+  printf '%s\n' "$screen" | grep -cF -- "$2 $3." || true
+}
+
 # <team> <agent> <type> <terminal> <pane> <session_cell>
 #   -> the cli_session action. This is the half that TYPES into the pane
-#   (`<rename_cmd> <team>-<agent>`), behind three gates: the cell is a mismatch,
-#   the type declares a rename command, and the pane reports ready.
+#   (`<rename_cmd> <team>-<agent>`). Two shapes, told apart by the manifest, not by
+#   the type name: a rename_confirm type (codex) cannot be pre-read, so it types
+#   UNCONDITIONALLY and confirms by a NEW announcement line; a readback type
+#   (claude-code) types only on a mismatch and re-reads the name. Both need the
+#   type to declare a rename command and the pane to report ready.
 agmsg_team_rename_session_loaded() {
   # $4 (terminal) is accepted for a signature parallel to the pane-names half;
   # the rename goes through the loaded driver's terminal_poke and needs no name.
   local team="$1" agent="$2" type="$3" pane="$5"
   local session_cell="$6"
   local expected_session="$team-$agent" readiness state reason rc=0 observed title tries
-  local rename_cmd session_src
+  local rename_cmd session_src rename_confirm before after
+
+  # A rename_confirm type (codex) has no dependable pre-read of its current name,
+  # so --fix does NOT gate the keystroke on the (unknown) pre-check: it types
+  # UNCONDITIONALLY and confirms by a NEW announcement line. "Cannot read the
+  # name" is not "cannot rename" (#1109 followup). Kept separate from the readback
+  # path below so a reader can see why codex behaves differently.
+  rename_confirm="$(agmsg_type_get "$type" rename_confirm 2>/dev/null || true)"
+  if [ -n "$rename_confirm" ]; then
+    rename_cmd="$(agmsg_type_get "$type" rename_cmd 2>/dev/null || true)"
+    if [ -z "$rename_cmd" ]; then
+      _agmsg_team_fix_result cli_session skipped no_rename_cmd
+      return 0
+    fi
+    readiness="$(agmsg_team_input_ready_loaded "$type" "$pane")"
+    IFS="$(printf '\t')" read -r state reason <<EOF
+$readiness
+EOF
+    if [ "$state" != ready ]; then
+      _agmsg_team_fix_result cli_session skipped "${state}_$reason"
+      return 0
+    fi
+    # Newness, not presence: count the confirmation line before and after, require
+    # an INCREASE. A pre-existing line (an earlier run, a hand-typed rename) is in
+    # `before`, so it cannot pass a keystroke that never landed.
+    before="$(_agmsg_rename_confirm_count "$pane" "$rename_confirm" "$expected_session")"
+    rc=0
+    terminal_poke "$pane" "$rename_cmd $expected_session" >/dev/null 2>&1 || rc=$?
+    if [ "$rc" -ne 0 ]; then
+      _agmsg_team_fix_result cli_session failed "terminal_poke_rc_$rc"
+      return 0
+    fi
+    tries=0
+    while [ "$tries" -lt 20 ]; do
+      after="$(_agmsg_rename_confirm_count "$pane" "$rename_confirm" "$expected_session")"
+      if [ "$after" -gt "$before" ]; then
+        _agmsg_team_fix_result cli_session changed renamed_and_verified
+        return 0
+      fi
+      sleep 0.1 2>/dev/null || true
+      tries=$((tries + 1))
+    done
+    # Typed, but no NEW confirmation line. The line is the command's own immediate
+    # output, not a header that may already have scrolled off, so its absence is a
+    # real failure -- never poked_unverified.
+    _agmsg_team_fix_result cli_session failed rename_not_observed
+    return 0
+  fi
 
   case "$session_cell" in
     mismatch\(*)

--- a/scripts/lib/team-status.sh
+++ b/scripts/lib/team-status.sh
@@ -169,7 +169,8 @@ agmsg_team_fix_pane_names_loaded() {
 # /rename by hand), so a later run must not read an EARLIER line as its own. The
 # caller counts before and after its keystroke and requires an INCREASE; the
 # expected name is the same every run, so newness -- not the name -- is the only
-# thing that separates this rename from a prior one. Unreadable pane -> 0.
+# thing that separates this rename from a prior one. An unreadable pane fails
+# (rc 1, no output) rather than reading as 0 -- see the read-failure note below.
 _agmsg_rename_confirm_count() {   # <pane> <confirm_prefix> <expected>
   local screen
   # Ask for a generous window so a pre-existing line is captured too. Drivers honor

--- a/scripts/lib/team-status.sh
+++ b/scripts/lib/team-status.sh
@@ -172,6 +172,11 @@ agmsg_team_fix_pane_names_loaded() {
 # thing that separates this rename from a prior one. Unreadable pane -> 0.
 _agmsg_rename_confirm_count() {   # <pane> <confirm_prefix> <expected>
   local screen
+  # Ask for a generous window so a pre-existing line is captured too. Drivers honor
+  # this differently -- tmux takes --lines as given; the herdr driver maps it to its
+  # own recent window (~80 lines) and ignores a larger number -- so this is a
+  # request, not a guarantee of depth. It does not need to be: before and after read
+  # the SAME window on the SAME driver, so the count DELTA is valid whatever the depth.
   screen="$(terminal_peek "$1" --lines 400 2>/dev/null)" || { printf '0\n'; return 0; }
   printf '%s\n' "$screen" | grep -cF -- "$2 $3." || true
 }

--- a/scripts/lib/team-status.sh
+++ b/scripts/lib/team-status.sh
@@ -177,7 +177,13 @@ _agmsg_rename_confirm_count() {   # <pane> <confirm_prefix> <expected>
   # own recent window (~80 lines) and ignores a larger number -- so this is a
   # request, not a guarantee of depth. It does not need to be: before and after read
   # the SAME window on the SAME driver, so the count DELTA is valid whatever the depth.
-  screen="$(terminal_peek "$1" --lines 400 2>/dev/null)" || { printf '0\n'; return 0; }
+  #
+  # A READ FAILURE is not zero matches (advisor, #1120). Returning 0 here would let a
+  # transient peek failure before the keystroke set a false baseline of 0, and a
+  # recovered read afterward count a PRE-EXISTING line as if it were new -> a false
+  # renamed_and_verified. So fail with NO output and let the caller treat an unread
+  # count as "cannot establish/confirm", never as zero.
+  screen="$(terminal_peek "$1" --lines 400 2>/dev/null)" || return 1
   printf '%s\n' "$screen" | grep -cF -- "$2 $3." || true
 }
 
@@ -219,7 +225,16 @@ EOF
     # Newness, not presence: count the confirmation line before and after, require
     # an INCREASE. A pre-existing line (an earlier run, a hand-typed rename) is in
     # `before`, so it cannot pass a keystroke that never landed.
-    before="$(_agmsg_rename_confirm_count "$pane" "$rename_confirm" "$expected_session")"
+    #
+    # The baseline must be READ, not assumed. If the before-peek fails we have no
+    # trustworthy zero to measure against -- and a recovered after-peek would then
+    # count a pre-existing line as new (advisor, #1120). So an unreadable baseline
+    # does NOT type: a keystroke we could not verify is worse than none, and this is
+    # transient -- the next --fix run reads the baseline and proceeds.
+    before="$(_agmsg_rename_confirm_count "$pane" "$rename_confirm" "$expected_session")" || {
+      _agmsg_team_fix_result cli_session skipped baseline_unreadable
+      return 0
+    }
     rc=0
     terminal_poke "$pane" "$rename_cmd $expected_session" >/dev/null 2>&1 || rc=$?
     if [ "$rc" -ne 0 ]; then
@@ -228,8 +243,11 @@ EOF
     fi
     tries=0
     while [ "$tries" -lt 20 ]; do
-      after="$(_agmsg_rename_confirm_count "$pane" "$rename_confirm" "$expected_session")"
-      if [ "$after" -gt "$before" ]; then
+      # A failed after-peek is not "zero matches" either -- leave `after` empty so
+      # it cannot satisfy the comparison, and try again; only a real read that
+      # EXCEEDS the baseline confirms.
+      after="$(_agmsg_rename_confirm_count "$pane" "$rename_confirm" "$expected_session")" || after=""
+      if [ -n "$after" ] && [ "$after" -gt "$before" ]; then
         _agmsg_team_fix_result cli_session changed renamed_and_verified
         return 0
       fi

--- a/tests/test_team_status.bats
+++ b/tests/test_team_status.bats
@@ -708,3 +708,26 @@ _codex_type_get() {   # codex declares rename_cmd + rename_confirm; name not on 
   [ "${lines[0]}" = $'cli_session\tskipped\tnot_ready_agent_status_thinking' ]
   [ ! -e "$BATS_TEST_TMPDIR/poke" ]
 }
+
+@test "codex session rename: a transient read failure before the keystroke does not verify a pre-existing line (#1120 advisor)" {
+  _codex_type_get
+  # the pane already carries the line (an earlier run / a hand-typed rename)
+  printf 'Session renamed to team-alice. To resume run codex resume\n' > "$BATS_TEST_TMPDIR/screen"
+  printf '0' > "$BATS_TEST_TMPDIR/peekn"
+  terminal_team_input_ready() { printf 'ready\n'; }
+  # the BEFORE baseline read fails transiently; later reads recover and show the
+  # pre-existing line. A count function that returned 0 on a failed read would set
+  # a false baseline of 0, then count the recovered pre-existing line as new.
+  terminal_peek() {
+    local n; n="$(cat "$BATS_TEST_TMPDIR/peekn")"; n=$((n + 1)); printf '%s' "$n" > "$BATS_TEST_TMPDIR/peekn"
+    [ "$n" -eq 1 ] && return 1
+    cat "$BATS_TEST_TMPDIR/screen" 2>/dev/null
+  }
+  terminal_poke() { printf '%s\n' "$2" > "$BATS_TEST_TMPDIR/poke"; }   # keystroke does NOT land
+  sleep() { :; }
+  run agmsg_team_rename_session_loaded team alice codex herdr w2:p3 'unknown:name_not_visible'
+  [ "$status" -eq 0 ]
+  # No trustworthy baseline -> nothing typed, nothing verified.
+  [ "${lines[0]}" = $'cli_session\tskipped\tbaseline_unreadable' ]
+  [ ! -e "$BATS_TEST_TMPDIR/poke" ]
+}

--- a/tests/test_team_status.bats
+++ b/tests/test_team_status.bats
@@ -616,3 +616,80 @@ _herdr_observe_stub() {   # <entries-json>
   [ "$(< "$BATS_TEST_TMPDIR/poke")" = '/rename team-alice' ]
   [ ! -e "$BATS_TEST_TMPDIR/names" ]
 }
+
+# --- codex: --fix / --rename-sessions type UNCONDITIONALLY and confirm NEWNESS ---
+# codex's current name is not dependably readable (its "Thread name:" header
+# scrolls off), so --fix does not gate the keystroke on the (unknown) pre-check.
+# It types and verifies by the rename command's own "Session renamed to <name>."
+# announcement. That line PERSISTS in the scrollback and --fix runs repeatedly (a
+# person may also have typed /rename by hand -- tl seeded exactly this on the live
+# panes), so verification is on the line's NEWNESS (a count increase), never its
+# presence. Read and write are separate capabilities, declared in the manifest
+# (rename_confirm), not branched on the type name (#1109 followup).
+_codex_type_get() {   # codex declares rename_cmd + rename_confirm; name not on title
+  agmsg_type_get() {
+    case "$2" in
+      cli)                 printf 'codex\n' ;;
+      rename_cmd)          printf '/rename\n' ;;
+      rename_confirm)      printf 'Session renamed to\n' ;;
+      session_name_source) printf 'screen:Thread name:\n' ;;
+    esac
+  }
+}
+
+@test "codex session rename: types even when the name is unreadable, verifies a NEW confirmation line" {
+  _codex_type_get
+  : > "$BATS_TEST_TMPDIR/screen"
+  terminal_team_input_ready() { printf 'ready\n'; }
+  terminal_peek() { cat "$BATS_TEST_TMPDIR/screen" 2>/dev/null; }
+  # typing /rename is what makes codex print the confirmation line
+  terminal_poke() {
+    printf '%s\n' "$2" > "$BATS_TEST_TMPDIR/poke"
+    printf 'Session renamed to team-alice. To resume run codex resume\n' >> "$BATS_TEST_TMPDIR/screen"
+  }
+  # session_cell is unknown -- the realistic codex case -- and it must STILL type
+  run agmsg_team_rename_session_loaded team alice codex herdr w2:p3 'unknown:name_not_visible'
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = $'cli_session\tchanged\trenamed_and_verified' ]
+  [ "$(< "$BATS_TEST_TMPDIR/poke")" = '/rename team-alice' ]
+}
+
+@test "codex session rename: a PRE-EXISTING confirmation line does not verify a keystroke that never landed (#1109)" {
+  _codex_type_get
+  # an earlier --fix run, or a hand-typed /rename, already left this line
+  printf 'Session renamed to team-alice. To resume run codex resume\n' > "$BATS_TEST_TMPDIR/screen"
+  terminal_team_input_ready() { printf 'ready\n'; }
+  terminal_peek() { cat "$BATS_TEST_TMPDIR/screen" 2>/dev/null; }
+  terminal_poke() { printf '%s\n' "$2" > "$BATS_TEST_TMPDIR/poke"; }   # keystroke does NOT reach codex
+  sleep() { :; }                                                       # do not wait out the retry loop
+  run agmsg_team_rename_session_loaded team alice codex herdr w2:p3 'unknown:name_not_visible'
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = $'cli_session\tfailed\trename_not_observed' ]
+}
+
+@test "codex session rename: typed but no confirmation line -> failed rename_not_observed" {
+  _codex_type_get
+  : > "$BATS_TEST_TMPDIR/screen"
+  terminal_team_input_ready() { printf 'ready\n'; }
+  terminal_peek() { cat "$BATS_TEST_TMPDIR/screen" 2>/dev/null; }
+  terminal_poke() { printf 'unrelated output\n' >> "$BATS_TEST_TMPDIR/screen"; }   # typed, codex did not confirm
+  sleep() { :; }
+  run agmsg_team_rename_session_loaded team alice codex herdr w2:p3 'unknown:name_not_visible'
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = $'cli_session\tfailed\trename_not_observed' ]
+}
+
+@test "codex session rename: a confirmation line for a DIFFERENT name does not count as ours" {
+  _codex_type_get
+  : > "$BATS_TEST_TMPDIR/screen"
+  terminal_team_input_ready() { printf 'ready\n'; }
+  terminal_peek() { cat "$BATS_TEST_TMPDIR/screen" 2>/dev/null; }
+  # the pane shows another seat's rename; ours never confirms (name-specific match,
+  # so a malformed or foreign name cannot false-verify -- no overlap with the
+  # unknown:name_malformed screen check, which this path does not use)
+  terminal_poke() { printf 'Session renamed to team-bob. To resume run codex resume\n' >> "$BATS_TEST_TMPDIR/screen"; }
+  sleep() { :; }
+  run agmsg_team_rename_session_loaded team alice codex herdr w2:p3 'unknown:name_not_visible'
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = $'cli_session\tfailed\trename_not_observed' ]
+}

--- a/tests/test_team_status.bats
+++ b/tests/test_team_status.bats
@@ -693,3 +693,18 @@ _codex_type_get() {   # codex declares rename_cmd + rename_confirm; name not on 
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = $'cli_session\tfailed\trename_not_observed' ]
 }
+
+@test "codex session rename: never types without positive readiness" {
+  _codex_type_get
+  : > "$BATS_TEST_TMPDIR/screen"
+  # a pane mid-turn: the confirm arm must skip on the readiness gate, before any
+  # keystroke -- the same guard the claude-code arm has, given its own red here so
+  # deleting it cannot pass unnoticed.
+  terminal_team_input_ready() { printf 'not_ready:agent_status_thinking\n'; return 1; }
+  terminal_peek() { cat "$BATS_TEST_TMPDIR/screen" 2>/dev/null; }
+  terminal_poke() { printf 'called\n' > "$BATS_TEST_TMPDIR/poke"; }
+  run agmsg_team_rename_session_loaded team alice codex herdr w2:p3 'unknown:name_not_visible'
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = $'cli_session\tskipped\tnot_ready_agent_status_thinking' ]
+  [ ! -e "$BATS_TEST_TMPDIR/poke" ]
+}


### PR DESCRIPTION
## What

`team --fix` and `--rename-sessions` now rename a codex seat. A codex seat came up named by its CLI and `--fix` never changed it — the release-gate-visible half of "codex's name does not change".

## Why it did not work

The rename command was already declared for codex, so the gap was not "codex cannot be renamed". The session fix arm gated the keystroke on a pre-read of the current name, and codex's name is not dependably readable: its `Thread name:` header appears at session start and scrolls off, so an established session observes as `unknown`, and `unknown` took the `skipped` branch. That conflated "cannot read the name" with "cannot rename".

## The change

Two capabilities, split in the manifest, not branched on a type name:
- A type that declares `rename_confirm` (codex: the `Session renamed to <name>.` line the rename command prints) is NOT pre-checked. `--fix` / `--rename-sessions` type the rename unconditionally and confirm by that announcement.
- A type without it (name on the terminal title) keeps pre-checking and reading the name back — unchanged.

## Newness, not presence

The confirmation line persists in the scrollback and `--fix` runs repeatedly (and a person may type the rename by hand), so the line's presence is not proof this run typed it — an earlier line would pass a keystroke that never landed. The fix counts the confirmation lines before and after the keystroke and requires an increase; the expected name is the same every run, so newness — not the name — separates this rename from a prior one.

## Tests

Assert the success (a new line) and the failures a success-only test would miss: a pre-existing line plus a keystroke that never lands, a keystroke with no confirmation, and a confirmation for a different name. The newness check is mutation-verified (`>=` for `>` reddens the pre-existing-line test). The title-readback path is unchanged and covered by regression. `test_team_status` 49/49, `test_type_registry` 29/29, enforced-assertions at baseline.