### PR TITLE
fix(terminals): a naming failure says which step failed, and what the server said

### DIFF
--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -993,8 +993,29 @@ terminal_name() {
   # written, so a member ended up with neither name and no record — the
   # requirement this driver serves broke through that door. tmux has always had
   # this order; herdr was the one driver that put the ornament in front.
-  key="$(_herdr_internal_key "$team" "$name")" || { echo runtime_error; return 13; }
-  herdr agent rename "$id" "$key" >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  # Two DIFFERENT failures used to leave the same word and nothing else (#1127):
+  # the key could not be COMPUTED, and the server refused to APPLY it. Both
+  # printed `runtime_error` with herdr's own stderr thrown away, so a naming
+  # failure on a live seat could not be attributed to either -- measured on this
+  # fleet, where a seat's record was repaired in the same action that failed to
+  # name, and the message said only `(runtime_error)`.
+  #
+  # The token on stdout stays `runtime_error`: it is the driver contract and
+  # callers read it. What changes is that the REASON is no longer discarded --
+  # the pattern this file already uses elsewhere, a line on stderr naming which
+  # step failed, and for the server call the server's own words with it.
+  key="$(_herdr_internal_key "$team" "$name")" || {
+    echo runtime_error
+    echo "herdr: cannot compute the internal key for '$team/$name' — the sha256 helper is unavailable, so the pane was not named" >&2
+    return 13
+  }
+  local _err _rc=0
+  _err="$(herdr agent rename "$id" "$key" 2>&1 >/dev/null)" || _rc=$?
+  if [ "$_rc" -ne 0 ]; then
+    echo runtime_error
+    echo "herdr: 'agent rename' for '$team/$name' on pane '$id' failed (rc=$_rc)${_err:+: $_err}" >&2
+    return 13
+  fi
 
   # The label, and its failure is deliberately NOT fatal — the same shape tmux
   # has. Not merely for symmetry: the caller writes the placement record only

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -557,7 +557,18 @@ terminal_label_of() {   # <id>
 terminal_name() {
   local id="$1" team="$2" name="$3" mode="${4:-}" label
   label="$team:$name"
-  _tmux_do "$id" set-option -p -t "$(_tmux_bare_of "$id")" @agmsg_agent "$label" >/dev/null 2>&1 || { echo runtime_error; return 13; }
+  # The reason is kept, not discarded (#1127). The token on stdout stays
+  # `runtime_error` -- it is the driver contract -- and tmux's own words go to
+  # stderr, which is the pattern the rest of this file already follows. A
+  # naming failure that says only `runtime_error` cannot be attributed to a
+  # dead server, a vanished pane, or a refused option.
+  local _err _rc=0
+  _err="$(_tmux_do "$id" set-option -p -t "$(_tmux_bare_of "$id")" @agmsg_agent "$label" 2>&1 >/dev/null)" || _rc=$?
+  if [ "$_rc" -ne 0 ]; then
+    echo runtime_error
+    echo "tmux: could not set @agmsg_agent on pane '$id' (rc=$_rc)${_err:+: $_err}" >&2
+    return 13
+  fi
   if [ "$mode" = key ]; then echo ok; return 0; fi
   case "$(_tmux_bare_of "$id")" in
     @*) _tmux_do "$id" rename-window -t "$(_tmux_bare_of "$id")" "$label" >/dev/null 2>&1 || true ;;

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2572,3 +2572,87 @@ echo "fell through"'
   refute grep -q 'RESOLVED' <<<"$output"
   refute grep -q '%5' <<<"$output"
 }
+
+# --- #1127: a naming failure says WHICH step failed, and what the server said --
+#
+# Measured on this fleet: a seat's placement record was repaired in the same
+# action that failed to name its pane, and all the operator got was
+# `(runtime_error)`. Two different failures print that word -- the key could not
+# be COMPUTED, and the server refused to APPLY it -- and both discarded the
+# server's own stderr, so the case could not be narrowed at all.
+#
+# The token stays: `runtime_error` on stdout is the driver contract and callers
+# read it. What these pin is that the reason is no longer thrown away.
+
+@test "naming failure: herdr says the server refused, and passes its words on (#1127)" {
+  cat > "$FAKEBIN/herdr" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = agent ] && [ "$2" = rename ]; then
+  echo 'herdr: pane w1:pX is gone' >&2
+  exit 4
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/herdr"
+  export PATH="$FAKEBIN:$PATH"
+  agmsg_terminal_load herdr
+
+  run terminal_name w1:pX team alice
+  [ "$status" -eq 13 ]
+  # The contract token is unchanged -- callers switch on it.
+  grep -q '^runtime_error$' <<<"$output"
+  # WHICH step, and the server's own words.
+  grep -q 'agent rename' <<<"$output"
+  grep -q 'pane w1:pX is gone' <<<"$output"
+}
+
+@test "naming failure: herdr distinguishes a key it cannot COMPUTE (#1127)" {
+  # The partner. Without it, one message for both failures passes the test above
+  # -- which is the state #1127 is about.
+  cat > "$FAKEBIN/herdr" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$FAKEBIN/herdr"
+  export PATH="$FAKEBIN:$PATH"
+  agmsg_terminal_load herdr
+  # No sha256 helper: the key cannot be built. Shadow it for this test only.
+  agmsg_sha256() { return 1; }
+  _herdr_internal_key() { return 1; }
+
+  run terminal_name w1:pX team alice
+  [ "$status" -eq 13 ]
+  grep -q '^runtime_error$' <<<"$output"
+  grep -q 'internal key' <<<"$output"
+  # And it does NOT claim the server refused, which is the other failure.
+  refute grep -q 'agent rename' <<<"$output"
+}
+
+@test "naming failure: tmux passes the server's words on too (#1127)" {
+  cat > "$FAKEBIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+echo "can't find pane %9" >&2
+exit 1
+EOF
+  chmod +x "$FAKEBIN/tmux"
+  export PATH="$FAKEBIN:$PATH"
+  agmsg_terminal_load tmux
+
+  run terminal_name %9 team alice
+  [ "$status" -eq 13 ]
+  grep -q '^runtime_error$' <<<"$output"
+  grep -q '@agmsg_agent' <<<"$output"
+  grep -q "can't find pane %9" <<<"$output"
+}
+
+@test "naming SUCCESS still prints only the token, on both drivers (#1127 control)" {
+  # "Print the reason always" would pass all three tests above. A successful
+  # naming must stay quiet: callers read stdout, and a stray line there is a
+  # different bug.
+  _install_fake_tmux
+  export PATH="$FAKEBIN:$PATH"
+  agmsg_terminal_load tmux
+  run terminal_name %1 team alice
+  [ "$status" -eq 0 ]
+  [ "$output" = ok ]
+}


