### PR TITLE
feat(sweep): fan out self-repair across terminal instances (#1152)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -105,6 +105,14 @@ If argument is "team", "team --json", "team --fix", "team --fix-pane-names", or 
    - `--rename-sessions` repairs the CLI session name by **typing** the type's rename command (e.g. `/rename <team>-<agent>`) into each session whose name mismatches, is renamable, and is at a prompt; reported as `changed`, `poked_unverified`, `skipped`, or `failed`.
    - `--fix` does both, unconditionally, including the keystroke.
 
+If argument starts with "sweep" followed by a team name:
+1. Run `~/.agents/skills/__SKILL_NAME__/scripts/sweep.sh <team>`.
+2. This is an explicit leader action. Never run it from inbox delivery, session
+   startup, a status command, or any other automatic path.
+3. Show the complete result. A skipped `none`, `unknown`, unreadable,
+   unsupported, or malformed observation is part of the result, not noise to
+   summarize away; the command returns non-zero when any such row exists.
+
 If argument starts with "send" (e.g. "send misaki check the server"):
 1. Parse target agent and message from the arguments
 2. Determine which team the target agent belongs to, then run:

--- a/scripts/lib/sweep.sh
+++ b/scripts/lib/sweep.sh
@@ -12,8 +12,8 @@ _AGMSG_SWEEP_SH=1
 # observation without an environment-based target injection path in the shipped
 # command.
 _agmsg_sweep_agent_rows() {
-  declare -F agmsg_terminal_agents >/dev/null 2>&1 || return 127
-  agmsg_terminal_agents
+  declare -F agmsg_terminal_enumerate >/dev/null 2>&1 || return 127
+  agmsg_terminal_enumerate
 }
 
 # These two adapters are intentionally fail-closed until the instance-aware

--- a/scripts/lib/sweep.sh
+++ b/scripts/lib/sweep.sh
@@ -24,8 +24,8 @@ _agmsg_sweep_label_at() { return 127; }       # <kind> <instance> <pane>
 _agmsg_sweep_poke_fenced() { return 127; }    # <kind> <instance> <pane> <owner> <text>
 _agmsg_sweep_instance_allowed() { return 127; } # <team> <kind> <instance>
 _agmsg_sweep_locator() {                      # <kind> <instance> <pane>
-  declare -F agmsg_terminal_locator >/dev/null 2>&1 || return 127
-  agmsg_terminal_locator "$1" "$2" "$3"
+  declare -F agmsg_locator_compose >/dev/null 2>&1 || return 127
+  agmsg_locator_compose "$1" "$2" "$3"
 }
 
 # Is <label> exactly one local registration in <team> whose type agrees with
@@ -158,7 +158,11 @@ EOF
     # for the write; that would create a second address derivation that could
     # cross instances.
     ref=""; locator_rc=0
-    ref="$(_agmsg_sweep_locator "$kind" "$instance" "$pane" 2>/dev/null)" || locator_rc=$?
+    # Composer stderr carries its named refusal (instance_malformed,
+    # pane_malformed, unknown_kind). Preserve it: a generic rc without the
+    # grammar reason would make malformed input indistinguishable from an
+    # unavailable implementation.
+    ref="$(_agmsg_sweep_locator "$kind" "$instance" "$pane")" || locator_rc=$?
     if [ "$locator_rc" -ne 0 ] || [ -z "$ref" ]; then
       _agmsg_sweep_report_skip "$kind" "$instance" "$pane" "locator_unavailable:rc_$locator_rc"
       rc=1

--- a/scripts/lib/sweep.sh
+++ b/scripts/lib/sweep.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# sweep.sh -- explicit leader-side fan-out for a team's self-repair (#1152).
+
+[ -n "${_AGMSG_SWEEP_SH:-}" ] && return 0
+_AGMSG_SWEEP_SH=1
+
+# This is the only seam between the command and #1155. Once that change lands,
+# the body is exactly the production primitive. Keeping the call here also lets
+# the orchestrator tests replace the observation without an environment-based
+# target injection path in the shipped command.
+_agmsg_sweep_agent_rows() {
+  declare -F agmsg_terminal_agents >/dev/null 2>&1 || return 127
+  agmsg_terminal_agents
+}
+
+# These two adapters are intentionally fail-closed until the instance-aware
+# label reader and compare-and-poke ABI land. Neither may be emulated by loading
+# a driver against the leader's environment: two terminal instances routinely
+# contain the same bare pane id.
+_agmsg_sweep_label_at() { return 127; }       # <kind> <instance> <pane>
+_agmsg_sweep_poke_fenced() { return 127; }    # <kind> <instance> <pane> <owner> <text>
+_agmsg_sweep_instance_allowed() { return 127; } # <team> <kind> <instance>
+
+# Is <label> exactly one local registration in <team> whose type agrees with
+# the process observation? Prints the agent name on success. A label is only a
+# target-selection fact; it is never used as the terminal address.
+_agmsg_sweep_roster_match() {   # <team> <label> <type>
+  local team="$1" label="$2" type="$3" cfg esc out
+  cfg="$SKILL_DIR/teams/$team/config.json"
+  [ -r "$cfg" ] || return 1
+  command -v sqlite3 >/dev/null 2>&1 || return 2
+  esc="$(sed "s/'/''/g" "$cfg")" || return 2
+  out="$(sqlite3 -noheader :memory: "
+    WITH cfg(j) AS (SELECT json('$esc')),
+    matches(agent) AS (
+      SELECT a.key
+      FROM cfg, json_each(json_extract(cfg.j, '\$.agents')) AS a
+      WHERE '$team:' || a.key = '$(printf '%s' "$label" | sed "s/'/''/g")'
+        AND EXISTS (
+          SELECT 1
+          FROM json_each(json_extract(a.value, '\$.registrations')) AS r
+          WHERE json_extract(r.value, '\$.type') = '$(printf '%s' "$type" | sed "s/'/''/g")'
+        )
+    )
+    SELECT CASE WHEN count(*) = 1 THEN min(agent) ELSE '' END FROM matches;
+  " 2>/dev/null)" || return 2
+  [ -n "$out" ] || return 1
+  printf '%s\n' "$out"
+}
+
+_agmsg_sweep_report_skip() {   # <kind> <instance> <pane> <reason>
+  printf 'skipped kind=%s instance=%s pane=%s reason=%s\n' "$1" "$2" "$3" "$4" >&2
+}
+
+# Consume #1155 rows:
+#   kind<TAB>instance<TAB>pane<TAB>state<TAB>payload
+# plus its ! / !! / ? hole rows. Every row that is not a complete, corroborated
+# agent candidate is loud and makes the command non-zero.
+agmsg_sweep_run() {   # <team>
+  local team="${1-}" rows rows_rc=0 rc=0 tab line
+  local kind instance pane state payload extra label label_rc agent owner ref text poke_rc
+  [ -n "$team" ] || { echo 'sweep: team is required' >&2; return 2; }
+  tab="$(printf '\t')"
+
+  if rows="$(_agmsg_sweep_agent_rows)"; then rows_rc=0; else rows_rc=$?; fi
+  if [ "$rows_rc" -ne 0 ]; then
+    echo "sweep: pane/agent enumeration failed (rc=$rows_rc); nothing was written" >&2
+    return 1
+  fi
+
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    IFS="$tab" read -r kind instance pane state payload extra <<EOF
+$line
+EOF
+    if [ -n "${extra:-}" ]; then
+      _agmsg_sweep_report_skip "${kind:-?}" "${instance:-?}" "${pane:-?}" malformed_row
+      rc=1
+      continue
+    fi
+    case "$kind" in
+      '!'|'!!'|'?')
+        _agmsg_sweep_report_skip "$kind" "${instance:-?}" "${pane:-?}" enumeration_hole
+        rc=1
+        continue
+        ;;
+    esac
+    if [ -z "${kind:-}" ] || [ -z "${instance:-}" ] || [ -z "${pane:-}" ] \
+       || [ -z "${state:-}" ]; then
+      _agmsg_sweep_report_skip "${kind:-?}" "${instance:-?}" "${pane:-?}" malformed_row
+      rc=1
+      continue
+    fi
+    case "$state" in
+      agent) [ -n "${payload:-}" ] || {
+          _agmsg_sweep_report_skip "$kind" "$instance" "$pane" malformed_agent_row
+          rc=1
+          continue
+        } ;;
+      none|unknown)
+        _agmsg_sweep_report_skip "$kind" "$instance" "$pane" "$state${payload:+:$payload}"
+        rc=1
+        continue
+        ;;
+      *)
+        _agmsg_sweep_report_skip "$kind" "$instance" "$pane" malformed_state
+        rc=1
+        continue
+        ;;
+    esac
+
+    # A team-scoped sweep may not wander into every local terminal instance.
+    # The instance must occur in that team's own recorded placements. Unknown
+    # is a refusal, not permission: another team's instance may reuse every bare
+    # pane id in this row.
+    if ! _agmsg_sweep_instance_allowed "$team" "$kind" "$instance"; then
+      _agmsg_sweep_report_skip "$kind" "$instance" "$pane" instance_not_allowed
+      rc=1
+      continue
+    fi
+
+    label=""; label_rc=0
+    label="$(_agmsg_sweep_label_at "$kind" "$instance" "$pane" 2>/dev/null)" || label_rc=$?
+    if [ "$label_rc" -ne 0 ] || [ -z "$label" ]; then
+      _agmsg_sweep_report_skip "$kind" "$instance" "$pane" "label_unavailable:rc_$label_rc"
+      rc=1
+      continue
+    fi
+    agent=""
+    agent="$(_agmsg_sweep_roster_match "$team" "$label" "$payload" 2>/dev/null)" || agent=""
+    if [ -z "$agent" ]; then
+      _agmsg_sweep_report_skip "$kind" "$instance" "$pane" roster_label_process_mismatch
+      rc=1
+      continue
+    fi
+
+    # The address and the instruction are made once, from this row's variables.
+    # Do not parse the ref back into a bare pane for the write: that would create
+    # a second address derivation that could cross instances.
+    ref="$kind:$instance:$pane"
+    text="\$agmsg fix --pane $ref"
+    owner="$team/$agent"
+    poke_rc=0
+    _agmsg_sweep_poke_fenced "$kind" "$instance" "$pane" "$owner" "$text" >/dev/null || poke_rc=$?
+    if [ "$poke_rc" -ne 0 ]; then
+      _agmsg_sweep_report_skip "$kind" "$instance" "$pane" "write_fence_or_poke_failed:rc_$poke_rc"
+      rc=1
+      continue
+    fi
+    printf 'sent team=%s agent=%s type=%s pane=%s\n' "$team" "$agent" "$payload" "$ref"
+  done <<EOF
+$rows
+EOF
+  return "$rc"
+}

