### PR TITLE
fix(despawn): wait for the pane to close, not only the lock (#1097)

### DIFF
--- a/scripts/despawn.sh
+++ b/scripts/despawn.sh
@@ -199,7 +199,25 @@ done
 #
 # So ask the terminal. The record is deleted, and success reported, only when the
 # answer is a settled `gone`.
+#
+# And ask it MORE THAN ONCE. The watcher releases the lock before it folds its
+# pane, so the moment this loop is reached the pane is still `present` on a
+# graceful teardown that is working correctly — measured on a live herdr session
+# it stayed for tens of seconds (#1097). Checking once here reported `needs-force`
+# every time, teaching everyone to reach for --force (which skips the member's own
+# cleanup — the exact habit the graceful path exists to avoid). So wait for the
+# pane to actually go, drawing from the SAME --timeout budget the lock wait used
+# (the timeout covers the pane wait, not only the lock wait): `waited` is not
+# reset. Only a pane still `present` when that budget is spent is a real
+# needs-force. `unknown` is NOT polled — it means the terminal could not be asked
+# at all (unsupported/unreachable), where waiting cannot change the answer and
+# would only burn the whole timeout before the same needs-force.
 _pane_state="$(recorded_pane_state)"
+while [ "$_pane_state" = "present" ] && [ "$waited" -lt "$TIMEOUT" ]; do
+  sleep 1
+  waited=$((waited + 1))
+  _pane_state="$(recorded_pane_state)"
+done
 case "$_pane_state" in
   no-record|gone)
     rm -f "$SPAWN_REC" 2>/dev/null || true
@@ -218,7 +236,7 @@ case "$_pane_state" in
     echo "status=ok name=$NAME team=$TEAM after=${waited}s"
     ;;
   present)
-    echo "despawn: '$NAME' released its lock but the recorded pane is STILL OPEN — the teardown did not fold the window. The placement record is kept; retry with --force to tear it down through it." >&2
+    echo "despawn: '$NAME' released its lock but the recorded pane is STILL OPEN after ${waited}s — the teardown did not fold the window within the timeout. The placement record is kept; retry with --force to tear it down through it." >&2
     echo "status=needs-force name=$NAME team=$TEAM note=pane-still-open after=${waited}s"
     exit 1
     ;;

--- a/tests/test_despawn.bats
+++ b/tests/test_despawn.bats
@@ -330,7 +330,7 @@ _despawn_member_with_env() {   # <bindir> <env assignments...>
   # break the watcher's unrelated cleanup, or the test measures two things.
   DESPAWN_RC=0
   PATH="${DESPAWN_BIN:+$DESPAWN_BIN:}$bindir:$PATH" bash "$SCRIPTS/despawn.sh" \
-    team leader alice --timeout 10 >"$RUN/despawn.out" 2>"$RUN/despawn.err" || DESPAWN_RC=$?
+    team leader alice --timeout "${DESPAWN_TIMEOUT:-10}" >"$RUN/despawn.out" 2>"$RUN/despawn.err" || DESPAWN_RC=$?
   for i in 1 2 3 4 5 6 7 8 9 10; do kill -0 "$WPID" 2>/dev/null || break; sleep 0.5; done
   kill "$WPID" 2>/dev/null || true; wait "$WPID" 2>/dev/null || true
 }
@@ -504,5 +504,103 @@ EOF
   run env PATH="$bin:$PATH" bash "$SCRIPTS/despawn.sh" team leader alice --timeout 2
   [ "$status" -ne 0 ]
   printf '%s' "$output" | grep -Fq 'needs-force'
