### PR TITLE
fix(terminal): discover trusted drivers for resolution instead of naming three (#1133)

### DIFF
--- a/scripts/drivers/terminals/herdr/terminal.conf
+++ b/scripts/drivers/terminals/herdr/terminal.conf
@@ -4,5 +4,6 @@
 # Detection resolves THIS session's pane from the session id via `agent list`
 # (the inherited HERDR_PANE_ID is NOT trusted — measured 2026-08-29).
 name=herdr
+priority=10
 backend=herdr pane
 capabilities=spawn despawn peek poke where arrange name

--- a/scripts/drivers/terminals/plain/terminal.conf
+++ b/scripts/drivers/terminals/plain/terminal.conf
@@ -5,6 +5,7 @@
 # v1 scope) and DESPAWNS as a no-op (an OS window has no handle; it closes with
 # its process). It has no addressable pane, so peek/poke/name are unsupported.
 name=plain
+priority=100
 backend=OS terminal window (no addressable pane)
 # Space-separated capability set, tested via agmsg_terminal_has: spawn + despawn.
 capabilities=spawn despawn

--- a/scripts/drivers/terminals/tmux/terminal.conf
+++ b/scripts/drivers/terminals/tmux/terminal.conf
@@ -3,5 +3,6 @@
 # the visible buffer (capture-pane), send keystrokes (send-keys), and title a
 # pane. Detection is env-only ($TMUX / $TMUX_PANE).
 name=tmux
+priority=20
 backend=tmux pane/window
 capabilities=spawn despawn peek poke where arrange name

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -130,6 +130,34 @@ agmsg_terminal_has() {
   return 1
 }
 
+# Print every eligible terminal driver name in detection order. Discovery uses
+# the same bases and external-driver trust gate as agmsg_terminal_dir; a driver
+# that can be loaded by name is therefore also eligible for automatic
+# resolution. Lower numeric `priority` wins, with the name as a deterministic
+# tiebreak. Missing or malformed priorities default to 50, between the bundled
+# pane drivers and plain's final fallback.
+agmsg_terminal_candidates() {
+  local kind base dir name names="" priority
+  while IFS=$'\t' read -r kind base; do
+    for dir in "$base"/terminals/*; do
+      [ -d "$dir" ] && [ -f "$dir/terminal.conf" ] || continue
+      name="${dir##*/}"
+      case "$name" in ''|*[!a-zA-Z0-9_-]*) continue ;; esac
+      if [ "$kind" != builtin ] && ! agmsg_driver_is_trusted terminals "$name" "$dir"; then
+        continue
+      fi
+      case " $names " in *" $name "*) ;; *) names="${names:+$names }$name" ;; esac
+    done
+  done <<EOF
+$(agmsg_driver_bases)
+EOF
+  for name in $names; do
+    priority="$(agmsg_terminal_get "$name" priority 50)"
+    case "$priority" in ''|*[!0-9]*) priority=50 ;; esac
+    printf '%s\t%s\n' "$priority" "$name"
+  done | sort -n -k1,1 -k2,2 | cut -f2
+}
+
 # The full terminal ABI. EVERY driver must define EVERY one of these; the loader
 # verifies it. Naming the set here (not relying on each driver being complete) is
 # what makes a missing op FAIL rather than silently borrow the previously loaded
