### PR TITLE
fix(self-name): the fast half asks the pane, instead of trusting the environment twice

### DIFF
--- a/scripts/lib/self-name.sh
+++ b/scripts/lib/self-name.sh
@@ -36,12 +36,20 @@
 #     server generation as the environment shows it (tmux: the pid in $TMUX;
 #     herdr: the socket file's inode+ctime, recreated at server start), so a
 #     restart makes the mark not match and the seat names itself again.
-#   BLIND SPOT, stated rather than papered over: a name removed while the
-#   server generation and the pane are unchanged (someone renamed the pane by
-#   hand, or a terminal that clears names without restarting) is not seen
-#   here -- the mark says named, nothing in the environment says otherwise,
-#   and no terminal call is made. `team --fix` (which observes the terminal)
-#   or `rename` repairs that case; this hook does not claim to.
+#   - the name was removed while the server generation and the pane are
+#     unchanged (someone renamed the pane by hand, or a terminal that clears
+#     names without restarting): the fast half asks the pane which agmsg label
+#     it carries, so the missing name IS seen and the seat names itself again.
+#     This was a stated BLIND SPOT until #1130 -- nothing in the environment
+#     changes, so a check that only read the environment could not know -- and
+#     it is closed by the same read that closed the bigger one below.
+#   - the environment is not this seat's at all: a seat whose commands run
+#     under a shared app-server inherits the daemon's pane, so the environment,
+#     and the mark and record written from it, all agree on somebody else's
+#     pane. That seat is perfectly self-consistent and used to short-circuit
+#     forever (#1130, measured: eleven hours of acting, the record never
+#     moved). The same read catches it, because the daemon's pane carries the
+#     daemon owner's label, not this seat's.
 #
 # Never fails the caller: naming is a side effect of the action, the action is
 # the thing. Every failure path returns 0 after one line on stderr.
@@ -54,6 +62,43 @@ _AGMSG_SELF_NAME_SH=1
 _agmsg_self_name_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${SKILL_DIR:=$(cd "$_agmsg_self_name_dir/../.." && pwd)}"
 export SKILL_DIR
