### PR TITLE
test: clean up leaked driver fixture temp dir in residue test

### DIFF
--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2393,6 +2393,10 @@ test("a staged input leaves nothing behind, whether the call succeeds or fails",
   const before = await residue();
 
   const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-residue-"));
+  t.after(async () => {
+    if (!root.startsWith(tmpdir())) throw new Error("unsafe test root");
+    await rm(root, { recursive: true, force: true });
+  });
   const input = Array.from({ length: 8 }, (_, index) => ({ type: "probe", index }));
 
   const ok = (pidFile, helperFile) => `#!/usr/bin/env bash


### PR DESCRIPTION
## Summary

The `"a staged input leaves nothing behind, whether the call succeeds or fails"` test in `tests/remote_sync_engine.test.mjs` creates two `mkdtemp()`'d directories under the `agmsg-sync-driver-residue-` prefix within the same test run: `root` (holding the successful `ok-driver.sh` fixture) and `bad` (holding the failing fixture, passed through `withDriverEnvironment`). Only `bad` was ever cleaned up — its `withDriverEnvironment(t, bad, ...)` call registers its own `t.after` cleanup, but `root`'s own `t.after` only restores the `AGMSG_SYNC_ROSTER_DRIVER` env var and never removes the directory itself.

This leaks exactly one directory per test-file run, 100% of the time, independent of pass/fail outcome. Content is always the same static, hardcoded fixture script (no dynamic/message data), so this is a test-hygiene leak rather than anything touching message safety.

## How I found this

While investigating #1106 (unrelated non-zero-exit issue) I ran this test file's driver-input tests several hundred times on Windows and noticed `%TEMP%` accumulating `agmsg-sync-driver-residue-*` directories at exactly +1 per invocation. Traced it to the missing cleanup above; empirically confirmed the count matches the invocation count exactly across 206 and then 406 runs (never more, never fewer).

## Fix

Mirrors the existing pattern already used for `bad` a few lines below in the same test: register a `t.after` that removes `root`, guarded by the same `"unsafe test root"` `tmpdir()` check used elsewhere in this file.

## Test plan

- `node --test --test-name-pattern 'whole input, from the start|leaves nothing behind' tests/remote_sync_engine.test.mjs` — still `pass 2 / fail 0`, exit 0
- Ran the same command (and the CI-equivalent `bats --print-output-on-failure --filter "driver-input" tests/test_remote_sync_driver_input.bats`) repeatedly before and after the fix; before the fix the leftover-directory count grows by 1 each run, after the fix it does not

## Scope

This PR is the code fix only. It intentionally does not delete the directories that have already accumulated on any given machine from before this fix — that's a separate operational/cleanup decision, out of scope here.
