### PR TITLE
fix(team): --fix creates a placement record from the label for a seat that has none (#1140)

### DIFF
--- a/scripts/lib/team-status.sh
+++ b/scripts/lib/team-status.sh
@@ -136,6 +136,39 @@ agmsg_team_verify_placement() {
   return 0
 }
 
+# #1140: the sibling of verify_placement for a seat that has NO record at all. A
+# seat can be DENIED terminal operations -- a sandbox returns PermissionDenied for
+# `agent rename` -- so it can never name itself, and the record write sits BEHIND
+# naming, so no record is ever written either. --fix, running outside the sandbox,
+# is the only actor that can place it, and the material is here: if the label
+# settles on exactly one pane, create the record so the repair can continue on that
+# pane. Zero or many matches -> print nothing / rc 1, and the seat stays unfixable,
+# exactly as before -- this only turns "no record" into "a record" when the label
+# is unambiguous, never inventing a pane. (Making the sandbox seat able to name
+# ITSELF is an environment decision and is out of scope; this only lets an outside
+# --fix place it.)
+#
+#   agmsg_team_create_placement_from_label <team> <agent> <rec-path> <project> <type>
+#     -> prints the created ref, rc 0; or nothing, rc 1.
+agmsg_team_create_placement_from_label() {
+  local team="$1" agent="$2" rec="$3" project="$4" type="$5"
+  local verified v_terminal v_id v_ref tab
+  [ -n "$rec" ] || return 1
+  declare -F _agmsg_terminal_resolve_by_label >/dev/null 2>&1 || return 1
+  verified="$(_agmsg_terminal_resolve_by_label "$team" "$agent" 2>/dev/null)" || return 1
+  [ -n "$verified" ] || return 1
+  tab="$(printf '\t')"
+  v_terminal="${verified%%"$tab"*}"; v_id="${verified#*"$tab"}"
+  [ -n "$v_terminal" ] && [ -n "$v_id" ] || return 1
+  v_ref="$(agmsg_terminal_ref "$v_terminal" "$v_id" 2>/dev/null)" || return 1
+  [ -n "$v_ref" ] || return 1
+  declare -F agmsg_write_atomic >/dev/null 2>&1 || return 1
+  mkdir -p "$(dirname "$rec")" 2>/dev/null || true
+  agmsg_write_atomic "$rec" "$(printf '%s\t%s\t%s' "$v_ref" "$project" "$type")" 2>/dev/null || return 1
+  printf '%s\n' "$v_ref"
+  return 0
+}
+
 _agmsg_team_identity_field_loaded() {
   local field="$1"; shift
   local identity _activity _al _el _ak _ek _as _es pane_cell key_cell session_cell _consistency

--- a/scripts/lib/team-status.sh
+++ b/scripts/lib/team-status.sh
@@ -148,6 +148,17 @@ agmsg_team_verify_placement() {
 # ITSELF is an environment decision and is out of scope; this only lets an outside
 # --fix place it.)
 #
+# EFFECTIVE FOR herdr NOW; tmux WAITS ON #1146. This is only as good as the label
+# resolver, and for tmux the resolver cannot answer from where --fix runs: --fix
+# runs from OUTSIDE the seat's pane (that is its whole purpose), so $TMUX is unset,
+# and terminal_find_by_label abstains without it (#1132/#1126 -- a bare `%N` with
+# no socket is not a resolvable ref, #1051). herdr's `pane list` needs no such
+# environment, so herdr seats are placed today; tmux seats will be once #1146 gives
+# the resolver a socket without $TMUX. Measured live (2026-09-10): a tmux seat
+# stays no_placement_record. This function is correct either way -- when the
+# resolver answers, it places; when it abstains, it leaves the seat unfixable, as
+# before.
+#
 #   agmsg_team_create_placement_from_label <team> <agent> <rec-path> <project> <type>
 #     -> prints the created ref, rc 0; or nothing, rc 1.
 agmsg_team_create_placement_from_label() {

--- a/scripts/team.sh
+++ b/scripts/team.sh
@@ -175,27 +175,41 @@ _member_status() {
   fi
   rec="$(agmsg_spawn_path "$team" "$agent" 2>/dev/null)" || rec=""
   if [ -z "$rec" ] || [ ! -f "$rec" ]; then
-    reason=no_placement_record
-    _emit_unknown_row "$agent" "$type" "$project" unknown "unknown:$reason" \
-      "unknown:$reason" "unknown:$reason" "$delivery" "$reason"
-    _emit_unfixable_actions "$reason"
-    return 0
-  fi
-  IFS="$(printf '\t')" read -r ref rec_project rec_type < "$rec" || true
-  if [ -z "$ref" ]; then
-    reason=empty_placement_record
-    _emit_unknown_row "$agent" "$type" "$project" unknown "unknown:$reason" \
-      "unknown:$reason" "unknown:$reason" "$delivery" "$reason"
-    _emit_unfixable_actions "$reason"
-    return 0
-  fi
-  # #1131: under a repair verb the record is a CLAIM to verify, not an address to
-  # trust. If the label settles the seat on a different pane, correct the record
-  # and act on the real pane -- so --fix never overwrites another seat's label to
-  # match a wrong record. A read-only `team` status must not rewrite records, so
-  # only --fix / --fix-pane-names / --rename-sessions does this.
-  if [ "$FIX" -eq 1 ] && declare -F agmsg_team_verify_placement >/dev/null 2>&1; then
-    ref="$(agmsg_team_verify_placement "$team" "$agent" "$rec" "$ref" "$rec_project" "$rec_type")"
+    # #1140: no record. A seat denied terminal operations (a sandbox returns
+    # PermissionDenied for the naming call) can never name itself, and the record
+    # write sits BEHIND naming -- so it never gets a record. --fix, from OUTSIDE
+    # the sandbox, can place it FROM THE LABEL when the label settles on exactly
+    # one pane; the repair then continues on that pane. Zero or many matches ->
+    # unfixable, as before. A read-only `team` status never creates a record.
+    ref=""
+    if [ "$FIX" -eq 1 ] && [ -n "$rec" ] && declare -F agmsg_team_create_placement_from_label >/dev/null 2>&1; then
+      ref="$(agmsg_team_create_placement_from_label "$team" "$agent" "$rec" "$project" "$type")" || ref=""
+    fi
+    if [ -z "$ref" ]; then
+      reason=no_placement_record
+      _emit_unknown_row "$agent" "$type" "$project" unknown "unknown:$reason" \
+        "unknown:$reason" "unknown:$reason" "$delivery" "$reason"
+      _emit_unfixable_actions "$reason"
+      return 0
+    fi
+    rec_project="$project"; rec_type="$type"       # the record just created carries these
+  else
+    IFS="$(printf '\t')" read -r ref rec_project rec_type < "$rec" || true
+    if [ -z "$ref" ]; then
+      reason=empty_placement_record
+      _emit_unknown_row "$agent" "$type" "$project" unknown "unknown:$reason" \
+        "unknown:$reason" "unknown:$reason" "$delivery" "$reason"
+      _emit_unfixable_actions "$reason"
+      return 0
+    fi
+    # #1131: under a repair verb the record is a CLAIM to verify, not an address to
+    # trust. If the label settles the seat on a different pane, correct the record
+    # and act on the real pane -- so --fix never overwrites another seat's label to
+    # match a wrong record. A read-only `team` status must not rewrite records, so
+    # only --fix / --fix-pane-names / --rename-sessions does this.
+    if [ "$FIX" -eq 1 ] && declare -F agmsg_team_verify_placement >/dev/null 2>&1; then
+      ref="$(agmsg_team_verify_placement "$team" "$agent" "$rec" "$ref" "$rec_project" "$rec_type")"
+    fi
   fi
   terminal="$(agmsg_terminal_ref_terminal "$ref" 2>/dev/null)" || terminal=""
   pane="$(agmsg_terminal_ref_id "$ref" 2>/dev/null)" || pane=""

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -1226,7 +1226,13 @@ exit 0
 STUB
   chmod +x "$bin/tmux"
   export PATH="$bin:$PATH"
-  export TMUX="/tmp/tsock,999,0"           # provide the socket so the ref is socket-qualified
+  # $TMUX is set here to give the resolver a socket, so this pins the record LOGIC
+  # (a socket-qualified tmux ref is created from the label). It is NOT the real
+  # --fix environment: --fix runs from OUTSIDE the seat's pane, where $TMUX is
+  # unset, and the tmux resolver abstains without it (#1132) -- so a tmux seat is
+  # not actually reached by --fix until #1146. Measured live. herdr, whose
+  # resolver needs no such environment, is reached today (the herdr fixture above).
+  export TMUX="/tmp/tsock,999,0"
   export AGMSG_TERMINAL_DRIVER=tmux
   bash "$SCRIPTS/join.sh" fixteam alice claude-code /tmp/proj >/dev/null
   NRT_REC="$(SKILL_DIR="$TEST_SKILL_DIR" bash -c 'cd "$1" && . lib/actas-lock.sh && . lib/terminal-registry.sh && agmsg_spawn_path fixteam alice' _ "$SCRIPTS")"
@@ -1250,4 +1256,17 @@ STUB
   grep -q '%11' "$NRT_LOG"
   # (b) the other seat's pane was never written
   refute grep -q 'set-option .*-t %22 ' "$NRT_LOG"
+}
+
+# The measured LIVE gap (#1146): --fix runs from OUTSIDE the seat's pane, so it has
+# no $TMUX, and the tmux resolver abstains without it (#1132). So a tmux seat is not
+# actually reached by --fix today -- the same fixture, minus the $TMUX artifice.
+# This is the canary: when #1146 gives the resolver a socket without $TMUX, this
+# flips to a created record and this assertion reddens, saying the limitation lifted.
+@test "team --fix does not YET reach a tmux seat run from outside its pane -- no \$TMUX (#1146)" {
+  _install_norecord_tmux_fixture
+  unset TMUX
+  run bash "$SCRIPTS/team.sh" fixteam --fix-pane-names
+  [ "$status" -eq 0 ]
+  [ ! -e "$NRT_REC" ]
 }

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -1145,3 +1145,57 @@ STUB
   refute grep -q '^pane rename w1:pOTHER ' "$MIS_LOG"
   refute grep -q '^agent rename w1:pOTHER ' "$MIS_LOG"
 }
+
+# --- #1140: --fix CREATES a record for a seat that has none, from its label ---------
+# A seat denied terminal ops (a sandbox) can never name itself, and the record write
+# sits behind naming, so it never gets a record either. --fix, from outside, places
+# it from the label -- when exactly one pane carries it -- and repairs that pane. The
+# other seat's pane must not be touched (the #1131 (a)/(b) independence, again).
+_install_norecord_fixture() {   # alice has NO record; her label is on w1:pMINE
+  export NR_LOG="$BATS_TEST_TMPDIR/herdr.log"; : > "$NR_LOG"
+  local bin="$BATS_TEST_TMPDIR/bin"; mkdir -p "$bin"
+  cat > "$bin/herdr" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$NR_LOG"
+case "\$1/\$2" in
+  pane/list) echo '{"result":{"panes":[{"pane_id":"w1:pMINE","label":"fixteam:alice"},{"pane_id":"w1:pOTHER","label":"fixteam:bob"}]}}' ;;
+  pane/get)
+    case "\$3" in
+      w1:pMINE)  echo '{"result":{"pane":{"pane_id":"w1:pMINE","label":"fixteam:alice","agent_status":"idle","terminal_title":"t"}}}' ;;
+      w1:pOTHER) echo '{"result":{"pane":{"pane_id":"w1:pOTHER","label":"fixteam:bob","agent_status":"idle","terminal_title":"t"}}}' ;;
+      *)         echo '{"result":{"pane":{}}}' ;;
+    esac ;;
+  agent/list) echo '{"result":{"agents":[]}}' ;;
+  agent/get)  echo '{"result":{"agent":{"agent":"claude","agent_status":"idle"}}}' ;;
+  *)          echo '{"result":{"type":"ok"}}' ;;
+esac
+STUB
+  chmod +x "$bin/herdr"
+  export PATH="$bin:$PATH"
+  export AGMSG_TERMINAL_DRIVER=herdr
+  bash "$SCRIPTS/join.sh" fixteam alice claude-code /tmp/proj >/dev/null
+  NR_REC="$(SKILL_DIR="$TEST_SKILL_DIR" bash -c 'cd "$1" && . lib/actas-lock.sh && . lib/terminal-registry.sh && agmsg_spawn_path fixteam alice' _ "$SCRIPTS")"
+  rm -f "$NR_REC"        # THE POINT: no placement record exists
+  [ ! -e "$NR_REC" ]
+}
+
+@test "team --fix creates a placement record from the label for a seat that has none (#1140)" {
+  _install_norecord_fixture
+  run bash "$SCRIPTS/team.sh" fixteam --fix-pane-names
+  [ "$status" -eq 0 ]
+  # (a) a record now exists and names alice's OWN pane (the label's answer)
+  [ "$(cat "$NR_REC")" = $'herdr:w1:pMINE\t/tmp/proj\tclaude-code' ]
+  # positive control: --fix reached the created pane at all
+  grep -q '^pane get w1:pMINE$' "$NR_LOG"
+}
+
+@test "team --fix, creating a record from the label, does NOT touch another seat's pane (#1140)" {
+  _install_norecord_fixture
+  run bash "$SCRIPTS/team.sh" fixteam --fix-pane-names
+  [ "$status" -eq 0 ]
+  # positive control independent of the correction: the fix ran and observed a pane
+  grep -q '^pane get w1:p' "$NR_LOG"
+  # (b) THE POINT: the other seat's pane was never written with alice's identity
+  refute grep -q '^pane rename w1:pOTHER ' "$NR_LOG"
+  refute grep -q '^agent rename w1:pOTHER ' "$NR_LOG"
+}

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -1175,7 +1175,10 @@ STUB
   export AGMSG_TERMINAL_DRIVER=herdr
   bash "$SCRIPTS/join.sh" fixteam alice claude-code /tmp/proj >/dev/null
   NR_REC="$(SKILL_DIR="$TEST_SKILL_DIR" bash -c 'cd "$1" && . lib/actas-lock.sh && . lib/terminal-registry.sh && agmsg_spawn_path fixteam alice' _ "$SCRIPTS")"
