### PR TITLE
test(remote): drain stdin in the third driver stub with the #755 EPIPE race (#1178)

### DIFF
--- a/tests/remote_sync_engine.test.mjs
+++ b/tests/remote_sync_engine.test.mjs
@@ -2682,7 +2682,12 @@ async function withDriverEnvironment(t, root, script, buildCalls) {
 test("storage driver subprocess cannot observe HTTP or age identity secrets", async () => {
   const root = await mkdtemp(join(tmpdir(), "agmsg-sync-driver-env-"));
   const mock = join(root, "driver.sh");
+  // Same EPIPE race as the two stubs #759 fixed for #755: this one prints and
+  // exits without reading stdin, so a parent write/end that lands after exit
+  // hits a closed pipe and is reported as a driver failure. `cat` drains stdin
+  // first so the child stays alive until the parent has finished writing.
   await writeFile(mock, `#!/usr/bin/env bash
+cat >/dev/null
 [ -z "\${AGMSG_SYNC_TOKEN:-}" ] || exit 99
 [ -z "\${AGMSG_SYNC_TRUST_DIR:-}" ] || exit 95
 [ -z "\${AGMSG_AGE_IDENTITY:-}" ] || exit 98


### PR DESCRIPTION
The storage-driver-env stub in tests/remote_sync_engine.test.mjs prints and exits without reading stdin, the same shape #759 fixed in two other stubs for #755: a parent write/end landing after the child has already exited hits a closed pipe, and the call is reported as a driver failure rather than the success the assertion expects. This adds the same `cat >/dev/null` drain #759 used, and a sweep of the rest of the file found no further instances of the same shape. Fixes #1178.