### PR TITLE
fix(self-name): only join fills an empty placement record, and it RESERVES it

### DIFF
--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -254,7 +254,10 @@ if [ "$_agmsg_tr_rc" -eq 0 ] && declare -F agmsg_terminal_name_self_safe >/dev/n
   # depend on that staying true.
   for _nteam in ${TEAM_LIST[@]+"${TEAM_LIST[@]}"}; do
     [ -n "$_nteam" ] || continue
-    agmsg_terminal_name_self_safe "${SESSION_ID:-}" "$_nteam" "$AGENT" "$PROJECT" "$TYPE" || true
+    # `record`: the second of the two later chances to record a seat that was
+    # named without one (#1128). This process is the seat -- the inbox is read in
+    # the seat's own pane -- so it may speak for its placement.
+    agmsg_terminal_name_self_safe "${SESSION_ID:-}" "$_nteam" "$AGENT" "$PROJECT" "$TYPE" record || true
   done
 fi
 

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -254,18 +254,18 @@ if [ "$_agmsg_tr_rc" -eq 0 ] && declare -F agmsg_terminal_name_self_safe >/dev/n
   # depend on that staying true.
   for _nteam in ${TEAM_LIST[@]+"${TEAM_LIST[@]}"}; do
     [ -n "$_nteam" ] || continue
-    # `record_if_unset`: the later chance to record a seat that was named without
-    # one (#1128). The inbox is read in the seat's own pane, so this process can
-    # say "I am somewhere" -- but it does not check that the pane the environment
-    # handed over is where this seat LIVES, and an existing record was written by
-    # something that may have known more. Filling a hole needs no such proof;
-    # correcting a record does, and that belongs to the paths that check the
-    # label first (the action hook since #1130, and `team --fix`).
+    # NAMES ONLY -- no record (#1128, narrowed twice in review). The inbox is
+    # read in the seat's own pane, so this process can say "I am somewhere", but
+    # the pane comes from the resolver and when the label path finds nothing the
+    # resolver falls back to the environment -- which for a seat under a shared
+    # app-server is the daemon's pane (#1112). A hole filled with the wrong pane
+    # is still wrong, and "never overwrite" does not make an unsupported FIRST
+    # record safe.
     #
-    # Measured: with an unconditional `record` here, a record deleted moments
-    # earlier came straight back on the next inbox read -- which is what a
-    # despawn test caught, and it is the same shape as overwriting somebody's.
-    agmsg_terminal_name_self_safe "${SESSION_ID:-}" "$_nteam" "$AGENT" "$PROJECT" "$TYPE" record_if_unset || true
+    # The seat's own next action fills it instead, through lib/self-name.sh,
+    # which since #1130 asks the pane whether it carries this seat's label first.
+    # That is the evidence this path does not have.
+    agmsg_terminal_name_self_safe "${SESSION_ID:-}" "$_nteam" "$AGENT" "$PROJECT" "$TYPE" || true
   done
 fi
 

--- a/scripts/check-inbox.sh
+++ b/scripts/check-inbox.sh
@@ -254,10 +254,18 @@ if [ "$_agmsg_tr_rc" -eq 0 ] && declare -F agmsg_terminal_name_self_safe >/dev/n
   # depend on that staying true.
   for _nteam in ${TEAM_LIST[@]+"${TEAM_LIST[@]}"}; do
     [ -n "$_nteam" ] || continue
-    # `record`: the second of the two later chances to record a seat that was
-    # named without one (#1128). This process is the seat -- the inbox is read in
-    # the seat's own pane -- so it may speak for its placement.
-    agmsg_terminal_name_self_safe "${SESSION_ID:-}" "$_nteam" "$AGENT" "$PROJECT" "$TYPE" record || true
+    # `record_if_unset`: the later chance to record a seat that was named without
+    # one (#1128). The inbox is read in the seat's own pane, so this process can
+    # say "I am somewhere" -- but it does not check that the pane the environment
+    # handed over is where this seat LIVES, and an existing record was written by
+    # something that may have known more. Filling a hole needs no such proof;
+    # correcting a record does, and that belongs to the paths that check the
+    # label first (the action hook since #1130, and `team --fix`).
+    #
+    # Measured: with an unconditional `record` here, a record deleted moments
+    # earlier came straight back on the next inbox read -- which is what a
+    # despawn test caught, and it is the same shape as overwriting somebody's.
+    agmsg_terminal_name_self_safe "${SESSION_ID:-}" "$_nteam" "$AGENT" "$PROJECT" "$TYPE" record_if_unset || true
   done
 fi
 

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -256,8 +256,17 @@ set +e
 [ -r "$SCRIPT_DIR/lib/terminal-registry.sh" ] && . "$SCRIPT_DIR/lib/terminal-registry.sh"
 _agmsg_tr_rc=$?
 [ "$_agmsg_tr_e" = 1 ] && set -e
+# `record`, because joining is the moment this seat becomes addressable and the
+# placement record is what peek/poke/despawn resolve through (#1128). Without it
+# a seat that joined and has not acted yet is named but unreachable -- and the
+# two later chances to pick it up, the watcher and the inbox read, were missing
+# it for the same reason.
+#
+# This process is the seat: join runs in the pane that is joining, and name_self
+# resolves the caller's own pane. See the note at the `record` gate in
+# terminal-registry.sh for the paths that must NOT pass it.
 if [ "$_agmsg_tr_rc" -eq 0 ] && declare -F agmsg_terminal_name_self_safe >/dev/null 2>&1; then
-  agmsg_terminal_name_self_safe "" "$TEAM" "$AGENT_ID" "$PROJECT_PATH" "$AGENT_TYPE" || true
+  agmsg_terminal_name_self_safe "" "$TEAM" "$AGENT_ID" "$PROJECT_PATH" "$AGENT_TYPE" record || true
 fi
 
 echo "Joined team $TEAM as $AGENT_ID"

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -256,17 +256,21 @@ set +e
 [ -r "$SCRIPT_DIR/lib/terminal-registry.sh" ] && . "$SCRIPT_DIR/lib/terminal-registry.sh"
 _agmsg_tr_rc=$?
 [ "$_agmsg_tr_e" = 1 ] && set -e
-# `record`, because joining is the moment this seat becomes addressable and the
-# placement record is what peek/poke/despawn resolve through (#1128). Without it
-# a seat that joined and has not acted yet is named but unreachable -- and the
-# two later chances to pick it up, the watcher and the inbox read, were missing
-# it for the same reason.
+# `record_if_unset`, not `record` (#1128). Joining is the moment this seat
+# becomes addressable, and the placement record is what peek/poke/despawn resolve
+# through -- without it a seat that joined and has not acted yet is named but
+# unreachable. So the hole gets filled here.
 #
-# This process is the seat: join runs in the pane that is joining, and name_self
-# resolves the caller's own pane. See the note at the `record` gate in
-# terminal-registry.sh for the paths that must NOT pass it.
+# It is filled, not corrected. `/agmsg actas` runs join BEFORE actas-claim, and
+# join neither takes nor reads the exclusivity lock (measured on this tree: no
+# lock symbol appears in this file). So two shells can join one name from two
+# panes, and the second `actas` fails with status=held only AFTER an
+# unconditional record would have moved the placement to the pane that lost. An
+# existing record is left alone; #1130 repairs a wrong one when the seat acts,
+# and `team --fix` repairs it from the terminal, both after checking the label
+# this path cannot check.
 if [ "$_agmsg_tr_rc" -eq 0 ] && declare -F agmsg_terminal_name_self_safe >/dev/null 2>&1; then