--- a/scripts/lib/sweep.sh
+++ b/scripts/lib/sweep.sh
@@ -52,6 +52,16 @@ _agmsg_sweep_report_skip() {   # <kind> <instance> <pane> <reason>
   printf 'skipped kind=%s instance=%s pane=%s reason=%s\n' "$1" "$2" "$3" "$4" >&2
 }
 
+# Serialize one argument for the command line typed into an agent. Instance
+# paths may contain spaces and quotes; raw interpolation would let one ref turn
+# into several arguments before `fix` sees it. POSIX single-quote form is
+# understood by every shell-backed command parser used by the agent skills.
+_agmsg_sweep_quote_arg() {   # <value>
+  local value="${1-}" escaped
+  escaped="$(printf '%s' "$value" | sed "s/'/'\\\\''/g")" || return 1
+  printf "'%s'" "$escaped"
+}
+
 # Consume #1155 rows:
 #   kind<TAB>instance<TAB>pane<TAB>state<TAB>payload
 # plus its ! / !! / ? hole rows. Every row that is not a complete, corroborated
@@ -138,7 +148,7 @@ EOF
     # Do not parse the ref back into a bare pane for the write: that would create
     # a second address derivation that could cross instances.
     ref="$kind:$instance:$pane"
-    text="\$agmsg fix --pane $ref"
+    text="\$agmsg fix --pane $(_agmsg_sweep_quote_arg "$ref")"
     owner="$team/$agent"
     poke_rc=0
     _agmsg_sweep_poke_fenced "$kind" "$instance" "$pane" "$owner" "$text" >/dev/null || poke_rc=$?

--- a/scripts/lib/sweep.sh
+++ b/scripts/lib/sweep.sh
@@ -4,10 +4,13 @@
 [ -n "${_AGMSG_SWEEP_SH:-}" ] && return 0
 _AGMSG_SWEEP_SH=1
 
-# This is the only seam between the command and #1155. Once that change lands,
-# the body is exactly the production primitive. Keeping the call here also lets
-# the orchestrator tests replace the observation without an environment-based
-# target injection path in the shipped command.
+# This is the only seam between the command and #1155's read-only census. The
+# census is shared infrastructure, not a sweep-owned scan: diagnostics and this
+# command consume the same observation independently and never consume one
+# another's output. Once #1155 lands, the body is exactly the production
+# primitive. Keeping the call here also lets the orchestrator tests replace the
+# observation without an environment-based target injection path in the shipped
+# command.
 _agmsg_sweep_agent_rows() {
   declare -F agmsg_terminal_agents >/dev/null 2>&1 || return 127
   agmsg_terminal_agents
@@ -163,3 +166,9 @@ $rows
 EOF
   return "$rc"
 }
+
+# LIMIT: the command can target only locations the census can observe. A seat
+# whose real location is absent from that snapshot cannot be swept, and a
+# detector using the same census cannot diagnose that seat's lone bad claim by
+# comparing it with a location the census never saw. Never fill that hole from
+# a placement record: the record is the projection being repaired.