### PR DESCRIPTION
Fixes #1127.

Measured on this fleet: a seat's placement record was repaired in the **same
action** that failed to name its pane, and all the operator got was

```
agmsg: could not name this herdr pane for <team>:<agent> (runtime_error)
```

Two different failures print that word. In the herdr driver the internal key
could not be **computed**, or the server refused to **apply** it — and both
discarded the server's own stderr with `>/dev/null 2>&1`, so the case could not
be narrowed at all. Running the same two commands by hand succeeded, so the
failure is conditional on something the message does not carry.

## What changes, and what does not

`runtime_error` on stdout **stays exactly as it is** — it is the driver contract
and callers read it. What changes is that the reason is no longer thrown away.
Both drivers now follow the pattern the rest of these files already use: the
token on stdout, a line on stderr naming which step failed, and for the server
call the server's own words with it.

## Tests

| test | |
|---|---|
| herdr, the server refused | the token, the step, **and herdr's words** |
| herdr, the key cannot be computed | a *different* reason, and it does not claim the server refused |
| tmux, the option write failed | the token, the field, and tmux's words |
| naming **success** | stdout is still exactly `ok` |

| mutation | reddens |
|---|---|
| herdr throws the server's words away again | the herdr test alone |
| both herdr failures get the same reason | the key test alone |
| tmux throws the server's words away again | the tmux test alone |
| the reason is printed on success too | the tmux test **and** the control |

The last row is why the success control exists: "print the reason always" passes
all three of the others.

## Measured

`test_terminal_registry` 137/0, `test_self_name` 23/0, `test_spawn` 108/0,
`test_peek_poke` 36/0, `test_despawn` 18/0. `check-enforced-assertions` 626
(baseline), `check-errexit-status-reads` 0 (baseline).