### PR TITLE
feat(terminal): enumerate panes across every instance, as (kind, instance, pane) (#1152)

### DIFF
--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -1170,7 +1170,7 @@ terminal_pane_process_observe() {   # <candidate>
 # number of entries is compared against the number that passed. A session we
 # could not parse might be the one holding the pane the caller is looking for.
 terminal_enumerate_panes() {
-  local sessions jesc n_all n_ok sock out
+  local sessions jesc n_all n_ok sockets sock out
   command -v herdr >/dev/null 2>&1 || return 10
   command -v sqlite3 >/dev/null 2>&1 || return 10
   sessions="$(herdr session list --json 2>/dev/null)" || return 10
@@ -1188,13 +1188,15 @@ terminal_enumerate_panes() {
   # reproduced: `/a path/with spaces/herdr.sock` became `/a`, `path/with`,
   # `spaces/herdr.sock`). A path containing a newline is refused instead, since
   # a line-based channel cannot carry one.
-  sqlite3 :memory: "SELECT json_extract(value,'\$.socket_path') FROM json_each('$jesc','\$.sessions') WHERE json_type(value,'\$.running')='true' AND json_type(value,'\$.socket_path')='text'" 2>/dev/null \
-  | while IFS= read -r sock; do
+  sockets="$(sqlite3 :memory: "SELECT json_extract(value,'\$.socket_path') FROM json_each('$jesc','\$.sessions') WHERE json_type(value,'\$.running')='true' AND json_type(value,'\$.socket_path')='text'" 2>/dev/null)" || return 10
+  while IFS= read -r sock; do
     [ -n "$sock" ] || continue
     case "$sock" in (*[[:cntrl:]]*) printf '!\t%s\n' "malformed_socket_path"; continue ;; esac
     out="$(HERDR_SOCKET_PATH="$sock" herdr pane list 2>/dev/null)" || { printf '!\t%s\n' "$sock"; continue; }
     _herdr_panes_of "$sock" "$out" || printf '!\t%s\n' "$sock"
-  done
+  done <<EOF
+$sockets
+EOF
   return 0
 }
 

--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -1137,3 +1137,84 @@ terminal_pane_process_observe() {   # <candidate>
   unset -f _seen_pid
   printf '%s%s\n' "$id" "$pids"
 }
+
+# OPTIONAL OP. Every pane this terminal can see, ACROSS EVERY INSTANCE, each row
+# carrying the instance it was seen in. Contract: see the tmux driver's copy.
+#
+# WHY THIS OP HAS TO EXIST FOR HERDR TOO, and what it cost to find out. A herdr
+# pane id is unique within ONE instance and nowhere else. Measured on this
+# machine, with two instances running:
+#
+#   instance   response pane_id   shell_pid   who is actually there
+#   jugemu     w1:p7              2727        one team's seat
+#   oma        w1:p7              80649       a different team's seat
+#
+# BOTH answer `pane_id=w1:p7`. So an id echoed back by the server proves the
+# server answered about the id we asked for -- never that the instance we meant
+# answered. Every row here is qualified with the SOCKET it came from, which is
+# the value that makes the row answerable again, exactly as the tmux driver
+# qualifies with its socket.
+#
+#   <instance><TAB><pane>    a pane observed in that instance
+#   !<TAB><instance>         that instance could NOT be read
+#
+# `session list --json` reports `running` per session, so a session declared not
+# running is SKIPPED -- that is a decided fact, not a gap. A running session
+# whose pane list fails is the gap, and it gets a named row rather than being
+# dropped: without it the sweep would read "nobody is there" for an instance
+# nobody could open.
+#
+# AN ENTRY WE DO NOT UNDERSTAND FAILS THE WHOLE ENUMERATION, as in
+# terminal_pane_process_observe: `running` must be a JSON boolean and
+# `socket_path` a JSON string, checked by type in the query itself, and the
+# number of entries is compared against the number that passed. A session we
+# could not parse might be the one holding the pane the caller is looking for.
+terminal_enumerate_panes() {
+  local sessions jesc n_all n_ok sock out
+  command -v herdr >/dev/null 2>&1 || return 10
+  command -v sqlite3 >/dev/null 2>&1 || return 10
+  sessions="$(herdr session list --json 2>/dev/null)" || return 10
+  [ -n "$sessions" ] || return 10
+  jesc="$(printf '%s' "$sessions" | sed "s/'/''/g")"
+  n_all="$(sqlite3 :memory: "SELECT CASE WHEN json_type('$jesc','\$.sessions')='array' THEN json_array_length('$jesc','\$.sessions') ELSE -1 END" 2>/dev/null)" || return 10
+  case "$n_all" in ''|*[!0-9]*) return 10 ;; esac
+  n_ok="$(sqlite3 :memory: "SELECT count(*) FROM json_each('$jesc','\$.sessions') WHERE json_type(value,'\$.running') IN ('true','false') AND json_type(value,'\$.socket_path')='text'" 2>/dev/null)" || return 10
+  case "$n_ok" in ''|*[!0-9]*) return 10 ;; esac
+  [ "$n_ok" -eq "$n_all" ] || return 10
+  # ONE PATH PER LINE, never word-split. A socket path is a path: a home
+  # directory with a space in it is ordinary, and `for x in $(...)` turned one
+  # instance into THREE fabricated ones -- each reported as holding the same
+  # pane, which reads as MORE coverage rather than less (found in review,
+  # reproduced: `/a path/with spaces/herdr.sock` became `/a`, `path/with`,
+  # `spaces/herdr.sock`). A path containing a newline is refused instead, since
+  # a line-based channel cannot carry one.
+  sqlite3 :memory: "SELECT json_extract(value,'\$.socket_path') FROM json_each('$jesc','\$.sessions') WHERE json_type(value,'\$.running')='true' AND json_type(value,'\$.socket_path')='text'" 2>/dev/null \
+  | while IFS= read -r sock; do
+    [ -n "$sock" ] || continue
+    case "$sock" in (*[[:cntrl:]]*) printf '!\t%s\n' "malformed_socket_path"; continue ;; esac
+    out="$(HERDR_SOCKET_PATH="$sock" herdr pane list 2>/dev/null)" || { printf '!\t%s\n' "$sock"; continue; }
+    _herdr_panes_of "$sock" "$out" || printf '!\t%s\n' "$sock"
+  done
+  return 0
+}
+
+# The pane ids in one `pane list` payload, each prefixed with its instance.
+# Separate so the strictness lives in one place: a payload whose `panes` is not
+# an array, or that holds an entry with no text `pane_id`, is not a short list --
+# it is a payload this driver does not understand, and the caller turns that into
+# a named hole rather than into "that instance has fewer panes".
+_herdr_panes_of() {   # <socket> <pane-list-json>
+  local sock="$1" jesc n_all n_ok ids
+  jesc="$(printf '%s' "$2" | sed "s/'/''/g")"
+  n_all="$(sqlite3 :memory: "SELECT CASE WHEN json_type('$jesc','\$.result.panes')='array' THEN json_array_length('$jesc','\$.result.panes') ELSE -1 END" 2>/dev/null)" || return 1
+  case "$n_all" in ''|*[!0-9]*) return 1 ;; esac
+  n_ok="$(sqlite3 :memory: "SELECT count(*) FROM json_each('$jesc','\$.result.panes') WHERE json_type(value,'\$.pane_id')='text'" 2>/dev/null)" || return 1
+  case "$n_ok" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$n_ok" -eq "$n_all" ] || return 1
+  ids="$(sqlite3 :memory: "SELECT json_extract(value,'\$.pane_id') FROM json_each('$jesc','\$.result.panes') WHERE json_type(value,'\$.pane_id')='text'" 2>/dev/null)" || return 1
+  printf '%s\n' "$ids" | while IFS= read -r pane; do
+    [ -n "$pane" ] || continue
+    printf '%s\t%s\n' "$sock" "$pane"
+  done
+  return 0
+}

