### PR TITLE
fix(self-name): count only well-formed label candidates, and emit only well-formed ones (#1134)

### DIFF
--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -943,9 +943,23 @@ terminal_find_by_label() {   # <label>
   json="$(herdr pane list 2>/dev/null)" || return 10
   [ -n "$json" ] || return 10
   esc="$(printf '%s' "$json" | sed "s/'/''/g")"
-  sqlite3 :memory: "SELECT json_extract(value,'\$.pane_id') FROM json_each('$esc','\$.result.panes')
+  local rows id
+  rows="$(sqlite3 :memory: "SELECT json_extract(value,'\$.pane_id') FROM json_each('$esc','\$.result.panes')
                     WHERE json_extract(value,'\$.label') = '$(printf '%s' "$label" | sed "s/'/''/g")'
-                      AND json_extract(value,'\$.pane_id') IS NOT NULL" 2>/dev/null || return 10
+                      AND json_extract(value,'\$.pane_id') IS NOT NULL" 2>/dev/null)" || return 10
+  # EMITTER HALF (#1134): print only pane ids in this driver's grammar. herdr's
+  # listing is trusted for labels, not for the shape of its ids, and a row that
+  # is not a pane id is not an answer -- it used to be printed with rc 0 as if
+  # it were one. What this half guarantees: this driver never hands the resolver
+  # a row it could not act on. It does NOT protect the resolver from another
+  # driver's rows, and the resolver does not lean on it: the resolver validates
+  # every row itself before counting (the reader half). Each half has its own
+  # test; fixing one does not make the other's test pass.
+  printf '%s\n' "$rows" | while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    _herdr_pane_id_ok "$id" || continue
+    printf '%s\n' "$id"
+  done
   return 0
 }
 

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -292,9 +292,18 @@ _herdr_pane_id_ok() {
   # ONE herdr pane grammar (do not implement the predicate twice). The herdr
   # driver is always loaded through the registry, so the helper is in scope; a bare
   # source without it falls back to the inline grammar rather than accepting anything.
-  if declare -F _agmsg_terminal_id_ok >/dev/null 2>&1; then
-    _agmsg_terminal_id_ok herdr "$1"; return $?
-  fi
+  # The grammar lives in terminal_id_ok below (the driver ABI hook the registry
+  # asks); this is its local name. It used to delegate UP to the registry, which
+  # held a case over three drivers -- the #1141 review turned that around: the
+  # driver is the authority on its own ids, the registry asks.
+  terminal_id_ok "$1"
+}
+
+# ABI hook: is <id> a herdr pane id in THIS driver's grammar? Asked by the
+# registry (`_agmsg_terminal_id_ok herdr <id>`) for every row the label
+# resolver reads and every ref it validates; a malformed row must answer no.
+#   w<workspace>:p<pane>, alphanumerics only, exactly one colon.
+terminal_id_ok() {   # <id>
   case "$1" in
     w[0-9A-Za-z]*:p[0-9A-Za-z]*) : ;;
     *) return 1 ;;

--- a/scripts/drivers/terminals/plain/ops.sh
+++ b/scripts/drivers/terminals/plain/ops.sh
@@ -13,6 +13,11 @@
 
 terminal_check() { echo ok; return 0; }
 
+# ABI hook: is <id> a plain "pane" id? plain has no addressable pane; its one
+# id is the sentinel '-'. Asked by the registry (`_agmsg_terminal_id_ok plain`);
+# the grammar moved here from the registry (#1141 review).
+terminal_id_ok() { [ "$1" = '-' ]; }
+
 terminal_describe() {
   printf 'name=plain\n'
   printf 'backend=OS terminal window (no addressable pane)\n'

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -152,6 +152,38 @@ terminal_detect() {
 _tmux_sock_of() { case "$1" in *:*) printf '%s' "${1%:*}" ;; *) printf '' ;; esac; }
 _tmux_bare_of() { printf '%s' "${1##*:}"; }
 
