### PR TITLE
fix(tmux): search every server when the caller is not inside tmux (#1146)

### DIFF
--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -480,6 +480,38 @@ terminal_poke() {
 # (A label containing a NEWLINE would still split the row itself. That one is
 # closed upstream: `validate.sh` rejects control characters in both halves of the
 # pair, which is why the separator is the only case left to handle here.)
+# Search every tmux server this user owns for panes carrying <label>, printing
+# each hit socket-qualified. Used when the caller is not inside tmux, where
+# there is no $TMUX to name a server -- see terminal_find_by_label.
+#
+# Every line printed carries its own socket, so a caller cannot end up with an
+# id whose server is unknown; that ambiguity is the thing #1051 keeps out of
+# placement records and the reason #1126 refused the ambient-server shortcut.
+# Finding the same label on two servers is a genuine ambiguity and both lines
+# are printed: the caller counts, and more than one is not resolvable.
+_tmux_find_by_label_all_servers() {
+  local label="$1" dir sock out found=0
+  dir="${TMUX_TMPDIR:-/tmp}/tmux-$(id -u 2>/dev/null)"
+  [ -d "$dir" ] || return 0          # no servers is not a failure: zero matches
+  for sock in "$dir"/*; do
+    [ -S "$sock" ] || continue
+    # A stale socket makes tmux exit non-zero; that is one dead server, not a
+    # failed search, so keep going rather than reporting we could not answer.
+    out="$(tmux -S "$sock" list-panes -a -F '#{pane_id}|#{@agmsg_agent}' 2>/dev/null)" || continue
+    [ -n "$out" ] || continue
+    printf '%s\n' "$out" | awk -v want="$label" -v sock="$sock" '
+      {
+        p = index($0, "|")
+        if (p == 0) next
+        id = substr($0, 1, p - 1)
+        if (substr($0, p + 1) != want) next
+        printf "%s:%s\n", sock, id
+      }'
+    found=1
+  done
+  return 0
+}
+
 terminal_find_by_label() {   # <label>
   local label="$1" out sock
   [ -n "$label" ] || return 0
@@ -499,7 +531,18 @@ terminal_find_by_label() {   # <label>
   # `%N` in a placement record is the socket-less legacy form that a pane id is
   # not unique across (#1051). "Not under tmux" is the honest answer, and it is
   # the one `terminal_detect` already gives.
-  [ -n "${TMUX:-}" ] || return 10
+  #
+  # WITHOUT $TMUX we do not refuse outright: `team --fix` runs from outside the
+  # pane it repairs -- that is what it is for -- so it never has $TMUX, and
+  # refusing here means a tmux seat can never be repaired by the one command
+  # meant to repair it (#1146). What #1126 rejected was searching the AMBIENT
+  # server, which cannot say where an id came from. Enumerating the socket
+  # directory and qualifying every hit with the socket it came from says exactly
+  # that, so no bare `%N` reaches a placement record.
+  if [ -z "${TMUX:-}" ]; then
+    _tmux_find_by_label_all_servers "$label"
+    return $?
+  fi
   sock="${TMUX%%,*}"
   out="$(_tmux_do "${sock:+$sock:}" list-panes -a -F '#{pane_id}|#{@agmsg_agent}' 2>/dev/null)" || return 10
   printf '%s\n' "$out" | awk -v want="$label" -v sock="$sock" '

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -490,14 +490,31 @@ terminal_poke() {
 # Finding the same label on two servers is a genuine ambiguity and both lines
 # are printed: the caller counts, and more than one is not resolvable.
 _tmux_find_by_label_all_servers() {
-  local label="$1" dir sock out found=0
+  local label="$1" dir sock out err rc=0
   dir="${TMUX_TMPDIR:-/tmp}/tmux-$(id -u 2>/dev/null)"
   [ -d "$dir" ] || return 0          # no servers is not a failure: zero matches
+  err="$(mktemp "${TMPDIR:-/tmp}/agmsg-tmuxsrv.XXXXXX")" || err=""
   for sock in "$dir"/*; do
     [ -S "$sock" ] || continue
-    # A stale socket makes tmux exit non-zero; that is one dead server, not a
-    # failed search, so keep going rather than reporting we could not answer.
-    out="$(tmux -S "$sock" list-panes -a -F '#{pane_id}|#{@agmsg_agent}' 2>/dev/null)" || continue
+    rc=0
+    out="$(tmux -S "$sock" list-panes -a -F '#{pane_id}|#{@agmsg_agent}' 2>"${err:-/dev/null}")" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+      # A non-zero does NOT prove the server is gone. Permission, a transient
+      # failure or a protocol mismatch all look the same from here, and this
+      # search claims UNIQUENESS across every server: silently skipping a server
+      # we could not read can hide a second holder of this label and let the one
+      # hit elsewhere resolve as if it were the only one.
+      #
+      # So only a socket tmux itself calls absent is skipped. Anything else is
+      # undecidable, and undecidable poisons the answer: return 10, "could not
+      # answer", which the caller already treats as not-resolved rather than as
+      # zero matches.
+      if [ -n "$err" ] && grep -qiE 'no server running|no such file or directory' "$err" 2>/dev/null; then
+        continue                      # proven stale: one dead server, keep going
+      fi
+      [ -n "$err" ] && rm -f "$err"
+      return 10
+    fi
     [ -n "$out" ] || continue
     printf '%s\n' "$out" | awk -v want="$label" -v sock="$sock" '
       {
@@ -507,8 +524,8 @@ _tmux_find_by_label_all_servers() {
         if (substr($0, p + 1) != want) next
         printf "%s:%s\n", sock, id
       }'
-    found=1
   done
+  [ -n "$err" ] && rm -f "$err"
   return 0
 }
 
@@ -526,19 +543,20 @@ terminal_find_by_label() {   # <label>
   # nothing said -- resolution then fell back to the environment, which is the
   # answer the label path exists to replace.
   #
-  # And it has to REFUSE rather than search the ambient default server: without
-  # a socket there is no way to say which server an id came from, and a bare
-  # `%N` in a placement record is the socket-less legacy form that a pane id is
-  # not unique across (#1051). "Not under tmux" is the honest answer, and it is
-  # the one `terminal_detect` already gives.
+  # WITHOUT $TMUX the answer is neither the ambient server nor a refusal.
   #
-  # WITHOUT $TMUX we do not refuse outright: `team --fix` runs from outside the
-  # pane it repairs -- that is what it is for -- so it never has $TMUX, and
-  # refusing here means a tmux seat can never be repaired by the one command
-  # meant to repair it (#1146). What #1126 rejected was searching the AMBIENT
-  # server, which cannot say where an id came from. Enumerating the socket
-  # directory and qualifying every hit with the socket it came from says exactly
-  # that, so no bare `%N` reaches a placement record.
+  # #1126 refused, and was right about the hazard: with no socket there is no way
+  # to say which server an id came from, and a bare `%N` in a placement record is
+  # the socket-less legacy form a pane id is not unique across (#1051). Searching
+  # whatever server happens to be ambient reintroduces exactly that.
+  #
+  # It was wrong about the remedy. `team --fix` runs from OUTSIDE the pane it
+  # repairs -- that is what it is for -- so it never has $TMUX, and refusing here
+  # meant a tmux seat could not be repaired by the one command meant to repair it
+  # (#1146). Enumerating the socket directory and qualifying every hit with the
+  # socket it came from answers the question the ambient shortcut could not, so
+  # the hazard is met by the FORM of the answer rather than by declining to give
+  # one. No bare `%N` reaches a placement record either way.
   if [ -z "${TMUX:-}" ]; then
     _tmux_find_by_label_all_servers "$label"
     return $?

--- a/tests/test_team.bats
+++ b/tests/test_team.bats
@@ -1216,6 +1216,7 @@ _install_norecord_tmux_fixture() {
 printf '%s\n' "$*" >> "$NRT_LOG"
 t=""; prev=""; for x in "$@"; do [ "$prev" = -t ] && t="$x"; prev="$x"; done
 _label() { case "$1" in %11) printf 'fixteam:alice';; %22) printf 'fixteam:bob';; esac; }
+sock=""; [ "$1" = -S ] && sock="$2"
 case "$* " in
   *list-panes*)                   printf '%s|%s\n%s|%s\n' '%11' 'fixteam:alice' '%22' 'fixteam:bob' ;;
   *display-message*@agmsg_agent*) printf '%s|%s\n' "$t" "$(_label "$t")" ;;
@@ -1226,6 +1227,14 @@ exit 0
 STUB
   chmod +x "$bin/tmux"
   export PATH="$bin:$PATH"
+  # A real socket in a real socket directory: #1146 enumerates that directory and
+  # tests `[ -S ]` on each entry. A stub on PATH alone leaves nothing to
+  # enumerate, and the no-$TMUX arm would then be measuring "this fixture has no
+  # sockets" while reading as "the resolver declined".
+  export NRT_SOCKDIR="$BATS_TEST_TMPDIR/socks"
+  mkdir -p "$NRT_SOCKDIR/tmux-$(id -u)"
+  python3 -c 'import socket,sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1])' \
+    "$NRT_SOCKDIR/tmux-$(id -u)/srv" 2>/dev/null || true
   # $TMUX is set here to give the resolver a socket, so this pins the record LOGIC
   # (a socket-qualified tmux ref is created from the label). It is NOT the real
   # --fix environment: --fix runs from OUTSIDE the seat's pane, where $TMUX is
@@ -1258,15 +1267,25 @@ STUB
   refute grep -q 'set-option .*-t %22 ' "$NRT_LOG"
 }
 
-# The measured LIVE gap (#1146): --fix runs from OUTSIDE the seat's pane, so it has
-# no $TMUX, and the tmux resolver abstains without it (#1132). So a tmux seat is not
-# actually reached by --fix today -- the same fixture, minus the $TMUX artifice.
-# This is the canary: when #1146 gives the resolver a socket without $TMUX, this
-# flips to a created record and this assertion reddens, saying the limitation lifted.
-@test "team --fix does not YET reach a tmux seat run from outside its pane -- no \$TMUX (#1146)" {
+# This began as a canary for a limitation: `--fix` runs from OUTSIDE the seat's
+# pane, so it has no $TMUX, and the tmux resolver abstained without one (#1132) --
+# a tmux seat could not be repaired by the command meant to repair it. The canary
+# said "not yet", and was written to redden when the limitation lifted.
+#
+# It lifted (#1146): the resolver enumerates the socket directory and qualifies
+# every hit with the socket it came from, so it answers without $TMUX and still
+# never emits a bare `%N`. Turned over rather than deleted, so what it guarded
+# stays visible -- the same fixture, still with no $TMUX, now has to produce the
+# record.
+@test "team --fix reaches a tmux seat run from outside its pane, with no $TMUX (#1146)" {
   _install_norecord_tmux_fixture
   unset TMUX
+  export TMUX_TMPDIR="$NRT_SOCKDIR"
   run bash "$SCRIPTS/team.sh" fixteam --fix-pane-names
   [ "$status" -eq 0 ]
-  [ ! -e "$NRT_REC" ]
+  [ -e "$NRT_REC" ]
+  # What it wrote names the server it came from: lifting the limitation must not
+  # relax the hazard the partner test guards (#1051).
+  grep -q 'tmux:' "$NRT_REC"
+  refute grep -qE 'tmux:%[0-9]+' "$NRT_REC"
 }

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2847,6 +2847,29 @@ EOF
   bash "$BATS_TEST_TMPDIR/probe.sh" 2>&1
 }
 
+_fake_tmux_sockets_one_unreadable() {   # <dir> <bad> <good> <pane_id> <label> [bad-msg]
+  local dir="$1" bad="$2" good="$3" pane="$4" label="$5" msg="${6:-connect failed: permission denied}" uid n
+  uid="$(id -u)"
+  mkdir -p "$dir/tmux-$uid"
+  for n in "$bad" "$good"; do
+    python3 -c 'import socket,sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1])' "$dir/tmux-$uid/$n"
+  done
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+sock=""
+if [ "\$1" = -S ]; then sock="\$2"; shift 2; fi
+case "\$sock" in
+  */$bad) echo '$msg' >&2; exit 1 ;;
+esac
+case "\$1" in
+  list-panes)      [ -n "\$sock" ] && printf '%s|%s\n' '$pane' '$label' ;;
+  display-message) printf '%s|%s\n' "\$4" '$label' ;;
+esac
+exit 0
+EOF
+  chmod +x "$FAKEBIN/tmux"
+}
+
 _fake_tmux_sockets_with_label() {   # <dir> <server-names> <pane_id> <label>
   local dir="$1" servers="$2" pane="$3" label="$4" uid n
   uid="$(id -u)"
@@ -2972,6 +2995,33 @@ _agmsg_terminal_resolve_by_label team alice && echo "RESOLVED"
 echo "fell through"'
   grep -q 'fell through' <<<"$output"
   refute grep -q 'RESOLVED' <<<"$output"
+}
+@test "self-identity: a server we could not READ poisons uniqueness (#1146)" {
+  # Found in review, measured: one socket answering non-zero and one returning a
+  # hit resolved as though the hit were the only one. It is not -- a server we
+  # could not read may hold the same label, and this search claims uniqueness
+  # across every server. "Could not read" is not "is not there".
+  _fake_tmux_sockets_one_unreadable "$BATS_TEST_TMPDIR/mix" 'srvBad' 'srvGood' '%5' 'team:alice'
+  run _probe_under_set_u 'unset TMUX TMUX_PANE
+export TMUX_TMPDIR="'"$BATS_TEST_TMPDIR"'/mix"
+_agmsg_terminal_resolve_by_label team alice && echo "RESOLVED"
+echo "fell through"'
+  grep -q 'fell through' <<<"$output"
+  refute grep -q 'RESOLVED' <<<"$output"
+}
+
+@test "self-identity: a server tmux calls ABSENT is skipped, not fatal (#1146 control)" {
+  # The differential control for the test above. "Give up whenever any socket
+  # errors" also passes it, and would make one stale socket in the directory --
+  # the ordinary state of a machine that has run tmux before -- disable the
+  # search entirely. Only a server tmux itself reports as gone is skipped.
+  _fake_tmux_sockets_one_unreadable "$BATS_TEST_TMPDIR/stale" 'srvGone' 'srvGood' '%5' 'team:alice' 'no server running on /tmp/x'
+  run _probe_under_set_u 'unset TMUX TMUX_PANE
+export TMUX_TMPDIR="'"$BATS_TEST_TMPDIR"'/stale"
+agmsg_terminal_load tmux
+terminal_find_by_label "team:alice"'
+  [ "$status" -eq 0 ]
+  grep -q "srvGood:%5" <<<"$output"
 }
 
 # --- #1127: a naming failure says WHICH step failed, and what the server said --

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2847,6 +2847,31 @@ EOF
   bash "$BATS_TEST_TMPDIR/probe.sh" 2>&1
 }
 
