### PR TITLE
herdr: peek reads the confirmed-gone claim from error.code, not from a substring (#1169)

### DIFF
--- a/scripts/drivers/terminals/herdr/ops.sh
+++ b/scripts/drivers/terminals/herdr/ops.sh
@@ -844,16 +844,31 @@ terminal_peek() {
     # applies to its own list, and the one the tmux driver applies to "no server
     # running" — only herdr's OWN claim that the pane is gone may be read as
     # gone. Say what happened, not what it might mean.
-    case "$stdout_body" in
-      *pane_not_found*)
-        echo "herdr: could not read pane '$id': the terminal reports it no longer exists" >&2
-        return 12
-        ;;
-      *)
-        echo "herdr: could not read pane '$id': ${stderr_body:-${stdout_body:-herdr exited $rc with no diagnostic on either channel}}" >&2
-        return 11
-        ;;
-    esac
+    #
+    # The claim is read STRUCTURALLY (#1169): herdr's error reply is JSON with
+    # `error.code`, and only the code being exactly `pane_not_found`, about the
+    # pane we asked for, is gone. An earlier revision matched the substring
+    # anywhere in the body, so a different error whose message merely mentioned
+    # the word read as gone, and a renamed code would have silently become
+    # "unknown" -- the same family as #1158, a failure returning as a different
+    # value that looks like an answer. No sqlite3, no JSON, no code, a code
+    # about another pane: all of those are 11, with the body forwarded above.
+    local _code="" _pane="" _esc
+    if [ -n "$stdout_body" ] && command -v sqlite3 >/dev/null 2>&1; then
+      _esc="$(printf '%s' "$stdout_body" | sed "s/'/''/g")"
+      _code="$(sqlite3 :memory: "SELECT CASE WHEN json_valid('$_esc') AND json_type('$_esc','\$.error.code')='text' THEN json_extract('$_esc','\$.error.code') ELSE '' END" 2>/dev/null || true)"
+      _pane="$(sqlite3 :memory: "SELECT CASE WHEN json_valid('$_esc') AND json_type('$_esc','\$.error.pane')='text' THEN json_extract('$_esc','\$.error.pane') ELSE '' END" 2>/dev/null || true)"
+    fi
+    if [ "$_code" = pane_not_found ] && { [ -z "$_pane" ] || [ "$_pane" = "$(_herdr_bare_of "$id")" ]; }; then
+      echo "herdr: could not read pane '$id': the terminal reports it no longer exists" >&2
+      return 12
+    fi
+    if [ "$_code" = pane_not_found ]; then
+      echo "herdr: could not read pane '$id': the terminal reports pane '$_pane' does not exist -- a different pane, not this one" >&2
+      return 11
+    fi
+    echo "herdr: could not read pane '$id': ${stderr_body:-${stdout_body:-herdr exited $rc with no diagnostic on either channel}}" >&2
+    return 11
   fi
   cat "$tmp"   # only the real pane content reaches stdout, byte-for-byte
   rm -f "$tmp"

--- a/tests/test_peek_poke.bats
+++ b/tests/test_peek_poke.bats
@@ -359,6 +359,71 @@ EOF
   grep -q "could not read pane 'w1:p4'" "$errf"
 }
 