+
+# Does the pane the ENVIRONMENT names actually carry this seat's label? (#1130)
+#
+# The fast half exists to skip work when everything is already in place, and it
+# decided that from the mark, the record and the environment. All three can agree
+# and all three can be WRONG together: a seat whose commands run under a shared
+# app-server inherits the daemon's pane, so the environment answers with somebody
+# else's pane; whatever was written from that answer -- the mark, the record --
+# agrees with it by construction. Such a seat is perfectly self-consistent and
+# short-circuits forever. Measured on this fleet: a seat's record and mark both
+# named another seat's pane and had not moved in eleven hours of that seat acting,
+# because the hook returned here every single time. The label path added in #1112
+# sits in the slow half and was never reached.
+#
+# So the short-circuit is no longer keyed only on the input it was built to
+# distrust. This asks the pane itself, through the per-pane read the confirmation
+# in #1112 uses: if the environment's pane carries this seat's label, the
+# environment agreed with something that is not the environment and the skip is
+# earned. If it carries someone else's label, or none, or cannot be read, it is
+# not -- and the slow half runs, where the label resolves the right pane.
+#
+# It costs one per-pane query on the FAST path only (it is the last condition, so
+# a seat that already has work to do pays nothing extra). Measured on this
+# machine: `herdr pane get` 25 ms, against 71 ms for the `pane list` a full
+# re-resolution would cost; tmux answers `display-message` on a local socket.
+# That is the price of not trusting a value we decided not to trust.
+#
+# Any answer other than "carries my label" is a reason to do the work, INCLUDING
+# an unreadable one: a read that failed is not a pane that matched, and treating
+# it as one is the fold this codebase keeps paying for.
+_agmsg_self_name_env_corroborated() {   # <terminal> <id> <team> <agent>
+  local terminal="$1" id="$2" want="$3:$4" seen
+  agmsg_terminal_load "$terminal" >/dev/null 2>&1 || return 1
+  declare -F terminal_label_of >/dev/null 2>&1 || return 1
+  seen="$(terminal_label_of "$id" 2>/dev/null)" || return 1
+  [ "$seen" = "$want" ]
+}
 
 agmsg_self_name_on_action() {
   local team="${1:-}" agent="${2:-}" project="${3:-}" type="${4:-}"
@@ -97,7 +142,8 @@ agmsg_self_name_on_action() {
     [ -n "$rec" ] && [ -f "$rec" ] && IFS=$'\t' read -r recorded _ < "$rec" 2>/dev/null || true
   fi
   if [ -n "$have" ] && [ "${have%%	*}" = "$ref" ] && [ "${have#*	}" = "$epoch" ] \
-     && [ "$recorded" = "$ref" ]; then
+     && [ "$recorded" = "$ref" ] \
+     && _agmsg_self_name_env_corroborated "$terminal" "$id" "$team" "$agent"; then
     return 0                                 # named AND recorded at where I am
   fi
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -66,18 +66,54 @@ agmsg_renderable_types() {
 # call). Callers set FAKEBIN and ARGV_LOG first; nothing here reads them at
 # source time, so a suite that does not want a fake terminal is unaffected.
 agmsg_install_fake_tmux() {
+  # The label this fake REMEMBERS. A pane option that is set and then never
+  # readable is not a model of tmux: `terminal_label_of` asks a pane which agmsg
+  # label it carries, and code that acts on the answer (the self-naming fast
+  # half, #1130) cannot be tested against a fake that always answers nothing.
+  # So `set-option ... @agmsg_agent <label>` is stored per pane and
+  # `display-message` replays it. Only the one format that asks for the label is
+  # answered; every other format falls through to silence exactly as before, so
+  # suites that depend on this fake's other behaviour are untouched.
+  export FAKE_TMUX_STATE="${FAKE_TMUX_STATE:-$FAKEBIN/tmux.labels}"
+  : > "$FAKE_TMUX_STATE"
   cat > "$FAKEBIN/tmux" <<EOF
 #!/usr/bin/env bash
 { printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
-case "\$1" in
+state='$FAKE_TMUX_STATE'
+args=("\$@")
+if [ "\${args[0]}" = -S ]; then args=("\${args[@]:2}"); fi
+case "\${args[0]}" in
   new-window)   echo '@7' ;;
   split-window) echo '%9' ;;
   capture-pane) printf 'line one\nline two\n' ;;
+  set-option)
+    # set-option -p -t <id> @agmsg_agent <label>
+    if [ "\${args[4]}" = '@agmsg_agent' ]; then
+      pane="\${args[3]}"; label="\${args[5]}"
+      [ -f "\$state" ] && grep -v "^\$pane	" "\$state" > "\$state.new" 2>/dev/null || : > "\$state.new"
+      printf '%s\t%s\n' "\$pane" "\$label" >> "\$state.new"
+      mv "\$state.new" "\$state"
+    fi ;;
+  display-message)
+    # display-message -p -t <id> <format>
+    if [ "\${args[4]}" = '#{pane_id}|#{@agmsg_agent}' ]; then
+      pane="\${args[3]}"
+      label="\$(awk -F'\t' -v p="\$pane" '\$1 == p { print \$2 }' "\$state" 2>/dev/null)"
+      printf '%s|%s\n' "\$pane" "\$label"
+    fi ;;
 esac
 exit 0
 EOF
   chmod +x "$FAKEBIN/tmux"
   export PATH="$FAKEBIN:$PATH"
+}
+
+# Clear the agmsg label the fake tmux remembers for <pane>, without touching the
+# pane or the server -- the state "someone renamed the pane by hand" leaves.
+agmsg_fake_tmux_clear_label() {   # <pane>
+  [ -f "${FAKE_TMUX_STATE:-}" ] || return 0
+  grep -v "^$1	" "$FAKE_TMUX_STATE" > "$FAKE_TMUX_STATE.new" 2>/dev/null || : > "$FAKE_TMUX_STATE.new"
+  mv "$FAKE_TMUX_STATE.new" "$FAKE_TMUX_STATE"
 }
 
 # Skip a test on native Windows / Git Bash (MSYS/MINGW/Cygwin). Use ONLY for

--- a/tests/test_self_name.bats
+++ b/tests/test_self_name.bats
@@ -35,22 +35,68 @@ setup() {
 }
 teardown() { teardown_test_env; }
 