-  rm -f "$NR_REC"        # THE POINT: no placement record exists
+  # NOT removed by hand: join writes NO placement record by design (it is not the
+  # seat's claim on a pane), so this is naturally absent -- the measured state, and
+  # a test that reproduces it rather than manufacturing it. If join ever starts
+  # writing one, this assertion reddens and says so.
   [ ! -e "$NR_REC" ]
 }
 
@@ -1198,4 +1201,53 @@ STUB
   # (b) THE POINT: the other seat's pane was never written with alice's identity
   refute grep -q '^pane rename w1:pOTHER ' "$NR_LOG"
   refute grep -q '^agent rename w1:pOTHER ' "$NR_LOG"
+}
+
+# --- #1140: the MEASURED bare-tmux shape (join leaves no record, label resolves) ----
+# Not herdr and not a hand-removed record: a tmux fake shaped like the real thing --
+# `list-panes` publishes @agmsg_agent, and the ref that gets written is
+# socket-qualified. Two arms on the SAME fixture: read-only creates nothing (the
+# FIX gate), --fix creates the socket-qualified record (the measured shape).
+_install_norecord_tmux_fixture() {
+  export NRT_LOG="$BATS_TEST_TMPDIR/tmux.log"; : > "$NRT_LOG"
+  local bin="$BATS_TEST_TMPDIR/bin"; mkdir -p "$bin"
+  cat > "$bin/tmux" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$NRT_LOG"
+t=""; prev=""; for x in "$@"; do [ "$prev" = -t ] && t="$x"; prev="$x"; done
+_label() { case "$1" in %11) printf 'fixteam:alice';; %22) printf 'fixteam:bob';; esac; }
+case "$* " in
+  *list-panes*)                   printf '%s|%s\n%s|%s\n' '%11' 'fixteam:alice' '%22' 'fixteam:bob' ;;
+  *display-message*@agmsg_agent*) printf '%s|%s\n' "$t" "$(_label "$t")" ;;
+  *display-message*pane_title*)   printf '%s|%s\n' "$t" 'title' ;;
+  *show-options*)                 printf '%s\n' "$(_label "$t")" ;;
+esac
+exit 0
+STUB
+  chmod +x "$bin/tmux"
+  export PATH="$bin:$PATH"
+  export TMUX="/tmp/tsock,999,0"           # provide the socket so the ref is socket-qualified
+  export AGMSG_TERMINAL_DRIVER=tmux
+  bash "$SCRIPTS/join.sh" fixteam alice claude-code /tmp/proj >/dev/null
+  NRT_REC="$(SKILL_DIR="$TEST_SKILL_DIR" bash -c 'cd "$1" && . lib/actas-lock.sh && . lib/terminal-registry.sh && agmsg_spawn_path fixteam alice' _ "$SCRIPTS")"
+  [ ! -e "$NRT_REC" ]                      # join writes no record: the measured state, naturally
+}
+
+@test "team (read-only, no repair verb) creates NO record even with a unique tmux label (#1140)" {
+  _install_norecord_tmux_fixture
+  run bash "$SCRIPTS/team.sh" fixteam
+  [ "$status" -eq 0 ]
+  [ ! -e "$NRT_REC" ]                       # a read-only status never creates a record
+}
+
+@test "team --fix creates a socket-qualified tmux record from the label (#1140)" {
+  _install_norecord_tmux_fixture
+  run bash "$SCRIPTS/team.sh" fixteam --fix-pane-names
+  [ "$status" -eq 0 ]
+  # (a) a record now names alice's pane, with a SOCKET-QUALIFIED tmux ref
+  [ "$(cat "$NRT_REC")" = $'tmux:/tmp/tsock:%11\t/tmp/proj\tclaude-code' ]
+  # positive control: --fix reached alice's pane (%11) through the driver
+  grep -q '%11' "$NRT_LOG"
+  # (b) the other seat's pane was never written
+  refute grep -q 'set-option .*-t %22 ' "$NRT_LOG"
 }