+# herdr whose `pane read` fails with a DIFFERENT error whose message merely
+# mentions the word pane_not_found (#1169). A substring reader called this gone.
+_install_fake_herdr_other_error_mentioning_gone() {
+  cat > "$FAKEBIN/herdr" <<EOF
+#!/usr/bin/env bash
+{ printf 'herdr'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = pane ] && [ "\$2" = read ]; then
+  printf '{"error":{"code":"read_failed","message":"pane_not_found is not what happened; the read timed out","pane":"%s"}}\n' "\$3"
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/herdr"; export PATH="$FAKEBIN:$PATH"
+}
+
+# herdr that says a pane is gone -- a DIFFERENT pane than the one asked for.
+_install_fake_herdr_gone_other_pane() {
+  cat > "$FAKEBIN/herdr" <<EOF
+#!/usr/bin/env bash
+{ printf 'herdr'; for a in "\$@"; do printf ' [%s]' "\$a"; done; printf '\n'; } >> "$ARGV_LOG"
+if [ "\$1" = pane ] && [ "\$2" = read ]; then
+  printf '{"error":{"code":"pane_not_found","pane":"w9:p9"}}\n'
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/herdr"; export PATH="$FAKEBIN:$PATH"
+}
+
+@test "peek taxonomy: another error whose MESSAGE mentions pane_not_found is 11, not gone (#1169)" {
+  _install_fake_herdr_other_error_mentioning_gone
+  _write_record "herdr:w1:p4"
+  local outf errf rc=0; outf="$TEST_SKILL_DIR/o"; errf="$TEST_SKILL_DIR/e"
+  HERDR_ENV=1 bash "$SCRIPTS/peek.sh" testteam alice >"$outf" 2>"$errf" || rc=$?
+  [ "$rc" -eq 11 ]
+  [ ! -s "$outf" ]
+  grep -q "read_failed" "$errf"                       # the real body is forwarded
+  refute grep -q "no longer exists" "$errf"           # and no absence is claimed
+}
+
+@test "peek taxonomy: a pane_not_found about a DIFFERENT pane is 11, and says which pane (#1169)" {
+  _install_fake_herdr_gone_other_pane
+  _write_record "herdr:w1:p4"
+  local outf errf rc=0; outf="$TEST_SKILL_DIR/o"; errf="$TEST_SKILL_DIR/e"
+  HERDR_ENV=1 bash "$SCRIPTS/peek.sh" testteam alice >"$outf" 2>"$errf" || rc=$?
+  [ "$rc" -eq 11 ]
+  grep -q "pane 'w9:p9' does not exist -- a different pane" "$errf"
+  refute grep -q "no longer exists" "$errf"
+}
+
+@test "peek taxonomy: a renamed error code is 11 with the body forwarded, never a silent gone (#1169)" {
+  cat > "$FAKEBIN/herdr" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = pane ] && [ "\$2" = read ]; then printf '{"error":{"code":"PaneNotFound","pane":"%s"}}\n' "\$3"; exit 1; fi
+exit 0
+EOF
+  chmod +x "$FAKEBIN/herdr"; export PATH="$FAKEBIN:$PATH"
+  _write_record "herdr:w1:p4"
+  local outf errf rc=0; outf="$TEST_SKILL_DIR/o"; errf="$TEST_SKILL_DIR/e"
+  HERDR_ENV=1 bash "$SCRIPTS/peek.sh" testteam alice >"$outf" 2>"$errf" || rc=$?
+  [ "$rc" -eq 11 ]
+  grep -q "PaneNotFound" "$errf"
+  refute grep -q "no longer exists" "$errf"
+}
+
 # herdr whose `pane read` fails with an OS-level error on its REAL stderr — no
 # JSON body at all, and no claim from herdr that the pane is gone. Modeled on
 # the measured case (#1158): a sandbox that denies socket operations returns


### PR DESCRIPTION
Fixes #1169.

## What was wrong

`terminal_peek` in the herdr driver decided "the pane is confirmed gone" (rc 12) against "the read failed for a reason we did not establish" (rc 11) by matching the substring `pane_not_found` anywhere in herdr's stdout. Two failures of that: a different error whose message merely mentioned the word read as gone, and a renamed code would have silently become "unknown" — the family this tree has been chasing: a read failure returned as a different value that looks like an answer (#1158).

## The change

The claim is read structurally. herdr's error reply is JSON; only `error.code` being exactly `pane_not_found` is gone, and only when `error.pane`, if present, names the pane that was asked about. A `pane_not_found` about another pane is 11 and says which pane the terminal meant. No sqlite3, no JSON, no code, a renamed code: all 11, with both diagnostics forwarded verbatim as before. The rc 12 path's wording is unchanged.

## Tests (`tests/test_peek_poke.bats`)

- another error whose message mentions `pane_not_found` → 11, the real body forwarded, no absence claimed — **red on the substring reader**;
- a `pane_not_found` about a different pane → 11, and names that pane — **red on the substring reader**;
- a renamed code (`PaneNotFound`) → 11 with the body forwarded, never a silent gone — green before and after, kept as the documented case.

The existing gone case (rc 12 with the error JSON kept off stdout) and the no-absence-claim case (#1158) are unchanged. Suite 43/43; the four static checkers at their baselines; shellcheck reports nothing on the driver.
