### PR TITLE
test(remote): dump forensic state on the #1176 re-anchor test's own failure

### DIFF
--- a/tests/test_remote.bats
+++ b/tests/test_remote.bats
@@ -201,7 +201,27 @@ _binding_field() {  # $1 = team, $2 = json path under remote_binding
   run curl -sS "$ENDPOINT/_test/rotate-server-id"
   [ "$status" -eq 0 ]
 
+  # #1176: this assertion goes red on CI roughly 3 times in 16 runs and has
+  # never once reproduced locally (15 isolated repeats, a whole-file run, a
+  # deliberate 6s delay here to give the background sync engine's poll a
+  # chance to fire, and the exact 4-file combination the age-v1-contract leg
+  # runs -- all green). Whatever the CI-only condition is, the state that
+  # would show it is gone the moment teardown() runs rm -rf on
+  # $TEST_SKILL_DIR. Dump it into the test's own output NOW, unconditionally
+  # -- bats only surfaces this stream when the test actually fails, so it
+  # costs nothing on the green runs and is exactly what the next red one is
+  # missing today.
+  echo "DIAG(#1176) pre-reconnect: date=$(date -u +%Y-%m-%dT%H:%M:%S.%NZ 2>/dev/null || date -u)"
+  echo "DIAG(#1176) pre-reconnect: live server /v1/health = $(curl -sS "$ENDPOINT/v1/health" 2>&1)"
+  echo "DIAG(#1176) pre-reconnect: anchored=$anchored"
+  echo "DIAG(#1176) pre-reconnect: server.log tail:"
+  { tail -n 20 "$TEST_SKILL_DIR/server.log" 2>&1 | sed 's/^/DIAG(#1176)   /'; } || true
+  echo "DIAG(#1176) pre-reconnect: sync engine pidfile: $(cat "$TEST_SKILL_DIR/run/remote-sync.testteam.pid" 2>&1 || true)"
+  echo "DIAG(#1176) pre-reconnect: sync engine log tail:"
+  { tail -n 20 "$TEST_SKILL_DIR/run/remote-sync.testteam.log" 2>&1 | sed 's/^/DIAG(#1176)   /'; } || true
+
   run bash "$SCRIPTS/remote.sh" connect --endpoint "$ENDPOINT" testteam
+  echo "DIAG(#1176) reconnect: status=$status output=$output"
   [ "$status" -ne 0 ]
   [[ "$output" == *"Refusing to re-anchor"* ]]
   # The binding still points at the server it was made against.


### PR DESCRIPTION
Not a fix for #1176 — this is the observation step, not the diagnosis.

Could not reproduce the intermittent failure locally after:
- the target test alone, 15 consecutive runs
- the whole `tests/test_remote.bats` file, once
- a deliberate 6s sleep inserted between the rotate call and the second
  connect, to give the background sync engine's 5s poll a chance to fire
  mid-window
- the exact 4-file combination the `age-v1 contract` leg runs
  (`test_ci_workflow.bats test_key.bats test_printed_command_paths.bats
  test_remote.bats`) in one `bats` invocation, matching CI precisely

All green, confirmed genuinely executed (not skipped — `ok N ...` with
no `# skip` suffix) each time.

Whatever the CI-only condition is (population data: ~3 in 16 runs, across
`integration/terminal-driver-v1` itself and unrelated branches, so it is
not this PR's or any PR's diff), the state that would show it is gone the
moment `teardown()` runs `rm -rf` on `$TEST_SKILL_DIR`. This dumps it into
the test's own output right before the critical assertions instead:
current time, the live mock server's own `/v1/health` answer, the mock
server's log, and the background sync engine's pidfile and log.

Bats only surfaces a test's own output stream when that test fails, so
this costs nothing on the green runs — verified locally — and is exactly
what the next real occurrence is missing today. Verified the reverse too:
deliberately broke the assertion, confirmed every `DIAG(#1176)` line
appears, then restored it.