--- a/scripts/lib/sweep.sh
+++ b/scripts/lib/sweep.sh
@@ -33,8 +33,9 @@ _agmsg_sweep_locator() {                      # <kind> <instance> <pane>
 # the process observation? Prints the agent name on success. A label is only a
 # target-selection fact; it is never used as the terminal address.
 _agmsg_sweep_roster_match() {   # <team> <label> <type>
-  local team="$1" label="$2" type="$3" cfg esc out
-  cfg="$SKILL_DIR/teams/$team/config.json"
+  local team="$1" label="$2" type="$3" root="${SKILL_DIR:-}" cfg esc out
+  [ -n "$root" ] || return 2
+  cfg="$root/teams/$team/config.json"
   [ -r "$cfg" ] || return 1
   command -v sqlite3 >/dev/null 2>&1 || return 2
   esc="$(sed "s/'/''/g" "$cfg")" || return 2
@@ -79,6 +80,10 @@ agmsg_sweep_run() {   # <team>
   local kind instance pane census_extra process process_rc state payload process_extra
   local label label_rc agent owner ref locator_rc text poke_rc
   [ -n "$team" ] || { echo 'sweep: team is required' >&2; return 2; }
+  [ -n "${SKILL_DIR:-}" ] || {
+    echo 'sweep: skill_dir_unavailable; nothing was written' >&2
+    return 1
+  }
   tab="$(printf '\t')"
 
   if rows="$(_agmsg_sweep_agent_rows)"; then rows_rc=0; else rows_rc=$?; fi

--- a/scripts/lib/sweep.sh
+++ b/scripts/lib/sweep.sh
@@ -23,6 +23,10 @@ _agmsg_sweep_agent_rows() {
 _agmsg_sweep_label_at() { return 127; }       # <kind> <instance> <pane>
 _agmsg_sweep_poke_fenced() { return 127; }    # <kind> <instance> <pane> <owner> <text>
 _agmsg_sweep_instance_allowed() { return 127; } # <team> <kind> <instance>
+_agmsg_sweep_locator() {                      # <kind> <instance> <pane>
+  declare -F agmsg_terminal_locator >/dev/null 2>&1 || return 127
+  agmsg_terminal_locator "$1" "$2" "$3"
+}
 
 # Is <label> exactly one local registration in <team> whose type agrees with
 # the process observation? Prints the agent name on success. A label is only a
@@ -71,7 +75,7 @@ _agmsg_sweep_quote_arg() {   # <value>
 # agent candidate is loud and makes the command non-zero.
 agmsg_sweep_run() {   # <team>
   local team="${1-}" rows rows_rc=0 rc=0 tab line
-  local kind instance pane state payload extra label label_rc agent owner ref text poke_rc
+  local kind instance pane state payload extra label label_rc agent owner ref locator_rc text poke_rc
   [ -n "$team" ] || { echo 'sweep: team is required' >&2; return 2; }
   tab="$(printf '\t')"
 
@@ -147,10 +151,19 @@ EOF
       continue
     fi
 
-    # The address and the instruction are made once, from this row's variables.
-    # Do not parse the ref back into a bare pane for the write: that would create
-    # a second address derivation that could cross instances.
-    ref="$kind:$instance:$pane"
+    # The address and the instruction are made once, from this row's variables,
+    # through the shared terminal-registry grammar. This command neither parses
+    # nor hand-serializes a locator: four readers doing that would become four
+    # subtly different grammars. Do not parse the result back into a bare pane
+    # for the write; that would create a second address derivation that could
+    # cross instances.
+    ref=""; locator_rc=0
+    ref="$(_agmsg_sweep_locator "$kind" "$instance" "$pane" 2>/dev/null)" || locator_rc=$?
+    if [ "$locator_rc" -ne 0 ] || [ -z "$ref" ]; then
+      _agmsg_sweep_report_skip "$kind" "$instance" "$pane" "locator_unavailable:rc_$locator_rc"
+      rc=1
+      continue
+    fi
     text="\$agmsg fix --pane $(_agmsg_sweep_quote_arg "$ref")"
     owner="$team/$agent"
     poke_rc=0

--- a/scripts/lib/sweep.sh
+++ b/scripts/lib/sweep.sh
@@ -16,10 +16,11 @@ _agmsg_sweep_agent_rows() {
   agmsg_terminal_enumerate
 }
 
-# These two adapters are intentionally fail-closed until the instance-aware
-# label reader and compare-and-poke ABI land. Neither may be emulated by loading
-# a driver against the leader's environment: two terminal instances routinely
-# contain the same bare pane id.
+# These adapters are intentionally fail-closed until the instance-aware process
+# observer, label reader and compare-and-poke ABI land. None may be emulated by
+# loading a driver against the leader's environment: two terminal instances
+# routinely contain the same bare pane id.
+_agmsg_sweep_process_at() { return 127; }     # <kind> <instance> <pane>
 _agmsg_sweep_label_at() { return 127; }       # <kind> <instance> <pane>
 _agmsg_sweep_poke_fenced() { return 127; }    # <kind> <instance> <pane> <owner> <text>
 _agmsg_sweep_instance_allowed() { return 127; } # <team> <kind> <instance>
@@ -69,13 +70,14 @@ _agmsg_sweep_quote_arg() {   # <value>
   printf "'%s'" "$escaped"
 }
 
-# Consume #1155 rows:
-#   kind<TAB>instance<TAB>pane<TAB>state<TAB>payload
-# plus its ! / !! / ? hole rows. Every row that is not a complete, corroborated
-# agent candidate is loud and makes the command non-zero.
+# Consume #1155's (kind, instance, pane) census plus its ! / !! / ? hole rows.
+# Process state is a separate observation made against that exact triple; the
+# census never grows sweep-only classification fields. Every row that is not a
+# complete, corroborated agent candidate is loud and makes the command non-zero.
 agmsg_sweep_run() {   # <team>
   local team="${1-}" rows rows_rc=0 rc=0 tab line
-  local kind instance pane state payload extra label label_rc agent owner ref locator_rc text poke_rc
+  local kind instance pane census_extra process process_rc state payload process_extra
+  local label label_rc agent owner ref locator_rc text poke_rc
   [ -n "$team" ] || { echo 'sweep: team is required' >&2; return 2; }
   tab="$(printf '\t')"
 
@@ -87,10 +89,10 @@ agmsg_sweep_run() {   # <team>
 
   while IFS= read -r line; do
     [ -n "$line" ] || continue
-    IFS="$tab" read -r kind instance pane state payload extra <<EOF
+    IFS="$tab" read -r kind instance pane census_extra <<EOF
 $line
 EOF
-    if [ -n "${extra:-}" ]; then
+    if [ -n "${census_extra:-}" ]; then
       _agmsg_sweep_report_skip "${kind:-?}" "${instance:-?}" "${pane:-?}" malformed_row
       rc=1
       continue
@@ -102,9 +104,25 @@ EOF
         continue
         ;;
     esac
-    if [ -z "${kind:-}" ] || [ -z "${instance:-}" ] || [ -z "${pane:-}" ] \
-       || [ -z "${state:-}" ]; then
+    if [ -z "${kind:-}" ] || [ -z "${instance:-}" ] || [ -z "${pane:-}" ]; then
       _agmsg_sweep_report_skip "${kind:-?}" "${instance:-?}" "${pane:-?}" malformed_row
+      rc=1
+      continue
+    fi
+
+    process=""; process_rc=0
+    process="$(_agmsg_sweep_process_at "$kind" "$instance" "$pane" 2>/dev/null)" || process_rc=$?
+    if [ "$process_rc" -ne 0 ] || [ -z "$process" ]; then
+      _agmsg_sweep_report_skip "$kind" "$instance" "$pane" "process_unavailable:rc_$process_rc"
+      rc=1
+      continue
+    fi
+    state=""; payload=""; process_extra=""
+    IFS="$tab" read -r state payload process_extra <<EOF
+$process
+EOF
+    if [ -n "${process_extra:-}" ]; then
+      _agmsg_sweep_report_skip "$kind" "$instance" "$pane" malformed_process_observation
       rc=1
       continue
     fi

--- a/scripts/sweep.sh
+++ b/scripts/sweep.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Explicit leader-side fan-out. Nothing sources or invokes this entry point
+# automatically; running it is the operator's blast-radius decision.
+
+if [ "$#" -ne 1 ]; then
+  echo 'Usage: sweep.sh <team>' >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEAM="$1"
+
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/validate.sh"
+agmsg_validate_team_name "$TEAM" || exit 1
+[ -r "$SKILL_DIR/teams/$TEAM/config.json" ] \
+  || { echo "sweep: team not found: $TEAM" >&2; exit 1; }
+
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/terminal-registry.sh"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/sweep.sh"
+
+agmsg_sweep_run "$TEAM"

--- a/tests/test_sweep.bats
+++ b/tests/test_sweep.bats
@@ -96,3 +96,9 @@ _run_sweep_fixture() {   # <rows>
   [ "$output" = 'Usage: sweep.sh <team>' ]
   refute rg -n 'sweep\.sh|agmsg_sweep_run' "$SCRIPTS"/join.sh "$SCRIPTS"/team.sh "$SCRIPTS"/watch.sh "$SCRIPTS"/session-start.sh
 }
+
+@test "skill exposes sweep only as an explicit team-scoped action (#1152)" {
+  grep -Fq 'If argument starts with "sweep" followed by a team name:' "$BATS_TEST_DIRNAME/../SKILL.md"
+  grep -Fq 'scripts/sweep.sh <team>' "$BATS_TEST_DIRNAME/../SKILL.md"
+  grep -Fq 'Never run it from inbox delivery' "$BATS_TEST_DIRNAME/../SKILL.md"
+}

--- a/tests/test_sweep.bats
+++ b/tests/test_sweep.bats
@@ -20,11 +20,16 @@ _run_sweep_fixture() {   # <rows>
     _agmsg_sweep_instance_allowed() {
       [ "$2:$3" != "herdr:/run/oma.sock" ]
     }
+    _agmsg_sweep_locator() {
+      case "$2" in *:*) return 2 ;; esac
+      printf "%s:%s:%s\n" "$1" "$2" "$3"
+    }
     _agmsg_sweep_label_at() {
       case "$1:$2:$3" in
         herdr:/run/jugemu.sock:w1:p7) printf "alpha:alice\n" ;;
         tmux:/tmp/tmux-a:%4) printf "alpha:bob\n" ;;
         "tmux:/tmp/server with space:%4") printf "alpha:bob\n" ;;
+        tmux:/tmp/server:alternate:%4) printf "alpha:bob\n" ;;
         plain:iterm:/dev/ttys040) printf "alpha:alice\n" ;;
         *) return 1 ;;
       esac
@@ -74,6 +79,13 @@ _run_sweep_fixture() {   # <rows>
   grep -Fqx $'tmux\t/tmp/server with space\t%4\talpha/bob\t$agmsg fix --pane '\''tmux:/tmp/server with space:%4'\''' "$BATS_TEST_TMPDIR/pokes"
 }
 
+@test "an unrepresentable colon in an instance is loud and writes nothing (#1152)" {
+  _run_sweep_fixture $'tmux\t/tmp/server:alternate\t%4\tagent\tcodex'
+  [ "$status" -eq 1 ]
+  [ ! -e "$BATS_TEST_TMPDIR/pokes" ]
+  grep -Fq 'reason=locator_unavailable:rc_2' <<< "$output"
+}
+
 @test "fence refusal is loud and does not report a send (#1152)" {
   run bash -c '
     set -u
@@ -81,6 +93,7 @@ _run_sweep_fixture() {   # <rows>
     . "$SCRIPTS/lib/sweep.sh"
     _agmsg_sweep_agent_rows() { printf "herdr\t/run/jugemu.sock\tw1:p7\tagent\tclaude-code\n"; }
     _agmsg_sweep_instance_allowed() { return 0; }
+    _agmsg_sweep_locator() { printf "%s:%s:%s\n" "$1" "$2" "$3"; }
     _agmsg_sweep_label_at() { printf "alpha:alice\n"; }
     _agmsg_sweep_poke_fenced() { return 12; }
     agmsg_sweep_run alpha

--- a/tests/test_sweep.bats
+++ b/tests/test_sweep.bats
@@ -8,6 +8,20 @@ setup() {
   bash "$SCRIPTS/join.sh" alpha bob codex /tmp/b >/dev/null
 }
 
+@test "census seam delegates to the shared terminal enumeration primitive" {
+  run bash -c '
+    unset _AGMSG_SWEEP_SH
+    source "$1/lib/sweep.sh"
+    agmsg_terminal_enumerate() {
+      printf "herdr\t/run/jugemu.sock\tw1:p7\n"
+    }
+    _agmsg_sweep_agent_rows
+  ' _ "$SCRIPTS"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = $'herdr\t/run/jugemu.sock\tw1:p7' ]
+}
+
 teardown() { teardown_test_env; }
 
 _run_sweep_fixture() {   # <rows>

--- a/tests/test_sweep.bats
+++ b/tests/test_sweep.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_test_env
+  bash "$SCRIPTS/join.sh" alpha alice claude-code /tmp/a >/dev/null
+  bash "$SCRIPTS/join.sh" alpha bob codex /tmp/b >/dev/null
+}
+
+teardown() { teardown_test_env; }
+
+_run_sweep_fixture() {   # <rows>
+  local rows="$1"
+  run bash -c '
+    set -u
+    SCRIPTS=$1; SKILL_DIR=$2; ROWS=$3; LOG=$4
+    . "$SCRIPTS/lib/sweep.sh"
+    _agmsg_sweep_agent_rows() { printf "%s\n" "$ROWS"; }
+    _agmsg_sweep_instance_allowed() {
+      [ "$2:$3" != "herdr:/run/oma.sock" ]
+    }
+    _agmsg_sweep_label_at() {
+      case "$1:$2:$3" in
+        herdr:/run/jugemu.sock:w1:p7) printf "alpha:alice\n" ;;
+        tmux:/tmp/tmux-a:%4) printf "alpha:bob\n" ;;
+        plain:iterm:/dev/ttys040) printf "alpha:alice\n" ;;
+        *) return 1 ;;
+      esac
+    }
+    _agmsg_sweep_poke_fenced() {
+      printf "%s\t%s\t%s\t%s\t%s\n" "$1" "$2" "$3" "$4" "$5" >> "$LOG"
+    }
+    agmsg_sweep_run alpha
+  ' _ "$SCRIPTS" "$TEST_SKILL_DIR" "$rows" "$BATS_TEST_TMPDIR/pokes"
+}
+
+@test "sweep makes the poke target and fix ref from the same complete row (#1152)" {
+  _run_sweep_fixture $'herdr\t/run/jugemu.sock\tw1:p7\tagent\tclaude-code\ntmux\t/tmp/tmux-a\t%4\tagent\tcodex'
+  [ "$status" -eq 0 ]
+  grep -Fqx $'herdr\t/run/jugemu.sock\tw1:p7\talpha/alice\t$agmsg fix --pane herdr:/run/jugemu.sock:w1:p7' "$BATS_TEST_TMPDIR/pokes"
+  grep -Fqx $'tmux\t/tmp/tmux-a\t%4\talpha/bob\t$agmsg fix --pane tmux:/tmp/tmux-a:%4' "$BATS_TEST_TMPDIR/pokes"
+}
+
+@test "same bare pane in two instances cannot cross target and body (#1152)" {
+  _run_sweep_fixture $'herdr\t/run/jugemu.sock\tw1:p7\tagent\tclaude-code\nherdr\t/run/oma.sock\tw1:p7\tagent\tclaude-code'
+  [ "$status" -eq 1 ]
+  [ "$(wc -l < "$BATS_TEST_TMPDIR/pokes" | tr -d ' ')" -eq 1 ]
+  grep -Fqx $'herdr\t/run/jugemu.sock\tw1:p7\talpha/alice\t$agmsg fix --pane herdr:/run/jugemu.sock:w1:p7' "$BATS_TEST_TMPDIR/pokes"
+  refute grep -Fq '/run/oma.sock' "$BATS_TEST_TMPDIR/pokes"
+}
+
+@test "none unknown holes malformed rows and label mismatch are loud and never poked (#1152)" {
+  _run_sweep_fixture $'herdr\t/run/jugemu.sock\tw1:p1\tnone\t\nherdr\t/run/jugemu.sock\tw1:p2\tunknown\twalk_incomplete\n!\therdr\t/run/bad.sock\n!!\ttmux\n?\tplain\nherdr\t/run/jugemu.sock\tw1:p3\tagent\tcodex\textra\nherdr\t/run/jugemu.sock\tw1:p7\tagent\tcodex'
+  [ "$status" -eq 1 ]
+  [ ! -e "$BATS_TEST_TMPDIR/pokes" ]
+  grep -Fq 'reason=none' <<< "$output"
+  grep -Fq 'reason=unknown:walk_incomplete' <<< "$output"
+  grep -Fq 'reason=enumeration_hole' <<< "$output"
+  grep -Fq 'reason=malformed_row' <<< "$output"
+  grep -Fq 'reason=roster_label_process_mismatch' <<< "$output"
+}
+
+@test "plain emulator target uses the same fenced path as pane terminals (#1152)" {
+  _run_sweep_fixture $'plain\titerm\t/dev/ttys040\tagent\tclaude-code'
+  [ "$status" -eq 0 ]
+  grep -Fqx $'plain\titerm\t/dev/ttys040\talpha/alice\t$agmsg fix --pane plain:iterm:/dev/ttys040' "$BATS_TEST_TMPDIR/pokes"
+}
+
+@test "fence refusal is loud and does not report a send (#1152)" {
+  run bash -c '
+    set -u
+    SCRIPTS=$1; SKILL_DIR=$2
+    . "$SCRIPTS/lib/sweep.sh"
+    _agmsg_sweep_agent_rows() { printf "herdr\t/run/jugemu.sock\tw1:p7\tagent\tclaude-code\n"; }
+    _agmsg_sweep_instance_allowed() { return 0; }
+    _agmsg_sweep_label_at() { printf "alpha:alice\n"; }
+    _agmsg_sweep_poke_fenced() { return 12; }
+    agmsg_sweep_run alpha
+  ' _ "$SCRIPTS" "$TEST_SKILL_DIR"
+  [ "$status" -eq 1 ]
+  grep -Fq 'reason=write_fence_or_poke_failed:rc_12' <<< "$output"
+  refute grep -Fq 'sent team=' <<< "$output"
+}
+
+@test "entry point requires an explicit team and never sweeps from another command (#1152)" {
+  run bash "$SCRIPTS/sweep.sh"
+  [ "$status" -eq 2 ]
+  [ "$output" = 'Usage: sweep.sh <team>' ]
+  refute rg -n 'sweep\.sh|agmsg_sweep_run' "$SCRIPTS"/join.sh "$SCRIPTS"/team.sh "$SCRIPTS"/watch.sh "$SCRIPTS"/session-start.sh
+}

--- a/tests/test_sweep.bats
+++ b/tests/test_sweep.bats
@@ -22,6 +22,23 @@ setup() {
   [ "$output" = $'herdr\t/run/jugemu.sock\tw1:p7' ]
 }
 
+@test "missing SKILL_DIR is a named refusal and writes nothing" {
+  run bash -c '
+    unset _AGMSG_SWEEP_SH SKILL_DIR
+    source "$1/lib/sweep.sh"
+    _agmsg_sweep_agent_rows() { printf "herdr\t/run/jugemu.sock\tw1:p7\n"; }
+    _agmsg_sweep_process_at() { printf "agent\tclaude-code\n"; }
+    _agmsg_sweep_instance_allowed() { return 0; }
+    _agmsg_sweep_label_at() { printf "alpha:alice\n"; }
+    _agmsg_sweep_poke_fenced() { printf written >> "$2"; }
+    agmsg_sweep_run alpha
+  ' _ "$SCRIPTS" "$BATS_TEST_TMPDIR/pokes"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'sweep: skill_dir_unavailable; nothing was written'* ]]
+  [ ! -e "$BATS_TEST_TMPDIR/pokes" ]
+}
+
 teardown() { teardown_test_env; }
 
 _run_sweep_fixture() {   # <rows>

--- a/tests/test_sweep.bats
+++ b/tests/test_sweep.bats
@@ -18,7 +18,7 @@ setup() {
     _agmsg_sweep_agent_rows
   ' _ "$SCRIPTS"
 
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 0 ] || return 1
   [ "$output" = $'herdr\t/run/jugemu.sock\tw1:p7' ]
 }
 
@@ -34,8 +34,8 @@ setup() {
     agmsg_sweep_run alpha
   ' _ "$SCRIPTS" "$BATS_TEST_TMPDIR/pokes"
 
-  [ "$status" -eq 1 ]
-  [[ "$output" == *'sweep: skill_dir_unavailable; nothing was written'* ]]
+  [ "$status" -eq 1 ] || return 1
+  [[ "$output" == *'sweep: skill_dir_unavailable; nothing was written'* ]] || return 1
   [ ! -e "$BATS_TEST_TMPDIR/pokes" ]
 }
 
@@ -89,48 +89,48 @@ _run_sweep_fixture() {   # <rows>
 
 @test "sweep makes the poke target and fix ref from the same complete row (#1152)" {
   _run_sweep_fixture $'herdr\t/run/jugemu.sock\tw1:p7\tagent\tclaude-code\ntmux\t/tmp/tmux-a\t%4\tagent\tcodex'
-  [ "$status" -eq 0 ]
-  grep -Fqx $'herdr\t/run/jugemu.sock\tw1:p7\talpha/alice\t$agmsg fix --pane '\''herdr:/run/jugemu.sock:w1:p7'\''' "$BATS_TEST_TMPDIR/pokes"
+  [ "$status" -eq 0 ] || return 1
+  grep -Fqx $'herdr\t/run/jugemu.sock\tw1:p7\talpha/alice\t$agmsg fix --pane '\''herdr:/run/jugemu.sock:w1:p7'\''' "$BATS_TEST_TMPDIR/pokes" || return 1
   grep -Fqx $'tmux\t/tmp/tmux-a\t%4\talpha/bob\t$agmsg fix --pane '\''tmux:/tmp/tmux-a:%4'\''' "$BATS_TEST_TMPDIR/pokes"
 }
 
 @test "same bare pane in two instances cannot cross target and body (#1152)" {
   _run_sweep_fixture $'herdr\t/run/jugemu.sock\tw1:p7\tagent\tclaude-code\nherdr\t/run/oma.sock\tw1:p7\tagent\tclaude-code'
-  [ "$status" -eq 1 ]
-  [ "$(wc -l < "$BATS_TEST_TMPDIR/pokes" | tr -d ' ')" -eq 1 ]
-  grep -Fqx $'herdr\t/run/jugemu.sock\tw1:p7\talpha/alice\t$agmsg fix --pane '\''herdr:/run/jugemu.sock:w1:p7'\''' "$BATS_TEST_TMPDIR/pokes"
+  [ "$status" -eq 1 ] || return 1
+  [ "$(wc -l < "$BATS_TEST_TMPDIR/pokes" | tr -d ' ')" -eq 1 ] || return 1
+  grep -Fqx $'herdr\t/run/jugemu.sock\tw1:p7\talpha/alice\t$agmsg fix --pane '\''herdr:/run/jugemu.sock:w1:p7'\''' "$BATS_TEST_TMPDIR/pokes" || return 1
   refute grep -Fq '/run/oma.sock' "$BATS_TEST_TMPDIR/pokes"
 }
 
 @test "none unknown holes malformed rows and label mismatch are loud and never poked (#1152)" {
   _run_sweep_fixture $'herdr\t/run/jugemu.sock\tw1:p1\tnone\t\nherdr\t/run/jugemu.sock\tw1:p2\tunknown\twalk_incomplete\n!\therdr\t/run/bad.sock\n!!\ttmux\n?\tplain\nbroken\trow\nherdr\t/run/jugemu.sock\tw1:p3\tagent\tcodex\textra\nherdr\t/run/jugemu.sock\tw1:p7\tagent\tcodex'
-  [ "$status" -eq 1 ]
-  [ ! -e "$BATS_TEST_TMPDIR/pokes" ]
-  grep -Fq 'reason=none' <<< "$output"
-  grep -Fq 'reason=unknown:walk_incomplete' <<< "$output"
-  grep -Fq 'reason=enumeration_hole' <<< "$output"
-  grep -Fq 'reason=malformed_row' <<< "$output"
-  grep -Fq 'reason=malformed_process_observation' <<< "$output"
+  [ "$status" -eq 1 ] || return 1
+  [ ! -e "$BATS_TEST_TMPDIR/pokes" ] || return 1
+  grep -Fq 'reason=none' <<< "$output" || return 1
+  grep -Fq 'reason=unknown:walk_incomplete' <<< "$output" || return 1
+  grep -Fq 'reason=enumeration_hole' <<< "$output" || return 1
+  grep -Fq 'reason=malformed_row' <<< "$output" || return 1
+  grep -Fq 'reason=malformed_process_observation' <<< "$output" || return 1
   grep -Fq 'reason=roster_label_process_mismatch' <<< "$output"
 }
 
 @test "plain emulator target uses the same fenced path as pane terminals (#1152)" {
   _run_sweep_fixture $'plain\titerm\t/dev/ttys040\tagent\tclaude-code'
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 0 ] || return 1
   grep -Fqx $'plain\titerm\t/dev/ttys040\talpha/alice\t$agmsg fix --pane '\''plain:iterm:/dev/ttys040'\''' "$BATS_TEST_TMPDIR/pokes"
 }
 
 @test "instance paths with spaces stay one quoted fix argument (#1152)" {
   _run_sweep_fixture $'tmux\t/tmp/server with space\t%4\tagent\tcodex'
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 0 ] || return 1
   grep -Fqx $'tmux\t/tmp/server with space\t%4\talpha/bob\t$agmsg fix --pane '\''tmux:/tmp/server with space:%4'\''' "$BATS_TEST_TMPDIR/pokes"
 }
 
 @test "an unrepresentable colon in an instance is loud and writes nothing (#1152)" {
   _run_sweep_fixture $'tmux\t/tmp/server:alternate\t%4\tagent\tcodex'
-  [ "$status" -eq 1 ]
-  [ ! -e "$BATS_TEST_TMPDIR/pokes" ]
-  grep -Fq 'instance_malformed' <<< "$output"
+  [ "$status" -eq 1 ] || return 1
+  [ ! -e "$BATS_TEST_TMPDIR/pokes" ] || return 1
+  grep -Fq 'instance_malformed' <<< "$output" || return 1
   grep -Fq 'reason=locator_unavailable:rc_2' <<< "$output"
 }
 