+_fake_tmux_sockets_with_label() {   # <dir> <server-names> <pane_id> <label>
+  local dir="$1" servers="$2" pane="$3" label="$4" uid n
+  uid="$(id -u)"
+  mkdir -p "$dir/tmux-$uid"
+  for n in $servers; do
+    # A real socket, so the driver's `[ -S ]` test is exercised rather than
+    # bypassed: a plain file would let a laxer test pass and hide the difference.
+    python3 -c 'import socket,sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1])' "$dir/tmux-$uid/$n"
+  done
+  # Unlike the one-label fake, this one HONOURS -S and answers as the server it
+  # was asked about. A fake that ignores -S cannot tell "searched every server"
+  # apart from "searched one", which is the whole subject of these tests.
+  cat > "$FAKEBIN/tmux" <<EOF
+#!/usr/bin/env bash
+sock=""
+if [ "\$1" = -S ]; then sock="\$2"; shift 2; fi
+case "\$1" in
+  list-panes)      [ -n "\$sock" ] && printf '%s|%s\n' '$pane' '$label' ;;
+  display-message) printf '%s|%s\n' "\$4" '$label' ;;
+esac
+exit 0
+EOF
+  chmod +x "$FAKEBIN/tmux"
+}
+
 _fake_tmux_one_label() {   # <pane_id> <label>
   cat > "$FAKEBIN/tmux" <<EOF
 #!/usr/bin/env bash
@@ -2868,19 +2893,22 @@ EOF
   grep -q 'unbound variable' <<<"$output"
 }
 