-  agmsg_terminal_name_self_safe "" "$TEAM" "$AGENT_ID" "$PROJECT_PATH" "$AGENT_TYPE" record || true
+  agmsg_terminal_name_self_safe "" "$TEAM" "$AGENT_ID" "$PROJECT_PATH" "$AGENT_TYPE" record_if_unset || true
 fi
 
 echo "Joined team $TEAM as $AGENT_ID"

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -843,7 +843,34 @@ agmsg_terminal_name_self() {
   # writes a record: it runs in the PARENT's process on behalf of a child, so it
   # writes the child's record itself rather than reaching this line, and the
   # parent's own placement is never what it is claiming.
-  [ "$write_record" = record ] || return 0
+  #
+  # THREE strengths, not two, because the callers differ in what they can show
+  # (#1128):
+  #
+  #   (absent)         name only. The caller is not claiming placement at all.
+  #   record           "this pane is where I live". For a caller that can show
+  #                    it: actas, which has just taken the exclusivity lock;
+  #                    SessionStart; the action hook, which since #1130 asks the
+  #                    pane whether it carries this seat's label before it
+  #                    believes the environment.
+  #   record_if_unset  "nobody has said where I live, and I am somewhere". Fills
+  #                    the hole and never overwrites. For a caller that has a
+  #                    pane but no proof it is the only live instance of the
+  #                    seat -- `join`, which runs BEFORE actas-claim and neither
+  #                    takes nor reads the exclusivity lock (measured: no lock
+  #                    symbol appears in join.sh). Two shells can join one name
+  #                    from two panes; the second `actas` then fails with
+  #                    status=held, but an unconditional record would already
+  #                    have moved the placement to the pane that lost.
+  #
+  # A wrong existing record is not this caller's to repair. #1130 repairs it
+  # when the seat acts, and `team --fix` repairs it from the terminal -- both
+  # after checking the LABEL, which is the evidence join does not have.
+  case "$write_record" in
+    record) : ;;
+    record_if_unset) : ;;   # decided below, once the record path is known
+    *) return 0 ;;
+  esac
 
   # The record is what despawn/peek/poke resolve through, so it is written only
   # after the driver has actually named the pane.
