### PR TITLE
Default the test harness to AGMSG_SELF_NAME=off, with the regression control (#1095)

### DIFF
--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -3638,6 +3638,12 @@ EOF
 # Naming is an invariant re-asserted at every entry point, not an assignment made
 # once somewhere — measured across the nine types, no single place covers them.
 @test "check-inbox: names this pane on the way through (#1044)" {
+  # This test's whole subject is the naming primitive firing, exercised
+  # against a fake tmux on $FAKEBIN -- never a real terminal -- so it opts
+  # back into the primitive's own default (on) rather than the harness's
+  # #1095 off (test_helper.bash), the same way test_terminal_registry.bats
+  # already does for its own naming-focused tests.
+  unset AGMSG_SELF_NAME
   export FAKEBIN="$TEST_SKILL_DIR/fakebin" ARGV_LOG="$TEST_SKILL_DIR/argv.log"
   mkdir -p "$FAKEBIN"; : > "$ARGV_LOG"
   agmsg_install_fake_tmux
@@ -3664,6 +3670,9 @@ EOF
 # the same invocation carrying a session id, which does reach herdr and does
 # rename; the silence of the other half means something only next to it.
 @test "check-inbox: no session id names nothing; the same call with one does (#1044)" {
+  # Same reason as the sibling test above: naming itself is what this test
+  # verifies, against a fake herdr, never a real terminal.
+  unset AGMSG_SELF_NAME
   export FAKEBIN="$TEST_SKILL_DIR/fakebin" ARGV_LOG="$TEST_SKILL_DIR/argv.log"
   mkdir -p "$FAKEBIN"; : > "$ARGV_LOG"
   _fake_herdr_with_session "sess-x"

--- a/tests/test_dispatch.bats
+++ b/tests/test_dispatch.bats
@@ -201,6 +201,11 @@ teardown() {
 # pane, and must keep naming it. A stray AGMSG_SELF_NAME=off on either path turns
 # the matching half of this test red; the fake herdr logs every argv.
 @test "dispatch: join and the actas fallback name the seat's OWN pane (#1096)" {
+  # This test's whole subject is the naming primitive firing (against a fake
+  # herdr below, never a real terminal), so it opts back into the
+  # primitive's own default (on) rather than the harness's #1095 off
+  # (test_helper.bash).
+  unset AGMSG_SELF_NAME
   local proj="$BATS_TEST_TMPDIR/project-naming" log="$BATS_TEST_TMPDIR/herdr.log"
   local bin="$BATS_TEST_TMPDIR/bin"
   mkdir -p "$proj" "$bin"

--- a/tests/test_harness_self_name_off.bats
+++ b/tests/test_harness_self_name_off.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# #1095: the test harness must default every test to AGMSG_SELF_NAME=off, so a
+# naming-capable script (join.sh here — the exact script observed doing this
+# on a real machine) never touches the terminal it happens to be running in
+# with a fixture team/agent, when that terminal is inherited from a real
+# developer pane (bats runs inside whatever pane invoked it).
+#
+# The one-line default in test_helper.bash is not itself the protection --
+# a later edit could delete that line silently and nothing would say so.
+# THIS is the protection: this test deliberately does NOT set
+# AGMSG_SELF_NAME itself anywhere. It relies entirely on the harness's
+# default already being in place before its own setup() runs. If that
+# default is ever removed, join.sh's self-naming hook reaches the fake
+# terminal below, and this test goes red.
+
+load test_helper
+
+setup() {
+  setup_test_env
+  export SCRIPTS="$TEST_SKILL_DIR/scripts"
+  export FAKEBIN="$TEST_SKILL_DIR/fakebin"
+  export ARGV_LOG="$TEST_SKILL_DIR/argv.log"
+  mkdir -p "$FAKEBIN"
+  : > "$ARGV_LOG"
+  agmsg_install_fake_tmux
+  # Simulate running INSIDE a real terminal -- the exact condition #1095 was
+  # observed under. Deliberately NOT touching AGMSG_SELF_NAME here or
+  # anywhere else in this file: proving the HARNESS keeps it off is the
+  # entire point.
+  export TMUX="/tmp/sock,1,0" TMUX_PANE="%3"
+}
+
+teardown() { teardown_test_env; }
+
+@test "harness default: join.sh under a real-looking terminal touches it NOT AT ALL (#1095)" {
+  # A precondition the rest of this test depends on: confirm the harness
+  # actually set it, so a failure below is never mistaken for something else.
+  [ "${AGMSG_SELF_NAME:-}" = off ]
+  run bash "$SCRIPTS/join.sh" fixtureteam alice claude-code /tmp/project-1095
+  [ "$status" -eq 0 ]
+  # The naming hook's own terminal call is what must never happen here --
+  # not "the label came out right", which a fake could satisfy either way.
+  # Any line in this log is tmux having been asked something.
+  [ ! -s "$ARGV_LOG" ]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,6 +1,19 @@
 # Shared setup/teardown for agmsg BATS tests.
 # Each test gets an isolated skill directory with its own DB and teams.
 
+# #1095: a test that exercises join.sh/actas-claim.sh/spawn.sh/watch.sh/
+# session-start.sh/check-inbox.sh (or the two libraries under them) is, as far
+# as the self-naming primitive can tell, a seat acting -- so it names the pane
+# it is running in, with its own fixture team/agent. On a real machine that is
+# the developer's own terminal, inherited because bats runs inside it. This is
+# TOP-LEVEL, not inside setup_test_env(): `load test_helper` runs it before
+# ANY test's own setup(), so it reaches every file that loads this one,
+# including one (test_install.bats) whose own setup() never calls
+# setup_test_env. A file that deliberately exercises the switch itself
+# (test_self_name.bats, test_self_rename.bats) unsets this right after
+# loading -- that is a local, visible override, not a gap in this default.
+export AGMSG_SELF_NAME=off
+
 setup_test_env() {
   # A test never inherits the developer's terminal. The terminal drivers
   # identify "this pane" from the environment (tmux: $TMUX/$TMUX_PANE; herdr:

--- a/tests/test_self_name.bats
+++ b/tests/test_self_name.bats
@@ -33,6 +33,12 @@ setup() {
   export FAKEBIN ARGV_LOG
   # No terminal by default: each test sets the environment it wants.
   unset TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID HERDR_SOCKET_PATH
+  # This file's whole subject is the naming primitive itself, against fakes
+  # on $FAKEBIN -- never a real terminal -- so it opts back into the
+  # primitive's own default (on) rather than the harness's #1095 off
+  # (test_helper.bash). Individual tests below still set AGMSG_SELF_NAME=off
+  # locally to test the switch itself; that local set overrides this.
+  unset AGMSG_SELF_NAME
   # shellcheck disable=SC1090
   source "$SKILL_DIR/scripts/lib/self-name.sh"
 }

--- a/tests/test_spawn.bats
+++ b/tests/test_spawn.bats
@@ -1973,6 +1973,11 @@ OPS
 }
 
 @test "join: names its own pane at boot (control), and not under AGMSG_SELF_NAME=off (#1096)" {
+  # The control half needs naming ON by default (against the fake herdr
+  # below, never a real terminal) to mean anything against the off half
+  # right after it -- opt back in from the harness's #1095 off
+  # (test_helper.bash).
+  unset AGMSG_SELF_NAME
   _setup_fake_herdr
   # Control: a seat joining from its own pane names it -- key and prefixed label.
   bash "$SCRIPTS/join.sh" myteam bob claude-code "$PROJ"

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -22,6 +22,16 @@ setup() {
   : > "$ARGV_LOG"
   # A clean env baseline; individual tests opt into TMUX / HERDR_ENV.
   unset TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID HERDR_WORKSPACE_ID AGMSG_TERMINAL
+  # #1095's harness default (AGMSG_SELF_NAME=off, test_helper.bash) protects a
+  # test from touching a REAL terminal it happens to inherit -- this file's
+  # own baseline above already does that job independently (no real TMUX/HERDR
+  # ever reaches a test here; every test that wants one exports it AFTER this
+  # point, pointed at a fake on $FAKEBIN). This file's whole subject is the
+  # naming primitive itself, exercised in-process against that fake, so it
+  # opts back into the primitive's own default (on) rather than inheriting
+  # the harness's off, the same way test_self_name.bats and
+  # test_self_rename.bats already do.
+  unset AGMSG_SELF_NAME
   # shellcheck disable=SC1090
   source "$SKILL_DIR/scripts/lib/terminal-registry.sh"
 }

--- a/tests/test_watch.bats
+++ b/tests/test_watch.bats
@@ -1219,6 +1219,12 @@ STUB
 # "the watcher is usually done by now", which is a claim about the machine — the
 # reason the helpers above exist.
 @test "watch: the watcher names this session's pane (#1044)" {
+  # This test's subject is the naming primitive firing, against a fake tmux
+  # on $FAKEBIN -- never a real terminal -- so it opts back into the
+  # primitive's own default (on) rather than the harness's #1095 off
+  # (test_helper.bash), same as test_terminal_registry.bats's own naming
+  # tests.
+  unset AGMSG_SELF_NAME
   export FAKEBIN="$TEST_SKILL_DIR/fakebin" ARGV_LOG="$TEST_SKILL_DIR/argv.log"
   mkdir -p "$FAKEBIN"
   : > "$ARGV_LOG"


### PR DESCRIPTION
Fixes #1095.

`AGMSG_SELF_NAME=off` — the opt-out for a caller that must not touch a terminal at all — existed in `scripts/lib/terminal-registry.sh` (already honoured by the naming primitive itself, per the fix already landed on this branch) and worked, but nothing set it: not the harness, not CI. A test that runs `join.sh`/`actas-claim.sh`/`spawn.sh`/`watch.sh`/`session-start.sh`/`check-inbox.sh` (or the two libraries under them) is, as far as that primitive can tell, a seat acting — so it names the pane it happens to be running in, with its own fixture team/agent. On a real machine that pane is a developer's actual terminal, inherited because bats runs inside it.

## Changes

- **`tests/test_helper.bash`** now exports `AGMSG_SELF_NAME=off` at file scope (top-level, not inside `setup_test_env()`), so `load test_helper` sets it before any test's own `setup()` runs — including `test_install.bats`, whose own `setup()` never calls `setup_test_env`, and whose `join.sh` call was the exact case the issue measured (`.dotteam:alice`).
- **`tests/test_harness_self_name_off.bats`** is the control the issue's acceptance criteria and this fix's own review asked for: it deliberately never sets `AGMSG_SELF_NAME` itself anywhere, simulates running under a real-looking terminal (a fake `tmux`, `$TMUX`/`$TMUX_PANE` set), and asserts `join.sh`'s naming hook touches that terminal not at all. Verified red against a mutation that removes the harness default (checked by hand, not just by inspection).
- Six existing test files legitimately exercise the naming primitive itself against a **fake** terminal (never a real one) as their actual subject, and previously relied on the primitive's own on-by-default behavior without ever saying so. They now opt back into naming being on, the same way `test_self_rename.bats` already did:
  - `tests/test_terminal_registry.bats` — whole-file (matches its existing `TMUX`/`HERDR` env-isolation baseline)
  - `tests/test_self_name.bats` — whole-file (same reasoning; this is the file that tests the switch itself)
  - `tests/test_delivery.bats` — 2 individual tests (`#1044`)
  - `tests/test_watch.bats` — 1 individual test (`#1044`)
  - `tests/test_dispatch.bats` — 1 individual test (`#1096`)
  - `tests/test_spawn.bats` — 1 individual test (`#1096`)

  These were found by actually running every naming-adjacent suite one at a time after adding the harness default, not by inspection — the harness default is not a no-risk one-line change, it silently broke 6 tests across those files the first time it was applied.

## Verification

- `check-enforced-assertions.sh`: 626/626, baseline unchanged.
- Every test file touched or newly added run individually to completion: `test_harness_self_name_off.bats`, `test_terminal_registry.bats` (166/166), `test_delivery.bats` (198/198), `test_watch.bats` (39/39), `test_self_name.bats` (23/23), `test_self_rename.bats` (14/14, unaffected), `test_dispatch.bats` (15/15), `test_spawn.bats` (108/108), `test_peek_poke.bats` (40/40, unaffected), `test_team.bats` (95/95, unaffected).
- `bash -n tests/test_helper.bash`: OK.

Base: `integration/terminal-driver-v1` tip at branch time (`7fda4c3`).