@@ -147,37 +147,42 @@ _run_sweep_fixture() {   # <rows>
     _agmsg_sweep_poke_fenced() { return 12; }
     agmsg_sweep_run alpha
   ' _ "$SCRIPTS" "$TEST_SKILL_DIR"
-  [ "$status" -eq 1 ]
-  grep -Fq 'reason=write_fence_or_poke_failed:rc_12' <<< "$output"
+  [ "$status" -eq 1 ] || return 1
+  grep -Fq 'reason=write_fence_or_poke_failed:rc_12' <<< "$output" || return 1
   refute grep -Fq 'sent team=' <<< "$output"
 }
 
 @test "entry point requires an explicit team and never sweeps from another command (#1152)" {
   run bash "$SCRIPTS/sweep.sh"
-  [ "$status" -eq 2 ]
-  [ "$output" = 'Usage: sweep.sh <team>' ]
+  [ "$status" -eq 2 ] || return 1
+  [ "$output" = 'Usage: sweep.sh <team>' ] || return 1
   refute rg -n 'sweep\.sh|agmsg_sweep_run' "$SCRIPTS"/join.sh "$SCRIPTS"/team.sh "$SCRIPTS"/watch.sh "$SCRIPTS"/session-start.sh
 }
 
 @test "skill exposes sweep only as an explicit team-scoped action (#1152)" {
-  grep -Fq 'If argument starts with "sweep" followed by a team name:' "$BATS_TEST_DIRNAME/../SKILL.md"
-  grep -Fq 'scripts/sweep.sh <team>' "$BATS_TEST_DIRNAME/../SKILL.md"
+  grep -Fq 'If argument starts with "sweep" followed by a team name:' "$BATS_TEST_DIRNAME/../SKILL.md" || return 1
+  grep -Fq 'scripts/sweep.sh <team>' "$BATS_TEST_DIRNAME/../SKILL.md" || return 1
   grep -Fq 'Never run it from inbox delivery' "$BATS_TEST_DIRNAME/../SKILL.md"
 }
 
 @test "locator adapter uses the shared registry composer (#1152, #1168)" {
-  export SKILL_DIR="$TEST_SKILL_DIR"
-  # shellcheck disable=SC1090
-  source "$SCRIPTS/lib/terminal-registry.sh"
-  declare -F agmsg_locator_compose >/dev/null 2>&1 || skip "#1168 not in this base yet"
-  # shellcheck disable=SC1090
-  source "$SCRIPTS/lib/sweep.sh"
+  run bash -c '
+    unset _AGMSG_TERMINAL_REGISTRY_SH _AGMSG_SWEEP_SH
+    SKILL_DIR=$1
+    source "$1/scripts/lib/terminal-registry.sh"
+    source "$1/scripts/lib/sweep.sh"
+    _agmsg_sweep_locator herdr "/run/path with space/herdr.sock" w1:p7
+  ' _ "$TEST_SKILL_DIR"
+  [ "$status" -eq 0 ] || return 1
+  [ "$output" = "herdr:/run/path with space/herdr.sock:w1:p7" ] || return 1
 
-  run _agmsg_sweep_locator herdr "/run/path with space/herdr.sock" w1:p7
-  [ "$status" -eq 0 ]
-  [ "$output" = "herdr:/run/path with space/herdr.sock:w1:p7" ]
-
-  run _agmsg_sweep_locator herdr "/run/path:alternate/herdr.sock" w1:p7
-  [ "$status" -eq 2 ]
+  run bash -c '
+    unset _AGMSG_TERMINAL_REGISTRY_SH _AGMSG_SWEEP_SH
+    SKILL_DIR=$1
+    source "$1/scripts/lib/terminal-registry.sh"
+    source "$1/scripts/lib/sweep.sh"
+    _agmsg_sweep_locator herdr "/run/path:alternate/herdr.sock" w1:p7
+  ' _ "$TEST_SKILL_DIR"
+  [ "$status" -eq 2 ] || return 1
   [ "$output" = "agmsg: locator: instance_malformed" ]
 }