--- a/tests/test_team_status.bats
+++ b/tests/test_team_status.bats
@@ -771,3 +771,31 @@ _codex_type_get() {   # codex declares rename_cmd + rename_confirm; name not on 
   [ "$output" = 'herdr:w1:pOTHER' ]                                    # keep the record's ref
   [ "$(cat "$BATS_TEST_TMPDIR/rec")" = "$before" ]                     # NOT rewritten
 }
+
+# --- #1140: --fix CREATES a record for a seat that has none, from its label ------
+# The sibling of verify_placement: that one is "record exists but wrong", this is
+# "no record at all" (a sandbox seat denied naming never writes one). Same
+# env-independent material -- the label on exactly one pane.
+
+@test "create_placement: no record + a unique label pane -> the record is created for it (#1140)" {
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/terminal-registry.sh"
+  _agmsg_terminal_resolve_by_label() { printf 'herdr\tw1:pMINE\n'; }
+  local rec="$BATS_TEST_TMPDIR/newrec"
+  [ ! -e "$rec" ]
+  run agmsg_team_create_placement_from_label team alice "$rec" /proj claude-code
+  [ "$status" -eq 0 ]
+  [ "$output" = 'herdr:w1:pMINE' ]
+  [ "$(cat "$rec")" = $'herdr:w1:pMINE\t/proj\tclaude-code' ]
+}
+
+@test "create_placement: no unique label pane -> nothing is created, rc 1 (#1140)" {
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/terminal-registry.sh"
+  _agmsg_terminal_resolve_by_label() { return 1; }   # zero or many -> unfixable, as before
+  local rec="$BATS_TEST_TMPDIR/newrec"
+  run agmsg_team_create_placement_from_label team alice "$rec" /proj claude-code
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+  [ ! -e "$rec" ]     # a pane is never invented
+}