@@ -258,7 +286,8 @@ _agmsg_terminal_detect_one() {
 # decides nothing — these do.
 #
 # Precedence for both: an explicit override (AGMSG_TERMINAL_DRIVER, or arg 2) wins
-# over detection; else detection runs herdr > tmux > plain. This ends the historic
+# over detection; else every eligible driver runs in manifest-priority order.
+# Bundled priorities preserve herdr > tmux > plain. This ends the historic
 # $TMUX-vs-HERDR_* dual system; callers RECORD the resolved terminal rather than
 # re-deciding later from an inherited env (a nested herdr-in-tmux lies — measured
 # 2026-08-21). The override is a SPAWN/NAME preference only: ops on an EXISTING
@@ -283,7 +312,7 @@ agmsg_terminal_resolve_placement() {
     printf '%s\n' "$override"
     return 0
   fi
-  for name in herdr tmux plain; do
+  for name in $(agmsg_terminal_candidates); do
     if _agmsg_terminal_detect_one "$name" "$sid" >/dev/null 2>&1; then
       printf '%s\n' "$name"
       return 0
@@ -295,7 +324,7 @@ agmsg_terminal_resolve_placement() {
 # resolve-for-NAME (terminal_name / SessionStart): prints "<terminal>\t<self-id>"
 # and exit 0. ORDER (2026-09-01, from the nested-herdr measurement): prefer a
 # candidate that PRODUCED A PANE ID over one that only claimed PRESENCE; the
-# declaration order (herdr > tmux > plain) is the tiebreak AMONG id-producers.
+# manifest-priority order is the tiebreak AMONG id-producers.
 #
 # Why not "first present wins": a nested herdr-in-tmux inherits HERDR_* into a tmux
 # server it spawned, so herdr answers "present" though tmux is the real terminal. If
@@ -318,7 +347,8 @@ agmsg_terminal_resolve_name() {
   local sid="${1:-}" override="${2:-${AGMSG_TERMINAL_DRIVER:-}}" name id rc errf reason
   local reasons="" saw_present_unnamed=0 plain_present=0 plain_name=""
   errf="$(mktemp "${TMPDIR:-/tmp}/agmsg-detect.XXXXXX")" || errf=/dev/null
-  local names="herdr tmux plain"
+  local names
+  names="$(agmsg_terminal_candidates)"
   if [ -n "$override" ]; then
     agmsg_terminal_dir "$override" >/dev/null 2>&1 || {
       echo "agmsg: unknown terminal driver '$override' (AGMSG_TERMINAL_DRIVER)" >&2
@@ -642,7 +672,8 @@ _agmsg_terminal_resolve_by_label() {   # <team> <agent>
   [ -n "$team" ] && [ -n "$agent" ] || return 1
   label="$team:$agent"
   tab="$(printf '\t')"
-  local names="herdr tmux plain"
+  local names
+  names="$(agmsg_terminal_candidates)"
   [ -n "${AGMSG_TERMINAL_DRIVER:-}" ] && names="$AGMSG_TERMINAL_DRIVER"
   for name in $names; do
     agmsg_terminal_load "$name" >/dev/null 2>&1 || continue

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -32,6 +32,36 @@ teardown() { teardown_test_env; }
 # terminal layer too now (#1044).
 _install_fake_tmux() { agmsg_install_fake_tmux; }
 
+# Install and trust a fourth terminal driver. Its priority puts it after herdr
+# and before tmux, so every resolver can prove that it discovers manifests
+# instead of consulting a built-in name list.
+_install_external_terminal() {
+  local d="$SKILL_DIR/plugins/terminals/probe"
+  mkdir -p "$d"
+  cat > "$d/terminal.conf" <<'EOF'
+name=probe
+priority=15
+backend=test probe
+capabilities=name
+EOF
+  cat > "$d/ops.sh" <<'EOF'
+terminal_check() { echo ok; }
+terminal_describe() { echo name=probe; }
+terminal_detect() { printf 'probe-pane\n'; }
+terminal_spawn() { printf 'probe-spawned\n'; }
+terminal_despawn() { :; }
+terminal_pane_state() { echo present; }
+terminal_peek() { :; }
+terminal_poke() { :; }
+terminal_where() { echo probe-container; }
+terminal_arrange() { echo unchanged; }
+terminal_name() { :; }
+terminal_find_by_label() { printf 'probe-pane\n'; }
+terminal_label_of() { printf 'testteam:alice\n'; }
+EOF
+  agmsg_driver_trust terminals probe "$d"
+}
+
 # A fake `herdr` that logs argv and returns canned JSON/text for session <sid>.
 _install_fake_herdr() {
   local sid="${1:-}"
@@ -198,6 +228,17 @@ _fake_herdr_list_scalar_session() {
   run agmsg_terminal_resolve_name "sess-abc"
   [ "$status" -eq 0 ]
   [ "$output" = "$(printf 'herdr\twC:p4')" ]
+}
+
+@test "resolve: a trusted external manifest participates in every chooser (#1133)" {
+  _install_fake_tmux
+  _install_external_terminal
+  export TMUX="/tmp/sock,1,0" TMUX_PANE="%4"
+
+  [ "$(agmsg_terminal_candidates)" = "$(printf 'herdr\nprobe\ntmux\nplain')" ]
+  [ "$(agmsg_terminal_resolve_placement sess-x)" = "probe" ]
+  [ "$(agmsg_terminal_resolve_name sess-x)" = "$(printf 'probe\tprobe-pane')" ]
+  [ "$(_agmsg_terminal_resolve_by_label testteam alice)" = "$(printf 'probe\tprobe-pane')" ]
 }
 
 @test "resolve: an explicit override wins over detection" {


### PR DESCRIPTION
The terminal axis can load a driver by name, built-in or trusted external alike,
but every place that had to choose one named the three built-ins literally --
auto-detection, resolve-for-naming, and the label search added last week. An
external driver was reachable only when AGMSG_TERMINAL_DRIVER named it
explicitly, so it could never be found by the path every seat actually takes.

Enumerate the trusted manifests in priority order and feed that to all three
choosers. Order carries meaning here and a directory listing would lose it: the
existing rule prefers a candidate that produced a pane id over one that only
claimed presence, with declaration order as the tiebreak among id-producers, and
a nested herdr-in-tmux resolves differently if that changes. The priority now
lives in the manifest rather than in three copies of one list.

The label search still counts across every driver; that behaviour is unchanged.

Same shape as three defects found this week -- a caller assuming what one driver
happens to do -- and the list was not merely old: the third copy was added by the
label-first change itself.

Local: tests/test_terminal_registry.bats 138/138, bash -n and diff --check clean.
Pushed on the author's behalf; their sandbox refuses outbound network.