### PR TITLE
fix(team): --fix verifies the placement record against the label and corrects it (#1131)

### DIFF
--- a/scripts/lib/team-status.sh
+++ b/scripts/lib/team-status.sh
@@ -90,6 +90,52 @@ _agmsg_team_fix_result() {
   printf '%s\t%s\t%s\n' "$1" "$2" "$3"
 }
 
+# #1131: the placement record is a CLAIM about which pane a seat lives in, not a
+# guaranteed address. A record can point at ANOTHER seat's pane -- codex's commands
+# run under a shared app-server, so its environment reports the daemon's pane and
+# the record is written for a pane the seat does not live in (measured on live
+# seats: the environment named a pane a DIFFERENT seat was sitting in). Acting on
+# that pane would overwrite the other seat's label -- --fix would break the correct
+# row to match the wrong one. So before --fix trusts the record's pane, verify it
+# against an
+# environment-INDEPENDENT source: the pane whose label is <team>:<agent>, when
+# exactly one carries it (_agmsg_terminal_resolve_by_label, #1112). If the label
+# settles on a pane that DISAGREES with the record, the record is wrong -- rewrite
+# the RECORD (never the other seat's pane) and hand back the verified ref so the
+# caller acts on the real pane.
+#
+# When the label cannot settle it -- zero matches (a seat that never named itself)
+# or more than one -- the record is kept as-is: no worse than today. A seat with no
+# distinguishing label needs a different source entirely -- asking the seat to emit
+# a token and seeing which pane it lands in (the #1124 route) -- which is
+# deliberately out of scope for this change.
+#
+#   agmsg_team_verify_placement <team> <agent> <rec-path> <ref> <project> <type>
+#     -> prints the ref to act on (verified/corrected, or the original), rc 0.
+agmsg_team_verify_placement() {
+  local team="$1" agent="$2" rec="$3" ref="$4" project="$5" type="$6"
+  local verified v_terminal v_id v_ref tab
+  declare -F _agmsg_terminal_resolve_by_label >/dev/null 2>&1 || { printf '%s\n' "$ref"; return 0; }
+  verified="$(_agmsg_terminal_resolve_by_label "$team" "$agent" 2>/dev/null)" || verified=""
+  [ -n "$verified" ] || { printf '%s\n' "$ref"; return 0; }
+  tab="$(printf '\t')"
+  v_terminal="${verified%%"$tab"*}"; v_id="${verified#*"$tab"}"
+  [ -n "$v_terminal" ] && [ -n "$v_id" ] || { printf '%s\n' "$ref"; return 0; }
+  v_ref="$(agmsg_terminal_ref "$v_terminal" "$v_id" 2>/dev/null)" || v_ref=""
+  [ -n "$v_ref" ] || { printf '%s\n' "$ref"; return 0; }
+  if [ "$v_ref" = "$ref" ]; then
+    printf '%s\n' "$ref"; return 0            # the record already names the seat's pane
+  fi
+  # The record names a pane the label says is not this seat's. Correct the RECORD,
+  # atomically (a failed write must not truncate the record it was going to fix),
+  # and act on the pane the label found -- never the other seat's.
+  if declare -F agmsg_write_atomic >/dev/null 2>&1; then
+    agmsg_write_atomic "$rec" "$(printf '%s\t%s\t%s' "$v_ref" "$project" "$type")" 2>/dev/null || true
+  fi
+  printf '%s\n' "$v_ref"
+  return 0
+}
+
 _agmsg_team_identity_field_loaded() {
   local field="$1"; shift
   local identity _activity _al _el _ak _ek _as _es pane_cell key_cell session_cell _consistency

--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -181,13 +181,21 @@ _member_status() {
     _emit_unfixable_actions "$reason"
     return 0
   fi
-  IFS="$(printf '\t')" read -r ref _ _ < "$rec" || true
+  IFS="$(printf '\t')" read -r ref rec_project rec_type < "$rec" || true
   if [ -z "$ref" ]; then
     reason=empty_placement_record
     _emit_unknown_row "$agent" "$type" "$project" unknown "unknown:$reason" \
       "unknown:$reason" "unknown:$reason" "$delivery" "$reason"
     _emit_unfixable_actions "$reason"
     return 0
+  fi
+  # #1131: under a repair verb the record is a CLAIM to verify, not an address to
+  # trust. If the label settles the seat on a different pane, correct the record
+  # and act on the real pane -- so --fix never overwrites another seat's label to
+  # match a wrong record. A read-only `team` status must not rewrite records, so
+  # only --fix / --fix-pane-names / --rename-sessions does this.
+  if [ "$FIX" -eq 1 ] && declare -F agmsg_team_verify_placement >/dev/null 2>&1; then
+    ref="$(agmsg_team_verify_placement "$team" "$agent" "$rec" "$ref" "$rec_project" "$rec_type")"
   fi
   terminal="$(agmsg_terminal_ref_terminal "$ref" 2>/dev/null)" || terminal=""
   pane="$(agmsg_terminal_ref_id "$ref" 2>/dev/null)" || pane=""

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -1088,3 +1088,60 @@ STUB
   grep -qE '^  --fix-pane-names ' <<<"$output"
   grep -qE '^  --rename-sessions ' <<<"$output"
 }
+
+# --- #1131: --fix corrects a record that points at another seat's pane --------------
+# The record is a claim: codex's env reports the shared app-server's pane, so a
+# record can name a pane the seat does not live in. --fix must verify against the
+# label and correct the RECORD, never overwrite the other seat's pane. The fake
+# herdr answers `pane list` so the label resolves, and logs every write so "the
+# other pane was not touched" is a fact about the log.
+_install_misplaced_fixture() {   # alice's record wrongly names w1:pOTHER; her label is on w1:pMINE
+  export MIS_LOG="$BATS_TEST_TMPDIR/herdr.log"; : > "$MIS_LOG"
+  local bin="$BATS_TEST_TMPDIR/bin"; mkdir -p "$bin"
+  cat > "$bin/herdr" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$MIS_LOG"
+case "\$1/\$2" in
+  pane/list) echo '{"result":{"panes":[{"pane_id":"w1:pMINE","label":"fixteam:alice"},{"pane_id":"w1:pOTHER","label":"fixteam:bob"}]}}' ;;
+  pane/get)
+    case "\$3" in
+      w1:pMINE)  echo '{"result":{"pane":{"pane_id":"w1:pMINE","label":"fixteam:alice","agent_status":"idle","terminal_title":"t"}}}' ;;
+      w1:pOTHER) echo '{"result":{"pane":{"pane_id":"w1:pOTHER","label":"fixteam:bob","agent_status":"idle","terminal_title":"t"}}}' ;;
+      *)         echo '{"result":{"pane":{}}}' ;;
+    esac ;;
+  agent/list) echo '{"result":{"agents":[]}}' ;;
+  agent/get)  echo '{"result":{"agent":{"agent":"claude","agent_status":"idle"}}}' ;;
+  *)          echo '{"result":{"type":"ok"}}' ;;
+esac
+STUB
+  chmod +x "$bin/herdr"
+  export PATH="$bin:$PATH"
+  export AGMSG_TERMINAL_DRIVER=herdr
+  bash "$SCRIPTS/join.sh" fixteam alice claude-code /tmp/proj >/dev/null
+  MIS_REC="$(SKILL_DIR="$TEST_SKILL_DIR" bash -c 'cd "$1" && . lib/actas-lock.sh && . lib/terminal-registry.sh && agmsg_spawn_path fixteam alice' _ "$SCRIPTS")"
+  mkdir -p "$(dirname "$MIS_REC")"
+  printf 'herdr:w1:pOTHER\t/tmp/proj\tclaude-code\n' > "$MIS_REC"   # WRONG: another seat's pane
+}
+
+@test "team --fix corrects a record that names another seat's pane, to the seat's own pane (#1131)" {
+  _install_misplaced_fixture
+  run bash "$SCRIPTS/team.sh" fixteam --fix-pane-names
+  [ "$status" -eq 0 ]
+  # (a) the record now names alice's OWN pane (the label's answer), project/type kept
+  [ "$(cat "$MIS_REC")" = $'herdr:w1:pMINE\t/tmp/proj\tclaude-code' ]
+  # positive control: --fix reached the corrected pane at all
+  grep -q '^pane get w1:pMINE$' "$MIS_LOG"
+}
+
+@test "team --fix does NOT write identity onto the pane the wrong record named (#1131)" {
+  _install_misplaced_fixture
+  run bash "$SCRIPTS/team.sh" fixteam --fix-pane-names
+  [ "$status" -eq 0 ]
+  # positive control that does NOT depend on the correction: the fix ran and
+  # observed SOME pane, so an absence below is a real absence -- if it acted on the
+  # record's pane (the bug) the writes to w1:pOTHER would be present.
+  grep -q '^pane get w1:p' "$MIS_LOG"
+  # (b) THE POINT: the other seat's pane was never renamed to alice's identity.
+  refute grep -q '^pane rename w1:pOTHER ' "$MIS_LOG"
+  refute grep -q '^agent rename w1:pOTHER ' "$MIS_LOG"
+}