### PR DESCRIPTION
Closes #1140.

## The problem

A joined seat gets its pane labelled but **no placement record** — the record write sits behind naming, and a seat can even be denied terminal operations entirely (a sandbox returns `PermissionDenied` for the naming call), so it never names itself and never writes a record. `--fix` then skips every identity cell with `no_placement_record`, and the seat is unreachable through peek/poke — though the material to place it (its label on exactly one pane) is right there. This is not one seat's special case: **every seat that enters through `join` starts this way**.

## The change

The sibling of #1131's `agmsg_team_verify_placement` (the record exists but names the wrong pane); this is `agmsg_team_create_placement_from_label` (there is no record). When `--fix` meets a seat with no record, it resolves the seat by its label; if the label settles on exactly one pane, it creates the record for that pane and continues the repair there. Zero or many matches keep the seat unfixable, exactly as before — a pane is never invented. Only a repair verb creates a record; a read-only `team` status never does. Making a sandboxed seat able to name **itself** is an environment decision and stays out of scope.

## Reach: herdr now, tmux on #1146

Creation works wherever the label resolver can answer, and that differs by driver. herdr resolves a seat by listing panes, which needs nothing from the environment, so **herdr seats are placed today**. tmux resolves through `$TMUX`, and `--fix` runs from **outside** the seat's pane (that is its purpose), where `$TMUX` is unset and the tmux resolver abstains (#1132; a bare `%N` with no socket is not a resolvable ref, #1051) — so **a tmux seat stays `no_placement_record` until #1146**. Measured live.

## Tests

- The create half in isolation: a unique label creates the record; zero/many creates nothing and invents no pane.
- The whole `--fix` through `team.sh`, split so each half fails on its own assertion — **(a)** a record now names the seat's own pane, **(b)** another seat's pane is never written. Two mutations prove the independence: refusing to create reddens (a) alone; creating the record but handing the caller a different ref reddens (b) alone.
- The measured bare-tmux shape: a tmux fake whose `list-panes` publishes `@agmsg_agent`. Its `$TMUX` is a socket-providing artifice that pins the record **logic** (a socket-qualified `tmux:<socket>:<pane>` ref is created), and a **canary** (the same fixture minus `$TMUX`) asserts a tmux seat is not reached today — so when #1146 lets the resolver answer, that assertion reddens and says the limitation lifted.

`test_team_status` 56/56, `test_team` 95/95, enforced-assertions at baseline, private-names clean.

Base: integration/terminal-driver-v1.