+  [ -f "$rec" ]
+}
+
+# --- #1097: a graceful despawn waits for the PANE, not only the lock ----------
+#
+# The watcher releases the actas lock (via reset.sh) BEFORE it folds its pane, so
+# the instant the lock reads `free` the pane is still present on a teardown that
+# is working correctly -- measured tens of seconds on a live herdr session.
+# Checking the pane once, there, reported `needs-force` every time, teaching
+# everyone to reach for --force (which skips the member's own cleanup). The two
+# tests below force both ends, and each fails on its own if its wait is removed:
+# drop the pane-wait loop and the LATE closer reports needs-force instead of ok
+# (and its list-panes is polled once, not repeatedly); drop the loop's
+# `waited < TIMEOUT` bound and the NEVER closer never returns.
+#
+# Records carry a socket (terminal_pane_state returns `unknown` without one), and
+# the stubs answer the socketed `tmux -S <sock> list-panes` form, so `$1` is `-S`,
+# not the subcommand -- the argv is scanned instead. list-panes is reached only
+# from the caller's poll (terminal_despawn uses kill-pane, not list-panes), so the
+# late stub's wall-clock transition starts at the caller's first poll.
+
+# Present for ~2s from the first list-panes, then gone: an async fold that lags
+# the lock release. kill-pane succeeds (the fold was initiated).
+_stub_tmux_closes_late() {
+  local bin="$1"; mkdir -p "$bin"
+  cat > "$bin/tmux" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$bin/tmux.log"
+for a in "\$@"; do
+  case "\$a" in
+    list-panes)
+      f="$bin/lp_first_seen"
+      [ -f "\$f" ] || date +%s > "\$f"
+      if [ \$(( \$(date +%s) - \$(cat "\$f") )) -lt 2 ]; then echo '%1'; fi
+      exit 0 ;;
+    kill-pane)    exit 0 ;;
+    capture-pane) echo x; exit 0 ;;
+  esac
+done
+exit 0
+EOF
+  chmod +x "$bin/tmux"
+}
+
+@test "despawn: graceful — a member that closes its pane LATE still returns ok (#1097)" {
+  local bin="$BATS_TEST_TMPDIR/bin"
+  _stub_tmux_closes_late "$bin"
+  local rec; rec="$(_spawn_rec_path team alice)"
+  mkdir -p "$(dirname "$rec")"
+  printf 'tmux:/tmp/fake-tmux-socket:%%1\t%s\tclaude-code\n' "$PROJ" > "$rec"
+
+  _despawn_member_with_env "$bin" TMUX=/tmp/fake-tmux-socket,0,0 TMUX_PANE=%1
+
+  # Positive control: the caller polled the pane more than once -- it WAITED
+  # rather than catching an already-gone pane on a single check. Remove the
+  # pane-wait loop and this is exactly one list-panes call.
+  [ "$(grep -c 'list-panes' "$bin/tmux.log")" -ge 2 ]
+
+  # The point: a late close reads as success, and the record is cleared.
+  grep -Fq 'status=ok' "$RUN/despawn.out"
+  [ "$DESPAWN_RC" -eq 0 ]
+  [ ! -f "$rec" ]
+}
+
+# Present forever: the fold never takes. list-panes always names the pane.
+_stub_tmux_never_closes() {
+  local bin="$1"; mkdir -p "$bin"
+  cat > "$bin/tmux" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$bin/tmux.log"
+for a in "\$@"; do
+  case "\$a" in
+    list-panes)   echo '%1'; exit 0 ;;
+    kill-pane)    exit 0 ;;
+    capture-pane) echo x; exit 0 ;;
+  esac
+done
+exit 0
+EOF
+  chmod +x "$bin/tmux"
+}
+
+@test "despawn: graceful — a member that NEVER closes reports needs-force at the timeout (#1097)" {
+  local bin="$BATS_TEST_TMPDIR/bin"
+  _stub_tmux_never_closes "$bin"
+  local rec; rec="$(_spawn_rec_path team alice)"
+  mkdir -p "$(dirname "$rec")"
+  printf 'tmux:/tmp/fake-tmux-socket:%%1\t%s\tclaude-code\n' "$PROJ" > "$rec"
+
+  DESPAWN_TIMEOUT=3 _despawn_member_with_env "$bin" TMUX=/tmp/fake-tmux-socket,0,0 TMUX_PANE=%1
+
+  # It waited the whole budget before giving up: `after=3s` == the timeout. The
+  # old single-check code reported needs-force with after=<lock wait> (< 3), and
+  # an unbounded loop would never reach here at all.
+  grep -Fq 'status=needs-force' "$RUN/despawn.out"
+  grep -Fq 'note=pane-still-open' "$RUN/despawn.out"
+  grep -Fq 'after=3s' "$RUN/despawn.out"
+  [ "$DESPAWN_RC" -ne 0 ]
   [ -f "$rec" ]
 }

--- a/tests/test_despawn.bats
+++ b/tests/test_despawn.bats
@@ -521,28 +521,34 @@ EOF
 #
 # Records carry a socket (terminal_pane_state returns `unknown` without one), and
 # the stubs answer the socketed `tmux -S <sock> list-panes` form, so `$1` is `-S`,