--- a/tests/test_team_status.bats
+++ b/tests/test_team_status.bats
@@ -731,3 +731,43 @@ _codex_type_get() {   # codex declares rename_cmd + rename_confirm; name not on 
   [ "${lines[0]}" = $'cli_session\tskipped\tbaseline_unreadable' ]
   [ ! -e "$BATS_TEST_TMPDIR/poke" ]
 }
+
+# --- #1131: --fix treats the placement record as a claim, and corrects it -------
+# A record can point at ANOTHER seat's pane (codex's env reports the shared
+# app-server's pane). Verify against the label; if it disagrees, the record is
+# wrong -- rewrite the RECORD, never the other pane. The helper below is the
+# record half; the "other pane untouched" half is the team.sh integration test.
+
+@test "verify_placement: a record naming another pane is corrected to the label's pane (#1131)" {
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/terminal-registry.sh"
+  _agmsg_terminal_resolve_by_label() { printf 'herdr\tw1:pMINE\n'; }   # the label finds the real pane
+  printf 'herdr:w1:pOTHER\t/proj\tclaude-code\n' > "$BATS_TEST_TMPDIR/rec"
+  run agmsg_team_verify_placement team alice "$BATS_TEST_TMPDIR/rec" 'herdr:w1:pOTHER' /proj claude-code
+  [ "$status" -eq 0 ]
+  [ "$output" = 'herdr:w1:pMINE' ]                                     # act on the real pane
+  # the record now names the seat's own pane, project and type preserved
+  [ "$(cat "$BATS_TEST_TMPDIR/rec")" = $'herdr:w1:pMINE\t/proj\tclaude-code' ]
+}
+
+@test "verify_placement: a record already naming the seat's pane is left untouched (#1131)" {
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/terminal-registry.sh"
+  _agmsg_terminal_resolve_by_label() { printf 'herdr\tw1:pMINE\n'; }
+  printf 'herdr:w1:pMINE\t/proj\tclaude-code\n' > "$BATS_TEST_TMPDIR/rec"
+  local before; before="$(cat "$BATS_TEST_TMPDIR/rec")"
+  run agmsg_team_verify_placement team alice "$BATS_TEST_TMPDIR/rec" 'herdr:w1:pMINE' /proj claude-code
+  [ "$output" = 'herdr:w1:pMINE' ]
+  [ "$(cat "$BATS_TEST_TMPDIR/rec")" = "$before" ]
+}
+
+@test "verify_placement: when the label cannot settle it, the record is kept as-is (#1131)" {
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/terminal-registry.sh"
+  _agmsg_terminal_resolve_by_label() { return 1; }                     # zero or many matches
+  printf 'herdr:w1:pOTHER\t/proj\tclaude-code\n' > "$BATS_TEST_TMPDIR/rec"
+  local before; before="$(cat "$BATS_TEST_TMPDIR/rec")"
+  run agmsg_team_verify_placement team alice "$BATS_TEST_TMPDIR/rec" 'herdr:w1:pOTHER' /proj claude-code
+  [ "$output" = 'herdr:w1:pOTHER' ]                                    # keep the record's ref
+  [ "$(cat "$BATS_TEST_TMPDIR/rec")" = "$before" ]                     # NOT rewritten
+}


