### PR TITLE
fix(join): resolve session id from type manifest

### DIFF
--- a/docs/agent-types.md
+++ b/docs/agent-types.md
@@ -21,6 +21,7 @@ a manifest cannot execute code. Multi-value keys are whitespace-separated.
 | `template` | yes | the `/agmsg` command template filename, relative to the type dir (e.g. `template.md`); becomes `SKILL.md` |
 | `detect` | — | env-var names whose presence selects this type. `explicit` = never auto-detected from the environment |
 | `detect_proc` | — | parent-process-name glob patterns that select this type (e.g. `codex codex-*`) |
+| `session_env` | — | the single env-var name that carries this runtime's current session id. `join` passes its value to terminal self-naming; omitted means the type publishes no session id |
 | `cli` | spawnable types | the launch command. Usually a single binary name, but may be a fixed multi-word prefix (subcommand and/or flags a CLI needs ahead of its own options) — only the first word is resolved/checked as the executable; the rest are passed through as-is. Safe because this is manifest data agmsg ships, not runtime user input |
 | `spawnable` | — | `yes` if `spawn.sh` can launch this type |
 | `spawn` | — | a `.mjs` node-launcher (beside the manifest) `spawn.sh` runs via Node; also marks the type spawnable |
@@ -110,6 +111,7 @@ template=template.md
 cli=codex
 spawnable=yes
 detect=CODEX_SANDBOX CODEX_THREAD_ID
+session_env=CODEX_THREAD_ID
 detect_proc=codex codex-*
 hooks_file=.codex/hooks.json
 monitor=no

--- a/scripts/drivers/types/claude-code/type.conf
+++ b/scripts/drivers/types/claude-code/type.conf
@@ -32,6 +32,10 @@ session_name_source=title
 # always boot fresh.
 resume_arg=--resume
 detect=CLAUDE_CODE_SESSION_ID
+# Environment variable carrying this runtime's current session id. Unlike
+# detect=, this names one value with one meaning; join uses it to identify its
+# own pane through a terminal driver that needs the runtime session id.
+session_env=CLAUDE_CODE_SESSION_ID
 detect_proc=claude claude-code claude-*
 # Session-identity vars a same-type spawn must NOT inherit, or the child mistakes
 # the parent's session for its own and every turn fails auth (see spawn.sh, #294).

--- a/scripts/drivers/types/codex/type.conf
+++ b/scripts/drivers/types/codex/type.conf
@@ -100,6 +100,7 @@ rename_confirm=Session renamed to
 cmd_prefix=$
 model_arg=-m
 detect=CODEX_SANDBOX CODEX_THREAD_ID
+session_env=CODEX_THREAD_ID
 detect_proc=codex codex-*
 hooks_file=.codex/hooks.json
 monitor=no

--- a/scripts/drivers/types/grok-build/type.conf
+++ b/scripts/drivers/types/grok-build/type.conf
@@ -5,6 +5,7 @@ cli=grok
 spawnable=yes
 model_arg=--model
 detect=GROK_SESSION_ID
+session_env=GROK_SESSION_ID
 detect_proc=grok grok-*
 hooks_file=.grok/rules/agmsg.md
 # monitor=no: spawn skips the readiness handshake for grok-build. Its monitor

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -238,13 +238,12 @@ agmsg_lock_release
 # yourself the seat's placement is not. (The 6th argument is omitted deliberately;
 # its default is the safe half.)
 #
-# Called with NO session id: join is a plain CLI invocation and nothing tells it
-# which env var carries this type's session id (`detect=` answers whether a type
-# is present, not where its id lives -- a different question). A terminal that
-# does not need one (tmux, via $TMUX_PANE) is named here; one that does (herdr,
-# which looks the pane up by agent session id) is skipped in silence, and picked
-# up by actas or SessionStart, which both have the id. Passing "" is therefore a
-# statement, not an omission.
+# A type may publish its current session id through the manifest's `session_env=`
+# variable. This is deliberately NOT inferred from `detect=`: detection answers
+# whether a runtime is present and may name several markers or credentials,
+# while session_env names exactly one value with exactly this meaning. A missing
+# key or unset value remains the honest "this type/session publishes no id" and
+# drivers that do not need one (tmux, via $TMUX_PANE) still name normally.
 #
 # The source carries the errexit lift: on bash 3.2 a failure inside a sourced
 # file fires THIS script's `set -e`, so a plain `. x || true` would take the join
@@ -257,7 +256,22 @@ set +e
 _agmsg_tr_rc=$?
 [ "$_agmsg_tr_e" = 1 ] && set -e
 if [ "$_agmsg_tr_rc" -eq 0 ] && declare -F agmsg_terminal_name_self_safe >/dev/null 2>&1; then