--- a/tests/test_sweep.bats
+++ b/tests/test_sweep.bats
@@ -116,3 +116,20 @@ _run_sweep_fixture() {   # <rows>
   grep -Fq 'scripts/sweep.sh <team>' "$BATS_TEST_DIRNAME/../SKILL.md"
   grep -Fq 'Never run it from inbox delivery' "$BATS_TEST_DIRNAME/../SKILL.md"
 }
+
+@test "locator adapter uses the shared registry composer (#1152, #1168)" {
+  export SKILL_DIR="$TEST_SKILL_DIR"
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/terminal-registry.sh"
+  declare -F agmsg_locator_compose >/dev/null 2>&1 || skip "#1168 not in this base yet"
+  # shellcheck disable=SC1090
+  source "$SCRIPTS/lib/sweep.sh"
+
+  run _agmsg_sweep_locator herdr "/run/path with space/herdr.sock" w1:p7
+  [ "$status" -eq 0 ]
+  [ "$output" = "herdr:/run/path with space/herdr.sock:w1:p7" ]
+
+  run _agmsg_sweep_locator herdr "/run/path:alternate/herdr.sock" w1:p7
+  [ "$status" -eq 2 ]
+  [ "$output" = "agmsg: locator: instance_malformed" ]
+}

--- a/tests/test_sweep.bats
+++ b/tests/test_sweep.bats
@@ -21,7 +21,7 @@ _run_sweep_fixture() {   # <rows>
       [ "$2:$3" != "herdr:/run/oma.sock" ]
     }
     _agmsg_sweep_locator() {
-      case "$2" in *:*) return 2 ;; esac
+      case "$2" in *:*) echo instance_malformed >&2; return 2 ;; esac
       printf "%s:%s:%s\n" "$1" "$2" "$3"
     }
     _agmsg_sweep_label_at() {
@@ -83,6 +83,7 @@ _run_sweep_fixture() {   # <rows>
   _run_sweep_fixture $'tmux\t/tmp/server:alternate\t%4\tagent\tcodex'
   [ "$status" -eq 1 ]
   [ ! -e "$BATS_TEST_TMPDIR/pokes" ]
+  grep -Fq 'instance_malformed' <<< "$output"
   grep -Fq 'reason=locator_unavailable:rc_2' <<< "$output"
 }
 

--- a/tests/test_sweep.bats
+++ b/tests/test_sweep.bats
@@ -24,6 +24,7 @@ _run_sweep_fixture() {   # <rows>
       case "$1:$2:$3" in
         herdr:/run/jugemu.sock:w1:p7) printf "alpha:alice\n" ;;
         tmux:/tmp/tmux-a:%4) printf "alpha:bob\n" ;;