@@ -863,6 +890,13 @@ agmsg_terminal_name_self() {
   [ "$rc" -eq 0 ] && [ -n "$rec" ] && [ -n "$ref" ] || {
     echo "agmsg: named the pane but could not build its record path" >&2; return 1
   }
+  # `record_if_unset` fills a hole; it does not correct one. Decided here rather
+  # than at the caller because the record PATH is built here, and a caller
+  # rebuilding it is a second spelling of the same thing waiting to drift.
+  if [ "$write_record" = record_if_unset ] && [ -f "$rec" ]; then
+    return 0
+  fi
+
   # STOP-GAP (#1113, remove with #1112): do not take a pane another seat's record
   # already claims. Naming SUCCEEDED -- the pane carries this seat's label -- so
   # this returns 0; what is declined is the placement CLAIM, and the reason is

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -893,8 +893,31 @@ agmsg_terminal_name_self() {
   # `record_if_unset` fills a hole; it does not correct one. Decided here rather
   # than at the caller because the record PATH is built here, and a caller
   # rebuilding it is a second spelling of the same thing waiting to drift.
-  if [ "$write_record" = record_if_unset ] && [ -f "$rec" ]; then
-    return 0
+  #
+  # RESERVED, not tested-then-written. `[ -f "$rec" ]` followed by a temp+rename
+  # is check-then-act: two shells joining the same name at once both see it
+  # absent and the later rename wins, which is the exact two-shell race this mode
+  # exists to close (found in review). The reservation below is one atomic
+  # create: under `set -C` bash opens with O_EXCL, so exactly one of them gets
+  # the file and the other is told so by the redirect failing.
+  #
+  # `ln`/`mktemp` are not available to reach for -- `join` must work on a PATH
+  # carrying only bash, dirname, sqlite3, sed, date, mkdir, rmdir, cat, mv, head,
+  # od, tr, sort, basename and paste, and there is a test that enforces it.
+  # `set -C` is a shell builtin, so it costs nothing from that list.
+  #
+  # Two steps rather than one so that BOTH properties hold: existence is decided
+  # atomically here, and the content still arrives through the atomic write
+  # below, into a file this process now owns. A process killed between them
+  # leaves an empty record, which `peek` reports as a record with no pane id
+  # rather than resolving something wrong.
+  if [ "$write_record" = record_if_unset ]; then
+    local _reserved=0 _had_C=0
+    case $- in *C*) _had_C=1 ;; esac
+    set -C
+    if : > "$rec" 2>/dev/null; then _reserved=1; fi
+    [ "$_had_C" = 1 ] || set +C
+    [ "$_reserved" = 1 ] || return 0     # somebody else holds it; nothing to fill
   fi
 
   # STOP-GAP (#1113, remove with #1112): do not take a pane another seat's record

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -821,13 +821,28 @@ agmsg_terminal_name_self() {
   # this function only ever names the CALLER'S OWN pane -- resolved from the
   # caller's session id or, with an empty sid, its environment (above) -- so
   # `record` asserts "the pane I just resolved as mine is where I live". The
-  # callers that pass it are exactly the self-locating ones: SessionStart and
-  # actas name the seat as it starts, and the action hook (self-name.sh) does the
-  # same on every action for a hand-started seat that was never recorded (#1109).
-  # A future path that names a pane it was HANDED -- batch relabeling of someone
-  # else's pane -- must NOT pass record: it is not that seat and cannot speak for
-  # its placement. (spawn records too, but writes the record itself for the CHILD
-  # pane it created; it does not reach this line.)
+  # callers that pass it are exactly the self-locating ones -- every path that
+  # runs IN the seat's own process, ABOUT itself:
+  #
+  #   join.sh          the seat registers; this is when it becomes addressable
+  #   actas-claim.sh   the seat takes a role
+  #   session-start.sh the seat starts
+  #   watch.sh         the watcher re-arms for pairs this process serves
+  #   check-inbox.sh   the seat reads its own inbox
+  #   lib/self-name.sh the action hook, for a hand-started seat (#1109)
+  #
+  # The first, fourth and fifth did NOT pass it until #1128, so a seat that
+  # joined and had not acted yet was named and unrecorded -- addressable by
+  # label, unreachable by peek/poke, with both later chances to notice it also
+  # silent.
+  #
+  # The exclusion is not "which script" but "who is being named". A path that
+  # names a pane it was HANDED -- batch relabeling of someone else's pane -- must
+  # NOT pass record: it is not that seat and cannot speak for its placement. That
+  # is why spawn is absent from the list above even though it names a pane and
+  # writes a record: it runs in the PARENT's process on behalf of a child, so it
+  # writes the child's record itself rather than reaching this line, and the
+  # parent's own placement is never what it is claiming.
   [ "$write_record" = record ] || return 0
 
   # The record is what despawn/peek/poke resolve through, so it is written only

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -841,45 +841,34 @@ fi
 # session id and its pairs just as well, and the requirement is about the pane
 # having a name, not about which mode the watcher is in.
 #
-# `record` ONLY with an actas name (#1128, narrowed in review).
+# NO record, in either mode (#1128, narrowed twice in review).
 #
-# The first draft passed it always, on the argument that the actas-lock filter
-# above has already removed every pair owned by another live session, so what is
-# left is this process's to speak for. That argument does not reach far enough.
-# "Not held by anyone else" is not "here": a seat can be unheld and living in
-# another pane entirely, and a broad watcher subscribes to every unheld identity
-# of the project rather than to a particular seat. Recording from broad mode
-# therefore puts SOME identity in this pane on no evidence -- and the placement
-# guard, which refuses the second differently-named pair, only limits that to one
-# arbitrary false placement instead of preventing it.
+# The watcher NAMES -- naming is idempotent and says only "this pane carries this
+# label", which is not a claim about where the seat lives. It does not record.
 #
-# With an actas name the watcher was launched FOR one seat and serves only that
-# pair (the filter above narrows PAIRS to it), so it knows whose pane this is.
-# Without one it does not, and a claim it cannot support is not worth the repair
-# it would sometimes make: an unrecorded seat is fixed by its own next action
-# (lib/self-name.sh), which runs as the seat and can prove it.
+# Broad mode cannot: it subscribes to every identity of the project that no other
+# live session holds, which is not the same as every identity that lives HERE, so
+# a record from there puts SOME seat in this pane on no evidence. Limiting that
+# to one arbitrary false placement -- all the #1114 guard does -- is not
+# preventing it.
 #
-# And with an actas name it fills a hole rather than correcting one:
-# `record_if_unset`, the same strength `join` uses. Being launched FOR a seat
-# says this session acts as it; it does not check that the pane the environment
-# handed over is where that seat lives, and an existing record was written by
-# something that may have known more. The existing despawn suite already
-# encodes this -- "a record for (team, alice) proves a pane was placed for that
-# seat, never that THIS process is in it" -- and an unconditional record from
-# here broke exactly that test. Correcting a wrong record belongs to the paths
-# that check the LABEL first: the action hook (#1130) and `team --fix`.
+# With an actas name it still cannot show enough. Being launched FOR a seat says
+# this session acts as it; the pane comes from the resolver, and when the label
+# path finds nothing the resolver falls back to the environment -- which for a
+# seat under a shared app-server is the daemon's pane (#1112). "Never overwrite"
+# does not make an unsupported FIRST record safe: a hole filled with the wrong
+# pane is still wrong, and it then blocks the paths that could have filled it
+# right.
 #
-# The watcher still NAMES in both modes -- naming is idempotent and says only
-# "this pane carries this label", which is not a claim about where the seat
-# lives.
+# Nothing is lost by declining. A seat with no record gets one from its own next
+# action, through lib/self-name.sh, which since #1130 asks the pane whether it
+# carries this seat's label before it believes the environment. That is the
+# evidence this path does not have, and waiting one action for it is cheaper than
+# a wrong record nobody notices.
 if declare -F agmsg_terminal_name_self_safe >/dev/null 2>&1; then
   while IFS=$'\t' read -r _nt _na; do
     [ -z "$_nt" ] && continue
-    if [ -n "$ACTIVE_NAME" ]; then
-      agmsg_terminal_name_self_safe "$SESSION_ID" "$_nt" "$_na" "$PROJECT_PATH" "$AGENT_TYPE" record_if_unset || true
-    else
-      agmsg_terminal_name_self_safe "$SESSION_ID" "$_nt" "$_na" "$PROJECT_PATH" "$AGENT_TYPE" || true
-    fi
+    agmsg_terminal_name_self_safe "$SESSION_ID" "$_nt" "$_na" "$PROJECT_PATH" "$AGENT_TYPE" || true
   done <<< "$PAIRS"
 fi
 

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -841,12 +841,26 @@ fi
 # session id and its pairs just as well, and the requirement is about the pane
 # having a name, not about which mode the watcher is in.
 #
-# No record is written: holding the seat is `actas`'s claim to make, and a
-# watcher can be running for a seat it did not claim.
+# `record` IS written (#1128). The older reason not to -- "a watcher can be
+# running for a seat it did not claim" -- is about the actas EXCLUSIVITY claim,
+# which is a different claim from placement: one says who may act as the seat,
+# the other says which pane the seat is in. And the pairs that reach here have
+# already had the first question answered: the actas-lock filter above removed
+# every pair owned by another live session, so what is left is pairs this
+# process legitimately serves, in the pane this process is in.
+#
+# The watcher matters here because it is one of the two places a seat that was
+# named without a record gets picked up later -- and it was missing `record` for
+# the same reason join was (#1111).
+#
+# With more than one DIFFERENTLY-named pair in one pane, the second is refused by
+# the placement guard and says so on stderr; that is the guard working as
+# designed (#1114), not this call being wrong. Pairs that differ only by TEAM are
+# the same seat and are not refused.
 if declare -F agmsg_terminal_name_self_safe >/dev/null 2>&1; then
   while IFS=$'\t' read -r _nt _na; do
     [ -z "$_nt" ] && continue
-    agmsg_terminal_name_self_safe "$SESSION_ID" "$_nt" "$_na" "$PROJECT_PATH" "$AGENT_TYPE" || true
+    agmsg_terminal_name_self_safe "$SESSION_ID" "$_nt" "$_na" "$PROJECT_PATH" "$AGENT_TYPE" record || true
   done <<< "$PAIRS"
 fi
 

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -841,26 +841,45 @@ fi
 # session id and its pairs just as well, and the requirement is about the pane
 # having a name, not about which mode the watcher is in.
 #
-# `record` IS written (#1128). The older reason not to -- "a watcher can be
-# running for a seat it did not claim" -- is about the actas EXCLUSIVITY claim,
-# which is a different claim from placement: one says who may act as the seat,
-# the other says which pane the seat is in. And the pairs that reach here have
-# already had the first question answered: the actas-lock filter above removed
-# every pair owned by another live session, so what is left is pairs this
-# process legitimately serves, in the pane this process is in.
+# `record` ONLY with an actas name (#1128, narrowed in review).
 #
-# The watcher matters here because it is one of the two places a seat that was
-# named without a record gets picked up later -- and it was missing `record` for
-# the same reason join was (#1111).
+# The first draft passed it always, on the argument that the actas-lock filter
+# above has already removed every pair owned by another live session, so what is
+# left is this process's to speak for. That argument does not reach far enough.
+# "Not held by anyone else" is not "here": a seat can be unheld and living in
+# another pane entirely, and a broad watcher subscribes to every unheld identity
+# of the project rather than to a particular seat. Recording from broad mode
+# therefore puts SOME identity in this pane on no evidence -- and the placement
+# guard, which refuses the second differently-named pair, only limits that to one
+# arbitrary false placement instead of preventing it.
 #
-# With more than one DIFFERENTLY-named pair in one pane, the second is refused by
-# the placement guard and says so on stderr; that is the guard working as
-# designed (#1114), not this call being wrong. Pairs that differ only by TEAM are
-# the same seat and are not refused.
+# With an actas name the watcher was launched FOR one seat and serves only that
+# pair (the filter above narrows PAIRS to it), so it knows whose pane this is.
+# Without one it does not, and a claim it cannot support is not worth the repair
+# it would sometimes make: an unrecorded seat is fixed by its own next action
+# (lib/self-name.sh), which runs as the seat and can prove it.
+#
+# And with an actas name it fills a hole rather than correcting one:
+# `record_if_unset`, the same strength `join` uses. Being launched FOR a seat
+# says this session acts as it; it does not check that the pane the environment
+# handed over is where that seat lives, and an existing record was written by
+# something that may have known more. The existing despawn suite already
+# encodes this -- "a record for (team, alice) proves a pane was placed for that
+# seat, never that THIS process is in it" -- and an unconditional record from
+# here broke exactly that test. Correcting a wrong record belongs to the paths
+# that check the LABEL first: the action hook (#1130) and `team --fix`.
+#
+# The watcher still NAMES in both modes -- naming is idempotent and says only
+# "this pane carries this label", which is not a claim about where the seat
+# lives.
 if declare -F agmsg_terminal_name_self_safe >/dev/null 2>&1; then
   while IFS=$'\t' read -r _nt _na; do
     [ -z "$_nt" ] && continue
-    agmsg_terminal_name_self_safe "$SESSION_ID" "$_nt" "$_na" "$PROJECT_PATH" "$AGENT_TYPE" record || true
+    if [ -n "$ACTIVE_NAME" ]; then
+      agmsg_terminal_name_self_safe "$SESSION_ID" "$_nt" "$_na" "$PROJECT_PATH" "$AGENT_TYPE" record_if_unset || true
+    else
+      agmsg_terminal_name_self_safe "$SESSION_ID" "$_nt" "$_na" "$PROJECT_PATH" "$AGENT_TYPE" || true
+    fi
   done <<< "$PAIRS"
 fi
 

--- a/tests/test_despawn.bats
+++ b/tests/test_despawn.bats
@@ -328,6 +328,16 @@ _despawn_member_with_env() {   # <bindir> <env assignments...>
   # DESPAWN_BIN (optional) is prepended for the CALLER only, never for the
   # watcher: a stub that has to break one of despawn's own syscalls must not also
   # break the watcher's unrelated cleanup, or the test measures two things.
+  # DESPAWN_DROP_RECORD=1: remove the member's placement record after it is up
+  # and before despawn runs. Since #1128 both `join` and an actas-named watcher
+  # fill an EMPTY record, so "deliberately no record" can no longer be arranged
+  # by simply not writing one -- the member writes its own. Removing it here
+  # keeps the case the test is about (despawn with nothing to resolve) instead
+  # of quietly turning that test into a different one.
+  if [ "${DESPAWN_DROP_RECORD:-}" = 1 ]; then
+    rm -f "$(_spawn_rec_path team alice)"
+  fi
+
   DESPAWN_RC=0
   PATH="${DESPAWN_BIN:+$DESPAWN_BIN:}$bindir:$PATH" bash "$SCRIPTS/despawn.sh" \
     team leader alice --timeout 10 >"$RUN/despawn.out" 2>"$RUN/despawn.err" || DESPAWN_RC=$?
@@ -366,9 +376,21 @@ _despawn_member_with_env() {   # <bindir> <env assignments...>
 @test "despawn: graceful — no placement record closes nothing, and says why" {
   local bin="$BATS_TEST_TMPDIR/bin"
   _stub_tmux "$bin"
-  # deliberately NO record written
-
-  _despawn_member_with_env "$bin" TMUX=/tmp/fake-tmux-socket,0,0 TMUX_PANE=%9
+  # Deliberately NO record at despawn time. Since #1128 a member fills its own
+  # empty record -- `join` does, and so does an actas-named watcher -- so this
+  # state has to be arranged rather than assumed.
+  #
+  # BOTH halves are needed, and the second one is not belt-and-braces. The
+  # watcher writes its readiness sentinel BEFORE it names (watch.sh: the
+  # sentinel at ~827, the naming block at ~875), and the helper returns as soon
+  # as the sentinel appears -- so removing the record at that moment races the
+  # naming that is about to recreate it. Measured: the same test passed or
+  # failed depending on how much other work happened in between.
+  # AGMSG_SELF_NAME=off makes the watcher name nothing, which is exactly the
+  # member this test is about -- one that never named itself -- and removes the
+  # race instead of widening a window.
+  DESPAWN_DROP_RECORD=1 _despawn_member_with_env "$bin" \
+    AGMSG_SELF_NAME=off TMUX=/tmp/fake-tmux-socket,0,0 TMUX_PANE=%9
 
   # Nothing was closed...
   if [ -f "$bin/tmux.log" ]; then

--- a/tests/test_placement_on_join.bats
+++ b/tests/test_placement_on_join.bats
@@ -83,38 +83,40 @@ _join() { bash "$SCRIPTS/join.sh" "$1" "$2" claude-code "$PROJ" >/dev/null 2>&1;
 
 # --- the watcher re-arming ----------------------------------------------------
 
-@test "placement: a watcher launched FOR a seat records that seat (#1128)" {
-  # The watcher records only with an actas name, because only then does it know
-  # whose pane this is -- see the broad-mode test below, which is the half that
-  # keeps this one from being "record whatever you are subscribed to".
+@test "placement: a watcher does NOT record, in either mode (#1128)" {
+  # Narrowed twice in review, and this is where it landed. Being launched FOR a
+  # seat says this session acts as it; the pane still comes from the resolver,
+  # and when the label path finds nothing the resolver falls back to the
+  # environment -- the daemon's pane, for a seat under a shared app-server. A
+  # hole filled with the wrong pane is still wrong.
   _join team alice
   rm -f "$SKILL_DIR"/run/spawn.*
 
   AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" watch-sid-1128 "$PROJ" claude-code alice \
     >/dev/null 2>&1 3>&- &
   local pid=$!
-  local i
-  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
-    [ -n "$(_placement team alice)" ] && break
-    sleep 1
-  done
+  sleep 4
   kill "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
 
-  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+  [ -z "$(_placement team alice)" ]
+  # Positive control: it ran and it NAMED, so the absence is a decision.
+  grep -q '\[@agmsg_agent\] \[team:alice\]' "$ARGV_LOG"
 }
 
 # --- the inbox read -----------------------------------------------------------
 
-@test "placement: reading the inbox records the seat's pane (#1128)" {
-  # The second later chance. check-inbox.sh is the turn hook: it runs in the
-  # seat's own pane, about itself, so it may speak for its placement.
+@test "placement: reading the inbox does NOT record (#1128)" {
+  # Same reason as the watcher: the turn hook runs in the seat's own pane, but
+  # the pane comes from the resolver and can be the shared environment's. The
+  # seat's own next ACTION fills the record instead, through lib/self-name.sh,
+  # which since #1130 asks the pane whether it carries this seat's label first.
   _join team alice
   rm -f "$SKILL_DIR"/run/spawn.*
 
   echo '{}' | bash "$SCRIPTS/check-inbox.sh" claude-code "$PROJ" >/dev/null 2>&1 || true
 
-  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+  [ -z "$(_placement team alice)" ]
 }
 
 # --- the other direction: one pane cannot be two differently-named seats -------
@@ -211,4 +213,102 @@ _join() { bash "$SCRIPTS/join.sh" "$1" "$2" claude-code "$PROJ" >/dev/null 2>&1;
   run bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ"
   [ "$status" -eq 0 ]
   [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+}
+
+# --- the reservation is atomic, not check-then-act ----------------------------
+#
+# Raised in review: `[ -f "$rec" ]` followed by a temp+rename is check-then-act.
+# Two shells joining the same name at once both see it absent and the later
+# rename wins -- the exact two-shell race this mode exists to close. The
+# reservation is now one atomic create (`set -C`, so bash opens with O_EXCL).
+
+@test "placement: a rival that arrives inside the window is REFUSED, not clobbered (#1128)" {
+  # The deterministic form, at the seam instead of through timing. Eight
+  # concurrent joins do NOT catch this: measured, reverting the reservation to
+  # `[ -f ] && return` left that test green, because the window is small and
+  # whichever writer lands last still leaves one whole value. A race control
+  # that cannot fail is not a control.
+  #
+  # So the rival is placed exactly in the window: after this process has decided
+  # the record is absent, before its content is written. The rival follows the
+  # same protocol a real second join would -- an exclusive create -- so what is
+  # measured is whether OUR side had already taken the file.
+  #
+  #   reserved first  -> the rival's create fails; it never writes
+  #   check-then-act  -> the rival's create succeeds, it writes, and our later
+  #                      write lands on top of it
+  source "$SKILL_DIR/scripts/lib/terminal-registry.sh"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  export TMUX="/tmp/s,4242,0" TMUX_PANE="%3"
+  local rec; rec="$(agmsg_spawn_path team alice)"
+  mkdir -p "$(dirname "$rec")"
+  rm -f "$rec"
+
+  local flag="$BATS_TEST_TMPDIR/rival.created"
+  eval "_real_write_atomic() $(declare -f agmsg_write_atomic | tail -n +2)"
+  agmsg_write_atomic() {
+    # A second joiner, arriving now, doing exactly what this code does.
+    local had_C=0; case $- in *C*) had_C=1 ;; esac
+    set -C
+    if : > "$1" 2>/dev/null; then
+      : > "$flag"
+      printf 'tmux:/tmp/s:%%RIVAL\t/proj/R\tclaude-code\n' > "$1"
+    fi
+    [ "$had_C" = 1 ] || set +C
+    _real_write_atomic "$@"
+  }
+
+  agmsg_terminal_name_self "" team alice /proj/A claude-code record_if_unset
+
+  # The rival never got the file. (If it had, our write would have landed on top
+  # of it -- silently, which is the whole point.)
+  [ ! -f "$flag" ] || { echo "a rival created the record inside the window and was overwritten"; return 1; }
+  local r; IFS=$'\t' read -r r _ < "$rec"
+  [ "$r" = 'tmux:/tmp/s:%3' ]
+}
+
+@test "placement: concurrent first joins leave ONE whole record, not a mixture (#1128)" {
+  # Many joins at once, each from a different pane, all with nothing recorded.
+  # Exactly one of them may win, the file must hold that one's value whole, and
+  # it must not change afterwards.
+  bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null 2>&1
+  rm -f "$SKILL_DIR"/run/spawn.team__alice
+
+  local i pids=""
+  for i in 1 2 3 4 5 6 7 8; do
+    ( export TMUX="/tmp/s,4242,0" TMUX_PANE="%$i"
+      bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null 2>&1 ) &
+    pids="$pids $!"
+  done
+  for i in $pids; do wait "$i" 2>/dev/null || true; done
+
+  local got; got="$(_placement team alice)"
+  [ -n "$got" ] || { echo "no record was written at all"; return 1; }
+  # ONE writer's value, whole. A mixture (a clobbered rename landing on another
+  # writer's bytes) would not match any of them.
+  case "$got" in
+    tmux:/tmp/s:%1|tmux:/tmp/s:%2|tmux:/tmp/s:%3|tmux:/tmp/s:%4|\
+    tmux:/tmp/s:%5|tmux:/tmp/s:%6|tmux:/tmp/s:%7|tmux:/tmp/s:%8) : ;;
+    *) echo "record is not any single writer's value: '$got'"; return 1 ;;
+  esac
+
+  # And the winner stands: a ninth join from yet another pane changes nothing.
+  ( export TMUX="/tmp/s,4242,0" TMUX_PANE="%9"
+    bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ" >/dev/null 2>&1 )
+  [ "$(_placement team alice)" = "$got" ]
+}
+
+@test "placement: the reservation refuses a record that appears first (#1128)" {
+  # The deterministic half of the race, at the seam rather than through timing:
+  # the destination exists at reservation time, so the fill declines and the
+  # bytes that were there stay there -- byte for byte, because a rewrite that
+  # changed only the trailing newline would pass a string comparison.
+  _join team alice
+  local rec; rec="$(_recpath team alice)"
+  printf 'tmux:/tmp/s:%%FIRST\t/proj/F\tclaude-code\n' > "$rec"
+  local snap="$BATS_TEST_TMPDIR/first.snapshot"; cp "$rec" "$snap"
+
+  run bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ"
+  [ "$status" -eq 0 ]
+  cmp -s "$rec" "$snap"
 }

--- a/tests/test_placement_on_join.bats
+++ b/tests/test_placement_on_join.bats
@@ -112,3 +112,60 @@ _join() { bash "$SCRIPTS/join.sh" "$1" "$2" claude-code "$PROJ" >/dev/null 2>&1;
 
   [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
 }
+
+# --- the other direction: one pane cannot be two differently-named seats -------
+#
+# Raised in review of this change: the watcher serves every pair not held by
+# another live session, and "not held" says nothing about where that pair
+# actually is. Passing `record` for each of them would write THIS pane as the
+# placement of whichever one is reached first.
+#
+# It does not, and the reason is not in this file: the #1114 placement guard
+# refuses a pane another seat's record already claims. What is here is the proof
+# that the two changes meet correctly -- each alone is defensible and the seam is
+# where it would go wrong.
+
+@test "placement: a second, differently-named seat does not take the first one's pane (#1128)" {
+  _join team alice
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+
+  # A second seat joins from the SAME pane. It is a different name, so it is not
+  # "this seat under another team" and the guard treats it as what it is.
+  run bash "$SCRIPTS/join.sh" team bob claude-code "$PROJ"
+  [ "$status" -eq 0 ]
+
+  # alice keeps the pane, and bob did not take it.
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+  [ -z "$(_placement team bob)" ]
+  # And the refusal named the seat that holds it, rather than failing silently.
+  run bash -c "bash '$SCRIPTS/join.sh' team carol claude-code '$PROJ' 2>&1 >/dev/null"
+  grep -q 'already recorded as' <<<"$output"
+  grep -q 'team__alice' <<<"$output"
+}
+
+@test "placement: a broad watcher serving two names records ONE pane, not two (#1128)" {
+  # The shape review asked about, driven through the watcher rather than join.
+  # Both pairs are registered for this project and neither is held elsewhere, so
+  # both are in the watcher's subscription.
+  _join team alice
+  _join team bob
+  rm -f "$SKILL_DIR"/run/spawn.*
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" watch-sid-two "$PROJ" claude-code \
+    >/dev/null 2>&1 3>&- &
+  local pid=$! i
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+    [ -n "$(_placement team alice)$(_placement team bob)" ] && break
+    sleep 1
+  done
+  sleep 2
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  # Exactly one of them holds this pane. Which one is not the point and is not
+  # asserted -- that would pin an iteration order nothing promises.
+  local n=0
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ] && n=$((n + 1))
+  [ "$(_placement team bob)" = 'tmux:/tmp/s:%3' ] && n=$((n + 1))
+  [ "$n" -eq 1 ] || { echo "seats holding this pane: $n (alice='$(_placement team alice)' bob='$(_placement team bob)')"; return 1; }
+}

--- a/tests/test_placement_on_join.bats
+++ b/tests/test_placement_on_join.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+#
+# A seat that has JOINED and never acted must already be reachable (#1128).
+#
+# `agmsg_terminal_name_self` names the pane always and writes the placement
+# record only when its sixth argument is `record`. Three of the six call sites
+# did not pass it, and they were the three that matter most for a hand-started
+# seat: `join.sh` (the moment the seat becomes addressable) and the two later
+# chances to notice a seat that was named without a record -- the watcher
+# re-arming and the inbox read. So the seat carried its label and nothing knew
+# which pane it was in; `peek` refused with "no placement record".
+#
+# Why this file exists rather than one more assertion in the naming suites: an
+# assertion that the pane WAS NAMED stays green with the record write deleted --
+# that is precisely how these three were missed. Each test here asserts the
+# RECORD, and then that `peek` reaches the pane through it. Deleting the
+# `record` argument from one script reddens that script's test and no other.
+
+setup() {
+  load 'test_helper'
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  export PROJ="$TEST_SKILL_DIR/project"
+  mkdir -p "$PROJ" "$SKILL_DIR/run"
+  FAKEBIN="$BATS_TEST_TMPDIR/bin"; mkdir -p "$FAKEBIN"
+  ARGV_LOG="$BATS_TEST_TMPDIR/argv.log"; : > "$ARGV_LOG"
+  export FAKEBIN ARGV_LOG
+  agmsg_install_fake_tmux
+  # A pane of our own to be found in, and the seat is never asked to act.
+  export TMUX="/tmp/s,4242,0" TMUX_PANE="%3"
+}
+teardown() { teardown_test_env; }
+
+# The placement record's ref -- the half peek/poke/despawn resolve through.
+_placement() {   # <team> <agent>
+  local rec r
+  rec="$(bash -c '. "'"$SKILL_DIR"'/scripts/lib/actas-lock.sh"; agmsg_spawn_path "$1" "$2"' _ "$1" "$2")" || return 0
+  [ -f "$rec" ] || return 0
+  IFS=$'\t' read -r r _ < "$rec" || return 0
+  printf '%s' "$r"
+}
+
+# Does `peek` reach the pane? Asserted through the real entry point, because the
+# record exists to be resolved by it and nothing else proves that end to end.
+_peek_reaches() {   # <team> <agent>
+  local out
+  out="$(bash "$SCRIPTS/peek.sh" "$1" "$2" 2>&1)" || {
+    printf '%s' "$out"; return 1
+  }
+  printf '%s' "$out"
+}
+
+_join() { bash "$SCRIPTS/join.sh" "$1" "$2" claude-code "$PROJ" >/dev/null 2>&1; }
+
+# --- join --------------------------------------------------------------------
+
+@test "placement: a seat that joined and never acted is recorded and peek reaches it (#1128)" {
+  _join team alice
+  # The record, not the name. `_name_calls`-style assertions pass without it.
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+
+  run _peek_reaches team alice
+  [ "$status" -eq 0 ]
+  refute grep -q 'no placement record' <<<"$output"
+  # Positive control: peek actually went to the pane, on the record's own server.
+  grep -q 'tmux \[-S\] \[/tmp/s\] \[capture-pane\]' "$ARGV_LOG"
+}
+
+@test "placement: with no record, peek says exactly that -- the state #1128 left behind (#1128)" {
+  # The other direction, so the test above is not passed by "peek always works".
+  # A seat registered without ever being named: no record, and peek refuses by
+  # name rather than resolving something else.
+  _join team alice
+  rm -f "$SKILL_DIR"/run/spawn.*
+  run _peek_reaches team alice
+  [ "$status" -ne 0 ]
+  grep -q 'no placement record' <<<"$output"
+}
+
+# --- the watcher re-arming ----------------------------------------------------
+
+@test "placement: the watcher records the pairs it serves (#1128)" {
+  # One of the two later chances to pick up a seat that was named without a
+  # record. The watcher is run for one interval and stopped; the naming block
+  # runs at startup, before any polling.
+  _join team alice
+  rm -f "$SKILL_DIR"/run/spawn.*
+
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" watch-sid-1128 "$PROJ" claude-code \
+    >/dev/null 2>&1 3>&- &
+  local pid=$!
+  local i
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+    [ -n "$(_placement team alice)" ] && break
+    sleep 1
+  done
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+}
+
+# --- the inbox read -----------------------------------------------------------
+
+@test "placement: reading the inbox records the seat's pane (#1128)" {
+  # The second later chance. check-inbox.sh is the turn hook: it runs in the
+  # seat's own pane, about itself, so it may speak for its placement.
+  _join team alice
+  rm -f "$SKILL_DIR"/run/spawn.*
+
+  echo '{}' | bash "$SCRIPTS/check-inbox.sh" claude-code "$PROJ" >/dev/null 2>&1 || true
+
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+}

--- a/tests/test_placement_on_join.bats
+++ b/tests/test_placement_on_join.bats
@@ -40,6 +40,10 @@ _placement() {   # <team> <agent>
   printf '%s' "$r"
 }
 
+_recpath() {   # <team> <agent>
+  bash -c '. "'"$SKILL_DIR"'/scripts/lib/actas-lock.sh"; agmsg_spawn_path "$1" "$2"' _ "$1" "$2"
+}
+
 # Does `peek` reach the pane? Asserted through the real entry point, because the
 # record exists to be resolved by it and nothing else proves that end to end.
 _peek_reaches() {   # <team> <agent>
@@ -79,14 +83,14 @@ _join() { bash "$SCRIPTS/join.sh" "$1" "$2" claude-code "$PROJ" >/dev/null 2>&1;
 
 # --- the watcher re-arming ----------------------------------------------------
 
-@test "placement: the watcher records the pairs it serves (#1128)" {
-  # One of the two later chances to pick up a seat that was named without a
-  # record. The watcher is run for one interval and stopped; the naming block
-  # runs at startup, before any polling.
+@test "placement: a watcher launched FOR a seat records that seat (#1128)" {
+  # The watcher records only with an actas name, because only then does it know
+  # whose pane this is -- see the broad-mode test below, which is the half that
+  # keeps this one from being "record whatever you are subscribed to".
   _join team alice
   rm -f "$SKILL_DIR"/run/spawn.*
 
-  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" watch-sid-1128 "$PROJ" claude-code \
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" watch-sid-1128 "$PROJ" claude-code alice \
     >/dev/null 2>&1 3>&- &
   local pid=$!
   local i
@@ -143,29 +147,68 @@ _join() { bash "$SCRIPTS/join.sh" "$1" "$2" claude-code "$PROJ" >/dev/null 2>&1;
   grep -q 'team__alice' <<<"$output"
 }
 
-@test "placement: a broad watcher serving two names records ONE pane, not two (#1128)" {
-  # The shape review asked about, driven through the watcher rather than join.
-  # Both pairs are registered for this project and neither is held elsewhere, so
-  # both are in the watcher's subscription.
+@test "placement: a BROAD watcher records nothing at all (#1128)" {
+  # Raised in review, and the first draft got it wrong. A broad watcher
+  # subscribes to every identity of the project that no other live session
+  # holds -- which is not the same as every identity that lives HERE. It has no
+  # evidence which of them, if any, is in this pane.
+  #
+  # The first version of this test asked for "exactly one record" on the theory
+  # that the #1114 placement guard refuses the second. That limits an arbitrary
+  # false placement to one; it does not prevent it. The contract is zero: a
+  # process that cannot say whose pane this is does not get to say.
   _join team alice
   _join team bob
   rm -f "$SKILL_DIR"/run/spawn.*
 
-  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" watch-sid-two "$PROJ" claude-code \
+  AGMSG_WATCH_INTERVAL=1 bash "$SCRIPTS/watch.sh" watch-sid-broad "$PROJ" claude-code \
     >/dev/null 2>&1 3>&- &
-  local pid=$! i
-  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
-    [ -n "$(_placement team alice)$(_placement team bob)" ] && break
-    sleep 1
-  done
-  sleep 2
+  local pid=$!
+  sleep 4
   kill "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
 
-  # Exactly one of them holds this pane. Which one is not the point and is not
-  # asserted -- that would pin an iteration order nothing promises.
-  local n=0
-  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ] && n=$((n + 1))
-  [ "$(_placement team bob)" = 'tmux:/tmp/s:%3' ] && n=$((n + 1))
-  [ "$n" -eq 1 ] || { echo "seats holding this pane: $n (alice='$(_placement team alice)' bob='$(_placement team bob)')"; return 1; }
+  # Nothing recorded, for either of them.
+  [ -z "$(_placement team alice)" ]
+  [ -z "$(_placement team bob)" ]
+  # Positive control: the watcher DID run and DID name, so the absence above is
+  # a decision and not a watcher that never started.
+  grep -q '\[@agmsg_agent\]' "$ARGV_LOG"
+}
+
+@test "placement: join does not overwrite an existing record, whoever wrote it (#1128)" {
+  # The other half of "join fills the hole". join runs BEFORE actas-claim and
+  # neither takes nor reads the exclusivity lock -- measured, no lock symbol
+  # appears in join.sh -- so two shells can join one name from two panes, and
+  # the loser's `actas` fails with status=held only after an unconditional
+  # record would already have moved the placement to the loser's pane.
+  #
+  # So an existing record stands, whatever it says. Repairing a wrong one
+  # belongs to the paths that check the LABEL first (#1130 on action, and
+  # `team --fix`); this one cannot check it.
+  _join team alice
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+
+  printf 'tmux:/tmp/s:%%OTHER\t/proj/X\tclaude-code\n' > "$(_recpath team alice)"
+  : > "$ARGV_LOG"
+
+  run bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ"
+  [ "$status" -eq 0 ]
+
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%OTHER' ]
+  # Positive control: join ran and NAMED the pane, so the record standing still
+  # is a decision and not a join that did nothing.
+  grep -q '\[@agmsg_agent\] \[team:alice\]' "$ARGV_LOG"
+}
+
+@test "placement: join DOES write when there is no record (#1128 control)" {
+  # The partner. "Never record from join" also passes the test above, and it is
+  # exactly the state #1128 exists to end.
+  _join team alice
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
+  rm -f "$SKILL_DIR"/run/spawn.team__alice
+
+  run bash "$SCRIPTS/join.sh" team alice claude-code "$PROJ"
+  [ "$status" -eq 0 ]
+  [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
 }

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -1537,45 +1537,67 @@ M
 # `record`, which is measured: adding it to join.sh:260 leaves every test in this
 # file and in test_actas_integration green. A safe default proves nothing about
 # who takes it.
-@test "join: this seat's own STALE record is overwritten with where it joined from (#1128)" {
-  # This test used to assert the opposite -- that join names the pane and leaves
-  # the record alone -- and it is rewritten rather than deleted, because the
-  # reason it existed is worth keeping on the page: join does not take the actas
-  # lock, so "may I speak for this seat's placement" is a fair question to ask
-  # of it.
+@test "join: an existing placement record is left alone (#1128)" {
+  # This test has now been written three ways, and the reason it kept moving is
+  # worth leaving here. It began as "join names the pane but does NOT take the
+  # seat's placement". #1128 made join record, so it was rewritten as "join
+  # overwrites its own stale record", on the argument that two live instances of
+  # one seat cannot exist because actas forbids it. That argument does not hold
+  # for THIS path: `/agmsg actas` runs join BEFORE actas-claim, and join neither
+  # takes nor reads the exclusivity lock -- measured, no lock symbol appears in
+  # join.sh. Two shells can join one name from two panes; the second `actas`
+  # fails with status=held, but only after an unconditional record would have
+  # moved the placement to the pane that lost.
   #
-  # The answer (#1128): yes, for its OWN record. A seat joining from %1 is at
-  # %1, and a record saying otherwise is stale. Two live instances of one seat
-  # are what the actas exclusivity lock prevents, and it is the same reason the
-  # #1114 placement guard skips this seat's own records rather than treating
-  # them as rivals. What join must NOT do is speak for a seat it is not -- see
-  # the proxy-join test below, which is that half.
+  # So join FILLS the hole and does not correct one, and the original question
+  # -- may join speak for this seat's placement? -- keeps the answer it had.
   _install_fake_tmux
   export PATH="$FAKEBIN:$PATH"
   export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
   export AGMSG_STORAGE_PATH="$TEST_SKILL_DIR/db/messages.db"
   source "$SKILL_DIR/scripts/lib/actas-lock.sh"
 
-  # A stale record for this identity, pointing at a pane it is no longer in.
+  # A placement already held for this identity, and a byte-for-byte snapshot.
   local rec; rec="$(agmsg_spawn_path seatteam alice)"
   mkdir -p "$(dirname "$rec")"
   printf 'tmux:%%HELD\t/proj/OLD\tclaude-code\n' > "$rec"
+  local snapshot="$BATS_TEST_TMPDIR/placement.snapshot"
+  cp "$rec" "$snapshot"
 
   run bash "$SKILL_DIR/scripts/join.sh" seatteam alice claude-code /proj/A
   [ "$status" -eq 0 ]
 
   # Positive control FIRST: join reached the naming step and the pane really was
-  # named. Without it a join that skipped naming altogether would also leave a
-  # record behind, and this test would read that as the property holding.
+  # named. Without it a join that skipped naming altogether also leaves the
+  # record alone, and this test would read that as the property holding.
   grep -q '\[select-pane\]' "$ARGV_LOG" || grep -q '\[set-option\]' "$ARGV_LOG"
 
-  # The record now says where the seat joined from.
+  # `cmp`, not `[ "$(cat …)" = … ]`: command substitution strips every trailing
+  # newline, so the string form is blind to a rewrite that changes only that.
+  cmp -s "$rec" "$snapshot"
+  grep -q '%HELD' "$rec"
+  grep -q '/proj/OLD' "$rec"
+}
+
+@test "join: with NO existing record, join writes one (#1128 control)" {
+  # The partner, and the whole point of #1128: without it the test above is
+  # passed by a join that never records anything, which is the state that left
+  # hand-started seats unreachable.
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  export AGMSG_STORAGE_PATH="$TEST_SKILL_DIR/db/messages.db"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+
+  local rec; rec="$(agmsg_spawn_path seatteam alice)"
+  [ ! -f "$rec" ]
+
+  run bash "$SKILL_DIR/scripts/join.sh" seatteam alice claude-code /proj/A
+  [ "$status" -eq 0 ]
+
+  [ -f "$rec" ]
   local r; IFS=$'\t' read -r r _ < "$rec"
   [ "$r" = 'tmux:/tmp/fake:%1' ]
-  # And the stale one is gone -- named individually, so a rewrite that appended
-  # instead of replacing is caught.
-  refute grep -q '%HELD' "$rec"
-  refute grep -q '/proj/OLD' "$rec"
 }
 
 @test "join on behalf of ANOTHER seat writes no record (#1128, the #1096 half)" {

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -1537,38 +1537,77 @@ M
 # `record`, which is measured: adding it to join.sh:260 leaves every test in this
 # file and in test_actas_integration green. A safe default proves nothing about
 # who takes it.
-@test "join: names the pane but does NOT take the seat's placement" {
+@test "join: this seat's own STALE record is overwritten with where it joined from (#1128)" {
+  # This test used to assert the opposite -- that join names the pane and leaves
+  # the record alone -- and it is rewritten rather than deleted, because the
+  # reason it existed is worth keeping on the page: join does not take the actas
+  # lock, so "may I speak for this seat's placement" is a fair question to ask
+  # of it.
+  #
+  # The answer (#1128): yes, for its OWN record. A seat joining from %1 is at
+  # %1, and a record saying otherwise is stale. Two live instances of one seat
+  # are what the actas exclusivity lock prevents, and it is the same reason the
+  # #1114 placement guard skips this seat's own records rather than treating
+  # them as rivals. What join must NOT do is speak for a seat it is not -- see
+  # the proxy-join test below, which is that half.
   _install_fake_tmux
   export PATH="$FAKEBIN:$PATH"
   export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
   export AGMSG_STORAGE_PATH="$TEST_SKILL_DIR/db/messages.db"
   source "$SKILL_DIR/scripts/lib/actas-lock.sh"
 
-  # A placement already held for this identity by whoever actually claimed it,
-  # and a byte-for-byte snapshot of it to compare against afterwards.
+  # A stale record for this identity, pointing at a pane it is no longer in.
   local rec; rec="$(agmsg_spawn_path seatteam alice)"
   mkdir -p "$(dirname "$rec")"
   printf 'tmux:%%HELD\t/proj/OLD\tclaude-code\n' > "$rec"
-  local snapshot="$BATS_TEST_TMPDIR/placement.snapshot"
-  cp "$rec" "$snapshot"
 
   run bash "$SKILL_DIR/scripts/join.sh" seatteam alice claude-code /proj/A
   [ "$status" -eq 0 ]
 
   # Positive control FIRST: join reached the naming step and the pane really was
-  # named. Without it a join that skipped naming altogether also leaves the record
-  # alone, and this test would read that as the property holding.
+  # named. Without it a join that skipped naming altogether would also leave a
+  # record behind, and this test would read that as the property holding.
   grep -q '\[select-pane\]' "$ARGV_LOG" || grep -q '\[set-option\]' "$ARGV_LOG"
 
-  # The seat's placement is not join's to take. `cmp`, not `[ "$(cat …)" = … ]`:
-  # command substitution strips every trailing newline, so the string form is
-  # blind to a rewrite that changes only that — measured, both ways, before this
-  # line was written. Compared against the whole file, not against "a record
-  # exists": a version that emptied it would pass the weaker form.
-  cmp -s "$rec" "$snapshot"
-  # What that file still says, spelled out for the next reader.
-  grep -q '%HELD' "$rec"
-  grep -q '/proj/OLD' "$rec"
+  # The record now says where the seat joined from.
+  local r; IFS=$'\t' read -r r _ < "$rec"
+  [ "$r" = 'tmux:/tmp/fake:%1' ]
+  # And the stale one is gone -- named individually, so a rewrite that appended
+  # instead of replacing is caught.
+  refute grep -q '%HELD' "$rec"
+  refute grep -q '/proj/OLD' "$rec"
+}
+
+@test "join on behalf of ANOTHER seat writes no record (#1128, the #1096 half)" {
+  # The other half, and the one that keeps the test above honest. `spawn` runs
+  # join.sh in the CALLER'S process for the member it is creating (#1096's proxy
+  # join), so everything join resolves "from its own environment" is the
+  # caller's pane, not the new member's. Writing a record there would make the
+  # caller's pane the new member's placement -- #1096 itself, returning through
+  # a different door.
+  #
+  # spawn sets AGMSG_SELF_NAME=off on that one subprocess (spawn.sh), and the
+  # primitive checks it first, so naming and recording both stop. That was read
+  # rather than measured until this test.
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%1"
+  export AGMSG_STORAGE_PATH="$TEST_SKILL_DIR/db/messages.db"
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+
+  local rec; rec="$(agmsg_spawn_path seatteam newmember)"
+  [ ! -f "$rec" ]
+
+  run env AGMSG_SELF_NAME=off bash "$SKILL_DIR/scripts/join.sh" \
+    seatteam newmember claude-code /proj/A
+  [ "$status" -eq 0 ]
+
+  # No record: the caller's pane is not this member's placement.
+  [ ! -f "$rec" ]
+  # And nothing was named either -- the switch is about the whole act, not only
+  # the record. (Positive control that the fake was reachable at all: the
+  # previous test in this file names through the same fake and logs it.)
+  refute grep -q '\[@agmsg_agent\] \[seatteam:newmember\]' "$ARGV_LOG"
 }
 
 # --- AGMSG_TERMINAL_NAMING=off drops the label and keeps the key (#1044) ------


### PR DESCRIPTION
Fixes #1128.

A seat that joined and had not acted yet carried its label and nothing knew
which pane it was in — `peek` refused with "no placement record". `join.sh`
never passed the argument that writes one.

**Narrowed three times in review**, and each narrowing removed a claim nothing
could support. The PR is worth reading for the narrowings, not the original
diff.

## Who may write

Only `join`. The watcher and the inbox read **name and do not record**.

The argument is the one that removed broad mode, carried further. Being launched
*for* a seat, or reading that seat's own inbox, says this process **acts as**
the seat — it does not say the pane came from anywhere better than the
environment. When the label path finds nothing the resolver falls back to
exactly the shared app-server environment #1112 is about, so a hole filled from
there is filled with the daemon's pane. **"Never overwrite" does not make an
unsupported *first* record safe** — a wrong record blocks the paths that could
have filled it right.

Nothing is lost: a seat with no record gets one from its own next action,
through `lib/self-name.sh`, which since #1130 asks the pane whether it carries
this seat's label before believing the environment.

`join` keeps it because its authority is different in kind — it is the process
that is registering, in the pane it is registering from, at a moment when the
pane has no label yet for anyone to check.

## How it writes

`record_if_unset` **reserves** the record rather than testing for it.
`[ -f "$rec" ]` followed by a temp+rename is check-then-act: two shells joining
one name at once both see it absent and the later rename wins — the exact race
this mode exists to close. The reservation is a single atomic create (`set -C`,
so bash opens with `O_EXCL`).

`ln` and `mktemp` were not options: `join` must work on a PATH carrying only
bash, dirname, sqlite3, sed, date, mkdir, rmdir, cat, mv, head, od, tr, sort,
basename and paste, and there is a test that enforces it. `set -C` is a builtin.

Two steps, so both properties hold: existence is decided atomically, and the
content still arrives through the atomic write into a file this process owns. A
process killed between them leaves an empty record, which `peek` reports as a
record with no pane id rather than resolving something wrong.

## The race control had to be rewritten

Eight concurrent joins did **not** catch this. Measured: reverting the
reservation to `[ -f ] && return` left that test green, because the window is
small and whichever writer lands last still leaves one whole value. **A race
control that cannot fail is not a control.**

The deterministic form puts a rival exactly in the window — after this process
decides the record is absent, before its content is written — following the same
exclusive-create protocol a real second join would:

| | |
|---|---|
| reserved first | the rival's create fails; it never writes |
| check-then-act | the rival creates, writes, and is silently overwritten |

## Mutations

| mutation | reddens |
|---|---|
| the reservation becomes check-then-act | the in-window rival test **alone** |
| the reservation never yields | 3 |
| `record_if_unset` becomes unconditional | the two "does not overwrite" tests |
| `record_if_unset` never writes | 5 |
| join stops passing the mode | 5 |
| the `AGMSG_SELF_NAME=off` check is dropped | the proxy-join test alone |
| the #1114 guard is neutralised | the two seam tests |

## Measured

`test_placement_on_join` 11/0, `test_terminal_registry` 135/0, `test_despawn`
18/0, `test_watch` 39/0, `test_inbox` 15/0, `test_actas_integration` 14/0,
`test_self_name` 23/0, `test_peek_poke` 36/0, `test_spawn` 108/0.
`check-enforced-assertions` 626 (baseline), `check-errexit-status-reads` 0
(baseline).

The earlier CI red on this branch was three `test_despawn` tests whose fixtures
assumed a member never records itself; the log confirmed it, and they are fixed
here. One of them also had a race of its own — the watcher writes its readiness
sentinel *before* it names, so removing the record when the sentinel appears
races the naming about to recreate it.

## Note on ordering with #1117

This branch is on `b4bf997`, where the placement guard is still the **late** one
(after naming, two-argument helper). #1117 moves it before the rename and
changes the helper's signature, in the same region. Whichever lands second needs
a rebase and a re-run of the mutations that depend on the guard's position.