-# not the subcommand -- the argv is scanned instead. list-panes is reached only
-# from the caller's poll (terminal_despawn uses kill-pane, not list-panes), so the
-# late stub's wall-clock transition starts at the caller's first poll.
+# not the subcommand -- the argv is scanned instead. The gate keys on the EXACT
+# pane-state format `-F '#{pane_id}'`: the watcher's attach also runs list-panes,
+# with `-F '#{pane_id}|#{@agmsg_agent}'` (a label search), and an earlier version
+# that transitioned on the first list-panes of ANY kind was tripped by that label
+# search ~4s before the despawn caller ever polled, so the caller read `gone` on
+# its single check and the test passed even with the wait removed. The late stub
+# now counts only pane-state polls: present on the first, gone after.
 
-# Present for ~2s from the first list-panes, then gone: an async fold that lags
-# the lock release. kill-pane succeeds (the fold was initiated).
+# Pane-state poll present on the first check, gone after: an async fold that lags
+# the lock release. kill-pane succeeds (the fold was initiated). The label search
+# is answered (so the watcher resolves) but does not advance the pane-state count.
 _stub_tmux_closes_late() {
   local bin="$1"; mkdir -p "$bin"
   cat > "$bin/tmux" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$bin/tmux.log"
-for a in "\$@"; do
-  case "\$a" in
-    list-panes)
-      f="$bin/lp_first_seen"
-      [ -f "\$f" ] || date +%s > "\$f"
-      if [ \$(( \$(date +%s) - \$(cat "\$f") )) -lt 2 ]; then echo '%1'; fi
-      exit 0 ;;
-    kill-pane)    exit 0 ;;
-    capture-pane) echo x; exit 0 ;;
-  esac
-done
+args="\$*"
+case "\$args" in
+  *kill-pane*)                    exit 0 ;;
+  *capture-pane*)                 echo x; exit 0 ;;
+  *"#{pane_id}|#{@agmsg_agent}"*) echo '%1|alice'; exit 0 ;;   # label search: resolve, do not gate
+  *"-F #{pane_id}")                                            # terminal_pane_state's poll, and only it
+    c="$bin/ps_polls"
+    n=\$(cat "\$c" 2>/dev/null || echo 0); n=\$((n + 1)); echo "\$n" > "\$c"
+    [ "\$n" -le 1 ] && echo '%1'                               # present on the 1st poll, gone after
+    exit 0 ;;
+  *list-panes*)                   echo '%1'; exit 0 ;;         # any other list form: present, ungated
+esac
 exit 0
 EOF
   chmod +x "$bin/tmux"
@@ -557,10 +563,10 @@ EOF
 
   _despawn_member_with_env "$bin" TMUX=/tmp/fake-tmux-socket,0,0 TMUX_PANE=%1
 
-  # Positive control: the caller polled the pane more than once -- it WAITED
-  # rather than catching an already-gone pane on a single check. Remove the
-  # pane-wait loop and this is exactly one list-panes call.
-  [ "$(grep -c 'list-panes' "$bin/tmux.log")" -ge 2 ]
+  # Positive control: the caller polled the PANE STATE more than once -- it
+  # WAITED rather than catching an already-gone pane on a single check. Remove the
+  # pane-wait loop and this is exactly one pane-state poll.
+  [ "$(cat "$bin/ps_polls" 2>/dev/null || echo 0)" -ge 2 ]
 
   # The point: a late close reads as success, and the record is cleared.
   grep -Fq 'status=ok' "$RUN/despawn.out"
@@ -568,19 +574,25 @@ EOF
   [ ! -f "$rec" ]
 }
 
-# Present forever: the fold never takes. list-panes always names the pane.
+# Present forever: the fold never takes. Every pane-state poll names the pane,
+# and pane-state polls are counted so the test can prove the caller waited (polled
+# repeatedly) rather than refusing on a single check.
 _stub_tmux_never_closes() {
   local bin="$1"; mkdir -p "$bin"
   cat > "$bin/tmux" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$bin/tmux.log"
-for a in "\$@"; do
-  case "\$a" in
-    list-panes)   echo '%1'; exit 0 ;;
-    kill-pane)    exit 0 ;;
-    capture-pane) echo x; exit 0 ;;
-  esac
-done
+args="\$*"
+case "\$args" in
+  *kill-pane*)                    exit 0 ;;
+  *capture-pane*)                 echo x; exit 0 ;;
+  *"#{pane_id}|#{@agmsg_agent}"*) echo '%1|alice'; exit 0 ;;   # label search
+  *"-F #{pane_id}")                                            # terminal_pane_state's poll
+    c="$bin/ps_polls"
+    n=\$(cat "\$c" 2>/dev/null || echo 0); echo \$((n + 1)) > "\$c"
+    echo '%1'; exit 0 ;;
+  *list-panes*)                   echo '%1'; exit 0 ;;
+esac
 exit 0
 EOF
   chmod +x "$bin/tmux"
