### PR TITLE
fix(herdr): honor the requested peek depth instead of a fixed recent window (#1121)

### DIFF
--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -719,17 +719,18 @@ terminal_arrange() {
 }
 
 # record op: print the visible pane buffer verbatim (NOT parsed — `agent read`/
-# `pane read` output is raw terminal text). --lines N asks for more scrollback
-# (herdr's --source recent) rather than an exact count. ASSERTED argv.
+# `pane read` output is raw terminal text). --lines N selects herdr's recent
+# source and passes the requested depth through to the backend. ASSERTED argv.
 terminal_peek() {
   local id="$1"; shift
-  local src=visible
+  local src=visible lines=""
   while [ $# -gt 0 ]; do
     case "$1" in
-      --lines) src=recent; shift 2 ;;
+      --lines) src=recent; lines="${2:-}"; shift 2 ;;
       *) shift ;;
     esac
   done
+  case "$lines" in ''|*[!0-9]*) lines="" ;; esac
   # peek is a READ op: only the pane CONTENT may reach stdout. herdr writes an error
   # JSON to STDOUT on failure (e.g. {"error":{"code":"pane_not_found",...}}), which the
   # caller would otherwise read as the pane's content — "read" and "could-not-read"
@@ -750,7 +751,11 @@ terminal_peek() {
   # never the caller's content.
   local tmp rc=0
   tmp="$(mktemp)" || { echo "herdr: could not allocate a temp file to peek pane '$id'" >&2; return 12; }
-  herdr pane read "$id" --source "$src" >"$tmp" 2>/dev/null || rc=$?
+  if [ -n "$lines" ]; then
+    herdr pane read "$id" --source "$src" --lines "$lines" >"$tmp" 2>/dev/null || rc=$?
+  else
+    herdr pane read "$id" --source "$src" >"$tmp" 2>/dev/null || rc=$?
+  fi
   if [ "$rc" -ne 0 ]; then
     [ -s "$tmp" ] && cat "$tmp" >&2   # the error body is a diagnostic, not content
     rm -f "$tmp"

--- a/scripts/lib/team-status.sh
+++ b/scripts/lib/team-status.sh
@@ -219,11 +219,11 @@ agmsg_team_fix_pane_names_loaded() {
 # (rc 1, no output) rather than reading as 0 -- see the read-failure note below.
 _agmsg_rename_confirm_count() {   # <pane> <confirm_prefix> <expected>
   local screen
-  # Ask for a generous window so a pre-existing line is captured too. Drivers honor
-  # this differently -- tmux takes --lines as given; the herdr driver maps it to its
-  # own recent window (~80 lines) and ignores a larger number -- so this is a
-  # request, not a guarantee of depth. It does not need to be: before and after read
-  # the SAME window on the SAME driver, so the count DELTA is valid whatever the depth.
+  # Ask for a generous window so a pre-existing line is captured too. The shipped
+  # pane drivers pass this depth to their backends, but it remains a request rather
+  # than a guarantee about an external driver's buffer. It does not need to be a
+  # guarantee: before and after read the SAME window on the SAME driver, so the count
+  # DELTA is valid whatever depth the backend can provide.
   #
   # A READ FAILURE is not zero matches (advisor, #1120). Returning 0 here would let a
   # transient peek failure before the keystroke set a false baseline of 0, and a

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -24,8 +24,10 @@
 #   terminal_spawn <name> <project> <target> <boot...>   RECORD op: create a pane/window,
 #                                       launch boot, print the new bare pane id.
 #   terminal_despawn <id>               control op: kill the pane/window named by bare <id>.
-#   terminal_peek <id> [--lines N]      RECORD op: print visible pane text verbatim (NOT
-#                                       parsed). unsupported -> exit 13, reason on stderr.
+#   terminal_peek <id> [--lines N]      RECORD op: print pane text verbatim (NOT parsed).
+#                                       With --lines, request scrollback depth N; shipped
+#                                       pane drivers pass N unchanged to their backend.
+#                                       unsupported -> exit 13, reason on stderr.
 #   terminal_poke <id> <text>           control op: send text and submit. unsupported -> 13.
 #   terminal_pane_state <id>            READ ONLY: is that pane still there?
 #                                       Prints gone / present / unknown and

--- a/scripts/peek.sh
+++ b/scripts/peek.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 #
 #   <team>     team the member is in
 #   <name>     the member whose pane to read
-#   --lines N  include scrollback: the driver decides what N means for its
-#              backend (tmux: last N lines; herdr: the 'recent' source)
+#   --lines N  request scrollback depth N (passed unchanged to the tmux/herdr
+#              backend)
 #
 # Read-only. The member's placement record (run/spawn.<team>__<name>, written
 # at placement time) names the terminal and the pane id; that terminal's driver

--- a/tests/test_peek_poke.bats
+++ b/tests/test_peek_poke.bats
@@ -92,6 +92,15 @@ EOF
   grep -q '^tmux \[capture-pane\] \[-p\] \[-t\] \[%5\] \[-S\] \[-40\]$' "$ARGV_LOG"
 }
 
+@test "peek: herdr record forwards the requested scrollback depth (#1121)" {
+  _install_fake_herdr
+  _write_record "herdr:w1:p5"
+  run bash "$SCRIPTS/peek.sh" testteam alice --lines 40
+  [ "$status" -eq 0 ]
+  _out_has "herdr visible text"
+  grep -q '^herdr \[pane\] \[read\] \[w1:p5\] \[--source\] \[recent\] \[--lines\] \[40\]$' "$ARGV_LOG"
+}
+
 @test "peek: a legacy bare tmux id in the record still resolves as tmux" {
   _install_fake_tmux
   _write_record "%7"

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -647,6 +647,13 @@ EOF
   grep -qE '\[agent\] \[rename\] \[wC:p9\] \[a[0-9a-f]{24}\]' "$ARGV_LOG"
 }
 
+@test "herdr: peek passes the requested scrollback depth to pane read (#1121)" {
+  _install_fake_herdr "sess-77"
+  agmsg_terminal_load herdr
+  terminal_peek 'wC:p9' --lines 50 >/dev/null
+  grep -q '\[pane\] \[read\] \[wC:p9\] \[--source\] \[recent\] \[--lines\] \[50\]' "$ARGV_LOG"
+}
+
 _install_fake_herdr_layout() {
   cat > "$FAKEBIN/herdr" <<EOF
 #!/usr/bin/env bash


### PR DESCRIPTION
`terminal_peek` accepted a line count, but the herdr driver mapped it to a fixed recent window and dropped the number; the tmux driver honours it. The window therefore depended on which driver answered, and on herdr it was one fifth of what the internal caller requested. The herdr CLI itself accepts the depth.

Pass the requested number through to herdr. Callers already treat the count as a request rather than a guarantee, so downstream reasoning does not change; the request is now met by both shipped pane drivers.

The production inventory is four call sites across two files and three behaviours:

- One internal fixed-depth call: the Codex rename-confirmation path in `team-status.sh` passes `--lines 400`. It counts matching confirmation lines before and after typing and needs the larger window to keep an older matching line in both snapshots; correctness still comes from the count increasing, not from assuming that 400 lines are guaranteed.
- One user-depth forwarding call: `peek.sh` passes the value from its public `--lines N` option unchanged. Here N is directly part of the user's request, so dropping it violates the CLI contract.
- Two depth-independent calls: `peek.sh` without `--lines` asks for the visible/default buffer, and the read-only session-name observation in `team-status.sh` also asks for the default buffer. Neither depends on a numeric depth, and both remain unchanged.

The diff adds two independent argv regressions: one calls the driver ABI directly and one enters through public `peek.sh`. Mutating the herdr command to drop `--lines "$lines"` makes both dedicated tests red; the unmutated terminal-registry and peek/poke suites pass.

Found while reviewing Codex rename verification. The authoring seat could not perform live herdr validation because its sandbox refused pane access. The maintainer measured a real pane with 1183 lines of scrollback: integration returned 80 lines for `terminal_peek <pane> --lines 400`, while this PR returned 400. The CLI's help and that live measurement both confirm that the backend accepts the requested depth. The live command must use the flag form: a bare `terminal_peek <pane> 400` is not a depth request and falls through to the default on both trees.

Pushed on the author's behalf because the authoring sandbox refuses outbound network.