+# The fakes below REMEMBER the label they are told to set, because #1130 makes
+# the fast half read it back: a fake that accepts a name and then answers
+# nothing when asked models a terminal that forgets, which is a different
+# terminal from the one under test. Only the one format that asks for the label
+# is answered; anything else stays silent, as before.
 _install_fake_tmux() {
+  export FAKE_TMUX_STATE="$FAKEBIN/tmux.labels"; : > "$FAKE_TMUX_STATE"
   cat > "$FAKEBIN/tmux" <<EOF
 #!/usr/bin/env bash
 { printf 'tmux'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+state='$FAKE_TMUX_STATE'
+args=("\$@"); [ "\${args[0]}" = -S ] && args=("\${args[@]:2}")
+case "\${args[0]}" in
+  set-option)
+    if [ "\${args[4]}" = '@agmsg_agent' ]; then
+      grep -v "^\${args[3]}	" "\$state" > "\$state.n" 2>/dev/null || : > "\$state.n"
+      printf '%s\t%s\n' "\${args[3]}" "\${args[5]}" >> "\$state.n"; mv "\$state.n" "\$state"
+    fi ;;
+  display-message)
+    if [ "\${args[4]}" = '#{pane_id}|#{@agmsg_agent}' ]; then
+      printf '%s|%s\n' "\${args[3]}" "\$(awk -F'\t' -v p="\${args[3]}" '\$1 == p { print \$2 }' "\$state" 2>/dev/null)"
+    fi ;;
+esac
 exit 0
 EOF
   chmod +x "$FAKEBIN/tmux"
   export PATH="$FAKEBIN:$PATH"
 }
 
