### PR TITLE
fix(terminal): a seat finds its own pane by its label, not by its environment

### DIFF
--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -929,8 +929,13 @@ _herdr_internal_key() {
 # works for a codex seat (#1112). Its commands run under one shared app-server,
 # not in its pane, so the inherited HERDR_PANE_ID is the daemon's pane and all of
 # them resolve the same one; and herdr's own agent_session for those panes does
-# not match the thread actually running there. The label does not depend on
-# either: terminal_name wrote it on the pane it named.
+# not match the thread actually running there. The label depends on neither -- it
+# was written per pane rather than inherited by a process.
+#
+# Which is a claim about its FAILURE MODE, not about its truth: the label is
+# written by `spawn`, repaired by `team --fix` and written by seats themselves,
+# so it is written by the same machinery that is producing the wrong answers.
+# Less likely to be wrong, not known to be right.
 terminal_find_by_label() {   # <label>
   local label="$1" json esc
   [ -n "$label" ] || return 0

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -918,6 +918,32 @@ _herdr_internal_key() {
 # placement record's pane id. So under `key` that name is still established and
 # only the decoration is skipped —
 # and a key that cannot be set is an error there, because nothing else happened.
+# Which panes carry this agmsg label? One pane id per line; no match prints
+# nothing and still returns 0.
+#
+# `herdr pane list` returns every pane WITH its label in one call (measured: 38
+# panes, label present on each named one, null on the unnamed), so this needs no
+# per-pane round trip.
+#
+# This exists because neither of the other two ways to answer "which pane am I"
+# works for a codex seat (#1112). Its commands run under one shared app-server,
+# not in its pane, so the inherited HERDR_PANE_ID is the daemon's pane and all of
+# them resolve the same one; and herdr's own agent_session for those panes does
+# not match the thread actually running there. The label does not depend on
+# either: terminal_name wrote it on the pane it named.
+terminal_find_by_label() {   # <label>
+  local label="$1" json esc
+  [ -n "$label" ] || return 0
+  command -v herdr >/dev/null 2>&1 || return 10
+  json="$(herdr pane list 2>/dev/null)" || return 10
+  [ -n "$json" ] || return 10
+  esc="$(printf '%s' "$json" | sed "s/'/''/g")"
+  sqlite3 :memory: "SELECT json_extract(value,'\$.pane_id') FROM json_each('$esc','\$.result.panes')
+                    WHERE json_extract(value,'\$.label') = '$(printf '%s' "$label" | sed "s/'/''/g")'
+                      AND json_extract(value,'\$.pane_id') IS NOT NULL" 2>/dev/null || return 10
+  return 0
+}
+
 terminal_name() {
   local id="$1" team="$2" name="$3" mode="${4:-}" label key
   label="$(_herdr_label "$team" "$name")"

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -944,6 +944,32 @@ terminal_find_by_label() {   # <label>
   return 0
 }
 
+# What agmsg label does THIS one pane carry? Prints it and returns 0; 1 when the
+# pane carries none, 10 when herdr could not be reached, 13 for a ref this driver
+# cannot address.
+#
+# The confirmation half of `terminal_find_by_label` -- see the tmux driver for
+# why this is its own op and not a field of `terminal_team_observe`. Here it is
+# `herdr pane get <id>` against the listing's `herdr pane list`: one pane asked
+# about by name, so a listing whose filter was loose does not get to answer for
+# itself.
+terminal_label_of() {   # <id>
+  local id="$1" pane_json esc label
+  [ -n "$id" ] || return 13
+  command -v herdr >/dev/null 2>&1 || return 10
+  _herdr_pane_id_ok "$id" || return 13
+  pane_json="$(herdr pane get "$id" 2>/dev/null)" || return 10
+  esc="$(printf '%s' "$pane_json" | sed "s/'/''/g")"
+  # NULLIF: json_extract returns SQL NULL for a missing key and '' for a key set
+  # to the empty string, and both mean "this pane carries no label" -- neither is
+  # a label to confirm against. COALESCE alone would let '' through and an empty
+  # target would then confirm itself.
+  label="$(sqlite3 :memory: "SELECT COALESCE(NULLIF(json_extract('$esc','\$.result.pane.label'),''),'')" 2>/dev/null)" || return 10
+  [ -n "$label" ] || return 1
+  printf '%s\n' "$label"
+  return 0
+}
+
 terminal_name() {
   local id="$1" team="$2" name="$3" mode="${4:-}" label key
   label="$(_herdr_label "$team" "$name")"

--- a/scripts/drivers/terminals/plain/ops.sh
+++ b/scripts/drivers/terminals/plain/ops.sh
@@ -150,4 +150,5 @@ terminal_poke() { _plain_no_pane_but_maybe_native "poke"; }
 # plain has no panes to label, so it can never answer this. 13 = unsupported,
 # the same word it uses for every other addressable-pane op.
 terminal_find_by_label() { _plain_unsupported "find_by_label"; }
+terminal_label_of() { _plain_unsupported "label_of"; }
 terminal_name() { _plain_unsupported "name"; }

--- a/scripts/drivers/terminals/plain/ops.sh
+++ b/scripts/drivers/terminals/plain/ops.sh
@@ -147,4 +147,7 @@ terminal_team_observe() {
   printf 'n/a:unsupported\tn/a:no_addressable_pane\tn/a:no_addressable_pane\tn/a:no_addressable_pane\n'
 }
 terminal_poke() { _plain_no_pane_but_maybe_native "poke"; }
+# plain has no panes to label, so it can never answer this. 13 = unsupported,
+# the same word it uses for every other addressable-pane op.
+terminal_find_by_label() { _plain_unsupported "find_by_label"; }
 terminal_name() { _plain_unsupported "name"; }

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -449,13 +449,19 @@ terminal_poke() {
 # Which panes carry this agmsg label? One id per line, socket-qualified like every
 # other id this driver hands out; no match prints nothing and still returns 0.
 #
-# The label is authoritative in a way the environment is not. A seat resolves its
-# own pane from $TMUX_PANE, and for an agent whose commands run somewhere other
-# than its pane -- codex, through one shared app-server -- that answer belongs to
-# whoever started the daemon, so every seat under it resolves the same pane
-# (#1112). terminal_name wrote `@agmsg_agent` on the pane it actually named, so
-# asking the server which pane carries the label asks the thing that was set for
-# that pane and no other.
+# The label is not AUTHORITATIVE -- it is a more recent observation than the
+# alternatives, and that is a weaker claim on purpose. `spawn` writes it, `team
+# --fix` repairs it, and a seat writes it for itself: it is written by the very
+# machinery that is producing wrong answers, so a wrong label is possible and
+# nothing here can rule one out.
+#
+# What it is not is INHERITED. A seat resolves its own pane from $TMUX_PANE, and
+# for an agent whose commands run somewhere other than its pane -- codex, through
+# one shared app-server -- that answer belongs to whoever started the daemon, so
+# every seat under it resolves the same pane, confidently and identically
+# (#1112). `@agmsg_agent` was set on the pane that was actually named, one pane
+# at a time, so asking the server who carries the label asks about a value that
+# was written per pane rather than one that was copied into a process.
 #
 # One call, and the whole server: `-a` so a seat in another session still finds
 # itself. Nothing is filtered by the caller's own $TMUX_PANE on purpose -- that

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -446,6 +446,31 @@ terminal_poke() {
 # <mode> is `key` or absent — see the herdr driver for the split. Here the
 # `@agmsg_agent` pane option is the resolvable one and the window name / pane
 # title is the decoration, so `key` sets the option and stops.
+# Which panes carry this agmsg label? One id per line, socket-qualified like every
+# other id this driver hands out; no match prints nothing and still returns 0.
+#
+# The label is authoritative in a way the environment is not. A seat resolves its
+# own pane from $TMUX_PANE, and for an agent whose commands run somewhere other
+# than its pane -- codex, through one shared app-server -- that answer belongs to
+# whoever started the daemon, so every seat under it resolves the same pane
+# (#1112). terminal_name wrote `@agmsg_agent` on the pane it actually named, so
+# asking the server which pane carries the label asks the thing that was set for
+# that pane and no other.
+#
+# One call, and the whole server: `-a` so a seat in another session still finds
+# itself. Nothing is filtered by the caller's own $TMUX_PANE on purpose -- that
+# is the value under suspicion.
+terminal_find_by_label() {   # <label>
+  local label="$1" out sock
+  [ -n "$label" ] || return 0
+  command -v tmux >/dev/null 2>&1 || return 10
+  sock="${TMUX%%,*}"
+  out="$(_tmux_do "${sock:+$sock:}" list-panes -a -F '#{pane_id}|#{@agmsg_agent}' 2>/dev/null)" || return 10
+  printf '%s\n' "$out" | awk -F '|' -v want="$label" -v sock="$sock" '
+    $0 != "" && $2 == want { if (sock != "") printf "%s:%s\n", sock, $1; else print $1 }'
+  return 0
+}
+
 terminal_name() {
   local id="$1" team="$2" name="$3" mode="${4:-}" label
   label="$team:$name"

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -460,14 +460,75 @@ terminal_poke() {
 # One call, and the whole server: `-a` so a seat in another session still finds
 # itself. Nothing is filtered by the caller's own $TMUX_PANE on purpose -- that
 # is the value under suspicion.
+#
+# THE ID GOES FIRST and the row is split at the FIRST separator, because only the
+# id is constrained. `validate.sh` is a deny-list of path/JSON hazards and '|' is
+# deliberately not among them, so `team|alice` is a legal pair and its label
+# carries a '|' (#1122 review). A trailing label read as "everything after the
+# first separator" survives that; `-F '|'` and field 2 does not -- it would take
+# `team` and call it the whole label, matching a pane that carries a DIFFERENT
+# label whose first segment happens to agree. A pane id is `%<n>`/`@<n>` and can
+# never contain the separator, so putting it in front makes the split exact for
+# every label, not for the ones without a '|' in them.
+#
+# (A label containing a NEWLINE would still split the row itself. That one is
+# closed upstream: `validate.sh` rejects control characters in both halves of the
+# pair, which is why the separator is the only case left to handle here.)
 terminal_find_by_label() {   # <label>
   local label="$1" out sock
   [ -n "$label" ] || return 0
   command -v tmux >/dev/null 2>&1 || return 10
   sock="${TMUX%%,*}"
   out="$(_tmux_do "${sock:+$sock:}" list-panes -a -F '#{pane_id}|#{@agmsg_agent}' 2>/dev/null)" || return 10
-  printf '%s\n' "$out" | awk -F '|' -v want="$label" -v sock="$sock" '
-    $0 != "" && $2 == want { if (sock != "") printf "%s:%s\n", sock, $1; else print $1 }'
+  printf '%s\n' "$out" | awk -v want="$label" -v sock="$sock" '
+    {
+      p = index($0, "|")
+      if (p == 0) next
+      id = substr($0, 1, p - 1)
+      if (substr($0, p + 1) != want) next
+      if (sock != "") printf "%s:%s\n", sock, id; else print id
+    }'
+  return 0
+}
+
+# What agmsg label does THIS one pane carry? Prints it and returns 0; 1 when the
+# pane carries none, 10 when the server could not be reached, 13 for a ref this
+# driver cannot address.
+#
+# The confirmation half of `terminal_find_by_label`: the listing above is a
+# filter, and a filter that is too loose hands back somebody else's pane with
+# nothing in the count to notice. This asks the server about the single pane the
+# listing chose, through a DIFFERENT query (`display-message -t <id>` rather than
+# `list-panes -a`), so a wrong answer has to be wrong twice.
+#
+# Why this op exists rather than reading `terminal_team_observe`: the label does
+# not live in the same observation field for every driver. tmux has no pane-label
+# field of its own, so it publishes the pair as the KEY (`@agmsg_agent`) and its
+# label field is a constant `n/a:no_independent_field`; herdr has a real pane
+# label and its key is a hash. Reading a fixed field position therefore asks the
+# two drivers different questions -- and asked of tmux, a question whose answer
+# can never equal the label. That is not hypothetical: it shipped in the first
+# revision of #1112 and made the tmux label path fail its confirmation every
+# time, silently, while the herdr tests stayed green (#1122 review).
+#
+# Same identity canary as `terminal_team_observe`, for the same reason: the id
+# names a pane on the server the ref points at, and reading a same-numbered pane
+# on another server would answer confidently about the wrong one (#1051). The id
+# is asked for FIRST so the split at the first '|' lands on the constrained side
+# -- see above.
+terminal_label_of() {   # <id>
+  local id="$1" bare idfield facts seen label
+  [ -n "$id" ] || return 13
+  command -v tmux >/dev/null 2>&1 || return 10
+  bare="$(_tmux_bare_of "$id")"
+  idfield="$(_tmux_identity_field "$bare")" || return 13
+  facts="$(_tmux_do "$id" display-message -p -t "$bare" "$idfield|#{@agmsg_agent}" 2>/dev/null)" || return 10
+  case "$facts" in *'|'*) : ;; *) return 10 ;; esac
+  seen="${facts%%|*}"
+  label="${facts#*|}"
+  [ "$seen" = "$bare" ] || return 10
+  [ -n "$label" ] || return 1
+  printf '%s\n' "$label"
   return 0
 }
 

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -135,7 +135,7 @@ agmsg_terminal_has() {
 # what makes a missing op FAIL rather than silently borrow the previously loaded
 # driver's same-named function.
 _AGMSG_TERMINAL_REQUIRED="terminal_check terminal_describe terminal_detect terminal_spawn terminal_despawn terminal_pane_state terminal_peek terminal_poke terminal_where terminal_arrange terminal_name"
-_AGMSG_TERMINAL_OPTIONAL="terminal_team_observe terminal_team_input_ready"
+_AGMSG_TERMINAL_OPTIONAL="terminal_team_observe terminal_team_input_ready terminal_find_by_label terminal_label_of"
 
 # A driver's observation fields carry EITHER an observed value or one of these
 # prefixes, which say why there is no value. They are listed here, once, because
@@ -653,15 +653,28 @@ EOF
   # filtering, and a driver whose filter is loose would hand back somebody else's
   # pane with no way for the count to notice. Ask the pane what label it carries,
   # through the op that reads a single pane, and require the answer.
+  #
+  # Through `terminal_label_of`, NOT a field of `terminal_team_observe`: the pair
+  # does not sit in the same observation field for every driver. tmux has no
+  # pane-label field of its own, so it publishes the pair as the KEY and its
+  # label field is the constant `n/a:no_independent_field`; herdr's label field
+  # is a real label and its key is a hash. Reading a fixed position asks the two
+  # drivers different questions -- and asked of tmux, one whose answer can never
+  # be the label, so on tmux the confirmation failed every single time and the
+  # label path never once resolved. It shipped that way and every test stayed
+  # green, because every test that reached a SUCCESS was a herdr test (#1122
+  # review). The driver knows where its own label lives; ask it by name.
+  #
+  # REQUIRED, not "if it is there". A driver that found a pane by label but
+  # cannot read that label back has not confirmed anything, and an unconfirmed
+  # pane is exactly the thing this whole change refuses to take.
   id="${found#*$tab}"
   name="${found%%$tab*}"
   agmsg_terminal_load "$name" >/dev/null 2>&1 || return 1
-  if declare -F terminal_team_observe >/dev/null 2>&1; then
-    local obs seen
-    obs="$(terminal_team_observe "$id" 2>/dev/null)" || return 1
-    seen="${obs#*$tab}"; seen="${seen%%$tab*}"
-    [ "$seen" = "$label" ] || return 1
-  fi
+  declare -F terminal_label_of >/dev/null 2>&1 || return 1
+  local seen
+  seen="$(terminal_label_of "$id" 2>/dev/null)" || return 1
+  [ "$seen" = "$label" ] || return 1
   printf '%s\n' "$found"
   return 0
 }

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -615,7 +615,15 @@ _agmsg_placement_claimed_by() {   # <ref> <this-seat's-record-path>
 #
 # Two independent roads to one wrong answer is not a coincidence; both read the
 # process tree, and for these seats the process tree is not where they live. The
-# label does not: terminal_name wrote "<team>:<agent>" on the pane it named.
+# label is not read from the process tree: it was written on one pane at a time.
+#
+# That is the whole of the claim, and it is deliberately smaller than "the label
+# is correct". The label is written by `spawn`, repaired by `team --fix` and
+# written by seats naming themselves -- the same machinery whose wrong answers
+# this exists to route around. So a wrong label is possible, and preferring it
+# is a bet that a per-pane write is wrong less often than a value inherited by
+# every process under one daemon. Not authority: a more recent observation, from
+# a source that at least distinguishes one pane from another.
 #
 # EXACTLY ONE, or nothing. The label is not unique by construction -- it is
 # usable only WHEN it is unique, which is a different claim and the one the code
@@ -668,6 +676,15 @@ EOF
   # REQUIRED, not "if it is there". A driver that found a pane by label but
   # cannot read that label back has not confirmed anything, and an unconfirmed
   # pane is exactly the thing this whole change refuses to take.
+  #
+  # AND WHAT IT DOES NOT CATCH, so that nobody reads more into it later: a label
+  # that is simply WRONG. Asking the pane again returns the same wrong label,
+  # because the pane is where the wrong value was written. This catches a driver
+  # whose FILTER is loose -- a listing that answers with a pane it should not
+  # have matched -- and nothing about whether the label on that pane belongs to
+  # this seat. Deciding that needs evidence from outside the naming machinery
+  # entirely (asking the seat to emit something and seeing which pane it lands
+  # in); that is not this function and not this change.
   id="${found#*$tab}"
   name="${found%%$tab*}"
   agmsg_terminal_load "$name" >/dev/null 2>&1 || return 1

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -596,6 +596,76 @@ _agmsg_placement_claimed_by() {   # <ref> <this-seat's-record-path>
   return 0
 }
 
+# Resolve this seat's pane by its LABEL, when the label answers unambiguously.
+# Prints "<terminal>\t<id>" and returns 0; returns 1 for "the label did not
+# settle it", which is not a failure -- the caller falls through to the paths
+# that were here before.
+#
+# WHY this goes first (#1112). The two existing ways to answer "which pane am I"
+# both read something that is not the seat:
+#
+#   the environment    HERDR_PANE_ID / TMUX_PANE, inherited. A codex seat's
+#                      commands run under one shared app-server, not in its pane,
+#                      so all of them inherit the pane that started the daemon --
+#                      measured: three seats resolving one pane while sitting in
+#                      three.
+#   the session id     herdr's agent_session for those panes does not match the
+#                      thread actually running there -- measured on the same
+#                      three seats, and it returns the SAME wrong pane.
+#
+# Two independent roads to one wrong answer is not a coincidence; both read the
+# process tree, and for these seats the process tree is not where they live. The
+# label does not: terminal_name wrote "<team>:<agent>" on the pane it named.
+#
+# EXACTLY ONE, or nothing. The label is not unique by construction -- it is
+# usable only WHEN it is unique, which is a different claim and the one the code
+# makes.
+#
+# Zero matches is the ordinary bootstrap state (nothing has named this seat yet).
+# Two or more is not hypothetical: measured on a real tmux server, two panes
+# carried the same `@agmsg_agent`, both alive, one running a CLI and one a bare
+# shell -- and splitting a labelled pane does NOT copy the option (measured on a
+# dedicated server), so a duplicate is something agmsg itself wrote. Picking the
+# first would choose silently between panes, one of which is someone else's --
+# the failure this whole change exists to stop, re-introduced one layer up. Both
+# fall through.
+_agmsg_terminal_resolve_by_label() {   # <team> <agent>
+  local team="$1" agent="$2" label name ids id line found="" count=0 tab
+  [ -n "$team" ] && [ -n "$agent" ] || return 1
+  label="$team:$agent"
+  tab="$(printf '\t')"
+  local names="herdr tmux plain"
+  [ -n "${AGMSG_TERMINAL_DRIVER:-}" ] && names="$AGMSG_TERMINAL_DRIVER"
+  for name in $names; do
+    agmsg_terminal_load "$name" >/dev/null 2>&1 || continue
+    declare -F terminal_find_by_label >/dev/null 2>&1 || continue
+    ids="$(terminal_find_by_label "$label" 2>/dev/null)" || continue
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      count=$((count + 1))
+      found="$name$tab$line"
+    done <<EOF
+$ids
+EOF
+  done
+  [ "$count" -eq 1 ] || return 1
+  # The count says one; this says it is the RIGHT one. The driver did the
+  # filtering, and a driver whose filter is loose would hand back somebody else's
+  # pane with no way for the count to notice. Ask the pane what label it carries,
+  # through the op that reads a single pane, and require the answer.
+  id="${found#*$tab}"
+  name="${found%%$tab*}"
+  agmsg_terminal_load "$name" >/dev/null 2>&1 || return 1
+  if declare -F terminal_team_observe >/dev/null 2>&1; then
+    local obs seen
+    obs="$(terminal_team_observe "$id" 2>/dev/null)" || return 1
+    seen="${obs#*$tab}"; seen="${seen%%$tab*}"
+    [ "$seen" = "$label" ] || return 1
+  fi
+  printf '%s\n' "$found"
+  return 0
+}
+
 agmsg_terminal_name_self() {
   local sid="${1:-}" team="${2:-}" agent="${3:-}" project="${4:-}" type="${5:-}"
   local write_record="${6:-}"
@@ -631,7 +701,13 @@ agmsg_terminal_name_self() {
   # substitution ends the CALLER before the status can be read -- the shape review
   # caught four times in this branch -- so every capture carries `|| rc=$?`.
   local resolved="" rc=0
-  if [ -n "$sid" ]; then
+  # #1112: the label first, when it settles the question. Falls through silently
+  # when it does not -- zero matches is the ordinary state before anything has
+  # named this seat, and more than one means the label is not identifying here.
+  resolved="$(_agmsg_terminal_resolve_by_label "$team" "$agent" 2>/dev/null)" || resolved=""
+  if [ -n "$resolved" ]; then
+    :                                        # the label answered; skip the rest
+  elif [ -n "$sid" ]; then
     resolved="$(agmsg_terminal_resolve_name "$sid")" || rc=$?
     [ "$rc" -eq 0 ] || return "$rc"        # unnamed: resolver printed the reason
   else

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -1909,7 +1909,11 @@ _fake_herdr_list_anchored_plus() {
 # The op list is DERIVED, not typed: the ABI minus the ops that take no pane id.
 # A new id-taking op therefore fails this test until it is covered, instead of
 # quietly inheriting the old assumption (the fixture-enumeration mistake, again).
-_TMUX_NO_ID_OPS="terminal_check terminal_describe terminal_detect terminal_spawn"
+# terminal_find_by_label is on this list because its argument is a LABEL, not a
+# ref: it searches for the pane rather than being told which one, so there is no
+# owning server in its input to honour -- it asks the server the caller is on.
+# Its confirmation partner terminal_label_of DOES take a ref and is swept.
+_TMUX_NO_ID_OPS="terminal_check terminal_describe terminal_detect terminal_spawn terminal_find_by_label"
 
 # op -> the argument list to call it with, using SOCKID/BAREID as the id slot.
 _tmux_op_args() {
@@ -2323,6 +2327,12 @@ EOF
 if [ "\$1" = -S ]; then shift 2; fi
 if [ "\$1" = list-panes ]; then
   printf '%s\n' '%5|team:alice' '%6|team:alice'   # one CLI, one bare shell -- same label
+elif [ "\$1" = display-message ]; then
+  # BOTH panes confirm the label, because on the real server both really carried
+  # it. Without this the fake would refuse the confirmation instead, and the
+  # count -- the thing this test is about -- would never be what says no:
+  # measured, the 'exactly one -> at least one' mutation left this test GREEN.
+  printf '%s|%s\n' "\$4" 'team:alice'
 fi
 exit 0
 EOF
@@ -2338,4 +2348,138 @@ EOF
   # returns "the first" or "the last" is caught either way.
   refute grep -q '%5' <<<"$output"
   refute grep -q '%6' <<<"$output"
+}
+
+# --- #1112 on tmux: the label path had no test that ever SUCCEEDED -------------
+#
+# Everything above that reaches a resolution is a herdr test. The tmux side was
+# only ever exercised in its falling-through directions -- no match, two matches,
+# the environment regression -- so the confirmation step could read the wrong
+# observation field and fail on EVERY tmux pane without a single red (#1122
+# review). These fill that in: one tmux success, and the two ways it breaks.
+#
+# A fake tmux that answers `list-panes` AND `display-message` from ONE fixture,
+# so the listing and the confirmation cannot disagree by accident -- when a test
+# wants them to disagree it says so, in its own fake.
+_fake_tmux_labels() {   # <pane_id=label> ...
+  local pair id label rows="" cases=""
+  for pair in "$@"; do
+    id="${pair%%=*}"; label="${pair#*=}"
+    rows="$rows$id|$label
+"
+    cases="$cases    '$id') printf '%s|%s\n' '$id' '$label';;
+"
+  done
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = -S ]; then shift 2; fi
+if [ "\$1" = list-panes ]; then
+  cat <<'ROWS'
+$rows
+ROWS
+elif [ "\$1" = display-message ]; then
+  # display-message -p -t <id> <format>: \$4 is the pane asked about. The format
+  # asks for the pane's own id first and its @agmsg_agent second -- answer in
+  # that shape, from the same fixture the listing came from.
+  case "\$4" in
+$cases    *) exit 1;;
+  esac
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/tmux"
+  export PATH="$FAKEBIN:$PATH"
+}
+
+@test "self-identity: a unique tmux label RESOLVES, and it is socket-qualified (#1112)" {
+  # The success this suite never had. Without it the confirmation could read a
+  # field that on tmux can never hold the label -- which is what shipped -- and
+  # every test here stayed green because falling through is what they all
+  # assert.
+  _fake_tmux_labels "%5=team:alice" "%6=agmsg:other"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%9"
+  unset HERDR_ENV HERDR_PANE_ID
+  export AGMSG_TERMINAL_DRIVER=tmux
+
+  run _agmsg_terminal_resolve_by_label team alice
+  [ "$status" -eq 0 ]
+  # Socket-qualified: a bare %5 would address whichever server the ambient
+  # environment happens to point at.
+  [ "$output" = "tmux$(printf '\t')/tmp/fake:%5" ]
+}
+
+@test "self-identity: a tmux label containing '|' resolves to ITS pane, not another (#1112)" {
+  # '|' is legal in both halves of the pair -- validate.sh denies path and JSON
+  # hazards and deliberately not this -- so `team|x:alice` is a label a real seat
+  # can carry. The listing separates the id from the label with '|', so a split
+  # that takes "field 2" reads `team` and calls it the whole label: it would
+  # match this pane for the DIFFERENT label `team`, and miss it for its own.
+  #
+  # Both directions, in one fixture: %5 carries the '|' label, %7 carries the
+  # truncation of it.
+  _fake_tmux_labels "%5=team|x:alice" "%7=team"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%9"
+  unset HERDR_ENV HERDR_PANE_ID
+  export AGMSG_TERMINAL_DRIVER=tmux
+
+  run _agmsg_terminal_resolve_by_label 'team|x' alice
+  [ "$status" -eq 0 ]
+  [ "$output" = "tmux$(printf '\t')/tmp/fake:%5" ]
+
+  # ... and the truncation is not the same pane. Asking for `team` finds %7 only.
+  run _agmsg_terminal_resolve_by_label 'team' ''
+  [ "$status" -ne 0 ]
+}
+
+@test "self-identity: a loose tmux listing is caught by the confirmation (#1112)" {
+  # The tmux partner of the herdr looseness test. The listing claims %5 carries
+  # the label; the pane itself says otherwise. One match is not the same as the
+  # right match, and the count cannot tell the difference.
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = -S ]; then shift 2; fi
+if [ "\$1" = list-panes ]; then
+  printf '%s\n' '%5|team:alice'
+elif [ "\$1" = display-message ]; then
+  printf '%s\n' '%5|agmsg:somebody-else'
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/tmux"
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%9"
+  unset HERDR_ENV HERDR_PANE_ID
+  export AGMSG_TERMINAL_DRIVER=tmux
+
+  run _agmsg_terminal_resolve_by_label team alice
+  [ "$status" -ne 0 ]
+  refute grep -q '%5' <<<"$output"
+}
+
+@test "self-identity: a tmux pane that answers about ANOTHER pane is not confirmed (#1112)" {
+  # The identity canary, on the confirmation. `display-message -t %5` routed to
+  # the wrong server answers about that server's %5 -- confidently, and about a
+  # pane nobody asked about. Here it answers as %9 while carrying the label, so
+  # only the canary can refuse it.
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = -S ]; then shift 2; fi
+if [ "\$1" = list-panes ]; then
+  printf '%s\n' '%5|team:alice'
+elif [ "\$1" = display-message ]; then
+  printf '%s\n' '%9|team:alice'
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/tmux"
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%9"
+  unset HERDR_ENV HERDR_PANE_ID
+  export AGMSG_TERMINAL_DRIVER=tmux
+
+  run _agmsg_terminal_resolve_by_label team alice
+  [ "$status" -ne 0 ]
 }

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2152,3 +2152,190 @@ _tmux_op_args() {
   refute grep -q 'did NOT record it' <<<"$output"
   grep -q '^tmux:/tmp/fake:%1	/proj/NEW	claude-code$' "$mine"
 }
+
+# --- #1112: a seat identifies its own pane by its LABEL ------------------------
+#
+# The environment and the session id both read the process tree, and for a seat
+# whose commands run somewhere other than its pane (codex, under one shared
+# app-server) the process tree is not where it lives: three seats resolve one
+# pane while sitting in three. The label does not depend on either.
+#
+# A fake herdr that answers `pane list` from a fixture, so the 1 / 0 / many cases
+# are set exactly rather than hoped for.
+_fake_herdr_labels() {   # <pane_id=label> ...
+  local entries="" first=1 pair id label
+  for pair in "$@"; do
+    id="${pair%%=*}"; label="${pair#*=}"
+    [ "$first" = 1 ] || entries="$entries,"
+    first=0
+    if [ "$label" = "null" ]; then
+      entries="$entries{\"pane_id\":\"$id\",\"label\":null}"
+    else
+      entries="$entries{\"pane_id\":\"$id\",\"label\":\"$label\"}"
+    fi
+  done
+  cat > "$FAKEBIN/herdr" <<EOF
+#!/usr/bin/env bash
+{ printf 'herdr'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = pane ] && [ "\$2" = list ]; then
+  printf '%s\n' '{"id":"cli:pane:list","result":{"panes":[$entries]}}'
+elif [ "\$1" = pane ] && [ "\$2" = get ]; then
+  # terminal_team_observe reads label from here; answer from the same fixture so
+  # the confirmation step cannot disagree with the listing by construction.
+  case "\$3" in
+$(for pair in "$@"; do id="${pair%%=*}"; label="${pair#*=}"
+    printf '    %s) printf %s;;\n' "$id" "'{\"result\":{\"pane\":{\"agent_status\":\"idle\",\"label\":\"$label\",\"terminal_title\":\"t\"}}}\\n'"
+  done)
+    *) printf '{"result":{"pane":{}}}\n';;
+  esac
+elif [ "\$1" = agent ] && [ "\$2" = list ]; then
+  printf '{"id":"1","result":{"type":"list","agents":[]}}\n'
+elif [ "\$1" = pane ] && [ "\$2" = rename ]; then exit 0
+elif [ "\$1" = agent ] && [ "\$2" = rename ]; then exit 0
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/herdr"
+  export PATH="$FAKEBIN:$PATH"
+}
+
+@test "self-identity: the LABEL wins over an environment pointing at another pane (#1112)" {
+  # #1112 itself. The environment says w1:pDAEMON -- what a codex seat inherits
+  # from the shared app-server -- while the label says this seat is at w1:pMINE.
+  _fake_herdr_labels "w1:pDAEMON=agmsg:other" "w1:pMINE=team:alice"
+  export HERDR_ENV=1 HERDR_PANE_ID="w1:pDAEMON"
+  unset TMUX TMUX_PANE
+  export AGMSG_TERMINAL_DRIVER=herdr
+
+  run _agmsg_terminal_resolve_by_label team alice
+  [ "$status" -eq 0 ]
+  [ "$output" = "herdr$(printf '\t')w1:pMINE" ]
+}
+
+@test "self-identity: no label match falls through, it does not invent a pane (#1112)" {
+  # The ordinary bootstrap state: nothing has named this seat yet. Falling
+  # through is right; answering anything would be worse than answering nothing.
+  _fake_herdr_labels "w1:pDAEMON=agmsg:other" "w1:pX=null"
+  export HERDR_ENV=1 HERDR_PANE_ID="w1:pDAEMON"
+  unset TMUX TMUX_PANE
+  export AGMSG_TERMINAL_DRIVER=herdr
+
+  run _agmsg_terminal_resolve_by_label team alice
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "self-identity: TWO panes with the same label fall through, the first is NOT taken (#1112)" {
+  # The partner that keeps "exactly one" honest. Picking the first would choose
+  # silently between panes, one of which is somebody else's -- the same failure
+  # this change exists to stop, one layer up.
+  _fake_herdr_labels "w1:pONE=team:alice" "w1:pTWO=team:alice"
+  export HERDR_ENV=1 HERDR_PANE_ID="w1:pDAEMON"
+  unset TMUX TMUX_PANE
+  export AGMSG_TERMINAL_DRIVER=herdr
+
+  run _agmsg_terminal_resolve_by_label team alice
+  [ "$status" -ne 0 ]
+  refute grep -q 'pONE' <<<"$output"
+  refute grep -q 'pTWO' <<<"$output"
+}
+
+@test "self-identity: a driver whose filter is loose is caught by the confirmation (#1112)" {
+  # The count says one; that is not the same as it being the RIGHT one. If a
+  # driver's own filter were loose, the count would happily report a single
+  # match that belongs to another seat. The pane is asked what label it carries
+  # before the answer is used.
+  _fake_herdr_labels "w1:pWRONG=team:someone-else"
+  # The listing is made to answer for a label it does not carry: `pane list`
+  # returns the entry, `pane get` reports the truth, and they disagree.
+  cat > "$FAKEBIN/herdr" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = pane ] && [ "\$2" = list ]; then
+  printf '%s\n' '{"id":"1","result":{"panes":[{"pane_id":"w1:pWRONG","label":"team:alice"}]}}'
+elif [ "\$1" = pane ] && [ "\$2" = get ]; then
+  printf '%s\n' '{"result":{"pane":{"agent_status":"idle","label":"team:someone-else","terminal_title":"t"}}}'
+elif [ "\$1" = agent ] && [ "\$2" = list ]; then
+  printf '{"id":"1","result":{"type":"list","agents":[]}}\n'
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/herdr"; export PATH="$FAKEBIN:$PATH"
+  export HERDR_ENV=1 HERDR_PANE_ID="w1:pDAEMON"
+  unset TMUX TMUX_PANE
+  export AGMSG_TERMINAL_DRIVER=herdr
+
+  run _agmsg_terminal_resolve_by_label team alice
+  [ "$status" -ne 0 ]
+}
+
+@test "self-identity: the claude-code/tmux path still answers from the environment (#1112 regression)" {
+  # claude-code resolves correctly from its environment today, and that must not
+  # change. With no label anywhere, resolution falls through to exactly what it
+  # did before.
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  unset HERDR_ENV HERDR_PANE_ID
+  export AGMSG_TERMINAL_DRIVER=tmux
+
+  run agmsg_terminal_resolve_name ""
+  [ "$status" -eq 0 ]
+  [ "$output" = "tmux$(printf '\t')/tmp/fake:%1" ]
+}
+
+@test "self-identity: name_self actually USES the label path, not just the helper (#1112)" {
+  # The three tests above call the resolver directly, so all of them stay green
+  # with the call site deleted from agmsg_terminal_name_self -- measured: the
+  # mutation that removes the wiring produced no red at all. This one goes
+  # through name_self and looks at WHICH PANE the driver was told to rename, so
+  # the wiring is what it pins, not the helper.
+  _fake_herdr_labels "w1:pDAEMON=agmsg:other" "w1:pMINE=team:alice"
+  export HERDR_ENV=1 HERDR_PANE_ID="w1:pDAEMON"
+  unset TMUX TMUX_PANE
+  export AGMSG_TERMINAL_DRIVER=herdr
+  : > "$ARGV_LOG"
+
+  run agmsg_terminal_name_self "" team alice /proj/A claude-code
+  [ "$status" -eq 0 ]
+
+  # Positive control: the driver was called at all, so an absence below is real.
+  grep -q 'herdr \[' "$ARGV_LOG"
+  # The pane it named is the label's, not the inherited environment's.
+  grep -q 'w1:pMINE' "$ARGV_LOG"
+  refute grep -q 'w1:pDAEMON' "$ARGV_LOG"
+}
+
+@test "self-identity: the tmux duplicate seen on a REAL server falls through (#1112)" {
+  # Shaped after the measured case, not an invented one. On a real tmux server
+  # two panes carried the same @agmsg_agent -- both alive (pane_dead=0, both with
+  # pids), one running a CLI and one a bare shell. A duplicate is not a dead
+  # leftover, and it is not `split` inheriting the option either: measured on a
+  # dedicated server, splitting a labelled pane leaves the new pane's option
+  # EMPTY. So the likely origin is a seat that wrote its label onto a pane it does
+  # not live in -- the tmux face of the very bug this resolution exists to fix,
+  # which is exactly why the resolution must not then trust it.
+  #
+  # A local fake, because the shared one does not answer list-panes and other
+  # tests depend on its shape.
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+{ printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = -S ]; then shift 2; fi
+if [ "\$1" = list-panes ]; then
+  printf '%s\n' '%5|team:alice' '%6|team:alice'   # one CLI, one bare shell -- same label
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/tmux"
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%9"
+  unset HERDR_ENV HERDR_PANE_ID
+  export AGMSG_TERMINAL_DRIVER=tmux
+
+  run _agmsg_terminal_resolve_by_label team alice
+  [ "$status" -ne 0 ]
+  # Neither is chosen. Naming the panes individually, so a future change that
+  # returns "the first" or "the last" is caught either way.
+  refute grep -q '%5' <<<"$output"
+  refute grep -q '%6' <<<"$output"
+}


### PR DESCRIPTION
A seat asks "which pane am I" two ways today, and for a codex seat **both answer
with somebody else's pane**.

| | what it reads | what it answers |
|---|---|---|
| the environment | `HERDR_PANE_ID` / `TMUX_PANE`, inherited | a codex seat's commands run under one shared app-server, not in its pane, so every seat under that daemon inherits the pane that started it — measured: three seats all resolving `herdr:w1:p2` while sitting at `w1:p2`, `w1:pN`, `w1:pP` |
| the session id | herdr's `agent_session` | does not match the thread actually running there — measured on the same three seats, and it returns the **same wrong pane** |

Two independent roads to one wrong answer, because both read the process tree
and for these seats the process tree is not where they live. That is the defect:
not a bug in either lookup, but a wrong question asked twice.

## The label does not read the process tree

`terminal_name` wrote `<team>:<agent>` onto the pane it named, and spawn is what
named it. Two measurements, taken **different ways**, agree: each pane's screen
buffer against its label (3/3), and the label field of `herdr pane list` (38
panes, every named seat correct). Different methods reaching the same answer
multiply rather than add.

So resolution tries the label first:

```
label, when EXACTLY ONE pane carries it  ->  that pane
zero or more than one                    ->  fall through, unchanged
```

## Shape of the change

A new driver op, `terminal_find_by_label <label>`, in all three drivers.
**Additive** — no existing op signature changes and no existing caller moves,
which is why nothing outside these tests had to be touched. One call per driver:
`herdr pane list` returns every pane with its label; tmux carries it as the pane
option `@agmsg_agent`. `plain` answers unsupported.

## Exactly-one is a real condition, not a formality

The label is **not unique by construction** — it is usable only when it happens
to be unique, and the code says that rather than the other thing.

Measured on a real tmux server: two panes with the same `@agmsg_agent`, both
alive, one running a CLI and one a bare shell. Splitting a labelled pane does
**not** copy the option (measured on a dedicated server), so a duplicate is
something agmsg itself wrote — most likely a seat labelling a pane it does not
live in, which is this very defect wearing tmux clothes. All the more reason not
to pick the first.

And the count alone is not enough: a driver whose own filter went loose would
return a single match belonging to another seat, and counting would not notice.
The pane is asked what label it carries, through the op that reads one pane,
before the answer is used.

## Not fixed here, deliberately

A seat whose label has never been written — first run, not started by spawn —
still falls through to the inherited environment, which for codex is still
wrong. Every seat that is **up** has a label, and spawn-started seats get their
placement written directly. Covering the bootstrap needs a different mechanism (a
nonce echoed into the pane and read back), worth measuring on its own before
anyone builds it.

## Tests

label matches one / none / two; the label winning over an environment pointing
elsewhere (the defect itself); a loose driver filter caught by the confirmation;
the tmux duplicate shaped after the real observation rather than an invented one;
and the claude-code path still answering from its environment, unchanged.

One of those exists because a mutation found nothing: removing the label call
site from `agmsg_terminal_name_self` left every test green, because they all
called the resolver directly. The wiring now has its own control, which watches
which pane the driver is actually told to rename.

Measured: `test_terminal_registry` 125/0, `test_peek_poke` 36/0, `test_despawn`
18/0, `test_spawn` 108/0, both checkers at baseline.

Fixes #1112