-  agmsg_terminal_name_self_safe "" "$TEAM" "$AGENT_ID" "$PROJECT_PATH" "$AGENT_TYPE" || true
+  _agmsg_session_id=""
+  _agmsg_session_env="$(agmsg_type_get "$AGENT_TYPE" session_env)"
+  if [ -n "$_agmsg_session_env" ]; then
+    case "$_agmsg_session_env" in
+      [A-Za-z_]*)
+        case "$_agmsg_session_env" in
+          *[!A-Za-z0-9_]*)
+            printf "agmsg: type '%s' has invalid session_env=%s; session id ignored\n" \
+              "$AGENT_TYPE" "$_agmsg_session_env" >&2 ;;
+          *) _agmsg_session_id="${!_agmsg_session_env:-}" ;;
+        esac ;;
+      *) printf "agmsg: type '%s' has invalid session_env=%s; session id ignored\n" \
+           "$AGENT_TYPE" "$_agmsg_session_env" >&2 ;;
+    esac
+  fi
+  agmsg_terminal_name_self_safe "$_agmsg_session_id" "$TEAM" "$AGENT_ID" "$PROJECT_PATH" "$AGENT_TYPE" || true
 fi
 
 echo "Joined team $TEAM as $AGENT_ID"

--- a/tests/test_terminal_registry.bats
+++ b/tests/test_terminal_registry.bats
@@ -1744,6 +1744,28 @@ M
   grep -q '/proj/OLD' "$rec"
 }
 
+@test "join: resolves a herdr pane from the type's dedicated session_env (#1024)" {
+  _install_fake_herdr "thread-right"
+  export PATH="$FAKEBIN:$PATH"
+  export HERDR_ENV=1 CODEX_SANDBOX=marker CODEX_THREAD_ID=thread-right
+  export AGMSG_STORAGE_PATH="$TEST_SKILL_DIR/db/messages.db"
+
+  run bash "$SKILL_DIR/scripts/join.sh" seatteam alice codex /proj/A
+  [ "$status" -eq 0 ]
+
+  # Positive controls: join asked herdr and named the pane it found. The
+  # CODEX_SANDBOX marker is deliberately different; borrowing the first detect=
+  # key instead of session_env makes this test fail at the lookup.
+  grep -Fq 'herdr [agent] [list]' "$ARGV_LOG"
+  grep -Fq 'herdr [pane] [rename] [wC:p4] [seatteam:alice]' "$ARGV_LOG"
+
+  # Naming at join is still display-only. Supplying a session id must not turn
+  # join into a placement claim for an identity that another session may hold.
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  local rec; rec="$(agmsg_spawn_path seatteam alice)"
+  refute test -e "$rec"
+}
+
 # --- AGMSG_TERMINAL_NAMING=off drops the label and keeps the key (#1044) ------
 #
 # Two names, and only one of them is optional. The key is the name the TERMINAL

--- a/tests/test_type_registry.bats
+++ b/tests/test_type_registry.bats
@@ -273,6 +273,14 @@ EOF
   [ "$(g opencode detect_proc)" = "opencode opencode-*" ]
 }
 
+@test "type-registry: session identity is a dedicated per-type datum, not inferred from detect" {
+  g() { env -i PATH="$PATH" bash -c "source '$SCRIPTS/lib/type-registry.sh'; agmsg_type_get $1 session_env"; }
+  [ "$(g claude-code)" = "CLAUDE_CODE_SESSION_ID" ]
+  [ "$(g codex)" = "CODEX_THREAD_ID" ]
+  [ "$(g grok-build)" = "GROK_SESSION_ID" ]
+  [ -z "$(g gemini)" ]
+}
+
 @test "type-registry: whoami detects codex end-to-end from CODEX_THREAD_ID" {
   # Join a codex agent so whoami has a registration to report, then call it with
   # no explicit type: detection must pick codex from the manifest's detect= key.


### PR DESCRIPTION
Closes #1024.

Agent-type manifests now declare `session_env` when the runtime publishes a current session id: `CLAUDE_CODE_SESSION_ID`, `CODEX_THREAD_ID`, or `GROK_SESSION_ID`. `join.sh` reads that dedicated datum and passes its value into terminal self-naming instead of trying to infer identity from the unrelated, potentially multi-key `detect` field. Missing keys and unset values retain the existing empty-session behavior; malformed variable names are rejected with a named diagnostic.

The end-to-end regression gives codex both `CODEX_SANDBOX` and `CODEX_THREAD_ID`, makes only the thread id resolvable by herdr, and proves join names that pane without writing a placement claim.

Tests: `bats tests/test_type_registry.bats`; `bats tests/test_terminal_registry.bats`; `bash -n scripts/join.sh`.