-@test "self-identity: the tmux label search does not die on an unset \$TMUX (#1126)" {
+@test "self-identity: the tmux label search does not die on an unset $TMUX (#1126)" {
   # The defect: `sock="${TMUX%%,*}"` with no default. The function's subshell
   # died, the caller's `|| continue` swallowed it, and the label path was gone.
+  #
+  # WHAT it does instead of dying changed with #1146; the half this test pins --
+  # surviving -u at all -- did not. No pane comes back here because this fake
+  # publishes no socket directory: nothing to enumerate is "nothing found", and
+  # that is still not a crash.
   _fake_tmux_one_label '%5' 'team:alice'
   run _probe_under_set_u 'unset TMUX TMUX_PANE
+export TMUX_TMPDIR="$BATS_TEST_TMPDIR/no-such-sockets"
 agmsg_terminal_load tmux
 terminal_find_by_label "team:alice" || echo "refused rc=$?"
 echo done'
   refute grep -q 'unbound variable' <<<"$output"
   grep -q 'done' <<<"$output"
-  # Refusing is the right answer -- see the partner test below -- but it must be
-  # a REFUSAL, not a pane.
-  refute grep -q '%5' <<<"$output"
 }
 
 @test "self-identity: with \$TMUX set, the same search still finds the pane (#1126)" {
@@ -2897,19 +2925,53 @@ terminal_find_by_label "team:alice"'
   grep -q '/tmp/sock:%5' <<<"$output"
 }
 
-@test "self-identity: an unset \$TMUX resolves NOTHING rather than a socket-less pane (#1126)" {
-  # The second half of the fix, and the reason the answer is "refuse" and not
-  # "search the ambient default server": with no socket there is no way to say
-  # WHICH server an id came from, and a bare `%N` in a placement record is the
-  # legacy form a pane id is not unique across (#1051). `terminal_detect` has
-  # always treated an unset $TMUX as "not under tmux"; this now agrees with it.
-  _fake_tmux_one_label '%5' 'team:alice'
+@test "self-identity: an unset $TMUX finds the pane instead of declining (#1146)" {
+  # This half used to require that an unset $TMUX resolve NOTHING. That was right
+  # about the hazard and wrong about the remedy, so it is rewritten rather than
+  # deleted -- see the partner test for the hazard it was protecting.
+  #
+  # `team --fix` runs from outside the pane it repairs, so it never has $TMUX.
+  # Declining there meant a tmux seat could not be repaired by the one command
+  # meant to repair it.
+  _fake_tmux_sockets_with_label "$BATS_TEST_TMPDIR/socks" 'srvA' '%5' 'team:alice'
   run _probe_under_set_u 'unset TMUX TMUX_PANE
-_agmsg_terminal_resolve_by_label team alice && echo "RESOLVED: $?"
+export TMUX_TMPDIR="'"$BATS_TEST_TMPDIR"'/socks"
+agmsg_terminal_load tmux
+terminal_find_by_label "team:alice"'
+  [ "$status" -eq 0 ]
+  grep -q '%5' <<<"$output"
+}
+
+@test "self-identity: what comes back names its server, never a bare pane id (#1051, #1146)" {
+  # The hazard the old "resolve NOTHING" test was protecting, kept as its own
+  # gate: with no socket there is no way to say WHICH server an id came from, and
+  # a bare `%N` in a placement record is the legacy form a pane id is not unique
+  # across. Searching the AMBIENT server -- the shortcut #1126 rejected --
+  # reintroduces exactly that.
+  #
+  # Separate from the test above on purpose. Folded together, dropping the search
+  # and dropping the qualification redden the same single test, and either could
+  # then be fixed while the other stayed green.
+  _fake_tmux_sockets_with_label "$BATS_TEST_TMPDIR/socks3" 'srvA' '%5' 'team:alice'
+  run _probe_under_set_u 'unset TMUX TMUX_PANE
+export TMUX_TMPDIR="'"$BATS_TEST_TMPDIR"'/socks3"
+agmsg_terminal_load tmux
+terminal_find_by_label "team:alice"'
+  grep -q "srvA:%5" <<<"$output"
+  refute grep -qE '(^|[^:])%5$' <<<"$output"
+}
+
+@test "self-identity: one label on two servers is an ambiguity, not a pick (#1146)" {
+  # The differential control. "Print every hit" passes the test above on its own;
+  # this is what stops one label found on two servers from becoming a confident
+  # answer. The resolver counts, and more than one does not resolve.
+  _fake_tmux_sockets_with_label "$BATS_TEST_TMPDIR/socks2" 'srvA srvB' '%5' 'team:alice'
+  run _probe_under_set_u 'unset TMUX TMUX_PANE
+export TMUX_TMPDIR="'"$BATS_TEST_TMPDIR"'/socks2"
+_agmsg_terminal_resolve_by_label team alice && echo "RESOLVED"
 echo "fell through"'
   grep -q 'fell through' <<<"$output"
   refute grep -q 'RESOLVED' <<<"$output"
-  refute grep -q '%5' <<<"$output"
 }
 
 # --- #1127: a naming failure says WHICH step failed, and what the server said --


### PR DESCRIPTION
`team --fix` runs from outside the pane it repairs — that is what it is for — so it
never has `$TMUX`. The tmux label search declined without it, so a tmux seat
could not be repaired by the one command meant to repair it.

Both halves were individually right, which is why this survived: the driver
declined because without a socket it cannot say which server a bare `%N` belongs
to, and the repair path is correct to run outside the seat's pane.

Enumerate the socket directory and search each server, qualifying every hit with
the socket it came from. Not the ambient-server shortcut #1126 rejected — that
could not say where an id came from. Naming the socket answers exactly that, so
the hazard #1051 guards is met by the **form** of the answer rather than by
declining to answer.

## Measured on a real tmux server

Against the state the real entry path produces, not a fixture: a bare
`tmux new-session`, `join.sh` from inside that pane, then the repair from an
ordinary shell.

| | `terminal_find_by_label` |
|---|---|
| integration tip | rc 10, nothing — and `--fix` skips every cell |
| this change | `/tmp/tmux-501/default:%11` |

## On the two rewritten tests

They pinned "an unset `$TMUX` resolves NOTHING". Right about the hazard, wrong
about the remedy — so they are rewritten, not deleted; deleting them would take
the hazard with them.

They are also **split in two**. Folded together, dropping the search and dropping
the socket qualification reddened the same single test, so either could have been
fixed while the other stayed green. Measured after splitting:

| mutation | red |
|---|---|
| remove the all-server search | both (nothing comes back at all) |
| drop the socket qualification | the qualification test alone |

A third test keeps one label found on two servers an ambiguity rather than a pick.

The fake added here honours `-S` and publishes real sockets. The existing fake
ignores `-S`, which cannot tell "searched every server" from "searched one" —
the whole subject of these tests, and the same shape as #1129.

Suites: test_terminal_registry 150/150, test_self_name 23/23, enforced assertions
at the 626 baseline.