+# Clear the label the fake remembers for <pane>, touching neither the pane nor
+# the server -- the state a hand rename leaves.
+_clear_fake_label() {   # <pane>
+  grep -v "^$1	" "$FAKE_TMUX_STATE" > "$FAKE_TMUX_STATE.n" 2>/dev/null || : > "$FAKE_TMUX_STATE.n"
+  mv "$FAKE_TMUX_STATE.n" "$FAKE_TMUX_STATE"
+}
+
 _install_fake_herdr() {
+  export FAKE_HERDR_STATE="$FAKEBIN/herdr.labels"; : > "$FAKE_HERDR_STATE"
   cat > "$FAKEBIN/herdr" <<EOF
 #!/usr/bin/env bash
 { printf 'herdr'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+state='$FAKE_HERDR_STATE'
 if [ "\$1" = agent ] && [ "\$2" = list ]; then
   printf '{"id":"1","result":{"type":"list","agents":[]}}\n'
+elif [ "\$1" = pane ] && [ "\$2" = rename ]; then
+  grep -v "^\$3	" "\$state" > "\$state.n" 2>/dev/null || : > "\$state.n"
+  printf '%s\t%s\n' "\$3" "\$4" >> "\$state.n"; mv "\$state.n" "\$state"
+elif [ "\$1" = pane ] && [ "\$2" = list ]; then
+  rows=""
+  while IFS=\$'\t' read -r pid lbl; do
+    [ -n "\$pid" ] || continue
+    [ -n "\$rows" ] && rows="\$rows,"
+    rows="\$rows{\"pane_id\":\"\$pid\",\"label\":\"\$lbl\"}"
+  done < "\$state"
+  printf '{"id":"1","result":{"panes":[%s]}}\n' "\$rows"
+elif [ "\$1" = pane ] && [ "\$2" = get ]; then
+  lbl="\$(awk -F'\t' -v p="\$3" '\$1 == p { print \$2 }' "\$state" 2>/dev/null)"
+  if [ -n "\$lbl" ]; then
+    printf '{"result":{"pane":{"agent_status":"idle","label":"%s","terminal_title":"t"}}}\n' "\$lbl"
+  else
+    printf '{"result":{"pane":{"agent_status":"idle","terminal_title":"t"}}}\n'
+  fi
 fi
 exit 0
 EOF
@@ -110,13 +156,24 @@ _placement() {   # <team> <agent> -> "<terminal>:<id>" or empty
   [ "$(_mark team alice)" = $'tmux:/tmp/s:%3\tpid=4242' ]
 }
 
-@test "mark present and matching: the action does not call the terminal at all" {
+@test "mark present and matching: the action READS the pane and writes nothing (#1130)" {
+  # The invariant changed with #1130, and the change is the point: the fast half
+  # no longer decides from the environment alone, because a seat whose
+  # environment is somebody else's pane has a mark and a record that agree with
+  # it and short-circuits forever. It asks the pane which label it carries.
+  #
+  # "No calls at all" is therefore gone. What must still hold -- what the old
+  # assertion was protecting -- is that a settled seat does no WORK: it does not
+  # relabel, rekey or rewrite anything, and it does not go listing panes.
   _install_fake_tmux; _under_tmux /tmp/s 4242 %3
   agmsg_self_name_on_action team alice
   : > "$ARGV_LOG"
   agmsg_self_name_on_action team alice
   agmsg_self_name_on_action team alice
-  [ "$(_terminal_calls)" -eq 0 ]
+  [ "$(_name_calls)" -eq 0 ]
+  [ "$(grep -c '\[display-message\]' "$ARGV_LOG")" -eq 2 ]
+  refute grep -q '\[list-panes\]' "$ARGV_LOG"
+  [ "$(_terminal_calls)" -eq 2 ]
 }
 
 @test "mark present, but I am in another pane: named again, and the mark follows" {
@@ -141,16 +198,33 @@ _placement() {   # <team> <agent> -> "<terminal>:<id>" or empty
   [ "$(_mark team alice)" = $'tmux:/tmp/s:%3\tpid=5151' ]
 }
 
-@test "blind spot, pinned: the name removed while pane and server are unchanged is not seen" {
-  # Nothing in the environment changes when a name is cleared by hand, so the
-  # hook cannot know; it is documented as the case team --fix / rename repair.
+@test "the name removed while pane and server are unchanged IS seen now (#1130)" {
+  # This was the documented blind spot. Nothing in the ENVIRONMENT changes when
+  # a label is cleared by hand, so a fast half that read only the environment
+  # could not know, and the case was left to `team --fix` / `rename`. The #1130
+  # read closes it for free: the pane is asked, and the pane says it carries no
+  # agmsg label.
   _install_fake_tmux; _under_tmux /tmp/s 4242 %3
   agmsg_self_name_on_action team alice
+  [ "$(_name_calls)" -eq 1 ]
   : > "$ARGV_LOG"
-  # (the fake tmux has no state to clear; the point is that the hook makes no call)
+
+  # Settled: nothing to do.
   agmsg_self_name_on_action team alice
-  [ "$(_terminal_calls)" -eq 0 ]
-  grep -q 'BLIND SPOT' "$SKILL_DIR/scripts/lib/self-name.sh"
+  [ "$(_name_calls)" -eq 0 ]
+
+  # Someone clears the label by hand. The pane and the server are untouched, so
+  # the mark still matches, and so does the record.
+  _clear_fake_label %3
+  [ "$(_mark team alice)" = $'tmux:/tmp/s:%3\tpid=4242' ]
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+  : > "$ARGV_LOG"
+
+  agmsg_self_name_on_action team alice
+  [ "$(_name_calls)" -eq 1 ]
+  grep -q '\[-t\] \[%3\] \[@agmsg_agent\] \[team:alice\]' "$ARGV_LOG"
+  # And the documentation no longer claims otherwise.
+  refute grep -q 'BLIND SPOT, stated rather than papered over' "$SKILL_DIR/scripts/lib/self-name.sh"
 }
 
 @test "another seat in the same pane names it for itself: its own record has no mark for that pane" {
@@ -181,7 +255,13 @@ _placement() {   # <team> <agent> -> "<terminal>:<id>" or empty
   [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
   : > "$ARGV_LOG"
   agmsg_self_name_on_action team alice
-  [ "$(_terminal_calls)" -eq 0 ]
+  [ "$(_name_calls)" -eq 0 ]
+  # One read per action, no writes. The old assertion here was "no terminal
+  # calls at all"; #1130 makes the fast half ASK the pane which label it
+  # carries, because a seat whose environment is somebody else's pane has a
+  # mark and a record that agree with it and short-circuits forever. What the
+  # old assertion was protecting -- a settled seat does no WORK -- is kept.
+  refute grep -q '\[list-panes\]' "$ARGV_LOG"
 }
 
 @test "the action names first, then a boot path: same key both times" {
@@ -258,7 +338,13 @@ _placement() {   # <team> <agent> -> "<terminal>:<id>" or empty
   agmsg_self_name_on_action team alice
   : > "$ARGV_LOG"
   agmsg_self_name_on_action team alice
-  [ "$(_terminal_calls)" -eq 0 ]
+  [ "$(_name_calls)" -eq 0 ]
+  # One read per action, no writes. The old assertion here was "no terminal
+  # calls at all"; #1130 makes the fast half ASK the pane which label it
+  # carries, because a seat whose environment is somebody else's pane has a
+  # mark and a record that agree with it and short-circuits forever. What the
+  # old assertion was protecting -- a settled seat does no WORK -- is kept.
+  refute grep -q '\[list-panes\]' "$ARGV_LOG"
   # A restarted server recreates its socket. The fingerprint is inode:ctime
   # with ctime in whole seconds, and ext4 hands a just-freed inode straight
   # back (measured on the ubuntu runner: recreate within the same second and
@@ -398,4 +484,59 @@ _placement() {   # <team> <agent> -> "<terminal>:<id>" or empty
   # Control: the same call with the switch at its default names once.
   agmsg_terminal_name_self_safe "sid-1" team alice /tmp/p claude-code
   [ "$(_name_calls)" -eq 1 ]
+}
+
+
+# --- #1130: a seat that is WRONG but perfectly self-consistent -----------------
+
+@test "the environment, the mark and the record all name the SAME wrong pane -- one action moves it (#1130)" {
+  # The state measured on this fleet, reproduced through the code that creates
+  # it rather than hand-written: a seat resolves its pane from an environment it
+  # shares with a daemon, names THAT pane, and records it. Everything it can see
+  # then agrees, so the fast half short-circuits -- forever. The seat acted for
+  # eleven hours and its record never moved.
+  #
+  # Every existing test here starts from a CORRECT seat and asks that it stays
+  # correct. All of them were green while this shipped. This one starts broken.
+  _install_fake_herdr; _under_herdr w1:pDAEMON
+
+  # Act once under the wrong environment: this is how the bad state was made.
+  agmsg_self_name_on_action team alice
+  [ "$(_placement team alice)" = 'herdr:w1:pDAEMON' ]
+  local m0; m0="$(_mark team alice)"
+  [ "${m0%%	*}" = 'herdr:w1:pDAEMON' ]
+
+  # And now the truth: the daemon's pane belongs to the seat that started it,
+  # and this seat's label is on a different pane. (This is what the real server
+  # showed: the label was right, the record was somebody else's pane.)
+  printf 'w1:pDAEMON\tteam:other\nw1:pMINE\tteam:alice\n' > "$FAKE_HERDR_STATE"
+  : > "$ARGV_LOG"
+
+  # ONE ordinary action.
+  agmsg_self_name_on_action team alice
+
+  # It moved. The record is the half peek/poke/despawn resolve through, so this
+  # is the assertion that matters; a test on the label alone stays green.
+  [ "$(_placement team alice)" = 'herdr:w1:pMINE' ]
+  local m; m="$(_mark team alice)"
+  [ "${m%%	*}" = 'herdr:w1:pMINE' ]
+  # And it named ITS OWN pane, not the one it was squatting.
+  grep -q '^herdr \[agent\] \[rename\] \[w1:pMINE\] ' "$ARGV_LOG"
+  refute grep -q '\[rename\] \[w1:pDAEMON\]' "$ARGV_LOG"
+}
+
+@test "a seat whose environment IS its own pane still short-circuits (#1130 control)" {
+  # The partner. "Never short-circuit" also passes the test above, and it would
+  # cost every seat a full re-resolution on every action; this is what stops that
+  # from being the fix.
+  _install_fake_herdr; _under_herdr w1:pB
+  agmsg_self_name_on_action team alice
+  [ "$(_placement team alice)" = 'herdr:w1:pB' ]
+  : > "$ARGV_LOG"
+
+  agmsg_self_name_on_action team alice
+  [ "$(_name_calls)" -eq 0 ]
+  # It asked the pane, and it did NOT go listing panes to do it.
+  grep -q '^herdr \[pane\] \[get\] \[w1:pB\]' "$ARGV_LOG"
+  refute grep -q '\[pane\] \[list\]' "$ARGV_LOG"
 }


### PR DESCRIPTION
Fixes #1130.

The self-naming hook's fast half decided "nothing to do" from the environment,
the naming mark, and the placement record. All three can agree and all three can
be wrong **together**: a seat whose commands run under a shared app-server
inherits the daemon's pane, so the environment answers with somebody else's pane
— and the mark and the record were *written from that answer*, so they agree
with it by construction. Such a seat is perfectly self-consistent and
short-circuits forever.

Measured on this fleet: a seat's record and mark both named another seat's pane
and had not moved in **eleven hours** of that seat acting. The label-first
resolution added in #1112 sits in the slow half and was never reached.

## The fix

Before skipping, ask the pane which agmsg label it carries — the same per-pane
read #1112 uses to confirm a match. If the environment's pane carries this
seat's label, the environment agreed with something that is *not* the
environment and the skip is earned. Anything else — someone else's label, no
label, or a read that failed — is a reason to do the work.

An unreadable answer counts as disagreement, deliberately: a read that failed is
not a pane that matched.

### Why not the two obvious alternatives

| | cost / risk |
|---|---|
| re-resolve fully before comparing | one `pane list` per action — **71 ms** measured on this machine, against **25 ms** for the per-pane read |
| declare in the type manifest that a type shares its environment | a **declaration**; when it goes stale the same failure returns silently. This measures the state instead, so there is nothing to go stale |

It is the **last** condition of the short-circuit, so only the fast path pays
it: a seat that already has work to do makes no extra call.

## It also closes the #1109 blind spot

A label removed while the pane and the server are unchanged changes nothing in
the environment, so a check that read only the environment could not see it. The
pane can be asked. The test that pinned the blind spot is **rewritten in the
other direction rather than deleted**, so why it existed is still on the page.

## Tests

Every existing test here starts from a *correct* seat and asks that it stays
correct — all of them were green while this shipped. Two start broken:

- the environment, the mark and the record all name the same **wrong** pane and
  the seat's label is on a different one; one ordinary action moves the record.
  The bad state is built by the code path that creates it (act once under the
  wrong environment), not written by hand.
- the control: a seat whose environment **is** its own pane still
  short-circuits, and does not go listing panes to decide it. Without this,
  "never short-circuit" passes the first test and costs every seat a full
  re-resolution on every action.

| mutation | reddens |
|---|---|
| the corroboration always agrees (the shipped short-circuit) | **that one test** |
| the corroboration is dropped entirely | 4 |
| the corroboration never agrees (nothing short-circuits) | 6 |
| an unreadable read is treated as agreement (the fold) | the blind-spot test alone |

## `tests/test_helper.bash`

The shared fake tmux now remembers the label it is told to set and replays it.
**A fake that accepts a name and then answers nothing when asked models a
terminal that forgets, which is a different terminal from the one under test** —
the same family as tests that run without `set -u` when every entry point has it
(#1129). Only the one format that asks for the label is answered; every other
format falls through to silence as before.

Blast radius, **derived rather than assumed**: 102 suites, 85 load
`test_helper`, `agmsg_install_fake_tmux` is defined once and called by exactly
**3** of them, with no indirect callers inside the helper.

## Measured

| suite | |
|---|---|
| `test_self_name` | 23 / 0 |
| `test_delivery` | 198 / 0 |
| `test_terminal_registry` | 129 / 0 |
| `test_watch` | 39 / 0 |
| `test_spawn` | 108 / 0 |
| `test_peek_poke` | 36 / 0 |
| `test_inbox` | 15 / 0 |

`check-enforced-assertions` 626 (baseline), `check-errexit-status-reads` 0
(baseline).

**Not run**, and named so the gap is explicit: the other 95 suites. The three
direct callers of the changed helper and the one suite whose own fake I changed
are all above; nothing else references `agmsg_install_fake_tmux`,
`FAKE_TMUX_STATE`, or `agmsg_fake_tmux_clear_label`.