### PR DESCRIPTION
Closes #1131.

## The problem

`--fix` reads the placement record to decide which pane to repair. The record is a **claim**, not a guaranteed address: a codex seat's commands run under a shared app-server, so its environment reports the daemon's pane, and the record is written for a pane the seat does not live in. `--fix` then repaired the pane the record named — which can be a **different seat's** pane — overwriting the correct row's label to match the wrong record. It made the misplacement worse.

## The change

Before a repair verb trusts the record's pane, verify it against an **environment-independent** source: the pane whose label is `<team>:<agent>`, when exactly one carries it (the resolver #1112 added). If the label settles on a pane that disagrees with the record, the record is wrong — rewrite the **record** (project and type preserved) and act on the pane the label found, never the other seat's. When the label cannot settle it (zero or many matches), the record is kept as-is (no worse than before). A read-only `team` status never rewrites a record; only `--fix` / `--fix-pane-names` / `--rename-sessions` does.

## Tests

- The record half in isolation: a mismatching record is corrected, a matching one is left alone, an unresolvable one is kept.
- The whole `--fix` through `team.sh`, split so each half fails on its own assertion: **(a)** the record now names the seat's own pane, and **(b)** the pane the wrong record named is never written. Reverting to trusting the record reddens (a) and (b) each on its own assertion (mutation-verified).

`test_team_status` 54/54, `test_team` 90/90, enforced-assertions at baseline.

## Scope

A seat with no label to resolve by needs a source outside the naming machinery entirely (a token the seat emits, #1124); that route is deliberately out of scope here — noted in the code where the label cannot settle it.

Base: integration/terminal-driver-v1.