+# ABI hook: is <id> a tmux pane ref in THIS driver's grammar? Asked by the
+# registry (`_agmsg_terminal_id_ok tmux <id>`) for every row the label resolver
+# reads and every ref it validates. The grammar moved here from the registry
+# (#1141 review): a driver is the authority on its own ids.
+#
+# Two accepted forms, and the older one is accepted on purpose:
+#   <socket-path>:%N / <socket-path>:@N   written since refs carry the server
+#   %N / @N                               a record written before they did
+# A pane id is not unique across tmux servers (measured: two servers both
+# holding %0), so the socket is what makes a ref answerable. The legacy form
+# still resolves -- it just cannot be asked "is it still there?" (#1051).
+#
+# Split on the LAST colon: a socket path may contain one.
+terminal_id_ok() {   # <id>
+  local id="$1" rest _sock=""
+  case "$id" in
+    *:*) _sock="${id%:*}"; id="${id##*:}"
+         [ -n "$_sock" ] || return 1
+         # What breaks a record is a TAB or a newline -- it is one TAB-separated
+         # line -- not an ordinary space, and socket paths under a home
+         # directory containing a space are perfectly normal. So reject the
+         # CONTROL bytes (TAB 0x09, LF, CR and the rest) and let 0x20 through:
+         # [[:cntrl:]] is exactly that split, where [[:space:]] also swallows
+         # the space and would refuse a legitimate path.
+         case "$_sock" in *[[:cntrl:]]*) return 1 ;; esac ;;
+  esac
+  case "$id" in %*|@*) : ;; *) return 1 ;; esac
+  rest="${id#?}"
+  case "$rest" in ''|*[!0-9]*) return 1 ;; esac
+  return 0
+}
+
 # Run tmux against the server that owns <id>. With no socket in the id this is
 # plain `tmux`, which is what a legacy record gets and what the ambient
 # environment decides — the honest behaviour for a ref that does not say.

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -135,7 +135,7 @@ agmsg_terminal_has() {
 # what makes a missing op FAIL rather than silently borrow the previously loaded
 # driver's same-named function.
 _AGMSG_TERMINAL_REQUIRED="terminal_check terminal_describe terminal_detect terminal_spawn terminal_despawn terminal_pane_state terminal_peek terminal_poke terminal_where terminal_arrange terminal_name"
-_AGMSG_TERMINAL_OPTIONAL="terminal_team_observe terminal_team_input_ready terminal_find_by_label terminal_label_of"
+_AGMSG_TERMINAL_OPTIONAL="terminal_team_observe terminal_team_input_ready terminal_find_by_label terminal_label_of terminal_id_ok"
 
 # A driver's observation fields carry EITHER an observed value or one of these
 # prefixes, which say why there is no value. They are listed here, once, because
@@ -436,52 +436,62 @@ agmsg_terminal_self_env() {
 }
 
 # Print the terminal name of a record ref (stdout). Handles legacy bare ids.
-# Is <id> a well-formed id for <terminal>? The SINGLE authority for the per-terminal
-# bare-id grammar, shared by agmsg_terminal_ref_terminal (below) and the herdr
-# driver's _herdr_pane_id_ok (which delegates here), so the two cannot drift. The id
+# Is <id> a well-formed id for <terminal>? Answered by the DRIVER's terminal_id_ok
+# (the grammar lives in each ops.sh, and the herdr driver's _herdr_pane_id_ok is
+# that same function under its local name), so the emitter and every reader --
+# agmsg_terminal_ref_terminal below, the label resolver -- cannot drift. The id
 # is handed to a terminal as a TARGET, so this is the line between a value we may
 # pass and one we must refuse:
 #   tmux   %<n> / @<n>, n decimal   (rejects tmux:alice -> a real session; %9;kill)
 #   herdr  w<n>:p<x>, one ':', alnum+':' only   (rejects a newline / '|' / junk)
 #   plain  exactly '-'              (no addressable pane; any other value is corrupt)
 _agmsg_terminal_id_ok() {   # <terminal> <id>
-  local id="$2" rest
-  case "$1" in
-    tmux)
-      # Two accepted forms, and the older one is accepted on purpose:
-      #   <socket-path>:%N / <socket-path>:@N   written since refs carry the server
-      #   %N / @N                               a record written before they did
-      # A pane id is not unique across tmux servers (measured: two servers both
-      # holding %0), so the socket is what makes a ref answerable. The legacy form
-      # still resolves — it just cannot be asked "is it still there?" (#1051).
-      #
-      # Split on the LAST colon: a socket path may contain one.
-      local _sock=""
-      case "$id" in
-        *:*) _sock="${id%:*}"; id="${id##*:}"
-             [ -n "$_sock" ] || return 1
-             # What breaks a record is a TAB or a newline — it is one TAB-separated
-             # line — not an ordinary space, and socket paths under a home
-             # directory containing a space are perfectly normal. So reject the
-             # CONTROL bytes (TAB 0x09, LF, CR and the rest) and let 0x20 through:
-             # [[:cntrl:]] is exactly that split, where [[:space:]] also swallows
-             # the space and would refuse a legitimate path.
-             case "$_sock" in *[[:cntrl:]]*) return 1 ;; esac ;;
-      esac
-      case "$id" in %*|@*) : ;; *) return 1 ;; esac
-      rest="${id#?}"
-      case "$rest" in ''|*[!0-9]*) return 1 ;; esac
-      return 0 ;;
-    herdr)
-      case "$id" in w[0-9A-Za-z]*:p[0-9A-Za-z]*) : ;; *) return 1 ;; esac
-      case "$id" in *:*:*) return 1 ;; esac
-      case "$id" in *[!0-9A-Za-z:]*) return 1 ;; esac
-      return 0 ;;
-    plain)
-      [ "$id" = '-' ] || return 1
-      return 0 ;;
-    *) return 1 ;;
-  esac
+  local name="$1" id="$2"
+  [ -n "$name" ] && [ -n "$id" ] || return 1
+  # The driver NAME is validated before anything is loaded by it. This function
+  # now reaches the filesystem (a driver directory, resolved through the driver
+  # bases), and a name that is not a plain word -- "../../../plugins/terminals/x"
+  # -- would traverse from the builtin base into a plugin directory and read as
+  # builtin, past the trust gate (review warning, measured on a prototype). No
+  # caller hands this a name from an untrusted reference today; a generic scheme
+  # parser composed later could, so the line is drawn here as well as wherever
+  # discovery draws it.
+  case "$name" in *[!A-Za-z0-9_-]*) return 1 ;; esac
+  # The id grammar is a property of the DRIVER, so the driver is asked
+  # (`terminal_id_ok <id>` in its ops.sh); this registry no longer holds a case
+  # over three names. It did until the #1141 review composed it with #1143
+  # (trusted external drivers joining every chooser): a case that knew only
+  # herdr/tmux/plain answered "malformed" for every row an external driver
+  # emitted, and the label resolver -- which now validates each row before
+  # counting -- silently dropped that driver's correct pane. The same shape
+  # #1133 removes from the choosers, added back one layer down.
+  #
+  # Three answers, and the fallback is stated so nobody has to guess it:
+  #   the driver defines terminal_id_ok  -> its verdict (the built-in three do)
+  #   the driver exists but has no hook   -> ACCEPTED. A trusted external driver
+  #                                          is the only authority on its own ids;
+  #                                          refusing here would unmake #1143.
+  #                                          The cost is that malformed-row
+  #                                          filtering for such a driver is only
+  #                                          as good as its own emitter.
+  #   no such driver                      -> refused, as before
+  #
+  # Asked without disturbing the caller: when the driver is the one already
+  # loaded, call it directly (no fork -- this runs per scanned row); otherwise
+  # load it in a SUBSHELL, so the caller's driver functions are not replaced
+  # under it (a ref of terminal X is validated while driver Y is in use, e.g.
+  # the placement scan reading another seat's record).
+  if [ "$name" = "${_AGMSG_TERMINAL_LOADED:-}" ]; then
+    if declare -F terminal_id_ok >/dev/null 2>&1; then
+      terminal_id_ok "$id"; return $?
+    fi
+    return 0
+  fi
+  (
+    agmsg_terminal_load "$name" >/dev/null 2>&1 || exit 1
+    declare -F terminal_id_ok >/dev/null 2>&1 || exit 0
+    terminal_id_ok "$id"
+  )
 }
 
 agmsg_terminal_ref_terminal() {

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -650,6 +650,17 @@ _agmsg_terminal_resolve_by_label() {   # <team> <agent>
     ids="$(terminal_find_by_label "$label" 2>/dev/null)" || continue
     while IFS= read -r line; do
       [ -n "$line" ] || continue
+      # READER HALF (#1134): count only rows that are a pane in this driver's own
+      # grammar. A malformed row is not a candidate, so it must not count as one:
+      # counting it made one driver's garbage plus another driver's correct
+      # pane look like two candidates, and the correct pane was refused with the
+      # garbage. What this half guarantees is exactly that -- a driver that speaks
+      # badly cannot suppress a driver that speaks well. It does NOT rely on the
+      # drivers filtering their own output (the herdr emitter does, separately,
+      # and that is a courtesy, not a contract this loop leans on), and it does
+      # NOT decide whether a well-formed candidate is the right pane -- the
+      # confirmation below does that. Two well-formed candidates still refuse.
+      _agmsg_terminal_id_ok "$name" "$line" || continue
       count=$((count + 1))
       found="$name$tab$line"
     done <<EOF

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2656,3 +2656,48 @@ EOF
   [ "$status" -eq 0 ]
   [ "$output" = ok ]
 }
+
+# --- #1134: a malformed row from one driver must not suppress another's answer -----
+#
+# Two halves, each with its own red. The READER half (the resolver counts only
+# rows in the driver's grammar) is tested with a driver FILE that emits a
+# malformed row directly, so the emitter fix cannot make it pass. The EMITTER
+# half (the herdr driver prints only well-formed ids) is tested by calling the
+# real driver against a fake herdr, so the reader fix cannot make it pass.
+
+@test "resolve_by_label: one driver's malformed row does not suppress another driver's correct pane (#1134 reader)" {
+  # herdr speaks badly: its label search hands back `bad|id`, which is no pane in
+  # any grammar. tmux speaks well: the seat's label is on %5 of its server.
+  printf '\nterminal_find_by_label() { printf "bad|id\\n"; }\n' >> "$SKILL_DIR/scripts/drivers/terminals/herdr/ops.sh"
+  _fake_tmux_labels "%5=team:alice"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%5"
+  unset HERDR_ENV HERDR_PANE_ID AGMSG_TERMINAL_DRIVER
+
+  run _agmsg_terminal_resolve_by_label team alice
+  [ "$status" -eq 0 ]
+  [ "$output" = "tmux$(printf '\t')/tmp/fake:%5" ]
+}
+
+@test "herdr find_by_label: a listing row whose pane id is outside the grammar is not emitted (#1134 emitter)" {
+  # The listing carries the right label on two rows; one row's id is garbage.
+  # The driver prints the well-formed id only, and still exits 0.
+  _fake_herdr_labels "bad|id=team:alice" "w1:pOK=team:alice"
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/drivers/terminals/herdr/ops.sh"
+  run terminal_find_by_label team:alice
+  [ "$status" -eq 0 ]
+  [ "$output" = "w1:pOK" ]
+}
+
+@test "resolve_by_label: two WELL-FORMED candidates from two drivers are still refused (#1134 keeps #1112)" {
+  # The fix removes "refused because one driver spoke badly"; it must not remove
+  # "refused because two panes genuinely carry the label".
+  _fake_herdr_labels "w1:pONE=team:alice"
+  _fake_tmux_labels "%7=team:alice"
+  export HERDR_ENV=1 HERDR_PANE_ID="w1:pDAEMON" TMUX="/tmp/fake,1,0" TMUX_PANE="%7"
+  unset AGMSG_TERMINAL_DRIVER
+
+  run _agmsg_terminal_resolve_by_label team alice
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -1913,7 +1913,12 @@ _fake_herdr_list_anchored_plus() {
 # ref: it searches for the pane rather than being told which one, so there is no
 # owning server in its input to honour -- it asks the server the caller is on.
 # Its confirmation partner terminal_label_of DOES take a ref and is swept.
-_TMUX_NO_ID_OPS="terminal_check terminal_describe terminal_detect terminal_spawn terminal_find_by_label"
+# terminal_id_ok takes a ref STRING but never addresses a server: it is the
+# grammar the sweep's own refs must pass (#1141 review moved it into the
+# driver), so "did it reach the owning server" does not apply. What keeps it
+# honest is the oracle table in the "#1141 review" section: the socket form
+# and the legacy bare form are both accepted, as the registry accepted them.
+_TMUX_NO_ID_OPS="terminal_check terminal_describe terminal_detect terminal_spawn terminal_find_by_label terminal_id_ok"
 
 # op -> the argument list to call it with, using SOCKID/BAREID as the id slot.
 _tmux_op_args() {
@@ -2700,4 +2705,127 @@ EOF
   run _agmsg_terminal_resolve_by_label team alice
   [ "$status" -ne 0 ]
   [ -z "$output" ]
+}
+
+# --- #1141 review: the id grammar is the driver's, and the registry asks --------------
+#
+# _agmsg_terminal_id_ok used to hold a case over herdr/tmux/plain. Composed with
+# #1143 (trusted external drivers in every chooser) that case called every
+# external row malformed, and the label resolver -- which now validates rows
+# before counting -- dropped the external driver's correct pane. The registry
+# now asks the driver's terminal_id_ok; a driver without the hook is ACCEPTED.
+
+_install_external_terminal_nohook() {   # <name> [with-hook]
+  local d="$SKILL_DIR/plugins/terminals/$1"
+  mkdir -p "$d" "$SKILL_DIR/db"
+  printf 'name=%s\npriority=15\nbackend=test %s\ncapabilities=name\n' "$1" "$1" > "$d/terminal.conf"
+  cat > "$d/ops.sh" <<'OPS'
+terminal_check() { echo ok; }
+terminal_describe() { echo name=ext; }
+terminal_detect() { printf 'ext-pane\n'; }
+terminal_spawn() { printf 'ext-spawned\n'; }
+terminal_despawn() { :; }
+terminal_pane_state() { echo present; }
+terminal_peek() { :; }
+terminal_poke() { :; }
+terminal_where() { echo ext-container; }
+terminal_arrange() { echo unchanged; }
+terminal_name() { :; }
+terminal_find_by_label() { printf 'ext-pane\n'; }
+terminal_label_of() { printf 'testteam:alice\n'; }
+OPS
+  [ "${2:-}" = with-hook ] && printf 'terminal_id_ok() { [ "$1" = ext-pane ]; }\n' >> "$d/ops.sh"
+  printf 'terminals/%s\t%s\n' "$1" "$d" >> "$SKILL_DIR/db/trusted-plugins"
+}
+
+@test "id grammar: the three built-in drivers answer exactly as the registry's table did (#1141 review)" {
+  # The table this replaces, as an oracle. One wrong verdict on any row is a
+  # behaviour change for a built-in driver, which this move must not make.
+  # Rows are ';'-separated because an id under test may itself contain '|'.
+  local row term id want got rows=0
+  while IFS=';' read -r term id want; do
+    [ -n "$term" ] || continue
+    rows=$((rows + 1))
+    _agmsg_terminal_id_ok "$term" "$id" && got=0 || got=1
+    [ "$got" = "$want" ] || { echo "FAIL: $term '$id' -> $got, want $want"; return 1; }
+  done <<'TABLE'
+herdr;w1:pB;0
+herdr;wT:pSelf;0
+herdr;w1:p2:x;1
+herdr;bad|id;1
+herdr;%1;1
+herdr;/tmp/s:%1;1
+herdr;w1:p B;1
+tmux;%1;0
+tmux;@2;0
+tmux;/tmp/s:%7;0
+tmux;/tmp/with:colon:%7;0
+tmux;/home/a b/sock:%3;0
+tmux;:%1;1
+tmux;%x;1
+tmux;%;1
+tmux;w1:pB;1
+tmux;ext-pane;1
+plain;-;0
+plain;x;1
+bogus;w1:pB;1
+TABLE
+  # The loop ran over the whole table, not over nothing.
+  [ "$rows" -eq 20 ]
+}
+
+@test "id grammar: asking about another driver does not replace the caller's loaded driver (#1141 review)" {
+  _fake_tmux_labels "%5=team:alice"
+  export TMUX="/tmp/fake,1,0" TMUX_PANE="%5"
+  agmsg_terminal_load tmux
+  [ "$_AGMSG_TERMINAL_LOADED" = tmux ]
+  # Validate a herdr id while tmux is the loaded driver...
+  _agmsg_terminal_id_ok herdr w1:pB
+  refute _agmsg_terminal_id_ok herdr bad_id
+  # ...and tmux is still the loaded driver, with its own functions intact.
+  [ "$_AGMSG_TERMINAL_LOADED" = tmux ]
+  [ "$(terminal_find_by_label team:alice)" = '/tmp/fake:%5' ]
+}
+
+@test "id grammar: a trusted external driver without terminal_id_ok is accepted, with it its verdict is used (#1141 review)" {
+  _install_external_terminal_nohook ext
+  _agmsg_terminal_id_ok ext ext-pane
+  _agmsg_terminal_id_ok ext 'anything|goes'        # no hook: the driver is the authority
+  refute _agmsg_terminal_id_ok nosuchdriver ext-pane   # unknown driver: still refused
+  rm -rf "$SKILL_DIR/plugins/terminals/ext"; : > "$SKILL_DIR/db/trusted-plugins"
+  _install_external_terminal_nohook ext2 with-hook
+  _agmsg_terminal_id_ok ext2 ext-pane
+  refute _agmsg_terminal_id_ok ext2 'anything|goes'   # hook present: its grammar decides
+}
+
+@test "resolve_by_label: a trusted external driver's row is counted, not filtered as malformed (#1141 x #1143)" {
+  # The composition the review found: with #1141's per-row validation and a
+  # registry that only knew three grammars, an external driver's correct row
+  # read as garbage. Now it resolves. The external driver has no id hook.
+  #
+  # Reached through the driver override: on this branch the resolver still
+  # iterates the three built-in names, and putting external drivers into that
+  # list is #1143's change. #1143 carries the auto-discovery composition test;
+  # this one pins the half that is this branch's -- the row is accepted.
+  _install_external_terminal_nohook probe
+  unset TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID
+  export AGMSG_TERMINAL_DRIVER=probe
+  run _agmsg_terminal_resolve_by_label testteam alice
+  [ "$status" -eq 0 ]
+  [ "$output" = "probe$(printf '\t')ext-pane" ]
+}
+
+@test "id grammar: a driver name that is not a plain word is refused before anything is loaded (#1141 review)" {
+  # A hostile name that resolves, as a path, from the builtin base into a plugin
+  # directory. The plugin's ops.sh would leave a marker if it were ever sourced.
+  local d="$SKILL_DIR/plugins/terminals/evil"
+  mkdir -p "$d"
+  printf 'name=evil\npriority=1\nbackend=evil\ncapabilities=name\n' > "$d/terminal.conf"
+  printf ': > "%s/evil-was-sourced"\nterminal_id_ok() { return 0; }\n' "$BATS_TEST_TMPDIR" > "$d/ops.sh"
+  refute _agmsg_terminal_id_ok '../../../plugins/terminals/evil' evil-id
+  refute _agmsg_terminal_id_ok 'plugins/terminals/evil' evil-id
+  refute _agmsg_terminal_id_ok 'herdr:w1' w1:pB
+  refute test -e "$BATS_TEST_TMPDIR/evil-was-sourced"
+  # Control: a plain-word name of a real driver still answers.
+  _agmsg_terminal_id_ok herdr w1:pB
 }


### PR DESCRIPTION
Fixes #1134.

## What broke

`_agmsg_terminal_resolve_by_label` counted every non-empty row each driver returned, refused unless the count was one, and only then checked whether the single candidate was real. A malformed row therefore counted. One driver emitting garbage plus another emitting the correct pane looked like two candidates, and the correct pane was refused with the garbage; resolution then fell back to the environment, the answer the label path exists to replace. Measured on both sides: the herdr driver returns a pane id outside its grammar with rc 0, and with that row alongside a correct tmux row the resolver returns nothing.

Neither half is harmful alone: a single malformed row is caught by the confirmation of the sole candidate, and counting before validating costs nothing while every driver speaks well. Together they silently discard the right answer.

## The change

Both halves, each guaranteeing one thing and saying so in a comment:

- **Reader** (`scripts/lib/terminal-registry.sh`): each row is validated against the driver's own id grammar (`_agmsg_terminal_id_ok`) as it is read, and only survivors are counted. Guarantee: a driver that speaks badly cannot suppress a driver that speaks well. Refusing on two well-formed candidates is unchanged, and the confirmation of the winner is unchanged.
- **Emitter** (`scripts/drivers/terminals/herdr/ops.sh`): `terminal_find_by_label` prints only pane ids in the herdr grammar. Guarantee: this driver never hands the resolver a row it could not act on. It does not protect the resolver from other drivers, and the resolver does not lean on it.

## The id grammar is the driver's (review finding)

Composing this with #1143 (trusted external drivers joining every chooser) showed the reader half's validator, `_agmsg_terminal_id_ok`, was a case over three names: every row an external driver emitted read as malformed, and the resolver dropped that driver's correct pane. The same shape #1133 removes from the choosers, added back one layer down.

Now the registry asks the driver: each built-in driver defines `terminal_id_ok <id>` holding its own grammar (moved verbatim: tmux's socket-qualified and legacy forms, herdr's `w<ws>:p<pane>`, plain's `-`), and the herdr driver's `_herdr_pane_id_ok` is that function under its local name instead of delegating up to the registry, which would now recurse. Three answers, stated in the code: the driver's verdict when it defines the hook; **accepted** when a trusted external driver defines no hook, because it is the only authority on its own ids and refusing would unmake #1143 (the cost, also stated: malformed-row filtering for such a driver is only as good as its emitter); refused when no such driver exists. When the driver asked about is the loaded one it is called directly, no fork; otherwise it is loaded in a subshell so the caller's driver functions are not replaced under it. `terminal_id_ok` is in the optional-ops list, so unloading a driver clears it and no stale hook survives a load.

Because the registry now loads a driver by name to ask it, the name is validated before any load: `[A-Za-z0-9_-]` only, and anything else is refused without touching the filesystem. Today no caller derives that name from an untrusted reference (the reference parser fixes the scheme to the three built-ins), but a generic scheme parser composed later could, and a name like `../../../plugins/terminals/evil` would otherwise reach a plugin directory through the builtin base and read as builtin (review warning, measured against a prototype). Closing it here does not excuse the discovery layer from validating too.

Tests: a table of every verdict the old case gave, as an oracle, so no built-in decision changed; asking about herdr while tmux is loaded leaves tmux loaded with its functions intact; an external driver without the hook is accepted and with the hook obeyed, an unknown driver refused; and the label resolver, pointed at an external hookless driver through the driver override, counts its row (the auto-discovery composition is #1143's test). Refusing a hookless driver reddens the external and composition tests; removing the name validation reddens a test in which a hostile name pointing at an untrusted plugin is refused and the plugin's `ops.sh` is proven never sourced; loosening herdr's grammar reddens the oracle table.

The tmux "every id-taking op reaches the owning server" sweep now excludes `terminal_id_ok`, with the reason beside the exclusion: it takes a reference string but never addresses a server, being the grammar the sweep's own references must pass; the oracle table keeps it honest on both the socket form and the legacy bare form.

## Tests (`tests/test_terminal_registry.bats`)

Each half has its own red, so fixing one cannot hide a regression in the other:

- **reader**: the herdr driver file is overridden to emit `bad|id` directly, bypassing the emitter fix, while a fake tmux carries the label on `%5`; the resolver returns `tmux<TAB>/tmp/fake:%5`. Removing the reader's validation reddens it; the emitter fix does not touch it.
- **emitter**: the real herdr driver against a fake herdr whose listing has the label on `bad|id` and on `w1:pOK`; the driver prints exactly `w1:pOK` with rc 0. Removing the emitter's filter reddens it; the reader fix does not touch it.
- **kept**: two well-formed candidates from two drivers (herdr `w1:pONE`, tmux `%7`) are still refused with empty output.

The single-malformed-row case already passed before this change for a different reason (the confirmation step), which is why it is not the test here.
