### PR TITLE
The action hook resolves project/type when its callers have none, so arrange stops refusing hand-started seats (#1137)

### DIFF
--- a/scripts/lib/self-name.sh
+++ b/scripts/lib/self-name.sh
@@ -164,18 +164,18 @@ agmsg_self_name_on_action() {
     # the record's own project/type stay only as good as this detection is.
     if [ -z "$type" ]; then
       # shellcheck disable=SC1091
-      . "$SKILL_DIR/scripts/lib/type-registry.sh" 2>/dev/null || true
+      . "${SKILL_DIR:-}/scripts/lib/type-registry.sh" 2>/dev/null || true
       # shellcheck disable=SC1091
-      . "$SKILL_DIR/scripts/lib/compat.sh" 2>/dev/null || true
+      . "${SKILL_DIR:-}/scripts/lib/compat.sh" 2>/dev/null || true
       # shellcheck disable=SC1091
-      if . "$SKILL_DIR/scripts/lib/detect-cli-type.sh" 2>/dev/null \
+      if . "${SKILL_DIR:-}/scripts/lib/detect-cli-type.sh" 2>/dev/null \
         && declare -F agmsg_detect_cli_type >/dev/null 2>&1; then
         type="$(agmsg_detect_cli_type 2>/dev/null || true)"
       fi
     fi
     if [ -z "$project" ]; then
       # shellcheck disable=SC1091
-      if . "$SKILL_DIR/scripts/lib/resolve-project.sh" 2>/dev/null \
+      if . "${SKILL_DIR:-}/scripts/lib/resolve-project.sh" 2>/dev/null \
         && declare -F agmsg_resolve_project >/dev/null 2>&1; then
         project="$(agmsg_resolve_project "$(pwd)" "$type" "$team" 2>/dev/null || true)"
       fi

--- a/scripts/lib/self-name.sh
+++ b/scripts/lib/self-name.sh
@@ -147,6 +147,41 @@ agmsg_self_name_on_action() {
     return 0                                 # named AND recorded at where I am
   fi
 
+  # #1137: none of send.sh/inbox.sh/history.sh pass project or type -- they
+  # never had them to pass, not merely forgot to -- so a record this hook
+  # writes had two empty fields, and arrange.sh (which requires both) refused
+  # any seat whose ONLY placement record came from acting rather than from
+  # spawn/actas/SessionStart (measured live: 12 of 36 records). Resolve them
+  # here, the same way whoami.sh does for the identical question, rather than
+  # threading two new arguments through three callers that have no better
+  # source for them than this process's own cwd and type anyway. Only when
+  # the caller did not supply them -- a caller that already knows better
+  # (every other path through the primitive) is never second-guessed.
+  if [ -z "$project" ] || [ -z "$type" ]; then
+    # Best-effort, matching every other lazy source in this function: a
+    # failure here must not block the naming this hook exists to do, so a
+    # record written with what could be resolved is better than none, and
+    # the record's own project/type stay only as good as this detection is.
+    if [ -z "$type" ]; then
+      # shellcheck disable=SC1091
+      . "$SKILL_DIR/scripts/lib/type-registry.sh" 2>/dev/null || true
+      # shellcheck disable=SC1091
+      . "$SKILL_DIR/scripts/lib/compat.sh" 2>/dev/null || true
+      # shellcheck disable=SC1091
+      if . "$SKILL_DIR/scripts/lib/detect-cli-type.sh" 2>/dev/null \
+        && declare -F agmsg_detect_cli_type >/dev/null 2>&1; then
+        type="$(agmsg_detect_cli_type 2>/dev/null || true)"
+      fi
+    fi
+    if [ -z "$project" ]; then
+      # shellcheck disable=SC1091
+      if . "$SKILL_DIR/scripts/lib/resolve-project.sh" 2>/dev/null \
+        && declare -F agmsg_resolve_project >/dev/null 2>&1; then
+        project="$(agmsg_resolve_project "$(pwd)" "$type" "$team" 2>/dev/null || true)"
+      fi
+    fi
+  fi
+
   # Slow half, once: name the pane through the same primitive every other path
   # uses, and -- the #1109 fix -- record this pane as the seat's placement. The
   # `record` claim is legitimate here and only here among the label writers (see

--- a/tests/test_self_name.bats
+++ b/tests/test_self_name.bats
@@ -313,6 +313,35 @@ _placement() {   # <team> <agent> -> "<terminal>:<id>" or empty
   [ "$(_placement team alice)" = 'tmux:/tmp/s:%3' ]
 }
 
+@test "a hand-started seat's record carries project and type, not the two empty fields arrange.sh refuses (#1137)" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  # None of send.sh/inbox.sh/history.sh pass project or type -- this call
+  # shape (2 args) is exactly what they do.
+  [ -z "$(_placement team alice)" ]
+  agmsg_self_name_on_action team alice
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  local rec ref project type
+  rec="$(agmsg_spawn_path team alice)"
+  [ -f "$rec" ]
+  IFS=$'\t' read -r ref project type < "$rec"
+  [ "$ref" = 'tmux:/tmp/s:%3' ]
+  [ -n "$project" ]
+  [ -n "$type" ]
+}
+
+@test "a caller that already supplies project and type is never second-guessed (#1137)" {
+  _install_fake_tmux; _under_tmux /tmp/s 4242 %3
+  agmsg_self_name_on_action team alice /explicit/project explicit-type
+  # shellcheck disable=SC1090
+  source "$SKILL_DIR/scripts/lib/actas-lock.sh"
+  local rec ref project type
+  rec="$(agmsg_spawn_path team alice)"
+  IFS=$'\t' read -r ref project type < "$rec"
+  [ "$project" = /explicit/project ]
+  [ "$type" = explicit-type ]
+}
+
 @test "named once but never recorded: the next action writes the missing record (#1109)" {
   _install_fake_tmux; _under_tmux /tmp/s 4242 %3
   # A mark-only prior naming (watch.sh names with five args, no record): the mark


### PR DESCRIPTION
Fixes #1137.

`send.sh`/`inbox.sh`/`history.sh` call `agmsg_self_name_on_action` with only `<team> <agent>` — they never had a project or type to pass, not merely forgot to (verified: neither variable exists anywhere in any of the three files). The hook forwarded that straight through to the placement-record writer, so a record written by acting — the #1109 path, the one that exists for hand-started seats — carried two empty fields. `arrange.sh` requires both and refuses such a record outright with "missing project or type"; the issue measured 12 of 36 placement records stuck this way on one live machine, including seats in daily use.

## Coordination note

`scripts/lib/self-name.sh` (the action-hook path this fixes) is the exact layer #1152/#1157 (`feat/1152-self-write`, still open) plans to remove and replace. Cross-checked with the #1157 author before starting: their new writer (`agmsg_self_write`) already requires project/type as non-optional and has its own test for that; this fix is scoped to the current, still-live path only, and does not touch anything #1157 changes (no file overlap — confirmed by running the full affected suites, listed below). They're dropping `Closes #1137` from #1157's body so the two don't race to close the same issue.

## Fix

Resolve project/type inside `agmsg_self_name_on_action` itself, the same way `whoami.sh` already answers the identical question (`agmsg_detect_cli_type`, `agmsg_resolve_project`), instead of threading two new arguments through three callers that have no better source for them than this process's own cwd and type anyway. Only when the caller did not already supply them, and only right before the slow-half write — the common fast-path short-circuit (the cheap case this hook is designed around) is untouched. Best-effort, matching every other lazy `source` in this function: a resolution failure leaves the field empty exactly as before, never blocks the naming this hook exists to do.

## Verification

- `tests/test_self_name.bats` gains the failing-side control the day's standard calls for: a hand-started seat's action-hook record now carries non-empty project/type — verified red by reverting the fix and re-running (`project` empty, assertion fails) — and a caller that already supplies both explicitly is never second-guessed (its exact values pass through unchanged).
- Full file re-run after restoring the fix: `test_self_name.bats` 25/25, `test_dispatch.bats` 15/15, `test_delivery.bats` 198/198, `test_terminal_registry.bats` 166/166 — all clean.
- `check-enforced-assertions.sh`: 626/626, baseline unchanged.
- `bash -n scripts/lib/self-name.sh`: OK.

Base: `integration/terminal-driver-v1` tip at branch time (`026d10f4`).
