### PR TITLE
docs(antigravity): keep runtime instructions in English

### DIFF
--- a/scripts/drivers/types/antigravity/template.md
+++ b/scripts/drivers/types/antigravity/template.md
@@ -19,7 +19,7 @@
      Empty input means `1` (turn). Map `1`→`turn` and `2`→`off`, then run:
      `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> __AGENT_TYPE__ "$(pwd)"`
 
-     `monitor` は専用 headless bridge または `antigravity-tui-monitor.sh` を明示起動するモードです。TUI monitor中は bare `__CMD_PREFIX____SKILL_NAME__`、`inbox.sh`、`check-inbox.sh` を呼ばず、supervisor が表示する保留状態を使ってください。
+     `monitor` requires explicitly starting either the dedicated headless bridge or `antigravity-tui-monitor.sh`. While the TUI monitor is active, do not call bare `__CMD_PREFIX____SKILL_NAME__`, `inbox.sh`, or `check-inbox.sh`; use the pending state reported by the supervisor instead.
 <!-- /agmsg:slot delivery -->
 
 <!-- agmsg:slot mode -->
@@ -28,7 +28,7 @@ If argument is "mode" (no further args):
 2. Show the output to the user.
 
 If argument starts with "mode" followed by a mode name:
-1. Antigravity supports `monitor`, `turn`, and `off`; `both` is not supported. `monitor` は `antigravity-monitor.sh` または `antigravity-tui-monitor.sh` の明示起動が必要です。
+1. Antigravity supports `monitor`, `turn`, and `off`; `both` is not supported. `monitor` requires explicitly starting `antigravity-monitor.sh` or `antigravity-tui-monitor.sh`.
 2. Run: `~/.agents/skills/__SKILL_NAME__/scripts/delivery.sh set <mode> __AGENT_TYPE__ "$(pwd)"`
 
 If argument is "hook on", run `delivery.sh set turn __AGENT_TYPE__ "$(pwd)"`.
@@ -36,13 +36,13 @@ If argument is "hook off", run `delivery.sh set off __AGENT_TYPE__ "$(pwd)"`.
 <!-- /agmsg:slot mode -->
 
 <!-- agmsg:slot execute-extra -->
-まず `bash ~/.agents/skills/__SKILL_NAME__/scripts/drivers/types/antigravity/antigravity-tui-monitor.sh status --project <project> --team <team> --name <role>` を実行してください。出力が `runtime: tui-pty 未起動` なら、上の「引数なしの既定動作」以降をそのまま適用してください。それ以外に `tui-pty` を含む行があればAntigravityのTUI monitorが有効なので、**その既定動作を適用せず**、bare `__CMD_PREFIX____SKILL_NAME__`、`inbox.sh`、`check-inbox.sh` を実行しないでください。必要な状態確認はこのstatus（`tui-monitor status`）で行い、本文の再表示や既読化は行いません。TUI monitorへの受領確認は、envelope headerのbatch IDを使った `AGMSG_RECEIVED:<batch-id>` の一行です。
+First run `bash ~/.agents/skills/__SKILL_NAME__/scripts/drivers/types/antigravity/antigravity-tui-monitor.sh status --project <project> --team <team> --name <role>`. If the output reports that the `tui-pty` runtime has not started, apply the default no-argument behavior above as written. Any other line containing `tui-pty` means the Antigravity TUI monitor is active: **do not apply that default behavior**, and do not call bare `__CMD_PREFIX____SKILL_NAME__`, `inbox.sh`, or `check-inbox.sh`. Use this status command (`tui-monitor status`) for any required state checks; it neither redisplays message bodies nor marks them read. Acknowledge receipt to the TUI monitor with exactly one line, `AGMSG_RECEIVED:<batch-id>`, using the batch ID from the envelope header.
 
 If argument is "resume":
 1. Run: `~/.agents/skills/__SKILL_NAME__/scripts/antigravity-resume.sh "$(pwd)"`
 2. Show the output. This resumes only when exactly one paused Antigravity TUI is registered for the current project; zero or multiple paused TUI instances fail closed.
 
-If `agy-tui` stopped with `通常inboxによる既読試行を検知`, do not run bare `__CMD_PREFIX____SKILL_NAME__`, `inbox.sh`, or `check-inbox.sh` again. After confirming that no batch is pending, run `~/.agents/bin/agy-tui reset-guard --project "$(pwd)" --team <team> --name <role>` to clear only the read-denied guard; it does not read or ack messages.
+If `agy-tui` stopped after detecting a read attempt through the ordinary inbox path, do not run bare `__CMD_PREFIX____SKILL_NAME__`, `inbox.sh`, or `check-inbox.sh` again. After confirming that no batch is pending, run `~/.agents/bin/agy-tui reset-guard --project "$(pwd)" --team <team> --name <role>` to clear only the read-denied guard; it does not read or acknowledge messages.
 <!-- /agmsg:slot execute-extra -->
 
 <!-- agmsg:slot actas -->
@@ -51,5 +51,5 @@ If argument starts with "actas" followed by an agent name:
 2. Run `~/.agents/skills/__SKILL_NAME__/scripts/identities.sh "$(pwd)" __AGENT_TYPE__`.
 3. If needed, join with `~/.agents/skills/__SKILL_NAME__/scripts/join.sh <team> <name> __AGENT_TYPE__ "$(pwd)"`.
 4. Set the session's active FROM to `<name>` for subsequent sends.
-5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. Headless monitor は別workerへ、TUI monitor は明示起動した同じTUIへ配信します。"
+5. Tell the user: "Now acting as `<name>`. Sends will use `<name>` as the from agent. The headless monitor delivers to a separate worker; the TUI monitor delivers to the same TUI in which it was explicitly started."
 <!-- /agmsg:slot actas -->

--- a/tests/test_antigravity_resume.bats
+++ b/tests/test_antigravity_resume.bats
@@ -36,6 +36,25 @@ teardown() {
   rm -rf "$ROOT"
 }
 
+@test "antigravity runtime instructions and resume test names contain no CJK text (#1089)" {
+  local template="$BATS_TEST_DIRNAME/../scripts/drivers/types/antigravity/template.md"
+  run python3 - "$template" "$BATS_TEST_FILENAME" <<'PY'
+import pathlib
+import re
+import sys
+
+cjk = re.compile(r"[\u3040-\u30ff\u3400-\u9fff]")
+template = pathlib.Path(sys.argv[1]).read_text()
+test_names = "\n".join(
+    line for line in pathlib.Path(sys.argv[2]).read_text().splitlines()
+    if line.startswith('@test ')
+)
+if cjk.search(template) or cjk.search(test_names):
+    raise SystemExit("CJK text found in Antigravity runtime instructions or test names")
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "resume: exactly one paused TUI hands its identity to the existing resume" {
   run bash "$ROOT/scripts/antigravity-resume.sh" /tmp/project
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Closes #1089

Translate the Antigravity runtime overlay instructions into English without changing their operational requirements: an active TUI monitor owns inbox reads, status comes from the monitor, and receipt acknowledgment uses the envelope batch ID. The resume test names were already English on the current integration base.

Add a focused guard over the runtime template and resume test names so future CJK instruction text or unselectable test names fail visibly, while product-output assertions remain free to test the strings the commands actually emit.

Test: `bats tests/test_antigravity_resume.bats`