--- a/scripts/drivers/terminals/tmux/ops.sh
+++ b/scripts/drivers/terminals/tmux/ops.sh
@@ -653,3 +653,102 @@ terminal_pane_process_observe() {   # <candidate>
   case "$pane_pid" in ''|0*|*[!0-9]*) return 10 ;; esac
   printf '%s\t%s\n' "$bare" "$pane_pid"
 }
+
+# OPTIONAL OP. Every pane this terminal can see, ACROSS EVERY SERVER, each row
+# carrying the instance it was seen in.
+#
+# RESURRECTED FROM #1146 / PR #1147. The socket enumeration and -- more
+# importantly -- the rule for when a server counts as DEAD were already written
+# and measured there; that PR was closed only because a different design was
+# expected to replace it, and that expectation is gone. The mechanics below are
+# that branch's, unchanged in substance.
+#
+# WHY A PANE ID ALONE IS NOT AN ANSWER. A pane id is unique within one server and
+# nowhere else: `%0` exists on every server that has ever opened a pane (#1051).
+# So every row here is qualified with the socket it came from, and a caller can
+# never end up holding an id it cannot ask about again.
+#
+# stdout, one line per record:
+#
+#   <instance><TAB><pane>    a pane observed in that instance
+#   !<TAB><instance>         that instance could NOT be read
+#
+# THE SECOND ROW IS THE POINT, and it is where this differs from #1146's search.
+# That search asked "is this label unique across every server?", so a server it
+# could not read POISONED the whole answer -- it returned "could not answer"
+# rather than risk reporting one hit while a second hit sat unread. This op asks
+# a different question ("what is out there?"), and for that question one
+# unreadable server must not lose the panes of the servers that did answer. So
+# the hole is NAMED and enumeration continues. Same mechanics, different verdict,
+# because the question is different.
+#
+# A SOCKET PROVES NOTHING. It outlives the server that made it. Only tmux saying
+# `no server running` or `no such file or directory` is evidence of death;
+# permission, a transient failure and a protocol mismatch all look identical from
+# here, and treating those as death would silently drop a live server's panes.
+terminal_enumerate_panes() {
+  local dir uid sock socks out err rc=0
+  command -v tmux >/dev/null 2>&1 || return 10
+  # If the uid cannot be read, the socket directory cannot be NAMED -- and a
+  # directory we could not name is not an empty one. Measured on this machine
+  # (2026-09-11): while directory services were degraded, `id -un` returned the
+  # bare uid and name lookups failed outright. Falling through with an empty uid
+  # would build `/tmp/tmux-`, find nothing, and report "no servers".
+  uid="$(id -u 2>/dev/null)"
+  case "$uid" in ''|*[!0-9]*) return 10 ;; esac
+  dir="${TMUX_TMPDIR:-/tmp}/tmux-$uid"
+  # No socket directory IS an answer: this user has never run a tmux server.
+  # Distinct from the case above, where we could not look.
+  [ -d "$dir" ] || return 0
+  err="$(mktemp "${TMPDIR:-/tmp}/agmsg-tmuxenum.XXXXXX")" || err=""
+  # THE GLOB RUNS IN A SUBSHELL, with `nullglob` set there and nowhere else.
+  # Measured on this machine, both interpreters: with a caller's
+  # `shopt -s failglob` and an EMPTY socket directory, a bare
+  # `for sock in "$dir"/*` produced NO OUTPUT AT ALL -- the shell died at the
+  # expansion, before any row could be printed. That is the same shape as the
+  # errexit defect review found in the proof coordinator, arriving through a
+  # glob option instead: the caller's shell state reaching into a sourced file.
+  #
+  # A command substitution is its own subshell, so `shopt` inside it cannot leak
+  # back to the caller -- which is the only way to get a predictable glob without
+  # editing a setting that is not ours. Control bytes are refused rather than
+  # carried: every row here is TAB-separated and a socket name is not a place to
+  # smuggle one.
+  # TWO THINGS, and each was measured wrong first:
+  #
+  #   `shopt -u failglob`  nullglob does NOT cover this. With both set, failglob
+  #                        WINS: bash 5 still died with `no match:` after
+  #                        nullglob was set. The subshell is where the option
+  #                        can be dropped without editing the caller's.
+  #   `case … in (pat)`    bash 3.2 parses `$( … )` by counting parens, so a
+  #                        `case` pattern's closing `)` inside a command
+  #                        substitution ends the substitution early: measured,
+  #                        `syntax error near unexpected token 'newline'` on
+  #                        3.2 and fine on 5. The leading `(` balances it.
+  socks="$(shopt -u failglob 2>/dev/null; shopt -s nullglob 2>/dev/null
+           for s in "$dir"/*; do
+             [ -S "$s" ] || continue
+             case "$s" in (*[[:cntrl:]]*) continue ;; esac
+             printf '%s\n' "$s"
+           done)"
+  [ -n "$socks" ] || { [ -n "$err" ] && rm -f "$err"; return 0; }
+  printf '%s\n' "$socks" | while IFS= read -r sock; do
+    [ -n "$sock" ] || continue
+    rc=0
+    out="$(tmux -S "$sock" list-panes -a -F '#{pane_id}' 2>"${err:-/dev/null}")" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+      if [ -n "$err" ] && grep -qiE 'no server running|no such file or directory' "$err" 2>/dev/null; then
+        continue                      # proven stale: one dead server, keep going
+      fi
+      printf '!\t%s\n' "$sock"        # a hole with a name, not a silent drop
+      continue
+    fi
+    [ -n "$out" ] || continue
+    printf '%s\n' "$out" | while IFS= read -r pane; do
+      [ -n "$pane" ] || continue
+      printf '%s\t%s\n' "$sock" "$pane"
+    done
+  done
+  [ -n "$err" ] && rm -f "$err"
+  return 0
+}

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -200,7 +200,7 @@ EOF
 # what makes a missing op FAIL rather than silently borrow the previously loaded
 # driver's same-named function.
 _AGMSG_TERMINAL_REQUIRED="terminal_check terminal_describe terminal_detect terminal_spawn terminal_despawn terminal_pane_state terminal_peek terminal_poke terminal_where terminal_arrange terminal_name"
-_AGMSG_TERMINAL_OPTIONAL="terminal_capability terminal_team_observe terminal_team_input_ready terminal_find_by_label terminal_label_of terminal_id_ok terminal_pane_process_observe"
+_AGMSG_TERMINAL_OPTIONAL="terminal_capability terminal_team_observe terminal_team_input_ready terminal_find_by_label terminal_label_of terminal_id_ok terminal_pane_process_observe terminal_enumerate_panes"
 
 # Resolve one capability for the terminal instance addressed by <id>.
 # terminal.conf is the implementation ceiling: a runtime hook may narrow that
@@ -233,7 +233,6 @@ agmsg_terminal_capability() {   # <terminal> <capability> [id]
       return 2 ;;
   esac
 }
-
 # A driver's observation fields carry EITHER an observed value or one of these
 # prefixes, which say why there is no value. They are listed here, once, because
 # two sides need the same list and neither owns it: the drivers emit them, and
@@ -1146,4 +1145,71 @@ agmsg_terminal_name_self_safe() {
   _rc=$?
   [ "$_restore_e" = 1 ] && set -e
   return "$_rc"
+}
+
+# Every pane every terminal can see, as (kind, instance, pane) TRIPLES.
+#
+# A BARE PANE ID IS NOT AN ADDRESS. Measured on this machine, 2026-09-11: two
+# herdr instances were running, and enumerating both produced 52 rows in which
+# `w1:p1`, `w1:p2`, `w1:p4`, `w1:p5` and `w1:p7` each appeared TWICE -- the same
+# id naming a different pane, and a different team's seat, in each instance. The
+# tmux side has had the same property since #1051 (`%0` exists on every server).
+# So nothing here ever emits a pane id on its own; the instance travels with it,
+# and the instance is the value that makes the row answerable again -- a socket
+# path, not a display name.
+#
+# THREE ROW KINDS, because three things happen and collapsing any two of them
+# loses the one that matters:
+#
+#   <kind><TAB><instance><TAB><pane>   a pane was observed there
+#   !<TAB><kind><TAB><instance>        that instance could not be read
+#   !!<TAB><kind>                      that terminal's INSTANCE LIST could not be
+#                                      read, so no instance can even be named
+#   ?<TAB><kind>                       that terminal cannot enumerate at all
+#
+# FOUR CAUSES, FOUR ROWS, and none of them folded. `?` is a CONFIGURATION in
+# which the question has no answer and a caller can stop asking. `!` is one hole
+# in an otherwise good answer. `!!` is a terminal we could not open at all --
+# which looks identical to `?` from the outside and is the opposite instruction
+# to a caller (retry, not give up). Collapsing any pair of these is how "we could
+# not look" becomes "there is nobody there", which is the failure this whole
+# sweep exists to avoid.
+#
+# rc is 0 whenever the walk itself ran. A caller decides what to do about `!` and
+# `?` rows; this function does not decide for it.
+agmsg_terminal_enumerate() {
+  local was name out orc rc=0
+  was="${_AGMSG_TERMINAL_LOADED:-}"
+  for name in $(agmsg_terminal_candidates); do
+    if ! agmsg_terminal_load "$name" >/dev/null 2>&1; then
+      printf '?\t%s\n' "$name"
+      continue
+    fi
+    if ! declare -F terminal_enumerate_panes >/dev/null 2>&1; then
+      printf '?\t%s\n' "$name"
+      continue
+    fi
+    # CAPTURED, not piped. `op | while read` reports the WHILE's status, so the
+    # op could fail outright and the loop would report success over an empty
+    # stream -- "that terminal has no panes", which is the exact confusion this
+    # function exists to prevent. The capture is also written errexit-safe: a
+    # bare `out=$(...)` followed by `$?` kills a caller that has `set -e` before
+    # the row is ever printed.
+    if out="$(terminal_enumerate_panes 2>/dev/null)"; then orc=0; else orc=$?; fi
+    if [ "$orc" -ne 0 ]; then
+      printf '!!\t%s\n' "$name"
+      continue
+    fi
+    printf '%s\n' "$out" | while IFS= read -r row; do
+      [ -n "$row" ] || continue
+      case "$row" in
+        '!'*) printf '!\t%s\t%s\n' "$name" "${row#*	}" ;;
+        *)    printf '%s\t%s\n' "$name" "$row" ;;
+      esac
+    done
+  done
+  # Leave the caller with the driver it had. Loading one is a global side effect
+  # and this function is a reader.
+  [ -z "$was" ] || agmsg_terminal_load "$was" >/dev/null 2>&1 || rc=1
+  return "$rc"
 }

--- a/scripts/lib/terminal-registry.sh
+++ b/scripts/lib/terminal-registry.sh
@@ -1210,6 +1210,17 @@ agmsg_terminal_enumerate() {
   done
   # Leave the caller with the driver it had. Loading one is a global side effect
   # and this function is a reader.
-  [ -z "$was" ] || agmsg_terminal_load "$was" >/dev/null 2>&1 || rc=1
+  #
+  # NO DRIVER is a state too, and the version that only restored a NAMED driver
+  # left the LAST candidate loaded when the caller had none -- so a caller that
+  # deliberately held no driver got one, silently, from a function it called to
+  # read (found in review). Unsetting the ops is what "none" means here, and it
+  # is the same teardown `agmsg_terminal_load` does before it loads.
+  if [ -n "$was" ]; then
+    agmsg_terminal_load "$was" >/dev/null 2>&1 || rc=1
+  else
+    _agmsg_terminal_unset_ops
+    _AGMSG_TERMINAL_LOADED=""
+  fi
   return "$rc"
 }

--- a/tests/test_sweep_enumeration.bats
+++ b/tests/test_sweep_enumeration.bats
@@ -275,7 +275,7 @@ _sessions_json() {
   [ "$(printf '%s\n' "$output" | grep -c '^!')" -eq 1 ]
   printf '%s\n' "$output" | grep -q "^!"$'\t'"/s/sessions/odd/herdr.sock"
   # and NOT the one pane it could read from that instance
-  ! printf '%s\n' "$output" | grep -q 'w1:p3'
+  refute grep -q 'w1:p3' <<<"$output"
   printf '%s\n' "$output" | grep -q 'w1:p1'
 }
 
@@ -309,8 +309,8 @@ _load_registry() {
   # plain has no op at all: the question has no answer there, and a caller can
   # stop asking. That is NOT the same instruction as "could not read".
   printf '%s\n' "$output" | grep -q "^?"$'\t'"plain"
-  ! printf '%s\n' "$output" | grep -q "^!"$'\t'"plain"
-  ! printf '%s\n' "$output" | grep -q "^!!"$'\t'"plain"
+  refute grep -q "^!"$'\t'"plain" <<<"$output"
+  refute grep -q "^!!"$'\t'"plain" <<<"$output"
 }
 
 @test "registry: a terminal whose op fails outright is !! -- retry, not give up (#1152)" {
@@ -327,7 +327,7 @@ HEOF
   run agmsg_terminal_enumerate
   [ "$status" -eq 0 ]
   printf '%s\n' "$output" | grep -q "^!!"$'\t'"herdr"
-  ! printf '%s\n' "$output" | grep -q "^?"$'\t'"herdr"
+  refute grep -q "^?"$'\t'"herdr" <<<"$output"
   # and the terminal that DID answer is still reported
   printf '%s\n' "$output" | grep -q "^tmux"$'\t'".*A"$'\t'"%0"
 }
@@ -339,10 +339,17 @@ HEOF
   _herdr_panes one '{"result":{"panes":[{"pane_id":"w1:p1"}]}}'
   _fake_tmux
   _load_registry
-  agmsg_terminal_load plain
-  [ "$_AGMSG_TERMINAL_LOADED" = plain ]
+  # NOT `plain`: it is the LAST candidate, so a version with no restore at all
+  # would leave `plain` loaded and this test would pass on the ordering rather
+  # than on the restore. Measured -- with plain, deleting the restore reddened
+  # nothing. `herdr` is first, so only an actual restore puts it back.
+  agmsg_terminal_load herdr
+  [ "$_AGMSG_TERMINAL_LOADED" = herdr ]
   agmsg_terminal_enumerate >/dev/null
-  [ "$_AGMSG_TERMINAL_LOADED" = plain ]
+  [ "$_AGMSG_TERMINAL_LOADED" = herdr ]
+  # and the candidate order really is the thing that made the weaker version
+  # pass, so it is pinned: if plain ever stops being last, this test weakens.
+  [ "$(agmsg_terminal_candidates | tail -1)" = plain ]
 }
 
 @test "registry: a captured op status, not a piped one (#1152)" {

--- a/tests/test_sweep_enumeration.bats
+++ b/tests/test_sweep_enumeration.bats
@@ -368,3 +368,41 @@ HEOF
   # and never piped straight into the reader
   ! printf '%s\n' "$body" | grep -qE 'terminal_enumerate_panes[^|]*\|'
 }
+
+@test "registry: a caller holding NO driver is left holding none (#1152)" {
+  # "No driver" is a state, not a missing value. The version that restored only
+  # a NAMED driver left the LAST candidate loaded here -- so a reader handed the
+  # caller a driver it had not asked for. Found in review.
+  _fake_herdr "$(_sessions_json '{"name":"one","running":true,"socket_path":"/s/sessions/one/herdr.sock"}')"
+  _herdr_panes one '{"result":{"panes":[{"pane_id":"w1:p1"}]}}'
+  _fake_tmux
+  _load_registry
+  _AGMSG_TERMINAL_LOADED=""
+  _agmsg_terminal_unset_ops
+  agmsg_terminal_enumerate >/dev/null
+  [ -z "${_AGMSG_TERMINAL_LOADED:-}" ] || { echo "left holding [$_AGMSG_TERMINAL_LOADED]"; return 1; }
+  # and the ops really are gone, not merely the name
+  refute declare -F terminal_enumerate_panes
+}
+
+@test "herdr: a socket path with a space is ONE instance, not three (#1152)" {
+  # `for x in $(sqlite3 …)` word-splits, and a home directory with a space in it
+  # is ordinary. Measured before the fix: `/a path/with spaces/herdr.sock` became
+  # three rows, each claiming to hold the same pane -- which reads as MORE
+  # coverage, not less.
+  _fake_herdr "$(_sessions_json '{"name":"sp","running":true,"socket_path":"/a path/with spaces/herdr.sock"}')"
+  cat > "$BIN/herdr" <<'HEOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "session list") cat "$ANSDIR/sessions.json"; exit 0 ;;
+  "pane list") printf '{"result":{"panes":[{"pane_id":"w1:p1"}]}}'; exit 0 ;;
+esac
+exit 9
+HEOF
+  chmod +x "$BIN/herdr"
+  _load_herdr_op
+  run terminal_enumerate_panes
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c .)" -eq 1 ]
+  [ "$output" = "/a path/with spaces/herdr.sock"$'\t'"w1:p1" ]
+}

--- a/tests/test_sweep_enumeration.bats
+++ b/tests/test_sweep_enumeration.bats
@@ -18,6 +18,7 @@ setup() {
   load 'test_helper'
   setup_test_env
   export SKILL_DIR="$TEST_SKILL_DIR"
+  export REAL_SQLITE3="$(command -v sqlite3)"
   BIN="$BATS_TEST_TMPDIR/bin"; mkdir -p "$BIN"; export PATH="$BIN:$PATH"
   export TMUX_TMPDIR="$BATS_TEST_TMPDIR/tt"
   SOCKDIR="$TMUX_TMPDIR/tmux-$(id -u)"; mkdir -p "$SOCKDIR"
@@ -329,6 +330,29 @@ HEOF
   printf '%s\n' "$output" | grep -q "^!!"$'\t'"herdr"
   refute grep -q "^?"$'\t'"herdr" <<<"$output"
   # and the terminal that DID answer is still reported
+  printf '%s\n' "$output" | grep -q "^tmux"$'\t'".*A"$'\t'"%0"
+}
+
+@test "registry: a failed herdr running-socket query is !! -- not zero panes (#1152)" {
+  _fake_herdr "$(_sessions_json '{"name":"one","running":true,"socket_path":"/s/sessions/one/herdr.sock"}')"
+  _herdr_panes one '{"result":{"panes":[{"pane_id":"w1:p1"}]}}'
+  cat > "$BIN/sqlite3" <<'SEOF'
+#!/usr/bin/env bash
+last=""
+for arg in "$@"; do last="$arg"; done
+case "$last" in
+  *"SELECT json_extract(value,'$.socket_path')"*"json_type(value,'$.running')='true'"*) exit 19 ;;
+esac
+exec "$REAL_SQLITE3" "$@"
+SEOF
+  chmod +x "$BIN/sqlite3"
+  _fake_tmux; _socket A; _answers A 'ok:%0'
+  _load_registry
+  run agmsg_terminal_enumerate
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q "^!!"$'\t'"herdr"
+  refute grep -q "^herdr"$'\t' <<<"$output"
+  # Positive control: the registry continues and reports another terminal.
   printf '%s\n' "$output" | grep -q "^tmux"$'\t'".*A"$'\t'"%0"
 }
 

--- a/tests/test_sweep_enumeration.bats
+++ b/tests/test_sweep_enumeration.bats
@@ -1,0 +1,363 @@
+#!/usr/bin/env bats
+
+# Every pane every terminal can see, as (kind, instance, pane) triples (#1152).
+#
+# WHY THE TRIPLE. A pane id is unique inside one instance and nowhere else.
+# Measured live on 2026-09-11, not argued: two herdr instances were running and
+# enumerating both produced 52 rows in which `w1:p1`, `w1:p2`, `w1:p4`, `w1:p5`
+# and `w1:p7` each appeared TWICE -- the same id naming a different team's seat
+# in each. Two throwaway tmux servers showed the same with `%0`. So a bare pane
+# id never leaves this layer.
+#
+# The tmux cases here drive a FAKE tmux rather than a real one: the behaviours
+# that matter are error TEXTS and exit statuses, and a real server would make
+# them the runner's property instead of the test's. The real-tmux measurement is
+# reported separately; it agreed with every case below.
+
+setup() {
+  load 'test_helper'
+  setup_test_env
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  BIN="$BATS_TEST_TMPDIR/bin"; mkdir -p "$BIN"; export PATH="$BIN:$PATH"
+  export TMUX_TMPDIR="$BATS_TEST_TMPDIR/tt"
+  SOCKDIR="$TMUX_TMPDIR/tmux-$(id -u)"; mkdir -p "$SOCKDIR"
+}
+teardown() { teardown_test_env; }
+
+# A tmux whose answer per socket is written by the test.
+#   <sockdir>/<name>          the socket itself (a plain file is enough: the op
+#                             tests `-S`, so the test makes real sockets)
+#   $BATS_TEST_TMPDIR/ans.<name>   "ok:<pane ids>" | "err:<stderr text>"
+_fake_tmux() {
+  cat > "$BIN/tmux" <<'TEOF'
+#!/usr/bin/env bash
+sock=""; prev=""
+for a in "$@"; do
+  [ "$prev" = "-S" ] && sock="$a"
+  prev="$a"
+done
+name="${sock##*/}"
+ans="$(cat "$ANSDIR/ans.$name" 2>/dev/null)"
+case "$ans" in
+  ok:*) printf '%s\n' "${ans#ok:}" | tr ' ' '\n' | grep . ; exit 0 ;;
+  err:*) printf '%s\n' "${ans#err:}" >&2 ; exit 1 ;;
+  *) printf 'no server running on %s\n' "$sock" >&2 ; exit 1 ;;
+esac
+TEOF
+  chmod +x "$BIN/tmux"
+  export ANSDIR="$BATS_TEST_TMPDIR"
+}
+_socket() {   # <name> ; make a real unix socket so `[ -S ]` is true
+  python3 -c "
+import socket,sys
+s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1])
+" "$SOCKDIR/$1"
+}
+_answers() { printf '%s' "$2" > "$BATS_TEST_TMPDIR/ans.$1"; }
+
+_load_tmux_op() {
+  unset -f terminal_enumerate_panes
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/drivers/terminals/tmux/ops.sh"
+}
+
+# --- tmux: the four outcomes ---------------------------------------------------
+
+@test "tmux: every pane is qualified with the server it was seen in (#1152)" {
+  _fake_tmux; _socket A; _socket B
+  _answers A 'ok:%0'
+  _answers B 'ok:%0 %1'
+  _load_tmux_op
+  run terminal_enumerate_panes
+  [ "$status" -eq 0 ]
+  # The SAME pane id in two servers, told apart only by the instance. This is
+  # the property the triple exists for.
+  [ "$(printf '%s\n' "$output" | grep -c "A"$'\t'"%0")" -eq 1 ]
+  [ "$(printf '%s\n' "$output" | grep -c "B"$'\t'"%0")" -eq 1 ]
+  [ "$(printf '%s\n' "$output" | grep -c "B"$'\t'"%1")" -eq 1 ]
+  [ "$(printf '%s\n' "$output" | grep -c .)" -eq 3 ]
+  # and no row is a bare pane id
+  ! printf '%s\n' "$output" | grep -qE '^%'
+}
+
+@test "tmux: a server tmux calls absent is stale, and is skipped silently (#1152)" {
+  _fake_tmux; _socket A; _socket DEAD
+  _answers A 'ok:%0'
+  _answers DEAD 'err:no server running on /whatever'
+  _load_tmux_op
+  run terminal_enumerate_panes
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c .)" -eq 1 ]
+  ! printf '%s\n' "$output" | grep -q '^!'
+}
+
+@test "tmux: any OTHER failure is a named hole, never a silent drop (#1152)" {
+  # Measured against a real tmux: a live NON-tmux listener on the socket answers
+  # `server exited unexpectedly`, which is not evidence of death. Permission and
+  # protocol mismatches look the same from here. Dropping such a server would
+  # report its panes as absent.
+  _fake_tmux; _socket A; _socket WEIRD
+  _answers A 'ok:%0'
+  _answers WEIRD 'err:server exited unexpectedly'
+  _load_tmux_op
+  run terminal_enumerate_panes
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c '^!')" -eq 1 ]
+  printf '%s\n' "$output" | grep -q "^!"$'\t'".*WEIRD"
+  # the readable server is still reported -- one hole does not lose the rest
+  printf '%s\n' "$output" | grep -q "A"$'\t'"%0"
+}
+
+@test "tmux: no socket directory is zero servers; an unreadable uid is NOT (#1152)" {
+  _fake_tmux
+  rm -rf "$TMUX_TMPDIR"
+  _load_tmux_op
+  run terminal_enumerate_panes
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  # An `id` that cannot answer must not become "this user has no servers": the
+  # directory could not even be NAMED. Measured on this machine while directory
+  # services were degraded, `id -un` returned the bare uid and lookups failed.
+  cat > "$BIN/id" <<'IEOF'
+#!/usr/bin/env bash
+exit 1
+IEOF
+  chmod +x "$BIN/id"
+  run terminal_enumerate_panes
+  [ "$status" -eq 10 ]
+  [ -z "$output" ]
+}
+
+# --- the caller's shell state --------------------------------------------------
+
+@test "tmux: a caller's glob options cannot silence the enumeration (#1152)" {
+  # Measured, BOTH interpreters: with `shopt -s failglob` and an empty socket
+  # directory, a bare `for sock in "$dir"/*` produced NO OUTPUT AT ALL -- the
+  # shell died at the expansion. `nullglob` does not cover it; failglob wins over
+  # nullglob, so the subshell drops failglob explicitly.
+  _fake_tmux; _socket A; _answers A 'ok:%0'
+  local st
+  for st in nullglob failglob dotglob "nullglob failglob" "failglob dotglob"; do
+    run bash -c '
+      for t in '"$st"'; do shopt -s "$t"; done
+      set -o errexit
+      . "'"$SKILL_DIR"'/scripts/drivers/terminals/tmux/ops.sh"
+      terminal_enumerate_panes
+      printf "__rc=%s\n" "$?"
+      printf "__failglob=%s __nullglob=%s\n" \
+        "$(shopt -q failglob && echo on || echo off)" \
+        "$(shopt -q nullglob && echo on || echo off)"'
+    printf '%s\n' "$output" | grep -q "A"$'\t'"%0" || { echo "[$st] lost the pane row: $output"; return 1; }
+    printf '%s\n' "$output" | grep -q '__rc=0' || { echo "[$st] no rc line -- the shell died: $output"; return 1; }
+  done
+  # And the caller's options survive: the subshell's shopt must not leak.
+  run bash -c '
+    shopt -u failglob; shopt -u nullglob
+    . "'"$SKILL_DIR"'/scripts/drivers/terminals/tmux/ops.sh"
+    terminal_enumerate_panes >/dev/null
+    printf "failglob=%s nullglob=%s\n" \
+      "$(shopt -q failglob && echo on || echo off)" \
+      "$(shopt -q nullglob && echo on || echo off)"'
+  [ "$output" = "failglob=off nullglob=off" ]
+}
+
+@test "tmux: an empty directory under failglob still answers (the measured death) (#1152)" {
+  _fake_tmux                      # directory exists, no sockets in it
+  run bash -c '
+    shopt -s failglob
+    set -o errexit
+    . "'"$SKILL_DIR"'/scripts/drivers/terminals/tmux/ops.sh"
+    terminal_enumerate_panes
+    printf "__rc=%s\n" "$?"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "__rc=0" ]
+}
+
+# --- herdr: instances come from the session list --------------------------------
+
+_fake_herdr() {   # <sessions-json>
+  printf '%s' "$1" > "$BATS_TEST_TMPDIR/sessions.json"
+  cat > "$BIN/herdr" <<'HEOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "session list") cat "$ANSDIR/sessions.json"; exit 0 ;;
+esac
+case "$1 $2" in
+  "pane list")
+    f="$ANSDIR/panes.${HERDR_SOCKET_PATH##*/sessions/}"
+    f="${f%/herdr.sock}"
+    [ -f "$f" ] || exit 7
+    cat "$f"; exit 0 ;;
+esac
+exit 9
+HEOF
+  chmod +x "$BIN/herdr"
+  export ANSDIR="$BATS_TEST_TMPDIR"
+}
+_herdr_panes() { printf '%s' "$2" > "$BATS_TEST_TMPDIR/panes.$1"; }
+_load_herdr_op() {
+  unset -f terminal_enumerate_panes
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/drivers/terminals/herdr/ops.sh"
+}
+_sessions_json() {
+  printf '{"sessions":[%s]}' "$1"
+}
+
+@test "herdr: only running instances are visited, and rows carry the socket (#1152)" {
+  _fake_herdr "$(_sessions_json '
+    {"name":"off","running":false,"socket_path":"/s/sessions/off/herdr.sock"},
+    {"name":"one","running":true,"socket_path":"/s/sessions/one/herdr.sock"},
+    {"name":"two","running":true,"socket_path":"/s/sessions/two/herdr.sock"}')"
+  _herdr_panes one '{"result":{"panes":[{"pane_id":"w1:p1"},{"pane_id":"w1:p7"}]}}'
+  _herdr_panes two '{"result":{"panes":[{"pane_id":"w1:p7"}]}}'
+  _load_herdr_op
+  run terminal_enumerate_panes
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c .)" -eq 3 ]
+  # w1:p7 in BOTH instances, distinguished only by the socket -- the live shape
+  [ "$(printf '%s\n' "$output" | grep -c "one/herdr.sock"$'\t'"w1:p7")" -eq 1 ]
+  [ "$(printf '%s\n' "$output" | grep -c "two/herdr.sock"$'\t'"w1:p7")" -eq 1 ]
+  # the non-running session is a decided fact, not a hole
+  ! printf '%s\n' "$output" | grep -q 'off'
+}
+
+@test "herdr: a running instance that will not answer is a named hole (#1152)" {
+  _fake_herdr "$(_sessions_json '
+    {"name":"one","running":true,"socket_path":"/s/sessions/one/herdr.sock"},
+    {"name":"gone","running":true,"socket_path":"/s/sessions/gone/herdr.sock"}')"
+  _herdr_panes one '{"result":{"panes":[{"pane_id":"w1:p1"}]}}'
+  # no panes.gone file -> the fake exits non-zero for it
+  _load_herdr_op
+  run terminal_enumerate_panes
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c '^!')" -eq 1 ]
+  printf '%s\n' "$output" | grep -q "^!"$'\t'"/s/sessions/gone/herdr.sock"
+  printf '%s\n' "$output" | grep -q "one/herdr.sock"$'\t'"w1:p1"
+}
+
+@test "herdr: a session entry we cannot parse fails the WHOLE enumeration (#1152)" {
+  # A session we could not read might be the one holding the pane the caller
+  # wants. Reporting the others as if they were everything is the fold this
+  # whole layer exists to refuse.
+  local bad
+  for bad in \
+    '{"name":"one","running":"yes","socket_path":"/s/sessions/one/herdr.sock"}' \
+    '{"name":"one","running":true,"socket_path":123}' \
+    '{"name":"one","running":true}' \
+  ; do
+    _fake_herdr "$(_sessions_json "$bad")"
+    _load_herdr_op
+    run terminal_enumerate_panes
+    [ "$status" -ne 0 ] || { echo "accepted a session entry it cannot read: $bad"; return 1; }
+    [ -z "$output" ] || { echo "emitted rows anyway: $output"; return 1; }
+  done
+  # Not vacuous: the well-formed entry enumerates.
+  _fake_herdr "$(_sessions_json '{"name":"one","running":true,"socket_path":"/s/sessions/one/herdr.sock"}')"
+  _herdr_panes one '{"result":{"panes":[{"pane_id":"w1:p1"}]}}'
+  _load_herdr_op
+  run terminal_enumerate_panes
+  [ "$status" -eq 0 ]
+}
+
+@test "herdr: a pane entry we cannot parse makes THAT instance a hole (#1152)" {
+  # Scoped differently from a bad session entry on purpose: a payload we do not
+  # understand costs us that instance, and the instances that answered are still
+  # worth reporting -- but the instance must not come back as a SHORTER list.
+  _fake_herdr "$(_sessions_json '
+    {"name":"one","running":true,"socket_path":"/s/sessions/one/herdr.sock"},
+    {"name":"odd","running":true,"socket_path":"/s/sessions/odd/herdr.sock"}')"
+  _herdr_panes one '{"result":{"panes":[{"pane_id":"w1:p1"}]}}'
+  _herdr_panes odd '{"result":{"panes":[{"pane_id":"w1:p3"},{"pane_id":99}]}}'
+  _load_herdr_op
+  run terminal_enumerate_panes
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c '^!')" -eq 1 ]
+  printf '%s\n' "$output" | grep -q "^!"$'\t'"/s/sessions/odd/herdr.sock"
+  # and NOT the one pane it could read from that instance
+  ! printf '%s\n' "$output" | grep -q 'w1:p3'
+  printf '%s\n' "$output" | grep -q 'w1:p1'
+}
+
+# --- the registry: four causes, four rows, none folded --------------------------
+
+_load_registry() {
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/terminal-registry.sh"
+}
+
+@test "registry: rows carry the terminal KIND as well as the instance (#1152)" {
+  _fake_herdr "$(_sessions_json '{"name":"one","running":true,"socket_path":"/s/sessions/one/herdr.sock"}')"
+  _herdr_panes one '{"result":{"panes":[{"pane_id":"w1:p1"}]}}'
+  _fake_tmux; _socket A; _answers A 'ok:%0'
+  _load_registry
+  run agmsg_terminal_enumerate
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q "^herdr"$'\t'"/s/sessions/one/herdr.sock"$'\t'"w1:p1"
+  printf '%s\n' "$output" | grep -q "^tmux"$'\t'".*A"$'\t'"%0"
+  # nothing leaves here as a bare pane id or a bare (instance, pane) pair
+  ! printf '%s\n' "$output" | grep -vE '^(herdr|tmux|plain|\!|\!\!|\?)' | grep -q .
+}
+
+@test "registry: a terminal with no enumeration op is ? -- not an empty world (#1152)" {
+  _fake_herdr "$(_sessions_json '{"name":"one","running":true,"socket_path":"/s/sessions/one/herdr.sock"}')"
+  _herdr_panes one '{"result":{"panes":[{"pane_id":"w1:p1"}]}}'
+  _fake_tmux
+  _load_registry
+  run agmsg_terminal_enumerate
+  [ "$status" -eq 0 ]
+  # plain has no op at all: the question has no answer there, and a caller can
+  # stop asking. That is NOT the same instruction as "could not read".
+  printf '%s\n' "$output" | grep -q "^?"$'\t'"plain"
+  ! printf '%s\n' "$output" | grep -q "^!"$'\t'"plain"
+  ! printf '%s\n' "$output" | grep -q "^!!"$'\t'"plain"
+}
+
+@test "registry: a terminal whose op fails outright is !! -- retry, not give up (#1152)" {
+  # `?` and `!!` look identical from outside (no rows for that kind) and mean
+  # opposite things to a caller. Folding them is how "we could not look" becomes
+  # "there is nobody there".
+  cat > "$BIN/herdr" <<'HEOF'
+#!/usr/bin/env bash
+exit 3
+HEOF
+  chmod +x "$BIN/herdr"
+  _fake_tmux; _socket A; _answers A 'ok:%0'
+  _load_registry
+  run agmsg_terminal_enumerate
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q "^!!"$'\t'"herdr"
+  ! printf '%s\n' "$output" | grep -q "^?"$'\t'"herdr"
+  # and the terminal that DID answer is still reported
+  printf '%s\n' "$output" | grep -q "^tmux"$'\t'".*A"$'\t'"%0"
+}
+
+@test "registry: the driver the caller had loaded is the one it still has (#1152)" {
+  # Enumerating loads every candidate in turn. Loading is a global side effect
+  # and this function is a reader, so it must put the caller's back.
+  _fake_herdr "$(_sessions_json '{"name":"one","running":true,"socket_path":"/s/sessions/one/herdr.sock"}')"
+  _herdr_panes one '{"result":{"panes":[{"pane_id":"w1:p1"}]}}'
+  _fake_tmux
+  _load_registry
+  agmsg_terminal_load plain
+  [ "$_AGMSG_TERMINAL_LOADED" = plain ]
+  agmsg_terminal_enumerate >/dev/null
+  [ "$_AGMSG_TERMINAL_LOADED" = plain ]
+}
+
+@test "registry: a captured op status, not a piped one (#1152)" {
+  # `op | while read` reports the WHILE's status. Written that way, a driver
+  # whose op failed outright produced an empty stream and a zero -- reported as
+  # "that terminal has no panes", which is the confusion this layer exists to
+  # prevent. Derived from the source rather than asserted about behaviour, so it
+  # cannot pass by the op happening to succeed.
+  local body
+  body="$(awk '/^agmsg_terminal_enumerate\(\)/,/^}/' "$SKILL_DIR/scripts/lib/terminal-registry.sh" \
+          | grep -v '^[[:space:]]*#')"
+  [ -n "$body" ] || { echo "could not read the function"; return 1; }
+  # the op's output is captured into a variable before any loop touches it
+  printf '%s\n' "$body" | grep -qE 'if out="\$\(terminal_enumerate_panes' \
+    || { echo "the op's status is not captured:"; printf '%s\n' "$body"; return 1; }
+  # and never piped straight into the reader
+  ! printf '%s\n' "$body" | grep -qE 'terminal_enumerate_panes[^|]*\|'
+}

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -2091,7 +2091,13 @@ _fake_herdr_list_anchored_plus() {
 # driver), so "did it reach the owning server" does not apply. What keeps it
 # honest is the oracle table in the "#1141 review" section: the socket form
 # and the legacy bare form are both accepted, as the registry accepted them.
-_TMUX_NO_ID_OPS="terminal_check terminal_describe terminal_detect terminal_spawn terminal_capability terminal_find_by_label terminal_id_ok"
+# terminal_enumerate_panes takes NO argument at all: it is the op that DISCOVERS
+# servers rather than being handed one, so there is no owning server in its input
+# either. It still honours #1051 -- it addresses each server it found with that
+# server's own socket and emits every row socket-qualified -- and that is checked
+# where it belongs, in test_sweep_enumeration.bats, against a fake tmux whose
+# per-socket answers the test writes.
+_TMUX_NO_ID_OPS="terminal_check terminal_describe terminal_detect terminal_spawn terminal_capability terminal_find_by_label terminal_id_ok terminal_enumerate_panes"
 
 # op -> the argument list to call it with, using SOCKID/BAREID as the id slot.
 _tmux_op_args() {


### PR DESCRIPTION
Part of #1152 — priority 1 of the sweep: **enumerate panes across every instance**,
as `(kind, instance, pane)` triples. Independent of #1154; base is
`integration/terminal-driver-v1`.

### A bare pane id is not an address

Measured on one machine, 2026-09-11, with two herdr instances running:

```
instance   response pane_id   shell_pid   who is actually there
jugemu     w1:p7              2727        one team's seat
oma        w1:p7              80649       a different team's seat
```

Enumerating both produced 52 rows in which `w1:p1`, `w1:p2`, `w1:p4`, `w1:p5` and
`w1:p7` each appeared **twice**. Two throwaway tmux servers showed the same with `%0`.
So nothing here emits a pane id on its own, and the instance that travels with it is a
**socket path** — the value that makes the row answerable again — not a display name.

This also means an id-echo canary cannot tell a wrong-instance answer from a right one:
both instances answer `pane_id=w1:p7`. That hole is reported separately against #1154.

### The tmux half is resurrected, not rewritten

From PR #1147 (branch `fix/1146-tmux-search-all-servers`). Its socket enumeration and its
rule for when a server counts as dead were already written and measured there; the PR was
closed only because a different design was expected to replace it.

**One verdict changed in the move.** #1146's search asked *"is this label unique across
every server?"*, so a server it could not read poisoned the whole answer. This op asks
*"what is out there?"*, and for that question one unreadable server must not lose the
panes of the servers that answered. The hole is named and enumeration continues — same
mechanics, different verdict, because the question is different.

### Four causes, four row kinds, none folded

```
<kind> <instance> <pane>   a pane was observed there
!  <kind> <instance>       that instance could not be read
!! <kind>                  that terminal's instance LIST could not be read
?  <kind>                  that terminal cannot enumerate at all
```

`?` and `!!` look identical from outside — no rows for that kind — and mean opposite
things to a caller: stop asking, versus retry.

### Three things the measurements changed

- **A socket proves nothing**; it outlives its server. Only `no server running` /
  `no such file or directory` is evidence of death. Measured: a live **non-tmux** listener
  answers `server exited unexpectedly`, which is not that — so it becomes a named hole.
  A socket that is merely bound with nothing listening *does* report `no server running`
  and is correctly skipped. My first control was the second kind, so it exercised the
  stale path while claiming to test the unreadable one.
- **An `id` that cannot answer** must not become "this user has no servers" — the socket
  directory could not be *named*. Observed on this machine while directory services were
  degraded and `id -un` returned the bare uid.
- **The glob runs in a subshell with `failglob` dropped.** Measured, both interpreters:
  with a caller's `shopt -s failglob` and an empty socket directory, a bare
  `for sock in "$dir"/*` produced **no output at all** — the shell died at the expansion,
  before any row could be printed. `nullglob` does not cover it; `failglob` wins. And the
  `case` arm inside that substitution needs its leading `(`: bash 3.2 counts parens when
  parsing `$( )`, so a pattern's `)` ends the substitution early.

### Controls

15 tests, driving fake `tmux` and `herdr` binaries so the error texts and exit statuses
are the test's property rather than the runner's. The same four outcomes were also
produced against real tmux servers in one observation and agreed.

14 mutations, each with its own red: dropping the socket qualification → 5; dropping a
named hole → 1 each; widening the dead-pattern → 1; softening the uid guard → 1; removing
the failglob subshell → 1; the herdr session/pane strictness → 1 each; visiting
non-running instances → 1; dropping the kind → 2; folding `?` into `!!` → 1; piping the
op's status instead of capturing it → 2; dropping the driver restore → 1. Clean: 0.

**Two of those controls could not fail when first written**, and the numbers above are
after fixing them. The "driver is restored" test loaded `plain`, which is the *last*
candidate — so a version with no restore at all left `plain` loaded and the test passed
on iteration order (measured: zero reds). And three negations were written
`! cmd | grep -q …` in non-final position, where bash cannot fail the test (#670); the
enforced-assertions checker named all three, run synchronously before asking for review.
