### PR TITLE
Stop naming terminals in agent-facing docs; add a driver-neutral placement query (#1171)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -122,6 +122,11 @@ If argument is "version":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/version.sh`
 2. Show the output — the installed version (git-describe provenance recorded at install time).
 
+If argument is "where" (e.g. asked to report this session's own pane or placement):
+1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/where.sh`
+2. Report exactly what it prints. Do not try to answer this by naming a terminal yourself or running any terminal-specific command directly — this call already asked every driver on this session's behalf.
+3. `resolved=true placement=<terminal>:<id>` is a known pane; `resolved=true placement=none` is a GENUINE negative (this session's own terminal confirmed it has no addressable pane). `resolved=false` means placement could NOT be determined — `reason` names which terminal(s) were asked and why. Never report a `resolved=false` answer as "no pane" or "not attached to a pane"; those are different answers to different questions, and the difference is the entire point of this command (#1171).
+
 
 <!-- agmsg:slot actas -->
 If argument starts with "actas" followed by an agent name:
@@ -140,9 +145,9 @@ If argument starts with "drop" followed by an agent name:
 If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex reviewer --window"):
 1. Parse `<type>` (a spawnable agent type), `<name>`, and any options (`--boot-prompt <text>`, `--project <path>`, `--team <team>`, `--window`, `--split h|v`, `--terminal <template>`, `--no-wait`, `--ready-timeout <secs>`, `--model <id>`, `--fresh`).
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
-   - `spawn.sh` pre-joins `<name>`, then opens a tmux pane/window or a new OS terminal and launches the target CLI with `__CMD_PREFIX____SKILL_NAME__ actas <name>` as its initial prompt. `--boot-prompt` appends a first task to that prompt.
+   - `spawn.sh` pre-joins `<name>`, then opens a new pane or window through the terminal driver and launches the target CLI with `__CMD_PREFIX____SKILL_NAME__ actas <name>` as its initial prompt. `--boot-prompt` appends a first task to that prompt. Which terminal that is is the driver's decision, never something to name here.
    - By default it waits for a target watcher to attach and report `status=ready`; `--no-wait` returns immediately. Codex has no Monitor, so a Codex spawn skips that readiness wait.
-   - It refuses early when `<name>` is already held, the target CLI is missing, the project path is invalid, or no tmux/usable terminal is available.
+   - It refuses early when `<name>` is already held, the target CLI is missing, the project path is invalid, or the terminal driver has nowhere to place it.
 3. Show the script's output.
 
 If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --force"):
@@ -157,10 +162,10 @@ If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --for
 
 <!-- drop guidance is supplied by the type overlay -->
 
-If argument starts with "arrange" (e.g. "arrange alice place_below tmux:%2"):
-1. Parse `<agent> <place_below|place_right|swap> <anchor-ref>` and determine the source agent's team.
+If argument starts with "arrange" (e.g. "arrange alice place_below <anchor-ref>"):
+1. Parse `<agent> <place_below|place_right|swap> <anchor-ref>` and determine the source agent's team. `<anchor-ref>` is a placement reference for another pane — copy it exactly as another command reported it (e.g. `team`/`team --json`'s `terminal`/`pane` fields for that row); it is never something to construct from a remembered terminal syntax.
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/arrange.sh <team> <agent> <intent> <anchor-ref>`.
-3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `place_below` and `place_right` are idempotent, but `swap` is not: calling `swap` twice swaps the panes back, so a native swap normally reports `moved`; `unchanged` is only possible when the driver explicitly reports `changed=false`. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (`tmux:@N` window placements included).
+3. Show the script output. Report `moved` as a performed move and `unchanged` as already in the requested arrangement; do not collapse the two. `place_below` and `place_right` are idempotent, but `swap` is not: calling `swap` twice swaps the panes back, so a native swap normally reports `moved`; `unchanged` is only possible when the driver explicitly reports `changed=false`. `ambiguous_layout` means the layout must be simplified before retrying, `runtime_error` means inspect the terminal, and `unsupported` means the terminal/placement cannot be arranged (a window-level placement can be one such case).
 
 If argument starts with "peek" (e.g. "peek", "peek reviewer", "peek alice --lines 80"):
 1. With a name, parse `<name>` and an optional `--lines N` (how many of the pane's visible lines to return), determine which team `<name>` belongs to (as with `send`), then run `~/.agents/skills/__SKILL_NAME__/scripts/peek.sh <team> <name> [--lines N]`.

--- a/scripts/drivers/types/claude-code/template.md
+++ b/scripts/drivers/types/claude-code/template.md
@@ -66,9 +66,9 @@ If argument starts with "drop" followed by an agent name:
 If argument starts with "spawn" (e.g. "spawn codex reviewer", "spawn claude-code alice --window"):
 1. Parse `<type>` (a spawnable agent type), `<name>`, and any options (`--boot-prompt <text>`, `--project <path>`, `--team <team>`, `--window`, `--split h|v`, `--terminal <template>`, `--no-wait`, `--ready-timeout <secs>`, `--model <id>`, `--fresh`).
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
-   - `spawn.sh` pre-joins `<name>`, then opens a tmux pane/window or a new OS terminal and launches the target CLI with `/__SKILL_NAME__ actas <name>` as its initial prompt. `--boot-prompt` appends a first task to that prompt.
+   - `spawn.sh` pre-joins `<name>`, then opens a new pane or window through the terminal driver and launches the target CLI with `/__SKILL_NAME__ actas <name>` as its initial prompt. `--boot-prompt` appends a first task to that prompt. Which terminal that is is the driver's decision, never something to name here.
    - By default it blocks until a spawned Claude Code agent's watcher attaches and prints `status=ready`; `--no-wait` returns immediately. A spawned Codex agent has no Monitor and skips the readiness wait.
-   - It refuses early when `<name>` is already held by another live session, the target CLI is missing, the project path is invalid, or no tmux/usable terminal is available.
+   - It refuses early when `<name>` is already held by another live session, the target CLI is missing, the project path is invalid, or the terminal driver has nowhere to place it.
 3. Show the script's output. Do not TaskStop or relaunch this session's own Monitor; spawn affects a separate agent.
 
 If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --force"):

--- a/scripts/drivers/types/codex/template.md
+++ b/scripts/drivers/types/codex/template.md
@@ -30,9 +30,9 @@ If argument starts with "drop", run `reset.sh "$(pwd)" __AGENT_TYPE__ <name>` an
 If argument starts with "spawn" (e.g. "spawn claude-code alice", "spawn codex reviewer --window"):
 1. Parse `<type>` (a spawnable agent type), `<name>`, and any options (`--boot-prompt <text>`, `--project <path>`, `--team <team>`, `--window`, `--split h|v`, `--terminal <template>`, `--no-wait`, `--ready-timeout <secs>`, `--model <id>`, `--fresh`).
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/spawn.sh <type> <name> --project "$(pwd)" [options]`
-   - `spawn.sh` pre-joins `<name>`, then opens a tmux pane/window or a new OS terminal and launches the target CLI with `$__SKILL_NAME__ actas <name>` as its initial prompt. `--boot-prompt` appends a first task to that prompt. Codex spawn uses the bundled shim and bridge.
+   - `spawn.sh` pre-joins `<name>`, then opens a new pane or window through the terminal driver and launches the target CLI with `$__SKILL_NAME__ actas <name>` as its initial prompt. `--boot-prompt` appends a first task to that prompt. Codex spawn uses the bundled shim and bridge. Which terminal that is is the driver's decision, never something to name here.
    - By default it blocks until a spawned Claude Code agent's watcher attaches and prints `status=ready`; `--no-wait` returns immediately. A spawned Codex agent has no Monitor and skips the readiness wait.
-   - It refuses early when `<name>` is already held by another live session, the target CLI is missing, the project path is invalid, or no tmux/usable terminal is available.
+   - It refuses early when `<name>` is already held by another live session, the target CLI is missing, the project path is invalid, or the terminal driver has nowhere to place it.
 3. Show the script's output.
 
 If argument starts with "despawn" (e.g. "despawn reviewer", "despawn alice --force"):

--- a/scripts/where.sh
+++ b/scripts/where.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Where is THIS session — without the caller ever naming a terminal.
+#
+# #1171: asked to report its pane, an agent under herdr ran a raw `tmux
+# display-message`, got a connection error (there was no tmux server), and
+# reported that AS ITS OWN PLACEMENT: "this session is not attached to a
+# pane". A failed read of the wrong terminal became a confident negative
+# about the caller. That happened because SKILL.md taught tmux's syntax and
+# nothing else, and no script exposed a driver-neutral way to ask.
+#
+# This script is that way. It goes through the same driver auto-detection
+# every other self-placement path already uses (actas' self-naming, spawn's
+# placement resolution) — the caller never picks a terminal, and never sees
+# one to pick. A terminal name in the OUTPUT is diagnostic only, never
+# something the caller is meant to branch on.
+#
+# Usage: where.sh [session_id]
+#   session_id — optional. Only herdr's fallback path consults it; herdr's
+#   preferred HERDR_PANE_ID path and tmux's $TMUX_PANE need none. Omit it if
+#   the caller does not have one.
+#
+# Output (stdout, one line, key=value):
+#   resolved=true placement=<terminal>:<id> container=<container>
+#     A real, addressable pane was identified. `container` is best-effort
+#     extra context (e.g. the window/tab it lives in); if the driver could
+#     not answer THAT sub-question, container names why
+#     (unknown:<reason>) — that failure is about the container lookup, not
+#     about whether this session has a pane, which is already settled.
+#   resolved=true placement=none reason=no_addressable_pane terminal=<name>
+#     A GENUINE negative: <name> was identified as this session's terminal,
+#     and it confirmed it has no addressable pane (a plain OS terminal).
+#   resolved=false reason=<text>
+#     Placement could NOT be determined. <text> names every terminal that
+#     was actually asked and why it did not answer (e.g. "under a terminal
+#     but cannot identify this pane to name it — tmux: \$TMUX_PANE is
+#     unset — cannot identify this pane"). This is never collapsed into
+#     "no pane" — that claim requires resolved=true.
+#
+# Exit code mirrors `resolved`: 0 when true, 1 when false.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/terminal-registry.sh"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/team-status.sh"
+
+SID="${1:-}"
+
+errf="$(mktemp "${TMPDIR:-/tmp}/agmsg-where.XXXXXX")" || errf=/dev/null
+rc=0
+resolved="$(agmsg_terminal_resolve_name "$SID" 2>"$errf")" || rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  reason=""
+  if [ "$errf" != /dev/null ] && [ -s "$errf" ]; then
+    reason="$(cat "$errf" 2>/dev/null || true)"
+  fi
+  [ "$errf" = /dev/null ] || rm -f "$errf"
+  printf 'resolved=false reason=%s\n' "${reason:-could not determine placement for this session}"
+  exit 1
+fi
+[ "$errf" = /dev/null ] || rm -f "$errf"
+
+# agmsg_terminal_resolve_name prints exactly "<terminal>\t<id>" on success.
+terminal="${resolved%%$'\t'*}"
+id="${resolved#*$'\t'}"
+
+if [ "$id" = '-' ]; then
+  printf 'resolved=true placement=none reason=no_addressable_pane terminal=%s\n' "$terminal"
+  exit 0
+fi
+
+# terminal_where's own failures are named already (agmsg_team_location prints
+# unknown:<reason>) — that is about the CONTAINER sub-question, not about
+# whether this session has a pane, which the branch above already settled.
+location="$(agmsg_team_location "$terminal" "$id")"
+container="${location##*$'\t'}"
+printf 'resolved=true placement=%s:%s container=%s\n' "$terminal" "$id" "$container"
+exit 0

--- a/tests/test_claude_template.bats
+++ b/tests/test_claude_template.bats
@@ -39,3 +39,15 @@ setup() {
   grep -Fq 'Do not report `actas` as complete without saying this' "$RENDERED"
   grep -Fq 'Do not report the drop as complete without mentioning it' "$RENDERED"
 }
+
+@test "Claude rendered skill names no terminal driver, so an agent has no name to reach for (#1171)" {
+  # Measured on the pre-fix branch: tmux 4, herdr 0. The fix is not balancing
+  # that count -- it is dropping terminal names from agent-facing text
+  # entirely, so the choice this incident hinged on ("which terminal's
+  # syntax do I know") never comes up. Case-insensitive: a capitalized
+  # mention would steer just as much as a lowercase one.
+  run grep -ic 'tmux\|herdr' "$RENDERED"
+  [ "$status" -ne 0 ] || [ "$output" -eq 0 ]
+  grep -Fq 'If argument is "where"' "$RENDERED"
+  grep -Fq 'this call already asked every driver' "$RENDERED"
+}

--- a/tests/test_where.bats
+++ b/tests/test_where.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+# where.sh (#1171) — a driver-neutral way for a session to ask its own
+# placement, so a caller never has to guess or type a terminal-specific
+# command (the #1171 incident: an agent under herdr ran a raw `tmux
+# display-message`, and converted the resulting OS error into a false claim
+# about its own placement). The load-bearing property this file protects:
+# "could not determine" and "there is no pane" must come back as visibly
+# different answers — never the same bare negative.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export AGMSG_PLUGIN_DIRS=""
+}
+
+teardown() { teardown_test_env; }
+
+@test "where: nothing present resolves as a GENUINE no-pane answer (plain)" {
+  run bash "$SCRIPTS/where.sh"
+  [ "$status" -eq 0 ]
+  grep -q '^resolved=true' <<<"$output"
+  grep -q 'placement=none' <<<"$output"
+  grep -q 'reason=no_addressable_pane' <<<"$output"
+  grep -q 'terminal=plain' <<<"$output"
+}
+
+@test "where: herdr with a live HERDR_PANE_ID resolves to that pane, terminal name is diagnostic only" {
+  export HERDR_ENV=1 HERDR_PANE_ID=w1:p4
+  run bash "$SCRIPTS/where.sh"
+  [ "$status" -eq 0 ]
+  grep -q '^resolved=true' <<<"$output"
+  grep -q 'placement=herdr:w1:p4' <<<"$output"
+  # container is best-effort context, never absent outright — its failure
+  # (no herdr on PATH here) must say why, not just vanish.
+  grep -q 'container=' <<<"$output"
+}
+
+# --- the required RED control (#1171): present-but-unidentifiable must NOT
+# collapse into "no pane". tmux's own terminal_detect decides presence from
+# $TMUX alone (no tmux binary is invoked for detection), so setting $TMUX and
+# leaving $TMUX_PANE unset reproduces "a terminal is present and cannot say
+# which pane" without needing a real tmux server — exactly the shape of the
+# #1171 incident (asked, and the answer could not be trusted as absence).
+@test "where: tmux present but \$TMUX_PANE unset -> resolved=false with a reason, NEVER placement=none (#1171)" {
+  export TMUX="/tmp/sock,1,0"
+  unset TMUX_PANE
+  run bash "$SCRIPTS/where.sh"
+  [ "$status" -eq 1 ]
+  grep -q '^resolved=false' <<<"$output"
+  grep -q 'reason=' <<<"$output"
+  # names WHICH terminal was asked...
+  grep -q 'tmux' <<<"$output"
+  # ...and WHY it could not answer.
+  grep -q 'TMUX_PANE' <<<"$output"
+  # the one thing this answer must never say: a bare negative about placement.
+  refute grep -q 'placement=none' <<<"$output"
+  refute grep -q 'no_addressable_pane' <<<"$output"
+}
+
+@test "where: an unknown AGMSG_TERMINAL_DRIVER override fails loudly, naming the bad value" {
+  export AGMSG_TERMINAL_DRIVER=tnux
+  run bash "$SCRIPTS/where.sh"
+  [ "$status" -eq 1 ]
+  grep -q '^resolved=false' <<<"$output"
+  grep -q "tnux" <<<"$output"
+}


### PR DESCRIPTION
Fixes #1171.

An agent under herdr, asked to report its pane, ran a raw `tmux display-message` (the only terminal syntax SKILL.md ever taught), got a connection error, and reported that as a confident negative about its own placement: "this session is not attached to a pane". A failed read of the wrong terminal became a false claim, and anything downstream that consumed that report (a placement record, a collision check, a repair sweep) would have received "no pane here" when the truth was "the wrong terminal was asked".

the maintainer's ruling overrides the issue's own proposed scope: the fix is not naming the terminals actually supported (that would just be teaching herdr's syntax alongside tmux's). It is removing terminal names and grammar from agent-facing text entirely, so the choice of which terminal's command to run never comes up. Driver selection is the driver's job, not the agent's.

## Changes

1. **SKILL.md and the claude-code/codex type overlays** no longer name `tmux` or `herdr` anywhere (measured: 4 tmux / 0 herdr mentions before this PR, 0 of either after). The `arrange` worked example uses a placeholder anchor-ref (copied from another command's output) instead of tmux-shaped syntax (`tmux:%2`).
2. **`scripts/where.sh`** — a new driver-neutral "where is this session" entry point, built on the same auto-detection `actas`/`spawn` already use (`agmsg_terminal_resolve_name` + `agmsg_team_location`). Its answer keeps three cases distinct that must never collapse into each other:
   - a known pane: `resolved=true placement=<terminal>:<id> container=<container>`
   - a genuine absence of an addressable pane (the terminal itself confirmed it): `resolved=true placement=none reason=no_addressable_pane terminal=<name>`
   - placement that could NOT be determined: `resolved=false reason=<text naming every terminal asked and why>`

   The third case is exactly the one #1171's incident collapsed into the second.
3. **`tests/test_where.bats`** reproduces the failure shape without a real tmux server — tmux's own `terminal_detect` decides presence from `$TMUX` alone, so `$TMUX` set with `$TMUX_PANE` unset drives a present-but-unidentifiable terminal through `resolve_name`, and the test asserts `resolved=false` with a reason, never `placement=none`. Verified against a mutation of `where.sh` that collapses the failure branch into the old bug's shape — the test goes red.
4. **`tests/test_claude_template.bats`** adds a regression guard: the rendered claude-code SKILL.md must never again name `tmux` or `herdr`.

## Verification

- `check-enforced-assertions.sh`: 626/626, baseline unchanged.
- `bats tests/test_where.bats`, `tests/test_claude_template.bats`, `tests/test_team.bats`: all green.
- `bash -n scripts/where.sh`: OK.

Base: `integration/terminal-driver-v1` tip at branch time (`33b2b47`).