@@ -593,14 +605,21 @@ EOF
   mkdir -p "$(dirname "$rec")"
   printf 'tmux:/tmp/fake-tmux-socket:%%1\t%s\tclaude-code\n' "$PROJ" > "$rec"
 
-  DESPAWN_TIMEOUT=3 _despawn_member_with_env "$bin" TMUX=/tmp/fake-tmux-socket,0,0 TMUX_PANE=%1
+  # 8s, not a tight 2-3: the lock wait and the pane wait share this one budget, so
+  # it must clear the lock wait (~2-3s here, same watcher as the tests above that
+  # use --timeout 10) AND leave room for the caller to poll the pane more than once.
+  DESPAWN_TIMEOUT=8 _despawn_member_with_env "$bin" TMUX=/tmp/fake-tmux-socket,0,0 TMUX_PANE=%1
 
-  # It waited the whole budget before giving up: `after=3s` == the timeout. The
-  # old single-check code reported needs-force with after=<lock wait> (< 3), and
-  # an unbounded loop would never reach here at all.
+  # It polled the pane repeatedly across the budget before giving up -- not a
+  # single refusal. This is the discriminator: drop the pane-wait loop and the
+  # caller checks once (ps_polls == 1); an unbounded loop never returns here at
+  # all. (`after=3s` is not used as the guard: the lock wait alone can consume
+  # the whole budget, so it does not distinguish a waited-out pane from an
+  # immediate refusal.)
+  [ "$(cat "$bin/ps_polls" 2>/dev/null || echo 0)" -ge 2 ]
   grep -Fq 'status=needs-force' "$RUN/despawn.out"
   grep -Fq 'note=pane-still-open' "$RUN/despawn.out"
-  grep -Fq 'after=3s' "$RUN/despawn.out"
+  grep -Fq 'after=8s' "$RUN/despawn.out"
   [ "$DESPAWN_RC" -ne 0 ]
   [ -f "$rec" ]
 }


### PR DESCRIPTION
## What

A graceful `despawn` waited for the actas lock to go free, then checked the
recorded pane exactly once and reported `needs-force` if it was still there.

## Why it was always wrong

The watcher releases the lock (via `reset.sh`) **before** it folds its pane, so
at the instant the lock reads `free` the pane is still present on a teardown that
is working correctly — measured tens of seconds on a live herdr session. Every
graceful despawn of a healthy member therefore reported `needs-force`, teaching
everyone to reach for `--force`, which skips the member's own cleanup: the exact
habit the graceful path exists to avoid. (This is #1051 inverted — that one
reported `ok` for a pane still open; this one `needs-force` for a pane that
closes on its own a moment later. Both read a proxy instead of the thing.)

## Fix

After the lock is free, poll `recorded_pane_state` until the pane is `gone`, on
the **same `--timeout` budget** the lock wait drew from (`waited` is not reset —
the timeout covers the pane wait, not only the lock wait). Only a pane still
`present` when that budget is spent is a real `needs-force`. `unknown` is not
polled: it means the terminal could not be asked at all, where waiting cannot
change the answer and would only burn the whole timeout before the same
`needs-force`.

## Acceptance / tests

Two tests force both ends, and **each fails on its own if its wait is removed**
(verified by mutating the loop out — both go red):

- a member that closes its pane **late** still returns `ok`;
- a member that **never** closes still reports `needs-force`, having polled the
  pane repeatedly across the budget (`after=<timeout>`), not refused on one check.

The stubs gate on the exact `terminal_pane_state` format (`-F '#{pane_id}'`) and
count only those polls — an earlier cut anchored on the first `list-panes` of any
kind and was tripped by the watcher's label search ~4s before the caller polled,
so it passed even with the wait removed. `_despawn_member_with_env` gained an
optional `DESPAWN_TIMEOUT`. Full `tests/test_despawn.bats` is green (20/20).