+        "tmux:/tmp/server with space:%4") printf "alpha:bob\n" ;;
         plain:iterm:/dev/ttys040) printf "alpha:alice\n" ;;
         *) return 1 ;;
       esac
@@ -38,15 +39,15 @@ _run_sweep_fixture() {   # <rows>
 @test "sweep makes the poke target and fix ref from the same complete row (#1152)" {
   _run_sweep_fixture $'herdr\t/run/jugemu.sock\tw1:p7\tagent\tclaude-code\ntmux\t/tmp/tmux-a\t%4\tagent\tcodex'
   [ "$status" -eq 0 ]
-  grep -Fqx $'herdr\t/run/jugemu.sock\tw1:p7\talpha/alice\t$agmsg fix --pane herdr:/run/jugemu.sock:w1:p7' "$BATS_TEST_TMPDIR/pokes"
-  grep -Fqx $'tmux\t/tmp/tmux-a\t%4\talpha/bob\t$agmsg fix --pane tmux:/tmp/tmux-a:%4' "$BATS_TEST_TMPDIR/pokes"
+  grep -Fqx $'herdr\t/run/jugemu.sock\tw1:p7\talpha/alice\t$agmsg fix --pane '\''herdr:/run/jugemu.sock:w1:p7'\''' "$BATS_TEST_TMPDIR/pokes"
+  grep -Fqx $'tmux\t/tmp/tmux-a\t%4\talpha/bob\t$agmsg fix --pane '\''tmux:/tmp/tmux-a:%4'\''' "$BATS_TEST_TMPDIR/pokes"
 }
 
 @test "same bare pane in two instances cannot cross target and body (#1152)" {
   _run_sweep_fixture $'herdr\t/run/jugemu.sock\tw1:p7\tagent\tclaude-code\nherdr\t/run/oma.sock\tw1:p7\tagent\tclaude-code'
   [ "$status" -eq 1 ]
   [ "$(wc -l < "$BATS_TEST_TMPDIR/pokes" | tr -d ' ')" -eq 1 ]
-  grep -Fqx $'herdr\t/run/jugemu.sock\tw1:p7\talpha/alice\t$agmsg fix --pane herdr:/run/jugemu.sock:w1:p7' "$BATS_TEST_TMPDIR/pokes"
+  grep -Fqx $'herdr\t/run/jugemu.sock\tw1:p7\talpha/alice\t$agmsg fix --pane '\''herdr:/run/jugemu.sock:w1:p7'\''' "$BATS_TEST_TMPDIR/pokes"
   refute grep -Fq '/run/oma.sock' "$BATS_TEST_TMPDIR/pokes"
 }
 
@@ -64,7 +65,13 @@ _run_sweep_fixture() {   # <rows>
 @test "plain emulator target uses the same fenced path as pane terminals (#1152)" {
   _run_sweep_fixture $'plain\titerm\t/dev/ttys040\tagent\tclaude-code'
   [ "$status" -eq 0 ]
-  grep -Fqx $'plain\titerm\t/dev/ttys040\talpha/alice\t$agmsg fix --pane plain:iterm:/dev/ttys040' "$BATS_TEST_TMPDIR/pokes"
+  grep -Fqx $'plain\titerm\t/dev/ttys040\talpha/alice\t$agmsg fix --pane '\''plain:iterm:/dev/ttys040'\''' "$BATS_TEST_TMPDIR/pokes"
+}
+
+@test "instance paths with spaces stay one quoted fix argument (#1152)" {
+  _run_sweep_fixture $'tmux\t/tmp/server with space\t%4\tagent\tcodex'
+  [ "$status" -eq 0 ]
+  grep -Fqx $'tmux\t/tmp/server with space\t%4\talpha/bob\t$agmsg fix --pane '\''tmux:/tmp/server with space:%4'\''' "$BATS_TEST_TMPDIR/pokes"
 }
 
 @test "fence refusal is loud and does not report a send (#1152)" {

--- a/tests/test_sweep.bats
+++ b/tests/test_sweep.bats
@@ -30,7 +30,22 @@ _run_sweep_fixture() {   # <rows>
     set -u
     SCRIPTS=$1; SKILL_DIR=$2; ROWS=$3; LOG=$4
     . "$SCRIPTS/lib/sweep.sh"
-    _agmsg_sweep_agent_rows() { printf "%s\n" "$ROWS"; }
+    _agmsg_sweep_agent_rows() {
+      printf "%s\n" "$ROWS" | awk -F "\t" '\''
+        $1 == "!" || $1 == "!!" || $1 == "?" { print; next }
+        { print $1 "\t" $2 "\t" $3 }
+      '\''
+    }
+    _agmsg_sweep_process_at() {
+      printf "%s\n" "$ROWS" | awk -F "\t" -v kind="$1" -v instance="$2" -v pane="$3" '\''
+        $1 == kind && $2 == instance && $3 == pane {
+          out = $4
+          for (i = 5; i <= NF; i++) out = out "\t" $i
+          print out
+          exit
+        }
+      '\''
+    }
     _agmsg_sweep_instance_allowed() {
       [ "$2:$3" != "herdr:/run/oma.sock" ]
     }
@@ -71,13 +86,14 @@ _run_sweep_fixture() {   # <rows>
 }
 
 @test "none unknown holes malformed rows and label mismatch are loud and never poked (#1152)" {
-  _run_sweep_fixture $'herdr\t/run/jugemu.sock\tw1:p1\tnone\t\nherdr\t/run/jugemu.sock\tw1:p2\tunknown\twalk_incomplete\n!\therdr\t/run/bad.sock\n!!\ttmux\n?\tplain\nherdr\t/run/jugemu.sock\tw1:p3\tagent\tcodex\textra\nherdr\t/run/jugemu.sock\tw1:p7\tagent\tcodex'
+  _run_sweep_fixture $'herdr\t/run/jugemu.sock\tw1:p1\tnone\t\nherdr\t/run/jugemu.sock\tw1:p2\tunknown\twalk_incomplete\n!\therdr\t/run/bad.sock\n!!\ttmux\n?\tplain\nbroken\trow\nherdr\t/run/jugemu.sock\tw1:p3\tagent\tcodex\textra\nherdr\t/run/jugemu.sock\tw1:p7\tagent\tcodex'
   [ "$status" -eq 1 ]
   [ ! -e "$BATS_TEST_TMPDIR/pokes" ]
   grep -Fq 'reason=none' <<< "$output"
   grep -Fq 'reason=unknown:walk_incomplete' <<< "$output"
   grep -Fq 'reason=enumeration_hole' <<< "$output"
   grep -Fq 'reason=malformed_row' <<< "$output"
+  grep -Fq 'reason=malformed_process_observation' <<< "$output"
   grep -Fq 'reason=roster_label_process_mismatch' <<< "$output"
 }
 
@@ -106,7 +122,8 @@ _run_sweep_fixture() {   # <rows>
     set -u
     SCRIPTS=$1; SKILL_DIR=$2
     . "$SCRIPTS/lib/sweep.sh"
-    _agmsg_sweep_agent_rows() { printf "herdr\t/run/jugemu.sock\tw1:p7\tagent\tclaude-code\n"; }
+    _agmsg_sweep_agent_rows() { printf "herdr\t/run/jugemu.sock\tw1:p7\n"; }
+    _agmsg_sweep_process_at() { printf "agent\tclaude-code\n"; }
     _agmsg_sweep_instance_allowed() { return 0; }
     _agmsg_sweep_locator() { printf "%s:%s:%s\n" "$1" "$2" "$3"; }
     _agmsg_sweep_label_at() { printf "alpha:alice\n"; }


### PR DESCRIPTION
Adds the explicit, team-scoped leader sweep command for #1152. It consumes the shared terminal census as `(kind, instance, pane)` triples, keeps process classification outside the census, requires roster/label/process agreement, composes the target and `fix --pane` argument once from the same row, and routes every write through one fenced poke boundary.

The command is intentionally explicit-only and fail-closed: census holes, malformed observations, unknown occupants, instance refusals, locator refusals, label mismatches, and fence failures are loud and produce no write. Plain emulator locations use the same loop and fence boundary as herdr and tmux.

The shared census and locator composer are connected. The instance-aware label/process/write-fence production adapters remain rc 127 until #1157 supplies their ABI; tests replace only those internal seams and pin zero-write behavior. This PR remains draft until that final wiring lands.

Tests: `bats tests/test_sweep.bats`; `bats tests/test_sweep_enumeration.bats`; `bats tests/test_enforced_assertions.bats`; `bash -n scripts/lib/sweep.sh`; `git diff --check`.